### PR TITLE
make FPSCR.RN an enum

### DIFF
--- a/Source/Core/Common/ArmFPURoundMode.cpp
+++ b/Source/Core/Common/ArmFPURoundMode.cpp
@@ -35,12 +35,12 @@ namespace FPURoundMode
 static const u64 default_fpcr = GetFPCR();
 static u64 saved_fpcr = default_fpcr;
 
-void SetRoundMode(int mode)
+void SetRoundMode(RoundMode mode)
 {
   // We don't need to do anything here since SetSIMDMode is always called after calling this
 }
 
-void SetSIMDMode(int rounding_mode, bool non_ieee_mode)
+void SetSIMDMode(RoundMode rounding_mode, bool non_ieee_mode)
 {
   // When AH is disabled, FZ controls flush-to-zero for both inputs and outputs. When AH is enabled,
   // FZ controls flush-to-zero for outputs, and FIZ controls flush-to-zero for inputs.

--- a/Source/Core/Common/FPURoundMode.h
+++ b/Source/Core/Common/FPURoundMode.h
@@ -7,28 +7,17 @@
 
 namespace FPURoundMode
 {
-// TODO: MSVC currently produces broken code:
-// https://connect.microsoft.com/VisualStudio/feedback/details/828892/vc-2013-miscompilation-with-enums-and-bit-fields
-// Once that is fixed, change types in SetRoundMode(), SetSIMDMode(), and in UReg_FPSCR to
-// 'RoundMode'.
-
-enum RoundMode
+enum RoundMode : u32
 {
   ROUND_NEAR = 0,
   ROUND_CHOP = 1,
   ROUND_UP = 2,
   ROUND_DOWN = 3
 };
-enum PrecisionMode
-{
-  PREC_24 = 0,
-  PREC_53 = 1,
-  PREC_64 = 2
-};
 
-void SetRoundMode(int mode);
+void SetRoundMode(RoundMode mode);
 
-void SetSIMDMode(int rounding_mode, bool non_ieee_mode);
+void SetSIMDMode(RoundMode rounding_mode, bool non_ieee_mode);
 
 /*
  * There are two different flavors of float to int conversion:

--- a/Source/Core/Common/GenericFPURoundMode.cpp
+++ b/Source/Core/Common/GenericFPURoundMode.cpp
@@ -7,10 +7,10 @@
 // Generic, do nothing
 namespace FPURoundMode
 {
-void SetRoundMode(int mode)
+void SetRoundMode(RoundMode mode)
 {
 }
-void SetSIMDMode(int rounding_mode, bool non_ieee_mode)
+void SetSIMDMode(RoundMode rounding_mode, bool non_ieee_mode)
 {
 }
 void SaveSIMDState()

--- a/Source/Core/Common/x64FPURoundMode.cpp
+++ b/Source/Core/Common/x64FPURoundMode.cpp
@@ -14,14 +14,14 @@ namespace FPURoundMode
 static u32 saved_sse_state = _mm_getcsr();
 static const u32 default_sse_state = _mm_getcsr();
 
-void SetRoundMode(int mode)
+void SetRoundMode(RoundMode mode)
 {
   // Convert PowerPC to native rounding mode.
   static const int rounding_mode_lut[] = {FE_TONEAREST, FE_TOWARDZERO, FE_UPWARD, FE_DOWNWARD};
   fesetround(rounding_mode_lut[mode]);
 }
 
-void SetSIMDMode(int rounding_mode, bool non_ieee_mode)
+void SetSIMDMode(RoundMode rounding_mode, bool non_ieee_mode)
 {
   // OR-mask for disabling FPU exceptions (bits 7-12 in the MXCSR register)
   const u32 EXCEPTION_MASK = 0x1F80;

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -7,6 +7,7 @@
 
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
+#include "Common/FPURoundMode.h"
 
 // --- Gekko Instruction ---
 
@@ -435,7 +436,7 @@ union UReg_FPSCR
   struct
   {
     // Rounding mode (towards: nearest, zero, +inf, -inf)
-    u32 RN : 2;
+    FPURoundMode::RoundMode RN : 2;
     // Non-IEEE mode enable (aka flush-to-zero)
     u32 NI : 1;
     // Inexact exception enable


### PR DESCRIPTION
This just addresses a comment I came across when grepping for `_MSC_VER`.
Compiles without warnings on msvc, unittests pass, and f-zero seems to run fine. The url in the comment is dead but I assume the issue was something relating to sign extension based on commit history and https://bugs.webkit.org/show_bug.cgi?id=134237

If this change isn't wanted anymore maybe we can just remove the comment instead?