### PR TITLE
Socket: Fix AF_INET6 on non-Windows systems

### DIFF
--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -750,12 +750,31 @@ bool WiiSockMan::IsSocketBlocking(s32 wii_fd) const
 
 s32 WiiSockMan::NewSocket(s32 af, s32 type, s32 protocol)
 {
-  if (af != 2 && af != 23)  // AF_INET && AF_INET6
+  if (af == 2)
+  {
+    // AF_INET == 2 is true on all systems I've seen,
+    // but it's not guaranteed. Better set this again.
+    af = AF_INET;
+  }
+  else if (af == 23)
+  {
+    // AF_INET6 == 23 is only true on Wii and on Windows.
+    // On other OSes, AF_INET6 can have a different value.
+    // For example, on Linux it's 10 and on MacOS/iOS it's 30.
+    af = AF_INET6;
+  }
+  else
+  {
+    // Neither an AF_INET nor an AF_INET6 socket.
+    // Unsupported.
     return -SO_EAFNOSUPPORT;
+  }
+
   if (protocol != 0)  // IPPROTO_IP
     return -SO_EPROTONOSUPPORT;
   if (type != 1 && type != 2)  // SOCK_STREAM && SOCK_DGRAM
     return -SO_EPROTOTYPE;
+
   s32 fd = static_cast<s32>(socket(af, type, protocol));
   return AddSocket(fd, false);
 }


### PR DESCRIPTION
`WiiSockMan::NewSocket` in Socket.cpp is the function that's responsible for creating a host network socket when the emulated game wants to make a socket. 

Currently, Dolphin assumes that an IPv6 socket (AF_INET6) requested by the emulated software has the same integer value (23) on all operating systems and just passes that 23 through to the `socket` call. 

That assumption is true on Windows, but it's not true on other OSes. 
AF_INET6 is 23 on a Wii and on Windows, but it's 10 on most Linux systems, and 30 on MacOS or iOS. 

In theory, the same thing is true for IPv4 (AF_INET), too. AF_INET isn't 100% guaranteed to be 2, though it probably always is. Still, I added that bugfix for IPv4, too, just in case.

This particular issue is _probably_ not a big deal as I don't know of any Wii software that attempts to use any kind of IPv6 connection whatsoever, but it is a bug nevertheless. 

I wanted to try and add IPv6 support to Wii games after I noticed that Wii IOSes seem to actually support IPv6 in some way, did a first test in Dolphin on a Linux machine and noticed this address family value being wrong. 

Who knows, maybe I'll actually get that to work on a Wii some time; in that case I would probably be making more PRs as it looks like none of the other code that converts a host `sockaddr_in` to a Wii `sockaddr_in` is currently capable of handling IPv6, but I wanted to get this bug fixed so I don't forget about it. Missing code (as in not handling IPv6 `sockaddr_in`s correctly) is probably better than known-broken code like this one.

I can confirm that without this change, Wii software can't open an IPv6 socket on Linux, and with this change it can. But of course I wasn't able to actually send / receive anything as there's too much other code that doesn't yet support IPv6. 