### PR TITLE
VolumeVerifier: Fix potential crash when cancelling

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -378,7 +378,10 @@ VolumeVerifier::VolumeVerifier(const Volume& volume, bool redump_verification,
     m_redump_verification = false;
 }
 
-VolumeVerifier::~VolumeVerifier() = default;
+VolumeVerifier::~VolumeVerifier()
+{
+  WaitForAsyncOperations();
+}
 
 void VolumeVerifier::Start()
 {


### PR DESCRIPTION
The async operations may contain references to class members, so any running async operations must end before destroying the class.