### PR TITLE
[DO NOT MERGE!!] Don't clear cache on state load.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -60,9 +60,9 @@ void JitBaseBlockCache::Shutdown()
 // is full and when saving and loading states.
 void JitBaseBlockCache::Clear()
 {
-#if defined(_DEBUG) || defined(DEBUGFAST)
+//#if defined(_DEBUG) || defined(DEBUGFAST)
   Core::DisplayMessage("Clearing code cache.", 3000);
-#endif
+//#endif
   m_jit.js.fifoWriteAddresses.clear();
   m_jit.js.pairedQuantizeAddresses.clear();
   for (auto& e : block_map)

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -49,8 +49,6 @@ void SetJit(JitBase* jit)
 }
 void DoState(PointerWrap& p)
 {
-  if (g_jit && p.GetMode() == PointerWrap::MODE_READ)
-    g_jit->ClearCache();
 }
 CPUCoreBase* InitJitCore(PowerPC::CPUCore core)
 {

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -129,8 +129,8 @@ void DoState(PointerWrap& p)
 
   if (p.GetMode() == PointerWrap::MODE_READ)
   {
-    IBATUpdated();
-    DBATUpdated();
+    //IBATUpdated();
+    //DBATUpdated();
   }
 
   // SystemTimers::DecrementerSet();


### PR DESCRIPTION
Very dangerous nonsense to test whether this could be related to TAS desyncing issues. Don't try to use this on any game that dynamically loads code into main RAM.