### PR TITLE
[Do not merge] Test fix for texture invalidation

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -240,7 +240,7 @@ static void BPWritten(const BPCmd& bp)
     // known for configuring these out-of-range copies.
     u32 copy_width = srcRect.GetWidth();
     u32 copy_height = srcRect.GetHeight();
-    if (srcRect.right > EFB_WIDTH || srcRect.bottom > EFB_HEIGHT)
+    if (0 && (srcRect.right > EFB_WIDTH || srcRect.bottom > EFB_HEIGHT))
     {
       WARN_LOG_FMT(VIDEO, "Oversized EFB copy: {}x{} (offset {},{} stride {})", copy_width,
                    copy_height, srcRect.left, srcRect.top, destStride);


### PR DESCRIPTION
This seems to fix https://bugs.dolphin-emu.org/issues/12392?next_issue_id=11956&prev_issue_id=12435 and could fix other regressions from https://github.com/dolphin-emu/dolphin/pull/7925 but I can only test on fifologs.

I'm not sure if this is remotely correct but it doesn't seem to cause any issues.