### PR TITLE
Qt/MemoryWidget: Light refactoring and quality of life features.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -549,25 +549,19 @@ void MemoryViewWidget::wheelEvent(QWheelEvent* event)
 
 void MemoryViewWidget::mousePressEvent(QMouseEvent* event)
 {
-  auto* item_selected = itemAt(event->pos());
-  if (item_selected == nullptr)
+  if (event->button() != Qt::LeftButton)
     return;
 
-  const u32 address = item(row(item_selected), 1)->data(USER_ROLE_CELL_ADDRESS).toUInt();
+  auto* item = itemAt(event->pos());
+  if (!item)
+    return;
 
-  switch (event->button())
-  {
-  case Qt::LeftButton:
-    if (column(item_selected) == 0)
-      ToggleBreakpoint(address, true);
-    else
-      SetAddress(address);
-
-    Update();
-    break;
-  default:
-    break;
-  }
+  const u32 address = item->data(USER_ROLE_CELL_ADDRESS).toUInt();
+  if (item->data(USER_ROLE_IS_ROW_BREAKPOINT_CELL).toBool())
+    ToggleBreakpoint(address, true);
+  else
+    SetAddress(address);
+  Update();
 }
 
 void MemoryViewWidget::OnCopyAddress(u32 addr)

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -7,6 +7,8 @@
 
 #include "Common/CommonTypes.h"
 
+class QPoint;
+
 namespace AddressSpace
 {
 enum class Type;
@@ -44,8 +46,7 @@ public:
 
   void Update();
   void UpdateFont();
-  void ToggleBreakpoint();
-  void ToggleRowBreakpoint(bool row);
+  void ToggleBreakpoint(u32 addr, bool row);
 
   void SetAddressSpace(AddressSpace::Type address_space);
   AddressSpace::Type GetAddressSpace() const;
@@ -54,8 +55,6 @@ public:
   void SetAddress(u32 address);
 
   void SetBPLoggingEnabled(bool enabled);
-
-  u32 GetContextAddress() const;
 
   void resizeEvent(QResizeEvent*) override;
   void keyPressEvent(QKeyEvent* event) override;
@@ -68,9 +67,9 @@ signals:
   void RequestWatch(QString name, u32 address);
 
 private:
-  void OnContextMenu();
-  void OnCopyAddress();
-  void OnCopyHex();
+  void OnContextMenu(const QPoint& pos);
+  void OnCopyAddress(u32 addr);
+  void OnCopyHex(u32 addr);
   void UpdateBreakpointTags();
   void UpdateColumns(Type type, int first_column);
 
@@ -78,8 +77,6 @@ private:
   Type m_type = Type::Hex32;
   BPType m_bp_type = BPType::ReadWrite;
   bool m_do_log = true;
-  u32 m_context_address;
-  u32 m_base_address;
   u32 m_address = 0;
   int m_font_width = 0;
   int m_font_vspace = 0;

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -277,12 +277,13 @@ void MemoryWidget::CreateWidgets()
   auto* sidebar_scroll = new QScrollArea;
   sidebar_scroll->setWidget(sidebar);
   sidebar_scroll->setWidgetResizable(true);
-  sidebar_scroll->setFixedWidth(190);
 
   m_memory_view = new MemoryViewWidget(this);
 
   m_splitter->addWidget(m_memory_view);
   m_splitter->addWidget(sidebar_scroll);
+  m_splitter->setStretchFactor(0, 3);
+  m_splitter->setStretchFactor(1, 1);
 
   layout->addWidget(m_splitter);
 


### PR DESCRIPTION
User-visible changes:

- Sidebar can now be resized by the user.
- Right-click menu only shows up when the clicked cell actually has meaningful options for it.
- Right-click menu now has the option to copy the current value of the cell to clipboard.

Internal changes mostly for readability:

- Less transient state on the MemoryViewWidget itself.
- Cells now hold information whether they are the row breakpoint cell or not (instead of that being determined by being in column 0).
- Cells now hold information whether they are a value cell with a valid value or not (which is used to enable/disable the Copy Hex and Copy Value options).