### PR TITLE
boot from Default ISO if set when executing dol/elf

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -372,7 +372,7 @@ bool CBoot::SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type)
   values in this region will also be placed here by the game as it boots.
   They are:
   0x80000038  Start of FST
-  0x8000003c  Size of FST Size
+  0x8000003c  Size of FST
   0x80000060  Copyright code
   */
 

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -1087,7 +1087,7 @@ void DirectoryBlobPartition::BuildFST(std::vector<FSTBuilderNode> root_nodes, u6
   // overflow check, compare the aligned name offset with the aligned name table size
   ASSERT(Common::AlignUp(name_offset, 1ull << m_address_shift) == name_table_size);
 
-  // write FST size and location
+  // write FST location, size and max size
   Write32((u32)(fst_address >> m_address_shift), 0x0424, &m_disc_header);
   Write32((u32)(m_fst_data.size() >> m_address_shift), 0x0428, &m_disc_header);
   Write32((u32)(m_fst_data.size() >> m_address_shift), 0x042c, &m_disc_header);


### PR DESCRIPTION
This enables running dol from arbitrary (out-of-disc) path.
Does not work for elf - it would need to convert to dol and
expose the result via the DirectoryBlob object.