### PR TITLE
JitArm64: Improve srawx special case carry calculation

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1401,13 +1401,14 @@ void JitArm64::srawx(UGeckoInstruction inst)
     {
       gpr.BindToRegister(a, a == s);
 
-      ASR(gpr.R(a), gpr.R(s), 31);
-
       if (js.op->wantsCA)
       {
+        // Set the carry flag to the sign bit of s
         CMN(gpr.R(s), gpr.R(s));
         ComputeCarry();
       }
+
+      ASR(gpr.R(a), gpr.R(s), 31);
     }
     else if (amount == 0)
     {


### PR DESCRIPTION
At a first glance it may look like a part of the code I added to srawx in efeda3b has a bug when a == s. The code actually happens to work correctly, but in the interest of making the code easier to reason about, I'd like to change the way it's implemented. This change should improve the pipelining a little in the a == s case too.