### PR TITLE
Android: Improve OpenModeToAndroid's handling of 'b'

### DIFF
--- a/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
@@ -3,6 +3,7 @@
 
 #include "jni/AndroidCommon/AndroidCommon.h"
 
+#include <algorithm>
 #include <ios>
 #include <string>
 #include <string_view>
@@ -67,8 +68,7 @@ bool IsPathAndroidContent(const std::string& uri)
 std::string OpenModeToAndroid(std::string mode)
 {
   // The 'b' specifier is not supported by Android. Since we're on POSIX, it's fine to just skip it.
-  if (!mode.empty() && mode.back() == 'b')
-    mode.pop_back();
+  mode.erase(std::remove(mode.begin(), mode.end(), 'b'));
 
   if (mode == "r+")
     mode = "rw";


### PR DESCRIPTION
Now it also works when b isn't at the very end. (+ goes after b.)