### PR TITLE
SI: Don't cancel transfer with TSTART=0

### DIFF
--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -511,12 +511,10 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                    // be careful: run si-buffer after updating the INT flags
                    if (tmp_com_csr.TSTART)
                    {
+                     if (s_com_csr.TSTART)
+                       CoreTiming::RemoveEvent(s_tranfer_pending_event);
                      s_com_csr.TSTART = 1;
                      RunSIBuffer(0, 0);
-                   }
-                   else if (s_com_csr.TSTART)
-                   {
-                     CoreTiming::RemoveEvent(s_tranfer_pending_event);
                    }
 
                    if (!s_com_csr.TSTART)


### PR DESCRIPTION
As far as I can tell there is no such thing as transfer cancelling, I don't know where that came from. This hasn't been an issue so far because Dolphin's transfer are instantaneous except for GBAs
This was confirmed on hardware with
```
printf("start csr %08X buf %08X%08X\n", *si_comcsr, si_buffer[0], si_buffer[1]);
si_buffer[0] = 0; *si_comcsr = 0x40010303;
printf("started csr %08X buf %08X%08X\n", *si_comcsr, si_buffer[0], si_buffer[1]);
*si_comcsr &= ~SICOMCSR_TSTART;
printf("cancelled csr %08X buf %08X%08X\n", *si_comcsr, si_buffer[0], si_buffer[1]);
while(*si_comcsr & SICOMCSR_TSTART);
printf("waited csr %08X buf %08X%08X\n", *si_comcsr, si_buffer[0], si_buffer[1]);
```
![image](https://user-images.githubusercontent.com/40473493/123697228-f1305700-d85c-11eb-9477-0716fa54d325.png)
