### PR TITLE
Fifo recorder: Fix various indexed vertex component bugs

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -98,7 +98,7 @@ void FifoRecorder::FifoRecordAnalyzer::OnPrimitiveCommand(OpcodeDecoder::Primiti
   const u32 norm_size =
       VertexLoader_Normal::GetSize(vtx_desc.low.Normal, vtx_attr.g0.NormalFormat,
                                    vtx_attr.g0.NormalElements, vtx_attr.g0.NormalIndex3);
-  ProcessVertexComponent(CPArray::Normal, vtx_desc.low.Position, offset, vertex_size, num_vertices,
+  ProcessVertexComponent(CPArray::Normal, vtx_desc.low.Normal, offset, vertex_size, num_vertices,
                          vertex_data);
   offset += norm_size;
 
@@ -106,7 +106,7 @@ void FifoRecorder::FifoRecordAnalyzer::OnPrimitiveCommand(OpcodeDecoder::Primiti
   {
     const u32 color_size =
         VertexLoader_Color::GetSize(vtx_desc.low.Color[i], vtx_attr.GetColorFormat(i));
-    ProcessVertexComponent(CPArray::Color0 + i, vtx_desc.low.Position, offset, vertex_size,
+    ProcessVertexComponent(CPArray::Color0 + i, vtx_desc.low.Color[i], offset, vertex_size,
                            num_vertices, vertex_data);
     offset += color_size;
   }
@@ -114,7 +114,7 @@ void FifoRecorder::FifoRecordAnalyzer::OnPrimitiveCommand(OpcodeDecoder::Primiti
   {
     const u32 tc_size = VertexLoader_TextCoord::GetSize(
         vtx_desc.high.TexCoord[i], vtx_attr.GetTexFormat(i), vtx_attr.GetTexElements(i));
-    ProcessVertexComponent(CPArray::TexCoord0 + i, vtx_desc.low.Position, offset, vertex_size,
+    ProcessVertexComponent(CPArray::TexCoord0 + i, vtx_desc.high.TexCoord[i], offset, vertex_size,
                            num_vertices, vertex_data);
     offset += tc_size;
   }


### PR DESCRIPTION
See the individual commit messages for details.  

[These fifologs](https://github.com/dolphin-emu/dolphin/files/8723364/RS2Gameplay.7z.zip) are for the first commit (a regression from #9718) (images: [broken](https://user-images.githubusercontent.com/8334194/169202911-2f4a5b6c-c243-4c2e-9c13-5b34fd91f2b4.png), [fixed](https://user-images.githubusercontent.com/8334194/169202915-189e3f32-327f-4db6-b951-f7ac0f2968f4.png)).  JMC provided some luigi's mansion fifologs; here's images: [broken](https://user-images.githubusercontent.com/8334194/169219922-6b03eb9a-1595-4a2b-97ca-baf108f357b7.png), [fixed](https://user-images.githubusercontent.com/8334194/169219915-3faf1d6b-67a6-411f-9b09-26034856b44e.png).

