### PR TITLE
Core: Fix PauseAndLock segfaulting under certain circumstances

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -750,7 +750,7 @@ void RequestRefreshInfo()
 static bool PauseAndLock(bool do_lock, bool unpause_on_unlock)
 {
   // WARNING: PauseAndLock is not fully threadsafe so is only valid on the Host Thread
-  if (!IsRunning())
+  if (!IsRunningAndStarted())
     return true;
 
   bool was_unpaused = true;


### PR DESCRIPTION
This can happen if it's called before the core has fully initialized, as is happening in https://bugs.dolphin-emu.org/issues/12473.

There might be other side effects from this, so it should probably be tested more thoroughly. Maybe need a mutex?