### PR TITLE
Add sharp bilinear postprocessing shader.

### DIFF
--- a/Data/Sys/Shaders/sharp_bilinear.glsl
+++ b/Data/Sys/Shaders/sharp_bilinear.glsl
@@ -1,0 +1,47 @@
+// Based on https://github.com/libretro/slang-shaders/blob/master/interpolation/shaders/sharp-bilinear.slang
+// by Themaister, Public Domain license
+// Does a bilinear stretch, with a preapplied Nx nearest-neighbor scale,
+// giving a sharper image than plain bilinear.
+
+/*
+[configuration]
+[OptionRangeFloat]
+GUIName = Prescale Factor (set to 0 for automatic)
+OptionName = PRESCALE_FACTOR
+MinValue = 0.0
+MaxValue = 16.0
+StepAmount = 1.0
+DefaultValue = 0.0
+[/configuration]
+*/
+
+float CalculatePrescale(float config_scale) {
+  if (config_scale == 0.0) {
+    float2 source_size = GetResolution();
+    float2 window_size = GetWindowResolution();
+    return ceil(max(window_size.x / source_size.x, window_size.y / source_size.y));
+  } else {
+    return config_scale;
+  }
+}
+
+void main()
+{
+  float2 source_size = GetResolution();
+  float2 texel = GetCoordinates() * source_size;
+  float2 texel_floored = floor(texel);
+  float2 s = fract(texel);
+  float config_scale = GetOption(PRESCALE_FACTOR);
+  float scale = CalculatePrescale(config_scale);
+  float region_range = 0.5 - 0.5 / scale;
+
+  // Figure out where in the texel to sample to get correct pre-scaled bilinear.
+  // Uses the hardware bilinear interpolator to avoid having to sample 4 times manually.
+
+  float2 center_dist = s - 0.5;
+  float2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * scale + 0.5;
+
+  float2 mod_texel = texel_floored + f;
+
+  SetOutput(SampleLocation(mod_texel / source_size));
+}


### PR DESCRIPTION
Attempt at porting [this shader](https://github.com/libretro/slang-shaders/blob/master/interpolation/shaders/sharp-bilinear.slang) to Dolphin, for those who prefer a more pixel-y look. Honestly it looks pretty bad to me for 3D games, but ymmv.

I'm not sure this algorithm is completely correct; I attempted to do the equivalent with ImageMagick like this:

```
magick RSBP01_2021-07-04_01-56-21.png -scale 1920x1704! native_scaled_point.png
magick native_scaled_point.png -filter triangle -resize 1920x1096! native_scaled_final.png
```

and the resulting image is slightly different. So... not sure. I'll need to experiment a bit more so I actually understand how this code works, I think.

For reference:

[Native resolution screenshot](https://user-images.githubusercontent.com/4522237/124371142-36022680-dc7f-11eb-8114-5c30dd9c2d02.png)
[As displayed by Dolphin](https://user-images.githubusercontent.com/4522237/124371143-38fd1700-dc7f-11eb-9f0c-3015f0c90196.png)
[As displayed by Dolphin if we were to force point filtering](https://user-images.githubusercontent.com/4522237/124371144-3a2e4400-dc7f-11eb-8f60-bf8a67503cb3.png)
[As displayed by Dolphin with this shader](https://user-images.githubusercontent.com/4522237/124371146-3a2e4400-dc7f-11eb-8372-a958394b5dd9.png)
[As scaled by ImageMagick](https://user-images.githubusercontent.com/4522237/124371148-3ac6da80-dc7f-11eb-8f53-9c8843227151.png)


Oh, and the postproc shader config system seems to be completely broken, they fail to compile if they have an option. Someone should probably look at that...