### PR TITLE
GameINI: Disable force texture filtering for Mega Man X Collection

### DIFF
--- a/Data/Sys/GameSettings/GXG.ini
+++ b/Data/Sys/GameSettings/GXG.ini
@@ -7,3 +7,6 @@
 [ActionReplay]
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
+[Video_Enhancements]
+# Texture filtering causes lines with Mega Man X 3
+ForceFiltering = False


### PR DESCRIPTION
This fixes https://wiki.dolphin-emu.org/index.php?title=Mega_Man_X_Collection#Odd_Grid