### PR TITLE
Android: Use SwipeRefreshLayout in MainActivity

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/AppLinkActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/AppLinkActivity.java
@@ -67,8 +67,7 @@ public class AppLinkActivity extends FragmentActivity
     mAfterDirectoryInitializationRunner = new AfterDirectoryInitializationRunner();
     mAfterDirectoryInitializationRunner.run(this, true, () -> tryPlay(playAction));
 
-    IntentFilter gameFileCacheIntentFilter = new IntentFilter(
-            GameFileCacheService.BROADCAST_ACTION);
+    IntentFilter gameFileCacheIntentFilter = new IntentFilter(GameFileCacheService.DONE_LOADING);
 
     BroadcastReceiver gameFileCacheReceiver = new BroadcastReceiver()
     {
@@ -109,7 +108,7 @@ public class AppLinkActivity extends FragmentActivity
 
     // If game == null and the load isn't done, wait for the next GameFileCacheService broadcast.
     // If game == null and the load is done, call play with a null game, making us exit in failure.
-    if (game != null || GameFileCacheService.hasLoadedCache())
+    if (game != null || !GameFileCacheService.isLoading())
     {
       play(action, game);
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
@@ -18,6 +19,7 @@ import org.dolphinemu.dolphinemu.ui.platform.PlatformGamesFragment;
 public class PlatformPagerAdapter extends FragmentPagerAdapter
 {
   private Context mContext;
+  private SwipeRefreshLayout.OnRefreshListener mOnRefreshListener;
 
   private final static int[] TAB_ICONS =
           {
@@ -26,17 +28,19 @@ public class PlatformPagerAdapter extends FragmentPagerAdapter
                   R.drawable.ic_folder
           };
 
-  public PlatformPagerAdapter(FragmentManager fm, Context context)
+  public PlatformPagerAdapter(FragmentManager fm, Context context,
+          SwipeRefreshLayout.OnRefreshListener onRefreshListener)
   {
     super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
     mContext = context;
+    mOnRefreshListener = onRefreshListener;
   }
 
   @NonNull
   @Override
   public Fragment getItem(int position)
   {
-    return PlatformGamesFragment.newInstance(Platform.fromPosition(position));
+    return PlatformGamesFragment.newInstance(Platform.fromPosition(position), mOnRefreshListener);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
@@ -116,6 +116,8 @@ public class GameFileCache
     return cacheChanged;
   }
 
+  public native int getSize();
+
   public native GameFile[] getAllGames();
 
   public native GameFile addOrGet(String gamePath);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
@@ -15,7 +15,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -23,7 +23,17 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public final class GameFileCacheService extends IntentService
 {
-  public static final String BROADCAST_ACTION = "org.dolphinemu.dolphinemu.GAME_FILE_CACHE_UPDATED";
+  /**
+   * This is broadcast when the contents of the cache change.
+   */
+  public static final String CACHE_UPDATED = "org.dolphinemu.dolphinemu.GAME_FILE_CACHE_UPDATED";
+
+  /**
+   * This is broadcast when the service is done with all requested work, regardless of whether
+   * the contents of the cache actually changed. (Maybe the cache was already up to date.)
+   */
+  public static final String DONE_LOADING =
+          "org.dolphinemu.dolphinemu.GAME_FILE_CACHE_DONE_LOADING";
 
   private static final String ACTION_LOAD = "org.dolphinemu.dolphinemu.LOAD_GAME_FILE_CACHE";
   private static final String ACTION_RESCAN = "org.dolphinemu.dolphinemu.RESCAN_GAME_FILE_CACHE";
@@ -31,8 +41,7 @@ public final class GameFileCacheService extends IntentService
   private static GameFileCache gameFileCache = null;
   private static final AtomicReference<GameFile[]> gameFiles =
           new AtomicReference<>(new GameFile[]{});
-  private static final AtomicBoolean hasLoadedCache = new AtomicBoolean(false);
-  private static final AtomicBoolean hasScannedLibrary = new AtomicBoolean(false);
+  private static final AtomicInteger unhandledIntents = new AtomicInteger(0);
 
   public GameFileCacheService()
   {
@@ -96,14 +105,9 @@ public final class GameFileCacheService extends IntentService
       return new String[]{gameFile.getPath(), secondFile.getPath()};
   }
 
-  public static boolean hasLoadedCache()
+  public static boolean isLoading()
   {
-    return hasLoadedCache.get();
-  }
-
-  public static boolean hasScannedLibrary()
-  {
-    return hasScannedLibrary.get();
+    return unhandledIntents.get() != 0;
   }
 
   private static void startService(Context context, String action)
@@ -119,6 +123,8 @@ public final class GameFileCacheService extends IntentService
    */
   public static void startLoad(Context context)
   {
+    unhandledIntents.getAndIncrement();
+
     new AfterDirectoryInitializationRunner().run(context, false,
             () -> startService(context, ACTION_LOAD));
   }
@@ -130,6 +136,8 @@ public final class GameFileCacheService extends IntentService
    */
   public static void startRescan(Context context)
   {
+    unhandledIntents.getAndIncrement();
+
     new AfterDirectoryInitializationRunner().run(context, false,
             () -> startService(context, ACTION_RESCAN));
   }
@@ -156,9 +164,11 @@ public final class GameFileCacheService extends IntentService
       {
         gameFileCache = temp;
         gameFileCache.load();
-        updateGameFileArray();
-        hasLoadedCache.set(true);
-        sendBroadcast();
+        if (gameFileCache.getSize() != 0)
+        {
+          updateGameFileArray();
+          sendBroadcast(CACHE_UPDATED);
+        }
       }
     }
 
@@ -169,10 +179,17 @@ public final class GameFileCacheService extends IntentService
       {
         boolean changed = gameFileCache.scanLibrary();
         if (changed)
+        {
           updateGameFileArray();
-        hasScannedLibrary.set(true);
-        sendBroadcast();
+          sendBroadcast(CACHE_UPDATED);
+        }
       }
+    }
+
+    int intentsLeft = unhandledIntents.decrementAndGet();
+    if (intentsLeft == 0)
+    {
+      sendBroadcast(DONE_LOADING);
     }
   }
 
@@ -183,8 +200,8 @@ public final class GameFileCacheService extends IntentService
     gameFiles.set(gameFilesTemp);
   }
 
-  private void sendBroadcast()
+  private void sendBroadcast(String action)
   {
-    LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(BROADCAST_ACTION));
+    LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(action));
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.viewpager.widget.ViewPager;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -39,7 +40,8 @@ import org.dolphinemu.dolphinemu.utils.StartupHandler;
  * The main Activity of the Lollipop style UI. Manages several PlatformGamesFragments, which
  * individually display a grid of available games for each Fragment, in a tabbed layout.
  */
-public final class MainActivity extends AppCompatActivity implements MainView
+public final class MainActivity extends AppCompatActivity
+        implements MainView, SwipeRefreshLayout.OnRefreshListener
 {
   private ViewPager mViewPager;
   private Toolbar mToolbar;
@@ -97,7 +99,11 @@ public final class MainActivity extends AppCompatActivity implements MainView
 
     if (sShouldRescanLibrary && !cacheAlreadyLoading)
     {
-      GameFileCacheService.startRescan(this);
+      new AfterDirectoryInitializationRunner().run(this, false, () ->
+      {
+        setRefreshing(true);
+        GameFileCacheService.startRescan(this);
+      });
     }
 
     sShouldRescanLibrary = true;
@@ -267,6 +273,28 @@ public final class MainActivity extends AppCompatActivity implements MainView
     return mPresenter.handleOptionSelection(item.getItemId(), this);
   }
 
+  /**
+   * Called when the user requests a refresh by swiping down.
+   */
+  @Override
+  public void onRefresh()
+  {
+    setRefreshing(true);
+    GameFileCacheService.startRescan(this);
+  }
+
+  /**
+   * Shows or hides the loading indicator.
+   */
+  @Override
+  public void setRefreshing(boolean refreshing)
+  {
+    forEachPlatformGamesView(view -> view.setRefreshing(refreshing));
+  }
+
+  /**
+   * To be called when the game file cache is updated.
+   */
   @Override
   public void showGames()
   {
@@ -297,7 +325,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
   private void setPlatformTabsAndStartGameFileCacheService()
   {
     PlatformPagerAdapter platformPagerAdapter = new PlatformPagerAdapter(
-            getSupportFragmentManager(), this);
+            getSupportFragmentManager(), this, this);
     mViewPager.setAdapter(platformPagerAdapter);
     mViewPager.setOffscreenPageLimit(platformPagerAdapter.getCount());
     mTabLayout.setupWithViewPager(mViewPager);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -80,6 +80,8 @@ public final class MainActivity extends AppCompatActivity implements MainView
   {
     super.onResume();
 
+    boolean cacheAlreadyLoading = GameFileCacheService.isLoading();
+
     if (DirectoryInitialization.shouldStart(this))
     {
       DirectoryInitialization.start(this);
@@ -93,14 +95,12 @@ public final class MainActivity extends AppCompatActivity implements MainView
     // such as system language, cover downloading...
     forEachPlatformGamesView(PlatformGamesView::refetchMetadata);
 
-    if (sShouldRescanLibrary)
+    if (sShouldRescanLibrary && !cacheAlreadyLoading)
     {
       GameFileCacheService.startRescan(this);
     }
-    else
-    {
-      sShouldRescanLibrary = true;
-    }
+
+    sShouldRescanLibrary = true;
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -28,6 +28,7 @@ import org.dolphinemu.dolphinemu.features.settings.ui.SettingsActivity;
 import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.ui.platform.PlatformGamesView;
+import org.dolphinemu.dolphinemu.utils.Action1;
 import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner;
 import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
@@ -90,7 +91,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
 
     // In case the user changed a setting that affects how games are displayed,
     // such as system language, cover downloading...
-    refetchMetadata();
+    forEachPlatformGamesView(PlatformGamesView::refetchMetadata);
 
     if (sShouldRescanLibrary)
     {
@@ -266,26 +267,20 @@ public final class MainActivity extends AppCompatActivity implements MainView
     return mPresenter.handleOptionSelection(item.getItemId(), this);
   }
 
+  @Override
   public void showGames()
   {
-    for (Platform platform : Platform.values())
-    {
-      PlatformGamesView fragment = getPlatformGamesView(platform);
-      if (fragment != null)
-      {
-        fragment.showGames();
-      }
-    }
+    forEachPlatformGamesView(PlatformGamesView::showGames);
   }
 
-  private void refetchMetadata()
+  private void forEachPlatformGamesView(Action1<PlatformGamesView> action)
   {
     for (Platform platform : Platform.values())
     {
       PlatformGamesView fragment = getPlatformGamesView(platform);
       if (fragment != null)
       {
-        fragment.refetchMetadata();
+        action.call(fragment);
       }
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -54,12 +54,21 @@ public final class MainPresenter
 
     IntentFilter filter = new IntentFilter();
     filter.addAction(GameFileCacheService.CACHE_UPDATED);
+    filter.addAction(GameFileCacheService.DONE_LOADING);
     mBroadcastReceiver = new BroadcastReceiver()
     {
       @Override
       public void onReceive(Context context, Intent intent)
       {
-        mView.showGames();
+        switch (intent.getAction())
+        {
+          case GameFileCacheService.CACHE_UPDATED:
+            mView.showGames();
+            break;
+          case GameFileCacheService.DONE_LOADING:
+            mView.setRefreshing(false);
+            break;
+        }
       }
     };
     LocalBroadcastManager.getInstance(mContext).registerReceiver(mBroadcastReceiver, filter);
@@ -87,6 +96,7 @@ public final class MainPresenter
         return true;
 
       case R.id.menu_refresh:
+        mView.setRefreshing(true);
         GameFileCacheService.startRescan(context);
         return true;
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -53,7 +53,7 @@ public final class MainPresenter
     mView.setVersionString(versionName);
 
     IntentFilter filter = new IntentFilter();
-    filter.addAction(GameFileCacheService.BROADCAST_ACTION);
+    filter.addAction(GameFileCacheService.CACHE_UPDATED);
     mBroadcastReceiver = new BroadcastReceiver()
     {
       @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
@@ -24,6 +24,11 @@ public interface MainView
   void launchOpenFileActivity(int requestCode);
 
   /**
+   * Shows or hides the loading indicator.
+   */
+  void setRefreshing(boolean refreshing);
+
+  /**
    * To be called when the game file cache is updated.
    */
   void showGames();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -68,6 +68,8 @@ public final class TvMainActivity extends FragmentActivity implements MainView
   {
     super.onResume();
 
+    boolean cacheAlreadyLoading = GameFileCacheService.isLoading();
+
     if (DirectoryInitialization.shouldStart(this))
     {
       DirectoryInitialization.start(this);
@@ -80,14 +82,12 @@ public final class TvMainActivity extends FragmentActivity implements MainView
     // such as system language, cover downloading...
     refetchMetadata();
 
-    if (sShouldRescanLibrary)
+    if (sShouldRescanLibrary && !cacheAlreadyLoading)
     {
       GameFileCacheService.startRescan(this);
     }
-    else
-    {
-      sShouldRescanLibrary = true;
-    }
+
+    sShouldRescanLibrary = true;
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesView.java
@@ -1,5 +1,8 @@
 package org.dolphinemu.dolphinemu.ui.platform;
 
+import androidx.annotation.Nullable;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
 /**
  * Abstraction for a screen representing a single platform's games.
  */
@@ -20,6 +23,11 @@ public interface PlatformGamesView
    * @param gameId The ID of the game that was clicked.
    */
   void onItemClick(String gameId);
+
+  /**
+   * Shows or hides the loading indicator.
+   */
+  void setRefreshing(boolean refreshing);
 
   /**
    * To be called when the game file cache is updated.

--- a/Source/Android/app/src/main/res/layout/activity_tv_main.xml
+++ b/Source/Android/app/src/main/res/layout/activity_tv_main.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             android:id="@+id/content"
-             android:layout_width="match_parent"
-             android:layout_height="match_parent">
 
-</FrameLayout>
+<!-- The SwipeRefreshLayout is used mainly for its ability to show a loading indicator, not for
+     its ability to detect swipes. But if someone is using this activity with a touchscreen
+     for whatever reason, we get the ability to refresh by swiping down more or less for free. -->
+
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swipe_refresh"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+         android:id="@+id/content"
+         android:layout_width="match_parent"
+         android:layout_height="match_parent">
+
+    </FrameLayout>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_grid.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_grid.xml
@@ -4,12 +4,19 @@
              android:layout_width="match_parent"
              android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/grid_games"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginLeft="@dimen/activity_horizontal_margin"
-        android:layout_marginRight="@dimen/activity_horizontal_margin"
-        tools:listitem="@layout/card_game"/>
+        android:layout_marginRight="@dimen/activity_horizontal_margin">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/grid_games"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:listitem="@layout/card_game"/>
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </FrameLayout>

--- a/Source/Android/jni/GameList/GameFileCache.cpp
+++ b/Source/Android/jni/GameList/GameFileCache.cpp
@@ -39,6 +39,12 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_finali
   delete GetPointer(env, obj);
 }
 
+JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_getSize(JNIEnv* env,
+                                                                                  jobject obj)
+{
+  return static_cast<jint>(GetPointer(env, obj)->GetSize());
+}
+
 JNIEXPORT jobjectArray JNICALL
 Java_org_dolphinemu_dolphinemu_model_GameFileCache_getAllGames(JNIEnv* env, jobject obj)
 {


### PR DESCRIPTION
The main reason why I'm adding this isn't actually to allow users to swipe up to refresh, it's to add a loading indicator. Considering that the Storage Access Framework can be slow for folders with many items (many subfolders?), not showing a loading indicator might give users the impression that adding a folder resulted in nothing happening even though Dolphin is scanning for games in the background. But I suppose letting users swipe up to refresh is a nice bonus with the change.