### PR TITLE
VideoCommon/TextureInfo: Restore old mipmap detection logic

### DIFF
--- a/Source/Core/VideoCommon/TextureInfo.cpp
+++ b/Source/Core/VideoCommon/TextureInfo.cpp
@@ -74,6 +74,7 @@ TextureInfo::TextureInfo(const u8* ptr, const u8* tlut_ptr, u32 address,
 
   if (mip_count)
   {
+    m_mipmaps_enabled = true;
     const u32 raw_mip_count = *mip_count;
 
     // GPUs don't like when the specified mipmap count would require more than one 1x1-sized LOD in
@@ -151,7 +152,7 @@ TextureInfo::NameDetails TextureInfo::CalculateTextureName()
 
   NameDetails result;
   result.base_name = fmt::format("{}{}x{}{}_{:016x}", format_prefix, m_raw_width, m_raw_height,
-                                 m_mip_levels.empty() ? "" : "_m", tex_hash);
+                                 m_mipmaps_enabled ? "_m" : "", tex_hash);
   result.tlut_name = tlut_size ? fmt::format("_{:016x}", tlut_hash) : "";
   result.format_name = fmt::format("_{}", static_cast<int>(m_texture_format));
 

--- a/Source/Core/VideoCommon/TextureInfo.h
+++ b/Source/Core/VideoCommon/TextureInfo.h
@@ -102,6 +102,7 @@ private:
   TextureFormat m_texture_format;
   TLUTFormat m_tlut_format;
 
+  bool m_mipmaps_enabled = false;
   std::vector<MipLevel> m_mip_levels;
 
   u32 m_texture_size = 0;


### PR DESCRIPTION
A slight change to the logic here broke existing texture packs. While it's not ideal that texture names imply they have mipmaps when there's 0 mip levels, that's the way it was written so we're stuck with it.

Fixes https://bugs.dolphin-emu.org/issues/12514