### PR TITLE
VolumeVerifier: Use correct IOS filename for development discs.

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -630,14 +630,17 @@ bool VolumeVerifier::CheckPartition(const Partition& partition)
     // IOS9 is the only IOS which can be assumed to exist in a working state on any Wii
     // regardless of what updates have been installed. At least Mario Party 8
     // (RM8E01, revision 2) uses IOS9 without having it in its update partition.
-    bool has_correct_ios = tmd.IsValid() && (tmd.GetIOSId() & 0xFF) == 9;
+    const u64 ios_ver = tmd.GetIOSId() & 0xFF;
+    bool has_correct_ios = tmd.IsValid() && ios_ver == 9;
 
     if (!has_correct_ios && tmd.IsValid())
     {
       std::unique_ptr<FileInfo> file_info = filesystem->FindFileInfo("_sys");
       if (file_info)
       {
-        const std::string correct_ios = "IOS" + std::to_string(tmd.GetIOSId() & 0xFF) + "-";
+        const std::string ios_ver_str = std::to_string(ios_ver);
+        const std::string correct_ios =
+            IsDebugSigned() ? ("firmware.64." + ios_ver_str + ".") : ("IOS" + ios_ver_str + "-");
         for (const FileInfo& f : *file_info)
         {
           if (StringBeginsWith(f.GetName(), correct_ios))


### PR DESCRIPTION
Retail-signed discs use the format: IOS56-64-v5661.wad
Debug-signed discs use the format:  firmware.64.56.22.29.wad

Debug-signed discs usually have a 128 version of the firmware as well, since some devkits have 128 MB MEM2. (Retail has 64 MB.)

This fixes part of VolumeVerifier for debug discs. It's not validating the signatures properly. I attempted to add the debug root key (which is different from retail), and that helped, but ESDevice::VerifyContainer() was still getting an error from mbedtls, even though the public key appeared to be correctl