### PR TITLE
Add Medium Texture Cache setting to Ultimate Shooting Collection INI.

### DIFF
--- a/Data/Sys/GameSettings/RKA.ini
+++ b/Data/Sys/GameSettings/RKA.ini
@@ -1,4 +1,18 @@
 # RKAE6K, RKAJMS, RKAK8M, RKAP6K - Ultimate Shooting Collection
 
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
 [Video_Settings]
 SuggestedAspectRatio = 2
+SafeTextureCacheColorSamples = 512
+


### PR DESCRIPTION
Ultimate Shooting Collection needs Medium Texture Cache for some text to render correctly.