### PR TITLE
Fix menu bar becoming desynced when Pause at End of Movie is disabled

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1324,7 +1324,7 @@ void EndPlayInput(bool cont)
   {
     // We can be called by EmuThread during boot (CPU::State::PowerDown)
     bool was_running = Core::IsRunningAndStarted() && !CPU::IsStepping();
-    if (was_running)
+    if (was_running && Config::Get(Config::MAIN_MOVIE_PAUSE_MOVIE))
       CPU::Break();
     s_rerecords = 0;
     s_currentByte = 0;
@@ -1337,11 +1337,7 @@ void EndPlayInput(bool cont)
     // delete tmpInput;
     // tmpInput = nullptr;
 
-    Core::QueueHostJob([=] {
-      Core::UpdateWantDeterminism();
-      if (was_running && !Config::Get(Config::MAIN_MOVIE_PAUSE_MOVIE))
-        CPU::EnableStepping(false);
-    });
+    Core::QueueHostJob([=] { Core::UpdateWantDeterminism(); });
   }
 }
 


### PR DESCRIPTION
Previously, when Pause at End of Movie was disabled, the game would continue running as it should, but the menu bar would think the game was paused, showing the play button instead of the pause button.  To make things worse, clicking the play button would then restart the game, instead of pausing or doing nothing.  F10 paused/unpaused as normal, though.

The old behavior was essentially to enable stepping/pause mode (via `CPU::Break()`) and then if Pause at End of Movie was disabled, to un-pause on the host thread (via `CPU::EnableStepping(false)`).  For reasons which aren't entirely clear to me, the first one notified the menu bar (through the `Host::UpdateDisasmDialog` callback, not the `Settings::EmulationStateChanged` one), and the second did not.  In any case, this approach does not particularly make sense; I don't see any reason to pause and unpause if Pause at End of Movie is disabled; instead, we should only pause when Pause at End of Movie is enabled.

This behavior was probably introduced in c1944f623b5918ab45152795dea9e49f57878138, though I haven't tested it.