### PR TITLE
JitArm64: Make fcmpX with flush-to-zero enabled less bad

### DIFF
--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -63,13 +63,13 @@ CPUInfo::CPUInfo()
 void CPUInfo::Detect()
 {
   // Set some defaults here
-  // When ARMv8 CPUs come out, these need to be updated.
   HTT = false;
   OS64bit = true;
   CPU64bit = true;
   Mode64bit = true;
   vendor = CPUVendor::ARM;
   bFlushToZero = true;
+  bAFP = false;
 
 #ifdef __APPLE__
   num_cores = std::thread::hardware_concurrency();

--- a/Source/Core/Common/CPUDetect.h
+++ b/Source/Core/Common/CPUDetect.h
@@ -64,6 +64,7 @@ struct CPUInfo
   bool bCRC32 = false;
   bool bSHA1 = false;
   bool bSHA2 = false;
+  bool bAFP = false;  // Alternate floating-point behavior
 
   // Call Detect()
   explicit CPUInfo();


### PR DESCRIPTION
See the added code comment for details. Fixes Pokémon Battle Revolution not progressing past the title screen.