### PR TITLE
GameINI:  Enable Single Core for Baten Kaitos: Eternal Wings and the Lost Ocean

### DIFF
--- a/Data/Sys/GameSettings/GKB.ini
+++ b/Data/Sys/GameSettings/GKB.ini
@@ -1,7 +1,10 @@
 # GKBEAF, GKBJAF, GKBPAF - Baten Kaitos Eternal Wings and the Lost Ocean
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# This game will crash when shopping with certain items in inventory
+# unless Single Core is enabled.
+CPUThread = False
+
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
This fixes crashes when attempting to shop with certain items in your inventory.  This can be observed with the picture of kalas found on this savefile.  Simply load the savefile and go to the building on the far left of the second screen.

[AF-GKBE-BKData-000.zip](https://github.com/dolphin-emu/dolphin/files/6705413/AF-GKBE-BKData-000.zip)

Dualcore, shortly before crashing.

![GKBEAF_2021-06-23_19-55-36](https://user-images.githubusercontent.com/6598209/123182461-7a125180-d45d-11eb-9269-788fdb965c55.png)

Single Core

![GKBEAF_2021-06-23_19-56-25](https://user-images.githubusercontent.com/6598209/123182430-6b2b9f00-d45d-11eb-9400-c19c9832d0ee.png)
