### PR TITLE
Make all Qt ToolTips look similar to BalloonTips

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/BalloonTip.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/BalloonTip.cpp
@@ -14,7 +14,6 @@
 #include <QLabel>
 #include <QPainter>
 #include <QPainterPath>
-#include <QPropertyAnimation>
 #include <QPushButton>
 #include <QStyle>
 
@@ -30,6 +29,8 @@
 #endif
 
 #include "Core/Config/MainSettings.h"
+
+#include "DolphinQt/Settings.h"
 
 namespace
 {
@@ -73,54 +74,11 @@ BalloonTip::BalloonTip(PrivateTag, const QIcon& icon, QString title, QString mes
   setAttribute(Qt::WA_DeleteOnClose);
   setAutoFillBackground(true);
 
-  const QPalette& pal = parent->palette();
-
-  const auto theme_window_color = pal.color(QPalette::Base);
-  const auto theme_window_hsv = theme_window_color.toHsv();
-
-  const auto brightness = theme_window_hsv.value();
-
   QColor window_color;
   QColor text_color;
   QColor dolphin_emphasis;
-  const bool use_high_contrast = Config::Get(Config::MAIN_USE_HIGH_CONTRAST_TOOLTIPS);
-  if (brightness > 128)
-  {
-    if (use_high_contrast)
-    {
-      // Our theme color is light, so make it darker
-      window_color = QColor(72, 72, 72);
-      text_color = Qt::white;
-      dolphin_emphasis = Qt::yellow;
-      m_border_color = palette().color(QPalette::Window).darker(160);
-    }
-    else
-    {
-      window_color = pal.color(QPalette::Window);
-      text_color = pal.color(QPalette::Text);
-      dolphin_emphasis = QColor(QStringLiteral("#0090ff"));
-      m_border_color = pal.color(QPalette::Text);
-    }
-  }
-  else
-  {
-    if (use_high_contrast)
-    {
-      // Our theme color is dark, so make it lighter
-      window_color = Qt::white;
-      text_color = Qt::black;
-      dolphin_emphasis = QColor(QStringLiteral("#0090ff"));
-      m_border_color = palette().color(QPalette::Window).darker(160);
-    }
-    else
-    {
-      window_color = pal.color(QPalette::Window);
-      text_color = pal.color(QPalette::Text);
-      dolphin_emphasis = Qt::yellow;
-      m_border_color = pal.color(QPalette::Text);
-    }
-  }
-
+  Settings::Instance().GetToolTipStyle(window_color, text_color, dolphin_emphasis, m_border_color,
+                                       parent->palette(), palette());
   const auto style_sheet = QStringLiteral("background-color: #%1; color: #%2;")
                                .arg(window_color.rgba(), 0, 16)
                                .arg(text_color.rgba(), 0, 16);
@@ -188,6 +146,7 @@ void BalloonTip::UpdateBoundsAndRedraw(const QPoint& pos, ShowArrow show_arrow)
   const QRect screen_rect = screen->geometry();
 #endif
   QSize sh = sizeHint();
+  // The look should resemble the default tooltip style set in Settings::SetCurrentUserStyle()
   const int border = 1;
   const int arrow_height = 18;
   const int arrow_width = 18;

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -246,6 +246,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     DolphinAnalytics::Instance().ReportDolphinStart("qt");
 
     MainWindow win{std::move(boot), static_cast<const char*>(options.get("movie"))};
+    Settings::Instance().SetCurrentUserStyle(Settings::Instance().GetCurrentUserStyle());
     if (options.is_set("debugger"))
       Settings::Instance().SetDebugModeEnabled(true);
     win.Show();

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -10,6 +10,7 @@
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QSize>
+#include <QWidget>
 
 #include "AudioCommon/AudioCommon.h"
 
@@ -45,8 +46,6 @@ Settings::Settings()
 
   g_controller_interface.RegisterDevicesChangedCallback(
       [this] { QueueOnObject(this, [this] { emit DevicesChanged(); }); });
-
-  SetCurrentUserStyle(GetCurrentUserStyle());
 }
 
 Settings::~Settings() = default;
@@ -80,10 +79,13 @@ QString Settings::GetCurrentUserStyle() const
   return QFileInfo(GetQSettings().value(QStringLiteral("userstyle/path")).toString()).fileName();
 }
 
+// Calling this before the main window has been created breaks the style of some widgets on
+// Windows 10/Qt 5.15.0. But only if we set a stylesheet that isn't an empty string.
 void Settings::SetCurrentUserStyle(const QString& stylesheet_name)
 {
   QString stylesheet_contents;
 
+  // If we haven't found one, we continue with an empty (default) style
   if (!stylesheet_name.isEmpty() && AreUserStylesEnabled())
   {
     // Load custom user stylesheet
@@ -92,6 +94,26 @@ void Settings::SetCurrentUserStyle(const QString& stylesheet_name)
 
     if (stylesheet.open(QFile::ReadOnly))
       stylesheet_contents = QString::fromUtf8(stylesheet.readAll().data());
+  }
+
+  // Define tooltips style if not already defined
+  if (!stylesheet_contents.contains(QStringLiteral("QToolTip"), Qt::CaseSensitive))
+  {
+    const QPalette& palette = qApp->palette();
+    QColor window_color;
+    QColor text_color;
+    QColor unused_text_emphasis_color;
+    QColor border_color;
+    GetToolTipStyle(window_color, text_color, unused_text_emphasis_color, border_color, palette,
+                    palette);
+
+    const auto tooltip_stylesheet =
+        QStringLiteral("QToolTip { background-color: #%1; color: #%2; padding: 8px; "
+                       "border: 1px; border-style: solid; border-color: #%3; }")
+            .arg(window_color.rgba(), 0, 16)
+            .arg(text_color.rgba(), 0, 16)
+            .arg(border_color.rgba(), 0, 16);
+    stylesheet_contents.append(QStringLiteral("%1").arg(tooltip_stylesheet));
   }
 
   qApp->setStyleSheet(stylesheet_contents);
@@ -107,6 +129,32 @@ bool Settings::AreUserStylesEnabled() const
 void Settings::SetUserStylesEnabled(bool enabled)
 {
   GetQSettings().setValue(QStringLiteral("userstyle/enabled"), enabled);
+}
+
+void Settings::GetToolTipStyle(QColor& window_color, QColor& text_color,
+                               QColor& emphasis_text_color, QColor& border_color,
+                               const QPalette& palette, const QPalette& high_contrast_palette) const
+{
+  const auto theme_window_color = palette.color(QPalette::Base);
+  const auto theme_window_hsv = theme_window_color.toHsv();
+  const auto brightness = theme_window_hsv.value();
+  const bool brightness_over_threshold = brightness > 128;
+  const QColor emphasis_text_color_1 = Qt::yellow;
+  const QColor emphasis_text_color_2 = QColor(QStringLiteral("#0090ff"));  // ~light blue
+  if (Config::Get(Config::MAIN_USE_HIGH_CONTRAST_TOOLTIPS))
+  {
+    window_color = brightness_over_threshold ? QColor(72, 72, 72) : Qt::white;
+    text_color = brightness_over_threshold ? Qt::white : Qt::black;
+    emphasis_text_color = brightness_over_threshold ? emphasis_text_color_1 : emphasis_text_color_2;
+    border_color = high_contrast_palette.color(QPalette::Window).darker(160);
+  }
+  else
+  {
+    window_color = palette.color(QPalette::Window);
+    text_color = palette.color(QPalette::Text);
+    emphasis_text_color = brightness_over_threshold ? emphasis_text_color_2 : emphasis_text_color_1;
+    border_color = palette.color(QPalette::Text);
+  }
 }
 
 QStringList Settings::GetPaths() const

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -54,6 +54,10 @@ public:
   void SetUserStylesEnabled(bool enabled);
   bool AreUserStylesEnabled() const;
 
+  void GetToolTipStyle(QColor& window_color, QColor& text_color, QColor& emphasis_text_color,
+                       QColor& border_color, const QPalette& palette,
+                       const QPalette& high_contrast_palette) const;
+
   bool IsLogVisible() const;
   void SetLogVisible(bool visible);
   bool IsLogConfigVisible() const;


### PR DESCRIPTION
Dolphin still has a lot of tooltips which haven't been converted to BalloonTips, which is fine, and some are way harder to convert as there is no code for them yet (e.g. ComboBox per item ToolTips).

With this simple addition to the qApp style sheet (mostly using existing code), **ToolTips**, and only ToolTips, **will visualize themselves with the exact same colors and padding size of BalloonTips**. Plus, now parts of their code is shared, so it can safely be changed in one place to reflect to both.

Tested. Works with high and not high contrast, or any theme brightness. Also works on top of any other style sheet (the ToolTip style is only overridden if not already specified).
There should be no possible regression from this, and BalloonTips will still look exactly as before (and they will not follow the user custom style sheet, just like before, which I think is a bit weird but it's fine).

This **also fixes a bug** (?) with Qt 5.15.0 on Windows 10 where calling SetCurrentUserStyle(...) before the MainWindow has been created, with a style sheet string different from null/emtpy (even an empty space is enough), causes some widgets to appear with a different style (e.g. the log widget background changes from black to white).

Notes:
-Making parts of the text (emphasis) take another color is not possible on default ToolTips of course
-I've tried to round the borders of default ToolTips but the background is drawn in a squared fashion behind the borders.


High contrast standard **Qt ToolTip**:
![image](https://user-images.githubusercontent.com/7011366/116438432-1b629a00-a857-11eb-8897-be984178f8a1.png)

High contrast Dolphin **BalloonTip**:
![image](https://user-images.githubusercontent.com/7011366/116438504-2f0e0080-a857-11eb-89c6-d26a982f9977.png)