### PR TITLE
InputCommon: Link with SDL2-static when static SDL is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,7 +613,9 @@ if(UNIX)
 endif()
 
 if(ENABLE_SDL)
-  find_package(SDL2)
+  if(NOT APPLE)
+    find_package(SDL2)
+  endif()
 
   if(SDL2_FOUND)
     message(STATUS "Using system SDL2")

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -179,7 +179,11 @@ if(SDL2_FOUND)
     ControllerInterface/SDL/SDL.cpp
     ControllerInterface/SDL/SDL.h
   )
-  target_link_libraries(inputcommon PRIVATE SDL2::SDL2)
+  if(SDL_STATIC)
+    target_link_libraries(inputcommon PRIVATE SDL2::SDL2-static)
+  else()
+    target_link_libraries(inputcommon PRIVATE SDL2::SDL2)
+  endif()
 endif()
 
 if(MSVC)


### PR DESCRIPTION
I want to transition to using the version in Externals instead of a shared one from Homebrew for macOS. Using Homebrew-supplied libraries has caused us issues in the past, so I'd like to use as few of them as possible.