### PR TITLE
Freelook: enhance 2d camera.  Add ability to remove bloom, stretch or smush HUD and more!

### DIFF
--- a/Source/Core/Core/Config/FreeLookSettings.cpp
+++ b/Source/Core/Core/Config/FreeLookSettings.cpp
@@ -14,6 +14,8 @@ namespace Config
 // Configuration Information
 const Info<bool> FREE_LOOK_ENABLED{{System::FreeLook, "General", "Enabled"}, false};
 
+const Info<bool> FREE_LOOK_2D_ENABLED{{System::FreeLook, "General", "2DEnabled"}, false};
+
 // FreeLook.Controller1
 const Info<FreeLook::ControlType> FL1_CONTROL_TYPE{{System::FreeLook, "Camera1", "ControlType"},
                                                    FreeLook::ControlType::SixAxis};

--- a/Source/Core/Core/Config/FreeLookSettings.cpp
+++ b/Source/Core/Core/Config/FreeLookSettings.cpp
@@ -19,5 +19,6 @@ const Info<bool> FREE_LOOK_2D_ENABLED{{System::FreeLook, "General", "2DEnabled"}
 // FreeLook.Controller1
 const Info<FreeLook::ControlType> FL1_CONTROL_TYPE{{System::FreeLook, "Camera1", "ControlType"},
                                                    FreeLook::ControlType::SixAxis};
+const Info<std::string> FL1_2DLAYERS{{System::FreeLook, "Camera1", "2DLayers"}, ""};
 
 }  // namespace Config

--- a/Source/Core/Core/Config/FreeLookSettings.h
+++ b/Source/Core/Core/Config/FreeLookSettings.h
@@ -20,5 +20,6 @@ extern const Info<bool> FREE_LOOK_2D_ENABLED;
 
 // FreeLook.Controller1
 extern const Info<FreeLook::ControlType> FL1_CONTROL_TYPE;
+extern const Info<std::string> FL1_2DLAYERS;
 
 }  // namespace Config

--- a/Source/Core/Core/Config/FreeLookSettings.h
+++ b/Source/Core/Core/Config/FreeLookSettings.h
@@ -16,6 +16,7 @@ namespace Config
 // Configuration Information
 
 extern const Info<bool> FREE_LOOK_ENABLED;
+extern const Info<bool> FREE_LOOK_2D_ENABLED;
 
 // FreeLook.Controller1
 extern const Info<FreeLook::ControlType> FL1_CONTROL_TYPE;

--- a/Source/Core/Core/FreeLookConfig.cpp
+++ b/Source/Core/Core/FreeLookConfig.cpp
@@ -32,6 +32,7 @@ Config::Config()
 {
   camera_config.control_type = ControlType::SixAxis;
   enabled = false;
+  enabled_2d = false;
 }
 
 void Config::Refresh()
@@ -44,5 +45,6 @@ void Config::Refresh()
 
   camera_config.control_type = ::Config::Get(::Config::FL1_CONTROL_TYPE);
   enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED);
+  enabled_2d = ::Config::Get(::Config::FREE_LOOK_2D_ENABLED);
 }
 }  // namespace FreeLook

--- a/Source/Core/Core/FreeLookConfig.cpp
+++ b/Source/Core/Core/FreeLookConfig.cpp
@@ -31,6 +31,7 @@ void UpdateActiveConfig()
 Config::Config()
 {
   camera_config.control_type = ControlType::SixAxis;
+  camera_config_2d.layers = "";
   enabled = false;
   enabled_2d = false;
 }
@@ -44,6 +45,7 @@ void Config::Refresh()
   }
 
   camera_config.control_type = ::Config::Get(::Config::FL1_CONTROL_TYPE);
+  camera_config_2d.layers = ::Config::Get(::Config::FL1_2DLAYERS);
   enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED);
   enabled_2d = ::Config::Get(::Config::FREE_LOOK_2D_ENABLED);
 }

--- a/Source/Core/Core/FreeLookConfig.h
+++ b/Source/Core/Core/FreeLookConfig.h
@@ -31,6 +31,7 @@ struct Config final
 
   CameraConfig camera_config;
   bool enabled;
+  bool enabled_2d;
 };
 
 Config& GetConfig();

--- a/Source/Core/Core/FreeLookConfig.h
+++ b/Source/Core/Core/FreeLookConfig.h
@@ -23,6 +23,10 @@ struct CameraConfig
   ControlType control_type;
 };
 
+struct CameraConfig2D
+{
+};
+
 // NEVER inherit from this class.
 struct Config final
 {
@@ -30,6 +34,7 @@ struct Config final
   void Refresh();
 
   CameraConfig camera_config;
+  CameraConfig2D camera_config_2d;
   bool enabled;
   bool enabled_2d;
 };

--- a/Source/Core/Core/FreeLookConfig.h
+++ b/Source/Core/Core/FreeLookConfig.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace FreeLook
 {
 enum class ControlType : int
@@ -25,6 +27,7 @@ struct CameraConfig
 
 struct CameraConfig2D
 {
+  std::string layers;
 };
 
 // NEVER inherit from this class.

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -407,17 +407,33 @@ void FreeLook2DController::UpdateInput(CameraController2DInput* camera_controlle
   if (m_speed_buttons->controls[SpeedButtons::Increase]->GetState<bool>())
     camera_controller->ModifySpeed(camera_controller->GetSpeed() * 1.1 * dt);
 
-  if (m_texturelayer_buttons->controls[TextureLayerButtons::Next]->GetState<bool>())
+  const auto not_held = [](ControllerEmu::Control* control, bool& previous) {
+    const bool controller_state = control->GetState<bool>();
+    const bool result = controller_state && !previous;
+    previous = controller_state;
+    return result;
+  };
+
+  if (not_held(m_texturelayer_buttons->controls[TextureLayerButtons::Next].get(),
+               m_texturelayer_held_last_frame[TextureLayerButtons::Next]))
+  {
     camera_controller->IncrementLayer();
+  }
 
-  if (m_texturelayer_buttons->controls[TextureLayerButtons::Previous]->GetState<bool>())
+  if (not_held(m_texturelayer_buttons->controls[TextureLayerButtons::Previous].get(),
+               m_texturelayer_held_last_frame[TextureLayerButtons::Previous]))
+  {
     camera_controller->DecrementLayer();
+  }
 
-  if (m_speed_buttons->controls[SpeedButtons::Reset]->GetState<bool>())
+  if (not_held(m_speed_buttons->controls[SpeedButtons::Reset].get(), m_speed_reset_held_last_frame))
     camera_controller->ResetSpeed();
 
-  if (m_other_buttons->controls[OtherButtons::ResetView]->GetState<bool>())
+  if (not_held(m_other_buttons->controls[OtherButtons::ResetView].get(),
+               m_view_reset_held_last_frame))
+  {
     camera_controller->Reset();
+  }
 }
 
 namespace FreeLook

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -95,6 +95,15 @@ enum ZoomButtons
   Decrease,
 };
 }
+
+namespace TextureLayerButtons
+{
+enum TextureLayerButtons
+{
+  Next,
+  Previous,
+};
+}
 }  // namespace
 
 FreeLookController::FreeLookController(const unsigned int index) : m_index(index)
@@ -310,6 +319,12 @@ FreeLook2DController::FreeLook2DController(const unsigned int index) : m_index(i
   m_stretch_buttons->AddInput(ControllerEmu::Translate, _trans("Decrease X"));
   m_stretch_buttons->AddInput(ControllerEmu::Translate, _trans("Increase Y"));
   m_stretch_buttons->AddInput(ControllerEmu::Translate, _trans("Decrease Y"));
+
+  groups.emplace_back(m_texturelayer_buttons =
+                          new ControllerEmu::Buttons(_trans("Texture Layers")));
+
+  m_texturelayer_buttons->AddInput(ControllerEmu::Translate, _trans("Next"));
+  m_texturelayer_buttons->AddInput(ControllerEmu::Translate, _trans("Previous"));
 }
 
 std::string FreeLook2DController::GetName() const
@@ -327,6 +342,8 @@ ControllerEmu::ControlGroup* FreeLook2DController::GetGroup(FreeLook2DGroup grou
     return m_speed_buttons;
   case FreeLook2DGroup::Stretch:
     return m_stretch_buttons;
+  case FreeLook2DGroup::TextureLayer:
+    return m_texturelayer_buttons;
   case FreeLook2DGroup::Other:
     return m_other_buttons;
   default:
@@ -389,6 +406,12 @@ void FreeLook2DController::UpdateInput(CameraController2DInput* camera_controlle
 
   if (m_speed_buttons->controls[SpeedButtons::Increase]->GetState<bool>())
     camera_controller->ModifySpeed(camera_controller->GetSpeed() * 1.1 * dt);
+
+  if (m_texturelayer_buttons->controls[TextureLayerButtons::Next]->GetState<bool>())
+    camera_controller->IncrementLayer();
+
+  if (m_texturelayer_buttons->controls[TextureLayerButtons::Previous]->GetState<bool>())
+    camera_controller->DecrementLayer();
 
   if (m_speed_buttons->controls[SpeedButtons::Reset]->GetState<bool>())
     camera_controller->ResetSpeed();

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <chrono>
 #include <optional>
 
@@ -90,10 +91,17 @@ public:
 private:
   void UpdateInput(CameraController2DInput* camera_controller);
   ControllerEmu::Buttons* m_move_buttons;
+
   ControllerEmu::Buttons* m_speed_buttons;
+  bool m_speed_reset_held_last_frame;
+
   ControllerEmu::Buttons* m_stretch_buttons;
+
   ControllerEmu::Buttons* m_texturelayer_buttons;
+  std::array<bool, 2> m_texturelayer_held_last_frame;
+
   ControllerEmu::Buttons* m_other_buttons;
+  bool m_view_reset_held_last_frame;
 
   const unsigned int m_index;
   std::optional<std::chrono::steady_clock::time_point> m_last_free_look_rotate_time;

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 
+class CameraController2DInput;
 class InputConfig;
 
 namespace ControllerEmu
@@ -28,16 +29,28 @@ enum class FreeLookGroup
   Rotation,
 };
 
+enum class FreeLook2DGroup
+{
+  Move,
+  Speed,
+  Stretch,
+  Other,
+};
+
 namespace FreeLook
 {
 void Shutdown();
 void Initialize();
-void LoadInputConfig();
 bool IsInitialized();
 void UpdateInput();
 
+void LoadInputConfig();
 InputConfig* GetInputConfig();
 ControllerEmu::ControlGroup* GetInputGroup(int pad_num, FreeLookGroup group);
+
+void Load2DInputConfig();
+InputConfig* Get2DInputConfig();
+ControllerEmu::ControlGroup* Get2DInputGroup(int pad_num, FreeLook2DGroup group);
 
 }  // namespace FreeLook
 
@@ -58,6 +71,27 @@ private:
   ControllerEmu::Buttons* m_fov_buttons;
   ControllerEmu::Buttons* m_other_buttons;
   ControllerEmu::IMUGyroscope* m_rotation_gyro;
+
+  const unsigned int m_index;
+  std::optional<std::chrono::steady_clock::time_point> m_last_free_look_rotate_time;
+};
+
+class FreeLook2DController final : public ControllerEmu::EmulatedController
+{
+public:
+  explicit FreeLook2DController(unsigned int index);
+
+  std::string GetName() const override;
+
+  ControllerEmu::ControlGroup* GetGroup(FreeLook2DGroup group) const;
+  void Update();
+
+private:
+  void UpdateInput(CameraController2DInput* camera_controller);
+  ControllerEmu::Buttons* m_move_buttons;
+  ControllerEmu::Buttons* m_speed_buttons;
+  ControllerEmu::Buttons* m_stretch_buttons;
+  ControllerEmu::Buttons* m_other_buttons;
 
   const unsigned int m_index;
   std::optional<std::chrono::steady_clock::time_point> m_last_free_look_rotate_time;

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -34,6 +34,7 @@ enum class FreeLook2DGroup
   Move,
   Speed,
   Stretch,
+  TextureLayer,
   Other,
 };
 
@@ -91,6 +92,7 @@ private:
   ControllerEmu::Buttons* m_move_buttons;
   ControllerEmu::Buttons* m_speed_buttons;
   ControllerEmu::Buttons* m_stretch_buttons;
+  ControllerEmu::Buttons* m_texturelayer_buttons;
   ControllerEmu::Buttons* m_other_buttons;
 
   const unsigned int m_index;

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -611,6 +611,7 @@
     <ClInclude Include="VideoCommon\FramebufferShaderGen.h" />
     <ClInclude Include="VideoCommon\FrameDump.h" />
     <ClInclude Include="VideoCommon\FreeLookCamera.h" />
+    <ClInclude Include="VideoCommon\FreeLookCamera2D.h" />
     <ClInclude Include="VideoCommon\GeometryShaderGen.h" />
     <ClInclude Include="VideoCommon\GeometryShaderManager.h" />
     <ClInclude Include="VideoCommon\GXPipelineTypes.h" />
@@ -1167,6 +1168,7 @@
     <ClCompile Include="VideoCommon\FramebufferManager.cpp" />
     <ClCompile Include="VideoCommon\FramebufferShaderGen.cpp" />
     <ClCompile Include="VideoCommon\FreeLookCamera.cpp" />
+    <ClCompile Include="VideoCommon\FreeLookCamera2D.cpp" />
     <ClCompile Include="VideoCommon\GeometryShaderGen.cpp" />
     <ClCompile Include="VideoCommon\GeometryShaderManager.cpp" />
     <ClCompile Include="VideoCommon\HiresTextures_DDSLoader.cpp" />

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -73,6 +73,8 @@ add_executable(dolphin-emu
   Config/ControllersWindow.h
   Config/FilesystemWidget.cpp
   Config/FilesystemWidget.h
+  Config/FreeLook2DWidget.cpp
+  Config/FreeLook2DWidget.h
   Config/FreeLookWidget.cpp
   Config/FreeLookWidget.h
   Config/FreeLookWindow.cpp
@@ -120,6 +122,8 @@ add_executable(dolphin-emu
   Config/LogConfigWidget.h
   Config/LogWidget.cpp
   Config/LogWidget.h
+  Config/Mapping/FreeLook2DGeneral.cpp
+  Config/Mapping/FreeLook2DGeneral.h
   Config/Mapping/FreeLookGeneral.cpp
   Config/Mapping/FreeLookGeneral.h
   Config/Mapping/FreeLookRotation.cpp

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -73,6 +73,10 @@ add_executable(dolphin-emu
   Config/ControllersWindow.h
   Config/FilesystemWidget.cpp
   Config/FilesystemWidget.h
+  Config/FreeLook2DOptionsWidget.cpp
+  Config/FreeLook2DOptionsWidget.h
+  Config/FreeLook2DOptionsWindow.cpp
+  Config/FreeLook2DOptionsWindow.h
   Config/FreeLook2DWidget.cpp
   Config/FreeLook2DWidget.h
   Config/FreeLookWidget.cpp
@@ -112,10 +116,16 @@ add_executable(dolphin-emu
   Config/Graphics/GraphicsWindow.h
   Config/Graphics/HacksWidget.cpp
   Config/Graphics/HacksWidget.h
+  Config/Graphics/NewTextureDialog.cpp
+  Config/Graphics/NewTextureDialog.h
+  Config/Graphics/NewTextureLayerDialog.cpp
+  Config/Graphics/NewTextureLayerDialog.h
   Config/Graphics/PostProcessingConfigWindow.cpp
   Config/Graphics/PostProcessingConfigWindow.h
   Config/Graphics/SoftwareRendererWidget.cpp
   Config/Graphics/SoftwareRendererWidget.h
+  Config/Graphics/TextureLayersWidget.cpp
+  Config/Graphics/TextureLayersWidget.h
   Config/InfoWidget.cpp
   Config/InfoWidget.h
   Config/LogConfigWidget.cpp

--- a/Source/Core/DolphinQt/Config/FreeLook2DOptionsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLook2DOptionsWidget.cpp
@@ -1,0 +1,34 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/FreeLook2DOptionsWidget.h"
+
+#include <QBoxLayout>
+#include <QGroupBox>
+#include <QListWidget>
+#include <QPushButton>
+
+#include "Common/Config/Config.h"
+#include "Core/Config/FreeLookSettings.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "DolphinQt/Config/Graphics/TextureLayersWidget.h"
+
+FreeLook2DOptionsWidget::FreeLook2DOptionsWidget(QWidget* parent) : QWidget(parent)
+{
+  CreateLayout();
+}
+
+void FreeLook2DOptionsWidget::CreateLayout()
+{
+  auto* main_layout = new QVBoxLayout;
+
+  QGroupBox* texture_layers_group = new QGroupBox(tr("Texture layers"));
+  auto* groupbox_layout = new QVBoxLayout;
+  groupbox_layout->addWidget(new TextureLayersWidget(this, Config::FL1_2DLAYERS));
+  texture_layers_group->setLayout(groupbox_layout);
+  main_layout->addWidget(texture_layers_group);
+
+  setLayout(main_layout);
+}

--- a/Source/Core/DolphinQt/Config/FreeLook2DOptionsWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLook2DOptionsWidget.h
@@ -1,0 +1,21 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+class QGroupBox;
+
+class FreeLook2DOptionsWidget final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit FreeLook2DOptionsWidget(QWidget* parent);
+
+private:
+  void CreateLayout();
+
+  QGroupBox* m_texture_layer_group_box;
+};

--- a/Source/Core/DolphinQt/Config/FreeLook2DOptionsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLook2DOptionsWindow.cpp
@@ -1,0 +1,36 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/FreeLook2DOptionsWindow.h"
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+#include "Core/Config/FreeLookSettings.h"
+#include "DolphinQt/Config/FreeLook2DOptionsWidget.h"
+
+FreeLook2DOptionsWindow::FreeLook2DOptionsWindow(QWidget* parent, int index)
+    : QDialog(parent), m_port(index)
+{
+  CreateMainLayout();
+
+  setWindowTitle(tr("Free Look 2D Camera %1 Options").arg(index + 1));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+}
+
+void FreeLook2DOptionsWindow::CreateMainLayout()
+{
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
+  connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  auto* main_layout = new QVBoxLayout();
+  if (m_port == 0)
+  {
+    main_layout->addWidget(new FreeLook2DOptionsWidget(this));
+  }
+  main_layout->addWidget(m_button_box);
+  setLayout(main_layout);
+}

--- a/Source/Core/DolphinQt/Config/FreeLook2DOptionsWindow.h
+++ b/Source/Core/DolphinQt/Config/FreeLook2DOptionsWindow.h
@@ -1,0 +1,22 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+class QDialogButtonBox;
+
+class FreeLook2DOptionsWindow final : public QDialog
+{
+  Q_OBJECT
+public:
+  FreeLook2DOptionsWindow(QWidget* parent, int index);
+
+private:
+  void CreateMainLayout();
+
+  int m_port;
+  QDialogButtonBox* m_button_box;
+};

--- a/Source/Core/DolphinQt/Config/FreeLook2DWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLook2DWidget.cpp
@@ -1,0 +1,86 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/FreeLook2DWidget.h"
+
+#include <QCheckBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+#include "Core/Config/FreeLookSettings.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+
+#include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/Mapping/MappingWindow.h"
+#include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
+#include "DolphinQt/Settings.h"
+
+FreeLook2DWidget::FreeLook2DWidget(QWidget* parent) : QWidget(parent)
+{
+  CreateLayout();
+  LoadSettings();
+  ConnectWidgets();
+}
+
+void FreeLook2DWidget::CreateLayout()
+{
+  auto* layout = new QVBoxLayout();
+  layout->setStretch(0, 0);
+
+  m_enable_freelook = new ToolTipCheckBox(tr("Enable"));
+  m_enable_freelook->setChecked(Config::Get(Config::FREE_LOOK_2D_ENABLED));
+  m_enable_freelook->SetDescription(tr("Allows manipulation of the in-game camera for 2d "
+                                       "elements.<br><br><dolphin_emphasis>If unsure, "
+                                       "leave this unchecked.</dolphin_emphasis>"));
+  m_freelook_controller_configure_button = new QPushButton(tr("Configure Controller"));
+
+  auto* hlayout = new QHBoxLayout();
+  hlayout->addWidget(new QLabel(tr("Camera 1")));
+  hlayout->addWidget(m_freelook_controller_configure_button);
+
+  layout->addWidget(m_enable_freelook);
+  layout->addLayout(hlayout);
+  layout->insertStretch(-1, 1);
+
+  setLayout(layout);
+}
+
+void FreeLook2DWidget::ConnectWidgets()
+{
+  connect(m_freelook_controller_configure_button, &QPushButton::clicked, this,
+          &FreeLook2DWidget::OnFreeLookControllerConfigured);
+  connect(m_enable_freelook, &QCheckBox::clicked, this, &FreeLook2DWidget::SaveSettings);
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
+    const QSignalBlocker blocker(this);
+    LoadSettings();
+  });
+}
+
+void FreeLook2DWidget::OnFreeLookControllerConfigured()
+{
+  if (m_freelook_controller_configure_button != QObject::sender())
+    return;
+  const int index = 0;
+  MappingWindow* window = new MappingWindow(this, MappingWindow::Type::MAPPING_FREELOOK_2D, index);
+  window->setAttribute(Qt::WA_DeleteOnClose, true);
+  window->setWindowModality(Qt::WindowModality::WindowModal);
+  window->show();
+}
+
+void FreeLook2DWidget::LoadSettings()
+{
+  const bool checked = Config::Get(Config::FREE_LOOK_2D_ENABLED);
+  m_enable_freelook->setChecked(checked);
+  m_freelook_controller_configure_button->setEnabled(checked);
+}
+
+void FreeLook2DWidget::SaveSettings()
+{
+  const bool checked = m_enable_freelook->isChecked();
+  Config::SetBaseOrCurrent(Config::FREE_LOOK_2D_ENABLED, checked);
+  m_freelook_controller_configure_button->setEnabled(checked);
+}

--- a/Source/Core/DolphinQt/Config/FreeLook2DWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLook2DWidget.cpp
@@ -14,6 +14,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
+#include "DolphinQt/Config/FreeLook2DOptionsWindow.h"
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
@@ -37,9 +38,11 @@ void FreeLook2DWidget::CreateLayout()
                                        "elements.<br><br><dolphin_emphasis>If unsure, "
                                        "leave this unchecked.</dolphin_emphasis>"));
   m_freelook_controller_configure_button = new QPushButton(tr("Configure Controller"));
+  m_freelook_options_configure_button = new QPushButton(tr("Configure Options"));
 
   auto* hlayout = new QHBoxLayout();
   hlayout->addWidget(new QLabel(tr("Camera 1")));
+  hlayout->addWidget(m_freelook_options_configure_button);
   hlayout->addWidget(m_freelook_controller_configure_button);
 
   layout->addWidget(m_enable_freelook);
@@ -53,6 +56,8 @@ void FreeLook2DWidget::ConnectWidgets()
 {
   connect(m_freelook_controller_configure_button, &QPushButton::clicked, this,
           &FreeLook2DWidget::OnFreeLookControllerConfigured);
+  connect(m_freelook_options_configure_button, &QPushButton::clicked, this,
+          &FreeLook2DWidget::OnFreeLookOptionsConfigured);
   connect(m_enable_freelook, &QCheckBox::clicked, this, &FreeLook2DWidget::SaveSettings);
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     const QSignalBlocker blocker(this);
@@ -71,11 +76,23 @@ void FreeLook2DWidget::OnFreeLookControllerConfigured()
   window->show();
 }
 
+void FreeLook2DWidget::OnFreeLookOptionsConfigured()
+{
+  if (m_freelook_options_configure_button != QObject::sender())
+    return;
+  const int index = 0;
+  FreeLook2DOptionsWindow* window = new FreeLook2DOptionsWindow(this, index);
+  window->setAttribute(Qt::WA_DeleteOnClose, true);
+  window->setWindowModality(Qt::WindowModality::WindowModal);
+  window->show();
+}
+
 void FreeLook2DWidget::LoadSettings()
 {
   const bool checked = Config::Get(Config::FREE_LOOK_2D_ENABLED);
   m_enable_freelook->setChecked(checked);
   m_freelook_controller_configure_button->setEnabled(checked);
+  m_freelook_options_configure_button->setEnabled(checked);
 }
 
 void FreeLook2DWidget::SaveSettings()
@@ -83,4 +100,5 @@ void FreeLook2DWidget::SaveSettings()
   const bool checked = m_enable_freelook->isChecked();
   Config::SetBaseOrCurrent(Config::FREE_LOOK_2D_ENABLED, checked);
   m_freelook_controller_configure_button->setEnabled(checked);
+  m_freelook_options_configure_button->setEnabled(checked);
 }

--- a/Source/Core/DolphinQt/Config/FreeLook2DWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLook2DWidget.h
@@ -20,9 +20,11 @@ private:
   void ConnectWidgets();
 
   void OnFreeLookControllerConfigured();
+  void OnFreeLookOptionsConfigured();
   void LoadSettings();
   void SaveSettings();
 
   ToolTipCheckBox* m_enable_freelook;
   QPushButton* m_freelook_controller_configure_button;
+  QPushButton* m_freelook_options_configure_button;
 };

--- a/Source/Core/DolphinQt/Config/FreeLook2DWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLook2DWidget.h
@@ -1,0 +1,28 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+class ToolTipCheckBox;
+
+class FreeLook2DWidget final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit FreeLook2DWidget(QWidget* parent);
+
+private:
+  void CreateLayout();
+  void ConnectWidgets();
+
+  void OnFreeLookControllerConfigured();
+  void LoadSettings();
+  void SaveSettings();
+
+  ToolTipCheckBox* m_enable_freelook;
+  QPushButton* m_freelook_controller_configure_button;
+};

--- a/Source/Core/DolphinQt/Config/FreeLookWindow.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWindow.cpp
@@ -9,6 +9,7 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 
+#include "DolphinQt/Config/FreeLook2DWidget.h"
 #include "DolphinQt/Config/FreeLookWidget.h"
 
 FreeLookWindow::FreeLookWindow(QWidget* parent) : QDialog(parent)
@@ -24,8 +25,12 @@ void FreeLookWindow::CreateMainLayout()
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
+  auto* tab_widget = new QTabWidget();
+  tab_widget->addTab(new FreeLookWidget(this), tr("3D"));
+  tab_widget->addTab(new FreeLook2DWidget(this), tr("2D"));
+
   auto* main_layout = new QVBoxLayout();
-  main_layout->addWidget(new FreeLookWidget(this));
+  main_layout->addWidget(tab_widget);
   main_layout->addWidget(m_button_box);
   setLayout(main_layout);
 }

--- a/Source/Core/DolphinQt/Config/Graphics/NewTextureDialog.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/NewTextureDialog.cpp
@@ -1,0 +1,35 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Graphics/NewTextureDialog.h"
+
+#include <QBoxLayout>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QVBoxLayout>
+
+NewTextureDialog::NewTextureDialog(QWidget* parent) : QDialog(parent)
+{
+  CreateMainLayout();
+
+  setWindowTitle(tr("New Texture Dialog"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+}
+
+void NewTextureDialog::CreateMainLayout()
+{
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+  connect(m_button_box, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  auto* main_layout = new QVBoxLayout();
+
+  auto* hlayout = new QHBoxLayout;
+  m_texture_name_edit = new QLineEdit();
+  hlayout->addWidget(new QLabel(tr("Texture name: ")));
+  hlayout->addWidget(m_texture_name_edit);
+  main_layout->addItem(hlayout);
+  main_layout->addWidget(m_button_box);
+  setLayout(main_layout);
+}

--- a/Source/Core/DolphinQt/Config/Graphics/NewTextureDialog.h
+++ b/Source/Core/DolphinQt/Config/Graphics/NewTextureDialog.h
@@ -1,0 +1,25 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+#include <QLineEdit>
+
+class QDialogButtonBox;
+
+class NewTextureDialog final : public QDialog
+{
+  Q_OBJECT
+public:
+  NewTextureDialog(QWidget* parent);
+
+  QString GetTextureName() const { return m_texture_name_edit->text(); }
+
+private:
+  void CreateMainLayout();
+
+  QLineEdit* m_texture_name_edit;
+  QDialogButtonBox* m_button_box;
+};

--- a/Source/Core/DolphinQt/Config/Graphics/NewTextureLayerDialog.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/NewTextureLayerDialog.cpp
@@ -1,0 +1,35 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Graphics/NewTextureLayerDialog.h"
+
+#include <QBoxLayout>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QVBoxLayout>
+
+NewTextureLayerDialog::NewTextureLayerDialog(QWidget* parent) : QDialog(parent)
+{
+  CreateMainLayout();
+
+  setWindowTitle(tr("New Texture Layer Dialog"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+}
+
+void NewTextureLayerDialog::CreateMainLayout()
+{
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+  connect(m_button_box, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  auto* main_layout = new QVBoxLayout();
+
+  auto* hlayout = new QHBoxLayout;
+  m_texture_layer_name_edit = new QLineEdit();
+  hlayout->addWidget(new QLabel(tr("Texture Layer name: ")));
+  hlayout->addWidget(m_texture_layer_name_edit);
+  main_layout->addItem(hlayout);
+  main_layout->addWidget(m_button_box);
+  setLayout(main_layout);
+}

--- a/Source/Core/DolphinQt/Config/Graphics/NewTextureLayerDialog.h
+++ b/Source/Core/DolphinQt/Config/Graphics/NewTextureLayerDialog.h
@@ -1,0 +1,25 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+#include <QLineEdit>
+
+class QDialogButtonBox;
+
+class NewTextureLayerDialog final : public QDialog
+{
+  Q_OBJECT
+public:
+  NewTextureLayerDialog(QWidget* parent);
+
+  QString GetTextureLayerName() const { return m_texture_layer_name_edit->text(); }
+
+private:
+  void CreateMainLayout();
+
+  QLineEdit* m_texture_layer_name_edit;
+  QDialogButtonBox* m_button_box;
+};

--- a/Source/Core/DolphinQt/Config/Graphics/TextureLayersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/TextureLayersWidget.cpp
@@ -1,0 +1,229 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Graphics/TextureLayersWidget.h"
+
+#include <fmt/format.h>
+
+#include <QBoxLayout>
+#include <QGroupBox>
+#include <QListWidget>
+#include <QPushButton>
+
+#include "Common/Config/Config.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "DolphinQt/Config/Graphics/NewTextureDialog.h"
+#include "DolphinQt/Config/Graphics/NewTextureLayerDialog.h"
+
+TextureLayersWidget::TextureLayersWidget(QWidget* parent, const Config::Info<std::string>& config)
+    : QWidget(parent), m_config(config)
+{
+  CreateLayout();
+  ConnectWidgets();
+}
+
+void TextureLayersWidget::CreateLayout()
+{
+  setLayout(CreateTextureLayersUI());
+
+  BuildTextureLayersList();
+}
+
+QLayout* TextureLayersWidget::CreateTextureLayersUI()
+{
+  auto* texture_layers_vlayout = new QVBoxLayout;
+  m_texture_layer_list = new QListWidget();
+  m_texture_layer_list->setSelectionMode(QAbstractItemView::SelectionMode::SingleSelection);
+  texture_layers_vlayout->addWidget(m_texture_layer_list);
+
+  m_add_texture_layer = new QPushButton(tr("Add..."));
+  m_remove_texture_layer = new QPushButton(tr("Remove"));
+
+  QHBoxLayout* texture_layers_hlayout = new QHBoxLayout;
+  texture_layers_hlayout->addStretch();
+  texture_layers_hlayout->addWidget(m_add_texture_layer);
+  texture_layers_hlayout->addWidget(m_remove_texture_layer);
+
+  texture_layers_vlayout->addItem(texture_layers_hlayout);
+
+  auto* texture_layer_textures_vlayout = new QVBoxLayout;
+  m_texture_layer_textures_list = new QListWidget();
+  m_texture_layer_textures_list->setSelectionMode(QAbstractItemView::SelectionMode::MultiSelection);
+
+  texture_layer_textures_vlayout->addWidget(m_texture_layer_textures_list);
+
+  m_add_texture_layer_texture = new QPushButton(tr("Add..."));
+  m_add_texture_layer_texture->setEnabled(false);
+  m_remove_texture_layer_texture = new QPushButton(tr("Remove"));
+  m_remove_texture_layer_texture->setEnabled(false);
+
+  QHBoxLayout* texture_layer_textures_hlayout = new QHBoxLayout;
+  texture_layer_textures_hlayout->addStretch();
+  texture_layer_textures_hlayout->addWidget(m_add_texture_layer_texture);
+  texture_layer_textures_hlayout->addWidget(m_remove_texture_layer_texture);
+
+  texture_layer_textures_vlayout->addItem(texture_layer_textures_hlayout);
+
+  QHBoxLayout* hlayout = new QHBoxLayout;
+  hlayout->addItem(texture_layers_vlayout);
+  hlayout->addStretch();
+  hlayout->addItem(texture_layer_textures_vlayout);
+
+  return hlayout;
+}
+
+void TextureLayersWidget::ConnectWidgets()
+{
+  connect(m_add_texture_layer, &QPushButton::clicked, this,
+          &TextureLayersWidget::OnTextureLayerAdded);
+  connect(m_remove_texture_layer, &QPushButton::clicked, this,
+          &TextureLayersWidget::OnTextureLayerRemoved);
+  connect(m_texture_layer_list, &QListWidget::itemSelectionChanged, this,
+          &TextureLayersWidget::OnTextureLayerChanged);
+
+  connect(m_add_texture_layer_texture, &QPushButton::clicked, this,
+          &TextureLayersWidget::OnTextureAddedToLayer);
+  connect(m_remove_texture_layer_texture, &QPushButton::clicked, this,
+          &TextureLayersWidget::OnTextureRemovedFromLayer);
+}
+
+void TextureLayersWidget::BuildTextureLayersList()
+{
+  m_texture_layer_list->clear();
+
+  const auto& texture_layers_setting = Config::Get(m_config);
+  const auto texture_layers = SplitString(texture_layers_setting, ';');
+  for (const std::string& texture_layer : texture_layers)
+  {
+    const auto texture_layer_info = SplitString(texture_layer, ':');
+
+    QListWidgetItem* list_item = new QListWidgetItem(QString::fromStdString(texture_layer_info[0]));
+
+    if (texture_layer_info.size() > 1)
+    {
+      list_item->setData(Qt::UserRole, QString::fromStdString(texture_layer_info[1]));
+    }
+    else
+    {
+      list_item->setData(Qt::UserRole, QStringLiteral(""));
+    }
+    m_texture_layer_list->addItem(list_item);
+  }
+}
+
+void TextureLayersWidget::OnTexturesChanged()
+{
+  std::vector<std::string> texture_layers;
+  for (int i = 0; i < m_texture_layer_list->count(); i++)
+  {
+    const auto* item = m_texture_layer_list->item(i);
+    const auto textures = item->data(Qt::UserRole).toString().toStdString();
+    texture_layers.push_back(fmt::format("{}:{}", item->text().toStdString(), textures));
+  }
+
+  Config::SetBaseOrCurrent(m_config, fmt::to_string(fmt::join(texture_layers, ";")));
+}
+
+void TextureLayersWidget::OnTextureLayerAdded()
+{
+  if (m_add_texture_layer != QObject::sender())
+    return;
+  const int index = 0;
+  NewTextureLayerDialog* window = new NewTextureLayerDialog(this);
+  window->setModal(true);
+  if (window->exec() == QDialog::Rejected)
+    return;
+
+  auto* item = new QListWidgetItem(window->GetTextureLayerName());
+  item->setData(Qt::UserRole, QStringLiteral(""));
+  m_texture_layer_list->addItem(item);
+
+  OnTexturesChanged();
+  BuildTextureLayersList();
+}
+
+void TextureLayersWidget::OnTextureLayerRemoved()
+{
+  m_texture_layer_list->takeItem(m_texture_layer_list->row(m_texture_layer_list->currentItem()));
+
+  m_texture_layer_textures_list->clear();
+  m_texture_layer_textures_list->clearSelection();
+
+  m_add_texture_layer_texture->setEnabled(false);
+  m_remove_texture_layer_texture->setEnabled(false);
+
+  OnTexturesChanged();
+  BuildTextureLayersList();
+}
+
+void TextureLayersWidget::OnTextureLayerChanged()
+{
+  m_current_texture_layer = m_texture_layer_list->currentItem();
+
+  m_texture_layer_textures_list->clear();
+
+  const QString textures_str = m_current_texture_layer->data(Qt::UserRole).toString();
+  const auto textures = textures_str.split(QStringLiteral(","));
+
+  for (const auto& texture : textures)
+  {
+    if (texture.isEmpty())
+      continue;
+    QListWidgetItem* list_item = new QListWidgetItem(texture);
+    m_texture_layer_textures_list->addItem(list_item);
+  }
+
+  m_add_texture_layer_texture->setEnabled(true);
+  m_remove_texture_layer_texture->setEnabled(m_texture_layer_textures_list->count() > 0);
+}
+
+void TextureLayersWidget::OnTextureAddedToLayer()
+{
+  if (m_add_texture_layer_texture != QObject::sender())
+    return;
+  const int index = 0;
+  NewTextureDialog* window = new NewTextureDialog(this);
+  window->setModal(true);
+  if (window->exec() == QDialog::Rejected)
+    return;
+
+  auto* item = new QListWidgetItem(window->GetTextureName());
+  m_texture_layer_textures_list->addItem(item);
+
+  UpdateCurrentLayerTextures();
+}
+
+void TextureLayersWidget::OnTextureRemovedFromLayer()
+{
+  const auto items = m_texture_layer_textures_list->selectedItems();
+  for (const auto item : items)
+  {
+    m_texture_layer_textures_list->takeItem(m_texture_layer_textures_list->row(item));
+  }
+
+  UpdateCurrentLayerTextures();
+}
+
+void TextureLayersWidget::UpdateCurrentLayerTextures()
+{
+  QString layer_textures;
+  for (int i = 0; i < m_texture_layer_textures_list->count(); ++i)
+  {
+    QListWidgetItem* item = m_texture_layer_textures_list->item(i);
+
+    if (i == m_texture_layer_textures_list->count() - 1)
+    {
+      layer_textures += item->text();
+    }
+    else
+    {
+      layer_textures += item->text() + QStringLiteral(",");
+    }
+  }
+
+  m_current_texture_layer->setData(Qt::UserRole, layer_textures);
+
+  OnTexturesChanged();
+}

--- a/Source/Core/DolphinQt/Config/Graphics/TextureLayersWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/TextureLayersWidget.h
@@ -1,0 +1,49 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+#include "Common/Config/ConfigInfo.h"
+
+class QLayout;
+class QListWidget;
+class QListWidgetItem;
+class QPushButton;
+
+class TextureLayersWidget final : public QWidget
+{
+  Q_OBJECT
+public:
+  TextureLayersWidget(QWidget* parent, const Config::Info<std::string>& config);
+
+private:
+  void CreateLayout();
+  void ConnectWidgets();
+
+  QLayout* CreateTextureLayersUI();
+
+  void BuildTextureLayersList();
+  void OnTexturesChanged();
+
+  void OnTextureLayerAdded();
+  void OnTextureLayerRemoved();
+  void OnTextureLayerChanged();
+
+  void OnTextureAddedToLayer();
+  void OnTextureRemovedFromLayer();
+  void UpdateCurrentLayerTextures();
+
+  Config::Info<std::string> m_config;
+
+  QListWidget* m_texture_layer_list;
+  QPushButton* m_add_texture_layer;
+  QPushButton* m_remove_texture_layer;
+  QListWidgetItem* m_current_texture_layer;
+
+  QListWidget* m_texture_layer_textures_list;
+  QPushButton* m_add_texture_layer_texture;
+  QPushButton* m_remove_texture_layer_texture;
+};

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.cpp
@@ -29,7 +29,11 @@ void FreeLook2DGeneral::CreateMainLayout()
       CreateGroupBox(tr("Stretch"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Stretch)),
       0, 2);
   layout->addWidget(
-      CreateGroupBox(tr("Other"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Other)), 0,
+      CreateGroupBox(tr("Texture Layer"),
+                     FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::TextureLayer)),
+      0, 3);
+  layout->addWidget(
+      CreateGroupBox(tr("Other"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Other)), 1,
       3);
 
   setLayout(layout);

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.cpp
@@ -1,0 +1,51 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Mapping/FreeLook2DGeneral.h"
+
+#include <QGridLayout>
+#include <QGroupBox>
+
+#include "Core/FreeLookManager.h"
+#include "InputCommon/InputConfig.h"
+
+FreeLook2DGeneral::FreeLook2DGeneral(MappingWindow* window) : MappingWidget(window)
+{
+  CreateMainLayout();
+}
+
+void FreeLook2DGeneral::CreateMainLayout()
+{
+  auto* layout = new QGridLayout;
+
+  layout->addWidget(
+      CreateGroupBox(tr("Move"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Move)), 0,
+      0);
+  layout->addWidget(
+      CreateGroupBox(tr("Speed"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Speed)), 0,
+      1);
+  layout->addWidget(
+      CreateGroupBox(tr("Stretch"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Stretch)),
+      0, 2);
+  layout->addWidget(
+      CreateGroupBox(tr("Other"), FreeLook::Get2DInputGroup(GetPort(), FreeLook2DGroup::Other)), 0,
+      3);
+
+  setLayout(layout);
+}
+
+void FreeLook2DGeneral::LoadSettings()
+{
+  FreeLook::Load2DInputConfig();
+}
+
+void FreeLook2DGeneral::SaveSettings()
+{
+  FreeLook::Get2DInputConfig()->SaveConfig();
+}
+
+InputConfig* FreeLook2DGeneral::GetConfig()
+{
+  return FreeLook::Get2DInputConfig();
+}

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.h
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLook2DGeneral.h
@@ -1,0 +1,21 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "DolphinQt/Config/Mapping/MappingWidget.h"
+
+class FreeLook2DGeneral final : public MappingWidget
+{
+  Q_OBJECT
+public:
+  explicit FreeLook2DGeneral(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+  void CreateMainLayout();
+};

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -22,6 +22,7 @@
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 
+#include "DolphinQt/Config/Mapping/FreeLook2DGeneral.h"
 #include "DolphinQt/Config/Mapping/FreeLookGeneral.h"
 #include "DolphinQt/Config/Mapping/FreeLookRotation.h"
 #include "DolphinQt/Config/Mapping/GCKeyboardEmu.h"
@@ -439,6 +440,13 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
     AddWidget(tr("General"), widget);
     AddWidget(tr("Rotation"), new FreeLookRotation(this));
     setWindowTitle(tr("Free Look Controller %1").arg(GetPort() + 1));
+  }
+  break;
+  case Type::MAPPING_FREELOOK_2D:
+  {
+    widget = new FreeLook2DGeneral(this);
+    AddWidget(tr("General"), widget);
+    setWindowTitle(tr("Free Look 2D Controller %1").arg(GetPort() + 1));
   }
   break;
   default:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -45,6 +45,7 @@ public:
     MAPPING_HOTKEYS,
     // Freelook
     MAPPING_FREELOOK,
+    MAPPING_FREELOOK_2D,
   };
 
   explicit MappingWindow(QWidget* parent, Type type, int port_num);

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -56,6 +56,8 @@
     <ClCompile Include="Config\ControllerInterface\ServerStringValidator.cpp" />
     <ClCompile Include="Config\ControllersWindow.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
+    <ClCompile Include="Config\FreeLook2DOptionsWidget.cpp" />
+    <ClCompile Include="Config\FreeLook2DOptionsWindow.cpp" />
     <ClCompile Include="Config\FreeLook2DWidget.cpp" />
     <ClCompile Include="Config\FreeLookWidget.cpp" />
     <ClCompile Include="Config\FreeLookWindow.cpp" />
@@ -76,7 +78,10 @@
     <ClCompile Include="Config\Graphics\GraphicsWindow.cpp" />
     <ClCompile Include="Config\Graphics\HacksWidget.cpp" />
     <ClCompile Include="Config\Graphics\PostProcessingConfigWindow.cpp" />
+    <ClCompile Include="Config\Graphics\NewTextureDialog.cpp" />
+    <ClCompile Include="Config\Graphics\NewTextureLayerDialog.cpp" />
     <ClCompile Include="Config\Graphics\SoftwareRendererWidget.cpp" />
+    <ClCompile Include="Config\Graphics\TextureLayersWidget.cpp" />
     <ClCompile Include="Config\InfoWidget.cpp" />
     <ClCompile Include="Config\LogConfigWidget.cpp" />
     <ClCompile Include="Config\LogWidget.cpp" />
@@ -233,6 +238,8 @@
     <QtMoc Include="Config\ControllerInterface\ServerStringValidator.h" />
     <QtMoc Include="Config\ControllersWindow.h" />
     <QtMoc Include="Config\FilesystemWidget.h" />
+    <QtMoc Include="Config\FreeLook2DOptionsWidget.h" />
+    <QtMoc Include="Config\FreeLook2DOptionsWindow.h" />
     <QtMoc Include="Config\FreeLook2DWidget.h" />
     <QtMoc Include="Config\FreeLookWidget.h" />
     <QtMoc Include="Config\FreeLookWindow.h" />
@@ -253,7 +260,10 @@
     <QtMoc Include="Config\Graphics\GraphicsWindow.h" />
     <QtMoc Include="Config\Graphics\HacksWidget.h" />
     <QtMoc Include="Config\Graphics\PostProcessingConfigWindow.h" />
+    <QtMoc Include="Config\Graphics\NewTextureDialog.h" />
+    <QtMoc Include="Config\Graphics\NewTextureLayerDialog.h" />
     <QtMoc Include="Config\Graphics\SoftwareRendererWidget.h" />
+    <QtMoc Include="Config\Graphics\TextureLayersWidget.h" />
     <QtMoc Include="Config\InfoWidget.h" />
     <QtMoc Include="Config\LogConfigWidget.h" />
     <QtMoc Include="Config\LogWidget.h" />

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="Config\ControllerInterface\ServerStringValidator.cpp" />
     <ClCompile Include="Config\ControllersWindow.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
+    <ClCompile Include="Config\FreeLook2DWidget.cpp" />
     <ClCompile Include="Config\FreeLookWidget.cpp" />
     <ClCompile Include="Config\FreeLookWindow.cpp" />
     <ClCompile Include="Config\GamecubeControllersWidget.cpp" />
@@ -79,6 +80,7 @@
     <ClCompile Include="Config\InfoWidget.cpp" />
     <ClCompile Include="Config\LogConfigWidget.cpp" />
     <ClCompile Include="Config\LogWidget.cpp" />
+    <ClCompile Include="Config\Mapping\FreeLook2DGeneral.cpp" />
     <ClCompile Include="Config\Mapping\FreeLookGeneral.cpp" />
     <ClCompile Include="Config\Mapping\FreeLookRotation.cpp" />
     <ClCompile Include="Config\Mapping\GCKeyboardEmu.cpp" />
@@ -231,6 +233,7 @@
     <QtMoc Include="Config\ControllerInterface\ServerStringValidator.h" />
     <QtMoc Include="Config\ControllersWindow.h" />
     <QtMoc Include="Config\FilesystemWidget.h" />
+    <QtMoc Include="Config\FreeLook2DWidget.h" />
     <QtMoc Include="Config\FreeLookWidget.h" />
     <QtMoc Include="Config\FreeLookWindow.h" />
     <QtMoc Include="Config\GamecubeControllersWidget.h" />
@@ -254,6 +257,7 @@
     <QtMoc Include="Config\InfoWidget.h" />
     <QtMoc Include="Config\LogConfigWidget.h" />
     <QtMoc Include="Config\LogWidget.h" />
+    <QtMoc Include="Config\Mapping\FreeLook2DGeneral.h" />
     <QtMoc Include="Config\Mapping\FreeLookGeneral.h" />
     <QtMoc Include="Config\Mapping\FreeLookRotation.h" />
     <QtMoc Include="Config\Mapping\GCKeyboardEmu.h" />

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -35,6 +35,8 @@ add_library(videocommon
   FramebufferShaderGen.h
   FreeLookCamera.cpp
   FreeLookCamera.h
+  FreeLookCamera2D.cpp
+  FreeLookCamera2D.h
   GeometryShaderGen.cpp
   GeometryShaderGen.h
   GeometryShaderManager.cpp

--- a/Source/Core/VideoCommon/FreeLookCamera2D.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera2D.cpp
@@ -7,9 +7,12 @@
 #include <algorithm>
 #include <math.h>
 
+#include <fmt/format.h>
+
 #include "Common/MathUtil.h"
 
 #include "Common/ChunkFile.h"
+#include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/FreeLookConfig.h"
@@ -18,50 +21,210 @@
 
 FreeLookCamera2D g_freelook_camera_2d;
 
+template <>
+struct fmt::formatter<TextureLayer>
+{
+  constexpr auto parse(format_parse_context& ctxt) { return ctxt.begin(); }
+
+  template <typename FormatContext>
+  auto format(const TextureLayer& layer, FormatContext& ctxt)
+  {
+    return fmt::format_to(
+        ctxt.out(), fmt::format("{}:{}", layer.GetLayerName(), fmt::join(layer.GetNames(), ",")));
+  }
+};
+
 namespace
 {
 class BasicMovementController final : public CameraController2DInput
 {
-  void UpdateConfig(const FreeLook::CameraConfig2D&) override {}
   void MoveVertical(float amt) override
   {
-    m_position_offset.y += amt;
-    m_dirty = true;
+    if (m_current_layer)
+    {
+      m_current_layer->GetPositionOffset().y += amt;
+      m_dirty = true;
+    }
   }
 
   void MoveHorizontal(float amt) override
   {
-    m_position_offset.x += amt;
-    m_dirty = true;
+    if (m_current_layer)
+    {
+      m_current_layer->GetPositionOffset().x += amt;
+      m_dirty = true;
+    }
   }
-
-  const Common::Vec2& GetPositionOffset() const override { return m_position_offset; }
-
-  void DoState(PointerWrap& p) override
-  {
-    CameraController2DInput::DoState(p);
-    p.Do(m_position_offset);
-  }
-
-  void Reset() override
-  {
-    CameraController2DInput::Reset();
-    m_position_offset = Common::Vec2{};
-  }
-
-private:
-  Common::Vec2 m_position_offset;
 };
+
+bool wildcard_compare(const std::string& wildcard_texture, const std::string& full_texture)
+{
+  std::size_t wildcard_index = 0;
+  for (const char& c : full_texture)
+  {
+    const char wildcard_char = wildcard_texture[wildcard_index];
+    wildcard_index++;
+    if (wildcard_char == '*')
+    {
+      break;
+    }
+    else if (wildcard_char != '?' && wildcard_char != c)
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
 }  // namespace
+
+TextureLayer::TextureLayer(const std::string& layer_name, std::vector<std::string> texture_names)
+    : m_layer_name(layer_name), m_texture_names_ordered(std::move(texture_names))
+{
+  for (const auto& name : m_texture_names_ordered)
+  {
+    auto iter = name.find_first_of("?*");
+    if (iter == std::string::npos)
+    {
+      m_texture_names.insert(name);
+    }
+    else
+    {
+      m_texture_names_with_wildcards.emplace_back(name);
+    }
+  }
+}
+
+void TextureLayer::DoState(PointerWrap& p)
+{
+  p.Do(m_layer_name);
+  p.Do(m_texture_names_ordered);
+  p.Do(m_stretch_multiplier);
+  p.Do(m_position_offset);
+
+  if (p.GetMode() == PointerWrap::MODE_READ)
+  {
+    for (const auto& name : m_texture_names_ordered)
+    {
+      m_texture_names.insert(name);
+    }
+  }
+}
+
+void TextureLayer::Reset()
+{
+  m_stretch_multiplier = DEFAULT_STRETCH_MULTIPLIER;
+  m_position_offset = Common::Vec2{};
+}
+
+bool TextureLayer::Matches(const std::vector<std::string>& names) const
+{
+  return std::any_of(names.begin(), names.end(), [this](const std::string& name) {
+    if (m_texture_names.count(name) > 0)
+      return true;
+
+    for (const auto& wildcard_texture : m_texture_names_with_wildcards)
+    {
+      if (wildcard_compare(wildcard_texture, name))
+        return true;
+    }
+
+    return false;
+  });
+}
+
+const Common::Vec2& TextureLayer::GetPositionOffset() const
+{
+  return m_position_offset;
+}
+
+const Common::Vec2& TextureLayer::GetStretchMultiplier() const
+{
+  return m_stretch_multiplier;
+}
+
+Common::Vec2& TextureLayer::GetPositionOffset()
+{
+  return m_position_offset;
+}
+
+Common::Vec2& TextureLayer::GetStretchMultiplier()
+{
+  return m_stretch_multiplier;
+}
+
+void CameraController2D::UpdateConfig(const FreeLook::CameraConfig2D& config)
+{
+  const std::string old_layers_string = fmt::to_string(fmt::join(m_layers, ";"));
+  if (config.layers != old_layers_string)
+  {
+    m_layers.clear();
+    m_current_layer = nullptr;
+    const std::vector<std::string> layers = SplitString(config.layers, ';');
+    if (!layers.empty())
+    {
+      for (const std::string& layer : layers)
+      {
+        const std::vector<std::string> layer_details = SplitString(layer, ':');
+        const std::vector<std::string> textures = SplitString(layer_details[1], ',');
+        std::vector<std::string> textures_stripped;
+        textures_stripped.reserve(textures.size());
+        for (const std::string& texture : textures)
+        {
+          textures_stripped.push_back(std::string{StripSpaces(texture)});
+        }
+        m_layers.emplace_back(layer_details[0], std::move(textures_stripped));
+      }
+      m_current_layer = &m_layers[0];
+    }
+  }
+}
+
+const Common::Vec2&
+CameraController2D::GetPositionOffset(const std::vector<std::string>& names) const
+{
+  for (const auto& layer : m_layers)
+  {
+    if (layer.Matches(names))
+      return layer.GetPositionOffset();
+  }
+
+  static Common::Vec2 def_pos_offset;
+  return def_pos_offset;
+}
+
+const Common::Vec2&
+CameraController2D::GetStretchMultiplier(const std::vector<std::string>& names) const
+{
+  for (const auto& layer : m_layers)
+  {
+    if (layer.Matches(names))
+      return layer.GetStretchMultiplier();
+  }
+
+  static Common::Vec2 def_stretch_multiplier = Common::Vec2{1, 1};
+  return def_stretch_multiplier;
+}
+
+void CameraController2D::DoState(PointerWrap& p)
+{
+  p.DoEachElement(m_layers, [](PointerWrap& pw, TextureLayer& layer) { layer.DoState(pw); });
+}
 
 void CameraController2DInput::IncreaseStretchX(float amt)
 {
-  m_stretch_multiplier.x += amt;
+  if (m_current_layer)
+  {
+    m_current_layer->GetStretchMultiplier().x += amt;
+  }
 }
 
 void CameraController2DInput::IncreaseStretchY(float amt)
 {
-  m_stretch_multiplier.y += amt;
+  if (m_current_layer)
+  {
+    m_current_layer->GetStretchMultiplier().y += amt;
+  }
 }
 
 float CameraController2DInput::GetStretchMultiplierSize() const
@@ -69,14 +232,13 @@ float CameraController2DInput::GetStretchMultiplierSize() const
   return 1.0f;
 }
 
-const Common::Vec2& CameraController2DInput::GetStretchMultiplier() const
-{
-  return m_stretch_multiplier;
-}
-
 void CameraController2DInput::Reset()
 {
-  m_stretch_multiplier = DEFAULT_STRETCH_MULTIPLIER;
+  if (m_current_layer)
+  {
+    m_current_layer->Reset();
+  }
+  m_speed = DEFAULT_SPEED;
   m_dirty = true;
 }
 
@@ -98,8 +260,8 @@ float CameraController2DInput::GetSpeed() const
 
 void CameraController2DInput::DoState(PointerWrap& p)
 {
+  CameraController2D::DoState(p);
   p.Do(m_speed);
-  p.Do(m_stretch_multiplier);
 }
 
 FreeLookCamera2D::FreeLookCamera2D()
@@ -112,14 +274,15 @@ void FreeLookCamera2D::UpdateConfig(const FreeLook::CameraConfig2D& config)
   m_controller->UpdateConfig(config);
 }
 
-const Common::Vec2& FreeLookCamera2D::GetPositionOffset() const
+const Common::Vec2& FreeLookCamera2D::GetPositionOffset(const std::vector<std::string>& names) const
 {
-  return m_controller->GetPositionOffset();
+  return m_controller->GetPositionOffset(names);
 }
 
-const Common::Vec2& FreeLookCamera2D::GetStretchMultiplier() const
+const Common::Vec2&
+FreeLookCamera2D::GetStretchMultiplier(const std::vector<std::string>& names) const
 {
-  return m_controller->GetStretchMultiplier();
+  return m_controller->GetStretchMultiplier(names);
 }
 
 CameraController2D* FreeLookCamera2D::GetController() const

--- a/Source/Core/VideoCommon/FreeLookCamera2D.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera2D.cpp
@@ -211,6 +211,23 @@ void CameraController2D::DoState(PointerWrap& p)
   p.DoEachElement(m_layers, [](PointerWrap& pw, TextureLayer& layer) { layer.DoState(pw); });
 }
 
+void CameraController2D::SetLayer(std::size_t layer)
+{
+  if (layer < LayerCount())
+  {
+    m_current_layer = &m_layers[layer];
+    static constexpr int display_message_ms = 3000;
+    Core::DisplayMessage(
+        fmt::format("FreeLook 2d camera texture layer '{}' set", m_current_layer->GetLayerName()),
+        display_message_ms);
+  }
+}
+
+std::size_t CameraController2D::LayerCount() const
+{
+  return m_layers.size();
+}
+
 void CameraController2DInput::IncreaseStretchX(float amt)
 {
   if (m_current_layer)
@@ -225,6 +242,22 @@ void CameraController2DInput::IncreaseStretchY(float amt)
   {
     m_current_layer->GetStretchMultiplier().y += amt;
   }
+}
+
+void CameraController2DInput::IncrementLayer()
+{
+  m_current_layer_index++;
+  if (m_current_layer_index >= LayerCount())
+    m_current_layer_index = 0;
+  SetLayer(m_current_layer_index);
+}
+
+void CameraController2DInput::DecrementLayer()
+{
+  m_current_layer_index--;
+  if (m_current_layer_index < 0)
+    m_current_layer_index = LayerCount() - 1;
+  SetLayer(m_current_layer_index);
 }
 
 float CameraController2DInput::GetStretchMultiplierSize() const

--- a/Source/Core/VideoCommon/FreeLookCamera2D.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera2D.cpp
@@ -1,0 +1,132 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoCommon/FreeLookCamera2D.h"
+
+#include <algorithm>
+#include <math.h>
+
+#include "Common/MathUtil.h"
+
+#include "Common/ChunkFile.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "Core/FreeLookConfig.h"
+
+#include "VideoCommon/VideoCommon.h"
+
+FreeLookCamera2D g_freelook_camera_2d;
+
+namespace
+{
+class BasicMovementController final : public CameraController2DInput
+{
+  void MoveVertical(float amt) override
+  {
+    m_position_offset.y += amt;
+    m_dirty = true;
+  }
+
+  void MoveHorizontal(float amt) override
+  {
+    m_position_offset.x += amt;
+    m_dirty = true;
+  }
+
+  const Common::Vec2& GetPositionOffset() const override { return m_position_offset; }
+
+  void DoState(PointerWrap& p) override
+  {
+    CameraController2DInput::DoState(p);
+    p.Do(m_position_offset);
+  }
+
+  void Reset() override
+  {
+    CameraController2DInput::Reset();
+    m_position_offset = Common::Vec2{};
+  }
+
+private:
+  Common::Vec2 m_position_offset;
+};
+}  // namespace
+
+void CameraController2DInput::IncreaseStretchX(float amt)
+{
+  m_stretch_multiplier.x += amt;
+}
+
+void CameraController2DInput::IncreaseStretchY(float amt)
+{
+  m_stretch_multiplier.y += amt;
+}
+
+float CameraController2DInput::GetStretchMultiplierSize() const
+{
+  return 1.0f;
+}
+
+const Common::Vec2& CameraController2DInput::GetStretchMultiplier() const
+{
+  return m_stretch_multiplier;
+}
+
+void CameraController2DInput::Reset()
+{
+  m_stretch_multiplier = DEFAULT_STRETCH_MULTIPLIER;
+  m_dirty = true;
+}
+
+void CameraController2DInput::ModifySpeed(float amt)
+{
+  m_speed += amt;
+  m_speed = std::max(m_speed, 0.0f);
+}
+
+void CameraController2DInput::ResetSpeed()
+{
+  m_speed = DEFAULT_SPEED;
+}
+
+float CameraController2DInput::GetSpeed() const
+{
+  return m_speed;
+}
+
+void CameraController2DInput::DoState(PointerWrap& p)
+{
+  p.Do(m_speed);
+  p.Do(m_stretch_multiplier);
+}
+
+FreeLookCamera2D::FreeLookCamera2D()
+{
+  m_controller = std::make_unique<BasicMovementController>();
+}
+
+const Common::Vec2& FreeLookCamera2D::GetPositionOffset() const
+{
+  return m_controller->GetPositionOffset();
+}
+
+const Common::Vec2& FreeLookCamera2D::GetStretchMultiplier() const
+{
+  return m_controller->GetStretchMultiplier();
+}
+
+CameraController2D* FreeLookCamera2D::GetController() const
+{
+  return m_controller.get();
+}
+
+bool FreeLookCamera2D::IsActive() const
+{
+  return FreeLook::GetActiveConfig().enabled_2d;
+}
+
+void FreeLookCamera2D::DoState(PointerWrap& p)
+{
+  m_controller->DoState(p);
+}

--- a/Source/Core/VideoCommon/FreeLookCamera2D.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera2D.cpp
@@ -22,6 +22,7 @@ namespace
 {
 class BasicMovementController final : public CameraController2DInput
 {
+  void UpdateConfig(const FreeLook::CameraConfig2D&) override {}
   void MoveVertical(float amt) override
   {
     m_position_offset.y += amt;
@@ -104,6 +105,11 @@ void CameraController2DInput::DoState(PointerWrap& p)
 FreeLookCamera2D::FreeLookCamera2D()
 {
   m_controller = std::make_unique<BasicMovementController>();
+}
+
+void FreeLookCamera2D::UpdateConfig(const FreeLook::CameraConfig2D& config)
+{
+  m_controller->UpdateConfig(config);
 }
 
 const Common::Vec2& FreeLookCamera2D::GetPositionOffset() const

--- a/Source/Core/VideoCommon/FreeLookCamera2D.h
+++ b/Source/Core/VideoCommon/FreeLookCamera2D.h
@@ -10,6 +10,11 @@
 
 class PointerWrap;
 
+namespace FreeLook
+{
+struct CameraConfig2D;
+}
+
 class CameraController2D
 {
 public:
@@ -19,6 +24,8 @@ public:
   CameraController2D& operator=(const CameraController2D&) = delete;
   CameraController2D(CameraController2D&&) = delete;
   CameraController2D& operator=(CameraController2D&&) = delete;
+
+  virtual void UpdateConfig(const FreeLook::CameraConfig2D& config) = 0;
 
   virtual const Common::Vec2& GetPositionOffset() const = 0;
   virtual const Common::Vec2& GetStretchMultiplier() const = 0;
@@ -72,6 +79,7 @@ class FreeLookCamera2D
 {
 public:
   FreeLookCamera2D();
+  void UpdateConfig(const FreeLook::CameraConfig2D& config);
 
   const Common::Vec2& GetPositionOffset() const;
   const Common::Vec2& GetStretchMultiplier() const;

--- a/Source/Core/VideoCommon/FreeLookCamera2D.h
+++ b/Source/Core/VideoCommon/FreeLookCamera2D.h
@@ -78,6 +78,9 @@ private:
   std::vector<TextureLayer> m_layers;
 
 protected:
+  void SetLayer(std::size_t layer);
+  std::size_t LayerCount() const;
+
   TextureLayer* m_current_layer;
 };
 
@@ -91,6 +94,9 @@ public:
 
   void IncreaseStretchX(float amt);
   void IncreaseStretchY(float amt);
+
+  void IncrementLayer();
+  void DecrementLayer();
 
   void DoState(PointerWrap& p) override;
 
@@ -109,6 +115,7 @@ protected:
   bool m_dirty = false;
 
 private:
+  std::size_t m_current_layer_index;
   static constexpr float DEFAULT_SPEED = 1.0f;
 
   float m_speed = DEFAULT_SPEED;

--- a/Source/Core/VideoCommon/FreeLookCamera2D.h
+++ b/Source/Core/VideoCommon/FreeLookCamera2D.h
@@ -1,0 +1,89 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "Common/Matrix.h"
+
+class PointerWrap;
+
+class CameraController2D
+{
+public:
+  CameraController2D() = default;
+  virtual ~CameraController2D() = default;
+  CameraController2D(const CameraController2D&) = delete;
+  CameraController2D& operator=(const CameraController2D&) = delete;
+  CameraController2D(CameraController2D&&) = delete;
+  CameraController2D& operator=(CameraController2D&&) = delete;
+
+  virtual const Common::Vec2& GetPositionOffset() const = 0;
+  virtual const Common::Vec2& GetStretchMultiplier() const = 0;
+
+  virtual void DoState(PointerWrap& p) = 0;
+
+  virtual bool IsDirty() const = 0;
+  virtual void SetClean() = 0;
+
+  virtual bool SupportsInput() const = 0;
+};
+
+class CameraController2DInput : public CameraController2D
+{
+public:
+  const Common::Vec2& GetStretchMultiplier() const final override;
+
+  virtual void MoveVertical(float amt) = 0;
+  virtual void MoveHorizontal(float amt) = 0;
+
+  virtual void Reset();
+
+  void IncreaseStretchX(float amt);
+  void IncreaseStretchY(float amt);
+
+  void DoState(PointerWrap& p) override;
+
+  bool IsDirty() const final override { return m_dirty; }
+  void SetClean() final override { m_dirty = false; }
+
+  bool SupportsInput() const final override { return true; }
+
+  void ModifySpeed(float multiplier);
+  void ResetSpeed();
+  float GetSpeed() const;
+
+  float GetStretchMultiplierSize() const;
+
+protected:
+  bool m_dirty = false;
+
+private:
+  static constexpr float DEFAULT_SPEED = 1.0f;
+  static constexpr Common::Vec2 DEFAULT_STRETCH_MULTIPLIER = Common::Vec2{1, 1};
+  Common::Vec2 m_stretch_multiplier = DEFAULT_STRETCH_MULTIPLIER;
+
+  float m_speed = DEFAULT_SPEED;
+};
+
+class FreeLookCamera2D
+{
+public:
+  FreeLookCamera2D();
+
+  const Common::Vec2& GetPositionOffset() const;
+  const Common::Vec2& GetStretchMultiplier() const;
+
+  CameraController2D* GetController() const;
+
+  bool IsActive() const;
+
+  void DoState(PointerWrap& p);
+
+private:
+  std::unique_ptr<CameraController2D> m_controller;
+};
+
+extern FreeLookCamera2D g_freelook_camera_2d;

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -214,7 +214,7 @@ void HiresTexture::Prefetch()
                   10000);
 }
 
-std::string HiresTexture::GenBaseName(TextureInfo& texture_info, bool dump)
+std::string HiresTexture::GenBaseName(const TextureInfo& texture_info, bool dump)
 {
   if (!dump && s_textureMap.empty())
     return "";
@@ -262,7 +262,7 @@ u32 HiresTexture::CalculateMipCount(u32 width, u32 height)
   return mip_count;
 }
 
-std::shared_ptr<HiresTexture> HiresTexture::Search(TextureInfo& texture_info)
+std::shared_ptr<HiresTexture> HiresTexture::Search(const TextureInfo& texture_info)
 {
   const std::string base_filename = GenBaseName(texture_info);
 

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -26,9 +26,9 @@ public:
   static void Clear();
   static void Shutdown();
 
-  static std::shared_ptr<HiresTexture> Search(TextureInfo& texture_info);
+  static std::shared_ptr<HiresTexture> Search(const TextureInfo& texture_info);
 
-  static std::string GenBaseName(TextureInfo& texture_info, bool dump = false);
+  static std::string GenBaseName(const TextureInfo& texture_info, bool dump = false);
 
   static u32 CalculateMipCount(u32 width, u32 height);
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -65,6 +65,7 @@
 #include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/FramebufferShaderGen.h"
 #include "VideoCommon/FreeLookCamera.h"
+#include "VideoCommon/FreeLookCamera2D.h"
 #include "VideoCommon/NetPlayChatUI.h"
 #include "VideoCommon/NetPlayGolfUI.h"
 #include "VideoCommon/OnScreenDisplay.h"
@@ -438,6 +439,7 @@ void Renderer::CheckForConfigChanges()
   FreeLook::UpdateActiveConfig();
 
   g_freelook_camera.SetControlType(FreeLook::GetActiveConfig().camera_config.control_type);
+  g_freelook_camera_2d.UpdateConfig(FreeLook::GetActiveConfig().camera_config_2d);
 
   // Update texture cache settings with any changed options.
   g_texture_cache->OnConfigChanged(g_ActiveConfig);

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1189,15 +1189,13 @@ private:
   std::vector<Level> levels;
 };
 
-TextureCacheBase::TCacheEntry* TextureCacheBase::Load(const u32 stage)
+TextureCacheBase::TCacheEntry* TextureCacheBase::Load(const TextureInfo& texture_info)
 {
   // if this stage was not invalidated by changes to texture registers, keep the current texture
-  if (IsValidBindPoint(stage) && bound_textures[stage])
+  if (IsValidBindPoint(texture_info.GetStage()) && bound_textures[texture_info.GetStage()])
   {
-    return bound_textures[stage];
+    return bound_textures[texture_info.GetStage()];
   }
-
-  TextureInfo texture_info = TextureInfo::FromStage(stage);
 
   auto entry = GetTexture(g_ActiveConfig.iSafeTextureCache_ColorSamples, texture_info);
 
@@ -1205,17 +1203,18 @@ TextureCacheBase::TCacheEntry* TextureCacheBase::Load(const u32 stage)
     return nullptr;
 
   entry->frameCount = FRAMECOUNT_INVALID;
-  bound_textures[stage] = entry;
+  bound_textures[texture_info.GetStage()] = entry;
 
   // We need to keep track of invalided textures until they have actually been replaced or
   // re-loaded
-  valid_bind_points.set(stage);
+  valid_bind_points.set(texture_info.GetStage());
 
   return entry;
 }
 
 TextureCacheBase::TCacheEntry*
-TextureCacheBase::GetTexture(const int textureCacheSafetyColorSampleSize, TextureInfo& texture_info)
+TextureCacheBase::GetTexture(const int textureCacheSafetyColorSampleSize,
+                             const TextureInfo& texture_info)
 {
   u32 expanded_width = texture_info.GetExpandedWidth();
   u32 expanded_height = texture_info.GetExpandedHeight();

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2152,17 +2152,19 @@ void TextureCacheBase::CopyRenderTargetToTexture(
       if (g_ActiveConfig.bDumpEFBTarget && !is_xfb_copy)
       {
         static int efb_count = 0;
-        entry->texture->Save(
-            fmt::format("{}efb_frame_{}.png", File::GetUserPath(D_DUMPTEXTURES_IDX), efb_count++),
-            0);
+        entry->texture->Save(fmt::format("{}efb_frame_{}x{}_{}_c{}.png",
+                                         File::GetUserPath(D_DUMPTEXTURES_IDX), tex_w, tex_h,
+                                         static_cast<int>(baseFormat), efb_count++),
+                             0);
       }
 
       if (g_ActiveConfig.bDumpXFBTarget && is_xfb_copy)
       {
         static int xfb_count = 0;
-        entry->texture->Save(
-            fmt::format("{}xfb_copy_{}.png", File::GetUserPath(D_DUMPTEXTURES_IDX), xfb_count++),
-            0);
+        entry->texture->Save(fmt::format("{}xfb_copy_{}x{}_{}_c{}.png",
+                                         File::GetUserPath(D_DUMPTEXTURES_IDX), tex_w, tex_h,
+                                         static_cast<int>(baseFormat), xfb_count++),
+                             0);
       }
     }
   }

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -214,10 +214,11 @@ public:
 
   void Invalidate();
 
-  TCacheEntry* Load(const u32 stage);
+  TCacheEntry* Load(const TextureInfo& texture_info);
   static void InvalidateAllBindPoints() { valid_bind_points.reset(); }
   static bool IsValidBindPoint(u32 i) { return valid_bind_points.test(i); }
-  TCacheEntry* GetTexture(const int textureCacheSafetyColorSampleSize, TextureInfo& texture_info);
+  TCacheEntry* GetTexture(const int textureCacheSafetyColorSampleSize,
+                          const TextureInfo& texture_info);
   TCacheEntry* GetXFBTexture(u32 address, u32 width, u32 height, u32 stride,
                              MathUtil::Rectangle<int>* display_rect);
 

--- a/Source/Core/VideoCommon/TextureInfo.cpp
+++ b/Source/Core/VideoCommon/TextureInfo.cpp
@@ -42,20 +42,20 @@ TextureInfo TextureInfo::FromStage(u32 stage)
 
   if (from_tmem)
   {
-    return TextureInfo(&texMem[tmem_address_even], tlut_ptr, address, texture_format, tlut_format,
-                       width, height, true, &texMem[tmem_address_odd], &texMem[tmem_address_even],
-                       mip_count);
+    return TextureInfo(stage, &texMem[tmem_address_even], tlut_ptr, address, texture_format,
+                       tlut_format, width, height, true, &texMem[tmem_address_odd],
+                       &texMem[tmem_address_even], mip_count);
   }
 
-  return TextureInfo(Memory::GetPointer(address), tlut_ptr, address, texture_format, tlut_format,
-                     width, height, false, nullptr, nullptr, mip_count);
+  return TextureInfo(stage, Memory::GetPointer(address), tlut_ptr, address, texture_format,
+                     tlut_format, width, height, false, nullptr, nullptr, mip_count);
 }
 
-TextureInfo::TextureInfo(const u8* ptr, const u8* tlut_ptr, u32 address,
+TextureInfo::TextureInfo(u32 stage, const u8* ptr, const u8* tlut_ptr, u32 address,
                          TextureFormat texture_format, TLUTFormat tlut_format, u32 width,
                          u32 height, bool from_tmem, const u8* tmem_odd, const u8* tmem_even,
                          std::optional<u32> mip_count)
-    : m_ptr(ptr), m_tlut_ptr(tlut_ptr), m_address(address), m_from_tmem(from_tmem),
+    : m_stage(stage), m_ptr(ptr), m_tlut_ptr(tlut_ptr), m_address(address), m_from_tmem(from_tmem),
       m_tmem_odd(tmem_odd), m_texture_format(texture_format), m_tlut_format(tlut_format),
       m_raw_width(width), m_raw_height(height)
 {
@@ -101,7 +101,7 @@ std::string TextureInfo::NameDetails::GetFullName() const
   return fmt::format("{}_{}{}_{}", base_name, texture_name, tlut_name, format_name);
 }
 
-TextureInfo::NameDetails TextureInfo::CalculateTextureName()
+TextureInfo::NameDetails TextureInfo::CalculateTextureName() const
 {
   if (!m_ptr)
     return NameDetails{};
@@ -239,6 +239,11 @@ u32 TextureInfo::GetRawWidth() const
 u32 TextureInfo::GetRawHeight() const
 {
   return m_raw_height;
+}
+
+u32 TextureInfo::GetStage() const
+{
+  return m_stage;
 }
 
 bool TextureInfo::HasMipMaps() const

--- a/Source/Core/VideoCommon/TextureInfo.h
+++ b/Source/Core/VideoCommon/TextureInfo.h
@@ -18,9 +18,10 @@ class TextureInfo
 {
 public:
   static TextureInfo FromStage(u32 stage);
-  TextureInfo(const u8* ptr, const u8* tlut_ptr, u32 address, TextureFormat texture_format,
-              TLUTFormat tlut_format, u32 width, u32 height, bool from_tmem, const u8* tmem_odd,
-              const u8* tmem_even, std::optional<u32> mip_count);
+  TextureInfo(u32 stage, const u8* ptr, const u8* tlut_ptr, u32 address,
+              TextureFormat texture_format, TLUTFormat tlut_format, u32 width, u32 height,
+              bool from_tmem, const u8* tmem_odd, const u8* tmem_even,
+              std::optional<u32> mip_count);
 
   struct NameDetails
   {
@@ -31,7 +32,7 @@ public:
 
     std::string GetFullName() const;
   };
-  NameDetails CalculateTextureName();
+  NameDetails CalculateTextureName() const;
 
   const u8* GetData() const;
   const u8* GetTlutAddress() const;
@@ -55,6 +56,8 @@ public:
 
   u32 GetRawWidth() const;
   u32 GetRawHeight() const;
+
+  u32 GetStage() const;
 
   class MipLevel
   {
@@ -116,4 +119,6 @@ private:
   u32 m_block_height;
   u32 m_expanded_height;
   u32 m_raw_height;
+
+  u32 m_stage;
 };

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -8,7 +8,6 @@
 #include <cmath>
 #include <memory>
 
-#include "Common/BitSet.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -31,6 +30,7 @@
 #include "VideoCommon/SamplerCommon.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureInfo.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
@@ -336,7 +336,7 @@ bool VertexManagerBase::UploadTexelBuffer(const void* data, u32 data_size, Texel
   return false;
 }
 
-void VertexManagerBase::LoadTextures()
+BitSet32 VertexManagerBase::UsedTextures()
 {
   BitSet32 usedtextures;
   for (u32 i = 0; i < bpmem.genMode.numtevstages + 1u; ++i)
@@ -348,8 +348,13 @@ void VertexManagerBase::LoadTextures()
       if (bpmem.tevind[i].IsActive() && bpmem.tevind[i].bt < bpmem.genMode.numindstages)
         usedtextures[bpmem.tevindref.getTexMap(bpmem.tevind[i].bt)] = true;
 
-  for (unsigned int i : usedtextures)
-    g_texture_cache->Load(i);
+  return usedtextures;
+}
+
+void VertexManagerBase::LoadTextures(const std::vector<TextureInfo>& textures)
+{
+  for (auto& texture_info : textures)
+    g_texture_cache->Load(texture_info);
 
   g_texture_cache->BindTextures();
 }
@@ -453,7 +458,11 @@ void VertexManagerBase::Flush()
   }
 
   // Calculate ZSlope for zfreeze
-  VertexShaderManager::SetConstants();
+  const auto used_textures = UsedTextures();
+  std::vector<TextureInfo> textures;
+  for (const u32 i : used_textures)
+    textures.emplace_back(TextureInfo::FromStage(i));
+  VertexShaderManager::SetConstants(textures);
   if (!bpmem.genMode.zfreeze)
   {
     // Must be done after VertexShaderManager::SetConstants()
@@ -478,7 +487,7 @@ void VertexManagerBase::Flush()
     // Texture loading can cause palettes to be applied (-> uniforms -> draws).
     // Palette application does not use vertices, only a full-screen quad, so this is okay.
     // Same with GPU texture decoding, which uses compute shaders.
-    LoadTextures();
+    LoadTextures(textures);
 
     // Now we can upload uniforms, as nothing else will override them.
     GeometryShaderManager::SetConstants();

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <vector>
 
+#include "Common/BitSet.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "VideoCommon/IndexGenerator.h"
@@ -17,6 +18,7 @@ class DataReader;
 class NativeVertexFormat;
 class PointerWrap;
 struct PortableVertexDeclaration;
+class TextureInfo;
 
 struct Slope
 {
@@ -167,7 +169,9 @@ protected:
   u32 GetRemainingIndices(int primitive) const;
 
   void CalculateZSlope(NativeVertexFormat* format);
-  void LoadTextures();
+
+  BitSet32 UsedTextures();
+  void LoadTextures(const std::vector<TextureInfo>& textures);
 
   u8* m_cur_buffer_pointer = nullptr;
   u8* m_base_buffer_pointer = nullptr;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -135,7 +135,7 @@ void VertexShaderManager::Dirty()
 
 // Syncs the shader constant buffers with xfmem
 // TODO: A cleaner way to control the matrices without making a mess in the parameters field
-void VertexShaderManager::SetConstants(const std::vector<TextureInfo>&)
+void VertexShaderManager::SetConstants(const std::vector<TextureInfo>& textures)
 {
   if (constants.missing_color_hex != g_ActiveConfig.iMissingColorValue)
   {
@@ -398,14 +398,18 @@ void VertexShaderManager::SetConstants(const std::vector<TextureInfo>&)
 
     case ProjectionType::Orthographic:
     {
-      const Common::Vec2 stretch = g_freelook_camera_2d.IsActive() ?
-                                       g_freelook_camera_2d.GetStretchMultiplier() :
-                                       Common::Vec2{1, 1};
-
+      Common::Vec2 stretch{1, 1};
       Common::Vec2 offset;
-      if (g_freelook_camera_2d.IsActive())
+      if (g_freelook_camera_2d.IsActive() && !textures.empty())
       {
-        offset = g_freelook_camera_2d.GetPositionOffset();
+        std::vector<std::string> texture_names;
+        texture_names.reserve(textures.size());
+        for (const auto& texture_info : textures)
+        {
+          texture_names.push_back(texture_info.CalculateTextureName().GetFullName());
+        }
+        offset = g_freelook_camera_2d.GetPositionOffset(texture_names);
+        stretch = g_freelook_camera_2d.GetStretchMultiplier(texture_names);
       }
       g_fProjectionMatrix[0] = rawProjection[0] * stretch.x;
       g_fProjectionMatrix[1] = 0.0f;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -22,6 +22,7 @@
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/FreeLookCamera.h"
+#include "VideoCommon/FreeLookCamera2D.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexManagerBase.h"
@@ -357,7 +358,8 @@ void VertexShaderManager::SetConstants()
     }
   }
 
-  if (bProjectionChanged || g_freelook_camera.IsDirty())
+  if (bProjectionChanged || g_freelook_camera.IsDirty() ||
+      g_freelook_camera_2d.GetController()->IsDirty())
   {
     bProjectionChanged = false;
 
@@ -396,15 +398,24 @@ void VertexShaderManager::SetConstants()
 
     case ProjectionType::Orthographic:
     {
-      g_fProjectionMatrix[0] = rawProjection[0];
+      const Common::Vec2 stretch = g_freelook_camera_2d.IsActive() ?
+                                       g_freelook_camera_2d.GetStretchMultiplier() :
+                                       Common::Vec2{1, 1};
+
+      Common::Vec2 offset;
+      if (g_freelook_camera_2d.IsActive())
+      {
+        offset = g_freelook_camera_2d.GetPositionOffset();
+      }
+      g_fProjectionMatrix[0] = rawProjection[0] * stretch.x;
       g_fProjectionMatrix[1] = 0.0f;
       g_fProjectionMatrix[2] = 0.0f;
-      g_fProjectionMatrix[3] = rawProjection[1];
+      g_fProjectionMatrix[3] = rawProjection[1] + offset.x;
 
       g_fProjectionMatrix[4] = 0.0f;
-      g_fProjectionMatrix[5] = rawProjection[2];
+      g_fProjectionMatrix[5] = rawProjection[2] * stretch.y;
       g_fProjectionMatrix[6] = 0.0f;
-      g_fProjectionMatrix[7] = rawProjection[3];
+      g_fProjectionMatrix[7] = rawProjection[3] + offset.y;
 
       g_fProjectionMatrix[8] = 0.0f;
       g_fProjectionMatrix[9] = 0.0f;
@@ -437,6 +448,7 @@ void VertexShaderManager::SetConstants()
     memcpy(constants.projection.data(), corrected_matrix.data.data(), 4 * sizeof(float4));
 
     g_freelook_camera.SetClean();
+    g_freelook_camera_2d.GetController()->SetClean();
 
     dirty = true;
   }

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -135,7 +135,7 @@ void VertexShaderManager::Dirty()
 
 // Syncs the shader constant buffers with xfmem
 // TODO: A cleaner way to control the matrices without making a mess in the parameters field
-void VertexShaderManager::SetConstants()
+void VertexShaderManager::SetConstants(const std::vector<TextureInfo>&)
 {
   if (constants.missing_color_hex != g_ActiveConfig.iMissingColorValue)
   {

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -5,11 +5,13 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/ConstantManager.h"
 
 class PointerWrap;
+class TextureInfo;
 
 // The non-API dependent parts.
 class VertexShaderManager
@@ -20,7 +22,7 @@ public:
   static void DoState(PointerWrap& p);
 
   // constant management
-  static void SetConstants();
+  static void SetConstants(const std::vector<TextureInfo>& textures);
 
   static void InvalidateXFRange(int start, int end);
   static void SetTexMatrixChangedA(u32 value);


### PR DESCRIPTION
This builds on top of #9652

It allows direct movement of individual 2d images using the texture-ids that texture pack owners know and love.

This allows the HUD to be moved offscreen for pretty screenshots or maybe just reorganize things to give more screenspace:

![GIF 6-4-2021 12-53-04 AM](https://user-images.githubusercontent.com/15224722/120752467-6499af80-c4cf-11eb-9c12-41eb92181220.gif)

You can also stretch the HUD specifically so ultra wide monitors or triple monitor users have a more natural feel (HUD in center monitor).  Use the 3d fov hack for an even nicer experience!

![image](https://user-images.githubusercontent.com/15224722/120751460-a32e6a80-c4cd-11eb-9021-e4e21b5f3a35.png)
(credit to @DrBoiffard for the image)

But wait...there's more!  Depending on the game, you might also be able to target the efb textures.  In order to make it easier for users to do that, I changed Dolphin's "dump EFB" to output the size and the texture format.

What does that allow you to do?  You can move bloom or other effects off-screen, without requiring any gecko codes.

![RMCE01_2021-06-04_00-25-30](https://user-images.githubusercontent.com/15224722/120751921-6adb5c00-c4ce-11eb-839c-28d2c593b1e3.png)
(lots of brightness)

![RMCE01_2021-06-04_00-25-19](https://user-images.githubusercontent.com/15224722/120752071-a7a75300-c4ce-11eb-99a3-49f2e0018bad.png)
(goodbye!)

See [bloom removal album](https://imgur.com/a/5tRWtKl) for other games tested.

Unfortunately, some games will still be stubborn.  This will not work on games that use 3d HUDs.  It will also not work if your game is trying to draw multiple things in one call and you only want to move _one_ of them.