### PR TITLE
Assertion and panic alert improvements

### DIFF
--- a/Languages/update-source-strings.sh
+++ b/Languages/update-source-strings.sh
@@ -10,16 +10,10 @@ SRCDIR=Source
 find $SRCDIR -name '*.cpp' -o -name '*.h' -o -name '*.c' | \
 	xgettext -s -p ./Languages/po -o dolphin-emu.pot --package-name="Dolphin Emulator" \
 	--keyword=_ \
-	--keyword=wxTRANSLATE \
-	--keyword=AskYesNoT \
 	--keyword=AskYesNoFmtT \
-	--keyword=CriticalAlertT \
 	--keyword=CriticalAlertFmtT \
-	--keyword=PanicAlertT \
 	--keyword=PanicAlertFmtT \
-	--keyword=PanicYesNoT \
 	--keyword=PanicYesNoFmtT \
-	--keyword=SuccessAlertT \
 	--keyword=SuccessAlertFmtT \
 	--keyword=GetStringT \
 	--keyword=_trans \

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -5,7 +5,6 @@
 #include <UICommon/GameFile.h>
 #include <android/log.h>
 #include <android/native_window_jni.h>
-#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 #include <jni.h>

--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -17,6 +17,7 @@
 #include <thread>
 
 #include "Common/Assert.h"
+#include "Common/HRWrap.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
@@ -66,11 +67,11 @@ static bool HandleWinAPI(std::string_view message, HRESULT result)
       error = "Audio endpoint already in use!";
       break;
     default:
-      error = TStrToUTF8(_com_error(result).ErrorMessage()).c_str();
+      error = Common::GetHResultMessage(result);
       break;
     }
 
-    ERROR_LOG_FMT(AUDIO, "WASAPI: {}: {}", message, error);
+    ERROR_LOG_FMT(AUDIO, "WASAPI: {}: {} ({:08x})", message, error, result);
   }
 
   return SUCCEEDED(result);

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -577,13 +577,14 @@ void ARM64XEmitter::EncodeAddSubImmInst(u32 op, bool flags, u32 shift, u32 imm, 
 
 void ARM64XEmitter::EncodeLogicalImmInst(u32 op, ARM64Reg Rd, ARM64Reg Rn, LogicalImm imm)
 {
-  ASSERT_MSG(DYNAREC, imm.valid, "Invalid logical immediate");
+  ASSERT_MSG(DYNA_REC, imm.valid, "Invalid logical immediate");
 
   // Sometimes Rd is fixed to SP, but can still be 32bit or 64bit.
   // Use Rn to determine bitness here.
   bool b64Bit = Is64Bit(Rn);
 
-  ASSERT_MSG(DYNAREC, b64Bit || !imm.n, "64-bit logical immediate does not fit in 32-bit register");
+  ASSERT_MSG(DYNA_REC, b64Bit || !imm.n,
+             "64-bit logical immediate does not fit in 32-bit register");
 
   Write32((b64Bit << 31) | (op << 29) | (0x24 << 23) | (imm.n << 22) | (imm.r << 16) |
           (imm.s << 10) | (DecodeReg(Rn) << 5) | DecodeReg(Rd));

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -5,12 +5,13 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <cstring>
 #include <optional>
 #include <tuple>
 #include <utility>
 #include <vector>
+
+#include <fmt/format.h>
 
 #include "Common/Align.h"
 #include "Common/Assert.h"
@@ -307,13 +308,12 @@ void ARM64XEmitter::EncodeCompareBranchInst(u32 op, ARM64Reg Rt, const void* ptr
   bool b64Bit = Is64Bit(Rt);
   s64 distance = (s64)ptr - (s64)m_code;
 
-  ASSERT_MSG(DYNA_REC, !(distance & 0x3), "%s: distance must be a multiple of 4: %" PRIx64,
-             __func__, distance);
+  ASSERT_MSG(DYNA_REC, !(distance & 0x3), "Distance must be a multiple of 4: {}", distance);
 
   distance >>= 2;
 
   ASSERT_MSG(DYNA_REC, distance >= -0x40000 && distance <= 0x3FFFF,
-             "%s: Received too large distance: %" PRIx64, __func__, distance);
+             "Received too large distance: {}", distance);
 
   Write32((b64Bit << 31) | (0x34 << 24) | (op << 24) | (((u32)distance << 5) & 0xFFFFE0) |
           DecodeReg(Rt));
@@ -325,13 +325,12 @@ void ARM64XEmitter::EncodeTestBranchInst(u32 op, ARM64Reg Rt, u8 bits, const voi
   u8 b5 = (bits >> 5) & 0x1;
   s64 distance = (s64)ptr - (s64)m_code;
 
-  ASSERT_MSG(DYNA_REC, !(distance & 0x3), "%s: distance must be a multiple of 4: %" PRIx64,
-             __func__, distance);
+  ASSERT_MSG(DYNA_REC, !(distance & 0x3), "distance must be a multiple of 4: {}", distance);
 
   distance >>= 2;
 
-  ASSERT_MSG(DYNA_REC, distance >= -0x3FFF && distance < 0x3FFF,
-             "%s: Received too large distance: %" PRIx64, __func__, distance);
+  ASSERT_MSG(DYNA_REC, distance >= -0x3FFF && distance < 0x3FFF, "Received too large distance: {}",
+             distance);
 
   Write32((b5 << 31) | (0x36 << 24) | (op << 24) | (b40 << 19) |
           ((static_cast<u32>(distance) << 5) & 0x7FFE0) | DecodeReg(Rt));
@@ -341,13 +340,12 @@ void ARM64XEmitter::EncodeUnconditionalBranchInst(u32 op, const void* ptr)
 {
   s64 distance = (s64)ptr - s64(m_code);
 
-  ASSERT_MSG(DYNA_REC, !(distance & 0x3), "%s: distance must be a multiple of 4: %" PRIx64,
-             __func__, distance);
+  ASSERT_MSG(DYNA_REC, !(distance & 0x3), "distance must be a multiple of 4: {}", distance);
 
   distance >>= 2;
 
   ASSERT_MSG(DYNA_REC, distance >= -0x2000000LL && distance <= 0x1FFFFFFLL,
-             "%s: Received too large distance: %" PRIx64, __func__, distance);
+             "Received too large distance: {}", distance);
 
   Write32((op << 31) | (0x5 << 26) | (distance & 0x3FFFFFF));
 }
@@ -359,8 +357,7 @@ void ARM64XEmitter::EncodeUnconditionalBranchInst(u32 opc, u32 op2, u32 op3, u32
 
 void ARM64XEmitter::EncodeExceptionInst(u32 instenc, u32 imm)
 {
-  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFFF), "%s: Exception instruction too large immediate: %d",
-             __func__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFFF), "Exception instruction too large immediate: {}", imm);
 
   Write32((0xD4 << 24) | (ExcEnc[instenc][0] << 21) | (imm << 5) | (ExcEnc[instenc][1] << 2) |
           ExcEnc[instenc][2]);
@@ -395,8 +392,8 @@ void ARM64XEmitter::EncodeCondCompareImmInst(u32 op, ARM64Reg Rn, u32 imm, u32 n
 {
   bool b64Bit = Is64Bit(Rn);
 
-  ASSERT_MSG(DYNA_REC, !(imm & ~0x1F), "%s: too large immediate: %d", __func__, imm);
-  ASSERT_MSG(DYNA_REC, !(nzcv & ~0xF), "%s: Flags out of range: %d", __func__, nzcv);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0x1F), "too large immediate: {}", imm);
+  ASSERT_MSG(DYNA_REC, !(nzcv & ~0xF), "Flags out of range: {}", nzcv);
 
   Write32((b64Bit << 31) | (op << 30) | (1 << 29) | (0xD2 << 21) | (imm << 16) | (cond << 12) |
           (1 << 11) | (DecodeReg(Rn) << 5) | nzcv);
@@ -407,7 +404,7 @@ void ARM64XEmitter::EncodeCondCompareRegInst(u32 op, ARM64Reg Rn, ARM64Reg Rm, u
 {
   bool b64Bit = Is64Bit(Rm);
 
-  ASSERT_MSG(DYNA_REC, !(nzcv & ~0xF), "%s: Flags out of range: %d", __func__, nzcv);
+  ASSERT_MSG(DYNA_REC, !(nzcv & ~0xF), "Flags out of range: {}", nzcv);
 
   Write32((b64Bit << 31) | (op << 30) | (1 << 29) | (0xD2 << 21) | (DecodeReg(Rm) << 16) |
           (cond << 12) | (DecodeReg(Rn) << 5) | nzcv);
@@ -464,7 +461,7 @@ void ARM64XEmitter::EncodeLoadRegisterInst(u32 bitop, ARM64Reg Rt, u32 imm)
   bool b64Bit = Is64Bit(Rt);
   bool bVec = IsVector(Rt);
 
-  ASSERT_MSG(DYNA_REC, !(imm & 0xFFFFF), "%s: offset too large %d", __func__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & 0xFFFFF), "offset too large {}", imm);
 
   if (b64Bit && bitop != 0x2)  // LDRSW(0x2) uses 64bit reg, doesn't have 64bit bit set
     bitop |= 0x1;
@@ -494,7 +491,7 @@ void ARM64XEmitter::EncodeLoadStorePairedInst(u32 op, ARM64Reg Rt, ARM64Reg Rt2,
   else
     imm >>= 2;
 
-  ASSERT_MSG(DYNA_REC, !(imm & ~0xF), "%s: offset too large %d", __func__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0xF), "offset too large {}", imm);
 
   u32 opc = 0;
   if (b128Bit)
@@ -515,7 +512,7 @@ void ARM64XEmitter::EncodeLoadStoreIndexedInst(u32 op, u32 op2, ARM64Reg Rt, ARM
 
   u32 offset = imm & 0x1FF;
 
-  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "%s: offset too large %d", __func__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "offset too large {}", imm);
 
   Write32((b64Bit << 30) | (op << 22) | (bVec << 26) | (offset << 12) | (op2 << 10) |
           (DecodeReg(Rn) << 5) | DecodeReg(Rt));
@@ -533,10 +530,8 @@ void ARM64XEmitter::EncodeLoadStoreIndexedInst(u32 op, ARM64Reg Rt, ARM64Reg Rn,
   else if (size == 16)
     imm >>= 1;
 
-  ASSERT_MSG(DYNA_REC, imm >= 0, "%s(IndexType::Unsigned): offset must be positive %d", __func__,
-             imm);
-  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFF), "%s(IndexType::Unsigned): offset too large %d", __func__,
-             imm);
+  ASSERT_MSG(DYNA_REC, imm >= 0, "(IndexType::Unsigned): offset must be positive {}", imm);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFF), "(IndexType::Unsigned): offset too large {}", imm);
 
   Write32((b64Bit << 30) | (op << 22) | (bVec << 26) | (imm << 10) | (DecodeReg(Rn) << 5) |
           DecodeReg(Rt));
@@ -546,7 +541,7 @@ void ARM64XEmitter::EncodeMOVWideInst(u32 op, ARM64Reg Rd, u32 imm, ShiftAmount 
 {
   bool b64Bit = Is64Bit(Rd);
 
-  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFFF), "%s: immediate out of range: %d", __func__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFFF), "immediate out of range: {}", imm);
 
   Write32((b64Bit << 31) | (op << 29) | (0x25 << 23) | (static_cast<u32>(pos) << 21) | (imm << 5) |
           DecodeReg(Rd));
@@ -574,7 +569,7 @@ void ARM64XEmitter::EncodeAddSubImmInst(u32 op, bool flags, u32 shift, u32 imm, 
 {
   bool b64Bit = Is64Bit(Rd);
 
-  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFF), "%s: immediate too large: %x", __func__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFF), "immediate too large: {}", imm);
 
   Write32((b64Bit << 31) | (op << 30) | (flags << 29) | (0x11 << 24) | (shift << 22) | (imm << 10) |
           (DecodeReg(Rn) << 5) | DecodeReg(Rd));
@@ -612,7 +607,7 @@ void ARM64XEmitter::EncodeLoadStorePair(u32 op, u32 load, IndexType type, ARM64R
     type_encode = 0b011;
     break;
   case IndexType::Unsigned:
-    ASSERT_MSG(DYNA_REC, false, "%s doesn't support IndexType::Unsigned!", __func__);
+    ASSERT_MSG(DYNA_REC, false, "IndexType::Unsigned is not supported!");
     break;
   }
 
@@ -626,7 +621,7 @@ void ARM64XEmitter::EncodeLoadStorePair(u32 op, u32 load, IndexType type, ARM64R
     imm >>= 2;
   }
 
-  ASSERT_MSG(DYNA_REC, imm >= -64 && imm < 64, "imm too large for load/store pair!");
+  ASSERT_MSG(DYNA_REC, imm >= -64 && imm < 64, "imm too large for load/store pair! {}", imm);
 
   Write32((op << 30) | (0b101 << 27) | (type_encode << 23) | (load << 22) | ((imm & 0x7F) << 15) |
           (DecodeReg(Rt2) << 10) | (DecodeReg(Rn) << 5) | DecodeReg(Rt));
@@ -639,8 +634,7 @@ void ARM64XEmitter::EncodeAddressInst(u32 op, ARM64Reg Rd, s32 imm)
 
 void ARM64XEmitter::EncodeLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 {
-  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "%s received too large offset: %d", __func__,
-             imm);
+  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "offset too large: {}", imm);
 
   Write32((size << 30) | (0b111 << 27) | (op << 22) | ((imm & 0x1FF) << 12) | (DecodeReg(Rn) << 5) |
           DecodeReg(Rt));
@@ -694,16 +688,16 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
     [[fallthrough]];
   case FixupBranch::Type::CBZ:
   {
-    ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, static_cast<int>(branch.type), distance);
+    ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance),
+               "Branch type {}: Received too large distance: {}", branch.type, distance);
     const bool b64Bit = Is64Bit(branch.reg);
     inst = (b64Bit << 31) | (0x1A << 25) | (Not << 24) | (MaskImm19(distance) << 5) |
            DecodeReg(branch.reg);
   }
   break;
   case FixupBranch::Type::BConditional:
-    ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, static_cast<int>(branch.type), distance);
+    ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance),
+               "Branch type {}: Received too large distance: {}", branch.type, distance);
     inst = (0x2A << 25) | (MaskImm19(distance) << 5) | branch.cond;
     break;
   case FixupBranch::Type::TBNZ:
@@ -711,20 +705,20 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
     [[fallthrough]];
   case FixupBranch::Type::TBZ:
   {
-    ASSERT_MSG(DYNA_REC, IsInRangeImm14(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, static_cast<int>(branch.type), distance);
+    ASSERT_MSG(DYNA_REC, IsInRangeImm14(distance),
+               "Branch type {}: Received too large distance: {}", branch.type, distance);
     inst = ((branch.bit & 0x20) << 26) | (0x1B << 25) | (Not << 24) | ((branch.bit & 0x1F) << 19) |
            (MaskImm14(distance) << 5) | DecodeReg(branch.reg);
   }
   break;
   case FixupBranch::Type::B:
-    ASSERT_MSG(DYNA_REC, IsInRangeImm26(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, static_cast<int>(branch.type), distance);
+    ASSERT_MSG(DYNA_REC, IsInRangeImm26(distance),
+               "Branch type {}: Received too large distance: {}", branch.type, distance);
     inst = (0x5 << 26) | MaskImm26(distance);
     break;
   case FixupBranch::Type::BL:
-    ASSERT_MSG(DYNA_REC, IsInRangeImm26(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, static_cast<int>(branch.type), distance);
+    ASSERT_MSG(DYNA_REC, IsInRangeImm26(distance),
+               "Branch type {}: Received too large distance: {}", branch.type, distance);
     inst = (0x25 << 26) | MaskImm26(distance);
     break;
   }
@@ -815,7 +809,7 @@ void ARM64XEmitter::B(CCFlags cond, const void* ptr)
   distance >>= 2;
 
   ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance),
-             "%s: Received too large distance: %p->%p %" PRIi64 " %" PRIx64, __func__, m_code, ptr,
+             "Received too large distance: {}->{} (dist {} {:#x})", fmt::ptr(m_code), fmt::ptr(ptr),
              distance, distance);
   Write32((0x54 << 24) | (MaskImm19(distance) << 5) | cond);
 }
@@ -1434,24 +1428,21 @@ void ARM64XEmitter::BFI(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
   u32 size = Is64Bit(Rn) ? 64 : 32;
   ASSERT_MSG(DYNA_REC, lsb < size && width >= 1 && width <= size - lsb,
-             "%s passed lsb %d and width %d which is greater than the register size!", __func__,
-             lsb, width);
+             "lsb {} and width {} is greater than the register size {}!", lsb, width, size);
   BFM(Rd, Rn, (size - lsb) % size, width - 1);
 }
 void ARM64XEmitter::BFXIL(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
   u32 size = Is64Bit(Rn) ? 64 : 32;
   ASSERT_MSG(DYNA_REC, lsb < size && width >= 1 && width <= size - lsb,
-             "%s passed lsb %d and width %d which is greater than the register size!", __func__,
-             lsb, width);
+             "lsb {} and width {} is greater than the register size {}!", lsb, width, size);
   BFM(Rd, Rn, lsb, lsb + width - 1);
 }
 void ARM64XEmitter::UBFIZ(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
   u32 size = Is64Bit(Rn) ? 64 : 32;
   ASSERT_MSG(DYNA_REC, lsb < size && width >= 1 && width <= size - lsb,
-             "%s passed lsb %d and width %d which is greater than the register size!", __func__,
-             lsb, width);
+             "lsb {} and width {} is greater than the register size {}!", lsb, width, size);
   UBFM(Rd, Rn, (size - lsb) % size, width - 1);
 }
 void ARM64XEmitter::EXTR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u32 shift)
@@ -1472,7 +1463,7 @@ void ARM64XEmitter::SXTH(ARM64Reg Rd, ARM64Reg Rn)
 }
 void ARM64XEmitter::SXTW(ARM64Reg Rd, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, Is64Bit(Rd), "%s requires 64bit register as destination", __func__);
+  ASSERT_MSG(DYNA_REC, Is64Bit(Rd), "64bit register required as destination");
   SBFM(Rd, Rn, 0, 31);
 }
 void ARM64XEmitter::UXTB(ARM64Reg Rd, ARM64Reg Rn)
@@ -1763,7 +1754,7 @@ void ARM64XEmitter::LDUR(ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 }
 void ARM64XEmitter::LDURSW(ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 {
-  ASSERT_MSG(DYNA_REC, !Is64Bit(Rt), "%s must have a 64bit destination register!", __func__);
+  ASSERT_MSG(DYNA_REC, !Is64Bit(Rt), "Must have a 64bit destination register!");
   EncodeLoadStoreUnscaled(2, 2, Rt, Rn, imm);
 }
 
@@ -2015,7 +2006,7 @@ void ARM64XEmitter::ABI_PushRegisters(BitSet32 registers)
     STP(IndexType::Signed, odd_reg, even_reg, ARM64Reg::SP, 16 * (i + 1));
   }
 
-  ASSERT_MSG(DYNA_REC, it == registers.end(), "%s registers don't match.", __func__);
+  ASSERT_MSG(DYNA_REC, it == registers.end(), "Registers don't match: {:b}", registers.m_val);
 }
 
 void ARM64XEmitter::ABI_PopRegisters(BitSet32 registers, BitSet32 ignore_mask)
@@ -2052,7 +2043,7 @@ void ARM64XEmitter::ABI_PopRegisters(BitSet32 registers, BitSet32 ignore_mask)
   else
     LDP(IndexType::Post, first, second, ARM64Reg::SP, stack_size);
 
-  ASSERT_MSG(DYNA_REC, it == registers.end(), "%s registers don't match.", __func__);
+  ASSERT_MSG(DYNA_REC, it == registers.end(), "Registers don't match: {:b}", registers.m_val);
 }
 
 // Float Emitter
@@ -2076,10 +2067,10 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
   if (type == IndexType::Unsigned)
   {
     ASSERT_MSG(DYNA_REC, !(imm & ((size - 1) >> 3)),
-               "%s(IndexType::Unsigned) immediate offset must be aligned to size! (%d) (%p)",
-               __func__, imm, m_emit->GetCodePtr());
-    ASSERT_MSG(DYNA_REC, imm >= 0, "%s(IndexType::Unsigned) immediate offset must be positive!",
-               __func__);
+               "(IndexType::Unsigned) immediate offset must be aligned to size! ({}) ({})", imm,
+               fmt::ptr(m_emit->GetCodePtr()));
+    ASSERT_MSG(DYNA_REC, imm >= 0, "(IndexType::Unsigned) immediate offset must be positive! ({})",
+               imm);
     if (size == 16)
       imm >>= 1;
     else if (size == 32)
@@ -2093,7 +2084,7 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
   else
   {
     ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255),
-               "%s immediate offset must be within range of -256 to 256!", __func__);
+               "immediate offset must be within range of -256 to 256! {}", imm);
     encoded_imm = (imm & 0x1FF) << 2;
     if (type == IndexType::Post)
       encoded_imm |= 1;
@@ -2109,7 +2100,7 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
 void ARM64FloatEmitter::EmitScalar2Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd,
                                           ARM64Reg Rn, ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s only supports double and single registers!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "Only double and single registers are supported!");
 
   Write32((M << 31) | (S << 29) | (0b11110001 << 21) | (type << 22) | (DecodeReg(Rm) << 16) |
           (opcode << 12) | (1 << 11) | (DecodeReg(Rn) << 5) | DecodeReg(Rd));
@@ -2118,7 +2109,7 @@ void ARM64FloatEmitter::EmitScalar2Source(bool M, bool S, u32 type, u32 opcode, 
 void ARM64FloatEmitter::EmitScalarThreeSame(bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn,
                                             ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s only supports double and single registers!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "Only double and single registers are supported!");
 
   Write32((1 << 30) | (U << 29) | (0b11110001 << 21) | (size << 22) | (DecodeReg(Rm) << 16) |
           (opcode << 11) | (1 << 10) | (DecodeReg(Rn) << 5) | DecodeReg(Rd));
@@ -2127,7 +2118,7 @@ void ARM64FloatEmitter::EmitScalarThreeSame(bool U, u32 size, u32 opcode, ARM64R
 void ARM64FloatEmitter::EmitThreeSame(bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn,
                                       ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "Singles are not supported!");
   bool quad = IsQuad(Rd);
 
   Write32((quad << 30) | (U << 29) | (0b1110001 << 21) | (size << 22) | (DecodeReg(Rm) << 16) |
@@ -2148,7 +2139,7 @@ void ARM64FloatEmitter::EmitScalar2RegMisc(bool U, u32 size, u32 opcode, ARM64Re
 
 void ARM64FloatEmitter::Emit2RegMisc(bool Q, bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "Singles are not supported!");
 
   Write32((Q << 30) | (U << 29) | (0b1110001 << 21) | (size << 22) | (opcode << 12) | (1 << 11) |
           (DecodeReg(Rn) << 5) | DecodeReg(Rd));
@@ -2157,7 +2148,7 @@ void ARM64FloatEmitter::Emit2RegMisc(bool Q, bool U, u32 size, u32 opcode, ARM64
 void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode, bool S, u32 size,
                                                      ARM64Reg Rt, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rt), "%s doesn't support singles!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rt), "Singles are not supported!");
   bool quad = IsQuad(Rt);
 
   Write32((quad << 30) | (0b1101 << 24) | (L << 22) | (R << 21) | (opcode << 13) | (S << 12) |
@@ -2167,7 +2158,7 @@ void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode,
 void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode, bool S, u32 size,
                                                      ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rt), "%s doesn't support singles!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rt), "Singles are not supported!");
   bool quad = IsQuad(Rt);
 
   Write32((quad << 30) | (0x1B << 23) | (L << 22) | (R << 21) | (DecodeReg(Rm) << 16) |
@@ -2176,7 +2167,7 @@ void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode,
 
 void ARM64FloatEmitter::Emit1Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "Vector is not supported!");
 
   Write32((M << 31) | (S << 29) | (0xF1 << 21) | (type << 22) | (opcode << 15) | (1 << 14) |
           (DecodeReg(Rn) << 5) | DecodeReg(Rd));
@@ -2185,7 +2176,7 @@ void ARM64FloatEmitter::Emit1Source(bool M, bool S, u32 type, u32 opcode, ARM64R
 void ARM64FloatEmitter::EmitConversion(bool sf, bool S, u32 type, u32 rmode, u32 opcode,
                                        ARM64Reg Rd, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, Rn <= ARM64Reg::SP, "%s only supports GPR as source!", __func__);
+  ASSERT_MSG(DYNA_REC, Rn <= ARM64Reg::SP, "Only GPRs are supported as source!");
 
   Write32((sf << 31) | (S << 29) | (0xF1 << 21) | (type << 22) | (rmode << 19) | (opcode << 16) |
           (DecodeReg(Rn) << 5) | DecodeReg(Rd));
@@ -2272,7 +2263,7 @@ void ARM64FloatEmitter::EmitConversion2(bool sf, bool S, bool direction, u32 typ
 
 void ARM64FloatEmitter::EmitCompare(bool M, bool S, u32 op, u32 opcode2, ARM64Reg Rn, ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rn), "%s doesn't support vector!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rn), "Vector is not supported!");
   bool is_double = IsDouble(Rn);
 
   Write32((M << 31) | (S << 29) | (0xF1 << 21) | (is_double << 22) | (DecodeReg(Rm) << 16) |
@@ -2282,7 +2273,7 @@ void ARM64FloatEmitter::EmitCompare(bool M, bool S, u32 op, u32 opcode2, ARM64Re
 void ARM64FloatEmitter::EmitCondSelect(bool M, bool S, CCFlags cond, ARM64Reg Rd, ARM64Reg Rn,
                                        ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "Vector is not supported!");
   bool is_double = IsDouble(Rd);
 
   Write32((M << 31) | (S << 29) | (0xF1 << 21) | (is_double << 22) | (DecodeReg(Rm) << 16) |
@@ -2291,7 +2282,7 @@ void ARM64FloatEmitter::EmitCondSelect(bool M, bool S, CCFlags cond, ARM64Reg Rd
 
 void ARM64FloatEmitter::EmitPermute(u32 size, u32 op, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "Singles are not supported!");
 
   bool quad = IsQuad(Rd);
 
@@ -2309,7 +2300,7 @@ void ARM64FloatEmitter::EmitPermute(u32 size, u32 op, ARM64Reg Rd, ARM64Reg Rn, 
 
 void ARM64FloatEmitter::EmitScalarImm(bool M, bool S, u32 type, u32 imm5, ARM64Reg Rd, u32 imm8)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "Vector is not supported!");
 
   bool is_double = !IsSingle(Rd);
 
@@ -2320,7 +2311,7 @@ void ARM64FloatEmitter::EmitScalarImm(bool M, bool S, u32 type, u32 imm5, ARM64R
 void ARM64FloatEmitter::EmitShiftImm(bool Q, bool U, u32 immh, u32 immb, u32 opcode, ARM64Reg Rd,
                                      ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, immh, "%s bad encoding! Can't have zero immh", __func__);
+  ASSERT_MSG(DYNA_REC, immh != 0, "Can't have zero immh");
 
   Write32((Q << 30) | (U << 29) | (0xF << 24) | (immh << 19) | (immb << 16) | (opcode << 11) |
           (1 << 10) | (DecodeReg(Rn) << 5) | DecodeReg(Rd));
@@ -2370,7 +2361,7 @@ void ARM64FloatEmitter::EmitLoadStoreMultipleStructurePost(u32 size, bool L, u32
 void ARM64FloatEmitter::EmitScalar1Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd,
                                           ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __func__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "Vector is not supported!");
 
   Write32((M << 31) | (S << 29) | (0xF1 << 21) | (type << 22) | (opcode << 15) | (1 << 14) |
           (DecodeReg(Rn) << 5) | DecodeReg(Rd));
@@ -2388,8 +2379,7 @@ void ARM64FloatEmitter::EmitVectorxElement(bool U, u32 size, bool L, u32 opcode,
 
 void ARM64FloatEmitter::EmitLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 {
-  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "%s received too large offset: %d", __func__,
-             imm);
+  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "received too large offset: {}", imm);
 
   Write32((size << 30) | (0xF << 26) | (op << 22) | ((imm & 0x1FF) << 12) | (DecodeReg(Rn) << 5) |
           DecodeReg(Rt));
@@ -2413,30 +2403,30 @@ void ARM64FloatEmitter::EncodeLoadStorePair(u32 size, bool load, IndexType type,
     type_encode = 0b011;
     break;
   case IndexType::Unsigned:
-    ASSERT_MSG(DYNA_REC, false, "%s doesn't support IndexType::Unsigned!", __func__);
+    ASSERT_MSG(DYNA_REC, false, "IndexType::Unsigned is unsupported!");
     break;
   }
 
   if (size == 128)
   {
-    ASSERT_MSG(DYNA_REC, !(imm & 0xF), "%s received invalid offset 0x%x!", __func__, imm);
+    ASSERT_MSG(DYNA_REC, !(imm & 0xF), "Invalid offset {:#x}! (size {})", imm, size);
     opc = 2;
     imm >>= 4;
   }
   else if (size == 64)
   {
-    ASSERT_MSG(DYNA_REC, !(imm & 0x7), "%s received invalid offset 0x%x!", __func__, imm);
+    ASSERT_MSG(DYNA_REC, !(imm & 0x7), "Invalid offset {:#x}! (size {})", imm, size);
     opc = 1;
     imm >>= 3;
   }
   else if (size == 32)
   {
-    ASSERT_MSG(DYNA_REC, !(imm & 0x3), "%s received invalid offset 0x%x!", __func__, imm);
+    ASSERT_MSG(DYNA_REC, !(imm & 0x3), "Invalid offset {:#x}! (size {})", imm, size);
     opc = 0;
     imm >>= 2;
   }
 
-  ASSERT_MSG(DYNA_REC, imm >= -64 && imm < 64, "imm too large for load/store pair!");
+  ASSERT_MSG(DYNA_REC, imm >= -64 && imm < 64, "imm too large for load/store pair! {}", imm);
 
   Write32((opc << 30) | (0b1011 << 26) | (type_encode << 23) | (load << 22) | ((imm & 0x7F) << 15) |
           (DecodeReg(Rt2) << 10) | (DecodeReg(Rn) << 5) | DecodeReg(Rt));
@@ -2445,7 +2435,7 @@ void ARM64FloatEmitter::EncodeLoadStorePair(u32 size, bool load, IndexType type,
 void ARM64FloatEmitter::EncodeLoadStoreRegisterOffset(u32 size, bool load, ARM64Reg Rt, ARM64Reg Rn,
                                                       ArithOption Rm)
 {
-  ASSERT_MSG(DYNA_REC, Rm.IsExtended(), "%s must contain an extended reg as Rm!", __func__);
+  ASSERT_MSG(DYNA_REC, Rm.IsExtended(), "Must contain an extended reg as Rm!");
 
   u32 encoded_size = 0;
   u32 encoded_op = 0;
@@ -2803,8 +2793,8 @@ void ARM64FloatEmitter::ST1(u8 size, ARM64Reg Rt, u8 index, ARM64Reg Rn, ARM64Re
 // Loadstore multiple structure
 void ARM64FloatEmitter::LD1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!",
-             __func__);
+  ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "Must have a count of 1 to 4 registers! ({})",
+             count);
   u32 opcode = 0;
   if (count == 1)
     opcode = 0b111;
@@ -2819,9 +2809,9 @@ void ARM64FloatEmitter::LD1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 void ARM64FloatEmitter::LD1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM64Reg Rn,
                             ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!",
-             __func__);
-  ASSERT_MSG(DYNA_REC, type == IndexType::Post, "%s only supports post indexing!", __func__);
+  ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "Must have a count of 1 to 4 registers! ({})",
+             count);
+  ASSERT_MSG(DYNA_REC, type == IndexType::Post, "Only post indexing is supported!");
 
   u32 opcode = 0;
   if (count == 1)
@@ -2836,8 +2826,8 @@ void ARM64FloatEmitter::LD1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM6
 }
 void ARM64FloatEmitter::ST1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!",
-             __func__);
+  ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "Must have a count of 1 to 4 registers! ({})",
+             count);
   u32 opcode = 0;
   if (count == 1)
     opcode = 0b111;
@@ -2852,9 +2842,9 @@ void ARM64FloatEmitter::ST1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 void ARM64FloatEmitter::ST1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM64Reg Rn,
                             ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!",
-             __func__);
-  ASSERT_MSG(DYNA_REC, type == IndexType::Post, "%s only supports post indexing!", __func__);
+  ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "Must have a count of 1 to 4 registers! ({})",
+             count);
+  ASSERT_MSG(DYNA_REC, type == IndexType::Post, "Only post indexing is supporte!");
 
   u32 opcode = 0;
   if (count == 1)
@@ -2954,7 +2944,7 @@ void ARM64FloatEmitter::FRSQRTE(ARM64Reg Rd, ARM64Reg Rn)
 // Scalar - 2 Source
 void ARM64FloatEmitter::ADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, IsDouble(Rd), "%s only supports double registers!", __func__);
+  ASSERT_MSG(DYNA_REC, IsDouble(Rd), "Only double registers are supported!");
   EmitScalarThreeSame(0, 3, 0b10000, Rd, Rn, Rm);
 }
 void ARM64FloatEmitter::FADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
@@ -3292,9 +3282,9 @@ void ARM64FloatEmitter::INS(u8 size, ARM64Reg Rd, u8 index1, ARM64Reg Rn, u8 ind
 void ARM64FloatEmitter::UMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 {
   bool b64Bit = Is64Bit(Rd);
-  ASSERT_MSG(DYNA_REC, Rd < ARM64Reg::SP, "%s destination must be a GPR!", __func__);
+  ASSERT_MSG(DYNA_REC, Rd < ARM64Reg::SP, "Destination must be a GPR!");
   ASSERT_MSG(DYNA_REC, !(b64Bit && size != 64),
-             "%s must have a size of 64 when destination is 64bit!", __func__);
+             "Must have a size of 64 when destination is 64bit!");
   u32 imm5 = 0;
 
   if (size == 8)
@@ -3323,8 +3313,8 @@ void ARM64FloatEmitter::UMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 void ARM64FloatEmitter::SMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 {
   bool b64Bit = Is64Bit(Rd);
-  ASSERT_MSG(DYNA_REC, Rd < ARM64Reg::SP, "%s destination must be a GPR!", __func__);
-  ASSERT_MSG(DYNA_REC, size != 64, "%s doesn't support 64bit destination. Use UMOV!", __func__);
+  ASSERT_MSG(DYNA_REC, Rd < ARM64Reg::SP, "Destination must be a GPR!");
+  ASSERT_MSG(DYNA_REC, size != 64, "SMOV doesn't support 64bit destination. Use UMOV!");
   u32 imm5 = 0;
 
   if (size == 8)
@@ -3562,8 +3552,8 @@ void ARM64FloatEmitter::UXTL2(u8 src_size, ARM64Reg Rd, ARM64Reg Rn)
 
 void ARM64FloatEmitter::SSHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper)
 {
-  ASSERT_MSG(DYNA_REC, shift < src_size, "%s shift amount must less than the element size!",
-             __func__);
+  ASSERT_MSG(DYNA_REC, shift < src_size, "Shift amount must less than the element size! {} {}",
+             shift, src_size);
   u32 immh = 0;
   u32 immb = shift & 0xFFF;
 
@@ -3585,8 +3575,8 @@ void ARM64FloatEmitter::SSHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, 
 
 void ARM64FloatEmitter::USHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper)
 {
-  ASSERT_MSG(DYNA_REC, shift < src_size, "%s shift amount must less than the element size!",
-             __func__);
+  ASSERT_MSG(DYNA_REC, shift < src_size, "Shift amount must less than the element size! {} {}",
+             shift, src_size);
   u32 immh = 0;
   u32 immb = shift & 0xFFF;
 
@@ -3608,8 +3598,8 @@ void ARM64FloatEmitter::USHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, 
 
 void ARM64FloatEmitter::SHRN(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper)
 {
-  ASSERT_MSG(DYNA_REC, shift < dest_size, "%s shift amount must less than the element size!",
-             __func__);
+  ASSERT_MSG(DYNA_REC, shift < dest_size, "Shift amount must less than the element size! {} {}",
+             shift, dest_size);
   u32 immh = 0;
   u32 immb = shift & 0xFFF;
 
@@ -3642,7 +3632,8 @@ void ARM64FloatEmitter::UXTL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, bool upper)
 // vector x indexed element
 void ARM64FloatEmitter::FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index)
 {
-  ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!", __func__);
+  ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "Only 32bit or 64bit sizes are supported! {}",
+             size);
 
   bool L = false;
   bool H = false;
@@ -3661,7 +3652,8 @@ void ARM64FloatEmitter::FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 
 
 void ARM64FloatEmitter::FMLA(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index)
 {
-  ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!", __func__);
+  ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "Only 32bit or 64bit sizes are supported! {}",
+             size);
 
   bool L = false;
   bool H = false;
@@ -3687,14 +3679,14 @@ void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
   u8 abcdefgh = imm & 0xFF;
   if (size == 8)
   {
-    ASSERT_MSG(DYNA_REC, shift == 0, "%s(size8) doesn't support shift!", __func__);
-    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "%s(size8) only supports 8bit values!", __func__);
+    ASSERT_MSG(DYNA_REC, shift == 0, "size8 doesn't support shift! ({})", shift);
+    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "size8 only supports 8bit values! ({})", imm);
   }
   else if (size == 16)
   {
-    ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8, "%s(size16) only supports shift of {0, 8}!",
-               __func__);
-    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "%s(size16) only supports 8bit values!", __func__);
+    ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8, "size16 only supports shift of 0 or 8! ({})",
+               shift);
+    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "size16 only supports 8bit values! ({})", imm);
 
     if (shift == 8)
       cmode |= 2;
@@ -3702,9 +3694,9 @@ void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
   else if (size == 32)
   {
     ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8 || shift == 16 || shift == 24,
-               "%s(size32) only supports shift of {0, 8, 16, 24}!", __func__);
+               "size32 only supports shift of 0, 8, 16, or 24! ({})", shift);
     // XXX: Implement support for MOVI - shifting ones variant
-    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "%s(size32) only supports 8bit values!", __func__);
+    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "size32 only supports 8bit values! ({})", imm);
     switch (shift)
     {
     case 8:
@@ -3722,7 +3714,7 @@ void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
   }
   else  // 64
   {
-    ASSERT_MSG(DYNA_REC, shift == 0, "%s(size64) doesn't support shift!", __func__);
+    ASSERT_MSG(DYNA_REC, shift == 0, "size64 doesn't support shift! ({})", shift);
 
     op = 1;
     cmode = 0xE;
@@ -3730,7 +3722,8 @@ void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
     for (int i = 0; i < 8; ++i)
     {
       u8 tmp = (imm >> (i << 3)) & 0xFF;
-      ASSERT_MSG(DYNA_REC, tmp == 0xFF || tmp == 0, "%s(size64) Invalid immediate!", __func__);
+      ASSERT_MSG(DYNA_REC, tmp == 0xFF || tmp == 0, "size64 Invalid immediate! ({} -> {})", imm,
+                 tmp);
       if (tmp == 0xFF)
         abcdefgh |= (1 << i);
     }
@@ -3744,8 +3737,8 @@ void ARM64FloatEmitter::ORR_BIC(u8 size, ARM64Reg Rd, u8 imm, u8 shift, u8 op)
   u8 cmode = 1;
   if (size == 16)
   {
-    ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8, "%s(size16) only supports shift of {0, 8}!",
-               __func__);
+    ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8, "size16 only supports shift of 0 or 8! {}",
+               shift);
 
     if (shift == 8)
       cmode |= 2;
@@ -3753,7 +3746,7 @@ void ARM64FloatEmitter::ORR_BIC(u8 size, ARM64Reg Rd, u8 imm, u8 shift, u8 op)
   else if (size == 32)
   {
     ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8 || shift == 16 || shift == 24,
-               "%s(size32) only supports shift of {0, 8, 16, 24}!", __func__);
+               "size32 only supports shift of 0, 8, 16, or 24! ({})", shift);
     // XXX: Implement support for MOVI - shifting ones variant
     switch (shift)
     {
@@ -3772,7 +3765,7 @@ void ARM64FloatEmitter::ORR_BIC(u8 size, ARM64Reg Rd, u8 imm, u8 shift, u8 op)
   }
   else
   {
-    ASSERT_MSG(DYNA_REC, false, "%s only supports size of {16, 32}!", __func__);
+    ASSERT_MSG(DYNA_REC, false, "Only size of 16 or 32 is supported! ({})", size);
   }
   EncodeModImm(Q, op, cmode, 0, Rd, imm);
 }
@@ -3964,8 +3957,8 @@ void ARM64XEmitter::ANDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
   else
   {
     ASSERT_MSG(DYNA_REC, scratch != ARM64Reg::INVALID_REG,
-               "ANDI2R - failed to construct logical immediate value from %08x, need scratch",
-               (u32)imm);
+               "ANDI2R - failed to construct logical immediate value from {:#10x}, need scratch",
+               imm);
     MOVI2R(scratch, imm);
     AND(Rd, Rn, scratch);
   }
@@ -3980,8 +3973,8 @@ void ARM64XEmitter::ORRI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
   else
   {
     ASSERT_MSG(DYNA_REC, scratch != ARM64Reg::INVALID_REG,
-               "ORRI2R - failed to construct logical immediate value from %08x, need scratch",
-               (u32)imm);
+               "ORRI2R - failed to construct logical immediate value from {:#10x}, need scratch",
+               imm);
     MOVI2R(scratch, imm);
     ORR(Rd, Rn, scratch);
   }
@@ -3996,8 +3989,8 @@ void ARM64XEmitter::EORI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
   else
   {
     ASSERT_MSG(DYNA_REC, scratch != ARM64Reg::INVALID_REG,
-               "EORI2R - failed to construct logical immediate value from %08x, need scratch",
-               (u32)imm);
+               "EORI2R - failed to construct logical immediate value from {:#10x}, need scratch",
+               imm);
     MOVI2R(scratch, imm);
     EOR(Rd, Rn, scratch);
   }
@@ -4012,8 +4005,8 @@ void ARM64XEmitter::ANDSI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
   else
   {
     ASSERT_MSG(DYNA_REC, scratch != ARM64Reg::INVALID_REG,
-               "ANDSI2R - failed to construct logical immediate value from %08x, need scratch",
-               (u32)imm);
+               "ANDSI2R - failed to construct logical immediate value from {:#10x}, need scratch",
+               imm);
     MOVI2R(scratch, imm);
     ANDS(Rd, Rn, scratch);
   }
@@ -4085,8 +4078,8 @@ void ARM64XEmitter::ADDI2R_internal(ARM64Reg Rd, ARM64Reg Rn, u64 imm, bool nega
   }
 
   ASSERT_MSG(DYNA_REC, has_scratch,
-             "ADDI2R - failed to construct arithmetic immediate value from %08x, need scratch",
-             (u32)imm);
+             "ADDI2R - failed to construct arithmetic immediate value from {:#10x}, need scratch",
+             imm);
 
   negative ^= MOVI2R2(scratch, imm, imm_neg);
   if (!negative)
@@ -4218,7 +4211,7 @@ void ARM64FloatEmitter::MOVI2F(ARM64Reg Rd, float value, ARM64Reg scratch, bool 
   else
   {
     ASSERT_MSG(DYNA_REC, scratch != ARM64Reg::INVALID_REG,
-               "Failed to find a way to generate FP immediate %f without scratch", value);
+               "Failed to find a way to generate FP immediate {} without scratch", value);
     if (negate)
       value = -value;
 

--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -13,31 +13,32 @@
   {                                                                                                \
     if (!(_a_))                                                                                    \
     {                                                                                              \
-      if (!PanicYesNo(_fmt_, ##__VA_ARGS__))                                                       \
+      if (!PanicYesNo("An error occurred.\n\n" _fmt_ "\n\n"                                        \
+                      "  Condition: %s\n  File: %s\n  Line: %d\n  Function: %s\n\n"                \
+                      "Ignore and continue?",                                                      \
+                      ##__VA_ARGS__, #_a_, __FILE__, __LINE__, __func__))                          \
         Crash();                                                                                   \
     }                                                                                              \
   } while (0)
 
-#define DEBUG_ASSERT_MSG(_t_, _a_, _msg_, ...)                                                     \
+#define DEBUG_ASSERT_MSG(_t_, _a_, _fmt_, ...)                                                     \
   do                                                                                               \
   {                                                                                                \
     if constexpr (Common::Log::MAX_LOGLEVEL >= Common::Log::LogLevel::LDEBUG)                      \
-    {                                                                                              \
-      if (!(_a_))                                                                                  \
-      {                                                                                            \
-        ERROR_LOG(_t_, _msg_, ##__VA_ARGS__);                                                      \
-        if (!PanicYesNo(_msg_, ##__VA_ARGS__))                                                     \
-          Crash();                                                                                 \
-      }                                                                                            \
-    }                                                                                              \
+      ASSERT_MSG(_t_, _a_, _fmt_, ##__VA_ARGS__);                                                  \
   } while (0)
 
 #define ASSERT(_a_)                                                                                \
   do                                                                                               \
   {                                                                                                \
-    ASSERT_MSG(MASTER_LOG, _a_,                                                                    \
-               _trans("An error occurred.\n\n  Line: %d\n  File: %s\n\nIgnore and continue?"),     \
-               __LINE__, __FILE__);                                                                \
+    if (!(_a_))                                                                                    \
+    {                                                                                              \
+      if (!PanicYesNo("An error occurred.\n\n"                                                     \
+                      "  Condition: %s\n  File: %s\n  Line: %d\n  Function: %s\n\n"                \
+                      "Ignore and continue?",                                                      \
+                      #_a_, __FILE__, __LINE__, __func__))                                         \
+        Crash();                                                                                   \
+    }                                                                                              \
   } while (0)
 
 #define DEBUG_ASSERT(_a_)                                                                          \

--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -13,10 +13,10 @@
   {                                                                                                \
     if (!(_a_))                                                                                    \
     {                                                                                              \
-      if (!PanicYesNo("An error occurred.\n\n" _fmt_ "\n\n"                                        \
-                      "  Condition: %s\n  File: %s\n  Line: %d\n  Function: %s\n\n"                \
-                      "Ignore and continue?",                                                      \
-                      ##__VA_ARGS__, #_a_, __FILE__, __LINE__, __func__))                          \
+      if (!PanicYesNoFmt("An error occurred.\n\n" _fmt_ "\n\n"                                     \
+                         "  Condition: {}\n  File: {}\n  Line: {}\n  Function: {}\n\n"             \
+                         "Ignore and continue?",                                                   \
+                         ##__VA_ARGS__, #_a_, __FILE__, __LINE__, __func__))                       \
         Crash();                                                                                   \
     }                                                                                              \
   } while (0)
@@ -33,10 +33,10 @@
   {                                                                                                \
     if (!(_a_))                                                                                    \
     {                                                                                              \
-      if (!PanicYesNo("An error occurred.\n\n"                                                     \
-                      "  Condition: %s\n  File: %s\n  Line: %d\n  Function: %s\n\n"                \
-                      "Ignore and continue?",                                                      \
-                      #_a_, __FILE__, __LINE__, __func__))                                         \
+      if (!PanicYesNoFmt("An error occurred.\n\n"                                                  \
+                         "  Condition: {}\n  File: {}\n  Line: {}\n  Function: {}\n\n"             \
+                         "Ignore and continue?",                                                   \
+                         #_a_, __FILE__, __LINE__, __func__))                                      \
         Crash();                                                                                   \
     }                                                                                              \
   } while (0)

--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -13,10 +13,11 @@
   {                                                                                                \
     if (!(_a_))                                                                                    \
     {                                                                                              \
-      if (!PanicYesNoFmt("An error occurred.\n\n" _fmt_ "\n\n"                                     \
-                         "  Condition: {}\n  File: {}\n  Line: {}\n  Function: {}\n\n"             \
-                         "Ignore and continue?",                                                   \
-                         ##__VA_ARGS__, #_a_, __FILE__, __LINE__, __func__))                       \
+      if (!PanicYesNoFmtAssert(_t_,                                                                \
+                               "An error occurred.\n\n" _fmt_ "\n\n"                               \
+                               "  Condition: {}\n  File: {}\n  Line: {}\n  Function: {}\n\n"       \
+                               "Ignore and continue?",                                             \
+                               ##__VA_ARGS__, #_a_, __FILE__, __LINE__, __func__))                 \
         Crash();                                                                                   \
     }                                                                                              \
   } while (0)

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -164,7 +164,7 @@ elseif(WIN32)
     winmm.lib
   )
   if (_M_X86_64)
-	  target_link_libraries(common PRIVATE opengl32.lib)
+    target_link_libraries(common PRIVATE opengl32.lib)
   endif()
 elseif (ANDROID)
   target_link_libraries(common
@@ -284,6 +284,10 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_libraries(common PUBLIC dl rt)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_sources(common PUBLIC HRWrap.h HRWrap.cpp)
 endif()
 
 if(USE_UPNP)

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -25,6 +25,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/EnumMap.h"
@@ -332,8 +334,8 @@ private:
 
     case MODE_VERIFY:
       DEBUG_ASSERT_MSG(COMMON, !memcmp(data, *ptr, size),
-                       "Savestate verification failure: buf %p != %p (size %u).\n", data, *ptr,
-                       size);
+                       "Savestate verification failure: buf {} != {} (size {}).\n", fmt::ptr(data),
+                       fmt::ptr(*ptr), size);
       break;
     }
 

--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -15,7 +15,7 @@
 #define CHECK_HEAP_INTEGRITY()                                                                     \
   {                                                                                                \
     if (!_CrtCheckMemory())                                                                        \
-      PanicAlert("memory corruption detected. see log.");                                          \
+      PanicAlertFmt("memory corruption detected. see log.");                                       \
   }
 // If you want to see how much a pain in the ass singletons are, for example:
 // {614} normal block at 0x030C5310, 188 bytes long.

--- a/Source/Core/Common/HRWrap.cpp
+++ b/Source/Core/Common/HRWrap.cpp
@@ -1,0 +1,17 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "HRWrap.h"
+
+#include <comdef.h>
+#include "Common/StringUtil.h"
+
+namespace Common
+{
+std::string GetHResultMessage(HRESULT hr)
+{
+  // See https://stackoverflow.com/a/7008111
+  _com_error err(hr);
+  return TStrToUTF8(err.ErrorMessage());
+}
+}  // namespace Common

--- a/Source/Core/Common/HRWrap.h
+++ b/Source/Core/Common/HRWrap.h
@@ -1,0 +1,33 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <fmt/format.h>
+#include <string>
+#include <winerror.h>
+
+namespace Common
+{
+std::string GetHResultMessage(HRESULT hr);
+
+// Wrapper for HRESULT to be used with fmt.  Note that we can't create a fmt::formatter directly
+// for HRESULT as HRESULT is simply a typedef on long and not a distinct type.
+struct HRWrap
+{
+  constexpr explicit HRWrap(HRESULT hr) : m_hr(hr) {}
+  const HRESULT m_hr;
+};
+}  // namespace Common
+
+template <>
+struct fmt::formatter<Common::HRWrap>
+{
+  constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const Common::HRWrap& hr, FormatContext& ctx)
+  {
+    return fmt::format_to(ctx.out(), "{} ({:#010x})", Common::GetHResultMessage(hr.m_hr),
+                          static_cast<u32>(hr.m_hr));
+  }
+};

--- a/Source/Core/Common/Image.cpp
+++ b/Source/Core/Common/Image.cpp
@@ -80,7 +80,7 @@ bool SavePNG(const std::string& path, const u8* input, ImageByteFormat format, u
     byte_per_pixel = 4;
     break;
   default:
-    ASSERT_MSG(FRAMEDUMP, false, "Invalid format %d", static_cast<int>(format));
+    ASSERT_MSG(FRAMEDUMP, false, "Invalid format {}", format);
     return false;
   }
 

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -106,10 +106,11 @@ std::string GetStringT(const char* string)
   return s_str_translator(string);
 }
 
-static bool ShowMessageAlert(std::string_view text, bool yes_no, MsgType style)
+static bool ShowMessageAlert(std::string_view text, bool yes_no, Common::Log::LogType log_type,
+                             MsgType style)
 {
   const char* caption = GetCaption(style);
-  ERROR_LOG_FMT(MASTER_LOG, "{}: {}", caption, text);
+  GENERIC_LOG_FMT(log_type, Common::Log::LogLevel::LERROR, "{}: {}", caption, text);
 
   // Panic alerts.
   if (style == MsgType::Warning && s_abort_on_panic_alert)
@@ -129,11 +130,11 @@ static bool ShowMessageAlert(std::string_view text, bool yes_no, MsgType style)
 
 // This is the first stop for gui alerts where the log is updated and the
 // correct window is shown, when using fmt
-bool MsgAlertFmtImpl(bool yes_no, MsgType style, fmt::string_view format,
-                     const fmt::format_args& args)
+bool MsgAlertFmtImpl(bool yes_no, MsgType style, Common::Log::LogType log_type,
+                     fmt::string_view format, const fmt::format_args& args)
 {
   const auto message = fmt::vformat(format, args);
 
-  return ShowMessageAlert(message, yes_no, style);
+  return ShowMessageAlert(message, yes_no, log_type, style);
 }
 }  // namespace Common

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -107,10 +107,13 @@ std::string GetStringT(const char* string)
 }
 
 static bool ShowMessageAlert(std::string_view text, bool yes_no, Common::Log::LogType log_type,
-                             MsgType style)
+                             MsgType style, const char* file, int line)
 {
   const char* caption = GetCaption(style);
-  GENERIC_LOG_FMT(log_type, Common::Log::LogLevel::LERROR, "{}: {}", caption, text);
+  // Directly call GenericLogFmt rather than using the normal log macros so that we can use the
+  // caller's line file and line number
+  Common::Log::GenericLogFmt<2>(Common::Log::LogLevel::LERROR, log_type, file, line,
+                                FMT_STRING("{}: {}"), caption, text);
 
   // Panic alerts.
   if (style == MsgType::Warning && s_abort_on_panic_alert)
@@ -130,11 +133,11 @@ static bool ShowMessageAlert(std::string_view text, bool yes_no, Common::Log::Lo
 
 // This is the first stop for gui alerts where the log is updated and the
 // correct window is shown, when using fmt
-bool MsgAlertFmtImpl(bool yes_no, MsgType style, Common::Log::LogType log_type,
-                     fmt::string_view format, const fmt::format_args& args)
+bool MsgAlertFmtImpl(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
+                     int line, fmt::string_view format, const fmt::format_args& args)
 {
   const auto message = fmt::vformat(format, args);
 
-  return ShowMessageAlert(message, yes_no, log_type, style);
+  return ShowMessageAlert(message, yes_no, log_type, style, file, line);
 }
 }  // namespace Common

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -128,20 +128,6 @@ static bool ShowMessageAlert(std::string_view text, bool yes_no, MsgType style)
 }
 
 // This is the first stop for gui alerts where the log is updated and the
-// correct window is shown, but only for legacy printf-style messages
-bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
-{
-  char buffer[2048];
-
-  va_list args;
-  va_start(args, format);
-  CharArrayFromFormatV(buffer, sizeof(buffer) - 1, s_str_translator(format).c_str(), args);
-  va_end(args);
-
-  return ShowMessageAlert(buffer, yes_no, style);
-}
-
-// This is the first stop for gui alerts where the log is updated and the
 // correct window is shown, when using fmt
 bool MsgAlertFmtImpl(bool yes_no, MsgType style, fmt::string_view format,
                      const fmt::format_args& args)

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -30,12 +30,6 @@ void RegisterStringTranslator(StringTranslator translator);
 
 std::string GetStringT(const char* string);
 
-bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
-#ifdef __GNUC__
-    __attribute__((format(printf, 3, 4)))
-#endif
-    ;
-
 bool MsgAlertFmtImpl(bool yes_no, MsgType style, fmt::string_view format,
                      const fmt::format_args& args);
 
@@ -58,39 +52,6 @@ std::string FmtFormatT(const char* string, Args&&... args)
   return fmt::format(Common::GetStringT(string), std::forward<Args>(args)...);
 }
 }  // namespace Common
-
-// Deprecated variants of the alert macros. See the fmt variants down below.
-
-#define SuccessAlert(format, ...)                                                                  \
-  Common::MsgAlert(false, Common::MsgType::Information, format, ##__VA_ARGS__)
-
-#define PanicAlert(format, ...)                                                                    \
-  Common::MsgAlert(false, Common::MsgType::Warning, format, ##__VA_ARGS__)
-
-#define PanicYesNo(format, ...)                                                                    \
-  Common::MsgAlert(true, Common::MsgType::Warning, format, ##__VA_ARGS__)
-
-#define AskYesNo(format, ...)                                                                      \
-  Common::MsgAlert(true, Common::MsgType::Question, format, ##__VA_ARGS__)
-
-#define CriticalAlert(format, ...)                                                                 \
-  Common::MsgAlert(false, Common::MsgType::Critical, format, ##__VA_ARGS__)
-
-// Use these macros (that do the same thing) if the message should be translated.
-#define SuccessAlertT(format, ...)                                                                 \
-  Common::MsgAlert(false, Common::MsgType::Information, format, ##__VA_ARGS__)
-
-#define PanicAlertT(format, ...)                                                                   \
-  Common::MsgAlert(false, Common::MsgType::Warning, format, ##__VA_ARGS__)
-
-#define PanicYesNoT(format, ...)                                                                   \
-  Common::MsgAlert(true, Common::MsgType::Warning, format, ##__VA_ARGS__)
-
-#define AskYesNoT(format, ...)                                                                     \
-  Common::MsgAlert(true, Common::MsgType::Question, format, ##__VA_ARGS__)
-
-#define CriticalAlertT(format, ...)                                                                \
-  Common::MsgAlert(false, Common::MsgType::Critical, format, ##__VA_ARGS__)
 
 // Fmt-capable variants of the macros
 

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -3,7 +3,6 @@
 
 #include "Common/x64Emitter.h"
 
-#include <cinttypes>
 #include <cstring>
 
 #include "Common/CPUDetect.h"
@@ -310,7 +309,7 @@ void OpArg::WriteRest(XEmitter* emit, int extraBytes, X64Reg _operandReg,
     s64 distance = (s64)offset - (s64)ripAddr;
     ASSERT_MSG(DYNA_REC,
                (distance < 0x80000000LL && distance >= -0x80000000LL) || !warn_64bit_offset,
-               "WriteRest: op out of range (0x%" PRIx64 " uses 0x%" PRIx64 ")", ripAddr, offset);
+               "WriteRest: op out of range ({:#x} uses {:#x})", ripAddr, offset);
     s32 offs = (s32)distance;
     emit->Write32((u32)offs);
     return;
@@ -440,7 +439,7 @@ void XEmitter::JMP(const u8* addr, bool force5Bytes)
   {
     s64 distance = (s64)(fn - ((u64)code + 2));
     ASSERT_MSG(DYNA_REC, distance >= -0x80 && distance < 0x80,
-               "Jump target too far away, needs force5Bytes = true");
+               "Jump target too far away ({}), needs force5Bytes = true", distance);
     // 8 bits will do
     Write8(0xEB);
     Write8((u8)(s8)distance);
@@ -450,7 +449,7 @@ void XEmitter::JMP(const u8* addr, bool force5Bytes)
     s64 distance = (s64)(fn - ((u64)code + 5));
 
     ASSERT_MSG(DYNA_REC, distance >= -0x80000000LL && distance < 0x80000000LL,
-               "Jump target too far away, needs indirect register");
+               "Jump target too far away ({}), needs indirect register", distance);
     Write8(0xE9);
     Write32((u32)(s32)distance);
   }
@@ -489,7 +488,7 @@ void XEmitter::CALL(const void* fnptr)
 {
   u64 distance = u64(fnptr) - (u64(code) + 5);
   ASSERT_MSG(DYNA_REC, distance < 0x0000000080000000ULL || distance >= 0xFFFFFFFF80000000ULL,
-             "CALL out of range (%p calls %p)", code, fnptr);
+             "CALL out of range ({} calls {})", fmt::ptr(code), fmt::ptr(fnptr));
   Write8(0xE8);
   Write32(u32(distance));
 }
@@ -572,7 +571,7 @@ void XEmitter::J_CC(CCFlags conditionCode, const u8* addr)
   {
     distance = (s64)(fn - ((u64)code + 6));
     ASSERT_MSG(DYNA_REC, distance >= -0x80000000LL && distance < 0x80000000LL,
-               "Jump target too far away, needs indirect register");
+               "Jump target too far away ({}), needs indirect register", distance);
     Write8(0x0F);
     Write8(0x80 + conditionCode);
     Write32((u32)(s32)distance);
@@ -593,14 +592,14 @@ void XEmitter::SetJumpTarget(const FixupBranch& branch)
   {
     s64 distance = (s64)(code - branch.ptr);
     ASSERT_MSG(DYNA_REC, distance >= -0x80 && distance < 0x80,
-               "Jump target too far away, needs force5Bytes = true");
+               "Jump target too far away ({}), needs force5Bytes = true", distance);
     branch.ptr[-1] = (u8)(s8)distance;
   }
   else if (branch.type == FixupBranch::Type::Branch32Bit)
   {
     s64 distance = (s64)(code - branch.ptr);
     ASSERT_MSG(DYNA_REC, distance >= -0x80000000LL && distance < 0x80000000LL,
-               "Jump target too far away, needs indirect register");
+               "Jump target too far away ({}), needs indirect register", distance);
 
     s32 valid_distance = static_cast<s32>(distance);
     std::memcpy(&branch.ptr[-4], &valid_distance, sizeof(s32));
@@ -1535,7 +1534,7 @@ void OpArg::WriteNormalOp(XEmitter* emit, bool toRM, NormalOp op, const OpArg& o
     }
     else
     {
-      ASSERT_MSG(DYNA_REC, 0, "WriteNormalOp - Unhandled case %d %d", operand.scale, bits);
+      ASSERT_MSG(DYNA_REC, 0, "WriteNormalOp - Unhandled case {} {}", operand.scale, bits);
     }
 
     // pass extension in REG of ModRM

--- a/Source/Core/Core/ARDecrypt.cpp
+++ b/Source/Core/Core/ARDecrypt.cpp
@@ -476,14 +476,15 @@ void DecryptARCode(std::vector<std::string> vCodes, std::vector<AREntry>* ops)
   else if (!batchdecrypt(uCodes.data(), (u16)vCodes.size() << 1))
   {
     // Commented out since we just send the code anyways and hope for the best XD
-    // PanicAlert("Action Replay Code Decryption Error:\nCRC Check Failed\n\n"
-    // "First Code in Block(should be verification code):\n%s", vCodes[0].c_str());
+    // PanicAlertFmt("Action Replay Code Decryption Error:\nCRC Check Failed\n\n"
+    //               "First Code in Block (should be verification code):\n{}",
+    //               vCodes[0]);
 
     for (size_t i = 0; i < (vCodes.size() << 1); i += 2)
     {
       ops->emplace_back(uCodes[i], uCodes[i + 1]);
-      // PanicAlert("Decrypted AR Code without verification code:\n%08X %08X", uCodes[i],
-      // uCodes[i+1]);
+      // PanicAlertFmt("Decrypted AR Code without verification code:\n{:08X} {:08X}", uCodes[i],
+      //               uCodes[i + 1]);
     }
   }
   else
@@ -492,7 +493,7 @@ void DecryptARCode(std::vector<std::string> vCodes, std::vector<AREntry>* ops)
     for (size_t i = 2; i < (vCodes.size() << 1); i += 2)
     {
       ops->emplace_back(uCodes[i], uCodes[i + 1]);
-      // PanicAlert("Decrypted AR Code:\n%08X %08X", uCodes[i], uCodes[i+1]);
+      // PanicAlertFmt("Decrypted AR Code:\n{:08X} {:08X}", uCodes[i], uCodes[i+1]);
     }
   }
 }

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -4,7 +4,6 @@
 #include "Core/ConfigManager.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <climits>
 #include <memory>
 #include <optional>

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -108,9 +108,9 @@ EventType* RegisterEvent(const std::string& name, TimedCallback callback)
   // check for existing type with same name.
   // we want event type names to remain unique so that we can use them for serialization.
   ASSERT_MSG(POWERPC, s_event_types.find(name) == s_event_types.end(),
-             "CoreTiming Event \"%s\" is already registered. Events should only be registered "
+             "CoreTiming Event \"{}\" is already registered. Events should only be registered "
              "during Init to avoid breaking save states.",
-             name.c_str());
+             name);
 
   auto info = s_event_types.emplace(name, EventType{callback, nullptr});
   EventType* event_type = &info.first->second;
@@ -257,7 +257,7 @@ void ScheduleEvent(s64 cycles_into_future, EventType* event_type, u64 userdata, 
   {
     from_cpu_thread = from == FromThread::CPU;
     ASSERT_MSG(POWERPC, from_cpu_thread == Core::IsCPUThread(),
-               "A \"%s\" event was scheduled from the wrong thread (%s)", event_type->name->c_str(),
+               "A \"{}\" event was scheduled from the wrong thread ({})", *event_type->name,
                from_cpu_thread ? "CPU" : "non-CPU");
   }
 

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -300,7 +300,7 @@ u16 SDSP::ReadRegister(size_t reg) const
   case DSP_REG_ACM1:
     return r.ac[reg - DSP_REG_ACM0].m;
   default:
-    ASSERT_MSG(DSP_CORE, 0, "cannot happen");
+    ASSERT_MSG(DSPLLE, 0, "cannot happen");
     return 0;
   }
 }

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -687,7 +687,7 @@ u16 Interpreter::OpReadRegister(int reg_)
   case DSP_REG_ACM1:
     return state.r.ac[reg - DSP_REG_ACM0].m;
   default:
-    ASSERT_MSG(DSP_INT, 0, "cannot happen");
+    ASSERT_MSG(DSPLLE, 0, "cannot happen");
     return 0;
   }
 }

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -153,7 +153,7 @@ void DSPEmitter::FallBackToInterpreter(UDSPInstruction inst)
   const auto interpreter_function = Interpreter::GetOp(inst);
 
   m_gpr.PushRegs();
-  ASSERT_MSG(DSPLLE, interpreter_function != nullptr, "No function for %04x", inst);
+  ASSERT_MSG(DSPLLE, interpreter_function != nullptr, "No function for {:04x}", inst);
   ABI_CallFunctionPC(FallbackThunk, &m_dsp_core.GetInterpreter(), inst);
   m_gpr.PopRegs();
 }

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
@@ -298,21 +298,21 @@ void DSPJitRegCache::FlushRegs(DSPJitRegCache& cache, bool emit)
   for (size_t i = 0; i < m_xregs.size(); i++)
   {
     ASSERT_MSG(DSPLLE, m_xregs[i].guest_reg == cache.m_xregs[i].guest_reg,
-               "cache and current xreg guest_reg mismatch for %zu", i);
+               "cache and current xreg guest_reg mismatch for {}", i);
   }
 
   for (size_t i = 0; i < m_regs.size(); i++)
   {
     ASSERT_MSG(DSPLLE, m_regs[i].loc.IsImm() == cache.m_regs[i].loc.IsImm(),
-               "cache and current reg loc mismatch for %zu", i);
+               "cache and current reg loc mismatch for {}", i);
     ASSERT_MSG(DSPLLE, m_regs[i].loc.GetSimpleReg() == cache.m_regs[i].loc.GetSimpleReg(),
-               "cache and current reg loc mismatch for %zu", i);
+               "cache and current reg loc mismatch for {}", i);
     ASSERT_MSG(DSPLLE, m_regs[i].dirty || !cache.m_regs[i].dirty,
-               "cache and current reg dirty mismatch for %zu", i);
+               "cache and current reg dirty mismatch for {}", i);
     ASSERT_MSG(DSPLLE, m_regs[i].used == cache.m_regs[i].used,
-               "cache and current reg used mismatch for %zu", i);
+               "cache and current reg used mismatch for {}", i);
     ASSERT_MSG(DSPLLE, m_regs[i].shift == cache.m_regs[i].shift,
-               "cache and current reg shift mismatch for %zu", i);
+               "cache and current reg shift mismatch for {}", i);
   }
 
   m_use_ctr = cache.m_use_ctr;
@@ -326,7 +326,7 @@ void DSPJitRegCache::FlushMemBackedRegs()
 
   for (size_t i = 0; i < m_regs.size(); i++)
   {
-    ASSERT_MSG(DSPLLE, !m_regs[i].used, "register %u still in use", static_cast<u32>(i));
+    ASSERT_MSG(DSPLLE, !m_regs[i].used, "register {} still in use", static_cast<u32>(i));
 
     if (m_regs[i].used)
     {
@@ -356,27 +356,27 @@ void DSPJitRegCache::FlushRegs()
       MovToMemory(i);
     }
 
-    ASSERT_MSG(DSPLLE, !m_regs[i].loc.IsSimpleReg(), "register %zu is still a simple reg", i);
+    ASSERT_MSG(DSPLLE, !m_regs[i].loc.IsSimpleReg(), "register {} is still a simple reg", i);
   }
 
-  ASSERT_MSG(DSPLLE, m_xregs[RSP].guest_reg == DSP_REG_STATIC, "wrong xreg state for %d", RSP);
-  ASSERT_MSG(DSPLLE, m_xregs[RBX].guest_reg == DSP_REG_STATIC, "wrong xreg state for %d", RBX);
-  ASSERT_MSG(DSPLLE, m_xregs[RBP].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", RBP);
-  ASSERT_MSG(DSPLLE, m_xregs[RSI].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", RSI);
-  ASSERT_MSG(DSPLLE, m_xregs[RDI].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", RDI);
+  ASSERT_MSG(DSPLLE, m_xregs[RSP].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}", RSP);
+  ASSERT_MSG(DSPLLE, m_xregs[RBX].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}", RBX);
+  ASSERT_MSG(DSPLLE, m_xregs[RBP].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", RBP);
+  ASSERT_MSG(DSPLLE, m_xregs[RSI].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", RSI);
+  ASSERT_MSG(DSPLLE, m_xregs[RDI].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", RDI);
 #ifdef STATIC_REG_ACCS
-  ASSERT_MSG(DSPLLE, m_xregs[R8].guest_reg == DSP_REG_STATIC, "wrong xreg state for %d", R8);
-  ASSERT_MSG(DSPLLE, m_xregs[R9].guest_reg == DSP_REG_STATIC, "wrong xreg state for %d", R9);
+  ASSERT_MSG(DSPLLE, m_xregs[R8].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}", R8);
+  ASSERT_MSG(DSPLLE, m_xregs[R9].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}", R9);
 #else
-  ASSERT_MSG(DSPLLE, m_xregs[R8].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", R8);
-  ASSERT_MSG(DSPLLE, m_xregs[R9].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", R9);
+  ASSERT_MSG(DSPLLE, m_xregs[R8].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", R8);
+  ASSERT_MSG(DSPLLE, m_xregs[R9].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", R9);
 #endif
-  ASSERT_MSG(DSPLLE, m_xregs[R10].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", R10);
-  ASSERT_MSG(DSPLLE, m_xregs[R11].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", R11);
-  ASSERT_MSG(DSPLLE, m_xregs[R12].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", R12);
-  ASSERT_MSG(DSPLLE, m_xregs[R13].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", R13);
-  ASSERT_MSG(DSPLLE, m_xregs[R14].guest_reg == DSP_REG_NONE, "wrong xreg state for %d", R14);
-  ASSERT_MSG(DSPLLE, m_xregs[R15].guest_reg == DSP_REG_STATIC, "wrong xreg state for %d", R15);
+  ASSERT_MSG(DSPLLE, m_xregs[R10].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", R10);
+  ASSERT_MSG(DSPLLE, m_xregs[R11].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", R11);
+  ASSERT_MSG(DSPLLE, m_xregs[R12].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", R12);
+  ASSERT_MSG(DSPLLE, m_xregs[R13].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", R13);
+  ASSERT_MSG(DSPLLE, m_xregs[R14].guest_reg == DSP_REG_NONE, "wrong xreg state for {}", R14);
+  ASSERT_MSG(DSPLLE, m_xregs[R15].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}", R15);
 
   m_use_ctr = 0;
 }
@@ -403,7 +403,7 @@ void DSPJitRegCache::SaveRegs()
       MovToMemory(i);
     }
 
-    ASSERT_MSG(DSPLLE, !m_regs[i].loc.IsSimpleReg(), "register %zu is still a simple reg", i);
+    ASSERT_MSG(DSPLLE, !m_regs[i].loc.IsSimpleReg(), "register {} is still a simple reg", i);
   }
 }
 
@@ -418,7 +418,7 @@ void DSPJitRegCache::PushRegs()
       MovToMemory(i);
     }
 
-    ASSERT_MSG(DSPLLE, !m_regs[i].loc.IsSimpleReg(), "register %zu is still a simple reg", i);
+    ASSERT_MSG(DSPLLE, !m_regs[i].loc.IsSimpleReg(), "register {} is still a simple reg", i);
   }
 
   int push_count = 0;
@@ -445,7 +445,7 @@ void DSPJitRegCache::PushRegs()
 
     ASSERT_MSG(DSPLLE,
                m_xregs[i].guest_reg == DSP_REG_NONE || m_xregs[i].guest_reg == DSP_REG_STATIC,
-               "register %zu is still used", i);
+               "register {} is still used", i);
   }
 }
 
@@ -486,10 +486,10 @@ X64Reg DSPJitRegCache::MakeABICallSafe(X64Reg reg)
 
 void DSPJitRegCache::MovToHostReg(size_t reg, X64Reg host_reg, bool load)
 {
-  ASSERT_MSG(DSPLLE, reg < m_regs.size(), "bad register name %zu", reg);
-  ASSERT_MSG(DSPLLE, m_regs[reg].parentReg == DSP_REG_NONE, "register %zu is proxy for %d", reg,
+  ASSERT_MSG(DSPLLE, reg < m_regs.size(), "bad register name {}", reg);
+  ASSERT_MSG(DSPLLE, m_regs[reg].parentReg == DSP_REG_NONE, "register {} is proxy for {}", reg,
              m_regs[reg].parentReg);
-  ASSERT_MSG(DSPLLE, !m_regs[reg].used, "moving to host reg in use guest reg %zu", reg);
+  ASSERT_MSG(DSPLLE, !m_regs[reg].used, "moving to host reg in use guest reg {}", reg);
   X64Reg old_reg = m_regs[reg].loc.GetSimpleReg();
   if (old_reg == host_reg)
   {
@@ -529,10 +529,10 @@ void DSPJitRegCache::MovToHostReg(size_t reg, X64Reg host_reg, bool load)
 
 void DSPJitRegCache::MovToHostReg(size_t reg, bool load)
 {
-  ASSERT_MSG(DSPLLE, reg < m_regs.size(), "bad register name %zu", reg);
-  ASSERT_MSG(DSPLLE, m_regs[reg].parentReg == DSP_REG_NONE, "register %zu is proxy for %d", reg,
+  ASSERT_MSG(DSPLLE, reg < m_regs.size(), "bad register name {}", reg);
+  ASSERT_MSG(DSPLLE, m_regs[reg].parentReg == DSP_REG_NONE, "register {} is proxy for {}", reg,
              m_regs[reg].parentReg);
-  ASSERT_MSG(DSPLLE, !m_regs[reg].used, "moving to host reg in use guest reg %zu", reg);
+  ASSERT_MSG(DSPLLE, !m_regs[reg].used, "moving to host reg in use guest reg {}", reg);
 
   if (m_regs[reg].loc.IsSimpleReg())
   {
@@ -559,11 +559,11 @@ void DSPJitRegCache::MovToHostReg(size_t reg, bool load)
 
 void DSPJitRegCache::RotateHostReg(size_t reg, int shift, bool emit)
 {
-  ASSERT_MSG(DSPLLE, reg < m_regs.size(), "bad register name %zu", reg);
-  ASSERT_MSG(DSPLLE, m_regs[reg].parentReg == DSP_REG_NONE, "register %zu is proxy for %d", reg,
+  ASSERT_MSG(DSPLLE, reg < m_regs.size(), "bad register name {}", reg);
+  ASSERT_MSG(DSPLLE, m_regs[reg].parentReg == DSP_REG_NONE, "register {} is proxy for {}", reg,
              m_regs[reg].parentReg);
-  ASSERT_MSG(DSPLLE, m_regs[reg].loc.IsSimpleReg(), "register %zu is not a simple reg", reg);
-  ASSERT_MSG(DSPLLE, !m_regs[reg].used, "rotating in use guest reg %zu", reg);
+  ASSERT_MSG(DSPLLE, m_regs[reg].loc.IsSimpleReg(), "register {} is not a simple reg", reg);
+  ASSERT_MSG(DSPLLE, !m_regs[reg].used, "rotating in use guest reg {}", reg);
 
   if (shift > m_regs[reg].shift && emit)
   {
@@ -600,10 +600,10 @@ void DSPJitRegCache::RotateHostReg(size_t reg, int shift, bool emit)
 
 void DSPJitRegCache::MovToMemory(size_t reg)
 {
-  ASSERT_MSG(DSPLLE, reg < m_regs.size(), "bad register name %zu", reg);
-  ASSERT_MSG(DSPLLE, m_regs[reg].parentReg == DSP_REG_NONE, "register %zu is proxy for %d", reg,
+  ASSERT_MSG(DSPLLE, reg < m_regs.size(), "bad register name {}", reg);
+  ASSERT_MSG(DSPLLE, m_regs[reg].parentReg == DSP_REG_NONE, "register {} is proxy for {}", reg,
              m_regs[reg].parentReg);
-  ASSERT_MSG(DSPLLE, !m_regs[reg].used, "moving to memory in use guest reg %zu", reg);
+  ASSERT_MSG(DSPLLE, !m_regs[reg].used, "moving to memory in use guest reg {}", reg);
 
   if (m_regs[reg].used)
   {
@@ -683,7 +683,7 @@ OpArg DSPJitRegCache::GetReg(int reg, bool load)
     shift = 0;
   }
 
-  ASSERT_MSG(DSPLLE, !m_regs[real_reg].used, "register %d already in use", real_reg);
+  ASSERT_MSG(DSPLLE, !m_regs[real_reg].used, "register {} already in use", real_reg);
 
   if (m_regs[real_reg].used)
   {
@@ -694,7 +694,7 @@ OpArg DSPJitRegCache::GetReg(int reg, bool load)
   MovToHostReg(real_reg, load);
 
   // TODO: actually handle INVALID_REG
-  ASSERT_MSG(DSPLLE, m_regs[real_reg].loc.IsSimpleReg(), "did not get host reg for %d", reg);
+  ASSERT_MSG(DSPLLE, m_regs[real_reg].loc.IsSimpleReg(), "did not get host reg for {}", reg);
 
   RotateHostReg(real_reg, shift, load);
   const OpArg oparg = m_regs[real_reg].loc;
@@ -962,7 +962,7 @@ void DSPJitRegCache::SpillXReg(X64Reg reg)
   if (m_xregs[reg].guest_reg <= DSP_REG_MAX_MEM_BACKED)
   {
     ASSERT_MSG(DSPLLE, !m_regs[m_xregs[reg].guest_reg].used,
-               "to be spilled host reg %x(guest reg %zx) still in use!", reg,
+               "to be spilled host reg {:#x} (guest reg {:#x}) still in use!", reg,
                m_xregs[reg].guest_reg);
 
     MovToMemory(m_xregs[reg].guest_reg);
@@ -970,7 +970,7 @@ void DSPJitRegCache::SpillXReg(X64Reg reg)
   else
   {
     ASSERT_MSG(DSPLLE, m_xregs[reg].guest_reg == DSP_REG_NONE,
-               "to be spilled host reg %x still in use!", reg);
+               "to be spilled host reg {:#x} still in use!", reg);
   }
 }
 

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
@@ -3,7 +3,6 @@
 
 #include "Core/DSP/Jit/x64/DSPJitRegCache.h"
 
-#include <cinttypes>
 #include <cstddef>
 
 #include "Common/Assert.h"

--- a/Source/Core/Core/HW/DVD/DVDMath.cpp
+++ b/Source/Core/Core/HW/DVD/DVDMath.cpp
@@ -3,7 +3,6 @@
 
 #include "Core/HW/DVD/DVDMath.h"
 
-#include <cinttypes>
 #include <cmath>
 
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/HW/EXI/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.cpp
@@ -123,7 +123,7 @@ void CEXIChannel::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                          break;
                        default:
                          DEBUG_ASSERT_MSG(EXPANSIONINTERFACE, 0,
-                                          "EXI Imm: Unknown transfer type %i", m_control.RW);
+                                          "EXI Imm: Unknown transfer type {}", m_control.RW);
                        }
                      }
                      else
@@ -139,7 +139,7 @@ void CEXIChannel::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                          break;
                        default:
                          DEBUG_ASSERT_MSG(EXPANSIONINTERFACE, 0,
-                                          "EXI DMA: Unknown transfer type %i", m_control.RW);
+                                          "EXI DMA: Unknown transfer type {}", m_control.RW);
                        }
                      }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -110,7 +110,7 @@ CEXIMemoryCard::CEXIMemoryCard(const int index, bool gci_folder,
     : m_card_index(index)
 {
   ASSERT_MSG(EXPANSIONINTERFACE, static_cast<std::size_t>(index) < s_et_cmd_done.size(),
-             "Trying to create invalid memory card index %d.", index);
+             "Trying to create invalid memory card index {}.", index);
 
   // NOTE: When loading a save state, DMA completion callbacks (s_et_transfer_complete) and such
   //   may have been restored, we need to anticipate those arriving.

--- a/Source/Core/Core/HW/GCMemcard/GCIFile.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCIFile.cpp
@@ -3,8 +3,6 @@
 
 #include "Core/HW/GCMemcard/GCIFile.h"
 
-#include <cinttypes>
-
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -4,7 +4,6 @@
 #include "Core/HW/GCMemcard/GCMemcard.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <cstring>
 #include <utility>
 #include <vector>

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cinttypes>
 #include <cstring>
 #include <memory>
 #include <mutex>

--- a/Source/Core/Core/HW/SI/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI/SI_Device.cpp
@@ -195,7 +195,7 @@ std::unique_ptr<ISIDevice> SIDevice_Create(const SIDevices device, const int por
 #ifdef HAS_LIBMGBA
     return std::make_unique<CSIDevice_GBAEmu>(device, port_number);
 #else
-    PanicAlertT("Error: This build does not support emulated GBA controllers");
+    PanicAlertFmtT("Error: This build does not support emulated GBA controllers");
     return std::make_unique<CSIDevice_Null>(device, port_number);
 #endif
 

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -26,6 +26,7 @@
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/DynamicLibrary.h"
+#include "Common/HRWrap.h"
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
 #include "Common/Thread.h"
@@ -247,7 +248,7 @@ int IOWritePerSetOutputReport(HANDLE& dev_handle, const u8* buf, size_t len, DWO
       // Some third-party adapters (DolphinBar) use this
       // error code to signal the absence of a Wiimote
       // linked to the HID device.
-      WARN_LOG_FMT(WIIMOTE, "IOWrite[WWM_SET_OUTPUT_REPORT]: Error: {:08x}", err);
+      WARN_LOG_FMT(WIIMOTE, "IOWrite[WWM_SET_OUTPUT_REPORT]: Error: {}", Common::HRWrap(err));
     }
   }
 
@@ -297,7 +298,8 @@ int IOWritePerWriteFile(HANDLE& dev_handle, OVERLAPPED& hid_overlap_write,
       // Pending is no error!
       break;
     default:
-      WARN_LOG_FMT(WIIMOTE, "IOWrite[WWM_WRITE_FILE]: Error on WriteFile: {:08x}", error);
+      WARN_LOG_FMT(WIIMOTE, "IOWrite[WWM_WRITE_FILE]: Error on WriteFile: {}",
+                   Common::HRWrap(error));
       CancelIo(dev_handle);
       return 0;
     }
@@ -771,7 +773,7 @@ int IORead(HANDLE& dev_handle, OVERLAPPED& hid_overlap_read, u8* buf, int index)
     }
     else
     {
-      WARN_LOG_FMT(WIIMOTE, "ReadFile error {} on Wiimote {}.", read_err, index + 1);
+      WARN_LOG_FMT(WIIMOTE, "ReadFile on Wiimote {}: {}", index + 1, Common::HRWrap(read_err));
       return 0;
     }
   }
@@ -955,8 +957,8 @@ bool AttachWiimote(HANDLE hRadio, const BLUETOOTH_RADIO_INFO& radio_info,
 
     if (ERROR_SUCCESS != auth_result)
     {
-      ERROR_LOG_FMT(WIIMOTE, "AttachWiimote: BluetoothAuthenticateDeviceEx returned {:08x}",
-                    auth_result);
+      ERROR_LOG_FMT(WIIMOTE, "AttachWiimote: BluetoothAuthenticateDeviceEx failed: {}",
+                    Common::HRWrap(auth_result));
     }
 
     DWORD pcServices = 16;
@@ -967,8 +969,8 @@ bool AttachWiimote(HANDLE hRadio, const BLUETOOTH_RADIO_INFO& radio_info,
 
     if (ERROR_SUCCESS != srv_result)
     {
-      ERROR_LOG_FMT(WIIMOTE, "AttachWiimote: BluetoothEnumerateInstalledServices returned {:08x}",
-                    srv_result);
+      ERROR_LOG_FMT(WIIMOTE, "AttachWiimote: BluetoothEnumerateInstalledServices failed: {}",
+                    Common::HRWrap(auth_result));
     }
 #endif
     // Activate service
@@ -979,7 +981,8 @@ bool AttachWiimote(HANDLE hRadio, const BLUETOOTH_RADIO_INFO& radio_info,
 
     if (FAILED(hr))
     {
-      ERROR_LOG_FMT(WIIMOTE, "AttachWiimote: BluetoothSetServiceState returned {:08x}", hr);
+      ERROR_LOG_FMT(WIIMOTE, "AttachWiimote: BluetoothSetServiceState failed: {}",
+                    Common::HRWrap(hr));
     }
     else
     {

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -4,7 +4,6 @@
 #include "Core/IOS/ES/ES.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <cstddef>
 #include <utility>
 #include <vector>

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <deque>
 #include <map>
 #include <memory>

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -683,7 +683,7 @@ std::optional<IPCReply> Kernel::HandleIPCCommand(const Request& request)
     ret = device->IOCtlV(IOCtlVRequest{request.address});
     break;
   default:
-    ASSERT_MSG(IOS, false, "Unexpected command: %x", request.command);
+    ASSERT_MSG(IOS, false, "Unexpected command: {:#x}", request.command);
     ret = IPCReply{IPC_EINVAL, 978_tbticks};
     break;
   }

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <cstddef>
 #include <cstring>
 #include <map>

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -178,7 +178,7 @@ std::optional<IPCReply> BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
       break;
     }
     default:
-      DEBUG_ASSERT_MSG(IOS_WIIMOTE, 0, "Unknown USB::IOCTLV_USBV0_BLKMSG: %x", ctrl.endpoint);
+      DEBUG_ASSERT_MSG(IOS_WIIMOTE, 0, "Unknown USB::IOCTLV_USBV0_BLKMSG: {:#x}", ctrl.endpoint);
     }
     break;
   }
@@ -194,7 +194,7 @@ std::optional<IPCReply> BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
     }
     else
     {
-      DEBUG_ASSERT_MSG(IOS_WIIMOTE, 0, "Unknown USB::IOCTLV_USBV0_INTRMSG: %x", ctrl.endpoint);
+      DEBUG_ASSERT_MSG(IOS_WIIMOTE, 0, "Unknown USB::IOCTLV_USBV0_INTRMSG: {:#x}", ctrl.endpoint);
     }
     break;
   }
@@ -1085,8 +1085,9 @@ void BluetoothEmuDevice::ExecuteHCICommandMessage(const USB::V0CtrlMessage& ctrl
     }
     else
     {
-      DEBUG_ASSERT_MSG(IOS_WIIMOTE, 0, "Unknown USB_IOCTL_CTRLMSG: 0x%04X (ocf: 0x%x  ogf 0x%x)",
-                       msg.Opcode, ocf, ogf);
+      DEBUG_ASSERT_MSG(IOS_WIIMOTE, 0,
+                       "Unknown USB_IOCTL_CTRLMSG: {:#06x} (ocf: {:#04x} ogf {:#04x})", msg.Opcode,
+                       ocf, ogf);
     }
     break;
   }

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -610,7 +610,7 @@ void WiimoteDevice::ReceiveConfigurationReq(u8 ident, u8* data, u32 size)
     break;
 
     default:
-      DEBUG_ASSERT_MSG(IOS_WIIMOTE, 0, "Unknown Option: 0x%02x", options->type);
+      DEBUG_ASSERT_MSG(IOS_WIIMOTE, 0, "Unknown Option: {:#04x}", options->type);
       break;
     }
 

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -56,7 +56,7 @@ V5IsoMessage::V5IsoMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     total_packet_size += packet_size;
   }
   length = ioctlv.GetVector(2)->size;
-  ASSERT_MSG(IOS_USB, length == total_packet_size, "Wrong buffer size (0x%x != 0x%x)", length,
+  ASSERT_MSG(IOS_USB, length == total_packet_size, "Wrong buffer size ({:#x} != {:#x})", length,
              total_packet_size);
 }
 }  // namespace USB

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -4,7 +4,6 @@
 #include "Core/IOS/WFS/WFSSRV.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <string>
 #include <vector>
 

--- a/Source/Core/Core/LibusbUtils.cpp
+++ b/Source/Core/Core/LibusbUtils.cpp
@@ -23,7 +23,7 @@ public:
   Impl()
   {
     const int ret = libusb_init(&m_context);
-    ASSERT_MSG(IOS_USB, ret == LIBUSB_SUCCESS, "Failed to init libusb: %s", libusb_error_name(ret));
+    ASSERT_MSG(IOS_USB, ret == LIBUSB_SUCCESS, "Failed to init libusb: {}", libusb_error_name(ret));
     if (ret != LIBUSB_SUCCESS)
       return;
 

--- a/Source/Core/Core/MemTools.cpp
+++ b/Source/Core/Core/MemTools.cpp
@@ -328,7 +328,7 @@ void InstallExceptionHandler()
   signal_stack.ss_size = SIGSTKSZ;
   signal_stack.ss_flags = 0;
   if (sigaltstack(&signal_stack, nullptr))
-    PanicAlert("sigaltstack failed");
+    PanicAlertFmt("sigaltstack failed");
   struct sigaction sa;
   sa.sa_handler = nullptr;
   sa.sa_sigaction = &sigsegv_handler;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cinttypes>
 #include <cstddef>
 #include <cstdio>
 #include <memory>

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -340,7 +340,7 @@ void Interpreter::unknown_instruction(UGeckoInstruction inst)
                    i + 1, rGPR[i + 1], i + 2, rGPR[i + 2], i + 3, rGPR[i + 3]);
   }
   ASSERT_MSG(POWERPC, 0,
-             "\nIntCPU: Unknown instruction %08x at PC = %08x  last_PC = %08x  LR = %08x\n",
+             "\nIntCPU: Unknown instruction {:08x} at PC = {:08x}  last_PC = {:08x}  LR = {:08x}\n",
              inst.hex, PC, last_pc, LR);
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -4,7 +4,6 @@
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 
 #include <array>
-#include <cinttypes>
 #include <string>
 
 #include <fmt/format.h>

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -341,7 +341,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
     break;
 
   case SPR_WPAR:
-    ASSERT_MSG(POWERPC, rGPR[inst.RD] == 0x0C008000, "Gather pipe @ %08x", PC);
+    ASSERT_MSG(POWERPC, rGPR[inst.RD] == 0x0C008000, "Gather pipe @ {:08x}", PC);
     GPFifo::ResetGatherPipe();
     break;
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -1142,7 +1142,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
         // it.
         FixupBranch memException;
         ASSERT_MSG(DYNA_REC, !(js.fastmemLoadStore && js.fixupExceptionHandler),
-                   "Fastmem loadstores shouldn't have exception handler fixups (PC=%x)!",
+                   "Fastmem loadstores shouldn't have exception handler fixups (PC={:x})!",
                    op.address);
         if (!js.fastmemLoadStore && !js.fixupExceptionHandler)
         {

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/FPURegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/FPURegCache.cpp
@@ -15,13 +15,13 @@ FPURegCache::FPURegCache(Jit64& jit) : RegCache{jit}
 
 void FPURegCache::StoreRegister(preg_t preg, const OpArg& new_loc)
 {
-  ASSERT_MSG(DYNA_REC, m_regs[preg].IsBound(), "Unbound register - %zu", preg);
+  ASSERT_MSG(DYNA_REC, m_regs[preg].IsBound(), "Unbound register - {}", preg);
   m_emitter->MOVAPD(new_loc, m_regs[preg].Location()->GetSimpleReg());
 }
 
 void FPURegCache::LoadRegister(preg_t preg, X64Reg new_loc)
 {
-  ASSERT_MSG(DYNA_REC, !m_regs[preg].IsDiscarded(), "Discarded register - %zu", preg);
+  ASSERT_MSG(DYNA_REC, !m_regs[preg].IsDiscarded(), "Discarded register - {}", preg);
   m_emitter->MOVAPD(new_loc, m_regs[preg].Location().value());
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/GPRRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/GPRRegCache.cpp
@@ -15,13 +15,13 @@ GPRRegCache::GPRRegCache(Jit64& jit) : RegCache{jit}
 
 void GPRRegCache::StoreRegister(preg_t preg, const OpArg& new_loc)
 {
-  ASSERT_MSG(DYNA_REC, !m_regs[preg].IsDiscarded(), "Discarded register - %zu", preg);
+  ASSERT_MSG(DYNA_REC, !m_regs[preg].IsDiscarded(), "Discarded register - {}", preg);
   m_emitter->MOV(32, new_loc, m_regs[preg].Location().value());
 }
 
 void GPRRegCache::LoadRegister(preg_t preg, X64Reg new_loc)
 {
-  ASSERT_MSG(DYNA_REC, !m_regs[preg].IsDiscarded(), "Discarded register - %zu", preg);
+  ASSERT_MSG(DYNA_REC, !m_regs[preg].IsDiscarded(), "Discarded register - {}", preg);
   m_emitter->MOV(32, ::Gen::R(new_loc), m_regs[preg].Location().value());
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -440,7 +440,7 @@ void RegCache::Reset(BitSet32 pregs)
 {
   for (preg_t i : pregs)
   {
-    ASSERT_MSG(DYNAREC, !m_regs[i].IsAway(),
+    ASSERT_MSG(DYNA_REC, !m_regs[i].IsAway(),
                "Attempted to reset a loaded register (did you mean to flush it?)");
     m_regs[i].SetFlushed();
   }

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -389,9 +389,10 @@ void RegCache::Discard(BitSet32 pregs)
 
   for (preg_t i : pregs)
   {
-    ASSERT_MSG(DYNA_REC, !m_regs[i].IsLocked(),
-               "Someone forgot to unlock PPC reg %zu (X64 reg %i).", i, RX(i));
-    ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction is in progress!");
+    ASSERT_MSG(DYNA_REC, !m_regs[i].IsLocked(), "Someone forgot to unlock PPC reg {} (X64 reg {}).",
+               i, RX(i));
+    ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction is in progress for {}!",
+               i);
 
     if (m_regs[i].IsBound())
     {
@@ -412,9 +413,10 @@ void RegCache::Flush(BitSet32 pregs)
 
   for (preg_t i : pregs)
   {
-    ASSERT_MSG(DYNA_REC, !m_regs[i].IsLocked(),
-               "Someone forgot to unlock PPC reg %zu (X64 reg %i).", i, RX(i));
-    ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction is in progress!");
+    ASSERT_MSG(DYNA_REC, !m_regs[i].IsLocked(), "Someone forgot to unlock PPC reg {} (X64 reg {}).",
+               i, RX(i));
+    ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction is in progress for {}!",
+               i);
 
     switch (m_regs[i].GetLocationType())
     {
@@ -496,7 +498,7 @@ BitSet32 RegCache::RegistersInUse() const
 
 void RegCache::FlushX(X64Reg reg)
 {
-  ASSERT_MSG(DYNA_REC, reg < m_xregs.size(), "Flushing non-existent reg %i", reg);
+  ASSERT_MSG(DYNA_REC, reg < m_xregs.size(), "Flushing non-existent reg {}", reg);
   ASSERT(!m_xregs[reg].IsLocked());
   if (!m_xregs[reg].IsFree())
   {
@@ -520,7 +522,7 @@ void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
   {
     X64Reg xr = GetFreeXReg();
 
-    ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsDirty(), "Xreg %i already dirty", xr);
+    ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsDirty(), "Xreg {} already dirty", xr);
     ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsLocked(), "GetFreeXReg returned locked register");
     ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Invalid transaction state");
 
@@ -537,7 +539,7 @@ void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
                             [xr](const auto& r) {
                               return r.Location().has_value() && r.Location()->IsSimpleReg(xr);
                             }),
-               "Xreg %i already bound", xr);
+               "Xreg {} already bound", xr);
 
     m_regs[i].SetBoundTo(xr);
   }
@@ -549,13 +551,14 @@ void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
       m_xregs[RX(i)].MakeDirty();
   }
 
-  ASSERT_MSG(DYNA_REC, !m_xregs[RX(i)].IsLocked(), "WTF, this reg should have been flushed");
+  ASSERT_MSG(DYNA_REC, !m_xregs[RX(i)].IsLocked(),
+             "WTF, this reg ({} -> {}) should have been flushed", i, RX(i));
 }
 
 void RegCache::StoreFromRegister(preg_t i, FlushMode mode)
 {
   // When a transaction is in progress, allowing the store would overwrite the old value.
-  ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction is in progress!");
+  ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction on {} is in progress!", i);
 
   bool doStore = false;
 
@@ -673,13 +676,13 @@ float RegCache::ScoreRegister(X64Reg xreg) const
 
 const OpArg& RegCache::R(preg_t preg) const
 {
-  ASSERT_MSG(DYNA_REC, !m_regs[preg].IsDiscarded(), "Discarded register - %zu", preg);
+  ASSERT_MSG(DYNA_REC, !m_regs[preg].IsDiscarded(), "Discarded register - {}", preg);
   return m_regs[preg].Location().value();
 }
 
 X64Reg RegCache::RX(preg_t preg) const
 {
-  ASSERT_MSG(DYNA_REC, m_regs[preg].IsBound(), "Unbound register - %zu", preg);
+  ASSERT_MSG(DYNA_REC, m_regs[preg].IsBound(), "Unbound register - {}", preg);
   return m_regs[preg].Location()->GetSimpleReg();
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -4,7 +4,6 @@
 #include "Core/PowerPC/Jit64/RegCache/JitRegCache.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <cmath>
 #include <limits>
 #include <utility>

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <array>
-#include <cinttypes>
 #include <cstddef>
 #include <type_traits>
 #include <variant>

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -3,7 +3,6 @@
 
 #include "Core/PowerPC/Jit64Common/TrampolineCache.h"
 
-#include <cinttypes>
 #include <string>
 
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -715,8 +715,9 @@ void JitArm64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
     return;
   }
 
-  PanicAlertT("JIT failed to find code space after a cache clear. This should never happen. Please "
-              "report this incident on the bug tracker. Dolphin will now exit.");
+  PanicAlertFmtT(
+      "JIT failed to find code space after a cache clear. This should never happen. Please "
+      "report this incident on the bug tracker. Dolphin will now exit.");
   exit(-1);
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -3,7 +3,6 @@
 
 #include "Core/PowerPC/JitArm64/Jit.h"
 
-#include <cinttypes>
 #include <cstddef>
 #include <optional>
 #include <string>

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -36,7 +36,7 @@ void Arm64RegCache::ResetRegisters(BitSet32 regs)
     OpArg& reg = m_guest_registers[i];
     ARM64Reg host_reg = reg.GetReg();
 
-    ASSERT_MSG(DYNAREC, host_reg == ARM64Reg::INVALID_REG,
+    ASSERT_MSG(DYNA_REC, host_reg == ARM64Reg::INVALID_REG,
                "Attempted to reset a loaded register (did you mean to flush it?)");
     reg.Flush();
   }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -90,8 +90,7 @@ void Arm64RegCache::LockRegister(ARM64Reg host_reg)
 {
   auto reg = std::find(m_host_registers.begin(), m_host_registers.end(), host_reg);
   ASSERT_MSG(DYNA_REC, reg != m_host_registers.end(),
-             "Don't try locking a register that isn't in the cache. Reg %d",
-             static_cast<int>(host_reg));
+             "Don't try locking a register that isn't in the cache. Reg {}", host_reg);
   reg->Lock();
 }
 
@@ -99,8 +98,7 @@ void Arm64RegCache::UnlockRegister(ARM64Reg host_reg)
 {
   auto reg = std::find(m_host_registers.begin(), m_host_registers.end(), host_reg);
   ASSERT_MSG(DYNA_REC, reg != m_host_registers.end(),
-             "Don't try unlocking a register that isn't in the cache. Reg %d",
-             static_cast<int>(host_reg));
+             "Don't try unlocking a register that isn't in the cache. Reg {}", host_reg);
   reg->Unlock();
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
@@ -48,7 +48,7 @@ private:
       m_emit->STR(IndexType::Unsigned, reg, ARM64Reg::X0, 0);
       break;
     default:
-      ASSERT_MSG(DYNA_REC, false, "Unknown size %d passed to MMIOWriteCodeGenerator!", sbits);
+      ASSERT_MSG(DYNA_REC, false, "Unknown size {} passed to MMIOWriteCodeGenerator!", sbits);
       break;
     }
   }
@@ -141,7 +141,7 @@ private:
       m_emit->LDR(IndexType::Unsigned, m_dst_reg, ARM64Reg::X0, 0);
       break;
     default:
-      ASSERT_MSG(DYNA_REC, false, "Unknown size %d passed to MMIOReadCodeGenerator!", sbits);
+      ASSERT_MSG(DYNA_REC, false, "Unknown size {} passed to MMIOReadCodeGenerator!", sbits);
       break;
     }
   }

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -4,7 +4,6 @@
 #include "Core/PowerPC/JitInterface.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <cstdio>
 #include <string>
 #include <unordered_set>

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -52,7 +52,7 @@ GekkoOPInfo* GetOpInfo(UGeckoInstruction inst)
     case 63:
       return m_infoTable63[inst.SUBOP10];
     default:
-      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid subtable op %08x @ %08x", inst.hex, PC);
+      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid subtable op {:08x} @ {:08x}", inst.hex, PC);
       return nullptr;
     }
   }
@@ -60,7 +60,7 @@ GekkoOPInfo* GetOpInfo(UGeckoInstruction inst)
   {
     if (info->type == OpType::Invalid)
     {
-      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid op %08x @ %08x", inst.hex, PC);
+      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid op {:08x} @ {:08x}", inst.hex, PC);
       return nullptr;
     }
     return m_infoTable[inst.OPCD];
@@ -85,7 +85,8 @@ Interpreter::Instruction GetInterpreterOp(UGeckoInstruction inst)
     case 63:
       return Interpreter::m_op_table63[inst.SUBOP10];
     default:
-      ASSERT_MSG(POWERPC, 0, "GetInterpreterOp - invalid subtable op %08x @ %08x", inst.hex, PC);
+      ASSERT_MSG(POWERPC, 0, "GetInterpreterOp - invalid subtable op {:08x} @ {:08x}", inst.hex,
+                 PC);
       return nullptr;
     }
   }
@@ -93,7 +94,7 @@ Interpreter::Instruction GetInterpreterOp(UGeckoInstruction inst)
   {
     if (info->type == OpType::Invalid)
     {
-      ASSERT_MSG(POWERPC, 0, "GetInterpreterOp - invalid op %08x @ %08x", inst.hex, PC);
+      ASSERT_MSG(POWERPC, 0, "GetInterpreterOp - invalid op {:08x} @ {:08x}", inst.hex, PC);
       return nullptr;
     }
     return Interpreter::m_op_table[inst.OPCD];

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <cstddef>
 #include <cstdio>
 #include <vector>

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -600,7 +600,7 @@ void CheckExternalExceptions()
     }
     else
     {
-      DEBUG_ASSERT_MSG(POWERPC, 0, "Unknown EXT interrupt: Exceptions == %08x", exceptions);
+      DEBUG_ASSERT_MSG(POWERPC, 0, "Unknown EXT interrupt: Exceptions == {:08x}", exceptions);
       ERROR_LOG_FMT(POWERPC, "Unknown EXTERNAL INTERRUPT exception: Exceptions == {:08x}",
                     exceptions);
     }

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -3,7 +3,6 @@
 
 #include "Core/WiiRoot.h"
 
-#include <cinttypes>
 #include <optional>
 #include <string>
 #include <vector>

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -107,6 +107,7 @@
     <ClInclude Include="Common\GL\GLUtil.h" />
     <ClInclude Include="Common\GL\GLX11Window.h" />
     <ClInclude Include="Common\Hash.h" />
+    <ClInclude Include="Common\HRWrap.h" />
     <ClInclude Include="Common\HttpRequest.h" />
     <ClInclude Include="Common\Image.h" />
     <ClInclude Include="Common\ImageC.h" />
@@ -707,6 +708,7 @@
     <ClCompile Include="Common\GL\GLInterface\WGL.cpp" />
     <ClCompile Include="Common\GL\GLUtil.cpp" />
     <ClCompile Include="Common\Hash.cpp" />
+    <ClCompile Include="Common\HRWrap.cpp" />
     <ClCompile Include="Common\HttpRequest.cpp" />
     <ClCompile Include="Common\Image.cpp" />
     <ClCompile Include="Common\ImageC.c">

--- a/Source/Core/DolphinNoGUI/PlatformX11.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformX11.cpp
@@ -82,7 +82,7 @@ bool PlatformX11::Init()
   m_display = XOpenDisplay(nullptr);
   if (!m_display)
   {
-    PanicAlert("No X11 display found");
+    PanicAlertFmt("No X11 display found");
     return false;
   }
 

--- a/Source/Core/DolphinQt/WiiUpdate.cpp
+++ b/Source/Core/DolphinQt/WiiUpdate.cpp
@@ -3,7 +3,6 @@
 
 #include "DolphinQt/WiiUpdate.h"
 
-#include <cinttypes>
 #include <future>
 
 #include <QCloseEvent>

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <type_traits>
 
+#include "Common/HRWrap.h"
 #include "Common/Logging/Log.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/DInput/DInput.h"
@@ -62,12 +63,14 @@ void InitJoystick(IDirectInput8* const idi8, HWND hwnd)
     {
       if (SUCCEEDED(js_device->SetDataFormat(&c_dfDIJoystick)))
       {
-        if (FAILED(js_device->SetCooperativeLevel(GetAncestor(hwnd, GA_ROOT),
-                                                  DISCL_BACKGROUND | DISCL_EXCLUSIVE)))
+        HRESULT hr = js_device->SetCooperativeLevel(GetAncestor(hwnd, GA_ROOT),
+                                                    DISCL_BACKGROUND | DISCL_EXCLUSIVE);
+        if (FAILED(hr))
         {
-          WARN_LOG_FMT(
-              CONTROLLERINTERFACE,
-              "DInput: Failed to acquire device exclusively. Force feedback will be unavailable.");
+          WARN_LOG_FMT(CONTROLLERINTERFACE,
+                       "DInput: Failed to acquire device exclusively. Force feedback will be "
+                       "unavailable.  {}",
+                       Common::HRWrap(hr));
           // Fall back to non-exclusive mode, with no rumble
           if (FAILED(
                   js_device->SetCooperativeLevel(nullptr, DISCL_BACKGROUND | DISCL_NONEXCLUSIVE)))

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -296,7 +296,7 @@ static void HotplugThreadFunc()
   udev* const udev = udev_new();
   Common::ScopeGuard udev_guard([udev] { udev_unref(udev); });
 
-  ASSERT_MSG(PAD, udev != nullptr, "Couldn't initialize libudev.");
+  ASSERT_MSG(CONTROLLERINTERFACE, udev != nullptr, "Couldn't initialize libudev.");
 
   // Set up monitoring
   udev_monitor* const monitor = udev_monitor_new_from_netlink(udev, "udev");
@@ -366,7 +366,7 @@ static void StartHotplugThread()
   }
 
   s_wakeup_eventfd = eventfd(0, 0);
-  ASSERT_MSG(PAD, s_wakeup_eventfd != -1, "Couldn't create eventfd.");
+  ASSERT_MSG(CONTROLLERINTERFACE, s_wakeup_eventfd != -1, "Couldn't create eventfd.");
   s_hotplug_thread = std::thread(HotplugThreadFunc);
 }
 
@@ -406,7 +406,7 @@ void PopulateDevices()
   // this ever changes, hopefully udev will take care of this.
 
   udev* const udev = udev_new();
-  ASSERT_MSG(PAD, udev != nullptr, "Couldn't initialize libudev.");
+  ASSERT_MSG(CONTROLLERINTERFACE, udev != nullptr, "Couldn't initialize libudev.");
 
   // List all input devices
   udev_enumerate* const enumerate = udev_enumerate_new(udev);

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <iterator>

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -66,7 +66,7 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   HRESULT hr = dxgi_factory->EnumAdapters(adapter_index, adapter.GetAddressOf());
   if (FAILED(hr))
   {
-    WARN_LOG_FMT(VIDEO, "Adapter {} not found, using default", adapter_index);
+    WARN_LOG_FMT(VIDEO, "Adapter {} not found, using default: {}", adapter_index, DX11HRWrap(hr));
     adapter = nullptr;
   }
 
@@ -80,7 +80,7 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
         D3D11_SDK_VERSION, device.GetAddressOf(), &feature_level, context.GetAddressOf());
 
     // Debugbreak on D3D error
-    if (SUCCEEDED(hr) && SUCCEEDED(device.As(&s_debug)))
+    if (SUCCEEDED(hr) && SUCCEEDED(hr = device.As(&s_debug)))
     {
       ComPtr<ID3D11InfoQueue> info_queue;
       if (SUCCEEDED(s_debug.As(&info_queue)))
@@ -98,7 +98,7 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
     }
     else
     {
-      WARN_LOG_FMT(VIDEO, "Debug layer requested but not available.");
+      WARN_LOG_FMT(VIDEO, "Debug layer requested but not available: {}", DX11HRWrap(hr));
     }
   }
 
@@ -113,7 +113,8 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   if (FAILED(hr))
   {
     PanicAlertFmtT(
-        "Failed to initialize Direct3D.\nMake sure your video card supports at least D3D 10.0");
+        "Failed to initialize Direct3D.\nMake sure your video card supports at least D3D 10.0\n{0}",
+        DX11HRWrap(hr));
     dxgi_factory.Reset();
     D3DCommon::UnloadLibraries();
     s_d3d11_library.Close();
@@ -123,7 +124,9 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   hr = device.As(&device1);
   if (FAILED(hr))
   {
-    WARN_LOG_FMT(VIDEO, "Missing Direct3D 11.1 support. Logical operations will not be supported.");
+    WARN_LOG_FMT(VIDEO,
+                 "Missing Direct3D 11.1 support. Logical operations will not be supported.\n{}",
+                 DX11HRWrap(hr));
   }
 
   stateman = std::make_unique<StateManager>();

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -7,12 +7,12 @@
 #include <d3d11_1.h>
 #include <d3dcompiler.h>
 #include <dxgi1_5.h>
+#include <fmt/format.h>
 #include <vector>
 #include <wrl/client.h>
 
-#include "Common/Common.h"
 #include "Common/CommonTypes.h"
-#include "Common/MsgHandler.h"
+#include "Common/HRWrap.h"
 
 namespace DX11
 {
@@ -41,4 +41,32 @@ bool SupportsLogicOp(u32 adapter_index);
 
 }  // namespace D3D
 
+// Wrapper for HRESULT to be used with fmt.  Note that we can't create a fmt::formatter directly
+// for HRESULT as HRESULT is simply a typedef on long and not a distinct type.
+// Unlike the version in Common, this variant also knows to call GetDeviceRemovedReason if needed.
+struct DX11HRWrap
+{
+  constexpr explicit DX11HRWrap(HRESULT hr) : m_hr(hr) {}
+  const HRESULT m_hr;
+};
+
 }  // namespace DX11
+
+template <>
+struct fmt::formatter<DX11::DX11HRWrap>
+{
+  constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const DX11::DX11HRWrap& hr, FormatContext& ctx)
+  {
+    if (hr.m_hr == DXGI_ERROR_DEVICE_REMOVED && DX11::D3D::device != nullptr)
+    {
+      return fmt::format_to(ctx.out(), "{}\nDevice removal reason: {}", Common::HRWrap(hr.m_hr),
+                            Common::HRWrap(DX11::D3D::device->GetDeviceRemovedReason()));
+    }
+    else
+    {
+      return fmt::format_to(ctx.out(), "{}", Common::HRWrap(hr.m_hr));
+    }
+  }
+};

--- a/Source/Core/VideoBackends/D3D/D3DBoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBoundingBox.cpp
@@ -35,7 +35,7 @@ bool D3DBoundingBox::Initialize()
   data.SysMemSlicePitch = 0;
   HRESULT hr;
   hr = D3D::device->CreateBuffer(&desc, &data, &m_buffer);
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create BoundingBox Buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create BoundingBox Buffer: {}", DX11HRWrap(hr));
   if (FAILED(hr))
     return false;
   D3DCommon::SetDebugObjectName(m_buffer.Get(), "BoundingBox Buffer");
@@ -45,7 +45,8 @@ bool D3DBoundingBox::Initialize()
   desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
   desc.BindFlags = 0;
   hr = D3D::device->CreateBuffer(&desc, nullptr, &m_staging_buffer);
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create BoundingBox Staging Buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create BoundingBox Staging Buffer: {}",
+             DX11HRWrap(hr));
   if (FAILED(hr))
     return false;
   D3DCommon::SetDebugObjectName(m_staging_buffer.Get(), "BoundingBox Staging Buffer");
@@ -58,7 +59,7 @@ bool D3DBoundingBox::Initialize()
   UAVdesc.Buffer.Flags = 0;
   UAVdesc.Buffer.NumElements = NUM_BBOX_VALUES;
   hr = D3D::device->CreateUnorderedAccessView(m_buffer.Get(), &UAVdesc, &m_uav);
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create BoundingBox UAV");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create BoundingBox UAV: {}", DX11HRWrap(hr));
   if (FAILED(hr))
     return false;
   D3DCommon::SetDebugObjectName(m_uav.Get(), "BoundingBox UAV");

--- a/Source/Core/VideoBackends/D3D/D3DBoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBoundingBox.cpp
@@ -6,8 +6,10 @@
 #include <algorithm>
 #include <array>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
+
 #include "VideoBackends/D3D/D3DState.h"
 #include "VideoBackends/D3DCommon/D3DCommon.h"
 
@@ -33,7 +35,7 @@ bool D3DBoundingBox::Initialize()
   data.SysMemSlicePitch = 0;
   HRESULT hr;
   hr = D3D::device->CreateBuffer(&desc, &data, &m_buffer);
-  CHECK(SUCCEEDED(hr), "Create BoundingBox Buffer.");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create BoundingBox Buffer");
   if (FAILED(hr))
     return false;
   D3DCommon::SetDebugObjectName(m_buffer.Get(), "BoundingBox Buffer");
@@ -43,7 +45,7 @@ bool D3DBoundingBox::Initialize()
   desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
   desc.BindFlags = 0;
   hr = D3D::device->CreateBuffer(&desc, nullptr, &m_staging_buffer);
-  CHECK(SUCCEEDED(hr), "Create BoundingBox Staging Buffer.");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create BoundingBox Staging Buffer");
   if (FAILED(hr))
     return false;
   D3DCommon::SetDebugObjectName(m_staging_buffer.Get(), "BoundingBox Staging Buffer");
@@ -56,7 +58,7 @@ bool D3DBoundingBox::Initialize()
   UAVdesc.Buffer.Flags = 0;
   UAVdesc.Buffer.NumElements = NUM_BBOX_VALUES;
   hr = D3D::device->CreateUnorderedAccessView(m_buffer.Get(), &UAVdesc, &m_uav);
-  CHECK(SUCCEEDED(hr), "Create BoundingBox UAV.");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create BoundingBox UAV");
   if (FAILED(hr))
     return false;
   D3DCommon::SetDebugObjectName(m_uav.Get(), "BoundingBox UAV");

--- a/Source/Core/VideoBackends/D3D/D3DNativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DNativeVertexFormat.cpp
@@ -183,7 +183,7 @@ ID3D11InputLayout* D3DVertexFormat::GetInputLayout(const void* vs_bytecode, size
 
   HRESULT hr = D3D::device->CreateInputLayout(m_elems.data(), m_num_elems, vs_bytecode,
                                               vs_bytecode_size, &layout);
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create input layout");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create input layout: {}", DX11HRWrap(hr));
 
   // This method can be called from multiple threads, so ensure that only one thread sets the
   // cached input layout pointer. If another thread beats this thread, use the existing layout.

--- a/Source/Core/VideoBackends/D3D/D3DNativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DNativeVertexFormat.cpp
@@ -3,6 +3,7 @@
 
 #include <array>
 
+#include "Common/Assert.h"
 #include "Common/EnumMap.h"
 
 #include "VideoBackends/D3D/D3DBase.h"
@@ -182,7 +183,7 @@ ID3D11InputLayout* D3DVertexFormat::GetInputLayout(const void* vs_bytecode, size
 
   HRESULT hr = D3D::device->CreateInputLayout(m_elems.data(), m_num_elems, vs_bytecode,
                                               vs_bytecode_size, &layout);
-  CHECK(SUCCEEDED(hr), "Failed to create input layout");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create input layout");
 
   // This method can be called from multiple threads, so ensure that only one thread sets the
   // cached input layout pointer. If another thread beats this thread, use the existing layout.

--- a/Source/Core/VideoBackends/D3D/D3DRender.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DRender.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <cmath>
 #include <cstring>
 #include <memory>

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 
+#include "Common/Assert.h"
 #include "Common/BitSet.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -348,7 +349,7 @@ ID3D11SamplerState* StateCache::Get(SamplerState state)
 
   ComPtr<ID3D11SamplerState> res;
   HRESULT hr = D3D::device->CreateSamplerState(&sampdc, res.GetAddressOf());
-  CHECK(SUCCEEDED(hr), "Creating D3D sampler state failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D sampler state failed");
   return m_sampler.emplace(state, std::move(res)).first->second.Get();
 }
 
@@ -425,7 +426,7 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
 
   ComPtr<ID3D11BlendState> res;
   HRESULT hr = D3D::device->CreateBlendState(&desc, res.GetAddressOf());
-  CHECK(SUCCEEDED(hr), "Creating D3D blend state failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D blend state failed");
   return m_blend.emplace(state.hex, std::move(res)).first->second.Get();
 }
 
@@ -446,7 +447,7 @@ ID3D11RasterizerState* StateCache::Get(RasterizationState state)
 
   ComPtr<ID3D11RasterizerState> res;
   HRESULT hr = D3D::device->CreateRasterizerState(&desc, res.GetAddressOf());
-  CHECK(SUCCEEDED(hr), "Creating D3D rasterizer state failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D rasterizer state failed");
   return m_raster.emplace(state.hex, std::move(res)).first->second.Get();
 }
 
@@ -488,7 +489,7 @@ ID3D11DepthStencilState* StateCache::Get(DepthState state)
 
   ComPtr<ID3D11DepthStencilState> res;
   HRESULT hr = D3D::device->CreateDepthStencilState(&depthdc, res.GetAddressOf());
-  CHECK(SUCCEEDED(hr), "Creating D3D depth stencil state failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D depth stencil state failed");
   return m_depth.emplace(state.hex, std::move(res)).first->second.Get();
 }
 

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -349,7 +349,7 @@ ID3D11SamplerState* StateCache::Get(SamplerState state)
 
   ComPtr<ID3D11SamplerState> res;
   HRESULT hr = D3D::device->CreateSamplerState(&sampdc, res.GetAddressOf());
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D sampler state failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D sampler state failed: {}", DX11HRWrap(hr));
   return m_sampler.emplace(state, std::move(res)).first->second.Get();
 }
 
@@ -387,7 +387,7 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
     {
       return m_blend.emplace(state.hex, std::move(res)).first->second.Get();
     }
-    WARN_LOG_FMT(VIDEO, "Creating D3D blend state failed with an error: {:08X}", hr);
+    WARN_LOG_FMT(VIDEO, "Creating D3D blend state failed with an error: {}", DX11HRWrap(hr));
   }
 
   D3D11_BLEND_DESC desc = {};
@@ -426,7 +426,7 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
 
   ComPtr<ID3D11BlendState> res;
   HRESULT hr = D3D::device->CreateBlendState(&desc, res.GetAddressOf());
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D blend state failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D blend state failed: {}", DX11HRWrap(hr));
   return m_blend.emplace(state.hex, std::move(res)).first->second.Get();
 }
 
@@ -447,7 +447,7 @@ ID3D11RasterizerState* StateCache::Get(RasterizationState state)
 
   ComPtr<ID3D11RasterizerState> res;
   HRESULT hr = D3D::device->CreateRasterizerState(&desc, res.GetAddressOf());
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D rasterizer state failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D rasterizer state failed: {}", DX11HRWrap(hr));
   return m_raster.emplace(state.hex, std::move(res)).first->second.Get();
 }
 
@@ -489,7 +489,7 @@ ID3D11DepthStencilState* StateCache::Get(DepthState state)
 
   ComPtr<ID3D11DepthStencilState> res;
   HRESULT hr = D3D::device->CreateDepthStencilState(&depthdc, res.GetAddressOf());
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D depth stencil state failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating D3D depth stencil state failed: {}", DX11HRWrap(hr));
   return m_depth.emplace(state.hex, std::move(res)).first->second.Get();
 }
 

--- a/Source/Core/VideoBackends/D3D/D3DSwapChain.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DSwapChain.cpp
@@ -31,7 +31,7 @@ bool SwapChain::CreateSwapChainBuffers()
 {
   ComPtr<ID3D11Texture2D> texture;
   HRESULT hr = m_swap_chain->GetBuffer(0, IID_PPV_ARGS(&texture));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to get swap chain buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to get swap chain buffer: {}", DX11HRWrap(hr));
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3D/D3DSwapChain.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DSwapChain.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoBackends/D3D/D3DSwapChain.h"
 
+#include "Common/Assert.h"
+
 #include "VideoBackends/D3D/DXTexture.h"
 
 namespace DX11
@@ -29,7 +31,7 @@ bool SwapChain::CreateSwapChainBuffers()
 {
   ComPtr<ID3D11Texture2D> texture;
   HRESULT hr = m_swap_chain->GetBuffer(0, IID_PPV_ARGS(&texture));
-  CHECK(SUCCEEDED(hr), "Get swap chain buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to get swap chain buffer");
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3D/D3DVertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DVertexManager.cpp
@@ -34,7 +34,8 @@ static ComPtr<ID3D11Buffer> AllocateConstantBuffer(u32 size)
                                   D3D11_CPU_ACCESS_WRITE);
   ComPtr<ID3D11Buffer> cbuf;
   const HRESULT hr = D3D::device->CreateBuffer(&cbdesc, nullptr, &cbuf);
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create shader constant buffer (size={})", cbsize);
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create shader constant buffer (size={}): {}", cbsize,
+             DX11HRWrap(hr));
   if (FAILED(hr))
     return nullptr;
 
@@ -60,7 +61,7 @@ CreateTexelBufferView(ID3D11Buffer* buffer, TexelBufferFormat format, DXGI_FORMA
                                             VertexManager::TEXEL_STREAM_BUFFER_SIZE /
                                                 VertexManager::GetTexelBufferElementSize(format));
   HRESULT hr = D3D::device->CreateShaderResourceView(buffer, &srv_desc, &srv);
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create SRV for texel buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create SRV for texel buffer: {}", DX11HRWrap(hr));
   return srv;
 }
 
@@ -80,7 +81,7 @@ bool VertexManager::Initialize()
   for (int i = 0; i < BUFFER_COUNT; i++)
   {
     HRESULT hr = D3D::device->CreateBuffer(&bufdesc, nullptr, &m_buffers[i]);
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create buffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create buffer: {}", DX11HRWrap(hr));
     if (m_buffers[i])
       D3DCommon::SetDebugObjectName(m_buffers[i].Get(), "Buffer of VertexManager");
   }
@@ -94,7 +95,7 @@ bool VertexManager::Initialize()
   CD3D11_BUFFER_DESC texel_buf_desc(TEXEL_STREAM_BUFFER_SIZE, D3D11_BIND_SHADER_RESOURCE,
                                     D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
   HRESULT hr = D3D::device->CreateBuffer(&texel_buf_desc, nullptr, &m_texel_buffer);
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating texel buffer failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating texel buffer failed: {}", DX11HRWrap(hr));
   if (!m_texel_buffer)
     return false;
 
@@ -132,7 +133,7 @@ bool VertexManager::MapTexelBuffer(u32 required_size, D3D11_MAPPED_SUBRESOURCE& 
   {
     // Restart buffer.
     HRESULT hr = D3D::context->Map(m_texel_buffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &sr);
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map texel buffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map texel buffer: {}", DX11HRWrap(hr));
     if (FAILED(hr))
       return false;
 
@@ -142,7 +143,7 @@ bool VertexManager::MapTexelBuffer(u32 required_size, D3D11_MAPPED_SUBRESOURCE& 
   {
     // Don't overwrite the earlier-used space.
     HRESULT hr = D3D::context->Map(m_texel_buffer.Get(), 0, D3D11_MAP_WRITE_NO_OVERWRITE, 0, &sr);
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map texel buffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map texel buffer: {}", DX11HRWrap(hr));
     if (FAILED(hr))
       return false;
   }

--- a/Source/Core/VideoBackends/D3D/D3DVertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DVertexManager.cpp
@@ -34,7 +34,7 @@ static ComPtr<ID3D11Buffer> AllocateConstantBuffer(u32 size)
                                   D3D11_CPU_ACCESS_WRITE);
   ComPtr<ID3D11Buffer> cbuf;
   const HRESULT hr = D3D::device->CreateBuffer(&cbdesc, nullptr, &cbuf);
-  CHECK(SUCCEEDED(hr), "shader constant buffer (size=%u)", cbsize);
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create shader constant buffer (size={})", cbsize);
   if (FAILED(hr))
     return nullptr;
 
@@ -59,8 +59,8 @@ CreateTexelBufferView(ID3D11Buffer* buffer, TexelBufferFormat format, DXGI_FORMA
   CD3D11_SHADER_RESOURCE_VIEW_DESC srv_desc(buffer, srv_format, 0,
                                             VertexManager::TEXEL_STREAM_BUFFER_SIZE /
                                                 VertexManager::GetTexelBufferElementSize(format));
-  CHECK(SUCCEEDED(D3D::device->CreateShaderResourceView(buffer, &srv_desc, &srv)),
-        "Create SRV for texel buffer");
+  HRESULT hr = D3D::device->CreateShaderResourceView(buffer, &srv_desc, &srv);
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create SRV for texel buffer");
   return srv;
 }
 
@@ -79,8 +79,8 @@ bool VertexManager::Initialize()
 
   for (int i = 0; i < BUFFER_COUNT; i++)
   {
-    CHECK(SUCCEEDED(D3D::device->CreateBuffer(&bufdesc, nullptr, &m_buffers[i])),
-          "Failed to create buffer.");
+    HRESULT hr = D3D::device->CreateBuffer(&bufdesc, nullptr, &m_buffers[i]);
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create buffer");
     if (m_buffers[i])
       D3DCommon::SetDebugObjectName(m_buffers[i].Get(), "Buffer of VertexManager");
   }
@@ -93,8 +93,8 @@ bool VertexManager::Initialize()
 
   CD3D11_BUFFER_DESC texel_buf_desc(TEXEL_STREAM_BUFFER_SIZE, D3D11_BIND_SHADER_RESOURCE,
                                     D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
-  CHECK(SUCCEEDED(D3D::device->CreateBuffer(&texel_buf_desc, nullptr, &m_texel_buffer)),
-        "Creating texel buffer failed");
+  HRESULT hr = D3D::device->CreateBuffer(&texel_buf_desc, nullptr, &m_texel_buffer);
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating texel buffer failed");
   if (!m_texel_buffer)
     return false;
 
@@ -132,7 +132,7 @@ bool VertexManager::MapTexelBuffer(u32 required_size, D3D11_MAPPED_SUBRESOURCE& 
   {
     // Restart buffer.
     HRESULT hr = D3D::context->Map(m_texel_buffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &sr);
-    CHECK(SUCCEEDED(hr), "Map texel buffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map texel buffer");
     if (FAILED(hr))
       return false;
 
@@ -142,7 +142,7 @@ bool VertexManager::MapTexelBuffer(u32 required_size, D3D11_MAPPED_SUBRESOURCE& 
   {
     // Don't overwrite the earlier-used space.
     HRESULT hr = D3D::context->Map(m_texel_buffer.Get(), 0, D3D11_MAP_WRITE_NO_OVERWRITE, 0, &sr);
-    CHECK(SUCCEEDED(hr), "Map texel buffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map texel buffer");
     if (FAILED(hr))
       return false;
   }

--- a/Source/Core/VideoBackends/D3D/DXShader.cpp
+++ b/Source/Core/VideoBackends/D3D/DXShader.cpp
@@ -55,7 +55,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
   {
     ComPtr<ID3D11VertexShader> vs;
     HRESULT hr = D3D::device->CreateVertexShader(bytecode.data(), bytecode.size(), nullptr, &vs);
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create vertex shader");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create vertex shader: {}", DX11HRWrap(hr));
     if (FAILED(hr))
       return nullptr;
 
@@ -66,7 +66,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
   {
     ComPtr<ID3D11GeometryShader> gs;
     HRESULT hr = D3D::device->CreateGeometryShader(bytecode.data(), bytecode.size(), nullptr, &gs);
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create geometry shader");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create geometry shader: {}", DX11HRWrap(hr));
     if (FAILED(hr))
       return nullptr;
 
@@ -78,7 +78,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
   {
     ComPtr<ID3D11PixelShader> ps;
     HRESULT hr = D3D::device->CreatePixelShader(bytecode.data(), bytecode.size(), nullptr, &ps);
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create pixel shader");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create pixel shader: {}", DX11HRWrap(hr));
     if (FAILED(hr))
       return nullptr;
 
@@ -90,7 +90,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
   {
     ComPtr<ID3D11ComputeShader> cs;
     HRESULT hr = D3D::device->CreateComputeShader(bytecode.data(), bytecode.size(), nullptr, &cs);
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create compute shader");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create compute shader: {}", DX11HRWrap(hr));
     if (FAILED(hr))
       return nullptr;
 

--- a/Source/Core/VideoBackends/D3D/DXShader.cpp
+++ b/Source/Core/VideoBackends/D3D/DXShader.cpp
@@ -55,7 +55,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
   {
     ComPtr<ID3D11VertexShader> vs;
     HRESULT hr = D3D::device->CreateVertexShader(bytecode.data(), bytecode.size(), nullptr, &vs);
-    CHECK(SUCCEEDED(hr), "Create vertex shader");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create vertex shader");
     if (FAILED(hr))
       return nullptr;
 
@@ -66,7 +66,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
   {
     ComPtr<ID3D11GeometryShader> gs;
     HRESULT hr = D3D::device->CreateGeometryShader(bytecode.data(), bytecode.size(), nullptr, &gs);
-    CHECK(SUCCEEDED(hr), "Create geometry shader");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create geometry shader");
     if (FAILED(hr))
       return nullptr;
 
@@ -78,7 +78,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
   {
     ComPtr<ID3D11PixelShader> ps;
     HRESULT hr = D3D::device->CreatePixelShader(bytecode.data(), bytecode.size(), nullptr, &ps);
-    CHECK(SUCCEEDED(hr), "Create pixel shader");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create pixel shader");
     if (FAILED(hr))
       return nullptr;
 
@@ -90,7 +90,7 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
   {
     ComPtr<ID3D11ComputeShader> cs;
     HRESULT hr = D3D::device->CreateComputeShader(bytecode.data(), bytecode.size(), nullptr, &cs);
-    CHECK(SUCCEEDED(hr), "Create compute shader");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create compute shader");
     if (FAILED(hr))
       return nullptr;
 

--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -207,7 +207,7 @@ std::unique_ptr<DXStagingTexture> DXStagingTexture::Create(StagingTextureType ty
 
   ComPtr<ID3D11Texture2D> texture;
   HRESULT hr = D3D::device->CreateTexture2D(&desc, nullptr, texture.GetAddressOf());
-  CHECK(SUCCEEDED(hr), "Create staging texture");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create staging texture");
   if (FAILED(hr))
     return nullptr;
 
@@ -298,7 +298,7 @@ bool DXStagingTexture::Map()
 
   D3D11_MAPPED_SUBRESOURCE sr;
   HRESULT hr = D3D::context->Map(m_tex.Get(), 0, map_type, 0, &sr);
-  CHECK(SUCCEEDED(hr), "Map readback texture");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map readback texture");
   if (FAILED(hr))
     return false;
 
@@ -363,7 +363,7 @@ std::unique_ptr<DXFramebuffer> DXFramebuffer::Create(DXTexture* color_attachment
         color_attachment->GetLayers());
     HRESULT hr = D3D::device->CreateRenderTargetView(color_attachment->GetD3DTexture(), &desc,
                                                      rtv.GetAddressOf());
-    CHECK(SUCCEEDED(hr), "Create render target view for framebuffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create render target view for framebuffer");
     if (FAILED(hr))
       return nullptr;
 
@@ -375,7 +375,8 @@ std::unique_ptr<DXFramebuffer> DXFramebuffer::Create(DXTexture* color_attachment
       desc.Format = integer_format;
       hr = D3D::device->CreateRenderTargetView(color_attachment->GetD3DTexture(), &desc,
                                                integer_rtv.GetAddressOf());
-      CHECK(SUCCEEDED(hr), "Create integer render target view for framebuffer");
+      ASSERT_MSG(VIDEO, SUCCEEDED(hr),
+                 "Failed to create integer render target view for framebuffer");
     }
   }
 
@@ -389,7 +390,7 @@ std::unique_ptr<DXFramebuffer> DXFramebuffer::Create(DXTexture* color_attachment
         depth_attachment->GetLayers(), 0);
     HRESULT hr = D3D::device->CreateDepthStencilView(depth_attachment->GetD3DTexture(), &desc,
                                                      dsv.GetAddressOf());
-    CHECK(SUCCEEDED(hr), "Create depth stencil view for framebuffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create depth stencil view for framebuffer");
     if (FAILED(hr))
       return nullptr;
   }

--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -51,8 +51,8 @@ std::unique_ptr<DXTexture> DXTexture::Create(const TextureConfig& config, std::s
   HRESULT hr = D3D::device->CreateTexture2D(&desc, nullptr, d3d_texture.GetAddressOf());
   if (FAILED(hr))
   {
-    PanicAlertFmt("Failed to create {}x{}x{} D3D backing texture", config.width, config.height,
-                  config.layers);
+    PanicAlertFmt("Failed to create {}x{}x{} D3D backing texture: {}", config.width, config.height,
+                  config.layers, DX11HRWrap(hr));
     return nullptr;
   }
 
@@ -98,8 +98,8 @@ bool DXTexture::CreateSRV()
   HRESULT hr = D3D::device->CreateShaderResourceView(m_texture.Get(), &desc, m_srv.GetAddressOf());
   if (FAILED(hr))
   {
-    PanicAlertFmt("Failed to create {}x{}x{} D3D SRV", m_config.width, m_config.height,
-                  m_config.layers);
+    PanicAlertFmt("Failed to create {}x{}x{} D3D SRV: {}", m_config.width, m_config.height,
+                  m_config.layers, DX11HRWrap(hr));
     return false;
   }
 
@@ -115,8 +115,8 @@ bool DXTexture::CreateUAV()
   HRESULT hr = D3D::device->CreateUnorderedAccessView(m_texture.Get(), &desc, m_uav.GetAddressOf());
   if (FAILED(hr))
   {
-    PanicAlertFmt("Failed to create {}x{}x{} D3D UAV", m_config.width, m_config.height,
-                  m_config.layers);
+    PanicAlertFmt("Failed to create {}x{}x{} D3D UAV: {}", m_config.width, m_config.height,
+                  m_config.layers, DX11HRWrap(hr));
     return false;
   }
 
@@ -207,7 +207,7 @@ std::unique_ptr<DXStagingTexture> DXStagingTexture::Create(StagingTextureType ty
 
   ComPtr<ID3D11Texture2D> texture;
   HRESULT hr = D3D::device->CreateTexture2D(&desc, nullptr, texture.GetAddressOf());
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create staging texture");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create staging texture: {}", DX11HRWrap(hr));
   if (FAILED(hr))
     return nullptr;
 
@@ -298,7 +298,7 @@ bool DXStagingTexture::Map()
 
   D3D11_MAPPED_SUBRESOURCE sr;
   HRESULT hr = D3D::context->Map(m_tex.Get(), 0, map_type, 0, &sr);
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map readback texture");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map readback texture: {}", DX11HRWrap(hr));
   if (FAILED(hr))
     return false;
 
@@ -363,7 +363,8 @@ std::unique_ptr<DXFramebuffer> DXFramebuffer::Create(DXTexture* color_attachment
         color_attachment->GetLayers());
     HRESULT hr = D3D::device->CreateRenderTargetView(color_attachment->GetD3DTexture(), &desc,
                                                      rtv.GetAddressOf());
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create render target view for framebuffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create render target view for framebuffer: {}",
+               DX11HRWrap(hr));
     if (FAILED(hr))
       return nullptr;
 
@@ -376,7 +377,7 @@ std::unique_ptr<DXFramebuffer> DXFramebuffer::Create(DXTexture* color_attachment
       hr = D3D::device->CreateRenderTargetView(color_attachment->GetD3DTexture(), &desc,
                                                integer_rtv.GetAddressOf());
       ASSERT_MSG(VIDEO, SUCCEEDED(hr),
-                 "Failed to create integer render target view for framebuffer");
+                 "Failed to create integer render target view for framebuffer: {}", DX11HRWrap(hr));
     }
   }
 
@@ -390,7 +391,8 @@ std::unique_ptr<DXFramebuffer> DXFramebuffer::Create(DXTexture* color_attachment
         depth_attachment->GetLayers(), 0);
     HRESULT hr = D3D::device->CreateDepthStencilView(depth_attachment->GetD3DTexture(), &desc,
                                                      dsv.GetAddressOf());
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create depth stencil view for framebuffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create depth stencil view for framebuffer: {}",
+               DX11HRWrap(hr));
     if (FAILED(hr))
       return nullptr;
   }

--- a/Source/Core/VideoBackends/D3D12/D3D12BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12BoundingBox.cpp
@@ -42,7 +42,7 @@ std::vector<BBoxType> D3D12BoundingBox::Read(u32 index, u32 length)
   static constexpr D3D12_RANGE read_range = {0, BUFFER_SIZE};
   void* mapped_pointer;
   HRESULT hr = m_readback_buffer->Map(0, &read_range, &mapped_pointer);
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Map bounding box CPU buffer failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Map bounding box CPU buffer failed: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return values;
 
@@ -103,7 +103,7 @@ bool D3D12BoundingBox::CreateBuffers()
   HRESULT hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &gpu_heap_properties, D3D12_HEAP_FLAG_NONE, &buffer_desc,
       D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr, IID_PPV_ARGS(&m_gpu_buffer));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating bounding box GPU buffer failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating bounding box GPU buffer failed: {}", DX12HRWrap(hr));
   if (FAILED(hr) || !g_dx_context->GetDescriptorHeapManager().Allocate(&m_gpu_descriptor))
     return false;
 
@@ -116,7 +116,7 @@ bool D3D12BoundingBox::CreateBuffers()
   hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &cpu_heap_properties, D3D12_HEAP_FLAG_NONE, &buffer_desc, D3D12_RESOURCE_STATE_COPY_DEST,
       nullptr, IID_PPV_ARGS(&m_readback_buffer));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating bounding box CPU buffer failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating bounding box CPU buffer failed: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3D12/D3D12BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12BoundingBox.cpp
@@ -3,6 +3,7 @@
 
 #include "VideoBackends/D3D12/D3D12BoundingBox.h"
 
+#include "Common/Assert.h"
 #include "Common/Logging/Log.h"
 
 #include "VideoBackends/D3D12/D3D12Renderer.h"
@@ -41,7 +42,7 @@ std::vector<BBoxType> D3D12BoundingBox::Read(u32 index, u32 length)
   static constexpr D3D12_RANGE read_range = {0, BUFFER_SIZE};
   void* mapped_pointer;
   HRESULT hr = m_readback_buffer->Map(0, &read_range, &mapped_pointer);
-  CHECK(SUCCEEDED(hr), "Map bounding box CPU buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Map bounding box CPU buffer failed");
   if (FAILED(hr))
     return values;
 
@@ -102,7 +103,7 @@ bool D3D12BoundingBox::CreateBuffers()
   HRESULT hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &gpu_heap_properties, D3D12_HEAP_FLAG_NONE, &buffer_desc,
       D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr, IID_PPV_ARGS(&m_gpu_buffer));
-  CHECK(SUCCEEDED(hr), "Creating bounding box GPU buffer failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating bounding box GPU buffer failed");
   if (FAILED(hr) || !g_dx_context->GetDescriptorHeapManager().Allocate(&m_gpu_descriptor))
     return false;
 
@@ -115,7 +116,7 @@ bool D3D12BoundingBox::CreateBuffers()
   hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &cpu_heap_properties, D3D12_HEAP_FLAG_NONE, &buffer_desc, D3D12_RESOURCE_STATE_COPY_DEST,
       nullptr, IID_PPV_ARGS(&m_readback_buffer));
-  CHECK(SUCCEEDED(hr), "Creating bounding box CPU buffer failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating bounding box CPU buffer failed");
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.cpp
@@ -23,7 +23,7 @@ bool PerfQuery::Initialize()
 {
   constexpr D3D12_QUERY_HEAP_DESC desc = {D3D12_QUERY_HEAP_TYPE_OCCLUSION, PERF_QUERY_BUFFER_SIZE};
   HRESULT hr = g_dx_context->GetDevice()->CreateQueryHeap(&desc, IID_PPV_ARGS(&m_query_heap));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create query heap");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create query heap: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return false;
 
@@ -41,7 +41,7 @@ bool PerfQuery::Initialize()
   hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST,
       nullptr, IID_PPV_ARGS(&m_query_readback_buffer));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create query buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create query buffer: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return false;
 
@@ -221,7 +221,7 @@ void PerfQuery::AccumulateQueriesFromBuffer(u32 query_count)
                                   (m_query_readback_pos + query_count) * sizeof(PerfQueryDataType)};
   u8* mapped_ptr;
   HRESULT hr = m_query_readback_buffer->Map(0, &read_range, reinterpret_cast<void**>(&mapped_ptr));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map query readback buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map query readback buffer: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return;
 

--- a/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
+
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3D12/D3D12Renderer.h"
 #include "VideoBackends/D3D12/DX12Context.h"
@@ -22,7 +23,7 @@ bool PerfQuery::Initialize()
 {
   constexpr D3D12_QUERY_HEAP_DESC desc = {D3D12_QUERY_HEAP_TYPE_OCCLUSION, PERF_QUERY_BUFFER_SIZE};
   HRESULT hr = g_dx_context->GetDevice()->CreateQueryHeap(&desc, IID_PPV_ARGS(&m_query_heap));
-  CHECK(SUCCEEDED(hr), "Failed to create query heap");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create query heap");
   if (FAILED(hr))
     return false;
 
@@ -40,7 +41,7 @@ bool PerfQuery::Initialize()
   hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_COPY_DEST,
       nullptr, IID_PPV_ARGS(&m_query_readback_buffer));
-  CHECK(SUCCEEDED(hr), "Failed to create query buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create query buffer");
   if (FAILED(hr))
     return false;
 
@@ -220,7 +221,7 @@ void PerfQuery::AccumulateQueriesFromBuffer(u32 query_count)
                                   (m_query_readback_pos + query_count) * sizeof(PerfQueryDataType)};
   u8* mapped_ptr;
   HRESULT hr = m_query_readback_buffer->Map(0, &read_range, reinterpret_cast<void**>(&mapped_ptr));
-  CHECK(SUCCEEDED(hr), "Failed to map query readback buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map query readback buffer");
   if (FAILED(hr))
     return;
 

--- a/Source/Core/VideoBackends/D3D12/D3D12StreamBuffer.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12StreamBuffer.cpp
@@ -46,13 +46,13 @@ bool StreamBuffer::AllocateBuffer(u32 size)
   HRESULT hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ,
       nullptr, IID_PPV_ARGS(&m_buffer));
-  CHECK(SUCCEEDED(hr), "Allocate buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to allocate buffer of size {}", size);
   if (FAILED(hr))
     return false;
 
   static const D3D12_RANGE read_range = {};
   hr = m_buffer->Map(0, &read_range, reinterpret_cast<void**>(&m_host_pointer));
-  CHECK(SUCCEEDED(hr), "Map buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map buffer of size {}", size);
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3D12/D3D12StreamBuffer.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12StreamBuffer.cpp
@@ -46,13 +46,14 @@ bool StreamBuffer::AllocateBuffer(u32 size)
   HRESULT hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc, D3D12_RESOURCE_STATE_GENERIC_READ,
       nullptr, IID_PPV_ARGS(&m_buffer));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to allocate buffer of size {}", size);
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to allocate buffer of size {}: {}", size,
+             DX12HRWrap(hr));
   if (FAILED(hr))
     return false;
 
   static const D3D12_RANGE read_range = {};
   hr = m_buffer->Map(0, &read_range, reinterpret_cast<void**>(&m_host_pointer));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map buffer of size {}", size);
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to map buffer of size {}: {}", size, DX12HRWrap(hr));
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3D12/D3D12SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12SwapChain.cpp
@@ -34,7 +34,7 @@ bool SwapChain::CreateSwapChainBuffers()
   {
     ComPtr<ID3D12Resource> resource;
     HRESULT hr = m_swap_chain->GetBuffer(i, IID_PPV_ARGS(&resource));
-    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to get swap chain buffer {}", i);
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to get swap chain buffer {}: {}", i, DX12HRWrap(hr));
 
     BufferResources buffer;
     buffer.texture = DXTexture::CreateAdopted(resource.Get());

--- a/Source/Core/VideoBackends/D3D12/D3D12SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12SwapChain.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoBackends/D3D12/D3D12SwapChain.h"
 
+#include "Common/Assert.h"
+
 #include "VideoBackends/D3D12/DX12Context.h"
 #include "VideoBackends/D3D12/DX12Texture.h"
 
@@ -32,16 +34,17 @@ bool SwapChain::CreateSwapChainBuffers()
   {
     ComPtr<ID3D12Resource> resource;
     HRESULT hr = m_swap_chain->GetBuffer(i, IID_PPV_ARGS(&resource));
-    CHECK(SUCCEEDED(hr), "Get swap chain buffer");
+    ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to get swap chain buffer {}", i);
 
     BufferResources buffer;
     buffer.texture = DXTexture::CreateAdopted(resource.Get());
-    CHECK(buffer.texture, "Create swap chain buffer texture");
+    ASSERT_MSG(VIDEO, buffer.texture != nullptr, "Failed to create swap chain buffer texture");
     if (!buffer.texture)
       return false;
 
     buffer.framebuffer = DXFramebuffer::Create(buffer.texture.get(), nullptr);
-    CHECK(buffer.texture, "Create swap chain buffer framebuffer");
+    ASSERT_MSG(VIDEO, buffer.framebuffer != nullptr,
+               "Failed to create swap chain buffer framebuffer");
     if (!buffer.framebuffer)
       return false;
 

--- a/Source/Core/VideoBackends/D3D12/DX12Context.h
+++ b/Source/Core/VideoBackends/D3D12/DX12Context.h
@@ -7,6 +7,8 @@
 #include <memory>
 
 #include "Common/CommonTypes.h"
+#include "Common/HRWrap.h"
+
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3D12/D3D12StreamBuffer.h"
 #include "VideoBackends/D3D12/DescriptorAllocator.h"
@@ -187,4 +189,34 @@ private:
 
 extern std::unique_ptr<DXContext> g_dx_context;
 
+// Wrapper for HRESULT to be used with fmt.  Note that we can't create a fmt::formatter directly
+// for HRESULT as HRESULT is simply a typedef on long and not a distinct type.
+// Unlike the version in Common, this variant also knows to call GetDeviceRemovedReason if needed.
+struct DX12HRWrap
+{
+  constexpr explicit DX12HRWrap(HRESULT hr) : m_hr(hr) {}
+  const HRESULT m_hr;
+};
+
 }  // namespace DX12
+
+template <>
+struct fmt::formatter<DX12::DX12HRWrap>
+{
+  constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const DX12::DX12HRWrap& hr, FormatContext& ctx)
+  {
+    if (hr.m_hr == DXGI_ERROR_DEVICE_REMOVED && DX12::g_dx_context != nullptr &&
+        DX12::g_dx_context->GetDevice() != nullptr)
+    {
+      return fmt::format_to(
+          ctx.out(), "{}\nDevice removal reason: {}", Common::HRWrap(hr.m_hr),
+          Common::HRWrap(DX12::g_dx_context->GetDevice()->GetDeviceRemovedReason()));
+    }
+    else
+    {
+      return fmt::format_to(ctx.out(), "{}", Common::HRWrap(hr.m_hr));
+    }
+  }
+};

--- a/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
@@ -210,8 +210,8 @@ std::unique_ptr<DXPipeline> DXPipeline::Create(const AbstractPipelineConfig& con
   HRESULT hr = g_dx_context->GetDevice()->CreateGraphicsPipelineState(&desc, IID_PPV_ARGS(&pso));
   if (FAILED(hr))
   {
-    WARN_LOG_FMT(VIDEO, "CreateGraphicsPipelineState() {}failed with HRESULT {:08X}",
-                 cache_data ? "with cache data " : "", hr);
+    WARN_LOG_FMT(VIDEO, "CreateGraphicsPipelineState() {}failed: {}",
+                 cache_data ? "with cache data " : "", DX12HRWrap(hr));
     return nullptr;
   }
 
@@ -227,7 +227,7 @@ AbstractPipeline::CacheData DXPipeline::GetCacheData() const
   HRESULT hr = m_pipeline->GetCachedBlob(&blob);
   if (FAILED(hr))
   {
-    WARN_LOG_FMT(VIDEO, "ID3D12Pipeline::GetCachedBlob() failed with HRESULT {:08X}", hr);
+    WARN_LOG_FMT(VIDEO, "ID3D12Pipeline::GetCachedBlob() failed: {}", DX12HRWrap(hr));
     return {};
   }
 

--- a/Source/Core/VideoBackends/D3D12/DX12Shader.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Shader.cpp
@@ -52,7 +52,7 @@ bool DXShader::CreateComputePipeline()
 
   HRESULT hr = g_dx_context->GetDevice()->CreateComputePipelineState(
       &desc, IID_PPV_ARGS(&m_compute_pipeline));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating compute pipeline failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating compute pipeline failed: {}", DX12HRWrap(hr));
 
   if (m_compute_pipeline && !m_name.empty())
     m_compute_pipeline->SetName(m_name.c_str());

--- a/Source/Core/VideoBackends/D3D12/DX12Shader.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Shader.cpp
@@ -3,6 +3,7 @@
 
 #include "VideoBackends/D3D12/DX12Shader.h"
 
+#include "Common/Assert.h"
 #include "Common/StringUtil.h"
 
 #include "VideoBackends/D3D12/Common.h"
@@ -51,7 +52,7 @@ bool DXShader::CreateComputePipeline()
 
   HRESULT hr = g_dx_context->GetDevice()->CreateComputePipelineState(
       &desc, IID_PPV_ARGS(&m_compute_pipeline));
-  CHECK(SUCCEEDED(hr), "Creating compute pipeline failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating compute pipeline failed");
 
   if (m_compute_pipeline && !m_name.empty())
     m_compute_pipeline->SetName(m_name.c_str());

--- a/Source/Core/VideoBackends/D3D12/DX12Texture.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Texture.cpp
@@ -39,7 +39,7 @@ static ComPtr<ID3D12Resource> CreateTextureUploadBuffer(u32 buffer_size)
   HRESULT hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &heap_properties, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
       IID_PPV_ARGS(&resource));
-  CHECK(SUCCEEDED(hr), "Create texture upload buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create texture upload buffer");
   return resource;
 }
 
@@ -116,7 +116,7 @@ std::unique_ptr<DXTexture> DXTexture::Create(const TextureConfig& config, std::s
   HRESULT hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc, resource_state,
       config.IsRenderTarget() ? &optimized_clear_value : nullptr, IID_PPV_ARGS(&resource));
-  CHECK(SUCCEEDED(hr), "Create D3D12 texture resource");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create D3D12 texture resource");
   if (FAILED(hr))
     return nullptr;
 
@@ -598,7 +598,7 @@ bool DXStagingTexture::Map()
 
   const D3D12_RANGE read_range = {0u, m_type == StagingTextureType::Upload ? 0u : m_buffer_size};
   HRESULT hr = m_resource->Map(0, &read_range, reinterpret_cast<void**>(&m_map_pointer));
-  CHECK(SUCCEEDED(hr), "Map resource failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Map resource failed");
   if (FAILED(hr))
     return false;
 
@@ -663,7 +663,7 @@ std::unique_ptr<DXStagingTexture> DXStagingTexture::Create(StagingTextureType ty
       &heap_properties, D3D12_HEAP_FLAG_NONE, &desc,
       is_upload ? D3D12_RESOURCE_STATE_GENERIC_READ : D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
       IID_PPV_ARGS(&resource));
-  CHECK(SUCCEEDED(hr), "Create staging texture resource");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create staging texture resource");
   if (FAILED(hr))
     return nullptr;
 

--- a/Source/Core/VideoBackends/D3D12/DX12Texture.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Texture.cpp
@@ -39,7 +39,7 @@ static ComPtr<ID3D12Resource> CreateTextureUploadBuffer(u32 buffer_size)
   HRESULT hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &heap_properties, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
       IID_PPV_ARGS(&resource));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create texture upload buffer");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create texture upload buffer: {}", DX12HRWrap(hr));
   return resource;
 }
 
@@ -116,7 +116,7 @@ std::unique_ptr<DXTexture> DXTexture::Create(const TextureConfig& config, std::s
   HRESULT hr = g_dx_context->GetDevice()->CreateCommittedResource(
       &heap_properties, D3D12_HEAP_FLAG_NONE, &resource_desc, resource_state,
       config.IsRenderTarget() ? &optimized_clear_value : nullptr, IID_PPV_ARGS(&resource));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create D3D12 texture resource");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create D3D12 texture resource: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return nullptr;
 
@@ -230,9 +230,15 @@ void DXTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
   {
     const D3D12_RANGE read_range = {0, 0};
     staging_buffer = CreateTextureUploadBuffer(upload_size);
-    if (!staging_buffer || FAILED(staging_buffer->Map(0, &read_range, &upload_buffer_ptr)))
+    if (!staging_buffer)
     {
-      PanicAlertFmt("Failed to allocate/map temporary texture upload buffer");
+      PanicAlertFmt("Failed to allocate temporary texture upload buffer");
+      return;
+    }
+    HRESULT hr = staging_buffer->Map(0, &read_range, &upload_buffer_ptr);
+    if (FAILED(hr))
+    {
+      PanicAlertFmt("Failed to map temporary texture upload buffer: {}", DX12HRWrap(hr));
       return;
     }
 
@@ -598,7 +604,7 @@ bool DXStagingTexture::Map()
 
   const D3D12_RANGE read_range = {0u, m_type == StagingTextureType::Upload ? 0u : m_buffer_size};
   HRESULT hr = m_resource->Map(0, &read_range, reinterpret_cast<void**>(&m_map_pointer));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Map resource failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Map resource failed: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return false;
 
@@ -663,7 +669,7 @@ std::unique_ptr<DXStagingTexture> DXStagingTexture::Create(StagingTextureType ty
       &heap_properties, D3D12_HEAP_FLAG_NONE, &desc,
       is_upload ? D3D12_RESOURCE_STATE_GENERIC_READ : D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
       IID_PPV_ARGS(&resource));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create staging texture resource");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create staging texture resource: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return nullptr;
 

--- a/Source/Core/VideoBackends/D3D12/DescriptorAllocator.cpp
+++ b/Source/Core/VideoBackends/D3D12/DescriptorAllocator.cpp
@@ -18,7 +18,8 @@ bool DescriptorAllocator::Create(ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_TYP
   const D3D12_DESCRIPTOR_HEAP_DESC desc = {type, static_cast<UINT>(num_descriptors),
                                            D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE};
   HRESULT hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&m_descriptor_heap));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating descriptor heap for linear allocator failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating descriptor heap for linear allocator failed: {}",
+             DX12HRWrap(hr));
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3D12/DescriptorAllocator.cpp
+++ b/Source/Core/VideoBackends/D3D12/DescriptorAllocator.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoBackends/D3D12/DescriptorAllocator.h"
 
+#include "Common/Assert.h"
+
 #include "VideoBackends/D3D12/DX12Context.h"
 
 namespace DX12
@@ -16,7 +18,7 @@ bool DescriptorAllocator::Create(ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_TYP
   const D3D12_DESCRIPTOR_HEAP_DESC desc = {type, static_cast<UINT>(num_descriptors),
                                            D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE};
   HRESULT hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&m_descriptor_heap));
-  CHECK(SUCCEEDED(hr), "Creating descriptor heap for linear allocator failed");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Creating descriptor heap for linear allocator failed");
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.cpp
@@ -20,7 +20,7 @@ bool DescriptorHeapManager::Create(ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_T
                                      D3D12_DESCRIPTOR_HEAP_FLAG_NONE};
 
   HRESULT hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&m_descriptor_heap));
-  CHECK(SUCCEEDED(hr), "Create descriptor heap");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create descriptor heap");
   if (FAILED(hr))
     return false;
 
@@ -176,7 +176,7 @@ bool SamplerHeapManager::Create(ID3D12Device* device, u32 num_descriptors)
 {
   const D3D12_DESCRIPTOR_HEAP_DESC desc = {D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, num_descriptors};
   HRESULT hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&m_descriptor_heap));
-  CHECK(SUCCEEDED(hr), "Failed to create sampler descriptor heap");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create sampler descriptor heap");
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.cpp
@@ -20,7 +20,7 @@ bool DescriptorHeapManager::Create(ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_T
                                      D3D12_DESCRIPTOR_HEAP_FLAG_NONE};
 
   HRESULT hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&m_descriptor_heap));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create descriptor heap");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create descriptor heap: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return false;
 
@@ -176,7 +176,7 @@ bool SamplerHeapManager::Create(ID3D12Device* device, u32 num_descriptors)
 {
   const D3D12_DESCRIPTOR_HEAP_DESC desc = {D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, num_descriptors};
   HRESULT hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&m_descriptor_heap));
-  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create sampler descriptor heap");
+  ASSERT_MSG(VIDEO, SUCCEEDED(hr), "Failed to create sampler descriptor heap: {}", DX12HRWrap(hr));
   if (FAILED(hr))
     return false;
 

--- a/Source/Core/VideoBackends/D3DCommon/D3DCommon.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/D3DCommon.cpp
@@ -10,6 +10,7 @@
 
 #include "Common/Assert.h"
 #include "Common/DynamicLibrary.h"
+#include "Common/HRWrap.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
@@ -89,7 +90,7 @@ Microsoft::WRL::ComPtr<IDXGIFactory> CreateDXGIFactory(bool debug_device)
   HRESULT hr = create_dxgi_factory(IID_PPV_ARGS(factory.ReleaseAndGetAddressOf()));
   if (FAILED(hr))
   {
-    PanicAlertFmt("CreateDXGIFactory() failed with HRESULT {:08X}", hr);
+    PanicAlertFmt("CreateDXGIFactory() failed: {}", Common::HRWrap(hr));
     return nullptr;
   }
 

--- a/Source/Core/VideoBackends/D3DCommon/D3DCommon.h
+++ b/Source/Core/VideoBackends/D3DCommon/D3DCommon.h
@@ -11,13 +11,6 @@
 
 #include "Common/CommonTypes.h"
 
-#define CHECK(cond, Message, ...)                                                                  \
-  if (!(cond))                                                                                     \
-  {                                                                                                \
-    PanicAlert("%s failed in %s at line %d: " Message, __func__, __FILE__, __LINE__,               \
-               ##__VA_ARGS__);                                                                     \
-  }
-
 struct IDXGIFactory;
 
 enum class AbstractTextureFormat : u32;

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -8,6 +8,7 @@
 
 #include "Common/Assert.h"
 #include "Common/FileUtil.h"
+#include "Common/HRWrap.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
@@ -118,8 +119,8 @@ std::optional<Shader::BinaryData> Shader::CompileShader(D3D_FEATURE_LEVEL featur
     file << "Video Backend: " + g_video_backend->GetDisplayName();
     file.close();
 
-    PanicAlertFmt("Failed to compile {}:\nDebug info ({}):\n{}", filename, target,
-                  static_cast<const char*>(errors->GetBufferPointer()));
+    PanicAlertFmt("Failed to compile {}: {}\nDebug info ({}):\n{}", filename, Common::HRWrap(hr),
+                  target, static_cast<const char*>(errors->GetBufferPointer()));
     return std::nullopt;
   }
 

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
@@ -8,8 +8,10 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonFuncs.h"
+#include "Common/HRWrap.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+
 #include "VideoCommon/VideoConfig.h"
 
 static bool IsTearingSupported(IDXGIFactory2* dxgi_factory)
@@ -125,7 +127,7 @@ bool SwapChain::CreateSwapChain(bool stereo)
 
   if (FAILED(hr))
   {
-    PanicAlertFmt("Failed to create swap chain with HRESULT {:08X}", hr);
+    PanicAlertFmt("Failed to create swap chain: {}", Common::HRWrap(hr));
     return false;
   }
 
@@ -133,7 +135,7 @@ bool SwapChain::CreateSwapChain(bool stereo)
   hr = m_dxgi_factory->MakeWindowAssociation(static_cast<HWND>(m_wsi.render_surface),
                                              DXGI_MWA_NO_WINDOW_CHANGES | DXGI_MWA_NO_ALT_ENTER);
   if (FAILED(hr))
-    WARN_LOG_FMT(VIDEO, "MakeWindowAssociation() failed with HRESULT {:08X}", hr);
+    WARN_LOG_FMT(VIDEO, "MakeWindowAssociation() failed: {}", Common::HRWrap(hr));
 
   m_stereo = stereo;
   if (!CreateSwapChainBuffers())
@@ -166,7 +168,7 @@ bool SwapChain::ResizeSwapChain()
                                            GetDXGIFormatForAbstractFormat(m_texture_format, false),
                                            GetSwapChainFlags());
   if (FAILED(hr))
-    WARN_LOG_FMT(VIDEO, "ResizeBuffers() failed with HRESULT {:08X}", hr);
+    WARN_LOG_FMT(VIDEO, "ResizeBuffers() failed: {}", Common::HRWrap(hr));
 
   DXGI_SWAP_CHAIN_DESC desc;
   if (SUCCEEDED(m_swap_chain->GetDesc(&desc)))
@@ -236,7 +238,7 @@ bool SwapChain::Present()
   HRESULT hr = m_swap_chain->Present(static_cast<UINT>(g_ActiveConfig.bVSyncActive), present_flags);
   if (FAILED(hr))
   {
-    WARN_LOG_FMT(VIDEO, "Swap chain present failed with HRESULT {:08X}", hr);
+    WARN_LOG_FMT(VIDEO, "Swap chain present failed: {}", Common::HRWrap(hr));
     return false;
   }
 

--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -4,7 +4,6 @@
 #include "VideoBackends/OGL/OGLRender.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <cmath>
 #include <cstdio>
 #include <memory>

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -345,7 +345,7 @@ void RunGpuLoop()
 
             ASSERT_MSG(COMMANDPROCESSOR,
                        (s32)fifo.CPReadWriteDistance.load(std::memory_order_relaxed) - 32 >= 0,
-                       "Negative fifo.CPReadWriteDistance = %i in FIFO Loop !\nThat can produce "
+                       "Negative fifo.CPReadWriteDistance = {} in FIFO Loop !\nThat can produce "
                        "instability in the game. Please report it.",
                        fifo.CPReadWriteDistance.load(std::memory_order_relaxed) - 32);
 

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -176,11 +176,11 @@ void VertexLoader::CompileVertexTranslator()
     if (tc != VertexComponentFormat::NotPresent)
     {
       ASSERT_MSG(VIDEO, VertexComponentFormat::Direct <= tc && tc <= VertexComponentFormat::Index16,
-                 "Invalid texture coordinates!\n(tc = %d)", (u32)tc);
+                 "Invalid texture coordinates!\n(tc = {})", tc);
       ASSERT_MSG(VIDEO, ComponentFormat::UByte <= format && format <= ComponentFormat::Float,
-                 "Invalid texture coordinates format!\n(format = %d)", (u32)format);
+                 "Invalid texture coordinates format!\n(format = {})", format);
       ASSERT_MSG(VIDEO, elements == TexComponentCount::S || elements == TexComponentCount::ST,
-                 "Invalid number of texture coordinates elements!\n(elements = %d)", (u32)elements);
+                 "Invalid number of texture coordinates elements!\n(elements = {})", elements);
 
       WriteCall(VertexLoader_TextCoord::GetFunction(tc, format, elements));
     }

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -4,7 +4,6 @@
 #include "VideoCommon/VertexLoaderBase.h"
 
 #include <array>
-#include <cinttypes>
 #include <cstring>
 #include <memory>
 #include <string>

--- a/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
@@ -1,7 +1,6 @@
 // Copyright 2021 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <cinttypes>
 #include <functional>
 #include <vector>
 


### PR DESCRIPTION
* The failed condition and the relevant function are now included in the assert message.  This applies even when using `ASSERT_MSG`; now, all relevant information is shown with that too.
* `ASSERT_MSG` now uses fmt.  I've updated all uses of this (and in some cases added additional details to the message).
* The `CHECK` macro in the D3D backends has been removed and replaced with `ASSERT_MSG`.
* I added an `HRWrap` struct that can be used to format `HRESULT` in messages; a `fmt::formatter` exists for it.  This uses `_com_result` based on [this](https://stackoverflow.com/a/7008111).  This gives _MUCH_ more useful information (compared to both just a hex value, and to no information at all (which was the norm for most uses)) and it should be fairly user-friendly.  ~~I put this in `D3DCommon.h`, but maybe this should be somewhere else so that it could be used in other code.~~  This is now located in `Common/HRWrap.h`, and used by a few places outside of D3D.  D3D11 and D3D12 both have their own variants that call `GetDeviceRemovedReason` when needed.
* The legacy non-format variants of `PanicAlert` have been removed; they're no longer used by anything.
* `ASSERT_MSG`'s first parameter now indicating the log type is now actually used.
* `PanicAlertFmtT` now actually works.  Yes, this was broken.  The values were extracted for translation beforehand, but they were never actually translated at runtime.  You can test this by modifying `dsp_rom.bin` so that it has an invalid hash, and then setting the language to French; the message will still be in English despite [a translation for it existing](https://github.com/dolphin-emu/dolphin/blob/aa6db1e029f513b3eb4b1d418a61dbc8eca20a41/Languages/po/fr.po#L11687-L11710).  This will hopefully make it easier for people to understand these messages (though it may make things a bit harder for support).

<details><summary>Before</summary>

```patch
diff --git a/Source/Core/Core/Core.cpp b/Source/Core/Core/Core.cpp
index 622d7f9d90..9174a0ca94 100644
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -20,6 +20,7 @@
 
 #include "AudioCommon/AudioCommon.h"
 
+#include "Common/Assert.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
@@ -439,6 +440,8 @@ static void FifoPlayerThread(const std::optional<std::string>& savestate_path,
 // See the BootManager.cpp file description for a complete call schedule.
 static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi)
 {
+  ASSERT(false);
+  ASSERT_MSG(CORE, false, "Test: %d", 42);
   const SConfig& core_parameter = SConfig::GetInstance();
   CallOnStateChangedCallbacks(State::Starting);
   Common::ScopeGuard flag_guard{[] {
```

would result in these dialogs:

![image](https://user-images.githubusercontent.com/8334194/141254944-33be7095-a1bd-475e-ae22-9a7cc288a834.png)
![image](https://user-images.githubusercontent.com/8334194/141254951-919b1f41-d5de-4a46-ab39-6850bdaca70a.png)

and this being logged:

```
27:16:705 Common\MsgHandler.cpp:112 E[MASTER]: Warning: An error occurred.

  Line: 443
  File: C:\Users\Pokechu22\source\repos\dolphin\Source\Core\Core\Core.cpp

Ignore and continue?
27:20:730 Common\MsgHandler.cpp:112 E[MASTER]: Warning: Test: 42
```
</details>
<details><summary>After</summary>

```patch
diff --git a/Source/Core/Core/Core.cpp b/Source/Core/Core/Core.cpp
index 622d7f9d90..c447c208e1 100644
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -20,6 +20,7 @@

 #include "AudioCommon/AudioCommon.h"

+#include "Common/Assert.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
@@ -439,6 +440,8 @@ static void FifoPlayerThread(const std::optional<std::string>& savestate_path,
 // See the BootManager.cpp file description for a complete call schedule.
 static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi)
 {
+  ASSERT(false);
+  ASSERT_MSG(CORE, false, "Test: {}", 42);
   const SConfig& core_parameter = SConfig::GetInstance();
   CallOnStateChangedCallbacks(State::Starting);
   Common::ScopeGuard flag_guard{[] {
```

would result in these dialogs:

![image](https://user-images.githubusercontent.com/8334194/141254963-eceec2ce-39eb-471e-9a78-bdc3b495e65e.png)
![image](https://user-images.githubusercontent.com/8334194/141254971-62fa4e15-1a0d-40a8-8d3d-63c360d376f4.png)

and this being logged:

```
23:50:874 Common\MsgHandler.cpp:113 E[MASTER]: Warning: An error occurred.

  Condition: false
  File: C:\Users\Pokechu22\source\repos\dolphin\Source\Core\Core\Core.cpp
  Line: 443
  Function: EmuThread

Ignore and continue?
23:59:503 Common\MsgHandler.cpp:113 E[CORE]: Warning: An error occurred.

Test: 42

  Condition: false
  File: C:\Users\Pokechu22\source\repos\dolphin\Source\Core\Core\Core.cpp
  Line: 444
  Function: EmuThread

Ignore and continue?
```
</details>