### PR TITLE
PPCCache: Improve variable naming and readability

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -585,7 +585,13 @@ void Interpreter::eieio(UGeckoInstruction inst)
 
 void Interpreter::icbi(UGeckoInstruction inst)
 {
-  // TODO: Raise DSI if translation fails (except for direct-store segments).
+  // TODO: The 750cl manual gives conflicting information about whether translation to a physical
+  // address is performed (and thus whether an exception can be raised); subsection
+  // 3.4.2.6 Instruction Cache Block Invalidate (icbi) on page 140 (in section 3.4 Cache Control)
+  // says that it does not need to be translated because it invalidates all ways associated with the
+  // set index for the address, and the same set index is used for both physical and virtual
+  // addresses, but the information on the icbi instruction on page 432 does not mention this.
+  // For now, we don't raise any exceptions, and don't translate the address.
   const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
   PowerPC::ppcState.iCache.Invalidate(address);
 }

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -13,78 +13,181 @@
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/PowerPC.h"
 
+#ifdef _MSC_VER
+// C++20 is used only for better compile-time checks (constexpr std::all_of and also consteval)
+#define ICACHE_HAS_CXX_20
+#define ICACHE_CONSTEVAL consteval
+#else
+#define ICACHE_CONSTEVAL constexpr
+#endif
+
 namespace PowerPC
 {
+// This is a tree-based Pseudo Least Recently Used (PLRU) algorithm, and matches the algorithm
+// described in the ppc_750cl manual for the instruction cache (and the data cache, although the
+// data cache uses 3 states (invalid (I), exclusive (E), and modified (M)) while the instruction
+// cache only has two (invalid (I) and valid (V)).
 namespace
 {
-constexpr std::array<u32, 8> s_plru_mask{
-    11, 11, 19, 19, 37, 37, 69, 69,
-};
-constexpr std::array<u32, 8> s_plru_value{
-    11, 3, 17, 1, 36, 4, 64, 0,
-};
+constexpr u32 NUM_PLRU_BITS = ICACHE_WAYS - 1;
+constexpr u8 NUM_PLRU_BIT_VALUES = 1 << NUM_PLRU_BITS;
+constexpr u8 PLRU_BIT_MASK = NUM_PLRU_BIT_VALUES - 1;
 
-constexpr std::array<u32, 255> s_way_from_valid = [] {
-  std::array<u32, 255> data{};
-  for (size_t m = 0; m < data.size(); m++)
+// See Table 3-3. PLRU Bit Update Rules on page 143 of the 750cl manual.
+// The first entry in the pair is the mask indicating which bits to update.
+// The second entry is the value to set those bits to. This value correspons with making all parent
+// nodes in a tree point away from the entry that was most recently updated; for instance, L2 is
+// reached by B0 = 0, then B1 = 1, then B4 = 1, so when L2 is used, the algorithm sets B0 to 1,
+// B1 to 0, and B4 to 0, and leaves the other bits unchanged.
+//
+// To ensure alignment with the comment, an 8-bit binary literal is used below, but there are
+// actually only 7 PLRU bits. Additionally, note that the table shows B0 as the leftmost bit and B6
+// as the rightmost bit; the order is reversed here.
+constexpr std::array<std::pair<u8, u8>, ICACHE_WAYS> PLRU_RULES{{
+    {
+        // ___1_11 for access to L0
+        0b00001011,
+        0b00001011,
+    },
+    {
+        // ___0_11 for access to L1
+        0b00001011,
+        0b00000011,
+    },
+    {
+        // __1__01 for access to L2
+        0b00010011,
+        0b00010001,
+    },
+    {
+        // __0__01 for access to L3
+        0b00010011,
+        0b00000001,
+    },
+    {
+        // _1__1_0 for access to L4
+        0b00100101,
+        0b00100100,
+    },
+    {
+        // _0__1_0 for access to L5
+        0b00100101,
+        0b00000100,
+    },
+    {
+        // 1___0_0 for access to L6
+        0b01000101,
+        0b01000000,
+    },
+    {
+        // 0___0_0 for access to L7
+        0b01000101,
+        0b00000000,
+    },
+}};
+#ifdef ICACHE_HAS_CXX_20
+static_assert(std::all_of(PLRU_RULES.begin(), PLRU_RULES.end(),
+                          [](auto& pair) { return (pair.first & ~PLRU_BIT_MASK) == 0; }),
+              "PLRU mask contains bits not matching the number of PLRU bits");
+static_assert(std::all_of(PLRU_RULES.begin(), PLRU_RULES.end(),
+                          [](auto& pair) { return (pair.second & ~pair.first) == 0; }),
+              "PLRU new value should not contain any bits not set in the corresponding mask");
+#endif
+
+// See the top half of Figure 3-5. PLRU Replacement Algorithm on page 142 of the 750cl manual.
+// This is the lowest-order invalid block in the set.
+ICACHE_CONSTEVAL u8 WayFromValid(u8 valid_bits)
+{
+  u8 lowest_invalid_block = 0;
+  while ((valid_bits & (1 << lowest_invalid_block)) != 0)
   {
-    u32 w = 0;
-    while ((m & (size_t{1} << w)) != 0)
-      w++;
-    data[m] = w;
+    lowest_invalid_block++;
   }
-  return data;
+  return lowest_invalid_block;
+}
+// This array is a used to pre-compute which way to replace if an invalid way exists.
+// Note that this array has a size of 255, not 256; if all ways are valid,
+// then WAY_FROM_PLRU must be used instead.
+constexpr std::array<u8, (1 << ICACHE_WAYS) - 1> WAY_FROM_VALID = []() ICACHE_CONSTEVAL {
+  std::array<u8, (1 << ICACHE_WAYS) - 1> result{};
+  for (u8 valid_bits = 0; valid_bits < result.size(); valid_bits++)
+    result[valid_bits] = WayFromValid(valid_bits);
+  return result;
 }();
+#ifdef ICACHE_HAS_CXX_20
+static_assert(std::all_of(WAY_FROM_VALID.begin(), WAY_FROM_VALID.end(),
+                          [](u8 way) { return way < ICACHE_WAYS; }),
+              "WAY_FROM_VALID must reference valid ways only");
+#endif
 
-constexpr std::array<u32, 128> s_way_from_plru = [] {
-  std::array<u32, 128> data{};
-
-  for (size_t m = 0; m < data.size(); m++)
+// See the bottom half of Figure 3-5. PLRU Replacement Algorithm on page 142 of the 750cl manual,
+// or Table 3-4. PLRU Replacement Block Selection on page 143.
+// PLRU bits are numbered in a breadth-first manner.
+ICACHE_CONSTEVAL u8 WayFromPLRU(u8 plru_bits)
+{
+  if ((plru_bits & (1 << 0)) == 0)  // B0 = 0
   {
-    std::array<u32, 7> b{};
-    for (size_t i = 0; i < b.size(); i++)
-      b[i] = u32(m & (size_t{1} << i));
-
-    u32 w = 0;
-    if (b[0] != 0)
+    if ((plru_bits & (1 << 1)) == 0)  // B1 = 0
     {
-      if (b[2] != 0)
+      if ((plru_bits & (1 << 3)) == 0)  // B3 = 0
       {
-        if (b[6] != 0)
-          w = 7;
-        else
-          w = 6;
+        return 0;
       }
-      else if (b[5] != 0)
+      else  // B3 = 1
       {
-        w = 5;
-      }
-      else
-      {
-        w = 4;
+        return 1;
       }
     }
-    else if (b[1] != 0)
+    else  // B1 = 1
     {
-      if (b[4] != 0)
-        w = 3;
-      else
-        w = 2;
+      if ((plru_bits & (1 << 4)) == 0)  // B4 = 0
+      {
+        return 2;
+      }
+      else  // B4 = 1
+      {
+        return 3;
+      }
     }
-    else if (b[3] != 0)
-    {
-      w = 1;
-    }
-    else
-    {
-      w = 0;
-    }
-
-    data[m] = w;
   }
-
-  return data;
+  else  // B0 = 1
+  {
+    if ((plru_bits & (1 << 2)) == 0)  // B2 = 0
+    {
+      if ((plru_bits & (1 << 5)) == 0)  // B5 = 0
+      {
+        return 4;
+      }
+      else  // B5 = 1
+      {
+        return 5;
+      }
+    }
+    else  // B2 = 1
+    {
+      if ((plru_bits & (1 << 6)) == 0)  // B6 = 0
+      {
+        return 6;
+      }
+      else  // B6 = 1
+      {
+        return 7;
+      }
+    }
+  }
+}
+// This array is a used to pre-compute which block to replace based on the PLRU bits.
+constexpr std::array<u8, NUM_PLRU_BIT_VALUES> WAY_FROM_PLRU = []() ICACHE_CONSTEVAL {
+  std::array<u8, NUM_PLRU_BIT_VALUES> result{};
+  for (u8 plru_bits = 0; plru_bits < result.size(); plru_bits++)
+    result[plru_bits] = WayFromPLRU(plru_bits);
+  return result;
 }();
+#ifdef ICACHE_HAS_CXX_20
+static_assert(std::all_of(WAY_FROM_PLRU.begin(), WAY_FROM_PLRU.end(),
+                          [](u8 way) { return way < ICACHE_WAYS; }),
+              "WAY_FROM_PLRU must reference valid ways only");
+#endif
 }  // Anonymous namespace
 
 InstructionCache::~InstructionCache()
@@ -164,9 +267,9 @@ u32 InstructionCache::ReadInstruction(u32 addr)
       return Memory::Read_U32(addr);
     // select a way
     if (valid[set] != 0xff)
-      t = s_way_from_valid[valid[set]];
+      t = WAY_FROM_VALID[valid[set]];
     else
-      t = s_way_from_plru[plru[set]];
+      t = WAY_FROM_PLRU[plru[set]];
     // load
     Memory::CopyFromEmu(reinterpret_cast<u8*>(data[set][t].data()), (addr & ~0x1f), 32);
     if (valid[set] & (1 << t))
@@ -189,7 +292,8 @@ u32 InstructionCache::ReadInstruction(u32 addr)
     valid[set] |= (1 << t);
   }
   // update plru
-  plru[set] = (plru[set] & ~s_plru_mask[t]) | s_plru_value[t];
+  plru[set] = (plru[set] & ~PLRU_RULES[t].first) | PLRU_RULES[t].second;
+
   const u32 res = Common::swap32(data[set][t][(addr >> 2) & 7]);
   const u32 inmem = Memory::Read_U32(addr);
   if (res != inmem)

--- a/Source/Core/Core/PowerPC/PPCCache.h
+++ b/Source/Core/Core/PowerPC/PPCCache.h
@@ -16,21 +16,12 @@ constexpr u32 ICACHE_SETS = 128;
 constexpr u32 ICACHE_WAYS = 8;
 constexpr u32 ICACHE_BLOCK_SIZE_WORDS = 8;  // 8 32-bit words, or 32 bytes
 
-constexpr u32 ICACHE_EXRAM_BIT = 0x10000000;
-constexpr u32 ICACHE_VMEM_BIT = 0x20000000;
-
 struct InstructionCache
 {
   std::array<std::array<std::array<u32, ICACHE_BLOCK_SIZE_WORDS>, ICACHE_WAYS>, ICACHE_SETS> data{};
   std::array<std::array<u32, ICACHE_WAYS>, ICACHE_SETS> tags{};
   std::array<u32, ICACHE_SETS> plru{};
   std::array<u32, ICACHE_SETS> valid{};
-
-  // Note: This is only for performance purposes; this same data could be computed at runtime
-  // from the tags and valid fields (and that's how it's done on the actual cache)
-  std::array<u8, 1 << 20> lookup_table{};
-  std::array<u8, 1 << 21> lookup_table_ex{};
-  std::array<u8, 1 << 20> lookup_table_vmem{};
 
   bool m_disable_icache = false;
   std::optional<size_t> m_config_callback_id = std::nullopt;

--- a/Source/Core/Core/PowerPC/PPCCache.h
+++ b/Source/Core/Core/PowerPC/PPCCache.h
@@ -14,15 +14,14 @@ namespace PowerPC
 {
 constexpr u32 ICACHE_SETS = 128;
 constexpr u32 ICACHE_WAYS = 8;
-// size of an instruction cache block in words
-constexpr u32 ICACHE_BLOCK_SIZE = 8;
+constexpr u32 ICACHE_BLOCK_SIZE_WORDS = 8;  // 8 32-bit words, or 32 bytes
 
 constexpr u32 ICACHE_EXRAM_BIT = 0x10000000;
 constexpr u32 ICACHE_VMEM_BIT = 0x20000000;
 
 struct InstructionCache
 {
-  std::array<std::array<std::array<u32, ICACHE_BLOCK_SIZE>, ICACHE_WAYS>, ICACHE_SETS> data{};
+  std::array<std::array<std::array<u32, ICACHE_BLOCK_SIZE_WORDS>, ICACHE_WAYS>, ICACHE_SETS> data{};
   std::array<std::array<u32, ICACHE_WAYS>, ICACHE_SETS> tags{};
   std::array<u32, ICACHE_SETS> plru{};
   std::array<u32, ICACHE_SETS> valid{};

--- a/Source/Core/Core/PowerPC/PPCCache.h
+++ b/Source/Core/Core/PowerPC/PPCCache.h
@@ -20,19 +20,22 @@ struct InstructionCache
 {
   std::array<std::array<std::array<u32, ICACHE_BLOCK_SIZE_WORDS>, ICACHE_WAYS>, ICACHE_SETS> data{};
   std::array<std::array<u32, ICACHE_WAYS>, ICACHE_SETS> tags{};
-  std::array<u32, ICACHE_SETS> plru{};
-  std::array<u32, ICACHE_SETS> valid{};
+  std::array<u8, ICACHE_SETS> plru{};
+  std::array<u8, ICACHE_SETS> valid{};
 
   bool m_disable_icache = false;
   std::optional<size_t> m_config_callback_id = std::nullopt;
 
   InstructionCache() = default;
   ~InstructionCache();
-  u32 ReadInstruction(u32 addr);
+  u32 ReadInstruction(u32 physical_addr);
   void Invalidate(u32 addr);
   void Init();
   void Reset();
   void DoState(PointerWrap& p);
   void RefreshConfig();
+
+private:
+  u32 ReadFromBlock(u32 set, u32 way, u32 block_offset_words);
 };
 }  // namespace PowerPC


### PR DESCRIPTION
This PR makes the instruction cache code easier to understand (and makes it more obvious that it implements the algorithms described in the [ppc 750cl manual](https://fail0verflow.com/media/files/ppc_750cl.pdf), which presumably match those used by Gekko/Broadway).

It also removes an optimisation where a lookup table for each physical address (or, rather each 32-byte block of addresses) mapped to the corresponding cache way (if one existed). That lookup table accounted for 4MB of savestate data, and also did not seem to improve performance in any noticeable way (I speculate that this is because 4MB of data like that results in a large number of host data cache misses, while using the actual tag and valid system means that less memory is used and thus it fits in d-cache better, but I haven't attempted to verify this). The lookup table also had hardcoded assumptions about the size of MEM1 and MEM2.

<details><summary>Measurement information</summary>

I measured performance on master and on this PR with the following code:

```patch
diff --git a/Source/Core/Core/PowerPC/PPCCache.cpp b/Source/Core/Core/PowerPC/PPCCache.cpp
index 9207ea5f72..0acbd7d281 100644
--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/Swap.h"
+#include "Common/Timer.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/DolphinAnalytics.h"
 #include "Core/HW/Memmap.h"
@@ -93,8 +94,26 @@ InstructionCache::~InstructionCache()
     Config::RemoveConfigChangedCallback(*m_config_callback_id);
 }
 
+static int reset_counter = 0;
+static Common::Timer timer;
+
 void InstructionCache::Reset()
 {
+  // Called by (Interpreter|Jit)_SystemRegisters.cpp when the HID0[ICFI] bit is set
+  // This happens right when the GC IPL starts, and also twice right before it launches a game
+  if (reset_counter == 1)
+  {
+    // IPL started
+    timer.Start();
+  }
+  else if (reset_counter == 3)
+  {
+    // IPL launched game
+    timer.Stop();
+    SuccessAlertFmt("{}", timer.GetTimeElapsed());  // ms
+  }
+  reset_counter++;
+
   valid.fill(0);
   plru.fill(0);
   lookup_table.fill(0xFF);
@@ -111,6 +130,7 @@ void InstructionCache::Init()
 
   data.fill({});
   tags.fill({});
+  reset_counter = 0;
   Reset();
 }
 
```

I measured how long it took the GameCube IPL to boot Super Mario Sunshine, specifically how long it took between the first icache invalidation and the 3rd one (which seemed to be a good indication of how long it took).

I used single core, speed limit unlimited, DSP HLE, MMU enabled, and the Null video backend, and also had all logging disabled (log level set to notice, and write to file/console/window all unchecked, though some log types were checked). I also set Dolphin has high priority in task manager, but did not have Dolphin focused (instead I was watching a YouTube video), as the pure interpreter takes ~4 minutes for this.

I calculated mean and stdev like this:

```python
import statistics
def info(*args):
  m = round(statistics.mean(args))
  d = round(statistics.stdev(args))
  print(m, d)
```

Old results were measured on a different day from new results, and it's entirely likely that there was a different amount of CPU usage between the two.

</details>

<table>
<tr><td></td><th colspan="7">Times (ms)</th><th>Mean</th><th>Stdev</th><th>Change</th></tr>
<tr><th>Old Jit</th><td>843</td><td>823</td><td>824</td><td>821</td><td>917</td><td>921</td><td>819</td><td>853</td><td>46</td><td rowspan="2">+73 ms<br/>(108.5%)</td></tr>
<tr><th>New Jit</th><td>819</td><td>976</td><td>936</td><td>943</td><td>936</td><td>933</td><td>937</td><td>926</td><td>49</td></tr>
<tr><th>Old cached int</th><td>2242</td><td>2233</td><td>2234</td><td>2228</td><td>2237</td><td>2227</td><td>2495</td><td>2271</td><td>99</td><td rowspan="2">+58ms<br/>(102.5%)</td></tr>
<tr><th>New cached int</th><td>2309</td><td>2231</td><td>2222</td><td>2291</td><td>2471</td><td>2322</td><td>2460</td><td>2329</td><td>100</td></tr>
<tr><th>Old pure int</th><td>239070</td><td>249271</td><td>224431</td><td>248168</td><td>248171</td><td>251915</td><td>242709</td><td>243391</td><td>9412</td><td rowspan="2">-10260ms<br/>(95.7%)</td></tr>
<tr><th>New pure int</th><td>216076</td><td>234897</td><td>233723</td><td>236847</td><td>236137</td><td>236713</td><td>237524</td><td>233131</td><td>7630</td></tr>
</table>

I don't think this is a significant change in performance (and my methodology wasn't perfect either, so these values probably don't reflect reality perfectly).