### PR TITLE
VideoCommon: fix uint shader compiler error when using d3d

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1675,9 +1675,17 @@ static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_dat
   else
     out.Write(")) {{\n");
 
-  out.Write("\t\tocol0 = float4(0.0, 0.0, 0.0, 0.0);\n");
-  if (use_dual_source && !(api_type == APIType::D3D && uid_data->uint_output))
-    out.Write("\t\tocol1 = float4(0.0, 0.0, 0.0, 0.0);\n");
+  if (uid_data->uint_output)
+    out.Write("\t\tocol0 = uint4(0, 0, 0, 0);\n");
+  else
+    out.Write("\t\tocol0 = float4(0.0, 0.0, 0.0, 0.0);\n");
+  if (use_dual_source)
+  {
+    if (uid_data->uint_output)
+      out.Write("\t\tocol1 = uint4(0, 0, 0, 0);\n");
+    else
+      out.Write("\t\tocol1 = float4(0.0, 0.0, 0.0, 0.0);\n");
+  }
   if (per_pixel_depth)
   {
     out.Write("\t\tdepth = {};\n",
@@ -1805,8 +1813,9 @@ static void WriteLogicOp(ShaderCode& out, const pixel_shader_uid_data* uid_data)
 static void WriteColor(ShaderCode& out, APIType api_type, const pixel_shader_uid_data* uid_data,
                        bool use_dual_source)
 {
-  // D3D requires that the shader outputs be uint when writing to a uint render target for logic op.
-  if (api_type == APIType::D3D && uid_data->uint_output)
+  // Some backends require the shader outputs be uint when writing to a uint render target for logic
+  // op.
+  if (uid_data->uint_output)
   {
     if (uid_data->rgba6_format)
       out.Write("\tocol0 = uint4(prev & 0xFC);\n");

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -1092,8 +1092,9 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
               "  }}\n");
   }
 
-  // D3D requires that the shader outputs be uint when writing to a uint render target for logic op.
-  if (api_type == APIType::D3D && uid_data->uint_output)
+  // Some backends require that the shader outputs be uint when writing to a uint render target for
+  // logic op.
+  if (uid_data->uint_output)
   {
     out.Write("  if (bpmem_rgba6_format)\n"
               "    ocol0 = uint4(TevResult & 0xFC);\n"


### PR DESCRIPTION
When doing some testing on a separate PR, I noticed that the NES Legend of Zelda (on the Gamecube Collector's Edition) would give a shader compiler error when using D3D.

The compiler error was:

> ERROR: 0:160: 'assign' :  cannot convert from ' const 4-component vector of float' to 'layout( location=0 index=0) out 4-component vector of uint'

This PR fixes that error.