### PR TITLE
VideoCommon: enhance wildcard support in hi res texture lookup

### DIFF
--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -221,19 +221,28 @@ std::string HiresTexture::GenBaseName(TextureInfo& texture_info, bool dump)
 
   const auto texture_name_details = texture_info.CalculateTextureName();
 
-  // try to match a wildcard template
-  if (!dump)
-  {
-    const std::string texture_name =
-        fmt::format("{}_${}", texture_name_details.base_name, texture_name_details.format_name);
-    if (s_textureMap.find(texture_name) != s_textureMap.end())
-      return texture_name;
-  }
-
-  // else generate the complete texture
+  // look for an exact match first
   const std::string full_name = texture_name_details.GetFullName();
   if (dump || s_textureMap.find(full_name) != s_textureMap.end())
     return full_name;
+
+  // else try and find a wildcard
+  if (!dump)
+  {
+    // Single wildcard ignoring the tlut hash
+    const std::string texture_name_single_wildcard_tlut =
+        fmt::format("{}_{}_$_{}", texture_name_details.base_name, texture_name_details.texture_name,
+                    texture_name_details.format_name);
+    if (s_textureMap.find(texture_name_single_wildcard_tlut) != s_textureMap.end())
+      return texture_name_single_wildcard_tlut;
+
+    // Single wildcard ignoring the texture hash
+    const std::string texture_name_single_wildcard_tex =
+        fmt::format("{}_${}_{}", texture_name_details.base_name, texture_name_details.tlut_name,
+                    texture_name_details.format_name);
+    if (s_textureMap.find(texture_name_single_wildcard_tex) != s_textureMap.end())
+      return texture_name_single_wildcard_tex;
+  }
 
   return "";
 }

--- a/Source/Core/VideoCommon/TextureInfo.cpp
+++ b/Source/Core/VideoCommon/TextureInfo.cpp
@@ -4,6 +4,7 @@
 
 #include "VideoCommon/TextureInfo.h"
 
+#include <fmt/format.h>
 #include <xxhash.h>
 
 #include "Common/Align.h"
@@ -95,6 +96,11 @@ TextureInfo::TextureInfo(const u8* ptr, const u8* tlut_ptr, u32 address,
   }
 }
 
+std::string TextureInfo::NameDetails::GetFullName() const
+{
+  return fmt::format("{}_{}{}_{}", base_name, texture_name, tlut_name, format_name);
+}
+
 TextureInfo::NameDetails TextureInfo::CalculateTextureName()
 {
   if (!m_ptr)
@@ -151,10 +157,11 @@ TextureInfo::NameDetails TextureInfo::CalculateTextureName()
   const u64 tlut_hash = tlut_size ? XXH64(tlut, tlut_size, 0) : 0;
 
   NameDetails result;
-  result.base_name = fmt::format("{}{}x{}{}_{:016x}", format_prefix, m_raw_width, m_raw_height,
-                                 m_mipmaps_enabled ? "_m" : "", tex_hash);
+  result.base_name = fmt::format("{}{}x{}{}", format_prefix, m_raw_width, m_raw_height,
+                                 m_mipmaps_enabled ? "_m" : "");
+  result.texture_name = fmt::format("{:016x}", tex_hash);
   result.tlut_name = tlut_size ? fmt::format("_{:016x}", tlut_hash) : "";
-  result.format_name = fmt::format("_{}", static_cast<int>(m_texture_format));
+  result.format_name = fmt::to_string(static_cast<int>(m_texture_format));
 
   return result;
 }

--- a/Source/Core/VideoCommon/TextureInfo.h
+++ b/Source/Core/VideoCommon/TextureInfo.h
@@ -25,10 +25,11 @@ public:
   struct NameDetails
   {
     std::string base_name;
+    std::string texture_name;
     std::string tlut_name;
     std::string format_name;
 
-    std::string GetFullName() const { return base_name + tlut_name + format_name; }
+    std::string GetFullName() const;
   };
   NameDetails CalculateTextureName();
 


### PR DESCRIPTION
Splits out the texture hash from the rest of the texture name generation, so that it can be "wildcard"'d out of the texture name.

Additionally, have exact texture matches take precedent over wildcard matches.  This is _technically_ a breaking change in that it could effect existing texture packs if they had both a wildcard and an exact match texture in the pack.  However, I imagine most packs aren't doing this because it'd be wasted space.

Should resolve [12505](https://bugs.dolphin-emu.org/issues/12505)