### PR TITLE
MoltenVK: Use an external project instead of a pre-compiled dylib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,6 +573,10 @@ add_subdirectory(Externals/glslang)
 
 if(ENABLE_VULKAN)
   add_definitions(-DHAS_VULKAN)
+
+  if(APPLE)
+    add_subdirectory(Externals/MoltenVK)
+  endif()
 endif()
 
 if(NOT WIN32 OR (NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")))

--- a/Externals/MoltenVK/CMakeLists.txt
+++ b/Externals/MoltenVK/CMakeLists.txt
@@ -1,0 +1,18 @@
+include(ExternalProject)
+
+ExternalProject_Add(MoltenVK
+  GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
+  GIT_TAG v1.1.5
+
+  CONFIGURE_COMMAND <SOURCE_DIR>/fetchDependencies --macos
+
+  BUILD_COMMAND make -C <SOURCE_DIR> macos
+  BUILD_IN_SOURCE ON
+  BUILD_BYPRODUCTS <SOURCE_DIR>/Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib
+
+  INSTALL_COMMAND ""
+
+  LOG_CONFIGURE ON
+  LOG_BUILD ON
+  LOG_OUTPUT_ON_FAILURE ON
+)

--- a/Externals/MoltenVK/version.txt
+++ b/Externals/MoltenVK/version.txt
@@ -1,1 +1,0 @@
-MoltenVK from https://vulkan.lunarg.com/sdk/home#mac, version 1.2.170.0

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -528,8 +528,12 @@ if(APPLE)
   endforeach()
 
   # Copy MoltenVK into the bundle
-  target_sources(dolphin-emu PRIVATE "${CMAKE_SOURCE_DIR}/Externals/MoltenVK/libvulkan.dylib")
-  set_source_files_properties("${CMAKE_SOURCE_DIR}/Externals/MoltenVK/libvulkan.dylib" PROPERTIES MACOSX_PACKAGE_LOCATION Frameworks)
+  if(ENABLE_VULKAN)
+    add_dependencies(dolphin-emu MoltenVK)
+    ExternalProject_Get_Property(MoltenVK SOURCE_DIR)
+    target_sources(dolphin-emu PRIVATE "${SOURCE_DIR}/Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib")
+    set_source_files_properties("${SOURCE_DIR}/Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib" PROPERTIES MACOSX_PACKAGE_LOCATION Frameworks GENERATED ON)
+  endif()
 
   # Update library references to make the bundle portable
   include(DolphinPostprocessBundle)

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
@@ -43,8 +43,8 @@ static bool OpenVulkanLibrary()
   if (libvulkan_env && s_vulkan_module.Open(libvulkan_env))
     return true;
 
-  // Use the libvulkan.dylib from the application bundle.
-  std::string filename = File::GetBundleDirectory() + "/Contents/Frameworks/libvulkan.dylib";
+  // Use the libMoltenVK.dylib from the application bundle.
+  std::string filename = File::GetBundleDirectory() + "/Contents/Frameworks/libMoltenVK.dylib";
   return s_vulkan_module.Open(filename.c_str());
 #else
   std::string filename = Common::DynamicLibrary::GetVersionedFilename("vulkan", 1);


### PR DESCRIPTION
Changes the build system to build MoltenVK instead of having a dylib in the repository. This also opens up the opportunity to modify MoltenVK to our needs if needed.

Also, the MoltenVK version has been updated to v1.1.5 (Vulkan SDK 1.2.189).

~~**EDIT**: This PR is being blocked by the presence of the Intel macOS buildbot (``pr-osx-x64``). The M1 Mac Mini can build MoltenVK perfectly fine for both Intel and ARM, so the Intel buildbot needs to be shut down before can be merged.~~