### PR TITLE
Common::CurrentThreadId() : linux implementation

### DIFF
--- a/Source/Core/Common/Thread.cpp
+++ b/Source/Core/Common/Thread.cpp
@@ -37,6 +37,8 @@ int CurrentThreadId()
   return GetCurrentThreadId();
 #elif defined __APPLE__
   return mach_thread_self();
+#elif defined __linux__
+  return gettid();
 #else
   return 0;
 #endif


### PR DESCRIPTION
POSIX pthreads doesn't provide a portable way to get a thread ID that
can readily be cast to an int. But linux provides gettid() which returns
a `pid_t` : `a signed integer type [...] In the GNU C Library, this is an int`