### PR TITLE
WiiTASInputWindow: Update on extension change

### DIFF
--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -41,3 +41,8 @@ void ControllersWindow::ConnectWidgets()
 {
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 }
+
+WiimoteControllersWidget* ControllersWindow::GetWiimoteControllers()
+{
+  return m_wiimote_controllers;
+}

--- a/Source/Core/DolphinQt/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.h
@@ -15,6 +15,7 @@ class ControllersWindow final : public QDialog
   Q_OBJECT
 public:
   explicit ControllersWindow(QWidget* parent);
+  WiimoteControllersWidget* GetWiimoteControllers();
 
 private:
   void CreateMainLayout();

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -43,6 +43,7 @@
 #include "DolphinQt/Config/Mapping/WiimoteEmuGeneral.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuMotionControl.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuMotionControlIMU.h"
+#include "DolphinQt/Config/WiimoteControllersWidget.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 #include "DolphinQt/Settings.h"
@@ -550,4 +551,10 @@ void MappingWindow::ShowExtensionMotionTabs(bool show)
     m_tab_widget->removeTab(5);
     m_tab_widget->removeTab(4);
   }
+}
+
+void MappingWindow::OnExtensionChanged(int port, int extension)
+{
+  WiimoteControllersWidget* wiimote_parent = static_cast<WiimoteControllersWidget*>(parent());
+  wiimote_parent->WiimoteExtChanged(port, extension);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -53,6 +53,7 @@ public:
   ControllerEmu::EmulatedController* GetController() const;
   bool IsMappingAllDevices() const;
   void ShowExtensionMotionTabs(bool show);
+  void OnExtensionChanged(int port, int extension);
 
 signals:
   // Emitted when config has changed so widgets can update to reflect the change.

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
@@ -98,6 +98,8 @@ void WiimoteEmuGeneral::OnAttachmentSelected(int extension)
 
   ce_extension->SetSelectedAttachment(extension);
 
+  GetParent()->OnExtensionChanged(GetPort(), extension);
+
   ConfigChanged();
   SaveSettings();
 }

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -337,3 +337,8 @@ void WiimoteControllersWidget::SaveSettings()
 
   SConfig::GetInstance().SaveSettings();
 }
+
+void WiimoteControllersWidget::OnExtensionChanged(int port, int extension)
+{
+  emit WiimoteExtChanged(port, extension);
+}

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
@@ -22,6 +22,9 @@ class WiimoteControllersWidget final : public QWidget
 public:
   explicit WiimoteControllersWidget(QWidget* parent);
 
+signals:
+  void WiimoteExtChanged(int port, int extension);
+
 private:
   void OnWiimoteModeChanged();
   void UpdateDisabledWiimoteControls();
@@ -30,6 +33,7 @@ private:
   void OnBluetoothPassthroughResetPressed();
   void OnWiimoteRefreshPressed();
   void OnWiimoteConfigure();
+  void OnExtensionChanged(int port, int extension);
 
   void CreateLayout();
   void ConnectWidgets();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -29,6 +29,7 @@
 #include <qpa/qplatformnativeinterface.h>
 #endif
 
+#include "Common/CommonTypes.h"
 #include "Common/ScopeGuard.h"
 #include "Common/Version.h"
 #include "Common/WindowSystemInfo.h"
@@ -70,6 +71,7 @@
 #include "DolphinQt/Config/LogWidget.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/Config/SettingsWindow.h"
+#include "DolphinQt/Config/WiimoteControllersWidget.h"
 #include "DolphinQt/Debugger/BreakpointWidget.h"
 #include "DolphinQt/Debugger/CodeViewWidget.h"
 #include "DolphinQt/Debugger/CodeWidget.h"
@@ -1159,6 +1161,9 @@ void MainWindow::ShowControllersWindow()
   {
     m_controllers_window = new ControllersWindow(this);
     InstallHotkeyFilter(m_controllers_window);
+    connect(m_controllers_window->GetWiimoteControllers(),
+            &WiimoteControllersWidget::WiimoteExtChanged, this,
+            [this](int port, int extension) { UpdateWiiTASInputExt(port, extension); });
   }
 
   m_controllers_window->show();
@@ -1815,4 +1820,11 @@ void MainWindow::Show()
     StartGame(std::move(m_pending_boot));
     m_pending_boot.reset();
   }
+}
+
+void MainWindow::UpdateWiiTASInputExt(int port, int ext)
+{
+  m_wii_tas_input_windows[port]->UpdateExt(static_cast<u8>(ext));
+  QSize newSize = m_wii_tas_input_windows[port]->sizeHint();
+  m_wii_tas_input_windows[port]->resize(newSize);
 }

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -178,6 +178,7 @@ private:
   void OnActivateChat();
   void OnRequestGolfControl();
   void ShowTASInput();
+  void UpdateWiiTASInputExt(int port, int ext);
 
   void ChangeDisc();
   void EjectDisc();

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.h
@@ -26,9 +26,9 @@ public:
   explicit WiiTASInputWindow(QWidget* parent, int num);
   void GetValues(WiimoteCommon::DataReportBuilder& rpt, int ext,
                  const WiimoteEmu::EncryptionKey& key);
+  void UpdateExt(u8 ext);
 
 private:
-  void UpdateExt(u8 ext);
   int m_num;
   TASCheckBox* m_a_button;
   TASCheckBox* m_b_button;


### PR DESCRIPTION
Previously, TAS Input window would not be updated in response to a WiiMote extension change. The change to the window would only be applied on the next bootup of Dolphin.

Since TASInputWindows are maintained in MainWindow, we need MainWindow to receive a signal. This signal has to be emitted as a result of execution in WiimoteEmuGeneral(). Holding this to be true, referencing the sender proved to be a bit challenging for me when trying to stay solely in DolphinQt rather than using `Host.h`.

Here are the parent-child relationships:
- MainWindow has child `ControllersWindow* m_controllers_window`.
- ControllersWindow has child `WiimoteControllersWidget* m_wiimote_controllers`.
- `WiimoteControllersWidget::OnWiimoteConfigure()` has **local** child `MappingWindow* window`.
- `MappingWindow::SetMappingType()` has **local** child `WiimoteEmuGeneral* widget`.
- WiimoteEmuGeneral has `OnAttachmentSelected()` which is called on extension change.

Starting from MainWindow, we can navigate from `m_controllers_window` to `m_wiimote_controllers`. We are unable to get to WiimoteControllersWidget's `window` because it is only local to `OnWiimoteConfigure()`.

Now we have to try working our way up the relationships.

`OnAttachmentSelected()` can get its MappingWindow parent, which can get its WiimoteControllersWidget parent.

Since MainWindow can get to WiimoteControllersWidget, and WiimoteEmuGeneral was able to get to WiimoteControllersWidget, this means I am connected to the object emitting the signal, thus the signal can be recognized.


This seems to be a bit cleaner of a solution than I had before, but do let me know if I can do anything to improve further. For one, I don't understand if it is better/worse to use `static_cast<WiimoteControllersWidget*>(parent())` instead of `qobject_cast<WiimoteControllersWidget*>(parent())`.


For the TAS Input GUI, `m_wii_tas_input_windows[port]->resize(newSize);` was used as otherwise switching from an extension which has a larger TAS Input window to an extension which has a smaller TAS Input window would cause the window to remain enlarged.