### PR TITLE
Add new "input override" system for TAS input and Android touch controls

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -280,9 +280,6 @@ public final class NativeLibrary
   public static native void SetMotionSensorsEnabled(boolean accelerometerEnabled,
           boolean gyroscopeEnabled);
 
-  // Angle is in radians and should be non-negative
-  public static native double GetInputRadiusAtAngle(int emu_pad_id, int stick, double angle);
-
   /**
    * Gets the Dolphin version string.
    *

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/InputOverrider.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/InputOverrider.java
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.input.model;
+
+public final class InputOverrider
+{
+  public static final class ControlId
+  {
+    public static final int GCPAD_A_BUTTON = 0;
+    public static final int GCPAD_B_BUTTON = 1;
+    public static final int GCPAD_X_BUTTON = 2;
+    public static final int GCPAD_Y_BUTTON = 3;
+    public static final int GCPAD_Z_BUTTON = 4;
+    public static final int GCPAD_START_BUTTON = 5;
+    public static final int GCPAD_DPAD_UP = 6;
+    public static final int GCPAD_DPAD_DOWN = 7;
+    public static final int GCPAD_DPAD_LEFT = 8;
+    public static final int GCPAD_DPAD_RIGHT = 9;
+    public static final int GCPAD_L_DIGITAL = 10;
+    public static final int GCPAD_R_DIGITAL = 11;
+    public static final int GCPAD_L_ANALOG = 12;
+    public static final int GCPAD_R_ANALOG = 13;
+    public static final int GCPAD_MAIN_STICK_X = 14;
+    public static final int GCPAD_MAIN_STICK_Y = 15;
+    public static final int GCPAD_C_STICK_X = 16;
+    public static final int GCPAD_C_STICK_Y = 17;
+
+    public static final int WIIMOTE_A_BUTTON = 18;
+    public static final int WIIMOTE_B_BUTTON = 19;
+    public static final int WIIMOTE_ONE_BUTTON = 20;
+    public static final int WIIMOTE_TWO_BUTTON = 21;
+    public static final int WIIMOTE_PLUS_BUTTON = 22;
+    public static final int WIIMOTE_MINUS_BUTTON = 23;
+    public static final int WIIMOTE_HOME_BUTTON = 24;
+    public static final int WIIMOTE_DPAD_UP = 25;
+    public static final int WIIMOTE_DPAD_DOWN = 26;
+    public static final int WIIMOTE_DPAD_LEFT = 27;
+    public static final int WIIMOTE_DPAD_RIGHT = 28;
+    public static final int WIIMOTE_IR_X = 29;
+    public static final int WIIMOTE_IR_Y = 30;
+
+    public static final int NUNCHUK_C_BUTTON = 31;
+    public static final int NUNCHUK_Z_BUTTON = 32;
+    public static final int NUNCHUK_STICK_X = 33;
+    public static final int NUNCHUK_STICK_Y = 34;
+
+    public static final int CLASSIC_A_BUTTON = 35;
+    public static final int CLASSIC_B_BUTTON = 36;
+    public static final int CLASSIC_X_BUTTON = 37;
+    public static final int CLASSIC_Y_BUTTON = 38;
+    public static final int CLASSIC_ZL_BUTTON = 39;
+    public static final int CLASSIC_ZR_BUTTON = 40;
+    public static final int CLASSIC_PLUS_BUTTON = 41;
+    public static final int CLASSIC_MINUS_BUTTON = 42;
+    public static final int CLASSIC_HOME_BUTTON = 43;
+    public static final int CLASSIC_DPAD_UP = 44;
+    public static final int CLASSIC_DPAD_DOWN = 45;
+    public static final int CLASSIC_DPAD_LEFT = 46;
+    public static final int CLASSIC_DPAD_RIGHT = 47;
+    public static final int CLASSIC_L_DIGITAL = 48;
+    public static final int CLASSIC_R_DIGITAL = 49;
+    public static final int CLASSIC_L_ANALOG = 50;
+    public static final int CLASSIC_R_ANALOG = 51;
+    public static final int CLASSIC_LEFT_STICK_X = 52;
+    public static final int CLASSIC_LEFT_STICK_Y = 53;
+    public static final int CLASSIC_RIGHT_STICK_X = 54;
+    public static final int CLASSIC_RIGHT_STICK_Y = 55;
+  }
+
+  public static native void registerGameCube(int controllerIndex);
+
+  public static native void registerWii(int controllerIndex);
+
+  public static native void unregisterGameCube(int controllerIndex);
+
+  public static native void unregisterWii(int controllerIndex);
+
+  public static native void setControlState(int controllerIndex, int control, double state);
+
+  public static native void clearControlState(int controllerIndex, int control);
+
+  // Angle is in radians and should be non-negative
+  public static native double getGateRadiusAtAngle(int emuPadId, int stick, double angle);
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -40,8 +40,7 @@ public enum IntSetting implements AbstractIntSetting
           InputOverlayPointer.MODE_FOLLOW),
 
   MAIN_DOUBLE_TAP_BUTTON(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID_OVERLAY_BUTTONS,
-          "DoubleTapButton",
-          InputOverlayPointer.DOUBLE_TAP_OPTIONS.get(InputOverlayPointer.DOUBLE_TAP_A)),
+          "DoubleTapButton", NativeLibrary.ButtonType.WIIMOTE_BUTTON_A),
 
   SYSCONF_LANGUAGE(Settings.FILE_SYSCONF, "IPL", "LNG", 0x01),
   SYSCONF_SOUND_MODE(Settings.FILE_SYSCONF, "IPL", "SND", 0x01),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -139,6 +139,15 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
   }
 
   @Override
+  public void onDestroy()
+  {
+    if (mInputOverlay != null)
+      mInputOverlay.onDestroy();
+
+    super.onDestroy();
+  }
+
+  @Override
   public void onDetach()
   {
     NativeLibrary.clearEmulationActivity();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableButton.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableButton.java
@@ -18,8 +18,9 @@ import android.view.MotionEvent;
  */
 public final class InputOverlayDrawableButton
 {
-  // The ID identifying what type of button this Drawable represents.
-  private int mButtonType;
+  // The legacy ID identifying what type of button this Drawable represents.
+  private int mLegacyId;
+  private int mControl;
   private int mTrackId;
   private int mPreviousTouchX, mPreviousTouchY;
   private int mControlPositionX, mControlPositionY;
@@ -35,28 +36,33 @@ public final class InputOverlayDrawableButton
    * @param res                {@link Resources} instance.
    * @param defaultStateBitmap {@link Bitmap} to use with the default state Drawable.
    * @param pressedStateBitmap {@link Bitmap} to use with the pressed state Drawable.
-   * @param buttonType         Identifier for this type of button.
+   * @param legacyId           Legacy identifier (ButtonType) for this type of button.
+   * @param control            Control ID for this type of button.
    */
   public InputOverlayDrawableButton(Resources res, Bitmap defaultStateBitmap,
-          Bitmap pressedStateBitmap, int buttonType)
+          Bitmap pressedStateBitmap, int legacyId, int control)
   {
     mTrackId = -1;
     mDefaultStateBitmap = new BitmapDrawable(res, defaultStateBitmap);
     mPressedStateBitmap = new BitmapDrawable(res, pressedStateBitmap);
-    mButtonType = buttonType;
+    mLegacyId = legacyId;
+    mControl = control;
 
     mWidth = mDefaultStateBitmap.getIntrinsicWidth();
     mHeight = mDefaultStateBitmap.getIntrinsicHeight();
   }
 
   /**
-   * Gets this InputOverlayDrawableButton's button ID.
-   *
-   * @return this InputOverlayDrawableButton's button ID.
+   * Gets this InputOverlayDrawableButton's legacy button ID.
    */
-  public int getId()
+  public int getLegacyId()
   {
-    return mButtonType;
+    return mLegacyId;
+  }
+
+  public int getControl()
+  {
+    return mControl;
   }
 
   public void setTrackId(int trackId)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableDpad.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableDpad.java
@@ -18,8 +18,9 @@ import android.view.MotionEvent;
  */
 public final class InputOverlayDrawableDpad
 {
-  // The ID identifying what type of button this Drawable represents.
-  private int[] mButtonType = new int[4];
+  // The legacy ID identifying what type of button this Drawable represents.
+  private int mLegacyId;
+  private int[] mControls = new int[4];
   private int mTrackId;
   private int mPreviousTouchX, mPreviousTouchY;
   private int mControlPositionX, mControlPositionY;
@@ -47,17 +48,15 @@ public final class InputOverlayDrawableDpad
    * @param defaultStateBitmap              {@link Bitmap} of the default state.
    * @param pressedOneDirectionStateBitmap  {@link Bitmap} of the pressed state in one direction.
    * @param pressedTwoDirectionsStateBitmap {@link Bitmap} of the pressed state in two direction.
-   * @param buttonUp                        Identifier for the up button.
-   * @param buttonDown                      Identifier for the down button.
-   * @param buttonLeft                      Identifier for the left button.
-   * @param buttonRight                     Identifier for the right button.
+   * @param legacyId                        Legacy identifier (ButtonType) for the up button.
+   * @param upControl                       Control identifier for the up button.
+   * @param downControl                     Control identifier for the down button.
+   * @param leftControl                     Control identifier for the left button.
+   * @param rightControl                    Control identifier for the right button.
    */
-  public InputOverlayDrawableDpad(Resources res,
-          Bitmap defaultStateBitmap,
-          Bitmap pressedOneDirectionStateBitmap,
-          Bitmap pressedTwoDirectionsStateBitmap,
-          int buttonUp, int buttonDown,
-          int buttonLeft, int buttonRight)
+  public InputOverlayDrawableDpad(Resources res, Bitmap defaultStateBitmap,
+          Bitmap pressedOneDirectionStateBitmap, Bitmap pressedTwoDirectionsStateBitmap,
+          int legacyId, int upControl, int downControl, int leftControl, int rightControl)
   {
     mTrackId = -1;
     mDefaultStateBitmap = new BitmapDrawable(res, defaultStateBitmap);
@@ -67,10 +66,11 @@ public final class InputOverlayDrawableDpad
     mWidth = mDefaultStateBitmap.getIntrinsicWidth();
     mHeight = mDefaultStateBitmap.getIntrinsicHeight();
 
-    mButtonType[0] = buttonUp;
-    mButtonType[1] = buttonDown;
-    mButtonType[2] = buttonLeft;
-    mButtonType[3] = buttonRight;
+    mLegacyId = legacyId;
+    mControls[0] = upControl;
+    mControls[1] = downControl;
+    mControls[2] = leftControl;
+    mControls[3] = rightControl;
   }
 
   public void draw(Canvas canvas)
@@ -127,14 +127,17 @@ public final class InputOverlayDrawableDpad
     }
   }
 
-  /**
-   * Gets one of the InputOverlayDrawableDpad's button IDs.
-   *
-   * @return the requested InputOverlayDrawableDpad's button ID.
-   */
-  public int getId(int direction)
+  public int getLegacyId()
   {
-    return mButtonType[direction];
+    return mLegacyId;
+  }
+
+  /**
+   * Gets one of the InputOverlayDrawableDpad's control IDs.
+   */
+  public int getControl(int direction)
+  {
+    return mControls[direction];
   }
 
   public void setTrackId(int trackId)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableJoystick.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableJoystick.java
@@ -12,7 +12,7 @@ import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.view.MotionEvent;
 
-import org.dolphinemu.dolphinemu.NativeLibrary;
+import org.dolphinemu.dolphinemu.features.input.model.InputOverrider;
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
 
 /**
@@ -21,10 +21,12 @@ import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
  */
 public final class InputOverlayDrawableJoystick
 {
-  private final int[] axisIDs = {0, 0, 0, 0};
-  private final float[] axises = {0f, 0f};
+  private float mCurrentX = 0.0f;
+  private float mCurrentY = 0.0f;
   private int trackId = -1;
-  private final int mJoystickType;
+  private final int mJoystickLegacyId;
+  private final int mJoystickXControl;
+  private final int mJoystickYControl;
   private int mControlPositionX, mControlPositionY;
   private int mPreviousTouchX, mPreviousTouchY;
   private final int mWidth;
@@ -47,16 +49,17 @@ public final class InputOverlayDrawableJoystick
    * @param bitmapInnerPressed {@link Bitmap} which represents the pressed inner movable part of the joystick.
    * @param rectOuter          {@link Rect} which represents the outer joystick bounds.
    * @param rectInner          {@link Rect} which represents the inner joystick bounds.
-   * @param joystick           Identifier for which joystick this is.
+   * @param legacyId           Legacy identifier (ButtonType) for which joystick this is.
+   * @param xControl           The control which the x value of the joystick will be written to.
+   * @param yControl           The control which the y value of the joystick will be written to.
    */
   public InputOverlayDrawableJoystick(Resources res, Bitmap bitmapOuter, Bitmap bitmapInnerDefault,
-          Bitmap bitmapInnerPressed, Rect rectOuter, Rect rectInner, int joystick)
+          Bitmap bitmapInnerPressed, Rect rectOuter, Rect rectInner, int legacyId, int xControl,
+          int yControl)
   {
-    axisIDs[0] = joystick + 1;
-    axisIDs[1] = joystick + 2;
-    axisIDs[2] = joystick + 3;
-    axisIDs[3] = joystick + 4;
-    mJoystickType = joystick;
+    mJoystickLegacyId = legacyId;
+    mJoystickXControl = xControl;
+    mJoystickYControl = yControl;
 
     mOuterBitmap = new BitmapDrawable(res, bitmapOuter);
     mDefaultStateInnerBitmap = new BitmapDrawable(res, bitmapInnerDefault);
@@ -76,13 +79,13 @@ public final class InputOverlayDrawableJoystick
   }
 
   /**
-   * Gets this InputOverlayDrawableJoystick's button ID.
+   * Gets this InputOverlayDrawableJoystick's legacy ID.
    *
-   * @return this InputOverlayDrawableJoystick's button ID.
+   * @return this InputOverlayDrawableJoystick's legacy ID.
    */
-  public int getId()
+  public int getLegacyId()
   {
-    return mJoystickType;
+    return mJoystickLegacyId;
   }
 
   public void draw(Canvas canvas)
@@ -125,7 +128,7 @@ public final class InputOverlayDrawableJoystick
         {
           pressed = true;
           mPressedState = false;
-          axises[0] = axises[1] = 0.0f;
+          mCurrentX = mCurrentY = 0.0f;
           mOuterBitmap.setAlpha(mOpacity);
           mBoundsBoxBitmap.setAlpha(0);
           setVirtBounds(new Rect(mOrigBounds.left, mOrigBounds.top, mOrigBounds.right,
@@ -153,10 +156,8 @@ public final class InputOverlayDrawableJoystick
         maxX -= getVirtBounds().centerX();
         touchY -= getVirtBounds().centerY();
         maxY -= getVirtBounds().centerY();
-        final float AxisX = touchX / maxX;
-        final float AxisY = touchY / maxY;
-        axises[0] = AxisY;
-        axises[1] = AxisX;
+        mCurrentX = touchX / maxX;
+        mCurrentY = touchY / maxY;
 
         SetInnerBounds();
       }
@@ -193,36 +194,40 @@ public final class InputOverlayDrawableJoystick
     }
   }
 
-
-  public float[] getAxisValues()
+  public float getX()
   {
-    float[] joyaxises = {0f, 0f, 0f, 0f};
-    joyaxises[1] = Math.min(axises[0], 1.0f);
-    joyaxises[0] = Math.min(axises[0], 0.0f);
-    joyaxises[3] = Math.min(axises[1], 1.0f);
-    joyaxises[2] = Math.min(axises[1], 0.0f);
-    return joyaxises;
+    return mCurrentX;
   }
 
-  public int[] getAxisIDs()
+  public float getY()
   {
-    return axisIDs;
+    return mCurrentY;
+  }
+
+  public int getXControl()
+  {
+    return mJoystickXControl;
+  }
+
+  public int getYControl()
+  {
+    return mJoystickYControl;
   }
 
   private void SetInnerBounds()
   {
-    double y = axises[0];
-    double x = axises[1];
+    double x = mCurrentX;
+    double y = mCurrentY;
 
     double angle = Math.atan2(y, x) + Math.PI + Math.PI;
     double radius = Math.hypot(y, x);
-    double maxRadius = NativeLibrary.GetInputRadiusAtAngle(0, mJoystickType, angle);
+    double maxRadius = InputOverrider.getGateRadiusAtAngle(0, mJoystickXControl, angle);
     if (radius > maxRadius)
     {
       y = maxRadius * Math.sin(angle);
       x = maxRadius * Math.cos(angle);
-      axises[0] = (float) y;
-      axises[1] = (float) x;
+      mCurrentY = (float) y;
+      mCurrentX = (float) x;
     }
 
     int pixelX = getVirtBounds().centerX() + (int) (x * (getVirtBounds().width() / 2));

--- a/Source/Android/jni/CMakeLists.txt
+++ b/Source/Android/jni/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(main SHARED
   GameList/GameFile.cpp
   GameList/GameFile.h
   GameList/GameFileCache.cpp
+  Input/InputOverrider.cpp
   IniFile.cpp
   MainAndroid.cpp
   RiivolutionPatches.cpp

--- a/Source/Android/jni/Input/InputOverrider.cpp
+++ b/Source/Android/jni/Input/InputOverrider.cpp
@@ -1,0 +1,62 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <jni.h>
+
+#include "InputCommon/ControllerInterface/Touch/InputOverrider.h"
+
+extern "C" {
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_registerGameCube(
+    JNIEnv*, jclass, int controller_index)
+{
+  ciface::Touch::RegisterGameCubeInputOverrider(controller_index);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_registerWii(JNIEnv*, jclass,
+                                                                               int controller_index)
+{
+  ciface::Touch::RegisterWiiInputOverrider(controller_index);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_unregisterGameCube(
+    JNIEnv*, jclass, int controller_index)
+{
+  ciface::Touch::UnregisterGameCubeInputOverrider(controller_index);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_unregisterWii(
+    JNIEnv*, jclass, int controller_index)
+{
+  ciface::Touch::UnregisterWiiInputOverrider(controller_index);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_setControlState(
+    JNIEnv*, jclass, int controller_index, int control, double state)
+{
+  ciface::Touch::SetControlState(controller_index, static_cast<ciface::Touch::ControlID>(control),
+                                 state);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_clearControlState(
+    JNIEnv*, jclass, int controller_index, int control)
+{
+  ciface::Touch::ClearControlState(controller_index,
+                                   static_cast<ciface::Touch::ControlID>(control));
+}
+
+JNIEXPORT double JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_getGateRadiusAtAngle(
+    JNIEnv*, jclass, int controller_index, int stick, double angle)
+{
+  const auto casted_stick = static_cast<ciface::Touch::ControlID>(stick);
+  return ciface::Touch::GetGateRadiusAtAngle(controller_index, casted_stick, angle);
+}
+};

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -302,13 +302,6 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetMotionSen
   ciface::Android::SetMotionSensorsEnabled(accelerometer_enabled, gyroscope_enabled);
 }
 
-JNIEXPORT double JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetInputRadiusAtAngle(
-    JNIEnv*, jclass, int emu_pad_id, int stick, double angle)
-{
-  const auto casted_stick = static_cast<ButtonManager::ButtonType>(stick);
-  return ButtonManager::GetInputRadiusAtAngle(emu_pad_id, casted_stick, angle);
-}
-
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetVersionString(JNIEnv* env,
                                                                                         jclass)
 {

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -138,14 +138,15 @@ GCPadStatus GCPad::GetInput() const
   const auto lock = GetStateLock();
   GCPadStatus pad = {};
 
-  if (!(m_always_connected_setting.GetValue() || IsDefaultDeviceConnected()))
+  if (!(m_always_connected_setting.GetValue() || IsDefaultDeviceConnected() ||
+        m_input_override_function))
   {
     pad.isConnected = false;
     return pad;
   }
 
   // buttons
-  m_buttons->GetState(&pad.button, button_bitmasks);
+  m_buttons->GetState(&pad.button, button_bitmasks, m_input_override_function);
 
   // set analog A/B analog to full or w/e, prolly not needed
   if (pad.button & PAD_BUTTON_A)
@@ -154,20 +155,20 @@ GCPadStatus GCPad::GetInput() const
     pad.analogB = 0xFF;
 
   // dpad
-  m_dpad->GetState(&pad.button, dpad_bitmasks);
+  m_dpad->GetState(&pad.button, dpad_bitmasks, m_input_override_function);
 
   // sticks
-  const auto main_stick_state = m_main_stick->GetState();
+  const auto main_stick_state = m_main_stick->GetState(m_input_override_function);
   pad.stickX = MapFloat<u8>(main_stick_state.x, GCPadStatus::MAIN_STICK_CENTER_X, 1);
   pad.stickY = MapFloat<u8>(main_stick_state.y, GCPadStatus::MAIN_STICK_CENTER_Y, 1);
 
-  const auto c_stick_state = m_c_stick->GetState();
+  const auto c_stick_state = m_c_stick->GetState(m_input_override_function);
   pad.substickX = MapFloat<u8>(c_stick_state.x, GCPadStatus::C_STICK_CENTER_X, 1);
   pad.substickY = MapFloat<u8>(c_stick_state.y, GCPadStatus::C_STICK_CENTER_Y, 1);
 
   // triggers
   std::array<ControlState, 2> triggers;
-  m_triggers->GetState(&pad.button, trigger_bitmasks, triggers.data());
+  m_triggers->GetState(&pad.button, trigger_bitmasks, triggers.data(), m_input_override_function);
   pad.triggerLeft = MapFloat<u8>(triggers[0], 0);
   pad.triggerRight = MapFloat<u8>(triggers[1], 0);
 

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -36,62 +36,47 @@ static const u16 trigger_bitmasks[] = {
 static const u16 dpad_bitmasks[] = {PAD_BUTTON_UP, PAD_BUTTON_DOWN, PAD_BUTTON_LEFT,
                                     PAD_BUTTON_RIGHT};
 
-static const char* const named_buttons[] = {"A", "B", "X", "Y", "Z", "Start"};
-
-static const char* const named_triggers[] = {
-    // i18n: The left trigger button (labeled L on real controllers)
-    _trans("L"),
-    // i18n: The right trigger button (labeled R on real controllers)
-    _trans("R"),
-    // i18n: The left trigger button (labeled L on real controllers) used as an analog input
-    _trans("L-Analog"),
-    // i18n: The right trigger button (labeled R on real controllers) used as an analog input
-    _trans("R-Analog")};
-
 GCPad::GCPad(const unsigned int index) : m_index(index)
 {
   // buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  for (const char* named_button : named_buttons)
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(BUTTONS_GROUP));
+  for (const char* named_button : {A_BUTTON, B_BUTTON, X_BUTTON, Y_BUTTON, Z_BUTTON})
   {
-    const bool is_start = named_button == std::string("Start");
-    const ControllerEmu::Translatability translate =
-        is_start ? ControllerEmu::Translate : ControllerEmu::DoNotTranslate;
-    // i18n: The START/PAUSE button on GameCube controllers
-    std::string ui_name = is_start ? _trans("START") : named_button;
-    m_buttons->AddInput(translate, named_button, std::move(ui_name));
+    m_buttons->AddInput(ControllerEmu::DoNotTranslate, named_button);
   }
+  // i18n: The START/PAUSE button on GameCube controllers
+  m_buttons->AddInput(ControllerEmu::Translate, START_BUTTON, _trans("START"));
 
   // sticks
   groups.emplace_back(m_main_stick = new ControllerEmu::OctagonAnalogStick(
-                          "Main Stick", _trans("Control Stick"), MAIN_STICK_GATE_RADIUS));
+                          MAIN_STICK_GROUP, _trans("Control Stick"), MAIN_STICK_GATE_RADIUS));
   groups.emplace_back(m_c_stick = new ControllerEmu::OctagonAnalogStick(
-                          "C-Stick", _trans("C Stick"), C_STICK_GATE_RADIUS));
+                          C_STICK_GROUP, _trans("C Stick"), C_STICK_GATE_RADIUS));
 
   // triggers
-  groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));
-  for (const char* named_trigger : named_triggers)
+  groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(TRIGGERS_GROUP));
+  for (const char* named_trigger : {L_DIGITAL, R_DIGITAL, L_ANALOG, R_ANALOG})
   {
     m_triggers->AddInput(ControllerEmu::Translate, named_trigger);
   }
 
   // rumble
-  groups.emplace_back(m_rumble = new ControllerEmu::ControlGroup(_trans("Rumble")));
+  groups.emplace_back(m_rumble = new ControllerEmu::ControlGroup(RUMBLE_GROUP));
   m_rumble->AddOutput(ControllerEmu::Translate, _trans("Motor"));
 
   // Microphone
-  groups.emplace_back(m_mic = new ControllerEmu::Buttons(_trans("Microphone")));
+  groups.emplace_back(m_mic = new ControllerEmu::Buttons(MIC_GROUP));
   m_mic->AddInput(ControllerEmu::Translate, _trans("Button"));
 
   // dpad
-  groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
+  groups.emplace_back(m_dpad = new ControllerEmu::Buttons(DPAD_GROUP));
   for (const char* named_direction : named_directions)
   {
     m_dpad->AddInput(ControllerEmu::Translate, named_direction);
   }
 
   // options
-  groups.emplace_back(m_options = new ControllerEmu::ControlGroup(_trans("Options")));
+  groups.emplace_back(m_options = new ControllerEmu::ControlGroup(OPTIONS_GROUP));
   m_options->AddSetting(
       &m_always_connected_setting,
       // i18n: Treat a controller as always being connected regardless of what

--- a/Source/Core/Core/HW/GCPadEmu.h
+++ b/Source/Core/Core/HW/GCPadEmu.h
@@ -5,6 +5,8 @@
 
 #include <string>
 
+#include "Common/Common.h"
+
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
@@ -48,6 +50,31 @@ public:
   // Values averaged from multiple genuine GameCube controllers.
   static constexpr ControlState MAIN_STICK_GATE_RADIUS = 0.7937125;
   static constexpr ControlState C_STICK_GATE_RADIUS = 0.7221375;
+
+  static constexpr const char* BUTTONS_GROUP = _trans("Buttons");
+  static constexpr const char* MAIN_STICK_GROUP = "Main Stick";
+  static constexpr const char* C_STICK_GROUP = "C-Stick";
+  static constexpr const char* DPAD_GROUP = _trans("D-Pad");
+  static constexpr const char* TRIGGERS_GROUP = _trans("Triggers");
+  static constexpr const char* RUMBLE_GROUP = _trans("Rumble");
+  static constexpr const char* MIC_GROUP = _trans("Microphone");
+  static constexpr const char* OPTIONS_GROUP = _trans("Options");
+
+  static constexpr const char* A_BUTTON = "A";
+  static constexpr const char* B_BUTTON = "B";
+  static constexpr const char* X_BUTTON = "X";
+  static constexpr const char* Y_BUTTON = "Y";
+  static constexpr const char* Z_BUTTON = "Z";
+  static constexpr const char* START_BUTTON = "Start";
+
+  // i18n: The left trigger button (labeled L on real controllers)
+  static constexpr const char* L_DIGITAL = _trans("L");
+  // i18n: The right trigger button (labeled R on real controllers)
+  static constexpr const char* R_DIGITAL = _trans("R");
+  // i18n: The left trigger button (labeled L on real controllers) used as an analog input
+  static constexpr const char* L_ANALOG = _trans("L-Analog");
+  // i18n: The right trigger button (labeled R on real controllers) used as an analog input
+  static constexpr const char* R_ANALOG = _trans("R-Analog");
 
 private:
   ControllerEmu::Buttons* m_buttons;

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -119,8 +119,6 @@ int CSIDevice_GCController::RunBuffer(u8* buffer, int request_length)
 
 void CSIDevice_GCController::HandleMoviePadStatus(int device_number, GCPadStatus* pad_status)
 {
-  Movie::CallGCInputManip(pad_status, device_number);
-
   Movie::SetPolledDevice();
   if (NetPlay_GetInput(device_number, pad_status))
   {

--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <optional>
 
 #include "Common/MathUtil.h"
 #include "Core/Config/SYSCONFSettings.h"
@@ -221,9 +222,10 @@ WiimoteCommon::AccelData ConvertAccelData(const Common::Vec3& accel, u16 zero_g,
        u16(std::clamp(std::lround(scaled_accel.z + zero_g), 0l, MAX_VALUE))});
 }
 
-void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group, float time_elapsed)
+void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group,
+                  const ControllerEmu::InputOverrideFunction& override_func, float time_elapsed)
 {
-  const auto cursor = ir_group->GetState(true);
+  const auto cursor = ir_group->GetState(true, override_func);
 
   if (!cursor.IsVisible())
   {

--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
@@ -15,6 +15,7 @@
 #include "InputCommon/ControllerEmu/ControlGroup/IMUCursor.h"
 #include "InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Tilt.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
 
 namespace WiimoteEmu
 {
@@ -81,7 +82,8 @@ void ApproachAngleWithAccel(RotationalState* state, const Common::Vec3& target, 
 void EmulateShake(PositionalState* state, ControllerEmu::Shake* shake_group, float time_elapsed);
 void EmulateTilt(RotationalState* state, ControllerEmu::Tilt* tilt_group, float time_elapsed);
 void EmulateSwing(MotionState* state, ControllerEmu::Force* swing_group, float time_elapsed);
-void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group, float time_elapsed);
+void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group,
+                  const ControllerEmu::InputOverrideFunction& override_func, float time_elapsed);
 void EmulateIMUCursor(IMUCursorState* state, ControllerEmu::IMUCursor* imu_ir_group,
                       ControllerEmu::IMUAccelerometer* imu_accelerometer_group,
                       ControllerEmu::IMUGyroscope* imu_gyroscope_group, float time_elapsed);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -86,7 +86,7 @@ Classic::Classic() : Extension1stParty("Classic", _trans("Classic Controller"))
   }
 
   // sticks
-  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / CAL_STICK_RANGE;
+  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / CAL_STICK_RADIUS;
   groups.emplace_back(m_left_stick =
                           new ControllerEmu::OctagonAnalogStick(_trans("Left Stick"), gate_radius));
   groups.emplace_back(
@@ -116,8 +116,8 @@ void Classic::BuildDesiredExtensionState(DesiredExtensionState* target_state)
     const ControllerEmu::AnalogStick::StateData left_stick_state =
         m_left_stick->GetState(m_input_override_function);
 
-    const u8 x = static_cast<u8>(LEFT_STICK_CENTER + (left_stick_state.x * LEFT_STICK_RADIUS));
-    const u8 y = static_cast<u8>(LEFT_STICK_CENTER + (left_stick_state.y * LEFT_STICK_RADIUS));
+    const u8 x = MapFloat<u8>(left_stick_state.x, LEFT_STICK_CENTER, 0, LEFT_STICK_RANGE);
+    const u8 y = MapFloat<u8>(left_stick_state.y, LEFT_STICK_CENTER, 0, LEFT_STICK_RANGE);
 
     classic_data.SetLeftStick({x, y});
   }
@@ -127,8 +127,8 @@ void Classic::BuildDesiredExtensionState(DesiredExtensionState* target_state)
     const ControllerEmu::AnalogStick::StateData right_stick_data =
         m_right_stick->GetState(m_input_override_function);
 
-    const u8 x = static_cast<u8>(RIGHT_STICK_CENTER + (right_stick_data.x * RIGHT_STICK_RADIUS));
-    const u8 y = static_cast<u8>(RIGHT_STICK_CENTER + (right_stick_data.y * RIGHT_STICK_RADIUS));
+    const u8 x = MapFloat<u8>(right_stick_data.x, RIGHT_STICK_CENTER, 0, RIGHT_STICK_RANGE);
+    const u8 y = MapFloat<u8>(right_stick_data.y, RIGHT_STICK_CENTER, 0, RIGHT_STICK_RANGE);
 
     classic_data.SetRightStick({x, y});
   }
@@ -141,8 +141,8 @@ void Classic::BuildDesiredExtensionState(DesiredExtensionState* target_state)
     m_triggers->GetState(&buttons, classic_trigger_bitmasks.data(), triggers,
                          m_input_override_function);
 
-    const u8 lt = static_cast<u8>(triggers[0] * TRIGGER_RANGE);
-    const u8 rt = static_cast<u8>(triggers[1] * TRIGGER_RANGE);
+    const u8 lt = MapFloat<u8>(triggers[0], 0, 0, TRIGGER_RANGE);
+    const u8 rt = MapFloat<u8>(triggers[1], 0, 0, TRIGGER_RANGE);
 
     classic_data.SetLeftTrigger(lt);
     classic_data.SetRightTrigger(rt);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -39,32 +39,9 @@ constexpr std::array<u16, 9> classic_button_bitmasks{{
     Classic::BUTTON_HOME,
 }};
 
-constexpr std::array<std::string_view, 9> classic_button_names{{
-    "A",
-    "B",
-    "X",
-    "Y",
-    "ZL",
-    "ZR",
-    "-",
-    "+",
-    "Home",
-}};
-
 constexpr std::array<u16, 2> classic_trigger_bitmasks{{
     Classic::TRIGGER_L,
     Classic::TRIGGER_R,
-}};
-
-constexpr std::array<const char*, 4> classic_trigger_names{{
-    // i18n: The left trigger button (labeled L on real controllers)
-    _trans("L"),
-    // i18n: The right trigger button (labeled R on real controllers)
-    _trans("R"),
-    // i18n: The left trigger button (labeled L on real controllers) used as an analog input
-    _trans("L-Analog"),
-    // i18n: The right trigger button (labeled R on real controllers) used as an analog input
-    _trans("R-Analog"),
 }};
 
 constexpr std::array<u16, 4> classic_dpad_bitmasks{{
@@ -77,30 +54,30 @@ constexpr std::array<u16, 4> classic_dpad_bitmasks{{
 Classic::Classic() : Extension1stParty("Classic", _trans("Classic Controller"))
 {
   // buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  for (auto& button_name : classic_button_names)
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(BUTTONS_GROUP));
+  for (auto& button_name :
+       {A_BUTTON, B_BUTTON, X_BUTTON, Y_BUTTON, ZL_BUTTON, ZR_BUTTON, MINUS_BUTTON, PLUS_BUTTON})
   {
-    std::string_view ui_name = (button_name == "Home") ? "HOME" : button_name;
-    m_buttons->AddInput(ControllerEmu::DoNotTranslate, std::string(button_name),
-                        std::string(ui_name));
+    m_buttons->AddInput(ControllerEmu::DoNotTranslate, button_name);
   }
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, HOME_BUTTON, "HOME");
 
   // sticks
   constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / CAL_STICK_RADIUS;
   groups.emplace_back(m_left_stick =
-                          new ControllerEmu::OctagonAnalogStick(_trans("Left Stick"), gate_radius));
-  groups.emplace_back(
-      m_right_stick = new ControllerEmu::OctagonAnalogStick(_trans("Right Stick"), gate_radius));
+                          new ControllerEmu::OctagonAnalogStick(LEFT_STICK_GROUP, gate_radius));
+  groups.emplace_back(m_right_stick =
+                          new ControllerEmu::OctagonAnalogStick(RIGHT_STICK_GROUP, gate_radius));
 
   // triggers
-  groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));
-  for (const char* trigger_name : classic_trigger_names)
+  groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(TRIGGERS_GROUP));
+  for (const char* trigger_name : {L_DIGITAL, R_DIGITAL, L_ANALOG, R_ANALOG})
   {
     m_triggers->AddInput(ControllerEmu::Translate, trigger_name);
   }
 
   // dpad
-  groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
+  groups.emplace_back(m_dpad = new ControllerEmu::Buttons(DPAD_GROUP));
   for (const char* named_direction : named_directions)
   {
     m_dpad->AddInput(ControllerEmu::Translate, named_direction);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -113,7 +113,8 @@ void Classic::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 
   // left stick
   {
-    const ControllerEmu::AnalogStick::StateData left_stick_state = m_left_stick->GetState();
+    const ControllerEmu::AnalogStick::StateData left_stick_state =
+        m_left_stick->GetState(m_input_override_function);
 
     const u8 x = static_cast<u8>(LEFT_STICK_CENTER + (left_stick_state.x * LEFT_STICK_RADIUS));
     const u8 y = static_cast<u8>(LEFT_STICK_CENTER + (left_stick_state.y * LEFT_STICK_RADIUS));
@@ -123,7 +124,8 @@ void Classic::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 
   // right stick
   {
-    const ControllerEmu::AnalogStick::StateData right_stick_data = m_right_stick->GetState();
+    const ControllerEmu::AnalogStick::StateData right_stick_data =
+        m_right_stick->GetState(m_input_override_function);
 
     const u8 x = static_cast<u8>(RIGHT_STICK_CENTER + (right_stick_data.x * RIGHT_STICK_RADIUS));
     const u8 y = static_cast<u8>(RIGHT_STICK_CENTER + (right_stick_data.y * RIGHT_STICK_RADIUS));
@@ -135,19 +137,20 @@ void Classic::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 
   // triggers
   {
-    ControlState trigs[2] = {0, 0};
-    m_triggers->GetState(&buttons, classic_trigger_bitmasks.data(), trigs);
+    ControlState triggers[2] = {0, 0};
+    m_triggers->GetState(&buttons, classic_trigger_bitmasks.data(), triggers,
+                         m_input_override_function);
 
-    const u8 lt = static_cast<u8>(trigs[0] * TRIGGER_RANGE);
-    const u8 rt = static_cast<u8>(trigs[1] * TRIGGER_RANGE);
+    const u8 lt = static_cast<u8>(triggers[0] * TRIGGER_RANGE);
+    const u8 rt = static_cast<u8>(triggers[1] * TRIGGER_RANGE);
 
     classic_data.SetLeftTrigger(lt);
     classic_data.SetRightTrigger(rt);
   }
 
   // buttons and dpad
-  m_buttons->GetState(&buttons, classic_button_bitmasks.data());
-  m_dpad->GetState(&buttons, classic_dpad_bitmasks.data());
+  m_buttons->GetState(&buttons, classic_button_bitmasks.data(), m_input_override_function);
+  m_dpad->GetState(&buttons, classic_dpad_bitmasks.data(), m_input_override_function);
 
   classic_data.SetButtons(buttons);
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
@@ -216,6 +216,31 @@ public:
 
   static constexpr u8 TRIGGER_RANGE = 0x1F;
 
+  static constexpr const char* BUTTONS_GROUP = _trans("Buttons");
+  static constexpr const char* LEFT_STICK_GROUP = _trans("Left Stick");
+  static constexpr const char* RIGHT_STICK_GROUP = _trans("Right Stick");
+  static constexpr const char* TRIGGERS_GROUP = _trans("Triggers");
+  static constexpr const char* DPAD_GROUP = _trans("D-Pad");
+
+  static constexpr const char* A_BUTTON = "A";
+  static constexpr const char* B_BUTTON = "B";
+  static constexpr const char* X_BUTTON = "X";
+  static constexpr const char* Y_BUTTON = "Y";
+  static constexpr const char* ZL_BUTTON = "ZL";
+  static constexpr const char* ZR_BUTTON = "ZR";
+  static constexpr const char* MINUS_BUTTON = "-";
+  static constexpr const char* PLUS_BUTTON = "+";
+  static constexpr const char* HOME_BUTTON = "Home";
+
+  // i18n: The left trigger button (labeled L on real controllers)
+  static constexpr const char* L_DIGITAL = _trans("L");
+  // i18n: The right trigger button (labeled R on real controllers)
+  static constexpr const char* R_DIGITAL = _trans("R");
+  // i18n: The left trigger button (labeled L on real controllers) used as an analog input
+  static constexpr const char* L_ANALOG = _trans("L-Analog");
+  // i18n: The right trigger button (labeled R on real controllers) used as an analog input
+  static constexpr const char* R_ANALOG = _trans("R-Analog");
+
 private:
   ControllerEmu::Buttons* m_buttons;
   ControllerEmu::MixedTriggers* m_triggers;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
@@ -205,13 +205,14 @@ public:
   static constexpr u8 STICK_GATE_RADIUS = 0x61;
 
   static constexpr u8 CAL_STICK_CENTER = 0x80;
-  static constexpr u8 CAL_STICK_RANGE = 0x7f;
+  static constexpr u8 CAL_STICK_RADIUS = 0x7f;
+  static constexpr u8 CAL_STICK_RANGE = 0xff;
 
   static constexpr u8 LEFT_STICK_CENTER = CAL_STICK_CENTER >> (CAL_STICK_BITS - LEFT_STICK_BITS);
-  static constexpr u8 LEFT_STICK_RADIUS = CAL_STICK_RANGE >> (CAL_STICK_BITS - LEFT_STICK_BITS);
+  static constexpr u8 LEFT_STICK_RANGE = CAL_STICK_RANGE >> (CAL_STICK_BITS - LEFT_STICK_BITS);
 
   static constexpr u8 RIGHT_STICK_CENTER = CAL_STICK_CENTER >> (CAL_STICK_BITS - RIGHT_STICK_BITS);
-  static constexpr u8 RIGHT_STICK_RADIUS = CAL_STICK_RANGE >> (CAL_STICK_BITS - RIGHT_STICK_BITS);
+  static constexpr u8 RIGHT_STICK_RANGE = CAL_STICK_RANGE >> (CAL_STICK_BITS - RIGHT_STICK_BITS);
 
   static constexpr u8 TRIGGER_RANGE = 0x1F;
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
@@ -44,12 +44,12 @@ void DrawsomeTablet::BuildDesiredExtensionState(DesiredExtensionState* target_st
   // the "Drawsome" game expects you to go "off screen" a bit to access some menu items.
   constexpr u16 MIN_Y = 0x15ff + 0x100;
   constexpr u16 MAX_Y = 0x00;
-  constexpr double CENTER_X = (MAX_X + MIN_X) / 2.0;
-  constexpr double CENTER_Y = (MAX_Y + MIN_Y) / 2.0;
+  constexpr u16 CENTER_X = (MAX_X + MIN_X + 1) / 2;
+  constexpr u16 CENTER_Y = (MAX_Y + MIN_Y + 1) / 2;
 
   const auto stylus_state = m_stylus->GetState(m_input_override_function);
-  const auto stylus_x = u16(std::lround(CENTER_X + stylus_state.x * (MAX_X - CENTER_X)));
-  const auto stylus_y = u16(std::lround(CENTER_Y + stylus_state.y * (MAX_Y - CENTER_Y)));
+  const u16 stylus_x = MapFloat<u16>(stylus_state.x, CENTER_X, MIN_X, MAX_X);
+  const u16 stylus_y = MapFloat<u16>(-stylus_state.y, CENTER_Y, MAX_Y, MIN_Y);
 
   tablet_data.stylus_x1 = u8(stylus_x);
   tablet_data.stylus_x2 = u8(stylus_x >> 8);
@@ -75,7 +75,7 @@ void DrawsomeTablet::BuildDesiredExtensionState(DesiredExtensionState* target_st
   constexpr u16 MAX_PRESSURE = 0x7ff;
 
   const auto touch_state = m_touch->GetState(m_input_override_function);
-  const auto pressure = u16(std::lround(touch_state.data[0] * MAX_PRESSURE));
+  const u16 pressure = MapFloat<u16>(touch_state.data[0], 0, 0, MAX_PRESSURE);
 
   tablet_data.pressure1 = u8(pressure);
   tablet_data.pressure2 = u8(pressure >> 8);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
@@ -47,7 +47,7 @@ void DrawsomeTablet::BuildDesiredExtensionState(DesiredExtensionState* target_st
   constexpr double CENTER_X = (MAX_X + MIN_X) / 2.0;
   constexpr double CENTER_Y = (MAX_Y + MIN_Y) / 2.0;
 
-  const auto stylus_state = m_stylus->GetState();
+  const auto stylus_state = m_stylus->GetState(m_input_override_function);
   const auto stylus_x = u16(std::lround(CENTER_X + stylus_state.x * (MAX_X - CENTER_X)));
   const auto stylus_y = u16(std::lround(CENTER_Y + stylus_state.y * (MAX_Y - CENTER_Y)));
 
@@ -74,7 +74,7 @@ void DrawsomeTablet::BuildDesiredExtensionState(DesiredExtensionState* target_st
   // Pressure (0 - 0x7ff):
   constexpr u16 MAX_PRESSURE = 0x7ff;
 
-  const auto touch_state = m_touch->GetState();
+  const auto touch_state = m_touch->GetState(m_input_override_function);
   const auto pressure = u16(std::lround(touch_state.data[0] * MAX_PRESSURE));
 
   tablet_data.pressure1 = u8(pressure);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
@@ -84,17 +84,18 @@ void Drums::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   DesiredState& state = target_state->data.emplace<DesiredState>();
 
   {
-    const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
+    const ControllerEmu::AnalogStick::StateData stick_state =
+        m_stick->GetState(m_input_override_function);
 
     state.stick_x = MapFloat(stick_state.x, STICK_CENTER, STICK_MIN, STICK_MAX);
     state.stick_y = MapFloat(stick_state.y, STICK_CENTER, STICK_MIN, STICK_MAX);
   }
 
   state.buttons = 0;
-  m_buttons->GetState(&state.buttons, drum_button_bitmasks.data());
+  m_buttons->GetState(&state.buttons, drum_button_bitmasks.data(), m_input_override_function);
 
   state.drum_pads = 0;
-  m_pads->GetState(&state.drum_pads, drum_pad_bitmasks.data());
+  m_pads->GetState(&state.drum_pads, drum_pad_bitmasks.data(), m_input_override_function);
 
   state.softness = u8(7 - std::lround(m_hit_strength_setting.GetValue() * 7 / 100));
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
@@ -87,6 +87,8 @@ void Drums::BuildDesiredExtensionState(DesiredExtensionState* target_state)
     const ControllerEmu::AnalogStick::StateData stick_state =
         m_stick->GetState(m_input_override_function);
 
+    state.stick_x = MapFloat<u8>(stick_state.x, STICK_CENTER, STICK_MIN, STICK_MAX);
+    state.stick_y = MapFloat<u8>(stick_state.y, STICK_CENTER, STICK_MIN, STICK_MAX);
     state.stick_x = MapFloat(stick_state.x, STICK_CENTER, STICK_MIN, STICK_MAX);
     state.stick_y = MapFloat(stick_state.y, STICK_CENTER, STICK_MIN, STICK_MAX);
   }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
@@ -101,7 +101,8 @@ void Guitar::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 
   // stick
   {
-    const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
+    const ControllerEmu::AnalogStick::StateData stick_state =
+        m_stick->GetState(m_input_override_function);
 
     guitar_data.sx = static_cast<u8>((stick_state.x * STICK_RADIUS) + STICK_CENTER);
     guitar_data.sy = static_cast<u8>((stick_state.y * STICK_RADIUS) + STICK_CENTER);
@@ -111,7 +112,8 @@ void Guitar::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   if (m_slider_bar->controls[0]->control_ref->BoundCount() &&
       m_slider_bar->controls[1]->control_ref->BoundCount())
   {
-    const ControllerEmu::Slider::StateData slider_data = m_slider_bar->GetState();
+    const ControllerEmu::Slider::StateData slider_data =
+        m_slider_bar->GetState(m_input_override_function);
 
     guitar_data.sb = s_slider_bar_control_codes.lower_bound(slider_data.value)->second;
   }
@@ -122,17 +124,18 @@ void Guitar::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   }
 
   // whammy bar
-  const ControllerEmu::Triggers::StateData whammy_state = m_whammy->GetState();
+  const ControllerEmu::Triggers::StateData whammy_state =
+      m_whammy->GetState(m_input_override_function);
   guitar_data.whammy = static_cast<u8>(whammy_state.data[0] * 0x1F);
 
   // buttons
-  m_buttons->GetState(&guitar_data.bt, guitar_button_bitmasks.data());
+  m_buttons->GetState(&guitar_data.bt, guitar_button_bitmasks.data(), m_input_override_function);
 
   // frets
-  m_frets->GetState(&guitar_data.bt, guitar_fret_bitmasks.data());
+  m_frets->GetState(&guitar_data.bt, guitar_fret_bitmasks.data(), m_input_override_function);
 
   // strum
-  m_strum->GetState(&guitar_data.bt, guitar_strum_bitmasks.data());
+  m_strum->GetState(&guitar_data.bt, guitar_strum_bitmasks.data(), m_input_override_function);
 
   // flip button bits
   guitar_data.bt ^= 0xFFFF;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
@@ -104,8 +104,8 @@ void Guitar::BuildDesiredExtensionState(DesiredExtensionState* target_state)
     const ControllerEmu::AnalogStick::StateData stick_state =
         m_stick->GetState(m_input_override_function);
 
-    guitar_data.sx = static_cast<u8>((stick_state.x * STICK_RADIUS) + STICK_CENTER);
-    guitar_data.sy = static_cast<u8>((stick_state.y * STICK_RADIUS) + STICK_CENTER);
+    guitar_data.sx = MapFloat<u8>(stick_state.x, STICK_CENTER, 0, STICK_RANGE);
+    guitar_data.sy = MapFloat<u8>(stick_state.y, STICK_CENTER, 0, STICK_RANGE);
   }
 
   // slider bar
@@ -126,7 +126,7 @@ void Guitar::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   // whammy bar
   const ControllerEmu::Triggers::StateData whammy_state =
       m_whammy->GetState(m_input_override_function);
-  guitar_data.whammy = static_cast<u8>(whammy_state.data[0] * 0x1F);
+  guitar_data.whammy = MapFloat<u8>(whammy_state.data[0], 0, 0, 0x1F);
 
   // buttons
   m_buttons->GetState(&guitar_data.bt, guitar_button_bitmasks.data(), m_input_override_function);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.h
@@ -69,6 +69,7 @@ public:
 
   static const u8 STICK_CENTER = 0x20;
   static const u8 STICK_RADIUS = 0x1f;
+  static const u8 STICK_RANGE = 0x3f;
 
   // TODO: Test real hardware. Is this accurate?
   static const u8 STICK_GATE_RADIUS = 0x16;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -70,8 +70,8 @@ void Nunchuk::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   bool override_occurred = false;
   const ControllerEmu::AnalogStick::StateData stick_state =
       m_stick->GetState(m_input_override_function, &override_occurred);
-  nc_data.jx = u8(STICK_CENTER + stick_state.x * STICK_RADIUS);
-  nc_data.jy = u8(STICK_CENTER + stick_state.y * STICK_RADIUS);
+  nc_data.jx = MapFloat<u8>(stick_state.x, STICK_CENTER, 0, STICK_RANGE);
+  nc_data.jy = MapFloat<u8>(stick_state.y, STICK_CENTER, 0, STICK_RANGE);
 
   if (!override_occurred)
   {

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -37,14 +37,13 @@ constexpr std::array<u8, 2> nunchuk_button_bitmasks{{
 Nunchuk::Nunchuk() : Extension1stParty(_trans("Nunchuk"))
 {
   // buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "C");
-  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "Z");
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(BUTTONS_GROUP));
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, C_BUTTON);
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, Z_BUTTON);
 
   // stick
   constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
-  groups.emplace_back(m_stick =
-                          new ControllerEmu::OctagonAnalogStick(_trans("Stick"), gate_radius));
+  groups.emplace_back(m_stick = new ControllerEmu::OctagonAnalogStick(STICK_GROUP, gate_radius));
 
   // swing
   groups.emplace_back(m_swing = new ControllerEmu::Force(_trans("Swing")));
@@ -59,7 +58,7 @@ Nunchuk::Nunchuk() : Extension1stParty(_trans("Nunchuk"))
 
   // accelerometer
   groups.emplace_back(m_imu_accelerometer = new ControllerEmu::IMUAccelerometer(
-                          "IMUAccelerometer", _trans("Accelerometer")));
+                          ACCELEROMETER_GROUP, _trans("Accelerometer")));
 }
 
 void Nunchuk::BuildDesiredExtensionState(DesiredExtensionState* target_state)

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
@@ -5,6 +5,8 @@
 
 #include <array>
 
+#include "Common/Common.h"
+
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
 #include "Core/HW/WiimoteEmu/Dynamics.h"
 #include "Core/HW/WiimoteEmu/Extension/Extension.h"
@@ -156,6 +158,8 @@ public:
 
   ControllerEmu::ControlGroup* GetGroup(NunchukGroup group);
 
+  void LoadDefaults(const ControllerInterface& ciface) override;
+
   static constexpr u8 BUTTON_C = 0x02;
   static constexpr u8 BUTTON_Z = 0x01;
 
@@ -168,7 +172,12 @@ public:
   static constexpr u8 STICK_RADIUS = 0x7F;
   static constexpr u8 STICK_RANGE = 0xFF;
 
-  void LoadDefaults(const ControllerInterface& ciface) override;
+  static constexpr const char* BUTTONS_GROUP = _trans("Buttons");
+  static constexpr const char* STICK_GROUP = _trans("Stick");
+  static constexpr const char* ACCELEROMETER_GROUP = "IMUAccelerometer";
+
+  static constexpr const char* C_BUTTON = "C";
+  static constexpr const char* Z_BUTTON = "Z";
 
 private:
   ControllerEmu::Tilt* m_tilt;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
@@ -166,6 +166,7 @@ public:
 
   static constexpr u8 STICK_CENTER = 0x80;
   static constexpr u8 STICK_RADIUS = 0x7F;
+  static constexpr u8 STICK_RANGE = 0xFF;
 
   void LoadDefaults(const ControllerInterface& ciface) override;
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.cpp
@@ -64,8 +64,9 @@ void Shinkansen::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   // guesses).
   const u8 brake_values[] = {0, 53, 79, 105, 132, 159, 187, 217, 250};
   const u8 power_values[] = {255, 229, 208, 189, 170, 153, 135, 118, 101, 85, 68, 51, 35, 17};
-  state.brake = brake_values[size_t(analog[0] * (sizeof(brake_values) - 1))];
-  state.power = power_values[size_t(analog[1] * (sizeof(power_values) - 1))];
+  // Not casting from size_t would trigger a static assert in MapFloat due to its use of llround
+  state.brake = brake_values[MapFloat(analog[0], 0, 0, static_cast<int>(sizeof(brake_values) - 1))];
+  state.power = power_values[MapFloat(analog[1], 0, 0, static_cast<int>(sizeof(power_values) - 1))];
 
   // Note: This currently assumes a little-endian host.
   const u16 button_bitmasks[] = {

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
@@ -54,8 +54,8 @@ void TaTaCon::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
   DataFormat tatacon_data = {};
 
-  m_center->GetState(&tatacon_data.state, center_bitmasks.data());
-  m_rim->GetState(&tatacon_data.state, rim_bitmasks.data());
+  m_center->GetState(&tatacon_data.state, center_bitmasks.data(), m_input_override_function);
+  m_rim->GetState(&tatacon_data.state, rim_bitmasks.data(), m_input_override_function);
 
   // Flip button bits.
   tatacon_data.state ^= 0xff;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -86,7 +86,8 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 
   // stick
   {
-    const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
+    const ControllerEmu::AnalogStick::StateData stick_state =
+        m_stick->GetState(m_input_override_function);
 
     tt_data.sx = static_cast<u8>((stick_state.x * STICK_RADIUS) + STICK_CENTER);
     tt_data.sy = static_cast<u8>((stick_state.y * STICK_RADIUS) + STICK_CENTER);
@@ -94,7 +95,7 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 
   // left table
   {
-    const ControllerEmu::Slider::StateData lt = m_left_table->GetState();
+    const ControllerEmu::Slider::StateData lt = m_left_table->GetState(m_input_override_function);
     const s8 tt = static_cast<s8>(lt.value * TABLE_RANGE);
 
     tt_data.ltable1 = tt;
@@ -103,7 +104,7 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 
   // right table
   {
-    const ControllerEmu::Slider::StateData rt = m_right_table->GetState();
+    const ControllerEmu::Slider::StateData rt = m_right_table->GetState(m_input_override_function);
     const s8 tt = static_cast<s8>(rt.value * TABLE_RANGE);
 
     tt_data.rtable1 = tt;
@@ -114,7 +115,7 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 
   // effect dial
   {
-    const auto dial_state = m_effect_dial->GetState();
+    const auto dial_state = m_effect_dial->GetState(m_input_override_function);
     const u8 dial = static_cast<u8>(dial_state.value * EFFECT_DIAL_RANGE) + EFFECT_DIAL_CENTER;
 
     tt_data.dial1 = dial;
@@ -123,13 +124,13 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 
   // crossfade slider
   {
-    const ControllerEmu::Slider::StateData cfs = m_crossfade->GetState();
+    const ControllerEmu::Slider::StateData cfs = m_crossfade->GetState(m_input_override_function);
 
     tt_data.slider = static_cast<u8>((cfs.value * CROSSFADE_RANGE) + CROSSFADE_CENTER);
   }
 
   // buttons
-  m_buttons->GetState(&tt_data.bt, turntable_button_bitmasks.data());
+  m_buttons->GetState(&tt_data.bt, turntable_button_bitmasks.data(), m_input_override_function);
 
   // flip button bits :/
   tt_data.bt ^= (BUTTON_L_GREEN | BUTTON_L_RED | BUTTON_L_BLUE | BUTTON_R_GREEN | BUTTON_R_RED |

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -89,14 +89,14 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
     const ControllerEmu::AnalogStick::StateData stick_state =
         m_stick->GetState(m_input_override_function);
 
-    tt_data.sx = static_cast<u8>((stick_state.x * STICK_RADIUS) + STICK_CENTER);
-    tt_data.sy = static_cast<u8>((stick_state.y * STICK_RADIUS) + STICK_CENTER);
+    tt_data.sx = MapFloat<u8>(stick_state.x, STICK_CENTER, 0, STICK_RANGE);
+    tt_data.sy = MapFloat<u8>(stick_state.y, STICK_CENTER, 0, STICK_RANGE);
   }
 
   // left table
   {
     const ControllerEmu::Slider::StateData lt = m_left_table->GetState(m_input_override_function);
-    const s8 tt = static_cast<s8>(lt.value * TABLE_RANGE);
+    const s8 tt = MapFloat<u8>(lt.value, 0, 0, TABLE_RANGE);
 
     tt_data.ltable1 = tt;
     tt_data.ltable2 = tt >> 5;
@@ -105,7 +105,7 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   // right table
   {
     const ControllerEmu::Slider::StateData rt = m_right_table->GetState(m_input_override_function);
-    const s8 tt = static_cast<s8>(rt.value * TABLE_RANGE);
+    const s8 tt = MapFloat<u8>(rt.value, 0, 0, TABLE_RANGE);
 
     tt_data.rtable1 = tt;
     tt_data.rtable2 = tt >> 1;
@@ -116,7 +116,7 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   // effect dial
   {
     const auto dial_state = m_effect_dial->GetState(m_input_override_function);
-    const u8 dial = static_cast<u8>(dial_state.value * EFFECT_DIAL_RANGE) + EFFECT_DIAL_CENTER;
+    const u8 dial = MapFloat<u8>(dial_state.value, EFFECT_DIAL_CENTER, 0, EFFECT_DIAL_RANGE);
 
     tt_data.dial1 = dial;
     tt_data.dial2 = dial >> 3;
@@ -126,7 +126,7 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   {
     const ControllerEmu::Slider::StateData cfs = m_crossfade->GetState(m_input_override_function);
 
-    tt_data.slider = static_cast<u8>((cfs.value * CROSSFADE_RANGE) + CROSSFADE_CENTER);
+    tt_data.slider = MapFloat<u8>(cfs.value, CROSSFADE_CENTER, 0, CROSSFADE_RANGE);
   }
 
   // buttons

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
@@ -78,6 +78,7 @@ public:
   static constexpr int STICK_BIT_COUNT = 6;
   static constexpr u8 STICK_CENTER = (1 << STICK_BIT_COUNT) / 2;
   static constexpr u8 STICK_RADIUS = STICK_CENTER - 1;
+  static constexpr u8 STICK_RANGE = (1 << STICK_BIT_COUNT) - 1;
   // TODO: Test real hardware. Is this accurate?
   static constexpr u8 STICK_GATE_RADIUS = 0x16;
 
@@ -86,11 +87,11 @@ public:
 
   static constexpr int EFFECT_DIAL_BIT_COUNT = 5;
   static constexpr u8 EFFECT_DIAL_CENTER = (1 << EFFECT_DIAL_BIT_COUNT) / 2;
-  static constexpr u8 EFFECT_DIAL_RANGE = EFFECT_DIAL_CENTER - 1;
+  static constexpr u8 EFFECT_DIAL_RANGE = (1 << EFFECT_DIAL_BIT_COUNT) - 1;
 
   static constexpr int CROSSFADE_BIT_COUNT = 4;
   static constexpr u8 CROSSFADE_CENTER = (1 << CROSSFADE_BIT_COUNT) / 2;
-  static constexpr u8 CROSSFADE_RANGE = CROSSFADE_CENTER - 1;
+  static constexpr u8 CROSSFADE_RANGE = (1 << CROSSFADE_BIT_COUNT) - 1;
 
 private:
   ControllerEmu::Buttons* m_buttons;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -11,6 +11,7 @@
 #include <fmt/format.h>
 
 #include "Common/Assert.h"
+#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
@@ -63,10 +64,6 @@ static const u16 dpad_bitmasks[] = {Wiimote::PAD_UP, Wiimote::PAD_DOWN, Wiimote:
 
 static const u16 dpad_sideways_bitmasks[] = {Wiimote::PAD_RIGHT, Wiimote::PAD_LEFT, Wiimote::PAD_UP,
                                              Wiimote::PAD_DOWN};
-
-constexpr std::array<std::string_view, 7> named_buttons{
-    "A", "B", "1", "2", "-", "+", "Home",
-};
 
 void Wiimote::Reset()
 {
@@ -212,24 +209,23 @@ void Wiimote::Reset()
 Wiimote::Wiimote(const unsigned int index) : m_index(index), m_bt_device_index(index)
 {
   // Buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  for (auto& named_button : named_buttons)
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(BUTTONS_GROUP));
+  for (auto& named_button : {A_BUTTON, B_BUTTON, ONE_BUTTON, TWO_BUTTON, MINUS_BUTTON, PLUS_BUTTON})
   {
-    std::string_view ui_name = (named_button == "Home") ? "HOME" : named_button;
-    m_buttons->AddInput(ControllerEmu::DoNotTranslate, std::string(named_button),
-                        std::string(ui_name));
+    m_buttons->AddInput(ControllerEmu::DoNotTranslate, named_button);
   }
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, HOME_BUTTON, "HOME");
 
   // Pointing (IR)
   // i18n: "Point" refers to the action of pointing a Wii Remote.
-  groups.emplace_back(m_ir = new ControllerEmu::Cursor("IR", _trans("Point")));
+  groups.emplace_back(m_ir = new ControllerEmu::Cursor(IR_GROUP, _trans("Point")));
   groups.emplace_back(m_swing = new ControllerEmu::Force(_trans("Swing")));
   groups.emplace_back(m_tilt = new ControllerEmu::Tilt(_trans("Tilt")));
   groups.emplace_back(m_shake = new ControllerEmu::Shake(_trans("Shake")));
   groups.emplace_back(m_imu_accelerometer = new ControllerEmu::IMUAccelerometer(
-                          "IMUAccelerometer", _trans("Accelerometer")));
+                          ACCELEROMETER_GROUP, _trans("Accelerometer")));
   groups.emplace_back(m_imu_gyroscope =
-                          new ControllerEmu::IMUGyroscope("IMUGyroscope", _trans("Gyroscope")));
+                          new ControllerEmu::IMUGyroscope(GYROSCOPE_GROUP, _trans("Gyroscope")));
   groups.emplace_back(m_imu_ir = new ControllerEmu::IMUCursor("IMUIR", _trans("Point")));
 
   const auto fov_default =
@@ -273,7 +269,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index), m_bt_device_index(i
   m_rumble->AddOutput(ControllerEmu::Translate, _trans("Motor"));
 
   // D-Pad
-  groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
+  groups.emplace_back(m_dpad = new ControllerEmu::Buttons(DPAD_GROUP));
   for (const char* named_direction : named_directions)
   {
     m_dpad->AddInput(ControllerEmu::Translate, named_direction);

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <numeric>
+#include <optional>
 #include <string>
 
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
@@ -146,6 +147,10 @@ public:
   // Active extension number is exposed for TAS.
   ExtensionNumber GetActiveExtensionNumber() const;
 
+  static Common::Vec3
+  OverrideVec3(const ControllerEmu::ControlGroup* control_group, Common::Vec3 vec,
+               const ControllerEmu::InputOverrideFunction& input_override_function);
+
 private:
   // Used only for error generation:
   static constexpr u8 EEPROM_I2C_ADDR = 0x50;
@@ -161,11 +166,10 @@ private:
   void BuildDesiredWiimoteState(DesiredWiimoteState* target_state);
 
   // Returns simulated accelerometer data in m/s^2.
-  Common::Vec3 GetAcceleration(
-      Common::Vec3 extra_acceleration = Common::Vec3(0, 0, float(GRAVITY_ACCELERATION))) const;
+  Common::Vec3 GetAcceleration(Common::Vec3 extra_acceleration) const;
 
   // Returns simulated gyroscope data in radians/s.
-  Common::Vec3 GetAngularVelocity(Common::Vec3 extra_angular_velocity = {}) const;
+  Common::Vec3 GetAngularVelocity(Common::Vec3 extra_angular_velocity) const;
 
   // Returns the transformation of the world around the wiimote.
   // Used for simulating camera data and for rotating acceleration data.
@@ -176,6 +180,10 @@ private:
   // Returns the world rotation from the effects of sideways/upright settings.
   Common::Quaternion GetOrientation() const;
 
+  std::optional<Common::Vec3> OverrideVec3(const ControllerEmu::ControlGroup* control_group,
+                                           std::optional<Common::Vec3> optional_vec) const;
+  Common::Vec3 OverrideVec3(const ControllerEmu::ControlGroup* control_group,
+                            Common::Vec3 vec) const;
   Common::Vec3 GetTotalAcceleration() const;
   Common::Vec3 GetTotalAngularVelocity() const;
   Common::Matrix44 GetTotalTransformation() const;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -8,6 +8,8 @@
 #include <optional>
 #include <string>
 
+#include "Common/Common.h"
+
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
 
 #include "Core/HW/WiimoteEmu/Camera.h"
@@ -112,6 +114,20 @@ public:
   static constexpr u16 BUTTON_A = 0x0800;
   static constexpr u16 BUTTON_MINUS = 0x1000;
   static constexpr u16 BUTTON_HOME = 0x8000;
+
+  static constexpr const char* BUTTONS_GROUP = _trans("Buttons");
+  static constexpr const char* DPAD_GROUP = _trans("D-Pad");
+  static constexpr const char* ACCELEROMETER_GROUP = "IMUAccelerometer";
+  static constexpr const char* GYROSCOPE_GROUP = "IMUGyroscope";
+  static constexpr const char* IR_GROUP = "IR";
+
+  static constexpr const char* A_BUTTON = "A";
+  static constexpr const char* B_BUTTON = "B";
+  static constexpr const char* ONE_BUTTON = "1";
+  static constexpr const char* TWO_BUTTON = "2";
+  static constexpr const char* MINUS_BUTTON = "-";
+  static constexpr const char* PLUS_BUTTON = "+";
+  static constexpr const char* HOME_BUTTON = "Home";
 
   explicit Wiimote(unsigned int index);
   ~Wiimote();

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -122,9 +122,6 @@ static bool s_bPolled = false;
 static std::mutex s_input_display_lock;
 static std::string s_InputDisplay[8];
 
-static GCManipFunction s_gc_manip_func;
-static WiiManipFunction s_wii_manip_func;
-
 static std::string s_current_file_name;
 
 static void GetSettings();
@@ -1424,28 +1421,6 @@ void SaveRecording(const std::string& filename)
     Core::DisplayMessage(fmt::format("DTM {} saved", filename), 2000);
   else
     Core::DisplayMessage(fmt::format("Failed to save {}", filename), 2000);
-}
-
-void SetGCInputManip(GCManipFunction func)
-{
-  s_gc_manip_func = std::move(func);
-}
-void SetWiiInputManip(WiiManipFunction func)
-{
-  s_wii_manip_func = std::move(func);
-}
-
-// NOTE: CPU Thread
-void CallGCInputManip(GCPadStatus* PadStatus, int controllerID)
-{
-  if (s_gc_manip_func)
-    s_gc_manip_func(PadStatus, controllerID);
-}
-// NOTE: CPU Thread
-void CallWiiInputManip(DataReportBuilder& rpt, int controllerID, int ext, const EncryptionKey& key)
-{
-  if (s_wii_manip_func)
-    s_wii_manip_func(rpt, controllerID, ext, key);
 }
 
 // NOTE: GPU Thread

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -5,7 +5,6 @@
 
 #include <array>
 #include <cstring>
-#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -200,14 +199,4 @@ std::string GetInputDisplay();
 std::string GetRTCDisplay();
 std::string GetRerecords();
 
-// Done this way to avoid mixing of core and gui code
-using GCManipFunction = std::function<void(GCPadStatus*, int)>;
-using WiiManipFunction = std::function<void(WiimoteCommon::DataReportBuilder&, int, int,
-                                            const WiimoteEmu::EncryptionKey&)>;
-
-void SetGCInputManip(GCManipFunction);
-void SetWiiInputManip(WiiManipFunction);
-void CallGCInputManip(GCPadStatus* PadStatus, int controllerID);
-void CallWiiInputManip(WiimoteCommon::DataReportBuilder& rpt, int controllerID, int ext,
-                       const WiimoteEmu::EncryptionKey& key);
 }  // namespace Movie

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -403,15 +403,6 @@ void MainWindow::CreateComponents()
     m_wii_tas_input_windows[i] = new WiiTASInputWindow(nullptr, i);
   }
 
-  Movie::SetGCInputManip([this](GCPadStatus* pad_status, int controller_id) {
-    m_gc_tas_input_windows[controller_id]->GetValues(pad_status);
-  });
-
-  Movie::SetWiiInputManip([this](WiimoteCommon::DataReportBuilder& rpt, int controller_id, int ext,
-                                 const WiimoteEmu::EncryptionKey& key) {
-    m_wii_tas_input_windows[controller_id]->GetValues(rpt, ext, key);
-  });
-
   m_jit_widget = new JITWidget(this);
   m_log_widget = new LogWidget(this);
   m_log_config_widget = new LogConfigWidget(this);

--- a/Source/Core/DolphinQt/TAS/GCTASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/GCTASInputWindow.h
@@ -6,18 +6,25 @@
 #include "DolphinQt/TAS/TASInputWindow.h"
 
 class QGroupBox;
+class QHideEvent;
+class QShowEvent;
 class QSpinBox;
 class TASCheckBox;
-struct GCPadStatus;
 
 class GCTASInputWindow : public TASInputWindow
 {
   Q_OBJECT
 public:
-  explicit GCTASInputWindow(QWidget* parent, int num);
-  void GetValues(GCPadStatus* pad);
+  explicit GCTASInputWindow(QWidget* parent, int controller_id);
+
+  void hideEvent(QHideEvent* event) override;
+  void showEvent(QShowEvent* event) override;
 
 private:
+  int m_controller_id;
+
+  InputOverrider m_overrider;
+
   TASCheckBox* m_a_button;
   TASCheckBox* m_b_button;
   TASCheckBox* m_x_button;

--- a/Source/Core/DolphinQt/TAS/IRWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/IRWidget.cpp
@@ -54,8 +54,8 @@ void IRWidget::paintEvent(QPaintEvent* event)
   painter.drawLine(PADDING + w / 2, PADDING, PADDING + w / 2, PADDING + h);
 
   // convert from value space to widget space
-  u16 x = PADDING + (w - (m_x * w) / ir_max_x);
-  u16 y = PADDING + ((m_y * h) / ir_max_y);
+  u16 x = PADDING + ((m_x * w) / ir_max_x);
+  u16 y = PADDING + (h - (m_y * h) / ir_max_y);
 
   painter.drawLine(PADDING + w / 2, PADDING + h / 2, x, y);
 
@@ -87,8 +87,8 @@ void IRWidget::handleMouseEvent(QMouseEvent* event)
   else
   {
     // convert from widget space to value space
-    int new_x = ir_max_x - (event->pos().x() * ir_max_x) / width();
-    int new_y = (event->pos().y() * ir_max_y) / height();
+    int new_x = (event->pos().x() * ir_max_x) / width();
+    int new_y = ir_max_y - (event->pos().y() * ir_max_y) / height();
 
     m_x = std::max(0, std::min(static_cast<int>(ir_max_x), new_x));
     m_y = std::max(0, std::min(static_cast<int>(ir_max_y), new_y));

--- a/Source/Core/DolphinQt/TAS/IRWidget.h
+++ b/Source/Core/DolphinQt/TAS/IRWidget.h
@@ -34,5 +34,7 @@ private:
 };
 
 // Should be part of class but fails to compile on mac os
+static const u16 ir_min_x = 0;
+static const u16 ir_min_y = 0;
 static const u16 ir_max_x = 1023;
 static const u16 ir_max_y = 767;

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -4,6 +4,7 @@
 #include "DolphinQt/TAS/TASInputWindow.h"
 
 #include <cmath>
+#include <utility>
 
 #include <QCheckBox>
 #include <QGroupBox>
@@ -23,7 +24,23 @@
 #include "DolphinQt/TAS/TASCheckBox.h"
 #include "DolphinQt/TAS/TASSlider.h"
 
-#include "InputCommon/GCPadStatus.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/StickGate.h"
+
+void InputOverrider::AddFunction(std::string_view group_name, std::string_view control_name,
+                                 OverrideFunction function)
+{
+  m_functions.emplace(std::make_pair(group_name, control_name), std::move(function));
+}
+
+ControllerEmu::InputOverrideFunction InputOverrider::GetInputOverrideFunction() const
+{
+  return [this](std::string_view group_name, std::string_view control_name,
+                ControlState controller_state) {
+    const auto it = m_functions.find(std::make_pair(group_name, control_name));
+    return it != m_functions.end() ? it->second(controller_state) : std::nullopt;
+  };
+}
 
 TASInputWindow::TASInputWindow(QWidget* parent) : QDialog(parent)
 {
@@ -63,13 +80,22 @@ int TASInputWindow::GetTurboReleaseFrames() const
   return m_turbo_release_frames->value();
 }
 
-TASCheckBox* TASInputWindow::CreateButton(const QString& name)
+TASCheckBox* TASInputWindow::CreateButton(const QString& text, std::string_view group_name,
+                                          std::string_view control_name, InputOverrider* overrider)
 {
-  return new TASCheckBox(name, this);
+  TASCheckBox* checkbox = new TASCheckBox(text, this);
+
+  overrider->AddFunction(group_name, control_name, [this, checkbox](ControlState controller_state) {
+    return GetButton(checkbox, controller_state);
+  });
+
+  return checkbox;
 }
 
-QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, QSpinBox*& y_value,
-                                             u16 max_x, u16 max_y, Qt::Key x_shortcut_key,
+QGroupBox* TASInputWindow::CreateStickInputs(const QString& text, std::string_view group_name,
+                                             InputOverrider* overrider, QSpinBox*& x_value,
+                                             QSpinBox*& y_value, u16 min_x, u16 min_y, u16 max_x,
+                                             u16 max_y, Qt::Key x_shortcut_key,
                                              Qt::Key y_shortcut_key)
 {
   const QKeySequence x_shortcut_key_sequence = QKeySequence(Qt::ALT | x_shortcut_key);
@@ -77,7 +103,7 @@ QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, Q
 
   auto* box =
       new QGroupBox(QStringLiteral("%1 (%2/%3)")
-                        .arg(name, x_shortcut_key_sequence.toString(QKeySequence::NativeText),
+                        .arg(text, x_shortcut_key_sequence.toString(QKeySequence::NativeText),
                              y_shortcut_key_sequence.toString(QKeySequence::NativeText)));
 
   const int x_default = static_cast<int>(std::round(max_x / 2.));
@@ -112,25 +138,64 @@ QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, Q
   layout->addLayout(visual_layout);
   box->setLayout(layout);
 
+  overrider->AddFunction(group_name, ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE,
+                         [this, x_value, x_default, min_x, max_x](ControlState controller_state) {
+                           return GetSpinBox(x_value, x_default, min_x, max_x, controller_state);
+                         });
+
+  overrider->AddFunction(group_name, ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE,
+                         [this, y_value, y_default, min_y, max_y](ControlState controller_state) {
+                           return GetSpinBox(y_value, y_default, min_y, max_y, controller_state);
+                         });
+
   return box;
 }
 
-QBoxLayout* TASInputWindow::CreateSliderValuePairLayout(QString name, QSpinBox*& value,
-                                                        int default_, u16 max, Qt::Key shortcut_key,
-                                                        QWidget* shortcut_widget, bool invert)
+QBoxLayout* TASInputWindow::CreateSliderValuePairLayout(
+    const QString& text, std::string_view group_name, std::string_view control_name,
+    InputOverrider* overrider, QSpinBox*& value, u16 zero, int default_, u16 min, u16 max,
+    Qt::Key shortcut_key, QWidget* shortcut_widget, std::optional<ControlState> scale)
 {
   const QKeySequence shortcut_key_sequence = QKeySequence(Qt::ALT | shortcut_key);
 
   auto* label = new QLabel(QStringLiteral("%1 (%2)").arg(
-      name, shortcut_key_sequence.toString(QKeySequence::NativeText)));
+      text, shortcut_key_sequence.toString(QKeySequence::NativeText)));
 
   QBoxLayout* layout = new QHBoxLayout;
   layout->addWidget(label);
 
-  value = CreateSliderValuePair(layout, default_, max, shortcut_key_sequence, Qt::Horizontal,
-                                shortcut_widget, invert);
+  value = CreateSliderValuePair(group_name, control_name, overrider, layout, zero, default_, min,
+                                max, shortcut_key_sequence, Qt::Horizontal, shortcut_widget, scale);
 
   return layout;
+}
+
+QSpinBox* TASInputWindow::CreateSliderValuePair(
+    std::string_view group_name, std::string_view control_name, InputOverrider* overrider,
+    QBoxLayout* layout, u16 zero, int default_, u16 min, u16 max,
+    QKeySequence shortcut_key_sequence, Qt::Orientation orientation, QWidget* shortcut_widget,
+    std::optional<ControlState> scale)
+{
+  QSpinBox* value = CreateSliderValuePair(layout, default_, max, shortcut_key_sequence, orientation,
+                                          shortcut_widget);
+
+  InputOverrider::OverrideFunction func;
+  if (scale)
+  {
+    func = [this, value, zero, scale](ControlState controller_state) {
+      return GetSpinBox(value, zero, controller_state, *scale);
+    };
+  }
+  else
+  {
+    func = [this, value, zero, min, max](ControlState controller_state) {
+      return GetSpinBox(value, zero, min, max, controller_state);
+    };
+  }
+
+  overrider->AddFunction(group_name, control_name, std::move(func));
+
+  return value;
 }
 
 // The shortcut_widget argument needs to specify the container widget that will be hidden/shown.
@@ -138,7 +203,7 @@ QBoxLayout* TASInputWindow::CreateSliderValuePairLayout(QString name, QSpinBox*&
 QSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int default_, u16 max,
                                                 QKeySequence shortcut_key_sequence,
                                                 Qt::Orientation orientation,
-                                                QWidget* shortcut_widget, bool invert)
+                                                QWidget* shortcut_widget)
 {
   auto* value = new QSpinBox();
   value->setRange(0, 99999);
@@ -151,7 +216,6 @@ QSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int default_
   slider->setRange(0, max);
   slider->setValue(default_);
   slider->setFocusPolicy(Qt::ClickFocus);
-  slider->setInvertedAppearance(invert);
 
   connect(slider, &QSlider::valueChanged, value, &QSpinBox::setValue);
   connect(value, qOverload<int>(&QSpinBox::valueChanged), slider, &QSlider::setValue);
@@ -170,10 +234,10 @@ QSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int default_
   return value;
 }
 
-template <typename UX>
-void TASInputWindow::GetButton(TASCheckBox* checkbox, UX& buttons, UX mask)
+std::optional<ControlState> TASInputWindow::GetButton(TASCheckBox* checkbox,
+                                                      ControlState controller_state)
 {
-  const bool pressed = (buttons & mask) != 0;
+  const bool pressed = std::llround(controller_state) > 0;
   if (m_use_controller->isChecked())
   {
     if (pressed)
@@ -188,50 +252,54 @@ void TASInputWindow::GetButton(TASCheckBox* checkbox, UX& buttons, UX mask)
     }
   }
 
-  if (checkbox->GetValue())
-    buttons |= mask;
-  else
-    buttons &= ~mask;
+  return checkbox->GetValue() ? 1.0 : 0.0;
 }
-template void TASInputWindow::GetButton<u8>(TASCheckBox* button, u8& pad, u8 mask);
-template void TASInputWindow::GetButton<u16>(TASCheckBox* button, u16& pad, u16 mask);
 
-void TASInputWindow::GetSpinBoxU8(QSpinBox* spin, u8& controller_value)
+std::optional<ControlState> TASInputWindow::GetSpinBox(QSpinBox* spin, u16 zero, u16 min, u16 max,
+                                                       ControlState controller_state)
 {
+  const u16 controller_value =
+      ControllerEmu::EmulatedController::MapFloat<u16>(controller_state, zero, 0, max);
+
   if (m_use_controller->isChecked())
   {
-    if (!m_spinbox_most_recent_values_u8.count(spin) ||
-        m_spinbox_most_recent_values_u8[spin] != controller_value)
+    if (!m_spinbox_most_recent_values.count(spin) ||
+        m_spinbox_most_recent_values[spin] != controller_value)
     {
       QueueOnObjectBlocking(spin, [spin, controller_value] { spin->setValue(controller_value); });
     }
 
-    m_spinbox_most_recent_values_u8[spin] = controller_value;
+    m_spinbox_most_recent_values[spin] = controller_value;
   }
   else
   {
-    m_spinbox_most_recent_values_u8.clear();
+    m_spinbox_most_recent_values.clear();
   }
 
-  controller_value = spin->value();
+  return ControllerEmu::EmulatedController::MapToFloat<ControlState, u16>(spin->value(), zero, min,
+                                                                          max);
 }
 
-void TASInputWindow::GetSpinBoxU16(QSpinBox* spin, u16& controller_value)
+std::optional<ControlState> TASInputWindow::GetSpinBox(QSpinBox* spin, u16 zero,
+                                                       ControlState controller_state,
+                                                       ControlState scale)
 {
+  const u16 controller_value = static_cast<u16>(std::llround(controller_state * scale + zero));
+
   if (m_use_controller->isChecked())
   {
-    if (!m_spinbox_most_recent_values_u16.count(spin) ||
-        m_spinbox_most_recent_values_u16[spin] != controller_value)
+    if (!m_spinbox_most_recent_values.count(spin) ||
+        m_spinbox_most_recent_values[spin] != controller_value)
     {
       QueueOnObjectBlocking(spin, [spin, controller_value] { spin->setValue(controller_value); });
     }
 
-    m_spinbox_most_recent_values_u16[spin] = controller_value;
+    m_spinbox_most_recent_values[spin] = controller_value;
   }
   else
   {
-    m_spinbox_most_recent_values_u16.clear();
+    m_spinbox_most_recent_values.clear();
   }
 
-  controller_value = spin->value();
+  return (spin->value() - zero) / scale;
 }

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
@@ -15,18 +15,14 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/MathUtil.h"
 
 #include "Core/Core.h"
-#include "Core/HW/WiimoteCommon/DataReport.h"
-#include "Core/HW/WiimoteEmu/Encryption.h"
+#include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/Extension/Classic.h"
-#include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
-
-#include "Core/HW/WiimoteEmu/Extension/Classic.h"
+#include "Core/HW/WiimoteEmu/Extension/Extension.h"
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
-
-#include "Core/HW/WiimoteEmu/Camera.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 
 #include "DolphinQt/QtUtils/AspectRatioWidget.h"
@@ -34,6 +30,9 @@
 #include "DolphinQt/TAS/IRWidget.h"
 #include "DolphinQt/TAS/TASCheckBox.h"
 
+#include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/StickGate.h"
 #include "InputCommon/InputConfig.h"
 
 using namespace WiimoteCommon;
@@ -48,21 +47,25 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
                                     ir_x_shortcut_key_sequence.toString(QKeySequence::NativeText),
                                     ir_y_shortcut_key_sequence.toString(QKeySequence::NativeText)));
 
-  const int ir_x_default = static_cast<int>(std::round(ir_max_x / 2.));
-  const int ir_y_default = static_cast<int>(std::round(ir_max_y / 2.));
+  const int ir_x_center = static_cast<int>(std::round(ir_max_x / 2.));
+  const int ir_y_center = static_cast<int>(std::round(ir_max_y / 2.));
 
   auto* x_layout = new QHBoxLayout;
-  m_ir_x_value = CreateSliderValuePair(x_layout, ir_x_default, ir_max_x, ir_x_shortcut_key_sequence,
-                                       Qt::Horizontal, m_ir_box, true);
+  m_ir_x_value = CreateSliderValuePair(
+      WiimoteEmu::Wiimote::IR_GROUP, ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE,
+      &m_wiimote_overrider, x_layout, ir_x_center, ir_x_center, ir_min_x, ir_max_x,
+      ir_x_shortcut_key_sequence, Qt::Horizontal, m_ir_box);
 
   auto* y_layout = new QVBoxLayout;
-  m_ir_y_value = CreateSliderValuePair(y_layout, ir_y_default, ir_max_y, ir_y_shortcut_key_sequence,
-                                       Qt::Vertical, m_ir_box, true);
+  m_ir_y_value = CreateSliderValuePair(
+      WiimoteEmu::Wiimote::IR_GROUP, ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE,
+      &m_wiimote_overrider, y_layout, ir_y_center, ir_y_center, ir_min_y, ir_max_y,
+      ir_y_shortcut_key_sequence, Qt::Vertical, m_ir_box);
   m_ir_y_value->setMaximumWidth(60);
 
   auto* visual = new IRWidget(this);
-  visual->SetX(ir_x_default);
-  visual->SetY(ir_y_default);
+  visual->SetX(ir_x_center);
+  visual->SetY(ir_y_center);
 
   connect(m_ir_x_value, qOverload<int>(&QSpinBox::valueChanged), visual, &IRWidget::SetX);
   connect(m_ir_y_value, qOverload<int>(&QSpinBox::valueChanged), visual, &IRWidget::SetY);
@@ -80,16 +83,19 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
   ir_layout->addLayout(visual_layout);
   m_ir_box->setLayout(ir_layout);
 
-  m_nunchuk_stick_box = CreateStickInputs(tr("Nunchuk Stick"), m_nunchuk_stick_x_value,
-                                          m_nunchuk_stick_y_value, 255, 255, Qt::Key_X, Qt::Key_Y);
+  m_nunchuk_stick_box = CreateStickInputs(
+      tr("Nunchuk Stick"), WiimoteEmu::Nunchuk::STICK_GROUP, &m_nunchuk_overrider,
+      m_nunchuk_stick_x_value, m_nunchuk_stick_y_value, 0, 0, 255, 255, Qt::Key_X, Qt::Key_Y);
 
   m_classic_left_stick_box =
-      CreateStickInputs(tr("Left Stick"), m_classic_left_stick_x_value,
-                        m_classic_left_stick_y_value, 63, 63, Qt::Key_F, Qt::Key_G);
+      CreateStickInputs(tr("Left Stick"), WiimoteEmu::Classic::LEFT_STICK_GROUP,
+                        &m_classic_overrider, m_classic_left_stick_x_value,
+                        m_classic_left_stick_y_value, 0, 0, 63, 63, Qt::Key_F, Qt::Key_G);
 
   m_classic_right_stick_box =
-      CreateStickInputs(tr("Right Stick"), m_classic_right_stick_x_value,
-                        m_classic_right_stick_y_value, 31, 31, Qt::Key_Q, Qt::Key_W);
+      CreateStickInputs(tr("Right Stick"), WiimoteEmu::Classic::RIGHT_STICK_GROUP,
+                        &m_classic_overrider, m_classic_right_stick_x_value,
+                        m_classic_right_stick_y_value, 0, 0, 31, 31, Qt::Key_Q, Qt::Key_W);
 
   // Need to enforce the same minimum width because otherwise the different lengths in the labels
   // used on the QGroupBox will cause the StickWidgets to have different sizes.
@@ -104,18 +110,33 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
   top_layout->addWidget(m_classic_left_stick_box);
   top_layout->addWidget(m_classic_right_stick_box);
 
+  constexpr u16 ACCEL_ZERO_G = WiimoteEmu::Wiimote::ACCEL_ZERO_G << 2;
+  constexpr u16 ACCEL_ONE_G = WiimoteEmu::Wiimote::ACCEL_ONE_G << 2;
+  constexpr u16 ACCEL_MIN = 0;
+  constexpr u16 ACCEL_MAX = (1 << 10) - 1;
+  constexpr double ACCEL_SCALE = (ACCEL_ONE_G - ACCEL_ZERO_G) / MathUtil::GRAVITY_ACCELERATION;
+
   auto* remote_orientation_x_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("X"), m_remote_orientation_x_value, 512, 1023, Qt::Key_Q,
-                                  m_remote_orientation_box);
+      CreateSliderValuePairLayout(tr("X"), WiimoteEmu::Wiimote::ACCELEROMETER_GROUP,
+                                  ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE,
+                                  &m_wiimote_overrider, m_remote_orientation_x_value, ACCEL_ZERO_G,
+                                  ACCEL_ZERO_G, ACCEL_MIN, ACCEL_MAX, Qt::Key_Q,
+                                  m_remote_orientation_box, ACCEL_SCALE);
   auto* remote_orientation_y_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("Y"), m_remote_orientation_y_value, 512, 1023, Qt::Key_W,
-                                  m_remote_orientation_box);
+      CreateSliderValuePairLayout(tr("Y"), WiimoteEmu::Wiimote::ACCELEROMETER_GROUP,
+                                  ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE,
+                                  &m_wiimote_overrider, m_remote_orientation_y_value, ACCEL_ZERO_G,
+                                  ACCEL_ZERO_G, ACCEL_MIN, ACCEL_MAX, Qt::Key_W,
+                                  m_remote_orientation_box, ACCEL_SCALE);
   auto* remote_orientation_z_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("Z"), m_remote_orientation_z_value, 616, 1023, Qt::Key_E,
-                                  m_remote_orientation_box);
+      CreateSliderValuePairLayout(tr("Z"), WiimoteEmu::Wiimote::ACCELEROMETER_GROUP,
+                                  ControllerEmu::ReshapableInput::Z_INPUT_OVERRIDE,
+                                  &m_wiimote_overrider, m_remote_orientation_z_value, ACCEL_ZERO_G,
+                                  ACCEL_ONE_G, ACCEL_MIN, ACCEL_MAX, Qt::Key_E,
+                                  m_remote_orientation_box, ACCEL_SCALE);
 
   auto* remote_orientation_layout = new QVBoxLayout;
   remote_orientation_layout->addLayout(remote_orientation_x_layout);
@@ -127,15 +148,24 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
 
   auto* nunchuk_orientation_x_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("X"), m_nunchuk_orientation_x_value, 512, 1023, Qt::Key_I,
+      CreateSliderValuePairLayout(tr("X"), WiimoteEmu::Nunchuk::ACCELEROMETER_GROUP,
+                                  ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE,
+                                  &m_nunchuk_overrider, m_nunchuk_orientation_x_value, ACCEL_ZERO_G,
+                                  ACCEL_ZERO_G, ACCEL_MIN, ACCEL_MAX, Qt::Key_I,
                                   m_nunchuk_orientation_box);
   auto* nunchuk_orientation_y_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("Y"), m_nunchuk_orientation_y_value, 512, 1023, Qt::Key_O,
+      CreateSliderValuePairLayout(tr("Y"), WiimoteEmu::Nunchuk::ACCELEROMETER_GROUP,
+                                  ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE,
+                                  &m_nunchuk_overrider, m_nunchuk_orientation_y_value, ACCEL_ZERO_G,
+                                  ACCEL_ZERO_G, ACCEL_MIN, ACCEL_MAX, Qt::Key_O,
                                   m_nunchuk_orientation_box);
   auto* nunchuk_orientation_z_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("Z"), m_nunchuk_orientation_z_value, 512, 1023, Qt::Key_P,
+      CreateSliderValuePairLayout(tr("Z"), WiimoteEmu::Nunchuk::ACCELEROMETER_GROUP,
+                                  ControllerEmu::ReshapableInput::Z_INPUT_OVERRIDE,
+                                  &m_nunchuk_overrider, m_nunchuk_orientation_z_value, ACCEL_ZERO_G,
+                                  ACCEL_ONE_G, ACCEL_MIN, ACCEL_MAX, Qt::Key_P,
                                   m_nunchuk_orientation_box);
 
   auto* nunchuk_orientation_layout = new QVBoxLayout;
@@ -145,29 +175,46 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
   m_nunchuk_orientation_box->setLayout(nunchuk_orientation_layout);
 
   m_triggers_box = new QGroupBox(tr("Triggers"));
-  auto* l_trigger_layout = CreateSliderValuePairLayout(tr("Left"), m_left_trigger_value, 0, 31,
-                                                       Qt::Key_N, m_triggers_box);
-  auto* r_trigger_layout = CreateSliderValuePairLayout(tr("Right"), m_right_trigger_value, 0, 31,
-                                                       Qt::Key_M, m_triggers_box);
+  auto* l_trigger_layout = CreateSliderValuePairLayout(
+      tr("Left"), WiimoteEmu::Classic::TRIGGERS_GROUP, WiimoteEmu::Classic::L_ANALOG,
+      &m_classic_overrider, m_left_trigger_value, 0, 0, 0, 31, Qt::Key_N, m_triggers_box);
+  auto* r_trigger_layout = CreateSliderValuePairLayout(
+      tr("Right"), WiimoteEmu::Classic::TRIGGERS_GROUP, WiimoteEmu::Classic::R_ANALOG,
+      &m_classic_overrider, m_right_trigger_value, 0, 0, 0, 31, Qt::Key_M, m_triggers_box);
 
   auto* triggers_layout = new QVBoxLayout;
   triggers_layout->addLayout(l_trigger_layout);
   triggers_layout->addLayout(r_trigger_layout);
   m_triggers_box->setLayout(triggers_layout);
 
-  m_a_button = CreateButton(QStringLiteral("&A"));
-  m_b_button = CreateButton(QStringLiteral("&B"));
-  m_1_button = CreateButton(QStringLiteral("&1"));
-  m_2_button = CreateButton(QStringLiteral("&2"));
-  m_plus_button = CreateButton(QStringLiteral("&+"));
-  m_minus_button = CreateButton(QStringLiteral("&-"));
-  m_home_button = CreateButton(QStringLiteral("&HOME"));
-  m_left_button = CreateButton(QStringLiteral("&Left"));
-  m_up_button = CreateButton(QStringLiteral("&Up"));
-  m_down_button = CreateButton(QStringLiteral("&Down"));
-  m_right_button = CreateButton(QStringLiteral("&Right"));
-  m_c_button = CreateButton(QStringLiteral("&C"));
-  m_z_button = CreateButton(QStringLiteral("&Z"));
+  m_a_button = CreateButton(QStringLiteral("&A"), WiimoteEmu::Wiimote::BUTTONS_GROUP,
+                            WiimoteEmu::Wiimote::A_BUTTON, &m_wiimote_overrider);
+  m_b_button = CreateButton(QStringLiteral("&B"), WiimoteEmu::Wiimote::BUTTONS_GROUP,
+                            WiimoteEmu::Wiimote::B_BUTTON, &m_wiimote_overrider);
+  m_1_button = CreateButton(QStringLiteral("&1"), WiimoteEmu::Wiimote::BUTTONS_GROUP,
+                            WiimoteEmu::Wiimote::ONE_BUTTON, &m_wiimote_overrider);
+  m_2_button = CreateButton(QStringLiteral("&2"), WiimoteEmu::Wiimote::BUTTONS_GROUP,
+                            WiimoteEmu::Wiimote::TWO_BUTTON, &m_wiimote_overrider);
+  m_plus_button = CreateButton(QStringLiteral("&+"), WiimoteEmu::Wiimote::BUTTONS_GROUP,
+                               WiimoteEmu::Wiimote::PLUS_BUTTON, &m_wiimote_overrider);
+  m_minus_button = CreateButton(QStringLiteral("&-"), WiimoteEmu::Wiimote::BUTTONS_GROUP,
+                                WiimoteEmu::Wiimote::MINUS_BUTTON, &m_wiimote_overrider);
+  m_home_button = CreateButton(QStringLiteral("&HOME"), WiimoteEmu::Wiimote::BUTTONS_GROUP,
+                               WiimoteEmu::Wiimote::HOME_BUTTON, &m_wiimote_overrider);
+
+  m_left_button = CreateButton(QStringLiteral("&Left"), WiimoteEmu::Wiimote::DPAD_GROUP,
+                               DIRECTION_LEFT, &m_wiimote_overrider);
+  m_up_button = CreateButton(QStringLiteral("&Up"), WiimoteEmu::Wiimote::DPAD_GROUP, DIRECTION_UP,
+                             &m_wiimote_overrider);
+  m_down_button = CreateButton(QStringLiteral("&Down"), WiimoteEmu::Wiimote::DPAD_GROUP,
+                               DIRECTION_DOWN, &m_wiimote_overrider);
+  m_right_button = CreateButton(QStringLiteral("&Right"), WiimoteEmu::Wiimote::DPAD_GROUP,
+                                DIRECTION_RIGHT, &m_wiimote_overrider);
+
+  m_c_button = CreateButton(QStringLiteral("&C"), WiimoteEmu::Nunchuk::BUTTONS_GROUP,
+                            WiimoteEmu::Nunchuk::C_BUTTON, &m_nunchuk_overrider);
+  m_z_button = CreateButton(QStringLiteral("&Z"), WiimoteEmu::Nunchuk::BUTTONS_GROUP,
+                            WiimoteEmu::Nunchuk::Z_BUTTON, &m_nunchuk_overrider);
 
   auto* buttons_layout = new QGridLayout;
   buttons_layout->addWidget(m_a_button, 0, 0);
@@ -196,21 +243,38 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
   m_nunchuk_buttons_box = new QGroupBox(tr("Nunchuk Buttons"));
   m_nunchuk_buttons_box->setLayout(nunchuk_buttons_layout);
 
-  m_classic_a_button = CreateButton(QStringLiteral("&A"));
-  m_classic_b_button = CreateButton(QStringLiteral("&B"));
-  m_classic_x_button = CreateButton(QStringLiteral("&X"));
-  m_classic_y_button = CreateButton(QStringLiteral("&Y"));
-  m_classic_l_button = CreateButton(QStringLiteral("&L"));
-  m_classic_r_button = CreateButton(QStringLiteral("&R"));
-  m_classic_zl_button = CreateButton(QStringLiteral("&ZL"));
-  m_classic_zr_button = CreateButton(QStringLiteral("ZR"));
-  m_classic_plus_button = CreateButton(QStringLiteral("&+"));
-  m_classic_minus_button = CreateButton(QStringLiteral("&-"));
-  m_classic_home_button = CreateButton(QStringLiteral("&HOME"));
-  m_classic_left_button = CreateButton(QStringLiteral("L&eft"));
-  m_classic_up_button = CreateButton(QStringLiteral("&Up"));
-  m_classic_down_button = CreateButton(QStringLiteral("&Down"));
-  m_classic_right_button = CreateButton(QStringLiteral("R&ight"));
+  m_classic_a_button = CreateButton(QStringLiteral("&A"), WiimoteEmu::Classic::BUTTONS_GROUP,
+                                    WiimoteEmu::Classic::A_BUTTON, &m_classic_overrider);
+  m_classic_b_button = CreateButton(QStringLiteral("&B"), WiimoteEmu::Classic::BUTTONS_GROUP,
+                                    WiimoteEmu::Classic::B_BUTTON, &m_classic_overrider);
+  m_classic_x_button = CreateButton(QStringLiteral("&X"), WiimoteEmu::Classic::BUTTONS_GROUP,
+                                    WiimoteEmu::Classic::X_BUTTON, &m_classic_overrider);
+  m_classic_y_button = CreateButton(QStringLiteral("&Y"), WiimoteEmu::Classic::BUTTONS_GROUP,
+                                    WiimoteEmu::Classic::Y_BUTTON, &m_classic_overrider);
+  m_classic_zl_button = CreateButton(QStringLiteral("&ZL"), WiimoteEmu::Classic::BUTTONS_GROUP,
+                                     WiimoteEmu::Classic::ZL_BUTTON, &m_classic_overrider);
+  m_classic_zr_button = CreateButton(QStringLiteral("ZR"), WiimoteEmu::Classic::BUTTONS_GROUP,
+                                     WiimoteEmu::Classic::ZR_BUTTON, &m_classic_overrider);
+  m_classic_plus_button = CreateButton(QStringLiteral("&+"), WiimoteEmu::Classic::BUTTONS_GROUP,
+                                       WiimoteEmu::Classic::PLUS_BUTTON, &m_classic_overrider);
+  m_classic_minus_button = CreateButton(QStringLiteral("&-"), WiimoteEmu::Classic::BUTTONS_GROUP,
+                                        WiimoteEmu::Classic::MINUS_BUTTON, &m_classic_overrider);
+  m_classic_home_button = CreateButton(QStringLiteral("&HOME"), WiimoteEmu::Classic::BUTTONS_GROUP,
+                                       WiimoteEmu::Classic::HOME_BUTTON, &m_classic_overrider);
+
+  m_classic_l_button = CreateButton(QStringLiteral("&L"), WiimoteEmu::Classic::TRIGGERS_GROUP,
+                                    WiimoteEmu::Classic::L_DIGITAL, &m_classic_overrider);
+  m_classic_r_button = CreateButton(QStringLiteral("&R"), WiimoteEmu::Classic::TRIGGERS_GROUP,
+                                    WiimoteEmu::Classic::R_DIGITAL, &m_classic_overrider);
+
+  m_classic_left_button = CreateButton(QStringLiteral("L&eft"), WiimoteEmu::Classic::DPAD_GROUP,
+                                       DIRECTION_LEFT, &m_classic_overrider);
+  m_classic_up_button = CreateButton(QStringLiteral("&Up"), WiimoteEmu::Classic::DPAD_GROUP,
+                                     DIRECTION_UP, &m_classic_overrider);
+  m_classic_down_button = CreateButton(QStringLiteral("&Down"), WiimoteEmu::Classic::DPAD_GROUP,
+                                       DIRECTION_DOWN, &m_classic_overrider);
+  m_classic_right_button = CreateButton(QStringLiteral("R&ight"), WiimoteEmu::Classic::DPAD_GROUP,
+                                        DIRECTION_RIGHT, &m_classic_overrider);
 
   auto* classic_buttons_layout = new QGridLayout;
   classic_buttons_layout->addWidget(m_classic_a_button, 0, 0);
@@ -247,11 +311,9 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
 
   setLayout(layout);
 
-  u8 ext = 0;
   if (Core::IsRunning())
   {
-    ext = static_cast<WiimoteEmu::Wiimote*>(Wiimote::GetConfig()->GetController(num))
-              ->GetActiveExtensionNumber();
+    m_active_extension = GetWiimote()->GetActiveExtensionNumber();
   }
   else
   {
@@ -261,16 +323,35 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
     ini.GetIfExists("Wiimote" + std::to_string(num + 1), "Extension", &extension);
 
     if (extension == "Nunchuk")
-      ext = 1;
-    if (extension == "Classic")
-      ext = 2;
+      m_active_extension = WiimoteEmu::ExtensionNumber::NUNCHUK;
+    else if (extension == "Classic")
+      m_active_extension = WiimoteEmu::ExtensionNumber::CLASSIC;
+    else
+      m_active_extension = WiimoteEmu::ExtensionNumber::NONE;
   }
-  UpdateExt(ext);
+  UpdateExt();
 }
 
-void WiiTASInputWindow::UpdateExt(u8 ext)
+WiimoteEmu::Wiimote* WiiTASInputWindow::GetWiimote()
 {
-  if (ext == 1)
+  return static_cast<WiimoteEmu::Wiimote*>(Wiimote::GetConfig()->GetController(m_num));
+}
+
+ControllerEmu::Attachments* WiiTASInputWindow::GetAttachments()
+{
+  return static_cast<ControllerEmu::Attachments*>(
+      GetWiimote()->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Attachments));
+}
+
+WiimoteEmu::Extension* WiiTASInputWindow::GetExtension()
+{
+  return static_cast<WiimoteEmu::Extension*>(
+      GetAttachments()->GetAttachmentList()[m_active_extension].get());
+}
+
+void WiiTASInputWindow::UpdateExt()
+{
+  if (m_active_extension == WiimoteEmu::ExtensionNumber::NUNCHUK)
   {
     setWindowTitle(tr("Wii TAS Input %1 - Wii Remote + Nunchuk").arg(m_num + 1));
     m_ir_box->show();
@@ -284,7 +365,7 @@ void WiiTASInputWindow::UpdateExt(u8 ext)
     m_remote_buttons_box->show();
     m_classic_buttons_box->hide();
   }
-  else if (ext == 2)
+  else if (m_active_extension == WiimoteEmu::ExtensionNumber::CLASSIC)
   {
     setWindowTitle(tr("Wii TAS Input %1 - Classic Controller").arg(m_num + 1));
     m_ir_box->hide();
@@ -314,183 +395,22 @@ void WiiTASInputWindow::UpdateExt(u8 ext)
   }
 }
 
-void WiiTASInputWindow::GetValues(DataReportBuilder& rpt, int ext,
-                                  const WiimoteEmu::EncryptionKey& key)
+void WiiTASInputWindow::hideEvent(QHideEvent* event)
 {
-  if (!isVisible())
-    return;
+  GetWiimote()->ClearInputOverrideFunction();
+  GetExtension()->ClearInputOverrideFunction();
+}
 
-  UpdateExt(ext);
+void WiiTASInputWindow::showEvent(QShowEvent* event)
+{
+  WiimoteEmu::Wiimote* wiimote = GetWiimote();
 
-  if (m_remote_buttons_box->isVisible() && rpt.HasCore())
-  {
-    DataReportBuilder::CoreData core;
-    rpt.GetCoreData(&core);
+  if (m_active_extension != WiimoteEmu::ExtensionNumber::CLASSIC)
+    wiimote->SetInputOverrideFunction(m_wiimote_overrider.GetInputOverrideFunction());
 
-    using EmuWiimote = WiimoteEmu::Wiimote;
+  if (m_active_extension == WiimoteEmu::ExtensionNumber::NUNCHUK)
+    GetExtension()->SetInputOverrideFunction(m_nunchuk_overrider.GetInputOverrideFunction());
 
-    u16& buttons = core.hex;
-    GetButton<u16>(m_a_button, buttons, EmuWiimote::BUTTON_A);
-    GetButton<u16>(m_b_button, buttons, EmuWiimote::BUTTON_B);
-    GetButton<u16>(m_1_button, buttons, EmuWiimote::BUTTON_ONE);
-    GetButton<u16>(m_2_button, buttons, EmuWiimote::BUTTON_TWO);
-    GetButton<u16>(m_plus_button, buttons, EmuWiimote::BUTTON_PLUS);
-    GetButton<u16>(m_minus_button, buttons, EmuWiimote::BUTTON_MINUS);
-    GetButton<u16>(m_home_button, buttons, EmuWiimote::BUTTON_HOME);
-    GetButton<u16>(m_left_button, buttons, EmuWiimote::PAD_LEFT);
-    GetButton<u16>(m_up_button, buttons, EmuWiimote::PAD_UP);
-    GetButton<u16>(m_down_button, buttons, EmuWiimote::PAD_DOWN);
-    GetButton<u16>(m_right_button, buttons, EmuWiimote::PAD_RIGHT);
-
-    rpt.SetCoreData(core);
-  }
-
-  if (m_remote_orientation_box->isVisible() && rpt.HasAccel())
-  {
-    // FYI: Interleaved reports may behave funky as not all data is always available.
-
-    AccelData accel;
-    rpt.GetAccelData(&accel);
-
-    GetSpinBoxU16(m_remote_orientation_x_value, accel.value.x);
-    GetSpinBoxU16(m_remote_orientation_y_value, accel.value.y);
-    GetSpinBoxU16(m_remote_orientation_z_value, accel.value.z);
-
-    rpt.SetAccelData(accel);
-  }
-
-  if (m_ir_box->isVisible() && rpt.HasIR() && !m_use_controller->isChecked())
-  {
-    u8* const ir_data = rpt.GetIRDataPtr();
-
-    u16 y = m_ir_y_value->value();
-    std::array<u16, 4> x;
-    x[0] = m_ir_x_value->value();
-    x[1] = x[0] + 100;
-    x[2] = x[0] - 10;
-    x[3] = x[1] + 10;
-
-    // FYI: This check is not entirely foolproof.
-    // TODO: IR "full" mode not implemented.
-    u8 mode = WiimoteEmu::CameraLogic::IR_MODE_BASIC;
-
-    if (rpt.GetIRDataSize() == sizeof(WiimoteEmu::IRExtended) * 4)
-      mode = WiimoteEmu::CameraLogic::IR_MODE_EXTENDED;
-    else if (rpt.GetIRDataSize() == sizeof(WiimoteEmu::IRFull) * 2)
-      mode = WiimoteEmu::CameraLogic::IR_MODE_FULL;
-
-    if (mode == WiimoteEmu::CameraLogic::IR_MODE_BASIC)
-    {
-      memset(ir_data, 0xFF, sizeof(WiimoteEmu::IRBasic) * 2);
-      auto* const ir_basic = reinterpret_cast<WiimoteEmu::IRBasic*>(ir_data);
-      for (int i = 0; i < 2; ++i)
-      {
-        if (x[i * 2] < 1024 && y < 768)
-        {
-          ir_basic[i].x1 = static_cast<u8>(x[i * 2]);
-          ir_basic[i].x1hi = x[i * 2] >> 8;
-
-          ir_basic[i].y1 = static_cast<u8>(y);
-          ir_basic[i].y1hi = y >> 8;
-        }
-        if (x[i * 2 + 1] < 1024 && y < 768)
-        {
-          ir_basic[i].x2 = static_cast<u8>(x[i * 2 + 1]);
-          ir_basic[i].x2hi = x[i * 2 + 1] >> 8;
-
-          ir_basic[i].y2 = static_cast<u8>(y);
-          ir_basic[i].y2hi = y >> 8;
-        }
-      }
-    }
-    else
-    {
-      // TODO: this code doesnt work, resulting in no IR TAS inputs in e.g. wii sports menu when no
-      // remote extension is used
-      memset(ir_data, 0xFF, sizeof(WiimoteEmu::IRExtended) * 4);
-      auto* const ir_extended = reinterpret_cast<WiimoteEmu::IRExtended*>(ir_data);
-      for (size_t i = 0; i < x.size(); ++i)
-      {
-        if (x[i] < 1024 && y < 768)
-        {
-          ir_extended[i].x = static_cast<u8>(x[i]);
-          ir_extended[i].xhi = x[i] >> 8;
-
-          ir_extended[i].y = static_cast<u8>(y);
-          ir_extended[i].yhi = y >> 8;
-
-          ir_extended[i].size = 10;
-        }
-      }
-    }
-  }
-
-  if (rpt.HasExt() && m_nunchuk_stick_box->isVisible())
-  {
-    u8* const ext_data = rpt.GetExtDataPtr();
-
-    auto& nunchuk = *reinterpret_cast<WiimoteEmu::Nunchuk::DataFormat*>(ext_data);
-
-    GetSpinBoxU8(m_nunchuk_stick_x_value, nunchuk.jx);
-    GetSpinBoxU8(m_nunchuk_stick_y_value, nunchuk.jy);
-
-    auto accel = nunchuk.GetAccel().value;
-    GetSpinBoxU16(m_nunchuk_orientation_x_value, accel.x);
-    GetSpinBoxU16(m_nunchuk_orientation_y_value, accel.y);
-    GetSpinBoxU16(m_nunchuk_orientation_z_value, accel.z);
-    nunchuk.SetAccel(accel);
-
-    u8 bt = nunchuk.GetButtons();
-    GetButton<u8>(m_c_button, bt, WiimoteEmu::Nunchuk::BUTTON_C);
-    GetButton<u8>(m_z_button, bt, WiimoteEmu::Nunchuk::BUTTON_Z);
-    nunchuk.SetButtons(bt);
-
-    key.Encrypt(reinterpret_cast<u8*>(&nunchuk), 0, sizeof(nunchuk));
-  }
-
-  if (m_classic_left_stick_box->isVisible())
-  {
-    u8* const ext_data = rpt.GetExtDataPtr();
-
-    auto& cc = *reinterpret_cast<WiimoteEmu::Classic::DataFormat*>(ext_data);
-    key.Decrypt(reinterpret_cast<u8*>(&cc), 0, sizeof(cc));
-
-    u16 bt = cc.GetButtons();
-    GetButton<u16>(m_classic_a_button, bt, WiimoteEmu::Classic::BUTTON_A);
-    GetButton<u16>(m_classic_b_button, bt, WiimoteEmu::Classic::BUTTON_B);
-    GetButton<u16>(m_classic_x_button, bt, WiimoteEmu::Classic::BUTTON_X);
-    GetButton<u16>(m_classic_y_button, bt, WiimoteEmu::Classic::BUTTON_Y);
-    GetButton<u16>(m_classic_plus_button, bt, WiimoteEmu::Classic::BUTTON_PLUS);
-    GetButton<u16>(m_classic_minus_button, bt, WiimoteEmu::Classic::BUTTON_MINUS);
-    GetButton<u16>(m_classic_l_button, bt, WiimoteEmu::Classic::TRIGGER_L);
-    GetButton<u16>(m_classic_r_button, bt, WiimoteEmu::Classic::TRIGGER_R);
-    GetButton<u16>(m_classic_zl_button, bt, WiimoteEmu::Classic::BUTTON_ZL);
-    GetButton<u16>(m_classic_zr_button, bt, WiimoteEmu::Classic::BUTTON_ZR);
-    GetButton<u16>(m_classic_home_button, bt, WiimoteEmu::Classic::BUTTON_HOME);
-    GetButton<u16>(m_classic_left_button, bt, WiimoteEmu::Classic::PAD_LEFT);
-    GetButton<u16>(m_classic_up_button, bt, WiimoteEmu::Classic::PAD_UP);
-    GetButton<u16>(m_classic_down_button, bt, WiimoteEmu::Classic::PAD_DOWN);
-    GetButton<u16>(m_classic_right_button, bt, WiimoteEmu::Classic::PAD_RIGHT);
-    cc.SetButtons(bt);
-
-    auto right_stick = cc.GetRightStick().value;
-    GetSpinBoxU8(m_classic_right_stick_x_value, right_stick.x);
-    GetSpinBoxU8(m_classic_right_stick_y_value, right_stick.y);
-    cc.SetRightStick(right_stick);
-
-    auto left_stick = cc.GetLeftStick().value;
-    GetSpinBoxU8(m_classic_left_stick_x_value, left_stick.x);
-    GetSpinBoxU8(m_classic_left_stick_y_value, left_stick.y);
-    cc.SetLeftStick(left_stick);
-
-    u8 rt = cc.GetRightTrigger().value;
-    GetSpinBoxU8(m_right_trigger_value, rt);
-    cc.SetRightTrigger(rt);
-
-    u8 lt = cc.GetLeftTrigger().value;
-    GetSpinBoxU8(m_left_trigger_value, lt);
-    cc.SetLeftTrigger(lt);
-
-    key.Encrypt(reinterpret_cast<u8*>(&cc), 0, sizeof(cc));
-  }
+  if (m_active_extension == WiimoteEmu::ExtensionNumber::CLASSIC)
+    GetExtension()->SetInputOverrideFunction(m_classic_overrider.GetInputOverrideFunction());
 }

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.h
@@ -5,31 +5,48 @@
 
 #include "DolphinQt/TAS/TASInputWindow.h"
 
-namespace WiimoteCommon
-{
-class DataReportBuilder;
-}
+#include "Core/HW/WiimoteEmu/ExtensionPort.h"
+
+class QGroupBox;
+class QHideEvent;
+class QShowEvent;
+class QSpinBox;
+class TASCheckBox;
 
 namespace WiimoteEmu
 {
-class EncryptionKey;
-}
+class Extension;
+class Wiimote;
+}  // namespace WiimoteEmu
 
-class QGroupBox;
-class QSpinBox;
-class TASCheckBox;
+namespace ControllerEmu
+{
+class Attachments;
+}
 
 class WiiTASInputWindow : public TASInputWindow
 {
   Q_OBJECT
 public:
   explicit WiiTASInputWindow(QWidget* parent, int num);
-  void GetValues(WiimoteCommon::DataReportBuilder& rpt, int ext,
-                 const WiimoteEmu::EncryptionKey& key);
+
+  void hideEvent(QHideEvent* event) override;
+  void showEvent(QShowEvent* event) override;
 
 private:
-  void UpdateExt(u8 ext);
+  WiimoteEmu::Wiimote* GetWiimote();
+  ControllerEmu::Attachments* GetAttachments();
+  WiimoteEmu::Extension* GetExtension();
+
+  void UpdateExt();
+
+  WiimoteEmu::ExtensionNumber m_active_extension;
   int m_num;
+
+  InputOverrider m_wiimote_overrider;
+  InputOverrider m_nunchuk_overrider;
+  InputOverrider m_classic_overrider;
+
   TASCheckBox* m_a_button;
   TASCheckBox* m_b_button;
   TASCheckBox* m_1_button;

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -140,6 +140,8 @@ elseif(ANDROID)
     ControllerInterface/Android/Android.h
     ControllerInterface/Touch/ButtonManager.cpp
     ControllerInterface/Touch/ButtonManager.h
+    ControllerInterface/Touch/InputOverrider.cpp
+    ControllerInterface/Touch/InputOverrider.h
     ControllerInterface/Touch/Touchscreen.cpp
     ControllerInterface/Touch/Touchscreen.h
   )

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -4,6 +4,7 @@
 #include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 
 #include <cmath>
+#include <optional>
 
 #include "Common/Common.h"
 #include "Common/MathUtil.h"
@@ -46,6 +47,34 @@ AnalogStick::ReshapeData AnalogStick::GetReshapableState(bool adjusted) const
 AnalogStick::StateData AnalogStick::GetState() const
 {
   return GetReshapableState(true);
+}
+
+AnalogStick::StateData AnalogStick::GetState(const InputOverrideFunction& override_func) const
+{
+  bool override_occurred = false;
+  return GetState(override_func, &override_occurred);
+}
+
+AnalogStick::StateData AnalogStick::GetState(const InputOverrideFunction& override_func,
+                                             bool* override_occurred) const
+{
+  StateData state = GetState();
+  if (!override_func)
+    return state;
+
+  if (const std::optional<ControlState> x_override = override_func(name, X_INPUT_OVERRIDE, state.x))
+  {
+    state.x = *x_override;
+    *override_occurred = true;
+  }
+
+  if (const std::optional<ControlState> y_override = override_func(name, Y_INPUT_OVERRIDE, state.y))
+  {
+    state.y = *y_override;
+    *override_occurred = true;
+  }
+
+  return state;
 }
 
 ControlState AnalogStick::GetGateRadiusAtAngle(double ang) const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -21,6 +21,8 @@ public:
   ControlState GetGateRadiusAtAngle(double ang) const override;
 
   StateData GetState() const;
+  StateData GetState(const InputOverrideFunction& override_func) const;
+  StateData GetState(const InputOverrideFunction& override_func, bool* override_occurred) const;
 
 private:
   Control* GetModifierInput() const override;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <string>
 
 #include "InputCommon/ControlReference/ControlReference.h"
@@ -23,6 +24,22 @@ public:
   {
     for (auto& control : controls)
       *buttons |= *(bitmasks++) * control->GetState<bool>();
+  }
+
+  template <typename C>
+  void GetState(C* const buttons, const C* bitmasks,
+                const InputOverrideFunction& override_func) const
+  {
+    if (!override_func)
+      return GetState(buttons, bitmasks);
+
+    for (auto& control : controls)
+    {
+      ControlState state = control->GetState();
+      if (std::optional<ControlState> state_override = override_func(name, control->name, state))
+        state = *state_override;
+      *buttons |= *(bitmasks++) * (std::lround(state) > 0);
+    }
   }
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -5,14 +5,18 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerInterface/CoreDevice.h"
 
 namespace ControllerEmu
 {
@@ -26,6 +30,9 @@ class NumericSetting;
 
 template <typename T>
 class SettingValue;
+
+using InputOverrideFunction = std::function<std::optional<ControlState>(
+    const std::string_view group_name, const std::string_view control_name, ControlState state)>;
 
 enum class GroupType
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -29,6 +29,7 @@ public:
 
   // Modifies the state
   StateData GetState(bool adjusted);
+  StateData GetState(bool adjusted, const ControllerEmu::InputOverrideFunction& override_func);
 
   // Yaw movement in radians.
   ControlState GetTotalYaw() const;
@@ -40,6 +41,8 @@ public:
   ControlState GetVerticalOffset() const;
 
 private:
+  Cursor::StateData UpdateState(Cursor::ReshapeData input);
+
   // This is used to reduce the cursor speed for relative input
   // to something that makes sense with the default range.
   static constexpr double STEP_PER_SEC = 0.01 * 200;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
@@ -4,6 +4,7 @@
 #include "InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -60,6 +61,53 @@ void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlSta
     }
 
     analog[i] = analog_value;
+  }
+}
+
+void MixedTriggers::GetState(u16* digital, const u16* bitmasks, ControlState* analog,
+                             const InputOverrideFunction& override_func, bool adjusted) const
+{
+  if (!override_func)
+    return GetState(digital, bitmasks, analog, adjusted);
+
+  const ControlState threshold = GetThreshold();
+  ControlState deadzone = GetDeadzone();
+
+  // Return raw values. (used in UI)
+  if (!adjusted)
+  {
+    deadzone = 0.0;
+  }
+
+  const int trigger_count = int(controls.size() / 2);
+  for (int i = 0; i != trigger_count; ++i)
+  {
+    bool button_bool = false;
+    const ControlState button_value = ApplyDeadzone(controls[i]->GetState(), deadzone);
+    ControlState analog_value = ApplyDeadzone(controls[trigger_count + i]->GetState(), deadzone);
+
+    // Apply threshold:
+    if (button_value > threshold)
+    {
+      analog_value = 1.0;
+      button_bool = true;
+    }
+
+    if (const std::optional<ControlState> button_override =
+            override_func(name, controls[i]->name, static_cast<ControlState>(button_bool)))
+    {
+      button_bool = std::lround(*button_override) > 0;
+    }
+
+    if (const std::optional<ControlState> analog_override =
+            override_func(name, controls[trigger_count + i]->name, analog_value))
+    {
+      analog_value = *analog_override;
+    }
+
+    if (button_bool)
+      *digital |= bitmasks[i];
+    analog[i] = std::min(analog_value, 1.0);
   }
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
@@ -17,6 +17,8 @@ public:
 
   void GetState(u16* digital, const u16* bitmasks, ControlState* analog,
                 bool adjusted = true) const;
+  void GetState(u16* digital, const u16* bitmasks, ControlState* analog,
+                const InputOverrideFunction& override_func, bool adjusted = true) const;
 
   ControlState GetDeadzone() const;
   ControlState GetThreshold() const;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
@@ -35,4 +35,21 @@ Slider::StateData Slider::GetState() const
 
   return {std::clamp(ApplyDeadzone(state, deadzone), -1.0, 1.0)};
 }
+
+Slider::StateData Slider::GetState(const InputOverrideFunction& override_func) const
+{
+  if (!override_func)
+    return GetState();
+
+  const ControlState deadzone = m_deadzone_setting.GetValue() / 100;
+  ControlState state = controls[1]->GetState() - controls[0]->GetState();
+
+  state = ApplyDeadzone(state, deadzone);
+
+  if (std::optional<ControlState> state_override = override_func(name, X_INPUT_OVERRIDE, state))
+    state = *state_override;
+
+  return {std::clamp(state, -1.0, 1.0)};
+}
+
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.h
@@ -23,6 +23,9 @@ public:
   explicit Slider(const std::string& name_);
 
   StateData GetState() const;
+  StateData GetState(const InputOverrideFunction& override_func) const;
+
+  static constexpr const char* X_INPUT_OVERRIDE = "X";
 
 private:
   SettingValue<double> m_deadzone_setting;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.h
@@ -26,6 +26,7 @@ public:
   explicit Triggers(const std::string& name);
 
   StateData GetState() const;
+  StateData GetState(const InputOverrideFunction& override_func) const;
 
 private:
   SettingValue<double> m_deadzone_setting;

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 
 #include "Common/IniFile.h"
 
@@ -176,4 +177,15 @@ void EmulatedController::LoadDefaults(const ControllerInterface& ciface)
     SetDefaultDevice(default_device_string);
   }
 }
+
+void EmulatedController::SetInputOverrideFunction(InputOverrideFunction override_func)
+{
+  m_input_override_function = std::move(override_func);
+}
+
+void EmulatedController::ClearInputOverrideFunction()
+{
+  m_input_override_function = {};
+}
+
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -20,8 +20,13 @@
 
 class ControllerInterface;
 
-const char* const named_directions[] = {_trans("Up"), _trans("Down"), _trans("Left"),
-                                        _trans("Right")};
+constexpr const char* DIRECTION_UP = _trans("Up");
+constexpr const char* DIRECTION_DOWN = _trans("Down");
+constexpr const char* DIRECTION_LEFT = _trans("Left");
+constexpr const char* DIRECTION_RIGHT = _trans("Right");
+
+constexpr const char* named_directions[] = {DIRECTION_UP, DIRECTION_DOWN, DIRECTION_LEFT,
+                                            DIRECTION_RIGHT};
 
 class ControlReference;
 
@@ -204,7 +209,7 @@ public:
 
   std::vector<std::unique_ptr<ControlGroup>> groups;
 
-  // Maps a float from -1.0..+1.0 to an integer of the provided values.
+  // Maps a float from -1.0..+1.0 to an integer in the provided range.
   template <typename T, typename F>
   static T MapFloat(F input_value, T zero_value, T neg_1_value = std::numeric_limits<T>::min(),
                     T pos_1_value = std::numeric_limits<T>::max())
@@ -225,6 +230,21 @@ public:
       return T(std::llround((pos_1_value - zero_value) * input_value + zero_value));
     else
       return T(std::llround((zero_value - neg_1_value) * input_value + zero_value));
+  }
+
+  // The inverse of the function above.
+  // Maps an integer in the provided range to a float in the range -1.0..1.0.
+  template <typename F, typename T>
+  static F MapToFloat(T input_value, T zero_value, T neg_1_value = std::numeric_limits<T>::min(),
+                      T pos_1_value = std::numeric_limits<T>::max())
+  {
+    static_assert(std::is_integral<T>(), "T is only sane for int types.");
+    static_assert(std::is_floating_point<F>(), "F is only sane for float types.");
+
+    if (input_value >= zero_value)
+      return F(input_value - zero_value) / F(pos_1_value - zero_value);
+    else
+      return -F(zero_value - input_value) / F(zero_value - neg_1_value);
   }
 
 protected:

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -15,6 +15,7 @@
 #include "Common/IniFile.h"
 #include "Common/MathUtil.h"
 #include "InputCommon/ControlReference/ExpressionParser.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
 class ControllerInterface;
@@ -184,6 +185,9 @@ public:
   void SetDefaultDevice(const std::string& device);
   void SetDefaultDevice(ciface::Core::DeviceQualifier devq);
 
+  void SetInputOverrideFunction(InputOverrideFunction override_func);
+  void ClearInputOverrideFunction();
+
   void UpdateReferences(const ControllerInterface& devi);
   void UpdateSingleControlReference(const ControllerInterface& devi, ControlReference* ref);
 
@@ -227,6 +231,8 @@ protected:
   // TODO: Wiimote attachments actually end up using their parent controller value for this,
   // so theirs won't be used (and thus shouldn't even exist).
   ciface::ExpressionParser::ControlEnvironment::VariableContainer m_expression_vars;
+
+  InputOverrideFunction m_input_override_function;
 
   void UpdateReferences(ciface::ExpressionParser::ControlEnvironment& env);
 

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -106,6 +106,10 @@ public:
   const ReshapeData& GetCenter() const;
   void SetCenter(ReshapeData center);
 
+  static constexpr const char* X_INPUT_OVERRIDE = "X";
+  static constexpr const char* Y_INPUT_OVERRIDE = "Y";
+  static constexpr const char* Z_INPUT_OVERRIDE = "Z";
+
 protected:
   ReshapeData Reshape(ControlState x, ControlState y, ControlState modifier = 0.0,
                       ControlState clamp = 1.0) const;

--- a/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.cpp
@@ -9,22 +9,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include "Common/Assert.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
-
-#include "Core/Core.h"
-#include "Core/HW/GCPad.h"
-#include "Core/HW/GCPadEmu.h"
-#include "Core/HW/Wiimote.h"
-#include "Core/HW/WiimoteEmu/Extension/Classic.h"
-#include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
-#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
-
-#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
-#include "InputCommon/ControllerEmu/StickGate.h"
 
 namespace ButtonManager
 {
@@ -698,39 +686,6 @@ float GetAxisValue(int pad_id, ButtonType axis)
     }
   }
   return value;
-}
-
-double GetInputRadiusAtAngle(int pad_id, ButtonType stick, double angle)
-{
-  // To avoid a crash, don't access controllers before they've been initialized by the boot process
-  if (!Core::IsRunningAndStarted())
-    return 0;
-
-  ControllerEmu::ControlGroup* group;
-
-  switch (stick)
-  {
-  case STICK_MAIN:
-    group = Pad::GetGroup(pad_id, PadGroup::MainStick);
-    break;
-  case STICK_C:
-    group = Pad::GetGroup(pad_id, PadGroup::CStick);
-    break;
-  case NUNCHUK_STICK:
-    group = Wiimote::GetNunchukGroup(pad_id, WiimoteEmu::NunchukGroup::Stick);
-    break;
-  case CLASSIC_STICK_LEFT:
-    group = Wiimote::GetClassicGroup(pad_id, WiimoteEmu::ClassicGroup::LeftStick);
-    break;
-  case CLASSIC_STICK_RIGHT:
-    group = Wiimote::GetClassicGroup(pad_id, WiimoteEmu::ClassicGroup::RightStick);
-    break;
-  default:
-    ASSERT(false);
-    return 0;
-  }
-
-  return static_cast<ControllerEmu::ReshapableInput*>(group)->GetInputRadiusAtAngle(angle);
 }
 
 bool GamepadEvent(const std::string& dev, int button, int action)

--- a/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.h
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.h
@@ -272,9 +272,6 @@ void Init(const std::string&);
 bool GetButtonPressed(int pad_id, ButtonType button);
 float GetAxisValue(int pad_id, ButtonType axis);
 
-// emu_pad_id is numbered 0 to 3 for both GC pads and Wiimotes
-double GetInputRadiusAtAngle(int emu_pad_id, ButtonType stick, double angle);
-
 bool GamepadEvent(const std::string& dev, int button, int action);
 void GamepadAxisEvent(const std::string& dev, int axis, float value);
 

--- a/Source/Core/InputCommon/ControllerInterface/Touch/InputOverrider.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/InputOverrider.cpp
@@ -1,0 +1,272 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "InputCommon/ControllerInterface/Touch/InputOverrider.h"
+
+#include <array>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "Common/Assert.h"
+
+#include "Core/HW/GCPad.h"
+#include "Core/HW/GCPadEmu.h"
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/Extension/Classic.h"
+#include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+
+#include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/StickGate.h"
+#include "InputCommon/ControllerInterface/CoreDevice.h"
+#include "InputCommon/InputConfig.h"
+
+namespace ciface::Touch
+{
+namespace
+{
+struct InputState
+{
+  ControlState normal_state = 0;
+  ControlState override_state = 0;
+  bool overriding = false;
+};
+
+using ControlsMap = std::map<std::pair<std::string_view, std::string_view>, ControlID>;
+using StateArray = std::array<InputState, ControlID::NUMBER_OF_CONTROLS>;
+
+std::array<StateArray, 4> s_state_arrays;
+
+const ControlsMap s_gcpad_controls_map = {{
+    {{GCPad::BUTTONS_GROUP, GCPad::A_BUTTON}, ControlID::GCPAD_A_BUTTON},
+    {{GCPad::BUTTONS_GROUP, GCPad::B_BUTTON}, ControlID::GCPAD_B_BUTTON},
+    {{GCPad::BUTTONS_GROUP, GCPad::X_BUTTON}, ControlID::GCPAD_X_BUTTON},
+    {{GCPad::BUTTONS_GROUP, GCPad::Y_BUTTON}, ControlID::GCPAD_Y_BUTTON},
+    {{GCPad::BUTTONS_GROUP, GCPad::Z_BUTTON}, ControlID::GCPAD_Z_BUTTON},
+    {{GCPad::BUTTONS_GROUP, GCPad::START_BUTTON}, ControlID::GCPAD_START_BUTTON},
+    {{GCPad::DPAD_GROUP, DIRECTION_UP}, ControlID::GCPAD_DPAD_UP},
+    {{GCPad::DPAD_GROUP, DIRECTION_DOWN}, ControlID::GCPAD_DPAD_DOWN},
+    {{GCPad::DPAD_GROUP, DIRECTION_LEFT}, ControlID::GCPAD_DPAD_LEFT},
+    {{GCPad::DPAD_GROUP, DIRECTION_RIGHT}, ControlID::GCPAD_DPAD_RIGHT},
+    {{GCPad::TRIGGERS_GROUP, GCPad::L_DIGITAL}, ControlID::GCPAD_L_DIGITAL},
+    {{GCPad::TRIGGERS_GROUP, GCPad::R_DIGITAL}, ControlID::GCPAD_R_DIGITAL},
+    {{GCPad::TRIGGERS_GROUP, GCPad::L_ANALOG}, ControlID::GCPAD_L_ANALOG},
+    {{GCPad::TRIGGERS_GROUP, GCPad::R_ANALOG}, ControlID::GCPAD_R_ANALOG},
+    {{GCPad::MAIN_STICK_GROUP, ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE},
+     ControlID::GCPAD_MAIN_STICK_X},
+    {{GCPad::MAIN_STICK_GROUP, ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE},
+     ControlID::GCPAD_MAIN_STICK_Y},
+    {{GCPad::C_STICK_GROUP, ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE},
+     ControlID::GCPAD_C_STICK_X},
+    {{GCPad::C_STICK_GROUP, ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE},
+     ControlID::GCPAD_C_STICK_Y},
+}};
+
+const ControlsMap s_wiimote_controls_map = {{
+    {{WiimoteEmu::Wiimote::BUTTONS_GROUP, WiimoteEmu::Wiimote::A_BUTTON},
+     ControlID::WIIMOTE_A_BUTTON},
+    {{WiimoteEmu::Wiimote::BUTTONS_GROUP, WiimoteEmu::Wiimote::B_BUTTON},
+     ControlID::WIIMOTE_B_BUTTON},
+    {{WiimoteEmu::Wiimote::BUTTONS_GROUP, WiimoteEmu::Wiimote::ONE_BUTTON},
+     ControlID::WIIMOTE_ONE_BUTTON},
+    {{WiimoteEmu::Wiimote::BUTTONS_GROUP, WiimoteEmu::Wiimote::TWO_BUTTON},
+     ControlID::WIIMOTE_TWO_BUTTON},
+    {{WiimoteEmu::Wiimote::BUTTONS_GROUP, WiimoteEmu::Wiimote::PLUS_BUTTON},
+     ControlID::WIIMOTE_PLUS_BUTTON},
+    {{WiimoteEmu::Wiimote::BUTTONS_GROUP, WiimoteEmu::Wiimote::MINUS_BUTTON},
+     ControlID::WIIMOTE_MINUS_BUTTON},
+    {{WiimoteEmu::Wiimote::BUTTONS_GROUP, WiimoteEmu::Wiimote::HOME_BUTTON},
+     ControlID::WIIMOTE_HOME_BUTTON},
+    {{WiimoteEmu::Wiimote::DPAD_GROUP, DIRECTION_UP}, ControlID::WIIMOTE_DPAD_UP},
+    {{WiimoteEmu::Wiimote::DPAD_GROUP, DIRECTION_DOWN}, ControlID::WIIMOTE_DPAD_DOWN},
+    {{WiimoteEmu::Wiimote::DPAD_GROUP, DIRECTION_LEFT}, ControlID::WIIMOTE_DPAD_LEFT},
+    {{WiimoteEmu::Wiimote::DPAD_GROUP, DIRECTION_RIGHT}, ControlID::WIIMOTE_DPAD_RIGHT},
+    {{WiimoteEmu::Wiimote::IR_GROUP, ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE},
+     ControlID::WIIMOTE_IR_X},
+    {{WiimoteEmu::Wiimote::IR_GROUP, ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE},
+     ControlID::WIIMOTE_IR_Y},
+}};
+
+const ControlsMap s_nunchuk_controls_map = {{
+    {{WiimoteEmu::Nunchuk::BUTTONS_GROUP, WiimoteEmu::Nunchuk::C_BUTTON},
+     ControlID::NUNCHUK_C_BUTTON},
+    {{WiimoteEmu::Nunchuk::BUTTONS_GROUP, WiimoteEmu::Nunchuk::Z_BUTTON},
+     ControlID::NUNCHUK_Z_BUTTON},
+    {{WiimoteEmu::Nunchuk::STICK_GROUP, ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE},
+     ControlID::NUNCHUK_STICK_X},
+    {{WiimoteEmu::Nunchuk::STICK_GROUP, ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE},
+     ControlID::NUNCHUK_STICK_Y},
+}};
+
+const ControlsMap s_classic_controls_map = {{
+    {{WiimoteEmu::Classic::BUTTONS_GROUP, WiimoteEmu::Classic::A_BUTTON},
+     ControlID::CLASSIC_A_BUTTON},
+    {{WiimoteEmu::Classic::BUTTONS_GROUP, WiimoteEmu::Classic::B_BUTTON},
+     ControlID::CLASSIC_B_BUTTON},
+    {{WiimoteEmu::Classic::BUTTONS_GROUP, WiimoteEmu::Classic::X_BUTTON},
+     ControlID::CLASSIC_X_BUTTON},
+    {{WiimoteEmu::Classic::BUTTONS_GROUP, WiimoteEmu::Classic::Y_BUTTON},
+     ControlID::CLASSIC_Y_BUTTON},
+    {{WiimoteEmu::Classic::BUTTONS_GROUP, WiimoteEmu::Classic::ZL_BUTTON},
+     ControlID::CLASSIC_ZL_BUTTON},
+    {{WiimoteEmu::Classic::BUTTONS_GROUP, WiimoteEmu::Classic::ZR_BUTTON},
+     ControlID::CLASSIC_ZR_BUTTON},
+    {{WiimoteEmu::Classic::BUTTONS_GROUP, WiimoteEmu::Classic::PLUS_BUTTON},
+     ControlID::CLASSIC_PLUS_BUTTON},
+    {{WiimoteEmu::Classic::BUTTONS_GROUP, WiimoteEmu::Classic::MINUS_BUTTON},
+     ControlID::CLASSIC_MINUS_BUTTON},
+    {{WiimoteEmu::Classic::BUTTONS_GROUP, WiimoteEmu::Classic::HOME_BUTTON},
+     ControlID::CLASSIC_HOME_BUTTON},
+    {{WiimoteEmu::Classic::DPAD_GROUP, DIRECTION_UP}, ControlID::CLASSIC_DPAD_UP},
+    {{WiimoteEmu::Classic::DPAD_GROUP, DIRECTION_DOWN}, ControlID::CLASSIC_DPAD_DOWN},
+    {{WiimoteEmu::Classic::DPAD_GROUP, DIRECTION_LEFT}, ControlID::CLASSIC_DPAD_LEFT},
+    {{WiimoteEmu::Classic::DPAD_GROUP, DIRECTION_RIGHT}, ControlID::CLASSIC_DPAD_RIGHT},
+    {{WiimoteEmu::Classic::TRIGGERS_GROUP, WiimoteEmu::Classic::L_DIGITAL},
+     ControlID::CLASSIC_L_DIGITAL},
+    {{WiimoteEmu::Classic::TRIGGERS_GROUP, WiimoteEmu::Classic::R_DIGITAL},
+     ControlID::CLASSIC_R_DIGITAL},
+    {{WiimoteEmu::Classic::TRIGGERS_GROUP, WiimoteEmu::Classic::L_ANALOG},
+     ControlID::CLASSIC_L_ANALOG},
+    {{WiimoteEmu::Classic::TRIGGERS_GROUP, WiimoteEmu::Classic::R_ANALOG},
+     ControlID::CLASSIC_R_ANALOG},
+    {{WiimoteEmu::Classic::LEFT_STICK_GROUP, ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE},
+     ControlID::CLASSIC_LEFT_STICK_X},
+    {{WiimoteEmu::Classic::LEFT_STICK_GROUP, ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE},
+     ControlID::CLASSIC_LEFT_STICK_Y},
+    {{WiimoteEmu::Classic::RIGHT_STICK_GROUP, ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE},
+     ControlID::CLASSIC_RIGHT_STICK_X},
+    {{WiimoteEmu::Classic::RIGHT_STICK_GROUP, ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE},
+     ControlID::CLASSIC_RIGHT_STICK_Y},
+}};
+
+ControllerEmu::InputOverrideFunction GetInputOverrideFunction(const ControlsMap& controls_map,
+                                                              size_t i)
+{
+  StateArray& state_array = s_state_arrays[i];
+
+  return [&](std::string_view group_name, std::string_view control_name,
+             ControlState controller_state) -> std::optional<ControlState> {
+    const auto it = controls_map.find(std::make_pair(group_name, control_name));
+    if (it == controls_map.end())
+      return std::nullopt;
+
+    const ControlID control = it->second;
+    InputState& input_state = state_array[control];
+    if (input_state.normal_state != controller_state)
+    {
+      input_state.normal_state = controller_state;
+      input_state.overriding = false;
+    }
+
+    return input_state.overriding ? std::make_optional(input_state.override_state) : std::nullopt;
+  };
+}
+
+}  // namespace
+
+void RegisterGameCubeInputOverrider(int controller_index)
+{
+  Pad::GetConfig()
+      ->GetController(controller_index)
+      ->SetInputOverrideFunction(GetInputOverrideFunction(s_gcpad_controls_map, controller_index));
+}
+
+void RegisterWiiInputOverrider(int controller_index)
+{
+  auto* wiimote =
+      static_cast<WiimoteEmu::Wiimote*>(Wiimote::GetConfig()->GetController(controller_index));
+
+  wiimote->SetInputOverrideFunction(
+      GetInputOverrideFunction(s_wiimote_controls_map, controller_index));
+
+  auto& attachments = static_cast<ControllerEmu::Attachments*>(
+                          wiimote->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Attachments))
+                          ->GetAttachmentList();
+
+  attachments[WiimoteEmu::ExtensionNumber::NUNCHUK]->SetInputOverrideFunction(
+      GetInputOverrideFunction(s_nunchuk_controls_map, controller_index));
+  attachments[WiimoteEmu::ExtensionNumber::CLASSIC]->SetInputOverrideFunction(
+      GetInputOverrideFunction(s_classic_controls_map, controller_index));
+}
+
+void UnregisterGameCubeInputOverrider(int controller_index)
+{
+  Pad::GetConfig()->GetController(controller_index)->ClearInputOverrideFunction();
+
+  for (size_t i = ControlID::FIRST_GC_CONTROL; i <= ControlID::LAST_GC_CONTROL; ++i)
+    s_state_arrays[controller_index][i].overriding = false;
+}
+
+void UnregisterWiiInputOverrider(int controller_index)
+{
+  auto* wiimote =
+      static_cast<WiimoteEmu::Wiimote*>(Wiimote::GetConfig()->GetController(controller_index));
+
+  wiimote->ClearInputOverrideFunction();
+
+  auto& attachments = static_cast<ControllerEmu::Attachments*>(
+                          wiimote->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Attachments))
+                          ->GetAttachmentList();
+
+  attachments[WiimoteEmu::ExtensionNumber::NUNCHUK]->ClearInputOverrideFunction();
+  attachments[WiimoteEmu::ExtensionNumber::CLASSIC]->ClearInputOverrideFunction();
+
+  for (size_t i = ControlID::FIRST_WII_CONTROL; i <= ControlID::LAST_WII_CONTROL; ++i)
+    s_state_arrays[controller_index][i].overriding = false;
+}
+
+void SetControlState(int controller_index, ControlID control, double state)
+{
+  InputState& input_state = s_state_arrays[controller_index][control];
+
+  input_state.override_state = state;
+  input_state.overriding = true;
+}
+
+void ClearControlState(int controller_index, ControlID control)
+{
+  InputState& input_state = s_state_arrays[controller_index][control];
+
+  input_state.overriding = false;
+}
+
+double GetGateRadiusAtAngle(int controller_index, ControlID stick, double angle)
+{
+  ControllerEmu::ControlGroup* group;
+
+  switch (stick)
+  {
+  case ControlID::GCPAD_MAIN_STICK_X:
+  case ControlID::GCPAD_MAIN_STICK_Y:
+    group = Pad::GetGroup(controller_index, PadGroup::MainStick);
+    break;
+  case ControlID::GCPAD_C_STICK_X:
+  case ControlID::GCPAD_C_STICK_Y:
+    group = Pad::GetGroup(controller_index, PadGroup::CStick);
+    break;
+  case ControlID::NUNCHUK_STICK_X:
+  case ControlID::NUNCHUK_STICK_Y:
+    group = Wiimote::GetNunchukGroup(controller_index, WiimoteEmu::NunchukGroup::Stick);
+    break;
+  case ControlID::CLASSIC_LEFT_STICK_X:
+  case ControlID::CLASSIC_LEFT_STICK_Y:
+    group = Wiimote::GetClassicGroup(controller_index, WiimoteEmu::ClassicGroup::LeftStick);
+    break;
+  case ControlID::CLASSIC_RIGHT_STICK_X:
+  case ControlID::CLASSIC_RIGHT_STICK_Y:
+    group = Wiimote::GetClassicGroup(controller_index, WiimoteEmu::ClassicGroup::RightStick);
+    break;
+  default:
+    ASSERT(false);
+    return 0;
+  }
+
+  return static_cast<ControllerEmu::ReshapableInput*>(group)->GetGateRadiusAtAngle(angle);
+}
+}  // namespace ciface::Touch

--- a/Source/Core/InputCommon/ControllerInterface/Touch/InputOverrider.h
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/InputOverrider.h
@@ -1,0 +1,89 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace ciface::Touch
+{
+enum ControlID
+{
+  GCPAD_A_BUTTON = 0,
+  GCPAD_B_BUTTON = 1,
+  GCPAD_X_BUTTON = 2,
+  GCPAD_Y_BUTTON = 3,
+  GCPAD_Z_BUTTON = 4,
+  GCPAD_START_BUTTON = 5,
+  GCPAD_DPAD_UP = 6,
+  GCPAD_DPAD_DOWN = 7,
+  GCPAD_DPAD_LEFT = 8,
+  GCPAD_DPAD_RIGHT = 9,
+  GCPAD_L_DIGITAL = 10,
+  GCPAD_R_DIGITAL = 11,
+  GCPAD_L_ANALOG = 12,
+  GCPAD_R_ANALOG = 13,
+  GCPAD_MAIN_STICK_X = 14,
+  GCPAD_MAIN_STICK_Y = 15,
+  GCPAD_C_STICK_X = 16,
+  GCPAD_C_STICK_Y = 17,
+
+  WIIMOTE_A_BUTTON = 18,
+  WIIMOTE_B_BUTTON = 19,
+  WIIMOTE_ONE_BUTTON = 20,
+  WIIMOTE_TWO_BUTTON = 21,
+  WIIMOTE_PLUS_BUTTON = 22,
+  WIIMOTE_MINUS_BUTTON = 23,
+  WIIMOTE_HOME_BUTTON = 24,
+  WIIMOTE_DPAD_UP = 25,
+  WIIMOTE_DPAD_DOWN = 26,
+  WIIMOTE_DPAD_LEFT = 27,
+  WIIMOTE_DPAD_RIGHT = 28,
+  WIIMOTE_IR_X = 29,
+  WIIMOTE_IR_Y = 30,
+
+  NUNCHUK_C_BUTTON = 31,
+  NUNCHUK_Z_BUTTON = 32,
+  NUNCHUK_STICK_X = 33,
+  NUNCHUK_STICK_Y = 34,
+
+  CLASSIC_A_BUTTON = 35,
+  CLASSIC_B_BUTTON = 36,
+  CLASSIC_X_BUTTON = 37,
+  CLASSIC_Y_BUTTON = 38,
+  CLASSIC_ZL_BUTTON = 39,
+  CLASSIC_ZR_BUTTON = 40,
+  CLASSIC_PLUS_BUTTON = 41,
+  CLASSIC_MINUS_BUTTON = 42,
+  CLASSIC_HOME_BUTTON = 43,
+  CLASSIC_DPAD_UP = 44,
+  CLASSIC_DPAD_DOWN = 45,
+  CLASSIC_DPAD_LEFT = 46,
+  CLASSIC_DPAD_RIGHT = 47,
+  CLASSIC_L_DIGITAL = 48,
+  CLASSIC_R_DIGITAL = 49,
+  CLASSIC_L_ANALOG = 50,
+  CLASSIC_R_ANALOG = 51,
+  CLASSIC_LEFT_STICK_X = 52,
+  CLASSIC_LEFT_STICK_Y = 53,
+  CLASSIC_RIGHT_STICK_X = 54,
+  CLASSIC_RIGHT_STICK_Y = 55,
+
+  NUMBER_OF_CONTROLS,
+
+  FIRST_GC_CONTROL = GCPAD_A_BUTTON,
+  LAST_GC_CONTROL = GCPAD_C_STICK_Y,
+  FIRST_WII_CONTROL = WIIMOTE_A_BUTTON,
+  LAST_WII_CONTROL = CLASSIC_RIGHT_STICK_Y,
+
+};
+void RegisterGameCubeInputOverrider(int controller_index);
+void RegisterWiiInputOverrider(int controller_index);
+void UnregisterGameCubeInputOverrider(int controller_index);
+void UnregisterWiiInputOverrider(int controller_index);
+
+void SetControlState(int controller_index, ControlID control, double state);
+void ClearControlState(int controller_index, ControlID control);
+
+// Angle is in radians and should be non-negative
+double GetGateRadiusAtAngle(int controller_index, ControlID stick, double angle);
+}  // namespace ciface::Touch


### PR DESCRIPTION
Dolphin currently has two parts of the codebase that directly map UI elements to emulated controls: TAS input in DolphinQt, and the touch overlay on Android. The two accomplish this using entirely different methods, both of which have their own drawbacks. TAS input manually pokes around inside Wii Remote input reports instead of letting this be handled by the normal input report creation code, and does so in a way that isn't always reliable. The Android touch overlay requires a fixed mapping to be present in GCPadNew.ini and WiimoteNew.ini, meaning that these two files can't be used for storing the user's actual controller mappings, which has led to the creation of a second controller mapping system implemented in Java which lacks many of the features present on PC.

This pull request tries to improve the situation by replacing both of these two systems with a new "input override" framework. The basis of it is that each `EmulatedController` lets you set a callback function which can inspect and replace the input coming from InputCommon. TAS input and Android both register such callback functions.

Getting rid of the Android touch overlay's dependency on ButtonManager like this PR does is a prerequisite for getting rid of the controller indirection on Android. I'm aiming to work on fully getting rid of the controller indirection around July if this gets merged.

One important note: This pull request breaks a certain hack that some Android users have been using in which they intentionally desync the controller used by the emulation core and the controller used by the touch overlay by first configuring one Wii Remote extension in a game INI and then configuring a different Wii Remote extension in the touch overlay settings. Normally this would result in the touch overlay not working, but what these Android users then do is to edit the fixed mappings in WiimoteNew.ini (typically by using a profile instead of by editing the file directly) to let them play games that use a Wii Remote or Wii Remote + Nunchuk using an on-screen Classic Controller, which has more buttons. (This is especially popular for Skyward Sword, because of its complex motion controls.) With this PR, the contents of WiimoteNew.ini no longer affect the touch controller, so this "trick" no longer works. Since editing the fixed mappings in WiimoteNew.ini isn't something you're intended to do, and since this PR is necessary for future improvements of the controller code on Android, I am not going to try to support this hack. The proper way to go would be to add a way for users to add custom touch overlay buttons with custom mappings, but that would have to be a future project.

@jordan-woyak I would appreciate if you could review this. Not sure if this approach is the best one possible, but I would really like to be able to get rid of the controller indirection on Android.