### PR TITLE
Fix saving RGBA images

### DIFF
--- a/Source/Core/Common/Image.cpp
+++ b/Source/Core/Common/Image.cpp
@@ -68,18 +68,19 @@ bool SavePNG(const std::string& path, const u8* input, ImageByteFormat format, u
   timer.Start();
 
   size_t byte_per_pixel;
-  int png_format;
+  int color_type;
   switch (format)
   {
   case ImageByteFormat::RGB:
-    png_format = PNG_FORMAT_RGB;
+    color_type = PNG_COLOR_TYPE_RGB;
     byte_per_pixel = 3;
     break;
   case ImageByteFormat::RGBA:
-    png_format = PNG_FORMAT_RGBA;
+    color_type = PNG_COLOR_TYPE_RGBA;
     byte_per_pixel = 4;
     break;
   default:
+    ASSERT_MSG(FRAMEDUMP, false, "Invalid format %d", static_cast<int>(format));
     return false;
   }
 
@@ -110,7 +111,7 @@ bool SavePNG(const std::string& path, const u8* input, ImageByteFormat format, u
   bool success = false;
   if (png_ptr != nullptr && info_ptr != nullptr)
   {
-    success = SavePNG0(png_ptr, info_ptr, png_format, width, height, level, &buffer, WriteCallback,
+    success = SavePNG0(png_ptr, info_ptr, color_type, width, height, level, &buffer, WriteCallback,
                        const_cast<u8**>(rows.data()));
   }
   png_destroy_write_struct(&png_ptr, &info_ptr);

--- a/Source/Core/Common/ImageC.c
+++ b/Source/Core/Common/ImageC.c
@@ -25,3 +25,19 @@ bool SavePNG0(png_structp png_ptr, png_infop info_ptr, int png_format, png_uint_
 
   return true;
 }
+
+// pngerror.c says: "Note that the error function MUST NOT return to the calling routine or serious
+// problems will occur.  The return method used in the default routine calls
+// longjmp(png_ptr->jmp_buf_ptr, 1)"
+void PngError(png_structp png_ptr, png_const_charp msg)
+{
+  struct ErrorHandler* error_logger = (struct ErrorHandler*)png_get_error_ptr(png_ptr);
+  error_logger->StoreError(error_logger, msg);
+  png_longjmp(png_ptr, 1);
+}
+
+void PngWarning(png_structp png_ptr, png_const_charp msg)
+{
+  struct ErrorHandler* error_logger = (struct ErrorHandler*)png_get_error_ptr(png_ptr);
+  error_logger->StoreWarning(error_logger, msg);
+}

--- a/Source/Core/Common/ImageC.c
+++ b/Source/Core/Common/ImageC.c
@@ -9,7 +9,7 @@
 // The main purpose of this function is to allow specifying the compression level, which
 // png_image_write_to_memory does not allow.  row_pointers is not modified by libpng, but also isn't
 // const for some reason.
-bool SavePNG0(png_structp png_ptr, png_infop info_ptr, int png_format, png_uint_32 width,
+bool SavePNG0(png_structp png_ptr, png_infop info_ptr, int color_type, png_uint_32 width,
               png_uint_32 height, int level, png_voidp io_ptr, png_rw_ptr write_fn,
               png_bytepp row_pointers)
 {
@@ -17,7 +17,7 @@ bool SavePNG0(png_structp png_ptr, png_infop info_ptr, int png_format, png_uint_
     return false;
 
   png_set_compression_level(png_ptr, level);
-  png_set_IHDR(png_ptr, info_ptr, width, height, 8, png_format, PNG_INTERLACE_NONE,
+  png_set_IHDR(png_ptr, info_ptr, width, height, 8, color_type, PNG_INTERLACE_NONE,
                PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
   png_set_rows(png_ptr, info_ptr, row_pointers);
   png_set_write_fn(png_ptr, io_ptr, write_fn, NULL);

--- a/Source/Core/Common/ImageC.h
+++ b/Source/Core/Common/ImageC.h
@@ -7,9 +7,23 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
-    bool
-    SavePNG0(png_structp png_ptr, png_infop info_ptr, int png_format, png_uint_32 width,
-             png_uint_32 height, int level, png_voidp io_ptr, png_rw_ptr write_fn,
-             png_bytepp row_pointers);
+struct ErrorHandler
+{
+  void* error_list;    // std::vector<std::string>*
+  void* warning_list;  // std::vector<std::string>*
+  void (*StoreError)(struct ErrorHandler* self, const char* msg);
+  void (*StoreWarning)(struct ErrorHandler* self, const char* msg);
+};
+
+bool SavePNG0(png_structp png_ptr, png_infop info_ptr, int png_format, png_uint_32 width,
+              png_uint_32 height, int level, png_voidp io_ptr, png_rw_ptr write_fn,
+              png_bytepp row_pointers);
+
+void PngError(png_structp png_ptr, png_const_charp msg);
+void PngWarning(png_structp png_ptr, png_const_charp msg);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Source/Core/Common/ImageC.h
+++ b/Source/Core/Common/ImageC.h
@@ -17,7 +17,7 @@ struct ErrorHandler
   void (*StoreWarning)(struct ErrorHandler* self, const char* msg);
 };
 
-bool SavePNG0(png_structp png_ptr, png_infop info_ptr, int png_format, png_uint_32 width,
+bool SavePNG0(png_structp png_ptr, png_infop info_ptr, int color_type, png_uint_32 width,
               png_uint_32 height, int level, png_voidp io_ptr, png_rw_ptr write_fn,
               png_bytepp row_pointers);
 


### PR DESCRIPTION
Fixes [broken texture dumping](https://forums.dolphin-emu.org/Thread-texture-dumping).

`PNG_FORMAT_RGB` and `PNG_COLOR_TYPE_RGB` both evaluate to 2, but `PNG_FORMAT_RGBA` evaluates to 3 while `PNG_COLOR_TYPE_RGBA` evaluates to 6; the bit indicating a palette is 1 while the bit indicating alpha is 4.

This generates an error, but because the default libpng error handler logs to stderr, it wasn't seen.  I've also added custom error handlers that put it into Dolphin's logging system.  With that, the following message now showed up (prior to fixing the above issue):

```
30:33:346 Common\Image.cpp:140 E[FRAMEDUMP]: Failed to save 852 by 480 image to C:/Users/Pokechu22/Documents/Dolphin Emulator/Dump/Textures/OHBCHB/tex1_852x480_502591290a4f95cd_6.png at level 6: 0 warnings, 1 errors
30:33:346 Common\Image.cpp:142 E[FRAMEDUMP]: libpng error: Valid palette required for paletted images
```