### PR TITLE
Convert NaN to 1 when generating texture coordinates

### DIFF
--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -137,6 +137,15 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum,
   }
   }
 
+  // Convert NaNs to 1 - needed to fix eyelids in Shadow the Hedgehog during cutscenes
+  // See https://bugs.dolphin-emu.org/issues/11458
+  if (std::isnan(src.x))
+    src.x = 1;
+  if (std::isnan(src.y))
+    src.y = 1;
+  if (std::isnan(src.z))
+    src.z = 1;
+
   const float* mat = &xfmem.posMatrices[srcVertex->texMtx[coordNum] * 4];
   Vec3* dst = &dstVertex->texCoords[coordNum];
 

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -435,6 +435,13 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
   out.Write("    coord.z = 1.0f;\n"
             "\n");
 
+  // Convert NaNs to 1 - needed to fix eyelids in Shadow the Hedgehog during cutscenes
+  // See https://bugs.dolphin-emu.org/issues/11458
+  out.Write("  // Convert NaN to 1\n");
+  out.Write("  if (isnan(coord.x)) coord.x = 1.0;\n");
+  out.Write("  if (isnan(coord.y)) coord.y = 1.0;\n");
+  out.Write("  if (isnan(coord.z)) coord.z = 1.0;\n");
+
   out.Write("  // first transformation\n");
   out.Write("  uint texgentype = {};\n", BitfieldExtract<&TexMtxInfo::texgentype>("texMtxInfo"));
   out.Write("  float3 output_tex;\n"

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -332,6 +332,13 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     if (texinfo.inputform == TexInputForm::AB11)
       out.Write("coord.z = 1.0;\n");
 
+    // Convert NaNs to 1 - needed to fix eyelids in Shadow the Hedgehog during cutscenes
+    // See https://bugs.dolphin-emu.org/issues/11458
+    out.Write("// Convert NaN to 1\n");
+    out.Write("if (isnan(coord.x)) coord.x = 1.0;\n");
+    out.Write("if (isnan(coord.y)) coord.y = 1.0;\n");
+    out.Write("if (isnan(coord.z)) coord.z = 1.0;\n");
+
     // first transformation
     switch (texinfo.texgentype)
     {


### PR DESCRIPTION
This fixes eyelids in Shadow the Hedgehog during cutscenes (https://bugs.dolphin-emu.org/issues/11458).

The eyelids (objects 36 and 37) draw on the same data, but object 36 uses texture coord 0 for its texture coordinate while object 37 uses the normal for its texture coordinate.  The normal coordinates come from 00793400 (80793400 virtual), and some of them are NaN (specifically encoded as ffc00000).  This specifically affects the center of the white part of the eye and the top left part of it, but because of how NaN behaves, the result of trying to interpolate anything with those vertices is NaN.

I used the hardware fifoplayer with the fifolog from that issue, and things rendered correctly, so this isn't a case of bad emulation creating NaNs:

![Screenshot 2021-07-20 10-55-24](https://user-images.githubusercontent.com/8334194/126420002-6914953f-a709-408d-8b18-a8c9f13b3d2e.png)

My fix is to convert NaN to 1 before doing any math with it, which seems to give correct results.  (Remember that if `x` is `NaN`, `x != x` is true.)