### PR TITLE
Android: Actually use a thread for DirectoryInitialization

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -55,8 +55,7 @@ public final class DirectoryInitialization
     directoryState.setValue(DirectoryInitializationState.INITIALIZING);
 
     // Can take a few seconds to run, so don't block UI thread.
-    //noinspection TrivialFunctionalExpressionUsage
-    ((Runnable) () -> init(context)).run();
+    new Thread(() -> init(context)).start();
   }
 
   private static void init(Context context)


### PR DESCRIPTION
`((Runnable) () -> init(context)).run()` is just a more complicated way of writing `init(context)`, and doesn't on its own launch a thread.