### PR TITLE
PowerPC: fix WSACleanup() calls not mirroring WSAStartup()

### DIFF
--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -834,7 +834,8 @@ static void gdb_init_generic(int domain, const sockaddr* server_addr, socklen_t 
                              sockaddr* client_addr, socklen_t* client_addrlen)
 {
 #ifdef _WIN32
-  WSAStartup(MAKEWORD(2, 2), &InitData);
+  if (!gdb_active())
+    WSAStartup(MAKEWORD(2, 2), &InitData);
 #endif
 
   memset(bp_x, 0, sizeof bp_x);

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -859,7 +859,7 @@ static void gdb_init_generic(int domain, const sockaddr* server_addr, socklen_t 
   INFO_LOG_FMT(GDB_STUB, "Waiting for gdb to connect...");
 
   sock = accept(tmpsock, client_addr, client_addrlen);
-  if (sock < 0)
+  if (sock == -1) 
     ERROR_LOG_FMT(GDB_STUB, "Failed to accept gdb client");
   INFO_LOG_FMT(GDB_STUB, "Client connected.");
 
@@ -869,10 +869,18 @@ static void gdb_init_generic(int domain, const sockaddr* server_addr, socklen_t 
   close(tmpsock);
 #endif
   tmpsock = -1;
+
+#ifdef _WIN32
+  if (!gdb_active())
+    WSACleanup();
+#endif
 }
 
 void gdb_deinit()
 {
+  if (!gdb_active())
+    return;
+
   if (tmpsock != -1)
   {
     shutdown(tmpsock, SHUT_RDWR);


### PR DESCRIPTION
Now checking sockets against -1 for errors because Windows, Linux and Max OS all return -1 on failure, otherwise our gdb_active() check might return the wrong value.

Fixes https://bugs.dolphin-emu.org/issues/12429 and also netplay breaking after stopping the emulation for the first time.