### PR TITLE
PixelShaderGen: Fix invalid use of int3(0)

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1688,7 +1688,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     };
 
     static constexpr EnumMap<const char*, TevCompareMode::RGB8> tev_rgb_comparison_eq{
-        "((tevin_a.r == tevin_b.r) ? tevin_c.rgb : int3(0))",  // TevCompareMode::R8
+        "((tevin_a.r == tevin_b.r) ? tevin_c.rgb : int3(0,0,0))",  // TevCompareMode::R8
         "((idot(tevin_a.rgb,comp16) == idot(tevin_b.rgb,comp16)) ? tevin_c.rgb : int3(0,0,0))",  // GR16
         "((idot(tevin_a.rgb,comp24) == idot(tevin_b.rgb,comp24)) ? tevin_c.rgb : int3(0,0,0))",  // BGR24
         "((int3(1,1,1) - sign(abs(tevin_a.rgb - tevin_b.rgb))) * tevin_c.rgb)"  // RGB8


### PR DESCRIPTION
This syntax is [allowed by GLSL](https://www.khronos.org/opengl/wiki/Data_Type_(GLSL)#Vector_constructors), but HLSL doesn't allow it (I couldn't find any documentation explicitly rejecting it, but I couldn't find any allowing it either, and the shader compiler gets mad).  This meant that games using R8 comparisons in equal mode would produce shaders that failed to compile.  Super Mario Galaxy's water levels were affected by this; see https://github.com/dolphin-emu/dolphin/pull/9718#issuecomment-1011802368.

I initially used `int3(0)` in a bunch of places since it's simpler, but when I discovered that HLSL doesn't accept it, I changed it; I thought I changed all of the instances of it, but I guess I missed that one.