### PR TITLE
NetPlayClient: Remove a designated initializer

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2534,7 +2534,8 @@ PadDetails GetPadDetails(int pad_num)
 {
   std::lock_guard lk(crit_netplay_client);
 
-  PadDetails res{.local_pad = 4};
+  PadDetails res{};
+  res.local_pad = 4;
   if (!netplay_client)
     return res;
 


### PR DESCRIPTION
release-ubu-x64 currently fails with "sorry, unimplemented: non-trivial designated initializers not supported". pr-ubu-x64 doesn't for some reason, but we might as well remove the designated initializer.