### PR TITLE
Fix switch warning in GameListModel

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -195,6 +195,8 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
 
       return tags.join(QStringLiteral(", "));
     }
+  default:
+    return QVariant();
   }
 
   return QVariant();
@@ -231,8 +233,9 @@ QVariant GameListModel::headerData(int section, Qt::Orientation orientation, int
     return tr("Compression");
   case Column::Tags:
     return tr("Tags");
+  default:
+    return QVariant();
   }
-  return QVariant();
 }
 
 int GameListModel::rowCount(const QModelIndex& parent) const


### PR DESCRIPTION
`-Wswitch` warnings were coming from GameListModel during build because of
unhandled branches. Adding a default branch brings some quiet to the otherwise
noisy act of compilation.