### PR TITLE
RenderBase: Show input count on m_ShowFrameCount

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -569,6 +569,7 @@ void Renderer::DrawDebugText()
       else if (config.m_ShowFrameCount)
       {
         ImGui::Text("Frame: %" PRIu64, Movie::GetCurrentFrame());
+        ImGui::Text("Input: %" PRIu64, Movie::GetCurrentInputCount());
       }
       if (SConfig::GetInstance().m_ShowLag)
         ImGui::Text("Lag: %" PRIu64 "\n", Movie::GetCurrentLagCount());


### PR DESCRIPTION
Just to stay consistent, I believe it is best to show total input polls alongside the framecount if m_ShowFrameCount is true.