### PR TITLE
DolphinNoGUI: Add audiodump as command-line argument

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -220,6 +220,9 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     game_specified = true;
   }
 
+  if (options.is_set("audiodump"))
+    Config::SetBaseOrCurrent(Config::MAIN_DUMP_AUDIO, true);
+
   int retval;
 
   if (save_state_path && !game_specified)

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -121,6 +121,8 @@ std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options)
       .choices({"HLE", "LLE"})
       .help("Choose audio emulation from [%choices]");
 
+  parser->add_option("--audiodump").action("store_true").help("Dump Audio to file");
+
   return parser;
 }
 


### PR DESCRIPTION
This simply allows the user to specify enabling audiodump via the CLI.

I envision the future possibility of communities, such as Mario Kart Wii, creating automated workflows to standardize the process of recording high-quality framedump/audiodumps via CLI. With this vision in mind, I feel that adding CLI audiodump support is beneficial.

AdmiralCurtiss had suggested that this simply be a long-name command, as `-a` is already taken. I agree, as it is likely a niche group of users who will regularly use this feature.