### PR TITLE
MemoryViewWidget: Remove unnecessary column

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -68,7 +68,7 @@ void MemoryViewWidget::Update()
 {
   clearSelection();
 
-  setColumnCount(3 + GetColumnCount(m_type));
+  setColumnCount(2 + GetColumnCount(m_type));
 
   if (rowCount() == 0)
     setRowCount(1);


### PR DESCRIPTION
This column would end up containing junk data after changing the data type, specifically whatever data was already in that column in the previous datatype.

Column 0 is used for a breakpoint indicator (if the entire row has breakpoints).  Column 1 is the address.  Columns 2 through 2+n, exclusive, are used for the data for the row, where n varies by data type (for U8 it's 16, but for float and U32 it's 4); for example, with float, columns 2, 3, 4, and 5 are in use.  Thus, there are 6 columns (0 through 5), which is 2+4, not 3+4.

Before: [First set to U8](https://user-images.githubusercontent.com/8334194/126725530-33737d38-eee1-4d45-8a6d-2a1914fa7d64.png), [then change to float](https://user-images.githubusercontent.com/8334194/126725539-0883e351-755d-4cbe-84cd-643958deb9e3.png)
After: [First set to U8](https://user-images.githubusercontent.com/8334194/126725548-85570bf7-3101-4d0f-8217-7fd0fa1cd686.png), [then change to float](https://user-images.githubusercontent.com/8334194/126725554-0bd4195e-2cf4-4660-b920-a22394363c06.png)
