### PR TITLE
VideoBackends / VideoCommon: expose ability to view shader/texture debug names

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DRender.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DRender.cpp
@@ -52,9 +52,10 @@ bool Renderer::IsHeadless() const
   return !m_swap_chain;
 }
 
-std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config)
+std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config,
+                                                         std::string_view name)
 {
-  return DXTexture::Create(config);
+  return DXTexture::Create(config, name);
 }
 
 std::unique_ptr<AbstractStagingTexture> Renderer::CreateStagingTexture(StagingTextureType type,
@@ -70,20 +71,21 @@ std::unique_ptr<AbstractFramebuffer> Renderer::CreateFramebuffer(AbstractTexture
                                static_cast<DXTexture*>(depth_attachment));
 }
 
-std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 std::string_view source)
+std::unique_ptr<AbstractShader>
+Renderer::CreateShaderFromSource(ShaderStage stage, std::string_view source, std::string_view name)
 {
   auto bytecode = DXShader::CompileShader(D3D::feature_level, stage, source);
   if (!bytecode)
     return nullptr;
 
-  return DXShader::CreateFromBytecode(stage, std::move(*bytecode));
+  return DXShader::CreateFromBytecode(stage, std::move(*bytecode), name);
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage stage,
-                                                                 const void* data, size_t length)
+                                                                 const void* data, size_t length,
+                                                                 std::string_view name)
 {
-  return DXShader::CreateFromBytecode(stage, DXShader::CreateByteCode(data, length));
+  return DXShader::CreateFromBytecode(stage, DXShader::CreateByteCode(data, length), name);
 }
 
 std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config,

--- a/Source/Core/VideoBackends/D3D/D3DRender.h
+++ b/Source/Core/VideoBackends/D3D/D3DRender.h
@@ -24,13 +24,15 @@ public:
 
   bool IsHeadless() const override;
 
-  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
+  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config,
+                                                 std::string_view name) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
-                                                         std::string_view source) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, std::string_view source,
+                                                         std::string_view name) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
-                                                         size_t length) override;
+                                                         size_t length,
+                                                         std::string_view name) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
   std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,

--- a/Source/Core/VideoBackends/D3D/DXShader.cpp
+++ b/Source/Core/VideoBackends/D3D/DXShader.cpp
@@ -7,9 +7,15 @@
 
 namespace DX11
 {
-DXShader::DXShader(ShaderStage stage, BinaryData bytecode, ID3D11DeviceChild* shader)
-    : D3DCommon::Shader(stage, std::move(bytecode)), m_shader(shader)
+DXShader::DXShader(ShaderStage stage, BinaryData bytecode, ID3D11DeviceChild* shader,
+                   std::string_view name)
+    : D3DCommon::Shader(stage, std::move(bytecode)), m_shader(shader), m_name(name)
 {
+  if (!m_name.empty())
+  {
+    m_shader->SetPrivateData(WKPDID_D3DDebugObjectName, static_cast<UINT>(m_name.size()),
+                             m_name.data());
+  }
 }
 
 DXShader::~DXShader() = default;
@@ -38,7 +44,8 @@ ID3D11ComputeShader* DXShader::GetD3DComputeShader() const
   return static_cast<ID3D11ComputeShader*>(m_shader.Get());
 }
 
-std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, BinaryData bytecode)
+std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, BinaryData bytecode,
+                                                       std::string_view name)
 {
   switch (stage)
   {
@@ -50,7 +57,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
     if (FAILED(hr))
       return nullptr;
 
-    return std::make_unique<DXShader>(ShaderStage::Vertex, std::move(bytecode), vs.Get());
+    return std::make_unique<DXShader>(ShaderStage::Vertex, std::move(bytecode), vs.Get(), name);
   }
 
   case ShaderStage::Geometry:
@@ -61,7 +68,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
     if (FAILED(hr))
       return nullptr;
 
-    return std::make_unique<DXShader>(ShaderStage::Geometry, std::move(bytecode), gs.Get());
+    return std::make_unique<DXShader>(ShaderStage::Geometry, std::move(bytecode), gs.Get(), name);
   }
   break;
 
@@ -73,7 +80,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
     if (FAILED(hr))
       return nullptr;
 
-    return std::make_unique<DXShader>(ShaderStage::Pixel, std::move(bytecode), ps.Get());
+    return std::make_unique<DXShader>(ShaderStage::Pixel, std::move(bytecode), ps.Get(), name);
   }
   break;
 
@@ -85,7 +92,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
     if (FAILED(hr))
       return nullptr;
 
-    return std::make_unique<DXShader>(ShaderStage::Compute, std::move(bytecode), cs.Get());
+    return std::make_unique<DXShader>(ShaderStage::Compute, std::move(bytecode), cs.Get(), name);
   }
   break;
 

--- a/Source/Core/VideoBackends/D3D/DXShader.h
+++ b/Source/Core/VideoBackends/D3D/DXShader.h
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
+
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3DCommon/Shader.h"
@@ -12,7 +15,8 @@ namespace DX11
 class DXShader final : public D3DCommon::Shader
 {
 public:
-  DXShader(ShaderStage stage, BinaryData bytecode, ID3D11DeviceChild* shader);
+  DXShader(ShaderStage stage, BinaryData bytecode, ID3D11DeviceChild* shader,
+           std::string_view name);
   ~DXShader() override;
 
   ID3D11VertexShader* GetD3DVertexShader() const;
@@ -20,10 +24,12 @@ public:
   ID3D11PixelShader* GetD3DPixelShader() const;
   ID3D11ComputeShader* GetD3DComputeShader() const;
 
-  static std::unique_ptr<DXShader> CreateFromBytecode(ShaderStage stage, BinaryData bytecode);
+  static std::unique_ptr<DXShader> CreateFromBytecode(ShaderStage stage, BinaryData bytecode,
+                                                      std::string_view name);
 
 private:
   ComPtr<ID3D11DeviceChild> m_shader;
+  std::string m_name;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/DXTexture.h
+++ b/Source/Core/VideoBackends/D3D/DXTexture.h
@@ -5,6 +5,8 @@
 
 #include <d3d11.h>
 #include <memory>
+#include <string>
+#include <string_view>
 #include "Common/CommonTypes.h"
 
 #include "VideoCommon/AbstractFramebuffer.h"
@@ -18,7 +20,7 @@ class DXTexture final : public AbstractTexture
 public:
   ~DXTexture();
 
-  static std::unique_ptr<DXTexture> Create(const TextureConfig& config);
+  static std::unique_ptr<DXTexture> Create(const TextureConfig& config, std::string_view name);
   static std::unique_ptr<DXTexture> CreateAdopted(ComPtr<ID3D11Texture2D> texture);
 
   void CopyRectangleFromTexture(const AbstractTexture* src,
@@ -35,7 +37,7 @@ public:
   ID3D11UnorderedAccessView* GetD3DUAV() const { return m_uav.Get(); }
 
 private:
-  DXTexture(const TextureConfig& config, ComPtr<ID3D11Texture2D> texture);
+  DXTexture(const TextureConfig& config, ComPtr<ID3D11Texture2D> texture, std::string_view name);
 
   bool CreateSRV();
   bool CreateUAV();
@@ -43,6 +45,7 @@ private:
   ComPtr<ID3D11Texture2D> m_texture;
   ComPtr<ID3D11ShaderResourceView> m_srv;
   ComPtr<ID3D11UnorderedAccessView> m_uav;
+  std::string m_name;
 };
 
 class DXStagingTexture final : public AbstractStagingTexture

--- a/Source/Core/VideoBackends/D3D12/D3D12Renderer.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12Renderer.cpp
@@ -62,9 +62,10 @@ void Renderer::Shutdown()
   ::Renderer::Shutdown();
 }
 
-std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config)
+std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config,
+                                                         std::string_view name)
 {
-  return DXTexture::Create(config);
+  return DXTexture::Create(config, name);
 }
 
 std::unique_ptr<AbstractStagingTexture> Renderer::CreateStagingTexture(StagingTextureType type,
@@ -80,16 +81,17 @@ std::unique_ptr<AbstractFramebuffer> Renderer::CreateFramebuffer(AbstractTexture
                                static_cast<DXTexture*>(depth_attachment));
 }
 
-std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 std::string_view source)
+std::unique_ptr<AbstractShader>
+Renderer::CreateShaderFromSource(ShaderStage stage, std::string_view source, std::string_view name)
 {
-  return DXShader::CreateFromSource(stage, source);
+  return DXShader::CreateFromSource(stage, source, name);
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage stage,
-                                                                 const void* data, size_t length)
+                                                                 const void* data, size_t length,
+                                                                 std::string_view name)
 {
-  return DXShader::CreateFromBytecode(stage, DXShader::CreateByteCode(data, length));
+  return DXShader::CreateFromBytecode(stage, DXShader::CreateByteCode(data, length), name);
 }
 
 std::unique_ptr<NativeVertexFormat>

--- a/Source/Core/VideoBackends/D3D12/D3D12Renderer.h
+++ b/Source/Core/VideoBackends/D3D12/D3D12Renderer.h
@@ -30,16 +30,18 @@ public:
   bool Initialize() override;
   void Shutdown() override;
 
-  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
+  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config,
+                                                 std::string_view name) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
-                                                         std::string_view source) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, std::string_view source,
+                                                         std::string_view name) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
-                                                         size_t length) override;
+                                                         size_t length,
+                                                         std::string_view name) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
   std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,

--- a/Source/Core/VideoBackends/D3D12/DX12Shader.h
+++ b/Source/Core/VideoBackends/D3D12/DX12Shader.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <string_view>
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3DCommon/Shader.h"
@@ -18,15 +19,19 @@ public:
   ID3D12PipelineState* GetComputePipeline() const { return m_compute_pipeline.Get(); }
   D3D12_SHADER_BYTECODE GetD3DByteCode() const;
 
-  static std::unique_ptr<DXShader> CreateFromBytecode(ShaderStage stage, BinaryData bytecode);
-  static std::unique_ptr<DXShader> CreateFromSource(ShaderStage stage, std::string_view source);
+  static std::unique_ptr<DXShader> CreateFromBytecode(ShaderStage stage, BinaryData bytecode,
+                                                      std::string_view name);
+  static std::unique_ptr<DXShader> CreateFromSource(ShaderStage stage, std::string_view source,
+                                                    std::string_view name);
 
 private:
-  DXShader(ShaderStage stage, BinaryData bytecode);
+  DXShader(ShaderStage stage, BinaryData bytecode, std::string_view name);
 
   bool CreateComputePipeline();
 
   ComPtr<ID3D12PipelineState> m_compute_pipeline;
+
+  std::wstring m_name;
 };
 
 }  // namespace DX12

--- a/Source/Core/VideoBackends/D3D12/DX12Texture.h
+++ b/Source/Core/VideoBackends/D3D12/DX12Texture.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <string_view>
 #include "Common/CommonTypes.h"
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"
@@ -18,7 +20,7 @@ class DXTexture final : public AbstractTexture
 public:
   ~DXTexture();
 
-  static std::unique_ptr<DXTexture> Create(const TextureConfig& config);
+  static std::unique_ptr<DXTexture> Create(const TextureConfig& config, std::string_view name);
   static std::unique_ptr<DXTexture> CreateAdopted(ID3D12Resource* resource);
 
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
@@ -43,7 +45,8 @@ public:
   void DestroyResource();
 
 private:
-  DXTexture(const TextureConfig& config, ID3D12Resource* resource, D3D12_RESOURCE_STATES state);
+  DXTexture(const TextureConfig& config, ID3D12Resource* resource, D3D12_RESOURCE_STATES state,
+            std::string_view name);
 
   bool CreateSRVDescriptor();
   bool CreateUAVDescriptor();
@@ -51,6 +54,8 @@ private:
   ComPtr<ID3D12Resource> m_resource;
   DescriptorHandle m_srv_descriptor = {};
   DescriptorHandle m_uav_descriptor = {};
+
+  std::wstring m_name;
 
   mutable D3D12_RESOURCE_STATES m_state;
 };

--- a/Source/Core/VideoBackends/Null/NullRender.cpp
+++ b/Source/Core/VideoBackends/Null/NullRender.cpp
@@ -28,7 +28,8 @@ bool Renderer::IsHeadless() const
   return true;
 }
 
-std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config)
+std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config,
+                                                         [[maybe_unused]] std::string_view name)
 {
   return std::make_unique<NullTexture>(config);
 }
@@ -46,13 +47,15 @@ public:
 };
 
 std::unique_ptr<AbstractShader>
-Renderer::CreateShaderFromSource(ShaderStage stage, [[maybe_unused]] std::string_view source)
+Renderer::CreateShaderFromSource(ShaderStage stage, [[maybe_unused]] std::string_view source,
+                                 [[maybe_unused]] std::string_view name)
 {
   return std::make_unique<NullShader>(stage);
 }
 
-std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage stage,
-                                                                 const void* data, size_t length)
+std::unique_ptr<AbstractShader>
+Renderer::CreateShaderFromBinary(ShaderStage stage, const void* data, size_t length,
+                                 [[maybe_unused]] std::string_view name)
 {
   return std::make_unique<NullShader>(stage);
 }

--- a/Source/Core/VideoBackends/Null/NullRender.h
+++ b/Source/Core/VideoBackends/Null/NullRender.h
@@ -15,16 +15,18 @@ public:
 
   bool IsHeadless() const override;
 
-  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
+  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config,
+                                                 std::string_view name) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
-                                                         std::string_view source) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, std::string_view source,
+                                                         std::string_view name) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
-                                                         size_t length) override;
+                                                         size_t length,
+                                                         std::string_view name) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
   std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,

--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -807,9 +807,10 @@ void Renderer::Shutdown()
   glDeleteFramebuffers(1, &m_shared_read_framebuffer);
 }
 
-std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config)
+std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config,
+                                                         std::string_view name)
 {
-  return std::make_unique<OGLTexture>(config);
+  return std::make_unique<OGLTexture>(config, name);
 }
 
 std::unique_ptr<AbstractStagingTexture> Renderer::CreateStagingTexture(StagingTextureType type,
@@ -825,14 +826,15 @@ std::unique_ptr<AbstractFramebuffer> Renderer::CreateFramebuffer(AbstractTexture
                                 static_cast<OGLTexture*>(depth_attachment));
 }
 
-std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 std::string_view source)
+std::unique_ptr<AbstractShader>
+Renderer::CreateShaderFromSource(ShaderStage stage, std::string_view source, std::string_view name)
 {
-  return OGLShader::CreateFromSource(stage, source);
+  return OGLShader::CreateFromSource(stage, source, name);
 }
 
-std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage stage,
-                                                                 const void* data, size_t length)
+std::unique_ptr<AbstractShader>
+Renderer::CreateShaderFromBinary(ShaderStage stage, const void* data, size_t length,
+                                 [[maybe_unused]] std::string_view name)
 {
   return nullptr;
 }

--- a/Source/Core/VideoBackends/OGL/OGLRender.h
+++ b/Source/Core/VideoBackends/OGL/OGLRender.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <string>
+#include <string_view>
 
 #include "Common/GL/GLContext.h"
 #include "Common/GL/GLExtensions/GLExtensions.h"
@@ -91,13 +92,15 @@ public:
   bool Initialize() override;
   void Shutdown() override;
 
-  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
+  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config,
+                                                 std::string_view name) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
-                                                         std::string_view source) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, std::string_view source,
+                                                         std::string_view name) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
-                                                         size_t length) override;
+                                                         size_t length,
+                                                         std::string_view name) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
   std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,

--- a/Source/Core/VideoBackends/OGL/OGLShader.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLShader.cpp
@@ -23,17 +23,26 @@ static GLenum GetGLShaderTypeForStage(ShaderStage stage)
   }
 }
 
-OGLShader::OGLShader(ShaderStage stage, GLenum gl_type, GLuint gl_id, std::string source)
+OGLShader::OGLShader(ShaderStage stage, GLenum gl_type, GLuint gl_id, std::string source,
+                     std::string name)
     : AbstractShader(stage), m_id(ProgramShaderCache::GenerateShaderID()), m_type(gl_type),
-      m_gl_id(gl_id), m_source(std::move(source))
+      m_gl_id(gl_id), m_source(std::move(source)), m_name(std::move(name))
 {
+  if (!m_name.empty())
+  {
+    glObjectLabel(GetGLShaderTypeForStage(stage), m_gl_id, -1, m_name.c_str());
+  }
 }
 
-OGLShader::OGLShader(GLuint gl_compute_program_id, std::string source)
+OGLShader::OGLShader(GLuint gl_compute_program_id, std::string source, std::string name)
     : AbstractShader(ShaderStage::Compute), m_id(ProgramShaderCache::GenerateShaderID()),
       m_type(GL_COMPUTE_SHADER), m_gl_compute_program_id(gl_compute_program_id),
-      m_source(std::move(source))
+      m_source(std::move(source)), m_name(std::move(name))
 {
+  if (!m_name.empty())
+  {
+    glObjectLabel(GL_COMPUTE_SHADER, m_gl_compute_program_id, -1, m_name.c_str());
+  }
 }
 
 OGLShader::~OGLShader()
@@ -44,9 +53,11 @@ OGLShader::~OGLShader()
     glDeleteProgram(m_gl_compute_program_id);
 }
 
-std::unique_ptr<OGLShader> OGLShader::CreateFromSource(ShaderStage stage, std::string_view source)
+std::unique_ptr<OGLShader> OGLShader::CreateFromSource(ShaderStage stage, std::string_view source,
+                                                       std::string_view name)
 {
   std::string source_str(source);
+  std::string name_str(name);
   if (stage != ShaderStage::Compute)
   {
     GLenum shader_type = GetGLShaderTypeForStage(stage);
@@ -54,14 +65,15 @@ std::unique_ptr<OGLShader> OGLShader::CreateFromSource(ShaderStage stage, std::s
     if (!shader_id)
       return nullptr;
 
-    return std::make_unique<OGLShader>(stage, shader_type, shader_id, std::move(source_str));
+    return std::make_unique<OGLShader>(stage, shader_type, shader_id, std::move(source_str),
+                                       std::move(name_str));
   }
 
   // Compute shaders.
   SHADER prog;
   if (!ProgramShaderCache::CompileComputeShader(prog, source_str))
     return nullptr;
-  return std::make_unique<OGLShader>(prog.glprogid, std::move(source_str));
+  return std::make_unique<OGLShader>(prog.glprogid, std::move(source_str), std::move(name_str));
 }
 
 }  // namespace OGL

--- a/Source/Core/VideoBackends/OGL/OGLShader.h
+++ b/Source/Core/VideoBackends/OGL/OGLShader.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <string_view>
 
 #include "Common/CommonTypes.h"
@@ -16,8 +17,9 @@ namespace OGL
 class OGLShader final : public AbstractShader
 {
 public:
-  explicit OGLShader(ShaderStage stage, GLenum gl_type, GLuint gl_id, std::string source);
-  explicit OGLShader(GLuint gl_compute_program_id, std::string source);
+  explicit OGLShader(ShaderStage stage, GLenum gl_type, GLuint gl_id, std::string source,
+                     std::string name);
+  explicit OGLShader(GLuint gl_compute_program_id, std::string source, std::string name);
   ~OGLShader() override;
 
   u64 GetID() const { return m_id; }
@@ -26,7 +28,8 @@ public:
   GLuint GetGLComputeProgramID() const { return m_gl_compute_program_id; }
   const std::string& GetSource() const { return m_source; }
 
-  static std::unique_ptr<OGLShader> CreateFromSource(ShaderStage stage, std::string_view source);
+  static std::unique_ptr<OGLShader> CreateFromSource(ShaderStage stage, std::string_view source,
+                                                     std::string_view name);
 
 private:
   u64 m_id;
@@ -34,6 +37,7 @@ private:
   GLuint m_gl_id = 0;
   GLuint m_gl_compute_program_id = 0;
   std::string m_source;
+  std::string m_name;
 };
 
 }  // namespace OGL

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -104,7 +104,8 @@ bool UsePersistentStagingBuffers()
 }
 }  // Anonymous namespace
 
-OGLTexture::OGLTexture(const TextureConfig& tex_config) : AbstractTexture(tex_config)
+OGLTexture::OGLTexture(const TextureConfig& tex_config, std::string_view name)
+    : AbstractTexture(tex_config), m_name(name)
 {
   DEBUG_ASSERT_MSG(VIDEO, !tex_config.IsMultisampled() || tex_config.levels == 1,
                    "OpenGL does not support multisampled textures with mip levels");
@@ -113,6 +114,11 @@ OGLTexture::OGLTexture(const TextureConfig& tex_config) : AbstractTexture(tex_co
   glGenTextures(1, &m_texId);
   glActiveTexture(GL_MUTABLE_TEXTURE_INDEX);
   glBindTexture(target, m_texId);
+
+  if (!m_name.empty())
+  {
+    glObjectLabel(GL_TEXTURE, m_texId, -1, m_name.c_str());
+  }
 
   glTexParameteri(target, GL_TEXTURE_MAX_LEVEL, m_config.levels - 1);
 

--- a/Source/Core/VideoBackends/OGL/OGLTexture.h
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "Common/GL/GLUtil.h"
@@ -17,7 +19,7 @@ namespace OGL
 class OGLTexture final : public AbstractTexture
 {
 public:
-  explicit OGLTexture(const TextureConfig& tex_config);
+  explicit OGLTexture(const TextureConfig& tex_config, std::string_view name);
   ~OGLTexture();
 
   void CopyRectangleFromTexture(const AbstractTexture* src,
@@ -42,6 +44,7 @@ private:
                        u32 dst_layer, u32 dst_level);
 
   GLuint m_texId;
+  std::string m_name;
 };
 
 class OGLStagingTexture final : public AbstractStagingTexture

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -38,7 +38,8 @@ bool SWRenderer::IsHeadless() const
   return m_window->IsHeadless();
 }
 
-std::unique_ptr<AbstractTexture> SWRenderer::CreateTexture(const TextureConfig& config)
+std::unique_ptr<AbstractTexture> SWRenderer::CreateTexture(const TextureConfig& config,
+                                                           [[maybe_unused]] std::string_view name)
 {
   return std::make_unique<SWTexture>(config);
 }
@@ -78,13 +79,15 @@ public:
 };
 
 std::unique_ptr<AbstractShader>
-SWRenderer::CreateShaderFromSource(ShaderStage stage, [[maybe_unused]] std::string_view source)
+SWRenderer::CreateShaderFromSource(ShaderStage stage, [[maybe_unused]] std::string_view source,
+                                   [[maybe_unused]] std::string_view name)
 {
   return std::make_unique<SWShader>(stage);
 }
 
-std::unique_ptr<AbstractShader> SWRenderer::CreateShaderFromBinary(ShaderStage stage,
-                                                                   const void* data, size_t length)
+std::unique_ptr<AbstractShader>
+SWRenderer::CreateShaderFromBinary(ShaderStage stage, const void* data, size_t length,
+                                   [[maybe_unused]] std::string_view name)
 {
   return std::make_unique<SWShader>(stage);
 }

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 
 #include "Common/CommonTypes.h"
 
@@ -20,7 +21,8 @@ public:
 
   bool IsHeadless() const override;
 
-  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
+  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config,
+                                                 std::string_view name) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;
   std::unique_ptr<AbstractFramebuffer>
@@ -28,10 +30,11 @@ public:
 
   void BindBackbuffer(const ClearColor& clear_color = {}) override;
 
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
-                                                         std::string_view source) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, std::string_view source,
+                                                         std::string_view name) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
-                                                         size_t length) override;
+                                                         size_t length,
+                                                         std::string_view name) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
   std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -58,7 +58,7 @@ bool StateTracker::Initialize()
 {
   // Create a dummy texture which can be used in place of a real binding.
   m_dummy_texture =
-      VKTexture::Create(TextureConfig(1, 1, 1, 1, 1, AbstractTextureFormat::RGBA8, 0));
+      VKTexture::Create(TextureConfig(1, 1, 1, 1, 1, AbstractTextureFormat::RGBA8, 0), "");
   if (!m_dummy_texture)
     return false;
   m_dummy_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentInitCommandBuffer(),

--- a/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKRenderer.cpp
@@ -82,9 +82,10 @@ void Renderer::Shutdown()
   m_swap_chain.reset();
 }
 
-std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config)
+std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config,
+                                                         std::string_view name)
 {
-  return VKTexture::Create(config);
+  return VKTexture::Create(config, name);
 }
 
 std::unique_ptr<AbstractStagingTexture> Renderer::CreateStagingTexture(StagingTextureType type,
@@ -93,16 +94,17 @@ std::unique_ptr<AbstractStagingTexture> Renderer::CreateStagingTexture(StagingTe
   return VKStagingTexture::Create(type, config);
 }
 
-std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 std::string_view source)
+std::unique_ptr<AbstractShader>
+Renderer::CreateShaderFromSource(ShaderStage stage, std::string_view source, std::string_view name)
 {
-  return VKShader::CreateFromSource(stage, source);
+  return VKShader::CreateFromSource(stage, source, name);
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage stage,
-                                                                 const void* data, size_t length)
+                                                                 const void* data, size_t length,
+                                                                 std::string_view name)
 {
-  return VKShader::CreateFromBinary(stage, data, length);
+  return VKShader::CreateFromBinary(stage, data, length, name);
 }
 
 std::unique_ptr<NativeVertexFormat>

--- a/Source/Core/VideoBackends/Vulkan/VKRenderer.h
+++ b/Source/Core/VideoBackends/Vulkan/VKRenderer.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <string_view>
 
 #include "Common/CommonTypes.h"
 #include "VideoBackends/Vulkan/Constants.h"
@@ -35,16 +36,18 @@ public:
   bool Initialize() override;
   void Shutdown() override;
 
-  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
+  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config,
+                                                 std::string_view name) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
-                                                         std::string_view source) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, std::string_view source,
+                                                         std::string_view name) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
-                                                         size_t length) override;
+                                                         size_t length,
+                                                         std::string_view name) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
   std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,

--- a/Source/Core/VideoBackends/Vulkan/VKShader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.cpp
@@ -11,16 +11,35 @@
 
 namespace Vulkan
 {
-VKShader::VKShader(ShaderStage stage, std::vector<u32> spv, VkShaderModule mod)
+VKShader::VKShader(ShaderStage stage, std::vector<u32> spv, VkShaderModule mod,
+                   std::string_view name)
     : AbstractShader(stage), m_spv(std::move(spv)), m_module(mod),
-      m_compute_pipeline(VK_NULL_HANDLE)
+      m_compute_pipeline(VK_NULL_HANDLE), m_name(name)
 {
+  if (!m_name.empty())
+  {
+    VkDebugUtilsObjectNameInfoEXT name_info = {};
+    name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+    name_info.objectType = VK_OBJECT_TYPE_SHADER_MODULE;
+    name_info.objectHandle = reinterpret_cast<uint64_t>(m_module);
+    name_info.pObjectName = m_name.data();
+    vkSetDebugUtilsObjectNameEXT(g_vulkan_context->GetDevice(), &name_info);
+  }
 }
 
-VKShader::VKShader(std::vector<u32> spv, VkPipeline compute_pipeline)
+VKShader::VKShader(std::vector<u32> spv, VkPipeline compute_pipeline, std::string_view name)
     : AbstractShader(ShaderStage::Compute), m_spv(std::move(spv)), m_module(VK_NULL_HANDLE),
-      m_compute_pipeline(compute_pipeline)
+      m_compute_pipeline(compute_pipeline), m_name(name)
 {
+  if (!m_name.empty())
+  {
+    VkDebugUtilsObjectNameInfoEXT name_info = {};
+    name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+    name_info.objectType = VK_OBJECT_TYPE_PIPELINE;
+    name_info.objectHandle = reinterpret_cast<uint64_t>(m_compute_pipeline);
+    name_info.pObjectName = m_name.data();
+    vkSetDebugUtilsObjectNameEXT(g_vulkan_context->GetDevice(), &name_info);
+  }
 }
 
 VKShader::~VKShader()
@@ -38,8 +57,8 @@ AbstractShader::BinaryData VKShader::GetBinary() const
   return ret;
 }
 
-static std::unique_ptr<VKShader> CreateShaderObject(ShaderStage stage,
-                                                    ShaderCompiler::SPIRVCodeVector spv)
+static std::unique_ptr<VKShader>
+CreateShaderObject(ShaderStage stage, ShaderCompiler::SPIRVCodeVector spv, std::string_view name)
 {
   VkShaderModuleCreateInfo info = {};
   info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
@@ -56,7 +75,7 @@ static std::unique_ptr<VKShader> CreateShaderObject(ShaderStage stage,
 
   // If it's a graphics shader, we defer pipeline creation.
   if (stage != ShaderStage::Compute)
-    return std::make_unique<VKShader>(stage, std::move(spv), mod);
+    return std::make_unique<VKShader>(stage, std::move(spv), mod, name);
 
   // If it's a compute shader, we create the pipeline straight away.
   const VkComputePipelineCreateInfo pipeline_info = {
@@ -82,10 +101,11 @@ static std::unique_ptr<VKShader> CreateShaderObject(ShaderStage stage,
     return nullptr;
   }
 
-  return std::make_unique<VKShader>(std::move(spv), pipeline);
+  return std::make_unique<VKShader>(std::move(spv), pipeline, name);
 }
 
-std::unique_ptr<VKShader> VKShader::CreateFromSource(ShaderStage stage, std::string_view source)
+std::unique_ptr<VKShader> VKShader::CreateFromSource(ShaderStage stage, std::string_view source,
+                                                     std::string_view name)
 {
   std::optional<ShaderCompiler::SPIRVCodeVector> spv;
   switch (stage)
@@ -109,11 +129,11 @@ std::unique_ptr<VKShader> VKShader::CreateFromSource(ShaderStage stage, std::str
   if (!spv)
     return nullptr;
 
-  return CreateShaderObject(stage, std::move(*spv));
+  return CreateShaderObject(stage, std::move(*spv), name);
 }
 
 std::unique_ptr<VKShader> VKShader::CreateFromBinary(ShaderStage stage, const void* data,
-                                                     size_t length)
+                                                     size_t length, std::string_view name)
 {
   const size_t size_in_words = Common::AlignUp(length, sizeof(ShaderCompiler::SPIRVCodeType)) /
                                sizeof(ShaderCompiler::SPIRVCodeType);
@@ -121,7 +141,7 @@ std::unique_ptr<VKShader> VKShader::CreateFromBinary(ShaderStage stage, const vo
   if (length > 0)
     std::memcpy(spv.data(), data, length);
 
-  return CreateShaderObject(stage, std::move(spv));
+  return CreateShaderObject(stage, std::move(spv), name);
 }
 
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/VKShader.h
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -17,22 +18,24 @@ namespace Vulkan
 class VKShader final : public AbstractShader
 {
 public:
-  VKShader(ShaderStage stage, std::vector<u32> spv, VkShaderModule mod);
-  VKShader(std::vector<u32> spv, VkPipeline compute_pipeline);
+  VKShader(ShaderStage stage, std::vector<u32> spv, VkShaderModule mod, std::string_view name);
+  VKShader(std::vector<u32> spv, VkPipeline compute_pipeline, std::string_view name);
   ~VKShader() override;
 
   VkShaderModule GetShaderModule() const { return m_module; }
   VkPipeline GetComputePipeline() const { return m_compute_pipeline; }
   BinaryData GetBinary() const override;
 
-  static std::unique_ptr<VKShader> CreateFromSource(ShaderStage stage, std::string_view source);
+  static std::unique_ptr<VKShader> CreateFromSource(ShaderStage stage, std::string_view source,
+                                                    std::string_view name);
   static std::unique_ptr<VKShader> CreateFromBinary(ShaderStage stage, const void* data,
-                                                    size_t length);
+                                                    size_t length, std::string_view name);
 
 private:
   std::vector<u32> m_spv;
   VkShaderModule m_module;
   VkPipeline m_compute_pipeline;
+  std::string m_name;
 };
 
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include "VideoBackends/Vulkan/VulkanLoader.h"
 #include "VideoCommon/AbstractFramebuffer.h"
@@ -29,7 +31,7 @@ public:
 
   VKTexture() = delete;
   VKTexture(const TextureConfig& tex_config, VkDeviceMemory device_memory, VkImage image,
-            VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED,
+            std::string_view name, VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED,
             ComputeImageLayout compute_layout = ComputeImageLayout::Undefined);
   ~VKTexture();
 
@@ -55,7 +57,7 @@ public:
   VkFormat GetVkFormat() const { return GetVkFormatForHostTextureFormat(m_config.format); }
   bool IsAdopted() const { return m_device_memory != VkDeviceMemory(VK_NULL_HANDLE); }
 
-  static std::unique_ptr<VKTexture> Create(const TextureConfig& tex_config);
+  static std::unique_ptr<VKTexture> Create(const TextureConfig& tex_config, std::string_view name);
   static std::unique_ptr<VKTexture>
   CreateAdopted(const TextureConfig& tex_config, VkImage image,
                 VkImageViewType view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY,
@@ -77,6 +79,7 @@ private:
   VkImageView m_view = VK_NULL_HANDLE;
   mutable VkImageLayout m_layout = VK_IMAGE_LAYOUT_UNDEFINED;
   mutable ComputeImageLayout m_compute_layout = ComputeImageLayout::Undefined;
+  std::string m_name;
 };
 
 class VKStagingTexture final : public AbstractStagingTexture

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -223,6 +223,7 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
 
   AddExtension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, false);
   AddExtension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, false);
+  AddExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, false);
 
   return true;
 }

--- a/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
+++ b/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
@@ -197,4 +197,6 @@ VULKAN_DEVICE_ENTRY_POINT(vkAcquireFullScreenExclusiveModeEXT, false)
 VULKAN_DEVICE_ENTRY_POINT(vkReleaseFullScreenExclusiveModeEXT, false)
 #endif
 
+VULKAN_DEVICE_ENTRY_POINT(vkSetDebugUtilsObjectNameEXT, false)
+
 #endif  // VULKAN_DEVICE_ENTRY_POINT

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -93,7 +93,8 @@ public:
   virtual bool IsFullscreen() const { return false; }
   virtual void BeginUtilityDrawing();
   virtual void EndUtilityDrawing();
-  virtual std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) = 0;
+  virtual std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config,
+                                                         std::string_view name = "") = 0;
   virtual std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) = 0;
   virtual std::unique_ptr<AbstractFramebuffer>
@@ -125,9 +126,11 @@ public:
 
   // Shader modules/objects.
   virtual std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
-                                                                 std::string_view source) = 0;
-  virtual std::unique_ptr<AbstractShader>
-  CreateShaderFromBinary(ShaderStage stage, const void* data, size_t length) = 0;
+                                                                 std::string_view source,
+                                                                 std::string_view name = "") = 0;
+  virtual std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage,
+                                                                 const void* data, size_t length,
+                                                                 std::string_view name = "") = 0;
   virtual std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) = 0;
   virtual std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,


### PR DESCRIPTION
This gives the ability to view an application defined name for our Shaders/Textures in applications like RenderDoc.  Currently nothing takes advantage of this but a future feature will.  Breaking it out to make it easier to review.