### PR TITLE
Increase audio buffer size to 32768 samples (1024 ms)

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -231,6 +231,13 @@ void Mixer::MixerFifo::PushSamples(const short* samples, unsigned int num_sample
   // needs to get updates to not deadlock.
   u32 indexW = m_indexW.load();
 
+  // The game is trying to supply too many samples; we'll *never* have enough free space for it.
+  if (num_samples >= MAX_SAMPLES)
+  {
+    ERROR_LOG_FMT(AUDIO, "Game is trying to supply {} samples, but we can only store {}",
+                  num_samples, MAX_SAMPLES);
+  }
+
   // Check if we have enough free space
   // indexW == m_indexR results in empty buffer, so indexR must always be smaller than indexW
   if (num_samples * 2 + ((indexW - m_indexR.load()) & INDEX_MASK) >= MAX_SAMPLES * 2)

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -52,7 +52,11 @@ public:
   void UpdateSpeed(float val) { m_speed.store(val); }
 
 private:
-  static constexpr u32 MAX_SAMPLES = 1024 * 4;  // 128 ms
+  // Datel titles supply a large number of samples at a time (pressing B in a menu in Action Replay
+  // Max uses 14624 samples at a time, and MaxPlay uses 5848 samples at a time for its background
+  // music). The Wii compatible Action Replay uses 18384 at a time.
+  // Licensed titles generally use way less than that.
+  static constexpr u32 MAX_SAMPLES = 32768;  // 1024 ms at 32000 Hz
   static constexpr u32 INDEX_MASK = MAX_SAMPLES * 2 - 1;
   static constexpr int MAX_FREQ_SHIFT = 200;  // Per 32000 Hz
   static constexpr float CONTROL_FACTOR = 0.2f;

--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -15,8 +15,6 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 
-constexpr size_t WaveFileWriter::BUFFER_SIZE;
-
 WaveFileWriter::WaveFileWriter()
 {
 }
@@ -119,8 +117,11 @@ void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count, int
   if (!file)
     ERROR_LOG_FMT(AUDIO, "WaveFileWriter - file not open.");
 
-  if (count > BUFFER_SIZE * 2)
+  if (count > BUFFER_SAMPLE_COUNT)
+  {
     ERROR_LOG_FMT(AUDIO, "WaveFileWriter - buffer too small (count = {}).", count);
+    return;
+  }
 
   if (skip_silence)
   {

--- a/Source/Core/AudioCommon/WaveFile.h
+++ b/Source/Core/AudioCommon/WaveFile.h
@@ -38,12 +38,12 @@ public:
   u32 GetAudioSize() const { return audio_size; }
 
 private:
-  static constexpr size_t BUFFER_SIZE = 32 * 1024;
+  static constexpr size_t BUFFER_SAMPLE_COUNT = 32768;
 
   File::IOFile file;
   bool skip_silence = false;
   u32 audio_size = 0;
-  std::array<short, BUFFER_SIZE> conv_buffer{};
+  std::array<short, BUFFER_SAMPLE_COUNT * 2> conv_buffer{};
   void Write(u32 value);
   void Write4(const char* ptr);
   std::string basename;


### PR DESCRIPTION
This fixes missing audio in various Datel titles; see https://bugs.dolphin-emu.org/issues/12281.  They send a large number of samples at the same time, since they don't have to deal with an actual DSP program generating them.

It also fixes a crash when dumping audio on the Wii-compatible action replay, caused by an out-of-bounds array access in WaveFile.  There was bounds-checking, but the bounds checking doubled the buffer size for the number of samples, when it should have doubled the sample count (I've changed it so that the actual buffer is twice as large, and the constant indicates the sample count, though).  Also, that bounds checking logged a message and then proceeded to clobber memory regardless (it now returns without writing anything).  After clobbering dolphin would show [this](https://user-images.githubusercontent.com/8334194/172959646-123779e8-e851-4a6a-9dc9-04babb8b4c79.png) and then crash since `basename` got overwritten.

This PR _does_ fix datel titles, but it seems to introduce other issues (in particular, audio gets desynced after holding tab to disable the speed limit - this may be fixable though).  I'm also not sure if this buffer has any meaning on real hardware (its size was last bumped in #3200 from 2048 samples to 4096 samples).  Also, on datel titles, sometimes sound effects get played twice; I don't know what causes this (nor is it something that happens all of the time).