### PR TITLE
Qt: Re-add IOS version to the game info tab

### DIFF
--- a/Source/Core/DolphinQt/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt/Config/InfoWidget.cpp
@@ -17,6 +17,7 @@
 
 #include "DiscIO/Blob.h"
 #include "DiscIO/Enums.h"
+#include "DiscIO/Volume.h"
 
 #include "DolphinQt/Config/InfoWidget.h"
 #include "DolphinQt/QtUtils/ImageConverter.h"
@@ -25,6 +26,8 @@
 
 InfoWidget::InfoWidget(const UICommon::GameFile& game) : m_game(game)
 {
+  m_volume = DiscIO::CreateVolume(m_game.GetFilePath());
+
   QVBoxLayout* layout = new QVBoxLayout();
 
   layout->addWidget(CreateFileDetails());
@@ -35,6 +38,8 @@ InfoWidget::InfoWidget(const UICommon::GameFile& game) : m_game(game)
 
   setLayout(layout);
 }
+
+InfoWidget::~InfoWidget() = default;
 
 QGroupBox* InfoWidget::CreateFileDetails()
 {
@@ -120,6 +125,17 @@ QGroupBox* InfoWidget::CreateGameDetails()
 
   if (!m_game.GetApploaderDate().empty())
     layout->addRow(tr("Apploader Date:"), CreateValueDisplay(m_game.GetApploaderDate()));
+
+  if (m_volume)
+  {
+    const DiscIO::Partition partition = m_volume->GetGamePartition();
+    const IOS::ES::TMDReader& tmd = m_volume->GetTMD(partition);
+    if (tmd.IsValid())
+    {
+      const auto ios = fmt::format("IOS{}", static_cast<u32>(tmd.GetIOSId()));
+      layout->addRow(tr("IOS Version:"), CreateValueDisplay(ios));
+    }
+  }
 
   group->setLayout(layout);
   return group;

--- a/Source/Core/DolphinQt/Config/InfoWidget.h
+++ b/Source/Core/DolphinQt/Config/InfoWidget.h
@@ -4,11 +4,17 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include <QWidget>
 
 #include "UICommon/GameFile.h"
+
+namespace DiscIO
+{
+class Volume;
+}
 
 class QComboBox;
 class QGroupBox;
@@ -21,6 +27,7 @@ class InfoWidget final : public QWidget
   Q_OBJECT
 public:
   explicit InfoWidget(const UICommon::GameFile& game);
+  ~InfoWidget() override;
 
 private:
   void ChangeLanguage();
@@ -34,6 +41,7 @@ private:
   void CreateLanguageSelector();
   QWidget* CreateBannerGraphic(const QPixmap& image);
 
+  std::unique_ptr<DiscIO::Volume> m_volume;
   UICommon::GameFile m_game;
   QComboBox* m_language_selector;
   QLineEdit* m_name = {};


### PR DESCRIPTION
This was accidentally removed during the Qt migration: https://github.com/dolphin-emu/dolphin/pull/4734

~~Also adds the TMD region to the game info tab, as it's useful for figuring out what region Dolphin is ultimately using for Wii games~~ The country field should suffice, as it shows the value of TypicalCountryForRegion(region) and TypicalCountryForRegion is bijective