### PR TITLE
Android: Get rid of the boot timeout

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -84,7 +84,6 @@ std::mutex s_surface_lock;
 bool s_need_nonblocking_alert_msg;
 
 Common::Flag s_is_booting;
-bool s_have_wm_user_stop = false;
 bool s_game_metadata_is_valid = false;
 }  // Anonymous namespace
 
@@ -123,7 +122,6 @@ void Host_Message(HostMessageID id)
   }
   else if (id == HostMessageID::WMUserStop)
   {
-    s_have_wm_user_stop = true;
     if (Core::IsRunning())
       Core::QueueHostJob(&Core::Stop);
   }
@@ -554,8 +552,6 @@ static void Run(JNIEnv* env, std::unique_ptr<BootParameters>&& boot, bool riivol
 
   WiimoteReal::InitAdapterClass();
 
-  s_have_wm_user_stop = false;
-
   if (riivolution && std::holds_alternative<BootParameters::Disc>(boot->parameters))
   {
     const std::string& riivolution_dir = File::GetUserPath(D_RIIVOLUTION_IDX);
@@ -572,41 +568,25 @@ static void Run(JNIEnv* env, std::unique_ptr<BootParameters>&& boot, bool riivol
   s_need_nonblocking_alert_msg = true;
   std::unique_lock<std::mutex> surface_guard(s_surface_lock);
 
-  bool successful_boot = BootManager::BootCore(std::move(boot), wsi);
-  if (successful_boot)
+  if (BootManager::BootCore(std::move(boot), wsi))
   {
     ButtonManager::Init(SConfig::GetInstance().GetGameID());
 
-    static constexpr int TIMEOUT = 10000;
     static constexpr int WAIT_STEP = 25;
-    int time_waited = 0;
-    // A Core::CORE_ERROR state would be helpful here.
-    while (!Core::IsRunningAndStarted())
-    {
-      if (time_waited >= TIMEOUT || s_have_wm_user_stop)
-      {
-        successful_boot = false;
-        break;
-      }
-
+    while (Core::GetState() == Core::State::Starting)
       std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_STEP));
-      time_waited += WAIT_STEP;
-    }
   }
 
   s_is_booting.Clear();
   s_need_nonblocking_alert_msg = false;
   surface_guard.unlock();
 
-  if (successful_boot)
+  while (Core::IsRunning())
   {
-    while (Core::IsRunningAndStarted())
-    {
-      host_identity_guard.unlock();
-      s_update_main_frame_event.Wait();
-      host_identity_guard.lock();
-      Core::HostDispatchJobs();
-    }
+    host_identity_guard.unlock();
+    s_update_main_frame_event.Wait();
+    host_identity_guard.lock();
+    Core::HostDispatchJobs();
   }
 
   s_game_metadata_is_valid = false;


### PR DESCRIPTION
We don't have a timeout like this on other platforms, and it doesn't accomplish anything useful as far as I can tell. If you trigger it, all that happens is that you don't get a working game and also can't press Exit Emulation without Dolphin hanging (stuck in Core::Shutdown).