### PR TITLE
PixelShaderGen: Use LOD bias when sampling texture on Metal and OpenGL ES

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DMain.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DMain.cpp
@@ -109,6 +109,7 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsPipelineCacheData = false;
   g_Config.backend_info.bSupportsCoarseDerivatives = true;
   g_Config.backend_info.bSupportsTextureQueryLevels = true;
+  g_Config.backend_info.bSupportsLodBiasInSampler = true;
   g_Config.backend_info.bSupportsLogicOp = D3D::SupportsLogicOp(g_Config.iAdapter);
 
   g_Config.backend_info.Adapters = D3DCommon::GetAdapterNames();

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -85,6 +85,7 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsPipelineCacheData = true;
   g_Config.backend_info.bSupportsCoarseDerivatives = true;
   g_Config.backend_info.bSupportsTextureQueryLevels = true;
+  g_Config.backend_info.bSupportsLodBiasInSampler = true;
 
   // We can only check texture support once we have a device.
   if (g_dx_context)

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -58,6 +58,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsPipelineCacheData = false;
   g_Config.backend_info.bSupportsCoarseDerivatives = false;
   g_Config.backend_info.bSupportsTextureQueryLevels = false;
+  g_Config.backend_info.bSupportsLodBiasInSampler = false;
 
   // aamodes: We only support 1 sample, so no MSAA
   g_Config.backend_info.Adapters.clear();

--- a/Source/Core/VideoBackends/OGL/OGLMain.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLMain.cpp
@@ -93,6 +93,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsPartialDepthCopies = true;
   g_Config.backend_info.bSupportsShaderBinaries = false;
   g_Config.backend_info.bSupportsPipelineCacheData = false;
+  g_Config.backend_info.bSupportsLodBiasInSampler = true;
 
   // TODO: There is a bug here, if texel buffers or SSBOs/atomics are not supported the graphics
   // options will show the option when it is not supported. The only way around this would be

--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -513,6 +513,9 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     // ARB_get_texture_sub_image (unlikely, except maybe on NVIDIA), we can use that instead.
     g_Config.backend_info.bSupportsDepthReadback = g_ogl_config.bSupportsTextureSubImage;
 
+    // GL_TEXTURE_LOD_BIAS is not supported on GLES.
+    g_Config.backend_info.bSupportsLodBiasInSampler = false;
+
     if (GLExtensions::Supports("GL_EXT_shader_framebuffer_fetch"))
     {
       g_ogl_config.SupportedFramebufferFetch = EsFbFetchType::FbFetchExt;

--- a/Source/Core/VideoBackends/OGL/SamplerCache.cpp
+++ b/Source/Core/VideoBackends/OGL/SamplerCache.cpp
@@ -97,8 +97,10 @@ void SamplerCache::SetParameters(GLuint sampler_id, const SamplerState& params)
   glSamplerParameterf(sampler_id, GL_TEXTURE_MIN_LOD, params.tm1.min_lod / 16.f);
   glSamplerParameterf(sampler_id, GL_TEXTURE_MAX_LOD, params.tm1.max_lod / 16.f);
 
-  if (!static_cast<Renderer*>(g_renderer.get())->IsGLES())
+  if (g_ActiveConfig.backend_info.bSupportsLodBiasInSampler)
+  {
     glSamplerParameterf(sampler_id, GL_TEXTURE_LOD_BIAS, params.tm0.lod_bias / 256.f);
+  }
 
   if (params.tm0.anisotropic_filtering && g_ogl_config.bSupportsAniso)
   {

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -87,6 +87,7 @@ void VideoSoftware::InitBackendInfo()
   g_Config.backend_info.bSupportsBBox = true;
   g_Config.backend_info.bSupportsCoarseDerivatives = false;
   g_Config.backend_info.bSupportsTextureQueryLevels = false;
+  g_Config.backend_info.bSupportsLodBiasInSampler = false;
 
   // aamodes
   g_Config.backend_info.AAModes = {1};

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -289,6 +289,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsFramebufferFetch = false;          // Dependent on OS and features.
   config->backend_info.bSupportsCoarseDerivatives = true;          // Assumed support.
   config->backend_info.bSupportsTextureQueryLevels = true;         // Assumed support.
+  config->backend_info.bSupportsLodBiasInSampler = false;          // Dependent on OS.
 }
 
 void VulkanContext::PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list)
@@ -315,6 +316,13 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
       (features.fragmentStoresAndAtomics == VK_TRUE);
   config->backend_info.bSupportsSSAA = (features.sampleRateShading == VK_TRUE);
   config->backend_info.bSupportsLogicOp = (features.logicOp == VK_TRUE);
+
+#ifdef __APPLE__
+  // Metal doesn't support this.
+  config->backend_info.bSupportsLodBiasInSampler = false;
+#else
+  config->backend_info.bSupportsLodBiasInSampler = true;
+#endif
 
   // Disable geometry shader when shaderTessellationAndGeometryPointSize is not supported.
   // Seems this is needed for gl_Layer.

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -648,7 +648,19 @@ uint WrapCoord(int coord, uint wrap, int size) {{
               "  float3 coords = float3(float(uv.x) / size_s, float(uv.y) / size_t, layer);\n");
     if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
     {
-      out.Write("  return iround(255.0 * texture(tex, coords));\n}}\n");
+      if (!host_config.backend_sampler_lod_bias)
+      {
+        out.Write("  uint texmode0 = samp_texmode0(texmap);\n"
+                  "  float lod_bias = {} / 256.0f;\n"
+                  "  return iround(255.0 * texture(tex, coords, lod_bias));\n",
+                  BitfieldExtract<&SamplerState::TM0::lod_bias>("texmode0"));
+      }
+      else
+      {
+        out.Write("  return iround(255.0 * texture(tex, coords));\n");
+      }
+
+      out.Write("}}\n");
     }
     else if (api_type == APIType::D3D)
     {

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -42,6 +42,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.manual_texture_sampling = !g_ActiveConfig.bFastTextureSampling;
   bits.manual_texture_sampling_custom_texture_sizes =
       g_ActiveConfig.ManualTextureSamplingWithHiResTextures();
+  bits.backend_sampler_lod_bias = g_ActiveConfig.backend_info.bSupportsLodBiasInSampler;
   return bits;
 }
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -172,6 +172,7 @@ union ShaderHostConfig
   BitField<23, 1, bool, u32> enable_validation_layer;
   BitField<24, 1, bool, u32> manual_texture_sampling;
   BitField<25, 1, bool, u32> manual_texture_sampling_custom_texture_sizes;
+  BitField<26, 1, bool, u32> backend_sampler_lod_bias;
 
   static ShaderHostConfig GetCurrent();
 };

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -233,6 +233,7 @@ struct VideoConfig final
     bool bSupportsPipelineCacheData = false;
     bool bSupportsCoarseDerivatives = false;
     bool bSupportsTextureQueryLevels = false;
+    bool bSupportsLodBiasInSampler = false;
   } backend_info;
 
   // Utility


### PR DESCRIPTION
#9998, take two.

In Twilight Princess, the iris of Midna's eyes disappears as the camera moves further away from her model. This is done by using two mipmaps: one with her iris, and one with just the pale yellow of her sclera. The game sets the distance at which the transition between the two mipmaps occurs by setting the LOD bias value to a large negative value.

To emulate LOD bias in the Vulkan backend, ``mipLodBias`` in the ``VkSamplerCreateInfo`` for the texture's sampler is set. Unfortunately, Metal does not support setting LOD bias in a sampler, so `mipLodBias` is ignored by MoltenVK. On OpenGL ES, the sampler parameter for setting LOD bias (``GL_TEXTURE_LOD_BIAS``) is unsupported, unlike desktop OpenGL.

This causes Midna's iris to only appear when the camera is very close to her.

While manual texture sampling does solve this issue, it can be less performant at higher resolutions and on low-power platforms (i.e. Android). As a separate workaround, we can pass through a bias value in the ``texture()`` call in the fragment shader, which both OpenGL ES and Metal support.

Fixes https://bugs.dolphin-emu.org/issues/11568 and https://bugs.dolphin-emu.org/issues/11993..

<details>
<summary>Screenshots (macOS)</summary>

Broken:

![image](https://bugs.dolphin-emu.org/attachments/download/7247/Screenshot%202019-02-12%20at%2017.15.41.png)

Fixed:

![image](https://user-images.githubusercontent.com/11504941/128438842-dc31a5c1-6c38-4aee-a686-3a80c6c34f84.png)

</details>