### PR TITLE
Externals: Use Common ASSERT for IM_ASSERT

### DIFF
--- a/Externals/imgui/CMakeLists.txt
+++ b/Externals/imgui/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(SRCS
   imgui.cpp
   imgui_draw.cpp
@@ -8,3 +12,8 @@ set(SRCS
 add_library(imgui STATIC ${SRCS})
 target_include_directories(imgui PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
+target_link_libraries(imgui
+PRIVATE
+  common
+  fmt::fmt
+)

--- a/Externals/imgui/README.txt
+++ b/Externals/imgui/README.txt
@@ -1,0 +1,1 @@
+When updating, make sure to preserve changes to imconfig.h.  Dolphin modifies it to use a custom assertion handler and to tweak settings.

--- a/Externals/imgui/imconfig.h
+++ b/Externals/imgui/imconfig.h
@@ -27,7 +27,7 @@
 //#define IMGUI_API __declspec( dllimport )
 
 //---- Don't define obsolete functions/enums/behaviors. Consider enabling from time to time after updating to avoid using soon-to-be obsolete function/names.
-//#define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+#define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 
 //---- Disable all of Dear ImGui or don't implement standard windows.
 // It is very strongly recommended to NOT disable the demo windows during development. Please read comments in imgui_demo.cpp.

--- a/Externals/imgui/imconfig.h
+++ b/Externals/imgui/imconfig.h
@@ -14,10 +14,11 @@
 
 #pragma once
 
+#include "Common/Assert.h"
+
 //---- Define assertion handler. Defaults to calling assert().
 // If your macro uses multiple statements, make sure is enclosed in a 'do { .. } while (0)' block so it can be used as a single statement.
-//#define IM_ASSERT(_EXPR)  MyAssert(_EXPR)
-//#define IM_ASSERT(_EXPR)  ((void)(_EXPR))     // Disable asserts
+#define IM_ASSERT(_EXPR)  ASSERT(_EXPR)
 
 //---- Define attributes of all API symbols declarations, e.g. for DLL under Windows
 // Using Dear ImGui via a shared library is not recommended, because of function call overhead and because we don't guarantee backward nor forward ABI compatibility.

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -971,6 +971,11 @@ void Renderer::RecordVideoMemory()
 
 bool Renderer::InitializeImGui()
 {
+  if (!IMGUI_CHECKVERSION())
+  {
+    PanicAlertFmt("ImGui version check failed");
+    return false;
+  }
   if (!ImGui::CreateContext())
   {
     PanicAlertFmt("Creating ImGui context failed");


### PR DESCRIPTION
The first commit calls the `IMGUI_CHECKVERSION` macro, which is intended to prevent issues like the one I caused after #10188 where the wrong version of imgui was linked.  The second commit is also future-proofing.

The third commit switches to Common's `ASSERT` macro for the `IM_ASSERT` macro.  This does mean imgui now depends on both common and fmt, but since imgui is only used by dolphinqt (and the cmakelists file is added by dolphin in the first place), I don't think this is a problem.  In my opinion, it's better to use the same assert window for everything, rather than have the default assert/retry/ignore one appear sometimes.

Examples by removing the call to `ImGui::CreateContext()` in `Renderer::InitializeImGui`:

Before:

![image](https://user-images.githubusercontent.com/8334194/149705452-0bcbe675-173b-4989-bd57-c59a72ccd03c.png)

After:

![image](https://user-images.githubusercontent.com/8334194/149705465-8d993041-a129-4b31-a3eb-660a7396456e.png)

I did attempt to avoid the direct dependency by declaring a global variable in `imconfig.h` to be modified, but that failed because `imconfig.h` is included in multiple locations.

<details><summary>Failed patch</summary>

```patch
diff --git a/Externals/imgui/imconfig.h b/Externals/imgui/imconfig.h
index f255601704..57c287f798 100644
--- a/Externals/imgui/imconfig.h
+++ b/Externals/imgui/imconfig.h
@@ -14,10 +14,30 @@
 
 #pragma once
 
+#include <assert.h>
+
+//---- Tip: You can add extra functions within the ImGui:: namespace, here or in your own headers files.
+namespace ImGui
+{
+  // condition, file, line, func
+  void (*g_dolphin_assert_handler)(const char*, const char*, int, const char*) = nullptr;
+}
+
 //---- Define assertion handler. Defaults to calling assert().
 // If your macro uses multiple statements, make sure is enclosed in a 'do { .. } while (0)' block so it can be used as a single statement.
-//#define IM_ASSERT(_EXPR)  MyAssert(_EXPR)
-//#define IM_ASSERT(_EXPR)  ((void)(_EXPR))     // Disable asserts
+#define IM_ASSERT(_EXPR)                                                                           \
+  do                                                                                               \
+  {                                                                                                \
+    if (ImGui::g_dolphin_assert_handler != nullptr)                                                \
+    {                                                                                              \
+      if (!(_EXPR))                                                                                  \
+        ImGui::g_dolphin_assert_handler(#_EXPR, __FILE__, __LINE__, __func__);                     \
+    }                                                                                              \
+    else                                                                                           \
+    {                                                                                              \
+      assert(_EXPR && "g_dolphin_assert_handler not set by Dolphin");                              \
+    }                                                                                              \
+  } while (0)
 
 //---- Define attributes of all API symbols declarations, e.g. for DLL under Windows
 // Using Dear ImGui via a shared library is not recommended, because of function call overhead and because we don't guarantee backward nor forward ABI compatibility.
@@ -113,11 +133,3 @@
 
 //---- Debug Tools: Enable slower asserts
 //#define IMGUI_DEBUG_PARANOID
-
-//---- Tip: You can add extra functions within the ImGui:: namespace, here or in your own headers files.
-/*
-namespace ImGui
-{
-    void MyFunction(const char* name, const MyMatrix44& v);
-}
-*/
diff --git a/Source/Core/VideoCommon/RenderBase.cpp b/Source/Core/VideoCommon/RenderBase.cpp
index 861c69d985..78b6022482 100644
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -971,6 +971,14 @@ void Renderer::RecordVideoMemory()
 
 bool Renderer::InitializeImGui()
 {
+  ImGui::g_dolphin_assert_handler = [](const char* cond, const char* file, int line,
+                                       const char* func) {
+    if (!PanicYesNoFmt("An ImGui error occurred.\n\n"
+                       "  Condition: {}\n  File: {}\n  Line: {}\n  Function: {}\n\n"
+                       "Ignore and continue?",
+                       cond, file, line, func))
+      Crash();
+  };
   if (!IMGUI_CHECKVERSION())
   {
     PanicAlertFmt("ImGui version check failed");
```

</details>