### PR TITLE
GameSettings: Patches for black screen effect for remaining versions of Pokémon Battle Revolution.

### DIFF
--- a/Data/Sys/GameSettings/RPBJ01r0.ini
+++ b/Data/Sys/GameSettings/RPBJ01r0.ini
@@ -1,0 +1,10 @@
+# RPBJ01 - Pokemon Battle Revolution
+
+[OnFrame]
+# Fixes black pixels on the bottom/right of the screen, and black in
+# some move effects that apply distortion to the screen
+# This fixes a bug in the base game, not an emulation issue
+# See https://gist.github.com/Pokechu22/e9fa9037fe21312ff32475638b78ba27
+$Fix black screen effects
+0x802342DC:dword:0x39080000
+0x802342E4:dword:0x38030000

--- a/Data/Sys/GameSettings/RPBJ01r1.ini
+++ b/Data/Sys/GameSettings/RPBJ01r1.ini
@@ -1,0 +1,10 @@
+# RPBJ01 - Pokemon Battle Revolution
+
+[OnFrame]
+# Fixes black pixels on the bottom/right of the screen, and black in
+# some move effects that apply distortion to the screen
+# This fixes a bug in the base game, not an emulation issue
+# See https://gist.github.com/Pokechu22/e9fa9037fe21312ff32475638b78ba27
+$Fix black screen effects
+0x80234580:dword:0x39080000
+0x80234588:dword:0x38030000

--- a/Data/Sys/GameSettings/RPBJ01r2.ini
+++ b/Data/Sys/GameSettings/RPBJ01r2.ini
@@ -1,0 +1,10 @@
+# RPBJ01 - Pokemon Battle Revolution
+
+[OnFrame]
+# Fixes black pixels on the bottom/right of the screen, and black in
+# some move effects that apply distortion to the screen
+# This fixes a bug in the base game, not an emulation issue
+# See https://gist.github.com/Pokechu22/e9fa9037fe21312ff32475638b78ba27
+$Fix black screen effects
+0x80234580:dword:0x39080000
+0x80234588:dword:0x38030000

--- a/Data/Sys/GameSettings/RPBP01.ini
+++ b/Data/Sys/GameSettings/RPBP01.ini
@@ -1,0 +1,10 @@
+# RPBP01 - Pokemon Battle Revolution
+
+[OnFrame]
+# Fixes black pixels on the bottom/right of the screen, and black in
+# some move effects that apply distortion to the screen
+# This fixes a bug in the base game, not an emulation issue
+# See https://gist.github.com/Pokechu22/e9fa9037fe21312ff32475638b78ba27
+$Fix black screen effects
+0x8023FF50:dword:0x39080000
+0x8023FF58:dword:0x38030000


### PR DESCRIPTION
See 254f39cf785e7dc4790acca38aa0dc10f506aa70 / https://bugs.dolphin-emu.org/issues/12629.


(Fun fact: The Japanese version of PBR does not support widescreen!)