### PR TITLE
Software: Fix bad backbuffer size

### DIFF
--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -27,7 +27,8 @@
 namespace SW
 {
 SWRenderer::SWRenderer(std::unique_ptr<SWOGLWindow> window)
-    : ::Renderer(static_cast<int>(MAX_XFB_WIDTH), static_cast<int>(MAX_XFB_HEIGHT), 1.0f,
+    : ::Renderer(static_cast<int>(std::max(window->GetContext()->GetBackBufferWidth(), 1u)),
+                 static_cast<int>(std::max(window->GetContext()->GetBackBufferHeight(), 1u)), 1.0f,
                  AbstractTextureFormat::RGBA8),
       m_window(std::move(window))
 {
@@ -54,6 +55,18 @@ SWRenderer::CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture
 {
   return SWFramebuffer::Create(static_cast<SWTexture*>(color_attachment),
                                static_cast<SWTexture*>(depth_attachment));
+}
+
+void SWRenderer::BindBackbuffer(const ClearColor& clear_color)
+{
+  // Look for framebuffer resizes
+  if (!m_surface_resized.TestAndClear())
+    return;
+
+  GLContext* context = m_window->GetContext();
+  context->Update();
+  m_backbuffer_width = context->GetBackBufferWidth();
+  m_backbuffer_height = context->GetBackBufferHeight();
 }
 
 class SWShader final : public AbstractShader

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -27,6 +27,8 @@ public:
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 
+  void BindBackbuffer(const ClearColor& clear_color = {}) override;
+
   std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
                                                          std::string_view source) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,


### PR DESCRIPTION
`MAX_XFB_WIDTH`/`HEIGHT` are the largest XFB sizes seen in practice, but do not make sense to use for the backbuffer size, which should be the size of the window.  The old code created screenshots with a size of 720x540 on NTSC games when "Dump Frames at Internal Resolution" is unchecked; now, the window size is used.  See [bug 12519](https://bugs.dolphin-emu.org/issues/12519) (though note that this does not entirely fix that).

With "Auto-Adjust Window Size" checked, screenshots of Super Mario Sunshine's title screen are now 640 by 480 with or without "Dump Frames at Internal Resolution" checked.  With "Dump Frames at Internal Resolution" unchecked, resizing the window results in the screenshot being saved at a 4:3 aspect ratio based on the window's height (the software renderer itself also stretches the image, unlike other renderers which add bars on the side to maintain 4:3).

This change was based on the following code from `OGLRenderer`:

https://github.com/dolphin-emu/dolphin/blob/95aadff0e7f8e5f6bbcc0d7d650e45040b417e6b/Source/Core/VideoBackends/OGL/OGLRender.cpp#L325-L328
https://github.com/dolphin-emu/dolphin/blob/95aadff0e7f8e5f6bbcc0d7d650e45040b417e6b/Source/Core/VideoBackends/OGL/OGLRender.cpp#L1105-L1114