### PR TITLE
FreeLook: support exact rotation (allowing for more accurate headtracking)

### DIFF
--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -220,7 +220,7 @@ void FreeLookController::Update()
   const auto gyro_motion_quat =
       Common::Quaternion::RotateXYZ(gyro_motion_rad_velocity_converted * dt);
 
-  g_freelook_camera.Rotate(gyro_motion_quat);
+  g_freelook_camera.RotateIncremental(gyro_motion_quat);
   if (m_move_buttons->controls[MoveButtons::Up]->GetState<bool>())
     g_freelook_camera.MoveVertical(-g_freelook_camera.GetSpeed() * dt);
 

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -114,7 +114,7 @@ FreeLookController::FreeLookController(const unsigned int index) : m_index(index
   m_fov_buttons->AddInput(ControllerEmu::Translate, _trans("Increase Y"));
   m_fov_buttons->AddInput(ControllerEmu::Translate, _trans("Decrease Y"));
 
-  groups.emplace_back(m_rotation_gyro = new ControllerEmu::IMUGyroscope(
+  groups.emplace_back(m_incremental_rotation_gyro = new ControllerEmu::IMUGyroscope(
                           _trans("Incremental Rotation"), _trans("Incremental Rotation")));
 
   groups.emplace_back(m_exact_rotation_group = new ControllerEmu::ControlGroup(
@@ -167,32 +167,32 @@ void FreeLookController::LoadDefaults(const ControllerInterface& ciface)
                                       hotkey_string({"Shift", "`Axis Z-`"}));
 
 #if defined HAVE_X11 && HAVE_X11
-  m_rotation_gyro->SetControlExpression(GyroButtons::PitchUp,
-                                        "if(`Click 3`,`RelativeMouse Y-` * 0.10, 0)");
-  m_rotation_gyro->SetControlExpression(GyroButtons::PitchDown,
-                                        "if(`Click 3`,`RelativeMouse Y+` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::PitchUp,
+                                                    "if(`Click 3`,`RelativeMouse Y-` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::PitchDown,
+                                                    "if(`Click 3`,`RelativeMouse Y+` * 0.10, 0)");
 #else
-  m_rotation_gyro->SetControlExpression(GyroButtons::PitchUp,
-                                        "if(`Click 1`,`RelativeMouse Y-` * 0.10, 0)");
-  m_rotation_gyro->SetControlExpression(GyroButtons::PitchDown,
-                                        "if(`Click 1`,`RelativeMouse Y+` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::PitchUp,
+                                                    "if(`Click 1`,`RelativeMouse Y-` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::PitchDown,
+                                                    "if(`Click 1`,`RelativeMouse Y+` * 0.10, 0)");
 #endif
 
-  m_rotation_gyro->SetControlExpression(GyroButtons::RollLeft,
-                                        "if(`Click 2`,`RelativeMouse X-` * 0.10, 0)");
-  m_rotation_gyro->SetControlExpression(GyroButtons::RollRight,
-                                        "if(`Click 2`,`RelativeMouse X+` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::RollLeft,
+                                                    "if(`Click 2`,`RelativeMouse X-` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::RollRight,
+                                                    "if(`Click 2`,`RelativeMouse X+` * 0.10, 0)");
 
 #if defined HAVE_X11 && HAVE_X11
-  m_rotation_gyro->SetControlExpression(GyroButtons::YawLeft,
-                                        "if(`Click 3`,`RelativeMouse X-` * 0.10, 0)");
-  m_rotation_gyro->SetControlExpression(GyroButtons::YawRight,
-                                        "if(`Click 3`,`RelativeMouse X+` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::YawLeft,
+                                                    "if(`Click 3`,`RelativeMouse X-` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::YawRight,
+                                                    "if(`Click 3`,`RelativeMouse X+` * 0.10, 0)");
 #else
-  m_rotation_gyro->SetControlExpression(GyroButtons::YawLeft,
-                                        "if(`Click 1`,`RelativeMouse X-` * 0.10, 0)");
-  m_rotation_gyro->SetControlExpression(GyroButtons::YawRight,
-                                        "if(`Click 1`,`RelativeMouse X+` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::YawLeft,
+                                                    "if(`Click 1`,`RelativeMouse X-` * 0.10, 0)");
+  m_incremental_rotation_gyro->SetControlExpression(GyroButtons::YawRight,
+                                                    "if(`Click 1`,`RelativeMouse X+` * 0.10, 0)");
 #endif
 }
 
@@ -208,8 +208,8 @@ ControllerEmu::ControlGroup* FreeLookController::GetGroup(FreeLookGroup group) c
     return m_fov_buttons;
   case FreeLookGroup::Other:
     return m_other_buttons;
-  case FreeLookGroup::Rotation:
-    return m_rotation_gyro;
+  case FreeLookGroup::RotationIncremental:
+    return m_incremental_rotation_gyro;
   case FreeLookGroup::RotationExact:
     return m_exact_rotation_group;
   default:
@@ -245,8 +245,9 @@ void FreeLookController::Update()
                                                static_cast<float>(m_roll.GetValue())});
   }
 
-  const auto gyro_motion_rad_velocity =
-      m_rotation_gyro->GetState() ? *m_rotation_gyro->GetState() : Common::Vec3{};
+  const auto gyro_motion_rad_velocity = m_incremental_rotation_gyro->GetState() ?
+                                            *m_incremental_rotation_gyro->GetState() :
+                                            Common::Vec3{};
 
   // Due to gyroscope implementation we need to swap the yaw and roll values
   // and because of the different axis used for Wii and the PS3 motion directions,

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -9,6 +9,7 @@
 
 #include "Common/CommonTypes.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 class InputConfig;
 
@@ -26,6 +27,7 @@ enum class FreeLookGroup
   FieldOfView,
   Other,
   Rotation,
+  RotationExact,
 };
 
 namespace FreeLook
@@ -58,6 +60,16 @@ private:
   ControllerEmu::Buttons* m_fov_buttons;
   ControllerEmu::Buttons* m_other_buttons;
   ControllerEmu::IMUGyroscope* m_rotation_gyro;
+  ControllerEmu::ControlGroup* m_exact_rotation_group;
+
+  ControllerEmu::SettingValue<double> m_pitch;
+  double m_last_pitch;
+
+  ControllerEmu::SettingValue<double> m_yaw;
+  double m_last_yaw;
+
+  ControllerEmu::SettingValue<double> m_roll;
+  double m_last_roll;
 
   const unsigned int m_index;
   std::optional<std::chrono::steady_clock::time_point> m_last_free_look_rotate_time;

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -26,7 +26,7 @@ enum class FreeLookGroup
   Speed,
   FieldOfView,
   Other,
-  Rotation,
+  RotationIncremental,
   RotationExact,
 };
 
@@ -59,7 +59,7 @@ private:
   ControllerEmu::Buttons* m_speed_buttons;
   ControllerEmu::Buttons* m_fov_buttons;
   ControllerEmu::Buttons* m_other_buttons;
-  ControllerEmu::IMUGyroscope* m_rotation_gyro;
+  ControllerEmu::IMUGyroscope* m_incremental_rotation_gyro;
   ControllerEmu::ControlGroup* m_exact_rotation_group;
 
   ControllerEmu::SettingValue<double> m_pitch;

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.cpp
@@ -40,7 +40,7 @@ void FreeLookRotation::CreateMainLayout()
 
   m_main_layout->addWidget(
       CreateGroupBox(tr("Incremental Rotation (rad/sec)"),
-                     FreeLook::GetInputGroup(GetPort(), FreeLookGroup::Rotation)),
+                     FreeLook::GetInputGroup(GetPort(), FreeLookGroup::RotationIncremental)),
       1, 0);
 
   m_main_layout->addWidget(

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.cpp
@@ -43,6 +43,11 @@ void FreeLookRotation::CreateMainLayout()
                      FreeLook::GetInputGroup(GetPort(), FreeLookGroup::Rotation)),
       1, 0);
 
+  m_main_layout->addWidget(
+      CreateGroupBox(tr("Exact Rotation"),
+                     FreeLook::GetInputGroup(GetPort(), FreeLookGroup::RotationExact)),
+      2, 0);
+
   setLayout(m_main_layout);
 }
 

--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -58,9 +58,12 @@ public:
     m_mat = Common::Matrix44::Translate(Common::Vec3{0, 0, amt}) * m_mat;
   }
 
-  void Rotate(const Common::Vec3& amt) override { Rotate(Common::Quaternion::RotateXYZ(amt)); }
+  void RotateIncremental(const Common::Vec3& amt) override
+  {
+    RotateIncremental(Common::Quaternion::RotateXYZ(amt));
+  }
 
-  void Rotate(const Common::Quaternion& quat) override
+  void RotateIncremental(const Common::Quaternion& quat) override
   {
     m_mat = Common::Matrix44::FromQuaternion(quat) * m_mat;
   }
@@ -100,7 +103,7 @@ public:
     m_position += forward * amt;
   }
 
-  void Rotate(const Common::Vec3& amt) override
+  void RotateIncremental(const Common::Vec3& amt) override
   {
     if (amt.Length() == 0)
       return;
@@ -112,9 +115,9 @@ public:
         (Quaternion::RotateX(m_rotation.x) * Quaternion::RotateY(m_rotation.y)).Normalized();
   }
 
-  void Rotate(const Common::Quaternion& quat) override
+  void RotateIncremental(const Common::Quaternion& quat) override
   {
-    Rotate(Common::FromQuaternionToEuler(quat));
+    RotateIncremental(Common::FromQuaternionToEuler(quat));
   }
 
   void Reset() override
@@ -156,7 +159,7 @@ public:
     m_distance = std::clamp(m_distance, 0.0f, m_distance);
   }
 
-  void Rotate(const Common::Vec3& amt) override
+  void RotateIncremental(const Common::Vec3& amt) override
   {
     if (amt.Length() == 0)
       return;
@@ -168,9 +171,9 @@ public:
         (Quaternion::RotateX(m_rotation.x) * Quaternion::RotateY(m_rotation.y)).Normalized();
   }
 
-  void Rotate(const Common::Quaternion& quat) override
+  void RotateIncremental(const Common::Quaternion& quat) override
   {
-    Rotate(Common::FromQuaternionToEuler(quat));
+    RotateIncremental(Common::FromQuaternionToEuler(quat));
   }
 
   void Reset() override
@@ -250,15 +253,15 @@ void FreeLookCamera::MoveForward(float amt)
   m_dirty = true;
 }
 
-void FreeLookCamera::Rotate(const Common::Vec3& amt)
+void FreeLookCamera::RotateIncremental(const Common::Vec3& amt)
 {
-  m_camera_controller->Rotate(amt);
+  m_camera_controller->RotateIncremental(amt);
   m_dirty = true;
 }
 
-void FreeLookCamera::Rotate(const Common::Quaternion& amt)
+void FreeLookCamera::RotateIncremental(const Common::Quaternion& amt)
 {
-  m_camera_controller->Rotate(amt);
+  m_camera_controller->RotateIncremental(amt);
   m_dirty = true;
 }
 

--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -58,6 +58,16 @@ public:
     m_mat = Common::Matrix44::Translate(Common::Vec3{0, 0, amt}) * m_mat;
   }
 
+  void RotateExact(const Common::Vec3& amt) override
+  {
+    RotateIncremental(Common::Quaternion::RotateXYZ(amt));
+  }
+
+  void RotateExact(const Common::Quaternion& quat) override
+  {
+    m_mat = Common::Matrix44::FromQuaternion(quat);
+  }
+
   void RotateIncremental(const Common::Vec3& amt) override
   {
     RotateIncremental(Common::Quaternion::RotateXYZ(amt));
@@ -101,6 +111,23 @@ public:
   {
     const Common::Vec3 forward = m_rotate_quat.Conjugate() * Common::Vec3{0, 0, 1};
     m_position += forward * amt;
+  }
+
+  void RotateExact(const Common::Vec3& amt) override
+  {
+    if (amt.Length() == 0)
+      return;
+
+    m_rotation = amt;
+
+    using Common::Quaternion;
+    m_rotate_quat =
+        (Quaternion::RotateX(m_rotation.x) * Quaternion::RotateY(m_rotation.y)).Normalized();
+  }
+
+  void RotateExact(const Common::Quaternion& quat) override
+  {
+    RotateExact(Common::FromQuaternionToEuler(quat));
   }
 
   void RotateIncremental(const Common::Vec3& amt) override
@@ -157,6 +184,23 @@ public:
   {
     m_distance += -1 * amt;
     m_distance = std::clamp(m_distance, 0.0f, m_distance);
+  }
+
+  void RotateExact(const Common::Vec3& amt) override
+  {
+    if (amt.Length() == 0)
+      return;
+
+    m_rotation = amt;
+
+    using Common::Quaternion;
+    m_rotate_quat =
+        (Quaternion::RotateX(m_rotation.x) * Quaternion::RotateY(m_rotation.y)).Normalized();
+  }
+
+  void RotateExact(const Common::Quaternion& quat) override
+  {
+    RotateExact(Common::FromQuaternionToEuler(quat));
   }
 
   void RotateIncremental(const Common::Vec3& amt) override
@@ -250,6 +294,18 @@ void FreeLookCamera::MoveHorizontal(float amt)
 void FreeLookCamera::MoveForward(float amt)
 {
   m_camera_controller->MoveForward(amt);
+  m_dirty = true;
+}
+
+void FreeLookCamera::RotateExact(const Common::Vec3& amt)
+{
+  m_camera_controller->RotateExact(amt);
+  m_dirty = true;
+}
+
+void FreeLookCamera::RotateExact(const Common::Quaternion& amt)
+{
+  m_camera_controller->RotateExact(amt);
   m_dirty = true;
 }
 

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -31,8 +31,8 @@ public:
 
   virtual void MoveForward(float amt) = 0;
 
-  virtual void Rotate(const Common::Vec3& amt) = 0;
-  virtual void Rotate(const Common::Quaternion& quat) = 0;
+  virtual void RotateIncremental(const Common::Vec3& amt) = 0;
+  virtual void RotateIncremental(const Common::Quaternion& quat) = 0;
 
   virtual void Reset() = 0;
 
@@ -51,8 +51,8 @@ public:
   void MoveHorizontal(float amt);
   void MoveForward(float amt);
 
-  void Rotate(const Common::Vec3& amt);
-  void Rotate(const Common::Quaternion& amt);
+  void RotateIncremental(const Common::Vec3& amt);
+  void RotateIncremental(const Common::Quaternion& amt);
 
   void IncreaseFovX(float fov);
   void IncreaseFovY(float fov);

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -31,6 +31,9 @@ public:
 
   virtual void MoveForward(float amt) = 0;
 
+  virtual void RotateExact(const Common::Vec3& amt) = 0;
+  virtual void RotateExact(const Common::Quaternion& quat) = 0;
+
   virtual void RotateIncremental(const Common::Vec3& amt) = 0;
   virtual void RotateIncremental(const Common::Quaternion& quat) = 0;
 
@@ -50,6 +53,9 @@ public:
   void MoveVertical(float amt);
   void MoveHorizontal(float amt);
   void MoveForward(float amt);
+
+  void RotateExact(const Common::Vec3& amt);
+  void RotateExact(const Common::Quaternion& amt);
 
   void RotateIncremental(const Common::Vec3& amt);
   void RotateIncremental(const Common::Quaternion& amt);


### PR DESCRIPTION
This adds support for Free Look to specify exact camera rotation in radians or via an input expression:

![image](https://user-images.githubusercontent.com/15224722/111060688-6d488f80-8464-11eb-9cf6-8217b648fd9a.png)

There are a couple primary use cases for this:

* In theory this has the ability to support something called ["FlickStick"](https://www.youtube.com/watch?v=C5L_Px3dFtE) .  When I started thinking of this feature, "FlickStick" was what I had mind.  It wasn't until I started my implementation that I found out a community had already came up with something similar!  Flickstick is fairly complex in nature but this feature can allow us to get a bit closer to it by allowing the controller's stick angle to act as the angle for Free Look
* In the DSU spec, technically rotations are supposed to be from a gyro (relative rotation in angular velocity) but this allows supporting other forms of input.  For example, my [OpenTrackDSU](https://github.com/iwubcode/OpenTrackDSUServer) was hacked to support relative values but [OpenTrack](https://github.com/opentrack/opentrack) actually supports exact pitch/yaw/roll.  So by providing this, the data will be more exact.