### PR TITLE
Android: Expand the game INI deletion prompt

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -354,7 +354,7 @@
     <string name="preferences_game_properties">Game Properties</string>
     <string name="preferences_extensions">Extension Bindings</string>
     <string name="game_ini_junk_title">Junk Data Found</string>
-    <string name="game_ini_junk_question">The settings file for this game contains junk data created by an old version of Dolphin. Would you like to fix this by deleting the settings file for this game? All game-specific settings and cheats that you have added will be removed. This cannot be undone.</string>
+    <string name="game_ini_junk_question">The settings file for this game contains extraneous data added by an old version of Dolphin. This will likely prevent global settings from working as intended.\n\nWould you like to fix this by deleting the settings file for this game? All game-specific settings and cheats that you have added will be removed. This cannot be undone.</string>
     <string name="game_details_country">Country</string>
     <string name="game_details_company">Company</string>
     <string name="game_details_game_id">Game ID</string>


### PR DESCRIPTION
See PR #8203 for background on the game INI deletion prompt.

It's been almost two years since PR #8203 was merged, so you would think that people are no longer creating game INIs that contain a copy of every global setting, right? Unfortunately, MMJ was forked not too long before that and never backported the change, so right now there's a not insignificant number of people online posting game INIs full of this garbage for others to use.

One thing that's been missing from the game INI deletion prompt is a description of what the problem with having tons of extra lines in a game INI actually is. This change adds that, in the the hope that it will make people ignore the warning less often.