### PR TITLE
Include digital L and R buttons in Input Display

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -648,8 +648,16 @@ static void SetInputDisplayString(ControllerState padState, int controllerID)
     if (padState.reset)
       display_str += " RESET";
 
-    display_str += Analog1DToString(padState.TriggerL, " L");
-    display_str += Analog1DToString(padState.TriggerR, " R");
+    if (padState.TriggerL == 255 || padState.L)
+      display_str += " L";
+    else
+      display_str += Analog1DToString(padState.TriggerL, " L");
+
+    if (padState.TriggerR == 255 || padState.R)
+      display_str += " R";
+    else
+      display_str += Analog1DToString(padState.TriggerR, " R");
+
     display_str += Analog2DToString(padState.AnalogStickX, padState.AnalogStickY, " ANA");
     display_str += Analog2DToString(padState.CStickX, padState.CStickY, " C");
   }


### PR DESCRIPTION
Previously, using TAS Input to activate the digital L and R buttons would not show these inputs in the Input Display.

This commit adds the digital L and R presses to the Input Display, and also displays just "L" or "R" if the analog is set to 255.

Here is a before and after image.
<img src="https://user-images.githubusercontent.com/16770560/134787150-16c131c7-110c-47c6-8f47-25050870aed2.png" width="300"><img src="https://user-images.githubusercontent.com/16770560/134787107-da17a6c5-0757-47c5-98c7-0903619275ec.png" width="300">

