### PR TITLE
GBA: Add "Scan e-Reader Card(s)" context menu item

### DIFF
--- a/Source/Core/DolphinQt/GBAWidget.h
+++ b/Source/Core/DolphinQt/GBAWidget.h
@@ -44,6 +44,7 @@ public:
 
   void LoadROM();
   void UnloadROM();
+  void PromptForEReaderCards();
   void ResetCore();
   void DoState(bool export_state);
   void Resize(int scale);


### PR DESCRIPTION
See [issue 12588](https://bugs.dolphin-emu.org/issues/12588).  This doesn't introduce any more complicated functionality; it only exposes the functionality that was already available via drag and drop in a more discoverable way.

I haven't tested this at all.