### PR TITLE
Windows: Remove unused Qt5 block and reference

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -156,15 +156,6 @@ int main(int argc, char* argv[])
   QApplication app(argc, argv);
 #endif
 
-#if defined(_WIN32) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-  // On Windows, Qt 5's default system font (MS Shell Dlg 2) is outdated.
-  // Interestingly, the QMenu font is correct and comes from lfMenuFont
-  // (Segoe UI on English computers).
-  // So use it for the entire application.
-  // This code will become unnecessary and obsolete once we switch to Qt 6.
-  QApplication::setFont(QApplication::font("QMenu"));
-#endif
-
 #ifdef _WIN32
   FreeConsole();
 #endif

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -119,8 +119,7 @@ QString Settings::GetCurrentUserStyle() const
   return QFileInfo(GetQSettings().value(QStringLiteral("userstyle/path")).toString()).fileName();
 }
 
-// Calling this before the main window has been created breaks the style of some widgets on
-// Windows 10/Qt 5.15.0. But only if we set a stylesheet that isn't an empty string.
+// Calling this before the main window has been created breaks the style of some widgets.
 void Settings::SetCurrentUserStyle(const QString& stylesheet_name)
 {
   QString stylesheet_contents;


### PR DESCRIPTION
Remove a Windows/Qt5 only section of Main.cpp now that Windows has a minimum Qt version of 6.3.

The SetCurrentUserStyle comment was overly specific; the bug also occurs with light-mode macOS, Windows with Qt 6.3, or an empty stylesheet_name.