### PR TITLE
DSPLLE: Don't log when DIRQ is set to 0

### DIFF
--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -96,9 +96,15 @@ void SDSP::WriteIFX(u32 address, u16 value)
   {
   case DSP_DIRQ:
     if ((value & 1) != 0)
+    {
       Host::InterruptRequest();
-    else
+    }
+    else if (value != 0)
+    {
+      // The homebrew libasnd uCode frequently writes 0 to DIRQ with a comment
+      // saying "clear the interrupt" - we don't need to log in this case.
       WARN_LOG_FMT(DSPLLE, "Unknown Interrupt Request pc={:#06x} ({:#06x})", pc, value);
+    }
     break;
 
   case DSP_DMBH:


### PR DESCRIPTION
No interrupt is generated in this case. The homebrew liband uCode writes zero fairly frequently, so logging it results in spam.

For reference:

https://github.com/devkitPro/libogc/blob/6c104219be4f3741c59446948052311a405de7cf/libasnd/dsp_mixer/dsp_mixer.s#L334
https://github.com/devkitPro/libogc/blob/6c104219be4f3741c59446948052311a405de7cf/libasnd/dsp_mixer/dsp_mixer.s#L348
https://github.com/devkitPro/libogc/blob/6c104219be4f3741c59446948052311a405de7cf/libasnd/dsp_mixer/dsp_mixer.s#L385