### PR TITLE
RenderWidget: Set Window to Top for Cursor Lock

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -254,6 +254,10 @@ void RenderWidget::SetCursorLocked(bool locked, bool follow_aspect_ratio)
   if (locked)
   {
 #ifdef _WIN32
+    // This will prevent the mouse from interacting with the task bar
+    // while in windowed / borderless fullscreen.
+    SetWindowPos((HWND) winId(), HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+
     RECT rect;
     rect.left = render_rect.left();
     rect.right = render_rect.right();
@@ -280,6 +284,7 @@ void RenderWidget::SetCursorLocked(bool locked, bool follow_aspect_ratio)
   else
   {
 #ifdef _WIN32
+    SetWindowPos((HWND) winId(), HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     ClipCursor(nullptr);
 #endif
 


### PR DESCRIPTION
Simple solution to the task bar being in the way when using the lock mouse cursor feature by setting the window to be topmost while focused. This is particularly annoying for users with the setting `Auto Hide Task Bar` enabled, because the mouse is able to enter the region for the taskbar to show up above the dolphin window. 

This calls `SetWindowPos` with the `NOMOVE`, `NOSIZE` and `NOACTIVATE` flags, the last flag is important to prevent a loop with popup boxes fighting for focus.