### PR TITLE
DolphinQt/Android: Unify the JIT naming scheme

### DIFF
--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -5,9 +5,9 @@
 
     <!-- New UI CPU Core selection - Default -->
     <string-array name="emuCoresEntriesX86_64" translatable="false">
-        <item>JIT Recompiler</item>
-        <item>Cached Interpreter</item>
-        <item>Interpreter</item>
+        <item>JIT Recompiler for x86-64 (recommended)</item>
+        <item>Cached Interpreter (slower)</item>
+        <item>Interpreter (slowest)</item>
     </string-array>
     <integer-array name="emuCoresValuesX86_64" translatable="false">
         <item>1</item>
@@ -15,9 +15,9 @@
         <item>0</item>
     </integer-array>
     <string-array name="emuCoresEntriesARM64" translatable="false">
-        <item>JIT ARM64 Recompiler</item>
-        <item>Cached Interpreter</item>
-        <item>Interpreter</item>
+        <item>JIT Recompiler for ARM64 (recommended)</item>
+        <item>Cached Interpreter (slower)</item>
+        <item>Interpreter (slowest)</item>
     </string-array>
     <integer-array name="emuCoresValuesARM64" translatable="false">
         <item>4</item>

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -28,8 +28,8 @@
 static const std::map<PowerPC::CPUCore, const char*> CPU_CORE_NAMES = {
     {PowerPC::CPUCore::Interpreter, QT_TR_NOOP("Interpreter (slowest)")},
     {PowerPC::CPUCore::CachedInterpreter, QT_TR_NOOP("Cached Interpreter (slower)")},
-    {PowerPC::CPUCore::JIT64, QT_TR_NOOP("JIT Recompiler (recommended)")},
-    {PowerPC::CPUCore::JITARM64, QT_TR_NOOP("JIT Arm64 (experimental)")},
+    {PowerPC::CPUCore::JIT64, QT_TR_NOOP("JIT Recompiler for x86-64 (recommended)")},
+    {PowerPC::CPUCore::JITARM64, QT_TR_NOOP("JIT Recompiler for ARM64 (recommended)")},
 };
 
 AdvancedPane::AdvancedPane(QWidget* parent) : QWidget(parent)


### PR DESCRIPTION
I think the AArch64 JIT has come far enough that it doesn't have to be called experimental anymore.

I'm also labeling the x86-64 JIT as x86-64 for consistence with the AArch64 JIT. This will especially be helpful if we start supporting AArch64 on macOS, as AArch64 macOS can run both the x86-64 JIT and the AArch64 JIT depending on whether you enable Rosetta 2.