### PR TITLE
VideoCommon: Remember to flush command buffers after multiple EFB copies

### DIFF
--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -757,6 +757,16 @@ void VertexManagerBase::OnDraw()
 {
   m_draw_counter++;
 
+  // If the last efb copy was too close to the one before it, don't forget about it until the next
+  // efb copy happens (which might not be for a long time)
+  u32 diff = m_draw_counter - m_last_efb_copy_draw_counter;
+  if (m_unflushed_efb_copy && diff > MINIMUM_DRAW_CALLS_PER_COMMAND_BUFFER_FOR_READBACK)
+  {
+    g_renderer->Flush();
+    m_unflushed_efb_copy = false;
+    m_last_efb_copy_draw_counter = m_draw_counter;
+  }
+
   // If we didn't have any CPU access last frame, do nothing.
   if (m_scheduled_command_buffer_kicks.empty() || !m_allow_background_execution)
     return;
@@ -768,6 +778,8 @@ void VertexManagerBase::OnDraw()
   {
     // Kick a command buffer on the background thread.
     g_renderer->Flush();
+    m_unflushed_efb_copy = false;
+    m_last_efb_copy_draw_counter = m_draw_counter;
   }
 }
 
@@ -794,8 +806,12 @@ void VertexManagerBase::OnEFBCopyToRAM()
   const u32 diff = m_draw_counter - m_last_efb_copy_draw_counter;
   m_last_efb_copy_draw_counter = m_draw_counter;
   if (diff < MINIMUM_DRAW_CALLS_PER_COMMAND_BUFFER_FOR_READBACK)
+  {
+    m_unflushed_efb_copy = true;
     return;
+  }
 
+  m_unflushed_efb_copy = false;
   g_renderer->Flush();
 }
 

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -210,6 +210,7 @@ private:
   // CPU access tracking
   u32 m_draw_counter = 0;
   u32 m_last_efb_copy_draw_counter = 0;
+  bool m_unflushed_efb_copy = false;
   std::vector<u32> m_cpu_accesses_this_frame;
   std::vector<u32> m_scheduled_command_buffer_kicks;
   bool m_allow_background_execution = true;


### PR DESCRIPTION
When using deferred readbacks, there was a system set up to not flush command buffers if multiple EFB copies were issued in succession, but it only ever checked whether it needed to flush when an EFB copy was issued, so things ended up looking like this (CPU/GPU activity traces from Metroid Prime 3 Elysia @ 3x IR):
![image](https://user-images.githubusercontent.com/3315070/175266238-ed50b67b-8aa9-4470-a59a-aaa26db12427.png)

After the change, which also rechecks whether it needs to flush after each draw:
![image](https://user-images.githubusercontent.com/3315070/175258983-1273495d-de69-4257-adcd-3a28e5feb7f2.png)

Brings the scene in question from 53fps to 60fps on my laptop.

Side note, counter is updated after every EFB copy, so if the cutoff was 10 and the following was issued:
EFB Copy, 4 Draws, EFB Copy, 4 Draws, EFB Copy, 4 Draws, EFB Copy
there would be no flushes in the middle (or at the end).

No flush at the end is definitely a bug, but is no flushes in the middle a bug?  I went back and forth on this, and in the end settled on "no" (though the above screenshot is actually from when I was on "yes", you can see one extra command buffer submission in the middle of the readbacks because of it), but some outside input would be nice.