### PR TITLE
Jits: Fix fcmpX FPRF mask

### DIFF
--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -401,6 +401,7 @@ union UReg_MSR
 #define FPRF_SHIFT 12
 #define FPRF_WIDTH 5
 #define FPRF_MASK (0x1F << FPRF_SHIFT)
+#define FPCC_MASK (0xF << FPRF_SHIFT)
 
 // FPSCR exception flags
 enum FPSCRExceptionFlag : u32

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/FloatUtils.h"
+#include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -169,7 +170,7 @@ void Interpreter::Helper_FloatCompareOrdered(UGeckoInstruction inst, double fa, 
   const u32 compare_value = static_cast<u32>(compare_result);
 
   // Clear and set the FPCC bits accordingly.
-  FPSCR.FPRF = (FPSCR.FPRF & ~0xF) | compare_value;
+  FPSCR.FPRF = (FPSCR.FPRF & ~FPCC_MASK) | compare_value;
 
   PowerPC::ppcState.cr.SetField(inst.CRFD, compare_value);
 }
@@ -203,7 +204,7 @@ void Interpreter::Helper_FloatCompareUnordered(UGeckoInstruction inst, double fa
   const u32 compare_value = static_cast<u32>(compare_result);
 
   // Clear and set the FPCC bits accordingly.
-  FPSCR.FPRF = (FPSCR.FPRF & ~0xF) | compare_value;
+  FPSCR.FPRF = (FPSCR.FPRF & ~FPCC_MASK) | compare_value;
 
   PowerPC::ppcState.cr.SetField(inst.CRFD, compare_value);
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -631,7 +631,7 @@ void Jit64::FloatCompare(UGeckoInstruction inst, bool upper)
   RegCache::Realize(Ra, Rb);
 
   if (fprf)
-    AND(32, PPCSTATE(fpscr), Imm32(~FPRF_MASK));
+    AND(32, PPCSTATE(fpscr), Imm32(~FPCC_MASK));
 
   if (upper)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -402,7 +402,7 @@ void JitArm64::fcmpX(UGeckoInstruction inst)
   {
     fpscr_reg = gpr.GetReg();
     LDR(IndexType::Unsigned, fpscr_reg, PPC_REG, PPCSTATE_OFF(fpscr));
-    ANDI2R(fpscr_reg, fpscr_reg, ~FPRF_MASK);
+    ANDI2R(fpscr_reg, fpscr_reg, ~FPCC_MASK);
   }
 
   FixupBranch pNaN, pLesser, pGreater;


### PR DESCRIPTION
fcmpX only updates the FPCC bits, not the C bit. This was already correctly implemented in the interpreter.

Not known to affect any games, but affects https://github.com/dolphin-emu/hwtests/pull/41.