### PR TITLE
TextureCacheBase: Don't log error while measuring state size.

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -459,7 +459,7 @@ void TextureCacheBase::SerializeTexture(AbstractTexture* tex, const TextureConfi
     // needing to allocate/free an extra buffer.
     u8* texture_data = p.DoExternal(total_size);
 
-    if (p.GetMode() == PointerWrap::MODE_MEASURE)
+    if (!skip_readback && p.GetMode() == PointerWrap::MODE_MEASURE)
     {
       ERROR_LOG_FMT(VIDEO, "Couldn't acquire {} bytes for serializing texture.", total_size);
       return;


### PR DESCRIPTION
Messed this up in #10592. It's harmless, but prints irrelevant error messages during the state size measuring step.