### PR TITLE
Cleanup and Update N64 Virtual Console INIs

### DIFF
--- a/Data/Sys/GameSettings/NAC.ini
+++ b/Data/Sys/GameSettings/NAC.ini
@@ -1,4 +1,4 @@
-# NACE01 - Zelda: Ocarina
+# NACJ01, NACE01, NACP01 - The Legend of Zelda: Ocarina of Time (Virtual Console)
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/NAE.ini
+++ b/Data/Sys/GameSettings/NAE.ini
@@ -1,4 +1,4 @@
-# NAEE01, NAEP01 - Paper Mario
+# NAEE01, NAEP01 - Paper Mario (Virtual Console)
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/NAF.ini
+++ b/Data/Sys/GameSettings/NAF.ini
@@ -1,4 +1,4 @@
-# NAFE01, NAFP01 - F-Zero X
+# NAFE01, NAFP01 - F-Zero X (Virtual Console)
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/NAL.ini
+++ b/Data/Sys/GameSettings/NAL.ini
@@ -19,5 +19,9 @@ StereoConvergence = 5000
 # This game creates a large number of EFB copies at different addresses, resulting
 # in a large texture cache which takes considerable time to save.
 SaveTextureCacheToState = False
-# This game crashes very soon after boot if above 1x IR
-InternalResolution = 1
+
+[Video_Hacks]
+# This game crashes very soon after boot if EFB copies are scaled at higher resolutions.
+# This is due to Dolphin running out of memory.  Disabling Scaled EFB copies allows playing
+# at higher resolutions without the game crashing for now.
+EFBScaledCopy = False

--- a/Data/Sys/GameSettings/NAT.ini
+++ b/Data/Sys/GameSettings/NAT.ini
@@ -16,5 +16,9 @@
 # This game creates a large number of EFB copies at different addresses, resulting
 # in a large texture cache which takes considerable time to save.
 SaveTextureCacheToState = False
-# This game crashes very soon after boot if above 1x IR
-InternalResolution = 1
+
+[Video_Hacks]
+# This game crashes very soon after boot if EFB copies are scaled at higher resolutions.
+# This is due to Dolphin running out of memory.  Disabling Scaled EFB copies allows playing
+# at higher resolutions without the game crashing for now.
+EFBScaledCopy = False


### PR DESCRIPTION
This Pull Request updates N64 INIs based on what I know about various behaviors since the last time we updated it.  This should result in more sane settings for Mario Tennis and Super Smash Bros. while still preventing the out of memory crash due to the tremendous amounts of EFB copies.