### PR TITLE
OGL: Use GL_EXT_texture_lod_bias on OpenGL ES if available

### DIFF
--- a/Source/Core/Common/GL/GLExtensions/EXT_texture_lod_bias.h
+++ b/Source/Core/Common/GL/GLExtensions/EXT_texture_lod_bias.h
@@ -1,0 +1,10 @@
+/*
+** Copyright (c) 2013-2015 The Khronos Group Inc.
+** SPDX-License-Identifier: MIT
+*/
+
+#include "Common/GL/GLExtensions/gl_common.h"
+
+#define GL_TEXTURE_FILTER_CONTROL_EXT 0x8500
+#define GL_TEXTURE_LOD_BIAS_EXT 0x8501
+#define GL_MAX_TEXTURE_LOD_BIAS_EXT 0x84FD

--- a/Source/Core/Common/GL/GLExtensions/GLExtensions.h
+++ b/Source/Core/Common/GL/GLExtensions/GLExtensions.h
@@ -35,6 +35,7 @@
 #include "Common/GL/GLExtensions/ARB_viewport_array.h"
 #include "Common/GL/GLExtensions/EXT_texture_compression_s3tc.h"
 #include "Common/GL/GLExtensions/EXT_texture_filter_anisotropic.h"
+#include "Common/GL/GLExtensions/EXT_texture_lod_bias.h"
 #include "Common/GL/GLExtensions/HP_occlusion_test.h"
 #include "Common/GL/GLExtensions/KHR_debug.h"
 #include "Common/GL/GLExtensions/NV_depth_buffer_float.h"

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -83,6 +83,7 @@
     <ClInclude Include="Common\GL\GLExtensions\ARB_viewport_array.h" />
     <ClInclude Include="Common\GL\GLExtensions\EXT_texture_compression_s3tc.h" />
     <ClInclude Include="Common\GL\GLExtensions\EXT_texture_filter_anisotropic.h" />
+    <ClInclude Include="Common\GL\GLExtensions\EXT_texture_lod_bias.h" />
     <ClInclude Include="Common\GL\GLExtensions\gl_1_1.h" />
     <ClInclude Include="Common\GL\GLExtensions\gl_1_2.h" />
     <ClInclude Include="Common\GL\GLExtensions\gl_1_3.h" />

--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -513,8 +513,8 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     // ARB_get_texture_sub_image (unlikely, except maybe on NVIDIA), we can use that instead.
     g_Config.backend_info.bSupportsDepthReadback = g_ogl_config.bSupportsTextureSubImage;
 
-    // GL_TEXTURE_LOD_BIAS is not supported on GLES.
-    g_Config.backend_info.bSupportsLodBiasInSampler = false;
+    // LOD bias is supported in GLES with an extension.
+    g_Config.backend_info.bSupportsLodBiasInSampler = GLExtensions::Supports("GL_EXT_texture_lod_bias");
 
     if (GLExtensions::Supports("GL_EXT_shader_framebuffer_fetch"))
     {

--- a/Source/Core/VideoBackends/OGL/SamplerCache.cpp
+++ b/Source/Core/VideoBackends/OGL/SamplerCache.cpp
@@ -99,7 +99,14 @@ void SamplerCache::SetParameters(GLuint sampler_id, const SamplerState& params)
 
   if (g_ActiveConfig.backend_info.bSupportsLodBiasInSampler)
   {
-    glSamplerParameterf(sampler_id, GL_TEXTURE_LOD_BIAS, params.tm0.lod_bias / 256.f);
+    if (!static_cast<Renderer*>(g_renderer.get())->IsGLES())
+    {
+      glSamplerParameterf(sampler_id, GL_TEXTURE_LOD_BIAS, params.tm0.lod_bias / 256.f);
+    }
+    else
+    {
+      glSamplerParameterf(sampler_id, GL_TEXTURE_LOD_BIAS_EXT, params.tm0.lod_bias / 256.f);
+    }
   }
 
   if (params.tm0.anisotropic_filtering && g_ogl_config.bSupportsAniso)


### PR DESCRIPTION
This adds support for [EXT_texture_lod_bias](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_lod_bias.txt) on OpenGL ES.