### PR TITLE
Remove Input Mapping Delay

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -21,7 +21,7 @@
 namespace MappingCommon
 {
 constexpr auto INPUT_DETECT_INITIAL_TIME = std::chrono::seconds(3);
-constexpr auto INPUT_DETECT_CONFIRMATION_TIME = std::chrono::milliseconds(500);
+constexpr auto INPUT_DETECT_CONFIRMATION_TIME = std::chrono::milliseconds(0);
 constexpr auto INPUT_DETECT_MAXIMUM_TIME = std::chrono::seconds(5);
 
 constexpr auto OUTPUT_TEST_TIME = std::chrono::seconds(2);


### PR DESCRIPTION
While this opens up the possibility to create more complex expressions, the half second delay was the source of much confusion and frustration for users who didn't know what the emulator was doing.  The emulator essentially hard locked for 500ms and sometimes would get all kinds of weird inputs because they'd start spamming buttons trying to unfreeze it.

This makes the delay 0, returning the behavior to the way it was before.  This means you cannot do | statements without using the advanced input expression anymore.