### PR TITLE
VideoCommon: Use the copy filter for EFB copies as well as XFB copies

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -275,13 +275,12 @@ static void BPWritten(const BPCmd& bp)
     {
       // bpmem.zcontrol.pixel_format to PixelFormat::Z24 is when the game wants to copy from ZBuffer
       // (Zbuffer uses 24-bit Format)
-      static constexpr CopyFilterCoefficients::Values filter_coefficients = {
-          {0, 0, 21, 22, 21, 0, 0}};
       bool is_depth_copy = bpmem.zcontrol.pixel_format == PixelFormat::Z24;
       g_texture_cache->CopyRenderTargetToTexture(
           destAddr, PE_copy.tp_realFormat(), copy_width, copy_height, destStride, is_depth_copy,
           srcRect, PE_copy.intensity_fmt, PE_copy.half_scale, 1.0f, 1.0f,
-          bpmem.triggerEFBCopy.clamp_top, bpmem.triggerEFBCopy.clamp_bottom, filter_coefficients);
+          bpmem.triggerEFBCopy.clamp_top, bpmem.triggerEFBCopy.clamp_bottom,
+          bpmem.copyfilter.GetCoefficients());
     }
     else
     {


### PR DESCRIPTION
This fixes the pink screens in EA Sports Active.  See https://gist.github.com/Pokechu22/49455f9094ed0ff017da64e3f7aa0404 for details.

This will also need to be implemented for the software renderer, which has its own implementation of EFB copies.  Unfortunately it doesn't seem like there is a quick fix for it, as the relevant code (in [TextureEncoder.cpp](https://github.com/dolphin-emu/dolphin/blob/2c5d11cacebe05450ee4c5d276044e110ed286c1/Source/Core/VideoBackends/Software/TextureEncoder.cpp#L1423), while XFBs are in [EfbInterface.cpp](https://github.com/dolphin-emu/dolphin/blob/2c5d11cacebe05450ee4c5d276044e110ed286c1/Source/Core/VideoBackends/Software/EfbInterface.cpp#L556)) is pretty complicated.