### PR TITLE
updater: use new platform id for win-arm64

### DIFF
--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -128,12 +128,8 @@ std::string GenerateChangelog(const picojson::array& versions)
 
 bool AutoUpdateChecker::SystemSupportsAutoUpdates()
 {
-#if defined AUTOUPDATE
-#if defined _WIN32 || defined __APPLE__
+#if defined(AUTOUPDATE) && (defined(_WIN32) || defined(__APPLE__))
   return true;
-#else
-  return false;
-#endif
 #else
   return false;
 #endif
@@ -141,9 +137,13 @@ bool AutoUpdateChecker::SystemSupportsAutoUpdates()
 
 static std::string GetPlatformID()
 {
-#if defined _WIN32
+#if defined(_WIN32)
+#if defined(_M_ARM_64)
+  return "win-arm64";
+#else
   return "win";
-#elif defined __APPLE__
+#endif
+#elif defined(__APPLE__)
 #if defined(MACOS_UNIVERSAL_BUILD)
   return "macos-universal";
 #else


### PR DESCRIPTION
www appears to just be using "win" for deciding which binary to serve, so add a new identifier for arm64