### PR TITLE
VideoCommon: Round bounding box coordinates down and remove pixel center offset

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -495,19 +495,9 @@ void UpdateBoundingBoxBuffer(int2 min_pos, int2 max_pos) {{
 }}
 
 void UpdateBoundingBox(float2 rawpos) {{
-  // The pixel center in the GameCube GPU is 7/12, not 0.5 (see VertexShaderGen.cpp)
-  // Adjust for this by unapplying the offset we added in the vertex shader.
-  const float PIXEL_CENTER_OFFSET = 7.0 / 12.0 - 0.5;
-  float2 offset = float2(PIXEL_CENTER_OFFSET, -PIXEL_CENTER_OFFSET);
-
-#ifdef API_OPENGL
-  // OpenGL lower-left origin means that Y goes in the opposite direction.
-  offset.y = -offset.y;
-#endif
-
   // The rightmost shaded pixel is not included in the right bounding box register,
   // such that width = right - left + 1. This has been verified on hardware.
-  int2 pos = iround(rawpos * cefbscale + offset);
+  int2 pos = int2(rawpos * cefbscale);
 
   // The GC/Wii GPU rasterizes in 2x2 pixel groups, so bounding box values will be rounded to the
   // extents of these groups, rather than the exact pixel.


### PR DESCRIPTION
Fragment coordinates always have a 0.5 offset from a whole integer, as that's where the pixel center is on modern GPUs. Therefore, we want to always round the fragment coordinates down for bounding box calculations. This also renders the pixel center offset useless, as 0.5 vs ~0.5833333 makes no difference when rounding down.

Fixes softlocks in certain cutscenes of Paper Mario: TTYD and Super Paper Mario, caused (presumably) by rounding up to a coordinate outside the render area.