### PR TITLE
JitArm64: Allocate 64 MB for farcode

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -28,8 +28,12 @@
 using namespace Arm64Gen;
 
 constexpr size_t CODE_SIZE = 1024 * 1024 * 32;
-constexpr size_t FARCODE_SIZE = 1024 * 1024 * 16;
-constexpr size_t FARCODE_SIZE_MMU = 1024 * 1024 * 48;
+// We use a bigger farcode size for JitArm64 than Jit64, because JitArm64 always emits farcode
+// for the slow path of each loadstore instruction. Jit64 postpones emitting farcode until the
+// farcode actually is needed, saving it from having to emit farcode for most instructions.
+// TODO: Perhaps implement something similar to Jit64. But using more RAM isn't much of a problem.
+constexpr size_t FARCODE_SIZE = 1024 * 1024 * 64;
+constexpr size_t FARCODE_SIZE_MMU = 1024 * 1024 * 64;
 
 constexpr size_t STACK_SIZE = 2 * 1024 * 1024;
 constexpr size_t SAFE_STACK_SIZE = 512 * 1024;


### PR DESCRIPTION
My change in 867cd99 caused farcode to fill up much more than before. Most games still ran fine, but certain games would have multiple cache clears per minute, on top of being overall slow.

Maybe there's something prettier we can do about this than just allocating more RAM, but we have the resource budget for making Dolphin use more RAM, so I consider increasing the size of the cache to be a good solution at least for the time being.

At least for Prince of Persia: The Forgotten Sands, 48 MB isn't enough to stop the cache clears, but 64 MB is. (I only played the game for a few minutes when testing, though.)