### PR TITLE
WIP - Disable logic ops fix, attempt to fix Kirby Air Ride black textures

### DIFF
--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -588,14 +588,15 @@ AbstractPipelineConfig ShaderCache::GetGXPipelineConfig(
   config.blending_state = blending_state;
   config.framebuffer_state = g_framebuffer_manager->GetEFBFramebufferState();
 
-  // We can use framebuffer fetch to emulate logic ops in the fragment shader.
-  if (config.blending_state.logicopenable && !g_ActiveConfig.backend_info.bSupportsLogicOp &&
-      !g_ActiveConfig.backend_info.bSupportsFramebufferFetch)
-  {
-    WARN_LOG_FMT(VIDEO,
-                 "Approximating logic op with blending, this will produce incorrect rendering.");
-    config.blending_state.ApproximateLogicOpWithBlending();
-  }
+  // TODO If this fixes issues in Kirby Air Ride, see if there's an easy way to expose this as a configurable setting.
+  // // We can use framebuffer fetch to emulate logic ops in the fragment shader.
+  // if (config.blending_state.logicopenable && !g_ActiveConfig.backend_info.bSupportsLogicOp &&
+  //     !g_ActiveConfig.backend_info.bSupportsFramebufferFetch)
+  // {
+  //   WARN_LOG_FMT(VIDEO,
+  //                "Approximating logic op with blending, this will produce incorrect rendering.");
+  //   config.blending_state.ApproximateLogicOpWithBlending();
+  // }
 
   return config;
 }


### PR DESCRIPTION
**Work in progress, not ready for review.** 

Checking to see if this will fix an issue with black textures on Kirby Air Ride when Vulkan backend is selected. Right now, this branch effectively disables the changes from https://github.com/dolphin-emu/dolphin/pull/8284. I'm opening a draft PR to see if I can grab a binary from the CI build instead of setting up my dev environment locally while I test the feasibility of this approach.

https://wiki.dolphin-emu.org/index.php?title=Kirby_Air_Ride
bug: https://bugs.dolphin-emu.org/issues/11843
