### PR TITLE
UberShaderPixel: Fix typo in fog calculation

### DIFF
--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -1062,7 +1062,7 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
             "    }} else {{\n"
             "      // orthographic\n"
             "      // ze = a*Zs    (here, no B_SHF)\n"
-            "      ze = " I_FOGF ".z * float(zCoord) / 16777216.0;\n"
+            "      ze = " I_FOGF ".x * float(zCoord) / 16777216.0;\n"
             "    }}\n"
             "\n"
             "    if (bool({})) {{\n",


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/12814.  The typo was introduced in #6352; see [specialized shaders](https://github.com/dolphin-emu/dolphin/pull/6352/files#diff-15dbecba159f6aa3db86aa8bad1b7f2d403e9de959d84c0d5d04af06b0f41414L1341-R1342) vs [ubershaders](https://github.com/dolphin-emu/dolphin/pull/6352/files#diff-cf173f4d3f10e7603ea9af059d550e4532033584d0b6fce2151a81306ba41163L1165-R1165).