### PR TITLE
Config: Add an ini setting to control real Wii Remote report duplication.

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -109,6 +109,8 @@ const Info<DiscIO::Region> MAIN_FALLBACK_REGION{{System::Main, "Core", "Fallback
 const Info<bool> MAIN_AUTO_DISC_CHANGE{{System::Main, "Core", "AutoDiscChange"}, false};
 const Info<bool> MAIN_ALLOW_SD_WRITES{{System::Main, "Core", "WiiSDCardAllowWrites"}, true};
 const Info<bool> MAIN_ENABLE_SAVESTATES{{System::Main, "Core", "EnableSaveStates"}, false};
+const Info<bool> MAIN_REAL_WII_REMOTE_REPEAT_REPORTS{
+    {System::Main, "Core", "RealWiiRemoteRepeatReports"}, true};
 
 // Main.Display
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -87,6 +87,7 @@ extern const Info<bool> MAIN_AUTO_DISC_CHANGE;
 extern const Info<bool> MAIN_ALLOW_SD_WRITES;
 extern const Info<bool> MAIN_ENABLE_SAVESTATES;
 extern const Info<DiscIO::Region> MAIN_FALLBACK_REGION;
+extern const Info<bool> MAIN_REAL_WII_REMOTE_REPEAT_REPORTS;
 
 // Main.DSP
 

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -26,7 +26,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
 
   if (config_location.system == Config::System::Main)
   {
-    for (const std::string& section :
+    for (const std::string_view section :
          {"NetPlay", "General", "Display", "Network", "Analytics", "AndroidOverlayButtons"})
     {
       if (config_location.section == section)
@@ -47,7 +47,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
     }
   }
 
-  static constexpr std::array<const Config::Location*, 17> s_setting_saveable = {
+  static constexpr auto s_setting_saveable = {
       // Main.Core
 
       &Config::MAIN_DEFAULT_ISO.GetLocation(),
@@ -63,6 +63,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_GFX_BACKEND.GetLocation(),
       &Config::MAIN_ENABLE_SAVESTATES.GetLocation(),
       &Config::MAIN_FALLBACK_REGION.GetLocation(),
+      &Config::MAIN_REAL_WII_REMOTE_REPEAT_REPORTS.GetLocation(),
 
       // Main.Interface
 
@@ -78,7 +79,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_USE_DISCORD_PRESENCE.GetLocation(),
   };
 
-  return std::any_of(s_setting_saveable.cbegin(), s_setting_saveable.cend(),
+  return std::any_of(begin(s_setting_saveable), end(s_setting_saveable),
                      [&config_location](const Config::Location* location) {
                        return *location == config_location;
                      });

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -16,6 +16,7 @@
 #include "Common/IniFile.h"
 #include "Common/Swap.h"
 #include "Common/Thread.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/Wiimote.h"
@@ -437,12 +438,17 @@ void Wiimote::Update()
 {
   // Wii remotes send input at 200hz once a Wii enables "sniff mode" on the connection.
   // PC bluetooth stacks do not enable sniff mode causing remotes to send input at only 100hz.
+  //
   // Commercial games do not send speaker data unless input rates approach 200hz.
+  // Some games will also present input issues.
+  // e.g. Super Mario Galaxy's star cursor drops in and out.
+  //
   // If we want speaker data we must pretend input is at 200hz.
   // We duplicate data reports to accomplish this.
   // Unfortunately this breaks detection of motion gestures in some games.
   // e.g. Sonic and the Secret Rings, Jett Rocket
-  const bool repeat_reports_to_maintain_200hz = SConfig::GetInstance().m_WiimoteEnableSpeaker;
+  const bool repeat_reports_to_maintain_200hz =
+      Config::Get(Config::MAIN_REAL_WII_REMOTE_REPEAT_REPORTS);
 
   const Report& rpt = ProcessReadQueue(repeat_reports_to_maintain_200hz);
 


### PR DESCRIPTION
It is enabled by default.

Untested.

This should unbreak input in Super Mario Galaxy.

It will also re-break gestures in "Jett Rocket" and "Sonic and the Secret Rings".
Game INIs should be updated.