### PR TITLE
BS2Emu: Stop clearing the RTC flags

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -461,8 +461,13 @@ bool CBoot::EmulatedBS2_Wii(const DiscIO::VolumeDisc& volume,
     state->discstate = 0x01;
   });
 
-  // The system menu clears the RTC flags
-  ExpansionInterface::g_rtc_flags.m_hex = 0;
+  // The system menu clears the RTC flags.
+  // However, the system menu also updates the disc cache when this happens; see
+  // https://wiibrew.org/wiki/MX23L4005#DI and
+  // https://wiibrew.org/wiki//title/00000001/00000002/data/cache.dat for details. If we clear the
+  // RTC flags, then the system menu thinks the disc cache is up to date, and will show the wrong
+  // disc in the disc channel (and reboot the first time the disc is opened)
+  // ExpansionInterface::g_rtc_flags.m_hex = 0;
 
   // While reading a disc, the system menu reads the first partition table
   // (0x20 bytes from 0x00040020) and stores a pointer to the data partition entry.


### PR DESCRIPTION
The system menu does clear the RTC flags, but we currently aren't updating the cache file, and since we clear them the system menu doesn't know to update the cache either.  This means that launching a game via the system menu, and then launching a game directly and exiting via HOME will result in the system menu using an outdated cache and displaying the old game.  This causes it to fail to launch the game on the disc channel (since it doesn't match the cache), resulting in it resetting (though it will ignore the cache after resetting).  Not clearing the cache avoids this issue.