### PR TITLE
OGLMain: Set default value for bSupportsSettingObjectNames

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLMain.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLMain.cpp
@@ -111,6 +111,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsBPTCTextures = false;
   g_Config.backend_info.bSupportsCoarseDerivatives = false;
   g_Config.backend_info.bSupportsTextureQueryLevels = false;
+  g_Config.backend_info.bSupportsSettingObjectNames = false;
 
   g_Config.backend_info.Adapters.clear();
 


### PR DESCRIPTION
I was able to reproduce the OpenGL crash from [12836](https://bugs.dolphin-emu.org/issues/12836), but only when starting Dolphin with Vulkan set, switching to OpenGL, and starting a game. I think this might be because the value from Vulkan carries over to OpenGL and doesn't get overwritten?

I tested my reproduction steps 5 times and it hasn't crashed yet, so I believe this fixes the issue.