### PR TITLE
INI: add RealWiiRemoteRepeatReports False to Order Up!

### DIFF
--- a/Data/Sys/GameSettings/ROX.ini
+++ b/Data/Sys/GameSettings/ROX.ini
@@ -1,0 +1,14 @@
+# ROXP7J, ROXX7J, ROXE20 - Order Up!
+
+[Core]
+# Values set here will override the main Dolphin settings.
+RealWiiRemoteRepeatReports = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.


### PR DESCRIPTION
This game has a chopping minigame that doesn't work without this setting.  There's a video and everything on our Wiki: https://wiki.dolphin-emu.org/index.php?title=Order_Up!

User on discord helped verify that this setting fixes it.  It still seems to struggle with very fast swings but I was unable to test it myself on Wii/Bluetooth Passthrough, so I don't know if that's just how the game is or if it's still a tad touchy.  Still, this makes it actually playable, to the point where the user could still get a "perfect" on the task.