### PR TITLE
GDB Stub: validate the address exists before reading/writting to it

### DIFF
--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -536,9 +536,10 @@ static void ReadMemory()
 
   if (len * 2 > sizeof reply)
     SendReply("E01");
+
+  if (!PowerPC::HostIsRAMAddress(addr))
+    return SendReply("E00");
   u8* data = Memory::GetPointer(addr);
-  if (!data)
-    return SendReply("E0");
   Mem2hex(reply, data, len);
   reply[len * 2] = '\0';
   SendReply((char*)reply);
@@ -560,9 +561,9 @@ static void WriteMemory()
     len = (len << 4) | Hex2char(s_cmd_bfr[i++]);
   INFO_LOG_FMT(GDB_STUB, "gdb: write memory: {:08x} bytes to {:08x}", len, addr);
 
-  u8* dst = Memory::GetPointer(addr);
-  if (!dst)
+  if (!PowerPC::HostIsRAMAddress(addr))
     return SendReply("E00");
+  u8* dst = Memory::GetPointer(addr);
   Hex2mem(dst, s_cmd_bfr + i + 1, len);
   SendReply("OK");
 }


### PR DESCRIPTION
This prevented unknown pointer spams when you connect with ghidra because it seems to want to probe memory that happened to be invalid, this shouldn't happen, we should just return an error and not panic.