### PR TITLE
JitArm64: Disable indexed paired loadstore instructions

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -125,10 +125,10 @@ constexpr std::array<GekkoOPTemplate, 17> table4_2{{
 }};
 
 constexpr std::array<GekkoOPTemplate, 4> table4_3{{
-    {6, &JitArm64::psq_lXX},    // psq_lx
-    {7, &JitArm64::psq_stXX},   // psq_stx
-    {38, &JitArm64::psq_lXX},   // psq_lux
-    {39, &JitArm64::psq_stXX},  // psq_stux
+    {6, &JitArm64::FallBackToInterpreter},   // psq_lx (disabled for the time being due to bugs)
+    {7, &JitArm64::FallBackToInterpreter},   // psq_stx (disabled for the time being due to bugs)
+    {38, &JitArm64::FallBackToInterpreter},  // psq_lux (disabled for the time being due to bugs)
+    {39, &JitArm64::FallBackToInterpreter},  // psq_stux (disabled for the time being due to bugs)
 }};
 
 constexpr std::array<GekkoOPTemplate, 13> table19{{


### PR DESCRIPTION
Since the merge of PR #10036, we've gotten reports that the following games are broken on JitArm64:

* Sonic Heroes
* The SpongeBob SquarePants Movie
* Astérix & Obélix XXL
* The Incredibles: Rise of the Underminer

Disabling the register cache avoids the issue, so the cause of the bug might not actually have anything to do with the newly implemented instructions. Nevertheless, I don't want to ship a beta with this problem present, so I would like to disable these instructions for the time being.