### PR TITLE
InputCommon: Re-enable "Modifier" "Range" settings.

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -198,10 +198,6 @@ void GCPad::LoadDefaults(const ControllerInterface& ciface)
   m_buttons->SetControlExpression(5, "`Return`");
 #endif
 
-  // stick modifiers to 50 %
-  m_main_stick->controls[4]->control_ref->range = 0.5f;
-  m_c_stick->controls[4]->control_ref->range = 0.5f;
-
   // D-Pad
   m_dpad->SetControlExpression(0, "`T`");  // Up
   m_dpad->SetControlExpression(1, "`G`");  // Down

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -40,9 +40,7 @@ AnalogStick::ReshapeData AnalogStick::GetReshapableState(bool adjusted) const
   if (!adjusted)
     return {x, y};
 
-  const ControlState modifier = controls[4]->GetState();
-
-  return Reshape(x, y, modifier);
+  return Reshape(x, y, GetModifierInput()->GetState());
 }
 
 AnalogStick::StateData AnalogStick::GetState() const
@@ -53,6 +51,11 @@ AnalogStick::StateData AnalogStick::GetState() const
 ControlState AnalogStick::GetGateRadiusAtAngle(double ang) const
 {
   return m_stick_gate->GetRadiusAtAngle(ang);
+}
+
+Control* AnalogStick::GetModifierInput() const
+{
+  return controls[4].get();
 }
 
 OctagonAnalogStick::OctagonAnalogStick(const char* name_, ControlState gate_radius)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -23,6 +23,8 @@ public:
   StateData GetState() const;
 
 private:
+  Control* GetModifierInput() const override;
+
   std::unique_ptr<StickGate> m_stick_gate;
 };
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -50,9 +50,7 @@ Tilt::ReshapeData Tilt::GetReshapableState(bool adjusted) const
   if (!adjusted)
     return {x, y};
 
-  const ControlState modifier = controls[4]->GetState();
-
-  return Reshape(x, y, modifier);
+  return Reshape(x, y, GetModifierInput()->GetState());
 }
 
 Tilt::StateData Tilt::GetState() const
@@ -74,6 +72,11 @@ ControlState Tilt::GetDefaultInputRadiusAtAngle(double ang) const
 ControlState Tilt::GetMaxRotationalVelocity() const
 {
   return m_max_rotational_velocity.GetValue() * MathUtil::TAU;
+}
+
+Control* Tilt::GetModifierInput() const
+{
+  return controls[4].get();
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
@@ -31,6 +31,8 @@ public:
   ControlState GetMaxRotationalVelocity() const;
 
 private:
+  Control* GetModifierInput() const override;
+
   SettingValue<double> m_max_angle_setting;
   SettingValue<double> m_max_rotational_velocity;
 };

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -110,6 +110,8 @@ protected:
   ReshapeData Reshape(ControlState x, ControlState y, ControlState modifier = 0.0,
                       ControlState clamp = 1.0) const;
 
+  virtual Control* GetModifierInput() const;
+
 private:
   void LoadConfig(IniFile::Section*, const std::string&, const std::string&) override;
   void SaveConfig(IniFile::Section*, const std::string&, const std::string&) override;


### PR DESCRIPTION
Use value of "Modifier" button "Range" setting rather than always applying 50%.
Make "Clear" button reset "Modifier" "Range" settings to 50%.