### PR TITLE
Hackfix for clipping in Gormiti

### DIFF
--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -90,7 +90,7 @@ static inline int CalcClipMask(const OutputVertexData* v)
   if (pos.y + pos.w < 0)
     cmask |= CLIP_NEG_Y_BIT;
 
-  if (pos.w * pos.z > 0)
+  if (pos.w * pos.z >= 0)
     cmask |= CLIP_POS_Z_BIT;
 
   if (pos.z + pos.w < 0)

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -269,7 +269,7 @@ ShaderCode GenVertexShader(APIType api_type, const ShaderHostConfig& host_config
     // own clipping. We want to clip so that -w <= z <= 0, which matches the console -1..0 range.
     // We adjust our depth value for clipping purposes to match the perspective projection in the
     // software backend, which is a hack to fix Sonic Adventure and Unleashed games.
-    out.Write("float clipDepth = o.pos.z * (1.0 - 1e-7);\n"
+    out.Write("float clipDepth = (o.pos.z + 1e-7) * (1.0 - 2e-7);\n"
               "float clipDist0 = clipDepth + o.pos.w;\n"  // Near: z < -w
               "float clipDist1 = -clipDepth;\n");         // Far: z > 0
     if (host_config.backend_geometry_shaders)
@@ -277,6 +277,12 @@ ShaderCode GenVertexShader(APIType api_type, const ShaderHostConfig& host_config
       out.Write("o.clipDist0 = clipDist0;\n"
                 "o.clipDist1 = clipDist1;\n");
     }
+  }
+  else
+  {
+    // Same depth adjustment for Sonic. Without depth clamping, it unfortunately
+    // affects non-clipping uses of depth too.
+    out.Write("o.pos.z = (o.pos.z + 1e-7) * (1.0 - 2e-7);\n");
   }
 
   // Write the true depth value. If the game uses depth textures, then the pixel shader will

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -484,7 +484,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     // own clipping. We want to clip so that -w <= z <= 0, which matches the console -1..0 range.
     // We adjust our depth value for clipping purposes to match the perspective projection in the
     // software backend, which is a hack to fix Sonic Adventure and Unleashed games.
-    out.Write("float clipDepth = o.pos.z * (1.0 - 1e-7);\n"
+    out.Write("float clipDepth = (o.pos.z + 1e-7) * (1.0 - 2e-7);\n"
               "float clipDist0 = clipDepth + o.pos.w;\n"  // Near: z < -w
               "float clipDist1 = -clipDepth;\n");         // Far: z > 0
 
@@ -498,7 +498,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   {
     // Same depth adjustment for Sonic. Without depth clamping, it unfortunately
     // affects non-clipping uses of depth too.
-    out.Write("o.pos.z = o.pos.z * (1.0 - 1e-7);\n");
+    out.Write("o.pos.z = (o.pos.z + 1e-7) * (1.0 - 2e-7);\n");
   }
 
   // Write the true depth value. If the game uses depth textures, then the pixel shader will


### PR DESCRIPTION
This should fix [bug 12436](https://bugs.dolphin-emu.org/issues/12436).

I don't really know what I'm doing here, to be honest; I don't fully understand the clipping code.

What I do know is that the game deliberately draws a black rectangle over the entire screen (the first 3 values are the x/y/z coordinates, with the hex values first and then the decoded float values in parentheses, and the last value is the color, where alpha is 1):

```
Primitive GX_DRAW_TRIANGLE_STRIP (3) VAT 0

00000000 (0) 00000000 (0) 3f800000 (1)  00000001  
00000000 (0) 43f00000 (480) 3f800000 (1)  00000001  
44200000 (640) 00000000 (0) 3f800000 (1)  00000001  
44200000 (640) 43f00000 (480) 3f800000 (1)  00000001  
```

It also configures the alpha test and z-test to pass for these.  I can only assume that this is deliberate anti-emulation code, because there doesn't seem to be any other purpose to this rectangle.

Testing using the hardware fifoplayer showed that this rectangle did not render; I assume this is because it is passing the far plane (but I'm not 100% sure whether it's the far or near plane, as I don't have a perfect understanding of this part of rendering.  The z coordinate is transformed to -1 and then projected position's z-coordinate is 0, so I think it it's the far plane, though.)  My guess is that this is supposed to be a `>= 0` comparison for clipping instead of a `> 0` comparison, which I did with the software renderer, but I did some hacky stuff in the hardware renderers instead.

This PR also applies the sonic epsilon hack for `host_config.backend_depth_clamp = false` to UberShaders (it was implemented for specialized shaders in #9591).  I haven't tested anything for `backend_depth_clamp = false`.