### PR TITLE
Recompile shaders when 'Enable API Validation Layers' is toggled

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -203,7 +203,8 @@ void AdvancedWidget::AddDescriptions()
                  "unchecked.</dolphin_emphasis>");
   static const char TR_VALIDATION_LAYER_DESCRIPTION[] =
       QT_TR_NOOP("Enables validation of API calls made by the video backend, which may assist in "
-                 "debugging graphical issues.<br><br><dolphin_emphasis>If unsure, leave this "
+                 "debugging graphical issues. On D3D backends, this also enables debug symbols "
+                 "for the compiled shaders.<br><br><dolphin_emphasis>If unsure, leave this "
                  "unchecked.</dolphin_emphasis>");
   static const char TR_DUMP_TEXTURE_DESCRIPTION[] =
       QT_TR_NOOP("Dumps decoded game textures based on the other flags to "

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -199,8 +199,7 @@ void AdvancedWidget::AddDescriptions()
                  "leave this unchecked.</dolphin_emphasis>");
   static const char TR_TEXTURE_FORMAT_DESCRIPTION[] =
       QT_TR_NOOP("Modifies textures to show the format they're encoded in.<br><br>May require "
-                 "an emulation "
-                 "reset to apply.<br><br><dolphin_emphasis>If unsure, leave this "
+                 "an emulation reset to apply.<br><br><dolphin_emphasis>If unsure, leave this "
                  "unchecked.</dolphin_emphasis>");
   static const char TR_VALIDATION_LAYER_DESCRIPTION[] =
       QT_TR_NOOP("Enables validation of API calls made by the video backend, which may assist in "
@@ -213,9 +212,8 @@ void AdvancedWidget::AddDescriptions()
   static const char TR_DUMP_MIP_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
       "Whether to dump mipmapped game textures to "
       "User/Dump/Textures/&lt;game_id&gt;/.  This includes arbitrary mipmapped textures if "
-      "'Arbitrary "
-      "Mipmap Detection' is enabled in Enhancements.<br><br><dolphin_emphasis>If unsure, leave "
-      "this checked.</dolphin_emphasis>");
+      "'Arbitrary Mipmap Detection' is enabled in Enhancements.<br><br>"
+      "<dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
   static const char TR_DUMP_BASE_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
       "Whether to dump base game textures to "
       "User/Dump/Textures/&lt;game_id&gt;/.  This includes arbitrary base textures if 'Arbitrary "
@@ -224,31 +222,26 @@ void AdvancedWidget::AddDescriptions()
   static const char TR_LOAD_CUSTOM_TEXTURE_DESCRIPTION[] =
       QT_TR_NOOP("Loads custom textures from User/Load/Textures/&lt;game_id&gt;/ and "
                  "User/Load/DynamicInputTextures/&lt;game_id&gt;/.<br><br><dolphin_emphasis>If "
-                 "unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
+                 "unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_CACHE_CUSTOM_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
       "Caches custom textures to system RAM on startup.<br><br>This can require exponentially "
       "more RAM but fixes possible stuttering.<br><br><dolphin_emphasis>If unsure, leave this "
       "unchecked.</dolphin_emphasis>");
   static const char TR_DUMP_EFB_DESCRIPTION[] =
-      QT_TR_NOOP("Dumps the contents of EFB copies to User/Dump/Textures/.<br><br "
-                 "/><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
+      QT_TR_NOOP("Dumps the contents of EFB copies to User/Dump/Textures/.<br><br>"
+                 "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_DUMP_XFB_DESCRIPTION[] =
-      QT_TR_NOOP("Dumps the contents of XFB copies to User/Dump/Textures/.<br><br "
-                 "/><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
+      QT_TR_NOOP("Dumps the contents of XFB copies to User/Dump/Textures/.<br><br>"
+                 "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_DISABLE_VRAM_COPIES_DESCRIPTION[] =
       QT_TR_NOOP("Disables the VRAM copy of the EFB, forcing a round-trip to RAM. Inhibits all "
                  "upscaling.<br><br><dolphin_emphasis>If unsure, leave this "
                  "unchecked.</dolphin_emphasis>");
   static const char TR_INTERNAL_RESOLUTION_FRAME_DUMPING_DESCRIPTION[] = QT_TR_NOOP(
       "Creates frame dumps and screenshots at the internal resolution of the renderer, rather than "
-      "the size of the window it is displayed within.<br><br>If the aspect ratio is "
-      "widescreen, the "
-      "output image will be scaled horizontally to preserve the vertical resolution.<br><br "
-      "/><dolphin_emphasis>If "
-      "unsure, leave this unchecked.</dolphin_emphasis>");
+      "the size of the window it is displayed within.<br><br>If the aspect ratio is widescreen, "
+      "the output image will be scaled horizontally to preserve the vertical resolution.<br><br>"
+      "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 #if defined(HAVE_FFMPEG)
   static const char TR_USE_FFV1_DESCRIPTION[] =
       QT_TR_NOOP("Encodes frame dumps using the FFV1 codec.<br><br><dolphin_emphasis>If "
@@ -264,9 +257,8 @@ void AdvancedWidget::AddDescriptions()
   static const char TR_BACKEND_MULTITHREADING_DESCRIPTION[] =
       QT_TR_NOOP("Enables multithreaded command submission in backends where supported. Enabling "
                  "this option may result in a performance improvement on systems with more than "
-                 "two CPU cores. Currently, this is limited to the Vulkan backend.<br><br "
-                 "/><dolphin_emphasis>If unsure, "
-                 "leave this checked.</dolphin_emphasis>");
+                 "two CPU cores. Currently, this is limited to the Vulkan backend.<br><br>"
+                 "<dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
   static const char TR_DEFER_EFB_ACCESS_INVALIDATION_DESCRIPTION[] = QT_TR_NOOP(
       "Defers invalidation of the EFB access cache until a GPU synchronization command "
       "is executed. If disabled, the cache will be invalidated with every draw call. "

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -35,7 +35,7 @@ ShaderCache::~ShaderCache()
 bool ShaderCache::Initialize()
 {
   m_api_type = g_ActiveConfig.backend_info.api_type;
-  m_host_config = ShaderHostConfig::GetCurrent();
+  m_host_config.bits = ShaderHostConfig::GetCurrent().bits;
 
   if (!CompileSharedPipelines())
     return false;

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -53,7 +53,7 @@ public:
   void InitializeShaderCache();
 
   // Changes the shader host config. Shaders should be reloaded afterwards.
-  void SetHostConfig(const ShaderHostConfig& host_config) { m_host_config = host_config; }
+  void SetHostConfig(const ShaderHostConfig& host_config) { m_host_config.bits = host_config.bits; }
 
   // Reloads/recreates all shaders and pipelines.
   void Reload();

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -38,6 +38,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.backend_shader_framebuffer_fetch = g_ActiveConfig.backend_info.bSupportsFramebufferFetch;
   bits.backend_logic_op = g_ActiveConfig.backend_info.bSupportsLogicOp;
   bits.backend_palette_conversion = g_ActiveConfig.backend_info.bSupportsPaletteConversion;
+  bits.enable_validation_layer = g_ActiveConfig.bEnableValidationLayer;
   return bits;
 }
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -11,6 +11,7 @@
 
 #include <fmt/format.h>
 
+#include "Common/BitField.h"
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
@@ -143,33 +144,29 @@ union ShaderHostConfig
 {
   u32 bits;
 
-  struct
-  {
-    u32 msaa : 1;
-    u32 ssaa : 1;
-    u32 stereo : 1;
-    u32 wireframe : 1;
-    u32 per_pixel_lighting : 1;
-    u32 vertex_rounding : 1;
-    u32 fast_depth_calc : 1;
-    u32 bounding_box : 1;
-    u32 backend_dual_source_blend : 1;
-    u32 backend_geometry_shaders : 1;
-    u32 backend_early_z : 1;
-    u32 backend_bbox : 1;
-    u32 backend_gs_instancing : 1;
-    u32 backend_clip_control : 1;
-    u32 backend_ssaa : 1;
-    u32 backend_atomics : 1;
-    u32 backend_depth_clamp : 1;
-    u32 backend_reversed_depth_range : 1;
-    u32 backend_bitfield : 1;
-    u32 backend_dynamic_sampler_indexing : 1;
-    u32 backend_shader_framebuffer_fetch : 1;
-    u32 backend_logic_op : 1;
-    u32 backend_palette_conversion : 1;
-    u32 pad : 9;
-  };
+  BitField<0, 1, bool, u32> msaa;
+  BitField<1, 1, bool, u32> ssaa;
+  BitField<2, 1, bool, u32> stereo;
+  BitField<3, 1, bool, u32> wireframe;
+  BitField<4, 1, bool, u32> per_pixel_lighting;
+  BitField<5, 1, bool, u32> vertex_rounding;
+  BitField<6, 1, bool, u32> fast_depth_calc;
+  BitField<7, 1, bool, u32> bounding_box;
+  BitField<8, 1, bool, u32> backend_dual_source_blend;
+  BitField<9, 1, bool, u32> backend_geometry_shaders;
+  BitField<10, 1, bool, u32> backend_early_z;
+  BitField<11, 1, bool, u32> backend_bbox;
+  BitField<12, 1, bool, u32> backend_gs_instancing;
+  BitField<13, 1, bool, u32> backend_clip_control;
+  BitField<14, 1, bool, u32> backend_ssaa;
+  BitField<15, 1, bool, u32> backend_atomics;
+  BitField<16, 1, bool, u32> backend_depth_clamp;
+  BitField<17, 1, bool, u32> backend_reversed_depth_range;
+  BitField<18, 1, bool, u32> backend_bitfield;
+  BitField<19, 1, bool, u32> backend_dynamic_sampler_indexing;
+  BitField<20, 1, bool, u32> backend_shader_framebuffer_fetch;
+  BitField<21, 1, bool, u32> backend_logic_op;
+  BitField<22, 1, bool, u32> backend_palette_conversion;
 
   static ShaderHostConfig GetCurrent();
 };

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -167,6 +167,7 @@ union ShaderHostConfig
   BitField<20, 1, bool, u32> backend_shader_framebuffer_fetch;
   BitField<21, 1, bool, u32> backend_logic_op;
   BitField<22, 1, bool, u32> backend_palette_conversion;
+  BitField<23, 1, bool, u32> enable_validation_layer;
 
   static ShaderHostConfig GetCurrent();
 };


### PR DESCRIPTION
This causes shaders to be reloaded when 'Enable API Validation Layers' is toggled.  It also does some general fixing and cleanup of related code.