### PR TITLE
fix unused variable warning

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -461,7 +461,7 @@ void VertexLoaderARM64::GenerateVertexLoader()
     const int limit = m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT ? 3 : 1;
 
     s32 offset = -1;
-    for (int i = 0; i < (m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT ? 3 : 1); i++)
+    for (int i = 0; i < limit; i++)
     {
       if (!i || m_VtxAttr.g0.NormalIndex3)
       {


### PR DESCRIPTION
not sure why this diverged from x64 version of the file, seems to have been copy pasted at some point.