### PR TITLE
DolphinQt: fix input profile drop down not resizing

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -85,7 +85,7 @@ void MappingWindow::CreateDevicesLayout()
   m_devices_combo = new QComboBox();
   m_devices_refresh = new QPushButton(tr("Refresh"));
 
-  m_devices_combo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  m_devices_combo->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
   m_devices_refresh->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
   m_devices_layout->addWidget(m_devices_combo);


### PR DESCRIPTION
This fixes the input profile drop down not resizing.  This regression was due to #8867 where I made that change because I was trying to fix the device drop down from disappearing with a small window (in order to do that I changed the size policy from `Ignored` to `Expanding`).  However, this  made the device drop down take up all the space!  So now I've tried changing the size policy from `Expanding` to `Minimum`.

Please test!