### PR TITLE
UnitTests: Skip PageFaultTest if exception handlers aren't supported

### DIFF
--- a/Source/Core/Core/MemTools.cpp
+++ b/Source/Core/Core/MemTools.cpp
@@ -113,6 +113,11 @@ void UninstallExceptionHandler()
     s_veh_handle = nullptr;
 }
 
+bool IsExceptionHandlerSupported()
+{
+  return true;
+}
+
 #elif defined(__APPLE__) && !defined(USE_SIGACTION_ON_APPLE)
 
 static void CheckKR(const char* name, kern_return_t kr)
@@ -245,6 +250,11 @@ void UninstallExceptionHandler()
 {
 }
 
+bool IsExceptionHandlerSupported()
+{
+  return true;
+}
+
 #elif defined(_POSIX_VERSION) && !defined(_M_GENERIC)
 
 static struct sigaction old_sa_segv;
@@ -353,13 +363,25 @@ void UninstallExceptionHandler()
   sigaction(SIGBUS, &old_sa_bus, nullptr);
 #endif
 }
+
+bool IsExceptionHandlerSupported()
+{
+  return true;
+}
+
 #else  // _M_GENERIC or unsupported platform
 
 void InstallExceptionHandler()
 {
 }
+
 void UninstallExceptionHandler()
 {
+}
+
+bool IsExceptionHandlerSupported()
+{
+  return false;
 }
 
 #endif

--- a/Source/Core/Core/MemTools.h
+++ b/Source/Core/Core/MemTools.h
@@ -7,4 +7,5 @@ namespace EMM
 {
 void InstallExceptionHandler();
 void UninstallExceptionHandler();
+bool IsExceptionHandlerSupported();
 }  // namespace EMM

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -61,6 +61,11 @@ static void ASAN_DISABLE perform_invalid_access(void* data)
 
 TEST(PageFault, PageFault)
 {
+  if (!EMM::IsExceptionHandlerSupported())
+  {
+    // TODO: Use GTEST_SKIP() instead when GTest is updated to 1.10+
+    return;
+  }
   EMM::InstallExceptionHandler();
   void* data = Common::AllocateMemoryPages(PAGE_GRAN);
   EXPECT_NE(data, nullptr);


### PR DESCRIPTION
The nightly generic builder has been failing on the PageFaultTest because the generic build doesn't install an exception handler. This PR adds a function to see if the build supports exception handlers and skips the test if it doesn't.

Questions/Comments:
- Are there any situations where not installing an exception handler would be a problem for the generic build, and thus having this test fail is necessary?
- Skipping the test this way shows that the test passed; it would be better to use GTEST_SKIP() but that requires bumping to GTest 1.10 which would be a separate PR.