### PR TITLE
GameList: Fix grid mode zoom keybind inconsistency

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -96,11 +96,26 @@ GameList::GameList(QWidget* parent) : QStackedWidget(parent), m_model(this)
   m_prefer_list = Settings::Instance().GetPreferredView();
   ConsiderViewChange();
 
-  auto* zoom_in = new QShortcut(QKeySequence::ZoomIn, this);
-  auto* zoom_out = new QShortcut(QKeySequence::ZoomOut, this);
+  const auto* zoom_in = new QShortcut(QKeySequence::ZoomIn, this);
+  const auto* zoom_out = new QShortcut(QKeySequence::ZoomOut, this);
 
   connect(zoom_in, &QShortcut::activated, this, &GameList::ZoomIn);
   connect(zoom_out, &QShortcut::activated, this, &GameList::ZoomOut);
+
+  // On most keyboards the key to the left of the primary delete key represents 'plus' when shift is
+  // held and 'equal' when it isn't. By common convention, pressing control and that key is treated
+  // conceptually as 'control plus' (which is then interpreted as an appropriate zooming action)
+  // instead of the technically correct 'control equal'. Qt doesn't account for this convention so
+  // an alternate shortcut is needed to avoid counterintuitive behavior.
+  const auto* zoom_in_alternate = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Equal), this);
+  connect(zoom_in_alternate, &QShortcut::activated, this, &GameList::ZoomIn);
+
+  // The above correction introduces a different inconsistency: now zooming in can be done using
+  // conceptual 'control plus' or 'control shift plus', while zooming out can only be done using
+  // 'control minus'. Adding an alternate shortcut representing 'control shift minus' restores
+  // consistency.
+  const auto* zoom_out_alternate = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Underscore), this);
+  connect(zoom_out_alternate, &QShortcut::activated, this, &GameList::ZoomOut);
 
   connect(&Settings::Instance(), &Settings::MetadataRefreshCompleted, this,
           [this] { m_grid_proxy->invalidate(); });


### PR DESCRIPTION
Makes Gamelist's grid mode ZoomIn keybind behave as expected. Fixes https://bugs.dolphin-emu.org/issues/12538.

From the included comment:
On most keyboards the key to the left of the primary delete key represents 'plus' when shift is held and 'equal' when it isn't. By common convention, pressing control and that key is treated treated conceptually as 'control plus' (which is then interpreted as an appropriate zooming action) instead of the technically correct 'control equal'. Qt doesn't account for this convention so an alternate shortcut is needed to avoid counterintuitive behavior.

The above correction introduces a different inconsistency: now zooming in can be done using conceptual 'control plus' or 'control shift plus', while zooming out can only be done using 'control minus'. Adding an alternate shortcut representing 'control shift minus' restores consistency.