### PR TITLE
VideoCommon: Fix bounding box on AMD/OpenGL/Windows

### DIFF
--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -126,6 +126,8 @@ constexpr BugInfo m_known_bugs[] = {
      -1.0, -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_ARM, DRIVER_ARM, Family::UNKNOWN, BUG_BROKEN_VECTOR_BITWISE_AND,
      -1.0, -1.0, true},
+    {API_OPENGL, OS_WINDOWS, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN, BUG_BROKEN_SSBO_FIELD_ATOMICS,
+     -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -298,6 +298,14 @@ enum Bug
   // Started version: -1
   // Ended version: -1
   BUG_BROKEN_VECTOR_BITWISE_AND,
+
+  // BUG: Atomic writes to different fields or array elements of an SSBO have no effect, only
+  // writing to the first field/element works. This causes bounding box emulation to give garbage
+  // values under OpenGL.
+  // Affected devices: AMD (Windows)
+  // Started version: -1
+  // Ended version: -1
+  BUG_BROKEN_SSBO_FIELD_ATOMICS,
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
At least on my (old) AMD device, bounding box does not work on OpenGL; using an `int4` works, while using 4 ints (either as an array or 4 separate fields) does not work.  The Metal shader compiler does not work with `int4`, though, so both variants need to be supported.

I don't know if this is an issue on newer AMD devices as well.

See also #9762.