### PR TITLE
ControllerInterface: fix UpdateReferences() deadlock (DEPRECATED)

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -409,6 +409,13 @@ void ControllerInterface::UpdateInput()
   }
 }
 
+std::unique_lock<std::recursive_mutex>
+ControllerInterface::GetDevicesPopulationDeferredMutex() const
+{
+  std::unique_lock<std::recursive_mutex> lock(m_devices_population_mutex, std::defer_lock);
+  return lock;
+}
+
 void ControllerInterface::SetCurrentInputChannel(ciface::InputChannel input_channel)
 {
   tls_input_channel = input_channel;

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -92,6 +92,7 @@ public:
   // more than one thread, or that are called by a single other thread.
   // Without this, our devices list might end up in a mixed state.
   void PlatformPopulateDevices(std::function<void()> callback);
+  std::unique_lock<std::recursive_mutex> GetDevicesPopulationDeferredMutex() const;
   bool IsInit() const { return m_is_init; }
   void UpdateInput();
 


### PR DESCRIPTION
An earlier version of https://github.com/dolphin-emu/dolphin/pull/10228, before I realized there was an actually better way of fixing the android deadlock.

Just uploaded to have it stashed somewhere, which doesn't mean I don't have faith in the newer fix :)