### PR TITLE
Work around false SLOTS defined but not used warning on GCC

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI.h
+++ b/Source/Core/Core/HW/EXI/EXI.h
@@ -37,10 +37,12 @@ enum class Slot : int
   B,
   SP1,
 };
-static constexpr auto SLOTS = {Slot::A, Slot::B, Slot::SP1};
-static constexpr auto MAX_SLOT = Slot::SP1;
-static constexpr auto MEMCARD_SLOTS = {Slot::A, Slot::B};
-static constexpr auto MAX_MEMCARD_SLOT = Slot::B;
+// Note: using auto here results in a false warning on GCC
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80351
+constexpr std::initializer_list<Slot> SLOTS = {Slot::A, Slot::B, Slot::SP1};
+constexpr auto MAX_SLOT = Slot::SP1;
+constexpr std::initializer_list<Slot> MEMCARD_SLOTS = {Slot::A, Slot::B};
+constexpr auto MAX_MEMCARD_SLOT = Slot::B;
 constexpr bool IsMemcardSlot(Slot slot)
 {
   return slot == Slot::A || slot == Slot::B;


### PR DESCRIPTION
This warning was caused by #10364; see e.g. [this build log](https://dolphin.ci/#/builders/19/builds/5831).  The bug in question is https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80351, and it seems to be solvable by explicitly using `std::initializer_list` instead of `auto`.  The warning is generated only for the first `auto` initializer list, but we need to change both `SLOTS` and `MEMCARD_SLOTS` as if only `SLOTS` is changed, then `MEMCARD_SLOTS` becomes the first `auto` initializer list and generates a warning.  An alternative solution is to mark `SLOTS` as `[[maybe_unused]]`, which does _not_ require changing `MEMCARD_SLOTS`, but that seems a bit silly.  (I've requested an account on the GCC bugzilla to add some additional notes there, but it hasn't been created yet.)