### PR TITLE
JitArm64: Remove fast path for converting single to double

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -170,11 +170,9 @@ public:
   void ConvertDoubleToSinglePair(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
                                  Arm64Gen::ARM64Reg src_reg);
   void ConvertSingleToDoubleLower(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
-                                  Arm64Gen::ARM64Reg src_reg,
-                                  Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);
+                                  Arm64Gen::ARM64Reg src_reg);
   void ConvertSingleToDoublePair(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
-                                 Arm64Gen::ARM64Reg src_reg,
-                                 Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);
+                                 Arm64Gen::ARM64Reg src_reg);
 
   void FloatCompare(UGeckoInstruction inst, bool upper = false);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -678,11 +678,8 @@ void JitArm64::ConvertDoubleToSinglePair(size_t guest_reg, ARM64Reg dest_reg, AR
   ABI_PopRegisters(gpr_saved);
 }
 
-void JitArm64::ConvertSingleToDoubleLower(size_t guest_reg, ARM64Reg dest_reg, ARM64Reg src_reg,
-                                          ARM64Reg scratch_reg)
+void JitArm64::ConvertSingleToDoubleLower(size_t guest_reg, ARM64Reg dest_reg, ARM64Reg src_reg)
 {
-  ASSERT(scratch_reg != src_reg);
-
   if (js.fpr_is_store_safe[guest_reg])
   {
     m_float_emit.FCVT(64, 32, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
@@ -692,27 +689,6 @@ void JitArm64::ConvertSingleToDoubleLower(size_t guest_reg, ARM64Reg dest_reg, A
   const bool switch_to_farcode = !IsInFarCode();
 
   FlushCarry();
-
-  // Do we know that the input isn't NaN, and that the input isn't denormal or FPCR.FZ is not set?
-  // (This check unfortunately also catches zeroes)
-
-  FixupBranch fast;
-  if (scratch_reg != ARM64Reg::INVALID_REG)
-  {
-    m_float_emit.FABS(EncodeRegToSingle(scratch_reg), EncodeRegToSingle(src_reg));
-    m_float_emit.FCMP(EncodeRegToSingle(scratch_reg));
-    fast = B(CCFlags::CC_GT);
-
-    if (switch_to_farcode)
-    {
-      FixupBranch slow = B();
-
-      SwitchToFarCode();
-      SetJumpTarget(slow);
-    }
-  }
-
-  // If no (or if we don't have a scratch register), call the bit-exact routine
 
   const BitSet32 gpr_saved = gpr.GetCallerSavedUsed() & BitSet32{0, 1, 2, 3, 4, 30};
   ABI_PushRegisters(gpr_saved);
@@ -722,71 +698,17 @@ void JitArm64::ConvertSingleToDoubleLower(size_t guest_reg, ARM64Reg dest_reg, A
   m_float_emit.FMOV(EncodeRegToDouble(dest_reg), ARM64Reg::X1);
 
   ABI_PopRegisters(gpr_saved);
-
-  // If yes, do a fast conversion with FCVT
-
-  if (scratch_reg != ARM64Reg::INVALID_REG)
-  {
-    FixupBranch continue1 = B();
-
-    if (switch_to_farcode)
-      SwitchToNearCode();
-
-    SetJumpTarget(fast);
-
-    m_float_emit.FCVT(64, 32, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
-
-    SetJumpTarget(continue1);
-  }
 }
 
-void JitArm64::ConvertSingleToDoublePair(size_t guest_reg, ARM64Reg dest_reg, ARM64Reg src_reg,
-                                         ARM64Reg scratch_reg)
+void JitArm64::ConvertSingleToDoublePair(size_t guest_reg, ARM64Reg dest_reg, ARM64Reg src_reg)
 {
-  ASSERT(scratch_reg != src_reg);
-
   if (js.fpr_is_store_safe[guest_reg])
   {
     m_float_emit.FCVTL(64, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
     return;
   }
 
-  const bool switch_to_farcode = !IsInFarCode();
-
   FlushCarry();
-
-  // Do we know that neither input is NaN, and that neither input is denormal or FPCR.FZ is not set?
-  // (This check unfortunately also catches zeroes)
-
-  FixupBranch fast;
-  if (scratch_reg != ARM64Reg::INVALID_REG)
-  {
-    // Set each 32-bit element of scratch_reg to 0x0000'0000 or 0xFFFF'FFFF depending on whether
-    // the absolute value of the corresponding element in src_reg compares greater than 0
-    m_float_emit.MOVI(8, EncodeRegToDouble(scratch_reg), 0);
-    m_float_emit.FACGT(32, EncodeRegToDouble(scratch_reg), EncodeRegToDouble(src_reg),
-                       EncodeRegToDouble(scratch_reg));
-
-    // 0x0000'0000'0000'0000 (zero)     -> 0x0000'0000'0000'0000 (zero)
-    // 0x0000'0000'FFFF'FFFF (denormal) -> 0xFF00'0000'FFFF'FFFF (normal)
-    // 0xFFFF'FFFF'0000'0000 (NaN)      -> 0x00FF'FFFF'0000'0000 (normal)
-    // 0xFFFF'FFFF'FFFF'FFFF (NaN)      -> 0xFFFF'FFFF'FFFF'FFFF (NaN)
-    m_float_emit.INS(8, EncodeRegToDouble(scratch_reg), 7, EncodeRegToDouble(scratch_reg), 0);
-
-    // Is scratch_reg a NaN (0xFFFF'FFFF'FFFF'FFFF)?
-    m_float_emit.FCMP(EncodeRegToDouble(scratch_reg));
-    fast = B(CCFlags::CC_VS);
-
-    if (switch_to_farcode)
-    {
-      FixupBranch slow = B();
-
-      SwitchToFarCode();
-      SetJumpTarget(slow);
-    }
-  }
-
-  // If no (or if we don't have a scratch register), call the bit-exact routine
 
   const BitSet32 gpr_saved = gpr.GetCallerSavedUsed() & BitSet32{0, 1, 2, 3, 4, 30};
   ABI_PushRegisters(gpr_saved);
@@ -799,21 +721,6 @@ void JitArm64::ConvertSingleToDoublePair(size_t guest_reg, ARM64Reg dest_reg, AR
   m_float_emit.INS(64, dest_reg, 1, ARM64Reg::X1);
 
   ABI_PopRegisters(gpr_saved);
-
-  // If yes, do a fast conversion with FCVTL
-
-  if (scratch_reg != ARM64Reg::INVALID_REG)
-  {
-    FixupBranch continue1 = B();
-
-    if (switch_to_farcode)
-      SwitchToNearCode();
-
-    SetJumpTarget(fast);
-    m_float_emit.FCVTL(64, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
-
-    SetJumpTarget(continue1);
-  }
 }
 
 bool JitArm64::IsFPRStoreSafe(size_t guest_reg) const

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -470,9 +470,7 @@ ARM64Reg Arm64FPRCache::R(size_t preg, RegType type)
       return host_reg;
 
     // Else convert this register back to doubles.
-    const ARM64Reg tmp_reg = GetReg();
-    m_jit->ConvertSingleToDoublePair(preg, host_reg, host_reg, tmp_reg);
-    UnlockRegister(tmp_reg);
+    m_jit->ConvertSingleToDoublePair(preg, host_reg, host_reg);
 
     reg.Load(host_reg, RegType::Register);
     [[fallthrough]];
@@ -488,9 +486,7 @@ ARM64Reg Arm64FPRCache::R(size_t preg, RegType type)
       return host_reg;
 
     // Else convert this register back to a double.
-    const ARM64Reg tmp_reg = GetReg();
-    m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg, tmp_reg);
-    UnlockRegister(tmp_reg);
+    m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg);
 
     reg.Load(host_reg, RegType::LowerPair);
     [[fallthrough]];
@@ -525,9 +521,7 @@ ARM64Reg Arm64FPRCache::R(size_t preg, RegType type)
       return host_reg;
     }
 
-    const ARM64Reg tmp_reg = GetReg();
-    m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg, tmp_reg);
-    UnlockRegister(tmp_reg);
+    m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg);
 
     reg.Load(host_reg, RegType::Duplicated);
     [[fallthrough]];
@@ -600,17 +594,15 @@ ARM64Reg Arm64FPRCache::RW(size_t preg, RegType type, bool set_dirty)
       flush_reg = GetReg();
       if (!m_jit->IsFPRStoreSafe(preg))
       {
-        ARM64Reg scratch_reg = GetReg();
         m_float_emit->INS(32, flush_reg, 0, host_reg, 1);
-        m_jit->ConvertSingleToDoubleLower(preg, flush_reg, flush_reg, scratch_reg);
+        m_jit->ConvertSingleToDoubleLower(preg, flush_reg, flush_reg);
         m_float_emit->STR(64, IndexType::Unsigned, flush_reg, PPC_REG, u32(PPCSTATE_OFF_PS1(preg)));
-        Unlock(scratch_reg);
         reg.Load(host_reg, RegType::LowerPairSingle);
         break;
       }
       else
       {
-        m_jit->ConvertSingleToDoublePair(preg, flush_reg, host_reg, flush_reg);
+        m_jit->ConvertSingleToDoublePair(preg, flush_reg, host_reg);
         m_float_emit->STR(128, IndexType::Unsigned, flush_reg, PPC_REG,
                           u32(PPCSTATE_OFF_PS0(preg)));
         reg.SetDirty(false);
@@ -626,7 +618,7 @@ ARM64Reg Arm64FPRCache::RW(size_t preg, RegType type, bool set_dirty)
       break;
     case RegType::DuplicatedSingle:
       flush_reg = GetReg();
-      m_jit->ConvertSingleToDoubleLower(preg, flush_reg, host_reg, flush_reg);
+      m_jit->ConvertSingleToDoubleLower(preg, flush_reg, host_reg);
       [[fallthrough]];
     case RegType::Duplicated:
       // Store PSR1 (which is equal to PSR0) in memory.
@@ -742,36 +734,17 @@ void Arm64FPRCache::FlushRegister(size_t preg, bool maintain_state, ARM64Reg tmp
   const bool dirty = reg.IsDirty();
   RegType type = reg.GetType();
 
-  bool allocated_tmp_reg = false;
-  if (tmp_reg != ARM64Reg::INVALID_REG)
-  {
-    ASSERT(IsVector(tmp_reg));
-  }
-  else if (GetUnlockedRegisterCount() > 0)
-  {
-    // Calling GetReg here with 0 registers free could cause problems for two reasons:
-    //
-    // 1. When GetReg needs to flush, it calls this function, which can lead to infinite recursion
-    // 2. When GetReg needs to flush, it does not respect maintain_state == true
-    //
-    // So if we have 0 registers free, just don't allocate a temporary register.
-    // The emitted code will still work but might be a little less efficient.
-
-    tmp_reg = GetReg();
-    allocated_tmp_reg = true;
-  }
-
   // If we're in single mode, just convert it back to a double.
   if (type == RegType::Single)
   {
     if (dirty)
-      m_jit->ConvertSingleToDoublePair(preg, host_reg, host_reg, tmp_reg);
+      m_jit->ConvertSingleToDoublePair(preg, host_reg, host_reg);
     type = RegType::Register;
   }
   if (type == RegType::DuplicatedSingle || type == RegType::LowerPairSingle)
   {
     if (dirty)
-      m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg, tmp_reg);
+      m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg);
 
     if (type == RegType::DuplicatedSingle)
       type = RegType::Duplicated;
@@ -823,9 +796,6 @@ void Arm64FPRCache::FlushRegister(size_t preg, bool maintain_state, ARM64Reg tmp
       reg.Flush();
     }
   }
-
-  if (allocated_tmp_reg)
-    UnlockRegister(tmp_reg);
 }
 
 void Arm64FPRCache::FlushRegisters(BitSet32 regs, bool maintain_state, ARM64Reg tmp_reg)

--- a/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
@@ -52,14 +52,14 @@ public:
 
     convert_single_to_double_lower = Common::BitCast<u64 (*)(u32)>(GetCodePtr());
     m_float_emit.INS(32, ARM64Reg::S0, 0, ARM64Reg::W0);
-    ConvertSingleToDoubleLower(0, ARM64Reg::D0, ARM64Reg::S0, ARM64Reg::Q1);
+    ConvertSingleToDoubleLower(0, ARM64Reg::D0, ARM64Reg::S0);
     m_float_emit.UMOV(64, ARM64Reg::X0, ARM64Reg::D0, 0);
     RET();
 
     convert_single_to_double_pair = Common::BitCast<Pair<u64> (*)(u32, u32)>(GetCodePtr());
     m_float_emit.INS(32, ARM64Reg::D0, 0, ARM64Reg::W0);
     m_float_emit.INS(32, ARM64Reg::D0, 1, ARM64Reg::W1);
-    ConvertSingleToDoublePair(0, ARM64Reg::Q0, ARM64Reg::D0, ARM64Reg::Q1);
+    ConvertSingleToDoublePair(0, ARM64Reg::Q0, ARM64Reg::D0);
     m_float_emit.UMOV(64, ARM64Reg::X0, ARM64Reg::Q0, 0);
     m_float_emit.UMOV(64, ARM64Reg::X1, ARM64Reg::Q0, 1);
     RET();


### PR DESCRIPTION
The fast path is of course faster in the cases where we can take it, but the added check for whether to use the fast path gives us additional overhead in the slow case, and the extra code has a negative impact on the icache.

I'm submitting this as a pull request so that we can do performance testing on it. Do not merge this unless it's shown to be faster!