### PR TITLE
WiiUtils: Add helper functions to get emulated/real Bluetooth device

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -16,6 +16,7 @@
 #include "Core/IOS/USB/Bluetooth/WiimoteDevice.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayClient.h"
+#include "Core/WiiUtils.h"
 
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/InputConfig.h"
@@ -49,16 +50,8 @@ void SetSource(unsigned int index, WiimoteSource source)
 
 void UpdateSource(unsigned int index)
 {
-  const auto ios = IOS::HLE::GetIOS();
-  if (!ios)
-    return;
-
-  if (s_wiimote_sources[index] != WiimoteSource::Emulated)
-    return;
-
-  const auto bluetooth = std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(
-      ios->GetDeviceByName("/dev/usb/oh1/57e/305"));
-  if (!bluetooth)
+  const auto bluetooth = WiiUtils::GetBluetoothEmuDevice();
+  if (bluetooth == nullptr)
     return;
 
   bluetooth->AccessWiimoteByIndex(index)->SetSource(GetHIDWiimoteSource(index));

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -62,6 +62,7 @@
 #include "Core/IOS/USB/Bluetooth/WiimoteDevice.h"
 #include "Core/NetPlayProto.h"
 #include "Core/State.h"
+#include "Core/WiiUtils.h"
 
 #include "DiscIO/Enums.h"
 
@@ -469,16 +470,13 @@ void ChangeWiiPads(bool instantly)
   if (instantly && (s_controllers >> 4) == controllers)
     return;
 
-  const auto ios = IOS::HLE::GetIOS();
-  const auto bt = ios ? std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(
-                            ios->GetDeviceByName("/dev/usb/oh1/57e/305")) :
-                        nullptr;
+  const auto bt = WiiUtils::GetBluetoothEmuDevice();
   for (int i = 0; i < MAX_WIIMOTES; ++i)
   {
     const bool is_using_wiimote = IsUsingWiimote(i);
 
     WiimoteCommon::SetSource(i, is_using_wiimote ? WiimoteSource::Emulated : WiimoteSource::None);
-    if (!SConfig::GetInstance().m_bt_passthrough_enabled && bt)
+    if (bt != nullptr)
       bt->AccessWiimoteByIndex(i)->Activate(is_using_wiimote);
   }
 }

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -36,6 +36,8 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/IOS.h"
+#include "Core/IOS/USB/Bluetooth/BTEmu.h"
+#include "Core/IOS/USB/Bluetooth/BTReal.h"
 #include "Core/IOS/Uids.h"
 #include "Core/SysConf.h"
 #include "DiscIO/DiscExtractor.h"
@@ -956,5 +958,25 @@ NANDCheckResult CheckNAND(IOS::HLE::Kernel& ios)
 bool RepairNAND(IOS::HLE::Kernel& ios)
 {
   return !CheckNAND(ios, true).bad;
+}
+
+static std::shared_ptr<IOS::HLE::Device> GetBluetoothDevice()
+{
+  auto* ios = IOS::HLE::GetIOS();
+  return ios ? ios->GetDeviceByName("/dev/usb/oh1/57e/305") : nullptr;
+}
+
+std::shared_ptr<IOS::HLE::BluetoothEmuDevice> GetBluetoothEmuDevice()
+{
+  if (SConfig::GetInstance().m_bt_passthrough_enabled)
+    return nullptr;
+  return std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(GetBluetoothDevice());
+}
+
+std::shared_ptr<IOS::HLE::BluetoothRealDevice> GetBluetoothRealDevice()
+{
+  if (!SConfig::GetInstance().m_bt_passthrough_enabled)
+    return nullptr;
+  return std::static_pointer_cast<IOS::HLE::BluetoothRealDevice>(GetBluetoothDevice());
 }
 }  // namespace WiiUtils

--- a/Source/Core/Core/WiiUtils.h
+++ b/Source/Core/Core/WiiUtils.h
@@ -12,6 +12,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/IOS/USB/Bluetooth/BTReal.h"
 
 // Small utility functions for common Wii related tasks.
 
@@ -22,6 +23,7 @@ class VolumeWAD;
 
 namespace IOS::HLE
 {
+class BluetoothEmuDevice;
 class ESDevice;
 class Kernel;
 }  // namespace IOS::HLE
@@ -101,4 +103,11 @@ struct NANDCheckResult
 };
 NANDCheckResult CheckNAND(IOS::HLE::Kernel& ios);
 bool RepairNAND(IOS::HLE::Kernel& ios);
+
+// Get the BluetoothEmuDevice for an active emulation instance.
+// It is only safe to call this from the CPU thread.
+// Returns nullptr if we're not currently emulating a Wii game or if Bluetooth passthrough is used.
+std::shared_ptr<IOS::HLE::BluetoothEmuDevice> GetBluetoothEmuDevice();
+// Same as GetBluetoothEmuDevice, but for Bluetooth passthrough.
+std::shared_ptr<IOS::HLE::BluetoothRealDevice> GetBluetoothRealDevice();
 }  // namespace WiiUtils

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -24,6 +24,7 @@
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTReal.h"
+#include "Core/WiiUtils.h"
 
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
@@ -242,11 +243,9 @@ void WiimoteControllersWidget::OnBluetoothPassthroughResetPressed()
     return;
   }
 
-  auto device = ios->GetDeviceByName("/dev/usb/oh1/57e/305");
+  auto device = WiiUtils::GetBluetoothRealDevice();
   if (device != nullptr)
-  {
-    std::static_pointer_cast<IOS::HLE::BluetoothBaseDevice>(device)->TriggerSyncButtonHeldEvent();
-  }
+    device->TriggerSyncButtonHeldEvent();
 }
 
 void WiimoteControllersWidget::OnBluetoothPassthroughSyncPressed()
@@ -260,13 +259,9 @@ void WiimoteControllersWidget::OnBluetoothPassthroughSyncPressed()
     return;
   }
 
-  auto device = ios->GetDeviceByName("/dev/usb/oh1/57e/305");
-
+  auto device = WiiUtils::GetBluetoothRealDevice();
   if (device != nullptr)
-  {
-    std::static_pointer_cast<IOS::HLE::BluetoothBaseDevice>(device)
-        ->TriggerSyncButtonPressedEvent();
-  }
+    device->TriggerSyncButtonPressedEvent();
 }
 
 void WiimoteControllersWidget::OnWiimoteRefreshPressed()

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -12,6 +12,9 @@
 #ifdef DeleteFile
 #undef DeleteFile
 #endif
+#ifdef interface
+#undef interface
+#endif
 #endif
 
 #include "DolphinQt/GameList/GameList.h"

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -25,7 +25,9 @@
 #include "Core/HotkeyManager.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTBase.h"
+#include "Core/IOS/USB/Bluetooth/BTReal.h"
 #include "Core/State.h"
+#include "Core/WiiUtils.h"
 
 #include "DolphinQt/Settings.h"
 
@@ -231,15 +233,8 @@ void HotkeyScheduler::Run()
         emit ToggleReadOnlyMode();
 
       // Wiimote
-      if (SConfig::GetInstance().m_bt_passthrough_enabled)
-      {
-        const auto ios = IOS::HLE::GetIOS();
-        auto device = ios ? ios->GetDeviceByName("/dev/usb/oh1/57e/305") : nullptr;
-
-        if (device != nullptr)
-          std::static_pointer_cast<IOS::HLE::BluetoothBaseDevice>(device)->UpdateSyncButtonState(
-              IsHotkey(HK_TRIGGER_SYNC_BUTTON, true));
-      }
+      if (auto bt = WiiUtils::GetBluetoothRealDevice())
+        bt->UpdateSyncButtonState(IsHotkey(HK_TRIGGER_SYNC_BUTTON, true));
 
       if (SConfig::GetInstance().bEnableDebugging)
       {

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -57,6 +57,7 @@
 #include "Core/NetPlayProto.h"
 #include "Core/NetPlayServer.h"
 #include "Core/State.h"
+#include "Core/WiiUtils.h"
 
 #include "DiscIO/NANDImporter.h"
 
@@ -1723,12 +1724,8 @@ void MainWindow::ShowTASInput()
 
 void MainWindow::OnConnectWiiRemote(int id)
 {
-  const auto ios = IOS::HLE::GetIOS();
-  if (!ios || SConfig::GetInstance().m_bt_passthrough_enabled)
-    return;
   Core::RunAsCPUThread([&] {
-    if (const auto bt = std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(
-            ios->GetDeviceByName("/dev/usb/oh1/57e/305")))
+    if (const auto bt = WiiUtils::GetBluetoothEmuDevice())
     {
       const auto wm = bt->AccessWiimoteByIndex(id);
       wm->Activate(!wm->IsConnected());

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1023,12 +1023,8 @@ void MenuBar::UpdateToolsMenu(bool emulation_started)
     m_perform_online_update_for_current_region->setEnabled(tmd.IsValid());
   }
 
-  const auto ios = IOS::HLE::GetIOS();
-  const auto bt = ios ? std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(
-                            ios->GetDeviceByName("/dev/usb/oh1/57e/305")) :
-                        nullptr;
-  const bool enable_wiimotes =
-      emulation_started && bt && !SConfig::GetInstance().m_bt_passthrough_enabled;
+  const auto bt = WiiUtils::GetBluetoothEmuDevice();
+  const bool enable_wiimotes = emulation_started && bt != nullptr;
 
   for (std::size_t i = 0; i < m_wii_remotes.size(); i++)
   {


### PR DESCRIPTION
This adds a function to get the emulated or real Bluetooth device for
an active emulation instance. This lets us deduplicate all the
`ios->GetDeviceByName("/dev/usb/oh1/57e/305")` calls that are currently
scattered in the codebase and ensures Bluetooth passthrough is being
handled correctly.

This also fixes the broken check in WiimoteCommon::UpdateSource.
There was a confusion between "emulated Bluetooth" (as opposed to
"real Bluetooth" aka Bluetooth passthrough) and "emulated Wiimote".