### PR TITLE
GameINI: Add Safe Texture Cache to Inazuma Eleven GO: Strikers 2013

### DIFF
--- a/Data/Sys/GameSettings/S5S.ini
+++ b/Data/Sys/GameSettings/S5S.ini
@@ -1,0 +1,17 @@
+# S5SJHF - Inazuma Eleven GO: Strikers 2013
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+# SafeTextureCache is required for text to render properly.
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
Certain text characters do not render properly with any other texture cache setting.  We tested 2048 and 512, and that was not enough to completely remedy the issue.