### PR TITLE
Show panic alerts if the CP configuration doesn't match the XF configuration

### DIFF
--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -136,7 +136,7 @@ void DolphinAnalytics::ReportGameStart()
 }
 
 // Keep in sync with enum class GameQuirk definition.
-constexpr std::array<const char*, 24> GAME_QUIRKS_NAMES{
+constexpr std::array<const char*, 27> GAME_QUIRKS_NAMES{
     "icache-matters",
     "directly-reads-wiimote-input",
     "uses-DVDLowStopLaser",
@@ -161,6 +161,9 @@ constexpr std::array<const char*, 24> GAME_QUIRKS_NAMES{
     "sets-xf-clipdisable-bit-0",
     "sets-xf-clipdisable-bit-1",
     "sets-xf-clipdisable-bit-2",
+    "mismatched-gpu-colors-between-cp-and-xf",
+    "mismatched-gpu-normals-between-cp-and-xf",
+    "mismatched-gpu-tex-coords-between-cp-and-xf",
 };
 static_assert(GAME_QUIRKS_NAMES.size() == static_cast<u32>(GameQuirk::COUNT),
               "Game quirks names and enum definition are out of sync.");

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -136,7 +136,7 @@ void DolphinAnalytics::ReportGameStart()
 }
 
 // Keep in sync with enum class GameQuirk definition.
-constexpr std::array<const char*, 27> GAME_QUIRKS_NAMES{
+constexpr std::array<const char*, 28> GAME_QUIRKS_NAMES{
     "icache-matters",
     "directly-reads-wiimote-input",
     "uses-DVDLowStopLaser",
@@ -164,6 +164,7 @@ constexpr std::array<const char*, 27> GAME_QUIRKS_NAMES{
     "mismatched-gpu-colors-between-cp-and-xf",
     "mismatched-gpu-normals-between-cp-and-xf",
     "mismatched-gpu-tex-coords-between-cp-and-xf",
+    "mismatched-gpu-matrix-indices-between-cp-and-xf",
 };
 static_assert(GAME_QUIRKS_NAMES.size() == static_cast<u32>(GameQuirk::COUNT),
               "Game quirks names and enum definition are out of sync.");

--- a/Source/Core/Core/DolphinAnalytics.h
+++ b/Source/Core/Core/DolphinAnalytics.h
@@ -87,6 +87,10 @@ enum class GameQuirk
   MISMATCHED_GPU_COLORS_BETWEEN_CP_AND_XF,
   MISMATCHED_GPU_NORMALS_BETWEEN_CP_AND_XF,
   MISMATCHED_GPU_TEX_COORDS_BETWEEN_CP_AND_XF,
+  // Both CP and XF have normally-identical matrix index information.  We currently always
+  // use the CP one in the hardware renderers and the XF one in the software renderer,
+  // but testing is needed to find out which of these is actually used for what.
+  MISMATCHED_GPU_MATRIX_INDICES_BETWEEN_CP_AND_XF,
 
   COUNT,
 };

--- a/Source/Core/Core/DolphinAnalytics.h
+++ b/Source/Core/Core/DolphinAnalytics.h
@@ -81,6 +81,13 @@ enum class GameQuirk
   SETS_XF_CLIPDISABLE_BIT_1,
   SETS_XF_CLIPDISABLE_BIT_2,
 
+  // Similar to the XF-BP mismatch, CP and XF might be configured with different vertex formats.
+  // Real hardware seems to hang in this case, so games probably don't do this, but it would
+  // be good to know if anything does it.
+  MISMATCHED_GPU_COLORS_BETWEEN_CP_AND_XF,
+  MISMATCHED_GPU_NORMALS_BETWEEN_CP_AND_XF,
+  MISMATCHED_GPU_TEX_COORDS_BETWEEN_CP_AND_XF,
+
   COUNT,
 };
 

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -677,10 +677,9 @@ public:
       }
       process_component(vtx_desc.low.Position, vtx_attr.g0.PosFormat,
                         vtx_attr.g0.PosElements == CoordComponentCount::XY ? 2 : 3);
-      // TODO: Is this calculation correct?
       const u32 normal_component_count =
           vtx_desc.low.Normal == VertexComponentFormat::Direct ? 3 : 1;
-      const u32 normal_elements = vtx_attr.g0.NormalElements == NormalComponentCount::NBT ? 3 : 1;
+      const u32 normal_elements = vtx_attr.g0.NormalElements == NormalComponentCount::NTB ? 3 : 1;
       process_component(vtx_desc.low.Normal, vtx_attr.g0.NormalFormat,
                         normal_component_count * normal_elements,
                         vtx_attr.g0.NormalIndex3 ? normal_elements : 1);

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -106,20 +106,6 @@ void SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_
 
 void SWVertexLoader::SetFormat()
 {
-  // matrix index from xf regs or cp memory?
-  if (xfmem.MatrixIndexA.PosNormalMtxIdx != g_main_cp_state.matrix_index_a.PosNormalMtxIdx ||
-      xfmem.MatrixIndexA.Tex0MtxIdx != g_main_cp_state.matrix_index_a.Tex0MtxIdx ||
-      xfmem.MatrixIndexA.Tex1MtxIdx != g_main_cp_state.matrix_index_a.Tex1MtxIdx ||
-      xfmem.MatrixIndexA.Tex2MtxIdx != g_main_cp_state.matrix_index_a.Tex2MtxIdx ||
-      xfmem.MatrixIndexA.Tex3MtxIdx != g_main_cp_state.matrix_index_a.Tex3MtxIdx ||
-      xfmem.MatrixIndexB.Tex4MtxIdx != g_main_cp_state.matrix_index_b.Tex4MtxIdx ||
-      xfmem.MatrixIndexB.Tex5MtxIdx != g_main_cp_state.matrix_index_b.Tex5MtxIdx ||
-      xfmem.MatrixIndexB.Tex6MtxIdx != g_main_cp_state.matrix_index_b.Tex6MtxIdx ||
-      xfmem.MatrixIndexB.Tex7MtxIdx != g_main_cp_state.matrix_index_b.Tex7MtxIdx)
-  {
-    ERROR_LOG_FMT(VIDEO, "Matrix indices don't match");
-  }
-
   m_vertex.posMtx = xfmem.MatrixIndexA.PosNormalMtxIdx;
   m_vertex.texMtx[0] = xfmem.MatrixIndexA.Tex0MtxIdx;
   m_vertex.texMtx[1] = xfmem.MatrixIndexA.Tex1MtxIdx;

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -162,12 +162,12 @@ struct fmt::formatter<CoordComponentCount> : EnumFormatter<CoordComponentCount::
 enum class NormalComponentCount
 {
   N = 0,
-  NBT = 1,
+  NTB = 1,
 };
 template <>
-struct fmt::formatter<NormalComponentCount> : EnumFormatter<NormalComponentCount::NBT>
+struct fmt::formatter<NormalComponentCount> : EnumFormatter<NormalComponentCount::NTB>
 {
-  constexpr formatter() : EnumFormatter({"1 (n)", "3 (n, b, t)"}) {}
+  constexpr formatter() : EnumFormatter({"1 (normal)", "3 (normal, tangent, binormal)"}) {}
 };
 
 enum class ColorComponentCount
@@ -348,8 +348,9 @@ struct fmt::formatter<UVAT_group0>
   {
     static constexpr std::array<const char*, 2> byte_dequant = {
         "shift does not apply to u8/s8 components", "shift applies to u8/s8 components"};
-    static constexpr std::array<const char*, 2> normalindex3 = {"single index per normal",
-                                                                "triple-index per nine-normal"};
+    static constexpr std::array<const char*, 2> normalindex3 = {
+        "single index shared by normal, tangent, and binormal",
+        "three indices, one each for normal, tangent, and binormal"};
 
     return fmt::format_to(ctx.out(),
                           "Position elements: {}\n"

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -129,7 +129,7 @@ void VertexLoader::CompileVertexTranslator()
     }
     WriteCall(pFunc);
 
-    for (int i = 0; i < (m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT ? 3 : 1); i++)
+    for (int i = 0; i < (m_VtxAttr.g0.NormalElements == NormalComponentCount::NTB ? 3 : 1); i++)
     {
       m_native_vtx_decl.normals[i].components = 3;
       m_native_vtx_decl.normals[i].enable = true;

--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -472,7 +472,7 @@ void VertexLoaderARM64::GenerateVertexLoader()
   {
     static const u8 map[8] = {7, 6, 15, 14};
     const u8 scaling_exponent = map[u32(m_VtxAttr.g0.NormalFormat.Value())];
-    const int limit = m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT ? 3 : 1;
+    const int limit = m_VtxAttr.g0.NormalElements == NormalComponentCount::NTB ? 3 : 1;
 
     s32 offset = -1;
     for (int i = 0; i < limit; i++)

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -152,7 +152,7 @@ u32 VertexLoaderBase::GetVertexComponents(const TVtxDesc& vtx_desc, const VAT& v
   if (vtx_desc.low.Normal != VertexComponentFormat::NotPresent)
   {
     components |= VB_HAS_NORMAL;
-    if (vtx_attr.g0.NormalElements == NormalComponentCount::NBT)
+    if (vtx_attr.g0.NormalElements == NormalComponentCount::NTB)
       components |= VB_HAS_TANGENT | VB_HAS_BINORMAL;
   }
   for (u32 i = 0; i < vtx_desc.low.Color.Size(); i++)

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -321,6 +321,18 @@ static void CheckCPConfiguration(int vtx_attr_group)
     // Don't bail out, though; we can still render something successfully
     // (real hardware seems to hang in this case, though)
   }
+
+  if (g_main_cp_state.matrix_index_a.Hex != xfmem.MatrixIndexA.Hex ||
+      g_main_cp_state.matrix_index_b.Hex != xfmem.MatrixIndexB.Hex)
+  {
+    PanicAlertFmt("Mismatched matrix index configuration between CP and XF stages - "
+                  "index A: {:08x}/{:08x}, index B {:08x}/{:08x}. "
+                  "Please report on the issue tracker.",
+                  g_main_cp_state.matrix_index_a.Hex, xfmem.MatrixIndexA.Hex,
+                  g_main_cp_state.matrix_index_b.Hex, xfmem.MatrixIndexB.Hex);
+    DolphinAnalytics::Instance().ReportGameQuirk(
+        GameQuirk::MISMATCHED_GPU_MATRIX_INDICES_BETWEEN_CP_AND_XF);
+  }
 }
 
 int RunVertices(int vtx_attr_group, OpcodeDecoder::Primitive primitive, int count, DataReader src,

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -16,6 +16,7 @@
 #include "Common/EnumMap.h"
 #include "Common/Logging/Log.h"
 
+#include "Core/DolphinAnalytics.h"
 #include "Core/HW/Memmap.h"
 
 #include "VideoCommon/BPMemory.h"
@@ -28,6 +29,7 @@
 #include "VideoCommon/VertexLoaderBase.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VertexShaderManager.h"
+#include "VideoCommon/XFMemory.h"
 
 namespace VertexLoaderManager
 {
@@ -249,6 +251,78 @@ static VertexLoaderBase* RefreshLoader(int vtx_attr_group, bool preprocess = fal
   return loader;
 }
 
+static void CheckCPConfiguration(int vtx_attr_group)
+{
+  // Validate that the XF input configuration matches the CP configuration
+  u32 num_cp_colors = std::count_if(
+      g_main_cp_state.vtx_desc.low.Color.begin(), g_main_cp_state.vtx_desc.low.Color.end(),
+      [](auto format) { return format != VertexComponentFormat::NotPresent; });
+  u32 num_cp_tex_coords = std::count_if(
+      g_main_cp_state.vtx_desc.high.TexCoord.begin(), g_main_cp_state.vtx_desc.high.TexCoord.end(),
+      [](auto format) { return format != VertexComponentFormat::NotPresent; });
+
+  u32 num_cp_normals;
+  if (g_main_cp_state.vtx_desc.low.Normal == VertexComponentFormat::NotPresent)
+    num_cp_normals = 0;
+  else if (g_main_cp_state.vtx_attr[vtx_attr_group].g0.NormalElements == NormalComponentCount::NTB)
+    num_cp_normals = 3;
+  else
+    num_cp_normals = 1;
+
+  std::optional<u32> num_xf_normals;
+  switch (xfmem.invtxspec.numnormals)
+  {
+  case NormalCount::None:
+    num_xf_normals = 0;
+    break;
+  case NormalCount::Normal:
+    num_xf_normals = 1;
+    break;
+  case NormalCount::NormalTangentBinormal:
+    num_xf_normals = 3;
+    break;
+  default:
+    PanicAlertFmt("xfmem.invtxspec.numnormals is invalid: {}", xfmem.invtxspec.numnormals);
+    break;
+  }
+
+  if (num_cp_colors != xfmem.invtxspec.numcolors || num_cp_normals != num_xf_normals ||
+      num_cp_tex_coords != xfmem.invtxspec.numtextures)
+  {
+    PanicAlertFmt("Mismatched configuration between CP and XF stages - {}/{} colors, {}/{} "
+                  "normals, {}/{} texture coordinates. Please report on the issue tracker.\n\n"
+                  "VCD: {:08x} {:08x}\nVAT {}: {:08x} {:08x} {:08x}\nXF vertex spec: {:08x}",
+                  num_cp_colors, xfmem.invtxspec.numcolors, num_cp_normals,
+                  num_xf_normals.has_value() ? fmt::to_string(num_xf_normals.value()) : "invalid",
+                  num_cp_tex_coords, xfmem.invtxspec.numtextures, g_main_cp_state.vtx_desc.low.Hex,
+                  g_main_cp_state.vtx_desc.high.Hex, vtx_attr_group,
+                  g_main_cp_state.vtx_attr[vtx_attr_group].g0.Hex,
+                  g_main_cp_state.vtx_attr[vtx_attr_group].g1.Hex,
+                  g_main_cp_state.vtx_attr[vtx_attr_group].g2.Hex, xfmem.invtxspec.hex);
+
+    // Analytics reporting so we can discover which games have this problem, that way when we
+    // eventually simulate the behavior we have test cases for it.
+    if (num_cp_colors != xfmem.invtxspec.numcolors)
+    {
+      DolphinAnalytics::Instance().ReportGameQuirk(
+          GameQuirk::MISMATCHED_GPU_COLORS_BETWEEN_CP_AND_XF);
+    }
+    if (num_cp_normals != num_xf_normals)
+    {
+      DolphinAnalytics::Instance().ReportGameQuirk(
+          GameQuirk::MISMATCHED_GPU_NORMALS_BETWEEN_CP_AND_XF);
+    }
+    if (num_cp_tex_coords != xfmem.invtxspec.numtextures)
+    {
+      DolphinAnalytics::Instance().ReportGameQuirk(
+          GameQuirk::MISMATCHED_GPU_TEX_COORDS_BETWEEN_CP_AND_XF);
+    }
+
+    // Don't bail out, though; we can still render something successfully
+    // (real hardware seems to hang in this case, though)
+  }
+}
+
 int RunVertices(int vtx_attr_group, OpcodeDecoder::Primitive primitive, int count, DataReader src,
                 bool is_preprocess)
 {
@@ -264,6 +338,8 @@ int RunVertices(int vtx_attr_group, OpcodeDecoder::Primitive primitive, int coun
 
   if (is_preprocess)
     return size;
+
+  CheckCPConfiguration(vtx_attr_group);
 
   // If the native vertex format changed, force a flush.
   if (loader->m_native_vertex_format != s_current_vtx_fmt ||

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -461,7 +461,7 @@ void VertexLoaderX64::GenerateVertexLoader()
   {
     static const u8 map[8] = {7, 6, 15, 14};
     const u8 scaling_exponent = map[u32(m_VtxAttr.g0.NormalFormat.Value())];
-    const int limit = m_VtxAttr.g0.NormalElements == NormalComponentCount::NBT ? 3 : 1;
+    const int limit = m_VtxAttr.g0.NormalElements == NormalComponentCount::NTB ? 3 : 1;
 
     for (int i = 0; i < limit; i++)
     {

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -123,7 +123,7 @@ struct Set
 
 using Common::EnumMap;
 using Formats = EnumMap<Set, ComponentFormat::Float>;
-using Elements = EnumMap<Formats, NormalComponentCount::NBT>;
+using Elements = EnumMap<Formats, NormalComponentCount::NTB>;
 using Indices = std::array<Elements, 2>;
 using Types = EnumMap<Indices, VertexComponentFormat::Index16>;
 
@@ -140,11 +140,11 @@ constexpr Types InitializeTable()
   table[VCF::Direct][false][NCC::N][FMT::UShort] = Normal_Direct<u16, 1>();
   table[VCF::Direct][false][NCC::N][FMT::Short] = Normal_Direct<s16, 1>();
   table[VCF::Direct][false][NCC::N][FMT::Float] = Normal_Direct<float, 1>();
-  table[VCF::Direct][false][NCC::NBT][FMT::UByte] = Normal_Direct<u8, 3>();
-  table[VCF::Direct][false][NCC::NBT][FMT::Byte] = Normal_Direct<s8, 3>();
-  table[VCF::Direct][false][NCC::NBT][FMT::UShort] = Normal_Direct<u16, 3>();
-  table[VCF::Direct][false][NCC::NBT][FMT::Short] = Normal_Direct<s16, 3>();
-  table[VCF::Direct][false][NCC::NBT][FMT::Float] = Normal_Direct<float, 3>();
+  table[VCF::Direct][false][NCC::NTB][FMT::UByte] = Normal_Direct<u8, 3>();
+  table[VCF::Direct][false][NCC::NTB][FMT::Byte] = Normal_Direct<s8, 3>();
+  table[VCF::Direct][false][NCC::NTB][FMT::UShort] = Normal_Direct<u16, 3>();
+  table[VCF::Direct][false][NCC::NTB][FMT::Short] = Normal_Direct<s16, 3>();
+  table[VCF::Direct][false][NCC::NTB][FMT::Float] = Normal_Direct<float, 3>();
 
   // Same as above, since there are no indices
   table[VCF::Direct][true][NCC::N][FMT::UByte] = Normal_Direct<u8, 1>();
@@ -152,57 +152,57 @@ constexpr Types InitializeTable()
   table[VCF::Direct][true][NCC::N][FMT::UShort] = Normal_Direct<u16, 1>();
   table[VCF::Direct][true][NCC::N][FMT::Short] = Normal_Direct<s16, 1>();
   table[VCF::Direct][true][NCC::N][FMT::Float] = Normal_Direct<float, 1>();
-  table[VCF::Direct][true][NCC::NBT][FMT::UByte] = Normal_Direct<u8, 3>();
-  table[VCF::Direct][true][NCC::NBT][FMT::Byte] = Normal_Direct<s8, 3>();
-  table[VCF::Direct][true][NCC::NBT][FMT::UShort] = Normal_Direct<u16, 3>();
-  table[VCF::Direct][true][NCC::NBT][FMT::Short] = Normal_Direct<s16, 3>();
-  table[VCF::Direct][true][NCC::NBT][FMT::Float] = Normal_Direct<float, 3>();
+  table[VCF::Direct][true][NCC::NTB][FMT::UByte] = Normal_Direct<u8, 3>();
+  table[VCF::Direct][true][NCC::NTB][FMT::Byte] = Normal_Direct<s8, 3>();
+  table[VCF::Direct][true][NCC::NTB][FMT::UShort] = Normal_Direct<u16, 3>();
+  table[VCF::Direct][true][NCC::NTB][FMT::Short] = Normal_Direct<s16, 3>();
+  table[VCF::Direct][true][NCC::NTB][FMT::Float] = Normal_Direct<float, 3>();
 
   table[VCF::Index8][false][NCC::N][FMT::UByte] = Normal_Index<u8, u8, 1>();
   table[VCF::Index8][false][NCC::N][FMT::Byte] = Normal_Index<u8, s8, 1>();
   table[VCF::Index8][false][NCC::N][FMT::UShort] = Normal_Index<u8, u16, 1>();
   table[VCF::Index8][false][NCC::N][FMT::Short] = Normal_Index<u8, s16, 1>();
   table[VCF::Index8][false][NCC::N][FMT::Float] = Normal_Index<u8, float, 1>();
-  table[VCF::Index8][false][NCC::NBT][FMT::UByte] = Normal_Index<u8, u8, 3>();
-  table[VCF::Index8][false][NCC::NBT][FMT::Byte] = Normal_Index<u8, s8, 3>();
-  table[VCF::Index8][false][NCC::NBT][FMT::UShort] = Normal_Index<u8, u16, 3>();
-  table[VCF::Index8][false][NCC::NBT][FMT::Short] = Normal_Index<u8, s16, 3>();
-  table[VCF::Index8][false][NCC::NBT][FMT::Float] = Normal_Index<u8, float, 3>();
+  table[VCF::Index8][false][NCC::NTB][FMT::UByte] = Normal_Index<u8, u8, 3>();
+  table[VCF::Index8][false][NCC::NTB][FMT::Byte] = Normal_Index<u8, s8, 3>();
+  table[VCF::Index8][false][NCC::NTB][FMT::UShort] = Normal_Index<u8, u16, 3>();
+  table[VCF::Index8][false][NCC::NTB][FMT::Short] = Normal_Index<u8, s16, 3>();
+  table[VCF::Index8][false][NCC::NTB][FMT::Float] = Normal_Index<u8, float, 3>();
 
-  // Same for NormalComponentCount::N; differs for NBT
+  // Same for NormalComponentCount::N; differs for NTB
   table[VCF::Index8][true][NCC::N][FMT::UByte] = Normal_Index<u8, u8, 1>();
   table[VCF::Index8][true][NCC::N][FMT::Byte] = Normal_Index<u8, s8, 1>();
   table[VCF::Index8][true][NCC::N][FMT::UShort] = Normal_Index<u8, u16, 1>();
   table[VCF::Index8][true][NCC::N][FMT::Short] = Normal_Index<u8, s16, 1>();
   table[VCF::Index8][true][NCC::N][FMT::Float] = Normal_Index<u8, float, 1>();
-  table[VCF::Index8][true][NCC::NBT][FMT::UByte] = Normal_Index_Indices3<u8, u8>();
-  table[VCF::Index8][true][NCC::NBT][FMT::Byte] = Normal_Index_Indices3<u8, s8>();
-  table[VCF::Index8][true][NCC::NBT][FMT::UShort] = Normal_Index_Indices3<u8, u16>();
-  table[VCF::Index8][true][NCC::NBT][FMT::Short] = Normal_Index_Indices3<u8, s16>();
-  table[VCF::Index8][true][NCC::NBT][FMT::Float] = Normal_Index_Indices3<u8, float>();
+  table[VCF::Index8][true][NCC::NTB][FMT::UByte] = Normal_Index_Indices3<u8, u8>();
+  table[VCF::Index8][true][NCC::NTB][FMT::Byte] = Normal_Index_Indices3<u8, s8>();
+  table[VCF::Index8][true][NCC::NTB][FMT::UShort] = Normal_Index_Indices3<u8, u16>();
+  table[VCF::Index8][true][NCC::NTB][FMT::Short] = Normal_Index_Indices3<u8, s16>();
+  table[VCF::Index8][true][NCC::NTB][FMT::Float] = Normal_Index_Indices3<u8, float>();
 
   table[VCF::Index16][false][NCC::N][FMT::UByte] = Normal_Index<u16, u8, 1>();
   table[VCF::Index16][false][NCC::N][FMT::Byte] = Normal_Index<u16, s8, 1>();
   table[VCF::Index16][false][NCC::N][FMT::UShort] = Normal_Index<u16, u16, 1>();
   table[VCF::Index16][false][NCC::N][FMT::Short] = Normal_Index<u16, s16, 1>();
   table[VCF::Index16][false][NCC::N][FMT::Float] = Normal_Index<u16, float, 1>();
-  table[VCF::Index16][false][NCC::NBT][FMT::UByte] = Normal_Index<u16, u8, 3>();
-  table[VCF::Index16][false][NCC::NBT][FMT::Byte] = Normal_Index<u16, s8, 3>();
-  table[VCF::Index16][false][NCC::NBT][FMT::UShort] = Normal_Index<u16, u16, 3>();
-  table[VCF::Index16][false][NCC::NBT][FMT::Short] = Normal_Index<u16, s16, 3>();
-  table[VCF::Index16][false][NCC::NBT][FMT::Float] = Normal_Index<u16, float, 3>();
+  table[VCF::Index16][false][NCC::NTB][FMT::UByte] = Normal_Index<u16, u8, 3>();
+  table[VCF::Index16][false][NCC::NTB][FMT::Byte] = Normal_Index<u16, s8, 3>();
+  table[VCF::Index16][false][NCC::NTB][FMT::UShort] = Normal_Index<u16, u16, 3>();
+  table[VCF::Index16][false][NCC::NTB][FMT::Short] = Normal_Index<u16, s16, 3>();
+  table[VCF::Index16][false][NCC::NTB][FMT::Float] = Normal_Index<u16, float, 3>();
 
-  // Same for NormalComponentCount::N; differs for NBT
+  // Same for NormalComponentCount::N; differs for NTB
   table[VCF::Index16][true][NCC::N][FMT::UByte] = Normal_Index<u16, u8, 1>();
   table[VCF::Index16][true][NCC::N][FMT::Byte] = Normal_Index<u16, s8, 1>();
   table[VCF::Index16][true][NCC::N][FMT::UShort] = Normal_Index<u16, u16, 1>();
   table[VCF::Index16][true][NCC::N][FMT::Short] = Normal_Index<u16, s16, 1>();
   table[VCF::Index16][true][NCC::N][FMT::Float] = Normal_Index<u16, float, 1>();
-  table[VCF::Index16][true][NCC::NBT][FMT::UByte] = Normal_Index_Indices3<u16, u8>();
-  table[VCF::Index16][true][NCC::NBT][FMT::Byte] = Normal_Index_Indices3<u16, s8>();
-  table[VCF::Index16][true][NCC::NBT][FMT::UShort] = Normal_Index_Indices3<u16, u16>();
-  table[VCF::Index16][true][NCC::NBT][FMT::Short] = Normal_Index_Indices3<u16, s16>();
-  table[VCF::Index16][true][NCC::NBT][FMT::Float] = Normal_Index_Indices3<u16, float>();
+  table[VCF::Index16][true][NCC::NTB][FMT::UByte] = Normal_Index_Indices3<u16, u8>();
+  table[VCF::Index16][true][NCC::NTB][FMT::Byte] = Normal_Index_Indices3<u16, s8>();
+  table[VCF::Index16][true][NCC::NTB][FMT::UShort] = Normal_Index_Indices3<u16, u16>();
+  table[VCF::Index16][true][NCC::NTB][FMT::Short] = Normal_Index_Indices3<u16, s16>();
+  table[VCF::Index16][true][NCC::NTB][FMT::Float] = Normal_Index_Indices3<u16, float>();
 
   return table;
 }

--- a/Source/Core/VideoCommon/XFMemory.h
+++ b/Source/Core/VideoCommon/XFMemory.h
@@ -416,23 +416,23 @@ struct Projection
 
 struct XFMemory
 {
-  float posMatrices[256];    // 0x0000 - 0x00ff
-  u32 unk0[768];             // 0x0100 - 0x03ff
-  float normalMatrices[96];  // 0x0400 - 0x045f
-  u32 unk1[160];             // 0x0460 - 0x04ff
-  float postMatrices[256];   // 0x0500 - 0x05ff
-  Light lights[8];           // 0x0600 - 0x067f
-  u32 unk2[2432];            // 0x0680 - 0x0fff
-  u32 error;                 // 0x1000
-  u32 diag;                  // 0x1001
-  u32 state0;                // 0x1002
-  u32 state1;                // 0x1003
-  u32 xfClock;               // 0x1004
-  ClipDisable clipDisable;   // 0x1005
-  u32 perf0;                 // 0x1006
-  u32 perf1;                 // 0x1007
-  INVTXSPEC hostinfo;        // 0x1008 number of textures,colors,normals from vertex input
-  NumColorChannel numChan;   // 0x1009
+  float posMatrices[256];                   // 0x0000 - 0x00ff
+  u32 unk0[768];                            // 0x0100 - 0x03ff
+  float normalMatrices[96];                 // 0x0400 - 0x045f
+  u32 unk1[160];                            // 0x0460 - 0x04ff
+  float postMatrices[256];                  // 0x0500 - 0x05ff
+  Light lights[8];                          // 0x0600 - 0x067f
+  u32 unk2[2432];                           // 0x0680 - 0x0fff
+  u32 error;                                // 0x1000
+  u32 diag;                                 // 0x1001
+  u32 state0;                               // 0x1002
+  u32 state1;                               // 0x1003
+  u32 xfClock;                              // 0x1004
+  ClipDisable clipDisable;                  // 0x1005
+  u32 perf0;                                // 0x1006
+  u32 perf1;                                // 0x1007
+  INVTXSPEC invtxspec;                      // 0x1008
+  NumColorChannel numChan;                  // 0x1009
   u32 ambColor[NUM_XF_COLOR_CHANNELS];      // 0x100a, 0x100b
   u32 matColor[NUM_XF_COLOR_CHANNELS];      // 0x100c, 0x100d
   LitChannel color[NUM_XF_COLOR_CHANNELS];  // 0x100e, 0x100f

--- a/Source/Core/VideoCommon/XFMemory.h
+++ b/Source/Core/VideoCommon/XFMemory.h
@@ -44,13 +44,13 @@ struct fmt::formatter<TexInputForm> : EnumFormatter<TexInputForm::ABC1>
 enum class NormalCount : u32
 {
   None = 0,
-  Normals = 1,
-  NormalsBinormals = 2
+  Normal = 1,
+  NormalTangentBinormal = 2
 };
 template <>
-struct fmt::formatter<NormalCount> : EnumFormatter<NormalCount::NormalsBinormals>
+struct fmt::formatter<NormalCount> : EnumFormatter<NormalCount::NormalTangentBinormal>
 {
-  constexpr formatter() : EnumFormatter({"None", "Normals only", "Normals and binormals"}) {}
+  constexpr formatter() : EnumFormatter({"None", "Normal only", "Normal, tangent, and binormal"}) {}
 };
 
 // Texture generation type

--- a/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
+++ b/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
@@ -330,7 +330,7 @@ TEST_F(VertexLoaderTest, LargeFloatVertexSpeed)
 
   m_vtx_attr.g0.PosElements = CoordComponentCount::XYZ;
   m_vtx_attr.g0.PosFormat = ComponentFormat::Float;
-  m_vtx_attr.g0.NormalElements = NormalComponentCount::NBT;
+  m_vtx_attr.g0.NormalElements = NormalComponentCount::NTB;
   m_vtx_attr.g0.NormalFormat = ComponentFormat::Float;
   m_vtx_attr.g0.Color0Elements = ColorComponentCount::RGBA;
   m_vtx_attr.g0.Color0Comp = ColorFormat::RGBA8888;


### PR DESCRIPTION
This is somewhat similar to #8717.  At least in some cases, on real hardware this mismatched configuration can result in a hang, but Dolphin was previously allowing it without any warnings (I ran into this [when experimenting with embossing](https://gist.github.com/Pokechu22/0589a46b2dea081e24470b3275766cc0)).

I've also added a check that the CP and XF matrix index registers match, since it's weird that they are duplicated (we currently always use the CP one with the hardware backends, and the XF one for the software renderer), and the XF input vertex spec register doesn't include a count for matrix indices (so if per-vertex matrix indices are enabled, it's not clear how XF knows which ones are in use).

<details><summary>Ways this could be triggered</summary>

As far as I can tell, this kind of bug can only easily be caused with normals, since the normal count is based on both the vertex descriptor and the vertex attribute table while colors and texture coordinates are based on the vertex descriptor only.  I ran into this by using `GX_SetVtxAttrFmt(GX_VTXFMT0, GX_VA_NBT, ...)` but also `GX_SetVtxDesc(GX_VA_NRM, ...)`; you need to use either `GX_VA_NBT` or `GX_VA_NRM` in both places.  As far as I can tell, that applies to both libogc and the official SDK.

Libogc also seems to have a bug where using `GX_SetVtxDesc(GX_VA_NRM, GX_NONE)` will result in 1 normal being used for the XF configuration, and `GX_SetVtxDesc(GX_VA_NBT, GX_NONE)` will result in 3 normals being used (the only way to set it to 0 is to use `GX_ClearVtxDesc()`).  The official SDK does not have this issue.

-----

Libogc [`GX_SetVtxAttrFmt`](https://github.com/devkitPro/libogc/blob/6c104219be4f3741c59446948052311a405de7cf/libogc/gx.c#L2540-L2550)
```C++
if (vtxattr==GX_VA_NRM && comptype==GX_NRM_XYZ
	&& (compsize==GX_S8 || compsize==GX_S16 || compsize==GX_F32))
{
	__gx->VAT0reg[vat].NormalElements = NormalComponentCount::N;
	__gx->VAT0reg[vat].NormalFormat = compsize;
	__gx->VAT0reg[vat].NormalIndex3 = false;
}
else if (vtxattr==GX_VA_NBT && (comptype==GX_NRM_NBT || comptype==GX_NRM_NBT3)
	&& (compsize==GX_S8 || compsize==GX_S16 || compsize==GX_F32))
{
	__gx->VAT0reg[vat].NormalElements = NormalComponentCount::NTB;
	__gx->VAT0reg[vat].NormalFormat = compsize;
	if (comptype==GX_NRM_NBT3)
		__gx->VAT0reg[vat].NormalIndex3 = true;
}
```

SDK (from Super Mario Sunshine) `GXSetVtxAttrFmt`
```C++
if (vtxattr==GX_VA_NRM || vtxattr == GX_VA_NBT)
{
	__gx->VAT0reg[vat].NormalFormat = compsize;
	if (comptype == GX_NRM_NBT3)
	{
		__gx->VAT0reg[vat].NormalElements = NormalComponentCount::NTB;
		__gx->VAT0reg[vat].NormalIndex3 = true;
	}
	else
	{
		if (comptype == GX_NRM_NBT)
			__gx->VAT0reg[vat].NormalElements = NormalComponentCount::NTB;
		else
			__gx->VAT0reg[vat].NormalElements = NormalComponentCount::N;
		__gx->VAT0reg[vat].NormalIndex3 = false;
	}
	break;
}
```

Libogc [`GX_SetVtxDesc`](https://github.com/devkitPro/libogc/blob/6c104219be4f3741c59446948052311a405de7cf/libogc/gx.c#L2324-L2331)
```C++
// vcdNrms is only set to 0 by GX_ClearVtxDesc; it's not set if type is GX_NONE
if (vtxattr==GX_VA_NRM)
{
	__gx->vcdLo.Normal = type;
	__gx->vcdNrms = 1;
}
else if (vtxattr==GX_VA_NBT)
{
	__gx->vcdLo.Normal = type;
	__gx->vcdNrms = 2;
}
```

SDK (from Super Mario Sunshine) `GXSetVtxDesc`
```C++
if (vtxattr==GX_VA_NRM)
{
	if (type == GX_NONE)
	{
		__gx->HasNormal = false;  // gx + 0x41c
	}
	else
	{
		__gx->HasNormal = true;  // gx + 0x41c
		__gx->HasNTB = false;  // gx + 0x41d
		__gx->NormalFmt = type;  // gx + 0x418
	}
}
else if (vtxattr==GX_VA_NBT)
{
	if (type == GX_NONE)
	{
		__gx->HasNTB = false;  // gx + 0x41c
	}
	else
	{
		__gx->HasNTB = true;  // gx + 0x41c
		__gx->HasNormal = false;  // gx + 0x41d
		__gx->NormalFmt = type;  // gx + 0x418
	}
}
if ((gx->HasNormal == false) && (gx->HasNTB == false))
	__gx->vcdLo.Normal = GX_NONE;
else
	__gx->vcdLo.Normal = gx->NormalFmt;
```

Libogc [`__GX_XfVtxSpecs`](https://github.com/devkitPro/libogc/blob/6c104219be4f3741c59446948052311a405de7cf/libogc/gx.c#L756-L758)
```C++
u32 nrms = 0;
if (__gx->vcdNrms==1) nrms = 1;
else if (__gx->vcdNrms==2) nrms = 2;
```

SDK (from Super Mario Sunshine) `__GXXfVtxSpecs`
```C++
u32 nrms;
if (gx->HasNTB == false)
{
	if (gx->HasNormal == false)
	{
		nrms = 0;
	}
	else
	{
		nrms = 1;
	}
}
else
{
	nrms = 2;
}
```

[`__GX_SetMatrixIndex`](https://github.com/devkitPro/libogc/blob/6c104219be4f3741c59446948052311a405de7cf/libogc/gx.c#L774-L783) and its SDK version always set both the CP and XF version to the same values, so that shouldn't have any issues.

-----

</details>

I currently do this check in `VertexLoaderManager::RunVertices`, which is called for _every_ primitive command.  This might be more frequent than it should be, but I can't put it in `VertexManagerBase::Flush` as we need to know the `vtx_attr_group` (and `Flush` might be called after multiple different `vtx_attr_group` values have been used).