### PR TITLE
DSP: Copy audio dma samples one block at a time

### DIFF
--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -119,10 +119,16 @@ void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count,
                                         u32 sample_rate_divisor, int l_volume, int r_volume)
 {
   if (!file)
+  {
     ERROR_LOG_FMT(AUDIO, "WaveFileWriter - file not open.");
+    return;
+  }
 
-  if (count > BUFFER_SIZE * 2)
+  if (count * 2 > BUFFER_SIZE)
+  {
     ERROR_LOG_FMT(AUDIO, "WaveFileWriter - buffer too small (count = {}).", count);
+    return;
+  }
 
   if (skip_silence)
   {


### PR DESCRIPTION
This fixes missing audio in various Datel titles; see https://bugs.dolphin-emu.org/issues/12281. They send a large number of samples at the same time, since they don't have to deal with an actual DSP program generating them. Before, we were sending all of the samples at once, which would be too large to ever fit in the buffer in `Mixer.cpp` and thus the code that prevents overflowing the buffer rejected the samples. This new approach should be more hardware-accurate, though I haven't done any testing related to it.

Compared to #10738, this change does not result in audio desyncs after pressing tab to disable the speed limit, and I never encountered any duplicated sound effects on Datel titles.

This PR reverts #720 (but it keeps the length 0 change from #762).  Other PRs that are good for context are #692 and #762. I don't own Xenoblade Chronicles, so I haven't confirmed whether this causes issues for it.

This PR also fixes a broken size check in `WaveFile`. That check used to be relevant for the Wii-compatible Action Replay (which would crash Dolphin if audio dumping was enabled), but the other change in this PR means that only 8 samples at a time are getting written. Still, it's better to fix it.