### PR TITLE
Gameini: Enable MMU for some games

### DIFF
--- a/Data/Sys/GameSettings/GLZ.ini
+++ b/Data/Sys/GameSettings/GLZ.ini
@@ -1,0 +1,13 @@
+# GLZP69, GLZE69, GLZD69, GLZF69 - 007: From Russia with Love
+
+[Core]
+# Displays in-game menus
+MMU = True
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 512
+
+[Video_Hacks]
+# Fixes Bloom
+#EFBToTextureEnable = False
+#DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RWG.ini
+++ b/Data/Sys/GameSettings/RWG.ini
@@ -1,0 +1,5 @@
+# RWGE08, RWGP08, RWGJ08 - We Love Golf!
+
+[Core]
+# Prevents crashing
+MMU = True


### PR DESCRIPTION
This is to enable MMU for a couple games.

"007: From Russia with Love" requires MMU to display in-game menus. Otherwise they are black. Also I have enabled medium texture cache to fix the jittery intro video.

"We Love Golf!" crashes without full MMU. This was apparently fixed in 5.0-540 (Dynamic bat) which is true only if MMU is enabled. Since it's not enabled by default the game should overwrite the MMU setting to work.