### PR TITLE
Core/DiscIO: Extract disc and partition constants to DiscUtils.h.

### DIFF
--- a/Source/Core/DiscIO/DiscExtractor.cpp
+++ b/Source/Core/DiscIO/DiscExtractor.cpp
@@ -137,7 +137,8 @@ bool ExportWiiUnencryptedHeader(const Volume& volume, const std::string& export_
   if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
-  return ExportData(volume, PARTITION_NONE, 0, 0x100, export_filename);
+  return ExportData(volume, PARTITION_NONE, WII_NONPARTITION_DISCHEADER_ADDRESS,
+                    WII_NONPARTITION_DISCHEADER_SIZE, export_filename);
 }
 
 bool ExportWiiRegionData(const Volume& volume, const std::string& export_filename)
@@ -145,7 +146,8 @@ bool ExportWiiRegionData(const Volume& volume, const std::string& export_filenam
   if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
-  return ExportData(volume, PARTITION_NONE, 0x4E000, 0x20, export_filename);
+  return ExportData(volume, PARTITION_NONE, WII_REGION_DATA_ADDRESS, WII_REGION_DATA_SIZE,
+                    export_filename);
 }
 
 bool ExportTicket(const Volume& volume, const Partition& partition,
@@ -154,7 +156,8 @@ bool ExportTicket(const Volume& volume, const Partition& partition,
   if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
-  return ExportData(volume, PARTITION_NONE, partition.offset, 0x2a4, export_filename);
+  return ExportData(volume, PARTITION_NONE, partition.offset + WII_PARTITION_TICKET_ADDRESS,
+                    WII_PARTITION_TICKET_SIZE, export_filename);
 }
 
 bool ExportTMD(const Volume& volume, const Partition& partition, const std::string& export_filename)
@@ -162,9 +165,10 @@ bool ExportTMD(const Volume& volume, const Partition& partition, const std::stri
   if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
-  const std::optional<u32> size = volume.ReadSwapped<u32>(partition.offset + 0x2a4, PARTITION_NONE);
-  const std::optional<u64> offset =
-      volume.ReadSwappedAndShifted(partition.offset + 0x2a8, PARTITION_NONE);
+  const std::optional<u32> size =
+      volume.ReadSwapped<u32>(partition.offset + WII_PARTITION_TMD_SIZE_ADDRESS, PARTITION_NONE);
+  const std::optional<u64> offset = volume.ReadSwappedAndShifted(
+      partition.offset + WII_PARTITION_TMD_OFFSET_ADDRESS, PARTITION_NONE);
   if (!size || !offset)
     return false;
 
@@ -177,9 +181,10 @@ bool ExportCertificateChain(const Volume& volume, const Partition& partition,
   if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
-  const std::optional<u32> size = volume.ReadSwapped<u32>(partition.offset + 0x2ac, PARTITION_NONE);
-  const std::optional<u64> offset =
-      volume.ReadSwappedAndShifted(partition.offset + 0x2b0, PARTITION_NONE);
+  const std::optional<u32> size = volume.ReadSwapped<u32>(
+      partition.offset + WII_PARTITION_CERT_CHAIN_SIZE_ADDRESS, PARTITION_NONE);
+  const std::optional<u64> offset = volume.ReadSwappedAndShifted(
+      partition.offset + WII_PARTITION_CERT_CHAIN_OFFSET_ADDRESS, PARTITION_NONE);
   if (!size || !offset)
     return false;
 
@@ -192,12 +197,13 @@ bool ExportH3Hashes(const Volume& volume, const Partition& partition,
   if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
-  const std::optional<u64> offset =
-      volume.ReadSwappedAndShifted(partition.offset + 0x2b4, PARTITION_NONE);
+  const std::optional<u64> offset = volume.ReadSwappedAndShifted(
+      partition.offset + WII_PARTITION_H3_OFFSET_ADDRESS, PARTITION_NONE);
   if (!offset)
     return false;
 
-  return ExportData(volume, PARTITION_NONE, partition.offset + *offset, 0x18000, export_filename);
+  return ExportData(volume, PARTITION_NONE, partition.offset + *offset, WII_PARTITION_H3_SIZE,
+                    export_filename);
 }
 
 bool ExportHeader(const Volume& volume, const Partition& partition,
@@ -206,7 +212,7 @@ bool ExportHeader(const Volume& volume, const Partition& partition,
   if (!IsDisc(volume.GetVolumeType()))
     return false;
 
-  return ExportData(volume, partition, 0, 0x440, export_filename);
+  return ExportData(volume, partition, DISCHEADER_ADDRESS, DISCHEADER_SIZE, export_filename);
 }
 
 bool ExportBI2Data(const Volume& volume, const Partition& partition,
@@ -215,7 +221,7 @@ bool ExportBI2Data(const Volume& volume, const Partition& partition,
   if (!IsDisc(volume.GetVolumeType()))
     return false;
 
-  return ExportData(volume, partition, 0x440, 0x2000, export_filename);
+  return ExportData(volume, partition, BI2_ADDRESS, BI2_SIZE, export_filename);
 }
 
 bool ExportApploader(const Volume& volume, const Partition& partition,
@@ -228,7 +234,7 @@ bool ExportApploader(const Volume& volume, const Partition& partition,
   if (!apploader_size)
     return false;
 
-  return ExportData(volume, partition, 0x2440, *apploader_size, export_filename);
+  return ExportData(volume, partition, APPLOADER_ADDRESS, *apploader_size, export_filename);
 }
 
 bool ExportDOL(const Volume& volume, const Partition& partition, const std::string& export_filename)

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -132,11 +132,16 @@ bool DiscScrubber::ParseDisc()
     u64 h3_offset;
     // The H3 size is always 0x18000
 
-    if (!ReadFromVolume(partition.offset + 0x2a4, tmd_size, PARTITION_NONE) ||
-        !ReadFromVolume(partition.offset + 0x2a8, tmd_offset, PARTITION_NONE) ||
-        !ReadFromVolume(partition.offset + 0x2ac, cert_chain_size, PARTITION_NONE) ||
-        !ReadFromVolume(partition.offset + 0x2b0, cert_chain_offset, PARTITION_NONE) ||
-        !ReadFromVolume(partition.offset + 0x2b4, h3_offset, PARTITION_NONE))
+    if (!ReadFromVolume(partition.offset + WII_PARTITION_TMD_SIZE_ADDRESS, tmd_size,
+                        PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + WII_PARTITION_TMD_OFFSET_ADDRESS, tmd_offset,
+                        PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + WII_PARTITION_CERT_CHAIN_SIZE_ADDRESS, cert_chain_size,
+                        PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + WII_PARTITION_CERT_CHAIN_OFFSET_ADDRESS,
+                        cert_chain_offset, PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + WII_PARTITION_H3_OFFSET_ADDRESS, h3_offset,
+                        PARTITION_NONE))
     {
       return false;
     }
@@ -145,7 +150,7 @@ bool DiscScrubber::ParseDisc()
 
     MarkAsUsed(partition.offset + tmd_offset, tmd_size);
     MarkAsUsed(partition.offset + cert_chain_offset, cert_chain_size);
-    MarkAsUsed(partition.offset + h3_offset, 0x18000);
+    MarkAsUsed(partition.offset + h3_offset, WII_PARTITION_H3_SIZE);
 
     // Parse Data! This is where the big gain is
     if (!ParsePartitionData(partition))

--- a/Source/Core/DiscIO/DiscUtils.h
+++ b/Source/Core/DiscIO/DiscUtils.h
@@ -29,6 +29,26 @@ constexpr u32 PARTITION_UPDATE = 1;
 constexpr u32 PARTITION_CHANNEL = 2;  // Mario Kart Wii, Wii Fit, Wii Fit Plus, Rabbids Go Home
 constexpr u32 PARTITION_INSTALL = 3;  // Dragon Quest X only
 
+constexpr u32 DISCHEADER_ADDRESS = 0;
+constexpr u32 DISCHEADER_SIZE = 0x440;
+constexpr u32 BI2_ADDRESS = 0x440;
+constexpr u32 BI2_SIZE = 0x2000;
+constexpr u32 APPLOADER_ADDRESS = 0x2440;
+
+constexpr u32 WII_PARTITION_TICKET_ADDRESS = 0;
+constexpr u32 WII_PARTITION_TICKET_SIZE = 0x2a4;
+constexpr u32 WII_PARTITION_TMD_SIZE_ADDRESS = 0x2a4;
+constexpr u32 WII_PARTITION_TMD_OFFSET_ADDRESS = 0x2a8;
+constexpr u32 WII_PARTITION_CERT_CHAIN_SIZE_ADDRESS = 0x2ac;
+constexpr u32 WII_PARTITION_CERT_CHAIN_OFFSET_ADDRESS = 0x2b0;
+constexpr u32 WII_PARTITION_H3_OFFSET_ADDRESS = 0x2b4;
+constexpr u32 WII_PARTITION_H3_SIZE = 0x18000;
+
+constexpr u32 WII_NONPARTITION_DISCHEADER_ADDRESS = 0;
+constexpr u32 WII_NONPARTITION_DISCHEADER_SIZE = 0x100;
+constexpr u32 WII_REGION_DATA_ADDRESS = 0x4E000;
+constexpr u32 WII_REGION_DATA_SIZE = 0x20;
+
 std::string NameForPartitionType(u32 partition_type, bool include_prefix);
 
 std::optional<u64> GetApploaderSize(const Volume& volume, const Partition& partition);

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -27,6 +27,7 @@
 
 #include "DiscIO/Blob.h"
 #include "DiscIO/DiscExtractor.h"
+#include "DiscIO/DiscUtils.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/FileSystemGCWii.h"
 #include "DiscIO/Filesystem.h"
@@ -81,9 +82,10 @@ VolumeWii::VolumeWii(std::unique_ptr<BlobReader> reader)
       };
 
       auto get_tmd = [this, partition]() -> IOS::ES::TMDReader {
-        const std::optional<u32> tmd_size = m_reader->ReadSwapped<u32>(partition.offset + 0x2a4);
-        const std::optional<u64> tmd_address =
-            ReadSwappedAndShifted(partition.offset + 0x2a8, PARTITION_NONE);
+        const std::optional<u32> tmd_size =
+            m_reader->ReadSwapped<u32>(partition.offset + WII_PARTITION_TMD_SIZE_ADDRESS);
+        const std::optional<u64> tmd_address = ReadSwappedAndShifted(
+            partition.offset + WII_PARTITION_TMD_OFFSET_ADDRESS, PARTITION_NONE);
         if (!tmd_size || !tmd_address)
           return INVALID_TMD;
         if (!IOS::ES::IsValidTMDSize(*tmd_size))
@@ -100,9 +102,10 @@ VolumeWii::VolumeWii(std::unique_ptr<BlobReader> reader)
       };
 
       auto get_cert_chain = [this, partition]() -> std::vector<u8> {
-        const std::optional<u32> size = m_reader->ReadSwapped<u32>(partition.offset + 0x2ac);
-        const std::optional<u64> address =
-            ReadSwappedAndShifted(partition.offset + 0x2b0, PARTITION_NONE);
+        const std::optional<u32> size =
+            m_reader->ReadSwapped<u32>(partition.offset + WII_PARTITION_CERT_CHAIN_SIZE_ADDRESS);
+        const std::optional<u64> address = ReadSwappedAndShifted(
+            partition.offset + WII_PARTITION_CERT_CHAIN_OFFSET_ADDRESS, PARTITION_NONE);
         if (!size || !address)
           return {};
         std::vector<u8> cert_chain(*size);
@@ -114,12 +117,13 @@ VolumeWii::VolumeWii(std::unique_ptr<BlobReader> reader)
       auto get_h3_table = [this, partition]() -> std::vector<u8> {
         if (!m_encrypted)
           return {};
-        const std::optional<u64> h3_table_offset =
-            ReadSwappedAndShifted(partition.offset + 0x2b4, PARTITION_NONE);
+        const std::optional<u64> h3_table_offset = ReadSwappedAndShifted(
+            partition.offset + WII_PARTITION_H3_OFFSET_ADDRESS, PARTITION_NONE);
         if (!h3_table_offset)
           return {};
-        std::vector<u8> h3_table(H3_TABLE_SIZE);
-        if (!m_reader->Read(partition.offset + *h3_table_offset, H3_TABLE_SIZE, h3_table.data()))
+        std::vector<u8> h3_table(WII_PARTITION_H3_SIZE);
+        if (!m_reader->Read(partition.offset + *h3_table_offset, WII_PARTITION_H3_SIZE,
+                            h3_table.data()))
           return {};
         return h3_table;
       };
@@ -395,7 +399,7 @@ bool VolumeWii::CheckH3TableIntegrity(const Partition& partition) const
   const PartitionDetails& partition_details = it->second;
 
   const std::vector<u8>& h3_table = *partition_details.h3_table;
-  if (h3_table.size() != H3_TABLE_SIZE)
+  if (h3_table.size() != WII_PARTITION_H3_SIZE)
     return false;
 
   const IOS::ES::TMDReader& tmd = *partition_details.tmd;

--- a/Source/Core/DiscIO/VolumeWii.h
+++ b/Source/Core/DiscIO/VolumeWii.h
@@ -36,7 +36,6 @@ public:
   static constexpr size_t AES_KEY_SIZE = 16;
   static constexpr size_t SHA1_SIZE = 20;
 
-  static constexpr u32 H3_TABLE_SIZE = 0x18000;
   static constexpr u32 BLOCKS_PER_GROUP = 0x40;
 
   static constexpr u64 BLOCK_HEADER_SIZE = 0x0400;


### PR DESCRIPTION
I noticed a lot of these were duplicated across various files, figured it makes sense to collect them in one place.