### PR TITLE
Crusade against kilobyte, megabyte, and gigabyte

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -140,7 +140,7 @@
     <string name="wii_screensaver_description">Dims the screen after five minutes of inactivity.</string>
     <string name="sound_mode">Sound</string>
     <string name="insert_sd_card">Insert SD Card</string>
-    <string name="insert_sd_card_description">Supports SD and SDHC. Default size is 128 MB.</string>
+    <string name="insert_sd_card_description">Supports SD and SDHC. Default size is 128 MiB.</string>
     <string name="wii_sd_card_allow_writes">Allow Writes to SD Card</string>
     <string name="wiimote_rumble">Wii Remote Rumble</string>
     <string name="wiimote_volume">Wii Remote Speaker Volume</string>

--- a/Source/Core/Common/CompatPatches.cpp
+++ b/Source/Core/Common/CompatPatches.cpp
@@ -198,7 +198,7 @@ void CompatPatchesInstall(LdrWatcher* watcher)
 {
   watcher->Install({{L"EZFRD64.dll", L"811EZFRD64.DLL"}, [](const LdrDllLoadEvent& event) {
                       // *EZFRD64 is incldued in software packages for cheapo third-party gamepads
-                      // (and gamepad adapters). The module cannot handle its heap being above 4GB,
+                      // (and gamepad adapters). The module cannot handle its heap being above 4GiB,
                       // which tends to happen very often on modern Windows.
                       // NOTE: The patch will always be applied, but it will only actually avoid the
                       // crash if applied before module initialization (i.e. called on the Ldr

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -40,7 +40,7 @@ public:
 //
 // Suitable for caching generated shader bytecode between executions.
 // Not tuned for extreme performance but should be reasonably fast.
-// Does not support keys or values larger than 2GB, which should be reasonable.
+// Does not support keys or values larger than 2GiB, which should be reasonable.
 // Keys must have non-zero length; values can have zero length.
 
 // K and V are some POD type

--- a/Source/Core/Common/SDCardUtil.cpp
+++ b/Source/Core/Common/SDCardUtil.cpp
@@ -194,14 +194,15 @@ static bool write_empty(File::IOFile& file, std::size_t count)
   return true;
 }
 
-bool SDCardCreate(u64 disk_size /*in MB*/, const std::string& filename)
+bool SDCardCreate(u64 disk_size /*in MiB*/, const std::string& filename)
 {
-  // Convert MB to bytes
+  // Convert MiB to bytes
   disk_size *= 1024 * 1024;
 
   if (disk_size < 0x800000 || disk_size > 0x800000000ULL)
   {
-    ERROR_LOG_FMT(COMMON, "Trying to create SD Card image of size {}MB is out of range (8MB-32GB)",
+    ERROR_LOG_FMT(COMMON,
+                  "Trying to create SD Card image of size {}MiB is out of range (8MiB-32GiB)",
                   disk_size / (1024 * 1024));
     return false;
   }

--- a/Source/Core/Common/SDCardUtil.h
+++ b/Source/Core/Common/SDCardUtil.h
@@ -8,5 +8,5 @@
 
 namespace Common
 {
-bool SDCardCreate(u64 disk_size /*in MB*/, const std::string& filename);
+bool SDCardCreate(u64 disk_size /*in MiB*/, const std::string& filename);
 }  // namespace Common

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -176,7 +176,7 @@ void CBoot::SetupGCMemory()
   // Booted from bootrom. 0xE5207C22 = booted from jtag
   PowerPC::HostWrite_U32(0x0D15EA5E, 0x80000020);
 
-  // Physical Memory Size (24MB on retail)
+  // Physical Memory Size (24MiB on retail)
   PowerPC::HostWrite_U32(Memory::GetRamSizeReal(), 0x80000028);
 
   // Console type - DevKit  (retail ID == 0x00000003) see YAGCD 4.2.1.1.2
@@ -188,7 +188,7 @@ void CBoot::SetupGCMemory()
   // Fake the VI Init of the IPL (YAGCD 4.2.1.4)
   PowerPC::HostWrite_U32(DiscIO::IsNTSC(SConfig::GetInstance().m_region) ? 0 : 1, 0x800000CC);
 
-  PowerPC::HostWrite_U32(0x01000000, 0x800000d0);  // ARAM Size. 16MB main + 4/16/32MB external
+  PowerPC::HostWrite_U32(0x01000000, 0x800000d0);  // ARAM Size. 16MiB main + 4/16/32MiB external
                                                    // (retail consoles have no external ARAM)
 
   PowerPC::HostWrite_U32(0x09a7ec80, 0x800000F8);  // Bus Clock Speed
@@ -378,7 +378,7 @@ bool CBoot::SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type)
 
   Memory::Write_U32(0x0D15EA5E, 0x00000020);                // Another magic word
   Memory::Write_U32(0x00000001, 0x00000024);                // Unknown
-  Memory::Write_U32(Memory::GetRamSizeReal(), 0x00000028);  // MEM1 size 24MB
+  Memory::Write_U32(Memory::GetRamSizeReal(), 0x00000028);  // MEM1 size 24MiB
   const Core::ConsoleType board_model = console_type == IOS::HLE::IOSC::ConsoleType::RVT ?
                                             Core::ConsoleType::NDEV2_1 :
                                             Core::ConsoleType::RVL_Retail3;

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -515,7 +515,7 @@ static void Do_ARAM_DMA()
     DEBUG_LOG_FMT(DSPINTERFACE, "DMA {:08x} bytes from ARAM {:08x} to MRAM {:08x} PC: {:08x}",
                   s_arDMA.Cnt.count, s_arDMA.ARAddr, s_arDMA.MMAddr, PC);
 
-    // Outgoing data from ARAM is mirrored every 64MB (verified on real HW)
+    // Outgoing data from ARAM is mirrored every 64MiB (verified on real HW)
     s_arDMA.ARAddr &= 0x3ffffff;
     s_arDMA.MMAddr &= 0x3ffffff;
 
@@ -562,7 +562,7 @@ static void Do_ARAM_DMA()
     DEBUG_LOG_FMT(DSPINTERFACE, "DMA {:08x} bytes from MRAM {:08x} to ARAM {:08x} PC: {:08x}",
                   s_arDMA.Cnt.count, s_arDMA.MMAddr, s_arDMA.ARAddr, PC);
 
-    // Incoming data into ARAM is mirrored every 64MB (verified on real HW)
+    // Incoming data into ARAM is mirrored every 64MiB (verified on real HW)
     s_arDMA.ARAddr &= 0x3ffffff;
     s_arDMA.MMAddr &= 0x3ffffff;
 

--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -24,7 +24,7 @@ enum DSPInterruptType
 // aram size and mask
 enum
 {
-  ARAM_SIZE = 0x01000000,  // 16 MB
+  ARAM_SIZE = 0x01000000,  // 16 MiB
   ARAM_MASK = 0x00FFFFFF,
 };
 

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -63,7 +63,7 @@ u8* m_pFakeVMEM;
 // s_ram_size is the amount allocated by the emulator, whereas s_ram_size_real
 // is what will be reported in lowmem, and thus used by emulated software.
 // Note: Writing to lowmem is done by IPL. If using retail IPL, it will
-// always be set to 24MB.
+// always be set to 24MiB.
 static u32 s_ram_size_real;
 static u32 s_ram_size;
 static u32 s_ram_mask;
@@ -74,7 +74,7 @@ static u32 s_L1_cache_mask;
 static u32 s_io_size;
 // s_exram_size is the amount allocated by the emulator, whereas s_exram_size_real
 // is what gets used by emulated software.  If using retail IOS, it will
-// always be set to 64MB.
+// always be set to 64MiB.
 static u32 s_exram_size_real;
 static u32 s_exram_size;
 static u32 s_exram_mask;
@@ -185,33 +185,33 @@ struct LogicalMemoryView
 };
 
 // Dolphin allocates memory to represent four regions:
-// - 32MB RAM (actually 24MB on hardware), available on GameCube and Wii
-// - 64MB "EXRAM", RAM only available on Wii
-// - 32MB FakeVMem, allocated in GameCube mode when MMU support is turned off.
+// - 32MiB RAM (actually 24MiB on hardware), available on GameCube and Wii
+// - 64MiB "EXRAM", RAM only available on Wii
+// - 32MiB FakeVMem, allocated in GameCube mode when MMU support is turned off.
 //   This is used to approximate the behavior of a common library which pages
 //   memory to and from the DSP's dedicated RAM. The DSP's RAM (ARAM) isn't
 //   directly addressable on GameCube.
-// - 256KB Locked L1, to represent cache lines allocated out of the L1 data
+// - 256KiB Locked L1, to represent cache lines allocated out of the L1 data
 //   cache in Locked L1 mode.  Dolphin does not emulate this hardware feature
 //   accurately; it just pretends there is extra memory at 0xE0000000.
 //
-// The 4GB starting at physical_base represents access from the CPU
+// The 4GiB starting at physical_base represents access from the CPU
 // with address translation turned off. (This is only used by the CPU;
 // other devices, like the GPU, use other rules, approximated by
 // Memory::GetPointer.) This memory is laid out as follows:
-// [0x00000000, 0x02000000) - 32MB RAM
-// [0x02000000, 0x08000000) - Mirrors of 32MB RAM (not handled here)
+// [0x00000000, 0x02000000) - 32MiB RAM
+// [0x02000000, 0x08000000) - Mirrors of 32MiB RAM (not handled here)
 // [0x08000000, 0x0C000000) - EFB "mapping" (not handled here)
 // [0x0C000000, 0x0E000000) - MMIO etc. (not handled here)
-// [0x10000000, 0x14000000) - 64MB RAM (Wii-only; slightly slower)
+// [0x10000000, 0x14000000) - 64MiB RAM (Wii-only; slightly slower)
 // [0x7E000000, 0x80000000) - FakeVMEM
-// [0xE0000000, 0xE0040000) - 256KB locked L1
+// [0xE0000000, 0xE0040000) - 256KiB locked L1
 //
-// The 4GB starting at logical_base represents access from the CPU
+// The 4GiB starting at logical_base represents access from the CPU
 // with address translation turned on.  This mapping is computed based
 // on the BAT registers.
 //
-// Each of these 4GB regions is followed by 4GB of empty space so overflows
+// Each of these 4GiB regions is followed by 4GiB of empty space so overflows
 // in address computation in the JIT don't access the wrong memory.
 //
 // The neighboring mirrors of RAM ([0x02000000, 0x08000000), etc.) exist because
@@ -222,7 +222,7 @@ struct LogicalMemoryView
 //
 // Dolphin doesn't emulate the difference between cached and uncached access.
 //
-// TODO: The actual size of RAM is 24MB; the other 8MB shouldn't be backed by actual memory.
+// TODO: The actual size of RAM is 24MiB; the other 8MiB shouldn't be backed by actual memory.
 // TODO: Do we want to handle the mirrors of the GC RAM?
 static std::array<PhysicalMemoryRegion, 4> s_physical_regions;
 

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -715,7 +715,7 @@ Result<DirectoryStats> HostFileSystem::GetDirectoryStats(const std::string& wii_
 
     u64 total_size = ComputeTotalFileSize(parent_dir);  // "Real" size to convert to nand blocks
 
-    stats.used_clusters = (u32)(total_size / (16 * 1024));  // one block is 16kb
+    stats.used_clusters = (u32)(total_size / (16 * 1024));  // one block is 16KiB
   }
   else
   {

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -93,7 +93,7 @@ void SDIOSlot0Device::OpenInternal()
   m_card.Open(filename, "r+b");
   if (!m_card)
   {
-    WARN_LOG_FMT(IOS_SD, "Failed to open SD Card image, trying to create a new 128 MB image...");
+    WARN_LOG_FMT(IOS_SD, "Failed to open SD Card image, trying to create a new 128 MiB image...");
     if (Common::SDCardCreate(128, filename))
     {
       INFO_LOG_FMT(IOS_SD, "Successfully created {}", filename);

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -63,7 +63,7 @@ std::optional<IPCReply> WFSSRVDevice::IOCtl(const IOCtlRequest& request)
 
   case IOCTL_WFS_DEVICE_INFO:
     INFO_LOG_FMT(IOS_WFS, "IOCTL_WFS_DEVICE_INFO");
-    Memory::Write_U64(16ull << 30, request.buffer_out);  // 16GB storage.
+    Memory::Write_U64(16ull << 30, request.buffer_out);  // 16GiB storage.
     Memory::Write_U8(4, request.buffer_out + 8);
     break;
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -141,10 +141,10 @@ using namespace PowerPC;
 // our own logic.
 // But when windows reaches the last guard page, it raises a "Stack Overflow"
 // exception which we can hook into, however by default it leaves you with less
-// than 4kb of stack. So we use SetThreadStackGuarantee to trigger the Stack
-// Overflow early while we still have 512kb of stack remaining.
+// than 4KiB of stack. So we use SetThreadStackGuarantee to trigger the Stack
+// Overflow early while we still have 512KiB of stack remaining.
 // After resetting the stack to the top, we call _resetstkoflw() to restore
-// the guard page at the 512kb mark.
+// the guard page at the 512KiB mark.
 
 enum
 {

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -201,7 +201,7 @@ constexpr u32 BAT_MAPPED_BIT = 0x1;
 constexpr u32 BAT_PHYSICAL_BIT = 0x2;
 constexpr u32 BAT_WI_BIT = 0x4;
 constexpr u32 BAT_RESULT_MASK = UINT32_C(~0x7);
-using BatTable = std::array<u32, 1 << (32 - BAT_INDEX_SHIFT)>;  // 128 KB
+using BatTable = std::array<u32, 1 << (32 - BAT_INDEX_SHIFT)>;  // 128 KiB
 extern BatTable ibat_table;
 extern BatTable dbat_table;
 inline bool TranslateBatAddess(const BatTable& bat_table, u32* address, bool* wi)

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -180,8 +180,8 @@ static void DoState(PointerWrap& p)
   if (state_mem1_size != Memory::GetRamSizeReal() || state_mem2_size != Memory::GetExRamSizeReal())
   {
     OSD::AddMessage(fmt::format("Memory size mismatch!\n"
-                                "Current | MEM1 {:08X} ({:3}MB)    MEM2 {:08X} ({:3}MB)\n"
-                                "State   | MEM1 {:08X} ({:3}MB)    MEM2 {:08X} ({:3}MB)",
+                                "Current | MEM1 {:08X} ({:3}MiB)    MEM2 {:08X} ({:3}MiB)\n"
+                                "State   | MEM1 {:08X} ({:3}MiB)    MEM2 {:08X} ({:3}MiB)",
                                 Memory::GetRamSizeReal(), Memory::GetRamSizeReal() / 0x100000U,
                                 Memory::GetExRamSizeReal(), Memory::GetExRamSizeReal() / 0x100000U,
                                 state_mem1_size, state_mem1_size / 0x100000U, state_mem2_size,

--- a/Source/Core/DiscIO/DiscExtractor.cpp
+++ b/Source/Core/DiscIO/DiscExtractor.cpp
@@ -57,7 +57,7 @@ bool ExportData(const Volume& volume, const Partition& partition, u64 offset, u6
 
   while (size)
   {
-    // Limit read size to 128 MB
+    // Limit read size to 128 MiB
     const size_t read_size = static_cast<size_t>(std::min<u64>(size, 0x08000000));
 
     std::vector<u8> buffer(read_size);

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -281,7 +281,7 @@ void AdvancedPane::Update()
 
   m_mem1_override_slider_label->setText([] {
     const u32 mem1_size = Config::Get(Config::MAIN_MEM1_SIZE) / 0x100000;
-    return tr("%1 MB (MEM1)").arg(QString::number(mem1_size));
+    return tr("%1 MiB (MEM1)").arg(QString::number(mem1_size));
   }());
 
   m_mem2_override_slider->setEnabled(enable_ram_override_widgets && !running);
@@ -295,7 +295,7 @@ void AdvancedPane::Update()
 
   m_mem2_override_slider_label->setText([] {
     const u32 mem2_size = Config::Get(Config::MAIN_MEM2_SIZE) / 0x100000;
-    return tr("%1 MB (MEM2)").arg(QString::number(mem2_size));
+    return tr("%1 MiB (MEM2)").arg(QString::number(mem2_size));
   }());
 
   m_custom_rtc_checkbox->setEnabled(!running);

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -140,7 +140,7 @@ void WiiPane::CreateMisc()
                                        "(576i) for PAL games.\nMay not work for all games."));
   m_screensaver_checkbox->setToolTip(tr("Dims the screen after five minutes of inactivity."));
   m_system_language_choice->setToolTip(tr("Sets the Wii system language."));
-  m_sd_card_checkbox->setToolTip(tr("Supports SD and SDHC. Default size is 128 MB."));
+  m_sd_card_checkbox->setToolTip(tr("Supports SD and SDHC. Default size is 128 MiB."));
   m_connect_keyboard_checkbox->setToolTip(tr("May cause slow down in Wii Menu and some games."));
 
   misc_settings_group_layout->addWidget(m_pal60_mode_checkbox, 0, 0, 1, 1);

--- a/Source/Core/VideoBackends/D3D12/DX12Texture.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Texture.cpp
@@ -206,7 +206,7 @@ void DXTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
                      size_t buffer_size)
 {
   // Textures greater than 1024*1024 will be put in staging textures that are released after
-  // execution instead. A 2048x2048 texture is 16MB, and we'd only fit four of these in our
+  // execution instead. A 2048x2048 texture is 16MiB, and we'd only fit four of these in our
   // streaming buffer and be blocking frequently. Games are unlikely to have textures this
   // large anyway, so it's only really an issue for HD texture packs, and memory is not
   // a limiting factor in these scenarios anyway.

--- a/Source/Core/VideoBackends/OGL/OGLVertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLVertexManager.cpp
@@ -61,9 +61,9 @@ bool VertexManager::Initialize()
 
   if (g_ActiveConfig.backend_info.bSupportsPaletteConversion)
   {
-    // The minimum MAX_TEXTURE_BUFFER_SIZE that the spec mandates is 65KB, we are asking for a 1MB
+    // The minimum MAX_TEXTURE_BUFFER_SIZE that the spec mandates is 65KB, we are asking for a 1MiB
     // buffer here. This buffer is also used as storage for undecoded textures when compute shader
-    // texture decoding is enabled, in which case the requested size is 32MB.
+    // texture decoding is enabled, in which case the requested size is 32MiB.
     GLint max_buffer_size;
     glGetIntegerv(GL_MAX_TEXTURE_BUFFER_SIZE, &max_buffer_size);
     m_texel_buffer = StreamBuffer::Create(

--- a/Source/Core/VideoBackends/Vulkan/Constants.h
+++ b/Source/Core/VideoBackends/Vulkan/Constants.h
@@ -83,7 +83,7 @@ constexpr u32 NUM_COMPUTE_TEXEL_BUFFERS = 2;
 constexpr u32 TEXTURE_UPLOAD_BUFFER_SIZE = 32 * 1024 * 1024;
 
 // Textures greater than 1024*1024 will be put in staging textures that are released after
-// execution instead. A 2048x2048 texture is 16MB, and we'd only fit four of these in our
+// execution instead. A 2048x2048 texture is 16MiB, and we'd only fit four of these in our
 // streaming buffer and be blocking frequently. Games are unlikely to have textures this
 // large anyway, so it's only really an issue for HD texture packs, and memory is not
 // a limiting factor in these scenarios anyway.

--- a/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
@@ -84,7 +84,7 @@ bool VertexManager::Initialize()
                                                   g_vulkan_context->GetUniformBufferAlignment()) +
                                   sizeof(GeometryShaderConstants);
 
-  // Prefer an 8MB buffer if possible, but use less if the device doesn't support this.
+  // Prefer an 8MiB buffer if possible, but use less if the device doesn't support this.
   // This buffer is potentially going to be addressed as R8s in the future, so we assume
   // that one element is one byte. This doesn't use min() because of a NDK compiler bug..
   const u32 texel_buffer_size =

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -231,7 +231,7 @@ void PushFifoAuxBuffer(const void* ptr, size_t size)
     if (size > (size_t)(s_fifo_aux_data + FIFO_SIZE - s_fifo_aux_write_ptr))
     {
       // That will sync us up to the last 32 bytes, so this short region
-      // of FIFO would have to point to a 2MB display list or something.
+      // of FIFO would have to point to a 2MiB display list or something.
       PanicAlertFmt("Absurdly large aux buffer");
       return;
     }

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -155,7 +155,8 @@ void HiresTexture::Prefetch()
   size_t size_sum = 0;
   const size_t sys_mem = Common::MemPhysical();
   const size_t recommended_min_mem = 2 * size_t(1024 * 1024 * 1024);
-  // keep 2GB memory for system stability if system RAM is 4GB+ - use half of memory in other cases
+  // keep 2GiB memory for system stability if system RAM is 4GiB+ - use half of memory in other
+  // cases
   const size_t max_mem =
       (sys_mem / 2 < recommended_min_mem) ? (sys_mem / 2) : (sys_mem - recommended_min_mem);
 
@@ -200,7 +201,7 @@ void HiresTexture::Prefetch()
 
       OSD::AddMessage(
           fmt::format(
-              "Custom Textures prefetching after {:.1f} MB aborted, not enough RAM available",
+              "Custom Textures prefetching after {:.1f} MiB aborted, not enough RAM available",
               size_sum / (1024.0 * 1024.0)),
           10000);
       return;
@@ -208,7 +209,7 @@ void HiresTexture::Prefetch()
   }
 
   const u32 stop_time = Common::Timer::GetTimeMs();
-  OSD::AddMessage(fmt::format("Custom Textures loaded, {:.1f} MB in {:.1f}s",
+  OSD::AddMessage(fmt::format("Custom Textures loaded, {:.1f} MiB in {:.1f}s",
                               size_sum / (1024.0 * 1024.0), (stop_time - start_time) / 1000.0),
                   10000);
 }

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -4,7 +4,7 @@
 // ---------------------------------------------------------------------------------------------
 // GC graphics pipeline
 // ---------------------------------------------------------------------------------------------
-// 3d commands are issued through the fifo. The GPU draws to the 2MB EFB.
+// 3d commands are issued through the fifo. The GPU draws to the 2MiB EFB.
 // The efb can be copied back into ram in two forms: as textures or as XFB.
 // The XFB is the region in RAM that the VI chip scans out to the television.
 // So, after all rendering to EFB is done, the image is copied into one of two XFBs in RAM.

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -4,7 +4,7 @@
 // ---------------------------------------------------------------------------------------------
 // GC graphics pipeline
 // ---------------------------------------------------------------------------------------------
-// 3d commands are issued through the fifo. The GPU draws to the 2MB EFB.
+// 3d commands are issued through the fifo. The GPU draws to the 2MiB EFB.
 // The efb can be copied back into ram in two forms: as textures or as XFB.
 // The XFB is the region in RAM that the VI chip scans out to the television.
 // So, after all rendering to EFB is done, the image is copied into one of two XFBs in RAM.

--- a/Source/Core/VideoCommon/TMEM.cpp
+++ b/Source/Core/VideoCommon/TMEM.cpp
@@ -46,7 +46,7 @@
 // improved by overlapping the caches of texture units that are drawing the same textures.
 //
 // For trilinear textures, the even/odd banks contain the even/odd LODs of the texture. TMEM has two
-// banks of 512KB each, covering the upper and lower halves of TMEM's address space. The two banks
+// banks of 512KiB each, covering the upper and lower halves of TMEM's address space. The two banks
 // be accessed simultaneously, allowing a trilinear texture sample to be completed at the same cost
 // as a bilinear sample, assuming the even and odd banks are mapped onto different banks.
 //
@@ -211,11 +211,11 @@ static u32 CalculateUnitSize(TextureUnitState::BankConfig bank_config)
   {
     switch (width)
     {
-    case 3:  // 32KB
+    case 3:  // 32KiB
       return 32 * 1024;
-    case 4:  // 128KB
+    case 4:  // 128KiB
       return 128 * 1024;
-    case 5:  // 512KB
+    case 5:  // 512KiB
       return 512 * 1024;
     default:
       break;

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -86,7 +86,7 @@ public:
   static constexpr u32 MAXIBUFFERSIZE = MathUtil::NextPowerOf2(MAX_PRIMITIVES_PER_COMMAND * 3);
 
   // Streaming buffer sizes.
-  // Texel buffer will fit the maximum size of an encoded GX texture. 1024x1024, RGBA8 = 4MB.
+  // Texel buffer will fit the maximum size of an encoded GX texture. 1024x1024, RGBA8 = 4MiB.
   static constexpr u32 VERTEX_STREAM_BUFFER_SIZE = 48 * 1024 * 1024;
   static constexpr u32 INDEX_STREAM_BUFFER_SIZE = 8 * 1024 * 1024;
   static constexpr u32 UNIFORM_STREAM_BUFFER_SIZE = 32 * 1024 * 1024;


### PR DESCRIPTION
Where appropriate, replace kilobyte (KB) with kibibyte (KiB), megabyte (MB) with mebibyte (MiB), and gigabyte (GB) with gibibyte (GiB).