### PR TITLE
Add Override for Boot IOS for Wii Titles

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -478,8 +478,11 @@ bool CBoot::EmulatedBS2_Wii(const DiscIO::VolumeDisc& volume,
   Memory::Write_U32(0, 0x3194);
   Memory::Write_U32(static_cast<u32>(data_partition.offset >> 2), 0x3198);
 
+  const s32 ios_override = Config::Get(Config::MAIN_OVERRIDE_BOOT_IOS);
+  const u64 ios = ios_override >= 0 ? Titles::IOS(static_cast<u32>(ios_override)) : tmd.GetIOSId();
+
   const auto console_type = volume.GetTicket(data_partition).GetConsoleType();
-  if (!SetupWiiMemory(console_type) || !IOS::HLE::GetIOS()->BootIOS(tmd.GetIOSId()))
+  if (!SetupWiiMemory(console_type) || !IOS::HLE::GetIOS()->BootIOS(ios))
     return false;
 
   auto di =

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -182,6 +182,7 @@ const Info<std::string> MAIN_GFX_BACKEND{{System::Main, "Core", "GFXBackend"},
 
 const Info<std::string> MAIN_GPU_DETERMINISM_MODE{{System::Main, "Core", "GPUDeterminismMode"},
                                                   "auto"};
+const Info<s32> MAIN_OVERRIDE_BOOT_IOS{{System::Main, "Core", "OverrideBootIOS"}, -1};
 
 GPUDeterminismMode GetGPUDeterminismMode()
 {

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -130,6 +130,7 @@ extern const Info<bool> MAIN_ALLOW_SD_WRITES;
 extern const Info<bool> MAIN_ENABLE_SAVESTATES;
 extern const Info<DiscIO::Region> MAIN_FALLBACK_REGION;
 extern const Info<bool> MAIN_REAL_WII_REMOTE_REPEAT_REPORTS;
+extern const Info<s32> MAIN_OVERRIDE_BOOT_IOS;
 
 // Main.DSP
 

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -126,6 +126,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_SYNC_GPU_MAX_DISTANCE.GetLocation(),
       &Config::MAIN_SYNC_GPU_MIN_DISTANCE.GetLocation(),
       &Config::MAIN_SYNC_GPU_OVERCLOCK.GetLocation(),
+      &Config::MAIN_OVERRIDE_BOOT_IOS.GetLocation(),
 
       // UI.General
 


### PR DESCRIPTION
This allows any game to specify a different IOS as the IOS used to boot the game.

The target of this is primarily smash bros, as this allows SDHC cards to be used with the game if [Beero's SDHC](http://forums.kc-mm.com/index.php?topic=65342.0) Gecko Code is used.
Because the target of this is Smash Bro's, the default config for Smash has been updated to override the boot IOS to 58.

I put this under [Core], but I'm not sure that's the best place for this option, if there is a better place tell me, and I'll move it.