### PR TITLE
WiimoteScannerDarwin: fix hang on quit and clean up

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOAndroid.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOAndroid.h
@@ -48,6 +48,7 @@ public:
   bool IsReady() const override { return true; }
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}
+  void RequestStopSearching() override {}
 };
 }  // namespace WiimoteReal
 

--- a/Source/Core/Core/HW/WiimoteReal/IODummy.h
+++ b/Source/Core/Core/HW/WiimoteReal/IODummy.h
@@ -16,5 +16,6 @@ public:
   bool IsReady() const override { return false; }
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override {}
   void Update() override {}
+  void RequestStopSearching() override {}
 };
 }  // namespace WiimoteReal

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.h
@@ -47,6 +47,7 @@ public:
   bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}  // not needed on Linux
+  void RequestStopSearching() override {} // not needed on Linux
 private:
   int m_device_id;
   int m_device_sock;

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.h
@@ -46,8 +46,8 @@ public:
   ~WiimoteScannerLinux() override;
   bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
-  void Update() override {}  // not needed on Linux
-  void RequestStopSearching() override {} // not needed on Linux
+  void Update() override {}                // not needed on Linux
+  void RequestStopSearching() override {}  // not needed on Linux
 private:
   int m_device_id;
   int m_device_sock;

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.h
@@ -52,6 +52,7 @@ public:
   bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override;
+  void RequestStopSearching() override {}
 };
 }  // namespace WiimoteReal
 

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
@@ -24,6 +24,7 @@ public:
   bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}  // not needed
+  void RequestStopSearching() override { m_stop_scanning = true; }
 private:
   IOBluetoothHostController* m_host_controller;
   bool m_stop_scanning = false;

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
@@ -25,6 +25,7 @@ public:
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}  // not needed
   void RequestStopSearching() override { m_stop_scanning = true; }
+
 private:
   IOBluetoothHostController* m_host_controller;
   bool m_stop_scanning = false;

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
@@ -18,7 +18,7 @@ public:
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}  // not needed
 private:
-  bool stopScanning = false;
+  bool m_stop_scanning = false;
 };
 }  // namespace WiimoteReal
 

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
@@ -7,17 +7,25 @@
 #ifdef __APPLE__
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 
+#ifdef __OBJC__
+#import <IOBluetooth/IOBluetooth.h>
+#else
+// IOBluetooth's types won't be defined in pure C++ mode.
+typedef void IOBluetoothHostController;
+#endif
+
 namespace WiimoteReal
 {
 class WiimoteScannerDarwin final : public WiimoteScannerBackend
 {
 public:
-  WiimoteScannerDarwin() = default;
+  WiimoteScannerDarwin();
   ~WiimoteScannerDarwin() override;
   bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}  // not needed
 private:
+  IOBluetoothHostController* m_host_controller;
   bool m_stop_scanning = false;
 };
 }  // namespace WiimoteReal

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -21,27 +21,40 @@
 
 namespace WiimoteReal
 {
+WiimoteScannerDarwin::WiimoteScannerDarwin()
+{
+  m_host_controller = [IOBluetoothHostController defaultController];
+  if (![m_host_controller addressAsString])
+  {
+    WARN_LOG_FMT(WIIMOTE, "No Bluetooth host controller");
+    
+    [m_host_controller release];
+    m_host_controller = nil;
+    
+    return;
+  }
+  
+  [m_host_controller retain];
+}
+
 WiimoteScannerDarwin::~WiimoteScannerDarwin()
 {
+  [m_host_controller release];
+  m_host_controller = nil;
+  
   m_stop_scanning = true;
 }
 
 void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
                                         Wiimote*& found_board)
 {
-  // TODO: find the device in the constructor and save it for later
-  IOBluetoothHostController* bth;
-  IOBluetoothDeviceInquiry* bti;
-  found_board = nullptr;
-
-  bth = [[IOBluetoothHostController alloc] init];
-  bool btFailed = [bth addressAsString] == nil;
-  if (btFailed)
+  if (!m_host_controller)
   {
-    WARN_LOG_FMT(WIIMOTE, "No Bluetooth host controller");
-    [bth release];
     return;
   }
+  
+  IOBluetoothDeviceInquiry* bti;
+  found_board = nullptr;
 
   SearchBT* sbt = [[SearchBT alloc] init];
   sbt->maxDevices = 32;
@@ -52,7 +65,6 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
   if ([bti start] != kIOReturnSuccess)
   {
     ERROR_LOG_FMT(WIIMOTE, "Unable to do Bluetooth discovery");
-    [bth release];
     [sbt release];
     
     return;
@@ -86,16 +98,14 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
       found_wiimotes.push_back(wm);
     }
   }
-
-  [bth release];
+  
   [bti release];
   [sbt release];
 }
 
 bool WiimoteScannerDarwin::IsReady() const
 {
-  // TODO: only return true when a BT device is present
-  return true;
+  return m_host_controller != nil;
 }
 
 WiimoteDarwin::WiimoteDarwin(IOBluetoothDevice* device) : m_btd(device)

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -27,13 +27,13 @@ WiimoteScannerDarwin::WiimoteScannerDarwin()
   if (![m_host_controller addressAsString])
   {
     WARN_LOG_FMT(WIIMOTE, "No Bluetooth host controller");
-    
+
     [m_host_controller release];
     m_host_controller = nil;
-    
+
     return;
   }
-  
+
   [m_host_controller retain];
 }
 
@@ -41,7 +41,7 @@ WiimoteScannerDarwin::~WiimoteScannerDarwin()
 {
   [m_host_controller release];
   m_host_controller = nil;
-  
+
   m_stop_scanning = true;
 }
 
@@ -52,7 +52,7 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
   {
     return;
   }
-  
+
   IOBluetoothDeviceInquiry* bti;
   found_board = nullptr;
 
@@ -66,7 +66,7 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
   {
     ERROR_LOG_FMT(WIIMOTE, "Unable to do Bluetooth discovery");
     [sbt release];
-    
+
     return;
   }
 
@@ -98,7 +98,7 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
       found_wiimotes.push_back(wm);
     }
   }
-  
+
   [bti release];
   [sbt release];
 }

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -23,7 +23,7 @@ namespace WiimoteReal
 {
 WiimoteScannerDarwin::~WiimoteScannerDarwin()
 {
-  stopScanning = true;
+  m_stop_scanning = true;
 }
 
 void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
@@ -60,7 +60,7 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
   do
   {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
-  } while (!sbt->done && !stopScanning);
+  } while (!sbt->done && !m_stop_scanning);
 
   int found_devices = [[bti foundDevices] count];
 

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -54,7 +54,8 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
     ERROR_LOG_FMT(WIIMOTE, "Unable to do Bluetooth discovery");
     [bth release];
     [sbt release];
-    btFailed = true;
+    
+    return;
   }
 
   do

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin_private.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin_private.h
@@ -4,13 +4,6 @@
 
 #pragma once
 
-// Work around an Apple bug: for some reason, IOBluetooth.h errors on
-// inclusion in Mavericks, but only in Objective-C++ C++11 mode.  I filed
-// this as <rdar://15312520>; in the meantime...
-#import <Foundation/Foundation.h>
-#undef NS_ENUM_AVAILABLE
-#define NS_ENUM_AVAILABLE(...)
-// end hack
 #import <IOBluetooth/IOBluetooth.h>
 #include <IOKit/pwr_mgt/IOPMLib.h>
 

--- a/Source/Core/Core/HW/WiimoteReal/IOhidapi.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOhidapi.h
@@ -38,8 +38,8 @@ public:
   ~WiimoteScannerHidapi();
   bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
-  void Update() override {}  // not needed for hidapi
-  void RequestStopSearching() override {} // not needed for hidapi
+  void Update() override {}                // not needed for hidapi
+  void RequestStopSearching() override {}  // not needed for hidapi
 };
 }  // namespace WiimoteReal
 

--- a/Source/Core/Core/HW/WiimoteReal/IOhidapi.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOhidapi.h
@@ -39,6 +39,7 @@ public:
   bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}  // not needed for hidapi
+  void RequestStopSearching() override {} // not needed for hidapi
 };
 }  // namespace WiimoteReal
 

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -545,12 +545,12 @@ void WiimoteScanner::StopThread()
   if (m_scan_thread_running.TestAndClear())
   {
     SetScanMode(WiimoteScanMode::DO_NOT_SCAN);
-    
+
     for (const auto& backend : m_backends)
     {
       backend->RequestStopSearching();
     }
-    
+
     m_scan_thread.join();
   }
 }

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -545,6 +545,12 @@ void WiimoteScanner::StopThread()
   if (m_scan_thread_running.TestAndClear())
   {
     SetScanMode(WiimoteScanMode::DO_NOT_SCAN);
+    
+    for (const auto& backend : m_backends)
+    {
+      backend->RequestStopSearching();
+    }
+    
     m_scan_thread.join();
   }
 }

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -1,4 +1,4 @@
-﻿// Copyright 2008 Dolphin Emulator Project
+// Copyright 2008 Dolphin Emulator Project
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
@@ -155,6 +155,8 @@ public:
   virtual void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) = 0;
   // function called when not looking for more Wiimotes
   virtual void Update() = 0;
+  // requests the backend to stop scanning if FindWiimotes is blocking
+  virtual void RequestStopSearching() = 0;
 };
 
 enum class WiimoteScanMode


### PR DESCRIPTION
* Minor clean up on `WiimoteScannerDarwin`.
* Moved `IOBluetoothHostController` initialization to the constructor.
* Used `defaultController` to get an instance of `IOBluetoothHostController` instead of creating one manually (`[[IOBluetoothHostController alloc] init]` is not mentioned anywhere in documentation, seems to work by coincidence).
* Removes a hack that only applies to old macOS SDKs.
* Fixes a potential issue where Wiimote scanning would continue even if `[IOBluetoothDeviceInquiry start]` returns an error.
* Fixes Dolphin hanging on quit if Continuous Scanning is enabled and no Wiimote was ever connected. ([#12424](https://bugs.dolphin-emu.org/issues/12424))

Tested on MBP 16" (2019), macOS Big Sur 11.4, Xcode 12.5. Continuous Scanning still works and I was able to play a game of Wii Sports tennis just fine.