### PR TITLE
Round viewport coordinates when vertex rounding is enabled

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -227,7 +227,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
   GFX_HACK_COPY_EFB_SCALED(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS, "EFBScaledCopy", true),
   GFX_HACK_EFB_EMULATE_FORMAT_CHANGES(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS,
           "EFBEmulateFormatChanges", false),
-  GFX_HACK_VERTEX_ROUDING(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS, "VertexRounding", false),
+  GFX_HACK_VERTEX_ROUNDING(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS, "VertexRounding", false),
   GFX_HACK_FAST_TEXTURE_SAMPLING(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS,
           "FastTextureSampling", true),
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -696,7 +696,7 @@ public final class SettingsFragmentPresenter
             R.string.fast_depth_calculation, R.string.fast_depth_calculation_description));
     sl.add(new InvertedCheckBoxSetting(mContext, BooleanSetting.GFX_HACK_BBOX_ENABLE,
             R.string.disable_bbox, R.string.disable_bbox_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_VERTEX_ROUDING,
+    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_VERTEX_ROUNDING,
             R.string.vertex_rounding, R.string.vertex_rounding_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_SAVE_TEXTURE_CACHE_TO_STATE,
             R.string.texture_cache_to_state, R.string.texture_cache_to_state_description));

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -287,7 +287,7 @@
     <string name="disable_bbox">Disable Bounding Box</string>
     <string name="disable_bbox_description">Disables bounding box emulation. This may improve GPU performance significantly, but some games will break. If unsure, leave this checked.</string>
     <string name="vertex_rounding">Vertex Rounding</string>
-    <string name="vertex_rounding_description">Rounds 2D vertices to whole pixels. Fixes graphical problems in some games at higher internal resolutions. This setting has no effect when native internal resolution is used. If unsure, leave this unchecked.</string>
+    <string name="vertex_rounding_description">Rounds 2D vertices to whole pixels and rounds the viewport size to a whole number. Fixes graphical problems in some games at higher internal resolutions. This setting has no effect when native internal resolution is used. If unsure, leave this unchecked.</string>
     <string name="texture_cache_to_state">Save Texture Cache to State</string>
     <string name="texture_cache_to_state_description">Includes the contents of the embedded frame buffer (EFB) and upscaled EFB copies in save states. Fixes missing and/or non-upscaled textures/objects when loading states at the cost of additional save/load time.</string>
     <string name="aspect_ratio">Aspect Ratio</string>

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -148,7 +148,7 @@ const Info<bool> GFX_HACK_EARLY_XFB_OUTPUT{{System::GFX, "Hacks", "EarlyXFBOutpu
 const Info<bool> GFX_HACK_COPY_EFB_SCALED{{System::GFX, "Hacks", "EFBScaledCopy"}, true};
 const Info<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES{
     {System::GFX, "Hacks", "EFBEmulateFormatChanges"}, false};
-const Info<bool> GFX_HACK_VERTEX_ROUDING{{System::GFX, "Hacks", "VertexRounding"}, false};
+const Info<bool> GFX_HACK_VERTEX_ROUNDING{{System::GFX, "Hacks", "VertexRounding"}, false};
 const Info<u32> GFX_HACK_MISSING_COLOR_VALUE{{System::GFX, "Hacks", "MissingColorValue"},
                                              0xFFFFFFFF};
 const Info<bool> GFX_HACK_FAST_TEXTURE_SAMPLING{{System::GFX, "Hacks", "FastTextureSampling"},

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -122,7 +122,7 @@ extern const Info<bool> GFX_HACK_SKIP_DUPLICATE_XFBS;
 extern const Info<bool> GFX_HACK_EARLY_XFB_OUTPUT;
 extern const Info<bool> GFX_HACK_COPY_EFB_SCALED;
 extern const Info<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES;
-extern const Info<bool> GFX_HACK_VERTEX_ROUDING;
+extern const Info<bool> GFX_HACK_VERTEX_ROUNDING;
 extern const Info<u32> GFX_HACK_MISSING_COLOR_VALUE;
 extern const Info<bool> GFX_HACK_FAST_TEXTURE_SAMPLING;
 

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -98,7 +98,7 @@ public:
 
     if (m_settings.m_StrictSettingsSync)
     {
-      layer->Set(Config::GFX_HACK_VERTEX_ROUDING, m_settings.m_VertexRounding);
+      layer->Set(Config::GFX_HACK_VERTEX_ROUNDING, m_settings.m_VertexRounding);
       layer->Set(Config::GFX_EFB_SCALE, m_settings.m_InternalResolution);
       layer->Set(Config::GFX_HACK_COPY_EFB_SCALED, m_settings.m_EFBScaledCopy);
       layer->Set(Config::GFX_FAST_DEPTH_CALC, m_settings.m_FastDepthCalc);

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1363,7 +1363,7 @@ bool NetPlayServer::SetupNetSettings()
   settings.m_Fastmem = Config::Get(Config::MAIN_FASTMEM);
   settings.m_SkipIPL = Config::Get(Config::MAIN_SKIP_IPL) || !DoAllPlayersHaveIPLDump();
   settings.m_LoadIPLDump = Config::Get(Config::SESSION_LOAD_IPL_DUMP) && DoAllPlayersHaveIPLDump();
-  settings.m_VertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
+  settings.m_VertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUNDING);
   settings.m_InternalResolution = Config::Get(Config::GFX_EFB_SCALE);
   settings.m_EFBScaledCopy = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);
   settings.m_FastDepthCalc = Config::Get(Config::GFX_FAST_DEPTH_CALC);

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -275,10 +275,10 @@ void HacksWidget::AddDescriptions()
                  "states at the cost of additional save/load time.<br><br><dolphin_emphasis>If "
                  "unsure, leave this checked.</dolphin_emphasis>");
   static const char TR_VERTEX_ROUNDING_DESCRIPTION[] = QT_TR_NOOP(
-      "Rounds 2D vertices to whole pixels.<br><br>Fixes graphical problems in some games at "
-      "higher internal resolutions. This setting has no effect when native internal "
-      "resolution is used.<br><br><dolphin_emphasis>If unsure, leave this "
-      "unchecked.</dolphin_emphasis>");
+      "Rounds 2D vertices to whole pixels and rounds the viewport size to a whole number.<br><br>"
+      "Fixes graphical problems in some games at higher internal resolutions. This setting has no "
+      "effect when native internal resolution is used.<br><br>"
+      "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
   m_skip_efb_cpu->SetDescription(tr(TR_SKIP_EFB_CPU_ACCESS_DESCRIPTION));
   m_ignore_format_changes->SetDescription(tr(TR_IGNORE_FORMAT_CHANGE_DESCRIPTION));

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -103,7 +103,7 @@ void HacksWidget::CreateWidgets()
       new GraphicsBool(tr("Fast Depth Calculation"), Config::GFX_FAST_DEPTH_CALC);
   m_disable_bounding_box =
       new GraphicsBool(tr("Disable Bounding Box"), Config::GFX_HACK_BBOX_ENABLE, true);
-  m_vertex_rounding = new GraphicsBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUDING);
+  m_vertex_rounding = new GraphicsBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUNDING);
   m_save_texture_cache_state =
       new GraphicsBool(tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE);
 

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -303,7 +303,7 @@ void VertexShaderManager::SetConstants()
     // NOTE: If we ever emulate antialiasing, the sample locations set by
     // BP registers 0x01-0x04 need to be considered here.
     const float pixel_center_correction = 7.0f / 12.0f - 0.5f;
-    const bool bUseVertexRounding = g_ActiveConfig.bVertexRounding && g_ActiveConfig.iEFBScale != 1;
+    const bool bUseVertexRounding = g_ActiveConfig.UseVertexRounding();
     const float viewport_width = bUseVertexRounding ?
                                      (2.f * xfmem.viewport.wd) :
                                      g_renderer->EFBToScaledXf(2.f * xfmem.viewport.wd);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -134,7 +134,7 @@ void VideoConfig::Refresh()
   bSkipPresentingDuplicateXFBs = Config::Get(Config::GFX_HACK_SKIP_DUPLICATE_XFBS);
   bCopyEFBScaled = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);
   bEFBEmulateFormatChanges = Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);
-  bVertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
+  bVertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUNDING);
   iEFBAccessTileSize = Config::Get(Config::GFX_HACK_EFB_ACCESS_TILE_SIZE);
   iMissingColorValue = Config::Get(Config::GFX_HACK_MISSING_COLOR_VALUE);
   bFastTextureSampling = Config::Get(Config::GFX_HACK_FAST_TEXTURE_SAMPLING);


### PR DESCRIPTION
This should fix https://bugs.dolphin-emu.org/issues/9105 (an issue where a blue line appears in Wii Sports Resort's archery at 3x IR or higher).

The issue was caused by the game trying to reset the depth on a part of the screen by drawing a rectangle over it (object 264 in the fifolog), followed by it clearing the color of that region using an EFB copy, but at higher IRs these two things stop matching exactly.

<details><summary>Specifics</summary>

Object 264 has this:

```
BP register BPMEM_SCISSORTL
Scissor Top: 402
Scissor Left: 788

BP register BPMEM_SCISSORBR
Scissor Bottom: 489
Scissor Right: 852

BP register BPMEM_SCISSOROFFSET
Scissor X offset: 171
Scissor Y offset: 171
```

i.e. a scissor with a top coordinate of `402-(171*2)`=60, a left coordinate of 446, a bottom coordinate of 147, and a right coordinate of 510, so a 65 by 88 scissor rectangle with the top-left at (446, 60).

It also has this:

```
XF register Write 6 XF regs at 101a
XFMEM_SETVIEWPORT + 0
Viewport width: 32.5
XFMEM_SETVIEWPORT + 1
Viewport height: -44
XFMEM_SETVIEWPORT + 2
Viewport z range: 16777216
XFMEM_SETVIEWPORT + 3
Viewport x origin: 820.766
XFMEM_SETVIEWPORT + 4
Viewport y origin: 446
XFMEM_SETVIEWPORT + 5
Viewport far z: 16777216
```

This is centered at y=446-(171*2)=104 and x=478.766, and has a _radius_ of 32.5 horizontally/44 vertically, meaning the top-left is at (446.266, 60) and the size is 65 by 88.  The problem here is the discrepancy between 446 and 446.266, which is too small to see on real hardware at 1x IR, and still too small at 2x IR (where it becomes 892 and 892.532; I think these both round to 892 due to pixel centering, but I'm not 100% sure), but is a problem at 3x IR (1338 vs 1338.798) and definitely a problem at 4x IR (1784 vs 1785.064).  Note that there's no reason why the game couldn't have used precisely 446.

The EFB copy afterwards (EFB copy 27) uses this:

```
BP register BPMEM_EFB_TL
EFB Left: 446
EFB Top: 60

BP register BPMEM_EFB_WH
EFB Width: 64
EFB Height: 88
```

The mismatch between a width of 65 and of 64 is odd, and I'm not sure what the deal with it is, but it doesn't seem to actually cause problems (at least here), and existed before this PR.

-----

Here's a quick summary of the affected coordinates before and after this PR:
|Coord |Old color|Old depth|New color|New depth|
|------|---------|---------|---------|---------|
|Left  |446      |446      |446      |446      |
|Top   |60       |60       |60       |60       |
|Right |509      |510      |509      |510      |
|Bottom|147      |147      |147      |147      |

And at 3x IR (with the 1x IR equivalent in parentheses):

|Coord |Old color  |Old depth  |New color  |New depth  |
|------|-----------|-----------|-----------|-----------|
|Left  |1338 (446) |1339 (446⅓)|1338 (446) |1338 (446) |
|Top   |180 (60)   |180 (60)   |180 (60)   |180 (60)   |
|Right |1529 (509⅔)|1532 (510⅔)|1529 (509⅔)|1532 (510⅔)|
|Bottom|443 (147⅔) |443 (147⅔) |443 (147⅔) |443 (147⅔) |

The only difference is the change from old depth left to new depth left, where it went from 446⅓ to 446.  (Note that we don't want fractions on the top or left, but we want fractions on the bottom or right, since we want all pixels that correspond to a 1x IR pixel to be affected (e.g. if at 1x IR a pixel with x=147 is affected, we want x=147, x=147⅓, and x=147⅔ to be affected at 3x IR.)

-----

</details>

This could be tied behind an option (either vertex rounding or a new one), but I don't think should make any difference at 1x IR and will only ever result in games rendering better (unlike vertex rounding, which _slightly_ reduces detail).