### PR TITLE
Android: add two QoL settings to IR pointer

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -98,9 +98,10 @@ public final class EmulationActivity extends AppCompatActivity
           MENU_ACTION_SAVE_SLOT6, MENU_ACTION_LOAD_SLOT1, MENU_ACTION_LOAD_SLOT2,
           MENU_ACTION_LOAD_SLOT3, MENU_ACTION_LOAD_SLOT4, MENU_ACTION_LOAD_SLOT5,
           MENU_ACTION_LOAD_SLOT6, MENU_ACTION_EXIT, MENU_ACTION_CHANGE_DISC,
-          MENU_ACTION_RESET_OVERLAY, MENU_SET_IR_MODE, MENU_SET_IR_SENSITIVITY,
-          MENU_ACTION_CHOOSE_DOUBLETAP, MENU_ACTION_MOTION_CONTROLS, MENU_ACTION_PAUSE_EMULATION,
-          MENU_ACTION_UNPAUSE_EMULATION, MENU_ACTION_OVERLAY_CONTROLS, MENU_ACTION_SETTINGS})
+          MENU_ACTION_RESET_OVERLAY, MENU_SET_IR_RECENTER, MENU_SET_IR_MODE,
+          MENU_SET_IR_SENSITIVITY, MENU_ACTION_CHOOSE_DOUBLETAP, MENU_ACTION_MOTION_CONTROLS,
+          MENU_ACTION_PAUSE_EMULATION, MENU_ACTION_UNPAUSE_EMULATION, MENU_ACTION_OVERLAY_CONTROLS,
+          MENU_ACTION_SETTINGS})
   public @interface MenuAction
   {
   }
@@ -132,14 +133,15 @@ public final class EmulationActivity extends AppCompatActivity
   public static final int MENU_ACTION_JOYSTICK_REL_CENTER = 24;
   public static final int MENU_ACTION_RUMBLE = 25;
   public static final int MENU_ACTION_RESET_OVERLAY = 26;
-  public static final int MENU_SET_IR_MODE = 27;
-  public static final int MENU_SET_IR_SENSITIVITY = 28;
-  public static final int MENU_ACTION_CHOOSE_DOUBLETAP = 29;
-  public static final int MENU_ACTION_MOTION_CONTROLS = 30;
-  public static final int MENU_ACTION_PAUSE_EMULATION = 31;
-  public static final int MENU_ACTION_UNPAUSE_EMULATION = 32;
-  public static final int MENU_ACTION_OVERLAY_CONTROLS = 33;
-  public static final int MENU_ACTION_SETTINGS = 34;
+  public static final int MENU_SET_IR_RECENTER = 27;
+  public static final int MENU_SET_IR_MODE = 28;
+  public static final int MENU_SET_IR_SENSITIVITY = 29;
+  public static final int MENU_ACTION_CHOOSE_DOUBLETAP = 30;
+  public static final int MENU_ACTION_MOTION_CONTROLS = 31;
+  public static final int MENU_ACTION_PAUSE_EMULATION = 32;
+  public static final int MENU_ACTION_UNPAUSE_EMULATION = 33;
+  public static final int MENU_ACTION_OVERLAY_CONTROLS = 34;
+  public static final int MENU_ACTION_SETTINGS = 35;
 
   private static final SparseIntArray buttonsActionsMap = new SparseIntArray();
 
@@ -158,6 +160,8 @@ public final class EmulationActivity extends AppCompatActivity
     buttonsActionsMap.append(R.id.menu_emulation_rumble, EmulationActivity.MENU_ACTION_RUMBLE);
     buttonsActionsMap
             .append(R.id.menu_emulation_reset_overlay, EmulationActivity.MENU_ACTION_RESET_OVERLAY);
+    buttonsActionsMap.append(R.id.menu_emulation_ir_recenter,
+            EmulationActivity.MENU_SET_IR_RECENTER);
     buttonsActionsMap.append(R.id.menu_emulation_set_ir_mode,
             EmulationActivity.MENU_SET_IR_MODE);
     buttonsActionsMap.append(R.id.menu_emulation_set_ir_sensitivity,
@@ -482,6 +486,11 @@ public final class EmulationActivity extends AppCompatActivity
             .setChecked(BooleanSetting.MAIN_JOYSTICK_REL_CENTER.getBoolean(mSettings));
     menu.findItem(R.id.menu_emulation_rumble)
             .setChecked(BooleanSetting.MAIN_PHONE_RUMBLE.getBoolean(mSettings));
+    if (wii)
+    {
+      menu.findItem(R.id.menu_emulation_ir_recenter)
+              .setChecked(BooleanSetting.MAIN_IR_ALWAYS_RECENTER.getBoolean(mSettings));
+    }
 
     popup.setOnMenuItemClickListener(this::onOptionsItemSelected);
 
@@ -519,6 +528,10 @@ public final class EmulationActivity extends AppCompatActivity
       case MENU_ACTION_RUMBLE:
         item.setChecked(!item.isChecked());
         toggleRumble(item.isChecked());
+        break;
+      case MENU_SET_IR_RECENTER:
+        item.setChecked(!item.isChecked());
+        toggleRecenter(item.isChecked());
         break;
     }
   }
@@ -696,6 +709,12 @@ public final class EmulationActivity extends AppCompatActivity
   {
     BooleanSetting.MAIN_PHONE_RUMBLE.setBoolean(mSettings, state);
     Rumble.setPhoneVibrator(state, this);
+  }
+
+  private void toggleRecenter(boolean state)
+  {
+    BooleanSetting.MAIN_IR_ALWAYS_RECENTER.setBoolean(mSettings, state);
+    mEmulationFragment.refreshOverlayPointer(mSettings);
   }
 
   private void editControlsPlacement()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -9,7 +9,6 @@ import android.content.SharedPreferences;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.text.TextUtils;
 import android.util.SparseIntArray;
 import android.view.InputDevice;
 import android.view.KeyEvent;
@@ -99,9 +98,9 @@ public final class EmulationActivity extends AppCompatActivity
           MENU_ACTION_SAVE_SLOT6, MENU_ACTION_LOAD_SLOT1, MENU_ACTION_LOAD_SLOT2,
           MENU_ACTION_LOAD_SLOT3, MENU_ACTION_LOAD_SLOT4, MENU_ACTION_LOAD_SLOT5,
           MENU_ACTION_LOAD_SLOT6, MENU_ACTION_EXIT, MENU_ACTION_CHANGE_DISC,
-          MENU_ACTION_RESET_OVERLAY, MENU_SET_IR_SENSITIVITY, MENU_ACTION_CHOOSE_DOUBLETAP,
-          MENU_ACTION_MOTION_CONTROLS, MENU_ACTION_PAUSE_EMULATION, MENU_ACTION_UNPAUSE_EMULATION,
-          MENU_ACTION_OVERLAY_CONTROLS, MENU_ACTION_SETTINGS})
+          MENU_ACTION_RESET_OVERLAY, MENU_SET_IR_MODE, MENU_SET_IR_SENSITIVITY,
+          MENU_ACTION_CHOOSE_DOUBLETAP, MENU_ACTION_MOTION_CONTROLS, MENU_ACTION_PAUSE_EMULATION,
+          MENU_ACTION_UNPAUSE_EMULATION, MENU_ACTION_OVERLAY_CONTROLS, MENU_ACTION_SETTINGS})
   public @interface MenuAction
   {
   }
@@ -133,13 +132,14 @@ public final class EmulationActivity extends AppCompatActivity
   public static final int MENU_ACTION_JOYSTICK_REL_CENTER = 24;
   public static final int MENU_ACTION_RUMBLE = 25;
   public static final int MENU_ACTION_RESET_OVERLAY = 26;
-  public static final int MENU_SET_IR_SENSITIVITY = 27;
-  public static final int MENU_ACTION_CHOOSE_DOUBLETAP = 28;
-  public static final int MENU_ACTION_MOTION_CONTROLS = 29;
-  public static final int MENU_ACTION_PAUSE_EMULATION = 30;
-  public static final int MENU_ACTION_UNPAUSE_EMULATION = 31;
-  public static final int MENU_ACTION_OVERLAY_CONTROLS = 32;
-  public static final int MENU_ACTION_SETTINGS = 33;
+  public static final int MENU_SET_IR_MODE = 27;
+  public static final int MENU_SET_IR_SENSITIVITY = 28;
+  public static final int MENU_ACTION_CHOOSE_DOUBLETAP = 29;
+  public static final int MENU_ACTION_MOTION_CONTROLS = 30;
+  public static final int MENU_ACTION_PAUSE_EMULATION = 31;
+  public static final int MENU_ACTION_UNPAUSE_EMULATION = 32;
+  public static final int MENU_ACTION_OVERLAY_CONTROLS = 33;
+  public static final int MENU_ACTION_SETTINGS = 34;
 
   private static final SparseIntArray buttonsActionsMap = new SparseIntArray();
 
@@ -158,6 +158,8 @@ public final class EmulationActivity extends AppCompatActivity
     buttonsActionsMap.append(R.id.menu_emulation_rumble, EmulationActivity.MENU_ACTION_RUMBLE);
     buttonsActionsMap
             .append(R.id.menu_emulation_reset_overlay, EmulationActivity.MENU_ACTION_RESET_OVERLAY);
+    buttonsActionsMap.append(R.id.menu_emulation_set_ir_mode,
+            EmulationActivity.MENU_SET_IR_MODE);
     buttonsActionsMap.append(R.id.menu_emulation_set_ir_sensitivity,
             EmulationActivity.MENU_SET_IR_SENSITIVITY);
     buttonsActionsMap.append(R.id.menu_emulation_choose_doubletap,
@@ -644,6 +646,10 @@ public final class EmulationActivity extends AppCompatActivity
         startActivityForResult(intent, REQUEST_CHANGE_DISC);
         break;
 
+      case MENU_SET_IR_MODE:
+        setIRMode();
+        break;
+
       case MENU_SET_IR_SENSITIVITY:
         setIRSensitivity();
         break;
@@ -935,6 +941,20 @@ public final class EmulationActivity extends AppCompatActivity
               NativeLibrary.ReloadWiimoteConfig();
             });
     builder.setPositiveButton(R.string.ok, (dialogInterface, i) -> dialogInterface.dismiss());
+
+    builder.show();
+  }
+
+  private void setIRMode()
+  {
+    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
+    builder.setTitle(R.string.emulation_ir_mode);
+    builder.setSingleChoiceItems(R.array.irModeEntries,
+            IntSetting.MAIN_IR_MODE.getInt(mSettings),
+            (dialog, indexSelected) ->
+                    IntSetting.MAIN_IR_MODE.setInt(mSettings, indexSelected));
+    builder.setPositiveButton(R.string.ok, (dialogInterface, i) ->
+            mEmulationFragment.refreshOverlayPointer(mSettings));
 
     builder.show();
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -71,6 +71,8 @@ public enum BooleanSetting implements AbstractBooleanSetting
           "PhoneRumble", true),
   MAIN_SHOW_INPUT_OVERLAY(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
           "ShowInputOverlay", true),
+  MAIN_IR_ALWAYS_RECENTER(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
+          "IRAlwaysRecenter", false),
 
   MAIN_BUTTON_TOGGLE_GC_0(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID_OVERLAY_BUTTONS,
           "ButtonToggleGCButtonA", true),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -30,6 +30,8 @@ public enum IntSetting implements AbstractIntSetting
           "EmulationOrientation", ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE),
   MAIN_LAST_PLATFORM_TAB(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "LastPlatformTab", 0),
   MAIN_MOTION_CONTROLS(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "MotionControls", 1),
+  MAIN_IR_MODE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "IRMode",
+          InputOverlayPointer.MODE_FOLLOW),
 
   MAIN_DOUBLE_TAP_BUTTON(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID_OVERLAY_BUTTONS,
           "DoubleTapButton",

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -162,6 +162,12 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
       mInputOverlay.refreshControls();
   }
 
+  public void refreshOverlayPointer(Settings settings)
+  {
+    if (mInputOverlay != null)
+      mInputOverlay.refreshOverlayPointer(settings);
+  }
+
   public void resetInputOverlay()
   {
     if (mInputOverlay != null)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -165,7 +165,8 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     }
 
     overlayPointer = new InputOverlayPointer(mSurfacePosition, doubleTapButton,
-            IntSetting.MAIN_IR_MODE.getIntGlobal());
+            IntSetting.MAIN_IR_MODE.getIntGlobal(),
+            BooleanSetting.MAIN_IR_ALWAYS_RECENTER.getBooleanGlobal());
   }
 
   @Override
@@ -775,6 +776,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     if (overlayPointer != null)
     {
       overlayPointer.setMode(IntSetting.MAIN_IR_MODE.getInt(settings));
+      overlayPointer.setRecenter(BooleanSetting.MAIN_IR_ALWAYS_RECENTER.getBoolean(settings));
     }
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -164,7 +164,8 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
       doubleTapButton = InputOverlayPointer.DOUBLE_TAP_A;
     }
 
-    overlayPointer = new InputOverlayPointer(mSurfacePosition, doubleTapButton);
+    overlayPointer = new InputOverlayPointer(mSurfacePosition, doubleTapButton,
+            IntSetting.MAIN_IR_MODE.getIntGlobal());
   }
 
   @Override
@@ -767,6 +768,14 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     }
     mIsFirstRun = false;
     invalidate();
+  }
+
+  public void refreshOverlayPointer(Settings settings)
+  {
+    if (overlayPointer != null)
+    {
+      overlayPointer.setMode(IntSetting.MAIN_IR_MODE.getInt(settings));
+    }
   }
 
   public void resetButtonPlacement()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
@@ -17,12 +17,22 @@ public class InputOverlayPointer
   public static final int DOUBLE_TAP_2 = 2;
   public static final int DOUBLE_TAP_CLASSIC_A = 3;
 
+  public static final int MODE_DISABLED = 0;
+  public static final int MODE_FOLLOW = 1;
+  public static final int MODE_DRAG = 2;
+
   private final float[] axes = {0f, 0f};
+  private final float[] oldaxes = {0f, 0f};
 
   private float mGameCenterX;
   private float mGameCenterY;
   private float mGameWidthHalfInv;
   private float mGameHeightHalfInv;
+
+  private float mTouchStartX;
+  private float mTouchStartY;
+
+  private int mMode;
 
   private boolean doubleTap = false;
   private int doubleTapButton;
@@ -38,9 +48,10 @@ public class InputOverlayPointer
     DOUBLE_TAP_OPTIONS.add(NativeLibrary.ButtonType.CLASSIC_BUTTON_A);
   }
 
-  public InputOverlayPointer(Rect surfacePosition, int button)
+  public InputOverlayPointer(Rect surfacePosition, int button, int mode)
   {
     doubleTapButton = button;
+    mMode = mode;
 
     mGameCenterX = (surfacePosition.left + surfacePosition.right) / 2.0f;
     mGameCenterY = (surfacePosition.top + surfacePosition.bottom) / 2.0f;
@@ -76,36 +87,60 @@ public class InputOverlayPointer
       case MotionEvent.ACTION_DOWN:
       case MotionEvent.ACTION_POINTER_DOWN:
         trackId = event.getPointerId(pointerIndex);
+        mTouchStartX = event.getX(pointerIndex);
+        mTouchStartY = event.getY(pointerIndex);
         touchPress();
         break;
       case MotionEvent.ACTION_UP:
       case MotionEvent.ACTION_POINTER_UP:
         if (trackId == event.getPointerId(pointerIndex))
           trackId = -1;
+        if (mMode == MODE_DRAG)
+          updateOldAxes();
         break;
     }
 
     if (trackId == -1)
       return;
 
-    axes[0] = (event.getY(event.findPointerIndex(trackId)) - mGameCenterY) * mGameHeightHalfInv;
-    axes[1] = (event.getX(event.findPointerIndex(trackId)) - mGameCenterX) * mGameWidthHalfInv;
+    if (mMode == MODE_FOLLOW)
+    {
+      axes[0] = (event.getY(event.findPointerIndex(trackId)) - mGameCenterY) * mGameHeightHalfInv;
+      axes[1] = (event.getX(event.findPointerIndex(trackId)) - mGameCenterX) * mGameWidthHalfInv;
+    }
+    else if (mMode == MODE_DRAG)
+    {
+      axes[0] = oldaxes[0] +
+              (event.getY(event.findPointerIndex(trackId)) - mTouchStartY) * mGameHeightHalfInv;
+      axes[1] = oldaxes[1] +
+              (event.getX(event.findPointerIndex(trackId)) - mTouchStartX) * mGameWidthHalfInv;
+    }
   }
 
   private void touchPress()
   {
-    if (doubleTap)
+    if (mMode != MODE_DISABLED)
     {
-      NativeLibrary.onGamePadEvent(NativeLibrary.TouchScreenDevice,
-              doubleTapButton, NativeLibrary.ButtonState.PRESSED);
-      new Handler().postDelayed(() -> NativeLibrary.onGamePadEvent(NativeLibrary.TouchScreenDevice,
-              doubleTapButton, NativeLibrary.ButtonState.RELEASED), 50);
+      if (doubleTap)
+      {
+        NativeLibrary.onGamePadEvent(NativeLibrary.TouchScreenDevice,
+                doubleTapButton, NativeLibrary.ButtonState.PRESSED);
+        new Handler()
+                .postDelayed(() -> NativeLibrary.onGamePadEvent(NativeLibrary.TouchScreenDevice,
+                        doubleTapButton, NativeLibrary.ButtonState.RELEASED), 50);
+      }
+      else
+      {
+        doubleTap = true;
+        new Handler().postDelayed(() -> doubleTap = false, 300);
+      }
     }
-    else
-    {
-      doubleTap = true;
-      new Handler().postDelayed(() -> doubleTap = false, 300);
-    }
+  }
+
+  private void updateOldAxes()
+  {
+    oldaxes[0] = axes[0];
+    oldaxes[1] = axes[1];
   }
 
   public float[] getAxisValues()
@@ -116,5 +151,12 @@ public class InputOverlayPointer
     iraxes[3] = axes[1];
     iraxes[2] = axes[1];
     return iraxes;
+  }
+
+  public void setMode(int mode)
+  {
+    mMode = mode;
+    if (mode == MODE_DRAG)
+      updateOldAxes();
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
@@ -33,6 +33,7 @@ public class InputOverlayPointer
   private float mTouchStartY;
 
   private int mMode;
+  private boolean mRecenter;
 
   private boolean doubleTap = false;
   private int doubleTapButton;
@@ -48,10 +49,11 @@ public class InputOverlayPointer
     DOUBLE_TAP_OPTIONS.add(NativeLibrary.ButtonType.CLASSIC_BUTTON_A);
   }
 
-  public InputOverlayPointer(Rect surfacePosition, int button, int mode)
+  public InputOverlayPointer(Rect surfacePosition, int button, int mode, boolean recenter)
   {
     doubleTapButton = button;
     mMode = mode;
+    mRecenter = recenter;
 
     mGameCenterX = (surfacePosition.left + surfacePosition.right) / 2.0f;
     mGameCenterY = (surfacePosition.top + surfacePosition.bottom) / 2.0f;
@@ -97,6 +99,8 @@ public class InputOverlayPointer
           trackId = -1;
         if (mMode == MODE_DRAG)
           updateOldAxes();
+        if (mRecenter)
+          reset();
         break;
     }
 
@@ -143,6 +147,11 @@ public class InputOverlayPointer
     oldaxes[1] = axes[1];
   }
 
+  private void reset()
+  {
+    axes[0] = axes[1] = oldaxes[0] = oldaxes[1] = 0f;
+  }
+
   public float[] getAxisValues()
   {
     float[] iraxes = {0f, 0f, 0f, 0f};
@@ -158,5 +167,10 @@ public class InputOverlayPointer
     mMode = mode;
     if (mode == MODE_DRAG)
       updateOldAxes();
+  }
+
+  public void setRecenter(boolean recenter)
+  {
+    mRecenter = recenter;
   }
 }

--- a/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
@@ -39,6 +39,9 @@
         android:title="@string/emulation_ir_group">
         <menu>
             <item
+                android:id="@+id/menu_emulation_set_ir_mode"
+                android:title="@string/emulation_ir_mode"/>
+            <item
                 android:id="@+id/menu_emulation_set_ir_sensitivity"
                 android:title="@string/emulation_ir_sensitivity"/>
             <item

--- a/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
@@ -39,6 +39,10 @@
         android:title="@string/emulation_ir_group">
         <menu>
             <item
+                android:id="@+id/menu_emulation_ir_recenter"
+                android:checkable="true"
+                android:title="@string/emulation_ir_recenter"/>
+            <item
                 android:id="@+id/menu_emulation_set_ir_mode"
                 android:title="@string/emulation_ir_mode"/>
             <item

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -433,6 +433,12 @@
         <item>Right Stick</item>
     </string-array>
 
+    <string-array name="irModeEntries">
+        <item>Disabled</item>
+        <item>Follow</item>
+        <item>Drag</item>
+    </string-array>
+
     <string-array name="doubleTap">
         <item>Button A</item>
         <item>Button B</item>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -517,6 +517,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="emulation_menu_help">Press Back to access the menu.\nLong press Back to exit emulation.</string>
     <string name="emulation_touch_overlay_reset">Reset Overlay</string>
     <string name="emulation_ir_group">Touch IR Pointer</string>
+    <string name="emulation_ir_mode">IR Mode</string>
     <string name="emulation_ir_sensitivity">IR Sensitivity</string>
     <string name="emulation_choose_doubletap">Double tap button</string>
     <string name="emulation_motion_controls">Motion Controls</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -517,6 +517,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="emulation_menu_help">Press Back to access the menu.\nLong press Back to exit emulation.</string>
     <string name="emulation_touch_overlay_reset">Reset Overlay</string>
     <string name="emulation_ir_group">Touch IR Pointer</string>
+    <string name="emulation_ir_recenter">Always recenter</string>
     <string name="emulation_ir_mode">IR Mode</string>
     <string name="emulation_ir_sensitivity">IR Sensitivity</string>
     <string name="emulation_choose_doubletap">Double tap button</string>

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -38,10 +38,10 @@ bool IsSettingSaveable(const Config::Location& config_location)
     // TODO: Kill the current Android controller mappings system
     if (config_location.section == "Android")
     {
-      static constexpr std::array<const char*, 9> android_setting_saveable = {
-          "ControlScale",    "ControlOpacity", "EmulationOrientation", "JoystickRelCenter",
-          "LastPlatformTab", "MotionControls", "PhoneRumble",          "ShowInputOverlay",
-          "IRMode"};
+      static constexpr std::array<const char*, 10> android_setting_saveable = {
+          "ControlScale",    "ControlOpacity",  "EmulationOrientation", "JoystickRelCenter",
+          "LastPlatformTab", "MotionControls",  "PhoneRumble",          "ShowInputOverlay",
+          "IRMode",          "IRAlwaysRecenter"};
 
       return std::any_of(
           android_setting_saveable.cbegin(), android_setting_saveable.cend(),

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -38,9 +38,10 @@ bool IsSettingSaveable(const Config::Location& config_location)
     // TODO: Kill the current Android controller mappings system
     if (config_location.section == "Android")
     {
-      static constexpr std::array<const char*, 8> android_setting_saveable = {
+      static constexpr std::array<const char*, 9> android_setting_saveable = {
           "ControlScale",    "ControlOpacity", "EmulationOrientation", "JoystickRelCenter",
-          "LastPlatformTab", "MotionControls", "PhoneRumble",          "ShowInputOverlay"};
+          "LastPlatformTab", "MotionControls", "PhoneRumble",          "ShowInputOverlay",
+          "IRMode"};
 
       return std::any_of(
           android_setting_saveable.cbegin(), android_setting_saveable.cend(),


### PR DESCRIPTION
This PR adds the following settings:
* `IR Mode`: IR pointer can now follow the user's finger or be dragged around (see commit description for more info)
* `IR Always recenter`: recenter IR after every pointer interaction

These settings come from the MMJ fork, and were cleaned up and ported to the MMJR fork by me. Some users are still using those forks only because of these settings, so I figured I'd port them here too so we can finally get rid of them :)