### PR TITLE
Android: Use DeleteLocalRef more in AndroidCommon

### DIFF
--- a/Source/Android/jni/GameList/GameFileCache.cpp
+++ b/Source/Android/jni/GameList/GameFileCache.cpp
@@ -69,20 +69,8 @@ JNIEXPORT jobject JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_add
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_update(
     JNIEnv* env, jobject obj, jobjectArray folder_paths, jboolean recursive_scan)
 {
-  jsize size = env->GetArrayLength(folder_paths);
-
-  std::vector<std::string> folder_paths_vector;
-  folder_paths_vector.reserve(size);
-
-  for (jsize i = 0; i < size; ++i)
-  {
-    const auto path = reinterpret_cast<jstring>(env->GetObjectArrayElement(folder_paths, i));
-    folder_paths_vector.push_back(GetJString(env, path));
-    env->DeleteLocalRef(path);
-  }
-
   return GetPointer(env, obj)->Update(
-      UICommon::FindAllGamePaths(folder_paths_vector, recursive_scan));
+      UICommon::FindAllGamePaths(JStringArrayToVector(env, folder_paths), recursive_scan));
 }
 
 JNIEXPORT jboolean JNICALL


### PR DESCRIPTION
Any local references get cleaned up when returning to the JVM, but some of the functions in AndroidCommon return to C++ rather than the JVM, and functions with loops risk running into the limit of how many simultaneous local references are allowed.