### PR TITLE
Revert "msbuild: use pdbaltpath to strip dirname of pdb"

### DIFF
--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -174,7 +174,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
       <AdditionalOptions>/experimental:deterministic %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions>/PDBALTPATH:Build\$(Platform)\$(Configuration)\$(ProjectName)\bin\%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <!--Link Release-->
     <Link Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
This reverts commit f2c5c052bc5402856123b0f57c7c5a50be97ba49.

debuggers using path-based searching don't seem smart enough
to find a relative path if it's not relative to their pwd.

Using pdbaltpath is only really useful for sharing build outputs between different locations (e.g. between pr and release buildbots, with how windows buildbot is currently setup). Since we don't actually cache build outputs on windows yet and sharing between locations isn't a requirement for that, we can worry about the optimization later.