### PR TITLE
SoftwareRasterizer: Timings + Earlier depth

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -98,6 +98,7 @@ const Info<bool> GFX_SW_DUMP_TEV_TEX_FETCHES{{System::GFX, "Settings", "SWDumpTe
                                              false};
 const Info<int> GFX_SW_DRAW_START{{System::GFX, "Settings", "SWDrawStart"}, 0};
 const Info<int> GFX_SW_DRAW_END{{System::GFX, "Settings", "SWDrawEnd"}, 100000};
+const Info<bool> GFX_SW_NO_RAST_TIMINGS{{System::GFX, "Settings", "SWNoCycleCount"}, false};
 
 const Info<bool> GFX_PREFER_GLES{{System::GFX, "Settings", "PreferGLES"}, false};
 

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -79,6 +79,7 @@ extern const Info<bool> GFX_SW_DUMP_TEV_STAGES;
 extern const Info<bool> GFX_SW_DUMP_TEV_TEX_FETCHES;
 extern const Info<int> GFX_SW_DRAW_START;
 extern const Info<int> GFX_SW_DRAW_END;
+extern const Info<bool> GFX_SW_NO_RAST_TIMINGS;
 
 extern const Info<bool> GFX_PREFER_GLES;
 

--- a/Source/Core/DolphinQt/Config/Graphics/SoftwareRendererWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/SoftwareRendererWidget.cpp
@@ -70,6 +70,13 @@ void SoftwareRendererWidget::CreateWidgets()
   utility_layout->addWidget(m_dump_textures, 1, 1);
   utility_layout->addWidget(m_dump_objects, 1, 2);
 
+  auto* hacks_box = new QGroupBox(tr("Hacks"));
+  auto* hacks_layout = new QGridLayout();
+  m_no_rast_timings =
+      new GraphicsBool(tr("Disable Rasterizer Timings"), Config::GFX_SW_NO_RAST_TIMINGS);
+  hacks_box->setLayout(hacks_layout);
+  hacks_layout->addWidget(m_no_rast_timings, 1, 1);
+
   auto* debug_box = new QGroupBox(tr("Debug Only"));
   auto* debug_layout = new QGridLayout();
   m_dump_tev_stages = new GraphicsBool(tr("Dump TEV Stages"), Config::GFX_SW_DUMP_TEV_STAGES);
@@ -104,6 +111,7 @@ void SoftwareRendererWidget::CreateWidgets()
   main_layout->addWidget(rendering_box);
   main_layout->addWidget(overlay_box);
   main_layout->addWidget(utility_box);
+  main_layout->addWidget(hacks_box);
   main_layout->addWidget(object_range_box);
   main_layout->addStretch();
 
@@ -164,6 +172,9 @@ void SoftwareRendererWidget::AddDescriptions()
   static const char TR_SHOW_STATISTICS_DESCRIPTION[] =
       QT_TR_NOOP("Show various rendering statistics.<br><br><dolphin_emphasis>If unsure, leave "
                  "this unchecked.</dolphin_emphasis>");
+  static const char TR_NO_CYCLE_COUNT_DESCRIPTION[] =
+      QT_TR_NOOP("Force the software renderer to use the same inaccurate timings as the hardware "
+                 "backends. <br><br><dolphin_emphasis>If unsure, leave this unchecked");
   static const char TR_DUMP_TEXTURES_DESCRIPTION[] =
       QT_TR_NOOP("Dump decoded game textures to "
                  "User/Dump/Textures/&lt;game_id&gt;/.<br><br><dolphin_emphasis>If unsure, leave "
@@ -185,6 +196,7 @@ void SoftwareRendererWidget::AddDescriptions()
   m_dump_objects->SetDescription(tr(TR_DUMP_OBJECTS_DESCRIPTION));
   m_dump_tev_stages->SetDescription(tr(TR_DUMP_TEV_STAGES_DESCRIPTION));
   m_dump_tev_fetches->SetDescription(tr(TR_DUMP_TEV_FETCHES_DESCRIPTION));
+  m_no_rast_timings->SetDescription(tr(TR_NO_CYCLE_COUNT_DESCRIPTION));
 }
 
 void SoftwareRendererWidget::OnEmulationStateChanged(bool running)

--- a/Source/Core/DolphinQt/Config/Graphics/SoftwareRendererWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/SoftwareRendererWidget.h
@@ -31,6 +31,7 @@ private:
 
   ToolTipComboBox* m_backend_combo;
   GraphicsBool* m_show_statistics;
+  GraphicsBool* m_no_rast_timings;
   GraphicsBool* m_dump_textures;
   GraphicsBool* m_dump_objects;
   GraphicsBool* m_dump_tev_stages;

--- a/Source/Core/VideoBackends/Null/NullVertexManager.cpp
+++ b/Source/Core/VideoBackends/Null/NullVertexManager.cpp
@@ -9,8 +9,9 @@ VertexManager::VertexManager() = default;
 
 VertexManager::~VertexManager() = default;
 
-void VertexManager::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex)
+u32 VertexManager::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex)
 {
+  return 0;
 }
 
 }  // namespace Null

--- a/Source/Core/VideoBackends/Null/NullVertexManager.h
+++ b/Source/Core/VideoBackends/Null/NullVertexManager.h
@@ -14,6 +14,6 @@ public:
   ~VertexManager() override;
 
 protected:
-  void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
+  u32 DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
 };
 }  // namespace Null

--- a/Source/Core/VideoBackends/Software/Clipper.h
+++ b/Source/Core/VideoBackends/Software/Clipper.h
@@ -3,17 +3,19 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
+
 struct OutputVertexData;
 
 namespace Clipper
 {
 void Init();
 
-void ProcessTriangle(OutputVertexData* v0, OutputVertexData* v1, OutputVertexData* v2);
+u32 ProcessTriangle(OutputVertexData* v0, OutputVertexData* v1, OutputVertexData* v2);
 
-void ProcessLine(OutputVertexData* v0, OutputVertexData* v1);
+u32 ProcessLine(OutputVertexData* v0, OutputVertexData* v1);
 
-void ProcessPoint(OutputVertexData* v);
+u32 ProcessPoint(OutputVertexData* v);
 
 bool CullTest(const OutputVertexData* v0, const OutputVertexData* v1, const OutputVertexData* v2,
               bool& backface);

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -699,7 +699,7 @@ void ResetPerfQuery()
   perf_values = {};
 }
 
-void IncPerfCounterQuadCount(PerfQueryType type)
+void IncPerfCounterPixelCount(PerfQueryType type)
 {
   // NOTE: hardware doesn't process individual pixels but quads instead.
   // Current software renderer architecture works on pixels though, so
@@ -709,6 +709,10 @@ void IncPerfCounterQuadCount(PerfQueryType type)
   if (++quad[type] != 3)
     return;
   quad[type] = 0;
+  ++perf_values[type];
+}
+
+void IncPerfCounterQuadCount(PerfQueryType type) {
   ++perf_values[type];
 }
 }  // namespace EfbInterface

--- a/Source/Core/VideoBackends/Software/EfbInterface.h
+++ b/Source/Core/VideoBackends/Software/EfbInterface.h
@@ -58,5 +58,6 @@ void EncodeXFB(u8* xfb_in_ram, u32 memory_stride, const MathUtil::Rectangle<int>
 
 u32 GetPerfQueryResult(PerfQueryType type);
 void ResetPerfQuery();
+void IncPerfCounterPixelCount(PerfQueryType type);
 void IncPerfCounterQuadCount(PerfQueryType type);
 }  // namespace EfbInterface

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -71,6 +71,36 @@ void SetTevReg(int reg, int comp, s16 color)
   tev.SetRegColor(reg, comp, color);
 }
 
+// Does the depth test for all four pixels in the block
+// Returns true if at least one pixel passes
+static bool DepthTestBlock(s32 block_x, s32 block_y) {
+  int passCount = 0;
+
+  for (s32 yi = 0; yi < BLOCK_SIZE; yi++)
+  {
+    for (s32 xi = 0; xi < BLOCK_SIZE; xi++)
+    {
+      s32 x = block_x + xi;
+      s32 y = block_y + yi;
+      RasterBlockPixel& pixel = rasterBlock.Pixel[xi][yi];
+
+      float dx = vertexOffsetX + (float)(x - vertex0X);
+      float dy = vertexOffsetY + (float)(y - vertex0Y);
+
+      s32 z = (s32)std::clamp<float>(ZSlope.GetValue(dx, dy), 0.0f, 16777215.0f);
+
+      if (!pixel.mask)
+      {
+        bool passed = EfbInterface::ZCompare(x, y, z);
+        pixel.mask = !passed;
+        passCount += passed;
+      }
+    }
+  }
+
+  return passCount != 0;
+}
+
 static void Draw(s32 x, s32 y, s32 xi, s32 yi)
 {
   INCSTAT(g_stats.this_frame.rasterized_pixels);
@@ -80,18 +110,6 @@ static void Draw(s32 x, s32 y, s32 xi, s32 yi)
 
   s32 z = (s32)std::clamp<float>(ZSlope.GetValue(dx, dy), 0.0f, 16777215.0f);
 
-  if (bpmem.UseEarlyDepthTest() && g_ActiveConfig.bZComploc)
-  {
-    // TODO: Test if perf regs are incremented even if test is disabled
-    EfbInterface::IncPerfCounterQuadCount(PQ_ZCOMP_INPUT_ZCOMPLOC);
-    if (bpmem.zmode.testenable)
-    {
-      // early z
-      if (!EfbInterface::ZCompare(x, y, z))
-        return;
-    }
-    EfbInterface::IncPerfCounterQuadCount(PQ_ZCOMP_OUTPUT_ZCOMPLOC);
-  }
 
   RasterBlockPixel& pixel = rasterBlock.Pixel[xi][yi];
 
@@ -389,7 +407,8 @@ u32 DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertexData* v1
   minx &= ~(BLOCK_SIZE - 1);
   miny &= ~(BLOCK_SIZE - 1);
 
-  u32 num_blocks = 0;
+  u32 early_depth_blocks = 0;
+  u32 shadded_blocks = 0;
   // Loop through blocks
   for (s32 y = miny; y < maxy; y += BLOCK_SIZE)
   {
@@ -424,19 +443,16 @@ u32 DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertexData* v1
       if (a == 0x0 || b == 0x0 || c == 0x0)
         continue;
 
-      num_blocks++;
-
-      BuildBlock(x, y);
-
-      // Accept whole block when totally covered
       if (a == 0xF && b == 0xF && c == 0xF)
       {
+        // Accept whole block when totally covered
         for (s32 iy = 0; iy < BLOCK_SIZE; iy++)
         {
-          for (s32 ix = 0; ix < BLOCK_SIZE; ix++)
-          {
-            Draw(x + ix, y + iy, ix, iy);
-          }
+            for (s32 ix = 0; ix < BLOCK_SIZE; ix++)
+            {
+              RasterBlockPixel& pixel = rasterBlock.Pixel[ix][iy];
+              pixel.mask = false;
+            }
         }
       }
       else  // Partially covered block
@@ -453,10 +469,8 @@ u32 DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertexData* v1
 
           for (s32 ix = 0; ix < BLOCK_SIZE; ix++)
           {
-            if (CX1 > 0 && CX2 > 0 && CX3 > 0)
-            {
-              Draw(x + ix, y + iy, ix, iy);
-            }
+            RasterBlockPixel& pixel = rasterBlock.Pixel[ix][iy];
+            pixel.mask = !(CX1 > 0 && CX2 > 0 && CX3 > 0);
 
             CX1 -= FDY12;
             CX2 -= FDY23;
@@ -468,10 +482,40 @@ u32 DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertexData* v1
           CY3 += FDX31;
         }
       }
+
+      // If early depth-testing is enabled, and all pixels in the block fail, we can safely skip
+      // the entire block.
+      if (bpmem.UseEarlyDepthTest())
+      {
+        EfbInterface::IncPerfCounterPixelCount(PQ_ZCOMP_INPUT_ZCOMPLOC);
+        if (!DepthTestBlock(x, y))
+        {
+          continue;
+          early_depth_blocks++;
+        }
+
+        EfbInterface::IncPerfCounterPixelCount(PQ_ZCOMP_OUTPUT_ZCOMPLOC);
+      }
+
+      shadded_blocks++;
+
+      BuildBlock(x, y);
+
+      for (s32 iy = 0; iy < BLOCK_SIZE; iy++)
+      {
+        for (s32 ix = 0; ix < BLOCK_SIZE; ix++)
+        {
+          if (!rasterBlock.Pixel[ix][iy].mask)
+            Draw(x + ix, y + iy, ix, iy);
+        }
+      }
+
     }
   }
-  // Assume that each block with at least one pixel rendered takes one cycle per enabled tev stage
+
   // Assume that all triangles take at least two cycles
-  return std::max(2u, bpmem.genMode.numtevstages * num_blocks);
+  // Assume that each block with at least one pixel shaded takes one cycle per enabled tev stage
+  // Assume early depth blocks can be skipped at a rate of two per cycle
+  return std::max(2u, early_depth_blocks / 2 + bpmem.genMode.numtevstages * shadded_blocks);
 }
 }  // namespace Rasterizer

--- a/Source/Core/VideoBackends/Software/Rasterizer.h
+++ b/Source/Core/VideoBackends/Software/Rasterizer.h
@@ -29,6 +29,7 @@ struct RasterBlockPixel
 {
   float InvW;
   float Uv[8][2];
+  bool mask;
 };
 
 struct RasterBlock

--- a/Source/Core/VideoBackends/Software/Rasterizer.h
+++ b/Source/Core/VideoBackends/Software/Rasterizer.h
@@ -11,8 +11,8 @@ namespace Rasterizer
 {
 void Init();
 
-void DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertexData* v1,
-                           const OutputVertexData* v2);
+u32 DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertexData* v1,
+                          const OutputVertexData* v2);
 
 void SetTevReg(int reg, int comp, s16 color);
 

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -32,8 +32,9 @@ SWVertexLoader::SWVertexLoader() = default;
 
 SWVertexLoader::~SWVertexLoader() = default;
 
-void SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex)
+u32 SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex)
 {
+  u32 cycles = 0;
   DebugUtil::OnObjectBegin();
 
   u8 primitiveType = 0;
@@ -90,12 +91,14 @@ void SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_
     TransformUnit::TransformTexCoord(&m_vertex, outVertex);
 
     // assemble and rasterize the primitive
-    m_setup_unit.SetupVertex();
+    cycles += m_setup_unit.SetupVertex();
 
     INCSTAT(g_stats.this_frame.num_vertices_loaded)
   }
 
   DebugUtil::OnObjectEnd();
+
+  return cycles;
 }
 
 void SWVertexLoader::SetFormat(u8 attributeIndex, u8 primitiveType)

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.h
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.h
@@ -20,7 +20,7 @@ public:
   ~SWVertexLoader();
 
 protected:
-  void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
+  u32 DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
 
   void SetFormat(u8 attributeIndex, u8 primitiveType);
   void ParseVertex(const PortableVertexDeclaration& vdec, int index);

--- a/Source/Core/VideoBackends/Software/SetupUnit.h
+++ b/Source/Core/VideoBackends/Software/SetupUnit.h
@@ -15,18 +15,18 @@ class SetupUnit
   OutputVertexData* m_VertPointer[3]{};
   OutputVertexData* m_VertWritePointer{};
 
-  void SetupQuad();
-  void SetupTriangle();
-  void SetupTriStrip();
-  void SetupTriFan();
-  void SetupLine();
-  void SetupLineStrip();
-  void SetupPoint();
+  u32 SetupQuad();
+  u32 SetupTriangle();
+  u32 SetupTriStrip();
+  u32 SetupTriFan();
+  u32 SetupLine();
+  u32 SetupLineStrip();
+  u32 SetupPoint();
 
 public:
   void Init(u8 primitiveType);
 
   OutputVertexData* GetVertex();
 
-  void SetupVertex();
+  u32 SetupVertex();
 };

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -831,12 +831,12 @@ void Tev::Draw()
   if (late_ztest && bpmem.zmode.testenable)
   {
     // TODO: Check against hw if these values get incremented even if depth testing is disabled
-    EfbInterface::IncPerfCounterQuadCount(PQ_ZCOMP_INPUT);
+    EfbInterface::IncPerfCounterPixelCount(PQ_ZCOMP_INPUT);
 
     if (!EfbInterface::ZCompare(Position[0], Position[1], Position[2]))
       return;
 
-    EfbInterface::IncPerfCounterQuadCount(PQ_ZCOMP_OUTPUT);
+    EfbInterface::IncPerfCounterPixelCount(PQ_ZCOMP_OUTPUT);
   }
 
   // The GC/Wii GPU rasterizes in 2x2 pixel groups, so bounding box values will be rounded to the
@@ -865,7 +865,7 @@ void Tev::Draw()
 #endif
 
   INCSTAT(g_stats.this_frame.tev_pixels_out);
-  EfbInterface::IncPerfCounterQuadCount(PQ_BLEND_INPUT);
+  EfbInterface::IncPerfCounterPixelCount(PQ_BLEND_INPUT);
 
   EfbInterface::BlendTev(Position[0], Position[1], output);
 }

--- a/Source/Core/VideoCommon/OpcodeDecoding.h
+++ b/Source/Core/VideoCommon/OpcodeDecoding.h
@@ -11,6 +11,7 @@ namespace OpcodeDecoder
 {
 // Global flag to signal if FifoRecorder is active.
 extern bool g_record_fifo_data;
+extern bool g_sw_cyclecount;
 
 enum
 {

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -239,6 +239,11 @@ static VertexLoaderBase* RefreshLoader(int vtx_attr_group, bool preprocess = fal
   return loader;
 }
 
+u32 ForceFlush()
+{
+  return g_vertex_manager->Flush();
+}
+
 int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bool is_preprocess)
 {
   if (!count)
@@ -264,7 +269,7 @@ int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bo
   VertexShaderManager::SetVertexFormat(loader->m_native_components);
 
   // if cull mode is CULL_ALL, tell VertexManager to skip triangles and quads.
-  // They still need to go through vertex loading, because we need to calculate a zfreeze refrence
+  // They still need to go through vertex loading, because we need to calculate a zfreeze reference
   // slope.
   bool cullall = (bpmem.genMode.cullmode == CullMode::All && primitive < 5);
 

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -34,6 +34,9 @@ NativeVertexFormat* GetOrCreateMatchingFormat(const PortableVertexDeclaration& d
 // offsets set to the unused attributes.
 NativeVertexFormat* GetUberVertexFormat(const PortableVertexDeclaration& decl);
 
+// returns gpu execution cycles
+u32 ForceFlush();
+
 // Returns -1 if buf_size is insufficient, else the amount of bytes consumed
 int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bool is_preprocess);
 

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -97,7 +97,7 @@ public:
   DataReader PrepareForAdditionalData(int primitive, u32 count, u32 stride, bool cullall);
   void FlushData(u32 count, u32 stride);
 
-  void Flush();
+  u32 Flush();
 
   void DoState(PointerWrap& p);
 
@@ -160,7 +160,7 @@ protected:
   virtual void UploadUniforms();
 
   // Issues the draw call for the current batch in the backend.
-  virtual void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex);
+  virtual u32 DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex);
 
   u32 GetRemainingSize() const;
   u32 GetRemainingIndices(int primitive) const;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -11,6 +11,7 @@
 #include "Core/Core.h"
 #include "Core/Movie.h"
 #include "VideoCommon/OnScreenDisplay.h"
+#include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -102,6 +103,10 @@ void VideoConfig::Refresh()
   bDumpTevTextureFetches = Config::Get(Config::GFX_SW_DUMP_TEV_TEX_FETCHES);
   drawStart = Config::Get(Config::GFX_SW_DRAW_START);
   drawEnd = Config::Get(Config::GFX_SW_DRAW_END);
+  if (g_video_backend->GetName() == "Software Renderer")
+    bRastTimings = !Config::Get(Config::GFX_SW_NO_RAST_TIMINGS);
+  else
+    bRastTimings = false;
 
   bForceFiltering = Config::Get(Config::GFX_ENHANCE_FORCE_FILTERING);
   iMaxAnisotropy = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -157,6 +157,7 @@ struct VideoConfig final
   bool bDumpObjects = false;
   bool bDumpTevStages = false;
   bool bDumpTevTextureFetches = false;
+  bool bRastTimings = true;
 
   // Enable API validation layers, currently only supported with Vulkan.
   bool bEnableValidationLayer = false;


### PR DESCRIPTION
Draft PR that includes both #10259 and #10260. Both of those should be merged before this one. 

Only difference is that the second commit now has improved timings for 2x2 quads that fail early depth. 