### PR TITLE
Test (for FifoCI): disable embossmap texgen

### DIFF
--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -409,14 +409,8 @@ void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst)
       break;
     case TexGenType::EmbossMap:
     {
-      const LightPointer* light = (const LightPointer*)&xfmem.lights[texinfo.embosslightshift];
-
-      Vec3 ldir = (light->pos - dst->mvPosition).Normalized();
-      float d1 = ldir * dst->normal[1];
-      float d2 = ldir * dst->normal[2];
-
-      dst->texCoords[coordNum].x = dst->texCoords[texinfo.embosssourceshift].x + d1;
-      dst->texCoords[coordNum].y = dst->texCoords[texinfo.embosssourceshift].y + d2;
+      dst->texCoords[coordNum].x = dst->texCoords[texinfo.embosssourceshift].x;
+      dst->texCoords[coordNum].y = dst->texCoords[texinfo.embosssourceshift].y;
       dst->texCoords[coordNum].z = dst->texCoords[texinfo.embosssourceshift].z;
     }
     break;

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -451,8 +451,6 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
             "  {{\n");
   out.Write("  case {:s}:\n", TexGenType::EmbossMap);
   out.Write("    {{\n");
-  out.Write("      uint light = {};\n",
-            BitfieldExtract<&TexMtxInfo::embosslightshift>("texMtxInfo"));
   out.Write("      uint source = {};\n",
             BitfieldExtract<&TexMtxInfo::embosssourceshift>("texMtxInfo"));
   out.Write("      switch (source) {{\n");
@@ -460,8 +458,6 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
     out.Write("      case {}u: output_tex.xyz = o.tex{}; break;\n", i, i);
   out.Write("      default: output_tex.xyz = float3(0.0, 0.0, 0.0); break;\n"
             "      }}\n"
-            "      float3 ldir = normalize(" I_LIGHTS "[light].pos.xyz - pos.xyz);\n"
-            "      output_tex.xyz += float3(dot(ldir, _tangent), dot(ldir, _binormal), 0.0);\n"
             "    }}\n"
             "    break;\n\n");
   out.Write("  case {:s}:\n", TexGenType::Color0);

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -346,12 +346,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     {
     case TexGenType::EmbossMap:  // calculate tex coords into bump map
 
-      // transform the light dir into tangent space
-      out.Write("ldir = normalize(" LIGHT_POS ".xyz - pos.xyz);\n",
-                LIGHT_POS_PARAMS(texinfo.embosslightshift));
-      out.Write(
-          "o.tex{}.xyz = o.tex{}.xyz + float3(dot(ldir, _tangent), dot(ldir, _binormal), 0.0);\n",
-          i, texinfo.embosssourceshift);
+      out.Write("o.tex{}.xyz = o.tex{}.xyz;\n", i, texinfo.embosssourceshift);
 
       break;
     case TexGenType::Color0:


### PR DESCRIPTION
Basically, this disables the offset based on the light in all cases (treating it as 0, and copying the original coordinate unchanged), which should break all emboss map effects.  Thus we can see what games use these effects and what they'd look like without them.  This includes emboss effects that have binormal and tangent vectors specified, which already worked in Dolphin prior to #10584.