### PR TITLE
WiimoteReal: Remove unused IsReady() functions

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOAndroid.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOAndroid.h
@@ -44,7 +44,6 @@ class WiimoteScannerAndroid final : public WiimoteScannerBackend
 public:
   WiimoteScannerAndroid() = default;
   ~WiimoteScannerAndroid() override = default;
-  bool IsReady() const override { return true; }
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}
   void RequestStopSearching() override {}

--- a/Source/Core/Core/HW/WiimoteReal/IODummy.h
+++ b/Source/Core/Core/HW/WiimoteReal/IODummy.h
@@ -12,7 +12,6 @@ class WiimoteScannerDummy final : public WiimoteScannerBackend
 public:
   WiimoteScannerDummy() = default;
   ~WiimoteScannerDummy() override = default;
-  bool IsReady() const override { return false; }
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override {}
   void Update() override {}
   void RequestStopSearching() override {}

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
@@ -38,13 +38,8 @@ WiimoteScannerLinux::WiimoteScannerLinux() : m_device_id(-1), m_device_sock(-1)
 
 WiimoteScannerLinux::~WiimoteScannerLinux()
 {
-  if (IsReady())
+  if (m_device_sock > 0)
     close(m_device_sock);
-}
-
-bool WiimoteScannerLinux::IsReady() const
-{
-  return m_device_sock > 0;
 }
 
 void WiimoteScannerLinux::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wiimote*& found_board)

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.h
@@ -43,7 +43,6 @@ class WiimoteScannerLinux final : public WiimoteScannerBackend
 public:
   WiimoteScannerLinux();
   ~WiimoteScannerLinux() override;
-  bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}                // not needed on Linux
   void RequestStopSearching() override {}  // not needed on Linux

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -587,33 +587,6 @@ void WiimoteScannerWindows::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
   SetupDiDestroyDeviceInfoList(device_info);
 }
 
-bool WiimoteScannerWindows::IsReady() const
-{
-  if (!s_loaded_ok)
-  {
-    return false;
-  }
-
-  // TODO: don't search for a radio each time
-
-  BLUETOOTH_FIND_RADIO_PARAMS radioParam;
-  radioParam.dwSize = sizeof(radioParam);
-
-  HANDLE hRadio;
-  HBLUETOOTH_RADIO_FIND hFindRadio = pBluetoothFindFirstRadio(&radioParam, &hRadio);
-
-  if (nullptr != hFindRadio)
-  {
-    CloseHandle(hRadio);
-    pBluetoothFindRadioClose(hFindRadio);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
-}
-
 // Connect to a Wiimote with a known device path.
 bool WiimoteWindows::ConnectInternal()
 {

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.h
@@ -48,7 +48,6 @@ class WiimoteScannerWindows final : public WiimoteScannerBackend
 public:
   WiimoteScannerWindows();
   ~WiimoteScannerWindows() override;
-  bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override;
   void RequestStopSearching() override {}

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
@@ -20,7 +20,6 @@ class WiimoteScannerDarwin final : public WiimoteScannerBackend
 public:
   WiimoteScannerDarwin();
   ~WiimoteScannerDarwin() override;
-  bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}  // not needed
   void RequestStopSearching() override { m_stop_scanning = true; }

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -103,11 +103,6 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
   [sbt release];
 }
 
-bool WiimoteScannerDarwin::IsReady() const
-{
-  return m_host_controller != nil;
-}
-
 WiimoteDarwin::WiimoteDarwin(IOBluetoothDevice* device) : m_btd(device)
 {
   m_inputlen = 0;

--- a/Source/Core/Core/HW/WiimoteReal/IOhidapi.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOhidapi.cpp
@@ -50,11 +50,6 @@ WiimoteScannerHidapi::~WiimoteScannerHidapi()
     ERROR_LOG_FMT(WIIMOTE, "Failed to clean up hidapi.");
 }
 
-bool WiimoteScannerHidapi::IsReady() const
-{
-  return true;
-}
-
 void WiimoteScannerHidapi::FindWiimotes(std::vector<Wiimote*>& wiimotes, Wiimote*& board)
 {
   hid_device_info* list = hid_enumerate(0x0, 0x0);

--- a/Source/Core/Core/HW/WiimoteReal/IOhidapi.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOhidapi.h
@@ -35,7 +35,6 @@ class WiimoteScannerHidapi final : public WiimoteScannerBackend
 public:
   WiimoteScannerHidapi();
   ~WiimoteScannerHidapi();
-  bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}                // not needed for hidapi
   void RequestStopSearching() override {}  // not needed for hidapi

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -566,13 +566,6 @@ void WiimoteScanner::SetScanMode(WiimoteScanMode scan_mode)
   m_scan_mode_changed_or_population_event.Set();
 }
 
-bool WiimoteScanner::IsReady() const
-{
-  std::lock_guard lg(m_backends_mutex);
-  return std::any_of(m_backends.begin(), m_backends.end(),
-                     [](const auto& backend) { return backend->IsReady(); });
-}
-
 static void CheckForDisconnectedWiimotes()
 {
   std::lock_guard lk(g_wiimotes_mutex);

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -150,7 +150,6 @@ class WiimoteScannerBackend
 {
 public:
   virtual ~WiimoteScannerBackend() = default;
-  virtual bool IsReady() const = 0;
   virtual void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) = 0;
   // function called when not looking for more Wiimotes
   virtual void Update() = 0;
@@ -173,8 +172,6 @@ public:
   void StopThread();
   void SetScanMode(WiimoteScanMode scan_mode);
   void PopulateDevices();
-
-  bool IsReady() const;
 
 private:
   void ThreadFunc();


### PR DESCRIPTION
The backends have IsReady() functions which would be called from WiimoteScanner::IsReady(), but that function itself is never called. I went digging through history, and as far as I can tell it never was...?

The Linux backend did call WiimoteScannerLinux::IsReady() from its destructor, but in that context I think the code is clearer if it's inlined so I did.