### PR TITLE
Vulkan: Improve shader compile error handling

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -173,7 +173,7 @@ static std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage,
     stream << "Video Backend: " + g_video_backend->GetDisplayName();
     stream.close();
 
-    PanicAlertFmt("{} (written to {})", msg, filename);
+    PanicAlertFmt("{} (written to {})\nDebug info:\n{}", msg, filename, shader->getInfoLog());
   };
 
   if (!shader->parse(GetCompilerResourceLimits(), default_version, profile, false, true, messages,

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -171,6 +171,7 @@ static std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage,
     stream << "\n";
     stream << "Dolphin Version: " + Common::GetScmRevStr() + "\n";
     stream << "Video Backend: " + g_video_backend->GetDisplayName();
+    stream.close();
 
     PanicAlertFmt("{} (written to {})", msg, filename);
   };


### PR DESCRIPTION
Two fairly minor improvements:

* Close the output stream on shader compile error before showing the panic alert: This fixes the file showing up as 0 bytes in Windows Explorer (although the file would still display properly when opened).
* Include the info log in the shader compile error panic alert: The other backends do this, and it is helpful for quickly identifying errors during development.

Here's what the warning looked like beforehand:

![image](https://user-images.githubusercontent.com/8334194/164817538-1eb7389f-f27a-4481-a5a0-18de35251586.png)

And here's the new warning:

![image](https://user-images.githubusercontent.com/8334194/164817544-ee22a4f5-ca2c-40cb-a52a-7451a20dcffc.png)

And the relevant code on other backends, for reference:

https://github.com/dolphin-emu/dolphin/blob/2e01dc0c82b5f73215e3425ab45ff6c7ee50b389/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp#L357-L376

https://github.com/dolphin-emu/dolphin/blob/2e01dc0c82b5f73215e3425ab45ff6c7ee50b389/Source/Core/VideoBackends/D3DCommon/Shader.cpp#L108-L125