### PR TITLE
Build: Fix -fno-strict-aliasing on Xcode builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     list(APPEND CMAKE_PREFIX_PATH "/usr")
   endif()
 
+  # Prevents Xcode from overriding the -fno-strict-aliasing flag
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_STRICT_ALIASING NO)
+
   # Specify target CPUs.
   check_and_add_flag(HAVE_MSSSE3 -mssse3)
   check_and_add_flag(HAVE_ARCH_CORE2 -march=core2)


### PR DESCRIPTION
Xcode is configured by default to turn on the strict aliasing optimization through a separate project setting. This would cause the compiler to be called with both -fno-strict-aliasing(from the CMakeLists.txt) and -fstrict-aliasing(appended to the compiler arguments by Xcode) flags. This change turns off this default project setting, causing only the -fno-strict-aliasing flag to be provided to the compiler. 