### PR TITLE
SI/DeviceGBA: Ensure data socket isn't backed up

### DIFF
--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.h
@@ -28,7 +28,8 @@ public:
   bool IsConnected();
   void ClockSync();
   void Send(const u8* si_buffer);
-  int Receive(u8* si_buffer);
+  int Receive(u8* si_buffer, u8 bytes);
+  void Flush();
 
 private:
   void Disconnect();


### PR DESCRIPTION
When reading a reply from a message sent to the data socket there is the possibility that the other side gets sent multiple messages before replying to any of them, which can lead to multiple replies sent in a row. Though this only happens when things time out, it's quite possible for these timeouts to happen or build up over time, especially when initiating the connection.

This change makes sure to flush any pending bytes that have not been read yet out of the socket after a successful POLL reply is received, since that is the most common time when backups occur, and as well as using the exact number of bytes in an expected reply, to ensure the received data and the message it's replying to do not get out of sync.

---

An alternate approach not explored in this PR would be to modify `Receive` to read `bytes + 1` and do the flush if it receives `bytes + 1` instead of `bytes`, but I'm not sure which is better, if either.