### PR TITLE
DolphinQt: Remove Windows dialog help buttons

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -638,15 +638,15 @@ void CodeViewWidget::OnRenameSymbol()
 {
   const u32 addr = GetContextAddress();
 
-  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
+  Common::Symbol* const symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
   if (!symbol)
     return;
 
   bool good;
-  QString name =
+  const QString name =
       QInputDialog::getText(this, tr("Rename symbol"), tr("Symbol name:"), QLineEdit::Normal,
-                            QString::fromStdString(symbol->name), &good);
+                            QString::fromStdString(symbol->name), &good, Qt::WindowCloseButtonHint);
 
   if (good && !name.isEmpty())
   {
@@ -673,16 +673,16 @@ void CodeViewWidget::OnSetSymbolSize()
 {
   const u32 addr = GetContextAddress();
 
-  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
+  Common::Symbol* const symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
   if (!symbol)
     return;
 
   bool good;
-  int size =
+  const int size =
       QInputDialog::getInt(this, tr("Rename symbol"),
                            tr("Set symbol size (%1):").arg(QString::fromStdString(symbol->name)),
-                           symbol->size, 1, 0xFFFF, 1, &good);
+                           symbol->size, 1, 0xFFFF, 1, &good, Qt::WindowCloseButtonHint);
 
   if (!good)
     return;
@@ -696,18 +696,19 @@ void CodeViewWidget::OnSetSymbolEndAddress()
 {
   const u32 addr = GetContextAddress();
 
-  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
+  Common::Symbol* const symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
   if (!symbol)
     return;
 
   bool good;
-  QString name = QInputDialog::getText(
+  const QString name = QInputDialog::getText(
       this, tr("Set symbol end address"),
       tr("Symbol (%1) end address:").arg(QString::fromStdString(symbol->name)), QLineEdit::Normal,
-      QStringLiteral("%1").arg(addr + symbol->size, 8, 16, QLatin1Char('0')), &good);
+      QStringLiteral("%1").arg(addr + symbol->size, 8, 16, QLatin1Char('0')), &good,
+      Qt::WindowCloseButtonHint);
 
-  u32 address = name.toUInt(&good, 16);
+  const u32 address = name.toUInt(&good, 16);
 
   if (!good)
     return;

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -250,9 +250,11 @@ void WatchWidget::OnClear()
 
 void WatchWidget::OnNewWatch()
 {
-  QString text = QInputDialog::getText(this, tr("Input"), tr("Enter address to watch:"));
+  const QString text =
+      QInputDialog::getText(this, tr("Input"), tr("Enter address to watch:"), QLineEdit::Normal,
+                            QString{}, nullptr, Qt::WindowCloseButtonHint);
   bool good;
-  uint address = text.toUInt(&good, 16);
+  const uint address = text.toUInt(&good, 16);
 
   if (!good)
   {

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -1030,7 +1030,9 @@ void GameList::OnHeaderViewChanged()
 
 void GameList::NewTag()
 {
-  auto tag = QInputDialog::getText(this, tr("New tag"), tr("Name for a new tag:"));
+  const auto tag =
+      QInputDialog::getText(this, tr("New tag"), tr("Name for a new tag:"), QLineEdit::Normal,
+                            QString{}, nullptr, Qt::WindowCloseButtonHint);
 
   if (tag.isEmpty())
     return;
@@ -1040,7 +1042,9 @@ void GameList::NewTag()
 
 void GameList::DeleteTag()
 {
-  auto tag = QInputDialog::getText(this, tr("Remove tag"), tr("Name of the tag to remove:"));
+  const auto tag =
+      QInputDialog::getText(this, tr("Remove tag"), tr("Name of the tag to remove:"),
+                            QLineEdit::Normal, QString{}, nullptr, Qt::WindowCloseButtonHint);
 
   if (tag.isEmpty())
     return;

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1270,9 +1270,11 @@ void MenuBar::GenerateSymbolsFromRSO()
   if (ret == QMessageBox::Yes)
     return GenerateSymbolsFromRSOAuto();
 
-  QString text = QInputDialog::getText(this, tr("Input"), tr("Enter the RSO module address:"));
+  const QString text =
+      QInputDialog::getText(this, tr("Input"), tr("Enter the RSO module address:"),
+                            QLineEdit::Normal, QString{}, nullptr, Qt::WindowCloseButtonHint);
   bool good;
-  uint address = text.toUInt(&good, 16);
+  const uint address = text.toUInt(&good, 16);
 
   if (!good)
   {
@@ -1308,7 +1310,7 @@ void MenuBar::GenerateSymbolsFromRSOAuto()
   });
   progress.GetRaw()->exec();
 
-  auto matches = future.get();
+  const auto matches = future.get();
 
   QStringList items;
   for (const auto& match : matches)
@@ -1324,8 +1326,9 @@ void MenuBar::GenerateSymbolsFromRSOAuto()
   }
 
   bool ok;
-  const QString item = QInputDialog::getItem(
-      this, tr("Input"), tr("Select the RSO module address:"), items, 0, false, &ok);
+  const QString item =
+      QInputDialog::getItem(this, tr("Input"), tr("Select the RSO module address:"), items, 0,
+                            false, &ok, Qt::WindowCloseButtonHint);
 
   if (!ok)
     return;
@@ -1570,7 +1573,8 @@ void MenuBar::TrySaveSymbolMap(const QString& path)
 void MenuBar::CreateSignatureFile()
 {
   const QString text = QInputDialog::getText(
-      this, tr("Input"), tr("Only export symbols with prefix:\n(Blank for all symbols)"));
+      this, tr("Input"), tr("Only export symbols with prefix:\n(Blank for all symbols)"),
+      QLineEdit::Normal, QString{}, nullptr, Qt::WindowCloseButtonHint);
 
   const QString file = QFileDialog::getSaveFileName(this, tr("Save signature file"),
                                                     QDir::homePath(), GetSignatureSelector());
@@ -1594,7 +1598,8 @@ void MenuBar::CreateSignatureFile()
 void MenuBar::AppendSignatureFile()
 {
   const QString text = QInputDialog::getText(
-      this, tr("Input"), tr("Only append symbols with prefix:\n(Blank for all symbols)"));
+      this, tr("Input"), tr("Only append symbols with prefix:\n(Blank for all symbols)"),
+      QLineEdit::Normal, QString{}, nullptr, Qt::WindowCloseButtonHint);
 
   const QString file = QFileDialog::getSaveFileName(this, tr("Append signature to"),
                                                     QDir::homePath(), GetSignatureSelector());
@@ -1685,8 +1690,9 @@ void MenuBar::LogInstructions()
 void MenuBar::SearchInstruction()
 {
   bool good;
-  const QString op = QInputDialog::getText(this, tr("Search instruction"), tr("Instruction:"),
-                                           QLineEdit::Normal, QString{}, &good);
+  const QString op =
+      QInputDialog::getText(this, tr("Search instruction"), tr("Instruction:"), QLineEdit::Normal,
+                            QString{}, &good, Qt::WindowCloseButtonHint);
 
   if (!good)
     return;
@@ -1695,7 +1701,7 @@ void MenuBar::SearchInstruction()
   for (u32 addr = Memory::MEM1_BASE_ADDR; addr < Memory::MEM1_BASE_ADDR + Memory::GetRamSizeReal();
        addr += 4)
   {
-    auto ins_name =
+    const auto ins_name =
         QString::fromStdString(PPCTables::GetInstructionName(PowerPC::HostRead_U32(addr)));
     if (op == ins_name)
     {


### PR DESCRIPTION
Removes the Windows help button from a handful of dialogs. I left the XLinkKai and Ethernet dialogs alone because they're taken care of in https://github.com/dolphin-emu/dolphin/pull/10025.

Also throws a few consts around.

Fixes https://bugs.dolphin-emu.org/issues/11536.

As noted in that report there's an option to globally disable the help button, but that would require us to bump the minimum Qt version from 5.9 to 5.10. Once we do bump the version we'll want to go through and remove all the hints.