### PR TITLE
Qt/GameCubePane: Don't trigger config change events when populating GUI.

### DIFF
--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -37,6 +37,7 @@
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
+#include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/BroadbandAdapterSettingsDialog.h"
 
@@ -438,9 +439,9 @@ void GameCubePane::BrowseGBASaves()
 void GameCubePane::LoadSettings()
 {
   // IPL Settings
-  m_skip_main_menu->setChecked(Config::Get(Config::MAIN_SKIP_IPL));
-  m_language_combo->setCurrentIndex(
-      m_language_combo->findData(Config::Get(Config::MAIN_GC_LANGUAGE)));
+  SignalBlocking(m_skip_main_menu)->setChecked(Config::Get(Config::MAIN_SKIP_IPL));
+  SignalBlocking(m_language_combo)
+      ->setCurrentIndex(m_language_combo->findData(Config::Get(Config::MAIN_GC_LANGUAGE)));
 
   bool have_menu = false;
 
@@ -461,22 +462,26 @@ void GameCubePane::LoadSettings()
   // Device Settings
   for (ExpansionInterface::Slot slot : ExpansionInterface::SLOTS)
   {
-    QSignalBlocker blocker(m_slot_combos[slot]);
     const ExpansionInterface::EXIDeviceType exi_device =
         Config::Get(Config::GetInfoForEXIDevice(slot));
-    m_slot_combos[slot]->setCurrentIndex(
-        m_slot_combos[slot]->findData(static_cast<int>(exi_device)));
+    SignalBlocking(m_slot_combos[slot])
+        ->setCurrentIndex(m_slot_combos[slot]->findData(static_cast<int>(exi_device)));
     UpdateButton(slot);
   }
 
 #ifdef HAS_LIBMGBA
   // GBA Settings
-  m_gba_threads->setChecked(Config::Get(Config::MAIN_GBA_THREADS));
-  m_gba_bios_edit->setText(QString::fromStdString(File::GetUserPath(F_GBABIOS_IDX)));
-  m_gba_save_rom_path->setChecked(Config::Get(Config::MAIN_GBA_SAVES_IN_ROM_PATH));
-  m_gba_saves_edit->setText(QString::fromStdString(File::GetUserPath(D_GBASAVES_IDX)));
+  SignalBlocking(m_gba_threads)->setChecked(Config::Get(Config::MAIN_GBA_THREADS));
+  SignalBlocking(m_gba_bios_edit)
+      ->setText(QString::fromStdString(File::GetUserPath(F_GBABIOS_IDX)));
+  SignalBlocking(m_gba_save_rom_path)->setChecked(Config::Get(Config::MAIN_GBA_SAVES_IN_ROM_PATH));
+  SignalBlocking(m_gba_saves_edit)
+      ->setText(QString::fromStdString(File::GetUserPath(D_GBASAVES_IDX)));
   for (size_t i = 0; i < m_gba_rom_edits.size(); ++i)
-    m_gba_rom_edits[i]->setText(QString::fromStdString(Config::Get(Config::MAIN_GBA_ROM_PATHS[i])));
+  {
+    SignalBlocking(m_gba_rom_edits[i])
+        ->setText(QString::fromStdString(Config::Get(Config::MAIN_GBA_ROM_PATHS[i])));
+  }
 #endif
 }
 


### PR DESCRIPTION
Like #10484 but for the GameCubePane. Extracted from #10495 to reduce the size of that.