### PR TITLE
DSP masking and sign extension fixes

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -200,7 +200,7 @@ enum : u16
   SR_LOGIC_ZERO = 0x0040,
   SR_OVERFLOW_STICKY =
       0x0080,  // Set at the same time as 0x2 (under same conditions) - but not cleared the same
-  SR_100 = 0x0100,         // Unknown
+  SR_100 = 0x0100,         // Unknown, always reads back as 0
   SR_INT_ENABLE = 0x0200,  // Not 100% sure but duddie says so. This should replace the hack, if so.
   SR_400 = 0x0400,         // Unknown
   SR_EXT_INT_ENABLE = 0x0800,  // Appears in zelda - seems to disable external interrupts

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -687,7 +687,7 @@ void Interpreter::OpWriteRegister(int reg_, u16 val)
 
   switch (reg)
   {
-  // 8-bit sign extended registers. Should look at prod.h too...
+  // 8-bit sign extended registers.
   case DSP_REG_ACH0:
   case DSP_REG_ACH1:
     // sign extend from the bottom 8 bits.
@@ -720,10 +720,10 @@ void Interpreter::OpWriteRegister(int reg_, u16 val)
     state.r.wr[reg - DSP_REG_WR0] = val;
     break;
   case DSP_REG_CR:
-    state.r.cr = val;
+    state.r.cr = val & 0x00ff;
     break;
   case DSP_REG_SR:
-    state.r.sr = val;
+    state.r.sr = val & ~SR_100;
     break;
   case DSP_REG_PRODL:
     state.r.prod.l = val;
@@ -732,7 +732,8 @@ void Interpreter::OpWriteRegister(int reg_, u16 val)
     state.r.prod.m = val;
     break;
   case DSP_REG_PRODH:
-    state.r.prod.h = val;
+    // Unlike ac0.h and ac1.h, prod.h is not sign-extended
+    state.r.prod.h = val & 0x00ff;
     break;
   case DSP_REG_PRODM2:
     state.r.prod.m2 = val;

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -394,13 +394,14 @@ s16 Interpreter::GetAXHigh(s32 reg) const
 s64 Interpreter::GetLongAcc(s32 reg) const
 {
   const auto& state = m_dsp_core.DSPState();
-  return static_cast<s64>(state.r.ac[reg].val << 24) >> 24;
+  return static_cast<s64>(state.r.ac[reg].val);
 }
 
 void Interpreter::SetLongAcc(s32 reg, s64 value)
 {
   auto& state = m_dsp_core.DSPState();
-  state.r.ac[reg].val = static_cast<u64>(value);
+  // 40-bit sign extension
+  state.r.ac[reg].val = static_cast<u64>((value << (64 - 40)) >> (64 - 40));
 }
 
 s16 Interpreter::GetAccLow(s32 reg) const
@@ -690,8 +691,8 @@ void Interpreter::OpWriteRegister(int reg_, u16 val)
   // 8-bit sign extended registers.
   case DSP_REG_ACH0:
   case DSP_REG_ACH1:
-    // sign extend from the bottom 8 bits.
-    state.r.ac[reg - DSP_REG_ACH0].h = (u16)(s16)(s8)(u8)val;
+    // Sign extend from the bottom 8 bits.
+    state.r.ac[reg - DSP_REG_ACH0].h = static_cast<s8>(val);
     break;
 
   // Stack registers.

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitUtil.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitUtil.cpp
@@ -109,12 +109,6 @@ void DSPEmitter::dsp_op_write_reg(int reg, Gen::X64Reg host_sreg)
 {
   switch (reg & 0x1f)
   {
-  // 8-bit sign extended registers.
-  case DSP_REG_ACH0:
-  case DSP_REG_ACH1:
-    m_gpr.WriteReg(reg, R(host_sreg));
-    break;
-
   // Stack registers.
   case DSP_REG_ST0:
   case DSP_REG_ST1:
@@ -133,11 +127,6 @@ void DSPEmitter::dsp_op_write_reg_imm(int reg, u16 val)
 {
   switch (reg & 0x1f)
   {
-  // 8-bit sign extended registers. Should look at prod.h too...
-  case DSP_REG_ACH0:
-  case DSP_REG_ACH1:
-    m_gpr.WriteReg(reg, Imm16((u16)(s16)(s8)(u8)val));
-    break;
   // Stack registers.
   case DSP_REG_ST0:
   case DSP_REG_ST1:

--- a/Source/DSPSpy/tests/dsp_base.inc
+++ b/Source/DSPSpy/tests/dsp_base.inc
@@ -173,6 +173,9 @@ send_back:
 	; first, store $sr so we can modify it
 	sr	@(REGS_BASE + 19), $sr
 	set16
+	; Now store $wr0, as it must be 0xffff for srri to work as we expect
+	sr	@(REGS_BASE + 8), $wr0
+	lri	$wr0, #0xffff
 	; store registers to reg table
 	sr		@REGS_BASE,  $ar0
 	lri		$ar0, #(REGS_BASE + 1)
@@ -183,7 +186,8 @@ send_back:
 	srri	@$ar0, $ix1
 	srri	@$ar0, $ix2
 	srri	@$ar0, $ix3
-	srri	@$ar0, $wr0
+	; skip $wr0 since we already stored and modified it
+	iar	$ar0
 	srri	@$ar0, $wr1
 	srri	@$ar0, $wr2
 	srri	@$ar0, $wr3
@@ -210,6 +214,9 @@ send_back:
 	srri	@$ar0, $ac1.m
 
 ; Regs are stored. Prepare DMA.
+; $cr must be 0x00ff because the ROM uses lrs and srs with the assumption that
+; they will modify hardware registers.
+	lri		$cr, #0x00ff
 	lri		$ax0.l, #0x0000
 	lri		$ax1.l, #1		;(DSP_CR_IMEM | DSP_CR_TO_CPU)
 	lri		$ax0.h, #0x200
@@ -246,7 +253,8 @@ dma_copy:
 	lrri	$ix1, @$ar0
 	lrri	$ix2, @$ar0
 	lrri	$ix3, @$ar0
-	lrri	$wr0, @$ar0
+	; leave $wr for later
+	iar $ar0
 	lrri	$wr1, @$ar0
 	lrri	$wr2, @$ar0
 	lrri	$wr3, @$ar0
@@ -272,6 +280,7 @@ dma_copy:
 	lrri	$ac0.m, @$ar0
 	lrri	$ac1.m, @$ar0
 	lr	$ar0, @REGS_BASE
+	lr	$wr0, @(REGS_BASE+8)
 	lr	$sr, @(REGS_BASE+19)
 
 	ret		; from send_back

--- a/Source/DSPSpy/tests/reg_mask_test.ds
+++ b/Source/DSPSpy/tests/reg_mask_test.ds
@@ -1,0 +1,65 @@
+incdir "tests"
+include "dsp_base.inc"
+
+; Test what happens various values are written to every register
+	LRI $ar0, #0xffff
+	CALL set_all_regs
+	CALL send_back
+
+	LRI $ar0, #0x0000
+	CALL set_all_regs
+	CALL send_back
+
+	LRI $ar0, #0x007f
+	CALL set_all_regs
+	CALL send_back
+
+	LRI $ar0, #0x0080
+	CALL set_all_regs
+	CALL send_back
+
+	LRI $ar0, #0x0100
+	CALL set_all_regs
+	CALL send_back
+
+; We're done, DO NOT DELETE THIS LINE
+	JMP end_of_test
+
+; Copy $ar0 to all other registers
+set_all_regs:
+	SET16
+	MRR $ar1,     $ar0
+	MRR $ar2,     $ar0
+	MRR $ar3,     $ar0
+	MRR $ix0,     $ar0
+	MRR $ix1,     $ar0
+	MRR $ix2,     $ar0
+	MRR $ix3,     $ar0
+	MRR $wr0,     $ar0
+	MRR $wr1,     $ar0
+	MRR $wr2,     $ar0
+	MRR $wr3,     $ar0
+	; Don't write to the stacks; returning from this function breaks otherwise
+	; They don't show up in DSPSpy anyways
+	;MRR $st0,     $ar0
+	;MRR $st1,     $ar0
+	;MRR $st2,     $ar0
+	;MRR $st3,     $ar0
+	MRR $ac0.h,   $ar0
+	MRR $ac1.h,   $ar0
+	MRR $cr,      $ar0
+	; Wait to set $sr, as it can change the way stores work
+	MRR $prod.l,  $ar0
+	MRR $prod.m1, $ar0
+	MRR $prod.h,  $ar0
+	MRR $prod.m2, $ar0
+	MRR $ax0.l,   $ar0
+	MRR $ax1.l,   $ar0
+	MRR $ax0.h,   $ar0
+	MRR $ax1.h,   $ar0
+	MRR $ac0.l,   $ar0
+	MRR $ac1.l,   $ar0
+	MRR $ac0.m,   $ar0
+	MRR $ac1.m,   $ar0
+	MRR $sr,      $ar0
+	RET


### PR DESCRIPTION
The `cr` and `prod.h` registers are 8 bits and do not experience sign extension.  Also, the `SR_100` bit always seems to read back as 0, regardless of what's written to it `sr`.  Lastly, `ac0.h` and `ac1.h` do experience sign extension; this is already implemented, but the implementation worked incorrectly on the interpreter when the whole `acc0` or `acc1` register was updated and then `ac0.h` or `ac1.h` were read back directly.

<details><summary>Results</summary>

Apologies for how unreadable this is.  Think of it more as a table of thumbnails than something you can directly compare.

| Test | Hardware | Old JIT | Old Int | New JIT | New Int |
|------|----------|---------|---------|---------|---------|
| Less | ![Screenshot 2021-08-15 19-53-12](https://user-images.githubusercontent.com/8334194/129516116-50f71ffd-c998-4cef-9cbf-1463e86d423b.png) | ![OHBCHB_2021-08-15_19-55-44_Old_JIT](https://user-images.githubusercontent.com/8334194/129516313-702c9bb7-55b4-4e02-8a80-182ad828fbe4.png) | ![OHBCHB_2021-08-15_19-56-50_Old_Int](https://user-images.githubusercontent.com/8334194/129516314-3dde628a-7e3c-477e-b056-63898bfb415e.png) | ![OHBCHB_2021-08-15_19-59-04_New_JIT](https://user-images.githubusercontent.com/8334194/129516315-4d8d185c-8a93-4290-ab14-ab65dfa45902.png) | ![OHBCHB_2021-08-15_19-59-18_New_Int](https://user-images.githubusercontent.com/8334194/129516316-c83dd135-4137-4b5b-8e3a-b4ec99f0ee76.png) |
| FFFF | ![Screenshot 2021-08-15 22-10-38_FFFF](https://user-images.githubusercontent.com/8334194/129516122-e5812cde-3b6a-4891-8591-cf2e0caeb7f5.png) | ![OHBCHB_2021-08-15_21-43-23_Old_JIT_FFFF](https://user-images.githubusercontent.com/8334194/129516317-e20db887-d233-40f5-a7ef-b6c0307da6b1.png) | ![OHBCHB_2021-08-15_21-45-24_Old_Int_FFFF](https://user-images.githubusercontent.com/8334194/129516328-ea5338bc-abb6-404b-a551-69e94b4cc889.png) | ![OHBCHB_2021-08-15_21-47-10_New_JIT_FFFF](https://user-images.githubusercontent.com/8334194/129516335-b3d0e59c-12c7-48cc-8037-52e6002ee93d.png) | ![OHBCHB_2021-08-15_21-49-24_New_Int_FFFF](https://user-images.githubusercontent.com/8334194/129516342-c7637952-58e3-457a-8841-5b6115e211ab.png) |
| 0000 | ![Screenshot 2021-08-15 22-11-12_0000](https://user-images.githubusercontent.com/8334194/129516123-d53baeaa-56a5-4c9d-812e-ffa0e3e4b9ee.png) | ![OHBCHB_2021-08-15_21-43-43_Old_JIT_0000](https://user-images.githubusercontent.com/8334194/129516319-4a279a4d-497a-47d9-aacc-0a35e470b8d4.png) | ![OHBCHB_2021-08-15_21-45-26_Old_Int_0000](https://user-images.githubusercontent.com/8334194/129516329-4a520c45-2fa8-40e4-b940-b0c4366d01c1.png) | ![OHBCHB_2021-08-15_21-47-12_New_JIT_0000](https://user-images.githubusercontent.com/8334194/129516336-5e94f72a-0fee-47de-9785-b2466cdd27ed.png) | ![OHBCHB_2021-08-15_21-49-28_New_Int_0000](https://user-images.githubusercontent.com/8334194/129516345-4f9d2ea1-767d-4802-a419-dd7bd8a626d0.png) |
| 007F | ![Screenshot 2021-08-15 22-11-26_007F](https://user-images.githubusercontent.com/8334194/129516128-3aa8a5ee-54f4-41b1-8131-0784e82f33b1.png) | ![OHBCHB_2021-08-15_21-43-47_Old_JIT_007F](https://user-images.githubusercontent.com/8334194/129516321-95f354f0-90c7-405a-ace7-2e7627032e55.png) | ![OHBCHB_2021-08-15_21-45-29_Old_Int_007F](https://user-images.githubusercontent.com/8334194/129516331-5554187b-4391-4b6c-b8fc-42d8f5a72cab.png) | ![OHBCHB_2021-08-15_21-47-14_New_JIT_007F](https://user-images.githubusercontent.com/8334194/129516337-f1ee5f21-5030-4041-bcdb-2118e37b6112.png) | ![OHBCHB_2021-08-15_21-49-31_New_Int_007F](https://user-images.githubusercontent.com/8334194/129516347-4c246d1e-c9c4-4321-8483-7eacf29d9642.png) |
| 0080 | ![Screenshot 2021-08-15 22-11-42_0080](https://user-images.githubusercontent.com/8334194/129516130-e247f9bc-039a-48e4-90a3-959cf2e30f69.png) | ![OHBCHB_2021-08-15_21-43-49_Old_JIT_0080](https://user-images.githubusercontent.com/8334194/129516322-912de8e8-0a51-42fc-8f25-cf099fcf0785.png) | ![OHBCHB_2021-08-15_21-45-31_Old_Int_0080](https://user-images.githubusercontent.com/8334194/129516333-dc948d59-3661-4e06-ba71-fefb35820373.png) | ![OHBCHB_2021-08-15_21-47-16_New_JIT_0080](https://user-images.githubusercontent.com/8334194/129516339-82ade131-86a6-4889-a6ad-2845d06af4bd.png) | ![OHBCHB_2021-08-15_21-49-33_New_Int_0080](https://user-images.githubusercontent.com/8334194/129516351-bcd53b4e-8cae-45a8-b552-a0d5da61fdf9.png) |
| 0100 | ![Screenshot 2021-08-15 22-11-56_0100](https://user-images.githubusercontent.com/8334194/129516136-a420029e-2e28-4ac6-962a-5cf561b84e5a.png) | ![OHBCHB_2021-08-15_21-43-52_Old_JIT_0100](https://user-images.githubusercontent.com/8334194/129516326-2bf80014-00a9-426e-b4d4-2acc7bc71f92.png) | ![OHBCHB_2021-08-15_21-45-32_Old_Int_0100](https://user-images.githubusercontent.com/8334194/129516334-b8ca37bb-d083-4308-9f9a-ee056536312c.png) | ![OHBCHB_2021-08-15_21-47-18_New_JIT_0100](https://user-images.githubusercontent.com/8334194/129516341-8164710d-fe1f-46eb-9dfb-4e4ffe3e09f8.png) | ![OHBCHB_2021-08-15_21-49-36_New_Int_0100](https://user-images.githubusercontent.com/8334194/129516353-c01a5b9a-430c-40eb-bef9-f71eb1ae7d77.png) |

For the less test, the JIT behaves the same as it did before and as it does now, as it handled sign extension properly.  Its result is not correct for the `sr` register, but that's a separate issue (the JIT seems to not update flags for overflow properly) which will be handled later.  The interpreter now exactly matches hardware.

For the other tests, the old JIT and old interpreter had the same incorrect behavior, and the new JIT and the new interpreter have the same behavior that matches hardware.
</details>

I'm not completely confident on the code for the JIT, which I based based on the code for `DSP_REG_ACH0`.  It seems to work, but the TODO about immediate values is a bit odd.