### PR TITLE
UberShaderVertex: Fix Tony Hawk Pro Skater 4

### DIFF
--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -218,14 +218,14 @@ ShaderCode GenVertexShader(APIType api_type, const ShaderHostConfig& host_config
             "  if ((components & {}u) != 0u)\n"
             "    o.colors_0 = rawcolor0;\n"
             "  else\n"
-            "    o.colors_1 = float4(1.0, 1.0, 1.0, 1.0);\n"
+            "    o.colors_0 = float4(1.0, 1.0, 1.0, 1.0);\n"
             "}}\n",
             VB_HAS_COL0);
   out.Write("if (xfmem_numColorChans < 2u) {{\n"
             "  if ((components & {}u) != 0u)\n"
-            "    o.colors_0 = rawcolor1;\n"
+            "    o.colors_1 = rawcolor1;\n"
             "  else\n"
-            "    o.colors_1 = float4(1.0, 1.0, 1.0, 1.0);\n"
+            "    o.colors_1 = o.colors_0;\n"
             "}}\n",
             VB_HAS_COL1);
 

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -441,19 +441,38 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     out.Write("}}\n");
   }
 
+  // The number of colors available to TEV is determined by numColorChans.
+  // We have to provide the fields to match the interface, so set to zero if it's not enabled.
+
+  // When per-pixel lighting is enabled, the vertex colors are passed through unmodified so we can
+  // evaluate the lighting in the same manner in the pixel shader.
   if (uid_data->numColorChans == 0)
   {
     if ((uid_data->components & VB_HAS_COL0) != 0)
-      out.Write("o.colors_0 = rawcolor0;\n");
+    {
+      if (per_pixel_lighting)
+        out.Write("o.colors_0 = vertex_color_0;\n");
+      else
+        out.Write("o.colors_0 = rawcolor0;\n");
+    }
     else
-      out.Write("o.colors_0 = float4(1.0, 1.0, 1.0, 1.0);\n");
+    {
+      out.Write("o.colors_0 = float4(0.0, 0.0, 0.0, 0.0);\n");
+    }
   }
-  if (uid_data->numColorChans < 2)
+  if (uid_data->numColorChans <= 1)
   {
     if ((uid_data->components & VB_HAS_COL1) != 0)
-      out.Write("o.colors_1 = rawcolor1;\n");
+    {
+      if (per_pixel_lighting)
+        out.Write("o.colors_1 = vertex_color_1;\n");
+      else
+        out.Write("o.colors_1 = rawcolor1;\n");
+    }
     else
-      out.Write("o.colors_1 = o.colors_0;\n");
+    {
+      out.Write("o.colors_1 = float4(0.0, 0.0, 0.0, 0.0);\n");
+    }
   }
 
   // clipPos/w needs to be done in pixel shader, not here
@@ -464,22 +483,6 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   {
     out.Write("o.Normal = _norm0;\n"
               "o.WorldPos = pos.xyz;\n");
-
-    // Pass through the vertex colors unmodified so we can evaluate the lighting in the same manner.
-    if ((uid_data->components & VB_HAS_COL0) != 0)
-      out.Write("o.colors_0 = vertex_color_0;\n");
-
-    if ((uid_data->components & VB_HAS_COL1) != 0)
-      out.Write("o.colors_1 = vertex_color_1;\n");
-  }
-  else
-  {
-    // The number of colors available to TEV is determined by numColorChans.
-    // We have to provide the fields to match the interface, so set to zero if it's not enabled.
-    if (uid_data->numColorChans == 0)
-      out.Write("o.colors_0 = float4(0.0, 0.0, 0.0, 0.0);\n");
-    if (uid_data->numColorChans <= 1)
-      out.Write("o.colors_1 = float4(0.0, 0.0, 0.0, 0.0);\n");
   }
 
   // If we can disable the incorrect depth clipping planes using depth clamping, then we can do


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/12620

The changed code did not match the corresponding code in VertexShaderGen.  Some parts of the sky have 2 color channels in each vertex, while others only have 1, despite only color channel 0 being used and XFMEM_SETNUMCHAN being set to 1 for both of them.  The old code (from #4601) caused channel 0 to be set to channel 1 if the vertex contained both color channels but the number of channels was set to 1, which is wrong.

This code was also a bit funky because the [per-pixel-lighting code below](https://github.com/dolphin-emu/dolphin/blob/128e1029ddf09258dd476e8c5cc9fda9e85c2936/Source/Core/VideoCommon/VertexShaderGen.cpp#L463-L483) also affects things, but the same code existed in ubershaders.  I've tidied up the redundancies there.