### PR TITLE
WiiUtils: Change default NUS Shop URL to Dolphin's fake NUS

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -210,6 +210,9 @@ const Info<bool> MAIN_ENABLE_SAVESTATES{{System::Main, "Core", "EnableSaveStates
 const Info<bool> MAIN_REAL_WII_REMOTE_REPEAT_REPORTS{
     {System::Main, "Core", "RealWiiRemoteRepeatReports"}, true};
 
+// Empty means use the Dolphin default URL
+const Info<std::string> MAIN_WII_NUS_SHOP_URL{{System::Main, "Core", "WiiNusShopUrl"}, ""};
+
 // Main.Display
 
 const Info<std::string> MAIN_FULLSCREEN_DISPLAY_RES{

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -131,6 +131,7 @@ extern const Info<bool> MAIN_ENABLE_SAVESTATES;
 extern const Info<DiscIO::Region> MAIN_FALLBACK_REGION;
 extern const Info<bool> MAIN_REAL_WII_REMOTE_REPEAT_REPORTS;
 extern const Info<s32> MAIN_OVERRIDE_BOOT_IOS;
+extern const Info<std::string> MAIN_WII_NUS_SHOP_URL;
 
 // Main.DSP
 

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -461,10 +461,16 @@ OnlineSystemUpdater::Response OnlineSystemUpdater::GetSystemTitles()
   std::string base_url = Config::Get(Config::MAIN_WII_NUS_SHOP_URL);
   if (base_url.empty())
   {
-    // Note: We don't use HTTPS because that would require the user to have
-    // a device certificate which cannot be redistributed with Dolphin.
-    // This is fine, because IOS has signature checks.
-    base_url = "http://nus.shop.wii.com";
+    // The NUS servers for the Wii are offline (https://bugs.dolphin-emu.org/issues/12865),
+    // but the backing data CDN is still active and accessible from other URLs. We take advantage
+    // of this by hosting our own NetUpdateSOAP endpoint which serves the correct list of titles to
+    // install along with URLs for the Wii U CDN.
+#ifdef ANDROID
+    // HTTPS is unsupported on Android (https://bugs.dolphin-emu.org/issues/11772).
+    base_url = "http://fakenus.dolphin-emu.org";
+#else
+    base_url = "https://fakenus.dolphin-emu.org";
+#endif
   }
 
   const std::string url = fmt::format("{}/nus/services/NetUpdateSOAP", base_url);

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -458,11 +458,18 @@ OnlineSystemUpdater::Response OnlineSystemUpdater::GetSystemTitles()
   doc.save(stream);
   const std::string request = stream.str();
 
-  // Note: We don't use HTTPS because that would require the user to have
-  // a device certificate which cannot be redistributed with Dolphin.
-  // This is fine, because IOS has signature checks.
+  std::string base_url = Config::Get(Config::MAIN_WII_NUS_SHOP_URL);
+  if (base_url.empty())
+  {
+    // Note: We don't use HTTPS because that would require the user to have
+    // a device certificate which cannot be redistributed with Dolphin.
+    // This is fine, because IOS has signature checks.
+    base_url = "http://nus.shop.wii.com";
+  }
+
+  const std::string url = fmt::format("{}/nus/services/NetUpdateSOAP", base_url);
   const Common::HttpRequest::Response response =
-      m_http.Post("http://nus.shop.wii.com/nus/services/NetUpdateSOAP", request,
+      m_http.Post(url, request,
                   {
                       {"SOAPAction", "urn:nus.wsapi.broadon.com/GetSystemUpdate"},
                       {"User-Agent", "wii libnup/1.0"},


### PR DESCRIPTION
#10611, but without the Qt parts. Restores the Online System Update to working order.

delroth set up a fake NUS server that implements the ``NetUpdateSOAP`` endpoint by returning the correct titles for each region along with the Wii U CDN URL. (There appears to be multiple URLs which point to the same CDN, which makes it possible to do things like download a Wii title from the Wii U CDN.) Responses from this endpoint were created by looking at [a sample response from the server when it was still running](https://gist.github.com/icefire/138604) along with [a complete list of titles for each region as archived by yellows8's bot](https://yls8.mtheall.com/ninupdates/reports.php?date=10-19-15_01-40-04&sys=rvl). 

For more technical information, see [this gist](https://gist.github.com/OatmealDome/c21c28672fab8804b263a359cc2d72e1).

In addition, a setting was added to allow a user to override the NUS Shop URL if they want. An empty value will make Dolphin use its default server.
