### PR TITLE
Common: Fix CountTrailingZeros for weird compilers

### DIFF
--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -457,7 +457,7 @@ constexpr int CountTrailingZeros(uint32_t value)
     return _BitScanForward(&index, value) ? index : 32;
   }
 #else
-  return CountLeadingZerosConst(value);
+  return CountTrailingZerosConst(value);
 #endif
 }
 


### PR DESCRIPTION
Came up when I was rebasing the Metal branch (which also added a ctz implementation)