### PR TITLE
Disable Dual Core by default for multiple Heavy Iron games

### DIFF
--- a/Data/Sys/GameSettings/GGV.ini
+++ b/Data/Sys/GameSettings/GGV.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# Dual Core mode causes FIFO error
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GIC.ini
+++ b/Data/Sys/GameSettings/GIC.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# Dual Core mode causes FIFO error
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GIH.ini
+++ b/Data/Sys/GameSettings/GIH.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# Dual Core mode causes FIFO error
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GIQ.ini
+++ b/Data/Sys/GameSettings/GIQ.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# Dual Core mode causes FIFO error
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GQP.ini
+++ b/Data/Sys/GameSettings/GQP.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# Dual Core mode causes FIFO error
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
BFBB tends to crash when dual-core is enabled. Interestingly enough, this does not happen on 5.0 stable (actually, the loads are more accurate to an actual Gamecube on stable as well, but that's a different issue).

The main issue is that randomly while playing the game with dual-core enabled, the game will crash with a FIFO error. Disabling dual-core fixes the issue. I have seen many people ask why BFBB is giving them a FIFO error randomly, and every time they are able to fix it by disabling dual-core. Therefore, I believe it should be disabled by default for this game.