### PR TITLE
DolphinQt: Add support for a Steam Runtime build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,8 +428,10 @@ if(ENABLE_LTO)
   endif()
 endif()
 
-if(UNIX AND LINUX_LOCAL_DEV)
-  add_definitions(-DLINUX_LOCAL_DEV)
+if(UNIX)
+  if(LINUX_LOCAL_DEV OR (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND STEAM))
+    add_definitions(-DLINUX_LOCAL_DEV)
+  endif()
 endif()
 
 # BSDs put packages in /usr/local instead of /usr, so we need to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ if(NOT ANDROID)
 endif()
 
 option(USE_SHARED_ENET "Use shared libenet if found rather than Dolphin's soon-to-compatibly-diverge version" OFF)
+option(USE_SHARED_LIBPNG "Use shared libpng if found" ON)
 option(USE_UPNP "Enables UPnP port mapping support" ON)
 option(ENABLE_NOGUI "Enable NoGUI frontend" ON)
 option(ENABLE_QT "Enable Qt (Default)" ON)
@@ -413,6 +414,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   find_library(IOB_LIBRARY IOBluetooth)
   find_library(IOK_LIBRARY IOKit)
   find_library(OPENGL_LIBRARY OpenGL)
+
+  # We don't want to use shared libpng.
+  set(USE_SHARED_LIBPNG OFF)
 endif()
 
 if(ENABLE_LTO)
@@ -786,7 +790,7 @@ else()
   set(LZO lzo2)
 endif()
 
-if(NOT APPLE)
+if(USE_SHARED_LIBPNG)
   check_lib(PNG libpng png png.h QUIET)
 endif()
 if (PNG_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ option(ENABLE_VULKAN "Enables vulkan video backend" ON)
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence, show the current game on Discord" ON)
 option(USE_MGBA "Enables GBA controllers emulation using libmgba" ON)
 option(ENABLE_AUTOUPDATE "Enables support for automatic updates" ON)
+option(STEAM "Creates a build for Steam" ON)
 
 # Maintainers: if you consider blanket disabling this for your users, please
 # consider the following points:
@@ -935,6 +936,10 @@ if(SYSTEMD_FOUND)
   add_definitions(-DHAVE_LIBSYSTEMD)
 else()
   message(STATUS "libsystemd not found, disabling traversal server watchdog support")
+endif()
+
+if(STEAM)
+  add_definitions(-DSTEAM)
 endif()
 
 if (WIN32)

--- a/Source/Core/Common/GL/GLInterface/GLX.cpp
+++ b/Source/Core/Common/GL/GLInterface/GLX.cpp
@@ -13,7 +13,11 @@
 
 typedef GLXContext (*PFNGLXCREATECONTEXTATTRIBSPROC)(Display*, GLXFBConfig, GLXContext, Bool,
                                                      const int*);
+
+#ifndef GLX_EXT_swap_control
 typedef void (*PFNGLXSWAPINTERVALEXTPROC)(Display*, GLXDrawable, int);
+#endif
+
 typedef int (*PFNGLXSWAPINTERVALMESAPROC)(unsigned int);
 
 static PFNGLXCREATECONTEXTATTRIBSPROC glXCreateContextAttribs = nullptr;

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -552,16 +552,20 @@ ResultCode HostFileSystem::Rename(Uid uid, Gid gid, const std::string& old_path,
     }
   }
 
-  // Finally, remove the child from the old parent and move it to the new parent.
   FstEntry* new_entry = GetFstEntryForPath(new_path);
+  new_entry->name = split_new_path.file_name;
+
+  // Finally, remove the child from the old parent and move it to the new parent.
   const auto it = std::find_if(old_parent->children.begin(), old_parent->children.end(),
                                GetNamePredicate(split_old_path.file_name));
   if (it != old_parent->children.end())
   {
-    *new_entry = *it;
+    new_entry->data = it->data;
+    new_entry->children = it->children;
+
     old_parent->children.erase(it);
   }
-  new_entry->name = split_new_path.file_name;
+
   SaveFst();
 
   return ResultCode::Success;

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -627,6 +627,12 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND STEAM)
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${QT_DIR}/../../../plugins/platforms" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/platforms"
   )
 
+  # Copy qt.conf
+  target_sources(dolphin-emu PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/qt.conf")
+  add_custom_command(TARGET dolphin-emu POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/qt.conf" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/qt.conf"
+  )
+
   # Mark all data files as resources
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/Data/Sys")
   file(GLOB_RECURSE resources RELATIVE "${CMAKE_SOURCE_DIR}/Data" "${CMAKE_SOURCE_DIR}/Data/Sys/*")

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -620,6 +620,12 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND STEAM)
     BUILD_WITH_INSTALL_RPATH true
     INSTALL_RPATH "\$ORIGIN/lib"
   )
+
+  add_custom_command(TARGET dolphin-emu POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/lib"
+    COMMAND cp -P "${QT_DIR}/../../*.so*" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/lib"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${QT_DIR}/../../../plugins/platforms" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/platforms"
+  )
 endif()
 
 if(USE_MGBA)

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -606,6 +606,22 @@ else()
   install(TARGETS dolphin-emu RUNTIME DESTINATION ${bindir})
 endif()
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND STEAM)
+  # Set that we want ORIGIN in FLAGS.
+  # We also want RPATH, not RUNPATH, so disable the new tags.
+  target_link_options(dolphin-emu
+  PRIVATE
+    LINKER:-z,origin
+    LINKER:--disable-new-dtags
+  )
+
+  # For Steam Runtime builds, our Qt shared libraries will be in a "lib" folder.
+  set_target_properties(dolphin-emu PROPERTIES
+    BUILD_WITH_INSTALL_RPATH true
+    INSTALL_RPATH "\$ORIGIN/lib"
+  )
+endif()
+
 if(USE_MGBA)
   target_sources(dolphin-emu PRIVATE
     GBAHost.cpp

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -626,6 +626,19 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND STEAM)
     COMMAND cp -P "${QT_DIR}/../../*.so*" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/lib"
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${QT_DIR}/../../../plugins/platforms" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/platforms"
   )
+
+  # Mark all data files as resources
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/Data/Sys")
+  file(GLOB_RECURSE resources RELATIVE "${CMAKE_SOURCE_DIR}/Data" "${CMAKE_SOURCE_DIR}/Data/Sys/*")
+  foreach(res ${resources})
+    target_sources(dolphin-emu PRIVATE "${CMAKE_SOURCE_DIR}/Data/${res}")
+    source_group("Resources" FILES "${CMAKE_SOURCE_DIR}/Data/${res}")
+  endforeach()
+
+  # Copy Sys folder
+  add_custom_command(TARGET dolphin-emu POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/Data/Sys" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sys"
+  )
 endif()
 
 if(USE_MGBA)


### PR DESCRIPTION
This PR adds an easy flag to disable/enable things necessary for a Steam build, and makes changes to DolphinQt to create a build that will run in the Steam Runtime.

I built and tested this PR with Steam Runtime version 1, ``scout``, using the revision currently being used in general availability with the Steam client ([which is what Valve recommends for games](https://gitlab.steamos.cloud/steamrt/scout/sdk)).

## Building

Building Dolphin for the Steam Runtime is just like building for a regular Linux system. However, it must must be done within the Steam Runtime environment to prevent system libraries leaking into the application. A chroot environment or Docker container can be used, as outlined [here](https://github.com/ValveSoftware/steam-runtime#building-in-the-runtime).

Some extra CMake flags are required to produce a Steam Runtime build, as some libraries included in the runtime are too old. The recommended cmake configuration command is:

``
cmake .. -G Ninja -DCMAKE_C_COMPILER="gcc-9" -DCMAKE_CXX_COMPILER="g++-9" -DENABLE_EVDEV=OFF -DENABLE_LLVM=OFF -DUSE_SHARED_LIBPNG=OFF -DSTEAM=ON -DENABLE_SDL=ON -DCMAKE_PREFIX_PATH=/path/to/qt
``

## Running

Running a build can occur on any Linux machine. However, it is not possible to run Dolphin within the chroot environment or the Docker container used for building, due to libusb initialization on startup.

First, make sure the scout runtime is installed. This can be done by copying and pasting the following into the address bar

Then, run the build:

``
./steam-runtime/run.sh ./dolphin-emu
``

## Acknowledgements

Thanks to delroth, Techjar, and Warepire for their help getting DolphinQt working.