### PR TITLE
Fix input focus checks being wrong (issue 12540)

### DIFF
--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -88,7 +88,7 @@ bool Host::GetRenderFocus()
 #ifdef _WIN32
   // Unfortunately Qt calls SetRenderFocus() with a slight delay compared to what we actually need
   // to avoid inputs that cause a focus loss to be processed by the emulation
-  if (m_render_to_main)
+  if (m_render_to_main && !m_render_fullscreen)
     return GetForegroundWindow() == (HWND)m_main_window_handle.load();
   return GetForegroundWindow() == (HWND)m_render_handle.load();
 #else


### PR DESCRIPTION
When rendering to main and going full screen, we aren't using the main window handle as the code assumed, but the other, detached, render widget.

Fixes issue:
https://bugs.dolphin-emu.org/issues/12540
caused by https://github.com/dolphin-emu/dolphin/pull/9697