### PR TITLE
Vulkan: Fix subgroup reduction

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -103,7 +103,7 @@ static const char SUBGROUP_HELPER_HEADER[] = R"(
   #define SUPPORTS_SUBGROUP_REDUCTION 1
   #define CAN_USE_SUBGROUP_REDUCTION true
   #define IS_HELPER_INVOCATION gl_HelperInvocation
-  #define IS_FIRST_ACTIVE_INVOCATION (gl_SubgroupInvocationID == subgroupBallotFindLSB(subgroupBallot(true)))
+  #define IS_FIRST_ACTIVE_INVOCATION (gl_SubgroupInvocationID == subgroupBallotFindLSB(subgroupBallot(!gl_HelperInvocation)))
   #define SUBGROUP_MIN(value) value = subgroupMin(value)
   #define SUBGROUP_MAX(value) value = subgroupMax(value)
 )";


### PR DESCRIPTION
It seems that we were writing values from helper invocations, which produces wrong results.

Here's a hardware test to demonstrate the wrong results and the fix: https://qimg.techjargaming.com/f/Tzx3VrV2.7z

Hardware
![](https://qimg.techjargaming.com/i/rRL1T3TV.png)

Vulkan (Broken)
![](https://qimg.techjargaming.com/i/UPEzh3UF.png)

Vulkan (Fixed)
![](https://qimg.techjargaming.com/i/tcmu0Obu.png)