### PR TITLE
Qt: Set font size for default debug font.

### DIFF
--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -606,6 +606,7 @@ void Settings::SetDebugFont(QFont font)
 QFont Settings::GetDebugFont() const
 {
   QFont default_font = QFont(QFontDatabase::systemFont(QFontDatabase::FixedFont).family());
+  default_font.setPointSizeF(9.0);
 
   return GetQSettings().value(QStringLiteral("debugger/font"), default_font).value<QFont>();
 }


### PR DESCRIPTION
This works around (or fixes?) a weird issue I discovered while testing #10542 where the default font was rendered with a point size of 9, but reported a font size of 12 to QFontMetrics.

Before:
![old](https://user-images.githubusercontent.com/4522237/160971218-fa62eb9d-140f-4f46-b279-cd01407134a7.png)

After:
![fixed](https://user-images.githubusercontent.com/4522237/160971236-3409c87a-bc09-4563-8c24-6c8ff988742b.png)



If this causes issues on Linux or macOS, we can put it behind a define instead.