### PR TITLE
GameINI: MX Superfly - fix player textures

### DIFF
--- a/Data/Sys/GameSettings/GSV.ini
+++ b/Data/Sys/GameSettings/GSV.ini
@@ -1,0 +1,16 @@
+# GSVE78, GSVP78 - MX Superfly
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
MX Superfly uses EFB copies to generate the outfit for your character in career mode.  This makes the game awkward to play without this setting.