### PR TITLE
Game INI update for Tron Evolution Battle Grids (all editions)

### DIFF
--- a/Data/Sys/GameSettings/STR.ini
+++ b/Data/Sys/GameSettings/STR.ini
@@ -1,0 +1,16 @@
+# STRE4Q, STRP4Q, STRX4Q - Tron Evolution - Battle Grids
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
Automatically set Texture Cache Accuracy to safe in game INI as per wiki entry:
https://wiki.dolphin-emu.org/index.php?title=Tron:_Evolution_-_Battle_Grids