### PR TITLE
FileUtil: Only attempt to write to the destination in Copy if there is actually content to write

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -433,8 +433,18 @@ bool Copy(const std::string& source_path, const std::string& destination_path)
 #else
   std::ifstream source{source_path, std::ios::binary};
   std::ofstream destination{destination_path, std::ios::binary};
-  destination << source.rdbuf();
-  return source.good() && destination.good();
+
+  // Only attempt to write with << if there is actually something in the file
+  if (source.peek() != std::ifstream::traits_type::eof())
+  {
+    destination << source.rdbuf();
+    return source.good() && destination.good();
+  }
+  else
+  {
+    // We can't use source.good() here because eofbit will be set, so check for the other bits.
+    return !source.fail() && !source.bad() && destination.good();
+  }
 #endif
 }
 


### PR DESCRIPTION
`File::Copy()` fails with empty files because `<<` sets failbit on the destination stream if nothing was written. The macOS updater uses `File::Copy()` in a workaround for an OS quirk. A recent PR added empty files to the `Sys` folder, breaking the macOS updater.

Fixes https://bugs.dolphin-emu.org/issues/12968.

