### PR TITLE
GDB Stub: do not send a packet when we just connected

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -136,7 +136,8 @@ void Run()
         state_lock.unlock();
         if (GDBStub::IsActive() && GDBStub::HasControl())
         {
-          GDBStub::SendSignal(GDBStub::Signal::Sigtrap);
+          if (!GDBStub::JustConnected())
+            GDBStub::SendSignal(GDBStub::Signal::Sigtrap);
           GDBStub::ProcessCommands(true);
           // If we are still going to step, emulate the fact we just sent a step command
           if (GDBStub::HasControl())

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -61,6 +61,7 @@ enum class BreakpointType
 const s64 GDB_UPDATE_CYCLES = 100000;
 
 static bool s_has_control = false;
+static bool s_just_connected = false;
 
 static int s_tmpsock = -1;
 static int s_sock = -1;
@@ -898,6 +899,7 @@ static void HandleRemoveBreakpoint()
 
 void ProcessCommands(bool loop_until_continue)
 {
+  s_just_connected = false;
   while (IsActive())
   {
     if (CPU::GetState() == CPU::State::PowerDown)
@@ -1038,6 +1040,7 @@ static void InitGeneric(int domain, const sockaddr* server_addr, socklen_t serve
   if (s_sock < 0)
     ERROR_LOG_FMT(GDB_STUB, "Failed to accept gdb client");
   INFO_LOG_FMT(GDB_STUB, "Client connected.");
+  s_just_connected = true;
 
 #ifdef _WIN32
   closesocket(s_tmpsock);
@@ -1081,6 +1084,11 @@ bool HasControl()
 void TakeControl()
 {
   s_has_control = true;
+}
+
+bool JustConnected()
+{
+  return s_just_connected;
 }
 
 void SendSignal(Signal signal)

--- a/Source/Core/Core/PowerPC/GDBStub.h
+++ b/Source/Core/Core/PowerPC/GDBStub.h
@@ -22,6 +22,7 @@ void Deinit();
 bool IsActive();
 bool HasControl();
 void TakeControl();
+bool JustConnected();
 
 void ProcessCommands(bool loop_until_continue);
 void SendSignal(Signal signal);


### PR DESCRIPTION
When the CPU goes to stepping and gdb is active + has control, you are supposed to reply with a stop reply packet. The problem is we also do it if we just connected since the cpu will boot to stepping while it has connected with GDB just before.

This make sure we aren't sending the stop reply until the first processCommand loop.