### PR TITLE
InputCommon: dynamic input textures more optimizations

### DIFF
--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -154,6 +154,8 @@ public:
   void SortSections();
 
   Section* GetOrCreateSection(std::string_view section_name);
+  const Section* GetSection(std::string_view section_name) const;
+  Section* GetSection(std::string_view section_name);
 
   // This function is related to parsing data from lines of INI files
   // It's used outside of IniFile, which is why it is exposed publicly
@@ -164,9 +166,6 @@ public:
 
 private:
   std::list<Section> sections;
-
-  const Section* GetSection(std::string_view section_name) const;
-  Section* GetSection(std::string_view section_name);
 
   static const std::string& NULL_STRING;
 };

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -112,12 +112,6 @@ void EmulatedController::SetDefaultDevice(ciface::Core::DeviceQualifier devq)
   }
 }
 
-void EmulatedController::SetDynamicInputTextureManager(
-    InputCommon::DynamicInputTextureManager* dynamic_input_tex_config_manager)
-{
-  m_dynamic_input_tex_config_manager = dynamic_input_tex_config_manager;
-}
-
 void EmulatedController::LoadConfig(IniFile::Section* sec, const std::string& base)
 {
   std::string defdev = GetDefaultDevice().ToString();
@@ -129,11 +123,6 @@ void EmulatedController::LoadConfig(IniFile::Section* sec, const std::string& ba
 
   for (auto& cg : groups)
     cg->LoadConfig(sec, defdev, base);
-
-  if (base.empty())
-  {
-    GenerateTextures(sec);
-  }
 }
 
 void EmulatedController::SaveConfig(IniFile::Section* sec, const std::string& base)
@@ -144,11 +133,6 @@ void EmulatedController::SaveConfig(IniFile::Section* sec, const std::string& ba
 
   for (auto& ctrlGroup : groups)
     ctrlGroup->SaveConfig(sec, defdev, base);
-
-  if (base.empty())
-  {
-    GenerateTextures(sec);
-  }
 }
 
 void EmulatedController::LoadDefaults(const ControllerInterface& ciface)
@@ -161,14 +145,6 @@ void EmulatedController::LoadDefaults(const ControllerInterface& ciface)
   if (!default_device_string.empty())
   {
     SetDefaultDevice(default_device_string);
-  }
-}
-
-void EmulatedController::GenerateTextures(IniFile::Section* sec)
-{
-  if (m_dynamic_input_tex_config_manager)
-  {
-    m_dynamic_input_tex_config_manager->GenerateTextures(sec, GetName());
   }
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -17,7 +17,6 @@
 #include "Common/MathUtil.h"
 #include "InputCommon/ControlReference/ExpressionParser.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
-#include "InputCommon/DynamicInputTextureManager.h"
 
 class ControllerInterface;
 
@@ -183,7 +182,6 @@ public:
   const ciface::Core::DeviceQualifier& GetDefaultDevice() const;
   void SetDefaultDevice(const std::string& device);
   void SetDefaultDevice(ciface::Core::DeviceQualifier devq);
-  void SetDynamicInputTextureManager(InputCommon::DynamicInputTextureManager*);
 
   void UpdateReferences(const ControllerInterface& devi);
   void UpdateSingleControlReference(const ControllerInterface& devi, ControlReference* ref);
@@ -226,8 +224,6 @@ protected:
   void UpdateReferences(ciface::ExpressionParser::ControlEnvironment& env);
 
 private:
-  void GenerateTextures(IniFile::Section* sec);
-  InputCommon::DynamicInputTextureManager* m_dynamic_input_tex_config_manager = nullptr;
   ciface::Core::DeviceQualifier m_default_device;
   bool m_default_device_is_connected{false};
 };

--- a/Source/Core/InputCommon/DynamicInputTextureManager.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextureManager.cpp
@@ -40,13 +40,13 @@ void DynamicInputTextureManager::Load()
   }
 }
 
-void DynamicInputTextureManager::GenerateTextures(const IniFile::Section* sec,
-                                                  const std::string& controller_name)
+void DynamicInputTextureManager::GenerateTextures(const IniFile& file,
+                                                  const std::vector<std::string>& controller_names)
 {
   bool any_dirty = false;
   for (const auto& configuration : m_configuration)
   {
-    any_dirty |= configuration.GenerateTextures(sec, controller_name);
+    any_dirty |= configuration.GenerateTextures(file, controller_names);
   }
 
   if (any_dirty && g_renderer && Core::GetState() != Core::State::Starting)

--- a/Source/Core/InputCommon/DynamicInputTextureManager.h
+++ b/Source/Core/InputCommon/DynamicInputTextureManager.h
@@ -21,7 +21,7 @@ public:
   DynamicInputTextureManager();
   ~DynamicInputTextureManager();
   void Load();
-  void GenerateTextures(const IniFile::Section* sec, const std::string& controller_name);
+  void GenerateTextures(const IniFile& file, const std::vector<std::string>& controller_names);
 
 private:
   std::vector<DynamicInputTextures::Configuration> m_configuration;

--- a/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.h
+++ b/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.h
@@ -19,10 +19,11 @@ class Configuration
 public:
   explicit Configuration(const std::string& json_file);
   ~Configuration();
-  bool GenerateTextures(const IniFile::Section* sec, const std::string& controller_name) const;
+  bool GenerateTextures(const IniFile& file,
+                        const std::vector<std::string>& controller_names) const;
 
 private:
-  bool GenerateTexture(const IniFile::Section* sec, const std::string& controller_name,
+  bool GenerateTexture(const IniFile& file, const std::vector<std::string>& controller_names,
                        const Data& texture_data) const;
 
   std::vector<Data> m_dynamic_input_textures;

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -31,8 +31,7 @@ public:
   template <typename T, typename... Args>
   void CreateController(Args&&... args)
   {
-    OnControllerCreated(
-        *m_controllers.emplace_back(std::make_unique<T>(std::forward<Args>(args)...)));
+    m_controllers.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
   }
 
   ControllerEmu::EmulatedController* GetController(int index);
@@ -48,8 +47,9 @@ public:
   void RegisterHotplugCallback();
   void UnregisterHotplugCallback();
 
+  void GenerateControllerTextures(const IniFile& file);
+
 private:
-  void OnControllerCreated(ControllerEmu::EmulatedController& controller);
   ControllerInterface::HotplugCallbackHandle m_hotplug_callback_handle;
   std::vector<std::unique_ptr<ControllerEmu::EmulatedController>> m_controllers;
   const std::string m_ini_name;

--- a/Source/Core/InputCommon/InputProfile.cpp
+++ b/Source/Core/InputCommon/InputProfile.cpp
@@ -73,7 +73,8 @@ std::string ProfileCycler::GetProfile(CycleDirection cycle_direction, int& profi
 }
 
 void ProfileCycler::UpdateToProfile(const std::string& profile_filename,
-                                    ControllerEmu::EmulatedController* controller)
+                                    ControllerEmu::EmulatedController* controller,
+                                    InputConfig* device_configuration)
 {
   std::string base;
   SplitPath(profile_filename, nullptr, &base, nullptr);
@@ -86,6 +87,7 @@ void ProfileCycler::UpdateToProfile(const std::string& profile_filename,
                          display_message_ms);
     controller->LoadConfig(ini_file.GetOrCreateSection("Profile"));
     controller->UpdateReferences(g_controller_interface);
+    device_configuration->GenerateControllerTextures(ini_file);
   }
   else
   {
@@ -129,7 +131,7 @@ void ProfileCycler::CycleProfile(CycleDirection cycle_direction, InputConfig* de
   auto* controller = device_configuration->GetController(controller_index);
   if (controller)
   {
-    UpdateToProfile(profile, controller);
+    UpdateToProfile(profile, controller, device_configuration);
   }
   else
   {
@@ -168,7 +170,7 @@ void ProfileCycler::CycleProfileForGame(CycleDirection cycle_direction,
   auto* controller = device_configuration->GetController(controller_index);
   if (controller)
   {
-    UpdateToProfile(profile, controller);
+    UpdateToProfile(profile, controller, device_configuration);
   }
   else
   {

--- a/Source/Core/InputCommon/InputProfile.h
+++ b/Source/Core/InputCommon/InputProfile.h
@@ -45,7 +45,8 @@ private:
                                                           const std::vector<std::string>& profiles,
                                                           InputConfig* device_configuration);
   void UpdateToProfile(const std::string& profile_filename,
-                       ControllerEmu::EmulatedController* controller);
+                       ControllerEmu::EmulatedController* controller,
+                       InputConfig* device_configuration);
   std::string GetWiimoteInputProfilesForGame(int controller_index);
 
   int m_wiimote_profile_index = 0;


### PR DESCRIPTION
This reduces the number of image loads and the number of texture cache invalidations (in particular on startup) by having all the controllers be iterated over once, instead of happening on each load / save of the individual controllers.