### PR TITLE
HLE: Fix hooks overlapping Riivolution patches

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -235,4 +235,21 @@ u32 UnPatch(std::string_view patch_name)
 
   return 0;
 }
+
+u32 UnpatchRange(u32 start_addr, u32 end_addr)
+{
+  u32 count = 0;
+
+  auto i = s_hooked_addresses.lower_bound(start_addr);
+  while (i != s_hooked_addresses.end() && i->first < end_addr)
+  {
+    INFO_LOG_FMT(OSHLE, "Unpatch HLE hooks [{:08x};{:08x}): {} at {:08x}", start_addr, end_addr,
+                 os_patches[i->second].name, i->first);
+    PowerPC::ppcState.iCache.Invalidate(i->first);
+    i = s_hooked_addresses.erase(i);
+    count += 1;
+  }
+
+  return count;
+}
 }  // namespace HLE

--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -40,6 +40,7 @@ void Reload();
 
 void Patch(u32 pc, std::string_view func_name);
 u32 UnPatch(std::string_view patch_name);
+u32 UnpatchRange(u32 start_addr, u32 end_addr);
 void Execute(u32 current_pc, u32 hook_index);
 
 // Returns the HLE hook index of the address


### PR DESCRIPTION
This PR should fix HLE hooks overlapping Riivolution patches: https://github.com/dolphin-emu/dolphin/pull/10186#issuecomment-955634792

This should be thoroughly tested. Depending on the mods `HBReload` and `GeckoCodehandler` hooks can be overlapped.

I'm also open to other alternatives to fix this HLE over HLE issue.

Ready to be reviewed & tested.