### PR TITLE
Fix CMake Windows build after #10673 (HLSL from SPIRV).

### DIFF
--- a/Externals/spirv_cross/CMakeLists.txt
+++ b/Externals/spirv_cross/CMakeLists.txt
@@ -47,6 +47,7 @@ endif()
 endif()
 
 add_library(spirv_cross STATIC ${SRCS})
+dolphin_disable_warnings_msvc(spirv_cross)
 
 target_compile_definitions(spirv_cross PUBLIC SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
 target_include_directories(spirv_cross PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/SPIRV-Cross/include ${CMAKE_CURRENT_SOURCE_DIR}/SPIRV-Cross)

--- a/Source/Core/VideoBackends/D3DCommon/CMakeLists.txt
+++ b/Source/Core/VideoBackends/D3DCommon/CMakeLists.txt
@@ -14,6 +14,15 @@ PUBLIC
   spirv_cross
 )
 
+target_include_directories(videod3dcommon
+SYSTEM PUBLIC
+  ${CMAKE_SOURCE_DIR}/Externals/glslang/glslang/Public
+SYSTEM PRIVATE
+  ${CMAKE_SOURCE_DIR}/Externals/glslang/StandAlone
+  ${CMAKE_SOURCE_DIR}/Externals/glslang/SPIRV
+  ${CMAKE_SOURCE_DIR}/Externals/glslang
+)
+
 if(MSVC)
   # Add precompiled header
   target_link_libraries(videod3dcommon PRIVATE use_pch)


### PR DESCRIPTION
#10673 broke CMake builds on Windows, this fixes it.