### PR TITLE
MMU: Fix SDR updates being silently dropped in some cases

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -980,14 +980,16 @@ void SDRUpdated()
 {
   u32 htabmask = SDR1_HTABMASK(PowerPC::ppcState.spr[SPR_SDR]);
   if (!Common::IsValidLowMask(htabmask))
-  {
-    return;
-  }
+    WARN_LOG_FMT(POWERPC, "Invalid HTABMASK: 0b{:032b}", htabmask);
+
+  // While 6xx_pem.pdf §7.6.1.1 mentions that the number of trailing zeros in HTABORG
+  // must be equal to the number of trailing ones in the mask (i.e. HTABORG must be
+  // properly aligned), this is actually not a hard requirement. Real hardware will just OR
+  // the base address anyway. Ignoring SDR changes would lead to incorrect emulation.
   u32 htaborg = SDR1_HTABORG(PowerPC::ppcState.spr[SPR_SDR]);
   if (htaborg & htabmask)
-  {
-    return;
-  }
+    WARN_LOG_FMT(POWERPC, "Invalid HTABORG: htaborg=0x{:08x} htabmask=0x{:08x}", htaborg, htabmask);
+
   PowerPC::ppcState.pagetable_base = htaborg << 16;
   PowerPC::ppcState.pagetable_hashmask = ((htabmask << 10) | 0x3ff);
 }

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1113,7 +1113,7 @@ static TranslateAddressResult TranslatePageAddress(const u32 address, const XChe
 
   // hash function no 1 "xor" .360
   u32 hash = (VSID ^ page_index);
-  u32 pte1 = Common::swap32((VSID << 7) | api | PTE1_V);
+  u32 pte1 = (VSID << 7) | api | PTE1_V;
 
   for (int hash_func = 0; hash_func < 2; hash_func++)
   {
@@ -1121,7 +1121,7 @@ static TranslateAddressResult TranslatePageAddress(const u32 address, const XChe
     if (hash_func == 1)
     {
       hash = ~hash;
-      pte1 |= PTE1_H << 24;
+      pte1 |= PTE1_H;
     }
 
     u32 pteg_addr =
@@ -1129,7 +1129,7 @@ static TranslateAddressResult TranslatePageAddress(const u32 address, const XChe
 
     for (int i = 0; i < 8; i++, pteg_addr += 8)
     {
-      u32 pteg = Common::swap32(Memory::Read_U32(pteg_addr));
+      const u32 pteg = Memory::Read_U32(pteg_addr);
 
       if (pte1 == pteg)
       {


### PR DESCRIPTION
While 6xx_pem.pdf §7.6.1.1 mentions that the number of trailing zeros in HTABORG must be equal to the number of trailing ones in the mask (i.e. HTABORG must be properly aligned), this is actually not a hard requirement. Real hardware will just OR the base address anyway. Ignoring SDR changes would lead to incorrect emulation.

Logging a warning instead of dropping the SDR update silently is a saner behaviour.

(Thanks to @booto for helping me understand this a bit better and to @JMC47 for testing)

---

The only reason the US version of Pokemon Box worked with Dolphin's faulty assumption is that the pagetable buffer is heap allocated and it happens to be located at 0xbc0000 on that version. `0xbc0000 >> 16` = 0xbc is even so the alignment check would pass.

On the JP version, the pagetable buffer is found at 0xbf0000, which does not pass the check. (Side note: yes, this means that only half of the pagetable buffer is actually used. 0xc00000-0xc10000 is full of zeros.)

---

Real hardware doesn't appear to mask HTABORG or SDR:

* If it actually used 0xbe instead of 0xbf as the value of HTABORG, the JP version wouldn't work on console either, because there are only zeros and no valid pagetable entries at 0xbe0000-0xbf0000...
* ...assuming it configures the page tables by using the 0xbf0000 address. But the JP version doesn't use the address of the buffer it allocated. Instead it re-derives the pagetable base address and the addresses of all PTEs by reading back SDR and doing the following:
![image](https://user-images.githubusercontent.com/4209061/113751904-b4950980-970c-11eb-99e1-a75d6301e713.png)
    Assuming that real hw masked SDR, this would cause the game to clobber whatever is at 0xbe0000-0xbf0000, but theoretically the game would run fine if that memory area happens to be unallocated.

    **In practice** masking SDR in Dolphin makes the game clobber that memory area (as expected) **but also crashes the game** so that can't be what is happening on console.

Based on those observations, I am reasonably sure that real hardware doesn't actually mask HTABORG to fix its alignment.

In this situation, HTABORG = 0xbf and HTABMASK = 0x1 causes the second half of the pagetable to be aliased to the first half. This also seems to be the expected behavior because:

* The game's init code (shown above) calculates PTE addresses by doing an OR rather than an ADD, and the second half of the table is completely blank.
* OR'ing would be simpler than doing an addition for the hardware.
* It also matches the behavior described in 6xx_pem.pdf Figure 7-21:

![Figure 7-21](https://user-images.githubusercontent.com/4209061/113752905-c88d3b00-970d-11eb-92d2-c2f86094b9b5.png)

**Remaining mysteries**:

* What happens if HTABMASK is invalid (contains 0s at the end)? My gut feeling is that real hw would just blindly AND just like how it blindly ORs, but we would need a hwtest to be sure.
* What happens if the reserved bits in SDR aren't zero? 6xx_pem.pdf suggests that a MCE can occur but again I don't know what actually happens on a real Wii. (Note that Dolphin completely ignores the reserved bits, both prior to and after this PR.)

Perhaps those should be addressed in a followup PR.