### PR TITLE
Debugger CodeWidget: Add filter boxes to callstack, function calls, a…

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -7,6 +7,7 @@
 
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QLabel>
 #include <QLineEdit>
 #include <QListWidget>
 #include <QPushButton>
@@ -95,51 +96,45 @@ void CodeWidget::CreateWidgets()
   layout->setSpacing(0);
 
   m_search_address = new QLineEdit;
-  m_search_symbols = new QLineEdit;
   m_code_diff = new QPushButton(tr("Diff"));
   m_code_view = new CodeViewWidget;
 
   m_search_address->setPlaceholderText(tr("Search Address"));
-  m_search_symbols->setPlaceholderText(tr("Filter Symbols"));
-
-  // Callstack
-  auto* callstack_box = new QGroupBox(tr("Callstack"));
-  auto* callstack_layout = new QVBoxLayout;
-  m_callstack_list = new QListWidget;
-
-  callstack_box->setLayout(callstack_layout);
-  callstack_layout->addWidget(m_callstack_list);
-
-  // Symbols
-  auto* symbols_box = new QGroupBox(tr("Symbols"));
-  auto* symbols_layout = new QVBoxLayout;
-  m_symbols_list = new QListWidget;
-
-  symbols_box->setLayout(symbols_layout);
-  symbols_layout->addWidget(m_symbols_list);
-
-  // Function calls
-  auto* function_calls_box = new QGroupBox(tr("Function calls"));
-  auto* function_calls_layout = new QVBoxLayout;
-  m_function_calls_list = new QListWidget;
-
-  function_calls_box->setLayout(function_calls_layout);
-  function_calls_layout->addWidget(m_function_calls_list);
-
-  // Function callers
-  auto* function_callers_box = new QGroupBox(tr("Function callers"));
-  auto* function_callers_layout = new QVBoxLayout;
-  m_function_callers_list = new QListWidget;
-
-  function_callers_box->setLayout(function_callers_layout);
-  function_callers_layout->addWidget(m_function_callers_list);
 
   m_box_splitter = new QSplitter(Qt::Vertical);
+  m_box_splitter->setStyleSheet(QStringLiteral(
+      "QSplitter::handle { border-top: 1px dashed black; width: 1px; margin-left: 10px; "
+      "margin-right: 10px; }"));
 
-  m_box_splitter->addWidget(callstack_box);
-  m_box_splitter->addWidget(symbols_box);
-  m_box_splitter->addWidget(function_calls_box);
-  m_box_splitter->addWidget(function_callers_box);
+  auto add_search_line_edit = [this](const QString& name, QListWidget* list_widget) {
+    auto* widget = new QWidget;
+    auto* layout = new QGridLayout;
+    auto* label = new QLabel(name);
+    auto* search_line_edit = new QLineEdit;
+
+    widget->setLayout(layout);
+    layout->addWidget(label, 0, 0);
+    layout->addWidget(search_line_edit, 0, 1);
+    layout->addWidget(list_widget, 1, 0, -1, -1);
+    m_box_splitter->addWidget(widget);
+    return search_line_edit;
+  };
+
+  // Callstack
+  m_callstack_list = new QListWidget;
+  m_search_callstack = add_search_line_edit(tr("Callstack"), m_callstack_list);
+
+  // Symbols
+  m_symbols_list = new QListWidget;
+  m_search_symbols = add_search_line_edit(tr("Symbols"), m_symbols_list);
+
+  // Function calls
+  m_function_calls_list = new QListWidget;
+  m_search_calls = add_search_line_edit(tr("Calls"), m_function_calls_list);
+
+  // Function callers
+  m_function_callers_list = new QListWidget;
+  m_search_callers = add_search_line_edit(tr("Callers"), m_function_callers_list);
 
   m_code_splitter = new QSplitter(Qt::Horizontal);
 
@@ -147,7 +142,6 @@ void CodeWidget::CreateWidgets()
   m_code_splitter->addWidget(m_code_view);
 
   layout->addWidget(m_search_address, 0, 0);
-  layout->addWidget(m_search_symbols, 0, 1);
   layout->addWidget(m_code_diff, 0, 2);
   layout->addWidget(m_code_splitter, 1, 0, -1, -1);
 
@@ -161,6 +155,18 @@ void CodeWidget::ConnectWidgets()
   connect(m_search_address, &QLineEdit::textChanged, this, &CodeWidget::OnSearchAddress);
   connect(m_search_address, &QLineEdit::returnPressed, this, &CodeWidget::OnSearchAddress);
   connect(m_search_symbols, &QLineEdit::textChanged, this, &CodeWidget::OnSearchSymbols);
+  connect(m_search_calls, &QLineEdit::textChanged, this, [this]() {
+    const Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(m_code_view->GetAddress());
+    if (symbol)
+      UpdateFunctionCalls(symbol);
+  });
+  connect(m_search_callers, &QLineEdit::textChanged, this, [this]() {
+    const Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(m_code_view->GetAddress());
+    if (symbol)
+      UpdateFunctionCallers(symbol);
+  });
+  connect(m_search_callstack, &QLineEdit::textChanged, this, &CodeWidget::UpdateCallstack);
+
   connect(m_code_diff, &QPushButton::pressed, this, &CodeWidget::OnDiff);
 
   connect(m_symbols_list, &QListWidget::itemPressed, this, &CodeWidget::OnSelectSymbol);
@@ -318,12 +324,17 @@ void CodeWidget::UpdateCallstack()
     return;
   }
 
+  const QString filter = m_search_callstack->text();
+
   for (const auto& frame : stack)
   {
-    auto* item =
-        new QListWidgetItem(QString::fromStdString(frame.Name.substr(0, frame.Name.length() - 1)));
-    item->setData(Qt::UserRole, frame.vAddress);
+    const QString name = QString::fromStdString(frame.Name.substr(0, frame.Name.length() - 1));
 
+    if (name.toUpper().indexOf(filter.toUpper()) == -1)
+      continue;
+
+    auto* item = new QListWidgetItem(name);
+    item->setData(Qt::UserRole, frame.vAddress);
     m_callstack_list->addItem(item);
   }
 }
@@ -359,6 +370,7 @@ void CodeWidget::UpdateSymbols()
 void CodeWidget::UpdateFunctionCalls(const Common::Symbol* symbol)
 {
   m_function_calls_list->clear();
+  const QString filter = m_search_calls->text();
 
   for (const auto& call : symbol->calls)
   {
@@ -367,10 +379,14 @@ void CodeWidget::UpdateFunctionCalls(const Common::Symbol* symbol)
 
     if (call_symbol)
     {
-      auto* item = new QListWidgetItem(
-          QString::fromStdString(StringFromFormat("> %s (%08x)", call_symbol->name.c_str(), addr)));
-      item->setData(Qt::UserRole, addr);
+      const QString name =
+          QString::fromStdString(StringFromFormat("> %s (%08x)", call_symbol->name.c_str(), addr));
 
+      if (name.toUpper().indexOf(filter.toUpper()) == -1)
+        continue;
+
+      auto* item = new QListWidgetItem(name);
+      item->setData(Qt::UserRole, addr);
       m_function_calls_list->addItem(item);
     }
   }
@@ -379,6 +395,7 @@ void CodeWidget::UpdateFunctionCalls(const Common::Symbol* symbol)
 void CodeWidget::UpdateFunctionCallers(const Common::Symbol* symbol)
 {
   m_function_callers_list->clear();
+  const QString filter = m_search_callers->text();
 
   for (const auto& caller : symbol->callers)
   {
@@ -387,10 +404,14 @@ void CodeWidget::UpdateFunctionCallers(const Common::Symbol* symbol)
 
     if (caller_symbol)
     {
-      auto* item = new QListWidgetItem(QString::fromStdString(
-          StringFromFormat("< %s (%08x)", caller_symbol->name.c_str(), addr)));
-      item->setData(Qt::UserRole, addr);
+      const QString name = QString::fromStdString(
+          StringFromFormat("< %s (%08x)", caller_symbol->name.c_str(), addr));
 
+      if (name.toUpper().indexOf(filter.toUpper()) == -1)
+        continue;
+
+      auto* item = new QListWidgetItem(name);
+      item->setData(Qt::UserRole, addr);
       m_function_callers_list->addItem(item);
     }
   }

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -68,12 +68,15 @@ private:
 
   CodeDiffDialog* m_diff_dialog = nullptr;
   QLineEdit* m_search_address;
-  QLineEdit* m_search_symbols;
   QPushButton* m_code_diff;
 
+  QLineEdit* m_search_callstack;
   QListWidget* m_callstack_list;
+  QLineEdit* m_search_symbols;
   QListWidget* m_symbols_list;
+  QLineEdit* m_search_calls;
   QListWidget* m_function_calls_list;
+  QLineEdit* m_search_callers;
   QListWidget* m_function_callers_list;
   CodeViewWidget* m_code_view;
   QSplitter* m_box_splitter;


### PR DESCRIPTION
…nd function callers. Move symbols search box  to align with changes
![filters](https://user-images.githubusercontent.com/10532806/177342259-2c068398-4e35-4e78-9085-0221c4184c79.jpg)

I shortened function calls/callers to just calls/callers to make more room, if that's ok.