### PR TITLE
GameINI:  Fix de Blob 2 visual issues.

### DIFF
--- a/Data/Sys/GameSettings/SDB.ini
+++ b/Data/Sys/GameSettings/SDB.ini
@@ -12,6 +12,9 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Enhancements]
+ForceFiltering = False
+
 [Video_Hacks]
 EFBToTextureEnable = False
-
+DeferEFBCopies = False


### PR DESCRIPTION
de Blob 2 has the same engine as de blob and shares a lot of the same issues.  I copied the settings used for de blob.  It seems defer EFB copies was the main culprit of the black box issue returning, but force texture filtering could also cause problems.