### PR TITLE
ControllerEmu: Hide the cursor if the input gate is disabled

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -140,8 +140,11 @@ Cursor::StateData Cursor::GetState(const bool adjusted)
 
   m_prev_result = result;
 
-  // If auto-hide time is up or hide button is held:
-  if (!m_auto_hide_timer || controls[4]->GetState<bool>())
+  // If auto-hide time is up, the hide button is held, or the input gate is disabled, hide the
+  // cursor.  We need to check the input gate explicitly as the hide button check always returns
+  // false if the input gate is disabled (e.g. the window is not focused with background input
+  // disabled)
+  if (!m_auto_hide_timer || !ControlReference::GetInputGate() || controls[4]->GetState<bool>())
   {
     result.x = std::numeric_limits<ControlState>::quiet_NaN();
     result.y = 0;


### PR DESCRIPTION
Before, if the window was unfocused and background input was disabled, the cursor would become visible and move to the center of the screen.  Now, the cursor is set as hidden.

This is particularly useful for Super Paper Mario, where having the cursor on screen puts the game into a separate mode.  Without this change, even if Hide was bound to something like <code>!\`M\`</code>, the cursor would become visible when the window lost focus unless background input is enabled; this makes recording fifologs very annoying.
