### PR TITLE
UberShaderPixel: always set tevcoord, even if the stage has no texture

### DIFF
--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -893,7 +893,7 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
               "      // Emulate s24 overflows\n"
               "      tevcoord.xy = (tevcoord.xy << 8) >> 8;\n"
               "    }}\n"
-              "    else if (texture_enabled)\n"
+              "    else\n"
               "    {{\n"
               "      tevcoord.xy = fixedPoint_uv;\n"
               "    }}\n"


### PR DESCRIPTION
This fixes NES game graphics when UberShaders are in use.

For performance reasons, ubershaders are supposed to skip some of the indirect texture logic when the indirect functionality isn't enabled, since an indirect configuration that's all zeros does nothing.  However, prior to e1d45e9ba66d3ba7d6769e36c0fc82ceb5028ecb (part of #9651), that wasn't actually done and it was only skipped when the indirect functionality referred to an indirect stage index that was greater than the number of enabled ones (despite there being a comment claiming it also could be disabled when set to zero).

Super Mario Bros. has 3 TEV stages and 2 indirect stages enabled, and uses indirect logic in TEV stage 1 (the indirect logic for TEV stages 0 and 2 are set to 0).  TEV stage 0 doesn't have any texture enabled, but TEV stage 1 uses its texture coordinates for add-to-previous coordinate functionality.  Since the more detailed indirect texture logic for stage 0 was now being skipped, the `else if (texture_enabled)` code was hit, and and since there was no texture, `tevcoord.xy` was never updated (and thus `tevcoord` was `(0, 0, 0)`).  This meant that stage 1 used the wrong texture coordinates since it the values from the previous stage were wrong.  (This is based on object 1 in the [nes-vc](https://fifo.ci/dff/nes-vc/) test case ([dff](https://fifo.ci/media/dff/NESVCtest.dff))).

I'm guessing the `texture_enabled` check was added because on first glance, it looks like `tevcoord` is only used when the texture is enabled on that stage (immediately below), and then that assumption being violated by add-to-previous was never noticed because the `tevind != 0u` previously always succeeded.

This `texture_enabled` issue existed since ubershaders were first implemented, but it only became visible when skipping indirect stages where the value is 0 was fixed.