### PR TITLE
Qt/GeneralPane: Refresh widget state on config change

### DIFF
--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -55,6 +55,7 @@ GeneralPane::GeneralPane(QWidget* parent) : QWidget(parent)
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &GeneralPane::OnEmulationStateChanged);
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, &GeneralPane::LoadConfig);
 
   OnEmulationStateChanged(Core::GetState());
 }
@@ -235,6 +236,8 @@ void GeneralPane::CreateAnalytics()
 
 void GeneralPane::LoadConfig()
 {
+  const QSignalBlocker blocker(this);
+
   if (AutoUpdateChecker::SystemSupportsAutoUpdates())
   {
     const auto track = Settings::Instance().GetAutoUpdateTrack().toStdString();


### PR DESCRIPTION
This fixes a nasty issue where you can change the Dual Core setting during emulation, if it has been overridden by GameINI or NetPlay, by simply changing any of the non-disabled settings. This is because changing any of the settings will write all of them to the config.

This issue is particularly nasty because managing to disable Dual Core during emulation, and then stopping it, results in the emulator core being totally deadlocked. It's impossible to recover from this state, and Dolphin will remain as a zombie process on the system, consuming resources and holding locks, until forcibly killed.