### PR TITLE
Netplay: Auto Pad Buffer Option

### DIFF
--- a/Source/Core/Core/Config/NetplaySettings.cpp
+++ b/Source/Core/Core/Config/NetplaySettings.cpp
@@ -45,6 +45,7 @@ const Info<u32> NETPLAY_CHUNKED_UPLOAD_LIMIT{{System::Main, "NetPlay", "ChunkedU
 
 const Info<u32> NETPLAY_BUFFER_SIZE{{System::Main, "NetPlay", "BufferSize"}, 5};
 const Info<u32> NETPLAY_CLIENT_BUFFER_SIZE{{System::Main, "NetPlay", "BufferSizeClient"}, 1};
+const Info<bool> NETPLAY_AUTO_BUFFER{{System::Main, "NetPlay", "AutoBuffer"}, true};
 
 const Info<bool> NETPLAY_WRITE_SAVE_SDCARD_DATA{{System::Main, "NetPlay", "WriteSaveSDCardData"},
                                                 false};

--- a/Source/Core/Core/Config/NetplaySettings.h
+++ b/Source/Core/Core/Config/NetplaySettings.h
@@ -41,6 +41,7 @@ extern const Info<u32> NETPLAY_CHUNKED_UPLOAD_LIMIT;
 
 extern const Info<u32> NETPLAY_BUFFER_SIZE;
 extern const Info<u32> NETPLAY_CLIENT_BUFFER_SIZE;
+extern const Info<bool> NETPLAY_AUTO_BUFFER;
 
 extern const Info<bool> NETPLAY_WRITE_SAVE_SDCARD_DATA;
 extern const Info<bool> NETPLAY_LOAD_WII_SAVE;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1269,7 +1269,14 @@ bool NetPlayServer::StartGame()
 
   // no change, just update with clients
   if (!m_host_input_authority)
+  {
+    if (Config::Get(Config::NETPLAY_AUTO_BUFFER))
+    {
+      Config::SetBase(Config::NETPLAY_BUFFER_SIZE, CalculatePadBuffer());
+    }
+
     AdjustPadBufferSize(m_target_buffer_size);
+  }
 
   m_current_golfer = 1;
   m_pending_golfer = 0;
@@ -2157,5 +2164,42 @@ void NetPlayServer::ChunkedDataAbort()
   m_abort_chunked_data = true;
   m_chunked_data_event.Set();
   m_chunked_data_complete_event.Set();
+}
+
+// The calculations in this function are based off the discussions in this pr: 
+// https://github.com/dolphin-emu/dolphin/pull/9706#issuecomment-840262908
+u32 NetPlayServer::CalculatePadBuffer() const
+{
+  u32 total_latency = 0;
+  u32 player1_ping = 0;
+  u32 player2_ping = 0;
+
+  // Gather the two highest latencies of non-spectators.
+  for (const auto& player_entry : m_players)
+  {
+    // Check if the player has a mapped controller, otherwise they're a spectator.
+    const bool pad_mapped =
+      std::find(m_pad_map.begin(), m_pad_map.end(), player_entry.first) != m_pad_map.end();
+
+    const bool wiimote_mapped =
+      std::find(m_wiimote_map.begin(), m_wiimote_map.end(), player_entry.first) != m_wiimote_map.end();
+
+    if (pad_mapped || wiimote_mapped)
+    {
+      if (player_entry.second.ping > player1_ping)
+      {
+        player2_ping = player1_ping;
+        player1_ping = player_entry.second.ping;
+      }
+    }
+  }
+
+  // If the session only contains 2 players (1 host, 1 client),
+  // player2_ping will implicitly be 0.
+  total_latency = player1_ping + player2_ping;
+
+  constexpr u32 polling_rate = (1.0 / (120.0 / 2.0)) * 1000;
+
+  return (total_latency / polling_rate) + 1;
 }
 }  // namespace NetPlay

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -69,6 +69,7 @@ public:
   void KickPlayer(PlayerId player);
 
   u16 GetPort() const;
+  u32 CalculatePadBuffer() const;
 
   std::unordered_set<std::string> GetInterfaceSet() const;
   std::string GetInterfaceHost(const std::string& inter) const;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -7,6 +7,7 @@
 #include <QAction>
 #include <QActionGroup>
 #include <QApplication>
+#include <QCheckBox>
 #include <QClipboard>
 #include <QComboBox>
 #include <QGridLayout>
@@ -98,6 +99,8 @@ void NetPlayDialog::CreateMainLayout()
   m_main_layout = new QGridLayout;
   m_game_button = new QPushButton;
   m_start_button = new QPushButton(tr("Start"));
+  m_auto_buffer_box = new QCheckBox;
+  m_auto_buffer_label = new QLabel(tr("Auto Buffer:"));
   m_buffer_size_box = new QSpinBox;
   m_buffer_label = new QLabel(tr("Buffer:"));
   m_quit_button = new QPushButton(tr("Quit"));
@@ -192,10 +195,13 @@ void NetPlayDialog::CreateMainLayout()
   auto* options_widget = new QGridLayout;
 
   options_widget->addWidget(m_start_button, 0, 0, Qt::AlignVCenter);
-  options_widget->addWidget(m_buffer_label, 0, 1, Qt::AlignVCenter);
-  options_widget->addWidget(m_buffer_size_box, 0, 2, Qt::AlignVCenter);
-  options_widget->addWidget(m_quit_button, 0, 3, Qt::AlignVCenter | Qt::AlignRight);
-  options_widget->setColumnStretch(3, 1000);
+  options_widget->addWidget(m_auto_buffer_label, 0, 1, Qt::AlignVCenter);
+  options_widget->addWidget(m_auto_buffer_box, 0, 2, Qt::AlignVCenter);
+  options_widget->addWidget(m_buffer_label, 0, 3, Qt::AlignVCenter);
+  options_widget->addWidget(m_buffer_size_box, 0, 4, Qt::AlignVCenter);
+  options_widget->addWidget(m_quit_button, 0, 5, Qt::AlignVCenter | Qt::AlignRight);
+  options_widget->setColumnStretch(2, 50);
+  options_widget->setColumnStretch(5, 1000);
 
   m_main_layout->addLayout(options_widget, 2, 0, 1, -1, Qt::AlignRight);
   m_main_layout->setRowStretch(1, 1000);
@@ -292,6 +298,24 @@ void NetPlayDialog::ConnectWidgets()
           [this] { m_chat_send_button->setEnabled(!m_chat_type_edit->text().isEmpty()); });
 
   // Other
+  connect(m_auto_buffer_box, &QCheckBox::clicked, this, [this](bool value) {
+    m_buffer_size_box->setEnabled(!value);
+    m_buffer_label->setEnabled(!value);
+
+    if (value)
+    {
+      auto server = Settings::Instance().GetNetPlayServer();
+      if (server && !m_host_input_authority)
+      {
+        const u32 pad_buffer = server->CalculatePadBuffer();
+
+        Config::SetBase(Config::NETPLAY_BUFFER_SIZE, pad_buffer);
+        server->AdjustPadBufferSize(pad_buffer);
+        m_buffer_size_box->setValue(pad_buffer);
+      }
+    }
+  });
+
   connect(m_buffer_size_box, qOverload<int>(&QSpinBox::valueChanged), [this](int value) {
     if (value == m_buffer_size)
       return;
@@ -945,10 +969,11 @@ void NetPlayDialog::OnHostInputAuthorityChanged(bool enabled)
 
     if (is_hosting)
     {
-      m_buffer_size_box->setEnabled(enable_buffer);
       m_buffer_label->setEnabled(enable_buffer);
       m_buffer_size_box->setHidden(false);
       m_buffer_label->setHidden(false);
+      m_auto_buffer_box->setHidden(false);
+      m_auto_buffer_label->setHidden(false);
     }
     else
     {
@@ -956,6 +981,8 @@ void NetPlayDialog::OnHostInputAuthorityChanged(bool enabled)
       m_buffer_label->setEnabled(true);
       m_buffer_size_box->setHidden(!enable_buffer);
       m_buffer_label->setHidden(!enable_buffer);
+      m_auto_buffer_box->setHidden(true);
+      m_auto_buffer_label->setHidden(true);
     }
 
     m_buffer_label->setText(enabled ? tr("Max Buffer:") : tr("Buffer:"));
@@ -1079,6 +1106,7 @@ NetPlayDialog::FindGameFile(const NetPlay::SyncIdentifier& sync_identifier,
 void NetPlayDialog::LoadSettings()
 {
   const int buffer_size = Config::Get(Config::NETPLAY_BUFFER_SIZE);
+  const bool auto_buffer = Config::Get(Config::NETPLAY_AUTO_BUFFER);
   const bool write_save_sdcard_data = Config::Get(Config::NETPLAY_WRITE_SAVE_SDCARD_DATA);
   const bool load_wii_save = Config::Get(Config::NETPLAY_LOAD_WII_SAVE);
   const bool sync_saves = Config::Get(Config::NETPLAY_SYNC_SAVES);
@@ -1089,6 +1117,8 @@ void NetPlayDialog::LoadSettings()
   const bool golf_mode_overlay = Config::Get(Config::NETPLAY_GOLF_MODE_OVERLAY);
 
   m_buffer_size_box->setValue(buffer_size);
+  m_buffer_size_box->setEnabled(!auto_buffer);
+  m_auto_buffer_box->setChecked(auto_buffer);
   m_save_sd_action->setChecked(write_save_sdcard_data);
   m_load_wii_action->setChecked(load_wii_save);
   m_sync_save_data_action->setChecked(sync_saves);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -126,7 +126,9 @@ private:
   QMenu* m_other_menu;
   QPushButton* m_game_button;
   QPushButton* m_start_button;
+  QLabel* m_auto_buffer_label;
   QLabel* m_buffer_label;
+  QCheckBox* m_auto_buffer_box;
   QSpinBox* m_buffer_size_box;
   QAction* m_save_sd_action;
   QAction* m_load_wii_action;


### PR DESCRIPTION
Automatically set the pad buffer for users who do not know how to configure it or would rather automate the calculation used to estimate the optimal buffer size.

~~Calculation (No Host Input Authority):~~
~~`((total_latency * (number_of_players - 1)) / 15) + 1`~~

~~Calculation for Host Input Authority:~~
~~`(client_latency / 8) + 1`~~

Thanks to JMC for the calculations!

![image](https://user-images.githubusercontent.com/4237834/118002614-b3747f00-b33f-11eb-958c-e2d21229d3fb.png)