### PR TITLE
FileUtil: Remove redundant statement

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -859,7 +859,6 @@ std::string GetExePath()
     }
 #elif defined(__APPLE__)
     result = GetBundleDirectory();
-    result = result.substr(0, result.find_last_of("Dolphin.app/Contents/MacOS") + 1);
 #else
     char dolphin_exe_path[PATH_MAX];
     ssize_t len = ::readlink("/proc/self/exe", dolphin_exe_path, sizeof(dolphin_exe_path));


### PR DESCRIPTION
There are several problems with this statement:
* It tries to return [Directory containing Dolphin]/Dolphin.app/Contents/MacOS instead of the [Directory containing Dolphin]/Dolphin.app that is assumed by callers of the function.
* It uses std::string's find_last_of function, which returns the last instance of any character in the string rather than the last occurrence of the string as a whole.
* The haystack string is initialized with GetBundleDirectory() which returns [Directory containing Dolphin]/Dolphin.app, which would make the search fail if it were actually using a function that found the last instance of the string.

These errors coincidentally cancel each other out, but better to just remove the statement.