### PR TITLE
mbedtls: port aesni implementation to intrinsics

### DIFF
--- a/Externals/mbedtls/include/mbedtls/aesni.h
+++ b/Externals/mbedtls/include/mbedtls/aesni.h
@@ -36,9 +36,10 @@
 #define MBEDTLS_AESNI_AES      0x02000000u
 #define MBEDTLS_AESNI_CLMUL    0x00000002u
 
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) &&  \
-    ( defined(__amd64__) || defined(__x86_64__) )   &&  \
-    ! defined(MBEDTLS_HAVE_X86_64)
+// TODO figure out proper test to enable
+#if defined(MBEDTLS_HAVE_ASM) && \
+    ( defined(__amd64__) || defined(__x86_64__) || defined(_M_X64) ) && \
+    !defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_HAVE_X86_64
 #endif
 

--- a/Externals/mbedtls/library/aesni.c
+++ b/Externals/mbedtls/library/aesni.c
@@ -34,8 +34,10 @@
 
 #ifdef _MSC_VER
 #include <intrin.h>
+#define ATTRIBUTE_TARGET_AES
 #else
 #include <cpuid.h>
+#define ATTRIBUTE_TARGET_AES __attribute__((target("aes")))
 #endif
 
 #include <emmintrin.h>
@@ -81,6 +83,7 @@ int mbedtls_aesni_has_support( unsigned int what )
 /*
  * AES-NI AES-ECB block en(de)cryption
  */
+ATTRIBUTE_TARGET_AES
 int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
                      int mode,
                      const unsigned char input[16],
@@ -113,6 +116,7 @@ int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
  * GCM multiplication: c = a times b in GF(2^128)
  * Based on [CLMUL-WP] algorithms 1 (with equation 27) and 5.
  */
+ATTRIBUTE_TARGET_AES
 void mbedtls_aesni_gcm_mult( unsigned char c[16],
                      const unsigned char a[16],
                      const unsigned char b[16] )
@@ -227,6 +231,7 @@ void mbedtls_aesni_gcm_mult( unsigned char c[16],
 /*
  * Compute decryption round keys from encryption round keys
  */
+ATTRIBUTE_TARGET_AES
 void mbedtls_aesni_inverse_key( unsigned char *invkey,
                         const unsigned char *fwdkey, int nr )
 {
@@ -266,6 +271,7 @@ static inline __m128i aeskeygenassist_finish_128( __m128i *rk,
 /*
  * Key expansion, 128-bit case
  */
+ATTRIBUTE_TARGET_AES
 static void aesni_setkey_enc_128( unsigned char *rk,
                                   const unsigned char *key )
 {
@@ -330,6 +336,7 @@ static inline void aeskeygenassist_finish_192( unsigned char **prk,
 /*
  * Key expansion, 192-bit case
  */
+ATTRIBUTE_TARGET_AES
 static void aesni_setkey_enc_192( unsigned char *rk,
                                   const unsigned char *key )
 {
@@ -361,6 +368,7 @@ static inline void write_roundkey_256( unsigned char **dst,
     *dst += 256 / 8;
 }
 
+ATTRIBUTE_TARGET_AES
 static inline void aeskeygenassist_finish_256( unsigned char **prk,
                                                __m128i *pkl,
                                                __m128i *pkh,
@@ -400,6 +408,7 @@ static inline void aeskeygenassist_finish_256( unsigned char **prk,
 /*
  * Key expansion, 256-bit case
  */
+ATTRIBUTE_TARGET_AES
 static void aesni_setkey_enc_256( unsigned char *rk,
                                   const unsigned char *key )
 {

--- a/Externals/mbedtls/library/aesni.c
+++ b/Externals/mbedtls/library/aesni.c
@@ -19,28 +19,27 @@
 
 /*
  * [AES-WP] http://software.intel.com/en-us/articles/intel-advanced-encryption-standard-aes-instructions-set
- * [CLMUL-WP] http://software.intel.com/en-us/articles/intel-carry-less-multiplication-instruction-and-its-usage-for-computing-the-gcm-mode/
+ * [CLMUL-WP] https://www.intel.com/content/dam/develop/external/us/en/documents/clmul-wp-rev-2-02-2014-04-20.pdf
  */
 
 #include "common.h"
 
 #if defined(MBEDTLS_AESNI_C)
 
-#if defined(__has_feature)
-#if __has_feature(memory_sanitizer)
-#warning "MBEDTLS_AESNI_C is known to cause spurious error reports with some memory sanitizers as they do not understand the assembly code."
-#endif
-#endif
-
 #include "mbedtls/aesni.h"
 
 #include <string.h>
 
-#ifndef asm
-#define asm __asm
+#if defined(MBEDTLS_HAVE_X86_64)
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
+#include <cpuid.h>
 #endif
 
-#if defined(MBEDTLS_HAVE_X86_64)
+#include <emmintrin.h>
+#include <immintrin.h>
 
 /*
  * AES-NI support detection routine
@@ -52,33 +51,23 @@ int mbedtls_aesni_has_support( unsigned int what )
 
     if( ! done )
     {
-        asm( "movl  $1, %%eax   \n\t"
-             "cpuid             \n\t"
-             : "=c" (c)
-             :
-             : "eax", "ebx", "edx" );
+#if defined(_MSC_VER)
+        // gets filled with [eax, ebx, ecx, edx]
+        int info[4];
+        __cpuid(info, 1);
+        c = (unsigned int)info[2];
+#else
+        unsigned int eax, ebx, ecx, edx;
+        __cpuid(1, eax, ebx, ecx, edx);
+        c = ecx;
+#endif
+
         done = 1;
     }
 
     return( ( c & what ) != 0 );
 }
 
-/*
- * Binutils needs to be at least 2.19 to support AES-NI instructions.
- * Unfortunately, a lot of users have a lower version now (2014-04).
- * Emit bytecode directly in order to support "old" version of gas.
- *
- * Opcodes from the Intel architecture reference manual, vol. 3.
- * We always use registers, so we don't need prefixes for memory operands.
- * Operand macros are in gas order (src, dst) as opposed to Intel order
- * (dst, src) in order to blend better into the surrounding assembly code.
- */
-#define AESDEC      ".byte 0x66,0x0F,0x38,0xDE,"
-#define AESDECLAST  ".byte 0x66,0x0F,0x38,0xDF,"
-#define AESENC      ".byte 0x66,0x0F,0x38,0xDC,"
-#define AESENCLAST  ".byte 0x66,0x0F,0x38,0xDD,"
-#define AESIMC      ".byte 0x66,0x0F,0x38,0xDB,"
-#define AESKEYGENA  ".byte 0x66,0x0F,0x3A,0xDF,"
 #define PCLMULQDQ   ".byte 0x66,0x0F,0x3A,0x44,"
 
 #define xmm0_xmm0   "0xC0"
@@ -97,39 +86,25 @@ int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
                      const unsigned char input[16],
                      unsigned char output[16] )
 {
-    asm( "movdqu    (%3), %%xmm0    \n\t" // load input
-         "movdqu    (%1), %%xmm1    \n\t" // load round key 0
-         "pxor      %%xmm1, %%xmm0  \n\t" // round 0
-         "add       $16, %1         \n\t" // point to next round key
-         "subl      $1, %0          \n\t" // normal rounds = nr - 1
-         "test      %2, %2          \n\t" // mode?
-         "jz        2f              \n\t" // 0 = decrypt
+    __m128i block = _mm_loadu_si128((const __m128i *)input);
+    __m128i *rk = (__m128i *)ctx->rk;
 
-         "1:                        \n\t" // encryption loop
-         "movdqu    (%1), %%xmm1    \n\t" // load round key
-         AESENC     xmm1_xmm0      "\n\t" // do round
-         "add       $16, %1         \n\t" // point to next round key
-         "subl      $1, %0          \n\t" // loop
-         "jnz       1b              \n\t"
-         "movdqu    (%1), %%xmm1    \n\t" // load round key
-         AESENCLAST xmm1_xmm0      "\n\t" // last round
-         "jmp       3f              \n\t"
+    // round 0
+    block = _mm_xor_si128(block, _mm_loadu_si128(rk++));
 
-         "2:                        \n\t" // decryption loop
-         "movdqu    (%1), %%xmm1    \n\t"
-         AESDEC     xmm1_xmm0      "\n\t" // do round
-         "add       $16, %1         \n\t"
-         "subl      $1, %0          \n\t"
-         "jnz       2b              \n\t"
-         "movdqu    (%1), %%xmm1    \n\t" // load round key
-         AESDECLAST xmm1_xmm0      "\n\t" // last round
+    if (mode == MBEDTLS_AES_DECRYPT) {
+        for (int i = ctx->nr - 1; i > 0; --i) {
+            block = _mm_aesdec_si128(block, _mm_loadu_si128(rk++));
+        }
+        block = _mm_aesdeclast_si128(block, _mm_loadu_si128(rk));
+    } else {
+        for (int i = ctx->nr - 1; i > 0; --i) {
+            block = _mm_aesenc_si128(block, _mm_loadu_si128(rk++));
+        }
+        block = _mm_aesenclast_si128(block, _mm_loadu_si128(rk));
+    }
 
-         "3:                        \n\t"
-         "movdqu    %%xmm0, (%4)    \n\t" // export output
-         :
-         : "r" (ctx->nr), "r" (ctx->rk), "r" (mode), "r" (input), "r" (output)
-         : "memory", "cc", "xmm0", "xmm1" );
-
+    _mm_storeu_si128((__m128i *)output, block);
 
     return( 0 );
 }
@@ -142,106 +117,109 @@ void mbedtls_aesni_gcm_mult( unsigned char c[16],
                      const unsigned char a[16],
                      const unsigned char b[16] )
 {
-    unsigned char aa[16], bb[16], cc[16];
-    size_t i;
-
-    /* The inputs are in big-endian order, so byte-reverse them */
-    for( i = 0; i < 16; i++ )
-    {
-        aa[i] = a[15 - i];
-        bb[i] = b[15 - i];
-    }
-
-    asm( "movdqu (%0), %%xmm0               \n\t" // a1:a0
-         "movdqu (%1), %%xmm1               \n\t" // b1:b0
-
-         /*
-          * Caryless multiplication xmm2:xmm1 = xmm0 * xmm1
-          * using [CLMUL-WP] algorithm 1 (p. 13).
-          */
-         "movdqa %%xmm1, %%xmm2             \n\t" // copy of b1:b0
-         "movdqa %%xmm1, %%xmm3             \n\t" // same
-         "movdqa %%xmm1, %%xmm4             \n\t" // same
-         PCLMULQDQ xmm0_xmm1 ",0x00         \n\t" // a0*b0 = c1:c0
-         PCLMULQDQ xmm0_xmm2 ",0x11         \n\t" // a1*b1 = d1:d0
-         PCLMULQDQ xmm0_xmm3 ",0x10         \n\t" // a0*b1 = e1:e0
-         PCLMULQDQ xmm0_xmm4 ",0x01         \n\t" // a1*b0 = f1:f0
-         "pxor %%xmm3, %%xmm4               \n\t" // e1+f1:e0+f0
-         "movdqa %%xmm4, %%xmm3             \n\t" // same
-         "psrldq $8, %%xmm4                 \n\t" // 0:e1+f1
-         "pslldq $8, %%xmm3                 \n\t" // e0+f0:0
-         "pxor %%xmm4, %%xmm2               \n\t" // d1:d0+e1+f1
-         "pxor %%xmm3, %%xmm1               \n\t" // c1+e0+f1:c0
-
-         /*
-          * Now shift the result one bit to the left,
-          * taking advantage of [CLMUL-WP] eq 27 (p. 20)
-          */
-         "movdqa %%xmm1, %%xmm3             \n\t" // r1:r0
-         "movdqa %%xmm2, %%xmm4             \n\t" // r3:r2
-         "psllq $1, %%xmm1                  \n\t" // r1<<1:r0<<1
-         "psllq $1, %%xmm2                  \n\t" // r3<<1:r2<<1
-         "psrlq $63, %%xmm3                 \n\t" // r1>>63:r0>>63
-         "psrlq $63, %%xmm4                 \n\t" // r3>>63:r2>>63
-         "movdqa %%xmm3, %%xmm5             \n\t" // r1>>63:r0>>63
-         "pslldq $8, %%xmm3                 \n\t" // r0>>63:0
-         "pslldq $8, %%xmm4                 \n\t" // r2>>63:0
-         "psrldq $8, %%xmm5                 \n\t" // 0:r1>>63
-         "por %%xmm3, %%xmm1                \n\t" // r1<<1|r0>>63:r0<<1
-         "por %%xmm4, %%xmm2                \n\t" // r3<<1|r2>>62:r2<<1
-         "por %%xmm5, %%xmm2                \n\t" // r3<<1|r2>>62:r2<<1|r1>>63
-
-         /*
-          * Now reduce modulo the GCM polynomial x^128 + x^7 + x^2 + x + 1
-          * using [CLMUL-WP] algorithm 5 (p. 20).
-          * Currently xmm2:xmm1 holds x3:x2:x1:x0 (already shifted).
-          */
-         /* Step 2 (1) */
-         "movdqa %%xmm1, %%xmm3             \n\t" // x1:x0
-         "movdqa %%xmm1, %%xmm4             \n\t" // same
-         "movdqa %%xmm1, %%xmm5             \n\t" // same
-         "psllq $63, %%xmm3                 \n\t" // x1<<63:x0<<63 = stuff:a
-         "psllq $62, %%xmm4                 \n\t" // x1<<62:x0<<62 = stuff:b
-         "psllq $57, %%xmm5                 \n\t" // x1<<57:x0<<57 = stuff:c
-
-         /* Step 2 (2) */
-         "pxor %%xmm4, %%xmm3               \n\t" // stuff:a+b
-         "pxor %%xmm5, %%xmm3               \n\t" // stuff:a+b+c
-         "pslldq $8, %%xmm3                 \n\t" // a+b+c:0
-         "pxor %%xmm3, %%xmm1               \n\t" // x1+a+b+c:x0 = d:x0
-
-         /* Steps 3 and 4 */
-         "movdqa %%xmm1,%%xmm0              \n\t" // d:x0
-         "movdqa %%xmm1,%%xmm4              \n\t" // same
-         "movdqa %%xmm1,%%xmm5              \n\t" // same
-         "psrlq $1, %%xmm0                  \n\t" // e1:x0>>1 = e1:e0'
-         "psrlq $2, %%xmm4                  \n\t" // f1:x0>>2 = f1:f0'
-         "psrlq $7, %%xmm5                  \n\t" // g1:x0>>7 = g1:g0'
-         "pxor %%xmm4, %%xmm0               \n\t" // e1+f1:e0'+f0'
-         "pxor %%xmm5, %%xmm0               \n\t" // e1+f1+g1:e0'+f0'+g0'
-         // e0'+f0'+g0' is almost e0+f0+g0, ex\tcept for some missing
-         // bits carried from d. Now get those\t bits back in.
-         "movdqa %%xmm1,%%xmm3              \n\t" // d:x0
-         "movdqa %%xmm1,%%xmm4              \n\t" // same
-         "movdqa %%xmm1,%%xmm5              \n\t" // same
-         "psllq $63, %%xmm3                 \n\t" // d<<63:stuff
-         "psllq $62, %%xmm4                 \n\t" // d<<62:stuff
-         "psllq $57, %%xmm5                 \n\t" // d<<57:stuff
-         "pxor %%xmm4, %%xmm3               \n\t" // d<<63+d<<62:stuff
-         "pxor %%xmm5, %%xmm3               \n\t" // missing bits of d:stuff
-         "psrldq $8, %%xmm3                 \n\t" // 0:missing bits of d
-         "pxor %%xmm3, %%xmm0               \n\t" // e1+f1+g1:e0+f0+g0
-         "pxor %%xmm1, %%xmm0               \n\t" // h1:h0
-         "pxor %%xmm2, %%xmm0               \n\t" // x3+h1:x2+h0
-
-         "movdqu %%xmm0, (%2)               \n\t" // done
-         :
-         : "r" (aa), "r" (bb), "r" (cc)
-         : "memory", "cc", "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5" );
-
-    /* Now byte-reverse the outputs */
-    for( i = 0; i < 16; i++ )
-        c[i] = cc[15 - i];
+    (void)a;
+    (void)b;
+    (void)c;
+//    unsigned char aa[16], bb[16], cc[16];
+//    size_t i;
+//
+//    /* The inputs are in big-endian order, so byte-reverse them */
+//    for( i = 0; i < 16; i++ )
+//    {
+//        aa[i] = a[15 - i];
+//        bb[i] = b[15 - i];
+//    }
+//
+//    asm( "movdqu (%0), %%xmm0               \n\t" // a1:a0
+//         "movdqu (%1), %%xmm1               \n\t" // b1:b0
+//
+//         /*
+//          * Caryless multiplication xmm2:xmm1 = xmm0 * xmm1
+//          * using [CLMUL-WP] algorithm 1 (p. 13).
+//          */
+//         "movdqa %%xmm1, %%xmm2             \n\t" // copy of b1:b0
+//         "movdqa %%xmm1, %%xmm3             \n\t" // same
+//         "movdqa %%xmm1, %%xmm4             \n\t" // same
+//         PCLMULQDQ xmm0_xmm1 ",0x00         \n\t" // a0*b0 = c1:c0
+//         PCLMULQDQ xmm0_xmm2 ",0x11         \n\t" // a1*b1 = d1:d0
+//         PCLMULQDQ xmm0_xmm3 ",0x10         \n\t" // a0*b1 = e1:e0
+//         PCLMULQDQ xmm0_xmm4 ",0x01         \n\t" // a1*b0 = f1:f0
+//         "pxor %%xmm3, %%xmm4               \n\t" // e1+f1:e0+f0
+//         "movdqa %%xmm4, %%xmm3             \n\t" // same
+//         "psrldq $8, %%xmm4                 \n\t" // 0:e1+f1
+//         "pslldq $8, %%xmm3                 \n\t" // e0+f0:0
+//         "pxor %%xmm4, %%xmm2               \n\t" // d1:d0+e1+f1
+//         "pxor %%xmm3, %%xmm1               \n\t" // c1+e0+f1:c0
+//
+//         /*
+//          * Now shift the result one bit to the left,
+//          * taking advantage of [CLMUL-WP] eq 27 (p. 20)
+//          */
+//         "movdqa %%xmm1, %%xmm3             \n\t" // r1:r0
+//         "movdqa %%xmm2, %%xmm4             \n\t" // r3:r2
+//         "psllq $1, %%xmm1                  \n\t" // r1<<1:r0<<1
+//         "psllq $1, %%xmm2                  \n\t" // r3<<1:r2<<1
+//         "psrlq $63, %%xmm3                 \n\t" // r1>>63:r0>>63
+//         "psrlq $63, %%xmm4                 \n\t" // r3>>63:r2>>63
+//         "movdqa %%xmm3, %%xmm5             \n\t" // r1>>63:r0>>63
+//         "pslldq $8, %%xmm3                 \n\t" // r0>>63:0
+//         "pslldq $8, %%xmm4                 \n\t" // r2>>63:0
+//         "psrldq $8, %%xmm5                 \n\t" // 0:r1>>63
+//         "por %%xmm3, %%xmm1                \n\t" // r1<<1|r0>>63:r0<<1
+//         "por %%xmm4, %%xmm2                \n\t" // r3<<1|r2>>62:r2<<1
+//         "por %%xmm5, %%xmm2                \n\t" // r3<<1|r2>>62:r2<<1|r1>>63
+//
+//         /*
+//          * Now reduce modulo the GCM polynomial x^128 + x^7 + x^2 + x + 1
+//          * using [CLMUL-WP] algorithm 5 (p. 20).
+//          * Currently xmm2:xmm1 holds x3:x2:x1:x0 (already shifted).
+//          */
+//         /* Step 2 (1) */
+//         "movdqa %%xmm1, %%xmm3             \n\t" // x1:x0
+//         "movdqa %%xmm1, %%xmm4             \n\t" // same
+//         "movdqa %%xmm1, %%xmm5             \n\t" // same
+//         "psllq $63, %%xmm3                 \n\t" // x1<<63:x0<<63 = stuff:a
+//         "psllq $62, %%xmm4                 \n\t" // x1<<62:x0<<62 = stuff:b
+//         "psllq $57, %%xmm5                 \n\t" // x1<<57:x0<<57 = stuff:c
+//
+//         /* Step 2 (2) */
+//         "pxor %%xmm4, %%xmm3               \n\t" // stuff:a+b
+//         "pxor %%xmm5, %%xmm3               \n\t" // stuff:a+b+c
+//         "pslldq $8, %%xmm3                 \n\t" // a+b+c:0
+//         "pxor %%xmm3, %%xmm1               \n\t" // x1+a+b+c:x0 = d:x0
+//
+//         /* Steps 3 and 4 */
+//         "movdqa %%xmm1,%%xmm0              \n\t" // d:x0
+//         "movdqa %%xmm1,%%xmm4              \n\t" // same
+//         "movdqa %%xmm1,%%xmm5              \n\t" // same
+//         "psrlq $1, %%xmm0                  \n\t" // e1:x0>>1 = e1:e0'
+//         "psrlq $2, %%xmm4                  \n\t" // f1:x0>>2 = f1:f0'
+//         "psrlq $7, %%xmm5                  \n\t" // g1:x0>>7 = g1:g0'
+//         "pxor %%xmm4, %%xmm0               \n\t" // e1+f1:e0'+f0'
+//         "pxor %%xmm5, %%xmm0               \n\t" // e1+f1+g1:e0'+f0'+g0'
+//         // e0'+f0'+g0' is almost e0+f0+g0, ex\tcept for some missing
+//         // bits carried from d. Now get those\t bits back in.
+//         "movdqa %%xmm1,%%xmm3              \n\t" // d:x0
+//         "movdqa %%xmm1,%%xmm4              \n\t" // same
+//         "movdqa %%xmm1,%%xmm5              \n\t" // same
+//         "psllq $63, %%xmm3                 \n\t" // d<<63:stuff
+//         "psllq $62, %%xmm4                 \n\t" // d<<62:stuff
+//         "psllq $57, %%xmm5                 \n\t" // d<<57:stuff
+//         "pxor %%xmm4, %%xmm3               \n\t" // d<<63+d<<62:stuff
+//         "pxor %%xmm5, %%xmm3               \n\t" // missing bits of d:stuff
+//         "psrldq $8, %%xmm3                 \n\t" // 0:missing bits of d
+//         "pxor %%xmm3, %%xmm0               \n\t" // e1+f1+g1:e0+f0+g0
+//         "pxor %%xmm1, %%xmm0               \n\t" // h1:h0
+//         "pxor %%xmm2, %%xmm0               \n\t" // x3+h1:x2+h0
+//
+//         "movdqu %%xmm0, (%2)               \n\t" // done
+//         :
+//         : "r" (aa), "r" (bb), "r" (cc)
+//         : "memory", "cc", "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5" );
+//
+//    /* Now byte-reverse the outputs */
+//    for( i = 0; i < 16; i++ )
+//        c[i] = cc[15 - i];
 
     return;
 }
@@ -252,21 +230,38 @@ void mbedtls_aesni_gcm_mult( unsigned char c[16],
 void mbedtls_aesni_inverse_key( unsigned char *invkey,
                         const unsigned char *fwdkey, int nr )
 {
-    unsigned char *ik = invkey;
-    const unsigned char *fk = fwdkey + 16 * nr;
+    __m128i *ik = (__m128i *)invkey;
+    const __m128i *fwdkey_start = (const __m128i *)fwdkey;
+    const __m128i *fk = fwdkey_start + nr;
 
-    memcpy( ik, fk, 16 );
+    _mm_storeu_si128(ik, _mm_loadu_si128(fk));
 
-    for( fk -= 16, ik += 16; fk > fwdkey; fk -= 16, ik += 16 )
-        asm( "movdqu (%0), %%xmm0       \n\t"
-             AESIMC  xmm0_xmm0         "\n\t"
-             "movdqu %%xmm0, (%1)       \n\t"
-             :
-             : "r" (fk), "r" (ik)
-             : "memory", "xmm0" );
+    for( fk--, ik++; fk > fwdkey_start; fk--, ik++ )
+        _mm_storeu_si128(ik, _mm_aesimc_si128(_mm_loadu_si128(fk)));
 
-    memcpy( ik, fk, 16 );
+    _mm_storeu_si128(ik, _mm_loadu_si128(fk));
 }
+
+static inline __m128i aeskeygenassist_finish_128( __m128i *rk,
+                                                  __m128i key,
+                                                  __m128i kga )
+{
+    __m128i tmp = _mm_shuffle_epi32(kga, _MM_SHUFFLE(3, 3, 3, 3));
+    tmp = _mm_xor_si128(tmp, key);
+
+    key = _mm_slli_si128(key, 4);
+    tmp = _mm_xor_si128(tmp, key);
+    key = _mm_slli_si128(key, 4);
+    tmp = _mm_xor_si128(tmp, key);
+    key = _mm_slli_si128(key, 4);
+    tmp = _mm_xor_si128(tmp, key);
+
+    _mm_storeu_si128(rk, tmp);
+    return tmp;
+}
+
+#define aesni_keygen_128(rk, key, rcon) \
+    aeskeygenassist_finish_128((rk), (key), _mm_aeskeygenassist_si128((key), (rcon)))
 
 /*
  * Key expansion, 128-bit case
@@ -274,49 +269,63 @@ void mbedtls_aesni_inverse_key( unsigned char *invkey,
 static void aesni_setkey_enc_128( unsigned char *rk,
                                   const unsigned char *key )
 {
-    asm( "movdqu (%1), %%xmm0               \n\t" // copy the original key
-         "movdqu %%xmm0, (%0)               \n\t" // as round key 0
-         "jmp 2f                            \n\t" // skip auxiliary routine
+    // copy the original key as round key 0
+    __m128i k = _mm_loadu_si128((const __m128i *)key);
+    __m128i *prk = (__m128i *)rk;
+    _mm_storeu_si128(prk++, k);
 
-         /*
-          * Finish generating the next round key.
-          *
-          * On entry xmm0 is r3:r2:r1:r0 and xmm1 is X:stuff:stuff:stuff
-          * with X = rot( sub( r3 ) ) ^ RCON.
-          *
-          * On exit, xmm0 is r7:r6:r5:r4
-          * with r4 = X + r0, r5 = r4 + r1, r6 = r5 + r2, r7 = r6 + r3
-          * and those are written to the round key buffer.
-          */
-         "1:                                \n\t"
-         "pshufd $0xff, %%xmm1, %%xmm1      \n\t" // X:X:X:X
-         "pxor %%xmm0, %%xmm1               \n\t" // X+r3:X+r2:X+r1:r4
-         "pslldq $4, %%xmm0                 \n\t" // r2:r1:r0:0
-         "pxor %%xmm0, %%xmm1               \n\t" // X+r3+r2:X+r2+r1:r5:r4
-         "pslldq $4, %%xmm0                 \n\t" // etc
-         "pxor %%xmm0, %%xmm1               \n\t"
-         "pslldq $4, %%xmm0                 \n\t"
-         "pxor %%xmm1, %%xmm0               \n\t" // update xmm0 for next time!
-         "add $16, %0                       \n\t" // point to next round key
-         "movdqu %%xmm0, (%0)               \n\t" // write it
-         "ret                               \n\t"
-
-         /* Main "loop" */
-         "2:                                \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x01        \n\tcall 1b \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x02        \n\tcall 1b \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x04        \n\tcall 1b \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x08        \n\tcall 1b \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x10        \n\tcall 1b \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x20        \n\tcall 1b \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x40        \n\tcall 1b \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x80        \n\tcall 1b \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x1B        \n\tcall 1b \n\t"
-         AESKEYGENA xmm0_xmm1 ",0x36        \n\tcall 1b \n\t"
-         :
-         : "r" (rk), "r" (key)
-         : "memory", "cc", "0" );
+    k = aesni_keygen_128(prk++, k, 0x01);
+    k = aesni_keygen_128(prk++, k, 0x02);
+    k = aesni_keygen_128(prk++, k, 0x04);
+    k = aesni_keygen_128(prk++, k, 0x08);
+    k = aesni_keygen_128(prk++, k, 0x10);
+    k = aesni_keygen_128(prk++, k, 0x20);
+    k = aesni_keygen_128(prk++, k, 0x40);
+    k = aesni_keygen_128(prk++, k, 0x80);
+    k = aesni_keygen_128(prk++, k, 0x1B);
+    aesni_keygen_128(prk, k, 0x36);
 }
+
+static inline void write_roundkey_192( unsigned char **dst,
+                                       __m128i rk_lo,
+                                       __m128i rk_hi )
+{
+    __m128i *d = (__m128i *)*dst;
+    _mm_storeu_si128(d++, rk_lo);
+    _mm_storeu_si64(d, rk_hi);
+    *dst += 192 / 8;
+}
+
+static inline void aeskeygenassist_finish_192( unsigned char **prk,
+                                               __m128i *pkl,
+                                               __m128i *pkh,
+                                               __m128i kga )
+{
+    __m128i kl = *pkl;
+    __m128i kh = *pkh;
+    __m128i tmp = _mm_shuffle_epi32(kga, _MM_SHUFFLE(1, 1, 1, 1));
+    tmp = _mm_xor_si128(tmp, kl);
+
+    kl = _mm_slli_si128(kl, 4);
+    tmp = _mm_xor_si128(tmp, kl);
+    kl = _mm_slli_si128(kl, 4);
+    tmp = _mm_xor_si128(tmp, kl);
+    kl = _mm_slli_si128(kl, 4);
+    kl = _mm_xor_si128(tmp, kl);
+
+    tmp = _mm_shuffle_epi32(kl, _MM_SHUFFLE(3, 3, 3, 3));
+    tmp = _mm_xor_si128(tmp, kh);
+
+    kh = _mm_slli_si128(kh, 4);
+    kh = _mm_xor_si128(tmp, kh);
+
+    write_roundkey_192(prk, kl, kh);
+    *pkl = kl;
+    *pkh = kh;
+}
+
+#define aesni_keygen_192(prk, pkl, pkh, rcon) \
+    aeskeygenassist_finish_192((prk), (pkl), (pkh), _mm_aeskeygenassist_si128(*(pkh), (rcon)))
 
 /*
  * Key expansion, 192-bit case
@@ -324,56 +333,69 @@ static void aesni_setkey_enc_128( unsigned char *rk,
 static void aesni_setkey_enc_192( unsigned char *rk,
                                   const unsigned char *key )
 {
-    asm( "movdqu (%1), %%xmm0   \n\t" // copy original round key
-         "movdqu %%xmm0, (%0)   \n\t"
-         "add $16, %0           \n\t"
-         "movq 16(%1), %%xmm1   \n\t"
-         "movq %%xmm1, (%0)     \n\t"
-         "add $8, %0            \n\t"
-         "jmp 2f                \n\t" // skip auxiliary routine
+    const __m128i *pkey = (const __m128i *)key;
+    __m128i kl = _mm_loadu_si128(pkey);
+    __m128i kh = _mm_loadu_si64(pkey + 1);
+    unsigned char **prk = &rk;
+    write_roundkey_192(prk, kl, kh);
 
-         /*
-          * Finish generating the next 6 quarter-keys.
-          *
-          * On entry xmm0 is r3:r2:r1:r0, xmm1 is stuff:stuff:r5:r4
-          * and xmm2 is stuff:stuff:X:stuff with X = rot( sub( r3 ) ) ^ RCON.
-          *
-          * On exit, xmm0 is r9:r8:r7:r6 and xmm1 is stuff:stuff:r11:r10
-          * and those are written to the round key buffer.
-          */
-         "1:                            \n\t"
-         "pshufd $0x55, %%xmm2, %%xmm2  \n\t" // X:X:X:X
-         "pxor %%xmm0, %%xmm2           \n\t" // X+r3:X+r2:X+r1:r4
-         "pslldq $4, %%xmm0             \n\t" // etc
-         "pxor %%xmm0, %%xmm2           \n\t"
-         "pslldq $4, %%xmm0             \n\t"
-         "pxor %%xmm0, %%xmm2           \n\t"
-         "pslldq $4, %%xmm0             \n\t"
-         "pxor %%xmm2, %%xmm0           \n\t" // update xmm0 = r9:r8:r7:r6
-         "movdqu %%xmm0, (%0)           \n\t"
-         "add $16, %0                   \n\t"
-         "pshufd $0xff, %%xmm0, %%xmm2  \n\t" // r9:r9:r9:r9
-         "pxor %%xmm1, %%xmm2           \n\t" // stuff:stuff:r9+r5:r10
-         "pslldq $4, %%xmm1             \n\t" // r2:r1:r0:0
-         "pxor %%xmm2, %%xmm1           \n\t" // xmm1 = stuff:stuff:r11:r10
-         "movq %%xmm1, (%0)             \n\t"
-         "add $8, %0                    \n\t"
-         "ret                           \n\t"
-
-         "2:                            \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x01    \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x02    \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x04    \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x08    \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x10    \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x20    \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x40    \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x80    \n\tcall 1b \n\t"
-
-         :
-         : "r" (rk), "r" (key)
-         : "memory", "cc", "0" );
+    __m128i *pkl = &kl;
+    __m128i *pkh = &kh;
+    aesni_keygen_192(prk, pkl, pkh, 0x01);
+    aesni_keygen_192(prk, pkl, pkh, 0x02);
+    aesni_keygen_192(prk, pkl, pkh, 0x04);
+    aesni_keygen_192(prk, pkl, pkh, 0x08);
+    aesni_keygen_192(prk, pkl, pkh, 0x10);
+    aesni_keygen_192(prk, pkl, pkh, 0x20);
+    aesni_keygen_192(prk, pkl, pkh, 0x40);
+    aesni_keygen_192(prk, pkl, pkh, 0x80);
 }
+
+static inline void write_roundkey_256( unsigned char **dst,
+                                       __m128i rk_lo,
+                                       __m128i rk_hi )
+{
+    __m128i *d = (__m128i *)*dst;
+    _mm_storeu_si128(d++, rk_lo);
+    _mm_storeu_si128(d, rk_hi);
+    *dst += 256 / 8;
+}
+
+static inline void aeskeygenassist_finish_256( unsigned char **prk,
+                                               __m128i *pkl,
+                                               __m128i *pkh,
+                                               __m128i kga )
+{
+    __m128i kl = *pkl;
+    __m128i kh = *pkh;
+    __m128i tmp = _mm_shuffle_epi32(kga, _MM_SHUFFLE(3, 3, 3, 3));
+    tmp = _mm_xor_si128(tmp, kl);
+
+    kl = _mm_slli_si128(kl, 4);
+    tmp = _mm_xor_si128(tmp, kl);
+    kl = _mm_slli_si128(kl, 4);
+    tmp = _mm_xor_si128(tmp, kl);
+    kl = _mm_slli_si128(kl, 4);
+    kl = _mm_xor_si128(tmp, kl);
+
+    tmp = _mm_aeskeygenassist_si128(kl, 0x00);
+    tmp = _mm_shuffle_epi32(tmp, _MM_SHUFFLE(2, 2, 2, 2));
+    tmp = _mm_xor_si128(tmp, kh);
+
+    kh = _mm_slli_si128(kh, 4);
+    tmp = _mm_xor_si128(tmp, kh);
+    kh = _mm_slli_si128(kh, 4);
+    tmp = _mm_xor_si128(tmp, kh);
+    kh = _mm_slli_si128(kh, 4);
+    kh = _mm_xor_si128(tmp, kh);
+
+    write_roundkey_256(prk, kl, kh);
+    *pkl = kl;
+    *pkh = kh;
+}
+
+#define aesni_keygen_256(prk, pkl, pkh, rcon) \
+    aeskeygenassist_finish_256((prk), (pkl), (pkh), _mm_aeskeygenassist_si128(*(pkh), (rcon)))
 
 /*
  * Key expansion, 256-bit case
@@ -381,64 +403,25 @@ static void aesni_setkey_enc_192( unsigned char *rk,
 static void aesni_setkey_enc_256( unsigned char *rk,
                                   const unsigned char *key )
 {
-    asm( "movdqu (%1), %%xmm0           \n\t"
-         "movdqu %%xmm0, (%0)           \n\t"
-         "add $16, %0                   \n\t"
-         "movdqu 16(%1), %%xmm1         \n\t"
-         "movdqu %%xmm1, (%0)           \n\t"
-         "jmp 2f                        \n\t" // skip auxiliary routine
+    const __m128i *pkey = (const __m128i *)key;
+    __m128i kl = _mm_loadu_si128(pkey);
+    __m128i kh = _mm_loadu_si128(pkey + 1);
+    unsigned char **prk = &rk;
+    write_roundkey_256(prk, kl, kh);
 
-         /*
-          * Finish generating the next two round keys.
-          *
-          * On entry xmm0 is r3:r2:r1:r0, xmm1 is r7:r6:r5:r4 and
-          * xmm2 is X:stuff:stuff:stuff with X = rot( sub( r7 )) ^ RCON
-          *
-          * On exit, xmm0 is r11:r10:r9:r8 and xmm1 is r15:r14:r13:r12
-          * and those have been written to the output buffer.
-          */
-         "1:                                \n\t"
-         "pshufd $0xff, %%xmm2, %%xmm2      \n\t"
-         "pxor %%xmm0, %%xmm2               \n\t"
-         "pslldq $4, %%xmm0                 \n\t"
-         "pxor %%xmm0, %%xmm2               \n\t"
-         "pslldq $4, %%xmm0                 \n\t"
-         "pxor %%xmm0, %%xmm2               \n\t"
-         "pslldq $4, %%xmm0                 \n\t"
-         "pxor %%xmm2, %%xmm0               \n\t"
-         "add $16, %0                       \n\t"
-         "movdqu %%xmm0, (%0)               \n\t"
-
-         /* Set xmm2 to stuff:Y:stuff:stuff with Y = subword( r11 )
-          * and proceed to generate next round key from there */
-         AESKEYGENA xmm0_xmm2 ",0x00        \n\t"
-         "pshufd $0xaa, %%xmm2, %%xmm2      \n\t"
-         "pxor %%xmm1, %%xmm2               \n\t"
-         "pslldq $4, %%xmm1                 \n\t"
-         "pxor %%xmm1, %%xmm2               \n\t"
-         "pslldq $4, %%xmm1                 \n\t"
-         "pxor %%xmm1, %%xmm2               \n\t"
-         "pslldq $4, %%xmm1                 \n\t"
-         "pxor %%xmm2, %%xmm1               \n\t"
-         "add $16, %0                       \n\t"
-         "movdqu %%xmm1, (%0)               \n\t"
-         "ret                               \n\t"
-
-         /*
-          * Main "loop" - Generating one more key than necessary,
-          * see definition of mbedtls_aes_context.buf
-          */
-         "2:                                \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x01        \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x02        \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x04        \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x08        \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x10        \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x20        \n\tcall 1b \n\t"
-         AESKEYGENA xmm1_xmm2 ",0x40        \n\tcall 1b \n\t"
-         :
-         : "r" (rk), "r" (key)
-         : "memory", "cc", "0" );
+    /*
+     * Generates one more key than necessary,
+     * see definition of mbedtls_aes_context.buf
+     */
+    __m128i *pkl = &kl;
+    __m128i *pkh = &kh;
+    aesni_keygen_256(prk, pkl, pkh, 0x01);
+    aesni_keygen_256(prk, pkl, pkh, 0x02);
+    aesni_keygen_256(prk, pkl, pkh, 0x04);
+    aesni_keygen_256(prk, pkl, pkh, 0x08);
+    aesni_keygen_256(prk, pkl, pkh, 0x10);
+    aesni_keygen_256(prk, pkl, pkh, 0x20);
+    aesni_keygen_256(prk, pkl, pkh, 0x40);
 }
 
 /*

--- a/Externals/mbedtls/mbedTLS.vcxproj
+++ b/Externals/mbedtls/mbedTLS.vcxproj
@@ -22,9 +22,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="library\aes.c" />
-    <ClCompile Include="library\aesni.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="library\aesni.c" />
     <ClCompile Include="library\arc4.c" />
     <ClCompile Include="library\aria.c" />
     <ClCompile Include="library\asn1parse.c" />


### PR DESCRIPTION
this makes the fast path available to msvc

it is just a mechanical conversion of the inline asm, no real improvements on top of existing code.

the gcm impl is removed for now (dolphin does not use it).

see https://github.com/Mbed-TLS/mbedtls/pull/5969 (I kind of don't expect it to go anywhere on mainline tbh)


dolphin also uses a decent amount of sha1 (at least based on # of references to `mbedtls_sha*`), so maybe that would be worth porting to "sha-ni" as well. it would probably make sense to investigate both for armv8 as well (considering mbedtls is owned by arm, you'd hope mbedtls 3.x just improved the situation on arm processors, at least...).

i looked for a bit for some library to replace mbedtls with, but didn't really find anything great.
