### PR TITLE
Update supportedOS values in .manifest files

### DIFF
--- a/Source/Core/DolphinNoGUI/DolphinNoGUI.exe.manifest
+++ b/Source/Core/DolphinNoGUI/DolphinNoGUI.exe.manifest
@@ -21,9 +21,6 @@
 </dependency>
 <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
   <application>
-    <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-    <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-    <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
     <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
   </application>
 </compatibility>

--- a/Source/Core/DolphinQt/DolphinQt.manifest
+++ b/Source/Core/DolphinQt/DolphinQt.manifest
@@ -8,9 +8,6 @@
   </asmv3:application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>

--- a/Source/Core/DolphinTool/DolphinTool.exe.manifest
+++ b/Source/Core/DolphinTool/DolphinTool.exe.manifest
@@ -21,9 +21,6 @@
 </dependency>
 <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
   <application>
-    <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-    <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-    <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
     <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
   </application>
 </compatibility>

--- a/Source/Core/WinUpdater/Updater.exe.manifest
+++ b/Source/Core/WinUpdater/Updater.exe.manifest
@@ -21,9 +21,6 @@
 </dependency>
 <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
   <application>
-    <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-    <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-    <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
     <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
   </application>
 </compatibility>


### PR DESCRIPTION
With the dropping of support for Windows versions lower than 10, we should also update the .manifest files to reflect this. https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests#supportedos