### PR TITLE
Don't call OnConfigChanged() unless config actually changed

### DIFF
--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -94,8 +94,8 @@ LayerType GetActiveLayerForConfig(const Info<T>& info)
 template <typename T>
 void Set(LayerType layer, const Info<T>& info, const std::common_type_t<T>& value)
 {
-  GetLayer(layer)->Set(info, value);
-  OnConfigChanged();
+  if (GetLayer(layer)->Set(info, value))
+    OnConfigChanged();
 }
 
 template <typename T>

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -118,24 +118,25 @@ public:
   }
 
   template <typename T>
-  void Set(const Info<T>& config_info, const std::common_type_t<T>& value)
+  bool Set(const Info<T>& config_info, const std::common_type_t<T>& value)
   {
-    Set(config_info.GetLocation(), value);
+    return Set(config_info.GetLocation(), value);
   }
 
   template <typename T>
-  void Set(const Location& location, const T& value)
+  bool Set(const Location& location, const T& value)
   {
-    Set(location, ValueToString(value));
+    return Set(location, ValueToString(value));
   }
 
-  void Set(const Location& location, std::string new_value)
+  bool Set(const Location& location, std::string new_value)
   {
     const auto iter = m_map.find(location);
     if (iter != m_map.end() && iter->second == new_value)
-      return;
+      return false;
     m_is_dirty = true;
     m_map.insert_or_assign(location, std::move(new_value));
+    return true;
   }
 
   void MarkAsDirty() { m_is_dirty = true; }

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -381,7 +381,9 @@ void Init()
     Config::SetBase(Settings::SERVER_PORT, 0);
   }
 
+  // It would be much better to unbind from this callback on DeInit but it's not possible as of now
   Config::AddConfigChangedCallback(ConfigChanged);
+  ConfigChanged();  // Call it immediately to load settings
 }
 
 void PopulateDevices()


### PR DESCRIPTION
Also DualShock UDP Client was the only place in the code that assumed OnConfigChanged() was called at least once on startup or it won't load up the setting, so I took care of that.

OnConfigChanged() repopulates all the devices and it can be slow (and just plain unnecessary).
This might also help with any race conditions with devices population code, which as of now are unsafe and can break on some machines.