### PR TITLE
GeneralWidget: Convert Adapter tooltip to BalloonTip

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -203,9 +203,6 @@ void GeneralWidget::AddDescriptions()
       "backend, so for the best emulation experience it is recommended to try each and "
       "select the backend that is least problematic.<br><br><dolphin_emphasis>If unsure, "
       "select OpenGL.</dolphin_emphasis>");
-  static const char TR_ADAPTER_DESCRIPTION[] =
-      QT_TR_NOOP("Selects a hardware adapter to use.<br><br><dolphin_emphasis>If unsure, "
-                 "select the first one.</dolphin_emphasis>");
   static const char TR_FULLSCREEN_DESCRIPTION[] =
       QT_TR_NOOP("Uses the entire screen for rendering.<br><br>If disabled, a "
                  "render window will be created instead.<br><br><dolphin_emphasis>If "
@@ -274,7 +271,6 @@ void GeneralWidget::AddDescriptions()
   m_backend_combo->SetDescription(tr(TR_BACKEND_DESCRIPTION));
 
   m_adapter_combo->SetTitle(tr("Adapter"));
-  m_adapter_combo->SetDescription(tr(TR_ADAPTER_DESCRIPTION));
 
   m_aspect_combo->SetTitle(tr("Aspect Ratio"));
   m_aspect_combo->SetDescription(tr(TR_ASPECT_RATIO_DESCRIPTION));
@@ -324,8 +320,15 @@ void GeneralWidget::OnBackendChanged(const QString& backend_name)
   m_adapter_combo->setCurrentIndex(g_Config.iAdapter);
   m_adapter_combo->setEnabled(supports_adapters && !Core::IsRunning());
 
-  m_adapter_combo->setToolTip(supports_adapters ?
-                                  QString{} :
-                                  tr("%1 doesn't support this feature.")
-                                      .arg(tr(g_video_backend->GetDisplayName().c_str())));
+  static constexpr char TR_ADAPTER_AVAILABLE_DESCRIPTION[] =
+      QT_TR_NOOP("Selects a hardware adapter to use.<br><br>"
+                 "<dolphin_emphasis>If unsure, select the first one.</dolphin_emphasis>");
+  static constexpr char TR_ADAPTER_UNAVAILABLE_DESCRIPTION[] =
+      QT_TR_NOOP("Selects a hardware adapter to use.<br><br>"
+                 "<dolphin_emphasis>%1 doesn't support this feature.</dolphin_emphasis>");
+
+  m_adapter_combo->SetDescription(supports_adapters ?
+                                      tr(TR_ADAPTER_AVAILABLE_DESCRIPTION) :
+                                      tr(TR_ADAPTER_UNAVAILABLE_DESCRIPTION)
+                                          .arg(tr(g_video_backend->GetDisplayName().c_str())));
 }


### PR DESCRIPTION
Use a BalloonTip to inform the user when their selected backend (OpenGL or Null) doesn't support adapters, instead of using the default tooltips.

Before:
![OpenGL_before](https://user-images.githubusercontent.com/73494713/116828064-439d1200-ab51-11eb-914a-d443ec5d70e4.png)

After:
![OpenGL_after](https://user-images.githubusercontent.com/73494713/116828076-4b5cb680-ab51-11eb-8be2-bdaa532fa166.png)

Using a backend that supports adapters (unchanged by this PR):
![Direct3D](https://user-images.githubusercontent.com/73494713/116828084-59aad280-ab51-11eb-8694-a57329da6d6c.png)


