### PR TITLE
Android: Fix country constants in CoverHelper.getRegion

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CoverHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CoverHelper.java
@@ -33,22 +33,28 @@ public final class CoverHelper
       case 2: // PAL
         switch (game.getCountry())
         {
-          case 2: // German
-            region = "DE";
+          case 3: // Australia
+            region = "AU";
             break;
-          case 3: // French
+          case 4: // France
             region = "FR";
             break;
-          case 4: // Spanish
-            region = "ES";
+          case 5: // Germany
+            region = "DE";
             break;
-          case 5: // Italian
+          case 6: // Italy
             region = "IT";
             break;
-          case 6: // Dutch
+          case 8: // Netherlands
             region = "NL";
             break;
-          case 1: // English
+          case 9: // Russia
+            region = "RU";
+            break;
+          case 10: // Spain
+            region = "ES";
+            break;
+          case 0: // Europe
           default:
             region = "EN";
             break;


### PR DESCRIPTION
This code seems to have been written as if GameFile.getCountry returns a language rather than a country, which is wrong.