### PR TITLE
DSPDisassembler: Fix LSR/ASR formatting

### DIFF
--- a/Source/Core/Core/DSP/DSPDisassembler.cpp
+++ b/Source/Core/Core/DSP/DSPDisassembler.cpp
@@ -105,8 +105,9 @@ std::string DSPDisassembler::DisassembleParameters(const DSPOPCTemplate& opc, u1
         // LSL, LSR, ASL, ASR
         if (opc.params[j].mask == 0x003f)
         {
-          // 6-bit sign extension
-          buf += fmt::format("#{}", (val & 0x20) != 0 ? (val | 0xFFFFFFC0) : val);
+          // Left and right shifts function essentially as a single shift by a 7-bit signed value,
+          // but are split into two intructions for clarity.
+          buf += fmt::format("#{}", (val & 0x20) != 0 ? (64 - val) : val);
         }
         else
         {


### PR DESCRIPTION
Originally, 1479 (for example) would disassemble as `lsr $ACC0, #-7`.  At some point (likely the conversion to fmt), this regressed to `lsr $ACC0, #4294967289`.  Now, it disassembles as `lsr $ACC0, #7`.

<details><summary>Changes to DSP_UC_347112BA.txt (Wii Menu)</summary>

<pre lang="diff">
@@ -524,7 +524,7 @@
 02b5 00fe 0cd4 sr          @0x0cd4, $AC0.M
 02b7 00de 02d6 lr          $AC0.M, @0x02d6
 02b9 009f 0d53 lri         $AC1.M, #0x0d53
-02bb 14fb      asr         $ACC0, #4294967291
+02bb 14fb      asr         $ACC0, #5
 02bc 3400      andr        $AC0.M, $AX0.H
 02bd 4c00      add         $ACC0, $ACC1
 02be 1c7e      mrr         $AR3, $AC0.M
@@ -532,7 +532,7 @@
 02c0 00fe 0cd5 sr          @0x0cd5, $AC0.M
 02c2 00de 02d6 lr          $AC0.M, @0x02d6
 02c4 009f 0d73 lri         $AC1.M, #0x0d73
-02c6 14f6      asr         $ACC0, #4294967286
+02c6 14f6      asr         $ACC0, #10
 02c7 4c00      add         $ACC0, $ACC1
 02c8 1c7e      mrr         $AR3, $AC0.M
 02c9 0213      ilrr        $AC0.M, @$AR3
@@ -547,49 +547,49 @@
 02d6 1c7f      mrr         $AR3, $AC1.M
 02d7 0313      ilrr        $AC1.M, @$AR3
 02d8 00ff 0cd7 sr          @0x0cd7, $AC1.M
-02da 147e      lsr         $ACC0, #4294967294
+02da 147e      lsr         $ACC0, #2
 02db 1ffe      mrr         $AC1.M, $AC0.M
 02dc 3500      andr        $AC1.M, $AX0.H
 02dd 4700      addr        $ACC1, $AX1.H
 02de 1c7f      mrr         $AR3, $AC1.M
 02df 0313      ilrr        $AC1.M, @$AR3
 02e0 00ff 0cd8 sr          @0x0cd8, $AC1.M
-02e2 147e      lsr         $ACC0, #4294967294
+02e2 147e      lsr         $ACC0, #2
 02e3 1ffe      mrr         $AC1.M, $AC0.M
 02e4 3500      andr        $AC1.M, $AX0.H
 02e5 4700      addr        $ACC1, $AX1.H
 02e6 1c7f      mrr         $AR3, $AC1.M
 02e7 0313      ilrr        $AC1.M, @$AR3
 02e8 00ff 0cd9 sr          @0x0cd9, $AC1.M
-02ea 147e      lsr         $ACC0, #4294967294
+02ea 147e      lsr         $ACC0, #2
 02eb 1ffe      mrr         $AC1.M, $AC0.M
 02ec 3500      andr        $AC1.M, $AX0.H
 02ed 4700      addr        $ACC1, $AX1.H
 02ee 1c7f      mrr         $AR3, $AC1.M
 02ef 0313      ilrr        $AC1.M, @$AR3
 02f0 00ff 0cda sr          @0x0cda, $AC1.M
-02f2 147e      lsr         $ACC0, #4294967294
+02f2 147e      lsr         $ACC0, #2
 02f3 1ffe      mrr         $AC1.M, $AC0.M
 02f4 3500      andr        $AC1.M, $AX0.H
 02f5 4700      addr        $ACC1, $AX1.H
 02f6 1c7f      mrr         $AR3, $AC1.M
 02f7 0313      ilrr        $AC1.M, @$AR3
 02f8 00ff 0cdb sr          @0x0cdb, $AC1.M
-02fa 147e      lsr         $ACC0, #4294967294
+02fa 147e      lsr         $ACC0, #2
 02fb 1ffe      mrr         $AC1.M, $AC0.M
 02fc 3500      andr        $AC1.M, $AX0.H
 02fd 4700      addr        $ACC1, $AX1.H
 02fe 1c7f      mrr         $AR3, $AC1.M
 02ff 0313      ilrr        $AC1.M, @$AR3
 0300 00ff 0cdc sr          @0x0cdc, $AC1.M
-0302 147e      lsr         $ACC0, #4294967294
+0302 147e      lsr         $ACC0, #2
 0303 1ffe      mrr         $AC1.M, $AC0.M
 0304 3500      andr        $AC1.M, $AX0.H
 0305 4700      addr        $ACC1, $AX1.H
 0306 1c7f      mrr         $AR3, $AC1.M
 0307 0313      ilrr        $AC1.M, @$AR3
 0308 00ff 0cdd sr          @0x0cdd, $AC1.M
-030a 147e      lsr         $ACC0, #4294967294
+030a 147e      lsr         $ACC0, #2
 030b 1ffe      mrr         $AC1.M, $AC0.M
 030c 3500      andr        $AC1.M, $AX0.H
 030d 4700      addr        $ACC1, $AX1.H
@@ -734,7 +734,7 @@
 03e5 0010      addarn      $AR0, $IX0
 03e6 8900      clr         $ACC1
 03e7 1fbc      mrr         $AC1.L, $AC0.L
-03e8 1577      lsr         $ACC1, #4294967287
+03e8 1577      lsr         $ACC1, #9
 03e9 1512      lsl         $ACC1, #18
 03ea 1c7f      mrr         $AR3, $AC1.M
 03eb 001f      addarn      $AR3, $IX3
@@ -1379,7 +1379,7 @@
 0736 1160 074a bloopi      #0x60, 0x074a
 0738 8912      clr'mv      $ACC1 : $AX0.L, $AC0.M
 0739 1fbc      mrr         $AC1.L, $AC0.L
-073a 1577      lsr         $ACC1, #4294967287
+073a 1577      lsr         $ACC1, #9
 073b 1512      lsl         $ACC1, #18
 073c 1c7f      mrr         $AR3, $AC1.M
 073d 001f      addarn      $AR3, $IX3
</pre>
</details>
<details><summary>Changes to DSP_UC_56D36052.txt (Super Mario Sunshine)</summary>

<pre lang="diff">
@@ -35,7 +35,7 @@
 0031 1ffe      mrr         $AC1.M, $AC0.M
 0032 0340 00ff andi        $AC1.M, #0x00ff
 0034 00ff 0344 sr          @0x0344, $AC1.M
-0036 1479      lsr         $ACC0, #4294967289
+0036 1479      lsr         $ACC0, #7
 0037 0240 007e andi        $AC0.M, #0x007e
 0039 00fe 0343 sr          @0x0343, $AC0.M
 003b 0200 0071 addi        $AC0.M, #0x0071
@@ -140,7 +140,7 @@
 00d6 0000      nop         
 00d7 02df      ret         
 00d8 8a00      m2          
-00d9 157f      lsr         $ACC1, #4294967295
+00d9 157f      lsr         $ACC1, #1
 00da 1c20      mrr         $AR1, $AR0
 00db 1c03      mrr         $AR0, $AR3
 00dc 193a      lrri        $AX0.H, @$AR1
@@ -405,7 +405,7 @@
 0272 8100      clr         $ACC0
 0273 8900      clr         $ACC1
 0274 00de 0354 lr          $AC0.M, @0x0354
-0276 147c      lsr         $ACC0, #4294967292
+0276 147c      lsr         $ACC0, #4
 0277 0200 04fc addi        $AC0.M, #0x04fc
 0279 1c1e      mrr         $AR0, $AC0.M
 027a 181f      lrr         $AC1.M, @$AR0
@@ -570,7 +570,7 @@
 0378 0082 040a lri         $AR2, #0x040a
 037a 1106 037e bloopi      #0x06, 0x037e
 037c 18de      lrrd        $AC0.M, @$AR2
-037d 147f      lsr         $ACC0, #4294967295
+037d 147f      lsr         $ACC0, #1
 037e 4d36      add'sn      $ACC1, $ACC0 : @$AR2, $AC0.M
 037f b900      tst         $ACC1
 0380 0294 0386 jnz         0x0386
@@ -590,14 +590,14 @@
 0394 195e      lrri        $AC0.M, @$AR2
 0395 195f      lrri        $AC1.M, @$AR2
 0396 5c00      sub         $ACC0, $ACC1
-0397 14fb      asr         $ACC0, #4294967291
+0397 14fb      asr         $ACC0, #5
 0398 1f5e      mrr         $AX0.H, $AC0.M
 0399 1f1c      mrr         $AX0.L, $AC0.L
 039a 185e      lrr         $AC0.M, @$AR2
 039b 0240 00ff andi        $AC0.M, #0x00ff
 039d 1f7e      mrr         $AX1.H, $AC0.M
 039e 185e      lrr         $AC0.M, @$AR2
-039f 1478      lsr         $ACC0, #4294967288
+039f 1478      lsr         $ACC0, #8
 03a0 009c 0000 lri         $AC0.L, #0x0000
 03a2 d100      cmpar       $ACC0, $AX1.H
 03a3 0295 03ab jz          0x03ab
@@ -862,7 +862,7 @@
 053b 2cd7      srs         @ACEAL, $AC0.L
 053c 1fda      mrr         $AC0.M, $AX0.H
 053d 1f98      mrr         $AC0.L, $AX0.L
-053e 147f      lsr         $ACC0, #4294967295
+053e 147f      lsr         $ACC0, #1
 053f 2ed8      srs         @ACCAH, $AC0.M
 0540 2cd9      srs         @ACCAL, $AC0.L
 0541 1f40      mrr         $AX0.H, $AR0
@@ -1162,7 +1162,7 @@
 06f9 2234      lrs         $AX0.H, @0x0034
 06fa 2035      lrs         $AX0.L, @0x0035
 06fb 4800      addax       $ACC0, $AX0
-06fc 147c      lsr         $ACC0, #4294967292
+06fc 147c      lsr         $ACC0, #4
 06fd 2e36      srs         @0x0036, $AC0.M
 06fe 2c37      srs         @0x0037, $AC0.L
 06ff 2380      lrs         $AX1.H, @0xff80
@@ -1196,7 +1196,7 @@
 071d 8100      clr         $ACC0
 071e 268a      lrs         $AC0.M, @0xff8a
 071f 248b      lrs         $AC0.L, @0xff8b
-0720 147c      lsr         $ACC0, #4294967292
+0720 147c      lsr         $ACC0, #4
 0721 5800      subax       $ACC0, $AX0
 0722 0295 072b jz          0x072b
 0724 02bf 07b1 call        0x07b1
@@ -1326,7 +1326,7 @@
 07c9 0240 001e andi        $AC0.M, #0x001e
 07cb 0200 0300 addi        $AC0.M, #0x0300
 07cd 1c3e      mrr         $AR1, $AC0.M
-07ce 157c      lsr         $ACC1, #4294967292
+07ce 157c      lsr         $ACC1, #4
 07cf 0340 000f andi        $AC1.M, #0x000f
 07d1 0a11      lris        $AX0.H, #0x11
 07d2 5500      subr        $ACC1, $AX0.H
@@ -1446,7 +1446,7 @@
 086c 027d      iflz        
 086d 1b19      srri        @$AR0, $AX1.L
 086e 4800      addax       $ACC0, $AX0
-086f 147f      lsr         $ACC0, #4294967295
+086f 147f      lsr         $ACC0, #1
 0870 02df      ret         
 0871 1402      lsl         $ACC0, #2
 0872 8900      clr         $ACC1
@@ -1461,7 +1461,7 @@
 087f 027d      iflz        
 0880 1b19      srri        @$AR0, $AX1.L
 0881 4c00      add         $ACC0, $ACC1
-0882 147e      lsr         $ACC0, #4294967294
+0882 147e      lsr         $ACC0, #2
 0883 02df      ret         
 0884 1401      lsl         $ACC0, #1
 0885 0081 0ca0 lri         $AR1, #0x0ca0
@@ -1479,11 +1479,11 @@
 0897 4900      addax       $ACC1, $AX0
 0898 1fe2      mrr         $AC1.M, $AR2
 0899 4c39      add's       $ACC0, $ACC1 : @$AR1, $AC1.M
-089a 147f      lsr         $ACC0, #4294967295
+089a 147f      lsr         $ACC0, #1
 089b 02df      ret         
 089c 8900      clr         $ACC1
 089d 1fb8      mrr         $AC1.L, $AX0.L
-089e 157f      lsr         $ACC1, #4294967295
+089e 157f      lsr         $ACC1, #1
 089f 1050      loopi       #0x50
 08a0 4c20      add's       $ACC0, $ACC1 : @$AR0, $AC0.L
 08a1 02df      ret         
@@ -1511,7 +1511,7 @@
 08c1 340e      andr'nr     $AC0.M, $AX0.H : $AR2
 08c2 1b19      srri        @$AR0, $AX1.L
 08c3 1fc2      mrr         $AC0.M, $AR2
-08c4 147a      lsr         $ACC0, #4294967290
+08c4 147a      lsr         $ACC0, #6
 08c5 008a ffff lri         $WR2, #0xffff
 08c7 02df      ret         
 08c8 1050      loopi       #0x50
@@ -1537,7 +1537,7 @@
 08e2 340e      andr'nr     $AC0.M, $AX0.H : $AR2
 08e3 1b19      srri        @$AR0, $AX1.L
 08e4 1fc2      mrr         $AC0.M, $AR2
-08e5 147a      lsr         $ACC0, #4294967290
+08e5 147a      lsr         $ACC0, #6
 08e6 008a ffff lri         $WR2, #0xffff
 08e8 02df      ret         
 08e9 0082 0100 lri         $AR2, #0x0100
@@ -1559,14 +1559,14 @@
 0900 a000      mulx        $AX0.L, $AX1.L
 0901 140a      lsl         $ACC0, #10
 0902 4e00      addp        $ACC0
-0903 1476      lsr         $ACC0, #4294967286
+0903 1476      lsr         $ACC0, #10
 0904 4c4a      add'l       $ACC0, $ACC1 : $AX1.L, @$AR2
 0905 3606      andr'dr     $AC0.M, $AX1.H : $AR2
 0906 1cde      mrr         $IX2, $AC0.M
 0907 340e      andr'nr     $AC0.M, $AX0.H : $AR2
 0908 1b19      srri        @$AR0, $AX1.L
 0909 1fc2      mrr         $AC0.M, $AR2
-090a 147a      lsr         $ACC0, #4294967290
+090a 147a      lsr         $ACC0, #6
 090b 008a ffff lri         $WR2, #0xffff
 090d 02df      ret         
 090e 0080 01be lri         $AR0, #0x01be
@@ -1671,7 +1671,7 @@
 098f 8100      clr         $ACC0
 0990 263a      lrs         $AC0.M, @0x003a
 0991 243b      lrs         $AC0.L, @0x003b
-0992 1570      lsr         $ACC1, #4294967280
+0992 1570      lsr         $ACC1, #16
 0993 0a01      lris        $AX0.H, #0x01
 0994 0081 0405 lri         $AR1, #0x0405
 0996 5c00      sub         $ACC0, $ACC1
@@ -1780,7 +1780,7 @@
 0a16 8100      clr         $ACC0
 0a17 263a      lrs         $AC0.M, @0x003a
 0a18 243b      lrs         $AC0.L, @0x003b
-0a19 1570      lsr         $ACC1, #4294967280
+0a19 1570      lsr         $ACC1, #16
 0a1a 0a01      lris        $AX0.H, #0x01
 0a1b 0081 0405 lri         $AR1, #0x0405
 0a1d 5c00      sub         $ACC0, $ACC1
@@ -2058,12 +2058,12 @@
 0b6c 268a      lrs         $AC0.M, @0xff8a
 0b6d 248b      lrs         $AC0.L, @0xff8b
 0b6e 5a00      subax       $ACC0, $AX1
-0b6f 147c      lsr         $ACC0, #4294967292
+0b6f 147c      lsr         $ACC0, #4
 0b70 2e3a      srs         @0x003a, $AC0.M
 0b71 2c3b      srs         @0x003b, $AC0.L
 0b72 2634      lrs         $AC0.M, @0x0034
 0b73 2435      lrs         $AC0.L, @0x0035
-0b74 147c      lsr         $ACC0, #4294967292
+0b74 147c      lsr         $ACC0, #4
 0b75 2280      lrs         $AX0.H, @0xff80
 0b76 c010      mulc'mv     $AC0.M, $AX0.H : $AX0.L, $AC0.L
 0b77 9600      mulmv       $AX0.L, $AX0.H, $ACC0
@@ -2087,7 +2087,7 @@
 0b8c 0240 001e andi        $AC0.M, #0x001e
 0b8e 0200 0300 addi        $AC0.M, #0x0300
 0b90 1c3e      mrr         $AR1, $AC0.M
-0b91 157c      lsr         $ACC1, #4294967292
+0b91 157c      lsr         $ACC1, #4
 0b92 0340 000f andi        $AC1.M, #0x000f
 0b94 0a11      lris        $AX0.H, #0x11
 0b95 5500      subr        $ACC1, $AX0.H
@@ -2418,7 +2418,7 @@
 0d35 0295 0d44 jz          0x0d44
 0d37 8100      clr         $ACC0
 0d38 00de 042a lr          $AC0.M, @0x042a
-0d3a 147f      lsr         $ACC0, #4294967295
+0d3a 147f      lsr         $ACC0, #1
 0d3b 00fe 042b sr          @0x042b, $AC0.M
 0d3d b100      tst         $ACC0
 0d3e 0294 0d44 jnz         0x0d44
@@ -2427,7 +2427,7 @@
 0d44 8f00      set40       
 0d45 8100      clr         $ACC0
 0d46 00de 0428 lr          $AC0.M, @0x0428
-0d48 1478      lsr         $ACC0, #4294967288
+0d48 1478      lsr         $ACC0, #8
 0d49 00df 0428 lr          $AC1.M, @0x0428
 0d4b 0340 007f andi        $AC1.M, #0x007f
 0d4d 1f1e      mrr         $AX0.L, $AC0.M
@@ -2494,7 +2494,7 @@
 0da3 0083 0dd6 lri         $AR3, #0x0dd6
 0da5 1108 0dbe bloopi      #0x08, 0x0dbe
 0da7 195f      lrri        $AC1.M, @$AR2
-0da8 15fb      asr         $ACC1, #4294967291
+0da8 15fb      asr         $ACC1, #5
 0da9 1f1d      mrr         $AX0.L, $AC1.L
 0daa 1f5f      mrr         $AX0.H, $AC1.M
 0dab 193f      lrri        $AC1.M, @$AR1
@@ -2556,7 +2556,7 @@
 0dee 8100      clr         $ACC0
 0def 00de 0402 lr          $AC0.M, @0x0402
 0df1 00fe 0362 sr          @0x0362, $AC0.M
-0df3 1474      lsr         $ACC0, #4294967284
+0df3 1474      lsr         $ACC0, #12
 0df4 1f7e      mrr         $AX1.H, $AC0.M
 0df5 1f3c      mrr         $AX1.L, $AC0.L
 0df6 8900      clr         $ACC1
@@ -2591,7 +2591,7 @@
 0e1e 1fe0      mrr         $AC1.M, $AR0
 0e1f 8100      clr         $ACC0
 0e20 00de 0362 lr          $AC0.M, @0x0362
-0e22 1474      lsr         $ACC0, #4294967284
+0e22 1474      lsr         $ACC0, #12
 0e23 1f7e      mrr         $AX1.H, $AC0.M
 0e24 1f3c      mrr         $AX1.L, $AC0.L
 0e25 8f00      set40       
</pre>
</details>