### PR TITLE
DSPSpy: Fix incomplete result dumps

### DIFF
--- a/Source/DSPSpy/main_spy.cpp
+++ b/Source/DSPSpy/main_spy.cpp
@@ -474,11 +474,13 @@ void dump_all_ucodes(bool fastmode)
 
     real_dsp.Reset();
 
-    VIDEO_WaitVSync();
     // Loop over handling mail until we've stopped stepping
     // dsp_steps-3 compensates for mails to setup the ucode
     for (int steps_cache = dsp_steps - 3; steps_cache <= dsp_steps; steps_cache++)
+    {
+      VIDEO_WaitVSync();
       handle_dsp_mail();
+    }
     VIDEO_WaitVSync();
 
     sprintf(filename, "sd:/dsp_dump_all.bin");


### PR DESCRIPTION
The current code expects new mail almost immediately after the last map was sent for it to be saved properly. However, I have a test program that ends up looping for 32768 iterations before it sends more mail; this resulted in an incomplete result dump. I've changed it to wait a frame between checking for mail, which solves that issue. This does slow down dumping, but the end speed matches the speed at which the UI updates the registers so this isn't a big deal (the UI waits a frame between mail normally). (Theoretically, it could take even longer for dumping to finish, so this is not a perfect solution. However, for tests that take that long to run, it would be better to save the existing results instead of re-running the test and saving that; that'd be something to do with later improvements.)