### PR TITLE
DSPHLE: Add HLE version of libasnd ucode and fix build error

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
@@ -87,7 +87,7 @@ void ASndUCode::Initialize()
 void ASndUCode::Update()
 {
   // This is dubious in general, since we set the interrupt parameter on m_mail_handler.PushMail
-  if (!m_mail_handler.IsEmpty())
+  if (m_mail_handler.HasPending())
   {
     DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
   }


### PR DESCRIPTION
This was a conflict between 8a144a735f4116650f59e6931fed86c1c00fa03c and b063f15dccf030e9b4fdeac189f779181d25db9c; since #10763 had not been rebased, it built correctly, but once it was merged with master, #10761 was present and thus it failed to build.

Because of the build error, no entry will be visible for #10763 on https://dolphin-emu.org/download/ so I've titled this PR to mention the new feature, even though it was actually from the other PR.