### PR TITLE
GameINI: Add Vertex Rounding to Scooby-Doo: Night of 100 Frights

### DIFF
--- a/Data/Sys/GameSettings/GIH.ini
+++ b/Data/Sys/GameSettings/GIH.ini
@@ -1,0 +1,18 @@
+# GIHE78, GIHP78, GIHF78, GIHD78 - Scooby-Doo! Night of 100 Frights
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+# Fixes offset in upper left of screen at higher resolutions.
+# Option has no effect at 1x IR, so no reason not to enable.
+VertexRounding = True


### PR DESCRIPTION
This game is the earliest of Heavy Iron Studios' Gamecube games and has a similar offset issue to that of the SpongeBob and Incredibles games.  While they weren't offsetting it and breaking shadows like the other games, there's still an offset in the upper left corner of the screen, which is noticeable at 3x IR or higher.  This fixes that, and has no effect at 1x IR, so it's safe to enable by default.