### PR TITLE
Debugger MemoryWidget: More display types, use combo box for options

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -16,13 +16,20 @@ class MemoryViewWidget : public QTableWidget
 {
   Q_OBJECT
 public:
-  enum class Type
+  enum class Type : int
   {
-    U8,
-    U16,
-    U32,
+    Hex8 = 1,
+    Hex16,
+    Hex32,
+    Unsigned8,
+    Unsigned16,
+    Unsigned32,
+    Signed8,
+    Signed16,
+    Signed32,
     ASCII,
-    Float32
+    Float32,
+    Double
   };
 
   enum class BPType
@@ -41,7 +48,7 @@ public:
 
   void SetAddressSpace(AddressSpace::Type address_space);
   AddressSpace::Type GetAddressSpace() const;
-  void SetType(Type type);
+  void SetDisplay(Type type, int bytes_per_row, int alignment);
   void SetBPType(BPType type);
   void SetAddress(u32 address);
 
@@ -65,11 +72,14 @@ private:
   void OnCopyHex();
 
   AddressSpace::Type m_address_space{};
-  Type m_type = Type::U8;
+  Type m_type = Type::Hex8;
   BPType m_bp_type = BPType::ReadWrite;
   bool m_do_log = true;
   u32 m_context_address;
+  u32 m_base_address;
   u32 m_address = 0;
   int m_font_width = 0;
   int m_font_vspace = 0;
+  int m_bytes_per_row = 16;
+  int m_alignment = 16;
 };

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -64,7 +64,7 @@ private:
   void SaveSettings();
 
   void OnAddressSpaceChanged();
-  void OnTypeChanged();
+  void OnDisplayChanged();
   void OnBPLogChanged();
   void OnBPTypeChanged();
 
@@ -95,6 +95,9 @@ private:
   QLineEdit* m_data_edit;
   QCheckBox* m_base_check;
   QLabel* m_data_preview;
+  QComboBox* m_display_combo;
+  QComboBox* m_align_combo;
+  QComboBox* m_row_length_combo;
   QPushButton* m_set_value;
   QPushButton* m_from_file;
   QPushButton* m_dump_mram;
@@ -112,13 +115,6 @@ private:
   QRadioButton* m_address_space_physical;
   QRadioButton* m_address_space_effective;
   QRadioButton* m_address_space_auxiliary;
-
-  // Datatypes
-  QRadioButton* m_type_u8;
-  QRadioButton* m_type_u16;
-  QRadioButton* m_type_u32;
-  QRadioButton* m_type_ascii;
-  QRadioButton* m_type_float;
 
   // Breakpoint options
   QRadioButton* m_bp_read_write;


### PR DESCRIPTION
Added Int8/16/32 and double..

![PR_display](https://user-images.githubusercontent.com/10532806/161950146-f4d468e3-57e9-4e3e-af84-a1af246689a5.jpg)

- Do we want signed displays?
- 1.234e+09 syntax looks like it could be better, but what would I replace it with? Remove the +?
- Int8 looks terrible, but will look fine if we add a dual view  - two different column types with 4 bytes per row
- I left display type as a group, as it will likely get more items soon.
- Do we need to rename U8/16/32?
- Thoughts on sidebar rearrangement?

Most importantly, what else do I need to add? Do we need more customization in this PR like bytes per row?  A dual-view would require a lot of rearranging in the Update function to pass two view types through it. I think I would spin off column value updates and breakpoint tagging updates to two different functions, but will take suggestions on a better method to do it.