### PR TITLE
Android: Increase targetSdkVersion to 31 (Android 12)

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     ndkVersion "23.0.7599858"
 
     compileOptions {
@@ -26,7 +26,7 @@ android {
         // TODO If this is ever modified, change application_id in strings.xml
         applicationId "org.dolphinemu.dolphinemu"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         versionCode(getBuildVersionCode())
 

--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -29,7 +29,6 @@
         android:name="android.permission.VIBRATE"
         android:required="false"/>
 
-    <!-- Once compileSdkVersion is 31, add: android:dataExtractionRules="@xml/backup_rules_api_31" -->
     <application
         android:name=".DolphinApplication"
         android:label="@string/app_name"
@@ -38,6 +37,7 @@
         android:preserveLegacyExternalStorage="true"
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/backup_rules_api_31"
         android:supportsRtl="true"
         android:isGame="true"
         android:banner="@drawable/banner_tv"


### PR DESCRIPTION
Unlike with Android 11, there should be no downsides to doing this, so we might as well get this out of the way early. The main part of the work was already done in PR #9654.

Do not merge this until it has been tested by someone who has Android 12! I don't have Android 12 myself.