### PR TITLE
FreeLook: allow for specifying the exact field of view multiplier for the camera

### DIFF
--- a/Source/Core/Core/Config/FreeLookSettings.cpp
+++ b/Source/Core/Core/Config/FreeLookSettings.cpp
@@ -17,5 +17,7 @@ const Info<bool> FREE_LOOK_ENABLED{{System::FreeLook, "General", "Enabled"}, fal
 // FreeLook.Controller1
 const Info<FreeLook::ControlType> FL1_CONTROL_TYPE{{System::FreeLook, "Camera1", "ControlType"},
                                                    FreeLook::ControlType::SixAxis};
+const Info<float> FL1_FOV_HORIZONTAL{{System::FreeLook, "Camera1", "FovHorizontal"}, 1.0f};
+const Info<float> FL1_FOV_VERTICAL{{System::FreeLook, "Camera1", "FovVertical"}, 1.0f};
 
 }  // namespace Config

--- a/Source/Core/Core/Config/FreeLookSettings.h
+++ b/Source/Core/Core/Config/FreeLookSettings.h
@@ -19,5 +19,7 @@ extern const Info<bool> FREE_LOOK_ENABLED;
 
 // FreeLook.Controller1
 extern const Info<FreeLook::ControlType> FL1_CONTROL_TYPE;
+extern const Info<float> FL1_FOV_HORIZONTAL;
+extern const Info<float> FL1_FOV_VERTICAL;
 
 }  // namespace Config

--- a/Source/Core/Core/FreeLookConfig.cpp
+++ b/Source/Core/Core/FreeLookConfig.cpp
@@ -43,6 +43,9 @@ void Config::Refresh()
   }
 
   camera_config.control_type = ::Config::Get(::Config::FL1_CONTROL_TYPE);
+  camera_config.fov_horizontal = ::Config::Get(::Config::FL1_FOV_HORIZONTAL);
+  camera_config.fov_vertical = ::Config::Get(::Config::FL1_FOV_VERTICAL);
+
   enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED);
 }
 }  // namespace FreeLook

--- a/Source/Core/Core/FreeLookConfig.h
+++ b/Source/Core/Core/FreeLookConfig.h
@@ -21,6 +21,8 @@ enum class ControlType : int
 struct CameraConfig
 {
   ControlType control_type;
+  float fov_horizontal;
+  float fov_vertical;
 };
 
 // NEVER inherit from this class.

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 
 class InputConfig;
@@ -39,7 +40,8 @@ ControllerEmu::ControlGroup* GetInputGroup(int pad_num, FreeLookGroup group);
 class FreeLookController final : public ControllerEmu::EmulatedController
 {
 public:
-  explicit FreeLookController(unsigned int index);
+  FreeLookController(unsigned int index, const Config::Info<float>& fov_horizontal,
+                     const Config::Info<float>& fov_vertical);
 
   std::string GetName() const override;
   void LoadDefaults(const ControllerInterface& ciface) override;
@@ -48,6 +50,9 @@ public:
   void Update();
 
 private:
+  const Config::Info<float>& m_fov_horizontal;
+  const Config::Info<float>& m_fov_vertical;
+
   ControllerEmu::Buttons* m_move_buttons;
   ControllerEmu::Buttons* m_speed_buttons;
   ControllerEmu::Buttons* m_fov_buttons;

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -183,6 +183,8 @@ add_executable(dolphin-emu
   Config/SettingsWindow.h
   Config/ToolTipControls/ToolTipCheckBox.cpp
   Config/ToolTipControls/ToolTipCheckBox.h
+  Config/ToolTipControls/ToolTipDoubleSpinBox.cpp
+  Config/ToolTipControls/ToolTipDoubleSpinBox.h
   Config/ToolTipControls/ToolTipComboBox.cpp
   Config/ToolTipControls/ToolTipComboBox.h
   Config/ToolTipControls/ToolTipRadioButton.cpp

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -73,6 +73,10 @@ add_executable(dolphin-emu
   Config/ControllersWindow.h
   Config/FilesystemWidget.cpp
   Config/FilesystemWidget.h
+  Config/FreeLookOptionsWidget.cpp
+  Config/FreeLookOptionsWidget.h
+  Config/FreeLookOptionsWindow.cpp
+  Config/FreeLookOptionsWindow.h
   Config/FreeLookWidget.cpp
   Config/FreeLookWidget.h
   Config/FreeLookWindow.cpp

--- a/Source/Core/DolphinQt/Config/FreeLookOptionsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookOptionsWidget.cpp
@@ -1,0 +1,89 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/FreeLookOptionsWidget.h"
+
+#include <QFormLayout>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QLabel>
+
+#include "Common/Config/Config.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+
+#include "DolphinQt/Config/ToolTipControls/ToolTipDoubleSpinBox.h"
+#include "DolphinQt/Settings.h"
+
+FreeLookOptionsWidget::FreeLookOptionsWidget(QWidget* parent,
+                                             const ::Config::Info<float>& fov_horizontal,
+                                             const ::Config::Info<float>& fov_vertical)
+    : QWidget(parent), m_fov_horizontal_config(fov_horizontal), m_fov_vertical_config(fov_vertical)
+{
+  CreateLayout();
+  LoadSettings();
+  ConnectWidgets();
+}
+
+void FreeLookOptionsWidget::CreateLayout()
+{
+  auto* layout = new QGridLayout;
+
+  layout->addWidget(CreateFieldOfViewGroup());
+  setLayout(layout);
+}
+
+void FreeLookOptionsWidget::ConnectWidgets()
+{
+  connect(m_fov_horizontal, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
+          &FreeLookOptionsWidget::SaveSettings);
+  connect(m_fov_vertical, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
+          &FreeLookOptionsWidget::SaveSettings);
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
+    const QSignalBlocker blocker(this);
+    LoadSettings();
+  });
+}
+
+void FreeLookOptionsWidget::LoadSettings()
+{
+  m_fov_horizontal->setValue(::Config::Get(m_fov_horizontal_config));
+  m_fov_vertical->setValue(::Config::Get(m_fov_vertical_config));
+}
+
+void FreeLookOptionsWidget::SaveSettings()
+{
+  ::Config::SetBaseOrCurrent(m_fov_horizontal_config,
+                             static_cast<float>(m_fov_horizontal->value()));
+  ::Config::SetBaseOrCurrent(m_fov_vertical_config, static_cast<float>(m_fov_vertical->value()));
+}
+
+QGroupBox* FreeLookOptionsWidget::CreateFieldOfViewGroup()
+{
+  QGroupBox* group_box = new QGroupBox(tr("Field of View"));
+  QFormLayout* form_layout = new QFormLayout();
+
+  group_box->setLayout(form_layout);
+
+  m_fov_horizontal = new ToolTipDoubleSpinBox;
+  m_fov_horizontal->setMinimum(0.025);
+  m_fov_horizontal->setSingleStep(0.025);
+  m_fov_horizontal->setDecimals(3);
+  m_fov_horizontal->SetTitle(tr("Horizontal Multiplier"));
+  m_fov_horizontal->SetDescription(
+      tr("Multiplier for the field of view in the horizontal direction.<br><br>"));
+
+  m_fov_vertical = new ToolTipDoubleSpinBox;
+  m_fov_vertical->setMinimum(0.025);
+  m_fov_vertical->setSingleStep(0.025);
+  m_fov_vertical->setDecimals(3);
+  m_fov_vertical->SetTitle(tr("Vertical Multiplier"));
+  m_fov_vertical->SetDescription(
+      tr("Multiplier for the field of view in the vertical direction.<br><br>"));
+
+  form_layout->addRow(tr("Horizontal Multiplier:"), m_fov_horizontal);
+  form_layout->addRow(tr("Vertical Multiplier:"), m_fov_vertical);
+
+  return group_box;
+}

--- a/Source/Core/DolphinQt/Config/FreeLookOptionsWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLookOptionsWidget.h
@@ -1,0 +1,35 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+#include "Common/Config/ConfigInfo.h"
+
+class QGroupBox;
+class ToolTipDoubleSpinBox;
+
+class FreeLookOptionsWidget final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit FreeLookOptionsWidget(QWidget* parent, const Config::Info<float>& fov_horizontal,
+                                 const Config::Info<float>& fov_vertical);
+
+private:
+  void CreateLayout();
+  void ConnectWidgets();
+
+  void LoadSettings();
+  void SaveSettings();
+
+  QGroupBox* CreateFieldOfViewGroup();
+
+  const Config::Info<float>& m_fov_horizontal_config;
+  const Config::Info<float>& m_fov_vertical_config;
+
+  ToolTipDoubleSpinBox* m_fov_horizontal;
+  ToolTipDoubleSpinBox* m_fov_vertical;
+};

--- a/Source/Core/DolphinQt/Config/FreeLookOptionsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookOptionsWindow.cpp
@@ -1,0 +1,37 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/FreeLookOptionsWindow.h"
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+#include "Core/Config/FreeLookSettings.h"
+#include "DolphinQt/Config/FreeLookOptionsWidget.h"
+
+FreeLookOptionsWindow::FreeLookOptionsWindow(QWidget* parent, int index)
+    : QDialog(parent), m_port(index)
+{
+  CreateMainLayout();
+
+  setWindowTitle(tr("Free Look Camera %1 Options").arg(index + 1));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+}
+
+void FreeLookOptionsWindow::CreateMainLayout()
+{
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
+  connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  auto* main_layout = new QVBoxLayout();
+  if (m_port == 0)
+  {
+    main_layout->addWidget(
+        new FreeLookOptionsWidget(this, ::Config::FL1_FOV_HORIZONTAL, ::Config::FL1_FOV_VERTICAL));
+  }
+  main_layout->addWidget(m_button_box);
+  setLayout(main_layout);
+}

--- a/Source/Core/DolphinQt/Config/FreeLookOptionsWindow.h
+++ b/Source/Core/DolphinQt/Config/FreeLookOptionsWindow.h
@@ -1,0 +1,22 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+class QDialogButtonBox;
+
+class FreeLookOptionsWindow final : public QDialog
+{
+  Q_OBJECT
+public:
+  FreeLookOptionsWindow(QWidget* parent, int index);
+
+private:
+  void CreateMainLayout();
+
+  int m_port;
+  QDialogButtonBox* m_button_box;
+};

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
@@ -14,6 +14,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
+#include "DolphinQt/Config/FreeLookOptionsWindow.h"
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
@@ -36,6 +37,7 @@ void FreeLookWidget::CreateLayout()
       tr("Allows manipulation of the in-game camera.<br><br><dolphin_emphasis>If unsure, "
          "leave this unchecked.</dolphin_emphasis>"));
   m_freelook_controller_configure_button = new QPushButton(tr("Configure Controller"));
+  m_freelook_options_configure_button = new QPushButton(tr("Configure Options"));
 
   m_freelook_control_type = new GraphicsChoice({tr("Six Axis"), tr("First Person"), tr("Orbital")},
                                                Config::FL1_CONTROL_TYPE);
@@ -65,6 +67,7 @@ void FreeLookWidget::CreateLayout()
   hlayout->addWidget(new QLabel(tr("Camera 1")));
   hlayout->addWidget(m_freelook_control_type);
   hlayout->addWidget(m_freelook_controller_configure_button);
+  hlayout->addWidget(m_freelook_options_configure_button);
 
   layout->addWidget(m_enable_freelook);
   layout->addLayout(hlayout);
@@ -77,6 +80,8 @@ void FreeLookWidget::ConnectWidgets()
 {
   connect(m_freelook_controller_configure_button, &QPushButton::clicked, this,
           &FreeLookWidget::OnFreeLookControllerConfigured);
+  connect(m_freelook_options_configure_button, &QPushButton::clicked, this,
+          &FreeLookWidget::OnFreeLookOptionsConfigured);
   connect(m_enable_freelook, &QCheckBox::clicked, this, &FreeLookWidget::SaveSettings);
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     const QSignalBlocker blocker(this);
@@ -95,12 +100,24 @@ void FreeLookWidget::OnFreeLookControllerConfigured()
   window->show();
 }
 
+void FreeLookWidget::OnFreeLookOptionsConfigured()
+{
+  if (m_freelook_options_configure_button != QObject::sender())
+    return;
+  const int index = 0;
+  FreeLookOptionsWindow* window = new FreeLookOptionsWindow(this, index);
+  window->setAttribute(Qt::WA_DeleteOnClose, true);
+  window->setWindowModality(Qt::WindowModality::WindowModal);
+  window->show();
+}
+
 void FreeLookWidget::LoadSettings()
 {
   const bool checked = Config::Get(Config::FREE_LOOK_ENABLED);
   m_enable_freelook->setChecked(checked);
   m_freelook_control_type->setEnabled(checked);
   m_freelook_controller_configure_button->setEnabled(checked);
+  m_freelook_options_configure_button->setEnabled(checked);
 }
 
 void FreeLookWidget::SaveSettings()
@@ -109,4 +126,5 @@ void FreeLookWidget::SaveSettings()
   Config::SetBaseOrCurrent(Config::FREE_LOOK_ENABLED, checked);
   m_freelook_control_type->setEnabled(checked);
   m_freelook_controller_configure_button->setEnabled(checked);
+  m_freelook_options_configure_button->setEnabled(checked);
 }

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.h
@@ -21,10 +21,12 @@ private:
   void ConnectWidgets();
 
   void OnFreeLookControllerConfigured();
+  void OnFreeLookOptionsConfigured();
   void LoadSettings();
   void SaveSettings();
 
   ToolTipCheckBox* m_enable_freelook;
   GraphicsChoice* m_freelook_control_type;
   QPushButton* m_freelook_controller_configure_button;
+  QPushButton* m_freelook_options_configure_button;
 };

--- a/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipDoubleSpinBox.cpp
+++ b/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipDoubleSpinBox.cpp
@@ -1,0 +1,10 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/ToolTipControls/ToolTipDoubleSpinBox.h"
+
+QPoint ToolTipDoubleSpinBox::GetToolTipPosition() const
+{
+  return pos() + QPoint(width() / 2, height() / 2);
+}

--- a/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipDoubleSpinBox.h
+++ b/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipDoubleSpinBox.h
@@ -1,0 +1,15 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "DolphinQt/Config/ToolTipControls/ToolTipWidget.h"
+
+#include <QDoubleSpinBox>
+
+class ToolTipDoubleSpinBox : public ToolTipWidget<QDoubleSpinBox>
+{
+private:
+  QPoint GetToolTipPosition() const override;
+};

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -112,6 +112,7 @@
     <ClCompile Include="Config\SettingsWindow.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipCheckBox.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipComboBox.cpp" />
+    <ClCompile Include="Config\ToolTipControls\ToolTipDoubleSpinBox.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipRadioButton.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipSlider.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipSpinBox.cpp" />
@@ -281,6 +282,7 @@
     <QtMoc Include="Config\SettingsWindow.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipCheckBox.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipComboBox.h" />
+    <ClInclude Include="Config\ToolTipControls\ToolTipDoubleSpinBox.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipRadioButton.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipSlider.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipSpinBox.h" />

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -56,6 +56,8 @@
     <ClCompile Include="Config\ControllerInterface\ServerStringValidator.cpp" />
     <ClCompile Include="Config\ControllersWindow.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
+    <ClCompile Include="Config\FreeLookOptionsWidget.cpp" />
+    <ClCompile Include="Config\FreeLookOptionsWindow.cpp" />
     <ClCompile Include="Config\FreeLookWidget.cpp" />
     <ClCompile Include="Config\FreeLookWindow.cpp" />
     <ClCompile Include="Config\GamecubeControllersWidget.cpp" />
@@ -231,6 +233,8 @@
     <QtMoc Include="Config\ControllerInterface\ServerStringValidator.h" />
     <QtMoc Include="Config\ControllersWindow.h" />
     <QtMoc Include="Config\FilesystemWidget.h" />
+    <QtMoc Include="Config\FreeLookOptionsWidget.h" />
+    <QtMoc Include="Config\FreeLookOptionsWindow.h" />
     <QtMoc Include="Config\FreeLookWidget.h" />
     <QtMoc Include="Config\FreeLookWindow.h" />
     <QtMoc Include="Config\GamecubeControllersWidget.h" />

--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -189,6 +189,17 @@ FreeLookCamera::FreeLookCamera()
   SetControlType(FreeLook::ControlType::SixAxis);
 }
 
+void FreeLookCamera::UpdateConfig(const FreeLook::CameraConfig& config)
+{
+  SetControlType(config.control_type);
+  if (config.fov_horizontal != m_fov_x || config.fov_vertical != m_fov_y)
+  {
+    m_fov_x = config.fov_horizontal;
+    m_fov_y = config.fov_vertical;
+    m_dirty = true;
+  }
+}
+
 void FreeLookCamera::SetControlType(FreeLook::ControlType type)
 {
   if (m_current_type && *m_current_type == type)
@@ -246,18 +257,6 @@ void FreeLookCamera::Rotate(const Common::Vec3& amt)
   m_dirty = true;
 }
 
-void FreeLookCamera::IncreaseFovX(float fov)
-{
-  m_fov_x += fov;
-  m_fov_x = std::clamp(m_fov_x, m_fov_step_size, m_fov_x);
-}
-
-void FreeLookCamera::IncreaseFovY(float fov)
-{
-  m_fov_y += fov;
-  m_fov_y = std::clamp(m_fov_y, m_fov_step_size, m_fov_y);
-}
-
 float FreeLookCamera::GetFovStepSize() const
 {
   return m_fov_step_size;
@@ -266,9 +265,6 @@ float FreeLookCamera::GetFovStepSize() const
 void FreeLookCamera::Reset()
 {
   m_camera_controller->Reset();
-  m_fov_x = 1.0f;
-  m_fov_y = 1.0f;
-  m_dirty = true;
 }
 
 void FreeLookCamera::ModifySpeed(float multiplier)

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -43,7 +43,7 @@ class FreeLookCamera
 {
 public:
   FreeLookCamera();
-  void SetControlType(FreeLook::ControlType type);
+  void UpdateConfig(const FreeLook::CameraConfig& config);
   Common::Matrix44 GetView();
   Common::Vec2 GetFieldOfView() const;
 
@@ -53,8 +53,6 @@ public:
 
   void Rotate(const Common::Vec3& amt);
 
-  void IncreaseFovX(float fov);
-  void IncreaseFovY(float fov);
   float GetFovStepSize() const;
 
   void Reset();
@@ -71,6 +69,7 @@ public:
   bool IsActive() const;
 
 private:
+  void SetControlType(FreeLook::ControlType type);
   bool m_dirty = false;
   float m_fov_x = 1.0f;
   float m_fov_y = 1.0f;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -111,7 +111,7 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height, float backbuffer
   CalculateTargetSize();
 
   m_is_game_widescreen = SConfig::GetInstance().bWii && Config::Get(Config::SYSCONF_WIDESCREEN);
-  g_freelook_camera.SetControlType(FreeLook::GetActiveConfig().camera_config.control_type);
+  g_freelook_camera.UpdateConfig(FreeLook::GetActiveConfig().camera_config);
 }
 
 Renderer::~Renderer() = default;
@@ -407,7 +407,7 @@ void Renderer::CheckForConfigChanges()
   UpdateActiveConfig();
   FreeLook::UpdateActiveConfig();
 
-  g_freelook_camera.SetControlType(FreeLook::GetActiveConfig().camera_config.control_type);
+  g_freelook_camera.UpdateConfig(FreeLook::GetActiveConfig().camera_config);
 
   // Update texture cache settings with any changed options.
   g_texture_cache->OnConfigChanged(g_ActiveConfig);


### PR DESCRIPTION
This updates Dolphin to support specifying direct Free Look field of view multipliers via configuration or the UI using a 'Configure Options' button:

![image](https://user-images.githubusercontent.com/15224722/111107235-7e58d580-8524-11eb-92a7-933099b974b6.png)

the settings are then exposed as spin-boxes:

![image](https://user-images.githubusercontent.com/15224722/111877415-524cb280-8971-11eb-99ff-1ac52d8f2175.png)


This allows for game specific fov to be specified.  Also makes it easier to pinpoint the exact value you are interested in.

More options are planned in the future...