### PR TITLE
Android: Mark s_android_send_report as static

### DIFF
--- a/Source/Core/Common/AndroidAnalytics.cpp
+++ b/Source/Core/Common/AndroidAnalytics.cpp
@@ -8,15 +8,18 @@
 
 namespace Common
 {
-std::function<void(std::string, std::string)> s_android_send_report;
+static std::function<void(std::string, std::string)> s_android_send_report;
+
 void AndroidSetReportHandler(std::function<void(std::string, std::string)> func)
 {
   s_android_send_report = std::move(func);
 }
+
 AndroidAnalyticsBackend::AndroidAnalyticsBackend(std::string passed_endpoint)
     : m_endpoint{std::move(passed_endpoint)}
 {
 }
+
 AndroidAnalyticsBackend::~AndroidAnalyticsBackend() = default;
 
 void AndroidAnalyticsBackend::Send(std::string report)


### PR DESCRIPTION
Fixes a compiler warning.