### PR TITLE
Jit: Re-add dcbx masking

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -443,7 +443,7 @@ void Interpreter::dcbf(UGeckoInstruction inst)
   // the lack of precise L1 icache emulation in the JIT. (Portable software
   // should use icbi consistently, but games aren't portable.)
   const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
-  JitInterface::InvalidateICache(address & ~0x1f, 32, false);
+  JitInterface::InvalidateICacheLine(address);
 }
 
 void Interpreter::dcbi(UGeckoInstruction inst)
@@ -461,7 +461,7 @@ void Interpreter::dcbi(UGeckoInstruction inst)
   // the lack of precise L1 icache emulation in the JIT. (Portable software
   // should use icbi consistently, but games aren't portable.)
   const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
-  JitInterface::InvalidateICache(address & ~0x1f, 32, false);
+  JitInterface::InvalidateICacheLine(address);
 }
 
 void Interpreter::dcbst(UGeckoInstruction inst)
@@ -473,7 +473,7 @@ void Interpreter::dcbst(UGeckoInstruction inst)
   // the lack of precise L1 icache emulation in the JIT. (Portable software
   // should use icbi consistently, but games aren't portable.)
   const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
-  JitInterface::InvalidateICache(address & ~0x1f, 32, false);
+  JitInterface::InvalidateICacheLine(address);
 }
 
 void Interpreter::dcbt(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -274,9 +274,7 @@ void Jit64::dcbx(UGeckoInstruction inst)
   registersInUse[X64Reg(effective_address)] = false;
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
   MOV(32, R(ABI_PARAM1), R(effective_address));
-  MOV(32, R(ABI_PARAM2), Imm32(32));
-  XOR(32, R(ABI_PARAM3), R(ABI_PARAM3));
-  ABI_CallFunction(JitInterface::InvalidateICache);
+  ABI_CallFunction(JitInterface::InvalidateICacheLine);
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);
   asm_routines.ResetStack(*this);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -602,10 +602,8 @@ void JitArm64::dcbx(UGeckoInstruction inst)
   ABI_PushRegisters(gprs_to_push);
   m_float_emit.ABI_PushRegisters(fprs_to_push, ARM64Reg::X30);
 
-  MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICache);
-  // W0 was already set earlier
-  MOVI2R(ARM64Reg::W1, 32);
-  MOVI2R(ARM64Reg::W2, 0);
+  // W0 (the function call argument) was already set earlier
+  MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLine);
   BLR(ARM64Reg::X8);
 
   m_float_emit.ABI_PopRegisters(fprs_to_push, ARM64Reg::X30);

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -224,6 +224,11 @@ void InvalidateICache(u32 address, u32 size, bool forced)
     g_jit->GetBlockCache()->InvalidateICache(address, size, forced);
 }
 
+void InvalidateICacheLine(u32 address)
+{
+  InvalidateICache(address & ~0x1f, 32, false);
+}
+
 void CompileExceptionCheck(ExceptionType type)
 {
   if (!g_jit)

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -62,6 +62,7 @@ void ClearSafe();
 
 // If "forced" is true, a recompile is being requested on code that hasn't been modified.
 void InvalidateICache(u32 address, u32 size, bool forced);
+void InvalidateICacheLine(u32 address);
 
 void CompileExceptionCheck(ExceptionType type);
 


### PR DESCRIPTION
When making PR #9957, I checked whether the ~0x1f masking in dcbx actually was necessary. I came to the conclusion that it wasn't, so I removed it. However, I hadn't checked the second half of InvalidateICache closely enough – the masking is actually needed.

This commit re-adds the masking, but this time in C++ code instead of in jitted code in order to save icache. Though I suppose the difference doesn't matter all that much, since this is in farcode and all...

Hopefully fixes https://bugs.dolphin-emu.org/issues/12612 (not tested).