### PR TITLE
Android: Don't set android:debuggable="true"

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -38,9 +38,7 @@
         android:allowBackup="false"
         android:supportsRtl="true"
         android:isGame="true"
-        android:banner="@drawable/banner_tv"
-        android:debuggable="true"
-        tools:ignore="HardcodedDebugMode">
+        android:banner="@drawable/banner_tv">
         <meta-data
             android:name="android.max_aspect"
             android:value="2.1"/>


### PR DESCRIPTION
In PR #9654, I explicitly set `android:debuggable="true"` for Dolphin. (By default, it's set for debug builds but not release builds.) The reason I made the change is because debuggable must be set to true in order to allow `adb backup` to be used with apps which target Android 12. We have no reason to want to stop users from debugging Dolphin and certainly no reason to stop users from using `adb backup` (especially not after forced storage is going to force us to store the User folder in app-specific external storage!), but, it turns out that setting debuggable to true is forbidden by Google Play "for security reasons". Go figure. The beta build which was tagged earlier today was rejected because of this.