### PR TITLE
Android: Broadcast update before updating additional metadata

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
@@ -99,7 +99,7 @@ public class GameFileCache
    *
    * @return true if the cache was modified
    */
-  public boolean scanLibrary()
+  public boolean update()
   {
     boolean recursiveScan = BooleanSetting.MAIN_RECURSIVE_ISO_PATHS.getBooleanGlobal();
 
@@ -107,13 +107,7 @@ public class GameFileCache
 
     String[] folderPaths = folderPathsSet.toArray(new String[0]);
 
-    boolean cacheChanged = update(folderPaths, recursiveScan);
-    cacheChanged |= updateAdditionalMetadata();
-    if (cacheChanged)
-    {
-      save();
-    }
-    return cacheChanged;
+    return update(folderPaths, recursiveScan);
   }
 
   public native int getSize();
@@ -122,11 +116,11 @@ public class GameFileCache
 
   public native GameFile addOrGet(String gamePath);
 
-  private native boolean update(String[] folderPaths, boolean recursiveScan);
+  public native boolean update(String[] folderPaths, boolean recursiveScan);
 
-  private native boolean updateAdditionalMetadata();
+  public native boolean updateAdditionalMetadata();
 
   public native boolean load();
 
-  private native boolean save();
+  public native boolean save();
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
@@ -177,11 +177,23 @@ public final class GameFileCacheService extends IntentService
     {
       synchronized (gameFileCache)
       {
-        boolean changed = gameFileCache.scanLibrary();
+        boolean changed = gameFileCache.update();
         if (changed)
         {
           updateGameFileArray();
           sendBroadcast(CACHE_UPDATED);
+        }
+
+        boolean additionalMetadataChanged = gameFileCache.updateAdditionalMetadata();
+        if (additionalMetadataChanged)
+        {
+          updateGameFileArray();
+          sendBroadcast(CACHE_UPDATED);
+        }
+
+        if (changed || additionalMetadataChanged)
+        {
+          gameFileCache.save();
         }
       }
     }


### PR DESCRIPTION
In master, the game scanning process looks like this:

1. Scan for games
2. Scan for additional metadata (icon.png and meta.xml)
3. Save the cache if needed
4. Update the game list with the results

This change makes the game scanning process look like this:

1. Scan for games
2. Update the game list with the results
3. Scan for additional metadata (icon.png and meta.xml)
4. Update the game list with the results
5. Save the cache if needed

Updating the game list as soon as possible means the user has to wait less before their games show up. The new behavior matches what DolphinWX did before it was removed. (DolphinQt has an even fancier approach where games get added one by one.)