### PR TITLE
GameINI: Add FFCC GBA Connectivity patch to all regions

### DIFF
--- a/Data/Sys/GameSettings/GCCJGC.ini
+++ b/Data/Sys/GameSettings/GCCJGC.ini
@@ -1,0 +1,26 @@
+# GCCJGC - FINAL FANTASY Crystal Chronicles
+
+[OnFrame]
+
+# Fix a race condition that makes GBAs take longer to connect when entering a level.
+$Fix GBA connections
+0x800AFB3C:dword:0x4BF551C5
+0x80004D00:dword:0x7CE802A6
+0x80004D04:dword:0x428008E9
+0x80004D08:dword:0x3C608000
+0x80004D0C:dword:0x38834D28
+0x80004D10:dword:0x807F10A0
+0x80004D14:dword:0x3863132C
+0x80004D18:dword:0x38A00018
+0x80004D1C:dword:0x428008D1
+0x80004D20:dword:0x7CE803A6
+0x80004D24:dword:0x4E800020
+0x80004D28:dword:0x0480FF20
+0x80004D2C:dword:0x18705C70
+0x80004D30:dword:0x04490120
+0x80004D34:dword:0x08700149
+0x80004D38:dword:0x0C6009E0
+0x80004D3C:dword:0x38010003
+
+[OnFrame_Enabled]
+$Fix GBA connections

--- a/Data/Sys/GameSettings/GCCP01.ini
+++ b/Data/Sys/GameSettings/GCCP01.ini
@@ -1,0 +1,26 @@
+# GCCP01 - FINAL FANTASY Crystal Chronicles
+
+[OnFrame]
+
+# Fix a race condition that makes GBAs take longer to connect when entering a level.
+$Fix GBA connections
+0x800B1F8C:dword:0x4BF52D75
+0x80004d00:dword:0x7ce802a6
+0x80004d04:dword:0x428007f1
+0x80004d08:dword:0x3c608000
+0x80004d0c:dword:0x38834d28
+0x80004d10:dword:0x807f10a0
+0x80004d14:dword:0x38632504
+0x80004d18:dword:0x38a00018
+0x80004d1c:dword:0x428007d9
+0x80004d20:dword:0x7ce803a6
+0x80004d24:dword:0x4e800020
+0x80004d28:dword:0x0480ff20
+0x80004d2c:dword:0x18705c70
+0x80004d30:dword:0x04490120
+0x80004d34:dword:0x08700149
+0x80004d38:dword:0x0c6009e0
+0x80004D3C:dword:0x90010003
+
+[OnFrame_Enabled]
+$Fix GBA connections


### PR DESCRIPTION
This is a port of the NTSC patch to the Japanese and PAL regions.  Bonta helped with the GBA code for both versions and wrote the original NTSC patch, and leoetlino helped convert some addresses for the japanese version.