### PR TITLE
GameINI: Fix Final Fantasy Crystal Chronicles GBA race condition

### DIFF
--- a/Data/Sys/GameSettings/GCCE01.ini
+++ b/Data/Sys/GameSettings/GCCE01.ini
@@ -6,6 +6,29 @@
 $Fix buffer overrun bug (crash at Goblin Wall)
 0x80017B16:word:0x00003430
 
+# Fix a race condition that makes GBAs take longer to connect when entering a level.
+$Fix GBA connections
+0x800b1828:dword:0x4bf534d9
+0x80004d00:dword:0x7ce802a6
+0x80004d04:dword:0x428007f1
+0x80004d08:dword:0x3c608000
+0x80004d0c:dword:0x38834d28
+0x80004d10:dword:0x807f10a0
+0x80004d14:dword:0x38632504
+0x80004d18:dword:0x38a00018
+0x80004d1c:dword:0x428007d9
+0x80004d20:dword:0x7ce803a6
+0x80004d24:dword:0x4e800020
+0x80004d28:dword:0x0480ff20
+0x80004d2c:dword:0x18705c70
+0x80004d30:dword:0x04490120
+0x80004d34:dword:0x08700149
+0x80004d38:dword:0x0c6009e0
+0x80004d3c:dword:0x90010003
+
+[OnFrame_Enabled]
+$Fix GBA connections
+
 [ActionReplay]
 # Add action replay cheats here.
 $Infinite Health: Single Player


### PR DESCRIPTION
There is a race condition in FFCC when entering any level: GBAs will be stuck on a flickering "Waiting for connection..." screen for a random amount of time
The race happens on the GBA side during the handshake process. If the game also tries to send data during that process it will be pushed into a queue and transfers won't resume once the connection is established, causing it to timeout after 10 frames before trying again
Although this happens on HW, Dolphin is much more likely to lose the race repeatedly due to timing inaccuracies and that can last up to a minute depending on your luck and configuration which is why I believe this should be enabled by default
These patches apply the necessary changes to the rom at ``/dvd/gba/ffcc_cli.bin`` to clear the transfer queue once connected