### PR TITLE
GCAdapter: Simulate Dance Mat adapter

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -234,7 +234,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   {
     core->Set(fmt::format("SIDevice{}", i), m_SIDevice[i]);
     core->Set(fmt::format("AdapterRumble{}", i), m_AdapterRumble[i]);
-    core->Set(fmt::format("SimulateKonga{}", i), m_AdapterKonga[i]);
+    core->Set(fmt::format("AdapterSimulatedType{}", i), m_AdapterSimulatedType[i]);
   }
   core->Set("WiiSDCard", m_WiiSDCard);
   core->Set("WiiKeyboard", m_WiiKeyboard);
@@ -494,7 +494,16 @@ void SConfig::LoadCoreSettings(IniFile& ini)
     core->Get(fmt::format("SIDevice{}", i), &m_SIDevice[i],
               (i == 0) ? SerialInterface::SIDEVICE_GC_CONTROLLER : SerialInterface::SIDEVICE_NONE);
     core->Get(fmt::format("AdapterRumble{}", i), &m_AdapterRumble[i], true);
-    core->Get(fmt::format("SimulateKonga{}", i), &m_AdapterKonga[i], false);
+    core->Get(fmt::format("AdapterSimulatedType{}", i), &m_AdapterSimulatedType[i],
+              SerialInterface::SIDEVICE_NONE);
+    if (m_AdapterSimulatedType[i] == SerialInterface::SIDEVICE_NONE)
+    {
+      // No value for AdapterSimulatedType#, use deprecated SimulateKonga# if present
+      bool deprecatedKongaSetting;
+      core->Get(fmt::format("SimulateKonga{}", i), &deprecatedKongaSetting, false);
+      m_AdapterSimulatedType[i] = deprecatedKongaSetting ? SerialInterface::SIDEVICE_GC_TARUKONGA :
+                                                           SerialInterface::SIDEVICE_GC_CONTROLLER;
+    }
   }
   core->Get("WiiSDCard", &m_WiiSDCard, true);
   core->Get("WiiKeyboard", &m_WiiKeyboard, false);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -309,7 +309,7 @@ struct SConfig
   // Input settings
   bool m_BackgroundInput;
   bool m_AdapterRumble[4];
-  bool m_AdapterKonga[4];
+  SerialInterface::SIDevices m_AdapterSimulatedType[4];
 
   // Auto-update settings
   std::string m_auto_update_track;

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
@@ -16,21 +16,6 @@ CSIDevice_DanceMat::CSIDevice_DanceMat(SIDevices device, int device_number)
 {
 }
 
-int CSIDevice_DanceMat::RunBuffer(u8* buffer, int request_length)
-{
-  // Read the command
-  const auto command = static_cast<EBufferCommands>(buffer[0]);
-  if (command == EBufferCommands::CMD_STATUS)
-  {
-    ISIDevice::RunBuffer(buffer, request_length);
-
-    u32 id = Common::swap32(SI_DANCEMAT);
-    std::memcpy(buffer, &id, sizeof(id));
-    return sizeof(id);
-  }
-  return CSIDevice_GCController::RunBuffer(buffer, request_length);
-}
-
 u32 CSIDevice_DanceMat::MapPadStatus(const GCPadStatus& pad_status)
 {
   // Map the dpad to the blue arrows, the buttons to the orange arrows
@@ -68,5 +53,10 @@ bool CSIDevice_DanceMat::GetData(u32& hi, u32& low)
   low = 0x8080ffff;
 
   return true;
+}
+
+TSIDevices CSIDevice_DanceMat::GetControllerId() const
+{
+  return SI_DANCEMAT;
 }
 }  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
@@ -15,8 +15,8 @@ class CSIDevice_DanceMat : public CSIDevice_GCController
 public:
   CSIDevice_DanceMat(SIDevices device, int device_number);
 
-  int RunBuffer(u8* buffer, int request_length) override;
   u32 MapPadStatus(const GCPadStatus& pad_status) override;
   bool GetData(u32& hi, u32& low) override;
+  TSIDevices GetControllerId() const override;
 };
 }  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Core/HW/SI/SI_Device.h"
 #include "Core/HW/SI/SI_DeviceGCController.h"
 #include "InputCommon/GCPadStatus.h"
@@ -17,9 +19,9 @@ public:
   GCPadStatus GetPadStatus() override;
   int RunBuffer(u8* buffer, int request_length) override;
 
-  bool GetData(u32& hi, u32& low) override;
+  void OnSimulatedDeviceChanged(const SIDevices device_type, const int device_number);
 
 private:
-  bool m_simulate_konga{};
+  std::unique_ptr<ISIDevice> m_simulated_device;
 };
 }  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.h
@@ -80,6 +80,7 @@ public:
 
 protected:
   void SetOrigin(const GCPadStatus& pad_status);
+  virtual TSIDevices GetControllerId() const;
 };
 
 // "TaruKonga", the DK Bongo controller

--- a/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.cpp
@@ -4,11 +4,13 @@
 #include "DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.h"
 
 #include <QCheckBox>
+#include <QComboBox>
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QVBoxLayout>
 
 #include "Core/ConfigManager.h"
+#include "Core/HW/SI/SI_Device.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 
 #include "InputCommon/GCAdapter.h"
@@ -36,7 +38,13 @@ void GCPadWiiUConfigDialog::CreateLayout()
   m_layout = new QVBoxLayout();
   m_status_label = new QLabel();
   m_rumble = new QCheckBox(tr("Enable Rumble"));
-  m_simulate_bongos = new QCheckBox(tr("Simulate DK Bongos"));
+
+  m_simulated_type_combo = new QComboBox();
+  m_simulated_type_combo->addItem(tr("GameCube Controller"),
+                                  SerialInterface::SIDEVICE_GC_CONTROLLER);
+  m_simulated_type_combo->addItem(tr("DK Bongos"), SerialInterface::SIDEVICE_GC_TARUKONGA);
+  m_simulated_type_combo->addItem(tr("Dance Mat"), SerialInterface::SIDEVICE_DANCEMAT);
+
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Ok);
 
   UpdateAdapterStatus();
@@ -46,7 +54,7 @@ void GCPadWiiUConfigDialog::CreateLayout()
 
   m_layout->addWidget(m_status_label);
   m_layout->addWidget(m_rumble);
-  m_layout->addWidget(m_simulate_bongos);
+  m_layout->addWidget(m_simulated_type_combo);
   m_layout->addWidget(m_button_box);
 
   setLayout(m_layout);
@@ -55,7 +63,8 @@ void GCPadWiiUConfigDialog::CreateLayout()
 void GCPadWiiUConfigDialog::ConnectWidgets()
 {
   connect(m_rumble, &QCheckBox::toggled, this, &GCPadWiiUConfigDialog::SaveSettings);
-  connect(m_simulate_bongos, &QCheckBox::toggled, this, &GCPadWiiUConfigDialog::SaveSettings);
+  connect(m_simulated_type_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
+          &GCPadWiiUConfigDialog::SaveSettings);
   connect(m_button_box, &QDialogButtonBox::accepted, this, &GCPadWiiUConfigDialog::accept);
 }
 
@@ -81,17 +90,20 @@ void GCPadWiiUConfigDialog::UpdateAdapterStatus()
   m_status_label->setText(status_text);
 
   m_rumble->setEnabled(detected);
-  m_simulate_bongos->setEnabled(detected);
+  m_simulated_type_combo->setEnabled(detected);
 }
 
 void GCPadWiiUConfigDialog::LoadSettings()
 {
   m_rumble->setChecked(SConfig::GetInstance().m_AdapterRumble[m_port]);
-  m_simulate_bongos->setChecked(SConfig::GetInstance().m_AdapterKonga[m_port]);
+  const int index = m_simulated_type_combo->findData(
+      static_cast<int>(SConfig::GetInstance().m_AdapterSimulatedType[m_port]));
+  m_simulated_type_combo->setCurrentIndex(index);
 }
 
 void GCPadWiiUConfigDialog::SaveSettings()
 {
   SConfig::GetInstance().m_AdapterRumble[m_port] = m_rumble->isChecked();
-  SConfig::GetInstance().m_AdapterKonga[m_port] = m_simulate_bongos->isChecked();
+  SConfig::GetInstance().m_AdapterSimulatedType[m_port] =
+      static_cast<SerialInterface::SIDevices>(m_simulated_type_combo->currentData().toInt());
 }

--- a/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.h
+++ b/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.h
@@ -6,6 +6,7 @@
 #include <QDialog>
 
 class QCheckBox;
+class QComboBox;
 class QLabel;
 class QDialogButtonBox;
 class QVBoxLayout;
@@ -35,5 +36,5 @@ private:
 
   // Checkboxes
   QCheckBox* m_rumble;
-  QCheckBox* m_simulate_bongos;
+  QComboBox* m_simulated_type_combo;
 };


### PR DESCRIPTION
Experimental support for dance mats using GameCube Adapter Passthrough. I have neither an adaptor nor the dance mat so this is mostly untested.