### PR TITLE
ShaderCompiler: Attach shader source code to SPIR-V

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -203,9 +203,9 @@ void AdvancedWidget::AddDescriptions()
                  "unchecked.</dolphin_emphasis>");
   static const char TR_VALIDATION_LAYER_DESCRIPTION[] =
       QT_TR_NOOP("Enables validation of API calls made by the video backend, which may assist in "
-                 "debugging graphical issues. On D3D backends, this also enables debug symbols "
-                 "for the compiled shaders.<br><br><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
+                 "debugging graphical issues. On the Vulkan and D3D backends, this also enables "
+                 "debug symbols for the compiled shaders.<br><br><dolphin_emphasis>If unsure, "
+                 "leave this unchecked.</dolphin_emphasis>");
   static const char TR_DUMP_TEXTURE_DESCRIPTION[] =
       QT_TR_NOOP("Dumps decoded game textures based on the other flags to "
                  "User/Dump/Textures/&lt;game_id&gt;/.<br><br><dolphin_emphasis>If unsure, leave "

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -196,7 +196,21 @@ static std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage,
 
   SPIRVCodeVector out_code;
   spv::SpvBuildLogger logger;
-  glslang::GlslangToSpv(*intermediate, out_code, &logger);
+  glslang::SpvOptions options;
+
+  if (g_ActiveConfig.bEnableValidationLayer)
+  {
+    // Attach the source code to the SPIR-V for tools like RenderDoc.
+    intermediate->addSourceText(pass_source_code, pass_source_code_length);
+
+    options.generateDebugInfo = true;
+    options.disableOptimizer = true;
+    options.optimizeSize = false;
+    options.disassemble = false;
+    options.validate = true;
+  }
+
+  glslang::GlslangToSpv(*intermediate, out_code, &logger, &options);
 
   // Write out messages
   // Temporary: skip if it contains "Warning, version 450 is not yet complete; most version-specific


### PR DESCRIPTION
Title.

This PR was opened mostly so I can take advantage of the Windows buildbot, but perhaps it would be useful to upstream as well.