### PR TITLE
Create game INI for The Adventures of Tintin: The Game

### DIFF
--- a/Data/Sys/GameSettings/STN.ini
+++ b/Data/Sys/GameSettings/STN.ini
@@ -1,0 +1,9 @@
+# STNE41, STNP41 - The Adventures of Tintin: The Game
+
+[Video_Settings]
+# Fixes glitching in opening credits.
+SafeTextureCacheColorSamples = 512
+
+[Video_Hacks]
+# Fixes purple screen flashes between cutscenes.
+ImmediateXFBEnable = True


### PR DESCRIPTION
Creates a game INI for The Adventures of Tintin: The Game, with the following changes from default settings:

- Enable Immediately Present XFB: this prevents purple screen flashes between cutscenes.
- Set Texture Cache Accuracy to 512: this prevents glitching in the opening credits.

With these settings, my testing showed little to no performance loss and even a bit better performance in some parts of the game (as compared to disabling Store XFB Copies to Texture Only, which also prevented purple screen flashes but caused a 20-25% performance hit to an already demanding game in my tests).