### PR TITLE
Add option for setting the PNG zlib compression level

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -64,6 +64,8 @@ add_library(common
   HttpRequest.h
   Image.cpp
   Image.h
+  ImageC.c
+  ImageC.h
   IniFile.cpp
   IniFile.h
   Inline.h

--- a/Source/Core/Common/Image.h
+++ b/Source/Core/Common/Image.h
@@ -20,9 +20,9 @@ enum class ImageByteFormat
 };
 
 bool SavePNG(const std::string& path, const u8* input, ImageByteFormat format, u32 width,
-             u32 height, int stride = 0);
+             u32 height, int stride, int level = 6);
 bool ConvertRGBAToRGBAndSavePNG(const std::string& path, const u8* input, u32 width, u32 height,
-                                int stride = 0);
+                                int stride, int level);
 
 std::vector<u8> RGBAToRGB(const u8* input, u32 width, u32 height, int row_stride = 0);
 

--- a/Source/Core/Common/ImageC.c
+++ b/Source/Core/Common/ImageC.c
@@ -1,0 +1,27 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Common/ImageC.h"
+
+// Since libpng requires use of setjmp, and setjmp interacts poorly with destructors and other C++
+// features, this is in a separate C file.
+
+// The main purpose of this function is to allow specifying the compression level, which
+// png_image_write_to_memory does not allow.  row_pointers is not modified by libpng, but also isn't
+// const for some reason.
+bool SavePNG0(png_structp png_ptr, png_infop info_ptr, int png_format, png_uint_32 width,
+              png_uint_32 height, int level, png_voidp io_ptr, png_rw_ptr write_fn,
+              png_bytepp row_pointers)
+{
+  if (setjmp(png_jmpbuf(png_ptr)) != 0)
+    return false;
+
+  png_set_compression_level(png_ptr, level);
+  png_set_IHDR(png_ptr, info_ptr, width, height, 8, png_format, PNG_INTERLACE_NONE,
+               PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+  png_set_rows(png_ptr, info_ptr, row_pointers);
+  png_set_write_fn(png_ptr, io_ptr, write_fn, NULL);
+  png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
+
+  return true;
+}

--- a/Source/Core/Common/ImageC.h
+++ b/Source/Core/Common/ImageC.h
@@ -1,0 +1,15 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <png.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C"
+#endif
+    bool
+    SavePNG0(png_structp png_ptr, png_infop info_ptr, int png_format, png_uint_32 width,
+             png_uint_32 height, int level, png_voidp io_ptr, png_rw_ptr write_fn,
+             png_bytepp row_pointers);

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -49,6 +49,7 @@ const Info<std::string> GFX_DUMP_PATH{{System::GFX, "Settings", "DumpPath"}, ""}
 const Info<int> GFX_BITRATE_KBPS{{System::GFX, "Settings", "BitrateKbps"}, 25000};
 const Info<bool> GFX_INTERNAL_RESOLUTION_FRAME_DUMPS{
     {System::GFX, "Settings", "InternalResolutionFrameDumps"}, false};
+const Info<int> GFX_PNG_COMPRESSION_LEVEL{{System::GFX, "Settings", "PNGCompressionLevel"}, 6};
 const Info<bool> GFX_ENABLE_GPU_TEXTURE_DECODING{
     {System::GFX, "Settings", "EnableGPUTextureDecoding"}, false};
 const Info<bool> GFX_ENABLE_PIXEL_LIGHTING{{System::GFX, "Settings", "EnablePixelLighting"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -49,6 +49,7 @@ extern const Info<std::string> GFX_DUMP_ENCODER;
 extern const Info<std::string> GFX_DUMP_PATH;
 extern const Info<int> GFX_BITRATE_KBPS;
 extern const Info<bool> GFX_INTERNAL_RESOLUTION_FRAME_DUMPS;
+extern const Info<int> GFX_PNG_COMPRESSION_LEVEL;
 extern const Info<bool> GFX_ENABLE_GPU_TEXTURE_DECODING;
 extern const Info<bool> GFX_ENABLE_PIXEL_LIGHTING;
 extern const Info<bool> GFX_FAST_DEPTH_CALC;

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -110,6 +110,7 @@
     <ClInclude Include="Common\Hash.h" />
     <ClInclude Include="Common\HttpRequest.h" />
     <ClInclude Include="Common\Image.h" />
+    <ClInclude Include="Common\ImageC.h" />
     <ClInclude Include="Common\IniFile.h" />
     <ClInclude Include="Common\Inline.h" />
     <ClInclude Include="Common\Intrinsics.h" />
@@ -714,6 +715,11 @@
     <ClCompile Include="Common\Hash.cpp" />
     <ClCompile Include="Common\HttpRequest.cpp" />
     <ClCompile Include="Common\Image.cpp" />
+    <ClCompile Include="Common\ImageC.c">
+      <!-- This is a C file, not a C++ file, so we can't use the C++ pre-compiled header -->
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ForcedIncludeFiles />
+    </ClCompile>
     <ClCompile Include="Common\IniFile.cpp" />
     <ClCompile Include="Common\IOFile.cpp" />
     <ClCompile Include="Common\JitRegister.cpp" />

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -103,6 +103,7 @@ void AdvancedWidget::CreateWidgets()
                                               Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS);
   m_dump_use_ffv1 = new GraphicsBool(tr("Use Lossless Codec (FFV1)"), Config::GFX_USE_FFV1);
   m_dump_bitrate = new GraphicsInteger(0, 1000000, Config::GFX_BITRATE_KBPS, 1000);
+  m_png_compression_level = new GraphicsInteger(0, 9, Config::GFX_PNG_COMPRESSION_LEVEL);
 
   dump_layout->addWidget(m_use_fullres_framedumps, 0, 0);
 #if defined(HAVE_FFMPEG)
@@ -110,6 +111,9 @@ void AdvancedWidget::CreateWidgets()
   dump_layout->addWidget(new QLabel(tr("Bitrate (kbps):")), 1, 0);
   dump_layout->addWidget(m_dump_bitrate, 1, 1);
 #endif
+  dump_layout->addWidget(new QLabel(tr("PNG Compression Level:")), 2, 0);
+  m_png_compression_level->SetTitle(tr("PNG Compression Level"));
+  dump_layout->addWidget(m_png_compression_level, 2, 1);
 
   // Misc.
   auto* misc_box = new QGroupBox(tr("Misc"));
@@ -251,6 +255,16 @@ void AdvancedWidget::AddDescriptions()
       QT_TR_NOOP("Encodes frame dumps using the FFV1 codec.<br><br><dolphin_emphasis>If "
                  "unsure, leave this unchecked.</dolphin_emphasis>");
 #endif
+  static const char TR_PNG_COMPRESSION_LEVEL_DESCRIPTION[] =
+      QT_TR_NOOP("Specifies the zlib compression level to use when saving PNG images (both for "
+                 "screenshots and framedumping).<br><br>"
+                 "Since PNG uses lossless compression, this does not affect the image quality; "
+                 "instead, it is a trade-off between file size and compression time.<br><br>"
+                 "A value of 0 uses no compression at all.  A value of 1 uses very little "
+                 "compression, while the maximum value of 9 applies a lot of compression.  "
+                 "However, for PNG files, levels between 3 and 6 are generally about as good as "
+                 "level 9 but finish in significantly less time.<br><br>"
+                 "<dolphin_emphasis>If unsure, leave this at 6.</dolphin_emphasis>");
   static const char TR_CROPPING_DESCRIPTION[] = QT_TR_NOOP(
       "Crops the picture from its native aspect ratio to 4:3 or "
       "16:9.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
@@ -306,6 +320,7 @@ void AdvancedWidget::AddDescriptions()
 #ifdef HAVE_FFMPEG
   m_dump_use_ffv1->SetDescription(tr(TR_USE_FFV1_DESCRIPTION));
 #endif
+  m_png_compression_level->SetDescription(tr(TR_PNG_COMPRESSION_LEVEL_DESCRIPTION));
   m_enable_cropping->SetDescription(tr(TR_CROPPING_DESCRIPTION));
   m_enable_prog_scan->SetDescription(tr(TR_PROGRESSIVE_SCAN_DESCRIPTION));
   m_backend_multithreading->SetDescription(tr(TR_BACKEND_MULTITHREADING_DESCRIPTION));

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -52,6 +52,7 @@ private:
   GraphicsBool* m_dump_use_ffv1;
   GraphicsBool* m_use_fullres_framedumps;
   GraphicsInteger* m_dump_bitrate;
+  GraphicsInteger* m_png_compression_level;
 
   // Misc
   GraphicsBool* m_enable_cropping;

--- a/Source/Core/InputCommon/ImageOperations.cpp
+++ b/Source/Core/InputCommon/ImageOperations.cpp
@@ -91,7 +91,7 @@ bool WriteImage(const std::string& path, const ImagePixelData& image)
   }
 
   return Common::SavePNG(path, buffer.data(), Common::ImageByteFormat::RGBA, image.width,
-                         image.height);
+                         image.height, image.width * 4);
 }
 
 ImagePixelData Resize(ResizeMode mode, const ImagePixelData& src, u32 new_width, u32 new_height)

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -38,6 +38,7 @@
 #include "Common/Thread.h"
 #include "Common/Timer.h"
 
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/NetplaySettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
@@ -95,7 +96,8 @@ static float AspectToWidescreen(float aspect)
 static bool DumpFrameToPNG(const FrameDump::FrameData& frame, const std::string& file_name)
 {
   return Common::ConvertRGBAToRGBAndSavePNG(file_name, frame.data, frame.width, frame.height,
-                                            frame.stride);
+                                            frame.stride,
+                                            Config::Get(Config::GFX_PNG_COMPRESSION_LEVEL));
 }
 
 Renderer::Renderer(int backbuffer_width, int backbuffer_height, float backbuffer_scale,


### PR DESCRIPTION
When using large internal resolutions, it can take a while for the image to be compressed.  This PR adds a setting to change the zlib compression level, which enables a trade-off between smaller files and faster saving.  (Since PNG is lossless, the image quality is always the same).

Libpng notes this about the compression levels:

https://github.com/dolphin-emu/dolphin/blob/890a5ed99ad4130d68b3e7228c3398445c33cdc4/Externals/libpng/png.h#L1500-L1509

Libpng presumably uses zlib's default of 6 by default:

https://github.com/dolphin-emu/dolphin/blob/890a5ed99ad4130d68b3e7228c3398445c33cdc4/Externals/zlib/zlib.h#L235-L239 

Though libpng also does have a "fast" option which uses a value of 3:

https://github.com/dolphin-emu/dolphin/blob/890a5ed99ad4130d68b3e7228c3398445c33cdc4/Externals/libpng/pngwrite.c#L2104-L2116

Here are some results using frame 0 of the [Melty Molten Galaxy fifolog](https://fifo.ci/media/dff/MeltyMoltenGalaxy.dff) with arbitrary mipmap detection enabled at auto aspect ratio and an internal resolution of 16x (producing a 12968 by 7296 image):

|Level|Size (bytes)|Time (s)|Size diff|Time diff|
|:---:|-----------:|--------|--------:|--------:|
|  0  | 284,310,113|0:02.942|100%/100%|1.0x/1.0x|
|  1  |  60,348,200|0:04.437|21.2%/21%|1.5x/1.5x|
|  2  |  57,772,001|0:05.307|20.3%/96%|1.8x/1.2x|
|  3  |  54,902,451|0:07.170|19.3%/95%|2.4x/1.4x|
|  4  |  49,811,855|0:07.917|17.5%/91%|2.7x/1.1x|
|  5  |  48,492,485|0:10.111|17.1%/97%|3.4x/1.3x|
|  6  |  47,381,039|0:17.710|16.7%/98%|6.0x/1.8x|
|  7  |  46,835,815|0:29.212|16.5%/99%|9.9x/1.6x|
|  8  |  45,792,636|1:15.136|16.1%/98%|25.5x/2.6x|
|  9  |  45,346,752|2:18.179|15.9%/99%|47.0x/1.8x|

The size diff and time diff values are comparisons to level 0 followed by comparisons to the previous level.