### PR TITLE
Android: Fix rescanning on first app launch after cache clear

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -82,14 +82,14 @@ public final class MainActivity extends AppCompatActivity
   {
     super.onResume();
 
-    mPresenter.onResume();
-
     if (DirectoryInitialization.shouldStart(this))
     {
       DirectoryInitialization.start(this);
       new AfterDirectoryInitializationRunner()
               .run(this, false, this::setPlatformTabsAndStartGameFileCacheService);
     }
+
+    mPresenter.onResume();
 
     // In case the user changed a setting that affects how games are displayed,
     // such as system language, cover downloading...

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -132,7 +132,7 @@ public final class MainPresenter
       mDirToAdd = null;
     }
 
-    if (sShouldRescanLibrary && !GameFileCacheService.isLoading())
+    if (sShouldRescanLibrary && !GameFileCacheService.isRescanning())
     {
       new AfterDirectoryInitializationRunner().run(mContext, false, () ->
       {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -71,13 +71,13 @@ public final class TvMainActivity extends FragmentActivity
   {
     super.onResume();
 
-    mPresenter.onResume();
-
     if (DirectoryInitialization.shouldStart(this))
     {
       DirectoryInitialization.start(this);
       GameFileCacheService.startLoad(this);
     }
+
+    mPresenter.onResume();
 
     // In case the user changed a setting that affects how games are displayed,
     // such as system language, cover downloading...


### PR DESCRIPTION
GameFileCacheService.startRescan (in MainPresenter.onResume) does nothing if called before GameFileCacheService.startLoad. Fixes a PR #9569 regression where already added games would not show up after app launch under specific circumstances.

Unfortunately the loading indicator still doesn't show up during a rescan initiated by app launch, but that would be more annoying to fix, so I will leave it for now.