### PR TITLE
Fix GBR and GRB post-processing effects

### DIFF
--- a/Data/Sys/Shaders/swap_RGB_GBR.glsl
+++ b/Data/Sys/Shaders/swap_RGB_GBR.glsl
@@ -1,4 +1,4 @@
 void main()
 {
-	SetOutput(Sample());
+	SetOutput(Sample().gbra);
 }

--- a/Data/Sys/Shaders/swap_RGB_GRB.glsl
+++ b/Data/Sys/Shaders/swap_RGB_GRB.glsl
@@ -1,4 +1,4 @@
 void main()
 {
-	SetOutput(Sample());
+	SetOutput(Sample().grba);
 }


### PR DESCRIPTION
I was trying out some of the shaders and noticed that, unlike the other similar shaders, `swap_RGB_GBR.glsl` and `swap_RGB_GRB.glsl` post-processing effects appeared to do nothing. This PR fixes both of them, which have been broken for at least seven years. I compared their output with swapping channels on a screenshot in GIMP to make sure that these new ones work properly.