### PR TITLE
Jit64: dcbx loop detection for improved performance when invalidating large memory regions.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -190,9 +190,11 @@ void JitBaseBlockCache::InvalidateICache(u32 address, u32 length, bool forced)
     return;
   const u32 physical_address = translated.address;
 
-  // Optimize the common case of length == 32 which is used by Interpreter::dcb*
+  // Optimization for the case of invalidating a single cache line, which is used by the dcb*
+  // instructions. If the valid_block bit for that cacheline is not set, we can safely skip
+  // the remaining invalidation logic.
   bool destroy_block = true;
-  if (length == 32)
+  if (length == 32 && (physical_address & 0x1fu) == 0)
   {
     if (!valid_block.Test(physical_address / 32))
       destroy_block = false;

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -183,13 +183,46 @@ const u8* JitBaseBlockCache::Dispatch()
   return block->normalEntry;
 }
 
-void JitBaseBlockCache::InvalidateICache(u32 address, u32 length, bool forced)
+void JitBaseBlockCache::InvalidateICacheLine(u32 address)
 {
-  const auto translated = PowerPC::JitCache_TranslateAddress(address);
-  if (!translated.valid)
-    return;
-  const u32 physical_address = translated.address;
+  const u32 cache_line_address = address & ~0x1f;
+  const auto translated = PowerPC::JitCache_TranslateAddress(cache_line_address);
+  if (translated.valid)
+    InvalidateICacheInternal(translated.address, cache_line_address, 32, false);
+}
 
+void JitBaseBlockCache::InvalidateICache(u32 initial_address, u32 initial_length, bool forced)
+{
+  u32 address = initial_address;
+  u32 length = initial_length;
+  while (length > 0)
+  {
+    const auto translated = PowerPC::JitCache_TranslateAddress(address);
+
+    const bool address_from_bat = translated.valid && translated.translated && translated.from_bat;
+    const int shift = address_from_bat ? PowerPC::BAT_INDEX_SHIFT : PowerPC::HW_PAGE_INDEX_SHIFT;
+    const u32 mask = ~((1u << shift) - 1u);
+    const u32 first_address = address;
+    const u32 last_address = address + (length - 1u);
+    if ((first_address & mask) == (last_address & mask))
+    {
+      if (translated.valid)
+        InvalidateICacheInternal(translated.address, address, length, forced);
+      return;
+    }
+
+    const u32 end_of_page = (first_address + (1u << shift)) & mask;
+    const u32 length_this_page = end_of_page - first_address;
+    if (translated.valid)
+      InvalidateICacheInternal(translated.address, address, length_this_page, forced);
+    address = address + length_this_page;
+    length = length - length_this_page;
+  }
+}
+
+void JitBaseBlockCache::InvalidateICacheInternal(u32 physical_address, u32 address, u32 length,
+                                                 bool forced)
+{
   // Optimization for the case of invalidating a single cache line, which is used by the dcb*
   // instructions. If the valid_block bit for that cacheline is not set, we can safely skip
   // the remaining invalidation logic.

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -161,6 +161,7 @@ public:
   const u8* Dispatch();
 
   void InvalidateICache(u32 address, u32 length, bool forced);
+  void InvalidateICacheLine(u32 address);
   void ErasePhysicalRange(u32 address, u32 length);
 
   u32* GetBlockBitSet() const;
@@ -177,6 +178,7 @@ private:
   void LinkBlockExits(JitBlock& block);
   void LinkBlock(JitBlock& block);
   void UnlinkBlock(const JitBlock& block);
+  void InvalidateICacheInternal(u32 physical_address, u32 address, u32 length, bool forced);
 
   JitBlock* MoveBlockIntoFastCache(u32 em_address, u32 msr);
 

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -226,7 +226,8 @@ void InvalidateICache(u32 address, u32 size, bool forced)
 
 void InvalidateICacheLine(u32 address)
 {
-  InvalidateICache(address & ~0x1f, 32, false);
+  if (g_jit)
+    g_jit->GetBlockCache()->InvalidateICacheLine(address);
 }
 
 void CompileExceptionCheck(ExceptionType type)

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -230,6 +230,22 @@ void InvalidateICacheLine(u32 address)
     g_jit->GetBlockCache()->InvalidateICacheLine(address);
 }
 
+void InvalidateICacheLines(u32 address, u32 count)
+{
+  // This corresponds to a PPC code loop that:
+  // - calls some form of dcb* instruction on 'address'
+  // - increments 'address' by the size of a cache line (0x20 bytes)
+  // - decrements 'count' by 1
+  // - jumps back to the dcb* instruction if 'count' != 0
+  // with an extra optimization for the case of a single cache line invalidation
+  if (count == 1)
+    InvalidateICacheLine(address);
+  if (count == 0 || count >= static_cast<u32>(0x1'0000'0000 / 32))
+    InvalidateICache(address & ~0x1f, 0xffffffff, false);
+  else
+    InvalidateICache(address & ~0x1f, 32 * count, false);
+}
+
 void CompileExceptionCheck(ExceptionType type)
 {
   if (!g_jit)

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -63,6 +63,7 @@ void ClearSafe();
 // If "forced" is true, a recompile is being requested on code that hasn't been modified.
 void InvalidateICache(u32 address, u32 size, bool forced);
 void InvalidateICacheLine(u32 address);
+void InvalidateICacheLines(u32 address, u32 count);
 
 void CompileExceptionCheck(ExceptionType type);
 

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -30,10 +30,6 @@
 
 namespace PowerPC
 {
-constexpr size_t HW_PAGE_SIZE = 4096;
-constexpr u32 HW_PAGE_INDEX_SHIFT = 12;
-constexpr u32 HW_PAGE_INDEX_MASK = 0x3f;
-
 // EFB RE
 /*
 GXPeekZ

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -222,5 +222,9 @@ inline bool TranslateBatAddess(const BatTable& bat_table, u32* address, bool* wi
   return true;
 }
 
+constexpr size_t HW_PAGE_SIZE = 4096;
+constexpr u32 HW_PAGE_INDEX_SHIFT = 12;
+constexpr u32 HW_PAGE_INDEX_MASK = 0x3f;
+
 std::optional<u32> GetTranslatedAddress(u32 address);
 }  // namespace PowerPC

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -128,7 +128,7 @@ void InstructionCache::Invalidate(u32 addr)
     }
   }
   valid[set] = 0;
-  JitInterface::InvalidateICache(addr & ~0x1f, 32, false);
+  JitInterface::InvalidateICacheLine(addr);
 }
 
 u32 InstructionCache::ReadInstruction(u32 addr)


### PR DESCRIPTION
So unfortunately, I have to report that our recent dcbx fixes have once again made Mario Sunshine's boot sequence and A Boy and his Blob in general slow again.

I profiled this a bit and it turns out the big performance issue comes from a game calling dcbx, failing the BAT check on memory that is not mapped in the BAT, and then `JitCache_TranslateAddress()` having to go through the rather slow `TranslatePageAddress()`. This wouldn't be so bad once, but:

- Mario Sunshine calls this *on the entire address space*, one cache line at a time.
- A Boy and his Blob does this all the time in the background, on multiple ~266KB regions.

This, as it turns out, is slow. Profiler in Mario Sunshine's boot sequence shows >70% CPU usage in just the page translation code. Which makes sense when you think about it, we're effectively invoking InvalidateICache() about 134 million times.

This PR tries to detect such loops and transform them into larger invalidation calls, limited by the remaining downcount, instead of one per cache line.

Probably want an ARM implementation of this too.