### PR TITLE
Interpreter: Fix cycle counting inconsistency between debug mode and regular mode loops.

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -260,8 +260,8 @@ void Interpreter::Run()
       while (PowerPC::ppcState.downcount > 0)
       {
         m_end_block = false;
-        int i;
-        for (i = 0; !m_end_block; i++)
+        int cycles = 0;
+        while (!m_end_block)
         {
 #ifdef SHOW_HISTORY
           s_pc_vec.push_back(PC);
@@ -301,9 +301,9 @@ void Interpreter::Run()
             Host_UpdateDisasmDialog();
             return;
           }
-          SingleStepInner();
+          cycles += SingleStepInner();
         }
-        PowerPC::ppcState.downcount -= i;
+        PowerPC::ppcState.downcount -= cycles;
       }
     }
     else


### PR DESCRIPTION
Noticed this while doing my config system sweep. Dentomologist traced this divergence back to 34aebffff92e8f3357dea14082f3ac0973243599 and it doesn't look like an intentional change, so let's fix it I guess.