### PR TITLE
msbuild: use Build dir for Languages

### DIFF
--- a/Languages/Languages.vcxproj
+++ b/Languages/Languages.vcxproj
@@ -16,10 +16,6 @@
     <Import Project="$(VSPropsDir)Base.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <!--Output directly to binary directory...-->
-  <PropertyGroup>
-    <OutDir>$(BinaryOutputDir)</OutDir>
-  </PropertyGroup>
   <ItemGroup>
     <msgfmt Include="po\ar.po" />
     <msgfmt Include="po\ca.po" />
@@ -54,4 +50,10 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="po.targets" />
   </ImportGroup>
+  <ItemGroup>
+    <PoFiles Include="$(OutDir)\**\*.*" />
+  </ItemGroup>
+  <Target Name="AfterBuild" Inputs="@(PoFiles)" Outputs="@(PoFiles -> '$(BinaryOutputDir)%(RecursiveDir)%(Filename)%(Extension)')">
+    <Copy SourceFiles="@(PoFiles)" DestinationFolder="$(BinaryOutputDir)%(RecursiveDir)" />
+  </Target>
 </Project>


### PR DESCRIPTION
the buildbot deletes complete Binary directory before each build.
to prevent re-creating po files for each build, this commit places them in the Build directory and then copies the results to Binary directory (like everything else in dolphin).