### PR TITLE
Jit: Optimize block link queries by using hash tables

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -12,6 +12,8 @@
 #include <memory>
 #include <set>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -182,7 +184,7 @@ private:
 
   // links_to hold all exit points of all valid blocks in a reverse way.
   // It is used to query all blocks which links to an address.
-  std::multimap<u32, JitBlock*> links_to;  // destination_PC -> number
+  std::unordered_map<u32, std::unordered_set<JitBlock*>> links_to;  // destination_PC -> number
 
   // Map indexed by the physical address of the entry point.
   // This is used to query the block based on the current PC in a slow way.
@@ -192,7 +194,7 @@ private:
   // This is used for invalidation of memory regions. The range is grouped
   // in macro blocks of each 0x100 bytes.
   static constexpr u32 BLOCK_RANGE_MAP_ELEMENTS = 0x100;
-  std::map<u32, std::set<JitBlock*>> block_range_map;
+  std::map<u32, std::unordered_set<JitBlock*>> block_range_map;
 
   // This bitsets shows which cachelines overlap with any blocks.
   // It is used to provide a fast way to query if no icache invalidation is needed.


### PR DESCRIPTION
Repeated erase() + iteration on a std::multimap is extremely slow. Slow enough that it causes a 7 second long stutter during some transitions in F-Zero X (a N64 VC game that triggers many, many icache invalidations).

And slow enough that JitBaseBlockCache::DestroyBlock shows up on a flame graph as taking >50% of total CPU time on the CPU-GPU thread.

**Master**:

![flame](https://i.imgur.com/vvqiFL6.png)

This PR optimises those block link queries by replacing the std::multimap (which is typically implemented with red-black trees) with hash tables, which seem better suited to our repeated insert/erase/iteration workload.

**PR**: ~0.7s stutters (10x less), which is pretty close to 5.0 stable. (5.0-2021 introduced the performance regression and it is especially noticeable when branch following is disabled, which is the case for all N64 VC games since 5.0-8377.)

![flame pr](https://i.imgur.com/hAO74fy.png)

---

I briefly considered using a faster implementation (e.g. Swiss tables) since this is a pretty hot path, but that "only" led to a 4-5% improvement (stutters were just 30ms shorter)...