### PR TITLE
Freelook: add position offset binding

### DIFF
--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -9,6 +9,7 @@
 
 #include "Common/CommonTypes.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 class InputConfig;
 
@@ -26,6 +27,7 @@ enum class FreeLookGroup
   FieldOfView,
   Other,
   Rotation,
+  PositionOffset,
 };
 
 namespace FreeLook
@@ -54,6 +56,19 @@ public:
 
 private:
   ControllerEmu::Buttons* m_move_buttons;
+
+  // The following position offsets are doubles
+  // but used as floats in the camera system
+  // This is done because the settings and qt
+  // controls are in double format
+  ControllerEmu::SettingValue<double> m_pos_x;
+  double m_pos_last_x;
+  ControllerEmu::SettingValue<double> m_pos_y;
+  double m_pos_last_y;
+  ControllerEmu::SettingValue<double> m_pos_z;
+  double m_pos_last_z;
+  ControllerEmu::ControlGroup* m_position_offset_group;
+
   ControllerEmu::Buttons* m_speed_buttons;
   ControllerEmu::Buttons* m_fov_buttons;
   ControllerEmu::Buttons* m_other_buttons;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 130;  // Last changed in PR 9545
+constexpr u32 STATE_VERSION = 131;  // Last changed in PR 9626
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -122,6 +122,8 @@ add_executable(dolphin-emu
   Config/LogWidget.h
   Config/Mapping/FreeLookGeneral.cpp
   Config/Mapping/FreeLookGeneral.h
+  Config/Mapping/FreeLookPosition.cpp
+  Config/Mapping/FreeLookPosition.h
   Config/Mapping/FreeLookRotation.cpp
   Config/Mapping/FreeLookRotation.h
   Config/Mapping/GCKeyboardEmu.cpp

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLookGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLookGeneral.cpp
@@ -20,14 +20,12 @@ void FreeLookGeneral::CreateMainLayout()
   auto* layout = new QGridLayout;
 
   layout->addWidget(
-      CreateGroupBox(tr("Move"), FreeLook::GetInputGroup(GetPort(), FreeLookGroup::Move)), 0, 0);
-  layout->addWidget(
-      CreateGroupBox(tr("Speed"), FreeLook::GetInputGroup(GetPort(), FreeLookGroup::Speed)), 0, 1);
+      CreateGroupBox(tr("Speed"), FreeLook::GetInputGroup(GetPort(), FreeLookGroup::Speed)), 0, 0);
   layout->addWidget(CreateGroupBox(tr("Field of View"),
                                    FreeLook::GetInputGroup(GetPort(), FreeLookGroup::FieldOfView)),
-                    0, 2);
+                    0, 1);
   layout->addWidget(
-      CreateGroupBox(tr("Other"), FreeLook::GetInputGroup(GetPort(), FreeLookGroup::Other)), 0, 3);
+      CreateGroupBox(tr("Other"), FreeLook::GetInputGroup(GetPort(), FreeLookGroup::Other)), 0, 2);
 
   setLayout(layout);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLookPosition.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLookPosition.cpp
@@ -1,0 +1,50 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Mapping/FreeLookPosition.h"
+
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+
+#include "Core/FreeLookManager.h"
+#include "InputCommon/InputConfig.h"
+
+FreeLookPosition::FreeLookPosition(MappingWindow* window) : MappingWidget(window)
+{
+  CreateMainLayout();
+}
+
+void FreeLookPosition::CreateMainLayout()
+{
+  m_main_layout = new QGridLayout;
+
+  m_main_layout->addWidget(
+      CreateGroupBox(tr("Move"), FreeLook::GetInputGroup(GetPort(), FreeLookGroup::Move)), 0, 0);
+
+  m_main_layout->addWidget(
+      CreateGroupBox(tr("Offset"),
+                     FreeLook::GetInputGroup(GetPort(), FreeLookGroup::PositionOffset)),
+      0, 1);
+
+  m_main_layout->setColumnStretch(0, 1);
+  m_main_layout->setColumnStretch(1, 1);
+
+  setLayout(m_main_layout);
+}
+
+InputConfig* FreeLookPosition::GetConfig()
+{
+  return FreeLook::GetInputConfig();
+}
+
+void FreeLookPosition::LoadSettings()
+{
+  FreeLook::LoadInputConfig();
+}
+
+void FreeLookPosition::SaveSettings()
+{
+  FreeLook::GetInputConfig()->SaveConfig();
+}

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLookPosition.h
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLookPosition.h
@@ -1,0 +1,26 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "DolphinQt/Config/Mapping/MappingWidget.h"
+
+class QGridLayout;
+
+class FreeLookPosition final : public MappingWidget
+{
+  Q_OBJECT
+public:
+  explicit FreeLookPosition(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+  void CreateMainLayout();
+
+  // Main
+  QGridLayout* m_main_layout;
+};

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -23,6 +23,7 @@
 #include "Common/StringUtil.h"
 
 #include "DolphinQt/Config/Mapping/FreeLookGeneral.h"
+#include "DolphinQt/Config/Mapping/FreeLookPosition.h"
 #include "DolphinQt/Config/Mapping/FreeLookRotation.h"
 #include "DolphinQt/Config/Mapping/GCKeyboardEmu.h"
 #include "DolphinQt/Config/Mapping/GCMicrophone.h"
@@ -437,6 +438,7 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
   {
     widget = new FreeLookGeneral(this);
     AddWidget(tr("General"), widget);
+    AddWidget(tr("Position"), new FreeLookPosition(this));
     AddWidget(tr("Rotation"), new FreeLookRotation(this));
     setWindowTitle(tr("Free Look Controller %1").arg(GetPort() + 1));
   }

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="Config\LogConfigWidget.cpp" />
     <ClCompile Include="Config\LogWidget.cpp" />
     <ClCompile Include="Config\Mapping\FreeLookGeneral.cpp" />
+    <ClCompile Include="Config\Mapping\FreeLookPosition.cpp" />
     <ClCompile Include="Config\Mapping\FreeLookRotation.cpp" />
     <ClCompile Include="Config\Mapping\GCKeyboardEmu.cpp" />
     <ClCompile Include="Config\Mapping\GCMicrophone.cpp" />
@@ -255,6 +256,7 @@
     <QtMoc Include="Config\LogConfigWidget.h" />
     <QtMoc Include="Config\LogWidget.h" />
     <QtMoc Include="Config\Mapping\FreeLookGeneral.h" />
+    <QtMoc Include="Config\Mapping\FreeLookPosition.h" />
     <QtMoc Include="Config\Mapping\FreeLookRotation.h" />
     <QtMoc Include="Config\Mapping\GCKeyboardEmu.h" />
     <QtMoc Include="Config\Mapping\GCMicrophone.h" />

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -28,8 +28,8 @@ public:
 
   virtual void MoveVertical(float amt) = 0;
   virtual void MoveHorizontal(float amt) = 0;
-
   virtual void MoveForward(float amt) = 0;
+  virtual void SetPositionOffset(const Common::Vec3& offset) = 0;
 
   virtual void Rotate(const Common::Vec3& amt) = 0;
   virtual void Rotate(const Common::Quaternion& quat) = 0;
@@ -50,6 +50,7 @@ public:
   void MoveVertical(float amt);
   void MoveHorizontal(float amt);
   void MoveForward(float amt);
+  void SetPositionOffset(const Common::Vec3& offset);
 
   void Rotate(const Common::Vec3& amt);
   void Rotate(const Common::Quaternion& amt);


### PR DESCRIPTION
This adds the ability to offset the FreeLook camera directly using x,y,z coordinates.  These values can even be bound to an input expression:

![all-aboard](https://user-images.githubusercontent.com/15224722/113664880-266c4500-9672-11eb-90d8-bcc49e9c2e65.gif)

~~In theory this allows for headtracking using the positional element in OpenTrack or VR devices (untested at the moment)~~ (working, see post below!)


--

UI has changed, move is now put in a "Position" tab:

![image](https://user-images.githubusercontent.com/15224722/113818933-2d608980-973e-11eb-8e16-ac70c4de03f0.png)

here is what the tab looks like:

![image](https://user-images.githubusercontent.com/15224722/113818966-3a7d7880-973e-11eb-85e8-0622306df6d1.png)
