### PR TITLE
Jit64: Use farcode for exception exit in twX.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -2559,9 +2559,11 @@ void Jit64::twX(UGeckoInstruction inst)
       fixups.push_back(f);
     }
   }
-  FixupBranch dont_trap = J();
 
+  if (!fixups.empty())
   {
+    SwitchToFarCode();
+
     RCForkGuard gpr_guard = gpr.Fork();
     RCForkGuard fpr_guard = fpr.Fork();
 
@@ -2577,9 +2579,9 @@ void Jit64::twX(UGeckoInstruction inst)
     fpr.Flush();
 
     WriteExceptionExit();
-  }
 
-  SetJumpTarget(dont_trap);
+    SwitchToNearCode();
+  }
 
   if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
   {


### PR DESCRIPTION
See https://forums.dolphin-emu.org/Thread-new-5-0-15445-causes-jump-target-too-far-away-needs-force5bytes-true

I didn't do it yet, but it might be worth bisecting what change exactly caused the distance to become too long? 