### PR TITLE
RenderWidget: Add include to Windows.h

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -36,8 +36,7 @@
 #include "VideoCommon/VideoConfig.h"
 
 #ifdef _WIN32
-#include <WinUser.h>
-#include <windef.h>
+#include <Windows.h>
 #endif
 
 RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)


### PR DESCRIPTION
Fixes errors when building with CMake (Ninja).  
Currently it depends on PCH support, but it's broken currently.  
Not depending on PCH is good practice anyway.

Not sure if `Windows.h` is the most lightweight include though, but it at least fixes the error of there not being a target defined.