### PR TITLE
FifoPlayer: Wait after clearing the screen

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -571,18 +571,18 @@ void FifoPlayer::ClearEfb()
   // Trigger a bogus EFB copy to clear the screen
   // The target address is 0, and there shouldn't be anything there,
   // but even if there is it should be loaded in by LoadTextureMemory afterwards
-  X10Y10 tl;
+  X10Y10 tl = bpmem.copyTexSrcXY;
   tl.x = 0;
   tl.y = 0;
   LoadBPReg(BPMEM_EFB_TL, tl.hex);
-  X10Y10 wh;
+  X10Y10 wh = bpmem.copyTexSrcWH;
   wh.x = EFB_WIDTH - 1;
   wh.y = EFB_HEIGHT - 1;
   LoadBPReg(BPMEM_EFB_WH, wh.hex);
   LoadBPReg(BPMEM_MIPMAP_STRIDE, 0x140);
   // The clear color and Z value have already been loaded via LoadRegisters()
   LoadBPReg(BPMEM_EFB_ADDR, 0);
-  UPE_Copy copy;
+  UPE_Copy copy = bpmem.triggerEFBCopy;
   copy.clamp_top = false;
   copy.clamp_bottom = false;
   copy.yuv = false;

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -159,6 +159,7 @@ private:
   void WritePI(u32 address, u32 value);
 
   void FlushWGP();
+  void WaitForGPUInactive();
 
   void LoadBPReg(u8 reg, u32 value);
   void LoadCPReg(u8 reg, u32 value);


### PR DESCRIPTION
Continues #10258.  If we don't wait, then the copy will be performed at a later time, which may overwrite memory updates.  This was causing problems for me when messing with memory updates, since the EFB copy would end up overwriting memory that had been written by the memory update.  I think this may have been the cause of some of the differences in #10264, and will submit a second PR to check.