### PR TITLE
Qt: hide balloon tooltip when parent gets hidden

### DIFF
--- a/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipWidget.h
+++ b/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipWidget.h
@@ -33,15 +33,8 @@ private:
     m_timer_id = this->startTimer(TOOLTIP_DELAY);
   }
 
-  void leaveEvent(QEvent* event) override
-  {
-    if (m_timer_id)
-    {
-      this->killTimer(*m_timer_id);
-      m_timer_id.reset();
-    }
-    BalloonTip::HideBalloon();
-  }
+  void leaveEvent(QEvent* event) override { KillAndHide(); }
+  void hideEvent(QHideEvent* event) override { KillAndHide(); }
 
   void timerEvent(QTimerEvent* event) override
   {
@@ -53,6 +46,16 @@ private:
   }
 
   virtual QPoint GetToolTipPosition() const = 0;
+
+  void KillAndHide()
+  {
+    if (m_timer_id)
+    {
+      this->killTimer(*m_timer_id);
+      m_timer_id.reset();
+    }
+    BalloonTip::HideBalloon();
+  }
 
   std::optional<int> m_timer_id;
   QString m_title;


### PR DESCRIPTION
fixes balloon remaining onscreen when parent gets
hidden via escape key for example.

fixes https://bugs.dolphin-emu.org/issues/12891