### PR TITLE
GameINI: Fix comments causing errors in GALE01r0.ini

### DIFF
--- a/Data/Sys/GameSettings/GALE01r0.ini
+++ b/Data/Sys/GameSettings/GALE01r0.ini
@@ -127,59 +127,7 @@ $P1 - one-half size
 $P1 - one-tenth size
 0447E730 3DCCCCDF
 
-$GAME MODIFIER
-557E0000 60000000
-00000000 857E0000
-60000000 00400001
-057E0004 38BCFFF8
-057E002C 4A8381F4
-0401821C 497C7DE8
-057E0030 90010004
-057E00FC 4A98DC34
-0416DD2C 49672304
-
-$P1 Remove Skirt-Zelda
-*Game Modifier must be enabled
-0A4510C6 00000012
-40451170 000657FF
-
-$P1 Remove Skirt-Peach
-*Game Modifier must be enabled
-0A4510C6 0000000C
-40451170 000659FF
-
-$P2 Remove Skirt - Zelda
-*Game Modifier must be enabled
-0A451F56 00000012
-40452000 000657FF
-
-$P2 Remove Skirt - Peach
-*Game Modifier must be enabled
-0A451F56 0000000C
-40452000 000659FF
-
-$P3 Remove Skirt - Zelda
-*Game Modifier must be enabled
-0A452DE6 00000013
-40452E90 000657FF
-
-$P3 Remove Skirt - Peach
-*Game Modifier must be enabled
-0A452DE6 0000000C
-40452E90 000659FF
-
-$P4 Remove Skirt - Zelda
-*Game Modifier must be enabled
-0A453C76 00000013
-40453D20 000657FF
-
-$P4 Remove Skirt - Peach
-*Game Modifier must be enabled
-0A453C76 0000000C
-40453D20 000659FF
-
-$Each player gets a CPU clone that fights for them
-*Don't use in story modes or with Zelda/Sheik.
+$Each player gets a CPU clone that fights for them (don't use in story modes or with Zelda/Sheik)
 04031B4C 4BFD13CC
 04002F18 907E00B0
 04002F1C 88810028


### PR DESCRIPTION
Same problem as PR #10201... Except instead of just making the comments use #, I'm actually removing some of the codes entirely because they are of questionable value.

Should fix https://bugs.dolphin-emu.org/issues/12737.