### PR TITLE
Interpreter: Fix fctiwx rounding

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -73,7 +73,8 @@ void ConvertToInteger(UGeckoInstruction inst, RoundingMode rounding_mode)
       const double t = b + 0.5;
       i = static_cast<s32>(t);
 
-      if (t - i < 0 || (t - i == 0 && b > 0))
+      // Ties to even
+      if (t - i < 0 || (t - i == 0 && (i & 1)))
       {
         i--;
       }


### PR DESCRIPTION
The interpreter implementation of fctiwx was treating rounding mode 0 as "round to nearest, ties towards zero", which is not an actual IEEE-754 rounding mode. The IBM document mentioned in a comment at the top of the function, on the other hand, treats rounding mode 0 as "round to nearest, ties to even", which makes more sense.

This fixes one of JMC's console-recorded F-Zero GX replays on JitArm64. (JitArm64 uses an interpreter fallback for fctiwx.)