### PR TITLE
GameINI: SpongeBob SquarePants: Battle For Bikini Bottom Quality of Life settings

### DIFF
--- a/Data/Sys/GameSettings/GQP.ini
+++ b/Data/Sys/GameSettings/GQP.ini
@@ -1,0 +1,18 @@
+# GQPP78, GQPE78 - SpongeBob SquarePants: Battle for Bikini Bottom
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+# Fixes shadows at higher resolution.
+# Option has no effect at 1x IR, so no reason not to enable.
+VertexRounding = True

--- a/Data/Sys/GameSettings/GQPE78.ini
+++ b/Data/Sys/GameSettings/GQPE78.ini
@@ -1,0 +1,14 @@
+# GQPE78 - SpongeBob SquarePants: Battle for Bikini Bottom
+
+[OnFrame]
+$EFB Copy Fix
+0x803CD04C:byte:0x00000000
+
+[OnFrame_Enabled]
+# This game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00195313 to 1.00195.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GQPP78.ini
+++ b/Data/Sys/GameSettings/GQPP78.ini
@@ -1,0 +1,14 @@
+# GQPP78 - SpongeBob SquarePants: Battle for Bikini Bottom
+
+[OnFrame]
+$EFB Copy Fix
+0x803CD414:byte:0x00000000
+
+[OnFrame_Enabled]
+# This game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00195313 to 1.00195.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+$EFB Copy Fix


### PR DESCRIPTION
This enables Vertex Rounding Hack and has a game patch for two bugs resulting from game choices.  The game draws an EFB copy from texture coordinate 0.00195313 to 1.00195 repeating which only works due how to the numbers work out at low resolution.

The Vertex Rounding Hack is a null operation on 1x IR, so there should be no concern enabling it by default since higher resolutions are completely broken without it.

I spent all day testing the game and got nearly to the end with no crashes nor major graphical glitches at 4x internal resolution.  The PAL version of the patch I developed myself based on the NTSC version of the patch, which was based on the Action Replay code on the wiki - https://wiki.dolphin-emu.org/index.php?title=SpongeBob_SquarePants:_Battle_for_Bikini_Bottom