### PR TITLE
CoreTiming: ForceExceptionCheck only when exception is enabled

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -249,7 +249,7 @@ void ScheduleEvent(s64 cycles_into_future, EventType* event_type, u64 userdata, 
     s64 timeout = GetTicks() + cycles_into_future;
 
     // If this event needs to be scheduled before the next advance(), force one early
-    if (!s_is_global_timer_sane)
+    if (!s_is_global_timer_sane && PowerPC::ppcState.msr.EE == 1)
       ForceExceptionCheck(cycles_into_future);
 
     s_event_queue.emplace_back(Event{timeout, s_event_fifo_id++, userdata, event_type});

--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -48,6 +48,7 @@ public:
     Config::Init();
     SConfig::Init();
     PowerPC::Init(PowerPC::CPUCore::Interpreter);
+    PowerPC::ppcState.msr.EE = 1;  // Enable exception
     CoreTiming::Init();
   }
   ~ScopeInit()


### PR DESCRIPTION
An alternative to https://github.com/dolphin-emu/dolphin/pull/9774. It still fixes Syobon Action.

Ready to reviewed & tested.

**EDIT**: I had to enable exception manually for the CoreTimingTest. I'm open to suggestions and alternatives regarding that aspect such as:
 - Are there events where it doesn't apply?
 - A better way to fix the timing test? 
