### PR TITLE
AudioPane: Adjust DSP selection names

### DIFF
--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -48,9 +48,9 @@ void AudioPane::CreateWidgets()
   auto* dsp_layout = new QVBoxLayout;
 
   dsp_box->setLayout(dsp_layout);
-  m_dsp_hle = new QRadioButton(tr("DSP HLE (fast)"));
-  m_dsp_lle = new QRadioButton(tr("DSP LLE Recompiler"));
-  m_dsp_interpreter = new QRadioButton(tr("DSP LLE Interpreter (slow)"));
+  m_dsp_hle = new QRadioButton(tr("DSP HLE (recommended)"));
+  m_dsp_lle = new QRadioButton(tr("DSP LLE Recompiler (slow)"));
+  m_dsp_interpreter = new QRadioButton(tr("DSP LLE Interpreter (very slow)"));
 
   dsp_layout->addStretch(1);
   dsp_layout->addWidget(m_dsp_hle);


### PR DESCRIPTION
I've seen a lot of users selecting DSP-LLE because they figure "how slow can audio emulation be?" and not really realizing that DSP-LLE is the reason that their game is lagging.  I don't know if this is the right thing to do, but I feel like our DSP emulation is good enough that every game that needs DSP-LLE to function has it enabled by default.

Anyway, I think to help reduce user confusion it might be good to explicitly mark DSP-HLE as recommended, and mark DSP-LLE Recompiler as slow.  DSP-LLE Interpreter I've marked as very slow as it is very slow.