### PR TITLE
SI: Generate NOREP on timeout instead of generating Dolphin SDK reply

### DIFF
--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -240,7 +240,6 @@ static void SetNoResponse(u32 channel)
     s_status_reg.NOREP3 = 1;
     break;
   }
-  s_com_csr.COMERR = 1;
 }
 
 static void ChangeDeviceCallback(u64 user_data, s64 cycles_late)
@@ -331,6 +330,7 @@ static void RunSIBuffer(u64 user_data, s64 cycles_late)
     if (actual_response_length != 0)
     {
       s_com_csr.TSTART = 0;
+      s_com_csr.COMERR = actual_response_length < 0;
       if (actual_response_length < 0)
         SetNoResponse(s_com_csr.CHANNEL);
       GenerateSIInterrupt(INT_TCINT);
@@ -502,8 +502,6 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                    s_com_csr.OUTLNGTH = tmp_com_csr.OUTLNGTH;
                    s_com_csr.RDSTINTMSK = tmp_com_csr.RDSTINTMSK;
                    s_com_csr.TCINTMSK = tmp_com_csr.TCINTMSK;
-
-                   s_com_csr.COMERR = 0;
 
                    if (tmp_com_csr.RDSTINT)
                      s_com_csr.RDSTINT = 0;

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
@@ -332,10 +332,9 @@ int CSIDevice_GBA::RunBuffer(u8* buffer, int request_length)
     }
     else
     {
-      u32 reply = Common::swap32(SI_ERROR_NO_RESPONSE);
-      std::memcpy(buffer, &reply, sizeof(reply));
-      return sizeof(reply);
+      return -1;
     }
+
     m_last_cmd = buffer[0];
     m_timestamp_sent = CoreTiming::GetTicks();
     m_next_action = NextAction::WaitTransferTime;
@@ -371,11 +370,7 @@ int CSIDevice_GBA::RunBuffer(u8* buffer, int request_length)
 
     m_next_action = NextAction::SendCommand;
     if (num_data_received == 0)
-    {
-      u32 reply = Common::swap32(SI_ERROR_NO_RESPONSE);
-      std::memcpy(buffer, &reply, sizeof(reply));
-      return sizeof(reply);
-    }
+      return -1;
 #ifdef _DEBUG
     const Common::Log::LOG_LEVELS log_level =
         (m_last_cmd == CMD_STATUS || m_last_cmd == CMD_RESET) ? Common::Log::LERROR :

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -43,11 +43,7 @@ int CSIDevice_GCController::RunBuffer(u8* buffer, int request_length)
 
   GCPadStatus pad_status = GetPadStatus();
   if (!pad_status.isConnected)
-  {
-    u32 reply = Common::swap32(SI_ERROR_NO_RESPONSE);
-    std::memcpy(buffer, &reply, sizeof(reply));
-    return sizeof(reply);
-  }
+    return -1;
 
   // Read the command
   EBufferCommands command = static_cast<EBufferCommands>(buffer[0]);

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
@@ -16,9 +16,7 @@ CSIDevice_Null::CSIDevice_Null(SIDevices device, int device_number)
 
 int CSIDevice_Null::RunBuffer(u8* buffer, int request_length)
 {
-  u32 reply = Common::swap32(SI_ERROR_NO_RESPONSE);
-  std::memcpy(buffer, &reply, sizeof(reply));
-  return sizeof(reply);
+  return -1;
 }
 
 bool CSIDevice_Null::GetData(u32& hi, u32& low)


### PR DESCRIPTION
I've noticed that NOREP timeouts aren't actually generated in Dolphin when there's no reply, instead favoring generating the reply that I _believe_ is actually created by the Dolphin SDK instead. I don't have proof that this behavior is correct, but I'm also not sure where to begin investigating.