### PR TITLE
GameDB: Enabled Single Core Mode for PSO EP1&2 and EP3 improving online game stability

### DIFF
--- a/Data/Sys/GameSettings/GPO.ini
+++ b/Data/Sys/GameSettings/GPO.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GPS.ini
+++ b/Data/Sys/GameSettings/GPS.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
PSO EP1&2 and PSO EP3 tends to easily desync and crash the GPU/CPU threads when dual core mode is enabled (the default setting for most games on Dolphin) and since this game is constantly writing to your memory card while playing online, theres a chance these crashes will happen while the game is accessing/writing resulting in game data corruption making you lose all your progress and characters. So to avoid this, It's recommended to run this game in Single Core mode all the time.

Which why this PR is including now enabling Single Core Mode by default for both games.