### PR TITLE
GameINI: Disable XFB to Texture Only with Resident Evil 0

### DIFF
--- a/Data/Sys/GameSettings/GBZ.ini
+++ b/Data/Sys/GameSettings/GBZ.ini
@@ -1,0 +1,5 @@
+# GBZE08, GBZP08, GBZJ08 - Resident Evil 0
+
+[Video_Hacks]
+# Fixes purple screens when transitioning between menus.
+XFBToTextureEnable = False


### PR DESCRIPTION
Opening and closing menus have annoying purple flashing when XFB to Texture Only is enabled.