### PR TITLE
DataReport: Amend conditional test for data reports in IsValidMode

### DIFF
--- a/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
+++ b/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
@@ -335,7 +335,7 @@ InputReportID DataReportBuilder::GetMode() const
 bool DataReportBuilder::IsValidMode(InputReportID mode)
 {
   return (mode >= InputReportID::ReportCore && mode <= InputReportID::ReportCoreAccelIR10Ext6) ||
-         (mode >= InputReportID::ReportExt21 && InputReportID::ReportInterleave2 <= mode);
+         (mode >= InputReportID::ReportExt21 && mode <= InputReportID::ReportInterleave2);
 }
 
 bool DataReportBuilder::HasCore() const


### PR DESCRIPTION
This particular range check is kind of odd, and would only interpret interleave mode 2 as a valid mode, while rejecting interleave mode 1 and the extension byte mode.

As far as I know, and, based off the information on Wiibrew, we should be considering all three values within this range as valid.