### PR TITLE
Config: Port AutoUpdate settings to new config system.

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -7,6 +7,7 @@
 
 #include "AudioCommon/AudioCommon.h"
 #include "Common/Config/Config.h"
+#include "Common/Version.h"
 #include "Core/Config/DefaultLocale.h"
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/HW/Memmap.h"
@@ -251,5 +252,12 @@ const Info<bool> MAIN_GAMELIST_COLUMN_TAGS{{System::Main, "GameList", "ColumnTag
 // Main.FifoPlayer
 
 const Info<bool> MAIN_FIFOPLAYER_LOOP_REPLAY{{System::Main, "FifoPlayer", "LoopReplay"}, true};
+
+// Main.AutoUpdate
+
+const Info<std::string> MAIN_AUTOUPDATE_UPDATE_TRACK{{System::Main, "AutoUpdate", "UpdateTrack"},
+                                                     Common::scm_update_track_str};
+const Info<std::string> MAIN_AUTOUPDATE_HASH_OVERRIDE{{System::Main, "AutoUpdate", "HashOverride"},
+                                                      ""};
 
 }  // namespace Config

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -215,4 +215,9 @@ extern const Info<bool> MAIN_GAMELIST_COLUMN_TAGS;
 
 extern const Info<bool> MAIN_FIFOPLAYER_LOOP_REPLAY;
 
+// Main.AutoUpdate
+
+extern const Info<std::string> MAIN_AUTOUPDATE_UPDATE_TRACK;
+extern const Info<std::string> MAIN_AUTOUPDATE_HASH_OVERRIDE;
+
 }  // namespace Config

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -27,7 +27,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
   {
     for (const std::string_view section :
          {"NetPlay", "General", "GBA", "Display", "Network", "Analytics", "AndroidOverlayButtons",
-          "DSP", "GameList", "FifoPlayer"})
+          "DSP", "GameList", "FifoPlayer", "AutoUpdate"})
     {
       if (config_location.section == section)
         return true;

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -95,7 +95,6 @@ void SConfig::SaveSettings()
   SaveInputSettings(ini);
   SaveBluetoothPassthroughSettings(ini);
   SaveUSBPassthroughSettings(ini);
-  SaveAutoUpdateSettings(ini);
   SaveJitDebugSettings(ini);
 
   ini.Save(File::GetUserPath(F_DOLPHINCONFIG_IDX));
@@ -244,14 +243,6 @@ void SConfig::SaveUSBPassthroughSettings(IniFile& ini)
   section->Set("Devices", devices_string);
 }
 
-void SConfig::SaveAutoUpdateSettings(IniFile& ini)
-{
-  IniFile::Section* section = ini.GetOrCreateSection("AutoUpdate");
-
-  section->Set("UpdateTrack", m_auto_update_track);
-  section->Set("HashOverride", m_auto_update_hash_override);
-}
-
 void SConfig::SaveJitDebugSettings(IniFile& ini)
 {
   IniFile::Section* section = ini.GetOrCreateSection("Debug");
@@ -283,7 +274,6 @@ void SConfig::LoadSettings()
   LoadInputSettings(ini);
   LoadBluetoothPassthroughSettings(ini);
   LoadUSBPassthroughSettings(ini);
-  LoadAutoUpdateSettings(ini);
   LoadJitDebugSettings(ini);
 }
 
@@ -440,14 +430,6 @@ void SConfig::LoadUSBPassthroughSettings(IniFile& ini)
     if (vid && pid)
       m_usb_passthrough_devices.emplace(vid, pid);
   }
-}
-
-void SConfig::LoadAutoUpdateSettings(IniFile& ini)
-{
-  IniFile::Section* section = ini.GetOrCreateSection("AutoUpdate");
-
-  section->Get("UpdateTrack", &m_auto_update_track, Common::scm_update_track_str);
-  section->Get("HashOverride", &m_auto_update_hash_override, "");
 }
 
 void SConfig::LoadJitDebugSettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -241,10 +241,6 @@ struct SConfig
   bool m_AdapterRumble[4];
   bool m_AdapterKonga[4];
 
-  // Auto-update settings
-  std::string m_auto_update_track;
-  std::string m_auto_update_hash_override;
-
   SConfig(const SConfig&) = delete;
   SConfig& operator=(const SConfig&) = delete;
   SConfig(SConfig&&) = delete;
@@ -272,7 +268,6 @@ private:
   void SaveMovieSettings(IniFile& ini);
   void SaveBluetoothPassthroughSettings(IniFile& ini);
   void SaveUSBPassthroughSettings(IniFile& ini);
-  void SaveAutoUpdateSettings(IniFile& ini);
   void SaveJitDebugSettings(IniFile& ini);
 
   void LoadGeneralSettings(IniFile& ini);
@@ -282,7 +277,6 @@ private:
   void LoadMovieSettings(IniFile& ini);
   void LoadBluetoothPassthroughSettings(IniFile& ini);
   void LoadUSBPassthroughSettings(IniFile& ini);
-  void LoadAutoUpdateSettings(IniFile& ini);
   void LoadJitDebugSettings(IniFile& ini);
 
   void SetRunningGameMetadata(const std::string& game_id, const std::string& gametdb_id,

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -254,7 +254,7 @@ void DolphinAnalytics::MakeBaseBuilder()
   builder.AddData("version-dist", Common::scm_distributor_str);
 
   // Auto-Update information.
-  builder.AddData("update-track", SConfig::GetInstance().m_auto_update_track);
+  builder.AddData("update-track", Config::Get(Config::MAIN_AUTOUPDATE_UPDATE_TRACK));
 
   // CPU information.
   builder.AddData("cpu-summary", cpu_info.Summarize());

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -286,7 +286,8 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
 
     if (!Settings::Instance().IsBatchModeEnabled())
     {
-      auto* updater = new Updater(&win);
+      auto* updater = new Updater(&win, Config::Get(Config::MAIN_AUTOUPDATE_UPDATE_TRACK),
+                                  Config::Get(Config::MAIN_AUTOUPDATE_HASH_OVERRIDE));
       updater->start();
     }
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -548,12 +548,8 @@ void MenuBar::AddOptionsMenu()
 
 void MenuBar::InstallUpdateManually()
 {
-  auto& track = SConfig::GetInstance().m_auto_update_track;
-  auto previous_value = track;
-
-  track = "dev";
-
-  auto* updater = new Updater(this->parentWidget());
+  auto* updater =
+      new Updater(this->parentWidget(), "dev", Config::Get(Config::MAIN_AUTOUPDATE_HASH_OVERRIDE));
 
   if (!updater->CheckForUpdate())
   {
@@ -561,8 +557,6 @@ void MenuBar::InstallUpdateManually()
         this, tr("Update"),
         tr("You are running the latest version available on this update track."));
   }
-
-  track = previous_value;
 }
 
 void MenuBar::AddHelpMenu()

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -614,14 +614,14 @@ void Settings::SetAutoUpdateTrack(const QString& mode)
   if (mode == GetAutoUpdateTrack())
     return;
 
-  SConfig::GetInstance().m_auto_update_track = mode.toStdString();
+  Config::SetBase(Config::MAIN_AUTOUPDATE_UPDATE_TRACK, mode.toStdString());
 
   emit AutoUpdateTrackChanged(mode);
 }
 
 QString Settings::GetAutoUpdateTrack() const
 {
-  return QString::fromStdString(SConfig::GetInstance().m_auto_update_track);
+  return QString::fromStdString(Config::Get(Config::MAIN_AUTOUPDATE_UPDATE_TRACK));
 }
 
 void Settings::SetFallbackRegion(const DiscIO::Region& region)

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -3,6 +3,8 @@
 
 #include "DolphinQt/Updater.h"
 
+#include <utility>
+
 #include <QCheckBox>
 #include <QDialog>
 #include <QDialogButtonBox>
@@ -18,20 +20,22 @@
 
 // Refer to docs/autoupdate_overview.md for a detailed overview of the autoupdate process
 
-Updater::Updater(QWidget* parent) : m_parent(parent)
+Updater::Updater(QWidget* parent, std::string update_track, std::string hash_override)
+    : m_parent(parent), m_update_track(std::move(update_track)),
+      m_hash_override(std::move(hash_override))
 {
   connect(this, &QThread::finished, this, &QObject::deleteLater);
 }
 
 void Updater::run()
 {
-  AutoUpdateChecker::CheckForUpdate();
+  AutoUpdateChecker::CheckForUpdate(m_update_track, m_hash_override);
 }
 
 bool Updater::CheckForUpdate()
 {
   m_update_available = false;
-  AutoUpdateChecker::CheckForUpdate();
+  AutoUpdateChecker::CheckForUpdate(m_update_track, m_hash_override);
 
   return m_update_available;
 }

--- a/Source/Core/DolphinQt/Updater.h
+++ b/Source/Core/DolphinQt/Updater.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <QThread>
 
 #include "UICommon/AutoUpdate.h"
@@ -15,7 +17,7 @@ class Updater : public QThread, public AutoUpdateChecker
 {
   Q_OBJECT
 public:
-  explicit Updater(QWidget* parent);
+  explicit Updater(QWidget* parent, std::string update_track, std::string hash_override);
 
   void run() override;
   void OnUpdateAvailable(const NewVersionInformation& info) override;
@@ -23,5 +25,7 @@ public:
 
 private:
   QWidget* m_parent;
+  std::string m_update_track;
+  std::string m_hash_override;
   bool m_update_available = false;
 };

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -3,8 +3,10 @@
 
 #include "UICommon/AutoUpdate.h"
 
-#include <picojson.h>
 #include <string>
+
+#include <fmt/format.h>
+#include <picojson.h>
 
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
@@ -12,7 +14,6 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Common/Version.h"
-#include "Core/ConfigManager.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -149,22 +150,20 @@ static std::string GetPlatformID()
 #endif
 }
 
-void AutoUpdateChecker::CheckForUpdate()
+void AutoUpdateChecker::CheckForUpdate(std::string_view update_track,
+                                       std::string_view hash_override)
 {
   // Don't bother checking if updates are not supported or not enabled.
-  if (!SystemSupportsAutoUpdates() || SConfig::GetInstance().m_auto_update_track.empty())
+  if (!SystemSupportsAutoUpdates() || update_track.empty())
     return;
 
 #ifdef OS_SUPPORTS_UPDATER
   CleanupFromPreviousUpdate();
 #endif
 
-  std::string version_hash = SConfig::GetInstance().m_auto_update_hash_override.empty() ?
-                                 Common::scm_rev_git_str :
-                                 SConfig::GetInstance().m_auto_update_hash_override;
-  std::string url = "https://dolphin-emu.org/update/check/v1/" +
-                    SConfig::GetInstance().m_auto_update_track + "/" + version_hash + "/" +
-                    GetPlatformID();
+  std::string_view version_hash = hash_override.empty() ? Common::scm_rev_git_str : hash_override;
+  std::string url = fmt::format("https://dolphin-emu.org/update/check/v1/{}/{}/{}", update_track,
+                                version_hash, GetPlatformID());
 
   Common::HttpRequest req{std::chrono::seconds{10}};
   auto resp = req.Get(url);

--- a/Source/Core/UICommon/AutoUpdate.h
+++ b/Source/Core/UICommon/AutoUpdate.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 // Refer to docs/autoupdate_overview.md for a detailed overview of the autoupdate process
 
@@ -14,7 +15,7 @@ class AutoUpdateChecker
 public:
   // Initiates a check for updates in the background. Calls the OnUpdateAvailable callback if an
   // update is available, does "nothing" otherwise.
-  void CheckForUpdate();
+  void CheckForUpdate(std::string_view update_track, std::string_view hash_override);
 
   static bool SystemSupportsAutoUpdates();
 


### PR DESCRIPTION
I took the opportunity to do pass some data to `AutoUpdateChecker::CheckForUpdate()` so we don't have to do the weird set-call-revert thing in `InstallUpdateManually()`.