### PR TITLE
DiscIO: Fix reading certain WIA chunks with many exceptions

### DIFF
--- a/Source/Core/DiscIO/WIABlob.h
+++ b/Source/Core/DiscIO/WIABlob.h
@@ -202,6 +202,8 @@ private:
     bool HandleExceptions(const u8* data, size_t bytes_allocated, size_t bytes_written,
                           size_t* bytes_used, bool align);
 
+    size_t GetOutBytesWrittenExcludingExceptions() const;
+
     DecompressionBuffer m_in;
     DecompressionBuffer m_out;
     size_t m_in_bytes_read = 0;


### PR DESCRIPTION
The loop in `WIARVZFileReader::Chunk::Read` could terminate prematurely if the size argument was smaller than the size of an exception list which had only been partially loaded.