### PR TITLE
VideoCommon: Clear backend_info before populating

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -264,6 +264,9 @@ void VideoBackendBase::ActivateBackend(const std::string& name)
 void VideoBackendBase::PopulateBackendInfo()
 {
   g_Config.Refresh();
+  // Reset backend_info so if the backend forgets to initialize something it doesn't end up using
+  // a value from the previously used renderer
+  g_Config.backend_info = {};
   ActivateBackend(Config::Get(Config::MAIN_GFX_BACKEND));
   g_video_backend->InitBackendInfo();
   // We validate the config after initializing the backend info, as system-specific settings


### PR DESCRIPTION
Removes the requirement that backends manually populate every field in `backend_info` (they now only have to populate features that differ from the default value)

Fixes an issue where switching from a renderer that supported Framebuffer Fetch (e.g. MoltenVK or Metal) to OpenGL would leave the fbfetch support flag enabled.

Alternative Option: Fix the one bug in OpenGL and hope it's the only one like it