### PR TITLE
Debugger MemoryViewWidget: fixed, tighter spacing

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -35,6 +35,7 @@ public:
   explicit MemoryViewWidget(QWidget* parent = nullptr);
 
   void Update();
+  void UpdateFont();
   void ToggleBreakpoint();
   void ToggleRowBreakpoint(bool row);
 
@@ -69,4 +70,6 @@ private:
   bool m_do_log = true;
   u32 m_context_address;
   u32 m_address = 0;
+  int m_font_width = 0;
+  int m_font_vspace = 0;
 };


### PR DESCRIPTION
![PR2](https://user-images.githubusercontent.com/10532806/160502931-9e90c09a-0332-40d1-a2e3-f955b3fe30dc.jpg)

u32 felt better with a bit wider spacing. Float is aligned to the first digit, which looks way better.

Note that's just my debug font. Height spacing varies a bit based on font, I don't think there's a definite way to set that.