### PR TITLE
Android: Fix opening system file manager

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
@@ -59,22 +59,33 @@ public class UserDataActivity extends AppCompatActivity implements View.OnClickL
   {
     try
     {
-      startActivity(getFileManagerIntent());
+      // First, try the package name used on "normal" phones
+      startActivity(getFileManagerIntent("com.google.android.documentsui"));
     }
     catch (ActivityNotFoundException e)
     {
-      new AlertDialog.Builder(this, R.style.DolphinDialogBase)
-              .setMessage(R.string.user_data_open_system_file_manager_failed)
-              .setPositiveButton(R.string.ok, null)
-              .show();
+      try
+      {
+        // Next, try the AOSP package name
+        startActivity(getFileManagerIntent("com.android.documentsui"));
+      }
+      catch (ActivityNotFoundException e2)
+      {
+        // Activity not found. Perhaps it was removed by the OEM, or by some new Android version
+        // that didn't exist at the time of writing. Not much we can do other than tell the user
+        new AlertDialog.Builder(this, R.style.DolphinDialogBase)
+                .setMessage(R.string.user_data_open_system_file_manager_failed)
+                .setPositiveButton(R.string.ok, null)
+                .show();
+      }
     }
   }
 
-  private Intent getFileManagerIntent()
+  private Intent getFileManagerIntent(String packageName)
   {
     // Fragile, but some phones don't expose the system file manager in any better way
     Intent intent = new Intent(Intent.ACTION_MAIN);
-    intent.setClassName("com.android.documentsui", "com.android.documentsui.files.FilesActivity");
+    intent.setClassName(packageName, "com.android.documentsui.files.FilesActivity");
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     return intent;
   }


### PR DESCRIPTION
Turns out that most phones ship with a special Google version of DocumentsUI instead of just using the AOSP version, despite the two being pretty similar as far as I can tell. This change makes us check for both package names instead of just the AOSP package name.