### PR TITLE
Expose Control Expression variables to mappings UI

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
@@ -111,6 +111,7 @@ private:
   // Shared actions
   QPushButton* m_select_button;
   QComboBox* m_operators_combo;
+  QComboBox* m_variables_combo;
 
   // Input actions
   QPushButton* m_detect_button;

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -143,7 +143,7 @@ public:
 class ControlEnvironment
 {
 public:
-  using VariableContainer = std::map<std::string, ControlState>;
+  using VariableContainer = std::map<std::string, std::shared_ptr<ControlState>>;
 
   ControlEnvironment(const Core::DeviceContainer& container_, const Core::DeviceQualifier& default_,
                      VariableContainer& vars)
@@ -154,7 +154,10 @@ public:
   std::shared_ptr<Core::Device> FindDevice(ControlQualifier qualifier) const;
   Core::Device::Input* FindInput(ControlQualifier qualifier) const;
   Core::Device::Output* FindOutput(ControlQualifier qualifier) const;
-  ControlState* GetVariablePtr(const std::string& name);
+  // Returns an existing variable by the specified name if already existing. Creates it otherwise.
+  std::shared_ptr<ControlState> GetVariablePtr(const std::string& name);
+
+  void CleanUnusedVariables();
 
 private:
   VariableContainer& m_variables;

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -44,6 +44,8 @@ void EmulatedController::UpdateReferences(const ControllerInterface& devi)
   ciface::ExpressionParser::ControlEnvironment env(devi, GetDefaultDevice(), m_expression_vars);
 
   UpdateReferences(env);
+
+  env.CleanUnusedVariables();
 }
 
 void EmulatedController::UpdateReferences(ciface::ExpressionParser::ControlEnvironment& env)
@@ -75,7 +77,27 @@ void EmulatedController::UpdateSingleControlReference(const ControllerInterface&
                                                       ControlReference* ref)
 {
   ciface::ExpressionParser::ControlEnvironment env(devi, GetDefaultDevice(), m_expression_vars);
+
   ref->UpdateReference(env);
+
+  env.CleanUnusedVariables();
+}
+
+const ciface::ExpressionParser::ControlEnvironment::VariableContainer&
+EmulatedController::GetExpressionVariables() const
+{
+  return m_expression_vars;
+}
+
+void EmulatedController::ResetExpressionVariables()
+{
+  for (auto& var : m_expression_vars)
+  {
+    if (var.second)
+    {
+      *var.second = 0;
+    }
+  }
 }
 
 bool EmulatedController::IsDefaultDeviceConnected() const

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -191,6 +191,11 @@ public:
   // which happens while handling a hotplug event because a control reference's State()
   // could be called before we have finished updating the reference.
   [[nodiscard]] static std::unique_lock<std::recursive_mutex> GetStateLock();
+  const ciface::ExpressionParser::ControlEnvironment::VariableContainer&
+  GetExpressionVariables() const;
+
+  // Resets the values while keeping the list.
+  void ResetExpressionVariables();
 
   std::vector<std::unique_ptr<ControlGroup>> groups;
 
@@ -218,7 +223,8 @@ public:
   }
 
 protected:
-  // TODO: Wiimote attachment has its own member that isn't being used.
+  // TODO: Wiimote attachments actually end up using their parent controller value for this,
+  // so theirs won't be used (and thus shouldn't even exist).
   ciface::ExpressionParser::ControlEnvironment::VariableContainer m_expression_vars;
 
   void UpdateReferences(ciface::ExpressionParser::ControlEnvironment& env);


### PR DESCRIPTION
-add a way to reset their value (from the mappings UI)
-fix "memory leak" where they would never be cleaned, one would be created every time you wrote a character after a "$"
-fix ability to create variables with an empty string by just writing "$" (+ added a parsing error for the case)
-add $ operator to the UI operators list, to expose this functionality even more

The UI will now show all the custom variables used.
Their value is kept as long as there is at least one mapping (control expression) referencing them. You can ever change devices or input profile and as long as the variable was and is still referenced, the value will be kept.
Still, the ability to reset values without restarting Dolphin or being forced to change their names can be useful.
UI is always kept to date with the actual values underneath.

The control ref variables were a bit obscure and confusing and hidden away from users, so this should also help with making them aware of the feature.

Tested everything. There should be no negative consequences to this.

Pic is from my work branch, but you can understand what changed:
![unknown](https://user-images.githubusercontent.com/7011366/110864514-e7dda780-82ca-11eb-82d1-30f8efe46a83.png)