### PR TITLE
Common: Set bFMA to true for AArch64

### DIFF
--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -68,6 +68,7 @@ void CPUInfo::Detect()
   CPU64bit = true;
   Mode64bit = true;
   vendor = CPUVendor::ARM;
+  bFMA = true;
   bFlushToZero = true;
   bAFP = false;
 


### PR DESCRIPTION
Without this, the code added in PR #9804 misbehaves and considers AArch64 netplay clients to not have hardware FMA support, telling all clients to disable FMA support, which causes a desync between x64 and AArch64 due to JitArm64 not being able to disable FMA support. (The ability for JitArm64 to do so is added in PR #9815, but I thought I would submit this fix separately since that PR likely will take longer to review.)