### PR TITLE
GameINI: Force safe texture cache on Resident Evil 3

### DIFF
--- a/Data/Sys/GameSettings/GLE.ini
+++ b/Data/Sys/GameSettings/GLE.ini
@@ -1,0 +1,6 @@
+# GLEE08, GLEJ08, GLEP08 - Resident Evil 3: Nemesis
+
+[Video_Settings]
+# On middle and fast, item and weapon icons can disappear or not change when picking
+# an item up, moving an item to/from an item box, or equipping a weapon.
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
This is already recommended by the wiki, but I think it should be set by default.

Without safe texture cache accuracy, item and weapon icons can disappear when picking an item up or transferring an item to/from an item box. In addition, when equipping/unequipping a weapon, the previous weapon icon (or lack thereof) may stay in its place instead of changing. This can cause confusion when playing the game.

On fast accuracy, this issue occurs often. I also tried with middle accuracy, and the frequency of occurrence decreased, but it still sometimes happens. Safe accuracy appears to eliminate the problem entirely.

<details>
<summary>Example</summary>

Here, I have the shotgun equipped. However, the equipped weapon icon tells me I have the pistol equipped.

![image](https://user-images.githubusercontent.com/11504941/128643658-35b57172-7502-4174-8f63-19fbf634494b.png)
</details>