### PR TITLE
Avoid using panic alerts in DiscIO

### DIFF
--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -83,7 +83,7 @@ u64 CompressedBlobReader::GetBlockCompressedSize(u64 block_num) const
   else if (block_num == m_header.num_blocks - 1)
     return m_header.compressed_data_size - start;
   else
-    PanicAlertFmt("{} - illegal block number {}", __func__, block_num);
+    ERROR_LOG_FMT(DISCIO, "{} - illegal block number {}", __func__, block_num);
   return 0;
 }
 
@@ -96,7 +96,7 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
   if (offset & (1ULL << 63))
   {
     if (comp_block_size != m_header.block_size)
-      PanicAlertFmt("Uncompressed block with wrong size");
+      ERROR_LOG_FMT(DISCIO, "Uncompressed block with wrong size");
     uncompressed = true;
     offset &= ~(1ULL << 63);
   }
@@ -107,8 +107,8 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
   m_file.Seek(offset, SEEK_SET);
   if (!m_file.ReadBytes(m_zlib_buffer.data(), comp_block_size))
   {
-    PanicAlertFmtT("The disc image \"{0}\" is truncated, some of the data is missing.",
-                   m_file_name);
+    ERROR_LOG_FMT(DISCIO, "The disc image \"{}\" is truncated, some of the data is missing.",
+                  m_file_name);
     m_file.Clear();
     return false;
   }
@@ -117,9 +117,10 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
   const u32 block_hash = Common::HashAdler32(m_zlib_buffer.data(), comp_block_size);
   if (block_hash != m_hashes[block_num])
   {
-    PanicAlertFmtT("The disc image \"{0}\" is corrupt.\n"
-                   "Hash of block {1} is {2:08x} instead of {3:08x}.",
-                   m_file_name, block_num, block_hash, m_hashes[block_num]);
+    ERROR_LOG_FMT(DISCIO,
+                  "The disc image \"{}\" is corrupt.\n"
+                  "Hash of block {} is {:08x} instead of {:08x}.",
+                  m_file_name, block_num, block_hash, m_hashes[block_num]);
   }
 
   if (uncompressed)
@@ -133,7 +134,7 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
     z.avail_in = comp_block_size;
     if (z.avail_in > m_header.block_size)
     {
-      PanicAlertFmt("We have a problem");
+      ERROR_LOG_FMT(DISCIO, "Compressed block size is larger than uncompressed block size");
     }
     z.next_out = out_ptr;
     z.avail_out = m_header.block_size;
@@ -144,12 +145,12 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
     {
       // this seem to fire wrongly from time to time
       // to be sure, don't use compressed isos :P
-      PanicAlertFmt("Failure reading block {} - out of data and not at end.", block_num);
+      ERROR_LOG_FMT(DISCIO, "Failure reading block {} - out of data and not at end.", block_num);
     }
     inflateEnd(&z);
     if (uncomp_size != m_header.block_size)
     {
-      PanicAlertFmt("Wrong block size");
+      ERROR_LOG_FMT(DISCIO, "Wrong block size");
       return false;
     }
   }

--- a/Source/Core/DiscIO/DriveBlob.cpp
+++ b/Source/Core/DiscIO/DriveBlob.cpp
@@ -12,7 +12,6 @@
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
-#include "Common/MsgHandler.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/DriveBlob.h"
 
@@ -146,7 +145,7 @@ bool DriveReader::ReadMultipleAlignedBlocks(u64 block_num, u64 num_blocks, u8* o
       !ReadFile(m_disc_handle, out_ptr, static_cast<DWORD>(GetSectorSize() * num_blocks),
                 &bytes_read, nullptr))
   {
-    PanicAlertFmtT("Disc Read Error");
+    ERROR_LOG_FMT(DISCIO, "Disc Read Error");
     return false;
   }
   return bytes_read == GetSectorSize() * num_blocks;

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -24,7 +24,6 @@
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-#include "Common/MsgHandler.h"
 #include "Common/Swap.h"
 
 #include "DiscIO/Blob.h"
@@ -92,7 +91,7 @@ VolumeWii::VolumeWii(std::unique_ptr<BlobReader> reader)
         {
           // This check is normally done by ES in ES_DiVerify, but that would happen too late
           // (after allocating the buffer), so we do the check here.
-          PanicAlertFmt("Invalid TMD size");
+          ERROR_LOG_FMT(DISCIO, "Invalid TMD size");
           return INVALID_TMD;
         }
         std::vector<u8> tmd_buffer(*tmd_size);

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -16,7 +16,7 @@
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"
-#include "Common/MsgHandler.h"
+#include "Common/Logging/Log.h"
 #include "Common/Swap.h"
 
 namespace DiscIO
@@ -166,7 +166,7 @@ File::IOFile& WbfsFileReader::SeekToCluster(u64 offset, u64* available)
     }
   }
 
-  PanicAlertFmt("Read beyond end of disc");
+  ERROR_LOG_FMT(DISCIO, "Read beyond end of disc");
   if (available)
     *available = 0;
   m_files[0].file.Seek(0, SEEK_SET);


### PR DESCRIPTION
Panic alerts in DiscIO can potentially be very annoying since large amounts of them can pop up when loading the game list if you have some particularly weird files in your game list.

This was a much bigger problem back in 5.0 with its "Tried to decrypt data from a non-Wii volume" panic alert, but I figured I would take it all the way and remove the remaining panic alerts that can show up when loading the game list.

I have exempted uses of ASSERT/ASSERT_MSG since they indicate a bug in Dolphin rather than a malformed file.