### PR TITLE
Updater: Embed Updater app within the main app bundle on macOS

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -288,11 +288,7 @@ def build(config):
                 "-DCMAKE_IGNORE_PATH="+ignore_path,
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET="
                 + config[arch+"_mac_os_deployment_target"],
-                "-DMACOS_CODE_SIGNING_IDENTITY="
-                + config["codesign_identity"],
-                "-DMACOS_CODE_SIGNING_IDENTITY_UPDATER="
-                + config["codesign_identity"],
-                '-DMACOS_CODE_SIGNING="ON"'
+                '-DMACOS_CODE_SIGNING="OFF"'
             ],
             env=env, cwd=arch)
 

--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -310,6 +310,17 @@ def build(config):
     src_app1 = ARCHITECTURES[1]+"/Binaries/"
 
     recursive_merge_binaries(src_app0, src_app1, dst_app)
+
+    binaries_path = os.path.join(dst_app, "Dolphin.app", "Contents", "MacOS")
+
+    # Remove the embedded Updater if it exists
+    embedded_updater_path = os.path.join(binaries_path, "Dolphin Updater.app")
+    if os.path.exists(embedded_updater_path):
+        shutil.rmtree(embedded_updater_path)
+
+    # Embed the Updater app inside the main Dolphin app bundle
+    shutil.copytree(os.path.join(dst_app, "Dolphin Updater.app"), embedded_updater_path)
+
     for path in glob.glob(dst_app+"/*"):
         if os.path.isdir(path) and os.path.splitext(path)[1] != ".app":
             continue

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -90,6 +90,15 @@ void CleanupFromPreviousUpdate()
 #else
   File::Delete(reloc_updater_path);
 #endif
+
+#ifdef __APPLE__
+  // Clean up the old separate updater app if it exists.
+  const std::string old_updater_path = File::GetExeDirectory() + DIR_SEP + UPDATER_FILENAME;
+  if (File::Exists(old_updater_path))
+  {
+    File::DeleteDirRecursively(old_updater_path);
+  }
+#endif
 }
 #endif
 

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -72,7 +72,12 @@ std::string MakeUpdaterCommandLine(const std::map<std::string, std::string>& fla
 
 std::string GetUpdaterPath()
 {
+#ifdef __APPLE__
+  // Starting with PR 10428, the updater app is now embeded in the main bundle.
+  return File::GetBundleDirectory() + "/Contents/MacOS/" + UPDATER_FILENAME;
+#else
   return File::GetExeDirectory() + DIR_SEP + UPDATER_FILENAME;
+#endif
 }
 
 // Used to remove the relocated updater file once we don't need it anymore.

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -70,6 +70,11 @@ std::string MakeUpdaterCommandLine(const std::map<std::string, std::string>& fla
   return cmdline;
 }
 
+std::string GetUpdaterPath()
+{
+  return File::GetExeDirectory() + DIR_SEP + UPDATER_FILENAME;
+}
+
 // Used to remove the relocated updater file once we don't need it anymore.
 void CleanupFromPreviousUpdate()
 {
@@ -235,7 +240,7 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
     updater_flags["binary-to-restart"] = File::GetExePath();
 
   // Copy the updater so it can update itself if needed.
-  std::string updater_path = File::GetExeDirectory() + DIR_SEP + UPDATER_FILENAME;
+  std::string updater_path = GetUpdaterPath();
   std::string reloc_updater_path = File::GetExeDirectory() + DIR_SEP + UPDATER_RELOC_FILENAME;
 
 #ifdef __APPLE__


### PR DESCRIPTION
This PR embeds ``Dolphin Updater.app`` within the ``Dolphin.app`` bundle. It is inserted into the ``Dolphin.app/Contents/Helpers`` folder, which is [one of the canonical locations to place helper apps](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html#//apple_ref/doc/uid/TP40005929-CH4-TABLE3). In addition, if a separate ``Dolphin Updater.app`` is found during the auto-update cleanup, it is removed.

The goal here is to be able to ship a single app bundle to simplify installation. Users may not copy the Updater app from the DMG for whatever reason, preventing Dolphin's auto-update mechanism from working.

The buildbot configuration needs to be updated as well: dolphin-emu/sadm#153. When merging, that PR should be merged right before this PR is merged.