### PR TITLE
NetPlay: Refactor some functions into a common header

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -408,6 +408,8 @@ add_library(core
   Movie.h
   NetPlayClient.cpp
   NetPlayClient.h
+  NetPlayCommon.cpp
+  NetPlayCommon.h
   NetPlayServer.cpp
   NetPlayServer.h
   NetworkCaptureLogger.cpp

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -9,7 +9,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -221,8 +220,6 @@ private:
 
   void SyncSaveDataResponse(bool success);
   void SyncCodeResponse(bool success);
-  bool DecompressPacketIntoFile(sf::Packet& packet, const std::string& file_path);
-  std::optional<std::vector<u8>> DecompressPacketIntoBuffer(sf::Packet& packet);
 
   bool PollLocalPad(int local_pad, sf::Packet& packet);
   void SendPadHostPoll(PadIndex pad_num);

--- a/Source/Core/Core/NetPlayCommon.cpp
+++ b/Source/Core/Core/NetPlayCommon.cpp
@@ -1,0 +1,227 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Core/NetPlayCommon.h"
+
+#include <lzo/lzo1x.h>
+
+#include "Common/FileUtil.h"
+#include "Common/IOFile.h"
+#include "Common/MsgHandler.h"
+#include "Common/SFMLHelper.h"
+
+namespace NetPlay
+{
+constexpr u32 LZO_IN_LEN = 1024 * 64;
+constexpr u32 LZO_OUT_LEN = LZO_IN_LEN + (LZO_IN_LEN / 16) + 64 + 3;
+
+bool CompressFileIntoPacket(const std::string& file_path, sf::Packet& packet)
+{
+  File::IOFile file(file_path, "rb");
+  if (!file)
+  {
+    PanicAlertFmtT("Failed to open file \"{0}\".", file_path);
+    return false;
+  }
+
+  const sf::Uint64 size = file.GetSize();
+  packet << size;
+
+  if (size == 0)
+    return true;
+
+  std::vector<u8> in_buffer(LZO_IN_LEN);
+  std::vector<u8> out_buffer(LZO_OUT_LEN);
+  std::vector<u8> wrkmem(LZO1X_1_MEM_COMPRESS);
+
+  lzo_uint i = 0;
+  while (true)
+  {
+    lzo_uint32 cur_len = 0;  // number of bytes to read
+    lzo_uint out_len = 0;    // number of bytes to write
+
+    if ((i + LZO_IN_LEN) >= size)
+    {
+      cur_len = static_cast<lzo_uint32>(size - i);
+    }
+    else
+    {
+      cur_len = LZO_IN_LEN;
+    }
+
+    if (cur_len <= 0)
+      break;  // EOF
+
+    if (!file.ReadBytes(in_buffer.data(), cur_len))
+    {
+      PanicAlertFmtT("Error reading file: {0}", file_path.c_str());
+      return false;
+    }
+
+    if (lzo1x_1_compress(in_buffer.data(), cur_len, out_buffer.data(), &out_len, wrkmem.data()) !=
+        LZO_E_OK)
+    {
+      PanicAlertFmtT("Internal LZO Error - compression failed");
+      return false;
+    }
+
+    // The size of the data to write is 'out_len'
+    packet << static_cast<u32>(out_len);
+    for (size_t j = 0; j < out_len; j++)
+    {
+      packet << out_buffer[j];
+    }
+
+    if (cur_len != LZO_IN_LEN)
+      break;
+
+    i += cur_len;
+  }
+
+  // Mark end of data
+  packet << static_cast<u32>(0);
+
+  return true;
+}
+
+bool CompressBufferIntoPacket(const std::vector<u8>& in_buffer, sf::Packet& packet)
+{
+  const sf::Uint64 size = in_buffer.size();
+  packet << size;
+
+  if (size == 0)
+    return true;
+
+  std::vector<u8> out_buffer(LZO_OUT_LEN);
+  std::vector<u8> wrkmem(LZO1X_1_MEM_COMPRESS);
+
+  lzo_uint i = 0;
+  while (true)
+  {
+    lzo_uint32 cur_len = 0;  // number of bytes to read
+    lzo_uint out_len = 0;    // number of bytes to write
+
+    if ((i + LZO_IN_LEN) >= size)
+    {
+      cur_len = static_cast<lzo_uint32>(size - i);
+    }
+    else
+    {
+      cur_len = LZO_IN_LEN;
+    }
+
+    if (cur_len <= 0)
+      break;  // end of buffer
+
+    if (lzo1x_1_compress(&in_buffer[i], cur_len, out_buffer.data(), &out_len, wrkmem.data()) !=
+        LZO_E_OK)
+    {
+      PanicAlertFmtT("Internal LZO Error - compression failed");
+      return false;
+    }
+
+    // The size of the data to write is 'out_len'
+    packet << static_cast<u32>(out_len);
+    for (size_t j = 0; j < out_len; j++)
+    {
+      packet << out_buffer[j];
+    }
+
+    if (cur_len != LZO_IN_LEN)
+      break;
+
+    i += cur_len;
+  }
+
+  // Mark end of data
+  packet << static_cast<u32>(0);
+
+  return true;
+}
+
+bool DecompressPacketIntoFile(sf::Packet& packet, const std::string& file_path)
+{
+  u64 file_size = Common::PacketReadU64(packet);
+
+  if (file_size == 0)
+    return true;
+
+  File::IOFile file(file_path, "wb");
+  if (!file)
+  {
+    PanicAlertFmtT("Failed to open file \"{0}\". Verify your write permissions.", file_path);
+    return false;
+  }
+
+  std::vector<u8> in_buffer(LZO_OUT_LEN);
+  std::vector<u8> out_buffer(LZO_IN_LEN);
+
+  while (true)
+  {
+    u32 cur_len = 0;       // number of bytes to read
+    lzo_uint new_len = 0;  // number of bytes to write
+
+    packet >> cur_len;
+    if (!cur_len)
+      break;  // We reached the end of the data stream
+
+    for (size_t j = 0; j < cur_len; j++)
+    {
+      packet >> in_buffer[j];
+    }
+
+    if (lzo1x_decompress(in_buffer.data(), cur_len, out_buffer.data(), &new_len, nullptr) !=
+        LZO_E_OK)
+    {
+      PanicAlertFmtT("Internal LZO Error - decompression failed");
+      return false;
+    }
+
+    if (!file.WriteBytes(out_buffer.data(), new_len))
+    {
+      PanicAlertFmtT("Error writing file: {0}", file_path);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+std::optional<std::vector<u8>> DecompressPacketIntoBuffer(sf::Packet& packet)
+{
+  u64 size = Common::PacketReadU64(packet);
+
+  std::vector<u8> out_buffer(size);
+
+  if (size == 0)
+    return out_buffer;
+
+  std::vector<u8> in_buffer(LZO_OUT_LEN);
+
+  lzo_uint i = 0;
+  while (true)
+  {
+    u32 cur_len = 0;       // number of bytes to read
+    lzo_uint new_len = 0;  // number of bytes to write
+
+    packet >> cur_len;
+    if (!cur_len)
+      break;  // We reached the end of the data stream
+
+    for (size_t j = 0; j < cur_len; j++)
+    {
+      packet >> in_buffer[j];
+    }
+
+    if (lzo1x_decompress(in_buffer.data(), cur_len, &out_buffer[i], &new_len, nullptr) != LZO_E_OK)
+    {
+      PanicAlertFmtT("Internal LZO Error - decompression failed");
+      return {};
+    }
+
+    i += new_len;
+  }
+
+  return out_buffer;
+}
+}  // namespace NetPlay

--- a/Source/Core/Core/NetPlayCommon.h
+++ b/Source/Core/Core/NetPlayCommon.h
@@ -1,0 +1,21 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <SFML/Network/Packet.hpp>
+
+#include <array>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+
+namespace NetPlay
+{
+bool CompressFileIntoPacket(const std::string& file_path, sf::Packet& packet);
+bool CompressBufferIntoPacket(const std::vector<u8>& in_buffer, sf::Packet& packet);
+bool DecompressPacketIntoFile(sf::Packet& packet, const std::string& file_path);
+std::optional<std::vector<u8>> DecompressPacketIntoBuffer(sf::Packet& packet);
+}  // namespace NetPlay

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -117,11 +117,6 @@ struct NetTraversalConfig
   u16 traversal_port = 0;
 };
 
-struct Rpt : public std::vector<u8>
-{
-  u16 channel;
-};
-
 // messages
 enum
 {
@@ -210,13 +205,15 @@ enum
   SYNC_CODES_FAILURE = 6,
 };
 
-constexpr u32 NETPLAY_LZO_IN_LEN = 1024 * 64;
-constexpr u32 NETPLAY_LZO_OUT_LEN = NETPLAY_LZO_IN_LEN + (NETPLAY_LZO_IN_LEN / 16) + 64 + 3;
 constexpr u32 MAX_NAME_LENGTH = 30;
 constexpr size_t CHUNKED_DATA_UNIT_SIZE = 16384;
-constexpr u8 CHANNEL_COUNT = 2;
-constexpr u8 DEFAULT_CHANNEL = 0;
-constexpr u8 CHUNKED_DATA_CHANNEL = 1;
+
+enum : u8
+{
+  DEFAULT_CHANNEL,
+  CHUNKED_DATA_CHANNEL,
+  CHANNEL_COUNT
+};
 
 struct WiimoteInput
 {

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -120,8 +120,6 @@ private:
   bool SyncSaveData();
   bool SyncCodes();
   void CheckSyncAndStartGame();
-  bool CompressFileIntoPacket(const std::string& file_path, sf::Packet& packet);
-  bool CompressBufferIntoPacket(const std::vector<u8>& in_buffer, sf::Packet& packet);
 
   u64 GetInitialNetPlayRTC() const;
 

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -375,6 +375,7 @@
     <ClInclude Include="Core\MemTools.h" />
     <ClInclude Include="Core\Movie.h" />
     <ClInclude Include="Core\NetPlayClient.h" />
+    <ClInclude Include="Core\NetPlayCommon.h" />
     <ClInclude Include="Core\NetPlayProto.h" />
     <ClInclude Include="Core\NetPlayServer.h" />
     <ClInclude Include="Core\NetworkCaptureLogger.h" />
@@ -952,6 +953,7 @@
     <ClCompile Include="Core\MemTools.cpp" />
     <ClCompile Include="Core\Movie.cpp" />
     <ClCompile Include="Core\NetPlayClient.cpp" />
+    <ClCompile Include="Core\NetPlayCommon.cpp" />
     <ClCompile Include="Core\NetPlayServer.cpp" />
     <ClCompile Include="Core\NetworkCaptureLogger.cpp" />
     <ClCompile Include="Core\PatchEngine.cpp" />


### PR DESCRIPTION
This moves some functions to a common place so that both sides can use them, which may be needed for future features. Also reduces the amount of code in the client and server a little bit. I also removed an unused struct, and renamed/restructured some things.