### PR TITLE
Common: Make DynamicLibrary non-copyable

### DIFF
--- a/Source/Core/Common/DynamicLibrary.h
+++ b/Source/Core/Common/DynamicLibrary.h
@@ -24,6 +24,12 @@ public:
   // Closes the library.
   ~DynamicLibrary();
 
+  DynamicLibrary(const DynamicLibrary&) = delete;
+  DynamicLibrary(DynamicLibrary&&) = delete;
+
+  DynamicLibrary& operator=(const DynamicLibrary&) = delete;
+  DynamicLibrary& operator=(DynamicLibrary&&) = delete;
+
   // Returns the specified library name with the platform-specific suffix added.
   static std::string GetUnprefixedFilename(const char* filename);
 


### PR DESCRIPTION
The default implementations of DynamicLibrary's copy and move constructors and assignment operators are unsafe.