### PR TITLE
AudioInterface: Fix sample counter

### DIFF
--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -241,9 +241,10 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  }));
 
   mmio->Register(base | AI_SAMPLE_COUNTER, MMIO::ComplexRead<u32>([](u32) {
+                   const u64 cycles_streamed =
+                       IsPlaying() ? (CoreTiming::GetTicks() - s_last_cpu_time) : s_last_cpu_time;
                    return s_sample_counter +
-                          static_cast<u32>((CoreTiming::GetTicks() - s_last_cpu_time) /
-                                           s_cpu_cycles_per_sample);
+                          static_cast<u32>(cycles_streamed / s_cpu_cycles_per_sample);
                  }),
                  MMIO::ComplexWrite<u32>([](u32, u32 val) {
                    s_sample_counter = val;


### PR DESCRIPTION
This PR fixes the sample counter being incremented even when it's not playing.

Confirmed with this hardware test: [wii-audio-samples.zip](https://github.com/dolphin-emu/dolphin/files/6681093/wii-audio-samples.zip).

> ## HWTEST - Sample Counter
>
> ### PSTAT = 0
> Counter = 2
> Counter = 2
> Counter = 2
> Counter = 2
> Counter = 2
>
> ### PSTAT = 1
> Counter = 49
> Counter = 64058
> Counter = 128112
> Counter = 192166
> Counter = 256215

It doesn't seem to affect the games I have.

Ready to be reviewed & tested.