### PR TITLE
Android: Disable building unit tests by default

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -73,6 +73,9 @@ android {
                 arguments "-DANDROID_STL=c++_static", "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
                 // , "-DENABLE_GENERIC=ON"
                 abiFilters "arm64-v8a", "x86_64" //, "armeabi-v7a", "x86"
+
+                // Remove the line below if you want to build the C++ unit tests
+                targets "main"
             }
         }
     }


### PR DESCRIPTION
This reduces the build time for incremental builds from about 2 minutes to about 20 seconds. Most people never run the unit tests on Android anyway (I'm not aware of anyone other than me ever having done it).