### PR TITLE
Debugger: MemoryWidget: add float and integer input types. Add input preview.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -12,12 +12,28 @@
 
 class MemoryViewWidget;
 class QCheckBox;
+class QComboBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
 class QRadioButton;
 class QShowEvent;
 class QSplitter;
+
+enum class InputID : int
+{
+  // Order does not matter here.
+  S8 = 1,
+  S16,
+  S32,
+  U8,
+  U16,
+  U32,
+  HEXSTR,
+  FLOAT,
+  DOUBLE,
+  ASCII
+};
 
 class MemoryWidget : public QDockWidget
 {
@@ -55,7 +71,6 @@ private:
   void OnSearchAddress();
   void OnFindNextValue();
   void OnFindPreviousValue();
-  void ValidateSearchValue();
 
   void OnSetValue();
 
@@ -64,10 +79,9 @@ private:
   void OnDumpARAM();
   void OnDumpFakeVMEM();
 
-  bool IsValueValid() const;
-  QByteArray GetValueData() const;
+  void ValidateAndPreviewInputValue();
+  QByteArray GetInputData() const;
   TargetAddress GetTargetAddress() const;
-
   void FindValue(bool next);
 
   void closeEvent(QCloseEvent*) override;
@@ -78,6 +92,8 @@ private:
   QLineEdit* m_search_address;
   QLineEdit* m_search_offset;
   QLineEdit* m_data_edit;
+  QCheckBox* m_base_check;
+  QLabel* m_data_preview;
   QPushButton* m_set_value;
   QPushButton* m_dump_mram;
   QPushButton* m_dump_exram;
@@ -87,8 +103,7 @@ private:
   // Search
   QPushButton* m_find_next;
   QPushButton* m_find_previous;
-  QRadioButton* m_find_ascii;
-  QRadioButton* m_find_hex;
+  QComboBox* m_input_combo;
   QLabel* m_result_label;
 
   // Address Spaces


### PR DESCRIPTION
![inputpreview](https://user-images.githubusercontent.com/10532806/159589246-de5e3c01-410a-4742-ac3f-84975c606744.jpg)

Data preview has automatic spacing per byte.

Float is only for singles.
Integer can accept both unsigned and signed numbers up to 4 bytes.
Hex is right aligned and based on the view type.  Leading zeroes are always filled automatically.

View-based input:
-   "-2" integer in u8 view is FE, and in u16 view it's FF FE
-   "1" hex in u32 view is 00 00 00 01, and in u16 view it's 00 01
-   "123" hex in u8 view is 01 23 and 12345 -> 01 23 45. (u8 x3)
-  "12345" hex in u16 view is  00 01 23 45 (u16 x2)

Fixed a bug where an empty address offset would throw an error.

Loses the ability for infinite length hex string input, but still has it for ascii. Hex max length is 8 bytes.  I could go back and redo it if people actually slam massive hex strings in there.

Not sure if anyone is against right-aligned. For me, when inputting 4 byte numbers, I'm either filling all 4 bytes or just operating on the right hand side, like inputting "1e" -> 00 00 00 1E. Also, inputting just one digit when needed is more comfortable "1" -> 01. Plus the input preview clearly shows what will be entered.

/edit Given that more and more types may be added, converted to a combo list. Made types more explicit.
![PR_Input3](https://user-images.githubusercontent.com/10532806/161396718-61107999-1b0c-4457-a2e9-4b2bcbc3e1eb.jpg)

