### PR TITLE
Qt: Un-maximize GBA widget before resizing it

### DIFF
--- a/Source/Core/DolphinQt/GBAWidget.cpp
+++ b/Source/Core/DolphinQt/GBAWidget.cpp
@@ -229,6 +229,7 @@ void GBAWidget::DoState(bool export_state)
 
 void GBAWidget::Resize(int scale)
 {
+  showNormal();
   resize(m_core_info.width * scale, m_core_info.height * scale);
 }
 


### PR DESCRIPTION
This is more a "windows is silly" thing: if a window is maximized but then resized, it'll remain maximized and in the top-left corner of the screen, but the size will change.  However, if you attempt to move the window to a different place, it'll become un-maximized and the size it had before maximizing will be used (and it'll ignore the size you set when it was maximized).  Returning the window to a normal state fixes this.