### PR TITLE
More dolphin-tool features and options

### DIFF
--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -59,6 +59,7 @@ public:
   virtual u64 GetBlockSize() const = 0;
   virtual bool HasFastRandomAccessInBlock() const = 0;
   virtual std::string GetCompressionMethod() const = 0;
+  virtual std::optional<int> GetCompressionLevel() const = 0;
 
   // NOT thread-safe - can't call this from multiple threads.
   virtual bool Read(u64 offset, u64 size, u8* out_ptr) = 0;

--- a/Source/Core/DiscIO/CISOBlob.h
+++ b/Source/Core/DiscIO/CISOBlob.h
@@ -46,6 +46,7 @@ public:
   u64 GetBlockSize() const override { return m_block_size; }
   bool HasFastRandomAccessInBlock() const override { return true; }
   std::string GetCompressionMethod() const override { return {}; }
+  std::optional<int> GetCompressionLevel() const override { return std::nullopt; }
 
   bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;
 

--- a/Source/Core/DiscIO/CompressedBlob.h
+++ b/Source/Core/DiscIO/CompressedBlob.h
@@ -58,6 +58,7 @@ public:
   u64 GetBlockSize() const override { return m_header.block_size; }
   bool HasFastRandomAccessInBlock() const override { return false; }
   std::string GetCompressionMethod() const override { return "Deflate"; }
+  std::optional<int> GetCompressionLevel() const override { return std::nullopt; }
 
   u64 GetBlockCompressedSize(u64 block_num) const;
   bool GetBlock(u64 block_num, u8* out_ptr) override;

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -280,6 +280,7 @@ public:
   u64 GetBlockSize() const override { return 0; }
   bool HasFastRandomAccessInBlock() const override { return true; }
   std::string GetCompressionMethod() const override { return {}; }
+  std::optional<int> GetCompressionLevel() const override { return std::nullopt; }
 
 private:
   struct PartitionWithType

--- a/Source/Core/DiscIO/DriveBlob.h
+++ b/Source/Core/DiscIO/DriveBlob.h
@@ -32,6 +32,7 @@ public:
   u64 GetBlockSize() const override { return ECC_BLOCK_SIZE; }
   bool HasFastRandomAccessInBlock() const override { return false; }
   std::string GetCompressionMethod() const override { return {}; }
+  std::optional<int> GetCompressionLevel() const override { return std::nullopt; }
 
 private:
   DriveReader(const std::string& drive);

--- a/Source/Core/DiscIO/FileBlob.h
+++ b/Source/Core/DiscIO/FileBlob.h
@@ -27,6 +27,7 @@ public:
   u64 GetBlockSize() const override { return 0; }
   bool HasFastRandomAccessInBlock() const override { return true; }
   std::string GetCompressionMethod() const override { return {}; }
+  std::optional<int> GetCompressionLevel() const override { return std::nullopt; }
 
   bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;
 

--- a/Source/Core/DiscIO/ScrubbedBlob.h
+++ b/Source/Core/DiscIO/ScrubbedBlob.h
@@ -33,6 +33,10 @@ public:
   {
     return m_blob_reader->GetCompressionMethod();
   }
+  std::optional<int> GetCompressionLevel() const override
+  {
+    return m_blob_reader->GetCompressionLevel();
+  }
 
   bool Read(u64 offset, u64 size, u8* out_ptr) override;
 

--- a/Source/Core/DiscIO/TGCBlob.h
+++ b/Source/Core/DiscIO/TGCBlob.h
@@ -50,6 +50,7 @@ public:
   u64 GetBlockSize() const override { return 0; }
   bool HasFastRandomAccessInBlock() const override { return true; }
   std::string GetCompressionMethod() const override { return {}; }
+  std::optional<int> GetCompressionLevel() const override { return std::nullopt; }
 
   bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;
 

--- a/Source/Core/DiscIO/VolumeFileBlobReader.cpp
+++ b/Source/Core/DiscIO/VolumeFileBlobReader.cpp
@@ -58,6 +58,11 @@ std::string VolumeFileBlobReader::GetCompressionMethod() const
   return m_volume.GetBlobReader().GetCompressionMethod();
 }
 
+std::optional<int> VolumeFileBlobReader::GetCompressionLevel() const
+{
+  return m_volume.GetBlobReader().GetCompressionLevel();
+}
+
 bool VolumeFileBlobReader::Read(u64 offset, u64 length, u8* out_ptr)
 {
   if (offset + length > m_file_info->GetSize())

--- a/Source/Core/DiscIO/VolumeFileBlobReader.h
+++ b/Source/Core/DiscIO/VolumeFileBlobReader.h
@@ -30,6 +30,7 @@ public:
   u64 GetBlockSize() const override;
   bool HasFastRandomAccessInBlock() const override;
   std::string GetCompressionMethod() const override;
+  std::optional<int> GetCompressionLevel() const override;
 
   bool Read(u64 offset, u64 length, u8* out_ptr) override;
 

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -56,7 +56,7 @@ static void PushBack(std::vector<u8>* vector, const T& x)
   PushBack(vector, x_ptr, x_ptr + sizeof(T));
 }
 
-std::pair<int, int> GetAllowedCompressionLevels(WIARVZCompressionType compression_type)
+std::pair<int, int> GetAllowedCompressionLevels(WIARVZCompressionType compression_type, bool gui)
 {
   switch (compression_type)
   {
@@ -68,7 +68,10 @@ std::pair<int, int> GetAllowedCompressionLevels(WIARVZCompressionType compressio
     // The actual minimum level can be gotten by calling ZSTD_minCLevel(). However, returning that
     // would make the UI rather weird, because it is a negative number with very large magnitude.
     // Note: Level 0 is a special number which means "default level" (level 3 as of this writing).
-    return {1, ZSTD_maxCLevel()};
+    if (gui)
+      return {1, ZSTD_maxCLevel()};
+    else
+      return {ZSTD_minCLevel(), ZSTD_maxCLevel()};
   default:
     return {0, -1};
   }
@@ -1985,7 +1988,8 @@ WIARVZFileReader<RVZ>::Convert(BlobReader* infile, const VolumeDisc* infile_volu
 
   header_2.disc_type = Common::swap32(disc_type);
   header_2.compression_type = Common::swap32(static_cast<u32>(compression_type));
-  header_2.compression_level = Common::swap32(static_cast<u32>(compression_level));
+  header_2.compression_level =
+      static_cast<s32>(Common::swap32(static_cast<u32>(compression_level)));
   header_2.chunk_size = Common::swap32(static_cast<u32>(chunk_size));
 
   header_2.number_of_partition_entries = Common::swap32(static_cast<u32>(partition_entries.size()));

--- a/Source/Core/DiscIO/WIABlob.h
+++ b/Source/Core/DiscIO/WIABlob.h
@@ -34,7 +34,7 @@ enum class WIARVZCompressionType : u32
   Zstd = 5,
 };
 
-std::pair<int, int> GetAllowedCompressionLevels(WIARVZCompressionType compression_type);
+std::pair<int, int> GetAllowedCompressionLevels(WIARVZCompressionType compression_type, bool gui);
 
 constexpr u32 WIA_MAGIC = 0x01414957;  // "WIA\x1" (byteswapped to little endian)
 constexpr u32 RVZ_MAGIC = 0x015A5652;  // "RVZ\x1" (byteswapped to little endian)
@@ -56,6 +56,10 @@ public:
   u64 GetBlockSize() const override { return Common::swap32(m_header_2.chunk_size); }
   bool HasFastRandomAccessInBlock() const override { return false; }
   std::string GetCompressionMethod() const override;
+  std::optional<int> GetCompressionLevel() const override
+  {
+    return static_cast<int>(static_cast<s32>(Common::swap32(m_header_2.compression_level)));
+  }
 
   bool Read(u64 offset, u64 size, u8* out_ptr) override;
   bool SupportsReadWiiDecrypted(u64 offset, u64 size, u64 partition_data_offset) const override;
@@ -89,7 +93,7 @@ private:
   {
     u32 disc_type;
     u32 compression_type;
-    u32 compression_level;  // Informative only
+    s32 compression_level;  // Informative only
     u32 chunk_size;
 
     std::array<u8, 0x80> disc_header;

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -34,6 +34,7 @@ public:
   u64 GetBlockSize() const override { return m_wbfs_sector_size; }
   bool HasFastRandomAccessInBlock() const override { return true; }
   std::string GetCompressionMethod() const override { return {}; }
+  std::optional<int> GetCompressionLevel() const override { return std::nullopt; }
 
   bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;
 

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -262,7 +262,7 @@ void ConvertDialog::OnCompressionChanged()
   const auto compression_type =
       static_cast<DiscIO::WIARVZCompressionType>(m_compression->currentData().toInt());
 
-  const std::pair<int, int> range = DiscIO::GetAllowedCompressionLevels(compression_type);
+  const std::pair<int, int> range = DiscIO::GetAllowedCompressionLevels(compression_type, true);
 
   for (int i = range.first; i <= range.second; ++i)
   {

--- a/Source/Core/DolphinTool/CMakeLists.txt
+++ b/Source/Core/DolphinTool/CMakeLists.txt
@@ -5,6 +5,8 @@ add_executable(dolphin-tool
   ConvertCommand.h
   VerifyCommand.cpp
   VerifyCommand.h
+  HeaderCommand.cpp
+  HeaderCommand.h
   ToolMain.cpp
 )
 

--- a/Source/Core/DolphinTool/ConvertCommand.cpp
+++ b/Source/Core/DolphinTool/ConvertCommand.cpp
@@ -220,7 +220,8 @@ int ConvertCommand::Main(const std::vector<std::string>& args)
         return 1;
       }
 
-      const std::pair<int, int> range = DiscIO::GetAllowedCompressionLevels(compression_o.value());
+      const std::pair<int, int> range =
+          DiscIO::GetAllowedCompressionLevels(compression_o.value(), false);
       if (compression_level_o.value() < range.first || compression_level_o.value() > range.second)
       {
         std::cerr << "Error: Compression level not in acceptable range" << std::endl;

--- a/Source/Core/DolphinTool/DolphinTool.vcxproj
+++ b/Source/Core/DolphinTool/DolphinTool.vcxproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <ClCompile Include="ConvertCommand.cpp" />
     <ClCompile Include="VerifyCommand.cpp" />
+    <ClCompile Include="HeaderCommand.cpp" />
     <ClCompile Include="ToolHeadlessPlatform.cpp" />
     <ClCompile Include="ToolMain.cpp" />
   </ItemGroup>
@@ -52,6 +53,7 @@
     <ClInclude Include="Command.h" />
     <ClInclude Include="ConvertCommand.h" />
     <ClInclude Include="VerifyCommand.h" />
+    <ClInclude Include="HeaderCommand.h" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="DolphinTool.exe.manifest" />

--- a/Source/Core/DolphinTool/HeaderCommand.cpp
+++ b/Source/Core/DolphinTool/HeaderCommand.cpp
@@ -1,0 +1,106 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinTool/HeaderCommand.h"
+#include "DiscIO/Blob.h"
+#include "DiscIO/Volume.h"
+#include "DiscIO/VolumeDisc.h"
+
+#include <OptionParser.h>
+#include <optional>
+
+namespace DolphinTool
+{
+int HeaderCommand::Main(const std::vector<std::string>& args)
+{
+  auto parser = std::make_unique<optparse::OptionParser>();
+
+  parser->usage("usage: header [options]...");
+
+  parser->add_option("-i", "--input")
+      .type("string")
+      .action("store")
+      .help("Path to disc image FILE.")
+      .metavar("FILE");
+
+  parser->add_option("-b", "--block_size")
+      .action("store_true")
+      .help("Optional. Print the block size of GCZ/WIA/RVZ formats, then exit.");
+
+  parser->add_option("-c", "--compression")
+      .action("store_true")
+      .help("Optional. Print the compression method of GCZ/WIA/RVZ formats, then exit.");
+
+  parser->add_option("-l", "--compression_level")
+      .action("store_true")
+      .help("Optional. Print the level of compression for WIA/RVZ formats, then exit.");
+
+  const optparse::Values& options = parser->parse_args(args);
+
+  // Validate options
+  const std::string input_file_path = static_cast<const char*>(options.get("input"));
+  if (input_file_path.empty())
+  {
+    std::cerr << "Error: No input set" << std::endl;
+    return 1;
+  }
+
+  bool enable_block_size = options.is_set_by_user("block_size");
+  bool enable_compression_method = options.is_set_by_user("compression");
+  bool enable_compression_level = options.is_set_by_user("compression_level");
+
+  // Open the blob reader, plus get blob type
+  std::shared_ptr<DiscIO::BlobReader> blob_reader = DiscIO::CreateBlobReader(input_file_path);
+  if (!blob_reader)
+  {
+    std::cerr << "Error: Unable to open disc image" << std::endl;
+    return 1;
+  }
+  const DiscIO::BlobType blob_type = blob_reader->GetBlobType();
+
+  if (enable_block_size || enable_compression_method || enable_compression_level)
+  {
+    if (enable_block_size)
+    {
+      const auto block_size = blob_reader->GetBlockSize();
+      if (block_size == 0)
+        std::cout << "N/A" << std::endl;
+      else
+        std::cout << block_size << std::endl;
+    }
+    if (enable_compression_method)
+    {
+      const auto compression_method = blob_reader->GetCompressionMethod();
+      if (compression_method == "")
+        std::cout << "N/A" << std::endl;
+      else
+        std::cout << compression_method << std::endl;
+    }
+    if (enable_compression_level)
+    {
+      const auto compression_level_o = blob_reader->GetCompressionLevel();
+      if (compression_level_o == std::nullopt)
+        std::cout << "N/A" << std::endl;
+      else
+        std::cout << compression_level_o.value() << std::endl;
+    }
+  }
+  else
+  {
+    if (blob_type == DiscIO::BlobType::GCZ)
+    {
+      std::cout << "Block Size: " << blob_reader->GetBlockSize() << std::endl;
+      std::cout << "Compression Method: " << blob_reader->GetCompressionMethod() << std::endl;
+    }
+    if (blob_type == DiscIO::BlobType::WIA || blob_type == DiscIO::BlobType::RVZ)
+    {
+      std::cout << "Block Size: " << blob_reader->GetBlockSize() << std::endl;
+      std::cout << "Compression Method: " << blob_reader->GetCompressionMethod() << std::endl;
+      std::cout << "Compression Level: " << blob_reader->GetCompressionLevel().value() << std::endl;
+    }
+  }
+
+  return 0;
+}
+
+}  // namespace DolphinTool

--- a/Source/Core/DolphinTool/HeaderCommand.h
+++ b/Source/Core/DolphinTool/HeaderCommand.h
@@ -1,0 +1,19 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "DolphinTool/Command.h"
+
+namespace DolphinTool
+{
+class HeaderCommand final : public Command
+{
+public:
+  int Main(const std::vector<std::string>& args) override;
+};
+
+}  // namespace DolphinTool

--- a/Source/Core/DolphinTool/ToolMain.cpp
+++ b/Source/Core/DolphinTool/ToolMain.cpp
@@ -10,12 +10,13 @@
 #include "Common/Version.h"
 #include "DolphinTool/Command.h"
 #include "DolphinTool/ConvertCommand.h"
+#include "DolphinTool/HeaderCommand.h"
 #include "DolphinTool/VerifyCommand.h"
 
 static int PrintUsage(int code)
 {
   std::cerr << "usage: dolphin-tool COMMAND -h" << std::endl << std::endl;
-  std::cerr << "commands supported: [convert, verify]" << std::endl;
+  std::cerr << "commands supported: [convert, verify, header]" << std::endl;
 
   return code;
 }
@@ -38,6 +39,8 @@ int main(int argc, char* argv[])
     command = std::make_unique<DolphinTool::ConvertCommand>();
   else if (command_str == "verify")
     command = std::make_unique<DolphinTool::VerifyCommand>();
+  else if (command_str == "header")
+    command = std::make_unique<DolphinTool::HeaderCommand>();
   else
     return PrintUsage(1);
 


### PR DESCRIPTION
This PR adds more diagnostics to dolphin-tool.  The block size, compression method, and compression level are all now accessible from the command line.