### PR TITLE
Jit: Use ibat_table for dcbf/dcbi/dcbst address check

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -20,6 +20,7 @@
 #include "Core/PowerPC/Jit64/RegCache/JitRegCache.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
 #include "Core/PowerPC/JitInterface.h"
+#include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
 
 using namespace Gen;
@@ -246,7 +247,7 @@ void Jit64::dcbx(UGeckoInstruction inst)
   if (MSR.IR)
   {
     MOV(32, R(addr), R(value));
-    bat_lookup_failed = BATAddressLookup(value, tmp);
+    bat_lookup_failed = BATAddressLookup(value, tmp, PowerPC::ibat_table.data());
     AND(32, R(addr), Imm32(0x0001ffff));
     AND(32, R(value), Imm32(0xfffe0000));
     OR(32, R(value), R(addr));

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -91,9 +91,9 @@ void EmuCodeBlock::SwitchToNearCode()
   SetCodePtr(m_near_code, m_near_code_end, m_near_code_write_failed);
 }
 
-FixupBranch EmuCodeBlock::BATAddressLookup(X64Reg addr, X64Reg tmp)
+FixupBranch EmuCodeBlock::BATAddressLookup(X64Reg addr, X64Reg tmp, const void* bat_table)
 {
-  MOV(64, R(tmp), ImmPtr(&PowerPC::dbat_table[0]));
+  MOV(64, R(tmp), ImmPtr(bat_table));
   SHR(32, R(addr), Imm8(PowerPC::BAT_INDEX_SHIFT));
   MOV(32, R(addr), MComplex(tmp, addr, SCALE_4, 0));
   BT(32, R(addr), Imm8(IntLog2(PowerPC::BAT_MAPPED_BIT)));

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -51,7 +51,7 @@ public:
 
   // Writes upper 15 bits of physical address to addr and clobbers the lower 17 bits of addr.
   // Jumps to the returned FixupBranch if lookup fails.
-  Gen::FixupBranch BATAddressLookup(Gen::X64Reg addr, Gen::X64Reg tmp);
+  Gen::FixupBranch BATAddressLookup(Gen::X64Reg addr, Gen::X64Reg tmp, const void* bat_table);
 
   Gen::FixupBranch CheckIfSafeAddress(const Gen::OpArg& reg_value, Gen::X64Reg reg_addr,
                                       BitSet32 registers_in_use);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -234,7 +234,7 @@ protected:
   // If lookup succeeds, writes upper 15 bits of physical address to addr_out. If not,
   // jumps to the returned FixupBranch. Clobbers tmp and the 17 lower bits of addr_out.
   Arm64Gen::FixupBranch BATAddressLookup(Arm64Gen::ARM64Reg addr_out, Arm64Gen::ARM64Reg addr_in,
-                                         Arm64Gen::ARM64Reg tmp);
+                                         Arm64Gen::ARM64Reg tmp, const void* bat_table);
 
   void DoJit(u32 em_address, JitBlock* b, u32 nextPC);
 


### PR DESCRIPTION
Minor mistake in PR #9957. We should be using ibat_table instead of dbat_table, since we're dealing with invalidating icache.