### PR TITLE
VideoCommon: Properly mask fbfetch logic op emulation

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1843,7 +1843,7 @@ static void WriteLogicOp(ShaderCode& out, const pixel_shader_uid_data* uid_data)
   };
 
   out.Write("\tint4 fb_value = iround(initial_ocol0 * 255.0);\n");
-  out.Write("\tprev = {};\n", logic_op_mode[uid_data->logic_op_mode]);
+  out.Write("\tprev = ({}) & 0xff;\n", logic_op_mode[uid_data->logic_op_mode]);
 }
 
 static void WriteColor(ShaderCode& out, APIType api_type, const pixel_shader_uid_data* uid_data,

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -1086,6 +1086,7 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
     }
 
     out.Write("    }}\n"
+              "    TevResult &= 0xff;\n"
               "  }}\n");
   }
 


### PR DESCRIPTION
Fixes fbfetch logic op emulation to mask to 8 bits (previously was left as 32-bit)

Fixes [f-zero-missing-shadows.dff.zip](https://github.com/dolphin-emu/dolphin/files/9099912/f-zero-missing-shadows.dff.zip) on GPUs which used fbfetch to run logic ops