### PR TITLE
Software: Remove texinfo.sourcerow == SourceRow::Colors assert

### DIFF
--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -416,14 +416,12 @@ void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst)
     }
     break;
     case TexGenType::Color0:
-      ASSERT(texinfo.sourcerow == SourceRow::Colors);
       ASSERT(texinfo.inputform == TexInputForm::AB11);
       dst->texCoords[coordNum].x = (float)dst->color[0][0] / 255.0f;
       dst->texCoords[coordNum].y = (float)dst->color[0][1] / 255.0f;
       dst->texCoords[coordNum].z = 1.0f;
       break;
     case TexGenType::Color1:
-      ASSERT(texinfo.sourcerow == SourceRow::Colors);
       ASSERT(texinfo.inputform == TexInputForm::AB11);
       dst->texCoords[coordNum].x = (float)dst->color[1][0] / 255.0f;
       dst->texCoords[coordNum].y = (float)dst->color[1][1] / 255.0f;


### PR DESCRIPTION
The sourcerow asserts were removed for the hardware renderer in #3684, which was hardware tested.  Currently [ssbm-mod-lloyd](https://fifo.ci/dff/ssbb-mod-lloyd/) fails the `texinfo.sourcerow == SourceRow::Colors` assertion (sourcerow is set to Tex1).

There never was an equivalent for the input form asserts in the hardware renderer (I looked at [VertexShaderGen](https://github.com/dolphin-emu/dolphin/blob/9b16c360145e067172e6e6bbe5748f041c251f10/Source/Core/VideoCommon/Src/VertexShaderGen.cpp) as of 9b16c360145e067172e6e6bbe5748f041c251f10 and it didn't exist then).  As far as I can tell, nothing hits them (including the Lloyd test), but it does seem suspicious that the z-component is set to 1.0f with the assumption that AB11 is used.  I've left the assert since there's a chance that some game uses it, but I haven't hardware tested it myself and don't currently plan on doing so.

Even with the assert fixed, the Lloyd test looks incorrect, see [bug 9268](https://bugs.dolphin-emu.org/issues/9268).  Lloyd is too bright, but also, Sonic looks incorrect.  The Lloyd appearance issue applies to the hardware renderer too, but the Sonic one is unique to software and I don't know why it's happening.  I think it's still useful to merge this so that the Lloyd test actually runs on fifo.ci because the failed assert currently blocks that.

EDIT: The sonic appearance problem is not related to the assertion in question; the affected objects are 421/422 (counting EFBs separately, they will be 425/426) and are parts of LLoyd's face (I think).