### PR TITLE
WatchWidget: Add new/delete/clear toolbar items

### DIFF
--- a/Source/Core/DolphinQt/Debugger/WatchWidget.h
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.h
@@ -34,6 +34,10 @@ private:
   void CreateWidgets();
   void ConnectWidgets();
 
+  void OnDelete();
+  void OnClear();
+  void OnNewWatch();
+
   void OnLoad();
   void OnSave();
 
@@ -47,6 +51,9 @@ private:
 
   void UpdateIcons();
 
+  QAction* m_new;
+  QAction* m_delete;
+  QAction* m_clear;
   QAction* m_load;
   QAction* m_save;
   QToolBar* m_toolbar;


### PR DESCRIPTION
This PR adds to the Watch widget toolbar items to create, delete and clear watches.

Ready to reviewed & merged.