### PR TITLE
GameINI: Disable JIT branch following for Namco Museum.

### DIFF
--- a/Data/Sys/GameSettings/GNM.ini
+++ b/Data/Sys/GameSettings/GNM.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+JITFollowBranch = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
See https://bugs.dolphin-emu.org/issues/12658 for details.

This restores the performance back to 5.0 levels, though it's still not 100% perfect. Probably the best we can do for now though.