### PR TITLE
Remove spurious memory allocations in TextureCacheBase::SerializeTexture and DeserializeTexture

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -200,6 +200,16 @@ public:
     DoArray(arr, static_cast<u32>(N));
   }
 
+  // The caller is required to inspect the mode of this PointerWrap
+  // and deal with the pointer returned from this function themself.
+  [[nodiscard]] u8* DoExternal(u32& count)
+  {
+    Do(count);
+    u8* current = *ptr;
+    *ptr += count;
+    return current;
+  }
+
   void Do(Common::Flag& flag)
   {
     bool s = flag.IsSet();


### PR DESCRIPTION
I'm doing a project with Dolphin which wants to save state incredibly frequently (~every frame). Reallocating `texture_data` in `TextureCacheBase::SerializeTexture` takes up a non-negligible amount of the serialization time in my environment. For my own project I might be able to implement a check to see if textures have changed in the last frame and avoid re-serializing them, but this is general enough to save everybody some fractions of a second when they save state - maybe TASers would appreciate it?

This PR fixes the issue by adding a method to `PointerWrap` which sets aside some space for the caller to read/write/verify, then using it to set aside one large chunk of space all at once in the texture cache. This should not change the save-state format.

Additionally, the new method is used when deserializing textures as well to avoid a single memory allocation/copy/deallocation, but that's of much less concern and could be removed pretty easily.

I'm not a huge fan of the method I went with here - all of the paths that hit `DoExternal` need to handle the `mode` of the `PointerWrap`, but at present there's no enforcement of that. I've personally verified that only read and write operations take place to the pointers, but that's no guard against future changes so it's pretty reasonable to say `DoExternal` is going too far/breaking abstraction. If so, let me know: I may be able to change this to refactor `SerializeTexture` to do one allocation instead of worst-case layers * levels copies/reallocations.

If save state performance is important, I've got a few other lower-impact changes which I could also try to contribute if desired.