### PR TITLE
DolphinQt: Get rid of an extraneous colon in About dialog

### DIFF
--- a/Source/Core/DolphinQt/AboutDialog.cpp
+++ b/Source/Core/DolphinQt/AboutDialog.cpp
@@ -24,7 +24,7 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
 <p style='font-size:18pt;'>%VERSION_STRING%</p>
 
 <p style='font-size: small;'>
-%BRANCH%:<br>
+%BRANCH%<br>
 %REVISION%<br><br>
 %QT_VERSION%
 </p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4209061/116158482-0e2a9b80-a6ef-11eb-90de-9a3ec3f06d5a.png)
