### PR TITLE
Remove .vcxproj.user files

### DIFF
--- a/Languages/Languages.vcxproj.user
+++ b/Languages/Languages.vcxproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ShowAllFiles>true</ShowAllFiles>
-  </PropertyGroup>
-</Project>

--- a/Source/Core/DolphinLib.vcxproj.user
+++ b/Source/Core/DolphinLib.vcxproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ShowAllFiles>true</ShowAllFiles>
-  </PropertyGroup>
-</Project>

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj.user
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj.user
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <LocalDebuggerCommand>$(BinaryOutputDir)$(TargetFileName)</LocalDebuggerCommand>
-    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <ShowAllFiles>true</ShowAllFiles>
-  </PropertyGroup>
-</Project>

--- a/Source/UnitTests/UnitTests.vcxproj.user
+++ b/Source/UnitTests/UnitTests.vcxproj.user
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <!--For some stupid reason this has to be in the .user file...-->
-    <!--This is only used to allow UnitTests to find OpenAL DLL...kinda hacky-->
-    <LocalDebuggerWorkingDirectory>$(BinaryOutputDir)</LocalDebuggerWorkingDirectory>
-    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
`*.vcxproj.user` files are (rightfully) covered by our .gitignore, but some files are still present in the tree. This might depend on #8924 if I understand the UnitTests one correctly, although I'm sure we can find a way to move that setting into the regular .vcxproj file, and if we can't, that's an issue we should report to microsoft.