### PR TITLE
Silence the -Wswitch warnings in Tev

### DIFF
--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -814,6 +814,8 @@ void Tev::Draw()
       fog = 1.0f - fog;
       fog = pow(2.0f, -8.0f * fog * fog);
       break;
+    default:
+      break;
     }
 
     // lerp from output to fog color


### PR DESCRIPTION
The compiler was loudly announcing each and every branch Tev was not checking in
a switch statement, but Tev has learned it's lesson and will produce that
warning no more.