### PR TITLE
Android: Enable R8 code shrinking

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -49,6 +49,12 @@ android {
         // Signed by release key, allowing for upload to Play Store.
         release {
             signingConfig signingConfigs.release
+
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile(
+                'proguard-android-optimize.txt'),
+                'proguard-rules.pro'
         }
 
         // Signed by debug key disallowing distribution on Play Store.

--- a/Source/Android/app/proguard-rules.pro
+++ b/Source/Android/app/proguard-rules.pro
@@ -1,17 +1,3 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /home/sigma/apps/android-sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Being able to get sensible stack traces from users is more important
+# than the space savings obfuscation could give us
+-dontobfuscate


### PR DESCRIPTION
This decreases our APK size by a few megabytes. Most of the reduction is from Java libraries that we only use small parts of. Code shrinking gets rid of all the unused code from these libraries from the APK.

Because I highly value the ability to get stack traces that make sense, I have specifically disabled obfuscation (automatic renaming of symbols to short incomprehensible names).

I've only enabled code shrinking for release builds, purely because I feel like the extra build time (30 seconds on my machine) would be annoying when you want to make debug builds rapidly.