### PR TITLE
StickWidget: Inscribe stick circle within a square

### DIFF
--- a/Source/Core/DolphinQt/TAS/StickWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/StickWidget.cpp
@@ -47,6 +47,9 @@ void StickWidget::paintEvent(QPaintEvent* event)
 
   const int diameter = std::min(width(), height()) - PADDING * 2;
 
+  // inscribe the StickWidget inside a square
+  painter.fillRect(PADDING, PADDING, diameter, diameter, Qt::lightGray);
+
   painter.setBrush(Qt::white);
   painter.drawEllipse(PADDING, PADDING, diameter, diameter);
 


### PR DESCRIPTION
This PR creates a light gray box around ellipses in the StickWidget. This mimics the old GUI and is useful as it allows TASers to identify the edges of the interactive stick area when clicking outside of the circle.

5.0
![image](https://user-images.githubusercontent.com/16770560/134049177-0b44eff1-d0b6-41a4-bfb9-228fd9e53aae.png)

5.0-15224
![image](https://user-images.githubusercontent.com/16770560/134049243-eab00d28-e374-4b3b-b365-b3c51969c5e1.png)

This PR
![image](https://user-images.githubusercontent.com/16770560/134049275-b4389798-aed2-4533-9dd3-b73a93c23208.png)
