### PR TITLE
TASInputWindow: function as an input viewer when playing back recording

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -175,6 +175,14 @@ void Host_TitleChanged()
   env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(), IDCache::GetOnTitleChanged());
 }
 
+void Host_EnableTASInput()
+{
+}
+
+void Host_DisableTASInput()
+{
+}
+
 std::unique_ptr<GBAHostInterface> Host_CreateGBAHost(std::weak_ptr<HW::GBA::Core> core)
 {
   return nullptr;

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -110,15 +110,20 @@ int CSIDevice_GCController::RunBuffer(u8* buffer, int request_length)
 
 void CSIDevice_GCController::HandleMoviePadStatus(int device_number, GCPadStatus* pad_status)
 {
-  Movie::CallGCInputManip(pad_status, device_number);
+  if (!Movie::IsPlayingInput())
+  {
+    Movie::CallGCInputManip(pad_status, device_number);
+    Movie::SetPolledDevice();
+  }
 
-  Movie::SetPolledDevice();
   if (NetPlay_GetInput(device_number, pad_status))
   {
   }
   else if (Movie::IsPlayingInput())
   {
     Movie::PlayController(pad_status, device_number);
+    Movie::CallGCInputManip(pad_status, device_number);
+    Movie::SetPolledDevice();
     Movie::InputUpdate();
   }
   else if (Movie::IsRecordingInput())

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -60,6 +60,8 @@ void Host_RefreshDSPDebuggerWindow();
 void Host_RequestRenderWindowSize(int width, int height);
 void Host_UpdateDisasmDialog();
 void Host_UpdateMainFrame();
+void Host_EnableTASInput();
+void Host_DisableTASInput();
 void Host_UpdateTitle(const std::string& title);
 void Host_YieldToUI();
 void Host_TitleChanged();

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -57,6 +57,7 @@
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
 #include "Core/HW/WiimoteEmu/ExtensionPort.h"
 
+#include "Core/Host.h"
 #include "Core/IOS/USB/Bluetooth/BTEmu.h"
 #include "Core/IOS/USB/Bluetooth/WiimoteDevice.h"
 #include "Core/NetPlayProto.h"
@@ -1116,6 +1117,7 @@ void LoadInput(const std::string& movie_path)
       {
         s_playMode = MODE_PLAYING;
         Core::UpdateWantDeterminism();
+        Host_DisableTASInput();
         Core::DisplayMessage("Switched to playback", 2000);
       }
     }
@@ -1125,6 +1127,7 @@ void LoadInput(const std::string& movie_path)
       {
         s_playMode = MODE_RECORDING;
         Core::UpdateWantDeterminism();
+        Host_EnableTASInput();
         Core::DisplayMessage("Switched to recording", 2000);
       }
     }
@@ -1292,6 +1295,7 @@ void EndPlayInput(bool cont)
 
     s_playMode = MODE_RECORDING;
     Core::DisplayMessage("Reached movie end. Resuming recording.", 2000);
+    Host_EnableTASInput();
   }
   else if (s_playMode != MODE_NONE)
   {
@@ -1303,6 +1307,7 @@ void EndPlayInput(bool cont)
     s_currentByte = 0;
     s_playMode = MODE_NONE;
     Core::DisplayMessage("Movie End.", 2000);
+    Host_EnableTASInput();
     s_bRecordingFromSaveState = false;
     // we don't clear these things because otherwise we can't resume playback if we load a movie
     // state later

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -88,6 +88,14 @@ void Host_UpdateMainFrame()
   s_update_main_frame_event.Set();
 }
 
+void Host_EnableTASInput()
+{
+}
+
+void Host_DisableTASInput()
+{
+}
+
 void Host_RequestRenderWindowSize(int width, int height)
 {
 }

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -248,3 +248,13 @@ std::unique_ptr<GBAHostInterface> Host_CreateGBAHost(std::weak_ptr<HW::GBA::Core
   return nullptr;
 }
 #endif
+
+void Host_EnableTASInput()
+{
+  emit Host::GetInstance()->EnableTASInput();
+}
+
+void Host_DisableTASInput()
+{
+  emit Host::GetInstance()->DisableTASInput();
+}

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -41,6 +41,8 @@ signals:
   void RequestTitle(const QString& title);
   void RequestStop();
   void RequestRenderSize(int w, int h);
+  void EnableTASInput();
+  void DisableTASInput();
   void UpdateDisasmDialog();
   void NotifyMapLoaded();
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -661,6 +661,8 @@ void MainWindow::ConnectRenderWidget()
 void MainWindow::ConnectHost()
 {
   connect(Host::GetInstance(), &Host::RequestStop, this, &MainWindow::RequestStop);
+  connect(Host::GetInstance(), &Host::EnableTASInput, this, [this] { SetTASInputEnabled(true); });
+  connect(Host::GetInstance(), &Host::DisableTASInput, this, [this] { SetTASInputEnabled(false); });
 }
 
 void MainWindow::ConnectStack()

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -777,6 +777,8 @@ void MainWindow::Play(const std::optional<std::string>& savestate_path)
         Open();
       }
     }
+
+    SetTASInputEnabled(true);
   }
 }
 
@@ -1678,6 +1680,9 @@ void MainWindow::OnPlayRecording()
     emit RecordingStatusChanged(true);
 
     Play(savestate_path);
+
+    // Disable all TAS Input windows so they can be used as a read-only input viewer during playback
+    SetTASInputEnabled(false);
   }
 }
 
@@ -1692,6 +1697,7 @@ void MainWindow::OnStartRecording()
     // The user just chose to record a movie, so that should take precedence
     Movie::SetReadOnly(false);
     emit ReadOnlyModeChanged(true);
+    SetTASInputEnabled(true);
   }
 
   Movie::ControllerTypeArray controllers{};
@@ -1814,5 +1820,28 @@ void MainWindow::Show()
   {
     StartGame(std::move(m_pending_boot));
     m_pending_boot.reset();
+  }
+}
+
+void MainWindow::SetTASInputEnabled(bool enabled)
+{
+  for (int i = 0; i < num_gc_controllers; i++)
+  {
+    QList<QWidget*> widgets = m_gc_tas_input_windows[i]->findChildren<QWidget*>();
+
+    foreach (QWidget* widget, widgets)
+    {
+      widget->setEnabled(enabled);
+    }
+  }
+
+  for (int i = 0; i < num_wii_controllers; i++)
+  {
+    QList<QWidget*> widgets = m_wii_tas_input_windows[i]->findChildren<QWidget*>();
+
+    foreach (QWidget* widget, widgets)
+    {
+      widget->setEnabled(enabled);
+    }
   }
 }

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -178,6 +178,7 @@ private:
   void OnActivateChat();
   void OnRequestGolfControl();
   void ShowTASInput();
+  void SetTASInputEnabled(bool enabled);
 
   void ChangeDisc();
   void EjectDisc();

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -16,6 +16,8 @@
 
 #include "Common/CommonTypes.h"
 
+#include "Core/Movie.h"
+
 #include "DolphinQt/QtUtils/AspectRatioWidget.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/Resources.h"
@@ -174,7 +176,7 @@ template <typename UX>
 void TASInputWindow::GetButton(TASCheckBox* checkbox, UX& buttons, UX mask)
 {
   const bool pressed = (buttons & mask) != 0;
-  if (m_use_controller->isChecked())
+  if (m_use_controller->isChecked() || Movie::IsPlayingInput())
   {
     if (pressed)
     {
@@ -198,7 +200,7 @@ template void TASInputWindow::GetButton<u16>(TASCheckBox* button, u16& pad, u16 
 
 void TASInputWindow::GetSpinBoxU8(QSpinBox* spin, u8& controller_value)
 {
-  if (m_use_controller->isChecked())
+  if (m_use_controller->isChecked() || Movie::IsPlayingInput())
   {
     if (!m_spinbox_most_recent_values_u8.count(spin) ||
         m_spinbox_most_recent_values_u8[spin] != controller_value)
@@ -218,7 +220,7 @@ void TASInputWindow::GetSpinBoxU8(QSpinBox* spin, u8& controller_value)
 
 void TASInputWindow::GetSpinBoxU16(QSpinBox* spin, u16& controller_value)
 {
-  if (m_use_controller->isChecked())
+  if (m_use_controller->isChecked() || Movie::IsPlayingInput())
   {
     if (!m_spinbox_most_recent_values_u16.count(spin) ||
         m_spinbox_most_recent_values_u16[spin] != controller_value)

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -31,6 +31,12 @@ void Host_UpdateDisasmDialog()
 void Host_UpdateMainFrame()
 {
 }
+void Host_EnableTASInput()
+{
+}
+void Host_DisableTASInput()
+{
+}
 void Host_RequestRenderWindowSize(int, int)
 {
 }

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -31,6 +31,12 @@ void Host_UpdateDisasmDialog()
 void Host_UpdateMainFrame()
 {
 }
+void Host_EnableTASInput()
+{
+}
+void Host_DisableTASInput()
+{
+}
 void Host_RequestRenderWindowSize(int, int)
 {
 }


### PR DESCRIPTION
This pull request aims to introduce functionality for TAS Input to act as a read-only input viewer when a movie is being played back.

Initially, this is quite an easy fix by changing when `MovieGCInputManip` is called (to after the .dtm file inputs are writen to pad_status) and changing the `TASInputWindow::GetValue` if-statement condition to accept when a recording is being played back.

However, from here, the user is actually able to interact with the TAS Input window, and doing so will override the inputs from the recording file.

To handle that, I figured that simply setting all components of the TAS Input windows to read-only is sufficient. By extension, this also clearly indicates that a movie is being played back which avoids some confusion.

By this point, the TAS Input window is not properly adjusted when toggling read-only mode via hotkeys or the MenuBar...

To resolve this, in the third commit I handle all cases of playback change in Movie.cpp and use the Host to toggle the TAS Input window mode.