### PR TITLE
AX: handle DPL2 mixer control in old GameCube titles

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -291,18 +291,31 @@ AXMixControl AXUCode::ConvertMixerControl(u32 mixer_control)
   // TODO: find other UCode versions with different mixer_control values
   if (m_crc == 0x4e8a8b21)
   {
-    ret |= MIX_MAIN_L | MIX_MAIN_R;
-    if (mixer_control & 0x0001)
-      ret |= MIX_AUXA_L | MIX_AUXA_R;
-    if (mixer_control & 0x0002)
-      ret |= MIX_AUXB_L | MIX_AUXB_R;
-    if (mixer_control & 0x0004)
+    if (mixer_control & 0x0010)
     {
-      ret |= MIX_MAIN_S;
-      if (ret & MIX_AUXA_L)
-        ret |= MIX_AUXA_S;
-      if (ret & MIX_AUXB_L)
-        ret |= MIX_AUXB_S;
+      // DPL2 mixing
+      ret |= MIX_MAIN_L | MIX_MAIN_R;
+      if ((mixer_control & 0x0006) == 0)
+        ret |= MIX_AUXB_L | MIX_AUXB_R;
+      if ((mixer_control & 0x0007) == 1)
+        ret |= MIX_AUXA_L | MIX_AUXA_R | MIX_AUXA_S;
+    }
+    else
+    {
+      // non-DPL2 mixing
+      ret |= MIX_MAIN_L | MIX_MAIN_R;
+      if (mixer_control & 0x0001)
+        ret |= MIX_AUXA_L | MIX_AUXA_R;
+      if (mixer_control & 0x0002)
+        ret |= MIX_AUXB_L | MIX_AUXB_R;
+      if (mixer_control & 0x0004)
+      {
+        ret |= MIX_MAIN_S;
+        if (ret & MIX_AUXA_L)
+          ret |= MIX_AUXA_S;
+        if (ret & MIX_AUXB_L)
+          ret |= MIX_AUXB_S;
+      }
     }
     if (mixer_control & 0x0008)
       ret |= MIX_ALL_RAMPS;
@@ -318,6 +331,7 @@ AXMixControl AXUCode::ConvertMixerControl(u32 mixer_control)
       ret |= MIX_MAIN_S;
     if (mixer_control & 0x0008)
       ret |= MIX_MAIN_L_RAMP | MIX_MAIN_R_RAMP | MIX_MAIN_S_RAMP;
+
     if (mixer_control & 0x0010)
       ret |= MIX_AUXA_L;
     if (mixer_control & 0x0020)
@@ -328,6 +342,7 @@ AXMixControl AXUCode::ConvertMixerControl(u32 mixer_control)
       ret |= MIX_AUXA_S;
     if (mixer_control & 0x0100)
       ret |= MIX_AUXA_S_RAMP;
+
     if (mixer_control & 0x0200)
       ret |= MIX_AUXB_L;
     if (mixer_control & 0x0400)
@@ -340,6 +355,8 @@ AXMixControl AXUCode::ConvertMixerControl(u32 mixer_control)
       ret |= MIX_AUXB_S_RAMP;
 
     // TODO: 0x4000 is used for Dolby Pro 2 sound mixing
+    // It selects the input surround channel for all AUXB mixing channels.
+    // This will only matter once we have ITD support.
   }
 
   return (AXMixControl)ret;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -335,41 +335,41 @@ AXMixControl AXWiiUCode::ConvertMixerControl(u32 mixer_control)
   if (mixer_control & 0x00000002)
     ret |= MIX_MAIN_R;
   if (mixer_control & 0x00000004)
-    ret |= MIX_MAIN_L_RAMP | MIX_MAIN_R_RAMP;
+    ret |= MIX_MAIN_L | MIX_MAIN_R | MIX_MAIN_L_RAMP | MIX_MAIN_R_RAMP;
   if (mixer_control & 0x00000008)
     ret |= MIX_MAIN_S;
   if (mixer_control & 0x00000010)
-    ret |= MIX_MAIN_S_RAMP;
+    ret |= MIX_MAIN_S | MIX_MAIN_S_RAMP;
   if (mixer_control & 0x00010000)
     ret |= MIX_AUXA_L;
   if (mixer_control & 0x00020000)
     ret |= MIX_AUXA_R;
   if (mixer_control & 0x00040000)
-    ret |= MIX_AUXA_L_RAMP | MIX_AUXA_R_RAMP;
+    ret |= MIX_AUXA_L | MIX_AUXA_R | MIX_AUXA_L_RAMP | MIX_AUXA_R_RAMP;
   if (mixer_control & 0x00080000)
     ret |= MIX_AUXA_S;
   if (mixer_control & 0x00100000)
-    ret |= MIX_AUXA_S_RAMP;
+    ret |= MIX_AUXA_S | MIX_AUXA_S_RAMP;
   if (mixer_control & 0x00200000)
     ret |= MIX_AUXB_L;
   if (mixer_control & 0x00400000)
     ret |= MIX_AUXB_R;
   if (mixer_control & 0x00800000)
-    ret |= MIX_AUXB_L_RAMP | MIX_AUXB_R_RAMP;
+    ret |= MIX_AUXB_L | MIX_AUXB_R | MIX_AUXB_L_RAMP | MIX_AUXB_R_RAMP;
   if (mixer_control & 0x01000000)
     ret |= MIX_AUXB_S;
   if (mixer_control & 0x02000000)
-    ret |= MIX_AUXB_S_RAMP;
+    ret |= MIX_AUXB_S | MIX_AUXB_S_RAMP;
   if (mixer_control & 0x04000000)
     ret |= MIX_AUXC_L;
   if (mixer_control & 0x08000000)
     ret |= MIX_AUXC_R;
   if (mixer_control & 0x10000000)
-    ret |= MIX_AUXC_L_RAMP | MIX_AUXC_R_RAMP;
+    ret |= MIX_AUXC_L | MIX_AUXC_R | MIX_AUXC_L_RAMP | MIX_AUXC_R_RAMP;
   if (mixer_control & 0x20000000)
     ret |= MIX_AUXC_S;
   if (mixer_control & 0x40000000)
-    ret |= MIX_AUXC_S_RAMP;
+    ret |= MIX_AUXC_S | MIX_AUXC_S_RAMP;
 
   return (AXMixControl)ret;
 }


### PR DESCRIPTION
In old GameCube titles the DPL2 bit implicitly activates the AUXB_LR channels. Also, setting the AUXA bit activates all three channels (LRS). This fixes the audio test in Rogue Squadron 2 ([issue 12902](https://bugs.dolphin-emu.org/issues/12902)).

The other commit is just a theoretical accuracy improvement for AXWii. In practice it should not affect any games.