### PR TITLE
JitArm64: Add the ability to emit an unconditional exception exit

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -250,8 +250,10 @@ protected:
   // Exits
   void WriteExit(u32 destination, bool LK = false, u32 exit_address_after_return = 0);
   void WriteExit(Arm64Gen::ARM64Reg dest, bool LK = false, u32 exit_address_after_return = 0);
-  void WriteExceptionExit(u32 destination, bool only_external = false);
-  void WriteExceptionExit(Arm64Gen::ARM64Reg dest, bool only_external = false);
+  void WriteExceptionExit(u32 destination, bool only_external = false,
+                          bool always_exception = false);
+  void WriteExceptionExit(Arm64Gen::ARM64Reg dest, bool only_external = false,
+                          bool always_exception = false);
   void FakeLKExit(u32 exit_address_after_return);
   void WriteBLRExit(Arm64Gen::ARM64Reg dest);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -29,7 +29,7 @@ void JitArm64::sc(UGeckoInstruction inst)
 
   gpr.Unlock(WA);
 
-  WriteExceptionExit(js.compilerPC + 4);
+  WriteExceptionExit(js.compilerPC + 4, false, true);
 }
 
 void JitArm64::rfi(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -221,7 +221,7 @@ void JitArm64::twx(UGeckoInstruction inst)
   STR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
   gpr.Unlock(WA);
 
-  WriteExceptionExit(js.compilerPC);
+  WriteExceptionExit(js.compilerPC, false, true);
 
   SwitchToNearCode();
 


### PR DESCRIPTION
In cases where we already know that there is an exception, either because we just checked for it or because we were the ones that generated the exception to begin with, we can skip the branch inside WriteExceptionExit.