### PR TITLE
Android: Replace ViewPager with ViewPager2

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
@@ -2,45 +2,37 @@
 
 package org.dolphinemu.dolphinemu.adapters;
 
-import android.content.Context;
-import android.graphics.drawable.Drawable;
-import android.text.Spannable;
-import android.text.SpannableString;
-import android.text.style.ImageSpan;
-
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.fragment.app.FragmentActivity;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.ui.platform.PlatformGamesFragment;
 
-public class PlatformPagerAdapter extends FragmentPagerAdapter
+public class PlatformPagerAdapter extends FragmentStateAdapter
 {
-  private Context mContext;
   private SwipeRefreshLayout.OnRefreshListener mOnRefreshListener;
 
-  private final static int[] TAB_ICONS =
+  public final static int[] TAB_ICONS =
           {
                   R.drawable.ic_gamecube,
                   R.drawable.ic_wii,
                   R.drawable.ic_folder
           };
 
-  public PlatformPagerAdapter(FragmentManager fm, Context context,
+  public PlatformPagerAdapter(FragmentActivity fa,
           SwipeRefreshLayout.OnRefreshListener onRefreshListener)
   {
-    super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
-    mContext = context;
+    super(fa);
     mOnRefreshListener = onRefreshListener;
   }
 
   @NonNull
   @Override
-  public Fragment getItem(int position)
+  public Fragment createFragment(int position)
   {
     Platform platform = Platform.fromPosition(position);
 
@@ -50,26 +42,8 @@ public class PlatformPagerAdapter extends FragmentPagerAdapter
   }
 
   @Override
-  public int getCount()
+  public int getItemCount()
   {
     return TAB_ICONS.length;
-  }
-
-  @Override
-  public CharSequence getPageTitle(int position)
-  {
-    // Hax from https://guides.codepath.com/android/Google-Play-Style-Tabs-using-TabLayout#design-support-library
-    // Apparently a workaround for TabLayout not supporting icons.
-    // TODO: This workaround will eventually not be necessary; switch to more legit methods when that is the case
-    // TODO: Also remove additional hax from styles.xml
-    Drawable drawable = mContext.getResources().getDrawable(TAB_ICONS[position]);
-    drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
-
-    ImageSpan imageSpan = new ImageSpan(drawable, ImageSpan.ALIGN_BOTTOM);
-
-    SpannableString sb = new SpannableString(" ");
-    sb.setSpan(imageSpan, 0, 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-
-    return sb;
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -26,7 +26,6 @@ import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner;
 import org.dolphinemu.dolphinemu.utils.BooleanSupplier;
 import org.dolphinemu.dolphinemu.utils.CompletableFuture;
 import org.dolphinemu.dolphinemu.utils.ContentHandler;
-import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 import org.dolphinemu.dolphinemu.utils.ThreadUtil;
 import org.dolphinemu.dolphinemu.utils.WiiUtils;
@@ -63,9 +62,7 @@ public final class MainPresenter
     GameFileCacheManager.getGameFiles().observe(mActivity, (gameFiles) -> mView.showGames());
 
     Observer<Boolean> refreshObserver = (isLoading) ->
-    {
-      mView.setRefreshing(GameFileCacheManager.isLoadingOrRescanning());
-    };
+            mView.setRefreshing(GameFileCacheManager.isLoadingOrRescanning());
     GameFileCacheManager.isLoading().observe(mActivity, refreshObserver);
     GameFileCacheManager.isRescanning().observe(mActivity, refreshObserver);
   }

--- a/Source/Android/app/src/main/res/layout/activity_main.xml
+++ b/Source/Android/app/src/main/res/layout/activity_main.xml
@@ -25,15 +25,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/dolphin_blue"
-            app:tabGravity="fill"
             app:tabIndicatorColor="@color/dolphin_white"
-            app:tabIndicatorHeight="3dp"
-            app:tabMode="fixed"
-            app:tabTextAppearance="@style/MyCustomTextAppearance" />
+            app:tabIndicatorHeight="3dp" />
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/pager_platforms"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -48,6 +48,11 @@
         <item name="android:windowAllowReturnTransitionOverlap">true</item>
     </style>
 
+    <!-- Hax to make Tablayout render icons -->
+    <style name="MyCustomTextAppearance" parent="TextAppearance.Design.Tab">
+        <item name="textAllCaps">false</item>
+    </style>
+
     <!-- Android TV Themes -->
     <style name="DolphinTvBase" parent="Theme.Leanback.Browse">
         <item name="colorSurface">@color/dolphin_blue</item>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -48,11 +48,6 @@
         <item name="android:windowAllowReturnTransitionOverlap">true</item>
     </style>
 
-    <!-- Hax to make Tablayout render icons -->
-    <style name="MyCustomTextAppearance" parent="TextAppearance.Design.Tab">
-        <item name="textAllCaps">false</item>
-    </style>
-
     <!-- Android TV Themes -->
     <style name="DolphinTvBase" parent="Theme.Leanback.Browse">
         <item name="colorSurface">@color/dolphin_blue</item>


### PR DESCRIPTION
Allows for native use of icons in TabLayout and enables better design support in the future. ViewPager1 was deprecated and was using a hacky way of getting icons in the tabs.

Note - Due to how ViewPager2 works, the scroll speed is now constant and feels a bit slower to scroll than ViewPager1 does.