### PR TITLE
GameINI: Add FFCC Connectivity patch to all regions

### DIFF
--- a/Data/Sys/GameSettings/GCCJGC.ini
+++ b/Data/Sys/GameSettings/GCCJGC.ini
@@ -1,0 +1,25 @@
+# GCCJGC - FINAL FANTASY Crystal Chronicles
+
+[OnFrame]
+# Fix a race condition that makes GBAs take longer to connect when entering a level.
+$Fix GBA connections
+0x800afb3c:dword:0x4bf551c5
+0x80004d00:dword:0x7ce802a6
+0x80004d04:dword:0x428008e9
+0x80004d08:dword:0x3c608000
+0x80004d0c:dword:0x38834d28
+0x80004d10:dword:0x807f10a0
+0x80004d14:dword:0x3863132c
+0x80004d18:dword:0x38a00018
+0x80004d1c:dword:0x428008d1
+0x80004d20:dword:0x7ce803a6
+0x80004d24:dword:0x4e800020
+0x80004d28:dword:0x0480ff20
+0x80004d2c:dword:0x18705c70
+0x80004d30:dword:0x04490120
+0x80004d34:dword:0x08700149
+0x80004d38:dword:0x0c6009e0
+0x80004d3c:dword:0x38010003
+
+[OnFrame_Enabled]
+$Fix GBA connections

--- a/Data/Sys/GameSettings/GCCP01.ini
+++ b/Data/Sys/GameSettings/GCCP01.ini
@@ -1,0 +1,25 @@
+# GCCP01 - FINAL FANTASY Crystal Chronicles
+
+[OnFrame]
+# Fix a race condition that makes GBAs take longer to connect when entering a level.
+$Fix GBA connections
+0x800b1f8c:dword:0x4bf52d75
+0x80004d00:dword:0x7ce802a6
+0x80004d04:dword:0x428007f1
+0x80004d08:dword:0x3c608000
+0x80004d0c:dword:0x38834d28
+0x80004d10:dword:0x807f10a0
+0x80004d14:dword:0x38632504
+0x80004d18:dword:0x38a00018
+0x80004d1c:dword:0x428007d9
+0x80004d20:dword:0x7ce803a6
+0x80004d24:dword:0x4e800020
+0x80004d28:dword:0x0480ff20
+0x80004d2c:dword:0x18705c70
+0x80004d30:dword:0x04490120
+0x80004d34:dword:0x08700149
+0x80004d38:dword:0x0c6009e0
+0x80004d3c:dword:0x90010003
+
+[OnFrame_Enabled]
+$Fix GBA connections


### PR DESCRIPTION
This is a port of the NTSC patch to the Japanese and PAL regions. Bonta helped with the GBA code for both versions and wrote the original NTSC patch, and leoetlino helped convert some addresses for the japanese version.