### PR TITLE
VideoCommon: fix generic build

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -12,6 +12,7 @@
 
 #include <fmt/format.h>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"


### PR DESCRIPTION
On x86/ARM `Common/Assert.h` is included by way of
`VideoCommon/VertexLoader{X64,ARM64}.h`, on other platforms it is missing.

Commit is based on the breaking commit (daggy fix), not sure this is appreciated, considering Dolphin doesn't have maintenance branches to merge this into … `Contributing.md` doesn't say anything about it (and neither about commit naming). (*Update:* rebased onto master after advice on IRC)