### PR TITLE
Fix some missed items from SPDX transition 

### DIFF
--- a/Source/Core/Core/Config/UISettings.cpp
+++ b/Source/Core/Core/Config/UISettings.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Refer to the license.txt file included
 
 #include "Core/Config/UISettings.h"
 

--- a/Source/Core/DolphinQt/AboutDialog.cpp
+++ b/Source/Core/DolphinQt/AboutDialog.cpp
@@ -41,7 +41,7 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
 </p>
 
 <p>
-<a href='https://github.com/dolphin-emu/dolphin/blob/master/license.txt'>%LICENSE%</a> |
+<a href='https://github.com/dolphin-emu/dolphin/blob/master/COPYING'>%LICENSE%</a> |
 <a href='https://github.com/dolphin-emu/dolphin/graphs/contributors'>%AUTHORS%</a> |
 <a href='https://forums.dolphin-emu.org/'>%SUPPORT%</a>
 )")

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -375,9 +375,14 @@ if(WIN32)
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/Data/Sys" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sys"
   )
 
-  # Copy license.txt
+  # Copy COPYING
   add_custom_command(TARGET dolphin-emu POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/license.txt" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/license.txt"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/COPYING" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/COPYING"
+  )
+
+  # Copy Licenses dir
+  add_custom_command(TARGET dolphin-emu POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/LICENSES" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Licenses"
   )
 
   # Copy qt.conf


### PR DESCRIPTION
Just some minor things that were missed in #9862.

* The About dialog had a link to the now removed `license.txt` file.
* ``UISettings.cpp`` had a stray comment that was missed in the mass comment replacement (presumably due to the missing period).
* Windows builds still attempted to add a non-existent `license.txt` to the output directory. This has been replaced with adding the ``COPYING`` file and the ``LICENSES`` directory.