### PR TITLE
AudioPane: Remove main layout vertical stretching

### DIFF
--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -10,6 +10,7 @@
 #include <QFormLayout>
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QRadioButton>
 #include <QSlider>
@@ -155,18 +156,19 @@ void AudioPane::CreateWidgets()
   stretching_layout->addWidget(m_stretching_buffer_slider, 1, 1);
   stretching_layout->addWidget(m_stretching_buffer_indicator, 1, 2);
 
-  m_main_layout = new QGridLayout;
-
-  m_main_layout->setRowStretch(0, 0);
-
   dsp_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
-  m_main_layout->addWidget(dsp_box, 0, 0);
-  m_main_layout->addWidget(volume_box, 0, 1, -1, 1);
-  m_main_layout->addWidget(backend_box, 1, 0);
-  m_main_layout->addWidget(stretching_box, 2, 0);
+  auto* const main_vbox_layout = new QVBoxLayout;
+  main_vbox_layout->addWidget(dsp_box);
+  main_vbox_layout->addWidget(backend_box);
+  main_vbox_layout->addWidget(stretching_box);
+
+  m_main_layout = new QHBoxLayout;
+  m_main_layout->addLayout(main_vbox_layout);
+  m_main_layout->addWidget(volume_box);
 
   setLayout(m_main_layout);
+  setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 }
 
 void AudioPane::ConnectWidgets()

--- a/Source/Core/DolphinQt/Settings/AudioPane.h
+++ b/Source/Core/DolphinQt/Settings/AudioPane.h
@@ -13,8 +13,8 @@ enum class DPL2Quality;
 
 class QCheckBox;
 class QComboBox;
+class QHBoxLayout;
 class QLabel;
-class QGridLayout;
 class QRadioButton;
 class QSlider;
 class QSpinBox;
@@ -45,7 +45,7 @@ private:
   QString GetDPL2ApproximateLatencyLabel(AudioCommon::DPL2Quality value) const;
   void EnableDolbyQualityWidgets(bool enabled) const;
 
-  QGridLayout* m_main_layout;
+  QHBoxLayout* m_main_layout;
 
   // DSP Engine
   QRadioButton* m_dsp_hle;


### PR DESCRIPTION
Fixes AudioPane's layout to prevent it from vertically stretching to fill the window, which looks bad and was inconsistent with the other panes.

Before:
![Before](https://user-images.githubusercontent.com/73494713/119040096-dae3d100-b969-11eb-85a0-ad72246b2cb8.png)

After:
![After](https://user-images.githubusercontent.com/73494713/119040514-5e9dbd80-b96a-11eb-83e8-bc52f0bef972.png)
