### PR TITLE
Various GameINI Updates

### DIFF
--- a/Data/Sys/GameSettings/GR6.ini
+++ b/Data/Sys/GameSettings/GR6.ini
@@ -1,7 +1,7 @@
 # GR6P78, GR6E78, GR6D78, GR6F78 - Bratz: Rock Angelz
 
 [Core]
-# Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -17,3 +17,4 @@ SafeTextureCacheColorSamples = 0
 
 [Video_Hacks]
 EFBToTextureEnable = False
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/GVD.ini
+++ b/Data/Sys/GameSettings/GVD.ini
@@ -1,0 +1,20 @@
+# GVDP78, GVDE78 - Bratz: Forever Diamondz
+
+[Core]
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
+[Video_Hacks]
+EFBToTextureEnable = False
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/R5F.ini
+++ b/Data/Sys/GameSettings/R5F.ini
@@ -1,0 +1,4 @@
+# R5FP41, R5FE41 - Academy Of Champions: Soccer
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/R8R.ini
+++ b/Data/Sys/GameSettings/R8R.ini
@@ -1,0 +1,4 @@
+# R8RP41 - Arthur and the Revenge of Maltazard
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RB5.ini
+++ b/Data/Sys/GameSettings/RB5.ini
@@ -1,0 +1,4 @@
+# RB5E41, RB5P41 - Brothers In Arms: Earned In Blood
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RB9.ini
+++ b/Data/Sys/GameSettings/RB9.ini
@@ -1,4 +1,21 @@
 # RB9D78, RB9E78, RB9P78, RB9X78, RB9Y78 - Bratz: The Movie
 
+[Core]
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
 [Video_Settings]
+SafeTextureCacheColorSamples = 0
 SuggestedAspectRatio = 2
+
+[Video_Hacks]
+EFBToTextureEnable = False
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RCK.ini
+++ b/Data/Sys/GameSettings/RCK.ini
@@ -1,4 +1,5 @@
 # RCKPGN - Alan Hansen's Sports Challenge
 
 [Video_Settings]
+SafeTextureCacheColorSamples = 512
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RI8.ini
+++ b/Data/Sys/GameSettings/RI8.ini
@@ -1,0 +1,4 @@
+# RI8P41, RI8E41 - Brothers In Arms: Road To Hill 30
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RNO.ini
+++ b/Data/Sys/GameSettings/RNO.ini
@@ -1,7 +1,8 @@
 # RNOJ01, RNOP01 - Another Code R Kioku no Tobira
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Prevents save game corruption.
+SyncGPU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -17,3 +18,5 @@
 [Video_Hacks]
 EFBToTextureEnable = False
 ImmediateXFBEnable = False
+# Multiple choice options displays some graphic corruption
+# DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RRL.ini
+++ b/Data/Sys/GameSettings/RRL.ini
@@ -1,4 +1,20 @@
 # RRLE78, RRLP78, RRLX78, RRLY78, RRLZ78 - Bratz: Girlz Really Rock
 
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
 [Video_Settings]
+SafeTextureCacheColorSamples = 0
 SuggestedAspectRatio = 2
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RRT.ini
+++ b/Data/Sys/GameSettings/RRT.ini
@@ -1,0 +1,4 @@
+# RRTE52, RRTP52 - Block Party
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RSJ.ini
+++ b/Data/Sys/GameSettings/RSJ.ini
@@ -1,4 +1,5 @@
 # RSJE41, RSJP41 - Broken Sword: Shadow of the Templars (Director's Cut)
 
 [Video_Settings]
+SafeTextureCacheColorSamples = 0
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RVA.ini
+++ b/Data/Sys/GameSettings/RVA.ini
@@ -1,0 +1,4 @@
+# RVAE78, RVAP78 - Avatar: The Last Airbender - The Burning Earth
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/ST6.ini
+++ b/Data/Sys/GameSettings/ST6.ini
@@ -1,0 +1,7 @@
+# ST6E78, ST6P78 - The Biggest Loser: Challenge
+
+[Core]
+CPUThread = False
+
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
Mostly fixes for Wii games # - B

Some fixes to dual core issues, EFB Copies to Texture and Ram, Defer EFB Copies to RAM issues and Texture Cache Accuracy issues.