### PR TITLE
FreeLook: allow controlling exact position, rotation, field-of-view multiplier by UDP

### DIFF
--- a/Source/Core/Core/Config/FreeLookSettings.cpp
+++ b/Source/Core/Core/Config/FreeLookSettings.cpp
@@ -16,5 +16,7 @@ const Info<bool> FREE_LOOK_ENABLED{{System::FreeLook, "General", "Enabled"}, fal
 // FreeLook.Controller1
 const Info<FreeLook::ControlType> FL1_CONTROL_TYPE{{System::FreeLook, "Camera1", "ControlType"},
                                                    FreeLook::ControlType::SixAxis};
+const Info<std::string> FL1_UDP_ADDRESS{{System::FreeLook, "Camera1", "UDPAddress"}, "127.0.0.1"};
+const Info<u16> FL1_UDP_PORT{{System::FreeLook, "Camera1", "UDPPort"}, 36760};
 
 }  // namespace Config

--- a/Source/Core/Core/Config/FreeLookSettings.h
+++ b/Source/Core/Core/Config/FreeLookSettings.h
@@ -18,5 +18,7 @@ extern const Info<bool> FREE_LOOK_ENABLED;
 
 // FreeLook.Controller1
 extern const Info<FreeLook::ControlType> FL1_CONTROL_TYPE;
+extern const Info<std::string> FL1_UDP_ADDRESS;
+extern const Info<u16> FL1_UDP_PORT;
 
 }  // namespace Config

--- a/Source/Core/Core/FreeLookConfig.cpp
+++ b/Source/Core/Core/FreeLookConfig.cpp
@@ -43,5 +43,11 @@ void Config::Refresh()
 
   camera_config.control_type = ::Config::Get(::Config::FL1_CONTROL_TYPE);
   enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED);
+
+  if (camera_config.control_type == ControlType::UDP)
+  {
+    camera_config.udp_settings = UDPSettings{::Config::Get(::Config::FL1_UDP_ADDRESS),
+                                             ::Config::Get(::Config::FL1_UDP_PORT)};
+  }
 }
 }  // namespace FreeLook

--- a/Source/Core/Core/FreeLookConfig.h
+++ b/Source/Core/Core/FreeLookConfig.h
@@ -8,18 +8,31 @@
 
 #pragma once
 
+#include <optional>
+#include <string>
+
+#include "Common/CommonTypes.h"
+
 namespace FreeLook
 {
 enum class ControlType : int
 {
   SixAxis,
   FPS,
-  Orbital
+  Orbital,
+  UDP,
+};
+
+struct UDPSettings
+{
+  std::string address;
+  u16 port;
 };
 
 struct CameraConfig
 {
   ControlType control_type;
+  std::optional<UDPSettings> udp_settings;
 };
 
 // NEVER inherit from this class.

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -221,6 +221,11 @@ void FreeLookController::Update()
   {
     UpdateInput(static_cast<CameraControllerInput*>(camera_controller));
   }
+  else
+  {
+    m_last_free_look_rotate_time.reset();
+    static_cast<CameraControllerGeneric*>(camera_controller)->Update();
+  }
 }
 
 void FreeLookController::UpdateInput(CameraControllerInput* camera_controller)

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -624,6 +624,8 @@
     <ClInclude Include="VideoCommon\FramebufferShaderGen.h" />
     <ClInclude Include="VideoCommon\FrameDump.h" />
     <ClInclude Include="VideoCommon\FreeLookCamera.h" />
+    <ClInclude Include="VideoCommon\FreeLookUDPServer.h" />
+    <ClInclude Include="VideoCommon\FreeLookUDPSpec.h" />
     <ClInclude Include="VideoCommon\GeometryShaderGen.h" />
     <ClInclude Include="VideoCommon\GeometryShaderManager.h" />
     <ClInclude Include="VideoCommon\GXPipelineTypes.h" />
@@ -1193,6 +1195,7 @@
     <ClCompile Include="VideoCommon\FramebufferManager.cpp" />
     <ClCompile Include="VideoCommon\FramebufferShaderGen.cpp" />
     <ClCompile Include="VideoCommon\FreeLookCamera.cpp" />
+    <ClCompile Include="VideoCommon\FreeLookUDPServer.cpp" />
     <ClCompile Include="VideoCommon\GeometryShaderGen.cpp" />
     <ClCompile Include="VideoCommon\GeometryShaderManager.cpp" />
     <ClCompile Include="VideoCommon\HiresTextures_DDSLoader.cpp" />

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -77,6 +77,10 @@ add_executable(dolphin-emu
   Config/ControllersWindow.h
   Config/FilesystemWidget.cpp
   Config/FilesystemWidget.h
+  Config/FreeLookOptionsWindow.cpp
+  Config/FreeLookOptionsWindow.h
+  Config/FreeLookUDPOptionsWidget.cpp
+  Config/FreeLookUDPOptionsWidget.h
   Config/FreeLookWidget.cpp
   Config/FreeLookWidget.h
   Config/FreeLookWindow.cpp

--- a/Source/Core/DolphinQt/Config/FreeLookOptionsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookOptionsWindow.cpp
@@ -1,0 +1,40 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/Config/FreeLookOptionsWindow.h"
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+#include "Core/Config/FreeLookSettings.h"
+#include "Core/FreeLookConfig.h"
+#include "DolphinQt/Config/FreeLookUDPOptionsWidget.h"
+
+FreeLookOptionsWindow::FreeLookOptionsWindow(QWidget* parent, int index)
+    : QDialog(parent), m_port(index)
+{
+  CreateMainLayout();
+
+  setWindowTitle(tr("Free Look Camera %1 Options").arg(index + 1));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+}
+
+void FreeLookOptionsWindow::CreateMainLayout()
+{
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
+  connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  auto* main_layout = new QVBoxLayout();
+  if (m_port == 0)
+  {
+    if (Config::Get(Config::FL1_CONTROL_TYPE) == FreeLook::ControlType::UDP)
+    {
+      main_layout->addWidget(
+          new FreeLookUDPOptionsWidget(this, ::Config::FL1_UDP_ADDRESS, ::Config::FL1_UDP_PORT));
+    }
+  }
+  main_layout->addWidget(m_button_box);
+  setLayout(main_layout);
+}

--- a/Source/Core/DolphinQt/Config/FreeLookOptionsWindow.h
+++ b/Source/Core/DolphinQt/Config/FreeLookOptionsWindow.h
@@ -1,0 +1,21 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QDialog>
+
+class QDialogButtonBox;
+
+class FreeLookOptionsWindow final : public QDialog
+{
+  Q_OBJECT
+public:
+  FreeLookOptionsWindow(QWidget* parent, int index);
+
+private:
+  void CreateMainLayout();
+
+  int m_port;
+  QDialogButtonBox* m_button_box;
+};

--- a/Source/Core/DolphinQt/Config/FreeLookUDPOptionsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookUDPOptionsWidget.cpp
@@ -1,0 +1,59 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/Config/FreeLookUDPOptionsWidget.h"
+
+#include <QFormLayout>
+#include <QGridLayout>
+#include <QLineEdit>
+#include <QSpinBox>
+
+#include "Common/Config/Config.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+
+#include "DolphinQt/Settings.h"
+
+FreeLookUDPOptionsWidget::FreeLookUDPOptionsWidget(
+    QWidget* parent, const Config::Info<std::string>& udp_address_config,
+    const Config::Info<u16>& udp_port_config)
+    : QWidget(parent), m_udp_address_config(udp_address_config), m_udp_port_config(udp_port_config)
+{
+  CreateLayout();
+  LoadSettings();
+  ConnectWidgets();
+}
+
+void FreeLookUDPOptionsWidget::CreateLayout()
+{
+  auto* layout = new QFormLayout;
+  m_server_address = new QLineEdit(this);
+  m_server_port = new QSpinBox(this);
+  m_server_port->setMaximum(65535);
+  layout->addRow(tr("Address:"), m_server_address);
+  layout->addRow(tr("Port:"), m_server_port);
+  setLayout(layout);
+}
+
+void FreeLookUDPOptionsWidget::ConnectWidgets()
+{
+  connect(m_server_address, &QLineEdit::textChanged, this, &FreeLookUDPOptionsWidget::SaveSettings);
+  connect(m_server_port, qOverload<int>(&QSpinBox::valueChanged), this,
+          &FreeLookUDPOptionsWidget::SaveSettings);
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
+    const QSignalBlocker blocker(this);
+    LoadSettings();
+  });
+}
+
+void FreeLookUDPOptionsWidget::LoadSettings()
+{
+  m_server_address->setText(QString::fromStdString(::Config::Get(m_udp_address_config)));
+  m_server_port->setValue(::Config::Get(m_udp_port_config));
+}
+
+void FreeLookUDPOptionsWidget::SaveSettings()
+{
+  ::Config::SetBaseOrCurrent(m_udp_address_config, m_server_address->text().toStdString());
+  ::Config::SetBaseOrCurrent(m_udp_port_config, static_cast<u16>(m_server_port->value()));
+}

--- a/Source/Core/DolphinQt/Config/FreeLookUDPOptionsWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLookUDPOptionsWidget.h
@@ -1,0 +1,36 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+#include <QWidget>
+
+#include "Common/CommonTypes.h"
+#include "Common/Config/ConfigInfo.h"
+
+class QLineEdit;
+class QSpinBox;
+
+class FreeLookUDPOptionsWidget final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit FreeLookUDPOptionsWidget(QWidget* parent,
+                                    const Config::Info<std::string>& udp_address_config,
+                                    const Config::Info<u16>& udp_port_config);
+
+private:
+  void CreateLayout();
+  void ConnectWidgets();
+
+  void LoadSettings();
+  void SaveSettings();
+
+  const Config::Info<std::string>& m_udp_address_config;
+  const Config::Info<u16>& m_udp_port_config;
+
+  QLineEdit* m_server_address;
+  QSpinBox* m_server_port;
+};

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.h
@@ -20,10 +20,12 @@ private:
   void ConnectWidgets();
 
   void OnFreeLookControllerConfigured();
+  void OnFreeLookOptionsConfigured();
   void LoadSettings();
   void SaveSettings();
 
   ToolTipCheckBox* m_enable_freelook;
   GraphicsChoice* m_freelook_control_type;
   QPushButton* m_freelook_controller_configure_button;
+  QPushButton* m_freelook_options_configure_button;
 };

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -58,6 +58,8 @@
     <ClCompile Include="Config\ControllerInterface\ServerStringValidator.cpp" />
     <ClCompile Include="Config\ControllersWindow.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
+    <ClCompile Include="Config\FreeLookOptionsWindow.cpp" />
+    <ClCompile Include="Config\FreeLookUDPOptionsWidget.cpp" />
     <ClCompile Include="Config\FreeLookWidget.cpp" />
     <ClCompile Include="Config\FreeLookWindow.cpp" />
     <ClCompile Include="Config\GamecubeControllersWidget.cpp" />
@@ -245,6 +247,8 @@
     <QtMoc Include="Config\ControllerInterface\ServerStringValidator.h" />
     <QtMoc Include="Config\ControllersWindow.h" />
     <QtMoc Include="Config\FilesystemWidget.h" />
+    <QtMoc Include="Config\FreeLookOptionsWindow.h" />
+    <QtMoc Include="Config\FreeLookUDPOptionsWidget.h" />
     <QtMoc Include="Config\FreeLookWidget.h" />
     <QtMoc Include="Config\FreeLookWindow.h" />
     <QtMoc Include="Config\GamecubeControllersWidget.h" />

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -35,6 +35,9 @@ add_library(videocommon
   FramebufferShaderGen.h
   FreeLookCamera.cpp
   FreeLookCamera.h
+  FreeLookUDPServer.cpp
+  FreeLookUDPServer.h
+  FreeLookUDPSpec.h
   GeometryShaderGen.cpp
   GeometryShaderGen.h
   GeometryShaderManager.cpp

--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -286,6 +286,12 @@ void FreeLookCamera::SetControlType(FreeLook::ControlType type)
   m_current_type = type;
 }
 
+void FreeLookCamera::UpdateConfig(const FreeLook::CameraConfig& config)
+{
+  SetControlType(config.control_type);
+  m_camera_controller->UpdateConfig(config);
+}
+
 Common::Matrix44 FreeLookCamera::GetView() const
 {
   return m_camera_controller->GetView();

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -32,6 +32,8 @@ public:
   virtual void SetClean() = 0;
 
   virtual bool SupportsInput() const = 0;
+
+  virtual void UpdateConfig(const FreeLook::CameraConfig& config) = 0;
 };
 
 class CameraControllerInput : public CameraController
@@ -45,6 +47,8 @@ public:
   void SetClean() final override { m_dirty = false; }
 
   bool SupportsInput() const final override { return true; }
+
+  void UpdateConfig(const FreeLook::CameraConfig&) final override {}
 
   virtual void MoveVertical(float amt) = 0;
   virtual void MoveHorizontal(float amt) = 0;
@@ -79,7 +83,7 @@ class FreeLookCamera
 {
 public:
   FreeLookCamera();
-  void SetControlType(FreeLook::ControlType type);
+  void UpdateConfig(const FreeLook::CameraConfig& config);
   Common::Matrix44 GetView() const;
   Common::Vec2 GetFieldOfViewMultiplier() const;
 
@@ -90,6 +94,8 @@ public:
   CameraController* GetController() const;
 
 private:
+  void SetControlType(FreeLook::ControlType type);
+  bool m_dirty = false;
   std::optional<FreeLook::ControlType> m_current_type;
   std::unique_ptr<CameraController> m_camera_controller;
 };

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -79,6 +79,14 @@ private:
   bool m_dirty = false;
 };
 
+class CameraControllerGeneric : public CameraController
+{
+public:
+  virtual void Update() = 0;
+
+  bool SupportsInput() const final override { return false; }
+};
+
 class FreeLookCamera
 {
 public:

--- a/Source/Core/VideoCommon/FreeLookUDPServer.cpp
+++ b/Source/Core/VideoCommon/FreeLookUDPServer.cpp
@@ -1,0 +1,116 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "VideoCommon/FreeLookUDPServer.h"
+
+#include "Common/MathUtil.h"
+#include "VideoCommon/FreeLookUDPSpec.h"
+
+namespace
+{
+template <typename T>
+T GetMessage(const u8*& data)
+{
+  T msg;
+  memcpy(&msg, data, sizeof(T));
+  data += sizeof(T);
+  return msg;
+}
+}  // namespace
+
+FreeLookUDPServer::FreeLookUDPServer(std::string address, u16 port)
+{
+  m_socket.setBlocking(false);
+  m_socket.bind(port, address);
+}
+
+void FreeLookUDPServer::Update()
+{
+  std::array<u8, sf::UdpSocket::MaxDatagramSize> buffer;
+
+  sf::IpAddress sender;
+  unsigned short port;
+  std::size_t bytes_received;
+  while (m_socket.receive(buffer.data(), buffer.size(), bytes_received, sender, port) ==
+         sf::Socket::Done)
+  {
+    ProcessReceivedData(buffer.data(), bytes_received);
+  }
+}
+
+void FreeLookUDPServer::ProcessReceivedData(const u8* data, std::size_t packet_size)
+{
+  const std::size_t header_size = sizeof(PacketHeader);
+  if (packet_size < header_size)
+    return;
+
+  PacketHeader header;
+  memcpy(&header, data, header_size);
+
+  if (header.version != FREE_LOOK_PROTO_VERSION)
+    return;
+
+  packet_size -= header_size;
+  data += header_size;
+
+  if (header.payload_size > packet_size)
+    return;
+
+  for (u8 i = 0; i < header.message_count; i++)
+  {
+    switch (header.msg_type)
+    {
+    case MessageTransformByQuaternionPosition::msg_type:
+    {
+      auto msg = GetMessage<MessageTransformByQuaternionPosition>(data);
+      m_view = Common::Matrix44::Translate(Common::Vec3{static_cast<float>(msg.posx),
+                                                        static_cast<float>(msg.posy),
+                                                        static_cast<float>(msg.posz)}) *
+               Common::Matrix44::FromQuaternion(
+                   Common::Quaternion(static_cast<float>(msg.qw), static_cast<float>(msg.qx),
+                                      static_cast<float>(msg.qy), static_cast<float>(msg.qz)));
+      m_received_data = true;
+    }
+    break;
+
+    case MessageTransformByEulerPosition::msg_type:
+    {
+      auto msg = GetMessage<MessageTransformByEulerPosition>(data);
+
+      const double divisor = 360.0 / MathUtil::TAU;
+      const double pitch = msg.pitch / divisor;
+      const double yaw = msg.yaw / divisor;
+      const double roll = msg.roll / divisor;
+      const Common::Quaternion rotation = Common::Quaternion::RotateXYZ(Common::Vec3{
+          static_cast<float>(pitch), static_cast<float>(yaw), static_cast<float>(roll)});
+
+      m_view = Common::Matrix44::Translate(Common::Vec3{static_cast<float>(msg.posx),
+                                                        static_cast<float>(msg.posy),
+                                                        static_cast<float>(msg.posz)}) *
+               Common::Matrix44::FromQuaternion(rotation);
+      m_received_data = true;
+    }
+    break;
+
+    case MessageTransformByMatrix::msg_type:
+    {
+      auto msg = GetMessage<MessageTransformByMatrix>(data);
+      for (u8 j = 0; j < 16; j++)
+      {
+        m_view.data[j] = msg.data[j];
+      }
+      m_received_data = true;
+    }
+    break;
+
+    case MessageFieldOfView::msg_type:
+    {
+      auto msg = GetMessage<MessageFieldOfView>(data);
+      m_fov_multiplier.x = msg.horizontal_multiplier;
+      m_fov_multiplier.y = msg.vertical_multiplier;
+      m_received_data = true;
+    }
+    break;
+    }
+  }
+}

--- a/Source/Core/VideoCommon/FreeLookUDPServer.h
+++ b/Source/Core/VideoCommon/FreeLookUDPServer.h
@@ -1,0 +1,34 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+#include <SFML/Network/UdpSocket.hpp>
+
+#include "Common/CommonTypes.h"
+#include "Common/Matrix.h"
+
+class FreeLookUDPServer
+{
+public:
+  FreeLookUDPServer(std::string address, u16 port);
+
+  void Update();
+
+  Common::Matrix44 GetView() const { return m_view; }
+  Common::Vec2 GetFovMultiplier() const { return m_fov_multiplier; }
+
+  bool ReceivedData() const { return m_received_data; }
+  void ClearDataReceived() { m_received_data = false; }
+
+private:
+  void ProcessReceivedData(const u8* data, std::size_t packet_size);
+
+  sf::UdpSocket m_socket;
+
+  Common::Matrix44 m_view = Common::Matrix44::Identity();
+  Common::Vec2 m_fov_multiplier = Common::Vec2{1, 1};
+  bool m_received_data = false;
+};

--- a/Source/Core/VideoCommon/FreeLookUDPSpec.h
+++ b/Source/Core/VideoCommon/FreeLookUDPSpec.h
@@ -1,0 +1,60 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+
+#include "Common/CommonTypes.h"
+
+constexpr u16 FREE_LOOK_PROTO_VERSION = 1;
+
+#pragma pack(push, 1)
+
+struct PacketHeader
+{
+  u16 version;
+  u8 message_count;
+  u32 payload_size;  // not including header
+  u8 msg_type;
+};
+
+struct MessageTransformByQuaternionPosition
+{
+  static const u8 msg_type = 0;
+  double qx;
+  double qy;
+  double qz;
+  double qw;
+
+  double posx;
+  double posy;
+  double posz;
+};
+
+struct MessageTransformByEulerPosition
+{
+  static const u8 msg_type = 1;
+  double pitch;
+  double yaw;
+  double roll;
+
+  double posx;
+  double posy;
+  double posz;
+};
+
+struct MessageTransformByMatrix
+{
+  static const u8 msg_type = 2;
+  std::array<double, 16> data;
+};
+
+struct MessageFieldOfView
+{
+  static const u8 msg_type = 3;
+  double horizontal_multiplier;
+  double vertical_multiplier;
+};
+
+#pragma pack(pop)

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -111,7 +111,7 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height, float backbuffer
   CalculateTargetSize();
 
   m_is_game_widescreen = SConfig::GetInstance().bWii && Config::Get(Config::SYSCONF_WIDESCREEN);
-  g_freelook_camera.SetControlType(FreeLook::GetActiveConfig().camera_config.control_type);
+  g_freelook_camera.UpdateConfig(FreeLook::GetActiveConfig().camera_config);
 }
 
 Renderer::~Renderer() = default;
@@ -463,7 +463,7 @@ void Renderer::CheckForConfigChanges()
   UpdateActiveConfig();
   FreeLook::UpdateActiveConfig();
 
-  g_freelook_camera.SetControlType(FreeLook::GetActiveConfig().camera_config.control_type);
+  g_freelook_camera.UpdateConfig(FreeLook::GetActiveConfig().camera_config);
 
   // Update texture cache settings with any changed options.
   g_texture_cache->OnConfigChanged(g_ActiveConfig);


### PR DESCRIPTION
This PR allows Free Look to be controlled by UDP packets using a newly defined UDP spec that is supported by Dolphin.  Unlike the input controllers which deal with incremental values, this controller takes absolute data over a socket.

With this, you can write any script or tool to control Free Look externally!!  I will be including a formal document describing the spec for interested users.

Here's an example of OpenTrack using [OpenTrackFreeLook](https://github.com/iwubcode/OpenTrackFreeLook):

![freelook-opentrack](https://user-images.githubusercontent.com/15224722/115981867-975d9900-a55c-11eb-8487-e4968b9f5b56.gif)

Controlling via a scripting language is also pretty easy, here's an example of moving the Free Look camera to position 30.0 along the x axis and rotating its pitch to 20°:

```
import socket
import struct

ip = "127.0.0.1"
port = 36760

print(f"UDP target IP: {ip}")
print(f"UDP target port: {port}")
euler_pos_struct = struct.pack("<HBIBdddddd", 1, 1, 48, 1, 0.0, 20.0, 0.0, 30.0, 0.0, 0.0)

sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
sock.sendto(bytes(euler_pos_struct), (ip, port))
```

This should allow Free Look to be hooked up to the many inputs that [FreePie](https://andersmalmgren.github.io/FreePIE/) supports.

Want to do something crazy?  You wouldn't be the first.  Maybe you revive the script to [control Free Look via Blender](https://github.com/John10v10/-Useless-DolphinToolForBlender)!