### PR TITLE
Fix antialiasing modes being determined from the wrong graphics adapter

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -142,9 +142,10 @@ void GeneralWidget::ConnectWidgets()
   // Video Backend
   connect(m_backend_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &GeneralWidget::SaveSettings);
-  connect(m_adapter_combo, qOverload<int>(&QComboBox::currentIndexChanged), this, [](int index) {
+  connect(m_adapter_combo, qOverload<int>(&QComboBox::currentIndexChanged), this, [&](int index) {
     g_Config.iAdapter = index;
     Config::SetBaseOrCurrent(Config::GFX_ADAPTER, index);
+    emit BackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
   });
 }
 

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -272,11 +272,12 @@ void VideoBackendBase::ActivateBackend(const std::string& name)
 
 void VideoBackendBase::PopulateBackendInfo()
 {
-  // We refresh the config after initializing the backend info, as system-specific settings
-  // such as anti-aliasing, or the selected adapter may be invalid, and should be checked.
+  g_Config.Refresh();
   ActivateBackend(Config::Get(Config::MAIN_GFX_BACKEND));
   g_video_backend->InitBackendInfo();
-  g_Config.Refresh();
+  // We validate the config after initializing the backend info, as system-specific settings
+  // such as anti-aliasing, or the selected adapter may be invalid, and should be checked.
+  g_Config.VerifyValidity();
 }
 
 void VideoBackendBase::PopulateBackendInfoFromUI()

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -44,7 +44,12 @@ void VideoConfig::Refresh()
     // invalid values. Instead, pause emulation first, which will flush the video thread,
     // update the config and correct it, then resume emulation, after which the video
     // thread will detect the config has changed and act accordingly.
-    Config::AddConfigChangedCallback([]() { Core::RunAsCPUThread([]() { g_Config.Refresh(); }); });
+    Config::AddConfigChangedCallback([]() {
+      Core::RunAsCPUThread([]() {
+        g_Config.Refresh();
+        g_Config.VerifyValidity();
+      });
+    });
     s_has_registered_callback = true;
   }
 
@@ -140,8 +145,6 @@ void VideoConfig::Refresh()
   bFastTextureSampling = Config::Get(Config::GFX_HACK_FAST_TEXTURE_SAMPLING);
 
   bPerfQueriesEnable = Config::Get(Config::GFX_PERF_QUERIES_ENABLE);
-
-  VerifyValidity();
 }
 
 void VideoConfig::VerifyValidity()


### PR DESCRIPTION
This results in the list of available antialiasing modes being updated; before, it would only show the modes available for the adapter that was selected when the graphics window was opened (or the backend was last changed).

The list of available modes is updated by `GraphicsWindow::OnBackendChanged`'s call to `VideoBackendBase::PopulateBackendInfoFromUI`, and then `EnhancementsWidget::LoadSettings` updates the UI.  Both of these are connected to the `GraphicsWindow::BackendChanged` signal.

I have a dedicated NVIDIA GeForce GTX 1650 Ti GPU and also an integrated Intel GPU; the NVIDIA one supports up to 8x AA while the Intel one supports 16x (but becomes horrendously slow in that case).  The D3D "Microsoft Basic Render Driver" also claims to support 16x AA (but I don't think it actually does anything there).  If you have an NVIDIA GPU, the easiest way to reproduce the issue is to set the adapter to the NVIDIA GPU and the backend to D3D 11, then change the backend to D3D 12, then look at the list of AA modes (which should show 8x as the max), then change the adapter to the basic render driver, then look at the list of AA modes again (which should still show 8x as the max), and then switch the backend to D3D 11 and then back to D3D 12 and then look at the list of AA modes (which should now show 16x as the max for the basic render driver).