### PR TITLE
Android: Remove all setRetainInstance calls

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -100,7 +100,6 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   {
     super.onCreate(savedInstanceState);
 
-    setRetainInstance(true);
     Bundle args = getArguments();
     MenuTag menuTag = (MenuTag) args.getSerializable(ARGUMENT_MENU_TAG);
     String gameId = getArguments().getString(ARGUMENT_GAME_ID);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -75,9 +75,6 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
   {
     super.onCreate(savedInstanceState);
 
-    // So this fragment doesn't restart on configuration changes; i.e. rotation.
-    setRetainInstance(true);
-
     mGamePaths = getArguments().getStringArray(KEY_GAMEPATHS);
     mRiivolution = getArguments().getBoolean(KEY_RIIVOLUTION);
   }


### PR DESCRIPTION
Our reasons for using `setRetainInstance` were gotten rid of in PRs #9011 and #10008, so let's remove our calls to this deprecated method.