### PR TITLE
PowerPC: Implement broken masking for uncached unaligned writes

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -323,14 +323,14 @@ void Interpreter::lwzu(UGeckoInstruction inst)
 
 void Interpreter::stb(UGeckoInstruction inst)
 {
-  PowerPC::Write_U8((u8)rGPR[inst.RS], Helper_Get_EA(PowerPC::ppcState, inst));
+  PowerPC::Write_U8(rGPR[inst.RS], Helper_Get_EA(PowerPC::ppcState, inst));
 }
 
 void Interpreter::stbu(UGeckoInstruction inst)
 {
   const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
 
-  PowerPC::Write_U8((u8)rGPR[inst.RS], address);
+  PowerPC::Write_U8(rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
     rGPR[inst.RA] = address;
@@ -399,14 +399,14 @@ void Interpreter::stfsu(UGeckoInstruction inst)
 
 void Interpreter::sth(UGeckoInstruction inst)
 {
-  PowerPC::Write_U16((u16)rGPR[inst.RS], Helper_Get_EA(PowerPC::ppcState, inst));
+  PowerPC::Write_U16(rGPR[inst.RS], Helper_Get_EA(PowerPC::ppcState, inst));
 }
 
 void Interpreter::sthu(UGeckoInstruction inst)
 {
   const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
 
-  PowerPC::Write_U16((u16)rGPR[inst.RS], address);
+  PowerPC::Write_U16(rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
     rGPR[inst.RA] = address;
@@ -731,7 +731,7 @@ void Interpreter::stbux(UGeckoInstruction inst)
 {
   const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
 
-  PowerPC::Write_U8((u8)rGPR[inst.RS], address);
+  PowerPC::Write_U8(rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
     rGPR[inst.RA] = address;
@@ -740,7 +740,7 @@ void Interpreter::stbux(UGeckoInstruction inst)
 
 void Interpreter::stbx(UGeckoInstruction inst)
 {
-  PowerPC::Write_U8((u8)rGPR[inst.RS], Helper_Get_EA_X(PowerPC::ppcState, inst));
+  PowerPC::Write_U8(rGPR[inst.RS], Helper_Get_EA_X(PowerPC::ppcState, inst));
 }
 
 void Interpreter::stfdux(UGeckoInstruction inst)
@@ -819,14 +819,14 @@ void Interpreter::stfsx(UGeckoInstruction inst)
 
 void Interpreter::sthbrx(UGeckoInstruction inst)
 {
-  PowerPC::Write_U16(Common::swap16((u16)rGPR[inst.RS]), Helper_Get_EA_X(PowerPC::ppcState, inst));
+  PowerPC::Write_U16_Swap(rGPR[inst.RS], Helper_Get_EA_X(PowerPC::ppcState, inst));
 }
 
 void Interpreter::sthux(UGeckoInstruction inst)
 {
   const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
 
-  PowerPC::Write_U16((u16)rGPR[inst.RS], address);
+  PowerPC::Write_U16(rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
     rGPR[inst.RA] = address;
@@ -835,7 +835,7 @@ void Interpreter::sthux(UGeckoInstruction inst)
 
 void Interpreter::sthx(UGeckoInstruction inst)
 {
-  PowerPC::Write_U16((u16)rGPR[inst.RS], Helper_Get_EA_X(PowerPC::ppcState, inst));
+  PowerPC::Write_U16(rGPR[inst.RS], Helper_Get_EA_X(PowerPC::ppcState, inst));
 }
 
 // lswi - bizarro string instruction
@@ -968,7 +968,7 @@ void Interpreter::stwbrx(UGeckoInstruction inst)
 {
   const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
-  PowerPC::Write_U32(Common::swap32(rGPR[inst.RS]), address);
+  PowerPC::Write_U32_Swap(rGPR[inst.RS], address);
 }
 
 // The following two instructions are for SMP communications. On a single

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -197,18 +197,16 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode, AR
     }
     else if (flags & BackPatchInfo::FLAG_STORE)
     {
-      ARM64Reg temp = ARM64Reg::W0;
-      temp = ByteswapBeforeStore(this, temp, RS, flags, false);
-      if (temp != ARM64Reg::W0)
-        MOV(ARM64Reg::W0, temp);
+      const bool reverse = (flags & BackPatchInfo::FLAG_REVERSE) != 0;
 
       if (flags & BackPatchInfo::FLAG_SIZE_32)
-        MOVP2R(ARM64Reg::X8, &PowerPC::Write_U32);
+        MOVP2R(ARM64Reg::X8, reverse ? &PowerPC::Write_U32_Swap : &PowerPC::Write_U32);
       else if (flags & BackPatchInfo::FLAG_SIZE_16)
-        MOVP2R(ARM64Reg::X8, &PowerPC::Write_U16);
+        MOVP2R(ARM64Reg::X8, reverse ? &PowerPC::Write_U16_Swap : &PowerPC::Write_U16);
       else
         MOVP2R(ARM64Reg::X8, &PowerPC::Write_U8);
 
+      MOV(ARM64Reg::W0, RS);
       BLR(ARM64Reg::X8);
     }
     else if (flags & BackPatchInfo::FLAG_ZERO_256)

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -18,6 +18,7 @@
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/Memmap.h"
+#include "Core/HW/ProcessorInterface.h"
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/PowerPC.h"
 
@@ -367,6 +368,11 @@ static void WriteToHardware(u32 em_address, const u32 data, const u32 size)
     // the upper 32 bits and one for the lower 32 bits - which leads to some odd data duplication
     // behavior for write-through/cache-inhibited writes with a start address or end address that
     // isn't 32-bit aligned. See https://bugs.dolphin-emu.org/issues/12565 for details.
+
+    // TODO: This interrupt is supposed to have associated cause and address registers
+    // TODO: This should trigger the hwtest's interrupt handling, but it does not seem to
+    //       (https://github.com/dolphin-emu/hwtests/pull/42)
+    ProcessorInterface::SetInterrupt(ProcessorInterface::INT_CAUSE_PI);
 
     const u32 rotated_data = Common::RotateRight(data, ((em_address & 0x3) + size) * 8);
 

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -86,8 +86,8 @@ HostTryReadString(u32 address, size_t size = 0,
 // Writes a value to emulated memory using the currently active MMU settings.
 // If the write fails (eg. address does not correspond to a mapped address in the current address
 // space), a PanicAlert will be shown to the user.
-void HostWrite_U8(u8 var, u32 address);
-void HostWrite_U16(u16 var, u32 address);
+void HostWrite_U8(u32 var, u32 address);
+void HostWrite_U16(u32 var, u32 address);
 void HostWrite_U32(u32 var, u32 address);
 void HostWrite_U64(u64 var, u32 address);
 void HostWrite_F32(float var, u32 address);
@@ -111,9 +111,9 @@ struct TryWriteResult
 // If the write succeeds, the returned TryWriteResult contains information on whether the given
 // address had to be translated or not. Unlike the HostWrite functions, this does not raise a
 // user-visible alert on failure.
-TryWriteResult HostTryWriteU8(u8 var, const u32 address,
+TryWriteResult HostTryWriteU8(u32 var, const u32 address,
                               RequestedAddressSpace space = RequestedAddressSpace::Effective);
-TryWriteResult HostTryWriteU16(u16 var, const u32 address,
+TryWriteResult HostTryWriteU16(u32 var, const u32 address,
                                RequestedAddressSpace space = RequestedAddressSpace::Effective);
 TryWriteResult HostTryWriteU32(u32 var, const u32 address,
                                RequestedAddressSpace space = RequestedAddressSpace::Effective);
@@ -158,12 +158,12 @@ double Read_F64(u32 address);
 u32 Read_U8_ZX(u32 address);
 u32 Read_U16_ZX(u32 address);
 
-void Write_U8(u8 var, u32 address);
-void Write_U16(u16 var, u32 address);
+void Write_U8(u32 var, u32 address);
+void Write_U16(u32 var, u32 address);
 void Write_U32(u32 var, u32 address);
 void Write_U64(u64 var, u32 address);
 
-void Write_U16_Swap(u16 var, u32 address);
+void Write_U16_Swap(u32 var, u32 address);
 void Write_U32_Swap(u32 var, u32 address);
 void Write_U64_Swap(u64 var, u32 address);
 

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -199,16 +199,18 @@ constexpr int BAT_INDEX_SHIFT = 17;
 constexpr u32 BAT_PAGE_SIZE = 1 << BAT_INDEX_SHIFT;
 constexpr u32 BAT_MAPPED_BIT = 0x1;
 constexpr u32 BAT_PHYSICAL_BIT = 0x2;
-constexpr u32 BAT_RESULT_MASK = UINT32_C(~0x3);
+constexpr u32 BAT_WI_BIT = 0x4;
+constexpr u32 BAT_RESULT_MASK = UINT32_C(~0x7);
 using BatTable = std::array<u32, 1 << (32 - BAT_INDEX_SHIFT)>;  // 128 KB
 extern BatTable ibat_table;
 extern BatTable dbat_table;
-inline bool TranslateBatAddess(const BatTable& bat_table, u32* address)
+inline bool TranslateBatAddess(const BatTable& bat_table, u32* address, bool* wi)
 {
   u32 bat_result = bat_table[*address >> BAT_INDEX_SHIFT];
   if ((bat_result & BAT_MAPPED_BIT) == 0)
     return false;
   *address = (bat_result & BAT_RESULT_MASK) | (*address & (BAT_PAGE_SIZE - 1));
+  *wi = (bat_result & BAT_WI_BIT) != 0;
   return true;
 }
 


### PR DESCRIPTION
This implements the behavior described in https://bugs.dolphin-emu.org/issues/12565.

The implementation requires writes to pass through slowmem in order to be affected. Since most users probably don't care about emulating this behavior and thus wouldn't want performance to get lower just for the sake of emulating it, I've added a new INI-only setting `AlignmentQuirks` which controls whether slowmem is forced for uncached memory.

Thank you to eigenform, delroth, phire, marcan, segher, and Extrems for all helping in one way or another with the efforts to reverse engineer this behavior, and to Rylie for reporting the issue.