### PR TITLE
INI: Fix Summoner Invalid Reads

### DIFF
--- a/Data/Sys/GameSettings/GS2.ini
+++ b/Data/Sys/GameSettings/GS2.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
I was testing out an issue on the tracker and noticed the invalid read memory address is usually where a game will load the error handler so I tried it with full MMU.  It resolved the issue.

I was unable to reproduce the other issues in the bug report.  

Fixes https://bugs.dolphin-emu.org/issues/12458