### PR TITLE
MMU: Don't truncate 64-bit values when calling Memcheck()

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -293,7 +293,7 @@ bool MemChecks::OverlapsMemcheck(u32 address, u32 length) const
   });
 }
 
-bool TMemCheck::Action(Common::DebugInterface* debug_interface, u32 value, u32 addr, bool write,
+bool TMemCheck::Action(Common::DebugInterface* debug_interface, u64 value, u32 addr, bool write,
                        size_t size, u32 pc)
 {
   if (!is_enabled)

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -40,7 +40,7 @@ struct TMemCheck
   u32 num_hits = 0;
 
   // returns whether to break
-  bool Action(Common::DebugInterface* dbg_interface, u32 value, u32 addr, bool write, size_t size,
+  bool Action(Common::DebugInterface* debug_interface, u64 value, u32 addr, bool write, size_t size,
               u32 pc);
 };
 

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -499,7 +499,7 @@ TryReadResult<u32> HostTryReadInstruction(const u32 address, RequestedAddressSpa
   return TryReadResult<u32>();
 }
 
-static void Memcheck(u32 address, u32 var, bool write, size_t size)
+static void Memcheck(u32 address, u64 var, bool write, size_t size)
 {
   if (!memchecks.HasAny())
     return;
@@ -556,7 +556,7 @@ u32 Read_U32(const u32 address)
 u64 Read_U64(const u32 address)
 {
   u64 var = ReadFromHardware<XCheckTLBFlag::Read, u64>(address);
-  Memcheck(address, (u32)var, false, 8);
+  Memcheck(address, var, false, 8);
   return var;
 }
 
@@ -679,7 +679,7 @@ void Write_U32_Swap(const u32 var, const u32 address)
 
 void Write_U64(const u64 var, const u32 address)
 {
-  Memcheck(address, (u32)var, true, 8);
+  Memcheck(address, var, true, 8);
   WriteToHardware<XCheckTLBFlag::Write>(address, static_cast<u32>(var >> 32), 4);
   WriteToHardware<XCheckTLBFlag::Write>(address + sizeof(u32), static_cast<u32>(var), 4);
 }


### PR DESCRIPTION
Previously in Read_U64 and Write_U64 the value that was read or written would be truncated to a 32-bit value before being passed off to the memcheck handler, which can result in incorrect values being logged out.