### PR TITLE
Free Look: Add background input setting (disabled by default)

### DIFF
--- a/Source/Core/Core/Config/FreeLookSettings.cpp
+++ b/Source/Core/Core/Config/FreeLookSettings.cpp
@@ -12,6 +12,8 @@ namespace Config
 {
 // Configuration Information
 const Info<bool> FREE_LOOK_ENABLED{{System::FreeLook, "General", "Enabled"}, false};
+const Info<bool> FREE_LOOK_BACKGROUND_INPUT{{System::FreeLook, "General", "BackgroundInput"},
+                                            false};
 
 // FreeLook.Controller1
 const Info<FreeLook::ControlType> FL1_CONTROL_TYPE{{System::FreeLook, "Camera1", "ControlType"},

--- a/Source/Core/Core/Config/FreeLookSettings.h
+++ b/Source/Core/Core/Config/FreeLookSettings.h
@@ -15,6 +15,7 @@ namespace Config
 // Configuration Information
 
 extern const Info<bool> FREE_LOOK_ENABLED;
+extern const Info<bool> FREE_LOOK_BACKGROUND_INPUT;
 
 // FreeLook.Controller1
 extern const Info<FreeLook::ControlType> FL1_CONTROL_TYPE;

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -6,10 +6,14 @@
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
+#include "Common/ScopeGuard.h"
 
+#include "Core/Config/FreeLookSettings.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/FreeLookConfig.h"
 
+#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h"
 #include "InputCommon/InputConfig.h"
@@ -226,6 +230,11 @@ void FreeLookController::Update()
 void FreeLookController::UpdateInput(CameraControllerInput* camera_controller)
 {
   const auto lock = GetStateLock();
+  // Preserve the old controller gate state
+  const auto old_gate = ControlReference::GetInputGate();
+  Common::ScopeGuard gate_guard{[old_gate] { ControlReference::SetInputGate(old_gate); }};
+  // Switch to the free look focus gate
+  Core::UpdateInputGate(!Config::Get(Config::FREE_LOOK_BACKGROUND_INPUT));
 
   float dt = 1.0;
   if (m_last_free_look_rotate_time)

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
@@ -61,6 +61,9 @@ void FreeLookWidget::CreateLayout()
   description->setTextInteractionFlags(Qt::TextBrowserInteraction);
   description->setOpenExternalLinks(true);
 
+  m_freelook_background_input = new QCheckBox(tr("Background Input"));
+  m_freelook_background_input->setChecked(Config::Get(Config::FREE_LOOK_BACKGROUND_INPUT));
+
   auto* hlayout = new QHBoxLayout();
   hlayout->addWidget(new QLabel(tr("Camera 1")));
   hlayout->addWidget(m_freelook_control_type);
@@ -68,6 +71,7 @@ void FreeLookWidget::CreateLayout()
 
   layout->addWidget(m_enable_freelook);
   layout->addLayout(hlayout);
+  layout->addWidget(m_freelook_background_input);
   layout->addWidget(description);
 
   setLayout(layout);
@@ -78,6 +82,7 @@ void FreeLookWidget::ConnectWidgets()
   connect(m_freelook_controller_configure_button, &QPushButton::clicked, this,
           &FreeLookWidget::OnFreeLookControllerConfigured);
   connect(m_enable_freelook, &QCheckBox::clicked, this, &FreeLookWidget::SaveSettings);
+  connect(m_freelook_background_input, &QCheckBox::clicked, this, &FreeLookWidget::SaveSettings);
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     const QSignalBlocker blocker(this);
     LoadSettings();
@@ -101,12 +106,16 @@ void FreeLookWidget::LoadSettings()
   m_enable_freelook->setChecked(checked);
   m_freelook_control_type->setEnabled(checked);
   m_freelook_controller_configure_button->setEnabled(checked);
+  m_freelook_background_input->setEnabled(checked);
 }
 
 void FreeLookWidget::SaveSettings()
 {
   const bool checked = m_enable_freelook->isChecked();
   Config::SetBaseOrCurrent(Config::FREE_LOOK_ENABLED, checked);
+  Config::SetBaseOrCurrent(Config::FREE_LOOK_BACKGROUND_INPUT,
+                           m_freelook_background_input->isChecked());
   m_freelook_control_type->setEnabled(checked);
   m_freelook_controller_configure_button->setEnabled(checked);
+  m_freelook_background_input->setEnabled(checked);
 }

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.h
@@ -6,6 +6,7 @@
 #include <QWidget>
 
 class GraphicsChoice;
+class QCheckBox;
 class QPushButton;
 class ToolTipCheckBox;
 
@@ -26,4 +27,5 @@ private:
   ToolTipCheckBox* m_enable_freelook;
   GraphicsChoice* m_freelook_control_type;
   QPushButton* m_freelook_controller_configure_button;
+  QCheckBox* m_freelook_background_input;
 };


### PR DESCRIPTION
Before, Free Look would accept background input by default, which means it was easy to accidentally move the camera while typing in another window. (This is because HotkeyScheduler::Run sets the input gate to `true` after it's copied the hotkey state, supposedly for other threads (though `SetInputGate` uses a `thread_local` variable so I'm not 100% sure that's correct) and for the GBA windows (which always accept unfocused input, presumably because they won't be focused normally).