### PR TITLE
Android: Bump NDK and CMake versions

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
+    ndkVersion "23.0.7599858"
 
     compileOptions {
         // Flag to enable support for the new language APIs
@@ -63,7 +64,7 @@ android {
     externalNativeBuild {
         cmake {
             path "../../../CMakeLists.txt"
-            version "3.10.2"
+            version "3.18.1"
         }
     }
 


### PR DESCRIPTION
This should make C++20 and `std::filesystem` work. (Not that we really can use `std::filesystem` much on Android since it doesn't work with scoped storage...)