### PR TITLE
Avoid including scmrev.h except in Version.cpp

### DIFF
--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -33,6 +33,7 @@ const std::string scm_rev_git_str = SCM_REV_STR;
 const std::string scm_desc_str = SCM_DESC_STR;
 const std::string scm_branch_str = SCM_BRANCH_STR;
 const std::string scm_distributor_str = SCM_DISTRIBUTOR_STR;
+const std::string scm_update_track_str = SCM_UPDATE_TRACK_STR;
 
 #ifdef _WIN32
 const std::string netplay_dolphin_ver = SCM_DESC_STR " Win";

--- a/Source/Core/Common/Version.h
+++ b/Source/Core/Common/Version.h
@@ -14,5 +14,6 @@ extern const std::string scm_branch_str;
 extern const std::string scm_rev_str;
 extern const std::string scm_rev_git_str;
 extern const std::string scm_distributor_str;
+extern const std::string scm_update_track_str;
 extern const std::string netplay_dolphin_ver;
 }  // namespace Common

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -29,7 +29,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
-#include "Common/scmrev.h"
+#include "Common/Version.h"
 
 #include "Core/Boot/Boot.h"
 #include "Core/CommonTitles.h"
@@ -601,7 +601,7 @@ void SConfig::LoadAutoUpdateSettings(IniFile& ini)
 {
   IniFile::Section* section = ini.GetOrCreateSection("AutoUpdate");
 
-  section->Get("UpdateTrack", &m_auto_update_track, SCM_UPDATE_TRACK_STR);
+  section->Get("UpdateTrack", &m_auto_update_track, Common::scm_update_track_str);
   section->Get("HashOverride", &m_auto_update_hash_override, "");
 }
 

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -12,7 +12,7 @@
 #include "Common/NandPaths.h"
 #include "Common/SettingsHandler.h"
 #include "Common/Timer.h"
-#include "Common/scmrev.h"
+#include "Common/Version.h"
 #include "Core/BootManager.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -59,10 +59,10 @@ IPCReply GetVersion(const IOCtlVRequest& request)
     return IPCReply(IPC_EINVAL);
   }
 
-  const auto length = std::min(size_t(request.io_vectors[0].size), std::strlen(SCM_DESC_STR));
+  const auto length = std::min(size_t(request.io_vectors[0].size), Common::scm_desc_str.size());
 
   Memory::Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
-  Memory::CopyToEmu(request.io_vectors[0].address, SCM_DESC_STR, length);
+  Memory::CopyToEmu(request.io_vectors[0].address, Common::scm_desc_str.data(), length);
 
   return IPCReply(IPC_SUCCESS);
 }

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -12,7 +12,7 @@
 #include "Common/HttpRequest.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
-#include "Common/scmrev.h"
+#include "Common/Version.h"
 #include "Core/ConfigManager.h"
 
 #ifdef _WIN32
@@ -157,7 +157,7 @@ void AutoUpdateChecker::CheckForUpdate()
 #endif
 
   std::string version_hash = SConfig::GetInstance().m_auto_update_hash_override.empty() ?
-                                 SCM_REV_STR :
+                                 Common::scm_rev_str :
                                  SConfig::GetInstance().m_auto_update_hash_override;
   std::string url = "https://dolphin-emu.org/update/check/v1/" +
                     SConfig::GetInstance().m_auto_update_track + "/" + version_hash + "/" +


### PR DESCRIPTION
Any file which includes scmrev.h must be rebuilt when scmrev.h is regenerated. By not including scmrev.h from any file other than Version.cpp, incremental builds become a little faster.