### PR TITLE
MappingCommon: Fix detection of hotkey and conjunction expressions.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -107,16 +107,18 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
 
   for (auto& detection : detections)
   {
-    // Remove since released inputs.
+    // Remove since-released inputs.
     for (auto it = pressed_inputs.begin(); it != pressed_inputs.end();)
     {
-      if (!((*it)->release_time > detection.press_time))
+      if ((*it)->release_time && (*it)->release_time <= detection.press_time)
       {
         handle_release();
         it = pressed_inputs.erase(it);
       }
       else
+      {
         ++it;
+      }
     }
 
     handle_press(detection);


### PR DESCRIPTION
Flawed `optional` logic required inputs eventually be released (relying on since-removed 500ms confirmation delay PR #9685).
This un-breaks generation of hotkey (`@()`) and `&` expressions.