### PR TITLE
Jit64: subfic - Optimize constants for d != a

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -898,28 +898,31 @@ void Jit64::subfic(UGeckoInstruction inst)
   RCX64Reg Rd = gpr.Bind(d, RCMode::Write);
   RegCache::Realize(Ra, Rd);
 
-  if (d == a)
+  if (imm == 0)
   {
-    if (imm == 0)
-    {
-      // Flags act exactly like subtracting from 0
-      NEG(32, Rd);
-      // Output carry is inverted
-      FinalizeCarry(CC_NC);
-    }
-    else if (imm == -1)
-    {
-      NOT(32, Rd);
-      // CA is always set in this case
-      FinalizeCarry(true);
-    }
-    else
-    {
-      NOT(32, Rd);
-      ADD(32, Rd, Imm32(imm + 1));
-      // Output carry is normal
-      FinalizeCarry(CC_C);
-    }
+    if (d != a)
+      MOV(32, Rd, Ra);
+
+    // Flags act exactly like subtracting from 0
+    NEG(32, Rd);
+    // Output carry is inverted
+    FinalizeCarry(CC_NC);
+  }
+  else if (imm == -1)
+  {
+    if (d != a)
+      MOV(32, Rd, Ra);
+
+    NOT(32, Rd);
+    // CA is always set in this case
+    FinalizeCarry(true);
+  }
+  else if (d == a)
+  {
+    NOT(32, Rd);
+    ADD(32, Rd, Imm32(imm + 1));
+    // Output carry is normal
+    FinalizeCarry(CC_C);
   }
   else
   {


### PR DESCRIPTION
These optimizations were already present, but only when d == a. They also make sense when this condition does not hold.

---

<details><summary>imm == 0</summary>

Before:
```
41 BB 00 00 00 00    mov         r11d,0
45 2B DF             sub         r11d,r15d
```

After:
```
45 8B DF             mov         r11d,r15d
41 F7 DB             neg         r11d
```
</details>


<details><summary>imm == -1</summary>

Before:
```
41 BD FF FF FF FF    mov         r13d,0FFFFFFFFh
44 2B EE             sub         r13d,esi
0F 93 45 68          setae       byte ptr [rbp+68h]
```

After:
```
44 8B EE             mov         r13d,esi
41 F7 D5             not         r13d
C6 45 68 01          mov         byte ptr [rbp+68h],1
```
</details>