### PR TITLE
Fix backslash parsing issue in SplitPath

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -303,8 +303,9 @@ bool SplitPath(std::string_view full_path, std::string* path, std::string* filen
 
   size_t dir_end = full_path.find_last_of("/"
 // Windows needs the : included for something like just "C:" to be considered a directory
+// It also needs to parse escaped backslashes properly
 #ifdef _WIN32
-                                          ":"
+                                          ":\\"
 #endif
   );
   if (std::string::npos == dir_end)

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -303,7 +303,7 @@ bool SplitPath(std::string_view full_path, std::string* path, std::string* filen
 
   size_t dir_end = full_path.find_last_of("/"
 // Windows needs the : included for something like just "C:" to be considered a directory
-// It also needs to parse escaped backslashes properly
+// It also needs to parse backslashes properly, which may come from external command line options
 #ifdef _WIN32
                                           ":\\"
 #endif


### PR DESCRIPTION
From a bug mentioned here that I also ran into - https://forums.dolphin-emu.org/Thread-automatically-changing-discs-second-take?pid=508806#pid508806

For the "Change Discs Automatically" functionality, loading a .m3u file referencing multiple discs would allow both relative and absolute paths when loaded via GUI, but only absolute paths when using the -e/--exec command line option.

File paths provided via command line options could be using backslashes instead of forward slashes, which is the Windows path standard. This wasn't being considered in SplitPath, and caused issues down the line for functions that needed to re-append the folder path for relative file locations (such as ReadM3UFile in boot.cpp). Adding detection of the backslash character on _WIN32 fixes this.

First time contributing (and first time ever doing a pull request at all, actually) so please let me know if I've made any mistakes. Thank you!