### PR TITLE
Data: Add Rune Factory Frontier bloom definition graphics mod

### DIFF
--- a/Data/Sys/Load/GraphicMods/Rune Factory Frontier/metadata.json
+++ b/Data/Sys/Load/GraphicMods/Rune Factory Frontier/metadata.json
@@ -98,6 +98,15 @@
 					"texture_filename": "tex1_256x256_83aa16840fa69ffb_0"
 				}
 			]
+		},
+		{
+			"name": "Bloom",
+			"targets": [
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000002_320x240_1"
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
This was one of the very first games I tried (I really like Rune Factory games) when I was designing graphics mods but I somehow missed the EFB texture that defined bloom.  While testing the inputs/output PR, I took another look at the game and managed to find the effect that controlled bloom.