### PR TITLE
qt: unregister Settings' DevicesChanged callback during shutdown

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -360,6 +360,8 @@ void MainWindow::ShutdownControllers()
 {
   m_hotkey_scheduler->Stop();
 
+  Settings::Instance().UnregisterDevicesChangedCallback();
+
   Pad::Shutdown();
   Pad::ShutdownGBA();
   Keyboard::Shutdown();

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -69,7 +69,7 @@ Settings::Settings()
     }
   });
 
-  g_controller_interface.RegisterDevicesChangedCallback([this] {
+  m_hotplug_callback_handle = g_controller_interface.RegisterDevicesChangedCallback([this] {
     if (Host::GetInstance()->IsHostThread())
     {
       emit DevicesChanged();
@@ -89,6 +89,11 @@ Settings::Settings()
 }
 
 Settings::~Settings() = default;
+
+void Settings::UnregisterDevicesChangedCallback()
+{
+  g_controller_interface.UnregisterDevicesChangedCallback(m_hotplug_callback_handle);
+}
 
 Settings& Settings::Instance()
 {

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -12,6 +12,7 @@
 
 #include "Core/Config/MainSettings.h"
 #include "DiscIO/Enums.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 namespace Core
 {
@@ -43,6 +44,8 @@ public:
   Settings& operator=(Settings&&) = delete;
 
   ~Settings();
+
+  void UnregisterDevicesChangedCallback();
 
   static Settings& Instance();
   static QSettings& GetQSettings();
@@ -199,10 +202,12 @@ signals:
   void USBKeyboardConnectionChanged(bool connected);
 
 private:
+  Settings();
+
   bool m_batch = false;
   std::shared_ptr<NetPlay::NetPlayClient> m_client;
   std::shared_ptr<NetPlay::NetPlayServer> m_server;
-  Settings();
+  ControllerInterface::HotplugCallbackHandle m_hotplug_callback_handle;
 };
 
 Q_DECLARE_METATYPE(Core::State);


### PR DESCRIPTION
fixes a crash on close
fixes 12924