### PR TITLE
VulkanContext: Disable subgroup reduction on Macs with AMD GPUs

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -944,7 +944,8 @@ void VulkanContext::PopulateShaderSubgroupSupport()
                                                          VK_SUBGROUP_FEATURE_BALLOT_BIT;
   m_supports_shader_subgroup_operations =
       (subgroup_properties.supportedOperations & required_operations) == required_operations &&
-      subgroup_properties.supportedStages & VK_SHADER_STAGE_FRAGMENT_BIT;
+      subgroup_properties.supportedStages & VK_SHADER_STAGE_FRAGMENT_BIT &&
+      !DriverDetails::HasBug(DriverDetails::BUG_BROKEN_SUBGROUP_INVOCATION_ID);
 }
 
 bool VulkanContext::SupportsExclusiveFullscreen(const WindowSystemInfo& wsi, VkSurfaceKHR surface)

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -127,6 +127,8 @@ constexpr BugInfo m_known_bugs[] = {
      -1.0, -1.0, true},
     {API_OPENGL, OS_WINDOWS, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN, BUG_BROKEN_SSBO_FIELD_ATOMICS,
      -1.0, -1.0, true},
+    {API_VULKAN, OS_OSX, VENDOR_ATI, DRIVER_PORTABILITY, Family::UNKNOWN,
+     BUG_BROKEN_SUBGROUP_INVOCATION_ID, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -305,6 +305,12 @@ enum Bug
   // Started version: -1
   // Ended version: -1
   BUG_BROKEN_SSBO_FIELD_ATOMICS,
+
+  // BUG: Accessing gl_SubgroupInvocationID causes the Metal shader compiler to crash.
+  // Affected devices: AMD (macOS)
+  // Started version: -1
+  // Ended version: -1
+  BUG_BROKEN_SUBGROUP_INVOCATION_ID,
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
Based on #9783.

For whatever reason, attempting to access `gl_SubgroupInvocationID` causes `MTLCompilerService` to crash in LLVM code. This breaks bounding box. A crash log has been attached [here](https://bugs.dolphin-emu.org/issues/12667#note-2).

The relevant excerpt is as follows:

```
Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x00007fffb1d44a50
Exception Note:        EXC_CORPSE_NOTIFY

[...]

Thread 1 Crashed:
0   ???                           	0x00007fffb1d44a50 0 + 140736176867920
1   libLLVM.dylib                 	0x00007fff68d6ddf9 llvm::SelectionDAGISel::SelectAllBasicBlocks(llvm::Function const&) + 1573
2   libLLVM.dylib                 	0x00007fff68d6cfd1 llvm::SelectionDAGISel::runOnMachineFunction(llvm::MachineFunction&) + 1633
3   libLLVM.dylib                 	0x00007fff68797d65 llvm::MachineFunctionPass::runOnFunction(llvm::Function&) + 119
4   libLLVM.dylib                 	0x00007fff68919ff5 llvm::FPPassManager::runOnFunction(llvm::Function&) + 395
5   libLLVM.dylib                 	0x00007fff68919d56 llvm::FPPassManager::runOnModule(llvm::Module&) + 52
6   libLLVM.dylib                 	0x00007fff6891fa2e llvm::legacy::PassManagerImpl::run(llvm::Module&) + 652
7   com.apple.AMDRadeonX6000Shared	0x00007fff60bf79f5 AMDMTLCompilerPluginIL::compileShader(llvm::Module&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) + 639
```

More investigation is required and a bug report with a minimized test case should be submitted to Apple.

In the meantime, however, I have opened this PR which disables subgroup reduction completely on AMD GPUs so that games that rely on bounding box can become playable again.

Tested on a MacBook Pro 16" running macOS 11.5.2 with an AMD Radeon 5500M.