### PR TITLE
Jit: Perform BAT lookup in dcbf/dcbi/dcbst

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -234,21 +234,37 @@ void Jit64::dcbx(UGeckoInstruction inst)
   JITDISABLE(bJITLoadStoreOff);
 
   X64Reg addr = RSCRATCH;
+  X64Reg value = RSCRATCH2;
   RCOpArg Ra = inst.RA ? gpr.Use(inst.RA, RCMode::Read) : RCOpArg::Imm32(0);
   RCOpArg Rb = gpr.Use(inst.RB, RCMode::Read);
-  RegCache::Realize(Ra, Rb);
+  RCX64Reg tmp = gpr.Scratch();
+  RegCache::Realize(Ra, Rb, tmp);
 
   MOV_sum(32, addr, Ra, Rb);
-  AND(32, R(addr), Imm8(~31));
 
+  // Check whether a JIT cache line needs to be invalidated.
+  LEA(32, value, MScaled(addr, SCALE_8, 0));  // addr << 3 (masks the first 3 bits)
+  SHR(32, R(value), Imm8(3 + 5 + 5));         // >> 5 for cache line size, >> 5 for width of bitset
+  MOV(64, R(tmp), ImmPtr(GetBlockCache()->GetBlockBitSet()));
+  MOV(32, R(value), MComplex(tmp, value, SCALE_4, 0));
+  SHR(32, R(addr), Imm8(5));
+  BT(32, R(value), R(addr));
+
+  FixupBranch c = J_CC(CC_C, true);
+  SwitchToFarCode();
+  SetJumpTarget(c);
   BitSet32 registersInUse = CallerSavedRegistersInUse();
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
   MOV(32, R(ABI_PARAM1), R(addr));
+  SHL(32, R(ABI_PARAM1), Imm8(5));
   MOV(32, R(ABI_PARAM2), Imm32(32));
   XOR(32, R(ABI_PARAM3), R(ABI_PARAM3));
   ABI_CallFunction(JitInterface::InvalidateICache);
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);
   asm_routines.ResetStack(*this);
+  c = J(true);
+  SwitchToNearCode();
+  SetJumpTarget(c);
 }
 
 void Jit64::dcbt(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -240,31 +240,46 @@ void Jit64::dcbx(UGeckoInstruction inst)
   RCX64Reg tmp = gpr.Scratch();
   RegCache::Realize(Ra, Rb, tmp);
 
-  MOV_sum(32, addr, Ra, Rb);
+  // Translate effective address to physical address.
+  MOV_sum(32, value, Ra, Rb);
+  FixupBranch bat_lookup_failed;
+  if (MSR.IR)
+  {
+    MOV(32, R(addr), R(value));
+    bat_lookup_failed = BATAddressLookup(value, tmp);
+    AND(32, R(addr), Imm32(0x0001ffff));
+    AND(32, R(value), Imm32(0xfffe0000));
+    OR(32, R(value), R(addr));
+  }
+  MOV(32, R(addr), R(value));
 
   // Check whether a JIT cache line needs to be invalidated.
-  LEA(32, value, MScaled(addr, SCALE_8, 0));  // addr << 3 (masks the first 3 bits)
-  SHR(32, R(value), Imm8(3 + 5 + 5));         // >> 5 for cache line size, >> 5 for width of bitset
+  SHR(32, R(value), Imm8(5 + 5));  // >> 5 for cache line size, >> 5 for width of bitset
   MOV(64, R(tmp), ImmPtr(GetBlockCache()->GetBlockBitSet()));
   MOV(32, R(value), MComplex(tmp, value, SCALE_4, 0));
   SHR(32, R(addr), Imm8(5));
   BT(32, R(value), R(addr));
+  FixupBranch invalidate_needed = J_CC(CC_C, true);
 
-  FixupBranch c = J_CC(CC_C, true);
   SwitchToFarCode();
-  SetJumpTarget(c);
+  SetJumpTarget(invalidate_needed);
+  SHL(32, R(addr), Imm8(5));
+  if (MSR.IR)
+    SetJumpTarget(bat_lookup_failed);
+
   BitSet32 registersInUse = CallerSavedRegistersInUse();
+  registersInUse[X64Reg(tmp)] = false;
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
   MOV(32, R(ABI_PARAM1), R(addr));
-  SHL(32, R(ABI_PARAM1), Imm8(5));
   MOV(32, R(ABI_PARAM2), Imm32(32));
   XOR(32, R(ABI_PARAM3), R(ABI_PARAM3));
   ABI_CallFunction(JitInterface::InvalidateICache);
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);
   asm_routines.ResetStack(*this);
-  c = J(true);
+
+  FixupBranch done = J(true);
   SwitchToNearCode();
-  SetJumpTarget(c);
+  SetJumpTarget(done);
 }
 
 void Jit64::dcbt(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -91,6 +91,16 @@ void EmuCodeBlock::SwitchToNearCode()
   SetCodePtr(m_near_code, m_near_code_end, m_near_code_write_failed);
 }
 
+FixupBranch EmuCodeBlock::BATAddressLookup(X64Reg addr, X64Reg tmp)
+{
+  MOV(64, R(tmp), ImmPtr(&PowerPC::dbat_table[0]));
+  SHR(32, R(addr), Imm8(PowerPC::BAT_INDEX_SHIFT));
+  MOV(32, R(addr), MComplex(tmp, addr, SCALE_4, 0));
+  BT(32, R(addr), Imm8(IntLog2(PowerPC::BAT_MAPPED_BIT)));
+
+  return J_CC(CC_Z, m_far_code.Enabled());
+}
+
 FixupBranch EmuCodeBlock::CheckIfSafeAddress(const OpArg& reg_value, X64Reg reg_addr,
                                              BitSet32 registers_in_use)
 {

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -49,6 +49,10 @@ public:
     return Gen::M(m_const_pool.GetConstant(&value, sizeof(T), N, index));
   }
 
+  // Writes upper 15 bits of physical address to addr and clobbers the lower 17 bits of addr.
+  // Jumps to the returned FixupBranch if lookup fails.
+  Gen::FixupBranch BATAddressLookup(Gen::X64Reg addr, Gen::X64Reg tmp);
+
   Gen::FixupBranch CheckIfSafeAddress(const Gen::OpArg& reg_value, Gen::X64Reg reg_addr,
                                       BitSet32 registers_in_use);
   void UnsafeLoadRegToReg(Gen::X64Reg reg_addr, Gen::X64Reg reg_value, int accessSize,

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -229,6 +229,10 @@ protected:
   // Loadstore routines
   void SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 offset, bool update);
   void SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s32 offset);
+  // If lookup succeeds, writes upper 15 bits of physical address to addr_out. If not,
+  // jumps to the returned FixupBranch. Clobbers tmp and the 17 lower bits of addr_out.
+  Arm64Gen::FixupBranch BATAddressLookup(Arm64Gen::ARM64Reg addr_out, Arm64Gen::ARM64Reg addr_in,
+                                         Arm64Gen::ARM64Reg tmp);
 
   void DoJit(u32 em_address, JitBlock* b, u32 nextPC);
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -269,6 +269,11 @@ void JitBaseBlockCache::ErasePhysicalRange(u32 address, u32 length)
   }
 }
 
+u32* JitBaseBlockCache::GetBlockBitSet() const
+{
+  return valid_block.m_valid_block.get();
+}
+
 void JitBaseBlockCache::WriteDestroyBlock(const JitBlock& block)
 {
 }

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -121,7 +121,7 @@ public:
   void Set(u32 bit) { m_valid_block[bit / 32] |= 1u << (bit % 32); }
   void Clear(u32 bit) { m_valid_block[bit / 32] &= ~(1u << (bit % 32)); }
   void ClearAll() { memset(m_valid_block.get(), 0, sizeof(u32) * VALID_BLOCK_ALLOC_ELEMENTS); }
-  bool Test(u32 bit) { return (m_valid_block[bit / 32] & (1u << (bit % 32))) != 0; }
+  bool Test(u32 bit) const { return (m_valid_block[bit / 32] & (1u << (bit % 32))) != 0; }
 };
 
 class JitBaseBlockCache

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -99,18 +99,6 @@ typedef void (*CompiledCode)();
 class ValidBlockBitSet final
 {
 public:
-  ValidBlockBitSet()
-  {
-    m_valid_block.reset(new u32[VALID_BLOCK_ALLOC_ELEMENTS]);
-    ClearAll();
-  }
-
-  void Set(u32 bit) { m_valid_block[bit / 32] |= 1u << (bit % 32); }
-  void Clear(u32 bit) { m_valid_block[bit / 32] &= ~(1u << (bit % 32)); }
-  void ClearAll() { memset(m_valid_block.get(), 0, sizeof(u32) * VALID_BLOCK_ALLOC_ELEMENTS); }
-  bool Test(u32 bit) { return (m_valid_block[bit / 32] & (1u << (bit % 32))) != 0; }
-
-private:
   enum
   {
     // ValidBlockBitSet covers the whole 32-bit address-space in 32-byte
@@ -121,7 +109,19 @@ private:
     // The number of elements in the allocated array. Each u32 contains 32 bits.
     VALID_BLOCK_ALLOC_ELEMENTS = VALID_BLOCK_MASK_SIZE / 32
   };
+  // Directly accessed by Jit64.
   std::unique_ptr<u32[]> m_valid_block;
+
+  ValidBlockBitSet()
+  {
+    m_valid_block.reset(new u32[VALID_BLOCK_ALLOC_ELEMENTS]);
+    ClearAll();
+  }
+
+  void Set(u32 bit) { m_valid_block[bit / 32] |= 1u << (bit % 32); }
+  void Clear(u32 bit) { m_valid_block[bit / 32] &= ~(1u << (bit % 32)); }
+  void ClearAll() { memset(m_valid_block.get(), 0, sizeof(u32) * VALID_BLOCK_ALLOC_ELEMENTS); }
+  bool Test(u32 bit) { return (m_valid_block[bit / 32] & (1u << (bit % 32))) != 0; }
 };
 
 class JitBaseBlockCache
@@ -162,6 +162,8 @@ public:
 
   void InvalidateICache(u32 address, u32 length, bool forced);
   void ErasePhysicalRange(u32 address, u32 length);
+
+  u32* GetBlockBitSet() const;
 
 protected:
   virtual void DestroyBlock(JitBlock& block);


### PR DESCRIPTION
When PR #9314 fixed https://bugs.dolphin-emu.org/issues/12133, it did so by removing the broken address calculation entirely and always using the slow path. This caused a performance regression, https://bugs.dolphin-emu.org/issues/12477.

This pull request instead replaces the broken address calculation with a BAT lookup. If the BAT lookup succeeds, we can use the old fast path. Otherwise we use the slow path.

Intends to improve https://bugs.dolphin-emu.org/issues/12477.

@JMC47 Please test Happy Feet and some games with known performance problems.

Everyone else: I'm not entirely confident that I made no mistakes with the assembly, so don't let JMC merge this before it's been properly reviewed :)