### PR TITLE
Remove printf-style logging

### DIFF
--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -96,57 +96,7 @@ void GenericLogFmt(LogLevel level, LogType type, const char* file, int line, con
                 "too many arguments?");
   GenericLogFmtImpl(level, type, file, line, format, fmt::make_format_args(args...));
 }
-
-void GenericLog(LogLevel level, LogType type, const char* file, int line, const char* fmt, ...)
-#ifdef __GNUC__
-    __attribute__((format(printf, 5, 6)))
-#endif
-    ;
-
-void GenericLogV(LogLevel level, LogType type, const char* file, int line, const char* fmt,
-                 va_list args);
 }  // namespace Common::Log
-
-// Let the compiler optimize this out
-#define GENERIC_LOG(t, v, ...)                                                                     \
-  do                                                                                               \
-  {                                                                                                \
-    if (v <= Common::Log::MAX_LOGLEVEL)                                                            \
-      Common::Log::GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__);                              \
-  } while (0)
-
-#define ERROR_LOG(t, ...)                                                                          \
-  do                                                                                               \
-  {                                                                                                \
-    GENERIC_LOG(Common::Log::LogType::t, Common::Log::LogLevel::LERROR, __VA_ARGS__);              \
-  } while (0)
-#define WARN_LOG(t, ...)                                                                           \
-  do                                                                                               \
-  {                                                                                                \
-    GENERIC_LOG(Common::Log::LogType::t, Common::Log::LogLevel::LWARNING, __VA_ARGS__);            \
-  } while (0)
-#define NOTICE_LOG(t, ...)                                                                         \
-  do                                                                                               \
-  {                                                                                                \
-    GENERIC_LOG(Common::Log::LogType::t, Common::Log::LogLevel::LNOTICE, __VA_ARGS__);             \
-  } while (0)
-#define INFO_LOG(t, ...)                                                                           \
-  do                                                                                               \
-  {                                                                                                \
-    GENERIC_LOG(Common::Log::LogType::t, Common::Log::LogLevel::LINFO, __VA_ARGS__);               \
-  } while (0)
-#define DEBUG_LOG(t, ...)                                                                          \
-  do                                                                                               \
-  {                                                                                                \
-    GENERIC_LOG(Common::Log::LogType::t, Common::Log::LogLevel::LDEBUG, __VA_ARGS__);              \
-  } while (0)
-
-#define GENERIC_LOG_V(t, v, fmt, args)                                                             \
-  do                                                                                               \
-  {                                                                                                \
-    if (v <= Common::Log::MAX_LOGLEVEL)                                                            \
-      Common::Log::GenericLogV(v, t, __FILE__, __LINE__, fmt, args);                               \
-  } while (0)
 
 // fmtlib capable API
 

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -62,40 +62,6 @@ private:
   bool m_enable;
 };
 
-void GenericLog(LogLevel level, LogType type, const char* file, int line, const char* fmt, ...)
-{
-  auto* instance = LogManager::GetInstance();
-  if (instance == nullptr)
-    return;
-
-  if (!instance->IsEnabled(type, level))
-    return;
-
-  va_list args;
-  va_start(args, fmt);
-  char message[MAX_MSGLEN];
-  CharArrayFromFormatV(message, MAX_MSGLEN, fmt, args);
-  va_end(args);
-
-  instance->Log(level, type, file, line, message);
-}
-
-void GenericLogV(LogLevel level, LogType type, const char* file, int line, const char* fmt,
-                 va_list args)
-{
-  auto* instance = LogManager::GetInstance();
-  if (instance == nullptr)
-    return;
-
-  if (!instance->IsEnabled(type, level))
-    return;
-
-  char message[MAX_MSGLEN];
-  CharArrayFromFormatV(message, MAX_MSGLEN, fmt, args);
-
-  instance->Log(level, type, file, line, message);
-}
-
 void GenericLogFmtImpl(LogLevel level, LogType type, const char* file, int line,
                        fmt::string_view format, const fmt::format_args& args)
 {

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -50,7 +50,7 @@ CEXIETHERNET::CEXIETHERNET(BBADeviceType type)
 #if defined(__APPLE__)
   case BBADeviceType::TAPSERVER:
     m_network_interface = std::make_unique<TAPServerNetworkInterface>(this);
-    INFO_LOG(SP1, "Created tapserver physical network interface.");
+    INFO_LOG_FMT(SP1, "Created tapserver physical network interface.");
     break;
 #endif
   case BBADeviceType::XLINK:

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -709,7 +709,7 @@ void JitArm64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
   {
     // Code generation failed due to not enough free space in either the near or far code regions.
     // Clear the entire JIT cache and retry.
-    WARN_LOG(POWERPC, "flushing code caches, please report if this happens a lot");
+    WARN_LOG_FMT(POWERPC, "flushing code caches, please report if this happens a lot");
     ClearCache();
     Jit(em_address, false);
     return;
@@ -728,7 +728,7 @@ bool JitArm64::SetEmitterStateToFreeCodeRegion()
   auto free_near = m_free_ranges_near.by_size_begin();
   if (free_near == m_free_ranges_near.by_size_end())
   {
-    WARN_LOG(POWERPC, "Failed to find free memory region in near code region.");
+    WARN_LOG_FMT(POWERPC, "Failed to find free memory region in near code region.");
     return false;
   }
   SetCodePtr(free_near.from(), free_near.to());
@@ -736,7 +736,7 @@ bool JitArm64::SetEmitterStateToFreeCodeRegion()
   auto free_far = m_free_ranges_far.by_size_begin();
   if (free_far == m_free_ranges_far.by_size_end())
   {
-    WARN_LOG(POWERPC, "Failed to find free memory region in far code region.");
+    WARN_LOG_FMT(POWERPC, "Failed to find free memory region in far code region.");
     return false;
   }
   m_far_code.SetCodePtr(free_far.from(), free_far.to());
@@ -995,9 +995,9 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   if (HasWriteFailed() || m_far_code.HasWriteFailed())
   {
     if (HasWriteFailed())
-      WARN_LOG(POWERPC, "JIT ran out of space in near code region during code generation.");
+      WARN_LOG_FMT(POWERPC, "JIT ran out of space in near code region during code generation.");
     if (m_far_code.HasWriteFailed())
-      WARN_LOG(POWERPC, "JIT ran out of space in far code region during code generation.");
+      WARN_LOG_FMT(POWERPC, "JIT ran out of space in far code region during code generation.");
 
     return false;
   }

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -325,9 +325,9 @@ void MainWindow::InitControllers()
   if (!g_controller_interface.HasDefaultDevice())
   {
     // Note that the CI default device could be still temporarily removed at any time
-    WARN_LOG(CONTROLLERINTERFACE,
-             "No default device has been added in time. EmulatedController(s) defaulting adds"
-             " input mappings made for a specific default device depending on the platform");
+    WARN_LOG_FMT(CONTROLLERINTERFACE,
+                 "No default device has been added in time. EmulatedController(s) defaulting adds"
+                 " input mappings made for a specific default device depending on the platform");
   }
   GCAdapter::Init();
   Pad::Initialize();

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -28,7 +28,9 @@ extern "C" {
 #include "Common/ChunkFile.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
+#include "Common/Logging/LogManager.h"
 #include "Common/MsgHandler.h"
+#include "Common/StringUtil.h"
 
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
@@ -95,7 +97,17 @@ void InitAVCodec()
         // keep libav debug messages visible in release build of dolphin
         log_level = Common::Log::LogLevel::LINFO;
 
-      GENERIC_LOG_V(Common::Log::LogType::FRAMEDUMP, log_level, fmt, vl);
+      // Don't perform this formatting if the log level is disabled
+      auto* log_manager = Common::Log::LogManager::GetInstance();
+      if (log_manager != nullptr &&
+          log_manager->IsEnabled(Common::Log::LogType::FRAMEDUMP, log_level))
+      {
+        constexpr size_t MAX_MSGLEN = 1024;
+        char message[MAX_MSGLEN];
+        CharArrayFromFormatV(message, MAX_MSGLEN, fmt, vl);
+
+        GENERIC_LOG_FMT(Common::Log::LogType::FRAMEDUMP, log_level, "{}", message);
+      }
     });
 
     // TODO: We never call avformat_network_deinit.


### PR DESCRIPTION
I've gotten annoyed by accidentally trying to use fmt strings with `INFO_LOG`, so I've removed the printf-based logs (now only the `_FMT` variants remain).  This was originally planned in #9286 for after assertions were changed to fmt, which I did in #10209.  Renaming the `_FMT` variants to the original names could be done later on.

Note that the logging in FrameDump is receiving printf format strings and args from libav, so that still needs to handle printf strings.  #10572 added a separate logging method to handle this, but I've moved the formatting to within the libav log callback.  An alternative would be to keep `GENERIC_LOG_V` (possibly renaming it to `GENERIC_LOG_VPRINTF`), but it's only used here so I don't know how necessary that is.