### PR TITLE
VideoCommon: Better shader names

### DIFF
--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -430,7 +430,8 @@ ShaderCache::CompileVertexUberShader(const UberShader::VertexShaderUid& uid) con
 {
   const ShaderCode source_code =
       UberShader::GenVertexShader(m_api_type, m_host_config, uid.GetUidData());
-  return g_renderer->CreateShaderFromSource(ShaderStage::Vertex, source_code.GetBuffer());
+  return g_renderer->CreateShaderFromSource(ShaderStage::Vertex, source_code.GetBuffer(),
+                                            fmt::to_string(*uid.GetUidData()));
 }
 
 std::unique_ptr<AbstractShader> ShaderCache::CompilePixelShader(const PixelShaderUid& uid) const
@@ -445,7 +446,8 @@ ShaderCache::CompilePixelUberShader(const UberShader::PixelShaderUid& uid) const
 {
   const ShaderCode source_code =
       UberShader::GenPixelShader(m_api_type, m_host_config, uid.GetUidData());
-  return g_renderer->CreateShaderFromSource(ShaderStage::Pixel, source_code.GetBuffer());
+  return g_renderer->CreateShaderFromSource(ShaderStage::Pixel, source_code.GetBuffer(),
+                                            fmt::to_string(*uid.GetUidData()));
 }
 
 const AbstractShader* ShaderCache::InsertVertexShader(const VertexShaderUid& uid,

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -1347,11 +1347,11 @@ ShaderCache::GetTextureDecodingShader(TextureFormat format,
 {
   const auto key = std::make_pair(static_cast<u32>(format),
                                   static_cast<u32>(palette_format.value_or(TLUTFormat::IA8)));
-  auto iter = m_texture_decoding_shaders.find(key);
+  const auto iter = m_texture_decoding_shaders.find(key);
   if (iter != m_texture_decoding_shaders.end())
     return iter->second.get();
 
-  std::string shader_source =
+  const std::string shader_source =
       TextureConversionShaderTiled::GenerateDecodingShader(format, palette_format, APIType::OpenGL);
   if (shader_source.empty())
   {
@@ -1359,7 +1359,7 @@ ShaderCache::GetTextureDecodingShader(TextureFormat format,
     return nullptr;
   }
 
-  std::string name =
+  const std::string name =
       palette_format.has_value() ?
           fmt::format("Texture decoding compute shader: {}", format) :
           fmt::format("Texture decoding compute shader: {}, {}", format, *palette_format);
@@ -1372,7 +1372,7 @@ ShaderCache::GetTextureDecodingShader(TextureFormat format,
     return nullptr;
   }
 
-  auto iiter = m_texture_decoding_shaders.emplace(key, std::move(shader));
+  const auto iiter = m_texture_decoding_shaders.emplace(key, std::move(shader));
   return iiter.first->second.get();
 }
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -110,7 +110,8 @@ public:
                                                         TextureFormat to_format);
 
   // Texture decoding compute shaders
-  const AbstractShader* GetTextureDecodingShader(TextureFormat format, TLUTFormat palette_format);
+  const AbstractShader* GetTextureDecodingShader(TextureFormat format,
+                                                 std::optional<TLUTFormat> palette_format);
 
 private:
   static constexpr size_t NUM_PALETTE_CONVERSION_SHADERS = 3;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2809,7 +2809,8 @@ bool TextureCacheBase::DecodeTextureOnGPU(TCacheEntry* entry, u32 dst_level, con
   if (!info)
     return false;
 
-  const AbstractShader* shader = g_shader_cache->GetTextureDecodingShader(format, palette_format);
+  const AbstractShader* shader = g_shader_cache->GetTextureDecodingShader(
+      format, info->palette_size != 0 ? std::make_optional(palette_format) : std::nullopt);
   if (!shader)
     return false;
 

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -950,6 +950,7 @@ uint GetTiledTexelOffset(uint2 block_size, uint2 coords)
   return buffer_pos;
 }
 
+#if defined(HAS_PALETTE)
 uint4 GetPaletteColor(uint index)
 {
   // Fetch and swap BE to LE.
@@ -994,6 +995,7 @@ float4 GetPaletteColorNormalized(uint index)
   uint4 color = GetPaletteColor(index);
   return float4(color) / 255.0;
 }
+#endif // defined(HAS_PALETTE)
 
 )";
 
@@ -1385,7 +1387,7 @@ std::pair<u32, u32> GetDispatchCount(const DecodingShaderInfo* info, u32 width, 
           (height + (info->group_size_y - 1)) / info->group_size_y};
 }
 
-std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_format,
+std::string GenerateDecodingShader(TextureFormat format, std::optional<TLUTFormat> palette_format,
                                    APIType api_type)
 {
   const DecodingShaderInfo* info = GetDecodingShaderInfo(format);
@@ -1393,17 +1395,20 @@ std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_form
     return "";
 
   std::ostringstream ss;
-  switch (palette_format)
+  if (palette_format.has_value())
   {
-  case TLUTFormat::IA8:
-    ss << "#define PALETTE_FORMAT_IA8 1\n";
-    break;
-  case TLUTFormat::RGB565:
-    ss << "#define PALETTE_FORMAT_RGB565 1\n";
-    break;
-  case TLUTFormat::RGB5A3:
-    ss << "#define PALETTE_FORMAT_RGB5A3 1\n";
-    break;
+    switch (*palette_format)
+    {
+    case TLUTFormat::IA8:
+      ss << "#define PALETTE_FORMAT_IA8 1\n";
+      break;
+    case TLUTFormat::RGB565:
+      ss << "#define PALETTE_FORMAT_RGB565 1\n";
+      break;
+    case TLUTFormat::RGB5A3:
+      ss << "#define PALETTE_FORMAT_RGB5A3 1\n";
+      break;
+    }
   }
 
   ss << decoding_shader_header;

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -41,7 +42,7 @@ const DecodingShaderInfo* GetDecodingShaderInfo(TextureFormat format);
 std::pair<u32, u32> GetDispatchCount(const DecodingShaderInfo* info, u32 width, u32 height);
 
 // Returns the GLSL string containing the texture decoding shader for the specified format.
-std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_format,
+std::string GenerateDecodingShader(TextureFormat format, std::optional<TLUTFormat> palette_format,
                                    APIType api_type);
 
 // Returns the GLSL string containing the palette conversion shader for the specified format.

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -66,8 +66,7 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
   const u32 numTexgen = uid_data->num_texgens;
   ShaderCode out;
 
-  out.Write("// Pixel UberShader for {} texgens{}{}\n", numTexgen,
-            early_depth ? ", early-depth" : "", per_pixel_depth ? ", per-pixel depth" : "");
+  out.Write("// {}\n", *uid_data);
   WriteBitfieldExtractHeader(out, api_type, host_config);
   WritePixelShaderCommonHeader(out, api_type, host_config, bounding_box);
   if (per_pixel_lighting)

--- a/Source/Core/VideoCommon/UberShaderPixel.h
+++ b/Source/Core/VideoCommon/UberShaderPixel.h
@@ -34,3 +34,17 @@ void EnumeratePixelShaderUids(const std::function<void(const PixelShaderUid&)>& 
 void ClearUnusedPixelShaderUidBits(APIType api_type, const ShaderHostConfig& host_config,
                                    PixelShaderUid* uid);
 }  // namespace UberShader
+
+template <>
+struct fmt::formatter<UberShader::pixel_ubershader_uid_data>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const UberShader::pixel_ubershader_uid_data& uid, FormatContext& ctx) const
+  {
+    return fmt::format_to(ctx.out(), "Pixel UberShader for {} texgens{}{}{}", uid.num_texgens,
+                          uid.early_depth ? ", early-depth" : "",
+                          uid.per_pixel_depth ? ", per-pixel depth" : "",
+                          uid.uint_output ? ", uint output" : "");
+  }
+};

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -34,7 +34,7 @@ ShaderCode GenVertexShader(APIType api_type, const ShaderHostConfig& host_config
   const u32 num_texgen = uid_data->num_texgens;
   ShaderCode out;
 
-  out.Write("// Vertex UberShader\n\n");
+  out.Write("// {}\n\n", *uid_data);
   out.Write("{}", s_lighting_struct);
 
   // uniforms

--- a/Source/Core/VideoCommon/UberShaderVertex.h
+++ b/Source/Core/VideoCommon/UberShaderVertex.h
@@ -25,3 +25,14 @@ ShaderCode GenVertexShader(APIType api_type, const ShaderHostConfig& host_config
                            const vertex_ubershader_uid_data* uid_data);
 void EnumerateVertexShaderUids(const std::function<void(const VertexShaderUid&)>& callback);
 }  // namespace UberShader
+
+template <>
+struct fmt::formatter<UberShader::vertex_ubershader_uid_data>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const UberShader::vertex_ubershader_uid_data& uid, FormatContext& ctx) const
+  {
+    return fmt::format_to(ctx.out(), "Vertex UberShader for {} texgens", uid.num_texgens);
+  }
+};


### PR DESCRIPTION
- Adds names to ubershaders
- Removes palette from names of texture decoding shaders that don't require a palette
  - Also prevents separate versions from being made for each palette type, since they don't use palettes