### PR TITLE
HotkeyScheduler: add PlayRecording hotkey support

### DIFF
--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -186,7 +186,13 @@ void HotkeyScheduler::Run()
         emit ExitHotkey();
 
       if (!Core::IsRunningAndStarted())
+      {
+        // Only check for Play Recording hotkey when no game is running
+        if (IsHotkey(HK_PLAY_RECORDING))
+          emit PlayRecording();
+
         continue;
+      }
 
       // Disc
 

--- a/Source/Core/DolphinQt/HotkeyScheduler.h
+++ b/Source/Core/DolphinQt/HotkeyScheduler.h
@@ -47,6 +47,7 @@ signals:
   void StateLoadUndo();
   void StateSaveUndo();
   void StartRecording();
+  void PlayRecording();
   void ExportRecording();
   void ToggleReadOnlyMode();
   void ConnectWiiRemote(int id);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -590,6 +590,7 @@ void MainWindow::ConnectHotkeys()
           &MainWindow::SetStateSlot);
   connect(m_hotkey_scheduler, &HotkeyScheduler::StartRecording, this,
           &MainWindow::OnStartRecording);
+  connect(m_hotkey_scheduler, &HotkeyScheduler::PlayRecording, this, &MainWindow::OnPlayRecording);
   connect(m_hotkey_scheduler, &HotkeyScheduler::ExportRecording, this,
           &MainWindow::OnExportRecording);
   connect(m_hotkey_scheduler, &HotkeyScheduler::ConnectWiiRemote, this,


### PR DESCRIPTION
This hotkey was not previously implemented in the scheduler, even though it's present in the hotkey menu.