### PR TITLE
DolphinQt: Enable accuracy slider back after a custom value

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -151,6 +151,9 @@ void HacksWidget::ConnectWidgets()
 
 void HacksWidget::LoadSettings()
 {
+  // Need to enable the slider if it was turn off (in case of changes)
+  m_accuracy->setEnabled(true);
+
   const QSignalBlocker blocker(m_accuracy);
   auto samples = Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES);
 


### PR DESCRIPTION
According to this issue https://bugs.dolphin-emu.org/issues/12771, using a custom value on a particular game for the texture cache makes the slider disable until we reboot the app.

Choosing a custom value disable the slider, but don't make it active again after we end the instance of the current game. Then it keep the game config and we couldn't change it.

This change is about enabling the slider if it is disable (due to a custom value for a game).