### PR TITLE
Use custom isnan implementation to avoid HLSL optimizer issues

### DIFF
--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -176,6 +176,8 @@ union ShaderHostConfig
 std::string GetDiskShaderCacheFileName(APIType api_type, const char* type, bool include_gameid,
                                        bool include_host_config, bool include_api = true);
 
+void WriteIsNanHeader(ShaderCode& out, APIType api_type);
+
 void GenerateVSOutputMembers(ShaderCode& object, APIType api_type, u32 texgens,
                              const ShaderHostConfig& host_config, std::string_view qualifier);
 

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -50,6 +50,7 @@ ShaderCode GenVertexShader(APIType api_type, const ShaderHostConfig& host_config
   out.Write("}};\n\n");
 
   WriteUberShaderCommonHeader(out, api_type, host_config);
+  WriteIsNanHeader(out, api_type);
   WriteLightingFunction(out);
 
   if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
@@ -438,9 +439,9 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
   // Convert NaNs to 1 - needed to fix eyelids in Shadow the Hedgehog during cutscenes
   // See https://bugs.dolphin-emu.org/issues/11458
   out.Write("  // Convert NaN to 1\n");
-  out.Write("  if (isnan(coord.x)) coord.x = 1.0;\n");
-  out.Write("  if (isnan(coord.y)) coord.y = 1.0;\n");
-  out.Write("  if (isnan(coord.z)) coord.z = 1.0;\n");
+  out.Write("  if (dolphin_isnan(coord.x)) coord.x = 1.0;\n");
+  out.Write("  if (dolphin_isnan(coord.y)) coord.y = 1.0;\n");
+  out.Write("  if (dolphin_isnan(coord.z)) coord.z = 1.0;\n");
 
   out.Write("  // first transformation\n");
   out.Write("  uint texgentype = {};\n", BitfieldExtract<&TexMtxInfo::texgentype>("texMtxInfo"));

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -96,7 +96,9 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
 
   out.Write("struct VS_OUTPUT {{\n");
   GenerateVSOutputMembers(out, api_type, uid_data->numTexGens, host_config, "");
-  out.Write("}};\n");
+  out.Write("}};\n\n");
+
+  WriteIsNanHeader(out, api_type);
 
   if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
@@ -335,9 +337,9 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     // Convert NaNs to 1 - needed to fix eyelids in Shadow the Hedgehog during cutscenes
     // See https://bugs.dolphin-emu.org/issues/11458
     out.Write("// Convert NaN to 1\n");
-    out.Write("if (isnan(coord.x)) coord.x = 1.0;\n");
-    out.Write("if (isnan(coord.y)) coord.y = 1.0;\n");
-    out.Write("if (isnan(coord.z)) coord.z = 1.0;\n");
+    out.Write("if (dolphin_isnan(coord.x)) coord.x = 1.0;\n");
+    out.Write("if (dolphin_isnan(coord.y)) coord.y = 1.0;\n");
+    out.Write("if (dolphin_isnan(coord.z)) coord.z = 1.0;\n");
 
     // first transformation
     switch (texinfo.texgentype)


### PR DESCRIPTION
This adjusts the NaN replacement logic introduced in #9928 to work around the HLSL compiler optimizing away calls to isnan, which caused that functionality to not work with ubershaders on D3D11 and D3D12 (it did work with specialized shaders, despite a warning being logged for both; that warning is also now gone).  Note that the `D3DCOMPILE_IEEE_STRICTNESS` flag did not solve this issue, despite the warning suggesting that it might.

Suggested by @kayru and @jamiehayes.