### PR TITLE
Minor text capitalization

### DIFF
--- a/Data/Sys/GameSettings/D43E01.ini
+++ b/Data/Sys/GameSettings/D43E01.ini
@@ -23,7 +23,7 @@ $Infinite Hover When Moving
 02CA2AB2 0000000F
 $Infinite Rupees
 02BE181C 000003E7
-$Swords/Shields/boots/tunics
+$Swords/Shields/Boots/Tunics
 02BE1884 00007777
 $Have Quiver (Adult)
 00BE1889 00000001


### PR DESCRIPTION
Changed "$Swords/Shields/boots/tunics" to "$Swords/Shields/Boots/Tunics" for consistent capitalization in the line.