### PR TITLE
IOS: Don't let Kernel initialize WiiRoot if already initialized

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -256,8 +256,11 @@ Kernel::Kernel()
   // Until the Wii root and NAND path stuff is entirely managed by IOS and made non-static,
   // using more than one IOS instance at a time is not supported.
   ASSERT(GetIOS() == nullptr);
-  Core::InitializeWiiRoot(false);
-  m_is_responsible_for_nand_root = true;
+
+  m_is_responsible_for_nand_root = !Core::WiiRootIsInitialized();
+  if (m_is_responsible_for_nand_root)
+    Core::InitializeWiiRoot(false);
+
   AddCoreDevices();
 }
 

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -33,6 +33,7 @@ namespace Core
 namespace FS = IOS::HLE::FS;
 
 static std::string s_temp_wii_root;
+static bool s_wii_root_initialized = false;
 
 static bool CopyBackupFile(const std::string& path_from, const std::string& path_to)
 {
@@ -170,6 +171,8 @@ static void InitializeDeterministicWiiSaves(FS::FileSystem* session_fs)
 
 void InitializeWiiRoot(bool use_temporary)
 {
+  ASSERT(!s_wii_root_initialized);
+
   if (use_temporary)
   {
     s_temp_wii_root = File::GetUserPath(D_USER_IDX) + "WiiSession" DIR_SEP;
@@ -198,6 +201,8 @@ void InitializeWiiRoot(bool use_temporary)
   {
     File::SetUserPath(D_SESSION_WIIROOT_IDX, File::GetUserPath(D_WIIROOT_IDX));
   }
+
+  s_wii_root_initialized = true;
 }
 
 void ShutdownWiiRoot()
@@ -207,6 +212,13 @@ void ShutdownWiiRoot()
     File::DeleteDirRecursively(s_temp_wii_root);
     s_temp_wii_root.clear();
   }
+
+  s_wii_root_initialized = false;
+}
+
+bool WiiRootIsInitialized()
+{
+  return s_wii_root_initialized;
 }
 
 bool WiiRootIsTemporary()

--- a/Source/Core/Core/WiiRoot.h
+++ b/Source/Core/Core/WiiRoot.h
@@ -15,6 +15,7 @@ enum class RestoreReason
 void InitializeWiiRoot(bool use_temporary);
 void ShutdownWiiRoot();
 
+bool WiiRootIsInitialized();
 bool WiiRootIsTemporary();
 
 void BackupWiiSettings();


### PR DESCRIPTION
The SaveToSYSCONF call in BootManager.cpp was unintentionally overriding the temporary NAND set by the preceding InitializeWiiRoot call. Fixes https://bugs.dolphin-emu.org/issues/12500.