### PR TITLE
DolphinQt: Set emulation speed setting only when the combobox is actually touched.

### DIFF
--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -112,8 +112,11 @@ void GeneralPane::ConnectLayout()
   }
 
   // Advanced
-  connect(m_combobox_speedlimit, qOverload<int>(&QComboBox::currentIndexChanged),
-          [this]() { OnSaveConfig(); });
+  connect(m_combobox_speedlimit, qOverload<int>(&QComboBox::currentIndexChanged), [this]() {
+    Config::SetBaseOrCurrent(Config::MAIN_EMULATION_SPEED,
+                             m_combobox_speedlimit->currentIndex() * 0.1f);
+    Config::Save();
+  });
 
   connect(m_combobox_fallback_region, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &GeneralPane::OnSaveConfig);
@@ -354,8 +357,6 @@ void GeneralPane::OnSaveConfig()
                            m_checkbox_override_region_settings->isChecked());
   Config::SetBase(Config::MAIN_AUTO_DISC_CHANGE, m_checkbox_auto_disc_change->isChecked());
   Config::SetBaseOrCurrent(Config::MAIN_ENABLE_CHEATS, m_checkbox_cheats->isChecked());
-  Config::SetBaseOrCurrent(Config::MAIN_EMULATION_SPEED,
-                           m_combobox_speedlimit->currentIndex() * 0.1f);
   Settings::Instance().SetFallbackRegion(
       UpdateFallbackRegionFromIndex(m_combobox_fallback_region->currentIndex()));
 


### PR DESCRIPTION
This should fix https://forums.dolphin-emu.org/Thread-custom-speed-limit-value-that-isn-t-multiple-of-10-is-lost-when-config-is-saved