### PR TITLE
GameINI:  Change Texture Cache to Safe in R44J8P

### DIFF
--- a/Data/Sys/GameSettings/R44.ini
+++ b/Data/Sys/GameSettings/R44.ini
@@ -15,5 +15,6 @@
 [Video]
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+# Medium is not enough for this game.  See issue 12722 for more info.
+SafeTextureCacheColorSamples = 0
 SuggestedAspectRatio = 2


### PR DESCRIPTION
Suzumiya Haruhi no Heiretsu drops certain characters in medium texture cache, so it needs safe.  Considering other issues of this sort and the performance of the game, it seems like 0 is probably fine.