### PR TITLE
Concatenate green and blue values for color texgens

### DIFF
--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -425,14 +425,14 @@ void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst)
     break;
     case TexGenType::Color0:
       ASSERT(texinfo.inputform == TexInputForm::AB11);
-      dst->texCoords[coordNum].x = (float)dst->color[0][0] / 255.0f;
-      dst->texCoords[coordNum].y = (float)dst->color[0][1] / 255.0f;
+      dst->texCoords[coordNum].x = dst->color[0][0] / 255.0f;
+      dst->texCoords[coordNum].y = dst->color[0][1] / 255.0f + dst->color[0][2] / (255.0f * 256.0f);
       dst->texCoords[coordNum].z = 1.0f;
       break;
     case TexGenType::Color1:
       ASSERT(texinfo.inputform == TexInputForm::AB11);
-      dst->texCoords[coordNum].x = (float)dst->color[1][0] / 255.0f;
-      dst->texCoords[coordNum].y = (float)dst->color[1][1] / 255.0f;
+      dst->texCoords[coordNum].x = dst->color[1][0] / 255.0f;
+      dst->texCoords[coordNum].y = dst->color[1][1] / 255.0f + dst->color[1][2] / (255.0f * 256.0f);
       dst->texCoords[coordNum].z = 1.0f;
       break;
     default:

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -456,10 +456,10 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
             "    }}\n"
             "    break;\n\n");
   out.Write("  case {:s}:\n", TexGenType::Color0);
-  out.Write("    output_tex.xyz = float3(o.colors_0.x, o.colors_0.y, 1.0);\n"
+  out.Write("    output_tex.xyz = float3(o.colors_0.r, o.colors_0.g + o.colors_0.b / 256.0, 1.0);\n"
             "    break;\n\n");
   out.Write("  case {:s}:\n", TexGenType::Color1);
-  out.Write("    output_tex.xyz = float3(o.colors_1.x, o.colors_1.y, 1.0);\n"
+  out.Write("    output_tex.xyz = float3(o.colors_1.r, o.colors_1.g + o.colors_1.b / 256.0, 1.0);\n"
             "    break;\n\n");
   out.Write("  case {:s}:\n", TexGenType::Regular);
   out.Write("  default:\n"

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -365,10 +365,10 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
 
       break;
     case TexGenType::Color0:
-      out.Write("o.tex{}.xyz = float3(o.colors_0.x, o.colors_0.y, 1);\n", i);
+      out.Write("o.tex{}.xyz = float3(o.colors_0.r, o.colors_0.g + o.colors_0.b / 256.0, 1);\n", i);
       break;
     case TexGenType::Color1:
-      out.Write("o.tex{}.xyz = float3(o.colors_1.x, o.colors_1.y, 1);\n", i);
+      out.Write("o.tex{}.xyz = float3(o.colors_1.r, o.colors_1.g + o.colors_1.b / 256.0, 1);\n", i);
       break;
     case TexGenType::Regular:
     default:


### PR DESCRIPTION
YAGCD [says](http://hitmen.c02.at/files/yagcd/yagcd/chap5.html#sec5.11.4) (for `COLOR_STRGBC0`/`COLOR_STRGBC1`): "Color texgen: (s,t)=(r,g:b) (g and b are concatenated)".  I don't know if anything actually cares about this, and I haven't done any hardware testing to confirm this behavior (or what concatenation actually means here; I've assumed it's a multiplication by 256), but it's worth implementing at least as a test.