### PR TITLE
CMake: Include WIL headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,6 +805,7 @@ else()
 endif()
 
 if (WIN32)
+  include_directories(Externals/WIL/include)
   include_directories(Externals/OpenAL/include)
 endif()
 

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -2,6 +2,18 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#ifdef _WIN32
+#include <QCoreApplication>
+#include <shlobj.h>
+#include <wil/com.h>
+
+// This file uses some identifiers which are defined as macros in Windows headers.
+// Include and undefine the macros first thing we do to solve build errors.
+#ifdef DeleteFile
+#undef DeleteFile
+#endif
+#endif
+
 #include "DolphinQt/GameList/GameList.h"
 
 #include <algorithm>
@@ -52,20 +64,6 @@
 #include "DolphinQt/WiiUpdate.h"
 
 #include "UICommon/GameFile.h"
-
-#ifdef _WIN32
-#include <QCoreApplication>
-#include <shlobj.h>
-#include <wil/com.h>
-
-// This file uses some identifiers which are defined as macros in Windows headers.
-// Undefine them for the intellisense parser to solve some red squiggles.
-#ifdef __INTELLISENSE__
-#ifdef DeleteFile
-#undef DeleteFile
-#endif
-#endif
-#endif
 
 GameList::GameList(QWidget* parent) : QStackedWidget(parent), m_model(this)
 {


### PR DESCRIPTION
MSBuild does this, so CMake should too. Fixes the MSVC build when combined with PR #9457 or PR #9556.