### PR TITLE
Replace uses of cassert with Common/Assert.h

### DIFF
--- a/Source/Core/AudioCommon/OpenSLESStream.cpp
+++ b/Source/Core/AudioCommon/OpenSLESStream.cpp
@@ -5,7 +5,6 @@
 #ifdef ANDROID
 #include "AudioCommon/OpenSLESStream.h"
 
-#include <cassert>
 #include <cmath>
 
 #include <SLES/OpenSLES.h>
@@ -36,8 +35,8 @@ static int curBuffer = 0;
 
 static void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void* context)
 {
-  assert(bq == bqPlayerBufferQueue);
-  assert(nullptr == context);
+  ASSERT(bq == bqPlayerBufferQueue);
+  ASSERT(nullptr == context);
 
   // Render to the fresh buffer
   g_mixer->Mix(reinterpret_cast<short*>(buffer[curBuffer]), BUFFER_SIZE_IN_SAMPLES);
@@ -56,15 +55,15 @@ bool OpenSLESStream::Init()
   SLresult result;
   // create engine
   result = slCreateEngine(&engineObject, 0, nullptr, 0, nullptr, nullptr);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
   result = (*engineObject)->Realize(engineObject, SL_BOOLEAN_FALSE);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
   result = (*engineObject)->GetInterface(engineObject, SL_IID_ENGINE, &engineEngine);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
   result = (*engineEngine)->CreateOutputMix(engineEngine, &outputMixObject, 0, 0, 0);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
   result = (*outputMixObject)->Realize(outputMixObject, SL_BOOLEAN_FALSE);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
 
   SLDataLocator_AndroidSimpleBufferQueue loc_bufq = {SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, 2};
   SLDataFormat_PCM format_pcm = {SL_DATAFORMAT_PCM,
@@ -87,21 +86,21 @@ bool OpenSLESStream::Init()
   result =
       (*engineEngine)
           ->CreateAudioPlayer(engineEngine, &bqPlayerObject, &audioSrc, &audioSnk, 2, ids, req);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
 
   result = (*bqPlayerObject)->Realize(bqPlayerObject, SL_BOOLEAN_FALSE);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
   result = (*bqPlayerObject)->GetInterface(bqPlayerObject, SL_IID_PLAY, &bqPlayerPlay);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
   result =
       (*bqPlayerObject)->GetInterface(bqPlayerObject, SL_IID_BUFFERQUEUE, &bqPlayerBufferQueue);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
   result = (*bqPlayerObject)->GetInterface(bqPlayerObject, SL_IID_VOLUME, &bqPlayerVolume);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
   result = (*bqPlayerBufferQueue)->RegisterCallback(bqPlayerBufferQueue, bqPlayerCallback, nullptr);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
   result = (*bqPlayerPlay)->SetPlayState(bqPlayerPlay, SL_PLAYSTATE_PLAYING);
-  assert(SL_RESULT_SUCCESS == result);
+  ASSERT(SL_RESULT_SUCCESS == result);
 
   // Render and enqueue a first buffer.
   curBuffer ^= 1;

--- a/Source/Core/AudioCommon/PulseAudioStream.cpp
+++ b/Source/Core/AudioCommon/PulseAudioStream.cpp
@@ -5,6 +5,8 @@
 #include <cstring>
 
 #include "AudioCommon/PulseAudioStream.h"
+
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/Thread.h"
@@ -104,7 +106,7 @@ bool PulseAudio::PulseInit()
   }
   ss.channels = m_channels;
   ss.rate = m_mixer->GetSampleRate();
-  assert(pa_sample_spec_valid(&ss));
+  ASSERT(pa_sample_spec_valid(&ss));
   m_pa_s = pa_stream_new(m_pa_ctx, "Playback", &ss, channel_map_p);
   pa_stream_set_write_callback(m_pa_s, WriteCallback, this);
   pa_stream_set_underflow_callback(m_pa_s, UnderflowCallback, this);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -5,12 +5,12 @@
 #include "Core/HW/GCMemcard/GCMemcard.h"
 
 #include <algorithm>
-#include <cassert>
 #include <cinttypes>
 #include <cstring>
 #include <utility>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/ColorUtil.h"
 #include "Common/CommonFuncs.h"
@@ -240,7 +240,7 @@ std::pair<GCMemcardErrorCode, std::optional<GCMemcard>> GCMemcard::Open(std::str
     else
     {
       // should never reach here
-      assert(0);
+      ASSERT(false);
     }
   }
 
@@ -329,7 +329,7 @@ bool GCMemcard::Save()
 
 static std::pair<u16, u16> CalculateMemcardChecksums(const u8* data, size_t size)
 {
-  assert(size % 2 == 0);
+  ASSERT(size % 2 == 0);
   u16 csum = 0;
   u16 inv_csum = 0;
 
@@ -779,7 +779,7 @@ GCMemcardErrorCode BlockAlloc::CheckForErrors(u16 size_mbits) const
   {
     // check if free block count matches the actual amount of free blocks in m_map
     const u16 total_available_blocks = (size_mbits * MBIT_TO_BLOCKS) - MC_FST_BLOCKS;
-    assert(total_available_blocks <= m_map.size());
+    ASSERT(total_available_blocks <= m_map.size());
     u16 blocks_in_use = 0;
     for (size_t i = 0; i < total_available_blocks; ++i)
     {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardUtils.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardUtils.cpp
@@ -1,10 +1,10 @@
 #include "Core/HW/GCMemcard/GCMemcardUtils.h"
 
 #include <array>
-#include <cassert>
 #include <string>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"
 #include "Common/NandPaths.h"
@@ -330,7 +330,7 @@ std::string GetDefaultExtension(SavefileFormat format)
   case SavefileFormat::SAV:
     return ".sav";
   default:
-    assert(0);
+    ASSERT(false);
     return ".gci";
   }
 }

--- a/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
+++ b/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
@@ -2,11 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <cassert>
+#include "Core/HW/WiimoteCommon/DataReport.h"
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/MathUtil.h"
-#include "Core/HW/WiimoteCommon/DataReport.h"
 
 namespace WiimoteCommon
 {
@@ -308,7 +308,7 @@ std::unique_ptr<DataReportManipulator> MakeDataReportManipulator(InputReportID r
     ptr = std::make_unique<ReportInterleave2>();
     break;
   default:
-    assert(false);
+    ASSERT(false);
     break;
   }
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -5,9 +5,9 @@
 #include "Core/HW/WiimoteEmu/Extension/Classic.h"
 
 #include <array>
-#include <cassert>
 #include <string_view>
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
@@ -204,7 +204,7 @@ ControllerEmu::ControlGroup* Classic::GetGroup(ClassicGroup group)
   case ClassicGroup::RightStick:
     return m_right_stick;
   default:
-    assert(false);
+    ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
@@ -5,8 +5,8 @@
 #include "Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h"
 
 #include <array>
-#include <cassert>
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
@@ -101,7 +101,7 @@ ControllerEmu::ControlGroup* DrawsomeTablet::GetGroup(DrawsomeTabletGroup group)
   case DrawsomeTabletGroup::Touch:
     return m_touch;
   default:
-    assert(false);
+    ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
@@ -4,9 +4,9 @@
 
 #include "Core/HW/WiimoteEmu/Extension/Drums.h"
 
-#include <cassert>
 #include <type_traits>
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
@@ -199,7 +199,7 @@ ControllerEmu::ControlGroup* Drums::GetGroup(DrumsGroup group)
   case DrumsGroup::Stick:
     return m_stick;
   default:
-    assert(false);
+    ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
@@ -5,10 +5,10 @@
 #include "Core/HW/WiimoteEmu/Extension/Guitar.h"
 
 #include <array>
-#include <cassert>
 #include <cstring>
 #include <map>
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
@@ -164,7 +164,7 @@ ControllerEmu::ControlGroup* Guitar::GetGroup(GuitarGroup group)
   case GuitarGroup::SliderBar:
     return m_slider_bar;
   default:
-    assert(false);
+    ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -6,9 +6,9 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <cstring>
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
@@ -170,7 +170,7 @@ ControllerEmu::ControlGroup* Nunchuk::GetGroup(NunchukGroup group)
   case NunchukGroup::IMUAccelerometer:
     return m_imu_accelerometer;
   default:
-    assert(false);
+    ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
@@ -5,9 +5,9 @@
 #include "Core/HW/WiimoteEmu/Extension/TaTaCon.h"
 
 #include <array>
-#include <cassert>
 #include <cstring>
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
@@ -80,7 +80,7 @@ ControllerEmu::ControlGroup* TaTaCon::GetGroup(TaTaConGroup group)
   case TaTaConGroup::Rim:
     return m_rim;
   default:
-    assert(false);
+    ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -5,9 +5,9 @@
 #include "Core/HW/WiimoteEmu/Extension/Turntable.h"
 
 #include <array>
-#include <cassert>
 #include <cstring>
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
@@ -163,7 +163,7 @@ ControllerEmu::ControlGroup* Turntable::GetGroup(TurntableGroup group)
   case TurntableGroup::Crossfade:
     return m_crossfade;
   default:
-    assert(false);
+    ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
@@ -5,8 +5,8 @@
 #include "Core/HW/WiimoteEmu/Extension/UDrawTablet.h"
 
 #include <array>
-#include <cassert>
 
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
@@ -130,7 +130,7 @@ ControllerEmu::ControlGroup* UDrawTablet::GetGroup(UDrawTabletGroup group)
   case UDrawTabletGroup::Touch:
     return m_touch;
   default:
-    assert(false);
+    ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -5,12 +5,12 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include <algorithm>
-#include <cassert>
 #include <memory>
 #include <string_view>
 
 #include <fmt/format.h>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
@@ -338,7 +338,7 @@ ControllerEmu::ControlGroup* Wiimote::GetWiimoteGroup(WiimoteGroup group) const
   case WiimoteGroup::IMUPoint:
     return m_imu_ir;
   default:
-    assert(false);
+    ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -5,7 +5,6 @@
 #include "Core/NetPlayClient.h"
 
 #include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <cstring>
 #include <fstream>
@@ -2026,7 +2025,7 @@ bool NetPlayClient::WiimoteUpdate(int _number, u8* data, const std::size_t size,
     }
   }
 
-  assert(nw.data.size() == size);
+  ASSERT(nw.data.size() == size);
   std::copy(nw.data.begin(), nw.data.end(), data);
   return true;
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -5,7 +5,6 @@
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 
 #include <array>
-#include <cassert>
 #include <cinttypes>
 #include <string>
 

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -5,7 +5,6 @@
 #include "DiscIO/VolumeVerifier.h"
 
 #include <algorithm>
-#include <cassert>
 #include <future>
 #include <limits>
 #include <memory>
@@ -696,7 +695,7 @@ bool VolumeVerifier::ShouldHaveChannelPartition() const
       "RFNE01", "RFNJ01", "RFNK01", "RFNP01", "RFNW01", "RFPE01", "RFPJ01", "RFPK01", "RFPP01",
       "RFPW01", "RGWE41", "RGWJ41", "RGWP41", "RGWX41", "RMCE01", "RMCJ01", "RMCK01", "RMCP01",
   };
-  assert(std::is_sorted(channel_discs.cbegin(), channel_discs.cend()));
+  DEBUG_ASSERT(std::is_sorted(channel_discs.cbegin(), channel_discs.cend()));
 
   return std::binary_search(channel_discs.cbegin(), channel_discs.cend(),
                             std::string_view(m_volume.GetGameID()));
@@ -729,7 +728,7 @@ bool VolumeVerifier::ShouldBeDualLayer() const
       "SLSEXJ", "SLSP01", "SQIE4Q", "SQIP4Q", "SQIY4Q", "SR5E41", "SR5P41", "SUOE41", "SUOP41",
       "SVXX52", "SVXY52", "SX4E01", "SX4P01", "SZ3EGT", "SZ3PGT",
   };
-  assert(std::is_sorted(dual_layer_discs.cbegin(), dual_layer_discs.cend()));
+  DEBUG_ASSERT(std::is_sorted(dual_layer_discs.cbegin(), dual_layer_discs.cend()));
 
   return std::binary_search(dual_layer_discs.cbegin(), dual_layer_discs.cend(),
                             std::string_view(m_volume.GetGameID()));

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -5,7 +5,6 @@
 #include "DolphinQt/GCMemcardManager.h"
 
 #include <algorithm>
-#include <cassert>
 #include <string>
 #include <vector>
 
@@ -29,6 +28,7 @@
 #include <QTimer>
 #include <QToolButton>
 
+#include "Common/Assert.h"
 #include "Common/CommonPaths.h"
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
@@ -387,7 +387,7 @@ static QString GetFormatDescription(Memcard::SavefileFormat format)
   case Memcard::SavefileFormat::SAV:
     return QObject::tr("Datel MaxDrive/Pro files");
   default:
-    assert(0);
+    ASSERT(0);
     return QObject::tr("Native GCI File");
   }
 }

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -2,8 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "InputCommon/ControlReference/ExpressionParser.h"
+
 #include <algorithm>
-#include <cassert>
 #include <cmath>
 #include <functional>
 #include <iostream>
@@ -14,10 +15,10 @@
 #include <utility>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/Common.h"
 #include "Common/StringUtil.h"
 
-#include "InputCommon/ControlReference/ExpressionParser.h"
 #include "InputCommon/ControlReference/FunctionExpression.h"
 
 namespace ciface::ExpressionParser
@@ -384,7 +385,7 @@ public:
       return std::max(std::min(1 - lval, rval), std::min(lval, 1 - rval));
     }
     default:
-      assert(false);
+      ASSERT(false);
       return 0;
     }
   }
@@ -823,7 +824,7 @@ private:
     case TOK_COMMA:
       return 8;
     default:
-      assert(false);
+      ASSERT(false);
       return 0;
     }
   }

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -6,6 +6,10 @@
 #include <cmath>
 #include <cstring>
 
+#ifdef CHECK
+#include "Common/Assert.h"
+#endif
+
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/Intrinsics.h"
@@ -1362,8 +1366,8 @@ static void TexDecoder_DecodeImpl_CMPR(u32* dst, const u8* src, int width, int h
         dst32[(width * 0) + 6] = colors1[(dxt1sel >> ((0 * 8) + 2)) & 3];
         dst32[(width * 0) + 7] = colors1[(dxt1sel >> ((0 * 8) + 0)) & 3];
 #ifdef CHECK
-        assert(memcmp(&(tmp0[0]), &dst32[(width * 0)], 16) == 0);
-        assert(memcmp(&(tmp1[0]), &dst32[(width * 0) + 4], 16) == 0);
+        ASSERT(memcmp(&(tmp0[0]), &dst32[(width * 0)], 16) == 0);
+        ASSERT(memcmp(&(tmp1[0]), &dst32[(width * 0) + 4], 16) == 0);
 #endif
         // Row 1:
         dst32[(width * 1) + 0] = colors0[(dxt0sel >> ((1 * 8) + 6)) & 3];
@@ -1375,8 +1379,8 @@ static void TexDecoder_DecodeImpl_CMPR(u32* dst, const u8* src, int width, int h
         dst32[(width * 1) + 6] = colors1[(dxt1sel >> ((1 * 8) + 2)) & 3];
         dst32[(width * 1) + 7] = colors1[(dxt1sel >> ((1 * 8) + 0)) & 3];
 #ifdef CHECK
-        assert(memcmp(&(tmp0[1]), &dst32[(width * 1)], 16) == 0);
-        assert(memcmp(&(tmp1[1]), &dst32[(width * 1) + 4], 16) == 0);
+        ASSERT(memcmp(&(tmp0[1]), &dst32[(width * 1)], 16) == 0);
+        ASSERT(memcmp(&(tmp1[1]), &dst32[(width * 1) + 4], 16) == 0);
 #endif
         // Row 2:
         dst32[(width * 2) + 0] = colors0[(dxt0sel >> ((2 * 8) + 6)) & 3];
@@ -1388,8 +1392,8 @@ static void TexDecoder_DecodeImpl_CMPR(u32* dst, const u8* src, int width, int h
         dst32[(width * 2) + 6] = colors1[(dxt1sel >> ((2 * 8) + 2)) & 3];
         dst32[(width * 2) + 7] = colors1[(dxt1sel >> ((2 * 8) + 0)) & 3];
 #ifdef CHECK
-        assert(memcmp(&(tmp0[2]), &dst32[(width * 2)], 16) == 0);
-        assert(memcmp(&(tmp1[2]), &dst32[(width * 2) + 4], 16) == 0);
+        ASSERT(memcmp(&(tmp0[2]), &dst32[(width * 2)], 16) == 0);
+        ASSERT(memcmp(&(tmp1[2]), &dst32[(width * 2) + 4], 16) == 0);
 #endif
         // Row 3:
         dst32[(width * 3) + 0] = colors0[(dxt0sel >> ((3 * 8) + 6)) & 3];
@@ -1401,8 +1405,8 @@ static void TexDecoder_DecodeImpl_CMPR(u32* dst, const u8* src, int width, int h
         dst32[(width * 3) + 6] = colors1[(dxt1sel >> ((3 * 8) + 2)) & 3];
         dst32[(width * 3) + 7] = colors1[(dxt1sel >> ((3 * 8) + 0)) & 3];
 #ifdef CHECK
-        assert(memcmp(&(tmp0[3]), &dst32[(width * 3)], 16) == 0);
-        assert(memcmp(&(tmp1[3]), &dst32[(width * 3) + 4], 16) == 0);
+        ASSERT(memcmp(&(tmp0[3]), &dst32[(width * 3)], 16) == 0);
+        ASSERT(memcmp(&(tmp1[3]), &dst32[(width * 3) + 4], 16) == 0);
 #endif
       }
     }


### PR DESCRIPTION
This replaces the standard library `assert` with Dolphin's `ASSERT` macro.

I haven't changed any uses of cassert or assert.h in Externals, nor in pch (because the precompiled headers are used for externals, I'm pretty sure).