### PR TITLE
JitArm64: Simplify addex/subfex

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -263,6 +263,7 @@ protected:
   void ComputeCarry(Arm64Gen::ARM64Reg reg);  // reg must contain 0 or 1
   void ComputeCarry(bool carry);
   void ComputeCarry();
+  void LoadCarry();
   void FlushCarry();
 
   void reg_imm(u32 d, u32 a, u32 value, u32 (*do_op)(u32, u32),


### PR DESCRIPTION
Some of the code used when the carry flag is known to be a constant value is really not much better than just setting the carry flag and then using the normal code, and with how rarely this code runs, it isn't well tested either. Might as well get rid of some of this code and simplify things.