### PR TITLE
Android: Early changes to adapt for Android 12

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="org.dolphinemu.dolphinemu">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.dolphinemu.dolphinemu">
 
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -37,13 +38,16 @@
         android:allowBackup="false"
         android:supportsRtl="true"
         android:isGame="true"
-        android:banner="@drawable/banner_tv">
+        android:banner="@drawable/banner_tv"
+        android:debuggable="true"
+        tools:ignore="HardcodedDebugMode">
         <meta-data
             android:name="android.max_aspect"
             android:value="2.1"/>
 
         <activity
             android:name=".ui.main.MainActivity"
+            android:exported="true"
             android:theme="@style/DolphinBase">
 
             <!-- This intentfilter marks this Activity as the one that gets launched from Home screen. -->
@@ -56,6 +60,7 @@
 
         <activity
             android:name=".ui.main.TvMainActivity"
+            android:exported="true"
             android:theme="@style/DolphinTvBase">
 
             <!-- This intentfilter marks this Activity as the one that gets launched from Home screen. -->
@@ -68,26 +73,33 @@
 
         <activity
             android:name=".features.settings.ui.SettingsActivity"
+            android:exported="false"
             android:configChanges="orientation|screenSize"
             android:theme="@style/DolphinSettingsBase"
             android:label="@string/preferences_settings"/>
 
         <activity
             android:name=".activities.EmulationActivity"
+            android:exported="false"
             android:theme="@style/DolphinEmulationBase"
             android:preferMinimalPostProcessing="true"/>
 
         <activity
             android:name=".activities.CustomFilePickerActivity"
+            android:exported="false"
             android:label="@string/app_name"
             android:theme="@style/FilePickerTheme">
+
             <intent-filter>
                 <action android:name="android.intent.action.GET_CONTENT"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </activity>
 
-        <activity android:name=".activities.AppLinkActivity">
+        <activity
+            android:name=".activities.AppLinkActivity"
+            android:exported="true">
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
@@ -99,14 +111,22 @@
 
         <activity
             android:name=".activities.ConvertActivity"
+            android:exported="false"
             android:theme="@style/DolphinBase" />
 
-        <service android:name=".utils.DirectoryInitialization"/>
-        <service android:name=".services.GameFileCacheService"/>
+        <service
+            android:name=".utils.DirectoryInitialization"
+            android:exported="false"/>
+
+        <service
+            android:name=".services.GameFileCacheService"
+            android:exported="false"/>
+
         <service
             android:name=".services.SyncChannelJobService"
             android:exported="false"
             android:permission="android.permission.BIND_JOB_SERVICE"/>
+
         <service
             android:name=".services.SyncProgramsJobService"
             android:exported="false"

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_GCAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_GCAdapter.java
@@ -11,6 +11,7 @@ import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 import android.widget.Toast;
 
 import androidx.annotation.Keep;
@@ -46,11 +47,13 @@ public class Java_GCAdapter
         {
           if (!manager.hasPermission(dev))
           {
-            Intent intent = new Intent();
-            PendingIntent pend_intent;
-            intent.setClass(context, USBPermService.class);
-            pend_intent = PendingIntent.getService(context, 0, intent, 0);
-            manager.requestPermission(dev, pend_intent);
+            Intent intent = new Intent(context, USBPermService.class);
+
+            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ?
+                    PendingIntent.FLAG_IMMUTABLE : 0;
+            PendingIntent pendingIntent = PendingIntent.getService(context, 0, intent, flags);
+
+            manager.requestPermission(dev, pendingIntent);
           }
         }
       }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
@@ -9,6 +9,7 @@ import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 
 import androidx.annotation.Keep;
 
@@ -50,11 +51,14 @@ public class Java_WiimoteAdapter
           if (!manager.hasPermission(dev))
           {
             Log.warning("Requesting permission for Wii Remote adapter");
-            Intent intent = new Intent();
-            PendingIntent pend_intent;
-            intent.setClass(context, USBPermService.class);
-            pend_intent = PendingIntent.getService(context, 0, intent, 0);
-            manager.requestPermission(dev, pend_intent);
+
+            Intent intent = new Intent(context, USBPermService.class);
+
+            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ?
+                    PendingIntent.FLAG_IMMUTABLE : 0;
+            PendingIntent pendingIntent = PendingIntent.getService(context, 0, intent, flags);
+
+            manager.requestPermission(dev, pendingIntent);
           }
         }
       }


### PR DESCRIPTION
We don't actually need to do this until we bump targetSdkVersion to Android 12 (which we can't do yet since we're not compatible with scoped storage), but I figured I'd get it out of the way early.

Not tested on Android 12, but tested to not break stuff on Android 10.