### PR TITLE
Resolve additional warnings generated by clang

### DIFF
--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -23,8 +23,6 @@
 
 namespace Common::Log
 {
-constexpr size_t MAX_MSGLEN = 1024;
-
 const Config::Info<bool> LOGGER_WRITE_TO_FILE{{Config::System::Logger, "Options", "WriteToFile"},
                                               false};
 const Config::Info<bool> LOGGER_WRITE_TO_CONSOLE{

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
@@ -37,9 +37,6 @@ private:
 
   KeyArray MapKeys(const KeyboardStatus& key_status) const;
 
-  // PADAnalogMode
-  u8 m_mode = 0;
-
   // Internal counter synchonizing GC and keyboard
   u8 m_counter = 0;
 };


### PR DESCRIPTION
I decided to compile dolphin with clang and resolve some of the warnings that came up, there are a couple of warnings generated by code in Externals, mainly cubeb and mgba, that should be fixed upstream (maybe they already are), but combined with the other warning removal PR's this should make dolphin mostly warning-clean.