### PR TITLE
Memmap: Relax address range check

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -550,7 +550,7 @@ u8* GetPointer(u32 address)
 
   if (m_pEXRAM)
   {
-    if ((address >> 28) == 0x1 && (address & 0x0fffffff) < GetExRamSizeReal())
+    if ((address >> 28) == 0x1)
       return m_pEXRAM + (address & GetExRamMask());
   }
 


### PR DESCRIPTION
As noted in [#12536](https://bugs.dolphin-emu.org/issues/12536) Cabela's Big Game Hunter 2012 crashes with an Unknown Pointer error. This is caused by a display list writing the value 0x3ec00000 to the ARRAY_COLOR0 (index 2) component of g_main_cp_state.array_bases, which is well outside the Wii's ram range [0x10000000, 0x14000000). We currently mask off the top three bits from writes to array base values, turning 0x3ec00000 to 0x1ec00000 which is still outside the valid range. That value gets passed into GetPointer in memmap.cpp, which checks to see if the address is valid and throws a panic alert when it isn't.

This PR currently fixes the crash by simply relaxing the Wii range check in GetPointer to allow any value in [0x10000000, 0x2000000). That works because the address is masked with 0x03ffffff before being added to the base Wii ram address guaranteeing a value in range. There shouldn't be any games depending on the current stricter behavior, both because any such game would already be crashing with the current check, and because YAGCD indicates the top 6 bits of writes to Command Processor array base values are unused (presumably after checking bit index 3 to see if it's a write to GC or Wii memory).

This is a draft because I'm seeking feedback on the best implementation for this. The current way seeks to minimize potential side effects, which is simple since anything affected by it would have immediately crashed previously. Alternatives:
* Change the mask at the beginning of GetPointer from 0x3fffffff to 0x13ffffff
* Change the Wii mask value in CommandProccessor.h::GetPhysicalAddressMask() from 0x1fffffff to 0x13ffffff
* Change the ARRAY_BASE case in VertexLoaderManager.h::LoadCPReg() to use 0x13ffffff instead of GetPhysicalAddressMask()

Changing GetPhysicalAddressMask() seems like the semantically cleanest option, but it's also used in CommandProcessor::RegisterMMIO() to initialize WMASK_HI_RESTRICT which is used for a number of other values and I'm not sure that wouldn't break something else.

Fixes [#12536](https://bugs.dolphin-emu.org/issues/12536) and [#4871](https://bugs.dolphin-emu.org/issues/4871). Looking at the pointer value it's worth checking to see if this fixes [#12508](https://bugs.dolphin-emu.org/issues/12508) too.