### PR TITLE
Breakpoints: Change icon when disabled

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -338,9 +338,19 @@ void CodeViewWidget::Update()
 
     if (PowerPC::debug_interface.IsBreakpoint(addr))
     {
-      bp_item->setData(
-          Qt::DecorationRole,
-          Resources::GetScaledThemeIcon("debugger_breakpoint").pixmap(QSize(rowh - 2, rowh - 2)));
+      auto icon =
+          Resources::GetScaledThemeIcon("debugger_breakpoint").pixmap(QSize(rowh - 2, rowh - 2));
+      if (!PowerPC::breakpoints.IsBreakPointEnable(addr))
+      {
+        QPixmap disabled_icon(icon.size());
+        disabled_icon.fill(Qt::transparent);
+        QPainter p(&disabled_icon);
+        p.setOpacity(0.20);
+        p.drawPixmap(0, 0, icon);
+        p.end();
+        icon = disabled_icon;
+      }
+      bp_item->setData(Qt::DecorationRole, icon);
     }
 
     setItem(i, CODE_VIEW_COLUMN_BREAKPOINT, bp_item);


### PR DESCRIPTION
This PR changes the icon of breakpoints when disabled by making them more transparent.

What this PR won't do:
 - Changing memchecks icons (will be addressed in another PR).
 - ~The icons not updating in the code view will also be addressed in another PR since it affects mostly all BreakpointWidget features including creating a new breakpoint.~

Screenshot:
![image](https://user-images.githubusercontent.com/7890055/110081415-52f81d00-7da5-11eb-9ff5-df86dc2a8bb3.png)

Ready to be review & merged.