### PR TITLE
NetPlayServer: Clear remaining m_players when netplay thread ends so that their destructors can run while the ENetHost still exists.

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -357,7 +357,8 @@ void NetPlayServer::ThreadFunc()
     ClearPeerPlayerId(player_entry.second.socket);
     enet_peer_disconnect(player_entry.second.socket, 0);
   }
-}  // namespace NetPlay
+  m_players.clear();
+}
 
 static void SendSyncIdentifier(sf::Packet& spac, const SyncIdentifier& sync_identifier)
 {


### PR DESCRIPTION
Otherwise the QoSSession destructor attempts to access the already deleted ENetHost, which appears fairly harmless but is still technically a use-after-free. (and crashes Debug builds, which is how I found it)

e: Oh, to clarify, this is relevant when the host closes the window while some clients are still connected.