### PR TITLE
JitArm64: Fix W0 being present twice in register cache

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -4,7 +4,6 @@
 #include "Core/PowerPC/JitArm64/JitArm64_RegCache.h"
 
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <vector>
 
@@ -152,19 +151,11 @@ void Arm64GPRCache::Start(PPCAnalyst::BlockRegStats& stats)
 
 bool Arm64GPRCache::IsCalleeSaved(ARM64Reg reg) const
 {
-  static constexpr std::array<ARM64Reg, 11> callee_regs{{
-      ARM64Reg::X28,
-      ARM64Reg::X27,
-      ARM64Reg::X26,
-      ARM64Reg::X25,
-      ARM64Reg::X24,
-      ARM64Reg::X23,
-      ARM64Reg::X22,
-      ARM64Reg::X21,
-      ARM64Reg::X20,
-      ARM64Reg::X19,
-      ARM64Reg::INVALID_REG,
-  }};
+  static constexpr auto callee_regs = {
+      ARM64Reg::X28, ARM64Reg::X27, ARM64Reg::X26,         ARM64Reg::X25,
+      ARM64Reg::X24, ARM64Reg::X23, ARM64Reg::X22,         ARM64Reg::X21,
+      ARM64Reg::X20, ARM64Reg::X19, ARM64Reg::INVALID_REG,
+  };
 
   return std::find(callee_regs.begin(), callee_regs.end(), EncodeRegTo64(reg)) != callee_regs.end();
 }
@@ -382,7 +373,7 @@ void Arm64GPRCache::BindToRegister(const GuestRegInfo& guest_reg, bool do_load)
 void Arm64GPRCache::GetAllocationOrder()
 {
   // Callee saved registers first in hopes that we will keep everything stored there first
-  static constexpr std::array<ARM64Reg, 29> allocation_order{{
+  static constexpr auto allocation_order = {
       // Callee saved
       ARM64Reg::W27,
       ARM64Reg::W26,
@@ -414,7 +405,7 @@ void Arm64GPRCache::GetAllocationOrder()
       ARM64Reg::W1,
       ARM64Reg::W0,
       ARM64Reg::W30,
-  }};
+  };
 
   for (ARM64Reg reg : allocation_order)
     m_host_registers.push_back(HostReg(reg));
@@ -667,7 +658,7 @@ ARM64Reg Arm64FPRCache::RW(size_t preg, RegType type)
 
 void Arm64FPRCache::GetAllocationOrder()
 {
-  static constexpr std::array<ARM64Reg, 32> allocation_order{{
+  static constexpr auto allocation_order = {
       // Callee saved
       ARM64Reg::Q8,
       ARM64Reg::Q9,
@@ -703,7 +694,7 @@ void Arm64FPRCache::GetAllocationOrder()
       ARM64Reg::Q2,
       ARM64Reg::Q1,
       ARM64Reg::Q0,
-  }};
+  };
 
   for (ARM64Reg reg : allocation_order)
     m_host_registers.push_back(HostReg(reg));
@@ -727,17 +718,10 @@ void Arm64FPRCache::FlushByHost(ARM64Reg host_reg, ARM64Reg tmp_reg)
 
 bool Arm64FPRCache::IsCalleeSaved(ARM64Reg reg) const
 {
-  static constexpr std::array<ARM64Reg, 9> callee_regs{{
-      ARM64Reg::Q8,
-      ARM64Reg::Q9,
-      ARM64Reg::Q10,
-      ARM64Reg::Q11,
-      ARM64Reg::Q12,
-      ARM64Reg::Q13,
-      ARM64Reg::Q14,
-      ARM64Reg::Q15,
-      ARM64Reg::INVALID_REG,
-  }};
+  static constexpr auto callee_regs = {
+      ARM64Reg::Q8,  ARM64Reg::Q9,  ARM64Reg::Q10, ARM64Reg::Q11,         ARM64Reg::Q12,
+      ARM64Reg::Q13, ARM64Reg::Q14, ARM64Reg::Q15, ARM64Reg::INVALID_REG,
+  };
 
   return std::find(callee_regs.begin(), callee_regs.end(), reg) != callee_regs.end();
 }


### PR DESCRIPTION
Fixes a regression from PR #7155.

The GPR `allocation_order` is initialized with only 28 elements, so the 29th element ends up getting zero initialized. Very sneaky bug...