### PR TITLE
AudioCommon: Split Initialization

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -15,7 +15,6 @@
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-#include "Core/HW/AudioInterface.h"
 
 // This shouldn't be a global, at least not here.
 std::unique_ptr<SoundStream> g_sound_stream;
@@ -66,13 +65,11 @@ void InitSoundStream()
     g_sound_stream = std::make_unique<NullSound>();
     g_sound_stream->Init();
   }
+}
 
-  // Ideally these two calls would be done in AudioInterface::Init so that we don't
-  // need to have a dependency on AudioInterface here, but this has to be done
-  // after creating g_sound_stream (above) and before starting audio dumping (below)
-  g_sound_stream->GetMixer()->SetDMAInputSampleRate(AudioInterface::GetAIDSampleRate());
-  g_sound_stream->GetMixer()->SetStreamInputSampleRate(AudioInterface::GetAISSampleRate());
-
+void PostInitSoundStream()
+{
+  // This needs to be called after AudioInterface::Init where input sample rates are set
   UpdateSoundStream();
   SetSoundStreamRunning(true);
 

--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -19,6 +19,7 @@ extern std::unique_ptr<SoundStream> g_sound_stream;
 namespace AudioCommon
 {
 void InitSoundStream();
+void PostInitSoundStream();
 void ShutdownSoundStream();
 std::string GetDefaultSoundBackend();
 std::vector<std::string> GetSoundBackends();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -516,6 +516,9 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   Movie::Init(*boot);
   Common::ScopeGuard movie_guard{&Movie::Shutdown};
 
+  AudioCommon::InitSoundStream();
+  Common::ScopeGuard audio_guard{&AudioCommon::ShutdownSoundStream};
+
   HW::Init();
 
   Common::ScopeGuard hw_guard{[] {
@@ -566,8 +569,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   // it's now ok to initialize any custom textures
   HiresTexture::Update();
 
-  AudioCommon::InitSoundStream();
-  Common::ScopeGuard audio_guard{&AudioCommon::ShutdownSoundStream};
+  AudioCommon::PostInitSoundStream();
 
   // The hardware is initialized.
   s_hardware_initialized = true;

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -153,6 +153,9 @@ void Init()
   s_aid_sample_rate = Get32KHzSampleRate();
 
   event_type_ai = CoreTiming::RegisterEvent("AICallback", Update);
+
+  g_sound_stream->GetMixer()->SetDMAInputSampleRate(GetAIDSampleRate());
+  g_sound_stream->GetMixer()->SetStreamInputSampleRate(GetAISSampleRate());
 }
 
 void Shutdown()


### PR DESCRIPTION
This splits SoundStream initialization in two parts, allowing HW::Init to set sample rates and addresses a comment that's been around for a while