### PR TITLE
Core / DolphinQt: make WFS directory configurable

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -157,6 +157,7 @@ const Info<std::string> MAIN_LOAD_PATH{{System::Main, "General", "LoadPath"}, ""
 const Info<std::string> MAIN_RESOURCEPACK_PATH{{System::Main, "General", "ResourcePackPath"}, ""};
 const Info<std::string> MAIN_FS_PATH{{System::Main, "General", "NANDRootPath"}, ""};
 const Info<std::string> MAIN_SD_PATH{{System::Main, "General", "WiiSDCardPath"}, ""};
+const Info<std::string> MAIN_WFS_PATH{{System::Main, "General", "WFSPath"}, ""};
 
 // Main.GBA
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -138,6 +138,7 @@ extern const Info<std::string> MAIN_LOAD_PATH;
 extern const Info<std::string> MAIN_RESOURCEPACK_PATH;
 extern const Info<std::string> MAIN_FS_PATH;
 extern const Info<std::string> MAIN_SD_PATH;
+extern const Info<std::string> MAIN_WFS_PATH;
 
 // Main.GBA
 

--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -111,6 +111,17 @@ void PathPane::BrowseSDCard()
   }
 }
 
+void PathPane::BrowseWFS()
+{
+  const QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
+      this, tr("Select WFS Path"), QString::fromStdString(Config::Get(Config::MAIN_WFS_PATH))));
+  if (!dir.isEmpty())
+  {
+    m_wfs_edit->setText(dir);
+    Config::SetBase(Config::MAIN_WFS_PATH, dir.toStdString());
+  }
+}
+
 void PathPane::OnSDCardPathChanged()
 {
   Config::SetBase(Config::MAIN_SD_PATH, m_sdcard_edit->text().toStdString());
@@ -236,6 +247,15 @@ QGridLayout* PathPane::MakePathsLayout()
   layout->addWidget(new QLabel(tr("SD Card Path:")), 5, 0);
   layout->addWidget(m_sdcard_edit, 5, 1);
   layout->addWidget(sdcard_open, 5, 2);
+
+  m_wfs_edit = new QLineEdit(QString::fromStdString(File::GetUserPath(D_WFSROOT_IDX)));
+  connect(m_load_edit, &QLineEdit::editingFinished,
+          [=] { Config::SetBase(Config::MAIN_WFS_PATH, m_wfs_edit->text().toStdString()); });
+  QPushButton* wfs_open = new QPushButton(QStringLiteral("..."));
+  connect(wfs_open, &QPushButton::clicked, this, &PathPane::BrowseWFS);
+  layout->addWidget(new QLabel(tr("WFS Path:")), 6, 0);
+  layout->addWidget(m_wfs_edit, 6, 1);
+  layout->addWidget(wfs_open, 6, 2);
 
   return layout;
 }

--- a/Source/Core/DolphinQt/Settings/PathPane.h
+++ b/Source/Core/DolphinQt/Settings/PathPane.h
@@ -25,6 +25,7 @@ private:
   void BrowseLoad();
   void BrowseResourcePack();
   void BrowseSDCard();
+  void BrowseWFS();
   QGroupBox* MakeGameFolderBox();
   QGridLayout* MakePathsLayout();
   void RemovePath();
@@ -39,6 +40,7 @@ private:
   QLineEdit* m_load_edit;
   QLineEdit* m_resource_pack_edit;
   QLineEdit* m_sdcard_edit;
+  QLineEdit* m_wfs_edit;
 
   QPushButton* m_remove_path;
 };

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -77,12 +77,19 @@ static void CreateResourcePackPath(const std::string& path)
     File::SetUserPath(D_RESOURCEPACK_IDX, path + '/');
 }
 
+static void CreateWFSPath(const std::string& path)
+{
+  if (!path.empty())
+    File::SetUserPath(D_WFSROOT_IDX, path + '/');
+}
+
 static void InitCustomPaths()
 {
   File::SetUserPath(D_WIIROOT_IDX, Config::Get(Config::MAIN_FS_PATH));
   CreateLoadPath(Config::Get(Config::MAIN_LOAD_PATH));
   CreateDumpPath(Config::Get(Config::MAIN_DUMP_PATH));
   CreateResourcePackPath(Config::Get(Config::MAIN_RESOURCEPACK_PATH));
+  CreateWFSPath(Config::Get(Config::MAIN_WFS_PATH));
   File::SetUserPath(F_WIISDCARD_IDX, Config::Get(Config::MAIN_SD_PATH));
   File::SetUserPath(F_GBABIOS_IDX, Config::Get(Config::MAIN_GBA_BIOS_PATH));
   File::SetUserPath(D_GBASAVES_IDX, Config::Get(Config::MAIN_GBA_SAVES_PATH));


### PR DESCRIPTION
While the wfs path is only used for one game (DQX), it is a *huge* game.  It's nice to be able to load the files from another location easily.

Fixes:  https://bugs.dolphin-emu.org/issues/10472