### PR TITLE
Fix point sampling

### DIFF
--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -20,7 +20,7 @@ namespace VideoCommon
 // As pipelines encompass both shader UIDs and render states, changes to either of these should
 // also increment the pipeline UID version. Incrementing the UID version will cause all UID
 // caches to be invalidated.
-constexpr u32 GX_PIPELINE_UID_VERSION = 2;  // Last changed in PR 9122
+constexpr u32 GX_PIPELINE_UID_VERSION = 3;  // Last changed in PR 9520
 
 struct GXPipelineUid
 {

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -137,7 +137,8 @@ struct pixel_shader_uid_data
     u32 tevorders_texcoord : 3;
     u32 tevorders_enable : 1;
     u32 tevorders_colorchan : 3;
-    u32 pad1 : 6;
+    u32 tevorders_pointsample : 1;
+    u32 pad1 : 5;
 
     // TODO: Clean up the swapXY mess
     u32 hasindstage : 1;


### PR DESCRIPTION
Second attempt at fixing point sampling. 
Previous attempt (#9473 ) didn't use the UID correctly.
This doesn't implement the fix in the UberShader yet.