### PR TITLE
VideoCommon: Fix bounding box on AMD/OpenGL

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -462,7 +462,10 @@ globallycoherent RWBuffer<int> bbox_data : register(u2);
 #define bbox_bottom bbox_data[3]
 #else
 SSBO_BINDING(0) buffer BBox {{
-  int bbox_left, bbox_right, bbox_top, bbox_bottom;
+  int bbox_left;
+  int bbox_right;
+  int bbox_top;
+  int bbox_bottom;
 }};
 #endif
 


### PR DESCRIPTION
According to @Pokechu22, using `int4` instead of 4 `int`s fixes bounding box being broken on AMD with OpenGL.