### PR TITLE
Don't create GBA saves dir when building without mGBA

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -307,6 +307,7 @@ void SetIsoPaths(const std::vector<std::string>& paths)
 
 // Main.GBA
 
+#ifdef HAS_LIBMGBA
 const Info<std::string> MAIN_GBA_BIOS_PATH{{System::Main, "GBA", "BIOS"}, ""};
 const std::array<Info<std::string>, 4> MAIN_GBA_ROM_PATHS{
     Info<std::string>{{System::Main, "GBA", "Rom1"}, ""},
@@ -316,6 +317,7 @@ const std::array<Info<std::string>, 4> MAIN_GBA_ROM_PATHS{
 const Info<std::string> MAIN_GBA_SAVES_PATH{{System::Main, "GBA", "SavesPath"}, ""};
 const Info<bool> MAIN_GBA_SAVES_IN_ROM_PATH{{System::Main, "GBA", "SavesInRomPath"}, false};
 const Info<bool> MAIN_GBA_THREADS{{System::Main, "GBA", "Threads"}, true};
+#endif
 
 // Main.Network
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -179,11 +179,13 @@ void SetIsoPaths(const std::vector<std::string>& paths);
 
 // Main.GBA
 
+#ifdef HAS_LIBMGBA
 extern const Info<std::string> MAIN_GBA_BIOS_PATH;
 extern const std::array<Info<std::string>, 4> MAIN_GBA_ROM_PATHS;
 extern const Info<std::string> MAIN_GBA_SAVES_PATH;
 extern const Info<bool> MAIN_GBA_SAVES_IN_ROM_PATH;
 extern const Info<bool> MAIN_GBA_THREADS;
+#endif
 
 // Main.Network
 

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -138,10 +138,12 @@ public:
       layer->Set(Config::SESSION_GCI_FOLDER_CURRENT_GAME_ONLY, true);
     }
 
+#ifdef HAS_LIBMGBA
     for (size_t i = 0; i < m_settings.m_GBARomPaths.size(); ++i)
     {
       layer->Set(Config::MAIN_GBA_ROM_PATHS[i], m_settings.m_GBARomPaths[i]);
     }
+#endif
 
     // Check To Override Client's Cheat Codes
     if (m_settings.m_SyncCodes && !m_settings.m_IsHosting)

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -91,9 +91,11 @@ static void InitCustomPaths()
   CreateResourcePackPath(Config::Get(Config::MAIN_RESOURCEPACK_PATH));
   CreateWFSPath(Config::Get(Config::MAIN_WFS_PATH));
   File::SetUserPath(F_WIISDCARD_IDX, Config::Get(Config::MAIN_SD_PATH));
+#ifdef HAS_LIBMGBA
   File::SetUserPath(F_GBABIOS_IDX, Config::Get(Config::MAIN_GBA_BIOS_PATH));
   File::SetUserPath(D_GBASAVES_IDX, Config::Get(Config::MAIN_GBA_SAVES_PATH));
   File::CreateFullPath(File::GetUserPath(D_GBASAVES_IDX));
+#endif
 }
 
 void Init()


### PR DESCRIPTION
Currently, disabling mGBA when building gets rid of the ability to change the GBA saves directory in DolphinQt, but it doesn't actually get rid of Dolphin loading and storing the setting and creating the folder. If the setting is set to a path you don't want to use (perhaps you are trying to turn Dolphin portable), this is annoying.

To avoid accidentally making mistakes like this in the future, I'm gating the existence of the setting behind an ifdef.