### PR TITLE
Fix copy filter clamping (again)

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2676,7 +2676,8 @@ void TextureCacheBase::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_cop
   };
   Uniforms uniforms;
   const float rcp_efb_width = 1.0f / static_cast<float>(g_framebuffer_manager->GetEFBWidth());
-  const float rcp_efb_height = 1.0f / static_cast<float>(g_framebuffer_manager->GetEFBHeight());
+  const u32 efb_height = g_framebuffer_manager->GetEFBHeight();
+  const float rcp_efb_height = 1.0f / static_cast<float>(efb_height);
   uniforms.src_left = framebuffer_rect.left * rcp_efb_width;
   uniforms.src_top = framebuffer_rect.top * rcp_efb_height;
   uniforms.src_width = framebuffer_rect.GetWidth() * rcp_efb_width;
@@ -2685,9 +2686,15 @@ void TextureCacheBase::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_cop
   uniforms.filter_coefficients[1] = filter_coefficients.middle;
   uniforms.filter_coefficients[2] = filter_coefficients.lower;
   uniforms.gamma_rcp = 1.0f / gamma;
-  uniforms.clamp_top = clamp_top ? framebuffer_rect.top * rcp_efb_height : 0.0f;
-  int bottom_coord = framebuffer_rect.bottom - 1;
-  uniforms.clamp_bottom = clamp_bottom ? bottom_coord * rcp_efb_height : 1.0f;
+  //   NOTE: when the clamp bits aren't set, the hardware will happily read beyond the EFB,
+  //         which returns random garbage from the empty bus (confirmed by hardware tests).
+  //
+  //         In our implementation, the garbage just so happens to be the top or bottom row.
+  //         Statistically, that could happen.
+  const u32 top_coord = clamp_top ? framebuffer_rect.top : 0;
+  uniforms.clamp_top = (static_cast<float>(top_coord) + .5f) * rcp_efb_height;
+  const u32 bottom_coord = (clamp_bottom ? framebuffer_rect.bottom : efb_height) - 1;
+  uniforms.clamp_bottom = (static_cast<float>(bottom_coord) + .5f) * rcp_efb_height;
   uniforms.pixel_height = g_ActiveConfig.bCopyEFBScaled ? rcp_efb_height : 1.0f / EFB_HEIGHT;
   uniforms.padding = 0;
   g_vertex_manager->UploadUtilityUniforms(&uniforms, sizeof(uniforms));

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -127,7 +127,7 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
     {
       out.Write("VARYING_LOCATION(0) in vec3 v_tex0;\n");
     }
-    out.Write("FRAGMENT_OUTPUT_LOCATION(0) out vec4 ocol0;"
+    out.Write("FRAGMENT_OUTPUT_LOCATION(0) out vec4 ocol0;\n"
               "void main()\n{{\n");
   }
 


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/12813, which regressed in #10204.  The clamping logic was improved in #10222, but was off by half a pixel, which causes issues for the previous line when the copy filter is enabled.

Here's the EFB it's working with (as with before, the colors are weird because the EFB is RGBA6 for normal game logic, but RGB8 for the broken effect):

![image](https://user-images.githubusercontent.com/8334194/151100599-b788889d-3cd5-4177-b4c0-83899cadf3bd.png)

The EFB copy is for 152 by 85 at (336, 224).  The broken version produces this (upscaled 4x with nearest neighbor):

![image](https://user-images.githubusercontent.com/8334194/151101209-ba90cd3e-cd8c-4caa-8266-54f74d6687c9.png)

Now, it produces this:

![image](https://user-images.githubusercontent.com/8334194/151101233-cec17d78-5cc0-41ef-9330-a55d6d36be54.png)

The comment about clamping behavior is from the software renderer; I myself haven't performed the tests it is referring to:

https://github.com/dolphin-emu/dolphin/blob/b237c7479e21421e4017dea9df34309af4c0a2e8/Source/Core/VideoBackends/Software/EfbInterface.cpp#L589-L597

I also fixed an off-by-one when clamp is not enabled, mentioned in https://github.com/dolphin-emu/dolphin/pull/10222#discussion_r750597039 (at least, I think it's fixed; I'm not 100% confident in this).

FifoCI probably won't show any interesting differences from this change since the copy filter is disabled by default, and this issue only exists when the copy filter is enabled.