### PR TITLE
Compatibility Settings for Red Steel 2

### DIFF
--- a/Data/Sys/GameSettings/RD2.ini
+++ b/Data/Sys/GameSettings/RD2.ini
@@ -1,0 +1,18 @@
+# RD2X41, RD2J41, RD2P41, RD2K41, RD2E41 - Red Steel 2
+
+[Core]
+# The game hangs on New Game when using Dual Core
+# SyncGPU is slower than Single Core in this title.
+CPUThread = False
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Enhancements]
+# Anisotropic Filtering breaks FMVs
+MaxAnisotropy = 0


### PR DESCRIPTION
Red Steel 2 has FMVs that get corrupted with Anisotropic filtering.  It also hangs on dualcore.  While SyncGPU works, both another user and myself saw much smoother gameplay when using Single Core for unknown reasons.