### PR TITLE
Round down values after applying the copy filter

### DIFF
--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -279,6 +279,8 @@ static void WriteSampleColor(ShaderCode& code, std::string_view color_comp, std:
                              int x_offset, APIType api_type, const EFBCopyParams& params)
 {
   code.Write("  {} = SampleEFB(uv0, pixel_size, {}).{};\n", dest, x_offset, color_comp);
+  if (!params.depth)
+    code.Write("  {0} = floor({0} * 255.0) / 255.0;\n", dest);
 }
 
 static void WriteColorToIntensity(ShaderCode& code, std::string_view src, std::string_view dest)

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -216,6 +216,8 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
   }
   else if (uid_data->is_intensity)
   {
+    out.Write("  texcol = floor(texcol * 255.0) / 255.0;\n");
+
     if (!uid_data->efb_has_alpha)
       out.Write("  texcol.a = 1.0;\n");
 
@@ -250,6 +252,8 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
   }
   else
   {
+    out.Write("  texcol = floor(texcol * 255.0) / 255.0;\n");
+
     if (!uid_data->efb_has_alpha)
       out.Write("  texcol.a = 1.0;\n");
 


### PR DESCRIPTION
Fixes some additional pink splotches in EA Sports Active.  These were places where the original blue value was over 248, meaning it became 15.5 or higher when divided by 16, which was getting rounded up to 16, which then went outside of the palette.  I still need to do more hardware testing here, and the relevant code is a bit of a mess already, but this seems to improve things at least.

Real hardware:

![image](https://user-images.githubusercontent.com/8334194/152745598-a5dfd1e8-8c45-4113-874a-2034059aba1d.png)

Dolphin with this fix (Manual Texture Sampling disabled):

![image](https://user-images.githubusercontent.com/8334194/152745714-4ea68397-7088-4e5c-ae37-78851d9138c2.png)

Dolphin with this fix (Manual Texture Sampling enabled):

![image](https://user-images.githubusercontent.com/8334194/152745747-f6dbec0c-f85f-4441-8505-3eed609fbf4b.png)
