### PR TITLE
BS2Emu: Fix DFI typo

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -232,7 +232,7 @@ void CBoot::SetupGCMemory()
   PowerPC::HostWrite_U32(0x09a7ec80, 0x800000F8);  // Bus Clock Speed
   PowerPC::HostWrite_U32(0x1cf7c580, 0x800000FC);  // CPU Clock Speed
 
-  PowerPC::HostWrite_U32(0x4c000064, 0x80000300);  // Write default DFI Handler:     rfi
+  PowerPC::HostWrite_U32(0x4c000064, 0x80000300);  // Write default DSI Handler:     rfi
   PowerPC::HostWrite_U32(0x4c000064, 0x80000800);  // Write default FPU Handler:     rfi
   PowerPC::HostWrite_U32(0x4c000064, 0x80000C00);  // Write default Syscall Handler: rfi
 


### PR DESCRIPTION
Per [the PowerPC 750cl manual](https://fail0verflow.com/media/files/ppc_750cl.pdf), Table 4-2. Exceptions and Conditions, page 158, the exception at Vector Offset 0x300 is DSI, not DFI.  This typo was fixed for the Wii version in ac54c6a4e2f6790f628f8a8112ff1940732f5068 ([here](https://github.com/dolphin-emu/dolphin/commit/ac54c6a4e2f6790f628f8a8112ff1940732f5068#diff-175cbd0e5697394aeab090fc857f88554daf0faead0f5a832465d312efd1d384L339-R347)).