### PR TITLE
Android: Make primitive restart configurable

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -186,6 +186,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
           "WaitForShadersBeforeStarting", false),
   GFX_SAVE_TEXTURE_CACHE_TO_STATE(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS,
           "SaveTextureCacheToState", true),
+  GFX_PRIMITIVE_RESTART(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "PrimitiveRestart", true),
 
   GFX_ENHANCE_FORCE_FILTERING(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS,
           "ForceFiltering", false),
@@ -231,6 +232,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
           MAIN_WII_SD_CARD,  // Can actually be changed, but specialized code is required
           MAIN_MMU,
           MAIN_DSP_JIT,
+          GFX_PRIMITIVE_RESTART,
   };
 
   private static final Set<BooleanSetting> NOT_RUNTIME_EDITABLE =

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -744,6 +744,8 @@ public final class SettingsFragmentPresenter
             R.string.crop_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.SYSCONF_PROGRESSIVE_SCAN,
             R.string.progressive_scan, 0));
+    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_PRIMITIVE_RESTART,
+            R.string.primitive_restart, R.string.primitive_restart_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_BACKEND_MULTITHREADING,
             R.string.backend_multithreading, R.string.backend_multithreading_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_EFB_DEFER_INVALIDATION,

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -323,6 +323,8 @@
     <string name="crop">Crop</string>
     <string name="crop_description">Crops the picture from its native aspect ratio to 4:3 or 16:9. If unsure, leave this unchecked.</string>
     <string name="progressive_scan">Enable Progressive Scan</string>
+    <string name="primitive_restart">Primitive Restart</string>
+    <string name="primitive_restart_description">Enables primitive restart (if supported by the driver). May affect performance. If unsure, leave this checked.</string>
     <string name="backend_multithreading">Backend Multithreading</string> <!--Backend Multithreading is only disabled by default on Android  -->
     <string name="backend_multithreading_description">Enables graphics backend multithreading (Vulkan only). May affect performance. If unsure, leave this unchecked.</string>
     <string name="defer_efb_invalidation">Defer EFB Cache Invalidation</string>

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -89,6 +89,7 @@ const Info<int> GFX_SHADER_PRECOMPILER_THREADS{
     {System::GFX, "Settings", "ShaderPrecompilerThreads"}, -1};
 const Info<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE{
     {System::GFX, "Settings", "SaveTextureCacheToState"}, true};
+const Info<bool> GFX_PRIMITIVE_RESTART{{System::GFX, "Settings", "PrimitiveRestart"}, true};
 
 const Info<bool> GFX_SW_ZCOMPLOC{{System::GFX, "Settings", "SWZComploc"}, true};
 const Info<bool> GFX_SW_ZFREEZE{{System::GFX, "Settings", "SWZFreeze"}, true};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -71,6 +71,7 @@ extern const Info<ShaderCompilationMode> GFX_SHADER_COMPILATION_MODE;
 extern const Info<int> GFX_SHADER_COMPILER_THREADS;
 extern const Info<int> GFX_SHADER_PRECOMPILER_THREADS;
 extern const Info<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE;
+extern const Info<bool> GFX_PRIMITIVE_RESTART;
 
 extern const Info<bool> GFX_SW_ZCOMPLOC;
 extern const Info<bool> GFX_SW_ZFREEZE;

--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -784,7 +784,7 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
   glGenFramebuffers(1, &m_shared_read_framebuffer);
   glGenFramebuffers(1, &m_shared_draw_framebuffer);
 
-  if (g_ActiveConfig.backend_info.bSupportsPrimitiveRestart)
+  if (g_ActiveConfig.UsePrimitiveRestart())
     GLUtil::EnablePrimitiveRestart(m_main_gl_context.get());
 
   UpdateActiveConfig();

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -880,7 +880,7 @@ bool SharedContextAsyncShaderCompiler::WorkerThreadInitWorkerThread(void* param)
     glEnable(GL_CLIP_DISTANCE1);
     glEnable(GL_DEPTH_CLAMP);
   }
-  if (g_ActiveConfig.backend_info.bSupportsPrimitiveRestart)
+  if (g_ActiveConfig.UsePrimitiveRestart())
     GLUtil::EnablePrimitiveRestart(context);
 
   return true;

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -290,7 +290,7 @@ std::unique_ptr<VKPipeline> VKPipeline::Create(const AbstractPipelineConfig& con
   // VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY,
   // VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY or VK_PRIMITIVE_TOPOLOGY_PATCH_LIST,
   // primitiveRestartEnable must be VK_FALSE
-  if (g_ActiveConfig.backend_info.bSupportsPrimitiveRestart &&
+  if (g_ActiveConfig.UsePrimitiveRestart() &&
       IsStripPrimitiveTopology(input_assembly_state.topology))
   {
     input_assembly_state.primitiveRestartEnable = VK_TRUE;

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -378,8 +378,8 @@ void EnumerateGeometryShaderUids(const std::function<void(const GeometryShaderUi
   GeometryShaderUid uid;
 
   const std::array<PrimitiveType, 3> primitive_lut = {
-      {g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ? PrimitiveType::TriangleStrip :
-                                                               PrimitiveType::Triangles,
+      {g_ActiveConfig.UsePrimitiveRestart() ? PrimitiveType::TriangleStrip :
+                                              PrimitiveType::Triangles,
        PrimitiveType::Lines, PrimitiveType::Points}};
   for (PrimitiveType primitive : primitive_lut)
   {

--- a/Source/Core/VideoCommon/IndexGenerator.cpp
+++ b/Source/Core/VideoCommon/IndexGenerator.cpp
@@ -204,7 +204,7 @@ void IndexGenerator::Init()
 {
   using OpcodeDecoder::Primitive;
 
-  if (g_Config.backend_info.bSupportsPrimitiveRestart)
+  if (g_Config.UsePrimitiveRestart())
   {
     m_primitive_table[Primitive::GX_DRAW_QUADS] = AddQuads<true>;
     m_primitive_table[Primitive::GX_DRAW_QUADS_2] = AddQuads_nonstandard<true>;

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -125,7 +125,7 @@ DataReader VertexManagerBase::PrepareForAdditionalData(OpcodeDecoder::Primitive 
   u32 const needed_vertex_bytes = count * stride + 4;
 
   // We can't merge different kinds of primitives, so we have to flush here
-  PrimitiveType new_primitive_type = g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ?
+  PrimitiveType new_primitive_type = g_ActiveConfig.UsePrimitiveRestart() ?
                                          primitive_from_gx_pr[primitive] :
                                          primitive_from_gx[primitive];
   if (m_current_primitive_type != new_primitive_type)
@@ -192,7 +192,7 @@ u32 VertexManagerBase::GetRemainingIndices(OpcodeDecoder::Primitive primitive) c
 {
   const u32 index_len = MAXIBUFFERSIZE - m_index_generator.GetIndexLen();
 
-  if (g_Config.backend_info.bSupportsPrimitiveRestart)
+  if (g_Config.UsePrimitiveRestart())
   {
     switch (primitive)
     {

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -55,6 +55,7 @@ void VideoConfig::Refresh()
   aspect_mode = Config::Get(Config::GFX_ASPECT_RATIO);
   suggested_aspect_mode = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
   bCrop = Config::Get(Config::GFX_CROP);
+  bPrimitiveRestart = Config::Get(Config::GFX_PRIMITIVE_RESTART);
   iSafeTextureCache_ColorSamples = Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES);
   bShowFPS = Config::Get(Config::GFX_SHOW_FPS);
   bShowNetPlayPing = Config::Get(Config::GFX_SHOW_NETPLAY_PING);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -64,6 +64,7 @@ struct VideoConfig final
   AspectMode suggested_aspect_mode{};
   bool bCrop = false;  // Aspect ratio controls.
   bool bShaderCache = false;
+  bool bPrimitiveRestart = false;
 
   // Enhancements
   u32 iMultisamples = 0;
@@ -260,6 +261,10 @@ struct VideoConfig final
   bool UsingUberShaders() const;
   u32 GetShaderCompilerThreads() const;
   u32 GetShaderPrecompilerThreads() const;
+  bool UsePrimitiveRestart() const
+  {
+    return backend_info.bSupportsPrimitiveRestart && bPrimitiveRestart;
+  }
 };
 
 extern VideoConfig g_Config;


### PR DESCRIPTION
This significantly improves performance on Adreno when running at high resolutions. I don't know why.

TODO:

- [ ] If we could get this tested on more GPUs (especially OpenGL ES on Mali), that would be great (maybe we could just always disable this for mobile GPUs instead of having an option?)
- [ ] Would it be possible to correctly handle the setting changing while emulation is running? (Someone who knows the graphics backends please help me here) Otherwise I should make it so it isn't updated in VideoConfig::Refresh