### PR TITLE
VideoBackendBase: Prefer Vulkan over OGL on macOS Mojave and newer

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -214,6 +214,10 @@ const std::vector<std::unique_ptr<VideoBackendBase>>& VideoBackendBase::GetAvail
     std::vector<std::unique_ptr<VideoBackendBase>> backends;
 
     // OGL > D3D11 > D3D12 > Vulkan > SW > Null
+    //
+    // On macOS Mojave and newer, we prefer Vulkan over OGL due to outdated drivers.
+    // However, on macOS High Sierra and older, we still prefer OGL due to its older Metal version
+    // missing several features required by the Vulkan backend.
 #ifdef HAS_OPENGL
     backends.push_back(std::make_unique<OGL::VideoBackend>());
 #endif
@@ -222,7 +226,18 @@ const std::vector<std::unique_ptr<VideoBackendBase>>& VideoBackendBase::GetAvail
     backends.push_back(std::make_unique<DX12::VideoBackend>());
 #endif
 #ifdef HAS_VULKAN
-    backends.push_back(std::make_unique<Vulkan::VideoBackend>());
+#ifdef __APPLE__
+    // If we can run the Vulkan backend, emplace it at the beginning of the vector so
+    // it takes precedence over OpenGL.
+    if (__builtin_available(macOS 10.14, *))
+    {
+      backends.emplace(backends.begin(), std::make_unique<Vulkan::VideoBackend>());
+    }
+    else
+#endif
+    {
+      backends.push_back(std::make_unique<Vulkan::VideoBackend>());
+    }
 #endif
 #ifdef HAS_OPENGL
     backends.push_back(std::make_unique<SW::VideoSoftware>());


### PR DESCRIPTION
macOS's OpenGL support is terribly outdated - it's been stuck on OpenGL 4.1 since Mavericks (released in 2013!) and doesn't support key extensions like ``ARB_buffer_storage``. Plus, starting with macOS Mojave, OpenGL has been deprecated and may be removed in a future macOS.

Now that we have MoltenVK, it might be best to set the Vulkan backend as default for new users with Macs that run Mojave and newer. (High Sierra and older don't support some Metal features that Dolphin requires.)
