### PR TITLE
WIP: Android display cutout setting

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -164,6 +164,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
 
   GFX_WIDESCREEN_HACK(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "wideScreenHack", false),
   GFX_CROP(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "Crop", false),
+  GFX_CUTOUT(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "Cutout", false),
   GFX_SHOW_FPS(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "ShowFPS", false),
   GFX_OVERLAY_STATS(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "OverlayStats", false),
   GFX_DUMP_TEXTURES(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "DumpTextures", false),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -711,6 +711,8 @@ public final class SettingsFragmentPresenter
     sl.add(new HeaderSetting(mContext, R.string.misc, 0));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_CROP, R.string.crop,
             R.string.crop_description));
+    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_CUTOUT, R.string.cutout,
+      R.string.cutout_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.SYSCONF_PROGRESSIVE_SCAN,
             R.string.progressive_scan, 0));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_BACKEND_MULTITHREADING,

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -311,6 +311,8 @@
     <string name="misc">Misc</string>
     <string name="crop">Crop</string>
     <string name="crop_description">Crops the picture from its native aspect ratio to 4:3 or 16:9. If unsure, leave this unchecked.</string>
+    <string name="cutout">Cutout</string>
+    <string name="cutout_description">Enables the full use of the screen on a phone with a cutout.</string>
     <string name="progressive_scan">Enable Progressive Scan</string>
     <string name="backend_multithreading">Backend Multithreading</string> <!--Backend Multithreading is only disabled by default on Android  -->
     <string name="backend_multithreading_description">Enables graphics backend multithreading (Vulkan only). May affect performance. If unsure, leave this unchecked.</string>

--- a/Source/Android/gradle.properties
+++ b/Source/Android/gradle.properties
@@ -9,7 +9,7 @@
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -24,6 +24,7 @@ const Info<AspectMode> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"}
 const Info<AspectMode> GFX_SUGGESTED_ASPECT_RATIO{{System::GFX, "Settings", "SuggestedAspectRatio"},
                                                   AspectMode::Auto};
 const Info<bool> GFX_CROP{{System::GFX, "Settings", "Crop"}, false};
+const Info<bool> GFX_CUTOUT{{System::GFX, "Settings", "Cutout"}, false};
 const Info<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES{
     {System::GFX, "Settings", "SafeTextureCacheColorSamples"}, 128};
 const Info<bool> GFX_SHOW_FPS{{System::GFX, "Settings", "ShowFPS"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -27,6 +27,7 @@ extern const Info<bool> GFX_WIDESCREEN_HACK;
 extern const Info<AspectMode> GFX_ASPECT_RATIO;
 extern const Info<AspectMode> GFX_SUGGESTED_ASPECT_RATIO;
 extern const Info<bool> GFX_CROP;
+extern const Info<bool> GFX_CUTOUT;
 extern const Info<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES;
 extern const Info<bool> GFX_SHOW_FPS;
 extern const Info<bool> GFX_SHOW_NETPLAY_PING;

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -121,11 +121,13 @@ void AdvancedWidget::CreateWidgets()
   misc_box->setLayout(misc_layout);
 
   m_enable_cropping = new GraphicsBool(tr("Crop"), Config::GFX_CROP);
+  m_enable_cutout = new GraphicsBool(tr("Cutout"), Config::GFX_CUTOUT);
   m_enable_prog_scan = new ToolTipCheckBox(tr("Enable Progressive Scan"));
   m_backend_multithreading =
       new GraphicsBool(tr("Backend Multithreading"), Config::GFX_BACKEND_MULTITHREADING);
 
   misc_layout->addWidget(m_enable_cropping, 0, 0);
+  misc_layout->addWidget(m_enable_cutout, 0, 0);
   misc_layout->addWidget(m_enable_prog_scan, 0, 1);
   misc_layout->addWidget(m_backend_multithreading, 1, 0);
 #ifdef _WIN32
@@ -268,6 +270,9 @@ void AdvancedWidget::AddDescriptions()
   static const char TR_CROPPING_DESCRIPTION[] = QT_TR_NOOP(
       "Crops the picture from its native aspect ratio to 4:3 or "
       "16:9.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+  static const char TR_CUTOUT_DESCRIPTION[] = QT_TR_NOOP(
+          "Enables the full use of the screen on a phone with a cutout."
+          )
   static const char TR_PROGRESSIVE_SCAN_DESCRIPTION[] = QT_TR_NOOP(
       "Enables progressive scan if supported by the emulated software. Most games don't have "
       "any issue with this.<br><br><dolphin_emphasis>If unsure, leave this "
@@ -322,6 +327,7 @@ void AdvancedWidget::AddDescriptions()
 #endif
   m_png_compression_level->SetDescription(tr(TR_PNG_COMPRESSION_LEVEL_DESCRIPTION));
   m_enable_cropping->SetDescription(tr(TR_CROPPING_DESCRIPTION));
+  m_enable_cutout->SetDescription(tr(TR_CUTOUT_DESCRIPTION));
   m_enable_prog_scan->SetDescription(tr(TR_PROGRESSIVE_SCAN_DESCRIPTION));
   m_backend_multithreading->SetDescription(tr(TR_BACKEND_MULTITHREADING_DESCRIPTION));
 #ifdef _WIN32

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -56,6 +56,7 @@ private:
 
   // Misc
   GraphicsBool* m_enable_cropping;
+  GraphicsBool* m_enable_cutout;
   ToolTipCheckBox* m_enable_prog_scan;
   GraphicsBool* m_backend_multithreading;
   GraphicsBool* m_borderless_fullscreen;

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -60,6 +60,10 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
     resize(w / dpr, h / dpr);
   });
 
+  if(!Config::GFX_CUTOUT){
+  setWindowFlags(windowFlags() & ~Qt::MaximizeUsingFullscreenGeometryHint);
+  }
+
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     if (state == Core::State::Running)
       SetImGuiKeyMap();

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -55,6 +55,7 @@ void VideoConfig::Refresh()
   aspect_mode = Config::Get(Config::GFX_ASPECT_RATIO);
   suggested_aspect_mode = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
   bCrop = Config::Get(Config::GFX_CROP);
+  bCutout = Config::Get(Config::GFX_CUTOUT);
   iSafeTextureCache_ColorSamples = Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES);
   bShowFPS = Config::Get(Config::GFX_SHOW_FPS);
   bShowNetPlayPing = Config::Get(Config::GFX_SHOW_NETPLAY_PING);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -76,6 +76,7 @@ struct VideoConfig final
   bool bDisableCopyFilter = false;
   bool bArbitraryMipmapDetection = false;
   float fArbitraryMipmapDetectionThreshold = 0;
+  bool bCutout = false;
 
   // Information
   bool bShowFPS = false;


### PR DESCRIPTION
[Issue #12483](https://bugs.dolphin-emu.org/issues/12483)
Black bar at the top of the display on android.
The app does in fact not support the cutout display.
Make an option in the graphics advanced settings to enable cutout support.