### PR TITLE
RegisterWidget: Fix crash when right-clicking when there is no selected cell

### DIFF
--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -114,11 +114,11 @@ void RegisterWidget::ShowContextMenu()
 {
   QMenu* menu = new QMenu(this);
 
-  auto variant = m_table->currentItem()->data(DATA_TYPE);
+  auto* raw_item = m_table->currentItem();
 
-  if (!variant.isNull())
+  if (raw_item != nullptr && !raw_item->data(DATA_TYPE).isNull())
   {
-    auto* item = static_cast<RegisterColumn*>(m_table->currentItem());
+    auto* item = static_cast<RegisterColumn*>(raw_item);
     auto type = static_cast<RegisterType>(item->data(DATA_TYPE).toInt());
     auto display = item->GetDisplay();
 


### PR DESCRIPTION
Before, Dolphin would crash if you right-clicked in the blank space on the bottom-right, or if you right-clicked outside of the table without having first clicked on a register. Now, the context menu properly appears, with only "update" listed (I'm not entirely sure what that does, though).

Note that right-clicking outside of the table will use the currently selected register's context menu (instead of the update-only one); this behavior existed beforehand.

I also did a quick check of other uses of `customContextMenuRequested`, and they all seem to check that a selection exists (or else don't depend on having a selection at all), though I wasn't too deep in this checking (as long as it looked like an `if`-statement existed, I decided it was probably good).