### PR TITLE
Fix IPC_OVERHEAD_TICKS Typo

### DIFF
--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -46,7 +46,7 @@ struct IPCReply
   u64 reply_delay_ticks;
 };
 
-constexpr u64 IPC_OVERHEAD_TICKS = 2700_tbticks;
+constexpr u64 IPC_OVERHEAD_TICKS = 2700;
 
 // Used to make it more convenient for functions to return timing information
 // without having to explicitly keep track of ticks in callers.


### PR DESCRIPTION
Fixes Majora's Mask VC taking longer to load than on console (reported on https://bugs.dolphin-emu.org/issues/11346#note-11). Majora's Mask VC and Ocarina of Time VC match my console perfectly on load with this fix (ignoring the ES_Launch timings that are not yet implemented in Dolphin)