### PR TITLE
InputCommon/ControllerEmu: Use more locks

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -40,6 +40,8 @@ std::unique_lock<std::recursive_mutex> EmulatedController::GetStateLock()
 
 void EmulatedController::UpdateReferences(const ControllerInterface& devi)
 {
+  const auto lock = GetStateLock();
+
   m_default_device_is_connected = devi.HasConnectedDevice(m_default_device);
 
   ciface::ExpressionParser::ControlEnvironment env(devi, GetDefaultDevice(), m_expression_vars);
@@ -138,6 +140,7 @@ void EmulatedController::SetDefaultDevice(ciface::Core::DeviceQualifier devq)
 
 void EmulatedController::LoadConfig(IniFile::Section* sec, const std::string& base)
 {
+  const auto lock = GetStateLock();
   std::string defdev = GetDefaultDevice().ToString();
   if (base.empty())
   {
@@ -151,6 +154,7 @@ void EmulatedController::LoadConfig(IniFile::Section* sec, const std::string& ba
 
 void EmulatedController::SaveConfig(IniFile::Section* sec, const std::string& base)
 {
+  const auto lock = GetStateLock();
   const std::string defdev = GetDefaultDevice().ToString();
   if (base.empty())
     sec->Set(/*std::string(" ") +*/ base + "Device", defdev, "");
@@ -161,6 +165,7 @@ void EmulatedController::SaveConfig(IniFile::Section* sec, const std::string& ba
 
 void EmulatedController::LoadDefaults(const ControllerInterface& ciface)
 {
+  const auto lock = GetStateLock();
   // load an empty inifile section, clears everything
   IniFile::Section sec;
   LoadConfig(&sec);


### PR DESCRIPTION
Loading configs while another thread is messing with stuff just doesn't feel like a good idea.  It's hard to tell how much `LoadConfig` and `UpdateReferences` overlap in object usage, but it's definitely not zero because Thread Sanitizer keeps complaining about things.
Hopefully fixes Wiimote Scanning Thread crashes on startup (where main thread calls `LoadConfig` while wiimote scanning thread is in `UpdateReferences`)