### PR TITLE
DSP: Fix cycles overhead

### DIFF
--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -70,7 +70,11 @@ enum class FromThread
 // is scheduled earlier than the current values (when scheduled from the CPU Thread only).
 // Scheduling from a callback will not update the downcount until the Advance() completes.
 void ScheduleEvent(s64 cycles_into_future, EventType* event_type, u64 userdata = 0,
-                   FromThread from = FromThread::CPU);
+                   FromThread from = FromThread::CPU, bool cycle_safe = false);
+
+// Same as ScheduleEvent but without the ForceExceptionCheck.
+void ScheduleCycleSafeEvent(s64 cycles_into_future, EventType* event_type, u64 userdata = 0,
+                            FromThread from = FromThread::CPU);
 
 // We only permit one event of each type in the queue at a time.
 void RemoveEvent(EventType* event_type);

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -248,7 +248,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                    s_sample_counter = val;
                    s_last_cpu_time = CoreTiming::GetTicks();
                    CoreTiming::RemoveEvent(event_type_ai);
-                   CoreTiming::ScheduleEvent(GetAIPeriod(), event_type_ai);
+                   CoreTiming::ScheduleCycleSafeEvent(GetAIPeriod(), event_type_ai);
                  }));
 
   mmio->Register(base | AI_INTERRUPT_TIMING, MMIO::DirectRead<u32>(&s_interrupt_timing),
@@ -257,7 +257,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                                  PowerPC::ppcState.pc);
                    s_interrupt_timing = val;
                    CoreTiming::RemoveEvent(event_type_ai);
-                   CoreTiming::ScheduleEvent(GetAIPeriod(), event_type_ai);
+                   CoreTiming::ScheduleCycleSafeEvent(GetAIPeriod(), event_type_ai);
                  }));
 }
 

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -398,7 +398,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
           // TODO: need hardware tests for the timing of this interrupt.
           // Sky Crawlers crashes at boot if this is scheduled less than 87 cycles in the future.
           // Other Namco games crash too, see issue 9509. For now we will just push it to 200 cycles
-          CoreTiming::ScheduleEvent(200, s_et_GenerateDSPInterrupt, INT_AID);
+          CoreTiming::ScheduleCycleSafeEvent(200, s_et_GenerateDSPInterrupt, INT_AID);
         }
       }));
 
@@ -507,7 +507,7 @@ static void Do_ARAM_DMA()
 
   // ARAM DMA transfer rate has been measured on real hw
   int ticksToTransfer = (s_arDMA.Cnt.count / 32) * 246;
-  CoreTiming::ScheduleEvent(ticksToTransfer, s_et_CompleteARAM);
+  CoreTiming::ScheduleCycleSafeEvent(ticksToTransfer, s_et_CompleteARAM);
 
   // Real hardware DMAs in 32byte chunks, but we can get by with 8byte chunks
   if (s_arDMA.Cnt.dir)


### PR DESCRIPTION
This PR fixes https://dolp.in/i12498. `ForceExceptionCheck` was increasing the current instruction's cycles too much making it way too slow.

I created this hardware test to measure the access timings of some instructions/registers used during Syobon Action boot :  
[wii-cycles-timing.zip](https://github.com/dolphin-emu/dolphin/files/6586410/wii-cycles-timing.zip)

<details><summary>HWTEST results on Wii</summary>
<p>

| BL/BLR   | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| BL/BLR   |       1/1       |       1/1       |       1/1       |

| SPRG     | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| SPRG0    |       3/3       |       3/3       |       3/3       |
| SPRG1    |       3/41      |       3/12      |       3/12      |
| SPRG2    |       3/3       |       3/3       |       3/3       |
| SPRG3    |       3/3       |       3/3       |       3/3       |

| GQR      | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| GQR0     |       5/3       |       5/3       |       5/3       |
| GQR1     |      44/3       |       5/3       |       5/3       |
| GQR2     |       5/43      |       5/3       |       5/3       |
| GQR3     |       5/3       |       5/3       |       5/3       |
| GQR4     |       5/3       |       5/3       |       5/3       |
| GQR5     |      43/3       |       5/3       |       5/3       |
| GQR6     |       5/43      |       5/3       |       5/3       |
| GQR7     |       5/3       |       5/3       |       5/3       |

| DSP REG  | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| 5        |      76/57      |      35/1       |      34/1       |
| 24       |      35/1       |      34/1       |      34/1       |
| 25       |      35/1       |      34/1       |      34/1       |
| 27       |      35/1       |      34/1       |      34/1       |

| AI REG   | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| 0        |     116/1       |     116/1       |     116/1       |
| 1        |     125/1       |     116/1       |     116/1       |
| 2        |     119/1       |     116/1       |     125/1       |
| 3        |     116/1       |     116/1       |     116/1       |

| PI REG   | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| 0        |      46/1       |      47/1       |      47/1       |
| 1        |      45/1       |      47/1       |      47/1       |

</p>
</details>

<details><summary>HWTEST results on Dolphin (custom build)</summary>
<p>

| BL/BLR   | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| BL/BLR   |       2/2       |       2/2       |       2/2       |

| SPRG     | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| SPRG0    |       3/4       |       3/4       |       3/4       |
| SPRG1    |       3/4       |       3/4       |       3/4       |
| SPRG2    |       3/4       |       3/4       |       3/4       |
| SPRG3    |       3/4       |       3/4       |       3/4       |

| GQR      | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| GQR0     |       3/4       |       3/4       |       3/4       |
| GQR1     |       3/4       |       3/4       |       3/4       |
| GQR2     |       3/4       |       3/4       |       3/4       |
| GQR3     |       3/4       |       3/4       |       3/4       |
| GQR4     |       3/4       |       3/4       |       3/4       |
| GQR5     |       3/4       |       3/4       |       3/4       |
| GQR6     |       3/4       |       3/4       |       3/4       |
| GQR7     |       3/4       |       3/4       |       3/4       |

| DSP REG  | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| 5        |      35/3       |      35/3       |      35/3       |
| 24       |      35/3       |      35/3       |      35/3       |
| 25       |      35/3       |      35/3       |      35/3       |
| 27       |      35/3       |      35/3       |      35/3       |

| AI REG   | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| 0        |     116/3       |     116/3       |     116/3       |
| 1        |     116/3       |     116/3       |     116/3       |
| 2        |     116/5593    |     116/5917    |     116/4117    |
| 3        |     116/517     |     116/11317   |     116/5593    |

| PI REG   | Attempt 1       | Attempt 2       | Attempt 3       |
|----------|-----------------|-----------------|-----------------|
| 0        |       3/3       |       3/3       |       3/3       |
| 1        |       3/3       |       3/3       |       3/3       |

</p>
</details>

I used a custom build based on [this branch](https://github.com/sepalani/dolphin/commit/c1b65471b74a52f3ca63e3ac74e2ec9266abee3c) which is really WIP but implements some kind of MMIO access with cycles adjustment based on real hardware timing. From this branch, I found that the cycles overhead is caused by the `ForceExceptionCheck` call in the `Core:Timing::ScheduleEvent` function. In this branch, the performance monitor was updated (without speed hack support) based on the downcount to see the overhead which was previously hidden by the hardcoded opinfo's cycles.

I'm open to suggestion regarding the way this fix should be implemented, especially if you've better alternative regarding the function name or its implementation.

Ready to be reviewed & tested.