### PR TITLE
Android: Allow non-square overlay control images

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -102,11 +102,14 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     // Determine the button size based on the smaller screen dimension.
     // This makes sure the buttons are the same size in both portrait and landscape.
     DisplayMetrics dm = context.getResources().getDisplayMetrics();
-    int minDimension = Math.min(dm.widthPixels, dm.heightPixels);
+    int minScreenDimension = Math.min(dm.widthPixels, dm.heightPixels);
+
+    int maxBitmapDimension = Math.max(bitmap.getWidth(), bitmap.getHeight());
+    float bitmapScale = scale * minScreenDimension / maxBitmapDimension;
 
     return Bitmap.createScaledBitmap(bitmap,
-            (int) (minDimension * scale),
-            (int) (minDimension * scale),
+            (int) (bitmap.getWidth() * bitmapScale),
+            (int) (bitmap.getHeight() * bitmapScale),
             true);
   }
 


### PR DESCRIPTION
This removes an assumption in the code which made every overlay control image be scaled to a square even if the actual image was rectangular.