### PR TITLE
Android: Fix WAD import crashing

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -305,7 +305,7 @@ public final class MainPresenter
           builder.show();
         }
       });
-    }, mContext.getResources().getString(progressMessage)).start();
+    }, mContext.getResources().getString(progressTitle)).start();
   }
 
   public static void skipRescanningLibrary()


### PR DESCRIPTION
`progressMessage` can have the invalid value of 0. That `progressMessage` was being used for the thread name was a typo anyway – it's supposed to use `progressTitle`.