### PR TITLE
TASInputWindow: Switch parent depending on m_rendering_to_main, fixed window size

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -142,6 +142,8 @@ private:
   void StartGame(std::unique_ptr<BootParameters>&& parameters);
   void ShowRenderWidget();
   void HideRenderWidget(bool reinit = true, bool is_exit = false);
+  void AdoptAllTASInputWindows(QWidget* parent);
+  void AdoptTASInputWindow(QWidget* parent, QWidget* tas_input_window);
 
   void ShowSettingsWindow();
   void ShowGeneralWindow();

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -29,6 +29,7 @@ TASInputWindow::TASInputWindow(QWidget* parent) : QDialog(parent)
 {
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowIcon(Resources::GetAppIcon());
+  setFixedSize(sizeHint());
 
   QGridLayout* settings_layout = new QGridLayout;
 


### PR DESCRIPTION
In the current state of Dolphin dev, TAS Input window behavior is a bit inconvenient. Clicking on the game window will cause TAS Input to hide behind the game window. Instead, this PR will swap the TAS Input window(s) parent to the render widget on game bootup. If "Render to Main Window" is disabled, then this has the added benefit, compared to Dolphin 5.0, of not obstructing menu navigation.

I did not set a parent on the window object creation, as AdoptTASInput() is always called via ShowTASInput().

I also enabled fixed size for the TAS Input windows. It is unnecessary to be able to resize these windows. However, the only concern I have is that stick widgets are quite small (and misshapen in the case of WiiMote with no extensions). I believe another PR should be created to reshape these layouts to make room for enlarged stick widgets.