### PR TITLE
Updater: Display an appropriate error message on failure

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -284,7 +284,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
 
     if (!Settings::Instance().IsBatchModeEnabled())
     {
-      auto* updater = new Updater(&win);
+      auto* updater = new Updater(&win, Updater::ShouldSilentlyFail::Yes);
       updater->start();
     }
 

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -284,7 +284,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
 
     if (!Settings::Instance().IsBatchModeEnabled())
     {
-      auto* updater = new Updater(&win, Updater::ShouldSilentlyFail::Yes);
+      auto* const updater = new Updater(&win, Updater::ShouldSilentlyFail::Yes);
       updater->start();
     }
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -559,14 +559,9 @@ void MenuBar::InstallUpdateManually()
 
   track = "dev";
 
-  auto* updater = new Updater(this->parentWidget());
+  auto* updater = new Updater(this->parentWidget(), Updater::ShouldSilentlyFail::No);
 
-  if (!updater->CheckForUpdate())
-  {
-    ModalMessageBox::information(
-        this, tr("Update"),
-        tr("You are running the latest version available on this update track."));
-  }
+  updater->CheckForUpdate();
 
   track = previous_value;
 }

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -559,7 +559,7 @@ void MenuBar::InstallUpdateManually()
 
   track = "dev";
 
-  auto* updater = new Updater(this->parentWidget(), Updater::ShouldSilentlyFail::No);
+  auto* const updater = new Updater(this->parentWidget(), Updater::ShouldSilentlyFail::No);
 
   updater->CheckForUpdate();
 

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -121,8 +121,8 @@ void Updater::OnUpdateAvailable(const NewVersionInformation& info) const
   if (choice && *choice == QDialog::Accepted)
   {
     bool updater_process_started =
-        TriggerUpdate(info, later ? AutoUpdateChecker::RestartMode::NO_RESTART_AFTER_UPDATE :
-                                    AutoUpdateChecker::RestartMode::RESTART_AFTER_UPDATE);
+        TriggerUpdate(info, later ? AutoUpdateChecker::RestartMode::NoRestartAfterUpdate :
+                                    AutoUpdateChecker::RestartMode::RestartAfterUpdate);
 
     if (!later && updater_process_started)
     {

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -19,7 +19,7 @@
 
 // Refer to docs/autoupdate_overview.md for a detailed overview of the autoupdate process
 
-Updater::Updater(QWidget* parent, const ShouldSilentlyFail silently_fail)
+Updater::Updater(QWidget* const parent, const ShouldSilentlyFail silently_fail)
     : m_parent(parent), m_silently_fail(silently_fail)
 {
   connect(this, &QThread::finished, this, &QObject::deleteLater);
@@ -65,7 +65,7 @@ void Updater::OnErrorOccurred(const CheckError error) const
   }
 }
 
-void Updater::OnUpdateAvailable(const NewVersionInformation& info)
+void Updater::OnUpdateAvailable(const NewVersionInformation& info) const
 {
   bool later = false;
 

--- a/Source/Core/DolphinQt/Updater.h
+++ b/Source/Core/DolphinQt/Updater.h
@@ -15,13 +15,13 @@ class Updater : public QThread, public AutoUpdateChecker
 {
   Q_OBJECT
 public:
-  Updater(QWidget* parent, const ShouldSilentlyFail silently_fail);
+  Updater(QWidget* const parent, const ShouldSilentlyFail silently_fail);
 
   void run() override;
   void OnErrorOccurred(const CheckError error) const override;
-  void OnUpdateAvailable(const NewVersionInformation& info) override;
+  void OnUpdateAvailable(const NewVersionInformation& info) const override;
 
 private:
-  QWidget* m_parent;
+  QWidget* const m_parent;
   const ShouldSilentlyFail m_silently_fail;
 };

--- a/Source/Core/DolphinQt/Updater.h
+++ b/Source/Core/DolphinQt/Updater.h
@@ -15,13 +15,13 @@ class Updater : public QThread, public AutoUpdateChecker
 {
   Q_OBJECT
 public:
-  explicit Updater(QWidget* parent);
+  Updater(QWidget* parent, const ShouldSilentlyFail silently_fail);
 
   void run() override;
+  void OnErrorOccurred(const CheckError error) const override;
   void OnUpdateAvailable(const NewVersionInformation& info) override;
-  bool CheckForUpdate();
 
 private:
   QWidget* m_parent;
-  bool m_update_available = false;
+  const ShouldSilentlyFail m_silently_fail;
 };

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -234,7 +234,7 @@ bool AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
   updater_flags["install-base-path"] = File::GetExeDirectory();
   updater_flags["log-file"] = File::GetUserPath(D_LOGS_IDX) + UPDATER_LOG_FILE;
 
-  if (restart_mode == RestartMode::RESTART_AFTER_UPDATE)
+  if (restart_mode == RestartMode::RestartAfterUpdate)
     updater_flags["binary-to-restart"] = File::GetExePath();
 
   // Copy the updater so it can update itself if needed.

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -149,7 +149,7 @@ static std::string GetPlatformID()
 #endif
 }
 
-void AutoUpdateChecker::CheckForUpdate()
+void AutoUpdateChecker::CheckForUpdate() const
 {
   // Don't bother checking if updates are not supported or not enabled.
   if (!SystemSupportsAutoUpdates() || SConfig::GetInstance().m_auto_update_track.empty())
@@ -211,7 +211,7 @@ void AutoUpdateChecker::CheckForUpdate()
 }
 
 bool AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInformation& info,
-                                      AutoUpdateChecker::RestartMode restart_mode) const
+                                      const AutoUpdateChecker::RestartMode restart_mode) const
 {
   // Check to make sure we don't already have an update triggered
   if (s_update_triggered)

--- a/Source/Core/UICommon/AutoUpdate.h
+++ b/Source/Core/UICommon/AutoUpdate.h
@@ -51,8 +51,8 @@ public:
   // Starts the updater process, which will wait in the background until the current process exits.
   enum class RestartMode
   {
-    NO_RESTART_AFTER_UPDATE = 0,
-    RESTART_AFTER_UPDATE,
+    NoRestartAfterUpdate = 0,
+    RestartAfterUpdate,
   };
   bool TriggerUpdate(const NewVersionInformation& info, RestartMode restart_mode) const;
 

--- a/Source/Core/UICommon/AutoUpdate.h
+++ b/Source/Core/UICommon/AutoUpdate.h
@@ -14,7 +14,7 @@ class AutoUpdateChecker
 public:
   // Initiates a check for updates in the background. Calls the OnUpdateAvailable callback if an
   // update is available, does "nothing" otherwise.
-  void CheckForUpdate();
+  void CheckForUpdate() const;
 
   static bool SystemSupportsAutoUpdates();
 
@@ -57,6 +57,6 @@ public:
   bool TriggerUpdate(const NewVersionInformation& info, RestartMode restart_mode) const;
 
 protected:
-  virtual void OnUpdateAvailable(const NewVersionInformation& info) = 0;
+  virtual void OnUpdateAvailable(const NewVersionInformation& info) const = 0;
   virtual void OnErrorOccurred(CheckError error) const = 0;
 };

--- a/Source/Core/UICommon/AutoUpdate.h
+++ b/Source/Core/UICommon/AutoUpdate.h
@@ -18,6 +18,21 @@ public:
 
   static bool SystemSupportsAutoUpdates();
 
+  enum class ShouldSilentlyFail
+  {
+    Yes,
+    No,
+  };
+
+  // Passed to the OnErrorOccurred callback.
+  enum class CheckError
+  {
+    HttpRequestFailed,
+    InvalidJsonInServerResponse,
+    AlreadyUpToDate,
+    FailedToLaunchUpdater,
+  };
+
   struct NewVersionInformation
   {
     // Name (5.0-1234) and revision hash of the new version.
@@ -39,8 +54,9 @@ public:
     NO_RESTART_AFTER_UPDATE = 0,
     RESTART_AFTER_UPDATE,
   };
-  void TriggerUpdate(const NewVersionInformation& info, RestartMode restart_mode);
+  bool TriggerUpdate(const NewVersionInformation& info, RestartMode restart_mode) const;
 
 protected:
   virtual void OnUpdateAvailable(const NewVersionInformation& info) = 0;
+  virtual void OnErrorOccurred(CheckError error) const = 0;
 };


### PR DESCRIPTION
`AutoUpdateChecker::CheckForUpdate()` is binary in its return result - either there is an update (true), or Dolphin is up to date or there's an error (false). This means that even if an error occurred while checking for an update, DolphinQt will always say that "you are running the latest version".

(I think this is one of the contributing factors to how macOS universal updates were broken and nobody ever noticed.)

This PR aims to solve this by adding an error callback where DolphinQt can display appropriate error messages. Here they are:

<details>
<summary>Screenshots</summary>

### Up to Date

![image](https://user-images.githubusercontent.com/11504941/125996953-02df5936-13d3-4e4a-8cfa-51926eb9b6a8.png)

### HTTP Request Failed

![image](https://user-images.githubusercontent.com/11504941/125997064-60c75fe9-301c-47fe-b277-432397471f23.png)

### JSON Response Invalid

![image](https://user-images.githubusercontent.com/11504941/126029436-69653539-4e4c-42a3-99f0-b4eb322c0ac6.png)

### Updater Process Failed to Start

![image](https://user-images.githubusercontent.com/11504941/126029930-4ecc3d73-93e8-405e-9b54-766c0553bdaf.png)

</details>
