### PR TITLE
VideoCommon: Add names for textures and shaders

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -3,6 +3,7 @@
 
 #include "VideoCommon/FramebufferManager.h"
 
+#include <fmt/format.h>
 #include <memory>
 
 #include "Common/ChunkFile.h"
@@ -170,9 +171,10 @@ bool FramebufferManager::CreateEFBFramebuffer()
   const TextureConfig efb_depth_texture_config = GetEFBDepthTextureConfig();
 
   // We need a second texture to swap with for changing pixel formats
-  m_efb_color_texture = g_renderer->CreateTexture(efb_color_texture_config);
-  m_efb_depth_texture = g_renderer->CreateTexture(efb_depth_texture_config);
-  m_efb_convert_color_texture = g_renderer->CreateTexture(efb_color_texture_config);
+  m_efb_color_texture = g_renderer->CreateTexture(efb_color_texture_config, "EFB color texture");
+  m_efb_depth_texture = g_renderer->CreateTexture(efb_depth_texture_config, "EFB depth texture");
+  m_efb_convert_color_texture =
+      g_renderer->CreateTexture(efb_color_texture_config, "EFB convert color texture");
   if (!m_efb_color_texture || !m_efb_depth_texture || !m_efb_convert_color_texture)
     return false;
 
@@ -188,7 +190,8 @@ bool FramebufferManager::CreateEFBFramebuffer()
   {
     m_efb_resolve_color_texture = g_renderer->CreateTexture(
         TextureConfig(efb_color_texture_config.width, efb_color_texture_config.height, 1,
-                      efb_color_texture_config.layers, 1, efb_color_texture_config.format, 0));
+                      efb_color_texture_config.layers, 1, efb_color_texture_config.format, 0),
+        "EFB color resolve texture");
     if (!m_efb_resolve_color_texture)
       return false;
   }
@@ -199,7 +202,8 @@ bool FramebufferManager::CreateEFBFramebuffer()
     m_efb_depth_resolve_texture = g_renderer->CreateTexture(
         TextureConfig(efb_depth_texture_config.width, efb_depth_texture_config.height, 1,
                       efb_depth_texture_config.layers, 1, GetEFBDepthCopyFormat(),
-                      AbstractTextureFlag_RenderTarget));
+                      AbstractTextureFlag_RenderTarget),
+        "EFB depth resolve texture");
     if (!m_efb_depth_resolve_texture)
       return false;
 
@@ -311,9 +315,11 @@ bool FramebufferManager::CompileConversionPipelines()
 {
   for (u32 i = 0; i < NUM_EFB_REINTERPRET_TYPES; i++)
   {
+    EFBReinterpretType convtype = static_cast<EFBReinterpretType>(i);
     std::unique_ptr<AbstractShader> pixel_shader = g_renderer->CreateShaderFromSource(
-        ShaderStage::Pixel, FramebufferShaderGen::GenerateFormatConversionShader(
-                                static_cast<EFBReinterpretType>(i), GetEFBSamples()));
+        ShaderStage::Pixel,
+        FramebufferShaderGen::GenerateFormatConversionShader(convtype, GetEFBSamples()),
+        fmt::format("Framebuffer conversion pixel shader {}", convtype));
     if (!pixel_shader)
       return false;
 
@@ -472,7 +478,8 @@ bool FramebufferManager::CompileReadbackPipelines()
   if (IsEFBMultisampled())
   {
     auto depth_resolve_shader = g_renderer->CreateShaderFromSource(
-        ShaderStage::Pixel, FramebufferShaderGen::GenerateResolveDepthPixelShader(GetEFBSamples()));
+        ShaderStage::Pixel, FramebufferShaderGen::GenerateResolveDepthPixelShader(GetEFBSamples()),
+        "Depth resolve pixel shader");
     if (!depth_resolve_shader)
       return false;
 
@@ -484,7 +491,8 @@ bool FramebufferManager::CompileReadbackPipelines()
 
   // EFB restore pipeline
   auto restore_shader = g_renderer->CreateShaderFromSource(
-      ShaderStage::Pixel, FramebufferShaderGen::GenerateEFBRestorePixelShader());
+      ShaderStage::Pixel, FramebufferShaderGen::GenerateEFBRestorePixelShader(),
+      "EFB restore pixel shader");
   if (!restore_shader)
     return false;
 
@@ -514,7 +522,7 @@ bool FramebufferManager::CreateReadbackFramebuffer()
     const TextureConfig color_config(IsUsingTiledEFBCache() ? m_efb_cache_tile_size : EFB_WIDTH,
                                      IsUsingTiledEFBCache() ? m_efb_cache_tile_size : EFB_HEIGHT, 1,
                                      1, 1, GetEFBColorFormat(), AbstractTextureFlag_RenderTarget);
-    m_efb_color_cache.texture = g_renderer->CreateTexture(color_config);
+    m_efb_color_cache.texture = g_renderer->CreateTexture(color_config, "EFB color cache");
     if (!m_efb_color_cache.texture)
       return false;
 
@@ -536,7 +544,7 @@ bool FramebufferManager::CreateReadbackFramebuffer()
                                      IsUsingTiledEFBCache() ? m_efb_cache_tile_size : EFB_HEIGHT, 1,
                                      1, 1, GetEFBDepthCopyFormat(),
                                      AbstractTextureFlag_RenderTarget);
-    m_efb_depth_cache.texture = g_renderer->CreateTexture(depth_config);
+    m_efb_depth_cache.texture = g_renderer->CreateTexture(depth_config, "EFB depth cache");
     if (!m_efb_depth_cache.texture)
       return false;
 
@@ -684,7 +692,8 @@ void FramebufferManager::ClearEFB(const MathUtil::Rectangle<int>& rc, bool clear
 bool FramebufferManager::CompileClearPipelines()
 {
   auto vertex_shader = g_renderer->CreateShaderFromSource(
-      ShaderStage::Vertex, FramebufferShaderGen::GenerateClearVertexShader());
+      ShaderStage::Vertex, FramebufferShaderGen::GenerateClearVertexShader(),
+      "Clear vertex shader");
   if (!vertex_shader)
     return false;
 
@@ -853,7 +862,8 @@ bool FramebufferManager::CompilePokePipelines()
     return false;
 
   auto poke_vertex_shader = g_renderer->CreateShaderFromSource(
-      ShaderStage::Vertex, FramebufferShaderGen::GenerateEFBPokeVertexShader());
+      ShaderStage::Vertex, FramebufferShaderGen::GenerateEFBPokeVertexShader(),
+      "EFB poke vertex shader");
   if (!poke_vertex_shader)
     return false;
 

--- a/Source/Core/VideoCommon/FramebufferManager.h
+++ b/Source/Core/VideoCommon/FramebufferManager.h
@@ -8,6 +8,8 @@
 #include <optional>
 
 #include "Common/CommonTypes.h"
+#include "Common/EnumFormatter.h"
+
 #include "VideoCommon/AbstractFramebuffer.h"
 #include "VideoCommon/AbstractPipeline.h"
 #include "VideoCommon/AbstractStagingTexture.h"
@@ -28,6 +30,13 @@ enum class EFBReinterpretType
   RGB565ToRGBA6 = 5
 };
 constexpr u32 NUM_EFB_REINTERPRET_TYPES = 6;
+template <>
+struct fmt::formatter<EFBReinterpretType> : EnumFormatter<EFBReinterpretType::RGB565ToRGBA6>
+{
+  static constexpr array_type names = {"RGB8 to RGB565", "RGB8 to RGBA6",  "RGBA6 to RGB8",
+                                       "RGB6 to RGB565", "RGB565 to RGB8", "RGB565 to RGBA6"};
+  formatter() : EnumFormatter(names) {}
+};
 
 inline bool AddressRangesOverlap(u32 aLower, u32 aUpper, u32 bLower, u32 bUpper)
 {

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -3,8 +3,11 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <functional>
+
 #include "Common/CommonTypes.h"
+
 #include "VideoCommon/RenderState.h"
 #include "VideoCommon/ShaderGenCommon.h"
 
@@ -27,3 +30,15 @@ ShaderCode GenerateGeometryShaderCode(APIType api_type, const ShaderHostConfig& 
                                       const geometry_shader_uid_data* uid_data);
 GeometryShaderUid GetGeometryShaderUid(PrimitiveType primitive_type);
 void EnumerateGeometryShaderUids(const std::function<void(const GeometryShaderUid&)>& callback);
+
+template <>
+struct fmt::formatter<geometry_shader_uid_data>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const geometry_shader_uid_data& uid, FormatContext& ctx)
+  {
+    return format_to(ctx.out(), "passthrough: {}, {} tex gens, primitive type {}",
+                     uid.IsPassthrough(), uid.numTexGens, uid.primitive_type);
+  }
+};

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -646,7 +646,8 @@ bool PostProcessing::CompileVertexShader()
 
   ss << "}\n";
 
-  m_vertex_shader = g_renderer->CreateShaderFromSource(ShaderStage::Vertex, ss.str());
+  m_vertex_shader = g_renderer->CreateShaderFromSource(ShaderStage::Vertex, ss.str(),
+                                                       "Post-processing vertex shader");
   if (!m_vertex_shader)
   {
     PanicAlertFmt("Failed to compile post-processing vertex shader");
@@ -736,7 +737,8 @@ bool PostProcessing::CompilePixelShader()
   // Generate GLSL and compile the new shader.
   m_config.LoadShader(g_ActiveConfig.sPostProcessingShader);
   m_pixel_shader = g_renderer->CreateShaderFromSource(
-      ShaderStage::Pixel, GetHeader() + m_config.GetShaderCode() + GetFooter());
+      ShaderStage::Pixel, GetHeader() + m_config.GetShaderCode() + GetFooter(),
+      fmt::format("Post-processing pixel shader: {}", m_config.GetShader()));
   if (!m_pixel_shader)
   {
     PanicAlertFmt("Failed to compile post-processing shader {}", m_config.GetShader());
@@ -744,7 +746,8 @@ bool PostProcessing::CompilePixelShader()
     // Use default shader.
     m_config.LoadDefaultShader();
     m_pixel_shader = g_renderer->CreateShaderFromSource(
-        ShaderStage::Pixel, GetHeader() + m_config.GetShaderCode() + GetFooter());
+        ShaderStage::Pixel, GetHeader() + m_config.GetShaderCode() + GetFooter(),
+        "Default post-processing pixel shader");
     if (!m_pixel_shader)
       return false;
   }

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -995,7 +995,7 @@ bool Renderer::InitializeImGui()
   m_imgui_vertex_format = CreateNativeVertexFormat(vdecl);
   if (!m_imgui_vertex_format)
   {
-    PanicAlertFmt("Failed to create imgui vertex format");
+    PanicAlertFmt("Failed to create ImGui vertex format");
     return false;
   }
 
@@ -1008,10 +1008,11 @@ bool Renderer::InitializeImGui()
 
     TextureConfig font_tex_config(font_tex_width, font_tex_height, 1, 1, 1,
                                   AbstractTextureFormat::RGBA8, 0);
-    std::unique_ptr<AbstractTexture> font_tex = CreateTexture(font_tex_config);
+    std::unique_ptr<AbstractTexture> font_tex =
+        CreateTexture(font_tex_config, "ImGui font texture");
     if (!font_tex)
     {
-      PanicAlertFmt("Failed to create imgui texture");
+      PanicAlertFmt("Failed to create ImGui texture");
       return false;
     }
     font_tex->Load(0, font_tex_width, font_tex_height, font_tex_width, font_tex_pixels,
@@ -1032,13 +1033,14 @@ bool Renderer::InitializeImGui()
 
 bool Renderer::RecompileImGuiPipeline()
 {
-  std::unique_ptr<AbstractShader> vertex_shader = CreateShaderFromSource(
-      ShaderStage::Vertex, FramebufferShaderGen::GenerateImGuiVertexShader());
-  std::unique_ptr<AbstractShader> pixel_shader =
-      CreateShaderFromSource(ShaderStage::Pixel, FramebufferShaderGen::GenerateImGuiPixelShader());
+  std::unique_ptr<AbstractShader> vertex_shader =
+      CreateShaderFromSource(ShaderStage::Vertex, FramebufferShaderGen::GenerateImGuiVertexShader(),
+                             "ImGui vertex shader");
+  std::unique_ptr<AbstractShader> pixel_shader = CreateShaderFromSource(
+      ShaderStage::Pixel, FramebufferShaderGen::GenerateImGuiPixelShader(), "ImGui pixel shader");
   if (!vertex_shader || !pixel_shader)
   {
-    PanicAlertFmt("Failed to compile imgui shaders");
+    PanicAlertFmt("Failed to compile ImGui shaders");
     return false;
   }
 
@@ -1047,10 +1049,11 @@ bool Renderer::RecompileImGuiPipeline()
   if (UseGeometryShaderForUI())
   {
     geometry_shader = CreateShaderFromSource(
-        ShaderStage::Geometry, FramebufferShaderGen::GeneratePassthroughGeometryShader(1, 1));
+        ShaderStage::Geometry, FramebufferShaderGen::GeneratePassthroughGeometryShader(1, 1),
+        "ImGui passthrough geometry shader");
     if (!geometry_shader)
     {
-      PanicAlertFmt("Failed to compile imgui geometry shader");
+      PanicAlertFmt("Failed to compile ImGui geometry shader");
       return false;
     }
   }
@@ -1515,7 +1518,8 @@ bool Renderer::CheckFrameDumpRenderTexture(u32 target_width, u32 target_height)
   m_frame_dump_render_texture.reset();
   m_frame_dump_render_texture =
       CreateTexture(TextureConfig(target_width, target_height, 1, 1, 1,
-                                  AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget));
+                                  AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget),
+                    "Frame dump render texture");
   if (!m_frame_dump_render_texture)
   {
     PanicAlertFmt("Failed to allocate frame dump render texture");

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2610,7 +2610,8 @@ bool TextureCacheBase::CreateUtilityTextures()
 {
   constexpr TextureConfig encoding_texture_config(
       EFB_WIDTH * 4, 1024, 1, 1, 1, AbstractTextureFormat::BGRA8, AbstractTextureFlag_RenderTarget);
-  m_efb_encoding_texture = g_renderer->CreateTexture(encoding_texture_config);
+  m_efb_encoding_texture =
+      g_renderer->CreateTexture(encoding_texture_config, "EFB encoding texture");
   if (!m_efb_encoding_texture)
     return false;
 
@@ -2622,7 +2623,8 @@ bool TextureCacheBase::CreateUtilityTextures()
   {
     constexpr TextureConfig decoding_texture_config(
         1024, 1024, 1, 1, 1, AbstractTextureFormat::RGBA8, AbstractTextureFlag_ComputeImage);
-    m_decoding_texture = g_renderer->CreateTexture(decoding_texture_config);
+    m_decoding_texture =
+        g_renderer->CreateTexture(decoding_texture_config, "GPU texture decoding texture");
     if (!m_decoding_texture)
       return false;
   }

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <bitset>
+#include <fmt/format.h>
 #include <map>
 #include <memory>
 #include <optional>
@@ -69,6 +70,23 @@ struct EFBCopyParams
   bool depth;
   bool yuv;
   bool copy_filter;
+};
+
+template <>
+struct fmt::formatter<EFBCopyParams>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const EFBCopyParams& uid, FormatContext& ctx)
+  {
+    std::string copy_format;
+    if (uid.copy_format == EFBCopyFormat::XFB)
+      copy_format = "XFB";
+    else
+      copy_format = fmt::to_string(uid.copy_format);
+    return format_to(ctx.out(), "format: {}, copy format: {}, depth: {}, yuv: {}, copy filter: {}",
+                     uid.efb_format, copy_format, uid.depth, uid.yuv, uid.copy_filter);
+  }
 };
 
 // Reduced version of the full coefficient array, with a single value for each row.

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.h
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include <fmt/format.h>
+#include <string>
+
 #include "Common/CommonTypes.h"
+
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/TextureDecoder.h"
 
@@ -34,3 +38,23 @@ TCShaderUid GetShaderUid(EFBCopyFormat dst_format, bool is_depth_copy, bool is_i
                          bool scale_by_half, bool copy_filter);
 
 }  // namespace TextureConversionShaderGen
+
+template <>
+struct fmt::formatter<TextureConversionShaderGen::UidData>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const TextureConversionShaderGen::UidData& uid, FormatContext& ctx)
+  {
+    std::string dst_format;
+    if (uid.dst_format == EFBCopyFormat::XFB)
+      dst_format = "XFB";
+    else
+      dst_format = fmt::to_string(uid.dst_format);
+    return format_to(ctx.out(),
+                     "dst_format: {}, efb_has_alpha: {}, is_depth_copy: {}, is_intensity: {}, "
+                     "scale_by_half: {}, copy_filter: {}",
+                     dst_format, uid.efb_has_alpha, uid.is_depth_copy, uid.is_intensity,
+                     uid.scale_by_half, uid.copy_filter);
+  }
+};


### PR DESCRIPTION
This continues the work started in #10065.  Names are now present for all shaders other than the generated pixel/vertex shaders used for emulation and for all textures except the ones used in emulation (as there are a lot of these, and I haven't thought of a good way to create unique names for them).  Names are also not created for shaders created from a binary, but that only applies to shaders used for emulation.
