### PR TITLE
GameINI:  Fix water in Tomb Raider Legend

### DIFF
--- a/Data/Sys/GameSettings/GL8.ini
+++ b/Data/Sys/GameSettings/GL8.ini
@@ -1,0 +1,16 @@
+# GL8E4F, GL8F4F, GL8D4F, GL8P4F - Tomb Raider Legend
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
Disables Store EFB Copies to Texture Only.  As this game has a lot of water, the water not rendering correctly provides a pretty significant gameplay issue.

The game shows up in the gamelist as "Lara Croft Tomb Raider Legend" but I went with the wiki name instead as not to cause confusion.