### PR TITLE
VideoCommon: Fix D3D shader compilation warnings

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -216,7 +216,11 @@ ShaderCode GenerateGeometryShaderCode(APIType api_type, const ShaderHostConfig& 
   if (wireframe)
     out.Write("\tVS_OUTPUT first;\n");
 
-  out.Write("\tfor (int i = 0; i < {}; ++i) {{\n", vertex_in);
+  // Avoid D3D warning about forced unrolling of single-iteration loop
+  if (vertex_in > 1)
+    out.Write("\tfor (int i = 0; i < {}; ++i) {{\n", vertex_in);
+  else
+    out.Write("\tint i = 0;\n");
 
   if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
@@ -307,7 +311,9 @@ ShaderCode GenerateGeometryShaderCode(APIType api_type, const ShaderHostConfig& 
     EmitVertex(out, host_config, uid_data, "f", api_type, wireframe, stereo, true);
   }
 
-  out.Write("\t}}\n");
+  // Only close loop if previous code was in one (See D3D warning above)
+  if (vertex_in > 1)
+    out.Write("\t}}\n");
 
   EndPrimitive(out, host_config, uid_data, api_type, wireframe, stereo);
 

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -749,8 +749,8 @@ static void WriteXFBEncoder(ShaderCode& code, APIType api_type, const EFBCopyPar
   WriteSampleColor(code, "rgb", "color1", 1, api_type, params);
 
   // Gamma is only applied to XFB copies.
-  code.Write("  color0 = pow(color0, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n"
-             "  color1 = pow(color1, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
+  code.Write("  color0 = pow(abs(color0), float3(gamma_rcp, gamma_rcp, gamma_rcp));\n"
+             "  color1 = pow(abs(color1), float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
 
   // Convert to YUV.
   code.Write("  const float3 y_const = float3(0.257, 0.504, 0.098);\n"

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -313,8 +313,8 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
       break;
 
     case EFBCopyFormat::XFB:
-      out.Write(
-          "  ocol0 = float4(pow(texcol.rgb, float3(gamma_rcp, gamma_rcp, gamma_rcp)), 1.0f);\n");
+      out.Write("  ocol0 = float4(pow(abs(texcol.rgb), float3(gamma_rcp, gamma_rcp, gamma_rcp)), "
+                "1.0f);\n");
       break;
 
     default:

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -889,8 +889,8 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
   out.Write(
       "      uint alpha_compare_op = alpha_scale << 1 | uint(alpha_op);\n"
       "\n"
-      "      int alpha_A;\n"
-      "      int alpha_B;\n"
+      "      int alpha_A = 0;\n"
+      "      int alpha_B = 0;\n"
       "      if (alpha_bias != 3u || alpha_compare_op > 5u) {{\n"
       "        // Small optimisation here: alpha_A and alpha_B are unused by compare ops 0-5\n"
       "        alpha_A = selectAlphaInput(s, ss, {0}colors_0, {0}colors_1, alpha_a) & 255;\n"


### PR DESCRIPTION
Fix Direct3D shader warnings X3571 (negative pow() base), X4000 (potentially uninitialized variables), and X3557 (forced unrolling of single-iteration loop).

These warnings appear in both Direct3D 11 and 12. They all appear in Twilight Princess with Hybrid Ubershaders, though other games and settings probably trigger them as well.

Fixes most of [10578](https://bugs.dolphin-emu.org/issues/10578); I've been unable to trigger warning X3578 (Output value 'ocol1' is not completely initialized, see also [9994](https://bugs.dolphin-emu.org/issues/9994)) and so suspect it's been fixed in the meantime, but I haven't bisected it.