### PR TITLE
NetPlayIndex: Use scm_rev_str instead of scm_desc_str for version check

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -158,7 +158,7 @@ void NetPlayBrowser::Refresh()
   std::map<std::string, std::string> filters;
 
   if (m_check_hide_incompatible->isChecked())
-    filters["version"] = Common::scm_desc_str;
+    filters["revision"] = Common::scm_rev_str;
 
   if (!m_edit_name->text().isEmpty())
     filters["name"] = m_edit_name->text().toStdString();
@@ -246,7 +246,7 @@ void NetPlayBrowser::UpdateList()
     auto* player_count = new QTableWidgetItem(QStringLiteral("%1").arg(entry.player_count));
     auto* version = new QTableWidgetItem(QString::fromStdString(entry.version));
 
-    const bool enabled = Common::scm_desc_str == entry.version;
+    const bool enabled = Common::scm_rev_str == entry.revision;
 
     for (const auto& item : {region, name, password, in_game, game_id, player_count, version})
       item->setFlags(enabled ? Qt::ItemIsEnabled | Qt::ItemIsSelectable : Qt::NoItemFlags);

--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -96,11 +96,12 @@ NetPlayIndex::List(const std::map<std::string, std::string>& filters)
     const auto& port = entry.get("port");
     const auto& in_game = entry.get("in_game");
     const auto& version = entry.get("version");
+    const auto& revision = entry.get("revision");
 
     if (!name.is<std::string>() || !region.is<std::string>() || !method.is<std::string>() ||
         !server_id.is<std::string>() || !game_id.is<std::string>() || !has_password.is<bool>() ||
         !player_count.is<double>() || !port.is<double>() || !in_game.is<bool>() ||
-        !version.is<std::string>())
+        !version.is<std::string>() || !revision.is<std::string>())
     {
       continue;
     }
@@ -112,6 +113,7 @@ NetPlayIndex::List(const std::map<std::string, std::string>& filters)
     session.server_id = server_id.to_str();
     session.method = method.to_str();
     session.version = version.to_str();
+    session.revision = revision.to_str();
     session.has_password = has_password.get<bool>();
     session.player_count = static_cast<int>(player_count.get<double>());
     session.port = static_cast<int>(port.get<double>());
@@ -169,8 +171,9 @@ bool NetPlayIndex::Add(const NetPlaySession& session)
           "&game=" + request.EscapeComponent(session.game_id) +
           "&password=" + std::to_string(session.has_password) + "&method=" + session.method +
           "&server_id=" + session.server_id + "&in_game=" + std::to_string(session.in_game) +
-          "&port=" + std::to_string(session.port) + "&player_count=" +
-          std::to_string(session.player_count) + "&version=" + Common::scm_desc_str,
+          "&port=" + std::to_string(session.port) +
+          "&player_count=" + std::to_string(session.player_count) +
+          "&version=" + Common::scm_desc_str + "&revision=" + Common::scm_rev_str,
       {{"X-Is-Dolphin", "1"}}, Common::HttpRequest::AllowedReturnCodes::All);
 
   if (!response.has_value())

--- a/Source/Core/UICommon/NetPlayIndex.h
+++ b/Source/Core/UICommon/NetPlayIndex.h
@@ -22,6 +22,7 @@ struct NetPlaySession
   std::string server_id;
   std::string game_id;
   std::string version;
+  std::string revision;
 
   int player_count;
   int port;


### PR DESCRIPTION
Some build systems (i.e. Nix) make it architecturally impossible to acquire the correct scm_desc_str that we normally use for builds,
making it basically impossible for users of those to use the NetPlay browser, unless they manually override the version string. Not relying on this string in the first place for any actual functionality beyond display to the user would be beneficial, and using the scm_rev_str instead matches the check on actually joining a session anyways, so it makes sense to do it this way.

This requires a backend change to the NetPlay lobby server, found at 