### PR TITLE
PPCCache: Always invalidate the JIT cache on `icbi`, even if icache is disabled

### DIFF
--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -116,6 +116,8 @@ void InstructionCache::Init()
 
 void InstructionCache::Invalidate(u32 addr)
 {
+  JitInterface::InvalidateICacheLine(addr);
+
   if (!HID0.ICE || m_disable_icache)
     return;
 
@@ -134,7 +136,6 @@ void InstructionCache::Invalidate(u32 addr)
     }
   }
   valid[set] = 0;
-  JitInterface::InvalidateICacheLine(addr);
 }
 
 u32 InstructionCache::ReadInstruction(u32 addr)


### PR DESCRIPTION
This is a minor consistency fix that shouldn't actually matter in practice. If icache is disabled, but the still game explicitly says to invalidate icache, then we should invalidate the JIT cache so that instructions are re-fetched from memory (just as would happen if icache is enabled).

In practice, I don't think this matters, since although `icbi` [goes through `InstructionCache::Invalidate`](https://github.com/dolphin-emu/dolphin/blob/7321802b4bfc6bc2777203d08151570e28baf1f4/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp#L586-L591), `dcbf`, `dcbi`, and `dcbst` [use `JitInterface::InvalidateICacheLine` directly](https://github.com/dolphin-emu/dolphin/blob/7321802b4bfc6bc2777203d08151570e28baf1f4/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp#L439-L479). (The data cache instructions have [a special implementation in the JIT](https://github.com/dolphin-emu/dolphin/blob/7321802b4bfc6bc2777203d08151570e28baf1f4/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp#L230) that [still directly uses `InvalidateICacheLine`](https://github.com/dolphin-emu/dolphin/blob/7321802b4bfc6bc2777203d08151570e28baf1f4/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp#L359-L369), while [`icbi` falls back to the interpreter](https://github.com/dolphin-emu/dolphin/blob/7321802b4bfc6bc2777203d08151570e28baf1f4/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp#L283).)

I tested and confirmed that Scooby Doo: Mystery Mayhem and Ed, Edd n Eddy: The Mis-Edventures still work correctly (see #8937).