### PR TITLE
Implement EFB Peeks for compressed z16 formats

### DIFF
--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -222,8 +222,11 @@ void ClearScreen(const MathUtil::Rectangle<int>& rc)
 void OnPixelFormatChange()
 {
   // TODO : Check for Z compression format change
-  // When using 16bit Z, the game may enable a special compression format which we need to handle
-  // If we don't, Z values will be completely screwed up, currently only Star Wars:RS2 uses that.
+  // When using 16bit Z, the game may enable a special compression format which we might need to
+  // handle. Only a few games like RS2 and RS3 even use z compression but it looks like they
+  // always use ZFAR when using 16bit Z (on top of linear 24bit Z)
+
+  // Besides, we currently don't even emulate 16bit depth and force it to 24bit.
 
   /*
    * When changing the EFB format, the pixel data won't get converted to the new format but stays

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -4,7 +4,12 @@
 
 #pragma once
 
+#include <algorithm>
+
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+
+#include "VideoCommon/BPMemory.h"
 
 // These are accurate (disregarding AA modes).
 constexpr u32 EFB_WIDTH = 640;
@@ -58,4 +63,72 @@ inline u32 RGBA8ToRGB565ToRGBA8(u32 src)
 inline u32 Z24ToZ16ToZ24(u32 src)
 {
   return (src & 0xFFFF00) | (src >> 16);
+}
+
+inline u32 CompressZ16(u32 z24depth, DepthFormat format)
+{
+  // Flipper offers a number of choices for 16bit Z formats that adjust
+  // where the bulk of the precision lies.
+
+  if (format == DepthFormat::ZLINEAR)
+  {
+    // This is just a linear depth buffer with 16 bits of precision
+    return z24depth >> 8;
+  }
+
+  // ZNEAR/ZMID/ZFAR are custom floating point formats with 2/3/4 bits of exponent
+  // The exponent is simply the number of leading ones that have been removed
+  // The first zero bit is skipped and not stored. The mantissa contains the next 14/13/12 bits
+  // If exponent is at the MAX (3, 7, or 12) then the next bit might still be a one, and can't
+  // be skipped, so the mantissa simply contains the next 14/13/12 bits
+
+  u32 leading_ones = Common::CountLeadingZeros((~z24depth) << 8);
+  bool next_bit_is_one = false;  // AKA: Did we clamp leading_ones?
+  u32 exp_bits;
+
+  switch (format)
+  {
+  case DepthFormat::ZNEAR:
+    exp_bits = 2;
+    if (leading_ones >= 3u)
+    {
+      leading_ones = 3u;
+      next_bit_is_one = true;
+    }
+    break;
+  case DepthFormat::ZMID:
+    exp_bits = 3;
+    if (leading_ones >= 7u)
+    {
+      leading_ones = 7u;
+      next_bit_is_one = true;
+    }
+    break;
+  case DepthFormat::ZFAR:
+    exp_bits = 4;
+    if (leading_ones >= 12u)
+    {
+      // The hardware implementation only uses values 0 to 12 in the exponent
+      leading_ones = 12u;
+      next_bit_is_one = true;
+    }
+    break;
+  default:
+    return z24depth >> 8;
+  }
+
+  u32 mantissa_bits = 16 - exp_bits;
+
+  // Calculate which bits we need to extract from z24depth for our mantissa
+  u32 top = std::max<u32>(24 - leading_ones, mantissa_bits);
+  if (!next_bit_is_one)
+  {
+    top -= 1;  // We know the next bit is zero, so we don't need to include it.
+  }
+  u32 bottom = top - mantissa_bits;
+
+  u32 exponent = leading_ones << mantissa_bits;  // Upper bits contain exponent
+  u32 mantissa = Common::ExtractBits(z24depth, bottom, top - 1);
+
+  return exponent | mantissa;
 }


### PR DESCRIPTION


Dolphin doesn't correctly emulate 3xMSAA mode. It probably never will as it's kind of pointless when users can just force everything to have 4xMSAA or 16xMSAA or even stupidly high Internal Resolutions.

Besides, Not many games uses the 3xMSAA mode. It's a real pain to use when it cuts the vertical EFB resolution in half to 640x264, requiring multiple passes to get a complete 4:3 frame. 

But Rogue Squadron uses it. Actually, Factor 5 cheap out and only uses it during cutscenes. They cheap out even further by rendering many of those cutscenes in a "cinematic widescreen" aspect ratio with a resolution of 512x264 that just so happens to fit inside a single 3xMSAA EFB buffer. 

Dolphin's trickery is usually hidden from games. Except RS3 also directly accesses the EFB framebuffer to check the occlusion of engine exhaust plumes. This was previously working in main gameplay, but in cutscenes dolphin would return the wrong depth and the occlusion query would always pass, resulting in the lens flare effect shining though solid objects. 

Dolphin had some previous code to automatically convert from Z24 to Z16 formats during an efb peek, but it was hardcoded to the Linear format, while RS3 uses the ZFAR compressed Z16 format.

This PR implements the compressed Z16 formats, which fixes this visual glitch in RS3 cutscenes. 

# Screenshots:

### Before
![hanger-before](https://user-images.githubusercontent.com/138484/116069471-88532400-a6df-11eb-8890-fc01b8dbd0d9.png)
### After
![hanger-after](https://user-images.githubusercontent.com/138484/116069498-8db06e80-a6df-11eb-9e4c-b4fe53eae9e3.png)

### Before

![GLRE64_2021-04-26_22-30-42](https://user-images.githubusercontent.com/138484/116069675-c5b7b180-a6df-11eb-91de-9e3af6e354fb.png)
### After
![GLRE64_2021-04-26_22-21-44](https://user-images.githubusercontent.com/138484/116069686-c81a0b80-a6df-11eb-90e7-0c238e0ab950.png)
