### PR TITLE
Remove GetSysDirectory spam

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -885,7 +885,7 @@ std::string GetExeDirectory()
 #endif
 }
 
-std::string GetSysDirectory()
+static std::string CreateSysDirectoryPath()
 {
   std::string sysDir;
 
@@ -913,8 +913,14 @@ std::string GetSysDirectory()
 #endif
   sysDir += DIR_SEP;
 
-  INFO_LOG_FMT(COMMON, "GetSysDirectory: Setting to {}:", sysDir);
+  INFO_LOG_FMT(COMMON, "CreateSysDirectoryPath: Setting to {}", sysDir);
   return sysDir;
+}
+
+const std::string& GetSysDirectory()
+{
+  static const std::string sys_directory = CreateSysDirectoryPath();
+  return sys_directory;
 }
 
 #ifdef ANDROID

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -887,8 +887,6 @@ std::string GetExeDirectory()
 
 static std::string CreateSysDirectoryPath()
 {
-  std::string sysDir;
-
 #if defined(_WIN32) || defined(LINUX_LOCAL_DEV)
 #define SYSDATA_DIR "Sys"
 #elif defined __APPLE__
@@ -902,19 +900,18 @@ static std::string CreateSysDirectoryPath()
 #endif
 
 #if defined(__APPLE__)
-  sysDir = GetBundleDirectory() + DIR_SEP + SYSDATA_DIR;
+  const std::string sys_directory = GetBundleDirectory() + DIR_SEP SYSDATA_DIR DIR_SEP;
 #elif defined(_WIN32) || defined(LINUX_LOCAL_DEV)
-  sysDir = GetExeDirectory() + DIR_SEP + SYSDATA_DIR;
+  const std::string sys_directory = GetExeDirectory() + DIR_SEP SYSDATA_DIR DIR_SEP;
 #elif defined ANDROID
-  sysDir = s_android_sys_directory;
-  ASSERT_MSG(COMMON, !sysDir.empty(), "Sys directory has not been set");
+  const std::string sys_directory = s_android_sys_directory + DIR_SEP;
+  ASSERT_MSG(COMMON, !s_android_sys_directory.empty(), "Sys directory has not been set");
 #else
-  sysDir = SYSDATA_DIR;
+  const std::string sys_directory = SYSDATA_DIR DIR_SEP;
 #endif
-  sysDir += DIR_SEP;
 
-  INFO_LOG_FMT(COMMON, "CreateSysDirectoryPath: Setting to {}", sysDir);
-  return sysDir;
+  INFO_LOG_FMT(COMMON, "CreateSysDirectoryPath: Setting to {}", sys_directory);
+  return sys_directory;
 }
 
 const std::string& GetSysDirectory()

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -921,6 +921,8 @@ std::string GetSysDirectory()
 void SetSysDirectory(const std::string& path)
 {
   INFO_LOG_FMT(COMMON, "Setting Sys directory to {}", path);
+  ASSERT_MSG(COMMON, s_android_sys_directory.empty(), "Sys directory already set to {}",
+             s_android_sys_directory);
   s_android_sys_directory = path;
 }
 #endif

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -215,7 +215,7 @@ void SetUserPath(unsigned int dir_index, std::string path);
 std::string GetThemeDir(const std::string& theme_name);
 
 // Returns the path to where the sys file are
-std::string GetSysDirectory();
+const std::string& GetSysDirectory();
 
 #ifdef ANDROID
 void SetSysDirectory(const std::string& path);


### PR DESCRIPTION
Launching and then immediately closing Dolphin results in 51 (out of 81 total) lines of "Common\FileUtil.cpp:916 I[COMMON]: GetSysDirectory: Setting to [Dolphin Sys path]:". Most lines happen during startup and thus only show up in dolphin.log but 10 also appear in the log widget. Starting a game creates more such lines.

Unless I've misunderstood something the Sys path is constant for any given Dolphin session, and so there's no reason to recreate it each time GetSysDirectory is called. 

This PR creates and logs the Sys directory path once, and also does some minor refactoring and removes the extraneous colon at the end of the line.