### PR TITLE
fix the android buildbot

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-viewmodel:2.4.1'
     implementation 'androidx.fragment:fragment:1.4.1'
     implementation 'androidx.slidingpanelayout:slidingpanelayout:1.2.0'

--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.0.4'
     }
 }
 

--- a/Source/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Source/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 05 13:37:44 EST 2022
+#Sat May 28 22:34:03 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
the actual fix is just the AGP downgrade (see https://issuetracker.google.com/issues/232060576 - plz upvote that). 

currently active PRs which touch cmake files that are based on commits with AGP >= 7.1.0 would need to rebase on this commit.