### PR TITLE
DolphinQt: Renamed "Range" to "Multiplier" in advanced mapping window and improved UX.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -36,8 +36,6 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/MappingCommon.h"
 
-constexpr int SLIDER_TICK_COUNT = 100;
-
 namespace
 {
 // TODO: Make sure these functions return colors that will be visible in the current theme.
@@ -246,8 +244,7 @@ void IOWindow::CreateMainLayout()
   m_test_button = new QPushButton(tr("Test"), this);
   m_button_box = new QDialogButtonBox();
   m_clear_button = new QPushButton(tr("Clear"));
-  m_range_slider = new QSlider(Qt::Horizontal);
-  m_range_spinbox = new QSpinBox();
+  m_scalar_spinbox = new QSpinBox();
 
   m_parse_text = new InputStateLineEdit([this] {
     const auto lock = m_controller->GetStateLock();
@@ -319,16 +316,20 @@ void IOWindow::CreateMainLayout()
   // Devices
   m_main_layout->addWidget(m_devices_combo);
 
-  // Range
-  auto* range_hbox = new QHBoxLayout();
-  range_hbox->addWidget(new QLabel(tr("Range")));
-  range_hbox->addWidget(m_range_slider);
-  range_hbox->addWidget(m_range_spinbox);
-  m_range_slider->setMinimum(-500);
-  m_range_slider->setMaximum(500);
-  m_range_spinbox->setMinimum(-500);
-  m_range_spinbox->setMaximum(500);
-  m_main_layout->addLayout(range_hbox);
+  // Scalar
+  auto* scalar_hbox = new QHBoxLayout();
+  // i18n: Controller input values are multiplied by this percentage value.
+  scalar_hbox->addWidget(new QLabel(tr("Multiplier")));
+  scalar_hbox->addWidget(m_scalar_spinbox);
+
+  // Outputs are not bounds checked and greater than 100% has no use case.
+  // (incoming values are always 0 or 1)
+  // Negative 100% can be used to invert force feedback wheel direction.
+  const int scalar_min_max = (m_type == Type::Input) ? 1000 : 100;
+  m_scalar_spinbox->setMinimum(-scalar_min_max);
+  m_scalar_spinbox->setMaximum(scalar_min_max);
+  // i18n: Percentage symbol.
+  m_scalar_spinbox->setSuffix(tr("%"));
 
   // Options (Buttons, Outputs) and action buttons
 
@@ -387,6 +388,8 @@ void IOWindow::CreateMainLayout()
   else
     m_functions_combo->hide();
 
+  button_vbox->addLayout(scalar_hbox);
+
   m_main_layout->addLayout(hbox, 2);
   m_main_layout->addWidget(m_expression_text, 1);
   m_main_layout->addWidget(m_parse_text);
@@ -409,8 +412,7 @@ void IOWindow::ConfigChanged()
 
   m_expression_text->setPlainText(QString::fromStdString(m_reference->GetExpression()));
   m_expression_text->moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
-  m_range_spinbox->setValue(m_reference->range * SLIDER_TICK_COUNT);
-  m_range_slider->setValue(m_reference->range * SLIDER_TICK_COUNT);
+  m_scalar_spinbox->setValue(m_reference->range * 100.0);
 
   if (m_devq.ToString().empty())
     m_devq = m_controller->GetDefaultDevice();
@@ -436,7 +438,7 @@ void IOWindow::ConnectWidgets()
 
   connect(m_button_box, &QDialogButtonBox::clicked, this, &IOWindow::OnDialogButtonPressed);
   connect(m_devices_combo, &QComboBox::currentTextChanged, this, &IOWindow::OnDeviceChanged);
-  connect(m_range_spinbox, qOverload<int>(&QSpinBox::valueChanged), this,
+  connect(m_scalar_spinbox, qOverload<int>(&QSpinBox::valueChanged), this,
           &IOWindow::OnRangeChanged);
 
   connect(m_expression_text, &QPlainTextEdit::textChanged,
@@ -548,9 +550,7 @@ void IOWindow::OnTestButtonPressed()
 
 void IOWindow::OnRangeChanged(int value)
 {
-  m_reference->range = static_cast<double>(value) / SLIDER_TICK_COUNT;
-  m_range_spinbox->setValue(m_reference->range * SLIDER_TICK_COUNT);
-  m_range_slider->setValue(m_reference->range * SLIDER_TICK_COUNT);
+  m_reference->range = value / 100.0;
 }
 
 void IOWindow::ReleaseDevices()

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
@@ -105,9 +105,8 @@ private:
   // Options
   QTableWidget* m_option_list;
 
-  // Range
-  QSlider* m_range_slider;
-  QSpinBox* m_range_spinbox;
+  // Scalar
+  QSpinBox* m_scalar_spinbox;
 
   // Shared actions
   QPushButton* m_select_button;


### PR DESCRIPTION
The "Range" slider wasn't connected to anything.
The spin box behaved poorly because of the attempt to connect it to the slider.

I've removed the slider and relocated the spin box.

![image](https://user-images.githubusercontent.com/1768214/175856865-07effc53-0400-4e39-9d2d-bf7d12c995e6.png)

I've changed the maximum values to 1000% (for inputs) and 100% (for outputs).
A user in discord unsurprisingly made their rumble stop working with it set to like 104.

There's no use case for over 100 on outputs.
Negative values are still useful for inverting wheel force feedback.

I've renamed "Range" to "Multiplier".