### PR TITLE
Fixes to translatable strings

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -97,10 +97,10 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
       &m_always_connected_setting,
       // i18n: Treat a controller as always being connected regardless of what
       // devices the user actually has plugged in
-      {_trans("Always Connected"), _trans(""),
-       _trans("Always connected if checked.\n"
-              "If unchecked, it will link the emulated controller connection state\n"
-              "to the real default device connection state (if there is one).")},
+      {_trans("Always Connected"), "",
+       _trans("If checked, the emulated controller is always connected.\n"
+              "If unchecked, the connection state of the emulated controller is linked\n"
+              "to the connection state of the real default device (if there is one).")},
       false);
 }
 

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -632,6 +632,8 @@ void FIFOAnalyzer::UpdateDescription()
 
     text = QString::fromStdString(desc);
     text += QLatin1Char{'\n'};
+    // i18n: A normal matrix is a matrix used for transforming normal vectors. The word "normal"
+    // does not have its usual meaning here, but rather the meaning of "perpendicular to a surface".
     text += tr("Usually used for normal matrices");
     text += QLatin1Char{'\n'};
     text += QString::fromStdString(written);
@@ -642,6 +644,7 @@ void FIFOAnalyzer::UpdateDescription()
 
     text = QString::fromStdString(desc);
     text += QLatin1Char{'\n'};
+    // i18n: Tex coord is short for texture coordinate
     text += tr("Usually used for tex coord matrices");
     text += QLatin1Char{'\n'};
     text += QString::fromStdString(written);
@@ -659,11 +662,12 @@ void FIFOAnalyzer::UpdateDescription()
   else if ((*cmddata & 0xC0) == 0x80)
   {
     const u8 vat = *cmddata & OpcodeDecoder::GX_VAT_MASK;
-    const auto name = GetPrimitiveName(*cmddata);
+    const QString name = QString::fromStdString(GetPrimitiveName(*cmddata));
     const u16 vertex_count = Common::swap16(cmddata + 1);
 
-    text = tr("Primitive ");
-    text += QString::fromStdString(name);
+    // i18n: In this context, a primitive means a point, line, triangle or rectangle.
+    // Do not translate the word primitive as if it was an adjective.
+    text = tr("Primitive %1").arg(name);
     text += QLatin1Char{'\n'};
 
     const auto& vtx_desc = frame_info.objectCPStates[object_nr].vtxDesc;


### PR DESCRIPTION
Sending an empty string to the translation system will not result in getting an empty string back, but rather a description of the currently loaded translations file. So empty strings should not be marked as translatable.

Also adding some i18n comments and rewording a string I thought was hard to understand.