### PR TITLE
RenderBase: Put Opacity on FPS background.

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -561,6 +561,7 @@ void Renderer::DrawDebugText()
                                    10.0f * m_backbuffer_scale),
                             ImGuiCond_Always, ImVec2(1.0f, 0.0f));
     ImGui::SetNextWindowSize(ImVec2(100.0f * m_backbuffer_scale, 30.0f * m_backbuffer_scale));
+    ImGui::SetNextWindowBgAlpha(.6f);
 
     if (ImGui::Begin("FPS", nullptr,
                      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |


### PR DESCRIPTION
Sometimes when playing a dialogue can not be seen in full due to the shadow of the FPS, therefore by putting a little opacity it could already be seen perfectly.