### PR TITLE
Interpreter: Make signedness and narrowing conversions explicit

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
@@ -7,7 +7,6 @@
 #include "Core/HLE/HLE.h"
 #include "Core/PowerPC/Interpreter/ExceptionUtils.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
-#include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
 
 void Interpreter::bx(UGeckoInstruction inst)
@@ -15,10 +14,12 @@ void Interpreter::bx(UGeckoInstruction inst)
   if (inst.LK)
     LR = PC + 4;
 
+  const auto address = u32(SignExt26(inst.LI << 2));
+
   if (inst.AA)
-    NPC = SignExt26(inst.LI << 2);
+    NPC = address;
   else
-    NPC = PC + SignExt26(inst.LI << 2);
+    NPC = PC + address;
 
   m_end_block = true;
 }
@@ -29,11 +30,11 @@ void Interpreter::bcx(UGeckoInstruction inst)
   if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)
     CTR--;
 
-  const bool true_false = ((inst.BO >> 3) & 1);
-  const bool only_counter_check = ((inst.BO >> 4) & 1);
-  const bool only_condition_check = ((inst.BO >> 2) & 1);
+  const bool true_false = ((inst.BO >> 3) & 1) != 0;
+  const bool only_counter_check = ((inst.BO >> 4) & 1) != 0;
+  const bool only_condition_check = ((inst.BO >> 2) & 1) != 0;
   const u32 ctr_check = ((CTR != 0) ^ (inst.BO >> 1)) & 1;
-  const bool counter = only_condition_check || ctr_check;
+  const bool counter = only_condition_check || ctr_check != 0;
   const bool condition =
       only_counter_check || (PowerPC::ppcState.cr.GetBit(inst.BI) == u32(true_false));
 
@@ -42,10 +43,12 @@ void Interpreter::bcx(UGeckoInstruction inst)
     if (inst.LK)
       LR = PC + 4;
 
+    const auto address = u32(SignExt16(s16(inst.BD << 2)));
+
     if (inst.AA)
-      NPC = SignExt16(inst.BD << 2);
+      NPC = address;
     else
-      NPC = PC + SignExt16(inst.BD << 2);
+      NPC = PC + address;
   }
 
   m_end_block = true;
@@ -53,13 +56,13 @@ void Interpreter::bcx(UGeckoInstruction inst)
 
 void Interpreter::bcctrx(UGeckoInstruction inst)
 {
-  DEBUG_ASSERT_MSG(POWERPC, inst.BO_2 & BO_DONT_DECREMENT_FLAG,
+  DEBUG_ASSERT_MSG(POWERPC, (inst.BO_2 & BO_DONT_DECREMENT_FLAG) != 0,
                    "bcctrx with decrement and test CTR option is invalid!");
 
   const u32 condition =
       ((inst.BO_2 >> 4) | (PowerPC::ppcState.cr.GetBit(inst.BI_2) == ((inst.BO_2 >> 3) & 1))) & 1;
 
-  if (condition)
+  if (condition != 0)
   {
     NPC = CTR & (~3);
     if (inst.LK_3)
@@ -78,7 +81,7 @@ void Interpreter::bclrx(UGeckoInstruction inst)
   const u32 condition =
       ((inst.BO_2 >> 4) | (PowerPC::ppcState.cr.GetBit(inst.BI_2) == ((inst.BO_2 >> 3) & 1))) & 1;
 
-  if (counter & condition)
+  if ((counter & condition) != 0)
   {
     NPC = LR & (~3);
     if (inst.LK_3)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -312,37 +312,39 @@ inline FPResult NI_msub(UReg_FPSCR* fpscr, double a, double c, double b)
 // used by stfsXX instructions and ps_rsqrte
 inline u32 ConvertToSingle(u64 x)
 {
-  u32 exp = (x >> 52) & 0x7ff;
+  const u32 exp = u32((x >> 52) & 0x7ff);
+
   if (exp > 896 || (x & ~Common::DOUBLE_SIGN) == 0)
   {
-    return ((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff);
+    return u32(((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff));
   }
   else if (exp >= 874)
   {
-    u32 t = (u32)(0x80000000 | ((x & Common::DOUBLE_FRAC) >> 21));
+    u32 t = u32(0x80000000 | ((x & Common::DOUBLE_FRAC) >> 21));
     t = t >> (905 - exp);
-    t |= (x >> 32) & 0x80000000;
+    t |= u32((x >> 32) & 0x80000000);
     return t;
   }
   else
   {
     // This is said to be undefined.
     // The code is based on hardware tests.
-    return ((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff);
+    return u32(((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff));
   }
 }
 
 // used by psq_stXX operations.
 inline u32 ConvertToSingleFTZ(u64 x)
 {
-  u32 exp = (x >> 52) & 0x7ff;
+  const u32 exp = u32((x >> 52) & 0x7ff);
+
   if (exp > 896 || (x & ~Common::DOUBLE_SIGN) == 0)
   {
-    return ((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff);
+    return u32(((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff));
   }
   else
   {
-    return (x >> 32) & 0x80000000;
+    return u32((x >> 32) & 0x80000000);
   }
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -22,9 +22,9 @@ enum class RoundingMode
   TowardsNegativeInfinity = 0b11
 };
 
-static void SetFI(UReg_FPSCR* fpscr, int FI)
+void SetFI(UReg_FPSCR* fpscr, u32 FI)
 {
-  if (FI)
+  if (FI != 0)
   {
     SetFPException(fpscr, FPSCR_XX);
   }
@@ -484,7 +484,7 @@ void Interpreter::fresx(UGeckoInstruction inst)
   const auto compute_result = [inst](double value) {
     const double result = Common::ApproximateReciprocal(value);
     rPS(inst.FD).Fill(result);
-    PowerPC::UpdateFPRFSingle(result);
+    PowerPC::UpdateFPRFSingle(float(result));
   };
 
   if (b == 0.0)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -17,12 +17,12 @@
 
 static u32 Helper_Get_EA(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
 {
-  return inst.RA ? (ppcs.gpr[inst.RA] + inst.SIMM_16) : (u32)inst.SIMM_16;
+  return inst.RA ? (ppcs.gpr[inst.RA] + u32(inst.SIMM_16)) : u32(inst.SIMM_16);
 }
 
 static u32 Helper_Get_EA_U(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
 {
-  return (ppcs.gpr[inst.RA] + inst.SIMM_16);
+  return (ppcs.gpr[inst.RA] + u32(inst.SIMM_16));
 }
 
 static u32 Helper_Get_EA_X(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
@@ -205,7 +205,7 @@ void Interpreter::lfsx(UGeckoInstruction inst)
 
 void Interpreter::lha(UGeckoInstruction inst)
 {
-  const u32 temp = (u32)(s32)(s16)PowerPC::Read_U16(Helper_Get_EA(PowerPC::ppcState, inst));
+  const u32 temp = u32(s32(s16(PowerPC::Read_U16(Helper_Get_EA(PowerPC::ppcState, inst)))));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
@@ -216,7 +216,7 @@ void Interpreter::lha(UGeckoInstruction inst)
 void Interpreter::lhau(UGeckoInstruction inst)
 {
   const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
-  const u32 temp = (u32)(s32)(s16)PowerPC::Read_U16(address);
+  const u32 temp = u32(s32(s16(PowerPC::Read_U16(address))));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
@@ -258,11 +258,11 @@ void Interpreter::lmw(UGeckoInstruction inst)
     return;
   }
 
-  for (int i = inst.RD; i <= 31; i++, address += 4)
+  for (u32 i = inst.RD; i <= 31; i++, address += 4)
   {
     const u32 temp_reg = PowerPC::Read_U32(address);
 
-    if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
+    if ((PowerPC::ppcState.Exceptions & EXCEPTION_DSI) != 0)
     {
       PanicAlertFmt("DSI exception in lmw");
       NOTICE_LOG_FMT(POWERPC, "DSI exception in lmw");
@@ -286,10 +286,10 @@ void Interpreter::stmw(UGeckoInstruction inst)
     return;
   }
 
-  for (int i = inst.RS; i <= 31; i++, address += 4)
+  for (u32 i = inst.RS; i <= 31; i++, address += 4)
   {
     PowerPC::Write_U32(rGPR[i], address);
-    if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
+    if ((PowerPC::ppcState.Exceptions & EXCEPTION_DSI) != 0)
     {
       PanicAlertFmt("DSI exception in stmw");
       NOTICE_LOG_FMT(POWERPC, "DSI exception in stmw");
@@ -536,13 +536,13 @@ void Interpreter::eciwx(UGeckoInstruction inst)
 {
   const u32 EA = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
-  if (!(PowerPC::ppcState.spr[SPR_EAR] & 0x80000000))
+  if ((PowerPC::ppcState.spr[SPR_EAR] & 0x80000000) == 0)
   {
     GenerateDSIException(EA);
     return;
   }
 
-  if (EA & 3)
+  if ((EA & 0b11) != 0)
   {
     GenerateAlignmentException(EA);
     return;
@@ -555,13 +555,13 @@ void Interpreter::ecowx(UGeckoInstruction inst)
 {
   const u32 EA = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
-  if (!(PowerPC::ppcState.spr[SPR_EAR] & 0x80000000))
+  if ((PowerPC::ppcState.spr[SPR_EAR] & 0x80000000) == 0)
   {
     GenerateDSIException(EA);
     return;
   }
 
-  if (EA & 3)
+  if ((EA & 0b11) != 0)
   {
     GenerateAlignmentException(EA);
     return;
@@ -610,22 +610,22 @@ void Interpreter::lbzx(UGeckoInstruction inst)
 void Interpreter::lhaux(UGeckoInstruction inst)
 {
   const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
-  const s32 temp = (s32)(s16)PowerPC::Read_U16(address);
+  const s32 temp = s32{s16(PowerPC::Read_U16(address))};
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
-    rGPR[inst.RD] = temp;
+    rGPR[inst.RD] = u32(temp);
     rGPR[inst.RA] = address;
   }
 }
 
 void Interpreter::lhax(UGeckoInstruction inst)
 {
-  const s32 temp = (s32)(s16)PowerPC::Read_U16(Helper_Get_EA_X(PowerPC::ppcState, inst));
+  const s32 temp = s32{s16(PowerPC::Read_U16(Helper_Get_EA_X(PowerPC::ppcState, inst)))};
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
-    rGPR[inst.RD] = temp;
+    rGPR[inst.RD] = u32(temp);
   }
 }
 
@@ -675,15 +675,15 @@ void Interpreter::lswx(UGeckoInstruction inst)
   // Confirmed by hardware test that the zero case doesn't zero rGPR[r]
   for (u32 n = 0; n < static_cast<u8>(PowerPC::ppcState.xer_stringctrl); n++)
   {
-    const int reg = (inst.RD + (n >> 2)) & 0x1f;
-    const int offset = (n & 3) << 3;
+    const u32 reg = (inst.RD + (n >> 2)) & 0x1f;
+    const u32 offset = (n & 3) << 3;
 
-    if ((n & 3) == 0)
+    if ((n & 0b11) == 0)
       rGPR[reg] = 0;
 
     const u32 temp_value = PowerPC::Read_U8(EA) << (24 - offset);
     // Not64 (Homebrew N64 Emulator for Wii) triggers the following case.
-    if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
+    if ((PowerPC::ppcState.Exceptions & EXCEPTION_DSI) != 0)
     {
       NOTICE_LOG_FMT(POWERPC, "DSI exception in lswx");
       return;
@@ -842,10 +842,8 @@ void Interpreter::sthx(UGeckoInstruction inst)
 // FIXME: Should rollback if a DSI occurs
 void Interpreter::lswi(UGeckoInstruction inst)
 {
-  u32 EA;
-  if (inst.RA == 0)
-    EA = 0;
-  else
+  u32 EA = 0;
+  if (inst.RA != 0)
     EA = rGPR[inst.RA];
 
   if (MSR.LE)
@@ -854,14 +852,12 @@ void Interpreter::lswi(UGeckoInstruction inst)
     return;
   }
 
-  u32 n;
-  if (inst.NB == 0)
-    n = 32;
-  else
+  u32 n = 32;
+  if (inst.NB != 0)
     n = inst.NB;
 
-  int r = inst.RD - 1;
-  int i = 0;
+  u32 r = u32{inst.RD} - 1;
+  u32 i = 0;
   while (n > 0)
   {
     if (i == 0)
@@ -872,7 +868,7 @@ void Interpreter::lswi(UGeckoInstruction inst)
     }
 
     const u32 temp_value = PowerPC::Read_U8(EA) << (24 - i);
-    if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
+    if ((PowerPC::ppcState.Exceptions & EXCEPTION_DSI) != 0)
     {
       PanicAlertFmt("DSI exception in lsw.");
       return;
@@ -893,10 +889,8 @@ void Interpreter::lswi(UGeckoInstruction inst)
 // FIXME: Should rollback if a DSI occurs
 void Interpreter::stswi(UGeckoInstruction inst)
 {
-  u32 EA;
-  if (inst.RA == 0)
-    EA = 0;
-  else
+  u32 EA = 0;
+  if (inst.RA != 0)
     EA = rGPR[inst.RA];
 
   if (MSR.LE)
@@ -905,14 +899,12 @@ void Interpreter::stswi(UGeckoInstruction inst)
     return;
   }
 
-  u32 n;
-  if (inst.NB == 0)
-    n = 32;
-  else
+  u32 n = 32;
+  if (inst.NB != 0)
     n = inst.NB;
 
-  int r = inst.RS - 1;
-  int i = 0;
+  u32 r = u32{inst.RS} - 1;
+  u32 i = 0;
   while (n > 0)
   {
     if (i == 0)
@@ -921,7 +913,7 @@ void Interpreter::stswi(UGeckoInstruction inst)
       r &= 31;
     }
     PowerPC::Write_U8((rGPR[r] >> (24 - i)) & 0xFF, EA);
-    if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
+    if ((PowerPC::ppcState.Exceptions & EXCEPTION_DSI) != 0)
     {
       return;
     }
@@ -945,9 +937,9 @@ void Interpreter::stswx(UGeckoInstruction inst)
     return;
   }
 
-  u32 n = (u8)PowerPC::ppcState.xer_stringctrl;
-  int r = inst.RS;
-  int i = 0;
+  u32 n = u8(PowerPC::ppcState.xer_stringctrl);
+  u32 r = inst.RS;
+  u32 i = 0;
 
   while (n > 0)
   {

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -144,7 +144,7 @@ void Interpreter::ps_res(UGeckoInstruction inst)
   const double ps1 = Common::ApproximateReciprocal(b);
 
   rPS(inst.FD).SetBoth(ps0, ps1);
-  PowerPC::UpdateFPRFSingle(ps0);
+  PowerPC::UpdateFPRFSingle(float(ps0));
 
   if (inst.Rc)
     PowerPC::ppcState.UpdateCR1();


### PR DESCRIPTION
Makes our conversions between different signs and cases where truncations would occur to be explicit to indicate that they're intentional and, well, make implicit conversions explicit for reading purposes, which I think is preferable for the interpreter, given it essentially partially doubles as a reading reference for faster CPU backends to base behavior off of in tandem with other documenation. This also resolves numerous compiler warnings when stricter conversion warnings are enabled.

Note that we have a bunch of seemingly... old history tracing code in Interpreter.cpp, if this isn't particularly useful, I'm fine with completely removing it, since it'd make the interpreter's Run() member function a little more compact and nicer to read without the ifdefs.