### PR TITLE
PowerPC: Set host CPU rounding mode on init and savestate

### DIFF
--- a/Source/Core/Common/ArmFPURoundMode.cpp
+++ b/Source/Core/Common/ArmFPURoundMode.cpp
@@ -41,10 +41,6 @@ void SetRoundMode(int mode)
   // We don't need to do anything here since SetSIMDMode is always called after calling this
 }
 
-void SetPrecisionMode(PrecisionMode mode)
-{
-}
-
 void SetSIMDMode(int rounding_mode, bool non_ieee_mode)
 {
   // When AH is disabled, FZ controls flush-to-zero for both inputs and outputs. When AH is enabled,

--- a/Source/Core/Common/FPURoundMode.h
+++ b/Source/Core/Common/FPURoundMode.h
@@ -29,8 +29,6 @@ enum PrecisionMode
 
 void SetRoundMode(int mode);
 
-void SetPrecisionMode(PrecisionMode mode);
-
 void SetSIMDMode(int rounding_mode, bool non_ieee_mode);
 
 /*

--- a/Source/Core/Common/GenericFPURoundMode.cpp
+++ b/Source/Core/Common/GenericFPURoundMode.cpp
@@ -11,9 +11,6 @@ namespace FPURoundMode
 void SetRoundMode(int mode)
 {
 }
-void SetPrecisionMode(PrecisionMode mode)
-{
-}
 void SetSIMDMode(int rounding_mode, bool non_ieee_mode)
 {
 }

--- a/Source/Core/Common/x64FPURoundMode.cpp
+++ b/Source/Core/Common/x64FPURoundMode.cpp
@@ -22,11 +22,6 @@ void SetRoundMode(int mode)
   fesetround(rounding_mode_lut[mode]);
 }
 
-void SetPrecisionMode(PrecisionMode /* mode */)
-{
-  // x64 doesn't need this - fpu is done with SSE
-}
-
 void SetSIMDMode(int rounding_mode, bool non_ieee_mode)
 {
   // OR-mask for disabling FPU exceptions (bits 7-12 in the MXCSR register)

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -25,6 +25,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
+#include "Common/FPURoundMode.h"
 #include "Common/FileUtil.h"
 #include "Common/Flag.h"
 #include "Common/Logging/Log.h"
@@ -625,6 +626,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
     // thread, and then takes over and becomes the video thread
     Common::SetCurrentThreadName("Video thread");
     UndeclareAsCPUThread();
+    FPURoundMode::LoadDefaultSIMDState();
 
     // Spawn the CPU thread. The CPU thread will signal the event that boot is complete.
     s_cpu_thread = std::thread(cpuThreadFunc, savestate_path, delete_savestate);

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -87,6 +87,10 @@ static void ExecutePendingJobs(std::unique_lock<std::mutex>& state_lock)
 
 void Run()
 {
+  // Updating the host CPU's rounding mode must be done on the CPU thread.
+  // We can't rely on PowerPC::Init doing it, since it's called from EmuThread.
+  PowerPC::RoundingModeUpdated();
+
   std::unique_lock state_lock(s_state_change_lock);
   while (s_state != State::PowerDown)
   {

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -306,4 +306,6 @@ inline void SetXER_OV(bool value)
 
 void UpdateFPRF(double dvalue);
 
+void RoundingModeUpdated();
+
 }  // namespace PowerPC


### PR DESCRIPTION
Not doing this can cause desyncs when TASing. (I don't know how common such desyncs would be, though. For games that don't change rounding modes, they shouldn't be a problem.)