### PR TITLE
DiscIO: Don't return GameTDB ID for any Datel disc

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -61,10 +61,21 @@ const FileSystem* VolumeGC::GetFileSystem(const Partition& partition) const
 
 std::string VolumeGC::GetGameTDBID(const Partition& partition) const
 {
-  const std::string game_id = GetGameID(partition);
+  // Datel discs for the GameCube can have one of two different game IDs:
+  //
+  // 1: GNHE5d. (Yes, with a lowercase d.) This game ID is used not only for
+  // all kinds of Datel discs, but also for the licensed release NHL Hitz 2002.
+  //
+  // 2: DTLX01. This game ID is used for a few late Datel releases. Both Action Replay
+  // and FreeLoader are known to have been released under this game ID.
+  //
+  // Since no game ID used for Datel discs uniquely represents one product,
+  // never use the game ID of a Datel disc for looking up the title or cover art.
+  if (IsDatelDisc())
+    return "";
 
-  // Don't return an ID for Datel discs that are using the game ID of NHL Hitz 2002
-  return game_id == "GNHE5d" && IsDatelDisc() ? "" : game_id;
+  // Normal case. Just return the usual game ID.
+  return GetGameID(partition);
 }
 
 Region VolumeGC::GetRegion() const


### PR DESCRIPTION
DTLX01 can be either a Freeloader or Action Replay, so it's inappropriate to always use the same title and cover for it.