### PR TITLE
Config: Remove CompareServer and CompareClient settings.

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -191,9 +191,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
 
   SConfig& StartUp = SConfig::GetInstance();
 
-  StartUp.bRunCompareClient = false;
-  StartUp.bRunCompareServer = false;
-
   config_cache.SaveConfig(StartUp);
 
   if (!StartUp.SetPathsAndGameMetadata(*boot))

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -96,8 +96,6 @@ const Info<bool> MAIN_WII_KEYBOARD{{System::Main, "Core", "WiiKeyboard"}, false}
 const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING{
     {System::Main, "Core", "WiimoteContinuousScanning"}, false};
 const Info<bool> MAIN_WIIMOTE_ENABLE_SPEAKER{{System::Main, "Core", "WiimoteEnableSpeaker"}, false};
-const Info<bool> MAIN_RUN_COMPARE_SERVER{{System::Main, "Core", "RunCompareServer"}, false};
-const Info<bool> MAIN_RUN_COMPARE_CLIENT{{System::Main, "Core", "RunCompareClient"}, false};
 const Info<bool> MAIN_MMU{{System::Main, "Core", "MMU"}, false};
 const Info<int> MAIN_BB_DUMP_PORT{{System::Main, "Core", "BBDumpPort"}, -1};
 const Info<bool> MAIN_SYNC_GPU{{System::Main, "Core", "SyncGPU"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -72,8 +72,6 @@ extern const Info<bool> MAIN_WII_SD_CARD;
 extern const Info<bool> MAIN_WII_KEYBOARD;
 extern const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING;
 extern const Info<bool> MAIN_WIIMOTE_ENABLE_SPEAKER;
-extern const Info<bool> MAIN_RUN_COMPARE_SERVER;
-extern const Info<bool> MAIN_RUN_COMPARE_CLIENT;
 extern const Info<bool> MAIN_MMU;
 extern const Info<int> MAIN_BB_DUMP_PORT;
 extern const Info<bool> MAIN_SYNC_GPU;

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -119,8 +119,6 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("WiimoteContinuousScanning", m_WiimoteContinuousScanning);
   core->Set("WiimoteEnableSpeaker", m_WiimoteEnableSpeaker);
   core->Set("WiimoteControllerInterface", connect_wiimotes_for_ciface);
-  core->Set("RunCompareServer", bRunCompareServer);
-  core->Set("RunCompareClient", bRunCompareClient);
   core->Set("MMU", bMMU);
   core->Set("EmulationSpeed", m_EmulationSpeed);
   core->Set("GPUDeterminismMode", m_strGPUDeterminismMode);
@@ -159,8 +157,6 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("WiimoteContinuousScanning", &m_WiimoteContinuousScanning, false);
   core->Get("WiimoteEnableSpeaker", &m_WiimoteEnableSpeaker, false);
   core->Get("WiimoteControllerInterface", &connect_wiimotes_for_ciface, false);
-  core->Get("RunCompareServer", &bRunCompareServer, false);
-  core->Get("RunCompareClient", &bRunCompareClient, false);
   core->Get("MMU", &bMMU, bMMU);
   core->Get("BBDumpPort", &iBBDumpPort, -1);
   core->Get("SyncGPU", &bSyncGPU, false);
@@ -290,7 +286,6 @@ void SConfig::LoadDefaults()
   iTimingVariance = 40;
   bCPUThread = false;
   bSyncGPUOnSkipIdleHack = true;
-  bRunCompareServer = false;
   bFastmem = true;
   bDisableICache = false;
   bMMU = false;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -80,9 +80,6 @@ struct SConfig
   bool bSyncGPUOnSkipIdleHack = true;
   bool bCopyWiiSaveNetplay = true;
 
-  bool bRunCompareServer = false;
-  bool bRunCompareClient = false;
-
   bool bMMU = false;
   int iBBDumpPort = 0;
   bool bFastDiscSpeed = false;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -635,9 +635,8 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   // This adds the SyncGPU handler to CoreTiming, so now CoreTiming::Advance might block.
   Fifo::Prepare();
 
-  // Setup our core, but can't use dynarec if we are compare server
-  if (Config::Get(Config::MAIN_CPU_CORE) != PowerPC::CPUCore::Interpreter &&
-      (!core_parameter.bRunCompareServer || core_parameter.bRunCompareClient))
+  // Setup our core
+  if (Config::Get(Config::MAIN_CPU_CORE) != PowerPC::CPUCore::Interpreter)
   {
     PowerPC::SetMode(PowerPC::CoreMode::JIT);
   }


### PR DESCRIPTION
These don't seem to actually do anything except disabling the JIT in some combinations. I assume the functionality was removed at some point but the settings themselves weren't?