### PR TITLE
update to Qt6 on windows, support Qt6 elsewhere

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -261,7 +261,7 @@ def build(config):
             os.mkdir(arch)
 
         env = os.environ.copy()
-        env["Qt5_DIR"] = config[arch+"_qt5_path"]
+        env["QT_DIR"] = config[arch+"_qt5_path"]
         env["CMAKE_OSX_ARCHITECTURES"] = arch
         env["CMAKE_PREFIX_PATH"] = config[arch+"_cmake_prefix"]
 

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -10,8 +10,8 @@
       "cmakeCommandArgs": "",
       "variables": [
         {
-          "name": "Qt5_DIR",
-          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.0\\msvc2019_64\\lib\\cmake\\Qt5"
+          "name": "QT_DIR",
+          "value": "${workspaceRoot}\\Externals\\Qt\\Qt6.3.0\\x64\\lib\\cmake\\Qt6"
         }
       ]
     },
@@ -25,8 +25,8 @@
       "cmakeCommandArgs": "",
       "variables": [
         {
-          "name": "Qt5_DIR",
-          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.0\\msvc2019_64\\lib\\cmake\\Qt5"
+          "name": "QT_DIR",
+          "value": "${workspaceRoot}\\Externals\\Qt\\Qt6.3.0\\x64\\lib\\cmake\\Qt6"
         }
       ]
     },
@@ -40,8 +40,8 @@
       "cmakeCommandArgs": "",
       "variables": [
         {
-          "name": "Qt5_DIR",
-          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.0\\msvc2019_arm64\\lib\\cmake\\Qt5"
+          "name": "QT_DIR",
+          "value": "${workspaceRoot}\\Externals\\Qt\\Qt6.3.0\\ARM64\\lib\\cmake\\Qt6"
         },
         {
           "name": "CMAKE_SYSTEM_NAME",
@@ -63,8 +63,8 @@
       "cmakeCommandArgs": "",
       "variables": [
         {
-          "name": "Qt5_DIR",
-          "value": "${workspaceRoot}\\Externals\\Qt\\Qt5.15.0\\msvc2019_arm64\\lib\\cmake\\Qt5"
+          "name": "QT_DIR",
+          "value": "${workspaceRoot}\\Externals\\Qt\\Qt6.3.0\\ARM64\\lib\\cmake\\Qt6"
         },
         {
           "name": "CMAKE_SYSTEM_NAME",

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -1,17 +1,28 @@
-if (NOT Qt5_DIR AND MSVC)
+if(POLICY CMP0084)
+  # Disable trying to search for Qt3/4 if what we actually want is not found
+  cmake_policy(SET CMP0084 NEW)
+endif()
+
+if (NOT QT_DIR AND MSVC)
   if(_M_ARM_64)
-    set(Qt5_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt/Qt5.15.0/msvc2019_arm64/lib/cmake/Qt5")
+    set(QT_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt/Qt6.3.0/ARM64/lib/cmake/Qt6")
   else()
-    set(Qt5_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt/Qt5.15.0/msvc2019_64/lib/cmake/Qt5")
+    set(QT_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt/Qt6.3.0/x64/lib/cmake/Qt6")
   endif()
 endif()
 
-find_package(Qt5 5.9 REQUIRED COMPONENTS Gui Widgets)
-
-set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
-message(STATUS "Found Qt version ${Qt5Core_VERSION}")
-
 set(CMAKE_AUTOMOC ON)
+
+# For some reason the method in Qt6 documentation is not working (at least on ubuntu jammy)
+# When Qt5 and Qt6 are given in same NAMES entry, only Qt5 is ever found.
+find_package(QT NAMES Qt6 COMPONENTS Core Gui Widgets)
+if(NOT QT_DIR)
+  find_package(QT NAMES Qt5 COMPONENTS Core Gui Widgets)
+endif()
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
+message(STATUS "Found Qt version ${QT_VERSION}")
+
+set_property(TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
 
 add_executable(dolphin-emu
   AboutDialog.cpp
@@ -351,13 +362,13 @@ PRIVATE
 target_include_directories(dolphin-emu
 PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
+  ${Qt${QT_VERSION_MAJOR}Gui_PRIVATE_INCLUDE_DIRS}
 )
 
 target_link_libraries(dolphin-emu
 PRIVATE
   core
-  Qt5::Widgets
+  Qt${QT_VERSION_MAJOR}::Widgets
   uicommon
   imgui
 )
@@ -377,9 +388,9 @@ if (MSVC)
   set(qtGui "")
   set(qtGuiPriv "")
   set(qtWidgetsPriv "")
-  list(TRANSFORM Qt5Gui_INCLUDE_DIRS PREPEND "/external:I" OUTPUT_VARIABLE qtGui)
-  list(TRANSFORM Qt5Gui_PRIVATE_INCLUDE_DIRS PREPEND "/external:I" OUTPUT_VARIABLE qtGuiPriv)
-  list(TRANSFORM Qt5Widgets_PRIVATE_INCLUDE_DIRS PREPEND "/external:I" OUTPUT_VARIABLE qtWidgetsPriv)
+  list(TRANSFORM Qt6Gui_INCLUDE_DIRS PREPEND "/external:I" OUTPUT_VARIABLE qtGui)
+  list(TRANSFORM Qt6Gui_PRIVATE_INCLUDE_DIRS PREPEND "/external:I" OUTPUT_VARIABLE qtGuiPriv)
+  list(TRANSFORM Qt6Widgets_PRIVATE_INCLUDE_DIRS PREPEND "/external:I" OUTPUT_VARIABLE qtWidgetsPriv)
   target_compile_options(dolphin-emu PRIVATE "${qtGui}")
   target_compile_options(dolphin-emu PRIVATE "${qtGuiPriv}")
   target_compile_options(dolphin-emu PRIVATE "${qtWidgets}")
@@ -415,7 +426,7 @@ if(WIN32)
   )
 
   # Delegate to Qt's official deployment binary on Windows to copy over the necessary Qt-specific libraries, etc.
-  get_target_property(MOC_EXECUTABLE_LOCATION Qt5::moc IMPORTED_LOCATION)
+  get_target_property(MOC_EXECUTABLE_LOCATION Qt${QT_VERSION_MAJOR}::moc IMPORTED_LOCATION)
   get_filename_component(QT_BINARY_DIRECTORY "${MOC_EXECUTABLE_LOCATION}" DIRECTORY)
   find_program(WINDEPLOYQT_EXE windeployqt HINTS "${QT_BINARY_DIRECTORY}")
 
@@ -520,12 +531,18 @@ if(APPLE)
   target_sources(dolphin-emu PRIVATE "${CMAKE_SOURCE_DIR}/Data/Dolphin.icns")
   set_source_files_properties("${CMAKE_SOURCE_DIR}/Data/Dolphin.icns" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
+  # Plugins have to be manually included with Qt 6
+  if (QT_VERSION_MAJOR EQUAL 6)
+    find_package(Qt6QMacStylePlugin REQUIRED PATHS ${Qt6Widgets_DIR})
+    find_package(Qt6QCocoaIntegrationPlugin REQUIRED PATHS ${Qt6Gui_DIR})
+  endif()
+
   # Copy Qt plugins into the bundle
-  get_target_property(qtcocoa_location Qt5::QCocoaIntegrationPlugin LOCATION)
+  get_target_property(qtcocoa_location Qt${QT_VERSION_MAJOR}::QCocoaIntegrationPlugin LOCATION)
   target_sources(dolphin-emu PRIVATE "${qtcocoa_location}")
   set_source_files_properties("${qtcocoa_location}" PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/platforms)
 
-  get_target_property(qtmacstyle_location Qt5::QMacStylePlugin LOCATION)
+  get_target_property(qtmacstyle_location Qt${QT_VERSION_MAJOR}::QMacStylePlugin LOCATION)
   target_sources(dolphin-emu PRIVATE "${qtmacstyle_location}")
   set_source_files_properties("${qtmacstyle_location}" PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/styles)
 

--- a/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
@@ -55,7 +55,7 @@ void CheatSearchFactoryWidget::CreateWidgets()
   label_standard_address_space->setWordWrap(true);
 
   auto* custom_address_space_layout = new QVBoxLayout();
-  custom_address_space_layout->setMargin(6);
+  custom_address_space_layout->setContentsMargins(6, 6, 6, 6);
   auto* custom_address_space_button_group = new QButtonGroup(this);
   m_custom_virtual_address_space = new QRadioButton(tr("Use virtual addresses when possible"));
   m_custom_virtual_address_space->setChecked(true);

--- a/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
@@ -36,7 +36,7 @@ void CommonControllersWidget::CreateLayout()
   m_common_box->setLayout(m_common_layout);
 
   auto* layout = new QVBoxLayout;
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setAlignment(Qt::AlignTop);
   layout->addWidget(m_common_box);
   setLayout(layout);

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -92,7 +92,7 @@ void GamecubeControllersWidget::CreateLayout()
   m_gc_box->setLayout(m_gc_layout);
 
   auto* layout = new QVBoxLayout;
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setAlignment(Qt::AlignTop);
   layout->addWidget(m_gc_box);
   setLayout(layout);

--- a/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipWidget.h
+++ b/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipWidget.h
@@ -22,7 +22,11 @@ public:
   void SetDescription(QString description) { m_description = std::move(description); }
 
 private:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   void enterEvent(QEvent* event) override
+#else
+  void enterEvent(QEnterEvent* event) override
+#endif
   {
     if (m_timer_id)
       return;

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -74,7 +74,7 @@ static int GetLayoutHorizontalSpacing(const QGridLayout* layout)
   float pixel_ratio = QGuiApplication::primaryScreen()->devicePixelRatio();
 #ifdef __APPLE__
   // TODO is this still required?
-  hspacing = pixel_ratio * style->pixelMetric(QStyle::PM_DefaultLayoutSpacing);
+  hspacing = pixel_ratio * style->pixelMetric(QStyle::PM_LayoutHorizontalSpacing);
   if (hspacing >= 0)
     return hspacing;
 #endif
@@ -145,7 +145,7 @@ void WiimoteControllersWidget::CreateLayout()
   m_wiimote_layout->addWidget(m_wiimote_refresh, continuous_scanning_row, 3);
 
   auto* layout = new QVBoxLayout;
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setAlignment(Qt::AlignTop);
   layout->addWidget(m_wiimote_box);
   setLayout(layout);

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -13,14 +13,11 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VSPropsDir)Base.props" />
-    <Import Project="$(VSPropsDir)PCHUse.props" />
     <Import Project="$(VSPropsDir)QtCompile.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <!-- 5054  operator '+': deprecated between enumerations of different types (types defined in Qt headers) -->
-      <DisableSpecificWarnings>5054;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir)Config\Graphics;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ProjectDir)Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ProjectDir)Config\ControllerInterface;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -33,6 +30,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir)Settings;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ProjectDir)TAS;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ProjectDir)VideoInterface;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!--Ignore warnings in locally-instantiated fmt templates-->
+      <ExternalTemplatesDiagnostics>false</ExternalTemplatesDiagnostics>
     </ClCompile>
     <Manifest>
       <AdditionalManifestFiles>DolphinQt.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -380,6 +379,9 @@
     <ResourceCompile Include="DolphinQt.rc" />
   </ItemGroup>
   <ItemGroup>
+    <Natvis Include="qt6.natvis" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(CoreDir)DolphinLib.vcxproj">
       <Project>{D79392F7-06D6-4B4B-A39F-4D587C215D3A}</Project>
     </ProjectReference>
@@ -388,6 +390,16 @@
     </ProjectReference>
     <ProjectReference Include="$(DolphinRootDir)Languages\Languages.vcxproj">
       <Project>{0e033be3-2e08-428e-9ae9-bc673efa12b5}</Project>
+    </ProjectReference>
+    <!--
+      This project doesn't use PCH during compile (because RTTI setting differs),
+      but we still must link it for the dependants (DolphinLib)
+    -->
+    <ProjectReference Include="$(SourceDir)PCH\pch.vcxproj">
+      <Project>{76563A7F-1011-4EAD-B667-7BB18D09568E}</Project>
+      <Private>false</Private>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+      <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(ExternalsDir)ExternalsReferenceAll.props" />

--- a/Source/Core/DolphinQt/GBAWidget.cpp
+++ b/Source/Core/DolphinQt/GBAWidget.cpp
@@ -510,7 +510,13 @@ void GBAWidget::mouseMoveEvent(QMouseEvent* event)
 {
   if (!m_moving)
     return;
-  move(event->globalPos() - m_move_pos - (geometry().topLeft() - pos()));
+  auto event_pos =
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+      event->globalPosition().toPoint();
+#else
+      event->globalPos();
+#endif
+  move(event_pos - m_move_pos - (geometry().topLeft() - pos()));
 }
 
 void GBAWidget::paintEvent(QPaintEvent* event)

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -108,14 +108,14 @@ GameList::GameList(QWidget* parent) : QStackedWidget(parent), m_model(this)
   // conceptually as 'control plus' (which is then interpreted as an appropriate zooming action)
   // instead of the technically correct 'control equal'. Qt doesn't account for this convention so
   // an alternate shortcut is needed to avoid counterintuitive behavior.
-  const auto* zoom_in_alternate = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Equal), this);
+  const auto* zoom_in_alternate = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Equal), this);
   connect(zoom_in_alternate, &QShortcut::activated, this, &GameList::ZoomIn);
 
   // The above correction introduces a different inconsistency: now zooming in can be done using
   // conceptual 'control plus' or 'control shift plus', while zooming out can only be done using
   // 'control minus'. Adding an alternate shortcut representing 'control shift minus' restores
   // consistency.
-  const auto* zoom_out_alternate = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Underscore), this);
+  const auto* zoom_out_alternate = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Underscore), this);
   connect(zoom_out_alternate, &QShortcut::activated, this, &GameList::ZoomOut);
 
   connect(&Settings::Instance(), &Settings::MetadataRefreshCompleted, this,

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -132,8 +132,15 @@ int main(int argc, char* argv[])
   const optparse::Values& options = CommandLineParse::ParseArguments(parser.get(), argc, argv);
   const std::vector<std::string> args = parser->args();
 
+  // setHighDpiScaleFactorRoundingPolicy was added in 5.14, but default behavior changed in 6.0
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+  // Set to the previous default behavior
+  QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
+#else
   QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+
   QCoreApplication::setOrganizationName(QStringLiteral("Dolphin Emulator"));
   QCoreApplication::setOrganizationDomain(QStringLiteral("dolphin-emu.org"));
   QCoreApplication::setApplicationName(QStringLiteral("dolphin-emu"));
@@ -144,7 +151,7 @@ int main(int argc, char* argv[])
   QApplication app(argc, argv);
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
   // On Windows, Qt 5's default system font (MS Shell Dlg 2) is outdated.
   // Interestingly, the QMenu font is correct and comes from lfMenuFont
   // (Segoe UI on English computers).

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -825,7 +825,7 @@ void MainWindow::TogglePause()
 void MainWindow::OnStopComplete()
 {
   m_stop_requested = false;
-  HideRenderWidget(true, m_exit_requested);
+  HideRenderWidget(!m_exit_requested, m_exit_requested);
 #ifdef USE_DISCORD_PRESENCE
   if (!m_netplay_dialog->isVisible())
     Discord::UpdateDiscordPresence();
@@ -834,7 +834,7 @@ void MainWindow::OnStopComplete()
   SetFullScreenResolution(false);
 
   if (m_exit_requested || Settings::Instance().IsBatchModeEnabled())
-    QGuiApplication::instance()->quit();
+    QGuiApplication::exit(0);
 
   // If the current emulation prevented the booting of another, do that now
   if (m_pending_boot != nullptr)

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -218,7 +218,7 @@ void MenuBar::AddFileMenu()
   file_menu->addSeparator();
 
   m_exit_action = file_menu->addAction(tr("E&xit"), this, &MenuBar::Exit);
-  m_exit_action->setShortcuts({QKeySequence::Quit, QKeySequence(Qt::ALT + Qt::Key_F4)});
+  m_exit_action->setShortcuts({QKeySequence::Quit, QKeySequence(Qt::ALT | Qt::Key_F4)});
 }
 
 void MenuBar::AddToolsMenu()

--- a/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
+++ b/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
@@ -16,6 +16,11 @@ class ParallelProgressDialog final : public QObject
   Q_OBJECT
 
 public:
+  ParallelProgressDialog(const ParallelProgressDialog&) = delete;
+  ParallelProgressDialog& operator=(const ParallelProgressDialog&) = delete;
+  ParallelProgressDialog(ParallelProgressDialog&&) = delete;
+  ParallelProgressDialog& operator=(ParallelProgressDialog&&) = delete;
+
   // Only use this from the main thread
   template <typename... Args>
   ParallelProgressDialog(Args&&... args) : m_dialog{std::forward<Args>(args)...}

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -502,8 +502,8 @@ void RenderWidget::PassEventToImGui(const QEvent* event)
     // coordinates (as if the screen was standard dpi). We need to update the mouse position in
     // native coordinates, as the UI (and game) is rendered at native resolution.
     const float scale = devicePixelRatio();
-    ImGui::GetIO().MousePos.x = static_cast<const QMouseEvent*>(event)->x() * scale;
-    ImGui::GetIO().MousePos.y = static_cast<const QMouseEvent*>(event)->y() * scale;
+    ImGui::GetIO().MousePos.x = static_cast<const QMouseEvent*>(event)->pos().x() * scale;
+    ImGui::GetIO().MousePos.y = static_cast<const QMouseEvent*>(event)->pos().y() * scale;
   }
   break;
 

--- a/Source/Core/DolphinQt/TAS/IRWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/IRWidget.cpp
@@ -87,8 +87,8 @@ void IRWidget::handleMouseEvent(QMouseEvent* event)
   else
   {
     // convert from widget space to value space
-    int new_x = ir_max_x - (event->x() * ir_max_x) / width();
-    int new_y = (event->y() * ir_max_y) / height();
+    int new_x = ir_max_x - (event->pos().x() * ir_max_x) / width();
+    int new_y = (event->pos().y() * ir_max_y) / height();
 
     m_x = std::max(0, std::min(static_cast<int>(ir_max_x), new_x));
     m_y = std::max(0, std::min(static_cast<int>(ir_max_y), new_y));

--- a/Source/Core/DolphinQt/TAS/StickWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/StickWidget.cpp
@@ -90,8 +90,8 @@ void StickWidget::handleMouseEvent(QMouseEvent* event)
   else
   {
     // convert from widget space to value space
-    int new_x = (event->x() * m_max_x) / width();
-    int new_y = m_max_y - (event->y() * m_max_y) / height();
+    int new_x = (event->pos().x() * m_max_x) / width();
+    int new_y = m_max_y - (event->pos().y() * m_max_y) / height();
 
     m_x = std::max(0, std::min(static_cast<int>(m_max_x), new_x));
     m_y = std::max(0, std::min(static_cast<int>(m_max_y), new_y));

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -72,8 +72,8 @@ QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, Q
                                              u16 max_x, u16 max_y, Qt::Key x_shortcut_key,
                                              Qt::Key y_shortcut_key)
 {
-  const QKeySequence x_shortcut_key_sequence = QKeySequence(Qt::ALT + x_shortcut_key);
-  const QKeySequence y_shortcut_key_sequence = QKeySequence(Qt::ALT + y_shortcut_key);
+  const QKeySequence x_shortcut_key_sequence = QKeySequence(Qt::ALT | x_shortcut_key);
+  const QKeySequence y_shortcut_key_sequence = QKeySequence(Qt::ALT | y_shortcut_key);
 
   auto* box =
       new QGroupBox(QStringLiteral("%1 (%2/%3)")
@@ -119,7 +119,7 @@ QBoxLayout* TASInputWindow::CreateSliderValuePairLayout(QString name, QSpinBox*&
                                                         int default_, u16 max, Qt::Key shortcut_key,
                                                         QWidget* shortcut_widget, bool invert)
 {
-  const QKeySequence shortcut_key_sequence = QKeySequence(Qt::ALT + shortcut_key);
+  const QKeySequence shortcut_key_sequence = QKeySequence(Qt::ALT | shortcut_key);
 
   auto* label = new QLabel(QStringLiteral("%1 (%2)").arg(
       name, shortcut_key_sequence.toString(QKeySequence::NativeText)));

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
@@ -40,8 +40,8 @@ using namespace WiimoteCommon;
 
 WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(parent), m_num(num)
 {
-  const QKeySequence ir_x_shortcut_key_sequence = QKeySequence(Qt::ALT + Qt::Key_F);
-  const QKeySequence ir_y_shortcut_key_sequence = QKeySequence(Qt::ALT + Qt::Key_G);
+  const QKeySequence ir_x_shortcut_key_sequence = QKeySequence(Qt::ALT | Qt::Key_F);
+  const QKeySequence ir_y_shortcut_key_sequence = QKeySequence(Qt::ALT | Qt::Key_G);
 
   m_ir_box = new QGroupBox(QStringLiteral("%1 (%2/%3)")
                                .arg(tr("IR"),

--- a/Source/Core/DolphinQt/qt6.natvis
+++ b/Source/Core/DolphinQt/qt6.natvis
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    ****************************************************************************
+    **
+    ** Copyright (C) 2021 The Qt Company Ltd.
+    ** Contact: https://www.qt.io/licensing/
+    **
+    ** This file is part of the Qt VS Tools.
+    **
+    ** $QT_BEGIN_LICENSE:GPL-EXCEPT$
+    ** Commercial License Usage
+    ** Licensees holding valid commercial Qt licenses may use this file in
+    ** accordance with the commercial license agreement provided with the
+    ** Software or, alternatively, in accordance with the terms contained in
+    ** a written agreement between you and The Qt Company. For licensing terms
+    ** and conditions see https://www.qt.io/terms-conditions. For further
+    ** information use the contact form at https://www.qt.io/contact-us.
+    **
+    ** GNU General Public License Usage
+    ** Alternatively, this file may be used under the terms of the GNU
+    ** General Public License version 3 as published by the Free Software
+    ** Foundation with exceptions as appearing in the file LICENSE.GPL3-EXCEPT
+    ** included in the packaging of this file. Please review the following
+    ** information to ensure the GNU General Public License requirements will
+    ** be met: https://www.gnu.org/licenses/gpl-3.0.html.
+    **
+    ** $QT_END_LICENSE$
+    **
+    ****************************************************************************
+-->
+
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+   <Type Name="QSpecialInteger&lt;*&gt;">
+        <DisplayString>{val}</DisplayString>
+        <Expand>
+            <Item Name="[value]">val</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QBasicAtomicInteger&lt;*&gt;">
+        <DisplayString>{_q_value}</DisplayString>
+        <Expand>
+            <Item Name="[value]">_q_value</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QBasicAtomicPointer&lt;*&gt;">
+        <Intrinsic Name="isNull" Expression="value()==0" />
+        <Intrinsic Name="value" Expression="_q_value.value()" />
+        <DisplayString Condition="isNull()">empty</DisplayString>
+        <DisplayString Condition="!isNull()">{_q_value}</DisplayString>
+        <Expand>
+            <Item Name=" " Condition="!isNull()">*value()</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QPoint">
+        <AlternativeType Name="QPointF"/>
+        <DisplayString>{{ x = {xp}, y = {yp} }}</DisplayString>
+        <Expand>
+            <Item Name="[x]">xp</Item>
+            <Item Name="[y]">yp</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QRect">
+        <DisplayString>{{ x = {x1}, y = {y1}, width = {x2 - x1 + 1}, height = {y2 - y1 + 1} }}</DisplayString>
+        <Expand>
+            <Item Name="[x]">x1</Item>
+            <Item Name="[y]">y1</Item>
+            <Item Name="[width]">x2 - x1 + 1</Item>
+            <Item Name="[height]">y2 - y1 + 1</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QRectF">
+        <DisplayString>{{ x = {xp}, y = {yp}, width = {w}, height = {h} }}</DisplayString>
+        <Expand>
+            <Item Name="[x]">xp</Item>
+            <Item Name="[y]">yp</Item>
+            <Item Name="[width]">w</Item>
+            <Item Name="[height]">h</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QSize">
+        <AlternativeType Name="QSizeF"/>
+        <DisplayString>{{ width = {wd}, height = {ht} }}</DisplayString>
+        <Expand>
+            <Item Name="[width]">wd</Item>
+            <Item Name="[height]">ht</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QLine">
+        <AlternativeType Name="QLineF"/>
+        <DisplayString>{{ start point = {pt1}, end point = {pt2} }}</DisplayString>
+        <Expand>
+            <Synthetic Name="[start point]">
+                <DisplayString>{pt1}</DisplayString>
+                <Expand>
+                    <ExpandedItem>pt1</ExpandedItem>
+                </Expand>
+            </Synthetic>
+            <Synthetic Name="[end point]">
+                <DisplayString>{pt2}</DisplayString>
+                <Expand>
+                    <ExpandedItem>pt2</ExpandedItem>
+                </Expand>
+            </Synthetic>
+
+        </Expand>
+    </Type>
+
+   <Type Name="QPolygon">
+        <DisplayString>{{ size={d-&gt;size} }}</DisplayString>
+        <Expand>
+            <Item Name="[referenced]">d-&gt;ref.atomic._q_value</Item>
+            <ArrayItems>
+                <Size>d-&gt;size</Size>
+                <ValuePointer>(QPoint*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+   <Type Name="QPolygonF">
+        <DisplayString>{{ size={d-&gt;size} }}</DisplayString>
+        <Expand>
+            <Item Name="[closed]">
+                d-&gt;size &gt; 0
+                &amp;&amp; ((((QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)[0]).xp
+                == (((QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)[d-&gt;size - 1]).xp)
+                &amp;&amp; ((((QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)[0]).yp
+                == (((QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)[d-&gt;size - 1]).yp)
+            </Item>
+            <Item Name="[referenced]">d-&gt;ref.atomic._q_value</Item>
+            <ArrayItems>
+                <Size>d-&gt;size</Size>
+                <ValuePointer>(QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="QVector2D">
+        <DisplayString>{{ x = {xp}, y = {yp} }}</DisplayString>
+        <Expand>
+            <Item Name="[x]">xp</Item>
+            <Item Name="[y]">yp</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="QVector3D">
+        <DisplayString>{{ x = {xp}, y = {yp}, z = {zp} }}</DisplayString>
+        <Expand>
+            <Item Name="[x]">xp</Item>
+            <Item Name="[y]">yp</Item>
+            <Item Name="[z]">zp</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="QVector4D">
+        <DisplayString>{{ x = {xp}, y = {yp}, z = {zp}, w = {wp} }}</DisplayString>
+        <Expand>
+            <Item Name="[x]">xp</Item>
+            <Item Name="[y]">yp</Item>
+            <Item Name="[z]">zp</Item>
+            <Item Name="[w]">wp</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="QMatrix">
+        <DisplayString>
+            {{ m11 = {_m11}, m12 = {_m12}, m21 = {_m21}, m22 = {_m22}, ... }}
+        </DisplayString>
+        <Expand>
+            <Item Name="[m11]">_m11</Item>
+            <Item Name="[m12]">_m12</Item>
+            <Item Name="[m21]">_m21</Item>
+            <Item Name="[m22]">_m22</Item>
+            <Item Name="[dx]">_dx</Item>
+            <Item Name="[dy]">_dy</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="QMatrix4x4">
+        <DisplayString>
+            {{ m11 = {m[0][0]}, m12 = {m[1][0]}, m13 = {m[2][0]}, m14 = {m[3][0]}, ... }}
+        </DisplayString>
+        <Expand>
+            <Item Name="[m11]">m[0][0]</Item>
+            <Item Name="[m12]">m[1][0]</Item>
+            <Item Name="[m13]">m[2][0]</Item>
+            <Item Name="[m14]">m[3][0]</Item>
+            <Item Name="[m21]">m[0][1]</Item>
+            <Item Name="[m22]">m[1][1]</Item>
+            <Item Name="[m23]">m[2][1]</Item>
+            <Item Name="[m24]">m[3][1]</Item>
+            <Item Name="[m31]">m[0][2]</Item>
+            <Item Name="[m32]">m[1][2]</Item>
+            <Item Name="[m33]">m[2][2]</Item>
+            <Item Name="[m34]">m[3][2]</Item>
+            <Item Name="[m41]">m[0][3]</Item>
+            <Item Name="[m42]">m[1][3]</Item>
+            <Item Name="[m43]">m[2][3]</Item>
+            <Item Name="[m44]">m[3][3]</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QSizePolicy">
+        <DisplayString>
+            {{ horizontal = {static_cast&lt;Policy&gt;(bits.horPolicy)}, vertical = {static_cast&lt;Policy&gt;(bits.verPolicy)}, type = {ControlType(1 &lt;&lt; bits.ctype)} }}
+        </DisplayString>
+        <Expand>
+            <Synthetic Name="[vertical policy]">
+                <DisplayString>QSizePolicy::Policy::{static_cast&lt;Policy&gt;(bits.verPolicy)}</DisplayString>
+            </Synthetic>
+            <Synthetic Name="[horizontal policy]">
+                <DisplayString>QSizePolicy::Policy::{static_cast&lt;Policy&gt;(bits.horPolicy)}</DisplayString>
+            </Synthetic>
+            <Synthetic Name="[control type]">
+                <DisplayString>QSizePolicy::ControlType::{ControlType(1 &lt;&lt; bits.ctype)}</DisplayString>
+            </Synthetic>
+            <Synthetic Name="[expanding directions]">
+                <DisplayString
+                    Condition="(static_cast&lt;Policy&gt;(bits.verPolicy) &amp; ExpandFlag)">
+                    Qt::Vertical (2)
+                </DisplayString>
+                <DisplayString
+                    Condition="(static_cast&lt;Policy&gt;(bits.horPolicy) &amp; ExpandFlag)">
+                    Qt::Horizontal (1)
+                </DisplayString>
+            </Synthetic>
+            <Item Name="[vertical stretch]">static_cast&lt;int&gt;(bits.verStretch)</Item>
+            <Item Name="[horizontal stretch]">static_cast&lt;int&gt;(bits.horStretch)</Item>
+            <Item Name="[has height for width]">bits.hfw == 1</Item>
+            <Item Name="[has width for height]">bits.wfh == 1</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QChar">
+        <DisplayString>{ucs,c}</DisplayString>
+        <StringView>ucs,c</StringView>
+        <Expand>
+            <Item Name="[latin 1]">ucs > 0xff ? '\0' : char(ucs),c</Item>
+            <Item Name="[unicode]">ucs,c</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QString">
+        <DisplayString>&quot;{(reinterpret_cast&lt;unsigned short*&gt;(d.ptr)),sub}&quot;</DisplayString>
+        <StringView>(reinterpret_cast&lt;unsigned short*&gt;(d.ptr)),sub</StringView>
+        <Expand>
+            <Item Name="[size]">d.size</Item>
+            <ArrayItems>
+                <Size>d.size</Size>
+                <ValuePointer>d.ptr</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="QStringRef">
+        <DisplayString Condition="m_string == nullptr">{m_string,[m_size]} u""</DisplayString>
+        <DisplayString Condition="m_string != nullptr">{m_string-&gt;d.ptr+m_position,[m_size]}</DisplayString>
+        <StringView Condition="m_string == nullptr">""</StringView>
+        <StringView Condition="m_string != nullptr">m_string,[m_position+m_size]</StringView>
+        <Expand>
+            <Item Name="[position]" ExcludeView="simple">m_position</Item>
+            <Item Name="[size]" ExcludeView="simple">m_size</Item>
+            <ArrayItems Condition="m_string != nullptr">
+                <Size>m_size</Size>
+                <ValuePointer>m_string-&gt;d.ptr+m_position</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="QStringView">
+        <DisplayString>{m_data,[m_size]}</DisplayString>
+        <StringView>m_data,[m_size]</StringView>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">m_size</Item>
+            <ArrayItems>
+                <Size>m_size</Size>
+                <ValuePointer>m_data</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="QByteArray">
+        <DisplayString>&quot;{((reinterpret_cast&lt;char*&gt;(d.ptr))),sb}&quot;</DisplayString>
+        <StringView>((reinterpret_cast&lt;char*&gt;(d.ptr))),sb</StringView>
+        <Expand>
+            <Item Name="[size]">d.size</Item>
+            <ArrayItems>
+                <Size>d.size</Size>
+                <ValuePointer>d.ptr</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="QUrl">
+        <Intrinsic Name="isEmpty" Expression="size==0">
+            <Parameter Name="size" Type="int"/>
+        </Intrinsic>
+        <Intrinsic Name="memberOffset" Expression="sizeof(QAtomicInt) + sizeof(int) + (sizeof(QString) * count)">
+            <Parameter Name="count" Type="int"/>
+        </Intrinsic>
+        <Intrinsic Name="scheme" Expression="*((QString*)(((char*)(d) + memberOffset(0))))" />
+        <Intrinsic Name="username" Expression="*((QString*)(((char*)(d) + memberOffset(1))))" />
+        <Intrinsic Name="password" Expression="*((QString*)(((char*)(d) + memberOffset(2))))" />
+        <Intrinsic Name="host" Expression="*((QString*)(((char*)(d) + memberOffset(3))))" />
+        <Intrinsic Name="path" Expression="*((QString*)(((char*)(d) + memberOffset(4))))" />
+        <Intrinsic Name="query" Expression="*((QString*)(((char*)(d) + memberOffset(5))))" />
+        <Intrinsic Name="fragment" Expression="*((QString*)(((char*)(d) + memberOffset(6))))" />
+
+        <DisplayString Condition="!isEmpty(scheme().d-&gt;size)">{scheme()}://{host()}{path()}</DisplayString>
+        <DisplayString Condition="isEmpty(scheme().d-&gt;size)">{path()}</DisplayString>
+        <Expand>
+            <Item Name="[scheme]">scheme()</Item>
+            <Item Name="[username]">username()</Item>
+            <Item Name="[password]">password()</Item>
+            <Item Name="[host]">host()</Item>
+            <Item Name="[path]">path()</Item>
+            <Item Name="[query]">query()</Item>
+            <Item Name="[fragment]">fragment()</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="QDate">
+        <DisplayString>{{ julian day = {jd} }}</DisplayString>
+    </Type>
+
+   <Type Name="QTime">
+        <Intrinsic Name="hour" Expression="mds / 3600000" />
+        <Intrinsic Name="minute" Expression="(mds % 3600000) / 60000" />
+        <Intrinsic Name="second" Expression="(mds / 1000) % 60" />
+        <Intrinsic Name="millisecond" Expression="mds % 1000" />
+        <DisplayString Condition="mds == 1">{{ millisecond = {mds} }}</DisplayString>
+        <DisplayString Condition="mds != 1">{{ milliseconds = {mds} }}</DisplayString>
+        <Expand>
+            <Item Name="[hour]"
+                  Condition="(mds / 3600000) == 1">hour(), d</Item>
+            <Item Name="[hours]"
+                  Condition="(mds / 3600000) != 1">hour(), d</Item>
+            <Item Name="[minute]"
+                  Condition="((mds % 3600000) / 60000) == 1">minute(), d</Item>
+            <Item Name="[minutes]"
+                  Condition="((mds % 3600000) / 60000) != 1">minute(), d</Item>
+            <Item Name="[second]"
+                  Condition="((mds / 1000) % 60) == 1">second(), d</Item>
+            <Item Name="[seconds]"
+                  Condition="((mds / 1000) % 60) != 1">second(), d</Item>
+            <Item Name="[millisecond]"
+                  Condition="(mds % 1000) == 1">millisecond(), d</Item>
+            <Item Name="[milliseconds]"
+                  Condition="(mds % 1000) != 1">millisecond(), d</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QPair&lt;*,*&gt;">
+        <DisplayString>({first}, {second})</DisplayString>
+        <Expand>
+            <Item Name="[first]">first</Item>
+            <Item Name="[second]">second</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QList&lt;*&gt;">
+        <AlternativeType Name="QVector&lt;*&gt;"/>
+        <DisplayString>{{ size={d.size} }}</DisplayString>
+        <Expand>
+            <ArrayItems>
+                <Size>d.size</Size>
+                <ValuePointer>reinterpret_cast&lt;$T1*&gt;(d.ptr)</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+   <Type Name="QVarLengthArray&lt;*&gt;">
+        <DisplayString>{{ size={s} }}</DisplayString>
+        <Expand>
+            <Item Name="[capacity]">a</Item>
+            <ArrayItems>
+                <Size>s</Size>
+                <ValuePointer>ptr</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+   <Type Name="QMap&lt;*,*&gt;">
+        <AlternativeType Name="QMultiMap&lt;*,*&gt;"/>
+        <DisplayString>{{ size={d.d-&gt;m._Mypair._Myval2._Myval2._Mysize} }}</DisplayString>
+        <Expand>
+            <Item Name="[std::map]">d.d-&gt;m</Item>
+        </Expand>
+    </Type>
+
+   <Type Name="QHash&lt;*,*&gt;">
+        <AlternativeType Name="QMultiHash&lt;*,*&gt;"/>
+        <DisplayString>{{ size = {d-&gt;size} }}</DisplayString>
+        <Expand>
+            <Item Name="[referenced]">d-&gt;ref.atomic._q_value</Item>
+        </Expand>
+    </Type>
+
+</AutoVisualizer>

--- a/Source/VSProps/QtCompile.props
+++ b/Source/VSProps/QtCompile.props
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup Label="UserMacros">
-    <QTDIRDefault Condition="'$(Platform)'=='x64'">$(ExternalsDir)Qt\Qt5.15.0\msvc2019_64\</QTDIRDefault>
-    <QTDIRDefault Condition="'$(Platform)'=='ARM64'">$(ExternalsDir)Qt\Qt5.15.0\msvc2019_arm64\</QTDIRDefault>
-    <QTDIR Condition="Exists('$(QTDIRDefault)') And ('$(QTDIR)'=='' Or !Exists('$(QTDIR)'))">$(QTDIRDefault)</QTDIR>
+    <ExternalsQtDir>$(ExternalsDir)Qt\Qt6.3.0\</ExternalsQtDir>
+    <QtTargetDirDefault>$(ExternalsQtDir)$(Platform)\</QtTargetDirDefault>
+    <QTDIR Condition="Exists('$(QtTargetDirDefault)') And ('$(QTDIR)'=='' Or !Exists('$(QTDIR)'))">$(QtTargetDirDefault)</QTDIR>
     <QTDIR Condition="Exists('$(QTDIR)') And !HasTrailingSlash('$(QTDIR)')">$(QTDIR)\</QTDIR>
     <QtDirValid>false</QtDirValid>
     <QtDirValid Condition="Exists('$(QTDIR)')">true</QtDirValid>
@@ -13,6 +13,7 @@
     <QtPluginsDir>$(QTDIR)plugins\</QtPluginsDir>
     <QtToolOutDir>$(IntDir)</QtToolOutDir>
     <QtDebugSuffix>d</QtDebugSuffix>
+    <QtHostToolsDir>$(ExternalsQtDir)x64\</QtHostToolsDir>
     <QtLibSuffix Condition="'$(Configuration)'=='Debug'">$(QtDebugSuffix)</QtLibSuffix>
     <QtPluginFolder>QtPlugins</QtPluginFolder>
   </PropertyGroup>
@@ -25,16 +26,15 @@
       <AdditionalIncludeDirectories>$(QtIncludeDir)QtCore;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(QtIncludeDir)QtGui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(QtIncludeDir)QtWidgets;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Platform)'=='ARM64'">$(QtIncludeDir)QtANGLE;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <!--
-        Ignore warnings in locally-instantiated Qt templates.
-        This should be removed at some point (when Qt is fixed).
-        -->
-      <ExternalTemplatesDiagnostics>false</ExternalTemplatesDiagnostics>
+        As of Qt6.3, Qt needs user code deriving from certain Qt types to have RTTI (AS WELL AS MOC, UGH).
+        Do NOT enable in dolphin outside of Qt-dependant code.
+      -->
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(QtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Qt5Core$(QtLibSuffix).lib;Qt5Gui$(QtLibSuffix).lib;Qt5Widgets$(QtLibSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Qt6Core$(QtLibSuffix).lib;Qt6Gui$(QtLibSuffix).lib;Qt6Widgets$(QtLibSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <!--
       <AdditionalOptions>"/manifestdependency:type='Win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\" %(AdditionalOptions)</AdditionalOptions>
@@ -43,8 +43,8 @@
   </ItemDefinitionGroup>
 
   <!--
-    Use the moc implementation provided by "Qt VS Tools"
-    see: https://code.qt.io/cgit/qt-labs/vstools.git/tree/src/qtmsbuild
+    Use the moc implementation provided by (somewhat out-of-date version of) "Qt VS Tools"
+    see: https://code.qt.io/cgit/qt-labs/vstools.git/tree/QtMSBuild
     This provides a wrapper around moc which deals with parallel dispatch to moc,
     as well as creating ClCompile inputs from the moc outputs.
     Note that we currently pass the same ClCompile.PreprocessorDefinitions to moc,
@@ -54,8 +54,14 @@
   <Import Project="qtmoc.props" />
   <ItemDefinitionGroup>
     <QtMoc>
-      <OutputFile>$(QtToolOutDir)moc_%(Filename).cpp</OutputFile>
-      <QtMocDir>$(QtToolOutDir)</QtMocDir>
+      <!--
+        moc task does not properly detect outputs are outdated if Qt version changes
+        (possibly causing Q_MOC_OUTPUT_REVISION to change). This *might* be because we
+        don't give moc the include paths, so it doesn't notice the version change.
+        In any case, we can workaround it by manually changing output path when needed
+        to avoid conflicts. (the numeric postfix is the value of Q_MOC_OUTPUT_REVISION)
+        -->
+      <OutputFile>$(QtToolOutDir)moc_68\moc_%(Filename).cpp</OutputFile>
     </QtMoc>
   </ItemDefinitionGroup>
   <Import Project="qt_globals.targets"/>
@@ -72,34 +78,32 @@
 
   <!--Copy the needed dlls-->
   <ItemGroup>
-    <QtLibNames Include="Qt5Core$(QtLibSuffix);Qt5Gui$(QtLibSuffix);Qt5Widgets$(QtLibSuffix)" />
-
-    <!-- Include ANGLE for ARM64 since there is no native OpenGL -->
-    <QtLibNames Condition="'$(Platform)'=='ARM64'" Include="$(QtLibNames);libEGL$(QtLibSuffix);libGLESv2$(QtLibSuffix)" />
-
-    <QtDlls Include="@(QtLibNames -> '$(QtBinDir)%(Identity).dll')" />
-    <!--Filter plugins to copy based on the observation that all debug versions end in "d"-->
-    <QtAllPlugins Include="$(QtPluginsDir)**\*$(QtLibSuffix).dll" />
-    <QtPlugins Condition="'$(Configuration)'=='Debug'" Include="@(QtAllPlugins)" />
-    <QtPlugins Condition="'$(Configuration)'=='Release'" Exclude="$(QtPluginsDir)**\*$(QtDebugSuffix).dll" Include="@(QtAllPlugins)" />
-    <QtPluginsDest Include="@(QtPlugins -> '$(BinaryOutputDir)$(QtPluginFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <QtDllNames_ Include="Qt6Core;Qt6Gui;Qt6Widgets" />
+    <QtDllNames Include="@(QtDllNames_ -> '%(Identity)$(QtLibSuffix).dll')" />
+    <QtDllsSrc Include="@(QtDllNames -> '$(QtBinDir)%(Identity)')" />
+    <QtDllsDst Include="@(QtDllNames -> '$(BinaryOutputDir)%(Identity)')" />
+    <QtPluginNames_ Include="imageformats\qgif;imageformats\qicns;imageformats\qico;imageformats\qjpeg;
+      imageformats\qtga;imageformats\qwbmp;platforms\qdirect2d;platforms\qminimal;platforms\qoffscreen;
+      platforms\qwindows;styles\qwindowsvistastyle"/>
+    <QtPluginNames Include="@(QtPluginNames_ -> '%(Identity)$(QtLibSuffix).dll')" />
+    <QtPluginsSrc Include="@(QtPluginNames -> '$(QtPluginsDir)%(Identity)')" />
+    <QtPluginsDst Include="@(QtPluginNames -> '$(BinaryOutputDir)$(QtPluginFolder)\%(Identity)')" />
   </ItemGroup>
   <PropertyGroup>
     <QtConfFile>$(BinaryOutputDir)qt.conf</QtConfFile>
   </PropertyGroup>
   <Target Name="QtCopyBinaries"
     AfterTargets="Build"
-    Inputs="@(QtDlls);@(QtPlugins)"
-    Outputs="@(QtDlls -> '$(BinaryOutputDir)%(RecursiveDir)%(Filename)%(Extension)');@(QtPlugins -> '$(BinaryOutputDir)$(QtPluginFolder)\%(RecursiveDir)%(Filename)%(Extension)')">
-    <Message Text="Copying Qt .dlls" Importance="High" />
+    Inputs="@(QtDllsSrc);@(QtPluginsSrc)"
+    Outputs="@(QtDllsDst);@(QtPluginsDst)">
     <Copy
-      SourceFiles="@(QtDlls)"
-      DestinationFolder="$(BinaryOutputDir)"
+      SourceFiles="@(QtDllsSrc)"
+      DestinationFiles="@(QtDllsDst)"
       SkipUnchangedFiles="true"
     />
     <Copy
-      SourceFiles="@(QtPlugins)"
-      DestinationFiles="@(QtPluginsDest)"
+      SourceFiles="@(QtPluginsSrc)"
+      DestinationFiles="@(QtPluginsDst)"
       SkipUnchangedFiles="true"
     />
   </Target>

--- a/Source/VSProps/qtmoc.props
+++ b/Source/VSProps/qtmoc.props
@@ -50,7 +50,7 @@
       <ExecutionDescription>moc %(Identity)</ExecutionDescription>
 
       <QTDIR Condition="'$(QtVsProjectSettings)' != 'true'"
-        >$(QTDIR)</QTDIR>
+        >$(QtHostToolsDir)</QTDIR>
       <QTDIR Condition="'$(QtVsProjectSettings)' == 'true'"
         >$(QtInstallDir)</QTDIR>
 


### PR DESCRIPTION
The main point of this PR is to generate builds that can be tested, track bugs and comments on the [qt submodule update](https://github.com/shuffle2/ext-win-qt/tree/qt6.3.0). Would love review of the [build config](https://github.com/shuffle2/ext-win-qt/blob/qt6.3.0/Qt6.3.0/dolphin-x64.yml). I was able to disable a significant enough portion of the Qt modules such that I could add the compressed pdbs into the repo and still come in at less total size than the previous commit.

I've removed the pdb archives from the qt repo to minimize size as much as possible, but not sure what the best way to keep them available for people is. any ideas?

An ARM64 build is [here](https://drive.google.com/file/d/1vKfsEoC7WPPFwv0IjE-axxk7BY3XVlZq/view?usp=sharing)

Some known issues:
None!, Find some!

Fixed issues:
1. Either Qt or compiler bug relating to atomic ptr template https://bugreports.qt.io/browse/QTBUG-102246 . It seems to be a msvc arm64 compiler bug: https://developercommunity.visualstudio.com/t/codegen-elides-initializers-when-copying/10004323 . (or, can someone point out how the source code is invalid?)
   * Fix Version/s: 6.2.5, 6.3.1 (planned: 13.5.2022), 6.4.0 Beta1
   * I've manually applied the patch for the Qt build. But it only makes a difference for ARM64, anyway.
2. Apparently high dpi scaling issue? https://github.com/dolphin-emu/dolphin/pull/10546#issuecomment-1086663371 Would be great if someone more familiar with Qt could comment on if that's expected / new behavior / what to do / etc.
   * at least initially, I've made Qt6 use Qt5's scaling behavior to fix this
3. There is some change-detection issue with the current msbuild moc setup, which will cause problems for the buildbot if it tries to switch back and forth between Qt5 and Qt6 builds.
   * this should be fixed cleanly (i've changed the build to output the moc files to different directory)

note: this will need the changes in my branch of ext-win-qt submodule merged into the dolphin copy of that repo, and the submodule in this PR switched back.

I've created a PR for the submodule here: https://github.com/dolphin-emu/ext-win-qt/pull/18