### PR TITLE
Fix AbortOnPanicAlert with PanicAlertFmt

### DIFF
--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -106,20 +106,10 @@ std::string GetStringT(const char* string)
   return s_str_translator(string);
 }
 
-// This is the first stop for gui alerts where the log is updated and the
-// correct window is shown
-bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
+static bool ShowMessageAlert(std::string_view text, bool yes_no, MsgType style)
 {
-  // Read message and write it to the log
   const char* caption = GetCaption(style);
-  char buffer[2048];
-
-  va_list args;
-  va_start(args, format);
-  CharArrayFromFormatV(buffer, sizeof(buffer) - 1, s_str_translator(format).c_str(), args);
-  va_end(args);
-
-  ERROR_LOG_FMT(MASTER_LOG, "{}: {}", caption, buffer);
+  ERROR_LOG_FMT(MASTER_LOG, "{}: {}", caption, text);
 
   // Panic alerts.
   if (style == MsgType::Warning && s_abort_on_panic_alert)
@@ -131,26 +121,33 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
   if (s_msg_handler != nullptr &&
       (s_alert_enabled || style == MsgType::Question || style == MsgType::Critical))
   {
-    return s_msg_handler(caption, buffer, yes_no, style);
+    return s_msg_handler(caption, text.data(), yes_no, style);
   }
 
   return true;
 }
 
+// This is the first stop for gui alerts where the log is updated and the
+// correct window is shown, but only for legacy printf-style messages
+bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
+{
+  char buffer[2048];
+
+  va_list args;
+  va_start(args, format);
+  CharArrayFromFormatV(buffer, sizeof(buffer) - 1, s_str_translator(format).c_str(), args);
+  va_end(args);
+
+  return ShowMessageAlert(buffer, yes_no, style);
+}
+
+// This is the first stop for gui alerts where the log is updated and the
+// correct window is shown, when using fmt
 bool MsgAlertFmtImpl(bool yes_no, MsgType style, fmt::string_view format,
                      const fmt::format_args& args)
 {
-  const char* caption = GetCaption(style);
   const auto message = fmt::vformat(format, args);
-  ERROR_LOG_FMT(MASTER_LOG, "{}: {}", caption, message);
 
-  // Don't ignore questions, especially AskYesNo, PanicYesNo could be ignored
-  if (s_msg_handler != nullptr &&
-      (s_alert_enabled || style == MsgType::Question || style == MsgType::Critical))
-  {
-    return s_msg_handler(caption, message.c_str(), yes_no, style);
-  }
-
-  return true;
+  return ShowMessageAlert(message, yes_no, style);
 }
 }  // namespace Common


### PR DESCRIPTION
PR #10066 added functionality to call std::abort when a panic alert occurs; however, that PR only implemented it for `MsgAlert` and not `MsgAlertFmtImpl`, meaning that the functionality was not used with `PanicAlertFmt` (only `PanicAlert`, which is not used frequently).