### PR TITLE
Android: Modernize game card

### DIFF
--- a/Source/Android/app/src/main/res/layout/card_game.xml
+++ b/Source/Android/app/src/main/res/layout/card_game.xml
@@ -1,57 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:layout_width="160dp"
-    android:layout_height="249dp"
-    android:transitionName="card_game"
-    android:focusable="true"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
     android:clickable="true"
-    android:foreground="?android:attr/selectableItemBackground"
-    app:cardCornerRadius="8dp">
+    android:clipToPadding="false"
+    android:focusable="true"
+    android:orientation="vertical"
+    android:paddingStart="4dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="4dp"
+    android:transitionName="card_game"
+    tools:layout_width="160dp">
 
-    <LinearLayout
+    <androidx.cardview.widget.CardView
+        android:id="@+id/card_game_art"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="159dp"
+        android:layout_gravity="center"
+        app:cardCornerRadius="4dp"
+        tools:layout_width="140dp">
 
         <ImageView
             android:id="@+id/image_game_screen"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
+            android:layout_height="match_parent"
             android:layout_weight="1"
-            tools:src="@drawable/placeholder_screenshot"
-            tools:scaleType="centerCrop"/>
+            tools:scaleType="centerCrop"
+            tools:src="@drawable/placeholder_screenshot" />
+    </androidx.cardview.widget.CardView>
 
-        <TextView
-            android:id="@+id/text_game_title"
-            style="@android:style/TextAppearance.Material.Subhead"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:layout_marginTop="16dp"
-            android:ellipsize="end"
-            android:lines="1"
-            android:maxLines="1"
-            tools:text="The Legend of Zelda: The Wind Waker"/>
+    <TextView
+        android:id="@+id/text_game_title"
+        style="@android:style/TextAppearance.Material.Subhead"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:layout_marginTop="8dp"
+        android:ellipsize="end"
+        android:maxLines="2"
+        tools:layout_width="140dp"
+        tools:text="The Legend of Zelda: The Wind Waker" />
 
-        <TextView
-            android:id="@+id/text_game_caption"
-            style="@android:style/TextAppearance.Material.Caption"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:ellipsize="end"
-            android:lines="1"
-            android:maxLines="1"
-            tools:text="Nintendo"/>
+    <TextView
+        android:id="@+id/text_game_caption"
+        style="@android:style/TextAppearance.Material.Caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:ellipsize="end"
+        android:lines="1"
+        android:maxLines="1"
+        tools:layout_width="140dp"
+        tools:text="Nintendo" />
 
-    </LinearLayout>
-
-</androidx.cardview.widget.CardView>
-
+</LinearLayout>


### PR DESCRIPTION
Remove background on card
Increase max # of lines for game title
Root layout is now a linear layout with the card view rounding the corners on the box art

Depending on 

Before - 
![Before](https://user-images.githubusercontent.com/14132249/164760565-a26bee0f-9cdb-4d1e-81c2-099d13d6933c.png)

After - 
![After](https://user-images.githubusercontent.com/14132249/164760588-774bded3-9bdf-40f0-8a1c-976fb874f3bb.png)