### PR TITLE
DSP: Change external_interrupt_waiting from volatile to atomic

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -195,7 +195,7 @@ void SDSP::SetException(ExceptionType exception)
 
 void SDSP::SetExternalInterrupt(bool val)
 {
-  external_interrupt_waiting = val;
+  external_interrupt_waiting.store(val, std::memory_order_release);
 }
 
 void SDSP::CheckExternalInterrupt()

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -420,7 +420,7 @@ struct SDSP
 
   u8 reg_stack_ptrs[4]{};
   u8 exceptions = 0;  // pending exceptions
-  volatile bool external_interrupt_waiting = false;
+  std::atomic<bool> external_interrupt_waiting = false;
   bool reset_dspjit_codespace = false;
 
   // DSP hardware stacks. They're mapped to a bunch of registers, such that writes

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -69,10 +69,9 @@ int Interpreter::RunCyclesThread(int cycles)
     if ((state.cr & CR_HALT) != 0)
       return 0;
 
-    if (state.external_interrupt_waiting)
+    if (state.external_interrupt_waiting.exchange(false, std::memory_order_acquire))
     {
       m_dsp_core.CheckExternalInterrupt();
-      m_dsp_core.SetExternalInterrupt(false);
     }
 
     Step();

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -51,11 +51,10 @@ DSPEmitter::~DSPEmitter()
 
 u16 DSPEmitter::RunCycles(u16 cycles)
 {
-  if (m_dsp_core.DSPState().external_interrupt_waiting)
+  if (m_dsp_core.DSPState().external_interrupt_waiting.exchange(false, std::memory_order_acquire))
   {
     m_dsp_core.CheckExternalInterrupt();
     m_dsp_core.CheckExceptions();
-    m_dsp_core.SetExternalInterrupt(false);
   }
 
   m_cycles_left = cycles;
@@ -489,6 +488,9 @@ Gen::OpArg DSPEmitter::M_SDSP_cr()
 
 Gen::OpArg DSPEmitter::M_SDSP_external_interrupt_waiting()
 {
+  static_assert(decltype(SDSP::external_interrupt_waiting)::is_always_lock_free &&
+                sizeof(SDSP::external_interrupt_waiting) == sizeof(u8));
+
   return MDisp(R15, static_cast<int>(offsetof(SDSP, external_interrupt_waiting)));
 }
 


### PR DESCRIPTION
Making this volatile accomplishes... Well, nothing in practice. Making it atomic, on the other hand, lets us enforce a memory ordering.