### PR TITLE
Add a post-cache shader UID fixup pass 

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -1168,55 +1168,43 @@ void Renderer::ApplyBlendingState(const BlendingState state)
   if (m_current_blend_state == state)
     return;
 
-  bool useDualSource =
-      state.usedualsrc && g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
-      (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) || state.dstalpha);
-  // Only use shader blend if we need to and we don't support dual-source blending directly
-  bool useShaderBlend = !useDualSource && state.usedualsrc && state.dstalpha &&
-                        g_ActiveConfig.backend_info.bSupportsFramebufferFetch;
+  bool useDualSource = state.usedualsrc;
 
-  if (useShaderBlend)
-  {
-    glDisable(GL_BLEND);
-  }
+  const GLenum src_factors[8] = {GL_ZERO,
+                                 GL_ONE,
+                                 GL_DST_COLOR,
+                                 GL_ONE_MINUS_DST_COLOR,
+                                 useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
+                                 useDualSource ? GL_ONE_MINUS_SRC1_ALPHA :
+                                                 (GLenum)GL_ONE_MINUS_SRC_ALPHA,
+                                 GL_DST_ALPHA,
+                                 GL_ONE_MINUS_DST_ALPHA};
+  const GLenum dst_factors[8] = {GL_ZERO,
+                                 GL_ONE,
+                                 GL_SRC_COLOR,
+                                 GL_ONE_MINUS_SRC_COLOR,
+                                 useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
+                                 useDualSource ? GL_ONE_MINUS_SRC1_ALPHA :
+                                                 (GLenum)GL_ONE_MINUS_SRC_ALPHA,
+                                 GL_DST_ALPHA,
+                                 GL_ONE_MINUS_DST_ALPHA};
+
+  if (state.blendenable)
+    glEnable(GL_BLEND);
   else
-  {
-    const GLenum src_factors[8] = {GL_ZERO,
-                                   GL_ONE,
-                                   GL_DST_COLOR,
-                                   GL_ONE_MINUS_DST_COLOR,
-                                   useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
-                                   useDualSource ? GL_ONE_MINUS_SRC1_ALPHA :
-                                                   (GLenum)GL_ONE_MINUS_SRC_ALPHA,
-                                   GL_DST_ALPHA,
-                                   GL_ONE_MINUS_DST_ALPHA};
-    const GLenum dst_factors[8] = {GL_ZERO,
-                                   GL_ONE,
-                                   GL_SRC_COLOR,
-                                   GL_ONE_MINUS_SRC_COLOR,
-                                   useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
-                                   useDualSource ? GL_ONE_MINUS_SRC1_ALPHA :
-                                                   (GLenum)GL_ONE_MINUS_SRC_ALPHA,
-                                   GL_DST_ALPHA,
-                                   GL_ONE_MINUS_DST_ALPHA};
+    glDisable(GL_BLEND);
 
-    if (state.blendenable)
-      glEnable(GL_BLEND);
-    else
-      glDisable(GL_BLEND);
-
-    // Always call glBlendEquationSeparate and glBlendFuncSeparate, even when
-    // GL_BLEND is disabled, as a workaround for some bugs (possibly graphics
-    // driver issues?). See https://bugs.dolphin-emu.org/issues/10120 : "Sonic
-    // Adventure 2 Battle: graphics crash when loading first Dark level"
-    GLenum equation = state.subtract ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
-    GLenum equationAlpha = state.subtractAlpha ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
-    glBlendEquationSeparate(equation, equationAlpha);
-    glBlendFuncSeparate(src_factors[u32(state.srcfactor.Value())],
-                        dst_factors[u32(state.dstfactor.Value())],
-                        src_factors[u32(state.srcfactoralpha.Value())],
-                        dst_factors[u32(state.dstfactoralpha.Value())]);
-  }
+  // Always call glBlendEquationSeparate and glBlendFuncSeparate, even when
+  // GL_BLEND is disabled, as a workaround for some bugs (possibly graphics
+  // driver issues?). See https://bugs.dolphin-emu.org/issues/10120 : "Sonic
+  // Adventure 2 Battle: graphics crash when loading first Dark level"
+  GLenum equation = state.subtract ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
+  GLenum equationAlpha = state.subtractAlpha ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
+  glBlendEquationSeparate(equation, equationAlpha);
+  glBlendFuncSeparate(src_factors[u32(state.srcfactor.Value())],
+                      dst_factors[u32(state.dstfactor.Value())],
+                      src_factors[u32(state.srcfactoralpha.Value())],
+                      dst_factors[u32(state.dstfactoralpha.Value())]);
 
   const GLenum logic_op_codes[16] = {
       GL_CLEAR,         GL_AND,         GL_AND_REVERSE, GL_COPY,  GL_AND_INVERTED, GL_NOOP,

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -153,7 +153,7 @@ static void Draw(s32 x, s32 y, s32 xi, s32 yi)
 
   s32 z = (s32)std::clamp<float>(ZSlope.GetValue(x, y), 0.0f, 16777215.0f);
 
-  if (bpmem.UseEarlyDepthTest())
+  if (bpmem.GetEmulatedZ() == EmulatedZ::Early)
   {
     // TODO: Test if perf regs are incremented even if test is disabled
     EfbInterface::IncPerfCounterQuadCount(PQ_ZCOMP_INPUT_ZCOMPLOC);

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -840,7 +840,7 @@ void Tev::Draw()
     output[BLU_C] = (output[BLU_C] * invFog + fogInt * bpmem.fog.color.b) >> 8;
   }
 
-  if (bpmem.UseLateDepthTest())
+  if (bpmem.GetEmulatedZ() == EmulatedZ::Late)
   {
     // TODO: Check against hw if these values get incremented even if depth testing is disabled
     EfbInterface::IncPerfCounterQuadCount(PQ_ZCOMP_INPUT);

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -137,60 +137,48 @@ GetVulkanAttachmentBlendState(const BlendingState& state, AbstractPipelineUsage 
 {
   VkPipelineColorBlendAttachmentState vk_state = {};
 
-  bool use_dual_source =
-      state.usedualsrc && g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
-      (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) || state.dstalpha);
-  bool use_shader_blend = !use_dual_source && state.usedualsrc && state.dstalpha &&
-                          g_ActiveConfig.backend_info.bSupportsFramebufferFetch;
+  bool use_dual_source = state.usedualsrc;
 
-  if (use_shader_blend || (usage == AbstractPipelineUsage::GX &&
-                           DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DISCARD_WITH_EARLY_Z)))
+  vk_state.blendEnable = static_cast<VkBool32>(state.blendenable);
+  vk_state.colorBlendOp = state.subtract ? VK_BLEND_OP_REVERSE_SUBTRACT : VK_BLEND_OP_ADD;
+  vk_state.alphaBlendOp = state.subtractAlpha ? VK_BLEND_OP_REVERSE_SUBTRACT : VK_BLEND_OP_ADD;
+
+  if (use_dual_source)
   {
-    vk_state.blendEnable = VK_FALSE;
+    static constexpr std::array<VkBlendFactor, 8> src_factors = {
+        {VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_DST_COLOR,
+         VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR, VK_BLEND_FACTOR_SRC1_ALPHA,
+         VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA, VK_BLEND_FACTOR_DST_ALPHA,
+         VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA}};
+    static constexpr std::array<VkBlendFactor, 8> dst_factors = {
+        {VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_SRC_COLOR,
+         VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR, VK_BLEND_FACTOR_SRC1_ALPHA,
+         VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA, VK_BLEND_FACTOR_DST_ALPHA,
+         VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA}};
+
+    vk_state.srcColorBlendFactor = src_factors[u32(state.srcfactor.Value())];
+    vk_state.srcAlphaBlendFactor = src_factors[u32(state.srcfactoralpha.Value())];
+    vk_state.dstColorBlendFactor = dst_factors[u32(state.dstfactor.Value())];
+    vk_state.dstAlphaBlendFactor = dst_factors[u32(state.dstfactoralpha.Value())];
   }
   else
   {
-    vk_state.blendEnable = static_cast<VkBool32>(state.blendenable);
-    vk_state.colorBlendOp = state.subtract ? VK_BLEND_OP_REVERSE_SUBTRACT : VK_BLEND_OP_ADD;
-    vk_state.alphaBlendOp = state.subtractAlpha ? VK_BLEND_OP_REVERSE_SUBTRACT : VK_BLEND_OP_ADD;
+    static constexpr std::array<VkBlendFactor, 8> src_factors = {
+        {VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_DST_COLOR,
+         VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR, VK_BLEND_FACTOR_SRC_ALPHA,
+         VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VK_BLEND_FACTOR_DST_ALPHA,
+         VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA}};
 
-    if (use_dual_source)
-    {
-      static constexpr std::array<VkBlendFactor, 8> src_factors = {
-          {VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_DST_COLOR,
-           VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR, VK_BLEND_FACTOR_SRC1_ALPHA,
-           VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA, VK_BLEND_FACTOR_DST_ALPHA,
-           VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA}};
-      static constexpr std::array<VkBlendFactor, 8> dst_factors = {
-          {VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_SRC_COLOR,
-           VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR, VK_BLEND_FACTOR_SRC1_ALPHA,
-           VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA, VK_BLEND_FACTOR_DST_ALPHA,
-           VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA}};
+    static constexpr std::array<VkBlendFactor, 8> dst_factors = {
+        {VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_SRC_COLOR,
+         VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR, VK_BLEND_FACTOR_SRC_ALPHA,
+         VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VK_BLEND_FACTOR_DST_ALPHA,
+         VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA}};
 
-      vk_state.srcColorBlendFactor = src_factors[u32(state.srcfactor.Value())];
-      vk_state.srcAlphaBlendFactor = src_factors[u32(state.srcfactoralpha.Value())];
-      vk_state.dstColorBlendFactor = dst_factors[u32(state.dstfactor.Value())];
-      vk_state.dstAlphaBlendFactor = dst_factors[u32(state.dstfactoralpha.Value())];
-    }
-    else
-    {
-      static constexpr std::array<VkBlendFactor, 8> src_factors = {
-          {VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_DST_COLOR,
-           VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR, VK_BLEND_FACTOR_SRC_ALPHA,
-           VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VK_BLEND_FACTOR_DST_ALPHA,
-           VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA}};
-
-      static constexpr std::array<VkBlendFactor, 8> dst_factors = {
-          {VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_SRC_COLOR,
-           VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR, VK_BLEND_FACTOR_SRC_ALPHA,
-           VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VK_BLEND_FACTOR_DST_ALPHA,
-           VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA}};
-
-      vk_state.srcColorBlendFactor = src_factors[u32(state.srcfactor.Value())];
-      vk_state.srcAlphaBlendFactor = src_factors[u32(state.srcfactoralpha.Value())];
-      vk_state.dstColorBlendFactor = dst_factors[u32(state.dstfactor.Value())];
-      vk_state.dstAlphaBlendFactor = dst_factors[u32(state.dstfactoralpha.Value())];
-    }
+    vk_state.srcColorBlendFactor = src_factors[u32(state.srcfactor.Value())];
+    vk_state.srcAlphaBlendFactor = src_factors[u32(state.srcfactoralpha.Value())];
+    vk_state.dstColorBlendFactor = dst_factors[u32(state.dstfactor.Value())];
+    vk_state.dstAlphaBlendFactor = dst_factors[u32(state.dstfactoralpha.Value())];
   }
 
   if (state.colorupdate)

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -371,13 +371,6 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_REVERSED_DEPTH_RANGE))
     config->backend_info.bSupportsReversedDepthRange = false;
 
-  // Calling discard when early depth test is enabled can break on some Apple Silicon GPU drivers.
-  if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DISCARD_WITH_EARLY_Z))
-  {
-    // We will use shader blending, so disable hardware dual source blending.
-    config->backend_info.bSupportsDualSourceBlend = false;
-  }
-
   // Dynamic sampler indexing locks up Intel GPUs on MoltenVK/Metal
   if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING))
     config->backend_info.bSupportsDynamicSamplerIndexing = false;

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -2336,6 +2336,16 @@ struct BPCmd
   int newvalue;
 };
 
+enum class EmulatedZ : u32
+{
+  Disabled = 0,
+  Early = 1,
+  Late = 2,
+  ForcedEarly = 3,
+  EarlyWithFBFetch = 4,
+  EarlyWithZComplocHack = 5,
+};
+
 struct BPMemory
 {
   GenMode genMode;
@@ -2403,8 +2413,15 @@ struct BPMemory
   u32 bpMask;          // 0xFE
   u32 unknown18;       // ff
 
-  bool UseEarlyDepthTest() const { return zcontrol.early_ztest && zmode.testenable; }
-  bool UseLateDepthTest() const { return !zcontrol.early_ztest && zmode.testenable; }
+  EmulatedZ GetEmulatedZ() const
+  {
+    if (!zmode.testenable)
+      return EmulatedZ::Disabled;
+    if (zcontrol.early_ztest)
+      return EmulatedZ::Early;
+    else
+      return EmulatedZ::Late;
+  }
 };
 
 #pragma pack()

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -237,7 +237,8 @@ enum Bug
   // crash. Sometimes this happens in the kernel mode part of the driver, resulting in a BSOD.
   // These shaders are also particularly problematic on macOS's Intel drivers. On OpenGL, they can
   // cause depth issues. On Metal, they can cause the driver to not write a primitive to the depth
-  // buffer whenever a fragment is discarded. Disable dual-source blending support on these drivers.
+  // buffer if dual source blending is output in the shader but not subsequently used in blending.
+  // Compile separate shaders for DSB on vs off for these drivers.
   BUG_BROKEN_DUAL_SOURCE_BLENDING,
 
   // BUG: ImgTec GLSL shader compiler fails when negating the input to a bitwise operation

--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -19,7 +19,7 @@ namespace VideoCommon
 // As pipelines encompass both shader UIDs and render states, changes to either of these should
 // also increment the pipeline UID version. Incrementing the UID version will cause all UID
 // caches to be invalidated.
-constexpr u32 GX_PIPELINE_UID_VERSION = 4;  // Last changed in PR 10215
+constexpr u32 GX_PIPELINE_UID_VERSION = 5;  // Last changed in PR 10747
 
 struct GXPipelineUid
 {

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -12,6 +12,7 @@ enum class AlphaTestOp : u32;
 enum class AlphaTestResult;
 enum class CompareMode : u32;
 enum class DstBlendFactor : u32;
+enum class EmulatedZ : u32;
 enum class FogProjection : u32;
 enum class FogType : u32;
 enum class KonstSel : u32;
@@ -28,6 +29,7 @@ struct pixel_shader_uid_data
   u32 NumValues() const { return num_values; }
   u32 pad0 : 4;
   u32 useDstAlpha : 1;
+  u32 no_dual_src : 1;
   AlphaTestResult Pretest : 2;
   u32 nIndirectStagesUsed : 4;
   u32 genMode_numtexgens : 4;
@@ -36,16 +38,13 @@ struct pixel_shader_uid_data
   CompareMode alpha_test_comp0 : 3;
   CompareMode alpha_test_comp1 : 3;
   AlphaTestOp alpha_test_logic : 2;
-  u32 alpha_test_use_zcomploc_hack : 1;
   FogProjection fog_proj : 1;
 
   FogType fog_fsel : 3;
   u32 fog_RangeBaseEnabled : 1;
   ZTexOp ztex_op : 2;
   u32 per_pixel_depth : 1;
-  u32 forced_early_z : 1;
-  u32 early_ztest : 1;
-  u32 late_ztest : 1;
+  EmulatedZ ztest : 3;
   u32 bounding_box : 1;
   u32 zfreeze : 1;
   u32 numColorChans : 2;

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -448,7 +448,7 @@ void PixelShaderManager::SetGenModeChanged()
 
 void PixelShaderManager::SetZModeControl()
 {
-  u32 late_ztest = bpmem.UseLateDepthTest();
+  u32 late_ztest = bpmem.GetEmulatedZ() == EmulatedZ::Late;
   u32 rgba6_format =
       (bpmem.zcontrol.pixel_format == PixelFormat::RGBA6_Z24 && !g_ActiveConfig.bForceTrueColor) ?
           1 :

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -25,6 +25,34 @@ void DepthState::Generate(const BPMemory& bp)
   func = bp.zmode.func.Value();
 }
 
+static bool IsDualSrc(SrcBlendFactor factor)
+{
+  return factor == SrcBlendFactor::SrcAlpha || factor == SrcBlendFactor::InvSrcAlpha;
+}
+
+static bool IsDualSrc(DstBlendFactor factor)
+{
+  switch (factor)
+  {
+  case DstBlendFactor::SrcClr:
+  case DstBlendFactor::SrcAlpha:
+  case DstBlendFactor::InvSrcClr:
+  case DstBlendFactor::InvSrcAlpha:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool BlendingState::RequiresDualSrc() const
+{
+  bool requires_dual_src = false;
+  requires_dual_src |= IsDualSrc(srcfactor) || IsDualSrc(srcfactoralpha);
+  requires_dual_src |= IsDualSrc(dstfactor) || IsDualSrc(dstfactoralpha);
+  requires_dual_src &= blendenable && usedualsrc;
+  return requires_dual_src;
+}
+
 // If the framebuffer format has no alpha channel, it is assumed to
 // ONE on blending. As the backends may emulate this framebuffer
 // configuration with an alpha channel, we just drop all references

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -120,12 +120,12 @@ void BlendingState::Generate(const BPMemory& bp)
   // Start with everything disabled.
   hex = 0;
 
-  bool target_has_alpha = bp.zcontrol.pixel_format == PixelFormat::RGBA6_Z24;
-  bool alpha_test_may_succeed = bp.alpha_test.TestResult() != AlphaTestResult::Fail;
+  const bool target_has_alpha = bp.zcontrol.pixel_format == PixelFormat::RGBA6_Z24;
+  const bool alpha_test_may_succeed = bp.alpha_test.TestResult() != AlphaTestResult::Fail;
 
   colorupdate = bp.blendmode.colorupdate && alpha_test_may_succeed;
   alphaupdate = bp.blendmode.alphaupdate && target_has_alpha && alpha_test_may_succeed;
-  dstalpha = bp.dstalpha.enable && alphaupdate;
+  const bool dstalpha = bp.dstalpha.enable && alphaupdate;
   usedualsrc = true;
 
   // The subtract bit has the highest priority

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -130,7 +130,6 @@ union BlendingState
 
   BitField<0, 1, u32> blendenable;
   BitField<1, 1, u32> logicopenable;
-  BitField<2, 1, u32> dstalpha;
   BitField<3, 1, u32> colorupdate;
   BitField<4, 1, u32> alphaupdate;
   BitField<5, 1, u32> subtract;

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -142,6 +142,8 @@ union BlendingState
   BitField<17, 3, SrcBlendFactor> srcfactoralpha;
   BitField<20, 4, LogicOp> logicmode;
 
+  bool RequiresDualSrc() const;
+
   u32 hex;
 };
 

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -10,6 +10,7 @@
 #include "Common/MsgHandler.h"
 #include "Core/ConfigManager.h"
 
+#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/FramebufferShaderGen.h"
 #include "VideoCommon/RenderBase.h"
@@ -612,8 +613,95 @@ AbstractPipelineConfig ShaderCache::GetGXPipelineConfig(
   return config;
 }
 
-std::optional<AbstractPipelineConfig> ShaderCache::GetGXPipelineConfig(const GXPipelineUid& config)
+/// Edits the UID based on driver bugs and other special configurations
+static GXPipelineUid ApplyDriverBugs(const GXPipelineUid& in)
 {
+  GXPipelineUid out;
+  memcpy(&out, &in, sizeof(out));  // copy padding
+  pixel_shader_uid_data* ps = out.ps_uid.GetUidData();
+  BlendingState& blend = out.blending_state;
+
+  if (ps->ztest == EmulatedZ::ForcedEarly && !out.depth_state.updateenable)
+  {
+    // No need to force early depth test if you're not writing z
+    ps->ztest = EmulatedZ::Early;
+  }
+
+  const bool benefits_from_ps_dual_source_off =
+      (!g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
+       g_ActiveConfig.backend_info.bSupportsFramebufferFetch) ||
+      DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING);
+  if (benefits_from_ps_dual_source_off && !blend.RequiresDualSrc())
+  {
+    // Only use dual-source blending when required on drivers that don't support it very well.
+    ps->no_dual_src = true;
+    blend.usedualsrc = false;
+  }
+
+  if (g_ActiveConfig.backend_info.bSupportsFramebufferFetch)
+  {
+    bool fbfetch_blend = false;
+    if ((DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DISCARD_WITH_EARLY_Z) ||
+         !g_ActiveConfig.backend_info.bSupportsEarlyZ) &&
+        ps->ztest == EmulatedZ::ForcedEarly)
+    {
+      ps->ztest = EmulatedZ::EarlyWithFBFetch;
+      fbfetch_blend |= static_cast<bool>(out.blending_state.blendenable);
+      ps->no_dual_src = true;
+    }
+    fbfetch_blend |= blend.logicopenable && !g_ActiveConfig.backend_info.bSupportsLogicOp;
+    fbfetch_blend |= blend.usedualsrc && !g_ActiveConfig.backend_info.bSupportsDualSourceBlend;
+    if (fbfetch_blend)
+    {
+      ps->no_dual_src = true;
+      if (blend.logicopenable)
+      {
+        ps->logic_op_enable = true;
+        ps->logic_op_mode = static_cast<u32>(blend.logicmode.Value());
+        blend.logicopenable = false;
+      }
+      if (blend.blendenable)
+      {
+        ps->blend_enable = true;
+        ps->blend_src_factor = blend.srcfactor;
+        ps->blend_src_factor_alpha = blend.srcfactoralpha;
+        ps->blend_dst_factor = blend.dstfactor;
+        ps->blend_dst_factor_alpha = blend.dstfactoralpha;
+        ps->blend_subtract = blend.subtract;
+        ps->blend_subtract_alpha = blend.subtractAlpha;
+        blend.blendenable = false;
+      }
+    }
+  }
+
+  // force dual src off if we can't support it
+  if (!g_ActiveConfig.backend_info.bSupportsDualSourceBlend)
+  {
+    ps->no_dual_src = true;
+    blend.usedualsrc = false;
+  }
+
+  if (ps->ztest == EmulatedZ::ForcedEarly && !g_ActiveConfig.backend_info.bSupportsEarlyZ)
+  {
+    // These things should be false
+    ASSERT(!ps->zfreeze);
+    // ZCOMPLOC HACK:
+    // The only way to emulate alpha test + early-z is to force early-z in the shader.
+    // As this isn't available on all drivers and as we can't emulate this feature otherwise,
+    // we are only able to choose which one we want to respect more.
+    // Tests seem to have proven that writing depth even when the alpha test fails is more
+    // important that a reliable alpha test, so we just force the alpha test to always succeed.
+    // At least this seems to be less buggy.
+    ps->ztest = EmulatedZ::EarlyWithZComplocHack;
+  }
+
+  return out;
+}
+
+std::optional<AbstractPipelineConfig>
+ShaderCache::GetGXPipelineConfig(const GXPipelineUid& config_in)
+{
+  GXPipelineUid config = ApplyDriverBugs(config_in);
   const AbstractShader* vs;
   auto vs_iter = m_vs_cache.shader_map.find(config.vs_uid);
   if (vs_iter != m_vs_cache.shader_map.end() && !vs_iter->second.pending)
@@ -650,9 +738,25 @@ std::optional<AbstractPipelineConfig> ShaderCache::GetGXPipelineConfig(const GXP
                              config.depth_state, config.blending_state);
 }
 
-std::optional<AbstractPipelineConfig>
-ShaderCache::GetGXPipelineConfig(const GXUberPipelineUid& config)
+/// Edits the UID based on driver bugs and other special configurations
+static GXUberPipelineUid ApplyDriverBugs(const GXUberPipelineUid& in)
 {
+  GXUberPipelineUid out;
+  memcpy(&out, &in, sizeof(out));  // Copy padding
+  if (!g_ActiveConfig.backend_info.bSupportsDualSourceBlend ||
+      (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) &&
+       !out.blending_state.RequiresDualSrc()))
+  {
+    out.blending_state.usedualsrc = false;
+    out.ps_uid.GetUidData()->no_dual_src = true;
+  }
+  return out;
+}
+
+std::optional<AbstractPipelineConfig>
+ShaderCache::GetGXPipelineConfig(const GXUberPipelineUid& config_in)
+{
+  GXUberPipelineUid config = ApplyDriverBugs(config_in);
   const AbstractShader* vs;
   auto vs_iter = m_uber_vs_cache.shader_map.find(config.vs_uid);
   if (vs_iter != m_uber_vs_cache.shader_map.end() && !vs_iter->second.pending)
@@ -981,12 +1085,14 @@ void ShaderCache::QueuePipelineCompile(const GXPipelineUid& uid, u32 priority)
     {
       stages_ready = true;
 
-      auto vs_it = shader_cache->m_vs_cache.shader_map.find(uid.vs_uid);
+      GXPipelineUid actual_uid = ApplyDriverBugs(uid);
+
+      auto vs_it = shader_cache->m_vs_cache.shader_map.find(actual_uid.vs_uid);
       stages_ready &= vs_it != shader_cache->m_vs_cache.shader_map.end() && !vs_it->second.pending;
       if (vs_it == shader_cache->m_vs_cache.shader_map.end())
-        shader_cache->QueueVertexShaderCompile(uid.vs_uid, priority);
+        shader_cache->QueueVertexShaderCompile(actual_uid.vs_uid, priority);
 
-      PixelShaderUid ps_uid = uid.ps_uid;
+      PixelShaderUid ps_uid = actual_uid.ps_uid;
       ClearUnusedPixelShaderUidBits(shader_cache->m_api_type, shader_cache->m_host_config, &ps_uid);
 
       auto ps_it = shader_cache->m_ps_cache.shader_map.find(ps_uid);
@@ -1051,13 +1157,15 @@ void ShaderCache::QueueUberPipelineCompile(const GXUberPipelineUid& uid, u32 pri
     {
       stages_ready = true;
 
-      auto vs_it = shader_cache->m_uber_vs_cache.shader_map.find(uid.vs_uid);
+      GXUberPipelineUid actual_uid = ApplyDriverBugs(uid);
+
+      auto vs_it = shader_cache->m_uber_vs_cache.shader_map.find(actual_uid.vs_uid);
       stages_ready &=
           vs_it != shader_cache->m_uber_vs_cache.shader_map.end() && !vs_it->second.pending;
       if (vs_it == shader_cache->m_uber_vs_cache.shader_map.end())
-        shader_cache->QueueVertexUberShaderCompile(uid.vs_uid, priority);
+        shader_cache->QueueVertexUberShaderCompile(actual_uid.vs_uid, priority);
 
-      UberShader::PixelShaderUid ps_uid = uid.ps_uid;
+      UberShader::PixelShaderUid ps_uid = actual_uid.ps_uid;
       UberShader::ClearUnusedPixelShaderUidBits(shader_cache->m_api_type,
                                                 shader_cache->m_host_config, &ps_uid);
 

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -743,9 +743,17 @@ static GXUberPipelineUid ApplyDriverBugs(const GXUberPipelineUid& in)
 {
   GXUberPipelineUid out;
   memcpy(&out, &in, sizeof(out));  // Copy padding
-  if (!g_ActiveConfig.backend_info.bSupportsDualSourceBlend ||
-      (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) &&
-       !out.blending_state.RequiresDualSrc()))
+  if (g_ActiveConfig.backend_info.bSupportsFramebufferFetch)
+  {
+    // Always blend in shader
+    out.blending_state.hex = 0;
+    out.blending_state.colorupdate = in.blending_state.colorupdate.Value();
+    out.blending_state.alphaupdate = in.blending_state.alphaupdate.Value();
+    out.ps_uid.GetUidData()->no_dual_src = true;
+  }
+  else if (!g_ActiveConfig.backend_info.bSupportsDualSourceBlend ||
+           (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) &&
+            !out.blending_state.RequiresDualSrc()))
   {
     out.blending_state.usedualsrc = false;
     out.ps_uid.GetUidData()->no_dual_src = true;

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -21,12 +21,12 @@ PixelShaderUid GetPixelShaderUid()
 
   pixel_ubershader_uid_data* const uid_data = out.GetUidData();
   uid_data->num_texgens = xfmem.numTexGen.numTexGens;
-  uid_data->early_depth = bpmem.UseEarlyDepthTest() &&
+  uid_data->early_depth = bpmem.GetEmulatedZ() == EmulatedZ::Early &&
                           (g_ActiveConfig.bFastDepthCalc ||
                            bpmem.alpha_test.TestResult() == AlphaTestResult::Undetermined) &&
                           !(bpmem.zmode.testenable && bpmem.genMode.zfreeze);
   uid_data->per_pixel_depth =
-      (bpmem.ztex2.op != ZTexOp::Disabled && bpmem.UseLateDepthTest()) ||
+      (bpmem.ztex2.op != ZTexOp::Disabled && bpmem.GetEmulatedZ() == EmulatedZ::Late) ||
       (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !uid_data->early_depth) ||
       (bpmem.zmode.testenable && bpmem.genMode.zfreeze);
   uid_data->uint_output = bpmem.blendmode.UseLogicOp();
@@ -38,6 +38,10 @@ void ClearUnusedPixelShaderUidBits(APIType api_type, const ShaderHostConfig& hos
                                    PixelShaderUid* uid)
 {
   pixel_ubershader_uid_data* const uid_data = uid->GetUidData();
+
+  // Dual source is always enabled in the shader if this bug is not present
+  if (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING))
+    uid_data->no_dual_src = 0;
 
   // OpenGL and Vulkan convert implicitly normalized color outputs to their uint representation.
   // Therefore, it is not necessary to use a uint output on these backends. We also disable the
@@ -53,8 +57,9 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
   const bool msaa = host_config.msaa;
   const bool ssaa = host_config.ssaa;
   const bool stereo = host_config.stereo;
-  const bool use_dual_source = host_config.backend_dual_source_blend;
-  const bool use_shader_blend = !use_dual_source && host_config.backend_shader_framebuffer_fetch;
+  const bool use_dual_source = host_config.backend_dual_source_blend && !uid_data->no_dual_src;
+  const bool use_shader_blend = !host_config.backend_dual_source_blend &&
+                                host_config.backend_shader_framebuffer_fetch;
   const bool use_shader_logic_op =
       !host_config.backend_logic_op && host_config.backend_shader_framebuffer_fetch;
   const bool use_framebuffer_fetch =
@@ -1273,7 +1278,11 @@ void EnumeratePixelShaderUids(const std::function<void(const PixelShaderUid&)>& 
         for (u32 uint_output = 0; uint_output < 2; uint_output++)
         {
           puid->uint_output = uint_output;
-          callback(uid);
+          for (u32 no_dual_src = 0; no_dual_src < 2; no_dual_src++)
+          {
+            puid->no_dual_src = no_dual_src;
+            callback(uid);
+          }
         }
       }
     }

--- a/Source/Core/VideoCommon/UberShaderPixel.h
+++ b/Source/Core/VideoCommon/UberShaderPixel.h
@@ -18,6 +18,7 @@ struct pixel_ubershader_uid_data
   u32 early_depth : 1;
   u32 per_pixel_depth : 1;
   u32 uint_output : 1;
+  u32 no_dual_src : 1;
 
   u32 NumValues() const { return sizeof(pixel_ubershader_uid_data); }
 };
@@ -42,9 +43,9 @@ struct fmt::formatter<UberShader::pixel_ubershader_uid_data>
   template <typename FormatContext>
   auto format(const UberShader::pixel_ubershader_uid_data& uid, FormatContext& ctx) const
   {
-    return fmt::format_to(ctx.out(), "Pixel UberShader for {} texgens{}{}{}", uid.num_texgens,
-                          uid.early_depth ? ", early-depth" : "",
-                          uid.per_pixel_depth ? ", per-pixel depth" : "",
-                          uid.uint_output ? ", uint output" : "");
+    return fmt::format_to(
+        ctx.out(), "Pixel UberShader for {} texgens{}{}{}{}", uid.num_texgens,
+        uid.early_depth ? ", early-depth" : "", uid.per_pixel_depth ? ", per-pixel depth" : "",
+        uid.uint_output ? ", uint output" : "", uid.no_dual_src ? ", no dual-source blending" : "");
   }
 };


### PR DESCRIPTION
Adds a fixup pass that runs between the pipeline uid cache and actual pipeline generation that applies fixups based on the current backend's supported features.

A number of bugs (in particular `BUG_BROKEN_DUAL_SOURCE_BLENDING`) found themselves spread across VideoCommon and the backends, with each place having to guess at what the other would do, risking a failed pipeline compile if any disagreed.  With the new implementation, a single pass runs over the entire pipeline at a point where all other decisions have been finalized, so it can make decisions based on what is actually about to happen, rather than trying to guess.
I'm not super happy with the new location either though.  Other recommendations welcome.

Reasons for the new location:
- The UID cache is shared among all backends and GPUs, so placing it any earlier would mean that other GPUs' and backends' UIDs would end up getting compiled upon cache load, requiring some sort of validation of the UIDs in shader generation to make sure that you're not generating a shader that will fail to compile (even if the shader will never actually be used).
- Moving it any later will lose the ability to see the whole pipeline, which brings back the guesswork that was all over the old implementation.
- The current location is the only one currently in the emulator that satisfies both of the above needs
- Reduces the frequency that differences in bugs (which aren't serialized into cache IDs) result in bad cache hits in the shader binary cache when switching between two different GPUs in Vulkan.  We should really have a dedicated solution to this though.  Preferably one that takes actual shader source into account, so it notices when you edit shader generation functions.

Drawbacks of the new location:
- There's now two types of UIDs, one with and without fixups, with no differentiation in the type system to catch mixups
  - Maybe we should make the post-fixup UID a different type instead?
- If two UIDs map to the same post-fixup UID, the pipeline cache will still generate separate pipelines for them (since the cache is done on pre-fixup UIDs), which could result in unnecessary compilation stutter.
  - We could just leave this up to the backend/driver, as is done currently in the PR.
  - We could move the pipeline-reducing changes to a separate pre-UID-cache pass.  This would mean that when loading a uid cache touched by a GPU without fbfetch, the extra pipelines would still be unnecessarily created.  Both the "use fbfetch to remove separate pipeline blend modes" one included here and a future one I have planned wouldn't cause issues in any drivers just by compiling the additional pipelines, it would just be a bit wasteful.
  - We could add a second pipeline cache that isn't saved to disk and handles post-fixup UIDs

I also deleted dstalpha from the BlendingState struct, since none of the backends use it anymore.  I assume this is fine?  Also, should I adjust the positions of all the other bitfields to fill in the gap?

### Testing needed
- I changed the meaning of `BUG_BROKEN_DUAL_SOURCE_BLENDING` to "dual source breaks when the shader outputs  src1 but the blending configuration doesn't use it".  I can confirm (from testing for PCSX2) that this is the actual cause for the Intel graphics listed (and it means less brokenness for dstalpha, which previously still enabled DSB), but need verification that I didn't break things for the AMD GPUs with the flag.  If it does, maybe we should split it for the two different bug types.  I tried running on OpenGL+AMD+macOS and didn't notice anything weird, but maybe I didn't try the right game.
  - Mario Kart Double Dash uses dstalpha without blending, and is improved by this PR on Intel+MVK
    <details>
    <summary>Images</summary>

    ![image](https://user-images.githubusercontent.com/3315070/179317078-32a462b3-9159-45c8-bb1c-c2e13d8bf029.png)
    ![image](https://user-images.githubusercontent.com/3315070/179317276-cfa8c73a-4945-47b2-b7ff-9dfb8cdf6770.png)
    </details>

- I reduced `BUG_BROKEN_DISCARD_WITH_EARLY_Z` to only apply fbfetch when early z was in use.  I assume this won't break anything but you never know.  Please test on M1.
- I fully enabled all fbfetch things at all times on ubershaders when fbfetch is supported, which should reduce the number of different pipelines needed, but may slow down the shader a bit.  (It was also a lazy way for me to get around a bug in the unofficial Intel Metal fbfetch support, where fbfetch + dual source blend freezes the GPU.)  I assume this is fine since reducing compilation time is kind of the point of ubershaders, but it would be good to know others' opinions.  For reference, my UHD 630 goes from 24 to 20 fps at 2x resolution on the Wind Waker title screen flyover to enable fbfetch with exclusive ubershaders.
- I haven't actually tested this outside of macOS.  I don't see why it would break, but just in case.