### PR TITLE
DolphinQt/HacksWidget: Re-enable texture accuracy slider if it was disabled because of a custom value.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -154,6 +154,9 @@ void HacksWidget::LoadSettings()
   const QSignalBlocker blocker(m_accuracy);
   auto samples = Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES);
 
+  // Re-enable the slider in case it was disabled because of a custom value
+  m_accuracy->setEnabled(true);
+
   int slider_pos = 0;
 
   switch (samples)


### PR DESCRIPTION
Rebase of #10472, since the author of that one ignored our change requests.