### PR TITLE
CheatsManager: Avoid recreating child widgets on every OnStateChanged(), and take running game info directly from SConfig.

### DIFF
--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -191,6 +191,7 @@ struct SConfig
   bool m_disc_booted_from_game_list = false;
 
   const std::string& GetGameID() const { return m_game_id; }
+  const std::string& GetGameTDBID() const { return m_gametdb_id; }
   const std::string& GetTitleName() const { return m_title_name; }
   const std::string& GetTitleDescription() const { return m_title_description; }
   u64 GetTitleID() const { return m_title_id; }

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -193,7 +193,7 @@ void CheatsManager::OnStateChanged(Core::State state)
         if (m_ar_code)
           m_ar_code->deleteLater();
 
-        m_ar_code = new ARCodeWidget(*m_game_file, false);
+        m_ar_code = new ARCodeWidget(m_game_file->GetGameID(), m_game_file->GetRevision(), false);
         m_tab_widget->insertTab(0, m_ar_code, tr("AR Code"));
         m_tab_widget->insertTab(1, new GeckoCodeWidget(*m_game_file, false), tr("Gecko Codes"));
       }

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -195,7 +195,10 @@ void CheatsManager::OnStateChanged(Core::State state)
 
         m_ar_code = new ARCodeWidget(m_game_file->GetGameID(), m_game_file->GetRevision(), false);
         m_tab_widget->insertTab(0, m_ar_code, tr("AR Code"));
-        m_tab_widget->insertTab(1, new GeckoCodeWidget(*m_game_file, false), tr("Gecko Codes"));
+        auto* gecko_code =
+            new GeckoCodeWidget(m_game_file->GetGameID(), m_game_file->GetGameTDBID(),
+                                m_game_file->GetRevision(), false);
+        m_tab_widget->insertTab(1, gecko_code, tr("Gecko Codes"));
       }
     }
   }

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -151,8 +151,7 @@ static bool Compare(T mem_value, T value, CompareType op)
   }
 }
 
-CheatsManager::CheatsManager(const GameListModel& game_list_model, QWidget* parent)
-    : QDialog(parent), m_game_list_model(game_list_model)
+CheatsManager::CheatsManager(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("Cheats Manager"));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -175,32 +174,32 @@ void CheatsManager::OnStateChanged(Core::State state)
   if (state != Core::State::Running && state != Core::State::Paused)
     return;
 
-  for (int i = 0; i < m_game_list_model.rowCount(QModelIndex()); i++)
+  const auto& game_id = SConfig::GetInstance().GetGameID();
+  const auto& game_tdb_id = SConfig::GetInstance().GetGameTDBID();
+  u16 revision = SConfig::GetInstance().GetRevision();
+
+  if (m_game_id == game_id && m_game_tdb_id == game_tdb_id && m_revision == revision)
+    return;
+
+  m_game_id = game_id;
+  m_game_tdb_id = game_tdb_id;
+  m_revision = revision;
+
+  if (m_tab_widget->count() == 3)
   {
-    auto file = m_game_list_model.GetGameFile(i);
+    m_tab_widget->removeTab(0);
+    m_tab_widget->removeTab(0);
+  }
 
-    if (file->GetGameID() == SConfig::GetInstance().GetGameID())
-    {
-      m_game_file = file;
-      if (m_tab_widget->count() == 3)
-      {
-        m_tab_widget->removeTab(0);
-        m_tab_widget->removeTab(0);
-      }
+  if (m_tab_widget->count() == 1)
+  {
+    if (m_ar_code)
+      m_ar_code->deleteLater();
 
-      if (m_tab_widget->count() == 1)
-      {
-        if (m_ar_code)
-          m_ar_code->deleteLater();
-
-        m_ar_code = new ARCodeWidget(m_game_file->GetGameID(), m_game_file->GetRevision(), false);
-        m_tab_widget->insertTab(0, m_ar_code, tr("AR Code"));
-        auto* gecko_code =
-            new GeckoCodeWidget(m_game_file->GetGameID(), m_game_file->GetGameTDBID(),
-                                m_game_file->GetRevision(), false);
-        m_tab_widget->insertTab(1, gecko_code, tr("Gecko Codes"));
-      }
-    }
+    m_ar_code = new ARCodeWidget(m_game_id, m_revision, false);
+    m_tab_widget->insertTab(0, m_ar_code, tr("AR Code"));
+    auto* gecko_code = new GeckoCodeWidget(m_game_id, m_game_tdb_id, m_revision, false);
+    m_tab_widget->insertTab(1, gecko_code, tr("Gecko Codes"));
   }
 }
 

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -40,7 +40,7 @@ class CheatsManager : public QDialog
 {
   Q_OBJECT
 public:
-  explicit CheatsManager(const GameListModel& game_list_model, QWidget* parent = nullptr);
+  explicit CheatsManager(QWidget* parent = nullptr);
   ~CheatsManager();
 
 private:
@@ -62,10 +62,12 @@ private:
   void OnMatchContextMenu();
   void OnWatchItemChanged(QTableWidgetItem* item);
 
-  const GameListModel& m_game_list_model;
+  std::string m_game_id;
+  std::string m_game_tdb_id;
+  u16 m_revision = 0;
+
   std::vector<Result> m_results;
   std::vector<Result> m_watch;
-  std::shared_ptr<const UICommon::GameFile> m_game_file;
   QDialogButtonBox* m_button_box;
   QTabWidget* m_tab_widget = nullptr;
 

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -4,6 +4,8 @@
 
 #include "DolphinQt/Config/ARCodeWidget.h"
 
+#include <utility>
+
 #include <QButtonGroup>
 #include <QCursor>
 #include <QHBoxLayout>
@@ -23,8 +25,8 @@
 
 #include "UICommon/GameFile.h"
 
-ARCodeWidget::ARCodeWidget(const UICommon::GameFile& game, bool restart_required)
-    : m_game(game), m_game_id(game.GetGameID()), m_game_revision(game.GetRevision()),
+ARCodeWidget::ARCodeWidget(std::string game_id, u16 game_revision, bool restart_required)
+    : m_game_id(std::move(game_id)), m_game_revision(game_revision),
       m_restart_required(restart_required)
 {
   CreateWidgets();

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.h
@@ -16,11 +16,6 @@ namespace ActionReplay
 struct ARCode;
 }
 
-namespace UICommon
-{
-class GameFile;
-}
-
 class CheatWarningWidget;
 class QLabel;
 class QListWidget;
@@ -31,7 +26,7 @@ class ARCodeWidget : public QWidget
 {
   Q_OBJECT
 public:
-  explicit ARCodeWidget(const UICommon::GameFile& game, bool restart_required = true);
+  explicit ARCodeWidget(std::string game_id, u16 game_revision, bool restart_required = true);
   ~ARCodeWidget() override;
 
   void AddCode(ActionReplay::ARCode code);
@@ -56,7 +51,6 @@ private:
 
   void OnListReordered();
 
-  const UICommon::GameFile& m_game;
   std::string m_game_id;
   u16 m_game_revision;
 

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -4,6 +4,8 @@
 
 #include "DolphinQt/Config/GeckoCodeWidget.h"
 
+#include <utility>
+
 #include <QCursor>
 #include <QFontDatabase>
 #include <QFormLayout>
@@ -28,9 +30,10 @@
 
 #include "UICommon/GameFile.h"
 
-GeckoCodeWidget::GeckoCodeWidget(const UICommon::GameFile& game, bool restart_required)
-    : m_game(game), m_game_id(game.GetGameID()), m_gametdb_id(game.GetGameTDBID()),
-      m_game_revision(game.GetRevision()), m_restart_required(restart_required)
+GeckoCodeWidget::GeckoCodeWidget(std::string game_id, std::string gametdb_id, u16 game_revision,
+                                 bool restart_required)
+    : m_game_id(std::move(game_id)), m_gametdb_id(std::move(gametdb_id)),
+      m_game_revision(game_revision), m_restart_required(restart_required)
 {
   CreateWidgets();
   ConnectWidgets();

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
@@ -23,16 +23,12 @@ namespace Gecko
 class GeckoCode;
 }
 
-namespace UICommon
-{
-class GameFile;
-}
-
 class GeckoCodeWidget : public QWidget
 {
   Q_OBJECT
 public:
-  explicit GeckoCodeWidget(const UICommon::GameFile& game, bool restart_required = true);
+  explicit GeckoCodeWidget(std::string game_id, std::string gametdb_id, u16 game_revision,
+                           bool restart_required = true);
   ~GeckoCodeWidget() override;
 
 signals:
@@ -54,7 +50,6 @@ private:
   void SaveCodes();
   void SortAlphabetically();
 
-  const UICommon::GameFile& m_game;
   std::string m_game_id;
   std::string m_gametdb_id;
   u16 m_game_revision;

--- a/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
@@ -38,7 +38,7 @@ PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& ga
   QTabWidget* tab_widget = new QTabWidget(this);
   InfoWidget* info = new InfoWidget(game);
 
-  ARCodeWidget* ar = new ARCodeWidget(game);
+  ARCodeWidget* ar = new ARCodeWidget(game.GetGameID(), game.GetRevision());
   GeckoCodeWidget* gecko = new GeckoCodeWidget(game);
   PatchesWidget* patches = new PatchesWidget(game);
   GameConfigWidget* game_config = new GameConfigWidget(game);

--- a/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
@@ -39,7 +39,8 @@ PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& ga
   InfoWidget* info = new InfoWidget(game);
 
   ARCodeWidget* ar = new ARCodeWidget(game.GetGameID(), game.GetRevision());
-  GeckoCodeWidget* gecko = new GeckoCodeWidget(game);
+  GeckoCodeWidget* gecko =
+      new GeckoCodeWidget(game.GetGameID(), game.GetGameTDBID(), game.GetRevision());
   PatchesWidget* patches = new PatchesWidget(game);
   GameConfigWidget* game_config = new GameConfigWidget(game);
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -411,7 +411,7 @@ void MainWindow::CreateComponents()
   m_watch_widget = new WatchWidget(this);
   m_breakpoint_widget = new BreakpointWidget(this);
   m_code_widget = new CodeWidget(this);
-  m_cheats_manager = new CheatsManager(m_game_list->GetGameListModel(), this);
+  m_cheats_manager = new CheatsManager(this);
 
   const auto request_watch = [this](QString name, u32 addr) {
     m_watch_widget->AddWatch(name, addr);


### PR DESCRIPTION
While this does not fix the core issue, this does eliminate a big part of the lag you get after holding the Frame Advance button for a while -- enough for it to become unnoticeable on my system, but I suspect weaker systems might still run into it, though to a lesser degree.