### PR TITLE
IP/Top: Expand host nameserver usage

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -605,6 +605,7 @@ if (APPLE)
     ${CORESERV_LIBRARY}
     ${IOB_LIBRARY}
     ${IOK_LIBRARY}
+    resolv
   )
 elseif (ANDROID)
   target_link_libraries(core

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -864,7 +864,8 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
         FREE(AdapterAddresses);
       }
     }
-#elif defined(__linux__) && !defined(__ANDROID__)
+#elif (defined(__linux__) && !defined(ANDROID)) || defined(__APPLE__) || defined(__FreeBSD__) ||   \
+    defined(__OpenBSD__) || defined(__NetBSD__) || defined(__HAIKU__)
     if (!Core::WantsDeterminism())
     {
       if (res_init() == 0)

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -868,9 +868,22 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
     if (!Core::WantsDeterminism())
     {
       if (res_init() == 0)
-        address = ntohl(_res.nsaddr_list[0].sin_addr.s_addr);
+      {
+        for (int i = 0; i < _res.nscount; i++)
+        {
+          // Find the first available IPv4 nameserver.
+          sockaddr_in current = _res.nsaddr_list[i];
+          if (current.sin_family == AF_INET)
+          {
+            address = ntohl(_res.nsaddr_list[i].sin_addr.s_addr);
+            break;
+          }
+        }
+      }
       else
+      {
         WARN_LOG_FMT(IOS_NET, "Call to res_init failed");
+      }
     }
 #endif
     if (address == 0)


### PR DESCRIPTION
Currently, having an IPv6 nameserver as the first to the host makes Dolphin immediately fall back to the default/backup nameserver. This PR aims to find and use the host's first IPv4 nameserver, if possible.

This PR additionally aims to expand the amount of platforms using the host's first result. On macOS, this requires linking against `libresolv` as it's not within the standard library.