### PR TITLE
GameINI: SpongeBob SquarePants Movie QoL Settings

### DIFF
--- a/Data/Sys/GameSettings/GGV.ini
+++ b/Data/Sys/GameSettings/GGV.ini
@@ -1,8 +1,20 @@
 # GGVD78, GGVE78, GGVP78, GGVX78 - The SpongeBob SquarePants Movie
+
 [Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
 [OnFrame]
+# Add memory patches to be applied every frame here.
+
 [ActionReplay]
-[Gecko]
-[Video_Settings]
+# Add action replay cheats here.
+
 [Video_Hacks]
+# Fixes shadows at higher resolution.
+# Option has no effect at 1x IR, so no reason not to enable.
+VertexRounding = True
+# Needed for some FMVs.
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GGVD78.ini
+++ b/Data/Sys/GameSettings/GGVD78.ini
@@ -1,0 +1,14 @@
+# GGVD78 - The SpongeBob SquarePants Movie
+
+[OnFrame]
+$EFB Copy Fix
+0x804B9510:byte:0x00000000
+
+[OnFrame_Enabled]
+# This game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00390625 to 1.00390625.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GGVE78.ini
+++ b/Data/Sys/GameSettings/GGVE78.ini
@@ -1,0 +1,14 @@
+# GGVE78 - The SpongeBob SquarePants Movie
+
+[OnFrame]
+$EFB Copy Fix
+0x804B39D0:byte:0x00000000
+
+[OnFrame_Enabled]
+# This game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00390625 to 1.00390625.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GGVP78.ini
+++ b/Data/Sys/GameSettings/GGVP78.ini
@@ -1,0 +1,14 @@
+# GGVP78 - The SpongeBob SquarePants Movie
+
+[OnFrame]
+$EFB Copy Fix
+0x804B39D0:byte:0x00000000
+
+[OnFrame_Enabled]
+# This game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00390625 to 1.00390625.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GGVX78.ini
+++ b/Data/Sys/GameSettings/GGVX78.ini
@@ -1,0 +1,14 @@
+# GGVX78 - The SpongeBob SquarePants Movie
+
+[OnFrame]
+$EFB Copy Fix
+0x804BA014:byte:0x00000000
+
+[OnFrame_Enabled]
+# This game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00390625 to 1.00390625.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+$EFB Copy Fix


### PR DESCRIPTION
SpongeBob SquarePants: The Movie suffers from all of the same issues as Battle for Bikini Bottom.  These patches are not based on any existing cheats or codes, this one isn't as loved as Battle for Bikini Bottom and didn't receive an action replay code to fix everything.  There *is* a cheat that disables shadowing, but that wasn't good enough, so I sought out to make a new patch that does the same thing as the one for Battle for Bikini Bottom.

Heavy guidance was given by Pokechu22, who helped walking me through ghidra to find the memory addresses.  The game is rendering efb copies with coordinates 0.00390625 and 1.00390625, which cause severe problems at higher resolutions.  This patch adjusts them to render at 0 and 1, and enables the Vertex Rounding Hack to repair things at higher resolutions.

I tested the first stage of each version of the game, but I'm tired and didn't test any further.  And for those reviewing, for some reason the PAL and NTSC addresses are identical.  I triple checked that.