### PR TITLE
IOS/DI: Fake the error 001 read when running DirectoryBlobs or Riivolution-patched games.

### DIFF
--- a/Source/Core/Core/Config/SessionSettings.cpp
+++ b/Source/Core/Core/Config/SessionSettings.cpp
@@ -15,4 +15,6 @@ const Info<bool> SESSION_GCI_FOLDER_CURRENT_GAME_ONLY{
     {System::Session, "Core", "GCIFolderCurrentGameOnly"}, false};
 const Info<bool> SESSION_CODE_SYNC_OVERRIDE{{System::Session, "Core", "CheatSyncOverride"}, false};
 const Info<bool> SESSION_SAVE_DATA_WRITABLE{{System::Session, "Core", "SaveDataWritable"}, true};
+const Info<bool> SESSION_SHOULD_FAKE_ERROR_001{{System::Session, "Core", "ShouldFakeError001"},
+                                               false};
 }  // namespace Config

--- a/Source/Core/Core/Config/SessionSettings.h
+++ b/Source/Core/Core/Config/SessionSettings.h
@@ -13,4 +13,5 @@ extern const Info<bool> SESSION_LOAD_IPL_DUMP;
 extern const Info<bool> SESSION_GCI_FOLDER_CURRENT_GAME_ONLY;
 extern const Info<bool> SESSION_CODE_SYNC_OVERRIDE;
 extern const Info<bool> SESSION_SAVE_DATA_WRITABLE;
+extern const Info<bool> SESSION_SHOULD_FAKE_ERROR_001;
 }  // namespace Config

--- a/Source/Core/Core/HW/DVD/DVDInterface.h
+++ b/Source/Core/Core/HW/DVD/DVDInterface.h
@@ -134,6 +134,10 @@ bool UpdateRunningGameMetadata(std::optional<u64> title_id = {});
 void ExecuteCommand(ReplyType reply_type);
 void PerformDecryptingRead(u32 position, u32 length, u32 output_address,
                            const DiscIO::Partition& partition, ReplyType reply_type);
+
+// For circumventing Error #001 in DirectoryBlobs, which may have data in the offsets being checked.
+void ForceOutOfBoundsRead(ReplyType reply_type);
+
 // Exposed for use by emulated BS2; does not perform any checks on drive state
 void AudioBufferConfig(bool enable_dtk, u8 dtk_buffer_length);
 


### PR DESCRIPTION
@JosJuice Is this what you had in mind?