### PR TITLE
x64Emitter: remove unused x87 instructions

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -3399,56 +3399,6 @@ void XEmitter::GSOverride()
   Write8(0x65);
 }
 
-void XEmitter::FWAIT()
-{
-  Write8(0x9B);
-}
-
-// TODO: make this more generic
-void XEmitter::WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, const OpArg& arg)
-{
-  int mf = 0;
-  ASSERT_MSG(DYNA_REC, !(bits == 80 && op_80b == FloatOp::Invalid),
-             "WriteFloatLoadStore: 80 bits not supported for this instruction");
-  switch (bits)
-  {
-  case 32:
-    mf = 0;
-    break;
-  case 64:
-    mf = 4;
-    break;
-  case 80:
-    mf = 2;
-    break;
-  default:
-    ASSERT_MSG(DYNA_REC, 0, "WriteFloatLoadStore: invalid bits (should be 32/64/80)");
-  }
-  Write8(0xd9 | mf);
-  // x87 instructions use the reg field of the ModR/M byte as opcode:
-  if (bits == 80)
-    op = op_80b;
-  arg.WriteRest(this, 0, static_cast<X64Reg>(op));
-}
-
-void XEmitter::FLD(int bits, const OpArg& src)
-{
-  WriteFloatLoadStore(bits, FloatOp::LD, FloatOp::LD80, src);
-}
-void XEmitter::FST(int bits, const OpArg& dest)
-{
-  WriteFloatLoadStore(bits, FloatOp::ST, FloatOp::Invalid, dest);
-}
-void XEmitter::FSTP(int bits, const OpArg& dest)
-{
-  WriteFloatLoadStore(bits, FloatOp::STP, FloatOp::STP80, dest);
-}
-void XEmitter::FNSTSW_AX()
-{
-  Write8(0xDF);
-  Write8(0xE0);
-}
-
 void XEmitter::RDTSC()
 {
   Write8(0x0F);

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -374,7 +374,6 @@ private:
   void WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg,
                    int extrabytes = 0);
   void WriteMOVBE(int bits, u8 op, X64Reg regOp, const OpArg& arg);
-  void WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, const OpArg& arg);
   void WriteNormalOp(int bits, NormalOp op, const OpArg& a1, const OpArg& a2);
 
   void ABI_CalculateFrameSize(BitSet32 mask, size_t rsp_alignment, size_t needed_frame_size,
@@ -580,31 +579,6 @@ public:
   void REPNE();
   void FSOverride();
   void GSOverride();
-
-  // x87
-  enum x87StatusWordBits
-  {
-    x87_InvalidOperation = 0x1,
-    x87_DenormalizedOperand = 0x2,
-    x87_DivisionByZero = 0x4,
-    x87_Overflow = 0x8,
-    x87_Underflow = 0x10,
-    x87_Precision = 0x20,
-    x87_StackFault = 0x40,
-    x87_ErrorSummary = 0x80,
-    x87_C0 = 0x100,
-    x87_C1 = 0x200,
-    x87_C2 = 0x400,
-    x87_TopOfStack = 0x2000 | 0x1000 | 0x800,
-    x87_C3 = 0x4000,
-    x87_FPUBusy = 0x8000,
-  };
-
-  void FLD(int bits, const OpArg& src);
-  void FST(int bits, const OpArg& dest);
-  void FSTP(int bits, const OpArg& dest);
-  void FNSTSW_AX();
-  void FWAIT();
 
   // SSE/SSE2: Floating point arithmetic
   void ADDSS(X64Reg regOp, const OpArg& arg);

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -34,9 +34,7 @@ alignas(16) static const __m128i double_bottom_bits = _mm_set_epi64x(0, 0x07ffff
 
 // Since the following float conversion functions are used in non-arithmetic PPC float
 // instructions, they must convert floats bitexact and never flush denormals to zero or turn SNaNs
-// into QNaNs. This means we can't use CVTSS2SD/CVTSD2SS. The x87 FPU doesn't even support
-// flush-to-zero so we can use FLD+FSTP even on denormals.
-// If the number is a NaN, make sure to set the QNaN bit back to its original value.
+// into QNaNs. This means we can't use CVTSS2SD/CVTSD2SS.
 
 // Another problem is that officially, converting doubles to single format results in undefined
 // behavior.  Relying on undefined behavior is a bug so no software should ever do this.

--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -199,8 +199,6 @@ TEST_INSTR_NO_OPERANDS(CBW, "cbw")
 TEST_INSTR_NO_OPERANDS(CWDE, "cwde")
 TEST_INSTR_NO_OPERANDS(CDQE, "cdqe")
 TEST_INSTR_NO_OPERANDS(XCHG_AHAL, "xchg al, ah")
-TEST_INSTR_NO_OPERANDS(FWAIT, "fwait")
-TEST_INSTR_NO_OPERANDS(FNSTSW_AX, "fnstsw ax")
 TEST_INSTR_NO_OPERANDS(RDTSC, "rdtsc")
 
 TEST_F(x64EmitterTest, NOP_MultiByte)
@@ -747,30 +745,6 @@ TEST_F(x64EmitterTest, LDMXCSR)
 {
   emitter->LDMXCSR(MatR(R12));
   ExpectDisassembly("ldmxcsr dword ptr ds:[r12]");
-}
-
-TEST_F(x64EmitterTest, FLD_FST_FSTP)
-{
-  emitter->FLD(32, MatR(RBP));
-  emitter->FLD(64, MatR(RBP));
-  emitter->FLD(80, MatR(RBP));
-
-  emitter->FST(32, MatR(RBP));
-  emitter->FST(64, MatR(RBP));
-  // No 80 bit version of FST
-
-  emitter->FSTP(32, MatR(RBP));
-  emitter->FSTP(64, MatR(RBP));
-  emitter->FSTP(80, MatR(RBP));
-
-  ExpectDisassembly("fld dword ptr ss:[rbp] "
-                    "fld qword ptr ss:[rbp] "
-                    "fld tbyte ptr ss:[rbp] "
-                    "fst dword ptr ss:[rbp] "
-                    "fst qword ptr ss:[rbp] "
-                    "fstp dword ptr ss:[rbp] "
-                    "fstp qword ptr ss:[rbp] "
-                    "fstp tbyte ptr ss:[rbp]");
 }
 
 #define TWO_OP_SSE_TEST(Name, MemBits)                                                             \


### PR DESCRIPTION
The x87 instructions haven't been used outside of unit tests since 2795376b61371069ef2949eb31dbbddd7d9e209c and I doubt we'll find a new use.