### PR TITLE
VolumeVerifier: Skip "lacks some data" check for Datel discs

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -136,7 +136,7 @@ Platform VolumeGC::GetVolumeType() const
 
 bool VolumeGC::IsDatelDisc() const
 {
-  return !GetBootDOLOffset(*this, PARTITION_NONE).has_value();
+  return GetGameID() == "DTLX01" || !GetBootDOLOffset(*this, PARTITION_NONE).has_value();
 }
 
 std::array<u8, 20> VolumeGC::GetSyncHash() const

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -767,7 +767,7 @@ void VolumeVerifier::CheckVolumeSize()
   }
 
   if (m_content_index != m_content_offsets.size() || m_group_index != m_groups.size() ||
-      (volume_size_roughly_known && m_biggest_referenced_offset > volume_size))
+      (!m_is_datel && volume_size_roughly_known && m_biggest_referenced_offset > volume_size))
   {
     const bool second_layer_missing = is_disc && volume_size_roughly_known &&
                                       volume_size >= SL_DVD_SIZE && volume_size <= SL_DVD_R_SIZE;


### PR DESCRIPTION
Turns out there's some Freeloader disc for the GC that triggers this despite being a good dump. This warning is mostly intended to catch Wii games that have been truncated at the 4.00 GiB or 4.38 GiB mark anyway, and if someone does have a Datel dump that has been truncated, they'll still get the "unusual size" warning.