### PR TITLE
[DO NOT MERGE] BuildMacOSUniversalBinary: Bump minimum macOS to 10.14

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -64,7 +64,7 @@ DEFAULT_CONFIG = {
 
     # Minimum macOS version for each architecture slice
     "arm64_mac_os_deployment_target":  "11.0.0",
-    "x86_64_mac_os_deployment_target": "10.13.0",
+    "x86_64_mac_os_deployment_target": "10.14.0",
 
     # CMake Generator to use for building
     "generator": "Unix Makefiles",


### PR DESCRIPTION
For testing purposes. (https://bugs.dolphin-emu.org/issues/12752)