### PR TITLE
[Android] Fix unused variable warning

### DIFF
--- a/Source/Core/Common/Logging/ConsoleListener.h
+++ b/Source/Core/Common/Logging/ConsoleListener.h
@@ -14,5 +14,5 @@ public:
   void Log(Common::Log::LogLevel level, const char* text) override;
 
 private:
-  bool m_use_color = false;
+  [[maybe_unused]] bool m_use_color = false;
 };


### PR DESCRIPTION
Add [[maybe_unused]] attribute to m_use_color in ConsoleListener.

Fixes a warning on the Android builder.