### PR TITLE
Android: Adjust string about file manager apps on Android 11

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -358,7 +358,7 @@
     <string name="user_data_submenu">User Data</string>
     <string name="user_data_old_location">Your user data is stored in a location which will <b>not</b> be deleted when you uninstall the app:</string>
     <string name="user_data_new_location">Your user data is stored in a location which <b>will be deleted</b> when you uninstall the app:</string>
-    <string name="user_data_new_location_android_11">Because you\'re using Android 11 or newer, you can\'t access this location using file manager apps. However, you can access it using the system file manager, or by connecting your device to a PC.</string>
+    <string name="user_data_new_location_android_11">Because you\'re using Android 11 or newer, not all file manager apps can access this location. However, you can access it using the system file manager (if present on your device), or by connecting your device to a PC.</string>
     <string name="user_data_open_system_file_manager">Open System File Manager</string>
     <string name="user_data_open_system_file_manager_failed">Sorry, Dolphin couldn\'t find the system file manager on your device.</string>
 


### PR DESCRIPTION
When I made PR #9696, I assumed it was completely impossible for a non-preloaded app to access the entirety of the Android/data/ folder on Android 11. This turned out to be false. While you can't access the directory without using SAF (even if you have the Manage All Files permission), and the user can't navigate to the folder using the SAF folder picker, what you can do is pass the Android/data/ folder as an EXTRA_INITIAL_URI to the SAF folder picker. If the user then presses "use this folder" without navigating out of the folder, the app will be able to access the folder using SAF.

So what does that mean for Dolphin? It means scoped storage is a little less bad than I feared, and I have a string to adjust.