### PR TITLE
Jit64: Merge arithcx into addx/subfx

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -150,7 +150,6 @@ public:
   void DynaRunTable63(UGeckoInstruction inst);
 
   void addx(UGeckoInstruction inst);
-  void addcx(UGeckoInstruction inst);
   void mulli(UGeckoInstruction inst);
   void mulhwXx(UGeckoInstruction inst);
   void mullwx(UGeckoInstruction inst);

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -232,7 +232,6 @@ public:
 
   void subfic(UGeckoInstruction inst);
   void subfx(UGeckoInstruction inst);
-  void subfcx(UGeckoInstruction inst);
 
   void twX(UGeckoInstruction inst);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -150,7 +150,7 @@ public:
   void DynaRunTable63(UGeckoInstruction inst);
 
   void addx(UGeckoInstruction inst);
-  void arithcx(UGeckoInstruction inst);
+  void addcx(UGeckoInstruction inst);
   void mulli(UGeckoInstruction inst);
   void mulhwXx(UGeckoInstruction inst);
   void mullwx(UGeckoInstruction inst);
@@ -233,6 +233,7 @@ public:
 
   void subfic(UGeckoInstruction inst);
   void subfx(UGeckoInstruction inst);
+  void subfcx(UGeckoInstruction inst);
 
   void twX(UGeckoInstruction inst);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -150,8 +150,8 @@ constexpr std::array<GekkoOPTemplate, 13> s_table19{{
 constexpr std::array<GekkoOPTemplate, 107> s_table31{{
     {266, &Jit64::addx},      // addx
     {778, &Jit64::addx},      // addox
-    {10, &Jit64::addcx},    // addcx
-    {522, &Jit64::addcx},   // addcox
+    {10, &Jit64::addx},       // addcx
+    {522, &Jit64::addx},      // addcox
     {138, &Jit64::arithXex},  // addex
     {650, &Jit64::arithXex},  // addeox
     {234, &Jit64::arithXex},  // addmex
@@ -170,8 +170,8 @@ constexpr std::array<GekkoOPTemplate, 107> s_table31{{
     {616, &Jit64::negx},      // negox
     {40, &Jit64::subfx},      // subfx
     {552, &Jit64::subfx},     // subfox
-    {8, &Jit64::subfcx},     // subfcx
-    {520, &Jit64::subfcx},   // subfcox
+    {8, &Jit64::subfcx},       // subfcx
+    {520, &Jit64::subfcx},     // subfcox
     {136, &Jit64::arithXex},  // subfex
     {648, &Jit64::arithXex},  // subfeox
     {232, &Jit64::arithXex},  // subfmex

--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -170,8 +170,8 @@ constexpr std::array<GekkoOPTemplate, 107> s_table31{{
     {616, &Jit64::negx},      // negox
     {40, &Jit64::subfx},      // subfx
     {552, &Jit64::subfx},     // subfox
-    {8, &Jit64::subfcx},       // subfcx
-    {520, &Jit64::subfcx},     // subfcox
+    {8, &Jit64::subfx},       // subfcx
+    {520, &Jit64::subfx},     // subfcox
     {136, &Jit64::arithXex},  // subfex
     {648, &Jit64::arithXex},  // subfeox
     {232, &Jit64::arithXex},  // subfmex

--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -150,8 +150,8 @@ constexpr std::array<GekkoOPTemplate, 13> s_table19{{
 constexpr std::array<GekkoOPTemplate, 107> s_table31{{
     {266, &Jit64::addx},      // addx
     {778, &Jit64::addx},      // addox
-    {10, &Jit64::arithcx},    // addcx
-    {522, &Jit64::arithcx},   // addcox
+    {10, &Jit64::addcx},    // addcx
+    {522, &Jit64::addcx},   // addcox
     {138, &Jit64::arithXex},  // addex
     {650, &Jit64::arithXex},  // addeox
     {234, &Jit64::arithXex},  // addmex
@@ -170,8 +170,8 @@ constexpr std::array<GekkoOPTemplate, 107> s_table31{{
     {616, &Jit64::negx},      // negox
     {40, &Jit64::subfx},      // subfx
     {552, &Jit64::subfx},     // subfox
-    {8, &Jit64::arithcx},     // subfcx
-    {520, &Jit64::arithcx},   // subfcox
+    {8, &Jit64::subfcx},     // subfcx
+    {520, &Jit64::subfcx},   // subfcox
     {136, &Jit64::arithXex},  // subfex
     {648, &Jit64::arithXex},  // subfeox
     {232, &Jit64::arithXex},  // subfmex


### PR DESCRIPTION
Various optimizations for `addx`/`subfx` can be applied to `addcx`/`subfcx` as well. Rather than painstakingly replicating these optimizations in `arithcx`, I feel it makes more sense to remove it entirely and just add handling for the carry flag to `addx`/`subfx`.

---

**addcx**

<details><summary>Optimize for size</summary>

Before:
```
BE 01 00 00 00       mov         esi,1
03 75 A8             add         esi,dword ptr [rbp-58h]
```

After:
```
8B 75 A8             mov         esi,dword ptr [rbp-58h]
83 C6 01             add         esi,1
```
</details>

<details><summary>Optimize constant zero</summary>

Before:
```
44 8B C7             mov         r8d,edi
41 83 C0 00          add         r8d,0
```

After:
```
44 8B C7             mov         r8d,edi
F8                   clc
```
</details>

---

**subfcx**
<details><summary>Optimize constant a and b (Example 1)</summary>

Before:
```
BE 00 00 00 00       mov         esi,0
83 EE 08             sub         esi,8
```

After:
```
F8                   clc
```
</details>
<details><summary>Optimize constant a and b (Example 2)</summary>

Before:
```
41 BF FF 00 00 00    mov         r15d,0FFh
41 83 EF 08          sub         r15d,8
```

After:
```
F9                   stc
```
</details>

<details><summary>Optimize b == 0</summary>

Before:
```
41 B8 00 00 00 00    mov         r8d,0
45 2B C6             sub         r8d,r14d
```

After:
```
45 8B C6             mov         r8d,r14d
41 F7 D8             neg         r8d
```
</details>

<details><summary>Optimize constant a</summary>

Before:
```
41 BE 08 00 00 00    mov         r14d,8
41 8B C6             mov         eax,r14d
44 8B F6             mov         r14d,esi
44 2B F0             sub         r14d,eax
```

After:
```
44 8B F6             mov         r14d,esi
41 83 EE 08          sub         r14d,8
```
</details>

<details><summary>Optimize a == 0</summary>

Before:
```
44 8B EE             mov         r13d,esi
41 83 ED 00          sub         r13d,0
```

After:
```
44 8B EE             mov         r13d,esi
F9                   stc
```
</details>