### PR TITLE
Android: remove save icon and add up button

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatsActivity.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -94,6 +93,9 @@ public class CheatsActivity extends AppCompatActivity
     onSelectedCheatChanged(mViewModel.getSelectedCheat().getValue());
 
     mViewModel.getOpenDetailsViewEvent().observe(this, this::openDetailsView);
+
+    // show up button
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
   }
 
   @Override
@@ -103,18 +105,6 @@ public class CheatsActivity extends AppCompatActivity
     inflater.inflate(R.menu.menu_settings, menu);
 
     return true;
-  }
-
-  @Override
-  public boolean onOptionsItemSelected(MenuItem item)
-  {
-    if (item.getItemId() == R.id.menu_save_exit)
-    {
-      finish();
-      return true;
-    }
-
-    return false;
   }
 
   @Override
@@ -177,6 +167,13 @@ public class CheatsActivity extends AppCompatActivity
 
       mSlidingPaneLayout.open();
     }
+  }
+
+  @Override
+  public boolean onSupportNavigateUp()
+  {
+    onBackPressed();
+    return true;
   }
 
   private void openDetailsView(boolean open)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -75,6 +75,9 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 
     mPresenter = new SettingsActivityPresenter(this, getSettings());
     mPresenter.onCreate(savedInstanceState, menuTag, gameID, revision, isWii, this);
+
+    // show up button
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
   }
 
   @Override
@@ -84,12 +87,6 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     inflater.inflate(R.menu.menu_settings, menu);
 
     return true;
-  }
-
-  @Override
-  public boolean onOptionsItemSelected(MenuItem item)
-  {
-    return mPresenter.handleOptionsItem(item.getItemId());
   }
 
   @Override
@@ -292,6 +289,13 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   public void onExtensionSettingChanged(MenuTag menuTag, int value)
   {
     mPresenter.onExtensionSettingChanged(menuTag, value);
+  }
+
+  @Override
+  public boolean onSupportNavigateUp()
+  {
+    onBackPressed();
+    return true;
   }
 
   private SettingsFragment getFragment()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -120,17 +120,6 @@ public final class SettingsActivityPresenter
     }
   }
 
-  public boolean handleOptionsItem(int itemId)
-  {
-    if (itemId == R.id.menu_save_exit)
-    {
-      mView.finish();
-      return true;
-    }
-
-    return false;
-  }
-
   public void onSettingChanged()
   {
     mShouldSave = true;

--- a/Source/Android/app/src/main/res/menu/menu_settings.xml
+++ b/Source/Android/app/src/main/res/menu/menu_settings.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <item
-        android:id="@+id/menu_save_exit"
-        android:title="@string/preferences_save_exit"
-        android:icon="@drawable/ic_quicksave"
-        app:showAsAction="ifRoom"/>
-
-</menu>
+      xmlns:app="http://schemas.android.com/apk/res-auto"/>


### PR DESCRIPTION
This PR removes the save icon since it's no longer necessary. I've also added an up button to the top left of the screen in the settings and cheats view, which makes navigating feel much more natural.

Screenshots:

<img src="https://user-images.githubusercontent.com/26326692/148584651-b5bbece1-6025-4700-98c7-58f8c9298b43.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/26326692/148584470-c2d9cd2a-160b-426f-8350-10f45dbf0d2c.png" width="200" height="400" />

<img src="https://user-images.githubusercontent.com/26326692/148585062-7be89d5d-1907-42b5-93e4-6d911c3e562d.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/26326692/148584983-60701dcd-b924-418a-8921-da01d7bd31ab.png" width="200" height="400" />
