### PR TITLE
DolphinQt: Removed unused this capture in lambda

### DIFF
--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -32,7 +32,7 @@
 
 Host::Host()
 {
-  State::SetOnAfterLoadCallback([this] { Host_UpdateDisasmDialog(); });
+  State::SetOnAfterLoadCallback([] { Host_UpdateDisasmDialog(); });
 }
 
 Host::~Host()


### PR DESCRIPTION
The Host constructor sets a callback on a lambda that in turn calls Host_UpdateDisasmDialog. Since that function is not a member function capturing this is unnecessary.

Fixes -Wunused-lambda-capture warning on freebsd-x64.