### PR TITLE
GameList: Convert file extensions to lowercase

### DIFF
--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <algorithm>
-#include <cctype>
 #include <list>
 #include <map>
 #include <string>
@@ -22,9 +21,8 @@ struct CaseInsensitiveStringCompare
   bool operator()(std::string_view a, std::string_view b) const
   {
     return std::lexicographical_compare(
-        a.begin(), a.end(), b.begin(), b.end(), [](char lhs, char rhs) {
-          return std::tolower(static_cast<u8>(lhs)) < std::tolower(static_cast<u8>(rhs));
-        });
+        a.begin(), a.end(), b.begin(), b.end(),
+        [](char lhs, char rhs) { return Common::ToLower(lhs) < Common::ToLower(rhs); });
   }
 
   static bool IsEqual(std::string_view a, std::string_view b)
@@ -33,7 +31,7 @@ struct CaseInsensitiveStringCompare
       return false;
 
     return std::equal(a.begin(), a.end(), b.begin(), b.end(), [](char lhs, char rhs) {
-      return std::tolower(static_cast<u8>(lhs)) == std::tolower(static_cast<u8>(rhs));
+      return Common::ToLower(lhs) == Common::ToLower(rhs);
     });
   }
 };

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -101,8 +101,7 @@ static size_t DeterminePathCutOffPoint()
   constexpr const char* pattern2 = "\\source\\core\\";
 #endif
   std::string path = __FILE__;
-  std::transform(path.begin(), path.end(), path.begin(),
-                 [](char c) { return std::tolower(c, std::locale::classic()); });
+  Common::ToLower(&path);
   size_t pos = path.find(pattern);
 #ifdef _WIN32
   if (pos == std::string::npos)

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -4,7 +4,6 @@
 #include "Common/Network.h"
 
 #include <algorithm>
-#include <cctype>
 #include <string_view>
 
 #ifndef _WIN32
@@ -18,6 +17,7 @@
 #include <fmt/format.h>
 
 #include "Common/Random.h"
+#include "Common/StringUtil.h"
 
 namespace Common
 {
@@ -59,7 +59,7 @@ std::optional<MACAddress> StringToMacAddress(std::string_view mac_string)
 
   for (size_t i = 0; i < mac_string.size() && x < (MAC_ADDRESS_SIZE * 2); ++i)
   {
-    char c = tolower(mac_string.at(i));
+    char c = Common::ToLower(mac_string.at(i));
     if (c >= '0' && c <= '9')
     {
       mac[x / 2] |= (c - '0') << ((x & 1) ? 0 : 4);

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -669,3 +669,16 @@ std::string GetEscapedHtml(std::string html)
   }
   return html;
 }
+
+namespace Common
+{
+void ToLower(std::string* str)
+{
+  std::transform(str->begin(), str->end(), str->begin(), [](char c) { return Common::ToLower(c); });
+}
+
+void ToUpper(std::string* str)
+{
+  std::transform(str->begin(), str->end(), str->begin(), [](char c) { return Common::ToUpper(c); });
+}
+}  // namespace Common

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -240,3 +240,17 @@ std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
 #endif
 
 std::string GetEscapedHtml(std::string html);
+
+namespace Common
+{
+inline char ToLower(char ch)
+{
+  return std::tolower(ch, std::locale::classic());
+}
+inline char ToUpper(char ch)
+{
+  return std::toupper(ch, std::locale::classic());
+}
+void ToLower(std::string* str);
+void ToUpper(std::string* str);
+}  // namespace Common

--- a/Source/Core/Core/ARDecrypt.cpp
+++ b/Source/Core/Core/ARDecrypt.cpp
@@ -20,6 +20,7 @@
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
+#include "Common/StringUtil.h"
 #include "Common/Swap.h"
 
 namespace ActionReplay
@@ -462,7 +463,7 @@ void DecryptARCode(std::vector<std::string> vCodes, std::vector<AREntry>* ops)
 
   for (std::string& s : vCodes)
   {
-    std::transform(s.begin(), s.end(), s.begin(), toupper);
+    Common::ToUpper(&s);
   }
 
   const u32 ret = alphatobin(uCodes.data(), vCodes, (int)vCodes.size());

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -205,7 +205,7 @@ std::unique_ptr<BootParameters> BootParameters::GenerateFromFile(std::vector<std
   std::string folder_path;
   std::string extension;
   SplitPath(paths.front(), &folder_path, nullptr, &extension);
-  std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+  Common::ToLower(&extension);
 
   if (extension == ".m3u" || extension == ".m3u8")
   {
@@ -214,7 +214,7 @@ std::unique_ptr<BootParameters> BootParameters::GenerateFromFile(std::vector<std
       return {};
 
     SplitPath(paths.front(), nullptr, nullptr, &extension);
-    std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+    Common::ToLower(&extension);
   }
 
   std::string path = paths.front();
@@ -226,7 +226,7 @@ std::unique_ptr<BootParameters> BootParameters::GenerateFromFile(std::vector<std
   {
     const std::string display_name = GetAndroidContentDisplayName(path);
     SplitPath(display_name, nullptr, nullptr, &extension);
-    std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+    Common::ToLower(&extension);
   }
 #endif
 

--- a/Source/Core/Core/DSP/DSPDisassembler.cpp
+++ b/Source/Core/Core/DSP/DSPDisassembler.cpp
@@ -203,7 +203,7 @@ bool DSPDisassembler::DisassembleOpcode(const u16* binbuf, u16* pc, std::string&
   if (is_extended)
     opname += fmt::format("{}{}", settings_.ext_separator, opc_ext->name);
   if (settings_.lower_case_ops)
-    std::transform(opname.begin(), opname.end(), opname.begin(), ::tolower);
+    Common::ToLower(&opname);
 
   if (settings_.print_tabs)
     dest += fmt::format("{}\t", opname);

--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -4,7 +4,6 @@
 #include "Core/HW/DVD/FileMonitor.h"
 
 #include <algorithm>
-#include <cctype>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -29,7 +28,7 @@ static bool IsSoundFile(const std::string& filename)
 {
   std::string extension;
   SplitPath(filename, nullptr, nullptr, &extension);
-  std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+  Common::ToLower(&extension);
 
   static const std::unordered_set<std::string> extensions = {
       ".adp",    // 1080 Avalanche, Crash Bandicoot, etc.

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -31,8 +31,7 @@ CEXIETHERNET::CEXIETHERNET(BBADeviceType type)
   std::string mac_addr_setting = Config::Get(Config::MAIN_BBA_MAC);
   std::optional<Common::MACAddress> mac_addr = Common::StringToMacAddress(mac_addr_setting);
 
-  std::transform(mac_addr_setting.begin(), mac_addr_setting.end(), mac_addr_setting.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
+  Common::ToLower(&mac_addr_setting);
 
   if (!mac_addr)
   {

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -1132,8 +1132,10 @@ void DirectoryBlobPartition::WriteDirectory(std::vector<FSTBuilderNode>* parent_
   // Sort for determinism
   std::sort(sorted_entries.begin(), sorted_entries.end(),
             [](const FSTBuilderNode& one, const FSTBuilderNode& two) {
-              const std::string one_upper = ASCIIToUppercase(one.m_filename);
-              const std::string two_upper = ASCIIToUppercase(two.m_filename);
+              std::string one_upper = one.m_filename;
+              std::string two_upper = two.m_filename;
+              Common::ToUpper(&one_upper);
+              Common::ToUpper(&two_upper);
               return one_upper == two_upper ? one.m_filename < two.m_filename :
                                               one_upper < two_upper;
             });
@@ -1199,12 +1201,4 @@ static void Write32(u32 data, u32 offset, std::vector<u8>* buffer)
   (*buffer)[offset++] = (data >> 8) & 0xff;
   (*buffer)[offset] = data & 0xff;
 }
-
-static std::string ASCIIToUppercase(std::string str)
-{
-  std::transform(str.begin(), str.end(), str.begin(),
-                 [](char c) { return std::toupper(c, std::locale::classic()); });
-  return str;
-}
-
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -146,13 +146,9 @@ bool FileInfoGCWii::NameCaseInsensitiveEquals(std::string_view other) const
       // other is in UTF-8 and this is in Shift-JIS, so we convert so that we can compare correctly
       const std::string this_utf8 = SHIFTJISToUTF8(this_ptr);
       return std::equal(this_utf8.cbegin(), this_utf8.cend(), other.cbegin() + i, other.cend(),
-                        [](char a, char b) {
-                          return std::tolower(a, std::locale::classic()) ==
-                                 std::tolower(b, std::locale::classic());
-                        });
+                        [](char a, char b) { return Common::ToLower(a) == Common::ToLower(b); });
     }
-    else if (std::tolower(*this_ptr, std::locale::classic()) !=
-             std::tolower(*other_ptr, std::locale::classic()))
+    else if (Common::ToLower(*this_ptr) != Common::ToLower(*other_ptr))
     {
       return false;
     }

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -4,7 +4,6 @@
 #include "DiscIO/RiivolutionPatcher.h"
 
 #include <algorithm>
-#include <cctype>
 #include <locale>
 #include <string>
 #include <string_view>
@@ -324,9 +323,8 @@ static bool CaseInsensitiveEquals(std::string_view a, std::string_view b)
 {
   if (a.size() != b.size())
     return false;
-  return std::equal(a.begin(), a.end(), b.begin(), [](char ca, char cb) {
-    return std::tolower(ca, std::locale::classic()) == std::tolower(cb, std::locale::classic());
-  });
+  return std::equal(a.begin(), a.end(), b.begin(),
+                    [](char ca, char cb) { return Common::ToLower(ca) == Common::ToLower(cb); });
 }
 
 static FSTBuilderNode* FindFileNodeInFST(std::string_view path, std::vector<FSTBuilderNode>* fst,

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -10,7 +10,6 @@
 #include <QMouseEvent>
 #include <QScrollBar>
 
-#include <cctype>
 #include <cmath>
 
 #include "Common/StringUtil.h"

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -175,7 +175,7 @@ Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index)
   // checking the name is probably good (and hacky) enough
   // but I'll double check with the num of buttons/axes
   std::string lcasename = GetName();
-  std::transform(lcasename.begin(), lcasename.end(), lcasename.begin(), tolower);
+  Common::ToLower(&lcasename);
 
   if ((std::string::npos != lcasename.find("xbox 360")) &&
       (10 == SDL_JoystickNumButtons(joystick)) && (5 == SDL_JoystickNumAxes(joystick)) &&

--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -10,7 +10,6 @@
 #ifdef USE_DISCORD_PRESENCE
 
 #include <algorithm>
-#include <cctype>
 #include <ctime>
 #include <set>
 #include <string>
@@ -19,6 +18,7 @@
 #include <fmt/format.h>
 
 #include "Common/Hash.h"
+#include "Common/StringUtil.h"
 
 #endif
 
@@ -167,8 +167,7 @@ std::string ArtworkForGameId(const std::string& gameid)
   if (REGISTERED_GAMES.count(region_neutral_gameid) != 0)
   {
     // Discord asset keys can only be lowercase.
-    std::transform(region_neutral_gameid.begin(), region_neutral_gameid.end(),
-                   region_neutral_gameid.begin(), tolower);
+    Common::ToLower(&region_neutral_gameid);
     return "game_" + region_neutral_gameid;
   }
   return "";

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -610,7 +610,7 @@ std::string GameFile::GetNetPlayName(const Core::TitleDatabase& title_database) 
   int disc_number = GetDiscNumber() + 1;
 
   std::string lower_name = name;
-  std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), ::tolower);
+  Common::ToLower(&lower_name);
   if (disc_number > 1 &&
       lower_name.find(fmt::format("disc {}", disc_number)) == std::string::npos &&
       lower_name.find(fmt::format("disc{}", disc_number)) == std::string::npos)
@@ -786,7 +786,7 @@ std::string GameFile::GetFileFormatName() const
   case DiscIO::Platform::ELFOrDOL:
   {
     std::string extension = GetExtension();
-    std::transform(extension.begin(), extension.end(), extension.begin(), ::toupper);
+    Common::ToUpper(&extension);
 
     // substr removes the dot
     return extension.substr(std::min<size_t>(1, extension.size()));

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -387,6 +387,7 @@ std::string GameFile::GetExtension() const
 {
   std::string extension;
   SplitPath(m_file_path, nullptr, nullptr, &extension);
+  Common::ToLower(&extension);
   return extension;
 }
 

--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -1,7 +1,6 @@
 // Copyright 2014 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <cctype>
 #include <cstring>
 #include <disasm.h>  // From Bochs, fallback included in Externals.
 #include <gtest/gtest.h>
@@ -17,6 +16,7 @@
 #undef TEST
 
 #include "Common/CPUDetect.h"
+#include "Common/StringUtil.h"
 #include "Common/x64Emitter.h"
 
 namespace Gen
@@ -125,7 +125,7 @@ protected:
       bool inside_parens = false;
       for (auto c : str)
       {
-        c = tolower(c);
+        c = Common::ToLower(c);
         if (c == '(')
         {
           inside_parens = true;


### PR DESCRIPTION
This means that dol/elf files with upercase extensions (e.g. BOOT.DOL) are properly detected.  ISO files with uppercase extensions already worked.  This affected [Rick Dangerous Wii](https://wiibrew.org/wiki/Rick_Dangerous_Wii) (though it is still broken in [other ways](https://bugs.dolphin-emu.org/issues/12799)).

Note that the same case conversion is performed by `Boot.cpp`:

https://github.com/dolphin-emu/dolphin/blob/07fd17445c6ca4e89b0cef023ba711bb27c920aa/Source/Core/Core/Boot/Boot.cpp#L205-L208