### PR TITLE
Vulkan: Disable subgroup reduction on NVIDIA

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -944,7 +944,8 @@ void VulkanContext::PopulateShaderSubgroupSupport()
                                                          VK_SUBGROUP_FEATURE_BALLOT_BIT;
   m_supports_shader_subgroup_operations =
       (subgroup_properties.supportedOperations & required_operations) == required_operations &&
-      subgroup_properties.supportedStages & VK_SHADER_STAGE_FRAGMENT_BIT;
+      subgroup_properties.supportedStages & VK_SHADER_STAGE_FRAGMENT_BIT &&
+      !DriverDetails::HasBug(DriverDetails::BUG_BROKEN_SUBGROUP_REDUCTION);
 }
 
 bool VulkanContext::SupportsExclusiveFullscreen(const WindowSystemInfo& wsi, VkSurfaceKHR surface)

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -128,6 +128,8 @@ constexpr BugInfo m_known_bugs[] = {
      -1.0, -1.0, true},
     {API_OPENGL, OS_WINDOWS, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN, BUG_BROKEN_SSBO_FIELD_ATOMICS,
      -1.0, -1.0, true},
+    {API_VULKAN, OS_ALL, VENDOR_NVIDIA, DRIVER_NVIDIA, Family::UNKNOWN,
+     BUG_BROKEN_SUBGROUP_REDUCTION, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -306,6 +306,13 @@ enum Bug
   // Started version: -1
   // Ended version: -1
   BUG_BROKEN_SSBO_FIELD_ATOMICS,
+
+  // BUG: Subgroup reduction on NVIDIA drivers produces wrong results in some cases. This causes
+  // bounding box values to be off by several pixels.
+  // Affected devices: NVIDIA
+  // Started version: -1
+  // Ended version: -1
+  BUG_BROKEN_SUBGROUP_REDUCTION,
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
Subgroup reduction on NVIDIA drivers produces wrong results in some cases. This causes bounding box values to be off by several pixels.

OpenGL actually uses NV_thread_shuffle to implement a "subgroup reduction" so this bug check is not applicable there, and the extension is assumed and known to work without issues.

Here's a hardware test to demonstrate the wrong results and the fix: https://qimg.techjargaming.com/f/Tzx3VrV2.7z

Hardware
![](https://qimg.techjargaming.com/i/rRL1T3TV.png)

Vulkan (Broken)
![](https://qimg.techjargaming.com/i/UPEzh3UF.png)

Vulkan (Fixed)
![](https://qimg.techjargaming.com/i/tcmu0Obu.png)
