### PR TITLE
TextureConverterShaderGen: Set alpha to 1 on intensity formats if EFB lacks alpha

### DIFF
--- a/Data/Sys/GameSettings/RPBE01.ini
+++ b/Data/Sys/GameSettings/RPBE01.ini
@@ -1,0 +1,10 @@
+# RPBE01 - Pokemon Battle Revolution
+
+[OnFrame]
+# Fixes black pixels on the bottom/right of the screen, and black in
+# some move effects that apply distortion to the screen
+# This fixes a bug in the base game, not an emulation issue
+# See https://gist.github.com/Pokechu22/e9fa9037fe21312ff32475638b78ba27
+$Fix black screen effects
+0x80244A94:dword:0x39080000
+0x80244A9C:dword:0x38030000

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -2059,7 +2059,7 @@ struct fmt::formatter<UPE_Copy>
                      "Converting from RGB to YUV: {}\n"
                      "Target pixel format: {}\n"
                      "Gamma correction: {}\n"
-                     "Mipmap filter: {}\n"
+                     "Half scale: {}\n"
                      "Vertical scaling: {}\n"
                      "Clear: {}\n"
                      "Frame to field: {}\n"

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -216,6 +216,9 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
   }
   else if (uid_data->is_intensity)
   {
+    if (!uid_data->efb_has_alpha)
+      out.Write("  texcol.a = 1.0;\n");
+
     bool has_four_bits =
         (uid_data->dst_format == EFBCopyFormat::R4 || uid_data->dst_format == EFBCopyFormat::RA4);
     bool has_alpha =


### PR DESCRIPTION
We were already doing this for non-intensity formats, but it seems like the same applies to intensity formats.  Note that the software renderer already sets alpha to 1 for both intensity and regular formats.

~~This appears to fix [Rygar: The Battle of Argus's white screens](https://bugs.dolphin-emu.org/issues/12763), but I can't tell if this fix is actually correct (as the game's bloom effect doesn't seem to work properly still); I also haven't hardware tested this behavior (but it seems like it's probably correct to me).  It seems to roughly match the results I was getting with the hardware FIFO player, though.~~  The bloom effect works properly in areas where it is enabled (which does not include the area that was experiencing the white screen), and I've confirmed with the hardware FIFO player that I get matching results in areas with bloom enabled.  I haven't done a standalone hardware test confirming this behavior, but it seems like it is almost certainly correct.