### PR TITLE
OGL: Disable bounding box emulation on AMD/Windows

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -653,7 +653,9 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     glEnable(GL_PROGRAM_POINT_SIZE);
   }
 
-  g_Config.backend_info.bSupportsBBox = g_Config.backend_info.bSupportsFragmentStoresAndAtomics;
+  g_Config.backend_info.bSupportsBBox =
+      g_Config.backend_info.bSupportsFragmentStoresAndAtomics &&
+      !DriverDetails::HasBug(DriverDetails::BUG_BROKEN_SSBO_FIELD_ATOMICS);
 
   // Either method can do early-z tests. See PixelShaderGen for details.
   g_Config.backend_info.bSupportsEarlyZ =

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -126,6 +126,8 @@ constexpr BugInfo m_known_bugs[] = {
      -1.0, -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_ARM, DRIVER_ARM, Family::UNKNOWN, BUG_BROKEN_VECTOR_BITWISE_AND,
      -1.0, -1.0, true},
+    {API_OPENGL, OS_WINDOWS, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN, BUG_BROKEN_SSBO_FIELD_ATOMICS,
+     -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -298,6 +298,11 @@ enum Bug
   // Started version: -1
   // Ended version: -1
   BUG_BROKEN_VECTOR_BITWISE_AND,
+
+  // BUG: Atomic operations only work on the first field of an SSBO shader binding on the Windows
+  // AMD drivers, which causes bounding box emulation to spit out default values for the remaining 3
+  // registers.
+  BUG_BROKEN_SSBO_FIELD_ATOMICS,
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
AMD drivers on Windows only write to the first field of an SSBO binding in a shader when using atomics, which breaks bounding box emulation.