### PR TITLE
BuildMacOSUniversalBinary: Use Qt 6 by default

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -49,8 +49,8 @@ DEFAULT_CONFIG = {
     # Locations to qt5 directories for arm and x64 libraries
     # The default values of these paths are taken from the default
     # paths used for homebrew
-    "arm64_qt5_path":  "/opt/homebrew/opt/qt5",
-    "x86_64_qt5_path": "/usr/local/opt/qt5",
+    "arm64_qt5_path":  "/opt/homebrew/opt/qt@6",
+    "x86_64_qt5_path": "/usr/local/opt/qt@6",
 
     # Identity to use for code signing. "-" indicates that the app will not
     # be cryptographically signed/notarized but will instead just use a

--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -49,8 +49,8 @@ DEFAULT_CONFIG = {
     # Locations to qt5 directories for arm and x64 libraries
     # The default values of these paths are taken from the default
     # paths used for homebrew
-    "arm64_qt5_path":  "/opt/homebrew/opt/qt@6",
-    "x86_64_qt5_path": "/usr/local/opt/qt@6",
+    "arm64_qt5_path":  "/Users/administrator/qt/dolphin.mac.universal_6.3.1",
+    "x86_64_qt5_path": "/Users/administrator/qt/dolphin.mac.universal_6.3.1",
 
     # Identity to use for code signing. "-" indicates that the app will not
     # be cryptographically signed/notarized but will instead just use a


### PR DESCRIPTION
~~Not sure whether to change this here or to specify the paths in the buildbot config. Changing it here allows us to create builds for testing, at least.~~

~~The parameter names were left alone to preserve backward compatibility.~~

This PR is only for testing. I will open a PR to change the buildbot config shortly.