### PR TITLE
Android: Fix game card in landscape

### DIFF
--- a/Source/Android/app/src/main/res/layout/card_game.xml
+++ b/Source/Android/app/src/main/res/layout/card_game.xml
@@ -12,24 +12,20 @@
     android:paddingStart="4dp"
     android:paddingTop="8dp"
     android:paddingEnd="4dp"
-    android:transitionName="card_game"
-    tools:layout_width="160dp">
+    android:transitionName="card_game">
 
     <androidx.cardview.widget.CardView
         android:id="@+id/card_game_art"
-        android:layout_width="match_parent"
-        android:layout_height="159dp"
+        android:layout_width="115dp"
+        android:layout_height="161dp"
         android:layout_gravity="center"
-        app:cardCornerRadius="4dp"
-        tools:layout_width="140dp">
+        app:cardCornerRadius="4dp">
 
         <ImageView
             android:id="@+id/image_game_screen"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1"
-            tools:scaleType="centerCrop"
-            tools:src="@drawable/placeholder_screenshot" />
+            android:layout_weight="1"/>
     </androidx.cardview.widget.CardView>
 
     <TextView


### PR DESCRIPTION
Use strict dpi that follows the relative dimensions provided by GameTDB. Turns out this works for most of the games on the DB, but there are instances where images provided are not the typical 160x224 resolution. In that case, there will be small borders around the image.

Before landscape - 
![before](https://user-images.githubusercontent.com/14132249/168494801-a4a0dcfd-c26d-465b-a943-74e4ea8ce20f.png)

After landscape - 
![after](https://user-images.githubusercontent.com/14132249/168494803-9802c764-3b44-4000-8f08-8a07fdb2c585.png)

Example of non-standard res in master and this PR - 
![ex](https://user-images.githubusercontent.com/14132249/168494874-e9f3a673-d850-4636-b3ca-309d02debc90.png)

