### PR TITLE
Revert "DSPJit: Sign-extend acS.h to 32 bits"

### DIFF
--- a/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
@@ -704,6 +704,23 @@ OpArg DSPJitRegCache::GetReg(int reg, bool load)
   const OpArg oparg = m_regs[real_reg].loc;
   m_regs[real_reg].used = true;
 
+  // do some register specific fixup
+  switch (reg)
+  {
+  case DSP_REG_ACC0_64:
+  case DSP_REG_ACC1_64:
+    if (load)
+    {
+      // need to do this because interpreter only does 48 bits
+      // (and PutReg does the same)
+      m_emitter.SHL(64, oparg, Imm8(64 - 40));  // sign extend
+      m_emitter.SAR(64, oparg, Imm8(64 - 40));
+    }
+    break;
+  default:
+    break;
+  }
+
   return oparg;
 }
 
@@ -721,13 +738,15 @@ void DSPJitRegCache::PutReg(int reg, bool dirty)
   case DSP_REG_ACH1:
     if (dirty)
     {
+      // no need to extend to full 64bit here until interpreter
+      // uses that
       if (oparg.IsSimpleReg())
       {
         // register is already shifted correctly
         // (if at all)
 
         // sign extend from the bottom 8 bits.
-        m_emitter.MOVSX(32, 8, oparg.GetSimpleReg(), oparg);
+        m_emitter.MOVSX(16, 8, oparg.GetSimpleReg(), oparg);
       }
       else if (oparg.IsImm())
       {
@@ -740,8 +759,8 @@ void DSPJitRegCache::PutReg(int reg, bool dirty)
         // of real_reg, since it has the right loc
         X64Reg tmp = GetFreeXReg();
         // Sign extend from the bottom 8 bits.
-        m_emitter.MOVSX(32, 8, tmp, m_regs[reg].loc);
-        m_emitter.MOV(32, m_regs[reg].loc, R(tmp));
+        m_emitter.MOVSX(16, 8, tmp, m_regs[reg].loc);
+        m_emitter.MOV(16, m_regs[reg].loc, R(tmp));
         PutXReg(tmp);
       }
     }


### PR DESCRIPTION
This reverts commit dc2eab17789b39d8fcd6e32e98f8920078f08841.  That commit broke the DSP recompiler for most games (causing a large number of unknown pointer errors), similar to what happened with the DSP interpreter before [bug 12633](https://bugs.dolphin-emu.org/issues/12633) was fixed (by a different change in #10045).

I'm not entirely sure why this commit causes issues.  It may be something to do with multiple registers being stored in one host register, and thus the 32-bit operation causing one to be clobbered, but I'm not certain of this.  Reverting it for now seems to be the best choice, especially as `cond_test` has the same results with it reverted so it doesn't seem to actually make much of a difference.