### PR TITLE
JitArm64: Work around a GCC warning promoted to error

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -126,8 +126,8 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
   }
   else if (mmio_address)
   {
-    MMIOLoadToReg(Memory::mmio_mapping.get(), this, regs_in_use, fprs_in_use, dest_reg,
-                  mmio_address, flags);
+    MMIOLoadToReg(Memory::mmio_mapping.get(), this, &m_float_emit, regs_in_use, fprs_in_use,
+                  dest_reg, mmio_address, flags);
   }
   else
   {
@@ -260,8 +260,8 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
   }
   else if (mmio_address)
   {
-    MMIOWriteRegToAddr(Memory::mmio_mapping.get(), this, regs_in_use, fprs_in_use, RS, mmio_address,
-                       flags);
+    MMIOWriteRegToAddr(Memory::mmio_mapping.get(), this, &m_float_emit, regs_in_use, fprs_in_use,
+                       RS, mmio_address, flags);
   }
   else
   {

--- a/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
@@ -201,9 +201,8 @@ void SwapPairs(ARM64XEmitter* emit, ARM64Reg dst_reg, ARM64Reg src_reg, u32 flag
     emit->REV16(dst_reg, src_reg);
 }
 
-void ByteswapAfterLoad(ARM64XEmitter* emit, Arm64Gen::ARM64FloatEmitter* float_emit,
-                       ARM64Reg dst_reg, ARM64Reg src_reg, u32 flags, bool is_reversed,
-                       bool is_extended)
+void ByteswapAfterLoad(ARM64XEmitter* emit, ARM64FloatEmitter* float_emit, ARM64Reg dst_reg,
+                       ARM64Reg src_reg, u32 flags, bool is_reversed, bool is_extended)
 {
   if (is_reversed == !(flags & BackPatchInfo::FLAG_REVERSE))
   {
@@ -251,8 +250,8 @@ void ByteswapAfterLoad(ARM64XEmitter* emit, Arm64Gen::ARM64FloatEmitter* float_e
   }
 }
 
-ARM64Reg ByteswapBeforeStore(ARM64XEmitter* emit, Arm64Gen::ARM64FloatEmitter* float_emit,
-                             ARM64Reg tmp_reg, ARM64Reg src_reg, u32 flags, bool want_reversed)
+ARM64Reg ByteswapBeforeStore(ARM64XEmitter* emit, ARM64FloatEmitter* float_emit, ARM64Reg tmp_reg,
+                             ARM64Reg src_reg, u32 flags, bool want_reversed)
 {
   ARM64Reg dst_reg = src_reg;
 
@@ -290,8 +289,9 @@ ARM64Reg ByteswapBeforeStore(ARM64XEmitter* emit, Arm64Gen::ARM64FloatEmitter* f
   return dst_reg;
 }
 
-void MMIOLoadToReg(MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit, BitSet32 gprs_in_use,
-                   BitSet32 fprs_in_use, ARM64Reg dst_reg, u32 address, u32 flags)
+void MMIOLoadToReg(MMIO::Mapping* mmio, ARM64XEmitter* emit, ARM64FloatEmitter* float_emit,
+                   BitSet32 gprs_in_use, BitSet32 fprs_in_use, ARM64Reg dst_reg, u32 address,
+                   u32 flags)
 {
   ASSERT(!(flags & BackPatchInfo::FLAG_FLOAT));
 
@@ -314,15 +314,16 @@ void MMIOLoadToReg(MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit, BitSet32 
     mmio->GetHandlerForRead<u32>(address).Visit(gen);
   }
 
-  ByteswapAfterLoad(emit, nullptr, dst_reg, dst_reg, flags, false, true);
+  ByteswapAfterLoad(emit, float_emit, dst_reg, dst_reg, flags, false, true);
 }
 
-void MMIOWriteRegToAddr(MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit, BitSet32 gprs_in_use,
-                        BitSet32 fprs_in_use, ARM64Reg src_reg, u32 address, u32 flags)
+void MMIOWriteRegToAddr(MMIO::Mapping* mmio, ARM64XEmitter* emit, ARM64FloatEmitter* float_emit,
+                        BitSet32 gprs_in_use, BitSet32 fprs_in_use, ARM64Reg src_reg, u32 address,
+                        u32 flags)
 {
   ASSERT(!(flags & BackPatchInfo::FLAG_FLOAT));
 
-  src_reg = ByteswapBeforeStore(emit, nullptr, ARM64Reg::W1, src_reg, flags, false);
+  src_reg = ByteswapBeforeStore(emit, float_emit, ARM64Reg::W1, src_reg, flags, false);
 
   if (flags & BackPatchInfo::FLAG_SIZE_8)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit_Util.h
@@ -20,8 +20,10 @@ Arm64Gen::ARM64Reg ByteswapBeforeStore(Arm64Gen::ARM64XEmitter* emit,
                                        Arm64Gen::ARM64Reg tmp_reg, Arm64Gen::ARM64Reg src_reg,
                                        u32 flags, bool want_reversed);
 
-void MMIOLoadToReg(MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit, BitSet32 gprs_in_use,
+void MMIOLoadToReg(MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit,
+                   Arm64Gen::ARM64FloatEmitter* float_emit, BitSet32 gprs_in_use,
                    BitSet32 fprs_in_use, Arm64Gen::ARM64Reg dst_reg, u32 address, u32 flags);
 
-void MMIOWriteRegToAddr(MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit, BitSet32 gprs_in_use,
+void MMIOWriteRegToAddr(MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit,
+                        Arm64Gen::ARM64FloatEmitter* float_emit, BitSet32 gprs_in_use,
                         BitSet32 fprs_in_use, Arm64Gen::ARM64Reg src_reg, u32 address, u32 flags);


### PR DESCRIPTION
GCC complains about float_emit being null when inlining ByteswapAfterLoad into MMIOLoadToReg. ByteswapAfterLoad does dereference float_emit, but only when passing FLAG_FLOAT, which MMIOLoadToReg has an assert for and does not support.

Also cleaning up some unnecessarily specified namespaces while I'm at it.