### PR TITLE
Force Dual Core on for Bomberman Jetters

### DIFF
--- a/Data/Sys/GameSettings/GJB.ini
+++ b/Data/Sys/GameSettings/GJB.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# This game does not currently run in Single Core.
+CPUThread = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
This game requires emulating the Fifo Pipeline or have Single Core be able to read ahead in the Fifo.  Because Single Core currently processes things in a serialized manner, this game will not run regardless of CPU/GPU timing hacks.

This was previously attempted a few years ago in Single Core, but was not merged due to performance being ~15% slower.