### PR TITLE
BPMemory: Make ZTexOp enum an enum class

### DIFF
--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -241,7 +241,7 @@ struct fmt::formatter<ZTexFormat> : EnumFormatter<ZTexFormat::U24>
 };
 
 // Z texture operator
-enum ZTexOp : u32
+enum class ZTexOp : u32
 {
   Disabled = 0,
   Add = 1,

--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -12,8 +12,9 @@ using float4 = std::array<float, 4>;
 using uint4 = std::array<u32, 4>;
 using int4 = std::array<s32, 4>;
 
-enum class SrcBlendFactor : u32;
 enum class DstBlendFactor : u32;
+enum class SrcBlendFactor : u32;
+enum class ZTexOp : u32;
 
 struct PixelShaderConstants
 {
@@ -37,7 +38,7 @@ struct PixelShaderConstants
   u32 fogParam3;                // .x
   u32 fogRangeBase;             // .y
   u32 dstalpha;                 // .z
-  u32 ztex_op;                  // .w
+  ZTexOp ztex_op;               // .w
   u32 late_ztest;               // .x (bool)
   u32 rgba6_format;             // .y (bool)
   u32 dither;                   // .z (bool)

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -8,15 +8,16 @@
 #include "VideoCommon/ShaderGenCommon.h"
 
 enum class APIType;
-enum class AlphaTestResult;
-enum class SrcBlendFactor : u32;
-enum class DstBlendFactor : u32;
-enum class CompareMode : u32;
 enum class AlphaTestOp : u32;
-enum class RasColorChan : u32;
-enum class KonstSel : u32;
+enum class AlphaTestResult;
+enum class CompareMode : u32;
+enum class DstBlendFactor : u32;
 enum class FogProjection : u32;
 enum class FogType : u32;
+enum class KonstSel : u32;
+enum class RasColorChan : u32;
+enum class SrcBlendFactor : u32;
+enum class ZTexOp : u32;
 
 #pragma pack(1)
 struct pixel_shader_uid_data
@@ -40,7 +41,7 @@ struct pixel_shader_uid_data
 
   FogType fog_fsel : 3;
   u32 fog_RangeBaseEnabled : 1;
-  u32 ztex_op : 2;
+  ZTexOp ztex_op : 2;
   u32 per_pixel_depth : 1;
   u32 forced_early_z : 1;
   u32 early_ztest : 1;


### PR DESCRIPTION
Avoids placing generic names in the surrounding namespace.