### PR TITLE
Common/StringUtil: Use simpler formatting for floats and doubles.

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -279,12 +279,12 @@ std::string ValueToString(u64 value)
 
 std::string ValueToString(float value)
 {
-  return fmt::format("{:#.9g}", value);
+  return fmt::format("{:#}", value);
 }
 
 std::string ValueToString(double value)
 {
-  return fmt::format("{:#.17g}", value);
+  return fmt::format("{:#}", value);
 }
 
 std::string ValueToString(int value)


### PR DESCRIPTION
This prints floating point values nicer to the INI, and possibly other places; eg. `0.2` instead of `0.200000003`. For those worried about precision loss, fmt guarantees that writing floats with the default formatting round-trip correctly. [See the 'none' formatting type for floats here](https://fmt.dev/latest/syntax.html), and [the readme specifically mentions round-trip guarantees](https://github.com/fmtlib/fmt/blob/master/README.rst) -- also I've used fmt for some time now professionally and as far as I can tell this is true.

The `#` additionally forces the generation of a decimal point even when it wouldn't be necessary, which means values won't be misidentified as integers when parsing without type information.


(note that I noticed this because of [this extremely silly list of ini options](https://wiki.dolphin-emu.org/index.php?title=GameINI#Emulation_Speed_.28formerly_Framelimit.29) written by someone who clearly has no knowledge about floating point numbers)