### PR TITLE
Disable hotkeys on static QFileDialog calls

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -262,6 +262,8 @@ add_executable(dolphin-emu
   NetPlay/NetPlaySetupDialog.h
   NetPlay/PadMappingDialog.cpp
   NetPlay/PadMappingDialog.h
+  QtUtils/DolphinFileDialog.cpp
+  QtUtils/DolphinFileDialog.h
   QtUtils/DoubleClickEventFilter.cpp
   QtUtils/DoubleClickEventFilter.h
   QtUtils/ElidedButton.cpp

--- a/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
@@ -5,7 +5,6 @@
 
 #include <QApplication>
 #include <QCoreApplication>
-#include <QFileDialog>
 #include <QFileInfo>
 #include <QHeaderView>
 #include <QMenu>
@@ -23,6 +22,7 @@
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
 
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
 #include "DolphinQt/Resources.h"
@@ -211,7 +211,8 @@ void FilesystemWidget::PopulateDirectory(int partition_id, QStandardItem* root,
 
 QString FilesystemWidget::SelectFolder()
 {
-  return QFileDialog::getExistingDirectory(this, QObject::tr("Choose the folder to extract to"));
+  return DolphinFileDialog::getExistingDirectory(this,
+                                                 QObject::tr("Choose the folder to extract to"));
 }
 
 void FilesystemWidget::ShowContextMenu(const QPoint&)
@@ -296,7 +297,7 @@ void FilesystemWidget::ShowContextMenu(const QPoint&)
   case EntryType::File:
     menu->addAction(tr("Extract File..."), this, [this, partition, path] {
       auto dest =
-          QFileDialog::getSaveFileName(this, tr("Save File to"), QFileInfo(path).fileName());
+          DolphinFileDialog::getSaveFileName(this, tr("Save File to"), QFileInfo(path).fileName());
 
       if (!dest.isEmpty())
         ExtractFile(partition, path, dest);

--- a/Source/Core/DolphinQt/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt/Config/InfoWidget.cpp
@@ -4,7 +4,6 @@
 #include <QComboBox>
 #include <QCryptographicHash>
 #include <QDir>
-#include <QFileDialog>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QLabel>
@@ -19,6 +18,7 @@
 #include "DiscIO/Volume.h"
 
 #include "DolphinQt/Config/InfoWidget.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ImageConverter.h"
 
 #include "UICommon/UICommon.h"
@@ -190,8 +190,8 @@ QWidget* InfoWidget::CreateBannerGraphic(const QPixmap& image)
 
 void InfoWidget::SaveBanner()
 {
-  QString path = QFileDialog::getSaveFileName(this, tr("Select a File"), QDir::currentPath(),
-                                              tr("PNG image file (*.png);; All Files (*)"));
+  QString path = DolphinFileDialog::getSaveFileName(this, tr("Select a File"), QDir::currentPath(),
+                                                    tr("PNG image file (*.png);; All Files (*)"));
   ToQPixmap(m_game.GetBannerImage()).save(path, "PNG");
 }
 

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -11,7 +11,6 @@
 
 #include <QCheckBox>
 #include <QComboBox>
-#include <QFileDialog>
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QLabel>
@@ -26,6 +25,7 @@
 #include "DiscIO/Blob.h"
 #include "DiscIO/ScrubbedBlob.h"
 #include "DiscIO/WIABlob.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
 #include "UICommon/GameFile.h"
@@ -374,7 +374,7 @@ void ConvertDialog::Convert()
 
   if (m_files.size() > 1)
   {
-    dst_dir = QFileDialog::getExistingDirectory(
+    dst_dir = DolphinFileDialog::getExistingDirectory(
         this, tr("Select where you want to save the converted images"),
         QFileInfo(QString::fromStdString(m_files[0]->GetFilePath())).dir().absolutePath());
 
@@ -383,7 +383,7 @@ void ConvertDialog::Convert()
   }
   else
   {
-    dst_path = QFileDialog::getSaveFileName(
+    dst_path = DolphinFileDialog::getSaveFileName(
         this, tr("Select where you want to save the converted image"),
         QFileInfo(QString::fromStdString(m_files[0]->GetFilePath()))
             .dir()

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="NKitWarningDialog.cpp" />
     <ClCompile Include="QtUtils\AspectRatioWidget.cpp" />
     <ClCompile Include="QtUtils\BlockUserInputFilter.cpp" />
+    <ClCompile Include="QtUtils\DolphinFileDialog.cpp" />
     <ClCompile Include="QtUtils\DoubleClickEventFilter.cpp" />
     <ClCompile Include="QtUtils\ElidedButton.cpp" />
     <ClCompile Include="QtUtils\FileOpenEventFilter.cpp" />
@@ -217,6 +218,7 @@
     <ClInclude Include="Debugger\RegisterColumn.h" />
     <ClInclude Include="GBAHost.h" />
     <ClInclude Include="QtUtils\ActionHelper.h" />
+    <ClInclude Include="QtUtils\DolphinFileDialog.h" />
     <ClInclude Include="QtUtils\FlowLayout.h" />
     <ClInclude Include="QtUtils\ImageConverter.h" />
     <ClInclude Include="QtUtils\ModalMessageBox.h" />

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -6,7 +6,6 @@
 #include <QCheckBox>
 #include <QDialogButtonBox>
 #include <QEvent>
-#include <QFileDialog>
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QIcon>
@@ -27,6 +26,7 @@
 #include "Core/FifoPlayer/FifoRecorder.h"
 
 #include "DolphinQt/FIFO/FIFOAnalyzer.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/Resources.h"
@@ -189,8 +189,8 @@ void FIFOPlayerWindow::ConnectWidgets()
 
 void FIFOPlayerWindow::LoadRecording()
 {
-  QString path = QFileDialog::getOpenFileName(this, tr("Open FIFO log"), QString(),
-                                              tr("Dolphin FIFO Log (*.dff)"));
+  QString path = DolphinFileDialog::getOpenFileName(this, tr("Open FIFO log"), QString(),
+                                                    tr("Dolphin FIFO Log (*.dff)"));
 
   if (path.isEmpty())
     return;
@@ -200,8 +200,8 @@ void FIFOPlayerWindow::LoadRecording()
 
 void FIFOPlayerWindow::SaveRecording()
 {
-  QString path = QFileDialog::getSaveFileName(this, tr("Save FIFO log"), QString(),
-                                              tr("Dolphin FIFO Log (*.dff)"));
+  QString path = DolphinFileDialog::getSaveFileName(this, tr("Save FIFO log"), QString(),
+                                                    tr("Dolphin FIFO Log (*.dff)"));
 
   if (path.isEmpty())
     return;

--- a/Source/Core/DolphinQt/GBAWidget.cpp
+++ b/Source/Core/DolphinQt/GBAWidget.cpp
@@ -26,6 +26,7 @@
 #include "Core/HW/SI/SI_Device.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
@@ -183,7 +184,7 @@ void GBAWidget::UnloadROM()
 
 void GBAWidget::PromptForEReaderCards()
 {
-  const QStringList card_paths = QFileDialog::getOpenFileNames(
+  const QStringList card_paths = DolphinFileDialog::getOpenFileNames(
       this, tr("Select e-Reader Cards"), QString(), tr("e-Reader Cards (*.raw);;All Files (*)"),
       nullptr, QFileDialog::Options());
 
@@ -205,9 +206,10 @@ void GBAWidget::DoState(bool export_state)
     return;
 
   QString state_path = QDir::toNativeSeparators(
-      (export_state ? QFileDialog::getSaveFileName : QFileDialog::getOpenFileName)(
+      (export_state ? DolphinFileDialog::getSaveFileName : DolphinFileDialog::getOpenFileName)(
           this, tr("Select a File"), QString(),
-          tr("mGBA Save States (*.ss0 *.ss1 *.ss2 *.ss3 *.ss4 *.ss5 *.ss6 *.ss7 *.ss8 *.ss9);;"
+          tr("mGBA Save States (*.ss0 *.ss1 *.ss2 *.ss3 *.ss4 "
+             "*.ss5 *.ss6 *.ss7 *.ss8 *.ss9);;"
              "All Files (*)"),
           nullptr, QFileDialog::Options()));
 

--- a/Source/Core/DolphinQt/GCMemcardCreateNewDialog.cpp
+++ b/Source/Core/DolphinQt/GCMemcardCreateNewDialog.cpp
@@ -5,7 +5,6 @@
 
 #include <QComboBox>
 #include <QDialogButtonBox>
-#include <QFileDialog>
 #include <QGridLayout>
 #include <QLabel>
 #include <QPushButton>
@@ -18,6 +17,8 @@
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/GCMemcard/GCMemcard.h"
 #include "Core/HW/Sram.h"
+
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 
 GCMemcardCreateNewDialog::GCMemcardCreateNewDialog(QWidget* parent) : QDialog(parent)
 {
@@ -69,7 +70,7 @@ bool GCMemcardCreateNewDialog::CreateCard()
   const u16 size = static_cast<u16>(m_combobox_size->currentData().toInt());
   const bool is_shift_jis = m_radio_shiftjis->isChecked();
 
-  const QString path = QFileDialog::getSaveFileName(
+  const QString path = DolphinFileDialog::getSaveFileName(
       this, tr("Create New Memory Card"), QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)),
       tr("GameCube Memory Cards (*.raw *.gcp)") + QStringLiteral(";;") + tr("All Files (*)"));
 

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -11,7 +11,6 @@
 
 #include <QDialogButtonBox>
 #include <QDir>
-#include <QFileDialog>
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QHeaderView>
@@ -40,6 +39,7 @@
 #include "Core/HW/GCMemcard/GCMemcardUtils.h"
 
 #include "DolphinQt/GCMemcardCreateNewDialog.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 
 constexpr int ROW_HEIGHT = 36;
@@ -339,7 +339,7 @@ void GCMemcardManager::SetSlotFile(int slot, QString path)
 
 void GCMemcardManager::SetSlotFileInteractive(int slot)
 {
-  QString path = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
+  QString path = QDir::toNativeSeparators(DolphinFileDialog::getOpenFileName(
       this,
       slot == 0 ? tr("Set memory card file for Slot A") : tr("Set memory card file for Slot B"),
       QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)),
@@ -418,7 +418,7 @@ void GCMemcardManager::ExportFiles(Memcard::SavefileFormat format)
     const QString qformatdesc = GetFormatDescription(format);
     const std::string default_path =
         fmt::format("{}/{}{}", File::GetUserPath(D_GCUSER_IDX), basename, extension);
-    const QString qfilename = QFileDialog::getSaveFileName(
+    const QString qfilename = DolphinFileDialog::getSaveFileName(
         this, tr("Export Save File"), QString::fromStdString(default_path),
         QStringLiteral("%1 (*%2);;%3 (*)")
             .arg(qformatdesc, QString::fromStdString(extension), tr("All Files")));
@@ -435,9 +435,9 @@ void GCMemcardManager::ExportFiles(Memcard::SavefileFormat format)
     return;
   }
 
-  const QString qdirpath =
-      QFileDialog::getExistingDirectory(this, QObject::tr("Export Save Files"),
-                                        QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)));
+  const QString qdirpath = DolphinFileDialog::getExistingDirectory(
+      this, QObject::tr("Export Save Files"),
+      QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)));
   if (qdirpath.isEmpty())
     return;
 
@@ -567,7 +567,7 @@ void GCMemcardManager::ImportFile()
   if (!card)
     return;
 
-  const QStringList paths = QFileDialog::getOpenFileNames(
+  const QStringList paths = DolphinFileDialog::getOpenFileNames(
       this, tr("Import Save File(s)"), QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)),
       QStringLiteral("%1 (*.gci *.gcs *.sav);;%2 (*.gci);;%3 (*.gcs);;%4 (*.sav);;%5 (*)")
           .arg(tr("Supported file formats"), GetFormatDescription(Memcard::SavefileFormat::GCI),

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -59,6 +59,7 @@
 #include "DolphinQt/GameList/GridProxyModel.h"
 #include "DolphinQt/GameList/ListProxyModel.h"
 #include "DolphinQt/MenuBar.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/DoubleClickEventFilter.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
@@ -254,7 +255,7 @@ void GameList::MakeEmptyView()
   m_empty->installEventFilter(event_filter);
   connect(event_filter, &DoubleClickEventFilter::doubleClicked, [this] {
     auto current_dir = QDir::currentPath();
-    auto dir = QFileDialog::getExistingDirectory(this, tr("Select a Directory"), current_dir);
+    auto dir = DolphinFileDialog::getExistingDirectory(this, tr("Select a Directory"), current_dir);
     if (!dir.isEmpty())
       Settings::Instance().AddPath(dir);
   });
@@ -489,7 +490,7 @@ void GameList::OpenProperties()
 
 void GameList::ExportWiiSave()
 {
-  const QString export_dir = QFileDialog::getExistingDirectory(
+  const QString export_dir = DolphinFileDialog::getExistingDirectory(
       this, tr("Select Export Directory"), QString::fromStdString(File::GetUserPath(D_USER_IDX)),
       QFileDialog::ShowDirsOnly);
   if (export_dir.isEmpty())

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -7,7 +7,6 @@
 #include <QDir>
 #include <QDragEnterEvent>
 #include <QDropEvent>
-#include <QFileDialog>
 #include <QFileInfo>
 #include <QIcon>
 #include <QMimeData>
@@ -91,6 +90,7 @@
 #include "DolphinQt/NetPlay/NetPlayBrowser.h"
 #include "DolphinQt/NetPlay/NetPlayDialog.h"
 #include "DolphinQt/NetPlay/NetPlaySetupDialog.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/FileOpenEventFilter.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
@@ -712,7 +712,7 @@ void MainWindow::RefreshGameList()
 QStringList MainWindow::PromptFileNames()
 {
   auto& settings = Settings::Instance().GetQSettings();
-  QStringList paths = QFileDialog::getOpenFileNames(
+  QStringList paths = DolphinFileDialog::getOpenFileNames(
       this, tr("Select a File"),
       settings.value(QStringLiteral("mainwindow/lastdir"), QString{}).toString(),
       tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.tgc *.wbfs *.ciso *.gcz *.wia *.rvz *.wad "
@@ -1278,15 +1278,17 @@ void MainWindow::ShowFIFOPlayer()
 
 void MainWindow::StateLoad()
 {
-  QString path = QFileDialog::getOpenFileName(this, tr("Select a File"), QDir::currentPath(),
-                                              tr("All Save States (*.sav *.s##);; All Files (*)"));
+  QString path =
+      DolphinFileDialog::getOpenFileName(this, tr("Select a File"), QDir::currentPath(),
+                                         tr("All Save States (*.sav *.s##);; All Files (*)"));
   State::LoadAs(path.toStdString());
 }
 
 void MainWindow::StateSave()
 {
-  QString path = QFileDialog::getSaveFileName(this, tr("Select a File"), QDir::currentPath(),
-                                              tr("All Save States (*.sav *.s##);; All Files (*)"));
+  QString path =
+      DolphinFileDialog::getSaveFileName(this, tr("Select a File"), QDir::currentPath(),
+                                         tr("All Save States (*.sav *.s##);; All Files (*)"));
   State::SaveAs(path.toStdString());
 }
 
@@ -1612,9 +1614,10 @@ void MainWindow::OnImportNANDBackup()
   if (response == QMessageBox::No)
     return;
 
-  QString file = QFileDialog::getOpenFileName(this, tr("Select the save file"), QDir::currentPath(),
-                                              tr("BootMii NAND backup file (*.bin);;"
-                                                 "All Files (*)"));
+  QString file =
+      DolphinFileDialog::getOpenFileName(this, tr("Select the save file"), QDir::currentPath(),
+                                         tr("BootMii NAND backup file (*.bin);;"
+                                            "All Files (*)"));
 
   if (file.isEmpty())
     return;
@@ -1637,10 +1640,10 @@ void MainWindow::OnImportNANDBackup()
         },
         [this] {
           std::optional<std::string> keys_file = RunOnObject(this, [this] {
-            return QFileDialog::getOpenFileName(this, tr("Select the keys file (OTP/SEEPROM dump)"),
-                                                QDir::currentPath(),
-                                                tr("BootMii keys file (*.bin);;"
-                                                   "All Files (*)"))
+            return DolphinFileDialog::getOpenFileName(
+                       this, tr("Select the keys file (OTP/SEEPROM dump)"), QDir::currentPath(),
+                       tr("BootMii keys file (*.bin);;"
+                          "All Files (*)"))
                 .toStdString();
           });
           if (keys_file)
@@ -1659,8 +1662,8 @@ void MainWindow::OnImportNANDBackup()
 
 void MainWindow::OnPlayRecording()
 {
-  QString dtm_file = QFileDialog::getOpenFileName(this, tr("Select the Recording File to Play"),
-                                                  QString(), tr("Dolphin TAS Movies (*.dtm)"));
+  QString dtm_file = DolphinFileDialog::getOpenFileName(
+      this, tr("Select the Recording File to Play"), QString(), tr("Dolphin TAS Movies (*.dtm)"));
 
   if (dtm_file.isEmpty())
     return;
@@ -1729,8 +1732,8 @@ void MainWindow::OnStopRecording()
 void MainWindow::OnExportRecording()
 {
   Core::RunAsCPUThread([this] {
-    QString dtm_file = QFileDialog::getSaveFileName(this, tr("Save Recording File As"), QString(),
-                                                    tr("Dolphin TAS Movies (*.dtm)"));
+    QString dtm_file = DolphinFileDialog::getSaveFileName(
+        this, tr("Save Recording File As"), QString(), tr("Dolphin TAS Movies (*.dtm)"));
     if (!dtm_file.isEmpty())
       Movie::SaveRecording(dtm_file.toStdString());
   });

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -51,6 +51,7 @@
 
 #include "DolphinQt/AboutDialog.h"
 #include "DolphinQt/Host.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
 #include "DolphinQt/Settings.h"
@@ -1029,8 +1030,8 @@ void MenuBar::UpdateToolsMenu(bool emulation_started)
 
 void MenuBar::InstallWAD()
 {
-  QString wad_file = QFileDialog::getOpenFileName(this, tr("Select a title to install to NAND"),
-                                                  QString(), tr("WAD files (*.wad)"));
+  QString wad_file = DolphinFileDialog::getOpenFileName(
+      this, tr("Select a title to install to NAND"), QString(), tr("WAD files (*.wad)"));
 
   if (wad_file.isEmpty())
     return;
@@ -1049,9 +1050,10 @@ void MenuBar::InstallWAD()
 
 void MenuBar::ImportWiiSave()
 {
-  QString file = QFileDialog::getOpenFileName(this, tr("Select the save file"), QDir::currentPath(),
-                                              tr("Wii save files (*.bin);;"
-                                                 "All Files (*)"));
+  QString file =
+      DolphinFileDialog::getOpenFileName(this, tr("Select the save file"), QDir::currentPath(),
+                                         tr("Wii save files (*.bin);;"
+                                            "All Files (*)"));
 
   if (file.isEmpty())
     return;
@@ -1093,7 +1095,7 @@ void MenuBar::ImportWiiSave()
 
 void MenuBar::ExportWiiSaves()
 {
-  const QString export_dir = QFileDialog::getExistingDirectory(
+  const QString export_dir = DolphinFileDialog::getExistingDirectory(
       this, tr("Select Export Directory"), QString::fromStdString(File::GetUserPath(D_USER_IDX)),
       QFileDialog::ShowDirsOnly);
   if (export_dir.isEmpty())
@@ -1482,7 +1484,7 @@ void MenuBar::SaveSymbolMap()
 
 void MenuBar::LoadOtherSymbolMap()
 {
-  const QString file = QFileDialog::getOpenFileName(
+  const QString file = DolphinFileDialog::getOpenFileName(
       this, tr("Load map file"), QString::fromStdString(File::GetUserPath(D_MAPS_IDX)),
       tr("Dolphin Map File (*.map)"));
 
@@ -1498,7 +1500,7 @@ void MenuBar::LoadOtherSymbolMap()
 
 void MenuBar::LoadBadSymbolMap()
 {
-  const QString file = QFileDialog::getOpenFileName(
+  const QString file = DolphinFileDialog::getOpenFileName(
       this, tr("Load map file"), QString::fromStdString(File::GetUserPath(D_MAPS_IDX)),
       tr("Dolphin Map File (*.map)"));
 
@@ -1515,7 +1517,7 @@ void MenuBar::LoadBadSymbolMap()
 void MenuBar::SaveSymbolMapAs()
 {
   const std::string& title_id_str = SConfig::GetInstance().m_debugger_game_id;
-  const QString file = QFileDialog::getSaveFileName(
+  const QString file = DolphinFileDialog::getSaveFileName(
       this, tr("Save map file"),
       QString::fromStdString(File::GetUserPath(D_MAPS_IDX) + "/" + title_id_str + ".map"),
       tr("Dolphin Map File (*.map)"));
@@ -1568,8 +1570,8 @@ void MenuBar::CreateSignatureFile()
       this, tr("Input"), tr("Only export symbols with prefix:\n(Blank for all symbols)"),
       QLineEdit::Normal, QString{}, nullptr, Qt::WindowCloseButtonHint);
 
-  const QString file = QFileDialog::getSaveFileName(this, tr("Save signature file"),
-                                                    QDir::homePath(), GetSignatureSelector());
+  const QString file = DolphinFileDialog::getSaveFileName(this, tr("Save signature file"),
+                                                          QDir::homePath(), GetSignatureSelector());
   if (file.isEmpty())
     return;
 
@@ -1593,8 +1595,8 @@ void MenuBar::AppendSignatureFile()
       this, tr("Input"), tr("Only append symbols with prefix:\n(Blank for all symbols)"),
       QLineEdit::Normal, QString{}, nullptr, Qt::WindowCloseButtonHint);
 
-  const QString file = QFileDialog::getSaveFileName(this, tr("Append signature to"),
-                                                    QDir::homePath(), GetSignatureSelector());
+  const QString file = DolphinFileDialog::getSaveFileName(this, tr("Append signature to"),
+                                                          QDir::homePath(), GetSignatureSelector());
   if (file.isEmpty())
     return;
 
@@ -1616,8 +1618,8 @@ void MenuBar::AppendSignatureFile()
 
 void MenuBar::ApplySignatureFile()
 {
-  const QString file = QFileDialog::getOpenFileName(this, tr("Apply signature file"),
-                                                    QDir::homePath(), GetSignatureSelector());
+  const QString file = DolphinFileDialog::getOpenFileName(this, tr("Apply signature file"),
+                                                          QDir::homePath(), GetSignatureSelector());
 
   if (file.isEmpty())
     return;
@@ -1633,18 +1635,18 @@ void MenuBar::ApplySignatureFile()
 
 void MenuBar::CombineSignatureFiles()
 {
-  const QString priorityFile = QFileDialog::getOpenFileName(
+  const QString priorityFile = DolphinFileDialog::getOpenFileName(
       this, tr("Choose priority input file"), QDir::homePath(), GetSignatureSelector());
   if (priorityFile.isEmpty())
     return;
 
-  const QString secondaryFile = QFileDialog::getOpenFileName(
+  const QString secondaryFile = DolphinFileDialog::getOpenFileName(
       this, tr("Choose secondary input file"), QDir::homePath(), GetSignatureSelector());
   if (secondaryFile.isEmpty())
     return;
 
-  const QString saveFile = QFileDialog::getSaveFileName(this, tr("Save combined output file as"),
-                                                        QDir::homePath(), GetSignatureSelector());
+  const QString saveFile = DolphinFileDialog::getSaveFileName(
+      this, tr("Save combined output file as"), QDir::homePath(), GetSignatureSelector());
   if (saveFile.isEmpty())
     return;
 

--- a/Source/Core/DolphinQt/QtUtils/DolphinFileDialog.cpp
+++ b/Source/Core/DolphinQt/QtUtils/DolphinFileDialog.cpp
@@ -1,0 +1,39 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinFileDialog.h"
+
+#include <QFileDialog>
+#include <QObject>
+
+QString DolphinFileDialog::getExistingDirectory(QWidget* parent, const QString& caption,
+                                                const QString& dir, QFileDialog::Options options)
+{
+  const HotkeyDisabler disabler;
+  return QFileDialog::getExistingDirectory(parent, caption, dir, options);
+}
+
+QString DolphinFileDialog::getSaveFileName(QWidget* parent, const QString& caption,
+                                           const QString& dir, const QString& filter,
+                                           QString* selectedFilter, QFileDialog::Options options)
+{
+  const HotkeyDisabler disabler;
+  return QFileDialog::getSaveFileName(parent, caption, dir, filter, selectedFilter, options);
+}
+
+QString DolphinFileDialog::getOpenFileName(QWidget* parent, const QString& caption,
+                                           const QString& dir, const QString& filter,
+                                           QString* selectedFilter, QFileDialog::Options options)
+{
+  const HotkeyDisabler disabler;
+  return QFileDialog::getOpenFileName(parent, caption, dir, filter, selectedFilter, options);
+}
+
+QStringList DolphinFileDialog::getOpenFileNames(QWidget* parent, const QString& caption,
+                                                const QString& dir, const QString& filter,
+                                                QString* selectedFilter,
+                                                QFileDialog::Options options)
+{
+  const HotkeyDisabler disabler;
+  return QFileDialog::getOpenFileNames(parent, caption, dir, filter, selectedFilter, options);
+}

--- a/Source/Core/DolphinQt/QtUtils/DolphinFileDialog.h
+++ b/Source/Core/DolphinQt/QtUtils/DolphinFileDialog.h
@@ -1,0 +1,40 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "Core/HotkeyManager.h"
+
+#include <QFileDialog>
+#include <QObject>
+#include <QString>
+
+namespace DolphinFileDialog
+{
+class HotkeyDisabler final
+{
+public:
+  HotkeyDisabler() { HotkeyManagerEmu::Enable(false); }
+  ~HotkeyDisabler() { HotkeyManagerEmu::Enable(true); }
+};
+
+QString getExistingDirectory(QWidget* parent = nullptr, const QString& caption = QString(),
+                             const QString& dir = QString(),
+                             QFileDialog::Options options = QFileDialog::ShowDirsOnly);
+
+QString getOpenFileName(QWidget* parent = nullptr, const QString& caption = QString(),
+                        const QString& dir = QString(), const QString& filter = QString(),
+                        QString* selectedFilter = nullptr,
+                        QFileDialog::Options options = QFileDialog::Options());
+
+QStringList getOpenFileNames(QWidget* parent = nullptr, const QString& caption = QString(),
+                             const QString& dir = QString(), const QString& filter = QString(),
+                             QString* selectedFilter = nullptr,
+                             QFileDialog::Options options = QFileDialog::Options());
+
+QString getSaveFileName(QWidget* parent = nullptr, const QString& caption = QString(),
+                        const QString& dir = QString(), const QString& filter = QString(),
+                        QString* selectedFilter = nullptr,
+                        QFileDialog::Options options = QFileDialog::Options());
+
+}  // namespace DolphinFileDialog

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -32,6 +32,7 @@
 
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/GCMemcardManager.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/BroadbandAdapterSettingsDialog.h"
@@ -292,7 +293,7 @@ void GameCubePane::OnConfigPressed(int slot)
     qFatal("unknown settings pressed");
   }
 
-  QString filename = QFileDialog::getSaveFileName(
+  QString filename = DolphinFileDialog::getSaveFileName(
       this, tr("Choose a file to open"), QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)),
       filter, 0, QFileDialog::DontConfirmOverwrite);
 
@@ -390,7 +391,7 @@ void GameCubePane::OnConfigPressed(int slot)
 
 void GameCubePane::BrowseGBABios()
 {
-  QString file = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
+  QString file = QDir::toNativeSeparators(DolphinFileDialog::getOpenFileName(
       this, tr("Select GBA BIOS"), QString::fromStdString(File::GetUserPath(F_GBABIOS_IDX)),
       tr("All Files (*)")));
   if (!file.isEmpty())
@@ -419,9 +420,9 @@ void GameCubePane::SaveRomPathChanged()
 
 void GameCubePane::BrowseGBASaves()
 {
-  QString dir = QDir::toNativeSeparators(
-      QFileDialog::getExistingDirectory(this, tr("Select GBA Saves Path"),
-                                        QString::fromStdString(File::GetUserPath(D_GBASAVES_IDX))));
+  QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
+      this, tr("Select GBA Saves Path"),
+      QString::fromStdString(File::GetUserPath(D_GBASAVES_IDX))));
   if (!dir.isEmpty())
   {
     m_gba_saves_edit->setText(dir);
@@ -547,7 +548,7 @@ std::string GameCubePane::GetOpenGBARom(std::string_view title)
   if (!title.empty())
     caption += QStringLiteral(": %1").arg(QString::fromStdString(std::string(title)));
   return QDir::toNativeSeparators(
-             QFileDialog::getOpenFileName(
+             DolphinFileDialog::getOpenFileName(
                  nullptr, caption, QString(),
                  tr("Game Boy Advance ROMs (*.gba *.gbc *.gb *.7z *.zip *.agb *.mb *.rom *.bin);;"
                     "All Files (*)")))

--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -3,7 +3,6 @@
 
 #include <QCheckBox>
 #include <QDir>
-#include <QFileDialog>
 #include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
@@ -17,6 +16,7 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/UISettings.h"
 
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/PathPane.h"
 
@@ -34,17 +34,17 @@ PathPane::PathPane(QWidget* parent) : QWidget(parent)
 void PathPane::Browse()
 {
   QString dir = QDir::toNativeSeparators(
-      QFileDialog::getExistingDirectory(this, tr("Select a Directory"), QDir::currentPath()));
+      DolphinFileDialog::getExistingDirectory(this, tr("Select a Directory"), QDir::currentPath()));
   if (!dir.isEmpty())
     Settings::Instance().AddPath(dir);
 }
 
 void PathPane::BrowseDefaultGame()
 {
-  QString file = QDir::toNativeSeparators(
-      QFileDialog::getOpenFileName(this, tr("Select a Game"), Settings::Instance().GetDefaultGame(),
-                                   tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.tgc *.wbfs "
-                                      "*.ciso *.gcz *.wia *.rvz *.wad *.m3u);;All Files (*)")));
+  QString file = QDir::toNativeSeparators(DolphinFileDialog::getOpenFileName(
+      this, tr("Select a Game"), Settings::Instance().GetDefaultGame(),
+      tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.tgc *.wbfs "
+         "*.ciso *.gcz *.wia *.rvz *.wad *.m3u);;All Files (*)")));
 
   if (!file.isEmpty())
     Settings::Instance().SetDefaultGame(file);
@@ -52,7 +52,7 @@ void PathPane::BrowseDefaultGame()
 
 void PathPane::BrowseWiiNAND()
 {
-  QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
+  QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
       this, tr("Select Wii NAND Root"), QString::fromStdString(Config::Get(Config::MAIN_FS_PATH))));
   if (!dir.isEmpty())
   {
@@ -63,7 +63,7 @@ void PathPane::BrowseWiiNAND()
 
 void PathPane::BrowseDump()
 {
-  QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
+  QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
       this, tr("Select Dump Path"), QString::fromStdString(Config::Get(Config::MAIN_DUMP_PATH))));
   if (!dir.isEmpty())
   {
@@ -74,7 +74,7 @@ void PathPane::BrowseDump()
 
 void PathPane::BrowseLoad()
 {
-  QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
+  QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
       this, tr("Select Load Path"), QString::fromStdString(Config::Get(Config::MAIN_LOAD_PATH))));
   if (!dir.isEmpty())
   {
@@ -85,7 +85,7 @@ void PathPane::BrowseLoad()
 
 void PathPane::BrowseResourcePack()
 {
-  QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
+  QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
       this, tr("Select Resource Pack Path"),
       QString::fromStdString(Config::Get(Config::MAIN_RESOURCEPACK_PATH))));
   if (!dir.isEmpty())
@@ -97,7 +97,7 @@ void PathPane::BrowseResourcePack()
 
 void PathPane::BrowseSDCard()
 {
-  QString file = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
+  QString file = QDir::toNativeSeparators(DolphinFileDialog::getOpenFileName(
       this, tr("Select a SD Card Image"), QString::fromStdString(Config::Get(Config::MAIN_SD_PATH)),
       tr("SD Card Image (*.raw);;"
          "All Files (*)")));


### PR DESCRIPTION
Previously, if you had "Hotkeys Require Window Focus" disabled, you could repeatedly use the "Open" hotkey, for example, to stack File Open windows over top of each other over and over.

This PR just adds a wrapper function to toggle hotkeys for QFileDialogs. Thank you to lioncache for the approach.