### PR TITLE
PPCAnalyst: Count outputs as being in use

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -946,8 +946,8 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
     op.gprDiscardable = gprDiscardable;
     op.fprDiscardable = fprDiscardable;
     op.fprInXmm = fprInXmm;
-    gprInUse |= op.regsIn;
-    fprInUse |= op.fregsIn;
+    gprInUse |= op.regsIn | op.regsOut;
+    fprInUse |= op.fregsIn | op.GetFregsOut();
     if (op.canEndBlock || op.canCauseException)
     {
       gprDiscardable = BitSet32{};


### PR DESCRIPTION
In a code block where a guest register is accessed at least twice and the last access is a write and the register is not discardable immediately after the second-to-last instruction (perhaps there is an instruction in between that can cause an exception), currently Dolphin's JITs will flush the register after the second-to-last instruction.

It would be better if we replaced the flush after the second-to-last instruction with a flush that only happens if the exception path is taken. This change accomplishes that by marking guest registers as "in use" not just when they are used as inputs but also when they are used as outputs, preventing the loop in DoJit from flushing the register until after the last access.