### PR TITLE
VideoCommon: Rename ApiType to api_type

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -45,11 +45,12 @@ GeometryShaderUid GetGeometryShaderUid(PrimitiveType primitive_type)
 
 static void EmitVertex(ShaderCode& out, const ShaderHostConfig& host_config,
                        const geometry_shader_uid_data* uid_data, const char* vertex,
-                       APIType ApiType, bool wireframe, bool first_vertex = false);
+                       APIType api_type, bool wireframe, bool first_vertex = false);
 static void EndPrimitive(ShaderCode& out, const ShaderHostConfig& host_config,
-                         const geometry_shader_uid_data* uid_data, APIType ApiType, bool wireframe);
+                         const geometry_shader_uid_data* uid_data, APIType api_type,
+                         bool wireframe);
 
-ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& host_config,
+ShaderCode GenerateGeometryShaderCode(APIType api_type, const ShaderHostConfig& host_config,
                                       const geometry_shader_uid_data* uid_data)
 {
   ShaderCode out;
@@ -67,7 +68,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
   if (wireframe)
     vertex_out++;
 
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
     // Insert layout parameters
     if (host_config.backend_gs_instancing)
@@ -88,7 +89,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
   out.Write("{}", s_lighting_struct);
 
   // uniforms
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
     out.Write("UBO_BINDING(std140, 3) uniform GSBlock {{\n");
   else
     out.Write("cbuffer GSBlock {{\n");
@@ -99,21 +100,21 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
             "}};\n");
 
   out.Write("struct VS_OUTPUT {{\n");
-  GenerateVSOutputMembers(out, ApiType, uid_data->numTexGens, host_config, "");
+  GenerateVSOutputMembers(out, api_type, uid_data->numTexGens, host_config, "");
   out.Write("}};\n");
 
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
     if (host_config.backend_gs_instancing)
       out.Write("#define InstanceID gl_InvocationID\n");
 
     out.Write("VARYING_LOCATION(0) in VertexData {{\n");
-    GenerateVSOutputMembers(out, ApiType, uid_data->numTexGens, host_config,
+    GenerateVSOutputMembers(out, api_type, uid_data->numTexGens, host_config,
                             GetInterpolationQualifier(msaa, ssaa, true, true));
     out.Write("}} vs[{}];\n", vertex_in);
 
     out.Write("VARYING_LOCATION(0) out VertexData {{\n");
-    GenerateVSOutputMembers(out, ApiType, uid_data->numTexGens, host_config,
+    GenerateVSOutputMembers(out, api_type, uid_data->numTexGens, host_config,
                             GetInterpolationQualifier(msaa, ssaa, true, false));
 
     if (stereo)
@@ -152,7 +153,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
 
   if (primitive_type == PrimitiveType::Lines)
   {
-    if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+    if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
     {
       out.Write("\tVS_OUTPUT start, end;\n");
       AssignVSOutputMembers(out, "start", "vs[0]", uid_data->numTexGens, host_config);
@@ -183,7 +184,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
   }
   else if (primitive_type == PrimitiveType::Points)
   {
-    if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+    if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
     {
       out.Write("\tVS_OUTPUT center;\n");
       AssignVSOutputMembers(out, "center", "vs[0]", uid_data->numTexGens, host_config);
@@ -214,7 +215,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
 
   out.Write("\tfor (int i = 0; i < {}; ++i) {{\n", vertex_in);
 
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
     out.Write("\tVS_OUTPUT f;\n");
     AssignVSOutputMembers(out, "f", "vs[i]", uid_data->numTexGens, host_config);
@@ -237,7 +238,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
   {
     // Select the output layer
     out.Write("\tps.layer = eye;\n");
-    if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+    if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
       out.Write("\tgl_Layer = eye;\n");
 
     // For stereoscopy add a small horizontal offset in Normalized Device Coordinates proportional
@@ -269,8 +270,8 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
     }
     out.Write("\t}}\n");
 
-    EmitVertex(out, host_config, uid_data, "l", ApiType, wireframe, true);
-    EmitVertex(out, host_config, uid_data, "r", ApiType, wireframe);
+    EmitVertex(out, host_config, uid_data, "l", api_type, wireframe, true);
+    EmitVertex(out, host_config, uid_data, "r", api_type, wireframe);
   }
   else if (primitive_type == PrimitiveType::Points)
   {
@@ -298,19 +299,19 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
     }
     out.Write("\t}}\n");
 
-    EmitVertex(out, host_config, uid_data, "ll", ApiType, wireframe, true);
-    EmitVertex(out, host_config, uid_data, "lr", ApiType, wireframe);
-    EmitVertex(out, host_config, uid_data, "ul", ApiType, wireframe);
-    EmitVertex(out, host_config, uid_data, "ur", ApiType, wireframe);
+    EmitVertex(out, host_config, uid_data, "ll", api_type, wireframe, true);
+    EmitVertex(out, host_config, uid_data, "lr", api_type, wireframe);
+    EmitVertex(out, host_config, uid_data, "ul", api_type, wireframe);
+    EmitVertex(out, host_config, uid_data, "ur", api_type, wireframe);
   }
   else
   {
-    EmitVertex(out, host_config, uid_data, "f", ApiType, wireframe, true);
+    EmitVertex(out, host_config, uid_data, "f", api_type, wireframe, true);
   }
 
   out.Write("\t}}\n");
 
-  EndPrimitive(out, host_config, uid_data, ApiType, wireframe);
+  EndPrimitive(out, host_config, uid_data, api_type, wireframe);
 
   if (stereo && !host_config.backend_gs_instancing)
     out.Write("\t}}\n");
@@ -322,12 +323,12 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
 
 static void EmitVertex(ShaderCode& out, const ShaderHostConfig& host_config,
                        const geometry_shader_uid_data* uid_data, const char* vertex,
-                       APIType ApiType, bool wireframe, bool first_vertex)
+                       APIType api_type, bool wireframe, bool first_vertex)
 {
   if (wireframe && first_vertex)
     out.Write("\tif (i == 0) first = {};\n", vertex);
 
-  if (ApiType == APIType::OpenGL)
+  if (api_type == APIType::OpenGL)
   {
     out.Write("\tgl_Position = {}.pos;\n", vertex);
     if (host_config.backend_depth_clamp)
@@ -337,7 +338,7 @@ static void EmitVertex(ShaderCode& out, const ShaderHostConfig& host_config,
     }
     AssignVSOutputMembers(out, "ps", vertex, uid_data->numTexGens, host_config);
   }
-  else if (ApiType == APIType::Vulkan)
+  else if (api_type == APIType::Vulkan)
   {
     // Vulkan NDC space has Y pointing down (right-handed NDC space).
     out.Write("\tgl_Position = {}.pos;\n", vertex);
@@ -349,19 +350,19 @@ static void EmitVertex(ShaderCode& out, const ShaderHostConfig& host_config,
     out.Write("\tps.o = {};\n", vertex);
   }
 
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
     out.Write("\tEmitVertex();\n");
   else
     out.Write("\toutput.Append(ps);\n");
 }
 
 static void EndPrimitive(ShaderCode& out, const ShaderHostConfig& host_config,
-                         const geometry_shader_uid_data* uid_data, APIType ApiType, bool wireframe)
+                         const geometry_shader_uid_data* uid_data, APIType api_type, bool wireframe)
 {
   if (wireframe)
-    EmitVertex(out, host_config, uid_data, "first", ApiType, wireframe);
+    EmitVertex(out, host_config, uid_data, "first", api_type, wireframe);
 
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
     out.Write("\tEndPrimitive();\n");
   else
     out.Write("\toutput.RestartStrip();\n");

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -23,7 +23,7 @@ struct geometry_shader_uid_data
 
 using GeometryShaderUid = ShaderUid<geometry_shader_uid_data>;
 
-ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& host_config,
+ShaderCode GenerateGeometryShaderCode(APIType api_type, const ShaderHostConfig& host_config,
                                       const geometry_shader_uid_data* uid_data);
 GeometryShaderUid GetGeometryShaderUid(PrimitiveType primitive_type);
 void EnumerateGeometryShaderUids(const std::function<void(const GeometryShaderUid&)>& callback);

--- a/Source/Core/VideoCommon/UberShaderPixel.h
+++ b/Source/Core/VideoCommon/UberShaderPixel.h
@@ -27,10 +27,10 @@ using PixelShaderUid = ShaderUid<pixel_ubershader_uid_data>;
 
 PixelShaderUid GetPixelShaderUid();
 
-ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
+ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
                           const pixel_ubershader_uid_data* uid_data);
 
 void EnumeratePixelShaderUids(const std::function<void(const PixelShaderUid&)>& callback);
-void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host_config,
+void ClearUnusedPixelShaderUidBits(APIType api_type, const ShaderHostConfig& host_config,
                                    PixelShaderUid* uid);
 }  // namespace UberShader


### PR DESCRIPTION
This brings this parameter name in line with the coding style.  Note that PixelShaderGen was already corrected in #9171, and as far as I can tell this never applied to VertexShaderGen or UberShaderVertex.