### PR TITLE
Android: Fix recreating main activity

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
@@ -40,7 +40,11 @@ public class PlatformPagerAdapter extends FragmentPagerAdapter
   @Override
   public Fragment getItem(int position)
   {
-    return PlatformGamesFragment.newInstance(Platform.fromPosition(position), mOnRefreshListener);
+    Platform platform = Platform.fromPosition(position);
+
+    PlatformGamesFragment fragment = PlatformGamesFragment.newInstance(platform);
+    fragment.setOnRefreshListener(mOnRefreshListener);
+    return fragment;
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
@@ -26,21 +26,15 @@ public final class PlatformGamesFragment extends Fragment implements PlatformGam
   private SwipeRefreshLayout mSwipeRefresh;
   private SwipeRefreshLayout.OnRefreshListener mOnRefreshListener;
 
-  public static PlatformGamesFragment newInstance(Platform platform,
-          SwipeRefreshLayout.OnRefreshListener onRefreshListener)
+  public static PlatformGamesFragment newInstance(Platform platform)
   {
-    PlatformGamesFragment fragment = new PlatformGamesFragment(onRefreshListener);
+    PlatformGamesFragment fragment = new PlatformGamesFragment();
 
     Bundle args = new Bundle();
     args.putSerializable(ARG_PLATFORM, platform);
 
     fragment.setArguments(args);
     return fragment;
-  }
-
-  public PlatformGamesFragment(SwipeRefreshLayout.OnRefreshListener onRefreshListener)
-  {
-    mOnRefreshListener = onRefreshListener;
   }
 
   @Override
@@ -108,6 +102,14 @@ public final class PlatformGamesFragment extends Fragment implements PlatformGam
   public void refetchMetadata()
   {
     mAdapter.refetchMetadata();
+  }
+
+  public void setOnRefreshListener(@Nullable SwipeRefreshLayout.OnRefreshListener listener)
+  {
+    mOnRefreshListener = listener;
+
+    if (mSwipeRefresh != null)
+      mSwipeRefresh.setOnRefreshListener(listener);
   }
 
   public void setRefreshing(boolean refreshing)


### PR DESCRIPTION
4752ec8 broke this because I wasn't aware that a fragment has to have a constructor with no parameters in order for activity recreation to work.