### PR TITLE
DSP: Reword inappropriate references to Global User Directory

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -73,9 +73,9 @@ static bool VerifyRoms(const SDSP& dsp)
   if (rom_idx < 0)
   {
     if (AskYesNoFmtT("Your DSP ROMs have incorrect hashes.\n\n"
-                     "Delete the dsp_rom.bin and dsp_coef.bin files in the GC folder in the Global "
-                     "User Directory to use the free DSP ROM, or replace them with good dumps from "
-                     "a real GameCube/Wii.\n\n"
+                     "Delete the dsp_rom.bin and dsp_coef.bin files in the GC folder in the User "
+                     "folder to use the free DSP ROM, or replace them with good dumps from a real "
+                     "GameCube/Wii.\n\n"
                      "Would you like to stop now to fix the problem?\n"
                      "If you select \"No\", audio might be garbled."))
     {
@@ -88,9 +88,9 @@ static bool VerifyRoms(const SDSP& dsp)
     if (AskYesNoFmtT(
             "You are using an old free DSP ROM made by the Dolphin Team.\n"
             "Due to emulation accuracy improvements, this ROM no longer works correctly.\n\n"
-            "Delete the dsp_rom.bin and dsp_coef.bin files in the GC folder in the Global "
-            "User Directory to use the most recent free DSP ROM, or replace them with "
-            "good dumps from a real GameCube/Wii.\n\n"
+            "Delete the dsp_rom.bin and dsp_coef.bin files in the GC folder in the User folder "
+            "to use the most recent free DSP ROM, or replace them with good dumps from a real "
+            "GameCube/Wii.\n\n"
             "Would you like to stop now to fix the problem?\n"
             "If you select \"No\", audio might be garbled."))
     {


### PR DESCRIPTION
These messages apply to the User directory regardless of whether it's global or local, so we shouldn't specify "global".

Also changing "directory" to "folder", just for consistency with "GC folder" in the same sentence.