### PR TITLE
Fix FPRF handling of denormal singles

### DIFF
--- a/Source/Core/Common/FloatUtils.h
+++ b/Source/Core/Common/FloatUtils.h
@@ -87,7 +87,6 @@ enum PPCFpClass
 // Uses PowerPC conventions for the return value, so it can be easily
 // used directly in CPU emulation.
 u32 ClassifyDouble(double dvalue);
-// More efficient float version.
 u32 ClassifyFloat(float fvalue);
 
 struct BaseAndDec

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -36,15 +36,13 @@ inline void SetFPException(UReg_FPSCR* fpscr, u32 mask)
   fpscr->VX = (fpscr->Hex & FPSCR_VX_ANY) != 0;
 }
 
-inline double ForceSingle(const UReg_FPSCR& fpscr, double value)
+inline float ForceSingle(const UReg_FPSCR& fpscr, double value)
 {
-  // convert to float...
-  float x = (float)value;
+  float x = static_cast<float>(value);
   if (!cpu_info.bFlushToZero && fpscr.NI)
   {
     x = Common::FlushToZero(x);
   }
-  // ...and back to double:
   return x;
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -290,7 +290,7 @@ void Interpreter::fselx(UGeckoInstruction inst)
 void Interpreter::frspx(UGeckoInstruction inst)  // round to single
 {
   const double b = rPS(inst.FB).PS0AsDouble();
-  const double rounded = ForceSingle(FPSCR, b);
+  const float rounded = ForceSingle(FPSCR, b);
 
   if (std::isnan(b))
   {
@@ -349,7 +349,7 @@ void Interpreter::fmulsx(UGeckoInstruction inst)
 
   if (FPSCR.VE == 0 || d_value.HasNoInvalidExceptions())
   {
-    const double result = ForceSingle(FPSCR, d_value.value);
+    const float result = ForceSingle(FPSCR, d_value.value);
 
     rPS(inst.FD).Fill(result);
     FPSCR.FI = 0;
@@ -390,7 +390,7 @@ void Interpreter::fmaddsx(UGeckoInstruction inst)
 
   if (FPSCR.VE == 0 || d_value.HasNoInvalidExceptions())
   {
-    const double result = ForceSingle(FPSCR, d_value.value);
+    const float result = ForceSingle(FPSCR, d_value.value);
 
     rPS(inst.FD).Fill(result);
     FPSCR.FI = d_value.value != result;
@@ -428,7 +428,7 @@ void Interpreter::faddsx(UGeckoInstruction inst)
 
   if (FPSCR.VE == 0 || sum.HasNoInvalidExceptions())
   {
-    const double result = ForceSingle(FPSCR, sum.value);
+    const float result = ForceSingle(FPSCR, sum.value);
     rPS(inst.FD).Fill(result);
     PowerPC::UpdateFPRFSingle(result);
   }
@@ -468,7 +468,7 @@ void Interpreter::fdivsx(UGeckoInstruction inst)
 
   if (not_divide_by_zero && not_invalid)
   {
-    const double result = ForceSingle(FPSCR, quotient.value);
+    const float result = ForceSingle(FPSCR, quotient.value);
     rPS(inst.FD).Fill(result);
     PowerPC::UpdateFPRFSingle(result);
   }
@@ -592,7 +592,7 @@ void Interpreter::fmsubsx(UGeckoInstruction inst)
 
   if (FPSCR.VE == 0 || product.HasNoInvalidExceptions())
   {
-    const double result = ForceSingle(FPSCR, product.value);
+    const float result = ForceSingle(FPSCR, product.value);
     rPS(inst.FD).Fill(result);
     PowerPC::UpdateFPRFSingle(result);
   }
@@ -633,8 +633,8 @@ void Interpreter::fnmaddsx(UGeckoInstruction inst)
 
   if (FPSCR.VE == 0 || product.HasNoInvalidExceptions())
   {
-    const double tmp = ForceSingle(FPSCR, product.value);
-    const double result = std::isnan(tmp) ? tmp : -tmp;
+    const float tmp = ForceSingle(FPSCR, product.value);
+    const float result = std::isnan(tmp) ? tmp : -tmp;
 
     rPS(inst.FD).Fill(result);
     PowerPC::UpdateFPRFSingle(result);
@@ -676,8 +676,8 @@ void Interpreter::fnmsubsx(UGeckoInstruction inst)
 
   if (FPSCR.VE == 0 || product.HasNoInvalidExceptions())
   {
-    const double tmp = ForceSingle(FPSCR, product.value);
-    const double result = std::isnan(tmp) ? tmp : -tmp;
+    const float tmp = ForceSingle(FPSCR, product.value);
+    const float result = std::isnan(tmp) ? tmp : -tmp;
 
     rPS(inst.FD).Fill(result);
     PowerPC::UpdateFPRFSingle(result);
@@ -714,7 +714,7 @@ void Interpreter::fsubsx(UGeckoInstruction inst)
 
   if (FPSCR.VE == 0 || difference.HasNoInvalidExceptions())
   {
-    const double result = ForceSingle(FPSCR, difference.value);
+    const float result = ForceSingle(FPSCR, difference.value);
     rPS(inst.FD).Fill(result);
     PowerPC::UpdateFPRFSingle(result);
   }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -302,7 +302,7 @@ void Interpreter::frspx(UGeckoInstruction inst)  // round to single
     if (!is_snan || FPSCR.VE == 0)
     {
       rPS(inst.FD).Fill(rounded);
-      PowerPC::UpdateFPRF(b);
+      PowerPC::UpdateFPRFSingle(rounded);
     }
 
     FPSCR.ClearFIFR();
@@ -311,7 +311,7 @@ void Interpreter::frspx(UGeckoInstruction inst)  // round to single
   {
     SetFI(&FPSCR, b != rounded);
     FPSCR.FR = fabs(rounded) > fabs(b);
-    PowerPC::UpdateFPRF(rounded);
+    PowerPC::UpdateFPRFSingle(rounded);
     rPS(inst.FD).Fill(rounded);
   }
 
@@ -333,7 +333,7 @@ void Interpreter::fmulx(UGeckoInstruction inst)
     rPS(inst.FD).SetPS0(result);
     FPSCR.FI = 0;  // are these flags important?
     FPSCR.FR = 0;
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFDouble(result);
   }
 
   if (inst.Rc)
@@ -354,7 +354,7 @@ void Interpreter::fmulsx(UGeckoInstruction inst)
     rPS(inst.FD).Fill(result);
     FPSCR.FI = 0;
     FPSCR.FR = 0;
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFSingle(result);
   }
 
   if (inst.Rc)
@@ -372,7 +372,7 @@ void Interpreter::fmaddx(UGeckoInstruction inst)
   {
     const double result = ForceDouble(FPSCR, product.value);
     rPS(inst.FD).SetPS0(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFDouble(result);
   }
 
   if (inst.Rc)
@@ -395,7 +395,7 @@ void Interpreter::fmaddsx(UGeckoInstruction inst)
     rPS(inst.FD).Fill(result);
     FPSCR.FI = d_value.value != result;
     FPSCR.FR = 0;
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFSingle(result);
   }
 
   if (inst.Rc)
@@ -413,7 +413,7 @@ void Interpreter::faddx(UGeckoInstruction inst)
   {
     const double result = ForceDouble(FPSCR, sum.value);
     rPS(inst.FD).SetPS0(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFDouble(result);
   }
 
   if (inst.Rc)
@@ -430,7 +430,7 @@ void Interpreter::faddsx(UGeckoInstruction inst)
   {
     const double result = ForceSingle(FPSCR, sum.value);
     rPS(inst.FD).Fill(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFSingle(result);
   }
 
   if (inst.Rc)
@@ -450,7 +450,7 @@ void Interpreter::fdivx(UGeckoInstruction inst)
   {
     const double result = ForceDouble(FPSCR, quotient.value);
     rPS(inst.FD).SetPS0(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFDouble(result);
   }
 
   // FR,FI,OX,UX???
@@ -470,7 +470,7 @@ void Interpreter::fdivsx(UGeckoInstruction inst)
   {
     const double result = ForceSingle(FPSCR, quotient.value);
     rPS(inst.FD).Fill(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFSingle(result);
   }
 
   if (inst.Rc)
@@ -485,7 +485,7 @@ void Interpreter::fresx(UGeckoInstruction inst)
   const auto compute_result = [inst](double value) {
     const double result = Common::ApproximateReciprocal(value);
     rPS(inst.FD).Fill(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFSingle(result);
   };
 
   if (b == 0.0)
@@ -523,7 +523,7 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
   const auto compute_result = [inst](double value) {
     const double result = Common::ApproximateReciprocalSquareRoot(value);
     rPS(inst.FD).SetPS0(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFDouble(result);
   };
 
   if (b < 0.0)
@@ -574,7 +574,7 @@ void Interpreter::fmsubx(UGeckoInstruction inst)
   {
     const double result = ForceDouble(FPSCR, product.value);
     rPS(inst.FD).SetPS0(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFDouble(result);
   }
 
   if (inst.Rc)
@@ -594,7 +594,7 @@ void Interpreter::fmsubsx(UGeckoInstruction inst)
   {
     const double result = ForceSingle(FPSCR, product.value);
     rPS(inst.FD).Fill(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFSingle(result);
   }
 
   if (inst.Rc)
@@ -615,7 +615,7 @@ void Interpreter::fnmaddx(UGeckoInstruction inst)
     const double result = std::isnan(tmp) ? tmp : -tmp;
 
     rPS(inst.FD).SetPS0(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFDouble(result);
   }
 
   if (inst.Rc)
@@ -637,7 +637,7 @@ void Interpreter::fnmaddsx(UGeckoInstruction inst)
     const double result = std::isnan(tmp) ? tmp : -tmp;
 
     rPS(inst.FD).Fill(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFSingle(result);
   }
 
   if (inst.Rc)
@@ -658,7 +658,7 @@ void Interpreter::fnmsubx(UGeckoInstruction inst)
     const double result = std::isnan(tmp) ? tmp : -tmp;
 
     rPS(inst.FD).SetPS0(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFDouble(result);
   }
 
   if (inst.Rc)
@@ -680,7 +680,7 @@ void Interpreter::fnmsubsx(UGeckoInstruction inst)
     const double result = std::isnan(tmp) ? tmp : -tmp;
 
     rPS(inst.FD).Fill(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFSingle(result);
   }
 
   if (inst.Rc)
@@ -698,7 +698,7 @@ void Interpreter::fsubx(UGeckoInstruction inst)
   {
     const double result = ForceDouble(FPSCR, difference.value);
     rPS(inst.FD).SetPS0(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFDouble(result);
   }
 
   if (inst.Rc)
@@ -716,7 +716,7 @@ void Interpreter::fsubsx(UGeckoInstruction inst)
   {
     const double result = ForceSingle(FPSCR, difference.value);
     rPS(inst.FD).Fill(result);
-    PowerPC::UpdateFPRF(result);
+    PowerPC::UpdateFPRFSingle(result);
   }
 
   if (inst.Rc)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -117,7 +117,7 @@ void Interpreter::ps_div(UGeckoInstruction inst)
   const double ps1 = ForceSingle(FPSCR, NI_div(&FPSCR, a.PS1AsDouble(), b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -145,7 +145,7 @@ void Interpreter::ps_res(UGeckoInstruction inst)
   const double ps1 = Common::ApproximateReciprocal(b);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -178,7 +178,7 @@ void Interpreter::ps_rsqrte(UGeckoInstruction inst)
   const double dst_ps1 = ForceSingle(FPSCR, Common::ApproximateReciprocalSquareRoot(ps1));
 
   rPS(inst.FD).SetBoth(dst_ps0, dst_ps1);
-  PowerPC::UpdateFPRF(dst_ps0);
+  PowerPC::UpdateFPRFSingle(dst_ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -193,7 +193,7 @@ void Interpreter::ps_sub(UGeckoInstruction inst)
   const double ps1 = ForceSingle(FPSCR, NI_sub(&FPSCR, a.PS1AsDouble(), b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -208,7 +208,7 @@ void Interpreter::ps_add(UGeckoInstruction inst)
   const double ps1 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS1AsDouble(), b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -226,7 +226,7 @@ void Interpreter::ps_mul(UGeckoInstruction inst)
   const double ps1 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS1AsDouble(), c1).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -247,7 +247,7 @@ void Interpreter::ps_msub(UGeckoInstruction inst)
       ForceSingle(FPSCR, NI_msub(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -268,7 +268,7 @@ void Interpreter::ps_madd(UGeckoInstruction inst)
       ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -292,7 +292,7 @@ void Interpreter::ps_nmsub(UGeckoInstruction inst)
   const double ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -316,7 +316,7 @@ void Interpreter::ps_nmadd(UGeckoInstruction inst)
   const double ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -332,7 +332,7 @@ void Interpreter::ps_sum0(UGeckoInstruction inst)
   const double ps1 = ForceSingle(FPSCR, c.PS1AsDouble());
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -348,7 +348,7 @@ void Interpreter::ps_sum1(UGeckoInstruction inst)
   const double ps1 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS0AsDouble(), b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps1);
+  PowerPC::UpdateFPRFSingle(ps1);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -364,7 +364,7 @@ void Interpreter::ps_muls0(UGeckoInstruction inst)
   const double ps1 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS1AsDouble(), c0).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -380,7 +380,7 @@ void Interpreter::ps_muls1(UGeckoInstruction inst)
   const double ps1 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS1AsDouble(), c1).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -399,7 +399,7 @@ void Interpreter::ps_madds0(UGeckoInstruction inst)
       ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c0, b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();
@@ -418,7 +418,7 @@ void Interpreter::ps_madds1(UGeckoInstruction inst)
       ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRF(ps0);
+  PowerPC::UpdateFPRFSingle(ps0);
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -113,8 +113,8 @@ void Interpreter::ps_div(UGeckoInstruction inst)
   const auto& a = rPS(inst.FA);
   const auto& b = rPS(inst.FB);
 
-  const double ps0 = ForceSingle(FPSCR, NI_div(&FPSCR, a.PS0AsDouble(), b.PS0AsDouble()).value);
-  const double ps1 = ForceSingle(FPSCR, NI_div(&FPSCR, a.PS1AsDouble(), b.PS1AsDouble()).value);
+  const float ps0 = ForceSingle(FPSCR, NI_div(&FPSCR, a.PS0AsDouble(), b.PS0AsDouble()).value);
+  const float ps1 = ForceSingle(FPSCR, NI_div(&FPSCR, a.PS1AsDouble(), b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -174,8 +174,8 @@ void Interpreter::ps_rsqrte(UGeckoInstruction inst)
   if (Common::IsSNAN(ps0) || Common::IsSNAN(ps1))
     SetFPException(&FPSCR, FPSCR_VXSNAN);
 
-  const double dst_ps0 = ForceSingle(FPSCR, Common::ApproximateReciprocalSquareRoot(ps0));
-  const double dst_ps1 = ForceSingle(FPSCR, Common::ApproximateReciprocalSquareRoot(ps1));
+  const float dst_ps0 = ForceSingle(FPSCR, Common::ApproximateReciprocalSquareRoot(ps0));
+  const float dst_ps1 = ForceSingle(FPSCR, Common::ApproximateReciprocalSquareRoot(ps1));
 
   rPS(inst.FD).SetBoth(dst_ps0, dst_ps1);
   PowerPC::UpdateFPRFSingle(dst_ps0);
@@ -189,8 +189,8 @@ void Interpreter::ps_sub(UGeckoInstruction inst)
   const auto& a = rPS(inst.FA);
   const auto& b = rPS(inst.FB);
 
-  const double ps0 = ForceSingle(FPSCR, NI_sub(&FPSCR, a.PS0AsDouble(), b.PS0AsDouble()).value);
-  const double ps1 = ForceSingle(FPSCR, NI_sub(&FPSCR, a.PS1AsDouble(), b.PS1AsDouble()).value);
+  const float ps0 = ForceSingle(FPSCR, NI_sub(&FPSCR, a.PS0AsDouble(), b.PS0AsDouble()).value);
+  const float ps1 = ForceSingle(FPSCR, NI_sub(&FPSCR, a.PS1AsDouble(), b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -204,8 +204,8 @@ void Interpreter::ps_add(UGeckoInstruction inst)
   const auto& a = rPS(inst.FA);
   const auto& b = rPS(inst.FB);
 
-  const double ps0 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS0AsDouble(), b.PS0AsDouble()).value);
-  const double ps1 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS1AsDouble(), b.PS1AsDouble()).value);
+  const float ps0 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS0AsDouble(), b.PS0AsDouble()).value);
+  const float ps1 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS1AsDouble(), b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -222,8 +222,8 @@ void Interpreter::ps_mul(UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const double ps0 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS0AsDouble(), c0).value);
-  const double ps1 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS1AsDouble(), c1).value);
+  const float ps0 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS0AsDouble(), c0).value);
+  const float ps1 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS1AsDouble(), c1).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -241,10 +241,8 @@ void Interpreter::ps_msub(UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const double ps0 =
-      ForceSingle(FPSCR, NI_msub(&FPSCR, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const double ps1 =
-      ForceSingle(FPSCR, NI_msub(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+  const float ps0 = ForceSingle(FPSCR, NI_msub(&FPSCR, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+  const float ps1 = ForceSingle(FPSCR, NI_msub(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -262,10 +260,8 @@ void Interpreter::ps_madd(UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const double ps0 =
-      ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const double ps1 =
-      ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+  const float ps0 = ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+  const float ps1 = ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -283,13 +279,13 @@ void Interpreter::ps_nmsub(UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const double tmp0 =
+  const float tmp0 =
       ForceSingle(FPSCR, NI_msub(&FPSCR, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const double tmp1 =
+  const float tmp1 =
       ForceSingle(FPSCR, NI_msub(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
-  const double ps0 = std::isnan(tmp0) ? tmp0 : -tmp0;
-  const double ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
+  const float ps0 = std::isnan(tmp0) ? tmp0 : -tmp0;
+  const float ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -307,13 +303,13 @@ void Interpreter::ps_nmadd(UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const double tmp0 =
+  const float tmp0 =
       ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const double tmp1 =
+  const float tmp1 =
       ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
-  const double ps0 = std::isnan(tmp0) ? tmp0 : -tmp0;
-  const double ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
+  const float ps0 = std::isnan(tmp0) ? tmp0 : -tmp0;
+  const float ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -328,8 +324,8 @@ void Interpreter::ps_sum0(UGeckoInstruction inst)
   const auto& b = rPS(inst.FB);
   const auto& c = rPS(inst.FC);
 
-  const double ps0 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS0AsDouble(), b.PS1AsDouble()).value);
-  const double ps1 = ForceSingle(FPSCR, c.PS1AsDouble());
+  const float ps0 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS0AsDouble(), b.PS1AsDouble()).value);
+  const float ps1 = ForceSingle(FPSCR, c.PS1AsDouble());
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -344,8 +340,8 @@ void Interpreter::ps_sum1(UGeckoInstruction inst)
   const auto& b = rPS(inst.FB);
   const auto& c = rPS(inst.FC);
 
-  const double ps0 = ForceSingle(FPSCR, c.PS0AsDouble());
-  const double ps1 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS0AsDouble(), b.PS1AsDouble()).value);
+  const float ps0 = ForceSingle(FPSCR, c.PS0AsDouble());
+  const float ps1 = ForceSingle(FPSCR, NI_add(&FPSCR, a.PS0AsDouble(), b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps1);
@@ -360,8 +356,8 @@ void Interpreter::ps_muls0(UGeckoInstruction inst)
   const auto& c = rPS(inst.FC);
 
   const double c0 = Force25Bit(c.PS0AsDouble());
-  const double ps0 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS0AsDouble(), c0).value);
-  const double ps1 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS1AsDouble(), c0).value);
+  const float ps0 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS0AsDouble(), c0).value);
+  const float ps1 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS1AsDouble(), c0).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -376,8 +372,8 @@ void Interpreter::ps_muls1(UGeckoInstruction inst)
   const auto& c = rPS(inst.FC);
 
   const double c1 = Force25Bit(c.PS1AsDouble());
-  const double ps0 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS0AsDouble(), c1).value);
-  const double ps1 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS1AsDouble(), c1).value);
+  const float ps0 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS0AsDouble(), c1).value);
+  const float ps1 = ForceSingle(FPSCR, NI_mul(&FPSCR, a.PS1AsDouble(), c1).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -393,10 +389,8 @@ void Interpreter::ps_madds0(UGeckoInstruction inst)
   const auto& c = rPS(inst.FC);
 
   const double c0 = Force25Bit(c.PS0AsDouble());
-  const double ps0 =
-      ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const double ps1 =
-      ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c0, b.PS1AsDouble()).value);
+  const float ps0 = ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+  const float ps1 = ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c0, b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);
@@ -412,10 +406,8 @@ void Interpreter::ps_madds1(UGeckoInstruction inst)
   const auto& c = rPS(inst.FC);
 
   const double c1 = Force25Bit(c.PS1AsDouble());
-  const double ps0 =
-      ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS0AsDouble(), c1, b.PS0AsDouble()).value);
-  const double ps1 =
-      ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+  const float ps0 = ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS0AsDouble(), c1, b.PS0AsDouble()).value);
+  const float ps1 = ForceSingle(FPSCR, NI_madd(&FPSCR, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
   PowerPC::UpdateFPRFSingle(ps0);

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -121,8 +121,11 @@ public:
   // Generates a branch that will check if a given bit of a CR register part
   // is set or not.
   Gen::FixupBranch JumpIfCRFieldBit(int field, int bit, bool jump_if_set = true);
-  void SetFPRFIfNeeded(Gen::X64Reg xmm);
 
+  void SetFPRFIfNeeded(const Gen::OpArg& xmm, bool single);
+  void FinalizeSingleResult(Gen::X64Reg output, const Gen::OpArg& input, bool packed = true,
+                            bool duplicate = false);
+  void FinalizeDoubleResult(Gen::X64Reg output, const Gen::OpArg& input);
   void HandleNaNs(UGeckoInstruction inst, Gen::X64Reg xmm_out, Gen::X64Reg xmm_in,
                   Gen::X64Reg clobber = Gen::XMM0);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -77,8 +77,7 @@ void Jit64::ps_sum(UGeckoInstruction inst)
     PanicAlertFmt("ps_sum WTF!!!");
   }
   HandleNaNs(inst, Rd, tmp, tmp == XMM1 ? XMM0 : XMM1);
-  ForceSinglePrecision(Rd, Rd);
-  SetFPRFIfNeeded(Rd);
+  FinalizeSingleResult(Rd, Rd);
 }
 
 void Jit64::ps_muls(UGeckoInstruction inst)
@@ -112,8 +111,7 @@ void Jit64::ps_muls(UGeckoInstruction inst)
     Force25BitPrecision(XMM1, R(XMM1), XMM0);
   MULPD(XMM1, Ra);
   HandleNaNs(inst, Rd, XMM1);
-  ForceSinglePrecision(Rd, Rd);
-  SetFPRFIfNeeded(Rd);
+  FinalizeSingleResult(Rd, Rd);
 }
 
 void Jit64::ps_mergeXX(UGeckoInstruction inst)
@@ -171,8 +169,7 @@ void Jit64::ps_rsqrte(UGeckoInstruction inst)
   CALL(asm_routines.frsqrte);
   MOVLHPS(Rd, XMM0);
 
-  ForceSinglePrecision(Rd, Rd);
-  SetFPRFIfNeeded(Rd);
+  FinalizeSingleResult(Rd, Rd);
 }
 
 void Jit64::ps_res(UGeckoInstruction inst)
@@ -196,8 +193,7 @@ void Jit64::ps_res(UGeckoInstruction inst)
   CALL(asm_routines.fres);
   MOVLHPS(Rd, XMM0);
 
-  ForceSinglePrecision(Rd, Rd);
-  SetFPRFIfNeeded(Rd);
+  FinalizeSingleResult(Rd, Rd);
 }
 
 void Jit64::ps_cmpXX(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -117,14 +117,12 @@ public:
               void (Gen::XEmitter::*sseOp)(Gen::X64Reg, const Gen::OpArg&, u8), Gen::X64Reg regOp,
               const Gen::OpArg& arg1, const Gen::OpArg& arg2, u8 imm);
 
-  void ForceSinglePrecision(Gen::X64Reg output, const Gen::OpArg& input, bool packed = true,
-                            bool duplicate = false);
   void Force25BitPrecision(Gen::X64Reg output, const Gen::OpArg& input, Gen::X64Reg tmp);
 
   // RSCRATCH might get trashed
   void ConvertSingleToDouble(Gen::X64Reg dst, Gen::X64Reg src, bool src_is_gpr = false);
   void ConvertDoubleToSingle(Gen::X64Reg dst, Gen::X64Reg src);
-  void SetFPRF(Gen::X64Reg xmm);
+  void SetFPRF(Gen::X64Reg xmm, bool single);
   void Clear();
 
 protected:

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -626,9 +626,14 @@ void PowerPCState::SetSR(u32 index, u32 value)
 
 // FPSCR update functions
 
-void UpdateFPRF(double dvalue)
+void UpdateFPRFDouble(double dvalue)
 {
   FPSCR.FPRF = Common::ClassifyDouble(dvalue);
+}
+
+void UpdateFPRFSingle(float fvalue)
+{
+  FPSCR.FPRF = Common::ClassifyFloat(fvalue);
 }
 
 void RoundingModeUpdated()

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -304,7 +304,8 @@ inline void SetXER_OV(bool value)
   SetXER_SO(value);
 }
 
-void UpdateFPRF(double dvalue);
+void UpdateFPRFDouble(double dvalue);
+void UpdateFPRFSingle(float fvalue);
 
 void RoundingModeUpdated();
 

--- a/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
@@ -74,14 +74,14 @@ TEST(JitArm64, FPRF)
   for (const u64 double_input : double_test_values)
   {
     const u32 expected_double =
-        RunUpdateFPRF([&] { PowerPC::UpdateFPRF(Common::BitCast<double>(double_input)); });
+        RunUpdateFPRF([&] { PowerPC::UpdateFPRFDouble(Common::BitCast<double>(double_input)); });
     const u32 actual_double = RunUpdateFPRF([&] { test.fprf_double(double_input); });
     EXPECT_EQ(expected_double, actual_double);
 
     const u32 single_input = ConvertToSingle(double_input);
 
-    const u32 expected_single = RunUpdateFPRF(
-        [&] { PowerPC::UpdateFPRF(Common::BitCast<double>(ConvertToDouble(single_input))); });
+    const u32 expected_single =
+        RunUpdateFPRF([&] { PowerPC::UpdateFPRFSingle(Common::BitCast<float>(single_input)); });
     const u32 actual_single = RunUpdateFPRF([&] { test.fprf_single(single_input); });
     EXPECT_EQ(expected_single, actual_single);
   }


### PR DESCRIPTION
We were classifying denormal singles as if they were normals (because we converted singles to doubles and then classified them using the same code as for doubles), but this behavior has been confirmed incorrect by https://github.com/dolphin-emu/hwtests/pull/41.

When fixing this, I went with an approach of performing classification on 32-bit floats in all CPU emulation cores (i.e. classification is performed after forcing the result to single but before converting it back to double). It would be possible to perform classification after converting to double, but that would require us to check if the exponent is in a certain range instead of just checking if it is zero, so I think the approach I went with is better.