### PR TITLE
Android: Stop using custom path for GameFileCache

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
@@ -17,12 +17,12 @@ public class GameFileCache
   @Keep
   private long mPointer;
 
-  public GameFileCache(String path)
+  public GameFileCache()
   {
-    mPointer = newGameFileCache(path);
+    mPointer = newGameFileCache();
   }
 
-  private static native long newGameFileCache(String path);
+  private static native long newGameFileCache();
 
   @Override
   public native void finalize();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
@@ -172,7 +172,7 @@ public final class GameFileCacheService extends IntentService
     // Load the game list cache if it isn't already loaded, otherwise do nothing
     if (ACTION_LOAD.equals(intent.getAction()) && gameFileCache == null)
     {
-      GameFileCache temp = new GameFileCache(getCacheDir() + File.separator + "gamelist.cache");
+      GameFileCache temp = new GameFileCache();
       synchronized (temp)
       {
         gameFileCache = temp;

--- a/Source/Android/jni/GameList/GameFileCache.cpp
+++ b/Source/Android/jni/GameList/GameFileCache.cpp
@@ -27,10 +27,10 @@ static UICommon::GameFileCache* GetPointer(JNIEnv* env, jobject obj)
 extern "C" {
 #endif
 
-JNIEXPORT jlong JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_newGameFileCache(
-    JNIEnv* env, jclass, jstring path)
+JNIEXPORT jlong JNICALL
+Java_org_dolphinemu_dolphinemu_model_GameFileCache_newGameFileCache(JNIEnv* env, jclass)
 {
-  return reinterpret_cast<jlong>(new UICommon::GameFileCache(GetJString(env, path)));
+  return reinterpret_cast<jlong>(new UICommon::GameFileCache());
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_finalize(JNIEnv* env,

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -43,10 +43,6 @@ GameFileCache::GameFileCache() : m_path(File::GetUserPath(D_CACHE_IDX) + "gameli
 {
 }
 
-GameFileCache::GameFileCache(std::string path) : m_path(std::move(path))
-{
-}
-
 void GameFileCache::ForEach(std::function<void(const std::shared_ptr<const GameFile>&)> f) const
 {
   for (const std::shared_ptr<const GameFile>& item : m_cached_files)

--- a/Source/Core/UICommon/GameFileCache.h
+++ b/Source/Core/UICommon/GameFileCache.h
@@ -31,8 +31,7 @@ public:
     Yes = 1,
   };
 
-  GameFileCache();  // Uses the default path
-  explicit GameFileCache(std::string path);
+  GameFileCache();
 
   void ForEach(std::function<void(const std::shared_ptr<const GameFile>&)> f) const;
 


### PR DESCRIPTION
Back when I wrote this code, I believe I set it to use a custom path so that the cache would end up in a directory which Android considers to be a cache directory. But nowadays the directory which Dolphin's C++ code considers to be the cache directory is such a directory, so there's no longer any reason to override the default path.