### PR TITLE
MMIOHandlers: Move method definitions to MMIO.cpp

### DIFF
--- a/Source/Core/Core/HW/MMIO.cpp
+++ b/Source/Core/Core/HW/MMIO.cpp
@@ -291,6 +291,18 @@ void ReadHandler<T>::Visit(ReadHandlingMethodVisitor<T>& visitor)
 }
 
 template <typename T>
+T ReadHandler<T>::Read(u32 addr)
+{
+  // Check if the handler has already been initialized. For real
+  // handlers, this will always be the case, so this branch should be
+  // easily predictable.
+  if (!m_Method)
+    InitializeInvalid();
+
+  return m_ReadFunc(addr);
+}
+
+template <typename T>
 void ReadHandler<T>::ResetMethod(ReadHandlingMethod<T>* method)
 {
   m_Method.reset(method);
@@ -320,6 +332,12 @@ void ReadHandler<T>::ResetMethod(ReadHandlingMethod<T>* method)
 }
 
 template <typename T>
+void ReadHandler<T>::InitializeInvalid()
+{
+  ResetMethod(InvalidRead<T>());
+}
+
+template <typename T>
 WriteHandler<T>::WriteHandler()
 {
 }
@@ -342,6 +360,18 @@ void WriteHandler<T>::Visit(WriteHandlingMethodVisitor<T>& visitor)
     InitializeInvalid();
 
   m_Method->AcceptWriteVisitor(visitor);
+}
+
+template <typename T>
+void WriteHandler<T>::Write(u32 addr, T val)
+{
+  // Check if the handler has already been initialized. For real
+  // handlers, this will always be the case, so this branch should be
+  // easily predictable.
+  if (!m_Method)
+    InitializeInvalid();
+
+  m_WriteFunc(addr, val);
 }
 
 template <typename T>
@@ -371,6 +401,12 @@ void WriteHandler<T>::ResetMethod(WriteHandlingMethod<T>* method)
   FuncCreatorVisitor v;
   Visit(v);
   m_WriteFunc = v.ret;
+}
+
+template <typename T>
+void WriteHandler<T>::InitializeInvalid()
+{
+  ResetMethod(InvalidWrite<T>());
 }
 
 // Define all the public specializations that are exported in MMIOHandlers.h.

--- a/Source/Core/Core/HW/MMIOHandlers.h
+++ b/Source/Core/Core/HW/MMIOHandlers.h
@@ -127,16 +127,7 @@ public:
   // Entry point for read handling method visitors.
   void Visit(ReadHandlingMethodVisitor<T>& visitor);
 
-  T Read(u32 addr)
-  {
-    // Check if the handler has already been initialized. For real
-    // handlers, this will always be the case, so this branch should be
-    // easily predictable.
-    if (!m_Method)
-      InitializeInvalid();
-
-    return m_ReadFunc(addr);
-  }
+  T Read(u32 addr);
 
   // Internal method called when changing the internal method object. Its
   // main role is to make sure the read function is updated at the same time.
@@ -145,7 +136,7 @@ public:
 private:
   // Initialize this handler to an invalid handler. Done lazily to avoid
   // useless initialization of thousands of unused handler objects.
-  void InitializeInvalid() { ResetMethod(InvalidRead<T>()); }
+  void InitializeInvalid();
   std::unique_ptr<ReadHandlingMethod<T>> m_Method;
   std::function<T(u32)> m_ReadFunc;
 };
@@ -163,16 +154,7 @@ public:
   // Entry point for write handling method visitors.
   void Visit(WriteHandlingMethodVisitor<T>& visitor);
 
-  void Write(u32 addr, T val)
-  {
-    // Check if the handler has already been initialized. For real
-    // handlers, this will always be the case, so this branch should be
-    // easily predictable.
-    if (!m_Method)
-      InitializeInvalid();
-
-    m_WriteFunc(addr, val);
-  }
+  void Write(u32 addr, T val);
 
   // Internal method called when changing the internal method object. Its
   // main role is to make sure the write function is updated at the same
@@ -182,7 +164,7 @@ public:
 private:
   // Initialize this handler to an invalid handler. Done lazily to avoid
   // useless initialization of thousands of unused handler objects.
-  void InitializeInvalid() { ResetMethod(InvalidWrite<T>()); }
+  void InitializeInvalid();
   std::unique_ptr<WriteHandlingMethod<T>> m_Method;
   std::function<void(u32, T)> m_WriteFunc;
 };


### PR DESCRIPTION
This PR moves MMIOHandlers method definitions to MMIO.cpp.

It prevents some compilation issues when editing the header file.

Ready to be reviewed & merged.