### PR TITLE
NetPlay: Sync the EFB access tile size as an integer instead of a boolean.

### DIFF
--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -87,7 +87,7 @@ struct NetSettings
   float m_ArbitraryMipmapDetectionThreshold;
   bool m_EnableGPUTextureDecoding;
   bool m_DeferEFBCopies;
-  bool m_EFBAccessTileSize;
+  int m_EFBAccessTileSize;
   bool m_EFBAccessDeferInvalidation;
 
   bool m_StrictSettingsSync;


### PR DESCRIPTION
Fixes severe slowdown in affected titles (such as Rocket Power: Beach Bandits) when played in NetPlay.