### PR TITLE
macOS: Support double buffering on CAMetalLayer

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -90,6 +90,11 @@ const Info<int> GFX_SHADER_PRECOMPILER_THREADS{
 const Info<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE{
     {System::GFX, "Settings", "SaveTextureCacheToState"}, true};
 
+#if defined(__APPLE__)
+const Info<bool> GFX_METAL_DOUBLE_BUFFER{
+    {System::GFX, "Settings", "EnableMetalDoubleBuffer"}, false};
+#endif
+
 const Info<bool> GFX_SW_ZCOMPLOC{{System::GFX, "Settings", "SWZComploc"}, true};
 const Info<bool> GFX_SW_ZFREEZE{{System::GFX, "Settings", "SWZFreeze"}, true};
 const Info<bool> GFX_SW_DUMP_OBJECTS{{System::GFX, "Settings", "SWDumpObjects"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -91,8 +91,7 @@ const Info<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE{
     {System::GFX, "Settings", "SaveTextureCacheToState"}, true};
 
 #if defined(__APPLE__)
-const Info<bool> GFX_METAL_DOUBLE_BUFFER{
-    {System::GFX, "Settings", "EnableMetalDoubleBuffer"}, false};
+const Info<bool> GFX_METAL_DOUBLE_BUFFER{{System::GFX, "Settings", "EnableMetalDoubleBuffer"}, false};
 #endif
 
 const Info<bool> GFX_SW_ZCOMPLOC{{System::GFX, "Settings", "SWZComploc"}, true};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -72,6 +72,10 @@ extern const Info<int> GFX_SHADER_COMPILER_THREADS;
 extern const Info<int> GFX_SHADER_PRECOMPILER_THREADS;
 extern const Info<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE;
 
+#if defined(__APPLE__)
+extern const Info<bool> GFX_METAL_DOUBLE_BUFFER;
+#endif
+
 extern const Info<bool> GFX_SW_ZCOMPLOC;
 extern const Info<bool> GFX_SW_ZFREEZE;
 extern const Info<bool> GFX_SW_DUMP_OBJECTS;

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -82,6 +82,11 @@ void GeneralWidget::CreateWidgets()
   m_video_layout->addWidget(m_enable_vsync, 4, 0);
   m_video_layout->addWidget(m_enable_fullscreen, 4, 1);
 
+#if defined(__APPLE__)
+  m_enable_metal_double_buffering = new GraphicsBool(tr("Double Buffer Metal Layer"), Config::GFX_METAL_DOUBLE_BUFFER);
+  m_video_layout->addWidget(m_enable_metal_double_buffering, 8, 0);
+#endif
+
   // Other
   auto* m_options_box = new QGroupBox(tr("Other"));
   auto* m_options_layout = new QGridLayout();
@@ -189,6 +194,10 @@ void GeneralWidget::OnEmulationStateChanged(bool running)
   m_render_main_window->setEnabled(!running);
   m_enable_fullscreen->setEnabled(!running);
 
+#if defined(__APPLE__)
+  m_enable_metal_double_buffering->setEnabled(!running);
+#endif
+
   const bool supports_adapters = !g_Config.backend_info.Adapters.empty();
   m_adapter_combo->setEnabled(!running && supports_adapters);
 }
@@ -266,6 +275,12 @@ void GeneralWidget::AddDescriptions()
                  "two or fewer cores, it is recommended to enable this option, as a large shader "
                  "queue may reduce frame rates.<br><br><dolphin_emphasis>Otherwise, if "
                  "unsure, leave this unchecked.</dolphin_emphasis>");
+#if defined(__APPLE__)
+  static const char TR_ENABLE_METAL_DOUBLE_BUFFERING_DESCRIPTION[] =
+      QT_TR_NOOP("Instructs the underlying CAMetalLayer to use double buffering instead of triple "
+                 "buffering.<br><br><dolphin_emphasis>If unsure, leave this unchecked."
+                 "</dolphin_emphasis>");
+#endif
 
   m_backend_combo->SetTitle(tr("Backend"));
   m_backend_combo->SetDescription(tr(TR_BACKEND_DESCRIPTION));
@@ -278,6 +293,9 @@ void GeneralWidget::AddDescriptions()
   m_enable_vsync->SetDescription(tr(TR_VSYNC_DESCRIPTION));
 
   m_enable_fullscreen->SetDescription(tr(TR_FULLSCREEN_DESCRIPTION));
+#if defined(__APPLE__)
+  m_enable_metal_double_buffering->SetDescription(tr(TR_ENABLE_METAL_DOUBLE_BUFFERING_DESCRIPTION));
+#endif
 
   m_show_fps->SetDescription(tr(TR_SHOW_FPS_DESCRIPTION));
 

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -47,6 +47,9 @@ private:
   GraphicsChoice* m_aspect_combo;
   GraphicsBool* m_enable_vsync;
   GraphicsBool* m_enable_fullscreen;
+#if defined(__APPLE__)
+  GraphicsBool* m_enable_metal_double_buffering;
+#endif
 
   // Options
   GraphicsBool* m_show_fps;

--- a/Source/Core/VideoBackends/Vulkan/VKMain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKMain.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/Logging/LogManager.h"
 #include "Common/MsgHandler.h"
+#include "Core/Config/GraphicsSettings.h"
 
 #include "VideoBackends/Vulkan/CommandBufferManager.h"
 #include "VideoBackends/Vulkan/Constants.h"
@@ -345,12 +346,12 @@ void VideoBackend::PrepareWindow(WindowSystemInfo& wsi)
 
   // CAMetalLayer defaults to 3 for this value, which is equivalent to triple-buffering. This can 
   // be lowered to double-buffering through - the only valid values are `2` or `3`.
-  if (g_ActiveConfig.bMetalDoubleBuffer)
+  //if (g_ActiveConfig.bMetalDoubleBuffer)
+  if (Config::Get(Config::GFX_METAL_DOUBLE_BUFFER))
   {
     // [layer setMaximumDrawableCount:2];
     // (`unsigned long` is the type alias of `NSUInteger` on 64-bit platforms)
     reinterpret_cast<void (*)(id, SEL, unsigned long)>(objc_msgSend)(layer, sel_getUid("setMaximumDrawableCount:"), 2);
-    PanicAlertFmtT("Debug: Metal Double Buffering set");
   }
 
   // Store the layer pointer, that way MoltenVK doesn't call [NSView layer] outside the main thread.

--- a/Source/Core/VideoBackends/Vulkan/VKMain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKMain.cpp
@@ -343,6 +343,16 @@ void VideoBackend::PrepareWindow(WindowSystemInfo& wsi)
   reinterpret_cast<void (*)(id, SEL, double)>(objc_msgSend)(layer, sel_getUid("setContentsScale:"),
                                                             factor);
 
+  // CAMetalLayer defaults to 3 for this value, which is equivalent to triple-buffering. This can 
+  // be lowered to double-buffering through - the only valid values are `2` or `3`.
+  if (g_ActiveConfig.bMetalDoubleBuffer)
+  {
+    // [layer setMaximumDrawableCount:2];
+    // (`unsigned long` is the type alias of `NSUInteger` on 64-bit platforms)
+    reinterpret_cast<void (*)(id, SEL, unsigned long)>(objc_msgSend)(layer, sel_getUid("setMaximumDrawableCount:"), 2);
+    PanicAlertFmtT("Debug: Metal Double Buffering set");
+  }
+
   // Store the layer pointer, that way MoltenVK doesn't call [NSView layer] outside the main thread.
   wsi.render_surface = layer;
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -88,6 +88,11 @@ void VideoConfig::Refresh()
   bWireFrame = Config::Get(Config::GFX_ENABLE_WIREFRAME);
   bDisableFog = Config::Get(Config::GFX_DISABLE_FOG);
   bBorderlessFullscreen = Config::Get(Config::GFX_BORDERLESS_FULLSCREEN);
+
+#ifdef __APPLE__
+  bMetalDoubleBuffer = Config::Get(Config::GFX_METAL_DOUBLE_BUFFER);
+#endif
+
   bEnableValidationLayer = Config::Get(Config::GFX_ENABLE_VALIDATION_LAYER);
   bBackendMultithreading = Config::Get(Config::GFX_BACKEND_MULTITHREADING);
   iCommandBufferExecuteInterval = Config::Get(Config::GFX_COMMAND_BUFFER_EXECUTE_INTERVAL);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -65,6 +65,10 @@ struct VideoConfig final
   bool bCrop = false;  // Aspect ratio controls.
   bool bShaderCache = false;
 
+#ifdef __APPLE__
+  bool bMetalDoubleBuffer = false;
+#endif
+
   // Enhancements
   u32 iMultisamples = 0;
   bool bSSAA = false;


### PR DESCRIPTION
On macOS, `CAMetalLayer` has a `maximumDrawables` parameter that defaults to `3`, which is seemingly triple buffering. It can optionally be set to `2` to double buffer instead, though. 

I wanted to experiment with having this as a config option since I think it can save a frame of input lag, if my understanding of triple-buffering vs double-buffering is correct. Other platforms seem to have an easier time tweaking a setting like this, but unfortunately I think this is the only way to do this on macOS. I don't think MoltenVK has a flag for this either, but if it does and that's a preferable way to do it I'm down to alter this PR.

That all said, I invite anyone with more experience than me to correct me, as all the existing discussion I found on this topic (double vs triple buffering) seemed somewhat varied. I will say that when I tested this with Melee, my inputs feel less like I'm getting locked out - though if there's a more scientific way of testing this I'm happy to take a look.

I tested this on my 2020 M1 MBP, and I don't dip on FPS whether double or triple buffered - so if the input lag bit is true, this would be a cool flag to have.

I also expect that if this PR was considered for merging I'd need to clean it up slightly. My attempt at a `bMetalDoubleBuffer` variable in `VideoConfig` didn't seem to persist correctly, but there might be some odd flow I'm just not understanding - hence why it just calls `Config::Get` directly currently.

Thanks!