### PR TITLE
Android: Fix in game menu rippleColor and colorEdgeEffect

### DIFF
--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -27,7 +27,8 @@
         android:layout_height="0dp"
         android:layout_weight="1"
         android:scrollbarSize="8dp"
-        android:fadeScrollbars="false">
+        android:fadeScrollbars="false"
+        android:theme="@style/InGameScrollView">
 
         <LinearLayout
             android:id="@+id/layout_options"

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -29,7 +29,6 @@
     </style>
 
     <!-- Themes for Dialogs -->
-
     <style name="DolphinDialogBase" parent="Theme.Material3.DayNight.Dialog.Alert">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorAccent">@color/dolphin_blue_secondary</item>
@@ -70,6 +69,10 @@
         <item name="browseTitleViewLayout">@layout/titleview</item>
     </style>
 
+    <style name="InGameScrollView">
+        <item name="android:colorEdgeEffect">@color/dolphin_blue_secondary</item>
+    </style>
+
     <style name="InGameMenuOption" parent="Widget.Material3.Button.TextButton">
         <item name="android:textSize">16sp</item>
         <item name="android:fontFamily">sans-serif-condensed</item>
@@ -81,6 +84,7 @@
         <item name="android:paddingLeft">32dp</item>
         <item name="android:paddingRight">32dp</item>
         <item name="android:layout_margin">0dp</item>
+        <item name="rippleColor">@color/dolphin_blue_secondary</item>
     </style>
 
     <style name="OverlayInGameMenuOption" parent="InGameMenuOption">


### PR DESCRIPTION
The ripple effect was not visible when pressing a button. I've also fixed the color edge effect since it used the primary color and was therefore invisible too.

Before:

https://user-images.githubusercontent.com/26326692/164316507-742c5f24-b7c2-4658-bd2c-39b28ea802d4.mp4

After:

https://user-images.githubusercontent.com/26326692/164316509-82b045d6-ffd5-4b2b-b85f-99c7f5bbc36e.mp4
