### PR TITLE
IOS: Clean up the way IPC replies are constructed

### DIFF
--- a/Source/Core/Core/HW/SystemTimers.h
+++ b/Source/Core/Core/HW/SystemTimers.h
@@ -63,3 +63,12 @@ s64 GetLocalTimeRTCOffset();
 double GetEstimatedEmulationPerformance();
 
 }  // namespace SystemTimers
+
+inline namespace SystemTimersLiterals
+{
+/// Converts timebase ticks to clock ticks.
+constexpr u64 operator""_tbticks(unsigned long long value)
+{
+  return value * SystemTimers::TIMER_RATIO;
+}
+}  // namespace SystemTimersLiterals

--- a/Source/Core/Core/IOS/DI/DI.h
+++ b/Source/Core/Core/IOS/DI/DI.h
@@ -42,9 +42,9 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
   enum class DIIoctl : u32
   {

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -160,19 +160,19 @@ void Device::DoStateShared(PointerWrap& p)
   p.Do(m_is_active);
 }
 
-IPCCommandResult Device::Open(const OpenRequest& request)
+std::optional<IPCReply> Device::Open(const OpenRequest& request)
 {
   m_is_active = true;
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply{IPC_SUCCESS};
 }
 
-IPCCommandResult Device::Close(u32 fd)
+std::optional<IPCReply> Device::Close(u32 fd)
 {
   m_is_active = false;
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply{IPC_SUCCESS};
 }
 
-IPCCommandResult Device::Unsupported(const Request& request)
+std::optional<IPCReply> Device::Unsupported(const Request& request)
 {
   static const std::map<IPCCommandType, std::string_view> names{{
       {IPC_CMD_READ, "Read"},
@@ -183,27 +183,6 @@ IPCCommandResult Device::Unsupported(const Request& request)
   }};
 
   WARN_LOG_FMT(IOS, "{} does not support {}()", m_name, names.at(request.command));
-  return GetDefaultReply(IPC_EINVAL);
-}
-
-// Returns an IPCCommandResult for a reply with an average reply time for devices
-// Please avoid using this function if more accurate timings are known.
-IPCCommandResult Device::GetDefaultReply(const s32 return_value)
-{
-  // Based on a hardware test, a device takes at least ~2700 ticks to reply to an IPC request.
-  // Depending on how much work a command performs, this can take much longer (10000+)
-  // especially if the NAND filesystem is accessed.
-  //
-  // Because we currently don't emulate timing very accurately, we should not return
-  // the minimum possible reply time (~960 ticks from the kernel or ~2700 from devices)
-  // but an average time, otherwise we are going to be much too fast in most cases.
-  return {return_value, true, 4000 * SystemTimers::TIMER_RATIO};
-}
-
-// Returns an IPCCommandResult with no reply. Useful for async commands that will generate a reply
-// later. This takes no return value because it won't be used.
-IPCCommandResult Device::GetNoReply()
-{
-  return {IPC_SUCCESS, false, 0};
+  return IPCReply{IPC_EINVAL};
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -186,19 +187,23 @@ public:
   const std::string& GetDeviceName() const { return m_name; }
   // Replies to Open and Close requests are sent by the IPC request handler (HandleCommand),
   // not by the devices themselves.
-  virtual IPCCommandResult Open(const OpenRequest& request);
-  virtual IPCCommandResult Close(u32 fd);
-  virtual IPCCommandResult Seek(const SeekRequest& seek) { return Unsupported(seek); }
-  virtual IPCCommandResult Read(const ReadWriteRequest& read) { return Unsupported(read); }
-  virtual IPCCommandResult Write(const ReadWriteRequest& write) { return Unsupported(write); }
-  virtual IPCCommandResult IOCtl(const IOCtlRequest& ioctl) { return Unsupported(ioctl); }
-  virtual IPCCommandResult IOCtlV(const IOCtlVRequest& ioctlv) { return Unsupported(ioctlv); }
+  virtual std::optional<IPCReply> Open(const OpenRequest& request);
+  virtual std::optional<IPCReply> Close(u32 fd);
+  virtual std::optional<IPCReply> Seek(const SeekRequest& seek) { return Unsupported(seek); }
+  virtual std::optional<IPCReply> Read(const ReadWriteRequest& read) { return Unsupported(read); }
+  virtual std::optional<IPCReply> Write(const ReadWriteRequest& write)
+  {
+    return Unsupported(write);
+  }
+  virtual std::optional<IPCReply> IOCtl(const IOCtlRequest& ioctl) { return Unsupported(ioctl); }
+  virtual std::optional<IPCReply> IOCtlV(const IOCtlVRequest& ioctlv)
+  {
+    return Unsupported(ioctlv);
+  }
   virtual void Update() {}
   virtual void UpdateWantDeterminism(bool new_want_determinism) {}
   virtual DeviceType GetDeviceType() const { return m_device_type; }
   virtual bool IsOpened() const { return m_is_active; }
-  static IPCCommandResult GetDefaultReply(s32 return_value);
-  static IPCCommandResult GetNoReply();
 
 protected:
   Kernel& m_ios;
@@ -209,6 +214,6 @@ protected:
   bool m_is_active = false;
 
 private:
-  IPCCommandResult Unsupported(const Request& request);
+  std::optional<IPCReply> Unsupported(const Request& request);
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DeviceStub.cpp
+++ b/Source/Core/Core/IOS/DeviceStub.cpp
@@ -8,22 +8,22 @@
 
 namespace IOS::HLE
 {
-IPCCommandResult DeviceStub::Open(const OpenRequest& request)
+std::optional<IPCReply> DeviceStub::Open(const OpenRequest& request)
 {
   WARN_LOG_FMT(IOS, "{} faking Open()", m_name);
   m_is_active = true;
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult DeviceStub::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> DeviceStub::IOCtl(const IOCtlRequest& request)
 {
   WARN_LOG_FMT(IOS, "{} faking IOCtl()", m_name);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult DeviceStub::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> DeviceStub::IOCtlV(const IOCtlVRequest& request)
 {
   WARN_LOG_FMT(IOS, "{} faking IOCtlV()", m_name);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DeviceStub.h
+++ b/Source/Core/Core/IOS/DeviceStub.h
@@ -17,8 +17,8 @@ class DeviceStub final : public Device
 public:
   // Inherit the constructor from the Device class, since we don't need to do anything special.
   using Device::Device;
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -34,29 +34,29 @@ enum
 
 };
 
-IPCCommandResult GetSystemTime(const IOCtlVRequest& request)
+IPCReply GetSystemTime(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1))
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   if (request.io_vectors[0].size != 4)
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   const u32 milliseconds = Common::Timer::GetTimeMs();
 
   Memory::Write_U32(milliseconds, request.io_vectors[0].address);
-  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult GetVersion(const IOCtlVRequest& request)
+IPCReply GetVersion(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1))
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   const auto length = std::min(size_t(request.io_vectors[0].size), std::strlen(SCM_DESC_STR));
@@ -64,19 +64,19 @@ IPCCommandResult GetVersion(const IOCtlVRequest& request)
   Memory::Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
   Memory::CopyToEmu(request.io_vectors[0].address, SCM_DESC_STR, length);
 
-  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult GetCPUSpeed(const IOCtlVRequest& request)
+IPCReply GetCPUSpeed(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1))
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   if (request.io_vectors[0].size != 4)
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   const SConfig& config = SConfig::GetInstance();
@@ -86,66 +86,66 @@ IPCCommandResult GetCPUSpeed(const IOCtlVRequest& request)
 
   Memory::Write_U32(core_clock, request.io_vectors[0].address);
 
-  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult GetSpeedLimit(const IOCtlVRequest& request)
+IPCReply GetSpeedLimit(const IOCtlVRequest& request)
 {
   // get current speed limit
   if (!request.HasNumberOfValidVectors(0, 1))
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   if (request.io_vectors[0].size != 4)
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   const SConfig& config = SConfig::GetInstance();
   const u32 speed_percent = config.m_EmulationSpeed * 100;
   Memory::Write_U32(speed_percent, request.io_vectors[0].address);
 
-  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SetSpeedLimit(const IOCtlVRequest& request)
+IPCReply SetSpeedLimit(const IOCtlVRequest& request)
 {
   // set current speed limit
   if (!request.HasNumberOfValidVectors(1, 0))
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   if (request.in_vectors[0].size != 4)
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   const float speed = float(Memory::Read_U32(request.in_vectors[0].address)) / 100.0f;
   SConfig::GetInstance().m_EmulationSpeed = speed;
   BootManager::SetEmulationSpeedReset(true);
 
-  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult GetRealProductCode(const IOCtlVRequest& request)
+IPCReply GetRealProductCode(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1))
   {
-    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   const std::string backup_file_path = File::GetUserPath(D_BACKUP_IDX) + DIR_SEP + WII_SETTING;
 
   File::IOFile file(backup_file_path, "rb");
   if (!file)
-    return DolphinDevice::GetDefaultReply(IPC_ENOENT);
+    return IPCReply(IPC_ENOENT);
 
   Common::SettingsHandler::Buffer data;
 
   if (!file.ReadBytes(data.data(), data.size()))
-    return DolphinDevice::GetDefaultReply(IPC_ENOENT);
+    return IPCReply(IPC_ENOENT);
 
   Common::SettingsHandler gen;
   gen.SetBytes(std::move(data));
@@ -153,21 +153,19 @@ IPCCommandResult GetRealProductCode(const IOCtlVRequest& request)
 
   const size_t length = std::min<size_t>(request.io_vectors[0].size, code.length());
   if (length == 0)
-    return DolphinDevice::GetDefaultReply(IPC_ENOENT);
+    return IPCReply(IPC_ENOENT);
 
   Memory::Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
   Memory::CopyToEmu(request.io_vectors[0].address, code.c_str(), length);
-  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
 }  // namespace
 
-IPCCommandResult DolphinDevice::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> DolphinDevice::IOCtlV(const IOCtlVRequest& request)
 {
   if (Core::WantsDeterminism())
-  {
-    return DolphinDevice::GetDefaultReply(IPC_EACCES);
-  }
+    return IPCReply(IPC_EACCES);
 
   switch (request.request)
   {
@@ -184,7 +182,7 @@ IPCCommandResult DolphinDevice::IOCtlV(const IOCtlVRequest& request)
   case IOCTL_DOLPHIN_GET_REAL_PRODUCTCODE:
     return GetRealProductCode(request);
   default:
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DolphinDevice.h
+++ b/Source/Core/Core/IOS/DolphinDevice.h
@@ -13,6 +13,6 @@ class DolphinDevice final : public Device
 public:
   // Inherit the constructor from the Device class, since we don't need to do anything special.
   using Device::Device;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -48,9 +48,9 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult Close(u32 fd) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> Close(u32 fd) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
   struct TitleImportExportContext
   {
@@ -261,84 +261,84 @@ private:
   using ContextArray = std::array<Context, 3>;
 
   // Title management
-  IPCCommandResult ImportTicket(const IOCtlVRequest& request);
-  IPCCommandResult ImportTmd(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ImportTitleInit(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ImportContentBegin(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ImportContentData(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ImportContentEnd(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ImportTitleDone(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ImportTitleCancel(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ExportTitleInit(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ExportContentBegin(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ExportContentData(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ExportContentEnd(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult ExportTitleDone(Context& context, const IOCtlVRequest& request);
-  IPCCommandResult DeleteTitle(const IOCtlVRequest& request);
-  IPCCommandResult DeleteTitleContent(const IOCtlVRequest& request);
-  IPCCommandResult DeleteTicket(const IOCtlVRequest& request);
-  IPCCommandResult DeleteSharedContent(const IOCtlVRequest& request);
-  IPCCommandResult DeleteContent(const IOCtlVRequest& request);
+  IPCReply ImportTicket(const IOCtlVRequest& request);
+  IPCReply ImportTmd(Context& context, const IOCtlVRequest& request);
+  IPCReply ImportTitleInit(Context& context, const IOCtlVRequest& request);
+  IPCReply ImportContentBegin(Context& context, const IOCtlVRequest& request);
+  IPCReply ImportContentData(Context& context, const IOCtlVRequest& request);
+  IPCReply ImportContentEnd(Context& context, const IOCtlVRequest& request);
+  IPCReply ImportTitleDone(Context& context, const IOCtlVRequest& request);
+  IPCReply ImportTitleCancel(Context& context, const IOCtlVRequest& request);
+  IPCReply ExportTitleInit(Context& context, const IOCtlVRequest& request);
+  IPCReply ExportContentBegin(Context& context, const IOCtlVRequest& request);
+  IPCReply ExportContentData(Context& context, const IOCtlVRequest& request);
+  IPCReply ExportContentEnd(Context& context, const IOCtlVRequest& request);
+  IPCReply ExportTitleDone(Context& context, const IOCtlVRequest& request);
+  IPCReply DeleteTitle(const IOCtlVRequest& request);
+  IPCReply DeleteTitleContent(const IOCtlVRequest& request);
+  IPCReply DeleteTicket(const IOCtlVRequest& request);
+  IPCReply DeleteSharedContent(const IOCtlVRequest& request);
+  IPCReply DeleteContent(const IOCtlVRequest& request);
 
   // Device identity and encryption
-  IPCCommandResult GetDeviceId(const IOCtlVRequest& request);
-  IPCCommandResult GetDeviceCertificate(const IOCtlVRequest& request);
-  IPCCommandResult CheckKoreaRegion(const IOCtlVRequest& request);
-  IPCCommandResult Sign(const IOCtlVRequest& request);
-  IPCCommandResult VerifySign(const IOCtlVRequest& request);
-  IPCCommandResult Encrypt(u32 uid, const IOCtlVRequest& request);
-  IPCCommandResult Decrypt(u32 uid, const IOCtlVRequest& request);
+  IPCReply GetDeviceId(const IOCtlVRequest& request);
+  IPCReply GetDeviceCertificate(const IOCtlVRequest& request);
+  IPCReply CheckKoreaRegion(const IOCtlVRequest& request);
+  IPCReply Sign(const IOCtlVRequest& request);
+  IPCReply VerifySign(const IOCtlVRequest& request);
+  IPCReply Encrypt(u32 uid, const IOCtlVRequest& request);
+  IPCReply Decrypt(u32 uid, const IOCtlVRequest& request);
 
   // Misc
-  IPCCommandResult SetUID(u32 uid, const IOCtlVRequest& request);
-  IPCCommandResult GetTitleDirectory(const IOCtlVRequest& request);
-  IPCCommandResult GetTitleId(const IOCtlVRequest& request);
-  IPCCommandResult GetConsumption(const IOCtlVRequest& request);
-  IPCCommandResult Launch(const IOCtlVRequest& request);
-  IPCCommandResult LaunchBC(const IOCtlVRequest& request);
-  IPCCommandResult DIVerify(const IOCtlVRequest& request);
-  IPCCommandResult SetUpStreamKey(const Context& context, const IOCtlVRequest& request);
-  IPCCommandResult DeleteStreamKey(const IOCtlVRequest& request);
+  IPCReply SetUID(u32 uid, const IOCtlVRequest& request);
+  IPCReply GetTitleDirectory(const IOCtlVRequest& request);
+  IPCReply GetTitleId(const IOCtlVRequest& request);
+  IPCReply GetConsumption(const IOCtlVRequest& request);
+  std::optional<IPCReply> Launch(const IOCtlVRequest& request);
+  std::optional<IPCReply> LaunchBC(const IOCtlVRequest& request);
+  IPCReply DIVerify(const IOCtlVRequest& request);
+  IPCReply SetUpStreamKey(const Context& context, const IOCtlVRequest& request);
+  IPCReply DeleteStreamKey(const IOCtlVRequest& request);
 
   // Title contents
-  IPCCommandResult OpenActiveTitleContent(u32 uid, const IOCtlVRequest& request);
-  IPCCommandResult OpenContent(u32 uid, const IOCtlVRequest& request);
-  IPCCommandResult ReadContent(u32 uid, const IOCtlVRequest& request);
-  IPCCommandResult CloseContent(u32 uid, const IOCtlVRequest& request);
-  IPCCommandResult SeekContent(u32 uid, const IOCtlVRequest& request);
+  IPCReply OpenActiveTitleContent(u32 uid, const IOCtlVRequest& request);
+  IPCReply OpenContent(u32 uid, const IOCtlVRequest& request);
+  IPCReply ReadContent(u32 uid, const IOCtlVRequest& request);
+  IPCReply CloseContent(u32 uid, const IOCtlVRequest& request);
+  IPCReply SeekContent(u32 uid, const IOCtlVRequest& request);
 
   // Title information
-  IPCCommandResult GetTitleCount(const std::vector<u64>& titles, const IOCtlVRequest& request);
-  IPCCommandResult GetTitles(const std::vector<u64>& titles, const IOCtlVRequest& request);
-  IPCCommandResult GetOwnedTitleCount(const IOCtlVRequest& request);
-  IPCCommandResult GetOwnedTitles(const IOCtlVRequest& request);
-  IPCCommandResult GetTitleCount(const IOCtlVRequest& request);
-  IPCCommandResult GetTitles(const IOCtlVRequest& request);
-  IPCCommandResult GetBoot2Version(const IOCtlVRequest& request);
-  IPCCommandResult GetStoredContentsCount(const ES::TMDReader& tmd, const IOCtlVRequest& request);
-  IPCCommandResult GetStoredContents(const ES::TMDReader& tmd, const IOCtlVRequest& request);
-  IPCCommandResult GetStoredContentsCount(const IOCtlVRequest& request);
-  IPCCommandResult GetStoredContents(const IOCtlVRequest& request);
-  IPCCommandResult GetTMDStoredContentsCount(const IOCtlVRequest& request);
-  IPCCommandResult GetTMDStoredContents(const IOCtlVRequest& request);
-  IPCCommandResult GetStoredTMDSize(const IOCtlVRequest& request);
-  IPCCommandResult GetStoredTMD(const IOCtlVRequest& request);
-  IPCCommandResult GetSharedContentsCount(const IOCtlVRequest& request) const;
-  IPCCommandResult GetSharedContents(const IOCtlVRequest& request) const;
+  IPCReply GetTitleCount(const std::vector<u64>& titles, const IOCtlVRequest& request);
+  IPCReply GetTitles(const std::vector<u64>& titles, const IOCtlVRequest& request);
+  IPCReply GetOwnedTitleCount(const IOCtlVRequest& request);
+  IPCReply GetOwnedTitles(const IOCtlVRequest& request);
+  IPCReply GetTitleCount(const IOCtlVRequest& request);
+  IPCReply GetTitles(const IOCtlVRequest& request);
+  IPCReply GetBoot2Version(const IOCtlVRequest& request);
+  IPCReply GetStoredContentsCount(const ES::TMDReader& tmd, const IOCtlVRequest& request);
+  IPCReply GetStoredContents(const ES::TMDReader& tmd, const IOCtlVRequest& request);
+  IPCReply GetStoredContentsCount(const IOCtlVRequest& request);
+  IPCReply GetStoredContents(const IOCtlVRequest& request);
+  IPCReply GetTMDStoredContentsCount(const IOCtlVRequest& request);
+  IPCReply GetTMDStoredContents(const IOCtlVRequest& request);
+  IPCReply GetStoredTMDSize(const IOCtlVRequest& request);
+  IPCReply GetStoredTMD(const IOCtlVRequest& request);
+  IPCReply GetSharedContentsCount(const IOCtlVRequest& request) const;
+  IPCReply GetSharedContents(const IOCtlVRequest& request) const;
 
   // Views for tickets and TMDs
-  IPCCommandResult GetTicketViewCount(const IOCtlVRequest& request);
-  IPCCommandResult GetTicketViews(const IOCtlVRequest& request);
-  IPCCommandResult GetV0TicketFromView(const IOCtlVRequest& request);
-  IPCCommandResult GetTicketSizeFromView(const IOCtlVRequest& request);
-  IPCCommandResult GetTicketFromView(const IOCtlVRequest& request);
-  IPCCommandResult GetTMDViewSize(const IOCtlVRequest& request);
-  IPCCommandResult GetTMDViews(const IOCtlVRequest& request);
-  IPCCommandResult DIGetTicketView(const IOCtlVRequest& request);
-  IPCCommandResult DIGetTMDViewSize(const IOCtlVRequest& request);
-  IPCCommandResult DIGetTMDView(const IOCtlVRequest& request);
-  IPCCommandResult DIGetTMDSize(const IOCtlVRequest& request);
-  IPCCommandResult DIGetTMD(const IOCtlVRequest& request);
+  IPCReply GetTicketViewCount(const IOCtlVRequest& request);
+  IPCReply GetTicketViews(const IOCtlVRequest& request);
+  IPCReply GetV0TicketFromView(const IOCtlVRequest& request);
+  IPCReply GetTicketSizeFromView(const IOCtlVRequest& request);
+  IPCReply GetTicketFromView(const IOCtlVRequest& request);
+  IPCReply GetTMDViewSize(const IOCtlVRequest& request);
+  IPCReply GetTMDViews(const IOCtlVRequest& request);
+  IPCReply DIGetTicketView(const IOCtlVRequest& request);
+  IPCReply DIGetTMDViewSize(const IOCtlVRequest& request);
+  IPCReply DIGetTMDView(const IOCtlVRequest& request);
+  IPCReply DIGetTMDSize(const IOCtlVRequest& request);
+  IPCReply DIGetTMD(const IOCtlVRequest& request);
 
   ContextArray::iterator FindActiveContext(s32 fd);
   ContextArray::iterator FindInactiveContext();

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -27,23 +27,23 @@ ReturnCode ESDevice::GetDeviceId(u32* device_id) const
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ESDevice::GetDeviceId(const IOCtlVRequest& request)
+IPCReply ESDevice::GetDeviceId(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != sizeof(u32))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   u32 device_id;
   const ReturnCode ret = GetDeviceId(&device_id);
   if (ret != IPC_SUCCESS)
-    return GetDefaultReply(ret);
+    return IPCReply(ret);
   Memory::Write_U32(device_id, request.io_vectors[0].address);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ESDevice::Encrypt(u32 uid, const IOCtlVRequest& request)
+IPCReply ESDevice::Encrypt(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 2))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   u32 keyIndex = Memory::Read_U32(request.in_vectors[0].address);
   u8* source = Memory::GetPointer(request.in_vectors[2].address);
@@ -54,13 +54,13 @@ IPCCommandResult ESDevice::Encrypt(u32 uid, const IOCtlVRequest& request)
   // TODO: Check whether the active title is allowed to encrypt.
 
   const ReturnCode ret = m_ios.GetIOSC().Encrypt(keyIndex, iv, source, size, destination, PID_ES);
-  return GetDefaultReply(ret);
+  return IPCReply(ret);
 }
 
-IPCCommandResult ESDevice::Decrypt(u32 uid, const IOCtlVRequest& request)
+IPCReply ESDevice::Decrypt(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 2))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   u32 keyIndex = Memory::Read_U32(request.in_vectors[0].address);
   u8* source = Memory::GetPointer(request.in_vectors[2].address);
@@ -71,38 +71,38 @@ IPCCommandResult ESDevice::Decrypt(u32 uid, const IOCtlVRequest& request)
   // TODO: Check whether the active title is allowed to decrypt.
 
   const ReturnCode ret = m_ios.GetIOSC().Decrypt(keyIndex, iv, source, size, destination, PID_ES);
-  return GetDefaultReply(ret);
+  return IPCReply(ret);
 }
 
-IPCCommandResult ESDevice::CheckKoreaRegion(const IOCtlVRequest& request)
+IPCReply ESDevice::CheckKoreaRegion(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 0))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   // note by DacoTaco : name is unknown, I just tried to name it SOMETHING.
   // IOS70 has this to let system menu 4.2 check if the console is region changed. it returns
   // -1017
   // if the IOS didn't find the Korean keys and 0 if it does. 0 leads to a error 003
   INFO_LOG_FMT(IOS_ES, "IOCTL_ES_CHECKKOREAREGION: Title checked for Korean keys.");
-  return GetDefaultReply(ES_EINVAL);
+  return IPCReply(ES_EINVAL);
 }
 
-IPCCommandResult ESDevice::GetDeviceCertificate(const IOCtlVRequest& request)
+IPCReply ESDevice::GetDeviceCertificate(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != 0x180)
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   INFO_LOG_FMT(IOS_ES, "IOCTL_ES_GETDEVICECERT");
 
   const IOS::CertECC cert = m_ios.GetIOSC().GetDeviceCertificate();
   Memory::CopyToEmu(request.io_vectors[0].address, &cert, sizeof(cert));
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ESDevice::Sign(const IOCtlVRequest& request)
+IPCReply ESDevice::Sign(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 2))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   INFO_LOG_FMT(IOS_ES, "IOCTL_ES_SIGN");
   u8* ap_cert_out = Memory::GetPointer(request.io_vectors[1].address);
@@ -111,10 +111,10 @@ IPCCommandResult ESDevice::Sign(const IOCtlVRequest& request)
   u8* sig_out = Memory::GetPointer(request.io_vectors[0].address);
 
   if (!m_title_context.active)
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   m_ios.GetIOSC().Sign(sig_out, ap_cert_out, m_title_context.tmd.GetTitleId(), data, data_size);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
 ReturnCode ESDevice::VerifySign(const std::vector<u8>& hash, const std::vector<u8>& ecc_signature,
@@ -185,12 +185,12 @@ ReturnCode ESDevice::VerifySign(const std::vector<u8>& hash, const std::vector<u
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ESDevice::VerifySign(const IOCtlVRequest& request)
+IPCReply ESDevice::VerifySign(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
   if (request.in_vectors[1].size != sizeof(Common::ec::Signature))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   std::vector<u8> hash(request.in_vectors[0].size);
   Memory::CopyFromEmu(hash.data(), request.in_vectors[0].address, hash.size());
@@ -201,6 +201,6 @@ IPCCommandResult ESDevice::VerifySign(const IOCtlVRequest& request)
   std::vector<u8> certs(request.in_vectors[2].size);
   Memory::CopyFromEmu(certs.data(), request.in_vectors[2].address, certs.size());
 
-  return GetDefaultReply(VerifySign(hash, ecc_signature, certs));
+  return IPCReply(VerifySign(hash, ecc_signature, certs));
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/TitleInformation.cpp
+++ b/Source/Core/Core/IOS/ES/TitleInformation.cpp
@@ -16,31 +16,30 @@ namespace IOS::HLE
 {
 // Used by the GetStoredContents ioctlvs. This assumes that the first output vector
 // is used for the content count (u32).
-IPCCommandResult ESDevice::GetStoredContentsCount(const ES::TMDReader& tmd,
-                                                  const IOCtlVRequest& request)
+IPCReply ESDevice::GetStoredContentsCount(const ES::TMDReader& tmd, const IOCtlVRequest& request)
 {
   if (request.io_vectors[0].size != sizeof(u32) || !tmd.IsValid())
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   const u16 num_contents = static_cast<u16>(GetStoredContentsFromTMD(tmd).size());
   Memory::Write_U32(num_contents, request.io_vectors[0].address);
 
   INFO_LOG_FMT(IOS_ES, "GetStoredContentsCount ({:#x}):  {} content(s) for {:016x}",
                request.request, num_contents, tmd.GetTitleId());
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
 // Used by the GetStoredContents ioctlvs. This assumes that the second input vector is used
 // for the content count and the output vector is used to store a list of content IDs (u32s).
-IPCCommandResult ESDevice::GetStoredContents(const ES::TMDReader& tmd, const IOCtlVRequest& request)
+IPCReply ESDevice::GetStoredContents(const ES::TMDReader& tmd, const IOCtlVRequest& request)
 {
   if (!tmd.IsValid())
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   if (request.in_vectors[1].size != sizeof(u32) ||
       request.io_vectors[0].size != Memory::Read_U32(request.in_vectors[1].address) * sizeof(u32))
   {
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
   }
 
   const auto contents = GetStoredContentsFromTMD(tmd);
@@ -48,82 +47,81 @@ IPCCommandResult ESDevice::GetStoredContents(const ES::TMDReader& tmd, const IOC
   for (u32 i = 0; i < std::min(static_cast<u32>(contents.size()), max_content_count); ++i)
     Memory::Write_U32(contents[i].id, request.io_vectors[0].address + i * sizeof(u32));
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ESDevice::GetStoredContentsCount(const IOCtlVRequest& request)
+IPCReply ESDevice::GetStoredContentsCount(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != sizeof(u64))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
   const ES::TMDReader tmd = FindInstalledTMD(title_id);
   if (!tmd.IsValid())
-    return GetDefaultReply(FS_ENOENT);
+    return IPCReply(FS_ENOENT);
   return GetStoredContentsCount(tmd, request);
 }
 
-IPCCommandResult ESDevice::GetStoredContents(const IOCtlVRequest& request)
+IPCReply ESDevice::GetStoredContents(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1) || request.in_vectors[0].size != sizeof(u64))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
   const ES::TMDReader tmd = FindInstalledTMD(title_id);
   if (!tmd.IsValid())
-    return GetDefaultReply(FS_ENOENT);
+    return IPCReply(FS_ENOENT);
   return GetStoredContents(tmd, request);
 }
 
-IPCCommandResult ESDevice::GetTMDStoredContentsCount(const IOCtlVRequest& request)
+IPCReply ESDevice::GetTMDStoredContentsCount(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   std::vector<u8> tmd_bytes(request.in_vectors[0].size);
   Memory::CopyFromEmu(tmd_bytes.data(), request.in_vectors[0].address, tmd_bytes.size());
   return GetStoredContentsCount(ES::TMDReader{std::move(tmd_bytes)}, request);
 }
 
-IPCCommandResult ESDevice::GetTMDStoredContents(const IOCtlVRequest& request)
+IPCReply ESDevice::GetTMDStoredContents(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   std::vector<u8> tmd_bytes(request.in_vectors[0].size);
   Memory::CopyFromEmu(tmd_bytes.data(), request.in_vectors[0].address, tmd_bytes.size());
 
   const ES::TMDReader tmd{std::move(tmd_bytes)};
   if (!tmd.IsValid())
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   std::vector<u8> cert_store;
   ReturnCode ret = ReadCertStore(&cert_store);
   if (ret != IPC_SUCCESS)
-    return GetDefaultReply(ret);
+    return IPCReply(ret);
 
   ret = VerifyContainer(VerifyContainerType::TMD, VerifyMode::UpdateCertStore, tmd, cert_store);
   if (ret != IPC_SUCCESS)
-    return GetDefaultReply(ret);
+    return IPCReply(ret);
 
   return GetStoredContents(tmd, request);
 }
 
-IPCCommandResult ESDevice::GetTitleCount(const std::vector<u64>& titles,
-                                         const IOCtlVRequest& request)
+IPCReply ESDevice::GetTitleCount(const std::vector<u64>& titles, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != 4)
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   Memory::Write_U32(static_cast<u32>(titles.size()), request.io_vectors[0].address);
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ESDevice::GetTitles(const std::vector<u64>& titles, const IOCtlVRequest& request)
+IPCReply ESDevice::GetTitles(const std::vector<u64>& titles, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   const size_t max_count = Memory::Read_U32(request.in_vectors[0].address);
   for (size_t i = 0; i < std::min(max_count, titles.size()); i++)
@@ -131,112 +129,112 @@ IPCCommandResult ESDevice::GetTitles(const std::vector<u64>& titles, const IOCtl
     Memory::Write_U64(titles[i], request.io_vectors[0].address + static_cast<u32>(i) * sizeof(u64));
     INFO_LOG_FMT(IOS_ES, "     title {:016x}", titles[i]);
   }
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ESDevice::GetTitleCount(const IOCtlVRequest& request)
+IPCReply ESDevice::GetTitleCount(const IOCtlVRequest& request)
 {
   const std::vector<u64> titles = GetInstalledTitles();
   INFO_LOG_FMT(IOS_ES, "GetTitleCount: {} titles", titles.size());
   return GetTitleCount(titles, request);
 }
 
-IPCCommandResult ESDevice::GetTitles(const IOCtlVRequest& request)
+IPCReply ESDevice::GetTitles(const IOCtlVRequest& request)
 {
   return GetTitles(GetInstalledTitles(), request);
 }
 
-IPCCommandResult ESDevice::GetStoredTMDSize(const IOCtlVRequest& request)
+IPCReply ESDevice::GetStoredTMDSize(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
   const ES::TMDReader tmd = FindInstalledTMD(title_id);
   if (!tmd.IsValid())
-    return GetDefaultReply(FS_ENOENT);
+    return IPCReply(FS_ENOENT);
 
   const u32 tmd_size = static_cast<u32>(tmd.GetBytes().size());
   Memory::Write_U32(tmd_size, request.io_vectors[0].address);
 
   INFO_LOG_FMT(IOS_ES, "GetStoredTMDSize: {} bytes  for {:016x}", tmd_size, title_id);
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ESDevice::GetStoredTMD(const IOCtlVRequest& request)
+IPCReply ESDevice::GetStoredTMD(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
   const ES::TMDReader tmd = FindInstalledTMD(title_id);
   if (!tmd.IsValid())
-    return GetDefaultReply(FS_ENOENT);
+    return IPCReply(FS_ENOENT);
 
   // TODO: actually use this param in when writing to the outbuffer :/
   const u32 MaxCount = Memory::Read_U32(request.in_vectors[1].address);
 
   const std::vector<u8>& raw_tmd = tmd.GetBytes();
   if (raw_tmd.size() != request.io_vectors[0].size)
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   Memory::CopyToEmu(request.io_vectors[0].address, raw_tmd.data(), raw_tmd.size());
 
   INFO_LOG_FMT(IOS_ES, "GetStoredTMD: title {:016x} (buffer size: {})", title_id, MaxCount);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ESDevice::GetOwnedTitleCount(const IOCtlVRequest& request)
+IPCReply ESDevice::GetOwnedTitleCount(const IOCtlVRequest& request)
 {
   const std::vector<u64> titles = GetTitlesWithTickets();
   INFO_LOG_FMT(IOS_ES, "GetOwnedTitleCount: {} titles", titles.size());
   return GetTitleCount(titles, request);
 }
 
-IPCCommandResult ESDevice::GetOwnedTitles(const IOCtlVRequest& request)
+IPCReply ESDevice::GetOwnedTitles(const IOCtlVRequest& request)
 {
   return GetTitles(GetTitlesWithTickets(), request);
 }
 
-IPCCommandResult ESDevice::GetBoot2Version(const IOCtlVRequest& request)
+IPCReply ESDevice::GetBoot2Version(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   INFO_LOG_FMT(IOS_ES, "IOCTL_ES_GETBOOT2VERSION");
 
   // as of 26/02/2012, this was latest bootmii version
   Memory::Write_U32(4, request.io_vectors[0].address);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ESDevice::GetSharedContentsCount(const IOCtlVRequest& request) const
+IPCReply ESDevice::GetSharedContentsCount(const IOCtlVRequest& request) const
 {
   if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != sizeof(u32))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   const u32 count = GetSharedContentsCount();
   Memory::Write_U32(count, request.io_vectors[0].address);
 
   INFO_LOG_FMT(IOS_ES, "GetSharedContentsCount: {} contents", count);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ESDevice::GetSharedContents(const IOCtlVRequest& request) const
+IPCReply ESDevice::GetSharedContents(const IOCtlVRequest& request) const
 {
   if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != sizeof(u32))
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   const u32 max_count = Memory::Read_U32(request.in_vectors[0].address);
   if (request.io_vectors[0].size != 20 * max_count)
-    return GetDefaultReply(ES_EINVAL);
+    return IPCReply(ES_EINVAL);
 
   const std::vector<std::array<u8, 20>> hashes = GetSharedContents();
   const u32 count = std::min(static_cast<u32>(hashes.size()), max_count);
   Memory::CopyToEmu(request.io_vectors[0].address, hashes.data(), 20 * count);
 
   INFO_LOG_FMT(IOS_ES, "GetSharedContents: {} contents ({} requested)", count, max_count);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.h
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.h
@@ -26,13 +26,13 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult Close(u32 fd) override;
-  IPCCommandResult Read(const ReadWriteRequest& request) override;
-  IPCCommandResult Write(const ReadWriteRequest& request) override;
-  IPCCommandResult Seek(const SeekRequest& request) override;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> Close(u32 fd) override;
+  std::optional<IPCReply> Read(const ReadWriteRequest& request) override;
+  std::optional<IPCReply> Write(const ReadWriteRequest& request) override;
+  std::optional<IPCReply> Seek(const SeekRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
 private:
   struct Handle
@@ -62,19 +62,19 @@ private:
     ISFS_IOCTL_SHUTDOWN = 13,
   };
 
-  IPCCommandResult Format(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult GetStats(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult CreateDirectory(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult ReadDirectory(const Handle& handle, const IOCtlVRequest& request);
-  IPCCommandResult SetAttribute(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult GetAttribute(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult DeleteFile(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult RenameFile(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult CreateFile(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult SetFileVersionControl(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult GetFileStats(const Handle& handle, const IOCtlRequest& request);
-  IPCCommandResult GetUsage(const Handle& handle, const IOCtlVRequest& request);
-  IPCCommandResult Shutdown(const Handle& handle, const IOCtlRequest& request);
+  IPCReply Format(const Handle& handle, const IOCtlRequest& request);
+  IPCReply GetStats(const Handle& handle, const IOCtlRequest& request);
+  IPCReply CreateDirectory(const Handle& handle, const IOCtlRequest& request);
+  IPCReply ReadDirectory(const Handle& handle, const IOCtlVRequest& request);
+  IPCReply SetAttribute(const Handle& handle, const IOCtlRequest& request);
+  IPCReply GetAttribute(const Handle& handle, const IOCtlRequest& request);
+  IPCReply DeleteFile(const Handle& handle, const IOCtlRequest& request);
+  IPCReply RenameFile(const Handle& handle, const IOCtlRequest& request);
+  IPCReply CreateFile(const Handle& handle, const IOCtlRequest& request);
+  IPCReply SetFileVersionControl(const Handle& handle, const IOCtlRequest& request);
+  IPCReply GetFileStats(const Handle& handle, const IOCtlRequest& request);
+  IPCReply GetUsage(const Handle& handle, const IOCtlVRequest& request);
+  IPCReply Shutdown(const Handle& handle, const IOCtlRequest& request);
 
   u64 EstimateTicksForReadWrite(const Handle& handle, const ReadWriteRequest& request);
   u64 SimulatePopulateFileCache(u32 fd, u32 offset, u32 file_size);

--- a/Source/Core/Core/IOS/Network/IP/Top.h
+++ b/Source/Core/Core/IOS/Network/IP/Top.h
@@ -68,36 +68,36 @@ public:
   virtual ~NetIPTopDevice();
 
   void DoState(PointerWrap& p) override;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
   void Update() override;
 
 private:
-  IPCCommandResult HandleInitInterfaceRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleSocketRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleICMPSocketRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleCloseRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleDoSockRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleShutdownRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleListenRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleGetSockOptRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleSetSockOptRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleGetSockNameRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleGetPeerNameRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleGetHostIDRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleInetAToNRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleInetPToNRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleInetNToPRequest(const IOCtlRequest& request);
-  IPCCommandResult HandlePollRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleGetHostByNameRequest(const IOCtlRequest& request);
-  IPCCommandResult HandleICMPCancelRequest(const IOCtlRequest& request);
+  IPCReply HandleInitInterfaceRequest(const IOCtlRequest& request);
+  IPCReply HandleSocketRequest(const IOCtlRequest& request);
+  IPCReply HandleICMPSocketRequest(const IOCtlRequest& request);
+  IPCReply HandleCloseRequest(const IOCtlRequest& request);
+  std::optional<IPCReply> HandleDoSockRequest(const IOCtlRequest& request);
+  IPCReply HandleShutdownRequest(const IOCtlRequest& request);
+  IPCReply HandleListenRequest(const IOCtlRequest& request);
+  IPCReply HandleGetSockOptRequest(const IOCtlRequest& request);
+  IPCReply HandleSetSockOptRequest(const IOCtlRequest& request);
+  IPCReply HandleGetSockNameRequest(const IOCtlRequest& request);
+  IPCReply HandleGetPeerNameRequest(const IOCtlRequest& request);
+  IPCReply HandleGetHostIDRequest(const IOCtlRequest& request);
+  IPCReply HandleInetAToNRequest(const IOCtlRequest& request);
+  IPCReply HandleInetPToNRequest(const IOCtlRequest& request);
+  IPCReply HandleInetNToPRequest(const IOCtlRequest& request);
+  std::optional<IPCReply> HandlePollRequest(const IOCtlRequest& request);
+  IPCReply HandleGetHostByNameRequest(const IOCtlRequest& request);
+  IPCReply HandleICMPCancelRequest(const IOCtlRequest& request);
 
-  IPCCommandResult HandleGetInterfaceOptRequest(const IOCtlVRequest& request);
-  IPCCommandResult HandleSendToRequest(const IOCtlVRequest& request);
-  IPCCommandResult HandleRecvFromRequest(const IOCtlVRequest& request);
-  IPCCommandResult HandleGetAddressInfoRequest(const IOCtlVRequest& request);
-  IPCCommandResult HandleICMPPingRequest(const IOCtlVRequest& request);
+  IPCReply HandleGetInterfaceOptRequest(const IOCtlVRequest& request);
+  std::optional<IPCReply> HandleSendToRequest(const IOCtlVRequest& request);
+  std::optional<IPCReply> HandleRecvFromRequest(const IOCtlVRequest& request);
+  IPCReply HandleGetAddressInfoRequest(const IOCtlVRequest& request);
+  IPCReply HandleICMPPingRequest(const IOCtlVRequest& request);
 
 #ifdef _WIN32
   WSADATA InitData;

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -32,7 +32,7 @@ NetKDRequestDevice::~NetKDRequestDevice()
   WiiSockMan::GetInstance().Clean();
 }
 
-IPCCommandResult NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
 {
   s32 return_value = 0;
   switch (request.request)
@@ -169,7 +169,7 @@ IPCCommandResult NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
     request.Log(GetDeviceName(), Common::Log::IOS_WC24);
   }
 
-  return GetDefaultReply(return_value);
+  return IPCReply(return_value);
 }
 
 u8 NetKDRequestDevice::GetAreaCode(const std::string& area) const

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
@@ -21,7 +21,7 @@ public:
   NetKDRequestDevice(Kernel& ios, const std::string& device_name);
   ~NetKDRequestDevice() override;
 
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
 
 private:
   enum

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -19,7 +19,7 @@ NetKDTimeDevice::NetKDTimeDevice(Kernel& ios, const std::string& device_name)
 
 NetKDTimeDevice::~NetKDTimeDevice() = default;
 
-IPCCommandResult NetKDTimeDevice::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> NetKDTimeDevice::IOCtl(const IOCtlRequest& request)
 {
   s32 result = 0;
   u32 common_result = 0;
@@ -72,7 +72,7 @@ IPCCommandResult NetKDTimeDevice::IOCtl(const IOCtlRequest& request)
 
   // write return values
   Memory::Write_U32(common_result, request.buffer_out);
-  return GetDefaultReply(result);
+  return IPCReply(result);
 }
 
 u64 NetKDTimeDevice::GetAdjustedUTC() const

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.h
@@ -17,7 +17,7 @@ public:
   NetKDTimeDevice(Kernel& ios, const std::string& device_name);
   ~NetKDTimeDevice() override;
 
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
 
 private:
   // TODO: depending on CEXIIPL is a hack which I don't feel like

--- a/Source/Core/Core/IOS/Network/NCD/Manage.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.cpp
@@ -27,7 +27,7 @@ void NetNCDManageDevice::DoState(PointerWrap& p)
   p.Do(m_ipc_fd);
 }
 
-IPCCommandResult NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
 {
   s32 return_value = IPC_SUCCESS;
   u32 common_result = 0;
@@ -37,10 +37,10 @@ IPCCommandResult NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
   {
   case IOCTLV_NCD_LOCKWIRELESSDRIVER:
     if (!request.HasNumberOfValidVectors(0, 1))
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
 
     if (request.io_vectors[0].size < 2 * sizeof(u32))
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
 
     if (m_ipc_fd != 0)
     {
@@ -60,13 +60,13 @@ IPCCommandResult NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
   case IOCTLV_NCD_UNLOCKWIRELESSDRIVER:
   {
     if (!request.HasNumberOfValidVectors(1, 1))
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
 
     if (request.in_vectors[0].size < sizeof(u32))
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
 
     if (request.io_vectors[0].size < sizeof(u32))
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
 
     const u32 request_handle = Memory::Read_U32(request.in_vectors[0].address);
     if (m_ipc_fd == request_handle)
@@ -130,6 +130,6 @@ IPCCommandResult NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
   {
     Memory::Write_U32(common_result, request.io_vectors.at(common_vector).address + 4);
   }
-  return GetDefaultReply(return_value);
+  return IPCReply(return_value);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/NCD/Manage.h
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.h
@@ -18,7 +18,7 @@ class NetNCDManageDevice : public Device
 public:
   NetNCDManageDevice(Kernel& ios, const std::string& device_name);
 
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
   void DoState(PointerWrap& p) override;
 

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -113,10 +113,10 @@ int NetSSLDevice::GetSSLFreeID() const
   return 0;
 }
 
-IPCCommandResult NetSSLDevice::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> NetSSLDevice::IOCtl(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), Common::Log::IOS_SSL, Common::Log::LINFO);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
 constexpr std::array<u8, 32> s_client_cert_hash = {
@@ -167,7 +167,7 @@ static std::vector<u8> ReadCertFile(const std::string& path, const std::array<u8
   return bytes;
 }
 
-IPCCommandResult NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
 {
   u32 BufferIn = 0, BufferIn2 = 0, BufferIn3 = 0;
   u32 BufferInSize = 0, BufferInSize2 = 0, BufferInSize3 = 0;
@@ -210,7 +210,7 @@ IPCCommandResult NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
   // I don't trust SSL to be deterministic, and this is never going to sync
   // as such (as opposed to forwarding IPC results or whatever), so -
   if (Core::WantsDeterminism())
-    return GetDefaultReply(IPC_EACCES);
+    return IPCReply(IPC_EACCES);
 
   switch (request.request)
   {
@@ -499,7 +499,7 @@ IPCCommandResult NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
       sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_DOHANDSHAKE);
-      return GetNoReply();
+      return std::nullopt;
     }
     else
     {
@@ -514,7 +514,7 @@ IPCCommandResult NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
       sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_WRITE);
-      return GetNoReply();
+      return std::nullopt;
     }
     else
     {
@@ -538,7 +538,7 @@ IPCCommandResult NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
       sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_READ);
-      return GetNoReply();
+      return std::nullopt;
     }
     else
     {
@@ -600,6 +600,6 @@ IPCCommandResult NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
   }
 
   // SSL return codes are written to BufferIn
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/SSL.h
+++ b/Source/Core/Core/IOS/Network/SSL.h
@@ -87,8 +87,8 @@ public:
 
   virtual ~NetSSLDevice();
 
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
   int GetSSLFreeID() const;
 

--- a/Source/Core/Core/IOS/Network/WD/Command.cpp
+++ b/Source/Core/Core/IOS/Network/WD/Command.cpp
@@ -183,7 +183,7 @@ void NetWDCommandDevice::DoState(PointerWrap& p)
   p.Do(m_recv_notification_requests);
 }
 
-IPCCommandResult NetWDCommandDevice::Open(const OpenRequest& request)
+std::optional<IPCReply> NetWDCommandDevice::Open(const OpenRequest& request)
 {
   if (m_ipc_owner_fd < 0)
   {
@@ -197,7 +197,7 @@ IPCCommandResult NetWDCommandDevice::Open(const OpenRequest& request)
     {
       ERROR_LOG_FMT(IOS_NET, "Unsupported WD operating mode: {}", mode);
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::USES_UNCOMMON_WD_MODE);
-      return GetDefaultReply(s32(ResultCode::UnavailableCommand));
+      return IPCReply(s32(ResultCode::UnavailableCommand));
     }
 
     if (m_target_status == Status::Idle && mode <= WD::Mode::Unknown6)
@@ -212,12 +212,12 @@ IPCCommandResult NetWDCommandDevice::Open(const OpenRequest& request)
   return Device::Open(request);
 }
 
-IPCCommandResult NetWDCommandDevice::Close(u32 fd)
+std::optional<IPCReply> NetWDCommandDevice::Close(u32 fd)
 {
   if (m_ipc_owner_fd < 0 || fd != u32(m_ipc_owner_fd))
   {
     ERROR_LOG_FMT(IOS_NET, "Invalid close attempt.");
-    return GetDefaultReply(u32(ResultCode::InvalidFd));
+    return IPCReply(u32(ResultCode::InvalidFd));
   }
 
   INFO_LOG_FMT(IOS_NET, "Closing and resetting status to Idle");
@@ -228,11 +228,11 @@ IPCCommandResult NetWDCommandDevice::Close(u32 fd)
   return Device::Close(fd);
 }
 
-IPCCommandResult NetWDCommandDevice::SetLinkState(const IOCtlVRequest& request)
+IPCReply NetWDCommandDevice::SetLinkState(const IOCtlVRequest& request)
 {
   const auto* vector = request.GetVector(0);
   if (!vector || vector->address == 0)
-    return GetDefaultReply(u32(ResultCode::IllegalParameter));
+    return IPCReply(u32(ResultCode::IllegalParameter));
 
   const u32 state = Memory::Read_U32(vector->address);
   INFO_LOG_FMT(IOS_NET, "WD_SetLinkState called (state={}, mode={})", state, m_mode);
@@ -240,7 +240,7 @@ IPCCommandResult NetWDCommandDevice::SetLinkState(const IOCtlVRequest& request)
   if (state == 0)
   {
     if (!WD::IsValidMode(m_mode))
-      return GetDefaultReply(u32(ResultCode::UnavailableCommand));
+      return IPCReply(u32(ResultCode::UnavailableCommand));
 
     INFO_LOG_FMT(IOS_NET, "WD_SetLinkState: setting target status to 1 (Idle)");
     m_target_status = Status::Idle;
@@ -248,37 +248,37 @@ IPCCommandResult NetWDCommandDevice::SetLinkState(const IOCtlVRequest& request)
   else
   {
     if (state != 1)
-      return GetDefaultReply(u32(ResultCode::IllegalParameter));
+      return IPCReply(u32(ResultCode::IllegalParameter));
 
     if (!WD::IsValidMode(m_mode))
-      return GetDefaultReply(u32(ResultCode::UnavailableCommand));
+      return IPCReply(u32(ResultCode::UnavailableCommand));
 
     const auto target_status = GetTargetStatusForMode(m_mode);
     if (m_status != target_status && m_info.enabled_channels == 0)
-      return GetDefaultReply(u32(ResultCode::UnavailableCommand));
+      return IPCReply(u32(ResultCode::UnavailableCommand));
 
     INFO_LOG_FMT(IOS_NET, "WD_SetLinkState: setting target status to {}", target_status);
     m_target_status = target_status;
   }
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult NetWDCommandDevice::GetLinkState(const IOCtlVRequest& request) const
+IPCReply NetWDCommandDevice::GetLinkState(const IOCtlVRequest& request) const
 {
   INFO_LOG_FMT(IOS_NET, "WD_GetLinkState called (status={}, mode={})", m_status, m_mode);
   if (!WD::IsValidMode(m_mode))
-    return GetDefaultReply(u32(ResultCode::UnavailableCommand));
+    return IPCReply(u32(ResultCode::UnavailableCommand));
 
   // Contrary to what the name of the ioctl suggests, this returns a boolean, not the current state.
-  return GetDefaultReply(u32(m_status == GetTargetStatusForMode(m_mode)));
+  return IPCReply(u32(m_status == GetTargetStatusForMode(m_mode)));
 }
 
-IPCCommandResult NetWDCommandDevice::Disassociate(const IOCtlVRequest& request)
+IPCReply NetWDCommandDevice::Disassociate(const IOCtlVRequest& request)
 {
   const auto* vector = request.GetVector(0);
   if (!vector || vector->address == 0)
-    return GetDefaultReply(u32(ResultCode::IllegalParameter));
+    return IPCReply(u32(ResultCode::IllegalParameter));
 
   Common::MACAddress mac;
   Memory::CopyFromEmu(mac.data(), vector->address, mac.size());
@@ -289,7 +289,7 @@ IPCCommandResult NetWDCommandDevice::Disassociate(const IOCtlVRequest& request)
       m_mode != WD::Mode::Unknown6)
   {
     ERROR_LOG_FMT(IOS_NET, "WD_Disassociate: cannot disassociate in mode {}", m_mode);
-    return GetDefaultReply(u32(ResultCode::UnavailableCommand));
+    return IPCReply(u32(ResultCode::UnavailableCommand));
   }
 
   const auto target_status = GetTargetStatusForMode(m_mode);
@@ -297,31 +297,31 @@ IPCCommandResult NetWDCommandDevice::Disassociate(const IOCtlVRequest& request)
   {
     ERROR_LOG_FMT(IOS_NET, "WD_Disassociate: cannot disassociate in status {} (target {})",
                   m_status, target_status);
-    return GetDefaultReply(u32(ResultCode::UnavailableCommand));
+    return IPCReply(u32(ResultCode::UnavailableCommand));
   }
 
   // TODO: Check the input MAC address and only return 0x80008001 if it is unknown.
-  return GetDefaultReply(u32(ResultCode::IllegalParameter));
+  return IPCReply(u32(ResultCode::IllegalParameter));
 }
 
-IPCCommandResult NetWDCommandDevice::GetInfo(const IOCtlVRequest& request) const
+IPCReply NetWDCommandDevice::GetInfo(const IOCtlVRequest& request) const
 {
   const auto* vector = request.GetVector(0);
   if (!vector || vector->address == 0)
-    return GetDefaultReply(u32(ResultCode::IllegalParameter));
+    return IPCReply(u32(ResultCode::IllegalParameter));
 
   Memory::CopyToEmu(vector->address, &m_info, sizeof(m_info));
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult NetWDCommandDevice::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> NetWDCommandDevice::IOCtlV(const IOCtlVRequest& request)
 {
   switch (request.request)
   {
   case IOCTLV_WD_INVALID:
-    return GetDefaultReply(u32(ResultCode::UnavailableCommand));
+    return IPCReply(u32(ResultCode::UnavailableCommand));
   case IOCTLV_WD_GET_MODE:
-    return GetDefaultReply(s32(m_mode));
+    return IPCReply(s32(m_mode));
   case IOCTLV_WD_SET_LINKSTATE:
     return SetLinkState(request);
   case IOCTLV_WD_GET_LINKSTATE:
@@ -361,11 +361,11 @@ IPCCommandResult NetWDCommandDevice::IOCtlV(const IOCtlVRequest& request)
 
   case IOCTLV_WD_RECV_FRAME:
     m_recv_frame_requests.emplace_back(request.address);
-    return GetNoReply();
+    return std::nullopt;
 
   case IOCTLV_WD_RECV_NOTIFICATION:
     m_recv_notification_requests.emplace_back(request.address);
-    return GetNoReply();
+    return std::nullopt;
 
   case IOCTLV_WD_SET_CONFIG:
   case IOCTLV_WD_GET_CONFIG:
@@ -382,6 +382,6 @@ IPCCommandResult NetWDCommandDevice::IOCtlV(const IOCtlVRequest& request)
     request.Dump(GetDeviceName(), Common::Log::IOS_NET, Common::Log::LWARNING);
   }
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/WD/Command.h
+++ b/Source/Core/Core/IOS/Network/WD/Command.h
@@ -52,9 +52,9 @@ public:
 
   NetWDCommandDevice(Kernel& ios, const std::string& device_name);
 
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult Close(u32 fd) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> Close(u32 fd) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
   void Update() override;
   bool IsOpened() const override { return true; }
   void DoState(PointerWrap& p) override;
@@ -153,10 +153,10 @@ private:
   void HandleStateChange();
   static Status GetTargetStatusForMode(WD::Mode mode);
 
-  IPCCommandResult SetLinkState(const IOCtlVRequest& request);
-  IPCCommandResult GetLinkState(const IOCtlVRequest& request) const;
-  IPCCommandResult Disassociate(const IOCtlVRequest& request);
-  IPCCommandResult GetInfo(const IOCtlVRequest& request) const;
+  IPCReply SetLinkState(const IOCtlVRequest& request);
+  IPCReply GetLinkState(const IOCtlVRequest& request) const;
+  IPCReply Disassociate(const IOCtlVRequest& request);
+  IPCReply GetInfo(const IOCtlVRequest& request) const;
 
   s32 m_ipc_owner_fd = -1;
   WD::Mode m_mode = WD::Mode::NotInitialized;

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -79,17 +79,17 @@ void SDIOSlot0Device::OpenInternal()
   }
 }
 
-IPCCommandResult SDIOSlot0Device::Open(const OpenRequest& request)
+std::optional<IPCReply> SDIOSlot0Device::Open(const OpenRequest& request)
 {
   OpenInternal();
   m_registers.fill(0);
 
   m_is_active = true;
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0Device::Close(u32 fd)
+std::optional<IPCReply> SDIOSlot0Device::Close(u32 fd)
 {
   m_card.Close();
   m_block_length = 0;
@@ -98,7 +98,7 @@ IPCCommandResult SDIOSlot0Device::Close(u32 fd)
   return Device::Close(fd);
 }
 
-IPCCommandResult SDIOSlot0Device::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> SDIOSlot0Device::IOCtl(const IOCtlRequest& request)
 {
   Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
 
@@ -123,10 +123,10 @@ IPCCommandResult SDIOSlot0Device::IOCtl(const IOCtlRequest& request)
     break;
   }
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0Device::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> SDIOSlot0Device::IOCtlV(const IOCtlVRequest& request)
 {
   switch (request.request)
   {
@@ -137,7 +137,7 @@ IPCCommandResult SDIOSlot0Device::IOCtlV(const IOCtlVRequest& request)
     break;
   }
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
 s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 buffer_in_size,
@@ -325,7 +325,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
   return ret;
 }
 
-IPCCommandResult SDIOSlot0Device::WriteHCRegister(const IOCtlRequest& request)
+IPCReply SDIOSlot0Device::WriteHCRegister(const IOCtlRequest& request)
 {
   const u32 reg = Memory::Read_U32(request.buffer_in);
   const u32 val = Memory::Read_U32(request.buffer_in + 16);
@@ -335,7 +335,7 @@ IPCCommandResult SDIOSlot0Device::WriteHCRegister(const IOCtlRequest& request)
   if (reg >= m_registers.size())
   {
     WARN_LOG_FMT(IOS_SD, "IOCTL_WRITEHCR out of range");
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   }
 
   if ((reg == HCR_CLOCKCONTROL) && (val & 1))
@@ -354,17 +354,17 @@ IPCCommandResult SDIOSlot0Device::WriteHCRegister(const IOCtlRequest& request)
     m_registers[reg] = val;
   }
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0Device::ReadHCRegister(const IOCtlRequest& request)
+IPCReply SDIOSlot0Device::ReadHCRegister(const IOCtlRequest& request)
 {
   const u32 reg = Memory::Read_U32(request.buffer_in);
 
   if (reg >= m_registers.size())
   {
     WARN_LOG_FMT(IOS_SD, "IOCTL_READHCR out of range");
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   }
 
   const u32 val = m_registers[reg];
@@ -372,20 +372,20 @@ IPCCommandResult SDIOSlot0Device::ReadHCRegister(const IOCtlRequest& request)
 
   // Just reading the register
   Memory::Write_U32(val, request.buffer_out);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0Device::ResetCard(const IOCtlRequest& request)
+IPCReply SDIOSlot0Device::ResetCard(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_RESETCARD");
 
   // Returns 16bit RCA and 16bit 0s (meaning success)
   Memory::Write_U32(m_status, request.buffer_out);
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0Device::SetClk(const IOCtlRequest& request)
+IPCReply SDIOSlot0Device::SetClk(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_SETCLK");
 
@@ -395,10 +395,10 @@ IPCCommandResult SDIOSlot0Device::SetClk(const IOCtlRequest& request)
   if (clock != 1)
     INFO_LOG_FMT(IOS_SD, "Setting to {}, interesting", clock);
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0Device::SendCommand(const IOCtlRequest& request)
+std::optional<IPCReply> SDIOSlot0Device::SendCommand(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_SENDCMD {:x} IPC:{:08x}", Memory::Read_U32(request.buffer_in),
                request.address);
@@ -410,13 +410,13 @@ IPCCommandResult SDIOSlot0Device::SendCommand(const IOCtlRequest& request)
   {
     // Check if the condition is already true
     EventNotify();
-    return GetNoReply();
+    return std::nullopt;
   }
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0Device::GetStatus(const IOCtlRequest& request)
+IPCReply SDIOSlot0Device::GetStatus(const IOCtlRequest& request)
 {
   // Since IOS does the SD initialization itself, we just say we're always initialized.
   if (m_card)
@@ -450,19 +450,19 @@ IPCCommandResult SDIOSlot0Device::GetStatus(const IOCtlRequest& request)
                (status & CARD_INITIALIZED) ? " and initialized" : "");
 
   Memory::Write_U32(status, request.buffer_out);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0Device::GetOCRegister(const IOCtlRequest& request)
+IPCReply SDIOSlot0Device::GetOCRegister(const IOCtlRequest& request)
 {
   const u32 ocr = GetOCRegister();
   INFO_LOG_FMT(IOS_SD, "IOCTL_GETOCR. Replying with ocr {:x}", ocr);
   Memory::Write_U32(ocr, request.buffer_out);
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0Device::SendCommand(const IOCtlVRequest& request)
+IPCReply SDIOSlot0Device::SendCommand(const IOCtlVRequest& request)
 {
   DEBUG_LOG_FMT(IOS_SD, "IOCTLV_SENDCMD {:#010x}", Memory::Read_U32(request.in_vectors[0].address));
   Memory::Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
@@ -472,7 +472,7 @@ IPCCommandResult SDIOSlot0Device::SendCommand(const IOCtlVRequest& request)
                      request.in_vectors[1].address, request.in_vectors[1].size,
                      request.io_vectors[0].address, request.io_vectors[0].size);
 
-  return GetDefaultReply(return_value);
+  return IPCReply(return_value);
 }
 
 u32 SDIOSlot0Device::GetOCRegister() const

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -26,10 +26,10 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult Close(u32 fd) override;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> Close(u32 fd) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
   void EventNotify();
 
@@ -125,15 +125,15 @@ private:
     Request request;
   };
 
-  IPCCommandResult WriteHCRegister(const IOCtlRequest& request);
-  IPCCommandResult ReadHCRegister(const IOCtlRequest& request);
-  IPCCommandResult ResetCard(const IOCtlRequest& request);
-  IPCCommandResult SetClk(const IOCtlRequest& request);
-  IPCCommandResult SendCommand(const IOCtlRequest& request);
-  IPCCommandResult GetStatus(const IOCtlRequest& request);
-  IPCCommandResult GetOCRegister(const IOCtlRequest& request);
+  IPCReply WriteHCRegister(const IOCtlRequest& request);
+  IPCReply ReadHCRegister(const IOCtlRequest& request);
+  IPCReply ResetCard(const IOCtlRequest& request);
+  IPCReply SetClk(const IOCtlRequest& request);
+  std::optional<IPCReply> SendCommand(const IOCtlRequest& request);
+  IPCReply GetStatus(const IOCtlRequest& request);
+  IPCReply GetOCRegister(const IOCtlRequest& request);
 
-  IPCCommandResult SendCommand(const IOCtlVRequest& request);
+  IPCReply SendCommand(const IOCtlVRequest& request);
 
   s32 ExecuteCommand(const Request& request, u32 buffer_in, u32 buffer_in_size, u32 rw_buffer,
                      u32 rw_buffer_size, u32 buffer_out, u32 buffer_out_size);

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -16,7 +16,7 @@ namespace IOS::HLE
 {
 static std::unique_ptr<IOCtlRequest> s_event_hook_request;
 
-IPCCommandResult STMImmediateDevice::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> STMImmediateDevice::IOCtl(const IOCtlRequest& request)
 {
   s32 return_value = IPC_SUCCESS;
   switch (request.request)
@@ -59,7 +59,7 @@ IPCCommandResult STMImmediateDevice::IOCtl(const IOCtlRequest& request)
     request.DumpUnknown(GetDeviceName(), Common::Log::IOS_STM);
   }
 
-  return GetDefaultReply(return_value);
+  return IPCReply(return_value);
 }
 
 STMEventHookDevice::~STMEventHookDevice()
@@ -67,17 +67,17 @@ STMEventHookDevice::~STMEventHookDevice()
   s_event_hook_request.reset();
 }
 
-IPCCommandResult STMEventHookDevice::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> STMEventHookDevice::IOCtl(const IOCtlRequest& request)
 {
   if (request.request != IOCTL_STM_EVENTHOOK)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   if (s_event_hook_request)
-    return GetDefaultReply(IPC_EEXIST);
+    return IPCReply(IPC_EEXIST);
 
   // IOCTL_STM_EVENTHOOK waits until the reset button or power button is pressed.
   s_event_hook_request = std::make_unique<IOCtlRequest>(request.address);
-  return GetNoReply();
+  return std::nullopt;
 }
 
 void STMEventHookDevice::DoState(PointerWrap& p)

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -43,7 +43,7 @@ class STMImmediateDevice final : public Device
 {
 public:
   using Device::Device;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
 };
 
 // The /dev/stm/eventhook
@@ -52,7 +52,7 @@ class STMEventHookDevice final : public Device
 public:
   using Device::Device;
   ~STMEventHookDevice() override;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
   void DoState(PointerWrap& p) override;
 
   bool HasHookInstalled() const;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -127,7 +127,7 @@ bool BluetoothEmuDevice::RemoteDisconnect(const bdaddr_t& address)
   return SendEventDisconnect(GetConnectionHandle(address), 0x13);
 }
 
-IPCCommandResult BluetoothEmuDevice::Close(u32 fd)
+std::optional<IPCReply> BluetoothEmuDevice::Close(u32 fd)
 {
   // Clean up state
   m_scan_enable = 0;
@@ -139,7 +139,7 @@ IPCCommandResult BluetoothEmuDevice::Close(u32 fd)
   return Device::Close(fd);
 }
 
-IPCCommandResult BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
 {
   bool send_reply = true;
   switch (request.request)
@@ -204,7 +204,9 @@ IPCCommandResult BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
     request.DumpUnknown(GetDeviceName(), Common::Log::IOS_WIIMOTE);
   }
 
-  return send_reply ? GetDefaultReply(IPC_SUCCESS) : GetNoReply();
+  if (!send_reply)
+    return std::nullopt;
+  return IPCReply(IPC_SUCCESS);
 }
 
 // Here we handle the USB::IOCTLV_USBV0_BLKMSG Ioctlv

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -44,8 +44,8 @@ public:
 
   virtual ~BluetoothEmuDevice();
 
-  IPCCommandResult Close(u32 fd) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Close(u32 fd) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
   void Update() override;
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -46,9 +46,9 @@ public:
   BluetoothRealDevice(Kernel& ios, const std::string& device_name);
   ~BluetoothRealDevice() override;
 
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult Close(u32 fd) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> Close(u32 fd) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
   void DoState(PointerWrap& p) override;
   void UpdateSyncButtonState(bool is_held) override;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
@@ -10,11 +10,11 @@
 
 namespace IOS::HLE
 {
-IPCCommandResult BluetoothStubDevice::Open(const OpenRequest& request)
+std::optional<IPCReply> BluetoothStubDevice::Open(const OpenRequest& request)
 {
   PanicAlertFmtT("Bluetooth passthrough mode is enabled, but Dolphin was built without libusb."
                  " Passthrough mode cannot be used.");
-  return GetDefaultReply(IPC_ENOENT);
+  return IPCReply(IPC_ENOENT);
 }
 
 void BluetoothStubDevice::DoState(PointerWrap& p)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
@@ -18,7 +18,7 @@ class BluetoothStubDevice final : public BluetoothBaseDevice
 {
 public:
   using BluetoothBaseDevice::BluetoothBaseDevice;
-  IPCCommandResult Open(const OpenRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
   void DoState(PointerWrap& p) override;
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -33,7 +33,7 @@ USBHost::USBHost(Kernel& ios, const std::string& device_name) : Device(ios, devi
 
 USBHost::~USBHost() = default;
 
-IPCCommandResult USBHost::Open(const OpenRequest& request)
+std::optional<IPCReply> USBHost::Open(const OpenRequest& request)
 {
   if (!m_has_initialised && !Core::WantsDeterminism())
   {
@@ -43,7 +43,7 @@ IPCCommandResult USBHost::Open(const OpenRequest& request)
     GetScanThread().WaitForFirstScan();
     m_has_initialised = true;
   }
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
 void USBHost::UpdateWantDeterminism(const bool new_want_determinism)
@@ -213,18 +213,18 @@ void USBHost::ScanThread::Stop()
   m_host->DispatchHooks(hooks);
 }
 
-IPCCommandResult USBHost::HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
-                                         std::function<s32()> submit) const
+std::optional<IPCReply> USBHost::HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
+                                                std::function<s32()> submit) const
 {
   if (!device)
-    return GetDefaultReply(IPC_ENOENT);
+    return IPCReply(IPC_ENOENT);
 
   const s32 ret = submit();
   if (ret == IPC_SUCCESS)
-    return GetNoReply();
+    return std::nullopt;
 
   ERROR_LOG_FMT(IOS_USB, "[{:04x}:{:04x}] Failed to submit transfer (request {}): {}",
                 device->GetVid(), device->GetPid(), request, device->GetErrorName(ret));
-  return GetDefaultReply(ret <= 0 ? ret : IPC_EINVAL);
+  return IPCReply(ret <= 0 ? ret : IPC_EINVAL);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -33,7 +33,7 @@ public:
   USBHost(Kernel& ios, const std::string& device_name);
   virtual ~USBHost();
 
-  IPCCommandResult Open(const OpenRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
 
   void UpdateWantDeterminism(bool new_want_determinism) override;
   void DoState(PointerWrap& p) override;
@@ -72,8 +72,8 @@ protected:
   virtual bool ShouldAddDevice(const USB::Device& device) const;
   virtual ScanThread& GetScanThread() = 0;
 
-  IPCCommandResult HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
-                                  std::function<s32()> submit) const;
+  std::optional<IPCReply> HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
+                                         std::function<s32()> submit) const;
 
 private:
   bool AddDevice(std::unique_ptr<USB::Device> device);

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -31,14 +31,14 @@ OH0::~OH0()
   m_scan_thread.Stop();
 }
 
-IPCCommandResult OH0::Open(const OpenRequest& request)
+std::optional<IPCReply> OH0::Open(const OpenRequest& request)
 {
   if (HasFeature(m_ios.GetVersion(), Feature::NewUSB))
-    return GetDefaultReply(IPC_EACCES);
+    return IPCReply(IPC_EACCES);
   return USBHost::Open(request);
 }
 
-IPCCommandResult OH0::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> OH0::IOCtl(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
@@ -48,11 +48,11 @@ IPCCommandResult OH0::IOCtl(const IOCtlRequest& request)
   case USB::IOCTL_USBV0_CANCEL_INSERT_HOOK:
     return CancelInsertionHook(request);
   default:
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 }
 
-IPCCommandResult OH0::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> OH0::IOCtlV(const IOCtlVRequest& request)
 {
   INFO_LOG_FMT(IOS_USB, "/dev/usb/oh0 - IOCtlV {}", request.request);
   switch (request.request)
@@ -70,7 +70,7 @@ IPCCommandResult OH0::IOCtlV(const IOCtlVRequest& request)
   case USB::IOCTLV_USBV0_DEVINSERTHOOKID:
     return RegisterInsertionHookWithID(request);
   default:
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 }
 
@@ -88,26 +88,26 @@ void OH0::DoState(PointerWrap& p)
   USBHost::DoState(p);
 }
 
-IPCCommandResult OH0::CancelInsertionHook(const IOCtlRequest& request)
+IPCReply OH0::CancelInsertionHook(const IOCtlRequest& request)
 {
   if (!request.buffer_in || request.buffer_in_size != 4)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   // IOS assigns random IDs, but ours are simply the VID + PID (see RegisterInsertionHookWithID)
   TriggerHook(m_insertion_hooks,
               {Memory::Read_U16(request.buffer_in), Memory::Read_U16(request.buffer_in + 2)},
               USB_ECANCELED);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult OH0::GetDeviceList(const IOCtlVRequest& request) const
+IPCReply OH0::GetDeviceList(const IOCtlVRequest& request) const
 {
   if (!request.HasNumberOfValidVectors(2, 2))
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   const u8 max_entries_count = Memory::Read_U8(request.in_vectors[0].address);
   if (request.io_vectors[1].size != max_entries_count * sizeof(DeviceEntry))
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   const u8 interface_class = Memory::Read_U8(request.in_vectors[1].address);
   u8 entries_count = 0;
@@ -126,91 +126,91 @@ IPCCommandResult OH0::GetDeviceList(const IOCtlVRequest& request) const
     Memory::CopyToEmu(request.io_vectors[1].address + 8 * entries_count++, &entry, 8);
   }
   Memory::Write_U8(entries_count, request.io_vectors[0].address);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult OH0::GetRhDesca(const IOCtlRequest& request) const
+IPCReply OH0::GetRhDesca(const IOCtlRequest& request) const
 {
   if (!request.buffer_out || request.buffer_out_size != 4)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   // Based on a hardware test, this ioctl seems to return a constant value
   Memory::Write_U32(0x02000302, request.buffer_out);
   request.Dump(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LWARNING);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult OH0::GetRhPortStatus(const IOCtlVRequest& request) const
+IPCReply OH0::GetRhPortStatus(const IOCtlVRequest& request) const
 {
   if (!request.HasNumberOfValidVectors(1, 1))
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   ERROR_LOG_FMT(IOS_USB, "Unimplemented IOCtlV: IOCTLV_USBV0_GETRHPORTSTATUS");
   request.Dump(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LERROR);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult OH0::SetRhPortStatus(const IOCtlVRequest& request)
+IPCReply OH0::SetRhPortStatus(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 0))
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   ERROR_LOG_FMT(IOS_USB, "Unimplemented IOCtlV: IOCTLV_USBV0_SETRHPORTSTATUS");
   request.Dump(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LERROR);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult OH0::RegisterRemovalHook(const u64 device_id, const IOCtlRequest& request)
+std::optional<IPCReply> OH0::RegisterRemovalHook(const u64 device_id, const IOCtlRequest& request)
 {
   std::lock_guard lock{m_hooks_mutex};
   // IOS only allows a single device removal hook.
   if (m_removal_hooks.find(device_id) != m_removal_hooks.end())
-    return GetDefaultReply(IPC_EEXIST);
+    return IPCReply(IPC_EEXIST);
   m_removal_hooks.insert({device_id, request.address});
-  return GetNoReply();
+  return std::nullopt;
 }
 
-IPCCommandResult OH0::RegisterInsertionHook(const IOCtlVRequest& request)
+std::optional<IPCReply> OH0::RegisterInsertionHook(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 0))
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   const u16 vid = Memory::Read_U16(request.in_vectors[0].address);
   const u16 pid = Memory::Read_U16(request.in_vectors[1].address);
   if (HasDeviceWithVidPid(vid, pid))
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
 
   std::lock_guard lock{m_hooks_mutex};
   // TODO: figure out whether IOS allows more than one hook.
   m_insertion_hooks[{vid, pid}] = request.address;
-  return GetNoReply();
+  return std::nullopt;
 }
 
-IPCCommandResult OH0::RegisterInsertionHookWithID(const IOCtlVRequest& request)
+std::optional<IPCReply> OH0::RegisterInsertionHookWithID(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 1))
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   std::lock_guard lock{m_hooks_mutex};
   const u16 vid = Memory::Read_U16(request.in_vectors[0].address);
   const u16 pid = Memory::Read_U16(request.in_vectors[1].address);
   const bool trigger_only_for_new_device = Memory::Read_U8(request.in_vectors[2].address) == 1;
   if (!trigger_only_for_new_device && HasDeviceWithVidPid(vid, pid))
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   // TODO: figure out whether IOS allows more than one hook.
   m_insertion_hooks.insert({{vid, pid}, request.address});
   // The output vector is overwritten with an ID to use with ioctl 31 for cancelling the hook.
   Memory::Write_U32(vid << 16 | pid, request.io_vectors[0].address);
-  return GetNoReply();
+  return std::nullopt;
 }
 
-IPCCommandResult OH0::RegisterClassChangeHook(const IOCtlVRequest& request)
+std::optional<IPCReply> OH0::RegisterClassChangeHook(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0))
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   WARN_LOG_FMT(IOS_USB, "Unimplemented IOCtlV: USB::IOCTLV_USBV0_DEVICECLASSCHANGE (no reply)");
   request.Dump(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LWARNING);
-  return GetNoReply();
+  return std::nullopt;
 }
 
 bool OH0::HasDeviceWithVidPid(const u16 vid, const u16 pid) const
@@ -270,11 +270,11 @@ void OH0::DeviceClose(const u64 device_id)
   m_opened_devices.erase(device_id);
 }
 
-IPCCommandResult OH0::DeviceIOCtl(const u64 device_id, const IOCtlRequest& request)
+std::optional<IPCReply> OH0::DeviceIOCtl(const u64 device_id, const IOCtlRequest& request)
 {
   const auto device = GetDeviceById(device_id);
   if (!device)
-    return GetDefaultReply(IPC_ENOENT);
+    return IPCReply(IPC_ENOENT);
 
   switch (request.request)
   {
@@ -283,20 +283,20 @@ IPCCommandResult OH0::DeviceIOCtl(const u64 device_id, const IOCtlRequest& reque
   case USB::IOCTL_USBV0_SUSPENDDEV:
   case USB::IOCTL_USBV0_RESUMEDEV:
     // Unimplemented because libusb doesn't do power management.
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   case USB::IOCTL_USBV0_RESET_DEVICE:
     TriggerHook(m_removal_hooks, device_id, IPC_SUCCESS);
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   default:
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 }
 
-IPCCommandResult OH0::DeviceIOCtlV(const u64 device_id, const IOCtlVRequest& request)
+std::optional<IPCReply> OH0::DeviceIOCtlV(const u64 device_id, const IOCtlVRequest& request)
 {
   const auto device = GetDeviceById(device_id);
   if (!device)
-    return GetDefaultReply(IPC_ENOENT);
+    return IPCReply(IPC_ENOENT);
 
   switch (request.request)
   {
@@ -309,9 +309,9 @@ IPCCommandResult OH0::DeviceIOCtlV(const u64 device_id, const IOCtlVRequest& req
                           [&, this]() { return SubmitTransfer(*device, request); });
   case USB::IOCTLV_USBV0_UNKNOWN_32:
     request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB);
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   default:
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 }
 

--- a/Source/Core/Core/IOS/USB/OH0/OH0.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.h
@@ -37,27 +37,27 @@ public:
   OH0(Kernel& ios, const std::string& device_name);
   ~OH0() override;
 
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
   std::pair<ReturnCode, u64> DeviceOpen(u16 vid, u16 pid);
   void DeviceClose(u64 device_id);
-  IPCCommandResult DeviceIOCtl(u64 device_id, const IOCtlRequest& request);
-  IPCCommandResult DeviceIOCtlV(u64 device_id, const IOCtlVRequest& request);
+  std::optional<IPCReply> DeviceIOCtl(u64 device_id, const IOCtlRequest& request);
+  std::optional<IPCReply> DeviceIOCtlV(u64 device_id, const IOCtlVRequest& request);
 
   void DoState(PointerWrap& p) override;
 
 private:
-  IPCCommandResult CancelInsertionHook(const IOCtlRequest& request);
-  IPCCommandResult GetDeviceList(const IOCtlVRequest& request) const;
-  IPCCommandResult GetRhDesca(const IOCtlRequest& request) const;
-  IPCCommandResult GetRhPortStatus(const IOCtlVRequest& request) const;
-  IPCCommandResult SetRhPortStatus(const IOCtlVRequest& request);
-  IPCCommandResult RegisterRemovalHook(u64 device_id, const IOCtlRequest& request);
-  IPCCommandResult RegisterInsertionHook(const IOCtlVRequest& request);
-  IPCCommandResult RegisterInsertionHookWithID(const IOCtlVRequest& request);
-  IPCCommandResult RegisterClassChangeHook(const IOCtlVRequest& request);
+  IPCReply CancelInsertionHook(const IOCtlRequest& request);
+  IPCReply GetDeviceList(const IOCtlVRequest& request) const;
+  IPCReply GetRhDesca(const IOCtlRequest& request) const;
+  IPCReply GetRhPortStatus(const IOCtlVRequest& request) const;
+  IPCReply SetRhPortStatus(const IOCtlVRequest& request);
+  std::optional<IPCReply> RegisterRemovalHook(u64 device_id, const IOCtlRequest& request);
+  std::optional<IPCReply> RegisterInsertionHook(const IOCtlVRequest& request);
+  std::optional<IPCReply> RegisterInsertionHookWithID(const IOCtlVRequest& request);
+  std::optional<IPCReply> RegisterClassChangeHook(const IOCtlVRequest& request);
   s32 SubmitTransfer(USB::Device& device, const IOCtlVRequest& request);
 
   bool HasDeviceWithVidPid(u16 vid, u16 pid) const;

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -51,30 +51,30 @@ void OH0Device::DoState(PointerWrap& p)
   p.Do(m_device_id);
 }
 
-IPCCommandResult OH0Device::Open(const OpenRequest& request)
+std::optional<IPCReply> OH0Device::Open(const OpenRequest& request)
 {
   if (m_vid == 0 && m_pid == 0)
-    return GetDefaultReply(IPC_ENOENT);
+    return IPCReply(IPC_ENOENT);
 
   m_oh0 = std::static_pointer_cast<OH0>(GetIOS()->GetDeviceByName("/dev/usb/oh0"));
 
   ReturnCode return_code;
   std::tie(return_code, m_device_id) = m_oh0->DeviceOpen(m_vid, m_pid);
-  return GetDefaultReply(return_code);
+  return IPCReply(return_code);
 }
 
-IPCCommandResult OH0Device::Close(u32 fd)
+std::optional<IPCReply> OH0Device::Close(u32 fd)
 {
   m_oh0->DeviceClose(m_device_id);
   return Device::Close(fd);
 }
 
-IPCCommandResult OH0Device::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> OH0Device::IOCtl(const IOCtlRequest& request)
 {
   return m_oh0->DeviceIOCtl(m_device_id, request);
 }
 
-IPCCommandResult OH0Device::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> OH0Device::IOCtlV(const IOCtlVRequest& request)
 {
   return m_oh0->DeviceIOCtlV(m_device_id, request);
 }

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.h
@@ -20,10 +20,10 @@ class OH0Device final : public Device
 public:
   OH0Device(Kernel& ios, const std::string& device_name);
 
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult Close(u32 fd) override;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> Close(u32 fd) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
   void DoState(PointerWrap& p) override;
 
 private:

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -113,10 +113,10 @@ USBV5ResourceManager::USBV5Device* USBV5ResourceManager::GetUSBV5Device(u32 in_b
   return usbv5_device;
 }
 
-IPCCommandResult USBV5ResourceManager::GetDeviceChange(const IOCtlRequest& request)
+std::optional<IPCReply> USBV5ResourceManager::GetDeviceChange(const IOCtlRequest& request)
 {
   if (request.buffer_out_size != 0x180 || m_devicechange_hook_request)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   std::lock_guard lk{m_devicechange_hook_address_mutex};
   m_devicechange_hook_request = std::make_unique<IOCtlRequest>(request.address);
@@ -126,28 +126,27 @@ IPCCommandResult USBV5ResourceManager::GetDeviceChange(const IOCtlRequest& reque
     TriggerDeviceChangeReply();
     m_devicechange_first_call = false;
   }
-  return GetNoReply();
+  return std::nullopt;
 }
 
-IPCCommandResult USBV5ResourceManager::SetAlternateSetting(USBV5Device& device,
-                                                           const IOCtlRequest& request)
+IPCReply USBV5ResourceManager::SetAlternateSetting(USBV5Device& device, const IOCtlRequest& request)
 {
   const auto host_device = GetDeviceById(device.host_id);
   if (!host_device->AttachAndChangeInterface(device.interface_number))
-    return GetDefaultReply(-1);
+    return IPCReply(-1);
 
   const u8 alt_setting = Memory::Read_U8(request.buffer_in + 2 * sizeof(s32));
 
   const bool success = host_device->SetAltSetting(alt_setting) == 0;
-  return GetDefaultReply(success ? IPC_SUCCESS : IPC_EINVAL);
+  return IPCReply(success ? IPC_SUCCESS : IPC_EINVAL);
 }
 
-IPCCommandResult USBV5ResourceManager::Shutdown(const IOCtlRequest& request)
+IPCReply USBV5ResourceManager::Shutdown(const IOCtlRequest& request)
 {
   if (request.buffer_in != 0 || request.buffer_in_size != 0 || request.buffer_out != 0 ||
       request.buffer_out_size != 0)
   {
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 
   std::lock_guard lk{m_devicechange_hook_address_mutex};
@@ -156,11 +155,10 @@ IPCCommandResult USBV5ResourceManager::Shutdown(const IOCtlRequest& request)
     m_ios.EnqueueIPCReply(*m_devicechange_hook_request, IPC_SUCCESS);
     m_devicechange_hook_request.reset();
   }
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult USBV5ResourceManager::SuspendResume(USBV5Device& device,
-                                                     const IOCtlRequest& request)
+IPCReply USBV5ResourceManager::SuspendResume(USBV5Device& device, const IOCtlRequest& request)
 {
   const auto host_device = GetDeviceById(device.host_id);
   const s32 resumed = Memory::Read_U32(request.buffer_in + 8);
@@ -169,19 +167,19 @@ IPCCommandResult USBV5ResourceManager::SuspendResume(USBV5Device& device,
   // platform-independant way (libusb does not support power management).
   INFO_LOG_FMT(IOS_USB, "[{:04x}:{:04x} {}] Received {} command", host_device->GetVid(),
                host_device->GetPid(), device.interface_number, resumed == 0 ? "suspend" : "resume");
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult USBV5ResourceManager::HandleDeviceIOCtl(const IOCtlRequest& request,
-                                                         Handler handler)
+std::optional<IPCReply> USBV5ResourceManager::HandleDeviceIOCtl(const IOCtlRequest& request,
+                                                                Handler handler)
 {
   if (request.buffer_in == 0 || request.buffer_in_size != 0x20)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   std::lock_guard lock{m_usbv5_devices_mutex};
   USBV5Device* device = GetUSBV5Device(request.buffer_in);
   if (!device)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   return handler(*device);
 }
 

--- a/Source/Core/Core/IOS/USB/USBV5.h
+++ b/Source/Core/Core/IOS/USB/USBV5.h
@@ -68,8 +68,8 @@ class USBV5ResourceManager : public USBHost
 public:
   using USBHost::USBHost;
 
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override = 0;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override = 0;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override = 0;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override = 0;
 
   void DoState(PointerWrap& p) override;
 
@@ -77,13 +77,13 @@ protected:
   struct USBV5Device;
   USBV5Device* GetUSBV5Device(u32 in_buffer);
 
-  IPCCommandResult GetDeviceChange(const IOCtlRequest& request);
-  IPCCommandResult SetAlternateSetting(USBV5Device& device, const IOCtlRequest& request);
-  IPCCommandResult Shutdown(const IOCtlRequest& request);
-  IPCCommandResult SuspendResume(USBV5Device& device, const IOCtlRequest& request);
+  std::optional<IPCReply> GetDeviceChange(const IOCtlRequest& request);
+  IPCReply SetAlternateSetting(USBV5Device& device, const IOCtlRequest& request);
+  IPCReply Shutdown(const IOCtlRequest& request);
+  IPCReply SuspendResume(USBV5Device& device, const IOCtlRequest& request);
 
-  using Handler = std::function<IPCCommandResult(USBV5Device&)>;
-  IPCCommandResult HandleDeviceIOCtl(const IOCtlRequest& request, Handler handler);
+  using Handler = std::function<std::optional<IPCReply>(USBV5Device&)>;
+  std::optional<IPCReply> HandleDeviceIOCtl(const IOCtlRequest& request, Handler handler);
 
   void OnDeviceChange(ChangeEvent event, std::shared_ptr<USB::Device> device) override;
   void OnDeviceChangeEnd() override;

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -31,20 +31,20 @@ USB_HIDv4::~USB_HIDv4()
   m_scan_thread.Stop();
 }
 
-IPCCommandResult USB_HIDv4::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> USB_HIDv4::IOCtl(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {
   case USB::IOCTL_USBV4_GETVERSION:
-    return GetDefaultReply(VERSION);
+    return IPCReply(VERSION);
   case USB::IOCTL_USBV4_GETDEVICECHANGE:
     return GetDeviceChange(request);
   case USB::IOCTL_USBV4_SHUTDOWN:
     return Shutdown(request);
   case USB::IOCTL_USBV4_SET_SUSPEND:
     // Not implemented in IOS
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   case USB::IOCTL_USBV4_CANCELINTERRUPT:
     return CancelInterrupt(request);
   case USB::IOCTL_USBV4_GET_US_STRING:
@@ -53,36 +53,36 @@ IPCCommandResult USB_HIDv4::IOCtl(const IOCtlRequest& request)
   case USB::IOCTL_USBV4_INTRMSG_OUT:
   {
     if (request.buffer_in == 0 || request.buffer_in_size != 32)
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
     const auto device = GetDeviceByIOSID(Memory::Read_U32(request.buffer_in + 16));
     if (!device->Attach())
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
     return HandleTransfer(device, request.request,
                           [&, this]() { return SubmitTransfer(*device, request); });
   }
   default:
     request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB);
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   }
 }
 
-IPCCommandResult USB_HIDv4::CancelInterrupt(const IOCtlRequest& request)
+IPCReply USB_HIDv4::CancelInterrupt(const IOCtlRequest& request)
 {
   if (request.buffer_in == 0 || request.buffer_in_size != 8)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   auto device = GetDeviceByIOSID(Memory::Read_U32(request.buffer_in));
   if (!device)
-    return GetDefaultReply(IPC_ENOENT);
+    return IPCReply(IPC_ENOENT);
   device->CancelTransfer(Memory::Read_U8(request.buffer_in + 4));
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult USB_HIDv4::GetDeviceChange(const IOCtlRequest& request)
+std::optional<IPCReply> USB_HIDv4::GetDeviceChange(const IOCtlRequest& request)
 {
   std::lock_guard lk{m_devicechange_hook_address_mutex};
   if (request.buffer_out == 0 || request.buffer_out_size != 0x600)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   m_devicechange_hook_request = std::make_unique<IOCtlRequest>(request.address);
   // On the first call, the reply is sent immediately (instead of on device insertion/removal)
@@ -91,10 +91,10 @@ IPCCommandResult USB_HIDv4::GetDeviceChange(const IOCtlRequest& request)
     TriggerDeviceChangeReply();
     m_devicechange_first_call = false;
   }
-  return GetNoReply();
+  return std::nullopt;
 }
 
-IPCCommandResult USB_HIDv4::Shutdown(const IOCtlRequest& request)
+IPCReply USB_HIDv4::Shutdown(const IOCtlRequest& request)
 {
   std::lock_guard lk{m_devicechange_hook_address_mutex};
   if (m_devicechange_hook_request != 0)
@@ -103,7 +103,7 @@ IPCCommandResult USB_HIDv4::Shutdown(const IOCtlRequest& request)
     m_ios.EnqueueIPCReply(*m_devicechange_hook_request, -1);
     m_devicechange_hook_request.reset();
   }
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
 s32 USB_HIDv4::SubmitTransfer(USB::Device& device, const IOCtlRequest& request)

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
@@ -24,16 +24,16 @@ public:
   USB_HIDv4(Kernel& ios, const std::string& device_name);
   ~USB_HIDv4() override;
 
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
 
   void DoState(PointerWrap& p) override;
 
 private:
   std::shared_ptr<USB::Device> GetDeviceByIOSID(s32 ios_id) const;
 
-  IPCCommandResult CancelInterrupt(const IOCtlRequest& request);
-  IPCCommandResult GetDeviceChange(const IOCtlRequest& request);
-  IPCCommandResult Shutdown(const IOCtlRequest& request);
+  IPCReply CancelInterrupt(const IOCtlRequest& request);
+  std::optional<IPCReply> GetDeviceChange(const IOCtlRequest& request);
+  IPCReply Shutdown(const IOCtlRequest& request);
   s32 SubmitTransfer(USB::Device& device, const IOCtlRequest& request);
 
   void TriggerDeviceChangeReply();

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -23,14 +23,14 @@ USB_HIDv5::~USB_HIDv5()
   m_scan_thread.Stop();
 }
 
-IPCCommandResult USB_HIDv5::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> USB_HIDv5::IOCtl(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {
   case USB::IOCTL_USBV5_GETVERSION:
     Memory::Write_U32(USBV5_VERSION, request.buffer_out);
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   case USB::IOCTL_USBV5_GETDEVICECHANGE:
     return GetDeviceChange(request);
   case USB::IOCTL_USBV5_SHUTDOWN:
@@ -39,7 +39,7 @@ IPCCommandResult USB_HIDv5::IOCtl(const IOCtlRequest& request)
     return HandleDeviceIOCtl(request,
                              [&](USBV5Device& device) { return GetDeviceInfo(device, request); });
   case USB::IOCTL_USBV5_ATTACHFINISH:
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   case USB::IOCTL_USBV5_SUSPEND_RESUME:
     return HandleDeviceIOCtl(request,
                              [&](USBV5Device& device) { return SuspendResume(device, request); });
@@ -48,11 +48,11 @@ IPCCommandResult USB_HIDv5::IOCtl(const IOCtlRequest& request)
                              [&](USBV5Device& device) { return CancelEndpoint(device, request); });
   default:
     request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LERROR);
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   }
 }
 
-IPCCommandResult USB_HIDv5::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> USB_HIDv5::IOCtlV(const IOCtlVRequest& request)
 {
   request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
@@ -63,12 +63,12 @@ IPCCommandResult USB_HIDv5::IOCtlV(const IOCtlVRequest& request)
   {
     // IOS does not check the number of vectors, but let's do that to avoid out-of-bounds reads.
     if (request.in_vectors.size() + request.io_vectors.size() != 2)
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
 
     std::lock_guard lock{m_usbv5_devices_mutex};
     USBV5Device* device = GetUSBV5Device(request.in_vectors[0].address);
     if (!device)
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
     auto host_device = GetDeviceById(device->host_id);
     if (request.request == USB::IOCTLV_USBV5_CTRLMSG)
       host_device->Attach();
@@ -78,7 +78,7 @@ IPCCommandResult USB_HIDv5::IOCtlV(const IOCtlVRequest& request)
                           [&, this]() { return SubmitTransfer(*device, *host_device, request); });
   }
   default:
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 }
 
@@ -109,7 +109,7 @@ s32 USB_HIDv5::SubmitTransfer(USBV5Device& device, USB::Device& host_device,
   }
 }
 
-IPCCommandResult USB_HIDv5::CancelEndpoint(USBV5Device& device, const IOCtlRequest& request)
+IPCReply USB_HIDv5::CancelEndpoint(USBV5Device& device, const IOCtlRequest& request)
 {
   const u8 value = Memory::Read_U8(request.buffer_in + 8);
   u8 endpoint = 0;
@@ -130,13 +130,13 @@ IPCCommandResult USB_HIDv5::CancelEndpoint(USBV5Device& device, const IOCtlReque
   }
 
   GetDeviceById(device.host_id)->CancelTransfer(endpoint);
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult USB_HIDv5::GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request)
+IPCReply USB_HIDv5::GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request)
 {
   if (request.buffer_out == 0 || request.buffer_out_size != 0x60)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   const std::shared_ptr<USB::Device> host_device = GetDeviceById(device.host_id);
   const u8 alt_setting = Memory::Read_U8(request.buffer_in + 8);
@@ -161,7 +161,7 @@ IPCCommandResult USB_HIDv5::GetDeviceInfo(USBV5Device& device, const IOCtlReques
                                   interface.bAlternateSetting == alt_setting;
                          });
   if (it == interfaces.end())
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   it->Swap();
   Memory::CopyToEmu(request.buffer_out + 68, &*it, sizeof(*it));
 
@@ -186,7 +186,7 @@ IPCCommandResult USB_HIDv5::GetDeviceInfo(USBV5Device& device, const IOCtlReques
     }
   }
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
 bool USB_HIDv5::ShouldAddDevice(const USB::Device& device) const

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.h
@@ -17,12 +17,12 @@ public:
   using USBV5ResourceManager::USBV5ResourceManager;
   ~USB_HIDv5() override;
 
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
 private:
-  IPCCommandResult CancelEndpoint(USBV5Device& device, const IOCtlRequest& request);
-  IPCCommandResult GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request);
+  IPCReply CancelEndpoint(USBV5Device& device, const IOCtlRequest& request);
+  IPCReply GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request);
   s32 SubmitTransfer(USBV5Device& device, USB::Device& host_device, const IOCtlVRequest& ioctlv);
 
   bool ShouldAddDevice(const USB::Device& device) const override;

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -188,7 +188,7 @@ USB_KBD::USB_KBD(Kernel& ios, const std::string& device_name) : Device(ios, devi
 {
 }
 
-IPCCommandResult USB_KBD::Open(const OpenRequest& request)
+std::optional<IPCReply> USB_KBD::Open(const OpenRequest& request)
 {
   INFO_LOG_FMT(IOS, "USB_KBD: Open");
   IniFile ini;
@@ -203,13 +203,13 @@ IPCCommandResult USB_KBD::Open(const OpenRequest& request)
   return Device::Open(request);
 }
 
-IPCCommandResult USB_KBD::Write(const ReadWriteRequest& request)
+std::optional<IPCReply> USB_KBD::Write(const ReadWriteRequest& request)
 {
   // Stubbed.
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult USB_KBD::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> USB_KBD::IOCtl(const IOCtlRequest& request)
 {
   if (SConfig::GetInstance().m_WiiKeyboard && !Core::WantsDeterminism() &&
       ControlReference::GetInputGate() && !m_message_queue.empty())
@@ -217,7 +217,7 @@ IPCCommandResult USB_KBD::IOCtl(const IOCtlRequest& request)
     Memory::CopyToEmu(request.buffer_out, &m_message_queue.front(), sizeof(MessageData));
     m_message_queue.pop();
   }
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 
 bool USB_KBD::IsKeyPressed(int key) const

--- a/Source/Core/Core/IOS/USB/USB_KBD.h
+++ b/Source/Core/Core/IOS/USB/USB_KBD.h
@@ -20,9 +20,9 @@ class USB_KBD : public Device
 public:
   USB_KBD(Kernel& ios, const std::string& device_name);
 
-  IPCCommandResult Open(const OpenRequest& request) override;
-  IPCCommandResult Write(const ReadWriteRequest& request) override;
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> Open(const OpenRequest& request) override;
+  std::optional<IPCReply> Write(const ReadWriteRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
   void Update() override;
 
 private:

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -23,14 +23,14 @@ USB_VEN::~USB_VEN()
   m_scan_thread.Stop();
 }
 
-IPCCommandResult USB_VEN::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> USB_VEN::IOCtl(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {
   case USB::IOCTL_USBV5_GETVERSION:
     Memory::Write_U32(USBV5_VERSION, request.buffer_out);
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   case USB::IOCTL_USBV5_GETDEVICECHANGE:
     return GetDeviceChange(request);
   case USB::IOCTL_USBV5_SHUTDOWN:
@@ -39,7 +39,7 @@ IPCCommandResult USB_VEN::IOCtl(const IOCtlRequest& request)
     return HandleDeviceIOCtl(request,
                              [&](USBV5Device& device) { return GetDeviceInfo(device, request); });
   case USB::IOCTL_USBV5_ATTACHFINISH:
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   case USB::IOCTL_USBV5_SETALTERNATE:
     return HandleDeviceIOCtl(
         request, [&](USBV5Device& device) { return SetAlternateSetting(device, request); });
@@ -51,11 +51,11 @@ IPCCommandResult USB_VEN::IOCtl(const IOCtlRequest& request)
                              [&](USBV5Device& device) { return CancelEndpoint(device, request); });
   default:
     request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LERROR);
-    return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_SUCCESS);
   }
 }
 
-IPCCommandResult USB_VEN::IOCtlV(const IOCtlVRequest& request)
+std::optional<IPCReply> USB_VEN::IOCtlV(const IOCtlVRequest& request)
 {
   static const std::map<u32, u32> s_num_vectors = {
       {USB::IOCTLV_USBV5_CTRLMSG, 2},
@@ -72,12 +72,12 @@ IPCCommandResult USB_VEN::IOCtlV(const IOCtlVRequest& request)
   case USB::IOCTLV_USBV5_ISOMSG:
   {
     if (request.in_vectors.size() + request.io_vectors.size() != s_num_vectors.at(request.request))
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
 
     std::lock_guard lock{m_usbv5_devices_mutex};
     USBV5Device* device = GetUSBV5Device(request.in_vectors[0].address);
     if (!device)
-      return GetDefaultReply(IPC_EINVAL);
+      return IPCReply(IPC_EINVAL);
     auto host_device = GetDeviceById(device->host_id);
     if (request.request == USB::IOCTLV_USBV5_CTRLMSG)
       host_device->Attach();
@@ -87,7 +87,7 @@ IPCCommandResult USB_VEN::IOCtlV(const IOCtlVRequest& request)
                           [&, this]() { return SubmitTransfer(*host_device, request); });
   }
   default:
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   }
 }
 
@@ -108,19 +108,19 @@ s32 USB_VEN::SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv)
   }
 }
 
-IPCCommandResult USB_VEN::CancelEndpoint(USBV5Device& device, const IOCtlRequest& request)
+IPCReply USB_VEN::CancelEndpoint(USBV5Device& device, const IOCtlRequest& request)
 {
   const u8 endpoint = Memory::Read_U8(request.buffer_in + 8);
   // IPC_EINVAL (-4) is returned when no transfer was cancelled.
   if (GetDeviceById(device.host_id)->CancelTransfer(endpoint) < 0)
-    return GetDefaultReply(IPC_EINVAL);
-  return GetDefaultReply(IPC_SUCCESS);
+    return IPCReply(IPC_EINVAL);
+  return IPCReply(IPC_SUCCESS);
 }
 
-IPCCommandResult USB_VEN::GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request)
+IPCReply USB_VEN::GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request)
 {
   if (request.buffer_out == 0 || request.buffer_out_size != 0xc0)
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
 
   const std::shared_ptr<USB::Device> host_device = GetDeviceById(device.host_id);
   const u8 alt_setting = Memory::Read_U8(request.buffer_in + 8);
@@ -145,7 +145,7 @@ IPCCommandResult USB_VEN::GetDeviceInfo(USBV5Device& device, const IOCtlRequest&
                                   interface.bAlternateSetting == alt_setting;
                          });
   if (it == interfaces.end())
-    return GetDefaultReply(IPC_EINVAL);
+    return IPCReply(IPC_EINVAL);
   it->Swap();
   Memory::CopyToEmu(request.buffer_out + 52, &*it, sizeof(*it));
 
@@ -157,6 +157,6 @@ IPCCommandResult USB_VEN::GetDeviceInfo(USBV5Device& device, const IOCtlRequest&
                       sizeof(endpoints[i]));
   }
 
-  return GetDefaultReply(IPC_SUCCESS);
+  return IPCReply(IPC_SUCCESS);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
@@ -17,12 +17,12 @@ public:
   using USBV5ResourceManager::USBV5ResourceManager;
   ~USB_VEN() override;
 
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
 private:
-  IPCCommandResult CancelEndpoint(USBV5Device& device, const IOCtlRequest& request);
-  IPCCommandResult GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request);
+  IPCReply CancelEndpoint(USBV5Device& device, const IOCtlRequest& request);
+  IPCReply GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request);
 
   s32 SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv);
   bool HasInterfaceNumberInIDs() const override { return false; }

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -124,7 +124,7 @@ void WFSIDevice::FinalizePatchInstall()
   File::CopyDir(WFS::NativePath(patch_dir), WFS::NativePath(current_title_dir), true);
 }
 
-IPCCommandResult WFSIDevice::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> WFSIDevice::IOCtl(const IOCtlRequest& request)
 {
   s32 return_error_code = IPC_SUCCESS;
 
@@ -546,7 +546,7 @@ IPCCommandResult WFSIDevice::IOCtl(const IOCtlRequest& request)
     break;
   }
 
-  return GetDefaultReply(return_error_code);
+  return IPCReply(return_error_code);
 }
 
 u32 WFSIDevice::GetTmd(u16 group_id, u32 title_id, u64 subtitle_id, u32 address, u32* size) const

--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -37,7 +37,7 @@ class WFSIDevice : public Device
 public:
   WFSIDevice(Kernel& ios, const std::string& device_name);
 
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
 
 private:
   u32 GetTmd(u16 group_id, u32 title_id, u64 subtitle_id, u32 address, u32* size) const;

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -31,7 +31,7 @@ WFSSRVDevice::WFSSRVDevice(Kernel& ios, const std::string& device_name) : Device
   m_device_name = "msc01";
 }
 
-IPCCommandResult WFSSRVDevice::IOCtl(const IOCtlRequest& request)
+std::optional<IPCReply> WFSSRVDevice::IOCtl(const IOCtlRequest& request)
 {
   int return_error_code = IPC_SUCCESS;
 
@@ -90,7 +90,7 @@ IPCCommandResult WFSSRVDevice::IOCtl(const IOCtlRequest& request)
 
     // Leave hanging, but we need to acknowledge the request at shutdown time.
     m_hanging.push_back(request.address);
-    return GetNoReply();
+    return std::nullopt;
 
   case IOCTL_WFS_FLUSH:
     // Nothing to do.
@@ -359,7 +359,7 @@ IPCCommandResult WFSSRVDevice::IOCtl(const IOCtlRequest& request)
     break;
   }
 
-  return GetDefaultReply(return_error_code);
+  return IPCReply(return_error_code);
 }
 
 s32 WFSSRVDevice::Rename(std::string source, std::string dest) const

--- a/Source/Core/Core/IOS/WFS/WFSSRV.h
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.h
@@ -34,7 +34,7 @@ class WFSSRVDevice : public Device
 public:
   WFSSRVDevice(Kernel& ios, const std::string& device_name);
 
-  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
 
   s32 Rename(std::string source, std::string dest) const;
   void SetHomeDir(const std::string& home_dir);


### PR DESCRIPTION
Instead of constructing IPCCommandResult with static member functions
in the Device class, we can just add the relevant constructors to the
reply struct itself. Makes more sense than putting it in Device when the
struct is also used in the kernel code and doesn't use any Device
specific members...

This commit also changes the IPC command handlers to return an optional
IPCCommandResult rather than an IPCCommandResult. This removes the need
for a separate boolean that indicates whether the "result" is actually
a reply, and also avoids the need to set dummy result values and ticks.

It also makes it really obvious which commands can result in no reply
being generated.

Finally, this commit renames IPCCommandResult to IPCReply since the
struct is now only used for actual replies. This new name is less
verbose in my opinion.

The diff is quite large since this touches every command handler, but
the only functional change is that I fixed EnqueueIPCReply to
take a s64 for cycles_in_future to match IPCReply.