### PR TITLE
Fix IPL crash when launching MIOS-patched games

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -76,6 +76,14 @@ void Patch(u32 addr, std::string_view func_name)
 
 void PatchFixedFunctions()
 {
+  // MIOS puts patch data in low MEM1 (0x1800-0x3000) for its own use.
+  // Overwriting data in this range can cause the IPL to crash when launching games
+  // that get patched by MIOS. See https://bugs.dolphin-emu.org/issues/11952 for more info.
+  // Not applying the Gecko HLE patches means that Gecko codes will not work under MIOS,
+  // but this is better than the alternative of having specific games crash.
+  if (SConfig::GetInstance().m_is_mios)
+    return;
+
   // HLE jump to loader (homebrew).  Disabled when Gecko is active as it interferes with the code
   // handler
   if (!SConfig::GetInstance().bEnableCheats)

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -86,6 +86,7 @@ bool Load()
   NOTICE_LOG_FMT(IOS, "IPL ready.");
   SConfig::GetInstance().m_is_mios = true;
   DVDInterface::UpdateRunningGameMetadata();
+  SConfig::OnNewTitleLoad();
   return true;
 }
 }  // namespace IOS::HLE::MIOS


### PR DESCRIPTION
MIOS (the IPL code running on the PPC, not the ARM part) puts patch data in low MEM1 (0x1800-0x3000) for its own use. Overwriting data in this range can cause the IPL to crash when launching games that get patched by MIOS. See https://bugs.dolphin-emu.org/issues/11952 for more info.

Not applying the Gecko HLE patches means that Gecko codes will not work under MIOS, but this is better than the alternative of having specific games crash.

---

This also fixes an oversight from #9545, which moved the "new game has been loaded" logic to a separate OnNewTitleLoad function that has to be called explicitly *after* a title has loaded.

Those two changes fix Wind Waker and other MIOS-patched games when they are launched from the System Menu.
