### PR TITLE
Fix fifo recorder not saving texture data if the texture is reused across frames

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -14,6 +14,7 @@
 #include "Core/HW/Memmap.h"
 
 #include "VideoCommon/OpcodeDecoding.h"
+#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/XFStructs.h"
 
 class FifoRecorder::FifoRecordAnalyzer : public OpcodeDecoder::Callback
@@ -198,6 +199,8 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
 
   m_File->SetIsWii(SConfig::GetInstance().bWii);
 
+  g_texture_cache->RecordActiveTextures();
+
   if (!m_IsRecording)
   {
     m_WasRecording = false;
@@ -350,7 +353,7 @@ void FifoRecorder::EndFrame(u32 fifoStart, u32 fifoEnd)
 }
 
 void FifoRecorder::SetVideoMemory(const u32* bpMem, const u32* cpMem, const u32* xfMem,
-                                  const u32* xfRegs, u32 xfRegsSize, const u8* texMem)
+                                  const u32* xfRegs, u32 xfRegsSize, const u8* texMem_)
 {
   std::lock_guard lk(m_mutex);
 
@@ -363,7 +366,7 @@ void FifoRecorder::SetVideoMemory(const u32* bpMem, const u32* cpMem, const u32*
     u32 xfRegsCopySize = std::min((u32)FifoDataFile::XF_REGS_SIZE, xfRegsSize);
     memcpy(m_File->GetXFRegs(), xfRegs, xfRegsCopySize * 4);
 
-    memcpy(m_File->GetTexMem(), texMem, FifoDataFile::TEX_MEM_SIZE);
+    memcpy(m_File->GetTexMem(), texMem_, FifoDataFile::TEX_MEM_SIZE);
   }
 
   m_record_analyzer = std::make_unique<FifoRecordAnalyzer>(this, cpMem);

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <array>
-#include <bitset>
 #include <fmt/format.h>
 #include <map>
 #include <memory>
@@ -296,7 +295,6 @@ protected:
   size_t temp_size = 0;
 
   std::array<TCacheEntry*, 8> bound_textures{};
-  static std::bitset<8> valid_bind_points;
 
 private:
   using TexAddrCache = std::multimap<u32, TCacheEntry*>;

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -269,6 +269,8 @@ public:
   // Returns false if the top/bottom row coefficients are zero.
   static bool NeedsCopyFilterInShader(const EFBCopyFilterCoefficients& coefficients);
 
+  void RecordActiveTextures();
+
 protected:
   // Decodes the specified data to the GPU texture specified by entry.
   // Returns false if the configuration is not supported.


### PR DESCRIPTION
This affects the lesson07 and lesson08 examples and stuff derived from them.  This behavior broke in #5726.

This fix is somewhat jank because I don't fully understand what the texture cache code is doing. As such this is a draft.