### PR TITLE
Core/Memmap: Memory mapping logic fixes.

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -368,6 +368,9 @@ void UpdateLogicalMemory(const PowerPC::BatTable& dbat_table)
       u32 translated_address = dbat_table[i] & PowerPC::BAT_RESULT_MASK;
       for (const auto& physical_region : s_physical_regions)
       {
+        if (!physical_region.active)
+          continue;
+
         u32 mapping_address = physical_region.physical_address;
         u32 mapping_end = mapping_address + physical_region.size;
         u32 intersection_start = std::max(mapping_address, translated_address);


### PR DESCRIPTION
This fixes two potential (if unlikely to be relevant in practice) bugs:

- Remember which regions are mapped instead of re-checking via the flags each time. This fixes a potential issue where a memory region would not be unmapped when booting in Wii mode and then switching to GC mode by eg. using the Disc channel and a GC disc. (first commit)
- We didn't check which regions are active in `UpdateLogicalMemory()`, leading to an odd BAT config potentially attempting to map memory regions that haven't been allocated. (second commit)