### PR TITLE
WIP: Don't inline Display Lists into Fifologs

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -258,37 +258,37 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
 
 void LoadCPReg(u32 subCmd, u32 value, CPMemory& cpMem)
 {
-  switch (subCmd & 0xF0)
+  switch (subCmd & CP_COMMAND_MASK)
   {
-  case 0x50:
+  case VCD_LO:
     cpMem.vtxDesc.low.Hex = value;
     break;
 
-  case 0x60:
+  case VCD_HI:
     cpMem.vtxDesc.high.Hex = value;
     break;
 
-  case 0x70:
-    ASSERT((subCmd & 0x0F) < 8);
-    cpMem.vtxAttr[subCmd & 7].g0.Hex = value;
+  case CP_VAT_REG_A:
+    ASSERT(subCmd - CP_VAT_REG_A < CP_NUM_VAT_REG);
+    cpMem.vtxAttr[subCmd & CP_VAT_MASK].g0.Hex = value;
     break;
 
-  case 0x80:
-    ASSERT((subCmd & 0x0F) < 8);
-    cpMem.vtxAttr[subCmd & 7].g1.Hex = value;
+  case CP_VAT_REG_B:
+    ASSERT(subCmd - CP_VAT_REG_B < CP_NUM_VAT_REG);
+    cpMem.vtxAttr[subCmd & CP_VAT_MASK].g1.Hex = value;
     break;
 
-  case 0x90:
-    ASSERT((subCmd & 0x0F) < 8);
-    cpMem.vtxAttr[subCmd & 7].g2.Hex = value;
+  case CP_VAT_REG_C:
+    ASSERT(subCmd - CP_VAT_REG_C < CP_NUM_VAT_REG);
+    cpMem.vtxAttr[subCmd & CP_VAT_MASK].g2.Hex = value;
     break;
 
-  case 0xA0:
-    cpMem.arrayBases[subCmd & 0xF] = value;
+  case ARRAY_BASE:
+    cpMem.arrayBases[subCmd & CP_ARRAY_MASK] = value;
     break;
 
-  case 0xB0:
-    cpMem.arrayStrides[subCmd & 0xF] = value & 0xFF;
+  case ARRAY_STRIDE:
+    cpMem.arrayStrides[subCmd & CP_ARRAY_MASK] = value & 0xFF;
     break;
   }
 }

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -147,14 +147,14 @@ std::array<int, 21> CalculateVertexElementSizes(int vatIndex, const CPMemory& cp
 }
 }  // Anonymous namespace
 
-bool s_DrawingObject;
 FifoAnalyzer::CPMemory s_CpMem;
 
-u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list)
+u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list, CmdInfo *info_out)
 {
   const u8* dataStart = data;
 
   int cmd = ReadFifo8(data);
+  CmdInfo::Type type = CmdInfo::NORMAL;
 
   switch (cmd)
   {
@@ -165,8 +165,6 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list)
 
   case OpcodeDecoder::GX_LOAD_CP_REG:
   {
-    s_DrawingObject = false;
-
     u32 cmd2 = ReadFifo8(data);
     u32 value = ReadFifo32(data);
     LoadCPReg(cmd2, value, s_CpMem);
@@ -175,8 +173,6 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list)
 
   case OpcodeDecoder::GX_LOAD_XF_REG:
   {
-    s_DrawingObject = false;
-
     u32 cmd2 = ReadFifo32(data);
     u8 streamSize = ((cmd2 >> 16) & 15) + 1;
 
@@ -189,8 +185,6 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list)
   case OpcodeDecoder::GX_LOAD_INDX_C:
   case OpcodeDecoder::GX_LOAD_INDX_D:
   {
-    s_DrawingObject = false;
-
     int array = 0xc + (cmd - OpcodeDecoder::GX_LOAD_INDX_A) / 8;
     u32 value = ReadFifo32(data);
 
@@ -201,7 +195,9 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list)
 
   case OpcodeDecoder::GX_CMD_CALL_DL:
   {
-    const u32 address = ReadFifo32(data);
+    type = CmdInfo::DL_CALL;
+
+    const u32 address = ReadFifo32(data) & 0x1fffffff;
     const u32 count = ReadFifo32(data);
 
     if (!in_display_list && mode == DecodeMode::Record)
@@ -210,12 +206,16 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list)
       FifoRecordAnalyzer::ProcessDisplayList(address, count);
     }
 
+    if (info_out) {
+      info_out->display_list_address = address;
+      info_out->display_list_length = count;
+    }
+
     break;
   }
 
   case OpcodeDecoder::GX_LOAD_BP_REG:
   {
-    s_DrawingObject = false;
     ReadFifo32(data);
     break;
   }
@@ -223,7 +223,7 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list)
   default:
     if (cmd & 0x80)
     {
-      s_DrawingObject = true;
+      type = CmdInfo::DRAW;
 
       const std::array<int, 21> sizes =
           CalculateVertexElementSizes(cmd & OpcodeDecoder::GX_VAT_MASK, s_CpMem);
@@ -254,13 +254,21 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list)
     }
     else
     {
-      PanicAlertFmt("FifoPlayer: Unknown Opcode ({:#x}).\n", cmd);
+      //PanicAlertFmt("FifoPlayer: Unknown Opcode ({:#x}).\n", cmd);
+      //exit(0);
       return 0;
     }
     break;
   }
 
-  return (u32)(data - dataStart);
+  u32 length = (u32)(data - dataStart);
+
+  if (info_out) {
+    info_out->type = type;
+    info_out->cmd_length = length;
+  }
+
+  return length;
 }
 
 void LoadCPReg(u32 subCmd, u32 value, CPMemory& cpMem)

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -22,9 +22,9 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode);
 struct CPMemory
 {
   TVtxDesc vtxDesc;
-  std::array<VAT, 8> vtxAttr;
-  std::array<u32, 16> arrayBases;
-  std::array<u32, 16> arrayStrides;
+  std::array<VAT, CP_NUM_VAT_REG> vtxAttr;
+  std::array<u32, CP_NUM_ARRAYS> arrayBases;
+  std::array<u32, CP_NUM_ARRAYS> arrayStrides;
 };
 
 void LoadCPReg(u32 subCmd, u32 value, CPMemory& cpMem);

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -17,7 +17,20 @@ enum class DecodeMode
   Playback,
 };
 
-u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list = false);
+struct CmdInfo {
+  enum Type {
+    NORMAL,
+    DRAW,
+    EFB_COPY,
+    DL_CALL
+  };
+  Type type = NORMAL;
+  u32 cmd_length;
+  u32 display_list_address;
+  u32 display_list_length;
+};
+
+u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list = false, CmdInfo *info_out = nullptr);
 
 struct CPMemory
 {

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -17,7 +17,7 @@ enum class DecodeMode
   Playback,
 };
 
-u32 AnalyzeCommand(const u8* data, DecodeMode mode);
+u32 AnalyzeCommand(const u8* data, DecodeMode mode, bool in_display_list = false);
 
 struct CPMemory
 {

--- a/Source/Core/Core/FifoPlayer/FifoDataFile.h
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.h
@@ -24,6 +24,7 @@ struct MemoryUpdate
     XF_DATA = 0x02,
     VERTEX_STREAM = 0x04,
     TMEM = 0x08,
+    DISPLAY_LIST = 0x10,
   };
 
   u32 fifoPosition;

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
@@ -25,14 +25,14 @@ void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file,
                                          std::vector<AnalyzedFrameInfo>& frameInfo)
 {
   u32* cpMem = file->GetCPMem();
-  FifoAnalyzer::LoadCPReg(0x50, cpMem[0x50], s_CpMem);
-  FifoAnalyzer::LoadCPReg(0x60, cpMem[0x60], s_CpMem);
+  FifoAnalyzer::LoadCPReg(VCD_LO, cpMem[VCD_LO], s_CpMem);
+  FifoAnalyzer::LoadCPReg(VCD_HI, cpMem[VCD_HI], s_CpMem);
 
-  for (int i = 0; i < 8; ++i)
+  for (u32 i = 0; i < CP_NUM_VAT_REG; ++i)
   {
-    FifoAnalyzer::LoadCPReg(0x70 + i, cpMem[0x70 + i], s_CpMem);
-    FifoAnalyzer::LoadCPReg(0x80 + i, cpMem[0x80 + i], s_CpMem);
-    FifoAnalyzer::LoadCPReg(0x90 + i, cpMem[0x90 + i], s_CpMem);
+    FifoAnalyzer::LoadCPReg(CP_VAT_REG_A + i, cpMem[CP_VAT_REG_A + i], s_CpMem);
+    FifoAnalyzer::LoadCPReg(CP_VAT_REG_B + i, cpMem[CP_VAT_REG_B + i], s_CpMem);
+    FifoAnalyzer::LoadCPReg(CP_VAT_REG_C + i, cpMem[CP_VAT_REG_C + i], s_CpMem);
   }
 
   frameInfo.clear();

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 #include "Core/FifoPlayer/FifoDataFile.h"
@@ -80,6 +81,7 @@ void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file,
       {
         // Clean up frame analysis
         analyzed.objectStarts.clear();
+        analyzed.objectCPStates.clear();
         analyzed.objectEnds.clear();
 
         return;
@@ -88,9 +90,14 @@ void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file,
       if (wasDrawing != s_DrawingObject)
       {
         if (s_DrawingObject)
+        {
           analyzed.objectStarts.push_back(cmdStart);
+          analyzed.objectCPStates.push_back(s_CpMem);
+        }
         else
+        {
           analyzed.objectEnds.push_back(cmdStart);
+        }
       }
 
       cmdStart += cmdSize;
@@ -98,5 +105,8 @@ void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file,
 
     if (analyzed.objectEnds.size() < analyzed.objectStarts.size())
       analyzed.objectEnds.push_back(cmdStart);
+
+    ASSERT(analyzed.objectStarts.size() == analyzed.objectCPStates.size());
+    ASSERT(analyzed.objectStarts.size() == analyzed.objectEnds.size());
   }
 }

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
@@ -7,11 +7,15 @@
 #include <string>
 #include <vector>
 
+#include "Core/FifoPlayer/FifoAnalyzer.h"
 #include "Core/FifoPlayer/FifoDataFile.h"
 
 struct AnalyzedFrameInfo
 {
+  // Start of the primitives for the object (after previous update commands)
   std::vector<u32> objectStarts;
+  std::vector<FifoAnalyzer::CPMemory> objectCPStates;
+  // End of the primitives for the object
   std::vector<u32> objectEnds;
   std::vector<MemoryUpdate> memoryUpdates;
 };

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
@@ -10,14 +10,31 @@
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 #include "Core/FifoPlayer/FifoDataFile.h"
 
+struct Object {
+  u32 start;
+  u32 end;
+  FifoAnalyzer::CPMemory CPState;
+};
+
+struct DisplayList {
+  u32 id;
+  u32 address;
+  u32 refCount = 0;
+  std::vector<u8> cmdData;
+  std::vector<Object> objects;
+};
+
+struct DisplayListCall {
+  u32 offset;
+  u32 displayListId; // Index into AnalyzedFrameInfo::DisplayList
+};
+
 struct AnalyzedFrameInfo
 {
-  // Start of the primitives for the object (after previous update commands)
-  std::vector<u32> objectStarts;
-  std::vector<FifoAnalyzer::CPMemory> objectCPStates;
-  // End of the primitives for the object
-  std::vector<u32> objectEnds;
+  std::vector<Object> objects;
   std::vector<MemoryUpdate> memoryUpdates;
+  std::vector<DisplayList> displayLists;
+  std::vector<DisplayListCall> displayListCalls;
 };
 
 namespace FifoPlaybackAnalyzer

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -189,6 +189,18 @@ bool FifoPlayer::IsRunningWithFakeVideoInterfaceUpdates() const
   return m_File->ShouldGenerateFakeVIUpdates();
 }
 
+u32 FifoPlayer::GetMaxObjectCount() const
+{
+  u32 result = 0;
+  for (auto& frame : m_FrameInfo)
+  {
+    const u32 count = static_cast<u32>(frame.objectStarts.size());
+    if (count > result)
+      result = count;
+  }
+  return result;
+}
+
 u32 FifoPlayer::GetFrameObjectCount() const
 {
   if (m_CurrentFrame < m_FrameInfo.size())

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -384,6 +384,8 @@ void FifoPlayer::WriteFifo(const u8* data, u32 start, u32 end)
   {
     while (IsHighWatermarkSet())
     {
+      if (CPU::GetState() != CPU::State::Running)
+        break;
       CoreTiming::Idle();
       CoreTiming::Advance();
     }

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -51,7 +51,7 @@ bool FifoPlayer::Open(const std::string& filename)
   {
     FifoPlaybackAnalyzer::AnalyzeFrames(m_File.get(), m_FrameInfo);
 
-    m_FrameRangeEnd = m_File->GetFrameCount();
+    m_FrameRangeEnd = m_File->GetFrameCount() - 1;
   }
 
   if (m_FileLoadedCb)
@@ -131,13 +131,10 @@ private:
 
 CPU::State FifoPlayer::AdvanceFrame()
 {
-  if (m_CurrentFrame >= m_FrameRangeEnd)
+  if (m_CurrentFrame > m_FrameRangeEnd)
   {
     if (!m_Loop)
       return CPU::State::PowerDown;
-    // If there are zero frames in the range then sleep instead of busy spinning
-    if (m_FrameRangeStart >= m_FrameRangeEnd)
-      return CPU::State::Stepping;
 
     // When looping, reload the contents of all the BP/CP/CF registers.
     // This ensures that each time the first frame is played back, the state of the
@@ -215,9 +212,9 @@ void FifoPlayer::SetFrameRangeStart(u32 start)
 {
   if (m_File)
   {
-    u32 frameCount = m_File->GetFrameCount();
-    if (start > frameCount)
-      start = frameCount;
+    const u32 lastFrame = m_File->GetFrameCount() - 1;
+    if (start > lastFrame)
+      start = lastFrame;
 
     m_FrameRangeStart = start;
     if (m_FrameRangeEnd < start)
@@ -232,9 +229,9 @@ void FifoPlayer::SetFrameRangeEnd(u32 end)
 {
   if (m_File)
   {
-    u32 frameCount = m_File->GetFrameCount();
-    if (end > frameCount)
-      end = frameCount;
+    const u32 lastFrame = m_File->GetFrameCount() - 1;
+    if (end > lastFrame)
+      end = lastFrame;
 
     m_FrameRangeEnd = end;
     if (m_FrameRangeStart > end)

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -198,14 +198,19 @@ u32 FifoPlayer::GetMaxObjectCount() const
   return result;
 }
 
-u32 FifoPlayer::GetFrameObjectCount() const
+u32 FifoPlayer::GetFrameObjectCount(u32 frame) const
 {
-  if (m_CurrentFrame < m_FrameInfo.size())
+  if (frame < m_FrameInfo.size())
   {
-    return (u32)(m_FrameInfo[m_CurrentFrame].objectStarts.size());
+    return static_cast<u32>(m_FrameInfo[frame].objectStarts.size());
   }
 
   return 0;
+}
+
+u32 FifoPlayer::GetCurrentFrameObjectCount() const
+{
+  return GetFrameObjectCount(m_CurrentFrame);
 }
 
 void FifoPlayer::SetFrameRangeStart(u32 start)

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -191,7 +191,7 @@ u32 FifoPlayer::GetMaxObjectCount() const
   u32 result = 0;
   for (auto& frame : m_FrameInfo)
   {
-    const u32 count = static_cast<u32>(frame.objectStarts.size());
+    const u32 count = static_cast<u32>(frame.objects.size());
     if (count > result)
       result = count;
   }
@@ -202,7 +202,7 @@ u32 FifoPlayer::GetFrameObjectCount(u32 frame) const
 {
   if (frame < m_FrameInfo.size())
   {
-    return static_cast<u32>(m_FrameInfo[frame].objectStarts.size());
+    return static_cast<u32>(m_FrameInfo[frame].objects.size());
   }
 
   return 0;
@@ -263,7 +263,7 @@ void FifoPlayer::WriteFrame(const FifoFrameInfo& frame, const AnalyzedFrameInfo&
   m_FrameFifoSize = static_cast<u32>(frame.fifoData.size());
 
   // Determine start and end objects
-  u32 numObjects = (u32)(info.objectStarts.size());
+  u32 numObjects = (u32)(info.objects.size());
   u32 drawStart = std::min(numObjects, m_ObjectRangeStart);
   u32 drawEnd = std::min(numObjects - 1, m_ObjectRangeEnd);
 
@@ -283,9 +283,9 @@ void FifoPlayer::WriteFrame(const FifoFrameInfo& frame, const AnalyzedFrameInfo&
     // Write fifo data skipping objects before the draw range
     while (objectNum < drawStart)
     {
-      WriteFramePart(position, info.objectStarts[objectNum], memoryUpdate, frame, info);
+      WriteFramePart(position, info.objects[objectNum].start, memoryUpdate, frame, info);
 
-      position = info.objectEnds[objectNum];
+      position = info.objects[objectNum].end;
       ++objectNum;
     }
 
@@ -293,17 +293,17 @@ void FifoPlayer::WriteFrame(const FifoFrameInfo& frame, const AnalyzedFrameInfo&
     if (objectNum < numObjects && drawStart <= drawEnd)
     {
       objectNum = drawEnd;
-      WriteFramePart(position, info.objectEnds[objectNum], memoryUpdate, frame, info);
-      position = info.objectEnds[objectNum];
+      WriteFramePart(position, info.objects[objectNum].end, memoryUpdate, frame, info);
+      position = info.objects[objectNum].end;
       ++objectNum;
     }
 
     // Write fifo data skipping objects after the draw range
     while (objectNum < numObjects)
     {
-      WriteFramePart(position, info.objectStarts[objectNum], memoryUpdate, frame, info);
+      WriteFramePart(position, info.objects[objectNum].start, memoryUpdate, frame, info);
 
-      position = info.objectEnds[objectNum];
+      position = info.objects[objectNum].end;
       ++objectNum;
     }
   }

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -74,6 +74,7 @@ public:
   bool IsPlaying() const;
 
   FifoDataFile* GetFile() const { return m_File.get(); }
+  u32 GetMaxObjectCount() const;
   u32 GetFrameObjectCount() const;
   u32 GetCurrentFrameNum() const { return m_CurrentFrame; }
   const AnalyzedFrameInfo& GetAnalyzedFrameInfo(u32 frame) const { return m_FrameInfo[frame]; }

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -75,7 +75,8 @@ public:
 
   FifoDataFile* GetFile() const { return m_File.get(); }
   u32 GetMaxObjectCount() const;
-  u32 GetFrameObjectCount() const;
+  u32 GetFrameObjectCount(u32 frame) const;
+  u32 GetCurrentFrameObjectCount() const;
   u32 GetCurrentFrameNum() const { return m_CurrentFrame; }
   const AnalyzedFrameInfo& GetAnalyzedFrameInfo(u32 frame) const { return m_FrameInfo[frame]; }
   // Frame range

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
@@ -17,16 +17,16 @@ void FifoRecordAnalyzer::Initialize(const u32* cpMem)
 {
   s_DrawingObject = false;
 
-  FifoAnalyzer::LoadCPReg(0x50, *(cpMem + 0x50), s_CpMem);
-  FifoAnalyzer::LoadCPReg(0x60, *(cpMem + 0x60), s_CpMem);
-  for (int i = 0; i < 8; ++i)
-    FifoAnalyzer::LoadCPReg(0x70 + i, *(cpMem + 0x70 + i), s_CpMem);
+  FifoAnalyzer::LoadCPReg(VCD_LO, cpMem[VCD_LO], s_CpMem);
+  FifoAnalyzer::LoadCPReg(VCD_HI, cpMem[VCD_HI], s_CpMem);
+  for (u32 i = 0; i < CP_NUM_VAT_REG; ++i)
+    FifoAnalyzer::LoadCPReg(CP_VAT_REG_A + i, cpMem[CP_VAT_REG_A + i], s_CpMem);
 
-  const u32* const bases_start = cpMem + 0xA0;
+  const u32* const bases_start = cpMem + ARRAY_BASE;
   const u32* const bases_end = bases_start + s_CpMem.arrayBases.size();
   std::copy(bases_start, bases_end, s_CpMem.arrayBases.begin());
 
-  const u32* const strides_start = cpMem + 0xB0;
+  const u32* const strides_start = cpMem + ARRAY_STRIDE;
   const u32* const strides_end = strides_start + s_CpMem.arrayStrides.size();
   std::copy(strides_start, strides_end, s_CpMem.arrayStrides.begin());
 }

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
@@ -41,6 +41,19 @@ void FifoRecordAnalyzer::ProcessLoadIndexedXf(u32 val, int array)
   FifoRecorder::GetInstance().UseMemory(address, size * 4, MemoryUpdate::XF_DATA);
 }
 
+void FifoRecordAnalyzer::ProcessDisplayList(const u32 address, u32 count) {
+  FifoRecorder::GetInstance().UseMemory(address, count, MemoryUpdate::DISPLAY_LIST);
+
+  u8* data = Memory::GetPointer(address);
+  const u8* end = data + count;
+
+  while (data < end)
+  {
+    u32 analyzed_size = AnalyzeCommand(data, DecodeMode::Record, true);
+    data += analyzed_size;
+  }
+}
+
 void FifoRecordAnalyzer::WriteVertexArray(int arrayIndex, const u8* vertexData, int vertexSize,
                                           int numVertices)
 {

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
@@ -15,8 +15,6 @@ using namespace FifoAnalyzer;
 
 void FifoRecordAnalyzer::Initialize(const u32* cpMem)
 {
-  s_DrawingObject = false;
-
   FifoAnalyzer::LoadCPReg(VCD_LO, cpMem[VCD_LO], s_CpMem);
   FifoAnalyzer::LoadCPReg(VCD_HI, cpMem[VCD_HI], s_CpMem);
   for (u32 i = 0; i < CP_NUM_VAT_REG; ++i)

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
@@ -12,5 +12,6 @@ namespace FifoRecordAnalyzer
 void Initialize(const u32* cpMem);
 
 void ProcessLoadIndexedXf(u32 val, int array);
+void ProcessDisplayList(const u32 address, u32 count);
 void WriteVertexArray(int arrayIndex, const u8* vertexData, int vertexSize, int numVertices);
 }  // namespace FifoRecordAnalyzer

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -165,6 +165,9 @@ void FIFOAnalyzer::UpdateDetails()
   m_detail_list->clear();
   m_object_data_offsets.clear();
 
+  if (!FifoPlayer::GetInstance().IsPlaying())
+    return;
+
   auto items = m_tree_widget->selectedItems();
 
   if (items.isEmpty() || items[0]->data(0, OBJECT_ROLE).isNull())
@@ -316,6 +319,9 @@ void FIFOAnalyzer::BeginSearch()
 {
   QString search_str = m_search_edit->text();
 
+  if (!FifoPlayer::GetInstance().IsPlaying())
+    return;
+
   auto items = m_tree_widget->selectedItems();
 
   if (items.isEmpty() || items[0]->data(0, FRAME_ROLE).isNull())
@@ -461,6 +467,9 @@ void FIFOAnalyzer::ShowSearchResult(size_t index)
 void FIFOAnalyzer::UpdateDescription()
 {
   m_entry_detail_browser->clear();
+
+  if (!FifoPlayer::GetInstance().IsPlaying())
+    return;
 
   auto items = m_tree_widget->selectedItems();
 

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -271,21 +271,37 @@ void FIFOAnalyzer::UpdateDetails()
     break;
 
     case OpcodeDecoder::GX_LOAD_INDX_A:
-      new_label = QStringLiteral("LOAD INDX A");
+    {
+      const auto [desc, written] =
+          GetXFIndexedLoadInfo(ARRAY_XF_A, Common::swap32(&object[object_offset]));
       object_offset += 4;
-      break;
+      new_label = QStringLiteral("LOAD INDX A   %1").arg(QString::fromStdString(desc));
+    }
+    break;
     case OpcodeDecoder::GX_LOAD_INDX_B:
-      new_label = QStringLiteral("LOAD INDX B");
+    {
+      const auto [desc, written] =
+          GetXFIndexedLoadInfo(ARRAY_XF_B, Common::swap32(&object[object_offset]));
       object_offset += 4;
-      break;
+      new_label = QStringLiteral("LOAD INDX B   %1").arg(QString::fromStdString(desc));
+    }
+    break;
     case OpcodeDecoder::GX_LOAD_INDX_C:
-      new_label = QStringLiteral("LOAD INDX C");
+    {
+      const auto [desc, written] =
+          GetXFIndexedLoadInfo(ARRAY_XF_C, Common::swap32(&object[object_offset]));
       object_offset += 4;
-      break;
+      new_label = QStringLiteral("LOAD INDX C   %1").arg(QString::fromStdString(desc));
+    }
+    break;
     case OpcodeDecoder::GX_LOAD_INDX_D:
-      new_label = QStringLiteral("LOAD INDX D");
+    {
+      const auto [desc, written] =
+          GetXFIndexedLoadInfo(ARRAY_XF_D, Common::swap32(&object[object_offset]));
       object_offset += 4;
-      break;
+      new_label = QStringLiteral("LOAD INDX D   %1").arg(QString::fromStdString(desc));
+    }
+    break;
 
     case OpcodeDecoder::GX_CMD_CALL_DL:
       // The recorder should have expanded display lists into the fifo stream and skipped the
@@ -564,6 +580,46 @@ void FIFOAnalyzer::UpdateDescription()
       text += tr("No description available");
     else
       text += QString::fromStdString(desc);
+  }
+  else if (*cmddata == OpcodeDecoder::GX_LOAD_INDX_A)
+  {
+    const auto [desc, written] = GetXFIndexedLoadInfo(ARRAY_XF_A, Common::swap32(cmddata + 1));
+
+    text = QString::fromStdString(desc);
+    text += QLatin1Char{'\n'};
+    text += tr("Usually used for position matrices");
+    text += QLatin1Char{'\n'};
+    text += QString::fromStdString(written);
+  }
+  else if (*cmddata == OpcodeDecoder::GX_LOAD_INDX_B)
+  {
+    const auto [desc, written] = GetXFIndexedLoadInfo(ARRAY_XF_B, Common::swap32(cmddata + 1));
+
+    text = QString::fromStdString(desc);
+    text += QLatin1Char{'\n'};
+    text += tr("Usually used for normal matrices");
+    text += QLatin1Char{'\n'};
+    text += QString::fromStdString(written);
+  }
+  else if (*cmddata == OpcodeDecoder::GX_LOAD_INDX_C)
+  {
+    const auto [desc, written] = GetXFIndexedLoadInfo(ARRAY_XF_C, Common::swap32(cmddata + 1));
+
+    text = QString::fromStdString(desc);
+    text += QLatin1Char{'\n'};
+    text += tr("Usually used for tex coord matrices");
+    text += QLatin1Char{'\n'};
+    text += QString::fromStdString(written);
+  }
+  else if (*cmddata == OpcodeDecoder::GX_LOAD_INDX_D)
+  {
+    const auto [desc, written] = GetXFIndexedLoadInfo(ARRAY_XF_D, Common::swap32(cmddata + 1));
+
+    text = QString::fromStdString(desc);
+    text += QLatin1Char{'\n'};
+    text += tr("Usually used for light objects");
+    text += QLatin1Char{'\n'};
+    text += QString::fromStdString(written);
   }
   else
   {

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -668,15 +668,20 @@ void FIFOAnalyzer::UpdateDescription()
 
     const auto& vtx_desc = frame_info.objectCPStates[object_nr].vtxDesc;
     const auto& vtx_attr = frame_info.objectCPStates[object_nr].vtxAttr[vat];
-    const u32 vertex_size = VertexLoaderBase::GetVertexSize(vtx_desc, vtx_attr);
+    const auto component_sizes = VertexLoaderBase::GetVertexComponentSizes(vtx_desc, vtx_attr);
 
     u32 i = 3;
     for (u32 vertex_num = 0; vertex_num < vertex_count; vertex_num++)
     {
       text += QLatin1Char{'\n'};
-      // TODO: format each vertex nicely
-      for (u32 vertex_off = 0; vertex_off < vertex_size; vertex_off++)
-        text += QStringLiteral("%1").arg(cmddata[i++], 2, 16, QLatin1Char('0'));
+      for (u32 comp_size : component_sizes)
+      {
+        for (u32 comp_off = 0; comp_off < comp_size; comp_off++)
+        {
+          text += QStringLiteral("%1").arg(cmddata[i++], 2, 16, QLatin1Char('0'));
+        }
+        text += QLatin1Char{' '};
+      }
     }
   }
   else

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -139,23 +139,22 @@ void FIFOAnalyzer::UpdateTree()
 
   auto* file = FifoPlayer::GetInstance().GetFile();
 
-  int object_count = FifoPlayer::GetInstance().GetFrameObjectCount();
-  int frame_count = file->GetFrameCount();
-
-  for (int i = 0; i < frame_count; i++)
+  const u32 frame_count = file->GetFrameCount();
+  for (u32 frame = 0; frame < frame_count; frame++)
   {
-    auto* frame_item = new QTreeWidgetItem({tr("Frame %1").arg(i)});
+    auto* frame_item = new QTreeWidgetItem({tr("Frame %1").arg(frame)});
 
     recording_item->addChild(frame_item);
 
-    for (int j = 0; j < object_count; j++)
+    const u32 object_count = FifoPlayer::GetInstance().GetFrameObjectCount(frame);
+    for (u32 object = 0; object < object_count; object++)
     {
-      auto* object_item = new QTreeWidgetItem({tr("Object %1").arg(j)});
+      auto* object_item = new QTreeWidgetItem({tr("Object %1").arg(object)});
 
       frame_item->addChild(object_item);
 
-      object_item->setData(0, FRAME_ROLE, i);
-      object_item->setData(0, OBJECT_ROLE, j);
+      object_item->setData(0, FRAME_ROLE, frame);
+      object_item->setData(0, OBJECT_ROLE, object);
     }
   }
 }

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -339,6 +339,9 @@ void FIFOAnalyzer::UpdateDetails()
   }
 
   m_detail_list->addItem(new_label);
+
+  // Needed to ensure the description updates when changing objects
+  m_detail_list->setCurrentRow(0);
 }
 
 void FIFOAnalyzer::BeginSearch()
@@ -485,6 +488,9 @@ void FIFOAnalyzer::UpdateDescription()
   const auto items = m_tree_widget->selectedItems();
 
   if (items.isEmpty() || m_object_data_offsets.empty())
+    return;
+
+  if (items[0]->data(0, FRAME_ROLE).isNull() || items[0]->data(0, OBJECT_ROLE).isNull())
     return;
 
   const u32 frame_nr = items[0]->data(0, FRAME_ROLE).toUInt();

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -161,8 +161,12 @@ void FIFOAnalyzer::UpdateTree()
 
 void FIFOAnalyzer::UpdateDetails()
 {
-  m_detail_list->clear();
+  // Clearing the detail list can update the selection, which causes UpdateDescription to be called
+  // immediately.  However, the object data offsets have not been recalculated yet, which can cause
+  // the wrong data to be used, potentially leading to out of bounds data or other bad things.
+  // Clear m_object_data_offsets first, so that UpdateDescription exits immediately.
   m_object_data_offsets.clear();
+  m_detail_list->clear();
 
   if (!FifoPlayer::GetInstance().IsPlaying())
     return;
@@ -472,7 +476,7 @@ void FIFOAnalyzer::UpdateDescription()
 
   auto items = m_tree_widget->selectedItems();
 
-  if (items.isEmpty())
+  if (items.isEmpty() || m_object_data_offsets.empty())
     return;
 
   int frame_nr = items[0]->data(0, FRAME_ROLE).toInt();

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -209,7 +209,18 @@ void FIFOAnalyzer::UpdateDetails()
     switch (command)
     {
     case OpcodeDecoder::GX_NOP:
-      new_label = QStringLiteral("NOP");
+      if (object[object_offset] == OpcodeDecoder::GX_NOP)
+      {
+        u32 nop_count = 2;
+        while (object[++object_offset] == OpcodeDecoder::GX_NOP)
+          nop_count++;
+
+        new_label = QStringLiteral("NOP (%1x)").arg(nop_count);
+      }
+      else
+      {
+        new_label = QStringLiteral("NOP");
+      }
       break;
 
     case OpcodeDecoder::GX_CMD_UNKNOWN_METRICS:

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -323,13 +323,16 @@ void FIFOAnalyzer::UpdateDetails()
     break;
 
     case OpcodeDecoder::GX_CMD_CALL_DL:
-      // The recorder should have expanded display lists into the fifo stream and skipped the
-      // call to start them
-      // That is done to make it easier to track where memory is updated
-      ASSERT(false);
-      object_offset += 8;
-      new_label = QStringLiteral("CALL DL");
-      break;
+    {
+      const u32 address = Common::swap32(&object[object_offset]);
+      object_offset += 4;
+      const u32 count = Common::swap32(&object[object_offset]);
+      object_offset += 4;
+      new_label = QStringLiteral("CALL DL 0x%1-0x%2")
+                      .arg(address, 8, 16, QLatin1Char('0'))
+                      .arg(address + count, 8, 16, QLatin1Char('0'));
+    }
+     break;
 
     case OpcodeDecoder::GX_LOAD_BP_REG:
     {

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.h
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.h
@@ -8,6 +8,8 @@
 
 #include <QWidget>
 
+#include "Common/CommonTypes.h"
+
 class QGroupBox;
 class QLabel;
 class QLineEdit;
@@ -57,9 +59,13 @@ private:
 
   struct SearchResult
   {
-    int frame;
-    int object;
-    int cmd;
+    constexpr SearchResult(u32 frame, u32 object, u32 cmd)
+        : m_frame(frame), m_object(object), m_cmd(cmd)
+    {
+    }
+    const u32 m_frame;
+    const u32 m_object;
+    const u32 m_cmd;
   };
 
   std::vector<int> m_object_data_offsets;

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -262,7 +262,7 @@ void FIFOPlayerWindow::UpdateInfo()
     m_info_label->setText(
         tr("%1 frame(s)\n%2 object(s)\nCurrent Frame: %3")
             .arg(QString::number(file->GetFrameCount()),
-                 QString::number(FifoPlayer::GetInstance().GetFrameObjectCount()),
+                 QString::number(FifoPlayer::GetInstance().GetCurrentFrameObjectCount()),
                  QString::number(FifoPlayer::GetInstance().GetCurrentFrameNum())));
     return;
   }

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -245,6 +245,7 @@ void FIFOPlayerWindow::OnEmulationStopped()
     StopRecording();
 
   UpdateControls();
+  m_analyzer->Update();
 }
 
 void FIFOPlayerWindow::OnRecordingDone()

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -298,16 +298,16 @@ void FIFOPlayerWindow::OnFIFOLoaded()
 {
   FifoDataFile* file = FifoPlayer::GetInstance().GetFile();
 
-  auto object_count = FifoPlayer::GetInstance().GetFrameObjectCount();
+  auto object_count = FifoPlayer::GetInstance().GetMaxObjectCount();
   auto frame_count = file->GetFrameCount();
 
   m_frame_range_to->setMaximum(frame_count);
-  m_object_range_to->setMaximum(object_count);
+  m_object_range_to->setMaximum(object_count - 1);
 
   m_frame_range_from->setValue(0);
   m_object_range_from->setValue(0);
   m_frame_range_to->setValue(frame_count);
-  m_object_range_to->setValue(object_count);
+  m_object_range_to->setValue(object_count - 1);
 
   UpdateInfo();
   UpdateLimits();
@@ -336,8 +336,8 @@ void FIFOPlayerWindow::UpdateLimits()
 {
   m_frame_range_from->setMaximum(std::max(m_frame_range_to->value() - 1, 0));
   m_frame_range_to->setMinimum(m_frame_range_from->value() + 1);
-  m_object_range_from->setMaximum(std::max(m_object_range_to->value() - 1, 0));
-  m_object_range_to->setMinimum(m_object_range_from->value() + 1);
+  m_object_range_from->setMaximum(m_object_range_to->value());
+  m_object_range_to->setMinimum(m_object_range_from->value());
 }
 
 void FIFOPlayerWindow::UpdateControls()

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -301,12 +301,12 @@ void FIFOPlayerWindow::OnFIFOLoaded()
   auto object_count = FifoPlayer::GetInstance().GetMaxObjectCount();
   auto frame_count = file->GetFrameCount();
 
-  m_frame_range_to->setMaximum(frame_count);
+  m_frame_range_to->setMaximum(frame_count - 1);
   m_object_range_to->setMaximum(object_count - 1);
 
   m_frame_range_from->setValue(0);
   m_object_range_from->setValue(0);
-  m_frame_range_to->setValue(frame_count);
+  m_frame_range_to->setValue(frame_count - 1);
   m_object_range_to->setValue(object_count - 1);
 
   UpdateInfo();
@@ -334,8 +334,8 @@ void FIFOPlayerWindow::OnLimitsChanged()
 
 void FIFOPlayerWindow::UpdateLimits()
 {
-  m_frame_range_from->setMaximum(std::max(m_frame_range_to->value() - 1, 0));
-  m_frame_range_to->setMinimum(m_frame_range_from->value() + 1);
+  m_frame_range_from->setMaximum(m_frame_range_to->value());
+  m_frame_range_to->setMinimum(m_frame_range_from->value());
   m_object_range_from->setMaximum(m_object_range_to->value());
   m_object_range_to->setMinimum(m_object_range_from->value());
 }

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -304,6 +304,8 @@ void FIFOPlayerWindow::OnFIFOLoaded()
   m_frame_range_to->setMaximum(frame_count);
   m_object_range_to->setMaximum(object_count);
 
+  m_frame_range_from->setValue(0);
+  m_object_range_from->setValue(0);
   m_frame_range_to->setValue(frame_count);
   m_object_range_to->setValue(object_count);
 

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -50,10 +50,11 @@ FIFOPlayerWindow::FIFOPlayerWindow(QWidget* parent) : QDialog(parent)
   });
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
-    if (state == Core::State::Running)
+    if (state == Core::State::Running && m_emu_state != Core::State::Paused)
       OnEmulationStarted();
     else if (state == Core::State::Uninitialized)
       OnEmulationStopped();
+    m_emu_state = state;
   });
 }
 

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.h
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.h
@@ -6,6 +6,8 @@
 
 #include <QDialog>
 
+#include "Core/Core.h"
+
 class QCheckBox;
 class QDialogButtonBox;
 class QLabel;
@@ -62,4 +64,5 @@ private:
   QDialogButtonBox* m_button_box;
 
   FIFOAnalyzer* m_analyzer;
+  Core::State m_emu_state = Core::State::Uninitialized;
 };

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.h
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <QDialog>
+#include <QWidget>
 
 #include "Core/Core.h"
 
@@ -15,7 +15,7 @@ class QPushButton;
 class QSpinBox;
 class FIFOAnalyzer;
 
-class FIFOPlayerWindow : public QDialog
+class FIFOPlayerWindow : public QWidget
 {
   Q_OBJECT
 public:
@@ -44,6 +44,8 @@ private:
   void UpdateControls();
   void UpdateInfo();
   void UpdateLimits();
+
+  bool eventFilter(QObject* object, QEvent* event) final override;
 
   QLabel* m_info_label;
   QPushButton* m_load;

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1214,7 +1214,7 @@ void MainWindow::ShowFIFOPlayer()
 {
   if (!m_fifo_window)
   {
-    m_fifo_window = new FIFOPlayerWindow(this);
+    m_fifo_window = new FIFOPlayerWindow;
     connect(m_fifo_window, &FIFOPlayerWindow::LoadFIFORequested, this,
             [this](const QString& path) { StartGame(path, ScanForSecondDisc::No); });
   }

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -317,7 +317,7 @@ union UVAT_group0
   // 21:29
   BitField<21, 1, TexComponentCount> Tex0CoordElements;
   BitField<22, 3, ComponentFormat> Tex0CoordFormat;
-  BitField<25, 5, u32> Tex0Frac;
+  BitField<25, 5, u8, u32> Tex0Frac;
   // 30:31
   BitField<30, 1, bool, u32> ByteDequant;
   BitField<31, 1, bool, u32> NormalIndex3;
@@ -363,15 +363,15 @@ union UVAT_group1
   // 0:8
   BitField<0, 1, TexComponentCount> Tex1CoordElements;
   BitField<1, 3, ComponentFormat> Tex1CoordFormat;
-  BitField<4, 5, u32> Tex1Frac;
+  BitField<4, 5, u8, u32> Tex1Frac;
   // 9:17
   BitField<9, 1, TexComponentCount> Tex2CoordElements;
   BitField<10, 3, ComponentFormat> Tex2CoordFormat;
-  BitField<13, 5, u32> Tex2Frac;
+  BitField<13, 5, u8, u32> Tex2Frac;
   // 18:26
   BitField<18, 1, TexComponentCount> Tex3CoordElements;
   BitField<19, 3, ComponentFormat> Tex3CoordFormat;
-  BitField<22, 5, u32> Tex3Frac;
+  BitField<22, 5, u8, u32> Tex3Frac;
   // 27:30
   BitField<27, 1, TexComponentCount> Tex4CoordElements;
   BitField<28, 3, ComponentFormat> Tex4CoordFormat;
@@ -410,19 +410,19 @@ union UVAT_group2
 {
   u32 Hex;
   // 0:4
-  BitField<0, 5, u32> Tex4Frac;
+  BitField<0, 5, u8, u32> Tex4Frac;
   // 5:13
   BitField<5, 1, TexComponentCount> Tex5CoordElements;
   BitField<6, 3, ComponentFormat> Tex5CoordFormat;
-  BitField<9, 5, u32> Tex5Frac;
+  BitField<9, 5, u8, u32> Tex5Frac;
   // 14:22
   BitField<14, 1, TexComponentCount> Tex6CoordElements;
   BitField<15, 3, ComponentFormat> Tex6CoordFormat;
-  BitField<18, 5, u32> Tex6Frac;
+  BitField<18, 5, u8, u32> Tex6Frac;
   // 23:31
   BitField<23, 1, TexComponentCount> Tex7CoordElements;
   BitField<24, 3, ComponentFormat> Tex7CoordFormat;
-  BitField<27, 5, u32> Tex7Frac;
+  BitField<27, 5, u8, u32> Tex7Frac;
 };
 template <>
 struct fmt::formatter<UVAT_group2>
@@ -450,30 +450,123 @@ struct fmt::formatter<UVAT_group2>
   }
 };
 
-struct ColorAttr
+struct VAT
 {
-  ColorComponentCount Elements;
-  ColorFormat Comp;
-};
+  UVAT_group0 g0;
+  UVAT_group1 g1;
+  UVAT_group2 g2;
 
-struct TexAttr
-{
-  TexComponentCount Elements;
-  ComponentFormat Format;
-  u8 Frac;
+  constexpr ColorComponentCount GetColorElements(size_t idx) const
+  {
+    switch (idx)
+    {
+    case 0:
+      return g0.Color0Elements;
+    case 1:
+      return g0.Color1Elements;
+    default:
+      PanicAlertFmt("Invalid color index {}", idx);
+      return ColorComponentCount::RGB;
+    }
+  }
+  constexpr ColorFormat GetColorFormat(size_t idx) const
+  {
+    switch (idx)
+    {
+    case 0:
+      return g0.Color0Comp;
+    case 1:
+      return g0.Color1Comp;
+    default:
+      PanicAlertFmt("Invalid color index {}", idx);
+      return ColorFormat::RGB565;
+    }
+  }
+  constexpr TexComponentCount GetTexElements(size_t idx) const
+  {
+    switch (idx)
+    {
+    case 0:
+      return g0.Tex0CoordElements;
+    case 1:
+      return g1.Tex1CoordElements;
+    case 2:
+      return g1.Tex2CoordElements;
+    case 3:
+      return g1.Tex3CoordElements;
+    case 4:
+      return g1.Tex4CoordElements;
+    case 5:
+      return g2.Tex5CoordElements;
+    case 6:
+      return g2.Tex6CoordElements;
+    case 7:
+      return g2.Tex7CoordElements;
+    default:
+      PanicAlertFmt("Invalid tex coord index {}", idx);
+      return TexComponentCount::S;
+    }
+  }
+  constexpr ComponentFormat GetTexFormat(size_t idx) const
+  {
+    switch (idx)
+    {
+    case 0:
+      return g0.Tex0CoordFormat;
+    case 1:
+      return g1.Tex1CoordFormat;
+    case 2:
+      return g1.Tex2CoordFormat;
+    case 3:
+      return g1.Tex3CoordFormat;
+    case 4:
+      return g1.Tex4CoordFormat;
+    case 5:
+      return g2.Tex5CoordFormat;
+    case 6:
+      return g2.Tex6CoordFormat;
+    case 7:
+      return g2.Tex7CoordFormat;
+    default:
+      PanicAlertFmt("Invalid tex coord index {}", idx);
+      return ComponentFormat::UByte;
+    }
+  }
+  constexpr u8 GetTexFrac(size_t idx) const
+  {
+    switch (idx)
+    {
+    case 0:
+      return g0.Tex0Frac;
+    case 1:
+      return g1.Tex1Frac;
+    case 2:
+      return g1.Tex2Frac;
+    case 3:
+      return g1.Tex3Frac;
+    case 4:
+      return g2.Tex4Frac;
+    case 5:
+      return g2.Tex5Frac;
+    case 6:
+      return g2.Tex6Frac;
+    case 7:
+      return g2.Tex7Frac;
+    default:
+      PanicAlertFmt("Invalid tex coord index {}", idx);
+      return 0;
+    }
+  }
 };
-
-struct TVtxAttr
+template <>
+struct fmt::formatter<VAT>
 {
-  CoordComponentCount PosElements;
-  ComponentFormat PosFormat;
-  u8 PosFrac;
-  NormalComponentCount NormalElements;
-  ComponentFormat NormalFormat;
-  ColorAttr color[2];
-  TexAttr texCoord[8];
-  bool ByteDequant;
-  u8 NormalIndex3;
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const VAT& vat, FormatContext& ctx)
+  {
+    return format_to(ctx.out(), "{}\n{}\n{}", vat.g0, vat.g1, vat.g2);
+  }
 };
 
 // Matrix indices
@@ -515,23 +608,6 @@ struct fmt::formatter<TMatrixIndexB>
   {
     return format_to(ctx.out(), "Tex4: {}\nTex5: {}\nTex6: {}\nTex7: {}", m.Tex4MtxIdx,
                      m.Tex5MtxIdx, m.Tex6MtxIdx, m.Tex7MtxIdx);
-  }
-};
-
-struct VAT
-{
-  UVAT_group0 g0;
-  UVAT_group1 g1;
-  UVAT_group2 g2;
-};
-template <>
-struct fmt::formatter<VAT>
-{
-  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-  template <typename FormatContext>
-  auto format(const VAT& vat, FormatContext& ctx)
-  {
-    return format_to(ctx.out(), "{}\n{}\n{}", vat.g0, vat.g1, vat.g2);
   }
 };
 

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -319,8 +319,8 @@ union UVAT_group0
   BitField<22, 3, ComponentFormat> Tex0CoordFormat;
   BitField<25, 5, u32> Tex0Frac;
   // 30:31
-  BitField<30, 1, u32> ByteDequant;
-  BitField<31, 1, u32> NormalIndex3;
+  BitField<30, 1, bool, u32> ByteDequant;
+  BitField<31, 1, bool, u32> NormalIndex3;
 };
 template <>
 struct fmt::formatter<UVAT_group0>
@@ -376,7 +376,7 @@ union UVAT_group1
   BitField<27, 1, TexComponentCount> Tex4CoordElements;
   BitField<28, 3, ComponentFormat> Tex4CoordFormat;
   // 31
-  BitField<31, 1, u32> VCacheEnhance;
+  BitField<31, 1, bool, u32> VCacheEnhance;
 };
 template <>
 struct fmt::formatter<UVAT_group1>

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -63,6 +63,11 @@ enum
   ARRAY_TEXCOORD0 = 4,
   NUM_TEXCOORD_ARRAYS = 8,
 
+  ARRAY_XF_A = 12,  // Usually used for position matrices
+  ARRAY_XF_B = 13,  // Usually used for normal matrices
+  ARRAY_XF_C = 14,  // Usually used for tex coord matrices
+  ARRAY_XF_D = 15,  // Usually used for light objects
+
   // Number of arrays related to vertex components (position, normal, color, tex coord)
   // Excludes the 4 arrays used for indexed XF loads
   NUM_VERTEX_COMPONENT_ARRAYS = 12,

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -524,6 +524,16 @@ struct VAT
   UVAT_group1 g1;
   UVAT_group2 g2;
 };
+template <>
+struct fmt::formatter<VAT>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const VAT& vat, FormatContext& ctx)
+  {
+    return format_to(ctx.out(), "{}\n{}\n{}", vat.g0, vat.g1, vat.g2);
+  }
+};
 
 class VertexLoaderBase;
 

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -268,7 +268,8 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
     // Display lists get added directly into the FIFO stream
     if constexpr (!is_preprocess)
     {
-      if (g_record_fifo_data && cmd_byte != GX_CMD_CALL_DL)
+      //if (g_record_fifo_data && cmd_byte != GX_CMD_CALL_DL)
+      if (g_record_fifo_data && !in_display_list)
       {
         const u8* const opcode_end = src.GetPointer();
         FifoRecorder::GetInstance().WriteGPCommand(opcode_start, u32(opcode_end - opcode_start));

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -79,12 +79,8 @@ VertexLoader::VertexLoader(const TVtxDesc& vtx_desc, const VAT& vtx_attr)
 
 void VertexLoader::CompileVertexTranslator()
 {
-  m_VertexSize = 0;
-
   // Reset pipeline
   m_numPipelineStages = 0;
-
-  u32 components = 0;
 
   // Position in pc vertex format.
   int nat_offset = 0;
@@ -93,71 +89,24 @@ void VertexLoader::CompileVertexTranslator()
   if (m_VtxDesc.low.PosMatIdx)
   {
     WriteCall(PosMtx_ReadDirect_UByte);
-    components |= VB_HAS_POSMTXIDX;
     m_native_vtx_decl.posmtx.components = 4;
     m_native_vtx_decl.posmtx.enable = true;
     m_native_vtx_decl.posmtx.offset = nat_offset;
     m_native_vtx_decl.posmtx.type = VAR_UNSIGNED_BYTE;
     m_native_vtx_decl.posmtx.integer = true;
     nat_offset += 4;
-    m_VertexSize += 1;
   }
 
-  if (m_VtxDesc.low.Tex0MatIdx)
+  for (auto texmtxidx : m_VtxDesc.low.TexMatIdx)
   {
-    m_VertexSize += 1;
-    components |= VB_HAS_TEXMTXIDX0;
-    WriteCall(TexMtx_ReadDirect_UByte);
-  }
-  if (m_VtxDesc.low.Tex1MatIdx)
-  {
-    m_VertexSize += 1;
-    components |= VB_HAS_TEXMTXIDX1;
-    WriteCall(TexMtx_ReadDirect_UByte);
-  }
-  if (m_VtxDesc.low.Tex2MatIdx)
-  {
-    m_VertexSize += 1;
-    components |= VB_HAS_TEXMTXIDX2;
-    WriteCall(TexMtx_ReadDirect_UByte);
-  }
-  if (m_VtxDesc.low.Tex3MatIdx)
-  {
-    m_VertexSize += 1;
-    components |= VB_HAS_TEXMTXIDX3;
-    WriteCall(TexMtx_ReadDirect_UByte);
-  }
-  if (m_VtxDesc.low.Tex4MatIdx)
-  {
-    m_VertexSize += 1;
-    components |= VB_HAS_TEXMTXIDX4;
-    WriteCall(TexMtx_ReadDirect_UByte);
-  }
-  if (m_VtxDesc.low.Tex5MatIdx)
-  {
-    m_VertexSize += 1;
-    components |= VB_HAS_TEXMTXIDX5;
-    WriteCall(TexMtx_ReadDirect_UByte);
-  }
-  if (m_VtxDesc.low.Tex6MatIdx)
-  {
-    m_VertexSize += 1;
-    components |= VB_HAS_TEXMTXIDX6;
-    WriteCall(TexMtx_ReadDirect_UByte);
-  }
-  if (m_VtxDesc.low.Tex7MatIdx)
-  {
-    m_VertexSize += 1;
-    components |= VB_HAS_TEXMTXIDX7;
-    WriteCall(TexMtx_ReadDirect_UByte);
+    if (texmtxidx)
+      WriteCall(TexMtx_ReadDirect_UByte);
   }
 
   // Write vertex position loader
   WriteCall(VertexLoader_Position::GetFunction(m_VtxDesc.low.Position, m_VtxAttr.g0.PosFormat,
                                                m_VtxAttr.g0.PosElements));
 
-  m_VertexSize += VertexLoader_Position::GetSize(m_VtxDesc.low.Position, m_VtxAttr.g0.PosFormat,
-                                                 m_VtxAttr.g0.PosElements);
   int pos_elements = m_VtxAttr.g0.PosElements == CoordComponentCount::XY ? 2 : 3;
   m_native_vtx_decl.position.components = pos_elements;
   m_native_vtx_decl.position.enable = true;
@@ -169,10 +118,6 @@ void VertexLoader::CompileVertexTranslator()
   // Normals
   if (m_VtxDesc.low.Normal != VertexComponentFormat::NotPresent)
   {
-    m_VertexSize +=
-        VertexLoader_Normal::GetSize(m_VtxDesc.low.Normal, m_VtxAttr.g0.NormalFormat,
-                                     m_VtxAttr.g0.NormalElements, m_VtxAttr.g0.NormalIndex3);
-
     TPipelineFunction pFunc =
         VertexLoader_Normal::GetFunction(m_VtxDesc.low.Normal, m_VtxAttr.g0.NormalFormat,
                                          m_VtxAttr.g0.NormalElements, m_VtxAttr.g0.NormalIndex3);
@@ -194,10 +139,6 @@ void VertexLoader::CompileVertexTranslator()
       m_native_vtx_decl.normals[i].integer = false;
       nat_offset += 12;
     }
-
-    components |= VB_HAS_NRM0;
-    if (m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT)
-      components |= VB_HAS_NRM1 | VB_HAS_NRM2;
   }
 
   for (size_t i = 0; i < m_VtxDesc.low.Color.Size(); i++)
@@ -206,8 +147,6 @@ void VertexLoader::CompileVertexTranslator()
     m_native_vtx_decl.colors[i].type = VAR_UNSIGNED_BYTE;
     m_native_vtx_decl.colors[i].integer = false;
 
-    m_VertexSize +=
-        VertexLoader_Color::GetSize(m_VtxDesc.low.Color[i], m_VtxAttr.GetColorFormat(i));
     TPipelineFunction pFunc =
         VertexLoader_Color::GetFunction(m_VtxDesc.low.Color[i], m_VtxAttr.GetColorFormat(i));
 
@@ -218,7 +157,6 @@ void VertexLoader::CompileVertexTranslator()
 
     if (m_VtxDesc.low.Color[i] != VertexComponentFormat::NotPresent)
     {
-      components |= VB_HAS_COL0 << i;
       m_native_vtx_decl.colors[i].offset = nat_offset;
       m_native_vtx_decl.colors[i].enable = true;
       nat_offset += 4;
@@ -245,25 +183,21 @@ void VertexLoader::CompileVertexTranslator()
       ASSERT_MSG(VIDEO, elements == TexComponentCount::S || elements == TexComponentCount::ST,
                  "Invalid number of texture coordinates elements!\n(elements = %d)", (u32)elements);
 
-      components |= VB_HAS_UV0 << i;
       WriteCall(VertexLoader_TextCoord::GetFunction(tc, format, elements));
-      m_VertexSize += VertexLoader_TextCoord::GetSize(tc, format, elements);
     }
 
-    if (components & (VB_HAS_TEXMTXIDX0 << i))
+    if (m_VtxDesc.low.TexMatIdx[i])
     {
       m_native_vtx_decl.texcoords[i].enable = true;
+      m_native_vtx_decl.texcoords[i].components = 3;
+      nat_offset += 12;
       if (tc != VertexComponentFormat::NotPresent)
       {
         // if texmtx is included, texcoord will always be 3 floats, z will be the texmtx index
-        m_native_vtx_decl.texcoords[i].components = 3;
-        nat_offset += 12;
         WriteCall(elements == TexComponentCount::ST ? TexMtx_Write_Float : TexMtx_Write_Float2);
       }
       else
       {
-        m_native_vtx_decl.texcoords[i].components = 3;
-        nat_offset += 12;
         WriteCall(TexMtx_Write_Float3);
       }
     }
@@ -280,17 +214,21 @@ void VertexLoader::CompileVertexTranslator()
     if (tc == VertexComponentFormat::NotPresent)
     {
       // if there's more tex coords later, have to write a dummy call
-      size_t j = i + 1;
-      for (; j < m_VtxDesc.high.TexCoord.Size(); ++j)
+      bool has_more = false;
+      for (size_t j = 0; j < m_VtxDesc.high.TexCoord.Size(); ++j)
       {
         if (m_VtxDesc.high.TexCoord[j] != VertexComponentFormat::NotPresent)
         {
+          has_more = true;
           WriteCall(VertexLoader_TextCoord::GetDummyFunction());  // important to get indices right!
           break;
         }
+        else if (m_VtxDesc.low.TexMatIdx[i])
+        {
+          has_more = true;
+        }
       }
-      // tricky!
-      if (j == 8 && !((components & VB_HAS_TEXMTXIDXALL) & (VB_HAS_TEXMTXIDXALL << (i + 1))))
+      if (!has_more)
       {
         // no more tex coords and tex matrices, so exit loop
         break;
@@ -304,7 +242,6 @@ void VertexLoader::CompileVertexTranslator()
     WriteCall(SkipVertex);
   }
 
-  m_native_components = components;
   m_native_vtx_decl.stride = nat_offset;
 }
 

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -205,98 +205,16 @@ void VertexLoader::CompileVertexTranslator()
     m_native_vtx_decl.colors[i].components = 4;
     m_native_vtx_decl.colors[i].type = VAR_UNSIGNED_BYTE;
     m_native_vtx_decl.colors[i].integer = false;
-    switch (m_VtxDesc.low.Color[i])
-    {
-    case VertexComponentFormat::NotPresent:
-      break;
-    case VertexComponentFormat::Direct:
-      switch (m_VtxAttr.color[i].Comp)
-      {
-      case ColorFormat::RGB565:
-        m_VertexSize += 2;
-        WriteCall(Color_ReadDirect_16b_565);
-        break;
-      case ColorFormat::RGB888:
-        m_VertexSize += 3;
-        WriteCall(Color_ReadDirect_24b_888);
-        break;
-      case ColorFormat::RGB888x:
-        m_VertexSize += 4;
-        WriteCall(Color_ReadDirect_32b_888x);
-        break;
-      case ColorFormat::RGBA4444:
-        m_VertexSize += 2;
-        WriteCall(Color_ReadDirect_16b_4444);
-        break;
-      case ColorFormat::RGBA6666:
-        m_VertexSize += 3;
-        WriteCall(Color_ReadDirect_24b_6666);
-        break;
-      case ColorFormat::RGBA8888:
-        m_VertexSize += 4;
-        WriteCall(Color_ReadDirect_32b_8888);
-        break;
-      default:
-        ASSERT(0);
-        break;
-      }
-      break;
-    case VertexComponentFormat::Index8:
-      m_VertexSize += 1;
-      switch (m_VtxAttr.color[i].Comp)
-      {
-      case ColorFormat::RGB565:
-        WriteCall(Color_ReadIndex8_16b_565);
-        break;
-      case ColorFormat::RGB888:
-        WriteCall(Color_ReadIndex8_24b_888);
-        break;
-      case ColorFormat::RGB888x:
-        WriteCall(Color_ReadIndex8_32b_888x);
-        break;
-      case ColorFormat::RGBA4444:
-        WriteCall(Color_ReadIndex8_16b_4444);
-        break;
-      case ColorFormat::RGBA6666:
-        WriteCall(Color_ReadIndex8_24b_6666);
-        break;
-      case ColorFormat::RGBA8888:
-        WriteCall(Color_ReadIndex8_32b_8888);
-        break;
-      default:
-        ASSERT(0);
-        break;
-      }
-      break;
-    case VertexComponentFormat::Index16:
-      m_VertexSize += 2;
-      switch (m_VtxAttr.color[i].Comp)
-      {
-      case ColorFormat::RGB565:
-        WriteCall(Color_ReadIndex16_16b_565);
-        break;
-      case ColorFormat::RGB888:
-        WriteCall(Color_ReadIndex16_24b_888);
-        break;
-      case ColorFormat::RGB888x:
-        WriteCall(Color_ReadIndex16_32b_888x);
-        break;
-      case ColorFormat::RGBA4444:
-        WriteCall(Color_ReadIndex16_16b_4444);
-        break;
-      case ColorFormat::RGBA6666:
-        WriteCall(Color_ReadIndex16_24b_6666);
-        break;
-      case ColorFormat::RGBA8888:
-        WriteCall(Color_ReadIndex16_32b_8888);
-        break;
-      default:
-        ASSERT(0);
-        break;
-      }
-      break;
-    }
-    // Common for the three bottom cases
+
+    m_VertexSize += VertexLoader_Color::GetSize(m_VtxDesc.low.Color[i], m_VtxAttr.color[i].Comp);
+    TPipelineFunction pFunc =
+        VertexLoader_Color::GetFunction(m_VtxDesc.low.Color[i], m_VtxAttr.color[i].Comp);
+
+    if (pFunc != nullptr)
+      WriteCall(pFunc);
+    else
+      ASSERT(m_VtxDesc.low.Color[i] == VertexComponentFormat::NotPresent);
+
     if (m_VtxDesc.low.Color[i] != VertexComponentFormat::NotPresent)
     {
       components |= VB_HAS_COL0 << i;

--- a/Source/Core/VideoCommon/VertexLoader.h
+++ b/Source/Core/VideoCommon/VertexLoader.h
@@ -22,7 +22,6 @@ public:
   VertexLoader(const TVtxDesc& vtx_desc, const VAT& vtx_attr);
 
   int RunVertices(DataReader src, DataReader dst, int count) override;
-  std::string GetName() const override { return "OldLoader"; }
   bool IsInitialized() override { return true; }  // This vertex loader supports all formats
   // They are used for the communication with the loader functions
   float m_posScale;

--- a/Source/Core/VideoCommon/VertexLoader.h
+++ b/Source/Core/VideoCommon/VertexLoader.h
@@ -22,7 +22,6 @@ public:
   VertexLoader(const TVtxDesc& vtx_desc, const VAT& vtx_attr);
 
   int RunVertices(DataReader src, DataReader dst, int count) override;
-  bool IsInitialized() override { return true; }  // This vertex loader supports all formats
   // They are used for the communication with the loader functions
   float m_posScale;
   float m_tcScale[8];

--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -53,9 +53,6 @@ alignas(16) static const float scale_factors[] = {
 VertexLoaderARM64::VertexLoaderARM64(const TVtxDesc& vtx_desc, const VAT& vtx_att)
     : VertexLoaderBase(vtx_desc, vtx_att), m_float_emit(this)
 {
-  if (!IsInitialized())
-    return;
-
   AllocCodeSpace(4096);
   ClearCodeSpace();
   GenerateVertexLoader();

--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -393,10 +393,11 @@ void VertexLoaderARM64::GenerateVertexLoader()
   for (size_t i = 0; i < m_VtxDesc.high.TexCoord.Size(); i++)
   {
     has_tc |= m_VtxDesc.high.TexCoord[i] != VertexComponentFormat::NotPresent;
-    has_tc_scale |= !!m_VtxAttr.texCoord[i].Frac;
+    has_tc_scale |= (m_VtxAttr.GetTexFrac(i) != 0);
   }
 
-  bool need_scale = (m_VtxAttr.ByteDequant && m_VtxAttr.PosFrac) || (has_tc && has_tc_scale) ||
+  bool need_scale = (m_VtxAttr.g0.ByteDequant && m_VtxAttr.g0.PosFrac) ||
+                    (has_tc && has_tc_scale) ||
                     (m_VtxDesc.low.Normal != VertexComponentFormat::NotPresent);
 
   AlignCode16();
@@ -444,30 +445,30 @@ void VertexLoaderARM64::GenerateVertexLoader()
 
   // Position
   {
-    int elem_size = GetElementSize(m_VtxAttr.PosFormat);
-    int pos_elements = m_VtxAttr.PosElements == CoordComponentCount::XY ? 2 : 3;
+    int elem_size = GetElementSize(m_VtxAttr.g0.PosFormat);
+    int pos_elements = m_VtxAttr.g0.PosElements == CoordComponentCount::XY ? 2 : 3;
     int load_bytes = elem_size * pos_elements;
     int load_size = GetLoadSize(load_bytes);
     load_size <<= 3;
 
     s32 offset = GetAddressImm(ARRAY_POSITION, m_VtxDesc.low.Position, EncodeRegTo64(scratch1_reg),
                                load_size);
-    ReadVertex(m_VtxDesc.low.Position, m_VtxAttr.PosFormat, pos_elements, pos_elements,
-               m_VtxAttr.ByteDequant, m_VtxAttr.PosFrac, &m_native_vtx_decl.position, offset);
+    ReadVertex(m_VtxDesc.low.Position, m_VtxAttr.g0.PosFormat, pos_elements, pos_elements,
+               m_VtxAttr.g0.ByteDequant, m_VtxAttr.g0.PosFrac, &m_native_vtx_decl.position, offset);
   }
 
   if (m_VtxDesc.low.Normal != VertexComponentFormat::NotPresent)
   {
     static const u8 map[8] = {7, 6, 15, 14};
-    const u8 scaling_exponent = map[u32(m_VtxAttr.NormalFormat)];
-    const int limit = m_VtxAttr.NormalElements == NormalComponentCount::NBT ? 3 : 1;
+    const u8 scaling_exponent = map[u32(m_VtxAttr.g0.NormalFormat.Value())];
+    const int limit = m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT ? 3 : 1;
 
     s32 offset = -1;
-    for (int i = 0; i < (m_VtxAttr.NormalElements == NormalComponentCount::NBT ? 3 : 1); i++)
+    for (int i = 0; i < (m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT ? 3 : 1); i++)
     {
-      if (!i || m_VtxAttr.NormalIndex3)
+      if (!i || m_VtxAttr.g0.NormalIndex3)
       {
-        int elem_size = GetElementSize(m_VtxAttr.NormalFormat);
+        int elem_size = GetElementSize(m_VtxAttr.g0.NormalFormat);
 
         int load_bytes = elem_size * 3;
         int load_size = GetLoadSize(load_bytes);
@@ -480,7 +481,7 @@ void VertexLoaderARM64::GenerateVertexLoader()
         else
           offset += i * elem_size * 3;
       }
-      int bytes_read = ReadVertex(m_VtxDesc.low.Normal, m_VtxAttr.NormalFormat, 3, 3, true,
+      int bytes_read = ReadVertex(m_VtxDesc.low.Normal, m_VtxAttr.g0.NormalFormat, 3, 3, true,
                                   scaling_exponent, &m_native_vtx_decl.normals[i], offset);
 
       if (offset == -1)
@@ -490,7 +491,7 @@ void VertexLoaderARM64::GenerateVertexLoader()
     }
 
     m_native_components |= VB_HAS_NRM0;
-    if (m_VtxAttr.NormalElements == NormalComponentCount::NBT)
+    if (m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT)
       m_native_components |= VB_HAS_NRM1 | VB_HAS_NRM2;
   }
 
@@ -503,13 +504,13 @@ void VertexLoaderARM64::GenerateVertexLoader()
     if (m_VtxDesc.low.Color[i] != VertexComponentFormat::NotPresent)
     {
       u32 align = 4;
-      if (m_VtxAttr.color[i].Comp == ColorFormat::RGB565 ||
-          m_VtxAttr.color[i].Comp == ColorFormat::RGBA4444)
+      if (m_VtxAttr.GetColorFormat(i) == ColorFormat::RGB565 ||
+          m_VtxAttr.GetColorFormat(i) == ColorFormat::RGBA4444)
         align = 2;
 
       s32 offset = GetAddressImm(ARRAY_COLOR0 + int(i), m_VtxDesc.low.Color[i],
                                  EncodeRegTo64(scratch1_reg), align);
-      ReadColor(m_VtxDesc.low.Color[i], m_VtxAttr.color[i].Comp, offset);
+      ReadColor(m_VtxDesc.low.Color[i], m_VtxAttr.GetColorFormat(i), offset);
       m_native_components |= VB_HAS_COL0 << i;
       m_native_vtx_decl.colors[i].components = 4;
       m_native_vtx_decl.colors[i].enable = true;
@@ -526,22 +527,22 @@ void VertexLoaderARM64::GenerateVertexLoader()
     m_native_vtx_decl.texcoords[i].type = VAR_FLOAT;
     m_native_vtx_decl.texcoords[i].integer = false;
 
-    int elements = m_VtxAttr.texCoord[i].Elements == TexComponentCount::S ? 1 : 2;
+    int elements = m_VtxAttr.GetTexElements(i) == TexComponentCount::S ? 1 : 2;
     if (m_VtxDesc.high.TexCoord[i] != VertexComponentFormat::NotPresent)
     {
       m_native_components |= VB_HAS_UV0 << i;
 
-      int elem_size = GetElementSize(m_VtxAttr.texCoord[i].Format);
+      int elem_size = GetElementSize(m_VtxAttr.GetTexFormat(i));
       int load_bytes = elem_size * (elements + 2);
       int load_size = GetLoadSize(load_bytes);
       load_size <<= 3;
 
       s32 offset = GetAddressImm(ARRAY_TEXCOORD0 + int(i), m_VtxDesc.high.TexCoord[i],
                                  EncodeRegTo64(scratch1_reg), load_size);
-      u8 scaling_exponent = m_VtxAttr.texCoord[i].Frac;
-      ReadVertex(m_VtxDesc.high.TexCoord[i], m_VtxAttr.texCoord[i].Format, elements,
-                 m_VtxDesc.low.TexMatIdx[i] ? 2 : elements, m_VtxAttr.ByteDequant, scaling_exponent,
-                 &m_native_vtx_decl.texcoords[i], offset);
+      u8 scaling_exponent = m_VtxAttr.GetTexFrac(i);
+      ReadVertex(m_VtxDesc.high.TexCoord[i], m_VtxAttr.GetTexFormat(i), elements,
+                 m_VtxDesc.low.TexMatIdx[i] ? 2 : elements, m_VtxAttr.g0.ByteDequant,
+                 scaling_exponent, &m_native_vtx_decl.texcoords[i], offset);
     }
     if (m_VtxDesc.low.TexMatIdx[i])
     {

--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -423,7 +423,6 @@ void VertexLoaderARM64::GenerateVertexLoader()
     STR(IndexType::Unsigned, scratch1_reg, EncodeRegTo64(scratch2_reg), 0);
     SetJumpTarget(dont_store);
 
-    m_native_components |= VB_HAS_POSMTXIDX;
     m_native_vtx_decl.posmtx.components = 4;
     m_native_vtx_decl.posmtx.enable = true;
     m_native_vtx_decl.posmtx.offset = m_dst_ofs;
@@ -486,10 +485,6 @@ void VertexLoaderARM64::GenerateVertexLoader()
       else
         offset += bytes_read;
     }
-
-    m_native_components |= VB_HAS_NRM0;
-    if (m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT)
-      m_native_components |= VB_HAS_NRM1 | VB_HAS_NRM2;
   }
 
   for (size_t i = 0; i < m_VtxDesc.low.Color.Size(); i++)
@@ -508,7 +503,6 @@ void VertexLoaderARM64::GenerateVertexLoader()
       s32 offset = GetAddressImm(ARRAY_COLOR0 + int(i), m_VtxDesc.low.Color[i],
                                  EncodeRegTo64(scratch1_reg), align);
       ReadColor(m_VtxDesc.low.Color[i], m_VtxAttr.GetColorFormat(i), offset);
-      m_native_components |= VB_HAS_COL0 << i;
       m_native_vtx_decl.colors[i].components = 4;
       m_native_vtx_decl.colors[i].enable = true;
       m_native_vtx_decl.colors[i].offset = m_dst_ofs;
@@ -527,8 +521,6 @@ void VertexLoaderARM64::GenerateVertexLoader()
     int elements = m_VtxAttr.GetTexElements(i) == TexComponentCount::S ? 1 : 2;
     if (m_VtxDesc.high.TexCoord[i] != VertexComponentFormat::NotPresent)
     {
-      m_native_components |= VB_HAS_UV0 << i;
-
       int elem_size = GetElementSize(m_VtxAttr.GetTexFormat(i));
       int load_bytes = elem_size * (elements + 2);
       int load_size = GetLoadSize(load_bytes);
@@ -543,7 +535,6 @@ void VertexLoaderARM64::GenerateVertexLoader()
     }
     if (m_VtxDesc.low.TexMatIdx[i])
     {
-      m_native_components |= VB_HAS_TEXMTXIDX0 << i;
       m_native_vtx_decl.texcoords[i].components = 3;
       m_native_vtx_decl.texcoords[i].enable = true;
       m_native_vtx_decl.texcoords[i].type = VAR_FLOAT;
@@ -609,7 +600,7 @@ void VertexLoaderARM64::GenerateVertexLoader()
 
   FlushIcache();
 
-  m_VertexSize = m_src_ofs;
+  ASSERT(m_vertex_size == m_src_ofs);
   m_native_vtx_decl.stride = m_dst_ofs;
 }
 

--- a/Source/Core/VideoCommon/VertexLoaderARM64.h
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.h
@@ -19,7 +19,6 @@ public:
   VertexLoaderARM64(const TVtxDesc& vtx_desc, const VAT& vtx_att);
 
 protected:
-  bool IsInitialized() override { return true; }
   int RunVertices(DataReader src, DataReader dst, int count) override;
 
 private:

--- a/Source/Core/VideoCommon/VertexLoaderARM64.h
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.h
@@ -19,7 +19,6 @@ public:
   VertexLoaderARM64(const TVtxDesc& vtx_desc, const VAT& vtx_att);
 
 protected:
-  std::string GetName() const override { return "VertexLoaderARM64"; }
   bool IsInitialized() override { return true; }
   int RunVertices(DataReader src, DataReader dst, int count) override;
 

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -34,31 +34,23 @@ public:
                      const TVtxDesc& vtx_desc, const VAT& vtx_attr)
       : VertexLoaderBase(vtx_desc, vtx_attr), a(std::move(a_)), b(std::move(b_))
   {
-    m_initialized = a && b && a->IsInitialized() && b->IsInitialized();
-
-    if (m_initialized)
+    ASSERT(a && b);
+    if (a->m_VertexSize == b->m_VertexSize && a->m_native_components == b->m_native_components &&
+        a->m_native_vtx_decl.stride == b->m_native_vtx_decl.stride)
     {
-      m_initialized = a->m_VertexSize == b->m_VertexSize &&
-                      a->m_native_components == b->m_native_components &&
-                      a->m_native_vtx_decl.stride == b->m_native_vtx_decl.stride;
-
-      if (m_initialized)
-      {
-        m_VertexSize = a->m_VertexSize;
-        m_native_components = a->m_native_components;
-        memcpy(&m_native_vtx_decl, &a->m_native_vtx_decl, sizeof(PortableVertexDeclaration));
-      }
-      else
-      {
-        ERROR_LOG_FMT(VIDEO, "Can't compare vertex loaders that expect different vertex formats!");
-        ERROR_LOG_FMT(VIDEO, "a: m_VertexSize {}, m_native_components {:#010x}, stride {}",
-                      a->m_VertexSize, a->m_native_components, a->m_native_vtx_decl.stride);
-        ERROR_LOG_FMT(VIDEO, "b: m_VertexSize {}, m_native_components {:#010x}, stride {}",
-                      b->m_VertexSize, b->m_native_components, b->m_native_vtx_decl.stride);
-      }
+      m_VertexSize = a->m_VertexSize;
+      m_native_components = a->m_native_components;
+      memcpy(&m_native_vtx_decl, &a->m_native_vtx_decl, sizeof(PortableVertexDeclaration));
+    }
+    else
+    {
+      ERROR_LOG_FMT(VIDEO, "Can't compare vertex loaders that expect different vertex formats!");
+      ERROR_LOG_FMT(VIDEO, "a: m_VertexSize {}, m_native_components {:#010x}, stride {}",
+                    a->m_VertexSize, a->m_native_components, a->m_native_vtx_decl.stride);
+      ERROR_LOG_FMT(VIDEO, "b: m_VertexSize {}, m_native_components {:#010x}, stride {}",
+                    b->m_VertexSize, b->m_native_components, b->m_native_vtx_decl.stride);
     }
   }
-  ~VertexLoaderTester() override {}
   int RunVertices(DataReader src, DataReader dst, int count) override
   {
     buffer_a.resize(count * a->m_native_vtx_decl.stride + 4);
@@ -81,21 +73,17 @@ public:
                std::min(count_a, count_b) * m_native_vtx_decl.stride))
     {
       ERROR_LOG_FMT(VIDEO,
-                    "The two vertex loaders have loaded different data "
-                    "(guru meditation {:#010x}, {:#010x}, {:#010x}, {:#010x}, {:#010x}).",
-                    m_VtxDesc.low.Hex, m_VtxDesc.high.Hex, m_VtxAttr.g0.Hex, m_VtxAttr.g1.Hex,
-                    m_VtxAttr.g2.Hex);
+                    "The two vertex loaders have loaded different data.  Configuration:"
+                    "\nVertex desc:\n{}\n\nVertex attr:\n{}",
+                    m_VtxDesc, m_VtxAttr);
     }
 
     memcpy(dst.GetPointer(), buffer_a.data(), count_a * m_native_vtx_decl.stride);
     m_numLoadedVertices += count;
     return count_a;
   }
-  bool IsInitialized() override { return m_initialized; }
 
 private:
-  bool m_initialized;
-
   std::unique_ptr<VertexLoaderBase> a;
   std::unique_ptr<VertexLoaderBase> b;
 
@@ -106,33 +94,29 @@ private:
 std::unique_ptr<VertexLoaderBase> VertexLoaderBase::CreateVertexLoader(const TVtxDesc& vtx_desc,
                                                                        const VAT& vtx_attr)
 {
-  std::unique_ptr<VertexLoaderBase> loader;
+  std::unique_ptr<VertexLoaderBase> loader = nullptr;
 
   //#define COMPARE_VERTEXLOADERS
 
-#if defined(COMPARE_VERTEXLOADERS) && defined(_M_X86_64)
-  // first try: Any new VertexLoader vs the old one
-  loader = std::make_unique<VertexLoaderTester>(
-      std::make_unique<VertexLoader>(vtx_desc, vtx_attr),     // the software one
-      std::make_unique<VertexLoaderX64>(vtx_desc, vtx_attr),  // the new one to compare
-      vtx_desc, vtx_attr);
-  if (loader->IsInitialized())
-    return loader;
-#elif defined(_M_X86_64)
+#if defined(_M_X86_64)
   loader = std::make_unique<VertexLoaderX64>(vtx_desc, vtx_attr);
-  if (loader->IsInitialized())
-    return loader;
 #elif defined(_M_ARM_64)
   loader = std::make_unique<VertexLoaderARM64>(vtx_desc, vtx_attr);
-  if (loader->IsInitialized())
-    return loader;
 #endif
 
-  // last try: The old VertexLoader
-  loader = std::make_unique<VertexLoader>(vtx_desc, vtx_attr);
-  if (loader->IsInitialized())
-    return loader;
+  // Use the software loader as a fallback
+  // (not currently applicable, as both VertexLoaderX64 and VertexLoaderARM64
+  // are always usable, but if a loader that only works on some CPUs is created
+  // then this fallback would be used)
+  if (!loader)
+    loader = std::make_unique<VertexLoader>(vtx_desc, vtx_attr);
 
-  PanicAlertFmt("No Vertex Loader found.");
-  return nullptr;
+#if defined(COMPARE_VERTEXLOADERS)
+  return std::make_unique<VertexLoaderTester>(
+      std::make_unique<VertexLoader>(vtx_desc, vtx_attr),  // the software one
+      std::move(loader),                                   // the new one to compare
+      vtx_desc, vtx_attr);
+#else
+  return loader;
+#endif
 }

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -26,53 +26,6 @@
 #include "VideoCommon/VertexLoaderARM64.h"
 #endif
 
-VertexLoaderBase::VertexLoaderBase(const TVtxDesc& vtx_desc, const VAT& vtx_attr)
-    : m_VtxDesc{vtx_desc}, m_vat{vtx_attr}
-{
-  SetVAT(vtx_attr);
-}
-
-void VertexLoaderBase::SetVAT(const VAT& vat)
-{
-  m_VtxAttr.PosElements = vat.g0.PosElements;
-  m_VtxAttr.PosFormat = vat.g0.PosFormat;
-  m_VtxAttr.PosFrac = vat.g0.PosFrac;
-  m_VtxAttr.NormalElements = vat.g0.NormalElements;
-  m_VtxAttr.NormalFormat = vat.g0.NormalFormat;
-  m_VtxAttr.color[0].Elements = vat.g0.Color0Elements;
-  m_VtxAttr.color[0].Comp = vat.g0.Color0Comp;
-  m_VtxAttr.color[1].Elements = vat.g0.Color1Elements;
-  m_VtxAttr.color[1].Comp = vat.g0.Color1Comp;
-  m_VtxAttr.texCoord[0].Elements = vat.g0.Tex0CoordElements;
-  m_VtxAttr.texCoord[0].Format = vat.g0.Tex0CoordFormat;
-  m_VtxAttr.texCoord[0].Frac = vat.g0.Tex0Frac;
-  m_VtxAttr.ByteDequant = vat.g0.ByteDequant;
-  m_VtxAttr.NormalIndex3 = vat.g0.NormalIndex3;
-
-  m_VtxAttr.texCoord[1].Elements = vat.g1.Tex1CoordElements;
-  m_VtxAttr.texCoord[1].Format = vat.g1.Tex1CoordFormat;
-  m_VtxAttr.texCoord[1].Frac = vat.g1.Tex1Frac;
-  m_VtxAttr.texCoord[2].Elements = vat.g1.Tex2CoordElements;
-  m_VtxAttr.texCoord[2].Format = vat.g1.Tex2CoordFormat;
-  m_VtxAttr.texCoord[2].Frac = vat.g1.Tex2Frac;
-  m_VtxAttr.texCoord[3].Elements = vat.g1.Tex3CoordElements;
-  m_VtxAttr.texCoord[3].Format = vat.g1.Tex3CoordFormat;
-  m_VtxAttr.texCoord[3].Frac = vat.g1.Tex3Frac;
-  m_VtxAttr.texCoord[4].Elements = vat.g1.Tex4CoordElements;
-  m_VtxAttr.texCoord[4].Format = vat.g1.Tex4CoordFormat;
-
-  m_VtxAttr.texCoord[4].Frac = vat.g2.Tex4Frac;
-  m_VtxAttr.texCoord[5].Elements = vat.g2.Tex5CoordElements;
-  m_VtxAttr.texCoord[5].Format = vat.g2.Tex5CoordFormat;
-  m_VtxAttr.texCoord[5].Frac = vat.g2.Tex5Frac;
-  m_VtxAttr.texCoord[6].Elements = vat.g2.Tex6CoordElements;
-  m_VtxAttr.texCoord[6].Format = vat.g2.Tex6CoordFormat;
-  m_VtxAttr.texCoord[6].Frac = vat.g2.Tex6Frac;
-  m_VtxAttr.texCoord[7].Elements = vat.g2.Tex7CoordElements;
-  m_VtxAttr.texCoord[7].Format = vat.g2.Tex7CoordFormat;
-  m_VtxAttr.texCoord[7].Frac = vat.g2.Tex7Frac;
-};
-
 // a hacky implementation to compare two vertex loaders
 class VertexLoaderTester : public VertexLoaderBase
 {
@@ -130,8 +83,8 @@ public:
       ERROR_LOG_FMT(VIDEO,
                     "The two vertex loaders have loaded different data "
                     "(guru meditation {:#010x}, {:#010x}, {:#010x}, {:#010x}, {:#010x}).",
-                    m_VtxDesc.low.Hex, m_VtxDesc.high.Hex, m_vat.g0.Hex, m_vat.g1.Hex,
-                    m_vat.g2.Hex);
+                    m_VtxDesc.low.Hex, m_VtxDesc.high.Hex, m_VtxAttr.g0.Hex, m_VtxAttr.g1.Hex,
+                    m_VtxAttr.g2.Hex);
     }
 
     memcpy(dst.GetPointer(), buffer_a.data(), count_a * m_native_vtx_decl.stride);

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -73,46 +73,6 @@ void VertexLoaderBase::SetVAT(const VAT& vat)
   m_VtxAttr.texCoord[7].Frac = vat.g2.Tex7Frac;
 };
 
-std::string VertexLoaderBase::ToString() const
-{
-  std::string dest;
-  dest.reserve(250);
-
-  dest += GetName();
-  dest += ": ";
-
-  dest += fmt::format("{}b skin: {} P: {} {}-{} ", m_VertexSize, m_VtxDesc.low.PosMatIdx,
-                      m_VtxAttr.PosElements, m_VtxDesc.low.Position, m_VtxAttr.PosFormat);
-
-  if (m_VtxDesc.low.Normal != VertexComponentFormat::NotPresent)
-  {
-    dest += fmt::format("Nrm: {} {}-{} ", m_VtxAttr.NormalElements, m_VtxDesc.low.Normal,
-                        m_VtxAttr.NormalFormat);
-  }
-
-  for (size_t i = 0; i < g_main_cp_state.vtx_desc.low.Color.Size(); i++)
-  {
-    if (g_main_cp_state.vtx_desc.low.Color[i] == VertexComponentFormat::NotPresent)
-      continue;
-
-    const auto& color = m_VtxAttr.color[i];
-    dest += fmt::format("C{}: {} {}-{} ", i, color.Elements, g_main_cp_state.vtx_desc.low.Color[i],
-                        color.Comp);
-  }
-
-  for (size_t i = 0; i < g_main_cp_state.vtx_desc.high.TexCoord.Size(); i++)
-  {
-    if (g_main_cp_state.vtx_desc.high.TexCoord[i] == VertexComponentFormat::NotPresent)
-      continue;
-
-    const auto& tex_coord = m_VtxAttr.texCoord[i];
-    dest += fmt::format("T{}: {} {}-{} ", i, tex_coord.Elements,
-                        g_main_cp_state.vtx_desc.high.TexCoord[i], tex_coord.Format);
-  }
-  dest += fmt::format(" - {} v", m_numLoadedVertices);
-  return dest;
-}
-
 // a hacky implementation to compare two vertex loaders
 class VertexLoaderTester : public VertexLoaderBase
 {
@@ -178,7 +138,6 @@ public:
     m_numLoadedVertices += count;
     return count_a;
   }
-  std::string GetName() const override { return "CompareLoader"; }
   bool IsInitialized() override { return m_initialized; }
 
 private:

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -19,6 +19,10 @@
 
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/VertexLoader.h"
+#include "VideoCommon/VertexLoader_Color.h"
+#include "VideoCommon/VertexLoader_Normal.h"
+#include "VideoCommon/VertexLoader_Position.h"
+#include "VideoCommon/VertexLoader_TextCoord.h"
 
 #ifdef _M_X86_64
 #include "VideoCommon/VertexLoaderX64.h"
@@ -35,20 +39,22 @@ public:
       : VertexLoaderBase(vtx_desc, vtx_attr), a(std::move(a_)), b(std::move(b_))
   {
     ASSERT(a && b);
-    if (a->m_VertexSize == b->m_VertexSize && a->m_native_components == b->m_native_components &&
+    if (a->m_vertex_size == b->m_vertex_size && a->m_native_components == b->m_native_components &&
         a->m_native_vtx_decl.stride == b->m_native_vtx_decl.stride)
     {
-      m_VertexSize = a->m_VertexSize;
-      m_native_components = a->m_native_components;
+      // These are generated from the VAT and vertex desc, so they should match.
+      // m_native_vtx_decl.stride isn't set yet, though.
+      ASSERT(m_vertex_size == a->m_vertex_size && m_native_components == a->m_native_components);
+
       memcpy(&m_native_vtx_decl, &a->m_native_vtx_decl, sizeof(PortableVertexDeclaration));
     }
     else
     {
-      ERROR_LOG_FMT(VIDEO, "Can't compare vertex loaders that expect different vertex formats!");
-      ERROR_LOG_FMT(VIDEO, "a: m_VertexSize {}, m_native_components {:#010x}, stride {}",
-                    a->m_VertexSize, a->m_native_components, a->m_native_vtx_decl.stride);
-      ERROR_LOG_FMT(VIDEO, "b: m_VertexSize {}, m_native_components {:#010x}, stride {}",
-                    b->m_VertexSize, b->m_native_components, b->m_native_vtx_decl.stride);
+      PanicAlertFmt("Can't compare vertex loaders that expect different vertex formats!\n"
+                    "a: m_vertex_size {}, m_native_components {:#010x}, stride {}\n"
+                    "b: m_vertex_size {}, m_native_components {:#010x}, stride {}",
+                    a->m_vertex_size, a->m_native_components, a->m_native_vtx_decl.stride,
+                    b->m_vertex_size, b->m_native_components, b->m_native_vtx_decl.stride);
     }
   }
   int RunVertices(DataReader src, DataReader dst, int count) override
@@ -90,6 +96,62 @@ private:
   std::vector<u8> buffer_a;
   std::vector<u8> buffer_b;
 };
+
+u32 VertexLoaderBase::GetVertexSize(const TVtxDesc& vtx_desc, const VAT& vtx_attr)
+{
+  u32 size = 0;
+  if (vtx_desc.low.PosMatIdx)
+    size++;
+  for (auto texmtxidx : vtx_desc.low.TexMatIdx)
+  {
+    if (texmtxidx)
+      size++;
+  }
+  size += VertexLoader_Position::GetSize(vtx_desc.low.Position, vtx_attr.g0.PosFormat,
+                                         vtx_attr.g0.PosElements);
+  size += VertexLoader_Normal::GetSize(vtx_desc.low.Normal, vtx_attr.g0.NormalFormat,
+                                       vtx_attr.g0.NormalElements, vtx_attr.g0.NormalIndex3);
+  for (u32 i = 0; i < vtx_desc.low.Color.Size(); i++)
+  {
+    size += VertexLoader_Color::GetSize(vtx_desc.low.Color[i], vtx_attr.GetColorFormat(i));
+  }
+  for (u32 i = 0; i < vtx_desc.high.TexCoord.Size(); i++)
+  {
+    size += VertexLoader_TextCoord::GetSize(vtx_desc.high.TexCoord[i], vtx_attr.GetTexFormat(i),
+                                            vtx_attr.GetTexElements(i));
+  }
+  return size;
+}
+
+u32 VertexLoaderBase::GetVertexComponents(const TVtxDesc& vtx_desc, const VAT& vtx_attr)
+{
+  u32 components = 0;
+  if (vtx_desc.low.PosMatIdx)
+    components |= VB_HAS_POSMTXIDX;
+  for (u32 i = 0; i < vtx_desc.low.TexMatIdx.Size(); i++)
+  {
+    if (vtx_desc.low.TexMatIdx[i])
+      components |= VB_HAS_TEXMTXIDX0 << i;
+  }
+  // Vertices always have positions; thus there is no VB_HAS_POS as it would always be set
+  if (vtx_desc.low.Normal != VertexComponentFormat::NotPresent)
+  {
+    components |= VB_HAS_NRM0;
+    if (vtx_attr.g0.NormalElements == NormalComponentCount::NBT)
+      components |= VB_HAS_NRM1 | VB_HAS_NRM2;
+  }
+  for (u32 i = 0; i < vtx_desc.low.Color.Size(); i++)
+  {
+    if (vtx_desc.low.Color[i] != VertexComponentFormat::NotPresent)
+      components |= VB_HAS_COL0 << i;
+  }
+  for (u32 i = 0; i < vtx_desc.high.TexCoord.Size(); i++)
+  {
+    if (vtx_desc.high.TexCoord[i] != VertexComponentFormat::NotPresent)
+      components |= VB_HAS_UV0 << i;
+  }
+  return components;
+}
 
 std::unique_ptr<VertexLoaderBase> VertexLoaderBase::CreateVertexLoader(const TVtxDesc& vtx_desc,
                                                                        const VAT& vtx_attr)

--- a/Source/Core/VideoCommon/VertexLoaderBase.h
+++ b/Source/Core/VideoCommon/VertexLoaderBase.h
@@ -60,15 +60,17 @@ struct hash<VertexLoaderUID>
 class VertexLoaderBase
 {
 public:
+  static u32 GetVertexSize(const TVtxDesc& vtx_desc, const VAT& vtx_attr);
+  static u32 GetVertexComponents(const TVtxDesc& vtx_desc, const VAT& vtx_attr);
   static std::unique_ptr<VertexLoaderBase> CreateVertexLoader(const TVtxDesc& vtx_desc,
                                                               const VAT& vtx_attr);
   virtual ~VertexLoaderBase() {}
   virtual int RunVertices(DataReader src, DataReader dst, int count) = 0;
 
   // per loader public state
-  int m_VertexSize = 0;  // number of bytes of a raw GC vertex
   PortableVertexDeclaration m_native_vtx_decl{};
-  u32 m_native_components = 0;
+  const u32 m_vertex_size;  // number of bytes of a raw GC vertex
+  const u32 m_native_components;
 
   // used by VertexLoaderManager
   NativeVertexFormat* m_native_vertex_format = nullptr;
@@ -76,7 +78,10 @@ public:
 
 protected:
   VertexLoaderBase(const TVtxDesc& vtx_desc, const VAT& vtx_attr)
-      : m_VtxDesc{vtx_desc}, m_VtxAttr{vtx_attr} {};
+      : m_VtxDesc{vtx_desc}, m_VtxAttr{vtx_attr}, m_vertex_size{GetVertexSize(vtx_desc, vtx_attr)},
+        m_native_components{GetVertexComponents(vtx_desc, vtx_attr)}
+  {
+  }
 
   // GC vertex format
   const VAT m_VtxAttr;

--- a/Source/Core/VideoCommon/VertexLoaderBase.h
+++ b/Source/Core/VideoCommon/VertexLoaderBase.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/CPMemory.h"
@@ -62,6 +63,7 @@ class VertexLoaderBase
 public:
   static u32 GetVertexSize(const TVtxDesc& vtx_desc, const VAT& vtx_attr);
   static u32 GetVertexComponents(const TVtxDesc& vtx_desc, const VAT& vtx_attr);
+  static std::vector<u32> GetVertexComponentSizes(const TVtxDesc& vtx_desc, const VAT& vtx_attr);
   static std::unique_ptr<VertexLoaderBase> CreateVertexLoader(const TVtxDesc& vtx_desc,
                                                               const VAT& vtx_attr);
   virtual ~VertexLoaderBase() {}

--- a/Source/Core/VideoCommon/VertexLoaderBase.h
+++ b/Source/Core/VideoCommon/VertexLoaderBase.h
@@ -65,8 +65,6 @@ public:
   virtual ~VertexLoaderBase() {}
   virtual int RunVertices(DataReader src, DataReader dst, int count) = 0;
 
-  virtual bool IsInitialized() = 0;
-
   // per loader public state
   int m_VertexSize = 0;  // number of bytes of a raw GC vertex
   PortableVertexDeclaration m_native_vtx_decl{};

--- a/Source/Core/VideoCommon/VertexLoaderBase.h
+++ b/Source/Core/VideoCommon/VertexLoaderBase.h
@@ -67,11 +67,6 @@ public:
 
   virtual bool IsInitialized() = 0;
 
-  // For debugging / profiling
-  std::string ToString() const;
-
-  virtual std::string GetName() const = 0;
-
   // per loader public state
   int m_VertexSize = 0;  // number of bytes of a raw GC vertex
   PortableVertexDeclaration m_native_vtx_decl{};

--- a/Source/Core/VideoCommon/VertexLoaderBase.h
+++ b/Source/Core/VideoCommon/VertexLoaderBase.h
@@ -77,11 +77,10 @@ public:
   int m_numLoadedVertices = 0;
 
 protected:
-  VertexLoaderBase(const TVtxDesc& vtx_desc, const VAT& vtx_attr);
-  void SetVAT(const VAT& vat);
+  VertexLoaderBase(const TVtxDesc& vtx_desc, const VAT& vtx_attr)
+      : m_VtxDesc{vtx_desc}, m_VtxAttr{vtx_attr} {};
 
   // GC vertex format
-  TVtxAttr m_VtxAttr;  // VAT decoded into easy format
-  TVtxDesc m_VtxDesc;  // Not really used currently - or well it is, but could be easily avoided.
-  VAT m_vat;
+  const VAT m_VtxAttr;
+  const TVtxDesc m_VtxDesc;
 };

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -114,34 +114,6 @@ struct entry
 };
 }  // namespace
 
-std::string VertexLoadersToString()
-{
-  std::lock_guard<std::mutex> lk(s_vertex_loader_map_lock);
-  std::vector<entry> entries;
-
-  size_t total_size = 0;
-  for (const auto& map_entry : s_vertex_loader_map)
-  {
-    entry e = {map_entry.second->ToString(),
-               static_cast<u64>(map_entry.second->m_numLoadedVertices)};
-
-    total_size += e.text.size() + 1;
-    entries.push_back(std::move(e));
-  }
-
-  sort(entries.begin(), entries.end());
-
-  std::string dest;
-  dest.reserve(total_size);
-  for (const entry& entry : entries)
-  {
-    dest += entry.text;
-    dest += '\n';
-  }
-
-  return dest;
-}
-
 void MarkAllDirty()
 {
   g_main_cp_state.attr_dirty = BitSet32::AllTrue(8);

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -247,7 +247,7 @@ int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bo
 
   VertexLoaderBase* loader = RefreshLoader(vtx_attr_group, is_preprocess);
 
-  int size = count * loader->m_VertexSize;
+  int size = count * loader->m_vertex_size;
   if ((int)src.size() < size)
     return -1;
 

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -38,9 +38,6 @@ NativeVertexFormat* GetUberVertexFormat(const PortableVertexDeclaration& decl);
 // Returns -1 if buf_size is insufficient, else the amount of bytes consumed
 int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bool is_preprocess);
 
-// For debugging
-std::string VertexLoadersToString();
-
 NativeVertexFormat* GetCurrentVertexFormat();
 
 // Resolved pointers to array bases. Used by vertex loaders.

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -45,9 +45,6 @@ static OpArg MPIC(const void* ptr)
 VertexLoaderX64::VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att)
     : VertexLoaderBase(vtx_desc, vtx_att)
 {
-  if (!IsInitialized())
-    return;
-
   AllocCodeSpace(4096);
   ClearCodeSpace();
   GenerateVertexLoader();

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -53,7 +53,8 @@ VertexLoaderX64::VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att)
   GenerateVertexLoader();
   WriteProtect();
 
-  const std::string name = ToString();
+  const std::string name =
+      fmt::format("VertexLoaderX64\nVtx desc: \n{}\nVAT:\n{}", vtx_desc, vtx_att);
   JitRegister::Register(region, GetCodePtr(), name.c_str());
 }
 

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -418,7 +418,6 @@ void VertexLoaderX64::GenerateVertexLoader()
     MOV(32, MPIC(VertexLoaderManager::position_matrix_index, count_reg, SCALE_4), R(scratch1));
     SetJumpTarget(dont_store);
 
-    m_native_components |= VB_HAS_POSMTXIDX;
     m_native_vtx_decl.posmtx.components = 4;
     m_native_vtx_decl.posmtx.enable = true;
     m_native_vtx_decl.posmtx.offset = m_dst_ofs;
@@ -457,10 +456,6 @@ void VertexLoaderX64::GenerateVertexLoader()
       data.AddMemOffset(ReadVertex(data, m_VtxDesc.low.Normal, m_VtxAttr.g0.NormalFormat, 3, 3,
                                    true, scaling_exponent, &m_native_vtx_decl.normals[i]));
     }
-
-    m_native_components |= VB_HAS_NRM0;
-    if (m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT)
-      m_native_components |= VB_HAS_NRM1 | VB_HAS_NRM2;
   }
 
   for (size_t i = 0; i < m_VtxDesc.low.Color.Size(); i++)
@@ -469,7 +464,6 @@ void VertexLoaderX64::GenerateVertexLoader()
     {
       data = GetVertexAddr(ARRAY_COLOR0 + int(i), m_VtxDesc.low.Color[i]);
       ReadColor(data, m_VtxDesc.low.Color[i], m_VtxAttr.GetColorFormat(i));
-      m_native_components |= VB_HAS_COL0 << i;
       m_native_vtx_decl.colors[i].components = 4;
       m_native_vtx_decl.colors[i].enable = true;
       m_native_vtx_decl.colors[i].offset = m_dst_ofs;
@@ -489,11 +483,9 @@ void VertexLoaderX64::GenerateVertexLoader()
       ReadVertex(data, m_VtxDesc.high.TexCoord[i], m_VtxAttr.GetTexFormat(i), elements,
                  m_VtxDesc.low.TexMatIdx[i] ? 2 : elements, m_VtxAttr.g0.ByteDequant,
                  scaling_exponent, &m_native_vtx_decl.texcoords[i]);
-      m_native_components |= VB_HAS_UV0 << i;
     }
     if (m_VtxDesc.low.TexMatIdx[i])
     {
-      m_native_components |= VB_HAS_TEXMTXIDX0 << i;
       m_native_vtx_decl.texcoords[i].components = 3;
       m_native_vtx_decl.texcoords[i].enable = true;
       m_native_vtx_decl.texcoords[i].type = VAR_FLOAT;
@@ -544,7 +536,7 @@ void VertexLoaderX64::GenerateVertexLoader()
     RET();
   }
 
-  m_VertexSize = m_src_ofs;
+  ASSERT(m_vertex_size == m_src_ofs);
   m_native_vtx_decl.stride = m_dst_ofs;
 }
 

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -439,30 +439,30 @@ void VertexLoaderX64::GenerateVertexLoader()
   }
 
   OpArg data = GetVertexAddr(ARRAY_POSITION, m_VtxDesc.low.Position);
-  int pos_elements = m_VtxAttr.PosElements == CoordComponentCount::XY ? 2 : 3;
-  ReadVertex(data, m_VtxDesc.low.Position, m_VtxAttr.PosFormat, pos_elements, pos_elements,
-             m_VtxAttr.ByteDequant, m_VtxAttr.PosFrac, &m_native_vtx_decl.position);
+  int pos_elements = m_VtxAttr.g0.PosElements == CoordComponentCount::XY ? 2 : 3;
+  ReadVertex(data, m_VtxDesc.low.Position, m_VtxAttr.g0.PosFormat, pos_elements, pos_elements,
+             m_VtxAttr.g0.ByteDequant, m_VtxAttr.g0.PosFrac, &m_native_vtx_decl.position);
 
   if (m_VtxDesc.low.Normal != VertexComponentFormat::NotPresent)
   {
     static const u8 map[8] = {7, 6, 15, 14};
-    const u8 scaling_exponent = map[u32(m_VtxAttr.NormalFormat)];
-    const int limit = m_VtxAttr.NormalElements == NormalComponentCount::NBT ? 3 : 1;
+    const u8 scaling_exponent = map[u32(m_VtxAttr.g0.NormalFormat.Value())];
+    const int limit = m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT ? 3 : 1;
 
     for (int i = 0; i < limit; i++)
     {
-      if (!i || m_VtxAttr.NormalIndex3)
+      if (!i || m_VtxAttr.g0.NormalIndex3)
       {
         data = GetVertexAddr(ARRAY_NORMAL, m_VtxDesc.low.Normal);
-        int elem_size = GetElementSize(m_VtxAttr.NormalFormat);
+        int elem_size = GetElementSize(m_VtxAttr.g0.NormalFormat);
         data.AddMemOffset(i * elem_size * 3);
       }
-      data.AddMemOffset(ReadVertex(data, m_VtxDesc.low.Normal, m_VtxAttr.NormalFormat, 3, 3, true,
-                                   scaling_exponent, &m_native_vtx_decl.normals[i]));
+      data.AddMemOffset(ReadVertex(data, m_VtxDesc.low.Normal, m_VtxAttr.g0.NormalFormat, 3, 3,
+                                   true, scaling_exponent, &m_native_vtx_decl.normals[i]));
     }
 
     m_native_components |= VB_HAS_NRM0;
-    if (m_VtxAttr.NormalElements == NormalComponentCount::NBT)
+    if (m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT)
       m_native_components |= VB_HAS_NRM1 | VB_HAS_NRM2;
   }
 
@@ -471,7 +471,7 @@ void VertexLoaderX64::GenerateVertexLoader()
     if (m_VtxDesc.low.Color[i] != VertexComponentFormat::NotPresent)
     {
       data = GetVertexAddr(ARRAY_COLOR0 + int(i), m_VtxDesc.low.Color[i]);
-      ReadColor(data, m_VtxDesc.low.Color[i], m_VtxAttr.color[i].Comp);
+      ReadColor(data, m_VtxDesc.low.Color[i], m_VtxAttr.GetColorFormat(i));
       m_native_components |= VB_HAS_COL0 << i;
       m_native_vtx_decl.colors[i].components = 4;
       m_native_vtx_decl.colors[i].enable = true;
@@ -484,14 +484,14 @@ void VertexLoaderX64::GenerateVertexLoader()
 
   for (size_t i = 0; i < m_VtxDesc.high.TexCoord.Size(); i++)
   {
-    int elements = m_VtxAttr.texCoord[i].Elements == TexComponentCount::ST ? 2 : 1;
+    int elements = m_VtxAttr.GetTexElements(i) == TexComponentCount::ST ? 2 : 1;
     if (m_VtxDesc.high.TexCoord[i] != VertexComponentFormat::NotPresent)
     {
       data = GetVertexAddr(ARRAY_TEXCOORD0 + int(i), m_VtxDesc.high.TexCoord[i]);
-      u8 scaling_exponent = m_VtxAttr.texCoord[i].Frac;
-      ReadVertex(data, m_VtxDesc.high.TexCoord[i], m_VtxAttr.texCoord[i].Format, elements,
-                 m_VtxDesc.low.TexMatIdx[i] ? 2 : elements, m_VtxAttr.ByteDequant, scaling_exponent,
-                 &m_native_vtx_decl.texcoords[i]);
+      u8 scaling_exponent = m_VtxAttr.GetTexFrac(i);
+      ReadVertex(data, m_VtxDesc.high.TexCoord[i], m_VtxAttr.GetTexFormat(i), elements,
+                 m_VtxDesc.low.TexMatIdx[i] ? 2 : elements, m_VtxAttr.g0.ByteDequant,
+                 scaling_exponent, &m_native_vtx_decl.texcoords[i]);
       m_native_components |= VB_HAS_UV0 << i;
     }
     if (m_VtxDesc.low.TexMatIdx[i])

--- a/Source/Core/VideoCommon/VertexLoaderX64.h
+++ b/Source/Core/VideoCommon/VertexLoaderX64.h
@@ -18,7 +18,6 @@ public:
   VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att);
 
 protected:
-  std::string GetName() const override { return "VertexLoaderX64"; }
   bool IsInitialized() override { return true; }
   int RunVertices(DataReader src, DataReader dst, int count) override;
 

--- a/Source/Core/VideoCommon/VertexLoaderX64.h
+++ b/Source/Core/VideoCommon/VertexLoaderX64.h
@@ -18,7 +18,6 @@ public:
   VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att);
 
 protected:
-  bool IsInitialized() override { return true; }
   int RunVertices(DataReader src, DataReader dst, int count) override;
 
 private:

--- a/Source/Core/VideoCommon/VertexLoader_Color.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Color.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 
 #include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
 #include "Common/Swap.h"
 
 #include "VideoCommon/VertexLoader.h"
@@ -136,7 +137,6 @@ void Color_ReadIndex_32b_8888(VertexLoader* loader)
                       (index * g_main_cp_state.array_strides[ARRAY_COLOR0 + loader->m_colIndex]);
   SetCol(loader, Read32(address));
 }
-}  // Anonymous namespace
 
 void Color_ReadDirect_24b_888(VertexLoader* loader)
 {
@@ -149,10 +149,12 @@ void Color_ReadDirect_32b_888x(VertexLoader* loader)
   SetCol(loader, Read24(DataGetPosition()));
   DataSkip(4);
 }
+
 void Color_ReadDirect_16b_565(VertexLoader* loader)
 {
   SetCol565(loader, DataRead<u16>());
 }
+
 void Color_ReadDirect_16b_4444(VertexLoader* loader)
 {
   u16 value;
@@ -161,62 +163,52 @@ void Color_ReadDirect_16b_4444(VertexLoader* loader)
   SetCol4444(loader, value);
   DataSkip(2);
 }
+
 void Color_ReadDirect_24b_6666(VertexLoader* loader)
 {
   SetCol6666(loader, Common::swap32(DataGetPosition() - 1));
   DataSkip(3);
 }
+
 void Color_ReadDirect_32b_8888(VertexLoader* loader)
 {
   SetCol(loader, DataReadU32Unswapped());
 }
 
-void Color_ReadIndex8_16b_565(VertexLoader* loader)
+constexpr TPipelineFunction s_table_read_color[4][6] = {
+    {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr},
+    {Color_ReadDirect_16b_565, Color_ReadDirect_24b_888, Color_ReadDirect_32b_888x,
+     Color_ReadDirect_16b_4444, Color_ReadDirect_24b_6666, Color_ReadDirect_32b_8888},
+    {Color_ReadIndex_16b_565<u8>, Color_ReadIndex_24b_888<u8>, Color_ReadIndex_32b_888x<u8>,
+     Color_ReadIndex_16b_4444<u8>, Color_ReadIndex_24b_6666<u8>, Color_ReadIndex_32b_8888<u8>},
+    {Color_ReadIndex_16b_565<u16>, Color_ReadIndex_24b_888<u16>, Color_ReadIndex_32b_888x<u16>,
+     Color_ReadIndex_16b_4444<u16>, Color_ReadIndex_24b_6666<u16>, Color_ReadIndex_32b_8888<u16>},
+};
+
+constexpr u32 s_table_read_color_vertex_size[4][6] = {
+    {0, 0, 0, 0, 0, 0},
+    {2, 3, 4, 2, 3, 4},
+    {1, 1, 1, 1, 1, 1},
+    {2, 2, 2, 2, 2, 2},
+};
+}  // Anonymous namespace
+
+u32 VertexLoader_Color::GetSize(VertexComponentFormat type, ColorFormat format)
 {
-  Color_ReadIndex_16b_565<u8>(loader);
-}
-void Color_ReadIndex8_24b_888(VertexLoader* loader)
-{
-  Color_ReadIndex_24b_888<u8>(loader);
-}
-void Color_ReadIndex8_32b_888x(VertexLoader* loader)
-{
-  Color_ReadIndex_32b_888x<u8>(loader);
-}
-void Color_ReadIndex8_16b_4444(VertexLoader* loader)
-{
-  Color_ReadIndex_16b_4444<u8>(loader);
-}
-void Color_ReadIndex8_24b_6666(VertexLoader* loader)
-{
-  Color_ReadIndex_24b_6666<u8>(loader);
-}
-void Color_ReadIndex8_32b_8888(VertexLoader* loader)
-{
-  Color_ReadIndex_32b_8888<u8>(loader);
+  if (format > ColorFormat::RGBA8888)
+  {
+    PanicAlertFmt("Invalid color format {}", format);
+    return 0;
+  }
+  return s_table_read_color_vertex_size[u32(type)][u32(format)];
 }
 
-void Color_ReadIndex16_16b_565(VertexLoader* loader)
+TPipelineFunction VertexLoader_Color::GetFunction(VertexComponentFormat type, ColorFormat format)
 {
-  Color_ReadIndex_16b_565<u16>(loader);
-}
-void Color_ReadIndex16_24b_888(VertexLoader* loader)
-{
-  Color_ReadIndex_24b_888<u16>(loader);
-}
-void Color_ReadIndex16_32b_888x(VertexLoader* loader)
-{
-  Color_ReadIndex_32b_888x<u16>(loader);
-}
-void Color_ReadIndex16_16b_4444(VertexLoader* loader)
-{
-  Color_ReadIndex_16b_4444<u16>(loader);
-}
-void Color_ReadIndex16_24b_6666(VertexLoader* loader)
-{
-  Color_ReadIndex_24b_6666<u16>(loader);
-}
-void Color_ReadIndex16_32b_8888(VertexLoader* loader)
-{
-  Color_ReadIndex_32b_8888<u16>(loader);
+  if (format > ColorFormat::RGBA8888)
+  {
+    PanicAlertFmt("Invalid color format {}", format);
+    return nullptr;
+  }
+  return s_table_read_color[u32(type)][u32(format)];
 }

--- a/Source/Core/VideoCommon/VertexLoader_Color.h
+++ b/Source/Core/VideoCommon/VertexLoader_Color.h
@@ -4,25 +4,15 @@
 
 #pragma once
 
-class VertexLoader;
+#include "Common/CommonTypes.h"
+#include "VideoCommon/VertexLoader.h"
 
-void Color_ReadDirect_24b_888(VertexLoader* loader);
-void Color_ReadDirect_32b_888x(VertexLoader* loader);
-void Color_ReadDirect_16b_565(VertexLoader* loader);
-void Color_ReadDirect_16b_4444(VertexLoader* loader);
-void Color_ReadDirect_24b_6666(VertexLoader* loader);
-void Color_ReadDirect_32b_8888(VertexLoader* loader);
+enum class VertexComponentFormat;
+enum class ColorFormat;
 
-void Color_ReadIndex8_16b_565(VertexLoader* loader);
-void Color_ReadIndex8_24b_888(VertexLoader* loader);
-void Color_ReadIndex8_32b_888x(VertexLoader* loader);
-void Color_ReadIndex8_16b_4444(VertexLoader* loader);
-void Color_ReadIndex8_24b_6666(VertexLoader* loader);
-void Color_ReadIndex8_32b_8888(VertexLoader* loader);
-
-void Color_ReadIndex16_16b_565(VertexLoader* loader);
-void Color_ReadIndex16_24b_888(VertexLoader* loader);
-void Color_ReadIndex16_32b_888x(VertexLoader* loader);
-void Color_ReadIndex16_16b_4444(VertexLoader* loader);
-void Color_ReadIndex16_24b_6666(VertexLoader* loader);
-void Color_ReadIndex16_32b_8888(VertexLoader* loader);
+class VertexLoader_Color
+{
+public:
+  static u32 GetSize(VertexComponentFormat type, ColorFormat format);
+  static TPipelineFunction GetFunction(VertexComponentFormat type, ColorFormat format);
+};

--- a/Source/Core/VideoCommon/XFStructs.h
+++ b/Source/Core/VideoCommon/XFStructs.h
@@ -13,3 +13,4 @@ std::pair<std::string, std::string> GetXFRegInfo(u32 address, u32 value);
 std::string GetXFMemName(u32 address);
 std::string GetXFMemDescription(u32 address, u32 value);
 std::pair<std::string, std::string> GetXFTransferInfo(const u8* data);
+std::pair<std::string, std::string> GetXFIndexedLoadInfo(u8 array, u32 value);

--- a/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
+++ b/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
@@ -62,7 +62,7 @@ protected:
   void CreateAndCheckSizes(size_t input_size, size_t output_size)
   {
     m_loader = VertexLoaderBase::CreateVertexLoader(m_vtx_desc, m_vtx_attr);
-    ASSERT_EQ((int)input_size, m_loader->m_VertexSize);
+    ASSERT_EQ(input_size, m_loader->m_vertex_size);
     ASSERT_EQ((int)output_size, m_loader->m_native_vtx_decl.stride);
   }
 


### PR DESCRIPTION
Built on top of #9540 -- Only last two commits are relevant.

This is a WIP for feedback and comment. 

-----------

There are several reasons why I want to make this change:

1. To make it possible to investigate how games utilise display lists
2. I'm considering making dolphin cache display lists. 
   - Investigation would be useful before starting on this
   - Once implemented, it would be nice to have fifoci stress display list caching. 
3. This makes fifologs smaller (at least when uncompressed) 
4. This can theoretically speed up the capturing of fifologs, which could be useful for future "paused free-look" or "graphics debugger" functionality. 

**This PR is current a draft, some questions to consider before it can be ready:**

 - [ ] How do we want displaylists to be showed in the Analyzer UI?

In the current implementation, all displaylists are displayed after all objects for a frame. Some kind of interleaved or tree view might be better.

![image](https://user-images.githubusercontent.com/138484/117835281-f6950a80-b2cb-11eb-9b08-ff8602115d24.png)


 - [ ] Should this be an optional capture mode, or the new default?

Unfortunately, old versions of dolphin can't quite read these new fifologs, but only because they have ASSERT(false) in their fifolog read path when they encounter a CALL DL command

 - [ ] How do we want first/last object to interact with displaylists?

Do we want to treat a call to a displaylist with multiple inner objects as a single object? Or inline the objects counts.

Currently, this PR doesn't support skipping objects inside Displaylists at all. They always draw (making it possible to see just how many objects a drawn via displaylists). But it's totally possible to implement skipping of individual objects within displaylists.