### PR TITLE
BBA: Fix TAP detection

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
@@ -66,11 +66,16 @@ bool IsTAPDevice(const TCHAR* guid)
 
         if (status == ERROR_SUCCESS && data_type == REG_SZ)
         {
-          if (!_tcscmp(component_id, TAP_COMPONENT_ID) && !_tcscmp(net_cfg_instance_id, guid))
+          TCHAR* const component_id_sub = _tcsstr(component_id, TAP_COMPONENT_ID);
+
+          if (component_id_sub)
           {
-            RegCloseKey(unit_key);
-            RegCloseKey(netcard_key);
-            return true;
+            if (!_tcscmp(component_id_sub, TAP_COMPONENT_ID) && !_tcscmp(net_cfg_instance_id, guid))
+            {
+              RegCloseKey(unit_key);
+              RegCloseKey(netcard_key);
+              return true;
+            }
           }
         }
       }


### PR DESCRIPTION
Current code expects the component ID of the tap adapter to be equal to `tap0901`, however on my machine (Windows 10, latest TAP adapter) the component ID is `root\tap0901`. This should be a fix that is backwards compatible with "old"(?) setups.