### PR TITLE
Fix several compile warnings on GCC

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -37,7 +37,7 @@ constexpr Dest SaturatingCast(T value)
 {
   static_assert(std::is_integral<Dest>());
 
-  constexpr Dest lo = std::numeric_limits<Dest>::lowest();
+  [[maybe_unused]] constexpr Dest lo = std::numeric_limits<Dest>::lowest();
   constexpr Dest hi = std::numeric_limits<Dest>::max();
 
   // T being a signed integer and Dest unsigned is a problematic case because the value will

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -1031,7 +1031,7 @@ int AddOnStateChangedCallback(StateChangedCallbackFunc callback)
 
 bool RemoveOnStateChangedCallback(int* handle)
 {
-  if (handle && *handle >= 0 && s_on_state_changed_callbacks.size() > *handle)
+  if (handle && *handle >= 0 && s_on_state_changed_callbacks.size() > static_cast<size_t>(*handle))
   {
     s_on_state_changed_callbacks[*handle] = StateChangedCallbackFunc();
     *handle = -1;

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -470,6 +470,10 @@ void DSPEmitter::CompileDispatcher()
   RET();
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
 Gen::OpArg DSPEmitter::M_SDSP_pc()
 {
   return MDisp(R15, static_cast<int>(offsetof(SDSP, pc)));
@@ -503,5 +507,8 @@ Gen::OpArg DSPEmitter::M_SDSP_reg_stack_ptrs(size_t index)
   return MDisp(R15, static_cast<int>(offsetof(SDSP, reg_stack_ptrs) +
                                      sizeof(SDSP::reg_stack_ptrs[0]) * index));
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace DSP::JIT::x64

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitMultiplier.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitMultiplier.cpp
@@ -149,7 +149,14 @@ void DSPEmitter::multiply_mulx(u8 axh0, u8 axh1)
 // direct use of prod regs by AX/AXWII (look @that part of ucode).
 void DSPEmitter::clrp(const UDSPInstruction opc)
 {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
   int offset = static_cast<int>(offsetof(SDSP, r.prod.val));
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
   // 64bit move to memory does not work. use 2 32bits
   MOV(32, MDisp(R15, offset + 0 * sizeof(u32)), Imm32(0xfff00000U));
   MOV(32, MDisp(R15, offset + 1 * sizeof(u32)), Imm32(0x001000ffU));

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
@@ -20,6 +20,10 @@ namespace DSP::JIT::x64
 constexpr std::array<X64Reg, 15> s_allocation_order = {
     {R8, R9, R10, R11, R12, R13, R14, R15, RSI, RDI, RBX, RCX, RDX, RAX, RBP}};
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
 static Gen::OpArg GetRegisterPointer(size_t reg)
 {
   switch (reg)
@@ -95,6 +99,9 @@ static Gen::OpArg GetRegisterPointer(size_t reg)
     return M(static_cast<void*>(nullptr));
   }
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #define STATIC_REG_ACCS
 //#undef STATIC_REG_ACCS

--- a/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
@@ -285,19 +285,19 @@ std::unique_ptr<FifoDataFile> FifoDataFile::Load(const std::string& filename, bo
 
   u32 size = std::min<u32>(BP_MEM_SIZE, header.bpMemSize);
   file.Seek(header.bpMemOffset, File::SeekOrigin::Begin);
-  file.ReadArray(&dataFile->m_BPMem);
+  file.ReadArray(dataFile->m_BPMem.data(), size);
 
   size = std::min<u32>(CP_MEM_SIZE, header.cpMemSize);
   file.Seek(header.cpMemOffset, File::SeekOrigin::Begin);
-  file.ReadArray(&dataFile->m_CPMem);
+  file.ReadArray(dataFile->m_CPMem.data(), size);
 
   size = std::min<u32>(XF_MEM_SIZE, header.xfMemSize);
   file.Seek(header.xfMemOffset, File::SeekOrigin::Begin);
-  file.ReadArray(&dataFile->m_XFMem);
+  file.ReadArray(dataFile->m_XFMem.data(), size);
 
   size = std::min<u32>(XF_REGS_SIZE, header.xfRegsSize);
   file.Seek(header.xfRegsOffset, File::SeekOrigin::Begin);
-  file.ReadArray(&dataFile->m_XFRegs);
+  file.ReadArray(dataFile->m_XFRegs.data(), size);
 
   // Texture memory saving was added in version 4.
   dataFile->m_TexMem.fill(0);

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1747,18 +1747,20 @@ bool NetPlayClient::StartGame(const std::string& path)
 
   // boot game
   auto boot_session_data = std::make_unique<BootSessionData>();
-  boot_session_data->SetWiiSyncData(
-      std::move(m_wii_sync_fs), std::move(m_wii_sync_titles), std::move(m_wii_sync_redirect_folder),
-      [] {
-        // on emulation end clean up the Wii save sync directory -- see OnSyncSaveDataWii()
-        const std::string path = File::GetUserPath(D_USER_IDX) + "Wii" GC_MEMCARD_NETPLAY DIR_SEP;
-        if (File::Exists(path))
-          File::DeleteDirRecursively(path);
-        const std::string redirect_path =
-            File::GetUserPath(D_USER_IDX) + "Redirect" GC_MEMCARD_NETPLAY DIR_SEP;
-        if (File::Exists(redirect_path))
-          File::DeleteDirRecursively(redirect_path);
-      });
+  boot_session_data->SetWiiSyncData(std::move(m_wii_sync_fs), std::move(m_wii_sync_titles),
+                                    std::move(m_wii_sync_redirect_folder), [] {
+                                      // on emulation end clean up the Wii save sync directory --
+                                      // see OnSyncSaveDataWii()
+                                      const std::string wii_path = File::GetUserPath(D_USER_IDX) +
+                                                                   "Wii" GC_MEMCARD_NETPLAY DIR_SEP;
+                                      if (File::Exists(wii_path))
+                                        File::DeleteDirRecursively(wii_path);
+                                      const std::string redirect_path =
+                                          File::GetUserPath(D_USER_IDX) +
+                                          "Redirect" GC_MEMCARD_NETPLAY DIR_SEP;
+                                      if (File::Exists(redirect_path))
+                                        File::DeleteDirRecursively(redirect_path);
+                                    });
   m_dialog->BootGame(path, std::move(boot_session_data));
 
   UpdateDevices();

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -633,7 +633,7 @@ static void WriteRegister()
   }
   else if (id >= 88 && id < 104)
   {
-    PowerPC::ppcState.sr[SPR_IBAT0U + id - 88] = re32hex(bufptr);
+    PowerPC::ppcState.spr[SPR_IBAT0U + id - 88] = re32hex(bufptr);
   }
   else
   {

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -40,7 +40,7 @@ typedef SSIZE_T ssize_t;
 
 namespace GDBStub
 {
-std::optional<Common::SocketContext> s_socket_context;
+static std::optional<Common::SocketContext> s_socket_context;
 
 #define GDB_BFR_MAX 10000
 

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -1113,10 +1113,11 @@ void VolumeVerifier::Process()
     bytes_to_read = Common::AlignUp(content.size, 0x40);
     content_read = true;
 
-    if (m_content_index + 1 < m_content_offsets.size() &&
-        m_content_offsets[m_content_index + 1] < m_progress + bytes_to_read)
+    const u16 next_content_index = m_content_index + 1;
+    if (next_content_index < m_content_offsets.size() &&
+        m_content_offsets[next_content_index] < m_progress + bytes_to_read)
     {
-      excess_bytes = m_progress + bytes_to_read - m_content_offsets[m_content_index + 1];
+      excess_bytes = m_progress + bytes_to_read - m_content_offsets[next_content_index];
     }
   }
   else if (m_content_index < m_content_offsets.size() &&

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -376,7 +376,7 @@ void CodeViewWidget::Update()
 
 void CodeViewWidget::CalculateBranchIndentation()
 {
-  const size_t rows = rowCount();
+  const u32 rows = rowCount();
   const size_t columns = m_branches.size();
   if (rows < 1 || columns < 1)
     return;
@@ -442,7 +442,7 @@ void CodeViewWidget::CalculateBranchIndentation()
   };
 
   const u32 first_visible_addr = AddressForRow(0);
-  const u32 last_visible_addr = AddressForRow(static_cast<int>(rows - 1));
+  const u32 last_visible_addr = AddressForRow(rows - 1);
 
   if (first_visible_addr <= last_visible_addr)
   {
@@ -456,7 +456,7 @@ void CodeViewWidget::CalculateBranchIndentation()
     // first_visible_addr to fffffffc, and the second for 00000000 to last_visible_addr.
     // That means we need to find the row corresponding to 00000000.
     int addr_zero_row = -1;
-    for (int row = 0; row < rows; row++)
+    for (u32 row = 0; row < rows; row++)
     {
       if (AddressForRow(row) == 0)
       {

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -704,6 +704,8 @@ public:
         case VertexComponentFormat::Direct:
           process_simple_component(component_sizes[vtx_attr.GetColorFormat(c)]);
           break;
+        case VertexComponentFormat::NotPresent:
+          break;
         }
       }
       for (u32 t = 0; t < vtx_desc.high.TexCoord.Size(); t++)

--- a/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
+++ b/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
@@ -207,10 +207,10 @@ void RiivolutionBootWidget::MakeGUIForParsedFile(std::string path, std::string r
       connect(selection, qOverload<int>(&QComboBox::currentIndexChanged), this,
               [this, selection](int idx) {
                 const auto gui_index = selection->currentData().value<GuiRiivolutionPatchIndex>();
-                auto& disc = m_discs[gui_index.m_disc_index].disc;
-                auto& section = disc.m_sections[gui_index.m_section_index];
-                auto& option = section.m_options[gui_index.m_option_index];
-                option.m_selected_choice = static_cast<u32>(gui_index.m_choice_index);
+                auto& selected_disc = m_discs[gui_index.m_disc_index].disc;
+                auto& selected_section = selected_disc.m_sections[gui_index.m_section_index];
+                auto& selected_option = selected_section.m_options[gui_index.m_option_index];
+                selected_option.m_selected_choice = static_cast<u32>(gui_index.m_choice_index);
               });
 
       grid_layout->addWidget(label, row, 0, 1, 1);


### PR DESCRIPTION
See https://dolphin.ci/#/builders/19/builds/5836 for most of them.  Some of these fixes solve actual problems (e.g. https://github.com/dolphin-emu/dolphin/pull/10298#pullrequestreview-853889957), but several are just false positives.

I haven't included the fix from #10374, nor have I fixed the memcpy-relatated warnings or the conversion from `unsigned int` to `unsigned int:21` in PixelShaderGen.