### PR TITLE
DVDInterface: Fix decrypting reads clearing the drive state

### DIFF
--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -1251,7 +1251,9 @@ void PerformDecryptingRead(u32 position, u32 length, u32 output_address,
                            const DiscIO::Partition& partition, ReplyType reply_type)
 {
   DIInterruptType interrupt_type = DIInterruptType::TCINT;
-  SetDriveState(DriveState::Ready);
+
+  if (s_drive_state == DriveState::ReadyNoReadsMade)
+    SetDriveState(DriveState::Ready);
 
   const bool command_handled_by_thread =
       ExecuteReadCommand(static_cast<u64>(position) << 2, output_address, length, length, partition,


### PR DESCRIPTION
This broke ejecting Wii discs while the game is running, as the drive state was set to Ready even when no disc was present, but other code still reported the missing disc, which confused games as you can't be both ready to read and have no disc.  That would cause games to show an unrecoverable error screen, instead of a "please insert the game disc" screen.

This only affected Wii games; the GameCube games used regular disc reads which worked fine.

This issue was introduced in #8571.  Oops.  I only noticed it now when testing #9848.

Tested with a few different Wii games (Kirby's Dream Collection, NSMBW, Kirby's Epic Yarn), and also with some GameCube games (Paper Mario: TTYD, and the [GameCube Preview Disc](https://wiki.dolphin-emu.org/index.php?title=Nintendo_GameCube_Preview_Disc)).  I tested by ejecting the disc while the game was running, and then using change disc with the wrong disc, and then ejecting again and switching back to the correct disc; normal gameplay should resume.  (The Viewtiful Joe demo on the Preview Disc lost its background music after doing this, but I confirmed that that also happens on console.  That doesn't apply to the music for the preview disc menu, which _does_ come back after reinserting the correct disc.)