### PR TITLE
Change _WIN32 check to a _MSC_VER check in Inline.h

### DIFF
--- a/Source/Core/Common/Inline.h
+++ b/Source/Core/Common/Inline.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define DOLPHIN_FORCE_INLINE __forceinline
 #else
 #define DOLPHIN_FORCE_INLINE inline __attribute__((always_inline))


### PR DESCRIPTION
This is compiler dependent, not OS dependent.