### PR TITLE
Core: fix hotkeys not being recognized on game list

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -152,6 +152,11 @@ bool Host_RendererHasFocus()
   return true;
 }
 
+bool Host_MainWindowHasFocus()
+{
+  return false;
+}
+
 bool Host_RendererHasFullFocus()
 {
   // Mouse cursor locking actually exists in Android but we don't implement (nor need) that

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -1115,9 +1115,12 @@ void DoFrameStep()
 
 void UpdateInputGate(bool require_focus, bool require_full_focus)
 {
+  // Check for core not running and main window focus
+  const bool main_window_focus_passes = Host_MainWindowHasFocus() && !IsRunning();
   // If the user accepts background input, controls should pass even if an on screen interface is on
   const bool focus_passes =
-      !require_focus || (Host_RendererHasFocus() && !Host_UIBlocksControllerState());
+      !require_focus ||
+      ((Host_RendererHasFocus() || (main_window_focus_passes)) && !Host_UIBlocksControllerState());
   // Ignore full focus if we don't require basic focus
   const bool full_focus_passes =
       !require_focus || !require_full_focus || (focus_passes && Host_RendererHasFullFocus());

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -53,6 +53,7 @@ bool Host_UIBlocksControllerState();
 bool Host_RendererHasFocus();
 bool Host_RendererHasFullFocus();
 bool Host_RendererIsFullscreen();
+bool Host_MainWindowHasFocus();
 
 void Host_Message(HostMessageID id);
 void Host_NotifyMapLoaded();

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -108,6 +108,11 @@ bool Host_RendererIsFullscreen()
   return s_platform->IsWindowFullscreen();
 }
 
+bool Host_MainWindowHasFocus()
+{
+  return false;
+}
+
 void Host_YieldToUI()
 {
 }

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -118,6 +118,16 @@ void Host::SetRenderFullFocus(bool focus)
   m_render_full_focus = focus;
 }
 
+bool Host::GetMainWindowFocus()
+{
+  return m_main_window_focus;
+}
+
+void Host::SetMainWindowFocus(bool focus)
+{
+  m_main_window_focus = focus;
+}
+
 bool Host::GetGBAFocus()
 {
 #ifdef HAS_LIBMGBA
@@ -180,6 +190,11 @@ void Host_UpdateTitle(const std::string& title)
 bool Host_RendererHasFocus()
 {
   return Host::GetInstance()->GetRenderFocus() || Host::GetInstance()->GetGBAFocus();
+}
+
+bool Host_MainWindowHasFocus()
+{
+  return Host::GetInstance()->GetMainWindowFocus();
 }
 
 bool Host_RendererHasFullFocus()

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -28,12 +28,14 @@ public:
   bool GetRenderFullFocus();
   bool GetRenderFullscreen();
   bool GetGBAFocus();
+  bool GetMainWindowFocus();
 
   void SetMainWindowHandle(void* handle);
   void SetRenderHandle(void* handle);
   void SetRenderFocus(bool focus);
   void SetRenderFullFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
+  void SetMainWindowFocus(bool focus);
   void ResizeSurface(int new_width, int new_height);
   void RequestNotifyMapLoaded();
 
@@ -53,4 +55,5 @@ private:
   std::atomic<bool> m_render_focus{false};
   std::atomic<bool> m_render_full_focus{false};
   std::atomic<bool> m_render_fullscreen{false};
+  std::atomic<bool> m_main_window_focus{false};
 };

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -807,6 +807,8 @@ void MainWindow::OnStopComplete()
 
   SetFullScreenResolution(false);
 
+  Host::GetInstance()->SetMainWindowFocus(true);
+
   if (m_exit_requested || Settings::Instance().IsBatchModeEnabled())
     QGuiApplication::instance()->quit();
 
@@ -1035,6 +1037,8 @@ void MainWindow::StartGame(std::unique_ptr<BootParameters>&& parameters)
 
   // We need the render widget before booting.
   ShowRenderWidget();
+
+  Host::GetInstance()->SetMainWindowFocus(false);
 
   // Boot up, show an error if it fails to load the game.
   if (!BootManager::BootCore(std::move(parameters),
@@ -1530,6 +1534,17 @@ bool MainWindow::eventFilter(QObject* object, QEvent* event)
       m_exit_requested = true;
 
     static_cast<QCloseEvent*>(event)->ignore();
+    return true;
+  }
+
+  if (event->type() == QEvent::WindowActivate)
+  {
+    Host::GetInstance()->SetMainWindowFocus(true);
+    return true;
+  }
+  else if (event->type() == QEvent::WindowDeactivate)
+  {
+    Host::GetInstance()->SetMainWindowFocus(false);
     return true;
   }
 

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -46,6 +46,10 @@ bool Host_RendererIsFullscreen()
 {
   return false;
 }
+bool Host_MainWindowHasFocus()
+{
+  return false;
+}
 void Host_YieldToUI()
 {
 }

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -50,6 +50,10 @@ bool Host_RendererIsFullscreen()
 {
   return false;
 }
+bool Host_MainWindowHasFocus()
+{
+  return false;
+}
 void Host_YieldToUI()
 {
 }


### PR DESCRIPTION
Previously I had PR #10122 merged in which the HotkeyScheduler was changed to check for certain hotkeys before checking if the core is running and started.

However, those hotkeys do not pass the focus_passes check. It appears I mistakenly had "Hotkeys Require Window Focus" disabled and failed to identify that...

As such, I've added a case to pass the focus check if the core is not running and the main window has focus.

This appears to resolve the issue.

I was not able to identify any negative implications of this change. Please let me know if you find this is not the case.

NOTE: this will conflict with #10125 and will need to be resolved upon its merge.