### PR TITLE
Core: Use proper names for left, right, and middle click on Quartz ciface

### DIFF
--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -142,11 +142,17 @@ void FreeLookController::LoadDefaults(const ControllerInterface& ciface)
   m_fov_buttons->SetControlExpression(FieldOfViewButtons::DecreaseY,
                                       hotkey_string({"Shift", "`Axis Z-`"}));
 
+  // Left Click
 #if defined HAVE_X11 && HAVE_X11
   m_rotation_gyro->SetControlExpression(GyroButtons::PitchUp,
                                         "if(`Click 3`,`RelativeMouse Y-` * 0.10, 0)");
   m_rotation_gyro->SetControlExpression(GyroButtons::PitchDown,
                                         "if(`Click 3`,`RelativeMouse Y+` * 0.10, 0)");
+#elif __APPLE__
+  m_rotation_gyro->SetControlExpression(GyroButtons::PitchUp,
+                                        "if(`Left Click`,`RelativeMouse Y-` * 0.10, 0)");
+  m_rotation_gyro->SetControlExpression(GyroButtons::PitchDown,
+                                        "if(`Left Click`,`RelativeMouse Y+` * 0.10, 0)");
 #else
   m_rotation_gyro->SetControlExpression(GyroButtons::PitchUp,
                                         "if(`Click 1`,`RelativeMouse Y-` * 0.10, 0)");
@@ -154,16 +160,30 @@ void FreeLookController::LoadDefaults(const ControllerInterface& ciface)
                                         "if(`Click 1`,`RelativeMouse Y+` * 0.10, 0)");
 #endif
 
+  // Middle Click
+#ifdef __APPLE__
+  m_rotation_gyro->SetControlExpression(GyroButtons::RollLeft,
+                                        "if(`Middle Click`,`RelativeMouse X-` * 0.10, 0)");
+  m_rotation_gyro->SetControlExpression(GyroButtons::RollRight,
+                                        "if(`Middle Click`,`RelativeMouse X+` * 0.10, 0)");
+#else
   m_rotation_gyro->SetControlExpression(GyroButtons::RollLeft,
                                         "if(`Click 2`,`RelativeMouse X-` * 0.10, 0)");
   m_rotation_gyro->SetControlExpression(GyroButtons::RollRight,
                                         "if(`Click 2`,`RelativeMouse X+` * 0.10, 0)");
+#endif
 
+  // Right Click
 #if defined HAVE_X11 && HAVE_X11
   m_rotation_gyro->SetControlExpression(GyroButtons::YawLeft,
                                         "if(`Click 3`,`RelativeMouse X-` * 0.10, 0)");
   m_rotation_gyro->SetControlExpression(GyroButtons::YawRight,
                                         "if(`Click 3`,`RelativeMouse X+` * 0.10, 0)");
+#elif __APPLE__
+  m_rotation_gyro->SetControlExpression(GyroButtons::YawLeft,
+                                        "if(`Right Click`,`RelativeMouse X-` * 0.10, 0)");
+  m_rotation_gyro->SetControlExpression(GyroButtons::YawRight,
+                                        "if(`Right Click`,`RelativeMouse X+` * 0.10, 0)");
 #else
   m_rotation_gyro->SetControlExpression(GyroButtons::YawLeft,
                                         "if(`Click 1`,`RelativeMouse X-` * 0.10, 0)");

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -613,6 +613,11 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
   m_buttons->SetControlExpression(0, "`Click 1`");
   // B
   m_buttons->SetControlExpression(1, "`Click 3`");
+#elif __APPLE__
+  // A
+  m_buttons->SetControlExpression(0, "`Left Click`");
+  // B
+  m_buttons->SetControlExpression(1, "`Right Click`");
 #else
   // A
   m_buttons->SetControlExpression(0, "`Click 0`");
@@ -633,7 +638,11 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
 
   // Shake
   for (int i = 0; i < 3; ++i)
+#ifdef __APPLE__
+    m_shake->SetControlExpression(i, "`Middle Click`");
+#else
     m_shake->SetControlExpression(i, "`Click 2`");
+#endif
 
   // Pointing (IR)
   m_ir->SetControlExpression(0, "`Cursor Y-`");


### PR DESCRIPTION
Dolphin currently uses `Click 0`, `Click 1`, and `Click 2` as the default expressions for A, B and Shake. While this was correct for the (now removed) mouse support in the IOKit ciface, it is no longer true for the Quartz ciface, which defines these buttons as `Left Click`, `Right Click`, and `Middle Click`.

Fixes A, B, and Shake not being mapped to left, right, and middle click as intended when loading defaults on macOS.