### PR TITLE
IOS: Improve timing accuracy for title launches (both ARM and PPC)

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -706,19 +706,23 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
 
   if (Core::IsRunning())
-  {
-    // TODO: have a callback mechanism for title changes?
-    if (!g_symbolDB.IsEmpty())
-    {
-      g_symbolDB.Clear();
-      Host_NotifyMapLoaded();
-    }
-    CBoot::LoadMapFromFilename();
-    HLE::Reload();
-    PatchEngine::Reload();
-    HiresTexture::Update();
     DolphinAnalytics::Instance().ReportGameStart();
+}
+
+void SConfig::OnNewTitleLoad()
+{
+  if (!Core::IsRunning())
+    return;
+
+  if (!g_symbolDB.IsEmpty())
+  {
+    g_symbolDB.Clear();
+    Host_NotifyMapLoaded();
   }
+  CBoot::LoadMapFromFilename();
+  HLE::Reload();
+  PatchEngine::Reload();
+  HiresTexture::Update();
 }
 
 void SConfig::LoadDefaults()

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -197,6 +197,10 @@ struct SConfig
   void SetRunningGameMetadata(const DiscIO::Volume& volume, const DiscIO::Partition& partition);
   void SetRunningGameMetadata(const IOS::ES::TMDReader& tmd, DiscIO::Platform platform);
   void SetRunningGameMetadata(const std::string& game_id);
+  // Reloads title-specific map files, patches, custom textures, etc.
+  // This should only be called after the new title has been loaded into memory.
+  static void OnNewTitleLoad();
+
   void LoadDefaults();
   static std::string MakeGameID(std::string_view file_name);
   // Replaces NTSC-K with some other region, and doesn't replace non-NTSC-K regions

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -122,6 +122,8 @@ void ESDevice::FinalizeEmulationState()
 
 void ESDevice::FinishInit()
 {
+  m_ios.InitIPC();
+
   if (s_title_to_launch != 0)
   {
     NOTICE_LOG_FMT(IOS, "Re-launching title after IOS reload.");

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -47,7 +47,7 @@ public:
   static void FinalizeEmulationState();
 
   ReturnCode DIVerify(const ES::TMDReader& tmd, const ES::TicketReader& ticket);
-  bool LaunchTitle(u64 title_id, HangPPC hang_ppc = HangPPC::No, bool skip_reload = false);
+  bool LaunchTitle(u64 title_id, HangPPC hang_ppc = HangPPC::No);
 
   void DoState(PointerWrap& p) override;
 
@@ -347,7 +347,7 @@ private:
   ContextArray::iterator FindInactiveContext();
 
   bool LaunchIOS(u64 ios_title_id, HangPPC hang_ppc);
-  bool LaunchPPCTitle(u64 title_id, bool skip_reload);
+  bool LaunchPPCTitle(u64 title_id);
   bool IsActiveTitlePermittedByTicket(const u8* ticket_view) const;
 
   ReturnCode CheckStreamKeyPermissions(u32 uid, const u8* ticket_view,
@@ -371,6 +371,10 @@ private:
 
   std::string GetContentPath(u64 title_id, const ES::Content& content, Ticks ticks = {}) const;
 
+  s32 WriteSystemFile(const std::string& path, const std::vector<u8>& data, Ticks ticks = {});
+  s32 WriteLaunchFile(const ES::TMDReader& tmd, Ticks ticks = {});
+  bool BootstrapPPC();
+
   struct OpenedContent
   {
     bool m_opened = false;
@@ -385,5 +389,6 @@ private:
 
   ContextArray m_contexts;
   TitleContext m_title_context{};
+  std::string m_pending_ppc_boot_content_path;
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -43,6 +43,9 @@ class ESDevice final : public Device
 public:
   ESDevice(Kernel& ios, const std::string& device_name);
 
+  static void InitializeEmulationState();
+  static void FinalizeEmulationState();
+
   ReturnCode DIVerify(const ES::TMDReader& tmd, const ES::TicketReader& ticket);
   bool LaunchTitle(u64 title_id, bool skip_reload = false);
 
@@ -363,6 +366,8 @@ private:
   // Finish stale imports and clear the import directory.
   void FinishStaleImport(u64 title_id);
   void FinishAllStaleImports();
+
+  void FinishInit();
 
   std::string GetContentPath(u64 title_id, const ES::Content& content, Ticks ticks = {}) const;
 

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -47,7 +47,7 @@ public:
   static void FinalizeEmulationState();
 
   ReturnCode DIVerify(const ES::TMDReader& tmd, const ES::TicketReader& ticket);
-  bool LaunchTitle(u64 title_id, bool skip_reload = false);
+  bool LaunchTitle(u64 title_id, HangPPC hang_ppc = HangPPC::No, bool skip_reload = false);
 
   void DoState(PointerWrap& p) override;
 
@@ -346,7 +346,7 @@ private:
   ContextArray::iterator FindActiveContext(s32 fd);
   ContextArray::iterator FindInactiveContext();
 
-  bool LaunchIOS(u64 ios_title_id);
+  bool LaunchIOS(u64 ios_title_id, HangPPC hang_ppc);
   bool LaunchPPCTitle(u64 title_id, bool skip_reload);
   bool IsActiveTitlePermittedByTicket(const u8* ticket_view) const;
 

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -151,6 +151,8 @@ struct Ticket
 static_assert(sizeof(Ticket) == 0x2A4, "Ticket has the wrong size");
 #pragma pack(pop)
 
+constexpr u32 MAX_TMD_SIZE = 0x49e4;
+
 class SignedBlobReader
 {
 public:

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.h
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.h
@@ -35,7 +35,13 @@ public:
   s32 Write(u64 fd, const u8* data, u32 size, std::optional<u32> ipc_buffer_addr = {},
             Ticks ticks = {});
   s32 Seek(u64 fd, u32 offset, FS::SeekMode mode, Ticks ticks = {});
+
   FS::Result<FS::FileStatus> GetFileStatus(u64 fd, Ticks ticks = {});
+  FS::ResultCode RenameFile(FS::Uid uid, FS::Gid gid, const std::string& old_path,
+                            const std::string& new_path, Ticks ticks = {});
+  FS::ResultCode DeleteFile(FS::Uid uid, FS::Gid gid, const std::string& path, Ticks ticks = {});
+  FS::ResultCode CreateFile(FS::Uid uid, FS::Gid gid, const std::string& path,
+                            FS::FileAttribute attribute, FS::Modes modes, Ticks ticks = {});
 
   template <typename T>
   s32 Read(u64 fd, T* data, size_t count, Ticks ticks = {})

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -433,7 +433,7 @@ static constexpr SystemTimers::TimeBaseTick GetIOSBootTicks(u32 version)
 // Passing a boot content path is optional because we do not require IOSes
 // to be installed at the moment. If one is passed, the boot binary must exist
 // on the NAND, or the call will fail like on a Wii.
-bool Kernel::BootIOS(const u64 ios_title_id, const std::string& boot_content_path)
+bool Kernel::BootIOS(const u64 ios_title_id, HangPPC hang_ppc, const std::string& boot_content_path)
 {
   // IOS suspends regular PPC<->ARM IPC before loading a new IOS.
   // IPC is not resumed if the boot fails for any reason.
@@ -452,6 +452,9 @@ bool Kernel::BootIOS(const u64 ios_title_id, const std::string& boot_content_pat
     if (!elf.LoadIntoMemory(true))
       return false;
   }
+
+  if (hang_ppc == HangPPC::Yes)
+    ResetAndPausePPC();
 
   if (Core::IsRunningAndStarted())
     CoreTiming::ScheduleEvent(GetIOSBootTicks(GetVersion()), s_event_finish_ios_boot, ios_title_id);

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -137,6 +137,12 @@ static bool SetupMemory(u64 ios_title_id, MemorySetupType setup_type)
     return true;
   }
 
+  // This region is typically used to store constants (e.g. game ID, console type, ...)
+  // and system information (see below).
+  constexpr u32 LOW_MEM1_REGION_START = 0;
+  constexpr u32 LOW_MEM1_REGION_SIZE = 0x3fff;
+  Memory::Memset(LOW_MEM1_REGION_START, 0, LOW_MEM1_REGION_SIZE);
+
   Memory::Write_U32(target_imv->mem1_physical_size, ADDR_MEM1_SIZE);
   Memory::Write_U32(target_imv->mem1_simulated_size, ADDR_MEM1_SIM_SIZE);
   Memory::Write_U32(target_imv->mem1_end, ADDR_MEM1_END);

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -856,6 +856,7 @@ IOSC& Kernel::GetIOSC()
 static void FinishPPCBootstrap(u64 userdata, s64 cycles_late)
 {
   ReleasePPC();
+  SConfig::OnNewTitleLoad();
   INFO_LOG_FMT(IOS, "Bootstrapping done.");
 }
 

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -864,6 +864,8 @@ void Init()
       device->EventNotify();
   });
 
+  ESDevice::InitializeEmulationState();
+
   s_event_finish_ppc_bootstrap =
       CoreTiming::RegisterEvent("IOSFinishPPCBootstrap", FinishPPCBootstrap);
 
@@ -883,6 +885,7 @@ void Init()
 void Shutdown()
 {
   s_ios.reset();
+  ESDevice::FinalizeEmulationState();
 }
 
 EmulationKernel* GetIOS()

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -166,6 +166,7 @@ protected:
   IPCMsgQueue m_request_queue;  // ppc -> arm
   IPCMsgQueue m_reply_queue;    // arm -> ppc
   u64 m_last_reply_time = 0;
+  bool m_ipc_paused = false;
 
   IOSC m_iosc;
   std::shared_ptr<FS::FileSystem> m_fs;

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -97,6 +97,12 @@ enum class MemorySetupType
   Full,
 };
 
+enum class HangPPC : bool
+{
+  No = false,
+  Yes = true,
+};
+
 void RAMOverrideForIOSMemoryValues(MemorySetupType setup_type);
 
 void WriteReturnValue(s32 value, u32 address);
@@ -132,7 +138,8 @@ public:
   u16 GetGidForPPC() const;
 
   bool BootstrapPPC(const std::string& boot_content_path);
-  bool BootIOS(u64 ios_title_id, const std::string& boot_content_path = "");
+  bool BootIOS(u64 ios_title_id, HangPPC hang_ppc = HangPPC::No,
+               const std::string& boot_content_path = {});
   void InitIPC();
   u32 GetVersion() const;
 

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -133,6 +133,7 @@ public:
 
   bool BootstrapPPC(const std::string& boot_content_path);
   bool BootIOS(u64 ios_title_id, const std::string& boot_content_path = "");
+  void InitIPC();
   u32 GetVersion() const;
 
   IOSC& GetIOSC();
@@ -142,7 +143,6 @@ protected:
 
   void ExecuteIPCCommand(u32 address);
   std::optional<IPCReply> HandleIPCCommand(const Request& request);
-  void EnqueueIPCAcknowledgement(u32 address, int cycles_in_future = 0);
 
   void AddDevice(std::unique_ptr<Device> device);
   void AddCoreDevices();
@@ -165,7 +165,6 @@ protected:
   using IPCMsgQueue = std::deque<u32>;
   IPCMsgQueue m_request_queue;  // ppc -> arm
   IPCMsgQueue m_reply_queue;    // arm -> ppc
-  IPCMsgQueue m_ack_queue;      // arm -> ppc
   u64 m_last_reply_time = 0;
 
   IOSC m_iosc;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 129;  // Last changed in PR 9511
+constexpr u32 STATE_VERSION = 130;  // Last changed in PR 9545
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -584,7 +584,6 @@ void DirectoryBlobReader::SetPartitionHeader(DirectoryBlobPartition* partition,
   constexpr u32 TICKET_OFFSET = 0x0;
   constexpr u32 TICKET_SIZE = 0x2a4;
   constexpr u32 TMD_OFFSET = 0x2c0;
-  constexpr u32 MAX_TMD_SIZE = 0x49e4;
   constexpr u32 H3_OFFSET = 0x4000;
   constexpr u32 H3_SIZE = 0x18000;
 
@@ -594,7 +593,7 @@ void DirectoryBlobReader::SetPartitionHeader(DirectoryBlobPartition* partition,
       partition_address + TICKET_OFFSET, TICKET_SIZE, partition_root + "ticket.bin");
 
   const u64 tmd_size = m_nonpartition_contents.CheckSizeAndAdd(
-      partition_address + TMD_OFFSET, MAX_TMD_SIZE, partition_root + "tmd.bin");
+      partition_address + TMD_OFFSET, IOS::ES::MAX_TMD_SIZE, partition_root + "tmd.bin");
 
   const u64 cert_offset = Common::AlignUp(TMD_OFFSET + tmd_size, 0x20ull);
   const u64 max_cert_size = H3_OFFSET - cert_offset;


### PR DESCRIPTION
(alternative title: make ES_Launch slower and potentially break it)

This is a series of commits to make ES launch timings closer to console:

* In BootstrapPPC, we no longer neglect the amount of time it takes to read the DOL/ELF into memory.
* IOS and ES's slow boot time (>400ms) is now taken into account.
* IOS reloads are no longer instant. This fixes [reloadtest (from this HackMii post)](https://hackmii.com/2009/08/timing-is-everything-the-case-of-the-unsoftmoddable-wii/) as it makes the reasonable assumption that ES launches for IOS titles do not complete instantly.
* We now simulate what IOS does with /sys/launch.sys when launching a PPC title because FS operations that modify the NAND are particularly slow.
 
(those commits can be reviewed one at a time)

This PR also simplifies IPC reinitialisation after an IOS relaunch and makes it more accurate. Contrary to what the current code suggests, there is no complicated ack queue or anything. The extra IPC ack is actually triggered by a syscall that is invoked in ES's main function; the syscall literally just sets Y2, IX1 and IX2 in HW_IPC_ARMCTRL.

Needs careful testing because ES_Launch is cursed