### PR TITLE
TASInputWindow: always recognize hotkeys

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -158,6 +158,11 @@ bool Host_RendererHasFullFocus()
   return true;
 }
 
+bool Host_TASInputHasFullFocus()
+{
+  return false;
+}
+
 bool Host_RendererIsFullscreen()
 {
   return false;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -1116,11 +1116,13 @@ void DoFrameStep()
 void UpdateInputGate(bool require_focus, bool require_full_focus)
 {
   // If the user accepts background input, controls should pass even if an on screen interface is on
-  const bool focus_passes =
-      !require_focus || (Host_RendererHasFocus() && !Host_UIBlocksControllerState());
+  const bool focus_passes = !require_focus ||
+                            (Host_RendererHasFocus() && !Host_UIBlocksControllerState()) ||
+                            Host_TASInputHasFullFocus();
   // Ignore full focus if we don't require basic focus
-  const bool full_focus_passes =
-      !require_focus || !require_full_focus || (focus_passes && Host_RendererHasFullFocus());
+  const bool full_focus_passes = !require_focus || !require_full_focus ||
+                                 (focus_passes && Host_RendererHasFullFocus()) ||
+                                 Host_TASInputHasFullFocus();
   ControlReference::SetInputGate(focus_passes && full_focus_passes);
 }
 

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -52,6 +52,7 @@ std::vector<std::string> Host_GetPreferredLocales();
 bool Host_UIBlocksControllerState();
 bool Host_RendererHasFocus();
 bool Host_RendererHasFullFocus();
+bool Host_TASInputHasFullFocus();
 bool Host_RendererIsFullscreen();
 
 void Host_Message(HostMessageID id);

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -103,6 +103,11 @@ bool Host_RendererHasFullFocus()
   return Host_RendererHasFocus();
 }
 
+bool Host_TASInputHasFullFocus()
+{
+  return false;
+}
+
 bool Host_RendererIsFullscreen()
 {
   return s_platform->IsWindowFullscreen();

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -118,6 +118,16 @@ void Host::SetRenderFullFocus(bool focus)
   m_render_full_focus = focus;
 }
 
+bool Host::GetTASInputFullFocus()
+{
+  return m_tas_input_full_focus;
+}
+
+void Host::SetTASInputFullFocus(bool focus)
+{
+  m_tas_input_full_focus = focus;
+}
+
 bool Host::GetGBAFocus()
 {
 #ifdef HAS_LIBMGBA
@@ -185,6 +195,11 @@ bool Host_RendererHasFocus()
 bool Host_RendererHasFullFocus()
 {
   return Host::GetInstance()->GetRenderFullFocus();
+}
+
+bool Host_TASInputHasFullFocus()
+{
+  return Host::GetInstance()->GetTASInputFullFocus();
 }
 
 bool Host_RendererIsFullscreen()

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -27,6 +27,7 @@ public:
   bool GetRenderFocus();
   bool GetRenderFullFocus();
   bool GetRenderFullscreen();
+  bool GetTASInputFullFocus();
   bool GetGBAFocus();
 
   void SetMainWindowHandle(void* handle);
@@ -34,6 +35,7 @@ public:
   void SetRenderFocus(bool focus);
   void SetRenderFullFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
+  void SetTASInputFullFocus(bool focus);
   void ResizeSurface(int new_width, int new_height);
   void RequestNotifyMapLoaded();
 
@@ -52,5 +54,6 @@ private:
   std::atomic<bool> m_render_to_main{false};
   std::atomic<bool> m_render_focus{false};
   std::atomic<bool> m_render_full_focus{false};
+  std::atomic<bool> m_tas_input_full_focus{false};
   std::atomic<bool> m_render_fullscreen{false};
 };

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1758,6 +1758,7 @@ void MainWindow::ShowTASInput()
       m_gc_tas_input_windows[i]->show();
       m_gc_tas_input_windows[i]->raise();
       m_gc_tas_input_windows[i]->activateWindow();
+      m_gc_tas_input_windows[i]->setFocus();
     }
   }
 
@@ -1769,6 +1770,7 @@ void MainWindow::ShowTASInput()
       m_wii_tas_input_windows[i]->show();
       m_wii_tas_input_windows[i]->raise();
       m_wii_tas_input_windows[i]->activateWindow();
+      m_wii_tas_input_windows[i]->setFocus();
     }
   }
 }

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -16,6 +16,7 @@
 
 #include "Common/CommonTypes.h"
 
+#include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/AspectRatioWidget.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/Resources.h"
@@ -234,4 +235,14 @@ void TASInputWindow::GetSpinBoxU16(QSpinBox* spin, u16& controller_value)
   }
 
   controller_value = spin->value();
+}
+
+void TASInputWindow::focusOutEvent(QFocusEvent* event)
+{
+  Host::GetInstance()->SetTASInputFullFocus(false);
+}
+
+void TASInputWindow::focusInEvent(QFocusEvent* event)
+{
+  Host::GetInstance()->SetTASInputFullFocus(true);
 }

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.h
@@ -45,6 +45,9 @@ protected:
   QSpinBox* m_turbo_press_frames;
   QSpinBox* m_turbo_release_frames;
 
+  void focusOutEvent(QFocusEvent* event);
+  void focusInEvent(QFocusEvent* event);
+
 private:
   std::map<TASCheckBox*, bool> m_checkbox_set_by_controller;
   std::map<QSpinBox*, u8> m_spinbox_most_recent_values_u8;

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -42,6 +42,10 @@ bool Host_RendererHasFullFocus()
 {
   return false;
 }
+bool Host_TASInputHasFullFocus()
+{
+  return false;
+}
 bool Host_RendererIsFullscreen()
 {
   return false;

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -46,6 +46,10 @@ bool Host_RendererHasFullFocus()
 {
   return false;
 }
+bool Host_TASInputHasFullFocus()
+{
+  return false;
+}
 bool Host_RendererIsFullscreen()
 {
   return false;


### PR DESCRIPTION
This is a quality-of-life fix for those using TAS Input to record Tool-Assisted recordings.

Previously, hotkeys would not be recognized when TAS Input windows are in focus, unless "Hotkeys Require Window Focus" was disabled. Disabling this setting obviously causes hotkeys to register while other applications are in focus.

TASers do not expect to have to tab into the game renderer in order to frame advance. If they share my belief, then it is inconvenient if hotkeys are registered when tabbed out into other applications.

As such, this commit allows hotkeys to register always when TAS Input windows are in focus.

I believe I have added a `Host_TASInputHasFullFocus()` function for every GUI backend, but please let me know if I have missed one.

NOTE: this will conflict with #10130 and will need to be resolved upon its merge.