### PR TITLE
UICommon: Change default user directory location to AppData on Windows

### DIFF
--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -344,15 +344,34 @@ void SetUserDirectory(std::string custom_path)
   }
 
   if (local)  // Case 1-2
+  {
     user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
+  }
   else if (configPath)  // Case 3
+  {
     user_path = TStrToUTF8(configPath.get());
+  }
   else if (old_user_folder && File::Exists(old_user_folder.value()))  // Case 4
+  {
     user_path = old_user_folder.value();
+  }
   else if (appdata_found)  // Case 5
+  {
     user_path = TStrToUTF8(appdata) + DIR_SEP "Dolphin Emulator" DIR_SEP;
+
+    // Set the UserConfigPath value in the registry for backwards compatibility with older Dolphin
+    // builds, which will look for the default User directory in Documents. If we set this key,
+    // they will use this as the User directory instead.
+    // (If we're in this case, then this key doesn't exist, so it's OK to set it.)
+    std::wstring wstr_path = UTF8ToWString(user_path);
+    RegSetKeyValueW(HKEY_CURRENT_USER, TEXT("Software\\Dolphin Emulator"), TEXT("UserConfigPath"),
+                    REG_SZ, wstr_path.c_str(),
+                    static_cast<DWORD>((wstr_path.size() + 1) * sizeof(wchar_t)));
+  }
   else  // Case 6
+  {
     user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
+  }
 
   CoTaskMemFree(appdata);
   CoTaskMemFree(documents);

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -289,8 +289,8 @@ void SetUserDirectory(std::string custom_path)
   //    -> Use GetExeDirectory()\User
   // 3. HKCU\Software\Dolphin Emulator\UserConfigPath exists
   //    -> Use this as the user directory path
-  // 4. My Documents exists
-  //    -> Use My Documents\Dolphin Emulator as the User directory path
+  // 4. AppData\Roaming exists
+  //    -> Use AppData\Roaming\Dolphin Emulator as the User directory path
   // 5. Default
   //    -> Use GetExeDirectory()\User
 
@@ -323,22 +323,22 @@ void SetUserDirectory(std::string custom_path)
 
   local = local != 0 || File::Exists(File::GetExeDirectory() + DIR_SEP "portable.txt");
 
-  // Get Documents path in case we need it.
+  // Get AppData path in case we need it.
   // TODO: Maybe use WIL when it's available?
-  PWSTR my_documents = nullptr;
-  bool my_documents_found =
-      SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_DEFAULT, nullptr, &my_documents));
+  PWSTR appdata = nullptr;
+  bool appdata_found =
+      SUCCEEDED(SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_DEFAULT, nullptr, &appdata));
 
   if (local)  // Case 1-2
     user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
   else if (configPath)  // Case 3
     user_path = TStrToUTF8(configPath.get());
-  else if (my_documents_found)  // Case 4
-    user_path = TStrToUTF8(my_documents) + DIR_SEP "Dolphin Emulator" DIR_SEP;
+  else if (appdata_found)  // Case 4
+    user_path = TStrToUTF8(appdata) + DIR_SEP "Dolphin Emulator" DIR_SEP;
   else  // Case 5
     user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
 
-  CoTaskMemFree(my_documents);
+  CoTaskMemFree(appdata);
 #else
   if (File::IsDirectory(ROOT_DIR DIR_SEP USERDATA_DIR))
   {


### PR DESCRIPTION
This PR moves the user folder to `%appdata%\Dolphin Emulator` to minimize the chances that external software can interfere with Dolphin when accessing it (shoutouts to OneDrive and various anti-virus scanners).

Here is how the user directory is determined on Windows with my changes:

1. If the file `portable.txt` or the registry value `HKCU\Software\Dolphin Emulator\LocalUserConfig` exists, a folder named `User` next to the executable will be selected as the user directory.
2. If Dolphin finds a registry value in `HKCU\Software\Dolphin Emulator\UserConfigPath`, it will use that as the user directory. This functionality dates back to at least 4.0 stable.
3. **NEW**: If the old user directory at `%userprofile%\My Documents\Dolphin Emulator` exists, Dolphin will use that as the user directory.
4. **NEW**: Otherwise, `%appdata%\Dolphin Emulator` will be used. In addition, for backwards compatibility, the registry value `HKCU\Software\Dolphin Emulator\UserConfigPath` will be set to that path to ensure that Dolphin builds made before this PR will continue to use it as the user directory (see step 2).
6. If neither `%appdata%` or `%userprofile%\My Documents` exists, Dolphin will act like `portable.txt` exists.

I do see one flaw with my backward compatibility approach: if `%userprofile%` changes, the old path in `UserConfigPath` will continue to be used, which might cause the user to think their data is gone. I personally don't think this is worth handling, since [Microsoft specifically warns against moving the user profile in Windows 10 and above](https://docs.microsoft.com/en-us/troubleshoot/windows-client/user-profiles-and-logon/renaming-user-account-not-change-profile-path). 