### PR TITLE
PPCAnalyst: Don't treat blr as writing to CR

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -643,13 +643,6 @@ void PPCAnalyzer::SetInstructionStats(CodeBlock* block, CodeOp* code, const Gekk
   if (opinfo->flags & FL_IN_FLOAT_S)
     code->fregsIn[code->inst.FS] = true;
 
-  // For analysis purposes, we can assume that blr eats opinfo->flags.
-  if (opinfo->type == OpType::Branch && code->inst.hex == 0x4e800020)
-  {
-    code->outputCR0 = true;
-    code->outputCR1 = true;
-  }
-
   code->branchUsesCtr = false;
   code->branchTo = UINT32_MAX;
 


### PR DESCRIPTION
This piece of code is rather hard to understand, but my best guess at what it's trying to do is that it tries to create opportunities to skip writing CRs back to ppcState if we know that there are no CR instructions (or branch instructions, etc) between an instruction that writes to a CR register and the next blr. This is technically inaccurate emulation, but as long as games don't do anything too weird with their ABIs, I suppose it doesn't break anything.

So why do I want to get rid of it? Well, other than breaking some hypothetical weird game, I imagine it could trip up people trying to debug a game who are looking at the CR contents. And the code is just plain confusing. (blr clearly doesn't write to CRs!)