### PR TITLE
Core/NetPlay: Extend enet peer timeout

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -150,6 +150,9 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
       return;
     }
 
+    // Extend reliable traffic timeout
+    enet_peer_timeout(m_server, 0, 30000, 30000);
+
     ENetEvent netEvent;
     int net = enet_host_service(m_client, &netEvent, 5000);
     if (net > 0 && netEvent.type == ENET_EVENT_TYPE_CONNECT)

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -415,6 +415,9 @@ ConnectionError NetPlayServer::OnConnect(ENetPeer* socket, sf::Packet& rpac)
   if (StringUTF8CodePointCount(player.name) > MAX_NAME_LENGTH)
     return ConnectionError::NameTooLong;
 
+  // Extend reliable traffic timeout
+  enet_peer_timeout(socket, 0, 30000, 30000);
+
   // cause pings to be updated
   m_update_pings = true;
 


### PR DESCRIPTION
This extends the timeout to 30 seconds, so users who have brief connection issues won't be so swiftly disconnected, allowing the NetPlay session to continue.

This isn't easy to test normally, but I happen to have the right setup locally to create artificial packet loss, so I was able to verify that it works as intended.