### PR TITLE
AudioInterface: Fix AIDFR initialization

### DIFF
--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -142,6 +142,7 @@ void Init()
 {
   s_control.hex = 0;
   s_control.AISFR = AIS_48KHz;
+  s_control.AIDFR = AID_32KHz;
   s_volume.hex = 0;
   s_sample_counter = 0;
   s_interrupt_timing = 0;


### PR DESCRIPTION
`AIDFR` was initialised with the value 0 (`AID_48KHz`) which doesn't match what it does a [few lines below](https://github.com/dolphin-emu/dolphin/blob/eaf8e3000894a95d96a5ee8f27f3203cab0c2eaf/Source/Core/Core/HW/AudioInterface.cpp#L154):
```C++
s_aid_sample_rate = Get32KHzSampleRate();
```

This fixes libogc `AUDIO_Init` function taking the [AI_SAMPLERATE_48KHZ route](https://github.com/devkitPro/libogc/blob/bc4b778d558915aa40676e33514c4c9ba2af66b8/libogc/audio.c#L254) on Dolphin while it doesn't on real hardware.

It doesn't seem to fix what I was looking for, except the timing of some of my hardware tests.

Ready to be reviewed & merged.