### PR TITLE
Fix warnings on generic builder

### DIFF
--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -584,7 +584,6 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
             }
           }
           break;
-
         case P_ACCL:
           if ((int)par[i].val < DSP_REG_ACL0 || (int)par[i].val > DSP_REG_ACL1)
           {
@@ -601,6 +600,8 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
               ShowError(AssemblerError::WrongParameterExpectedAccumulator);
             }
           }
+          break;
+        default:
           break;
         }
         continue;

--- a/Source/UnitTests/Core/IOS/FS/FileSystemTest.cpp
+++ b/Source/UnitTests/Core/IOS/FS/FileSystemTest.cpp
@@ -93,7 +93,7 @@ TEST(FileSystem, PathSplitting)
 
 TEST_F(FileSystemTest, EssentialDirectories)
 {
-  for (const std::string& path :
+  for (const std::string path :
        {"/sys", "/ticket", "/title", "/shared1", "/shared2", "/tmp", "/import", "/meta"})
   {
     EXPECT_TRUE(m_fs->ReadDirectory(Uid{0}, Gid{0}, path).Succeeded()) << path;
@@ -457,7 +457,7 @@ TEST_F(FileSystemTest, CreateFullPath)
   ASSERT_EQ(m_fs->CreateFullPath(Uid{0}, Gid{0}, "/tmp/a/b/c/d", 0, modes), ResultCode::Success);
 
   // Parent directories should be created by CreateFullPath.
-  for (const std::string& path : {"/tmp", "/tmp/a", "/tmp/a/b", "/tmp/a/b/c"})
+  for (const std::string path : {"/tmp", "/tmp/a", "/tmp/a/b", "/tmp/a/b/c"})
     EXPECT_TRUE(m_fs->ReadDirectory(Uid{0}, Gid{0}, path).Succeeded());
 
   // If parent directories already exist, the call should still succeed.


### PR DESCRIPTION
Now that the nightly-generic builder is working it uncovered a couple warnings I haven't seen from the other builders.

The other warnings it gave are covered by #10624.