### PR TITLE
NetPlay: Split save and SD card write settings

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -358,7 +358,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     StartUp.bCPUThread = netplay_settings.m_CPUthread;
     StartUp.bEnableCheats = netplay_settings.m_EnableCheats;
     StartUp.bDSPHLE = netplay_settings.m_DSPHLE;
-    StartUp.bEnableMemcardSdWriting = netplay_settings.m_WriteToMemcard;
     StartUp.bCopyWiiSaveNetplay = netplay_settings.m_CopyWiiSave;
     StartUp.cpu_core = netplay_settings.m_CPUcore;
     StartUp.SelectedLanguage = netplay_settings.m_SelectedLanguage;

--- a/Source/Core/Core/Config/NetplaySettings.cpp
+++ b/Source/Core/Core/Config/NetplaySettings.cpp
@@ -45,8 +45,7 @@ const Info<u32> NETPLAY_CHUNKED_UPLOAD_LIMIT{{System::Main, "NetPlay", "ChunkedU
 const Info<u32> NETPLAY_BUFFER_SIZE{{System::Main, "NetPlay", "BufferSize"}, 5};
 const Info<u32> NETPLAY_CLIENT_BUFFER_SIZE{{System::Main, "NetPlay", "BufferSizeClient"}, 1};
 
-const Info<bool> NETPLAY_WRITE_SAVE_SDCARD_DATA{{System::Main, "NetPlay", "WriteSaveSDCardData"},
-                                                false};
+const Info<bool> NETPLAY_WRITE_SAVE_DATA{{System::Main, "NetPlay", "WriteSaveData"}, true};
 const Info<bool> NETPLAY_LOAD_WII_SAVE{{System::Main, "NetPlay", "LoadWiiSave"}, false};
 const Info<bool> NETPLAY_SYNC_SAVES{{System::Main, "NetPlay", "SyncSaves"}, true};
 const Info<bool> NETPLAY_SYNC_CODES{{System::Main, "NetPlay", "SyncCodes"}, true};

--- a/Source/Core/Core/Config/NetplaySettings.h
+++ b/Source/Core/Core/Config/NetplaySettings.h
@@ -41,7 +41,7 @@ extern const Info<u32> NETPLAY_CHUNKED_UPLOAD_LIMIT;
 extern const Info<u32> NETPLAY_BUFFER_SIZE;
 extern const Info<u32> NETPLAY_CLIENT_BUFFER_SIZE;
 
-extern const Info<bool> NETPLAY_WRITE_SAVE_SDCARD_DATA;
+extern const Info<bool> NETPLAY_WRITE_SAVE_DATA;
 extern const Info<bool> NETPLAY_LOAD_WII_SAVE;
 extern const Info<bool> NETPLAY_SYNC_SAVES;
 extern const Info<bool> NETPLAY_SYNC_CODES;

--- a/Source/Core/Core/Config/SessionSettings.cpp
+++ b/Source/Core/Core/Config/SessionSettings.cpp
@@ -14,5 +14,5 @@ const Info<bool> SESSION_LOAD_IPL_DUMP{{System::Session, "Core", "LoadIPLDump"},
 const Info<bool> SESSION_GCI_FOLDER_CURRENT_GAME_ONLY{
     {System::Session, "Core", "GCIFolderCurrentGameOnly"}, false};
 const Info<bool> SESSION_CODE_SYNC_OVERRIDE{{System::Session, "Core", "CheatSyncOverride"}, false};
-const Info<bool> SESSION_WII_SD_CARD_WRITABLE{{System::Session, "Core", "WiiSDCardWritable"}, true};
+const Info<bool> SESSION_SAVE_DATA_WRITABLE{{System::Session, "Core", "SaveDataWritable"}, true};
 }  // namespace Config

--- a/Source/Core/Core/Config/SessionSettings.h
+++ b/Source/Core/Core/Config/SessionSettings.h
@@ -12,5 +12,5 @@ extern const Info<bool> SESSION_USE_FMA;
 extern const Info<bool> SESSION_LOAD_IPL_DUMP;
 extern const Info<bool> SESSION_GCI_FOLDER_CURRENT_GAME_ONLY;
 extern const Info<bool> SESSION_CODE_SYNC_OVERRIDE;
-extern const Info<bool> SESSION_WII_SD_CARD_WRITABLE;
+extern const Info<bool> SESSION_SAVE_DATA_WRITABLE;
 }  // namespace Config

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -39,7 +39,7 @@ public:
     layer->Set(Config::MAIN_SLOT_A, static_cast<int>(m_settings.m_EXIDevice[0]));
     layer->Set(Config::MAIN_SLOT_B, static_cast<int>(m_settings.m_EXIDevice[1]));
     layer->Set(Config::MAIN_SERIAL_PORT_1, static_cast<int>(m_settings.m_EXIDevice[2]));
-    layer->Set(Config::SESSION_WII_SD_CARD_WRITABLE, m_settings.m_WriteToMemcard);
+    layer->Set(Config::SESSION_SAVE_DATA_WRITABLE, m_settings.m_WriteToMemcard);
     layer->Set(Config::MAIN_RAM_OVERRIDE_ENABLE, m_settings.m_RAMOverrideEnable);
     layer->Set(Config::MAIN_MEM1_SIZE, m_settings.m_Mem1Size);
     layer->Set(Config::MAIN_MEM2_SIZE, m_settings.m_Mem2Size);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -757,7 +757,6 @@ void SConfig::LoadDefaults()
   iBBDumpPort = -1;
   bSyncGPU = false;
   bFastDiscSpeed = false;
-  bEnableMemcardSdWriting = true;
   SelectedLanguage = 0;
   bOverrideRegionSettings = false;
   bWii = false;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -119,7 +119,6 @@ struct SConfig
   bool bSyncGPUOnSkipIdleHack = true;
   bool bHLE_BS2 = true;
   bool bEnableCheats = false;
-  bool bEnableMemcardSdWriting = true;
   bool bCopyWiiSaveNetplay = true;
 
   bool bDPL2Decoder = false;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -236,7 +236,7 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot,
 
 void GCMemcardDirectory::FlushThread()
 {
-  if (!SConfig::GetInstance().bEnableMemcardSdWriting)
+  if (!Config::Get(Config::SESSION_SAVE_DATA_WRITABLE))
   {
     return;
   }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
@@ -23,6 +23,7 @@
 #include "Common/Thread.h"
 #include "Common/Timer.h"
 
+#include "Core/Config/SessionSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
@@ -136,7 +137,7 @@ void MemoryCard::CheckPath(std::string& memcardPath, const std::string& gameRegi
 
 void MemoryCard::FlushThread()
 {
-  if (!SConfig::GetInstance().bEnableMemcardSdWriting)
+  if (!Config::Get(Config::SESSION_SAVE_DATA_WRITABLE))
   {
     return;
   }

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -15,6 +15,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/SDCardUtil.h"
 #include "Core/Config/MainSettings.h"
+#include "Core/Config/SessionSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/IOS.h"
@@ -276,8 +277,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
     INFO_LOG_FMT(IOS_SD, "{}Write {} Block(s) from {:#010x} bsize {} to offset {:#010x}!",
                  req.isDMA ? "DMA " : "", req.blocks, req.addr, req.bsize, req.arg);
 
-    if (m_card && SConfig::GetInstance().bEnableMemcardSdWriting &&
-        Config::Get(Config::MAIN_ALLOW_SD_WRITES))
+    if (m_card && Config::Get(Config::MAIN_ALLOW_SD_WRITES))
     {
       const u32 size = req.bsize * req.blocks;
       const u64 address = GetAddressFromRequest(req.arg);

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1293,7 +1293,7 @@ bool NetPlayServer::SetupNetSettings()
   settings.m_OverrideRegionSettings = Config::Get(Config::MAIN_OVERRIDE_REGION_SETTINGS);
   settings.m_DSPHLE = Config::Get(Config::MAIN_DSP_HLE);
   settings.m_DSPEnableJIT = Config::Get(Config::MAIN_DSP_JIT);
-  settings.m_WriteToMemcard = Config::Get(Config::NETPLAY_WRITE_SAVE_SDCARD_DATA);
+  settings.m_WriteToMemcard = Config::Get(Config::NETPLAY_WRITE_SAVE_DATA);
   settings.m_RAMOverrideEnable = Config::Get(Config::MAIN_RAM_OVERRIDE_ENABLE);
   settings.m_Mem1Size = Config::Get(Config::MAIN_MEM1_SIZE);
   settings.m_Mem2Size = Config::Get(Config::MAIN_MEM2_SIZE);

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -17,6 +17,7 @@
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 #include "Core/CommonTitles.h"
+#include "Core/Config/SessionSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/WiiSave.h"
 #include "Core/IOS/ES/ES.h"
@@ -310,7 +311,7 @@ void InitializeWiiFileSystemContents()
 
 void CleanUpWiiFileSystemContents()
 {
-  if (!WiiRootIsTemporary() || !SConfig::GetInstance().bEnableMemcardSdWriting ||
+  if (!WiiRootIsTemporary() || !Config::Get(Config::SESSION_SAVE_DATA_WRITABLE) ||
       NetPlay::GetWiiSyncFS())
   {
     return;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -108,10 +108,8 @@ void NetPlayDialog::CreateMainLayout()
 
   m_data_menu = m_menu_bar->addMenu(tr("Data"));
   m_data_menu->setToolTipsVisible(true);
-  m_save_sd_action = m_data_menu->addAction(tr("Write Save/SD Data"));
-  m_save_sd_action->setToolTip(
-      tr("If \"Allow Writes to SD Card\" is disabled this does not override it."));
-  m_save_sd_action->setCheckable(true);
+  m_write_save_data_action = m_data_menu->addAction(tr("Write Save Data"));
+  m_write_save_data_action->setCheckable(true);
   m_load_wii_action = m_data_menu->addAction(tr("Load Wii Save"));
   m_load_wii_action->setCheckable(true);
   m_sync_save_data_action = m_data_menu->addAction(tr("Sync Saves"));
@@ -362,7 +360,7 @@ void NetPlayDialog::ConnectWidgets()
 
   connect(m_buffer_size_box, qOverload<int>(&QSpinBox::valueChanged), this,
           &NetPlayDialog::SaveSettings);
-  connect(m_save_sd_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
+  connect(m_write_save_data_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_load_wii_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_sync_save_data_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_sync_codes_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
@@ -769,7 +767,7 @@ void NetPlayDialog::SetOptionsEnabled(bool enabled)
     m_start_button->setEnabled(enabled);
     m_game_button->setEnabled(enabled);
     m_load_wii_action->setEnabled(enabled);
-    m_save_sd_action->setEnabled(enabled);
+    m_write_save_data_action->setEnabled(enabled);
     m_sync_save_data_action->setEnabled(enabled);
     m_sync_codes_action->setEnabled(enabled);
     m_assign_ports_button->setEnabled(enabled);
@@ -1038,7 +1036,7 @@ std::string NetPlayDialog::FindGBARomPath(const std::array<u8, 20>& hash, std::s
 void NetPlayDialog::LoadSettings()
 {
   const int buffer_size = Config::Get(Config::NETPLAY_BUFFER_SIZE);
-  const bool write_save_sdcard_data = Config::Get(Config::NETPLAY_WRITE_SAVE_SDCARD_DATA);
+  const bool write_save_data = Config::Get(Config::NETPLAY_WRITE_SAVE_DATA);
   const bool load_wii_save = Config::Get(Config::NETPLAY_LOAD_WII_SAVE);
   const bool sync_saves = Config::Get(Config::NETPLAY_SYNC_SAVES);
   const bool sync_codes = Config::Get(Config::NETPLAY_SYNC_CODES);
@@ -1049,7 +1047,7 @@ void NetPlayDialog::LoadSettings()
   const bool hide_remote_gbas = Config::Get(Config::NETPLAY_HIDE_REMOTE_GBAS);
 
   m_buffer_size_box->setValue(buffer_size);
-  m_save_sd_action->setChecked(write_save_sdcard_data);
+  m_write_save_data_action->setChecked(write_save_data);
   m_load_wii_action->setChecked(load_wii_save);
   m_sync_save_data_action->setChecked(sync_saves);
   m_sync_codes_action->setChecked(sync_codes);
@@ -1089,7 +1087,7 @@ void NetPlayDialog::SaveSettings()
   else
     Config::SetBase(Config::NETPLAY_BUFFER_SIZE, m_buffer_size_box->value());
 
-  Config::SetBase(Config::NETPLAY_WRITE_SAVE_SDCARD_DATA, m_save_sd_action->isChecked());
+  Config::SetBase(Config::NETPLAY_WRITE_SAVE_DATA, m_write_save_data_action->isChecked());
   Config::SetBase(Config::NETPLAY_LOAD_WII_SAVE, m_load_wii_action->isChecked());
   Config::SetBase(Config::NETPLAY_SYNC_SAVES, m_sync_save_data_action->isChecked());
   Config::SetBase(Config::NETPLAY_SYNC_CODES, m_sync_codes_action->isChecked());

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -130,7 +130,7 @@ private:
   QPushButton* m_start_button;
   QLabel* m_buffer_label;
   QSpinBox* m_buffer_size_box;
-  QAction* m_save_sd_action;
+  QAction* m_write_save_data_action;
   QAction* m_load_wii_action;
   QAction* m_sync_save_data_action;
   QAction* m_sync_codes_action;


### PR DESCRIPTION
This actually eliminates any setting pertaining to SD cards from the NetPlay dialog, as it would effectively just be a duplicate of the setting in the Wii pane, potentially causing confusion.

This also enables save data writing by default, as this is probably what most players want, and should avoid them losing hours of progress because they forgot to tick a checkbox.