### PR TITLE
VideoBackends: fix crash that can occur when using d3d12 with shaders

### DIFF
--- a/Source/Core/VideoBackends/D3D12/DX12Shader.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Shader.cpp
@@ -13,10 +13,6 @@ namespace DX12
 DXShader::DXShader(ShaderStage stage, BinaryData bytecode, std::string_view name)
     : D3DCommon::Shader(stage, std::move(bytecode)), m_name(UTF8ToWString(name))
 {
-  if (!m_name.empty())
-  {
-    m_compute_pipeline->SetName(m_name.c_str());
-  }
 }
 
 DXShader::~DXShader() = default;
@@ -56,7 +52,15 @@ bool DXShader::CreateComputePipeline()
   HRESULT hr = g_dx_context->GetDevice()->CreateComputePipelineState(
       &desc, IID_PPV_ARGS(&m_compute_pipeline));
   CHECK(SUCCEEDED(hr), "Creating compute pipeline failed");
-  return SUCCEEDED(hr);
+  if (SUCCEEDED(hr))
+  {
+    if (!m_name.empty())
+    {
+      m_compute_pipeline->SetName(m_name.c_str());
+    }
+    return true;
+  }
+  return false;
 }
 
 }  // namespace DX12


### PR DESCRIPTION
This wasn't a problem initially because nothing was using the debug features initially but then #10269 was merged which could potentially cause this behavior.