### PR TITLE
JitArm64: Don't hardcode exception constants

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -748,7 +748,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 
       // Inline exception check
       LDR(IndexType::Unsigned, ARM64Reg::W30, PPC_REG, PPCSTATE_OFF(Exceptions));
-      TBZ(ARM64Reg::W30, 3, done_here);  // EXCEPTION_EXTERNAL_INT
+      TBZ(ARM64Reg::W30, IntLog2(EXCEPTION_EXTERNAL_INT), done_here);
       LDR(IndexType::Unsigned, ARM64Reg::W30, PPC_REG, PPCSTATE_OFF(msr));
       TBZ(ARM64Reg::W30, 11, done_here);
       MOVP2R(ARM64Reg::X30, &ProcessorInterface::m_InterruptCause);
@@ -774,7 +774,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       ARM64Reg WA = gpr.GetReg();
       ARM64Reg XA = EncodeRegTo64(WA);
       LDR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
-      FixupBranch NoExtException = TBZ(WA, 3);  // EXCEPTION_EXTERNAL_INT
+      FixupBranch NoExtException = TBZ(WA, IntLog2(EXCEPTION_EXTERNAL_INT));
       FixupBranch Exception = B();
       SwitchToFarCode();
       const u8* done_here = GetCodePtr();
@@ -816,7 +816,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
         fpr.Flush(FlushMode::MaintainState);
 
         LDR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
-        ORR(WA, WA, 26, 0);  // EXCEPTION_FPU_UNAVAILABLE
+        ORRI2R(WA, WA, EXCEPTION_FPU_UNAVAILABLE);
         STR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
 
         gpr.Unlock(WA);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -25,7 +25,7 @@ void JitArm64::sc(UGeckoInstruction inst)
   ARM64Reg WA = gpr.GetReg();
 
   LDR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
-  ORR(WA, WA, 31, 0);  // Same as WA | EXCEPTION_SYSCALL
+  ORRI2R(WA, WA, EXCEPTION_SYSCALL);
   STR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
 
   gpr.Unlock(WA);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -218,7 +218,7 @@ void JitArm64::twx(UGeckoInstruction inst)
   fpr.Flush(FlushMode::MaintainState);
 
   LDR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
-  ORR(WA, WA, 24, 0);  // Same as WA | EXCEPTION_PROGRAM
+  ORRI2R(WA, WA, EXCEPTION_PROGRAM);
   STR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
   gpr.Unlock(WA);
 


### PR DESCRIPTION
Split out from PR #9865, since I don't think that PR is going to be merged any time soon.

Unlike most constants we emit in JitArm64, these constants are **not** inherent to the CPU we're emulating, and can have whatever  values we want, so let's handle them in a more robust way. I was rather confused when I found out that a previous iteration of PR #9865 broke JitArm64, because I hadn't thought that making some simple changes to the values of an enum would do it!