### PR TITLE
DolphinQt: Add entitlement to allow debugger to attach in Debug builds

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -527,12 +527,12 @@ if(APPLE)
     # Code sign make file builds
     add_custom_command(TARGET dolphin-emu
       POST_BUILD COMMAND
-      /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Dolphin.app" || true)
+      /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu$<$<CONFIG:Debug>:Debug>.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Dolphin.app" || true)
     
     # Code sign builds for build systems that do have release/debug variants (Xcode)
     add_custom_command(TARGET dolphin-emu
       POST_BUILD COMMAND
-      /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/Dolphin.app" || true)
+      /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmuDebug.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/Dolphin.app" || true)
       
     add_custom_command(TARGET dolphin-emu
       POST_BUILD COMMAND

--- a/Source/Core/DolphinQt/DolphinEmuDebug.entitlements
+++ b/Source/Core/DolphinQt/DolphinEmuDebug.entitlements
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<!-- Needed for GameCube microphone emulation -->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<!-- TODO: It is likely this requirement is coming from Qt, but should confirm -->
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<!-- This is needed to use adhoc signed linked libraries -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<!-- This is needed to attach a debugger to the process -->
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
In order to attach a debugger to a process with a Hardened Runtime (e.g. on an M1 mac), one needs the `com.apple.security.get-task-allow` entitlement.

Normally this entitlement is injected by XCode when running from XCode (assuming the XCode attribute `CODE_SIGN_INJECT_BASE_ENTITLEMENTS` is enabled), but this doesn't happen when building from a makefile or when you manually specify entitlements directly to codesign like this.