### PR TITLE
Jits: Don't use fast double-to-single when input is double precision

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -104,7 +104,7 @@ void Jit64::stfXXX(UGeckoInstruction inst)
 
   if (single)
   {
-    if (js.fpr_is_store_safe[s])
+    if (js.fpr_is_store_safe[s] && js.op->fprIsSingle[s])
     {
       RCOpArg Rs = fpr.Use(s, RCMode::Read);
       RegCache::Realize(Rs);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -603,7 +603,7 @@ void JitArm64::frsqrtex(UGeckoInstruction inst)
 
 void JitArm64::ConvertDoubleToSingleLower(size_t guest_reg, ARM64Reg dest_reg, ARM64Reg src_reg)
 {
-  if (js.fpr_is_store_safe[guest_reg])
+  if (js.fpr_is_store_safe[guest_reg] && js.op->fprIsSingle[guest_reg])
   {
     m_float_emit.FCVT(32, 64, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
     return;
@@ -623,7 +623,7 @@ void JitArm64::ConvertDoubleToSingleLower(size_t guest_reg, ARM64Reg dest_reg, A
 
 void JitArm64::ConvertDoubleToSinglePair(size_t guest_reg, ARM64Reg dest_reg, ARM64Reg src_reg)
 {
-  if (js.fpr_is_store_safe[guest_reg])
+  if (js.fpr_is_store_safe[guest_reg] && js.op->fprIsSingle[guest_reg])
   {
     m_float_emit.FCVTN(32, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
     return;


### PR DESCRIPTION
The fast path of using CVTSD2SS/FCVTN rounds the significand if it can't be exactly represented as a single, whereas the accurate path instead truncates the significand. So we should only use the fast path if we know that the lower bits of the significand are not set.

This is not known to affect any games.