### PR TITLE
VideoCommon: Fix color channel logic when per-pixel lighting is in use

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -787,6 +787,10 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
     // out.SetConstantsUsed(C_PLIGHTS, C_PLIGHTS+31); // TODO: Can be optimized further
     // out.SetConstantsUsed(C_PMATERIALS, C_PMATERIALS+3);
     GenerateLightingShaderCode(out, uid_data->lighting, "colors_", "col");
+    // The number of colors available to TEV is determined by numColorChans.
+    // Normally this is performed in the vertex shader after lighting, but with per-pixel lighting,
+    // we need to perform it here.  (It needs to be done after lighting, as what was originally
+    // black might become a different color after lighting).
     if (uid_data->numColorChans == 0)
       out.Write("col0 = float4(0.0, 0.0, 0.0, 0.0);\n");
     if (uid_data->numColorChans <= 1)

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -748,6 +748,14 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
     WriteVertexLighting(out, api_type, "lit_pos", "lit_normal", "colors_0", "colors_1",
                         "lit_colors_0", "lit_colors_1");
     color_input_prefix = "lit_";
+    out.Write("  // The number of colors available to TEV is determined by numColorChans.\n"
+              "  // Normally this is performed in the vertex shader after lighting,\n"
+              "  // but with per-pixel lighting, we need to perform it here.\n"
+              "  // TODO: Actually implement this for ubershaders\n"
+              "  // if (xfmem_numColorChans == 0u)\n"
+              "  //   o.colors_0 = float4(0.0, 0.0, 0.0, 0.0);\n"
+              "  // if (xfmem_numColorChans <= 1u)\n"
+              "  //   o.colors_1 = float4(0.0, 0.0, 0.0, 0.0);\n");
   }
 
   out.Write("  uint num_stages = {};\n\n",


### PR DESCRIPTION
Fixes [bug 12698](https://bugs.dolphin-emu.org/issues/12698).

This was broken in #10012 (specifically by 06579e4d53844e5a45ae18f8eda6c4ee69ebad2c and c3dec343918ff44e90886daf71a6bf0c49033de1) when I attempted to simplify the logic incorrectly.

<details><summary>For color channel 0, this is approximately the code that is generated prior to that PR:</summary>

```C++
  if ((uid_data->components & VB_HAS_COL0) != 0)
  {
    out.Write("vertex_color_0 = rawcolor0;\n");
  }
  else
  {
    out.Write("vertex_color_0 = missing_color_value;\n");
  }
```
```C++
  // roughly
  out.write("o.colors_0 = LightingShaderCode(vertex_color_0);");
```
```C++
  if (uid_data->numColorChans == 0)
  {
    if ((uid_data->components & VB_HAS_COL0) != 0)
      out.Write("o.colors_0 = rawcolor0;\n");
    else
      out.Write("o.colors_0 = float4(1.0, 1.0, 1.0, 1.0);\n");
  }

  if (per_pixel_lighting)
  {
    if ((uid_data->components & VB_HAS_COL0) != 0)
      out.Write("o.colors_0 = vertex_color_0;\n");
  }
  else
  {
    if (uid_data->numColorChans == 0)
      out.Write("o.colors_0 = float4(0.0, 0.0, 0.0, 0.0);\n");
  }
```

Here is a table of results:

|chans==0|VB_HAS_COL0|per-pixel|Result|
|--------|-----------|---------|------|
|Yes|Yes|Yes|`vertex_color_0` => `rawcolor0`
|Yes|Yes|No|`float4(0, 0, 0, 0)`
|Yes|No|Yes|`float4(1, 1, 1, 1)` - `vertex_color_0` => `missing_color_value` would also work
|Yes|No|No|`float4(0, 0, 0, 0)`
|No|Yes|Yes|`vertex_color_0` => `rawcolor0`
|No|Yes|No|`LightingShaderCode(vertex_color_0)` => `LightingShaderCode(rawcolor0)`
|No|No|Yes|`LightingShaderCode(vertex_color_0)` => `LightingShaderCode(missing_color_value)`
|No|No|No|`LightingShaderCode(vertex_color_0)` => `LightingShaderCode(missing_color_value)`
</details>

<details><summary>For color channel 0, this is approximately the code that is generated after that PR:</summary>

```C++
  if ((uid_data->components & VB_HAS_COL0) != 0)
  {
    out.Write("vertex_color_0 = rawcolor0;\n");
  }
  else
  {
    out.Write("vertex_color_0 = missing_color_value;\n");
  }
```
```C++
  // roughly
  out.write("o.colors_0 = LightingShaderCode(vertex_color_0);");
```
```C++
  if (uid_data->numColorChans == 0)
  {
    if ((uid_data->components & VB_HAS_COL0) != 0)
    {
      if (per_pixel_lighting)
        out.Write("o.colors_0 = vertex_color_0;\n");
      else
        out.Write("o.colors_0 = rawcolor0;\n");
    }
    else
    {
      out.Write("o.colors_0 = float4(0.0, 0.0, 0.0, 0.0);\n");
    }
  }
```

Here is a table of results:

|chans==0|VB_HAS_COL0|per-pixel|Result|
|--------|-----------|---------|------|
|Yes|Yes|Yes|`vertex_color_0` => `rawcolor0`
|Yes|Yes|No|`rawcolor0`
|Yes|No|Yes|`float4(0, 0, 0, 0)`
|Yes|No|No|`float4(0, 0, 0, 0)`
|No|Yes|Yes|`LightingShaderCode(vertex_color_0)` => `LightingShaderCode(rawcolor0)`
|No|Yes|No|`LightingShaderCode(vertex_color_0)` => `LightingShaderCode(rawcolor0)`
|No|No|Yes|`LightingShaderCode(vertex_color_0)` => `LightingShaderCode(missing_color_value)`
|No|No|No|`LightingShaderCode(vertex_color_0)` => `LightingShaderCode(missing_color_value)`

As you can see, the results disagree in several places.
</details>

<details><summary>For color channel 0, this is approximately the code that is generated with this PR:</summary>

```C++
  if ((uid_data->components & VB_HAS_COL0) != 0)
  {
    out.Write("vertex_color_0 = rawcolor0;\n");
  }
  else
  {
    out.Write("vertex_color_0 = missing_color_value;\n");
  }
```
```C++
  // roughly
  out.write("o.colors_0 = LightingShaderCode(vertex_color_0);");
```
```C++
  if (per_pixel_lighting) {
    out.Write("o.colors_0 = vertex_color_0;\n");
  } else if (uid_data->numColorChans == 0)
    out.Write("o.colors_0 = float4(0.0, 0.0, 0.0, 0.0);\n");
  }
```

Here is a table of results:

|chans==0|VB_HAS_COL0|per-pixel|Result|
|--------|-----------|---------|------|
|Yes|Yes|Yes|`vertex_color_0` => `rawcolor0`
|Yes|Yes|No|`float4(0, 0, 0, 0)`
|Yes|No|Yes|`vertex_color_0` => `missing_color_value`
|Yes|No|No|`float4(0, 0, 0, 0)`
|No|Yes|Yes|`vertex_color_0` => `rawcolor0`
|No|Yes|No|`LightingShaderCode(vertex_color_0)` => `LightingShaderCode(rawcolor0)`
|No|No|Yes|`vertex_color_0` => `missing_color_value`
|No|No|No|`LightingShaderCode(vertex_color_0)` => `LightingShaderCode(missing_color_value)`

These also don't match the old behavior, but now the pixel shader is always getting the raw color, never a pre-lit value.
</details>

In addition to fixing the darkness in Xenoblade Chronicles, this also makes the debug cubes in Super Mario Sunshine have the same brightness with per-pixel lighting enabled as with it disabled.  (This only shows up with the fifoplayer; `missing_color_value` is set to 0 by gameini when launching the game normally.)  Here are images from both games, along with the CRC32 hashes of those images to more easily identify distinct results:

<table><tr><th>Test</th><th width="30%">5.0-15105</th><th width="30%">5.0-15260</th><th width="30%">This PR</th></tr>
<tr><th>Super Mario Sunshine, no per-pixel lighting</th>
<td><img alt="00000000_2021-10-13_15-45-46 s 5.0-15105 no ppl" src="https://user-images.githubusercontent.com/8334194/137250012-c09c3024-ff46-4288-a192-8ed0cf7c2443.png" /><br>2B87C475</td>
<td><img alt="00000000_2021-10-13_15-43-59 s 5.0-15260 no ppl" src="https://user-images.githubusercontent.com/8334194/137250008-8068c25e-1240-4acc-b92b-9f0de5bd368b.png" /><br>2B87C475</td>
<td><img alt="00000000_2021-10-13_15-48-24 s new no ppl" src="https://user-images.githubusercontent.com/8334194/137250018-99f9fa8e-c91a-40bd-a2d0-1a0b49852a2f.png" /><br>2B87C475</td>
</tr><tr><th>Super Mario Sunshine, with per-pixel lighting</th>
<td><img alt="00000000_2021-10-13_15-45-49 s 5.0-15105 with ppl" src="https://user-images.githubusercontent.com/8334194/137250013-f5713a93-4bf1-4124-aee4-cf9b7d0a90ae.png" /><br>733708B3</td>
<td><img alt="00000000_2021-10-13_15-44-03 s 5.0-15260 with ppl" src="https://user-images.githubusercontent.com/8334194/137250010-c58ce2e2-28d3-4c95-9897-e694c7e89afd.png" /><br>6DF359AE</td>
<td><img alt="00000000_2021-10-13_15-48-26 s new with ppl" src="https://user-images.githubusercontent.com/8334194/137250019-6553c84a-8e74-4816-bbb7-aefe159e151e.png" /><br>49E8A160</td>
</tr><tr><th>Xenoblade, no per-pixel lighting</th>
<td><img alt="00000000_2021-10-13_15-46-24 x 5.0-15105 no ppl" src="https://user-images.githubusercontent.com/8334194/137250014-4f55b0e9-ba7d-4f8e-83b3-a16ad77c2607.png" /><br>378454C1</td>
<td><img alt="00000000_2021-10-13_15-46-57 x 5.0-15260 no ppl" src="https://user-images.githubusercontent.com/8334194/137250017-1d65e46f-c3c7-4024-a33c-dd6ffc5e6df5.png" /><br>378454C1</td>
<td><img alt="00000000_2021-10-13_15-49-07 x new no ppl" src="https://user-images.githubusercontent.com/8334194/137250020-bb13ec98-ea69-44e3-ba62-6402f6751b35.png" /><br>378454C1</td>
</tr><tr><th>Xenoblade, with per-pixel lighting</th>
<td><img alt="00000000_2021-10-13_15-46-28 x 5.0-15105 with ppl" src="https://user-images.githubusercontent.com/8334194/137250016-e7efebb9-84a4-40fc-bc4a-9f8b58c8b3fd.png" /><br>6FC10472</td>
<td><img alt="00000000_2021-10-13_16-20-35 x 5.0-15260 with ppl" src="https://user-images.githubusercontent.com/8334194/137250022-e34b9290-5b11-4ae1-98cb-0a2f438bc6f2.png" /><br>64A4CC02</td>
<td><img alt="00000000_2021-10-13_15-49-10 x new with ppl" src="https://user-images.githubusercontent.com/8334194/137250021-76b33e84-4100-4c48-9953-751b5e495bbc.png" /><br>6FC10472</td>
</tr></table>

Both specialized shaders and ubershaders give exactly identical results for all of these.