### PR TITLE
UICommon: Append trailing slash to DOLPHIN_EMU_USERPATH

### DIFF
--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -308,7 +308,7 @@ void SetUserDirectory(const std::string& custom_path)
 #if defined(__APPLE__) || defined(ANDROID)
     if (env_path)
     {
-      user_path = env_path;
+      user_path = std::string(env_path) + DIR_SEP;
     }
     else
     {
@@ -333,7 +333,7 @@ void SetUserDirectory(const std::string& custom_path)
     }
     else if (env_path)
     {
-      user_path = env_path;
+      user_path = std::string(env_path) + DIR_SEP;
     }
     else if (!File::Exists(user_path))
     {


### PR DESCRIPTION
This fixes a really annoying issue. If you define a path in ``DOLPHIN_EMU_USERPATH`` and don't put a trailing slash, all the users directories will be created incorrectly.

For example, if ``DOLPHIN_EMU_USERPATH`` is ``/path/to/user``, folders like ``/path/to/userWii`` and ``/path/to/userConfig`` are created.

To fix this, I append a ``DIR_SEP`` to the variable in case it isn't suffixed by one already.