### PR TITLE
DVDInterface: Mask upper bits of DIMAR in GC mode

### DIFF
--- a/Source/Core/Core/HW/DVD/DVDInterface.h
+++ b/Source/Core/Core/HW/DVD/DVDInterface.h
@@ -113,7 +113,7 @@ void ResetDrive(bool spinup);
 void Shutdown();
 void DoState(PointerWrap& p);
 
-void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
+void RegisterMMIO(MMIO::Mapping* mmio, u32 base, bool is_wii);
 
 void SetDisc(std::unique_ptr<DiscIO::VolumeDisc> disc,
              std::optional<std::vector<std::string>> auto_disc_change_paths);

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -141,14 +141,14 @@ static void InitMMIO(bool is_wii)
   ProcessorInterface::RegisterMMIO(mmio_mapping.get(), 0x0C003000);
   MemoryInterface::RegisterMMIO(mmio_mapping.get(), 0x0C004000);
   DSP::RegisterMMIO(mmio_mapping.get(), 0x0C005000);
-  DVDInterface::RegisterMMIO(mmio_mapping.get(), 0x0C006000);
+  DVDInterface::RegisterMMIO(mmio_mapping.get(), 0x0C006000, false);
   SerialInterface::RegisterMMIO(mmio_mapping.get(), 0x0C006400);
   ExpansionInterface::RegisterMMIO(mmio_mapping.get(), 0x0C006800);
   AudioInterface::RegisterMMIO(mmio_mapping.get(), 0x0C006C00);
   if (is_wii)
   {
     IOS::RegisterMMIO(mmio_mapping.get(), 0x0D000000);
-    DVDInterface::RegisterMMIO(mmio_mapping.get(), 0x0D006000);
+    DVDInterface::RegisterMMIO(mmio_mapping.get(), 0x0D006000, true);
     SerialInterface::RegisterMMIO(mmio_mapping.get(), 0x0D006400);
     ExpansionInterface::RegisterMMIO(mmio_mapping.get(), 0x0D006800);
     AudioInterface::RegisterMMIO(mmio_mapping.get(), 0x0D006C00);


### PR DESCRIPTION
The masking was removed in d3aad1d6d527a06166806d38bd065ab1d7484d50, based on a Wii hardware test. Based on https://bugs.dolphin-emu.org/issues/12970 the masking should apply in GameCube mode, though. (I have not actually tested this, as I do not have easy access to a GameCube.)