### PR TITLE
Fix improperly exclusive radio buttons

### DIFF
--- a/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
@@ -55,7 +55,7 @@ void CheatSearchFactoryWidget::CreateWidgets()
 
   auto* custom_address_space_layout = new QVBoxLayout();
   custom_address_space_layout->setMargin(6);
-  auto* custom_address_space_button_group = new QButtonGroup();
+  auto* custom_address_space_button_group = new QButtonGroup(this);
   m_custom_virtual_address_space = new QRadioButton(tr("Use virtual addresses when possible"));
   m_custom_virtual_address_space->setChecked(true);
   m_custom_physical_address_space = new QRadioButton(tr("Use physical addresses"));

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -5,7 +5,6 @@
 
 #include <utility>
 
-#include <QButtonGroup>
 #include <QCursor>
 #include <QHBoxLayout>
 #include <QListWidget>

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
@@ -5,7 +5,6 @@
 
 #include <fmt/format.h>
 
-#include <QButtonGroup>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QGridLayout>

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 
+#include <QButtonGroup>
 #include <QCheckBox>
 #include <QGroupBox>
 #include <QHBoxLayout>
@@ -103,6 +104,12 @@ void MemoryWidget::CreateWidgets()
   m_address_splitter->setCollapsible(0, false);
   m_address_splitter->setStretchFactor(1, 2);
 
+  auto* search_type_group = new QButtonGroup(this);
+  m_find_ascii = new QRadioButton(tr("ASCII"));
+  m_find_hex = new QRadioButton(tr("Hex string"));
+  search_type_group->addButton(m_find_ascii);
+  search_type_group->addButton(m_find_hex);
+
   // Dump
   m_dump_mram = new QPushButton(tr("Dump &MRAM"));
   m_dump_exram = new QPushButton(tr("Dump &ExRAM"));
@@ -116,8 +123,6 @@ void MemoryWidget::CreateWidgets()
 
   m_find_next = new QPushButton(tr("Find &Next"));
   m_find_previous = new QPushButton(tr("Find &Previous"));
-  m_find_ascii = new QRadioButton(tr("ASCII"));
-  m_find_hex = new QRadioButton(tr("Hex string"));
   m_result_label = new QLabel;
 
   search_layout->addWidget(m_find_next);

--- a/Source/Core/DolphinQt/Debugger/NewBreakpointDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/NewBreakpointDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "DolphinQt/Debugger/NewBreakpointDialog.h"
 
+#include <QButtonGroup>
 #include <QCheckBox>
 #include <QDialogButtonBox>
 #include <QGridLayout>
@@ -31,10 +32,12 @@ NewBreakpointDialog::NewBreakpointDialog(BreakpointWidget* parent)
 void NewBreakpointDialog::CreateWidgets()
 {
   m_buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+  auto* type_group = new QButtonGroup(this);
 
   // Instruction BP
   m_instruction_bp = new QRadioButton(tr("Instruction Breakpoint"));
   m_instruction_bp->setChecked(true);
+  type_group->addButton(m_instruction_bp);
   m_instruction_box = new QGroupBox;
   m_instruction_address = new QLineEdit;
 
@@ -45,11 +48,15 @@ void NewBreakpointDialog::CreateWidgets()
 
   // Memory BP
   m_memory_bp = new QRadioButton(tr("Memory Breakpoint"));
+  type_group->addButton(m_memory_bp);
   m_memory_box = new QGroupBox;
+  auto* memory_type_group = new QButtonGroup(this);
   m_memory_use_address = new QRadioButton(tr("Address"));
   m_memory_use_address->setChecked(true);
+  memory_type_group->addButton(m_memory_use_address);
   // i18n: A range of memory addresses
   m_memory_use_range = new QRadioButton(tr("Range"));
+  memory_type_group->addButton(m_memory_use_range);
   m_memory_address_from = new QLineEdit;
   m_memory_address_to = new QLineEdit;
   m_memory_address_from_label = new QLabel;  // Set by OnAddressTypeChanged

--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -3,7 +3,6 @@
 
 #include "DolphinQt/Settings/USBDeviceAddToWhitelistDialog.h"
 
-#include <QButtonGroup>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QErrorMessage>

--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.h
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.h
@@ -7,7 +7,6 @@
 
 class QTimer;
 class QDialog;
-class QButtonGroup;
 class QHeaderView;
 class QLabel;
 class QLineEdit;


### PR DESCRIPTION
[`QRadioButton`](https://doc.qt.io/qt-5/qradiobutton.html) has an `autoExclusive` function, but it only works if the buttons share the same parent widget.  [`QButtonGroup`](https://doc.qt.io/qt-5/qbuttongroup.html) can be used to manually specify groups.

<details><summary>Example of the problem</summary>

Open the breakpoints tab by selecting View &rarr; Breakpoints (the debugging UI may need to be enabled).  Then, while a game is running, select "New".  Then, click on the "Memory breakpoint" button 4 times.  _Weird_ stuff happens.

![image](https://user-images.githubusercontent.com/8334194/151849572-2c911668-5ab4-40f4-8f2b-ad1b9b9a6044.png)
![image](https://user-images.githubusercontent.com/8334194/151849585-de2d77c9-3361-41cb-bbfb-8594b056bd42.png)
![image](https://user-images.githubusercontent.com/8334194/151849597-1ab49d17-8549-472c-abc3-784f3653039b.png)
![image](https://user-images.githubusercontent.com/8334194/151849608-bab6a36b-5c4a-43ab-bc82-7b8b645fe354.png)
![image](https://user-images.githubusercontent.com/8334194/151849613-0f223cea-74fc-4bf1-a274-c815a05073a2.png)

</details>

I'm not 100% sure that this doesn't leak memory; the documentation isn't explicit about what owns the `QButtonGroup` object (to my understanding, Qt normally manages deletion of objects, but I don't know if it'll follow the `addButton` chain backwards).  We already use it this way [in `CheatSearchFactoryWidget.cpp`](https://github.com/dolphin-emu/dolphin/blob/4d1e6ff76a47ab8ac7417a7859c816467b4bfd04/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp#L56-L69) though.