### PR TITLE
StringUtil: Remove unused function BuildCompleteFilename

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -342,19 +342,6 @@ std::string PathToFileName(std::string_view path)
   return file_name + extension;
 }
 
-void BuildCompleteFilename(std::string& complete_filename, std::string_view path,
-                           std::string_view filename)
-{
-  complete_filename = path;
-
-  // check for seperator
-  if (DIR_SEP_CHR != *complete_filename.rbegin())
-    complete_filename += DIR_SEP_CHR;
-
-  // add the filename
-  complete_filename += filename;
-}
-
 std::vector<std::string> SplitString(const std::string& str, const char delim)
 {
   std::istringstream iss(str);

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -162,9 +162,6 @@ bool SplitPath(std::string_view full_path, std::string* path, std::string* filen
 
 std::string PathToFileName(std::string_view path);
 
-void BuildCompleteFilename(std::string& complete_filename, std::string_view path,
-                           std::string_view filename);
-
 bool StringBeginsWith(std::string_view str, std::string_view begin);
 bool StringEndsWith(std::string_view str, std::string_view end);
 void StringPopBackIf(std::string* s, char c);


### PR DESCRIPTION
Aside from being unused it has a strange interface and implementation. 

It's barely been touched since the initial git megacommit; I'm guessing it was meant to work around missing Return Value Optimization in ancient compilers?