### PR TITLE
Common/FileUtil: Strip trailing path separator in ScanDirectoryTree().

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -483,8 +483,16 @@ bool CreateEmptyFile(const std::string& filename)
 }
 
 // Recursive or non-recursive list of files and directories under directory.
-FSTEntry ScanDirectoryTree(const std::string& directory, bool recursive)
+FSTEntry ScanDirectoryTree(std::string directory, bool recursive)
 {
+#ifdef _WIN32
+  if (!directory.empty() && (directory.back() == '/' || directory.back() == '\\'))
+    directory.pop_back();
+#else
+  if (!directory.empty() && directory.back() == '/')
+    directory.pop_back();
+#endif
+
   INFO_LOG_FMT(COMMON, "ScanDirectoryTree: directory {}", directory);
   FSTEntry parent_entry;
   parent_entry.physicalName = directory;

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -176,7 +176,7 @@ bool Copy(const std::string& srcFilename, const std::string& destFilename);
 bool CreateEmptyFile(const std::string& filename);
 
 // Recursive or non-recursive list of files and directories under directory.
-FSTEntry ScanDirectoryTree(const std::string& directory, bool recursive);
+FSTEntry ScanDirectoryTree(std::string directory, bool recursive);
 
 // deletes the given directory and anything under it. Returns true on success.
 bool DeleteDirRecursively(const std::string& directory);


### PR DESCRIPTION
Noticed this during debugging. This causes an inconsistency between the path returned in the 'root' directory node and the path returned in all child directory nodes.

Before:
![before](https://user-images.githubusercontent.com/4522237/133197133-66ca57d7-7a99-471d-a4d4-038ec870ab30.png)

Note how the `rootEntry.physicalName` ends in a trailing slash but all child directories do not, and how all child names have a `//` after `files`.

After:
![after](https://user-images.githubusercontent.com/4522237/133197138-ea78c3a8-d966-405c-a75a-0728fa22dfd4.png)


I hope no one is relying on this behavoir somewhere...