### PR TITLE
Add Bloom Definitions for Sin and Punishment 2

### DIFF
--- a/Data/Sys/Load/GraphicMods/Sin and Punishment - Star Successor/metadata.json
+++ b/Data/Sys/Load/GraphicMods/Sin and Punishment - Star Successor/metadata.json
@@ -1,0 +1,27 @@
+{
+	"meta":
+	{
+		"title": "Bloom Texture Definitions",
+		"author": "Silent Hell"
+	},
+	"groups":
+	[
+		{
+			"name": "Bloom",
+			"targets": [
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000142_38x28_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000143_19x14_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000144_9x7_6"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Adds bloom definitions for Sin and Punishment: Star Successor for use with bloom removal and native resolution bloom.

Original
![R2VE01_2022-07-09_00-56-07](https://user-images.githubusercontent.com/29898818/178094144-30d4afd5-c637-4d07-82c6-73dcdde2a801.png)
No bloom
![R2VE01_2022-07-09_00-56-51](https://user-images.githubusercontent.com/29898818/178094143-e724cee7-5848-44d2-8336-284b12397f16.png)
Native resolution bloom
![R2VE01_2022-07-09_00-56-41](https://user-images.githubusercontent.com/29898818/178094145-62dd56f7-7034-4549-b799-7a0c018eb427.png)

