### PR TITLE
RiivolutionPatcher: Use case-insensitive filename comparison when searching for files in a folder patch.

### DIFF
--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -378,7 +378,7 @@ static DiscIO::FSTBuilderNode* FindFilenameNodeInFST(std::string_view filename,
       if (result)
         return result;
     }
-    else if (node.m_filename == filename)
+    else if (CaseInsensitiveEquals(node.m_filename, filename))
     {
       return &node;
     }


### PR DESCRIPTION
Should fix https://bugs.dolphin-emu.org/issues/12738