### PR TITLE
MenuBar: Check for updates on the current update track

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -554,11 +554,6 @@ void MenuBar::AddOptionsMenu()
 
 void MenuBar::InstallUpdateManually()
 {
-  auto& track = SConfig::GetInstance().m_auto_update_track;
-  auto previous_value = track;
-
-  track = "dev";
-
   auto* updater = new Updater(this->parentWidget());
 
   if (!updater->CheckForUpdate())
@@ -567,8 +562,6 @@ void MenuBar::InstallUpdateManually()
         this, tr("Update"),
         tr("You are running the latest version available on this update track."));
   }
-
-  track = previous_value;
 }
 
 void MenuBar::AddHelpMenu()


### PR DESCRIPTION
Going to Help -> Check for Updates always checks for updates on the ``dev`` update track, regardless of what track the user has chosen. However, the error message for when no update is detected states that it checked on "this update track", presumably referring to the user's current one.

This seems like a bug? Maybe it's debug code that was unintentionally left in? 