### PR TITLE
Fix indirect textures when format is not ITF_8

### DIFF
--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -459,22 +459,22 @@ void Tev::Indirect(unsigned int stageNum, s32 s, s32 t)
     AlphaBump = AlphaBump & 0xf8;
     break;
   case IndTexFormat::ITF_5:
-    indcoord[0] = (indmap[TextureSampler::ALP_SMP] & 0x1f) + bias[0];
-    indcoord[1] = (indmap[TextureSampler::BLU_SMP] & 0x1f) + bias[1];
-    indcoord[2] = (indmap[TextureSampler::GRN_SMP] & 0x1f) + bias[2];
-    AlphaBump = AlphaBump & 0xe0;
+    indcoord[0] = (indmap[TextureSampler::ALP_SMP] >> 3) + bias[0];
+    indcoord[1] = (indmap[TextureSampler::BLU_SMP] >> 3) + bias[1];
+    indcoord[2] = (indmap[TextureSampler::GRN_SMP] >> 3) + bias[2];
+    AlphaBump = AlphaBump << 5;
     break;
   case IndTexFormat::ITF_4:
-    indcoord[0] = (indmap[TextureSampler::ALP_SMP] & 0x0f) + bias[0];
-    indcoord[1] = (indmap[TextureSampler::BLU_SMP] & 0x0f) + bias[1];
-    indcoord[2] = (indmap[TextureSampler::GRN_SMP] & 0x0f) + bias[2];
-    AlphaBump = AlphaBump & 0xf0;
+    indcoord[0] = (indmap[TextureSampler::ALP_SMP] >> 4) + bias[0];
+    indcoord[1] = (indmap[TextureSampler::BLU_SMP] >> 4) + bias[1];
+    indcoord[2] = (indmap[TextureSampler::GRN_SMP] >> 4) + bias[2];
+    AlphaBump = AlphaBump << 4;
     break;
   case IndTexFormat::ITF_3:
-    indcoord[0] = (indmap[TextureSampler::ALP_SMP] & 0x07) + bias[0];
-    indcoord[1] = (indmap[TextureSampler::BLU_SMP] & 0x07) + bias[1];
-    indcoord[2] = (indmap[TextureSampler::GRN_SMP] & 0x07) + bias[2];
-    AlphaBump = AlphaBump & 0xf8;
+    indcoord[0] = (indmap[TextureSampler::ALP_SMP] >> 5) + bias[0];
+    indcoord[1] = (indmap[TextureSampler::BLU_SMP] >> 5) + bias[1];
+    indcoord[2] = (indmap[TextureSampler::GRN_SMP] >> 5) + bias[2];
+    AlphaBump = AlphaBump << 3;
     break;
   default:
     PanicAlertFmt("Invalid indirect format {}", indirect.fmt);

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1019,7 +1019,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
           '3',  // ITF_3: 0bIIIAAAAA -> 0bAAAAA000, shift of 3
       };
 
-      out.Write("alphabump = (iindtex{}.{} << {}) & 248;\n", tevind.bt.Value(),
+      out.Write("\talphabump = (iindtex{}.{} << {}) & 248;\n", tevind.bt.Value(),
                 tev_ind_alpha_sel[u32(tevind.bs.Value())],
                 tev_ind_alpha_shift[u32(tevind.fmt.Value())]);
     }

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1006,17 +1006,22 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
           "z",
       };
 
-      // 0b11111000, 0b11100000, 0b11110000, 0b11111000
-      static constexpr std::array<const char*, 4> tev_ind_alpha_mask{
-          "248",
-          "224",
-          "240",
-          "248",
+      // According to libogc, the bump alpha value is 5 bits, and comes from the bottom bits of the
+      // component byte, except in the case of ITF_8, which presumably uses the top bits with a
+      // mask.
+      // https://github.com/devkitPro/libogc/blob/bd24a9b3f59502f9b30d6bac0ae35fc485045f78/gc/ogc/gx.h#L3038-L3041
+      // https://github.com/devkitPro/libogc/blob/bd24a9b3f59502f9b30d6bac0ae35fc485045f78/gc/ogc/gx.h#L790-L800
+
+      static constexpr std::array<char, 4> tev_ind_alpha_shift{
+          '0',  // ITF_8: 0bXXXXXYYY -> 0bXXXXX000? No shift?
+          '5',  // ITF_5: 0bIIIIIAAA -> 0bAAA00000, shift of 5
+          '4',  // ITF_4: 0bIIIIAAAA -> 0bAAAA0000, shift of 4
+          '3',  // ITF_3: 0bIIIAAAAA -> 0bAAAAA000, shift of 3
       };
 
-      out.Write("alphabump = iindtex{}.{} & {};\n", tevind.bt.Value(),
+      out.Write("alphabump = (iindtex{}.{} << {}) & 248;\n", tevind.bt.Value(),
                 tev_ind_alpha_sel[u32(tevind.bs.Value())],
-                tev_ind_alpha_mask[u32(tevind.fmt.Value())]);
+                tev_ind_alpha_shift[u32(tevind.fmt.Value())]);
     }
     else
     {
@@ -1026,14 +1031,14 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     if (has_ind_stage && tevind.matrix_index != IndMtxIndex::Off)
     {
       // format
-      static constexpr std::array<const char*, 4> tev_ind_fmt_mask{
-          "255",
-          "31",
-          "15",
-          "7",
+      static constexpr std::array<char, 4> tev_ind_fmt_shift{
+          '0',  // ITF_8: 0bXXXXXXXX -> 0bXXXXXXXX, no shift
+          '3',  // ITF_5: 0bIIIIIAAA -> 0b000IIIII, shift of 3
+          '4',  // ITF_4: 0bIIIIAAAA -> 0b0000IIII, shift of 4
+          '5',  // ITF_3: 0bIIIAAAAA -> 0b00000III, shift of 5
       };
-      out.Write("\tint3 iindtevcrd{} = iindtex{} & {};\n", n, tevind.bt.Value(),
-                tev_ind_fmt_mask[u32(tevind.fmt.Value())]);
+      out.Write("\tint3 iindtevcrd{} = iindtex{} >> {};\n", n, tevind.bt.Value(),
+                tev_ind_fmt_shift[u32(tevind.fmt.Value())]);
 
       // bias - TODO: Check if this needs to be this complicated...
       // indexed by bias

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -828,24 +828,24 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
               "          break;\n"
               "        case {:s}:\n",
               IndTexFormat::ITF_5);
-    out.Write("          indcoord.x = (indcoord.x & 0x1f) + ((bias & 1u) != 0u ? 1 : 0);\n"
-              "          indcoord.y = (indcoord.y & 0x1f) + ((bias & 2u) != 0u ? 1 : 0);\n"
-              "          indcoord.z = (indcoord.z & 0x1f) + ((bias & 4u) != 0u ? 1 : 0);\n"
-              "          s.AlphaBump = s.AlphaBump & 0xe0;\n"
+    out.Write("          indcoord.x = (indcoord.x >> 3) + ((bias & 1u) != 0u ? 1 : 0);\n"
+              "          indcoord.y = (indcoord.y >> 3) + ((bias & 2u) != 0u ? 1 : 0);\n"
+              "          indcoord.z = (indcoord.z >> 3) + ((bias & 4u) != 0u ? 1 : 0);\n"
+              "          s.AlphaBump = s.AlphaBump << 5;\n"
               "          break;\n"
               "        case {:s}:\n",
               IndTexFormat::ITF_4);
-    out.Write("          indcoord.x = (indcoord.x & 0x0f) + ((bias & 1u) != 0u ? 1 : 0);\n"
-              "          indcoord.y = (indcoord.y & 0x0f) + ((bias & 2u) != 0u ? 1 : 0);\n"
-              "          indcoord.z = (indcoord.z & 0x0f) + ((bias & 4u) != 0u ? 1 : 0);\n"
-              "          s.AlphaBump = s.AlphaBump & 0xf0;\n"
+    out.Write("          indcoord.x = (indcoord.x >> 4) + ((bias & 1u) != 0u ? 1 : 0);\n"
+              "          indcoord.y = (indcoord.y >> 4) + ((bias & 2u) != 0u ? 1 : 0);\n"
+              "          indcoord.z = (indcoord.z >> 4) + ((bias & 4u) != 0u ? 1 : 0);\n"
+              "          s.AlphaBump = s.AlphaBump << 4;\n"
               "          break;\n"
               "        case {:s}:\n",
               IndTexFormat::ITF_3);
-    out.Write("          indcoord.x = (indcoord.x & 0x07) + ((bias & 1u) != 0u ? 1 : 0);\n"
-              "          indcoord.y = (indcoord.y & 0x07) + ((bias & 2u) != 0u ? 1 : 0);\n"
-              "          indcoord.z = (indcoord.z & 0x07) + ((bias & 4u) != 0u ? 1 : 0);\n"
-              "          s.AlphaBump = s.AlphaBump & 0xf8;\n"
+    out.Write("          indcoord.x = (indcoord.x >> 5) + ((bias & 1u) != 0u ? 1 : 0);\n"
+              "          indcoord.y = (indcoord.y >> 5) + ((bias & 2u) != 0u ? 1 : 0);\n"
+              "          indcoord.z = (indcoord.z >> 5) + ((bias & 4u) != 0u ? 1 : 0);\n"
+              "          s.AlphaBump = s.AlphaBump << 3;\n"
               "          break;\n"
               "        }}\n"
               "\n"


### PR DESCRIPTION
This affects the skyward sword map.  As mentioned in [issue 9070](https://bugs.dolphin-emu.org/issues/9070#note-11), this regressed in #68 (tev_fixes_new), specifically in 3ea97f77301d57f7ffddefb45f7e34ca926d5098.  It turns out that this commit swapped the shifts used for "bump alpha" and the indirect offset; [per libogc](https://github.com/devkitPro/libogc/blob/bd24a9b3f59502f9b30d6bac0ae35fc485045f78/gc/ogc/gx.h#L790-L800), the indirect offsets are the high bits and the bump alpha comes from the low bits.  (This is further confounded by bump alpha [being only 5 bits](https://github.com/devkitPro/libogc/blob/bd24a9b3f59502f9b30d6bac0ae35fc485045f78/gc/ogc/gx.h#L3038-L3041); in the most common ITF_8 case where bump alpha and the indirect offset are both from the same value, it seems like it does use the top 5 bits, though I haven't hardware tested it).  The old code handled it mostly correctly, but because it was trying to implement bit manipulation using floats, it had various rounding issues (and was hard to understand).