### PR TITLE
INI Settings for Paper Mario: Thousand-Year Door Demo Disc

### DIFF
--- a/Data/Sys/GameSettings/D56E01.ini
+++ b/Data/Sys/GameSettings/D56E01.ini
@@ -1,0 +1,19 @@
+# D56E01 - Interactive Multi-Game Demo Disc Version 35
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False
+BBoxEnable = True
+ImmediateXFBEnable = False
+DeferEFBCopies = False


### PR DESCRIPTION
Interactive Demo Disc Version 35 comes with Paper Mario: The Thousand-Year Door.  Note that D56J01 is a different game.  The settings are copied from the original game's INI as it contains scenes from the first couple of chapters.

The other games on the disc do not require any particular settings.