### PR TITLE
JitArm64: Allow DoJit at address 0 (fix launching Wii titles)

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -623,12 +623,6 @@ void JitArm64::Jit(u32)
 
 void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 {
-  if (em_address == 0)
-  {
-    Core::SetState(Core::State::Paused);
-    WARN_LOG_FMT(DYNA_REC, "ERROR: Compiling at 0. LR={:08x} CTR={:08x}", LR, CTR);
-  }
-
   js.isLastInstruction = false;
   js.firstFPInstructionFound = false;
   js.assumeNoPairedQuantize = false;


### PR DESCRIPTION
`JitArm64::DoJit` contains a check where it prints a warning and tries to pause emulation if instructed to compile code at address 0. I'm assuming this was done in order to provide a nicer error behavior in cases where PC was accidentally set to null. Unfortunately, it has started causing us problems recently, as 688bd61 writes and runs some code at address 0 to simulate the PPC being held in reset. What makes this worse is that calling `Core::SetState` from the CPU thread is actually not allowed and will cause a deadlock instead of  the intended behavior. I don't believe there is anything on a real console that would stop you from executing code at address 0 (as long as the MMU has been set up to allow it), and `Jit64::DoJit` doesn't contain any check like this, so let's remove the check.