### PR TITLE
AudioCommon: fix bogus error + cleanup

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.cpp
+++ b/Source/Core/AudioCommon/AlsaSoundStream.cpp
@@ -41,11 +41,6 @@ bool AlsaSound::Init()
   return true;
 }
 
-void AlsaSound::Update()
-{
-  // don't need to do anything here.
-}
-
 // Called on audio thread.
 void AlsaSound::SoundLoop()
 {

--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -23,12 +23,13 @@ public:
   ~AlsaSound() override;
 
   bool Init() override;
-  void SoundLoop() override;
   bool SetRunning(bool running) override;
 
   static bool isValid() { return true; }
 
 private:
+  void SoundLoop();
+
   // maximum number of frames the buffer can hold
   static constexpr size_t BUFFER_SIZE_MAX = 8192;
 

--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -24,7 +24,6 @@ public:
 
   bool Init() override;
   void SoundLoop() override;
-  void Update() override;
   bool SetRunning(bool running) override;
 
   static bool isValid() { return true; }

--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -25,7 +25,7 @@ public:
   bool Init() override;
   bool SetRunning(bool running) override;
 
-  static bool isValid() { return true; }
+  static bool IsValid() { return true; }
 
 private:
   void SoundLoop();

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -30,17 +30,17 @@ static std::unique_ptr<SoundStream> CreateSoundStreamForBackend(std::string_view
 {
   if (backend == BACKEND_CUBEB)
     return std::make_unique<CubebStream>();
-  else if (backend == BACKEND_OPENAL && OpenALStream::isValid())
+  else if (backend == BACKEND_OPENAL && OpenALStream::IsValid())
     return std::make_unique<OpenALStream>();
   else if (backend == BACKEND_NULLSOUND)
     return std::make_unique<NullSound>();
-  else if (backend == BACKEND_ALSA && AlsaSound::isValid())
+  else if (backend == BACKEND_ALSA && AlsaSound::IsValid())
     return std::make_unique<AlsaSound>();
-  else if (backend == BACKEND_PULSEAUDIO && PulseAudio::isValid())
+  else if (backend == BACKEND_PULSEAUDIO && PulseAudio::IsValid())
     return std::make_unique<PulseAudio>();
-  else if (backend == BACKEND_OPENSLES && OpenSLESStream::isValid())
+  else if (backend == BACKEND_OPENSLES && OpenSLESStream::IsValid())
     return std::make_unique<OpenSLESStream>();
-  else if (backend == BACKEND_WASAPI && WASAPIStream::isValid())
+  else if (backend == BACKEND_WASAPI && WASAPIStream::IsValid())
     return std::make_unique<WASAPIStream>();
   return {};
 }
@@ -96,7 +96,7 @@ std::string GetDefaultSoundBackend()
 #if defined ANDROID
   backend = BACKEND_OPENSLES;
 #elif defined __linux__
-  if (AlsaSound::isValid())
+  if (AlsaSound::IsValid())
     backend = BACKEND_ALSA;
 #elif defined(__APPLE__) || defined(_WIN32)
   backend = BACKEND_CUBEB;
@@ -115,15 +115,15 @@ std::vector<std::string> GetSoundBackends()
 
   backends.emplace_back(BACKEND_NULLSOUND);
   backends.emplace_back(BACKEND_CUBEB);
-  if (AlsaSound::isValid())
+  if (AlsaSound::IsValid())
     backends.emplace_back(BACKEND_ALSA);
-  if (PulseAudio::isValid())
+  if (PulseAudio::IsValid())
     backends.emplace_back(BACKEND_PULSEAUDIO);
-  if (OpenALStream::isValid())
+  if (OpenALStream::IsValid())
     backends.emplace_back(BACKEND_OPENAL);
-  if (OpenSLESStream::isValid())
+  if (OpenSLESStream::IsValid())
     backends.emplace_back(BACKEND_OPENSLES);
-  if (WASAPIStream::isValid())
+  if (WASAPIStream::IsValid())
     backends.emplace_back(BACKEND_WASAPI);
 
   return backends;

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -197,8 +197,6 @@ void SendAIBuffer(const short* samples, unsigned int num_samples)
   {
     pMixer->PushSamples(samples, num_samples);
   }
-
-  g_sound_stream->Update();
 }
 
 void StartAudioDump()

--- a/Source/Core/AudioCommon/NullSoundStream.cpp
+++ b/Source/Core/AudioCommon/NullSoundStream.cpp
@@ -3,10 +3,6 @@
 
 #include "AudioCommon/NullSoundStream.h"
 
-void NullSound::SoundLoop()
-{
-}
-
 bool NullSound::Init()
 {
   return true;

--- a/Source/Core/AudioCommon/NullSoundStream.cpp
+++ b/Source/Core/AudioCommon/NullSoundStream.cpp
@@ -20,7 +20,3 @@ bool NullSound::SetRunning(bool running)
 void NullSound::SetVolume(int volume)
 {
 }
-
-void NullSound::Update()
-{
-}

--- a/Source/Core/AudioCommon/NullSoundStream.h
+++ b/Source/Core/AudioCommon/NullSoundStream.h
@@ -12,7 +12,6 @@ public:
   void SoundLoop() override;
   bool SetRunning(bool running) override;
   void SetVolume(int volume) override;
-  void Update() override;
 
   static bool isValid() { return true; }
 };

--- a/Source/Core/AudioCommon/NullSoundStream.h
+++ b/Source/Core/AudioCommon/NullSoundStream.h
@@ -12,5 +12,5 @@ public:
   bool SetRunning(bool running) override;
   void SetVolume(int volume) override;
 
-  static bool isValid() { return true; }
+  static bool IsValid() { return true; }
 };

--- a/Source/Core/AudioCommon/NullSoundStream.h
+++ b/Source/Core/AudioCommon/NullSoundStream.h
@@ -9,7 +9,6 @@ class NullSound final : public SoundStream
 {
 public:
   bool Init() override;
-  void SoundLoop() override;
   bool SetRunning(bool running) override;
   void SetVolume(int volume) override;
 

--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -126,9 +126,6 @@ bool OpenALStream::Init()
 OpenALStream::~OpenALStream()
 {
   m_run_thread.Clear();
-  // kick the thread if it's waiting
-  m_sound_sync_event.Set();
-
   m_thread.join();
 
   palSourceStop(m_source);
@@ -153,11 +150,6 @@ void OpenALStream::SetVolume(int volume)
 
   if (m_source)
     palSourcef(m_source, AL_GAIN, m_volume);
-}
-
-void OpenALStream::Update()
-{
-  m_sound_sync_event.Set();
 }
 
 bool OpenALStream::SetRunning(bool running)

--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -83,7 +83,7 @@ static bool InitLibrary()
   return true;
 }
 
-bool OpenALStream::isValid()
+bool OpenALStream::IsValid()
 {
   return InitLibrary();
 }

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -56,13 +56,14 @@ public:
   OpenALStream() : m_source(0) {}
   ~OpenALStream() override;
   bool Init() override;
-  void SoundLoop() override;
   void SetVolume(int volume) override;
   bool SetRunning(bool running) override;
 
   static bool isValid();
 
 private:
+  void SoundLoop();
+
   std::thread m_thread;
   Common::Flag m_run_thread;
 

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -59,7 +59,7 @@ public:
   void SetVolume(int volume) override;
   bool SetRunning(bool running) override;
 
-  static bool isValid();
+  static bool IsValid();
 
 private:
   void SoundLoop();

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -59,15 +59,12 @@ public:
   void SoundLoop() override;
   void SetVolume(int volume) override;
   bool SetRunning(bool running) override;
-  void Update() override;
 
   static bool isValid();
 
 private:
   std::thread m_thread;
   Common::Flag m_run_thread;
-
-  Common::Event m_sound_sync_event;
 
   std::vector<short> m_realtime_buffer;
   std::array<ALuint, OAL_BUFFERS> m_buffers;

--- a/Source/Core/AudioCommon/OpenSLESStream.h
+++ b/Source/Core/AudioCommon/OpenSLESStream.h
@@ -16,7 +16,7 @@ public:
   bool Init() override;
   bool SetRunning(bool running) override { return true; }
   void SetVolume(int volume) override;
-  static bool isValid() { return true; }
+  static bool IsValid() { return true; }
 
 private:
   std::thread thread;

--- a/Source/Core/AudioCommon/OpenSLESStream.h
+++ b/Source/Core/AudioCommon/OpenSLESStream.h
@@ -14,7 +14,7 @@ class OpenSLESStream final : public SoundStream
 public:
   ~OpenSLESStream() override;
   bool Init() override;
-  bool SetRunning(bool running) override { return running; }
+  bool SetRunning(bool running) override { return true; }
   void SetVolume(int volume) override;
   static bool isValid() { return true; }
 

--- a/Source/Core/AudioCommon/PulseAudioStream.h
+++ b/Source/Core/AudioCommon/PulseAudioStream.h
@@ -20,7 +20,7 @@ public:
   ~PulseAudio() override;
 
   bool Init() override;
-  bool SetRunning(bool running) override { return running; }
+  bool SetRunning(bool running) override { return true; }
   static bool isValid() { return true; }
   void StateCallback(pa_context* c);
   void WriteCallback(pa_stream* s, size_t length);

--- a/Source/Core/AudioCommon/PulseAudioStream.h
+++ b/Source/Core/AudioCommon/PulseAudioStream.h
@@ -27,7 +27,7 @@ public:
   void UnderflowCallback(pa_stream* s);
 
 private:
-  void SoundLoop() override;
+  void SoundLoop();
 
   bool PulseInit();
   void PulseShutdown();

--- a/Source/Core/AudioCommon/PulseAudioStream.h
+++ b/Source/Core/AudioCommon/PulseAudioStream.h
@@ -21,7 +21,7 @@ public:
 
   bool Init() override;
   bool SetRunning(bool running) override { return true; }
-  static bool isValid() { return true; }
+  static bool IsValid() { return true; }
   void StateCallback(pa_context* c);
   void WriteCallback(pa_stream* s, size_t length);
   void UnderflowCallback(pa_stream* s);

--- a/Source/Core/AudioCommon/SoundStream.h
+++ b/Source/Core/AudioCommon/SoundStream.h
@@ -21,7 +21,6 @@ public:
   virtual bool Init() { return false; }
   virtual void SetVolume(int) {}
   virtual void SoundLoop() {}
-  virtual void Update() {}
   // Returns true if successful.
   virtual bool SetRunning(bool running) { return false; }
 };

--- a/Source/Core/AudioCommon/SoundStream.h
+++ b/Source/Core/AudioCommon/SoundStream.h
@@ -22,5 +22,6 @@ public:
   virtual void SetVolume(int) {}
   virtual void SoundLoop() {}
   virtual void Update() {}
+  // Returns true if successful.
   virtual bool SetRunning(bool running) { return false; }
 };

--- a/Source/Core/AudioCommon/SoundStream.h
+++ b/Source/Core/AudioCommon/SoundStream.h
@@ -20,7 +20,6 @@ public:
   Mixer* GetMixer() const { return m_mixer.get(); }
   virtual bool Init() { return false; }
   virtual void SetVolume(int) {}
-  virtual void SoundLoop() {}
   // Returns true if successful.
   virtual bool SetRunning(bool running) { return false; }
 };

--- a/Source/Core/AudioCommon/SoundStream.h
+++ b/Source/Core/AudioCommon/SoundStream.h
@@ -16,7 +16,7 @@ protected:
 public:
   SoundStream() : m_mixer(new Mixer(48000)) {}
   virtual ~SoundStream() {}
-  static bool isValid() { return false; }
+  static bool IsValid() { return false; }
   Mixer* GetMixer() const { return m_mixer.get(); }
   virtual bool Init() { return false; }
   virtual void SetVolume(int) {}

--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -49,7 +49,7 @@ WASAPIStream::~WASAPIStream()
     m_thread.join();
 }
 
-bool WASAPIStream::isValid()
+bool WASAPIStream::IsValid()
 {
   return true;
 }

--- a/Source/Core/AudioCommon/WASAPIStream.h
+++ b/Source/Core/AudioCommon/WASAPIStream.h
@@ -35,13 +35,14 @@ public:
   ~WASAPIStream();
   bool Init() override;
   bool SetRunning(bool running) override;
-  void SoundLoop() override;
 
   static bool isValid();
   static std::vector<std::string> GetAvailableDevices();
   static Microsoft::WRL::ComPtr<IMMDevice> GetDeviceByName(std::string_view name);
 
 private:
+  void SoundLoop();
+
   u32 m_frames_in_buffer = 0;
   std::atomic<bool> m_running = false;
   std::thread m_thread;

--- a/Source/Core/AudioCommon/WASAPIStream.h
+++ b/Source/Core/AudioCommon/WASAPIStream.h
@@ -36,7 +36,7 @@ public:
   bool Init() override;
   bool SetRunning(bool running) override;
 
-  static bool isValid();
+  static bool IsValid();
   static std::vector<std::string> GetAvailableDevices();
   static Microsoft::WRL::ComPtr<IMMDevice> GetDeviceByName(std::string_view name);
 


### PR DESCRIPTION
This gets rid of the bogus "AudioCommon/AudioCommon.cpp:181 E[Audio]: Error stopping stream." errors.