### PR TITLE
UpdaterCommon: Fix code signing error after updating on macOS

### DIFF
--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -460,7 +460,7 @@ bool UpdateFiles(const std::vector<TodoList::UpdateOp>& to_update,
     std::string content_filename = HexEncode(op.new_hash.data(), op.new_hash.size());
     fprintf(log_fp, "Updating file %s from content %s...\n", op.filename.c_str(),
             content_filename.c_str());
-    if (!File::Copy(temp_path + DIR_SEP + content_filename, path))
+    if (!File::Rename(temp_path + DIR_SEP + content_filename, path))
     {
       fprintf(log_fp, "Could not update file %s.\n", op.filename.c_str());
       return false;


### PR DESCRIPTION
Upon launching an app, macOS's kernel caches all code signatures from the main executable and any frameworks it uses.  When the updater notices a file needs to be updated, it uses ``File::Copy()``, which reads the contents of the new file and writes it over the contents of the old file. This operation does *not* invalidate the code signature cache. Therefore, when Dolphin is launched after the update operation is complete, the cached code signature is used to validate the new files. macOS then proceeds to kill Dolphin due to a code signing error.

The solution: Use Rename instead of Copy.


([Thanks to Quinn from the Apple Developer Forums for making a post about this quirk](https://developer.apple.com/forums/thread/130313?answerId=410704022#410704022).

Also, this PR only fixes one issue with the macOS updater. If the bundle has the ``com.apple.quarantine`` xattr set, then the updater may fail to launch. #8915 fixes this issue.)