### PR TITLE
NetworkCaptureLogger: Add GameCube BBA support

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -347,6 +347,7 @@ const Info<bool> MAIN_NETWORK_SSL_VERIFY_CERTIFICATES{
 const Info<bool> MAIN_NETWORK_SSL_DUMP_ROOT_CA{{System::Main, "Network", "SSLDumpRootCA"}, false};
 const Info<bool> MAIN_NETWORK_SSL_DUMP_PEER_CERT{{System::Main, "Network", "SSLDumpPeerCert"},
                                                  false};
+const Info<bool> MAIN_NETWORK_DUMP_BBA{{System::Main, "Network", "DumpBBA"}, false};
 const Info<bool> MAIN_NETWORK_DUMP_AS_PCAP{{System::Main, "Network", "DumpAsPCAP"}, false};
 // Default value based on:
 //  - [RFC 1122] 4.2.3.5 TCP Connection Failures (at least 3 minutes)

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -206,6 +206,7 @@ extern const Info<bool> MAIN_NETWORK_SSL_DUMP_WRITE;
 extern const Info<bool> MAIN_NETWORK_SSL_VERIFY_CERTIFICATES;
 extern const Info<bool> MAIN_NETWORK_SSL_DUMP_ROOT_CA;
 extern const Info<bool> MAIN_NETWORK_SSL_DUMP_PEER_CERT;
+extern const Info<bool> MAIN_NETWORK_DUMP_BBA;
 extern const Info<bool> MAIN_NETWORK_DUMP_AS_PCAP;
 extern const Info<int> MAIN_NETWORK_TIMEOUT;
 

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -46,6 +46,10 @@ void DummyNetworkCaptureLogger::LogWrite(const void* data, std::size_t length, s
 {
 }
 
+void DummyNetworkCaptureLogger::LogBBA(const void* data, std::size_t length)
+{
+}
+
 NetworkCaptureType DummyNetworkCaptureLogger::GetCaptureType() const
 {
   return NetworkCaptureType::None;
@@ -113,6 +117,13 @@ void PCAPSSLCaptureLogger::LogRead(const void* data, std::size_t length, s32 soc
 void PCAPSSLCaptureLogger::LogWrite(const void* data, std::size_t length, s32 socket, sockaddr* to)
 {
   Log(LogType::Write, data, length, socket, to);
+}
+
+void PCAPSSLCaptureLogger::LogBBA(const void* data, std::size_t length)
+{
+  if (!Config::Get(Config::MAIN_NETWORK_DUMP_BBA))
+    return;
+  m_file->AddPacket(static_cast<const u8*>(data), length);
 }
 
 void PCAPSSLCaptureLogger::Log(LogType log_type, const void* data, std::size_t length, s32 socket,

--- a/Source/Core/Core/NetworkCaptureLogger.h
+++ b/Source/Core/Core/NetworkCaptureLogger.h
@@ -51,6 +51,8 @@ public:
   virtual void LogRead(const void* data, std::size_t length, s32 socket, sockaddr* from) = 0;
   virtual void LogWrite(const void* data, std::size_t length, s32 socket, sockaddr* to) = 0;
 
+  virtual void LogBBA(const void* data, std::size_t length) = 0;
+
   virtual NetworkCaptureType GetCaptureType() const = 0;
 };
 
@@ -64,6 +66,8 @@ public:
 
   void LogRead(const void* data, std::size_t length, s32 socket, sockaddr* from) override;
   void LogWrite(const void* data, std::size_t length, s32 socket, sockaddr* to) override;
+
+  void LogBBA(const void* data, std::size_t length) override;
 
   NetworkCaptureType GetCaptureType() const override;
 };
@@ -90,6 +94,8 @@ public:
 
   void LogRead(const void* data, std::size_t length, s32 socket, sockaddr* from) override;
   void LogWrite(const void* data, std::size_t length, s32 socket, sockaddr* to) override;
+
+  void LogBBA(const void* data, std::size_t length) override;
 
   NetworkCaptureType GetCaptureType() const override;
 

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -223,6 +223,9 @@ void NetworkWidget::ConnectWidgets()
   connect(m_verify_certificates_checkbox, &QCheckBox::stateChanged, [](int state) {
     Config::SetBaseOrCurrent(Config::MAIN_NETWORK_SSL_VERIFY_CERTIFICATES, state == Qt::Checked);
   });
+  connect(m_dump_bba_checkbox, &QCheckBox::stateChanged, [](int state) {
+    Config::SetBaseOrCurrent(Config::MAIN_NETWORK_DUMP_BBA, state == Qt::Checked);
+  });
   connect(m_open_dump_folder, &QPushButton::pressed, [] {
     const std::string location = File::GetUserPath(D_DUMPSSL_IDX);
     const QUrl url = QUrl::fromLocalFile(QString::fromStdString(location));
@@ -352,6 +355,7 @@ QGroupBox* NetworkWidget::CreateDumpOptionsGroup()
   // i18n: CA stands for certificate authority
   m_dump_root_ca_checkbox = new QCheckBox(tr("Dump root CA certificates"));
   m_dump_peer_cert_checkbox = new QCheckBox(tr("Dump peer certificates"));
+  m_dump_bba_checkbox = new QCheckBox(tr("Dump GameCube BBA traffic"));
   m_open_dump_folder = new QPushButton(tr("Open dump folder"));
   m_open_dump_folder->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
@@ -370,6 +374,7 @@ QGroupBox* NetworkWidget::CreateDumpOptionsGroup()
   dump_options_layout->addWidget(m_dump_ssl_write_checkbox);
   dump_options_layout->addWidget(m_dump_root_ca_checkbox);
   dump_options_layout->addWidget(m_dump_peer_cert_checkbox);
+  dump_options_layout->addWidget(m_dump_bba_checkbox);
   dump_options_layout->addWidget(m_open_dump_folder);
 
   dump_options_layout->setSpacing(1);
@@ -414,23 +419,28 @@ void NetworkWidget::OnDumpFormatComboChanged(int index)
   case FormatComboId::BinarySSL:
     m_dump_ssl_read_checkbox->setChecked(true);
     m_dump_ssl_write_checkbox->setChecked(true);
+    m_dump_bba_checkbox->setChecked(false);
     break;
   case FormatComboId::BinarySSLRead:
     m_dump_ssl_read_checkbox->setChecked(true);
     m_dump_ssl_write_checkbox->setChecked(false);
+    m_dump_bba_checkbox->setChecked(false);
     break;
   case FormatComboId::BinarySSLWrite:
     m_dump_ssl_read_checkbox->setChecked(false);
     m_dump_ssl_write_checkbox->setChecked(true);
+    m_dump_bba_checkbox->setChecked(false);
     break;
   default:
     m_dump_ssl_read_checkbox->setChecked(false);
     m_dump_ssl_write_checkbox->setChecked(false);
+    m_dump_bba_checkbox->setChecked(false);
     break;
   }
   // Enable raw or decrypted SSL choices for PCAP
   const bool is_pcap = combo_id == FormatComboId::PCAP;
   m_dump_ssl_read_checkbox->setEnabled(is_pcap);
   m_dump_ssl_write_checkbox->setEnabled(is_pcap);
+  m_dump_bba_checkbox->setEnabled(is_pcap);
   Config::SetBaseOrCurrent(Config::MAIN_NETWORK_DUMP_AS_PCAP, is_pcap);
 }

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.h
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.h
@@ -58,5 +58,6 @@ private:
   QCheckBox* m_dump_root_ca_checkbox;
   QCheckBox* m_dump_peer_cert_checkbox;
   QCheckBox* m_verify_certificates_checkbox;
+  QCheckBox* m_dump_bba_checkbox;
   QPushButton* m_open_dump_folder;
 };


### PR DESCRIPTION
This PR allows to dump BBA network traffic into a PCAP file.

It seems to produce a legit PCAP file when I entered LAN mode of Kirby Air Ride. I haven't tested it beyond this point.

A screenshot of the option in the Network widget:
![image](https://user-images.githubusercontent.com/7890055/178227577-28d71421-4ecc-4aeb-a603-c31d7bd4c72a.png)

Ready to be reviewed & tested.