### PR TITLE
JitArm64: Improve Arm64FPRCache::GetCallerSavedUsed

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -351,6 +351,7 @@ protected:
 
 private:
   bool IsCalleeSaved(Arm64Gen::ARM64Reg reg) const;
+  bool IsTopHalfUsed(Arm64Gen::ARM64Reg reg) const;
 
   void FlushRegisters(BitSet32 regs, bool maintain_state, Arm64Gen::ARM64Reg tmp_reg);
 };


### PR DESCRIPTION
If we're only using the lower 64 bits of a callee-saved register, GetCallerSavedUsed can return false for it.