### PR TITLE
Enable deb package generation with cpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -931,6 +931,10 @@ set(CPACK_RPM_PACKAGE_LICENSE GPL-2.0)
 # TODO: CPACK_NSIS_*
 # TODO: Use CPack components for DSPSpy, etc => cpack_add_component
 
+# Debian Specific. Install dpkg-dev for automatic deps generation
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+set(CPACK_DEBIAN_PACKAGE_SECTION "Games")
+
 set(CPACK_SET_DESTDIR ON)
 set(CPACK_SOURCE_GENERATOR "TGZ;TBZ2;ZIP")
 set(CPACK_SOURCE_IGNORE_FILES  "\\\\.#;/#;.*~;\\\\.swp;/\\\\.git")


### PR DESCRIPTION
This adds the variables necessary for `cpack` to generate a deb package right from this project, and enables the generation of the dependencies section of the deb via `dpkg-shlibdeps` (installed via the `dpkg-dev` package in Debian, Ubuntu, and Mint).

To build a debian package using this pull request:
```sh
## Follow the usual steps from the docs, but create a branch using this PR
git clone https://github.com/dolphin-emu/dolphin.git dolphin-emu
cd ./dolphin-emu
git fetch origin pull/10170/head:pr10170
git checkout pr10170
git submodule update --init
mkdir Build && cd Build

## Specify the package contact (Required for building debs with cpack)
cmake -DCPACK_PACKAGE_CONTACT="Your Name Here" ..
make -j$(nproc)

## instead of 'make install' generate the deb
cpack -G DEB
```