### PR TITLE
DolphinQt/Android: Add warning when converting NKit files

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
@@ -60,6 +60,8 @@ public class GameFile
 
   public native boolean isDatelDisc();
 
+  public native boolean isNKit();
+
   public native int[] getBanner();
 
   public native int getBannerWidth();

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -425,6 +425,7 @@
     <string name="convert_converting">Converting</string>
     <string name="convert_warning_iso">Removing junk data does not save any space when converting to ISO (unless you package the ISO file in a compressed file format such as ZIP afterwards). Do you want to continue anyway?</string>
     <string name="convert_warning_gcz">Converting Wii disc images to GCZ without removing junk data does not save any noticeable amount of space compared to converting to ISO. Do you want to continue anyway?</string>
+    <string name="convert_warning_nkit">Dolphin can\'t convert NKit files to non-NKit files. Converting an NKit file in Dolphin will result in another NKit file.\n\nIf you want to convert an NKit file to a non-NKit file, you can use the same program as you originally used when converting the file to the NKit format.\n\nDo you want to continue anyway?</string>
     <string name="convert_success_message">The disc image was successfully converted.</string>
     <string name="convert_failure_message">Dolphin failed to complete the requested action.</string>
     <string name="convert_format_info">

--- a/Source/Android/jni/GameList/GameFile.cpp
+++ b/Source/Android/jni/GameList/GameFile.cpp
@@ -162,6 +162,12 @@ JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_isDatel
   return static_cast<jboolean>(GetRef(env, obj)->IsDatelDisc());
 }
 
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_isNKit(JNIEnv* env,
+                                                                                jobject obj)
+{
+  return static_cast<jboolean>(GetRef(env, obj)->IsNKit());
+}
+
 JNIEXPORT jintArray JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_getBanner(JNIEnv* env,
                                                                                     jobject obj)
 {

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -329,6 +329,21 @@ void ConvertDialog::Convert()
     }
   }
 
+  if (std::any_of(m_files.begin(), m_files.end(), std::mem_fn(&UICommon::GameFile::IsNKit)))
+  {
+    if (!ShowAreYouSureDialog(
+            tr("Dolphin can't convert NKit files to non-NKit files. Converting an NKit file in "
+               "Dolphin will result in another NKit file.\n"
+               "\n"
+               "If you want to convert an NKit file to a non-NKit file, you can use the same "
+               "program as you originally used when converting the file to the NKit format.\n"
+               "\n"
+               "Do you want to continue anyway?")))
+    {
+      return;
+    }
+  }
+
   QString extension;
   QString filter;
   switch (format)

--- a/Source/Core/UICommon/GameFile.h
+++ b/Source/Core/UICommon/GameFile.h
@@ -106,6 +106,7 @@ public:
   u64 GetVolumeSize() const { return m_volume_size; }
   bool IsVolumeSizeAccurate() const { return m_volume_size_is_accurate; }
   bool IsDatelDisc() const { return m_is_datel_disc; }
+  bool IsNKit() const { return m_is_nkit; }
   const GameBanner& GetBannerImage() const;
   const GameCover& GetCoverImage() const;
   void DoState(PointerWrap& p);


### PR DESCRIPTION
Yes, that's right! It's time to add even more NKit warnings, because users still don't understand what NKit is or how it works!

More specifically, some users seem to be under the impression that converting an NKit file to for instance RVZ using Dolphin's convert feature will result in a normal RVZ file, when it in fact results in an NKit RVZ file (since NKit is not a container format in the sense that GCZ/WIA/RVZ/WBFS/CISO is, but rather a kind of trimmed ISO). I can hardly blame users for not knowing this, because it's not intuitive unless you know the technical details of how NKit works.