### PR TITLE
FileUtil: Remove duplication in FileInfo constructor

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -92,12 +92,6 @@ FileInfo::FileInfo(const char* path) : FileInfo(std::string(path))
 #else
 FileInfo::FileInfo(const std::string& path) : FileInfo(path.c_str())
 {
-#ifdef ANDROID
-  if (IsPathAndroidContent(path))
-    AndroidContentInit(path);
-  else
-#endif
-    m_exists = stat(path.c_str(), &m_stat) == 0;
 }
 
 FileInfo::FileInfo(const char* path)


### PR DESCRIPTION
On non-Windows platforms FileUtil's FileInfo(std::string) constructor initialized itself with the char* constructor, then did the same thing in its own function body. In addition to being duplicate code this resulted in two stats (or possibly worse on Android).