### PR TITLE
Memory Card Path handling improvements.

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -311,8 +311,8 @@ std::unique_ptr<BootParameters> BootParameters::GenerateFromFile(std::vector<std
 
 BootParameters::IPL::IPL(DiscIO::Region region_) : region(region_)
 {
-  const std::string directory = SConfig::GetInstance().GetDirectoryForRegion(region);
-  path = SConfig::GetInstance().GetBootROMPath(directory);
+  const std::string directory = Config::GetDirectoryForRegion(region);
+  path = Config::GetBootROMPath(directory);
 }
 
 BootParameters::IPL::IPL(DiscIO::Region region_, Disc&& disc_) : IPL(region_)
@@ -441,7 +441,7 @@ bool CBoot::Load_BS2(const std::string& boot_rom_filename)
   if (known_ipl && pal_ipl != (boot_region == DiscIO::Region::PAL))
   {
     PanicAlertFmtT("{0} IPL found in {1} directory. The disc might not be recognized",
-                   pal_ipl ? "PAL" : "NTSC", SConfig::GetDirectoryForRegion(boot_region));
+                   pal_ipl ? "PAL" : "NTSC", Config::GetDirectoryForRegion(boot_region));
   }
 
   // Run the descrambler over the encrypted section containing BS1/BS2

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -20,6 +20,7 @@
 #include "Core/Config/DefaultLocale.h"
 #include "Core/HW/EXI/EXI.h"
 #include "Core/HW/EXI/EXI_Device.h"
+#include "Core/HW/GCMemcard/GCMemcard.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SI/SI_Device.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -558,5 +559,60 @@ std::string GetBootROMPath(const std::string& region_directory)
   if (!File::Exists(path))
     return File::GetSysDirectory() + GC_SYS_DIR + DIR_SEP + region_directory + DIR_SEP GC_IPL;
   return path;
+}
+
+std::string GetMemcardPath(ExpansionInterface::Slot slot, DiscIO::Region region, u16 size_mb)
+{
+  return GetMemcardPath(Config::Get(GetInfoForMemcardPath(slot)), slot, region, size_mb);
+}
+
+std::string GetMemcardPath(std::string configured_filename, ExpansionInterface::Slot slot,
+                           DiscIO::Region region, u16 size_mb)
+{
+  const std::string region_dir = Config::GetDirectoryForRegion(Config::ToGameCubeRegion(region));
+
+  std::string blocks_string = "";
+  if (size_mb < Memcard::MBIT_SIZE_MEMORY_CARD_2043)
+    blocks_string = fmt::format(".{}", Memcard::MbitToFreeBlocks(size_mb));
+
+  if (configured_filename.empty())
+  {
+    // Use default memcard path if there is no user defined one.
+    const bool is_slot_a = slot == ExpansionInterface::Slot::A;
+    return fmt::format("{}{}.{}{}.raw", File::GetUserPath(D_GCUSER_IDX),
+                       is_slot_a ? GC_MEMCARDA : GC_MEMCARDB, region_dir, blocks_string);
+  }
+
+  // Custom path is expected to be stored in the form of
+  // "/path/to/file.{region_code}.raw"
+  // with an arbitrary but supported region code.
+  // Try to extract and replace that region code.
+  // If there's no region code just insert one before the extension.
+
+#ifdef _WIN32
+  // Forward slashes are required for SplitPath().
+  for (char& c : configured_filename)
+  {
+    if (c == '\\')
+      c = '/';
+  }
+#endif
+
+  std::string dir;
+  std::string name;
+  std::string ext;
+  SplitPath(configured_filename, &dir, &name, &ext);
+
+  const std::string_view us_region = "." USA_DIR;
+  const std::string_view jp_region = "." JAP_DIR;
+  const std::string_view eu_region = "." EUR_DIR;
+  if (StringEndsWith(name, us_region))
+    name = name.substr(0, name.size() - us_region.size());
+  else if (StringEndsWith(name, jp_region))
+    name = name.substr(0, name.size() - jp_region.size());
+  else if (StringEndsWith(name, eu_region))
+    name = name.substr(0, name.size() - eu_region.size());
+
+  return fmt::format("{}{}.{}{}{}", dir, name, region_dir, blocks_string, ext);
 }
 }  // namespace Config

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -12,6 +12,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/Config/Config.h"
 #include "Common/EnumMap.h"
+#include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 #include "Common/StringUtil.h"
@@ -510,5 +511,52 @@ std::set<std::pair<u16, u16>> GetUSBDeviceWhitelist()
 void SetUSBDeviceWhitelist(const std::set<std::pair<u16, u16>>& devices)
 {
   Config::SetBase(Config::MAIN_USB_PASSTHROUGH_DEVICES, SaveUSBWhitelistToString(devices));
+}
+
+// The reason we need this function is because some memory card code
+// expects to get a non-NTSC-K region even if we're emulating an NTSC-K Wii.
+DiscIO::Region ToGameCubeRegion(DiscIO::Region region)
+{
+  if (region != DiscIO::Region::NTSC_K)
+    return region;
+
+  // GameCube has no NTSC-K region. No choice of replacement value is completely
+  // non-arbitrary, but let's go with NTSC-J since Korean GameCubes are NTSC-J.
+  return DiscIO::Region::NTSC_J;
+}
+
+const char* GetDirectoryForRegion(DiscIO::Region region)
+{
+  if (region == DiscIO::Region::Unknown)
+    region = ToGameCubeRegion(Config::Get(Config::MAIN_FALLBACK_REGION));
+
+  switch (region)
+  {
+  case DiscIO::Region::NTSC_J:
+    return JAP_DIR;
+
+  case DiscIO::Region::NTSC_U:
+    return USA_DIR;
+
+  case DiscIO::Region::PAL:
+    return EUR_DIR;
+
+  case DiscIO::Region::NTSC_K:
+    ASSERT_MSG(BOOT, false, "NTSC-K is not a valid GameCube region");
+    return JAP_DIR;  // See ToGameCubeRegion
+
+  default:
+    ASSERT_MSG(BOOT, false, "Default case should not be reached");
+    return EUR_DIR;
+  }
+}
+
+std::string GetBootROMPath(const std::string& region_directory)
+{
+  const std::string path =
+      File::GetUserPath(D_GCUSER_IDX) + DIR_SEP + region_directory + DIR_SEP GC_IPL;
+  if (!File::Exists(path))
+    return File::GetSysDirectory() + GC_SYS_DIR + DIR_SEP + region_directory + DIR_SEP GC_IPL;
+  return path;
 }
 }  // namespace Config

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -320,4 +320,11 @@ extern const Info<std::string> MAIN_USB_PASSTHROUGH_DEVICES;
 std::set<std::pair<u16, u16>> GetUSBDeviceWhitelist();
 void SetUSBDeviceWhitelist(const std::set<std::pair<u16, u16>>& devices);
 
+// GameCube path utility functions
+
+// Replaces NTSC-K with some other region, and doesn't replace non-NTSC-K regions
+DiscIO::Region ToGameCubeRegion(DiscIO::Region region);
+// The region argument must be valid for GameCube (i.e. must not be NTSC-K)
+const char* GetDirectoryForRegion(DiscIO::Region region);
+std::string GetBootROMPath(const std::string& region_directory);
 }  // namespace Config

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -70,6 +70,9 @@ const Info<std::string>& GetInfoForMemcardPath(ExpansionInterface::Slot slot);
 extern const Info<std::string> MAIN_AGP_CART_A_PATH;
 extern const Info<std::string> MAIN_AGP_CART_B_PATH;
 const Info<std::string>& GetInfoForAGPCartPath(ExpansionInterface::Slot slot);
+extern const Info<std::string> MAIN_GCI_FOLDER_A_PATH;
+extern const Info<std::string> MAIN_GCI_FOLDER_B_PATH;
+const Info<std::string>& GetInfoForGCIPath(ExpansionInterface::Slot slot);
 extern const Info<std::string> MAIN_GCI_FOLDER_A_PATH_OVERRIDE;
 extern const Info<std::string> MAIN_GCI_FOLDER_B_PATH_OVERRIDE;
 const Info<std::string>& GetInfoForGCIPathOverride(ExpansionInterface::Slot slot);
@@ -331,4 +334,7 @@ std::string GetMemcardPath(ExpansionInterface::Slot slot, DiscIO::Region region,
                            u16 size_mb = 0x80);
 std::string GetMemcardPath(std::string configured_filename, ExpansionInterface::Slot slot,
                            DiscIO::Region region, u16 size_mb = 0x80);
+std::string GetGCIFolderPath(ExpansionInterface::Slot slot, DiscIO::Region region);
+std::string GetGCIFolderPath(std::string configured_folder, ExpansionInterface::Slot slot,
+                             DiscIO::Region region);
 }  // namespace Config

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -327,4 +327,8 @@ DiscIO::Region ToGameCubeRegion(DiscIO::Region region);
 // The region argument must be valid for GameCube (i.e. must not be NTSC-K)
 const char* GetDirectoryForRegion(DiscIO::Region region);
 std::string GetBootROMPath(const std::string& region_directory);
+std::string GetMemcardPath(ExpansionInterface::Slot slot, DiscIO::Region region,
+                           u16 size_mb = 0x80);
+std::string GetMemcardPath(std::string configured_filename, ExpansionInterface::Slot slot,
+                           DiscIO::Region region, u16 size_mb = 0x80);
 }  // namespace Config

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -125,6 +125,8 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_SYNC_GPU_MAX_DISTANCE.GetLocation(),
       &Config::MAIN_SYNC_GPU_MIN_DISTANCE.GetLocation(),
       &Config::MAIN_SYNC_GPU_OVERCLOCK.GetLocation(),
+      &Config::MAIN_GCI_FOLDER_A_PATH.GetLocation(),
+      &Config::MAIN_GCI_FOLDER_B_PATH.GetLocation(),
 
       // UI.General
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -72,13 +72,7 @@ struct SConfig
 
   void LoadDefaults();
   static std::string MakeGameID(std::string_view file_name);
-  // Replaces NTSC-K with some other region, and doesn't replace non-NTSC-K regions
-  static DiscIO::Region ToGameCubeRegion(DiscIO::Region region);
-  // The region argument must be valid for GameCube (i.e. must not be NTSC-K)
-  static const char* GetDirectoryForRegion(DiscIO::Region region);
-  std::string GetBootROMPath(const std::string& region_directory) const;
   bool SetPathsAndGameMetadata(const BootParameters& boot);
-  static DiscIO::Region GetFallbackRegion();
   DiscIO::Language GetCurrentLanguage(bool wii) const;
   DiscIO::Language GetLanguageAdjustedForRegion(bool wii, DiscIO::Region region) const;
 

--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -117,7 +117,7 @@ void Init()
     if (size_override >= 0 && size_override <= 4)
       size_mbits = Memcard::MBIT_SIZE_MEMORY_CARD_59 << size_override;
     const bool shift_jis =
-        SConfig::ToGameCubeRegion(SConfig::GetInstance().m_region) == DiscIO::Region::NTSC_J;
+        Config::ToGameCubeRegion(SConfig::GetInstance().m_region) == DiscIO::Region::NTSC_J;
     const CardFlashId& flash_id = g_SRAM.settings_ex.flash_id[Memcard::SLOT_A];
     const u32 rtc_bias = g_SRAM.settings.rtc_bias;
     const u32 sram_language = static_cast<u32>(g_SRAM.settings.language);

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -188,7 +188,7 @@ void CEXIMemoryCard::SetupGciFolder(const Memcard::HeaderData& header_data)
   if (!file_info.Exists())
   {
     if (migrate)  // first use of memcard folder, migrate automatically
-      MigrateFromMemcardFile(dir_path + DIR_SEP, m_card_slot);
+      MigrateFromMemcardFile(dir_path + DIR_SEP, m_card_slot, SConfig::GetInstance().m_region);
     else
       File::CreateFullPath(dir_path + DIR_SEP);
   }
@@ -198,7 +198,7 @@ void CEXIMemoryCard::SetupGciFolder(const Memcard::HeaderData& header_data)
     {
       PanicAlertFmtT("{0} was not a directory, moved to *.original", dir_path);
       if (migrate)
-        MigrateFromMemcardFile(dir_path + DIR_SEP, m_card_slot);
+        MigrateFromMemcardFile(dir_path + DIR_SEP, m_card_slot, SConfig::GetInstance().m_region);
       else
         File::CreateFullPath(dir_path + DIR_SEP);
     }
@@ -218,22 +218,16 @@ void CEXIMemoryCard::SetupGciFolder(const Memcard::HeaderData& header_data)
 
 void CEXIMemoryCard::SetupRawMemcard(u16 size_mb)
 {
-  std::string filename = Config::Get(Config::GetInfoForMemcardPath(m_card_slot));
+  std::string filename;
   if (Movie::IsPlayingInput() && Movie::IsConfigSaved() && Movie::IsUsingMemcard(m_card_slot) &&
       Movie::IsStartingFromClearSave())
   {
     filename = File::GetUserPath(D_GCUSER_IDX) +
                fmt::format("Movie{}.raw", s_card_short_names[m_card_slot]);
   }
-
-  const std::string region_dir =
-      Config::GetDirectoryForRegion(Config::ToGameCubeRegion(SConfig::GetInstance().m_region));
-  MemoryCard::CheckPath(filename, region_dir, m_card_slot);
-
-  if (size_mb < Memcard::MBIT_SIZE_MEMORY_CARD_2043)
+  else
   {
-    filename.insert(filename.find_last_of('.'),
-                    fmt::format(".{}", Memcard::MbitToFreeBlocks(size_mb)));
+    filename = Config::GetMemcardPath(m_card_slot, SConfig::GetInstance().m_region, size_mb);
   }
 
   m_memory_card = std::make_unique<MemoryCard>(filename, m_card_slot, size_mb);

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -162,8 +162,8 @@ CEXIMemoryCard::GetGCIFolderPath(Slot card_slot, AllowMovieFolder allow_movie_fo
   if (use_movie_folder)
     path += "Movie" DIR_SEP;
 
-  const DiscIO::Region region = SConfig::ToGameCubeRegion(SConfig::GetInstance().m_region);
-  path = path + SConfig::GetDirectoryForRegion(region) + DIR_SEP +
+  const DiscIO::Region region = Config::ToGameCubeRegion(SConfig::GetInstance().m_region);
+  path = path + Config::GetDirectoryForRegion(region) + DIR_SEP +
          fmt::format("Card {}", s_card_short_names[card_slot]);
   return {std::move(path), !use_movie_folder};
 }
@@ -227,7 +227,7 @@ void CEXIMemoryCard::SetupRawMemcard(u16 size_mb)
   }
 
   const std::string region_dir =
-      SConfig::GetDirectoryForRegion(SConfig::ToGameCubeRegion(SConfig::GetInstance().m_region));
+      Config::GetDirectoryForRegion(Config::ToGameCubeRegion(SConfig::GetInstance().m_region));
   MemoryCard::CheckPath(filename, region_dir, m_card_slot);
 
   if (size_mb < Memcard::MBIT_SIZE_MEMORY_CARD_2043)

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -148,24 +148,23 @@ std::pair<std::string /* path */, bool /* migrate */>
 CEXIMemoryCard::GetGCIFolderPath(Slot card_slot, AllowMovieFolder allow_movie_folder)
 {
   std::string path_override = Config::Get(Config::GetInfoForGCIPathOverride(card_slot));
-
   if (!path_override.empty())
     return {std::move(path_override), false};
-
-  std::string path = File::GetUserPath(D_GCUSER_IDX);
 
   const bool use_movie_folder = allow_movie_folder == AllowMovieFolder::Yes &&
                                 Movie::IsPlayingInput() && Movie::IsConfigSaved() &&
                                 Movie::IsUsingMemcard(card_slot) &&
                                 Movie::IsStartingFromClearSave();
 
-  if (use_movie_folder)
-    path += "Movie" DIR_SEP;
-
   const DiscIO::Region region = Config::ToGameCubeRegion(SConfig::GetInstance().m_region);
-  path = path + Config::GetDirectoryForRegion(region) + DIR_SEP +
-         fmt::format("Card {}", s_card_short_names[card_slot]);
-  return {std::move(path), !use_movie_folder};
+  if (use_movie_folder)
+  {
+    return {fmt::format("{}{}/Movie/Card {}", File::GetUserPath(D_GCUSER_IDX),
+                        Config::GetDirectoryForRegion(region), s_card_short_names[card_slot]),
+            false};
+  }
+
+  return {Config::GetGCIFolderPath(card_slot, region), true};
 }
 
 void CEXIMemoryCard::SetupGciFolder(const Memcard::HeaderData& header_data)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -705,10 +705,11 @@ void GCMemcardDirectory::DoState(PointerWrap& p)
   }
 }
 
-void MigrateFromMemcardFile(const std::string& directory_name, ExpansionInterface::Slot card_slot)
+void MigrateFromMemcardFile(const std::string& directory_name, ExpansionInterface::Slot card_slot,
+                            DiscIO::Region region)
 {
   File::CreateFullPath(directory_name);
-  std::string ini_memcard = Config::Get(Config::GetInfoForMemcardPath(card_slot));
+  std::string ini_memcard = Config::GetMemcardPath(card_slot, region);
   if (File::Exists(ini_memcard))
   {
     auto [error_code, memcard] = Memcard::GCMemcard::Open(ini_memcard.c_str());

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -12,10 +12,12 @@
 #include "Core/HW/GCMemcard/GCIFile.h"
 #include "Core/HW/GCMemcard/GCMemcard.h"
 #include "Core/HW/GCMemcard/GCMemcardBase.h"
+#include "DiscIO/Enums.h"
 
 // Uncomment this to write the system data of the memorycard from directory to disc
 //#define _WRITE_MC_HEADER 1
-void MigrateFromMemcardFile(const std::string& directory_name, ExpansionInterface::Slot card_slot);
+void MigrateFromMemcardFile(const std::string& directory_name, ExpansionInterface::Slot card_slot,
+                            DiscIO::Region region);
 
 class GCMemcardDirectory : public MemoryCardBase
 {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
@@ -90,55 +90,6 @@ MemoryCard::~MemoryCard()
   }
 }
 
-void MemoryCard::CheckPath(std::string& memcardPath, const std::string& gameRegion,
-                           ExpansionInterface::Slot card_slot)
-{
-  bool is_slot_a = card_slot == ExpansionInterface::Slot::A;
-  std::string ext("." + gameRegion + ".raw");
-  if (memcardPath.empty())
-  {
-    // Use default memcard path if there is no user defined name
-    std::string defaultFilename = is_slot_a ? GC_MEMCARDA : GC_MEMCARDB;
-    memcardPath = File::GetUserPath(D_GCUSER_IDX) + defaultFilename + ext;
-  }
-  else
-  {
-    std::string filename = memcardPath;
-    std::string region = filename.substr(filename.size() - 7, 3);
-    bool hasregion = false;
-    hasregion |= region.compare(USA_DIR) == 0;
-    hasregion |= region.compare(JAP_DIR) == 0;
-    hasregion |= region.compare(EUR_DIR) == 0;
-    if (!hasregion)
-    {
-      // filename doesn't have region in the extension
-      if (File::Exists(filename))
-      {
-        // If the old file exists we are polite and ask if we should copy it
-        std::string oldFilename = filename;
-        filename.replace(filename.size() - 4, 4, ext);
-        if (PanicYesNoFmtT("Memory Card filename in Slot {0} is incorrect\n"
-                           "Region not specified\n\n"
-                           "Slot {1} path was changed to\n"
-                           "{2}\n"
-                           "Would you like to copy the old file to this new location?\n",
-                           is_slot_a ? 'A' : 'B', is_slot_a ? 'A' : 'B', filename))
-        {
-          if (!File::Copy(oldFilename, filename))
-            PanicAlertFmtT("Copy failed");
-        }
-      }
-      memcardPath = filename;  // Always correct the path!
-    }
-    else if (region.compare(gameRegion) != 0)
-    {
-      // filename has region, but it's not == gameRegion
-      // Just set the correct filename, the EXI Device will create it if it doesn't exist
-      memcardPath = filename.replace(filename.size() - ext.size(), ext.size(), ext);
-    }
-  }
-}
-
 void MemoryCard::FlushThread()
 {
   if (!Config::Get(Config::SESSION_SAVE_DATA_WRITABLE))

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.h
@@ -20,8 +20,6 @@ public:
   MemoryCard(const std::string& filename, ExpansionInterface::Slot card_slot,
              u16 size_mbits = Memcard::MBIT_SIZE_MEMORY_CARD_2043);
   ~MemoryCard();
-  static void CheckPath(std::string& memcardPath, const std::string& gameRegion,
-                        ExpansionInterface::Slot slot);
   void FlushThread();
   void MakeDirty();
 

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1465,6 +1465,9 @@ void GetSettings()
   }
   else
   {
+    const auto raw_memcard_exists = [](ExpansionInterface::Slot card_slot) {
+      return File::Exists(Config::GetMemcardPath(card_slot, SConfig::GetInstance().m_region));
+    };
     const auto gci_folder_has_saves = [](ExpansionInterface::Slot card_slot) {
       const auto [path, migrate] = ExpansionInterface::CEXIMemoryCard::GetGCIFolderPath(
           card_slot, ExpansionInterface::AllowMovieFolder::No);
@@ -1472,11 +1475,10 @@ void GetSettings()
       return number_of_saves > 0;
     };
 
-    s_bClearSave =
-        !(slot_a_has_raw_memcard && File::Exists(Config::Get(Config::MAIN_MEMCARD_A_PATH))) &&
-        !(slot_b_has_raw_memcard && File::Exists(Config::Get(Config::MAIN_MEMCARD_B_PATH))) &&
-        !(slot_a_has_gci_folder && gci_folder_has_saves(ExpansionInterface::Slot::A)) &&
-        !(slot_b_has_gci_folder && gci_folder_has_saves(ExpansionInterface::Slot::B));
+    s_bClearSave = !(slot_a_has_raw_memcard && raw_memcard_exists(ExpansionInterface::Slot::A)) &&
+                   !(slot_b_has_raw_memcard && raw_memcard_exists(ExpansionInterface::Slot::B)) &&
+                   !(slot_a_has_gci_folder && gci_folder_has_saves(ExpansionInterface::Slot::A)) &&
+                   !(slot_b_has_gci_folder && gci_folder_has_saves(ExpansionInterface::Slot::B));
   }
   s_memcards |= (slot_a_has_raw_memcard || slot_a_has_gci_folder) << 0;
   s_memcards |= (slot_b_has_raw_memcard || slot_b_has_gci_folder) << 1;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1470,8 +1470,8 @@ bool NetPlayServer::StartGame()
 
   const sf::Uint64 initial_rtc = GetInitialNetPlayRTC();
 
-  const std::string region = SConfig::GetDirectoryForRegion(
-      SConfig::ToGameCubeRegion(m_dialog->FindGameFile(m_selected_game_identifier)->GetRegion()));
+  const std::string region = Config::GetDirectoryForRegion(
+      Config::ToGameCubeRegion(m_dialog->FindGameFile(m_selected_game_identifier)->GetRegion()));
 
   // sync GC SRAM with clients
   if (!g_SRAM_netplay_initialized)
@@ -1666,7 +1666,7 @@ bool NetPlayServer::SyncSaveData()
     return true;
 
   const std::string region =
-      SConfig::GetDirectoryForRegion(SConfig::ToGameCubeRegion(game->GetRegion()));
+      Config::GetDirectoryForRegion(Config::ToGameCubeRegion(game->GetRegion()));
 
   for (ExpansionInterface::Slot slot : ExpansionInterface::MEMCARD_SLOTS)
   {

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1665,8 +1665,8 @@ bool NetPlayServer::SyncSaveData()
   if (save_count == 0)
     return true;
 
-  const std::string region =
-      Config::GetDirectoryForRegion(Config::ToGameCubeRegion(game->GetRegion()));
+  const auto game_region = game->GetRegion();
+  const std::string region = Config::GetDirectoryForRegion(Config::ToGameCubeRegion(game_region));
 
   for (ExpansionInterface::Slot slot : ExpansionInterface::MEMCARD_SLOTS)
   {
@@ -1674,17 +1674,11 @@ bool NetPlayServer::SyncSaveData()
 
     if (m_settings.m_EXIDevice[slot] == ExpansionInterface::EXIDeviceType::MemoryCard)
     {
-      std::string path = Config::Get(Config::GetInfoForMemcardPath(slot));
-
-      MemoryCard::CheckPath(path, region, slot);
-
       const int size_override = m_settings.m_MemcardSizeOverride;
+      u16 card_size_mbits = Memcard::MBIT_SIZE_MEMORY_CARD_2043;
       if (size_override >= 0 && size_override <= 4)
-      {
-        path.insert(path.find_last_of('.'),
-                    fmt::format(".{}", Memcard::MbitToFreeBlocks(Memcard::MBIT_SIZE_MEMORY_CARD_59
-                                                                 << size_override)));
-      }
+        card_size_mbits = static_cast<u16>(Memcard::MBIT_SIZE_MEMORY_CARD_59 << size_override);
+      std::string path = Config::GetMemcardPath(slot, game_region, card_size_mbits);
 
       sf::Packet pac;
       pac << MessageID::SyncSaveData;

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -227,7 +227,8 @@ void GCMemcardManager::LoadDefaultMemcards()
       continue;
     }
 
-    const QString path = QString::fromStdString(Config::Get(Config::GetInfoForMemcardPath(slot)));
+    const QString path = QString::fromStdString(
+        Config::GetMemcardPath(slot, Config::Get(Config::MAIN_FALLBACK_REGION)));
     SetSlotFile(slot, path);
   }
 }

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -695,7 +695,7 @@ void GameList::OpenGCSaveFolder()
     }
     case ExpansionInterface::EXIDeviceType::MemoryCard:
     {
-      std::string memcard_path = Config::Get(Config::GetInfoForMemcardPath(slot));
+      const std::string memcard_path = Config::GetMemcardPath(slot, game->GetRegion());
 
       std::string memcard_dir;
 

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -674,7 +674,7 @@ void GameList::OpenGCSaveFolder()
     case ExpansionInterface::EXIDeviceType::MemoryCardFolder:
     {
       std::string path = StringFromFormat("%s/%s/%s", File::GetUserPath(D_GCUSER_IDX).c_str(),
-                                          SConfig::GetDirectoryForRegion(game->GetRegion()),
+                                          Config::GetDirectoryForRegion(game->GetRegion()),
                                           slot == Slot::A ? "Card A" : "Card B");
 
       std::string override_path = Config::Get(Config::GetInfoForGCIPathOverride(slot));

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -673,13 +673,11 @@ void GameList::OpenGCSaveFolder()
     {
     case ExpansionInterface::EXIDeviceType::MemoryCardFolder:
     {
-      std::string path = StringFromFormat("%s/%s/%s", File::GetUserPath(D_GCUSER_IDX).c_str(),
-                                          Config::GetDirectoryForRegion(game->GetRegion()),
-                                          slot == Slot::A ? "Card A" : "Card B");
-
       std::string override_path = Config::Get(Config::GetInfoForGCIPathOverride(slot));
-
-      if (!override_path.empty())
+      std::string path;
+      if (override_path.empty())
+        path = Config::GetGCIFolderPath(slot, game->GetRegion());
+      else
         path = override_path;
 
       QDir dir(QString::fromStdString(path));

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -991,12 +991,9 @@ void MenuBar::UpdateToolsMenu(bool emulation_started)
 {
   m_boot_sysmenu->setEnabled(!emulation_started);
   m_perform_online_update_menu->setEnabled(!emulation_started);
-  m_ntscj_ipl->setEnabled(!emulation_started &&
-                          File::Exists(SConfig::GetInstance().GetBootROMPath(JAP_DIR)));
-  m_ntscu_ipl->setEnabled(!emulation_started &&
-                          File::Exists(SConfig::GetInstance().GetBootROMPath(USA_DIR)));
-  m_pal_ipl->setEnabled(!emulation_started &&
-                        File::Exists(SConfig::GetInstance().GetBootROMPath(EUR_DIR)));
+  m_ntscj_ipl->setEnabled(!emulation_started && File::Exists(Config::GetBootROMPath(JAP_DIR)));
+  m_ntscu_ipl->setEnabled(!emulation_started && File::Exists(Config::GetBootROMPath(USA_DIR)));
+  m_pal_ipl->setEnabled(!emulation_started && File::Exists(Config::GetBootROMPath(EUR_DIR)));
   m_import_backup->setEnabled(!emulation_started);
   m_check_nand->setEnabled(!emulation_started);
 

--- a/Source/Core/DolphinQt/Settings/GameCubePane.h
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.h
@@ -40,6 +40,7 @@ private:
   void OnConfigPressed(ExpansionInterface::Slot slot);
 
   void BrowseMemcard(ExpansionInterface::Slot slot);
+  void BrowseGCIFolder(ExpansionInterface::Slot slot);
   void BrowseAGPRom(ExpansionInterface::Slot slot);
   void BrowseGBABios();
   void BrowseGBARom(size_t index);
@@ -59,6 +60,10 @@ private:
   Common::EnumMap<QHBoxLayout*, ExpansionInterface::MAX_MEMCARD_SLOT> m_agp_path_layouts;
   Common::EnumMap<QLabel*, ExpansionInterface::MAX_MEMCARD_SLOT> m_agp_path_labels;
   Common::EnumMap<QLineEdit*, ExpansionInterface::MAX_MEMCARD_SLOT> m_agp_paths;
+
+  Common::EnumMap<QHBoxLayout*, ExpansionInterface::MAX_MEMCARD_SLOT> m_gci_path_layouts;
+  Common::EnumMap<QLabel*, ExpansionInterface::MAX_MEMCARD_SLOT> m_gci_path_labels;
+  Common::EnumMap<QLineEdit*, ExpansionInterface::MAX_MEMCARD_SLOT> m_gci_paths;
 
   QCheckBox* m_gba_threads;
   QCheckBox* m_gba_save_rom_path;

--- a/Source/Core/DolphinQt/Settings/GameCubePane.h
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.h
@@ -14,6 +14,8 @@
 
 class QCheckBox;
 class QComboBox;
+class QHBoxLayout;
+class QLabel;
 class QLineEdit;
 class QPushButton;
 
@@ -49,6 +51,14 @@ private:
 
   Common::EnumMap<QPushButton*, ExpansionInterface::MAX_SLOT> m_slot_buttons;
   Common::EnumMap<QComboBox*, ExpansionInterface::MAX_SLOT> m_slot_combos;
+
+  Common::EnumMap<QHBoxLayout*, ExpansionInterface::MAX_MEMCARD_SLOT> m_memcard_path_layouts;
+  Common::EnumMap<QLabel*, ExpansionInterface::MAX_MEMCARD_SLOT> m_memcard_path_labels;
+  Common::EnumMap<QLineEdit*, ExpansionInterface::MAX_MEMCARD_SLOT> m_memcard_paths;
+
+  Common::EnumMap<QHBoxLayout*, ExpansionInterface::MAX_MEMCARD_SLOT> m_agp_path_layouts;
+  Common::EnumMap<QLabel*, ExpansionInterface::MAX_MEMCARD_SLOT> m_agp_path_labels;
+  Common::EnumMap<QLineEdit*, ExpansionInterface::MAX_MEMCARD_SLOT> m_agp_paths;
 
   QCheckBox* m_gba_threads;
   QCheckBox* m_gba_save_rom_path;

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -265,7 +265,7 @@ void GeneralPane::LoadConfig()
     m_combobox_speedlimit->setCurrentIndex(selection);
   m_checkbox_dualcore->setChecked(Config::Get(Config::MAIN_CPU_THREAD));
 
-  const auto fallback = Settings::Instance().GetFallbackRegion();
+  const auto fallback = Config::Get(Config::MAIN_FALLBACK_REGION);
 
   if (fallback == DiscIO::Region::NTSC_J)
     m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_NTSCJ_INDEX);


### PR DESCRIPTION
Does a few things:

- Unify handling of raw memory card path. I've wanted to do this for a while, since several places in the code handled this differently and you could get some weird results where eg. the GUI thought a different memory card was inserted compared to the actual emulation. This should unify it, as best as possible anyway.
- GameCube Config window now actually shows the selected memory card path.
- GCI Folder paths are now configurable.

The last one might be a bit unintuitive... I didn't want to use the existing GCI folder override option because it forces all regions to use the same folder, which is not great if you're eg. mixing JP and US games. So this is what I came up with. Feel free to discuss this with me.

Implements or fixes:
https://bugs.dolphin-emu.org/issues/12169 (partial)
https://bugs.dolphin-emu.org/issues/10442