### PR TITLE
Android: Rename "Enable Logging" to "Write Logs to File"

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -668,8 +668,8 @@ public final class SettingsFragmentPresenter
 
   private void addLogConfigurationSettings(ArrayList<SettingsItem> sl)
   {
-    sl.add(new CheckBoxSetting(BooleanSetting.LOGGER_WRITE_TO_FILE, R.string.enable_logging,
-            R.string.enable_logging_description));
+    sl.add(new CheckBoxSetting(BooleanSetting.LOGGER_WRITE_TO_FILE, R.string.log_to_file,
+            R.string.log_to_file_description));
     sl.add(new SingleChoiceSetting(IntSetting.LOGGER_VERBOSITY, R.string.log_verbosity, 0,
             getLogVerbosityEntries(), getLogVerbosityValues()));
     sl.add(new RunRunnable(R.string.log_enable_all, 0, R.string.log_enable_all_confirmation, 0,

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -289,8 +289,8 @@
 
     <!-- Log Configuration -->
     <string name="log_submenu">Log</string>
-    <string name="enable_logging">Enable Logging</string>
-    <string name="enable_logging_description">Log messages from enabled log types to dolphin-emu/Logs/. Will decrease performance.</string>
+    <string name="log_to_file">Write Logs to File</string>
+    <string name="log_to_file_description">Log messages from enabled log types to the Logs folder. Will decrease performance.</string>
     <string name="log_verbosity">Verbosity</string>
     <string name="log_enable_all">Enable all Log Types</string>
     <string name="log_enable_all_confirmation">Are you sure you want to enable all log types?</string>


### PR DESCRIPTION
This option does in fact not enable and disable logging as a whole. You can get logs through logcat regardless of this setting.

Also taking the opportunity to remove the reference to the "dolphin-emu" folder name since we will no longer be using that folder once scoped storage is applied to Dolphin.