### PR TITLE
NetPlay: Sync more settings

### DIFF
--- a/Source/Core/Common/Config/Enums.h
+++ b/Source/Core/Common/Config/Enums.h
@@ -8,14 +8,15 @@
 
 namespace Config
 {
+// Layers in ascending order of priority.
 enum class LayerType
 {
   Base,
+  CommandLine,
   GlobalGame,
   LocalGame,
   Movie,
   Netplay,
-  CommandLine,
   CurrentRun,
   Meta,
 };
@@ -36,11 +37,11 @@ enum class System
 
 constexpr std::array<LayerType, 7> SEARCH_ORDER{{
     LayerType::CurrentRun,
-    LayerType::CommandLine,
-    LayerType::Movie,
     LayerType::Netplay,
+    LayerType::Movie,
     LayerType::LocalGame,
     LayerType::GlobalGame,
+    LayerType::CommandLine,
     LayerType::Base,
 }};
 }  // namespace Config

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -433,13 +433,14 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
   if (StartUp.bWii && DiscIO::IsNTSC(StartUp.m_region) && Config::Get(Config::SYSCONF_PAL60))
     Config::SetCurrent(Config::SYSCONF_PAL60, false);
 
+  Core::UpdateWantDeterminism(/*initial*/ true);
+
   if (StartUp.bWii)
   {
-    const bool want_determinism = Movie::IsMovieActive() || NetPlay::IsNetPlayRunning();
-    Core::InitializeWiiRoot(want_determinism);
+    Core::InitializeWiiRoot(Core::WantsDeterminism());
 
     // Ensure any new settings are written to the SYSCONF
-    if (!want_determinism)
+    if (!Core::WantsDeterminism())
     {
       Core::BackupWiiSettings();
       ConfigLoaders::SaveToSYSCONF(Config::LayerType::Meta);

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <functional>
 #include <list>
 #include <map>
 #include <memory>
@@ -29,7 +30,7 @@
 
 namespace ConfigLoaders
 {
-void SaveToSYSCONF(Config::LayerType layer)
+void SaveToSYSCONF(Config::LayerType layer, std::function<bool(const Config::Location&)> predicate)
 {
   if (Core::IsRunning())
     return;
@@ -40,7 +41,10 @@ void SaveToSYSCONF(Config::LayerType layer)
   for (const Config::SYSCONFSetting& setting : Config::SYSCONF_SETTINGS)
   {
     std::visit(
-        [layer, &setting, &sysconf](auto* info) {
+        [&](auto* info) {
+          if (predicate && !predicate(info->GetLocation()))
+            return;
+
           const std::string key = info->GetLocation().section + "." + info->GetLocation().key;
 
           if (setting.type == SysConf::Entry::Type::Long)

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -68,8 +68,7 @@ void SaveToSYSCONF(Config::LayerType layer, std::function<bool(const Config::Loc
         setting.config_info);
   }
 
-  if (SConfig::GetInstance().bEnableCustomRTC)
-    sysconf.SetData<u32>("IPL.CB", SysConf::Entry::Type::Long, 0);
+  sysconf.SetData<u32>("IPL.CB", SysConf::Entry::Type::Long, 0);
 
   // Disable WiiConnect24's standby mode. If it is enabled, it prevents us from receiving
   // shutdown commands in the State Transition Manager (STM).

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.h
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.h
@@ -4,16 +4,19 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 
 namespace Config
 {
 class ConfigLayerLoader;
 enum class LayerType;
+struct Location;
 }  // namespace Config
 
 namespace ConfigLoaders
 {
-void SaveToSYSCONF(Config::LayerType layer);
+void SaveToSYSCONF(Config::LayerType layer,
+                   std::function<bool(const Config::Location&)> predicate = {});
 std::unique_ptr<Config::ConfigLayerLoader> GenerateBaseConfigLoader();
 }  // namespace ConfigLoaders

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -39,9 +39,21 @@ public:
     layer->Set(Config::MAIN_SLOT_B, static_cast<int>(m_settings.m_EXIDevice[1]));
     layer->Set(Config::MAIN_SERIAL_PORT_1, static_cast<int>(m_settings.m_EXIDevice[2]));
     layer->Set(Config::MAIN_WII_SD_CARD_WRITABLE, m_settings.m_WriteToMemcard);
+    layer->Set(Config::MAIN_MEM1_SIZE, m_settings.m_Mem1Size);
+    layer->Set(Config::MAIN_MEM2_SIZE, m_settings.m_Mem2Size);
+    layer->Set(Config::MAIN_FALLBACK_REGION, m_settings.m_FallbackRegion);
     layer->Set(Config::MAIN_DSP_JIT, m_settings.m_DSPEnableJIT);
-    layer->Set(Config::SYSCONF_PROGRESSIVE_SCAN, m_settings.m_ProgressiveScan);
-    layer->Set(Config::SYSCONF_PAL60, m_settings.m_PAL60);
+
+    for (size_t i = 0; i < Config::SYSCONF_SETTINGS.size(); ++i)
+    {
+      std::visit(
+          [&](auto* info) {
+            layer->Set(*info, static_cast<decltype(info->GetDefaultValue())>(
+                                  m_settings.m_SYSCONFSettings[i]));
+          },
+          Config::SYSCONF_SETTINGS[i].config_info);
+    }
+
     layer->Set(Config::GFX_HACK_EFB_ACCESS_ENABLE, m_settings.m_EFBAccessEnable);
     layer->Set(Config::GFX_HACK_BBOX_ENABLE, m_settings.m_BBoxEnable);
     layer->Set(Config::GFX_HACK_FORCE_PROGRESSIVE, m_settings.m_ForceProgressive);
@@ -60,12 +72,14 @@ public:
     layer->Set(Config::MAIN_SYNC_GPU_MAX_DISTANCE, m_settings.m_SyncGpuMaxDistance);
     layer->Set(Config::MAIN_SYNC_GPU_MIN_DISTANCE, m_settings.m_SyncGpuMinDistance);
     layer->Set(Config::MAIN_SYNC_GPU_OVERCLOCK, m_settings.m_SyncGpuOverclock);
+
     layer->Set(Config::MAIN_JIT_FOLLOW_BRANCH, m_settings.m_JITFollowBranch);
     layer->Set(Config::MAIN_FAST_DISC_SPEED, m_settings.m_FastDiscSpeed);
     layer->Set(Config::MAIN_MMU, m_settings.m_MMU);
     layer->Set(Config::MAIN_FASTMEM, m_settings.m_Fastmem);
     layer->Set(Config::MAIN_SKIP_IPL, m_settings.m_SkipIPL);
     layer->Set(Config::MAIN_LOAD_IPL_DUMP, m_settings.m_LoadIPLDump);
+
     layer->Set(Config::GFX_HACK_DEFER_EFB_COPIES, m_settings.m_DeferEFBCopies);
     layer->Set(Config::GFX_HACK_EFB_ACCESS_TILE_SIZE, m_settings.m_EFBAccessTileSize);
     layer->Set(Config::GFX_HACK_EFB_DEFER_INVALIDATION, m_settings.m_EFBAccessDeferInvalidation);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -590,7 +590,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
     return;
 
   // Initialise Wii filesystem contents.
-  // This is done here after Boot and not in HW to ensure that we operate
+  // This is done here after Boot and not in BootManager to ensure that we operate
   // with the correct title context since save copying requires title directories to exist.
   Common::ScopeGuard wiifs_guard{&Core::CleanUpWiiFileSystemContents};
   if (SConfig::GetInstance().bWii)

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -231,8 +231,6 @@ bool Init(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
   // Drain any left over jobs
   HostDispatchJobs();
 
-  Core::UpdateWantDeterminism(/*initial*/ true);
-
   INFO_LOG_FMT(BOOT, "Starting core = {} mode", SConfig::GetInstance().bWii ? "Wii" : "GameCube");
   INFO_LOG_FMT(BOOT, "CPU Thread separate = {}", SConfig::GetInstance().bCPUThread ? "Yes" : "No");
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -136,8 +136,7 @@ CEXIIPL::CEXIIPL()
   // We Overwrite language selection here since it's possible on the GC to change the language as
   // you please
   g_SRAM.settings.language = SConfig::GetInstance().SelectedLanguage;
-  if (SConfig::GetInstance().bEnableCustomRTC)
-    g_SRAM.settings.rtc_bias = 0;
+  g_SRAM.settings.rtc_bias = 0;
   FixSRAMChecksums();
 }
 

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -25,7 +25,6 @@
 #include "Core/HW/WII_IPC.h"
 #include "Core/IOS/IOS.h"
 #include "Core/State.h"
-#include "Core/WiiRoot.h"
 
 namespace HW
 {
@@ -52,8 +51,6 @@ void Init()
 
   if (SConfig::GetInstance().bWii)
   {
-    // The NAND should only be initialised once per emulation session.
-    Core::InitializeWiiRoot(Core::WantsDeterminism());
     IOS::Init();
     IOS::HLE::Init();  // Depends on Memory
   }
@@ -64,7 +61,6 @@ void Shutdown()
   // IOS should always be shut down regardless of bWii because it can be running in GC mode (MIOS).
   IOS::HLE::Shutdown();  // Depends on Memory
   IOS::Shutdown();
-  Core::ShutdownWiiRoot();
 
   SystemTimers::Shutdown();
   CPU::Shutdown();

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -654,11 +654,18 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       packet >> m_net_settings.m_EnableCheats;
       packet >> m_net_settings.m_SelectedLanguage;
       packet >> m_net_settings.m_OverrideRegionSettings;
-      packet >> m_net_settings.m_ProgressiveScan;
-      packet >> m_net_settings.m_PAL60;
       packet >> m_net_settings.m_DSPEnableJIT;
       packet >> m_net_settings.m_DSPHLE;
       packet >> m_net_settings.m_WriteToMemcard;
+      packet >> m_net_settings.m_Mem1Size;
+      packet >> m_net_settings.m_Mem2Size;
+
+      {
+        std::underlying_type_t<DiscIO::Region> tmp;
+        packet >> tmp;
+        m_net_settings.m_FallbackRegion = static_cast<DiscIO::Region>(tmp);
+      }
+
       packet >> m_net_settings.m_CopyWiiSave;
       packet >> m_net_settings.m_OCEnable;
       packet >> m_net_settings.m_OCFactor;
@@ -669,6 +676,9 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
         packet >> tmp;
         device = static_cast<ExpansionInterface::TEXIDevices>(tmp);
       }
+
+      for (u32& value : m_net_settings.m_SYSCONFSettings)
+        packet >> value;
 
       packet >> m_net_settings.m_EFBAccessEnable;
       packet >> m_net_settings.m_BBoxEnable;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -6,9 +6,15 @@
 
 #include <array>
 #include <vector>
+
 #include "Common/CommonTypes.h"
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/HW/EXI/EXI_Device.h"
 
+namespace DiscIO
+{
+enum class Region;
+}
 namespace IOS::HLE::FS
 {
 class FileSystem;
@@ -27,15 +33,19 @@ struct NetSettings
   bool m_EnableCheats;
   int m_SelectedLanguage;
   bool m_OverrideRegionSettings;
-  bool m_ProgressiveScan;
-  bool m_PAL60;
   bool m_DSPHLE;
   bool m_DSPEnableJIT;
   bool m_WriteToMemcard;
+  u32 m_Mem1Size;
+  u32 m_Mem2Size;
+  DiscIO::Region m_FallbackRegion;
   bool m_CopyWiiSave;
   bool m_OCEnable;
   float m_OCFactor;
   std::array<ExpansionInterface::TEXIDevices, 3> m_EXIDevice;
+
+  std::array<u32, Config::SYSCONF_SETTINGS.size()> m_SYSCONFSettings;
+
   bool m_EFBAccessEnable;
   bool m_BBoxEnable;
   bool m_ForceProgressive;
@@ -76,6 +86,7 @@ struct NetSettings
   bool m_DeferEFBCopies;
   bool m_EFBAccessTileSize;
   bool m_EFBAccessDeferInvalidation;
+
   bool m_StrictSettingsSync;
   bool m_SyncSaveData;
   bool m_SyncCodes;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1303,17 +1303,21 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_EnableCheats;
   spac << m_settings.m_SelectedLanguage;
   spac << m_settings.m_OverrideRegionSettings;
-  spac << m_settings.m_ProgressiveScan;
-  spac << m_settings.m_PAL60;
   spac << m_settings.m_DSPEnableJIT;
   spac << m_settings.m_DSPHLE;
   spac << m_settings.m_WriteToMemcard;
+  spac << m_settings.m_Mem1Size;
+  spac << m_settings.m_Mem2Size;
+  spac << static_cast<std::underlying_type_t<DiscIO::Region>>(m_settings.m_FallbackRegion);
   spac << m_settings.m_CopyWiiSave;
   spac << m_settings.m_OCEnable;
   spac << m_settings.m_OCFactor;
 
   for (auto& device : m_settings.m_EXIDevice)
     spac << device;
+
+  for (u32 value : m_settings.m_SYSCONFSettings)
+    spac << value;
 
   spac << m_settings.m_EFBAccessEnable;
   spac << m_settings.m_BBoxEnable;

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -202,11 +202,16 @@ void InitializeWiiRoot(bool use_temporary)
 
 void ShutdownWiiRoot()
 {
-  if (!s_temp_wii_root.empty())
+  if (WiiRootIsTemporary())
   {
     File::DeleteDirRecursively(s_temp_wii_root);
     s_temp_wii_root.clear();
   }
+}
+
+bool WiiRootIsTemporary()
+{
+  return !s_temp_wii_root.empty();
 }
 
 void BackupWiiSettings()
@@ -282,7 +287,7 @@ void InitializeWiiFileSystemContents()
   if (!CopySysmenuFilesToFS(fs.get(), File::GetSysDirectory() + WII_USER_DIR, ""))
     WARN_LOG_FMT(CORE, "Failed to copy initial System Menu files to the NAND");
 
-  if (s_temp_wii_root.empty())
+  if (!WiiRootIsTemporary())
     return;
 
   // Generate a SYSCONF with default settings for the temporary Wii NAND.
@@ -294,7 +299,7 @@ void InitializeWiiFileSystemContents()
 
 void CleanUpWiiFileSystemContents()
 {
-  if (s_temp_wii_root.empty() || !SConfig::GetInstance().bEnableMemcardSdWriting ||
+  if (!WiiRootIsTemporary() || !SConfig::GetInstance().bEnableMemcardSdWriting ||
       NetPlay::GetWiiSyncFS())
   {
     return;

--- a/Source/Core/Core/WiiRoot.h
+++ b/Source/Core/Core/WiiRoot.h
@@ -15,6 +15,8 @@ enum class RestoreReason
 void InitializeWiiRoot(bool use_temporary);
 void ShutdownWiiRoot();
 
+bool WiiRootIsTemporary();
+
 void BackupWiiSettings();
 void RestoreWiiSettings(RestoreReason reason);
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -446,11 +446,12 @@ void NetPlayDialog::OnStart()
   settings.m_EnableCheats = Config::Get(Config::MAIN_ENABLE_CHEATS);
   settings.m_SelectedLanguage = Config::Get(Config::MAIN_GC_LANGUAGE);
   settings.m_OverrideRegionSettings = Config::Get(Config::MAIN_OVERRIDE_REGION_SETTINGS);
-  settings.m_ProgressiveScan = Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN);
-  settings.m_PAL60 = Config::Get(Config::SYSCONF_PAL60);
   settings.m_DSPHLE = Config::Get(Config::MAIN_DSP_HLE);
   settings.m_DSPEnableJIT = Config::Get(Config::MAIN_DSP_JIT);
   settings.m_WriteToMemcard = m_save_sd_action->isChecked();
+  settings.m_Mem1Size = Config::Get(Config::MAIN_MEM1_SIZE);
+  settings.m_Mem2Size = Config::Get(Config::MAIN_MEM2_SIZE);
+  settings.m_FallbackRegion = Config::Get(Config::MAIN_FALLBACK_REGION);
   settings.m_CopyWiiSave = m_load_wii_action->isChecked();
   settings.m_OCEnable = Config::Get(Config::MAIN_OVERCLOCK_ENABLE);
   settings.m_OCFactor = Config::Get(Config::MAIN_OVERCLOCK);
@@ -460,6 +461,17 @@ void NetPlayDialog::OnStart()
       static_cast<ExpansionInterface::TEXIDevices>(Config::Get(Config::MAIN_SLOT_B));
   // There's no way the BBA is going to sync, disable it
   settings.m_EXIDevice[2] = ExpansionInterface::EXIDEVICE_NONE;
+
+  for (size_t i = 0; i < Config::SYSCONF_SETTINGS.size(); ++i)
+  {
+    std::visit(
+        [&](auto* info) {
+          static_assert(sizeof(info->GetDefaultValue()) <= sizeof(u32));
+          settings.m_SYSCONFSettings[i] = static_cast<u32>(Config::Get(*info));
+        },
+        Config::SYSCONF_SETTINGS[i].config_info);
+  }
+
   settings.m_EFBAccessEnable = Config::Get(Config::GFX_HACK_EFB_ACCESS_ENABLE);
   settings.m_BBoxEnable = Config::Get(Config::GFX_HACK_BBOX_ENABLE);
   settings.m_ForceProgressive = Config::Get(Config::GFX_HACK_FORCE_PROGRESSIVE);


### PR DESCRIPTION
Fixes certain netplay desyncs, https://bugs.dolphin-emu.org/issues/10328, and a bug where the Wii language stored in a DTM file would be ignored. Prerequisite for PR #9388.