### PR TITLE
Android: Consistently round corners in every layout

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
@@ -19,6 +19,10 @@ import java.io.File;
 
 public class PicassoUtils
 {
+
+  // Corner radius for images in dp
+  private static final int CORNER_RADIUS = 8;
+
   public static void loadGameBanner(ImageView imageView, GameFile gameFile)
   {
     Picasso picassoInstance = new Picasso.Builder(imageView.getContext())
@@ -47,7 +51,7 @@ public class PicassoUtils
               .noPlaceholder()
               .fit()
               .centerInside()
-              .config(Bitmap.Config.ARGB_8888)
+              .transform(new RoundTransform(CORNER_RADIUS))
               .error(R.drawable.no_banner)
               .into(imageView);
     }
@@ -59,7 +63,7 @@ public class PicassoUtils
               .noPlaceholder()
               .fit()
               .centerInside()
-              .config(Bitmap.Config.ARGB_8888)
+              .transform(new RoundTransform(CORNER_RADIUS))
               .error(R.drawable.no_banner)
               .into(imageView);
     }
@@ -73,7 +77,7 @@ public class PicassoUtils
               .noPlaceholder()
               .fit()
               .centerInside()
-              .config(Bitmap.Config.ARGB_8888)
+              .transform(new RoundTransform(CORNER_RADIUS))
               .error(R.drawable.no_banner)
               .into(imageView, new Callback()
               {
@@ -94,7 +98,7 @@ public class PicassoUtils
                           .fit()
                           .centerInside()
                           .noPlaceholder()
-                          .config(Bitmap.Config.ARGB_8888)
+                          .transform(new RoundTransform(CORNER_RADIUS))
                           .error(R.drawable.no_banner)
                           .into(imageView, new Callback()
                           {
@@ -116,7 +120,7 @@ public class PicassoUtils
                                       .fit()
                                       .centerInside()
                                       .noPlaceholder()
-                                      .config(Bitmap.Config.ARGB_8888)
+                                      .transform(new RoundTransform(CORNER_RADIUS))
                                       .error(R.drawable.no_banner)
                                       .into(imageView, new Callback()
                                       {
@@ -147,7 +151,7 @@ public class PicassoUtils
               .noPlaceholder()
               .fit()
               .centerInside()
-              .config(Bitmap.Config.ARGB_8888)
+              .transform(new RoundTransform(CORNER_RADIUS))
               .into(imageView);
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/RoundTransform.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/RoundTransform.java
@@ -1,0 +1,43 @@
+package org.dolphinemu.dolphinemu.utils;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapShader;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Shader;
+
+public class RoundTransform implements com.squareup.picasso.Transformation {
+
+  private final int cornerRadius;
+
+  // Radius is corner rounding in dp
+  public RoundTransform(int cornerRadius) {
+    this.cornerRadius = cornerRadius;
+  }
+
+  @Override
+  public Bitmap transform(Bitmap source) {
+    final Paint paint = new Paint();
+    paint.setAntiAlias(true);
+    paint.setShader(new BitmapShader(source, Shader.TileMode.CLAMP,
+      Shader.TileMode.CLAMP));
+
+    Bitmap output = Bitmap.createBitmap(source.getWidth(),
+      source.getHeight(), Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(output);
+    canvas.drawRoundRect(new RectF(0, 0, source.getWidth(),
+      source.getHeight()), cornerRadius, cornerRadius, paint);
+
+    if (source != output)
+      source.recycle();
+
+    return output;
+  }
+
+  @Override
+  public String key() {
+    return "roundcorner";
+  }
+
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/RoundTransform.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/RoundTransform.java
@@ -11,14 +11,14 @@ public class RoundTransform implements com.squareup.picasso.Transformation {
 
   private final int cornerRadius;
 
-  // Radius is corner rounding in dp
+  // Radius is corner rounding in px
   public RoundTransform(int cornerRadius) {
     this.cornerRadius = cornerRadius;
   }
 
   @Override
   public Bitmap transform(Bitmap source) {
-    final Paint paint = new Paint();
+    Paint paint = new Paint();
     paint.setAntiAlias(true);
     paint.setShader(new BitmapShader(source, Shader.TileMode.CLAMP,
       Shader.TileMode.CLAMP));
@@ -29,8 +29,7 @@ public class RoundTransform implements com.squareup.picasso.Transformation {
     canvas.drawRoundRect(new RectF(0, 0, source.getWidth(),
       source.getHeight()), cornerRadius, cornerRadius, paint);
 
-    if (source != output)
-      source.recycle();
+    source.recycle();
 
     return output;
   }

--- a/Source/Android/app/src/main/res/layout/card_game.xml
+++ b/Source/Android/app/src/main/res/layout/card_game.xml
@@ -15,22 +15,13 @@
     android:transitionName="card_game"
     tools:layout_width="160dp">
 
-    <androidx.cardview.widget.CardView
-        android:id="@+id/card_game_art"
+    <ImageView
+        android:id="@+id/image_game_screen"
         android:layout_width="match_parent"
         android:layout_height="159dp"
-        android:layout_gravity="center"
-        app:cardCornerRadius="4dp"
-        tools:layout_width="140dp">
-
-        <ImageView
-            android:id="@+id/image_game_screen"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            tools:scaleType="centerCrop"
-            tools:src="@drawable/placeholder_screenshot" />
-    </androidx.cardview.widget.CardView>
+        android:layout_gravity="center|top"
+        tools:layout_width="140dp"
+        tools:scaleType="centerCrop" />
 
     <TextView
         android:id="@+id/text_game_title"


### PR DESCRIPTION
Previously when in landscape mode, there would be an issue with the card view where top and bottom borders would appear. Here the corners are baked into the cached box art. Now regardless of the orientation or the layout, the corners on the box art will be properly rounded.

Before Vertical -
![before vertical](https://user-images.githubusercontent.com/14132249/166085770-659db0a6-90ce-47ec-98c9-c66cfba28aa0.png)

After Vertical - 
![after vertical](https://user-images.githubusercontent.com/14132249/166085782-8f3e2679-9a9c-4164-ae3c-0d35642f3a63.png)

Before Landscape - 
![before land](https://user-images.githubusercontent.com/14132249/166085791-7e31782c-23be-4201-a0b7-fcc9d565120f.png)

After Landscape - 
![after land](https://user-images.githubusercontent.com/14132249/166085799-72c697df-20a3-4f5c-bfd9-3294668076a5.png)

Before TV - 
![before tv](https://user-images.githubusercontent.com/14132249/166085808-8dfb2fed-bb51-442e-9732-c1bbafb02f41.png)

After TV - 
![after tv](https://user-images.githubusercontent.com/14132249/166085813-8cf155fd-65ba-4dbf-ac8a-a523d0e89603.png)

