### PR TITLE
JitArm64: Implement "soft MMU"

### DIFF
--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -27,6 +27,11 @@ namespace Memory
 extern u8* physical_base;
 extern u8* logical_base;
 
+// This page table is used for a "soft MMU" implementation when
+// setting up the full memory map in process memory isn't possible.
+extern u8* physical_page_mappings_base;
+extern u8* logical_page_mappings_base;
+
 // The actual memory used for backing the memory map.
 extern u8* m_pRAM;
 extern u8* m_pEXRAM;

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -21,16 +21,13 @@ class Mapping;
 namespace Memory
 {
 // Base is a pointer to the base of the memory map. Yes, some MMU tricks
-// are used to set up a full GC or Wii memory map in process memory.  on
-// 32-bit, you have to mask your offsets with 0x3FFFFFFF. This means that
-// some things are mirrored too many times, but eh... it works.
-
+// are used to set up a full GC or Wii memory map in process memory.
 // In 64-bit, this might point to "high memory" (above the 32-bit limit),
 // so be sure to load it into a 64-bit register.
 extern u8* physical_base;
 extern u8* logical_base;
 
-// These are guaranteed to point to "low memory" addresses (sub-32-bit).
+// The actual memory used for backing the memory map.
 extern u8* m_pRAM;
 extern u8* m_pEXRAM;
 extern u8* m_pL1Cache;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -249,7 +249,6 @@ protected:
   // Additional scratch registers are used in the following situations:
   //
   // emitting_routine && mode == Auto:                                            X2
-  // emitting_routine && mode == Auto && (flags & BackPatchInfo::FLAG_STORE):     X0
   // emitting_routine && mode == Auto && !(flags & BackPatchInfo::FLAG_STORE):    X3
   // emitting_routine && mode != AlwaysSafe && !jo.fastmem_arena:                 X3
   // mode != AlwaysSafe && !jo.fastmem_arena:                                     X2

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -248,10 +248,12 @@ protected:
   //
   // Additional scratch registers are used in the following situations:
   //
-  // emitting_routine && (mode == Auto || (mode != AlwaysSafe && !jo.fastmem_arena)):   X2
-  // emitting_routine && mode == Auto && (flags & BackPatchInfo::FLAG_STORE):           X0
-  // emitting_routine && mode == Auto && !(flags & BackPatchInfo::FLAG_STORE):          X3
-  // !emitting_routine && mode != AlwaysSafe && !jo.fastmem_arena:                      X30
+  // emitting_routine && mode == Auto:                                            X2
+  // emitting_routine && mode == Auto && (flags & BackPatchInfo::FLAG_STORE):     X0
+  // emitting_routine && mode == Auto && !(flags & BackPatchInfo::FLAG_STORE):    X3
+  // emitting_routine && mode != AlwaysSafe && !jo.fastmem_arena:                 X3
+  // mode != AlwaysSafe && !jo.fastmem_arena:                                     X2
+  // !emitting_routine && mode != AlwaysSafe && !jo.fastmem_arena:                X30
   //
   // mode != AlwaysUnsafe:
   //             X30 (plus most other registers, unless marked in gprs_to_push and fprs_to_push)

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -243,7 +243,7 @@ protected:
   // Store float:    X1       Q0
   // Load float:     X0
   //
-  // If using MemAccessMode::AlwaysUnsafe, the addr argument can be any register.
+  // If mode == AlwaysUnsafe, the addr argument can be any register.
   // Otherwise it must be the register listed in the table above.
   //
   // Additional scratch registers are used in the following situations:
@@ -254,9 +254,10 @@ protected:
   // emitting_routine && mode != AlwaysSafe && !jo.fastmem_arena:                 X3
   // mode != AlwaysSafe && !jo.fastmem_arena:                                     X2
   // !emitting_routine && mode != AlwaysSafe && !jo.fastmem_arena:                X30
+  // !emitting_routine && mode == Auto && jo.fastmem_arena:                       X30
   //
-  // mode != AlwaysUnsafe:
-  //             X30 (plus most other registers, unless marked in gprs_to_push and fprs_to_push)
+  // Furthermore, any callee-saved register which isn't marked in gprs_to_push/fprs_to_push
+  // may be clobbered if mode != AlwaysUnsafe.
   void EmitBackpatchRoutine(u32 flags, MemAccessMode mode, Arm64Gen::ARM64Reg RS,
                             Arm64Gen::ARM64Reg addr, BitSet32 gprs_to_push = BitSet32(0),
                             BitSet32 fprs_to_push = BitSet32(0), bool emitting_routine = false);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -215,10 +215,28 @@ protected:
   // Dump a memory range of code
   void DumpCode(const u8* start, const u8* end);
 
+  // This enum is used for selecting an implementation of EmitBackpatchRoutine.
+  //
+  // The below descriptions of each enum entry apply when jo.fastmem_arena is true.
+  // If jo.fastmem_arena is false, the slow C++ code is always called instead.
+  enum class MemAccessMode
+  {
+    // Always calls the slow C++ code. For performance reasons, should generally only be used if
+    // the guest address is known in advance and IsOptimizableRAMAddress returns false for it.
+    AlwaysSafe,
+    // Only emits fast access code. Must only be used if the guest address is known in advance
+    // and IsOptimizableRAMAddress returns true for it, otherwise Dolphin will likely crash!
+    AlwaysUnsafe,
+    // Best in most cases. Tries to run fast access code, and if that fails, uses backpatching to
+    // replace the code with a call to the slow C++ code.
+    Auto,
+  };
+
   // This is the core routine for accessing emulated memory, with support for
-  // many different kinds of loads and stores as well as fastmem backpatching.
+  // many different kinds of loads and stores as well as fastmem/backpatching.
   //
   // Registers used:
+  //
   //                 addr     scratch
   // Store:          X1       X0
   // Load:           X0
@@ -226,15 +244,18 @@ protected:
   // Store float:    X1       Q0
   // Load float:     X0
   //
-  // If fastmem && !do_farcode, the addr argument can be any register.
+  // If using MemAccessMode::AlwaysUnsafe, the addr argument can be any register.
   // Otherwise it must be the register listed in the table above.
   //
   // Additional scratch registers are used in the following situations:
-  // fastmem && do_farcode && emitting_routine:                                            X2
-  // fastmem && do_farcode && emitting_routine && (flags & BackPatchInfo::FLAG_STORE):     X0
-  // fastmem && do_farcode && emitting_routine && !(flags & BackPatchInfo::FLAG_STORE):    X3
-  // !fastmem || do_farcode:    X30 (plus lots more unless you set gprs_to_push and fprs_to_push)
-  void EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode, Arm64Gen::ARM64Reg RS,
+  //
+  // mode == Auto && emitting_routine:                                            X2
+  // mode == Auto && emitting_routine && (flags & BackPatchInfo::FLAG_STORE):     X0
+  // mode == Auto && emitting_routine && !(flags & BackPatchInfo::FLAG_STORE):    X3
+  //
+  // mode != AlwaysUnsafe || !jo.fastmem_arena:
+  //             X30 (plus most other registers, unless marked in gprs_to_push and fprs_to_push)
+  void EmitBackpatchRoutine(u32 flags, MemAccessMode mode, Arm64Gen::ARM64Reg RS,
                             Arm64Gen::ARM64Reg addr, BitSet32 gprs_to_push = BitSet32(0),
                             BitSet32 fprs_to_push = BitSet32(0), bool emitting_routine = false);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -54,11 +54,15 @@ void JitArm64::DoBacktrace(uintptr_t access_address, SContext* ctx)
   ERROR_LOG_FMT(DYNA_REC, "Full block: {}", pc_memory);
 }
 
-void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode, ARM64Reg RS,
-                                    ARM64Reg addr, BitSet32 gprs_to_push, BitSet32 fprs_to_push,
+void JitArm64::EmitBackpatchRoutine(u32 flags, MemAccessMode mode, ARM64Reg RS, ARM64Reg addr,
+                                    BitSet32 gprs_to_push, BitSet32 fprs_to_push,
                                     bool emitting_routine)
 {
   const u32 access_size = BackPatchInfo::GetFlagSize(flags);
+
+  const bool fastmem = jo.fastmem_arena && mode != MemAccessMode::AlwaysSafe;
+  const bool do_farcode = jo.fastmem_arena && (mode == MemAccessMode::Auto ||
+                                               mode == MemAccessMode::AutoWithoutBackpatch);
 
   bool in_far_code = false;
   const u8* fastmem_start = GetCodePtr();

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -74,10 +74,10 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, MemAccessMode mode, ARM64Reg RS, 
 
     if (!jo.fastmem_arena)
     {
-      const ARM64Reg temp = emitting_routine ? ARM64Reg::W2 : ARM64Reg::W30;
+      const ARM64Reg temp = emitting_routine ? ARM64Reg::W3 : ARM64Reg::W30;
 
       memory_base = EncodeRegTo64(temp);
-      memory_offset = ARM64Reg::W8;  // TODO
+      memory_offset = ARM64Reg::W2;
 
       LSR(temp, addr, PowerPC::BAT_INDEX_SHIFT);
       LDR(memory_base, MEM_REG, ArithOption(temp, true));

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -27,6 +27,8 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
 {
   // We want to make sure to not get LR as a temp register
   gpr.Lock(ARM64Reg::W0, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W2);
 
   gpr.BindToRegister(dest, dest == (u32)addr || dest == (u32)offsetReg, false);
   ARM64Reg dest_reg = gpr.R(dest);
@@ -121,6 +123,8 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
   BitSet32 fprs_in_use = fpr.GetCallerSavedUsed();
   if (!update || early_update)
     regs_in_use[DecodeReg(ARM64Reg::W0)] = 0;
+  if (!jo.fastmem_arena)
+    regs_in_use[DecodeReg(ARM64Reg::W2)] = 0;
   if (!jo.memcheck)
     regs_in_use[DecodeReg(dest_reg)] = 0;
 
@@ -157,6 +161,8 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
   }
 
   gpr.Unlock(ARM64Reg::W0, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Unlock(ARM64Reg::W2);
 }
 
 void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s32 offset,
@@ -164,6 +170,8 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
 {
   // We want to make sure to not get LR as a temp register
   gpr.Lock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W2);
 
   ARM64Reg RS = gpr.R(value);
 
@@ -259,6 +267,8 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
   regs_in_use[DecodeReg(ARM64Reg::W0)] = 0;
   if (!update || early_update)
     regs_in_use[DecodeReg(ARM64Reg::W1)] = 0;
+  if (!jo.fastmem_arena)
+    regs_in_use[DecodeReg(ARM64Reg::W2)] = 0;
 
   u32 access_size = BackPatchInfo::GetFlagSize(flags);
   u32 mmio_address = 0;
@@ -315,6 +325,8 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
   }
 
   gpr.Unlock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Unlock(ARM64Reg::W2);
 }
 
 FixupBranch JitArm64::BATAddressLookup(ARM64Reg addr_out, ARM64Reg addr_in, ARM64Reg tmp,
@@ -497,6 +509,8 @@ void JitArm64::lmw(UGeckoInstruction inst)
   s32 offset = inst.SIMM_16;
 
   gpr.Lock(ARM64Reg::W0, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W2);
 
   // MMU games make use of a >= d despite this being invalid according to the PEM.
   // Because of this, make sure to not re-read rA after starting doing the loads.
@@ -522,6 +536,8 @@ void JitArm64::lmw(UGeckoInstruction inst)
 
     BitSet32 regs_in_use = gpr.GetCallerSavedUsed();
     BitSet32 fprs_in_use = fpr.GetCallerSavedUsed();
+    if (!jo.fastmem_arena)
+      regs_in_use[DecodeReg(ARM64Reg::W2)] = 0;
     if (i == 31)
       regs_in_use[DecodeReg(addr_reg)] = 0;
     if (!jo.memcheck)
@@ -538,6 +554,8 @@ void JitArm64::lmw(UGeckoInstruction inst)
   }
 
   gpr.Unlock(ARM64Reg::W0, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Unlock(ARM64Reg::W2);
 }
 
 void JitArm64::stmw(UGeckoInstruction inst)
@@ -549,6 +567,8 @@ void JitArm64::stmw(UGeckoInstruction inst)
   s32 offset = inst.SIMM_16;
 
   gpr.Lock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W2);
 
   ARM64Reg addr_reg = ARM64Reg::W1;
   if (a)
@@ -572,6 +592,8 @@ void JitArm64::stmw(UGeckoInstruction inst)
     BitSet32 regs_in_use = gpr.GetCallerSavedUsed();
     BitSet32 fprs_in_use = fpr.GetCallerSavedUsed();
     regs_in_use[DecodeReg(ARM64Reg::W0)] = 0;
+    if (!jo.fastmem_arena)
+      regs_in_use[DecodeReg(ARM64Reg::W2)] = 0;
     if (i == 31)
       regs_in_use[DecodeReg(addr_reg)] = 0;
 
@@ -583,6 +605,8 @@ void JitArm64::stmw(UGeckoInstruction inst)
   }
 
   gpr.Unlock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Unlock(ARM64Reg::W2);
 }
 
 void JitArm64::dcbx(UGeckoInstruction inst)
@@ -771,8 +795,14 @@ void JitArm64::dcbz(UGeckoInstruction inst)
   int a = inst.RA, b = inst.RB;
 
   gpr.Lock(ARM64Reg::W0, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W2);
 
-  Common::ScopeGuard register_guard([&] { gpr.Unlock(ARM64Reg::W0, ARM64Reg::W30); });
+  Common::ScopeGuard register_guard([&] {
+    gpr.Unlock(ARM64Reg::W0, ARM64Reg::W30);
+    if (!jo.fastmem_arena)
+      gpr.Unlock(ARM64Reg::W2);
+  });
 
   constexpr ARM64Reg addr_reg = ARM64Reg::W0;
   constexpr ARM64Reg temp_reg = ARM64Reg::W30;
@@ -839,6 +869,8 @@ void JitArm64::dcbz(UGeckoInstruction inst)
   BitSet32 gprs_to_push = gpr.GetCallerSavedUsed();
   BitSet32 fprs_to_push = fpr.GetCallerSavedUsed();
   gprs_to_push[DecodeReg(ARM64Reg::W0)] = 0;
+  if (!jo.fastmem_arena)
+    gprs_to_push[DecodeReg(ARM64Reg::W2)] = 0;
 
   EmitBackpatchRoutine(BackPatchInfo::FLAG_ZERO_256, MemAccessMode::Auto, ARM64Reg::W0,
                        EncodeRegTo64(addr_reg), gprs_to_push, fprs_to_push);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -79,6 +79,8 @@ void JitArm64::lfXX(UGeckoInstruction inst)
 
   gpr.Lock(ARM64Reg::W0, ARM64Reg::W30);
   fpr.Lock(ARM64Reg::Q0);
+  if (!jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W2);
 
   const ARM64Reg VD = fpr.RW(inst.FD, type, false);
   ARM64Reg addr_reg = ARM64Reg::W0;
@@ -166,6 +168,8 @@ void JitArm64::lfXX(UGeckoInstruction inst)
   BitSet32 fprs_in_use = fpr.GetCallerSavedUsed();
   if (!update || early_update)
     regs_in_use[DecodeReg(ARM64Reg::W0)] = 0;
+  if (!jo.fastmem_arena)
+    regs_in_use[DecodeReg(ARM64Reg::W2)] = 0;
   fprs_in_use[DecodeReg(ARM64Reg::Q0)] = 0;
   if (!jo.memcheck)
     fprs_in_use[DecodeReg(VD)] = 0;
@@ -190,6 +194,8 @@ void JitArm64::lfXX(UGeckoInstruction inst)
 
   gpr.Unlock(ARM64Reg::W0, ARM64Reg::W30);
   fpr.Unlock(ARM64Reg::Q0);
+  if (!jo.fastmem_arena)
+    gpr.Unlock(ARM64Reg::W2);
 }
 
 void JitArm64::stfXX(UGeckoInstruction inst)
@@ -273,6 +279,8 @@ void JitArm64::stfXX(UGeckoInstruction inst)
   }
 
   gpr.Lock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
+  if (!jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W2);
 
   ARM64Reg addr_reg = ARM64Reg::W1;
 
@@ -364,6 +372,8 @@ void JitArm64::stfXX(UGeckoInstruction inst)
   regs_in_use[DecodeReg(ARM64Reg::W0)] = 0;
   if (!update || early_update)
     regs_in_use[DecodeReg(ARM64Reg::W1)] = 0;
+  if (!jo.fastmem_arena)
+    regs_in_use[DecodeReg(ARM64Reg::W2)] = 0;
   fprs_in_use[DecodeReg(ARM64Reg::Q0)] = 0;
 
   if (is_immediate)
@@ -418,4 +428,6 @@ void JitArm64::stfXX(UGeckoInstruction inst)
 
   gpr.Unlock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
   fpr.Unlock(ARM64Reg::Q0);
+  if (!jo.fastmem_arena)
+    gpr.Unlock(ARM64Reg::W2);
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -170,13 +170,13 @@ void JitArm64::lfXX(UGeckoInstruction inst)
   if (!jo.memcheck)
     fprs_in_use[DecodeReg(VD)] = 0;
 
-  if (jo.fastmem_arena && is_immediate && PowerPC::IsOptimizableRAMAddress(imm_addr))
+  if (is_immediate && PowerPC::IsOptimizableRAMAddress(imm_addr))
   {
-    EmitBackpatchRoutine(flags, true, false, VD, XA, BitSet32(0), BitSet32(0));
+    EmitBackpatchRoutine(flags, MemAccessMode::AlwaysUnsafe, VD, XA, regs_in_use, fprs_in_use);
   }
   else
   {
-    EmitBackpatchRoutine(flags, jo.fastmem, jo.fastmem, VD, XA, regs_in_use, fprs_in_use);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, VD, XA, regs_in_use, fprs_in_use);
   }
 
   const ARM64Reg VD_again = fpr.RW(inst.FD, type, true);
@@ -389,21 +389,21 @@ void JitArm64::stfXX(UGeckoInstruction inst)
       STR(IndexType::Unsigned, ARM64Reg::X0, PPC_REG, PPCSTATE_OFF(gather_pipe_ptr));
       js.fifoBytesSinceCheck += accessSize >> 3;
     }
-    else if (jo.fastmem_arena && PowerPC::IsOptimizableRAMAddress(imm_addr))
+    else if (PowerPC::IsOptimizableRAMAddress(imm_addr))
     {
       set_addr_reg_if_needed();
-      EmitBackpatchRoutine(flags, true, false, V0, XA, BitSet32(0), BitSet32(0));
+      EmitBackpatchRoutine(flags, MemAccessMode::AlwaysUnsafe, V0, XA, regs_in_use, fprs_in_use);
     }
     else
     {
       set_addr_reg_if_needed();
-      EmitBackpatchRoutine(flags, false, false, V0, XA, regs_in_use, fprs_in_use);
+      EmitBackpatchRoutine(flags, MemAccessMode::AlwaysSafe, V0, XA, regs_in_use, fprs_in_use);
     }
   }
   else
   {
     set_addr_reg_if_needed();
-    EmitBackpatchRoutine(flags, jo.fastmem, jo.fastmem, V0, XA, regs_in_use, fprs_in_use);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, V0, XA, regs_in_use, fprs_in_use);
   }
 
   if (update && !early_update)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -44,6 +44,10 @@ void JitArm64::psq_lXX(UGeckoInstruction inst)
     gpr.Lock(ARM64Reg::W1, ARM64Reg::W2, ARM64Reg::W3);
     fpr.Lock(ARM64Reg::Q1);
   }
+  else if (!jo.fastmem_arena)
+  {
+    gpr.Lock(ARM64Reg::W2);
+  }
 
   constexpr ARM64Reg addr_reg = ARM64Reg::W0;
   constexpr ARM64Reg scale_reg = ARM64Reg::W1;
@@ -82,6 +86,8 @@ void JitArm64::psq_lXX(UGeckoInstruction inst)
     // Wipe the registers we are using as temporaries
     if (!update || early_update)
       gprs_in_use[DecodeReg(ARM64Reg::W0)] = false;
+    if (!jo.fastmem_arena)
+      gprs_in_use[DecodeReg(ARM64Reg::W2)] = false;
     fprs_in_use[DecodeReg(ARM64Reg::Q0)] = false;
     if (!jo.memcheck)
       fprs_in_use[DecodeReg(VS)] = 0;
@@ -129,6 +135,10 @@ void JitArm64::psq_lXX(UGeckoInstruction inst)
   {
     gpr.Unlock(ARM64Reg::W1, ARM64Reg::W2, ARM64Reg::W3);
     fpr.Unlock(ARM64Reg::Q1);
+  }
+  else if (!jo.fastmem_arena)
+  {
+    gpr.Unlock(ARM64Reg::W2);
   }
 }
 
@@ -189,8 +199,10 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
   }
 
   gpr.Lock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
-  if (!js.assumeNoPairedQuantize)
+  if (!js.assumeNoPairedQuantize || !jo.fastmem_arena)
     gpr.Lock(ARM64Reg::W2);
+  if (!js.assumeNoPairedQuantize && !jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W3);
 
   constexpr ARM64Reg scale_reg = ARM64Reg::W0;
   constexpr ARM64Reg addr_reg = ARM64Reg::W1;
@@ -229,6 +241,8 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
     gprs_in_use[DecodeReg(ARM64Reg::W0)] = false;
     if (!update || early_update)
       gprs_in_use[DecodeReg(ARM64Reg::W1)] = false;
+    if (!jo.fastmem_arena)
+      gprs_in_use[DecodeReg(ARM64Reg::W2)] = false;
 
     u32 flags = BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_32;
     if (!w)
@@ -261,9 +275,10 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
 
   gpr.Unlock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
   fpr.Unlock(ARM64Reg::Q0);
+  if (!js.assumeNoPairedQuantize || !jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W2);
+  if (!js.assumeNoPairedQuantize && !jo.fastmem_arena)
+    gpr.Lock(ARM64Reg::W3);
   if (!js.assumeNoPairedQuantize)
-  {
-    gpr.Unlock(ARM64Reg::W2);
     fpr.Unlock(ARM64Reg::Q1);
-  }
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -90,7 +90,7 @@ void JitArm64::psq_lXX(UGeckoInstruction inst)
     if (!w)
       flags |= BackPatchInfo::FLAG_PAIR;
 
-    EmitBackpatchRoutine(flags, jo.fastmem, jo.fastmem, VS, EncodeRegTo64(addr_reg), gprs_in_use,
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, VS, EncodeRegTo64(addr_reg), gprs_in_use,
                          fprs_in_use);
   }
   else
@@ -234,7 +234,7 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
     if (!w)
       flags |= BackPatchInfo::FLAG_PAIR;
 
-    EmitBackpatchRoutine(flags, jo.fastmem, jo.fastmem, VS, EncodeRegTo64(addr_reg), gprs_in_use,
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, VS, EncodeRegTo64(addr_reg), gprs_in_use,
                          fprs_in_use);
   }
   else

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -393,7 +393,7 @@ void Arm64GPRCache::GetAllocationOrder()
       ARM64Reg::W11,
       ARM64Reg::W10,
       ARM64Reg::W9,
-      // ARM64Reg::W8,
+      ARM64Reg::W8,
       ARM64Reg::W7,
       ARM64Reg::W6,
       ARM64Reg::W5,

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -393,7 +393,7 @@ void Arm64GPRCache::GetAllocationOrder()
       ARM64Reg::W11,
       ARM64Reg::W10,
       ARM64Reg::W9,
-      ARM64Reg::W8,
+      // ARM64Reg::W8,
       ARM64Reg::W7,
       ARM64Reg::W6,
       ARM64Reg::W5,

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -93,10 +93,10 @@ void JitArm64::GenerateAsm()
     // set the mem_base based on MSR flags
     LDR(IndexType::Unsigned, ARM64Reg::W28, PPC_REG, PPCSTATE_OFF(msr));
     FixupBranch physmem = TBNZ(ARM64Reg::W28, 31 - 27);
-    MOVP2R(MEM_REG, Memory::physical_base);
+    MOVP2R(MEM_REG, jo.fastmem_arena ? Memory::physical_base : Memory::physical_page_mappings_base);
     FixupBranch membaseend = B();
     SetJumpTarget(physmem);
-    MOVP2R(MEM_REG, Memory::logical_base);
+    MOVP2R(MEM_REG, jo.fastmem_arena ? Memory::logical_base : Memory::logical_page_mappings_base);
     SetJumpTarget(membaseend);
 
     // iCache[(address >> 2) & iCache_Mask];
@@ -141,10 +141,10 @@ void JitArm64::GenerateAsm()
   // set the mem_base based on MSR flags and jump to next block.
   LDR(IndexType::Unsigned, ARM64Reg::W28, PPC_REG, PPCSTATE_OFF(msr));
   FixupBranch physmem = TBNZ(ARM64Reg::W28, 31 - 27);
-  MOVP2R(MEM_REG, Memory::physical_base);
+  MOVP2R(MEM_REG, jo.fastmem_arena ? Memory::physical_base : Memory::physical_page_mappings_base);
   BR(ARM64Reg::X0);
   SetJumpTarget(physmem);
-  MOVP2R(MEM_REG, Memory::logical_base);
+  MOVP2R(MEM_REG, jo.fastmem_arena ? Memory::logical_base : Memory::logical_page_mappings_base);
   BR(ARM64Reg::X0);
 
   // Call JIT

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -699,6 +699,7 @@ void JitArm64::GenerateQuantizedStores()
   // X0 is the scale
   // X1 is the address
   // X2 is a temporary
+  // X3 is a temporary if jo.fastmem_arena is false (used in EmitBackpatchRoutine)
   // X30 is LR
   // Q0 is the register
   // Q1 is a temporary
@@ -707,6 +708,8 @@ void JitArm64::GenerateQuantizedStores()
   BitSet32 gprs_to_push = CALLER_SAVED_GPRS & ~BitSet32{0, 2};
   if (!jo.memcheck)
     gprs_to_push &= ~BitSet32{1};
+  if (!jo.fastmem_arena)
+    gprs_to_push &= ~BitSet32{3};
   BitSet32 fprs_to_push = BitSet32(0xFFFFFFFF) & ~BitSet32{0, 1};
   ARM64FloatEmitter float_emit(this);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -510,7 +510,7 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags = BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_32;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg,
                          gprs_to_push & ~BitSet32{1}, fprs_to_push, true);
 
     RET(ARM64Reg::X30);
@@ -520,8 +520,8 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags = BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_8;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     float_emit.UXTL(8, ARM64Reg::D0, ARM64Reg::D0);
     float_emit.UXTL(16, ARM64Reg::D0, ARM64Reg::D0);
@@ -538,8 +538,8 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags = BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_8;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     float_emit.SXTL(8, ARM64Reg::D0, ARM64Reg::D0);
     float_emit.SXTL(16, ARM64Reg::D0, ARM64Reg::D0);
@@ -556,8 +556,8 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags = BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_16;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     float_emit.UXTL(16, ARM64Reg::D0, ARM64Reg::D0);
     float_emit.UCVTF(32, ARM64Reg::D0, ARM64Reg::D0);
@@ -573,8 +573,8 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags = BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_16;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     float_emit.SXTL(16, ARM64Reg::D0, ARM64Reg::D0);
     float_emit.SCVTF(32, ARM64Reg::D0, ARM64Reg::D0);
@@ -591,7 +591,7 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags =
         BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_32;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg,
                          gprs_to_push & ~BitSet32{1}, fprs_to_push, true);
 
     RET(ARM64Reg::X30);
@@ -601,8 +601,8 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags =
         BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_8;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     float_emit.UXTL(8, ARM64Reg::D0, ARM64Reg::D0);
     float_emit.UXTL(16, ARM64Reg::D0, ARM64Reg::D0);
@@ -619,8 +619,8 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags =
         BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_8;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     float_emit.SXTL(8, ARM64Reg::D0, ARM64Reg::D0);
     float_emit.SXTL(16, ARM64Reg::D0, ARM64Reg::D0);
@@ -637,8 +637,8 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags =
         BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_16;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     float_emit.UXTL(16, ARM64Reg::D0, ARM64Reg::D0);
     float_emit.UCVTF(32, ARM64Reg::D0, ARM64Reg::D0);
@@ -654,8 +654,8 @@ void JitArm64::GenerateQuantizedLoads()
     constexpr u32 flags =
         BackPatchInfo::FLAG_LOAD | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_16;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     float_emit.SXTL(16, ARM64Reg::D0, ARM64Reg::D0);
     float_emit.SCVTF(32, ARM64Reg::D0, ARM64Reg::D0);
@@ -718,8 +718,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags = BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_32;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }
@@ -737,8 +737,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags = BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_8;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }
@@ -756,8 +756,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags = BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_8;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }
@@ -774,8 +774,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags = BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_16;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }
@@ -792,8 +792,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags = BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT |
                           BackPatchInfo::FLAG_PAIR | BackPatchInfo::FLAG_SIZE_16;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }
@@ -803,8 +803,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags =
         BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_32;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }
@@ -822,8 +822,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags =
         BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_8;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }
@@ -841,8 +841,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags =
         BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_8;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }
@@ -859,8 +859,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags =
         BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_16;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }
@@ -877,8 +877,8 @@ void JitArm64::GenerateQuantizedStores()
     constexpr u32 flags =
         BackPatchInfo::FLAG_STORE | BackPatchInfo::FLAG_FLOAT | BackPatchInfo::FLAG_SIZE_16;
 
-    EmitBackpatchRoutine(flags, jo.fastmem_arena, jo.fastmem_arena, ARM64Reg::D0, addr_reg,
-                         gprs_to_push, fprs_to_push, true);
+    EmitBackpatchRoutine(flags, MemAccessMode::Auto, ARM64Reg::D0, addr_reg, gprs_to_push,
+                         fprs_to_push, true);
 
     RET(ARM64Reg::X30);
   }

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -197,11 +197,12 @@ TranslateResult JitCache_TranslateAddress(u32 address);
 
 constexpr int BAT_INDEX_SHIFT = 17;
 constexpr u32 BAT_PAGE_SIZE = 1 << BAT_INDEX_SHIFT;
+constexpr u32 BAT_PAGE_COUNT = 1 << (32 - BAT_INDEX_SHIFT);
 constexpr u32 BAT_MAPPED_BIT = 0x1;
 constexpr u32 BAT_PHYSICAL_BIT = 0x2;
 constexpr u32 BAT_WI_BIT = 0x4;
 constexpr u32 BAT_RESULT_MASK = UINT32_C(~0x7);
-using BatTable = std::array<u32, 1 << (32 - BAT_INDEX_SHIFT)>;  // 128 KB
+using BatTable = std::array<u32, BAT_PAGE_COUNT>;  // 128 KB
 extern BatTable ibat_table;
 extern BatTable dbat_table;
 inline bool TranslateBatAddess(const BatTable& bat_table, u32* address, bool* wi)


### PR DESCRIPTION
This is used when fastmem isn't available. Instead of always falling back to the C++ code in MMU.cpp, the JIT translates addresses on its own by looking them up in a table that Dolphin constructs. This is slower than fastmem, but faster than the old non-fastmem code.

This is primarily useful for iOS, since that's the only major platform nowadays where you can't reliably get fastmem. I think it would make sense to merge this feature to master despite this, since there's nothing actually iOS-specific about the feature. It would be of use for me when I have to disable fastmem to stop Android Studio from constantly breaking on segfaults, for instance.