### PR TITLE
FreeLook: add separate camera for modifying orthographic projections from games

### DIFF
--- a/Source/Core/Core/Config/FreeLookSettings.cpp
+++ b/Source/Core/Core/Config/FreeLookSettings.cpp
@@ -14,6 +14,8 @@ namespace Config
 // Configuration Information
 const Info<bool> FREE_LOOK_ENABLED{{System::FreeLook, "General", "Enabled"}, false};
 
+const Info<bool> FREE_LOOK_2D_ENABLED{{System::FreeLook, "General", "2DEnabled"}, false};
+
 // FreeLook.Controller1
 const Info<FreeLook::ControlType> FL1_CONTROL_TYPE{{System::FreeLook, "Camera1", "ControlType"},
                                                    FreeLook::ControlType::SixAxis};

--- a/Source/Core/Core/Config/FreeLookSettings.h
+++ b/Source/Core/Core/Config/FreeLookSettings.h
@@ -16,6 +16,7 @@ namespace Config
 // Configuration Information
 
 extern const Info<bool> FREE_LOOK_ENABLED;
+extern const Info<bool> FREE_LOOK_2D_ENABLED;
 
 // FreeLook.Controller1
 extern const Info<FreeLook::ControlType> FL1_CONTROL_TYPE;

--- a/Source/Core/Core/FreeLookConfig.cpp
+++ b/Source/Core/Core/FreeLookConfig.cpp
@@ -32,6 +32,7 @@ Config::Config()
 {
   camera_config.control_type = ControlType::SixAxis;
   enabled = false;
+  enabled_2d = false;
 }
 
 void Config::Refresh()
@@ -44,5 +45,6 @@ void Config::Refresh()
 
   camera_config.control_type = ::Config::Get(::Config::FL1_CONTROL_TYPE);
   enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED);
+  enabled_2d = ::Config::Get(::Config::FREE_LOOK_2D_ENABLED);
 }
 }  // namespace FreeLook

--- a/Source/Core/Core/FreeLookConfig.h
+++ b/Source/Core/Core/FreeLookConfig.h
@@ -31,6 +31,7 @@ struct Config final
 
   CameraConfig camera_config;
   bool enabled;
+  bool enabled_2d;
 };
 
 Config& GetConfig();

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 
+class CameraController2DInput;
 class InputConfig;
 
 namespace ControllerEmu
@@ -28,16 +29,28 @@ enum class FreeLookGroup
   Rotation,
 };
 
+enum class FreeLook2DGroup
+{
+  Move,
+  Speed,
+  Stretch,
+  Other,
+};
+
 namespace FreeLook
 {
 void Shutdown();
 void Initialize();
-void LoadInputConfig();
 bool IsInitialized();
 void UpdateInput();
 
+void LoadInputConfig();
 InputConfig* GetInputConfig();
 ControllerEmu::ControlGroup* GetInputGroup(int pad_num, FreeLookGroup group);
+
+void Load2DInputConfig();
+InputConfig* Get2DInputConfig();
+ControllerEmu::ControlGroup* Get2DInputGroup(int pad_num, FreeLook2DGroup group);
 
 }  // namespace FreeLook
 
@@ -58,6 +71,27 @@ private:
   ControllerEmu::Buttons* m_fov_buttons;
   ControllerEmu::Buttons* m_other_buttons;
   ControllerEmu::IMUGyroscope* m_rotation_gyro;
+
+  const unsigned int m_index;
+  std::optional<std::chrono::steady_clock::time_point> m_last_free_look_rotate_time;
+};
+
+class FreeLook2DController final : public ControllerEmu::EmulatedController
+{
+public:
+  explicit FreeLook2DController(unsigned int index);
+
+  std::string GetName() const override;
+
+  ControllerEmu::ControlGroup* GetGroup(FreeLook2DGroup group) const;
+  void Update();
+
+private:
+  void UpdateInput(CameraController2DInput* camera_controller);
+  ControllerEmu::Buttons* m_move_buttons;
+  ControllerEmu::Buttons* m_speed_buttons;
+  ControllerEmu::Buttons* m_stretch_buttons;
+  ControllerEmu::Buttons* m_other_buttons;
 
   const unsigned int m_index;
   std::optional<std::chrono::steady_clock::time_point> m_last_free_look_rotate_time;

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -612,6 +612,7 @@
     <ClInclude Include="VideoCommon\FramebufferShaderGen.h" />
     <ClInclude Include="VideoCommon\FrameDump.h" />
     <ClInclude Include="VideoCommon\FreeLookCamera.h" />
+    <ClInclude Include="VideoCommon\FreeLookCamera2D.h" />
     <ClInclude Include="VideoCommon\GeometryShaderGen.h" />
     <ClInclude Include="VideoCommon\GeometryShaderManager.h" />
     <ClInclude Include="VideoCommon\GXPipelineTypes.h" />
@@ -1166,6 +1167,7 @@
     <ClCompile Include="VideoCommon\FramebufferManager.cpp" />
     <ClCompile Include="VideoCommon\FramebufferShaderGen.cpp" />
     <ClCompile Include="VideoCommon\FreeLookCamera.cpp" />
+    <ClCompile Include="VideoCommon\FreeLookCamera2D.cpp" />
     <ClCompile Include="VideoCommon\GeometryShaderGen.cpp" />
     <ClCompile Include="VideoCommon\GeometryShaderManager.cpp" />
     <ClCompile Include="VideoCommon\HiresTextures_DDSLoader.cpp" />

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -73,6 +73,8 @@ add_executable(dolphin-emu
   Config/ControllersWindow.h
   Config/FilesystemWidget.cpp
   Config/FilesystemWidget.h
+  Config/FreeLook2DWidget.cpp
+  Config/FreeLook2DWidget.h
   Config/FreeLookWidget.cpp
   Config/FreeLookWidget.h
   Config/FreeLookWindow.cpp
@@ -120,6 +122,8 @@ add_executable(dolphin-emu
   Config/LogConfigWidget.h
   Config/LogWidget.cpp
   Config/LogWidget.h
+  Config/Mapping/FreeLook2DGeneral.cpp
+  Config/Mapping/FreeLook2DGeneral.h
   Config/Mapping/FreeLookGeneral.cpp
   Config/Mapping/FreeLookGeneral.h
   Config/Mapping/FreeLookRotation.cpp

--- a/Source/Core/DolphinQt/Config/FreeLook2DWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLook2DWidget.cpp
@@ -1,0 +1,86 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/FreeLook2DWidget.h"
+
+#include <QCheckBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+#include "Core/Config/FreeLookSettings.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+
+#include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/Mapping/MappingWindow.h"
+#include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
+#include "DolphinQt/Settings.h"
+
+FreeLook2DWidget::FreeLook2DWidget(QWidget* parent) : QWidget(parent)
+{
+  CreateLayout();
+  LoadSettings();
+  ConnectWidgets();
+}
+
+void FreeLook2DWidget::CreateLayout()
+{
+  auto* layout = new QVBoxLayout();
+  layout->setStretch(0, 0);
+
+  m_enable_freelook = new ToolTipCheckBox(tr("Enable"));
+  m_enable_freelook->setChecked(Config::Get(Config::FREE_LOOK_2D_ENABLED));
+  m_enable_freelook->SetDescription(tr("Allows manipulation of the in-game camera for 2d "
+                                       "elements.<br><br><dolphin_emphasis>If unsure, "
+                                       "leave this unchecked.</dolphin_emphasis>"));
+  m_freelook_controller_configure_button = new QPushButton(tr("Configure Controller"));
+
+  auto* hlayout = new QHBoxLayout();
+  hlayout->addWidget(new QLabel(tr("Camera 1")));
+  hlayout->addWidget(m_freelook_controller_configure_button);
+
+  layout->addWidget(m_enable_freelook);
+  layout->addLayout(hlayout);
+  layout->insertStretch(-1, 1);
+
+  setLayout(layout);
+}
+
+void FreeLook2DWidget::ConnectWidgets()
+{
+  connect(m_freelook_controller_configure_button, &QPushButton::clicked, this,
+          &FreeLook2DWidget::OnFreeLookControllerConfigured);
+  connect(m_enable_freelook, &QCheckBox::clicked, this, &FreeLook2DWidget::SaveSettings);
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
+    const QSignalBlocker blocker(this);
+    LoadSettings();
+  });
+}
+
+void FreeLook2DWidget::OnFreeLookControllerConfigured()
+{
+  if (m_freelook_controller_configure_button != QObject::sender())
+    return;
+  const int index = 0;
+  MappingWindow* window = new MappingWindow(this, MappingWindow::Type::MAPPING_FREELOOK_2D, index);
+  window->setAttribute(Qt::WA_DeleteOnClose, true);
+  window->setWindowModality(Qt::WindowModality::WindowModal);
+  window->show();
+}
+
+void FreeLook2DWidget::LoadSettings()
+{
+  const bool checked = Config::Get(Config::FREE_LOOK_2D_ENABLED);
+  m_enable_freelook->setChecked(checked);
+  m_freelook_controller_configure_button->setEnabled(checked);
+}
+
+void FreeLook2DWidget::SaveSettings()
+{
+  const bool checked = m_enable_freelook->isChecked();
+  Config::SetBaseOrCurrent(Config::FREE_LOOK_2D_ENABLED, checked);
+  m_freelook_controller_configure_button->setEnabled(checked);
+}

--- a/Source/Core/DolphinQt/Config/FreeLook2DWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLook2DWidget.h
@@ -1,0 +1,28 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+class ToolTipCheckBox;
+
+class FreeLook2DWidget final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit FreeLook2DWidget(QWidget* parent);
+
+private:
+  void CreateLayout();
+  void ConnectWidgets();
+
+  void OnFreeLookControllerConfigured();
+  void LoadSettings();
+  void SaveSettings();
+
+  ToolTipCheckBox* m_enable_freelook;
+  QPushButton* m_freelook_controller_configure_button;
+};

--- a/Source/Core/DolphinQt/Config/FreeLookWindow.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWindow.cpp
@@ -9,6 +9,7 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 
+#include "DolphinQt/Config/FreeLook2DWidget.h"
 #include "DolphinQt/Config/FreeLookWidget.h"
 
 FreeLookWindow::FreeLookWindow(QWidget* parent) : QDialog(parent)
@@ -24,8 +25,12 @@ void FreeLookWindow::CreateMainLayout()
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
+  auto* tab_widget = new QTabWidget();
+  tab_widget->addTab(new FreeLookWidget(this), tr("3D"));
+  tab_widget->addTab(new FreeLook2DWidget(this), tr("2D"));
+
   auto* main_layout = new QVBoxLayout();
-  main_layout->addWidget(new FreeLookWidget(this));
+  main_layout->addWidget(tab_widget);
   main_layout->addWidget(m_button_box);
   setLayout(main_layout);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.cpp
@@ -1,0 +1,51 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Mapping/FreeLook2DGeneral.h"
+
+#include <QGridLayout>
+#include <QGroupBox>
+
+#include "Core/FreeLookManager.h"
+#include "InputCommon/InputConfig.h"
+
+FreeLook2DGeneral::FreeLook2DGeneral(MappingWindow* window) : MappingWidget(window)
+{
+  CreateMainLayout();
+}
+
+void FreeLook2DGeneral::CreateMainLayout()
+{
+  auto* layout = new QGridLayout;
+
+  layout->addWidget(
+      CreateGroupBox(tr("Move"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Move)), 0,
+      0);
+  layout->addWidget(
+      CreateGroupBox(tr("Speed"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Speed)), 0,
+      1);
+  layout->addWidget(
+      CreateGroupBox(tr("Stretch"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Stretch)),
+      0, 2);
+  layout->addWidget(
+      CreateGroupBox(tr("Other"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Other)), 0,
+      3);
+
+  setLayout(layout);
+}
+
+void FreeLook2DGeneral::LoadSettings()
+{
+  FreeLook::Load2DInputConfig();
+}
+
+void FreeLook2DGeneral::SaveSettings()
+{
+  FreeLook::Get2DInputConfig()->SaveConfig();
+}
+
+InputConfig* FreeLook2DGeneral::GetConfig()
+{
+  return FreeLook::Get2DInputConfig();
+}

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.h
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.h
@@ -1,0 +1,21 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "DolphinQt/Config/Mapping/MappingWidget.h"
+
+class FreeLook2DGeneral final : public MappingWidget
+{
+  Q_OBJECT
+public:
+  explicit FreeLook2DGeneral(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+  void CreateMainLayout();
+};

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -22,6 +22,7 @@
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 
+#include "DolphinQt/Config/Mapping/FreeLook2DGeneral.h"
 #include "DolphinQt/Config/Mapping/FreeLookGeneral.h"
 #include "DolphinQt/Config/Mapping/FreeLookRotation.h"
 #include "DolphinQt/Config/Mapping/GCKeyboardEmu.h"
@@ -439,6 +440,13 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
     AddWidget(tr("General"), widget);
     AddWidget(tr("Rotation"), new FreeLookRotation(this));
     setWindowTitle(tr("Free Look Controller %1").arg(GetPort() + 1));
+  }
+  break;
+  case Type::MAPPING_FREELOOK_2D:
+  {
+    widget = new FreeLook2DGeneral(this);
+    AddWidget(tr("General"), widget);
+    setWindowTitle(tr("Free Look 2D Controller %1").arg(GetPort() + 1));
   }
   break;
   default:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -45,6 +45,7 @@ public:
     MAPPING_HOTKEYS,
     // Freelook
     MAPPING_FREELOOK,
+    MAPPING_FREELOOK_2D,
   };
 
   explicit MappingWindow(QWidget* parent, Type type, int port_num);

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="Config\ControllerInterface\ServerStringValidator.cpp" />
     <ClCompile Include="Config\ControllersWindow.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
+    <ClCompile Include="Config\FreeLook2DWidget.cpp" />
     <ClCompile Include="Config\FreeLookWidget.cpp" />
     <ClCompile Include="Config\FreeLookWindow.cpp" />
     <ClCompile Include="Config\GamecubeControllersWidget.cpp" />
@@ -79,6 +80,7 @@
     <ClCompile Include="Config\InfoWidget.cpp" />
     <ClCompile Include="Config\LogConfigWidget.cpp" />
     <ClCompile Include="Config\LogWidget.cpp" />
+    <ClCompile Include="Config\Mapping\FreeLook2DGeneral.cpp" />
     <ClCompile Include="Config\Mapping\FreeLookGeneral.cpp" />
     <ClCompile Include="Config\Mapping\FreeLookRotation.cpp" />
     <ClCompile Include="Config\Mapping\GCKeyboardEmu.cpp" />
@@ -231,6 +233,7 @@
     <QtMoc Include="Config\ControllerInterface\ServerStringValidator.h" />
     <QtMoc Include="Config\ControllersWindow.h" />
     <QtMoc Include="Config\FilesystemWidget.h" />
+    <QtMoc Include="Config\FreeLook2DWidget.h" />
     <QtMoc Include="Config\FreeLookWidget.h" />
     <QtMoc Include="Config\FreeLookWindow.h" />
     <QtMoc Include="Config\GamecubeControllersWidget.h" />
@@ -254,6 +257,7 @@
     <QtMoc Include="Config\InfoWidget.h" />
     <QtMoc Include="Config\LogConfigWidget.h" />
     <QtMoc Include="Config\LogWidget.h" />
+    <QtMoc Include="Config\Mapping\FreeLook2DGeneral.h" />
     <QtMoc Include="Config\Mapping\FreeLookGeneral.h" />
     <QtMoc Include="Config\Mapping\FreeLookRotation.h" />
     <QtMoc Include="Config\Mapping\GCKeyboardEmu.h" />

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -35,6 +35,8 @@ add_library(videocommon
   FramebufferShaderGen.h
   FreeLookCamera.cpp
   FreeLookCamera.h
+  FreeLookCamera2D.cpp
+  FreeLookCamera2D.h
   GeometryShaderGen.cpp
   GeometryShaderGen.h
   GeometryShaderManager.cpp

--- a/Source/Core/VideoCommon/FreeLookCamera2D.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera2D.cpp
@@ -1,0 +1,132 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoCommon/FreeLookCamera2D.h"
+
+#include <algorithm>
+#include <math.h>
+
+#include "Common/MathUtil.h"
+
+#include "Common/ChunkFile.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "Core/FreeLookConfig.h"
+
+#include "VideoCommon/VideoCommon.h"
+
+FreeLookCamera2D g_freelook_camera_2d;
+
+namespace
+{
+class BasicMovementController final : public CameraController2DInput
+{
+  void MoveVertical(float amt) override
+  {
+    m_position_offset.y += amt;
+    m_dirty = true;
+  }
+
+  void MoveHorizontal(float amt) override
+  {
+    m_position_offset.x += amt;
+    m_dirty = true;
+  }
+
+  const Common::Vec2& GetPositionOffset() const override { return m_position_offset; }
+
+  void DoState(PointerWrap& p) override
+  {
+    CameraController2DInput::DoState(p);
+    p.Do(m_position_offset);
+  }
+
+  void Reset() override
+  {
+    CameraController2DInput::Reset();
+    m_position_offset = Common::Vec2{};
+  }
+
+private:
+  Common::Vec2 m_position_offset;
+};
+}  // namespace
+
+void CameraController2DInput::IncreaseStretchX(float amt)
+{
+  m_stretch_multiplier.x += amt;
+}
+
+void CameraController2DInput::IncreaseStretchY(float amt)
+{
+  m_stretch_multiplier.y += amt;
+}
+
+float CameraController2DInput::GetStretchMultiplierSize() const
+{
+  return 1.0f;
+}
+
+const Common::Vec2& CameraController2DInput::GetStretchMultiplier() const
+{
+  return m_stretch_multiplier;
+}
+
+void CameraController2DInput::Reset()
+{
+  m_stretch_multiplier = DEFAULT_STRETCH_MULTIPLIER;
+  m_dirty = true;
+}
+
+void CameraController2DInput::ModifySpeed(float amt)
+{
+  m_speed += amt;
+  m_speed = std::max(m_speed, 0.0f);
+}
+
+void CameraController2DInput::ResetSpeed()
+{
+  m_speed = DEFAULT_SPEED;
+}
+
+float CameraController2DInput::GetSpeed() const
+{
+  return m_speed;
+}
+
+void CameraController2DInput::DoState(PointerWrap& p)
+{
+  p.Do(m_speed);
+  p.Do(m_stretch_multiplier);
+}
+
+FreeLookCamera2D::FreeLookCamera2D()
+{
+  m_controller = std::make_unique<BasicMovementController>();
+}
+
+const Common::Vec2& FreeLookCamera2D::GetPositionOffset() const
+{
+  return m_controller->GetPositionOffset();
+}
+
+const Common::Vec2& FreeLookCamera2D::GetStretchMultiplier() const
+{
+  return m_controller->GetStretchMultiplier();
+}
+
+CameraController2D* FreeLookCamera2D::GetController() const
+{
+  return m_controller.get();
+}
+
+bool FreeLookCamera2D::IsActive() const
+{
+  return FreeLook::GetActiveConfig().enabled_2d;
+}
+
+void FreeLookCamera2D::DoState(PointerWrap& p)
+{
+  m_controller->DoState(p);
+}

--- a/Source/Core/VideoCommon/FreeLookCamera2D.h
+++ b/Source/Core/VideoCommon/FreeLookCamera2D.h
@@ -1,0 +1,89 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "Common/Matrix.h"
+
+class PointerWrap;
+
+class CameraController2D
+{
+public:
+  CameraController2D() = default;
+  virtual ~CameraController2D() = default;
+  CameraController2D(const CameraController2D&) = delete;
+  CameraController2D& operator=(const CameraController2D&) = delete;
+  CameraController2D(CameraController2D&&) = delete;
+  CameraController2D& operator=(CameraController2D&&) = delete;
+
+  virtual const Common::Vec2& GetPositionOffset() const = 0;
+  virtual const Common::Vec2& GetStretchMultiplier() const = 0;
+
+  virtual void DoState(PointerWrap& p) = 0;
+
+  virtual bool IsDirty() const = 0;
+  virtual void SetClean() = 0;
+
+  virtual bool SupportsInput() const = 0;
+};
+
+class CameraController2DInput : public CameraController2D
+{
+public:
+  const Common::Vec2& GetStretchMultiplier() const final override;
+
+  virtual void MoveVertical(float amt) = 0;
+  virtual void MoveHorizontal(float amt) = 0;
+
+  virtual void Reset();
+
+  void IncreaseStretchX(float amt);
+  void IncreaseStretchY(float amt);
+
+  void DoState(PointerWrap& p) override;
+
+  bool IsDirty() const final override { return m_dirty; }
+  void SetClean() final override { m_dirty = false; }
+
+  bool SupportsInput() const final override { return true; }
+
+  void ModifySpeed(float multiplier);
+  void ResetSpeed();
+  float GetSpeed() const;
+
+  float GetStretchMultiplierSize() const;
+
+protected:
+  bool m_dirty = false;
+
+private:
+  static constexpr float DEFAULT_SPEED = 1.0f;
+  static constexpr Common::Vec2 DEFAULT_STRETCH_MULTIPLIER = Common::Vec2{1, 1};
+  Common::Vec2 m_stretch_multiplier = DEFAULT_STRETCH_MULTIPLIER;
+
+  float m_speed = DEFAULT_SPEED;
+};
+
+class FreeLookCamera2D
+{
+public:
+  FreeLookCamera2D();
+
+  const Common::Vec2& GetPositionOffset() const;
+  const Common::Vec2& GetStretchMultiplier() const;
+
+  CameraController2D* GetController() const;
+
+  bool IsActive() const;
+
+  void DoState(PointerWrap& p);
+
+private:
+  std::unique_ptr<CameraController2D> m_controller;
+};
+
+extern FreeLookCamera2D g_freelook_camera_2d;


### PR DESCRIPTION
This adds logic to Dolphin that allows you to modify orthographic projections from games ("2D").

Not all games will be able to take advantage of this (as some do weird things with 2d) but in theory it can remove bloom or disable the HUD by moving them off the "screen".

Possibly, it can be used to support modifying the aspect ratio of the 2d elements so that VR or ultra-wide monitors can feel more comfortable.

Best case, it can be used for some cool screenshots on certain games (though some games will need added post processing effects to fix missing bloom..coming soon™).


Before:

![image](https://user-images.githubusercontent.com/15224722/115133829-bd20f600-9fd0-11eb-983a-fe39bcc7c267.png)

After:

![image](https://user-images.githubusercontent.com/15224722/115133843-d0cc5c80-9fd0-11eb-8588-5c22fe9b7716.png)

--

Initial 2d edit screen:

![image](https://user-images.githubusercontent.com/15224722/115133852-e772b380-9fd0-11eb-9420-a82888f1f0ec.png)

2d / ortho freelook camera controller screen (no defaults, these are what I used to test):

![image](https://user-images.githubusercontent.com/15224722/115133861-f3f70c00-9fd0-11eb-9a9f-f00c66b6bf72.png)

