### PR TITLE
DiscIO: Store partition key directly in ReuseID

### DIFF
--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -1305,7 +1305,7 @@ WIARVZFileReader<RVZ>::ProcessAndCompress(CompressThreadState* state, CompressPa
     std::vector<u8>& data = parameters.data;
 
     if (AllSame(data))
-      entry.reuse_id = ReuseID{nullptr, data.size(), false, data.front()};
+      entry.reuse_id = ReuseID{WiiKey{}, data.size(), false, data.front()};
 
     if constexpr (RVZ)
     {
@@ -1344,7 +1344,7 @@ WIARVZFileReader<RVZ>::ProcessAndCompress(CompressThreadState* state, CompressPa
     const auto create_reuse_id = [&partition_entry, blocks,
                                   blocks_per_chunk](u8 value, bool encrypted, u64 block) {
       const u64 size = std::min(blocks - block, blocks_per_chunk) * VolumeWii::BLOCK_DATA_SIZE;
-      return ReuseID{&partition_entry.partition_key, size, encrypted, value};
+      return ReuseID{partition_entry.partition_key, size, encrypted, value};
     };
 
     const u8* parameters_data_end = parameters.data.data() + parameters.data.size();

--- a/Source/Core/DiscIO/WIABlob.h
+++ b/Source/Core/DiscIO/WIABlob.h
@@ -258,7 +258,7 @@ private:
 
 #undef COMPARE_TIED
 
-    const WiiKey* partition_key;
+    WiiKey partition_key;
     u64 data_size;
     bool encrypted;
     u8 value;


### PR DESCRIPTION
~The main reason I'm making this change is to avoid the ICE mentioned in https://github.com/dolphin-emu/dolphin/commit/e5b9e1ba1f7a8c7a48671f947cf096e0f4cb0fe9#r51445090, but there is also the advantage that~ this lets us reuse blocks in the case where different partition entries use the same key (which probably isn't actually all that common).