### PR TITLE
Watches: Fix Save and Load from strings

### DIFF
--- a/Source/Core/Common/Debug/Watches.cpp
+++ b/Source/Core/Common/Debug/Watches.cpp
@@ -5,6 +5,7 @@
 #include "Common/Debug/Watches.h"
 
 #include <algorithm>
+#include <locale>
 #include <sstream>
 
 namespace Common::Debug
@@ -88,11 +89,11 @@ void Watches::LoadFromStrings(const std::vector<std::string>& watches)
 {
   for (const std::string& watch : watches)
   {
-    std::stringstream ss;
+    std::istringstream ss(watch);
+    ss.imbue(std::locale::classic());
     u32 address;
     std::string name;
-    ss << std::hex << watch;
-    ss >> address;
+    ss >> std::hex >> address;
     ss >> std::ws;
     std::getline(ss, name);
     SetWatch(address, name);
@@ -105,6 +106,7 @@ std::vector<std::string> Watches::SaveToStrings() const
   for (const auto& watch : m_watches)
   {
     std::ostringstream ss;
+    ss.imbue(std::locale::classic());
     ss << std::hex << watch.address << " " << watch.name;
     watches.push_back(ss.str());
   }


### PR DESCRIPTION
This PR fixes (de)serialisation issues where decimal separator can get inserted in the watch's address.

Ready to be reviewed & merged.