### PR TITLE
GameINI: Fix GFXBackend crash

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -242,6 +242,9 @@ bool Init(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
 
   Host_UpdateMainFrame();  // Disable any menus or buttons at boot
 
+  // Manually reactivate the video backend in case a GameINI overrides the video backend setting.
+  VideoBackendBase::PopulateBackendInfo();
+
   // Issue any API calls which must occur on the main thread for the graphics backend.
   WindowSystemInfo prepared_wsi(wsi);
   g_video_backend->PrepareWindow(prepared_wsi);


### PR DESCRIPTION
Fixes a regression from [5.0-12066](https://dolphin-emu.org/download/dev/a660033e8c394634a22c02a031969685fcdb4fba/), where setting the GFXBackend variable to a backend other than the current global one would crash Dolphin upon launching that game.

Fixes [https://bugs.dolphin-emu.org/issues/12529](https://bugs.dolphin-emu.org/issues/12529)