### PR TITLE
VideoCommon/FrameDump: Build fix for libavformat major version 59 and newer.

### DIFF
--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -154,7 +154,7 @@ bool FrameDump::CreateVideoFile()
 
   File::CreateFullPath(dump_path);
 
-  AVOutputFormat* const output_format = av_guess_format(format.c_str(), dump_path.c_str(), nullptr);
+  auto* const output_format = av_guess_format(format.c_str(), dump_path.c_str(), nullptr);
   if (!output_format)
   {
     ERROR_LOG_FMT(FRAMEDUMP, "Invalid format {}", format);


### PR DESCRIPTION
`av_guess_format` now returns a pointer to const.
https://ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga00bceb049f2b20716e2f36ebc990a350

```cpp
#define FF_API_AVIOFORMAT               (LIBAVFORMAT_VERSION_MAJOR < 59)
```

```cpp
#if FF_API_AVIOFORMAT
#define ff_const59
#else
#define ff_const59 const
#endif
```

```cpp
ff_const59 AVOutputFormat *av_guess_format(const char *short_name,
                                const char *filename,
                                const char *mime_type);
```