### PR TITLE
VideoCommon: Don't add garbage to shader uids in debug builds

### DIFF
--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -71,6 +71,8 @@ public:
   static_assert(std::is_trivially_copyable_v<uid_data>,
                 "uid_data must be a trivially copyable type");
 
+  ShaderUid() { memset(GetUidData(), 0, GetUidDataSize()); }
+
   bool operator==(const ShaderUid& obj) const
   {
     return memcmp(GetUidData(), obj.GetUidData(), GetUidDataSize()) == 0;


### PR DESCRIPTION
Prevents debug builds from leaving stack data in UIDs, making them no longer compare equal

There wasn't anything stopping compilers from doing it in release builds either, but most optimizations would make the padding zero