### PR TITLE
[WIP] Add timing hack to fix Splinter Cell: Chaos Theory and Speed Challenge.

### DIFF
--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -250,7 +250,9 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
         src.Skip(bytes);
 
         // 4 GPU ticks per vertex, 3 CPU ticks per GPU tick
-        total_cycles += num_vertices * 4 * 3 + 6;
+        // HACK: In Speed Challenge and many Datel Products, lower than 1600 hangs.
+        // If Dolphin's GPU timings are ever made halfway decent, this hack can be removed.
+        total_cycles += std::max(1600, num_vertices * 4 * 3 + 6);
       }
       else
       {


### PR DESCRIPTION
Dolphin's GPU timings are awful, and the GPU is way too fast especially in low polygon scenes.  In order to rectify this, I readded the old timings we used before 4.0-5369, but only use it when there's very few vertices being rendered.

This needs heavy testing in order to make sure there aren't performance regressions or any other crashes.  This is known to fix most Action Replay titles, both Advance Game Ports hanging, and Ubisoft's Speed Challenge.  This is very likely to either break/fix fifo sensitive titles that have either regressed or been fixed by various things.

Code was initially an if/else, but JosJuice pointed out to me there was a much cleaner way to do it, resulting in this.

![image](https://user-images.githubusercontent.com/6598209/141704034-db7c64d5-358c-44da-a42c-7c236eb7ad4b.png)
