### PR TITLE
BPStructs: ensure side effects are same

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -226,6 +226,8 @@ static void BPWritten(const BPCmd& bp)
     srcRect.right = bpmem.copyTexSrcXY.x + bpmem.copyTexSrcWH.x + 1;
     srcRect.bottom = bpmem.copyTexSrcXY.y + bpmem.copyTexSrcWH.y + 1;
 
+    const UPE_Copy PE_copy = bpmem.triggerEFBCopy;
+
     // Since the copy X and Y coordinates/sizes are 10-bit, the game can configure a copy region up
     // to 1024x1024. Hardware tests have found that the number of bytes written does not depend on
     // the configured stride, instead it is based on the size registers, writing beyond the length
@@ -250,6 +252,12 @@ static void BPWritten(const BPCmd& bp)
         // Just ignore it
         // Apparently Mario Kart Wii in wifi mode can generate a deformed EFB copy of size 4x4
         // at offset (328,1020)
+        if (PE_copy.copy_to_xfb == 1)
+        {
+          // Make sure we disable Bounding box to match the side effects of the non-failure path
+          BoundingBox::Disable();
+        }
+
         return;
       }
 
@@ -262,7 +270,6 @@ static void BPWritten(const BPCmd& bp)
     const u32 copy_height = srcRect.GetHeight();
 
     // Check if we are to copy from the EFB or draw to the XFB
-    const UPE_Copy PE_copy = bpmem.triggerEFBCopy;
     if (PE_copy.copy_to_xfb == 0)
     {
       // bpmem.zcontrol.pixel_format to PixelFormat::Z24 is when the game wants to copy from ZBuffer


### PR DESCRIPTION
I Missed this side effect when fixing crash in Mario Kart Wii wifi

Hopefully this fixes the bug in Paper Mario