### PR TITLE
Disable Immediate XFB in King Kong

### DIFF
--- a/Data/Sys/GameSettings/GWK.ini
+++ b/Data/Sys/GameSettings/GWK.ini
@@ -1,0 +1,17 @@
+# GWKE41, GWKP41 - Peter Jackson's King Kong: The Official Game of the Movie
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+# Prevents the game from pushing extra XFB copies and breaking vsync
+ImmediateXFBEnable = False


### PR DESCRIPTION
The game has extra XFB copies in some menus, messing up framepacing on VRR monitors and breaking vsync in general.