### PR TITLE
TASInputWindow: Shrink width for stick input slider value boxes

### DIFF
--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -86,11 +86,12 @@ QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, Q
   auto* x_layout = new QHBoxLayout;
   x_value = CreateSliderValuePair(x_layout, x_default, max_x, x_shortcut_key_sequence,
                                   Qt::Horizontal, box);
+  x_value->setMaximumWidth(40);
 
   auto* y_layout = new QVBoxLayout;
   y_value =
       CreateSliderValuePair(y_layout, y_default, max_y, y_shortcut_key_sequence, Qt::Vertical, box);
-  y_value->setMaximumWidth(60);
+  y_value->setMaximumWidth(40);
 
   auto* visual = new StickWidget(this, max_x, max_y);
   visual->SetX(x_default);


### PR DESCRIPTION
The value boxes for TAS Input stick sliders was unnecessarily wide, which would cause the aspect_ratio widget containing the stick to be severely restricted in size... Thus, this change ends up making the stick a lot bigger.

![image](https://user-images.githubusercontent.com/16770560/143966143-d6c859a1-b4a2-440a-8a33-ebd56effca9c.png)
