### PR TITLE
Change BitfieldExtract to use a pointer to the bitfield member

### DIFF
--- a/Source/Core/Common/BitField.h
+++ b/Source/Core/Common/BitField.h
@@ -155,8 +155,8 @@ public:
 
   constexpr T Value() const { return Value(std::is_signed<T>()); }
   constexpr operator T() const { return Value(); }
-  constexpr std::size_t StartBit() const { return position; }
-  constexpr std::size_t NumBits() const { return bits; }
+  static constexpr std::size_t StartBit() { return position; }
+  static constexpr std::size_t NumBits() { return bits; }
 
 private:
   // Unsigned version of StorageType

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -125,6 +125,7 @@ add_library(common
   TraversalClient.cpp
   TraversalClient.h
   TraversalProto.h
+  TypeUtils.h
   UPnP.cpp
   UPnP.h
   VariantUtil.h

--- a/Source/Core/Common/TypeUtils.h
+++ b/Source/Core/Common/TypeUtils.h
@@ -1,0 +1,70 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <type_traits>
+
+namespace Common
+{
+template <typename>
+struct MemberPointerInfo;
+// Helper to get information about a pointer to a data member.
+// See https://en.cppreference.com/w/cpp/language/pointer#Pointers_to_members
+// This template takes the type for a member pointer.
+template <typename M, typename O>
+struct MemberPointerInfo<M O::*>
+{
+  using MemberType = M;
+  using ObjectType = O;
+};
+
+// This template takes a specific member pointer.
+template <auto member_pointer>
+using MemberType = typename MemberPointerInfo<decltype(member_pointer)>::MemberType;
+
+// This template takes a specific member pointer.
+template <auto member_pointer>
+using ObjectType = typename MemberPointerInfo<decltype(member_pointer)>::ObjectType;
+
+namespace detail
+{
+template <int x>
+struct Data
+{
+  static constexpr int GetX() { return x; }
+};
+struct Foo
+{
+  Data<1> a;
+  Data<2> b;
+  int c;
+};
+struct Bar : Foo
+{
+  int d;
+};
+
+static_assert(std::is_same_v<MemberType<&Foo::a>, Data<1>>);
+static_assert(MemberType<&Foo::a>::GetX() == 1);
+static_assert(std::is_same_v<MemberType<&Foo::b>, Data<2>>);
+static_assert(MemberType<&Foo::b>::GetX() == 2);
+static_assert(std::is_same_v<MemberType<&Foo::c>, int>);
+
+static_assert(std::is_same_v<ObjectType<&Foo::a>, Foo>);
+static_assert(std::is_same_v<ObjectType<&Foo::b>, Foo>);
+static_assert(std::is_same_v<ObjectType<&Foo::c>, Foo>);
+
+static_assert(std::is_same_v<MemberType<&Foo::c>, MemberPointerInfo<int Foo::*>::MemberType>);
+static_assert(std::is_same_v<ObjectType<&Foo::c>, MemberPointerInfo<int Foo::*>::ObjectType>);
+
+static_assert(std::is_same_v<MemberType<&Bar::c>, int>);
+static_assert(std::is_same_v<MemberType<&Bar::d>, int>);
+
+static_assert(std::is_same_v<ObjectType<&Bar::d>, Bar>);
+// Somewhat unexpected behavior:
+static_assert(std::is_same_v<ObjectType<&Bar::c>, Foo>);
+static_assert(!std::is_same_v<ObjectType<&Bar::c>, Bar>);
+}  // namespace detail
+}  // namespace Common

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -152,6 +152,7 @@
     <ClInclude Include="Common\Timer.h" />
     <ClInclude Include="Common\TraversalClient.h" />
     <ClInclude Include="Common\TraversalProto.h" />
+    <ClInclude Include="Common\TypeUtils.h" />
     <ClInclude Include="Common\UPnP.h" />
     <ClInclude Include="Common\VariantUtil.h" />
     <ClInclude Include="Common\Version.h" />

--- a/Source/Core/VideoCommon/UberShaderCommon.cpp
+++ b/Source/Core/VideoCommon/UberShaderCommon.cpp
@@ -103,29 +103,29 @@ void WriteVertexLighting(ShaderCode& out, APIType api_type, std::string_view wor
             "  int4 lacc = int4(255, 255, 255, 255);\n"
             "\n");
 
-  out.Write("  if ({} != 0u)\n", BitfieldExtract("colorreg", LitChannel().matsource));
+  out.Write("  if ({} != 0u)\n", BitfieldExtract<&LitChannel::matsource>("colorreg"));
   out.Write("    mat.xyz = int3(round(((chan == 0u) ? {}.xyz : {}.xyz) * 255.0));\n",
             in_color_0_var, in_color_1_var);
 
-  out.Write("  if ({} != 0u)\n", BitfieldExtract("alphareg", LitChannel().matsource));
+  out.Write("  if ({} != 0u)\n", BitfieldExtract<&LitChannel::matsource>("alphareg"));
   out.Write("    mat.w = int(round(((chan == 0u) ? {}.w : {}.w) * 255.0));\n", in_color_0_var,
             in_color_1_var);
   out.Write("  else\n"
             "    mat.w = " I_MATERIALS " [chan + 2u].w;\n"
             "\n");
 
-  out.Write("  if ({} != 0u) {{\n", BitfieldExtract("colorreg", LitChannel().enablelighting));
-  out.Write("    if ({} != 0u)\n", BitfieldExtract("colorreg", LitChannel().ambsource));
+  out.Write("  if ({} != 0u) {{\n", BitfieldExtract<&LitChannel::enablelighting>("colorreg"));
+  out.Write("    if ({} != 0u)\n", BitfieldExtract<&LitChannel::ambsource>("colorreg"));
   out.Write("      lacc.xyz = int3(round(((chan == 0u) ? {}.xyz : {}.xyz) * 255.0));\n",
             in_color_0_var, in_color_1_var);
   out.Write("    else\n"
             "      lacc.xyz = " I_MATERIALS " [chan].xyz;\n"
             "\n");
   out.Write("    uint light_mask = {} | ({} << 4u);\n",
-            BitfieldExtract("colorreg", LitChannel().lightMask0_3),
-            BitfieldExtract("colorreg", LitChannel().lightMask4_7));
-  out.Write("    uint attnfunc = {};\n", BitfieldExtract("colorreg", LitChannel().attnfunc));
-  out.Write("    uint diffusefunc = {};\n", BitfieldExtract("colorreg", LitChannel().diffusefunc));
+            BitfieldExtract<&LitChannel::lightMask0_3>("colorreg"),
+            BitfieldExtract<&LitChannel::lightMask4_7>("colorreg"));
+  out.Write("    uint attnfunc = {};\n", BitfieldExtract<&LitChannel::attnfunc>("colorreg"));
+  out.Write("    uint diffusefunc = {};\n", BitfieldExtract<&LitChannel::diffusefunc>("colorreg"));
   out.Write(
       "    for (uint light_index = 0u; light_index < 8u; light_index++) {{\n"
       "      if ((light_mask & (1u << light_index)) != 0u)\n"
@@ -135,8 +135,8 @@ void WriteVertexLighting(ShaderCode& out, APIType api_type, std::string_view wor
             "  }}\n"
             "\n");
 
-  out.Write("  if ({} != 0u) {{\n", BitfieldExtract("alphareg", LitChannel().enablelighting));
-  out.Write("    if ({} != 0u) {{\n", BitfieldExtract("alphareg", LitChannel().ambsource));
+  out.Write("  if ({} != 0u) {{\n", BitfieldExtract<&LitChannel::enablelighting>("alphareg"));
+  out.Write("    if ({} != 0u) {{\n", BitfieldExtract<&LitChannel::ambsource>("alphareg"));
   out.Write("      if ((components & ({}u << chan)) != 0u) // VB_HAS_COL0\n", VB_HAS_COL0);
   out.Write("        lacc.w = int(round(((chan == 0u) ? {}.w : {}.w) * 255.0));\n", in_color_0_var,
             in_color_1_var);
@@ -149,10 +149,10 @@ void WriteVertexLighting(ShaderCode& out, APIType api_type, std::string_view wor
             "    }}\n"
             "\n");
   out.Write("    uint light_mask = {} | ({} << 4u);\n",
-            BitfieldExtract("alphareg", LitChannel().lightMask0_3),
-            BitfieldExtract("alphareg", LitChannel().lightMask4_7));
-  out.Write("    uint attnfunc = {};\n", BitfieldExtract("alphareg", LitChannel().attnfunc));
-  out.Write("    uint diffusefunc = {};\n", BitfieldExtract("alphareg", LitChannel().diffusefunc));
+            BitfieldExtract<&LitChannel::lightMask0_3>("alphareg"),
+            BitfieldExtract<&LitChannel::lightMask4_7>("alphareg"));
+  out.Write("    uint attnfunc = {};\n", BitfieldExtract<&LitChannel::attnfunc>("alphareg"));
+  out.Write("    uint diffusefunc = {};\n", BitfieldExtract<&LitChannel::diffusefunc>("alphareg"));
   out.Write("    for (uint light_index = 0u; light_index < 8u; light_index++) {{\n\n"
             "      if ((light_mask & (1u << light_index)) != 0u)\n\n"
             "        lacc.w += CalculateLighting(light_index, attnfunc, diffusefunc, {}, {}).w;\n",

--- a/Source/Core/VideoCommon/UberShaderCommon.h
+++ b/Source/Core/VideoCommon/UberShaderCommon.h
@@ -10,6 +10,7 @@
 #include <fmt/format.h>
 
 #include "Common/CommonTypes.h"
+#include "Common/TypeUtils.h"
 
 class ShaderCode;
 enum class APIType;
@@ -29,10 +30,11 @@ void WriteVertexLighting(ShaderCode& out, APIType api_type, std::string_view wor
                          std::string_view out_color_1_var);
 
 // bitfieldExtract generator for BitField types
-template <typename T>
-std::string BitfieldExtract(std::string_view source, T type)
+template <auto ptr_to_bitfield_member>
+std::string BitfieldExtract(std::string_view source)
 {
-  return fmt::format("bitfieldExtract({}, {}, {})", source, static_cast<u32>(type.StartBit()),
-                     static_cast<u32>(type.NumBits()));
+  using BitFieldT = Common::MemberType<ptr_to_bitfield_member>;
+  return fmt::format("bitfieldExtract({}, {}, {})", source, static_cast<u32>(BitFieldT::StartBit()),
+                     static_cast<u32>(BitFieldT::NumBits()));
 }
 }  // namespace UberShader

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -402,7 +402,7 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
   out.Write("  // Texcoord transforms\n");
   out.Write("  float4 coord = float4(0.0, 0.0, 1.0, 1.0);\n"
             "  uint texMtxInfo = xfmem_texMtxInfo(texgen);\n");
-  out.Write("  switch ({}) {{\n", BitfieldExtract("texMtxInfo", TexMtxInfo().sourcerow));
+  out.Write("  switch ({}) {{\n", BitfieldExtract<&TexMtxInfo::sourcerow>("texMtxInfo"));
   out.Write("  case {:s}:\n", SourceRow::Geom);
   out.Write("    coord.xyz = rawpos.xyz;\n");
   out.Write("    break;\n\n");
@@ -435,21 +435,21 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
 
   out.Write("  // Input form of AB11 sets z element to 1.0\n");
   out.Write("  if ({} == {:s}) // inputform == AB11\n",
-            BitfieldExtract("texMtxInfo", TexMtxInfo().inputform), TexInputForm::AB11);
+            BitfieldExtract<&TexMtxInfo::inputform>("texMtxInfo"), TexInputForm::AB11);
   out.Write("    coord.z = 1.0f;\n"
             "\n");
 
   out.Write("  // first transformation\n");
-  out.Write("  uint texgentype = {};\n", BitfieldExtract("texMtxInfo", TexMtxInfo().texgentype));
+  out.Write("  uint texgentype = {};\n", BitfieldExtract<&TexMtxInfo::texgentype>("texMtxInfo"));
   out.Write("  float3 output_tex;\n"
             "  switch (texgentype)\n"
             "  {{\n");
   out.Write("  case {:s}:\n", TexGenType::EmbossMap);
   out.Write("    {{\n");
   out.Write("      uint light = {};\n",
-            BitfieldExtract("texMtxInfo", TexMtxInfo().embosslightshift));
+            BitfieldExtract<&TexMtxInfo::embosslightshift>("texMtxInfo"));
   out.Write("      uint source = {};\n",
-            BitfieldExtract("texMtxInfo", TexMtxInfo().embosssourceshift));
+            BitfieldExtract<&TexMtxInfo::embosssourceshift>("texMtxInfo"));
   out.Write("      switch (source) {{\n");
   for (u32 i = 0; i < num_texgen; i++)
     out.Write("      case {}u: output_tex.xyz = o.tex{}; break;\n", i, i);
@@ -481,7 +481,7 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
     out.Write("        case {}u: tmp = int(rawtex{}.z); break;\n", i, i);
   out.Write("        }}\n"
             "\n");
-  out.Write("        if ({} == {:s}) {{\n", BitfieldExtract("texMtxInfo", TexMtxInfo().projection),
+  out.Write("        if ({} == {:s}) {{\n", BitfieldExtract<&TexMtxInfo::projection>("texMtxInfo"),
             TexSize::STQ);
   out.Write("          output_tex.xyz = float3(dot(coord, " I_TRANSFORMMATRICES "[tmp]),\n"
             "                                  dot(coord, " I_TRANSFORMMATRICES "[tmp + 1]),\n"
@@ -492,7 +492,7 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
             "                                  1.0);\n"
             "        }}\n"
             "      }} else {{\n");
-  out.Write("        if ({} == {:s}) {{\n", BitfieldExtract("texMtxInfo", TexMtxInfo().projection),
+  out.Write("        if ({} == {:s}) {{\n", BitfieldExtract<&TexMtxInfo::projection>("texMtxInfo"),
             TexSize::STQ);
   out.Write("          output_tex.xyz = float3(dot(coord, " I_TEXMATRICES "[3u * texgen]),\n"
             "                                  dot(coord, " I_TEXMATRICES "[3u * texgen + 1u]),\n"
@@ -510,12 +510,12 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
 
   out.Write("  if (xfmem_dualTexInfo != 0u) {{\n");
   out.Write("    uint postMtxInfo = xfmem_postMtxInfo(texgen);");
-  out.Write("    uint base_index = {};\n", BitfieldExtract("postMtxInfo", PostMtxInfo().index));
+  out.Write("    uint base_index = {};\n", BitfieldExtract<&PostMtxInfo::index>("postMtxInfo"));
   out.Write("    float4 P0 = " I_POSTTRANSFORMMATRICES "[base_index & 0x3fu];\n"
             "    float4 P1 = " I_POSTTRANSFORMMATRICES "[(base_index + 1u) & 0x3fu];\n"
             "    float4 P2 = " I_POSTTRANSFORMMATRICES "[(base_index + 2u) & 0x3fu];\n"
             "\n");
-  out.Write("    if ({} != 0u)\n", BitfieldExtract("postMtxInfo", PostMtxInfo().normalize));
+  out.Write("    if ({} != 0u)\n", BitfieldExtract<&PostMtxInfo::normalize>("postMtxInfo"));
   out.Write("      output_tex.xyz = normalize(output_tex.xyz);\n"
             "\n"
             "    // multiply by postmatrix\n"


### PR DESCRIPTION
This PR changes `BitfieldExtract` to use a pointer to a member to deduce information about the BitField instead of creating a temporary variable and passing its bitfield instance.  The pointer-to-member is also a template argument instead of a regular argument.  For example, `BitfieldExtract("colorreg", LitChannel().matsource)` is now `BitfieldExtract<&LitChannel::matsource>("colorreg")`, and `BitfieldExtract("ss.cc", TevStageCombiner().colorC.bias)` is now `BitfieldExtract<&TevStageCombiner::ColorCombiner::bias>("ss.cc")`.

As an additional change to make this work, I made `BitField::StartBit` and `BitField::NumBits` static.  The other code that already used `StartBit` is not affected by this change (for instance `int(TwoTevStageOrders().enable1.StartBit() - TwoTevStageOrders().enable0.StartBit())`).

Note that this does not make any difference with performance ([compiler explorer](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAM1QDsCBlZAQwBtMQBGAFlJvoCqAZ0wAFAB4gA5AAYppAFZdSrZrVDIApACYAQjt2kR7ZATx1KmWugDCqVgFcAtrS68r6ADJ5amAHLOAEaYxCAAbLwADqhChOa0do4ubqTRsWZ03r4BTsGhEUaYJhm0DATMxASJzq48hcXxZRUEWf5BIeG8QuWV1cl13c2tOXmdAJRGqA7EyBxSOgDMPsiOWADUmgs2yN3oWFSb2JoyAIKLy6uYG1sEAJ6RmAD6BMTMhEKHx2enBJhOkapftcbLEAF5PAhrVBUKgiAiPT6nbrEBymNYAMVQqC%2BmgA7PpTms1gB6YloWjdTDiSLENZgiFQmFwiBjNbk7obfFrYiYAjTWiM2G8hELXScgAiXyJgzMyDZdEp1Np9OeguZrLxYp5fOIAuhQvhmzFeMlpxNRpxpwctHia10FRx%2BKlGKxmxsMkOa2YFsJLuxW24nsCPrOuMlostJ2RqMh9tBjoJJyJ1tt9uI2mdmudRMx/psnE93ojvpzrq2CyDIaJ5uLSbtFW0a0CDtrNcTXypv11awAbqg8Og1k4KgBrEIQFWQntsByYMYhr6/f6Aq5uu4PWjMJxXAAqiJOfYHa1%2B3U4EB3x/nZqdvuHxDHxAgBAAdPr1fPW2HI0uAcwgW7JzVXlSGPe4rC3Xd90PQcTwIbQIFzN0315T0dxAEAACpIheK9Q0TIkIGgsZsOII0iVJNZhEwQc6FYW5j1QNYsHQVFINvUdx2QggP3bL8zR%2BP5f3/G4wM3bc1h3ED13A8SBCg/sYMwboFnPSj0KwnCE2dQiFOIl4yJJYlKJEGjaDohimOo1iJOdO8H3PdCuJZHjHVNb4Th/FdgWksTIIWI4kReGMhz%2BPJHmiHwu0eHwaC069w0TTy/1XESNwgiSpNE9K5P8r5ozRbdchCcL%2B3oYqYrzC8BHU/cs19BxYnUEKiuIZ4wOucUbNrZNGuAKFAgUTBTDah4Osohcv1bATl2S4FmAcIg1hI%2BSj1g7gWTiusGp8Pq0wvTZOp89LCrCiKytaiq3SwFZpIgEiP2wdCTuK6SqyHDjHz2xymV5ZyJrcr5IvenwNuvfDjyUggzzTFln2YFzfVg6GKlhwIEbrWD4J0MI03Q%2BG3sxiBsdxkA0YJyGVOJio8fRolYMp7Qcep0naYh7pAy2KnQhAItsA27q2YIDmbC59Dg38/n20RyHkdBVGKjh1mkYgON5eIZ8yYFwmqdBdC020Gnye6LHGbjPWGzFpWKaJ03mF1kB9cNrXrZ18300to2hbdV2HYtnnDkl501u9237cd0mA/R50KIYBAplYQdaFQSE0H%2BPB2Gj4lg62NMMMjt7SWzmwzd99M84lqOwykCZWGkABWeRXFkeRUGkEW9AMOkphmVdtAWTh5AIaQ5DGCYRxAbgAA5n1xHhOEnmRcW4ABObgp%2BXhYVGkbhG%2BHlvpHkIQQBkUgh%2BbiY4FgGBEBQVA0/YMgKAgVPInTjoVjUYBOE4GROD4dOuxHwgIEPepBAg%2BAqLcaQA9SCp23PQAA8mZKBzdSBYGHOodgoD8A8lMHgHsSlQFUiGgtOYMDIpFFAawPAgRXjEFuHYLAoCXh4CcNA6ufA6CMBYFguo/ACBUQkKApQ2gVCfxQAYAwKgaFH0gBMVA2F4hHykAAWgQY2FRuwDpaA7noTguI1gqIAOpsFYIYoxnZXiHyKENEolhrB9FqKQDwwx2ihD/mkOIdBHHKE8SUVxLVlDGFsY0HoVR7A1CCTYvBdAmiVACaMP%2BgxegRP6EYMJCSOicAmEIbuswuA13rrvVBrcpDiEnmEFREQ2SqCat/Z8MhnycDWBAXAhASAbD7n/NYdh74hE6QsbQrJ276D0IPPeF8kAvzfo/Sg0yH4gC/jITeVAAEhCASA1B4DNz0PYbAu%2B8CCBILotgv4n8sGoJwSEghyi5DOPECQ34eyKG11QdQ2hkDGFzDuSwthUgB4TH4UwNgHA%2BFcMEZIVBSg/61I0JIvQ0jAiyJZKQBRJRlFqOaZogg6BtHwt0Po8xpjzGWOYNYhoFgIAeB8X/FxPg2iBI8TELxCRUlOL8fETJ7j6ghNiWEmlPKYmlAyfSkYWT0nNAFcklooq3EFMmNMfJ2St5SAbqQJudzSnlMqdU4AyA5Q/2fAsFpbSiC0kWN03pr8H4DOyT0/F4zz5jy4DIE%2Bryd6kDYXXE%2BGr95SEPsfU%2BEzSCXxvlMAgkQFrkDmXfa14rqLtO5UCnhoLeD8IhaAgA7q8SI7DCmquKZq6QFq1iZsIAgNY2qqncDWHqg1jSFiOpHiGpA4bI0EGjc/WNMyQCiITWa5QyaQUpHTSIIRqDs3MFzf8jhry1W%2BtRcWvujYy0EArVW6pH86mcAaU0pt1d80eq9T60BpSA0nzPiPZ1dcd3aEnnXSenBl7aG9XXG9i8VWNvVaeg%2BQanUqu0IWv1%2B7R6kAIcQWIFhuBAA%3D%3D%3D)); the only change is the syntax.

This didn't take too long to do, and it's subjective whether or not this is really an improvement.  If people don't like it, then I'm fine with it not being merged.