### PR TITLE
TASInputWindow: Revise trigger analogs and orientation sliders to grid layout

### DIFF
--- a/Source/Core/DolphinQt/TAS/GCTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/GCTASInputWindow.cpp
@@ -7,6 +7,8 @@
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
+#include <QLabel>
+#include <QShortcut>
 #include <QSpacerItem>
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -14,6 +16,7 @@
 #include "Common/CommonTypes.h"
 
 #include "DolphinQt/TAS/TASCheckBox.h"
+#include "DolphinQt/TAS/TASSlider.h"
 
 #include "InputCommon/GCPadStatus.h"
 
@@ -30,17 +33,7 @@ GCTASInputWindow::GCTASInputWindow(QWidget* parent, int num) : TASInputWindow(pa
   top_layout->addWidget(m_main_stick_box);
   top_layout->addWidget(m_c_stick_box);
 
-  m_triggers_box = new QGroupBox(tr("Triggers"));
-
-  auto* l_trigger_layout =
-      CreateSliderValuePairLayout(tr("Left"), m_l_trigger_value, 0, 255, Qt::Key_N, m_triggers_box);
-  auto* r_trigger_layout = CreateSliderValuePairLayout(tr("Right"), m_r_trigger_value, 0, 255,
-                                                       Qt::Key_M, m_triggers_box);
-
-  auto* triggers_layout = new QVBoxLayout;
-  triggers_layout->addLayout(l_trigger_layout);
-  triggers_layout->addLayout(r_trigger_layout);
-  m_triggers_box->setLayout(triggers_layout);
+  SetTriggersBox();
 
   m_a_button = CreateButton(QStringLiteral("&A"));
   m_b_button = CreateButton(QStringLiteral("&B"));
@@ -82,6 +75,40 @@ GCTASInputWindow::GCTASInputWindow(QWidget* parent, int num) : TASInputWindow(pa
   layout->addWidget(m_settings_box);
 
   setLayout(layout);
+}
+
+void GCTASInputWindow::SetTriggersBox()
+{
+  m_triggers_box = new QGroupBox(tr("Triggers"));
+
+  const QKeySequence l_shortcut_key_sequence = QKeySequence(Qt::ALT + Qt::Key_N);
+  const QKeySequence r_shortcut_key_sequence = QKeySequence(Qt::ALT + Qt::Key_M);
+
+  auto* l_label =
+      new QLabel(tr("Left (%1)").arg(l_shortcut_key_sequence.toString(QKeySequence::NativeText)));
+  auto* r_label =
+      new QLabel(tr("Right (%1)").arg(r_shortcut_key_sequence.toString(QKeySequence::NativeText)));
+
+  QBoxLayout* l_layout = new QHBoxLayout;
+  l_layout->addWidget(l_label);
+  QBoxLayout* r_layout = new QHBoxLayout;
+  r_layout->addWidget(r_label);
+
+  SliderValuePair* l_sliderValuePair = CreateSliderValuePair(
+      l_layout, 0, 255, l_shortcut_key_sequence, Qt::Horizontal, m_triggers_box);
+  SliderValuePair* r_sliderValuePair = CreateSliderValuePair(
+      r_layout, 0, 255, r_shortcut_key_sequence, Qt::Horizontal, m_triggers_box);
+
+  // Create grid layout
+  QGridLayout* triggers_layout = new QGridLayout;
+  triggers_layout->addWidget(l_label, 0, 0);
+  triggers_layout->addWidget(l_sliderValuePair->slider, 0, 1);
+  triggers_layout->addWidget(l_sliderValuePair->value, 0, 2);
+  triggers_layout->addWidget(r_label, 1, 0);
+  triggers_layout->addWidget(r_sliderValuePair->slider, 1, 1);
+  triggers_layout->addWidget(r_sliderValuePair->value, 1, 2);
+
+  m_triggers_box->setLayout(triggers_layout);
 }
 
 void GCTASInputWindow::GetValues(GCPadStatus* pad)

--- a/Source/Core/DolphinQt/TAS/GCTASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/GCTASInputWindow.h
@@ -18,6 +18,7 @@ public:
   void GetValues(GCPadStatus* pad);
 
 private:
+  void SetTriggersBox();
   TASCheckBox* m_a_button;
   TASCheckBox* m_b_button;
   TASCheckBox* m_x_button;

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -85,11 +85,13 @@ QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, Q
 
   auto* x_layout = new QHBoxLayout;
   x_value = CreateSliderValuePair(x_layout, x_default, max_x, x_shortcut_key_sequence,
-                                  Qt::Horizontal, box);
+                                  Qt::Horizontal, box)
+                ->value;
 
   auto* y_layout = new QVBoxLayout;
   y_value =
-      CreateSliderValuePair(y_layout, y_default, max_y, y_shortcut_key_sequence, Qt::Vertical, box);
+      CreateSliderValuePair(y_layout, y_default, max_y, y_shortcut_key_sequence, Qt::Vertical, box)
+          ->value;
   y_value->setMaximumWidth(60);
 
   auto* visual = new StickWidget(this, max_x, max_y);
@@ -127,19 +129,22 @@ QBoxLayout* TASInputWindow::CreateSliderValuePairLayout(QString name, QSpinBox*&
   QBoxLayout* layout = new QHBoxLayout;
   layout->addWidget(label);
 
-  value = CreateSliderValuePair(layout, default_, max, shortcut_key_sequence, Qt::Horizontal,
-                                shortcut_widget, invert);
+  SliderValuePair* sliderValuePair = CreateSliderValuePair(
+      layout, default_, max, shortcut_key_sequence, Qt::Horizontal, shortcut_widget, invert);
+
+  value = sliderValuePair->value;
 
   return layout;
 }
 
 // The shortcut_widget argument needs to specify the container widget that will be hidden/shown.
 // This is done to avoid ambigous shortcuts
-QSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int default_, u16 max,
-                                                QKeySequence shortcut_key_sequence,
-                                                Qt::Orientation orientation,
-                                                QWidget* shortcut_widget, bool invert)
+SliderValuePair* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int default_, u16 max,
+                                                       QKeySequence shortcut_key_sequence,
+                                                       Qt::Orientation orientation,
+                                                       QWidget* shortcut_widget, bool invert)
 {
+  auto* sliderValuePair = new SliderValuePair();
   auto* value = new QSpinBox();
   value->setRange(0, 99999);
   value->setValue(default_);
@@ -167,7 +172,10 @@ QSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int default_
   if (orientation == Qt::Vertical)
     layout->setAlignment(slider, Qt::AlignRight);
 
-  return value;
+  sliderValuePair->slider = slider;
+  sliderValuePair->value = value;
+
+  return sliderValuePair;
 }
 
 template <typename UX>

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.h
@@ -15,6 +15,13 @@ class QGroupBox;
 class QSpinBox;
 class QString;
 class TASCheckBox;
+class TASSlider;
+
+struct SliderValuePair
+{
+  TASSlider* slider;
+  QSpinBox* value;
+};
 
 class TASInputWindow : public QDialog
 {
@@ -32,9 +39,10 @@ protected:
   QBoxLayout* CreateSliderValuePairLayout(QString name, QSpinBox*& value, int default_, u16 max,
                                           Qt::Key shortcut_key, QWidget* shortcut_widget,
                                           bool invert = false);
-  QSpinBox* CreateSliderValuePair(QBoxLayout* layout, int default_, u16 max,
-                                  QKeySequence shortcut_key_sequence, Qt::Orientation orientation,
-                                  QWidget* shortcut_widget, bool invert = false);
+  SliderValuePair* CreateSliderValuePair(QBoxLayout* layout, int default_, u16 max,
+                                         QKeySequence shortcut_key_sequence,
+                                         Qt::Orientation orientation, QWidget* shortcut_widget,
+                                         bool invert = false);
   template <typename UX>
   void GetButton(TASCheckBox* button, UX& pad, UX mask);
   void GetSpinBoxU8(QSpinBox* spin, u8& controller_value);

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.h
@@ -29,6 +29,7 @@ public:
 
 private:
   void UpdateExt(u8 ext);
+  void SetOrientationAndTriggerBoxes();
   int m_num;
   TASCheckBox* m_a_button;
   TASCheckBox* m_b_button;


### PR DESCRIPTION
It always bugged me that sliders didn't always line up if the left label was a different length.

Before: ----------------------------------------------After: 
<img src="https://user-images.githubusercontent.com/16770560/155265673-b95e5764-50d7-47dc-a07c-cbd96f6bc636.png" width="300"><img src="https://user-images.githubusercontent.com/16770560/155265561-cb4999f7-fb15-470f-b402-4562abc14bcf.png" width="300">

In order to properly align them I obviously had to use a QGridBox. Doing so means that I need to retrieve the label, slider, and spinbox widgets. In the current code, the TASSlider widgets become inaccessible (afaik), so I chose to change the return value to a struct which contains both the slider and spinbox.

This applies changes to Gamecube, Wii, and all WiiMote extension TAS Input window variants.

I'm uncertain at this time if there's a better approach or how well this can be cleaned up, so I'd appreciate any feedback. Thank you!