### PR TITLE
UpdaterCommon: Copy content file to a temporary file before renaming on macOS

### DIFF
--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -435,8 +435,19 @@ bool UpdateFiles(const std::vector<TodoList::UpdateOp>& to_update,
     // Unfortunately, there is a quirk in the kernel with how it handles the cache: if the file is
     // simply overwritten, the cache isn't invalidated and the old code signature is used to verify
     // the new file. This causes macOS to kill the process with a code signing error. To workaround
-    // this, we use File::Rename() instead of File::Copy().
-    if (!File::Rename(temp_path + DIR_SEP + content_filename, path))
+    // this, we use File::Rename() instead of File::Copy(). However, this also means that if two
+    // files have the same hash, the first file will succeed, but the second file will fail because
+    // the source file no longer exists. To deal with this, we copy the content file to a temporary
+    // file and then rename the temporary file to the destination path.
+    const std::string temporary_file = temp_path + DIR_SEP + "temporary_file";
+    if (!File::Copy(temp_path + DIR_SEP + content_filename, temporary_file))
+    {
+      fprintf(log_fp, "Could not copy %s to %s.\n", content_filename.c_str(),
+              temporary_file.c_str());
+      return false;
+    }
+
+    if (!File::Rename(temporary_file, path))
 #else
     if (!File::Copy(temp_path + DIR_SEP + content_filename, path))
 #endif


### PR DESCRIPTION
This fixes an issue with the auto updater that wasn't noticed until now.

On macOS, we rename files instead of copying them to avoid a quirk in the kernel's code signature cache (#9858). 

#10297 added two files: ``RPBJ01r1.ini‎‎`` and ``RPBJ01r2.ini‎‎``. These both have the same hash, so they have the same content file name. This caused the updater to break when updating ``RPBJ01r2.ini‎‎``, as the content file for ``RPBJ01r1.ini‎‎`` would be moved into the new path, making it impossible for ``RPBJ01r2.ini‎‎`` to be updated as the content file would no longer exist.

To fix this, we copy the content file to a temporary file and then move the temporary file to the target path.

Unfortunately, builds after #9858 will not be able to update to builds after #10297. They will need to do this manually. 