### PR TITLE
HotkeyScheduler: Check for certain hotkeys in game list

### DIFF
--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -169,11 +169,24 @@ void HotkeyScheduler::Run()
 
       HotkeyManagerEmu::GetStatus(true);
 
-      if (!Core::IsRunningAndStarted())
-        continue;
-
+      // Open
       if (IsHotkey(HK_OPEN))
         emit Open();
+
+      // Refresh Game List
+      if (IsHotkey(HK_REFRESH_LIST))
+        emit RefreshGameListHotkey();
+
+      // Recording
+      if (IsHotkey(HK_START_RECORDING))
+        emit StartRecording();
+
+      // Exit
+      if (IsHotkey(HK_EXIT))
+        emit ExitHotkey();
+
+      if (!Core::IsRunningAndStarted())
+        continue;
 
       // Disc
 
@@ -191,10 +204,6 @@ void HotkeyScheduler::Run()
         // Prevent fullscreen from getting toggled too often
         Common::SleepCurrentThread(100);
       }
-
-      // Refresh Game List
-      if (IsHotkey(HK_REFRESH_LIST))
-        emit RefreshGameListHotkey();
 
       // Pause and Unpause
       if (IsHotkey(HK_PLAY_PAUSE))
@@ -215,10 +224,6 @@ void HotkeyScheduler::Run()
       if (IsHotkey(HK_SCREENSHOT))
         emit ScreenShotHotkey();
 
-      // Exit
-      if (IsHotkey(HK_EXIT))
-        emit ExitHotkey();
-
       // Unlock Cursor
       if (IsHotkey(HK_UNLOCK_CURSOR))
         emit UnlockCursor();
@@ -231,10 +236,6 @@ void HotkeyScheduler::Run()
 
       if (IsHotkey(HK_REQUEST_GOLF_CONTROL))
         emit RequestGolfControl();
-
-      // Recording
-      if (IsHotkey(HK_START_RECORDING))
-        emit StartRecording();
 
       if (IsHotkey(HK_EXPORT_RECORDING))
         emit ExportRecording();


### PR DESCRIPTION
There are certain hotkeys that we absolutely want to be able to use without being in-game. Presently, no hotkeys are recognized unless we are in-game.

I've identified and moved the following hotkeys to be checked before the HotkeyScheduler checks to see if the Core is running:

- _Open_
- _Exit_
- _Start Recording_
- _Refresh Game List_

Note that _Play Recording_ should also be implemented here, however it looks like there is no signal for a PlayRecording() function, so this will have to be handled in a later PR once that signal is created and implemented.