### PR TITLE
DSPInterpreter: Fix typo in isOverflow comment

### DIFF
--- a/Source/Core/Core/DSP/Interpreter/DSPIntCCUtil.h
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntCCUtil.h
@@ -23,7 +23,7 @@ constexpr bool isCarrySubtract(u64 val, u64 result)
 
 constexpr bool isOverflow(s64 val1, s64 val2, s64 res)
 {
-  // val1 > 0 and val1 > 0 yet res < 0, or val1 < 0 and val2 < 0 yet res > 0.
+  // val1 > 0 and val2 > 0 yet res < 0, or val1 < 0 and val2 < 0 yet res > 0.
   return ((val1 ^ res) & (val2 ^ res)) < 0;
 }
 


### PR DESCRIPTION
I added this comment in #10045, but I specified "val1" twice by accident.