### PR TITLE
BlendingState: Set source and destination alpha factors in logic op workaround

### DIFF
--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -196,7 +196,9 @@ void BlendingState::ApproximateLogicOpWithBlending()
   blendenable = true;
   subtract = approximations[u32(logicmode.Value())].subtract;
   srcfactor = approximations[u32(logicmode.Value())].srcfactor;
+  srcfactoralpha = approximations[u32(logicmode.Value())].srcfactor;
   dstfactor = approximations[u32(logicmode.Value())].dstfactor;
+  dstfactoralpha = approximations[u32(logicmode.Value())].dstfactor;
 }
 
 void SamplerState::Generate(const BPMemory& bp, u32 index)


### PR DESCRIPTION
Title. Kirby's Air Ride uses the alpha value as a multiplier for the pixel's color in shadow rendering. If we don't update it, then the alpha ends up being set to 0 for the entire frame, causing the entire world to be shadowed in darkness as every color gets multiplied by zero.

The FifoCI diff can be found [here](https://fifo.ci/compare/7365753-7365499/). Doesn't seem to affect any other games.

Fixes Kirby's Air Ride on Intel Macs.