### PR TITLE
VolumeVerifier: Align partition reads to groups

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -126,7 +126,7 @@ public:
   virtual bool IsNKit() const = 0;
   virtual bool SupportsIntegrityCheck() const { return false; }
   virtual bool CheckH3TableIntegrity(const Partition& partition) const { return false; }
-  virtual bool CheckBlockIntegrity(u64 block_index, const std::vector<u8>& encrypted_data,
+  virtual bool CheckBlockIntegrity(u64 block_index, const u8* encrypted_data,
                                    const Partition& partition) const
   {
     return false;

--- a/Source/Core/DiscIO/VolumeVerifier.h
+++ b/Source/Core/DiscIO/VolumeVerifier.h
@@ -135,11 +135,12 @@ public:
   const Result& GetResult() const;
 
 private:
-  struct BlockToVerify
+  struct GroupToVerify
   {
     Partition partition;
     u64 offset;
-    u64 block_index;
+    size_t block_index_start;
+    size_t block_index_end;
   };
 
   std::vector<Partition> CheckPartitions();
@@ -182,14 +183,14 @@ private:
   std::future<void> m_md5_future;
   std::future<void> m_sha1_future;
   std::future<void> m_content_future;
-  std::future<void> m_block_future;
+  std::future<void> m_group_future;
 
   DiscScrubber m_scrubber;
   IOS::ES::TicketReader m_ticket;
   std::vector<u64> m_content_offsets;
   u16 m_content_index = 0;
-  std::vector<BlockToVerify> m_blocks;
-  size_t m_block_index = 0;  // Index in m_blocks, not index in a specific partition
+  std::vector<GroupToVerify> m_groups;
+  size_t m_group_index = 0;  // Index in m_groups, not index in a specific partition
   std::map<Partition, size_t> m_block_errors;
   std::map<Partition, size_t> m_unused_block_errors;
 

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -412,12 +412,9 @@ bool VolumeWii::CheckH3TableIntegrity(const Partition& partition) const
   return h3_table_sha1 == contents[0].sha1;
 }
 
-bool VolumeWii::CheckBlockIntegrity(u64 block_index, const std::vector<u8>& encrypted_data,
+bool VolumeWii::CheckBlockIntegrity(u64 block_index, const u8* encrypted_data,
                                     const Partition& partition) const
 {
-  if (encrypted_data.size() != BLOCK_TOTAL_SIZE)
-    return false;
-
   auto it = m_partitions.find(partition);
   if (it == m_partitions.end())
     return false;
@@ -431,10 +428,10 @@ bool VolumeWii::CheckBlockIntegrity(u64 block_index, const std::vector<u8>& encr
     return false;
 
   HashBlock hashes;
-  DecryptBlockHashes(encrypted_data.data(), &hashes, aes_context);
+  DecryptBlockHashes(encrypted_data, &hashes, aes_context);
 
   u8 cluster_data[BLOCK_DATA_SIZE];
-  DecryptBlockData(encrypted_data.data(), cluster_data, aes_context);
+  DecryptBlockData(encrypted_data, cluster_data, aes_context);
 
   for (u32 hash_index = 0; hash_index < 31; ++hash_index)
   {
@@ -474,7 +471,7 @@ bool VolumeWii::CheckBlockIntegrity(u64 block_index, const Partition& partition)
   std::vector<u8> cluster(BLOCK_TOTAL_SIZE);
   if (!m_reader->Read(cluster_offset, cluster.size(), cluster.data()))
     return false;
-  return CheckBlockIntegrity(block_index, cluster, partition);
+  return CheckBlockIntegrity(block_index, cluster.data(), partition);
 }
 
 bool VolumeWii::HashGroup(const std::array<u8, BLOCK_DATA_SIZE> in[BLOCKS_PER_GROUP],

--- a/Source/Core/DiscIO/VolumeWii.h
+++ b/Source/Core/DiscIO/VolumeWii.h
@@ -82,7 +82,7 @@ public:
   bool IsDatelDisc() const override;
   bool SupportsIntegrityCheck() const override { return m_encrypted; }
   bool CheckH3TableIntegrity(const Partition& partition) const override;
-  bool CheckBlockIntegrity(u64 block_index, const std::vector<u8>& encrypted_data,
+  bool CheckBlockIntegrity(u64 block_index, const u8* encrypted_data,
                            const Partition& partition) const override;
   bool CheckBlockIntegrity(u64 block_index, const Partition& partition) const override;
 


### PR DESCRIPTION
Dependent on PR #8625.

This improves the speed of verifying Wii WIA/RVZ files. For me, the verification speed for LZMA2-compressed files has gone from 11-12 MiB/s to 13-14 MiB/s.

One thing VolumeVerifier does to achieve parallelism is to compute hashes for one chunk of data while reading the next chunk of data. In master, when reading data from a Wii partition, each such chunk is 32 KiB. This is normally fine, but with WIA and RVZ it leads to rather lopsided read times (without the compute times being lopsided): The first 32 KiB of each 2 MiB takes a long time to read, and the remaining part of the 2 MiB can be read nearly instantly. (The WIA/RVZ code has to read the entire 2 MiB in order to compute hashes which appear at the beginning of the 2 MiB, and then caches the result afterwards.) This leads to us at times not doing much reading and at other times not doing much computation. To improve this, this change makes us use 2 MiB chunks instead of 32 KiB chunks when reading from Wii partitions.

(block = 32 KiB, group = 2 MiB)