### PR TITLE
GameINI: Rayman Arena - Add Disable Culling Patch that fixes "Rise and Shrine" Hang

### DIFF
--- a/Data/Sys/GameSettings/GYRE41.ini
+++ b/Data/Sys/GameSettings/GYRE41.ini
@@ -1,0 +1,14 @@
+# GYRE41 - Rayman Arena
+
+[OnFrame]
+$Disable Culling to Fix Rise and Shrine Hang
+0x8005EE90:dword:0x38600001
+0x8005EE94:dword:0x4E800020
+0x8005EF08:dword:0x38600001
+0x8005EF0C:dword:0x4E800020
+
+# This extremely minor patch that disables culling
+# in this game.  For some reason, this culling function
+# causes the "Rise and Shrine" hang in Dolphin.
+# There is no noticeable side-effects unless Dolphin's
+# built-in Widescreen Hack is enabled.


### PR DESCRIPTION
So funny story: the author of the "widescreen" patch for Rayman Arena (which is a patch ported from gamemasterplc's widescreen code Rayman 3) told me that it fixes the infamous hang in Rise and Shrine.  Now, Rayman Arena is a serious bastard of a game, and has hanged in Dolphin on this map as far back as I could get the game to run in Dolphin.  I thought to myself:

"How in the world could a widescreen patch work-around the bug???"

So I tried it.  And it worked.  So I began studying the code and found out it wasn't exactly a widescreen patch, it was a no culling patch.  But here's the thing: Rayman Arena already has almost no culling.  The only thing it culls is a few character models and item boxes at the start of the match.  The impact of the no culling cheat is actually very subtle, even when looking at statistics about what the game is rendering.

Before:
![image](https://user-images.githubusercontent.com/6598209/128881572-a10cb550-220b-4ef8-8716-8848a5cb27e4.png)
After:
![image](https://user-images.githubusercontent.com/6598209/128881607-aab6ffb4-c1d7-49b0-b0c8-318a26a1151b.png)

The only difference is that the AI opponent is rendering.  In the past, @leoetlino and I have experimented with trying to adjust the timings of Rayman Arena to work in Dolphin and found that the *only* way to fully avoid the hang is to set Dolphin's Emulated GPU Clock to 1% or lower in Single Core.  And that leaves the game completely unplayable.  Users have gone to another solution: changing the emulated CPU clock to 150% or above and mashing to skip the cutscene at the start of this level where the hang occurs.

The thing that truly confuses me is that if you're playing without the patch, the level *never even starts rendering* as far as I can tell.  In order to get those statistics, I overclocked the CPU to 150% to get it to render a couple of frames before freezing, as at the base clock it will freeze while the loading screen is still up.

In terms of performance, the No Culling Patch is so lightweight that I see literally no difference in performance, and honestly I kind of think it performs slightly better but that may be confirmation bias creeping in.

For now, I'm just pushing this pull request to try and get some more eyes on yet another Ubisoft game doing something.  Does anyone have any idea why such a minor different matters when doing *wild* changes to Dolphin's timings don't?  This patch is useful as it gives us a side by side look with the failure state vs a successful state with minimal changes to the game or dolphin compared to previous efforts, but until we understand why the game is failing, I'm uncomfortable merging it.