### PR TITLE
Updater: Escape HTML characters in commit descriptions

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -5,6 +5,7 @@
 #include "Common/StringUtil.h"
 
 #include <algorithm>
+#include <array>
 #include <codecvt>
 #include <cstdarg>
 #include <cstddef>
@@ -664,3 +665,21 @@ std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line)
   return argv;
 }
 #endif
+
+std::string GetEscapedHtml(std::string html)
+{
+  static constexpr std::array<std::array<const char*, 2>, 5> replacements{{
+      // Escape ampersand first to avoid escaping the ampersands in other replacements
+      {{"&", "&amp;"}},
+      {{"<", "&lt;"}},
+      {{">", "&gt;"}},
+      {{"\"", "&quot;"}},
+      {{"'", "&apos;"}},
+  }};
+
+  for (const auto& [unescaped, escaped] : replacements)
+  {
+    html = ReplaceAll(html, unescaped, escaped);
+  }
+  return html;
+}

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -242,3 +242,5 @@ inline bool IsPrintableCharacter(char c)
 #ifdef _WIN32
 std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
 #endif
+
+std::string GetEscapedHtml(std::string html);

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -109,10 +109,10 @@ std::string GenerateChangelog(const picojson::array& versions)
       {
         changelog += ver_obj["shortrev"].get<std::string>();
       }
-
+      const std::string escaped_description =
+          GetEscapedHtml(ver_obj["short_descr"].get<std::string>());
       changelog += " by <a href = \"" + ver_obj["author_url"].get<std::string>() + "\">" +
-                   ver_obj["author"].get<std::string>() + "</a> &mdash; " +
-                   ver_obj["short_descr"].get<std::string>();
+                   ver_obj["author"].get<std::string>() + "</a> &mdash; " + escaped_description;
     }
     else
     {

--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -105,3 +105,13 @@ TEST(StringUtil, ToString_TryParse_Roundtrip)
   DoRoundTripTest<float>({0.0f, 1.0f, -1.0f, -0.5f, 0.5f, -1e-3f, 1e-3f, 1e3f, -1e3f});
   DoRoundTripTest<double>({0.0, 1.0, -1.0, -0.5, 0.5, -1e-3, 1e-3, 1e3, -1e3});
 }
+
+TEST(StringUtil, GetEscapedHtml)
+{
+  static constexpr auto no_escape_needed =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+      "!@#$%^*()-_=+,./?;:[]{}| \\\t\n";
+  EXPECT_EQ(GetEscapedHtml(no_escape_needed), no_escape_needed);
+  EXPECT_EQ(GetEscapedHtml("&<>'\""), "&amp;&lt;&gt;&apos;&quot;");
+  EXPECT_EQ(GetEscapedHtml("&&&"), "&amp;&amp;&amp;");
+}


### PR DESCRIPTION
Escapes &<>'" characters in the "Update available" modal's short commit descriptions.

Before:
![Before](https://user-images.githubusercontent.com/73494713/119396373-9d44b800-bc89-11eb-81a1-7b139c428a90.png)

After:
![After](https://user-images.githubusercontent.com/73494713/119396386-a0d83f00-bc89-11eb-9d17-12518fa45a8d.png)

Fixes https://bugs.dolphin-emu.org/issues/12521
