### PR TITLE
Qt/MemoryViewWidget: Don't elide text

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -254,6 +254,7 @@ void MemoryViewWidget::Update()
   m_table->verticalHeader()->setDefaultSectionSize(m_font_vspace - 1);
   m_table->verticalHeader()->setMinimumSectionSize(m_font_vspace - 1);
   m_table->horizontalHeader()->setMinimumSectionSize(m_font_width * 2);
+  m_table->setTextElideMode(Qt::TextElideMode::ElideNone);
 
   const AddressSpace::Accessors* accessors = AddressSpace::GetAccessors(m_address_space);
 


### PR DESCRIPTION
Before, the Hex 32 display would get truncated on Linux.

Tested on WSL with VcXsrv.  Before:

![image](https://user-images.githubusercontent.com/8334194/174700059-ff183854-98f4-489b-9520-37e24fba9a99.png)

After:

![image](https://user-images.githubusercontent.com/8334194/174700070-ca6b7acb-2c5f-4b96-8758-cf3bcc1dd7ce.png)
