### PR TITLE
Ignore unknown opcode for 0x3f

### DIFF
--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -29,7 +29,7 @@ namespace GPFifo
 // the same function could use both methods. Compile 2 different versions of each such block?
 
 // More room for the fastmodes
-alignas(32) static u8 s_gather_pipe[GATHER_PIPE_SIZE * 16];
+alignas(GATHER_PIPE_SIZE) static u8 s_gather_pipe[GATHER_PIPE_EXTRA_SIZE];
 
 static size_t GetGatherPipeCount()
 {

--- a/Source/Core/Core/HW/GPFifo.h
+++ b/Source/Core/Core/HW/GPFifo.h
@@ -9,10 +9,7 @@ class PointerWrap;
 
 namespace GPFifo
 {
-enum
-{
-  GATHER_PIPE_SIZE = 32
-};
+constexpr u32 GATHER_PIPE_SIZE = 32;
 
 // Init
 void Init();

--- a/Source/Core/Core/HW/GPFifo.h
+++ b/Source/Core/Core/HW/GPFifo.h
@@ -10,6 +10,7 @@ class PointerWrap;
 namespace GPFifo
 {
 constexpr u32 GATHER_PIPE_SIZE = 32;
+constexpr u32 GATHER_PIPE_EXTRA_SIZE = GATHER_PIPE_SIZE * 16;
 
 // Init
 void Init();

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -1018,7 +1018,8 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
     bool gatherPipeIntCheck = js.fifoWriteAddresses.find(op.address) != js.fifoWriteAddresses.end();
 
     // Gather pipe writes using an immediate address are explicitly tracked.
-    if (jo.optimizeGatherPipe && (js.fifoBytesSinceCheck >= 32 || js.mustCheckFifo))
+    if (jo.optimizeGatherPipe &&
+        (js.fifoBytesSinceCheck >= GPFifo::GATHER_PIPE_SIZE || js.mustCheckFifo))
     {
       js.fifoBytesSinceCheck = 0;
       js.mustCheckFifo = false;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -835,7 +835,8 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
     // Gather pipe writes using a non-immediate address are discovered by profiling.
     bool gatherPipeIntCheck = js.fifoWriteAddresses.find(op.address) != js.fifoWriteAddresses.end();
 
-    if (jo.optimizeGatherPipe && (js.fifoBytesSinceCheck >= 32 || js.mustCheckFifo))
+    if (jo.optimizeGatherPipe &&
+        (js.fifoBytesSinceCheck >= GPFifo::GATHER_PIPE_SIZE || js.mustCheckFifo))
     {
       js.fifoBytesSinceCheck = 0;
       js.mustCheckFifo = false;

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -634,41 +634,29 @@ void HandleUnknownOpcode(u8 cmd_byte, const u8* buffer, bool preprocess)
                    "Further errors will be sent to the Video Backend log and\n"
                    "Dolphin will now likely crash or hang. Enjoy.",
                    cmd_byte, fmt::ptr(buffer), preprocess);
-
-    PanicAlertFmt("Illegal command {:02x}\n"
-                  "CPBase: {:#010x}\n"
-                  "CPEnd: {:#010x}\n"
-                  "CPHiWatermark: {:#010x}\n"
-                  "CPLoWatermark: {:#010x}\n"
-                  "CPReadWriteDistance: {:#010x}\n"
-                  "CPWritePointer: {:#010x}\n"
-                  "CPReadPointer: {:#010x}\n"
-                  "CPBreakpoint: {:#010x}\n"
-                  "bFF_GPReadEnable: {}\n"
-                  "bFF_BPEnable: {}\n"
-                  "bFF_BPInt: {}\n"
-                  "bFF_Breakpoint: {}\n"
-                  "bFF_GPLinkEnable: {}\n"
-                  "bFF_HiWatermarkInt: {}\n"
-                  "bFF_LoWatermarkInt: {}\n",
-                  cmd_byte, fifo.CPBase.load(std::memory_order_relaxed),
-                  fifo.CPEnd.load(std::memory_order_relaxed), fifo.CPHiWatermark,
-                  fifo.CPLoWatermark, fifo.CPReadWriteDistance.load(std::memory_order_relaxed),
-                  fifo.CPWritePointer.load(std::memory_order_relaxed),
-                  fifo.CPReadPointer.load(std::memory_order_relaxed),
-                  fifo.CPBreakpoint.load(std::memory_order_relaxed),
-                  fifo.bFF_GPReadEnable.load(std::memory_order_relaxed) ? "true" : "false",
-                  fifo.bFF_BPEnable.load(std::memory_order_relaxed) ? "true" : "false",
-                  fifo.bFF_BPInt.load(std::memory_order_relaxed) ? "true" : "false",
-                  fifo.bFF_Breakpoint.load(std::memory_order_relaxed) ? "true" : "false",
-                  fifo.bFF_GPLinkEnable.load(std::memory_order_relaxed) ? "true" : "false",
-                  fifo.bFF_HiWatermarkInt.load(std::memory_order_relaxed) ? "true" : "false",
-                  fifo.bFF_LoWatermarkInt.load(std::memory_order_relaxed) ? "true" : "false");
   }
 
   // We always generate this log message, though we only generate the panic alerts once.
-  ERROR_LOG_FMT(VIDEO, "FIFO: Unknown Opcode ({:#04x} @ {}, preprocessing = {})", cmd_byte,
-                fmt::ptr(buffer), preprocess ? "yes" : "no");
+  ERROR_LOG_FMT(VIDEO,
+                "FIFO: Unknown Opcode {:#04x} @ {}, preprocessing = {}, CPBase: {:#010x}, CPEnd: "
+                "{:#010x}, CPHiWatermark: {:#010x}, CPLoWatermark: {:#010x}, CPReadWriteDistance: "
+                "{:#010x}, CPWritePointer: {:#010x}, CPReadPointer: {:#010x}, CPBreakpoint: "
+                "{:#010x}, bFF_GPReadEnable: {}, bFF_BPEnable: {}, bFF_BPInt: {}, bFF_Breakpoint: "
+                "{}, bFF_GPLinkEnable: {}, bFF_HiWatermarkInt: {}, bFF_LoWatermarkInt: {}",
+                cmd_byte, fmt::ptr(buffer), preprocess ? "yes" : "no",
+                fifo.CPBase.load(std::memory_order_relaxed),
+                fifo.CPEnd.load(std::memory_order_relaxed), fifo.CPHiWatermark, fifo.CPLoWatermark,
+                fifo.CPReadWriteDistance.load(std::memory_order_relaxed),
+                fifo.CPWritePointer.load(std::memory_order_relaxed),
+                fifo.CPReadPointer.load(std::memory_order_relaxed),
+                fifo.CPBreakpoint.load(std::memory_order_relaxed),
+                fifo.bFF_GPReadEnable.load(std::memory_order_relaxed) ? "true" : "false",
+                fifo.bFF_BPEnable.load(std::memory_order_relaxed) ? "true" : "false",
+                fifo.bFF_BPInt.load(std::memory_order_relaxed) ? "true" : "false",
+                fifo.bFF_Breakpoint.load(std::memory_order_relaxed) ? "true" : "false",
+                fifo.bFF_GPLinkEnable.load(std::memory_order_relaxed) ? "true" : "false",
+                fifo.bFF_HiWatermarkInt.load(std::memory_order_relaxed) ? "true" : "false",
+                fifo.bFF_LoWatermarkInt.load(std::memory_order_relaxed) ? "true" : "false");
 }
 
 }  // namespace CommandProcessor

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -382,7 +382,7 @@ void GatherPipeBursted()
   }
   else
   {
-    fifo.CPWritePointer.fetch_add(GATHER_PIPE_SIZE, std::memory_order_relaxed);
+    fifo.CPWritePointer.fetch_add(GPFifo::GATHER_PIPE_SIZE, std::memory_order_relaxed);
   }
 
   if (m_CPCtrlReg.GPReadEnable && m_CPCtrlReg.GPLinkEnable)
@@ -396,7 +396,7 @@ void GatherPipeBursted()
   if (fifo.bFF_HiWatermark.load(std::memory_order_relaxed) != 0)
     CoreTiming::ForceExceptionCheck(0);
 
-  fifo.CPReadWriteDistance.fetch_add(GATHER_PIPE_SIZE, std::memory_order_seq_cst);
+  fifo.CPReadWriteDistance.fetch_add(GPFifo::GATHER_PIPE_SIZE, std::memory_order_seq_cst);
 
   Fifo::RunGpu();
 

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -97,7 +97,6 @@ enum
 
 enum
 {
-  GATHER_PIPE_SIZE = 32,
   INT_CAUSE_CP = 0x800
 };
 


### PR DESCRIPTION
Fixes the unknown opcode with Prince of Persia: Rival Swords (https://bugs.dolphin-emu.org/issues/9203).

This bug occurs because the game has some sort of caching layer to reduce the number of calls to GX functions.  For instance, calls to their function to configure vertex descriptor (at `8010d558`) compare with a cached value before calling `GXSetVtxDesc` (at `80499164`).  I'm not sure whether this actually has any tangible benefit, as those functions don't directly send graphics commands but instead update other internal state, but still, it's something they do.

They have a function that draws a black rectangle over the entire screen (at `80111b40` via `800ae644`), which among other things configures the vertex descriptor to have a position and a color, and then draws the rectangle:

```
80 0004 // Primitive GX_DRAW_QUADS (0) VAT 0, 4 vertices 16 bytes/vertex 64 total bytes
x            y            z             color
00000000 (0) 00000000 (0) 00000000 (0)  00000000 // vertex 1
00000000 (0) 3f800000 (1) 00000000 (0)  00000000 // vertex 2
3f800000 (1) 3f800000 (1) 00000000 (0)  00000000 // vertex 3
3f800000 (1) 00000000 (0) 00000000 (0)  00000000 // vertex 4
```

However, when using Bink Video, Bink's drawing function (at `801e088c`) does not use their caching system and instead directly calls `GXSetVtxDesc`.  Thus, their cache doesn't match reality, so when it comes time to draw the black rectangle, the cache function thinks that the vertex descriptor is already configured correctly and thus never calls `GXSetVtxDesc`.  The vertex descriptor that ends up being used has a position only, without any color data; the same data is thus interpreted this way instead:

```
80 0004 // Primitive GX_DRAW_QUADS (0) VAT 0, 4 vertices 12 bytes/vertex 48 total bytes
x            y            z
00000000 (0) 00000000 (0) 00000000 (0) // vertex 1
00000000 (0) 00000000 (0) 3f800000 (1) // vertex 2
00000000 (0) 00000000 (0) 3f800000 (1) // vertex 3
3f800000 (1) 00000000 (0) 00000000 (0) // vertex 4
3f // Unknown opcode
80 0000 // Primitive GX_DRAW_QUADS (0) Vat 0, 0 vertices 12 bytes/vertex 0 total bytes
00000000 00000000 00000000 // NOP (12x)
```

Things work out on later frames as the cache state and the actual GX state ends up in sync (though I'm not entirely sure what ends up making them consistent).

Using the hardware fifoplayer, I was able to confirm that the 3f was being read but ignored, by replacing it with 0x18 and observing that that produced a hang.

------

It does seem like the developers were aware that this kind of issue could happen, because the Bink drawing code _is_ modified (the Bink changelog mentions, more or less, that the relevant code is in `wiitextures.c` which is distributed in source form to developers, and I've seen other games that modify it too).  But rather than changing the Bink code to use their caching functions, they instead did a weird halfhearted workaround:

```C++
u32 old_pos, old_color_0, old_tex_0, old_tex_1;
// 801e09b8
GXClearVtxDesc();
// -snip-
// 801e0a18
GXGetVtxDesc(9 /* GX_VA_POS */, &old_pos);
GXGetVtxDesc(0xb /* GX_VA_CLR0 */, &old_color_0);
GXGetVtxDesc(0xd /* GX_VA_TEX0 */, &old_tex_0);
GXGetVtxDesc(0xe /* GX_VA_TEX1 */, &old_tex_1);
GXSetVtxDesc(9 /* GX_VA_POS */, 1 /* GX_DIRECT */);
GXSetVtxDesc(0xb /* GX_VA_CLR0 */, 1 /* GX_DIRECT */);
GXSetVtxDesc(0xd /* GX_VA_TEX0 */, 1 /* GX_DIRECT */);
GXSetVtxDesc(0xe /* GX_VA_TEX1 */, 1 /* GX_DIRECT */);
// -snip-, skipping actual drawing code and going to the end of the function
// 801e1368                        
GXSetVtxDesc(9 /* GX_VA_POS */, old_pos);
GXSetVtxDesc(0xb /* GX_VA_CLR0 */, old_color_0);
GXSetVtxDesc(0xd /* GX_VA_TEX0 */, old_tex_0);
GXSetVtxDesc(0xe /* GX_VA_TEX1 */, old_tex_1);
```

But, this doesn't work, as `GXClearVtxDesc` clears the vertex descriptor, so `GXGetVtxDesc` just returns the default values, and thus the ending state is different from the starting state.

I attempted to make a game patch that moves the `GXClearVtxDesc` call after the `GXGetVtxDesc` calls.  This patch _does_ solve the unknown opcode issue (at least in the situation I tested), but there are a lot of other issues because other things are also out of sync (later versions of Bink [reset the state afterwards](http://www.radgametools.com/bnkhist.htm#Changes%20from%201.8x%20to%201.9a%20\(11-04-2007\)), but this version doesn't completely do it, resulting in a red flash on the frame where the unknown opcode would previously appear; [here's a fifolog of the patched version](https://github.com/dolphin-emu/dolphin/files/8054894/RivalSwordsUnknownPatched.zip)).  This patch isn't included in the PR.

```
$HackyFix
0x801E09B8:dword:0x60000000
0x801E0A48:dword:0x4BE23944
0x8000438C:dword:0x48495669
0x80004390:dword:0x38600009
0x80004394:dword:0x481DC6B8
```

For comparison purposes, I also looked at other games: Raving Rabbids (at `803783c8`), the Activision Demo Pack (`80104d80` for DemoLauncher.elf), and Shrek the Third (`8021e1e8`); none of them have this kind of call to `GXSetVtxDesc`, though the Activision Demo Pack does have the Bink code changed to use their own state-tracking cache code.

I think the home-menu code also doesn't use their wrapper, so even changing Bink code for Rival Swords wouldn't fix the issue entirely, though I don't know for sure what would be broken.

-------

I also did some refactoring to allow changing GATHER_PIPE_SIZE, in an attempt at making unknown opcode errors easier to debug; it's not perfect, but it helps.  Those changes are only refactoring, and should not produce any different behaviors.