### PR TITLE
Be more clear on formatting styles for single-line conditionals.

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -116,7 +116,7 @@ Summary:
       // code
     }
     ```
-  - Acceptable:
+  - No:
 
     ```c++
     if (condition)
@@ -124,7 +124,7 @@ Summary:
     else
       // code line
     ```
-  - No:
+  - Definitely no:
 
     ```c++
     if (condition)


### PR DESCRIPTION
Right now in Contributing.md we are inconsistent with our formatting styles for single-line conditionals. While I personally think  having braces merges better with Dolphin's codebase and C++ style, we should be consistent whatever we decide in the end. Depending on what we decide, I or someone else can make a PR updating our codebase to account for that.