### PR TITLE
Move some NetPlay-specific settings to SessionSettings

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -21,7 +21,6 @@ namespace Config
 // Main.Core
 
 const Info<bool> MAIN_SKIP_IPL{{System::Main, "Core", "SkipIPL"}, true};
-const Info<bool> MAIN_LOAD_IPL_DUMP{{System::Main, "Core", "LoadIPLDump"}, true};
 const Info<PowerPC::CPUCore> MAIN_CPU_CORE{{System::Main, "Core", "CPUCore"},
                                            PowerPC::DefaultCPUCore()};
 const Info<bool> MAIN_JIT_FOLLOW_BRANCH{{System::Main, "Core", "JITFollowBranch"}, true};
@@ -49,9 +48,6 @@ const Info<std::string> MAIN_GCI_FOLDER_A_PATH_OVERRIDE{
     {System::Main, "Core", "GCIFolderAPathOverride"}, ""};
 const Info<std::string> MAIN_GCI_FOLDER_B_PATH_OVERRIDE{
     {System::Main, "Core", "GCIFolderBPathOverride"}, ""};
-const Info<bool> MAIN_GCI_FOLDER_CURRENT_GAME_ONLY{
-    {System::Main, "Core", "GCIFolderCurrentGameOnly"}, false};
-const Info<bool> MAIN_CODE_SYNC_OVERRIDE{{System::Main, "Core", "CheatSyncOverride"}, false};
 const Info<int> MAIN_SLOT_A{{System::Main, "Core", "SlotA"},
                             ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER};
 const Info<int> MAIN_SLOT_B{{System::Main, "Core", "SlotB"}, ExpansionInterface::EXIDEVICE_NONE};
@@ -77,7 +73,6 @@ Info<bool> GetInfoForSimulateKonga(u32 channel)
 }
 
 const Info<bool> MAIN_WII_SD_CARD{{System::Main, "Core", "WiiSDCard"}, true};
-const Info<bool> MAIN_WII_SD_CARD_WRITABLE{{System::Main, "Core", "WiiSDCardWritable"}, true};
 const Info<bool> MAIN_WII_KEYBOARD{{System::Main, "Core", "WiiKeyboard"}, false};
 const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING{
     {System::Main, "Core", "WiimoteContinuousScanning"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -24,7 +24,6 @@ namespace Config
 // Main.Core
 
 extern const Info<bool> MAIN_SKIP_IPL;
-extern const Info<bool> MAIN_LOAD_IPL_DUMP;
 extern const Info<PowerPC::CPUCore> MAIN_CPU_CORE;
 extern const Info<bool> MAIN_JIT_FOLLOW_BRANCH;
 extern const Info<bool> MAIN_FASTMEM;
@@ -48,8 +47,6 @@ extern const Info<std::string> MAIN_AGP_CART_A_PATH;
 extern const Info<std::string> MAIN_AGP_CART_B_PATH;
 extern const Info<std::string> MAIN_GCI_FOLDER_A_PATH_OVERRIDE;
 extern const Info<std::string> MAIN_GCI_FOLDER_B_PATH_OVERRIDE;
-extern const Info<bool> MAIN_CODE_SYNC_OVERRIDE;
-extern const Info<bool> MAIN_GCI_FOLDER_CURRENT_GAME_ONLY;
 extern const Info<int> MAIN_SLOT_A;
 extern const Info<int> MAIN_SLOT_B;
 extern const Info<int> MAIN_SERIAL_PORT_1;
@@ -58,7 +55,6 @@ Info<u32> GetInfoForSIDevice(u32 channel);
 Info<bool> GetInfoForAdapterRumble(u32 channel);
 Info<bool> GetInfoForSimulateKonga(u32 channel);
 extern const Info<bool> MAIN_WII_SD_CARD;
-extern const Info<bool> MAIN_WII_SD_CARD_WRITABLE;
 extern const Info<bool> MAIN_WII_KEYBOARD;
 extern const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING;
 extern const Info<bool> MAIN_WIIMOTE_ENABLE_SPEAKER;

--- a/Source/Core/Core/Config/SessionSettings.cpp
+++ b/Source/Core/Core/Config/SessionSettings.cpp
@@ -11,4 +11,9 @@
 namespace Config
 {
 const Info<bool> SESSION_USE_FMA{{System::Session, "Core", "UseFMA"}, CPUInfo().bFMA};
+const Info<bool> SESSION_LOAD_IPL_DUMP{{System::Session, "Core", "LoadIPLDump"}, true};
+const Info<bool> SESSION_GCI_FOLDER_CURRENT_GAME_ONLY{
+    {System::Session, "Core", "GCIFolderCurrentGameOnly"}, false};
+const Info<bool> SESSION_CODE_SYNC_OVERRIDE{{System::Session, "Core", "CheatSyncOverride"}, false};
+const Info<bool> SESSION_WII_SD_CARD_WRITABLE{{System::Session, "Core", "WiiSDCardWritable"}, true};
 }  // namespace Config

--- a/Source/Core/Core/Config/SessionSettings.h
+++ b/Source/Core/Core/Config/SessionSettings.h
@@ -10,4 +10,8 @@
 namespace Config
 {
 extern const Info<bool> SESSION_USE_FMA;
+extern const Info<bool> SESSION_LOAD_IPL_DUMP;
+extern const Info<bool> SESSION_GCI_FOLDER_CURRENT_GAME_ONLY;
+extern const Info<bool> SESSION_CODE_SYNC_OVERRIDE;
+extern const Info<bool> SESSION_WII_SD_CARD_WRITABLE;
 }  // namespace Config

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -40,7 +40,7 @@ public:
     layer->Set(Config::MAIN_SLOT_A, static_cast<int>(m_settings.m_EXIDevice[0]));
     layer->Set(Config::MAIN_SLOT_B, static_cast<int>(m_settings.m_EXIDevice[1]));
     layer->Set(Config::MAIN_SERIAL_PORT_1, static_cast<int>(m_settings.m_EXIDevice[2]));
-    layer->Set(Config::MAIN_WII_SD_CARD_WRITABLE, m_settings.m_WriteToMemcard);
+    layer->Set(Config::SESSION_WII_SD_CARD_WRITABLE, m_settings.m_WriteToMemcard);
     layer->Set(Config::MAIN_RAM_OVERRIDE_ENABLE, m_settings.m_RAMOverrideEnable);
     layer->Set(Config::MAIN_MEM1_SIZE, m_settings.m_Mem1Size);
     layer->Set(Config::MAIN_MEM2_SIZE, m_settings.m_Mem2Size);
@@ -83,7 +83,7 @@ public:
     layer->Set(Config::MAIN_MMU, m_settings.m_MMU);
     layer->Set(Config::MAIN_FASTMEM, m_settings.m_Fastmem);
     layer->Set(Config::MAIN_SKIP_IPL, m_settings.m_SkipIPL);
-    layer->Set(Config::MAIN_LOAD_IPL_DUMP, m_settings.m_LoadIPLDump);
+    layer->Set(Config::SESSION_LOAD_IPL_DUMP, m_settings.m_LoadIPLDump);
 
     layer->Set(Config::GFX_HACK_DEFER_EFB_COPIES, m_settings.m_DeferEFBCopies);
     layer->Set(Config::GFX_HACK_EFB_ACCESS_TILE_SIZE, m_settings.m_EFBAccessTileSize);
@@ -131,14 +131,14 @@ public:
         layer->Set(Config::MAIN_MEMCARD_B_PATH, make_memcard_path('B'));
       }
 
-      layer->Set(Config::MAIN_GCI_FOLDER_CURRENT_GAME_ONLY, true);
+      layer->Set(Config::SESSION_GCI_FOLDER_CURRENT_GAME_ONLY, true);
     }
 
     // Check To Override Client's Cheat Codes
     if (m_settings.m_SyncCodes && !m_settings.m_IsHosting)
     {
       // Raise flag to use host's codes
-      layer->Set(Config::MAIN_CODE_SYNC_OVERRIDE, true);
+      layer->Set(Config::SESSION_CODE_SYNC_OVERRIDE, true);
     }
   }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -21,7 +21,7 @@
 #include "Common/Swap.h"
 #include "Common/Timer.h"
 
-#include "Core/Config/MainSettings.h"
+#include "Core/Config/SessionSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -106,7 +106,7 @@ CEXIIPL::CEXIIPL()
 
   // Load whole ROM dump
   // Note: The Wii doesn't have a copy of the IPL, only fonts.
-  if (!SConfig::GetInstance().bWii && Config::Get(Config::MAIN_LOAD_IPL_DUMP) &&
+  if (!SConfig::GetInstance().bWii && Config::Get(Config::SESSION_LOAD_IPL_DUMP) &&
       LoadFileToIPL(SConfig::GetInstance().m_strBootROM, 0))
   {
     // Descramble the encrypted section (contains BS1 and BS2)
@@ -207,7 +207,7 @@ void CEXIIPL::LoadFontFile(const std::string& filename, u32 offset)
   // in some titles. This function check if the user has IPL dumps available and load the fonts
   // from those dumps instead of loading the bundled fonts
 
-  if (!Config::Get(Config::MAIN_LOAD_IPL_DUMP))
+  if (!Config::Get(Config::SESSION_LOAD_IPL_DUMP))
   {
     // IPL loading disabled, load bundled font instead
     LoadFileToIPL(filename, offset);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -30,6 +30,7 @@
 #include "Common/Timer.h"
 
 #include "Core/Config/MainSettings.h"
+#include "Core/Config/SessionSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
@@ -164,7 +165,7 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot,
     File::IOFile((m_save_directory + MC_HDR), "rb").ReadBytes(&m_hdr, Memcard::BLOCK_SIZE);
   }
 
-  const bool current_game_only = Config::Get(Config::MAIN_GCI_FOLDER_CURRENT_GAME_ONLY);
+  const bool current_game_only = Config::Get(Config::SESSION_GCI_FOLDER_CURRENT_GAME_ONLY);
   std::vector<std::string> filenames = Common::DoFileSearch({m_save_directory}, {".gci"});
 
   // split up into files for current games we should definitely load,

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1290,7 +1290,7 @@ bool NetPlayServer::SetupNetSettings()
   settings.m_MMU = Config::Get(Config::MAIN_MMU);
   settings.m_Fastmem = Config::Get(Config::MAIN_FASTMEM);
   settings.m_SkipIPL = Config::Get(Config::MAIN_SKIP_IPL) || !DoAllPlayersHaveIPLDump();
-  settings.m_LoadIPLDump = Config::Get(Config::MAIN_LOAD_IPL_DUMP) && DoAllPlayersHaveIPLDump();
+  settings.m_LoadIPLDump = Config::Get(Config::SESSION_LOAD_IPL_DUMP) && DoAllPlayersHaveIPLDump();
   settings.m_VertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
   settings.m_InternalResolution = Config::Get(Config::GFX_EFB_SCALE);
   settings.m_EFBScaledCopy = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -21,7 +21,7 @@
 
 #include "Core/ActionReplay.h"
 #include "Core/CheatCodes.h"
-#include "Core/Config/MainSettings.h"
+#include "Core/Config/SessionSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/GeckoCode.h"
 #include "Core/GeckoCodeConfig.h"
@@ -165,7 +165,7 @@ void LoadPatches()
   LoadPatchSection("OnFrame", s_on_frame, globalIni, localIni);
 
   // Check if I'm syncing Codes
-  if (Config::Get(Config::MAIN_CODE_SYNC_OVERRIDE))
+  if (Config::Get(Config::SESSION_CODE_SYNC_OVERRIDE))
   {
     Gecko::SetSyncedCodesAsActive();
     ActionReplay::SetSyncedCodesAsActive();


### PR DESCRIPTION
This moves some settings that are only used during a NetPlay session to the Session config, so there's no possibility of them being permanently set by accident.