### PR TITLE
DiscIO/DirectoryBlob: Handle reads between files.

### DIFF
--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -179,6 +179,9 @@ bool DiscContentContainer::Read(u64 offset, u64 length, u8* buffer) const
     // Zero fill to start of DiscContent data
     PadToAddress(it->GetOffset(), &offset, &length, &buffer);
 
+    if (length == 0)
+      return true;
+
     if (!it->Read(&offset, &length, &buffer))
       return false;
 


### PR DESCRIPTION
If someone passes an offset past the end of a file but before the start of another file to `DiscContentContainer::Read()`, the `PadToAddress()` call completely fills the buffer with zeroes and reduces the length to 0, but the code flow then tries to call `it->Read()` anyway, triggering a debug assert about an out-of-bounds offset.

To easily observe this just launch an extracted game in a Debug build, the read from `VolumeDisc::IsNKit()` is between files in our built disc layout.