### PR TITLE
Android: Fix in-game menu font spacing and checkbox margin

### DIFF
--- a/Source/Android/app/src/main/res/layout-ldrtl/list_item_cheat.xml
+++ b/Source/Android/app/src/main/res/layout-ldrtl/list_item_cheat.xml
@@ -26,12 +26,13 @@
         android:id="@+id/checkbox"
         android:layout_width="48dp"
         android:layout_height="64dp"
-        app:layout_constraintStart_toEndOf="@id/text_name"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:gravity="center"
         android:focusable="true"
-        android:nextFocusRight="@id/root" />
+        android:gravity="center"
+        android:nextFocusRight="@id/root"
+        android:buttonTint="@color/dolphin_blue"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/text_name"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_cheat_warning.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_cheat_warning.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:layout_marginRight="10dp">
 
     <TextView
         android:id="@+id/text_warning"
@@ -11,10 +11,10 @@
         android:layout_height="match_parent"
         android:layout_margin="@dimen/spacing_large"
         android:text="@string/cheats_disabled_warning"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/button_settings"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/button_settings"
@@ -23,9 +23,9 @@
         android:layout_margin="@dimen/spacing_small"
         android:text="@string/cheats_open_settings"
         android:textColor="@color/dolphin_white"
-        app:layout_constraintStart_toEndOf="@id/text_warning"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toEndOf="@id/text_warning"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -12,14 +12,15 @@
         android:id="@+id/text_game_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        tools:text="The Legend of Zelda: The Wind Waker"
-        android:textColor="@android:color/white"
-        android:textSize="20sp"
-        android:maxLines="@integer/game_title_lines"
-        android:ellipsize="end"
+        android:layout_marginBottom="16dp"
         android:layout_marginHorizontal="32dp"
         android:layout_marginTop="32dp"
-        android:layout_marginBottom="16dp"/>
+        android:ellipsize="end"
+        android:letterSpacing="0"
+        android:maxLines="@integer/game_title_lines"
+        android:textColor="@android:color/white"
+        android:textSize="20sp"
+        tools:text="The Legend of Zelda: The Wind Waker" />
 
     <ScrollView
         android:layout_width="match_parent"
@@ -36,8 +37,9 @@
 
             <Button
                 android:id="@+id/menu_pause_emulation"
-                android:text="@string/pause_emulation"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption"
+                android:letterSpacing="0"
+                android:text="@string/pause_emulation" />
 
             <Button
                 android:id="@+id/menu_unpause_emulation"
@@ -47,8 +49,9 @@
 
             <Button
                 android:id="@+id/menu_take_screenshot"
-                android:text="@string/emulation_screenshot"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption"
+                android:letterSpacing="0"
+                android:text="@string/emulation_screenshot" />
 
             <Button
                 android:id="@+id/menu_quicksave"
@@ -76,22 +79,26 @@
 
             <Button
                 android:id="@+id/menu_settings"
-                android:text="@string/grid_menu_settings"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption"
+                android:letterSpacing="0"
+                android:text="@string/grid_menu_settings" />
 
             <Button
                 android:id="@+id/menu_overlay_controls"
-                android:text="@string/emulation_overlay_controls"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption"
+                android:letterSpacing="0"
+                android:text="@string/emulation_overlay_controls" />
 
             <Button
                 android:id="@+id/menu_refresh_wiimotes"
                 android:text="@string/emulation_refresh_wiimotes"
+                android:letterSpacing="0"
                 style="@style/InGameMenuOption"/>
 
             <Button
                 android:id="@+id/menu_change_disc"
                 android:text="@string/emulation_change_disc"
+                android:letterSpacing="0"
                 style="@style/InGameMenuOption"/>
 
         </LinearLayout>
@@ -108,7 +115,8 @@
 
     <Button
         android:id="@+id/menu_exit"
-        android:text="@string/emulation_exit"
-        style="@style/InGameMenuOption"/>
+        style="@style/InGameMenuOption"
+        android:letterSpacing="0"
+        android:text="@string/emulation_exit" />
 
 </LinearLayout>

--- a/Source/Android/app/src/main/res/layout/list_item_cheat.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_cheat.xml
@@ -26,12 +26,13 @@
         android:id="@+id/checkbox"
         android:layout_width="48dp"
         android:layout_height="64dp"
-        app:layout_constraintStart_toEndOf="@id/text_name"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:gravity="center"
         android:focusable="true"
-        android:nextFocusLeft="@id/root" />
+        android:gravity="center"
+        android:nextFocusRight="@id/root"
+        android:buttonTint="@color/dolphin_blue"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/text_name"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Source/Android/app/src/main/res/layout/list_item_setting_checkbox.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_setting_checkbox.xml
@@ -43,8 +43,10 @@
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         android:layout_marginEnd="@dimen/spacing_large"
+        android:buttonTint="@color/dolphin_blue"
         android:clickable="false"
         android:focusable="false"
-        android:buttonTint="@color/dolphin_blue"/>
+        android:minHeight="0dp"
+        android:minWidth="0dp" />
 
 </RelativeLayout>


### PR DESCRIPTION
Settings checkbox:
<img src="https://user-images.githubusercontent.com/26326692/151619156-a59c3bb0-b41f-4c61-8481-d67047976fb6.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/26326692/151618030-49c589fb-c367-4e58-8ad7-ad92af3cc6e5.png" width="200" height="400" />

Cheats checkbox:
<img src="https://user-images.githubusercontent.com/26326692/151621766-652d1b2b-45c7-4c04-b6c0-60f8cda4482b.png" width="200" height="400" /> <img src="https://user-images.githubusercontent.com/26326692/151621554-5e2a4aaa-19a3-4865-b615-f59fde171f67.png" width="200" height="400" />

In-game menu font spacing:
<img src="https://user-images.githubusercontent.com/26326692/151619301-79a8c258-4eb3-42b0-a020-856693b453e9.png" width="50%" height="50%" /> <img src="https://user-images.githubusercontent.com/26326692/151621978-e49e8c0e-6b64-4b96-89f0-08a325f76132.png" width="50%" height="50%" />
