### PR TITLE
GameINI: Fix Comment Causing Parsing Errors in Mario Party 6/7 INIs.

### DIFF
--- a/Data/Sys/GameSettings/GP6E01.ini
+++ b/Data/Sys/GameSettings/GP6E01.ini
@@ -441,7 +441,7 @@ $Game - Orb Expansion [Airsola]
 042bd36c 00000000
 042bd37c 00000000
 00000000 40000000
-*(Almost) all Orbs become obtainable on each board. Orb prices are rebalanced.
+# Almost all Orbs become obtainable on each board. Orb prices are rebalanced.
 
 [Gecko]
 # Add gecko cheats here.

--- a/Data/Sys/GameSettings/GP7E01.ini
+++ b/Data/Sys/GameSettings/GP7E01.ini
@@ -567,8 +567,11 @@ $Mechanics - Orb Expansion [Airsola]
 042ef734 000a0000
 042ef744 00000000
 00000000 40000000
-*Use with the Allow All Character Orbs cheat below. 
-*(Almost) all Orbs become obtainable on each board. Orb prices are rebalanced. CPUs cannot use character orbs that are not their own. Triple Shroom is removed, as this code is meant to be used in conjunction with the Orb balancing codes.
+
+# Use with the Allow All Character Orbs cheat below. 
+# (Almost) all Orbs become obtainable on each board. Orb prices are rebalanced. 
+# CPUs cannot use character orbs that are not their own. 
+# Triple Shroom is removed, as this code is meant to be used in conjunction with the Orb balancing codes.
 
 [Gecko]
 # Add gecko cheats here.


### PR DESCRIPTION
It appears that this code is a Gecko Code and was mistakenly put as an Action Replay code.  I may be wrong and it may be a different problem, but based on the how the code looks I'm confident this was the problem.  The code didn't crash the game when I moved it to Gecko, and it was causing problems when it was under Action Replay.