### PR TITLE
Allow binding exact position and orientation of Wiimote IR camera relative to sensor bar

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -16,6 +16,7 @@
 #include "InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.h"
 #include "InputCommon/ControllerEmu/ControlGroup/IMUCursor.h"
 #include "InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h"
+#include "InputCommon/ControllerEmu/ControlGroup/SensorBar.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Tilt.h"
 
 namespace
@@ -309,42 +310,59 @@ void ApproachAngleWithAccel(RotationalState* state, const Common::Vec3& angle_ta
 
 void EmulateIMUCursor(IMUCursorState* state, ControllerEmu::IMUCursor* imu_ir_group,
                       ControllerEmu::IMUAccelerometer* imu_accelerometer_group,
-                      ControllerEmu::IMUGyroscope* imu_gyroscope_group, float time_elapsed)
+                      ControllerEmu::IMUGyroscope* imu_gyroscope_group,
+                      ControllerEmu::SensorBar* sensor_bar_group, float time_elapsed)
 {
   const auto ang_vel = imu_gyroscope_group->GetState();
 
-  // Reset if pointing is disabled or we have no gyro data.
-  if (!imu_ir_group->enabled || !ang_vel.has_value())
+  // Reset if sensor bar simulation is disabled and also pointing is disabled or can't be simulated because we have no gyro data.
+  if (!sensor_bar_group->enabled && (!imu_ir_group->enabled || !ang_vel.has_value()))
   {
     *state = {};
     return;
   }
 
-  // Apply rotation from gyro data.
-  const auto gyro_rotation = GetRotationFromGyroscope(*ang_vel * -1 * time_elapsed);
-  state->rotation = gyro_rotation * state->rotation;
-
-  // If we have some non-zero accel data use it to adjust gyro drift.
-  constexpr auto ACCEL_WEIGHT = 0.02f;
-  auto const accel = imu_accelerometer_group->GetState().value_or(Common::Vec3{});
-  if (accel.LengthSquared())
-    state->rotation = ComplementaryFilter(state->rotation, accel, ACCEL_WEIGHT);
-
-  // Clamp yaw within configured bounds.
-  const auto yaw = GetYaw(state->rotation);
-  const auto max_yaw = float(imu_ir_group->GetTotalYaw() / 2);
-  auto target_yaw = std::clamp(yaw, -max_yaw, max_yaw);
-
-  // Handle the "Recenter" button being pressed.
-  if (imu_ir_group->controls[0]->GetState<bool>())
+  // 95% confidence level is arbitrary here
+  if (sensor_bar_group->enabled && sensor_bar_group->GetInputConfidence() >= 95)
   {
-    state->recentered_pitch = GetPitch(state->rotation);
-    target_yaw = 0;
-  }
+    // Reset this value as it will not be used
+    state->rotation = Common::Quaternion::Identity();
 
-  // Adjust yaw as needed.
-  if (yaw != target_yaw)
-    state->rotation *= Common::Quaternion::RotateZ(target_yaw - yaw);
+    const auto ir_camera_rotation = sensor_bar_group->GetIRCameraOrientation();
+    const auto ir_camera_position = sensor_bar_group->GetIRCameraDisplacement();
+    state->orientation = ir_camera_rotation;
+    state->position =
+        Common::Vec3{ir_camera_position.x, ir_camera_position.y, ir_camera_position.z};
+    return;
+  }
+  else
+  {
+    // Apply rotation from gyro data.
+    const auto gyro_rotation = GetRotationFromGyroscope(*ang_vel * -1 * time_elapsed);
+    state->rotation = gyro_rotation * state->rotation;
+
+    // If we have some non-zero accel data use it to adjust gyro drift.
+    constexpr auto ACCEL_WEIGHT = 0.02f;
+    auto const accel = imu_accelerometer_group->GetState().value_or(Common::Vec3{});
+    if (accel.LengthSquared())
+      state->rotation = ComplementaryFilter(state->rotation, accel, ACCEL_WEIGHT);
+
+    // Clamp yaw within configured bounds.
+    const auto yaw = GetYaw(state->rotation);
+    const auto max_yaw = float(imu_ir_group->GetTotalYaw() / 2);
+    auto target_yaw = std::clamp(yaw, -max_yaw, max_yaw);
+
+    // Handle the "Recenter" button being pressed.
+    if (imu_ir_group->controls[0]->GetState<bool>())
+    {
+      state->recentered_pitch = GetPitch(state->rotation);
+      target_yaw = 0;
+    }
+
+    // Adjust yaw as needed.
+    if (yaw != target_yaw)
+      state->rotation *= Common::Quaternion::RotateZ(target_yaw - yaw);
+  }
 
   // Normalize for floating point inaccuracies.
   state->rotation = state->rotation.Normalized();

--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
@@ -15,6 +15,7 @@
 #include "InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.h"
 #include "InputCommon/ControllerEmu/ControlGroup/IMUCursor.h"
 #include "InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h"
+#include "InputCommon/ControllerEmu/ControlGroup/SensorBar.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Tilt.h"
 
 namespace WiimoteEmu
@@ -45,6 +46,10 @@ struct IMUCursorState
 
   // Rotation of world around device.
   Common::Quaternion rotation;
+  // Orientation of device in world, relative to sensor bar
+  Common::Vec3 orientation;
+  // Position of device in world, relative to sensor bar
+  Common::Vec3 position;
 
   float recentered_pitch = {};
 };
@@ -86,7 +91,9 @@ void EmulateSwing(MotionState* state, ControllerEmu::Force* swing_group, float t
 void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group, float time_elapsed);
 void EmulateIMUCursor(IMUCursorState* state, ControllerEmu::IMUCursor* imu_ir_group,
                       ControllerEmu::IMUAccelerometer* imu_accelerometer_group,
-                      ControllerEmu::IMUGyroscope* imu_gyroscope_group, float time_elapsed);
+                      ControllerEmu::IMUGyroscope* imu_gyroscope_group,
+                      ControllerEmu::SensorBar* sensor_bar_group,
+                      float time_elapsed);
 
 // Convert m/s/s acceleration data to the format used by Wiimote/Nunchuk (10-bit unsigned integers).
 WiimoteCommon::AccelData ConvertAccelData(const Common::Vec3& accel, u16 zero_g, u16 one_g);

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -33,6 +33,7 @@ class IMUGyroscope;
 class IMUCursor;
 class ModifySettingsButton;
 class Output;
+class SensorBar;
 class Tilt;
 }  // namespace ControllerEmu
 
@@ -53,6 +54,7 @@ enum class WiimoteGroup
   IMUAccelerometer,
   IMUGyroscope,
   IMUPoint,
+  SensorBar,
 };
 
 enum class NunchukGroup;
@@ -159,7 +161,7 @@ private:
   // Used for simulating camera data and for rotating acceleration data.
   // Does not include orientation transformations.
   Common::Matrix44
-  GetTransformation(const Common::Matrix33& extra_rotation = Common::Matrix33::Identity()) const;
+  GetTransformation(const Common::Matrix33& extra_rotation = Common::Matrix33::Identity(), const Common::Vec3& position = Common::Vec3(0.f, 0.f, 0.f)) const;
 
   // Returns the world rotation from the effects of sideways/upright settings.
   Common::Quaternion GetOrientation() const;
@@ -257,6 +259,7 @@ private:
   ControllerEmu::IMUAccelerometer* m_imu_accelerometer;
   ControllerEmu::IMUGyroscope* m_imu_gyroscope;
   ControllerEmu::IMUCursor* m_imu_ir;
+  ControllerEmu::SensorBar* m_sensor_bar;
 
   ControllerEmu::SettingValue<bool> m_sideways_setting;
   ControllerEmu::SettingValue<bool> m_upright_setting;

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClInclude Include="AudioCommon\AudioCommon.h" />

--- a/Source/Core/DolphinLib.vcxproj
+++ b/Source/Core/DolphinLib.vcxproj
@@ -28,6 +28,18 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.h" />
+  </ItemGroup>
+  <ItemGroup>
     <ClInclude Include="Core\PowerPC\JitCommon\DivUtils.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/DolphinLib.vcxproj
+++ b/Source/Core/DolphinLib.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\VSProps\Base.Macros.props" />
   <Import Project="$(VSPropsDir)Base.Targets.props" />
@@ -26,12 +26,6 @@
     <ProjectReference Include="$(CoreDir)Common\SCMRevGen.vcxproj">
       <Project>{41279555-f94f-4ebc-99de-af863c10c5c4}</Project>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.cpp" />

--- a/Source/Core/DolphinLib.vcxproj
+++ b/Source/Core/DolphinLib.vcxproj
@@ -34,6 +34,12 @@
     <ClInclude Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="InputCommon\ControllerEmu\ControlGroup\SensorBar.h" />
+  </ItemGroup>
+  <ItemGroup>
     <ClInclude Include="Core\PowerPC\JitCommon\DivUtils.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControlIMU.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControlIMU.cpp
@@ -47,6 +47,8 @@ void WiimoteEmuMotionControlIMU::CreateMainLayout()
   auto* groups_layout = new QHBoxLayout();
   groups_layout->addWidget(
       CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::IMUPoint)));
+  groups_layout->addWidget(
+      CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::SensorBar)));
   groups_layout->addWidget(CreateGroupBox(
       Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::IMUAccelerometer)));
   groups_layout->addWidget(

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -39,6 +39,8 @@ add_library(inputcommon
   ControllerEmu/ControlGroup/MixedTriggers.h
   ControllerEmu/ControlGroup/ModifySettingsButton.cpp
   ControllerEmu/ControlGroup/ModifySettingsButton.h
+  ControllerEmu/ControlGroup/SensorBar.cpp
+  ControllerEmu/ControlGroup/SensorBar.h
   ControllerEmu/ControlGroup/Slider.cpp
   ControllerEmu/ControlGroup/Slider.h
   ControllerEmu/ControlGroup/Tilt.cpp

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -43,7 +43,8 @@ enum class GroupType
   Shake,
   IMUAccelerometer,
   IMUGyroscope,
-  IMUCursor
+  IMUCursor,
+  SensorBar
 };
 
 class ControlGroup

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/SensorBar.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/SensorBar.cpp
@@ -1,0 +1,115 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "InputCommon/ControllerEmu/ControlGroup/SensorBar.h"
+
+#include <memory>
+#include <string>
+
+#include "Common/Common.h"
+#include "Common/MathUtil.h"
+
+#include "InputCommon/ControlReference/ControlReference.h"
+#include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/Control/Input.h"
+
+namespace ControllerEmu
+{
+SensorBar::SensorBar(std::string name_, std::string ui_name_)
+    : ControlGroup(std::move(name_), std::move(ui_name_), GroupType::SensorBar,
+#ifdef ANDROID
+          // Enabling this on Android devices which have an accelerometer and gyroscope prevents
+          // touch controls from being used for pointing, and touch controls generally work better
+          ControlGroup::DefaultValue::Disabled)
+#else
+          // Most users probably won't have the setup for this
+          ControlGroup::DefaultValue::Disabled)
+#endif
+{
+  AddSetting(
+      &m_ir_camera_displacement_x_setting,
+      // i18n: Refers to the positional offset of an emulated wiimote's IR camera compared to the
+      // sensor bar.
+      {_trans("IR Camera X"),
+       // i18n: The symbol for meters.
+       _trans("m"),
+       // i18n: Refers to the emulated Wii remote.
+       _trans(
+           "How far the Wiimote's IR camera is to the right of the sensor bar's center.")},
+      0, -10, 10);
+  AddSetting(
+      &m_ir_camera_displacement_y_setting,
+      // i18n: Refers to the positional offset of an emulated wiimote's IR camera compared to the
+      // sensor bar.
+      {_trans("IR Camera Y"),
+       // i18n: The symbol for meters.
+       _trans("m"),
+       // i18n: Refers to the emulated Wii remote.
+       _trans(
+           "How far the Wiimote's IR camera is back from the sensor bar's center.")},
+      0, -10, 10);
+  AddSetting(
+      &m_ir_camera_displacement_z_setting,
+      // i18n: Refers to the positional offset of an emulated wiimote's IR camera compared to the
+      // sensor bar.
+      {_trans("IR Camera Z"),
+       // i18n: The symbol for meters.
+       _trans("m"),
+       // i18n: Refers to the emulated Wii remote.
+       _trans("How far the Wiimote's IR camera is above the sensor bar's center.")},
+      0, -10, 10);
+  AddSetting(&m_ir_camera_pitch_setting,
+             // i18n: Refers to the orientation of an emulated wiimote's IR camera.
+             {_trans("IR Camera Pitch"),
+              // i18n: The degrees symbol.
+              _trans("°"),
+              // i18n: Refers to the method used to pass position and orientation data to Dolphin.
+              _trans("The pitch of the Wiimote's IR camera.")},
+             0, -360, 360);
+  AddSetting(&m_ir_camera_roll_setting,
+             // i18n: Refers to the orientation of an emulated wiimote's IR camera
+             {_trans("IR Camera Roll"),
+              // i18n: The degrees symbol.
+              _trans("°"),
+              // i18n: Refers to the method used to pass position and orientation data to Dolphin.
+              _trans("The roll of the Wiimote's IR camera.")},
+             0, -360, 360);
+  AddSetting(&m_ir_camera_yaw_setting,
+             // i18n: Refers to the orientation of an emulated wiimote's IR camera.
+             {_trans("IR Camera Yaw"),
+              // i18n: The degrees symbol.
+              _trans("°"),
+              // i18n: Refers to the method used to pass position and orientation data to Dolphin.
+              _trans("The yaw of the Wiimote's IR camera.")},
+             0, -360, 360);
+  AddSetting(&m_input_confidence,
+             // i18n: Refers to how much confidence there is in the camera position and orientation being correct.
+             {_trans("Input Confidence"),
+              // i18n: The symbol for percent.
+              _trans("%"),
+              // i18n: Refers to the method used to pass position and orientation data to Dolphin.
+              _trans("How confident Dolphin should be that the above data is accurate.")},
+             100, 0, 100);
+}
+
+Common::Vec3 SensorBar::GetIRCameraDisplacement()
+{
+  return Common::Vec3(m_ir_camera_displacement_x_setting.GetValue(),
+                      m_ir_camera_displacement_y_setting.GetValue(),
+                      m_ir_camera_displacement_z_setting.GetValue());
+}
+
+Common::Vec3 SensorBar::GetIRCameraOrientation()
+{
+  return Common::Vec3(m_ir_camera_pitch_setting.GetValue() * MathUtil::TAU / 360,
+                      m_ir_camera_roll_setting.GetValue() * MathUtil::TAU / 360,
+                      m_ir_camera_yaw_setting.GetValue() * MathUtil::TAU / 360);
+}
+
+double SensorBar::GetInputConfidence()
+{
+  return m_input_confidence.GetValue();
+}
+
+}  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/SensorBar.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/SensorBar.h
@@ -1,0 +1,38 @@
+#pragma once
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "Common/MathUtil.h"
+#include "Common/Matrix.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
+#include "InputCommon/ControllerInterface/CoreDevice.h"
+
+namespace ControllerEmu
+{
+class SensorBar : public ControlGroup
+{
+public:
+  using StateData = Common::Vec3;
+
+  SensorBar(std::string name, std::string ui_name);
+
+  Common::Vec3 GetIRCameraDisplacement();
+  Common::Vec3 GetIRCameraOrientation();
+  double GetInputConfidence();
+
+  SettingValue<double> m_ir_camera_displacement_x_setting;
+  SettingValue<double> m_ir_camera_displacement_y_setting;
+  SettingValue<double> m_ir_camera_displacement_z_setting;
+  SettingValue<double> m_ir_camera_pitch_setting;
+  SettingValue<double> m_ir_camera_roll_setting;
+  SettingValue<double> m_ir_camera_yaw_setting;
+  SettingValue<double> m_input_confidence;
+};
+}  // namespace ControllerEmu


### PR DESCRIPTION
Hi folks, I'd like to suggest adding a new panel in the **Motion Input** tab that allows the user to bind the x-, y-, and z-coordinates of the Wiimote's IR camera, as well as its pitch, roll and yaw:

![image](https://user-images.githubusercontent.com/136441/112383274-d2ae4300-8ce4-11eb-9026-22bdfd7f7af5.png)

My personal main motivation for seeing this feature is for use with VR, since (unlike with, say, a Joy-Con) we can track the exact position and orientation of motion controllers, as well as the accelerometer and gyro values that many modern game controllers support.

At the moment, I believe (and please correct me if I'm wrong) that in order to simulate a sensor bar in Dolphin, I have two options:

- Raycast from the VR controller to get a point on the VR TV screen, and bind this to the **Motion Simulation** - **Point** inputs.
    - However, this doesn't support roll movements, unless I also add some **Tilt** bindings, at which point I would have a strange combination of **Motion Simulation** and **Motion Input** bindings.
    - Also, I'm guessing that this could cause some problems with games that use both accelerometer and IR camera inputs to figure out what the controller is doing - not sure.
- Use the **Motion Input** - **Point** panel's simulated pointer position
    - Although this is really good, it's not quite perfect, due to (what I appreciate is unavoidable) integration errors that blow up quickly.

I considered having inputs for the two sensor bar IR LEDs' positions and brightness, which the VR app would simulate and pass through, but since Dolphin already has a function to convert x/y/z/pitch/roll/yaw into these values, I thought it would be simpler to just pass those to that existing function.

Using these six values is also convenient for other existing software. For instance, [opentrack](https://github.com/opentrack/opentrack) can retrieve the six values from a number of different trackers. [I've made a small modification here](https://github.com/MichaelJW/OpenTrackDSUServer) to @iwubcode's excellent OpenTrackDSUServer that allows passing these raw values rather than calculated accelerometer and gyro values, so in theory someone could, for example, tape a [Delanclip](https://delanengineering.com/) to a Joy-Con, run both BetterJoy and OpenTrackDSUServer, and retrieve accel, gyro, button, _and_ IR position and orientation data, for very accurate Wiimote emulation.

I don't have a Delanclip, but I have tested this with Oculus Touch controllers and also with a simple Android app that uses the OS's built-in [AR image tracking](https://developers.google.com/ar/develop/c/augmented-images) to track the position and orientation of a comically large paper tracker taped to an Xbox controller:

![image](https://user-images.githubusercontent.com/136441/112385900-148cb880-8ce8-11eb-9e09-56dad8f6ccb2.png)

- See video here: https://www.youtube.com/watch?v=Cv8hhsi_Mnc
    - 0.00: 2006-style setup, with sensor bar beneath 40-inch TV, both 2m away from user
    - 0.52: Since it's VR, we can move the TV closer and make it bigger without it blocking the simulated IR line of sight
    - 1.18: Image tracker + Xbox One controller. This pad has no IMU; the motion and pointing is calculated from the AR paper tracker's position and orientation.

Since the AR example is pretty flaky in practice, I added an **Input Confidence** input, the idea being that the DSU server would pass through a number expressing how much confidence it had in the current packet of values, with the number being lower in low light, or if the tracker is further away, or moving quickly, or similar. 

At the moment, the implementation is simple: assuming both **Point** and **Sensor Bar** panels are enabled, then if **Input Confidence** is `95%` or above the **Sensor Bar** values are used, otherwise the calculated gyro values are used.

Some technical notes:

- This is my first time trying to contribute to a big C++ project like this; I'm unfamiliar with both the language and the codebase so while I have tried to match the coding style I'm sure I've made some mistakes - sorry!
- I've named the panel and the relevant bits of code "sensor bar" even though this is really about the IR camera, because there's already references to "cursor" and "IMUCamera" and so on and I thought this might help express that the purpose is to simulate the IR camera's ability to see the sensor bar. I appreciate it's confusing though.
- I may have introduced some redundancies by adding `orientation` and `position` variables when there are already `rotation` and `m_point_state.position` etc; I was struggling to figure out exactly how it all tied together so that I could fit this new stuff in without breaking what was already there.
    - Untangling this would be really helpful for improving the "fall back to gyro pointing" feature, but isn't strictly necessary.

Hope this is OK, looking forward to your feedback, thanks.