### PR TITLE
Core: Remove s_request_refresh_info

### DIFF
--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -123,7 +123,6 @@ void FrameUpdateOnCPUThread();
 void OnFrameEnd();
 
 void VideoThrottle();
-void RequestRefreshInfo();
 
 void UpdateTitle(u32 ElapseTime);
 


### PR DESCRIPTION
It's only used for frame stepping. We can use s_frame_step instead.