### PR TITLE
VideoBackends: fix opengl object label identifier

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLShader.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLShader.cpp
@@ -33,7 +33,7 @@ OGLShader::OGLShader(ShaderStage stage, GLenum gl_type, GLuint gl_id, std::strin
 {
   if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
-    glObjectLabel(GetGLShaderTypeForStage(stage), m_gl_id, -1, m_name.c_str());
+    glObjectLabel(GL_SHADER, m_gl_id, -1, m_name.c_str());
   }
 }
 
@@ -44,7 +44,7 @@ OGLShader::OGLShader(GLuint gl_compute_program_id, std::string source, std::stri
 {
   if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
-    glObjectLabel(GL_COMPUTE_SHADER, m_gl_compute_program_id, -1, m_name.c_str());
+    glObjectLabel(GL_SHADER, m_gl_compute_program_id, -1, m_name.c_str());
   }
 }
 


### PR DESCRIPTION
The object label was using an invalid enumeration as the identifier that wasn't valid in the OpenGL spec.  In most implementations this warns but in some implementations it can cause a crash!

Fixes https://bugs.dolphin-emu.org/issues/12868