### PR TITLE
DSPHLE: Handle mail more accurately

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -67,7 +67,7 @@ void DSPHLE::SendMailToDSP(u32 mail)
 
 void DSPHLE::SetUCode(u32 crc)
 {
-  m_mail_handler.Clear();
+  m_mail_handler.ClearPending();
   m_ucode = UCodeFactory(crc, this, m_wii);
   m_ucode->Initialize();
 }
@@ -77,7 +77,7 @@ void DSPHLE::SetUCode(u32 crc)
 // Even callers are deleted.
 void DSPHLE::SwapUCode(u32 crc)
 {
-  m_mail_handler.Clear();
+  m_mail_handler.ClearPending();
 
   if (m_last_ucode && UCodeInterface::GetCRC(m_last_ucode.get()) == crc)
   {

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -196,6 +196,7 @@ u16 DSPHLE::DSP_WriteControlRegister(u16 value)
   {
     INFO_LOG_FMT(DSPHLE, "DSP_CONTROL halt bit changed: {:04x} -> {:04x}", m_dsp_control.Hex,
                  value);
+    m_mail_handler.SetHalted(temp.DSPHalt);
   }
 
   if (temp.DSPReset)

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -39,7 +39,7 @@ void CMailHandler::PushMail(u32 mail, bool interrupt, int cycles_into_future)
 u16 CMailHandler::ReadDSPMailboxHigh()
 {
   // check if we have a mail for the CPU core
-  if (!m_pending_mails.empty())
+  if (!m_halted && !m_pending_mails.empty())
   {
     m_last_mail = m_pending_mails.front().first;
   }
@@ -49,7 +49,7 @@ u16 CMailHandler::ReadDSPMailboxHigh()
 u16 CMailHandler::ReadDSPMailboxLow()
 {
   // check if we have a mail for the CPU core
-  if (!m_pending_mails.empty())
+  if (!m_halted && !m_pending_mails.empty())
   {
     m_last_mail = m_pending_mails.front().first;
     const bool generate_interrupt = m_pending_mails.front().second;
@@ -79,13 +79,9 @@ bool CMailHandler::HasPending() const
   return !m_pending_mails.empty();
 }
 
-void CMailHandler::Halt(bool _Halt)
+void CMailHandler::SetHalted(bool halt)
 {
-  if (_Halt)
-  {
-    ClearPending();
-    PushMail(0x80544348);
-  }
+  m_halted = halt;
 }
 
 void CMailHandler::DoState(PointerWrap& p)

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -19,7 +19,6 @@ CMailHandler::CMailHandler()
 
 CMailHandler::~CMailHandler()
 {
-  Clear();
 }
 
 void CMailHandler::PushMail(u32 mail, bool interrupt, int cycles_into_future)
@@ -69,7 +68,7 @@ u16 CMailHandler::ReadDSPMailboxLow()
   return 0x00;
 }
 
-void CMailHandler::Clear()
+void CMailHandler::ClearPending()
 {
   while (!m_Mails.empty())
     m_Mails.pop();
@@ -84,7 +83,7 @@ void CMailHandler::Halt(bool _Halt)
 {
   if (_Halt)
   {
-    Clear();
+    ClearPending();
     PushMail(0x80544348);
   }
 }
@@ -93,7 +92,7 @@ void CMailHandler::DoState(PointerWrap& p)
 {
   if (p.IsReadMode())
   {
-    Clear();
+    ClearPending();
     int sz = 0;
     p.Do(sz);
     for (int i = 0; i < sz; i++)

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -75,9 +75,9 @@ void CMailHandler::Clear()
     m_Mails.pop();
 }
 
-bool CMailHandler::IsEmpty() const
+bool CMailHandler::HasPending() const
 {
-  return m_Mails.empty();
+  return !m_Mails.empty();
 }
 
 void CMailHandler::Halt(bool _Halt)

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.h
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <queue>
+#include <deque>
 #include <utility>
 
 #include "Common/CommonTypes.h"
@@ -33,7 +33,9 @@ public:
   u16 ReadDSPMailboxLow();
 
 private:
-  // mail handler
-  std::queue<std::pair<u32, bool>> m_Mails;
+  // The actual DSP only has a single pair of mail registers, and doesn't keep track of pending
+  // mails. But for HLE, it's a lot easier to write all the mails that will be read ahead of time,
+  // and then give them to the CPU in the requested order.
+  std::deque<std::pair<u32, bool>> m_pending_mails;
 };
 }  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.h
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.h
@@ -20,7 +20,7 @@ public:
 
   // TODO: figure out correct timing for interrupts rather than defaulting to "immediately."
   void PushMail(u32 mail, bool interrupt = false, int cycles_into_future = 0);
-  void Halt(bool _Halt);
+  void SetHalted(bool halt);
   void DoState(PointerWrap& p);
   bool HasPending() const;
 
@@ -42,5 +42,7 @@ private:
   // If no pending mail exists, the last mail that was read is returned,
   // but with the top bit (0x80000000) cleared.
   u32 m_last_mail = 0;
+  // When halted, the DSP itself is not running, but the last mail can be read.
+  bool m_halted = false;
 };
 }  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.h
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.h
@@ -27,6 +27,8 @@ public:
   // Clear any pending mail from the current uCode.  This is called by DSPHLE::SetUCode and
   // DSPHLE::SwapUCode. Since pending mail is an abstraction for DSPHLE and not something that
   // actually exists on real hardware, HLE implementations do not need to call this directly.
+  // Note that this function does not reset m_last_mail, which will continue to read the same value
+  // until the new uCode sends mail.
   void ClearPending();
 
   u16 ReadDSPMailboxHigh();
@@ -37,5 +39,8 @@ private:
   // mails. But for HLE, it's a lot easier to write all the mails that will be read ahead of time,
   // and then give them to the CPU in the requested order.
   std::deque<std::pair<u32, bool>> m_pending_mails;
+  // If no pending mail exists, the last mail that was read is returned,
+  // but with the top bit (0x80000000) cleared.
+  u32 m_last_mail = 0;
 };
 }  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.h
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.h
@@ -20,10 +20,14 @@ public:
 
   // TODO: figure out correct timing for interrupts rather than defaulting to "immediately."
   void PushMail(u32 mail, bool interrupt = false, int cycles_into_future = 0);
-  void Clear();
   void Halt(bool _Halt);
   void DoState(PointerWrap& p);
   bool HasPending() const;
+
+  // Clear any pending mail from the current uCode.  This is called by DSPHLE::SetUCode and
+  // DSPHLE::SwapUCode. Since pending mail is an abstraction for DSPHLE and not something that
+  // actually exists on real hardware, HLE implementations do not need to call this directly.
+  void ClearPending();
 
   u16 ReadDSPMailboxHigh();
   u16 ReadDSPMailboxLow();

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.h
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.h
@@ -23,7 +23,7 @@ public:
   void Clear();
   void Halt(bool _Halt);
   void DoState(PointerWrap& p);
-  bool IsEmpty() const;
+  bool HasPending() const;
 
   u16 ReadDSPMailboxHigh();
   u16 ReadDSPMailboxLow();

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -34,7 +34,6 @@ AXUCode::AXUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 
 AXUCode::~AXUCode()
 {
-  m_mail_handler.Clear();
 }
 
 void AXUCode::Initialize()

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -32,10 +32,6 @@ AXUCode::AXUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
   INFO_LOG_FMT(DSPHLE, "Instantiating AXUCode: crc={:08x}", crc);
 }
 
-AXUCode::~AXUCode()
-{
-}
-
 void AXUCode::Initialize()
 {
   m_mail_handler.PushMail(DSP_INIT, true);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -66,7 +66,6 @@ class AXUCode : public UCodeInterface
 {
 public:
   AXUCode(DSPHLE* dsphle, u32 crc);
-  ~AXUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -30,10 +30,6 @@ AXWiiUCode::AXWiiUCode(DSPHLE* dsphle, u32 crc) : AXUCode(dsphle, crc), m_last_m
   m_old_axwii = (crc == 0xfa450138) || (crc == 0x7699af32);
 }
 
-AXWiiUCode::~AXWiiUCode()
-{
-}
-
 void AXWiiUCode::HandleCommandList()
 {
   // Temp variables for addresses computation

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
@@ -15,7 +15,6 @@ class AXWiiUCode : public AXUCode
 {
 public:
   AXWiiUCode(DSPHLE* dsphle, u32 crc);
-  ~AXWiiUCode() override;
 
   void DoState(PointerWrap& p) override;
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -28,8 +28,8 @@ void CARDUCode::Initialize()
 
 void CARDUCode::Update()
 {
-  // check if we have to sent something
-  if (!m_mail_handler.IsEmpty())
+  // check if we have something to send
+  if (m_mail_handler.HasPending())
   {
     DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
   }

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -16,10 +16,6 @@ CARDUCode::CARDUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
   INFO_LOG_FMT(DSPHLE, "CARDUCode - initialized");
 }
 
-CARDUCode::~CARDUCode()
-{
-}
-
 void CARDUCode::Initialize()
 {
   m_mail_handler.PushMail(DSP_INIT);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -18,7 +18,6 @@ CARDUCode::CARDUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 
 CARDUCode::~CARDUCode()
 {
-  m_mail_handler.Clear();
 }
 
 void CARDUCode::Initialize()

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
@@ -14,7 +14,6 @@ class CARDUCode : public UCodeInterface
 {
 public:
   CARDUCode(DSPHLE* dsphle, u32 crc);
-  ~CARDUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -85,8 +85,8 @@ void GBAUCode::Initialize()
 
 void GBAUCode::Update()
 {
-  // check if we have to send something
-  if (!m_mail_handler.IsEmpty())
+  // check if we have something to send
+  if (m_mail_handler.HasPending())
   {
     DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
   }

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -75,7 +75,6 @@ GBAUCode::GBAUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 
 GBAUCode::~GBAUCode()
 {
-  m_mail_handler.Clear();
 }
 
 void GBAUCode::Initialize()

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -73,10 +73,6 @@ GBAUCode::GBAUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 {
 }
 
-GBAUCode::~GBAUCode()
-{
-}
-
 void GBAUCode::Initialize()
 {
   m_mail_handler.PushMail(DSP_INIT);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
@@ -18,7 +18,6 @@ void ProcessGBACrypto(u32 address);
 struct GBAUCode : public UCodeInterface
 {
   GBAUCode(DSPHLE* dsphle, u32 crc);
-  ~GBAUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
@@ -16,10 +16,6 @@ INITUCode::INITUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
   INFO_LOG_FMT(DSPHLE, "INITUCode - initialized");
 }
 
-INITUCode::~INITUCode()
-{
-}
-
 void INITUCode::Initialize()
 {
   m_mail_handler.PushMail(0x80544348);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
@@ -14,7 +14,6 @@ class INITUCode : public UCodeInterface
 {
 public:
   INITUCode(DSPHLE* dsphle, u32 crc);
-  ~INITUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -34,7 +34,6 @@ ROMUCode::~ROMUCode()
 
 void ROMUCode::Initialize()
 {
-  m_mail_handler.Clear();
   m_mail_handler.PushMail(0x8071FEED);
 }
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -28,10 +28,6 @@ ROMUCode::ROMUCode(DSPHLE* dsphle, u32 crc)
   INFO_LOG_FMT(DSPHLE, "UCode_Rom - initialized");
 }
 
-ROMUCode::~ROMUCode()
-{
-}
-
 void ROMUCode::Initialize()
 {
   m_mail_handler.PushMail(0x8071FEED);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
@@ -14,7 +14,6 @@ class ROMUCode : public UCodeInterface
 {
 public:
   ROMUCode(DSPHLE* dsphle, u32 crc);
-  ~ROMUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -130,7 +130,6 @@ ZeldaUCode::ZeldaUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 
 ZeldaUCode::~ZeldaUCode()
 {
-  m_mail_handler.Clear();
 }
 
 void ZeldaUCode::Initialize()

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -128,10 +128,6 @@ ZeldaUCode::ZeldaUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
   INFO_LOG_FMT(DSPHLE, "Zelda UCode loaded, crc={:08x}, flags={:08x}", crc, m_flags);
 }
 
-ZeldaUCode::~ZeldaUCode()
-{
-}
-
 void ZeldaUCode::Initialize()
 {
   if (m_flags & LIGHT_PROTOCOL)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -191,7 +191,6 @@ class ZeldaUCode : public UCodeInterface
 {
 public:
   ZeldaUCode(DSPHLE* dsphle, u32 crc);
-  ~ZeldaUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;


### PR DESCRIPTION
Split from #10732.  This (specifically the halted change) fixes booting Datel titles with DSP HLE ([issue 12943](https://bugs.dolphin-emu.org/issues/12943)).