### PR TITLE
Externals: Update Qt to 5.15.3 | Hotkey Save&Load State Delay Fix

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -11,7 +11,7 @@
       "variables": [
         {
           "name": "Qt5_DIR",
-          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.0\\msvc2019_64\\lib\\cmake\\Qt5"
+          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.3\\msvc2019_64\\lib\\cmake\\Qt5"
         }
       ]
     },
@@ -26,7 +26,7 @@
       "variables": [
         {
           "name": "Qt5_DIR",
-          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.0\\msvc2019_64\\lib\\cmake\\Qt5"
+          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.3\\msvc2019_64\\lib\\cmake\\Qt5"
         }
       ]
     },
@@ -41,7 +41,7 @@
       "variables": [
         {
           "name": "Qt5_DIR",
-          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.0\\msvc2019_arm64\\lib\\cmake\\Qt5"
+          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.3\\msvc2019_arm64\\lib\\cmake\\Qt5"
         },
         {
           "name": "CMAKE_SYSTEM_NAME",
@@ -64,7 +64,7 @@
       "variables": [
         {
           "name": "Qt5_DIR",
-          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.0\\msvc2019_arm64\\lib\\cmake\\Qt5"
+          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.3\\msvc2019_arm64\\lib\\cmake\\Qt5"
         },
         {
           "name": "CMAKE_SYSTEM_NAME",

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -1,8 +1,8 @@
 if (NOT Qt5_DIR AND MSVC)
   if(_M_ARM_64)
-    set(Qt5_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt/Qt5.15.0/msvc2019_arm64/lib/cmake/Qt5")
+    set(Qt5_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt/Qt5.15.3/msvc2019_arm64/lib/cmake/Qt5")
   else()
-    set(Qt5_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt/Qt5.15.0/msvc2019_64/lib/cmake/Qt5")
+    set(Qt5_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt/Qt5.15.3/msvc2019_64/lib/cmake/Qt5")
   endif()
 endif()
 

--- a/Source/VSProps/QtCompile.props
+++ b/Source/VSProps/QtCompile.props
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="UserMacros">
-    <QTDIRDefault Condition="'$(Platform)'=='x64'">$(ExternalsDir)Qt\Qt5.15.0\msvc2019_64\</QTDIRDefault>
-    <QTDIRDefault Condition="'$(Platform)'=='ARM64'">$(ExternalsDir)Qt\Qt5.15.0\msvc2019_arm64\</QTDIRDefault>
+    <QTDIRDefault Condition="'$(Platform)'=='x64'">$(ExternalsDir)Qt\Qt5.15.3\msvc2019_64\</QTDIRDefault>
+    <QTDIRDefault Condition="'$(Platform)'=='ARM64'">$(ExternalsDir)Qt\Qt5.15.3\msvc2019_arm64\</QTDIRDefault>
     <QTDIR Condition="Exists('$(QTDIRDefault)') And ('$(QTDIR)'=='' Or !Exists('$(QTDIR)'))">$(QTDIRDefault)</QTDIR>
     <QTDIR Condition="Exists('$(QTDIR)') And !HasTrailingSlash('$(QTDIR)')">$(QTDIR)\</QTDIR>
     <QtDirValid>false</QtDirValid>


### PR DESCRIPTION
## Summary
* Update from Qt 5.15.0 -> 5.15.3
* **Do not merge**, Externals submodule has not updated yet until this PR is complete https://github.com/dolphin-emu/ext-win-qt/pull/17
* Fixes the bug described below, which has been present since [build 5.0-12462](https://github.com/dolphin-emu/dolphin/pull/9046/files)
* A demo of the bug + the fix can be found here:
https://youtu.be/nSQotRmMWJ0

--
## What is the Hotkey Save&Load State Bug?
* Games will sporadically (or immediately, its variable) ignore or delay Save/Load state Hotkey presses if assigned to an XInput device.
* During the delayed/frozen state, the Dolphin window title will not update.
* The emulation is not affected; the XInput device can be used for other Hotkeys such as Emulation Speed up/down and regular in-emulation input use with no issues.
* The 'delayed' save/load state will either be dropped or execute later on (sometimes up to 1+ min delay)

## Expected behavior:
* Hotkeys assigned to XInput devices should have the same responsiveness as keyboard
* Dolphin window title should not freeze
* SaveState/LoadState should not have a huge delay when assigned to an XInput device in Hotkeys

## Hotkey Save&Load State Bug Reproduce Steps
Start on Dolphin 5.0-9777
- Configure GC Port 1 to use XInput0 with various keys
- Set Hotkeys to XInput0
- Configure Hotkeys Emulation Speed Up/Down to XInput0 (any keys)
- Configure Hotkeys for SaveState Slot0 and LoadState Slot0

1. Open a game and spam savestate/loadstate, should properly work fine

2. Try up/down emulation speed hotkeys- notice they still work

Upgrade to Dolphin 5.0-16195

3. Open a game and spam savestate/loadstate - eventually there will be a noticeable delay of multiple seconds. While delay occurs the Window Title is frozen (fps, % etc will not update). Some savestate/loadstate commands will not register during this period. GC Pad with the same XInput will work properly during this

4. Try up/down emulation speed hotkeys. These will work even during lagging savestate/loadstate issue 
I'm trying to narrow down when this broke further, but I'm thinking its probably related to savestate/loadstate specifically and not the hotkey thread

5. (Optional) On affected broken builds, if you open the Hotkeys window before launching a game, and then launch a game the issue is gone during that session. 