### PR TITLE
VideoCommon: Add shader logic ops support for Apple Silicon GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,10 @@ add_subdirectory(Externals/glslang)
 
 if(ENABLE_VULKAN)
   add_definitions(-DHAS_VULKAN)
+
+  if(APPLE)
+    add_subdirectory(Externals/MoltenVK)
+  endif()
 endif()
 
 if(NOT WIN32 OR (NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")))

--- a/Externals/MoltenVK/CMakeLists.txt
+++ b/Externals/MoltenVK/CMakeLists.txt
@@ -1,0 +1,18 @@
+include(ExternalProject)
+
+ExternalProject_Add(MoltenVK
+  GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
+  GIT_TAG v1.1.4
+
+  CONFIGURE_COMMAND <SOURCE_DIR>/fetchDependencies --macos
+
+  BUILD_COMMAND make -C <SOURCE_DIR> macos
+  BUILD_IN_SOURCE ON
+  BUILD_BYPRODUCTS <SOURCE_DIR>/Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib
+
+  INSTALL_COMMAND ""
+
+  LOG_CONFIGURE ON
+  LOG_BUILD ON
+  LOG_OUTPUT_ON_FAILURE ON
+)

--- a/Externals/MoltenVK/CMakeLists.txt
+++ b/Externals/MoltenVK/CMakeLists.txt
@@ -6,6 +6,8 @@ ExternalProject_Add(MoltenVK
 
   CONFIGURE_COMMAND <SOURCE_DIR>/fetchDependencies --macos
 
+  PATCH_COMMAND git reset --hard v1.1.4 && git apply ${CMAKE_SOURCE_DIR}/Externals/MoltenVK/patches/0001-SPIRVToMSLConverter-Enable-use_framebuffer_fetch_sub.patch
+
   BUILD_COMMAND make -C <SOURCE_DIR> macos
   BUILD_IN_SOURCE ON
   BUILD_BYPRODUCTS <SOURCE_DIR>/Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib

--- a/Externals/MoltenVK/patches/0001-SPIRVToMSLConverter-Enable-use_framebuffer_fetch_sub.patch
+++ b/Externals/MoltenVK/patches/0001-SPIRVToMSLConverter-Enable-use_framebuffer_fetch_sub.patch
@@ -1,0 +1,24 @@
+From 4ca33b7a9b149c6fbcc1c88ce08fc49f21294f6d Mon Sep 17 00:00:00 2001
+From: OatmealDome <julian@oatmealdome.me>
+Date: Sat, 31 Jul 2021 19:18:35 -0400
+Subject: [PATCH] SPIRVToMSLConverter: Enable use_framebuffer_fetch_subpasses
+
+---
+ .../MoltenVKShaderConverter/SPIRVToMSLConverter.cpp              | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
+index 17c79394..97e98004 100644
+--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
++++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
+@@ -92,6 +92,7 @@ MVK_PUBLIC_SYMBOL SPIRVToMSLConversionOptions::SPIRVToMSLConversionOptions() {
+ #endif
+ 
+ 	mslOptions.pad_fragment_output_components = true;
++	mslOptions.use_framebuffer_fetch_subpasses = true;
+ }
+ 
+ MVK_PUBLIC_SYMBOL bool mvk::MSLShaderInput::matches(const mvk::MSLShaderInput& other) const {
+-- 
+2.30.1 (Apple Git-130)
+

--- a/Externals/MoltenVK/version.txt
+++ b/Externals/MoltenVK/version.txt
@@ -1,1 +1,0 @@
-MoltenVK from https://vulkan.lunarg.com/sdk/home#mac, version 1.2.170.0

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -511,8 +511,12 @@ if(APPLE)
   endforeach()
 
   # Copy MoltenVK into the bundle
-  target_sources(dolphin-emu PRIVATE "${CMAKE_SOURCE_DIR}/Externals/MoltenVK/libvulkan.dylib")
-  set_source_files_properties("${CMAKE_SOURCE_DIR}/Externals/MoltenVK/libvulkan.dylib" PROPERTIES MACOSX_PACKAGE_LOCATION Frameworks)
+  if(ENABLE_VULKAN)
+    add_dependencies(dolphin-emu MoltenVK)
+    ExternalProject_Get_Property(MoltenVK SOURCE_DIR)
+    target_sources(dolphin-emu PRIVATE "${SOURCE_DIR}/Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib")
+    set_source_files_properties("${SOURCE_DIR}/Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib" PROPERTIES MACOSX_PACKAGE_LOCATION Frameworks GENERATED ON)
+  endif()
 
   # Update library references to make the bundle portable
   include(DolphinPostprocessBundle)

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -54,6 +54,9 @@ static const char SHADER_HEADER[] = R"(
   #define VARYING_LOCATION(x) layout(location = x)
   #define FORCE_EARLY_Z layout(early_fragment_tests) in
 
+  // Metal framebuffer fetch helpers.
+  #define FB_FETCH_VALUE subpassLoad(in_ocol0)
+
   // hlsl to glsl function translation
   #define API_VULKAN 1
   #define float2 vec2

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -50,6 +50,7 @@ static const char SHADER_HEADER[] = R"(
   #define SAMPLER_BINDING(x) layout(set = 1, binding = x)
   #define TEXEL_BUFFER_BINDING(x) layout(set = 1, binding = (x + 8))
   #define SSBO_BINDING(x) layout(set = 2, binding = x)
+  #define INPUT_ATTACHMENT_BINDING(x, y, z) layout(set = x, binding = y, input_attachment_index = z)
   #define VARYING_LOCATION(x) layout(location = x)
   #define FORCE_EARLY_Z layout(early_fragment_tests) in
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -284,7 +284,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsBPTCTextures = false;              // Dependent on features.
   config->backend_info.bSupportsLogicOp = false;                   // Dependent on features.
   config->backend_info.bSupportsLargePoints = false;               // Dependent on features.
-  config->backend_info.bSupportsFramebufferFetch = false;          // No support.
+  config->backend_info.bSupportsFramebufferFetch = false;          // Dependent on OS and features.
 }
 
 void VulkanContext::PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list)
@@ -335,6 +335,15 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   config->backend_info.bSupportsLargePoints = features.largePoints &&
                                               properties.limits.pointSizeRange[0] <= 1.0f &&
                                               properties.limits.pointSizeRange[1] >= 16;
+
+  std::string device_name = properties.deviceName;
+  u32 vendor_id = properties.vendorID;
+
+  // Only Apple family GPUs support framebuffer fetch.
+  if (vendor_id == 0x106B || device_name.find("Apple") != std::string::npos)
+  {
+    config->backend_info.bSupportsFramebufferFetch = true;
+  }
 
   // Our usage of primitive restart appears to be broken on AMD's binary drivers.
   // Seems to be fine on GCN Gen 1-2, unconfirmed on GCN Gen 3, causes driver resets on GCN Gen 4.

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
@@ -44,8 +44,8 @@ static bool OpenVulkanLibrary()
   if (libvulkan_env && s_vulkan_module.Open(libvulkan_env))
     return true;
 
-  // Use the libvulkan.dylib from the application bundle.
-  std::string filename = File::GetBundleDirectory() + "/Contents/Frameworks/libvulkan.dylib";
+  // Use the libMoltenVK.dylib from the application bundle.
+  std::string filename = File::GetBundleDirectory() + "/Contents/Frameworks/libMoltenVK.dylib";
   return s_vulkan_module.Open(filename.c_str());
 #else
   std::string filename = Common::DynamicLibrary::GetVersionedFilename("vulkan", 1);

--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -14,6 +14,7 @@ using int4 = std::array<s32, 4>;
 
 enum class SrcBlendFactor : u32;
 enum class DstBlendFactor : u32;
+enum class LogicOp : u32;
 
 struct PixelShaderConstants
 {
@@ -53,6 +54,9 @@ struct PixelShaderConstants
   DstBlendFactor blend_dst_factor_alpha;
   u32 blend_subtract;
   u32 blend_subtract_alpha;
+  // For shader_framebuffer_fetch logic ops:
+  u32 logic_op_enable;  // bool
+  LogicOp logic_op_mode;
 };
 
 struct VertexShaderConstants

--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -19,7 +19,7 @@ namespace VideoCommon
 // As pipelines encompass both shader UIDs and render states, changes to either of these should
 // also increment the pipeline UID version. Incrementing the UID version will cause all UID
 // caches to be invalidated.
-constexpr u32 GX_PIPELINE_UID_VERSION = 3;  // Last changed in PR 9532
+constexpr u32 GX_PIPELINE_UID_VERSION = 4;  // Last changed in PR 9990
 
 struct GXPipelineUid
 {

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -318,7 +318,7 @@ PixelShaderUid GetPixelShaderUid()
   BlendingState state = {};
   state.Generate(bpmem);
 
-  if (state.usedualsrc && state.dstalpha && g_ActiveConfig.backend_info.bSupportsFramebufferFetch &&
+  if (state.usedualsrc && g_ActiveConfig.backend_info.bSupportsFramebufferFetch &&
       !g_ActiveConfig.backend_info.bSupportsDualSourceBlend)
   {
     uid_data->blend_enable = state.blendenable;
@@ -613,13 +613,8 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
     }
   }
 
-  // Only use dual-source blending when required on drivers that don't support it very well.
-  const bool use_dual_source =
-      host_config.backend_dual_source_blend &&
-      (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) ||
-       uid_data->useDstAlpha);
-  const bool use_shader_blend =
-      !use_dual_source && (uid_data->useDstAlpha && host_config.backend_shader_framebuffer_fetch);
+  const bool use_dual_source = host_config.backend_dual_source_blend;
+  const bool use_shader_blend = !use_dual_source && host_config.backend_shader_framebuffer_fetch;
 
   if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -422,6 +422,8 @@ void WritePixelShaderCommonHeader(ShaderCode& out, APIType api_type,
             "\tuint  blend_dst_factor_alpha;\n"
             "\tbool  blend_subtract;\n"
             "\tbool  blend_subtract_alpha;\n"
+            "\tbool  logic_op_enable;\n"
+            "\tuint  logic_op_mode;\n"
             "}};\n\n");
   out.Write("#define bpmem_combiners(i) (bpmem_pack1[(i)].xy)\n"
             "#define bpmem_tevind(i) (bpmem_pack1[(i)].z)\n"

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -330,6 +330,9 @@ PixelShaderUid GetPixelShaderUid()
     uid_data->blend_subtract_alpha = state.subtractAlpha;
   }
 
+  uid_data->logic_op_enable = state.logicopenable;
+  uid_data->logic_op_mode = u32(state.logicmode.Value());
+
   return out;
 }
 

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -58,6 +58,8 @@ struct pixel_shader_uid_data
   DstBlendFactor blend_dst_factor_alpha : 3;  // Only used with shader_framebuffer_fetch blend
   u32 blend_subtract : 1;                     // Only used with shader_framebuffer_fetch blend
   u32 blend_subtract_alpha : 1;               // Only used with shader_framebuffer_fetch blend
+  u32 logic_op_enable : 1;                    // Only used with shader_framebuffer_fetch logic ops
+  u32 logic_op_mode : 4;                      // Only used with shader_framebuffer_fetch logic ops
 
   u32 texMtxInfo_n_projection : 8;  // 8x1 bit
   u32 tevindref_bi0 : 3;

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -504,6 +504,16 @@ void PixelShaderManager::SetBlendModeChanged()
     constants.blend_subtract_alpha = state.subtractAlpha;
     dirty = true;
   }
+  if (constants.logic_op_enable != state.logicopenable)
+  {
+    constants.logic_op_enable = state.logicopenable;
+    dirty = true;
+  }
+  if (constants.logic_op_mode != state.logicmode)
+  {
+    constants.logic_op_mode = state.logicmode;
+    dirty = true;
+  }
   s_bDestAlphaDirty = true;
 }
 

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -583,7 +583,14 @@ AbstractPipelineConfig ShaderCache::GetGXPipelineConfig(
   config.blending_state = blending_state;
   config.framebuffer_state = g_framebuffer_manager->GetEFBFramebufferState();
 
+#ifdef __APPLE__
+  // We can use framebuffer fetch with Metal (Vulkan over MoltenVK) to emulate logic ops in the
+  // fragment shader.
+  if (config.blending_state.logicopenable && !g_ActiveConfig.backend_info.bSupportsLogicOp &&
+      !g_ActiveConfig.backend_info.bSupportsFramebufferFetch)
+#else
   if (config.blending_state.logicopenable && !g_ActiveConfig.backend_info.bSupportsLogicOp)
+#endif
   {
     WARN_LOG_FMT(VIDEO,
                  "Approximating logic op with blending, this will produce incorrect rendering.");

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -55,6 +55,12 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
   const bool stereo = host_config.stereo;
   const bool use_dual_source = host_config.backend_dual_source_blend;
   const bool use_shader_blend = !use_dual_source && host_config.backend_shader_framebuffer_fetch;
+  const bool use_shader_logic_op =
+#ifdef __APPLE__
+      !host_config.backend_logic_op && host_config.backend_shader_framebuffer_fetch;
+#else
+      false;
+#endif
   const bool early_depth = uid_data->early_depth != 0;
   const bool per_pixel_depth = uid_data->per_pixel_depth != 0;
   const bool bounding_box = host_config.bounding_box;
@@ -71,7 +77,37 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
   // Shader inputs/outputs in GLSL (HLSL is in main).
   if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
+#ifdef __APPLE__
+    // Framebuffer fetch is only supported by Metal, so ensure that we're running Vulkan (MoltenVK)
+    // if we want to use it.
+    if (api_type == APIType::Vulkan)
+    {
+      if (use_dual_source)
+      {
+        out.Write("FRAGMENT_OUTPUT_LOCATION_INDEXED(0, 0) out vec4 ocol0;\n"
+                  "FRAGMENT_OUTPUT_LOCATION_INDEXED(0, 1) out vec4 ocol1;\n");
+      }
+      else if (use_shader_blend)
+      {
+        // Metal doesn't support a single unified variable for both input and output, so we declare
+        // the output separately. The input will be defined later below.
+        out.Write("FRAGMENT_OUTPUT_LOCATION(0) out vec4 real_ocol0;\n");
+      }
+      else
+      {
+        out.Write("FRAGMENT_OUTPUT_LOCATION(0) out vec4 ocol0;\n");
+      }
+
+      if (use_shader_blend || use_shader_logic_op)
+      {
+        // Subpass inputs will be converted to framebuffer fetch by SPIRV-Cross.
+        out.Write("INPUT_ATTACHMENT_BINDING(0, 0, 0) uniform subpassInput in_ocol0;\n");
+      }
+    }
+    else if (use_dual_source)
+#else
     if (use_dual_source)
+#endif
     {
       if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_FRAGMENT_SHADER_INDEX_DECORATION))
       {
@@ -1231,6 +1267,40 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
             "    TevResult.rgb = (TevResult.rgb * (256 - ifog) + " I_FOGCOLOR ".rgb * ifog) >> 8;\n"
             "  }}\n"
             "\n");
+
+  if (use_shader_logic_op)
+  {
+    static constexpr std::array<const char*, 16> logic_op_mode{
+        "int4(0, 0, 0, 0)",          // CLEAR
+        "TevResult & fb_value",      // AND
+        "TevResult & ~fb_value",     // AND_REVERSE
+        "TevResult",                 // COPY
+        "~TevResult & fb_value",     // AND_INVERTED
+        "fb_value",                  // NOOP
+        "TevResult ^ fb_value",      // XOR
+        "TevResult | fb_value",      // OR
+        "~(TevResult | fb_value)",   // NOR
+        "~(TevResult ^ fb_value)",   // EQUIV
+        "~fb_value",                 // INVERT
+        "TevResult | ~fb_value",     // OR_REVERSE
+        "~TevResult",                // COPY_INVERTED
+        "~TevResult | fb_value",     // OR_INVERTED
+        "~(TevResult & fb_value)",   // NAND
+        "int4(255, 255, 255, 255)",  // SET
+    };
+
+    out.Write("  // Logic Ops\n"
+              "  if (logic_op_enable) {{\n"
+              "    int4 fb_value = int4(FB_FETCH_VALUE * 255.0);"
+              "    switch (logic_op_mode) {{\n");
+    for (size_t i = 0; i < logic_op_mode.size(); i++)
+    {
+      out.Write("      case {}u: TevResult = {}; break;\n", i, logic_op_mode[i]);
+    }
+
+    out.Write("    }}\n"
+              "  }}\n");
+  }
 
   // D3D requires that the shader outputs be uint when writing to a uint render target for logic op.
   if (api_type == APIType::D3D && uid_data->uint_output)


### PR DESCRIPTION
This PR adds a shader logic ops implementation for Apple Silicon GPUs. While Metal does not support logic ops itself, it *does* support framebuffer fetch, allowing us to implement it in the fragment shader. (Note that Intel, AMD, and NVIDIA GPUs do *not* support framebuffer fetch, so this PR will not solve the logic ops problem on Intel Macs.)

Fixes Kirby's Air Ride and more on M1 Macs.

**Depends on**: #9981, #9988 