### PR TITLE
PixelShaderGen: Pass LOD bias to fragment shader and use when sampling texture on Metal and OpenGL ES

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DMain.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DMain.cpp
@@ -106,6 +106,7 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsSSAA = true;
   g_Config.backend_info.bSupportsShaderBinaries = true;
   g_Config.backend_info.bSupportsPipelineCacheData = false;
+  g_Config.backend_info.bSupportsLodBiasInSampler = true;
   g_Config.backend_info.bSupportsLogicOp = D3D::SupportsLogicOp(g_Config.iAdapter);
 
   g_Config.backend_info.Adapters = D3DCommon::GetAdapterNames();

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -82,6 +82,7 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.AAModes = DXContext::GetAAModes(g_Config.iAdapter);
   g_Config.backend_info.bSupportsShaderBinaries = true;
   g_Config.backend_info.bSupportsPipelineCacheData = true;
+  g_Config.backend_info.bSupportsLodBiasInSampler = true;
 
   // We can only check texture support once we have a device.
   if (g_dx_context)

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -55,6 +55,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsPartialDepthCopies = false;
   g_Config.backend_info.bSupportsShaderBinaries = false;
   g_Config.backend_info.bSupportsPipelineCacheData = false;
+  g_Config.backend_info.bSupportsLodBiasInSampler = false;
 
   // aamodes: We only support 1 sample, so no MSAA
   g_Config.backend_info.Adapters.clear();

--- a/Source/Core/VideoBackends/OGL/OGLMain.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLMain.cpp
@@ -93,6 +93,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsPartialDepthCopies = true;
   g_Config.backend_info.bSupportsShaderBinaries = false;
   g_Config.backend_info.bSupportsPipelineCacheData = false;
+  g_Config.backend_info.bSupportsLodBiasInSampler = true;
 
   // TODO: There is a bug here, if texel buffers or SSBOs/atomics are not supported the graphics
   // options will show the option when it is not supported. The only way around this would be

--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -512,6 +512,9 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     // ARB_get_texture_sub_image (unlikely, except maybe on NVIDIA), we can use that instead.
     g_Config.backend_info.bSupportsDepthReadback = g_ogl_config.bSupportsTextureSubImage;
 
+    // GL_TEXTURE_LOD_BIAS is not supported on GLES.
+    g_Config.backend_info.bSupportsLodBiasInSampler = false;
+
     if (GLExtensions::Supports("GL_EXT_shader_framebuffer_fetch"))
     {
       g_ogl_config.SupportedFramebufferFetch = EsFbFetchType::FbFetchExt;

--- a/Source/Core/VideoBackends/OGL/SamplerCache.cpp
+++ b/Source/Core/VideoBackends/OGL/SamplerCache.cpp
@@ -98,8 +98,10 @@ void SamplerCache::SetParameters(GLuint sampler_id, const SamplerState& params)
   glSamplerParameterf(sampler_id, GL_TEXTURE_MIN_LOD, params.min_lod / 16.f);
   glSamplerParameterf(sampler_id, GL_TEXTURE_MAX_LOD, params.max_lod / 16.f);
 
-  if (!static_cast<Renderer*>(g_renderer.get())->IsGLES())
+  if (g_ActiveConfig.backend_info.bSupportsLodBiasInSampler)
+  {
     glSamplerParameterf(sampler_id, GL_TEXTURE_LOD_BIAS, params.lod_bias / 256.f);
+  }
 
   if (params.anisotropic_filtering && g_ogl_config.bSupportsAniso)
   {

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -83,6 +83,7 @@ void VideoSoftware::InitBackendInfo()
   g_Config.backend_info.bSupportsLogicOp = true;
   g_Config.backend_info.bSupportsShaderBinaries = false;
   g_Config.backend_info.bSupportsPipelineCacheData = false;
+  g_Config.backend_info.bSupportsLodBiasInSampler = false;
 
   // aamodes
   g_Config.backend_info.AAModes = {1};

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -285,6 +285,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsLogicOp = false;                   // Dependent on features.
   config->backend_info.bSupportsLargePoints = false;               // Dependent on features.
   config->backend_info.bSupportsFramebufferFetch = false;          // No support.
+  config->backend_info.bSupportsLodBiasInSampler = false;          // Dependent on OS.
 }
 
 void VulkanContext::PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list)
@@ -311,6 +312,13 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
       (features.fragmentStoresAndAtomics == VK_TRUE);
   config->backend_info.bSupportsSSAA = (features.sampleRateShading == VK_TRUE);
   config->backend_info.bSupportsLogicOp = (features.logicOp == VK_TRUE);
+
+#ifdef __APPLE__
+  // Metal doesn't support this.
+  config->backend_info.bSupportsLodBiasInSampler = false;
+#else
+  config->backend_info.bSupportsLodBiasInSampler = true;
+#endif
 
   // Disable geometry shader when shaderTessellationAndGeometryPointSize is not supported.
   // Seems this is needed for gl_Layer.

--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -21,6 +21,7 @@ struct PixelShaderConstants
   std::array<int4, 4> kcolors;
   int4 alpha;
   std::array<float4, 8> texdims;
+  std::array<float, 8> lodbias;
   std::array<int4, 2> zbias;
   std::array<int4, 2> indtexscale;
   std::array<int4, 6> indtexmtx;

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -285,6 +285,12 @@ void PixelShaderManager::SetTexDims(int texmapid, u32 width, u32 height)
   constants.texdims[texmapid][1] = rheight;
 }
 
+void PixelShaderManager::SetLodBias(int texmapid, float bias)
+{
+  constants.lodbias[texmapid] = bias;
+  dirty = true;
+}
+
 void PixelShaderManager::SetZTextureBias()
 {
   constants.zbias[1][3] = bpmem.ztex1.bias;

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -30,6 +30,7 @@ public:
   static void SetAlphaTestChanged();
   static void SetDestAlphaChanged();
   static void SetTexDims(int texmapid, u32 width, u32 height);
+  static void SetLodBias(int texmapid, float bias);
   static void SetZTextureBias();
   static void SetViewportChanged();
   static void SetEfbScaleChanged(float scalex, float scaley);

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -38,6 +38,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.backend_shader_framebuffer_fetch = g_ActiveConfig.backend_info.bSupportsFramebufferFetch;
   bits.backend_logic_op = g_ActiveConfig.backend_info.bSupportsLogicOp;
   bits.backend_palette_conversion = g_ActiveConfig.backend_info.bSupportsPaletteConversion;
+  bits.backend_sampler_lod_bias = g_ActiveConfig.backend_info.bSupportsLodBiasInSampler;
   bits.enable_validation_layer = g_ActiveConfig.bEnableValidationLayer;
   return bits;
 }

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -199,6 +199,7 @@ const char* GetInterpolationQualifier(bool msaa, bool ssaa, bool in_glsl_interfa
 #define I_KCOLORS "k"
 #define I_ALPHA "alphaRef"
 #define I_TEXDIMS "texdim"
+#define I_LODBIAS "clodbias"
 #define I_ZBIAS "czbias"
 #define I_INDTEXSCALE "cindscale"
 #define I_INDTEXMTX "cindmtx"

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -167,7 +167,8 @@ union ShaderHostConfig
   BitField<20, 1, bool, u32> backend_shader_framebuffer_fetch;
   BitField<21, 1, bool, u32> backend_logic_op;
   BitField<22, 1, bool, u32> backend_palette_conversion;
-  BitField<23, 1, bool, u32> enable_validation_layer;
+  BitField<23, 1, bool, u32> backend_sampler_lod_bias;
+  BitField<24, 1, bool, u32> enable_validation_layer;
 
   static ShaderHostConfig GetCurrent();
 };

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1024,6 +1024,8 @@ static void SetSamplerState(u32 index, float custom_tex_scale, bool custom_tex,
     state.anisotropic_filtering = 0;
   }
 
+  PixelShaderManager::SetLodBias(index, state.lod_bias / 256.0f);
+
   g_renderer->SetSamplerState(index, state);
 }
 

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -228,7 +228,7 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
     // supports this in the future.
     out.Write("int4 sampleTexture(uint sampler_num, float3 uv) {{\n");
     if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
-      out.Write("  return iround(texture(samp[sampler_num], uv) * 255.0);\n");
+      out.Write("  return iround(texture(samp[sampler_num], uv, lodbias(sampler_num)) * 255.0);\n");
     else if (api_type == APIType::D3D)
       out.Write("  return iround(Tex[sampler_num].Sample(samp[sampler_num], uv) * 255.0);\n");
     out.Write("}}\n\n");
@@ -244,7 +244,8 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
     for (int i = 0; i < 8; i++)
     {
       if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
-        out.Write("  case {}u: return iround(texture(samp[{}], uv) * 255.0);\n", i, i);
+        out.Write("  case {}u: return iround(texture(samp[{}], uv, lodbias({}u)) * 255.0);\n", i, i,
+                  i);
       else if (api_type == APIType::D3D)
         out.Write("  case {}u: return iround(Tex[{}].Sample(samp[{}], uv) * 255.0);\n", i, i, i);
     }

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -225,6 +225,7 @@ struct VideoConfig final
     bool bSupportsDepthReadback;
     bool bSupportsShaderBinaries;
     bool bSupportsPipelineCacheData;
+    bool bSupportsLodBiasInSampler;
   } backend_info;
 
   // Utility


### PR DESCRIPTION
In Twilight Princess, the iris of Midna's eyes disappears as the camera moves further away from her model. This is done by using two mipmaps: one with her iris, and one with just the pale yellow of her sclera. The game sets the distance at which the transition between the two mipmaps occurs by setting the LOD bias value to a large negative value.

To emulate LOD bias in the Vulkan backend, ``mipLodBias`` in the ``VkSamplerCreateInfo`` for the texture's sampler is set. Unfortunately, Metal does not support setting LOD bias in a sampler, so `mipLodBias` is ignored by MoltenVK. On OpenGL ES, the sampler parameter for setting LOD bias (``GL_TEXTURE_LOD_BIAS``) is unsupported, unlike desktop OpenGL.

This causes Midna's iris to only appear when the camera is very close to her.

However, we can pass through a bias value in the ``texture()`` call in the fragment shader, which both OpenGL ES and Metal support. This is what this PR implements.

Fixes https://bugs.dolphin-emu.org/issues/11568 and https://bugs.dolphin-emu.org/issues/11993..

<details>
<summary>Screenshots (macOS)</summary>

Broken:

![image](https://bugs.dolphin-emu.org/attachments/download/7247/Screenshot%202019-02-12%20at%2017.15.41.png)

Fixed:

![image](https://user-images.githubusercontent.com/11504941/128438842-dc31a5c1-6c38-4aee-a686-3a80c6c34f84.png)

</details>