### PR TITLE
Core: Use log variant of PrintCallstack, not print variant

### DIFF
--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -97,28 +97,6 @@ bool GetCallstack(std::vector<CallstackEntry>& output)
   return true;
 }
 
-void PrintCallstack()
-{
-  fmt::print("== STACK TRACE - SP = {:08x} ==", PowerPC::ppcState.gpr[1]);
-
-  if (LR == 0)
-  {
-    fmt::print(" LR = 0 - this is bad");
-  }
-
-  if (g_symbolDB.GetDescription(PC) != g_symbolDB.GetDescription(LR))
-  {
-    fmt::print(" * {}  [ LR = {:08x} ]", g_symbolDB.GetDescription(LR), LR);
-  }
-
-  WalkTheStack([](u32 func_addr) {
-    std::string func_desc = g_symbolDB.GetDescription(func_addr);
-    if (func_desc.empty() || func_desc == "Invalid")
-      func_desc = "(unknown)";
-    fmt::print(" * {} [ addr = {:08x} ]", func_desc, func_addr);
-  });
-}
-
 void PrintCallstack(Common::Log::LOG_TYPE type, Common::Log::LOG_LEVELS level)
 {
   GENERIC_LOG_FMT(type, level, "== STACK TRACE - SP = {:08x} ==", PowerPC::ppcState.gpr[1]);

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.h
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.h
@@ -19,7 +19,6 @@ struct CallstackEntry
 };
 
 bool GetCallstack(std::vector<CallstackEntry>& output);
-void PrintCallstack();
 void PrintCallstack(Common::Log::LOG_TYPE type, Common::Log::LOG_LEVELS level);
 void PrintDataBuffer(Common::Log::LOG_TYPE type, const u8* data, size_t size,
                      std::string_view title);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -340,7 +340,7 @@ void Interpreter::unknown_instruction(UGeckoInstruction inst)
   const u32 opcode = PowerPC::HostRead_U32(last_pc);
   const std::string disasm = Common::GekkoDisassembler::Disassemble(opcode, last_pc);
   NOTICE_LOG_FMT(POWERPC, "Last PC = {:08x} : {}", last_pc, disasm);
-  Dolphin_Debugger::PrintCallstack();
+  Dolphin_Debugger::PrintCallstack(Common::Log::POWERPC, Common::Log::LNOTICE);
   NOTICE_LOG_FMT(
       POWERPC,
       "\nIntCPU: Unknown instruction {:08x} at PC = {:08x}  last_PC = {:08x}  LR = {:08x}\n",


### PR DESCRIPTION
There are two reasons for this.

1. Using Dolphin's logging system lets the user decide whether the printout should go to the terminal, the GUI, or a file. `fmt::print` always prints to stdout... unless you're on Android, in which case it does nothing at all, because Android disables stdout.

2. The Windows version of Dolphin crashes when you use `fmt::print`. Yes, really. The crash happens because a call to `std::fprint` in `fmt::v7::detail::fwrite_fully` returns that less characters were written than requested, which fmt handles by throwing an exception. (As always, Dolphin does not use exception handling.) I'm not sure why `std::fprint` is doing this, but since switching away from using `fmt::print` is a good idea due to the previous point anyway, I'd say it's best to just switch.