### PR TITLE
Android: Increase target and compileSdk version to 32 (Android 12L/Sv2)

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     ndkVersion "23.0.7599858"
 
     compileOptions {
@@ -26,7 +26,7 @@ android {
         // TODO If this is ever modified, change application_id in strings.xml
         applicationId "org.dolphinemu.dolphinemu"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 32
 
         versionCode(getBuildVersionCode())
 

--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.1'
+        classpath 'com.android.tools.build:gradle:7.1.2'
     }
 }
 


### PR DESCRIPTION
This PR updates the target and compile SDK version to 32. See the [Android 12L announcement](https://developer.android.com/about/versions/12/12L) for more information on Android 12L.

I have tested this on the Android Emulator. Adding and booting games works fine.
![image](https://user-images.githubusercontent.com/26326692/160252097-677b8cc0-35c5-4bd1-88b1-8744977b949a.png)

It's worth noting that the on-screen controls don't play nicely with the split-screen mode: 
![image](https://user-images.githubusercontent.com/26326692/160252148-17df6590-59e3-49f4-b980-0431933a6cc1.png)
However, this is nothing related to the Android SDK version and already happens on the current SDK version (31) on odd form factors, like the one you can see in the first screenshot.