### PR TITLE
NetPlayDialog: Display external IP/Port as seen by the traversal server.

### DIFF
--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -29,6 +29,11 @@ TraversalHostId TraversalClient::GetHostID() const
   return m_HostId;
 }
 
+TraversalInetAddress TraversalClient::GetExternalAddress() const
+{
+  return m_external_address;
+}
+
 TraversalClient::State TraversalClient::GetState() const
 {
   return m_State;
@@ -153,6 +158,7 @@ void TraversalClient::HandleServerPacket(TraversalPacket* packet)
       break;
     }
     m_HostId = packet->helloFromServer.yourHostId;
+    m_external_address = packet->helloFromServer.yourAddress;
     m_State = State::Connected;
     if (m_Client)
       m_Client->OnTraversalStateChanged();

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -44,6 +44,7 @@ public:
   ~TraversalClient();
 
   TraversalHostId GetHostID() const;
+  TraversalInetAddress GetExternalAddress() const;
   State GetState() const;
   FailureReason GetFailureReason() const;
 
@@ -77,6 +78,7 @@ private:
 
   ENetHost* m_NetHost;
   TraversalHostId m_HostId{};
+  TraversalInetAddress m_external_address{};
   State m_State{};
   FailureReason m_FailureReason{};
   TraversalRequestId m_ConnectRequestId = 0;

--- a/Source/Core/Common/TraversalProto.h
+++ b/Source/Core/Common/TraversalProto.h
@@ -69,7 +69,7 @@ struct TraversalPacket
     {
       u8 ok;
       TraversalHostId yourHostId;
-      TraversalInetAddress yourAddress;  // currently unused
+      TraversalInetAddress yourAddress;
     } helloFromServer;
     struct
     {


### PR DESCRIPTION
This changes the "External" address display to that as seen by the traversal server (when using the traversal server).

e.g. When a 2nd device on my LAN tries to host with the traversal server at port 2626 my router maps the external port to 1025.
![image](https://user-images.githubusercontent.com/1768214/156698019-b0006202-ea08-4c33-8c55-d01981027bec.png)
Other routers will do similar things.

Maybe network problems can be better diagnosed with this information?

"Direct" connection display still assumes the external port is unchanged.