### PR TITLE
JitArm64: Flush outputs to zero in software

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -2925,6 +2925,11 @@ void ARM64FloatEmitter::ADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
   ASSERT_MSG(DYNA_REC, IsDouble(Rd), "%s only supports double registers!", __func__);
   EmitScalarThreeSame(0, 3, 0b10000, Rd, Rn, Rm);
 }
+void ARM64FloatEmitter::CMTST(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
+{
+  ASSERT_MSG(DYNA_REC, IsDouble(Rd), "%s only supports double registers!", __func__);
+  EmitScalarThreeSame(0, 3, 0b10001, Rd, Rn, Rm);
+}
 void ARM64FloatEmitter::FADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
   EmitScalar2Source(0, 0, IsDouble(Rd), 2, Rd, Rn, Rm);
@@ -3019,6 +3024,20 @@ void ARM64FloatEmitter::BIT(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 void ARM64FloatEmitter::BSL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
   EmitThreeSame(1, 1, 3, Rd, Rn, Rm);
+}
+void ARM64FloatEmitter::CMTST(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
+{
+  u32 encoded_size = 0;
+  if (size == 8)
+    encoded_size = 0;
+  else if (size == 16)
+    encoded_size = 1;
+  else if (size == 32)
+    encoded_size = 2;
+  else if (size == 64)
+    encoded_size = 3;
+
+  EmitThreeSame(0, encoded_size, 0b10001, Rd, Rn, Rm);
 }
 void ARM64FloatEmitter::DUP(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 {

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -1225,6 +1225,7 @@ public:
 
   // Scalar - 2 Source
   void ADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+  void CMTST(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
   void FADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
   void FMUL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
   void FSUB(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
@@ -1251,6 +1252,7 @@ public:
   void BIF(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
   void BIT(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
   void BSL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+  void CMTST(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
   void DUP(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index);
   void FABS(u8 size, ARM64Reg Rd, ARM64Reg Rn);
   void FADD(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);

--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -68,8 +68,10 @@ void CPUInfo::Detect()
   Mode64bit = true;
   vendor = CPUVendor::ARM;
   bFMA = true;
-  bFlushToZero = true;
   bAFP = false;
+
+  // We don't want to enable flush-to-zero if it causes inputs to be flushed
+  bFlushToZero = bAFP;
 
 #ifdef __APPLE__
   num_cores = std::thread::hardware_concurrency();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -286,6 +286,7 @@ protected:
                bool Rc = false);
 
   void SetFPRFIfNeeded(bool single, Arm64Gen::ARM64Reg reg);
+  void FlushToZeroIfNeeded(bool single, bool packed, Arm64Gen::ARM64Reg reg);
   void Force25BitPrecision(Arm64Gen::ARM64Reg output, Arm64Gen::ARM64Reg input,
                            Arm64Gen::ARM64Reg temp);
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -167,8 +167,7 @@ public:
   void ConvertDoubleToSinglePair(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
                                  Arm64Gen::ARM64Reg src_reg);
   void ConvertSingleToDoubleLower(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
-                                  Arm64Gen::ARM64Reg src_reg,
-                                  Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);
+                                  Arm64Gen::ARM64Reg src_reg);
   void ConvertSingleToDoublePair(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
                                  Arm64Gen::ARM64Reg src_reg,
                                  Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Common/Arm64Emitter.h"
-#include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
@@ -377,19 +376,7 @@ void JitArm64::FloatCompare(UGeckoInstruction inst, bool upper)
   const u32 b = inst.FB;
   const int crf = inst.CRFD;
 
-  // On the GC/Wii CPU, outputs are flushed to zero if FPSCR.NI is set, and inputs are never
-  // flushed to zero. Ideally we would emulate FPSCR.NI by setting FPCR.FZ and FPCR.AH, but
-  // unfortunately FPCR.AH is a very new feature that we can't rely on (as of 2021). For CPUs
-  // without FPCR.AH, the best we can do (without killing the performance by explicitly flushing
-  // outputs using bitwise operations) is to only set FPCR.FZ, which flushes both inputs and
-  // outputs. This may cause problems in some cases, and one such case is Pokémon Battle Revolution,
-  // which does not progress past the title screen if a denormal single compares equal to zero.
-  // Workaround: Perform the comparison using a double operation instead. This ensures that denormal
-  // singles behave correctly in comparisons, but we still have a problem with denormal doubles.
-  const bool input_ftz_workaround =
-      !cpu_info.bAFP && (!js.fpr_is_store_safe[a] || !js.fpr_is_store_safe[b]);
-
-  const bool singles = fpr.IsSingle(a, !upper) && fpr.IsSingle(b, !upper) && !input_ftz_workaround;
+  const bool singles = fpr.IsSingle(a, !upper) && fpr.IsSingle(b, !upper);
   const RegType lower_type = singles ? RegType::LowerPairSingle : RegType::LowerPair;
   const RegType upper_type = singles ? RegType::Single : RegType::Register;
   const auto reg_encoder = singles ? EncodeRegToSingle : EncodeRegToDouble;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -117,6 +117,7 @@ void JitArm64::ps_mulsX(UGeckoInstruction inst)
 
   fpr.FixSinglePrecision(d);
 
+  FlushToZeroIfNeeded(true, true, VD);
   SetFPRFIfNeeded(true, VD);
 }
 
@@ -268,6 +269,7 @@ void JitArm64::ps_maddXX(UGeckoInstruction inst)
 
   fpr.FixSinglePrecision(d);
 
+  FlushToZeroIfNeeded(true, true, VD);
   SetFPRFIfNeeded(true, VD);
 }
 
@@ -354,6 +356,7 @@ void JitArm64::ps_sumX(UGeckoInstruction inst)
 
   fpr.FixSinglePrecision(d);
 
+  FlushToZeroIfNeeded(true, true, VD);
   SetFPRFIfNeeded(true, VD);
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -499,9 +499,7 @@ ARM64Reg Arm64FPRCache::R(size_t preg, RegType type)
       return host_reg;
 
     // Else convert this register back to a double.
-    const ARM64Reg tmp_reg = GetReg();
-    m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg, tmp_reg);
-    UnlockRegister(tmp_reg);
+    m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg);
 
     reg.Load(host_reg, RegType::LowerPair);
     [[fallthrough]];
@@ -536,9 +534,7 @@ ARM64Reg Arm64FPRCache::R(size_t preg, RegType type)
       return host_reg;
     }
 
-    const ARM64Reg tmp_reg = GetReg();
-    m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg, tmp_reg);
-    UnlockRegister(tmp_reg);
+    m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg);
 
     reg.Load(host_reg, RegType::Duplicated);
     [[fallthrough]];
@@ -622,11 +618,9 @@ ARM64Reg Arm64FPRCache::RW(size_t preg, RegType type)
       flush_reg = GetReg();
       if (!m_jit->IsFPRStoreSafe(preg))
       {
-        ARM64Reg scratch_reg = GetReg();
         m_float_emit->INS(32, flush_reg, 0, host_reg, 1);
-        m_jit->ConvertSingleToDoubleLower(preg, flush_reg, flush_reg, scratch_reg);
+        m_jit->ConvertSingleToDoubleLower(preg, flush_reg, flush_reg);
         m_float_emit->STR(64, IndexType::Unsigned, flush_reg, PPC_REG, u32(PPCSTATE_OFF_PS1(preg)));
-        Unlock(scratch_reg);
         break;
       }
       else
@@ -645,7 +639,7 @@ ARM64Reg Arm64FPRCache::RW(size_t preg, RegType type)
       break;
     case RegType::DuplicatedSingle:
       flush_reg = GetReg();
-      m_jit->ConvertSingleToDoubleLower(preg, flush_reg, host_reg, flush_reg);
+      m_jit->ConvertSingleToDoubleLower(preg, flush_reg, host_reg);
       [[fallthrough]];
     case RegType::Duplicated:
       // Store PSR1 (which is equal to PSR0) in memory.
@@ -789,7 +783,7 @@ void Arm64FPRCache::FlushRegister(size_t preg, bool maintain_state, ARM64Reg tmp
   if (type == RegType::DuplicatedSingle || type == RegType::LowerPairSingle)
   {
     if (dirty)
-      m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg, tmp_reg);
+      m_jit->ConvertSingleToDoubleLower(preg, host_reg, host_reg);
 
     if (type == RegType::DuplicatedSingle)
       type = RegType::Duplicated;

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -395,6 +395,8 @@ void JitArm64::GenerateConvertSingleToDouble()
   ADD(ARM64Reg::X1, ARM64Reg::X2, ARM64Reg::X1);
   RET();
 
+  GetAsmRoutines()->cstd_nan = GetCodePtr();
+  UBFX(ARM64Reg::W1, ARM64Reg::W0, 23, 8);
   SetJumpTarget(normal_or_nan);
   CMP(ARM64Reg::W1, 0xff);
   AND(ARM64Reg::W2, ARM64Reg::W0, LogicalImm(0x40000000, 32));

--- a/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
@@ -26,6 +26,7 @@ struct CommonAsmRoutinesBase
   const u8* mfcr;
   const u8* cdts;
   const u8* cstd;
+  const u8* cstd_nan;
   const u8* fprf_single;
   const u8* fprf_double;
 

--- a/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
@@ -52,7 +52,7 @@ public:
 
     convert_single_to_double_lower = Common::BitCast<u64 (*)(u32)>(GetCodePtr());
     m_float_emit.INS(32, ARM64Reg::S0, 0, ARM64Reg::W0);
-    ConvertSingleToDoubleLower(0, ARM64Reg::D0, ARM64Reg::S0, ARM64Reg::Q1);
+    ConvertSingleToDoubleLower(0, ARM64Reg::D0, ARM64Reg::S0);
     m_float_emit.UMOV(64, ARM64Reg::X0, ARM64Reg::D0, 0);
     RET();
 


### PR DESCRIPTION
This is an alternative to PR #9751. This PR fixes all instances of inputs being flushed to zero, whereas that PR only fixes one specific instance of inputs being flushed to zero, but the performance impact of this PR is much greater.

Needs performance testing.