### PR TITLE
MsgHandler: Correct question and warning captions

### DIFF
--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -55,10 +55,10 @@ bool s_alert_enabled = true;
 
 const char* GetCaption(MsgType style)
 {
-  static const std::string info_caption = s_str_translator(_trans("Information"));
-  static const std::string warn_caption = s_str_translator(_trans("Question"));
-  static const std::string ques_caption = s_str_translator(_trans("Warning"));
-  static const std::string crit_caption = s_str_translator(_trans("Critical"));
+  static const std::string info_caption = GetStringT("Information");
+  static const std::string ques_caption = GetStringT("Question");
+  static const std::string warn_caption = GetStringT("Warning");
+  static const std::string crit_caption = GetStringT("Critical");
 
   switch (style)
   {


### PR DESCRIPTION
I guess at some point they were inadvertently swapped and because of the contents of some of the messages displayed with those captions, the issue went unnoticed. For instance, `PanicYesNo` would be used with a question, so it makes sense that it would be captioned "Question" even though the code asks for "Warning".

Also, simply refer to `GetStringT` for marking the captions as it does the same thing but is easier to read at a glance.