### PR TITLE
Movie: Convert PlayMode to enum class and move to cpp file

### DIFF
--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -37,13 +37,6 @@ class EncryptionKey;
 namespace Movie
 {
 // Enumerations and structs
-enum PlayMode
-{
-  MODE_NONE = 0,
-  MODE_RECORDING,
-  MODE_PLAYING
-};
-
 enum class ControllerType
 {
   None = 0,


### PR DESCRIPTION
Standard "enum -> enum class" conversion, and nothing outside Movie.cpp was referencing PlayMode so I moved it there.