### PR TITLE
Use config changed callback to detect SD insertion/ejection

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -228,7 +228,6 @@ public enum BooleanSetting implements AbstractBooleanSetting
           MAIN_CPU_THREAD,
           MAIN_ENABLE_CHEATS,
           MAIN_OVERRIDE_REGION_SETTINGS,
-          MAIN_WII_SD_CARD,  // Can actually be changed, but specialized code is required
           MAIN_MMU,
           MAIN_DSP_JIT,
   };

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -125,8 +125,6 @@ public:
   std::shared_ptr<FSDevice> GetFSDevice();
   std::shared_ptr<ESDevice> GetES();
 
-  void SDIO_EventNotify();
-
   void EnqueueIPCRequest(u32 address);
   void EnqueueIPCReply(const Request& request, s32 return_value, s64 cycles_in_future = 0,
                        CoreTiming::FromThread from = CoreTiming::FromThread::CPU);

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -22,6 +22,7 @@ class SDIOSlot0Device : public Device
 {
 public:
   SDIOSlot0Device(Kernel& ios, const std::string& device_name);
+  ~SDIOSlot0Device() override;
 
   void DoState(PointerWrap& p) override;
 
@@ -29,8 +30,6 @@ public:
   std::optional<IPCReply> Close(u32 fd) override;
   std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
   std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
-
-  void EventNotify();
 
 private:
   // SD Host Controller Registers
@@ -124,6 +123,10 @@ private:
     Request request;
   };
 
+  void RefreshConfig();
+
+  void EventNotify();
+
   IPCReply WriteHCRegister(const IOCtlRequest& request);
   IPCReply ReadHCRegister(const IOCtlRequest& request);
   IPCReply ResetCard(const IOCtlRequest& request);
@@ -162,5 +165,8 @@ private:
   std::array<u32, 0x200 / sizeof(u32)> m_registers{};
 
   File::IOFile m_card;
+
+  size_t m_config_callback_id;
+  bool m_sd_card_inserted = false;
 };
 }  // namespace IOS::HLE

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -705,10 +705,6 @@ void Settings::SetSDCardInserted(bool inserted)
   {
     Config::SetBaseOrCurrent(Config::MAIN_WII_SD_CARD, inserted);
     emit SDCardInsertionChanged(inserted);
-
-    auto* ios = IOS::HLE::GetIOS();
-    if (ios)
-      ios->SDIO_EventNotify();
   }
 }
 


### PR DESCRIPTION
This saves the GUI from having to manually call SDIO_EventNotify. With that out of the way, we can let users change the "Insert SD Card" setting on Android while a game is running.