### PR TITLE
JitArm64: Jump to dispatcher on downcount <= 0, not < 0

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
@@ -34,7 +34,7 @@ void JitArm64BlockCache::WriteLinkBlock(Arm64Gen::ARM64XEmitter& emit,
     // The "fast" BL must be the third instruction. So just use the former two to inline the
     // downcount check here. It's better to do this near jump before the long jump to the other
     // block.
-    FixupBranch fast_link = emit.B(CC_PL);
+    FixupBranch fast_link = emit.B(CC_GT);
     emit.BL(dest->checkedEntry);
     emit.SetJumpTarget(fast_link);
     emit.BL(dest->normalEntry);
@@ -45,13 +45,13 @@ void JitArm64BlockCache::WriteLinkBlock(Arm64Gen::ARM64XEmitter& emit,
   s64 distance = ((s64)dest->normalEntry - (s64)emit.GetCodePtr()) >> 2;
   if (distance >= -0x40000 && distance <= 0x3FFFF)
   {
-    emit.B(CC_PL, dest->normalEntry);
+    emit.B(CC_GT, dest->normalEntry);
     emit.B(dest->checkedEntry);
     emit.BRK(101);
     return;
   }
 
-  FixupBranch fast_link = emit.B(CC_PL);
+  FixupBranch fast_link = emit.B(CC_GT);
   emit.B(dest->checkedEntry);
   emit.SetJumpTarget(fast_link);
   emit.B(dest->normalEntry);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -80,8 +80,7 @@ void JitArm64::GenerateAsm()
 
   // Downcount Check
   // The result of slice decrementation should be in flags if somebody jumped here
-  // IMPORTANT - We jump on negative, not carry!!!
-  FixupBranch bail = B(CC_MI);
+  FixupBranch bail = B(CC_LE);
 
   dispatcher_no_check = GetCodePtr();
 


### PR DESCRIPTION
All the other CPU emulation cores do it on <= 0.