### PR TITLE
Show a panic alert if movie is missing its starting savestate

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -985,7 +985,16 @@ bool PlayInput(const std::string& movie_path, std::optional<std::string>* savest
   {
     const std::string savestate_path_temp = movie_path + ".sav";
     if (File::Exists(savestate_path_temp))
+    {
       *savestate_path = savestate_path_temp;
+    }
+    else
+    {
+      PanicAlertFmtT("Movie {0} indicates that it starts from a savestate, but {1} doesn't exist. "
+                     "The movie will likely not sync!",
+                     movie_path, savestate_path_temp);
+    }
+
     s_bRecordingFromSaveState = true;
     Movie::LoadInput(movie_path);
   }


### PR DESCRIPTION
Previously, if a movie is started and its savestate is missing, then it'll just silently play the movie from the start of the game.  That's not great behavior, so I added a panic alert to this case:

![image](https://user-images.githubusercontent.com/8334194/167489896-362a059b-ec81-4940-8a16-1e3388548793.png)

I've hit this case because I renamed my movie file without renaming the savestate.  Other situations (such as the savestate being from an incompatible version) aren't covered (in the incompatible version case, you currently get an on-screen display message instead).