### PR TITLE
Fix crash when stopping a game that does not use the BBA when XLink Kai BBA is selected in configuration

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/XLINK_KAI_BBA.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/XLINK_KAI_BBA.cpp
@@ -58,6 +58,10 @@ bool CEXIETHERNET::XLinkNetworkInterface::Activate()
 
 void CEXIETHERNET::XLinkNetworkInterface::Deactivate()
 {
+  // Is the BBA Active? If not skip shutdown
+  if (!IsActivated())
+    return;
+
   // Send d; to tell XLink we want to disconnect cleanly
   // disconnect;optional_locally_unique_name;optional_padding
   std::string cmd =


### PR DESCRIPTION
This PR fixes a bug reported here https://bugs.dolphin-emu.org/issues/12273
Crash is caused by a thread being terminated that never started since the BBA wasn't activated.