### PR TITLE
AudioInterface: Initialize s_cpu_cycles_per_sample to a sane value.

### DIFF
--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -111,7 +111,7 @@ static u32 s_sample_counter = 0;
 static u32 s_interrupt_timing = 0;
 
 static u64 s_last_cpu_time = 0;
-static u64 s_cpu_cycles_per_sample = 0xFFFFFFFFFFFULL;
+static u64 s_cpu_cycles_per_sample = 0;
 
 static u32 s_ais_sample_rate = 48000;
 static u32 s_aid_sample_rate = 32000;
@@ -148,10 +148,10 @@ void Init()
   s_interrupt_timing = 0;
 
   s_last_cpu_time = 0;
-  s_cpu_cycles_per_sample = 0xFFFFFFFFFFFULL;
 
   s_ais_sample_rate = Get48KHzSampleRate();
   s_aid_sample_rate = Get32KHzSampleRate();
+  s_cpu_cycles_per_sample = SystemTimers::GetTicksPerSecond() / s_ais_sample_rate;
 
   event_type_ai = CoreTiming::RegisterEvent("AICallback", Update);
 


### PR DESCRIPTION
I'm not sure what the previous default was, it doesn't seem to be anything sensible. I can trace it back to literally the first commit in the git but I haven't found an explanation for it.

Re-fixes the Naruto games after #9788.