### PR TITLE
Fix hotkey suppression crash

### DIFF
--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -503,7 +503,7 @@ public:
       const bool is_suppressed = s_hotkey_suppressions.IsSuppressedIgnoringModifiers(
           m_final_input->GetInput(), m_modifiers);
 
-      if (final_input_state < CONDITION_THRESHOLD)
+      if (final_input_state <= CONDITION_THRESHOLD)
         m_is_blocked = false;
 
       // If some other hotkey suppressed us, require a release of final input to be ready again.


### PR DESCRIPTION
`EnableSuppression()` was called in `UpdateReferences()` but then not executed if `m_suppressor` is already valid, causing input to stay nullptr in the `m_suppressions` map, which would fail to find an element and crash because it wasn't checked for validity.

I fixed the source of that happening, but also added safety checks around against nullptr.

I had gotten this was crash twice in months, both times in Debug, on startup, without doing anything, while Dolphin was loading (from the hotkey thread). It was probably just an order/timing dependency between threads.

If I had to guess, I'd say that it worked before because `EnableSuppression()` is called constantly by `GetValue()` so it would constantly refresh, but if things didn't happen in a specific order, it would crash.

The crash (on the `it` iterator) (callstack in on my branch, slightly different, but this bug was present and triggerable on master as well):
![CqRFlvgQzq](https://user-images.githubusercontent.com/7011366/116120651-7023da80-a6c8-11eb-83c9-00b8c2406210.png)

I've also included a small consistency fix for `final_input_state` being checked < and then > against `CONDITION_THRESHOLD` and not <= and then >.

Tested.