### PR TITLE
Core / VideoCommon: refactor FreeLookCamera

### DIFF
--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -197,6 +197,15 @@ void FreeLookController::Update()
   if (!g_freelook_camera.IsActive())
     return;
 
+  auto* camera_controller = g_freelook_camera.GetController();
+  if (camera_controller->SupportsInput())
+  {
+    UpdateInput();
+  }
+}
+
+void FreeLookController::UpdateInput()
+{
   const auto lock = GetStateLock();
 
   float dt = 1.0;
@@ -220,48 +229,50 @@ void FreeLookController::Update()
   const auto gyro_motion_quat =
       Common::Quaternion::RotateXYZ(gyro_motion_rad_velocity_converted * dt);
 
-  g_freelook_camera.Rotate(gyro_motion_quat);
+  auto* camera_controller = static_cast<CameraControllerInput*>(g_freelook_camera.GetController());
+
+  camera_controller->Rotate(gyro_motion_quat);
   if (m_move_buttons->controls[MoveButtons::Up]->GetState<bool>())
-    g_freelook_camera.MoveVertical(-g_freelook_camera.GetSpeed() * dt);
+    camera_controller->MoveVertical(-camera_controller->GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Down]->GetState<bool>())
-    g_freelook_camera.MoveVertical(g_freelook_camera.GetSpeed() * dt);
+    camera_controller->MoveVertical(camera_controller->GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Left]->GetState<bool>())
-    g_freelook_camera.MoveHorizontal(g_freelook_camera.GetSpeed() * dt);
+    camera_controller->MoveHorizontal(camera_controller->GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Right]->GetState<bool>())
-    g_freelook_camera.MoveHorizontal(-g_freelook_camera.GetSpeed() * dt);
+    camera_controller->MoveHorizontal(-camera_controller->GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Forward]->GetState<bool>())
-    g_freelook_camera.MoveForward(g_freelook_camera.GetSpeed() * dt);
+    camera_controller->MoveForward(camera_controller->GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Backward]->GetState<bool>())
-    g_freelook_camera.MoveForward(-g_freelook_camera.GetSpeed() * dt);
+    camera_controller->MoveForward(-camera_controller->GetSpeed() * dt);
 
   if (m_fov_buttons->controls[FieldOfViewButtons::IncreaseX]->GetState<bool>())
-    g_freelook_camera.IncreaseFovX(g_freelook_camera.GetFovStepSize() * dt);
+    camera_controller->IncreaseFovX(camera_controller->GetFovStepSize() * dt);
 
   if (m_fov_buttons->controls[FieldOfViewButtons::DecreaseX]->GetState<bool>())
-    g_freelook_camera.IncreaseFovX(-1.0f * g_freelook_camera.GetFovStepSize() * dt);
+    camera_controller->IncreaseFovX(-1.0f * camera_controller->GetFovStepSize() * dt);
 
   if (m_fov_buttons->controls[FieldOfViewButtons::IncreaseY]->GetState<bool>())
-    g_freelook_camera.IncreaseFovY(g_freelook_camera.GetFovStepSize() * dt);
+    camera_controller->IncreaseFovY(camera_controller->GetFovStepSize() * dt);
 
   if (m_fov_buttons->controls[FieldOfViewButtons::DecreaseY]->GetState<bool>())
-    g_freelook_camera.IncreaseFovY(-1.0f * g_freelook_camera.GetFovStepSize() * dt);
+    camera_controller->IncreaseFovY(-1.0f * camera_controller->GetFovStepSize() * dt);
 
   if (m_speed_buttons->controls[SpeedButtons::Decrease]->GetState<bool>())
-    g_freelook_camera.ModifySpeed(g_freelook_camera.GetSpeed() * -0.9 * dt);
+    camera_controller->ModifySpeed(camera_controller->GetSpeed() * -0.9 * dt);
 
   if (m_speed_buttons->controls[SpeedButtons::Increase]->GetState<bool>())
-    g_freelook_camera.ModifySpeed(g_freelook_camera.GetSpeed() * 1.1 * dt);
+    camera_controller->ModifySpeed(camera_controller->GetSpeed() * 1.1 * dt);
 
   if (m_speed_buttons->controls[SpeedButtons::Reset]->GetState<bool>())
-    g_freelook_camera.ResetSpeed();
+    camera_controller->ResetSpeed();
 
   if (m_other_buttons->controls[OtherButtons::ResetView]->GetState<bool>())
-    g_freelook_camera.Reset();
+    camera_controller->Reset();
 }
 
 namespace FreeLook

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -53,6 +53,7 @@ public:
   void Update();
 
 private:
+  void UpdateInput();
   ControllerEmu::Buttons* m_move_buttons;
   ControllerEmu::Buttons* m_speed_buttons;
   ControllerEmu::Buttons* m_fov_buttons;

--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -36,12 +36,12 @@ std::string to_string(FreeLook::ControlType type)
   return "";
 }
 
-class SixAxisController final : public CameraController
+class SixAxisController final : public CameraControllerInput
 {
 public:
   SixAxisController() = default;
 
-  Common::Matrix44 GetView() override { return m_mat; }
+  Common::Matrix44 GetView() const override { return m_mat; }
 
   void MoveVertical(float amt) override
   {
@@ -65,18 +65,26 @@ public:
     m_mat = Common::Matrix44::FromQuaternion(quat) * m_mat;
   }
 
-  void Reset() override { m_mat = Common::Matrix44::Identity(); }
+  void Reset() override
+  {
+    CameraControllerInput::Reset();
+    m_mat = Common::Matrix44::Identity();
+  }
 
-  void DoState(PointerWrap& p) override { p.Do(m_mat); }
+  void DoState(PointerWrap& p) override
+  {
+    CameraControllerInput::DoState(p);
+    p.Do(m_mat);
+  }
 
 private:
   Common::Matrix44 m_mat = Common::Matrix44::Identity();
 };
 
-class FPSController final : public CameraController
+class FPSController final : public CameraControllerInput
 {
 public:
-  Common::Matrix44 GetView() override
+  Common::Matrix44 GetView() const override
   {
     return Common::Matrix44::FromQuaternion(m_rotate_quat) *
            Common::Matrix44::Translate(m_position);
@@ -119,6 +127,7 @@ public:
 
   void Reset() override
   {
+    CameraControllerInput::Reset();
     m_position = Common::Vec3{};
     m_rotation = Common::Vec3{};
     m_rotate_quat = Common::Quaternion::Identity();
@@ -126,6 +135,7 @@ public:
 
   void DoState(PointerWrap& p) override
   {
+    CameraControllerInput::DoState(p);
     p.Do(m_rotation);
     p.Do(m_rotate_quat);
     p.Do(m_position);
@@ -137,10 +147,10 @@ private:
   Common::Vec3 m_position = Common::Vec3{};
 };
 
-class OrbitalController final : public CameraController
+class OrbitalController final : public CameraControllerInput
 {
 public:
-  Common::Matrix44 GetView() override
+  Common::Matrix44 GetView() const override
   {
     return Common::Matrix44::Translate(Common::Vec3{0, 0, -m_distance}) *
            Common::Matrix44::FromQuaternion(m_rotate_quat);
@@ -175,6 +185,7 @@ public:
 
   void Reset() override
   {
+    CameraControllerInput::Reset();
     m_rotation = Common::Vec3{};
     m_rotate_quat = Common::Quaternion::Identity();
     m_distance = 0;
@@ -182,6 +193,7 @@ public:
 
   void DoState(PointerWrap& p) override
   {
+    CameraControllerInput::DoState(p);
     p.Do(m_rotation);
     p.Do(m_rotate_quat);
     p.Do(m_distance);
@@ -193,6 +205,58 @@ private:
   Common::Quaternion m_rotate_quat = Common::Quaternion::Identity();
 };
 }  // namespace
+
+Common::Vec2 CameraControllerInput::GetFieldOfView() const
+{
+  return Common::Vec2{m_fov_x, m_fov_y};
+}
+
+void CameraControllerInput::DoState(PointerWrap& p)
+{
+  p.Do(m_speed);
+  p.Do(m_fov_x);
+  p.Do(m_fov_y);
+}
+
+void CameraControllerInput::IncreaseFovX(float fov)
+{
+  m_fov_x += fov;
+  m_fov_x = std::clamp(m_fov_x, m_min_fov_multiplier, m_fov_x);
+}
+
+void CameraControllerInput::IncreaseFovY(float fov)
+{
+  m_fov_y += fov;
+  m_fov_y = std::clamp(m_fov_y, m_min_fov_multiplier, m_fov_y);
+}
+
+float CameraControllerInput::GetFovStepSize() const
+{
+  return 1.5f;
+}
+
+void CameraControllerInput::Reset()
+{
+  m_fov_x = 1.0f;
+  m_fov_y = 1.0f;
+  m_dirty = true;
+}
+
+void CameraControllerInput::ModifySpeed(float amt)
+{
+  m_speed += amt;
+  m_speed = std::clamp(m_speed, 0.0f, m_speed);
+}
+
+void CameraControllerInput::ResetSpeed()
+{
+  m_speed = 60.0f;
+}
+
+float CameraControllerInput::GetSpeed() const
+{
+  return m_speed;
+}
 
 FreeLookCamera::FreeLookCamera()
 {
@@ -222,95 +286,21 @@ void FreeLookCamera::SetControlType(FreeLook::ControlType type)
   m_current_type = type;
 }
 
-Common::Matrix44 FreeLookCamera::GetView()
+Common::Matrix44 FreeLookCamera::GetView() const
 {
   return m_camera_controller->GetView();
 }
 
 Common::Vec2 FreeLookCamera::GetFieldOfView() const
 {
-  return Common::Vec2{m_fov_x, m_fov_y};
-}
-
-void FreeLookCamera::MoveVertical(float amt)
-{
-  m_camera_controller->MoveVertical(amt);
-  m_dirty = true;
-}
-
-void FreeLookCamera::MoveHorizontal(float amt)
-{
-  m_camera_controller->MoveHorizontal(amt);
-  m_dirty = true;
-}
-
-void FreeLookCamera::MoveForward(float amt)
-{
-  m_camera_controller->MoveForward(amt);
-  m_dirty = true;
-}
-
-void FreeLookCamera::Rotate(const Common::Vec3& amt)
-{
-  m_camera_controller->Rotate(amt);
-  m_dirty = true;
-}
-
-void FreeLookCamera::Rotate(const Common::Quaternion& amt)
-{
-  m_camera_controller->Rotate(amt);
-  m_dirty = true;
-}
-
-void FreeLookCamera::IncreaseFovX(float fov)
-{
-  m_fov_x += fov;
-  m_fov_x = std::clamp(m_fov_x, m_min_fov_multiplier, m_fov_x);
-}
-
-void FreeLookCamera::IncreaseFovY(float fov)
-{
-  m_fov_y += fov;
-  m_fov_y = std::clamp(m_fov_y, m_min_fov_multiplier, m_fov_y);
-}
-
-float FreeLookCamera::GetFovStepSize() const
-{
-  return 1.5f;
-}
-
-void FreeLookCamera::Reset()
-{
-  m_camera_controller->Reset();
-  m_fov_x = 1.0f;
-  m_fov_y = 1.0f;
-  m_dirty = true;
-}
-
-void FreeLookCamera::ModifySpeed(float amt)
-{
-  m_speed += amt;
-  m_speed = std::clamp(m_speed, 0.0f, m_speed);
-}
-
-void FreeLookCamera::ResetSpeed()
-{
-  m_speed = 60.0f;
-}
-
-float FreeLookCamera::GetSpeed() const
-{
-  return m_speed;
+  return m_camera_controller->GetFieldOfView();
 }
 
 void FreeLookCamera::DoState(PointerWrap& p)
 {
   if (p.mode == PointerWrap::MODE_WRITE || p.mode == PointerWrap::MODE_MEASURE)
   {
-    p.Do(m_speed);
     p.Do(m_current_type);
-    p.Do(m_fov_x);
-    p.Do(m_fov_y);
     if (m_camera_controller)
     {
       m_camera_controller->DoState(p);
@@ -319,10 +309,7 @@ void FreeLookCamera::DoState(PointerWrap& p)
   else
   {
     const auto old_type = m_current_type;
-    p.Do(m_speed);
     p.Do(m_current_type);
-    p.Do(m_fov_x);
-    p.Do(m_fov_y);
     if (old_type == m_current_type)
     {
       m_camera_controller->DoState(p);
@@ -341,17 +328,12 @@ void FreeLookCamera::DoState(PointerWrap& p)
   }
 }
 
-bool FreeLookCamera::IsDirty() const
-{
-  return m_dirty;
-}
-
-void FreeLookCamera::SetClean()
-{
-  m_dirty = false;
-}
-
 bool FreeLookCamera::IsActive() const
 {
   return FreeLook::GetActiveConfig().enabled;
+}
+
+CameraController* FreeLookCamera::GetController() const
+{
+  return m_camera_controller.get();
 }

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -24,7 +24,28 @@ public:
   CameraController(CameraController&&) = delete;
   CameraController& operator=(CameraController&&) = delete;
 
-  virtual Common::Matrix44 GetView() = 0;
+  virtual Common::Matrix44 GetView() const = 0;
+  virtual Common::Vec2 GetFieldOfView() const = 0;
+
+  virtual void DoState(PointerWrap& p) = 0;
+
+  virtual bool IsDirty() const = 0;
+  virtual void SetClean() = 0;
+
+  virtual bool SupportsInput() const = 0;
+};
+
+class CameraControllerInput : public CameraController
+{
+public:
+  Common::Vec2 GetFieldOfView() const final override;
+
+  void DoState(PointerWrap& p) override;
+
+  bool IsDirty() const final override { return m_dirty; }
+  void SetClean() final override { m_dirty = false; }
+
+  bool SupportsInput() const final override { return true; }
 
   virtual void MoveVertical(float amt) = 0;
   virtual void MoveHorizontal(float amt) = 0;
@@ -36,7 +57,21 @@ public:
 
   virtual void Reset() = 0;
 
-  virtual void DoState(PointerWrap& p) = 0;
+  void IncreaseFovX(float fov);
+  void IncreaseFovY(float fov);
+  float GetFovStepSize() const;
+
+  void ModifySpeed(float multiplier);
+  void ResetSpeed();
+  float GetSpeed() const;
+
+private:
+  float m_fov_x = 1.0f;
+  float m_fov_y = 1.0f;
+
+  float m_min_fov_multiplier = 0.025f;
+  float m_speed = 60.0f;
+  bool m_dirty = false;
 };
 
 class FreeLookCamera
@@ -44,42 +79,19 @@ class FreeLookCamera
 public:
   FreeLookCamera();
   void SetControlType(FreeLook::ControlType type);
-  Common::Matrix44 GetView();
+  Common::Matrix44 GetView() const;
   Common::Vec2 GetFieldOfView() const;
-
-  void MoveVertical(float amt);
-  void MoveHorizontal(float amt);
-  void MoveForward(float amt);
-
-  void Rotate(const Common::Vec3& amt);
-  void Rotate(const Common::Quaternion& amt);
-
-  void IncreaseFovX(float fov);
-  void IncreaseFovY(float fov);
-  float GetFovStepSize() const;
-
-  void Reset();
 
   void DoState(PointerWrap& p);
 
-  bool IsDirty() const;
-  void SetClean();
-
-  void ModifySpeed(float multiplier);
-  void ResetSpeed();
-  float GetSpeed() const;
-
   bool IsActive() const;
+
+  CameraController* GetController() const;
 
 private:
   bool m_dirty = false;
-  float m_fov_x = 1.0f;
-  float m_fov_y = 1.0f;
   std::optional<FreeLook::ControlType> m_current_type;
   std::unique_ptr<CameraController> m_camera_controller;
-
-  float m_min_fov_multiplier = 0.025f;
-  float m_speed = 60.0f;
 };
 
 extern FreeLookCamera g_freelook_camera;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -345,7 +345,7 @@ void VertexShaderManager::SetConstants()
     }
   }
 
-  if (bProjectionChanged || g_freelook_camera.IsDirty())
+  if (bProjectionChanged || g_freelook_camera.GetController()->IsDirty())
   {
     bProjectionChanged = false;
 
@@ -424,7 +424,7 @@ void VertexShaderManager::SetConstants()
 
     memcpy(constants.projection.data(), corrected_matrix.data.data(), 4 * sizeof(float4));
 
-    g_freelook_camera.SetClean();
+    g_freelook_camera.GetController()->SetClean();
 
     dirty = true;
   }


### PR DESCRIPTION
This just refactors the `FreeLookCamera` so things that it previously managed (dirty state, field of view, etc) come from the controller.  Also the controller has been split into the base controller and a new controller called `CameraControllerInput` which all controllers derive from.  This will be used in a future PR.