### PR TITLE
Gameini: Disable ICache for Indiana Jones and the Staff of Kings

### DIFF
--- a/Data/Sys/GameSettings/RJ8.ini
+++ b/Data/Sys/GameSettings/RJ8.ini
@@ -1,0 +1,21 @@
+# RJ8P64, RJ8E64 - Indiana Jones and the Staff of Kings
+
+[Core]
+# Values set here will override the main Dolphin settings.
+# The JIT cache causes problems with emulated icache invalidation in this game resulting in areas failing to load
+DisableICache = True
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 2048
+
+[Video_Hacks]
+EFBEmulateFormatChanges = True


### PR DESCRIPTION
The option to disable ICache is recent but it allows Indiana Jones and the Staff of Kings to proceed where it would otherwise crash.

This game got past the first loading screen and in-game in 3.0-195(1387da790062f67ea79db470999e37d0ed43c57f), however at certain parts the game will crash. Recent logs will state that an ICache read returned stale data.