### PR TITLE
Bump minimum macOS to 10.13 High Sierra

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -64,7 +64,7 @@ DEFAULT_CONFIG = {
 
     # Minimum macOS version for each architecture slice
     "arm64_mac_os_deployment_target":  "11.0.0",
-    "x86_64_mac_os_deployment_target": "10.12.0",
+    "x86_64_mac_os_deployment_target": "10.13.0",
 
     # CMake Generator to use for building
     "generator": "Unix Makefiles",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ cmake_minimum_required(VERSION 3.10)
 
 # MacOS prior to 10.14 did not support aligned alloc which is used to implement
 # std::unique_ptr in the arm64 C++ standard library. x86_64 builds can override
-# this to 10.12.0 using -DCMAKE_OSX_DEPLOYMENT_TARGET="10.12.0" without issue.
+# this to 10.13.0 using -DCMAKE_OSX_DEPLOYMENT_TARGET="10.13.0" without issue.
 # This is done in the universal binary building script to build a binary that 
-# runs on 10.12 on x86_64 computers, while still containing an arm64 slice.
+# runs on 10.13 on x86_64 computers, while still containing an arm64 slice.
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14.0" CACHE STRING "")
 

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 * OS
     * Windows (7 SP1 or higher).
     * Linux.
-    * macOS (10.12 Sierra or higher).
+    * macOS (10.13 High Sierra or higher).
     * Unix-like systems other than Linux are not officially supported but might work.
 * Processor
     * A CPU with SSE2 support.


### PR DESCRIPTION
As discussed [here](https://forums.dolphin-emu.org/Thread-unable-to-open-newest-version-of-dolphin-in-os-x-sierra?pid=520790#pid520790) and on IRC.

The minimum macOS version supported by Qt 5.14 is 10.13 High Sierra.