### PR TITLE
VideoConfig: Add flag for whether the system supports setting object names

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DMain.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DMain.cpp
@@ -111,6 +111,7 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsTextureQueryLevels = true;
   g_Config.backend_info.bSupportsLodBiasInSampler = true;
   g_Config.backend_info.bSupportsLogicOp = D3D::SupportsLogicOp(g_Config.iAdapter);
+  g_Config.backend_info.bSupportsSettingObjectNames = true;
 
   g_Config.backend_info.Adapters = D3DCommon::GetAdapterNames();
   g_Config.backend_info.AAModes = D3D::GetAAModes(g_Config.iAdapter);

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -86,6 +86,7 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsCoarseDerivatives = true;
   g_Config.backend_info.bSupportsTextureQueryLevels = true;
   g_Config.backend_info.bSupportsLodBiasInSampler = true;
+  g_Config.backend_info.bSupportsSettingObjectNames = true;
 
   // We can only check texture support once we have a device.
   if (g_dx_context)

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -59,6 +59,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsCoarseDerivatives = false;
   g_Config.backend_info.bSupportsTextureQueryLevels = false;
   g_Config.backend_info.bSupportsLodBiasInSampler = false;
+  g_Config.backend_info.bSupportsSettingObjectNames = false;
 
   // aamodes: We only support 1 sample, so no MSAA
   g_Config.backend_info.Adapters.clear();

--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -583,6 +583,7 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
       g_ogl_config.bSupports3DTextureStorageMultisample = true;
       g_Config.backend_info.bSupportsBitfield = true;
       g_Config.backend_info.bSupportsDynamicSamplerIndexing = true;
+      g_Config.backend_info.bSupportsSettingObjectNames = true;
     }
   }
   else
@@ -628,6 +629,7 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
       g_ogl_config.bSupportsTextureStorage = true;
       g_ogl_config.bSupportsImageLoadStore = true;
       g_Config.backend_info.bSupportsSSAA = true;
+      g_Config.backend_info.bSupportsSettingObjectNames = true;
 
       // Compute shaders are core in GL4.3.
       g_Config.backend_info.bSupportsComputeShaders = true;

--- a/Source/Core/VideoBackends/OGL/OGLShader.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLShader.cpp
@@ -5,6 +5,8 @@
 
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 
+#include "VideoCommon/VideoConfig.h"
+
 namespace OGL
 {
 static GLenum GetGLShaderTypeForStage(ShaderStage stage)
@@ -29,7 +31,7 @@ OGLShader::OGLShader(ShaderStage stage, GLenum gl_type, GLuint gl_id, std::strin
     : AbstractShader(stage), m_id(ProgramShaderCache::GenerateShaderID()), m_type(gl_type),
       m_gl_id(gl_id), m_source(std::move(source)), m_name(std::move(name))
 {
-  if (!m_name.empty())
+  if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
     glObjectLabel(GetGLShaderTypeForStage(stage), m_gl_id, -1, m_name.c_str());
   }
@@ -40,7 +42,7 @@ OGLShader::OGLShader(GLuint gl_compute_program_id, std::string source, std::stri
       m_type(GL_COMPUTE_SHADER), m_gl_compute_program_id(gl_compute_program_id),
       m_source(std::move(source)), m_name(std::move(name))
 {
-  if (!m_name.empty())
+  if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
     glObjectLabel(GL_COMPUTE_SHADER, m_gl_compute_program_id, -1, m_name.c_str());
   }

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -9,6 +9,8 @@
 
 #include "VideoBackends/OGL/SamplerCache.h"
 
+#include "VideoCommon/VideoConfig.h"
+
 namespace OGL
 {
 namespace
@@ -116,7 +118,7 @@ OGLTexture::OGLTexture(const TextureConfig& tex_config, std::string_view name)
   glActiveTexture(GL_MUTABLE_TEXTURE_INDEX);
   glBindTexture(target, m_texId);
 
-  if (!m_name.empty())
+  if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
     glObjectLabel(GL_TEXTURE, m_texId, -1, m_name.c_str());
   }

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -88,6 +88,7 @@ void VideoSoftware::InitBackendInfo()
   g_Config.backend_info.bSupportsCoarseDerivatives = false;
   g_Config.backend_info.bSupportsTextureQueryLevels = false;
   g_Config.backend_info.bSupportsLodBiasInSampler = false;
+  g_Config.backend_info.bSupportsSettingObjectNames = false;
 
   // aamodes
   g_Config.backend_info.AAModes = {1};

--- a/Source/Core/VideoBackends/Vulkan/VKShader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.cpp
@@ -17,7 +17,7 @@ VKShader::VKShader(ShaderStage stage, std::vector<u32> spv, VkShaderModule mod,
     : AbstractShader(stage), m_spv(std::move(spv)), m_module(mod),
       m_compute_pipeline(VK_NULL_HANDLE), m_name(name)
 {
-  if (!m_name.empty() && vkSetDebugUtilsObjectNameEXT)
+  if (!m_name.empty())
   {
     VkDebugUtilsObjectNameInfoEXT name_info = {};
     name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
@@ -32,7 +32,7 @@ VKShader::VKShader(std::vector<u32> spv, VkPipeline compute_pipeline, std::strin
     : AbstractShader(ShaderStage::Compute), m_spv(std::move(spv)), m_module(VK_NULL_HANDLE),
       m_compute_pipeline(compute_pipeline), m_name(name)
 {
-  if (!m_name.empty() && vkSetDebugUtilsObjectNameEXT)
+  if (!m_name.empty())
   {
     VkDebugUtilsObjectNameInfoEXT name_info = {};
     name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;

--- a/Source/Core/VideoBackends/Vulkan/VKShader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.cpp
@@ -10,6 +10,8 @@
 #include "VideoBackends/Vulkan/ShaderCompiler.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
+#include "VideoCommon/VideoConfig.h"
+
 namespace Vulkan
 {
 VKShader::VKShader(ShaderStage stage, std::vector<u32> spv, VkShaderModule mod,
@@ -17,7 +19,7 @@ VKShader::VKShader(ShaderStage stage, std::vector<u32> spv, VkShaderModule mod,
     : AbstractShader(stage), m_spv(std::move(spv)), m_module(mod),
       m_compute_pipeline(VK_NULL_HANDLE), m_name(name)
 {
-  if (!m_name.empty())
+  if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
     VkDebugUtilsObjectNameInfoEXT name_info = {};
     name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
@@ -32,7 +34,7 @@ VKShader::VKShader(std::vector<u32> spv, VkPipeline compute_pipeline, std::strin
     : AbstractShader(ShaderStage::Compute), m_spv(std::move(spv)), m_module(VK_NULL_HANDLE),
       m_compute_pipeline(compute_pipeline), m_name(name)
 {
-  if (!m_name.empty())
+  if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
     VkDebugUtilsObjectNameInfoEXT name_info = {};
     name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -29,7 +29,7 @@ VKTexture::VKTexture(const TextureConfig& tex_config, VkDeviceMemory device_memo
     : AbstractTexture(tex_config), m_device_memory(device_memory), m_image(image), m_layout(layout),
       m_compute_layout(compute_layout), m_name(name)
 {
-  if (!m_name.empty() && vkSetDebugUtilsObjectNameEXT)
+  if (!m_name.empty())
   {
     VkDebugUtilsObjectNameInfoEXT name_info = {};
     name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -21,6 +21,8 @@
 #include "VideoBackends/Vulkan/VKStreamBuffer.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
+#include "VideoCommon/VideoConfig.h"
+
 namespace Vulkan
 {
 VKTexture::VKTexture(const TextureConfig& tex_config, VkDeviceMemory device_memory, VkImage image,
@@ -29,7 +31,7 @@ VKTexture::VKTexture(const TextureConfig& tex_config, VkDeviceMemory device_memo
     : AbstractTexture(tex_config), m_device_memory(device_memory), m_image(image), m_layout(layout),
       m_compute_layout(compute_layout), m_name(name)
 {
-  if (!m_name.empty())
+  if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
     VkDebugUtilsObjectNameInfoEXT name_info = {};
     name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -224,7 +224,11 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
 
   AddExtension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, false);
   AddExtension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, false);
-  AddExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, false);
+
+  if (AddExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, false))
+  {
+    g_Config.backend_info.bSupportsSettingObjectNames = true;
+  }
 
   return true;
 }
@@ -290,6 +294,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsCoarseDerivatives = true;          // Assumed support.
   config->backend_info.bSupportsTextureQueryLevels = true;         // Assumed support.
   config->backend_info.bSupportsLodBiasInSampler = false;          // Dependent on OS.
+  config->backend_info.bSupportsSettingObjectNames = false;        // Dependent on features.
 }
 
 void VulkanContext::PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list)

--- a/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
+++ b/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
@@ -61,6 +61,7 @@ VULKAN_INSTANCE_ENTRY_POINT(vkDestroyDebugReportCallbackEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkDebugReportMessageEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceProperties2, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceSurfaceCapabilities2KHR, false)
+VULKAN_INSTANCE_ENTRY_POINT(vkSetDebugUtilsObjectNameEXT, false)
 
 #endif  // VULKAN_INSTANCE_ENTRY_POINT
 
@@ -196,7 +197,5 @@ VULKAN_DEVICE_ENTRY_POINT(vkQueuePresentKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkAcquireFullScreenExclusiveModeEXT, false)
 VULKAN_DEVICE_ENTRY_POINT(vkReleaseFullScreenExclusiveModeEXT, false)
 #endif
-
-VULKAN_DEVICE_ENTRY_POINT(vkSetDebugUtilsObjectNameEXT, false)
 
 #endif  // VULKAN_DEVICE_ENTRY_POINT

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -234,6 +234,7 @@ struct VideoConfig final
     bool bSupportsCoarseDerivatives = false;
     bool bSupportsTextureQueryLevels = false;
     bool bSupportsLodBiasInSampler = false;
+    bool bSupportsSettingObjectNames = false;
   } backend_info;
 
   // Utility


### PR DESCRIPTION
Basically, the proper version of #10342.

A flag has been added to ``VideoConfig``: ``bSupportsSettingObjectNames``. This is now checked before calling ``glObjectLabel`` in the OpenGL backend and ``vkSetDebugUtilsObjectNameEXT`` in the Vulkan backend.

For the OpenGL backend, support is only set if on [OpenGL >4.3](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glObjectLabel.xhtml) or [OpenGL ES 3.2](https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glObjectLabel.xhtml). This fixes a crash when using the OpenGL backend on macOS, the Android Emulator, and probably some other devices.

For the Vulkan backend, support is only set if the ``VK_EXT_debug_utils`` extension was loaded correctly. In addition, a bug has been fixed where ``vkSetDebugUtilsObjectNameEXT`` was loaded as if it were a device function. [It is actually an instance function](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_debug_utils.html). (This caused Dolphin to fail when loading the function from MoltenVK.)

For the Direct3D backends, support is assumed because I haven't heard of any crashing related to this.