### PR TITLE
Natvis improvements

### DIFF
--- a/Source/Core/Common/BitField.natvis
+++ b/Source/Core/Common/BitField.natvis
@@ -11,61 +11,64 @@
     This is a re-implementation of the abstract bitfield class' algrothm (in BitField.h)
     for Visual Studio to use for pretty-printing during debugging.
   -->
-  <Type Name="BitField&lt;*,*,*&gt;">
-    <DisplayString Condition="$T2 == 1"><![CDATA[{(storage & (1 << $T1)) != 0}]]></DisplayString>
-    <DisplayString><![CDATA[{(storage >> $T1) & ((1 << $T2) - 1)}]]></DisplayString>
+  <Type Name="BitField&lt;*,*,*,*&gt;">
+    <DisplayString><![CDATA[{($T3)((storage >> $T1) & ((1 << $T2) - 1))}]]></DisplayString>
     <Expand>
       <Item Name="Offset">$T1</Item>
       <Item Name="Size">$T2</Item>
     </Expand>
   </Type>
 
+  <!-- Similar re-implementation for BitFieldArray -->
+  <Type Name="BitFieldArray&lt;*,*,*,*,*&gt;">
+    <Expand>
+      <IndexListItems>
+        <Size>$T3</Size>
+        <ValueNode><![CDATA[($T4)((storage >> ($T1 + $T2*$i)) & ((1 << $T2) - 1))]]></ValueNode>
+      </IndexListItems>
+      <!-- Put these after the index list, so that the index list is the main thing in the unexpanded preview -->
+      <Item Name="Offset">$T1</Item>
+      <Item Name="Size">$T2</Item>
+      <Item Name="Count">$T3</Item>
+    </Expand>
+  </Type>
 
   <!--Specialised versions for signed types-->
-  <Type Name="BitField&lt;*,*,__int64&gt;">
+  <Type Name="BitField&lt;*,*,signed char,*&gt;">
+    <!-- It seems like we can't use s8/s16/s32/s64, nor can we use std::int8_t or the like; we have to use these names -->
+    <AlternativeType Name="BitField&lt;*,*,short,*&gt;" />
+    <AlternativeType Name="BitField&lt;*,*,int,*&gt;" />
+    <AlternativeType Name="BitField&lt;*,*,long long,*&gt;" />
+
     <!-- This is what I have do to get a sign extension in this crappy natvis "language"
          Basically, we check the top bit, if it's one, we add the remaining
          bits to the smallest (most negative) number. -->
-    <DisplayString Condition="(storage &amp; (1 &lt;&lt; ($T1 + $T2))) != 0">
-      <![CDATA[{(-1 * (1 << ($T2-1))) + ((storage >> $T1) & ((1 << ($T2-1)) - 1))}]]>
+    <DisplayString Condition="(storage &amp; (1 &lt;&lt; ($T1 + $T2 - 1))) != 0">
+      <![CDATA[{($T3)((-1 * (1 << ($T2-1))) + ((storage >> $T1) & ((1 << ($T2-1)) - 1)))}]]>
     </DisplayString>
-    <DisplayString><![CDATA[{(storage >> $T1) & ((1 << ($T2-1)) - 1)}]]></DisplayString>
+    <DisplayString><![CDATA[{($T3)((storage >> $T1) & ((1 << ($T2-1)) - 1))}]]></DisplayString>
     <Expand>
       <Item Name="Offset">$T1</Item>
       <Item Name="Size">$T2</Item>
     </Expand>
   </Type>
 
-  <!-- Oh, and I can't do a generic match for all signed types, so these are identical to the __int64 case above 
-       Would be nice if std::numeric_limits<$T3>::is_signed or std::is_signed<$T3>::value worked -->
-  <Type Name="BitField&lt;*,*,__int32&gt;">
-    <DisplayString Condition="(storage &amp; (1 &lt;&lt; ($T1 + $T2))) != 0">
-      <![CDATA[{(-1 * (1 << ($T2-1))) + ((storage >> $T1) & ((1 << ($T2-1)) - 1))}]]>
-    </DisplayString>
-    <DisplayString><![CDATA[{(storage >> $T1) & ((1 << ($T2-1)) - 1)}]]></DisplayString>
+  <Type Name="BitFieldArray&lt;*,*,*,signed char,*&gt;">
+    <AlternativeType Name="BitFieldArray&lt;*,*,*,short,*&gt;" />
+    <AlternativeType Name="BitFieldArray&lt;*,*,*,int,*&gt;" />
+    <AlternativeType Name="BitFieldArray&lt;*,*,*,long,*&gt;" />
+
     <Expand>
+      <IndexListItems>
+        <Size>$T3</Size>
+        <ValueNode Condition="(storage &amp; (1 &lt;&lt; ($T1 + $T2 * $i + $T2 - 1))) != 0">
+          <![CDATA[($T4)((-1 * (1 << ($T2-1))) + ((storage >> ($T1 + $T2*$i)) & ((1 << ($T2-1)) - 1)))]]>
+        </ValueNode>
+        <ValueNode><![CDATA[($T4)((storage >> ($T1 + $T2*$i)) & ((1 << ($T2-1)) - 1))]]></ValueNode>
+      </IndexListItems>
       <Item Name="Offset">$T1</Item>
       <Item Name="Size">$T2</Item>
-    </Expand>
-  </Type>
-  <Type Name="BitField&lt;*,*,__int16&gt;">
-    <DisplayString Condition="(storage &amp; (1 &lt;&lt; ($T1 + $T2))) != 0">
-      <![CDATA[{(-1 * (1 << ($T2-1))) + ((storage >> $T1) & ((1 << ($T2-1)) - 1))}]]>
-    </DisplayString>
-    <DisplayString><![CDATA[{(storage >> $T1) & ((1 << ($T2-1)) - 1)}]]></DisplayString>
-    <Expand>
-      <Item Name="Offset">$T1</Item>
-      <Item Name="Size">$T2</Item>
-    </Expand>
-  </Type>
-  <Type Name="BitField&lt;*,*,__int8&gt;">
-    <DisplayString Condition="(storage &amp; (1 &lt;&lt; ($T1 + $T2))) != 0">
-      <![CDATA[{(-1 * (1 << ($T2-1))) + ((storage >> $T1) & ((1 << ($T2-1)) - 1))}]]>
-    </DisplayString>
-    <DisplayString><![CDATA[{(storage >> $T1) & ((1 << ($T2-1)) - 1)}]]></DisplayString>
-    <Expand>
-      <Item Name="Offset">$T1</Item>
-      <Item Name="Size">$T2</Item>
+      <Item Name="Count">$T3</Item>
     </Expand>
   </Type>
 </AutoVisualizer>

--- a/Source/Core/Common/EnumMap.natvis
+++ b/Source/Core/Common/EnumMap.natvis
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2022 Dolphin Emulator Project
+  SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="Common::EnumMap&lt;*,*,*&gt;">
+    <Expand>
+      <!-- The following would work, except ValueNode for IndexListItems doesn't support the Name attribute.
+      It's only allowed for LinkedListItems and TreeItems, for some reason.  So we get to reimplement it with CustomListItems. -->
+      <!--
+      <IndexListItems>
+        <Size>$T2 + 1</Size>
+        <ValueNode Name="[{($T3)$i}]">m_array[$i]</ValueNode>
+      </IndexListItems>
+      -->
+      <CustomListItems MaxItemsPerView="5000">
+        <Variable Name="i" InitialValue="0" />
+        <!-- Size is incremented by 1 since the template argument is the last member (inclusive), but we want the count (exclusive) -->
+        <Size>$T2 + 1</Size>
+        <Loop>
+          <Break Condition="i > $T2" />
+          <Item Name="[{($T3)i}]">m_array[i]</Item>
+          <Exec>i++</Exec>
+        </Loop>
+      </CustomListItems>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -1240,5 +1240,6 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="Common\BitField.natvis" />
+    <Natvis Include="Common\EnumMap.natvis" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I've improved the natvis files for BitField, and added one for EnumMap.  See [this page](https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2022) for more info about natvis, and [here's Microsoft's STL natvis](https://github.com/microsoft/STL/blob/main/stl/debugger/STL.natvis).  Basically, it's an XML pseudo-language with a lot of quirks which is used for defining how things should show up in the visual studio debugger.

Here's some screenshots of the new EnumMap display in the debugger:

![image](https://user-images.githubusercontent.com/8334194/147892378-b52d467a-c90a-41de-8e0f-0992f7a53e6b.png)
![image](https://user-images.githubusercontent.com/8334194/147892658-05f7ee13-aeaa-4be5-93aa-5825c9b51f57.png)

<details><summary>And here's a diff in formatting for all of the stuff in <code>BitFieldTest</code>:</summary>

```diff
 TEST(BitField, Storage)
 ?object
 {hex=0 full_u64=0 full_s64=0 ...}
     hex: 0
     full_u64: 0
     full_s64: 0
     regular_field_unsigned: 0
     regular_field_unsigned2: 0
     regular_field_signed: 0
     at_dword_boundary: 0
-    signed_1bit: false
+    signed_1bit: 0
     flag: false
-    enum_1: 0
-    enum_2: 0
+    enum_1: A (0)
+    enum_2: A (0)
 ?object
 {hex=18446744073709551615 full_u64=18446744073709551615 full_s64=-1 ...}
     hex: 18446744073709551615
     full_u64: 18446744073709551615
     full_s64: -1
     regular_field_unsigned: 7
     regular_field_unsigned2: 7
     regular_field_signed: 7
     at_dword_boundary: 15
-    signed_1bit: true
-    flag: false
-    enum_1: 3
-    enum_2: 3
+    signed_1bit: 1
+    flag: true
+    enum_1: D (3)
+    enum_2: D (3)
 ?object
 {hex=9223372036854775807 full_u64=9223372036854775807 full_s64=9223372036854775807 ...}
     hex: 9223372036854775807
     full_u64: 9223372036854775807
     full_s64: 9223372036854775807
     regular_field_unsigned: 7
     regular_field_unsigned2: 7
     regular_field_signed: 7
     at_dword_boundary: 15
-    signed_1bit: true
+    signed_1bit: 1
     flag: false
-    enum_1: 3
-    enum_2: 3
+    enum_1: D (3)
+    enum_2: D (3)
 ?object
 {hex=9223372036854775808 full_u64=9223372036854775808 full_s64=-9223372036854775808 ...}
     hex: 9223372036854775808
     full_u64: 9223372036854775808
     full_s64: -9223372036854775808
     regular_field_unsigned: 0
     regular_field_unsigned2: 0
     regular_field_signed: 0
     at_dword_boundary: 0
-    signed_1bit: false
-    flag: false
-    enum_1: 0
-    enum_2: 0
+    signed_1bit: 0
+    flag: true
+    enum_1: A (0)
+    enum_2: A (0)
 ?object
 {hex=9223372036854775880 full_u64=9223372036854775880 full_s64=-9223372036854775736 ...}
     hex: 9223372036854775880
     full_u64: 9223372036854775880
     full_s64: -9223372036854775736
     regular_field_unsigned: 0
     regular_field_unsigned2: 0
     regular_field_signed: 0
     at_dword_boundary: 0
-    signed_1bit: false
-    flag: false
-    enum_1: 0
-    enum_2: 0
+    signed_1bit: 0
+    flag: true
+    enum_1: A (0)
+    enum_2: A (0)
 ?object
 {hex=1115638279670828351 full_u64=1115638279670828351 full_s64=1115638279670828351 ...}
     hex: 1115638279670828351
     full_u64: 1115638279670828351
     full_s64: 1115638279670828351
     regular_field_unsigned: 6
     regular_field_unsigned2: 6
     regular_field_signed: 6
     at_dword_boundary: 10
-    signed_1bit: true
+    signed_1bit: 1
     flag: false
-    enum_1: 3
-    enum_2: 3
+    enum_1: D (3)
+    enum_2: D (3)
 ?object
 {hex=12157589738054409517 full_u64=12157589738054409517 full_s64=-6289154335655142099 ...}
     hex: 12157589738054409517
     full_u64: 12157589738054409517
     full_s64: -6289154335655142099
     regular_field_unsigned: 6
     regular_field_unsigned2: 6
     regular_field_signed: 6
     at_dword_boundary: 15
-    signed_1bit: true
-    flag: false
-    enum_1: 2
-    enum_2: 0
+    signed_1bit: 1
+    flag: true
+    enum_1: C (2)
+    enum_2: A (0)
 ?object
 {hex=1952210759788999965 full_u64=1952210759788999965 full_s64=1952210759788999965 ...}
     hex: 1952210759788999965
     full_u64: 1952210759788999965
     full_s64: 1952210759788999965
     regular_field_unsigned: 2
     regular_field_unsigned2: 2
     regular_field_signed: 2
     at_dword_boundary: 14
-    signed_1bit: false
+    signed_1bit: 0
     flag: false
-    enum_1: 3
-    enum_2: 3
+    enum_1: D (3)
+    enum_2: D (3)
 ?object
 {hex=16372065037784856923 full_u64=16372065037784856923 full_s64=-2074679035924694693 ...}
     hex: 16372065037784856923
     full_u64: 16372065037784856923
     full_s64: -2074679035924694693
     regular_field_unsigned: 4
     regular_field_unsigned2: 4
     regular_field_signed: 4
     at_dword_boundary: 2
-    signed_1bit: false
-    flag: false
-    enum_1: 2
-    enum_2: 1
+    signed_1bit: 0
+    flag: true
+    enum_1: C (2)
+    enum_2: B (1)
 
 TEST(BitFieldArray, Unsigned)
 ?object
 {hex=0 a=0 b=0 ...}
     hex: 0
     a: 0
     b: 0
     c: 0
-    arr: {storage=0 }
+    arr: {[0]=0 [1]=0 [2]=0 ...}
 ?object
 {hex=2 a=2 b=0 ...}
     hex: 2
     a: 2
     b: 0
     c: 0
-    arr: {storage=2 }
+    arr: {[0]=2 [1]=0 [2]=0 ...}
 ?object
 {hex=14 a=2 b=3 ...}
     hex: 14
     a: 2
     b: 3
     c: 0
-    arr: {storage=14 }
+    arr: {[0]=2 [1]=3 [2]=0 ...}
 ?object
 {hex=62 a=2 b=3 ...}
     hex: 62
     a: 2
     b: 3
     c: 3
-    arr: {storage=62 }
+    arr: {[0]=2 [1]=3 [2]=3 ...}
 ?object
 {hex=58 a=2 b=2 ...}
     hex: 58
     a: 2
     b: 2
     c: 3
-    arr: {storage=58 }
+    arr: {[0]=2 [1]=2 [2]=3 ...}
 ?object
 {hex=21 a=1 b=1 ...}
     hex: 21
     a: 1
     b: 1
     c: 1
-    arr: {storage=21 }
+    arr: {[0]=1 [1]=1 [2]=1 ...}
 ?object
 {hex=63 a=3 b=3 ...}
     hex: 63
     a: 3
     b: 3
     c: 3
-    arr: {storage=63 }
+    arr: {[0]=3 [1]=3 [2]=3 ...}
 ?object
 {hex=36 a=0 b=1 ...}
     hex: 36
     a: 0
     b: 1
     c: 2
-    arr: {storage=36 }
+    arr: {[0]=0 [1]=1 [2]=2 ...}
 
 TEST(BitFieldArray, Signed)
 ?object
 {hex=0 a=0 b=0 ...}
     hex: 0
     a: 0
     b: 0
     c: 0
-    arr: {storage=0 }
+    arr: {[0]=0 [1]=0 [2]=0 ...}
 ?object
-{hex=64 a=2 b=0 ...}
+{hex=64 a=-2 b=0 ...}
     hex: 64
-    a: 2
+    a: -2
     b: 0
     c: 0
-    arr: {storage=64 }
+    arr: {[0]=-2 [1]=0 [2]=0 ...}
 ?object
-{hex=448 a=2 b=3 ...}
+{hex=448 a=-2 b=-1 ...}
     hex: 448
-    a: 2
-    b: 3
+    a: -2
+    b: -1
     c: 0
-    arr: {storage=448 }
+    arr: {[0]=-2 [1]=-1 [2]=0 ...}
 ?object
-{hex=1984 a=2 b=3 ...}
+{hex=1984 a=-2 b=-1 ...}
     hex: 1984
-    a: 2
-    b: 3
-    c: 3
-    arr: {storage=1984 }
+    a: -2
+    b: -1
+    c: -1
+    arr: {[0]=-2 [1]=-1 [2]=-1 ...}
 ?object
-{hex=1856 a=2 b=2 ...}
+{hex=1856 a=-2 b=-2 ...}
     hex: 1856
-    a: 2
-    b: 2
-    c: 3
-    arr: {storage=1856 }
+    a: -2
+    b: -2
+    c: -1
+    arr: {[0]=-2 [1]=-2 [2]=-1 ...}
 ?object
 {hex=672 a=1 b=1 ...}
     hex: 672
     a: 1
     b: 1
     c: 1
-    arr: {storage=672 }
+    arr: {[0]=1 [1]=1 [2]=1 ...}
 ?object
-{hex=2016 a=3 b=3 ...}
+{hex=2016 a=-1 b=-1 ...}
     hex: 2016
-    a: 3
-    b: 3
-    c: 3
-    arr: {storage=2016 }
+    a: -1
+    b: -1
+    c: -1
+    arr: {[0]=-1 [1]=-1 [2]=-1 ...}
 ?object
 {hex=1152 a=0 b=1 ...}
     hex: 1152
     a: 0
     b: 1
-    c: 2
-    arr: {storage=1152 }
+    c: -2
+    arr: {[0]=0 [1]=1 [2]=-2 ...}
 
 TEST(BitFieldArray, Enum)
 ?object
-{hex=0 a=0 b=0 ...}
+{hex=0 a=A (0) b=A (0) ...}
     hex: 0
-    a: 0
-    b: 0
-    c: 0
-    d: 0
-    arr: {storage=0 }
+    a: A (0)
+    b: A (0)
+    c: A (0)
+    d: A (0)
+    arr: {[0]=A (0) [1]=A (0) [2]=A (0) ...}
 ?object
-{hex=1073741824 a=1 b=0 ...}
+{hex=1073741824 a=B (1) b=A (0) ...}
     hex: 1073741824
-    a: 1
-    b: 0
-    c: 0
-    d: 0
-    arr: {storage=1073741824 }
+    a: B (1)
+    b: A (0)
+    c: A (0)
+    d: A (0)
+    arr: {[0]=B (1) [1]=A (0) [2]=A (0) ...}
 ?object
-{hex=9663676416 a=1 b=2 ...}
+{hex=9663676416 a=B (1) b=C (2) ...}
     hex: 9663676416
-    a: 1
-    b: 2
-    c: 0
-    d: 0
-    arr: {storage=9663676416 }
+    a: B (1)
+    b: C (2)
+    c: A (0)
+    d: A (0)
+    arr: {[0]=B (1) [1]=C (2) [2]=A (0) ...}
 ?object
-{hex=44023414784 a=1 b=2 ...}
+{hex=44023414784 a=B (1) b=C (2) ...}
     hex: 44023414784
-    a: 1
-    b: 2
-    c: 2
-    d: 0
-    arr: {storage=44023414784 }
+    a: B (1)
+    b: C (2)
+    c: C (2)
+    d: A (0)
+    arr: {[0]=B (1) [1]=C (2) [2]=C (2) ...}
 ?object
-{hex=112742891520 a=1 b=2 ...}
+{hex=112742891520 a=B (1) b=C (2) ...}
     hex: 112742891520
-    a: 1
-    b: 2
-    c: 2
-    d: 1
-    arr: {storage=112742891520 }
+    a: B (1)
+    b: C (2)
+    c: C (2)
+    d: B (1)
+    arr: {[0]=B (1) [1]=C (2) [2]=C (2) ...}
 ?object
-{hex=273804165120 a=3 b=3 ...}
+{hex=273804165120 a=D (3) b=D (3) ...}
     hex: 273804165120
-    a: 3
-    b: 3
-    c: 3
-    d: 3
-    arr: {storage=273804165120 }
+    a: D (3)
+    b: D (3)
+    c: D (3)
+    d: D (3)
+    arr: {[0]=D (3) [1]=D (3) [2]=D (3) ...}
 ?object
-{hex=182536110080 a=2 b=2 ...}
+{hex=182536110080 a=C (2) b=C (2) ...}
     hex: 182536110080
-    a: 2
-    b: 2
-    c: 2
-    d: 2
-    arr: {storage=182536110080 }
+    a: C (2)
+    b: C (2)
+    c: C (2)
+    d: C (2)
+    arr: {[0]=C (2) [1]=C (2) [2]=C (2) ...}
 ?object
-{hex=244813135872 a=0 b=1 ...}
+{hex=244813135872 a=A (0) b=B (1) ...}
     hex: 244813135872
-    a: 0
-    b: 1
-    c: 2
-    d: 3
-    arr: {storage=244813135872 }
+    a: A (0)
+    b: B (1)
+    c: C (2)
+    d: D (3)
+    arr: {[0]=A (0) [1]=B (1) [2]=C (2) ...}
 
 TEST(BitFieldArray, StorageType)
 ?object
-{hex=10737418240 arr1={storage=10737418240 } arr2={storage=10737418240 } }
+{hex=10737418240 arr1={[0]=0 '\0' [1]=0 '\0' [2]=0 '\0' ...} arr2={[0]=false [1]=true [2]=false ...} }
     hex: 10737418240
-    arr1: {storage=10737418240 }
-    arr2: {storage=10737418240 }
+    arr1: {[0]=0 '\0' [1]=0 '\0' [2]=0 '\0' ...}
+    arr2: {[0]=false [1]=true [2]=false ...}
 ?object
-{hex=11282810912 arr1={storage=11282810912 } arr2={storage=11282810912 } }
+{hex=11282810912 arr1={[0]=0 '\0' [1]=1 '\x1' [2]=2 '\x2' ...} arr2={[0]=false [1]=true [2]=false ...} }
     hex: 11282810912
-    arr1: {storage=11282810912 }
-    arr2: {storage=11282810912 }
+    arr1: {[0]=0 '\0' [1]=1 '\x1' [2]=2 '\x2' ...}
+    arr2: {[0]=false [1]=true [2]=false ...}
 ?object
-{hex=5914101792 arr1={storage=5914101792 } arr2={storage=5914101792 } }
+{hex=5914101792 arr1={[0]=0 '\0' [1]=1 '\x1' [2]=2 '\x2' ...} arr2={[0]=true [1]=false [2]=true ...} }
     hex: 5914101792
-    arr1: {storage=5914101792 }
-    arr2: {storage=5914101792 }
+    arr1: {[0]=0 '\0' [1]=1 '\x1' [2]=2 '\x2' ...}
+    arr2: {[0]=true [1]=false [2]=true ...}
 ?object
-{hex=10209069088 arr1={storage=10209069088 } arr2={storage=10209069088 } }
+{hex=10209069088 arr1={[0]=0 '\0' [1]=1 '\x1' [2]=2 '\x2' ...} arr2={[0]=true [1]=false [2]=false ...} }
     hex: 10209069088
-    arr1: {storage=10209069088 }
-    arr2: {storage=10209069088 }
+    arr1: {[0]=0 '\0' [1]=1 '\x1' [2]=2 '\x2' ...}
+    arr2: {[0]=true [1]=false [2]=false ...}
 ?object
-{hex=10209069088 arr1={storage=10209069088 } arr2={storage=10209069088 } }
+{hex=10209069088 arr1={[0]=0 '\0' [1]=1 '\x1' [2]=2 '\x2' ...} arr2={[0]=true [1]=false [2]=false ...} }
     hex: 10209069088
-    arr1: {storage=10209069088 }
-    arr2: {storage=10209069088 }
+    arr1: {[0]=0 '\0' [1]=1 '\x1' [2]=2 '\x2' ...}
+    arr2: {[0]=true [1]=false [2]=false ...}
 
 EnumMap example (located in PixelShaderGen)
 ?tev_alpha_funcs_table
-{m_array={ size=8 } }
-    m_array: { size=8 }
+{0x00007ff7449c81e0 "(false)", 0x00007ff7449c81e8 "(prev.a <  {})", 0x00007ff7449c81f8 "(prev.a == {})", ...}
+    [Never (0)]: 0x00007ff7449c81e0 "(false)"
+    [Less (1)]: 0x00007ff7449c81e8 "(prev.a <  {})"
+    [Equal (2)]: 0x00007ff7449c81f8 "(prev.a == {})"
+    [LEqual (3)]: 0x00007ff7449c8208 "(prev.a <= {})"
+    [Greater (4)]: 0x00007ff7449c8218 "(prev.a >  {})"
+    [NEqual (5)]: 0x00007ff7449c8228 "(prev.a != {})"
+    [GEqual (6)]: 0x00007ff7449c8238 "(prev.a >= {})"
+    [Always (7)]: 0x00007ff7449c80ac "(true)"
+    [Raw View]: {m_array={ size=8 } }
```

</details>

The main benefit here is looking at graphics registers (particularly BP and CP ones) in the visual studio debugger.  This is completely separate from the logic used by the fifo player (and `EnumFormatter` and the names used there).

Note that `signed_1bit` isn't handled right, but the signed field logic is already painful enough, and I don't think we actually use that in Dolphin (only in the unit test), so I'm not going to worry about it.