### PR TITLE
Android: Don't use getEmulationActivity in GCAdapter/Wiimote code

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_GCAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_GCAdapter.java
@@ -1,6 +1,5 @@
 package org.dolphinemu.dolphinemu.utils;
 
-import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -16,7 +15,8 @@ import android.widget.Toast;
 
 import androidx.annotation.Keep;
 
-import org.dolphinemu.dolphinemu.NativeLibrary;
+import org.dolphinemu.dolphinemu.DolphinApplication;
+import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.services.USBPermService;
 
 import java.util.HashMap;
@@ -36,33 +36,25 @@ public class Java_GCAdapter
 
   private static void RequestPermission()
   {
-    Context context = NativeLibrary.getEmulationActivity();
-    if (context != null)
+    HashMap<String, UsbDevice> devices = manager.getDeviceList();
+    for (Map.Entry<String, UsbDevice> pair : devices.entrySet())
     {
-      HashMap<String, UsbDevice> devices = manager.getDeviceList();
-      for (Map.Entry<String, UsbDevice> pair : devices.entrySet())
+      UsbDevice dev = pair.getValue();
+      if (dev.getProductId() == 0x0337 && dev.getVendorId() == 0x057e)
       {
-        UsbDevice dev = pair.getValue();
-        if (dev.getProductId() == 0x0337 && dev.getVendorId() == 0x057e)
+        if (!manager.hasPermission(dev))
         {
-          if (!manager.hasPermission(dev))
-          {
-            Intent intent = new Intent(context, USBPermService.class);
+          Context context = DolphinApplication.getAppContext();
+          Intent intent = new Intent(context, USBPermService.class);
 
-            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ?
-                    PendingIntent.FLAG_IMMUTABLE : 0;
-            PendingIntent pendingIntent = PendingIntent.getService(context, 0, intent, flags);
+          int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ?
+                  PendingIntent.FLAG_IMMUTABLE : 0;
+          PendingIntent pendingIntent = PendingIntent.getService(context, 0, intent, flags);
 
-            manager.requestPermission(dev, pendingIntent);
-          }
+          manager.requestPermission(dev, pendingIntent);
         }
       }
     }
-    else
-    {
-      Log.warning("Cannot request GameCube Adapter permission as EmulationActivity is null.");
-    }
-
   }
 
   public static void Shutdown()
@@ -153,17 +145,8 @@ public class Java_GCAdapter
             }
           }
 
-          final Activity emulationActivity = NativeLibrary.getEmulationActivity();
-          if (emulationActivity != null)
-          {
-            emulationActivity.runOnUiThread(() -> Toast.makeText(emulationActivity,
-                    "GameCube Adapter couldn't be opened. Please re-plug the device.",
-                    Toast.LENGTH_LONG).show());
-          }
-          else
-          {
-            Log.warning("Cannot show toast for GameCube Adapter failure.");
-          }
+          Toast.makeText(DolphinApplication.getAppContext(), R.string.replug_gc_adapter,
+                  Toast.LENGTH_LONG).show();
           usb_con.close();
         }
       }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
@@ -13,7 +13,7 @@ import android.os.Build;
 
 import androidx.annotation.Keep;
 
-import org.dolphinemu.dolphinemu.NativeLibrary;
+import org.dolphinemu.dolphinemu.DolphinApplication;
 import org.dolphinemu.dolphinemu.services.USBPermService;
 
 import java.util.Arrays;
@@ -38,34 +38,27 @@ public class Java_WiimoteAdapter
 
   private static void RequestPermission()
   {
-    Context context = NativeLibrary.getEmulationActivity();
-    if (context != null)
+    HashMap<String, UsbDevice> devices = manager.getDeviceList();
+    for (Map.Entry<String, UsbDevice> pair : devices.entrySet())
     {
-      HashMap<String, UsbDevice> devices = manager.getDeviceList();
-      for (Map.Entry<String, UsbDevice> pair : devices.entrySet())
+      UsbDevice dev = pair.getValue();
+      if (dev.getProductId() == NINTENDO_WIIMOTE_PRODUCT_ID &&
+              dev.getVendorId() == NINTENDO_VENDOR_ID)
       {
-        UsbDevice dev = pair.getValue();
-        if (dev.getProductId() == NINTENDO_WIIMOTE_PRODUCT_ID &&
-                dev.getVendorId() == NINTENDO_VENDOR_ID)
+        if (!manager.hasPermission(dev))
         {
-          if (!manager.hasPermission(dev))
-          {
-            Log.warning("Requesting permission for Wii Remote adapter");
+          Log.warning("Requesting permission for Wii Remote adapter");
 
-            Intent intent = new Intent(context, USBPermService.class);
+          Context context = DolphinApplication.getAppContext();
+          Intent intent = new Intent(context, USBPermService.class);
 
-            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ?
-                    PendingIntent.FLAG_IMMUTABLE : 0;
-            PendingIntent pendingIntent = PendingIntent.getService(context, 0, intent, flags);
+          int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ?
+                  PendingIntent.FLAG_IMMUTABLE : 0;
+          PendingIntent pendingIntent = PendingIntent.getService(context, 0, intent, flags);
 
-            manager.requestPermission(dev, pendingIntent);
-          }
+          manager.requestPermission(dev, pendingIntent);
         }
       }
-    }
-    else
-    {
-      Log.warning("Cannot request Wiimote adapter permission as EmulationActivity is null.");
     }
   }
 

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -466,6 +466,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="default_values">Default Values</string>
     <string name="slider_setting_value">%1$d%2$s</string>
     <string name="disc_number">Disc %1$d</string>
+    <string name="replug_gc_adapter">GameCube Adapter couldn\'t be opened. Please re-plug the device.</string>
     <string name="disabled_gc_overlay_notice">GameCube Controller 1 is set to \"None\"</string>
     <string name="ignore_warning_alert_messages">Ignore for this session</string>
 


### PR DESCRIPTION
The app context (which can be obtained though `DolphinApplication.getAppContext()`) should work just as well as an activity context.

Also moving a hardcoded string to strings.xml.