### PR TITLE
Jit64: divwx - One more micro-optimization

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1496,15 +1496,18 @@ void Jit64::divwx(UGeckoInstruction inst)
       X64Reg tmp = RSCRATCH;
       if (!Ra.IsSimpleReg())
       {
+        // Load dividend from memory
         MOV(32, R(tmp), Ra);
         MOV(32, Rd, R(tmp));
       }
       else if (d == a)
       {
+        // Make a copy of the dividend
         MOV(32, R(tmp), Ra);
       }
       else
       {
+        // Copy dividend directly into destination
         MOV(32, Rd, Ra);
         tmp = Ra.GetSimpleReg();
       }
@@ -1538,11 +1541,11 @@ void Jit64::divwx(UGeckoInstruction inst)
       else if (d == a)
       {
         // Rd holds the dividend, while RSCRATCH holds the sum
-        // This is opposite of the other cases
+        // This is the reverse of the other cases
         dividend = Rd;
         sum = RSCRATCH;
         src = RSCRATCH;
-        // Negate condition to compensate the swapped values
+        // Negate condition to compensate for the swapped values
         cond = CC_S;
       }
       else

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1494,6 +1494,8 @@ void Jit64::divwx(UGeckoInstruction inst)
     else if (divisor == 2 || divisor == -2)
     {
       X64Reg tmp = RSCRATCH;
+      X64Reg sign = tmp;
+
       if (!Ra.IsSimpleReg())
       {
         // Load dividend from memory
@@ -1510,9 +1512,10 @@ void Jit64::divwx(UGeckoInstruction inst)
         // Copy dividend directly into destination
         MOV(32, Rd, Ra);
         tmp = Ra.GetSimpleReg();
+        sign = Rd;
       }
 
-      SHR(32, Rd, Imm8(31));
+      SHR(32, R(sign), Imm8(31));
       ADD(32, Rd, R(tmp));
       SAR(32, Rd, Imm8(1));
 


### PR DESCRIPTION
The division by 2 case can be improved ever so slightly by using eax when possible to isolate the sign bit. This saves a byte when the destination ends up as r8-15, because those require a REX prefix.

I also improved the comments a little in this area.

---

Before:
```
41 8B C5             mov         eax,r13d
41 C1 ED 1F          shr         r13d,1Fh
44 03 E8             add         r13d,eax
41 D1 FD             sar         r13d,1
```

After:
```
41 8B C5             mov         eax,r13d
C1 E8 1F             shr         eax,1Fh
44 03 E8             add         r13d,eax
41 D1 FD             sar         r13d,1
```