### PR TITLE
Android: Only use getActionIndex for ACTION_POINTER_DOWN/ACTION_POINTER_UP

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -198,14 +198,17 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
       return onTouchWhileEditing(event);
     }
 
-    int pointerIndex = event.getActionIndex();
+    int action = event.getActionMasked();
+    boolean firstPointer = action != MotionEvent.ACTION_POINTER_DOWN &&
+            action != MotionEvent.ACTION_POINTER_UP;
+    int pointerIndex = firstPointer ? 0 : event.getActionIndex();
     // Tracks if any button/joystick is pressed down
     boolean pressed = false;
 
     for (InputOverlayDrawableButton button : overlayButtons)
     {
       // Determine the button state to apply based on the MotionEvent action flag.
-      switch (event.getAction() & MotionEvent.ACTION_MASK)
+      switch (action)
       {
         case MotionEvent.ACTION_DOWN:
         case MotionEvent.ACTION_POINTER_DOWN:

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableButton.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableButton.java
@@ -71,22 +71,19 @@ public final class InputOverlayDrawableButton
 
   public void onConfigureTouch(MotionEvent event)
   {
-    int pointerIndex = event.getActionIndex();
-    int fingerPositionX = (int) event.getX(pointerIndex);
-    int fingerPositionY = (int) event.getY(pointerIndex);
     switch (event.getAction())
     {
       case MotionEvent.ACTION_DOWN:
-        mPreviousTouchX = fingerPositionX;
-        mPreviousTouchY = fingerPositionY;
+        mPreviousTouchX = (int) event.getX();
+        mPreviousTouchY = (int) event.getY();
         break;
       case MotionEvent.ACTION_MOVE:
-        mControlPositionX += fingerPositionX - mPreviousTouchX;
-        mControlPositionY += fingerPositionY - mPreviousTouchY;
+        mControlPositionX += (int) event.getX() - mPreviousTouchX;
+        mControlPositionY += (int) event.getY() - mPreviousTouchY;
         setBounds(mControlPositionX, mControlPositionY, getWidth() + mControlPositionX,
                 getHeight() + mControlPositionY);
-        mPreviousTouchX = fingerPositionX;
-        mPreviousTouchY = fingerPositionY;
+        mPreviousTouchX = (int) event.getX();
+        mPreviousTouchY = (int) event.getY();
         break;
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableDpad.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableDpad.java
@@ -149,22 +149,19 @@ public final class InputOverlayDrawableDpad
 
   public void onConfigureTouch(MotionEvent event)
   {
-    int pointerIndex = event.getActionIndex();
-    int fingerPositionX = (int) event.getX(pointerIndex);
-    int fingerPositionY = (int) event.getY(pointerIndex);
     switch (event.getAction())
     {
       case MotionEvent.ACTION_DOWN:
-        mPreviousTouchX = fingerPositionX;
-        mPreviousTouchY = fingerPositionY;
+        mPreviousTouchX = (int) event.getX();
+        mPreviousTouchY = (int) event.getY();
         break;
       case MotionEvent.ACTION_MOVE:
-        mControlPositionX += fingerPositionX - mPreviousTouchX;
-        mControlPositionY += fingerPositionY - mPreviousTouchY;
+        mControlPositionX += (int) event.getX() - mPreviousTouchX;
+        mControlPositionY += (int) event.getY() - mPreviousTouchY;
         setBounds(mControlPositionX, mControlPositionY, getWidth() + mControlPositionX,
                 getHeight() + mControlPositionY);
-        mPreviousTouchX = fingerPositionX;
-        mPreviousTouchY = fingerPositionY;
+        mPreviousTouchX = (int) event.getX();
+        mPreviousTouchY = (int) event.getY();
         break;
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableJoystick.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableJoystick.java
@@ -95,10 +95,13 @@ public final class InputOverlayDrawableJoystick
   public boolean TrackEvent(MotionEvent event)
   {
     boolean reCenter = BooleanSetting.MAIN_JOYSTICK_REL_CENTER.getBooleanGlobal();
-    int pointerIndex = event.getActionIndex();
+    int action = event.getActionMasked();
+    boolean firstPointer = action != MotionEvent.ACTION_POINTER_DOWN &&
+            action != MotionEvent.ACTION_POINTER_UP;
+    int pointerIndex = firstPointer ? 0 : event.getActionIndex();
     boolean pressed = false;
 
-    switch (event.getAction() & MotionEvent.ACTION_MASK)
+    switch (action)
     {
       case MotionEvent.ACTION_DOWN:
       case MotionEvent.ACTION_POINTER_DOWN:
@@ -163,18 +166,15 @@ public final class InputOverlayDrawableJoystick
 
   public void onConfigureTouch(MotionEvent event)
   {
-    int pointerIndex = event.getActionIndex();
-    int fingerPositionX = (int) event.getX(pointerIndex);
-    int fingerPositionY = (int) event.getY(pointerIndex);
     switch (event.getAction())
     {
       case MotionEvent.ACTION_DOWN:
-        mPreviousTouchX = fingerPositionX;
-        mPreviousTouchY = fingerPositionY;
+        mPreviousTouchX = (int) event.getX();
+        mPreviousTouchY = (int) event.getY();
         break;
       case MotionEvent.ACTION_MOVE:
-        int deltaX = fingerPositionX - mPreviousTouchX;
-        int deltaY = fingerPositionY - mPreviousTouchY;
+        int deltaX = (int) event.getX() - mPreviousTouchX;
+        int deltaY = (int) event.getY() - mPreviousTouchY;
         mControlPositionX += deltaX;
         mControlPositionY += deltaY;
         setBounds(new Rect(mControlPositionX, mControlPositionY,
@@ -187,8 +187,8 @@ public final class InputOverlayDrawableJoystick
         setOrigBounds(new Rect(new Rect(mControlPositionX, mControlPositionY,
                 mOuterBitmap.getIntrinsicWidth() + mControlPositionX,
                 mOuterBitmap.getIntrinsicHeight() + mControlPositionY)));
-        mPreviousTouchX = fingerPositionX;
-        mPreviousTouchY = fingerPositionY;
+        mPreviousTouchX = (int) event.getX();
+        mPreviousTouchY = (int) event.getY();
         break;
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
@@ -82,9 +82,12 @@ public class InputOverlayPointer
 
   public void onTouch(MotionEvent event)
   {
-    int pointerIndex = event.getActionIndex();
+    int action = event.getActionMasked();
+    boolean firstPointer = action != MotionEvent.ACTION_POINTER_DOWN &&
+            action != MotionEvent.ACTION_POINTER_UP;
+    int pointerIndex = firstPointer ? 0 : event.getActionIndex();
 
-    switch (event.getAction() & MotionEvent.ACTION_MASK)
+    switch (action)
     {
       case MotionEvent.ACTION_DOWN:
       case MotionEvent.ACTION_POINTER_DOWN:


### PR DESCRIPTION
According to the documentation, `getActionIndex` should only be used with `ACTION_POINTER_DOWN` and `ACTION_POINTER_UP`. We've had a few crashes reported in the Play Console regarding invalid pointer indices for `getY`, and I'm hoping this will help with that.