### PR TITLE
Android: Set android:hasFragileUserData

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -40,7 +40,8 @@
         android:fullBackupContent="@xml/backup_rules"
         android:supportsRtl="true"
         android:isGame="true"
-        android:banner="@drawable/banner_tv">
+        android:banner="@drawable/banner_tv"
+        android:hasFragileUserData="true">
         <meta-data
             android:name="android.max_aspect"
             android:value="2.1"/>

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
@@ -37,17 +37,19 @@ public class UserDataActivity extends AppCompatActivity implements View.OnClickL
     TextView textAndroid11 = findViewById(R.id.text_android_11);
     Button buttonOpenSystemFileManager = findViewById(R.id.button_open_system_file_manager);
 
-    textType.setText(DirectoryInitialization.isUsingLegacyUserDirectory() ?
-            R.string.user_data_old_location : R.string.user_data_new_location);
+    boolean android_10 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;
+    boolean android_11 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R;
+    boolean legacy = DirectoryInitialization.isUsingLegacyUserDirectory();
+
+    int user_data_new_location = android_10 ?
+            R.string.user_data_new_location_android_10 : R.string.user_data_new_location;
+    textType.setText(legacy ? R.string.user_data_old_location : user_data_new_location);
 
     textPath.setText(DirectoryInitialization.getUserDirectory());
 
-    boolean show_android_11_text = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
-            !DirectoryInitialization.isUsingLegacyUserDirectory();
-    textAndroid11.setVisibility(show_android_11_text ? View.VISIBLE : View.GONE);
+    textAndroid11.setVisibility(android_11 && !legacy ? View.VISIBLE : View.GONE);
 
-    boolean show_file_manager_button = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R;
-    buttonOpenSystemFileManager.setVisibility(show_file_manager_button ? View.VISIBLE : View.GONE);
+    buttonOpenSystemFileManager.setVisibility(android_11 ? View.VISIBLE : View.GONE);
 
     buttonOpenSystemFileManager.setOnClickListener(this);
   }

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -358,6 +358,8 @@
     <string name="user_data_submenu">User Data</string>
     <string name="user_data_old_location">Your user data is stored in a location which will <b>not</b> be deleted when you uninstall the app:</string>
     <string name="user_data_new_location">Your user data is stored in a location which <b>will be deleted</b> when you uninstall the app:</string>
+    <!-- Android 10 and up support android:hasFragileUserData -->
+    <string name="user_data_new_location_android_10">Your user data is stored in a location which by default <b>will be deleted</b> when you uninstall the app:</string>
     <string name="user_data_new_location_android_11">Because you\'re using Android 11 or newer, not all file manager apps can access this location. However, you can access it using the system file manager (if present on your device), or by connecting your device to a PC.</string>
     <string name="user_data_open_system_file_manager">Open System File Manager</string>
     <string name="user_data_open_system_file_manager_failed">Sorry, Dolphin couldn\'t find the system file manager on your device.</string>


### PR DESCRIPTION
This makes Android ask the user whether they want to delete user data when uninstalling the app instead of always deleting user data, which is pretty great now that we're forced to use scoped storage. It only works on Android 10 and up, though.