### PR TITLE
GLInterface: Remove unneeded wglShareLists call

### DIFF
--- a/Source/Core/Common/GL/GLInterface/WGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/WGL.cpp
@@ -396,20 +396,9 @@ HGLRC GLContextWGL::CreateCoreContext(HDC dc, HGLRC share_context)
                                       0};
 
     // Attempt creating this context.
-    HGLRC core_context = wglCreateContextAttribsARB(dc, nullptr, attribs.data());
+    HGLRC core_context = wglCreateContextAttribsARB(dc, share_context, attribs.data());
     if (core_context)
     {
-      // If we're creating a shared context, share the resources before the context is used.
-      if (share_context)
-      {
-        if (!wglShareLists(share_context, core_context))
-        {
-          ERROR_LOG_FMT(VIDEO, "wglShareLists failed");
-          wglDeleteContext(core_context);
-          return nullptr;
-        }
-      }
-
       INFO_LOG_FMT(VIDEO, "WGL: Created a GL {}.{} core context", version.first, version.second);
       return core_context;
     }


### PR DESCRIPTION
When RenderDoc is attached, `wglShareLists` fails for some reason (see baldurk/renderdoc#2361).  `wglCreateContextAttribsARB` has a parameter for the share context, so there's no reason to use a separate `wglShareLists` call.

Note that using OpenGL in Dolphin with RenderDoc still has a separate issue with this patch where the screen appears black initially.  This has been fixed on RenderDoc's side, but it seems to be possible to work around it by starting a game/fifolog, then closing it, then starting it again.

This patch is from https://github.com/baldurk/renderdoc/issues/2361#issuecomment-919342173.