### PR TITLE
VertexLoaderTest: Fix memset assignment warning

### DIFF
--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -193,7 +193,7 @@ struct TVtxDesc
     BitField<15, 2, VertexComponentFormat> Color1;
     BitFieldArray<13, 2, 2, VertexComponentFormat> Color;
 
-    u32 Hex;
+    u32 Hex = 0;
   };
   union High
   {
@@ -207,7 +207,7 @@ struct TVtxDesc
     BitField<14, 2, VertexComponentFormat> Tex7Coord;
     BitFieldArray<0, 2, 8, VertexComponentFormat> TexCoord;
 
-    u32 Hex;
+    u32 Hex = 0;
   };
 
   Low low;
@@ -288,7 +288,7 @@ struct fmt::formatter<TVtxDesc>
 
 union UVAT_group0
 {
-  u32 Hex;
+  u32 Hex = 0;
   // 0:8
   BitField<0, 1, CoordComponentCount> PosElements;
   BitField<1, 3, ComponentFormat> PosFormat;
@@ -347,7 +347,7 @@ struct fmt::formatter<UVAT_group0>
 
 union UVAT_group1
 {
-  u32 Hex;
+  u32 Hex = 0;
   // 0:8
   BitField<0, 1, TexComponentCount> Tex1CoordElements;
   BitField<1, 3, ComponentFormat> Tex1CoordFormat;
@@ -396,7 +396,7 @@ struct fmt::formatter<UVAT_group1>
 
 union UVAT_group2
 {
-  u32 Hex;
+  u32 Hex = 0;
   // 0:4
   BitField<0, 5, u32> Tex4Frac;
   // 5:13

--- a/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
+++ b/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
@@ -23,9 +23,7 @@ TEST(VertexLoaderUID, UniqueEnough)
   std::unordered_set<VertexLoaderUID> uids;
 
   TVtxDesc vtx_desc;
-  memset(&vtx_desc, 0, sizeof(vtx_desc));
   VAT vat;
-  memset(&vat, 0, sizeof(vat));
   uids.insert(VertexLoaderUID(vtx_desc, vat));
 
   vtx_desc.SetLegacyHex(0xFEDCBA9876543210ull);
@@ -50,8 +48,12 @@ protected:
     memset(input_memory, 0, sizeof(input_memory));
     memset(output_memory, 0xFF, sizeof(input_memory));
 
-    memset(&m_vtx_desc, 0, sizeof(m_vtx_desc));
-    memset(&m_vtx_attr, 0, sizeof(m_vtx_attr));
+    m_vtx_desc.low.Hex = 0;
+    m_vtx_desc.high.Hex = 0;
+
+    m_vtx_attr.g0.Hex = 0;
+    m_vtx_attr.g1.Hex = 0;
+    m_vtx_attr.g2.Hex = 0;
 
     m_loader = nullptr;
 


### PR DESCRIPTION
Testing a fix for Debian unit test warning -Wclass-memaccess.