### PR TITLE
Fix swapped frame advance speed increase/decrease

### DIFF
--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -88,13 +88,13 @@ static void HandleFrameStepHotkeys()
 
   if (IsHotkey(HK_FRAME_ADVANCE_INCREASE_SPEED))
   {
-    frame_step_delay = std::min(frame_step_delay + 1, MAX_FRAME_STEP_DELAY);
+    frame_step_delay = std::max(frame_step_delay - 1, 0);
     return;
   }
 
   if (IsHotkey(HK_FRAME_ADVANCE_DECREASE_SPEED))
   {
-    frame_step_delay = std::max(frame_step_delay - 1, 0);
+    frame_step_delay = std::min(frame_step_delay + 1, MAX_FRAME_STEP_DELAY);
     return;
   }
 


### PR DESCRIPTION
Frame Advance Speed hotkeys were swapped. This likely occurred because speed and delay are inverses (i.e. a speed increase should DECREASE the delay and vice versa).

I also don't like how pressing increase speed once while at the default delay causes you to reach the speed cap (default delay is 1, speed cap is 0). But, I figure I might as well put that in a separate PR since there may be a bit of discussion as to how we should handle that (change default maybe?) and so that this change gets implemented quicker.