### PR TITLE
Fix perf query regression

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DPerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DPerfQuery.cpp
@@ -27,16 +27,20 @@ PerfQuery::~PerfQuery() = default;
 
 void PerfQuery::EnableQuery(PerfQueryGroup type)
 {
-  const u32 query_count = m_query_count.load(std::memory_order_relaxed);
+  u32 query_count = m_query_count.load(std::memory_order_relaxed);
 
   // Is this sane?
   if (query_count > m_query_buffer.size() / 2)
+  {
     WeakFlush();
+    query_count = m_query_count.load(std::memory_order_relaxed);
+  }
 
   if (m_query_buffer.size() == query_count)
   {
     // TODO
     FlushOne();
+    query_count = m_query_count.load(std::memory_order_relaxed);
     ERROR_LOG_FMT(VIDEO, "Flushed query buffer early!");
   }
 

--- a/Source/Core/VideoBackends/OGL/OGLPerfQuery.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLPerfQuery.cpp
@@ -99,15 +99,19 @@ PerfQueryGL::~PerfQueryGL()
 
 void PerfQueryGL::EnableQuery(PerfQueryGroup type)
 {
-  const u32 query_count = m_query_count.load(std::memory_order_relaxed);
+  u32 query_count = m_query_count.load(std::memory_order_relaxed);
 
   // Is this sane?
   if (query_count > m_query_buffer.size() / 2)
+  {
     WeakFlush();
+    query_count = m_query_count.load(std::memory_order_relaxed);
+  }
 
   if (m_query_buffer.size() == query_count)
   {
     FlushOne();
+    query_count = m_query_count.load(std::memory_order_relaxed);
     // ERROR_LOG_FMT(VIDEO, "Flushed query buffer early!");
   }
 
@@ -195,14 +199,19 @@ PerfQueryGLESNV::~PerfQueryGLESNV()
 
 void PerfQueryGLESNV::EnableQuery(PerfQueryGroup type)
 {
-  const u32 query_count = m_query_count.load(std::memory_order_relaxed);
+  u32 query_count = m_query_count.load(std::memory_order_relaxed);
+
   // Is this sane?
   if (query_count > m_query_buffer.size() / 2)
+  {
     WeakFlush();
+    query_count = m_query_count.load(std::memory_order_relaxed);
+  }
 
   if (m_query_buffer.size() == query_count)
   {
     FlushOne();
+    query_count = m_query_count.load(std::memory_order_relaxed);
     // ERROR_LOG_FMT(VIDEO, "Flushed query buffer early!");
   }
 


### PR DESCRIPTION
When trying to do a small optimization in PR #9710, I failed to take into account that `WeakFlush` and `FlushOne` update `m_query_count`.

Only D3D11 and OGL had this problem, not D3D12 and Vulkan.