### PR TITLE
Fix PCH when building with CMake + Ninja + MSVC on Windows

### DIFF
--- a/Source/PCH/CMakeLists.txt
+++ b/Source/PCH/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(pch pch.h pch.cpp)
 set(PCH_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set(PCH_NAME ${PCH.pch})
-target_compile_options(pch PUBLIC /Ycpch.h /Fp${PCH_DIRECTORY}/${PCH_NAME}) 
+target_compile_options(pch PUBLIC /Ycpch.h /Fp${PCH_DIRECTORY}/${PCH_NAME})
+# fmt/format.h is included in the PCH
+target_link_libraries(pch PUBLIC fmt::fmt)


### PR DESCRIPTION
fmt/format.h is included in the PCH, so we need to make sure fmt is
actually in the include path.

Not sure how Visual Studio + CMake manages to build without this.