### PR TITLE
DolphinQt: Disable verify button when emulation is running

### DIFF
--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -17,9 +17,11 @@
 #include <QVBoxLayout>
 
 #include "Common/CommonTypes.h"
+#include "Core/Core.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeVerifier.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
+#include "DolphinQt/Settings.h"
 
 VerifyWidget::VerifyWidget(std::shared_ptr<DiscIO::Volume> volume) : m_volume(std::move(volume))
 {
@@ -38,6 +40,20 @@ VerifyWidget::VerifyWidget(std::shared_ptr<DiscIO::Volume> volume) : m_volume(st
   layout->setStretchFactor(m_summary_text, 2);
 
   setLayout(layout);
+
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
+          &VerifyWidget::OnEmulationStateChanged);
+
+  OnEmulationStateChanged();
+}
+
+void VerifyWidget::OnEmulationStateChanged()
+{
+  const bool running = Core::GetState() != Core::State::Uninitialized;
+
+  // Verifying a Wii game while emulation is running doesn't work correctly
+  // due to verification of a Wii game creating an instance of IOS
+  m_verify_button->setEnabled(!running);
 }
 
 void VerifyWidget::CreateWidgets()

--- a/Source/Core/DolphinQt/Config/VerifyWidget.h
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.h
@@ -27,6 +27,9 @@ class VerifyWidget final : public QWidget
 public:
   explicit VerifyWidget(std::shared_ptr<DiscIO::Volume> volume);
 
+private slots:
+  void OnEmulationStateChanged();
+
 private:
   void CreateWidgets();
   std::pair<QCheckBox*, QLineEdit*> AddHashLine(QFormLayout* layout, QString text);


### PR DESCRIPTION
Verifying a Wii game creates an instance of IOS, and Dolphin can't handle more than one instance of IOS at the same time. Properly supporting it is probably more effort than it's worth.

Fixes https://bugs.dolphin-emu.org/issues/12494.