### PR TITLE
GameINI:  Improve Rendering in Sin & Punishment: Star Successor

### DIFF
--- a/Data/Sys/GameSettings/R2V.ini
+++ b/Data/Sys/GameSettings/R2V.ini
@@ -1,0 +1,18 @@
+# R2VE01, R2VP01, R2VJ01 - Sin & Punishment: Star Successor
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+# Store EFB Copies to Texture Only must be disabled to prevent
+# the copy region from showing incorrect graphics.
+EFBToTextureEnable = False


### PR DESCRIPTION
Sin & Punishment: Star Successor has rendering issues in the upper left part of the screen.  While we can't completely fix it, by disabling Store EFB Copies to Texture only, we can make it from a missing box to just a couple of lines being incorrectly visible that make up the copy region's borders.

This makes the game much more playable in the meantime.