### PR TITLE
Ignore the top bit of the indirect texture matrix scale

### DIFF
--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -375,7 +375,10 @@ union IND_MTXC
 {
   BitField<0, 11, s32> me;
   BitField<11, 11, s32> mf;
-  BitField<22, 2, u8, u32> s2;  // bits 4-5 of scale factor
+  BitField<22, 1, u8, u32> s2;  // bit 4 of scale factor
+  // The SDK treats the scale factor as 6 bits, 2 on each column; however, hardware seems to ignore
+  // the top bit.
+  BitField<22, 2, u8, u32> sdk_s2;
   u32 hex;
 };
 

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -362,6 +362,20 @@ union IND_MTXA
   BitField<22, 2, u8, u32> s0;  // bits 0-1 of scale factor
   u32 hex;
 };
+template <>
+struct fmt::formatter<IND_MTXA>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const IND_MTXA& col, FormatContext& ctx)
+  {
+    return format_to(ctx.out(),
+                     "Row 0 (ma): {} ({})\n"
+                     "Row 1 (mb): {} ({})\n"
+                     "Scale bits: {} (shifted: {})",
+                     col.ma / 1024.0f, col.ma, col.mb / 1024.0f, col.mb, col.s0, col.s0);
+  }
+};
 
 union IND_MTXB
 {
@@ -369,6 +383,20 @@ union IND_MTXB
   BitField<11, 11, s32> md;
   BitField<22, 2, u8, u32> s1;  // bits 2-3 of scale factor
   u32 hex;
+};
+template <>
+struct fmt::formatter<IND_MTXB>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const IND_MTXB& col, FormatContext& ctx)
+  {
+    return format_to(ctx.out(),
+                     "Row 0 (mc): {} ({})\n"
+                     "Row 1 (md): {} ({})\n"
+                     "Scale bits: {} (shifted: {})",
+                     col.mc / 1024.0f, col.mc, col.md / 1024.0f, col.md, col.s1, col.s1 << 2);
+  }
 };
 
 union IND_MTXC
@@ -380,6 +408,21 @@ union IND_MTXC
   // the top bit.
   BitField<22, 2, u8, u32> sdk_s2;
   u32 hex;
+};
+template <>
+struct fmt::formatter<IND_MTXC>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const IND_MTXC& col, FormatContext& ctx)
+  {
+    return format_to(ctx.out(),
+                     "Row 0 (me): {} ({})\n"
+                     "Row 1 (mf): {} ({})\n"
+                     "Scale bits: {} (shifted: {}), given to SDK as {} ({})",
+                     col.me / 1024.0f, col.me, col.mf / 1024.0f, col.mf, col.s2, col.s2 << 4,
+                     col.sdk_s2, col.sdk_s2 << 4);
+  }
 };
 
 struct IND_MTX

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -764,35 +764,25 @@ std::pair<std::string, std::string> GetBPRegInfo(u8 cmd, u32 cmddata)
     // TODO: Description
 
   case BPMEM_IND_MTXA:  // 0x06
-  case BPMEM_IND_MTXB:  // 0x07
-  case BPMEM_IND_MTXC:  // 0x08
   case BPMEM_IND_MTXA + 3:
-  case BPMEM_IND_MTXB + 3:
-  case BPMEM_IND_MTXC + 3:
   case BPMEM_IND_MTXA + 6:
+    return std::make_pair(fmt::format("BPMEM_IND_MTXA Matrix {}", (cmd - BPMEM_IND_MTXA) / 3),
+                          fmt::format("Matrix {} column A\n{}", (cmd - BPMEM_IND_MTXA) / 3,
+                                      IND_MTXA{.hex = cmddata}));
+
+  case BPMEM_IND_MTXB:  // 0x07
+  case BPMEM_IND_MTXB + 3:
   case BPMEM_IND_MTXB + 6:
+    return std::make_pair(fmt::format("BPMEM_IND_MTXB Matrix {}", (cmd - BPMEM_IND_MTXB) / 3),
+                          fmt::format("Matrix {} column B\n{}", (cmd - BPMEM_IND_MTXB) / 3,
+                                      IND_MTXB{.hex = cmddata}));
+
+  case BPMEM_IND_MTXC:  // 0x08
+  case BPMEM_IND_MTXC + 3:
   case BPMEM_IND_MTXC + 6:
-  {
-    const u32 matrix_num = (cmd - BPMEM_IND_MTXA) / 3;
-    const u32 matrix_col = (cmd - BPMEM_IND_MTXA) % 3;
-    // These all use the same structure, though the meaning is *slightly* different;
-    // for conveninece implement it only once
-    const s32 row0 = cmddata & 0x0007ff;           // ma or mc or me
-    const s32 row1 = (cmddata & 0x3ff800) >> 11;   // mb or md or mf
-    const u32 scale = (cmddata & 0xc00000) >> 22;  // 2 bits of a 6-bit field for each column
-
-    const float row0f = static_cast<float>(row0) / (1 << 10);
-    const float row1f = static_cast<float>(row0) / (1 << 10);
-
-    return std::make_pair(fmt::format("BPMEM_IND_MTX{} Matrix {}", "ABC"[matrix_col], matrix_num),
-                          fmt::format("Matrix {} column {} ({})\n"
-                                      "Row 0 (m{}): {} ({})\n"
-                                      "Row 1 (m{}): {} ({})\n"
-                                      "Scale bits: {} (shifted: {})",
-                                      matrix_num, matrix_col, "ABC"[matrix_col], "ace"[matrix_col],
-                                      row0f, row0, "bdf"[matrix_col], row1f, row1, scale,
-                                      scale << (2 * matrix_col)));
-  }
+    return std::make_pair(fmt::format("BPMEM_IND_MTXC Matrix {}", (cmd - BPMEM_IND_MTXC) / 3),
+                          fmt::format("Matrix {} column C\n{}", (cmd - BPMEM_IND_MTXC) / 3,
+                                      IND_MTXC{.hex = cmddata}));
 
   case BPMEM_IND_IMASK:  // 0x0F
     return DescriptionlessReg(BPMEM_IND_IMASK);


### PR DESCRIPTION
This PR replaces #9861; from that:

> This fixes the appearance of Zora eyes (and bodies) in Twilight Princess; see [bug 10346](https://bugs.dolphin-emu.org/issues/10346).  This originally regressed in #68, and I bisected the issue to cff952c397833873055e42a85b76ff8a621a0792 (though shaders from that commit will not run unless line 707 is changed by replacing `int2(round(dot(...), dot(...)))` with `int2(round(dot(...)), round(dot(...)))`).

However, this version should avoid introducing regressions.  I semi-hardware tested it and the behavior seems to be that the top bit of the scale factor is ignored, i.e. supplying a scale value of 47 is the same as supplying one of 15, resulting in a scale factor of 2^(15-17) = 2^(-2).  Specifically, I tested it with the Super Mario Bros. fifolog using [the hardware FIFO player](https://github.com/dolphin-emu/fifoplayer), and manually edited the scale factor for Object 3 (the hardware FIFO player lets you modify the FIFO while it's doing playback, which is neat).  I confirmed that there was no wrapping between 0 and 31, and tested some of the values for 32-63 which matched the earlier values (but did not test them all due to it being a bit of a pain).  I also checked the Zora eyes fifolog and confirmed that 47 and 15 looked the same (while supplying 46/48 or 14/16 looked different).

This change does also produce a rendering difference for the goop bubbles in Super Mario Sunshine.  Unfortunately the hardware FIFO player is buggy and doesn't like Sunshine; I was only able to see the goop bubbles by hiding geometry for objects 371-441 and 100-200 to avoid vertex explosions (these may be excessive ranges, but they seemed to work).  Although that did hide the goop itself, the goop bubbles did still show up, and the leftmost one was green and white (showing part of the path).  I also tested on the game itself, and can confirm that the goop bubbles aren't supposed to match the appearance of the goop they obstruct; they're supposed to look like a different part of the area.