### PR TITLE
GameINI: Set safe texture cache in WarioWare: Smooth Moves for Writer's Block and Brain Age microgames.

### DIFF
--- a/Data/Sys/GameSettings/ROD.ini
+++ b/Data/Sys/GameSettings/ROD.ini
@@ -16,3 +16,4 @@ EFBEmulateFormatChanges = True
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
The line you're drawing in those games doesn't properly show up otherwise.