### PR TITLE
VideoCommon: fix projection graphics mod affecting more than intended

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -38,6 +38,7 @@ static bool bProjectionChanged;
 static bool bViewportChanged;
 static bool bTexMtxInfoChanged;
 static bool bLightingConfigChanged;
+static bool bProjectionGraphicsModChange;
 static BitSet32 nMaterialsChanged;
 static std::array<int, 2> nTransformMatricesChanged;      // min,max
 static std::array<int, 2> nNormalMatricesChanged;         // min,max
@@ -63,6 +64,7 @@ void VertexShaderManager::Init()
   bViewportChanged = false;
   bTexMtxInfoChanged = false;
   bLightingConfigChanged = false;
+  bProjectionGraphicsModChange = false;
 
   std::memset(static_cast<void*>(&xfmem), 0, sizeof(xfmem));
   constants = {};
@@ -322,9 +324,10 @@ void VertexShaderManager::SetConstants(const std::vector<std::string>& textures)
   }
 
   if (bProjectionChanged || g_freelook_camera.GetController()->IsDirty() ||
-      !projection_actions.empty())
+      !projection_actions.empty() || bProjectionGraphicsModChange)
   {
     bProjectionChanged = false;
+    bProjectionGraphicsModChange = !projection_actions.empty();
 
     const auto& rawProjection = xfmem.projection.rawProjection;
 


### PR DESCRIPTION
Graphics mods have the ability to move objects by modifying the projection matrix (similar to how FreeLook works), however previous mods were impacting more draw calls than expected.  This is because we wouldn't revert the graphics mod projection until the emulated hardware received a new projection change.  This change will make the projection "dirty" triggering it on the subsequent draw, ensuring that the projection is properly reset.

Here's an unmodded example:

![SO3EE9_2022-06-29_20-00-55](https://user-images.githubusercontent.com/15224722/176571430-b884232c-513e-42ca-a9d9-7f9bb57cf78f.png)

Here's a mod that moves the minimap (and removes the "quick menu") in master.  You can see it moves more than just the minimap:

![SO3EE9_2022-06-29_20-00-37](https://user-images.githubusercontent.com/15224722/176571501-9ae0ed4e-193a-4fd2-9f2c-0b910f6e7517.png)


Here it is in this PR, only the minimap is moved:

![SO3EE9_2022-06-29_20-02-01](https://user-images.githubusercontent.com/15224722/176571552-91927def-7232-4fd8-b16e-f94756237852.png)

