### PR TITLE
Debugger MemoryWidget: Add dual views

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -21,6 +21,7 @@ public:
     Hex8 = 1,
     Hex16,
     Hex32,
+    Hex64,
     Unsigned8,
     Unsigned16,
     Unsigned32,
@@ -74,7 +75,7 @@ private:
   void UpdateColumns(Type type, int first_column);
 
   AddressSpace::Type m_address_space{};
-  Type m_type = Type::Hex8;
+  Type m_type = Type::Hex32;
   BPType m_bp_type = BPType::ReadWrite;
   bool m_do_log = true;
   u32 m_context_address;

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -48,7 +48,7 @@ public:
 
   void SetAddressSpace(AddressSpace::Type address_space);
   AddressSpace::Type GetAddressSpace() const;
-  void SetDisplay(Type type, int bytes_per_row, int alignment);
+  void SetDisplay(Type type, int bytes_per_row, int alignment, bool dual_view);
   void SetBPType(BPType type);
   void SetAddress(u32 address);
 
@@ -70,6 +70,8 @@ private:
   void OnContextMenu();
   void OnCopyAddress();
   void OnCopyHex();
+  void UpdateBreakpointTags();
+  void UpdateColumns(Type type, int first_column);
 
   AddressSpace::Type m_address_space{};
   Type m_type = Type::Hex8;
@@ -82,4 +84,5 @@ private:
   int m_font_vspace = 0;
   int m_bytes_per_row = 16;
   int m_alignment = 16;
+  bool m_dual_view = false;
 };

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -215,9 +215,12 @@ void MemoryWidget::CreateWidgets()
   m_row_length_combo->addItem(tr("8 Bytes"), 8);
   m_row_length_combo->addItem(tr("16 Bytes"), 16);
 
+  m_dual_check = new QCheckBox(tr("Dual View"));
+
   displaytype_layout->addWidget(m_display_combo);
   displaytype_layout->addWidget(m_align_combo);
   displaytype_layout->addWidget(m_row_length_combo);
+  displaytype_layout->addWidget(m_dual_check);
 
   // MBP options
   auto* bp_group = new QGroupBox(tr("Memory breakpoint options"));
@@ -317,6 +320,8 @@ void MemoryWidget::ConnectWidgets()
     connect(combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
             &MemoryWidget::OnDisplayChanged);
   }
+
+  connect(m_dual_check, &QCheckBox::toggled, this, &MemoryWidget::OnDisplayChanged);
 
   for (auto* radio : {m_bp_read_write, m_bp_read_only, m_bp_write_only})
     connect(radio, &QRadioButton::toggled, this, &MemoryWidget::OnBPTypeChanged);
@@ -431,6 +436,10 @@ void MemoryWidget::OnDisplayChanged()
   const auto type = static_cast<MemoryViewWidget::Type>(m_display_combo->currentData().toInt());
   int bytes_per_row = m_row_length_combo->currentData().toInt();
   int alignment;
+  bool dual_view = m_dual_check->isChecked();
+
+  if (dual_view)
+    bytes_per_row = 4;
 
   if (type == MemoryViewWidget::Type::Double && bytes_per_row == 4)
     bytes_per_row = 8;
@@ -443,7 +452,7 @@ void MemoryWidget::OnDisplayChanged()
   else
     alignment = m_align_combo->currentData().toInt();
 
-  m_memory_view->SetDisplay(type, bytes_per_row, alignment);
+  m_memory_view->SetDisplay(type, bytes_per_row, alignment, dual_view);
 
   SaveSettings();
 }

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -215,6 +215,7 @@ void MemoryWidget::CreateWidgets()
   m_row_length_combo->addItem(tr("8 Bytes"), 8);
   m_row_length_combo->addItem(tr("16 Bytes"), 16);
 
+  m_row_length_combo->setCurrentIndex(2);
   m_dual_check = new QCheckBox(tr("Dual View"));
 
   displaytype_layout->addWidget(m_display_combo);
@@ -438,14 +439,11 @@ void MemoryWidget::OnDisplayChanged()
   int alignment;
   bool dual_view = m_dual_check->isChecked();
 
-  if (dual_view)
-    bytes_per_row = 4;
-
   if (type == MemoryViewWidget::Type::Double && bytes_per_row == 4)
     bytes_per_row = 8;
 
   // Alignment: First (fixed) option equals bytes per row. 'currentData' is correct for other
-  // options. Type-based must be calculated in memoryviewwidget and is left at 0. No alignment is
+  // options. Type-based must be calculated in memoryviewwidget and is left at 0. "No alignment" is
   // equivalent to a value of 1.
   if (m_align_combo->currentIndex() == 0)
     alignment = bytes_per_row;

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -98,6 +98,7 @@ private:
   QComboBox* m_display_combo;
   QComboBox* m_align_combo;
   QComboBox* m_row_length_combo;
+  QCheckBox* m_dual_check;
   QPushButton* m_set_value;
   QPushButton* m_from_file;
   QPushButton* m_dump_mram;


### PR DESCRIPTION
Relies on  #10563.  Restores the dual views ability that WX had, and improves on it.

![PR_dual_view](https://user-images.githubusercontent.com/10532806/162720085-113720ab-8344-4e82-be5c-df48cdfe9d14.jpg)

Looking for input on how customizable it should be. Currently it's always 4 bytes per row and the left side is always hex. It auto chooses the size/columns based on what is on the right.  The second display type box, for bytes per row, doesn't do anything in dual view, because it's always 4 bytes or 8 bytes for a double.

I think the left side always being hex is fine.

Currently Double has a small breakpoint display bug.  I also just added the Hex8/Hex16 ability to the left side, so it got a little more complicated than just having Hex32. I'll maybe need to clean it up more.