### PR TITLE
Use MagicYUV as the lossless video codec

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -41,7 +41,7 @@ const Info<bool> GFX_CACHE_HIRES_TEXTURES{{System::GFX, "Settings", "CacheHiresT
 const Info<bool> GFX_DUMP_EFB_TARGET{{System::GFX, "Settings", "DumpEFBTarget"}, false};
 const Info<bool> GFX_DUMP_XFB_TARGET{{System::GFX, "Settings", "DumpXFBTarget"}, false};
 const Info<bool> GFX_DUMP_FRAMES_AS_IMAGES{{System::GFX, "Settings", "DumpFramesAsImages"}, false};
-const Info<bool> GFX_USE_FFV1{{System::GFX, "Settings", "UseFFV1"}, false};
+const Info<bool> GFX_USE_MAGICYUV{{System::GFX, "Settings", "UseMagicYUV"}, false};
 const Info<std::string> GFX_DUMP_FORMAT{{System::GFX, "Settings", "DumpFormat"}, "avi"};
 const Info<std::string> GFX_DUMP_CODEC{{System::GFX, "Settings", "DumpCodec"}, ""};
 const Info<std::string> GFX_DUMP_ENCODER{{System::GFX, "Settings", "DumpEncoder"}, ""};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -42,7 +42,7 @@ extern const Info<bool> GFX_CACHE_HIRES_TEXTURES;
 extern const Info<bool> GFX_DUMP_EFB_TARGET;
 extern const Info<bool> GFX_DUMP_XFB_TARGET;
 extern const Info<bool> GFX_DUMP_FRAMES_AS_IMAGES;
-extern const Info<bool> GFX_USE_FFV1;
+extern const Info<bool> GFX_USE_MAGICYUV;
 extern const Info<std::string> GFX_DUMP_FORMAT;
 extern const Info<std::string> GFX_DUMP_CODEC;
 extern const Info<std::string> GFX_DUMP_ENCODER;

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -101,13 +101,13 @@ void AdvancedWidget::CreateWidgets()
 
   m_use_fullres_framedumps = new GraphicsBool(tr("Dump at Internal Resolution"),
                                               Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS);
-  m_dump_use_ffv1 = new GraphicsBool(tr("Use Lossless Codec (FFV1)"), Config::GFX_USE_FFV1);
+  m_dump_use_magicyuv = new GraphicsBool(tr("Use Lossless Codec (MagicYUV)"), Config::GFX_USE_MAGICYUV);
   m_dump_bitrate = new GraphicsInteger(0, 1000000, Config::GFX_BITRATE_KBPS, 1000);
   m_png_compression_level = new GraphicsInteger(0, 9, Config::GFX_PNG_COMPRESSION_LEVEL);
 
   dump_layout->addWidget(m_use_fullres_framedumps, 0, 0);
 #if defined(HAVE_FFMPEG)
-  dump_layout->addWidget(m_dump_use_ffv1, 0, 1);
+  dump_layout->addWidget(m_dump_use_magicyuv, 0, 1);
   dump_layout->addWidget(new QLabel(tr("Bitrate (kbps):")), 1, 0);
   dump_layout->addWidget(m_dump_bitrate, 1, 1);
 #endif
@@ -162,7 +162,7 @@ void AdvancedWidget::CreateWidgets()
 void AdvancedWidget::ConnectWidgets()
 {
   connect(m_load_custom_textures, &QCheckBox::toggled, this, &AdvancedWidget::SaveSettings);
-  connect(m_dump_use_ffv1, &QCheckBox::toggled, this, &AdvancedWidget::SaveSettings);
+  connect(m_dump_use_magicyuv, &QCheckBox::toggled, this, &AdvancedWidget::SaveSettings);
   connect(m_enable_prog_scan, &QCheckBox::toggled, this, &AdvancedWidget::SaveSettings);
   connect(m_dump_textures, &QCheckBox::toggled, this, &AdvancedWidget::SaveSettings);
 }
@@ -170,7 +170,7 @@ void AdvancedWidget::ConnectWidgets()
 void AdvancedWidget::LoadSettings()
 {
   m_prefetch_custom_textures->setEnabled(Config::Get(Config::GFX_HIRES_TEXTURES));
-  m_dump_bitrate->setEnabled(!Config::Get(Config::GFX_USE_FFV1));
+  m_dump_bitrate->setEnabled(!Config::Get(Config::GFX_USE_MAGICYUV));
 
   m_enable_prog_scan->setChecked(Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN));
   m_dump_mip_textures->setEnabled(Config::Get(Config::GFX_DUMP_TEXTURES));
@@ -180,7 +180,7 @@ void AdvancedWidget::LoadSettings()
 void AdvancedWidget::SaveSettings()
 {
   m_prefetch_custom_textures->setEnabled(Config::Get(Config::GFX_HIRES_TEXTURES));
-  m_dump_bitrate->setEnabled(!Config::Get(Config::GFX_USE_FFV1));
+  m_dump_bitrate->setEnabled(!Config::Get(Config::GFX_USE_MAGICYUV));
 
   Config::SetBase(Config::SYSCONF_PROGRESSIVE_SCAN, m_enable_prog_scan->isChecked());
   m_dump_mip_textures->setEnabled(Config::Get(Config::GFX_DUMP_TEXTURES));
@@ -251,8 +251,8 @@ void AdvancedWidget::AddDescriptions()
       "the output image will be scaled horizontally to preserve the vertical resolution.<br><br>"
       "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 #if defined(HAVE_FFMPEG)
-  static const char TR_USE_FFV1_DESCRIPTION[] =
-      QT_TR_NOOP("Encodes frame dumps using the FFV1 codec.<br><br><dolphin_emphasis>If "
+  static const char TR_USE_MAGICYUV_DESCRIPTION[] =
+      QT_TR_NOOP("Encodes frame dumps using the MagicYUV codec.<br><br><dolphin_emphasis>If "
                  "unsure, leave this unchecked.</dolphin_emphasis>");
 #endif
   static const char TR_PNG_COMPRESSION_LEVEL_DESCRIPTION[] =
@@ -318,7 +318,7 @@ void AdvancedWidget::AddDescriptions()
   m_disable_vram_copies->SetDescription(tr(TR_DISABLE_VRAM_COPIES_DESCRIPTION));
   m_use_fullres_framedumps->SetDescription(tr(TR_INTERNAL_RESOLUTION_FRAME_DUMPING_DESCRIPTION));
 #ifdef HAVE_FFMPEG
-  m_dump_use_ffv1->SetDescription(tr(TR_USE_FFV1_DESCRIPTION));
+  m_dump_use_magicyuv->SetDescription(tr(TR_USE_MAGICYUV_DESCRIPTION));
 #endif
   m_png_compression_level->SetDescription(tr(TR_PNG_COMPRESSION_LEVEL_DESCRIPTION));
   m_enable_cropping->SetDescription(tr(TR_CROPPING_DESCRIPTION));

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -49,7 +49,7 @@ private:
   GraphicsBool* m_dump_base_textures;
 
   // Frame dumping
-  GraphicsBool* m_dump_use_ffv1;
+  GraphicsBool* m_dump_use_magicyuv;
   GraphicsBool* m_use_fullres_framedumps;
   GraphicsInteger* m_dump_bitrate;
   GraphicsInteger* m_png_compression_level;

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -168,7 +168,7 @@ bool FrameDump::CreateVideoFile()
     return false;
   }
 
-  const std::string& codec_name = g_Config.bUseFFV1 ? "ffv1" : g_Config.sDumpCodec;
+  const std::string& codec_name = g_Config.bUseMagicYUV ? "magicyuv" : g_Config.sDumpCodec;
 
   AVCodecID codec_id = output_format->video_codec;
 
@@ -215,7 +215,7 @@ bool FrameDump::CreateVideoFile()
   m_context->codec->time_base = time_base;
   m_context->codec->gop_size = 1;
   m_context->codec->level = 1;
-  m_context->codec->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGR0 : AV_PIX_FMT_YUV420P;
+  m_context->codec->pix_fmt = g_Config.bUseMagicYUV ? AV_PIX_FMT_GBRP : AV_PIX_FMT_YUV420P;
 
   if (output_format->flags & AVFMT_GLOBALHEADER)
     m_context->codec->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -70,7 +70,7 @@ void VideoConfig::Refresh()
   bDumpEFBTarget = Config::Get(Config::GFX_DUMP_EFB_TARGET);
   bDumpXFBTarget = Config::Get(Config::GFX_DUMP_XFB_TARGET);
   bDumpFramesAsImages = Config::Get(Config::GFX_DUMP_FRAMES_AS_IMAGES);
-  bUseFFV1 = Config::Get(Config::GFX_USE_FFV1);
+  bUseMagicYUV = Config::Get(Config::GFX_USE_MAGICYUV);
   sDumpFormat = Config::Get(Config::GFX_DUMP_FORMAT);
   sDumpCodec = Config::Get(Config::GFX_DUMP_CODEC);
   sDumpEncoder = Config::Get(Config::GFX_DUMP_ENCODER);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -100,7 +100,7 @@ struct VideoConfig final
   bool bDumpEFBTarget = false;
   bool bDumpXFBTarget = false;
   bool bDumpFramesAsImages = false;
-  bool bUseFFV1 = false;
+  bool bUseMagicYUV = false;
   std::string sDumpCodec;
   std::string sDumpEncoder;
   std::string sDumpFormat;


### PR DESCRIPTION
A much faster video codec than FFV1, this enables high-resolution
dumps to be performed in much more reasonable time, and even realtime
recording on some lower resolutions.

Really motivated by wanting to do 1080p/2160p recordings faster. I can achieve exactly as such now in roughly 50% realtime, versus ~3% I got with FFV1.