### PR TITLE
Apple M1: Fix "Building and running unit tests" message

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -337,7 +337,7 @@ def build(config):
             if not os.path.exists(arch):
                 os.mkdir(arch)
 
-            print("Building and running unit tests for: {arch}")
+            print(f"Building and running unit tests for: {arch}")
             unit_test_results[arch] = \
                 subprocess.call(["cmake", "--build", ".",
                                  "--config", config["build_type"],


### PR DESCRIPTION
For `{arch}` to be converted, the string needs to be an f-string.  See e.g. the end of https://dolphin.ci/#/builders/26/builds/2728/steps/4/logs/stdio:

> ```
> Built Universal Binary successfully!
> Building and running unit tests for: {arch}
> Building and running unit tests for: {arch}
> x86_64 Unit Tests: PASSED
> arm64 Unit Tests: FAILED (1)
> ```

This change is untested, but should be checkable once the osx build occurs.