### PR TITLE
D3D12: Transition compute textures to UAV state

### DIFF
--- a/Source/Core/VideoBackends/D3D12/D3D12Renderer.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12Renderer.cpp
@@ -319,6 +319,9 @@ void Renderer::SetComputeImageTexture(AbstractTexture* texture, bool read, bool 
     return;
 
   m_state.compute_image_texture = dxtex;
+  if (dxtex)
+    dxtex->TransitionToState(D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
   m_dirty_bits |= DirtyState_ComputeImageTexture;
 }
 


### PR DESCRIPTION
When doing GPU texture decoding Dolphin never transitions the decoding texture to RESOURCE_STATE_UNORDERED_ACCESS despite writing to it in a compute shader. It gets created with `RESOURCE_STATE_PIXEL_SHADER_RESOURCE` so there isn't any implicit state promotion going on either.

This could fix https://bugs.dolphin-emu.org/issues/12094. I can't reproduce that bug though, it seems to only affect AMD GPUs.
Nvidia GPUs ignore the VkImageLayout with Vulkan so the reason for why it works on Nvidia might be something similar.