### PR TITLE
Fix creation of rvz with > 2mb chunk size

### DIFF
--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -1142,8 +1142,8 @@ static bool AllSame(const u8* begin, const u8* end)
 
 template <typename OutputParametersEntry>
 static void RVZPack(const u8* in, OutputParametersEntry* out, u64 bytes_per_chunk, size_t chunks,
-                    u64 total_size, u64 data_offset, u64 in_offset, bool multipart,
-                    bool allow_junk_reuse, bool compression, const FileSystem* file_system)
+                    u64 total_size, u64 data_offset, bool multipart, bool allow_junk_reuse,
+                    bool compression, const FileSystem* file_system)
 {
   using Seed = std::array<u32, LaggedFibonacciGenerator::SEED_SIZE>;
   struct JunkInfo
@@ -1162,7 +1162,7 @@ static void RVZPack(const u8* in, OutputParametersEntry* out, u64 bytes_per_chun
   {
     // Skip the 0 to 32 zero bytes that typically come after a file
     size_t zeroes = 0;
-    while (position + zeroes < total_size && in[in_offset + position + zeroes] == 0)
+    while (position + zeroes < total_size && in[position + zeroes] == 0)
       ++zeroes;
 
     // If there are very many zero bytes (perhaps the PRNG junk data has been scrubbed?)
@@ -1182,7 +1182,7 @@ static void RVZPack(const u8* in, OutputParametersEntry* out, u64 bytes_per_chun
 
     Seed seed;
     const size_t bytes_reconstructed = LaggedFibonacciGenerator::GetSeed(
-        in + in_offset + position, bytes_to_read, data_offset_mod, seed.data());
+        in + position, bytes_to_read, data_offset_mod, seed.data());
 
     if (bytes_reconstructed > 0)
       junk_info.emplace(position + bytes_reconstructed, JunkInfo{position, seed});
@@ -1248,7 +1248,7 @@ static void RVZPack(const u8* in, OutputParametersEntry* out, u64 bytes_per_chun
         if (next_junk_start == end_offset)
         {
           // Storing this chunk without RVZ packing would be inefficient, so store it without
-          PushBack(&entry.main_data, in + in_offset + current_offset, in + in_offset + end_offset);
+          PushBack(&entry.main_data, in + current_offset, in + end_offset);
           break;
         }
 
@@ -1258,7 +1258,7 @@ static void RVZPack(const u8* in, OutputParametersEntry* out, u64 bytes_per_chun
       const u64 non_junk_bytes = next_junk_start - current_offset;
       if (non_junk_bytes > 0)
       {
-        const u8* ptr = in + in_offset + current_offset;
+        const u8* ptr = in + current_offset;
 
         PushBack(&entry.main_data, Common::swap32(static_cast<u32>(non_junk_bytes)));
         PushBack(&entry.main_data, ptr, ptr + non_junk_bytes);
@@ -1284,8 +1284,7 @@ template <typename OutputParametersEntry>
 static void RVZPack(const u8* in, OutputParametersEntry* out, u64 size, u64 data_offset,
                     bool allow_junk_reuse, bool compression, const FileSystem* file_system)
 {
-  RVZPack(in, out, size, 1, size, data_offset, 0, false, allow_junk_reuse, compression,
-          file_system);
+  RVZPack(in, out, size, 1, size, data_offset, false, allow_junk_reuse, compression, file_system);
 }
 
 template <bool RVZ>
@@ -1473,8 +1472,8 @@ WIARVZFileReader<RVZ>::ProcessAndCompress(CompressThreadState* state, CompressPa
           const u64 data_offset = parameters.data_offset + write_offset_of_group;
 
           RVZPack(state->decryption_buffer[0].data(), output_entries.data() + first_chunk,
-                  bytes_per_chunk, chunks, total_size, data_offset, write_offset_of_group,
-                  groups > 1, allow_junk_reuse, compression, file_system);
+                  bytes_per_chunk, chunks, total_size, data_offset, groups > 1, allow_junk_reuse,
+                  compression, file_system);
         }
         else
         {


### PR DESCRIPTION
Makes dolphin able to create rvzs of Wii discs with a > 2mb chunk size without filling them with garbage.

`ProcessAndCompress` would pass `RVZPack` a pointer to a local single-group-sized buffer, but tell it to read from the offset that it would if that buffer was the size of a chunk, making it read past the end of the buffer for groups that weren't group 0.

Side note: 16mb zstandard chunks work just fine on modern computers for most games*, and decompress faster than 2mb lzma chunks

\* Games that use DTK audio have trouble due to DTK audio emulation not respecting disk seek times, but they have trouble at 2mb too