### PR TITLE
Add bloom definitions for Sonic Colors

### DIFF
--- a/Data/Sys/Load/GraphicMods/Sonic Colors/metadata.json
+++ b/Data/Sys/Load/GraphicMods/Sonic Colors/metadata.json
@@ -1,0 +1,51 @@
+{
+	"meta":
+	{
+		"title": "Bloom Texture Definitions",
+		"author": "Silent Hell"
+	},
+	"groups":
+	[
+		{
+			"name": "Bloom",
+			"targets": [
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000007_160x120_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000008_160x120_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000009_80x60_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000010_80x60_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000011_40x30_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000012_40x30_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000013_20x15_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000014_20x15_6"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000015_160x120_6"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Adds definitions to add or remove bloom to Sonic Colors.

Original
![SNCE8P_2022-07-11_22-44-13](https://user-images.githubusercontent.com/29898818/178404444-1050b385-393b-4bd6-9693-17a98ff0f850.png)

Native
![SNCE8P_2022-07-11_22-44-48](https://user-images.githubusercontent.com/29898818/178404487-6fd750aa-9ef3-4504-aee1-8121b5132b50.png)

Remove
![SNCE8P_2022-07-11_22-44-29](https://user-images.githubusercontent.com/29898818/178404518-f55b533d-9f9f-4317-b18f-03a3642a888b.png)

