### PR TITLE
docs/DSP: Fix "ILLR" typo in Instruction Memory section

### DIFF
--- a/docs/DSP/GameCube_DSP_Users_Manual/GameCube_DSP_Users_Manual.tex
+++ b/docs/DSP/GameCube_DSP_Users_Manual/GameCube_DSP_Users_Manual.tex
@@ -46,7 +46,7 @@
 % Document front page material
 \title{\textbf{\Huge GameCube DSP User's Manual}}
 \author{Reverse-engineered and documented by Duddie \\ \href{mailto:duddie@walla.com}{duddie@walla.com}}
-\date{\today\\v0.1.0}
+\date{\today\\v0.1.2}
 
 % Title formatting commands
 \newcommand{\OpcodeTitle}[1]{\subsection{#1}\label{instruction:#1}}
@@ -258,6 +258,8 @@ The purpose of this documentation is purely academic and it aims at understandin
 0.0.6            & 2018.04.13    & BhaaL           & Updated register tables, fixed opcode operations                                         \\ \hline
 0.0.7            & Mid 2020      & Tilka           & Fixed typos and register names, and improved readability.                                \\ \hline
 0.1.0            & 2021.08.21    & Pokechu22       & Added missing instructions, improved documentation of hardware registers, documented additional behaviors, and improved formatting. \\ \hline
+0.1.1            & 2022.05.14    & xperia64        & Added tested DSP bootloading transfer size                                               \\ \hline
+0.1.2            & 2022.05.21    & Pokechu22       & Fixed ``ILLR'' typo in Instruction Memory section                                        \\ \hline
 \end{tabular}
 \end{table}
 
@@ -397,7 +399,7 @@ Instruction Memory (IMEM) is divided into instruction RAM (IRAM) and instruction
 
 Exception vectors are located at the top of the RAM and occupy the first 16 words, with 2 words available for each exception (enough for a \Opcode{JMP} instruction for each exception).
 
-There are no DSP instructions that write to IMEM; however, the \texttt{ILLR} family of instructions can read from it.  This is sometimes used for jump tables or indexing into a list of pointers (which may point into either IMEM or DMEM).
+There are no DSP instructions that write to IMEM; however, the \Opcode{ILRR} family of instructions can read from it.  This is sometimes used for jump tables or indexing into a list of pointers (which may point into either IMEM or DMEM).
 
 \begin{table}[htb]
 \centering


### PR DESCRIPTION
A typo I noticed.  I also changed it to a link to the ILRR instruction.

This also updates the history section for both this PR and #10662 - this is something the GFDL requires (and I'm not 100% sure that this is enough either).  Maybe git history is sufficient for this purpose (MediaWiki revision history is, to my understanding), but it's also useful to have a specific revision that can be pointed back to.  (It might be worth contacting Duddie if anyone knows how to to see about relicensing to CC-BY-SA or similar.)