### PR TITLE
MathUtil: Mark IntLog2 as constexpr

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -191,7 +191,7 @@ private:
 float MathFloatVectorSum(const std::vector<float>&);
 
 // Rounds down. 0 -> undefined
-inline int IntLog2(u64 val)
+constexpr int IntLog2(u64 val)
 {
   return 63 - Common::CountLeadingZeros(val);
 }


### PR DESCRIPTION
Mostly everything else in MathUtil was already marked as constexpr
and the only function IntLog2 calls (CountLeadingZeros) is already constexpr.