### PR TITLE
Fix some warnings found with gcc 11 and ffmpeg master

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -25,6 +25,8 @@ add_library(common
   Config/Layer.cpp
   Config/Layer.h
   CPUDetect.h
+  CRC32.cpp
+  CRC32.h
   Crypto/AES.cpp
   Crypto/AES.h
   Crypto/bn.cpp

--- a/Source/Core/Common/CRC32.cpp
+++ b/Source/Core/Common/CRC32.cpp
@@ -1,0 +1,19 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <zlib.h>
+
+#include "Common/CRC32.h"
+
+namespace Common
+{
+u32 ComputeCRC32(std::string_view data)
+{
+  const Bytef* buf = reinterpret_cast<const Bytef*>(data.data());
+  uInt len = static_cast<uInt>(data.size());
+  // Use zlibs crc32 implementation to compute the hash
+  u32 hash = crc32(0L, Z_NULL, 0);
+  hash = crc32(hash, buf, len);
+  return hash;
+}
+}  // namespace Common

--- a/Source/Core/Common/CRC32.h
+++ b/Source/Core/Common/CRC32.h
@@ -1,0 +1,11 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <string_view>
+
+#include "Common/CommonTypes.h"
+
+namespace Common
+{
+u32 ComputeCRC32(std::string_view data);
+}  // namespace Common

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -20,10 +20,9 @@ namespace fs = std::filesystem;
 #include <utility>
 #include <vector>
 
-#include <zlib.h>
-
 #include "Common/Align.h"
 #include "Common/CDUtils.h"
+#include "Common/CRC32.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
@@ -355,9 +354,7 @@ bool CBoot::Load_BS2(const std::string& boot_rom_filename)
   if (!File::ReadFileToString(boot_rom_filename, data))
     return false;
 
-  // Use zlibs crc32 implementation to compute the hash
-  u32 ipl_hash = crc32(0L, Z_NULL, 0);
-  ipl_hash = crc32(ipl_hash, (const Bytef*)data.data(), (u32)data.size());
+  const u32 ipl_hash = Common::ComputeCRC32(data);
   bool known_ipl = false;
   bool pal_ipl = false;
   switch (ipl_hash)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -546,8 +546,11 @@ void BluetoothRealDevice::SaveLinkKeys()
     oss << Common::MacAddressToString(address);
     oss << '=';
     oss << std::hex;
-    for (const u16& data : entry.second)
-      oss << std::setfill('0') << std::setw(2) << data;
+    for (u8 data : entry.second)
+    {
+      // We cast to u16 here in order to have it displayed as two nibbles.
+      oss << std::setfill('0') << std::setw(2) << static_cast<u16>(data);
+    }
     oss << std::dec << ',';
   }
   std::string config_string = oss.str();

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -21,6 +21,7 @@
     <ClInclude Include="Common\BitUtils.h" />
     <ClInclude Include="Common\BlockingLoop.h" />
     <ClInclude Include="Common\CDUtils.h" />
+    <ClInclude Include="Common\CRC32.h" />
     <ClInclude Include="Common\ChunkFile.h" />
     <ClInclude Include="Common\CodeBlock.h" />
     <ClInclude Include="Common\ColorUtil.h" />
@@ -689,6 +690,7 @@
     <ClCompile Include="AudioCommon\WaveFile.cpp" />
     <ClCompile Include="Common\Analytics.cpp" />
     <ClCompile Include="Common\CDUtils.cpp" />
+    <ClCompile Include="Common\CRC32.cpp" />
     <ClCompile Include="Common\ColorUtil.cpp" />
     <ClCompile Include="Common\CommonFuncs.cpp" />
     <ClCompile Include="Common\CompatPatches.cpp" />

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -195,6 +195,8 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
 
       return tags.join(QStringLiteral(", "));
     }
+  default:
+    break;
   }
 
   return QVariant();
@@ -231,6 +233,8 @@ QVariant GameListModel::headerData(int section, Qt::Orientation orientation, int
     return tr("Compression");
   case Column::Tags:
     return tr("Tags");
+  default:
+    break;
   }
   return QVariant();
 }

--- a/Source/Core/DolphinQt/QtUtils/SignalDaemon.cpp
+++ b/Source/Core/DolphinQt/QtUtils/SignalDaemon.cpp
@@ -34,8 +34,9 @@ void SignalDaemon::OnNotifierActivated()
   m_term->setEnabled(false);
 
   char tmp;
-  if (read(s_sigterm_fd[1], &tmp, sizeof(char)))
+  if (read(s_sigterm_fd[1], &tmp, sizeof(char)) != sizeof(char))
   {
+    // Not much we can do here.
   }
 
   m_term->setEnabled(true);
@@ -45,10 +46,14 @@ void SignalDaemon::OnNotifierActivated()
 
 void SignalDaemon::HandleInterrupt(int)
 {
-  write(STDERR_FILENO, message, sizeof(message));
+  if (write(STDERR_FILENO, message, sizeof(message)) != sizeof(message))
+  {
+    // Not much we can do here.
+  }
 
   char a = 1;
-  if (write(s_sigterm_fd[0], &a, sizeof(a)))
+  if (write(s_sigterm_fd[0], &a, sizeof(a)) != sizeof(a))
   {
+    // Not much we can do here.
   }
 }

--- a/Source/Core/DolphinQt/Resources.cpp
+++ b/Source/Core/DolphinQt/Resources.cpp
@@ -21,9 +21,10 @@ QList<QPixmap> Resources::m_platforms;
 QList<QPixmap> Resources::m_countries;
 QList<QPixmap> Resources::m_misc;
 
-QIcon Resources::GetIcon(const QString& name, const QString& dir)
+QIcon Resources::GetIcon(std::string_view name, const QString& dir)
 {
-  QString base_path = dir + QLatin1Char{'/'} + name;
+  QString name_owned = QString::fromLatin1(name.data(), static_cast<int>(name.size()));
+  QString base_path = dir + QLatin1Char{'/'} + name_owned;
 
   const auto dpr = QGuiApplication::primaryScreen()->devicePixelRatio();
 
@@ -42,7 +43,7 @@ QIcon Resources::GetIcon(const QString& name, const QString& dir)
   return icon;
 }
 
-QPixmap Resources::GetPixmap(const QString& name, const QString& dir)
+QPixmap Resources::GetPixmap(std::string_view name, const QString& dir)
 {
   const auto icon = GetIcon(name, dir);
   return icon.pixmap(icon.availableSizes()[0]);
@@ -58,30 +59,30 @@ static QString GetResourcesDir()
   return QString::fromStdString(File::GetSysDirectory() + "Resources");
 }
 
-QIcon Resources::GetScaledIcon(const std::string& name)
+QIcon Resources::GetScaledIcon(std::string_view name)
 {
-  return GetIcon(QString::fromStdString(name), GetResourcesDir());
+  return GetIcon(name, GetResourcesDir());
 }
 
-QIcon Resources::GetScaledThemeIcon(const std::string& name)
+QIcon Resources::GetScaledThemeIcon(std::string_view name)
 {
-  return GetIcon(QString::fromStdString(name), GetCurrentThemeDir());
+  return GetIcon(name, GetCurrentThemeDir());
 }
 
-QPixmap Resources::GetScaledPixmap(const std::string& name)
+QPixmap Resources::GetScaledPixmap(std::string_view name)
 {
-  return GetPixmap(QString::fromStdString(name), GetResourcesDir());
+  return GetPixmap(name, GetResourcesDir());
 }
 
 void Resources::Init()
 {
-  for (const std::string& platform :
+  for (std::string_view platform :
        {"Platform_Gamecube", "Platform_Wii", "Platform_Wad", "Platform_File"})
   {
     m_platforms.append(GetScaledPixmap(platform));
   }
 
-  for (const std::string& country :
+  for (std::string_view country :
        {"Flag_Europe", "Flag_Japan", "Flag_USA", "Flag_Australia", "Flag_France", "Flag_Germany",
         "Flag_Italy", "Flag_Korea", "Flag_Netherlands", "Flag_Russia", "Flag_Spain", "Flag_Taiwan",
         "Flag_International", "Flag_Unknown"})

--- a/Source/Core/DolphinQt/Resources.h
+++ b/Source/Core/DolphinQt/Resources.h
@@ -5,6 +5,7 @@
 
 #include <QList>
 #include <QPixmap>
+#include <string_view>
 
 namespace DiscIO
 {
@@ -30,16 +31,16 @@ public:
 
   static QPixmap GetMisc(MiscID id);
 
-  static QIcon GetScaledIcon(const std::string& name);
-  static QIcon GetScaledThemeIcon(const std::string& name);
+  static QIcon GetScaledIcon(std::string_view name);
+  static QIcon GetScaledThemeIcon(std::string_view name);
   static QIcon GetAppIcon();
 
-  static QPixmap GetScaledPixmap(const std::string& name);
+  static QPixmap GetScaledPixmap(std::string_view name);
 
 private:
   Resources() {}
-  static QIcon GetIcon(const QString& name, const QString& dir);
-  static QPixmap GetPixmap(const QString& name, const QString& dir);
+  static QIcon GetIcon(std::string_view name, const QString& dir);
+  static QPixmap GetPixmap(std::string_view name, const QString& dir);
 
   static QList<QPixmap> m_platforms;
   static QList<QPixmap> m_countries;

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -440,7 +440,7 @@ void GameCubePane::LoadSettings()
 
   bool have_menu = false;
 
-  for (const std::string& dir : {USA_DIR, JAP_DIR, EUR_DIR})
+  for (const std::string dir : {USA_DIR, JAP_DIR, EUR_DIR})
   {
     const auto path = DIR_SEP + dir + DIR_SEP GC_IPL;
     if (File::Exists(File::GetUserPath(D_GCUSER_IDX) + path) ||

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -45,7 +45,7 @@ GameFileCache::GameFileCache() : m_path(File::GetUserPath(D_CACHE_IDX) + "gameli
 
 void GameFileCache::ForEach(std::function<void(const std::shared_ptr<const GameFile>&)> f) const
 {
-  for (const std::shared_ptr<const GameFile>& item : m_cached_files)
+  for (const std::shared_ptr<GameFile>& item : m_cached_files)
     f(item);
 }
 

--- a/Source/Core/VideoCommon/BoundingBox.cpp
+++ b/Source/Core/VideoCommon/BoundingBox.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoCommon/BoundingBox.h"
 
+#include <algorithm>
+
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -48,6 +48,30 @@ static void UpdateInterrupts_Wrapper(u64 userdata, s64 cyclesLate)
   UpdateInterrupts(userdata);
 }
 
+void SCPFifoStruct::Init()
+{
+  CPBase = 0;
+  CPEnd = 0;
+  CPHiWatermark = 0;
+  CPLoWatermark = 0;
+  CPReadWriteDistance = 0;
+  CPWritePointer = 0;
+  CPReadPointer = 0;
+  CPBreakpoint = 0;
+  SafeCPReadPointer = 0;
+
+  bFF_GPLinkEnable = 0;
+  bFF_GPReadEnable = 0;
+  bFF_BPEnable = 0;
+  bFF_BPInt = 0;
+
+  bFF_Breakpoint.store(0, std::memory_order_relaxed);
+  bFF_HiWatermark.store(0, std::memory_order_relaxed);
+  bFF_HiWatermarkInt.store(0, std::memory_order_relaxed);
+  bFF_LoWatermark.store(0, std::memory_order_relaxed);
+  bFF_LoWatermarkInt.store(0, std::memory_order_relaxed);
+}
+
 void SCPFifoStruct::DoState(PointerWrap& p)
 {
   p.Do(CPBase);
@@ -117,12 +141,7 @@ void Init()
 
   m_tokenReg = 0;
 
-  memset(&fifo, 0, sizeof(fifo));
-  fifo.bFF_Breakpoint.store(0, std::memory_order_relaxed);
-  fifo.bFF_HiWatermark.store(0, std::memory_order_relaxed);
-  fifo.bFF_HiWatermarkInt.store(0, std::memory_order_relaxed);
-  fifo.bFF_LoWatermark.store(0, std::memory_order_relaxed);
-  fifo.bFF_LoWatermarkInt.store(0, std::memory_order_relaxed);
+  fifo.Init();
 
   s_interrupt_set.Clear();
   s_interrupt_waiting.Clear();

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -40,6 +40,7 @@ struct SCPFifoStruct
   std::atomic<u32> bFF_LoWatermark;
   std::atomic<u32> bFF_HiWatermark;
 
+  void Init();
   void DoState(PointerWrap& p);
 };
 

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -333,12 +333,18 @@ void FrameDump::AddFrame(const FrameData& frame)
 
 void FrameDump::ProcessPackets()
 {
+  auto pkt = std::unique_ptr<AVPacket, std::function<void(AVPacket*)>>(
+      av_packet_alloc(), [](AVPacket* packet) { av_packet_free(&packet); });
+
+  if (!pkt)
+  {
+    ERROR_LOG_FMT(FRAMEDUMP, "Could not allocate packet");
+    return;
+  }
+
   while (true)
   {
-    AVPacket pkt;
-    av_init_packet(&pkt);
-
-    const int receive_error = avcodec_receive_packet(m_context->codec, &pkt);
+    const int receive_error = avcodec_receive_packet(m_context->codec, pkt.get());
 
     if (receive_error == AVERROR(EAGAIN) || receive_error == AVERROR_EOF)
     {
@@ -352,10 +358,10 @@ void FrameDump::ProcessPackets()
       break;
     }
 
-    av_packet_rescale_ts(&pkt, m_context->codec->time_base, m_context->stream->time_base);
-    pkt.stream_index = m_context->stream->index;
+    av_packet_rescale_ts(pkt.get(), m_context->codec->time_base, m_context->stream->time_base);
+    pkt->stream_index = m_context->stream->index;
 
-    if (const int write_error = av_interleaved_write_frame(m_context->format, &pkt))
+    if (const int write_error = av_interleaved_write_frame(m_context->format, pkt.get()))
     {
       ERROR_LOG_FMT(FRAMEDUMP, "Error writing packet: {}", write_error);
       break;


### PR DESCRIPTION
These are all mostly obvious.

The main remaining ones are:
- `DSP::SDSP` not being pod yet `offsetof()` being used on it, same for `memcpy()` on `CPMemory`.
- Some signed comparison issues where I’m not sure in which direction to cast.
- Some invalid size copies in `IOS/ES/Formats.cpp` which made me notice the addition of `ticket_version` in `Ticket` which isn’t there in `TicketView`, making me wonder just how this ever worked.