### PR TITLE
Debugger MemoryWidget: Navigate to memory from breakpoint widget and cheat search.

### DIFF
--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -448,8 +448,12 @@ void CheatSearchWidget::OnAddressTableContextMenu()
   if (m_address_table->selectedItems().isEmpty())
     return;
 
+  auto* item = m_address_table->selectedItems()[0];
+  const u32 address = item->data(ADDRESS_TABLE_ADDRESS_ROLE).toUInt();
+
   QMenu* menu = new QMenu(this);
 
+  menu->addAction(tr("Show in memory"), [this, address] { emit ShowMemory(address); });
   menu->addAction(tr("Generate Action Replay Code"), this, &CheatSearchWidget::GenerateARCode);
 
   menu->exec(QCursor::pos());

--- a/Source/Core/DolphinQt/CheatSearchWidget.h
+++ b/Source/Core/DolphinQt/CheatSearchWidget.h
@@ -41,6 +41,7 @@ public:
 
 signals:
   void ActionReplayCodeGenerated(const ActionReplay::ARCode& ar_code);
+  void ShowMemory(const u32 address);
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -122,6 +122,7 @@ void CheatsManager::OnNewSessionCreated(const Cheats::CheatSearchSessionBase& se
                if (m_ar_code)
                  m_ar_code->AddCode(ar_code);
              });
+  w->connect(w, &CheatSearchWidget::ShowMemory, [this](u32 address) { emit ShowMemory(address); });
   m_tab_widget->setCurrentIndex(tab_index);
 }
 

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -35,6 +35,7 @@ public:
 
 signals:
   void OpenGeneralSettings();
+  void ShowMemory(u32 address);
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -18,6 +18,7 @@
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 
+#include "DolphinQt/Debugger/MemoryWidget.h"
 #include "DolphinQt/Debugger/NewBreakpointDialog.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
@@ -355,13 +356,13 @@ void BreakpointWidget::OnContextMenu()
     if (bp_iter == inst_breakpoints.end())
       return;
 
+    menu->addAction(tr("Show in Code"), [this, bp_address] { emit ShowCode(bp_address); });
     menu->addAction(bp_iter->is_enabled ? tr("Disable") : tr("Enable"), [this, &bp_address]() {
       PowerPC::breakpoints.ToggleBreakPoint(bp_address);
 
       emit BreakpointsChanged();
       Update();
     });
-    menu->addAction(tr("Go to"), [this, bp_address] { emit SelectedBreakpoint(bp_address); });
   }
   else
   {
@@ -372,6 +373,7 @@ void BreakpointWidget::OnContextMenu()
     if (mb_iter == memory_breakpoints.end())
       return;
 
+    menu->addAction(tr("Show in Memory"), [this, bp_address] { emit ShowMemory(bp_address); });
     menu->addAction(mb_iter->is_enabled ? tr("Disable") : tr("Enable"), [this, &bp_address]() {
       PowerPC::memchecks.ToggleBreakPoint(bp_address);
 

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -31,7 +31,8 @@ public:
 
 signals:
   void BreakpointsChanged();
-  void SelectedBreakpoint(u32 address);
+  void ShowCode(u32 address);
+  void ShowMemory(u32 address);
 
 protected:
   void closeEvent(QCloseEvent*) override;

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -310,6 +310,7 @@ void WatchWidget::ShowContextMenu()
 
       if (row >= 0)
       {
+        menu->addAction(tr("Show in Memory"), this, [this, row] { ShowInMemory(row); });
         // i18n: This kind of "watch" is used for watching emulated memory.
         // It's not related to timekeeping devices.
         menu->addAction(tr("&Delete Watch"), this, [this, row] { DeleteWatch(row); });
@@ -393,6 +394,11 @@ void WatchWidget::DeleteWatch(int row)
 void WatchWidget::AddWatchBreakpoint(int row)
 {
   emit RequestMemoryBreakpoint(PowerPC::debug_interface.GetWatch(row).address);
+}
+
+void WatchWidget::ShowInMemory(int row)
+{
+  emit ShowMemory(PowerPC::debug_interface.GetWatch(row).address);
 }
 
 void WatchWidget::AddWatch(QString name, u32 addr)

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.h
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.h
@@ -24,6 +24,7 @@ public:
   void AddWatch(QString name, u32 addr);
 signals:
   void RequestMemoryBreakpoint(u32 addr);
+  void ShowMemory(u32 addr);
 
 protected:
   void closeEvent(QCloseEvent*) override;
@@ -47,7 +48,7 @@ private:
   void OnItemChanged(QTableWidgetItem* item);
   void DeleteWatch(int row);
   void AddWatchBreakpoint(int row);
-
+  void ShowInMemory(int row);
   void UpdateIcons();
 
   QAction* m_new;

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -455,6 +455,7 @@ void MainWindow::CreateComponents()
   };
 
   connect(m_watch_widget, &WatchWidget::RequestMemoryBreakpoint, request_memory_breakpoint);
+  connect(m_watch_widget, &WatchWidget::ShowMemory, m_memory_widget, &MemoryWidget::SetAddress);
   connect(m_register_widget, &RegisterWidget::RequestMemoryBreakpoint, request_memory_breakpoint);
   connect(m_register_widget, &RegisterWidget::RequestWatch, request_watch);
   connect(m_register_widget, &RegisterWidget::RequestViewInMemory, request_view_in_memory);
@@ -480,10 +481,13 @@ void MainWindow::CreateComponents()
           &CodeWidget::Update);
   connect(m_breakpoint_widget, &BreakpointWidget::BreakpointsChanged, m_memory_widget,
           &MemoryWidget::Update);
-  connect(m_breakpoint_widget, &BreakpointWidget::SelectedBreakpoint, [this](u32 address) {
+  connect(m_breakpoint_widget, &BreakpointWidget::ShowCode, [this](u32 address) {
     if (Core::GetState() == Core::State::Paused)
       m_code_widget->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithDetailedUpdate);
   });
+  connect(m_breakpoint_widget, &BreakpointWidget::ShowMemory, m_memory_widget,
+          &MemoryWidget::SetAddress);
+  connect(m_cheats_manager, &CheatsManager::ShowMemory, m_memory_widget, &MemoryWidget::SetAddress);
 }
 
 void MainWindow::ConnectMenuBar()


### PR DESCRIPTION
When an address is sent to memory widget, it doesn't go in the memory address target box and must still be copied there before being able to get edited.  This is a bit annoying, but forcibly changing the target address could be annoying as well.  This wouldn't be a big issue if we could edit cells directly.  I think we need another PR to improve this some way.