### PR TITLE
DolphinQt: Show the current user data directory in the Paths section of the settings.

### DIFF
--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -26,6 +26,7 @@ PathPane::PathPane(QWidget* parent) : QWidget(parent)
   setWindowTitle(tr("Paths"));
 
   QVBoxLayout* layout = new QVBoxLayout;
+  layout->addWidget(MakeUserdirBox());
   layout->addWidget(MakeGameFolderBox());
   layout->addLayout(MakePathsLayout());
 
@@ -130,6 +131,33 @@ void PathPane::OnSDCardPathChanged()
 void PathPane::OnNANDPathChanged()
 {
   Config::SetBase(Config::MAIN_FS_PATH, m_nand_edit->text().toStdString());
+}
+
+QGroupBox* PathPane::MakeUserdirBox()
+{
+  auto* group_box = new QGroupBox(tr("Dolphin User Data Directory"));
+  auto* group_layout = new QVBoxLayout();
+  group_box->setLayout(group_layout);
+
+  auto* label_1 = new QLabel(
+      tr("Your user data (settings, saves, etc.) is stored in the following directory:"));
+  label_1->setWordWrap(true);
+  group_layout->addWidget(label_1);
+
+  auto* line_edit = new QLineEdit(QString::fromStdString(File::GetUserPath(D_USER_IDX)));
+  line_edit->setReadOnly(true);
+  group_layout->addWidget(line_edit);
+
+  auto* label_2 =
+      new QLabel(tr("This directory cannot be changed while Dolphin is running "
+                    "and is displayed for informational purposes only. To change where Dolphin "
+                    "stores your user data, please refer to <a "
+                    "href=\"https://dolphin-emu.org/docs/guides/controlling-global-user-directory/"
+                    "\">Controlling the Global User Directory on dolphin-emu.org</a>."));
+  label_2->setWordWrap(true);
+  group_layout->addWidget(label_2);
+
+  return group_box;
 }
 
 QGroupBox* PathPane::MakeGameFolderBox()

--- a/Source/Core/DolphinQt/Settings/PathPane.h
+++ b/Source/Core/DolphinQt/Settings/PathPane.h
@@ -26,6 +26,7 @@ private:
   void BrowseResourcePack();
   void BrowseSDCard();
   void BrowseWFS();
+  QGroupBox* MakeUserdirBox();
   QGroupBox* MakeGameFolderBox();
   QGridLayout* MakePathsLayout();
   void RemovePath();


### PR DESCRIPTION
This comes up often enough in support questions that I think it's useful to just show in the GUI, even if you can't change it directly.

![Clipboard01](https://user-images.githubusercontent.com/4522237/159421805-d6ce5b76-7b64-4cab-9677-65746b5e2488.png)

