### PR TITLE
Fix MEM2 in the memory viewer in physical mode

### DIFF
--- a/Source/Core/Core/HW/AddressSpace.cpp
+++ b/Source/Core/Core/HW/AddressSpace.cpp
@@ -246,22 +246,22 @@ struct CompositeAddressSpaceAccessors : Accessors
 
   u8 ReadU8(u32 address) const override
   {
-    auto it = FindAppropriateAccessor(address);
-    if (it == m_accessor_mappings.end())
+    auto mapping = FindAppropriateAccessor(address);
+    if (mapping == m_accessor_mappings.end())
     {
       return 0;
     }
-    return it->accessors->ReadU8(address);
+    return mapping->accessors->ReadU8(address - mapping->base);
   }
 
   void WriteU8(u32 address, u8 value) override
   {
-    auto it = FindAppropriateAccessor(address);
-    if (it == m_accessor_mappings.end())
+    auto mapping = FindAppropriateAccessor(address);
+    if (mapping == m_accessor_mappings.end())
     {
       return;
     }
-    return it->accessors->WriteU8(address, value);
+    return mapping->accessors->WriteU8(address - mapping->base, value);
   }
 
   std::optional<u32> Search(u32 haystack_offset, const u8* needle_start, std::size_t needle_size,


### PR DESCRIPTION
Previously, looking at MEM2 in the physical mode (at 10000000) would show all zeros.  However, the search feature would match the actual data.  This happened because ReadU8 and WriteU8 did not account for the accessor's base offset (though search did).  I'm somewhat surprised it didn't just crash in this case.

Note that effective mode (where MEM2 is at 90000000) worked properly before in most cases.  The one exception I know of is with the FIFO player, where nothing seems to be mapped at 90000000; this is probably because fifologs don't store BATs.  However, graphics-related logic all operates on physical addresses, so I'm not going to worry about that for now.

This change should have no impact on emulation, only on the memory viewer.