### PR TITLE
Apple M1: Add support for running unit tests on universal builds

### DIFF
--- a/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
@@ -33,6 +33,8 @@ class TestConversion : private JitArm64
 public:
   TestConversion()
   {
+    const Common::ScopedJITPageWriteAndNoExecute enable_jit_page_writes;
+
     AllocCodeSpace(4096);
     AddChildCodeSpace(&farcode, 2048);
 

--- a/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
@@ -26,6 +26,8 @@ class TestFPRF : public JitArm64
 public:
   TestFPRF()
   {
+    const Common::ScopedJITPageWriteAndNoExecute enable_jit_page_writes;
+
     AllocCodeSpace(4096);
 
     const u8* raw_fprf_single = GetCodePtr();

--- a/Source/UnitTests/Core/PowerPC/JitArm64/Fres.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/Fres.cpp
@@ -24,6 +24,8 @@ class TestFres : public JitArm64
 public:
   TestFres()
   {
+    const Common::ScopedJITPageWriteAndNoExecute enable_jit_page_writes;
+
     AllocCodeSpace(4096);
 
     const u8* raw_fres = GetCodePtr();

--- a/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
@@ -24,6 +24,8 @@ class TestFrsqrte : public JitArm64
 public:
   TestFrsqrte()
   {
+    const Common::ScopedJITPageWriteAndNoExecute enable_jit_page_writes;
+
     AllocCodeSpace(4096);
 
     const u8* raw_frsqrte = GetCodePtr();

--- a/Source/UnitTests/Core/PowerPC/JitArm64/MovI2R.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/MovI2R.cpp
@@ -26,8 +26,11 @@ public:
     ResetCodePtr();
 
     const u8* fn = GetCodePtr();
-    MOVI2R(ARM64Reg::W0, value);
-    RET();
+    {
+      const Common::ScopedJITPageWriteAndNoExecute enable_jit_page_writes;
+      MOVI2R(ARM64Reg::W0, value);
+      RET();
+    }
 
     FlushIcacheSection(const_cast<u8*>(fn), const_cast<u8*>(GetCodePtr()));
 
@@ -40,8 +43,11 @@ public:
     ResetCodePtr();
 
     const u8* fn = GetCodePtr();
-    MOVI2R(ARM64Reg::X0, value);
-    RET();
+    {
+      const Common::ScopedJITPageWriteAndNoExecute enable_jit_page_writes;
+      MOVI2R(ARM64Reg::X0, value);
+      RET();
+    }
 
     FlushIcacheSection(const_cast<u8*>(fn), const_cast<u8*>(GetCodePtr()));
 


### PR DESCRIPTION
This change adds support for unit testing to the universal binary build script through a new `--run_unit_tests` command line option. When this is specified, unit testing is performed for both the x86 and ARM64 slices that are built. 

It also fixes the PowerPC unit tests that were segfaulting on M1 silicon because they were not wrapping their code gen for W^X execution. 