### PR TITLE
JitArm64: Fix MSVC warning '~': zero extending 'u32' to 'u64'

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -714,7 +714,8 @@ void JitArm64::mcrfs(UGeckoInstruction inst)
 
   if (mask != 0)
   {
-    ANDI2R(WA, WA, ~mask);
+    const u32 inverted_mask = ~mask;
+    ANDI2R(WA, WA, inverted_mask);
     STR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(fpscr));
   }
 


### PR DESCRIPTION
While the third parameter of ANDI2R is u64, the upper half of it does not get read if we're emitting a 32-bit instruction (which we are doing here).