### PR TITLE
DolphinQt: ignore warnings from qt headers on buildbot

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -350,10 +350,11 @@ if (WIN32)
 endif()
 
 if (MSVC)
-  # Disable some warnings
-
-  # 5054: operator '+': deprecated between enumerations of different types (in Qt headers)
-  target_compile_options(dolphin-emu PRIVATE /wd5054)
+  # Don't propogate warnings in qt headers to Dolphin
+  target_compile_options(dolphin-emu PRIVATE /experimental:external)
+  target_compile_options(dolphin-emu PRIVATE /external:W0)
+  target_compile_options(dolphin-emu PRIVATE "/external:I${Qt5Gui_PRIVATE_INCLUDE_DIRS}")
+  target_compile_options(dolphin-emu PRIVATE "/external:I${Qt5Widgets_PRIVATE_INCLUDE_DIRS}")
 endif()
 
 if(WIN32)

--- a/Source/Core/DolphinQt/QtUtils/FlowLayout.cpp
+++ b/Source/Core/DolphinQt/QtUtils/FlowLayout.cpp
@@ -66,8 +66,7 @@ FlowLayout::FlowLayout(int margin, int h_spacing, int v_spacing)
 
 FlowLayout::~FlowLayout()
 {
-  QLayoutItem* item;
-  while ((item = takeAt(0)))
+  while (QLayoutItem* item = takeAt(0))
     delete item;
 }
 

--- a/Source/VSProps/QtCompile.props
+++ b/Source/VSProps/QtCompile.props
@@ -28,10 +28,11 @@
       <AdditionalIncludeDirectories>$(QtIncludeDir)QtWidgets;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Platform)'=='ARM64'">$(QtIncludeDir)QtANGLE;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <!--
-      Negate the previously enabled warning (set in Base.props). Not compatible with QtCore\qtmap.h
-      This isn't too bad since we live with the fact that Qt-using projects will have different compiler args already.
+      Set the qt directories as 'external', so we avoid any warnings in them
       -->
-      <AdditionalOptions>%(AdditionalOptions) /wd4946</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /experimental:external</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /external:W0</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /external:I$(QtIncludeDir)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(QtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>


### PR DESCRIPTION
Uses the [experimental external feature](https://devblogs.microsoft.com/cppblog/broken-warnings-theory/) to ignore warnings in header.  This is experimental right now but the [latest preview release notes](https://docs.microsoft.com/en-us/visualstudio/releases/2019/release-notes-preview#16.10.0.pre.3.0) seem to indicate it's going out of experimental status.

This should fix the build errors we're seeing.

I wasn't sure if there was a better place for this.  Also, ideally this should be applied to _all_ our external library headers but that's a much larger change.