### PR TITLE
DolphinQt: Add "Reset Ignore Panic Handler" MenuBar Option

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -165,6 +165,7 @@ void MenuBar::OnDebugModeToggled(bool enabled)
   // Options
   m_boot_to_pause->setVisible(enabled);
   m_automatic_start->setVisible(enabled);
+  m_reset_ignore_panic_handler->setVisible(enabled);
   m_change_font->setVisible(enabled);
 
   // View
@@ -542,6 +543,13 @@ void MenuBar::AddOptionsMenu()
 
   connect(m_automatic_start, &QAction::toggled, this,
           [](bool enable) { SConfig::GetInstance().bAutomaticStart = enable; });
+
+  m_reset_ignore_panic_handler = options_menu->addAction(tr("Reset Ignore Panic Handler"));
+
+  connect(m_reset_ignore_panic_handler, &QAction::triggered, this, []() {
+    if (Config::Get(Config::MAIN_USE_PANIC_HANDLERS))
+      Common::SetEnableAlert(true);
+  });
 
   m_change_font = options_menu->addAction(tr("&Font..."), this, &MenuBar::ChangeDebugFont);
 }

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -234,6 +234,7 @@ private:
   // Options
   QAction* m_boot_to_pause;
   QAction* m_automatic_start;
+  QAction* m_reset_ignore_panic_handler;
   QAction* m_change_font;
   QAction* m_controllers_action;
 


### PR DESCRIPTION
### Overview:
* Adds a "Reset Ignore Panic Handler" button to the Options subgroup in the MenuBar; It will only appear if Debug mode is enabled
* The button will do nothing if Config -> Interface -> Use Panic Handlers is disabled

Originally, I was going to make this a toggle like Automatic Start and Boot to Pause. Since Main.cpp calls SetEnabledAlert directly and there is no way to call MenuBar qActions from Main.cpp, I opted to go with a stateless button. User usage of the button also made little sense to have a toggle, since Config -> Interface already has a "Use Panic Handlers".

### Why this is useful:
When a person debugging runs into an exception like this, sometimes there are 5000+ messages and the only choice is to choose "Ignore for this session". There really should be a "pause" option for those scenarios, but that's coming in another PR. This prevents any further pop-up messages about exceptions. The person debugging then has no way to re-enable the Ignore flag[*note1] without completely restarting Dolphin. With this change now there is a clear way to do it under the Options sub-menu.

![mem-exception](https://user-images.githubusercontent.com/14857235/137616638-e0b70464-6de3-40ce-88b3-ae45ae2c7ed9.png)

![reset-ignore-button-fix](https://user-images.githubusercontent.com/14857235/137815099-6ae698a1-6921-4897-aba8-28b63af89739.png)

[*note1] - You could disable panic handlers under Interface and re-enable them, but the state of the config at this point is desynced under that scenario. 