### PR TITLE
DolphinQt: Remove WA_PaintOnScreen attribute from RenderWidget

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -96,7 +96,6 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
 
   // We need a native window to render into.
   setAttribute(Qt::WA_NativeWindow);
-  setAttribute(Qt::WA_PaintOnScreen);
 }
 
 QPaintEngine* RenderWidget::paintEngine() const


### PR DESCRIPTION
The attribute prevents the render widget from being resized with the mouse and I see no reason why it was there in the first place.