### PR TITLE
VideoCommon: move TCacheEntry to its own file, so it can be forward declared

### DIFF
--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -668,6 +668,7 @@
     <ClInclude Include="VideoCommon\ShaderGenCommon.h" />
     <ClInclude Include="VideoCommon\Statistics.h" />
     <ClInclude Include="VideoCommon\TextureCacheBase.h" />
+    <ClInclude Include="VideoCommon\TextureCacheEntry.h" />
     <ClInclude Include="VideoCommon\TextureConfig.h" />
     <ClInclude Include="VideoCommon\TextureConversionShader.h" />
     <ClInclude Include="VideoCommon\TextureConverterShaderGen.h" />
@@ -1255,6 +1256,7 @@
     <ClCompile Include="VideoCommon\ShaderGenCommon.cpp" />
     <ClCompile Include="VideoCommon\Statistics.cpp" />
     <ClCompile Include="VideoCommon\TextureCacheBase.cpp" />
+    <ClCompile Include="VideoCommon\TextureCacheEntry.cpp" />
     <ClCompile Include="VideoCommon\TextureConfig.cpp" />
     <ClCompile Include="VideoCommon\TextureConversionShader.cpp" />
     <ClCompile Include="VideoCommon\TextureConverterShaderGen.cpp" />

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -104,6 +104,8 @@ add_library(videocommon
   Statistics.h
   TextureCacheBase.cpp
   TextureCacheBase.h
+  TextureCacheEntry.cpp
+  TextureCacheEntry.h
   TextureConfig.cpp
   TextureConfig.h
   TextureConversionShader.cpp

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -79,6 +79,7 @@
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureCacheEntry.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -13,7 +13,6 @@
 #include <string_view>
 #include <tuple>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "Common/BitSet.h"
@@ -21,7 +20,6 @@
 #include "Common/MathUtil.h"
 #include "VideoCommon/AbstractTexture.h"
 #include "VideoCommon/BPMemory.h"
-#include "VideoCommon/TextureConfig.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/TextureInfo.h"
 
@@ -33,26 +31,10 @@ struct VideoConfig;
 constexpr std::string_view EFB_DUMP_PREFIX = "efb1";
 constexpr std::string_view XFB_DUMP_PREFIX = "xfb1";
 
-struct TextureAndTLUTFormat
+namespace VideoCommon::TextureCache
 {
-  TextureAndTLUTFormat(TextureFormat texfmt_ = TextureFormat::I4,
-                       TLUTFormat tlutfmt_ = TLUTFormat::IA8)
-      : texfmt(texfmt_), tlutfmt(tlutfmt_)
-  {
-  }
-
-  bool operator==(const TextureAndTLUTFormat& other) const
-  {
-    if (IsColorIndexed(texfmt))
-      return texfmt == other.texfmt && tlutfmt == other.tlutfmt;
-
-    return texfmt == other.texfmt;
-  }
-
-  bool operator!=(const TextureAndTLUTFormat& other) const { return !operator==(other); }
-  TextureFormat texfmt;
-  TLUTFormat tlutfmt;
-};
+struct CacheEntry;
+}
 
 struct EFBCopyParams
 {
@@ -108,114 +90,7 @@ private:
   static const int FRAMECOUNT_INVALID = 0;
 
 public:
-  struct TCacheEntry
-  {
-    // common members
-    std::unique_ptr<AbstractTexture> texture;
-    std::unique_ptr<AbstractFramebuffer> framebuffer;
-    u32 addr = 0;
-    u32 size_in_bytes = 0;
-    u64 base_hash = 0;
-    u64 hash = 0;  // for paletted textures, hash = base_hash ^ palette_hash
-    TextureAndTLUTFormat format;
-    u32 memory_stride = 0;
-    bool is_efb_copy = false;
-    bool is_custom_tex = false;
-    bool may_have_overlapping_textures = true;
-    bool tmem_only = false;           // indicates that this texture only exists in the tmem cache
-    bool has_arbitrary_mips = false;  // indicates that the mips in this texture are arbitrary
-                                      // content, aren't just downscaled
-    bool should_force_safe_hashing = false;  // for XFB
-    bool is_xfb_copy = false;
-    bool is_xfb_container = false;
-    u64 id = 0;
-
-    bool reference_changed = false;  // used by xfb to determine when a reference xfb changed
-
-    // Texture dimensions from the GameCube's point of view
-    u32 native_width = 0;
-    u32 native_height = 0;
-    u32 native_levels = 0;
-
-    // used to delete textures which haven't been used for TEXTURE_KILL_THRESHOLD frames
-    int frameCount = FRAMECOUNT_INVALID;
-
-    // Keep an iterator to the entry in textures_by_hash, so it does not need to be searched when
-    // removing the cache entry
-    std::multimap<u64, TCacheEntry*>::iterator textures_by_hash_iter;
-
-    // This is used to keep track of both:
-    //   * efb copies used by this partially updated texture
-    //   * partially updated textures which refer to this efb copy
-    std::unordered_set<TCacheEntry*> references;
-
-    // Pending EFB copy
-    std::unique_ptr<AbstractStagingTexture> pending_efb_copy;
-    u32 pending_efb_copy_width = 0;
-    u32 pending_efb_copy_height = 0;
-    bool pending_efb_copy_invalidated = false;
-
-    std::string texture_info_name = "";
-
-    explicit TCacheEntry(std::unique_ptr<AbstractTexture> tex,
-                         std::unique_ptr<AbstractFramebuffer> fb);
-
-    ~TCacheEntry();
-
-    void SetGeneralParameters(u32 _addr, u32 _size, TextureAndTLUTFormat _format,
-                              bool force_safe_hashing)
-    {
-      addr = _addr;
-      size_in_bytes = _size;
-      format = _format;
-      should_force_safe_hashing = force_safe_hashing;
-    }
-
-    void SetDimensions(unsigned int _native_width, unsigned int _native_height,
-                       unsigned int _native_levels)
-    {
-      native_width = _native_width;
-      native_height = _native_height;
-      native_levels = _native_levels;
-      memory_stride = _native_width;
-    }
-
-    void SetHashes(u64 _base_hash, u64 _hash)
-    {
-      base_hash = _base_hash;
-      hash = _hash;
-    }
-
-    // This texture entry is used by the other entry as a sub-texture
-    void CreateReference(TCacheEntry* other_entry)
-    {
-      // References are two-way, so they can easily be destroyed later
-      this->references.emplace(other_entry);
-      other_entry->references.emplace(this);
-    }
-
-    void SetXfbCopy(u32 stride);
-    void SetEfbCopy(u32 stride);
-    void SetNotCopy();
-
-    bool OverlapsMemoryRange(u32 range_address, u32 range_size) const;
-
-    bool IsEfbCopy() const { return is_efb_copy; }
-    bool IsCopy() const { return is_xfb_copy || is_efb_copy; }
-    u32 NumBlocksX() const;
-    u32 NumBlocksY() const;
-    u32 BytesPerRow() const;
-
-    u64 CalculateHash() const;
-
-    int HashSampleSize() const;
-    u32 GetWidth() const { return texture->GetConfig().width; }
-    u32 GetHeight() const { return texture->GetConfig().height; }
-    u32 GetNumLevels() const { return texture->GetConfig().levels; }
-    u32 GetNumLayers() const { return texture->GetConfig().layers; }
-    AbstractTextureFormat GetFormat() const { return texture->GetConfig().format; }
-    void DoState(PointerWrap& p);
-  };
+  using TCacheEntry = VideoCommon::TextureCache::CacheEntry;
 
   // Minimal version of TCacheEntry just for TexPool
   struct TexPoolEntry

--- a/Source/Core/VideoCommon/TextureCacheEntry.cpp
+++ b/Source/Core/VideoCommon/TextureCacheEntry.cpp
@@ -1,0 +1,235 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "VideoCommon/TextureCacheEntry.h"
+
+#include "Common/Align.h"
+#include "Common/Assert.h"
+#include "Common/ChunkFile.h"
+#include "Common/Hash.h"
+#include "Core/HW/Memmap.h"
+
+#include "VideoCommon/AbstractFramebuffer.h"
+#include "VideoCommon/AbstractStagingTexture.h"
+#include "VideoCommon/AbstractTexture.h"
+#include "VideoCommon/VideoConfig.h"
+
+namespace VideoCommon::TextureCache
+{
+CacheEntry::CacheEntry(std::unique_ptr<AbstractTexture> tex,
+                       std::unique_ptr<AbstractFramebuffer> fb)
+    : texture(std::move(tex)), framebuffer(std::move(fb))
+{
+}
+
+CacheEntry::~CacheEntry()
+{
+  for (auto& reference : references)
+    reference->references.erase(this);
+}
+
+void CacheEntry::SetGeneralParameters(u32 _addr, u32 _size, TextureAndTLUTFormat _format,
+                                      bool force_safe_hashing)
+{
+  addr = _addr;
+  size_in_bytes = _size;
+  format = _format;
+  should_force_safe_hashing = force_safe_hashing;
+}
+
+void CacheEntry::SetDimensions(unsigned int _native_width, unsigned int _native_height,
+                               unsigned int _native_levels)
+{
+  native_width = _native_width;
+  native_height = _native_height;
+  native_levels = _native_levels;
+  memory_stride = _native_width;
+}
+
+void CacheEntry::SetHashes(u64 _base_hash, u64 _hash)
+{
+  base_hash = _base_hash;
+  hash = _hash;
+}
+
+void CacheEntry::CreateReference(CacheEntry* other_entry)
+{
+  // References are two-way, so they can easily be destroyed later
+  this->references.emplace(other_entry);
+  other_entry->references.emplace(this);
+}
+
+void CacheEntry::SetXfbCopy(u32 stride)
+{
+  is_efb_copy = false;
+  is_xfb_copy = true;
+  is_xfb_container = false;
+  memory_stride = stride;
+
+  ASSERT_MSG(VIDEO, memory_stride >= BytesPerRow(), "Memory stride is too small");
+
+  size_in_bytes = memory_stride * NumBlocksY();
+}
+
+void CacheEntry::SetEfbCopy(u32 stride)
+{
+  is_efb_copy = true;
+  is_xfb_copy = false;
+  is_xfb_container = false;
+  memory_stride = stride;
+
+  ASSERT_MSG(VIDEO, memory_stride >= BytesPerRow(), "Memory stride is too small");
+
+  size_in_bytes = memory_stride * NumBlocksY();
+}
+
+void CacheEntry::SetNotCopy()
+{
+  is_efb_copy = false;
+  is_xfb_copy = false;
+  is_xfb_container = false;
+}
+
+bool CacheEntry::OverlapsMemoryRange(u32 range_address, u32 range_size) const
+{
+  if (addr + size_in_bytes <= range_address)
+    return false;
+
+  if (addr >= range_address + range_size)
+    return false;
+
+  return true;
+}
+
+bool CacheEntry::IsEfbCopy() const
+{
+  return is_efb_copy;
+}
+
+bool CacheEntry::IsCopy() const
+{
+  return is_xfb_copy || is_efb_copy;
+}
+
+u32 CacheEntry::NumBlocksX() const
+{
+  const u32 blockW = TexDecoder_GetBlockWidthInTexels(format.texfmt);
+
+  // Round up source height to multiple of block size
+  const u32 actualWidth = Common::AlignUp(native_width, blockW);
+
+  return actualWidth / blockW;
+}
+
+u32 CacheEntry::NumBlocksY() const
+{
+  u32 blockH = TexDecoder_GetBlockHeightInTexels(format.texfmt);
+  // Round up source height to multiple of block size
+  u32 actualHeight = Common::AlignUp(native_height, blockH);
+
+  return actualHeight / blockH;
+}
+
+u32 CacheEntry::BytesPerRow() const
+{
+  // RGBA takes two cache lines per block; all others take one
+  const u32 bytes_per_block = format == TextureFormat::RGBA8 ? 64 : 32;
+
+  return NumBlocksX() * bytes_per_block;
+}
+
+u64 CacheEntry::CalculateHash() const
+{
+  const u32 bytes_per_row = BytesPerRow();
+  const u32 hash_sample_size = HashSampleSize();
+
+  // FIXME: textures from tmem won't get the correct hash.
+  u8* ptr = Memory::GetPointer(addr);
+  if (memory_stride == bytes_per_row)
+  {
+    return Common::GetHash64(ptr, size_in_bytes, hash_sample_size);
+  }
+  else
+  {
+    const u32 num_blocks_y = NumBlocksY();
+    u64 temp_hash = size_in_bytes;
+
+    u32 samples_per_row = 0;
+    if (hash_sample_size != 0)
+    {
+      // Hash at least 4 samples per row to avoid hashing in a bad pattern, like just on the left
+      // side of the efb copy
+      samples_per_row = std::max(hash_sample_size / num_blocks_y, 4u);
+    }
+
+    for (u32 i = 0; i < num_blocks_y; i++)
+    {
+      // Multiply by a prime number to mix the hash up a bit. This prevents identical blocks from
+      // canceling each other out
+      temp_hash = (temp_hash * 397) ^ Common::GetHash64(ptr, bytes_per_row, samples_per_row);
+      ptr += memory_stride;
+    }
+    return temp_hash;
+  }
+}
+
+int CacheEntry::HashSampleSize() const
+{
+  if (should_force_safe_hashing)
+  {
+    return 0;
+  }
+
+  return g_ActiveConfig.iSafeTextureCache_ColorSamples;
+}
+
+u32 CacheEntry::GetWidth() const
+{
+  return texture->GetConfig().width;
+}
+
+u32 CacheEntry::GetHeight() const
+{
+  return texture->GetConfig().height;
+}
+
+u32 CacheEntry::GetNumLevels() const
+{
+  return texture->GetConfig().levels;
+}
+
+u32 CacheEntry::GetNumLayers() const
+{
+  return texture->GetConfig().layers;
+}
+
+AbstractTextureFormat CacheEntry::GetFormat() const
+{
+  return texture->GetConfig().format;
+}
+
+void CacheEntry::DoState(PointerWrap& p)
+{
+  p.Do(addr);
+  p.Do(size_in_bytes);
+  p.Do(base_hash);
+  p.Do(hash);
+  p.Do(format);
+  p.Do(memory_stride);
+  p.Do(is_efb_copy);
+  p.Do(is_custom_tex);
+  p.Do(may_have_overlapping_textures);
+  p.Do(tmem_only);
+  p.Do(has_arbitrary_mips);
+  p.Do(should_force_safe_hashing);
+  p.Do(is_xfb_copy);
+  p.Do(is_xfb_container);
+  p.Do(id);
+  p.Do(reference_changed);
+  p.Do(native_width);
+  p.Do(native_height);
+  p.Do(native_levels);
+  p.Do(frameCount);
+}
+
+}  // namespace VideoCommon::TextureCache

--- a/Source/Core/VideoCommon/TextureCacheEntry.h
+++ b/Source/Core/VideoCommon/TextureCacheEntry.h
@@ -1,0 +1,131 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <unordered_set>
+
+#include "Common/CommonTypes.h"
+#include "VideoCommon/TextureConfig.h"
+#include "VideoCommon/TextureDecoder.h"
+
+class AbstractFramebuffer;
+class AbstractStagingTexture;
+class AbstractTexture;
+class PointerWrap;
+
+namespace VideoCommon::TextureCache
+{
+struct TextureAndTLUTFormat
+{
+  TextureAndTLUTFormat(TextureFormat texfmt_ = TextureFormat::I4,
+                       TLUTFormat tlutfmt_ = TLUTFormat::IA8)
+      : texfmt(texfmt_), tlutfmt(tlutfmt_)
+  {
+  }
+
+  bool operator==(const TextureAndTLUTFormat& other) const
+  {
+    if (IsColorIndexed(texfmt))
+      return texfmt == other.texfmt && tlutfmt == other.tlutfmt;
+
+    return texfmt == other.texfmt;
+  }
+
+  bool operator!=(const TextureAndTLUTFormat& other) const { return !operator==(other); }
+  TextureFormat texfmt;
+  TLUTFormat tlutfmt;
+};
+
+struct CacheEntry
+{
+  static const int FRAMECOUNT_INVALID = 0;
+
+  // common members
+  std::unique_ptr<AbstractTexture> texture;
+  std::unique_ptr<AbstractFramebuffer> framebuffer;
+  u32 addr = 0;
+  u32 size_in_bytes = 0;
+  u64 base_hash = 0;
+  u64 hash = 0;  // for paletted textures, hash = base_hash ^ palette_hash
+  TextureAndTLUTFormat format;
+  u32 memory_stride = 0;
+  bool is_efb_copy = false;
+  bool is_custom_tex = false;
+  bool may_have_overlapping_textures = true;
+  bool tmem_only = false;           // indicates that this texture only exists in the tmem cache
+  bool has_arbitrary_mips = false;  // indicates that the mips in this texture are arbitrary
+                                    // content, aren't just downscaled
+  bool should_force_safe_hashing = false;  // for XFB
+  bool is_xfb_copy = false;
+  bool is_xfb_container = false;
+  u64 id = 0;
+
+  bool reference_changed = false;  // used by xfb to determine when a reference xfb changed
+
+  // Texture dimensions from the GameCube's point of view
+  u32 native_width = 0;
+  u32 native_height = 0;
+  u32 native_levels = 0;
+
+  // used to delete textures which haven't been used for TEXTURE_KILL_THRESHOLD frames
+  int frameCount = FRAMECOUNT_INVALID;
+
+  // Keep an iterator to the entry in textures_by_hash, so it does not need to be searched when
+  // removing the cache entry
+  std::multimap<u64, CacheEntry*>::iterator textures_by_hash_iter;
+
+  // This is used to keep track of both:
+  //   * efb copies used by this partially updated texture
+  //   * partially updated textures which refer to this efb copy
+  std::unordered_set<CacheEntry*> references;
+
+  // Pending EFB copy
+  std::unique_ptr<AbstractStagingTexture> pending_efb_copy;
+  u32 pending_efb_copy_width = 0;
+  u32 pending_efb_copy_height = 0;
+  bool pending_efb_copy_invalidated = false;
+
+  std::string texture_info_name = "";
+
+  explicit CacheEntry(std::unique_ptr<AbstractTexture> tex,
+                      std::unique_ptr<AbstractFramebuffer> fb);
+
+  ~CacheEntry();
+
+  void SetGeneralParameters(u32 _addr, u32 _size, TextureAndTLUTFormat _format,
+                            bool force_safe_hashing);
+
+  void SetDimensions(unsigned int _native_width, unsigned int _native_height,
+                     unsigned int _native_levels);
+
+  void SetHashes(u64 _base_hash, u64 _hash);
+
+  // This texture entry is used by the other entry as a sub-texture
+  void CreateReference(CacheEntry* other_entry);
+
+  void SetXfbCopy(u32 stride);
+  void SetEfbCopy(u32 stride);
+  void SetNotCopy();
+
+  bool OverlapsMemoryRange(u32 range_address, u32 range_size) const;
+
+  bool IsEfbCopy() const;
+  bool IsCopy() const;
+  u32 NumBlocksX() const;
+  u32 NumBlocksY() const;
+  u32 BytesPerRow() const;
+
+  u64 CalculateHash() const;
+
+  int HashSampleSize() const;
+  u32 GetWidth() const;
+  u32 GetHeight() const;
+  u32 GetNumLevels() const;
+  u32 GetNumLayers() const;
+  AbstractTextureFormat GetFormat() const;
+  void DoState(PointerWrap& p);
+};
+}  // namespace VideoCommon::TextureCache

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -29,6 +29,7 @@
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureCacheEntry.h"
 #include "VideoCommon/TextureInfo.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderManager.h"


### PR DESCRIPTION
I also moved functions that were header only to be in the cpp and tried to forward declare what I could.