### PR TITLE
Gdb stub: fix watchpoints

### DIFF
--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -58,6 +58,8 @@ enum class BreakpointType
   Access,
 };
 
+constexpr u32 NUM_BREAKPOINT_TYPES = 4;
+
 const s64 GDB_UPDATE_CYCLES = 100000;
 
 static bool s_has_control = false;
@@ -857,7 +859,7 @@ static void HandleAddBreakpoint()
   u32 i, addr = 0, len = 0;
 
   type = Hex2char(s_cmd_bfr[1]);
-  if (type > 4)
+  if (type > NUM_BREAKPOINT_TYPES)
     return SendReply("E01");
 
   i = 3;
@@ -878,7 +880,7 @@ static void HandleRemoveBreakpoint()
   u32 type, addr, len, i;
 
   type = Hex2char(s_cmd_bfr[1]);
-  if (type >= 4)
+  if (type > NUM_BREAKPOINT_TYPES)
     return SendReply("E01");
 
   addr = 0;

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -53,8 +53,8 @@ enum class BreakpointType
 {
   ExecuteSoft = 0,
   ExecuteHard,
-  Read,
   Write,
+  Read,
   Access,
 };
 


### PR DESCRIPTION
This fixes 2 issues with watchpoints:

1: z4 packets would get ignored because of a bogus check for bogus types
2: read only watchpoint and write only watchpoint were reversed in the enum