### PR TITLE
DTM: add timebase as desync-prevention method

### DIFF
--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -138,6 +138,13 @@ static_assert(sizeof(DTMHeader) == 256, "DTMHeader should be 256 bytes");
 
 #pragma pack(pop)
 
+static constexpr size_t DTMWiiFrameLength(size_t size)
+{
+  return size + sizeof(u64);
+}
+
+constexpr size_t DTMGCFrameLength = sizeof(ControllerState) + sizeof(u64);
+
 void FrameUpdate();
 void InputUpdate();
 void Init(const BootParameters& boot);


### PR DESCRIPTION
**NOTE: This adds extra data to the .dtm format. In the event this PR is merged, DTMs from prior revisions will become pretty much incomprehensible after the header.**

This PR aims to implement an idea introduced by JMC47. By storing the timebase on each input poll and comparing it with the timebase occurred during playback, we can quickly observe the exact point in-game that caused a desync in movie playback.

On every input poll, the `u64 timebase` is read by `Movie::InputUpdate()` and stored to `s_temp_input`. On state load, the dtm is compared with the savestate movie and looks for mismatched timebases to indicate that a desync has occured. On desync detection, a panic alert gives a warning to not continue recording beyond this point in the movie. More on this later.

During playback, to allow TASers to pinpoint the exact frame that they experience a desync, the timebase is checked on every input poll. On mismatch detected (once per playback session, as otherwise this warning would occur every frame going forward), the user is prompted with a warning dialog advising them to not continue.

A few comments:

**Why do we need to write the entire u64 timebase? Why not just the lowest byte, which would catch >99% of desyncs?**
Yes, u64 is overkill in this aspect. But, quite a number of TASers often like to hex edit, that is, manually modify the dtm file. Yes, most hex editors allow you to resize the number of byte columns shown, but because the header is 0x100 in size, input sequences of 8 bytes + the size of the timebase will become misaligned unless timebase+inputs = 2<sup>n</sup> bytes long. If timebase is < 8 bytes long, then this would make hex editing much more tedious and less intuitive.

From a filesize perspective, my 2 hour TTYD TAS is only 9MB and zips to 53KB. The filesize increase of 100% due to adding timebase thus should not be significant enough to warrant reducing the number of bytes we save.

**Why write timebase on every input poll?**
Well the true granularity of data in the .dtm is input polls, which constitute 8 bytes each. It seems like a very poor idea to try to write the timebase on every frame, when there may not always be 2 input polls per frame. After all, it's much easier to explain "each input poll is 16 bytes", rather than "each frame is on average 16 bytes, followed by 8 bytes". Thus, this means the overall file layout stays uniform.

**If a TASer wants to hex edit, then their timebase will obviously become incorrect at some point.**
I imagine that the best way to handle this is the fact that the user can always press to ignore the warning for the current session, continue onward, and then overwrite the movie with latest changes. In doing so, the movie will now reflect the correct timebases.

There's been a bit of a discussion about a DTM 2.0 version, which begs the question: should this PR be merged before there is finalized discussion about what other changes should be made to the format? Is it okay to make these changes independently? Just food for thought.

_A change like this would truly introduce a life-saving safety net for TASers. I would love to see this added in the near future._

I'd appreciate any questions you may have, and any cleanup suggestions. Thanks!