### PR TITLE
BlockingLoop/Jit64: Indicate explicit fallthrough where applicable

### DIFF
--- a/Source/Core/Common/BlockingLoop.h
+++ b/Source/Core/Common/BlockingLoop.h
@@ -158,6 +158,7 @@ public:
         // However, if we're not in the STATE_DONE state any more, the event should also be
         // triggered so that we'll skip the next waiting call quite fast.
         m_done_event.Set();
+        [[fallthrough]];
 
       case STATE_DONE:
         // We're done now. So time to check if we want to sleep or if we want to stay in a busy
@@ -173,6 +174,7 @@ public:
           // Busy loop.
           break;
         }
+        [[fallthrough]];
 
       case STATE_SLEEPING:
         // Just relax

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -74,6 +74,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
     {
     case 534:  // lwbrx
       byte_reversed = true;
+      [[fallthrough]];
     case 23:  // lwzx
     case 55:  // lwzux
       accessSize = 32;
@@ -87,6 +88,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
       break;
     case 790:  // lhbrx
       byte_reversed = true;
+      [[fallthrough]];
     case 279:  // lhzx
     case 311:  // lhzux
       accessSize = 16;


### PR DESCRIPTION
Makes it explicit that falling through into the next case is intended.