### PR TITLE
INI: Fix Memcard detection in SSX Tricky and SpongeBob:CFtKK

### DIFF
--- a/Data/Sys/GameSettings/GQ4.ini
+++ b/Data/Sys/GameSettings/GQ4.ini
@@ -1,4 +1,4 @@
-# GSTE69, GSTP69, GSTJ13 - SSX Tricky
+# GQ4P78, GQ4E78, GQ4F78, GQ4D78 - SpongeBob SquarePants: Creature From the Krusty Krab [GC]
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -13,7 +13,5 @@ MemoryCardSize = 2
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
 
-[Video_Hacks]
-ImmediateXFBEnable = False
+


### PR DESCRIPTION
These games need MemoryCardSize = 2 or else they'll freak out and think the memory card is broken.

I also added the japanese version of SSX Tricky to the INI because it should be affected by GST.