### PR TITLE
msvc: use external header feature solution-wide

### DIFF
--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
@@ -59,12 +59,6 @@ private:
   InterruptCallbackType m_callback;
 };
 
-#ifdef _MSC_VER
-#pragma warning(push)
-// Disable warning for zero-sized array:
-#pragma warning(disable : 4200)
-#endif
-
 #pragma pack(push, 1)
 
 template <typename T>
@@ -83,9 +77,5 @@ struct TypedInputData
 };
 
 #pragma pack(pop)
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 }  // namespace WiimoteCommon

--- a/Source/PCH/pch.h
+++ b/Source/PCH/pch.h
@@ -7,7 +7,7 @@
 #define STRINGIFY_HELPER(x) #x
 #define STRINGIFY(x) STRINGIFY_HELPER(x)
 
-#if defined _MSC_FULL_VER && _MSC_FULL_VER < 192829335
+#if defined _MSC_FULL_VER && _MSC_FULL_VER < 192930037
 #pragma message("Current _MSC_FULL_VER: " STRINGIFY(_MSC_FULL_VER))
 #error Please update your build environment to the latest Visual Studio 2019!
 #endif

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -7,48 +7,52 @@
     <TargetName Condition="'$(ConfigurationType)'=='Application'">$(ProjectName)$(TargetSuffix)</TargetName>
     <!--Set link /INCREMENTAL:NO to remove some entropy from builds (assists with /Brepro)-->
     <LinkIncremental>false</LinkIncremental>
+    <!--
+      Coagulate external include directories.
+      Order matters! (first hit, first use).
+        Note: Directory containing source file being compiled is always searched first.
+      -->
+    <ExternalIncludePath>$(ExternalsDir)Bochs_disasm;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)bzip2;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)cpp-optparse;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)FreeSurround\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)cubeb\include;$(ExternalsDir)cubeb\msvc;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)curl\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)discord-rpc\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)ed25519;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)enet\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)ffmpeg\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)fmt\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)GL;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)glslang;$(ExternalsDir)glslang\StandAlone;$(ExternalsDir)glslang\glslang\Public;$(ExternalsDir)glslang\SPIRV;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)imgui;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)liblzma\api;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)libpng;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)libusb\libusb;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)LZO;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)miniupnpc\src;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)minizip;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)mbedtls\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)OpenAL\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)picojson;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)pugixml;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)rangeset\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)SFML\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)soundtouch;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)Vulkan\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)WIL\include;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)xxhash;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)zlib;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(ExternalsDir)zstd\lib;$(ExternalIncludePath)</ExternalIncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <!--ClCompile Base-->
     <ClCompile>
-      <!--
-      Coagulate all the needed include directories.
-      Order matters! (first hit, first use).
-        Note: Directory containing source file being compiled is always searched first.
-      -->
       <AdditionalIncludeDirectories>$(CoreDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)Bochs_disasm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)bzip2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)cpp-optparse;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)FreeSurround\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)cubeb\include;$(ExternalsDir)cubeb\msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)curl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)discord-rpc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)ed25519;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)enet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)ffmpeg\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)fmt\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)GL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)glslang;$(ExternalsDir)glslang\StandAlone;$(ExternalsDir)glslang\glslang\Public;$(ExternalsDir)glslang\SPIRV;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)liblzma\api;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)libpng;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)libusb\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)LZO;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)miniupnpc\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)minizip;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)mbedtls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)OpenAL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)picojson;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)pugixml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)rangeset\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)SFML\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)soundtouch;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)Vulkan\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)WIL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)xxhash;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir)zstd\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!--Base external header policy: ignore all warnings except template instantiations, and disable analyzer-->
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <ExternalTemplatesDiagnostics>true</ExternalTemplatesDiagnostics>
+      <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
       <PreprocessorDefinitions>FMT_HEADER_ONLY=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!--
         It would be a good idea to disable _CRT_SECURE_NO_WARNINGS and get rid of e.g. C string parsing funcs
@@ -174,25 +178,6 @@
       <LinkTimeCodeGeneration Condition="'$(DolphinRelease)'=='true'">true</LinkTimeCodeGeneration>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Lib>
-    <!--
-    Prefer VTune 2015 over 2013 but support both since there is no non-commercial license for 2015 :(
-    -->
-    <ItemDefinitionGroup Condition="Exists('$(VTUNE_AMPLIFIER_XE_2015_DIR)')">
-      <ClCompile>
-        <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);"$(VTUNE_AMPLIFIER_XE_2015_DIR)\include"</AdditionalIncludeDirectories>
-      </ClCompile>
-      <Link>
-        <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);"$(VTUNE_AMPLIFIER_XE_2015_DIR)\lib64"</AdditionalLibraryDirectories>
-      </Link>
-    </ItemDefinitionGroup>
-    <ItemDefinitionGroup Condition="Exists('$(VTUNE_AMPLIFIER_XE_2013_DIR)') And !Exists('$(VTUNE_AMPLIFIER_XE_2015_DIR)')">
-      <ClCompile>
-        <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);"$(VTUNE_AMPLIFIER_XE_2013_DIR)\include"</AdditionalIncludeDirectories>
-      </ClCompile>
-      <Link>
-        <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);"$(VTUNE_AMPLIFIER_XE_2013_DIR)\lib64"</AdditionalLibraryDirectories>
-      </Link>
-    </ItemDefinitionGroup>
   </ItemDefinitionGroup>
   <ItemGroup />
 </Project>

--- a/Source/VSProps/QtCompile.props
+++ b/Source/VSProps/QtCompile.props
@@ -17,23 +17,23 @@
     <QtLibSuffix Condition="'$(Configuration)'=='Debug'">$(QtDebugSuffix)</QtLibSuffix>
     <QtPluginFolder>QtPlugins</QtPluginFolder>
   </PropertyGroup>
+  <PropertyGroup>
+    <ExternalIncludePath>$(QtIncludeDir);$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(QtIncludeDir)QtCore;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(QtIncludeDir)QtGui;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath>$(QtIncludeDir)QtWidgets;$(ExternalIncludePath)</ExternalIncludePath>
+    <ExternalIncludePath Condition="'$(Platform)'=='ARM64'">$(QtIncludeDir)QtANGLE;$(ExternalIncludePath)</ExternalIncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">QT_NO_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>QT_DLL;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>QT_USE_QSTRINGBUILDER;QT_NO_CAST_FROM_ASCII;QT_NO_CAST_TO_ASCII;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(QtToolOutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(QtIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(QtIncludeDir)QtCore;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(QtIncludeDir)QtGui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(QtIncludeDir)QtWidgets;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Platform)'=='ARM64'">$(QtIncludeDir)QtANGLE;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <!--
-      Set the qt directories as 'external', so we avoid any warnings in them
-      -->
-      <AdditionalOptions>%(AdditionalOptions) /experimental:external</AdditionalOptions>
-      <AdditionalOptions>%(AdditionalOptions) /external:W0</AdditionalOptions>
-      <AdditionalOptions>%(AdditionalOptions) /external:I "$(QtIncludeDirWithoutTrailingSeparator)"</AdditionalOptions>
+        Ignore warnings in locally-instantiated Qt templates.
+        This should probably be removed at some point (when Qt is fixed).
+        -->
+      <ExternalTemplatesDiagnostics>false</ExternalTemplatesDiagnostics>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(QtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>


### PR DESCRIPTION
Add external include paths to ExternalIncludePath instead of
AdditionalIncludeDirectories. msbuild appends these paths to
EXTERNAL_INCLUDE env var, which is passed to /external:env:.

Specify /external:W0 and /external:templates-, with override for
DolphinQt for the template flag, since Qt 5.15.0 causes some warnings
in qmap.h

fixes the [(harmless) warnings](https://dolphin.ci/#/builders/21/builds/4024/steps/3/logs/warnings__18_) that showed up recently