### PR TITLE
Ensure user paths are stored in a consistent manner.

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -387,7 +387,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetCacheDire
     JNIEnv* env, jclass, jstring jDirectory)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
-  File::SetUserPath(D_CACHE_IDX, GetJString(env, jDirectory) + DIR_SEP);
+  File::SetUserPath(D_CACHE_IDX, GetJString(env, jDirectory));
 }
 
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_DefaultCPUCore(JNIEnv*, jclass)

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -932,7 +932,7 @@ static void RebuildUserDirectories(unsigned int dir_index)
   {
   case D_USER_IDX:
     s_user_paths[D_GCUSER_IDX] = s_user_paths[D_USER_IDX] + GC_USER_DIR DIR_SEP;
-    s_user_paths[D_WIIROOT_IDX] = s_user_paths[D_USER_IDX] + WII_USER_DIR;
+    s_user_paths[D_WIIROOT_IDX] = s_user_paths[D_USER_IDX] + WII_USER_DIR DIR_SEP;
     s_user_paths[D_CONFIG_IDX] = s_user_paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;
     s_user_paths[D_GAMESETTINGS_IDX] = s_user_paths[D_USER_IDX] + GAMESETTINGS_DIR DIR_SEP;
     s_user_paths[D_MAPS_IDX] = s_user_paths[D_USER_IDX] + MAPS_DIR DIR_SEP;
@@ -978,7 +978,7 @@ static void RebuildUserDirectories(unsigned int dir_index)
     s_user_paths[F_ARAMDUMP_IDX] = s_user_paths[D_DUMP_IDX] + ARAM_DUMP;
     s_user_paths[F_FAKEVMEMDUMP_IDX] = s_user_paths[D_DUMP_IDX] + FAKEVMEM_DUMP;
     s_user_paths[F_GCSRAM_IDX] = s_user_paths[D_GCUSER_IDX] + GC_SRAM;
-    s_user_paths[F_WIISDCARD_IDX] = s_user_paths[D_WIIROOT_IDX] + DIR_SEP WII_SDCARD;
+    s_user_paths[F_WIISDCARD_IDX] = s_user_paths[D_WIIROOT_IDX] + WII_SDCARD;
 
     s_user_paths[D_MEMORYWATCHER_IDX] = s_user_paths[D_USER_IDX] + MEMORYWATCHER_DIR DIR_SEP;
     s_user_paths[F_MEMORYWATCHERLOCATIONS_IDX] =

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -62,7 +62,8 @@ enum
   D_DYNAMICINPUT_IDX,
   D_GBAUSER_IDX,
   D_GBASAVES_IDX,
-  F_DOLPHINCONFIG_IDX,
+  FIRST_FILE_USER_PATH_IDX,
+  F_DOLPHINCONFIG_IDX = FIRST_FILE_USER_PATH_IDX,
   F_GCPADCONFIG_IDX,
   F_WIIPADCONFIG_IDX,
   F_GCKEYBOARDCONFIG_IDX,
@@ -208,7 +209,7 @@ const std::string& GetUserPath(unsigned int dir_index);
 
 // Sets a user directory path
 // Rebuilds internal directory structure to compensate for the new directory
-void SetUserPath(unsigned int dir_index, const std::string& path);
+void SetUserPath(unsigned int dir_index, std::string path);
 
 // probably doesn't belong here
 std::string GetThemeDir(const std::string& theme_name);

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -19,7 +19,9 @@ namespace Common
 std::string RootUserPath(FromWhichRoot from)
 {
   int idx = from == FROM_CONFIGURED_ROOT ? D_WIIROOT_IDX : D_SESSION_WIIROOT_IDX;
-  return File::GetUserPath(idx);
+  std::string dir = File::GetUserPath(idx);
+  dir.pop_back();  // remove trailing path separator
+  return dir;
 }
 
 static std::string RootUserPath(std::optional<FromWhichRoot> from)

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -117,6 +117,8 @@ HostFileSystem::HostFileSystem(const std::string& root_path,
                                std::vector<NandRedirect> nand_redirects)
     : m_root_path{root_path}, m_nand_redirects(std::move(nand_redirects))
 {
+  while (StringEndsWith(m_root_path, "/"))
+    m_root_path.pop_back();
   File::CreateFullPath(m_root_path + "/");
   ResetFst();
   LoadFst();

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -557,7 +557,7 @@ void IOSC::LoadDefaultEntries(ConsoleType console_type)
 
 void IOSC::LoadEntries()
 {
-  File::IOFile file{File::GetUserPath(D_WIIROOT_IDX) + "/keys.bin", "rb"};
+  File::IOFile file{File::GetUserPath(D_WIIROOT_IDX) + "keys.bin", "rb"};
   if (!file)
   {
     WARN_LOG_FMT(IOS, "keys.bin could not be found. Default values will be used.");

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -65,14 +65,14 @@ static bool CopyBackupFile(const std::string& path_from, const std::string& path
 
 static void DeleteBackupFile(const std::string& file_name)
 {
-  File::Delete(File::GetUserPath(D_BACKUP_IDX) + DIR_SEP + file_name);
+  File::Delete(File::GetUserPath(D_BACKUP_IDX) + file_name);
 }
 
 static void BackupFile(const std::string& path_in_nand)
 {
   const std::string file_name = PathToFileName(path_in_nand);
-  const std::string original_path = File::GetUserPath(D_WIIROOT_IDX) + DIR_SEP + path_in_nand;
-  const std::string backup_path = File::GetUserPath(D_BACKUP_IDX) + DIR_SEP + file_name;
+  const std::string original_path = File::GetUserPath(D_WIIROOT_IDX) + path_in_nand;
+  const std::string backup_path = File::GetUserPath(D_BACKUP_IDX) + file_name;
 
   CopyBackupFile(original_path, backup_path);
 }
@@ -80,8 +80,8 @@ static void BackupFile(const std::string& path_in_nand)
 static void RestoreFile(const std::string& path_in_nand)
 {
   const std::string file_name = PathToFileName(path_in_nand);
-  const std::string original_path = File::GetUserPath(D_WIIROOT_IDX) + DIR_SEP + path_in_nand;
-  const std::string backup_path = File::GetUserPath(D_BACKUP_IDX) + DIR_SEP + file_name;
+  const std::string original_path = File::GetUserPath(D_WIIROOT_IDX) + path_in_nand;
+  const std::string backup_path = File::GetUserPath(D_BACKUP_IDX) + file_name;
 
   if (CopyBackupFile(backup_path, original_path))
     DeleteBackupFile(file_name);

--- a/Source/Core/DiscIO/NANDImporter.cpp
+++ b/Source/Core/DiscIO/NANDImporter.cpp
@@ -34,10 +34,9 @@ void NANDImporter::ImportNANDBin(const std::string& path_to_bin,
   if (!ReadNANDBin(path_to_bin, get_otp_dump_path))
     return;
 
-  const std::string nand_root = File::GetUserPath(D_WIIROOT_IDX);
+  std::string nand_root = File::GetUserPath(D_WIIROOT_IDX);
+  nand_root.pop_back();  // remove trailing path separator
   m_nand_root_length = nand_root.length();
-  if (nand_root.back() == '/')
-    m_nand_root_length++;
 
   FindSuperblock();
   ProcessEntry(0, nand_root);

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -54,7 +54,7 @@ namespace UICommon
 static void CreateDumpPath(const std::string& path)
 {
   if (!path.empty())
-    File::SetUserPath(D_DUMP_IDX, path + '/');
+    File::SetUserPath(D_DUMP_IDX, path);
   File::CreateFullPath(File::GetUserPath(D_DUMPAUDIO_IDX));
   File::CreateFullPath(File::GetUserPath(D_DUMPDSP_IDX));
   File::CreateFullPath(File::GetUserPath(D_DUMPSSL_IDX));
@@ -66,7 +66,7 @@ static void CreateDumpPath(const std::string& path)
 static void CreateLoadPath(const std::string& path)
 {
   if (!path.empty())
-    File::SetUserPath(D_LOAD_IDX, path + '/');
+    File::SetUserPath(D_LOAD_IDX, path);
   File::CreateFullPath(File::GetUserPath(D_HIRESTEXTURES_IDX));
   File::CreateFullPath(File::GetUserPath(D_RIIVOLUTION_IDX));
 }
@@ -74,7 +74,7 @@ static void CreateLoadPath(const std::string& path)
 static void CreateResourcePackPath(const std::string& path)
 {
   if (!path.empty())
-    File::SetUserPath(D_RESOURCEPACK_IDX, path + '/');
+    File::SetUserPath(D_RESOURCEPACK_IDX, path);
 }
 
 static void CreateWFSPath(const std::string& path)
@@ -217,7 +217,7 @@ void SetUserDirectory(const std::string& custom_path)
   if (!custom_path.empty())
   {
     File::CreateFullPath(custom_path + DIR_SEP);
-    File::SetUserPath(D_USER_IDX, custom_path + DIR_SEP);
+    File::SetUserPath(D_USER_IDX, custom_path);
     return;
   }
 
@@ -281,15 +281,6 @@ void SetUserDirectory(const std::string& custom_path)
     user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
 
   CoTaskMemFree(my_documents);
-
-  // Prettify the path: it will be displayed in some places, we don't want a mix
-  // of \ and /.
-  user_path = ReplaceAll(std::move(user_path), "\\", DIR_SEP);
-
-  // Make sure it ends in DIR_SEP.
-  if (user_path.back() != DIR_SEP_CHR)
-    user_path += DIR_SEP;
-
 #else
   if (File::IsDirectory(ROOT_DIR DIR_SEP USERDATA_DIR))
   {

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -51,10 +51,10 @@
 
 namespace UICommon
 {
-static void CreateDumpPath(const std::string& path)
+static void CreateDumpPath(std::string path)
 {
   if (!path.empty())
-    File::SetUserPath(D_DUMP_IDX, path);
+    File::SetUserPath(D_DUMP_IDX, std::move(path));
   File::CreateFullPath(File::GetUserPath(D_DUMPAUDIO_IDX));
   File::CreateFullPath(File::GetUserPath(D_DUMPDSP_IDX));
   File::CreateFullPath(File::GetUserPath(D_DUMPSSL_IDX));
@@ -63,18 +63,18 @@ static void CreateDumpPath(const std::string& path)
   File::CreateFullPath(File::GetUserPath(D_DUMPTEXTURES_IDX));
 }
 
-static void CreateLoadPath(const std::string& path)
+static void CreateLoadPath(std::string path)
 {
   if (!path.empty())
-    File::SetUserPath(D_LOAD_IDX, path);
+    File::SetUserPath(D_LOAD_IDX, std::move(path));
   File::CreateFullPath(File::GetUserPath(D_HIRESTEXTURES_IDX));
   File::CreateFullPath(File::GetUserPath(D_RIIVOLUTION_IDX));
 }
 
-static void CreateResourcePackPath(const std::string& path)
+static void CreateResourcePackPath(std::string path)
 {
   if (!path.empty())
-    File::SetUserPath(D_RESOURCEPACK_IDX, path);
+    File::SetUserPath(D_RESOURCEPACK_IDX, std::move(path));
 }
 
 static void CreateWFSPath(const std::string& path)
@@ -212,12 +212,12 @@ void CreateDirectories()
 #endif
 }
 
-void SetUserDirectory(const std::string& custom_path)
+void SetUserDirectory(std::string custom_path)
 {
   if (!custom_path.empty())
   {
     File::CreateFullPath(custom_path + DIR_SEP);
-    File::SetUserPath(D_USER_IDX, custom_path);
+    File::SetUserPath(D_USER_IDX, std::move(custom_path));
     return;
   }
 

--- a/Source/Core/UICommon/UICommon.h
+++ b/Source/Core/UICommon/UICommon.h
@@ -23,7 +23,7 @@ void InhibitScreenSaver(bool enable);
 void SetLocale(std::string locale_name);
 
 void CreateDirectories();
-void SetUserDirectory(const std::string& custom_path);
+void SetUserDirectory(std::string custom_path);
 
 bool TriggerSTMPowerEvent();
 


### PR DESCRIPTION
That is:
- All path separators are forward slashes.
- Directory paths end with a separator.
- File paths do not end with a separator.