### PR TITLE
Add Integer Scaling and Internal aspect ratio

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -20,6 +20,7 @@ const Info<int> GFX_ADAPTER{{System::GFX, "Hardware", "Adapter"}, 0};
 // Graphics.Settings
 
 const Info<bool> GFX_WIDESCREEN_HACK{{System::GFX, "Settings", "wideScreenHack"}, false};
+const Info<bool> GFX_INTEGER_SCALING{{System::GFX, "Settings", "IntegerScaling"}, false};
 const Info<AspectMode> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"}, AspectMode::Auto};
 const Info<AspectMode> GFX_SUGGESTED_ASPECT_RATIO{{System::GFX, "Settings", "SuggestedAspectRatio"},
                                                   AspectMode::Auto};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -24,6 +24,7 @@ extern const Info<int> GFX_ADAPTER;
 // Graphics.Settings
 
 extern const Info<bool> GFX_WIDESCREEN_HACK;
+extern const Info<bool> GFX_INTEGER_SCALING;
 extern const Info<AspectMode> GFX_ASPECT_RATIO;
 extern const Info<AspectMode> GFX_SUGGESTED_ASPECT_RATIO;
 extern const Info<bool> GFX_CROP;

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -55,12 +55,13 @@ void GeneralWidget::CreateWidgets()
   m_video_layout = new QGridLayout();
 
   m_backend_combo = new ToolTipComboBox();
-  m_aspect_combo =
-      new GraphicsChoice({tr("Auto"), tr("Force 16:9"), tr("Force 4:3"), tr("Stretch to Window")},
-                         Config::GFX_ASPECT_RATIO);
+  m_aspect_combo = new GraphicsChoice(
+      {tr("Auto"), tr("Force 16:9"), tr("Force 4:3"), tr("Internal"), tr("Stretch to Window")},
+      Config::GFX_ASPECT_RATIO);
   m_adapter_combo = new ToolTipComboBox;
   m_enable_vsync = new GraphicsBool(tr("V-Sync"), Config::GFX_VSYNC);
   m_enable_fullscreen = new GraphicsBool(tr("Start in Fullscreen"), Config::MAIN_FULLSCREEN);
+  m_enable_integer_scaling = new GraphicsBool(tr("Integer Scaling"), Config::GFX_INTEGER_SCALING);
 
   m_video_box->setLayout(m_video_layout);
 
@@ -81,6 +82,8 @@ void GeneralWidget::CreateWidgets()
 
   m_video_layout->addWidget(m_enable_vsync, 4, 0);
   m_video_layout->addWidget(m_enable_fullscreen, 4, 1);
+
+  m_video_layout->addWidget(m_enable_integer_scaling, 5, 0);
 
   // Other
   auto* m_options_box = new QGroupBox(tr("Other"));

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -47,6 +47,7 @@ private:
   GraphicsChoice* m_aspect_combo;
   GraphicsBool* m_enable_vsync;
   GraphicsBool* m_enable_fullscreen;
+  GraphicsBool* m_enable_integer_scaling;
 
   // Options
   GraphicsBool* m_show_fps;

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -403,6 +403,9 @@ void HotkeyScheduler::Run()
         case AspectMode::AnalogWide:
           OSD::AddMessage("Force 16:9");
           break;
+        case AspectMode::Internal:
+          OSD::AddMessage("Internal");
+          break;
         case AspectMode::Auto:
         default:
           OSD::AddMessage("Auto");

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -57,6 +57,7 @@ void VideoConfig::Refresh()
   iAdapter = Config::Get(Config::GFX_ADAPTER);
 
   bWidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
+  bIntegerScaling = Config::Get(Config::GFX_INTEGER_SCALING);
   aspect_mode = Config::Get(Config::GFX_ASPECT_RATIO);
   suggested_aspect_mode = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
   bCrop = Config::Get(Config::GFX_CROP);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -28,6 +28,7 @@ enum class AspectMode : int
   Auto,
   AnalogWide,
   Analog,
+  Internal,
   Stretch,
 };
 
@@ -60,6 +61,7 @@ struct VideoConfig final
   bool bVSync = false;
   bool bVSyncActive = false;
   bool bWidescreenHack = false;
+  bool bIntegerScaling = false;
   AspectMode aspect_mode{};
   AspectMode suggested_aspect_mode{};
   bool bCrop = false;  // Aspect ratio controls.


### PR DESCRIPTION
Feature request: https://bugs.dolphin-emu.org/issues/12725#change-744169  
I wanted to try this and give reference for further discussion on this feature.

Added integer scaling checkbox, which sets the render size to a multiple of the xfb size. Auto-calculates based on window size. Black bars will fill empty space on all sides.
Added internal aspect ratio option, which calculates the aspect ratio from the xfb.  I added it as an experiment, to see if anyone would like it. Black bars only appear on two sides with this option and it keeps the image proportional to the xfb.

First time working in this area of code, so may have missed some things, but seemed easy enough to implement the basics. Should get some people looking for this feature to test and make sure the results are what they want.