### PR TITLE
FifoPlayer: Copy data with memcpy instead of one byte at a time

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -381,8 +381,9 @@ void FifoPlayer::WriteFifo(const u8* data, u32 start, u32 end)
 
     u32 burstEnd = std::min(written + 255, lastBurstEnd);
 
-    while (written < burstEnd)
-      GPFifo::FastWrite8(data[written++]);
+    std::copy(data + written, data + burstEnd, PowerPC::ppcState.gather_pipe_ptr);
+    PowerPC::ppcState.gather_pipe_ptr += burstEnd - written;
+    written = burstEnd;
 
     GPFifo::Write8(data[written++]);
 


### PR DESCRIPTION
Copying with memcpy/std::copy is a lot faster than writing one byte at a time. And the behavior should be fully equivalent.

All FastWrite8 does is write a byte and increment the pointer:

https://github.com/dolphin-emu/dolphin/blob/5513d5f4f732fb1e436765ab87e7d60ba02b1ad6/Source/Core/Core/HW/GPFifo.cpp#L144-L148

Before: https://f.leolam.fr/out-rs3.svg

After: https://f.leolam.fr/out-rs3_v2.svg