### PR TITLE
Android: Replace deprecated method calls for adapter position

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/CheckBoxSettingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/CheckBoxSettingViewHolder.java
@@ -59,7 +59,7 @@ public final class CheckBoxSettingViewHolder extends SettingViewHolder
 
     mCheckbox.toggle();
 
-    getAdapter().onBooleanClick(mItem, getAdapterPosition(), mCheckbox.isChecked());
+    getAdapter().onBooleanClick(mItem, getBindingAdapterPosition(), mCheckbox.isChecked());
 
     setStyle(mTextSettingName, mItem);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/FilePickerViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/FilePickerViewHolder.java
@@ -90,7 +90,7 @@ public final class FilePickerViewHolder extends SettingViewHolder
       return;
     }
 
-    int position = getAdapterPosition();
+    int position = getBindingAdapterPosition();
     if (mFilePicker.getRequestType() == MainPresenter.REQUEST_DIRECTORY)
     {
       getAdapter().onFilePickerDirectoryClick(mItem, position);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/InputBindingSettingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/InputBindingSettingViewHolder.java
@@ -61,7 +61,7 @@ public final class InputBindingSettingViewHolder extends SettingViewHolder
       return;
     }
 
-    getAdapter().onInputBindingClick(mItem, getAdapterPosition());
+    getAdapter().onInputBindingClick(mItem, getBindingAdapterPosition());
 
     setStyle(mTextSettingName, mItem);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/RumbleBindingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/RumbleBindingViewHolder.java
@@ -61,7 +61,7 @@ public class RumbleBindingViewHolder extends SettingViewHolder
       return;
     }
 
-    getAdapter().onInputBindingClick(mItem, getAdapterPosition());
+    getAdapter().onInputBindingClick(mItem, getBindingAdapterPosition());
 
     setStyle(mTextSettingName, mItem);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SettingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SettingViewHolder.java
@@ -102,7 +102,7 @@ public abstract class SettingViewHolder extends RecyclerView.ViewHolder
     builder
             .setPositiveButton(R.string.ok, (dialog, whichButton) ->
             {
-              getAdapter().clearSetting(item, getAdapterPosition());
+              getAdapter().clearSetting(item, getBindingAdapterPosition());
               bind(item);
               Toast.makeText(context, R.string.setting_cleared, Toast.LENGTH_SHORT).show();
               dialog.dismiss();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SingleChoiceViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SingleChoiceViewHolder.java
@@ -98,7 +98,7 @@ public final class SingleChoiceViewHolder extends SettingViewHolder
       return;
     }
 
-    int position = getAdapterPosition();
+    int position = getBindingAdapterPosition();
     if (mItem instanceof SingleChoiceSetting)
     {
       getAdapter().onSingleChoiceClick((SingleChoiceSetting) mItem, position);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SliderViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SliderViewHolder.java
@@ -67,7 +67,7 @@ public final class SliderViewHolder extends SettingViewHolder
       return;
     }
 
-    getAdapter().onSliderClick(mItem, getAdapterPosition());
+    getAdapter().onSliderClick(mItem, getBindingAdapterPosition());
 
     setStyle(mTextSettingName, mItem);
   }


### PR DESCRIPTION
Replaces calls to getAdapterPosition (deprecated) with getBindingAdapterPosition. It's more specific and functions the same way as before.