### PR TITLE
GameDB: Adjusted graphic settings for PSO EP1&2 and PSO EP3

### DIFF
--- a/Data/Sys/GameSettings/GPO.ini
+++ b/Data/Sys/GameSettings/GPO.ini
@@ -13,5 +13,5 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+SafeTextureCacheColorSamples = 2048
 

--- a/Data/Sys/GameSettings/GPS.ini
+++ b/Data/Sys/GameSettings/GPS.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+SafeTextureCacheColorSamples = 2048
 
 [Video_Hacks]
 ImmediateXFBEnable = False


### PR DESCRIPTION
Adjusted the texture accuracy setting to the safest value for both PSO Episode 1 & 2 and Episode 3, this fixes the issue displaying texts within the game where letters and numbers are randomly missing. 