### PR TITLE
AndroidManifest.xml: Re-add package="org.dolphinemu.dolphinemu"

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.dolphinemu.dolphinemu">
 
     <uses-feature
         android:name="android.hardware.touchscreen"


### PR DESCRIPTION
Without this, debug builds of Dolphin fail to launch. The OS tries to locate org.dolphinemu.dolphinemu.debug.DolphinApplication but fails to find it because its actual name is org.dolphinemu.dolphinemu.DolphinApplication.

Partially reverts PR #10649.