### PR TITLE
Android: Don't save settings immediately after switching platform tab

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -279,4 +279,9 @@ public enum BooleanSetting implements AbstractBooleanSetting
   {
     return NativeConfig.getBoolean(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
   }
+
+  public void setBooleanGlobal(int layer, boolean newValue)
+  {
+    NativeConfig.setBoolean(layer, mFile, mSection, mKey, newValue);
+  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
@@ -78,4 +78,9 @@ public enum FloatSetting implements AbstractFloatSetting
   {
     return NativeConfig.getFloat(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
   }
+
+  public void setFloatGlobal(int layer, float newValue)
+  {
+    NativeConfig.setFloat(layer, mFile, mSection, mKey, newValue);
+  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -147,4 +147,9 @@ public enum IntSetting implements AbstractIntSetting
   {
     return NativeConfig.getInt(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
   }
+
+  public void setIntGlobal(int layer, int newValue)
+  {
+    NativeConfig.setInt(layer, mFile, mSection, mKey, newValue);
+  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
@@ -109,4 +109,9 @@ public enum StringSetting implements AbstractStringSetting
   {
     return NativeConfig.getString(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
   }
+
+  public void setStringGlobal(int layer, String newValue)
+  {
+    NativeConfig.setString(layer, mFile, mSection, mKey, newValue);
+  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -23,6 +23,7 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.adapters.PlatformPagerAdapter;
 import org.dolphinemu.dolphinemu.features.settings.model.IntSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.NativeConfig;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag;
 import org.dolphinemu.dolphinemu.features.settings.ui.SettingsActivity;
@@ -127,10 +128,17 @@ public final class MainActivity extends AppCompatActivity
   protected void onStop()
   {
     super.onStop();
+
     if (isChangingConfigurations())
     {
       skipRescanningLibrary();
     }
+    else if (DirectoryInitialization.areDolphinDirectoriesReady())
+    {
+      // If the currently selected platform tab changed, save it to disk
+      NativeConfig.save(NativeConfig.LAYER_BASE);
+    }
+
     StartupHandler.setSessionTime(this);
   }
 
@@ -335,16 +343,7 @@ public final class MainActivity extends AppCompatActivity
       public void onTabSelected(@NonNull TabLayout.Tab tab)
       {
         super.onTabSelected(tab);
-
-        try (Settings settings = new Settings())
-        {
-          settings.loadSettings();
-
-          IntSetting.MAIN_LAST_PLATFORM_TAB.setInt(settings, tab.getPosition());
-
-          // Context is set to null to avoid toasts
-          settings.saveSettings(null, null);
-        }
+        IntSetting.MAIN_LAST_PLATFORM_TAB.setIntGlobal(NativeConfig.LAYER_BASE, tab.getPosition());
       }
     });
 


### PR DESCRIPTION
We want to save the currently selected platform tab, but doing so immediately after switching tabs leads to unnecessarily much file I/O (on the main thread, no less). This change makes us defer the saving until later.