### PR TITLE
JitArm64: Implement FMA-less path for FMA instructions

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -4,8 +4,10 @@
 #include "Common/Arm64Emitter.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/SessionSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -89,6 +91,7 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
   ARM64Reg VA{}, VB{}, VC{}, VD{};
 
   ARM64Reg V0Q = ARM64Reg::INVALID_REG;
+  ARM64Reg V1Q = ARM64Reg::INVALID_REG;
 
   if (packed)
   {
@@ -151,17 +154,26 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
       VC = reg_encoder(fpr.R(c, type));
     VD = reg_encoder(fpr.RW(d, type_out));
 
+    const bool inaccurate_fma = op5 > 25 && !Config::Get(Config::SESSION_USE_FMA);
+
     if (round_c)
     {
       ASSERT_MSG(DYNA_REC, !inputs_are_singles, "Tried to apply 25-bit precision to single");
 
       V0Q = fpr.GetReg();
-      const ARM64Reg V1Q = fpr.GetReg();
+      V1Q = fpr.GetReg();
 
-      Force25BitPrecision(reg_encoder(V0Q), VC, reg_encoder(V1Q));
-      VC = reg_encoder(V0Q);
+      Force25BitPrecision(reg_encoder(V1Q), VC, reg_encoder(V0Q));
+      VC = reg_encoder(V1Q);
+    }
 
-      fpr.Unlock(V1Q);
+    ARM64Reg inaccurate_fma_temp_reg = VD;
+    if (inaccurate_fma && d == b)
+    {
+      if (V0Q == ARM64Reg::INVALID_REG)
+        V0Q = fpr.GetReg();
+
+      inaccurate_fma_temp_reg = reg_encoder(V0Q);
     }
 
     switch (op5)
@@ -178,23 +190,37 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
     case 25:
       m_float_emit.FMUL(VD, VA, VC);
       break;
-    case 28:  // fmsub: "D = A*C - B" vs "Vd = (-Va) + Vn*Vm"
-      m_float_emit.FNMSUB(VD, VA, VC, VB);
-      break;
-    case 29:  // fmadd: "D = A*C + B" vs "Vd = Va + Vn*Vm"
-      m_float_emit.FMADD(VD, VA, VC, VB);
-      break;
     // While it may seem like PowerPC's nmadd/nmsub map to AArch64's nmadd/msub [sic],
     // the subtly different definitions affect how signed zeroes are handled.
     // Also, PowerPC's nmadd/nmsub perform rounding before the final negation.
-    // So, negate using a separate instruction instead of using AArch64's nmadd/msub.
+    // So, we negate using a separate FNEG instruction instead of using AArch64's nmadd/msub.
+    case 28:  // fmsub: "D = A*C - B" vs "Vd = (-Va) + Vn*Vm"
     case 30:  // fnmsub: "D = -(A*C - B)" vs "Vd = -((-Va) + Vn*Vm)"
-      m_float_emit.FNMSUB(VD, VA, VC, VB);
-      m_float_emit.FNEG(VD, VD);
+      if (inaccurate_fma)
+      {
+        m_float_emit.FMUL(inaccurate_fma_temp_reg, VA, VC);
+        m_float_emit.FSUB(VD, inaccurate_fma_temp_reg, VB);
+      }
+      else
+      {
+        m_float_emit.FNMSUB(VD, VA, VC, VB);
+      }
+      if (op5 == 30)
+        m_float_emit.FNEG(VD, VD);
       break;
+    case 29:  // fmadd: "D = A*C + B" vs "Vd = Va + Vn*Vm"
     case 31:  // fnmadd: "D = -(A*C + B)" vs "Vd = -(Va + Vn*Vm)"
-      m_float_emit.FMADD(VD, VA, VC, VB);
-      m_float_emit.FNEG(VD, VD);
+      if (inaccurate_fma)
+      {
+        m_float_emit.FMUL(inaccurate_fma_temp_reg, VA, VC);
+        m_float_emit.FADD(VD, inaccurate_fma_temp_reg, VB);
+      }
+      else
+      {
+        m_float_emit.FMADD(VD, VA, VC, VB);
+      }
+      if (op5 == 31)
+        m_float_emit.FNEG(VD, VD);
       break;
     default:
       ASSERT_MSG(DYNA_REC, 0, "fp_arith");
@@ -204,6 +230,8 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
 
   if (V0Q != ARM64Reg::INVALID_REG)
     fpr.Unlock(V0Q);
+  if (V1Q != ARM64Reg::INVALID_REG)
+    fpr.Unlock(V1Q);
 
   if (outputs_are_singles)
   {


### PR DESCRIPTION
For determinism compatibility with old x64 CPUs. Off by default.

I haven't tested this on netplay, but I've tested that the new code path doesn't break games in any obvious way. (Other than breaking existing F-Zero GX replays, which is unsurprising)

This is a follow-up to PR #9804.