### PR TITLE
ShaderGenCommon: Add missing <functional> include

### DIFF
--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstring>
+#include <functional>
 #include <iterator>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
Dolphin fails to build on my system without this. No idea how it works on CI, but it should be here anyways since it's being used directly in this file.