### PR TITLE
VKMain: Explicitly call setDisplaySyncEnabled on the CAMetalLayer to set VSync

### DIFF
--- a/Externals/MoltenVK/CMakeLists.txt
+++ b/Externals/MoltenVK/CMakeLists.txt
@@ -1,8 +1,10 @@
 include(ExternalProject)
 
+set(MOLTENVK_VERSION "v1.1.5")
+
 ExternalProject_Add(MoltenVK
   GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-  GIT_TAG v1.1.5
+  GIT_TAG ${MOLTENVK_VERSION}
 
   CONFIGURE_COMMAND <SOURCE_DIR>/fetchDependencies --macos
 

--- a/Externals/MoltenVK/CMakeLists.txt
+++ b/Externals/MoltenVK/CMakeLists.txt
@@ -6,7 +6,7 @@ ExternalProject_Add(MoltenVK
   GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
   GIT_TAG ${MOLTENVK_VERSION}
 
-  CONFIGURE_COMMAND <SOURCE_DIR>/fetchDependencies --macos
+  CONFIGURE_COMMAND ${CMAKE_CURRENT_LIST_DIR}/configure.sh <DOWNLOAD_DIR> <SOURCE_DIR> ${MOLTENVK_VERSION}
 
   BUILD_COMMAND make -C <SOURCE_DIR> macos
   BUILD_IN_SOURCE ON

--- a/Externals/MoltenVK/configure.sh
+++ b/Externals/MoltenVK/configure.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# To lower build times, we avoid running the fetchDependencies script if the MoltenVK
+# version didn't change. The last-built MoltenVK version is stored inside a file in
+# the download directory. If the file doesn't exist or the file contains a different
+# MoltenVK version, fetchDependencies is ran.
+#
+# Usage: configure.sh <download directory> <source directory> <MoltenVK version>
+#
+
+set -e
+
+VERSION_PATH="$1/MoltenVK-last-version.txt"
+CURRENT_VERSION="$3"
+LAST_VERSION=$(cat "$VERSION_PATH" || true)
+
+if ! [ "$LAST_VERSION" = "$3" ]; then
+  $2/fetchDependencies --macos
+  echo $CURRENT_VERSION > $VERSION_PATH
+fi

--- a/Source/Core/VideoBackends/Vulkan/VKMain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKMain.cpp
@@ -324,6 +324,10 @@ void VideoBackend::PrepareWindow(WindowSystemInfo& wsi)
     return;
   }
 
+  // Explicitly tells the underlying layer to use VSync.
+  // [layer setDisplaySyncEnabled:bVSyncActive]
+  reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(layer, sel_getUid("setDisplaySyncEnabled:"), g_ActiveConfig.bVSyncActive);
+
   // [view setWantsLayer:YES]
   reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(view, sel_getUid("setWantsLayer:"), YES);
 


### PR DESCRIPTION
I'll let @ryanmcgrath speak for themselves, since this basically their patch:

> So, I've a question that probably makes me sound like I'm in some parallel universe, but curious if anyone in this channel knows: does the vsync toggle in Dolphin actually disable vsync under MoltenVK? Existing literature surrounding vsync on macOS in general is a mess.
> 
> This question may seem familiar as I asked it on the IRC channel some time ago, but humor me, lol
> 
> I ask because this notes: https://dolphin-emu.org/blog/2018/12/04/dolphin-progress-report-november-2018/#dev-diary-putting-a-mac-through-its-paces-by-mayimilae 
> 
>and the vsync toggle in the graphics UI doesn't actually do anything!
> 
> Granted it's from 2018, but I don't know if this'd have changed or been noted further. The only other person asking about this was a Dolphin forum post I found from the Mojave era where someone asked about it, but seemed inconclusive.
> 
>  I wound up "fixing" this over in Slippi due to a number of users complaining about stuttering on Vulkan, and I went down an absurd rabbit hole tracking this down. I worry it's placebo but would invite someone to correct me, lol...
> 
> The tl;dr is that I found that explicitly setting setDisplaySyncEnabled:NO on the CAMetalLayer at setup time, before MoltenVK gets ahold of it, kicked it off properly. I've not had time to actually build mainline Dolphin with this change to see if I'm just losing my mind, but I'd be curious if anyone has any thoughts - the number of people it created a smoother experience for is too high for me to not bring it up, I guess.
