### PR TITLE
GameINI: Replace all uses of SyncGPU with single core

### DIFF
--- a/Data/Sys/GameSettings/G2M.ini
+++ b/Data/Sys/GameSettings/G2M.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GEA.ini
+++ b/Data/Sys/GameSettings/GEA.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GFZ.ini
+++ b/Data/Sys/GameSettings/GFZ.ini
@@ -4,7 +4,7 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 FPRF = True
-SyncGPU = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GLS.ini
+++ b/Data/Sys/GameSettings/GLS.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = 1
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GSZ.ini
+++ b/Data/Sys/GameSettings/GSZ.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = 1
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GXX.ini
+++ b/Data/Sys/GameSettings/GXX.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/P2M.ini
+++ b/Data/Sys/GameSettings/P2M.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/R64.ini
+++ b/Data/Sys/GameSettings/R64.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RD2.ini
+++ b/Data/Sys/GameSettings/RD2.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # The game hangs on New Game when using Dual Core
-# SyncGPU is slower than Single Core in this title.
 CPUThread = False
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RNO.ini
+++ b/Data/Sys/GameSettings/RNO.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Prevents save game corruption.
-SyncGPU = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RRB.ini
+++ b/Data/Sys/GameSettings/RRB.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = 1
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RSN.ini
+++ b/Data/Sys/GameSettings/RSN.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RYB.ini
+++ b/Data/Sys/GameSettings/RYB.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
At least on Android, SyncGPU has really bad performance compared to single core. It's less stable too – I get fatal GPU desyncs in Pokémon XD using the default settings.