### PR TITLE
Main.cpp: Merge equivalent code paths.

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -145,12 +145,7 @@ int main(int argc, char* argv[])
   QCoreApplication::setOrganizationDomain(QStringLiteral("dolphin-emu.org"));
   QCoreApplication::setApplicationName(QStringLiteral("dolphin-emu"));
 
-#ifdef _WIN32
-  QApplication app(__argc, __argv);
-#else
   QApplication app(argc, argv);
-#endif
-
 #if defined(_WIN32) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
   // On Windows, Qt 5's default system font (MS Shell Dlg 2) is outdated.
   // Interestingly, the QMenu font is correct and comes from lfMenuFont


### PR DESCRIPTION
Removes a now-redundant snippet of #9104.

At the time `QApplication app` (which needs argc) was created in wWinMain on Windows and main on other platforms. wWinMain doesn't have an argc parameter, so __argc was the best alternative.

#10500 refactored Main.cpp so that a separate function handled the initial Windows argument processing and then called main (which is #defined to app_main on Windows). This means that `app` does have access to argc, so there's no longer a need for the Windows-specific branch.