### PR TITLE
Game INI updates

### DIFF
--- a/Data/Sys/GameSettings/GED.ini
+++ b/Data/Sys/GameSettings/GED.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-GPUDeterminismMode = fake-completion
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -13,6 +13,8 @@ GPUDeterminismMode = fake-completion
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+XFBToTextureEnable = False
+
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-

--- a/Data/Sys/GameSettings/S2E.ini
+++ b/Data/Sys/GameSettings/S2E.ini
@@ -13,5 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-MaxAnisotropy = 0
 ForceFiltering = False

--- a/Data/Sys/GameSettings/S5D.ini
+++ b/Data/Sys/GameSettings/S5D.ini
@@ -1,4 +1,19 @@
 # S5DE41, S5DP41 - Just Dance Disney Party 2 
 
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Enhancements]
+ForceFiltering = False
+
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SD2.ini
+++ b/Data/Sys/GameSettings/SD2.ini
@@ -12,9 +12,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
 [Video_Enhancements]
-MaxAnisotropy = 0
 ForceFiltering = False
+
+[Video_Hacks]
+FastTextureSampling = False

--- a/Data/Sys/GameSettings/SD2J01.ini
+++ b/Data/Sys/GameSettings/SD2J01.ini
@@ -15,9 +15,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
 [Video_Enhancements]
-MaxAnisotropy = 0
 ForceFiltering = False
+
+[Video_Hacks]
+FastTextureSampling = False

--- a/Data/Sys/GameSettings/SDN.ini
+++ b/Data/Sys/GameSettings/SDN.ini
@@ -13,5 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-MaxAnisotropy = 0
 ForceFiltering = False
+
+[Video_Hacks]
+FastTextureSampling = False

--- a/Data/Sys/GameSettings/SDZ.ini
+++ b/Data/Sys/GameSettings/SDZ.ini
@@ -1,4 +1,5 @@
-# SJDE41, SJDP41, SJDX41, SJDY41, SJDZ41 - Just Dance 3
+# SDZE41 - Just Dance Kids
+# SDZP41 - Dance Juniors [Europe]
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -14,6 +15,3 @@
 
 [Video_Enhancements]
 ForceFiltering = False
-
-[Video_Hacks]
-FastTextureSampling = False

--- a/Data/Sys/GameSettings/SEP.ini
+++ b/Data/Sys/GameSettings/SEP.ini
@@ -1,4 +1,4 @@
-# SJDE41, SJDP41, SJDX41, SJDY41, SJDZ41 - Just Dance 3
+# SEPE41, SEPP41, SEPX41, SEPZ41 - The Black Eyed Peas Experience
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -14,6 +14,3 @@
 
 [Video_Enhancements]
 ForceFiltering = False
-
-[Video_Hacks]
-FastTextureSampling = False

--- a/Data/Sys/GameSettings/SER.ini
+++ b/Data/Sys/GameSettings/SER.ini
@@ -12,6 +12,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Enhancements]
+ForceFiltering = False
+
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
-

--- a/Data/Sys/GameSettings/SJ6.ini
+++ b/Data/Sys/GameSettings/SJ6.ini
@@ -1,4 +1,4 @@
-# SJDE41, SJDP41, SJDX41, SJDY41, SJDZ41 - Just Dance 3
+# SJ6E41, SJ6P41 - Just Dance Disney Party
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -15,5 +15,5 @@
 [Video_Enhancements]
 ForceFiltering = False
 
-[Video_Hacks]
-FastTextureSampling = False
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SJ7.ini
+++ b/Data/Sys/GameSettings/SJ7.ini
@@ -1,4 +1,4 @@
-# SJDE41, SJDP41, SJDX41, SJDY41, SJDZ41 - Just Dance 3
+# SJ7E41, SJ7P41 - Just Dance Kids 2014
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -15,5 +15,5 @@
 [Video_Enhancements]
 ForceFiltering = False
 
-[Video_Hacks]
-FastTextureSampling = False
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SJ9.ini
+++ b/Data/Sys/GameSettings/SJ9.ini
@@ -1,4 +1,5 @@
-# SJDE41, SJDP41, SJDX41, SJDY41, SJDZ41 - Just Dance 3
+# SJ9E41 - Just Dance Summer Party
+# SJ9P41 - Just Dance 2 Extra Songs [Europe]
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/SJDJ01.ini
+++ b/Data/Sys/GameSettings/SJDJ01.ini
@@ -15,9 +15,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
 [Video_Enhancements]
-MaxAnisotropy = 0
 ForceFiltering = False
+
+[Video_Hacks]
+FastTextureSampling = False

--- a/Data/Sys/GameSettings/SJHE41.ini
+++ b/Data/Sys/GameSettings/SJHE41.ini
@@ -1,4 +1,4 @@
-# SJDE41, SJDP41, SJDX41, SJDY41, SJDZ41 - Just Dance 3
+# SJHE41 - Just Dance Greatest Hits
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/SJTP41.ini
+++ b/Data/Sys/GameSettings/SJTP41.ini
@@ -1,4 +1,4 @@
-# SJDE41, SJDP41, SJDX41, SJDY41, SJDZ41 - Just Dance 3
+# SJTP41 - Just Dance: Best Of
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/SJZ.ini
+++ b/Data/Sys/GameSettings/SJZ.ini
@@ -1,4 +1,5 @@
-# SJDE41, SJDP41, SJDX41, SJDY41, SJDZ41 - Just Dance 3
+# SJZE41 - Just Dance Kids 2
+# SJZP41 - Just Dance Kids [Europe]
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -15,5 +16,5 @@
 [Video_Enhancements]
 ForceFiltering = False
 
-[Video_Hacks]
-FastTextureSampling = False
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SMO.ini
+++ b/Data/Sys/GameSettings/SMO.ini
@@ -13,5 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-MaxAnisotropy = 0
 ForceFiltering = False

--- a/Data/Sys/GameSettings/SUO.ini
+++ b/Data/Sys/GameSettings/SUO.ini
@@ -1,4 +1,4 @@
-# SJDE41, SJDP41, SJDX41, SJDY41, SJDZ41 - Just Dance 3
+# SUOE41, SUOP41 - The Hip Hop Dance Experience
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -14,6 +14,3 @@
 
 [Video_Enhancements]
 ForceFiltering = False
-
-[Video_Hacks]
-FastTextureSampling = False


### PR DESCRIPTION
This PR provides a small batch of Game INI updates:

* **ABBA: You Can Dance and Michael Jackson: The Experience:** removed Anisotropic Filtering override as it doesn't cause visual glitches anymore.

* **Epic Mickey 2, Just Dance Kids, The Black Eyed Peas Experience, The Hip Hop Dance Experience:** disabled "Force Texture Filtering" to avoid FMV corruption.

* **Eternal Darkness:** replaced Deterministic GPU with Single Core mode and disabled "Store XFB Copies to Texture Only". Single Core fixes both the game hang after the Edgar Allan Poe quote as well as the aspect ratio distortion when entering/exiting the pause menu (Determinist GPU only prevented the hang), while "Store XFB Copies to Texture Only" fixes the purple transitions at the start/end of a chapter.

* **Just Dance 1, 2, 3, Best Of, Greatest Hits, Summer Party, Wii and Wii 2:** removed Safe Texture Cache and Anisotropic Filtering overrides as they don't cause visual glitches anymore. Enabled "Manual Texture Sampling" as it fixes vertical lines on dancers and loading screens (Just Dance 2, Wii and Summer Party are still affected but this option makes the lines less noticeable).

* **Just Dance Disney Party, Disney Party 2, Kids 2 and Kids 2014:** disabled "Force Texture Filtering" to avoid FMV corruption and enabled Safe Texture Cache to fix missing text and stuttery video playback.