### PR TITLE
Test (for FifoCI): Always dump frames as images

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -168,7 +168,7 @@ bool IsFile(const std::string& path)
 // Doesn't supports deleting a directory
 bool Delete(const std::string& filename, IfAbsentBehavior behavior)
 {
-  INFO_LOG_FMT(COMMON, "Delete: file {}", filename);
+  DEBUG_LOG_FMT(COMMON, "Delete: file {}", filename);
 
 #ifdef ANDROID
   if (StringBeginsWith(filename, "content://"))
@@ -219,7 +219,7 @@ bool Delete(const std::string& filename, IfAbsentBehavior behavior)
 // Returns true if successful, or path already exists.
 bool CreateDir(const std::string& path)
 {
-  INFO_LOG_FMT(COMMON, "CreateDir: directory {}", path);
+  DEBUG_LOG_FMT(COMMON, "CreateDir: directory {}", path);
 #ifdef _WIN32
   if (::CreateDirectory(UTF8ToTStr(path).c_str(), nullptr))
     return true;
@@ -252,11 +252,11 @@ bool CreateDir(const std::string& path)
 bool CreateFullPath(const std::string& fullPath)
 {
   int panicCounter = 100;
-  INFO_LOG_FMT(COMMON, "CreateFullPath: path {}", fullPath);
+  DEBUG_LOG_FMT(COMMON, "CreateFullPath: path {}", fullPath);
 
   if (Exists(fullPath))
   {
-    INFO_LOG_FMT(COMMON, "CreateFullPath: path exists {}", fullPath);
+    DEBUG_LOG_FMT(COMMON, "CreateFullPath: path exists {}", fullPath);
     return true;
   }
 
@@ -289,7 +289,7 @@ bool CreateFullPath(const std::string& fullPath)
 // Deletes a directory filename, returns true on success
 bool DeleteDir(const std::string& filename, IfAbsentBehavior behavior)
 {
-  INFO_LOG_FMT(COMMON, "DeleteDir: directory {}", filename);
+  DEBUG_LOG_FMT(COMMON, "DeleteDir: directory {}", filename);
 
   // Return true because we care about the directory not being there, not the actual delete.
   if (!File::Exists(filename))
@@ -348,7 +348,7 @@ static bool AttemptMaxTimesWithExponentialDelay(int max_attempts, std::chrono::m
 // renames file srcFilename to destFilename, returns true on success
 bool Rename(const std::string& srcFilename, const std::string& destFilename)
 {
-  INFO_LOG_FMT(COMMON, "Rename: {} --> {}", srcFilename, destFilename);
+  DEBUG_LOG_FMT(COMMON, "Rename: {} --> {}", srcFilename, destFilename);
 #ifdef _WIN32
   const std::wstring source_wstring = UTF8ToTStr(srcFilename);
   const std::wstring destination_wstring = UTF8ToTStr(destFilename);
@@ -357,7 +357,8 @@ bool Rename(const std::string& srcFilename, const std::string& destFilename)
   // Retry the operation with increasing delays, and if none of them work there's probably a
   // persistent problem.
   const bool success = AttemptMaxTimesWithExponentialDelay(
-      3, std::chrono::milliseconds(5), "Rename", [&source_wstring, &destination_wstring] {
+      3, std::chrono::milliseconds(5), fmt::format("Rename {} --> {}", srcFilename, destFilename),
+      [&source_wstring, &destination_wstring] {
         if (ReplaceFile(destination_wstring.c_str(), source_wstring.c_str(), nullptr,
                         REPLACEFILE_IGNORE_MERGE_ERRORS, nullptr, nullptr))
         {
@@ -421,7 +422,7 @@ bool RenameSync(const std::string& srcFilename, const std::string& destFilename)
 // copies file source_path to destination_path, returns true on success
 bool Copy(const std::string& source_path, const std::string& destination_path)
 {
-  INFO_LOG_FMT(COMMON, "Copy: {} --> {}", source_path, destination_path);
+  DEBUG_LOG_FMT(COMMON, "Copy: {} --> {}", source_path, destination_path);
 #ifdef _WIN32
   if (CopyFile(UTF8ToTStr(source_path).c_str(), UTF8ToTStr(destination_path).c_str(), FALSE))
     return true;
@@ -473,7 +474,7 @@ u64 GetSize(FILE* f)
 // creates an empty file filename, returns true on success
 bool CreateEmptyFile(const std::string& filename)
 {
-  INFO_LOG_FMT(COMMON, "CreateEmptyFile: {}", filename);
+  DEBUG_LOG_FMT(COMMON, "CreateEmptyFile: {}", filename);
 
   if (!File::IOFile(filename, "wb"))
   {
@@ -495,7 +496,7 @@ FSTEntry ScanDirectoryTree(std::string directory, bool recursive)
     directory.pop_back();
 #endif
 
-  INFO_LOG_FMT(COMMON, "ScanDirectoryTree: directory {}", directory);
+  DEBUG_LOG_FMT(COMMON, "ScanDirectoryTree: directory {}", directory);
   FSTEntry parent_entry;
   parent_entry.physicalName = directory;
   parent_entry.isDirectory = true;
@@ -596,7 +597,7 @@ FSTEntry ScanDirectoryTree(std::string directory, bool recursive)
 // Deletes the given directory and anything under it. Returns true on success.
 bool DeleteDirRecursively(const std::string& directory)
 {
-  INFO_LOG_FMT(COMMON, "DeleteDirRecursively: {}", directory);
+  DEBUG_LOG_FMT(COMMON, "DeleteDirRecursively: {}", directory);
   bool success = true;
 
 #ifdef _WIN32

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -87,7 +87,7 @@ static void SetPixelColorOnly(u32 offset, u8* rgb)
   break;
   case PixelFormat::RGB565_Z16:
   {
-    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    // TODO: RGB565_Z16 is not supported correctly yet
     u32 src = *(u32*)rgb;
     u32* dst = (u32*)&efb[offset];
     u32 val = *dst & 0xff000000;
@@ -129,7 +129,7 @@ static void SetPixelAlphaColor(u32 offset, u8* color)
   break;
   case PixelFormat::RGB565_Z16:
   {
-    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    // TODO: RGB565_Z16 is not supported correctly yet
     u32 src = *(u32*)color;
     u32* dst = (u32*)&efb[offset];
     u32 val = *dst & 0xff000000;
@@ -161,7 +161,7 @@ static u32 GetPixelColor(u32 offset)
            Convert6To8((src >> 18) & 0x3f) << 24;   // Red
 
   case PixelFormat::RGB565_Z16:
-    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    // TODO: RGB565_Z16 is not supported correctly yet
     return 0xff | ((src & 0x00ffffff) << 8);
 
   default:
@@ -186,7 +186,7 @@ static void SetPixelDepth(u32 offset, u32 depth)
   break;
   case PixelFormat::RGB565_Z16:
   {
-    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    // TODO: RGB565_Z16 is not supported correctly yet
     u32* dst = (u32*)&efb[offset];
     u32 val = *dst & 0xff000000;
     val |= depth & 0x00ffffff;
@@ -214,7 +214,7 @@ static u32 GetPixelDepth(u32 offset)
   break;
   case PixelFormat::RGB565_Z16:
   {
-    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    // TODO: RGB565_Z16 is not supported correctly yet
     depth = (*(u32*)&efb[offset]) & 0x00ffffff;
   }
   break;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -69,7 +69,7 @@ void VideoConfig::Refresh()
   bCacheHiresTextures = Config::Get(Config::GFX_CACHE_HIRES_TEXTURES);
   bDumpEFBTarget = Config::Get(Config::GFX_DUMP_EFB_TARGET);
   bDumpXFBTarget = Config::Get(Config::GFX_DUMP_XFB_TARGET);
-  bDumpFramesAsImages = Config::Get(Config::GFX_DUMP_FRAMES_AS_IMAGES);
+  bDumpFramesAsImages = true;  // Config::Get(Config::GFX_DUMP_FRAMES_AS_IMAGES);
   bUseFFV1 = Config::Get(Config::GFX_USE_FFV1);
   sDumpFormat = Config::Get(Config::GFX_DUMP_FORMAT);
   sDumpCodec = Config::Get(Config::GFX_DUMP_CODEC);


### PR DESCRIPTION
I noticed the [uberogl config](https://github.com/dolphin-emu/fifoci/blob/1a4734d36842db9e75d0dd67379b6237df3c4e52/runner/linux/Config-uberogl/GFX.ini) does not have `DumpFramesAsImages = True`, unlike the [regular ogl config](https://github.com/dolphin-emu/fifoci/blob/1a4734d36842db9e75d0dd67379b6237df3c4e52/runner/linux/Config-ogl/GFX.ini).  I suspect this is what causes duplicate frames for fifoci-uberogl-lin-radeon, but this PR is to confirm it via the PR fifoci runner (before I submit a PR to the fifoci repo to add the configuration, which does not trigger a test build).

This is based atop the reduce info logspam PR (#10504) so that the fifoci log can be checked if needed.  I actually noticed this while looking at its `pr-fifoci-uberogl-lin-radeon` log and seeing ffmpeg stuff in it.