### PR TITLE
Test: Disable skipping vertices when the position index is -1

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -184,9 +184,9 @@ std::unique_ptr<VertexLoaderBase> VertexLoaderBase::CreateVertexLoader(const TVt
   //#define COMPARE_VERTEXLOADERS
 
 #if defined(_M_X86_64)
-  loader = std::make_unique<VertexLoaderX64>(vtx_desc, vtx_attr);
+  // loader = std::make_unique<VertexLoaderX64>(vtx_desc, vtx_attr);
 #elif defined(_M_ARM_64)
-  loader = std::make_unique<VertexLoaderARM64>(vtx_desc, vtx_attr);
+  // loader = std::make_unique<VertexLoaderARM64>(vtx_desc, vtx_attr);
 #endif
 
   // Use the software loader as a fallback

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -58,7 +58,7 @@ void Pos_ReadIndex(VertexLoader* loader)
   static_assert(N <= 3, "N > 3 is not sane!");
 
   const auto index = DataRead<I>();
-  loader->m_vertexSkip = index == std::numeric_limits<I>::max();
+  loader->m_vertexSkip = false;
   const auto data =
       reinterpret_cast<const T*>(VertexLoaderManager::cached_arraybases[CPArray::Position] +
                                  (index * g_main_cp_state.array_strides[CPArray::Position]));


### PR DESCRIPTION
This is a test to see if anything other than mario tennis (see https://bugs.dolphin-emu.org/issues/7442) uses vertex indices of 0xffff.  Note that it also switches to the software vertex loader, because I don't want to figure out the JIT loaders; hopefully, they give the exact same output apart from this change.