### PR TITLE
HLE: Fix hook flag for HBReload

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -31,7 +31,7 @@ constexpr std::array<Hook, 23> os_patches{{
     {"FAKE_TO_SKIP_0",               HLE_Misc::UnimplementedFunction,       HookType::Replace, HookFlag::Generic},
 
     // Name doesn't matter, installed in CBoot::BootUp()
-    {"HBReload",                     HLE_Misc::HBReload,                    HookType::Replace, HookFlag::Generic},
+    {"HBReload",                     HLE_Misc::HBReload,                    HookType::Replace, HookFlag::Fixed},
 
     // Debug/OS Support
     {"OSPanic",                      HLE_OS::HLE_OSPanic,                   HookType::Replace, HookFlag::Debug},


### PR DESCRIPTION
The reload stub is at a fixed address (0x80001800) so its hook flag
should be HookFlag::Fixed.

Otherwise the hook is installed by HLE::PatchFixedFunctions but
immediately removed by HLE::PatchFunctions (which is called by
HLE::Reload right after PatchFixedFunctions).

Should fix https://bugs.dolphin-emu.org/issues/12716