### PR TITLE
Add an option to abort when a panic alert occurs

### DIFF
--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -4,6 +4,7 @@
 #include "Common/MsgHandler.h"
 
 #include <cstdarg>
+#include <cstdlib>
 #include <string>
 
 #ifdef _WIN32
@@ -51,6 +52,7 @@ std::string DefaultStringTranslator(const char* text)
 MsgAlertHandler s_msg_handler = DefaultMsgHandler;
 StringTranslator s_str_translator = DefaultStringTranslator;
 bool s_alert_enabled = true;
+bool s_abort_on_panic_alert = false;
 
 const char* GetCaption(MsgType style)
 {
@@ -94,6 +96,11 @@ void SetEnableAlert(bool enable)
   s_alert_enabled = enable;
 }
 
+void SetAbortOnPanicAlert(bool should_abort)
+{
+  s_abort_on_panic_alert = should_abort;
+}
+
 std::string GetStringT(const char* string)
 {
   return s_str_translator(string);
@@ -113,6 +120,12 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
   va_end(args);
 
   ERROR_LOG_FMT(MASTER_LOG, "{}: {}", caption, buffer);
+
+  // Panic alerts.
+  if (style == MsgType::Warning && s_abort_on_panic_alert)
+  {
+    std::abort();
+  }
 
   // Don't ignore questions, especially AskYesNo, PanicYesNo could be ignored
   if (s_msg_handler != nullptr &&

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -49,6 +49,7 @@ bool MsgAlertFmt(bool yes_no, MsgType style, const S& format, const Args&... arg
 }
 
 void SetEnableAlert(bool enable);
+void SetAbortOnPanicAlert(bool should_abort);
 
 // Like fmt::format, except the string becomes translatable
 template <typename... Args>

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -177,6 +177,7 @@ const Info<int> MAIN_NETWORK_TIMEOUT{{System::Main, "Network", "NetworkTimeout"}
 const Info<bool> MAIN_USE_HIGH_CONTRAST_TOOLTIPS{
     {System::Main, "Interface", "UseHighContrastTooltips"}, true};
 const Info<bool> MAIN_USE_PANIC_HANDLERS{{System::Main, "Interface", "UsePanicHandlers"}, true};
+const Info<bool> MAIN_ABORT_ON_PANIC_ALERT{{System::Main, "Interface", "AbortOnPanicAlert"}, false};
 const Info<bool> MAIN_OSD_MESSAGES{{System::Main, "Interface", "OnScreenDisplayMessages"}, true};
 const Info<bool> MAIN_SKIP_NKIT_WARNING{{System::Main, "Interface", "SkipNKitWarning"}, false};
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -142,6 +142,7 @@ extern const Info<int> MAIN_NETWORK_TIMEOUT;
 
 extern const Info<bool> MAIN_USE_HIGH_CONTRAST_TOOLTIPS;
 extern const Info<bool> MAIN_USE_PANIC_HANDLERS;
+extern const Info<bool> MAIN_ABORT_ON_PANIC_ALERT;
 extern const Info<bool> MAIN_OSD_MESSAGES;
 extern const Info<bool> MAIN_SKIP_NKIT_WARNING;
 

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -68,10 +68,8 @@ bool IsSettingSaveable(const Config::Location& config_location)
       // Main.Interface
 
       &Config::MAIN_USE_PANIC_HANDLERS.GetLocation(),
+      &Config::MAIN_ABORT_ON_PANIC_ALERT.GetLocation(),
       &Config::MAIN_OSD_MESSAGES.GetLocation(),
-
-      // Main.Interface
-
       &Config::MAIN_SKIP_NKIT_WARNING.GetLocation(),
 
       // UI.General

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -102,6 +102,7 @@ void Init()
   VideoBackendBase::ActivateBackend(Config::Get(Config::MAIN_GFX_BACKEND));
 
   Common::SetEnableAlert(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
+  Common::SetAbortOnPanicAlert(Config::Get(Config::MAIN_ABORT_ON_PANIC_ALERT));
 }
 
 void Shutdown()


### PR DESCRIPTION
Prompted by https://dolphin.ci/#/builders/24/builds/985

A 1-character typo in a recent PR caused FifoCI builds to break
horribly and spew millions of panic alerts until buildbot crashed.

This PR adds a new config option -- defaulting to off -- that allows
Dolphin to abort early on when a panic alert occurs instead of
continuing forever.