### PR TITLE
Disable icache emulation for Monster House

### DIFF
--- a/Data/Sys/GameSettings/GK5.ini
+++ b/Data/Sys/GameSettings/GK5.ini
@@ -1,7 +1,11 @@
 # GK5E78, GK5X78 - Monster House
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Monster House has stale icache values.  Disabling the icache causes "Invalid Read" errors
+# occasionally, but the game can be played from start to finish.
+DisableICache = True
+# In order to prevent the invalid read messages, we can enable MMU emulation.
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
This game has stale icache values in the logs during certain loadscreens, and after disabling them I was able to play through the entire game, with one crash that may have been related to savestates and memory cards since during that loadscreen it said the memory card did not match.

This does cause invalid reads to be spit out during parts of the game, but you can safely skip them.  Enabling MMU seems to surpress the invalid reads without side-effects, but the aforementioned memcard/savestate crash was with MMU on.

I did 100% complete the game with this set in order to verify that we can finally mark this annoying game as playable.