### PR TITLE
Externals/discord-rpc: Fix reference to discord_register.h

### DIFF
--- a/Externals/discord-rpc/src/discord-rpc.vcxproj
+++ b/Externals/discord-rpc/src/discord-rpc.vcxproj
@@ -26,7 +26,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\include\discord_rpc.h" />
-    <ClInclude Include="..\discord_register.h" />
+    <ClInclude Include="..\include\discord_register.h" />
     <ClInclude Include="rpc_connection.h" />
     <ClInclude Include="serialization.h" />
     <ClInclude Include="connection.h" />


### PR DESCRIPTION
The file is located at <code>Externals/discord-rpc/<ins>include/</ins>discord_register.h</code>, not `Externals/discord-rpc/discord_register.h`.  This didn't affect building (I think because of `..\include` being in `<AdditionalIncludeDirectories>`), but it did break trying to open `discord_register.h` in Visual Studio.