### PR TITLE
MoltenVK: Don't run fetchDependencies unnecessarily

### DIFF
--- a/Externals/MoltenVK/CMakeLists.txt
+++ b/Externals/MoltenVK/CMakeLists.txt
@@ -1,8 +1,10 @@
 include(ExternalProject)
 
+set(MOLTENVK_VERSION "v1.1.5")
+
 ExternalProject_Add(MoltenVK
   GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-  GIT_TAG v1.1.5
+  GIT_TAG ${MOLTENVK_VERSION}
 
   CONFIGURE_COMMAND <SOURCE_DIR>/fetchDependencies --macos
 

--- a/Externals/MoltenVK/CMakeLists.txt
+++ b/Externals/MoltenVK/CMakeLists.txt
@@ -6,7 +6,7 @@ ExternalProject_Add(MoltenVK
   GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
   GIT_TAG ${MOLTENVK_VERSION}
 
-  CONFIGURE_COMMAND <SOURCE_DIR>/fetchDependencies --macos
+  CONFIGURE_COMMAND ${CMAKE_CURRENT_LIST_DIR}/configure.sh <LOG_DIR> <SOURCE_DIR> ${MOLTENVK_VERSION}
 
   BUILD_COMMAND make -C <SOURCE_DIR> macos
   BUILD_IN_SOURCE ON

--- a/Externals/MoltenVK/configure.sh
+++ b/Externals/MoltenVK/configure.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# To lower build times, we avoid running the fetchDependencies script if the MoltenVK
+# version didn't change. The last-built MoltenVK version is stored inside a file in
+# the timestamp directory. If the file doesn't exist or the file contains a different
+# MoltenVK version, fetchDependencies is ran.
+#
+# Usage: configure.sh <timestamp directory> <source directory> <MoltenVK version>
+#
+
+set -e
+
+VERSION_PATH="$1/MoltenVK-last-version.txt"
+CURRENT_VERSION="$3"
+LAST_VERSION=$(cat "$VERSION_PATH" || true)
+
+if ! [ "$LAST_VERSION" = "$3" ]; then
+  $2/fetchDependencies --macos
+  echo $CURRENT_VERSION > $VERSION_PATH
+fi


### PR DESCRIPTION
Currently, MoltenVK's ``fetchDependencies`` script is ran on every build. The script clones various git repositories for dependencies and rebuilds each one of them. This causes rebuild times to take significantly longer, which makes development more annoying. To fix this, don't run the script after the initial build if MoltenVK's version hasn't been updated. 

Decreases rebuild times without any changes to source code from ~250s to ~10s on an M1 Mac Mini.