### PR TITLE
HW/Memmap: Refuse to load savestate if memory settings are different.

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static std::recursive_mutex g_save_thread_mutex;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 139;  // Last changed in PR 8350
+constexpr u32 STATE_VERSION = 140;  // Last changed in PR 10591
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This fixes ugly error messages (and potentially crashes, the state read logic doesn't seem to check if it reads past the end of the buffer...) when you try to load a GameCube savestate with MMU enabled when MMU is off and vice-versa.