### PR TITLE
Remove MMU Default in Disney Trio of Destruction

### DIFF
--- a/Data/Sys/GameSettings/SCY.ini
+++ b/Data/Sys/GameSettings/SCY.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
 LowDCBZHack = 1
 
 [OnLoad]

--- a/Data/Sys/GameSettings/SQI.ini
+++ b/Data/Sys/GameSettings/SQI.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
 LowDCBZHack = 1
 
 [OnLoad]

--- a/Data/Sys/GameSettings/STS.ini
+++ b/Data/Sys/GameSettings/STS.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
Apparently MMU is no longer needed in these titles.  All 3 booted and
played into gameplay in the latest builds without issues, and disabling
MMU results in a very slight, but noticeable performance boost.