### PR TITLE
DSP: Approximate INT_AID timing based on hwtest

### DIFF
--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -397,8 +397,11 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 
           // TODO: need hardware tests for the timing of this interrupt.
           // Sky Crawlers crashes at boot if this is scheduled less than 87 cycles in the future.
-          // Other Namco games crash too, see issue 9509. For now we will just push it to 200 cycles
-          CoreTiming::ScheduleEvent(200, s_et_GenerateDSPInterrupt, INT_AID);
+          // Other Namco games crash too, see issue 9509.
+          // Real hardware takes roughly ~68 microseconds to trigger libogc DMA callback based on
+          // https://dolp.in/pr9741 hardware test. The amount of cycles for this interrupt is
+          // approximated to reach this timing value.
+          CoreTiming::ScheduleEvent(17000, s_et_GenerateDSPInterrupt, INT_AID);
         }
       }));
 


### PR DESCRIPTION
This PR fixes this issue where Syobon Action isn't booting properly: https://dolp.in/i12498

After the interrupt is triggered the game can't resume its normal execution. The interrupt callback is called too frequently preventing it to load its splash screen and continue its normal execution.

I wrote a [hardware test](https://github.com/dolphin-emu/dolphin/files/6526913/wii-dma-start.zip) to approximate **roughly** the timing of this interrupt:
![hw_dma](https://user-images.githubusercontent.com/7890055/119236734-150bc900-bb4a-11eb-9501-21f85bb405fc.jpg)

This test tries to imitate the behaviour of an [old version of libasnd](https://github.com/devkitPro/libogc/blob/36f6bef9e1e8cb021a03d041ce0b47b568154d27/libasnd/asndlib.c#L268) that Syobon Action probably used. I say **roughly** as the timing is biased and taken at the beginning of libogc's DMA callback not right after the interrupt is triggered. Regardless, it gives a rough idea of the timing window of this interrupt.

The games I own are still working but the ones sensitive to this timing change should be tested.