### PR TITLE
FifoPlayer: Wait after clearing the screen + use early memory updates by default (test)

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -91,7 +91,7 @@ public:
   u32 GetObjectRangeEnd() const { return m_ObjectRangeEnd; }
   void SetObjectRangeEnd(u32 end) { m_ObjectRangeEnd = end; }
   // If enabled then all memory updates happen at once before the first frame
-  // Default is disabled
+  // Default is enabled
   void SetEarlyMemoryUpdates(bool enabled) { m_EarlyMemoryUpdates = enabled; }
   // Callbacks
   void SetFileLoadedCallback(CallbackFunc callback);
@@ -151,7 +151,7 @@ private:
   u32 m_ObjectRangeStart = 0;
   u32 m_ObjectRangeEnd = 10000;
 
-  bool m_EarlyMemoryUpdates = false;
+  bool m_EarlyMemoryUpdates = true;
 
   u64 m_CyclesPerFrame = 0;
   u32 m_ElapsedCycles = 0;

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -129,6 +129,7 @@ private:
   void WritePI(u32 address, u32 value);
 
   void FlushWGP();
+  void WaitForGPUInactive();
 
   void LoadBPReg(u8 reg, u32 value);
   void LoadCPReg(u8 reg, u32 value);

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -118,6 +118,7 @@ void FIFOPlayerWindow::CreateWidgets()
   auto* playback_group = new QGroupBox(tr("Playback Options"));
   auto* playback_layout = new QGridLayout;
   m_early_memory_updates = new QCheckBox(tr("Early Memory Updates"));
+  m_early_memory_updates->setChecked(true);
 
   playback_layout->addWidget(object_range_group, 0, 0);
   playback_layout->addWidget(frame_range_group, 0, 1);


### PR DESCRIPTION
Combination of #10273 and #10264, for testing.