### PR TITLE
Data: add Super Mario Galaxy bloom definition graphics mod

### DIFF
--- a/Data/Sys/Load/GraphicMods/Super Mario Galaxy/metadata.json
+++ b/Data/Sys/Load/GraphicMods/Super Mario Galaxy/metadata.json
@@ -1,0 +1,23 @@
+{
+	"meta":
+	{
+		"title": "Bloom Texture Definitions",
+		"author": "iwubcode"
+	},
+	"groups":
+	[
+		{
+			"name": "Bloom",
+			"targets": [
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000010_80x57_4"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000011_160x114_4"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Just was looking at the wiki today and noticed it talked about bloom issues in Super Mario Galaxy.

It is most noticeable when selecting a Galaxy, not sure if it's anywhere else.  However, like SMG2, it seems that the bloom effect matches the DOF effect in size/format.


Bloom at 6x IR no mod:

![RMGE01_2022-07-06_21-00-55](https://user-images.githubusercontent.com/15224722/177680738-cb249835-6a8d-4c8c-95aa-83965f699200.png)

Bloom at 6x IR with native resolution mod:

![RMGE01_2022-07-06_21-00-51](https://user-images.githubusercontent.com/15224722/177680783-4b6f6a0a-9c72-429e-826b-4d7166388a23.png)

