### PR TITLE
Common/Network: Use std::array in IPv4Header.

### DIFF
--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -102,8 +102,8 @@ IPv4Header::IPv4Header(u16 data_size, u8 ip_proto, const sockaddr_in& from, cons
   flags_fragment_offset = htons(0x4000);
   ttl = 0x40;
   protocol = ip_proto;
-  std::memcpy(&source_addr, &from.sin_addr, IPV4_ADDR_LEN);
-  std::memcpy(&destination_addr, &to.sin_addr, IPV4_ADDR_LEN);
+  std::memcpy(source_addr.data(), &from.sin_addr, IPV4_ADDR_LEN);
+  std::memcpy(destination_addr.data(), &to.sin_addr, IPV4_ADDR_LEN);
 
   header_checksum = htons(ComputeNetworkChecksum(this, Size()));
 }

--- a/Source/Core/Common/Network.h
+++ b/Source/Core/Common/Network.h
@@ -58,8 +58,8 @@ struct IPv4Header
   u8 ttl = 0;
   u8 protocol = 0;
   u16 header_checksum = 0;
-  u8 source_addr[IPV4_ADDR_LEN]{};
-  u8 destination_addr[IPV4_ADDR_LEN]{};
+  std::array<u8, IPV4_ADDR_LEN> source_addr{};
+  std::array<u8, IPV4_ADDR_LEN> destination_addr{};
 };
 static_assert(sizeof(IPv4Header) == IPv4Header::SIZE);
 


### PR DESCRIPTION
Noticed this while trying to write up an explanation for how and why to use BitCast in #10690. Trivial change.