### PR TITLE
PowerPC: Minor cleanup around JitCache_TranslateAddress().

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1097,17 +1097,15 @@ bool IsOptimizableGatherPipeWrite(u32 address)
 TranslateResult JitCache_TranslateAddress(u32 address)
 {
   if (!MSR.IR)
-    return TranslateResult{true, true, address};
+    return TranslateResult{address};
 
   // TODO: We shouldn't use FLAG_OPCODE if the caller is the debugger.
-  auto tlb_addr = TranslateAddress<XCheckTLBFlag::Opcode>(address);
+  const auto tlb_addr = TranslateAddress<XCheckTLBFlag::Opcode>(address);
   if (!tlb_addr.Success())
-  {
-    return TranslateResult{false, false, 0};
-  }
+    return TranslateResult{};
 
-  bool from_bat = tlb_addr.result == TranslateAddressResultEnum::BAT_TRANSLATED;
-  return TranslateResult{true, from_bat, tlb_addr.address};
+  const bool from_bat = tlb_addr.result == TranslateAddressResultEnum::BAT_TRANSLATED;
+  return TranslateResult{from_bat, tlb_addr.address};
 }
 
 // *********************************************************************************

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -109,9 +109,14 @@ enum class TranslateAddressResultEnum : u8
 
 struct TranslateAddressResult
 {
-  TranslateAddressResultEnum result;
   u32 address;
+  TranslateAddressResultEnum result;
   bool wi;  // Set to true if the view of memory is either write-through or cache-inhibited
+
+  TranslateAddressResult(TranslateAddressResultEnum result_, u32 address_, bool wi_ = false)
+      : address(address_), result(result_), wi(wi_)
+  {
+  }
   bool Success() const { return result <= TranslateAddressResultEnum::PAGE_TABLE_TRANSLATED; }
 };
 template <const XCheckTLBFlag flag>

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -189,9 +189,17 @@ bool IsOptimizableGatherPipeWrite(u32 address);
 
 struct TranslateResult
 {
-  bool valid;
-  bool from_bat;
-  u32 address;
+  bool valid = false;
+  bool translated = false;
+  bool from_bat = false;
+  u32 address = 0;
+
+  TranslateResult() = default;
+  explicit TranslateResult(u32 address_) : valid(true), address(address_) {}
+  TranslateResult(bool from_bat_, u32 address_)
+      : valid(true), translated(true), from_bat(from_bat_), address(address_)
+  {
+  }
 };
 TranslateResult JitCache_TranslateAddress(u32 address);
 


### PR DESCRIPTION
The only functional change is around `TranslateResult::from_bat`, which was previously true but is now false if `MSR.IR` is off... but since no one actually checks that variable at the moment even that doesn't actually change behavior. I'm keeping it around though because I found a use for it in #10007.