### PR TITLE
VolumeVerifier: increase problem severity for incorrectly signed TMDs

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -971,7 +971,11 @@ void VolumeVerifier::CheckMisc()
         es->VerifyContainer(IOS::HLE::ESDevice::VerifyContainerType::TMD,
                             IOS::HLE::ESDevice::VerifyMode::DoNotUpdateCertStore, tmd, cert_chain))
     {
-      AddProblem(Severity::Low, Common::GetStringT("The TMD is not correctly signed."));
+      AddProblem(
+          Severity::Medium,
+          Common::GetStringT("The TMD is not correctly signed. If you move or copy this title to "
+                             "the SD Card, the Wii System Menu will not launch it anymore and will "
+                             "also refuse to copy or move it back to the NAND."));
     }
   }
 


### PR DESCRIPTION
To avoid problems, Dolphin currently enforces a 512 MB size limit to the emulated Wii NAND. Since this can be rather small (especially if you have a lot of Virtual Console or WiiWare titles), the Wii System Menu 4.0+ ability to move channels to the SD Card is extremely helpful, especially when you can create virtual SD Cards as big as 32 GB and have them working without issues with Dolphin.

While moving titles to the virtual SD Card, I stumbled upon a few that would behave oddly: Dolphin could successfully launch them if booted directly from the WAD, as well as if booted from inside the Wii System Menu while they were stored on the NAND. From the data management screen, System Menu would also successfully copy or move those channels to the SD Card without errors. However, the transfer was one-way only: once stored on the SD Card, Wii System Menu would refuse to launch them ("This channel failed to load") as well as refuse to move or copy them back to the NAND ("The data may not have been copied/moved").

After a couple of tests and checks between the WADs that worked and the ones that didn't, I found the culprit: an incorrectly signed TMD. When a channel is stored on the SD Card, Wii System Menu will temporarily import it to the NAND before launching from there, checking the TMD in the process and refusing contents with incorrectly signed TMDs. The same happens when copying/moving content from the SD Card to the NAND, contents with incorrectly signed TMDs are refused. It doesn't seem to care about incorrectly signed tickets, however, those could be launched just fine from the SD Card.

Dolphin also doesn't seem to care about an incorrectly signed TMD when booting or installing WADs and the Wii System Menu apparently doesn't check the TMD signature either for contents already installed on the NAND, but it becomes an issue in the other scenarios (launching from the SD Card and copying/moving from the SD Card to the NAND).

So, **TL;DR**, this PR increases the problem severity on VolumeVerifier for WADs with incorrectly signed TMDs to medium and updates its description. Ccing @JosJuice and @leoetlino since this is related to areas you've extensively worked in the past...