### PR TITLE
GDB Stub: add support for lldb's qHostInfo

### DIFF
--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -28,6 +28,7 @@ typedef SSIZE_T ssize_t;
 #include "Common/Event.h"
 #include "Common/Logging/Log.h"
 #include "Common/SocketContext.h"
+#include "Common/StringUtil.h"
 #include "Core/Core.h"
 #include "Core/HW/CPU.h"
 #include "Core/HW/Memmap.h"
@@ -59,6 +60,9 @@ enum class BreakpointType
 };
 
 constexpr u32 NUM_BREAKPOINT_TYPES = 4;
+
+constexpr int MACH_O_POWERPC = 18;
+constexpr int MACH_O_POWERPC_750 = 9;
 
 const s64 GDB_UPDATE_CYCLES = 100000;
 
@@ -307,6 +311,14 @@ static void SendReply(const char* reply)
   }
 }
 
+static void WriteHostInfo()
+{
+  return SendReply(
+      fmt::format("cputype:{};cpusubtype:{};ostype:unknown;vendor:unknown;endian:big;ptrsize:4",
+                  MACH_O_POWERPC, MACH_O_POWERPC_750)
+          .c_str());
+}
+
 static void HandleQuery()
 {
   DEBUG_LOG_FMT(GDB_STUB, "gdb: query '{}'", CommandBufferAsString());
@@ -321,6 +333,8 @@ static void HandleQuery()
     return SendReply("l");
   else if (!strncmp((const char*)(s_cmd_bfr), "qThreadExtraInfo", strlen("qThreadExtraInfo")))
     return SendReply("00");
+  else if (!strncmp((const char*)(s_cmd_bfr), "qHostInfo", strlen("qHostInfo")))
+    return WriteHostInfo();
   else if (!strncmp((const char*)(s_cmd_bfr), "qSupported", strlen("qSupported")))
     return SendReply("swbreak+;hwbreak+");
 


### PR DESCRIPTION
This along with #10319 is actually all it takes to make lldb work correctly and it's very easy to implement so might as well add it.

NOTE: this is specific to lldb, more info here: https://github.com/llvm/llvm-project/blob/main/lldb/docs/lldb-gdb-remote.txt#L867

In my test though, it seems to mix up the packets with read memory, but I have a suspicion that it's an unrelated issue that I will be trying to address because from dolphin's side, it is replying correctly.