### PR TITLE
Jit64: Fix FPRF non-SSE4.1 handling of negative zero

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -994,7 +994,7 @@ void EmuCodeBlock::SetFPRF(Gen::X64Reg xmm)
                 Common::PPC_FPCLASS_PINF));
     continue3 = J();
     SetJumpTarget(zeroExponent);
-    TEST(64, R(RSCRATCH), R(RSCRATCH));
+    TEST(64, R(RSCRATCH), MConst(psDoubleNoSign));
     FixupBranch zero = J_CC(CC_Z);
     SHR(64, R(RSCRATCH), Imm8(63));
     LEA(32, RSCRATCH,


### PR DESCRIPTION
In the description of https://github.com/dolphin-emu/hwtests/pull/41, I said that it uncovered two issues in Dolphin... But after I wrote that, it actually uncovered a third issue which only happens when not using SSE4.1. Here's the fix for that issue.