### PR TITLE
Change the highlighted button on each window

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -290,6 +290,8 @@ add_executable(dolphin-emu
   QtUtils/WrapInScrollArea.h
   QtUtils/AspectRatioWidget.cpp
   QtUtils/AspectRatioWidget.h
+  QtUtils/NonDefaultQPushButton.cpp
+  QtUtils/NonDefaultQPushButton.h
   ResourcePackManager.cpp
   ResourcePackManager.h
   RiivolutionBootWidget.cpp

--- a/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
@@ -24,6 +24,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/MMU.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 
 CheatSearchFactoryWidget::CheatSearchFactoryWidget()
 {
@@ -118,7 +119,7 @@ void CheatSearchFactoryWidget::CreateWidgets()
 
   layout->addWidget(data_type_group);
 
-  m_new_search = new QPushButton(tr("New Search"));
+  m_new_search = new NonDefaultQPushButton(tr("New Search"));
   layout->addWidget(m_new_search);
 
   setLayout(layout);

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -20,6 +20,7 @@
 
 #include "DolphinQt/Config/CheatCodeEditor.h"
 #include "DolphinQt/Config/CheatWarningWidget.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 
 #include "UICommon/GameFile.h"
 
@@ -52,9 +53,9 @@ void ARCodeWidget::CreateWidgets()
 {
   m_warning = new CheatWarningWidget(m_game_id, m_restart_required, this);
   m_code_list = new QListWidget;
-  m_code_add = new QPushButton(tr("&Add New Code..."));
-  m_code_edit = new QPushButton(tr("&Edit Code..."));
-  m_code_remove = new QPushButton(tr("&Remove Code"));
+  m_code_add = new NonDefaultQPushButton(tr("&Add New Code..."));
+  m_code_edit = new NonDefaultQPushButton(tr("&Edit Code..."));
+  m_code_remove = new NonDefaultQPushButton(tr("&Remove Code"));
 
   m_code_list->setEnabled(!m_game_id.empty());
   m_code_add->setEnabled(!m_game_id.empty());

--- a/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
@@ -12,6 +12,7 @@
 #include "Core/Core.h"
 
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 
 CommonControllersWidget::CommonControllersWidget(QWidget* parent) : QWidget(parent)
 {
@@ -26,7 +27,8 @@ void CommonControllersWidget::CreateLayout()
   m_common_box = new QGroupBox(tr("Common"));
   m_common_layout = new QVBoxLayout();
   m_common_bg_input = new QCheckBox(tr("Background Input"));
-  m_common_configure_controller_interface = new QPushButton(tr("Alternate Input Sources"));
+  m_common_configure_controller_interface =
+      new NonDefaultQPushButton(tr("Alternate Input Sources"));
 
   m_common_layout->addWidget(m_common_bg_input);
   m_common_layout->addWidget(m_common_configure_controller_interface);

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
@@ -13,6 +13,7 @@
 
 #include "Common/Config/Config.h"
 #include "DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h"
 
 DualShockUDPClientWidget::DualShockUDPClientWidget()
@@ -32,10 +33,10 @@ void DualShockUDPClientWidget::CreateWidgets()
   m_server_list = new QListWidget();
   main_layout->addWidget(m_server_list);
 
-  m_add_server = new QPushButton(tr("Add..."));
+  m_add_server = new NonDefaultQPushButton(tr("Add..."));
   m_add_server->setEnabled(m_servers_enabled->isChecked());
 
-  m_remove_server = new QPushButton(tr("Remove"));
+  m_remove_server = new NonDefaultQPushButton(tr("Remove"));
   m_remove_server->setEnabled(m_servers_enabled->isChecked());
 
   QHBoxLayout* hlayout = new QHBoxLayout;

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
@@ -16,6 +16,7 @@
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
 
 FreeLookWidget::FreeLookWidget(QWidget* parent) : QWidget(parent)
@@ -34,7 +35,7 @@ void FreeLookWidget::CreateLayout()
   m_enable_freelook->SetDescription(
       tr("Allows manipulation of the in-game camera.<br><br><dolphin_emphasis>If unsure, "
          "leave this unchecked.</dolphin_emphasis>"));
-  m_freelook_controller_configure_button = new QPushButton(tr("Configure Controller"));
+  m_freelook_controller_configure_button = new NonDefaultQPushButton(tr("Configure Controller"));
 
   m_freelook_control_type = new GraphicsChoice({tr("Six Axis"), tr("First Person"), tr("Orbital")},
                                                Config::FL1_CONTROL_TYPE);

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -21,6 +21,7 @@
 
 #include "DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
 
 #include "InputCommon/GCAdapter.h"
@@ -76,7 +77,7 @@ void GamecubeControllersWidget::CreateLayout()
   {
     auto* gc_label = new QLabel(tr("Port %1").arg(i + 1));
     auto* gc_box = m_gc_controller_boxes[i] = new QComboBox();
-    auto* gc_button = m_gc_buttons[i] = new QPushButton(tr("Configure"));
+    auto* gc_button = m_gc_buttons[i] = new NonDefaultQPushButton(tr("Configure"));
 
     for (const auto& item : s_gc_types)
     {

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -26,6 +26,7 @@
 #include "DolphinQt/Config/CheatCodeEditor.h"
 #include "DolphinQt/Config/CheatWarningWidget.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 
 #include "UICommon/GameFile.h"
 
@@ -77,10 +78,10 @@ void GeckoCodeWidget::CreateWidgets()
   m_code_view->setReadOnly(true);
   m_code_view->setFixedHeight(line_height * 10);
 
-  m_add_code = new QPushButton(tr("&Add New Code..."));
-  m_edit_code = new QPushButton(tr("&Edit Code..."));
-  m_remove_code = new QPushButton(tr("&Remove Code"));
-  m_download_codes = new QPushButton(tr("Download Codes"));
+  m_add_code = new NonDefaultQPushButton(tr("&Add New Code..."));
+  m_edit_code = new NonDefaultQPushButton(tr("&Edit Code..."));
+  m_remove_code = new NonDefaultQPushButton(tr("&Remove Code"));
+  m_download_codes = new NonDefaultQPushButton(tr("Download Codes"));
 
   m_download_codes->setToolTip(tr("Download Codes from the WiiRD Database"));
 

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -19,6 +19,7 @@
 #include "DolphinQt/Config/Graphics/GraphicsSlider.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/Graphics/PostProcessingConfigWindow.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
 
 #include "UICommon/VideoUtils.h"
@@ -76,7 +77,7 @@ void EnhancementsWidget::CreateWidgets()
                                   Config::GFX_ENHANCE_MAX_ANISOTROPY);
 
   m_pp_effect = new ToolTipComboBox();
-  m_configure_pp_effect = new QPushButton(tr("Configure"));
+  m_configure_pp_effect = new NonDefaultQPushButton(tr("Configure"));
   m_scaled_efb_copy = new GraphicsBool(tr("Scaled EFB Copy"), Config::GFX_HACK_COPY_EFB_SCALED);
   m_per_pixel_lighting =
       new GraphicsBool(tr("Per-Pixel Lighting"), Config::GFX_ENABLE_PIXEL_LIGHTING);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -45,6 +45,7 @@
 #include "DolphinQt/Config/Mapping/WiimoteEmuMotionControl.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuMotionControlIMU.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/WindowActivationEventFilter.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 #include "DolphinQt/Settings.h"
@@ -94,7 +95,7 @@ void MappingWindow::CreateDevicesLayout()
   m_devices_layout = new QHBoxLayout();
   m_devices_box = new QGroupBox(tr("Device"));
   m_devices_combo = new QComboBox();
-  m_devices_refresh = new QPushButton(tr("Refresh"));
+  m_devices_refresh = new NonDefaultQPushButton(tr("Refresh"));
 
   m_devices_combo->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
   m_devices_refresh->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -110,9 +111,9 @@ void MappingWindow::CreateProfilesLayout()
   m_profiles_layout = new QHBoxLayout();
   m_profiles_box = new QGroupBox(tr("Profile"));
   m_profiles_combo = new QComboBox();
-  m_profiles_load = new QPushButton(tr("Load"));
-  m_profiles_save = new QPushButton(tr("Save"));
-  m_profiles_delete = new QPushButton(tr("Delete"));
+  m_profiles_load = new NonDefaultQPushButton(tr("Load"));
+  m_profiles_save = new NonDefaultQPushButton(tr("Save"));
+  m_profiles_delete = new NonDefaultQPushButton(tr("Delete"));
 
   auto* button_layout = new QHBoxLayout();
 
@@ -133,8 +134,8 @@ void MappingWindow::CreateResetLayout()
 {
   m_reset_layout = new QHBoxLayout();
   m_reset_box = new QGroupBox(tr("Reset"));
-  m_reset_clear = new QPushButton(tr("Clear"));
-  m_reset_default = new QPushButton(tr("Default"));
+  m_reset_clear = new NonDefaultQPushButton(tr("Clear"));
+  m_reset_default = new NonDefaultQPushButton(tr("Default"));
 
   m_reset_box->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -31,6 +31,7 @@
 
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
 
 #include "UICommon/UICommon.h"
@@ -89,9 +90,9 @@ void WiimoteControllersWidget::CreateLayout()
   m_wiimote_box->setLayout(m_wiimote_layout);
 
   m_wiimote_passthrough = new QRadioButton(tr("Passthrough a Bluetooth adapter"));
-  m_wiimote_sync = new QPushButton(tr("Sync"));
-  m_wiimote_reset = new QPushButton(tr("Reset"));
-  m_wiimote_refresh = new QPushButton(tr("Refresh"));
+  m_wiimote_sync = new NonDefaultQPushButton(tr("Sync"));
+  m_wiimote_reset = new NonDefaultQPushButton(tr("Reset"));
+  m_wiimote_refresh = new NonDefaultQPushButton(tr("Refresh"));
   m_wiimote_pt_labels[0] = new QLabel(tr("Sync real Wii Remotes and pair them"));
   m_wiimote_pt_labels[1] = new QLabel(tr("Reset all saved Wii Remote pairings"));
   m_wiimote_emu = new QRadioButton(tr("Emulate the Wii's Bluetooth adapter"));
@@ -123,7 +124,7 @@ void WiimoteControllersWidget::CreateLayout()
   {
     auto* wm_label = m_wiimote_labels[i] = new QLabel(tr("Wii Remote %1").arg(i + 1));
     auto* wm_box = m_wiimote_boxes[i] = new QComboBox();
-    auto* wm_button = m_wiimote_buttons[i] = new QPushButton(tr("Configure"));
+    auto* wm_button = m_wiimote_buttons[i] = new NonDefaultQPushButton(tr("Configure"));
 
     for (const auto& item : {tr("None"), tr("Emulated Wii Remote"), tr("Real Wii Remote")})
       wm_box->addItem(item);

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="QtUtils\FlowLayout.cpp" />
     <ClCompile Include="QtUtils\ImageConverter.cpp" />
     <ClCompile Include="QtUtils\ModalMessageBox.cpp" />
+    <ClCompile Include="QtUtils\NonDefaultQPushButton.cpp" />
     <ClCompile Include="QtUtils\PartiallyClosableTabWidget.cpp" />
     <ClCompile Include="QtUtils\UTF8CodePointCountValidator.cpp" />
     <ClCompile Include="QtUtils\WindowActivationEventFilter.cpp" />
@@ -223,6 +224,7 @@
     <ClInclude Include="QtUtils\FlowLayout.h" />
     <ClInclude Include="QtUtils\ImageConverter.h" />
     <ClInclude Include="QtUtils\ModalMessageBox.h" />
+    <ClInclude Include="QtUtils\NonDefaultQPushButton.h" />
     <ClInclude Include="QtUtils\QueueOnObject.h" />
     <ClInclude Include="QtUtils\RunOnObject.h" />
     <ClInclude Include="QtUtils\SignalBlocking.h" />

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -21,6 +21,7 @@
 #include "Common/Swap.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
 
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
 
 #include "VideoCommon/BPMemory.h"
@@ -82,9 +83,9 @@ void FIFOAnalyzer::CreateWidgets()
 
   m_search_box = new QGroupBox(tr("Search Current Object"));
   m_search_edit = new QLineEdit;
-  m_search_new = new QPushButton(tr("Search"));
-  m_search_next = new QPushButton(tr("Next Match"));
-  m_search_previous = new QPushButton(tr("Previous Match"));
+  m_search_new = new NonDefaultQPushButton(tr("Search"));
+  m_search_next = new NonDefaultQPushButton(tr("Next Match"));
+  m_search_previous = new NonDefaultQPushButton(tr("Previous Match"));
   m_search_label = new QLabel;
 
   m_search_next->setEnabled(false);

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -41,6 +41,7 @@
 #include "DolphinQt/GCMemcardCreateNewDialog.h"
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 
 using namespace ExpansionInterface;
 
@@ -106,9 +107,9 @@ void GCMemcardManager::CreateWidgets()
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
   // Actions
-  m_select_button = new QPushButton;
-  m_copy_button = new QPushButton;
-  m_delete_button = new QPushButton(tr("&Delete"));
+  m_select_button = new NonDefaultQPushButton;
+  m_copy_button = new NonDefaultQPushButton;
+  m_delete_button = new NonDefaultQPushButton(tr("&Delete"));
 
   m_export_button = new QToolButton(this);
   m_export_menu = new QMenu(m_export_button);
@@ -122,8 +123,8 @@ void GCMemcardManager::CreateWidgets()
   m_export_button->setPopupMode(QToolButton::MenuButtonPopup);
   m_export_button->setMenu(m_export_menu);
 
-  m_import_button = new QPushButton(tr("&Import..."));
-  m_fix_checksums_button = new QPushButton(tr("Fix Checksums"));
+  m_import_button = new NonDefaultQPushButton(tr("&Import..."));
+  m_fix_checksums_button = new NonDefaultQPushButton(tr("Fix Checksums"));
 
   auto* layout = new QGridLayout;
 
@@ -131,8 +132,8 @@ void GCMemcardManager::CreateWidgets()
   {
     m_slot_group[slot] = new QGroupBox(slot == Slot::A ? tr("Slot A") : tr("Slot B"));
     m_slot_file_edit[slot] = new QLineEdit;
-    m_slot_open_button[slot] = new QPushButton(tr("&Open..."));
-    m_slot_create_button[slot] = new QPushButton(tr("&Create..."));
+    m_slot_open_button[slot] = new NonDefaultQPushButton(tr("&Open..."));
+    m_slot_create_button[slot] = new NonDefaultQPushButton(tr("&Create..."));
     m_slot_table[slot] = new QTableWidget;
     m_slot_table[slot]->setTabKeyNavigation(false);
     m_slot_stat_label[slot] = new QLabel;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -25,6 +25,7 @@
 #include "Core/ConfigManager.h"
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
 
 NetPlayBrowser::NetPlayBrowser(QWidget* parent) : QDialog(parent)
@@ -84,7 +85,7 @@ void NetPlayBrowser::CreateWidgets()
 
   m_status_label = new QLabel;
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-  m_button_refresh = new QPushButton(tr("Refresh"));
+  m_button_refresh = new NonDefaultQPushButton(tr("Refresh"));
   m_edit_name = new QLineEdit;
   m_edit_game_id = new QLineEdit;
   m_check_hide_incompatible = new QCheckBox(tr("Hide Incompatible Sessions"));

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -21,6 +21,7 @@
 #include "Core/NetPlayProto.h"
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/UTF8CodePointCountValidator.h"
 #include "DolphinQt/Settings.h"
 
@@ -87,7 +88,7 @@ void NetPlaySetupDialog::CreateMainLayout()
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Cancel);
   m_nickname_edit = new QLineEdit;
   m_connection_type = new QComboBox;
-  m_reset_traversal_button = new QPushButton(tr("Reset Traversal Settings"));
+  m_reset_traversal_button = new NonDefaultQPushButton(tr("Reset Traversal Settings"));
   m_tab_widget = new QTabWidget;
 
   m_nickname_edit->setValidator(
@@ -101,7 +102,7 @@ void NetPlaySetupDialog::CreateMainLayout()
   m_ip_edit = new QLineEdit;
   m_connect_port_label = new QLabel(tr("Port:"));
   m_connect_port_box = new QSpinBox;
-  m_connect_button = new QPushButton(tr("Connect"));
+  m_connect_button = new NonDefaultQPushButton(tr("Connect"));
 
   m_connect_port_box->setMaximum(65535);
 
@@ -144,7 +145,7 @@ void NetPlaySetupDialog::CreateMainLayout()
   m_host_upnp = new QCheckBox(tr("Forward port (UPnP)"));
 #endif
   m_host_games = new QListWidget;
-  m_host_button = new QPushButton(tr("Host"));
+  m_host_button = new NonDefaultQPushButton(tr("Host"));
 
   m_host_port_box->setMaximum(65535);
   m_host_force_port_box->setMaximum(65535);

--- a/Source/Core/DolphinQt/QtUtils/NonDefaultQPushButton.cpp
+++ b/Source/Core/DolphinQt/QtUtils/NonDefaultQPushButton.cpp
@@ -1,0 +1,11 @@
+// Copyright 2022 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
+
+NonDefaultQPushButton::NonDefaultQPushButton(const QString& text, QWidget* parent)
+    : QPushButton(text, parent)
+{
+  this->setAutoDefault(false);
+}

--- a/Source/Core/DolphinQt/QtUtils/NonDefaultQPushButton.h
+++ b/Source/Core/DolphinQt/QtUtils/NonDefaultQPushButton.h
@@ -1,0 +1,15 @@
+// Copyright 2022 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QPushButton>
+
+// A custom QPushButton that sets the autoDefault option to false
+// This makes sure random buttons are not highlighted anymore by default
+class NonDefaultQPushButton : public QPushButton
+{
+public:
+  explicit NonDefaultQPushButton(const QString& text = {}, QWidget* parent = nullptr);
+};

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -13,6 +13,7 @@
 
 #include "Common/FileUtil.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "UICommon/ResourcePack/Manager.h"
 
 ResourcePackManager::ResourcePackManager(QWidget* widget) : QDialog(widget)
@@ -34,12 +35,12 @@ void ResourcePackManager::CreateWidgets()
   m_table_widget = new QTableWidget;
   m_table_widget->setTabKeyNavigation(false);
 
-  m_open_directory_button = new QPushButton(tr("Open Directory..."));
-  m_change_button = new QPushButton(tr("Install"));
-  m_remove_button = new QPushButton(tr("Remove"));
-  m_refresh_button = new QPushButton(tr("Refresh"));
-  m_priority_up_button = new QPushButton(tr("Up"));
-  m_priority_down_button = new QPushButton(tr("Down"));
+  m_open_directory_button = new NonDefaultQPushButton(tr("Open Directory..."));
+  m_change_button = new NonDefaultQPushButton(tr("Install"));
+  m_remove_button = new NonDefaultQPushButton(tr("Remove"));
+  m_refresh_button = new NonDefaultQPushButton(tr("Refresh"));
+  m_priority_up_button = new NonDefaultQPushButton(tr("Up"));
+  m_priority_down_button = new NonDefaultQPushButton(tr("Down"));
 
   auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok);
 

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -36,6 +36,7 @@
 #include "DolphinQt/GCMemcardManager.h"
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/BroadbandAdapterSettingsDialog.h"
 
@@ -94,7 +95,7 @@ void GameCubePane::CreateWidgets()
   {
     m_slot_combos[slot] = new QComboBox(device_box);
     m_slot_combos[slot]->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
-    m_slot_buttons[slot] = new QPushButton(tr("..."), device_box);
+    m_slot_buttons[slot] = new NonDefaultQPushButton(tr("..."), device_box);
     m_slot_buttons[slot]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   }
 
@@ -146,7 +147,7 @@ void GameCubePane::CreateWidgets()
   gba_row++;
 
   m_gba_bios_edit = new QLineEdit();
-  m_gba_browse_bios = new QPushButton(QStringLiteral("..."));
+  m_gba_browse_bios = new NonDefaultQPushButton(QStringLiteral("..."));
   gba_layout->addWidget(new QLabel(tr("BIOS:")), gba_row, 0);
   gba_layout->addWidget(m_gba_bios_edit, gba_row, 1);
   gba_layout->addWidget(m_gba_browse_bios, gba_row, 2);
@@ -155,7 +156,7 @@ void GameCubePane::CreateWidgets()
   for (size_t i = 0; i < m_gba_rom_edits.size(); ++i)
   {
     m_gba_rom_edits[i] = new QLineEdit();
-    m_gba_browse_roms[i] = new QPushButton(QStringLiteral("..."));
+    m_gba_browse_roms[i] = new NonDefaultQPushButton(QStringLiteral("..."));
     gba_layout->addWidget(new QLabel(tr("Port %1 ROM:").arg(i + 1)), gba_row, 0);
     gba_layout->addWidget(m_gba_rom_edits[i], gba_row, 1);
     gba_layout->addWidget(m_gba_browse_roms[i], gba_row, 2);
@@ -167,7 +168,7 @@ void GameCubePane::CreateWidgets()
   gba_row++;
 
   m_gba_saves_edit = new QLineEdit();
-  m_gba_browse_saves = new QPushButton(QStringLiteral("..."));
+  m_gba_browse_saves = new NonDefaultQPushButton(QStringLiteral("..."));
   gba_layout->addWidget(new QLabel(tr("Saves:")), gba_row, 0);
   gba_layout->addWidget(m_gba_saves_edit, gba_row, 1);
   gba_layout->addWidget(m_gba_browse_saves, gba_row, 2);

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -23,6 +23,7 @@
 #include "Core/PowerPC/PowerPC.h"
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
@@ -226,7 +227,8 @@ void GeneralPane::CreateAnalytics()
   m_main_layout->addWidget(analytics_group);
 
   m_checkbox_enable_analytics = new QCheckBox(tr("Enable Usage Statistics Reporting"));
-  m_button_generate_new_identity = new QPushButton(tr("Generate a New Statistics Identity"));
+  m_button_generate_new_identity =
+      new NonDefaultQPushButton(tr("Generate a New Statistics Identity"));
   analytics_group_layout->addWidget(m_checkbox_enable_analytics);
   analytics_group_layout->addWidget(m_button_generate_new_identity);
 }

--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -19,6 +19,7 @@
 #include "Core/Config/UISettings.h"
 
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
 
 PathPane::PathPane(QWidget* parent) : QWidget(parent)
@@ -155,8 +156,8 @@ QGroupBox* PathPane::MakeGameFolderBox()
   QHBoxLayout* hlayout = new QHBoxLayout;
 
   hlayout->addStretch();
-  QPushButton* add = new QPushButton(tr("Add..."));
-  m_remove_path = new QPushButton(tr("Remove"));
+  QPushButton* add = new NonDefaultQPushButton(tr("Add..."));
+  m_remove_path = new NonDefaultQPushButton(tr("Remove"));
 
   m_remove_path->setEnabled(false);
 
@@ -197,7 +198,7 @@ QGridLayout* PathPane::MakePathsLayout()
           [this] { Settings::Instance().SetDefaultGame(m_game_edit->text()); });
   connect(&Settings::Instance(), &Settings::DefaultGameChanged, this,
           [this](const QString& path) { m_game_edit->setText(path); });
-  QPushButton* game_open = new QPushButton(QStringLiteral("..."));
+  QPushButton* game_open = new NonDefaultQPushButton(QStringLiteral("..."));
   connect(game_open, &QPushButton::clicked, this, &PathPane::BrowseDefaultGame);
   layout->addWidget(new QLabel(tr("Default ISO:")), 0, 0);
   layout->addWidget(m_game_edit, 0, 1);
@@ -205,7 +206,7 @@ QGridLayout* PathPane::MakePathsLayout()
 
   m_nand_edit = new QLineEdit(QString::fromStdString(File::GetUserPath(D_WIIROOT_IDX)));
   connect(m_nand_edit, &QLineEdit::editingFinished, this, &PathPane::OnNANDPathChanged);
-  QPushButton* nand_open = new QPushButton(QStringLiteral("..."));
+  QPushButton* nand_open = new NonDefaultQPushButton(QStringLiteral("..."));
   connect(nand_open, &QPushButton::clicked, this, &PathPane::BrowseWiiNAND);
   layout->addWidget(new QLabel(tr("Wii NAND Root:")), 1, 0);
   layout->addWidget(m_nand_edit, 1, 1);
@@ -214,7 +215,7 @@ QGridLayout* PathPane::MakePathsLayout()
   m_dump_edit = new QLineEdit(QString::fromStdString(File::GetUserPath(D_DUMP_IDX)));
   connect(m_dump_edit, &QLineEdit::editingFinished,
           [=] { Config::SetBase(Config::MAIN_DUMP_PATH, m_dump_edit->text().toStdString()); });
-  QPushButton* dump_open = new QPushButton(QStringLiteral("..."));
+  QPushButton* dump_open = new NonDefaultQPushButton(QStringLiteral("..."));
   connect(dump_open, &QPushButton::clicked, this, &PathPane::BrowseDump);
   layout->addWidget(new QLabel(tr("Dump Path:")), 2, 0);
   layout->addWidget(m_dump_edit, 2, 1);
@@ -223,7 +224,7 @@ QGridLayout* PathPane::MakePathsLayout()
   m_load_edit = new QLineEdit(QString::fromStdString(File::GetUserPath(D_LOAD_IDX)));
   connect(m_load_edit, &QLineEdit::editingFinished,
           [=] { Config::SetBase(Config::MAIN_LOAD_PATH, m_load_edit->text().toStdString()); });
-  QPushButton* load_open = new QPushButton(QStringLiteral("..."));
+  QPushButton* load_open = new NonDefaultQPushButton(QStringLiteral("..."));
   connect(load_open, &QPushButton::clicked, this, &PathPane::BrowseLoad);
   layout->addWidget(new QLabel(tr("Load Path:")), 3, 0);
   layout->addWidget(m_load_edit, 3, 1);
@@ -234,7 +235,7 @@ QGridLayout* PathPane::MakePathsLayout()
   connect(m_resource_pack_edit, &QLineEdit::editingFinished, [=] {
     Config::SetBase(Config::MAIN_RESOURCEPACK_PATH, m_resource_pack_edit->text().toStdString());
   });
-  QPushButton* resource_pack_open = new QPushButton(QStringLiteral("..."));
+  QPushButton* resource_pack_open = new NonDefaultQPushButton(QStringLiteral("..."));
   connect(resource_pack_open, &QPushButton::clicked, this, &PathPane::BrowseResourcePack);
   layout->addWidget(new QLabel(tr("Resource Pack Path:")), 4, 0);
   layout->addWidget(m_resource_pack_edit, 4, 1);
@@ -242,7 +243,7 @@ QGridLayout* PathPane::MakePathsLayout()
 
   m_sdcard_edit = new QLineEdit(QString::fromStdString(File::GetUserPath(F_WIISDCARD_IDX)));
   connect(m_sdcard_edit, &QLineEdit::editingFinished, this, &PathPane::OnSDCardPathChanged);
-  QPushButton* sdcard_open = new QPushButton(QStringLiteral("..."));
+  QPushButton* sdcard_open = new NonDefaultQPushButton(QStringLiteral("..."));
   connect(sdcard_open, &QPushButton::clicked, this, &PathPane::BrowseSDCard);
   layout->addWidget(new QLabel(tr("SD Card Path:")), 5, 0);
   layout->addWidget(m_sdcard_edit, 5, 1);
@@ -251,7 +252,7 @@ QGridLayout* PathPane::MakePathsLayout()
   m_wfs_edit = new QLineEdit(QString::fromStdString(File::GetUserPath(D_WFSROOT_IDX)));
   connect(m_load_edit, &QLineEdit::editingFinished,
           [=] { Config::SetBase(Config::MAIN_WFS_PATH, m_wfs_edit->text().toStdString()); });
-  QPushButton* wfs_open = new QPushButton(QStringLiteral("..."));
+  QPushButton* wfs_open = new NonDefaultQPushButton(QStringLiteral("..."));
   connect(wfs_open, &QPushButton::clicked, this, &PathPane::BrowseWFS);
   layout->addWidget(new QLabel(tr("WFS Path:")), 6, 0);
   layout->addWidget(m_wfs_edit, 6, 1);

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -23,6 +23,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/USBDeviceAddToWhitelistDialog.h"
 
@@ -164,8 +165,8 @@ void WiiPane::CreateWhitelistedUSBPassthroughDevices()
   m_whitelist_usb_list = new QListWidget();
   whitelist_layout->addWidget(m_whitelist_usb_list, 0, 0, 1, -1);
   whitelist_layout->setColumnStretch(0, 1);
-  m_whitelist_usb_add_button = new QPushButton(tr("Add..."));
-  m_whitelist_usb_remove_button = new QPushButton(tr("Remove"));
+  m_whitelist_usb_add_button = new NonDefaultQPushButton(tr("Add..."));
+  m_whitelist_usb_remove_button = new NonDefaultQPushButton(tr("Remove"));
   whitelist_layout->addWidget(m_whitelist_usb_add_button, 1, 1);
   whitelist_layout->addWidget(m_whitelist_usb_remove_button, 1, 2);
   whitelist_layout->addWidget(m_whitelist_usb_list, 0, 0);


### PR DESCRIPTION
As described in [issue 11184](https://bugs.dolphin-emu.org/issues/11184), the first button on each pane, widget or window gets highlighted and selected. This is the default behaviour for QPushButtons in a QDialog. By setting the autoDefault to false for the buttons, the close or cancel button in the bottom becomes the default which is then highlighted. This makes more sense than highlighting the first random button. This also makes it so that when pressing enter, the window closes instead of performing whatever functionality the first button on a window has.