### PR TITLE
VideoCommon/FrameDump: Fix log messages with arguments.

### DIFF
--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -103,6 +103,9 @@ void GenericLog(LogLevel level, LogType type, const char* file, int line, const 
     __attribute__((format(printf, 5, 6)))
 #endif
     ;
+
+void GenericLogV(LogLevel level, LogType type, const char* file, int line, const char* fmt,
+                 va_list args);
 }  // namespace Common::Log
 
 // Let the compiler optimize this out
@@ -137,6 +140,13 @@ void GenericLog(LogLevel level, LogType type, const char* file, int line, const 
   do                                                                                               \
   {                                                                                                \
     GENERIC_LOG(Common::Log::LogType::t, Common::Log::LogLevel::LDEBUG, __VA_ARGS__);              \
+  } while (0)
+
+#define GENERIC_LOG_V(t, v, fmt, args)                                                             \
+  do                                                                                               \
+  {                                                                                                \
+    if (v <= Common::Log::MAX_LOGLEVEL)                                                            \
+      Common::Log::GenericLogV(v, t, __FILE__, __LINE__, fmt, args);                               \
   } while (0)
 
 // fmtlib capable API

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -80,6 +80,22 @@ void GenericLog(LogLevel level, LogType type, const char* file, int line, const 
   instance->Log(level, type, file, line, message);
 }
 
+void GenericLogV(LogLevel level, LogType type, const char* file, int line, const char* fmt,
+                 va_list args)
+{
+  auto* instance = LogManager::GetInstance();
+  if (instance == nullptr)
+    return;
+
+  if (!instance->IsEnabled(type, level))
+    return;
+
+  char message[MAX_MSGLEN];
+  CharArrayFromFormatV(message, MAX_MSGLEN, fmt, args);
+
+  instance->Log(level, type, file, line, message);
+}
+
 void GenericLogFmtImpl(LogLevel level, LogType type, const char* file, int line,
                        fmt::string_view format, const fmt::format_args& args)
 {

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -94,7 +94,7 @@ void InitAVCodec()
         // keep libav debug messages visible in release build of dolphin
         log_level = Common::Log::LogLevel::LINFO;
 
-      GENERIC_LOG(Common::Log::LogType::FRAMEDUMP, log_level, fmt, vl);
+      GENERIC_LOG_V(Common::Log::LogType::FRAMEDUMP, log_level, fmt, vl);
     });
 
     // TODO: We never call avformat_network_deinit.


### PR DESCRIPTION
Noticed this while making #10571. Unfortunately you can't just pass a `va_list` to a variadic function, so this printed garbage when the log message included arguments.