### PR TITLE
Symbols: Fix RSO Modules detection algorithm

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -7,11 +7,15 @@
 #include <array>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <QMenuBar>
 #include <QPointer>
 
+#include "Common/CommonTypes.h"
+
 class QMenu;
+class ParallelProgressDialog;
 
 namespace Core
 {
@@ -27,6 +31,9 @@ namespace UICommon
 {
 class GameFile;
 }
+
+using RSOPairEntry = std::pair<u32, std::string>;
+using RSOVector = std::vector<RSOPairEntry>;
 
 class MenuBar final : public QMenuBar
 {
@@ -155,6 +162,7 @@ private:
   void GenerateSymbolsFromSignatureDB();
   void GenerateSymbolsFromRSO();
   void GenerateSymbolsFromRSOAuto();
+  RSOVector DetectRSOModules(ParallelProgressDialog& progress);
   void LoadSymbolMap();
   void LoadOtherSymbolMap();
   void LoadBadSymbolMap();


### PR DESCRIPTION
The current algorithm for detecting a RSO modules have a flaw. In which RSO modules are only detected if the byte before the name of the module is a null byte `\0`. This is wrong because before the name can be any arbitrary data.

I modify the approach. Instead of looking for the first null byte before the name. I count the bytes before a non-ascii character is found. After that, I look for a `uint32` offset that point to the name's bytes. Also, to be even more sure about it, after we have found the offset, the next 4 bytes are the module's name length and I also check against that. 

Also, even after this fix, we are not going to be capable of detecting every RSO module, since modules can come without name ([File Format Specification](http://www.metroid2002.com/retromodding/wiki/RSO_(File_Format)))

## Before
![image](https://user-images.githubusercontent.com/2200611/109406528-c2b77380-7971-11eb-94ff-b16376574261.png)

## After
![image](https://user-images.githubusercontent.com/2200611/109406709-3ad26900-7973-11eb-8731-68394c16a4ed.png)

![image](https://user-images.githubusercontent.com/2200611/109406534-c9de8180-7971-11eb-832d-9bf738217cb8.png)

I had to add a loading bar, because now the process is considerably slower. Now the user know that some work is being done.
