### PR TITLE
MainSettings: Add setting to control Wii NUS Shop URL for system updates

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -210,6 +210,12 @@ const Info<bool> MAIN_ENABLE_SAVESTATES{{System::Main, "Core", "EnableSaveStates
 const Info<bool> MAIN_REAL_WII_REMOTE_REPEAT_REPORTS{
     {System::Main, "Core", "RealWiiRemoteRepeatReports"}, true};
 
+// Note: We don't use HTTPS because that would require the user to have
+// a device certificate which cannot be redistributed with Dolphin.
+// This is fine, because IOS has signature checks.
+const Info<std::string> MAIN_WII_NUS_SHOP_URL{{System::Main, "Core", "WiiNusShopUrl"},
+                                              "http://nus.shop.wii.com"};
+
 // Main.Display
 
 const Info<std::string> MAIN_FULLSCREEN_DISPLAY_RES{

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -131,6 +131,7 @@ extern const Info<bool> MAIN_ENABLE_SAVESTATES;
 extern const Info<DiscIO::Region> MAIN_FALLBACK_REGION;
 extern const Info<bool> MAIN_REAL_WII_REMOTE_REPEAT_REPORTS;
 extern const Info<s32> MAIN_OVERRIDE_BOOT_IOS;
+extern const Info<std::string> MAIN_WII_NUS_SHOP_URL;
 
 // Main.DSP
 

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -458,11 +458,10 @@ OnlineSystemUpdater::Response OnlineSystemUpdater::GetSystemTitles()
   doc.save(stream);
   const std::string request = stream.str();
 
-  // Note: We don't use HTTPS because that would require the user to have
-  // a device certificate which cannot be redistributed with Dolphin.
-  // This is fine, because IOS has signature checks.
+  const std::string url =
+      fmt::format("{}/nus/services/NetUpdateSOAP", Config::Get(Config::MAIN_WII_NUS_SHOP_URL));
   const Common::HttpRequest::Response response =
-      m_http.Post("http://nus.shop.wii.com/nus/services/NetUpdateSOAP", request,
+      m_http.Post(url, request,
                   {
                       {"SOAPAction", "urn:nus.wsapi.broadon.com/GetSystemUpdate"},
                       {"User-Agent", "wii libnup/1.0"},

--- a/Source/Core/DolphinQt/Settings/WiiPane.h
+++ b/Source/Core/DolphinQt/Settings/WiiPane.h
@@ -12,6 +12,7 @@ class QListWidget;
 class QPushButton;
 class QComboBox;
 class QCheckBox;
+class QLineEdit;
 
 class WiiPane : public QWidget
 {
@@ -51,6 +52,8 @@ private:
   QLabel* m_aspect_ratio_choice_label;
   QComboBox* m_sound_mode_choice;
   QLabel* m_sound_mode_choice_label;
+  QLabel* m_nus_url_label;
+  QLineEdit* m_nus_url_edit;
 
   // Whitelisted USB Passthrough Devices
   QListWidget* m_whitelist_usb_list;


### PR DESCRIPTION
Since Nintendo's servers are down and there is no indication of them coming back any time soon, let's allow the user to change the URL to a different server (for example, self hosted, RiiConnect24, etc).

An text box was added to the Wii tab:

![image](https://user-images.githubusercontent.com/11504941/165208762-5e133050-0de3-4fdb-ba25-504232de0751.png)