### PR TITLE
Android: Add online system update functionality

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -155,4 +155,3 @@
     </application>
 
 </manifest>
-

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -387,6 +387,11 @@ public final class NativeLibrary
   public static native void Run(String[] path, boolean riivolution, String savestatePath,
           boolean deleteSavestate);
 
+  /**
+   * Begins emulation of the System Menu.
+   */
+  public static native void RunSystemMenu();
+
   public static native void ChangeDisc(String path);
 
   // Surface Handling

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/OnlineUpdateProgressBarDialogFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/OnlineUpdateProgressBarDialogFragment.java
@@ -1,0 +1,110 @@
+package org.dolphinemu.dolphinemu.features.sysupdate.ui;
+
+import android.app.Dialog;
+import android.app.ProgressDialog;
+import android.content.pm.ActivityInfo;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProvider;
+
+import org.dolphinemu.dolphinemu.R;
+
+public class OnlineUpdateProgressBarDialogFragment extends DialogFragment
+{
+  @NonNull
+  @Override
+  public Dialog onCreateDialog(@Nullable Bundle savedInstanceState)
+  {
+    // Store the current orientation to be restored later
+    final int orientation = getActivity().getRequestedOrientation();
+    // Rotating the device while the update is running can result in a title failing to import.
+    getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+
+    SystemUpdateViewModel viewModel =
+            new ViewModelProvider(requireActivity()).get(SystemUpdateViewModel.class);
+
+    ProgressDialog progressDialog = new ProgressDialog(requireContext());
+    progressDialog.setTitle(getString(R.string.updating));
+    // We need to set the message to something here, otherwise the text will not appear when we set it later.
+    progressDialog.setMessage("");
+    progressDialog.setButton(Dialog.BUTTON_NEGATIVE, getString(R.string.cancel), (dialog, i) ->
+    {
+    });
+    progressDialog.setOnShowListener((dialogInterface) ->
+    {
+      // By default, the ProgressDialog will immediately dismiss itself upon a button being pressed.
+      // Setting the OnClickListener again after the dialog is shown overrides this behavior.
+      progressDialog.getButton(Dialog.BUTTON_NEGATIVE).setOnClickListener((view) ->
+      {
+        viewModel.setCanceled();
+      });
+    });
+    progressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+
+    viewModel.getProgressData().observe(this, (@Nullable Integer progress) ->
+    {
+      progressDialog.setProgress(progress.intValue());
+    });
+
+    viewModel.getTotalData().observe(this, (@Nullable Integer total) ->
+    {
+      if (total == 0)
+      {
+        return;
+      }
+
+      progressDialog.setMax(total.intValue());
+    });
+
+    viewModel.getTitleIdData().observe(this, (@Nullable Long titleId) ->
+    {
+      progressDialog.setMessage(getString(R.string.updating_message, titleId));
+    });
+
+    viewModel.getResultData().observe(this, (@Nullable Integer result) ->
+    {
+      if (result == -1)
+      {
+        // This is the default value, ignore
+        return;
+      }
+
+      OnlineUpdateResultFragment progressBarFragment = new OnlineUpdateResultFragment();
+      progressBarFragment.show(getParentFragmentManager(), "OnlineUpdateResultFragment");
+
+      getActivity().setRequestedOrientation(orientation);
+
+      dismiss();
+    });
+
+    if (savedInstanceState == null)
+    {
+      final String region;
+      int selectedItem = viewModel.getRegion();
+
+      switch (selectedItem)
+      {
+        case 0:
+          region = "EUR";
+          break;
+        case 1:
+          region = "JPN";
+          break;
+        case 2:
+          region = "KOR";
+          break;
+        case 3:
+          region = "USA";
+          break;
+        default:
+          region = "";
+          break;
+      }
+      viewModel.startUpdate(region);
+    }
+    return progressDialog;
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/OnlineUpdateRegionSelectDialogFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/OnlineUpdateRegionSelectDialogFragment.java
@@ -1,0 +1,42 @@
+package org.dolphinemu.dolphinemu.features.sysupdate.ui;
+
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProvider;
+
+import org.dolphinemu.dolphinemu.R;
+
+public class OnlineUpdateRegionSelectDialogFragment extends DialogFragment
+{
+  @NonNull
+  @Override
+  public Dialog onCreateDialog(@Nullable Bundle savedInstanceState)
+  {
+    String[] items = {getString(R.string.europe), getString(
+            R.string.japan), getString(R.string.korea), getString(R.string.united_states)};
+    int checkedItem = -1;
+
+    return new AlertDialog.Builder(requireContext(), R.style.DolphinDialogBase)
+            .setTitle(R.string.region_select_title)
+            .setSingleChoiceItems(items, checkedItem, (dialog, which) ->
+            {
+              SystemUpdateViewModel viewModel =
+                      new ViewModelProvider(requireActivity()).get(SystemUpdateViewModel.class);
+              viewModel.setRegion(which);
+
+              OnlineUpdateProgressBarDialogFragment progressBarFragment =
+                      new OnlineUpdateProgressBarDialogFragment();
+              progressBarFragment
+                      .show(getParentFragmentManager(), "OnlineUpdateProgressBarDialogFragment");
+              progressBarFragment.setCancelable(false);
+
+              dismiss();
+            })
+            .create();
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/OnlineUpdateResultFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/OnlineUpdateResultFragment.java
@@ -1,0 +1,105 @@
+package org.dolphinemu.dolphinemu.features.sysupdate.ui;
+
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProvider;
+
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.utils.WiiUtils;
+
+public class OnlineUpdateResultFragment extends DialogFragment
+{
+  private int mResult;
+
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState)
+  {
+    SystemUpdateViewModel viewModel =
+            new ViewModelProvider(requireActivity()).get(SystemUpdateViewModel.class);
+    if (savedInstanceState == null)
+    {
+      mResult = viewModel.getResultData().getValue().intValue();
+      viewModel.clear();
+    }
+    else
+    {
+      mResult = savedInstanceState.getInt("result");
+    }
+
+    String message;
+    switch (mResult)
+    {
+      case WiiUtils.UPDATE_RESULT_SUCCESS:
+        message = getString(R.string.update_success);
+        break;
+      case WiiUtils.UPDATE_RESULT_ALREADY_UP_TO_DATE:
+        message = getString(R.string.already_up_to_date);
+        break;
+      case WiiUtils.UPDATE_RESULT_REGION_MISMATCH:
+        message = getString(R.string.region_mismatch);
+        break;
+      case WiiUtils.UPDATE_RESULT_MISSING_UPDATE_PARTITION:
+        message = getString(R.string.missing_update_partition);
+        break;
+      case WiiUtils.UPDATE_RESULT_DISC_READ_FAILED:
+        message = getString(R.string.disc_read_failed);
+        break;
+      case WiiUtils.UPDATE_RESULT_SERVER_FAILED:
+        message = getString(R.string.server_failed);
+        break;
+      case WiiUtils.UPDATE_RESULT_DOWNLOAD_FAILED:
+        message = getString(R.string.download_failed);
+        break;
+      case WiiUtils.UPDATE_RESULT_IMPORT_FAILED:
+        message = getString(R.string.import_failed);
+        break;
+      case WiiUtils.UPDATE_RESULT_CANCELLED:
+        message = getString(R.string.update_cancelled);
+        break;
+      default:
+        throw new IllegalStateException("Unexpected value: " + mResult);
+    }
+
+    String title;
+    switch (mResult)
+    {
+      case WiiUtils.UPDATE_RESULT_SUCCESS:
+      case WiiUtils.UPDATE_RESULT_ALREADY_UP_TO_DATE:
+        title = getString(R.string.update_success_title);
+        break;
+      case WiiUtils.UPDATE_RESULT_REGION_MISMATCH:
+      case WiiUtils.UPDATE_RESULT_MISSING_UPDATE_PARTITION:
+      case WiiUtils.UPDATE_RESULT_DISC_READ_FAILED:
+      case WiiUtils.UPDATE_RESULT_SERVER_FAILED:
+      case WiiUtils.UPDATE_RESULT_DOWNLOAD_FAILED:
+      case WiiUtils.UPDATE_RESULT_IMPORT_FAILED:
+        title = getString(R.string.update_failed_title);
+        break;
+      case WiiUtils.UPDATE_RESULT_CANCELLED:
+        title = getString(R.string.update_cancelled_title);
+        break;
+      default:
+        throw new IllegalStateException("Unexpected value: " + mResult);
+    }
+
+    return new AlertDialog.Builder(requireContext(), R.style.DolphinDialogBase)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(R.string.ok, (dialog, which) ->
+            {
+              dismiss();
+            })
+            .create();
+  }
+
+  @Override
+  public void onSaveInstanceState(@NonNull Bundle outState)
+  {
+    super.onSaveInstanceState(outState);
+    outState.putInt("result", mResult);
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/SystemMenuNotInstalledDialogFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/SystemMenuNotInstalledDialogFragment.java
@@ -1,0 +1,34 @@
+package org.dolphinemu.dolphinemu.features.sysupdate.ui;
+
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentManager;
+
+import org.dolphinemu.dolphinemu.R;
+
+public class SystemMenuNotInstalledDialogFragment extends DialogFragment
+{
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState)
+  {
+    return new AlertDialog.Builder(requireContext(), R.style.DolphinDialogBase)
+            .setTitle(R.string.system_menu_not_installed_title)
+            .setMessage(R.string.system_menu_not_installed_message)
+            .setPositiveButton(R.string.yes, (dialog, which) ->
+            {
+              FragmentManager fragmentManager = getParentFragmentManager();
+              OnlineUpdateRegionSelectDialogFragment dialogFragment =
+                      new OnlineUpdateRegionSelectDialogFragment();
+              dialogFragment.show(fragmentManager, "OnlineUpdateRegionSelectDialogFragment");
+              dismiss();
+            })
+            .setNegativeButton(R.string.no, (dialog, which) ->
+            {
+              dismiss();
+            })
+            .create();
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/SystemUpdateViewModel.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/SystemUpdateViewModel.java
@@ -1,0 +1,90 @@
+package org.dolphinemu.dolphinemu.features.sysupdate.ui;
+
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import org.dolphinemu.dolphinemu.utils.WiiUtils;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class SystemUpdateViewModel extends ViewModel
+{
+  private static final ExecutorService executor = Executors.newFixedThreadPool(1);
+
+  private final MutableLiveData<Integer> mProgressData = new MutableLiveData<>();
+  private final MutableLiveData<Integer> mTotalData = new MutableLiveData<>();
+  private final MutableLiveData<Long> mTitleIdData = new MutableLiveData<>();
+  private final MutableLiveData<Integer> mResultData = new MutableLiveData<>();
+
+  private boolean mCanceled = false;
+  private int mRegion;
+
+  public SystemUpdateViewModel()
+  {
+    clear();
+  }
+
+  public void setRegion(int region)
+  {
+    mRegion = region;
+  }
+
+  public int getRegion()
+  {
+    return mRegion;
+  }
+
+  public MutableLiveData<Integer> getProgressData()
+  {
+    return mProgressData;
+  }
+
+  public MutableLiveData<Integer> getTotalData()
+  {
+    return mTotalData;
+  }
+
+  public MutableLiveData<Long> getTitleIdData()
+  {
+    return mTitleIdData;
+  }
+
+  public MutableLiveData<Integer> getResultData()
+  {
+    return mResultData;
+  }
+
+  public void setCanceled()
+  {
+    mCanceled = true;
+  }
+
+  public void startUpdate(String region)
+  {
+    mCanceled = false;
+
+    executor.execute(() ->
+    {
+      int result = WiiUtils.doOnlineUpdate(region, ((processed, total, titleId) ->
+      {
+        mProgressData.postValue(processed);
+        mTotalData.postValue(total);
+        mTitleIdData.postValue(titleId);
+
+        return !mCanceled;
+      }));
+
+      mResultData.postValue(result);
+    });
+  }
+
+  public void clear()
+  {
+    mProgressData.setValue(0);
+    mTotalData.setValue(0);
+    mTitleIdData.setValue(0l);
+    mResultData.setValue(-1);
+    mCanceled = false;
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
@@ -30,6 +29,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 {
   private static final String KEY_GAMEPATHS = "gamepaths";
   private static final String KEY_RIIVOLUTION = "riivolution";
+  private static final String KEY_SYSTEM_MENU = "systemMenu";
 
   private InputOverlay mInputOverlay;
 
@@ -37,14 +37,17 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
   private boolean mRiivolution;
   private boolean mRunWhenSurfaceIsValid;
   private boolean mLoadPreviousTemporaryState;
+  private boolean mLaunchSystemMenu;
 
   private EmulationActivity activity;
 
-  public static EmulationFragment newInstance(String[] gamePaths, boolean riivolution)
+  public static EmulationFragment newInstance(String[] gamePaths, boolean riivolution,
+          boolean systemMenu)
   {
     Bundle args = new Bundle();
     args.putStringArray(KEY_GAMEPATHS, gamePaths);
     args.putBoolean(KEY_RIIVOLUTION, riivolution);
+    args.putBoolean(KEY_SYSTEM_MENU, systemMenu);
 
     EmulationFragment fragment = new EmulationFragment();
     fragment.setArguments(args);
@@ -77,6 +80,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 
     mGamePaths = getArguments().getStringArray(KEY_GAMEPATHS);
     mRiivolution = getArguments().getBoolean(KEY_RIIVOLUTION);
+    mLaunchSystemMenu = getArguments().getBoolean(KEY_SYSTEM_MENU);
   }
 
   /**
@@ -269,6 +273,11 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
         {
           Log.debug("[EmulationFragment] Starting emulation thread from previous state.");
           NativeLibrary.Run(mGamePaths, mRiivolution, getTemporaryStateFilePath(), true);
+        }
+        if (mLaunchSystemMenu)
+        {
+          Log.debug("[EmulationFragment] Starting emulation thread for the Wii Menu.");
+          NativeLibrary.RunSystemMenu();
         }
         else
         {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -14,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.viewpager.widget.ViewPager;
 
@@ -27,6 +28,9 @@ import org.dolphinemu.dolphinemu.features.settings.model.IntSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.NativeConfig;
 import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag;
 import org.dolphinemu.dolphinemu.features.settings.ui.SettingsActivity;
+import org.dolphinemu.dolphinemu.features.sysupdate.ui.OnlineUpdateProgressBarDialogFragment;
+import org.dolphinemu.dolphinemu.features.sysupdate.ui.SystemMenuNotInstalledDialogFragment;
+import org.dolphinemu.dolphinemu.features.sysupdate.ui.SystemUpdateViewModel;
 import org.dolphinemu.dolphinemu.services.GameFileCacheManager;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.ui.platform.PlatformGamesView;
@@ -36,6 +40,7 @@ import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
 import org.dolphinemu.dolphinemu.utils.StartupHandler;
+import org.dolphinemu.dolphinemu.utils.WiiUtils;
 
 /**
  * The main Activity of the Lollipop style UI. Manages several PlatformGamesFragments, which
@@ -142,6 +147,14 @@ public final class MainActivity extends AppCompatActivity
   {
     MenuInflater inflater = getMenuInflater();
     inflater.inflate(R.menu.menu_game_grid, menu);
+
+    if (WiiUtils.isSystemMenuInstalled())
+    {
+      menu.findItem(R.id.menu_load_wii_system_menu).setTitle(
+              getString(R.string.grid_menu_load_wii_system_menu_installed,
+                      WiiUtils.getSystemMenuVersion()));
+    }
+
     return true;
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -378,6 +378,10 @@ public final class TvMainActivity extends FragmentActivity
             R.drawable.ic_folder,
             R.string.grid_menu_install_wad));
 
+    rowItems.add(new TvSettingsItem(R.id.menu_load_wii_system_menu,
+            R.drawable.ic_folder,
+            R.string.grid_menu_load_wii_system_menu));
+
     rowItems.add(new TvSettingsItem(R.id.menu_import_wii_save,
             R.drawable.ic_folder,
             R.string.grid_menu_import_wii_save));
@@ -385,6 +389,10 @@ public final class TvMainActivity extends FragmentActivity
     rowItems.add(new TvSettingsItem(R.id.menu_import_nand_backup,
             R.drawable.ic_folder,
             R.string.grid_menu_import_nand_backup));
+
+    rowItems.add(new TvSettingsItem(R.id.menu_online_system_update,
+            R.drawable.ic_folder,
+            R.string.grid_menu_online_system_update));
 
     // Create a header for this row.
     HeaderItem header = new HeaderItem(R.string.settings, getString(R.string.settings));

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUpdateCallback.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUpdateCallback.java
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.utils;
+
+import androidx.annotation.Keep;
+
+public interface WiiUpdateCallback
+{
+  @Keep
+  boolean run(int processed, int total, long titleId);
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.java
@@ -29,4 +29,6 @@ public final class WiiUtils
   public static native int doOnlineUpdate(String region, WiiUpdateCallback callback);
 
   public static native boolean isSystemMenuInstalled();
+
+  public static native String getSystemMenuVersion();
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.java
@@ -25,4 +25,6 @@ public final class WiiUtils
   public static native int importWiiSave(String file, BooleanSupplier canOverwrite);
 
   public static native void importNANDBin(String file);
+
+  public static native int doOnlineUpdate(String region, WiiUpdateCallback callback);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.java
@@ -10,6 +10,16 @@ public final class WiiUtils
   public static final int RESULT_CORRUPTED_SOURCE = 3;
   public static final int RESULT_TITLE_MISSING = 4;
 
+  public static final int UPDATE_RESULT_SUCCESS = 0;
+  public static final int UPDATE_RESULT_ALREADY_UP_TO_DATE = 1;
+  public static final int UPDATE_RESULT_REGION_MISMATCH = 2;
+  public static final int UPDATE_RESULT_MISSING_UPDATE_PARTITION = 3;
+  public static final int UPDATE_RESULT_DISC_READ_FAILED = 4;
+  public static final int UPDATE_RESULT_SERVER_FAILED = 5;
+  public static final int UPDATE_RESULT_DOWNLOAD_FAILED = 6;
+  public static final int UPDATE_RESULT_IMPORT_FAILED = 7;
+  public static final int UPDATE_RESULT_CANCELLED = 8;
+
   public static native boolean installWAD(String file);
 
   public static native int importWiiSave(String file, BooleanSupplier canOverwrite);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.java
@@ -27,4 +27,6 @@ public final class WiiUtils
   public static native void importNANDBin(String file);
 
   public static native int doOnlineUpdate(String region, WiiUpdateCallback callback);
+
+  public static native boolean isSystemMenuInstalled();
 }

--- a/Source/Android/app/src/main/res/menu/menu_game_grid.xml
+++ b/Source/Android/app/src/main/res/menu/menu_game_grid.xml
@@ -26,6 +26,11 @@
         app:showAsAction="never"/>
 
     <item
+        android:id="@+id/menu_load_wii_system_menu"
+        android:title="@string/grid_menu_load_wii_system_menu"
+        app:showAsAction="never"/>
+
+    <item
         android:id="@+id/menu_import_wii_save"
         android:title="@string/grid_menu_import_wii_save"
         app:showAsAction="never"/>
@@ -34,5 +39,11 @@
         android:id="@+id/menu_import_nand_backup"
         android:title="@string/grid_menu_import_nand_backup"
         app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/menu_online_system_update"
+        android:title="@string/grid_menu_online_system_update"
+        app:showAsAction="never"/>
+    <group />
 
 </menu>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -182,6 +182,29 @@
     <string name="osd_messages_description">Display messages over the emulation screen area. These messages include memory card writes, video backend and CPU information, and JIT cache clearing.</string>
     <string name="download_game_covers">Download Game Covers from GameTDB.com</string>
 
+    <!-- Online Update Region Select Fragment -->
+    <string name="region_select_title">Please select a region</string>
+    <string name="europe">Europe</string>
+    <string name="japan">Japan</string>
+    <string name="korea">Korea</string>
+    <string name="united_states">United States</string>
+
+    <!-- Online Update Progress Bar Fragment -->
+    <string name="updating">Updating</string>
+    <string name="updating_message">Updating title %016x...\nThis can take a while.</string>
+    <string name="update_success">The emulated Wii console has been updated.</string>
+    <string name="already_up_to_date">The emulated Wii console is already up-to-date.</string>
+    <string name="region_mismatch">The game\'s region does not match your console\'s. To avoid issues with the system menu, it is not possible to update the emulated console using this disc.</string>
+    <string name="missing_update_partition">The game disc does not contain any usable update information.</string>
+    <string name="disc_read_failed">The game disc does not contain any usable update information.</string>
+    <string name="server_failed">"Could not download update information from Nintendo. Please check your Internet connection and try again.</string>
+    <string name="download_failed">Could not download update files from Nintendo. Please check your Internet connection and try again.</string>
+    <string name="import_failed">"Could not install an update to the Wii system memory. Please refer to logs for more information.</string>
+    <string name="update_cancelled">The update has been cancelled. It is strongly recommended to finish it in order to avoid inconsistent system software versions.</string>
+    <string name="update_success_title">Update completed</string>
+    <string name="update_failed_title">Update failed</string>
+    <string name="update_cancelled_title">Update cancelled</string>
+
     <!-- Audio Settings -->
     <string name="audio_submenu">Audio</string>
     <string name="dsp_emulation_engine">DSP Emulation Engine</string>
@@ -391,6 +414,9 @@
     <string name="grid_menu_install_wad">Install WAD</string>
     <string name="grid_menu_import_wii_save">Import Wii Save</string>
     <string name="grid_menu_import_nand_backup">Import BootMii NAND Backup</string>
+    <string name="grid_menu_online_system_update">Perform Online System Update</string>
+    <string name="grid_menu_load_wii_system_menu">Load Wii System Menu</string>
+    <string name="grid_menu_load_wii_system_menu_installed">Load Wii System Menu (%s)</string>
     <string name="import_in_progress">Importing...</string>
     <string name="do_not_close_app">Do not close the app!</string>
     <string name="wad_install_success">Successfully installed this title to the NAND.</string>
@@ -401,6 +427,8 @@
     <string name="wii_save_import_corruped_source">Failed to import save file. The given file appears to be corrupted or is not a valid Wii save.</string>
     <string name="wii_save_import_title_missing">Failed to import save file. Please launch the game once, then try again.</string>
     <string name="nand_import_warning">Merging a new NAND over your currently selected NAND will overwrite any channels and savegames that already exist. This process is not reversible, so it is recommended that you keep backups of both NANDs. Are you sure you want to continue?</string>
+    <string name="system_menu_not_installed_title">Not installed</string>
+    <string name="system_menu_not_installed_message">The Wii Menu is currently not installed. Would you like to install it now?\nAn internet connection is required to download the update. It is recommended to download the update on Wi-Fi, as the amount of data downloaded may be large.</string>
 
     <!-- Game Properties Screen -->
     <string name="properties_details">Details</string>

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -73,6 +73,9 @@ static jmethodID s_patch_cheat_constructor;
 static jclass s_riivolution_patches_class;
 static jfieldID s_riivolution_patches_pointer;
 
+static jclass s_wii_update_cb_class;
+static jmethodID s_wii_update_cb_run;
+
 namespace IDCache
 {
 JNIEnv* GetEnvForThread()
@@ -338,6 +341,16 @@ jfieldID GetRiivolutionPatchesPointer()
   return s_riivolution_patches_pointer;
 }
 
+jclass GetWiiUpdateCallbackClass()
+{
+  return s_wii_update_cb_class;
+}
+
+jmethodID GetWiiUpdateCallbackFunction()
+{
+  return s_wii_update_cb_run;
+}
+
 }  // namespace IDCache
 
 extern "C" {
@@ -474,6 +487,12 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
   s_riivolution_patches_pointer = env->GetFieldID(riivolution_patches_class, "mPointer", "J");
   env->DeleteLocalRef(riivolution_patches_class);
 
+  const jclass wii_update_cb_class =
+      env->FindClass("org/dolphinemu/dolphinemu/utils/WiiUpdateCallback");
+  s_wii_update_cb_class = reinterpret_cast<jclass>(env->NewGlobalRef(wii_update_cb_class));
+  s_wii_update_cb_run = env->GetMethodID(s_wii_update_cb_class, "run", "(IIJ)Z");
+  env->DeleteLocalRef(wii_update_cb_class);
+
   return JNI_VERSION;
 }
 
@@ -498,5 +517,6 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved)
   env->DeleteGlobalRef(s_gecko_cheat_class);
   env->DeleteGlobalRef(s_patch_cheat_class);
   env->DeleteGlobalRef(s_riivolution_patches_class);
+  env->DeleteGlobalRef(s_wii_update_cb_class);
 }
 }

--- a/Source/Android/jni/AndroidCommon/IDCache.h
+++ b/Source/Android/jni/AndroidCommon/IDCache.h
@@ -72,4 +72,7 @@ jmethodID GetPatchCheatConstructor();
 jclass GetRiivolutionPatchesClass();
 jfieldID GetRiivolutionPatchesPointer();
 
+jclass GetWiiUpdateCallbackClass();
+jmethodID GetWiiUpdateCallbackFunction();
+
 }  // namespace IDCache

--- a/Source/Android/jni/WiiUtils.cpp
+++ b/Source/Android/jni/WiiUtils.cpp
@@ -35,6 +35,36 @@ static jint ConvertCopyResult(WiiSave::CopyResult result)
   static_assert(static_cast<int>(WiiSave::CopyResult::NumberOfEntries) == 5);
 }
 
+static jint ConvertUpdateResult(WiiUtils::UpdateResult result)
+{
+  switch (result)
+  {
+  case WiiUtils::UpdateResult::Succeeded:
+    return 0;
+  case WiiUtils::UpdateResult::AlreadyUpToDate:
+    return 1;
+  case WiiUtils::UpdateResult::RegionMismatch:
+    return 2;
+  case WiiUtils::UpdateResult::MissingUpdatePartition:
+    return 3;
+  case WiiUtils::UpdateResult::DiscReadFailed:
+    return 4;
+  case WiiUtils::UpdateResult::ServerFailed:
+    return 5;
+  case WiiUtils::UpdateResult::DownloadFailed:
+    return 6;
+  case WiiUtils::UpdateResult::ImportFailed:
+    return 7;
+  case WiiUtils::UpdateResult::Cancelled:
+    return 8;
+  default:
+    ASSERT(false);
+    return 1;
+  }
+
+  static_assert(static_cast<int>(WiiUtils::UpdateResult::NumberOfEntries) == 9);
+}
+
 extern "C" {
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_WiiUtils_installWAD(JNIEnv* env,

--- a/Source/Android/jni/WiiUtils.cpp
+++ b/Source/Android/jni/WiiUtils.cpp
@@ -9,7 +9,10 @@
 #include "jni/AndroidCommon/IDCache.h"
 
 #include "Common/ScopeGuard.h"
+#include "Core/CommonTitles.h"
 #include "Core/HW/WiiSave.h"
+#include "Core/IOS/ES/ES.h"
+#include "Core/IOS/IOS.h"
 #include "Core/WiiUtils.h"
 #include "DiscIO/NANDImporter.h"
 
@@ -127,5 +130,14 @@ JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_utils_WiiUtils_doOnlineUpd
   WiiUtils::UpdateResult result = WiiUtils::DoOnlineUpdate(callback, region);
 
   return ConvertUpdateResult(result);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_dolphinemu_dolphinemu_utils_WiiUtils_isSystemMenuInstalled(JNIEnv* env, jclass)
+{
+  IOS::HLE::Kernel ios;
+  const auto tmd = ios.GetES()->FindInstalledTMD(Titles::SYSTEM_MENU);
+
+  return tmd.IsValid();
 }
 }

--- a/Source/Android/jni/WiiUtils.cpp
+++ b/Source/Android/jni/WiiUtils.cpp
@@ -140,4 +140,18 @@ Java_org_dolphinemu_dolphinemu_utils_WiiUtils_isSystemMenuInstalled(JNIEnv* env,
 
   return tmd.IsValid();
 }
+
+JNIEXPORT jstring JNICALL
+Java_org_dolphinemu_dolphinemu_utils_WiiUtils_getSystemMenuVersion(JNIEnv* env, jclass)
+{
+  IOS::HLE::Kernel ios;
+  const auto tmd = ios.GetES()->FindInstalledTMD(Titles::SYSTEM_MENU);
+
+  if (!tmd.IsValid())
+  {
+    return ToJString(env, "");
+  }
+
+  return ToJString(env, DiscIO::GetSysMenuVersionString(tmd.GetTitleVersion()));
+}
 }

--- a/Source/Core/Core/WiiUtils.h
+++ b/Source/Core/Core/WiiUtils.h
@@ -82,6 +82,8 @@ enum class UpdateResult
   ImportFailed,
   // Update was cancelled.
   Cancelled,
+
+  NumberOfEntries,
 };
 
 // Return false to cancel the update as soon as the current title has finished updating.


### PR DESCRIPTION
This PR adds the online system update functionality to the Android version of Dolphin.
Thanks to @OatmealDome for helping me to debug my issues and help me out on the C++ part.

- The update process is very similar to the desktop version of Dolphin.
- Two new buttons have been added to the main view's menu: launch Wii Menu and Perform Online System Update
- New buttons have been added to Android TV as well.
- Logic has been to handle cases like launching the Wii Menu if it has not been installed.

There are two remaining issues:
1. The update fails if the screen is being rotated during the update. We mitigated this issue by locking the device orientation to the current position with `setRequestedOrientation`. The rotation will be unlocked after the update is done. A log file for this problem can be found here: https://gist.github.com/Simonx22/9dc0f0bd7650d600fbd62f273b4f5d2a
2. The update fails almost immediately on the official x64 Android Emulator. It works fine with the arm64 Emulator. A log file for this problem can be found here: https://gist.github.com/Simonx22/d3380f9efeb978a5f1dd2c7f3d07a88a

Screenshots:
<img src="https://user-images.githubusercontent.com/26326692/149408096-f3c2905f-c5e3-4b8d-afbe-21200e1736b1.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/26326692/149596126-1cc2fec7-0f53-4f42-95c0-8fe68bf6758e.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/26326692/149596172-578c571a-fd87-4705-a144-70274d36fd86.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/26326692/149408477-8d1c72fa-3c46-4ae4-ab42-c57e129372e6.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/26326692/149408758-a23a743c-85c8-4191-bb20-cd77a06d9342.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/26326692/149409040-59a8d22b-59c6-4bb3-994d-0dd8896f69b6.png" width="200" height="400" />