### PR TITLE
Vulkan: Check for vkSetDebugUtilsObjectNameEXT before using it

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VKShader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.cpp
@@ -17,7 +17,7 @@ VKShader::VKShader(ShaderStage stage, std::vector<u32> spv, VkShaderModule mod,
     : AbstractShader(stage), m_spv(std::move(spv)), m_module(mod),
       m_compute_pipeline(VK_NULL_HANDLE), m_name(name)
 {
-  if (!m_name.empty())
+  if (!m_name.empty() && vkSetDebugUtilsObjectNameEXT)
   {
     VkDebugUtilsObjectNameInfoEXT name_info = {};
     name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
@@ -32,7 +32,7 @@ VKShader::VKShader(std::vector<u32> spv, VkPipeline compute_pipeline, std::strin
     : AbstractShader(ShaderStage::Compute), m_spv(std::move(spv)), m_module(VK_NULL_HANDLE),
       m_compute_pipeline(compute_pipeline), m_name(name)
 {
-  if (!m_name.empty())
+  if (!m_name.empty() && vkSetDebugUtilsObjectNameEXT)
   {
     VkDebugUtilsObjectNameInfoEXT name_info = {};
     name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -29,7 +29,7 @@ VKTexture::VKTexture(const TextureConfig& tex_config, VkDeviceMemory device_memo
     : AbstractTexture(tex_config), m_device_memory(device_memory), m_image(image), m_layout(layout),
       m_compute_layout(compute_layout), m_name(name)
 {
-  if (!m_name.empty())
+  if (!m_name.empty() && vkSetDebugUtilsObjectNameEXT)
   {
     VkDebugUtilsObjectNameInfoEXT name_info = {};
     name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;


### PR DESCRIPTION
Fixes a crash that has been present on Android (and probably also macOS) since the merge of PR #10269.

This is my first time touching Vulkan, and I don't know if this is a "proper" solution. (Should we check for the existence of VK_EXT_debug_utils rather than checking the vkSetDebugUtilsObjectNameEXT function pointer directly?)