### PR TITLE
[PoC] SW: Implement uninitialized vertex component behavior

### DIFF
--- a/Source/Core/VideoBackends/Software/SWVertexLoader.h
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <vector>
 
@@ -14,11 +15,37 @@
 
 #include "VideoCommon/VertexManagerBase.h"
 
+// There is somewhat odd behavior where uninitialized components use values from 16 vertices ago
+// (only counting vertices that had initialized data).
+template <typename T>
+struct CacheEntry
+{
+  static constexpr auto CACHE_SIZE = 16;
+
+  std::array<T, CACHE_SIZE> data;
+  u8 index;
+
+  T Read() { return data[index]; }
+  void Write(const T& value)
+  {
+    data[index] = value;
+    index = (index + 1) % CACHE_SIZE;
+  }
+};
+
+struct CachedData
+{
+  CacheEntry<Vec3> position;
+  std::array<CacheEntry<Vec3>, 3> normal;
+  std::array<CacheEntry<std::array<u8, 4>>, 2> color;
+  std::array<CacheEntry<std::array<float, 2>>, 8> texCoords;
+};
+
 class SWVertexLoader final : public VertexManagerBase
 {
 public:
-  SWVertexLoader();
-  ~SWVertexLoader();
+  SWVertexLoader() = default;
+  ~SWVertexLoader() = default;
 
 protected:
   void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
@@ -28,4 +55,5 @@ protected:
 
   InputVertexData m_vertex;
   SetupUnit m_setup_unit;
+  CachedData m_cache;
 };


### PR DESCRIPTION
A proof of concept implementation for the uninitialized vertex behavior (what happens when you try to use color 0 or color 1 when it's not specified in the vertex descriptor and not overridden by a material color).  This implementation only exists for the software renderer.  [Here](https://gist.github.com/Pokechu22/1e79aadcf1d0d77c1816884ba725cb06) is the hardware test, but this is something where I could probably write an automated test for the [hwtests repo](https://github.com/dolphin-emu/hwtests/).

The basic explanation is that each component is tracked in an array with 16 elements, and if an uninitialized value is used, the value from 16 vertices ago is used (but the index only changes when the value is present).  This is tracked separately for each component.  I can't think of a reason why it'd be implemented that way on hardware, but it still seems to be.

This should produce the same results as #9532 in most cases, as in the majority of cases, the previous vertices were white.  The only exception I'm currently aware of are some custom smash characters, where the new result should be accurate to what happens on hardware.

Some notes:
* This **does not fix** the debug cubes in Super Mario Sunshine.  This kind of behavior seems like it's the perfect candidate for causing it, but it's inconsistent with the actual behavior; there's still some other thing that's not discovered.
* This doesn't implement the behavior when `GX_SetNumChans` (which affects the bp genmode) is less than the number of used colors either.  That has its own set of oddities, but I'm fairly sure it's not what affects Sunshine either.
* I have only tested this behavior with color 0 and color 1 on hardware, but assume it also affects position, texture coordinates, and normals.  I got bad results when applying it to the position and texture coordinate matrix indices (which seem to have default values specified in xfmem).