### PR TITLE
Fix loading save states with bluetooth passthrough

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -53,6 +53,9 @@ void UpdateSource(unsigned int index)
   if (!ios)
     return;
 
+  if (s_wiimote_sources[index] != WiimoteSource::Emulated)
+    return;
+
   const auto bluetooth = std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(
       ios->GetDeviceByName("/dev/usb/oh1/57e/305"));
   if (!bluetooth)


### PR DESCRIPTION
When a save state is loaded, the IOS device serving bluetooth is cast as BluetoothEmuDevice. If, however, a real Wiimote with BT passthrough is used, this caused the game to crash. Now the proper device class is used.