### PR TITLE
VulkanContext: Ensure present queue family is valid before incrementing queueCreateInfoCount

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -628,7 +628,8 @@ bool VulkanContext::CreateDevice(VkSurfaceKHR surface, bool enable_validation_la
   }};
 
   device_info.queueCreateInfoCount = 1;
-  if (m_graphics_queue_family_index != m_present_queue_family_index)
+  if (m_graphics_queue_family_index != m_present_queue_family_index &&
+      m_present_queue_family_index != queue_family_count)
   {
     device_info.queueCreateInfoCount = 2;
   }


### PR DESCRIPTION
``VulkanContext::CreateDevice()`` attempts to find appropriate graphics queue and present queue families. It will skip trying to find a present queue family if the surface is ``VK_NULL_HANDLE`` (headless mode). However, even if the present queue family isn't valid, ``queueCreateInfoCount`` will be set to ``2`` as long as the graphics queue family index isn't the same as the present queue family index (which it won't, as the default value is the number of queues).

This causes DolphinNoGUI in headless mode on macOS to crash, as MoltenVK would attempt to create an ``MVKQueue`` using an invalid configuration.