### PR TITLE
Android: XLink Kai Android UI option

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -18,6 +18,8 @@ public enum BooleanSetting implements AbstractBooleanSetting
   MAIN_OVERRIDE_REGION_SETTINGS(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE,
           "OverrideRegionSettings", false),
   MAIN_AUDIO_STRETCH(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "AudioStretch", false),
+  MAIN_BBA_XLINK_CHAT_OSD(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "BBA_XLINK_CHAT_OSD",
+          false),
   MAIN_ADAPTER_RUMBLE_0(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "AdapterRumble0", true),
   MAIN_ADAPTER_RUMBLE_1(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "AdapterRumble1", true),
   MAIN_ADAPTER_RUMBLE_2(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "AdapterRumble2", true),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -20,6 +20,7 @@ public enum IntSetting implements AbstractIntSetting
   MAIN_GC_LANGUAGE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SelectedLanguage", 0),
   MAIN_SLOT_A(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SlotA", 8),
   MAIN_SLOT_B(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SlotB", 255),
+  MAIN_SERIAL_PORT_1(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SerialPort1", 255),
   MAIN_FALLBACK_REGION(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "FallbackRegion", 2),
   MAIN_SI_DEVICE_0(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SIDevice0", 6),
   MAIN_SI_DEVICE_1(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SIDevice1", 0),
@@ -77,6 +78,7 @@ public enum IntSetting implements AbstractIntSetting
           MAIN_GC_LANGUAGE,
           MAIN_SLOT_A,  // Can actually be changed, but specific code is required
           MAIN_SLOT_B,  // Can actually be changed, but specific code is required
+          MAIN_SERIAL_PORT_1,
           MAIN_FALLBACK_REGION,
           MAIN_SI_DEVICE_0,  // Can actually be changed, but specific code is required
           MAIN_SI_DEVICE_1,  // Can actually be changed, but specific code is required

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
@@ -13,6 +13,10 @@ public enum StringSetting implements AbstractStringSetting
   // These entries have the same names and order as in C++, just for consistency.
 
   MAIN_DEFAULT_ISO(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "DefaultISO", ""),
+
+  MAIN_BBA_MAC(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "BBA_MAC", ""),
+  MAIN_BBA_XLINK_IP(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "BBA_XLINK_IP", ""),
+
   MAIN_GFX_BACKEND(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "GFXBackend",
           NativeLibrary.GetDefaultGraphicsBackendName()),
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/HeaderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/HeaderSetting.java
@@ -6,7 +6,7 @@ import android.content.Context;
 
 import org.dolphinemu.dolphinemu.features.settings.model.AbstractSetting;
 
-public final class HeaderSetting extends SettingsItem
+public class HeaderSetting extends SettingsItem
 {
   public HeaderSetting(Context context, int titleId, int descriptionId)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/HyperLinkHeaderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/HyperLinkHeaderSetting.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.settings.model.view;
+
+import android.content.Context;
+
+public final class HyperLinkHeaderSetting extends HeaderSetting
+{
+  public HyperLinkHeaderSetting(Context context, int titleId, int descriptionId)
+  {
+    super(context, titleId, descriptionId);
+  }
+
+  @Override
+  public int getType()
+  {
+    return SettingsItem.TYPE_HYPERLINK_HEADER;
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/InputStringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/InputStringSetting.java
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.settings.model.view;
+
+import android.content.Context;
+
+import org.dolphinemu.dolphinemu.features.settings.model.AbstractSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.AbstractStringSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.Settings;
+import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag;
+
+public class InputStringSetting extends SettingsItem
+{
+  private AbstractStringSetting mSetting;
+
+  private MenuTag mMenuTag;
+
+  public InputStringSetting(Context context, AbstractStringSetting setting, int titleId,
+          int descriptionId, MenuTag menuTag)
+  {
+    super(context, titleId, descriptionId);
+    mSetting = setting;
+    mMenuTag = menuTag;
+  }
+
+  public InputStringSetting(Context context, AbstractStringSetting setting, int titleId,
+          int descriptionId)
+  {
+    this(context, setting, titleId, descriptionId, null);
+  }
+
+  public InputStringSetting(Context context, AbstractStringSetting setting, int titleId,
+          int descriptionId, int choicesId, int valuesId, MenuTag menuTag)
+  {
+    super(context, titleId, descriptionId);
+    mSetting = setting;
+    mMenuTag = menuTag;
+  }
+
+  public InputStringSetting(Context context, AbstractStringSetting setting, int titleId,
+          int descriptionId, int choicesId, int valuesId)
+  {
+    this(context, setting, titleId, descriptionId, choicesId, valuesId, null);
+  }
+
+  public String getSelectedValue(Settings settings)
+  {
+    return mSetting.getString(settings);
+  }
+
+  public MenuTag getMenuTag()
+  {
+    return mMenuTag;
+  }
+
+  public void setSelectedValue(Settings settings, String selection)
+  {
+    mSetting.setString(settings, selection);
+  }
+
+  @Override
+  public int getType()
+  {
+    return TYPE_STRING;
+  }
+
+  @Override
+  public AbstractSetting getSetting()
+  {
+    return mSetting;
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.java
@@ -27,6 +27,8 @@ public abstract class SettingsItem
   public static final int TYPE_SINGLE_CHOICE_DYNAMIC_DESCRIPTIONS = 8;
   public static final int TYPE_FILE_PICKER = 9;
   public static final int TYPE_RUN_RUNNABLE = 10;
+  public static final int TYPE_STRING = 11;
+  public static final int TYPE_HYPERLINK_HEADER = 12;
 
   private final CharSequence mName;
   private final CharSequence mDescription;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
@@ -13,6 +13,7 @@ public enum MenuTag
   CONFIG_AUDIO("config_audio"),
   CONFIG_PATHS("config_paths"),
   CONFIG_GAME_CUBE("config_gamecube"),
+  CONFIG_SERIALPORT1("config_serialport1"),
   CONFIG_WII("config_wii"),
   CONFIG_ADVANCED("config_advanced"),
   CONFIG_LOG("config_log"),
@@ -72,6 +73,11 @@ public enum MenuTag
   public int getSubType()
   {
     return subType;
+  }
+
+  public boolean isSerialPort1Menu()
+  {
+    return this == CONFIG_SERIALPORT1;
   }
 
   public boolean isGCPadMenu()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -278,6 +278,12 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   }
 
   @Override
+  public void onSerialPort1SettingChanged(MenuTag menuTag, int value)
+  {
+    mPresenter.onSerialPort1SettingChanged(menuTag, value);
+  }
+
+  @Override
   public void onGcPadSettingChanged(MenuTag key, int value)
   {
     mPresenter.onGcPadSettingChanged(key, value);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -135,6 +135,16 @@ public final class SettingsActivityPresenter
     return mShouldSave;
   }
 
+  public void onSerialPort1SettingChanged(MenuTag key, int value)
+  {
+    if (value != 0 && value != 255) // Not disabled or dummy
+    {
+      Bundle bundle = new Bundle();
+      bundle.putInt(SettingsFragmentPresenter.ARG_SERIALPORT1_TYPE, value);
+      mView.showSettingsFragment(key, bundle, true, mGameId);
+    }
+  }
+
   public void onGcPadSettingChanged(MenuTag key, int value)
   {
     if (value != 0) // Not disabled

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -59,6 +59,15 @@ public interface SettingsActivityView
   void onSettingChanged();
 
   /**
+   * Called by a containing Fragment to tell the containing Activity that the Serial Port 1 setting
+   * was modified.
+   *
+   * @param menuTag Identifier for the SerialPort that was modified.
+   * @param value   New setting for the SerialPort.
+   */
+  void onSerialPort1SettingChanged(MenuTag menuTag, int value);
+
+  /**
    * Called by a containing Fragment to tell the containing Activity that a GCPad's setting
    * was modified.
    *

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -44,6 +44,7 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
     titles.put(MenuTag.CONFIG_AUDIO, R.string.audio_submenu);
     titles.put(MenuTag.CONFIG_PATHS, R.string.paths_submenu);
     titles.put(MenuTag.CONFIG_GAME_CUBE, R.string.gamecube_submenu);
+    titles.put(MenuTag.CONFIG_SERIALPORT1, R.string.serialport1_submenu);
     titles.put(MenuTag.CONFIG_WII, R.string.wii_submenu);
     titles.put(MenuTag.CONFIG_ADVANCED, R.string.advanced_submenu);
     titles.put(MenuTag.DEBUG, R.string.debug_submenu);
@@ -200,6 +201,12 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   public void onSettingChanged()
   {
     mActivity.onSettingChanged();
+  }
+
+  @Override
+  public void onSerialPort1SettingChanged(MenuTag menuTag, int value)
+  {
+    mActivity.onSerialPort1SettingChanged(menuTag, value);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -25,7 +25,9 @@ import org.dolphinemu.dolphinemu.features.settings.model.WiimoteProfileStringSet
 import org.dolphinemu.dolphinemu.features.settings.model.view.CheckBoxSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.FilePicker;
 import org.dolphinemu.dolphinemu.features.settings.model.view.HeaderSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.view.HyperLinkHeaderSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.InputBindingSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.view.InputStringSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.IntSliderSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.InvertedCheckBoxSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.LogCheckBoxSetting;
@@ -54,12 +56,14 @@ public final class SettingsFragmentPresenter
           NativeLibrary.GetLogTypeNames();
 
   public static final String ARG_CONTROLLER_TYPE = "controller_type";
+  public static final String ARG_SERIALPORT1_TYPE = "serialport1_type";
   private MenuTag mMenuTag;
   private String mGameID;
 
   private Settings mSettings;
   private ArrayList<SettingsItem> mSettingsList;
 
+  private int mSerialPort1Type;
   private int mControllerNumber;
   private int mControllerType;
 
@@ -82,6 +86,10 @@ public final class SettingsFragmentPresenter
     else if (menuTag.isWiimoteMenu())
     {
       mControllerNumber = menuTag.getSubType();
+    }
+    else if (menuTag.isSerialPort1Menu())
+    {
+      mSerialPort1Type = extras.getInt(ARG_SERIALPORT1_TYPE);
     }
   }
 
@@ -165,6 +173,10 @@ public final class SettingsFragmentPresenter
 
       case GRAPHICS:
         addGraphicsSettings(sl);
+        break;
+
+      case CONFIG_SERIALPORT1:
+        addSerialPortSubSettings(sl, mSerialPort1Type);
         break;
 
       case GCPAD_TYPE:
@@ -425,6 +437,10 @@ public final class SettingsFragmentPresenter
             R.array.slotDeviceEntries, R.array.slotDeviceValues));
     sl.add(new SingleChoiceSetting(mContext, IntSetting.MAIN_SLOT_B, R.string.slot_b_device, 0,
             R.array.slotDeviceEntries, R.array.slotDeviceValues));
+    sl.add(new SingleChoiceSetting(mContext, IntSetting.MAIN_SERIAL_PORT_1,
+            R.string.serial_port_1_device, 0,
+            R.array.serialPort1DeviceEntries, R.array.serialPort1DeviceValues,
+            MenuTag.CONFIG_SERIALPORT1));
   }
 
   private void addWiiSettings(ArrayList<SettingsItem> sl)
@@ -557,6 +573,16 @@ public final class SettingsFragmentPresenter
     sl.add(new SingleChoiceSetting(mContext, synchronizeGpuThread, R.string.synchronize_gpu_thread,
             R.string.synchronize_gpu_thread_description, R.array.synchronizeGpuThreadEntries,
             R.array.synchronizeGpuThreadValues));
+  }
+
+  private void addSerialPortSubSettings(ArrayList<SettingsItem> sl, int serialPort1Type)
+  {
+    if (serialPort1Type == 10) // XLink Kai
+    {
+      sl.add(new HyperLinkHeaderSetting(mContext, R.string.xlink_kai_guide_header, 0));
+      sl.add(new InputStringSetting(mContext, StringSetting.MAIN_BBA_XLINK_IP,
+              R.string.xlink_kai_bba_ip, R.string.xlink_kai_bba_ip_description));
+    }
   }
 
   private void addGcPadSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
@@ -72,6 +72,15 @@ public interface SettingsFragmentView
   void onSettingChanged();
 
   /**
+   * Called by a containing Fragment to tell the containing Activity that the Serial Port 1 setting
+   * was modified.
+   *
+   * @param menuTag Identifier for the SerialPort that was modified.
+   * @param value   New setting for the SerialPort.
+   */
+  void onSerialPort1SettingChanged(MenuTag menuTag, int value);
+
+  /**
    * Have the fragment tell the containing Activity that a GCPad's setting was modified.
    *
    * @param menuTag Identifier for the GCPad that was modified.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/HeaderHyperLinkViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/HeaderHyperLinkViewHolder.java
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.settings.ui.viewholder;
+
+import android.content.Context;
+import android.text.method.LinkMovementMethod;
+import android.view.View;
+
+import androidx.core.content.ContextCompat;
+
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem;
+import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
+
+public final class HeaderHyperLinkViewHolder extends HeaderViewHolder
+{
+  private Context mContext;
+
+  public HeaderHyperLinkViewHolder(View itemView, SettingsAdapter adapter, Context context)
+  {
+    super(itemView, adapter);
+    mContext = context;
+    itemView.setOnClickListener(null);
+  }
+
+  @Override
+  public void bind(SettingsItem item)
+  {
+    super.bind(item);
+    mHeaderName.setMovementMethod(LinkMovementMethod.getInstance());
+    mHeaderName.setLinkTextColor(ContextCompat.getColor(mContext, R.color.dolphin_blue_secondary));
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/HeaderViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/HeaderViewHolder.java
@@ -11,9 +11,9 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem;
 import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
 
-public final class HeaderViewHolder extends SettingViewHolder
+public class HeaderViewHolder extends SettingViewHolder
 {
-  private TextView mHeaderName;
+  protected TextView mHeaderName;
 
   public HeaderViewHolder(View itemView, SettingsAdapter adapter)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/InputStringSettingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/InputStringSettingViewHolder.java
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.settings.ui.viewholder;
+
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.model.view.InputStringSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem;
+import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
+
+public final class InputStringSettingViewHolder extends SettingViewHolder
+{
+  private InputStringSetting mInputString;
+
+  private TextView mTextSettingName;
+  private TextView mTextSettingDescription;
+
+  public InputStringSettingViewHolder(View itemView, SettingsAdapter adapter)
+  {
+    super(itemView, adapter);
+  }
+
+  @Override
+  protected void findViews(View root)
+  {
+    mTextSettingName = root.findViewById(R.id.text_setting_name);
+    mTextSettingDescription = root.findViewById(R.id.text_setting_description);
+  }
+
+  @Override
+  public void bind(SettingsItem item)
+  {
+    mInputString = (InputStringSetting) item;
+
+    String inputString = mInputString.getSelectedValue(getAdapter().getSettings());
+
+    mTextSettingName.setText(item.getName());
+
+    if (!TextUtils.isEmpty(inputString))
+    {
+      mTextSettingDescription.setText(inputString);
+    }
+    else
+    {
+      mTextSettingDescription.setText(item.getDescription());
+    }
+
+    setStyle(mTextSettingName, mInputString);
+  }
+
+  @Override
+  public void onClick(View clicked)
+  {
+    if (!mInputString.isEditable())
+    {
+      showNotRuntimeEditableError();
+      return;
+    }
+
+    int position = getAdapterPosition();
+
+    getAdapter().onInputStringClick(mInputString, position);
+
+    setStyle(mTextSettingName, mInputString);
+  }
+
+  @Nullable @Override
+  protected SettingsItem getItem()
+  {
+    return mInputString;
+  }
+}

--- a/Source/Android/app/src/main/res/layout/dialog_input_string.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_input_string.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/input"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp"
+        android:ems="10"
+        android:inputType="text"
+        android:importantForAutofill="no" />
+
+</LinearLayout>

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -97,6 +97,18 @@
         <item>8</item>
     </integer-array>
 
+    <!-- Slot SP1 Device selection -->
+    <string-array name="serialPort1DeviceEntries" translatable="false">
+        <item>Nothing</item>
+        <item>Dummy</item>
+        <item>Broadband Adapter (XLink Kai)</item>
+    </string-array>
+    <integer-array name="serialPort1DeviceValues" translatable="false">
+        <item>255</item>
+        <item>0</item>
+        <item>10</item>
+    </integer-array>
+
     <!-- GameCube System Languages -->
     <string-array name="wiiSystemLanguageEntries">
         <item>Japanese</item>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="system_language">System Language</string>
     <string name="slot_a_device">GameCube Slot A Device</string>
     <string name="slot_b_device">GameCube Slot B Device</string>
+    <string name="serial_port_1_device">GameCube Serial Port 1 Device</string>
     <string name="wii_submenu">Wii</string>
     <string name="wii_widescreen">Widescreen</string>
     <string name="wii_widescreen_description">Changes aspect ratio from 4:3 to 16:9 in games that support it.</string>
@@ -159,6 +160,12 @@
     <string name="analytics_desc">If authorized, Dolphin can collect data on its performance, feature usage, and configuration, as well as data on your system\'s hardware and operating system.\n\nNo private data is ever collected. This data helps us understand how people and emulated games use Dolphin and prioritize our efforts. It also helps us identify rare configurations that are causing bugs, performance and stability issues. This authorization can be revoked at any time through Dolphin\'s settings.</string>
     <string name="analytics_new_id">Generate a New Statistics Identity</string>
     <string name="analytics_new_id_confirmation">Are you sure you want to generate a new statistics identity?</string>
+
+    <!-- SerialPort1 Subsetting Fragment -->
+    <string name="serialport1_submenu">Serial Port 1</string>
+    <string name="xlink_kai_guide_header">For setup instructions, <a href="https://www.teamxlink.co.uk/wiki/Dolphin">refer to this page.</a></string>
+    <string name="xlink_kai_bba_ip">XLink Kai IP Address/hostname</string>
+    <string name="xlink_kai_bba_ip_description">IP address or hostname of device running the XLink Kai client</string>
 
     <!-- Interface Preference Fragment -->
     <string name="interface_submenu">Interface</string>


### PR DESCRIPTION
This adds xlink kai support to the android version of Dolphin, so multiplayer is possible from Android as well.
Below are some screenshots to show what these changes do:

![Screenshot_20220501-203457_Dolphin Emulator](https://user-images.githubusercontent.com/9693338/166159774-f539b1fb-1ed8-4641-9214-3c7f15557e12.png)
![Screenshot_20220502-092807_Dolphin Emulator](https://user-images.githubusercontent.com/9693338/166199606-6002a8d5-9e6b-4684-bc7b-65bf02a97e8b.png)
![Screenshot_20220502-093113_Dolphin Emulator](https://user-images.githubusercontent.com/9693338/166199949-24fdcb2e-5cf4-4d79-ba5e-76ff7bd2b976.png)




