### PR TITLE
GameINI: Fix transitions and crashes in Rogue Squadron 3

### DIFF
--- a/Data/Sys/GameSettings/GLR.ini
+++ b/Data/Sys/GameSettings/GLR.ini
@@ -3,6 +3,7 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 MMU = 1
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -20,4 +21,5 @@ MMU = 1
 [Video_Hacks]
 EFBToTextureEnable = False
 ImmediateXFBEnable = False
+XFBToTextureEnable = False
 DeferEFBCopies = False


### PR DESCRIPTION
Needs to come after https://github.com/dolphin-emu/dolphin/pull/7214 or this doesn't really do anything.

Transitions are fixed by disabling "Store XFB Copies to Texture Only"

Forcing Single Core, in cooperation with https://github.com/dolphin-emu/dolphin/pull/7214, fixes random crashes on the intro dance, main menu, ship selection, pausing, at the end of stages, and in multiplayer.

The performance implications are minor because the game runs like crap on the beefiest machines anyway.  I saw maybe a 1 FPS difference disabling Store XFB Copies to Texture Only.  It's Rogue Squadron 3, if you're playing it in Dolphin, it's mostly out of masochism or curiosity more than to try to get a playable full speed experience.

SyncGPU is not enough to prevent the crashes.  While they are rarer, I still crashed on ship selection 1/3 times, which I do not consider playable.  I want people to be able to boot this up and sort of see it play before realizing the monstrosity that Factor 5 created.