### PR TITLE
IOS/FS: Add a scoped FD class to make it harder to leak FDs

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -403,9 +403,9 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
   // To keep track of the PPC title launch, a temporary launch file (LAUNCH_FILE_PATH) is used
   // to store the title ID of the title to launch and its TMD.
   // The launch file not existing means an IOS reload is required.
-  const auto launch_file_fd = m_ios.GetFSDevice()->Open(PID_KERNEL, PID_KERNEL, LAUNCH_FILE_PATH,
-                                                        FS::Mode::Read, {}, &ticks);
-  if (launch_file_fd < 0)
+  if (const auto launch_file_fd = m_ios.GetFSDevice()->Open(
+          PID_KERNEL, PID_KERNEL, LAUNCH_FILE_PATH, FS::Mode::Read, {}, &ticks);
+      launch_file_fd.Get() < 0)
   {
     if (WriteLaunchFile(tmd, &ticks) != IPC_SUCCESS)
     {
@@ -423,7 +423,6 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
 
   // Otherwise, assume that the PPC title can now be launched directly.
   // Unlike IOS, we won't bother checking the title ID in the launch file. (It's not useful.)
-  m_ios.GetFSDevice()->Close(launch_file_fd, &ticks);
   m_ios.GetFSDevice()->DeleteFile(PID_KERNEL, PID_KERNEL, LAUNCH_FILE_PATH, &ticks);
   WriteSystemFile(SPACE_FILE_PATH, std::vector<u8>(SPACE_FILE_SIZE), &ticks);
 

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -29,12 +29,12 @@ s32 ESDevice::OpenContent(const ES::TMDReader& tmd, u16 content_index, u32 uid, 
       continue;
 
     const std::string path = GetContentPath(title_id, content, ticks);
-    s64 fd = m_ios.GetFSDevice()->Open(PID_KERNEL, PID_KERNEL, path, FS::Mode::Read, {}, ticks);
-    if (fd < 0)
-      return fd;
+    auto fd = m_ios.GetFSDevice()->Open(PID_KERNEL, PID_KERNEL, path, FS::Mode::Read, {}, ticks);
+    if (fd.Get() < 0)
+      return fd.Get();
 
     entry.m_opened = true;
-    entry.m_fd = fd;
+    entry.m_fd = fd.Release();
     entry.m_content = content;
     entry.m_title_id = title_id;
     entry.m_uid = uid;

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -346,16 +346,16 @@ u16 Kernel::GetGidForPPC() const
 static std::vector<u8> ReadBootContent(FSDevice* fs, const std::string& path, size_t max_size,
                                        Ticks ticks = {})
 {
-  const s64 fd = fs->Open(0, 0, path, FS::Mode::Read, {}, ticks);
-  if (fd < 0)
+  const auto fd = fs->Open(0, 0, path, FS::Mode::Read, {}, ticks);
+  if (fd.Get() < 0)
     return {};
 
-  const size_t file_size = fs->GetFileStatus(fd, ticks)->size;
+  const size_t file_size = fs->GetFileStatus(fd.Get(), ticks)->size;
   if (max_size != 0 && file_size > max_size)
     return {};
 
   std::vector<u8> buffer(file_size);
-  if (!fs->Read(fd, buffer.data(), buffer.size(), ticks))
+  if (!fs->Read(fd.Get(), buffer.data(), buffer.size(), ticks))
     return {};
   return buffer;
 }


### PR DESCRIPTION
This changes FileSystemProxy::Open to return a file descriptor wrapper
that will ensure the FD is closed when it goes out of scope.

By using such a wrapper we make it more difficult to forget to close
file descriptors.

This fixes a leak in ReadBootContent. I should have added such a class
from the beginning... In practice, I don't think this would have caused
any obvious issue because ReadBootContent is only called after an IOS
relaunch -- which clears all FDs -- and most titles do not get close
to the FD limit.