### PR TITLE
DolphinQt: Add com.apple.security.cs.allow-dyld-environment-variables to entitlements

### DIFF
--- a/Source/Core/DolphinQt/DolphinEmu.entitlements
+++ b/Source/Core/DolphinQt/DolphinEmu.entitlements
@@ -13,5 +13,8 @@
 	<!-- This is needed to use adhoc signed linked libraries -->
  	<key>com.apple.security.cs.disable-library-validation</key> 
   	<true/>
+	<!-- Allows the Steam overlay library to be injected into our process -->
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
 </dict>
 </plist>

--- a/Source/Core/DolphinQt/DolphinEmuDebug.entitlements
+++ b/Source/Core/DolphinQt/DolphinEmuDebug.entitlements
@@ -13,6 +13,9 @@
 	<!-- This is needed to use adhoc signed linked libraries -->
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<!-- Allows the Steam overlay library to be injected into our process -->
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
 	<!-- This is needed to attach a debugger to the process -->
 	<key>com.apple.security.get-task-allow</key>
 	<true/>


### PR DESCRIPTION
This allows the Steam overlay library to be injected into our process on macOS.