### PR TITLE
Convert PointerWrap::Mode to enum class

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -38,12 +38,12 @@
 class PointerWrap
 {
 public:
-  enum Mode
+  enum class Mode
   {
-    MODE_READ,
-    MODE_WRITE,
-    MODE_MEASURE,
-    MODE_VERIFY,
+    Read,
+    Write,
+    Measure,
+    Verify,
   };
 
 private:
@@ -57,12 +57,12 @@ public:
   {
   }
 
-  void SetMeasureMode() { m_mode = Mode::MODE_MEASURE; }
-  void SetVerifyMode() { m_mode = Mode::MODE_VERIFY; }
-  bool IsReadMode() const { return m_mode == Mode::MODE_READ; }
-  bool IsWriteMode() const { return m_mode == Mode::MODE_WRITE; }
-  bool IsMeasureMode() const { return m_mode == Mode::MODE_MEASURE; }
-  bool IsVerifyMode() const { return m_mode == Mode::MODE_VERIFY; }
+  void SetMeasureMode() { m_mode = Mode::Measure; }
+  void SetVerifyMode() { m_mode = Mode::Verify; }
+  bool IsReadMode() const { return m_mode == Mode::Read; }
+  bool IsWriteMode() const { return m_mode == Mode::Write; }
+  bool IsMeasureMode() const { return m_mode == Mode::Measure; }
+  bool IsVerifyMode() const { return m_mode == Mode::Verify; }
 
   template <typename K, class V>
   void Do(std::map<K, V>& x)
@@ -72,7 +72,7 @@ public:
 
     switch (m_mode)
     {
-    case MODE_READ:
+    case Mode::Read:
       for (x.clear(); count != 0; --count)
       {
         std::pair<K, V> pair;
@@ -82,9 +82,9 @@ public:
       }
       break;
 
-    case MODE_WRITE:
-    case MODE_MEASURE:
-    case MODE_VERIFY:
+    case Mode::Write:
+    case Mode::Measure:
+    case Mode::Verify:
       for (auto& elem : x)
       {
         Do(elem.first);
@@ -102,7 +102,7 @@ public:
 
     switch (m_mode)
     {
-    case MODE_READ:
+    case Mode::Read:
       for (x.clear(); count != 0; --count)
       {
         V value;
@@ -111,9 +111,9 @@ public:
       }
       break;
 
-    case MODE_WRITE:
-    case MODE_MEASURE:
-    case MODE_VERIFY:
+    case Mode::Write:
+    case Mode::Measure:
+    case Mode::Verify:
       for (const V& val : x)
       {
         Do(val);
@@ -161,7 +161,7 @@ public:
 
     switch (m_mode)
     {
-    case MODE_READ:
+    case Mode::Read:
       if (present)
       {
         x = std::make_optional<T>();
@@ -173,9 +173,9 @@ public:
       }
       break;
 
-    case MODE_WRITE:
-    case MODE_MEASURE:
-    case MODE_VERIFY:
+    case Mode::Write:
+    case Mode::Measure:
+    case Mode::Verify:
       if (present)
         Do(x.value());
 
@@ -343,18 +343,18 @@ private:
 
     switch (m_mode)
     {
-    case MODE_READ:
+    case Mode::Read:
       memcpy(data, *m_ptr_current, size);
       break;
 
-    case MODE_WRITE:
+    case Mode::Write:
       memcpy(*m_ptr_current, data, size);
       break;
 
-    case MODE_MEASURE:
+    case Mode::Measure:
       break;
 
-    case MODE_VERIFY:
+    case Mode::Verify:
       DEBUG_ASSERT_MSG(COMMON, !memcmp(data, *m_ptr_current, size),
                        "Savestate verification failure: buf {} != {} (size {}).\n", fmt::ptr(data),
                        fmt::ptr(*m_ptr_current), size);

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -192,11 +192,11 @@ void DoState(PointerWrap& p)
     // order (or at all) every time.
     // so, we savestate the event's type's name, and derive ev.type from that when loading.
     std::string name;
-    if (pw.GetMode() != PointerWrap::MODE_READ)
+    if (!pw.IsReadMode())
       name = *ev.type->name;
 
     pw.Do(name);
-    if (pw.GetMode() == PointerWrap::MODE_READ)
+    if (pw.IsReadMode())
     {
       auto itr = s_event_types.find(name);
       if (itr != s_event_types.end())
@@ -217,7 +217,7 @@ void DoState(PointerWrap& p)
   // When loading from a save state, we must assume the Event order is random and meaningless.
   // The exact layout of the heap in memory is implementation defined, therefore it is platform
   // and library version specific.
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
     std::make_heap(s_event_queue.begin(), s_event_queue.end(), std::greater<Event>());
 }
 

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -398,7 +398,7 @@ void SDSP::DoState(PointerWrap& p)
   Common::WriteProtectMemory(iram, DSP_IRAM_BYTE_SIZE, false);
   // TODO: This uses the wrong endianness (producing bad disassembly)
   // and a bogus byte count (producing bad hashes)
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
     Host::CodeLoaded(m_dsp_core, reinterpret_cast<const u8*>(iram), DSP_IRAM_BYTE_SIZE);
   p.DoArray(dram, DSP_DRAM_SIZE);
 }

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -95,11 +95,11 @@ void DSPHLE::DoState(PointerWrap& p)
 {
   bool is_hle = true;
   p.Do(is_hle);
-  if (!is_hle && p.GetMode() == PointerWrap::MODE_READ)
+  if (!is_hle && p.IsReadMode())
   {
     Core::DisplayMessage("State is incompatible with current DSP engine. Aborting load state.",
                          3000);
-    p.SetMode(PointerWrap::MODE_VERIFY);
+    p.SetVerifyMode();
     return;
   }
 

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -91,7 +91,7 @@ void CMailHandler::Halt(bool _Halt)
 
 void CMailHandler::DoState(PointerWrap& p)
 {
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     Clear();
     int sz = 0;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -747,15 +747,14 @@ void AXUCode::DoAXState(PointerWrap& p)
   auto old_checksum = m_coeffs_checksum;
   p.Do(m_coeffs_checksum);
 
-  if (p.GetMode() == PointerWrap::MODE_READ && m_coeffs_checksum &&
-      old_checksum != m_coeffs_checksum)
+  if (p.IsReadMode() && m_coeffs_checksum && old_checksum != m_coeffs_checksum)
   {
     if (!LoadResamplingCoefficients(true, *m_coeffs_checksum))
     {
       Core::DisplayMessage("Could not find the DSP polyphase resampling coefficients used by the "
                            "savestate. Aborting load state.",
                            3000);
-      p.SetMode(PointerWrap::MODE_VERIFY);
+      p.SetVerifyMode();
       return;
     }
   }

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -42,11 +42,11 @@ void DSPLLE::DoState(PointerWrap& p)
 {
   bool is_hle = false;
   p.Do(is_hle);
-  if (is_hle && p.GetMode() == PointerWrap::MODE_READ)
+  if (is_hle && p.IsReadMode())
   {
     Core::DisplayMessage("State is incompatible with current DSP engine. Aborting load state.",
                          3000);
-    p.SetMode(PointerWrap::MODE_VERIFY);
+    p.SetVerifyMode();
     return;
   }
   m_dsp_core.DoState(p);

--- a/Source/Core/Core/HW/GBACore.cpp
+++ b/Source/Core/Core/HW/GBACore.cpp
@@ -651,7 +651,7 @@ void Core::DoState(PointerWrap& p)
   {
     ::Core::DisplayMessage(fmt::format("GBA{} core not started. Aborting.", m_device_number + 1),
                            3000);
-    p.SetMode(PointerWrap::MODE_VERIFY);
+    p.SetVerifyMode();
     return;
   }
 
@@ -662,14 +662,13 @@ void Core::DoState(PointerWrap& p)
   auto old_title = m_game_title;
   p.Do(m_game_title);
 
-  if (p.GetMode() == PointerWrap::MODE_READ &&
-      (has_rom != !m_rom_path.empty() ||
-       (has_rom && (old_hash != m_rom_hash || old_title != m_game_title))))
+  if (p.IsReadMode() && (has_rom != !m_rom_path.empty() ||
+                         (has_rom && (old_hash != m_rom_hash || old_title != m_game_title))))
   {
     ::Core::DisplayMessage(
         fmt::format("Incompatible ROM state in GBA{}. Aborting load state.", m_device_number + 1),
         3000);
-    p.SetMode(PointerWrap::MODE_VERIFY);
+    p.SetVerifyMode();
     return;
   }
 
@@ -684,14 +683,14 @@ void Core::DoState(PointerWrap& p)
   std::vector<u8> core_state;
   core_state.resize(m_core->stateSize(m_core));
 
-  if (p.GetMode() == PointerWrap::MODE_WRITE || p.GetMode() == PointerWrap::MODE_VERIFY)
+  if (p.IsWriteMode() || p.IsVerifyMode())
   {
     m_core->saveState(m_core, core_state.data());
   }
 
   p.Do(core_state);
 
-  if (p.GetMode() == PointerWrap::MODE_READ && m_core->stateSize(m_core) == core_state.size())
+  if (p.IsReadMode() && m_core->stateSize(m_core) == core_state.size())
   {
     m_core->loadState(m_core, core_state.data());
     if (auto host = m_host.lock())

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -428,7 +428,7 @@ void DoState(PointerWrap& p)
     Core::DisplayMessage("State is incompatible with current memory settings (MMU and/or memory "
                          "overrides). Aborting load state.",
                          3000);
-    p.SetMode(PointerWrap::MODE_VERIFY);
+    p.SetVerifyMode();
     return;
   }
 

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -226,7 +226,7 @@ void DoState(PointerWrap& p)
       static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->DoState(p);
     }
 
-    if (p.GetMode() == PointerWrap::MODE_READ)
+    if (p.IsReadMode())
     {
       // If using a real wiimote or the save-state source does not match the current source,
       // then force a reconnection on load.

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -559,7 +559,7 @@ void Wiimote::DoState(PointerWrap& p)
   m_speaker_logic.DoState(p);
   m_camera_logic.DoState(p);
 
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
     m_camera_logic.SetEnabled(m_status.ir);
 
   p.Do(m_is_motion_plus_attached);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
@@ -136,7 +136,7 @@ void EncryptedExtension::DoState(PointerWrap& p)
 {
   p.Do(m_reg);
 
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     // No need to sync the key when we can just regenerate it.
     m_is_key_dirty = true;

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -260,7 +260,7 @@ void HostFileSystem::DoState(PointerWrap& p)
 
   // handle /tmp
   std::string Path = BuildFilename("/tmp").host_path;
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     File::DeleteDirRecursively(Path);
     File::CreateDir(Path);

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -807,7 +807,7 @@ void Kernel::DoState(PointerWrap& p)
   for (const auto& entry : m_device_map)
     entry.second->DoState(p);
 
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     for (u32 i = 0; i < IPC_MAX_FDS; i++)
     {

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -994,8 +994,7 @@ void WiiSockMan::Convert(sockaddr_in const& from, WiiSockAddrIn& to, s32 addrlen
 
 void WiiSockMan::DoState(PointerWrap& p)
 {
-  bool saving = p.GetMode() == PointerWrap::Mode::MODE_WRITE ||
-                p.GetMode() == PointerWrap::Mode::MODE_MEASURE;
+  bool saving = p.IsWriteMode() || p.IsMeasureMode();
   auto size = pending_polls.size();
   p.Do(size);
   if (!saving)

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -57,7 +57,7 @@ void SDIOSlot0Device::RefreshConfig()
 void SDIOSlot0Device::DoState(PointerWrap& p)
 {
   DoStateShared(p);
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     OpenInternal();
   }

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -90,10 +90,10 @@ void BluetoothEmuDevice::DoState(PointerWrap& p)
 {
   bool passthrough_bluetooth = false;
   p.Do(passthrough_bluetooth);
-  if (passthrough_bluetooth && p.GetMode() == PointerWrap::MODE_READ)
+  if (passthrough_bluetooth && p.IsReadMode())
   {
     Core::DisplayMessage("State needs Bluetooth passthrough to be enabled. Aborting load.", 4000);
-    p.SetMode(PointerWrap::MODE_VERIFY);
+    p.SetVerifyMode();
     return;
   }
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
@@ -19,6 +19,6 @@ std::optional<IPCReply> BluetoothStubDevice::Open(const OpenRequest& request)
 void BluetoothStubDevice::DoState(PointerWrap& p)
 {
   Core::DisplayMessage("The current IPC_HLE_Device_usb is a stub. Aborting load.", 4000);
-  p.SetMode(PointerWrap::MODE_VERIFY);
+  p.SetVerifyMode();
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -55,7 +55,7 @@ void USBHost::UpdateWantDeterminism(const bool new_want_determinism)
 
 void USBHost::DoState(PointerWrap& p)
 {
-  if (IsOpened() && p.GetMode() == PointerWrap::MODE_READ)
+  if (IsOpened() && p.IsReadMode())
   {
     // After a state has loaded, there may be insertion hooks for devices that were
     // already plugged in, and which need to be triggered.

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -75,7 +75,7 @@ std::optional<IPCReply> OH0::IOCtlV(const IOCtlVRequest& request)
 
 void OH0::DoState(PointerWrap& p)
 {
-  if (p.GetMode() == PointerWrap::MODE_READ && !m_devices.empty())
+  if (p.IsReadMode() && !m_devices.empty())
   {
     Core::DisplayMessage("It is suggested that you unplug and replug all connected USB devices.",
                          5000);

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -47,7 +47,7 @@ void SetJit(JitBase* jit)
 }
 void DoState(PointerWrap& p)
 {
-  if (g_jit && p.GetMode() == PointerWrap::MODE_READ)
+  if (g_jit && p.IsReadMode())
     g_jit->ClearCache();
 }
 CPUCoreBase* InitJitCore(PowerPC::CPUCore core)

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -100,7 +100,7 @@ std::ostream& operator<<(std::ostream& os, CPUCore core)
 void DoState(PointerWrap& p)
 {
   // some of this code has been disabled, because
-  // it changes registers even in MODE_MEASURE (which is suspicious and seems like it could cause
+  // it changes registers even in Mode::Measure (which is suspicious and seems like it could cause
   // desyncs)
   // and because the values it's changing have been added to CoreTiming::DoState, so it might
   // conflict to mess with them here.

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -132,7 +132,7 @@ void DoState(PointerWrap& p)
 
   ppcState.iCache.DoState(p);
 
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     RoundingModeUpdated();
     IBATUpdated();

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -226,7 +226,7 @@ void LoadFromBuffer(std::vector<u8>& buffer)
   Core::RunOnCPUThread(
       [&] {
         u8* ptr = buffer.data();
-        PointerWrap p(&ptr, buffer.size(), PointerWrap::Mode::MODE_READ);
+        PointerWrap p(&ptr, buffer.size(), PointerWrap::Mode::Read);
         DoState(p);
       },
       true);
@@ -237,14 +237,14 @@ void SaveToBuffer(std::vector<u8>& buffer)
   Core::RunOnCPUThread(
       [&] {
         u8* ptr = nullptr;
-        PointerWrap p_measure(&ptr, 0, PointerWrap::Mode::MODE_MEASURE);
+        PointerWrap p_measure(&ptr, 0, PointerWrap::Mode::Measure);
 
         DoState(p_measure);
         const size_t buffer_size = reinterpret_cast<size_t>(ptr);
         buffer.resize(buffer_size);
 
         ptr = buffer.data();
-        PointerWrap p(&ptr, buffer_size, PointerWrap::Mode::MODE_WRITE);
+        PointerWrap p(&ptr, buffer_size, PointerWrap::Mode::Write);
         DoState(p);
       },
       true);
@@ -412,7 +412,7 @@ void SaveAs(const std::string& filename, bool wait)
       [&] {
         // Measure the size of the buffer.
         u8* ptr = nullptr;
-        PointerWrap p_measure(&ptr, 0, PointerWrap::Mode::MODE_MEASURE);
+        PointerWrap p_measure(&ptr, 0, PointerWrap::Mode::Measure);
         DoState(p_measure);
         const size_t buffer_size = reinterpret_cast<size_t>(ptr);
 
@@ -422,7 +422,7 @@ void SaveAs(const std::string& filename, bool wait)
           std::lock_guard lk(g_cs_current_buffer);
           g_current_buffer.resize(buffer_size);
           ptr = g_current_buffer.data();
-          PointerWrap p(&ptr, buffer_size, PointerWrap::Mode::MODE_WRITE);
+          PointerWrap p(&ptr, buffer_size, PointerWrap::Mode::Write);
           DoState(p);
           is_write_mode = p.IsWriteMode();
         }
@@ -591,7 +591,7 @@ void LoadAs(const std::string& filename)
           if (!buffer.empty())
           {
             u8* ptr = buffer.data();
-            PointerWrap p(&ptr, buffer.size(), PointerWrap::Mode::MODE_READ);
+            PointerWrap p(&ptr, buffer.size(), PointerWrap::Mode::Read);
             DoState(p);
             loaded = true;
             loadedSuccessfully = p.IsReadMode();

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -230,14 +230,14 @@ bool GameFileCache::SyncCacheFile(bool save)
   {
     // Measure the size of the buffer.
     u8* ptr = nullptr;
-    PointerWrap p_measure(&ptr, 0, PointerWrap::Mode::MODE_MEASURE);
+    PointerWrap p_measure(&ptr, 0, PointerWrap::Mode::Measure);
     DoState(&p_measure);
     const size_t buffer_size = reinterpret_cast<size_t>(ptr);
 
     // Then actually do the write.
     std::vector<u8> buffer(buffer_size);
     ptr = buffer.data();
-    PointerWrap p(&ptr, buffer_size, PointerWrap::Mode::MODE_WRITE);
+    PointerWrap p(&ptr, buffer_size, PointerWrap::Mode::Write);
     DoState(&p, buffer_size);
     if (f.WriteBytes(buffer.data(), buffer.size()))
       success = true;
@@ -248,7 +248,7 @@ bool GameFileCache::SyncCacheFile(bool save)
     if (!buffer.empty() && f.ReadBytes(buffer.data(), buffer.size()))
     {
       u8* ptr = buffer.data();
-      PointerWrap p(&ptr, buffer.size(), PointerWrap::Mode::MODE_READ);
+      PointerWrap p(&ptr, buffer.size(), PointerWrap::Mode::Read);
       DoState(&p, buffer.size());
       if (p.IsReadMode())
         success = true;

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -230,14 +230,14 @@ bool GameFileCache::SyncCacheFile(bool save)
   {
     // Measure the size of the buffer.
     u8* ptr = nullptr;
-    PointerWrap p_measure(&ptr, 0, PointerWrap::MODE_MEASURE);
+    PointerWrap p_measure(&ptr, 0, PointerWrap::Mode::MODE_MEASURE);
     DoState(&p_measure);
     const size_t buffer_size = reinterpret_cast<size_t>(ptr);
 
     // Then actually do the write.
     std::vector<u8> buffer(buffer_size);
     ptr = buffer.data();
-    PointerWrap p(&ptr, buffer_size, PointerWrap::MODE_WRITE);
+    PointerWrap p(&ptr, buffer_size, PointerWrap::Mode::MODE_WRITE);
     DoState(&p, buffer_size);
     if (f.WriteBytes(buffer.data(), buffer.size()))
       success = true;
@@ -248,9 +248,9 @@ bool GameFileCache::SyncCacheFile(bool save)
     if (!buffer.empty() && f.ReadBytes(buffer.data(), buffer.size()))
     {
       u8* ptr = buffer.data();
-      PointerWrap p(&ptr, buffer.size(), PointerWrap::MODE_READ);
+      PointerWrap p(&ptr, buffer.size(), PointerWrap::Mode::MODE_READ);
       DoState(&p, buffer.size());
-      if (p.GetMode() == PointerWrap::MODE_READ)
+      if (p.IsReadMode())
         success = true;
     }
   }
@@ -271,16 +271,16 @@ void GameFileCache::DoState(PointerWrap* p, u64 size)
     u64 expected_size;
   } header = {CACHE_REVISION, size};
   p->Do(header);
-  if (p->GetMode() == PointerWrap::MODE_READ)
+  if (p->IsReadMode())
   {
     if (header.revision != CACHE_REVISION || header.expected_size != size)
     {
-      p->SetMode(PointerWrap::MODE_MEASURE);
+      p->SetMeasureMode();
       return;
     }
   }
   p->DoEachElement(m_cached_files, [](PointerWrap& state, std::shared_ptr<GameFile>& elem) {
-    if (state.GetMode() == PointerWrap::MODE_READ)
+    if (state.IsReadMode())
       elem = std::make_shared<GameFile>();
     elem->DoState(state);
   });

--- a/Source/Core/VideoCommon/BoundingBox.cpp
+++ b/Source/Core/VideoCommon/BoundingBox.cpp
@@ -104,7 +104,7 @@ void BoundingBox::DoState(PointerWrap& p)
   // We handle saving the backend values specially rather than using Readback() and Flush() so that
   // we don't mess up the current cache state
   std::vector<BBoxType> backend_values(NUM_BBOX_VALUES);
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     p.Do(backend_values);
 

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -26,7 +26,7 @@ void DoCPState(PointerWrap& p)
   p.Do(g_main_cp_state.vtx_desc);
   p.DoArray(g_main_cp_state.vtx_attr);
   p.DoMarker("CP Memory");
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     CopyPreprocessCPStateFromMain();
     VertexLoaderManager::g_bases_dirty = true;

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -94,7 +94,7 @@ void DoState(PointerWrap& p)
   p.DoPointer(write_ptr, s_video_buffer);
   s_video_buffer_write_ptr = write_ptr;
   p.DoPointer(s_video_buffer_read_ptr, s_video_buffer);
-  if (p.GetMode() == PointerWrap::MODE_READ && s_use_deterministic_gpu_thread)
+  if (p.IsReadMode() && s_use_deterministic_gpu_thread)
   {
     // We're good and paused, right?
     s_video_buffer_seen_ptr = s_video_buffer_pp_read_ptr = s_video_buffer_read_ptr;

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -482,7 +482,7 @@ void FrameDump::CloseVideoFile()
 
 void FrameDump::DoState(PointerWrap& p)
 {
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
     ++m_savestate_index;
 }
 

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -910,7 +910,7 @@ void FramebufferManager::DoState(PointerWrap& p)
   if (!save_efb_state)
     return;
 
-  if (p.GetMode() == PointerWrap::MODE_WRITE || p.GetMode() == PointerWrap::MODE_MEASURE)
+  if (p.IsWriteMode() || p.IsMeasureMode())
     DoSaveState(p);
   else
     DoLoadState(p);

--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -298,7 +298,7 @@ Common::Vec2 FreeLookCamera::GetFieldOfViewMultiplier() const
 
 void FreeLookCamera::DoState(PointerWrap& p)
 {
-  if (p.GetMode() == PointerWrap::MODE_WRITE || p.GetMode() == PointerWrap::MODE_MEASURE)
+  if (p.IsWriteMode() || p.IsMeasureMode())
   {
     p.Do(m_current_type);
     if (m_camera_controller)
@@ -314,7 +314,7 @@ void FreeLookCamera::DoState(PointerWrap& p)
     {
       m_camera_controller->DoState(p);
     }
-    else if (p.GetMode() == PointerWrap::MODE_READ)
+    else if (p.IsReadMode())
     {
       const std::string old_type_name = old_type ? to_string(*old_type) : "";
       const std::string loaded_type_name = m_current_type ? to_string(*m_current_type) : "";
@@ -323,7 +323,7 @@ void FreeLookCamera::DoState(PointerWrap& p)
                       "'{}'.  Aborting load state",
                       old_type_name, loaded_type_name);
       Core::DisplayMessage(message, 5000);
-      p.SetMode(PointerWrap::MODE_VERIFY);
+      p.SetVerifyMode();
     }
   }
 }

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -111,7 +111,7 @@ void GeometryShaderManager::DoState(PointerWrap& p)
 
   p.Do(constants);
 
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     // Fixup the current state from global GPU state
     // NOTE: This requires that all GPU memory has been loaded already.

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -542,7 +542,7 @@ void PixelShaderManager::DoState(PointerWrap& p)
 
   p.Do(constants);
 
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     // Fixup the current state from global GPU state
     // NOTE: This requires that all GPU memory has been loaded already.

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1810,7 +1810,7 @@ void Renderer::DoState(PointerWrap& p)
 
   m_bounding_box->DoState(p);
 
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     // Force the next xfb to be displayed.
     m_last_xfb_id = std::numeric_limits<u64>::max();

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -432,7 +432,7 @@ void TextureCacheBase::SerializeTexture(AbstractTexture* tex, const TextureConfi
                                         PointerWrap& p)
 {
   // If we're in measure mode, skip the actual readback to save some time.
-  const bool skip_readback = p.GetMode() == PointerWrap::MODE_MEASURE;
+  const bool skip_readback = p.IsMeasureMode();
   p.DoPOD(config);
 
   if (skip_readback || CheckReadbackTexture(config.width, config.height, config.format))
@@ -459,7 +459,7 @@ void TextureCacheBase::SerializeTexture(AbstractTexture* tex, const TextureConfi
     // needing to allocate/free an extra buffer.
     u8* texture_data = p.DoExternal(total_size);
 
-    if (!skip_readback && p.GetMode() == PointerWrap::MODE_MEASURE)
+    if (!skip_readback && p.IsMeasureMode())
     {
       ERROR_LOG_FMT(VIDEO, "Couldn't acquire {} bytes for serializing texture.", total_size);
       return;
@@ -502,7 +502,7 @@ std::optional<TextureCacheBase::TexPoolEntry> TextureCacheBase::DeserializeTextu
   u32 total_size = 0;
   u8* texture_data = p.DoExternal(total_size);
 
-  if (p.GetMode() != PointerWrap::MODE_READ || total_size == 0)
+  if (!p.IsReadMode() || total_size == 0)
     return std::nullopt;
 
   auto tex = AllocateTexture(config);
@@ -542,7 +542,7 @@ void TextureCacheBase::DoState(PointerWrap& p)
 
   p.Do(last_entry_id);
 
-  if (p.GetMode() == PointerWrap::MODE_WRITE || p.GetMode() == PointerWrap::MODE_MEASURE)
+  if (p.IsWriteMode() || p.IsMeasureMode())
     DoSaveState(p);
   else
     DoLoadState(p);
@@ -673,7 +673,7 @@ void TextureCacheBase::DoLoadState(PointerWrap& p)
   // Only clear out state when actually restoring/loading.
   // Since we throw away entries when not in loading mode now, we don't need to check
   // before inserting entries into the cache, as GetEntry will always return null.
-  const bool commit_state = p.GetMode() == PointerWrap::MODE_READ;
+  const bool commit_state = p.IsReadMode();
   if (commit_state)
     Invalidate();
 

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -519,7 +519,7 @@ void VertexManagerBase::Flush()
 
 void VertexManagerBase::DoState(PointerWrap& p)
 {
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     // Flush old vertex data before loading state.
     Flush();

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -635,7 +635,7 @@ void VertexShaderManager::DoState(PointerWrap& p)
 
   p.Do(constants);
 
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     Dirty();
   }

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -27,10 +27,10 @@ void VideoCommon_DoState(PointerWrap& p)
   bool software = false;
   p.Do(software);
 
-  if (p.GetMode() == PointerWrap::MODE_READ && software == true)
+  if (p.IsReadMode() && software == true)
   {
     // change mode to abort load of incompatible save state.
-    p.SetMode(PointerWrap::MODE_VERIFY);
+    p.SetVerifyMode();
   }
 
   // BP Memory
@@ -86,7 +86,7 @@ void VideoCommon_DoState(PointerWrap& p)
   p.DoMarker("Renderer");
 
   // Refresh state.
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsReadMode())
   {
     // Inform backend of new state from registers.
     BPReload();


### PR DESCRIPTION
Standard enum class conversion, along with some refactoring to make using PointerWraps a bit more convenient.

- Added IsReadMode, IsWriteMode, IsMeasureMode, and IsVerifyMode functions so you don't have to list out the full enum value.
- Likewise added SetMeasureMode and SetVerifyMode. As it stands PointerWraps are never set to Read or Write mode after creation, but more on that subject in a comment below.
- Removed extraneous comments.
- Removed unnecessary default enum value.
- Renamed the mode member variable to m_mode to match normal naming convention.

I've gone with smaller commits for easier reviewing, but I'll squish everything before merging.