### PR TITLE
GameINI:  Fix Garfield Hang

### DIFF
--- a/Data/Sys/GameSettings/SG7.ini
+++ b/Data/Sys/GameSettings/SG7.ini
@@ -1,0 +1,14 @@
+# SG7PVL, SG7E20 - The Garfield Show: Threat of the Space Lasagna
+
+[Core]
+# Garfield hangs on level start when Dual Core is enabled.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.


### PR DESCRIPTION
The Garfield Show: Threat of the Space Lasagna hangs on story mission start with Dual Core most of the time.

I didn't ask for SyncGPU to be tested as it's suffering from coderot at the moment and we're not sure of the future of it.  Single Core, isn't going anywhere, though.