### PR TITLE
DolphinQt: Add quotes around QtIncludeDir on Windows

### DIFF
--- a/Source/VSProps/QtCompile.props
+++ b/Source/VSProps/QtCompile.props
@@ -7,7 +7,8 @@
     <QTDIR Condition="Exists('$(QTDIR)') And !HasTrailingSlash('$(QTDIR)')">$(QTDIR)\</QTDIR>
     <QtDirValid>false</QtDirValid>
     <QtDirValid Condition="Exists('$(QTDIR)')">true</QtDirValid>
-    <QtIncludeDir>$(QTDIR)include\</QtIncludeDir>
+    <QtIncludeDirWithoutTrailingSeparator>$(QTDIR)include</QtIncludeDirWithoutTrailingSeparator>
+    <QtIncludeDir>$(QtIncludeDirWithoutTrailingSeparator)\</QtIncludeDir>
     <QtLibDir>$(QTDIR)lib\</QtLibDir>
     <QtBinDir>$(QTDIR)bin\</QtBinDir>
     <QtPluginsDir>$(QTDIR)plugins\</QtPluginsDir>
@@ -32,7 +33,7 @@
       -->
       <AdditionalOptions>%(AdditionalOptions) /experimental:external</AdditionalOptions>
       <AdditionalOptions>%(AdditionalOptions) /external:W0</AdditionalOptions>
-      <AdditionalOptions>%(AdditionalOptions) /external:I$(QtIncludeDir)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /external:I "$(QtIncludeDirWithoutTrailingSeparator)"</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(QtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>


### PR DESCRIPTION
As of 99a724361abb5c9728761dfc13b9f58a0b4fff8b Visual Studio gets hopelessly confused if QtIncludeDirectory has any spaces in the path. Adding quotes around the include directive solves the issue. 