### PR TITLE
FramebufferManager: Flush pending EFB pokes in PopulateEFBCache

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -593,6 +593,7 @@ void FramebufferManager::DestroyReadbackFramebuffer()
 
 void FramebufferManager::PopulateEFBCache(bool depth, u32 tile_index)
 {
+  FlushEFBPokes();
   g_vertex_manager->OnCPUEFBAccess();
 
   // Force the path through the intermediate texture, as we can't do an image copy from a depth


### PR DESCRIPTION
I.e. flush EFB pokes before running an EFB peek, if the cache tile isn't present.  If the cache tile is present, then EFB pokes should have been written to the cache tile and thus don't need to be flushed.

Found while working on dolphin-emu/hwtests#44 ([permalink to the relevant version](https://github.com/pokechu22/hwtests/tree/archive/efb-copy-filter-4)).  As part of that test, I send a bunch of EFB pokes, and then to make sure I wrote the EFB correctly, I use EFB peeks immediately afterwards to verify those values.  That was giving incorrect results in Dolphin (Test 1 was failing) but now gives correct results.  (This PR does not fix the other issues covered by that hardware test; tests other than 1 and 2 still fail with this PR.)