### PR TITLE
DolphinQt: Set default focus for NewBreakpointDialog

### DIFF
--- a/Source/Core/DolphinQt/Debugger/NewBreakpointDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/NewBreakpointDialog.cpp
@@ -19,6 +19,7 @@
 NewBreakpointDialog::NewBreakpointDialog(BreakpointWidget* parent)
     : QDialog(parent), m_parent(parent)
 {
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("New Breakpoint"));
   CreateWidgets();
   ConnectWidgets();
@@ -102,6 +103,8 @@ void NewBreakpointDialog::CreateWidgets()
   layout->addWidget(m_buttons);
 
   setLayout(layout);
+
+  m_instruction_address->setFocus();
 }
 
 void NewBreakpointDialog::ConnectWidgets()


### PR DESCRIPTION
I found it a little bit annoying that you can't start typing the desired address immediately after opening the window.

Also getting rid of the window's ? button while I'm at it.