### PR TITLE
GameINI:  Add missing Vertex Rounding to GIQ.ini

### DIFF
--- a/Data/Sys/GameSettings/GIQ.ini
+++ b/Data/Sys/GameSettings/GIQ.ini
@@ -15,5 +15,8 @@
 [Video_Settings]
 
 [Video_Hacks]
+# Fixes shadows at higher resolution.
+# Option has no effect at 1x IR, so no reason not to enable.
+VertexRounding = True
+# Needed for certain FMVs.
 ImmediateXFBEnable = False
-


### PR DESCRIPTION
This is necessary to actually fully fix the game at higher resolutions and was forgotten in the earlier batch of INI changes.