### PR TITLE
Android: Use JPEG compression for game covers

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CoverHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CoverHelper.java
@@ -73,7 +73,7 @@ public final class CoverHelper
     try
     {
       FileOutputStream out = new FileOutputStream(path);
-      cover.compress(Bitmap.CompressFormat.PNG, 100, out);
+      cover.compress(Bitmap.CompressFormat.JPEG, 90, out);
       out.close();
     }
     catch (Exception ignored)


### PR DESCRIPTION
If we use JPEG compression at 90% quality, there is drastically less stuttering when first caching cover images.

master - 
![using png](https://user-images.githubusercontent.com/14132249/176066571-2a91d939-4b0d-4115-87f5-68777351ef43.png)

Using JPEG at 100% -
![using jpeg](https://user-images.githubusercontent.com/14132249/176066606-347a173b-4c1b-47c9-944d-47e5e673d942.png)

Using JPEG at 90% -
![using jpeg 90](https://user-images.githubusercontent.com/14132249/176066620-48be2bd6-a987-4a4d-9657-91047c33a919.png)

Home screen using PNG -
![current](https://user-images.githubusercontent.com/14132249/176066903-a137e2dd-6e40-4b19-bf44-94445f77c202.png)

Home screen using JPEG 90% - 
![pr](https://user-images.githubusercontent.com/14132249/176066926-fcc24ffa-fba6-4fb0-a107-e351e01968d8.png)
