### PR TITLE
Android: Include empty folders when exporting user data

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
@@ -320,6 +320,10 @@ public class UserDataActivity extends AppCompatActivity
       {
         exportUserData(zos, child, new File(pathRelativeToRoot, child.getName()));
       }
+      if (children.length == 0 && pathRelativeToRoot != null)
+      {
+        zos.putNextEntry(new ZipEntry(pathRelativeToRoot.getPath() + '/'));
+      }
     }
     else
     {


### PR DESCRIPTION
I think users will have a hard time figuring out where to place texture packs and Riivolution mods and so on without this.