### PR TITLE
VideoCommon: Fix ubershaders on MoltenVK Intel

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -377,6 +377,10 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
     // We will use shader blending, so disable hardware dual source blending.
     config->backend_info.bSupportsDualSourceBlend = false;
   }
+
+  // Dynamic sampler indexing locks up Intel GPUs on MoltenVK/Metal
+  if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING))
+    config->backend_info.bSupportsDynamicSamplerIndexing = false;
 }
 
 void VulkanContext::PopulateBackendInfoMultisampleModes(

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -142,6 +142,8 @@ constexpr BugInfo m_known_bugs[] = {
      -1.0, -1.0, true},
     {API_VULKAN, OS_OSX, VENDOR_APPLE, DRIVER_PORTABILITY, Family::UNKNOWN,
      BUG_BROKEN_DISCARD_WITH_EARLY_Z, -1.0, -1.0, true},
+    {API_VULKAN, OS_OSX, VENDOR_INTEL, DRIVER_PORTABILITY, Family::UNKNOWN,
+     BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -328,6 +328,12 @@ enum Bug
   // Started version: -1
   // Ended version: -1
   BUG_BROKEN_DISCARD_WITH_EARLY_Z,
+
+  // BUG: Using dynamic sampler indexing locks up the GPU
+  // Affected devices: Intel (macOS Metal)
+  // Started version: -1
+  // Ended version: -1
+  BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING,
 };
 
 // Initializes our internal vendor, device family, and driver version

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -503,14 +503,6 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
             "int4 getTevReg(in State s, uint index) {{\n");
   WriteSwitch(out, api_type, "index", tev_regs_lookup_table, 2, false);
   out.Write("}}\n"
-            "\n"
-            "void setRegColor(inout State s, uint index, int3 color) {{\n");
-  WriteSwitch(out, api_type, "index", tev_c_set_table, 2, true);
-  out.Write("}}\n"
-            "\n"
-            "void setRegAlpha(inout State s, uint index, int alpha) {{\n");
-  WriteSwitch(out, api_type, "index", tev_a_set_table, 2, true);
-  out.Write("}}\n"
             "\n");
 
   // Since the fixed-point texture coodinate variables aren't global, we need to pass
@@ -861,9 +853,9 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
       "      else\n"
       "        color = clamp(color, -1024, 1023);\n"
       "\n"
-      "      // Write result to the correct input register of the next stage\n"
-      "      setRegColor(s, color_dest, color);\n"
-      "\n");
+      "      // Write result to the correct input register of the next stage\n");
+  WriteSwitch(out, api_type, "color_dest", tev_c_set_table, 6, true);
+  out.Write("\n");
 
   // Alpha combiner
   out.Write("      // Alpha Combiner\n");
@@ -927,11 +919,10 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
             "      else\n"
             "        alpha = clamp(alpha, -1024, 1023);\n"
             "\n"
-            "      // Write result to the correct input register of the next stage\n"
-            "      setRegAlpha(s, alpha_dest, alpha);\n"
-            "    }}\n");
-
-  out.Write("  }} // Main TEV loop\n"
+            "      // Write result to the correct input register of the next stage\n");
+  WriteSwitch(out, api_type, "alpha_dest", tev_a_set_table, 6, true);
+  out.Write("    }}\n"
+            "  }} // Main TEV loop\n"
             "\n");
 
   // Select the output color and alpha registers from the last stage.


### PR DESCRIPTION
Intel's Metal driver seems to have issues with dynamic sampler indexing

Also includes a small performance fix for Intel on MoltenVK