### PR TITLE
OGLRender: Don't include destination alpha in check for shader blending

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -318,7 +318,7 @@ PixelShaderUid GetPixelShaderUid()
   BlendingState state = {};
   state.Generate(bpmem);
 
-  if (state.usedualsrc && state.dstalpha && g_ActiveConfig.backend_info.bSupportsFramebufferFetch &&
+  if (state.usedualsrc && g_ActiveConfig.backend_info.bSupportsFramebufferFetch &&
       !g_ActiveConfig.backend_info.bSupportsDualSourceBlend)
   {
     uid_data->blend_enable = state.blendenable;
@@ -613,13 +613,8 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
     }
   }
 
-  // Only use dual-source blending when required on drivers that don't support it very well.
-  const bool use_dual_source =
-      host_config.backend_dual_source_blend &&
-      (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) ||
-       uid_data->useDstAlpha);
-  const bool use_shader_blend =
-      !use_dual_source && (uid_data->useDstAlpha && host_config.backend_shader_framebuffer_fetch);
+  const bool use_dual_source = host_config.backend_dual_source_blend;
+  const bool use_shader_blend = !use_dual_source && host_config.backend_shader_framebuffer_fetch;
 
   if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {


### PR DESCRIPTION
Because the condition for shader blending includes destination alpha, double blending may occur if ubershaders are used. (GL_BLEND isn't disabled if destination alpha is off, and the shader blend check in the ubershaders don't check for it. This means that blending may occur twice: once in hardware and once in the ubershader.)

However, this means that destination alpha will be broken when ``BUG_BROKEN_DUAL_SOURCE_BLENDING`` is present and shader blending isn't supported. Affected API/GPU/OS combos include:

- OpenGL + Intel + macOS
- OpenGL + AMD + Windows

Because of the above, I don't think this is the best solution for the problem, but I can't think of anything else. I'm probably missing something easy. Please let me know if you have any ideas.