### PR TITLE
GameINI: Enable Medium Tex Cache for Generator Rex

### DIFF
--- a/Data/Sys/GameSettings/SRX.ini
+++ b/Data/Sys/GameSettings/SRX.ini
@@ -1,0 +1,18 @@
+# SRXP52, SRXE52 - Generator Rex: Agent of Providence
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+# This game needs medium texture cache for proper
+# text rendering.
+SafeTextureCacheColorSamples = 512


### PR DESCRIPTION
Generator Rex: Agent of Providence needs medium texture cache in order to render text without problems.