### PR TITLE
GameINI: Fix F1 2002 crash starting a race

### DIFF
--- a/Data/Sys/GameSettings/GF2E69.ini
+++ b/Data/Sys/GameSettings/GF2E69.ini
@@ -1,0 +1,3 @@
+[Core]
+# Values set here will override the main Dolphin settings.
+JITFollowBranch = False


### PR DESCRIPTION
in F1 2002 when the game finishes loading to start the race it closes unexpectedly, this is because it requires having the JIT Follow Branch disabled.