### PR TITLE
MMU: Tidy up PTE-related code

### DIFF
--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -770,24 +770,6 @@ union UReg_THRM3
   explicit UReg_THRM3(u32 hex_) : Hex{hex_} {}
 };
 
-union UReg_PTE
-{
-  BitField<0, 6, u64> API;
-  BitField<6, 1, u64> H;
-  BitField<7, 24, u64> VSID;
-  BitField<31, 1, u64> V;
-  BitField<32, 2, u64> PP;
-  BitField<34, 1, u64> reserved_1;
-  BitField<35, 4, u64> WIMG;
-  BitField<39, 1, u64> C;
-  BitField<40, 1, u64> R;
-  BitField<41, 3, u64> reserved_2;
-  BitField<44, 20, u64> RPN;
-
-  u64 Hex = 0;
-  u32 Hex32[2];
-};
-
 union UPTE_Lo
 {
   BitField<0, 6, u32> API;

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -721,6 +721,27 @@ union UReg_BAT_Lo
   explicit UReg_BAT_Lo(u32 hex_) : Hex{hex_} {}
 };
 
+// Segment register
+union UReg_SR
+{
+  BitField<0, 24, u32> VSID;      // Virtual segment ID
+  BitField<24, 4, u32> reserved;  // Reserved
+  BitField<28, 1, u32> N;         // No-execute protection
+  BitField<29, 1, u32> Kp;        // User-state protection
+  BitField<30, 1, u32> Ks;        // Supervisor-state protection
+  BitField<31, 1, u32> T;         // Segment register format selector
+
+  // These override other fields if T = 1
+
+  BitField<0, 20, u32> CNTLR_SPEC;  // Device-specific data for I/O controller
+  BitField<20, 9, u32> BUID;        // Bus unit ID
+
+  u32 Hex = 0;
+
+  UReg_SR() = default;
+  explicit UReg_SR(u32 hex_) : Hex{hex_} {}
+};
+
 union UReg_THRM12
 {
   BitField<0, 1, u32> V;    // Valid

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -611,11 +611,14 @@ union UReg_HID4
 // SDR1 - Page Table format
 union UReg_SDR1
 {
-  BitField<0, 16, u32> htaborg;
-  BitField<16, 7, u32> reserved;
-  BitField<23, 9, u32> htabmask;
+  BitField<0, 9, u32> htabmask;
+  BitField<9, 7, u32> reserved;
+  BitField<16, 16, u32> htaborg;
 
   u32 Hex = 0;
+
+  UReg_SDR1() = default;
+  explicit UReg_SDR1(u32 hex_) : Hex{hex_} {}
 };
 
 // MMCR0 - Monitor Mode Control Register 0 format

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -764,6 +764,35 @@ union UReg_PTE
   u32 Hex32[2];
 };
 
+union UPTE_Lo
+{
+  BitField<0, 6, u32> API;
+  BitField<6, 1, u32> H;
+  BitField<7, 24, u32> VSID;
+  BitField<31, 1, u32> V;
+
+  u32 Hex = 0;
+
+  UPTE_Lo() = default;
+  explicit UPTE_Lo(u32 hex_) : Hex{hex_} {}
+};
+
+union UPTE_Hi
+{
+  BitField<0, 2, u32> PP;
+  BitField<2, 1, u32> reserved_1;
+  BitField<3, 4, u32> WIMG;
+  BitField<7, 1, u32> C;
+  BitField<8, 1, u32> R;
+  BitField<9, 3, u32> reserved_2;
+  BitField<12, 20, u32> RPN;
+
+  u32 Hex = 0;
+
+  UPTE_Hi() = default;
+  explicit UPTE_Hi(u32 hex_) : Hex{hex_} {}
+};
+
 //
 // --- Gekko Types and Defs ---
 //

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1171,29 +1171,31 @@ TranslateResult JitCache_TranslateAddress(u32 address)
 // Hey! these duplicate a structure in Gekko.h
 union UPTE1
 {
-  struct
-  {
-    u32 API : 6;
-    u32 H : 1;
-    u32 VSID : 24;
-    u32 V : 1;
-  };
-  u32 Hex;
+  BitField<0, 6, u32> API;
+  BitField<6, 1, u32> H;
+  BitField<7, 24, u32> VSID;
+  BitField<31, 1, u32> V;
+
+  u32 Hex = 0;
+
+  UPTE1() = default;
+  explicit UPTE1(u32 hex_) : Hex{hex_} {}
 };
 
 union UPTE2
 {
-  struct
-  {
-    u32 PP : 2;
-    u32 : 1;
-    u32 WIMG : 4;
-    u32 C : 1;
-    u32 R : 1;
-    u32 : 3;
-    u32 RPN : 20;
-  };
-  u32 Hex;
+  BitField<0, 2, u32> PP;
+  BitField<2, 1, u32> reserved_1;
+  BitField<3, 4, u32> WIMG;
+  BitField<7, 1, u32> C;
+  BitField<8, 1, u32> R;
+  BitField<9, 3, u32> reserved_2;
+  BitField<12, 20, u32> RPN;
+
+  u32 Hex = 0;
+
+  UPTE2() = default;
+  explicit UPTE2(u32 hex_) : Hex{hex_} {}
 };
 
 static void GenerateDSIException(u32 effective_address, bool write)
@@ -1258,8 +1260,7 @@ static TLBLookupResult LookupTLBPageAddress(const XCheckTLBFlag flag, const u32 
 
   if (tlbe.tag[0] == tag)
   {
-    UPTE2 PTE2;
-    PTE2.Hex = tlbe.pte[0];
+    UPTE2 PTE2(tlbe.pte[0]);
 
     // Check if C bit requires updating
     if (flag == XCheckTLBFlag::Write)
@@ -1282,8 +1283,7 @@ static TLBLookupResult LookupTLBPageAddress(const XCheckTLBFlag flag, const u32 
   }
   if (tlbe.tag[1] == tag)
   {
-    UPTE2 PTE2;
-    PTE2.Hex = tlbe.pte[1];
+    UPTE2 PTE2(tlbe.pte[1]);
 
     // Check if C bit requires updating
     if (flag == XCheckTLBFlag::Write)
@@ -1388,8 +1388,7 @@ static TranslateAddressResult TranslatePageAddress(const u32 address, const XChe
 
       if (pte1 == pteg)
       {
-        UPTE2 PTE2;
-        PTE2.Hex = Memory::Read_U32(pteg_addr + 4);
+        UPTE2 PTE2(Memory::Read_U32(pteg_addr + 4));
 
         // set the access bits
         switch (flag)

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1295,13 +1295,8 @@ void InvalidateTLBEntry(u32 address)
 {
   const u32 entry_index = (address >> HW_PAGE_INDEX_SHIFT) & HW_PAGE_INDEX_MASK;
 
-  TLBEntry& tlbe = ppcState.tlb[0][entry_index];
-  tlbe.tag[0] = TLBEntry::INVALID_TAG;
-  tlbe.tag[1] = TLBEntry::INVALID_TAG;
-
-  TLBEntry& tlbe_i = ppcState.tlb[1][entry_index];
-  tlbe_i.tag[0] = TLBEntry::INVALID_TAG;
-  tlbe_i.tag[1] = TLBEntry::INVALID_TAG;
+  ppcState.tlb[0][entry_index].Invalidate();
+  ppcState.tlb[1][entry_index].Invalidate();
 }
 
 // Page Address Translation

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1199,7 +1199,9 @@ static void GenerateISIException(u32 effective_address)
 
 void SDRUpdated()
 {
-  u32 htabmask = SDR1_HTABMASK(PowerPC::ppcState.spr[SPR_SDR]);
+  const auto sdr = UReg_SDR1{ppcState.spr[SPR_SDR]};
+  const u32 htabmask = sdr.htabmask;
+
   if (!Common::IsValidLowMask(htabmask))
     WARN_LOG_FMT(POWERPC, "Invalid HTABMASK: 0b{:032b}", htabmask);
 
@@ -1207,12 +1209,12 @@ void SDRUpdated()
   // must be equal to the number of trailing ones in the mask (i.e. HTABORG must be
   // properly aligned), this is actually not a hard requirement. Real hardware will just OR
   // the base address anyway. Ignoring SDR changes would lead to incorrect emulation.
-  u32 htaborg = SDR1_HTABORG(PowerPC::ppcState.spr[SPR_SDR]);
-  if (htaborg & htabmask)
+  const u32 htaborg = sdr.htaborg;
+  if ((htaborg & htabmask) != 0)
     WARN_LOG_FMT(POWERPC, "Invalid HTABORG: htaborg=0x{:08x} htabmask=0x{:08x}", htaborg, htabmask);
 
-  PowerPC::ppcState.pagetable_base = htaborg << 16;
-  PowerPC::ppcState.pagetable_hashmask = ((htabmask << 10) | 0x3ff);
+  ppcState.pagetable_base = htaborg << 16;
+  ppcState.pagetable_hashmask = ((htabmask << 10) | 0x3ff);
 }
 
 enum class TLBLookupResult

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1282,9 +1282,9 @@ static void UpdateTLBEntry(const XCheckTLBFlag flag, UPTE_Hi pte2, const u32 add
   if (IsNoExceptionFlag(flag))
     return;
 
-  const int tag = address >> HW_PAGE_INDEX_SHIFT;
+  const u32 tag = address >> HW_PAGE_INDEX_SHIFT;
   TLBEntry& tlbe = ppcState.tlb[IsOpcodeFlag(flag)][tag & HW_PAGE_INDEX_MASK];
-  const int index = tlbe.recent == 0 && tlbe.tag[0] != TLBEntry::INVALID_TAG;
+  const u32 index = tlbe.recent == 0 && tlbe.tag[0] != TLBEntry::INVALID_TAG;
   tlbe.recent = index;
   tlbe.paddr[index] = pte2.RPN << HW_PAGE_INDEX_SHIFT;
   tlbe.pte[index] = pte2.Hex;

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <iosfwd>
 #include <tuple>
@@ -49,12 +50,16 @@ constexpr size_t TLB_WAYS = 2;
 
 struct TLBEntry
 {
+  using WayArray = std::array<u32, TLB_WAYS>;
+
   static constexpr u32 INVALID_TAG = 0xffffffff;
 
-  u32 tag[TLB_WAYS] = {INVALID_TAG, INVALID_TAG};
-  u32 paddr[TLB_WAYS] = {};
-  u32 pte[TLB_WAYS] = {};
+  WayArray tag{INVALID_TAG, INVALID_TAG};
+  WayArray paddr{};
+  WayArray pte{};
   u32 recent = 0;
+
+  void Invalidate() { tag.fill(INVALID_TAG); }
 };
 
 struct PairedSingle

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -54,7 +54,7 @@ struct TLBEntry
   u32 tag[TLB_WAYS] = {INVALID_TAG, INVALID_TAG};
   u32 paddr[TLB_WAYS] = {};
   u32 pte[TLB_WAYS] = {};
-  u8 recent = 0;
+  u32 recent = 0;
 };
 
 struct PairedSingle


### PR DESCRIPTION
This moves the split PTE definition unions into Gekko.h and eliminates the need for several macro definitions in the MMU code, since we can use the register unions to access the relevant info.

This also fixes the layout of the SDR1 union, which has been incorrect (from a little-endian POV) since it was introduced.

Each commit should be fairly self-isolated for review