### PR TITLE
Core: Fix time base unit mixup

### DIFF
--- a/Source/Core/Core/HW/SystemTimers.h
+++ b/Source/Core/Core/HW/SystemTimers.h
@@ -33,6 +33,15 @@ enum
   TIMER_RATIO = 12
 };
 
+struct TimeBaseTick
+{
+  constexpr TimeBaseTick() = default;
+  constexpr explicit TimeBaseTick(u64 tb_ticks) : cpu_ticks(tb_ticks * TIMER_RATIO) {}
+  constexpr operator u64() const { return cpu_ticks; }
+
+  u64 cpu_ticks = 0;
+};
+
 enum class Mode
 {
   GC,
@@ -67,8 +76,8 @@ double GetEstimatedEmulationPerformance();
 inline namespace SystemTimersLiterals
 {
 /// Converts timebase ticks to clock ticks.
-constexpr u64 operator""_tbticks(unsigned long long value)
+constexpr SystemTimers::TimeBaseTick operator""_tbticks(unsigned long long value)
 {
-  return value * SystemTimers::TIMER_RATIO;
+  return SystemTimers::TimeBaseTick(value);
 }
 }  // namespace SystemTimersLiterals

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -46,7 +46,7 @@ struct IPCReply
   u64 reply_delay_ticks;
 };
 
-constexpr u64 IPC_OVERHEAD_TICKS = 2700_tbticks;
+constexpr SystemTimers::TimeBaseTick IPC_OVERHEAD_TICKS = 2700_tbticks;
 
 // Used to make it more convenient for functions to return timing information
 // without having to explicitly keep track of ticks in callers.
@@ -60,8 +60,6 @@ public:
     if (m_ticks != nullptr)
       *m_ticks += ticks;
   }
-
-  void AddTimeBaseTicks(u64 tb_ticks) { Add(tb_ticks * SystemTimers::TIMER_RATIO); }
 
 private:
   u64* m_ticks = nullptr;


### PR DESCRIPTION
And add a strongly typed integer type so that making this kind of mistake is more difficult
