### PR TITLE
AudioInterface: Cleanup

### DIFF
--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -338,10 +338,11 @@ static void Update(u64 userdata, s64 cycles_late)
 
 int GetAIPeriod()
 {
-  u64 period = s_cpu_cycles_per_sample * (s_interrupt_timing - s_sample_counter);
-  u64 s_period = s_cpu_cycles_per_sample * s_ais_sample_rate;
-  if (period == 0)
+  const u64 s_period = s_cpu_cycles_per_sample * s_ais_sample_rate;
+  if (s_interrupt_timing <= s_sample_counter)
     return static_cast<int>(s_period);
+
+  const u64 period = s_cpu_cycles_per_sample * (s_interrupt_timing - s_sample_counter);
   return static_cast<int>(std::min(period, s_period));
 }
 

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -287,7 +287,7 @@ static void IncreaseSampleCount(const u32 amount)
   const u32 old_sample_counter = s_sample_counter + 1;
   s_sample_counter += amount;
 
-  if ((s_interrupt_timing - old_sample_counter) <= (s_sample_counter - old_sample_counter))
+  if (old_sample_counter <= s_interrupt_timing && s_interrupt_timing <= s_sample_counter)
   {
     DEBUG_LOG_FMT(AUDIO_INTERFACE,
                   "GenerateAudioInterrupt {:08x}:{:08x} at PC {:08x} s_control.AIINTVLD={}",

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -281,18 +281,18 @@ void GenerateAISInterrupt()
 
 static void IncreaseSampleCount(const u32 amount)
 {
-  if (s_control.PSTAT)
-  {
-    const u32 old_sample_counter = s_sample_counter + 1;
-    s_sample_counter += amount;
+  if (!IsPlaying())
+    return;
 
-    if ((s_interrupt_timing - old_sample_counter) <= (s_sample_counter - old_sample_counter))
-    {
-      DEBUG_LOG_FMT(AUDIO_INTERFACE,
-                    "GenerateAudioInterrupt {:08x}:{:08x} at PC {:08x} s_control.AIINTVLD={}",
-                    s_sample_counter, s_interrupt_timing, PowerPC::ppcState.pc, s_control.AIINTVLD);
-      GenerateAudioInterrupt();
-    }
+  const u32 old_sample_counter = s_sample_counter + 1;
+  s_sample_counter += amount;
+
+  if ((s_interrupt_timing - old_sample_counter) <= (s_sample_counter - old_sample_counter))
+  {
+    DEBUG_LOG_FMT(AUDIO_INTERFACE,
+                  "GenerateAudioInterrupt {:08x}:{:08x} at PC {:08x} s_control.AIINTVLD={}",
+                  s_sample_counter, s_interrupt_timing, PowerPC::ppcState.pc, s_control.AIINTVLD);
+    GenerateAudioInterrupt();
   }
 }
 
@@ -323,17 +323,17 @@ u32 Get48KHzSampleRate()
 
 static void Update(u64 userdata, s64 cycles_late)
 {
-  if (s_control.PSTAT)
+  if (!IsPlaying())
+    return;
+
+  const u64 diff = CoreTiming::GetTicks() - s_last_cpu_time;
+  if (diff > s_cpu_cycles_per_sample)
   {
-    const u64 diff = CoreTiming::GetTicks() - s_last_cpu_time;
-    if (diff > s_cpu_cycles_per_sample)
-    {
-      const u32 samples = static_cast<u32>(diff / s_cpu_cycles_per_sample);
-      s_last_cpu_time += samples * s_cpu_cycles_per_sample;
-      IncreaseSampleCount(samples);
-    }
-    CoreTiming::ScheduleEvent(GetAIPeriod() - cycles_late, event_type_ai);
+    const u32 samples = static_cast<u32>(diff / s_cpu_cycles_per_sample);
+    s_last_cpu_time += samples * s_cpu_cycles_per_sample;
+    IncreaseSampleCount(samples);
   }
+  CoreTiming::ScheduleEvent(GetAIPeriod() - cycles_late, event_type_ai);
 }
 
 int GetAIPeriod()


### PR DESCRIPTION
This PRs refactors the AudioInterface a bit. It removes some underflows and uses the IsPlaying function more rather than relying directly on the control's state.

There shouldn't be any functional differences.

Ready to be reviewed & tested.