### PR TITLE
Tools: Add IDA Save/Load Dolphin Map Scripts for 7.x

### DIFF
--- a/Tools/IDA/IDA 6.x/LoadDolphinMap.py
+++ b/Tools/IDA/IDA 6.x/LoadDolphinMap.py
@@ -1,0 +1,62 @@
+# Copyright 2018 Dolphin Emulator Project
+# Licensed under GPLv2+
+# Refer to the LICENSES/GPL-2.0-or-later.txt file included.
+
+from collections import namedtuple
+
+
+DolphinSymbol = namedtuple("DolphinSymbol", [
+    "section", "addr", "size", "vaddr", "align", "name"
+])
+
+
+def load_dolphin_map(filepath):
+    with open(filepath, "r") as f:
+        section = ""
+        symbol_map = []
+        for line in f.readlines():
+            t = line.strip().split(" ", 4)
+            if len(t) == 3 and t[1] == "section" and t[2] == "layout":
+                section = t[0]
+                continue
+            if not section or len(t) != 5:
+                continue
+            symbol_map.append(DolphinSymbol(section, *t))
+        return symbol_map
+
+
+def ida_main():
+    import idc
+
+    filepath = idc.AskFile(0, "*.map", "Load a Dolphin emulator symbol map")
+    if filepath is None:
+        return
+    symbol_map = load_dolphin_map(filepath)
+
+    for symbol in symbol_map:
+        addr = int(symbol.vaddr, 16)
+        size = int(symbol.size, 16)
+        idc.MakeUnknown(addr, size, 0)
+        if symbol.section in [".init", ".text"]:
+            idc.MakeCode(addr)
+            success = idc.MakeFunction(
+                addr,
+                idc.BADADDR if not size else (addr+size)
+            )
+        else:
+            success = idc.MakeData(addr, idc.FF_BYTE, size, 0)
+
+        if not success:
+            idc.Message("Can't apply properties for symbol:"
+                        " {0.vaddr} - {0.name}\n".format(symbol))
+
+        flags = idc.SN_NOCHECK | idc.SN_PUBLIC
+        if symbol.name.startswith("zz_"):
+            flags |= idc.SN_AUTO | idc.SN_WEAK
+        else:
+            flags |= idc.SN_NON_AUTO
+        idc.MakeNameEx(addr, symbol.name, flags)
+
+
+if __name__ == "__main__":
+    ida_main()

--- a/Tools/IDA/IDA 6.x/SaveDolphinMap.py
+++ b/Tools/IDA/IDA 6.x/SaveDolphinMap.py
@@ -1,6 +1,6 @@
 # Copyright 2018 Dolphin Emulator Project
 # Licensed under GPLv2+
-# Refer to the license.txt file included.
+# Refer to the LICENSES/GPL-2.0-or-later.txt file included.
 
 from collections import namedtuple
 
@@ -27,6 +27,8 @@ def ida_main():
     import idc
 
     filepath = idc.AskFile(1, "*.map", "Save a Dolphin emulator symbol map")
+    if filepath is None:
+        return
     text_map = []
     data_map = []
     for ea, name in idautils.Names():

--- a/Tools/IDA/IDA 7.x/SaveDolphinMap.py
+++ b/Tools/IDA/IDA 7.x/SaveDolphinMap.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Dolphin Emulator Project
+# Licensed under GPLv2+
+# Refer to the LICENSES/GPL-2.0-or-later.txt file included.
+
+from collections import namedtuple
+
+
+DolphinSymbol = namedtuple("DolphinSymbol", [
+    "section", "addr", "size", "vaddr", "align", "name"
+])
+
+
+def save_dolphin_map(filepath, text_map, data_map):
+    line = "{0.addr:08x} {0.size:08x} {0.vaddr:08x} {0.align} {0.name}\n"
+    with open(filepath, "w") as f:
+        f.write(".text section layout\n")
+        for symbol in text_map:
+            f.write(line.format(symbol))
+        f.write("\n.data section layout\n")
+        for symbol in data_map:
+            f.write(line.format(symbol))
+
+
+def ida_main():
+    import idaapi
+    import idautils
+    import idc
+
+    filepath = ida_kernwin.ask_file(1, "*.map", "Save a Dolphin emulator symbol map")
+    if filepath is None:
+        return
+    text_map = []
+    data_map = []
+    for ea, name in idautils.Names():
+        f = idaapi.get_func(ea)
+        if f is not None:
+            text_map.append(
+                DolphinSymbol(".text", ea, f.size(), ea, 0, name)
+            )
+        else:
+            data_map.append(
+                DolphinSymbol(".data", ea, idc.get_item_size(ea), ea, 0, name)
+            )
+    save_dolphin_map(filepath, text_map, data_map)
+
+
+if __name__ == "__main__":
+    ida_main()


### PR DESCRIPTION
IDA 7.4+ breaks compatibility with IDA 6.x style scripts.
All IDA 7.0+ versions are compatible with IDA 7.x style scripts.

Updated unsupported calls per official hex-rays document:
https://hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml

* Kept legacy scripts and made folders IDA 6.X and IDA 7.X in Tools/IDA - intentionally specifying its the program again rather than allowing assumption of script version.
* Added cancel check to save/load for all scripts (including 6.x scripts)
* Updated copyright and license info to reflect current status