### PR TITLE
Fix default input config default device not being loaded/found

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -319,6 +319,13 @@ void MainWindow::InitControllers()
     return;
 
   g_controller_interface.Initialize(GetWindowSystemInfo(windowHandle()));
+  if (!g_controller_interface.HasDefaultDevice())
+  {
+    // Note that the CI default device could be still temporarily removed at any time
+    WARN_LOG(CONTROLLERINTERFACE,
+             "No default device has been added in time. EmulatedController(s) defaulting adds"
+             " input mappings made for a specific default device depending on the platform");
+  }
   Pad::Initialize();
   Pad::InitializeGBA();
   Keyboard::Initialize();

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -159,6 +159,10 @@ void ControllerInterface::RefreshDevices(RefreshReason reason)
   // with their own PlatformPopulateDevices().
   // This means that devices might end up in different order, unless we override their priority.
   // It also means they might appear as "disconnected" in the Qt UI for a tiny bit of time.
+  // This helps the emulation and host thread to not stall when repopulating devices for any reason.
+  // Every platform that adds a device that is meant to be used as default device should try to not
+  // do it async, to not risk the emulated controllers default config loading not finding a default
+  // device.
 
 #ifdef CIFACE_USE_WIN32
   ciface::Win32::PopulateDevices(m_wsi.render_window);

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -258,10 +258,18 @@ std::vector<std::string> DeviceContainer::GetAllDeviceStrings() const
   return device_strings;
 }
 
+bool DeviceContainer::HasDefaultDevice() const
+{
+  std::lock_guard lk(m_devices_mutex);
+  // Devices are already sorted by priority
+  return !m_devices.empty() && m_devices[0]->GetSortPriority() >= 0;
+}
+
 std::string DeviceContainer::GetDefaultDeviceString() const
 {
   std::lock_guard lk(m_devices_mutex);
-  if (m_devices.empty())
+  // Devices are already sorted by priority
+  if (m_devices.empty() || m_devices[0]->GetSortPriority() < 0)
     return "";
 
   DeviceQualifier device_qualifier;

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -136,6 +136,7 @@ public:
   // Use this to change the order in which devices are sorted in their list.
   // A higher priority means it will be one of the first ones (smaller index), making it more
   // likely to be index 0, which is automatically set as the default device when there isn't one.
+  // Every platform should have at least one device with priority >= 0.
   virtual int GetSortPriority() const { return 0; }
 
   const std::vector<Input*>& Inputs() const { return m_inputs; }
@@ -226,6 +227,7 @@ public:
   Device::Output* FindOutput(std::string_view name, const Device* def_dev) const;
 
   std::vector<std::string> GetAllDeviceStrings() const;
+  bool HasDefaultDevice() const;
   std::string GetDefaultDeviceString() const;
   std::shared_ptr<Device> FindDevice(const DeviceQualifier& devq) const;
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
@@ -64,6 +64,7 @@ public:
 
   std::string GetName() const override;
   std::string GetSource() const override;
+  int GetSortPriority() const override { return -2; }
 
   bool IsValid() const final override;
 

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -136,7 +136,7 @@ public:
   std::string GetSource() const final override;
   std::optional<int> GetPreferredId() const final override;
   // Always add these at the end, given their hotplug nature
-  int GetSortPriority() const override { return -2; }
+  int GetSortPriority() const override { return -4; }
 
 private:
   void ResetPadData();

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
@@ -323,7 +323,7 @@ std::string Device::GetSource() const
 // Always add these at the end, given their hotplug nature
 int Device::GetSortPriority() const
 {
-  return -1;
+  return -3;
 }
 
 void Device::RunTasks()

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
@@ -31,6 +31,7 @@ public:
   std::string GetName() const override;
   std::string GetSource() const override;
   std::optional<int> GetPreferredId() const override;
+  int GetSortPriority() const override { return -1; }
 
   void UpdateInput() override;
 


### PR DESCRIPTION
Fixes bug: https://bugs.dolphin-emu.org/issues/12744

Before https://github.com/dolphin-emu/dolphin/commit/e1e3db13baabefa89991388d37db0bb260c4f535 the ControllerInterface m_devices_mutex was "wrongfully" locked for the whole Initialize() call, which included the first device population refresh, this has the unwanted (accidental) consequence of often preventing the different pads (GC Pad, Wii Contollers, ...) input configs from loading until that mutex was released (the input config defaults loading was blocked in EmulatedController::LoadDefaults()), which meant that the devices population would often have the time to finish adding its first device, which would then be selected as default device (by design, the first device added to the CI is the default default device, usually the "Keyboard and Mouse" device).

After the commit mentioned above removed the unnecessary m_devices_mutex calls, the default default device would fail to load (be found) causing the default input mappings, which are specifically written for the default default device on every platform, to not be bound to any physical device input, breaking input on new dolphin installations (until a user tried to customize the default device manually).

Default devices are now always added synchronously to avoid the problem, and so they should in the future (I added comments and warnings to help with that).
The only one which was async was the Windows "Keyboard and Mouse" device, and I took care of that. I also changed devices sorting order to be clearer (and avoid other devices accidental ending up as default) (the sorting order only affect the Qt devices list order and nothing else). 