### PR TITLE
InputCommon: Add a new function ntimes(input, n)

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -292,6 +292,7 @@ void IOWindow::CreateMainLayout()
   m_functions_combo->addItem(QStringLiteral("tap"));
   m_functions_combo->addItem(QStringLiteral("relative"));
   m_functions_combo->addItem(QStringLiteral("pulse"));
+  m_functions_combo->addItem(QStringLiteral("ntimes"));
   m_functions_combo->addItem(QStringLiteral("sin"));
   m_functions_combo->addItem(QStringLiteral("cos"));
   m_functions_combo->addItem(QStringLiteral("tan"));

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
@@ -652,7 +652,7 @@ private:
   ControlState GetValue() const override
   {
     const ControlState input = GetArg(0).GetValue();
-    const int times = (GetArgCount() >= 2) ? int(GetArg(1).GetValue()) : 1;
+    const u32 times = GetArgCount() >= 2 ? u32(std::max(GetArg(1).GetValue() + 0.5, 0.0)) : 1;
 
     if (m_running)
     {
@@ -685,9 +685,9 @@ private:
 private:
   mutable bool m_zeroed = true;
   mutable bool m_running = false;
-  mutable int m_loops = 0;
+  mutable u32 m_loops = 0;
   mutable ControlState m_input = 0.0;
-  mutable int m_times = 0;
+  mutable u32 m_times = 0;
 };
 
 std::unique_ptr<FunctionExpression> MakeFunctionExpression(std::string_view name)

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
@@ -646,13 +646,13 @@ private:
     if (args.size() == 1 || args.size() == 2)
       return ArgumentsAreValid{};
     else
-      return ExpectedArguments{"input, [times = 1]"};
+      return ExpectedArguments{"input, times = 1"};
   }
 
   ControlState GetValue() const override
   {
     const ControlState input = GetArg(0).GetValue();
-    const ControlState times = GetArg(1).GetValue();
+    const int times = (GetArgCount() >= 2) ? int(GetArg(1).GetValue()) : 1;
 
     if (m_running)
     {

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
@@ -636,7 +636,7 @@ private:
   mutable Clock::time_point m_release_time = Clock::now();
 };
 
-// usage: ntimes(input, n = 1)
+// usage: ntimes(input, times = 1)
 class NTimesExpression : public FunctionExpression
 {
 private:
@@ -646,11 +646,14 @@ private:
     if (args.size() == 1 || args.size() == 2)
       return ArgumentsAreValid{};
     else
-      return ExpectedArguments{"input, times = 1"};
+      return ExpectedArguments{"input, [times = 1]"};
   }
 
   ControlState GetValue() const override
   {
+    const ControlState input = GetArg(0).GetValue();
+    const ControlState times = GetArg(1).GetValue();
+
     if (m_running)
     {
       m_loops++;
@@ -662,10 +665,10 @@ private:
       else
         return 0.0;
     }
-    else if (m_zeroed && GetArg(0).GetValue() != 0.0)
+    else if (m_zeroed && input != 0.0)
     {
-      m_input = GetArg(0).GetValue();
-      m_times = GetArg(1).GetValue();
+      m_input = input;
+      m_times = times;
       m_running = true;
       m_loops = 1;
       m_zeroed = false;
@@ -673,7 +676,7 @@ private:
     }
     else
     {
-      if (GetArg(0).GetValue() == 0.0)
+      if (input == 0.0)
         m_zeroed = true;
       return 0.0;
     }


### PR DESCRIPTION
Example: `ntimes(A, 5)` will output 0.0 until A is pressed, then alternately output 1.0 and 0.0 five times (when polled), and then output 0.0 until A is released and pressed again.

Example: `ntimes(0.7, 3)` will output `0.7 0.0 0.7 0.0 0.7 0.0 0.0 0.0 0.0 ...`.

This is very similar to `toggle()`, except that (a) the first argument does not have to be greater than 0.5 to trigger it, just non-zero, and (b) it won't trigger again until an input of zero has been received again.

This might not have any practical use in games that isn't already covered by other functions (especially `toggle()`). My interest is in using it to make precise changes to Dolphin settings. For instance, setting *Decrease FOV X* and *Decrease FOV Y* to `ntimes(A, 20)` lets me press a single button to change both FOV settings to exactly 0.500. I am not aware of another way to do this via a controller binding.