### PR TITLE
GLES: Fix missing precision for sampler2DMSArray

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -838,7 +838,7 @@ void ProgramShaderCache::CreateHeader()
       (is_glsles && g_ActiveConfig.backend_info.bSupportsPaletteConversion) ?
           "precision highp usamplerBuffer;" :
           "",
-      v > GlslEs300 ? "precision highp sampler2DMS;" : "",
+      v > GlslEs300 ? "precision highp sampler2DMSArray;" : "",
       v >= GlslEs310 ? "precision highp image2DArray;" : "");
 }
 


### PR DESCRIPTION
We don't use sampler2DMS, but we do use sampler2DMSArray.

I can't reproduce it on my phone, but a user who was running GLES on a Tegra X1 reported a shader compilation error related to this.