### PR TITLE
Open the properties window when alt+enter is used on the game list

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -856,9 +856,16 @@ void GameList::ConsiderViewChange()
 void GameList::keyPressEvent(QKeyEvent* event)
 {
   if (event->key() == Qt::Key_Return && GetSelectedGame() != nullptr)
-    emit GameSelected();
+  {
+    if (event->modifiers() == Qt::AltModifier)
+      OpenProperties();
+    else
+      emit GameSelected();
+  }
   else
+  {
     QStackedWidget::keyPressEvent(event);
+  }
 }
 
 void GameList::OnColumnVisibilityToggled(const QString& row, bool visible)


### PR DESCRIPTION
This is a keyboard shortcut on Windows at least, and I've accidentally started games several times trying to use it in Dolphin.