### PR TITLE
msvc: enable conformant __cplusplus macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,7 +265,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
   # Fix non-conformant lambda behavior (constexpr variables shouldn't need capturing)
   add_compile_options(/experimental:newLambdaProcessor)
   # Fix various other non-conformant behaviors
-  add_compile_options(/Zc:externConstexpr,lambda,preprocessor)
+  add_compile_options(/Zc:__cplusplus,externConstexpr,lambda,preprocessor)
 
   # Temporarily disable warnings to enable /Zc:preprocessor compatibility with WinSDK headers.
   add_compile_options(

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -97,7 +97,7 @@
       <!--Enable Standard Conformance-->
       <ConformanceMode>true</ConformanceMode>
       <!--Enforce some behaviors as standards-conformant when they don't default as such.-->
-      <AdditionalOptions>/Zc:externConstexpr,lambda,preprocessor,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus,externConstexpr,lambda,preprocessor,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
       <!--Enable detailed debug info-->
       <AdditionalOptions>/Zo %(AdditionalOptions)</AdditionalOptions>
       <!--Treat sources as utf-8-->


### PR DESCRIPTION
this is required for Qt6