### PR TITLE
Fix PanicAlert when recording FIFOs

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -224,7 +224,7 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
       // Determine offset of each element that might be a vertex array
       // The first 9 elements are never vertex arrays so we just accumulate their sizes.
       int offset = std::accumulate(sizes.begin(), sizes.begin() + 9, 0u);
-      std::array<int, 12> offsets;
+      std::array<int, NUM_VERTEX_COMPONENT_ARRAYS> offsets;
       for (size_t i = 0; i < offsets.size(); ++i)
       {
         offsets[i] = offset;

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
@@ -52,8 +52,8 @@ void FifoRecordAnalyzer::WriteVertexArray(int arrayIndex, const u8* vertexData, 
     arrayType = s_CpMem.vtxDesc.low.Normal;
   else if (arrayIndex >= ARRAY_COLOR0 && arrayIndex < ARRAY_COLOR0 + NUM_COLOR_ARRAYS)
     arrayType = s_CpMem.vtxDesc.low.Color[arrayIndex - ARRAY_COLOR0];
-  else if (arrayIndex >= ARRAY_POSITION && arrayIndex < ARRAY_POSITION + 8)
-    arrayType = s_CpMem.vtxDesc.high.TexCoord[arrayIndex - ARRAY_POSITION];
+  else if (arrayIndex >= ARRAY_TEXCOORD0 && arrayIndex < ARRAY_TEXCOORD0 + NUM_TEXCOORD_ARRAYS)
+    arrayType = s_CpMem.vtxDesc.high.TexCoord[arrayIndex - ARRAY_TEXCOORD0];
   else
   {
     PanicAlertFmt("Invalid arrayIndex {}", arrayIndex);

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
@@ -50,8 +50,8 @@ void FifoRecordAnalyzer::WriteVertexArray(int arrayIndex, const u8* vertexData, 
     arrayType = s_CpMem.vtxDesc.low.Position;
   else if (arrayIndex == ARRAY_NORMAL)
     arrayType = s_CpMem.vtxDesc.low.Normal;
-  else if (arrayIndex == ARRAY_COLOR || arrayIndex == ARRAY_COLOR2)
-    arrayType = s_CpMem.vtxDesc.low.Color[arrayIndex - ARRAY_COLOR];
+  else if (arrayIndex >= ARRAY_COLOR0 && arrayIndex < ARRAY_COLOR0 + NUM_COLOR_ARRAYS)
+    arrayType = s_CpMem.vtxDesc.low.Color[arrayIndex - ARRAY_COLOR0];
   else if (arrayIndex >= ARRAY_POSITION && arrayIndex < ARRAY_POSITION + 8)
     arrayType = s_CpMem.vtxDesc.high.TexCoord[arrayIndex - ARRAY_POSITION];
   else

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -51,9 +51,14 @@ enum
 {
   ARRAY_POSITION = 0,
   ARRAY_NORMAL = 1,
-  ARRAY_COLOR = 2,
-  ARRAY_COLOR2 = 3,
+  ARRAY_COLOR0 = 2,
+  NUM_COLOR_ARRAYS = 2,
   ARRAY_TEXCOORD0 = 4,
+  NUM_TEXCOORD_ARRAYS = 8,
+
+  // Number of arrays related to vertex components (position, normal, color, tex coord)
+  // Excludes the 4 arrays used for indexed XF loads
+  NUM_VERTEX_COMPONENT_ARRAYS = 12,
 };
 
 // Vertex components

--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -497,7 +497,7 @@ void VertexLoaderARM64::GenerateVertexLoader()
           m_VtxAttr.color[i].Comp == ColorFormat::RGBA4444)
         align = 2;
 
-      s32 offset = GetAddressImm(ARRAY_COLOR + int(i), m_VtxDesc.low.Color[i],
+      s32 offset = GetAddressImm(ARRAY_COLOR0 + int(i), m_VtxDesc.low.Color[i],
                                  EncodeRegTo64(scratch1_reg), align);
       ReadColor(m_VtxDesc.low.Color[i], m_VtxAttr.color[i].Comp, offset);
       m_native_components |= VB_HAS_COL0 << i;

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -47,7 +47,7 @@ static std::mutex s_vertex_loader_map_lock;
 static VertexLoaderMap s_vertex_loader_map;
 // TODO - change into array of pointers. Keep a map of all seen so far.
 
-u8* cached_arraybases[12];
+u8* cached_arraybases[NUM_VERTEX_COMPONENT_ARRAYS];
 
 void Init()
 {
@@ -88,8 +88,8 @@ void UpdateVertexArrayPointers()
   for (size_t i = 0; i < g_main_cp_state.vtx_desc.low.Color.Size(); i++)
   {
     if (IsIndexed(g_main_cp_state.vtx_desc.low.Color[i]))
-      cached_arraybases[ARRAY_COLOR + i] =
-          Memory::GetPointer(g_main_cp_state.array_bases[ARRAY_COLOR + i]);
+      cached_arraybases[ARRAY_COLOR0 + i] =
+          Memory::GetPointer(g_main_cp_state.array_bases[ARRAY_COLOR0 + i]);
   }
 
   for (size_t i = 0; i < g_main_cp_state.vtx_desc.high.TexCoord.Size(); i++)

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 
 #include "Common/CommonTypes.h"
+#include "VideoCommon/CPMemory.h"
 
 class DataReader;
 class NativeVertexFormat;
@@ -43,7 +44,7 @@ std::string VertexLoadersToString();
 NativeVertexFormat* GetCurrentVertexFormat();
 
 // Resolved pointers to array bases. Used by vertex loaders.
-extern u8* cached_arraybases[12];
+extern u8* cached_arraybases[NUM_VERTEX_COMPONENT_ARRAYS];
 void UpdateVertexArrayPointers();
 
 // Position cache for zfreeze (3 vertices, 4 floats each to allow SIMD overwrite).

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -469,7 +469,7 @@ void VertexLoaderX64::GenerateVertexLoader()
   {
     if (m_VtxDesc.low.Color[i] != VertexComponentFormat::NotPresent)
     {
-      data = GetVertexAddr(ARRAY_COLOR + int(i), m_VtxDesc.low.Color[i]);
+      data = GetVertexAddr(ARRAY_COLOR0 + int(i), m_VtxDesc.low.Color[i]);
       ReadColor(data, m_VtxDesc.low.Color[i], m_VtxAttr.color[i].Comp);
       m_native_components |= VB_HAS_COL0 << i;
       m_native_vtx_decl.colors[i].components = 4;

--- a/Source/Core/VideoCommon/VertexLoader_Color.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Color.cpp
@@ -77,8 +77,8 @@ void Color_ReadIndex_16b_565(VertexLoader* loader)
 {
   const auto index = DataRead<I>();
   const u8* const address =
-      VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] +
-      (index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+      VertexLoaderManager::cached_arraybases[ARRAY_COLOR0 + loader->m_colIndex] +
+      (index * g_main_cp_state.array_strides[ARRAY_COLOR0 + loader->m_colIndex]);
 
   u16 value;
   std::memcpy(&value, address, sizeof(u16));
@@ -90,8 +90,8 @@ template <typename I>
 void Color_ReadIndex_24b_888(VertexLoader* loader)
 {
   const auto index = DataRead<I>();
-  const u8* address = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] +
-                      (index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+  const u8* address = VertexLoaderManager::cached_arraybases[ARRAY_COLOR0 + loader->m_colIndex] +
+                      (index * g_main_cp_state.array_strides[ARRAY_COLOR0 + loader->m_colIndex]);
   SetCol(loader, Read24(address));
 }
 
@@ -99,8 +99,8 @@ template <typename I>
 void Color_ReadIndex_32b_888x(VertexLoader* loader)
 {
   const auto index = DataRead<I>();
-  const u8* address = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] +
-                      (index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+  const u8* address = VertexLoaderManager::cached_arraybases[ARRAY_COLOR0 + loader->m_colIndex] +
+                      (index * g_main_cp_state.array_strides[ARRAY_COLOR0 + loader->m_colIndex]);
   SetCol(loader, Read24(address));
 }
 
@@ -109,8 +109,8 @@ void Color_ReadIndex_16b_4444(VertexLoader* loader)
 {
   auto const index = DataRead<I>();
   const u8* const address =
-      VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] +
-      (index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+      VertexLoaderManager::cached_arraybases[ARRAY_COLOR0 + loader->m_colIndex] +
+      (index * g_main_cp_state.array_strides[ARRAY_COLOR0 + loader->m_colIndex]);
 
   u16 value;
   std::memcpy(&value, address, sizeof(u16));
@@ -122,8 +122,8 @@ template <typename I>
 void Color_ReadIndex_24b_6666(VertexLoader* loader)
 {
   const auto index = DataRead<I>();
-  const u8* data = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] +
-                   (index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]) - 1;
+  const u8* data = VertexLoaderManager::cached_arraybases[ARRAY_COLOR0 + loader->m_colIndex] +
+                   (index * g_main_cp_state.array_strides[ARRAY_COLOR0 + loader->m_colIndex]) - 1;
   const u32 val = Common::swap32(data);
   SetCol6666(loader, val);
 }
@@ -132,8 +132,8 @@ template <typename I>
 void Color_ReadIndex_32b_8888(VertexLoader* loader)
 {
   const auto index = DataRead<I>();
-  const u8* address = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] +
-                      (index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+  const u8* address = VertexLoaderManager::cached_arraybases[ARRAY_COLOR0 + loader->m_colIndex] +
+                      (index * g_main_cp_state.array_strides[ARRAY_COLOR0 + loader->m_colIndex]);
   SetCol(loader, Read32(address));
 }
 }  // Anonymous namespace

--- a/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
+++ b/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
@@ -352,7 +352,7 @@ TEST_F(VertexLoaderTest, LargeFloatVertexSpeed)
 
   CreateAndCheckSizes(33, 156);
 
-  for (int i = 0; i < 12; i++)
+  for (int i = 0; i < NUM_VERTEX_COMPONENT_ARRAYS; i++)
   {
     VertexLoaderManager::cached_arraybases[i] = m_src.GetPointer();
     g_main_cp_state.array_strides[i] = 129;


### PR DESCRIPTION
The typo (from f749fcfa9f42cda679ff7f4288c8418d2b56b08d) was `ARRAY_POSITION` being used instead of `ARRAY_TEXCOORD0`.