### PR TITLE
DSPHLE: Add variables in CMailHandler to savestate.

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -87,5 +87,7 @@ void CMailHandler::SetHalted(bool halt)
 void CMailHandler::DoState(PointerWrap& p)
 {
   p.Do(m_pending_mails);
+  p.Do(m_last_mail);
+  p.Do(m_halted);
 }
 }  // namespace DSP::HLE

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static std::recursive_mutex g_save_thread_mutex;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 142;  // Last changed in PR 10732
+constexpr u32 STATE_VERSION = 143;  // Last changed in PR 10784
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
Should fix https://github.com/dolphin-emu/dolphin/pull/10761#issuecomment-1166286482 but I haven't actually verified it. They should definitely be stored in the state either way though.