### PR TITLE
DolphinQt: Add function to import/export userdir from/to a zip file.

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(common
   MemArena.h
   MemoryUtil.cpp
   MemoryUtil.h
+  MinizipUtil.cpp
   MinizipUtil.h
   MsgHandler.cpp
   MsgHandler.h

--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -127,6 +127,19 @@ void Save()
   OnConfigChanged();
 }
 
+void Reload()
+{
+  {
+    WriteLock lock(s_layers_rw_lock);
+
+    for (auto& layer : s_layers)
+      layer.second->DeleteAllKeys();
+    for (auto& layer : s_layers)
+      layer.second->Load();
+  }
+  OnConfigChanged();
+}
+
 void Init()
 {
   // These layers contain temporary values

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -33,6 +33,7 @@ u64 GetConfigVersion();
 // Explicit load and save of layers
 void Load();
 void Save();
+void Reload();
 
 void Init();
 void Shutdown();

--- a/Source/Core/Common/MinizipUtil.cpp
+++ b/Source/Core/Common/MinizipUtil.cpp
@@ -1,0 +1,74 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Common/MinizipUtil.h"
+
+#include <ctime>  // required by minizip includes
+#include <string>
+
+#include <mz_strm.h>
+#include <mz_strm_os.h>
+#include <mz_zip.h>
+#include <mz_zip_rw.h>
+
+#include "Common/ScopeGuard.h"
+
+namespace Common
+{
+bool PackDirectoryToZip(const std::string& directory_path, const std::string& zip_path)
+{
+  void* stream = nullptr;
+  mz_stream_os_create(&stream);
+  if (!stream)
+    return false;
+
+  Common::ScopeGuard delete_stream_guard([&stream] { mz_stream_os_delete(&stream); });
+
+  if (mz_stream_os_open(stream, zip_path.c_str(), MZ_OPEN_MODE_CREATE) != MZ_OK)
+    return false;
+
+  Common::ScopeGuard close_stream_guard([&stream] { mz_stream_os_close(stream); });
+
+  void* writer = nullptr;
+  mz_zip_writer_create(&writer);
+  if (!writer)
+    return false;
+
+  Common::ScopeGuard delete_writer_guard([&writer] { mz_zip_writer_delete(&writer); });
+
+  mz_zip_writer_set_compress_method(writer, Z_DEFLATED);
+  mz_zip_writer_set_compress_level(writer, MZ_COMPRESS_LEVEL_NORMAL);
+
+  if (mz_zip_writer_open(writer, stream, 0) != MZ_OK)
+    return false;
+
+  Common::ScopeGuard close_writer_guard([&writer] { mz_zip_writer_close(writer); });
+
+  if (mz_zip_writer_add_path(writer, directory_path.c_str(), nullptr, 0, 1) != MZ_OK)
+    return false;
+
+  return true;
+}
+
+bool UnpackZipToDirectory(const std::string& zip_path, const std::string& directory_path)
+{
+  void* reader = nullptr;
+  mz_zip_reader_create(&reader);
+  if (!reader)
+    return false;
+
+  Common::ScopeGuard delete_reader_guard([&reader] { mz_zip_reader_delete(&reader); });
+
+  mz_zip_reader_set_encoding(reader, MZ_ENCODING_UTF8);
+
+  if (mz_zip_reader_open_file(reader, zip_path.c_str()) != MZ_OK)
+    return false;
+
+  Common::ScopeGuard close_reader_guard([&reader] { mz_zip_reader_close(reader); });
+
+  if (mz_zip_reader_save_all(reader, directory_path.c_str()) != MZ_OK)
+    return false;
+
+  return true;
+}
+}  // namespace Common

--- a/Source/Core/Common/MinizipUtil.h
+++ b/Source/Core/Common/MinizipUtil.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <algorithm>
+#include <string>
 
 #include <unzip.h>
 
@@ -38,4 +39,12 @@ bool ReadFileFromZip(unzFile file, ContiguousContainer* destination)
 
   return true;
 }
+
+// Packs the directory at directory_path into a new zip file at zip_path.
+// If zip_path exists it will be overwritten.
+bool PackDirectoryToZip(const std::string& directory_path, const std::string& zip_path);
+
+// Unpacks the zip file at zip_path into the directory at directory_path.
+// Existing files may be overwritten if the zip file contains a file with the same relative path.
+bool UnpackZipToDirectory(const std::string& zip_path, const std::string& directory_path);
 }  // namespace Common

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -681,4 +681,12 @@ void ToUpper(std::string* str)
 {
   std::transform(str->begin(), str->end(), str->begin(), [](char c) { return Common::ToUpper(c); });
 }
+
+bool CaseInsensitiveEquals(std::string_view a, std::string_view b)
+{
+  if (a.size() != b.size())
+    return false;
+  return std::equal(a.begin(), a.end(), b.begin(),
+                    [](char ca, char cb) { return Common::ToLower(ca) == Common::ToLower(cb); });
+}
 }  // namespace Common

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -261,4 +261,5 @@ inline char ToUpper(char ch)
 }
 void ToLower(std::string* str);
 void ToUpper(std::string* str);
+bool CaseInsensitiveEquals(std::string_view a, std::string_view b);
 }  // namespace Common

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -319,14 +319,6 @@ static void ApplyPatchToFile(const Patch& patch, const File& file_patch,
                    file_patch.m_fileoffset, file_patch.m_length, file_patch.m_resize);
 }
 
-static bool CaseInsensitiveEquals(std::string_view a, std::string_view b)
-{
-  if (a.size() != b.size())
-    return false;
-  return std::equal(a.begin(), a.end(), b.begin(),
-                    [](char ca, char cb) { return Common::ToLower(ca) == Common::ToLower(cb); });
-}
-
 static FSTBuilderNode* FindFileNodeInFST(std::string_view path, std::vector<FSTBuilderNode>* fst,
                                          bool create_if_not_exists)
 {
@@ -334,7 +326,7 @@ static FSTBuilderNode* FindFileNodeInFST(std::string_view path, std::vector<FSTB
   const bool is_file = path_separator == std::string_view::npos;
   const std::string_view name = is_file ? path : path.substr(0, path_separator);
   const auto it = std::find_if(fst->begin(), fst->end(), [&](const FSTBuilderNode& node) {
-    return CaseInsensitiveEquals(node.m_filename, name);
+    return Common::CaseInsensitiveEquals(node.m_filename, name);
   });
 
   if (it == fst->end())
@@ -376,7 +368,7 @@ static DiscIO::FSTBuilderNode* FindFilenameNodeInFST(std::string_view filename,
       if (result)
         return result;
     }
-    else if (CaseInsensitiveEquals(node.m_filename, filename))
+    else if (Common::CaseInsensitiveEquals(node.m_filename, filename))
     {
       return &node;
     }
@@ -397,7 +389,7 @@ static void ApplyFilePatchToFST(const Patch& patch, const File& file,
     if (node)
       ApplyPatchToFile(patch, file, node);
   }
-  else if (CaseInsensitiveEquals(file.m_disc, "main.dol"))
+  else if (Common::CaseInsensitiveEquals(file.m_disc, "main.dol"))
   {
     // Special case: If the filename is "main.dol", we want to patch the main executable.
     ApplyPatchToFile(patch, file, dol_node);

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -733,6 +733,7 @@
     <ClCompile Include="Common\Matrix.cpp" />
     <ClCompile Include="Common\MemArenaWin.cpp" />
     <ClCompile Include="Common\MemoryUtil.cpp" />
+    <ClCompile Include="Common\MinizipUtil.cpp" />
     <ClCompile Include="Common\MsgHandler.cpp" />
     <ClCompile Include="Common\NandPaths.cpp" />
     <ClCompile Include="Common\Network.cpp" />

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -510,6 +510,7 @@
     <ClInclude Include="UICommon\DiscordPresence.h" />
     <ClInclude Include="UICommon\GameFile.h" />
     <ClInclude Include="UICommon\GameFileCache.h" />
+    <ClInclude Include="UICommon\ImportExportUserdir.h" />
     <ClInclude Include="UICommon\NetPlayIndex.h" />
     <ClInclude Include="UICommon\ResourcePack\Manager.h" />
     <ClInclude Include="UICommon\ResourcePack\Manifest.h" />
@@ -1101,6 +1102,7 @@
     <ClCompile Include="UICommon\DiscordPresence.cpp" />
     <ClCompile Include="UICommon\GameFile.cpp" />
     <ClCompile Include="UICommon\GameFileCache.cpp" />
+    <ClCompile Include="UICommon\ImportExportUserdir.cpp" />
     <ClCompile Include="UICommon\NetPlayIndex.cpp" />
     <ClCompile Include="UICommon\ResourcePack\Manager.cpp" />
     <ClCompile Include="UICommon\ResourcePack\Manifest.cpp" />

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -282,13 +282,17 @@ void MenuBar::AddToolsMenu()
 
   tools_menu->addSeparator();
 
-  tools_menu->addAction(tr("Import Wii Save..."), this, &MenuBar::ImportWiiSave);
-  tools_menu->addAction(tr("Export All Wii Saves"), this, &MenuBar::ExportWiiSaves);
+  m_import_wii_save =
+      tools_menu->addAction(tr("Import Wii Save..."), this, &MenuBar::ImportWiiSave);
+  m_export_wii_saves =
+      tools_menu->addAction(tr("Export All Wii Saves"), this, &MenuBar::ExportWiiSaves);
 
   tools_menu->addSeparator();
 
-  tools_menu->addAction(tr("Import Global User Directory..."), this, &MenuBar::ImportUserDirBackup);
-  tools_menu->addAction(tr("Export Global User Directory..."), this, &MenuBar::ExportUserDirBackup);
+  m_import_userdir = tools_menu->addAction(tr("Import Global User Directory..."), this,
+                                           &MenuBar::ImportUserDirBackup);
+  m_export_userdir = tools_menu->addAction(tr("Export Global User Directory..."), this,
+                                           &MenuBar::ExportUserDirBackup);
 
   QMenu* menu = new QMenu(tr("Connect Wii Remotes"), tools_menu);
 
@@ -1015,6 +1019,11 @@ void MenuBar::UpdateToolsMenu(bool emulation_started)
                         File::Exists(SConfig::GetInstance().GetBootROMPath(EUR_DIR)));
   m_import_backup->setEnabled(!emulation_started);
   m_check_nand->setEnabled(!emulation_started);
+  m_wad_install_action->setEnabled(!emulation_started);
+  m_import_wii_save->setEnabled(!emulation_started);
+  m_export_wii_saves->setEnabled(!emulation_started);
+  m_import_userdir->setEnabled(!emulation_started);
+  m_export_userdir->setEnabled(!emulation_started);
 
   if (!emulation_started)
   {

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -289,10 +289,10 @@ void MenuBar::AddToolsMenu()
 
   tools_menu->addSeparator();
 
-  m_import_userdir = tools_menu->addAction(tr("Import Global User Directory..."), this,
-                                           &MenuBar::ImportUserDirBackup);
-  m_export_userdir = tools_menu->addAction(tr("Export Global User Directory..."), this,
-                                           &MenuBar::ExportUserDirBackup);
+  m_import_userdir =
+      tools_menu->addAction(tr("Import User Directory..."), this, &MenuBar::ImportUserDirBackup);
+  m_export_userdir =
+      tools_menu->addAction(tr("Export User Directory..."), this, &MenuBar::ExportUserDirBackup);
 
   QMenu* menu = new QMenu(tr("Connect Wii Remotes"), tools_menu);
 
@@ -1060,21 +1060,21 @@ void MenuBar::ImportUserDirBackup()
 {
   auto warning_result = ModalMessageBox::question(
       this, tr("Warning"),
-      tr("Importing a Global User Directory will delete all data currently stored within the "
-         "Global User Directory. This includes save files, controller configuration, and other "
-         "user-configured data. You may want to export your current Global User Directory before "
-         "importing a new one.\n\nAre you sure you want to continue?"));
+      tr("Importing a User Directory will delete all data currently stored within the User "
+         "Directory. This includes save files, controller configuration, and other user-configured "
+         "data. You may want to export your current User Directory before importing a new "
+         "one.\n\nAre you sure you want to continue?"));
   if (warning_result != QMessageBox::Yes)
     return;
 
   const QString path = DolphinFileDialog::getOpenFileName(
-      this, tr("Select the Global User Directory backup to import"), QDir::currentPath(),
+      this, tr("Select the User Directory backup to import"), QDir::currentPath(),
       QStringLiteral("%1 (*.zip);;%2 (*)").arg(tr("ZIP archive")).arg(tr("All Files")));
   if (path.isEmpty())
     return;
 
-  ParallelProgressDialog progress(tr("Importing Global User Directory from %1...").arg(path),
-                                  QString(), 0, 0, this);
+  ParallelProgressDialog progress(tr("Importing User Directory from %1...").arg(path), QString(), 0,
+                                  0, this);
   progress.GetRaw()->setWindowTitle(tr("Importing"));
   progress.GetRaw()->setWindowModality(Qt::WindowModal);
 
@@ -1090,36 +1090,35 @@ void MenuBar::ImportUserDirBackup()
   switch (result)
   {
   case UICommon::ImportUserDirResult::Success:
-    ModalMessageBox::information(this, tr("Success"),
-                                 tr("Successfully imported Global User Directory."));
+    ModalMessageBox::information(this, tr("Success"), tr("Successfully imported User Directory."));
     break;
   case UICommon::ImportUserDirResult::ArchiveFileError:
     ModalMessageBox::critical(this, tr("Failure"),
-                              tr("Importing Global User Directory failed: The selected archive "
-                                 "could not be opened or is corrupt."));
+                              tr("Importing User Directory failed: The selected archive could not "
+                                 "be opened or is corrupt."));
     break;
   case UICommon::ImportUserDirResult::ArchiveDoesNotContainUserdir:
     ModalMessageBox::critical(this, tr("Failure"),
-                              tr("Importing Global User Directory failed: The selected archive "
-                                 "does not appear to contain a Global User Directory backup."));
+                              tr("Importing User Directory failed: The selected archive does not "
+                                 "appear to contain a User Directory backup."));
     break;
   case UICommon::ImportUserDirResult::OldUserdirDeleteError:
     ModalMessageBox::critical(
         this, tr("Failure"),
-        tr("Importing Global User Directory failed: Unable to delete the existing Global User "
-           "Directory. The directory may now be in an inconsistent state. It is recommended to "
-           "close Dolphin and manually delete the directory before continuing."));
+        tr("Importing User Directory failed: Unable to delete the existing User Directory. The "
+           "directory may now be in an inconsistent state. It is recommended to close Dolphin and "
+           "manually delete the directory before continuing."));
     break;
   case UICommon::ImportUserDirResult::ExtractError:
     ModalMessageBox::critical(
         this, tr("Failure"),
-        tr("Importing Global User Directory failed: Failed to extract archive. The archive may be "
-           "corrupt or there may not be enough disk space available. The directory may now be in "
-           "an inconsistent state. It is recommended to close Dolphin and manually delete the "
+        tr("Importing User Directory failed: Failed to extract archive. The archive may be corrupt "
+           "or there may not be enough disk space available. The directory may now be in an "
+           "inconsistent state. It is recommended to close Dolphin and manually delete the "
            "directory before continuing."));
     break;
   default:
-    ModalMessageBox::critical(this, tr("Failure"), tr("Importing Global User Directory failed."));
+    ModalMessageBox::critical(this, tr("Failure"), tr("Importing User Directory failed."));
     break;
   }
 }
@@ -1127,13 +1126,13 @@ void MenuBar::ImportUserDirBackup()
 void MenuBar::ExportUserDirBackup()
 {
   const QString path = DolphinFileDialog::getSaveFileName(
-      this, tr("Select storage location for Global User Directory backup"), QDir::currentPath(),
+      this, tr("Select storage location for User Directory backup"), QDir::currentPath(),
       QStringLiteral("%1 (*.zip);;%2 (*)").arg(tr("ZIP archive")).arg(tr("All Files")));
   if (path.isEmpty())
     return;
 
-  ParallelProgressDialog progress(tr("Exporting Global User Directory to %1...").arg(path),
-                                  tr("Cancel"), 0, 0, this);
+  ParallelProgressDialog progress(tr("Exporting User Directory to %1...").arg(path), tr("Cancel"),
+                                  0, 0, this);
   progress.GetRaw()->setWindowTitle(tr("Exporting"));
   progress.GetRaw()->setWindowModality(Qt::WindowModal);
 
@@ -1155,12 +1154,11 @@ void MenuBar::ExportUserDirBackup()
 
   if (success)
   {
-    ModalMessageBox::information(this, tr("Success"),
-                                 tr("Successfully exported Global User Directory."));
+    ModalMessageBox::information(this, tr("Success"), tr("Successfully exported User Directory."));
   }
   else
   {
-    ModalMessageBox::critical(this, tr("Failure"), tr("Exporting Global User Directory failed."));
+    ModalMessageBox::critical(this, tr("Failure"), tr("Exporting User Directory failed."));
   }
 }
 

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -209,6 +209,10 @@ private:
   QAction* m_import_backup;
   QAction* m_check_nand;
   QAction* m_extract_certificates;
+  QAction* m_import_wii_save;
+  QAction* m_export_wii_saves;
+  QAction* m_import_userdir;
+  QAction* m_export_userdir;
   std::array<QAction*, 5> m_wii_remotes;
 
   // Emulation

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -146,6 +146,7 @@ private:
   void AddJITMenu();
   void AddSymbolsMenu();
 
+  void ImportUserDirBackup();
   void ExportUserDirBackup();
 
   void UpdateStateSlotMenu();

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -146,6 +146,8 @@ private:
   void AddJITMenu();
   void AddSymbolsMenu();
 
+  void ExportUserDirBackup();
+
   void UpdateStateSlotMenu();
 
   void InstallWAD();

--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(uicommon
   GameFile.h
   GameFileCache.cpp
   GameFileCache.h
+  ImportExportUserdir.cpp
+  ImportExportUserdir.h
   NetPlayIndex.cpp
   NetPlayIndex.h
   ResourcePack/Manager.cpp

--- a/Source/Core/UICommon/ImportExportUserdir.cpp
+++ b/Source/Core/UICommon/ImportExportUserdir.cpp
@@ -1,0 +1,105 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "UICommon/ImportExportUserdir.h"
+
+#include <ctime>  // required by minizip includes
+#include <string>
+
+#include <mz_strm.h>
+#include <mz_strm_os.h>
+#include <mz_zip.h>
+#include <mz_zip_rw.h>
+
+#include "Common/Config/Config.h"
+#include "Common/FileUtil.h"
+#include "Common/Flag.h"
+#include "Common/MinizipUtil.h"
+#include "Common/ScopeGuard.h"
+
+namespace UICommon
+{
+static bool ExportUserDirRecursive(void** writer, const File::FSTEntry& file,
+                                   const std::string& root_path,
+                                   Common::Flag* cancel_requested_flag)
+{
+  if (cancel_requested_flag->IsSet())
+    return false;
+
+  if (file.isDirectory)
+  {
+    const auto dir = File::ScanDirectoryTree(file.physicalName, false);
+
+    // if the directory has no children we need to explicitly add it to the zip, otherwise it will
+    // get implicitly added by its children
+    if (!dir.children.empty())
+    {
+      for (const auto& child : dir.children)
+      {
+        if (!ExportUserDirRecursive(writer, child, root_path, cancel_requested_flag))
+          return false;
+      }
+      return true;
+    }
+  }
+
+  auto error_code =
+      mz_zip_writer_add_path(*writer, file.physicalName.c_str(), root_path.c_str(), 0, 0);
+  if (error_code != MZ_OK)
+    return false;
+
+  return true;
+}
+
+bool ExportUserDir(const std::string& archive_path, Common::Flag* cancel_requested_flag)
+{
+  // Make sure the current settings are saved to disk so they'll get packed up.
+  Config::Save();
+
+  const std::string& directory_path = File::GetUserPath(D_USER_IDX);
+
+  void* stream = nullptr;
+  mz_stream_os_create(&stream);
+  if (!stream)
+    return false;
+
+  Common::ScopeGuard delete_stream_guard([&stream] { mz_stream_os_delete(&stream); });
+
+  if (mz_stream_os_open(stream, archive_path.c_str(), MZ_OPEN_MODE_CREATE) != MZ_OK)
+    return false;
+
+  Common::ScopeGuard delete_zip_on_failure_guard([&archive_path] { File::Delete(archive_path); });
+  Common::ScopeGuard close_stream_guard([&stream] { mz_stream_os_close(stream); });
+
+  void* writer = nullptr;
+  mz_zip_writer_create(&writer);
+  if (!writer)
+    return false;
+
+  Common::ScopeGuard delete_writer_guard([&writer] { mz_zip_writer_delete(&writer); });
+
+  mz_zip_writer_set_compress_method(writer, Z_DEFLATED);
+  mz_zip_writer_set_compress_level(writer, MZ_COMPRESS_LEVEL_NORMAL);
+
+  if (mz_zip_writer_open(writer, stream, 0) != MZ_OK)
+    return false;
+
+  Common::ScopeGuard close_writer_guard([&writer] { mz_zip_writer_close(writer); });
+
+  const auto root = File::ScanDirectoryTree(directory_path, false);
+
+  for (const auto& file : root.children)
+  {
+    // Skip the Logs directory, it's not particularly useful to backup and likely contains a file
+    // that we're currently writing to.
+    if (file.isDirectory && Common::CaseInsensitiveEquals(file.virtualName, "Logs"))
+      continue;
+
+    if (!ExportUserDirRecursive(&writer, file, directory_path, cancel_requested_flag))
+      return false;
+  }
+
+  delete_zip_on_failure_guard.Dismiss();
+  return true;
+}
+}  // namespace UICommon

--- a/Source/Core/UICommon/ImportExportUserdir.h
+++ b/Source/Core/UICommon/ImportExportUserdir.h
@@ -12,5 +12,6 @@ class Flag;
 
 namespace UICommon
 {
+bool ImportUserDir(const std::string& archive_path);
 bool ExportUserDir(const std::string& archive_path, Common::Flag* cancel_requested_flag);
 }  // namespace UICommon

--- a/Source/Core/UICommon/ImportExportUserdir.h
+++ b/Source/Core/UICommon/ImportExportUserdir.h
@@ -12,6 +12,16 @@ class Flag;
 
 namespace UICommon
 {
-bool ImportUserDir(const std::string& archive_path);
+enum class ImportUserDirResult
+{
+  Success,
+  UnknownError,
+  ArchiveFileError,
+  ArchiveDoesNotContainUserdir,
+  OldUserdirDeleteError,
+  ExtractError,
+};
+
+ImportUserDirResult ImportUserDir(const std::string& archive_path);
 bool ExportUserDir(const std::string& archive_path, Common::Flag* cancel_requested_flag);
 }  // namespace UICommon

--- a/Source/Core/UICommon/ImportExportUserdir.h
+++ b/Source/Core/UICommon/ImportExportUserdir.h
@@ -1,0 +1,16 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+namespace Common
+{
+class Flag;
+}
+
+namespace UICommon
+{
+bool ExportUserDir(const std::string& archive_path, Common::Flag* cancel_requested_flag);
+}  // namespace UICommon


### PR DESCRIPTION
Announced back in #10526 and reminded of by #10708, here's the userdir exporting feature from Android but in Qt.

This runs into the same small problem as my settings reset where some GUI elements don't understand how to react to config changes of values that have previously never changed within a session. Otherwise this should 'just work'.

@JosJuice Please test if the zips generated here are compatible with the zips from Android and vice-versa. Maybe we can also get Android to use this code to avoid duplication in Java?