### PR TITLE
GameINI: Fix PoP:TT Shadows

### DIFF
--- a/Data/Sys/GameSettings/GKM.ini
+++ b/Data/Sys/GameSettings/GKM.ini
@@ -14,4 +14,4 @@
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-
+FastDepthCalc = True


### PR DESCRIPTION
At extreme angles, there is severe shadow zfighting with fast depth disabled.  Enabling it causes it work on all backends without issue.  Verified in OpenGL, D3D11, D3D12, and Vulkan.  I assume that this is the correct setting name, as I copied it out of the GFX config file.