### PR TITLE
Preserve spaces in mapping preview of control names

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -50,12 +50,15 @@ static QString RefToDisplayString(ControlReference* ref)
         controls[i] = qualifier.has_device ? QStringLiteral(":") : QString();
         controls[i].append(QString::fromStdString(qualifier.control_name));
       }
+      else
+      {
+        controls[i].remove(QLatin1Char{' '});
+      }
     }
   }
   // Do not re-add "`" to the final string, we don't need to see it.
   expression = controls.join(QStringLiteral(""));
 
-  expression.remove(QLatin1Char{' '});
   expression.remove(QLatin1Char{'\t'});
   expression.remove(QLatin1Char{'\n'});
   expression.remove(QLatin1Char{'\r'});


### PR DESCRIPTION
PR https://github.com/dolphin-emu/dolphin/pull/9700 removed spaces from within control names, which some user complained about, and their point of view is kind of understandable:
https://bugs.dolphin-emu.org/issues/12605
with this change, only spaces outside (between) control names are trimmed, which are the ones we wanted to trim in the first place.
This will still retain the major advantages from 9700.

Basically, "**Button 1   +  Button 2**" was showing as "**Button1+Button2**", while it will now show as "**Button 1+Button 2**".