### PR TITLE
Config: Port EXI device and SI device settings to new config system.

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -67,7 +67,6 @@ public:
   bool bSetVolume = false;
   std::array<bool, MAX_BBMOTES> bSetWiimoteSource{};
   std::array<bool, SerialInterface::MAX_SI_CHANNELS> bSetPads{};
-  std::array<bool, ExpansionInterface::MAX_EXI_CHANNELS> bSetEXIDevice{};
 
 private:
   bool valid = false;
@@ -79,7 +78,6 @@ private:
   float fSyncGpuOverclock = 0;
   std::array<WiimoteSource, MAX_BBMOTES> iWiimoteSource{};
   std::array<SerialInterface::SIDevices, SerialInterface::MAX_SI_CHANNELS> Pads{};
-  std::array<ExpansionInterface::TEXIDevices, ExpansionInterface::MAX_EXI_CHANNELS> m_EXIDevice{};
 };
 
 void ConfigCache::SaveConfig(const SConfig& config)
@@ -97,12 +95,10 @@ void ConfigCache::SaveConfig(const SConfig& config)
     iWiimoteSource[i] = WiimoteCommon::GetSource(i);
 
   std::copy(std::begin(config.m_SIDevice), std::end(config.m_SIDevice), std::begin(Pads));
-  std::copy(std::begin(config.m_EXIDevice), std::end(config.m_EXIDevice), std::begin(m_EXIDevice));
 
   bSetVolume = false;
   bSetWiimoteSource.fill(false);
   bSetPads.fill(false);
-  bSetEXIDevice.fill(false);
 }
 
 void ConfigCache::RestoreConfig(SConfig* config)
@@ -134,12 +130,6 @@ void ConfigCache::RestoreConfig(SConfig* config)
   {
     if (bSetPads[i])
       config->m_SIDevice[i] = Pads[i];
-  }
-
-  for (unsigned int i = 0; i < ExpansionInterface::MAX_EXI_CHANNELS; ++i)
-  {
-    if (bSetEXIDevice[i])
-      config->m_EXIDevice[i] = m_EXIDevice[i];
   }
 }
 
@@ -237,12 +227,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     Config::AddLayer(ConfigLoaders::GenerateNetPlayConfigLoader(netplay_settings));
     StartUp.bCPUThread = netplay_settings.m_CPUthread;
     StartUp.bCopyWiiSaveNetplay = netplay_settings.m_CopyWiiSave;
-    StartUp.m_EXIDevice[0] = netplay_settings.m_EXIDevice[0];
-    StartUp.m_EXIDevice[1] = netplay_settings.m_EXIDevice[1];
-    StartUp.m_EXIDevice[2] = netplay_settings.m_EXIDevice[2];
-    config_cache.bSetEXIDevice[0] = true;
-    config_cache.bSetEXIDevice[1] = true;
-    config_cache.bSetEXIDevice[2] = true;
     StartUp.bSyncGPU = netplay_settings.m_SyncGPU;
     StartUp.iSyncGpuMaxDistance = netplay_settings.m_SyncGpuMaxDistance;
     StartUp.iSyncGpuMinDistance = netplay_settings.m_SyncGpuMinDistance;

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -76,11 +76,19 @@ const Info<std::string> MAIN_BBA_MAC{{System::Main, "Core", "BBA_MAC"}, ""};
 const Info<std::string> MAIN_BBA_XLINK_IP{{System::Main, "Core", "BBA_XLINK_IP"}, "127.0.0.1"};
 const Info<bool> MAIN_BBA_XLINK_CHAT_OSD{{System::Main, "Core", "BBA_XLINK_CHAT_OSD"}, true};
 
-Info<u32> GetInfoForSIDevice(u32 channel)
+const Info<SerialInterface::SIDevices>& GetInfoForSIDevice(int channel)
 {
-  return {{System::Main, "Core", fmt::format("SIDevice{}", channel)},
-          static_cast<u32>(channel == 0 ? SerialInterface::SIDEVICE_GC_CONTROLLER :
-                                          SerialInterface::SIDEVICE_NONE)};
+  static const std::array<const Info<SerialInterface::SIDevices>, 4> infos{
+      Info<SerialInterface::SIDevices>{{System::Main, "Core", "SIDevice0"},
+                                       SerialInterface::SIDEVICE_GC_CONTROLLER},
+      Info<SerialInterface::SIDevices>{{System::Main, "Core", "SIDevice1"},
+                                       SerialInterface::SIDEVICE_NONE},
+      Info<SerialInterface::SIDevices>{{System::Main, "Core", "SIDevice2"},
+                                       SerialInterface::SIDEVICE_NONE},
+      Info<SerialInterface::SIDevices>{{System::Main, "Core", "SIDevice3"},
+                                       SerialInterface::SIDEVICE_NONE},
+  };
+  return infos[channel];
 }
 
 const Info<bool>& GetInfoForAdapterRumble(int channel)

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -54,11 +54,24 @@ const Info<std::string> MAIN_GCI_FOLDER_A_PATH_OVERRIDE{
     {System::Main, "Core", "GCIFolderAPathOverride"}, ""};
 const Info<std::string> MAIN_GCI_FOLDER_B_PATH_OVERRIDE{
     {System::Main, "Core", "GCIFolderBPathOverride"}, ""};
-const Info<int> MAIN_SLOT_A{{System::Main, "Core", "SlotA"},
-                            ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER};
-const Info<int> MAIN_SLOT_B{{System::Main, "Core", "SlotB"}, ExpansionInterface::EXIDEVICE_NONE};
-const Info<int> MAIN_SERIAL_PORT_1{{System::Main, "Core", "SerialPort1"},
-                                   ExpansionInterface::EXIDEVICE_NONE};
+
+const Info<ExpansionInterface::TEXIDevices> MAIN_SLOT_A{
+    {System::Main, "Core", "SlotA"}, ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER};
+const Info<ExpansionInterface::TEXIDevices> MAIN_SLOT_B{{System::Main, "Core", "SlotB"},
+                                                        ExpansionInterface::EXIDEVICE_NONE};
+const Info<ExpansionInterface::TEXIDevices> MAIN_SERIAL_PORT_1{
+    {System::Main, "Core", "SerialPort1"}, ExpansionInterface::EXIDEVICE_NONE};
+
+const Info<ExpansionInterface::TEXIDevices>& GetInfoForEXIDevice(int channel)
+{
+  static constexpr std::array<const Info<ExpansionInterface::TEXIDevices>*, 3> infos{
+      &MAIN_SLOT_A,
+      &MAIN_SLOT_B,
+      &MAIN_SERIAL_PORT_1,
+  };
+  return *infos[channel];
+}
+
 const Info<std::string> MAIN_BBA_MAC{{System::Main, "Core", "BBA_MAC"}, ""};
 const Info<std::string> MAIN_BBA_XLINK_IP{{System::Main, "Core", "BBA_XLINK_IP"}, "127.0.0.1"};
 const Info<bool> MAIN_BBA_XLINK_CHAT_OSD{{System::Main, "Core", "BBA_XLINK_CHAT_OSD"}, true};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -31,6 +31,11 @@ namespace AudioCommon
 enum class DPL2Quality;
 }
 
+namespace ExpansionInterface
+{
+enum TEXIDevices : int;
+}
+
 namespace Config
 {
 // Main.Core
@@ -59,9 +64,10 @@ extern const Info<std::string> MAIN_AGP_CART_A_PATH;
 extern const Info<std::string> MAIN_AGP_CART_B_PATH;
 extern const Info<std::string> MAIN_GCI_FOLDER_A_PATH_OVERRIDE;
 extern const Info<std::string> MAIN_GCI_FOLDER_B_PATH_OVERRIDE;
-extern const Info<int> MAIN_SLOT_A;
-extern const Info<int> MAIN_SLOT_B;
-extern const Info<int> MAIN_SERIAL_PORT_1;
+extern const Info<ExpansionInterface::TEXIDevices> MAIN_SLOT_A;
+extern const Info<ExpansionInterface::TEXIDevices> MAIN_SLOT_B;
+extern const Info<ExpansionInterface::TEXIDevices> MAIN_SERIAL_PORT_1;
+const Info<ExpansionInterface::TEXIDevices>& GetInfoForEXIDevice(int channel);
 extern const Info<std::string> MAIN_BBA_MAC;
 extern const Info<std::string> MAIN_BBA_XLINK_IP;
 extern const Info<bool> MAIN_BBA_XLINK_CHAT_OSD;

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -36,6 +36,11 @@ namespace ExpansionInterface
 enum TEXIDevices : int;
 }
 
+namespace SerialInterface
+{
+enum SIDevices : int;
+}
+
 namespace Config
 {
 // Main.Core
@@ -71,7 +76,7 @@ const Info<ExpansionInterface::TEXIDevices>& GetInfoForEXIDevice(int channel);
 extern const Info<std::string> MAIN_BBA_MAC;
 extern const Info<std::string> MAIN_BBA_XLINK_IP;
 extern const Info<bool> MAIN_BBA_XLINK_CHAT_OSD;
-Info<u32> GetInfoForSIDevice(u32 channel);
+const Info<SerialInterface::SIDevices>& GetInfoForSIDevice(int channel);
 const Info<bool>& GetInfoForAdapterRumble(int channel);
 const Info<bool>& GetInfoForSimulateKonga(int channel);
 extern const Info<bool> MAIN_WII_SD_CARD;

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -75,6 +75,10 @@ static const INIToLocationMap& GetINIToLocationMap()
       {{"Wii", "Language"}, {Config::SYSCONF_LANGUAGE.GetLocation()}},
       {{"Core", "HLE_BS2"}, {Config::MAIN_SKIP_IPL.GetLocation()}},
       {{"Core", "GameCubeLanguage"}, {Config::MAIN_GC_LANGUAGE.GetLocation()}},
+      {{"Core", "PadType0"}, {Config::GetInfoForSIDevice(0).GetLocation()}},
+      {{"Core", "PadType1"}, {Config::GetInfoForSIDevice(1).GetLocation()}},
+      {{"Core", "PadType2"}, {Config::GetInfoForSIDevice(2).GetLocation()}},
+      {{"Core", "PadType3"}, {Config::GetInfoForSIDevice(3).GetLocation()}},
   };
   return ini_to_location;
 }

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -113,6 +113,10 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_SLOT_A.GetLocation(),
       &Config::MAIN_SLOT_B.GetLocation(),
       &Config::MAIN_SERIAL_PORT_1.GetLocation(),
+      &Config::GetInfoForSIDevice(0).GetLocation(),
+      &Config::GetInfoForSIDevice(1).GetLocation(),
+      &Config::GetInfoForSIDevice(2).GetLocation(),
+      &Config::GetInfoForSIDevice(3).GetLocation(),
 
       // UI.General
 

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -110,6 +110,9 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_WIIMOTE_CONTINUOUS_SCANNING.GetLocation(),
       &Config::MAIN_WIIMOTE_ENABLE_SPEAKER.GetLocation(),
       &Config::MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE.GetLocation(),
+      &Config::MAIN_SLOT_A.GetLocation(),
+      &Config::MAIN_SLOT_B.GetLocation(),
+      &Config::MAIN_SERIAL_PORT_1.GetLocation(),
 
       // UI.General
 

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -37,9 +37,9 @@ public:
     layer->Set(Config::MAIN_DSP_HLE, m_settings.m_DSPHLE);
     layer->Set(Config::MAIN_OVERCLOCK_ENABLE, m_settings.m_OCEnable);
     layer->Set(Config::MAIN_OVERCLOCK, m_settings.m_OCFactor);
-    layer->Set(Config::MAIN_SLOT_A, static_cast<int>(m_settings.m_EXIDevice[0]));
-    layer->Set(Config::MAIN_SLOT_B, static_cast<int>(m_settings.m_EXIDevice[1]));
-    layer->Set(Config::MAIN_SERIAL_PORT_1, static_cast<int>(m_settings.m_EXIDevice[2]));
+    layer->Set(Config::MAIN_SLOT_A, m_settings.m_EXIDevice[0]);
+    layer->Set(Config::MAIN_SLOT_B, m_settings.m_EXIDevice[1]);
+    layer->Set(Config::MAIN_SERIAL_PORT_1, m_settings.m_EXIDevice[2]);
     layer->Set(Config::SESSION_SAVE_DATA_WRITABLE, m_settings.m_WriteToMemcard);
     layer->Set(Config::MAIN_RAM_OVERRIDE_ENABLE, m_settings.m_RAMOverrideEnable);
     layer->Set(Config::MAIN_MEM1_SIZE, m_settings.m_Mem1Size);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -104,10 +104,6 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("SyncGpuMaxDistance", iSyncGpuMaxDistance);
   core->Set("SyncGpuMinDistance", iSyncGpuMinDistance);
   core->Set("SyncGpuOverclock", fSyncGpuOverclock);
-  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
-  {
-    core->Set(fmt::format("SIDevice{}", i), m_SIDevice[i]);
-  }
   core->Set("MMU", bMMU);
 }
 
@@ -127,11 +123,6 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   IniFile::Section* core = ini.GetOrCreateSection("Core");
 
   core->Get("CPUThread", &bCPUThread, true);
-  for (size_t i = 0; i < std::size(m_SIDevice); ++i)
-  {
-    core->Get(fmt::format("SIDevice{}", i), &m_SIDevice[i],
-              (i == 0) ? SerialInterface::SIDEVICE_GC_CONTROLLER : SerialInterface::SIDEVICE_NONE);
-  }
   core->Get("MMU", &bMMU, bMMU);
   core->Get("BBDumpPort", &iBBDumpPort, -1);
   core->Get("SyncGPU", &bSyncGPU, false);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -104,9 +104,6 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("SyncGpuMaxDistance", iSyncGpuMaxDistance);
   core->Set("SyncGpuMinDistance", iSyncGpuMinDistance);
   core->Set("SyncGpuOverclock", fSyncGpuOverclock);
-  core->Set("SlotA", m_EXIDevice[0]);
-  core->Set("SlotB", m_EXIDevice[1]);
-  core->Set("SerialPort1", m_EXIDevice[2]);
   for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
   {
     core->Set(fmt::format("SIDevice{}", i), m_SIDevice[i]);
@@ -130,9 +127,6 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   IniFile::Section* core = ini.GetOrCreateSection("Core");
 
   core->Get("CPUThread", &bCPUThread, true);
-  core->Get("SlotA", (int*)&m_EXIDevice[0], ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER);
-  core->Get("SlotB", (int*)&m_EXIDevice[1], ExpansionInterface::EXIDEVICE_NONE);
-  core->Get("SerialPort1", (int*)&m_EXIDevice[2], ExpansionInterface::EXIDEVICE_NONE);
   for (size_t i = 0; i < std::size(m_SIDevice); ++i)
   {
     core->Get(fmt::format("SIDevice{}", i), &m_SIDevice[i],

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -114,8 +114,6 @@ struct SConfig
   static IniFile LoadLocalGameIni(const std::string& id, std::optional<u16> revision);
   static IniFile LoadGameIni(const std::string& id, std::optional<u16> revision);
 
-  SerialInterface::SIDevices m_SIDevice[4];
-
   SConfig(const SConfig&) = delete;
   SConfig& operator=(const SConfig&) = delete;
   SConfig(SConfig&&) = delete;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -114,7 +114,6 @@ struct SConfig
   static IniFile LoadLocalGameIni(const std::string& id, std::optional<u16> revision);
   static IniFile LoadGameIni(const std::string& id, std::optional<u16> revision);
 
-  ExpansionInterface::TEXIDevices m_EXIDevice[3];
   SerialInterface::SIDevices m_SIDevice[4];
 
   SConfig(const SConfig&) = delete;

--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/EXI/EXI_Channel.h"
@@ -45,7 +46,7 @@ void AddMemoryCards(int i)
   {
     if (Movie::IsUsingMemcard(i))
     {
-      if (SConfig::GetInstance().m_EXIDevice[i] == EXIDEVICE_MEMORYCARDFOLDER)
+      if (Config::Get(Config::GetInfoForEXIDevice(i)) == EXIDEVICE_MEMORYCARDFOLDER)
         memorycard_device = EXIDEVICE_MEMORYCARDFOLDER;
       else
         memorycard_device = EXIDEVICE_MEMORYCARD;
@@ -57,7 +58,7 @@ void AddMemoryCards(int i)
   }
   else
   {
-    memorycard_device = SConfig::GetInstance().m_EXIDevice[i];
+    memorycard_device = Config::Get(Config::GetInfoForEXIDevice(i));
   }
 
   g_Channels[i]->AddDevice(memorycard_device, 0);
@@ -101,7 +102,7 @@ void Init()
     AddMemoryCards(i);
 
   g_Channels[0]->AddDevice(EXIDEVICE_MASKROM, 1);
-  g_Channels[0]->AddDevice(SConfig::GetInstance().m_EXIDevice[2], 2);  // Serial Port 1
+  g_Channels[0]->AddDevice(Config::Get(Config::MAIN_SERIAL_PORT_1), 2);
   g_Channels[2]->AddDevice(EXIDEVICE_AD16, 0);
 
   changeDevice = CoreTiming::RegisterEvent("ChangeEXIDevice", ChangeDeviceCallback);

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -16,6 +16,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/MMIO.h"
@@ -411,7 +412,7 @@ void Init()
       }
       else if (Movie::IsUsingPad(i))
       {
-        SIDevices current = SConfig::GetInstance().m_SIDevice[i];
+        SIDevices current = Config::Get(Config::GetInfoForSIDevice(i));
         // GC pad-compatible devices can be used for both playing and recording
         if (Movie::IsUsingBongo(i))
           s_desired_device_types[i] = SIDEVICE_GC_TARUKONGA;
@@ -423,7 +424,7 @@ void Init()
     }
     else if (!NetPlay::IsNetPlayRunning())
     {
-      s_desired_device_types[i] = SConfig::GetInstance().m_SIDevice[i];
+      s_desired_device_types[i] = Config::Get(Config::GetInfoForSIDevice(i));
     }
 
     AddDevice(s_desired_device_types[i], i);

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -81,9 +81,8 @@ bool CSIDevice_GCAdapter::GetData(u32& hi, u32& low)
   return true;
 }
 
-void CSIDevice_GCController::Rumble(int pad_num, ControlState strength)
+void CSIDevice_GCController::Rumble(int pad_num, ControlState strength, SIDevices device)
 {
-  SIDevices device = SConfig::GetInstance().m_SIDevice[pad_num];
   if (device == SIDEVICE_WIIU_ADAPTER)
     GCAdapter::Output(pad_num, static_cast<u8>(strength));
   else if (SIDevice_IsGCController(device))

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -10,6 +10,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/Swap.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/ProcessorInterface.h"
@@ -33,6 +34,14 @@ CSIDevice_GCController::CSIDevice_GCController(SIDevices device, int device_numb
   m_origin.origin_stick_y = GCPadStatus::MAIN_STICK_CENTER_Y;
   m_origin.substick_x = GCPadStatus::C_STICK_CENTER_X;
   m_origin.substick_y = GCPadStatus::C_STICK_CENTER_Y;
+
+  m_config_changed_callback_id = Config::AddConfigChangedCallback([this] { RefreshConfig(); });
+  RefreshConfig();
+}
+
+CSIDevice_GCController::~CSIDevice_GCController()
+{
+  Config::RemoveConfigChangedCallback(m_config_changed_callback_id);
 }
 
 int CSIDevice_GCController::RunBuffer(u8* buffer, int request_length)
@@ -299,10 +308,11 @@ void CSIDevice_GCController::SendCommand(u32 command, u8 poll)
 
     if (pad_num < 4)
     {
+      const SIDevices device = m_config_si_devices[pad_num];
       if (type == 1)
-        CSIDevice_GCController::Rumble(pad_num, 1.0);
+        CSIDevice_GCController::Rumble(pad_num, 1.0, device);
       else
-        CSIDevice_GCController::Rumble(pad_num, 0.0);
+        CSIDevice_GCController::Rumble(pad_num, 0.0, device);
     }
 
     if (poll == 0)
@@ -326,6 +336,15 @@ void CSIDevice_GCController::DoState(PointerWrap& p)
   p.Do(m_mode);
   p.Do(m_timer_button_combo_start);
   p.Do(m_last_button_combo);
+}
+
+void CSIDevice_GCController::RefreshConfig()
+{
+  for (int i = 0; i < 4; ++i)
+  {
+    const SerialInterface::SIDevices device = Config::Get(Config::GetInfoForSIDevice(i));
+    m_config_si_devices[i] = device;
+  }
 }
 
 CSIDevice_TaruKonga::CSIDevice_TaruKonga(SIDevices device, int device_number)

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "Core/HW/GCPad.h"
 #include "Core/HW/SI/SI_Device.h"
 #include "InputCommon/GCPadStatus.h"
@@ -52,6 +54,7 @@ protected:
 public:
   // Constructor
   CSIDevice_GCController(SIDevices device, int device_number);
+  ~CSIDevice_GCController() override;
 
   // Run the SI Buffer
   int RunBuffer(u8* buffer, int request_length) override;
@@ -74,12 +77,18 @@ public:
   static int NetPlay_InGamePadToLocalPad(int pad_num);
 
   // Direct rumble to the right GC Controller
-  static void Rumble(int pad_num, ControlState strength);
+  static void Rumble(int pad_num, ControlState strength, SIDevices device);
 
   static void HandleMoviePadStatus(int device_number, GCPadStatus* pad_status);
 
 protected:
   void SetOrigin(const GCPadStatus& pad_status);
+
+private:
+  void RefreshConfig();
+
+  std::array<SIDevices, 4> m_config_si_devices{};
+  size_t m_config_changed_callback_id;
 };
 
 // "TaruKonga", the DK Bongo controller

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1435,14 +1435,12 @@ void SetGraphicsConfig()
 // NOTE: EmuThread / Host Thread
 void GetSettings()
 {
-  const bool slot_a_has_raw_memcard =
-      SConfig::GetInstance().m_EXIDevice[0] == ExpansionInterface::EXIDEVICE_MEMORYCARD;
-  const bool slot_a_has_gci_folder =
-      SConfig::GetInstance().m_EXIDevice[0] == ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER;
-  const bool slot_b_has_raw_memcard =
-      SConfig::GetInstance().m_EXIDevice[1] == ExpansionInterface::EXIDEVICE_MEMORYCARD;
-  const bool slot_b_has_gci_folder =
-      SConfig::GetInstance().m_EXIDevice[1] == ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER;
+  const ExpansionInterface::TEXIDevices slot_a_type = Config::Get(Config::MAIN_SLOT_A);
+  const ExpansionInterface::TEXIDevices slot_b_type = Config::Get(Config::MAIN_SLOT_B);
+  const bool slot_a_has_raw_memcard = slot_a_type == ExpansionInterface::EXIDEVICE_MEMORYCARD;
+  const bool slot_a_has_gci_folder = slot_a_type == ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER;
+  const bool slot_b_has_raw_memcard = slot_b_type == ExpansionInterface::EXIDEVICE_MEMORYCARD;
+  const bool slot_b_has_gci_folder = slot_b_type == ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER;
 
   s_bSaveConfig = true;
   s_bNetPlay = NetPlay::IsNetPlayRunning();

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -453,9 +453,10 @@ void ChangePads()
 
   for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
   {
-    if (SConfig::GetInstance().m_SIDevice[i] == SerialInterface::SIDEVICE_GC_GBA_EMULATED)
+    const SerialInterface::SIDevices si_device = Config::Get(Config::GetInfoForSIDevice(i));
+    if (si_device == SerialInterface::SIDEVICE_GC_GBA_EMULATED)
       controllers[i] = ControllerType::GBA;
-    else if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
+    else if (SerialInterface::SIDevice_IsGCController(si_device))
       controllers[i] = ControllerType::GC;
     else
       controllers[i] = ControllerType::None;
@@ -473,9 +474,10 @@ void ChangePads()
     }
     else if (IsUsingPad(i))
     {
-      if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
+      const SerialInterface::SIDevices si_device = Config::Get(Config::GetInfoForSIDevice(i));
+      if (SerialInterface::SIDevice_IsGCController(si_device))
       {
-        device = SConfig::GetInstance().m_SIDevice[i];
+        device = si_device;
       }
       else
       {
@@ -548,7 +550,8 @@ bool BeginRecordingInput(const ControllerTypeArray& controllers,
 
     for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
     {
-      if (SConfig::GetInstance().m_SIDevice[i] == SerialInterface::SIDEVICE_GC_TARUKONGA)
+      const SerialInterface::SIDevices si_device = Config::Get(Config::GetInfoForSIDevice(i));
+      if (si_device == SerialInterface::SIDEVICE_GC_TARUKONGA)
         s_bongos |= (1 << i);
     }
 

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1838,11 +1838,13 @@ void NetPlayClient::UpdateDevices()
     else if (player_id == m_local_player->pid)
     {
       // Use local controller types for local controllers if they are compatible
-      if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[local_pad]))
+      const SerialInterface::SIDevices si_device =
+          Config::Get(Config::GetInfoForSIDevice(local_pad));
+      if (SerialInterface::SIDevice_IsGCController(si_device))
       {
-        SerialInterface::ChangeDevice(SConfig::GetInstance().m_SIDevice[local_pad], pad);
+        SerialInterface::ChangeDevice(si_device, pad);
 
-        if (SConfig::GetInstance().m_SIDevice[local_pad] == SerialInterface::SIDEVICE_WIIU_ADAPTER)
+        if (si_device == SerialInterface::SIDEVICE_WIIU_ADAPTER)
         {
           GCAdapter::ResetDeviceType(local_pad);
         }
@@ -2161,7 +2163,8 @@ bool NetPlayClient::PollLocalPad(const int local_pad, sf::Packet& packet)
   {
     pad_status = Pad::GetGBAStatus(local_pad);
   }
-  else if (SConfig::GetInstance().m_SIDevice[local_pad] == SerialInterface::SIDEVICE_WIIU_ADAPTER)
+  else if (Config::Get(Config::GetInfoForSIDevice(local_pad)) ==
+           SerialInterface::SIDEVICE_WIIU_ADAPTER)
   {
     pad_status = GCAdapter::Input(local_pad);
   }

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1307,10 +1307,8 @@ bool NetPlayServer::SetupNetSettings()
   settings.m_CopyWiiSave = Config::Get(Config::NETPLAY_LOAD_WII_SAVE);
   settings.m_OCEnable = Config::Get(Config::MAIN_OVERCLOCK_ENABLE);
   settings.m_OCFactor = Config::Get(Config::MAIN_OVERCLOCK);
-  settings.m_EXIDevice[0] =
-      static_cast<ExpansionInterface::TEXIDevices>(Config::Get(Config::MAIN_SLOT_A));
-  settings.m_EXIDevice[1] =
-      static_cast<ExpansionInterface::TEXIDevices>(Config::Get(Config::MAIN_SLOT_B));
+  settings.m_EXIDevice[0] = Config::Get(Config::MAIN_SLOT_A);
+  settings.m_EXIDevice[1] = Config::Get(Config::MAIN_SLOT_B);
   // There's no way the BBA is going to sync, disable it
   settings.m_EXIDevice[2] = ExpansionInterface::EXIDEVICE_NONE;
 
@@ -1595,11 +1593,12 @@ bool NetPlayServer::SyncSaveData()
 
   u8 save_count = 0;
 
-  constexpr size_t exi_device_count = 2;
-  for (size_t i = 0; i < exi_device_count; i++)
+  constexpr int exi_device_count = 2;
+  for (int i = 0; i < exi_device_count; ++i)
   {
     if (m_settings.m_EXIDevice[i] == ExpansionInterface::EXIDEVICE_MEMORYCARD ||
-        SConfig::GetInstance().m_EXIDevice[i] == ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER)
+        Config::Get(Config::GetInfoForEXIDevice(i)) ==
+            ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER)
     {
       save_count++;
     }
@@ -1654,7 +1653,7 @@ bool NetPlayServer::SyncSaveData()
   const std::string region =
       SConfig::GetDirectoryForRegion(SConfig::ToGameCubeRegion(game->GetRegion()));
 
-  for (size_t i = 0; i < exi_device_count; i++)
+  for (int i = 0; i < exi_device_count; ++i)
   {
     const bool is_slot_a = i == 0;
 
@@ -1695,7 +1694,7 @@ bool NetPlayServer::SyncSaveData()
       SendChunkedToClients(std::move(pac), 1,
                            fmt::format("Memory Card {} Synchronization", is_slot_a ? 'A' : 'B'));
     }
-    else if (SConfig::GetInstance().m_EXIDevice[i] ==
+    else if (Config::Get(Config::GetInfoForEXIDevice(i)) ==
              ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER)
     {
       const std::string path = File::GetUserPath(D_GCUSER_IDX) + region + DIR_SEP +

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -178,7 +178,8 @@ void GamecubeControllersWidget::LoadSettings()
 {
   for (size_t i = 0; i < m_gc_groups.size(); i++)
   {
-    const SerialInterface::SIDevices si_device = SConfig::GetInstance().m_SIDevice[i];
+    const SerialInterface::SIDevices si_device =
+        Config::Get(Config::GetInfoForSIDevice(static_cast<int>(i)));
     const std::optional<int> gc_index = ToGCMenuIndex(si_device);
     if (gc_index)
     {
@@ -194,7 +195,7 @@ void GamecubeControllersWidget::SaveSettings()
   {
     const int index = m_gc_controller_boxes[i]->currentIndex();
     const SerialInterface::SIDevices si_device = FromGCMenuIndex(index);
-    SConfig::GetInstance().m_SIDevice[i] = si_device;
+    Config::SetBaseOrCurrent(Config::GetInfoForSIDevice(static_cast<int>(i)), si_device);
 
     if (Core::IsRunning())
       SerialInterface::ChangeDevice(si_device, static_cast<s32>(i));

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -664,7 +664,9 @@ void GameList::OpenGCSaveFolder()
   for (int i = 0; i < 2; i++)
   {
     QUrl url;
-    switch (SConfig::GetInstance().m_EXIDevice[i])
+    const ExpansionInterface::TEXIDevices current_exi_device =
+        Config::Get(Config::GetInfoForEXIDevice(i));
+    switch (current_exi_device)
     {
     case ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER:
     {

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1728,9 +1728,10 @@ void MainWindow::OnStartRecording()
 
   for (int i = 0; i < 4; i++)
   {
-    if (SConfig::GetInstance().m_SIDevice[i] == SerialInterface::SIDEVICE_GC_GBA_EMULATED)
+    const SerialInterface::SIDevices si_device = Config::Get(Config::GetInfoForSIDevice(i));
+    if (si_device == SerialInterface::SIDEVICE_GC_GBA_EMULATED)
       controllers[i] = Movie::ControllerType::GBA;
-    else if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
+    else if (SerialInterface::SIDevice_IsGCController(si_device))
       controllers[i] = Movie::ControllerType::GC;
     else
       controllers[i] = Movie::ControllerType::None;
@@ -1782,8 +1783,9 @@ void MainWindow::ShowTASInput()
 {
   for (int i = 0; i < num_gc_controllers; i++)
   {
-    if (SConfig::GetInstance().m_SIDevice[i] != SerialInterface::SIDEVICE_NONE &&
-        SConfig::GetInstance().m_SIDevice[i] != SerialInterface::SIDEVICE_GC_GBA)
+    const auto si_device = Config::Get(Config::GetInfoForSIDevice(i));
+    if (si_device != SerialInterface::SIDEVICE_NONE &&
+        si_device != SerialInterface::SIDEVICE_GC_GBA)
     {
       m_gc_tas_input_windows[i]->show();
       m_gc_tas_input_windows[i]->raise();

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -458,8 +458,8 @@ void GameCubePane::LoadSettings()
   for (int i = 0; i < SLOT_COUNT; i++)
   {
     QSignalBlocker blocker(m_slot_combos[i]);
-    m_slot_combos[i]->setCurrentIndex(
-        m_slot_combos[i]->findData(SConfig::GetInstance().m_EXIDevice[i]));
+    const ExpansionInterface::TEXIDevices exi_device = Config::Get(Config::GetInfoForEXIDevice(i));
+    m_slot_combos[i]->setCurrentIndex(m_slot_combos[i]->findData(exi_device));
     UpdateButton(i);
   }
 
@@ -486,8 +486,10 @@ void GameCubePane::SaveSettings()
   for (int i = 0; i < SLOT_COUNT; i++)
   {
     const auto dev = ExpansionInterface::TEXIDevices(m_slot_combos[i]->currentData().toInt());
+    const ExpansionInterface::TEXIDevices current_exi_device =
+        Config::Get(Config::GetInfoForEXIDevice(i));
 
-    if (Core::IsRunning() && SConfig::GetInstance().m_EXIDevice[i] != dev)
+    if (Core::IsRunning() && current_exi_device != dev)
     {
       ExpansionInterface::ChangeDevice(
           // SlotB is on channel 1, slotA and SP1 are on 0
@@ -498,19 +500,7 @@ void GameCubePane::SaveSettings()
           (i == 2) ? 2 : 0);
     }
 
-    SConfig::GetInstance().m_EXIDevice[i] = dev;
-    switch (i)
-    {
-    case SLOT_A_INDEX:
-      Config::SetBaseOrCurrent(Config::MAIN_SLOT_A, dev);
-      break;
-    case SLOT_B_INDEX:
-      Config::SetBaseOrCurrent(Config::MAIN_SLOT_B, dev);
-      break;
-    case SLOT_SP1_INDEX:
-      Config::SetBaseOrCurrent(Config::MAIN_SERIAL_PORT_1, dev);
-      break;
-    }
+    Config::SetBaseOrCurrent(Config::GetInfoForEXIDevice(i), dev);
   }
 
 #ifdef HAS_LIBMGBA

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -83,6 +83,8 @@ static u8 s_endpoint_out = 0;
 static u64 s_last_init = 0;
 
 static std::optional<size_t> s_config_callback_id = std::nullopt;
+static std::array<SerialInterface::SIDevices, SerialInterface::MAX_SI_CHANNELS>
+    s_config_si_device_type{};
 static std::array<bool, SerialInterface::MAX_SI_CHANNELS> s_config_rumble_enabled{};
 
 static void Read()
@@ -205,7 +207,10 @@ void SetAdapterCallback(std::function<void()> func)
 static void RefreshConfig()
 {
   for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
+  {
+    s_config_si_device_type[i] = Config::Get(Config::GetInfoForSIDevice(i));
     s_config_rumble_enabled[i] = Config::Get(Config::GetInfoForAdapterRumble(i));
+  }
 }
 
 void Init()
@@ -542,9 +547,8 @@ void ResetDeviceType(int chan)
 
 bool UseAdapter()
 {
-  const auto& si_devices = SConfig::GetInstance().m_SIDevice;
-
-  return std::any_of(std::begin(si_devices), std::end(si_devices), [](const auto device_type) {
+  const auto& si_devices = s_config_si_device_type;
+  return std::any_of(si_devices.begin(), si_devices.end(), [](const auto device_type) {
     return device_type == SerialInterface::SIDEVICE_WIIU_ADAPTER;
   });
 }

--- a/Source/Core/InputCommon/GCAdapter_Android.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Android.cpp
@@ -12,7 +12,7 @@
 #include "Common/Flag.h"
 #include "Common/Logging/Log.h"
 #include "Common/Thread.h"
-#include "Core/ConfigManager.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/SI/SI.h"
@@ -60,6 +60,16 @@ static std::thread s_adapter_detect_thread;
 static Common::Flag s_adapter_detect_thread_running;
 
 static u64 s_last_init = 0;
+
+static std::optional<size_t> s_config_callback_id = std::nullopt;
+static std::array<SerialInterface::SIDevices, SerialInterface::MAX_SI_CHANNELS>
+    s_config_si_device_type{};
+
+static void RefreshConfig()
+{
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
+    s_config_si_device_type[i] = Config::Get(Config::GetInfoForSIDevice(i));
+}
 
 static void ScanThreadFunc()
 {
@@ -200,6 +210,10 @@ void Init()
   jclass adapter_class = env->FindClass("org/dolphinemu/dolphinemu/utils/Java_GCAdapter");
   s_adapter_class = reinterpret_cast<jclass>(env->NewGlobalRef(adapter_class));
 
+  if (!s_config_callback_id)
+    s_config_callback_id = Config::AddConfigChangedCallback(RefreshConfig);
+  RefreshConfig();
+
   if (UseAdapter())
     StartScanThread();
 }
@@ -236,6 +250,12 @@ void Shutdown()
 {
   StopScanThread();
   Reset();
+
+  if (s_config_callback_id)
+  {
+    Config::RemoveConfigChangedCallback(*s_config_callback_id);
+    s_config_callback_id = std::nullopt;
+  }
 }
 
 void StartScanThread()
@@ -376,8 +396,7 @@ void ResetDeviceType(int chan)
 
 bool UseAdapter()
 {
-  const auto& si_devices = SConfig::GetInstance().m_SIDevice;
-
+  const auto& si_devices = s_config_si_device_type;
   return std::any_of(std::begin(si_devices), std::end(si_devices), [](const auto device_type) {
     return device_type == SerialInterface::SIDEVICE_WIIU_ADAPTER;
   });


### PR DESCRIPTION
Separate PR here because of this snippet of code that I'm not sure how to translate correctly into the new system:

```
    for (unsigned int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
    {
      int source;
      controls_section->Get(fmt::format("PadType{}", i), &source, -1);
      if (source >= SerialInterface::SIDEVICE_NONE && source < SerialInterface::SIDEVICE_COUNT)
      {
        StartUp.m_SIDevice[i] = static_cast<SerialInterface::SIDevices>(source);
        config_cache.bSetPads[i] = true;
      }
    }
```

This happens while parsing GameINIs and basically means 'if `PadTypeN` is set to a valid value, override `SIDeviceN` with that, otherwise keep the value set by `SIDeviceN`'. I can and have added these to `GetINIToLocationMap()`, but that's not quite the same behavior -- if you set it to an invalid value, Dolphin will now use `SIDEVICE_NONE` rather than the current `SIDeviceN` value. Are we fine with this? If not, how do we adjust the code so that previous behavior still applies?