### PR TITLE
Riivolution: Add custom extension to patch boot.bin, bi2.bin, and apploader.img.

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -701,7 +701,8 @@ void AddRiivolutionPatches(BootParameters* boot_params,
   disc.volume = DiscIO::CreateDisc(DiscIO::DirectoryBlobReader::Create(
       std::move(disc.volume),
       [&](std::vector<DiscIO::FSTBuilderNode>* fst, DiscIO::FSTBuilderNode* dol_node) {
-        DiscIO::Riivolution::ApplyPatchesToFiles(riivolution_patches, fst, dol_node);
+        DiscIO::Riivolution::ApplyPatchesToFiles(
+            riivolution_patches, DiscIO::Riivolution::PatchIndex::FileSystem, fst, dol_node);
       }));
   boot_params->riivolution_patches = std::move(riivolution_patches);
 }

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -700,6 +700,10 @@ void AddRiivolutionPatches(BootParameters* boot_params,
   auto& disc = std::get<BootParameters::Disc>(boot_params->parameters);
   disc.volume = DiscIO::CreateDisc(DiscIO::DirectoryBlobReader::Create(
       std::move(disc.volume),
+      [&](std::vector<DiscIO::FSTBuilderNode>* fst) {
+        DiscIO::Riivolution::ApplyPatchesToFiles(
+            riivolution_patches, DiscIO::Riivolution::PatchIndex::DolphinSysFiles, fst, nullptr);
+      },
       [&](std::vector<DiscIO::FSTBuilderNode>* fst, DiscIO::FSTBuilderNode* dol_node) {
         DiscIO::Riivolution::ApplyPatchesToFiles(
             riivolution_patches, DiscIO::Riivolution::PatchIndex::FileSystem, fst, dol_node);

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -134,6 +134,12 @@ bool DiscContent::Read(u64* offset, u64* length, u8** buffer) const
       const ContentFixedByte& source = std::get<ContentFixedByte>(m_content_source);
       std::fill_n(*buffer, bytes_to_read, source.m_byte);
     }
+    else if (std::holds_alternative<ContentByteVector>(m_content_source))
+    {
+      const ContentByteVector& source = std::get<ContentByteVector>(m_content_source);
+      std::copy(source.m_bytes.begin() + offset_in_content,
+                source.m_bytes.begin() + offset_in_content + bytes_to_read, *buffer);
+    }
     else
     {
       PanicAlertFmt("DirectoryBlob: Invalid content source in DiscContent.");

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -362,6 +362,7 @@ std::unique_ptr<DirectoryBlobReader> DirectoryBlobReader::Create(const std::stri
 
 std::unique_ptr<DirectoryBlobReader> DirectoryBlobReader::Create(
     std::unique_ptr<DiscIO::VolumeDisc> volume,
+    const std::function<void(std::vector<FSTBuilderNode>* fst_nodes)>& sys_callback,
     const std::function<void(std::vector<FSTBuilderNode>* fst_nodes, FSTBuilderNode* dol_node)>&
         fst_callback)
 {
@@ -369,7 +370,7 @@ std::unique_ptr<DirectoryBlobReader> DirectoryBlobReader::Create(
     return nullptr;
 
   return std::unique_ptr<DirectoryBlobReader>(
-      new DirectoryBlobReader(std::move(volume), fst_callback));
+      new DirectoryBlobReader(std::move(volume), sys_callback, fst_callback));
 }
 
 DirectoryBlobReader::DirectoryBlobReader(const std::string& game_partition_root,
@@ -418,12 +419,14 @@ DirectoryBlobReader::DirectoryBlobReader(const std::string& game_partition_root,
 
 DirectoryBlobReader::DirectoryBlobReader(
     std::unique_ptr<DiscIO::VolumeDisc> volume,
+    const std::function<void(std::vector<FSTBuilderNode>* fst_nodes)>& sys_callback,
     const std::function<void(std::vector<FSTBuilderNode>* fst_nodes, FSTBuilderNode* dol_node)>&
         fst_callback)
     : m_encryption_cache(this), m_wrapped_volume(std::move(volume))
 {
-  DirectoryBlobPartition game_partition(
-      m_wrapped_volume.get(), m_wrapped_volume->GetGamePartition(), std::nullopt, fst_callback);
+  DirectoryBlobPartition game_partition(m_wrapped_volume.get(),
+                                        m_wrapped_volume->GetGamePartition(), std::nullopt,
+                                        sys_callback, fst_callback);
   m_is_wii = game_partition.IsWii();
 
   if (!m_is_wii)
@@ -463,7 +466,7 @@ DirectoryBlobReader::DirectoryBlobReader(
       if (type)
       {
         partitions.emplace_back(
-            DirectoryBlobPartition(m_wrapped_volume.get(), partition, m_is_wii, nullptr),
+            DirectoryBlobPartition(m_wrapped_volume.get(), partition, m_is_wii, nullptr, nullptr),
             static_cast<PartitionType>(*type));
       }
     }
@@ -820,32 +823,80 @@ DirectoryBlobPartition::DirectoryBlobPartition(const std::string& root_directory
   BuildFSTFromFolder(m_root_directory + "files/", fst_address);
 }
 
+static void FillSingleFileNode(FSTBuilderNode* node, std::vector<u8> data)
+{
+  std::vector<BuilderContentSource> contents;
+  const size_t size = data.size();
+  contents.emplace_back(BuilderContentSource{0, size, ContentByteVector{std::move(data)}});
+  node->m_size = size;
+  node->m_content = std::move(contents);
+}
+
+static FSTBuilderNode BuildSingleFileNode(std::string filename, std::vector<u8> data,
+                                          void* userdata)
+{
+  FSTBuilderNode node{std::move(filename), 0, {}, userdata};
+  FillSingleFileNode(&node, std::move(data));
+  return node;
+}
+
+static std::vector<u8> ExtractNodeToVector(std::vector<FSTBuilderNode>* nodes, void* userdata)
+{
+  std::vector<u8> data;
+  const auto it =
+      std::find_if(nodes->begin(), nodes->end(), [&userdata](const FSTBuilderNode& node) {
+        return node.m_user_data == userdata;
+      });
+  if (it == nodes->end() || !it->IsFile())
+    return data;
+
+  DiscContentContainer tmp;
+  for (auto& content : it->GetFileContent())
+    tmp.Add(content.m_offset, content.m_size, std::move(content.m_source));
+  data.resize(it->m_size);
+  tmp.Read(0, it->m_size, data.data());
+  return data;
+}
+
 DirectoryBlobPartition::DirectoryBlobPartition(
     DiscIO::VolumeDisc* volume, const DiscIO::Partition& partition, std::optional<bool> is_wii,
+    const std::function<void(std::vector<FSTBuilderNode>* fst_nodes)>& sys_callback,
     const std::function<void(std::vector<FSTBuilderNode>* fst_nodes, FSTBuilderNode* dol_node)>&
         fst_callback)
     : m_wrapped_partition(partition)
 {
+  std::vector<FSTBuilderNode> sys_nodes;
+
   std::vector<u8> disc_header(DISCHEADER_SIZE);
   if (!volume->Read(DISCHEADER_ADDRESS, DISCHEADER_SIZE, disc_header.data(), partition))
     disc_header.clear();
-  SetDiscHeader(std::move(disc_header));
-  SetDiscType(is_wii);
+  sys_nodes.emplace_back(BuildSingleFileNode("boot.bin", std::move(disc_header), &m_disc_header));
 
   std::vector<u8> bi2(BI2_SIZE);
   if (!volume->Read(BI2_ADDRESS, BI2_SIZE, bi2.data(), partition))
     bi2.clear();
-  SetBI2(std::move(bi2));
+  sys_nodes.emplace_back(BuildSingleFileNode("bi2.bin", std::move(bi2), &m_bi2));
 
   std::vector<u8> apploader;
   const auto apploader_size = GetApploaderSize(*volume, partition);
+  auto& apploader_node =
+      sys_nodes.emplace_back(FSTBuilderNode{"apploader.img", 0, {}, &m_apploader});
   if (apploader_size)
   {
     apploader.resize(*apploader_size);
     if (!volume->Read(APPLOADER_ADDRESS, *apploader_size, apploader.data(), partition))
       apploader.clear();
+    FillSingleFileNode(&apploader_node, std::move(apploader));
   }
-  const u64 new_dol_address = SetApploader(apploader, "apploader");
+
+  if (sys_callback)
+    sys_callback(&sys_nodes);
+
+  SetDiscHeader(ExtractNodeToVector(&sys_nodes, &m_disc_header));
+  SetDiscType(is_wii);
+  SetBI2(ExtractNodeToVector(&sys_nodes, &m_bi2));
+  const u64 new_dol_address =
+      SetApploader(ExtractNodeToVector(&sys_nodes, &m_apploader), "apploader");
 
   FSTBuilderNode dol_node{"main.dol", 0, {}};
   const auto dol_offset = GetBootDOLOffset(*volume, partition);

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -80,11 +80,18 @@ struct ContentFixedByte
   u8 m_byte;
 };
 
+// Content chunk representing an arbitrary byte sequence that's stored within the struct itself.
+struct ContentByteVector
+{
+  std::vector<u8> m_bytes;
+};
+
 using ContentSource = std::variant<ContentFile,       // File
                                    const u8*,         // Memory
                                    ContentPartition,  // Partition
                                    ContentVolume,     // Volume
-                                   ContentFixedByte   // Fixed value padding
+                                   ContentFixedByte,  // Fixed value padding
+                                   ContentByteVector  // Byte sequence
                                    >;
 
 struct BuilderContentSource

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -190,10 +190,11 @@ class DirectoryBlobPartition
 public:
   DirectoryBlobPartition() = default;
   DirectoryBlobPartition(const std::string& root_directory, std::optional<bool> is_wii);
-  DirectoryBlobPartition(DiscIO::VolumeDisc* volume, const DiscIO::Partition& partition,
-                         std::optional<bool> is_wii,
-                         const std::function<void(std::vector<FSTBuilderNode>* fst_nodes,
-                                                  FSTBuilderNode* dol_node)>& fst_callback);
+  DirectoryBlobPartition(
+      DiscIO::VolumeDisc* volume, const DiscIO::Partition& partition, std::optional<bool> is_wii,
+      const std::function<void(std::vector<FSTBuilderNode>* fst_nodes)>& sys_callback,
+      const std::function<void(std::vector<FSTBuilderNode>* fst_nodes, FSTBuilderNode* dol_node)>&
+          fst_callback);
 
   // We do not allow copying, because it might mess up the pointers inside DiscContents
   DirectoryBlobPartition(const DirectoryBlobPartition&) = delete;
@@ -265,6 +266,7 @@ public:
   static std::unique_ptr<DirectoryBlobReader> Create(const std::string& dol_path);
   static std::unique_ptr<DirectoryBlobReader> Create(
       std::unique_ptr<DiscIO::VolumeDisc> volume,
+      const std::function<void(std::vector<FSTBuilderNode>* fst_nodes)>& sys_callback,
       const std::function<void(std::vector<FSTBuilderNode>* fst_nodes, FSTBuilderNode* dol_node)>&
           fst_callback);
 
@@ -303,9 +305,11 @@ private:
 
   explicit DirectoryBlobReader(const std::string& game_partition_root,
                                const std::string& true_root);
-  explicit DirectoryBlobReader(std::unique_ptr<DiscIO::VolumeDisc> volume,
-                               const std::function<void(std::vector<FSTBuilderNode>* fst_nodes,
-                                                        FSTBuilderNode* dol_node)>& fst_callback);
+  explicit DirectoryBlobReader(
+      std::unique_ptr<DiscIO::VolumeDisc> volume,
+      const std::function<void(std::vector<FSTBuilderNode>* fst_nodes)>& sys_callback,
+      const std::function<void(std::vector<FSTBuilderNode>* fst_nodes, FSTBuilderNode* dol_node)>&
+          fst_callback);
 
   const DirectoryBlobPartition* GetPartition(u64 offset, u64 size, u64 partition_data_offset) const;
 

--- a/Source/Core/DiscIO/RiivolutionParser.cpp
+++ b/Source/Core/DiscIO/RiivolutionParser.cpp
@@ -172,9 +172,10 @@ std::optional<Disc> ParseString(std::string_view xml, std::string xml_path)
     for (const auto& patch_subnode : patch_node.children())
     {
       const std::string_view patch_name(patch_subnode.name());
-      if (patch_name == "file")
+      if (patch_name == "file" || patch_name == "dolphin_sys_file")
       {
-        auto& file = patch.m_file_patches.emplace_back();
+        auto& file = patch_name == "dolphin_sys_file" ? patch.m_sys_file_patches.emplace_back() :
+                                                        patch.m_file_patches.emplace_back();
         file.m_disc = patch_subnode.attribute("disc").as_string();
         file.m_external = patch_subnode.attribute("external").as_string();
         file.m_resize = patch_subnode.attribute("resize").as_bool(true);
@@ -183,9 +184,11 @@ std::optional<Disc> ParseString(std::string_view xml, std::string xml_path)
         file.m_fileoffset = patch_subnode.attribute("fileoffset").as_uint(0);
         file.m_length = patch_subnode.attribute("length").as_uint(0);
       }
-      else if (patch_name == "folder")
+      else if (patch_name == "folder" || patch_name == "dolphin_sys_folder")
       {
-        auto& folder = patch.m_folder_patches.emplace_back();
+        auto& folder = patch_name == "dolphin_sys_folder" ?
+                           patch.m_sys_folder_patches.emplace_back() :
+                           patch.m_folder_patches.emplace_back();
         folder.m_disc = patch_subnode.attribute("disc").as_string();
         folder.m_external = patch_subnode.attribute("external").as_string();
         folder.m_resize = patch_subnode.attribute("resize").as_bool(true);

--- a/Source/Core/DiscIO/RiivolutionParser.h
+++ b/Source/Core/DiscIO/RiivolutionParser.h
@@ -166,6 +166,8 @@ struct Patch
 
   std::vector<File> m_file_patches;
   std::vector<Folder> m_folder_patches;
+  std::vector<File> m_sys_file_patches;
+  std::vector<Folder> m_sys_folder_patches;
   std::vector<Savegame> m_savegame_patches;
   std::vector<Memory> m_memory_patches;
 

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -458,15 +458,20 @@ static void ApplyFolderPatchToFST(const Patch& patch, const Folder& folder,
   ApplyFolderPatchToFST(patch, folder, fst, dol_node, folder.m_disc, folder.m_external);
 }
 
-void ApplyPatchesToFiles(const std::vector<Patch>& patches,
+void ApplyPatchesToFiles(const std::vector<Patch>& patches, PatchIndex index,
                          std::vector<DiscIO::FSTBuilderNode>* fst, DiscIO::FSTBuilderNode* dol_node)
 {
   for (const auto& patch : patches)
   {
-    for (const auto& file : patch.m_file_patches)
+    const auto& file_patches =
+        index == PatchIndex::DolphinSysFiles ? patch.m_sys_file_patches : patch.m_file_patches;
+    const auto& folder_patches =
+        index == PatchIndex::DolphinSysFiles ? patch.m_sys_folder_patches : patch.m_folder_patches;
+
+    for (const auto& file : file_patches)
       ApplyFilePatchToFST(patch, file, fst, dol_node);
 
-    for (const auto& folder : patch.m_folder_patches)
+    for (const auto& folder : folder_patches)
       ApplyFolderPatchToFST(patch, folder, fst, dol_node);
   }
 }

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -397,7 +397,7 @@ static void ApplyFilePatchToFST(const Patch& patch, const File& file,
     if (node)
       ApplyPatchToFile(patch, file, node);
   }
-  else if (CaseInsensitiveEquals(file.m_disc, "main.dol"))
+  else if (dol_node && CaseInsensitiveEquals(file.m_disc, "main.dol"))
   {
     // Special case: If the filename is "main.dol", we want to patch the main executable.
     ApplyPatchToFile(patch, file, dol_node);

--- a/Source/Core/DiscIO/RiivolutionPatcher.h
+++ b/Source/Core/DiscIO/RiivolutionPatcher.h
@@ -65,7 +65,13 @@ private:
   std::string m_patch_root;
 };
 
-void ApplyPatchesToFiles(const std::vector<Patch>& patches,
+enum class PatchIndex
+{
+  FileSystem,
+  DolphinSysFiles,
+};
+
+void ApplyPatchesToFiles(const std::vector<Patch>& patches, PatchIndex index,
                          std::vector<DiscIO::FSTBuilderNode>* fst,
                          DiscIO::FSTBuilderNode* dol_node);
 void ApplyGeneralMemoryPatches(const std::vector<Patch>& patches);


### PR DESCRIPTION
As far as I can tell, Riivolution cannot do this on console (probably because it's not very useful on Wii games?). So here's a custom extension for it.

These work exactly like the `file` and `folder` patch commands but use `dolphin_sys_file` and `dolphin_sys_folder` instead, so eg:

```
<dolphin_sys_file external="bi2.bin" disc="/bi2.bin" />
```

If you have other suggestions for how to do this, feel free, but I think this is a fairly straightforward solution to the problem.

(Implements a request from https://forums.dolphin-emu.org/Thread-riivolution-replace-main-dol)