### PR TITLE
Android: Remove the EmulationState class

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -393,6 +393,8 @@ public final class NativeLibrary
 
   public static native void SurfaceDestroyed();
 
+  public static native boolean HasSurface();
+
   /**
    * Unpauses emulation from a paused state.
    */

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -411,11 +411,20 @@ public final class NativeLibrary
   public static native void StopEmulation();
 
   /**
+   * Ensures that IsRunning will return true from now on until emulation exits.
+   * (If this is not called, IsRunning will start returning true at some point
+   * after calling Run.)
+   */
+  public static native void SetIsBooting();
+
+  /**
    * Returns true if emulation is running (or is paused).
    */
   public static native boolean IsRunning();
 
   public static native boolean IsRunningAndStarted();
+
+  public static native boolean IsRunningAndUnpaused();
 
   /**
    * Enables or disables CPU block profiling

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -186,6 +186,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
   {
     Log.debug("[EmulationFragment] Surface destroyed.");
     NativeLibrary.SurfaceDestroyed();
+    mRunWhenSurfaceIsValid = true;
   }
 
   public void stopEmulation()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -231,7 +231,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
       this.temporaryStatePath = temporaryStatePath;
     }
 
-    public synchronized void run(boolean isActivityRecreated)
+    public void run(boolean isActivityRecreated)
     {
       if (isActivityRecreated)
       {
@@ -264,7 +264,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
       }
     }
 
-    public synchronized void newSurface()
+    public void newSurface()
     {
       if (mRunWhenSurfaceIsValid)
       {

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -442,6 +442,13 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SurfaceDestr
   }
 }
 
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_HasSurface(JNIEnv*, jclass)
+{
+  std::lock_guard guard(s_surface_lock);
+
+  return s_surf ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT jfloat JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetGameAspectRatio(JNIEnv*,
                                                                                          jclass)
 {

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -23,6 +23,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/FileUtil.h"
+#include "Common/Flag.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/LogManager.h"
 #include "Common/MsgHandler.h"
@@ -81,6 +82,7 @@ Common::Event s_update_main_frame_event;
 std::mutex s_surface_lock;
 bool s_need_nonblocking_alert_msg;
 
+Common::Flag s_is_booting;
 bool s_have_wm_user_stop = false;
 bool s_game_metadata_is_valid = false;
 }  // Anonymous namespace
@@ -247,15 +249,26 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulatio
   s_update_main_frame_event.Set();
 }
 
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetIsBooting(JNIEnv*, jclass)
+{
+  s_is_booting.Set();
+}
+
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunning(JNIEnv*, jclass)
 {
-  return static_cast<jboolean>(Core::IsRunning());
+  return s_is_booting.IsSet() || static_cast<jboolean>(Core::IsRunning());
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunningAndStarted(JNIEnv*,
                                                                                             jclass)
 {
   return static_cast<jboolean>(Core::IsRunningAndStarted());
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunningAndUnpaused(JNIEnv*, jclass)
+{
+  return static_cast<jboolean>(Core::GetState() == Core::State::Running);
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadEvent(
@@ -561,6 +574,7 @@ static void Run(JNIEnv* env, const std::vector<std::string>& paths,
     }
   }
 
+  s_is_booting.Clear();
   s_need_nonblocking_alert_msg = false;
   surface_guard.unlock();
 


### PR DESCRIPTION
The purpose of this class is to keep track of state which the emulation core is also keeping track of. This is rather risky – if we update the state of one of the two without updating the other, the two become out of sync, leading to some rather confusing problems. I think we're better off only keeping this state in the emulation core.

In particular, this change fixes a panic alert deadlock when booting a file that isn't a valid GC/Wii file while holding the phone in an orientation which does not match the orientation set in the Dolphin settings.