### PR TITLE
Jit64: mtfsfx - Optimized masking

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -792,10 +792,13 @@ void Jit64::mtfsfx(UGeckoInstruction inst)
   else
     MOV(32, R(RSCRATCH), Rb);
 
-  MOV(32, R(RSCRATCH2), PPCSTATE(fpscr));
-  AND(32, R(RSCRATCH), Imm32(mask));
-  AND(32, R(RSCRATCH2), Imm32(~mask));
-  OR(32, R(RSCRATCH), R(RSCRATCH2));
+  if (mask != 0xFFFFFFFF)
+  {
+    MOV(32, R(RSCRATCH2), PPCSTATE(fpscr));
+    AND(32, R(RSCRATCH), Imm32(mask));
+    AND(32, R(RSCRATCH2), Imm32(~mask));
+    OR(32, R(RSCRATCH), R(RSCRATCH2));
+  }
   MOV(32, PPCSTATE(fpscr), R(RSCRATCH));
 
   if (inst.FM & 1)


### PR DESCRIPTION
The masking logic can be eliminated when the mask is known to be all ones. This case is very common.

In fact, it's so common that I haven't been able to find instances of this instruction where this did not apply. Similar optimizations could be done for `mask == 0`, but, well, do games actually do this?

---

<details><summary>Example</summary>

Before:
```
66 48 0F 7E F0       movq        rax,xmm6
8B 55 5C             mov         edx,dword ptr [rbp+5Ch]
83 E0 FF             and         eax,0FFFFFFFFh
83 E2 00             and         edx,0
0B C2                or          eax,edx
89 45 5C             mov         dword ptr [rbp+5Ch],eax
48 8D 15 C3 3C FE 01 lea         rdx,[19520020h]
83 E0 07             and         eax,7
0F AE 14 82          ldmxcsr     dword ptr [rdx+rax*4]
```

After:
```
66 48 0F 7E F0       movq        rax,xmm6
89 45 5C             mov         dword ptr [rbp+5Ch],eax
48 8D 15 2A D1 FD 01 lea         rdx,[19440000h]
83 E0 07             and         eax,7
0F AE 14 82          ldmxcsr     dword ptr [rdx+rax*4]
```
</details>