### PR TITLE
Fix controllers after the first one not defaulting to the default device

### DIFF
--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -145,8 +145,23 @@ bool InputConfig::LoadConfig(bool isGC)
   }
   else
   {
-    m_controllers[0]->LoadDefaults(g_controller_interface);
-    m_controllers[0]->UpdateReferences(g_controller_interface);
+    // Only load the default profile for the first controller,
+    // otherwise they would all share the same mappings and default device
+    if (m_controllers.size() > 0)
+    {
+      m_controllers[0]->LoadDefaults(g_controller_interface);
+      m_controllers[0]->UpdateReferences(g_controller_interface);
+    }
+    // Set the "default" default device for all other controllers, or they would end up
+    // having no default device (which is fine, but might be confusing for some users)
+    const std::string& default_device_string = g_controller_interface.GetDefaultDeviceString();
+    if (!default_device_string.empty())
+    {
+      for (size_t i = 1; i < m_controllers.size(); ++i)
+      {
+        m_controllers[i]->SetDefaultDevice(default_device_string);
+      }
+    }
     return false;
   }
 }


### PR DESCRIPTION
Also fixes this bug: At the moment, Qt does not support a controller not having any default device, so it will still show the first device from the devices list as default, but internally it won't actually be selected, so input detection won't work as expected, until the user manually changes the device from the drop down list.

Also added a check to avoid potential crashes if we had no controllers. That function is only called on the first start up so there is no need to set the default device on the controller unless the default device string is valid. There is also no need to update references as all bindings would be empty. 

This will work even better when other parts of my input improvements from https://github.com/dolphin-emu/dolphin/pull/9489 are merged.