### PR TITLE
GameINI: Add Gladius Patch to Other Regions

### DIFF
--- a/Data/Sys/GameSettings/GLSD64.ini
+++ b/Data/Sys/GameSettings/GLSD64.ini
@@ -1,0 +1,20 @@
+# GLSD64 - Gladius
+
+[OnFrame]
+# This game can deadlock the CPU and GPU by setting FIFO breakpoints too
+# infrequently, provided the CPU gets too far ahead, as can happen under Dolphin
+# due to timing inaccuracies. The game never clears breakpoints, and it will
+# skip setting them if the previous one has not been hit by the GPU. If the CPU
+# gets far enough ahead it will reach the FIFO high water mark and trigger an
+# overflow interrupt, causing the render thread to be suspended. The GPU will
+# make forward progress until it hits the last set breakpoint. However, if the
+# distance between that breakpoint and the FIFO write pointer is greater than
+# the low water mark, then the GPU will never generate an underflow interrupt
+# and the render thread will never be resumed. This patch forces the game to
+# update the breakpoint unconditionally and has been tested on real hardware
+# with no apparent ill effect.
+$Fix freeze in opening cutscene
+0x8010A2EC:dword:0x60000000
+
+[OnFrame_Enabled]
+$Fix freeze in opening cutscene

--- a/Data/Sys/GameSettings/GLSF64.ini
+++ b/Data/Sys/GameSettings/GLSF64.ini
@@ -1,0 +1,20 @@
+# GLSF64 - Gladius
+
+[OnFrame]
+# This game can deadlock the CPU and GPU by setting FIFO breakpoints too
+# infrequently, provided the CPU gets too far ahead, as can happen under Dolphin
+# due to timing inaccuracies. The game never clears breakpoints, and it will
+# skip setting them if the previous one has not been hit by the GPU. If the CPU
+# gets far enough ahead it will reach the FIFO high water mark and trigger an
+# overflow interrupt, causing the render thread to be suspended. The GPU will
+# make forward progress until it hits the last set breakpoint. However, if the
+# distance between that breakpoint and the FIFO write pointer is greater than
+# the low water mark, then the GPU will never generate an underflow interrupt
+# and the render thread will never be resumed. This patch forces the game to
+# update the breakpoint unconditionally and has been tested on real hardware
+# with no apparent ill effect.
+$Fix freeze in opening cutscene
+0x8010A388:dword:0x60000000
+
+[OnFrame_Enabled]
+$Fix freeze in opening cutscene

--- a/Data/Sys/GameSettings/GLSP64.ini
+++ b/Data/Sys/GameSettings/GLSP64.ini
@@ -1,0 +1,20 @@
+# GLSP64 - Gladius
+
+[OnFrame]
+# This game can deadlock the CPU and GPU by setting FIFO breakpoints too
+# infrequently, provided the CPU gets too far ahead, as can happen under Dolphin
+# due to timing inaccuracies. The game never clears breakpoints, and it will
+# skip setting them if the previous one has not been hit by the GPU. If the CPU
+# gets far enough ahead it will reach the FIFO high water mark and trigger an
+# overflow interrupt, causing the render thread to be suspended. The GPU will
+# make forward progress until it hits the last set breakpoint. However, if the
+# distance between that breakpoint and the FIFO write pointer is greater than
+# the low water mark, then the GPU will never generate an underflow interrupt
+# and the render thread will never be resumed. This patch forces the game to
+# update the breakpoint unconditionally and has been tested on real hardware
+# with no apparent ill effect.
+$Fix freeze in opening cutscene
+0x8010A0F4:dword:0x60000000
+
+[OnFrame_Enabled]
+$Fix freeze in opening cutscene


### PR DESCRIPTION
Only the NTSC version of Gladius got a patch with smurf3tte's reverse engineering work.  Since most of the work was done, I ported over the fix to the PAL, French, and German releases.  Leoetlino helped figure out a consistent way to find the correct address.

These codes were tested to bypass the original crash in the intro, however I did not play the games beyond the 5 tutorial missions.