### PR TITLE
Fix various build warnings

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -27,7 +27,6 @@ namespace Arm64Gen
 namespace
 {
 const int kWRegSizeInBits = 32;
-const int kXRegSizeInBits = 64;
 
 uint64_t LargestPowerOf2Divisor(uint64_t value)
 {

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -26,8 +26,6 @@ namespace Arm64Gen
 {
 namespace
 {
-const int kWRegSizeInBits = 32;
-
 uint64_t LargestPowerOf2Divisor(uint64_t value)
 {
   return value & -(int64_t)value;
@@ -87,6 +85,8 @@ std::optional<std::tuple<u32, u32, u32>> IsImmLogical(u64 value, u32 width)
     negate = true;
     value = ~value;
   }
+
+  constexpr int kWRegSizeInBits = 32;
 
   if (width == kWRegSizeInBits)
   {

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -146,7 +146,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
 {
   // The game will send us a SendCMD with this information. To be able to read and write
   // to a file we need to prepare a 0x10 byte output buffer as response.
-  struct Request
+  struct
   {
     u32 command;
     u32 type;

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -725,11 +725,11 @@ void WiimoteDevice::SendConfigurationRequest(u16 cid, u16 mtu, u16 flush_time_ou
   SendCommandToACL(L2CAP_CONFIG_REQ, L2CAP_CONFIG_REQ, offset, buffer);
 }
 
-constexpr u8 SDP_UINT8 = 0x08;
-constexpr u8 SDP_UINT16 = 0x09;
+[[maybe_unused]] constexpr u8 SDP_UINT8 = 0x08;
+[[maybe_unused]] constexpr u8 SDP_UINT16 = 0x09;
 constexpr u8 SDP_UINT32 = 0x0A;
 constexpr u8 SDP_SEQ8 = 0x35;
-constexpr u8 SDP_SEQ16 = 0x36;
+[[maybe_unused]] constexpr u8 SDP_SEQ16 = 0x36;
 
 void WiimoteDevice::SDPSendServiceSearchResponse(u16 cid, u16 transaction_id,
                                                  u8* service_search_pattern,

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -186,8 +186,8 @@ void PCAPSSLCaptureLogger::LogIPv4(LogType log_type, const u8* data, u16 length,
   }
 
   std::vector<u8> packet;
-  auto insert = [&](const auto* data, std::size_t size) {
-    const u8* begin = reinterpret_cast<const u8*>(data);
+  auto insert = [&](const auto* new_data, std::size_t size) {
+    const u8* begin = reinterpret_cast<const u8*>(new_data);
     packet.insert(packet.end(), begin, begin + size);
   };
 

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWidget.h
@@ -6,15 +6,10 @@
 
 #include <QWidget>
 
-class QFormLayout;
-
 class GraphicsWidget : public QWidget
 {
   Q_OBJECT
 protected:
   virtual void LoadSettings() = 0;
   virtual void SaveSettings() = 0;
-
-private:
-  QFormLayout* m_main_layout;
 };

--- a/Source/Core/InputCommon/ControllerInterface/Touch/Touchscreen.h
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/Touchscreen.h
@@ -15,9 +15,9 @@ private:
   class Button : public Input
   {
   public:
-    std::string GetName() const;
+    std::string GetName() const override;
     Button(int pad_id, ButtonManager::ButtonType index) : m_pad_id(pad_id), m_index(index) {}
-    ControlState GetState() const;
+    ControlState GetState() const override;
 
   private:
     const int m_pad_id;
@@ -26,13 +26,13 @@ private:
   class Axis : public Input
   {
   public:
-    std::string GetName() const;
+    std::string GetName() const override;
     bool IsDetectable() const override { return false; }
     Axis(int pad_id, ButtonManager::ButtonType index, float neg = 1.0f)
         : m_pad_id(pad_id), m_index(index), m_neg(neg)
     {
     }
-    ControlState GetState() const;
+    ControlState GetState() const override;
 
   private:
     const int m_pad_id;
@@ -56,8 +56,8 @@ private:
 public:
   Touchscreen(int pad_id, bool accelerometer_enabled, bool gyroscope_enabled);
   ~Touchscreen() {}
-  std::string GetName() const;
-  std::string GetSource() const;
+  std::string GetName() const override;
+  std::string GetSource() const override;
 
 private:
   const int m_pad_id;

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -365,7 +365,7 @@ static void StopHotplugThread()
 
   // Write something to efd so that select() stops blocking.
   const uint64_t value = 1;
-  static_cast<void>(write(s_wakeup_eventfd, &value, sizeof(uint64_t)));
+  static_cast<void>(!write(s_wakeup_eventfd, &value, sizeof(uint64_t)));
 
   s_hotplug_thread.join();
   close(s_wakeup_eventfd);
@@ -525,7 +525,7 @@ bool evdevDevice::AddNode(std::string devnode, int fd, libevdev* dev)
     ie.code = FF_AUTOCENTER;
     ie.value = 0;
 
-    static_cast<void>(write(fd, &ie, sizeof(ie)));
+    static_cast<void>(!write(fd, &ie, sizeof(ie)));
   }
 
   // Constant FF effect
@@ -725,7 +725,7 @@ void evdevDevice::Effect::UpdateEffect()
       play.code = m_effect.id;
       play.value = 1;
 
-      static_cast<void>(write(m_fd, &play, sizeof(play)));
+      static_cast<void>(!write(m_fd, &play, sizeof(play)));
     }
     else
     {

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -186,9 +186,9 @@ bool InputConfig::ControllersNeedToBeCreated() const
   return m_controllers.empty();
 }
 
-std::size_t InputConfig::GetControllerCount() const
+int InputConfig::GetControllerCount() const
 {
-  return m_controllers.size();
+  return static_cast<int>(m_controllers.size());
 }
 
 void InputConfig::RegisterHotplugCallback()

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -41,7 +41,7 @@ public:
 
   std::string GetGUIName() const { return m_gui_name; }
   std::string GetProfileName() const { return m_profile_name; }
-  std::size_t GetControllerCount() const;
+  int GetControllerCount() const;
 
   // These should be used after creating all controllers and before clearing them, respectively.
   void RegisterHotplugCallback();

--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -67,7 +67,7 @@ public:
 
   void Reset() override { m_mat = Common::Matrix44::Identity(); }
 
-  void DoState(PointerWrap& p) { p.Do(m_mat); }
+  void DoState(PointerWrap& p) override { p.Do(m_mat); }
 
 private:
   Common::Matrix44 m_mat = Common::Matrix44::Identity();
@@ -119,7 +119,7 @@ public:
     m_rotate_quat = Common::Quaternion::Identity();
   }
 
-  void DoState(PointerWrap& p)
+  void DoState(PointerWrap& p) override
   {
     p.Do(m_rotation);
     p.Do(m_rotate_quat);
@@ -170,7 +170,7 @@ public:
     m_distance = 0;
   }
 
-  void DoState(PointerWrap& p)
+  void DoState(PointerWrap& p) override
   {
     p.Do(m_rotation);
     p.Do(m_rotate_quat);

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -79,7 +79,6 @@ private:
 
   float m_fov_step_size = 0.025f;
   float m_speed = 1.0f;
-  bool m_enabled = true;
 };
 
 extern FreeLookCamera g_freelook_camera;


### PR DESCRIPTION
Fix a number of build warnings on various platforms.

- Unused variables in Arm64Gen, FreeLookCamera and GraphicsWidget
- Variable shadowing in SDIOSlot0Device and NetworkCaptureLogger
- Missing maybe_unused attribute for unused but documenting constants in WiimoteDevice
- Missing override specifiers in Touchscreen subclasses and FreeLookCamera
- Spurious gcc warning about discarding return values with warn_unused_result attribute
- Signed/unsigned comparison in InputConfig
- Move Arm64Gen namespace variable into only consuming function (and make constexpr).