### PR TITLE
Renderbase: Show rerecord count

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -256,6 +256,7 @@ void SConfig::SaveMovieSettings(IniFile& ini)
   movie->Set("DumpFramesSilent", m_DumpFramesSilent);
   movie->Set("ShowInputDisplay", m_ShowInputDisplay);
   movie->Set("ShowRTC", m_ShowRTC);
+  movie->Set("ShowRerecord", m_ShowRerecord);
 }
 
 void SConfig::SaveInputSettings(IniFile& ini)
@@ -503,6 +504,7 @@ void SConfig::LoadMovieSettings(IniFile& ini)
   movie->Get("DumpFramesSilent", &m_DumpFramesSilent, false);
   movie->Get("ShowInputDisplay", &m_ShowInputDisplay, false);
   movie->Get("ShowRTC", &m_ShowRTC, false);
+  movie->Get("ShowRerecord", &m_ShowRerecord, false);
 }
 
 void SConfig::LoadInputSettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -268,6 +268,7 @@ struct SConfig
 
   std::string m_WirelessMac;
   bool m_PauseMovie;
+  bool m_ShowRerecord;
   bool m_ShowLag;
   bool m_ShowFrameCount;
   bool m_ShowRTC;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -202,6 +202,15 @@ std::string GetRTCDisplay()
   return format_time.str();
 }
 
+// NOTE: GPU Thread
+std::string GetRerecords()
+{
+  if (IsMovieActive())
+    return fmt::format("Rerecords: {}", s_rerecords);
+
+  return "Rerecords: N/A";
+}
+
 void FrameUpdate()
 {
   s_currentFrame++;

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -200,6 +200,7 @@ void CheckWiimoteStatus(int wiimote, const WiimoteCommon::DataReportBuilder& rpt
 
 std::string GetInputDisplay();
 std::string GetRTCDisplay();
+std::string GetRerecords();
 
 // Done this way to avoid mixing of core and gui code
 using GCManipFunction = std::function<void(GCPadStatus*, int)>;

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -756,6 +756,12 @@ void MenuBar::AddMovieMenu()
   connect(pause_at_end, &QAction::toggled,
           [](bool value) { SConfig::GetInstance().m_PauseMovie = value; });
 
+  auto* rerecord_counter = movie_menu->addAction(tr("Show Rerecord Counter"));
+  rerecord_counter->setCheckable(true);
+  rerecord_counter->setChecked(SConfig::GetInstance().m_ShowRerecord);
+  connect(rerecord_counter, &QAction::toggled,
+          [](bool value) { SConfig::GetInstance().m_ShowRerecord = value; });
+
   auto* lag_counter = movie_menu->addAction(tr("Show Lag Counter"));
   lag_counter->setCheckable(true);
   lag_counter->setChecked(SConfig::GetInstance().m_ShowLag);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -575,8 +575,9 @@ void Renderer::DrawDebugText()
     ImGui::End();
   }
 
-  const bool show_movie_window =
-      config.m_ShowFrameCount | config.m_ShowLag | config.m_ShowInputDisplay | config.m_ShowRTC;
+  const bool show_movie_window = config.m_ShowFrameCount | config.m_ShowLag |
+                                 config.m_ShowInputDisplay | config.m_ShowRTC |
+                                 config.m_ShowRerecord;
   if (show_movie_window)
   {
     // Position under the FPS display.
@@ -606,6 +607,8 @@ void Renderer::DrawDebugText()
         ImGui::TextUnformatted(Movie::GetInputDisplay().c_str());
       if (SConfig::GetInstance().m_ShowRTC)
         ImGui::TextUnformatted(Movie::GetRTCDisplay().c_str());
+      if (SConfig::GetInstance().m_ShowRerecord)
+        ImGui::TextUnformatted(Movie::GetRerecords().c_str());
     }
     ImGui::End();
   }


### PR DESCRIPTION
This PR adds a "Show Rerecord Count" toggle under the Movie menu. When enabled, this causes the RenderBase to show `s_rerecords` in the Movie window.

Note that the rerecord count will show 0 if a movie is not being recorded or playing back. I'm curious if anyone has any thoughts about if this should be hidden? Perhaps check for if `IsMovieActive()`? Or perhaps if the rerecord count doesn't update, it's a healthy reminder to TASers that they aren't actively recording a movie (I sometimes accidentally forget to check if I am in read-only mode or not).