### PR TITLE
LightingShaderGen: Make s_lighting_struct not inline

### DIFF
--- a/Source/Core/VideoCommon/LightingShaderGen.h
+++ b/Source/Core/VideoCommon/LightingShaderGen.h
@@ -36,13 +36,13 @@ struct LightingUidData
   u32 light_mask : 32;     // 4x8 bits
 };
 
-constexpr inline char s_lighting_struct[] = "struct Light {\n"
-                                            "\tint4 color;\n"
-                                            "\tfloat4 cosatt;\n"
-                                            "\tfloat4 distatt;\n"
-                                            "\tfloat4 pos;\n"
-                                            "\tfloat4 dir;\n"
-                                            "};\n";
+constexpr char s_lighting_struct[] = "struct Light {\n"
+                                     "\tint4 color;\n"
+                                     "\tfloat4 cosatt;\n"
+                                     "\tfloat4 distatt;\n"
+                                     "\tfloat4 pos;\n"
+                                     "\tfloat4 dir;\n"
+                                     "};\n";
 
 void GenerateLightingShaderCode(ShaderCode& object, const LightingUidData& uid_data,
                                 std::string_view in_color_name, std::string_view dest);


### PR DESCRIPTION
This generated warnings on the freebsd builder ([example](https://dolphin.ci/#/builders/13/builds/5539)).