### PR TITLE
More Graphics Mods Fixes

### DIFF
--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
@@ -219,6 +219,7 @@ void GraphicsModListWidget::OnModChanged(std::optional<std::string> absolute_pat
   {
     auto* description_label =
         new QLabel(tr("Description:  ") + QString::fromStdString(mod->m_description));
+    description_label->setWordWrap(true);
     m_mod_meta_layout->addWidget(description_label);
   }
 }

--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
@@ -107,6 +107,11 @@ void GraphicsModListWidget::ConnectWidgets()
 
 void GraphicsModListWidget::RefreshModList()
 {
+  if (m_needs_save)
+  {
+    SaveToDisk();
+  }
+
   m_mod_list->setCurrentItem(nullptr);
   m_mod_list->clear();
 


### PR DESCRIPTION
Some other minor fixes to graphics mods.

1.  The way the graphics mods UI works is it allows you to change your settings but only saves them when the window closes (to avoid additional disk writes).  However, it was rather jarring when you hit "Reload" after making changes because it would revert to your previous save.  Now if you click "Reload" (to see new graphics mods or to pickup new changes), it will save first..then reload.
2. Add word wrap to the description.  Long descriptions would cause the UI to spaz out.  Now it works properly.

Before:

![image](https://user-images.githubusercontent.com/15224722/176979458-8f8be84b-d2a6-49d3-9480-050514020bf0.png)

After:

![image](https://user-images.githubusercontent.com/15224722/176979483-40b8ba60-6194-41ff-882c-c242f1a0fbbb.png)
