### PR TITLE
CMakeLists: Add flag to enable / disable automatic update support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(ENABLE_TESTS "Enables building the unit tests" ON)
 option(ENABLE_VULKAN "Enables vulkan video backend" ON)
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence, show the current game on Discord" ON)
 option(USE_MGBA "Enables GBA controllers emulation using libmgba" ON)
+option(ENABLE_AUTOUPDATE "Enables support for automatic updates" ON)
 
 # Maintainers: if you consider blanket disabling this for your users, please
 # consider the following points:
@@ -534,6 +535,11 @@ endif()
 if(ENABLE_ANALYTICS)
   message(STATUS "Enabling analytics collection (subject to end-user opt-in)")
   add_definitions(-DUSE_ANALYTICS=1)
+endif()
+
+if(ENABLE_AUTOUPDATE)
+  message(STATUS "Enabling automatic update support")
+  add_definitions(-DAUTOUPDATE=1)
 endif()
 
 ########################################

--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -23,10 +23,10 @@ if (APPLE OR WIN32)
   add_subdirectory(UpdaterCommon)
 endif()
 
-if (APPLE)
+if (APPLE AND ENABLE_AUTOUPDATE)
   add_subdirectory(MacUpdater)
 endif()
 
-if (WIN32)
+if (WIN32 AND ENABLE_AUTOUPDATE)
   add_subdirectory(WinUpdater)
 endif()

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -128,8 +128,12 @@ std::string GenerateChangelog(const picojson::array& versions)
 
 bool AutoUpdateChecker::SystemSupportsAutoUpdates()
 {
+#if defined AUTOUPDATE
 #if defined _WIN32 || defined __APPLE__
   return true;
+#else
+  return false;
+#endif
 #else
   return false;
 #endif


### PR DESCRIPTION
This PR introduces a new CMake option (``ENABLE_AUTOUPDATE``) and a new define (``AUTOUPDATE``), which allows one to disable automatic updater support in Windows and macOS builds.