### PR TITLE
Create REX.ini file for Excite Truck visual issues

### DIFF
--- a/Data/Sys/GameSettings/REX.ini
+++ b/Data/Sys/GameSettings/REX.ini
@@ -1,0 +1,16 @@
+# REXE01, REXP01, REXJ01 - Excite Truck
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
With "Store EFB Copies to Texture Only" set to True (the default setting), areas of Excite Truck appear darker than on console. For example, in Sylvan Glen under the Bronze cup, all of the trees appear very dark, nearly black. On console, this does not occur.

Start of the race on Dolphin: https://youtu.be/KjJ-55lwFkE?t=817
Start of the race on Console: https://youtu.be/0W9blwA8AG4?t=699

Setting EFBToTextureEnable = False fixes this issue and does not appear to introduce any performance impacts, so I am recommending that this be disabled by default for this game.