### PR TITLE
Turn MAX_LOGLEVEL into a true constant (and fix self-comparison warning)

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -402,7 +402,7 @@ Java_org_dolphinemu_dolphinemu_NativeLibrary_GetDefaultGraphicsBackendName(JNIEn
 
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetMaxLogLevel(JNIEnv*, jclass)
 {
-  return static_cast<jint>(MAX_LOGLEVEL);
+  return static_cast<jint>(Common::Log::MAX_LOGLEVEL);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetProfiling(JNIEnv*, jclass,

--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -21,7 +21,7 @@
 #define DEBUG_ASSERT_MSG(_t_, _a_, _msg_, ...)                                                     \
   do                                                                                               \
   {                                                                                                \
-    if constexpr (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)                                 \
+    if constexpr (Common::Log::MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)                    \
     {                                                                                              \
       if (!(_a_))                                                                                  \
       {                                                                                            \
@@ -43,6 +43,6 @@
 #define DEBUG_ASSERT(_a_)                                                                          \
   do                                                                                               \
   {                                                                                                \
-    if constexpr (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)                                 \
+    if constexpr (Common::Log::MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)                    \
       ASSERT(_a_);                                                                                 \
   } while (0)

--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -76,6 +76,12 @@ enum LOG_LEVELS
   LDEBUG = 5,    // Detailed debugging - might make things slow.
 };
 
+#if defined(_DEBUG) || defined(DEBUGFAST)
+constexpr auto MAX_LOGLEVEL = Common::Log::LOG_LEVELS::LDEBUG;
+#else
+constexpr auto MAX_LOGLEVEL = Common::Log::LOG_LEVELS::LINFO;
+#endif  // logging
+
 static const char LOG_LEVEL_TO_CHAR[7] = "-NEWID";
 
 void GenericLogFmtImpl(LOG_LEVELS level, LOG_TYPE type, const char* file, int line,
@@ -99,19 +105,11 @@ void GenericLog(LOG_LEVELS level, LOG_TYPE type, const char* file, int line, con
     ;
 }  // namespace Common::Log
 
-#if defined(_DEBUG) || defined(DEBUGFAST)
-#define MAX_LOGLEVEL Common::Log::LOG_LEVELS::LDEBUG
-#else
-#ifndef MAX_LOGLEVEL
-#define MAX_LOGLEVEL Common::Log::LOG_LEVELS::LINFO
-#endif  // loglevel
-#endif  // logging
-
 // Let the compiler optimize this out
 #define GENERIC_LOG(t, v, ...)                                                                     \
   do                                                                                               \
   {                                                                                                \
-    if (v <= MAX_LOGLEVEL)                                                                         \
+    if (v <= Common::Log::MAX_LOGLEVEL)                                                            \
       Common::Log::GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__);                              \
   } while (0)
 
@@ -146,7 +144,7 @@ void GenericLog(LOG_LEVELS level, LOG_TYPE type, const char* file, int line, con
 #define GENERIC_LOG_FMT(t, v, format, ...)                                                         \
   do                                                                                               \
   {                                                                                                \
-    if (v <= MAX_LOGLEVEL)                                                                         \
+    if (v <= Common::Log::MAX_LOGLEVEL)                                                            \
     {                                                                                              \
       /* Use a macro-like name to avoid shadowing warnings */                                      \
       constexpr auto GENERIC_LOG_FMT_N = Common::CountFmtReplacementFields(format);                \

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -315,7 +315,7 @@ static void VLogInfo(std::string_view format, fmt::format_args args)
     return;
 
   const bool use_internal_log = s_use_internal_log.load(std::memory_order_relaxed);
-  if (MAX_LOGLEVEL < Common::Log::LINFO && !use_internal_log)
+  if (Common::Log::MAX_LOGLEVEL < Common::Log::LINFO && !use_internal_log)
     return;
 
   std::string text = fmt::vformat(format, args);

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -804,7 +804,7 @@ static int ParseAttribList(u8* attrib_id_list, u16& start_id, u16& end_id)
   const u8 type_id = attrib_list.Read8(attrib_offset);
   attrib_offset++;
 
-  if constexpr (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)
+  if constexpr (Common::Log::MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)
   {
     DEBUG_ASSERT(sequence == SDP_SEQ8);
     (void)seq_size;

--- a/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
@@ -77,7 +77,7 @@ void LogConfigWidget::CreateWidgets()
   verbosity_layout->addWidget(m_verbosity_error);
   verbosity_layout->addWidget(m_verbosity_warning);
   verbosity_layout->addWidget(m_verbosity_info);
-  if constexpr (MAX_LOGLEVEL == Common::Log::LOG_LEVELS::LDEBUG)
+  if constexpr (Common::Log::MAX_LOGLEVEL == Common::Log::LOG_LEVELS::LDEBUG)
   {
     verbosity_layout->addWidget(m_verbosity_debug);
   }


### PR DESCRIPTION
This replaces the MAX_LOGLEVEL define with a constexpr variable
in order to fix self-comparison warnings in the logging macros
when compiling with Clang. (Without this change, the log level check
in the logging macros is expanded into something like this:
`if (LINFO <= LINFO)`, which triggers a tautological compare warning.)