### PR TITLE
Socket: Fix some non-blocking connect edge cases

### DIFF
--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -186,4 +186,22 @@ u16 ComputeNetworkChecksum(const void* data, u16 length, u32 initial_value)
     checksum = (checksum >> 16) + (checksum & 0xFFFF);
   return ~static_cast<u16>(checksum);
 }
+
+NetworkErrorState SaveNetworkErrorState()
+{
+  return {
+      errno,
+#ifdef _WIN32
+      WSAGetLastError(),
+#endif
+  };
+}
+
+void RestoreNetworkErrorState(const NetworkErrorState& state)
+{
+  errno = state.error;
+#ifdef _WIN32
+  WSASetLastError(state.wsa_error);
+#endif
+}
 }  // namespace Common

--- a/Source/Core/Common/Network.h
+++ b/Source/Core/Common/Network.h
@@ -99,8 +99,18 @@ struct UDPHeader
 };
 static_assert(sizeof(UDPHeader) == UDPHeader::SIZE);
 
+struct NetworkErrorState
+{
+  int error;
+#ifdef _WIN32
+  int wsa_error;
+#endif
+};
+
 MACAddress GenerateMacAddress(MACConsumer type);
 std::string MacAddressToString(const MACAddress& mac);
 std::optional<MACAddress> StringToMacAddress(std::string_view mac_string);
 u16 ComputeNetworkChecksum(const void* data, u16 length, u32 initial_value = 0);
+NetworkErrorState SaveNetworkErrorState();
+void RestoreNetworkErrorState(const NetworkErrorState& state);
 }  // namespace Common

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -19,6 +19,8 @@
 #include "Common/BitUtils.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
+#include "Common/Network.h"
+#include "Common/ScopeGuard.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 #include "Core/IOS/Device.h"
@@ -225,6 +227,7 @@ s32 WiiSocket::CloseFd()
     GetIOS()->EnqueueIPCReply(it->request, -SO_ENOTCONN);
     it = pending_sockops.erase(it);
   }
+  connecting_state = ConnectingState::None;
   return ReturnValue;
 }
 
@@ -297,6 +300,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
 
         int ret = connect(fd, (sockaddr*)&local_name, sizeof(local_name));
         ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_CONNECT", false);
+        UpdateConnectingState(ReturnValue);
 
         INFO_LOG_FMT(IOS_NET, "IOCTL_SO_CONNECT ({:08x}, {}:{}) = {}", wii_fd,
                      inet_ntoa(local_name.sin_addr), Common::swap16(local_name.sin_port), ret);
@@ -342,10 +346,12 @@ void WiiSocket::Update(bool read, bool write, bool except)
           {
             ReturnValue = -SO_ENETUNREACH;
             ResetTimeout();
+            connecting_state = ConnectingState::Error;
           }
           break;
         case -SO_EISCONN:
           ReturnValue = SO_SUCCESS;
+          connecting_state = ConnectingState::Connected;
           [[fallthrough]];
         default:
           ResetTimeout();
@@ -393,6 +399,24 @@ void WiiSocket::Update(bool read, bool write, bool except)
           {
           case IOCTLV_NET_SSL_DOHANDSHAKE:
           {
+            // The Wii allows a socket with an in-progress connection to
+            // perform the SSL handshake. MbedTLS doesn't support it so
+            // we have to check it manually.
+            connecting_state = GetConnectingState();
+            if (connecting_state == ConnectingState::Connecting)
+            {
+              WriteReturnValue(SSL_ERR_RAGAIN, BufferIn);
+              ReturnValue = SSL_ERR_RAGAIN;
+              break;
+            }
+            else if (connecting_state == ConnectingState::None ||
+                     connecting_state == ConnectingState::Error)
+            {
+              WriteReturnValue(SSL_ERR_SYSCALL, BufferIn);
+              ReturnValue = SSL_ERR_SYSCALL;
+              break;
+            }
+
             mbedtls_ssl_context* ctx = &NetSSLDevice::_SSL[sslID].ctx;
             const int ret = mbedtls_ssl_handshake(ctx);
             if (ret != 0)
@@ -671,6 +695,100 @@ void WiiSocket::Update(bool read, bool write, bool except)
       ++it;
     }
   }
+}
+
+void WiiSocket::UpdateConnectingState(s32 connect_rv)
+{
+  if (connect_rv == -SO_EAGAIN || connect_rv == -SO_EALREADY || connect_rv == -SO_EINPROGRESS)
+  {
+    connecting_state = ConnectingState::Connecting;
+  }
+  else if (connect_rv >= 0)
+  {
+    connecting_state = ConnectingState::Connected;
+  }
+  else
+  {
+    connecting_state = ConnectingState::Error;
+  }
+}
+
+WiiSocket::ConnectingState WiiSocket::GetConnectingState() const
+{
+  const auto state = Common::SaveNetworkErrorState();
+  Common::ScopeGuard guard([&state] { Common::RestoreNetworkErrorState(state); });
+
+#ifdef _WIN32
+  constexpr int (*get_errno)() = &WSAGetLastError;
+#else
+  constexpr int (*get_errno)() = []() { return errno; };
+#endif
+
+  switch (connecting_state)
+  {
+  case ConnectingState::Error:
+  case ConnectingState::Connected:
+  case ConnectingState::None:
+    break;
+  case ConnectingState::Connecting:
+  {
+    const s32 nfds = fd + 1;
+    fd_set read_fds;
+    fd_set write_fds;
+    fd_set except_fds;
+    struct timeval t = {0, 0};
+    FD_ZERO(&read_fds);
+    FD_ZERO(&write_fds);
+    FD_ZERO(&except_fds);
+    FD_SET(fd, &write_fds);
+    FD_SET(fd, &except_fds);
+
+    auto& sm = WiiSockMan::GetInstance();
+    if (select(nfds, &read_fds, &write_fds, &except_fds, &t) < 0)
+    {
+      const s32 error = get_errno();
+      ERROR_LOG_FMT(IOS_SSL, "Failed to get socket (fd={}) connection state (err={}): {}", wii_fd,
+                    error, sm.DecodeError(error));
+      return ConnectingState::Error;
+    }
+
+    if (FD_ISSET(fd, &write_fds) == 0 && FD_ISSET(fd, &except_fds) == 0)
+      break;
+
+    s32 error = 0;
+    socklen_t len = sizeof(error);
+    if (getsockopt(fd, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) != 0)
+    {
+      error = get_errno();
+      ERROR_LOG_FMT(IOS_SSL, "Failed to get socket (fd={}) error state (err={}): {}", wii_fd, error,
+                    sm.DecodeError(error));
+      return ConnectingState::Error;
+    }
+
+    if (error != 0)
+    {
+      ERROR_LOG_FMT(IOS_SSL, "Non-blocking connect (fd={}) failed (err={}): {}", wii_fd, error,
+                    sm.DecodeError(error));
+      return ConnectingState::Error;
+    }
+
+    // Get peername to ensure the socket is connected
+    sockaddr_in peer;
+    socklen_t peer_len = sizeof(peer);
+    if (getpeername(fd, reinterpret_cast<sockaddr*>(&peer), &peer_len) != 0)
+    {
+      error = get_errno();
+      ERROR_LOG_FMT(IOS_SSL, "Non-blocking connect (fd={}) failed to get peername (err={}): {}",
+                    wii_fd, error, sm.DecodeError(error));
+      return ConnectingState::Error;
+    }
+
+    INFO_LOG_FMT(IOS_SSL, "Non-blocking connect (fd={}) succeeded", wii_fd);
+    return ConnectingState::Connected;
+  }
+  }
+
+  return connecting_state;
 }
 
 const WiiSocket::Timeout& WiiSocket::GetTimeout()

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -223,6 +223,7 @@ private:
   void UpdateConnectingState(s32 connect_rv);
   ConnectingState GetConnectingState() const;
   bool IsValid() const { return fd >= 0; }
+  bool IsTCP() const;
 
   s32 fd = -1;
   s32 wii_fd = -1;

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -248,8 +248,9 @@ public:
     return instance;             // Instantiated on first use.
   }
   void Update();
-  static void Convert(WiiSockAddrIn const& from, sockaddr_in& to);
-  static void Convert(sockaddr_in const& from, WiiSockAddrIn& to, s32 addrlen = -1);
+  static void ToNativeAddrIn(const u8* from, sockaddr_in* to);
+  static void ToWiiAddrIn(const sockaddr_in& from, u8* to,
+                          socklen_t addrlen = sizeof(WiiSockAddrIn));
   static s32 ConvertEvents(s32 events, ConvertDirection dir);
 
   void DoState(PointerWrap& p);

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -199,6 +199,14 @@ private:
     void Abort(s32 value);
   };
 
+  enum class ConnectingState
+  {
+    None,
+    Connecting,
+    Connected,
+    Error
+  };
+
   friend class WiiSockMan;
   void SetFd(s32 s);
   void SetWiiFd(s32 s);
@@ -212,11 +220,14 @@ private:
   void DoSock(Request request, NET_IOCTL type);
   void DoSock(Request request, SSL_IOCTL type);
   void Update(bool read, bool write, bool except);
+  void UpdateConnectingState(s32 connect_rv);
+  ConnectingState GetConnectingState() const;
   bool IsValid() const { return fd >= 0; }
 
   s32 fd = -1;
   s32 wii_fd = -1;
   bool nonBlock = false;
+  ConnectingState connecting_state = ConnectingState::None;
   std::list<sockop> pending_sockops;
 
   std::optional<Timeout> timeout;

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -15,6 +15,7 @@
 #include "Common/IOFile.h"
 #include "Common/Network.h"
 #include "Common/PcapFile.h"
+#include "Common/ScopeGuard.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 
@@ -90,24 +91,6 @@ void PCAPSSLCaptureLogger::OnNewSocket(s32 socket)
   m_write_sequence_number[socket] = 0;
 }
 
-PCAPSSLCaptureLogger::ErrorState PCAPSSLCaptureLogger::SaveState() const
-{
-  return {
-      errno,
-#ifdef _WIN32
-      WSAGetLastError(),
-#endif
-  };
-}
-
-void PCAPSSLCaptureLogger::RestoreState(const PCAPSSLCaptureLogger::ErrorState& state) const
-{
-  errno = state.error;
-#ifdef _WIN32
-  WSASetLastError(state.wsa_error);
-#endif
-}
-
 void PCAPSSLCaptureLogger::LogSSLRead(const void* data, std::size_t length, s32 socket)
 {
   if (!Config::Get(Config::MAIN_NETWORK_SSL_DUMP_READ))
@@ -135,7 +118,8 @@ void PCAPSSLCaptureLogger::LogWrite(const void* data, std::size_t length, s32 so
 void PCAPSSLCaptureLogger::Log(LogType log_type, const void* data, std::size_t length, s32 socket,
                                sockaddr* other)
 {
-  const auto state = SaveState();
+  const auto state = Common::SaveNetworkErrorState();
+  Common::ScopeGuard guard([&state] { Common::RestoreNetworkErrorState(state); });
   sockaddr_in sock;
   sockaddr_in peer;
   sockaddr_in* from;
@@ -144,16 +128,10 @@ void PCAPSSLCaptureLogger::Log(LogType log_type, const void* data, std::size_t l
   socklen_t peer_len = sizeof(sock);
 
   if (getsockname(socket, reinterpret_cast<sockaddr*>(&sock), &sock_len) != 0)
-  {
-    RestoreState(state);
     return;
-  }
 
   if (other == nullptr && getpeername(socket, reinterpret_cast<sockaddr*>(&peer), &peer_len) != 0)
-  {
-    RestoreState(state);
     return;
-  }
 
   if (log_type == LogType::Read)
   {
@@ -168,7 +146,6 @@ void PCAPSSLCaptureLogger::Log(LogType log_type, const void* data, std::size_t l
 
   LogIPv4(log_type, reinterpret_cast<const u8*>(data), static_cast<u16>(length), socket, *from,
           *to);
-  RestoreState(state);
 }
 
 void PCAPSSLCaptureLogger::LogIPv4(LogType log_type, const u8* data, u16 length, s32 socket,

--- a/Source/Core/Core/NetworkCaptureLogger.h
+++ b/Source/Core/Core/NetworkCaptureLogger.h
@@ -99,15 +99,6 @@ private:
     Read,
     Write,
   };
-  struct ErrorState
-  {
-    int error;
-#ifdef _WIN32
-    int wsa_error;
-#endif
-  };
-  ErrorState SaveState() const;
-  void RestoreState(const ErrorState& state) const;
 
   void Log(LogType log_type, const void* data, std::size_t length, s32 socket, sockaddr* other);
   void LogIPv4(LogType log_type, const u8* data, u16 length, s32 socket, const sockaddr_in& from,


### PR DESCRIPTION
Some Capcom games _(namely, Monster Hunter 3 and Monster Hunter G)_ use non-blocking connect then directly call some network/ssl functions. Unfortunately, it seems that mbedtls doesn't support SSL handshake when the connection is in progress (i.e. not fully completed yet). The same happens with network calls returning `ENOTCONN` instead of `EAGAIN`. In sum, the games will abort the connection if Dolphin isn't quick enough to connect before the network function is called. Obviously, it doesn't happen if you host locally the servers that the games are connecting to. However, it will happen if they are on the Internet and the network is too slow.

This PR refactors parts of the network code and fix some error codes. I'm unaware of other games affected by this issues. I wrote 2 hardware tests, one for the SSL handshake ([wii-ssl-connect.zip](https://github.com/dolphin-emu/dolphin/files/8786096/wii-ssl-connect.zip)), the other one for the send/recv ([wii-net-connect.zip](https://github.com/dolphin-emu/dolphin/files/8786093/wii-net-connect.zip)).

### HWTEST - SSL Connect (naswii.nintendowifi.net:443)
| Test case                      | Block | [Wii value](https://gist.github.com/sepalani/31e083de3d7a24912dccdae94c02388a) | [Dolphin value](https://gist.github.com/sepalani/67b1e21bcec933f6929c02d3b9dea303) | [PR value](https://gist.github.com/sepalani/2fc47ee436dc0527e238e677a72b719c) |
|--------------------------------|-------|-----------|---------------|----------|
| Invalid connect context (-1)   |   N/A |        -8 |            -8 |       -8 |
| Invalid handshake context (-1) |   N/A |        -8 |            -8 |       -8 |
| Invalid connect context (3)    |   N/A |         0 |            -8 |       -8 |
| Invalid socket (-1)            |   N/A |         0 |             0 |        0 |
| Invalid socket (12)            |   N/A |         0 |             0 |        0 |
| Disconnected connect           |  true |         0 |             0 |        0 |
| **Disconnected handshake**     |  true |        -5 |        **-1** |   **-5** |
| Disconnected connect           | false |         0 |             0 |        0 |
| **Disconnected handshake**     | false |        -5 |        **-1** |   **-5** |
| SSL connect                    |  true |         0 |             0 |        0 |
| SSL connect                    | false |         0 |             0 |        0 |
| Socket flags after SSL connect |  true |         0 |             0 |        0 |
| Socket flags after SSL connect | false |         4 |             4 |        4 |
| SSL handshake                  |  true |        -1 |            -1 |       -1 |
| SSL handshake                  | false |        -1 |            -1 |       -1 |
| SSL handshake (CLI)            |  true |         0 |             0 |        0 |
| **SSL handshake (CLI)**        | false |         0 |        **-1** |    **0** |
| SSL handshake (CA)             |  true |        -1 |            -1 |       -1 |
| SSL handshake (CA)             | false |        -1 |            -1 |       -1 |
| SSL handshake (CLI+CA)         |  true |         0 |             0 |        0 |
| **SSL handshake (CLI+CA)**     | false |         0 |        **-1** |    **0** |

### HWTEST - Non-blocking NET Connect (8.8.8.8:53)
| Test case            | Type | Connect value | [Wii value](https://gist.github.com/sepalani/a03fe0424294c16fdbdd72b4f23501b8)  | [Dolphin value](https://gist.github.com/sepalani/8a3ae15d511808cb670cd94a3a1729a4) | [PR value](https://gist.github.com/sepalani/24ec7932946740a267cba5eb0ec1809f)  |
|----------------------|------|---------------|------------|---------------|-----------|
| **Connect/Recv**     |  TCP |          -119 |        -11 |      **-128** |   **-11** |
| Connect/Recv         |  UDP |             0 |        -11 |           -11 |       -11 |
| _Connect/Send_       |  TCP |          -119 |          5 |        _-128_ |     _-11_ |
| Connect/Send         |  UDP |             0 |          5 |             5 |         5 |
| **Connect/RecvFrom** |  TCP |          -119 |        -11 |      **-128** |   **-11** |
| Connect/RecvFrom     |  UDP |             0 |        -11 |           -11 |       -11 |
| _Connect/SendTo_     |  TCP |          -119 |          5 |        _-128_ |     _-11_ |
| Connect/SendTo       |  UDP |             0 |          5 |             5 |         5 |

Ready to be reviewed & tested.