### PR TITLE
GeckoSockServer: Only join connectionThread if it is joinable

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -43,7 +43,7 @@ GeckoSockServer::~GeckoSockServer()
     clientThread.join();
   }
 
-  if (client_count <= 0)
+  if (client_count <= 0 && connectionThread.joinable())
   {
     server_running.Clear();
     connectionThread.join();


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/12153.