### PR TITLE
VertexShaderGen: Sonic epsilon hack for OpenGL ES

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -498,6 +498,12 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
                 "o.clipDist1 = clipDist1;\n");
     }
   }
+  else
+  {
+    // Same depth adjustment for Sonic. Without depth clamping, it unfortunately
+    // affects non-clipping uses of depth too.
+    out.Write("o.pos.z = o.pos.z * (1.0 - 1e-7);\n");
+  }
 
   // Write the true depth value. If the game uses depth textures, then the pixel shader will
   // override it with the correct values if not then early z culling will improve speed.


### PR DESCRIPTION
https://github.com/dolphin-emu/dolphin/pull/4164 moved the "Sonic epsilon hack" to vertex shaders. However, it was only done for targets with depth clamping. If this is not available, for example the target is OpenGL ES, the Sonic problem appears (https://bugs.dolphin-emu.org/issues/11897).

A version of the "Sonic epsilon hack" is added for targets without depth clamping.