### PR TITLE
Replace Cpp11 with Latest in .clang-format

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -78,7 +78,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        Latest
 TabWidth:        2
 UseTab:          Never
 ---


### PR DESCRIPTION

From https://clang.llvm.org/docs/ClangFormatStyleOptions.html:
```
LS_Latest (in configuration: Latest) Parse and format using the latest supported language version. Cpp11 is a deprecated alias for Latest
```