### PR TITLE
msvc: update to vs2022 and windows sdk 10.0.22000

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,9 +39,9 @@ Dolphin can only be installed on devices that satisfy the above requirements. At
 ## Building for Windows
 
 Use the solution file `Source/dolphin-emu.sln` to build Dolphin on Windows.
-Visual Studio 2019 16.3 or later is a hard requirement. Other compilers might be
+Visual Studio 2022 17.0 or later is a hard requirement. Other compilers might be
 able to build Dolphin on Windows but have not been tested and are not
-recommended to be used. Git and Windows 10 SDK must be installed when building.
+recommended to be used. Git and Windows 11 SDK must be installed when building.
 
 Make sure to pull submodules before building:
 ```sh

--- a/Source/Core/Common/SCMRevGen.vcxproj
+++ b/Source/Core/Common/SCMRevGen.vcxproj
@@ -26,7 +26,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -926,7 +926,8 @@ void JitArm64::mtfsfx(UGeckoInstruction inst)
 
     if (LogicalImm imm = LogicalImm(mask, 32))
     {
-      AND(WA, WA, LogicalImm(~mask, 32));
+      const u32 inverted_mask = ~mask;
+      AND(WA, WA, LogicalImm(inverted_mask, 32));
       AND(WB, WB, imm);
     }
     else

--- a/Source/PCH/pch.h
+++ b/Source/PCH/pch.h
@@ -6,15 +6,15 @@
 #define STRINGIFY_HELPER(x) #x
 #define STRINGIFY(x) STRINGIFY_HELPER(x)
 
-#if defined _MSC_FULL_VER && _MSC_FULL_VER < 192930133
+#if defined _MSC_FULL_VER && _MSC_FULL_VER < 193030705
 #pragma message("Current _MSC_FULL_VER: " STRINGIFY(_MSC_FULL_VER))
-#error Please update your build environment to the latest Visual Studio 2019!
+#error Please update your build environment to the latest Visual Studio 2022!
 #endif
 
 #include <sdkddkver.h>
-#ifndef NTDDI_WIN10_VB
+#ifndef NTDDI_WIN10_CO
 #pragma message("Current WDK_NTDDI_VERSION: " STRINGIFY(WDK_NTDDI_VERSION))
-#error Windows 10.0.19041 SDK or later is required
+#error Windows 10.0.22000 SDK or later is required
 #endif
 
 #undef STRINGIFY

--- a/Source/VSProps/Base.Macros.props
+++ b/Source/VSProps/Base.Macros.props
@@ -11,8 +11,7 @@
     <ExternalsDir>$(DolphinRootDir)Externals\</ExternalsDir>
     <SourceDir>$(DolphinRootDir)Source\</SourceDir>
     <CoreDir>$(SourceDir)Core\</CoreDir>
-    <CScript Condition="'$(ProgramFiles(x86))' != ''">%windir%\System32\cscript</CScript>
-    <CScript Condition="'$(ProgramFiles(x86))' == ''">%windir%\Sysnative\cscript</CScript>
+    <CScript>%windir%\System32\cscript</CScript>
     <VSPropsDir>$(SourceDir)VSProps\</VSPropsDir>
   </PropertyGroup>
   <PropertyGroup>

--- a/Source/VSProps/Configuration.Base.props
+++ b/Source/VSProps/Configuration.Base.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
     <!-- To use ASAN, just uncomment this. For simplicity, you should run VS/windbg/etc

--- a/Source/dolphin-emu.sln
+++ b/Source/dolphin-emu.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29519.181
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Dolphin", "Core\DolphinQt\DolphinQt.vcxproj", "{FA3FA62B-6F58-4B86-9453-4D149940A066}"
 EndProject


### PR DESCRIPTION
bumps some version numbers so the build will use vs2022 toolchain.

The buildbot is already using vs2022 (but v142 toolset will be used for existing PRs) / latest sdk for all builds.
