### PR TITLE
GameINI: Change Texture Cache to Safe in RMHJ08.ini and ROM.ini

### DIFF
--- a/Data/Sys/GameSettings/RMHJ08.ini
+++ b/Data/Sys/GameSettings/RMHJ08.ini
@@ -10,5 +10,8 @@ $Bloom OFF
 0x805DD6D8:dword:0x60000000
 0x805DD6DC:dword:0x60000000
 
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/ROM.ini
+++ b/Data/Sys/GameSettings/ROM.ini
@@ -1,0 +1,4 @@
+# ROMJ08 - Monster Hunter G
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
This PR fixes text corruption issues on Japanese Monster Hunter games, similarly to https://github.com/dolphin-emu/dolphin/pull/10196.

Without it:
 - NPC dialogs are displayed with wrong/corrupted characters.
 - The online login progress bar displays the wrong percentage number (sometimes beyond 100%).
 - It corrupts the on-screen keyboard used for chatting online.

Ready to be reviewed & merged.