### PR TITLE
GameINI: Add Safe Texture Cache to SpongeBob's Truth or Square

### DIFF
--- a/Data/Sys/GameSettings/R8I.ini
+++ b/Data/Sys/GameSettings/R8I.ini
@@ -1,0 +1,17 @@
+# R8IS78, R8IP78, R8IE78 - SpongeBob's Truth or Square
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+# Needs safe texture cache for text to render correctly.
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
Text in SpongeBob's Truth of Square needs Safe Texture Cache in order to render properly.