### PR TITLE
RenderWidget: Fix random crash due to missing ImGui context

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -549,6 +549,9 @@ void RenderWidget::SetImGuiKeyMap()
   }};
   auto lock = g_renderer->GetImGuiLock();
 
+  if (!ImGui::GetCurrentContext())
+    return;
+
   for (auto [imgui_key, qt_key] : key_map)
     ImGui::GetIO().KeyMap[imgui_key] = (qt_key & 0x1FF);
 }


### PR DESCRIPTION
`ImGui::GetIO` performs an assertion that a context exists, and if one doesn't then things will likely crash.  See https://bugs.dolphin-emu.org/issues/12045, https://bugs.dolphin-emu.org/issues/12472, and https://bugs.dolphin-emu.org/issues/12652.  Unfortunately this crash is hard to consistently reproduce (although I reported it in a movie context, that doesn't actually seem to be the cause and I can't reproduce it that way anymore; I've also run into this while using the fifoplayer), and I haven't actually confirmed it yet (by adding a panic alert to the no-context case).  I do know from previous times when it has happened that it is this `RenderWidget` call to `ImGui::GetIO` that causes the crash; I'm just not certain if anything else can cause a similar crash.