### PR TITLE
InputCommon: avoid updating devices that aren't used

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -270,7 +270,13 @@ void ControllerInterface::UpdateInput()
   {
     std::lock_guard lk(m_devices_mutex, std::adopt_lock);
     for (const auto& d : m_devices)
-      d->UpdateInput();
+    {
+      // Don't update devices that aren't referenced anywhere else
+      if (d.use_count() > 1)
+      {
+        d->UpdateInput();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This is an optimization.
All pointers to devices in Dolphin are std::shared_ptr.
ControlReferences keep a ptr to a device when they use an input (or output) from that device.
Some Mapping Widgets also keep ptrs to devices when they are open.

This means that we can safely skip updating devices that are currently not in use.
This would still update devices referenced by wiimotes when playing a GC game, but it's still better than nothing.

Also, updating devices tries to lock the devices mutex, and if it fails, it will skip that update. This should decrease the amount of time devices are locked for, and so the occurrence of devices updates being skipped.

A device update generally just queries the device and caches the new returned input values.
Unless some types of devices automatically disconnect when not queried for a long time, which I highly doubt, this should be absolutely fine. Sure in the first instance devices are updated again, a mouse device might return a huge relative movement, but that's also fine.

This is going to be fine even with the current implementations of relative input in a bunch of WIP PRs.
I was actually planning to get rid of shared_ptr for devices, given they are troubling, but even if we proceeded on that road, we could still implement a custom ref counter, if this turned out to be a worth optimization.

This would also help https://github.com/dolphin-emu/dolphin/pull/8747 as it updates devices at 200Hz, and it would be a shame to update devices which aren't used, especially if you have a lot connected to your machine.

Tested with XInput and Dinput and Keyboard/Mouse device on Windows.