### PR TITLE
Have audio dumps apply volume

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -256,17 +256,25 @@ void Mixer::MixerFifo::PushSamples(const short* samples, unsigned int num_sample
 void Mixer::PushSamples(const short* samples, unsigned int num_samples)
 {
   m_dma_mixer.PushSamples(samples, num_samples);
-  int sample_rate = m_dma_mixer.GetInputSampleRate();
   if (m_log_dsp_audio)
-    m_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples, sample_rate);
+  {
+    int sample_rate = m_dma_mixer.GetInputSampleRate();
+    auto volume = m_dma_mixer.GetVolume();
+    m_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples, sample_rate, volume.first,
+                                         volume.second);
+  }
 }
 
 void Mixer::PushStreamingSamples(const short* samples, unsigned int num_samples)
 {
   m_streaming_mixer.PushSamples(samples, num_samples);
-  int sample_rate = m_streaming_mixer.GetInputSampleRate();
   if (m_log_dtk_audio)
-    m_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples, sample_rate);
+  {
+    int sample_rate = m_streaming_mixer.GetInputSampleRate();
+    auto volume = m_streaming_mixer.GetVolume();
+    m_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples, sample_rate, volume.first,
+                                         volume.second);
+  }
 }
 
 void Mixer::PushWiimoteSpeakerSamples(const short* samples, unsigned int num_samples,
@@ -425,6 +433,11 @@ void Mixer::MixerFifo::SetVolume(unsigned int lvolume, unsigned int rvolume)
 {
   m_LVolume.store(lvolume + (lvolume >> 7));
   m_RVolume.store(rvolume + (rvolume >> 7));
+}
+
+std::pair<s32, s32> Mixer::MixerFifo::GetVolume() const
+{
+  return std::make_pair(m_LVolume.load(), m_RVolume.load());
 }
 
 unsigned int Mixer::MixerFifo::AvailableSamples() const

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -74,6 +74,7 @@ private:
     void SetInputSampleRate(unsigned int rate);
     unsigned int GetInputSampleRate() const;
     void SetVolume(unsigned int lvolume, unsigned int rvolume);
+    std::pair<s32, s32> GetVolume() const;
     unsigned int AvailableSamples() const;
 
   private:

--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -114,7 +114,8 @@ void WaveFileWriter::Write4(const char* ptr)
   file.WriteBytes(ptr, 4);
 }
 
-void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count, int sample_rate)
+void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count, int sample_rate,
+                                        int l_volume, int r_volume)
 {
   if (!file)
     ERROR_LOG_FMT(AUDIO, "WaveFileWriter - file not open.");
@@ -141,6 +142,10 @@ void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count, int
     // Flip the audio channels from RL to LR
     conv_buffer[2 * i] = Common::swap16((u16)sample_data[2 * i + 1]);
     conv_buffer[2 * i + 1] = Common::swap16((u16)sample_data[2 * i]);
+
+    // Apply volume (volume ranges from 0 to 256)
+    conv_buffer[2 * i] = conv_buffer[2 * i] * l_volume / 256;
+    conv_buffer[2 * i + 1] = conv_buffer[2 * i + 1] * r_volume / 256;
   }
 
   if (sample_rate != current_sample_rate)

--- a/Source/Core/AudioCommon/WaveFile.h
+++ b/Source/Core/AudioCommon/WaveFile.h
@@ -34,7 +34,8 @@ public:
   void Stop();
 
   void SetSkipSilence(bool skip) { skip_silence = skip; }
-  void AddStereoSamplesBE(const short* sample_data, u32 count, int sample_rate);  // big endian
+  void AddStereoSamplesBE(const short* sample_data, u32 count, int sample_rate, int l_volume,
+                          int r_volume);  // big endian
   u32 GetAudioSize() const { return audio_size; }
 
 private:


### PR DESCRIPTION
Fixes cases of audio dumps being "too loud" and in game audio controls having no effect within the dump.

See [Issue 12945](https://bugs.dolphin-emu.org/issues/12945)