### PR TITLE
Remove atomic usage and fix mutex locking in GCAdapter code

### DIFF
--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -51,7 +51,8 @@ static std::mutex s_mutex;
 static u8 s_controller_payload[37];
 static u8 s_controller_payload_swap[37];
 
-static std::atomic<int> s_controller_payload_size = {0};
+// Only access with s_mutex held!
+static int s_controller_payload_size = {0};
 
 static std::thread s_adapter_input_thread;
 static std::thread s_adapter_output_thread;
@@ -101,7 +102,7 @@ static void Read()
     {
       std::lock_guard<std::mutex> lk(s_mutex);
       std::swap(s_controller_payload_swap, s_controller_payload);
-      s_controller_payload_size.store(payload_size);
+      s_controller_payload_size = payload_size;
     }
 
     Common::YieldCPU();
@@ -459,7 +460,7 @@ GCPadStatus Input(int chan)
     std::lock_guard<std::mutex> lk(s_mutex);
     std::copy(std::begin(s_controller_payload), std::end(s_controller_payload),
               std::begin(controller_payload_copy));
-    payload_size = s_controller_payload_size.load();
+    payload_size = s_controller_payload_size;
   }
 
   GCPadStatus pad = {};

--- a/Source/Core/InputCommon/GCAdapter_Android.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Android.cpp
@@ -41,7 +41,7 @@ static u8 s_controller_rumble[4];
 // Input handling
 static std::mutex s_read_mutex;
 static std::array<u8, 37> s_controller_payload;
-static std::atomic<int> s_controller_payload_size{0};
+static int s_controller_payload_size{0};
 
 // Output handling
 static std::mutex s_write_mutex;
@@ -164,7 +164,7 @@ static void Read()
       {
         std::lock_guard<std::mutex> lk(s_read_mutex);
         std::copy(java_data, java_data + s_controller_payload.size(), s_controller_payload.begin());
-        s_controller_payload_size.store(read_size);
+        s_controller_payload_size = read_size;
       }
       env->ReleaseByteArrayElements(*java_controller_payload, java_data, 0);
 
@@ -284,7 +284,7 @@ GCPadStatus Input(int chan)
   {
     std::lock_guard<std::mutex> lk(s_read_mutex);
     controller_payload_copy = s_controller_payload;
-    payload_size = s_controller_payload_size.load();
+    payload_size = s_controller_payload_size;
   }
 
   GCPadStatus pad = {};

--- a/Source/Core/InputCommon/GCAdapter_Android.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Android.cpp
@@ -406,7 +406,7 @@ void ResetRumble()
 {
   unsigned char rumble[5] = {0x11, 0, 0, 0, 0};
   {
-    std::lock_guard<std::mutex> lk(s_read_mutex);
+    std::lock_guard<std::mutex> lk(s_write_mutex);
     memcpy(s_controller_write_payload, rumble, 5);
     s_controller_write_payload_size.store(5);
   }


### PR DESCRIPTION
> Remove unnecessary atomic usage in GCAdapter.cpp

Makes `s_controller_payload_size` non-atomic. You can safely read or write non-atomic integers on multiple threads, as long as every thread reading or writing it holds the same mutex while doing so (here, `s_mutex`).

Removing the atomic accesses makes the code faster, but the actual performance difference is probably negligible.

> Remove unnecessary atomic usage in GCAdapter_Android.cpp

Makes `s_controller_payload_size` non-atomic for the same reason. However `s_controller_write_payload_size` must remain atomic to avoid UB (though I doubt it needs to be seq_cst), since it's being read without a lock held. This threading system may have race conditions, I'm not sure.

Along the way I also noticed that `ResetRumble()` (apparently called on Core.cpp#`void SetState(State state)`) holds the wrong mutex, so I fixed that as well. ~~I did not test my changes on-device to verify this does not introduce deadlocks~~ this cannot introduce deadlocks since `ResetRumble()` is never called on Android! If it does, the old code was wrong as well, and a different change will have to be made (either different usage of mutexes, or a lock-free handshake), requiring that I study the control flow more carefully (which is difficult, and I would benefit from help on).

## Background

The atomic usage was introduced in https://github.com/dolphin-emu/dolphin/commit/07caff35ad9dfda2a0cec6ecc5fc442fc37da11f and https://github.com/dolphin-emu/dolphin/commit/a62a9b8161e8ce2058bfd5422dc19b8762418370. The `ResetRumble()` bug dates back to the file's creation at https://github.com/dolphin-emu/dolphin/commit/e62503c873833b33c63585c6f0810b824e5c6a6b. I did not look into why only the Android implementation has two mutexes.

## Android fails to ResetRumble entirely!

I decided to test `ResetRumble()` on Android:

- Install Dolphin (https://dl.dolphin-emu.org/builds/3a/50/dolphin-master-5.0-16101.apk) on my Pixel 4a running Android 12 (2022-03)
- Enable controller adapter support
- Plug in a Mayflash GameCube Controller Adapter (also connect gray plug for rumble support), set to Wii U mode (to a USB C-to-A hub)
- Boot Wind Waker and press Back to open the side menu
- Roll into a wall, and press "Pause Emulation" while rumble is active

This caused the rumble to remain running.

If I read the code properly, this is supposed to call `MENU_ACTION_PAUSE_EMULATION` -> `NativeLibrary.PauseEmulation() = Java_org_dolphinemu_dolphinemu_NativeLibrary_PauseEmulation` -> `namespace Core::SetState(Core::State::Paused)` -> `ResetRumble()` -> `GCAdapter::ResetRumble()`. Unfortunately, CMakeLists.txt doesn't set `__LIBUSB__` on Android, so Core.cpp#`ResetRumble()` doesn't call `GCAdapter::ResetRumble()` which would map to GCAdapter_Android.cpp#`GCAdapter::ResetRumble()`. Consequently, Android *never* calls `ResetRumble()`, so the current code is dead and the wrong mutex would never be reached!

Should I remove Core.cpp `#if defined(__LIBUSB__)` in yet another commit in this PR, or open a separate PR? At that point, I'd probably want to compile an Android build for testing. Also I didn't review all other uses of `__LIBUSB__` for correctness, though the build seems to work on all OSes right now.