### PR TITLE
Replace MemoryCard251 setting with generic MemoryCardSize

### DIFF
--- a/Data/Sys/GameSettings/GDK.ini
+++ b/Data/Sys/GameSettings/GDK.ini
@@ -4,7 +4,7 @@
 # Values set here will override the main Dolphin settings.
 # This game does not work properly with large memorycards, use a 251 block card
 # see https://www.nintendo.com/consumer/memorycard1019.jsp
-MemoryCard251 = True
+MemoryCardSize = 2
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GDQ.ini
+++ b/Data/Sys/GameSettings/GDQ.ini
@@ -4,7 +4,7 @@
 # Values set here will override the main Dolphin settings.
 # This game does not work properly with large memorycards, use a 251 block card
 # see https://www.nintendo.com/consumer/memorycard1019.jsp
-MemoryCard251 = True
+MemoryCardSize = 2
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GDX.ini
+++ b/Data/Sys/GameSettings/GDX.ini
@@ -2,4 +2,4 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MemoryCard251 = True
+MemoryCardSize = 2

--- a/Data/Sys/GameSettings/GPXJ01.ini
+++ b/Data/Sys/GameSettings/GPXJ01.ini
@@ -1,0 +1,4 @@
+# GPXJ01 - Pokémon Box: Ruby & Sapphire (JAP)
+
+[Core]
+MemoryCardSize = 0

--- a/Data/Sys/GameSettings/GWL.ini
+++ b/Data/Sys/GameSettings/GWL.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MemoryCard251 = True
+MemoryCardSize = 2
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GWT.ini
+++ b/Data/Sys/GameSettings/GWT.ini
@@ -4,7 +4,7 @@
 # Values set here will override the main Dolphin settings.
 # This game does not work properly with large memorycards, use a 251 block card
 # see https://www.nintendo.com/consumer/memorycard1019.jsp
-MemoryCard251 = True
+MemoryCardSize = 2
 CPUThread = False
 
 [OnLoad]

--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -75,11 +75,12 @@ void Init()
   CEXIMemoryCard::Init();
 
   {
-    bool use_memcard_251;
+    u16 size_mbits = Memcard::MBIT_SIZE_MEMORY_CARD_2043;
+    int size_override;
     IniFile gameIni = SConfig::GetInstance().LoadGameIni();
-    gameIni.GetOrCreateSection("Core")->Get("MemoryCard251", &use_memcard_251, false);
-    const u16 size_mbits =
-        use_memcard_251 ? Memcard::MBIT_SIZE_MEMORY_CARD_251 : Memcard::MBIT_SIZE_MEMORY_CARD_2043;
+    gameIni.GetOrCreateSection("Core")->Get("MemoryCardSize", &size_override, -1);
+    if (size_override >= 0 && size_override <= 4)
+      size_mbits = Memcard::MBIT_SIZE_MEMORY_CARD_59 << size_override;
     const bool shift_jis =
         SConfig::ToGameCubeRegion(SConfig::GetInstance().m_region) == DiscIO::Region::NTSC_J;
     const CardFlashId& flash_id = g_SRAM.settings_ex.flash_id[Memcard::SLOT_A];

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -236,8 +236,11 @@ void CEXIMemoryCard::SetupRawMemcard(u16 size_mb)
       SConfig::GetDirectoryForRegion(SConfig::ToGameCubeRegion(SConfig::GetInstance().m_region));
   MemoryCard::CheckPath(filename, region_dir, is_slot_a);
 
-  if (size_mb == Memcard::MBIT_SIZE_MEMORY_CARD_251)
-    filename.insert(filename.find_last_of('.'), ".251");
+  if (size_mb < Memcard::MBIT_SIZE_MEMORY_CARD_2043)
+  {
+    filename.insert(filename.find_last_of('.'),
+                    fmt::format(".{}", Memcard::MbitToFreeBlocks(size_mb)));
+  }
 
   m_memory_card = std::make_unique<MemoryCard>(filename, m_card_index, size_mb);
 }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -673,7 +673,7 @@ std::optional<DEntry> GCMemcard::GetDEntry(u8 index) const
 BlockAlloc::BlockAlloc(u16 size_mbits)
 {
   memset(this, 0, BLOCK_SIZE);
-  m_free_blocks = (size_mbits * MBIT_TO_BLOCKS) - MC_FST_BLOCKS;
+  m_free_blocks = MbitToFreeBlocks(size_mbits);
   m_last_allocated_block = 4;
   FixChecksums();
 }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -141,6 +141,11 @@ constexpr u8 MEMORY_CARD_ICON_FORMAT_CI8_UNIQUE_PALETTE = 3;
 // each palette entry is 16 bits in RGB5A3 format
 constexpr u32 MEMORY_CARD_CI8_PALETTE_ENTRIES = 256;
 
+constexpr u32 MbitToFreeBlocks(u16 size_mb)
+{
+  return size_mb * MBIT_TO_BLOCKS - MC_FST_BLOCKS;
+}
+
 struct GCMBlock
 {
   GCMBlock();

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -203,8 +203,7 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot,
   }
 
   // leave about 10% of free space on the card if possible
-  const int total_blocks =
-      m_hdr.m_data.m_size_mb * Memcard::MBIT_TO_BLOCKS - Memcard::MC_FST_BLOCKS;
+  const int total_blocks = Memcard::MbitToFreeBlocks(m_hdr.m_data.m_size_mb);
   const int reserved_blocks = total_blocks / 10;
 
   // load files for other games

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -39,6 +39,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/GeckoCode.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
+#include "Core/HW/GCMemcard/GCMemcard.h"
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/SI/SI_Device.h"
 #include "Core/HW/SI/SI_DeviceGCController.h"
@@ -856,8 +857,8 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
 
       bool is_slot_a;
       std::string region;
-      bool mc251;
-      packet >> is_slot_a >> region >> mc251;
+      int size_override;
+      packet >> is_slot_a >> region >> size_override;
 
       // This check is mainly intended to filter out characters which have special meanings in paths
       if (region != JAP_DIR && region != USA_DIR && region != EUR_DIR)
@@ -866,8 +867,15 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
         return 0;
       }
 
+      std::string size_suffix;
+      if (size_override >= 0 && size_override <= 4)
+      {
+        size_suffix = fmt::format(
+            ".{}", Memcard::MbitToFreeBlocks(Memcard::MBIT_SIZE_MEMORY_CARD_59 << size_override));
+      }
+
       const std::string path = File::GetUserPath(D_GCUSER_IDX) + GC_MEMCARD_NETPLAY +
-                               (is_slot_a ? "A." : "B.") + region + (mc251 ? ".251" : "") + ".raw";
+                               (is_slot_a ? "A." : "B.") + region + size_suffix + ".raw";
       if (File::Exists(path) && !File::Delete(path))
       {
         PanicAlertFmtT("Failed to delete NetPlay memory card. Verify your write permissions.");


### PR DESCRIPTION
This allows for a broader range of game-specific memory card sizes to be configured. Needed for Japanese version of Pokémon Box: Ruby & Sapphire, as that game requires a 59 block memory card.

Fixes https://bugs.dolphin-emu.org/issues/12185

The value follows a power of two scale, with 4 Mbit (59 blocks) as the base, so the sizes are as follows:
0 = 4 Mbit (59 blocks)
1 = 8 Mbit (123 blocks)
2 = 16 Mbit (251 blocks)
3 = 32 Mbit (507 blocks)
4 = 64 Mbit (1019 blocks)

Any value outside this range of 0-4 is simply ignored. 5 is technically valid, but we don't handle it specially as it would just be the default/maximum memory card size of 128 Mbit (2043 blocks).