### PR TITLE
Debugger: Fix "Add to watch" not working

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -403,6 +403,11 @@ void MemoryViewWidget::OnContextMenu()
 
   menu->addSeparator();
 
+  menu->addAction(tr("Add to watch"), this, [this] {
+    const u32 address = GetContextAddress();
+    const QString name = QStringLiteral("mem_%1").arg(address, 8, 16, QLatin1Char('0'));
+    emit RequestWatch(name, address);
+  });
   menu->addAction(tr("Toggle Breakpoint"), this, &MemoryViewWidget::ToggleBreakpoint);
 
   menu->exec(QCursor::pos());

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -57,6 +57,7 @@ public:
 signals:
   void BreakpointsChanged();
   void ShowCode(u32 address);
+  void RequestWatch(QString name, u32 address);
 
 private:
   void OnContextMenu();

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -272,6 +272,7 @@ void MemoryWidget::ConnectWidgets()
   connect(m_memory_view, &MemoryViewWidget::BreakpointsChanged, this,
           &MemoryWidget::BreakpointsChanged);
   connect(m_memory_view, &MemoryViewWidget::ShowCode, this, &MemoryWidget::ShowCode);
+  connect(m_memory_view, &MemoryViewWidget::RequestWatch, this, &MemoryWidget::RequestWatch);
 }
 
 void MemoryWidget::closeEvent(QCloseEvent*)

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -31,6 +31,7 @@ public:
 signals:
   void BreakpointsChanged();
   void ShowCode(u32 address);
+  void RequestWatch(QString name, u32 address);
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -125,7 +125,12 @@ void RegisterWidget::ShowContextMenu()
 
     // i18n: This kind of "watch" is used for watching emulated memory.
     // It's not related to timekeeping devices.
-    menu->addAction(tr("Add to &watch"), this,
+    menu->addAction(tr("Add to &watch"), this, [this, item] {
+      const u32 address = item->GetValue();
+      const QString name = QStringLiteral("reg_%1").arg(address, 8, 16, QLatin1Char('0'));
+      emit RequestWatch(name, address);
+    });
+    menu->addAction(tr("Add memory &breakpoint"), this,
                     [this, item] { emit RequestMemoryBreakpoint(item->GetValue()); });
     menu->addAction(tr("View &memory"), this,
                     [this, item] { emit RequestViewInMemory(item->GetValue()); });

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.h
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.h
@@ -27,6 +27,7 @@ signals:
   void RequestViewInCode(u32 addr);
   void RequestViewInMemory(u32 addr);
   void RequestMemoryBreakpoint(u32 addr);
+  void RequestWatch(QString name, u32 addr);
   void UpdateTable();
   void UpdateValue(QTableWidgetItem* item);
   void UpdateValueType(QTableWidgetItem* item);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -442,6 +442,7 @@ void MainWindow::CreateComponents()
   connect(m_memory_widget, &MemoryWidget::ShowCode, m_code_widget, [this](u32 address) {
     m_code_widget->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithDetailedUpdate);
   });
+  connect(m_memory_widget, &MemoryWidget::RequestWatch, request_watch);
 
   connect(m_breakpoint_widget, &BreakpointWidget::BreakpointsChanged, m_code_widget,
           &CodeWidget::Update);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -424,6 +424,7 @@ void MainWindow::CreateComponents()
 
   connect(m_watch_widget, &WatchWidget::RequestMemoryBreakpoint, request_memory_breakpoint);
   connect(m_register_widget, &RegisterWidget::RequestMemoryBreakpoint, request_memory_breakpoint);
+  connect(m_register_widget, &RegisterWidget::RequestWatch, request_watch);
   connect(m_register_widget, &RegisterWidget::RequestViewInMemory, request_view_in_memory);
   connect(m_register_widget, &RegisterWidget::RequestViewInCode, request_view_in_code);
   connect(m_thread_widget, &ThreadWidget::RequestBreakpoint, request_breakpoint);


### PR DESCRIPTION
This PR fixes the "Add to watch" action not working (and was adding a memory BP instead) in the RegisterWidget and also adds this action in the MemoryWidget.

Ready to be reviewed & merged.