### PR TITLE
Resolve Linux GCC Warnings

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -105,7 +105,7 @@ public:
     case Mode::Read:
       for (x.clear(); count != 0; --count)
       {
-        V value;
+        V value = {};
         Do(value);
         x.insert(value);
       }

--- a/Source/Core/Common/Logging/ConsoleListener.h
+++ b/Source/Core/Common/Logging/ConsoleListener.h
@@ -14,5 +14,7 @@ public:
   void Log(Common::Log::LogLevel level, const char* text) override;
 
 private:
-  [[maybe_unused]] bool m_use_color = false;
+#if !defined _WIN32 && !defined ANDROID
+  bool m_use_color = false;
+#endif
 };

--- a/Source/Core/Core/DSP/DSPDisassembler.cpp
+++ b/Source/Core/Core/DSP/DSPDisassembler.cpp
@@ -194,7 +194,7 @@ bool DSPDisassembler::DisassembleOpcode(const u16* binbuf, size_t binbuf_size, u
   // Size 2 - the op has a large immediate.
   if (opc->size == 2)
   {
-    if (wrapped_pc + 1 >= binbuf_size)
+    if (wrapped_pc + 1u >= binbuf_size)
     {
       if (settings_.show_hex)
         dest += fmt::format("{:04x} ???? ", op1);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -89,12 +89,13 @@ std::optional<IPCReply> BluetoothRealDevice::Open(const OpenRequest& request)
   const int ret = m_context.GetDeviceList([this](libusb_device* device) {
     libusb_device_descriptor device_descriptor;
     libusb_get_device_descriptor(device, &device_descriptor);
-    auto [ret, config_descriptor] = LibusbUtils::MakeConfigDescriptor(device);
-    if (ret != LIBUSB_SUCCESS || !config_descriptor)
+    auto [make_config_descriptor_ret, config_descriptor] =
+        LibusbUtils::MakeConfigDescriptor(device);
+    if (make_config_descriptor_ret != LIBUSB_SUCCESS || !config_descriptor)
     {
       ERROR_LOG_FMT(IOS_WIIMOTE, "Failed to get config descriptor for device {:04x}:{:04x}: {}",
                     device_descriptor.idVendor, device_descriptor.idProduct,
-                    LibusbUtils::ErrorWrap(ret));
+                    LibusbUtils::ErrorWrap(make_config_descriptor_ret));
       return true;
     }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -93,7 +93,7 @@ protected:
     u8* trampolineExceptionHandler;
 
     bool mustCheckFifo;
-    int fifoBytesSinceCheck;
+    u32 fifoBytesSinceCheck;
 
     PPCAnalyst::BlockStats st;
     PPCAnalyst::BlockRegStats gpa;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -419,7 +419,7 @@ void SaveAs(const std::string& filename, bool wait)
         // Then actually do the write.
         bool is_write_mode;
         {
-          std::lock_guard lk(g_cs_current_buffer);
+          std::lock_guard lk2(g_cs_current_buffer);
           g_current_buffer.resize(buffer_size);
           ptr = g_current_buffer.data();
           PointerWrap p(&ptr, buffer_size, PointerWrap::Mode::Write);
@@ -438,7 +438,7 @@ void SaveAs(const std::string& filename, bool wait)
           save_args.wait = wait;
 
           {
-            std::lock_guard lk(g_save_thread_mutex);
+            std::lock_guard lk3(g_save_thread_mutex);
             Flush();
             g_save_thread = std::thread(CompressAndDumpState, save_args);
           }
@@ -572,7 +572,7 @@ void LoadAs(const std::string& filename)
         // Save temp buffer for undo load state
         if (!Movie::IsJustStartingRecordingInputFromSaveState())
         {
-          std::lock_guard lk(g_cs_undo_load_buffer);
+          std::lock_guard lk2(g_cs_undo_load_buffer);
           SaveToBuffer(g_undo_load_buffer);
           if (Movie::IsMovieActive())
             Movie::SaveRecording(File::GetUserPath(D_STATESAVES_IDX) + "undo.dtm");

--- a/Source/Core/DolphinQt/WiiUpdate.cpp
+++ b/Source/Core/DolphinQt/WiiUpdate.cpp
@@ -10,6 +10,7 @@
 #include <QProgressDialog>
 #include <QPushButton>
 
+#include "Common/Assert.h"
 #include "Common/FileUtil.h"
 #include "Common/Flag.h"
 
@@ -70,6 +71,9 @@ static void ShowResult(QWidget* parent, WiiUtils::UpdateResult result)
     ModalMessageBox::critical(parent, QObject::tr("Update failed"),
                               QObject::tr("The game disc does not contain any usable "
                                           "update information."));
+    break;
+  default:
+    ASSERT(false);
     break;
   }
 }

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -28,14 +28,14 @@ static constexpr int BLOCK_SIZE = 2;
 struct SlopeContext
 {
   SlopeContext(const OutputVertexData* v0, const OutputVertexData* v1, const OutputVertexData* v2,
-               s32 x0, s32 y0, s32 x_off, s32 y_off)
-      : x0(x0), y0(y0)
+               s32 x0_, s32 y0_, s32 x_off, s32 y_off)
+      : x0(x0_), y0(y0_)
   {
     // adjust a little less than 0.5
     const float adjust = 0.495f;
 
-    xOff = ((float)x0 - (v0->screenPosition.x - x_off)) + adjust;
-    yOff = ((float)y0 - (v0->screenPosition.y - y_off)) + adjust;
+    xOff = ((float)x0_ - (v0->screenPosition.x - x_off)) + adjust;
+    yOff = ((float)y0_ - (v0->screenPosition.y - y_off)) + adjust;
 
     dx10 = v1->screenPosition.x - v0->screenPosition.x;
     dx20 = v2->screenPosition.x - v0->screenPosition.x;
@@ -55,10 +55,10 @@ struct SlopeContext
 struct Slope
 {
   Slope() = default;
-  Slope(float f0, float f1, float f2, const SlopeContext& ctx) : f0(f0)
+  Slope(float f0_, float f1, float f2, const SlopeContext& ctx) : f0(f0_)
   {
-    float delta_20 = f2 - f0;
-    float delta_10 = f1 - f0;
+    float delta_20 = f2 - f0_;
+    float delta_10 = f1 - f0_;
 
     //        x2 - x0    y1 - y0    x1 - x0    y2 - y0
     float a = delta_20 * ctx.dy10 - delta_10 * ctx.dy20;
@@ -371,9 +371,9 @@ static void DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertex
 
   // scissor
   ASSERT(scissor.rect.left >= 0);
-  ASSERT(scissor.rect.right <= EFB_WIDTH);
+  ASSERT(scissor.rect.right <= static_cast<int>(EFB_WIDTH));
   ASSERT(scissor.rect.top >= 0);
-  ASSERT(scissor.rect.bottom <= EFB_HEIGHT);
+  ASSERT(scissor.rect.bottom <= static_cast<int>(EFB_HEIGHT));
 
   minx = std::max(minx, scissor.rect.left);
   maxx = std::min(maxx, scissor.rect.right);

--- a/Source/Core/VideoCommon/BPFunctions.h
+++ b/Source/Core/VideoCommon/BPFunctions.h
@@ -19,7 +19,10 @@ namespace BPFunctions
 struct ScissorRange
 {
   constexpr ScissorRange() = default;
-  constexpr ScissorRange(int offset, int start, int end) : offset(offset), start(start), end(end) {}
+  constexpr ScissorRange(int offset_, int start_, int end_)
+      : offset(offset_), start(start_), end(end_)
+  {
+  }
   int offset = 0;
   int start = 0;
   int end = 0;

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -336,12 +336,12 @@ void Statistics::DisplayScissor()
 
     // Visualization of where things are updated on screen with this specific scissor
     ImGui::TableNextColumn();
-    float scale = ImGui::GetTextLineHeight() / EFB_HEIGHT;
+    float scale_height = ImGui::GetTextLineHeight() / EFB_HEIGHT;
     if (show_raw_scissors)
-      scale += ImGui::GetTextLineHeightWithSpacing() / EFB_HEIGHT;
+      scale_height += ImGui::GetTextLineHeightWithSpacing() / EFB_HEIGHT;
     ImVec2 p2 = ImGui::GetCursorScreenPos();
     // Use a height of 1 since we want this to span two table rows (if possible)
-    ImGui::Dummy(ImVec2(EFB_WIDTH * scale, 1));
+    ImGui::Dummy(ImVec2(EFB_WIDTH * scale_height, 1));
     for (size_t i = 0; i < info.m_result.size(); i++)
     {
       // The last entry in the sorted list of results is the one that is used by hardware backends
@@ -350,11 +350,12 @@ void Statistics::DisplayScissor()
       const ImU32 new_col = (col & ~IM_COL32_A_MASK) | (new_alpha << IM_COL32_A_SHIFT);
 
       const auto& r = info.m_result[i];
-      draw_list->AddRectFilled(ImVec2(p2.x + r.rect.left * scale, p2.y + r.rect.top * scale),
-                               ImVec2(p2.x + r.rect.right * scale, p2.y + r.rect.bottom * scale),
-                               new_col);
+      draw_list->AddRectFilled(
+          ImVec2(p2.x + r.rect.left * scale_height, p2.y + r.rect.top * scale_height),
+          ImVec2(p2.x + r.rect.right * scale_height, p2.y + r.rect.bottom * scale_height), new_col);
     }
-    draw_list->AddRect(p2, ImVec2(p2.x + EFB_WIDTH * scale, p2.y + EFB_HEIGHT * scale), light_grey);
+    draw_list->AddRect(
+        p2, ImVec2(p2.x + EFB_WIDTH * scale_height, p2.y + EFB_HEIGHT * scale_height), light_grey);
     ImGui::SameLine();
     ImGui::Text("%d", int(info.m_result.size()));
 
@@ -428,7 +429,7 @@ void Statistics::DisplayScissor()
           draw_scissor_table_header();
           for (size_t i = 0; i < scissors.size(); i++)
             draw_scissor_table_row(i);
-          for (size_t i = scissors.size(); i < scissor_expected_count; i++)
+          for (size_t i = scissors.size(); i < static_cast<size_t>(scissor_expected_count); i++)
             scissor_table_skip_row(i);
           ImGui::EndTable();
         }
@@ -440,7 +441,7 @@ void Statistics::DisplayScissor()
           draw_viewport_table_header();
           for (size_t i = 0; i < scissors.size(); i++)
             draw_viewport_table_row(i);
-          for (size_t i = scissors.size(); i < scissor_expected_count; i++)
+          for (size_t i = scissors.size(); i < static_cast<size_t>(scissor_expected_count); i++)
             viewport_table_skip_row(i);
           ImGui::EndTable();
         }


### PR DESCRIPTION
These annoyed me, so I fixed them.

These warnings are being resolved by #10610
/Core/Common/FifoPlayer.cpp : void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘struct CPState’ with no trivial copy-assignment; use copy-initialization instead [-Wclass-memaccess]
/Core/VideoCommon/CPMemory.cpp : void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘struct CPState’ with no trivial copy-assignment; use copy-initialization instead [-Wclass-memaccess]

This warning is being resolved by #10374
/Core/Core/HW/EXI/EXI.h : 'ExpansionInterface::SLOTS’ defined but not used [-Wunused-variable]