### PR TITLE
IOWindow: Do not accept on syntax errors

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -515,9 +515,11 @@ void IOWindow::OnDialogButtonPressed(QAbstractButton* button)
   {
     ModalMessageBox::warning(this, tr("Error"), tr("The expression contains a syntax error."));
   }
-
-  // must be the OK button
-  accept();
+  else
+  {
+    // must be the OK button
+    accept();
+  }
 }
 
 void IOWindow::OnDetectButtonPressed()

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -509,7 +509,6 @@ void IOWindow::OnDialogButtonPressed(QAbstractButton* button)
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
 
   UpdateExpression(m_expression_text->toPlainText().toStdString());
-  m_original_expression = m_reference->GetExpression();
 
   if (ciface::ExpressionParser::ParseStatus::SyntaxError == m_reference->GetParseStatus())
   {
@@ -518,6 +517,7 @@ void IOWindow::OnDialogButtonPressed(QAbstractButton* button)
   else
   {
     // must be the OK button
+    m_original_expression = m_reference->GetExpression();
     accept();
   }
 }


### PR DESCRIPTION
In the current Dolphin dev, typing anything into a hotkey formula box and clicking OK would prompt you with a syntax error window, only for your gibberish to be accepted as input. After closing out of the error window, your change would be applied and the formula window would close.

This PR fixes two issues, the latter of which is only exposed when the former is fixed.

1) Do not accept on hotkey syntax errors
- Pressing okay on the warning window when receiving a syntax error will still call accept() in the IOWindow. Thus, your syntactically incorrect changes will still be applied.
2) Do not overwrite hotkey config on window close
- With step 1 resolved, this then exposes the issue where the hotkey expression is already updated by the point that you hit "OK', regardless of whether or not there was a syntax issue. Closing the window after this point would still overwrite your expression with whatever gibberish you just entered. So the second commit moves the m_original_expression update so that it only updates when a syntax error does not occur.

Before:
https://i.imgur.com/SgWm6AW.mp4

After:
https://i.imgur.com/lcHY8fK.mp4