### PR TITLE
VideoCommon: Handle emboss texgen with only a single normal

### DIFF
--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -104,7 +104,25 @@ void TransformNormal(const InputVertexData* src, bool nbt, OutputVertexData* dst
   else
   {
     MultiplyVec3Mat33(src->normal[0], mat, dst->normal[0]);
+    //MultiplyVec3Mat33(src->normal[0] % Vec3(1, 0, 0), mat, dst->normal[1]);
+    //MultiplyVec3Mat33(src->normal[0] % (src->normal[0] % Vec3(1, 0, 0)), mat, dst->normal[2]);
+    //MultiplyVec3Mat33(Vec3(src->color[0][0], src->color[0][1], src->color[0][2]), mat,
+    //                  dst->normal[1]);
+    //MultiplyVec3Mat33(Vec3(src->color[1][0], src->color[1][1], src->color[1][2]), mat,
+    //                  dst->normal[2]);
+    MultiplyVec3Mat33(Vec3(0, 1, 0) * src->normal[0].Length(), mat, dst->normal[1]);
+    MultiplyVec3Mat33(Vec3(0, 0, 1) * src->normal[0].Length(), mat, dst->normal[2]);
+    //MultiplyVec3Mat33(Vec3(src->color[0][1], src->color[0][2], src->color[0][3]), mat,
+    //                  dst->normal[1]);
+    //MultiplyVec3Mat33(Vec3(src->color[1][1], src->color[1][2], src->color[1][3]), mat,
+    //                  dst->normal[2]);
+    //MultiplyVec3Mat33(Vec3(1, 0, 0), mat, dst->normal[1]);
+    //MultiplyVec3Mat33(Vec3(0, 1, 0), mat, dst->normal[2]);
+    //MultiplyVec3Mat33(Vec3(0, src->normal[0].y, 0), mat, dst->normal[1]);
+    //MultiplyVec3Mat33(Vec3(0, 0, src->normal[0].z), mat, dst->normal[2]);
     dst->normal[0].Normalize();
+    //dst->normal[1].Normalize();
+    //dst->normal[2].Normalize();
   }
 }
 
@@ -415,12 +433,36 @@ void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst)
       const LightPointer* light = (const LightPointer*)&xfmem.lights[texinfo.embosslightshift];
 
       Vec3 ldir = (light->pos - dst->mvPosition).Normalized();
-      float d1 = ldir * dst->normal[1];
-      float d2 = ldir * dst->normal[2];
+      //(dst->normal[0] % Vec3(1, 0, 0)).Normalized();  // dst->normal[1]
+      Vec3 binorm = dst->normal[1];
+      //(dst->normal[0] % binorm).Normalized();        // dst->normal[2]
+      Vec3 tangent = dst->normal[2];
+      float d1 = ldir * binorm;
+      float d2 = ldir * tangent;
 
       dst->texCoords[coordNum].x = dst->texCoords[texinfo.embosssourceshift].x + d1;
       dst->texCoords[coordNum].y = dst->texCoords[texinfo.embosssourceshift].y + d2;
       dst->texCoords[coordNum].z = dst->texCoords[texinfo.embosssourceshift].z;
+      /*
+      const float* mat = &xfmem.posMatrices[src->texMtx[coordNum] * 4];
+      Vec3 src2 = dst->texCoords[coordNum];
+      Vec3* dst2 = &dst->texCoords[coordNum];
+
+      if (texinfo.projection == TexSize::ST)
+      {
+        if (texinfo.inputform == TexInputForm::AB11)
+          MultiplyVec2Mat24(src2, mat, *dst2);
+        else
+          MultiplyVec3Mat24(src2, mat, *dst2);
+      }
+      else  // texinfo.projection == TexSize::STQ
+      {
+        if (texinfo.inputform == TexInputForm::AB11)
+          MultiplyVec2Mat34(src2, mat, *dst2);
+        else
+          MultiplyVec3Mat34(src2, mat, *dst2);
+      }
+      */
     }
     break;
     case TexGenType::Color0:

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -422,12 +422,8 @@ void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst)
       const LightPointer* light = (const LightPointer*)&xfmem.lights[texinfo.embosslightshift];
 
       Vec3 ldir = (light->pos - dst->mvPosition).Normalized();
-      //(dst->normal[0] % Vec3(1, 0, 0)).Normalized();  // dst->normal[1]
-      Vec3 binorm = dst->normal[1];
-      //(dst->normal[0] % binorm).Normalized();        // dst->normal[2]
-      Vec3 tangent = dst->normal[2];
-      float d1 = ldir * binorm;
-      float d2 = ldir * tangent;
+      float d1 = ldir * dst->normal[1];
+      float d2 = ldir * dst->normal[2];
 
       dst->texCoords[coordNum].x = dst->texCoords[texinfo.embosssourceshift].x + d1;
       dst->texCoords[coordNum].y = dst->texCoords[texinfo.embosssourceshift].y + d2;

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -99,14 +99,18 @@ void TransformNormal(const InputVertexData* src, bool nbt, OutputVertexData* dst
     MultiplyVec3Mat33(src->normal[0], mat, dst->normal[0]);
     MultiplyVec3Mat33(src->normal[1], mat, dst->normal[1]);
     MultiplyVec3Mat33(src->normal[2], mat, dst->normal[2]);
+    // Only the first normal gets normalized (TODO: why?)
     dst->normal[0].Normalize();
   }
   else
   {
     MultiplyVec3Mat33(src->normal[0], mat, dst->normal[0]);
     float length = src->normal[0].Length();
-    MultiplyVec3Mat33(Vec3(0, length, 0), mat, dst->normal[1]);
-    MultiplyVec3Mat33(Vec3(0, 0, length), mat, dst->normal[2]);
+    // TODO: hardware-confirm this
+    // Equivalent to MultiplyVec3Mat33(Vec3(0, length, 0), mat, dst->normal[1]);
+    dst->normal[1] = Vec3(mat[1], mat[4], mat[7]) * length;
+    // Equivalent to MultiplyVec3Mat33(Vec3(0, 0, length), mat, dst->normal[2]);
+    dst->normal[2] = Vec3(mat[2], mat[5], mat[8]) * length;
     dst->normal[0].Normalize();
   }
 }

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -104,25 +104,10 @@ void TransformNormal(const InputVertexData* src, bool nbt, OutputVertexData* dst
   else
   {
     MultiplyVec3Mat33(src->normal[0], mat, dst->normal[0]);
-    //MultiplyVec3Mat33(src->normal[0] % Vec3(1, 0, 0), mat, dst->normal[1]);
-    //MultiplyVec3Mat33(src->normal[0] % (src->normal[0] % Vec3(1, 0, 0)), mat, dst->normal[2]);
-    //MultiplyVec3Mat33(Vec3(src->color[0][0], src->color[0][1], src->color[0][2]), mat,
-    //                  dst->normal[1]);
-    //MultiplyVec3Mat33(Vec3(src->color[1][0], src->color[1][1], src->color[1][2]), mat,
-    //                  dst->normal[2]);
-    MultiplyVec3Mat33(Vec3(0, 1, 0) * src->normal[0].Length(), mat, dst->normal[1]);
-    MultiplyVec3Mat33(Vec3(0, 0, 1) * src->normal[0].Length(), mat, dst->normal[2]);
-    //MultiplyVec3Mat33(Vec3(src->color[0][1], src->color[0][2], src->color[0][3]), mat,
-    //                  dst->normal[1]);
-    //MultiplyVec3Mat33(Vec3(src->color[1][1], src->color[1][2], src->color[1][3]), mat,
-    //                  dst->normal[2]);
-    //MultiplyVec3Mat33(Vec3(1, 0, 0), mat, dst->normal[1]);
-    //MultiplyVec3Mat33(Vec3(0, 1, 0), mat, dst->normal[2]);
-    //MultiplyVec3Mat33(Vec3(0, src->normal[0].y, 0), mat, dst->normal[1]);
-    //MultiplyVec3Mat33(Vec3(0, 0, src->normal[0].z), mat, dst->normal[2]);
+    float length = src->normal[0].Length();
+    MultiplyVec3Mat33(Vec3(0, length, 0), mat, dst->normal[1]);
+    MultiplyVec3Mat33(Vec3(0, 0, length), mat, dst->normal[2]);
     dst->normal[0].Normalize();
-    //dst->normal[1].Normalize();
-    //dst->normal[2].Normalize();
   }
 }
 
@@ -443,26 +428,6 @@ void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst)
       dst->texCoords[coordNum].x = dst->texCoords[texinfo.embosssourceshift].x + d1;
       dst->texCoords[coordNum].y = dst->texCoords[texinfo.embosssourceshift].y + d2;
       dst->texCoords[coordNum].z = dst->texCoords[texinfo.embosssourceshift].z;
-      /*
-      const float* mat = &xfmem.posMatrices[src->texMtx[coordNum] * 4];
-      Vec3 src2 = dst->texCoords[coordNum];
-      Vec3* dst2 = &dst->texCoords[coordNum];
-
-      if (texinfo.projection == TexSize::ST)
-      {
-        if (texinfo.inputform == TexInputForm::AB11)
-          MultiplyVec2Mat24(src2, mat, *dst2);
-        else
-          MultiplyVec3Mat24(src2, mat, *dst2);
-      }
-      else  // texinfo.projection == TexSize::STQ
-      {
-        if (texinfo.inputform == TexInputForm::AB11)
-          MultiplyVec2Mat34(src2, mat, *dst2);
-        else
-          MultiplyVec3Mat34(src2, mat, *dst2);
-      }
-      */
     }
     break;
     case TexGenType::Color0:

--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -27,6 +27,7 @@ enum
   // VB_HAS_POS=0, // Implied, it always has pos! don't bother testing
   VB_HAS_NRM0 = (1 << 10),
   VB_HAS_NRM1 = (1 << 11),
+  // TODO: VB_HAS_NRM1 implies VB_HAS_NRM2; we don't need both
   VB_HAS_NRM2 = (1 << 12),
   VB_HAS_NRMALL = (7 << 10),
 

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -222,56 +222,47 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   // transforms
   if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
   {
+    // Vertex format has a per-vertex matrix
     out.Write("int posidx = int(posmtx.r);\n"
-              "float4 pos = float4(dot(" I_TRANSFORMMATRICES
-              "[posidx], rawpos), dot(" I_TRANSFORMMATRICES
-              "[posidx+1], rawpos), dot(" I_TRANSFORMMATRICES "[posidx+2], rawpos), 1);\n");
-
+              "float4 P0 = " I_TRANSFORMMATRICES "[posidx];\n"
+              "float4 P1 = " I_TRANSFORMMATRICES "[posidx + 1];\n"
+              "float4 P2 = " I_TRANSFORMMATRICES "[posidx + 2];\n");
     if ((uid_data->components & VB_HAS_NRMALL) != 0)
     {
       out.Write("int normidx = posidx & 31;\n"
-                "float3 N0 = " I_NORMALMATRICES "[normidx].xyz, N1 = " I_NORMALMATRICES
-                "[normidx+1].xyz, N2 = " I_NORMALMATRICES "[normidx+2].xyz;\n");
-    }
-
-    if ((uid_data->components & VB_HAS_NRM0) != 0)
-    {
-      out.Write("float3 _norm0 = normalize(float3(dot(N0, rawnorm0), dot(N1, rawnorm0), dot(N2, "
-                "rawnorm0)));\n");
-    }
-    if ((uid_data->components & VB_HAS_NRM1) != 0)
-    {
-      out.Write(
-          "float3 _norm1 = float3(dot(N0, rawnorm1), dot(N1, rawnorm1), dot(N2, rawnorm1));\n");
-    }
-    if ((uid_data->components & VB_HAS_NRM2) != 0)
-    {
-      out.Write(
-          "float3 _norm2 = float3(dot(N0, rawnorm2), dot(N1, rawnorm2), dot(N2, rawnorm2));\n");
+                "float3 N0 = " I_NORMALMATRICES "[normidx].xyz;\n"
+                "float3 N1 = " I_NORMALMATRICES "[normidx + 1].xyz;\n"
+                "float3 N2 = " I_NORMALMATRICES "[normidx + 2].xyz;\n");
     }
   }
   else
   {
-    out.Write("float4 pos = float4(dot(" I_POSNORMALMATRIX "[0], rawpos), dot(" I_POSNORMALMATRIX
-              "[1], rawpos), dot(" I_POSNORMALMATRIX "[2], rawpos), 1.0);\n");
-    if ((uid_data->components & VB_HAS_NRM0) != 0)
+    // One shared matrix
+    out.Write("float4 P0 = " I_POSNORMALMATRIX "[0];\n"
+              "float4 P1 = " I_POSNORMALMATRIX "[1];\n"
+              "float4 P2 = " I_POSNORMALMATRIX "[2];\n");
+    if ((uid_data->components & VB_HAS_NRMALL) != 0)
     {
-      out.Write("float3 _norm0 = normalize(float3(dot(" I_POSNORMALMATRIX
-                "[3].xyz, rawnorm0), dot(" I_POSNORMALMATRIX
-                "[4].xyz, rawnorm0), dot(" I_POSNORMALMATRIX "[5].xyz, rawnorm0)));\n");
+      out.Write("float3 N0 = " I_POSNORMALMATRIX "[3].xyz;\n"
+                "float3 N1 = " I_POSNORMALMATRIX "[4].xyz;\n"
+                "float3 N2 = " I_POSNORMALMATRIX "[5].xyz;\n");
     }
-    if ((uid_data->components & VB_HAS_NRM1) != 0)
-    {
-      out.Write("float3 _norm1 = float3(dot(" I_POSNORMALMATRIX
-                "[3].xyz, rawnorm1), dot(" I_POSNORMALMATRIX
-                "[4].xyz, rawnorm1), dot(" I_POSNORMALMATRIX "[5].xyz, rawnorm1));\n");
-    }
-    if ((uid_data->components & VB_HAS_NRM2) != 0)
-    {
-      out.Write("float3 _norm2 = float3(dot(" I_POSNORMALMATRIX
-                "[3].xyz, rawnorm2), dot(" I_POSNORMALMATRIX
-                "[4].xyz, rawnorm2), dot(" I_POSNORMALMATRIX "[5].xyz, rawnorm2));\n");
-    }
+  }
+
+  out.Write("float4 pos = float4(dot(P0, rawpos), dot(P1, rawpos), dot(P2, rawpos), 1.0);\n");
+  if ((uid_data->components & VB_HAS_NRM0) != 0)
+  {
+    // Only the first normal gets normalized (TODO: why?)
+    out.Write("float3 _norm0 = normalize(float3(dot(N0, rawnorm0), dot(N1, rawnorm0), dot(N2, "
+              "rawnorm0)));\n");
+  }
+  if ((uid_data->components & VB_HAS_NRM1) != 0)
+  {
+    out.Write("float3 _norm1 = float3(dot(N0, rawnorm1), dot(N1, rawnorm1), dot(N2, rawnorm1));\n");
+  }
+  if ((uid_data->components & VB_HAS_NRM2) != 0)
+  {
+    out.Write("float3 _norm2 = float3(dot(N0, rawnorm2), dot(N1, rawnorm2), dot(N2, rawnorm2));\n");
   }
 
   if ((uid_data->components & VB_HAS_NRM0) == 0)


### PR DESCRIPTION
Not hardware tested, but this does at least give close-to-correct results for Rogue Squadron 2 and 3.  This PR is mainly for fifoci.

<details><summary>Here are some images from the hardware fifoplayer:</summary>

![Screenshot 2021-12-27 14-44-49](https://user-images.githubusercontent.com/8334194/147608817-e8897799-dbe3-45ac-859c-6b6c6fd27586.png)
![Screenshot 2021-12-27 14-48-38](https://user-images.githubusercontent.com/8334194/147608820-4c289c9d-8da9-4102-8fe3-5a7820656101.png)
<!-- ![Screenshot 2021-12-27 15-00-54](https://user-images.githubusercontent.com/8334194/147608822-28663e02-84d5-40f7-9ba0-106a98acbf69.png) -->
![Screenshot 2021-12-27 15-06-11](https://user-images.githubusercontent.com/8334194/147608824-4f761558-3886-4176-8d6f-b76001252e19.png)

</details>
<details><summary>And cropped/resized to match the sizes Dolphin gives:</summary>

![image](https://user-images.githubusercontent.com/8334194/147608989-0e9d0fe2-2bd6-4c44-9615-2d4cc6cab77f.png)
![image](https://user-images.githubusercontent.com/8334194/147608997-e72b328e-dd6c-4717-bd18-17a55ca0651e.png)
![image](https://user-images.githubusercontent.com/8334194/147608998-1104cbc4-2a45-4ecd-9d18-b1b6d33f7348.png)

</details>

I don't know what the cause of the garbage data is, but perhaps it's because the game is using regions of memory that the hardware fifoplayer is trying to use, and memory updates are clobbering things.  But enough of the image is properly visible for comparison.

I'm fairly sure that `Vec3(0, 1, 0)` and `Vec3(0, 0, 1)` are correct, though I'm not sure about the magnitude.  I tried other vectors, and they give slightly different patterns in the sand; this one matches almost perfectly.  The magnitude affects how dark the pattern is, but due to my use of a capture card from an analog signal, I can't say with complete certainty what the correct brightness is.