### PR TITLE
CMakeLists: Change DiscIO dependency from common to core

### DIFF
--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -66,7 +66,7 @@ add_library(discio
 
 target_link_libraries(discio
 PUBLIC
-  common
+  core
   BZip2::BZip2
   lzma
   zstd

--- a/Source/Core/DolphinTool/CMakeLists.txt
+++ b/Source/Core/DolphinTool/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(dolphin-tool
 PRIVATE
   discio
   uicommon
-  videocommon
   cpp-optparse
 )
 


### PR DESCRIPTION
DiscIO depends on some IOS functions and other functions, which are in Core and not Common.  This results in link errors if using DiscIO on its own (which is why DolphinTool had a listed dependency on videocommon; videocommon has a dependency on core so adding that made things build).