### PR TITLE
Partially revert "Android: Clean up some hardcoded strings"

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/SyncChannelJobService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/SyncChannelJobService.java
@@ -85,7 +85,7 @@ public class SyncChannelJobService extends JobService
       }
       else
       {
-        subscriptions = TvUtil.createUniversalSubscriptions(context);
+        subscriptions = TvUtil.createUniversalSubscriptions();
         for (HomeScreenChannel subscription : subscriptions)
         {
           long channelId = createChannel(subscription);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/SyncProgramsJobService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/SyncProgramsJobService.java
@@ -96,8 +96,7 @@ public class SyncProgramsJobService extends JobService
           Channel channel = TvUtil.getChannelById(context, channelId);
           for (Platform platform : Platform.values())
           {
-            if (channel != null &&
-                    channel.getAppLinkIntentUri().equals(AppLinkHelper.buildBrowseUri(platform)))
+            if (channel != null && channel.getDisplayName().equals(platform.getIdString()))
             {
               getGamesByPlatform(platform);
               syncPrograms(channelId);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
@@ -251,19 +251,21 @@ public class TvUtil
   /**
    * Generates all subscriptions for homescreen channels.
    */
-  public static List<HomeScreenChannel> createUniversalSubscriptions(Context context)
+  public static List<HomeScreenChannel> createUniversalSubscriptions()
   {
-    return new ArrayList<>(createPlatformSubscriptions(context));
+    return new ArrayList<>(createPlatformSubscriptions());
   }
 
-  private static List<HomeScreenChannel> createPlatformSubscriptions(Context context)
+  private static List<HomeScreenChannel> createPlatformSubscriptions()
   {
     List<HomeScreenChannel> subs = new ArrayList<>();
     for (Platform platform : Platform.values())
     {
+      // TODO: Replace the getIdString calls with getHeaderName to get localized names.
+      // This would require SyncProgramsJobService to stop using the display name as a key
       subs.add(new HomeScreenChannel(
-              context.getString(platform.getHeaderName()),
-              context.getString(platform.getHeaderName()),
+              platform.getIdString(),
+              platform.getIdString(),
               AppLinkHelper.buildBrowseUri(platform)));
     }
     return subs;


### PR DESCRIPTION
This partially reverts commit cbc4989095baff7b84694802bb195c0c79d56ebe of PR #9835 due to a crash: https://bugs.dolphin-emu.org/issues/12561

I can't debug what the cause of the crash is due to not having an Android TV device. Let's just revert this for now to fix the crash.