### PR TITLE
WIP Gdb stub: memory map

### DIFF
--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -309,10 +309,18 @@ static void HandleQuery()
 {
   DEBUG_LOG_FMT(GDB_STUB, "gdb: query '{}'", CommandBufferAsString() + 1);
 
-  if (!strcmp((const char*)(s_cmd_bfr + 1), "TStatus"))
-  {
-    return SendReply("T0");
-  }
+  if (!strcmp((const char*)(s_cmd_bfr + 1), "Attached"))
+    return SendReply("1");
+  if (!strcmp((const char*)(s_cmd_bfr + 1), "C"))
+    return SendReply("QC1");
+  if (!strcmp((const char*)(s_cmd_bfr + 1), "fThreadInfo"))
+    return SendReply("m1");
+  else if (!strcmp((const char*)(s_cmd_bfr + 1), "sThreadInfo"))
+    return SendReply("l");
+  else if (!strncmp((const char*)(s_cmd_bfr + 1), "ThreadExtraInfo", 15))
+    return SendReply("00");
+  else if (!strncmp((const char*)(s_cmd_bfr + 1), "Supported", static_cast<size_t>(9)))
+    return SendReply("swbreak+;hwbreak+");
 
   SendReply("");
 }


### PR DESCRIPTION
DO NOT MERGE (blocked by #10299 , I will rebase to master once it's merged).

This allows gdb to get information about the memory mapping which can be seen with `info mem`. The mapping is more precise with MMU off and works for most cases while if MMU is on, it provides a default 32 bit mapping.

It was found with Ghidra to reduce the verbosity of the communication with MMU off which can be helpful.

As for why we provide a dummy mapping with MMU off, it's because it's not possible to tell GDB to refetch the mappings and the game can change them at any time. With MMU off however, it should work most of the time with some assumptions.