### PR TITLE
FifoPlayer: Add missing call to LoadSettings()

### DIFF
--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -38,6 +38,7 @@ FIFOPlayerWindow::FIFOPlayerWindow(QWidget* parent) : QWidget(parent)
   setWindowIcon(Resources::GetAppIcon());
 
   CreateWidgets();
+  LoadSettings();
   ConnectWidgets();
   AddDescriptions();
 


### PR DESCRIPTION
This resulted in the loop checkbox appearing unchecked, even though loop was enabled.  A mistake in #10355.