### PR TITLE
Debugger: Fix issue were loaded memory breakpoints were not being triggered (break)

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -159,7 +159,7 @@ MemChecks::TMemChecksStr MemChecks::GetStrings() const
     ss << " " << (mc.is_ranged ? mc.end_address : mc.start_address) << " "
        << (mc.is_ranged ? "n" : "") << (mc.is_break_on_read ? "r" : "")
        << (mc.is_break_on_write ? "w" : "") << (mc.log_on_hit ? "l" : "")
-       << (mc.break_on_hit ? "p" : "");
+       << (mc.break_on_hit ? "b" : "");
     mc_strings.push_back(ss.str());
   }
 


### PR DESCRIPTION
This was caused, because we were saving the `break_on_hit` flag with the letter `p`. Then while loading the breakpoints, we read the flag with the letter `b`, resulting in the `break_on_hit` flag being always false.