### PR TITLE
Qt/GeneralPane: Don't trigger config change events when populating GUI.

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -279,6 +279,7 @@ add_executable(dolphin-emu
   QtUtils/PartiallyClosableTabWidget.h
   QtUtils/ImageConverter.cpp
   QtUtils/ImageConverter.h
+  QtUtils/SignalBlocking.h
   QtUtils/UTF8CodePointCountValidator.cpp
   QtUtils/UTF8CodePointCountValidator.h
   QtUtils/WindowActivationEventFilter.cpp

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -225,6 +225,7 @@
     <ClInclude Include="QtUtils\ModalMessageBox.h" />
     <ClInclude Include="QtUtils\QueueOnObject.h" />
     <ClInclude Include="QtUtils\RunOnObject.h" />
+    <ClInclude Include="QtUtils\SignalBlocking.h" />
     <ClInclude Include="QtUtils\WinIconHelper.h" />
     <ClInclude Include="QtUtils\WrapInScrollArea.h" />
     <ClInclude Include="ResourcePackManager.h" />

--- a/Source/Core/DolphinQt/QtUtils/SignalBlocking.h
+++ b/Source/Core/DolphinQt/QtUtils/SignalBlocking.h
@@ -1,0 +1,32 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QSignalBlocker>
+
+// Helper class for populating a GUI element without triggering its data change signals.
+
+template <typename T>
+class SignalBlockerProxy
+{
+public:
+  explicit SignalBlockerProxy(T* object) : m_object(object), m_blocker(object) {}
+  SignalBlockerProxy(const SignalBlockerProxy& other) = delete;
+  SignalBlockerProxy(SignalBlockerProxy&& other) = default;
+  SignalBlockerProxy& operator=(const SignalBlockerProxy& other) = delete;
+  SignalBlockerProxy& operator=(SignalBlockerProxy&& other) = default;
+  ~SignalBlockerProxy() = default;
+
+  T* operator->() const { return m_object; }
+
+private:
+  T* m_object;
+  QSignalBlocker m_blocker;
+};
+
+template <typename T>
+SignalBlockerProxy<T> SignalBlocking(T* object)
+{
+  return SignalBlockerProxy<T>(object);
+}

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -23,6 +23,7 @@
 #include "Core/PowerPC/PowerPC.h"
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
 #include "UICommon/AutoUpdate.h"
@@ -238,45 +239,46 @@ void GeneralPane::LoadConfig()
   if (AutoUpdateChecker::SystemSupportsAutoUpdates())
   {
     const auto track = Settings::Instance().GetAutoUpdateTrack().toStdString();
-
     if (track == AUTO_UPDATE_DISABLE_STRING)
-      m_combobox_update_track->setCurrentIndex(AUTO_UPDATE_DISABLE_INDEX);
+      SignalBlocking(m_combobox_update_track)->setCurrentIndex(AUTO_UPDATE_DISABLE_INDEX);
     else if (track == AUTO_UPDATE_STABLE_STRING)
-      m_combobox_update_track->setCurrentIndex(AUTO_UPDATE_STABLE_INDEX);
+      SignalBlocking(m_combobox_update_track)->setCurrentIndex(AUTO_UPDATE_STABLE_INDEX);
     else if (track == AUTO_UPDATE_BETA_STRING)
-      m_combobox_update_track->setCurrentIndex(AUTO_UPDATE_BETA_INDEX);
+      SignalBlocking(m_combobox_update_track)->setCurrentIndex(AUTO_UPDATE_BETA_INDEX);
     else
-      m_combobox_update_track->setCurrentIndex(AUTO_UPDATE_DEV_INDEX);
+      SignalBlocking(m_combobox_update_track)->setCurrentIndex(AUTO_UPDATE_DEV_INDEX);
   }
 
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
-  m_checkbox_enable_analytics->setChecked(Settings::Instance().IsAnalyticsEnabled());
+  SignalBlocking(m_checkbox_enable_analytics)
+      ->setChecked(Settings::Instance().IsAnalyticsEnabled());
 #endif
-  m_checkbox_dualcore->setChecked(Config::Get(Config::MAIN_CPU_THREAD));
-  m_checkbox_cheats->setChecked(Settings::Instance().GetCheatsEnabled());
-  m_checkbox_override_region_settings->setChecked(
-      Config::Get(Config::MAIN_OVERRIDE_REGION_SETTINGS));
-  m_checkbox_auto_disc_change->setChecked(Config::Get(Config::MAIN_AUTO_DISC_CHANGE));
+  SignalBlocking(m_checkbox_dualcore)->setChecked(Config::Get(Config::MAIN_CPU_THREAD));
+  SignalBlocking(m_checkbox_cheats)->setChecked(Settings::Instance().GetCheatsEnabled());
+  SignalBlocking(m_checkbox_override_region_settings)
+      ->setChecked(Config::Get(Config::MAIN_OVERRIDE_REGION_SETTINGS));
+  SignalBlocking(m_checkbox_auto_disc_change)
+      ->setChecked(Config::Get(Config::MAIN_AUTO_DISC_CHANGE));
+
 #ifdef USE_DISCORD_PRESENCE
-  m_checkbox_discord_presence->setChecked(Config::Get(Config::MAIN_USE_DISCORD_PRESENCE));
+  SignalBlocking(m_checkbox_discord_presence)
+      ->setChecked(Config::Get(Config::MAIN_USE_DISCORD_PRESENCE));
 #endif
   int selection = qRound(Config::Get(Config::MAIN_EMULATION_SPEED) * 10);
   if (selection < m_combobox_speedlimit->count())
-    m_combobox_speedlimit->setCurrentIndex(selection);
-  m_checkbox_dualcore->setChecked(Config::Get(Config::MAIN_CPU_THREAD));
+    SignalBlocking(m_combobox_speedlimit)->setCurrentIndex(selection);
 
   const auto fallback = Settings::Instance().GetFallbackRegion();
-
   if (fallback == DiscIO::Region::NTSC_J)
-    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_NTSCJ_INDEX);
+    SignalBlocking(m_combobox_fallback_region)->setCurrentIndex(FALLBACK_REGION_NTSCJ_INDEX);
   else if (fallback == DiscIO::Region::NTSC_U)
-    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_NTSCU_INDEX);
+    SignalBlocking(m_combobox_fallback_region)->setCurrentIndex(FALLBACK_REGION_NTSCU_INDEX);
   else if (fallback == DiscIO::Region::PAL)
-    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_PAL_INDEX);
+    SignalBlocking(m_combobox_fallback_region)->setCurrentIndex(FALLBACK_REGION_PAL_INDEX);
   else if (fallback == DiscIO::Region::NTSC_K)
-    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_NTSCK_INDEX);
+    SignalBlocking(m_combobox_fallback_region)->setCurrentIndex(FALLBACK_REGION_NTSCK_INDEX);
   else
-    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_NTSCJ_INDEX);
+    SignalBlocking(m_combobox_fallback_region)->setCurrentIndex(FALLBACK_REGION_NTSCJ_INDEX);
 }
 
 static QString UpdateTrackFromIndex(int index)


### PR DESCRIPTION
I ran into this while implementing a 'reset all settings' feature. Turns out that blocking signals on QWidget doesn't block events from its children, so what happened is that I called reset settings, all settings were reset, then the GUI got the request to update itself, and during the update one of the GUI elements called its 'I have been changed' signal, which stored the current GUI back to the settings, reverting my reset. Not ideal!

Is there a better way to handle this? This is the best I could come up with, but maybe someone has a less boilerplate-y idea...