### PR TITLE
Delay singlecore gpu interrupts; Fixes Bomberman Jetters in single core mode.

### DIFF
--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -2205,7 +2205,7 @@ struct BPMemory
 
 extern BPMemory bpmem;
 
-void LoadBPReg(u32 value0);
-void LoadBPRegPreprocess(u32 value0);
+void LoadBPReg(u32 value0, int cycles_into_future);
+void LoadBPRegPreprocess(u32 value0, int cycles_into_future);
 
 std::pair<std::string, std::string> GetBPRegInfo(u8 cmd, u32 cmddata);

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -221,11 +221,11 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
         const u32 bp_cmd = src.Read<u32>();
         if constexpr (is_preprocess)
         {
-          LoadBPRegPreprocess(bp_cmd);
+          LoadBPRegPreprocess(bp_cmd, total_cycles);
         }
         else
         {
-          LoadBPReg(bp_cmd);
+          LoadBPReg(bp_cmd, total_cycles);
           INCSTAT(g_stats.this_frame.num_bp_loads);
         }
       }

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -277,7 +277,7 @@ static void SetTokenFinish_OnMainThread(u64 userdata, s64 cyclesLate)
 // Raise the event handler above on the CPU thread.
 // s_token_finish_mutex must be locked.
 // THIS IS EXECUTED FROM VIDEO THREAD
-static void RaiseEvent()
+static void RaiseEvent(int cycles_into_future)
 {
   if (s_event_raised)
     return;
@@ -285,14 +285,21 @@ static void RaiseEvent()
   s_event_raised = true;
 
   CoreTiming::FromThread from = CoreTiming::FromThread::NON_CPU;
+  s64 cycles = 0;  // we don't care about timings for dual core mode.
   if (!SConfig::GetInstance().bCPUThread || Fifo::UseDeterministicGPUThread())
+  {
     from = CoreTiming::FromThread::CPU;
-  CoreTiming::ScheduleEvent(0, et_SetTokenFinishOnMainThread, 0, from);
+
+    // Hack: Dolphin's single-core gpu timings are way too fast. Enforce a minimum delay to give
+    //       games time to setup any interrupt state
+    cycles = std::max(500, cycles_into_future);
+  }
+  CoreTiming::ScheduleEvent(cycles, et_SetTokenFinishOnMainThread, 0, from);
 }
 
 // SetToken
 // THIS IS EXECUTED FROM VIDEO THREAD
-void SetToken(const u16 token, const bool interrupt)
+void SetToken(const u16 token, const bool interrupt, int cycles_into_future)
 {
   DEBUG_LOG_FMT(PIXELENGINE, "VIDEO Backend raises INT_CAUSE_PE_TOKEN (btw, token: {:04x})", token);
 
@@ -301,12 +308,12 @@ void SetToken(const u16 token, const bool interrupt)
   s_token_pending = token;
   s_token_interrupt_pending |= interrupt;
 
-  RaiseEvent();
+  RaiseEvent(cycles_into_future);
 }
 
 // SetFinish
 // THIS IS EXECUTED FROM VIDEO THREAD (BPStructs.cpp) when a new frame has been drawn
-void SetFinish()
+void SetFinish(int cycles_into_future)
 {
   DEBUG_LOG_FMT(PIXELENGINE, "VIDEO Set Finish");
 
@@ -314,7 +321,7 @@ void SetFinish()
 
   s_finish_interrupt_pending |= true;
 
-  RaiseEvent();
+  RaiseEvent(cycles_into_future);
 }
 
 UPEAlphaReadReg GetAlphaReadMode()

--- a/Source/Core/VideoCommon/PixelEngine.h
+++ b/Source/Core/VideoCommon/PixelEngine.h
@@ -61,8 +61,8 @@ void DoState(PointerWrap& p);
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
 // gfx backend support
-void SetToken(const u16 token, const bool interrupt);
-void SetFinish();
+void SetToken(const u16 token, const bool interrupt, int cycle_delay);
+void SetFinish(int cycle_delay);
 UPEAlphaReadReg GetAlphaReadMode();
 
 }  // namespace PixelEngine


### PR DESCRIPTION
Fixes Bomberman Jetters in single core mode.

When single core mode pauses the CPU to execute the GPU
FIFO it greedily executes the whole thing. Before this commit,
Finish and Token interrupts would happen instantly, not even
taking into account how long the current FIFO window has
taken to execute. The interrupts would be effectively backdated
to the start of this execution window.

This commit does two things: It pipes the current FIFO window
execution time though to the interrupt scheduling and it enforces
a minimum delay of 500 cycles before an interrupt will be fired.