### PR TITLE
JitArm64: Fix JitRegister::Register call for cstd

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -201,7 +201,7 @@ void JitArm64::GenerateCommonAsm()
 
   GetAsmRoutines()->cstd = GetCodePtr();
   GenerateConvertSingleToDouble();
-  JitRegister::Register(GetAsmRoutines()->cdts, GetCodePtr(), "JIT_cstd");
+  JitRegister::Register(GetAsmRoutines()->cstd, GetCodePtr(), "JIT_cstd");
 
   GenerateQuantizedLoadStores();
 }


### PR DESCRIPTION
Seems like I made a little copy-paste error.