### PR TITLE
FifoPlayer: Clear EFB before starting playback

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -123,6 +123,7 @@ private:
   void LoadMemory();
   void LoadRegisters();
   void LoadTextureMemory();
+  void ClearEfb();
 
   void WriteCP(u32 address, u16 value);
   void WritePI(u32 address, u32 value);


### PR DESCRIPTION
This fixes the bad rendering on the first frame when using the software renderer: the software renderer's Z buffer started out at 0, but most games clear it to 0xffffff instead; this means that things don't render correctly except for in the regions where the screen was cleared by an EFB copy earlier in the frame.