### PR TITLE
DolphinTool: initialize user directories before verify/convert operations

### DIFF
--- a/Source/Core/DolphinTool/CMakeLists.txt
+++ b/Source/Core/DolphinTool/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(dolphin-tool PROPERTIES OUTPUT_NAME dolphin-tool)
 target_link_libraries(dolphin-tool
 PRIVATE
   discio
+  uicommon
   videocommon
   cpp-optparse
 )

--- a/Source/Core/DolphinTool/ConvertCommand.cpp
+++ b/Source/Core/DolphinTool/ConvertCommand.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinTool/ConvertCommand.h"
+#include "UICommon/UICommon.h"
 
 #include <OptionParser.h>
 
@@ -12,6 +13,11 @@ int ConvertCommand::Main(const std::vector<std::string>& args)
   auto parser = std::make_unique<optparse::OptionParser>();
 
   parser->usage("usage: convert [options]... [FILE]...");
+
+  parser->add_option("-u", "--user")
+      .action("store")
+      .help("User folder path, required for temporary processing files."
+            "Will be automatically created if this option is not set.");
 
   parser->add_option("-i", "--input")
       .type("string")
@@ -55,6 +61,15 @@ int ConvertCommand::Main(const std::vector<std::string>& args)
             "zstd: 5");
 
   const optparse::Values& options = parser->parse_args(args);
+
+  // Initialize the dolphin user directory, required for temporary processing files
+  // If this is not set, destructive file operations could occur due to path confusion
+  std::string user_directory;
+  if (options.is_set("user"))
+    user_directory = static_cast<const char*>(options.get("user"));
+
+  UICommon::SetUserDirectory(user_directory);
+  UICommon::Init();
 
   // Validate options
 

--- a/Source/Core/DolphinTool/VerifyCommand.cpp
+++ b/Source/Core/DolphinTool/VerifyCommand.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinTool/VerifyCommand.h"
+#include "UICommon/UICommon.h"
 
 #include <OptionParser.h>
 
@@ -12,6 +13,11 @@ int VerifyCommand::Main(const std::vector<std::string>& args)
   auto parser = std::make_unique<optparse::OptionParser>();
 
   parser->usage("usage: verify [options]...");
+
+  parser->add_option("-u", "--user")
+      .action("store")
+      .help("User folder path, required for temporary processing files."
+            "Will be automatically created if this option is not set.");
 
   parser->add_option("-i", "--input")
       .type("string")
@@ -27,6 +33,15 @@ int VerifyCommand::Main(const std::vector<std::string>& args)
       .choices({"crc32", "md5", "sha1"});
 
   const optparse::Values& options = parser->parse_args(args);
+
+  // Initialize the dolphin user directory, required for temporary processing files
+  // If this is not set, destructive file operations could occur due to path confusion
+  std::string user_directory;
+  if (options.is_set("user"))
+    user_directory = static_cast<const char*>(options.get("user"));
+
+  UICommon::SetUserDirectory(user_directory);
+  UICommon::Init();
 
   // Validate options
   const std::string input_file_path = static_cast<const char*>(options.get("input"));


### PR DESCRIPTION
Verify operation and potentially, convert, require ephemeral space to process Wii images
This should fix accidental deletion of Wii images on certain filesystems (tmpfs, zfs) and "IOS_FS: Failed to write new FST" warnings
