### PR TITLE
OpcodeDecoding: Don't raise panic alerts for unknown opcodes 0x01-0x07

### DIFF
--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -32,13 +32,7 @@
 
 namespace OpcodeDecoder
 {
-static bool s_is_fifo_error_seen = false;
 bool g_record_fifo_data = false;
-
-void Init()
-{
-  s_is_fifo_error_seen = false;
-}
 
 template <bool is_preprocess>
 class RunCallback final : public Callback
@@ -207,19 +201,7 @@ public:
     }
     else
     {
-      // Datel software uses 0x01 during startup, and Mario Party 5's Wiggler capsule
-      // accidentally uses 0x01-0x03 due to sending 4 more vertices than intended.
-      // Hardware testing indicates that 0x01-0x07 do nothing, so to avoid annoying the user with
-      // spurious popups, we don't create a panic alert in those cases.  Other unknown opcodes
-      // (such as 0x18) seem to result in hangs.
-      if (!s_is_fifo_error_seen && opcode > 0x07)
-      {
-        CommandProcessor::HandleUnknownOpcode(opcode, data, is_preprocess);
-        s_is_fifo_error_seen = true;
-      }
-
-      ERROR_LOG_FMT(VIDEO, "FIFO: Unknown Opcode({:#04x} @ {}, preprocessing = {})", opcode,
-                    fmt::ptr(data), is_preprocess ? "yes" : "no");
+      CommandProcessor::HandleUnknownOpcode(opcode, data, is_preprocess);
       m_cycles += 1;
     }
   }

--- a/Source/Core/VideoCommon/OpcodeDecoding.h
+++ b/Source/Core/VideoCommon/OpcodeDecoding.h
@@ -60,8 +60,6 @@ enum class Primitive : u8
   GX_DRAW_POINTS = 0x7           // 0xB8
 };
 
-void Init();
-
 // Interface for the Run and RunCommand functions below.
 // The functions themselves are templates so that the compiler generates separate versions for each
 // callback (with the callback functions inlined), so the callback doesn't actually need to be

--- a/Source/Core/VideoCommon/OpcodeDecoding.h
+++ b/Source/Core/VideoCommon/OpcodeDecoding.h
@@ -24,7 +24,6 @@ extern bool g_record_fifo_data;
 enum class Opcode
 {
   GX_NOP = 0x00,
-  GX_UNKNOWN_RESET = 0x01,
 
   GX_LOAD_BP_REG = 0x61,
   GX_LOAD_CP_REG = 0x08,

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -316,7 +316,6 @@ void VideoBackendBase::InitializeShared()
 
   CommandProcessor::Init();
   Fifo::Init();
-  OpcodeDecoder::Init();
   PixelEngine::Init();
   BPInit();
   VertexLoaderManager::Init();


### PR DESCRIPTION
A pop-up is no longer generated for the Wiggler capsule in Mario Party 5 (https://bugs.dolphin-emu.org/issues/8104).

Primitive data related to the unknown opcodes in Mario Party 5: https://gist.github.com/Pokechu22/83d5cd9443f3336f50bc5d626fb9636f

And some assorted images from the hardware fifo player: https://imgur.com/a/hx4qe42

Basically, the Wiggler capsule's animation draws a bunch of rings.  Each ring has 128 vertices in it, with positions moving around a circle and texture coordinates going up by .03125 (1/32) for each horizontal step.  The position, color, and texture coordinate data for each vertex is indexed into several arrays, with the first set of 4 vertices using indices 0, 1, 3, and 2.  However, after all 128 vertices are written, the game writes data for 4 more vertices, again using indices 0, 1, 3, and 2.  But since the game said it would only draw 128 vertices, not 132, those 4 vertices are instead interpreted as graphics commands.  Opcode 0 is a NOP, and my brief hardware testing indicates that opcodes 1-7 are also treated as NOPs, so on real hardware these are ignored, but Dolphin didn't like that extra data.  Now, that data is ignored (an error is logged, but no panic alert is generated).

If we modify the FIFO data to say that there are 132 vertices, then the [first part of the ring is drawn twice](https://i.imgur.com/uwk9EGp.png), which indicates that vertices 129-132 normally go unused.  (I also confirmed that nothing changes rendering-wise when modifying those vertices, and that the hardware FIFO player hangs if 0x18 is written into those vertices, where 0x18 is another unknown opcode; this indicates that not all unknown opcodes act like NOPs).

(As a side note, the ring also has a somewhat messed up texture ([image](https://i.imgur.com/0fmIF6H.png)).  This is because the last quad re-uses indices from the first quad, which is fine for positions, but it means that the texture coordinates are 0.96875 and 0 instead of 0.96875 and 1, so the texture doesn't loop properly.  Since the rings are normally pretty small and drawn on top of other stuff, and the Wiggler capsule is rare, this is hard to notice in normal gameplay.  This could be theoretically fixed with a game patch.)

Regarding `GX_UNKNOWN_RESET`, I can confirm that Datel software does use that command, but it looks like an accident (they write a 4-byte value of `0x00000001`, and that's from a variable that's changed in several places; they also trigger other unknown opcodes so ignoring only that one doesn't fix anything).  I don't think it has any actual meaning that we need to handle.