### PR TITLE
Test (for fifoci): determine uses of specular lights

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -16,6 +16,7 @@
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/PerfQueryBase.h"
+#include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoCommon.h"
 
 namespace EfbInterface
@@ -411,6 +412,12 @@ static void Dither(u16 x, u16 y, u8* color)
 void BlendTev(u16 x, u16 y, u8* color)
 {
   const u32 offset = GetColorOffset(x, y);
+  if (VertexShaderManager::g_UsingSpecularLight)
+  {
+    u8 black[4] = {0, 0, 0, 0};
+    SetPixelColorOnly(offset, black);
+    return;
+  }
   u32 dstClr = GetPixelColor(offset);
 
   u8* dstClrPtr = (u8*)&dstClr;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -48,6 +48,7 @@ static Common::Matrix44 s_viewportCorrection;
 
 VertexShaderConstants VertexShaderManager::constants;
 bool VertexShaderManager::dirty;
+bool VertexShaderManager::g_UsingSpecularLight = false;
 
 // Viewport correction:
 // In D3D, the viewport rectangle must fit within the render target.

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -40,4 +40,5 @@ public:
 
   static VertexShaderConstants constants;
   static bool dirty;
+  static bool g_UsingSpecularLight;
 };

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -240,6 +240,19 @@ void LoadXFReg(u16 base_address, u8 transfer_size, const u8* data)
       XFRegWritten(address, value);
       ((u32*)&xfmem)[address] = value;
 
+      if (address == XFMEM_SETCHAN0_COLOR || address == XFMEM_SETCHAN0_ALPHA ||
+          address == XFMEM_SETCHAN1_COLOR || address == XFMEM_SETCHAN1_ALPHA ||
+          address == XFMEM_SETNUMCHAN)
+      {
+        VertexShaderManager::g_UsingSpecularLight =
+            (xfmem.numChan.numColorChans >= 1 &&
+             (xfmem.color[0].attnfunc == AttenuationFunc::Spec ||
+              xfmem.alpha[0].attnfunc == AttenuationFunc::Spec)) ||
+            (xfmem.numChan.numColorChans >= 2 &&
+             (xfmem.color[1].attnfunc == AttenuationFunc::Spec ||
+              xfmem.alpha[1].attnfunc == AttenuationFunc::Spec));
+      }
+
       data += 4;
     }
   }


### PR DESCRIPTION
In the software renderer: pixel colors are set to black.

With specialized shaders: std::exit to generate a failure on fifoci (which allows comparing where they're used but don't show up in the end result... kinda.)