### PR TITLE
FilesystemWidget: Show more information about partitions

### DIFF
--- a/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
@@ -16,6 +16,8 @@
 
 #include <future>
 
+#include "Common/StringUtil.h"
+
 #include "DiscIO/DiscExtractor.h"
 #include "DiscIO/DiscUtils.h"
 #include "DiscIO/Filesystem.h"
@@ -101,7 +103,7 @@ void FilesystemWidget::PopulateView()
 
   for (size_t i = 0; i < partitions.size(); i++)
   {
-    auto* item = new QStandardItem(tr("Partition %1").arg(i));
+    auto* item = new QStandardItem;
     item->setEditable(false);
 
     item->setIcon(Resources::GetScaledIcon("isoproperties_disc"));
@@ -123,6 +125,58 @@ void FilesystemWidget::PopulateView()
 void FilesystemWidget::PopulateDirectory(int partition_id, QStandardItem* root,
                                          const DiscIO::Partition& partition)
 {
+  auto partition_type = m_volume->GetPartitionType(partition);
+  auto game_id = m_volume->GetGameID(partition);
+  auto title_id = m_volume->GetTitleID(partition);
+
+  QString text = root->text();
+
+  if (!text.isEmpty())
+    text += QStringLiteral(" - ");
+
+  if (partition_type)
+  {
+    QString partition_type_str;
+    switch (partition_type.value())
+    {
+    case DiscIO::PARTITION_DATA:
+      partition_type_str = tr("Data Partition (%1)").arg(partition_type.value());
+      break;
+    case DiscIO::PARTITION_UPDATE:
+      partition_type_str = tr("Update Partition (%1)").arg(partition_type.value());
+      break;
+    case DiscIO::PARTITION_CHANNEL:
+      partition_type_str = tr("Channel Partition (%1)").arg(partition_type.value());
+      break;
+    case DiscIO::PARTITION_INSTALL:
+      partition_type_str = tr("Install Partition (%1)").arg(partition_type.value());
+      break;
+    default:
+      partition_type_str =
+          tr("Other Partition (%1)").arg(partition_type.value(), 8, 16, QLatin1Char('0'));
+      break;
+    }
+    text += partition_type_str + QStringLiteral(" - ");
+  }
+
+  text += QString::fromStdString(game_id);
+
+  if (title_id)
+  {
+    text += QStringLiteral(" - %1 (").arg(title_id.value(), 16, 16, QLatin1Char('0'));
+    for (u32 i = 0; i < 4; i++)
+    {
+      char c = static_cast<char>(title_id.value() >> 8 * (3 - i));
+      if (IsPrintableCharacter(c))
+        text += QLatin1Char(c);
+      else
+        text += QLatin1Char('.');
+    }
+    text += QLatin1Char(')');
+  }
+
+  root->setText(text);
+
   const DiscIO::FileSystem* const file_system = m_volume->GetFileSystem(partition);
   if (file_system)
     PopulateDirectory(partition_id, root, file_system->GetRoot());


### PR DESCRIPTION
This adds the partition type, partition gameid, and partition title ID from the ticket into the filesystem widget.  This is mostly just information that's interesting but not particularly useful, but it does help with seeing how the different values differ.  Note that the partition gameid already shows up if you take screenshots while running something on a different partition (e.g. the Wii Fit Channel installer).

<details><summary>Screenshots</summary>

![Super Mario Sunshine](https://user-images.githubusercontent.com/8334194/127909787-1bab29e8-a1e2-426d-b841-9ae82d1ee74a.png)
![Super Mario Galaxy](https://user-images.githubusercontent.com/8334194/127909798-d4b80fd0-04ed-42b7-9278-cb2f3214ab14.png)
![Wii Freeloader (US)](https://user-images.githubusercontent.com/8334194/127909815-759e970d-fff7-4876-a71a-98b2cc433080.png)
![Wii Freeloader (EU)](https://user-images.githubusercontent.com/8334194/127909806-100fa56f-a2b8-40a2-a5ce-c9c5cdb1a587.png)
![Mario Kart Wii](https://user-images.githubusercontent.com/8334194/127909865-08149a06-c7d1-4a5f-b780-ec8b9f857f57.png)
![Wii Fit](https://user-images.githubusercontent.com/8334194/127909882-acf5596b-abce-444e-b4ba-82b9f23b3821.png)
![Wii Fit Plus](https://user-images.githubusercontent.com/8334194/127909907-ecee0a74-32fe-44c8-881b-d9ce01758c25.png)
![Super Smash Bros. Brawl](https://user-images.githubusercontent.com/8334194/127909961-99bdcb62-06ab-40a9-8a8f-ff27ffa5323e.png)
![Super Smash Bros. Brawl - expanded](https://user-images.githubusercontent.com/8334194/127909994-2d1c98c8-ef7f-4797-bc14-1e4deeca52f6.png)
</details>