### PR TITLE
Fix serialization of control expressions with line breaks

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -219,7 +219,7 @@ std::string ArrayToString(const u8* data, u32 size, int line_len, bool spaces)
   return oss.str();
 }
 
-// Turns "  hello " into "hello". Also handles tabs.
+// Turns "\n\r\t hello " into "hello" (trims at the start and end but not inside).
 std::string_view StripSpaces(std::string_view str)
 {
   const size_t s = str.find_first_not_of(" \t\r\n");
@@ -239,6 +239,13 @@ std::string_view StripQuotes(std::string_view s)
     return s.substr(1, s.size() - 2);
   else
     return s;
+}
+
+// Turns "\n\rhello" into "  hello".
+void ReplaceBreaksWithSpaces(std::string& str)
+{
+  std::replace(str.begin(), str.end(), '\r', ' ');
+  std::replace(str.begin(), str.end(), '\n', ' ');
 }
 
 bool TryParse(const std::string& str, bool* const output)

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -52,6 +52,8 @@ std::string_view StripQuotes(std::string_view s);
 
 std::string ReplaceAll(std::string result, std::string_view src, std::string_view dest);
 
+void ReplaceBreaksWithSpaces(std::string& str);
+
 bool TryParse(const std::string& str, bool* output);
 
 template <typename T, std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>* = nullptr>

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -117,7 +117,10 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
   for (auto& c : controls)
   {
     // control expression
-    sec->Set(group + c->name, c->control_ref->GetExpression(), "");
+    std::string expression = c->control_ref->GetExpression();
+    // We can't save line breaks in a single line config. Restoring them is too complicated.
+    ReplaceBreaksWithSpaces(expression);
+    sec->Set(group + c->name, expression, "");
 
     // range
     sec->Set(group + c->name + "/Range", c->control_ref->range * 100.0, 100.0);
@@ -135,7 +138,9 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
     }
     else
     {
-      sec->Set(base + name, ext->GetSelectionSetting().GetInputReference().GetExpression(), "None");
+      std::string expression = ext->GetSelectionSetting().GetInputReference().GetExpression();
+      ReplaceBreaksWithSpaces(expression);
+      sec->Set(base + name, expression, "None");
     }
 
     for (auto& ai : ext->GetAttachmentList())

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -113,9 +113,16 @@ public:
   void SaveToIni(IniFile::Section& section, const std::string& group_name) const override
   {
     if (IsSimpleValue())
+    {
       section.Set(group_name + m_details.ini_name, GetValue(), m_default_value);
+    }
     else
-      section.Set(group_name + m_details.ini_name, m_value.m_input.GetExpression(), "");
+    {
+      // We can't save line breaks in a single line config. Restoring them is too complicated.
+      std::string expression = m_value.m_input.GetExpression();
+      ReplaceBreaksWithSpaces(expression);
+      section.Set(group_name + m_details.ini_name, expression, "");
+    }
   }
 
   bool IsSimpleValue() const override { return m_value.IsSimpleValue(); }


### PR DESCRIPTION
The control expression editor allows line breaks, but the serialization was losing anything after the first line break (/r /n).

Instead of opting to encode them and decode them on serialization,
which I tried but was not safe, as it would lose `\n` written in the expression by users,
I opted to replace them with a space, to at least maintain some of the spacing the user originally put in.
Completely removing them could also have caused the expression to be parsed differently.
This cannot cause any breaking differences on the expression, and its in any way better than before, as before part of the string could just get lost.

![image](https://user-images.githubusercontent.com/7011366/117826705-0afbe780-b279-11eb-8b5a-e155d2bff001.png)