### PR TITLE
INI Changes

### DIFF
--- a/Data/Sys/GameSettings/GYA.ini
+++ b/Data/Sys/GameSettings/GYA.ini
@@ -14,3 +14,4 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/PM4.ini
+++ b/Data/Sys/GameSettings/PM4.ini
@@ -1,0 +1,5 @@
+# PM4E01 - Mario Kart: Double Dash‼ Bonus Disc
+
+[Core]
+MMU = True
+FPRF = True

--- a/Data/Sys/GameSettings/RBY.ini
+++ b/Data/Sys/GameSettings/RBY.ini
@@ -14,3 +14,4 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RFN.ini
+++ b/Data/Sys/GameSettings/RFN.ini
@@ -5,3 +5,5 @@
 # Since both the channel and the main game update these images, it must be disabled for both.  (They both have the same GameID, though.)
 # However, this has a performance impact, so if the Wii Fit Channel is not going to be used, this does not need to be disabled.
 #EFBToTextureEnable = False
+# Having EFBToTextureEnable disabled causes hangs in mini games if DeferEFBCopies is enabled.
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RFP.ini
+++ b/Data/Sys/GameSettings/RFP.ini
@@ -1,7 +1,13 @@
 # RFPE01, RFPJ01, RFPR01, RFPP01, RFPK01, RFPW01 - Wii Fit Plus and Wii Fit Plus Channel
 
+[Core]
+# Dualcore causes hangs in the Rhythm Parade mini game.
+CPUThread = False
+
 [Video_Hacks]
 # The Wii Fit Plus Channel shows Mii faces and a graph; however, EFBToTextureEnable must be disabled for this to work.
 # Since both the channel and the main game update these images, it must be disabled for both.  (They both have the same GameID, though.)
 # However, this has a performance impact, so if the Wii Fit Channel is not going to be used, this does not need to be disabled.
 #EFBToTextureEnable = False
+# Having EFBToTextureEnable disabled causes hangs in mini games if DeferEFBCopies is enabled.
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RH2.ini
+++ b/Data/Sys/GameSettings/RH2.ini
@@ -2,3 +2,6 @@
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+
+[Video_Hacks]
+XFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RKF.ini
+++ b/Data/Sys/GameSettings/RKF.ini
@@ -1,4 +1,7 @@
 # RKFEH4, RKFKZA, RKFP7U - The King of Fighters Collection: The Orochi Saga
 
+[Core]
+CPUThread = False
+
 [Video_Settings]
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RNC.ini
+++ b/Data/Sys/GameSettings/RNC.ini
@@ -1,4 +1,7 @@
 # RNCEH4, RNCPH4 - SNK Arcade Classics Volume 1
 
+[Core]
+CPUThread = False
+
 [Video_Settings]
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/SGX.ini
+++ b/Data/Sys/GameSettings/SGX.ini
@@ -1,0 +1,4 @@
+# SGXP41, SGXE41 - Battle of Giants: Dinosaurs Strike
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/STN.ini
+++ b/Data/Sys/GameSettings/STN.ini
@@ -1,0 +1,5 @@
+# STNE41, STNP41 - The Adventures of Tintin: The Game
+
+[Video_Settings]
+# Fixes glitching in opening credits.
+SafeTextureCacheColorSamples = 512


### PR DESCRIPTION
Fixes:
https://bugs.dolphin-emu.org/issues/12437 (Also happens on Wii version of Barnyard)
https://bugs.dolphin-emu.org/issues/12419

Dualcore disabled for SNK Arcade Classics Volume 1 and The King of Fighters Collection: The Orochi Saga to fix  the clitching sprites.
EFB to RAM Battle of Giants: Dinosaurs Strike in order to display the player dinosaur texture.