### PR TITLE
macOS: Move UI API calls to the main thread

### DIFF
--- a/Source/Core/Common/GL/GLInterface/AGL.h
+++ b/Source/Core/Common/GL/GLInterface/AGL.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+// This define will silence all "OpenGL is deprecated, use Metal" warnings.
+#define GL_SILENCE_DEPRECATION 1
+
 #if defined(__APPLE__) && defined(__OBJC__)
 #import <AppKit/AppKit.h>
 #else

--- a/Source/Core/Common/GL/GLInterface/AGL.mm
+++ b/Source/Core/Common/GL/GLInterface/AGL.mm
@@ -4,6 +4,9 @@
 #include "Common/GL/GLInterface/AGL.h"
 #include "Common/Logging/Log.h"
 
+// UpdateCachedDimensions and AttachContextToView contain calls to UI APIs, so they must only be
+// called from the main thread or they risk crashing!
+
 static bool UpdateCachedDimensions(NSView* view, u32* width, u32* height)
 {
   NSWindow* window = [view window];
@@ -35,12 +38,10 @@ static bool AttachContextToView(NSOpenGLContext* context, NSView* view, u32* wid
 
   (void)UpdateCachedDimensions(view, width, height);
 
-  // the following calls can crash if not called from the main thread on macOS 10.15
-  dispatch_sync(dispatch_get_main_queue(), ^{
-    [window makeFirstResponder:view];
-    [context setView:view];
-    [window makeKeyAndOrderFront:nil];
-  });
+  [window makeFirstResponder:view];
+  [context setView:view];
+  [window makeKeyAndOrderFront:nil];
+
   return true;
 }
 
@@ -98,8 +99,16 @@ bool GLContextAGL::Initialize(const WindowSystemInfo& wsi, bool stereo, bool cor
 
   m_view = static_cast<NSView*>(wsi.render_surface);
   m_opengl_mode = Mode::OpenGL;
-  if (!AttachContextToView(m_context, m_view, &m_backbuffer_width, &m_backbuffer_height))
+
+  __block bool success;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    success = AttachContextToView(m_context, m_view, &m_backbuffer_width, &m_backbuffer_height);
+  });
+
+  if (!success)
+  {
     return false;
+  }
 
   [m_context makeCurrentContext];
   return true;
@@ -140,11 +149,12 @@ void GLContextAGL::Update()
   if (!m_view)
     return;
 
-  if (UpdateCachedDimensions(m_view, &m_backbuffer_width, &m_backbuffer_height))
-    // the following calls can crash if not called from the main thread on macOS 10.15
-    dispatch_sync(dispatch_get_main_queue(), ^{
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    if (UpdateCachedDimensions(m_view, &m_backbuffer_width, &m_backbuffer_height))
+    {
       [m_context update];
-    });
+    }
+  });
 }
 
 void GLContextAGL::SwapInterval(int interval)

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
@@ -58,7 +58,7 @@ private:
 public:
   void UpdateInput() override;
 
-  explicit KeyboardAndMouse(void* window);
+  explicit KeyboardAndMouse(void* view);
 
   std::string GetName() const override;
   std::string GetSource() const override;

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -135,7 +135,7 @@ std::string KeyboardAndMouse::Key::GetName() const
   return m_name;
 }
 
-KeyboardAndMouse::KeyboardAndMouse(void* window)
+KeyboardAndMouse::KeyboardAndMouse(void* view)
 {
   // All keycodes in <HIToolbox/Events.h> are 0x7e or lower. If you notice
   // keys that aren't being recognized, bump this number up!
@@ -147,7 +147,20 @@ KeyboardAndMouse::KeyboardAndMouse(void* window)
   AddCombinedInput("Shift", {"Left Shift", "Right Shift"});
   AddCombinedInput("Ctrl", {"Left Control", "Right Control"});
 
-  m_windowid = [[reinterpret_cast<NSView*>(window) window] windowNumber];
+  NSView* cocoa_view = reinterpret_cast<NSView*>(view);
+
+  // PopulateDevices may be called on the Emuthread, so we need to ensure that
+  // these UI APIs are only ever called on the main thread.
+  if ([NSThread isMainThread])
+  {
+    m_windowid = [[cocoa_view window] windowNumber];
+  }
+  else
+  {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      m_windowid = [[cocoa_view window] windowNumber];
+    });
+  }
 
   // cursor, with a hax for-loop
   for (unsigned int i = 0; i < 4; ++i)


### PR DESCRIPTION
Just a minor cleanup that makes debugging in Xcode a better experience.

Some APIs must only be called from the main thread. The fact that these APIs were called from other threads and still worked without crashing / bugs is a coincidence. (The AGL GLInterface has apparently already been affected by this before, and was mostly fixed in #8544.)

Also, I define ``GL_SILENCE_DEPRECATION`` in all files that use the AppKit OpenGL APIs. This silences all warnings that say "OpenGL is deprecated, use Metal" when an OpenGL-related API is accessed. I think we all know that by now.

