### PR TITLE
GameINI:  Fix EFB Copy Offset in more games

### DIFF
--- a/Data/Sys/GameSettings/GICD78.ini
+++ b/Data/Sys/GameSettings/GICD78.ini
@@ -1,8 +1,8 @@
-# GICE78 - The Incredibles
+# GICD78 - The Incredibles
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803D2A94:dword:0x00000000
 
 [OnFrame_Enabled]
 # This game renders an EFB copy with texture repeating enabled
@@ -12,8 +12,3 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
-
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GICF78.ini
+++ b/Data/Sys/GameSettings/GICF78.ini
@@ -1,8 +1,8 @@
-# GICE78 - The Incredibles
+# GICF78 - The Incredibles
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803D2E94:dword:0x00000000
 
 [OnFrame_Enabled]
 # This game renders an EFB copy with texture repeating enabled
@@ -12,8 +12,3 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
-
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GICH78.ini
+++ b/Data/Sys/GameSettings/GICH78.ini
@@ -1,8 +1,8 @@
-# GICE78 - The Incredibles
+# GICH78 - The Incredibles
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803D2A94:dword:0x00000000
 
 [OnFrame_Enabled]
 # This game renders an EFB copy with texture repeating enabled
@@ -12,8 +12,3 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
-
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GICJG9.ini
+++ b/Data/Sys/GameSettings/GICJG9.ini
@@ -1,8 +1,8 @@
-# GICE78 - The Incredibles
+# GICJG9 - The Incredibles
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803D30F4:byte:0x00000000
 
 [OnFrame_Enabled]
 # This game renders an EFB copy with texture repeating enabled
@@ -12,8 +12,3 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
-
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GICP78.ini
+++ b/Data/Sys/GameSettings/GICP78.ini
@@ -1,8 +1,8 @@
-# GICE78 - The Incredibles
+# GICP78 - The Incredibles
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803D2914:dword:0x00000000
 
 [OnFrame_Enabled]
 # This game renders an EFB copy with texture repeating enabled
@@ -12,8 +12,3 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
-
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GIQ.ini
+++ b/Data/Sys/GameSettings/GIQ.ini
@@ -1,4 +1,4 @@
-# GIQE78 - The Incredibles 2
+# GIQJ8P, GIQE78, GIQX78, GIQY78 - The Incredibles: Rise of the Underminer
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/GIQE78.ini
+++ b/Data/Sys/GameSettings/GIQE78.ini
@@ -1,10 +1,17 @@
-# GIQE78 - The Incredibles 2
-
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
+# GIQE78 - The Incredibles: Rise of the Underminer
 
 [OnFrame]
-# Add memory patches to be applied every frame here.
+$EFB Copy Fix
+0x803F09F0:byte:0x00000000
+
+[OnFrame_Enabled]
+# This game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00390625 to 1.00390625.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+$EFB Copy Fix
 
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/GIQJ8P.ini
+++ b/Data/Sys/GameSettings/GIQJ8P.ini
@@ -1,8 +1,8 @@
-# GICE78 - The Incredibles
+# GIQJ8P - The Incredibles: Rise of the Underminer
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803F1850:dword:0x00000000
 
 [OnFrame_Enabled]
 # This game renders an EFB copy with texture repeating enabled
@@ -13,7 +13,3 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
 
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GIQX78.ini
+++ b/Data/Sys/GameSettings/GIQX78.ini
@@ -1,8 +1,8 @@
-# GICE78 - The Incredibles
+# GIQX78 - The Incredibles: Rise of the Underminer
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803F0E90:dword:0x00000000
 
 [OnFrame_Enabled]
 # This game renders an EFB copy with texture repeating enabled
@@ -13,7 +13,3 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
 
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GIQY78.ini
+++ b/Data/Sys/GameSettings/GIQY78.ini
@@ -1,8 +1,8 @@
-# GICE78 - The Incredibles
+# GIQY78 - The Incredibles: Rise of the Underminer
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803F0E90:dword:0x00000000
 
 [OnFrame_Enabled]
 # This game renders an EFB copy with texture repeating enabled
@@ -13,7 +13,3 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
 
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GU2.ini
+++ b/Data/Sys/GameSettings/GU2.ini
@@ -1,4 +1,4 @@
-# GICD78, GICE78, GICF78, GICH78, GICJG9, GICP78 - The Incredibles
+# GU2F78, GU2D78 - 2 Games in 1: The Incredibles / Finding Nemo
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
-# Fixes shadows at higher resolution.
+# Fixes shadows at higher resolution on disc 1.
 # Option has no effect at 1x IR, so no reason not to enable.
 VertexRounding = True
-EFBToTextureEnable = False
+

--- a/Data/Sys/GameSettings/GU2D78.ini
+++ b/Data/Sys/GameSettings/GU2D78.ini
@@ -1,19 +1,15 @@
-# GICE78 - The Incredibles
+# GU2D78 - 2 Games in 1: The Incredibles / Finding Nemo
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803D2A94:dword:0x00000000:0x3B800000
 
 [OnFrame_Enabled]
-# This game renders an EFB copy with texture repeating enabled
+# Disc one of this game renders an EFB copy with texture repeating enabled
 # and it draws from texture coordinate 0.00390625 to 1.00390625.
 # This only works on console and 1x IR due to low precision.
 # "EFB Copy Fix" adjusts the region to not cause bugs at higher
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
+# Patch has been made conditional to prevent causing issues on disc 2.
 $EFB Copy Fix
-
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GU2F78.ini
+++ b/Data/Sys/GameSettings/GU2F78.ini
@@ -1,19 +1,15 @@
-# GICE78 - The Incredibles
+# GU2F78 - 2 Games in 1: The Incredibles / Finding Nemo
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x803D2A94:dword:0x00000000:0x3B800000
 
 [OnFrame_Enabled]
-# This game renders an EFB copy with texture repeating enabled
+# Disc one of this game renders an EFB copy with texture repeating enabled
 # and it draws from texture coordinate 0.00390625 to 1.00390625.
 # This only works on console and 1x IR due to low precision.
 # "EFB Copy Fix" adjusts the region to not cause bugs at higher
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
+# Patch has been made conditional to prevent causing issues on disc 2.
 $EFB Copy Fix
-
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GU3.ini
+++ b/Data/Sys/GameSettings/GU3.ini
@@ -1,4 +1,4 @@
-# GICD78, GICE78, GICF78, GICH78, GICJG9, GICP78 - The Incredibles
+# GU3D78, GU3X78 - 2 Games in 1: The Incredibles / Finding Nemo
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
-# Fixes shadows at higher resolution.
+# Fixes shadows at higher resolution on disc 1.
 # Option has no effect at 1x IR, so no reason not to enable.
 VertexRounding = True
-EFBToTextureEnable = False
+

--- a/Data/Sys/GameSettings/GU3D78.ini
+++ b/Data/Sys/GameSettings/GU3D78.ini
@@ -1,0 +1,15 @@
+# GU3D78 - 2 Games in 1: The SpongeBob SquarePants Movie / Tak 2: The Staff of Dreams
+
+[OnFrame]
+$EFB Copy Fix
+0x803CD414:dword:0x00000000:0x3B000000
+
+[OnFrame_Enabled]
+# Disc 1 of this game game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00195313 to 1.00195.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+# The patch has been made conditional as not to crash disc 2's game.
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GU3X78.ini
+++ b/Data/Sys/GameSettings/GU3X78.ini
@@ -1,19 +1,15 @@
-# GICE78 - The Incredibles
+# GU3X78 - 2 Games in 1: The SpongeBob SquarePants Movie / Tak 2: The Staff of Dreams
 
 [OnFrame]
 $EFB Copy Fix
-0x803D2AD4:dword:0x00000000
+0x804BA014:dword:0x00000000:0x3B800000
 
 [OnFrame_Enabled]
-# This game renders an EFB copy with texture repeating enabled
+# Disc 1 of this game renders an EFB copy with texture repeating enabled
 # and it draws from texture coordinate 0.00390625 to 1.00390625.
 # This only works on console and 1x IR due to low precision.
 # "EFB Copy Fix" adjusts the region to not cause bugs at higher
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
+# The patch has been made conditional as not to crash disc 2's game.
 $EFB Copy Fix
-
-[ActionReplay]
-# Add action replay cheats here.
-$Infinite Health
-04097DB8 38000064

--- a/Data/Sys/GameSettings/GU4.ini
+++ b/Data/Sys/GameSettings/GU4.ini
@@ -1,4 +1,4 @@
-# GICD78, GICE78, GICF78, GICH78, GICJG9, GICP78 - The Incredibles
+# GU4Y78 - 2 Games in 1: Nickelodeon SpongeBob Schwammkopf: Der Film + Nickelodeon SpongeBob Schwammkopf: Schlacht um Bikini Bottom
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -16,4 +16,5 @@
 # Fixes shadows at higher resolution.
 # Option has no effect at 1x IR, so no reason not to enable.
 VertexRounding = True
-EFBToTextureEnable = False
+# Needed for some FMVs on disc 1.
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GU4Y78.ini
+++ b/Data/Sys/GameSettings/GU4Y78.ini
@@ -1,0 +1,22 @@
+# GU4Y78 - 2 Games in 1: Nickelodeon SpongeBob Schwammkopf: Der Film + Nickelodeon SpongeBob Schwammkopf: Schlacht um Bikini Bottom
+
+[OnFrame]
+$EFB Copy Fix
+0x803CD414:dword:0x00000000:0x3B000000
+0x804B9510:dword:0x00000000:0x3B800000
+
+[OnFrame_Enabled]
+# Disc 1 of this game game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00195313 to 1.00195.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+# Disc 2 of this game renders an EFB copy with texture repeating enabled
+# and it draws from texture coordinate 0.00390625 to 1.00390625.
+# This only works on console and 1x IR due to low precision.
+# "EFB Copy Fix" adjusts the region to not cause bugs at higher
+# resolutions.  In order for this patch to fully work, the
+# Vertex Rounding Hack must be enabled.
+# These patches have been made conditional.
+$EFB Copy Fix


### PR DESCRIPTION
SpongeBob SquarePants: Battle for Bikini Bottom and The Movie Game, along with the two Incredibles titles suffer from an EFB offset issue described in earlier commits.  This commit adds support for the Incredibles 1/2 revisions and adds additional inis for SpongeBob special releases.

To the best of my knowledge, no The Incredibles: Rise of the Underminer GIQP78 exists, but it is marked on our wiki so I added it to the base INI as a possible revision.  I did not provide a code for it, though.  These probably need a really good look over as this is probably the most changes I've ever packed into a single pull request.