### PR TITLE
Debugger: Allow to edit breakpoints

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -159,7 +159,7 @@ MemChecks::TMemChecksStr MemChecks::GetStrings() const
     ss << " " << (mc.is_ranged ? mc.end_address : mc.start_address) << " "
        << (mc.is_ranged ? "n" : "") << (mc.is_break_on_read ? "r" : "")
        << (mc.is_break_on_write ? "w" : "") << (mc.log_on_hit ? "l" : "")
-       << (mc.break_on_hit ? "p" : "");
+       << (mc.break_on_hit ? "b" : "");
     mc_strings.push_back(ss.str());
   }
 

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -29,7 +29,7 @@ struct TMemCheck
   u32 start_address = 0;
   u32 end_address = 0;
 
-  bool is_enabled = false;
+  bool is_enabled = true;
 
   bool is_ranged = false;
 

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -29,6 +29,8 @@ struct TMemCheck
   u32 start_address = 0;
   u32 end_address = 0;
 
+  bool is_enabled = false;
+
   bool is_ranged = false;
 
   bool is_break_on_read = false;
@@ -52,6 +54,7 @@ public:
   using TBreakPointsStr = std::vector<std::string>;
 
   const TBreakPoints& GetBreakPoints() const { return m_breakpoints; }
+  TBreakPoints& GetBreakPoints() { return m_breakpoints; }
   TBreakPointsStr GetStrings() const;
   void AddFromStrings(const TBreakPointsStr& bp_strings);
 
@@ -83,6 +86,7 @@ public:
   using TMemChecksStr = std::vector<std::string>;
 
   const TMemChecks& GetMemChecks() const { return m_mem_checks; }
+  TMemChecks& GetMemChecks() { return m_mem_checks; }
   TMemChecksStr GetStrings() const;
   void AddFromStrings(const TMemChecksStr& mc_strings);
 

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -391,7 +391,6 @@ void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool
 
   check.start_address = addr;
   check.end_address = addr;
-  check.is_enabled = true;
   check.is_ranged = false;
   check.is_break_on_read = on_read;
   check.is_break_on_write = on_write;
@@ -412,7 +411,6 @@ void BreakpointWidget::AddRangedMBP(u32 from, u32 to, bool on_read, bool on_writ
 
   check.start_address = from;
   check.end_address = to;
-  check.is_enabled = true;
   check.is_ranged = true;
   check.is_break_on_read = on_read;
   check.is_break_on_write = on_write;

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -46,6 +46,9 @@ private:
   void OnNewBreakpoint();
   void OnLoad();
   void OnSave();
+  void OnContextMenu();
+
+  void OnEditBreakPoint(u32 breakpoint_address);
 
   void UpdateIcons();
 

--- a/Source/Core/DolphinQt/Debugger/NewBreakpointDialog.h
+++ b/Source/Core/DolphinQt/Debugger/NewBreakpointDialog.h
@@ -16,11 +16,14 @@ class QLabel;
 class QLineEdit;
 class QRadioButton;
 
+struct TBreakPoint;
+struct TMemCheck;
+
 class NewBreakpointDialog : public QDialog
 {
   Q_OBJECT
 public:
-  explicit NewBreakpointDialog(BreakpointWidget* parent);
+  explicit NewBreakpointDialog(BreakpointWidget* parent, u32 breakpoint_address);
 
   void accept() override;
 
@@ -30,6 +33,10 @@ private:
 
   void OnBPTypeChanged();
   void OnAddressTypeChanged();
+
+  void OnLoadBreakpoint();
+
+  void LoadBreakpointFromCPU(u32 breakpoint_address);
 
   // Instruction BPs
   QRadioButton* m_instruction_bp;
@@ -56,4 +63,8 @@ private:
 
   QDialogButtonBox* m_buttons;
   BreakpointWidget* m_parent;
+
+  bool m_edit;
+  TBreakPoint* m_instruction_breakpoint{nullptr};
+  TMemCheck* m_memory_breakpoint{nullptr};
 };


### PR DESCRIPTION
**Depends on #9524**

## This PR do 4 things:
1. Removed the current action when selecting a breakpoint
2. Allow to toggle breakpoints between on/off
3. Add a `QTableWidget::itemDoubleClicked` listener that would directly open the edit breakpoint dialog
4. Add a Context Menu for the selected breakpoint, which add the following actions
   - Enable/Disable - Toogle between on/off
   - Go to - Old behavior of selecting a breakpoint while the game is paused
   - Edit - Launch the edit dialog

To not duplicate code, I added support to the `NewBreakpointDialog` to be able to edit existing breakpoint

### Context Menu
![image](https://user-images.githubusercontent.com/2200611/108598621-8c349400-7386-11eb-82d2-64b03d686201.png)
### Edit Instruction Breakpoint
![image](https://user-images.githubusercontent.com/2200611/108598648-b5552480-7386-11eb-82fd-f55dde7a5a30.png)
### Edit Memory Breakpoint
![image](https://user-images.githubusercontent.com/2200611/108598662-d0279900-7386-11eb-99bc-5bdd0d774172.png)



This is my first _major_ change to the codebase. Please, point out any mistake I have made or code that I should refactor in a better way.