### PR TITLE
Android: Get rid of __cplusplus macro checks

### DIFF
--- a/Source/Android/jni/GameList/GameFile.cpp
+++ b/Source/Android/jni/GameList/GameFile.cpp
@@ -36,9 +36,7 @@ jobject GameFileToJava(JNIEnv* env, std::shared_ptr<const UICommon::GameFile> ga
       reinterpret_cast<jlong>(new std::shared_ptr<const UICommon::GameFile>(std::move(game_file))));
 }
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_finalize(JNIEnv* env,
                                                                               jobject obj)
@@ -201,7 +199,4 @@ JNIEXPORT jobject JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_parse(JN
 
   return GameFileToJava(env, game_file);
 }
-
-#ifdef __cplusplus
 }
-#endif

--- a/Source/Android/jni/GameList/GameFileCache.cpp
+++ b/Source/Android/jni/GameList/GameFileCache.cpp
@@ -11,20 +11,13 @@
 #include "jni/AndroidCommon/IDCache.h"
 #include "jni/GameList/GameFile.h"
 
-namespace UICommon
-{
-class GameFile;
-}
-
 static UICommon::GameFileCache* GetPointer(JNIEnv* env, jobject obj)
 {
   return reinterpret_cast<UICommon::GameFileCache*>(
       env->GetLongField(obj, IDCache::GetGameFileCachePointer()));
 }
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
 JNIEXPORT jlong JNICALL
 Java_org_dolphinemu_dolphinemu_model_GameFileCache_newGameFileCache(JNIEnv* env, jclass)
@@ -96,7 +89,4 @@ JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_sa
 {
   return GetPointer(env, obj)->Save();
 }
-
-#ifdef __cplusplus
 }
-#endif


### PR DESCRIPTION
These files cannot compile correctly as C, so there's no reason to have ifdefs for C compatibility.

We switched to not checking the __cplusplus macro in our JNI code some time ago, but it seems like I forgot to remove it from these two files.