### PR TITLE
msbuild: use /external:anglebrackets

### DIFF
--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -19,7 +19,7 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <!-- 5054  operator '+': deprecated between enumerations of different types (in Qt headers) -->
+      <!-- 5054  operator '+': deprecated between enumerations of different types (types defined in Qt headers) -->
       <DisableSpecificWarnings>5054;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)Config\Graphics;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ProjectDir)Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -7,53 +7,54 @@
     <TargetName Condition="'$(ConfigurationType)'=='Application'">$(ProjectName)$(TargetSuffix)</TargetName>
     <!--Set link /INCREMENTAL:NO to remove some entropy from builds (assists with /Brepro)-->
     <LinkIncremental>false</LinkIncremental>
-    <!--
-      Coagulate external include directories.
-      Order matters! (first hit, first use).
-        Note: Directory containing source file being compiled is always searched first.
-      -->
-    <ExternalIncludePath>$(ExternalsDir)Bochs_disasm;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)bzip2;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)cpp-optparse;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)FreeSurround\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)cubeb\include;$(ExternalsDir)cubeb\msvc;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)curl\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)discord-rpc\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)ed25519;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)enet\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)ffmpeg\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)fmt\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)GL;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)glslang;$(ExternalsDir)glslang\StandAlone;$(ExternalsDir)glslang\glslang\Public;$(ExternalsDir)glslang\SPIRV;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)imgui;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)liblzma\api;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)libpng;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)libusb\libusb;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)LZO;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)mGBA\mgba\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)miniupnpc\src;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)minizip;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)mbedtls\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)OpenAL\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)picojson;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)pugixml;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)rangeset\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)SFML\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)soundtouch;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)Vulkan\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)WIL\include;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)xxhash;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)zlib;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(ExternalsDir)zstd\lib;$(ExternalIncludePath)</ExternalIncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <!--ClCompile Base-->
     <ClCompile>
       <AdditionalIncludeDirectories>$(CoreDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!--
+      Coagulate external include directories.
+      Order matters! (first hit, first use).
+        Note: Directory containing source file being compiled is always searched first.
+      -->
+      <AdditionalIncludeDirectories>$(ExternalsDir)Bochs_disasm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)bzip2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)cpp-optparse;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)FreeSurround\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)cubeb\include;$(ExternalsDir)cubeb\msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)curl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)discord-rpc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)ed25519;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)enet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)ffmpeg\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)fmt\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)GL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)glslang;$(ExternalsDir)glslang\StandAlone;$(ExternalsDir)glslang\glslang\Public;$(ExternalsDir)glslang\SPIRV;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)liblzma\api;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)libpng;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)libusb\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)LZO;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)mGBA\mgba\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)miniupnpc\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)minizip;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)mbedtls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)OpenAL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)picojson;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)pugixml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)rangeset\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)SFML\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)soundtouch;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)Vulkan\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)WIL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)xxhash;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)zstd\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <!--Base external header policy: ignore all warnings except template instantiations, and disable analyzer-->
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <ExternalTemplatesDiagnostics>true</ExternalTemplatesDiagnostics>
       <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
       <PreprocessorDefinitions>FMT_HEADER_ONLY=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!--
         It would be a good idea to disable _CRT_SECURE_NO_WARNINGS and get rid of e.g. C string parsing funcs

--- a/Source/VSProps/QtCompile.props
+++ b/Source/VSProps/QtCompile.props
@@ -7,8 +7,7 @@
     <QTDIR Condition="Exists('$(QTDIR)') And !HasTrailingSlash('$(QTDIR)')">$(QTDIR)\</QTDIR>
     <QtDirValid>false</QtDirValid>
     <QtDirValid Condition="Exists('$(QTDIR)')">true</QtDirValid>
-    <QtIncludeDirWithoutTrailingSeparator>$(QTDIR)include</QtIncludeDirWithoutTrailingSeparator>
-    <QtIncludeDir>$(QtIncludeDirWithoutTrailingSeparator)\</QtIncludeDir>
+    <QtIncludeDir>$(QTDIR)include\</QtIncludeDir>
     <QtLibDir>$(QTDIR)lib\</QtLibDir>
     <QtBinDir>$(QTDIR)bin\</QtBinDir>
     <QtPluginsDir>$(QTDIR)plugins\</QtPluginsDir>
@@ -17,21 +16,19 @@
     <QtLibSuffix Condition="'$(Configuration)'=='Debug'">$(QtDebugSuffix)</QtLibSuffix>
     <QtPluginFolder>QtPlugins</QtPluginFolder>
   </PropertyGroup>
-  <PropertyGroup>
-    <ExternalIncludePath>$(QtIncludeDir);$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(QtIncludeDir)QtCore;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(QtIncludeDir)QtGui;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath>$(QtIncludeDir)QtWidgets;$(ExternalIncludePath)</ExternalIncludePath>
-    <ExternalIncludePath Condition="'$(Platform)'=='ARM64'">$(QtIncludeDir)QtANGLE;$(ExternalIncludePath)</ExternalIncludePath>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">QT_NO_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>QT_DLL;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>QT_USE_QSTRINGBUILDER;QT_NO_CAST_FROM_ASCII;QT_NO_CAST_TO_ASCII;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(QtIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(QtIncludeDir)QtCore;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(QtIncludeDir)QtGui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(QtIncludeDir)QtWidgets;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Platform)'=='ARM64'">$(QtIncludeDir)QtANGLE;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <!--
         Ignore warnings in locally-instantiated Qt templates.
-        This should probably be removed at some point (when Qt is fixed).
+        This should be removed at some point (when Qt is fixed).
         -->
       <ExternalTemplatesDiagnostics>false</ExternalTemplatesDiagnostics>
     </ClCompile>


### PR DESCRIPTION
Revert usage of ExternalIncludePath, as that var is specifically
for external includes which do not get scanned for changes.

Instead, use /external:anglebrackets , which causes anything `#include`d with `<>` to be considered "external" (for adjusting warning level only - not affecting out-of-date checking). 