### PR TITLE
Cheats Manager UX improvements.

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -30,24 +30,30 @@ CheatsManager::CheatsManager(QWidget* parent) : QDialog(parent)
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &CheatsManager::OnStateChanged);
 
-  OnStateChanged(Core::GetState());
-
   CreateWidgets();
   ConnectWidgets();
+
+  RefreshCodeTabs(Core::GetState(), true);
 }
 
 CheatsManager::~CheatsManager() = default;
 
 void CheatsManager::OnStateChanged(Core::State state)
 {
-  if (state != Core::State::Running && state != Core::State::Paused)
+  RefreshCodeTabs(state, false);
+}
+
+void CheatsManager::RefreshCodeTabs(Core::State state, bool force)
+{
+  if (!force && (state == Core::State::Starting || state == Core::State::Stopping))
     return;
 
-  const auto& game_id = SConfig::GetInstance().GetGameID();
+  const auto& game_id =
+      state != Core::State::Uninitialized ? SConfig::GetInstance().GetGameID() : std::string();
   const auto& game_tdb_id = SConfig::GetInstance().GetGameTDBID();
   const u16 revision = SConfig::GetInstance().GetRevision();
 
-  if (m_game_id == game_id && m_game_tdb_id == game_tdb_id && m_revision == revision)
+  if (!force && m_game_id == game_id && m_game_tdb_id == game_tdb_id && m_revision == revision)
     return;
 
   m_game_id = game_id;

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -78,6 +78,10 @@ void CheatsManager::OnStateChanged(Core::State state)
   m_tab_widget->insertTab(1, m_gecko_code, tr("Gecko Codes"));
   m_tab_widget->setTabUnclosable(0);
   m_tab_widget->setTabUnclosable(1);
+
+  connect(m_ar_code, &ARCodeWidget::OpenGeneralSettings, this, &CheatsManager::OpenGeneralSettings);
+  connect(m_gecko_code, &GeckoCodeWidget::OpenGeneralSettings, this,
+          &CheatsManager::OpenGeneralSettings);
 }
 
 void CheatsManager::CreateWidgets()

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -33,6 +33,9 @@ public:
   explicit CheatsManager(QWidget* parent = nullptr);
   ~CheatsManager();
 
+signals:
+  void OpenGeneralSettings();
+
 private:
   void CreateWidgets();
   void ConnectWidgets();

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -43,6 +43,8 @@ private:
   void OnNewSessionCreated(const Cheats::CheatSearchSessionBase& session);
   void OnTabCloseRequested(int index);
 
+  void RefreshCodeTabs(Core::State state, bool force);
+
   std::string m_game_id;
   std::string m_game_tdb_id;
   u16 m_revision = 0;

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -31,14 +31,17 @@ ARCodeWidget::ARCodeWidget(std::string game_id, u16 game_revision, bool restart_
   CreateWidgets();
   ConnectWidgets();
 
-  IniFile game_ini_local;
+  if (!m_game_id.empty())
+  {
+    IniFile game_ini_local;
 
-  // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
-  // will always be stored in GS/${GAMEID}.ini
-  game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
+    // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
+    // will always be stored in GS/${GAMEID}.ini
+    game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
 
-  const IniFile game_ini_default = SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
-  m_ar_codes = ActionReplay::LoadCodes(game_ini_default, game_ini_local);
+    const IniFile game_ini_default = SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
+    m_ar_codes = ActionReplay::LoadCodes(game_ini_default, game_ini_local);
+  }
 
   UpdateList();
   OnSelectionChanged();
@@ -53,6 +56,11 @@ void ARCodeWidget::CreateWidgets()
   m_code_add = new QPushButton(tr("&Add New Code..."));
   m_code_edit = new QPushButton(tr("&Edit Code..."));
   m_code_remove = new QPushButton(tr("&Remove Code"));
+
+  m_code_list->setEnabled(!m_game_id.empty());
+  m_code_add->setEnabled(!m_game_id.empty());
+  m_code_edit->setEnabled(!m_game_id.empty());
+  m_code_remove->setEnabled(!m_game_id.empty());
 
   m_code_list->setContextMenuPolicy(Qt::CustomContextMenu);
 
@@ -171,6 +179,9 @@ void ARCodeWidget::UpdateList()
 
 void ARCodeWidget::SaveCodes()
 {
+  if (m_game_id.empty())
+    return;
+
   const auto ini_path =
       std::string(File::GetUserPath(D_GAMESETTINGS_IDX)).append(m_game_id).append(".ini");
 

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -37,14 +37,17 @@ GeckoCodeWidget::GeckoCodeWidget(std::string game_id, std::string gametdb_id, u1
   CreateWidgets();
   ConnectWidgets();
 
-  IniFile game_ini_local;
+  if (!m_game_id.empty())
+  {
+    IniFile game_ini_local;
 
-  // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
-  // will always be stored in GS/${GAMEID}.ini
-  game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
+    // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
+    // will always be stored in GS/${GAMEID}.ini
+    game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
 
-  const IniFile game_ini_default = SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
-  m_gecko_codes = Gecko::LoadCodes(game_ini_default, game_ini_local);
+    const IniFile game_ini_default = SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
+    m_gecko_codes = Gecko::LoadCodes(game_ini_default, game_ini_local);
+  }
 
   UpdateList();
 }
@@ -81,9 +84,16 @@ void GeckoCodeWidget::CreateWidgets()
 
   m_download_codes->setToolTip(tr("Download Codes from the WiiRD Database"));
 
-  m_download_codes->setEnabled(!m_game_id.empty());
+  m_code_list->setEnabled(!m_game_id.empty());
+  m_name_label->setEnabled(!m_game_id.empty());
+  m_creator_label->setEnabled(!m_game_id.empty());
+  m_code_description->setEnabled(!m_game_id.empty());
+  m_code_view->setEnabled(!m_game_id.empty());
+
+  m_add_code->setEnabled(!m_game_id.empty());
   m_edit_code->setEnabled(false);
   m_remove_code->setEnabled(false);
+  m_download_codes->setEnabled(!m_game_id.empty());
 
   auto* layout = new QVBoxLayout;
 
@@ -228,6 +238,9 @@ void GeckoCodeWidget::RemoveCode()
 
 void GeckoCodeWidget::SaveCodes()
 {
+  if (m_game_id.empty())
+    return;
+
   const auto ini_path =
       std::string(File::GetUserPath(D_GAMESETTINGS_IDX)).append(m_game_id).append(".ini");
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -220,6 +220,9 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
   ConnectMenuBar();
   ConnectHotkeys();
 
+  connect(m_cheats_manager, &CheatsManager::OpenGeneralSettings, this,
+          &MainWindow::ShowGeneralWindow);
+
   InitCoreCallbacks();
 
   NetPlayInit();

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -131,9 +131,6 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   // Options
   m_controllers_action->setEnabled(NetPlay::IsNetPlayRunning() ? !running : true);
 
-  // Tools
-  m_show_cheat_manager->setEnabled(Settings::Instance().GetCheatsEnabled() && running);
-
   // JIT
   m_jit_interpreter_core->setEnabled(running);
   m_jit_block_linking->setEnabled(!running);
@@ -228,12 +225,7 @@ void MenuBar::AddToolsMenu()
   tools_menu->addAction(tr("&Resource Pack Manager"), this,
                         [this] { emit ShowResourcePackManager(); });
 
-  m_show_cheat_manager =
-      tools_menu->addAction(tr("&Cheats Manager"), this, [this] { emit ShowCheatsManager(); });
-
-  connect(&Settings::Instance(), &Settings::EnableCheatsChanged, this, [this](bool enabled) {
-    m_show_cheat_manager->setEnabled(Core::GetState() != Core::State::Uninitialized && enabled);
-  });
+  tools_menu->addAction(tr("&Cheats Manager"), this, [this] { emit ShowCheatsManager(); });
 
   tools_menu->addAction(tr("FIFO Player"), this, &MenuBar::ShowFIFOPlayer);
 

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -196,7 +196,6 @@ private:
   QMenu* m_backup_menu;
 
   // Tools
-  QAction* m_show_cheat_manager;
   QAction* m_wad_install_action;
   QMenu* m_perform_online_update_menu;
   QAction* m_perform_online_update_for_current_region;


### PR DESCRIPTION
Fixes some annoyances pointed out by @Dentomologist back in #9886.

Specifically:

- The Cheats Manager option is no longer mysteriously greyed out if no game is running or if cheats are disabled and is instead always active.
- If no game is running the code tabs are greyed out instead of completely missing.
- If cheats are disabled and the "Warning: Cheats are disabled! [Configure Dolphin]" header thing shows (as the equivalent tabs in the game properties), the button now actually works -- it didn't before. Granted, it was rather hard to even reach this window in that situation (you'd have to start a game, open the window, close the game, then disable cheats without closing the window), but either way, it works correctly now.
- This also now allows running memory searches even if cheats are disabled, which is just a nice convenience thing.