### PR TITLE
Fix switch warning in RenderWidget

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -454,6 +454,8 @@ bool RenderWidget::event(QEvent* event)
   case QEvent::Close:
     emit Closed();
     break;
+  default:
+    break;
   }
   return QWidget::event(event);
 }


### PR DESCRIPTION
The compiler was throwing a bunch of `-Wswitch` warnings from RenderWidget
because of unhandled branches, so I added a default branch to quiet it.