### PR TITLE
Introducing: BitFieldView

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -34,6 +34,7 @@ BraceWrapping:
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false
+BreakBeforeConceptDeclarations: true
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit:     100
 CommentPragmas:  '^ (IWYU pragma:|NOLINT)'

--- a/Source/Core/Common/Align.h
+++ b/Source/Core/Common/Align.h
@@ -3,21 +3,19 @@
 #pragma once
 
 #include <cstddef>
-#include <type_traits>
+#include "Common/Future/CppLibConcepts.h"
 
 namespace Common
 {
-template <typename T>
+template <std::unsigned_integral T>
 constexpr T AlignUp(T value, size_t size)
 {
-  static_assert(std::is_unsigned<T>(), "T must be an unsigned value.");
   return static_cast<T>(value + (size - value % size) % size);
 }
 
-template <typename T>
+template <std::unsigned_integral T>
 constexpr T AlignDown(T value, size_t size)
 {
-  static_assert(std::is_unsigned<T>(), "T must be an unsigned value.");
   return static_cast<T>(value - value % size);
 }
 

--- a/Source/Core/Common/BitFieldView.h
+++ b/Source/Core/Common/BitFieldView.h
@@ -176,26 +176,22 @@ class MutLooseBitFieldView;
 template <class field_t, std::size_t width, class host_t>
 class ConLooseBitFieldView;
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class MutFixedBitFieldArrayView;
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t_>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t_>
 class ConFixedBitFieldArrayView;
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class MutLooseBitFieldArrayView;
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t_>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t_>
 class ConLooseBitFieldArrayView;
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class MutFixedBitFieldArrayViewIterator;
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class ConFixedBitFieldArrayViewIterator;
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class MutLooseBitFieldArrayViewIterator;
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class ConLooseBitFieldArrayViewIterator;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -239,11 +235,9 @@ concept CL_BFView = requires(T t)
   PassConLooseBitFieldView(t);
 };
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 void PassMutFixedBitFieldArrayView(MutFixedBitFieldArrayView<field_t, Ns, width, start, host_t>);
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 void PassConFixedBitFieldArrayView(ConFixedBitFieldArrayView<field_t, Ns, width, start, host_t>);
 
 template <class T>
@@ -257,9 +251,9 @@ concept CF_BFArrayView = requires(T t)
   PassConFixedBitFieldArrayView(t);
 };
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 void PassMutLooseBitFieldArrayView(MutLooseBitFieldArrayView<field_t, Ns, width, host_t>);
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 void PassConLooseBitFieldArrayView(ConLooseBitFieldArrayView<field_t, Ns, width, host_t>);
 
 template <class T>
@@ -273,12 +267,10 @@ concept CL_BFArrayView = requires(T t)
   PassConLooseBitFieldArrayView(t);
 };
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 void PassMutFixedBitFieldArrayViewIterator(
     MutFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>);
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 void PassConFixedBitFieldArrayViewIterator(
     ConFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>);
 
@@ -293,10 +285,10 @@ concept CF_BFArrayViewIter = requires(T t)
   PassConFixedBitFieldArrayViewIterator(t);
 };
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 void PassMutLooseBitFieldArrayViewIterator(
     MutLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>);
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 void PassConLooseBitFieldArrayViewIterator(
     ConLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>);
 
@@ -403,24 +395,22 @@ constexpr auto MakeBitFieldView(const std::size_t start, const host_t& host)
   return ConLooseBitFieldView<field_t, width, host_t>(start, host);
 }
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 constexpr auto MakeBitFieldArrayView(host_t& host)
 {
   return MutFixedBitFieldArrayView<field_t, Ns, width, start, host_t>(host);
 }
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 constexpr auto MakeBitFieldArrayView(const host_t& host)
 {
   return ConFixedBitFieldArrayView<field_t, Ns, width, start, host_t>(host);
 }
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 constexpr auto MakeBitFieldArrayView(const std::size_t start, host_t& host)
 {
   return MutLooseBitFieldArrayView<field_t, Ns, width, host_t>(start, host);
 }
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 constexpr auto MakeBitFieldArrayView(const std::size_t start, const host_t& host)
 {
   return ConLooseBitFieldArrayView<field_t, Ns, width, host_t>(start, host);
@@ -611,8 +601,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class MutFixedBitFieldArrayView final
 {
 protected:
@@ -669,8 +658,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class ConFixedBitFieldArrayView final
 {
 protected:
@@ -715,7 +703,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class MutLooseBitFieldArrayView final
 {
 protected:
@@ -770,7 +758,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class ConLooseBitFieldArrayView final
 {
 protected:
@@ -812,8 +800,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class MutFixedBitFieldArrayViewIterator final
 {
 protected:
@@ -871,8 +858,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
-          class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class ConFixedBitFieldArrayViewIterator final
 {
 protected:
@@ -931,7 +917,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class MutLooseBitFieldArrayViewIterator final
 {
 protected:
@@ -991,7 +977,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class ConLooseBitFieldArrayViewIterator final
 {
 protected:

--- a/Source/Core/Common/BitFieldView.h
+++ b/Source/Core/Common/BitFieldView.h
@@ -12,12 +12,11 @@
 #include "Common/BitUtils.h"      // Common::ExtractBitsU, Common::ExtractBitsS,
                                   // Common::InsertBits, Common::ExtractBit, Common::InsertBit,
                                   // Common::BitSize
-#include "Common/Concepts.h"      // Common::SameAsOrUnderlyingSameAs
+#include "Common/Concepts.h"      // Common::SameAsOrUnderlyingSameAs, Common::UnscopedEnum
 #include "Common/ConstantPack.h"  // Common::IndexPack
 #include "Common/TypeUtils.h"     // Common::ScopedEnumUnderlyingElseVoid
 
-#include "Common/Future/CppLibConcepts.h"      // std::integral
-#include "Common/Future/CppLibToUnderlying.h"  // std::to_underlying
+#include "Common/Future/CppLibConcepts.h"  // std::integral
 
 namespace Common
 {
@@ -465,9 +464,15 @@ public:
   constexpr MutFixedBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
 
   constexpr operator field_t() const { return Get(); }
-  constexpr explicit operator ScopedEnumUnderlyingElseVoid<field_t>() const
+  template <UnscopedEnum T>     // This only compiles because it is constrained, otherwise you
+  constexpr operator T() const  // would see the error "conversion function cannot be redeclared"
   {
-    return std::to_underlying(Get());
+    return static_cast<T>(Get());  // Surprisingly required static_cast
+  }
+  template <class T>
+  constexpr explicit operator T() const
+  {
+    return static_cast<T>(Get());  // Test your luck.
   }
   constexpr bool operator!() const { return !static_cast<bool>(Get()); }
 };
@@ -492,9 +497,15 @@ public:
   constexpr field_t Get() const { return GetFixedBitField<field_t, width, start>(host); }
 
   constexpr operator field_t() const { return Get(); }
-  constexpr explicit operator ScopedEnumUnderlyingElseVoid<field_t>() const
+  template <UnscopedEnum T>     // This only compiles because it is constrained, otherwise you
+  constexpr operator T() const  // would see the error "conversion function cannot be redeclared"
   {
-    return std::to_underlying(Get());
+    return static_cast<T>(Get());  // Surprisingly required static_cast
+  }
+  template <class T>
+  constexpr explicit operator T() const
+  {
+    return static_cast<T>(Get());  // Test your luck.
   }
   constexpr bool operator!() const { return !static_cast<bool>(Get()); }
 };
@@ -542,9 +553,15 @@ public:
   constexpr MutLooseBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
 
   constexpr operator field_t() const { return Get(); }
-  constexpr explicit operator ScopedEnumUnderlyingElseVoid<field_t>() const
+  template <UnscopedEnum T>     // This only compiles because it is constrained, otherwise you
+  constexpr operator T() const  // would see the error "conversion function cannot be redeclared"
   {
-    return std::to_underlying(Get());
+    return static_cast<T>(Get());  // Surprisingly required static_cast
+  }
+  template <class T>
+  constexpr explicit operator T() const
+  {
+    return static_cast<T>(Get());  // Test your luck.
   }
   constexpr bool operator!() const { return !static_cast<bool>(Get()); }
 };
@@ -571,9 +588,15 @@ public:
   constexpr field_t Get() const { return GetLooseBitField<field_t, width>(start, host); }
 
   constexpr operator field_t() const { return Get(); }
-  constexpr explicit operator ScopedEnumUnderlyingElseVoid<field_t>() const
+  template <UnscopedEnum T>     // This only compiles because it is constrained, otherwise you
+  constexpr operator T() const  // would see the error "conversion function cannot be redeclared"
   {
-    return std::to_underlying(Get());
+    return static_cast<T>(Get());  // Surprisingly required static_cast
+  }
+  template <class T>
+  constexpr explicit operator T() const
+  {
+    return static_cast<T>(Get());  // Test your luck.
   }
   constexpr bool operator!() const { return !static_cast<bool>(Get()); }
 };

--- a/Source/Core/Common/BitFieldView.h
+++ b/Source/Core/Common/BitFieldView.h
@@ -233,7 +233,7 @@ constexpr auto MakeBitFieldArrayView(const std::size_t start, const host_t& host
 template <class field_t, std::size_t width, std::size_t start, class host_t>
 class FixedBitFieldView final
 {
-protected:
+private:
   host_t& host;
 
 public:
@@ -286,7 +286,7 @@ public:
 template <class field_t, std::size_t width, class host_t>
 class LooseBitFieldView final
 {
-protected:
+private:
   host_t& host;
   const std::size_t start;
 
@@ -344,7 +344,7 @@ public:
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class FixedBitFieldArrayView final
 {
-protected:
+private:
   host_t& host;
 
 public:
@@ -401,7 +401,7 @@ public:
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class LooseBitFieldArrayView final
 {
-protected:
+private:
   host_t& host;
   const std::size_t start;
 
@@ -456,7 +456,7 @@ public:
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class FixedBitFieldArrayViewIterator final
 {
-protected:
+private:
   host_t& host;
   std::size_t idx;
 
@@ -512,7 +512,7 @@ public:
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class LooseBitFieldArrayViewIterator final
 {
-protected:
+private:
   host_t& host;
   std::size_t idx;
   const std::size_t start;
@@ -566,7 +566,65 @@ public:
     return idx == other.idx;
   }
 };
-};  // namespace Common
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// BitFieldView concepts
+
+namespace detail
+{
+template <IntegralOrEnum f, std::size_t w, std::size_t s, class h>
+void PassFixedBitFieldView(FixedBitFieldView<f, w, s, h>);
+template <IntegralOrEnum f, std::size_t w, class h>
+void PassLooseBitFieldView(LooseBitFieldView<f, w, h>);
+template <IntegralOrEnum f, AnyIndexPack Ns, std::size_t w, std::size_t s, class h>
+void PassFixedBitFieldArrayView(FixedBitFieldArrayView<f, Ns, w, s, h>);
+template <IntegralOrEnum f, AnyIndexPack Ns, std::size_t w, class h>
+void PassLooseBitFieldArrayView(LooseBitFieldArrayView<f, Ns, w, h>);
+template <IntegralOrEnum f, AnyIndexPack Ns, std::size_t w, std::size_t s, class h>
+void PassFixedBitFieldArrayViewIterator(FixedBitFieldArrayViewIterator<f, Ns, w, s, h>);
+template <IntegralOrEnum f, AnyIndexPack Ns, std::size_t w, class h>
+void PassLooseBitFieldArrayViewIterator(LooseBitFieldArrayViewIterator<f, Ns, w, h>);
+}  // namespace detail
+
+template <class T>
+concept AnyFixedBitFieldView = requires(T t)
+{
+  detail::PassFixedBitFieldView(t);
+};
+template <class T>
+concept AnyLooseBitFieldView = requires(T t)
+{
+  detail::PassLooseBitFieldView(t);
+};
+template <class T>
+concept AnyFixedBitFieldArrayView = requires(T t)
+{
+  detail::PassFixedBitFieldArrayView(t);
+};
+template <class T>
+concept AnyLooseBitFieldArrayView = requires(T t)
+{
+  detail::PassLooseBitFieldArrayView(t);
+};
+template <class T>
+concept AnyFixedBitFieldArrayViewIterator = requires(T t)
+{
+  detail::PassFixedBitFieldArrayViewIterator(t);
+};
+template <class T>
+concept AnyLooseBitFieldArrayViewIterator = requires(T t)
+{
+  detail::PassLooseBitFieldArrayViewIterator(t);
+};
+
+template <class T>
+concept AnyBitFieldView = AnyFixedBitFieldView<T> || AnyLooseBitFieldView<T>;
+template <class T>
+concept AnyBitFieldArrayView = AnyFixedBitFieldArrayView<T> || AnyLooseBitFieldArrayView<T>;
+template <class T>
+concept AnyBitFieldArrayViewIterator =
+    AnyFixedBitFieldArrayViewIterator<T> || AnyLooseBitFieldArrayViewIterator<T>;
+}  // namespace Common
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Easily create BitFieldView(Array) methods in a class which target a given host member.

--- a/Source/Core/Common/BitFieldView.h
+++ b/Source/Core/Common/BitFieldView.h
@@ -429,7 +429,7 @@ constexpr auto MakeBitFieldArrayView(const std::size_t start, const host_t& host
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, std::size_t width, std::size_t start, class host_t>
-class MutFixedBitFieldView
+class MutFixedBitFieldView final
 {
 protected:
   host_t& host;
@@ -482,7 +482,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, std::size_t width, std::size_t start, class host_t>
-class ConFixedBitFieldView
+class ConFixedBitFieldView final
 {
 protected:
   const host_t& host;
@@ -517,7 +517,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, std::size_t width, class host_t>
-class MutLooseBitFieldView
+class MutLooseBitFieldView final
 {
 protected:
   host_t& host;
@@ -575,7 +575,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, std::size_t width, class host_t>
-class ConLooseBitFieldView
+class ConLooseBitFieldView final
 {
 protected:
   const host_t& host;
@@ -613,7 +613,7 @@ public:
 
 template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
           class host_t>
-class MutFixedBitFieldArrayView
+class MutFixedBitFieldArrayView final
 {
 protected:
   host_t& host;
@@ -671,7 +671,7 @@ public:
 
 template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
           class host_t>
-class ConFixedBitFieldArrayView
+class ConFixedBitFieldArrayView final
 {
 protected:
   const host_t& host;
@@ -716,7 +716,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
-class MutLooseBitFieldArrayView
+class MutLooseBitFieldArrayView final
 {
 protected:
   host_t& host;
@@ -771,7 +771,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
-class ConLooseBitFieldArrayView
+class ConLooseBitFieldArrayView final
 {
 protected:
   const host_t& host;
@@ -814,7 +814,7 @@ public:
 
 template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
           class host_t>
-class MutFixedBitFieldArrayViewIterator
+class MutFixedBitFieldArrayViewIterator final
 {
 protected:
   host_t& host;
@@ -873,7 +873,7 @@ public:
 
 template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
           class host_t>
-class ConFixedBitFieldArrayViewIterator
+class ConFixedBitFieldArrayViewIterator final
 {
 protected:
   const host_t& host;
@@ -932,7 +932,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
-class MutLooseBitFieldArrayViewIterator
+class MutLooseBitFieldArrayViewIterator final
 {
 protected:
   host_t& host;
@@ -992,7 +992,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
-class ConLooseBitFieldArrayViewIterator
+class ConLooseBitFieldArrayViewIterator final
 {
 protected:
   const host_t& host;

--- a/Source/Core/Common/BitFieldView.h
+++ b/Source/Core/Common/BitFieldView.h
@@ -168,147 +168,19 @@ constexpr void SetLooseBitField(const std::size_t start, double& host, const fie
 // Forward declarations.
 
 template <class field_t, std::size_t width, std::size_t start, class host_t>
-class MutFixedBitFieldView;
+class FixedBitFieldView;
 template <class field_t, std::size_t width, class host_t>
-class MutLooseBitFieldView;
+class LooseBitFieldView;
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-class MutFixedBitFieldArrayView;
+class FixedBitFieldArrayView;
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-class MutLooseBitFieldArrayView;
+class LooseBitFieldArrayView;
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-class MutFixedBitFieldArrayViewIterator;
+class FixedBitFieldArrayViewIterator;
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-class MutLooseBitFieldArrayViewIterator;
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// BitFieldView concepts
-
-// This is the best solution I could come up with given the circumstances.  There exist tricks for
-// detecting if a type is an instantiation of a given template *without* abusing requires clauses,
-// but the ones I found do not work when value parameters are thrown into the mix.  In short,
-// template instances are just types, lacking a direct link back to the template it originated from.
-namespace detail
-{
-template <class field_t, std::size_t width, std::size_t start, class host_t>
-void PassMutFixedBitFieldView(MutFixedBitFieldView<field_t, width, start, host_t>);
-template <class T>
-concept MF_BFView = requires(T t)
-{
-  PassMutFixedBitFieldView(t);
-};
-
-template <class field_t, std::size_t width, class host_t>
-void PassMutLooseBitFieldView(MutLooseBitFieldView<field_t, width, host_t>);
-
-template <class T>
-concept ML_BFView = requires(T t)
-{
-  PassMutLooseBitFieldView(t);
-};
-
-template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-void PassMutFixedBitFieldArrayView(MutFixedBitFieldArrayView<field_t, Ns, width, start, host_t>);
-template <class T>
-concept MF_BFArrayView = requires(T t)
-{
-  PassMutFixedBitFieldArrayView(t);
-};
-
-template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-void PassMutLooseBitFieldArrayView(MutLooseBitFieldArrayView<field_t, Ns, width, host_t>);
-
-template <class T>
-concept ML_BFArrayView = requires(T t)
-{
-  PassMutLooseBitFieldArrayView(t);
-};
-
-template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-void PassMutFixedBitFieldArrayViewIterator(
-    MutFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>);
-
-template <class T>
-concept MF_BFArrayViewIter = requires(T t)
-{
-  PassMutFixedBitFieldArrayViewIterator(t);
-};
-
-template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-void PassMutLooseBitFieldArrayViewIterator(
-    MutLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>);
-
-template <class T>
-concept ML_BFArrayViewIter = requires(T t)
-{
-  PassMutLooseBitFieldArrayViewIterator(t);
-};
-};  // namespace detail
-
-template <class T>
-concept FixedBitFieldView = detail::MF_BFView<T>;
-template <class T>
-concept LooseBitFieldView = detail::ML_BFView<T>;
-template <class T>
-concept BitFieldView = FixedBitFieldView<T> || LooseBitFieldView<T>;
-
-template <class T>
-concept FixedBitFieldArrayView = detail::MF_BFArrayView<T>;
-template <class T>
-concept LooseBitFieldArrayView = detail::ML_BFArrayView<T>;
-template <class T>
-concept BitFieldArrayView = FixedBitFieldArrayView<T> || LooseBitFieldArrayView<T>;
-
-template <class T>
-concept FixedBitFieldArrayViewIterator = detail::MF_BFArrayViewIter<T>;
-template <class T>
-concept LooseBitFieldArrayViewIterator = detail::ML_BFArrayViewIter<T>;
-template <class T>
-concept BitFieldArrayViewIterator =
-    FixedBitFieldArrayViewIterator<T> || LooseBitFieldArrayViewIterator<T>;
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// BitFieldView type traits
-
-template <class T>
-struct IsFixedBitFieldView : std::bool_constant<FixedBitFieldView<T>>
-{
-};
-template <class T>
-struct IsLooseBitFieldView : std::bool_constant<LooseBitFieldView<T>>
-{
-};
-template <class T>
-struct IsBitFieldView : std::bool_constant<BitFieldView<T>>
-{
-};
-
-template <class T>
-struct IsFixedBitFieldArrayView : std::bool_constant<FixedBitFieldArrayView<T>>
-{
-};
-template <class T>
-struct IsLooseBitFieldArrayView : std::bool_constant<LooseBitFieldArrayView<T>>
-{
-};
-template <class T>
-struct IsBitFieldArrayView : std::bool_constant<BitFieldArrayView<T>>
-{
-};
-
-template <class T>
-struct IsFixedBitFieldArrayViewIterator : std::bool_constant<FixedBitFieldArrayViewIterator<T>>
-{
-};
-template <class T>
-struct IsLooseBitFieldArrayViewIterator : std::bool_constant<LooseBitFieldArrayViewIterator<T>>
-{
-};
-template <class T>
-struct IsBitFieldArrayViewIterator : std::bool_constant<BitFieldArrayViewIterator<T>>
-{
-};
+class LooseBitFieldArrayViewIterator;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Define some pre-C++17-esque helper functions.  We do this because, even as of C++17, one cannot
@@ -317,49 +189,49 @@ struct IsBitFieldArrayViewIterator : std::bool_constant<BitFieldArrayViewIterato
 template <class field_t, std::size_t width, std::size_t start, class host_t>
 constexpr auto MakeBitFieldView(host_t& host)
 {
-  return MutFixedBitFieldView<field_t, width, start, host_t>(host);
+  return FixedBitFieldView<field_t, width, start, host_t>(host);
 }
 template <class field_t, std::size_t width, std::size_t start, class host_t>
 constexpr auto MakeBitFieldView(const host_t& host)
 {
-  return MutFixedBitFieldView<field_t, width, start, const host_t>(host);
+  return FixedBitFieldView<field_t, width, start, const host_t>(host);
 }
 template <class field_t, std::size_t width, class host_t>
 constexpr auto MakeBitFieldView(const std::size_t start, host_t& host)
 {
-  return MutLooseBitFieldView<field_t, width, host_t>(start, host);
+  return LooseBitFieldView<field_t, width, host_t>(start, host);
 }
 template <class field_t, std::size_t width, class host_t>
 constexpr auto MakeBitFieldView(const std::size_t start, const host_t& host)
 {
-  return MutLooseBitFieldView<field_t, width, const host_t>(start, host);
+  return LooseBitFieldView<field_t, width, const host_t>(start, host);
 }
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 constexpr auto MakeBitFieldArrayView(host_t& host)
 {
-  return MutFixedBitFieldArrayView<field_t, Ns, width, start, host_t>(host);
+  return FixedBitFieldArrayView<field_t, Ns, width, start, host_t>(host);
 }
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 constexpr auto MakeBitFieldArrayView(const host_t& host)
 {
-  return MutFixedBitFieldArrayView<field_t, Ns, width, start, const host_t>(host);
+  return FixedBitFieldArrayView<field_t, Ns, width, start, const host_t>(host);
 }
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 constexpr auto MakeBitFieldArrayView(const std::size_t start, host_t& host)
 {
-  return MutLooseBitFieldArrayView<field_t, Ns, width, host_t>(start, host);
+  return LooseBitFieldArrayView<field_t, Ns, width, host_t>(start, host);
 }
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 constexpr auto MakeBitFieldArrayView(const std::size_t start, const host_t& host)
 {
-  return MutLooseBitFieldArrayView<field_t, Ns, width, const host_t>(start, host);
+  return LooseBitFieldArrayView<field_t, Ns, width, const host_t>(start, host);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, std::size_t width, std::size_t start, class host_t>
-class MutFixedBitFieldView final
+class FixedBitFieldView final
 {
 protected:
   host_t& host;
@@ -370,9 +242,9 @@ public:
   constexpr static std::size_t BitWidth() { return width; }
   constexpr static std::size_t BitStart() { return start; }
 
-  MutFixedBitFieldView() = delete;
-  constexpr MutFixedBitFieldView(host_t& host_) : host(host_){};
-  constexpr MutFixedBitFieldView& operator=(const MutFixedBitFieldView& rhs)
+  FixedBitFieldView() = delete;
+  constexpr FixedBitFieldView(host_t& host_) : host(host_){};
+  constexpr FixedBitFieldView& operator=(const FixedBitFieldView& rhs)
   {
     return operator=(rhs.Get());
   }
@@ -380,18 +252,18 @@ public:
   constexpr field_t Get() const { return GetFixedBitField<field_t, width, start>(host); }
   constexpr void Set(const field_t val) { SetFixedBitField<field_t, width, start>(host, val); }
 
-  constexpr MutFixedBitFieldView& operator=(const field_t rhs)
+  constexpr FixedBitFieldView& operator=(const field_t rhs)
   {
     Set(rhs);
     return *this;
   }
-  constexpr MutFixedBitFieldView& operator+=(const field_t rhs) { return operator=(Get() + rhs); }
-  constexpr MutFixedBitFieldView& operator-=(const field_t rhs) { return operator=(Get() - rhs); }
-  constexpr MutFixedBitFieldView& operator*=(const field_t rhs) { return operator=(Get() * rhs); }
-  constexpr MutFixedBitFieldView& operator/=(const field_t rhs) { return operator=(Get() / rhs); }
-  constexpr MutFixedBitFieldView& operator|=(const field_t rhs) { return operator=(Get() | rhs); }
-  constexpr MutFixedBitFieldView& operator&=(const field_t rhs) { return operator=(Get() & rhs); }
-  constexpr MutFixedBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
+  constexpr FixedBitFieldView& operator+=(const field_t rhs) { return operator=(Get() + rhs); }
+  constexpr FixedBitFieldView& operator-=(const field_t rhs) { return operator=(Get() - rhs); }
+  constexpr FixedBitFieldView& operator*=(const field_t rhs) { return operator=(Get() * rhs); }
+  constexpr FixedBitFieldView& operator/=(const field_t rhs) { return operator=(Get() / rhs); }
+  constexpr FixedBitFieldView& operator|=(const field_t rhs) { return operator=(Get() | rhs); }
+  constexpr FixedBitFieldView& operator&=(const field_t rhs) { return operator=(Get() & rhs); }
+  constexpr FixedBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
 
   constexpr operator field_t() const { return Get(); }
   /// This code enables implicit casts to unscoped enums, but also somehow clashes with Qt, which
@@ -412,7 +284,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, std::size_t width, class host_t>
-class MutLooseBitFieldView final
+class LooseBitFieldView final
 {
 protected:
   host_t& host;
@@ -424,10 +296,10 @@ public:
   constexpr static std::size_t BitWidth() { return width; }
   std::size_t BitStart() { return start; }
 
-  MutLooseBitFieldView() = delete;
-  constexpr MutLooseBitFieldView(const std::size_t start_, host_t& host_)
+  LooseBitFieldView() = delete;
+  constexpr LooseBitFieldView(const std::size_t start_, host_t& host_)
       : host(host_), start(start_){};
-  constexpr MutLooseBitFieldView& operator=(const MutLooseBitFieldView& rhs)
+  constexpr LooseBitFieldView& operator=(const LooseBitFieldView& rhs)
   {
     return operator=(rhs.Get());
   }
@@ -438,18 +310,18 @@ public:
     return SetLooseBitField<field_t, width>(start, host, val);
   }
 
-  constexpr MutLooseBitFieldView& operator=(const field_t rhs)
+  constexpr LooseBitFieldView& operator=(const field_t rhs)
   {
     Set(rhs);
     return *this;
   }
-  constexpr MutLooseBitFieldView& operator+=(const field_t rhs) { return operator=(Get() + rhs); }
-  constexpr MutLooseBitFieldView& operator-=(const field_t rhs) { return operator=(Get() - rhs); }
-  constexpr MutLooseBitFieldView& operator*=(const field_t rhs) { return operator=(Get() * rhs); }
-  constexpr MutLooseBitFieldView& operator/=(const field_t rhs) { return operator=(Get() / rhs); }
-  constexpr MutLooseBitFieldView& operator|=(const field_t rhs) { return operator=(Get() | rhs); }
-  constexpr MutLooseBitFieldView& operator&=(const field_t rhs) { return operator=(Get() & rhs); }
-  constexpr MutLooseBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
+  constexpr LooseBitFieldView& operator+=(const field_t rhs) { return operator=(Get() + rhs); }
+  constexpr LooseBitFieldView& operator-=(const field_t rhs) { return operator=(Get() - rhs); }
+  constexpr LooseBitFieldView& operator*=(const field_t rhs) { return operator=(Get() * rhs); }
+  constexpr LooseBitFieldView& operator/=(const field_t rhs) { return operator=(Get() / rhs); }
+  constexpr LooseBitFieldView& operator|=(const field_t rhs) { return operator=(Get() | rhs); }
+  constexpr LooseBitFieldView& operator&=(const field_t rhs) { return operator=(Get() & rhs); }
+  constexpr LooseBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
 
   constexpr operator field_t() const { return Get(); }
   /// This code enables implicit casts to unscoped enums, but also somehow clashes with Qt, which
@@ -470,7 +342,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-class MutFixedBitFieldArrayView final
+class FixedBitFieldArrayView final
 {
 protected:
   host_t& host;
@@ -478,22 +350,22 @@ protected:
 public:
   using reference =
       std::conditional_t<(Ns::size() > 1),
-                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         MutLooseBitFieldView<field_t, width, host_t>>;
+                         LooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         LooseBitFieldView<field_t, width, host_t>>;
   using const_reference =
       std::conditional_t<(Ns::size() > 1),
-                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, const host_t>,
-                         MutLooseBitFieldView<field_t, width, const host_t>>;
-  using iterator = MutFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>;
-  using const_iterator = MutFixedBitFieldArrayViewIterator<field_t, Ns, width, start, const host_t>;
+                         LooseBitFieldArrayView<field_t, typename Ns::peel, width, const host_t>,
+                         LooseBitFieldView<field_t, width, const host_t>>;
+  using iterator = FixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>;
+  using const_iterator = FixedBitFieldArrayViewIterator<field_t, Ns, width, start, const host_t>;
 
   using HostType = host_t;
   using FieldType = field_t;
   constexpr static std::size_t BitWidth() { return reference::BitWidth() * length(); }
   constexpr static std::size_t BitStart() { return start; }
 
-  MutFixedBitFieldArrayView() = delete;
-  constexpr MutFixedBitFieldArrayView(host_t& host_) : host(host_)
+  FixedBitFieldArrayView() = delete;
+  constexpr FixedBitFieldArrayView(host_t& host_) : host(host_)
   {
     // This static assertion is normally the job of the GetFixedBitField/SetFixedBitField functions.
     // BitFieldArrayViews never run into those functions, though, which could lead to nasty bugs.
@@ -527,7 +399,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-class MutLooseBitFieldArrayView final
+class LooseBitFieldArrayView final
 {
 protected:
   host_t& host;
@@ -536,22 +408,22 @@ protected:
 public:
   using reference =
       std::conditional_t<(Ns::size() > 1),
-                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         MutLooseBitFieldView<field_t, width, host_t>>;
+                         LooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         LooseBitFieldView<field_t, width, host_t>>;
   using const_reference =
       std::conditional_t<(Ns::size() > 1),
-                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, const host_t>,
-                         MutLooseBitFieldView<field_t, width, const host_t>>;
-  using iterator = MutLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>;
-  using const_iterator = MutLooseBitFieldArrayViewIterator<field_t, Ns, width, const host_t>;
+                         LooseBitFieldArrayView<field_t, typename Ns::peel, width, const host_t>,
+                         LooseBitFieldView<field_t, width, const host_t>>;
+  using iterator = LooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>;
+  using const_iterator = LooseBitFieldArrayViewIterator<field_t, Ns, width, const host_t>;
 
   using HostType = host_t;
   using FieldType = field_t;
   constexpr static std::size_t BitWidth() { return reference::BitWidth() * Ns::first; }
   std::size_t BitStart() { return start; }
 
-  MutLooseBitFieldArrayView() = delete;
-  constexpr MutLooseBitFieldArrayView(const std::size_t start_, host_t& host_)
+  LooseBitFieldArrayView() = delete;
+  constexpr LooseBitFieldArrayView(const std::size_t start_, host_t& host_)
       : host(host_), start(start_)
   {
   }
@@ -582,7 +454,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-class MutFixedBitFieldArrayViewIterator final
+class FixedBitFieldArrayViewIterator final
 {
 protected:
   host_t& host;
@@ -595,35 +467,33 @@ public:
   using pointer = void;
   using reference =
       std::conditional_t<(Ns::size() > 1),
-                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         MutLooseBitFieldView<field_t, width, host_t>>;
+                         LooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         LooseBitFieldView<field_t, width, host_t>>;
 
   using HostType = host_t;
   using FieldType = field_t;
   constexpr static std::size_t BitWidth() { return reference::BitWidth(); }
   constexpr static std::size_t BitStart() { return start; }
 
-  MutFixedBitFieldArrayViewIterator(host_t& host_, const std::size_t idx_) : host(host_), idx(idx_)
-  {
-  }
+  FixedBitFieldArrayViewIterator(host_t& host_, const std::size_t idx_) : host(host_), idx(idx_) {}
 
   // Required by std::input_or_output_iterator
-  constexpr MutFixedBitFieldArrayViewIterator() = default;
+  constexpr FixedBitFieldArrayViewIterator() = default;
   // Copy constructor and assignment operators, required by LegacyIterator
-  constexpr MutFixedBitFieldArrayViewIterator(const MutFixedBitFieldArrayViewIterator&) = default;
-  MutFixedBitFieldArrayViewIterator& operator=(const MutFixedBitFieldArrayViewIterator&) = default;
+  constexpr FixedBitFieldArrayViewIterator(const FixedBitFieldArrayViewIterator&) = default;
+  FixedBitFieldArrayViewIterator& operator=(const FixedBitFieldArrayViewIterator&) = default;
   // Move constructor and assignment operators, explicitly defined for completeness
-  constexpr MutFixedBitFieldArrayViewIterator(MutFixedBitFieldArrayViewIterator&&) = default;
-  MutFixedBitFieldArrayViewIterator& operator=(MutFixedBitFieldArrayViewIterator&&) = default;
+  constexpr FixedBitFieldArrayViewIterator(FixedBitFieldArrayViewIterator&&) = default;
+  FixedBitFieldArrayViewIterator& operator=(FixedBitFieldArrayViewIterator&&) = default;
 
-  MutFixedBitFieldArrayViewIterator& operator++()
+  FixedBitFieldArrayViewIterator& operator++()
   {
     ++idx;
     return *this;
   }
-  MutFixedBitFieldArrayViewIterator operator++(int)
+  FixedBitFieldArrayViewIterator operator++(int)
   {
-    MutFixedBitFieldArrayViewIterator other{*this};
+    FixedBitFieldArrayViewIterator other{*this};
     ++*this;
     return other;
   }
@@ -631,7 +501,7 @@ public:
   {
     return reference(start + reference::BitWidth() * idx, host);
   }
-  constexpr bool operator==(const MutFixedBitFieldArrayViewIterator& other) const
+  constexpr bool operator==(const FixedBitFieldArrayViewIterator& other) const
   {
     return idx == other.idx;
   }
@@ -640,7 +510,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-class MutLooseBitFieldArrayViewIterator final
+class LooseBitFieldArrayViewIterator final
 {
 protected:
   host_t& host;
@@ -654,36 +524,36 @@ public:
   using pointer = void;
   using reference =
       std::conditional_t<(Ns::size() > 1),
-                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         MutLooseBitFieldView<field_t, width, host_t>>;
+                         LooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         LooseBitFieldView<field_t, width, host_t>>;
 
   using HostType = host_t;
   using FieldType = field_t;
   constexpr static std::size_t BitWidth() { return reference::BitWidth(); }
   std::size_t BitStart() { return start; }
 
-  MutLooseBitFieldArrayViewIterator(const std::size_t start_, host_t& host_, const std::size_t idx_)
+  LooseBitFieldArrayViewIterator(const std::size_t start_, host_t& host_, const std::size_t idx_)
       : host(host_), idx(idx_), start(start_)
   {
   }
 
   // Required by std::input_or_output_iterator
-  constexpr MutLooseBitFieldArrayViewIterator() = default;
+  constexpr LooseBitFieldArrayViewIterator() = default;
   // Copy constructor and assignment operators, required by LegacyIterator
-  constexpr MutLooseBitFieldArrayViewIterator(const MutLooseBitFieldArrayViewIterator&) = default;
-  MutLooseBitFieldArrayViewIterator& operator=(const MutLooseBitFieldArrayViewIterator&) = default;
+  constexpr LooseBitFieldArrayViewIterator(const LooseBitFieldArrayViewIterator&) = default;
+  LooseBitFieldArrayViewIterator& operator=(const LooseBitFieldArrayViewIterator&) = default;
   // Move constructor and assignment operators, explicitly defined for completeness
-  constexpr MutLooseBitFieldArrayViewIterator(MutLooseBitFieldArrayViewIterator&&) = default;
-  MutLooseBitFieldArrayViewIterator& operator=(MutLooseBitFieldArrayViewIterator&&) = default;
+  constexpr LooseBitFieldArrayViewIterator(LooseBitFieldArrayViewIterator&&) = default;
+  LooseBitFieldArrayViewIterator& operator=(LooseBitFieldArrayViewIterator&&) = default;
 
-  MutLooseBitFieldArrayViewIterator& operator++()
+  LooseBitFieldArrayViewIterator& operator++()
   {
     ++idx;
     return *this;
   }
-  MutLooseBitFieldArrayViewIterator operator++(int)
+  LooseBitFieldArrayViewIterator operator++(int)
   {
-    MutLooseBitFieldArrayViewIterator other(*this);
+    LooseBitFieldArrayViewIterator other(*this);
     ++*this;
     return other;
   }
@@ -691,7 +561,7 @@ public:
   {
     return reference(start + reference::BitWidth() * idx, host);
   }
-  constexpr bool operator==(const MutLooseBitFieldArrayViewIterator& other) const
+  constexpr bool operator==(const LooseBitFieldArrayViewIterator& other) const
   {
     return idx == other.idx;
   }
@@ -755,13 +625,27 @@ public:
 
 #include <fmt/format.h>
 
-template <Common::BitFieldView T>
-struct fmt::formatter<T>
+template <Common::IntegralOrEnum field_t, std::size_t width, std::size_t start, class host_t>
+struct fmt::formatter<Common::FixedBitFieldView<field_t, width, start, host_t>>
 {
-  fmt::formatter<typename T::FieldType> m_formatter;
+  fmt::formatter<field_t> m_formatter;
   constexpr auto parse(format_parse_context& ctx) { return m_formatter.parse(ctx); }
   template <typename FormatContext>
-  auto format(const T& ref, FormatContext& ctx) const
+  auto format(const Common::FixedBitFieldView<field_t, width, start, host_t>& ref,
+              FormatContext& ctx) const
+  {
+    return m_formatter.format(ref.Get(), ctx);
+  }
+};
+
+template <Common::IntegralOrEnum field_t, std::size_t width, class host_t>
+struct fmt::formatter<Common::LooseBitFieldView<field_t, width, host_t>>
+{
+  fmt::formatter<field_t> m_formatter;
+  constexpr auto parse(format_parse_context& ctx) { return m_formatter.parse(ctx); }
+  template <typename FormatContext>
+  auto format(const Common::LooseBitFieldView<field_t, width, host_t>& ref,
+              FormatContext& ctx) const
   {
     return m_formatter.format(ref.Get(), ctx);
   }

--- a/Source/Core/Common/BitFieldView.h
+++ b/Source/Core/Common/BitFieldView.h
@@ -1,0 +1,1092 @@
+// Copyright 2022, Bradley G. (Minty Meeo)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cstddef>      // std::size_t
+#include <cstdint>      // std::uint32_t, std::uint64_t
+#include <iterator>     // std::input_iterator_tag, std::output_iterator_tag
+#include <type_traits>  // std::is_signed, std::is_arithmetic
+
+#include "Common/Assert.h"        // DEBUG_ASSERT
+#include "Common/BitUtils.h"      // Common::ExtractBitsU, Common::ExtractBitsS,
+                                  // Common::InsertBits, Common::ExtractBit, Common::InsertBit,
+                                  // Common::BitSize
+#include "Common/Concepts.h"      // Common::SameAsOrUnderlyingSameAs
+#include "Common/ConstantPack.h"  // Common::IndexPack
+#include "Common/TypeUtils.h"     // Common::ScopedEnumUnderlyingElseVoid
+
+#include "Common/Future/CppLibConcepts.h"      // std::integral
+#include "Common/Future/CppLibToUnderlying.h"  // std::to_underlying
+
+namespace Common
+{
+template <class T>
+concept FastBitFieldType = SameAsOrUnderlyingSameAs<T, bool>;
+template <class T>
+concept SaneBitFieldType = IntegralOrEnum<T> && !FastBitFieldType<T>;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Intermediary step between BitFieldView classes and BitUtil functions.  This step requires
+// field_t and host_t to satisfy constraints.  If host_t does not satisfy std::integral, you must
+// define a partial specialization for that host type (see: float and double specializations).  If
+// field_t does not satisfy IntegralOrEnum (which can be divided into SaneBitFieldType and
+// FastBitFieldType), you are using these functions wrong.  It is recommended that any host which
+// must exist in memory (like a wrapper host_t) always be passed by reference.
+
+template <SaneBitFieldType field_t, std::size_t width, std::size_t start, std::integral host_t>
+constexpr field_t GetFixedBitField(const host_t host) noexcept
+{
+  if constexpr (std::is_signed_v<field_t>)
+    return static_cast<field_t>(ExtractBitsS<width, start>(host));
+  else
+    return static_cast<field_t>(ExtractBitsU<width, start>(host));
+}
+
+template <SaneBitFieldType field_t, std::size_t width, std::integral host_t>
+constexpr field_t GetLooseBitField(const std::size_t start, const host_t host) noexcept
+{
+  if constexpr (std::is_signed_v<field_t>)
+    return static_cast<field_t>(ExtractBitsS<width>(start, host));
+  else
+    return static_cast<field_t>(ExtractBitsU<width>(start, host));
+}
+
+template <SaneBitFieldType field_t, std::size_t width, std::size_t start, std::integral host_t>
+constexpr void SetFixedBitField(host_t& host, const field_t val) noexcept
+{
+  InsertBits<width, start>(host, val);
+}
+
+template <SaneBitFieldType field_t, std::size_t width, std::integral host_t>
+constexpr void SetLooseBitField(const std::size_t start, host_t& host, const field_t val) noexcept
+{
+  InsertBits<width>(start, host, val);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Bool or enumeration of underlying type bool field type overload (for optimization)
+
+template <FastBitFieldType field_t, std::size_t width, std::size_t start, std::integral host_t>
+constexpr field_t GetFixedBitField(const host_t& host) noexcept
+{
+  static_assert(width == 1, "Boolean fields should only be 1 bit wide");
+  return static_cast<field_t>(ExtractBit<start>(host));
+}
+
+template <FastBitFieldType field_t, std::size_t width, std::integral host_t>
+constexpr field_t GetLooseBitField(const std::size_t start, const host_t& host) noexcept
+{
+  static_assert(width == 1, "Boolean fields should only be 1 bit wide");
+  return static_cast<field_t>(ExtractBit(start, host));
+}
+
+template <FastBitFieldType field_t, std::size_t width, std::size_t start, std::integral host_t>
+constexpr void SetFixedBitField(host_t& host, const field_t val) noexcept
+{
+  static_assert(width == 1, "Boolean fields should only be 1 bit wide");
+  InsertBit<start>(host, static_cast<bool>(val));
+}
+
+template <FastBitFieldType field_t, std::size_t width, std::integral host_t>
+constexpr void SetLooseBitField(const std::size_t start, host_t& host, const field_t val) noexcept
+{
+  static_assert(width == 1, "Boolean fields should only be 1 bit wide");
+  InsertBit(start, host, static_cast<bool>(val));
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Float host type specialization
+
+static_assert(sizeof(float) == sizeof(std::uint32_t));
+
+template <IntegralOrEnum field_t, std::size_t width, std::size_t start>
+constexpr field_t GetFixedBitField(const float& host) noexcept
+{
+  const std::uint32_t hostbits = BitCast<std::uint32_t>(host);
+  return GetFixedBitField<field_t, width, start>(hostbits);
+}
+
+template <IntegralOrEnum field_t, std::size_t width>
+constexpr field_t GetLooseBitField(const std::size_t start, const float& host) noexcept
+{
+  const std::uint32_t hostbits = BitCast<std::uint32_t>(host);
+  return GetLooseBitField<field_t, width>(start, hostbits);
+}
+
+template <IntegralOrEnum field_t, std::size_t width, std::size_t start>
+constexpr void SetFixedBitField(float& host, const field_t val) noexcept
+{
+  std::uint32_t hostbits = BitCast<std::uint32_t>(host);
+  SetFixedBitField<field_t, width, start>(hostbits, val);
+  host = BitCast<float>(hostbits);
+}
+
+template <IntegralOrEnum field_t, std::size_t width>
+constexpr void SetLooseBitField(const std::size_t start, float& host, const field_t val) noexcept
+{
+  std::uint32_t hostbits = BitCast<std::uint32_t>(host);
+  SetLooseBitField<field_t, width>(start, hostbits, val);
+  host = BitCast<float>(hostbits);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Double host type specialization
+
+static_assert(sizeof(double) == sizeof(std::uint64_t));
+
+template <IntegralOrEnum field_t, std::size_t width, std::size_t start>
+constexpr field_t GetFixedBitField(const double& host) noexcept
+{
+  const std::uint64_t hostbits = BitCast<std::uint64_t>(host);
+  return GetFixedBitField<field_t, width, start>(hostbits);
+}
+
+template <IntegralOrEnum field_t, std::size_t width>
+constexpr field_t GetLooseBitField(const std::size_t start, const double& host) noexcept
+{
+  const std::uint64_t hostbits = BitCast<std::uint64_t>(host);
+  return GetLooseBitField<field_t, width>(start, hostbits);
+}
+
+template <IntegralOrEnum field_t, std::size_t width, std::size_t start>
+constexpr void SetFixedBitField(double& host, const field_t val) noexcept
+{
+  std::uint64_t hostbits = BitCast<std::uint64_t>(host);
+  SetFixedBitField<field_t, width, start>(hostbits, val);
+  host = BitCast<double>(hostbits);
+}
+
+template <IntegralOrEnum field_t, std::size_t width>
+constexpr void SetLooseBitField(const std::size_t start, double& host, const field_t val) noexcept
+{
+  std::uint64_t hostbits = BitCast<std::uint64_t>(host);
+  SetLooseBitField<field_t, width>(start, hostbits, val);
+  host = BitCast<double>(hostbits);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Forward declarations.  Con is short for const.  Mut is short for mutable.
+
+template <class field_t, std::size_t width, std::size_t start, class host_t>
+class MutFixedBitFieldView;
+template <class field_t, std::size_t width, std::size_t start, class host_t>
+class ConFixedBitFieldView;
+template <class field_t, std::size_t width, class host_t>
+class MutLooseBitFieldView;
+template <class field_t, std::size_t width, class host_t>
+class ConLooseBitFieldView;
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+class MutFixedBitFieldArrayView;
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t_>
+class ConFixedBitFieldArrayView;
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+class MutLooseBitFieldArrayView;
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t_>
+class ConLooseBitFieldArrayView;
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+class MutFixedBitFieldArrayViewIterator;
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+class ConFixedBitFieldArrayViewIterator;
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+class MutLooseBitFieldArrayViewIterator;
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+class ConLooseBitFieldArrayViewIterator;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// BitFieldView concepts
+
+// This is the best solution I could come up with given the circumstances.  There exist tricks for
+// detecting if a type is an instantiation of a given template *without* abusing requires clauses,
+// but the ones I found do not work when value parameters are thrown into the mix.  In short,
+// template instances are just types, lacking a direct link back to the template it originated from.
+namespace detail
+{
+template <class field_t, std::size_t width, std::size_t start, class host_t>
+void PassMutFixedBitFieldView(MutFixedBitFieldView<field_t, width, start, host_t>);
+template <class field_t, std::size_t width, std::size_t start, class host_t>
+void PassConFixedBitFieldView(ConFixedBitFieldView<field_t, width, start, host_t>);
+
+template <class T>
+concept MF_BFView = requires(T t)
+{
+  PassMutFixedBitFieldView(t);
+};
+template <class T>
+concept CF_BFView = requires(T t)
+{
+  PassConFixedBitFieldView(t);
+};
+
+template <class field_t, std::size_t width, class host_t>
+void PassMutLooseBitFieldView(MutLooseBitFieldView<field_t, width, host_t>);
+template <class field_t, std::size_t width, class host_t>
+void PassConLooseBitFieldView(ConLooseBitFieldView<field_t, width, host_t>);
+
+template <class T>
+concept ML_BFView = requires(T t)
+{
+  PassMutLooseBitFieldView(t);
+};
+template <class T>
+concept CL_BFView = requires(T t)
+{
+  PassConLooseBitFieldView(t);
+};
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+void PassMutFixedBitFieldArrayView(MutFixedBitFieldArrayView<field_t, Ns, width, start, host_t>);
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+void PassConFixedBitFieldArrayView(ConFixedBitFieldArrayView<field_t, Ns, width, start, host_t>);
+
+template <class T>
+concept MF_BFArrayView = requires(T t)
+{
+  PassMutFixedBitFieldArrayView(t);
+};
+template <class T>
+concept CF_BFArrayView = requires(T t)
+{
+  PassConFixedBitFieldArrayView(t);
+};
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+void PassMutLooseBitFieldArrayView(MutLooseBitFieldArrayView<field_t, Ns, width, host_t>);
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+void PassConLooseBitFieldArrayView(ConLooseBitFieldArrayView<field_t, Ns, width, host_t>);
+
+template <class T>
+concept ML_BFArrayView = requires(T t)
+{
+  PassMutLooseBitFieldArrayView(t);
+};
+template <class T>
+concept CL_BFArrayView = requires(T t)
+{
+  PassConLooseBitFieldArrayView(t);
+};
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+void PassMutFixedBitFieldArrayViewIterator(
+    MutFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>);
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+void PassConFixedBitFieldArrayViewIterator(
+    ConFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>);
+
+template <class T>
+concept MF_BFArrayViewIter = requires(T t)
+{
+  PassMutFixedBitFieldArrayViewIterator(t);
+};
+template <class T>
+concept CF_BFArrayViewIter = requires(T t)
+{
+  PassConFixedBitFieldArrayViewIterator(t);
+};
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+void PassMutLooseBitFieldArrayViewIterator(
+    MutLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>);
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+void PassConLooseBitFieldArrayViewIterator(
+    ConLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>);
+
+template <class T>
+concept ML_BFArrayViewIter = requires(T t)
+{
+  PassMutLooseBitFieldArrayViewIterator(t);
+};
+template <class T>
+concept CL_BFArrayViewIter = requires(T t)
+{
+  PassConLooseBitFieldArrayViewIterator(t);
+};
+};  // namespace detail
+
+template <class T>
+concept FixedBitFieldView = detail::MF_BFView<T> || detail::CF_BFView<T>;
+template <class T>
+concept LooseBitFieldView = detail::ML_BFView<T> || detail::CL_BFView<T>;
+template <class T>
+concept BitFieldView = FixedBitFieldView<T> || LooseBitFieldView<T>;
+
+template <class T>
+concept FixedBitFieldArrayView = detail::MF_BFArrayView<T> || detail::CF_BFArrayView<T>;
+template <class T>
+concept LooseBitFieldArrayView = detail::ML_BFArrayView<T> || detail::CL_BFArrayView<T>;
+template <class T>
+concept BitFieldArrayView = FixedBitFieldArrayView<T> || LooseBitFieldArrayView<T>;
+
+template <class T>
+concept FixedBitFieldArrayViewIterator =
+    detail::MF_BFArrayViewIter<T> || detail::CF_BFArrayViewIter<T>;
+template <class T>
+concept LooseBitFieldArrayViewIterator =
+    detail::ML_BFArrayViewIter<T> || detail::CL_BFArrayViewIter<T>;
+template <class T>
+concept BitFieldArrayViewIterator =
+    FixedBitFieldArrayViewIterator<T> || LooseBitFieldArrayViewIterator<T>;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// BitFieldView type traits
+
+template <class T>
+struct IsFixedBitFieldView : std::bool_constant<FixedBitFieldView<T>>
+{
+};
+template <class T>
+struct IsLooseBitFieldView : std::bool_constant<LooseBitFieldView<T>>
+{
+};
+template <class T>
+struct IsBitFieldView : std::bool_constant<BitFieldView<T>>
+{
+};
+
+template <class T>
+struct IsFixedBitFieldArrayView : std::bool_constant<FixedBitFieldArrayView<T>>
+{
+};
+template <class T>
+struct IsLooseBitFieldArrayView : std::bool_constant<LooseBitFieldArrayView<T>>
+{
+};
+template <class T>
+struct IsBitFieldArrayView : std::bool_constant<BitFieldArrayView<T>>
+{
+};
+
+template <class T>
+struct IsFixedBitFieldArrayViewIterator : std::bool_constant<FixedBitFieldArrayViewIterator<T>>
+{
+};
+template <class T>
+struct IsLooseBitFieldArrayViewIterator : std::bool_constant<LooseBitFieldArrayViewIterator<T>>
+{
+};
+template <class T>
+struct IsBitFieldArrayViewIterator : std::bool_constant<BitFieldArrayViewIterator<T>>
+{
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Define some pre-C++17-esque helper functions.  We do this because, even as of C++17, one cannot
+// partially deduce template parameters for constructors.  For them, it's all or nothing.
+
+template <class field_t, std::size_t width, std::size_t start, class host_t>
+constexpr auto MakeBitFieldView(host_t& host)
+{
+  return MutFixedBitFieldView<field_t, width, start, host_t>(host);
+}
+template <class field_t, std::size_t width, std::size_t start, class host_t>
+constexpr auto MakeBitFieldView(const host_t& host)
+{
+  return ConFixedBitFieldView<field_t, width, start, host_t>(host);
+}
+template <class field_t, std::size_t width, class host_t>
+constexpr auto MakeBitFieldView(const std::size_t start, host_t& host)
+{
+  return MutLooseBitFieldView<field_t, width, host_t>(start, host);
+}
+template <class field_t, std::size_t width, class host_t>
+constexpr auto MakeBitFieldView(const std::size_t start, const host_t& host)
+{
+  return ConLooseBitFieldView<field_t, width, host_t>(start, host);
+}
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+constexpr auto MakeBitFieldArrayView(host_t& host)
+{
+  return MutFixedBitFieldArrayView<field_t, Ns, width, start, host_t>(host);
+}
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+constexpr auto MakeBitFieldArrayView(const host_t& host)
+{
+  return ConFixedBitFieldArrayView<field_t, Ns, width, start, host_t>(host);
+}
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+constexpr auto MakeBitFieldArrayView(const std::size_t start, host_t& host)
+{
+  return MutLooseBitFieldArrayView<field_t, Ns, width, host_t>(start, host);
+}
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+constexpr auto MakeBitFieldArrayView(const std::size_t start, const host_t& host)
+{
+  return ConLooseBitFieldArrayView<field_t, Ns, width, host_t>(start, host);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, std::size_t width, std::size_t start, class host_t>
+class MutFixedBitFieldView
+{
+protected:
+  host_t& host;
+
+public:
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return width; }
+  constexpr static std::size_t BitStart() { return start; }
+
+  MutFixedBitFieldView() = delete;
+  constexpr MutFixedBitFieldView(host_t& host_) : host(host_){};
+  constexpr MutFixedBitFieldView& operator=(const MutFixedBitFieldView& rhs)
+  {
+    return operator=(rhs.Get());
+  }
+
+  constexpr field_t Get() const { return GetFixedBitField<field_t, width, start>(host); }
+  constexpr void Set(const field_t val) { SetFixedBitField<field_t, width, start>(host, val); }
+
+  constexpr MutFixedBitFieldView& operator=(const field_t rhs)
+  {
+    Set(rhs);
+    return *this;
+  }
+  constexpr MutFixedBitFieldView& operator+=(const field_t rhs) { return operator=(Get() + rhs); }
+  constexpr MutFixedBitFieldView& operator-=(const field_t rhs) { return operator=(Get() - rhs); }
+  constexpr MutFixedBitFieldView& operator*=(const field_t rhs) { return operator=(Get() * rhs); }
+  constexpr MutFixedBitFieldView& operator/=(const field_t rhs) { return operator=(Get() / rhs); }
+  constexpr MutFixedBitFieldView& operator|=(const field_t rhs) { return operator=(Get() | rhs); }
+  constexpr MutFixedBitFieldView& operator&=(const field_t rhs) { return operator=(Get() & rhs); }
+  constexpr MutFixedBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
+
+  constexpr operator field_t() const { return Get(); }
+  constexpr explicit operator ScopedEnumUnderlyingElseVoid<field_t>() const
+  {
+    return std::to_underlying(Get());
+  }
+  constexpr bool operator!() const { return !static_cast<bool>(Get()); }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, std::size_t width, std::size_t start, class host_t>
+class ConFixedBitFieldView
+{
+protected:
+  const host_t& host;
+
+public:
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return width; }
+  constexpr static std::size_t BitStart() { return start; }
+
+  ConFixedBitFieldView() = delete;
+  constexpr ConFixedBitFieldView(const host_t& host_) : host(host_){};
+
+  constexpr field_t Get() const { return GetFixedBitField<field_t, width, start>(host); }
+
+  constexpr operator field_t() const { return Get(); }
+  constexpr explicit operator ScopedEnumUnderlyingElseVoid<field_t>() const
+  {
+    return std::to_underlying(Get());
+  }
+  constexpr bool operator!() const { return !static_cast<bool>(Get()); }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, std::size_t width, class host_t>
+class MutLooseBitFieldView
+{
+protected:
+  host_t& host;
+  const std::size_t start;
+
+public:
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return width; }
+  std::size_t BitStart() { return start; }
+
+  MutLooseBitFieldView() = delete;
+  constexpr MutLooseBitFieldView(const std::size_t start_, host_t& host_)
+      : host(host_), start(start_){};
+  constexpr MutLooseBitFieldView& operator=(const MutLooseBitFieldView& rhs)
+  {
+    return operator=(rhs.Get());
+  }
+
+  constexpr field_t Get() const { return GetLooseBitField<field_t, width>(start, host); }
+  constexpr void Set(const field_t val)
+  {
+    return SetLooseBitField<field_t, width>(start, host, val);
+  }
+
+  constexpr MutLooseBitFieldView& operator=(const field_t rhs)
+  {
+    Set(rhs);
+    return *this;
+  }
+  constexpr MutLooseBitFieldView& operator+=(const field_t rhs) { return operator=(Get() + rhs); }
+  constexpr MutLooseBitFieldView& operator-=(const field_t rhs) { return operator=(Get() - rhs); }
+  constexpr MutLooseBitFieldView& operator*=(const field_t rhs) { return operator=(Get() * rhs); }
+  constexpr MutLooseBitFieldView& operator/=(const field_t rhs) { return operator=(Get() / rhs); }
+  constexpr MutLooseBitFieldView& operator|=(const field_t rhs) { return operator=(Get() | rhs); }
+  constexpr MutLooseBitFieldView& operator&=(const field_t rhs) { return operator=(Get() & rhs); }
+  constexpr MutLooseBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
+
+  constexpr operator field_t() const { return Get(); }
+  constexpr explicit operator ScopedEnumUnderlyingElseVoid<field_t>() const
+  {
+    return std::to_underlying(Get());
+  }
+  constexpr bool operator!() const { return !static_cast<bool>(Get()); }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, std::size_t width, class host_t>
+class ConLooseBitFieldView
+{
+protected:
+  const host_t& host;
+  const std::size_t start;
+
+public:
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return width; }
+  std::size_t BitStart() { return start; }
+
+  ConLooseBitFieldView() = delete;
+  constexpr ConLooseBitFieldView(const std::size_t start_, const host_t& host_)
+      : host(host_), start(start_){};
+
+  constexpr field_t Get() const { return GetLooseBitField<field_t, width>(start, host); }
+
+  constexpr operator field_t() const { return Get(); }
+  constexpr explicit operator ScopedEnumUnderlyingElseVoid<field_t>() const
+  {
+    return std::to_underlying(Get());
+  }
+  constexpr bool operator!() const { return !static_cast<bool>(Get()); }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+class MutFixedBitFieldArrayView
+{
+protected:
+  host_t& host;
+
+public:
+  using reference =
+      std::conditional_t<(Ns::size() > 1),
+                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         MutLooseBitFieldView<field_t, width, host_t>>;
+  using const_reference =
+      std::conditional_t<(Ns::size() > 1),
+                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         ConLooseBitFieldView<field_t, width, host_t>>;
+  using iterator = MutFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>;
+  using const_iterator = ConFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>;
+
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return reference::BitWidth() * length(); }
+  constexpr static std::size_t BitStart() { return start; }
+
+  MutFixedBitFieldArrayView() = delete;
+  constexpr MutFixedBitFieldArrayView(host_t& host_) : host(host_)
+  {
+    // This static assertion is normally the job of the GetFixedBitField/SetFixedBitField functions.
+    // BitFieldArrayViews never run into those functions, though, which could lead to nasty bugs.
+    static_assert(!std::is_arithmetic_v<host_t> || start + BitWidth() <= BitSize<host_t>(),
+                  "BitFieldArrayView out of range");
+  }
+
+  constexpr reference at(const std::size_t idx)
+  {
+    DEBUG_ASSERT(idx < Ns::first);  // Index out of range
+    return reference(start + reference::BitWidth() * idx, host);
+  }
+  constexpr const_reference at(const std::size_t idx) const
+  {
+    DEBUG_ASSERT(idx < Ns::first);  // Index out of range
+    return const_reference(start + const_reference::BitWidth() * idx, host);
+  }
+  constexpr reference operator[](const std::size_t idx) { return at(idx); }
+  constexpr const_reference operator[](const std::size_t idx) const { return at(idx); }
+
+  constexpr iterator begin() { return iterator(host, 0); }
+  constexpr iterator end() { return iterator(host, length()); }
+  constexpr const_iterator begin() const { return const_iterator(host, 0); }
+  constexpr const_iterator end() const { return const_iterator(host, length()); }
+  constexpr const_iterator cbegin() const { return const_iterator(host, 0); }
+  constexpr const_iterator cend() const { return const_iterator(host, length()); }
+  constexpr static std::size_t size() { return Ns::first; }
+  constexpr static std::size_t length() { return Ns::first; }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+class ConFixedBitFieldArrayView
+{
+protected:
+  const host_t& host;
+
+public:
+  using const_reference =
+      std::conditional_t<(Ns::size() > 1),
+                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         ConLooseBitFieldView<field_t, width, host_t>>;
+  using const_iterator = ConFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>;
+
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return const_reference::BitWidth() * Ns::first; }
+  constexpr static std::size_t BitStart() { return start; }
+
+  ConFixedBitFieldArrayView() = delete;
+  constexpr ConFixedBitFieldArrayView(const host_t& host_) : host(host_)
+  {
+    // This static assertion is normally the job of the GetFixedBitField/SetFixedBitField functions.
+    // BitFieldArrayViews never run into those functions, though, which could lead to nasty bugs.
+    static_assert(!std::is_arithmetic_v<host_t> || start + BitWidth() <= BitSize<host_t>(),
+                  "BitFieldArrayView out of range");
+  }
+
+  constexpr const_reference at(const std::size_t idx) const
+  {
+    DEBUG_ASSERT(idx < Ns::first);  // Index out of range
+    return const_reference(start + const_reference::BitWidth() * idx, host);
+  }
+
+  constexpr const_reference operator[](const std::size_t idx) const { return at(idx); }
+
+  constexpr const_iterator begin() const { return const_iterator(host, 0); }
+  constexpr const_iterator end() const { return const_iterator(host, length()); }
+  constexpr const_iterator cbegin() const { return const_iterator(host, 0); }
+  constexpr const_iterator cend() const { return const_iterator(host, length()); }
+  constexpr static std::size_t size() { return Ns::first; }
+  constexpr static std::size_t length() { return Ns::first; }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+class MutLooseBitFieldArrayView
+{
+protected:
+  host_t& host;
+  const std::size_t start;
+
+public:
+  using reference =
+      std::conditional_t<(Ns::size() > 1),
+                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         MutLooseBitFieldView<field_t, width, host_t>>;
+  using const_reference =
+      std::conditional_t<(Ns::size() > 1),
+                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         ConLooseBitFieldView<field_t, width, host_t>>;
+  using iterator = MutLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>;
+  using const_iterator = ConLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>;
+
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return reference::BitWidth() * Ns::first; }
+  std::size_t BitStart() { return start; }
+
+  MutLooseBitFieldArrayView() = delete;
+  constexpr MutLooseBitFieldArrayView(const std::size_t start_, host_t& host_)
+      : host(host_), start(start_)
+  {
+  }
+
+  constexpr reference at(const std::size_t idx)
+  {
+    DEBUG_ASSERT(idx < Ns::first);  // Index out of range
+    return reference(start + reference::BitWidth() * idx, host);
+  }
+  constexpr const_reference at(const std::size_t idx) const
+  {
+    DEBUG_ASSERT(idx < Ns::first);  // Index out of range
+    return const_reference(start + const_reference::BitWidth() * idx, host);
+  }
+  constexpr reference operator[](const std::size_t idx) { return at(idx); }
+  constexpr const_reference operator[](const std::size_t idx) const { return at(idx); }
+
+  constexpr iterator begin() { return iterator(start, host, 0); }
+  constexpr iterator end() { return iterator(start, host, Ns::first); }
+  constexpr const_iterator begin() const { return const_iterator(start, host, 0); }
+  constexpr const_iterator end() const { return const_iterator(start, host, Ns::first); }
+  constexpr const_iterator cbegin() const { return const_iterator(start, host, 0); }
+  constexpr const_iterator cend() const { return const_iterator(start, host, Ns::first); }
+  constexpr static std::size_t size() { return Ns::first; }
+  constexpr static std::size_t length() { return Ns::first; }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+class ConLooseBitFieldArrayView
+{
+protected:
+  const host_t& host;
+  const std::size_t start;
+
+public:
+  using const_reference =
+      std::conditional_t<(Ns::size() > 1),
+                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         ConLooseBitFieldView<field_t, width, host_t>>;
+  using const_iterator = ConLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>;
+
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return const_reference::BitWidth() * Ns::first; }
+  std::size_t BitStart() { return start; }
+
+  ConLooseBitFieldArrayView() = delete;
+  constexpr ConLooseBitFieldArrayView(const std::size_t start_, const host_t& host_)
+      : host(host_), start(start_)
+  {
+  }
+
+  constexpr const_reference at(const std::size_t idx) const
+  {
+    DEBUG_ASSERT(idx < Ns::first);  // Index out of range
+    return const_reference(start + const_reference::BitWidth() * idx, host);
+  }
+  constexpr const_reference operator[](const std::size_t idx) const { return at(idx); }
+
+  constexpr const_iterator begin() const { return const_iterator(start, host, 0); }
+  constexpr const_iterator end() const { return const_iterator(start, host, Ns::first); }
+  constexpr const_iterator cbegin() const { return const_iterator(start, host, 0); }
+  constexpr const_iterator cend() const { return const_iterator(start, host, Ns::first); }
+  constexpr static std::size_t size() { return Ns::first; }
+  constexpr static std::size_t length() { return Ns::first; }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+class MutFixedBitFieldArrayViewIterator
+{
+protected:
+  host_t& host;
+  std::size_t idx;
+
+public:
+  using iterator_category = std::output_iterator_tag;
+  using value_type = field_t;
+  using difference_type = ptrdiff_t;
+  using pointer = void;
+  using reference =
+      std::conditional_t<(Ns::size() > 1),
+                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         MutLooseBitFieldView<field_t, width, host_t>>;
+
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return reference::BitWidth(); }
+  constexpr static std::size_t BitStart() { return start; }
+
+  MutFixedBitFieldArrayViewIterator(host_t& host_, const std::size_t idx_) : host(host_), idx(idx_)
+  {
+  }
+
+  // Required by std::input_or_output_iterator
+  constexpr MutFixedBitFieldArrayViewIterator() = default;
+  // Copy constructor and assignment operators, required by LegacyIterator
+  constexpr MutFixedBitFieldArrayViewIterator(const MutFixedBitFieldArrayViewIterator&) = default;
+  MutFixedBitFieldArrayViewIterator& operator=(const MutFixedBitFieldArrayViewIterator&) = default;
+  // Move constructor and assignment operators, explicitly defined for completeness
+  constexpr MutFixedBitFieldArrayViewIterator(MutFixedBitFieldArrayViewIterator&&) = default;
+  MutFixedBitFieldArrayViewIterator& operator=(MutFixedBitFieldArrayViewIterator&&) = default;
+
+  MutFixedBitFieldArrayViewIterator& operator++()
+  {
+    ++idx;
+    return *this;
+  }
+  MutFixedBitFieldArrayViewIterator operator++(int)
+  {
+    MutFixedBitFieldArrayViewIterator other{*this};
+    ++*this;
+    return other;
+  }
+  constexpr reference operator*() const
+  {
+    return reference(start + reference::BitWidth() * idx, host);
+  }
+  constexpr bool operator==(const MutFixedBitFieldArrayViewIterator& other) const
+  {
+    return idx == other.idx;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, std::size_t start,
+          class host_t>
+class ConFixedBitFieldArrayViewIterator
+{
+protected:
+  const host_t& host;
+  std::size_t idx;
+
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = field_t;
+  using difference_type = ptrdiff_t;
+  using pointer = void;
+  using reference =
+      std::conditional_t<(Ns::size() > 1),
+                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         ConLooseBitFieldView<field_t, width, host_t>>;
+
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return reference::BitWidth(); }
+  constexpr static std::size_t BitStart() { return start; }
+
+  ConFixedBitFieldArrayViewIterator(const host_t& host_, const std::size_t idx_)
+      : host(host_), idx(idx_)
+  {
+  }
+
+  // Required by std::input_or_output_iterator
+  constexpr ConFixedBitFieldArrayViewIterator() = default;
+  // Copy constructor and assignment operators, required by LegacyIterator
+  constexpr ConFixedBitFieldArrayViewIterator(const ConFixedBitFieldArrayViewIterator&) = default;
+  ConFixedBitFieldArrayViewIterator& operator=(const ConFixedBitFieldArrayViewIterator&) = default;
+  // Move constructor and assignment operators, explicitly defined for completeness
+  constexpr ConFixedBitFieldArrayViewIterator(ConFixedBitFieldArrayViewIterator&&) = default;
+  ConFixedBitFieldArrayViewIterator& operator=(ConFixedBitFieldArrayViewIterator&&) = default;
+
+  ConFixedBitFieldArrayViewIterator& operator++()
+  {
+    ++idx;
+    return *this;
+  }
+  ConFixedBitFieldArrayViewIterator operator++(int)
+  {
+    ConFixedBitFieldArrayViewIterator other(*this);
+    ++*this;
+    return other;
+  }
+  constexpr reference operator*() const
+  {
+    return reference(start + reference::BitWidth() * idx, host);
+  }
+  constexpr bool operator==(const ConFixedBitFieldArrayViewIterator other) const
+  {
+    return idx == other.idx;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+class MutLooseBitFieldArrayViewIterator
+{
+protected:
+  host_t& host;
+  std::size_t idx;
+  const std::size_t start;
+
+public:
+  using iterator_category = std::output_iterator_tag;
+  using value_type = field_t;
+  using difference_type = ptrdiff_t;
+  using pointer = void;
+  using reference =
+      std::conditional_t<(Ns::size() > 1),
+                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         MutLooseBitFieldView<field_t, width, host_t>>;
+
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return reference::BitWidth(); }
+  std::size_t BitStart() { return start; }
+
+  MutLooseBitFieldArrayViewIterator(const std::size_t start_, host_t& host_, const std::size_t idx_)
+      : host(host_), idx(idx_), start(start_)
+  {
+  }
+
+  // Required by std::input_or_output_iterator
+  constexpr MutLooseBitFieldArrayViewIterator() = default;
+  // Copy constructor and assignment operators, required by LegacyIterator
+  constexpr MutLooseBitFieldArrayViewIterator(const MutLooseBitFieldArrayViewIterator&) = default;
+  MutLooseBitFieldArrayViewIterator& operator=(const MutLooseBitFieldArrayViewIterator&) = default;
+  // Move constructor and assignment operators, explicitly defined for completeness
+  constexpr MutLooseBitFieldArrayViewIterator(MutLooseBitFieldArrayViewIterator&&) = default;
+  MutLooseBitFieldArrayViewIterator& operator=(MutLooseBitFieldArrayViewIterator&&) = default;
+
+  MutLooseBitFieldArrayViewIterator& operator++()
+  {
+    ++idx;
+    return *this;
+  }
+  MutLooseBitFieldArrayViewIterator operator++(int)
+  {
+    MutLooseBitFieldArrayViewIterator other(*this);
+    ++*this;
+    return other;
+  }
+  constexpr reference operator*() const
+  {
+    return reference(start + reference::BitWidth() * idx, host);
+  }
+  constexpr bool operator==(const MutLooseBitFieldArrayViewIterator& other) const
+  {
+    return idx == other.idx;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class field_t, AnyConstantPack<std::size_t> Ns, std::size_t width, class host_t>
+class ConLooseBitFieldArrayViewIterator
+{
+protected:
+  const host_t& host;
+  std::size_t idx;
+  const std::size_t start;
+
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = field_t;
+  using difference_type = ptrdiff_t;
+  using pointer = void;
+  using reference =
+      std::conditional_t<(Ns::size() > 1),
+                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
+                         ConLooseBitFieldView<field_t, width, host_t>>;
+
+  using HostType = host_t;
+  using FieldType = field_t;
+  constexpr static std::size_t BitWidth() { return reference::BitWidth(); }
+  std::size_t BitStart() { return start; }
+
+  ConLooseBitFieldArrayViewIterator(const std::size_t start_, const host_t& host_,
+                                    const std::size_t idx_)
+      : host(host_), idx(idx_), start(start_)
+  {
+  }
+
+  // Required by std::input_or_output_iterator
+  constexpr ConLooseBitFieldArrayViewIterator() = default;
+  // Copy constructor and assignment operators, required by LegacyIterator
+  constexpr ConLooseBitFieldArrayViewIterator(const ConLooseBitFieldArrayViewIterator&) = default;
+  ConLooseBitFieldArrayViewIterator& operator=(const ConLooseBitFieldArrayViewIterator&) = default;
+  // Move constructor and assignment operators, explicitly defined for completeness
+  constexpr ConLooseBitFieldArrayViewIterator(ConLooseBitFieldArrayViewIterator&&) = default;
+  ConLooseBitFieldArrayViewIterator& operator=(ConLooseBitFieldArrayViewIterator&&) = default;
+
+  ConLooseBitFieldArrayViewIterator& operator++()
+  {
+    ++idx;
+    return *this;
+  }
+  ConLooseBitFieldArrayViewIterator operator++(int)
+  {
+    ConLooseBitFieldArrayViewIterator other(*this);
+    ++*this;
+    return other;
+  }
+  constexpr reference operator*() const
+  {
+    return reference(start + reference::BitWidth() * idx, host);
+  }
+  constexpr bool operator==(const ConLooseBitFieldArrayViewIterator other) const
+  {
+    return idx == other.idx;
+  }
+};
+};  // namespace Common
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Easily create BitFieldView(Array) methods in a class which target a given host member.
+//
+// class Example
+// {
+//   u32 hex_a;
+//   u32 hex_b;
+//   u32 hex_c;
+//
+//   BFVIEW_IN(hex_a, u32, 3, 3, arbitrary_field)
+//   BFVIEW_IN(hex_b, u32, 2, 5, arbitrary_field_array, 9)      // 1-dimensional array
+//   BFVIEW_IN(hex_c, u32, 2, 5, arbitrary_field_matrix, 3, 3)  // 2-dimensional array
+// };
+
+#define BFVIEW_IN(host, field_t, width, start, name, ...)                                          \
+  constexpr auto name()                                                                            \
+  {                                                                                                \
+    return ::Common::MakeBitField##__VA_OPT__(                                                     \
+        Array)##View<field_t, __VA_OPT__(::Common::IndexPack<__VA_ARGS__>, ) width, start>(host);  \
+  }                                                                                                \
+  constexpr auto name() const                                                                      \
+  {                                                                                                \
+    return ::Common::MakeBitField##__VA_OPT__(                                                     \
+        Array)##View<field_t, __VA_OPT__(::Common::IndexPack<__VA_ARGS__>, ) width, start>(host);  \
+  }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Automagically ascertain the storage of a single-member class via a structured binding.
+//
+// class Example
+// {
+//   u32 hex;
+//
+//   BFVIEW(u32, 3, 3, arbitrary_field)
+//   BFVIEW(u32, 2, 5, arbitrary_field_array, 9)      // 1-dimensional array
+//   BFVIEW(u32, 2, 5, arbitrary_field_matrix, 3, 3)  // 2-dimensional array
+// };
+
+#define BFVIEW(field_t, width, start, name, ...)                                                   \
+  constexpr auto name()                                                                            \
+  {                                                                                                \
+    auto& [host] = *this;                                                                          \
+    return ::Common::MakeBitField##__VA_OPT__(                                                     \
+        Array)##View<field_t, __VA_OPT__(::Common::IndexPack<__VA_ARGS__>, ) width, start>(host);  \
+  }                                                                                                \
+  constexpr auto name() const                                                                      \
+  {                                                                                                \
+    auto& [host] = *this;                                                                          \
+    return ::Common::MakeBitField##__VA_OPT__(                                                     \
+        Array)##View<field_t, __VA_OPT__(::Common::IndexPack<__VA_ARGS__>, ) width, start>(host);  \
+  }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Custom fmt::formatter specializations
+
+#include <fmt/format.h>
+
+template <Common::BitFieldView T>
+struct fmt::formatter<T>
+{
+  fmt::formatter<typename T::FieldType> m_formatter;
+  constexpr auto parse(format_parse_context& ctx) { return m_formatter.parse(ctx); }
+  template <typename FormatContext>
+  auto format(const T& ref, FormatContext& ctx) const
+  {
+    return m_formatter.format(ref.Get(), ctx);
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/Core/Common/BitFieldView.h
+++ b/Source/Core/Common/BitFieldView.h
@@ -165,34 +165,22 @@ constexpr void SetLooseBitField(const std::size_t start, double& host, const fie
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-// Forward declarations.  Con is short for const.  Mut is short for mutable.
+// Forward declarations.
 
 template <class field_t, std::size_t width, std::size_t start, class host_t>
 class MutFixedBitFieldView;
-template <class field_t, std::size_t width, std::size_t start, class host_t>
-class ConFixedBitFieldView;
 template <class field_t, std::size_t width, class host_t>
 class MutLooseBitFieldView;
-template <class field_t, std::size_t width, class host_t>
-class ConLooseBitFieldView;
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class MutFixedBitFieldArrayView;
-template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t_>
-class ConFixedBitFieldArrayView;
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class MutLooseBitFieldArrayView;
-template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t_>
-class ConLooseBitFieldArrayView;
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class MutFixedBitFieldArrayViewIterator;
-template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-class ConFixedBitFieldArrayViewIterator;
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class MutLooseBitFieldArrayViewIterator;
-template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-class ConLooseBitFieldArrayViewIterator;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // BitFieldView concepts
@@ -205,125 +193,77 @@ namespace detail
 {
 template <class field_t, std::size_t width, std::size_t start, class host_t>
 void PassMutFixedBitFieldView(MutFixedBitFieldView<field_t, width, start, host_t>);
-template <class field_t, std::size_t width, std::size_t start, class host_t>
-void PassConFixedBitFieldView(ConFixedBitFieldView<field_t, width, start, host_t>);
-
 template <class T>
 concept MF_BFView = requires(T t)
 {
   PassMutFixedBitFieldView(t);
 };
-template <class T>
-concept CF_BFView = requires(T t)
-{
-  PassConFixedBitFieldView(t);
-};
 
 template <class field_t, std::size_t width, class host_t>
 void PassMutLooseBitFieldView(MutLooseBitFieldView<field_t, width, host_t>);
-template <class field_t, std::size_t width, class host_t>
-void PassConLooseBitFieldView(ConLooseBitFieldView<field_t, width, host_t>);
 
 template <class T>
 concept ML_BFView = requires(T t)
 {
   PassMutLooseBitFieldView(t);
 };
-template <class T>
-concept CL_BFView = requires(T t)
-{
-  PassConLooseBitFieldView(t);
-};
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 void PassMutFixedBitFieldArrayView(MutFixedBitFieldArrayView<field_t, Ns, width, start, host_t>);
-template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-void PassConFixedBitFieldArrayView(ConFixedBitFieldArrayView<field_t, Ns, width, start, host_t>);
-
 template <class T>
 concept MF_BFArrayView = requires(T t)
 {
   PassMutFixedBitFieldArrayView(t);
 };
-template <class T>
-concept CF_BFArrayView = requires(T t)
-{
-  PassConFixedBitFieldArrayView(t);
-};
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 void PassMutLooseBitFieldArrayView(MutLooseBitFieldArrayView<field_t, Ns, width, host_t>);
-template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-void PassConLooseBitFieldArrayView(ConLooseBitFieldArrayView<field_t, Ns, width, host_t>);
 
 template <class T>
 concept ML_BFArrayView = requires(T t)
 {
   PassMutLooseBitFieldArrayView(t);
 };
-template <class T>
-concept CL_BFArrayView = requires(T t)
-{
-  PassConLooseBitFieldArrayView(t);
-};
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 void PassMutFixedBitFieldArrayViewIterator(
     MutFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>);
-template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-void PassConFixedBitFieldArrayViewIterator(
-    ConFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>);
 
 template <class T>
 concept MF_BFArrayViewIter = requires(T t)
 {
   PassMutFixedBitFieldArrayViewIterator(t);
 };
-template <class T>
-concept CF_BFArrayViewIter = requires(T t)
-{
-  PassConFixedBitFieldArrayViewIterator(t);
-};
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 void PassMutLooseBitFieldArrayViewIterator(
     MutLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>);
-template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-void PassConLooseBitFieldArrayViewIterator(
-    ConLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>);
 
 template <class T>
 concept ML_BFArrayViewIter = requires(T t)
 {
   PassMutLooseBitFieldArrayViewIterator(t);
 };
-template <class T>
-concept CL_BFArrayViewIter = requires(T t)
-{
-  PassConLooseBitFieldArrayViewIterator(t);
-};
 };  // namespace detail
 
 template <class T>
-concept FixedBitFieldView = detail::MF_BFView<T> || detail::CF_BFView<T>;
+concept FixedBitFieldView = detail::MF_BFView<T>;
 template <class T>
-concept LooseBitFieldView = detail::ML_BFView<T> || detail::CL_BFView<T>;
+concept LooseBitFieldView = detail::ML_BFView<T>;
 template <class T>
 concept BitFieldView = FixedBitFieldView<T> || LooseBitFieldView<T>;
 
 template <class T>
-concept FixedBitFieldArrayView = detail::MF_BFArrayView<T> || detail::CF_BFArrayView<T>;
+concept FixedBitFieldArrayView = detail::MF_BFArrayView<T>;
 template <class T>
-concept LooseBitFieldArrayView = detail::ML_BFArrayView<T> || detail::CL_BFArrayView<T>;
+concept LooseBitFieldArrayView = detail::ML_BFArrayView<T>;
 template <class T>
 concept BitFieldArrayView = FixedBitFieldArrayView<T> || LooseBitFieldArrayView<T>;
 
 template <class T>
-concept FixedBitFieldArrayViewIterator =
-    detail::MF_BFArrayViewIter<T> || detail::CF_BFArrayViewIter<T>;
+concept FixedBitFieldArrayViewIterator = detail::MF_BFArrayViewIter<T>;
 template <class T>
-concept LooseBitFieldArrayViewIterator =
-    detail::ML_BFArrayViewIter<T> || detail::CL_BFArrayViewIter<T>;
+concept LooseBitFieldArrayViewIterator = detail::ML_BFArrayViewIter<T>;
 template <class T>
 concept BitFieldArrayViewIterator =
     FixedBitFieldArrayViewIterator<T> || LooseBitFieldArrayViewIterator<T>;
@@ -382,7 +322,7 @@ constexpr auto MakeBitFieldView(host_t& host)
 template <class field_t, std::size_t width, std::size_t start, class host_t>
 constexpr auto MakeBitFieldView(const host_t& host)
 {
-  return ConFixedBitFieldView<field_t, width, start, host_t>(host);
+  return MutFixedBitFieldView<field_t, width, start, const host_t>(host);
 }
 template <class field_t, std::size_t width, class host_t>
 constexpr auto MakeBitFieldView(const std::size_t start, host_t& host)
@@ -392,7 +332,7 @@ constexpr auto MakeBitFieldView(const std::size_t start, host_t& host)
 template <class field_t, std::size_t width, class host_t>
 constexpr auto MakeBitFieldView(const std::size_t start, const host_t& host)
 {
-  return ConLooseBitFieldView<field_t, width, host_t>(start, host);
+  return MutLooseBitFieldView<field_t, width, const host_t>(start, host);
 }
 
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
@@ -403,7 +343,7 @@ constexpr auto MakeBitFieldArrayView(host_t& host)
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 constexpr auto MakeBitFieldArrayView(const host_t& host)
 {
-  return ConFixedBitFieldArrayView<field_t, Ns, width, start, host_t>(host);
+  return MutFixedBitFieldArrayView<field_t, Ns, width, start, const host_t>(host);
 }
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 constexpr auto MakeBitFieldArrayView(const std::size_t start, host_t& host)
@@ -413,7 +353,7 @@ constexpr auto MakeBitFieldArrayView(const std::size_t start, host_t& host)
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 constexpr auto MakeBitFieldArrayView(const std::size_t start, const host_t& host)
 {
-  return ConLooseBitFieldArrayView<field_t, Ns, width, host_t>(start, host);
+  return MutLooseBitFieldArrayView<field_t, Ns, width, const host_t>(start, host);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -452,41 +392,6 @@ public:
   constexpr MutFixedBitFieldView& operator|=(const field_t rhs) { return operator=(Get() | rhs); }
   constexpr MutFixedBitFieldView& operator&=(const field_t rhs) { return operator=(Get() & rhs); }
   constexpr MutFixedBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
-
-  constexpr operator field_t() const { return Get(); }
-  /// This code enables implicit casts to unscoped enums, but also somehow clashes with Qt, which
-  /// globally deletes many non-typesafe operations for QFlags with Q_DECLARE_OPERATORS_FOR_FLAGS.
-  // template <class T> requires(std::is_enum_v<T> && !std::is_scoped_enum_v<T>)
-  // constexpr operator T() const
-  // {
-  //   return static_cast<T>(Get());  // Surprisingly required static_cast
-  // }
-  template <class T>
-  constexpr explicit operator T() const
-  {
-    return static_cast<T>(Get());  // Test your luck.
-  }
-  constexpr bool operator!() const { return !static_cast<bool>(Get()); }
-};
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-template <class field_t, std::size_t width, std::size_t start, class host_t>
-class ConFixedBitFieldView final
-{
-protected:
-  const host_t& host;
-
-public:
-  using HostType = host_t;
-  using FieldType = field_t;
-  constexpr static std::size_t BitWidth() { return width; }
-  constexpr static std::size_t BitStart() { return start; }
-
-  ConFixedBitFieldView() = delete;
-  constexpr ConFixedBitFieldView(const host_t& host_) : host(host_){};
-
-  constexpr field_t Get() const { return GetFixedBitField<field_t, width, start>(host); }
 
   constexpr operator field_t() const { return Get(); }
   /// This code enables implicit casts to unscoped enums, but also somehow clashes with Qt, which
@@ -564,43 +469,6 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, std::size_t width, class host_t>
-class ConLooseBitFieldView final
-{
-protected:
-  const host_t& host;
-  const std::size_t start;
-
-public:
-  using HostType = host_t;
-  using FieldType = field_t;
-  constexpr static std::size_t BitWidth() { return width; }
-  std::size_t BitStart() { return start; }
-
-  ConLooseBitFieldView() = delete;
-  constexpr ConLooseBitFieldView(const std::size_t start_, const host_t& host_)
-      : host(host_), start(start_){};
-
-  constexpr field_t Get() const { return GetLooseBitField<field_t, width>(start, host); }
-
-  constexpr operator field_t() const { return Get(); }
-  /// This code enables implicit casts to unscoped enums, but also somehow clashes with Qt, which
-  /// globally deletes many non-typesafe operations for QFlags with Q_DECLARE_OPERATORS_FOR_FLAGS.
-  // template <class T> requires(std::is_enum_v<T> && !std::is_scoped_enum_v<T>)
-  // constexpr operator T() const
-  // {
-  //   return static_cast<T>(Get());  // Surprisingly required static_cast
-  // }
-  template <class T>
-  constexpr explicit operator T() const
-  {
-    return static_cast<T>(Get());  // Test your luck.
-  }
-  constexpr bool operator!() const { return !static_cast<bool>(Get()); }
-};
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
 template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
 class MutFixedBitFieldArrayView final
 {
@@ -614,10 +482,10 @@ public:
                          MutLooseBitFieldView<field_t, width, host_t>>;
   using const_reference =
       std::conditional_t<(Ns::size() > 1),
-                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         ConLooseBitFieldView<field_t, width, host_t>>;
+                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, const host_t>,
+                         MutLooseBitFieldView<field_t, width, const host_t>>;
   using iterator = MutFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>;
-  using const_iterator = ConFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>;
+  using const_iterator = MutFixedBitFieldArrayViewIterator<field_t, Ns, width, start, const host_t>;
 
   using HostType = host_t;
   using FieldType = field_t;
@@ -658,51 +526,6 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-class ConFixedBitFieldArrayView final
-{
-protected:
-  const host_t& host;
-
-public:
-  using const_reference =
-      std::conditional_t<(Ns::size() > 1),
-                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         ConLooseBitFieldView<field_t, width, host_t>>;
-  using const_iterator = ConFixedBitFieldArrayViewIterator<field_t, Ns, width, start, host_t>;
-
-  using HostType = host_t;
-  using FieldType = field_t;
-  constexpr static std::size_t BitWidth() { return const_reference::BitWidth() * Ns::first; }
-  constexpr static std::size_t BitStart() { return start; }
-
-  ConFixedBitFieldArrayView() = delete;
-  constexpr ConFixedBitFieldArrayView(const host_t& host_) : host(host_)
-  {
-    // This static assertion is normally the job of the GetFixedBitField/SetFixedBitField functions.
-    // BitFieldArrayViews never run into those functions, though, which could lead to nasty bugs.
-    static_assert(!std::is_arithmetic_v<host_t> || start + BitWidth() <= BitSize<host_t>(),
-                  "BitFieldArrayView out of range");
-  }
-
-  constexpr const_reference at(const std::size_t idx) const
-  {
-    DEBUG_ASSERT(idx < Ns::first);  // Index out of range
-    return const_reference(start + const_reference::BitWidth() * idx, host);
-  }
-
-  constexpr const_reference operator[](const std::size_t idx) const { return at(idx); }
-
-  constexpr const_iterator begin() const { return const_iterator(host, 0); }
-  constexpr const_iterator end() const { return const_iterator(host, length()); }
-  constexpr const_iterator cbegin() const { return const_iterator(host, 0); }
-  constexpr const_iterator cend() const { return const_iterator(host, length()); }
-  constexpr static std::size_t size() { return Ns::first; }
-  constexpr static std::size_t length() { return Ns::first; }
-};
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class MutLooseBitFieldArrayView final
 {
@@ -717,10 +540,10 @@ public:
                          MutLooseBitFieldView<field_t, width, host_t>>;
   using const_reference =
       std::conditional_t<(Ns::size() > 1),
-                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         ConLooseBitFieldView<field_t, width, host_t>>;
+                         MutLooseBitFieldArrayView<field_t, typename Ns::peel, width, const host_t>,
+                         MutLooseBitFieldView<field_t, width, const host_t>>;
   using iterator = MutLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>;
-  using const_iterator = ConLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>;
+  using const_iterator = MutLooseBitFieldArrayViewIterator<field_t, Ns, width, const host_t>;
 
   using HostType = host_t;
   using FieldType = field_t;
@@ -748,48 +571,6 @@ public:
 
   constexpr iterator begin() { return iterator(start, host, 0); }
   constexpr iterator end() { return iterator(start, host, Ns::first); }
-  constexpr const_iterator begin() const { return const_iterator(start, host, 0); }
-  constexpr const_iterator end() const { return const_iterator(start, host, Ns::first); }
-  constexpr const_iterator cbegin() const { return const_iterator(start, host, 0); }
-  constexpr const_iterator cend() const { return const_iterator(start, host, Ns::first); }
-  constexpr static std::size_t size() { return Ns::first; }
-  constexpr static std::size_t length() { return Ns::first; }
-};
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-class ConLooseBitFieldArrayView final
-{
-protected:
-  const host_t& host;
-  const std::size_t start;
-
-public:
-  using const_reference =
-      std::conditional_t<(Ns::size() > 1),
-                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         ConLooseBitFieldView<field_t, width, host_t>>;
-  using const_iterator = ConLooseBitFieldArrayViewIterator<field_t, Ns, width, host_t>;
-
-  using HostType = host_t;
-  using FieldType = field_t;
-  constexpr static std::size_t BitWidth() { return const_reference::BitWidth() * Ns::first; }
-  std::size_t BitStart() { return start; }
-
-  ConLooseBitFieldArrayView() = delete;
-  constexpr ConLooseBitFieldArrayView(const std::size_t start_, const host_t& host_)
-      : host(host_), start(start_)
-  {
-  }
-
-  constexpr const_reference at(const std::size_t idx) const
-  {
-    DEBUG_ASSERT(idx < Ns::first);  // Index out of range
-    return const_reference(start + const_reference::BitWidth() * idx, host);
-  }
-  constexpr const_reference operator[](const std::size_t idx) const { return at(idx); }
-
   constexpr const_iterator begin() const { return const_iterator(start, host, 0); }
   constexpr const_iterator end() const { return const_iterator(start, host, Ns::first); }
   constexpr const_iterator cbegin() const { return const_iterator(start, host, 0); }
@@ -858,65 +639,6 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <class field_t, AnyIndexPack Ns, std::size_t width, std::size_t start, class host_t>
-class ConFixedBitFieldArrayViewIterator final
-{
-protected:
-  const host_t& host;
-  std::size_t idx;
-
-public:
-  using iterator_category = std::input_iterator_tag;
-  using value_type = field_t;
-  using difference_type = ptrdiff_t;
-  using pointer = void;
-  using reference =
-      std::conditional_t<(Ns::size() > 1),
-                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         ConLooseBitFieldView<field_t, width, host_t>>;
-
-  using HostType = host_t;
-  using FieldType = field_t;
-  constexpr static std::size_t BitWidth() { return reference::BitWidth(); }
-  constexpr static std::size_t BitStart() { return start; }
-
-  ConFixedBitFieldArrayViewIterator(const host_t& host_, const std::size_t idx_)
-      : host(host_), idx(idx_)
-  {
-  }
-
-  // Required by std::input_or_output_iterator
-  constexpr ConFixedBitFieldArrayViewIterator() = default;
-  // Copy constructor and assignment operators, required by LegacyIterator
-  constexpr ConFixedBitFieldArrayViewIterator(const ConFixedBitFieldArrayViewIterator&) = default;
-  ConFixedBitFieldArrayViewIterator& operator=(const ConFixedBitFieldArrayViewIterator&) = default;
-  // Move constructor and assignment operators, explicitly defined for completeness
-  constexpr ConFixedBitFieldArrayViewIterator(ConFixedBitFieldArrayViewIterator&&) = default;
-  ConFixedBitFieldArrayViewIterator& operator=(ConFixedBitFieldArrayViewIterator&&) = default;
-
-  ConFixedBitFieldArrayViewIterator& operator++()
-  {
-    ++idx;
-    return *this;
-  }
-  ConFixedBitFieldArrayViewIterator operator++(int)
-  {
-    ConFixedBitFieldArrayViewIterator other(*this);
-    ++*this;
-    return other;
-  }
-  constexpr reference operator*() const
-  {
-    return reference(start + reference::BitWidth() * idx, host);
-  }
-  constexpr bool operator==(const ConFixedBitFieldArrayViewIterator other) const
-  {
-    return idx == other.idx;
-  }
-};
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
 template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
 class MutLooseBitFieldArrayViewIterator final
 {
@@ -970,67 +692,6 @@ public:
     return reference(start + reference::BitWidth() * idx, host);
   }
   constexpr bool operator==(const MutLooseBitFieldArrayViewIterator& other) const
-  {
-    return idx == other.idx;
-  }
-};
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-template <class field_t, AnyIndexPack Ns, std::size_t width, class host_t>
-class ConLooseBitFieldArrayViewIterator final
-{
-protected:
-  const host_t& host;
-  std::size_t idx;
-  const std::size_t start;
-
-public:
-  using iterator_category = std::input_iterator_tag;
-  using value_type = field_t;
-  using difference_type = ptrdiff_t;
-  using pointer = void;
-  using reference =
-      std::conditional_t<(Ns::size() > 1),
-                         ConLooseBitFieldArrayView<field_t, typename Ns::peel, width, host_t>,
-                         ConLooseBitFieldView<field_t, width, host_t>>;
-
-  using HostType = host_t;
-  using FieldType = field_t;
-  constexpr static std::size_t BitWidth() { return reference::BitWidth(); }
-  std::size_t BitStart() { return start; }
-
-  ConLooseBitFieldArrayViewIterator(const std::size_t start_, const host_t& host_,
-                                    const std::size_t idx_)
-      : host(host_), idx(idx_), start(start_)
-  {
-  }
-
-  // Required by std::input_or_output_iterator
-  constexpr ConLooseBitFieldArrayViewIterator() = default;
-  // Copy constructor and assignment operators, required by LegacyIterator
-  constexpr ConLooseBitFieldArrayViewIterator(const ConLooseBitFieldArrayViewIterator&) = default;
-  ConLooseBitFieldArrayViewIterator& operator=(const ConLooseBitFieldArrayViewIterator&) = default;
-  // Move constructor and assignment operators, explicitly defined for completeness
-  constexpr ConLooseBitFieldArrayViewIterator(ConLooseBitFieldArrayViewIterator&&) = default;
-  ConLooseBitFieldArrayViewIterator& operator=(ConLooseBitFieldArrayViewIterator&&) = default;
-
-  ConLooseBitFieldArrayViewIterator& operator++()
-  {
-    ++idx;
-    return *this;
-  }
-  ConLooseBitFieldArrayViewIterator operator++(int)
-  {
-    ConLooseBitFieldArrayViewIterator other(*this);
-    ++*this;
-    return other;
-  }
-  constexpr reference operator*() const
-  {
-    return reference(start + reference::BitWidth() * idx, host);
-  }
-  constexpr bool operator==(const ConLooseBitFieldArrayViewIterator other) const
   {
     return idx == other.idx;
   }

--- a/Source/Core/Common/BitFieldView.h
+++ b/Source/Core/Common/BitFieldView.h
@@ -464,11 +464,13 @@ public:
   constexpr MutFixedBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
 
   constexpr operator field_t() const { return Get(); }
-  template <UnscopedEnum T>     // This only compiles because it is constrained, otherwise you
-  constexpr operator T() const  // would see the error "conversion function cannot be redeclared"
-  {
-    return static_cast<T>(Get());  // Surprisingly required static_cast
-  }
+  /// This code enables implicit casts to unscoped enums, but also somehow clashes with Qt, which
+  /// globally deletes many non-typesafe operations for QFlags with Q_DECLARE_OPERATORS_FOR_FLAGS.
+  // template <class T> requires(std::is_enum_v<T> && !std::is_scoped_enum_v<T>)
+  // constexpr operator T() const
+  // {
+  //   return static_cast<T>(Get());  // Surprisingly required static_cast
+  // }
   template <class T>
   constexpr explicit operator T() const
   {
@@ -497,11 +499,13 @@ public:
   constexpr field_t Get() const { return GetFixedBitField<field_t, width, start>(host); }
 
   constexpr operator field_t() const { return Get(); }
-  template <UnscopedEnum T>     // This only compiles because it is constrained, otherwise you
-  constexpr operator T() const  // would see the error "conversion function cannot be redeclared"
-  {
-    return static_cast<T>(Get());  // Surprisingly required static_cast
-  }
+  /// This code enables implicit casts to unscoped enums, but also somehow clashes with Qt, which
+  /// globally deletes many non-typesafe operations for QFlags with Q_DECLARE_OPERATORS_FOR_FLAGS.
+  // template <class T> requires(std::is_enum_v<T> && !std::is_scoped_enum_v<T>)
+  // constexpr operator T() const
+  // {
+  //   return static_cast<T>(Get());  // Surprisingly required static_cast
+  // }
   template <class T>
   constexpr explicit operator T() const
   {
@@ -553,11 +557,13 @@ public:
   constexpr MutLooseBitFieldView& operator^=(const field_t rhs) { return operator=(Get() ^ rhs); }
 
   constexpr operator field_t() const { return Get(); }
-  template <UnscopedEnum T>     // This only compiles because it is constrained, otherwise you
-  constexpr operator T() const  // would see the error "conversion function cannot be redeclared"
-  {
-    return static_cast<T>(Get());  // Surprisingly required static_cast
-  }
+  /// This code enables implicit casts to unscoped enums, but also somehow clashes with Qt, which
+  /// globally deletes many non-typesafe operations for QFlags with Q_DECLARE_OPERATORS_FOR_FLAGS.
+  // template <class T> requires(std::is_enum_v<T> && !std::is_scoped_enum_v<T>)
+  // constexpr operator T() const
+  // {
+  //   return static_cast<T>(Get());  // Surprisingly required static_cast
+  // }
   template <class T>
   constexpr explicit operator T() const
   {
@@ -588,11 +594,13 @@ public:
   constexpr field_t Get() const { return GetLooseBitField<field_t, width>(start, host); }
 
   constexpr operator field_t() const { return Get(); }
-  template <UnscopedEnum T>     // This only compiles because it is constrained, otherwise you
-  constexpr operator T() const  // would see the error "conversion function cannot be redeclared"
-  {
-    return static_cast<T>(Get());  // Surprisingly required static_cast
-  }
+  /// This code enables implicit casts to unscoped enums, but also somehow clashes with Qt, which
+  /// globally deletes many non-typesafe operations for QFlags with Q_DECLARE_OPERATORS_FOR_FLAGS.
+  // template <class T> requires(std::is_enum_v<T> && !std::is_scoped_enum_v<T>)
+  // constexpr operator T() const
+  // {
+  //   return static_cast<T>(Get());  // Surprisingly required static_cast
+  // }
   template <class T>
   constexpr explicit operator T() const
   {

--- a/Source/Core/Common/BitSet.h
+++ b/Source/Core/Common/BitSet.h
@@ -4,8 +4,8 @@
 
 #include <cstddef>
 #include <initializer_list>
-#include <type_traits>
 #include "Common/CommonTypes.h"
+#include "Common/Future/CppLibConcepts.h"
 
 #ifdef _WIN32
 
@@ -103,11 +103,9 @@ inline int LeastSignificantSetBit(u64 val)
 //   operation.)
 // - Counting set bits using .Count() - see comment on that method.
 
-template <typename IntTy>
+template <std::unsigned_integral IntTy>
 class BitSet
 {
-  static_assert(!std::is_signed<IntTy>::value, "BitSet should not be used with signed types");
-
 public:
   // A reference to a particular bit, returned from operator[].
   class Ref

--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -11,6 +11,9 @@
 #include <initializer_list>
 #include <type_traits>
 
+#include "Common/Concepts.h"
+#include "Common/Future/CppLibConcepts.h"
+
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif
@@ -161,11 +164,10 @@ constexpr T RotateRight(const T value, size_t amount) noexcept
 ///
 /// @return A bool indicating whether the mask is valid.
 ///
-template <typename T>
+template <std::unsigned_integral T>
 constexpr bool IsValidLowMask(const T mask) noexcept
 {
-  static_assert(std::is_integral<T>::value, "Mask must be an integral type.");
-  static_assert(std::is_unsigned<T>::value, "Signed masks can introduce hard to find bugs.");
+  // Signed masks can introduce hard to find bugs.
 
   // Can be efficiently determined without looping or bit counting. It's the counterpart
   // to https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
@@ -191,38 +193,28 @@ constexpr bool IsValidLowMask(const T mask) noexcept
 /// @pre Both To and From types must be the same size
 /// @pre Both To and From types must satisfy the TriviallyCopyable concept.
 ///
-template <typename To, typename From>
+template <TriviallyCopyable To, TriviallyCopyable From>
 inline To BitCast(const From& source) noexcept
 {
   static_assert(sizeof(From) == sizeof(To),
                 "BitCast source and destination types must be equal in size.");
-  static_assert(std::is_trivially_copyable<From>(),
-                "BitCast source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<To>(),
-                "BitCast destination type must be trivially copyable.");
 
   alignas(To) std::byte storage[sizeof(To)];
   std::memcpy(&storage, &source, sizeof(storage));
   return reinterpret_cast<To&>(storage);
 }
 
-template <typename T, typename PtrType>
+template <TriviallyCopyable T, TriviallyCopyable PtrType>
 class BitCastPtrType
 {
 public:
-  static_assert(std::is_trivially_copyable<PtrType>(),
-                "BitCastPtr source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastPtr destination type must be trivially copyable.");
-
   explicit BitCastPtrType(PtrType* ptr) : m_ptr(ptr) {}
 
   // Enable operator= only for pointers to non-const data
-  template <typename S>
-  inline typename std::enable_if<std::is_same<S, T>() && !std::is_const<PtrType>()>::type
-  operator=(const S& source)
+  inline BitCastPtrType& operator=(const T& source) requires NotConst<PtrType>
   {
     std::memcpy(m_ptr, &source, sizeof(source));
+    return *this;
   }
 
   inline operator T() const
@@ -247,46 +239,34 @@ inline auto BitCastPtr(PtrType* ptr) noexcept -> BitCastPtrType<T, PtrType>
 }
 
 // Similar to BitCastPtr, but specifically for aliasing structs to arrays.
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
+template <typename ArrayType, TriviallyCopyable T,
+          TriviallyCopyable Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
 inline auto BitCastToArray(const T& obj) noexcept -> Container
 {
   static_assert(sizeof(T) % sizeof(ArrayType) == 0,
                 "Size of array type must be a factor of size of source type.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastToArray source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastToArray array type must be trivially copyable.");
 
   Container result;
   std::memcpy(result.data(), &obj, sizeof(T));
   return result;
 }
 
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
+template <typename ArrayType, TriviallyCopyable T,
+          TriviallyCopyable Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
 inline void BitCastFromArray(const Container& array, T& obj) noexcept
 {
   static_assert(sizeof(T) % sizeof(ArrayType) == 0,
                 "Size of array type must be a factor of size of destination type.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastFromArray array type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastFromArray destination type must be trivially copyable.");
 
   std::memcpy(&obj, array.data(), sizeof(T));
 }
 
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
+template <typename ArrayType, TriviallyCopyable T,
+          TriviallyCopyable Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
 inline auto BitCastFromArray(const Container& array) noexcept -> T
 {
   static_assert(sizeof(T) % sizeof(ArrayType) == 0,
                 "Size of array type must be a factor of size of destination type.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastFromArray array type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastFromArray destination type must be trivially copyable.");
 
   T obj;
   std::memcpy(&obj, array.data(), sizeof(T));
@@ -352,11 +332,9 @@ public:
 
 // Left-shift a value and set new LSBs to that of the supplied LSB.
 // Converts a value from a N-bit range to an (N+X)-bit range. e.g. 0x101 -> 0x10111
-template <typename T>
+template <std::unsigned_integral T>
 T ExpandValue(T value, size_t left_shift_amount)
 {
-  static_assert(std::is_unsigned<T>(), "ExpandValue is only sane on unsigned types.");
-
   return (value << left_shift_amount) |
          (T(-ExtractBit<0>(value)) >> (BitSize<T>() - left_shift_amount));
 }

--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -1,5 +1,5 @@
-// Copyright 2017 Dolphin Emulator Project
-// SPDX-License-Identifier: GPL-2.0-or-later
+// 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: CC0-1.0
 
 #pragma once
 
@@ -11,6 +11,7 @@
 #include <initializer_list>
 #include <type_traits>
 
+#include "Common/Assert.h"
 #include "Common/Concepts.h"
 #include "Common/Future/CppLibConcepts.h"
 
@@ -34,80 +35,259 @@ constexpr size_t BitSize() noexcept
 }
 
 ///
-/// Extracts a bit from a value.
+/// Calculates a least-significant bit mask in four operations, assuming the width is never zero.
 ///
-/// @param  src The value to extract a bit from.
-/// @param  bit The bit to extract.
+/// @tparam T      The type of the bit mask.  Must satisfy std::integral.
+/// @param  width  The width of the bit mask.  Must not equal zero to avoid UB.
 ///
-/// @tparam T   The type of the value.
+/// @return A bit mask of the given width starting from the least-significant bit.
 ///
-/// @return The extracted bit.
-///
-template <typename T>
-constexpr T ExtractBit(const T src, const size_t bit) noexcept
+template <std::integral T>
+constexpr T CalcLowMaskFast(const size_t width) noexcept
 {
-  return (src >> bit) & static_cast<T>(1);
+  DEBUG_ASSERT(width > 0);              // width == 0 causes undefined behavior
+  DEBUG_ASSERT(width <= BitSize<T>());  // Bit width larger than BitSize<T>
+  constexpr std::make_unsigned_t<T> ones = ~std::make_unsigned_t<T>{0};
+  return static_cast<T>(ones >> (BitSize<T>() - width));
+}
+
+///
+/// Calculates a least-significant bit mask in six or seven operations.
+///
+/// @tparam T      The type of the bit mask.  Must satisfy std::integral.
+/// @param  width  The width of the bit mask.
+///
+/// @return A bit mask of the given width starting from the least-significant bit.
+///
+template <std::integral T>
+constexpr T CalcLowMaskSafe(const size_t width) noexcept
+{
+  if (width != 0)
+    return CalcLowMaskFast<T>(width);
+  else [[unlikely]]
+    return 0;
 }
 
 ///
 /// Extracts a bit from a value.
 ///
-/// @param  src The value to extract a bit from.
-///
-/// @tparam bit The bit to extract.
-/// @tparam T   The type of the value.
+/// @param  start  The bit to extract. Bit 0 is the least-significant bit.
+/// @param  host   The host value to extract the bit from. Must satisfy std::integral.
 ///
 /// @return The extracted bit.
 ///
-template <size_t bit, typename T>
-constexpr T ExtractBit(const T src) noexcept
+template <std::integral T>
+constexpr bool ExtractBit(const size_t start, const T host) noexcept
 {
-  static_assert(bit < BitSize<T>(), "Specified bit must be within T's bit width.");
-
-  return ExtractBit(src, bit);
+  DEBUG_ASSERT(start < BitSize<T>());  // Bit start out of range
+  return static_cast<bool>((host >> start) & T{1});
 }
 
 ///
-/// Extracts a range of bits from a value.
+/// Extracts a bit from a value.
 ///
-/// @param  src    The value to extract the bits from.
-/// @param  begin  The beginning of the bit range. This is inclusive.
-/// @param  end    The ending of the bit range. This is inclusive.
+/// @tparam start  The bit to extract. Bit 0 is the least-significant bit.
+/// @param  host   The host value to extract the bit from. Must satisfy std::integral.
 ///
-/// @tparam T      The type of the value.
-/// @tparam Result The returned result type. This is the unsigned analog
-///                of a signed type if a signed type is passed as T.
+/// @return The extracted bit.
+///
+template <size_t start, std::integral T>
+constexpr bool ExtractBit(const T host) noexcept
+{
+  static_assert(start < BitSize<T>(), "Bit start out of range");
+  return ExtractBit(start, host);
+}
+
+// TODO C++23: The x86 CPU extension "Bit Manipulation Instruction Set 1" provides unsigned bit
+// field extraction instructions which could theoretically be faster than the idiomatic way of doing
+// this. However, the only way to create specializations using BEXTR intrinsics while remaining
+// constexpr requires consteval if statements. Even then, BMI1 is from 2012-ish (SSE2 is Dolphin
+// Emulator's only hard-required x86 CPU extension atm), so these specializations would only really
+// be available to end-users using GCC/Clang who enable -march=native when compiling.
+// Bit Manipulation Instruction Set 2's PEXT/PDEP instructions also are worth looking at.
+
+///
+/// Extracts a zero-extended range of bits from a value.
+///
+/// @param  width  The width of the bit range in bits.
+/// @param  start  The beginning of the bit range. Bit 0 is the least-significant bit.
+/// @param  host   The host value to extract the bits from. Must satisfy std::integral.
 ///
 /// @return The extracted bits.
 ///
-template <typename T, typename Result = std::make_unsigned_t<T>>
-constexpr Result ExtractBits(const T src, const size_t begin, const size_t end) noexcept
+template <std::integral T>
+constexpr std::make_unsigned_t<T> ExtractBitsU(const size_t width, const size_t start,
+                                               const T host) noexcept
 {
-  return static_cast<Result>(((static_cast<Result>(src) << ((BitSize<T>() - 1) - end)) >>
-                              (BitSize<T>() - end + begin - 1)));
+  DEBUG_ASSERT(start + width <= BitSize<T>());  // Bitfield out of range
+  DEBUG_ASSERT(width > 0);                      // Bitfield is invalid (zero width)
+  const T mask = CalcLowMaskFast<T>(width);
+  return static_cast<std::make_unsigned_t<T>>((host >> start) & mask);
 }
 
 ///
-/// Extracts a range of bits from a value.
+/// Extracts a zero-extended range of bits from a value.
 ///
-/// @param  src    The value to extract the bits from.
-///
-/// @tparam begin  The beginning of the bit range. This is inclusive.
-/// @tparam end    The ending of the bit range. This is inclusive.
-/// @tparam T      The type of the value.
-/// @tparam Result The returned result type. This is the unsigned analog
-///                of a signed type if a signed type is passed as T.
+/// @tparam width  The width of the bit range in bits.
+/// @param  start  The beginning of the bit range. Bit 0 is the least-significant bit.
+/// @param  host   The host value to extract the bits from. Must satisfy std::integral.
 ///
 /// @return The extracted bits.
 ///
-template <size_t begin, size_t end, typename T, typename Result = std::make_unsigned_t<T>>
-constexpr Result ExtractBits(const T src) noexcept
+template <size_t width, std::integral T>
+constexpr std::make_unsigned_t<T> ExtractBitsU(const size_t start, const T host) noexcept
 {
-  static_assert(begin < end, "Beginning bit must be less than the ending bit.");
-  static_assert(begin < BitSize<T>(), "Beginning bit is larger than T's bit width.");
-  static_assert(end < BitSize<T>(), "Ending bit is larger than T's bit width.");
+  static_assert(width > 0, "Bitfield is invalid (zero width)");
+  return ExtractBitsU(width, start, host);
+}
 
-  return ExtractBits<T, Result>(src, begin, end);
+///
+/// Extracts a zero-extended range of bits from a value.
+///
+/// @tparam width  The width of the bit range in bits.
+/// @tparam start  The beginning of the bit range. Bit 0 is the least-significant bit.
+/// @param  host   The host value to extract the bits from. Must satisfy std::integral.
+///
+/// @return The extracted bits.
+///
+template <size_t width, size_t start, std::integral T>
+constexpr std::make_unsigned_t<T> ExtractBitsU(const T host) noexcept
+{
+  static_assert(start + width <= BitSize<T>(), "Bitfield out of range");
+  return ExtractBitsU<width>(start, host);
+}
+
+///
+/// Extracts a sign-extended range of bits from a value.
+///
+/// @param  width  The width of the bit range in bits.
+/// @param  start  The beginning of the bit range. Bit 0 is the least-significant bit.
+/// @param  host   The host value to extract the bits from. Must satisfy std::integral.
+///
+/// @return The extracted bits.
+///
+template <std::integral T>
+constexpr std::make_signed_t<T> ExtractBitsS(const size_t width, const size_t start,
+                                             const T host) noexcept
+{
+  // This idiom was both undefined and implementation-defined behavior up until C++20.
+  // https://en.cppreference.com/w/cpp/language/operator_arithmetic#Bitwise_shift_operators
+  DEBUG_ASSERT(start + width <= BitSize<T>());  // Bitfield out of range
+  DEBUG_ASSERT(width > 0);                      // Bitfield is invalid (zero width)
+  const size_t rshift = BitSize<T>() - width;
+  const size_t lshift = rshift - start;
+  return static_cast<std::make_signed_t<T>>(host << lshift) >> rshift;
+}
+
+///
+/// Extracts a sign-extended range of bits from a value.
+///
+/// @tparam width  The width of the bit range in bits.
+/// @param  start  The beginning of the bit range. Bit 0 is the least-significant bit.
+/// @param  host   The host value to extract the bits from. Must satisfy std::integral.
+///
+/// @return The extracted bits.
+///
+template <size_t width, std::integral T>
+constexpr std::make_signed_t<T> ExtractBitsS(const size_t start, const T host) noexcept
+{
+  static_assert(width > 0, "Bitfield is invalid (zero width)");
+  return ExtractBitsS(width, start, host);
+}
+
+///
+/// Extracts a sign-extended range of bits from a value.
+///
+/// @tparam width  The width of the bit range in bits.
+/// @tparam start  The beginning of the bit range. Bit 0 is the least-significant bit.
+/// @param  host   The host value to extract the bits from. Must satisfy std::integral.
+///
+/// @return The extracted bits.
+///
+template <size_t width, size_t start, std::integral T>
+constexpr std::make_signed_t<T> ExtractBitsS(const T host) noexcept
+{
+  static_assert(start + width <= BitSize<T>(), "Bitfield out of range");
+  return ExtractBitsS<width>(start, host);
+}
+
+///
+/// Inserts a bit into a value.
+///
+/// @param  start  The index of the bit. Bit 0 is the least-significant bit.
+/// @param  host   The host value to insert the bits into. Must satisfy std::integral.
+/// @param  val    The boolean value which is inserted into the host.
+///
+template <std::integral T>
+void InsertBit(size_t start, T& host, bool val) noexcept
+{
+  // Take advantage of the inherent bit-size of a C++ boolean to skip a mask.  This is a variant of
+  // https://graphics.stanford.edu/~seander/bithacks.html#ConditionalSetOrClearBitsWithoutBranching
+  DEBUG_ASSERT(start < BitSize<T>());  // Bit out of range
+  const T mask = (T{1} << start);
+  host = (host & ~mask) | (static_cast<T>(val) << start);
+}
+
+///
+/// Inserts a bit into a value.
+///
+/// @tparam start  The index of the bit. Bit 0 is the least-significant bit.
+/// @param  host   The host value to insert the bits into.  Must satisfy std::integral.
+/// @param  val    The boolean value which is inserted into the host.
+///
+template <size_t start, std::integral T>
+void InsertBit(T& host, bool val) noexcept
+{
+  static_assert(start < BitSize<T>(), "Bit out of range");
+  InsertBit(start, host, val);
+}
+
+///
+/// Inserts a range of bits into a value.
+///
+/// @param  width  The width of the bit range in bits.
+/// @param  start  The beginning of the bit range.  Bit 0 is the least-significant bit.
+/// @param  host   The host value to insert the field bits into.  Must satisfy std::integral.
+/// @param  val    The value which is inserted into the host.
+///
+template <std::integral T>
+constexpr void InsertBits(const size_t width, const size_t start, T& host, const auto val) noexcept
+{
+  // https://graphics.stanford.edu/~seander/bithacks.html#ConditionalSetOrClearBitsWithoutBranching
+  DEBUG_ASSERT(start + width <= BitSize<T>());  // BitField out of range
+  DEBUG_ASSERT(width > 0);                      // BitField is invalid (zero width)
+  const T mask = CalcLowMaskFast<T>(width) << start;
+  host = (host & ~mask) | ((static_cast<T>(val) << start) & mask);
+}
+
+///
+/// Inserts a range of bits into a value.
+///
+/// @tparam width  The width of the bit range in bits.
+/// @param  start  The beginning of the bit range.  Bit 0 is the least-significant bit.
+/// @param  host   The host value to insert the field bits into.  Must satisfy std::integral.
+/// @param  val    The value which is inserted into the host.
+///
+template <size_t width, std::integral T>
+constexpr void InsertBits(const size_t start, T& host, const auto val) noexcept
+{
+  static_assert(width > 0, "Bitfield is invalid (zero width)");
+  InsertBits(width, start, host, val);
+}
+
+///
+/// Inserts a range of bits into a value.
+///
+/// @tparam width  The width of the bit range in bits.
+/// @tparam start  The beginning of the bit range.  Bit 0 is the least-significant bit.
+/// @param  host   The host value to insert the field bits into.  Must satisfy std::integral.
+/// @param  val    The value which is inserted into the host.
+///
+template <size_t width, size_t start, std::integral T>
+constexpr void InsertBits(T& host, const auto val) noexcept
+{
+  static_assert(start + width <= BitSize<T>(), "Bitfield out of range");
+  InsertBits<width>(start, host, val);
 }
 
 ///
@@ -274,23 +454,6 @@ inline auto BitCastFromArray(const Container& array) noexcept -> T
 }
 
 template <typename T>
-void SetBit(T& value, size_t bit_number, bool bit_value)
-{
-  static_assert(std::is_unsigned<T>(), "SetBit is only sane on unsigned types.");
-
-  if (bit_value)
-    value |= (T{1} << bit_number);
-  else
-    value &= ~(T{1} << bit_number);
-}
-
-template <size_t bit_number, typename T>
-void SetBit(T& value, bool bit_value)
-{
-  SetBit(value, bit_number, bit_value);
-}
-
-template <typename T>
 class FlagBit
 {
 public:
@@ -336,7 +499,7 @@ template <std::unsigned_integral T>
 T ExpandValue(T value, size_t left_shift_amount)
 {
   return (value << left_shift_amount) |
-         (T(-ExtractBit<0>(value)) >> (BitSize<T>() - left_shift_amount));
+         (T(-static_cast<T>(ExtractBit<0>(value))) >> (BitSize<T>() - left_shift_amount));
 }
 
 template <typename T>

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(common
   CommonFuncs.h
   CommonPaths.h
   CommonTypes.h
+  Concepts.h
   Config/Config.cpp
   Config/Config.h
   Config/ConfigInfo.cpp
@@ -58,6 +59,7 @@ add_library(common
   FloatUtils.h
   FormatUtil.h
   FPURoundMode.h
+  Future/CppLibConcepts.h
   GekkoDisassembler.cpp
   GekkoDisassembler.h
   Hash.cpp

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(common
   Analytics.h
   Assert.h
   BitField.h
+  BitFieldView.h
   BitSet.h
   BitUtils.h
   BlockingLoop.h
@@ -25,6 +26,7 @@ add_library(common
   Config/Enums.h
   Config/Layer.cpp
   Config/Layer.h
+  ConstantPack.h
   CPUDetect.h
   Crypto/AES.cpp
   Crypto/AES.h
@@ -60,6 +62,8 @@ add_library(common
   FormatUtil.h
   FPURoundMode.h
   Future/CppLibConcepts.h
+  Future/CppLibIsScopedEnum.h
+  Future/CppLibToUnderlying.h
   GekkoDisassembler.cpp
   GekkoDisassembler.h
   Hash.cpp

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -21,7 +21,6 @@
 #include <optional>
 #include <set>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -29,6 +28,7 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/EnumMap.h"
 #include "Common/Flag.h"
 #include "Common/Inline.h"
@@ -195,13 +195,13 @@ public:
     DoArray(x.data(), static_cast<u32>(x.size()));
   }
 
-  template <typename T, typename std::enable_if_t<std::is_trivially_copyable_v<T>, int> = 0>
+  template <Common::TriviallyCopyable T>
   void DoArray(T* x, u32 count)
   {
     DoVoid(x, count * sizeof(T));
   }
 
-  template <typename T, typename std::enable_if_t<!std::is_trivially_copyable_v<T>, int> = 0>
+  template <Common::NotTriviallyCopyable T>
   void DoArray(T* x, u32 count)
   {
     for (u32 i = 0; i < count; ++i)
@@ -246,10 +246,9 @@ public:
       atomic.store(temp, std::memory_order_relaxed);
   }
 
-  template <typename T>
+  template <Common::TriviallyCopyable T>
   void Do(T& x)
   {
-    static_assert(std::is_trivially_copyable_v<T>, "Only sane for trivially copyable types");
     // Note:
     // Usually we can just use x = **ptr, etc.  However, this doesn't work
     // for unions containing BitFields (long story, stupid language rules)

--- a/Source/Core/Common/Concepts.h
+++ b/Source/Core/Common/Concepts.h
@@ -1,0 +1,68 @@
+// 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: CC0-1.0
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "Common/TypeUtils.h"
+
+#include "Common/Future/CppLibConcepts.h"
+
+namespace Common
+{
+template <class T>
+concept TriviallyCopyable = std::is_trivially_copyable<T>::value;
+
+template <class T>
+concept NotTriviallyCopyable = !TriviallyCopyable<T>;
+
+template <class T>
+concept Const = std::is_const<T>::value;
+
+template <class T>
+concept NotConst = !Const<T>;
+
+template <class T>
+concept Enumerated = std::is_enum<T>::value;
+
+template <class T>
+concept NotEnumerated = !Enumerated<T>;
+
+template <class T>
+concept Class = std::is_class<T>::value;
+
+template <class T>
+concept Union = std::is_union<T>::value;
+
+template <class T>
+concept Arithmetic = std::is_arithmetic<T>::value;
+
+template <class T>
+concept Pointer = std::is_pointer<T>::value;
+
+template <class T>
+concept Function = std::is_function<T>::value;
+
+template <class T>
+concept FunctionPointer = Function<std::remove_pointer_t<T>>;
+
+template <class T>
+concept IntegralOrEnum = std::integral<T> || Enumerated<T>;
+
+template <class T, class U>
+concept UnderlyingSameAs = std::same_as<std::underlying_type_t<T>, U>;
+
+template <class T, class U>
+concept SameAsOrUnderlyingSameAs = std::same_as<T, U> || UnderlyingSameAs<T, U>;
+
+template <size_t N, class... Ts>
+concept CountOfTypes = IsCountOfTypes<N, Ts...>::value;
+
+template <class T, class... Ts>
+concept ConvertibleFromAllOf = IsConvertibleFromAllOf<T, Ts...>::value;
+
+template <class T, class... Ts>
+concept SameAsAnyOf = IsSameAsAnyOf<T, Ts...>::value;
+};  // namespace Common

--- a/Source/Core/Common/Concepts.h
+++ b/Source/Core/Common/Concepts.h
@@ -31,6 +31,12 @@ template <class T>
 concept NotEnumerated = !Enumerated<T>;
 
 template <class T>
+concept ScopedEnum = std::is_scoped_enum<T>::value;
+
+template <class T>
+concept UnscopedEnum = Common::IsUnscopedEnum<T>::value;
+
+template <class T>
 concept Class = std::is_class<T>::value;
 
 template <class T>

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -10,17 +10,11 @@
 #include <utility>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Config/Enums.h"
 
 namespace Config
 {
-namespace detail
-{
-// std::underlying_type may only be used with enum types, so make sure T is an enum type first.
-template <typename T>
-using UnderlyingType = typename std::enable_if_t<std::is_enum<T>{}, std::underlying_type<T>>::type;
-}  // namespace detail
-
 struct Location
 {
   System system{};
@@ -55,12 +49,8 @@ public:
 
   // Make it easy to convert Info<Enum> into Info<UnderlyingType<Enum>>
   // so that enum settings can still easily work with code that doesn't care about the enum values.
-  template <typename Enum,
-            std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
-  Info(const Info<Enum>& other)
-  {
-    *this = other;
-  }
+  template <Common::Enumerated Enum>
+  requires Common::UnderlyingSameAs<Enum, T> Info(const Info<Enum>& other) { *this = other; }
 
   Info<T>& operator=(const Info<T>& other)
   {
@@ -81,9 +71,9 @@ public:
 
   // Make it easy to convert Info<Enum> into Info<UnderlyingType<Enum>>
   // so that enum settings can still easily work with code that doesn't care about the enum values.
-  template <typename Enum,
-            std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
-  Info<T>& operator=(const Info<Enum>& other)
+  template <Common::Enumerated Enum>
+  requires Common::UnderlyingSameAs<Enum, T> Info<T>
+  &operator=(const Info<Enum>& other)
   {
     m_location = other.GetLocation();
     m_default_value = static_cast<T>(other.GetDefaultValue());

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "Common/Concepts.h"
 #include "Common/Config/ConfigInfo.h"
 #include "Common/Config/Enums.h"
 #include "Common/StringUtil.h"
@@ -18,7 +19,7 @@ namespace Config
 {
 namespace detail
 {
-template <typename T, std::enable_if_t<!std::is_enum<T>::value>* = nullptr>
+template <Common::NotEnumerated T>
 std::optional<T> TryParse(const std::string& str_value)
 {
   T value;
@@ -27,7 +28,7 @@ std::optional<T> TryParse(const std::string& str_value)
   return value;
 }
 
-template <typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+template <Common::Enumerated T>
 std::optional<T> TryParse(const std::string& str_value)
 {
   const auto result = TryParse<std::underlying_type_t<T>>(str_value);

--- a/Source/Core/Common/ConstantPack.h
+++ b/Source/Core/Common/ConstantPack.h
@@ -4,10 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <utility>
 
 // ConstantPack allows one to recursively iterate through a std::integer_sequence
-// e.g. Common::ConstantPack<int, 1, 2, 3, 4>::peel::peel::first == 3
+// e.g. Common::ConstantPack<int, 23, 15, 73, 26, 64>::peel::peel::first == 73
+
+// ConstantPack can also be directly indexed.  Negative or out-of-bounds indicies are std::nullopt.
+// e.g. Common::ConstantPack<int, 23, 15, 73, 26, 64>::at<2>.value() == 73
 
 namespace Common
 {
@@ -16,6 +20,8 @@ struct ConstantPack : std::integer_sequence<T, vals...>
 {
   using value_type = T;
   using peel = ConstantPack<T, vals...>;
+  template <std::ptrdiff_t>
+  static constexpr auto at = std::nullopt;
 };
 
 template <typename T, T val, T... vals>
@@ -23,6 +29,9 @@ struct ConstantPack<T, val, vals...> : std::integer_sequence<T, val, vals...>
 {
   using value_type = T;
   using peel = ConstantPack<T, vals...>;
+  template <std::ptrdiff_t idx>
+  static constexpr auto at = (idx == 0) ? std::optional(first) : peel::template at<idx - 1>;
+
   static constexpr T first = val;
 };
 

--- a/Source/Core/Common/ConstantPack.h
+++ b/Source/Core/Common/ConstantPack.h
@@ -1,0 +1,43 @@
+// 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: CC0-1.0
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+// ConstantPack allows one to recursively iterate through a std::integer_sequence
+// e.g. Common::ConstantPack<int, 1, 2, 3, 4>::peel::peel::first == 3
+
+namespace Common
+{
+template <typename T, T... vals>
+struct ConstantPack : std::integer_sequence<T, vals...>
+{
+  using value_type = T;
+  using peel = ConstantPack<T, vals...>;
+};
+
+template <typename T, T val, T... vals>
+struct ConstantPack<T, val, vals...> : std::integer_sequence<T, val, vals...>
+{
+  using value_type = T;
+  using peel = ConstantPack<T, vals...>;
+  static constexpr T first = val;
+};
+
+template <std::size_t... vals>
+using IndexPack = ConstantPack<std::size_t, vals...>;
+
+namespace detail
+{
+template <typename T, T... vals>
+void PassConstantPack(ConstantPack<T, vals...>);
+}  // namespace detail
+
+template <class T, typename U = typename T::value_type>
+concept AnyConstantPack = requires(T t)
+{
+  detail::PassConstantPack<U>(t);
+};
+}  // namespace Common

--- a/Source/Core/Common/ConstantPack.h
+++ b/Source/Core/Common/ConstantPack.h
@@ -35,9 +35,19 @@ template <typename T, T... vals>
 void PassConstantPack(ConstantPack<T, vals...>);
 }  // namespace detail
 
-template <class T, typename U = typename T::value_type>
+template <class T>
 concept AnyConstantPack = requires(T t)
 {
-  detail::PassConstantPack<U>(t);
+  detail::PassConstantPack(t);
 };
+
+template <class T>
+concept AnyIndexPack = requires(T t)
+{
+  detail::PassConstantPack<std::size_t>(t);
+};
+
+// If you need to further constrain an AnyConstantPack to a certain type, use a requires clause:
+// requires std::same_as<typename T::value_type, TYPE>
+
 }  // namespace Common

--- a/Source/Core/Common/ConstantPack.h
+++ b/Source/Core/Common/ConstantPack.h
@@ -20,6 +20,7 @@ struct ConstantPack : std::integer_sequence<T, vals...>
 {
   using value_type = T;
   using peel = ConstantPack<T, vals...>;
+
   template <std::ptrdiff_t>
   static constexpr auto at = std::nullopt;
 };
@@ -29,10 +30,10 @@ struct ConstantPack<T, val, vals...> : std::integer_sequence<T, val, vals...>
 {
   using value_type = T;
   using peel = ConstantPack<T, vals...>;
+  static constexpr T first = val;
+
   template <std::ptrdiff_t idx>
   static constexpr auto at = (idx == 0) ? std::optional(first) : peel::template at<idx - 1>;
-
-  static constexpr T first = val;
 };
 
 template <std::size_t... vals>

--- a/Source/Core/Common/Crypto/SHA1.h
+++ b/Source/Core/Common/Crypto/SHA1.h
@@ -7,11 +7,11 @@
 #include <limits>
 #include <memory>
 #include <string_view>
-#include <type_traits>
 #include <vector>
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 
 namespace Common::SHA1
 {
@@ -32,10 +32,9 @@ std::unique_ptr<Context> CreateContext();
 
 Digest CalculateDigest(const u8* msg, size_t len);
 
-template <typename T>
+template <TriviallyCopyable T>
 inline Digest CalculateDigest(const std::vector<T>& msg)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   ASSERT(std::numeric_limits<size_t>::max() / sizeof(T) >= msg.size());
   return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), sizeof(T) * msg.size());
 }
@@ -45,10 +44,9 @@ inline Digest CalculateDigest(const std::string_view& msg)
   return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), msg.size());
 }
 
-template <typename T, size_t Size>
+template <TriviallyCopyable T, size_t Size>
 inline Digest CalculateDigest(const std::array<T, Size>& msg)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), sizeof(msg));
 }
 }  // namespace Common::SHA1

--- a/Source/Core/Common/EnumMap.h
+++ b/Source/Core/Common/EnumMap.h
@@ -66,14 +66,14 @@ public:
   // conversion would work (but since BitFieldViews are used for game-generated data, we need
   // to be careful about bounds-checking)
   template <IntegralOrEnum field_t, std::size_t width, std::size_t start, typename host_t>
-  constexpr const V& operator[](const MutFixedBitFieldView<field_t, width, start, host_t> key) const
+  constexpr const V& operator[](const FixedBitFieldView<field_t, width, start, host_t> key) const
   {
     static_assert(size_t{1} << width == s_size,
                   "Unsafe indexing into EnumMap (may go out of bounds)");
     return m_array[static_cast<std::size_t>(key.Get())];
   }
   template <IntegralOrEnum field_t, std::size_t width, std::size_t start, typename host_t>
-  constexpr V& operator[](const MutFixedBitFieldView<field_t, width, start, host_t> key)
+  constexpr V& operator[](const FixedBitFieldView<field_t, width, start, host_t> key)
   {
     static_assert(size_t{1} << T::BitWidth() == s_size,
                   "Unsafe indexing into EnumMap (may go out of bounds)");

--- a/Source/Core/Common/EnumMap.h
+++ b/Source/Core/Common/EnumMap.h
@@ -65,15 +65,15 @@ public:
   // This only exists to perform the safety check; without them, A BitFieldView's implicit
   // conversion would work (but since BitFieldViews are used for game-generated data, we need
   // to be careful about bounds-checking)
-  template <BitFieldView T>
-  constexpr const V& operator[](T key) const
+  template <IntegralOrEnum field_t, std::size_t width, std::size_t start, typename host_t>
+  constexpr const V& operator[](const MutFixedBitFieldView<field_t, width, start, host_t> key) const
   {
-    static_assert(size_t{1} << T::BitWidth() == s_size,
+    static_assert(size_t{1} << width == s_size,
                   "Unsafe indexing into EnumMap (may go out of bounds)");
     return m_array[static_cast<std::size_t>(key.Get())];
   }
-  template <BitFieldView T>
-  constexpr V& operator[](T key)
+  template <IntegralOrEnum field_t, std::size_t width, std::size_t start, typename host_t>
+  constexpr V& operator[](const MutFixedBitFieldView<field_t, width, start, host_t> key)
   {
     static_assert(size_t{1} << T::BitWidth() == s_size,
                   "Unsafe indexing into EnumMap (may go out of bounds)");

--- a/Source/Core/Common/EnumMap.h
+++ b/Source/Core/Common/EnumMap.h
@@ -6,7 +6,7 @@
 #include <array>
 #include <type_traits>
 
-#include "Common/TypeUtils.h"
+#include "Common/Concepts.h"
 
 template <std::size_t position, std::size_t bits, typename T, typename StorageType>
 struct BitField;
@@ -36,11 +36,9 @@ public:
   constexpr EnumMap(EnumMap&& other) = default;
   constexpr EnumMap& operator=(EnumMap&& other) = default;
 
-  // Constructor that accepts exactly size Vs (enforcing that all must be specified).
-  template <typename... T, typename = std::enable_if_t<Common::IsNOf<V, s_size, T...>::value>>
-  constexpr EnumMap(T... values) : m_array{static_cast<V>(values)...}
-  {
-  }
+  template <typename... Ts>
+  requires CountOfTypes<s_size, Ts...> && ConvertibleFromAllOf<V, Ts...>
+  constexpr EnumMap(Ts... values) : m_array{static_cast<V>(values)...} {}
 
   constexpr const V& operator[](T key) const { return m_array[static_cast<std::size_t>(key)]; }
   constexpr V& operator[](T key) { return m_array[static_cast<std::size_t>(key)]; }

--- a/Source/Core/Common/EnumMap.h
+++ b/Source/Core/Common/EnumMap.h
@@ -65,15 +65,15 @@ public:
   // This only exists to perform the safety check; without them, A BitFieldView's implicit
   // conversion would work (but since BitFieldViews are used for game-generated data, we need
   // to be careful about bounds-checking)
-  template <IntegralOrEnum field_t, std::size_t width, std::size_t start, typename host_t>
-  constexpr const V& operator[](const FixedBitFieldView<field_t, width, start, host_t> key) const
+  template <AnyBitFieldView T>
+  constexpr const V& operator[](const T key) const
   {
-    static_assert(size_t{1} << width == s_size,
+    static_assert(size_t{1} << T::BitWidth() == s_size,
                   "Unsafe indexing into EnumMap (may go out of bounds)");
     return m_array[static_cast<std::size_t>(key.Get())];
   }
-  template <IntegralOrEnum field_t, std::size_t width, std::size_t start, typename host_t>
-  constexpr V& operator[](const FixedBitFieldView<field_t, width, start, host_t> key)
+  template <AnyBitFieldView T>
+  constexpr V& operator[](const T key)
   {
     static_assert(size_t{1} << T::BitWidth() == s_size,
                   "Unsafe indexing into EnumMap (may go out of bounds)");

--- a/Source/Core/Common/FormatUtil.h
+++ b/Source/Core/Common/FormatUtil.h
@@ -8,6 +8,13 @@
 
 namespace Common
 {
+template <class T>
+#if FMT_VERSION >= 90000
+concept FmtCompileString = fmt::detail::is_compile_string<T>::value;
+#else
+concept FmtCompileString = fmt::is_compile_string<T>::value;
+#endif
+
 constexpr std::size_t CountFmtReplacementFields(std::string_view s)
 {
   std::size_t count = 0;

--- a/Source/Core/Common/Future/CppLibConcepts.h
+++ b/Source/Core/Common/Future/CppLibConcepts.h
@@ -1,0 +1,40 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <version>
+
+// The purpose of "future" headers is to backport syntactic-sugar C++ Standard Library features to
+// compilers versions lacking said library features (e.g. Dolphin's buildbots).  Please replace
+// usage of this header with the C++ Standard Library equivalent as soon as is possible.
+
+#ifdef __cpp_lib_concepts
+#include <concepts>
+#else
+#include <type_traits>
+namespace std
+{
+// Technically inaccurate because we haven't defined *all* of the standard concepts
+#define __cpp_lib_concepts 202002L
+
+template <class T, class U>
+concept same_as = std::is_same_v<T, U> && std::is_same_v<U, T>;
+
+template <class T>
+concept integral = std::is_integral_v<T>;
+
+template <class T>
+concept signed_integral = integral<T> && std::is_signed_v<T>;
+
+template <class T>
+concept unsigned_integral = integral<T> && std::is_unsigned_v<T>;
+
+template <class T>
+concept floating_point = std::is_floating_point_v<T>;
+
+template <class Derived, class Base>
+concept derived_from = std::is_base_of_v<Base, Derived> &&
+    std::is_convertible_v<const volatile Derived*, const volatile Base*>;
+};  // namespace std
+#endif

--- a/Source/Core/Common/Future/CppLibIsScopedEnum.h
+++ b/Source/Core/Common/Future/CppLibIsScopedEnum.h
@@ -1,0 +1,47 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <type_traits>
+#include <version>
+
+// The purpose of "future" headers is to backport syntactic-sugar C++ Standard Library features to
+// compilers versions lacking said library features (e.g. Dolphin's buildbots).  Please replace
+// usage of this header with the C++ Standard Library equivalent as soon as is possible.
+
+#ifndef __cpp_lib_is_scoped_enum
+namespace std
+{
+#define __cpp_lib_is_scoped_enum 202011L
+
+namespace detail
+{
+template <class T>
+concept unscoped_enum = requires(T t, void (*f)(int))
+{
+  is_enum_v<T>;
+  f(t);
+};
+
+template <class T>
+concept complete_type = requires(T t)
+{
+  t = t;
+};
+}  // namespace detail
+
+template <class T>
+struct is_scoped_enum : false_type
+{
+};
+
+template <detail::complete_type T>
+struct is_scoped_enum<T> : bool_constant<!detail::unscoped_enum<std::remove_cv_t<T>>>
+{
+};
+
+template <class T>
+inline constexpr bool is_scoped_enum_v = is_scoped_enum<T>::value;
+}  // namespace std
+#endif

--- a/Source/Core/Common/Future/CppLibToUnderlying.h
+++ b/Source/Core/Common/Future/CppLibToUnderlying.h
@@ -1,0 +1,23 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+// The purpose of "future" headers is to backport syntactic-sugar C++ Standard Library features to
+// compilers versions lacking said library features (e.g. Dolphin's buildbots).  Please replace
+// usage of this header with the C++ Standard Library equivalent as soon as is possible.
+
+#ifndef __cpp_lib_to_underlying
+namespace std
+{
+#define __cpp_lib_to_underlying 202102L
+template <typename T>
+[[nodiscard]] constexpr std::underlying_type_t<T> to_underlying(T val) noexcept
+{
+  return static_cast<std::underlying_type_t<T>>(val);
+}
+}  // namespace std
+#endif

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -7,9 +7,9 @@
 #include <cstring>
 #include <memory>
 #include <string>
-#include <type_traits>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/IOFile.h"
 #include "Common/Version.h"
 
@@ -27,7 +27,7 @@
 // value_type[value_size]   value;
 //}
 
-template <typename K, typename V>
+template <Common::TriviallyCopyable K, typename V>
 class LinearDiskCacheReader
 {
 public:
@@ -46,17 +46,14 @@ public:
 // K and V are some POD type
 // K : the key type
 // V : value array type
-template <typename K, typename V>
+// Since we're reading/writing directly to the storage of K instances, K must be trivially copyable.
+template <Common::TriviallyCopyable K, typename V>
 class LinearDiskCache
 {
 public:
   // return number of read entries
   u32 OpenAndRead(const std::string& filename, LinearDiskCacheReader<K, V>& reader)
   {
-    // Since we're reading/writing directly to the storage of K instances,
-    // K must be trivially copyable.
-    static_assert(std::is_trivially_copyable<K>::value, "K must be a trivially copyable type");
-
     // close any currently opened file
     Close();
     m_num_entries = 0;

--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -91,7 +91,7 @@ static const char LOG_LEVEL_TO_CHAR[7] = "-NEWID";
 void GenericLogFmtImpl(LogLevel level, LogType type, const char* file, int line,
                        fmt::string_view format, const fmt::format_args& args);
 
-template <std::size_t NumFields, typename S, typename... Args>
+template <std::size_t NumFields, FmtCompileString S, typename... Args>
 void GenericLogFmt(LogLevel level, LogType type, const char* file, int line, const S& format,
                    const Args&... args)
 {

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -11,6 +11,7 @@
 
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+#include "Common/Future/CppLibConcepts.h"
 
 namespace MathUtil
 {
@@ -32,11 +33,9 @@ constexpr auto Lerp(const T& x, const T& y, const F& a) -> decltype(x + (y - x) 
 
 // Casts the specified value to a Dest. The value will be clamped to fit in the destination type.
 // Warning: The result of SaturatingCast(NaN) is undefined.
-template <typename Dest, typename T>
+template <std::integral Dest, typename T>
 constexpr Dest SaturatingCast(T value)
 {
-  static_assert(std::is_integral<Dest>());
-
   [[maybe_unused]] constexpr Dest lo = std::numeric_limits<Dest>::lowest();
   constexpr Dest hi = std::numeric_limits<Dest>::max();
 

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -34,23 +34,18 @@ void RegisterStringTranslator(StringTranslator translator);
 bool MsgAlertFmtImpl(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                      int line, fmt::string_view format, const fmt::format_args& args);
 
-template <std::size_t NumFields, typename S, typename... Args>
+template <std::size_t NumFields, FmtCompileString S, typename... Args>
 bool MsgAlertFmt(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                  int line, const S& format, const Args&... args)
 {
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
-  static_assert(fmt::detail::is_compile_string<S>::value);
-#else
-  static_assert(fmt::is_compile_string<S>::value);
-#endif
   return MsgAlertFmtImpl(yes_no, style, log_type, file, line, format,
                          fmt::make_format_args(args...));
 }
 
-template <std::size_t NumFields, bool has_non_positional_args, typename S, typename... Args>
+template <std::size_t NumFields, bool has_non_positional_args, FmtCompileString S, typename... Args>
 bool MsgAlertFmtT(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                   int line, const S& format, fmt::string_view translated_format,
                   const Args&... args)
@@ -60,11 +55,6 @@ bool MsgAlertFmtT(bool yes_no, MsgType style, Common::Log::LogType log_type, con
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
-  static_assert(fmt::detail::is_compile_string<S>::value);
-#else
-  static_assert(fmt::is_compile_string<S>::value);
-#endif
   auto arg_list = fmt::make_format_args(args...);
   return MsgAlertFmtImpl(yes_no, style, log_type, file, line, translated_format, arg_list);
 }

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 
 #include "Common/BitUtils.h"
+#include "Common/Concepts.h"
 #include "Common/Random.h"
 #include "Common/StringUtil.h"
 
@@ -315,10 +316,9 @@ u16 ComputeTCPNetworkChecksum(const IPAddress& from, const IPAddress& to, const 
   return htons(static_cast<u16>(tcp_checksum));
 }
 
-template <typename Container, typename T>
+template <typename Container, Common::TriviallyCopyable T>
 static inline void InsertObj(Container* container, const T& obj)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   const u8* const ptr = reinterpret_cast<const u8*>(&obj);
   container->insert(container->end(), ptr, ptr + sizeof(obj));
 }

--- a/Source/Core/Common/Random.h
+++ b/Source/Core/Common/Random.h
@@ -5,9 +5,9 @@
 
 #include <cstddef>
 #include <memory>
-#include <type_traits>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 
 namespace Common::Random
 {
@@ -21,10 +21,9 @@ public:
 
   void Generate(void* buffer, std::size_t size);
 
-  template <typename T>
+  template <Arithmetic T>
   T GenerateValue()
   {
-    static_assert(std::is_arithmetic<T>(), "T must be an arithmetic type in GenerateValue.");
     T value;
     Generate(&value, sizeof(value));
     return value;
@@ -39,10 +38,9 @@ private:
 void Generate(void* buffer, std::size_t size);
 
 /// Generates a random value of arithmetic type `T`
-template <typename T>
+template <Arithmetic T>
 T GenerateValue()
 {
-  static_assert(std::is_arithmetic<T>(), "T must be an arithmetic type in GenerateValue.");
   T value;
   Generate(&value, sizeof(value));
   return value;

--- a/Source/Core/Common/SFMLHelper.h
+++ b/Source/Core/Common/SFMLHelper.h
@@ -8,13 +8,14 @@
 #include <SFML/Network/Packet.hpp>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Swap.h"
 
 sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u16>& data);
 sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u32>& data);
 sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u64>& data);
 
-template <typename Enum, std::enable_if_t<std::is_enum_v<Enum>>* = nullptr>
+template <Common::Enumerated Enum>
 sf::Packet& operator<<(sf::Packet& packet, Enum e)
 {
   using Underlying = std::underlying_type_t<Enum>;
@@ -22,7 +23,7 @@ sf::Packet& operator<<(sf::Packet& packet, Enum e)
   return packet;
 }
 
-template <typename Enum, std::enable_if_t<std::is_enum_v<Enum>>* = nullptr>
+template <Common::Enumerated Enum>
 sf::Packet& operator>>(sf::Packet& packet, Enum& e)
 {
   using Underlying = std::underlying_type_t<Enum>;

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -15,6 +15,8 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
+#include "Common/Future/CppLibConcepts.h"
 
 #ifdef _MSC_VER
 #include <filesystem>
@@ -58,7 +60,7 @@ void TruncateToCString(std::string* s);
 
 bool TryParse(const std::string& str, bool* output);
 
-template <typename T, std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>* = nullptr>
+template <Common::IntegralOrEnum T>
 bool TryParse(const std::string& str, T* output, int base = 0)
 {
   char* end_ptr = nullptr;
@@ -96,7 +98,7 @@ bool TryParse(const std::string& str, T* output, int base = 0)
   return true;
 }
 
-template <typename T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
+template <std::floating_point T>
 bool TryParse(std::string str, T* const output)
 {
   // Replace commas with dots.
@@ -142,7 +144,7 @@ std::string ValueToString(double value);
 std::string ValueToString(int value);
 std::string ValueToString(s64 value);
 std::string ValueToString(bool value);
-template <typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+template <Common::Enumerated T>
 std::string ValueToString(T value)
 {
   return ValueToString(static_cast<std::underlying_type_t<T>>(value));

--- a/Source/Core/Common/Swap.h
+++ b/Source/Core/Common/Swap.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstring>
-#include <type_traits>
 
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
@@ -17,6 +16,7 @@
 #endif
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 
 namespace Common
 {
@@ -157,19 +157,16 @@ inline void swap<8>(u8* data)
   std::memcpy(data, &value, sizeof(u64));
 }
 
-template <typename T>
+template <Arithmetic T>
 inline T FromBigEndian(T data)
 {
-  static_assert(std::is_arithmetic<T>::value, "function only makes sense with arithmetic types");
-
   swap<sizeof(data)>(reinterpret_cast<u8*>(&data));
   return data;
 }
 
-template <typename value_type>
+template <Arithmetic value_type>
 struct BigEndianValue
 {
-  static_assert(std::is_arithmetic<value_type>(), "value_type must be an arithmetic type");
   BigEndianValue() = default;
   explicit BigEndianValue(value_type val) { *this = val; }
   operator value_type() const { return FromBigEndian(raw); }

--- a/Source/Core/Common/TypeUtils.h
+++ b/Source/Core/Common/TypeUtils.h
@@ -88,40 +88,10 @@ struct IsSameAsAnyOf : std::disjunction<std::is_same<Ts, T>...>
 {
 };
 
-// Like std::conditional but operating on templates rather than types.
-// MetaConditional<C, X, Y>::type<T> is equivalent to std::conditional<C, X<T>, Y<T>>,
-// but doesn't require both X<T> and Y<T> to be valid.
-template <bool Cond, template <typename> class IfTrue, template <typename> class IfFalse>
-struct MetaConditional
+// Type trait for checking if T is an unscoped enum (why was this not included in C++23?)
+template <class T>
+struct IsUnscopedEnum : std::conjunction<std::is_enum<T>, std::negation<std::is_scoped_enum<T>>>
 {
-  template <typename T>
-  using type = IfTrue<T>;
-};
-// Partial specialization for false.
-template <template <typename> class IfTrue, template <typename> class IfFalse>
-struct MetaConditional<false, IfTrue, IfFalse>
-{
-  template <typename T>
-  using type = IfFalse<T>;
 };
 
-// FIXME: Even Clang 15 is not okay with a variadic template being used for the IfFalse templated
-// template in the following templated typedef.  GCC and MSVC have no such issue, otherwise I would
-// just use std::void_t.
-template <typename>
-using UnvariadicVoidTmpl = void;
-
-// Useful for defining an explicit casting operator overload for templated wrapper or interface
-// classes which may contain a scoped enum, as the declaration must still be a valid expression.
-// See: BitFieldView
-template <typename T>
-using ScopedEnumUnderlyingElseVoid =
-    typename MetaConditional<std::is_scoped_enum_v<T>, std::underlying_type_t,
-                             UnvariadicVoidTmpl>::template type<T>;
-
-// TODO add comment
-template <typename T>
-using EnumUnderlyingElseIdentity =
-    typename MetaConditional<std::is_enum_v<T>, std::underlying_type_t,
-                             std::type_identity_t>::template type<T>;
 }  // namespace Common

--- a/Source/Core/Common/TypeUtils.h
+++ b/Source/Core/Common/TypeUtils.h
@@ -1,5 +1,5 @@
-// Copyright 2021 Dolphin Emulator Project
-// SPDX-License-Identifier: GPL-2.0-or-later
+// 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: CC0-1.0
 
 #pragma once
 
@@ -68,19 +68,21 @@ static_assert(std::is_same_v<ObjectType<&Bar::c>, Foo>);
 static_assert(!std::is_same_v<ObjectType<&Bar::c>, Bar>);
 }  // namespace detail
 
-// Template for checking if Types is count occurrences of T.
-template <typename T, size_t count, typename... Ts>
-struct IsNOf : std::integral_constant<bool, std::conjunction_v<std::is_convertible<Ts, T>...> &&
-                                                sizeof...(Ts) == count>
+// Type trait for checking if the size of Types is equal to N
+template <std::size_t N, typename... Ts>
+struct IsCountOfTypes : std::bool_constant<sizeof...(Ts) == N>
 {
 };
 
-static_assert(IsNOf<int, 0>::value);
-static_assert(!IsNOf<int, 0, int>::value);
-static_assert(IsNOf<int, 1, int>::value);
-static_assert(!IsNOf<int, 1>::value);
-static_assert(!IsNOf<int, 1, int, int>::value);
-static_assert(IsNOf<int, 2, int, int>::value);
-static_assert(IsNOf<int, 2, int, short>::value);  // Type conversions ARE allowed
-static_assert(!IsNOf<int, 2, int, char*>::value);
+// Type trait for checking if all of the given Types are convertible to T
+template <typename T, typename... Ts>
+struct IsConvertibleFromAllOf : std::conjunction<std::is_convertible<Ts, T>...>
+{
+};
+
+// Type trait for checking if any of the given Types are the same as T
+template <typename T, typename... Ts>
+struct IsSameAsAnyOf : std::disjunction<std::is_same<Ts, T>...>
+{
+};
 }  // namespace Common

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -9,12 +9,12 @@
 #include <cstring>
 #include <functional>
 #include <tuple>
-#include <type_traits>
 
 #include "Common/Assert.h"
 #include "Common/BitSet.h"
 #include "Common/CodeBlock.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/x64ABI.h"
 
 namespace Gen
@@ -979,13 +979,9 @@ public:
   // Utility functions
   // The difference between this and CALL is that this aligns the stack
   // where appropriate.
-  template <typename FunctionPointer>
-  void ABI_CallFunction(FunctionPointer func)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunction(T func)
   {
-    static_assert(std::is_pointer<FunctionPointer>() &&
-                      std::is_function<std::remove_pointer_t<FunctionPointer>>(),
-                  "Supplied type must be a function pointer.");
-
     const void* ptr = reinterpret_cast<const void*>(func);
     const u64 address = reinterpret_cast<u64>(ptr);
     const u64 distance = address - (reinterpret_cast<u64>(code) + 5);
@@ -1002,46 +998,46 @@ public:
     }
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionC16(FunctionPointer func, u16 param1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionC16(T func, u16 param1)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCC16(FunctionPointer func, u32 param1, u16 param2)
-  {
-    MOV(32, R(ABI_PARAM1), Imm32(param1));
-    MOV(32, R(ABI_PARAM2), Imm32(param2));
-    ABI_CallFunction(func);
-  }
-
-  template <typename FunctionPointer>
-  void ABI_CallFunctionC(FunctionPointer func, u32 param1)
-  {
-    MOV(32, R(ABI_PARAM1), Imm32(param1));
-    ABI_CallFunction(func);
-  }
-
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCC(FunctionPointer func, u32 param1, u32 param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCC16(T func, u32 param1, u16 param2)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCP(FunctionPointer func, u32 param1, const void* param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionC(T func, u32 param1)
+  {
+    MOV(32, R(ABI_PARAM1), Imm32(param1));
+    ABI_CallFunction(func);
+  }
+
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCC(T func, u32 param1, u32 param2)
+  {
+    MOV(32, R(ABI_PARAM1), Imm32(param1));
+    MOV(32, R(ABI_PARAM2), Imm32(param2));
+    ABI_CallFunction(func);
+  }
+
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCP(T func, u32 param1, const void* param2)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(64, R(ABI_PARAM2), Imm64(reinterpret_cast<u64>(param2)));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCCC(FunctionPointer func, u32 param1, u32 param2, u32 param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCCC(T func, u32 param1, u32 param2, u32 param3)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
@@ -1049,8 +1045,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCCP(FunctionPointer func, u32 param1, u32 param2, const void* param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCCP(T func, u32 param1, u32 param2, const void* param3)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
@@ -1058,9 +1054,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCCCP(FunctionPointer func, u32 param1, u32 param2, u32 param3,
-                            const void* param4)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCCCP(T func, u32 param1, u32 param2, u32 param3, const void* param4)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
@@ -1069,23 +1064,23 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionP(FunctionPointer func, const void* param1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionP(T func, const void* param1)
   {
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(param1)));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPC(FunctionPointer func, const void* param1, u32 param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPC(T func, const void* param1, u32 param2)
   {
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(param1)));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPPC(FunctionPointer func, const void* param1, const void* param2, u32 param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPPC(T func, const void* param1, const void* param2, u32 param3)
   {
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(param1)));
     MOV(64, R(ABI_PARAM2), Imm64(reinterpret_cast<u64>(param2)));
@@ -1094,8 +1089,8 @@ public:
   }
 
   // Pass a register as a parameter.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionR(FunctionPointer func, X64Reg reg1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionR(T func, X64Reg reg1)
   {
     if (reg1 != ABI_PARAM1)
       MOV(32, R(ABI_PARAM1), R(reg1));
@@ -1103,8 +1098,8 @@ public:
   }
 
   // Pass a pointer and register as a parameter.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPR(FunctionPointer func, const void* ptr, X64Reg reg1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPR(T func, const void* ptr, X64Reg reg1)
   {
     MOV(64, R(ABI_PARAM2), R(reg1));
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(ptr)));
@@ -1112,24 +1107,24 @@ public:
   }
 
   // Pass two registers as parameters.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionRR(FunctionPointer func, X64Reg reg1, X64Reg reg2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionRR(T func, X64Reg reg1, X64Reg reg2)
   {
     MOVTwo(64, ABI_PARAM1, reg1, 0, ABI_PARAM2, reg2);
     ABI_CallFunction(func);
   }
 
   // Pass a pointer and two registers as parameters.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPRR(FunctionPointer func, const void* ptr, X64Reg reg1, X64Reg reg2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPRR(T func, const void* ptr, X64Reg reg1, X64Reg reg2)
   {
     MOVTwo(64, ABI_PARAM2, reg1, 0, ABI_PARAM3, reg2);
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(ptr)));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionAC(int bits, FunctionPointer func, const Gen::OpArg& arg1, u32 param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionAC(int bits, T func, const Gen::OpArg& arg1, u32 param2)
   {
     if (!arg1.IsSimpleReg(ABI_PARAM1))
       MOV(bits, R(ABI_PARAM1), arg1);
@@ -1137,8 +1132,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionA(int bits, FunctionPointer func, const Gen::OpArg& arg1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionA(int bits, T func, const Gen::OpArg& arg1)
   {
     if (!arg1.IsSimpleReg(ABI_PARAM1))
       MOV(bits, R(ABI_PARAM1), arg1);

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -14,6 +14,7 @@
 
 #include "Common/Align.h"
 #include "Common/BitUtils.h"
+#include "Common/Concepts.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Core.h"
@@ -58,10 +59,9 @@ Cheats::DataType Cheats::GetDataType(const Cheats::SearchValue& value)
   return static_cast<DataType>(value.m_value.index());
 }
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 static std::vector<u8> ToByteVector(const T& val)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   const auto* const begin = reinterpret_cast<const u8*>(&val);
   const auto* const end = begin + sizeof(T);
   return {begin, end};

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -509,7 +509,7 @@ std::string GCMemcard::DEntry_IconFmt(u8 index) const
   std::string format;
   for (size_t i = 0; i < 16; ++i)
   {
-    format.push_back(Common::ExtractBit(x, 15 - i) ? '1' : '0');
+    format.push_back(Common::ExtractBit(15 - i, x) ? '1' : '0');
   }
   return format;
 }
@@ -523,7 +523,7 @@ std::string GCMemcard::DEntry_AnimSpeed(u8 index) const
   std::string speed;
   for (size_t i = 0; i < 16; ++i)
   {
-    speed.push_back(Common::ExtractBit(x, 15 - i) ? '1' : '0');
+    speed.push_back(Common::ExtractBit(15 - i, x) ? '1' : '0');
   }
   return speed;
 }

--- a/Source/Core/Core/HW/MMIO.h
+++ b/Source/Core/Core/HW/MMIO.h
@@ -7,11 +7,12 @@
 #include <atomic>
 #include <string>
 #include <tuple>
-#include <type_traits>
 
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
+#include "Common/Future/CppLibConcepts.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/MMIOHandlers.h"
@@ -97,6 +98,9 @@ inline u16* HighPart(std::atomic<u32>* ptr)
 }
 }  // namespace Utils
 
+template <class Unit>
+concept HandlerConstraint = Common::SameAsAnyOf<Unit, u8, u16, u32>;
+
 class Mapping
 {
 public:
@@ -104,20 +108,20 @@ public:
   //
   // Example usages can be found in just about any HW/ module in Dolphin's
   // codebase.
-  template <typename Unit>
-  void RegisterRead(u32 addr, ReadHandlingMethod<Unit>* read)
+  template <HandlerConstraint T>
+  void RegisterRead(u32 addr, ReadHandlingMethod<T>* read)
   {
-    GetHandlerForRead<Unit>(addr).ResetMethod(read);
+    GetHandlerForRead<T>(addr).ResetMethod(read);
   }
 
-  template <typename Unit>
-  void RegisterWrite(u32 addr, WriteHandlingMethod<Unit>* write)
+  template <HandlerConstraint T>
+  void RegisterWrite(u32 addr, WriteHandlingMethod<T>* write)
   {
-    GetHandlerForWrite<Unit>(addr).ResetMethod(write);
+    GetHandlerForWrite<T>(addr).ResetMethod(write);
   }
 
-  template <typename Unit>
-  void Register(u32 addr, ReadHandlingMethod<Unit>* read, WriteHandlingMethod<Unit>* write)
+  template <HandlerConstraint T>
+  void Register(u32 addr, ReadHandlingMethod<T>* read, WriteHandlingMethod<T>* write)
   {
     RegisterRead(addr, read);
     RegisterWrite(addr, write);
@@ -129,16 +133,31 @@ public:
   // address. They are used by the Memory:: access functions, which are
   // called in interpreter mode, from Dolphin's own code, or from JIT'd code
   // where the access address could not be predicted.
-  template <typename Unit>
-  Unit Read(u32 addr)
+  template <HandlerConstraint T>
+  T Read(u32 addr)
   {
-    return GetHandlerForRead<Unit>(addr).Read(addr);
+    return GetHandlerForRead<T>(addr).Read(addr);
   }
 
-  template <typename Unit>
-  void Write(u32 addr, Unit val)
+  template <HandlerConstraint T>
+  void Write(u32 addr, T val)
   {
-    GetHandlerForWrite<Unit>(addr).Write(addr, val);
+    GetHandlerForWrite<T>(addr).Write(addr, val);
+  }
+
+  // Dummy 64 bits variants of these functions. While 64 bits MMIO access is
+  // not supported, we need these in order to make the code compile.
+  template <std::same_as<u64> T>
+  T Read(u32 addr)
+  {
+    ASSERT(false);
+    return 0;
+  }
+
+  template <std::same_as<u64> T>
+  void Write(u32 addr, T val)
+  {
+    ASSERT(false);
   }
 
   // Handlers access interface.
@@ -146,16 +165,16 @@ public:
   // Use when you care more about how to access the MMIO register for an
   // address than the current value of that register. For example, this is
   // what could be used to implement fast MMIO accesses in Dolphin's JIT.
-  template <typename Unit>
-  ReadHandler<Unit>& GetHandlerForRead(u32 addr)
+  template <HandlerConstraint T>
+  ReadHandler<T>& GetHandlerForRead(u32 addr)
   {
-    return GetReadHandler<Unit>(UniqueID(addr) / sizeof(Unit));
+    return GetReadHandler<T>(UniqueID(addr) / sizeof(T));
   }
 
-  template <typename Unit>
-  WriteHandler<Unit>& GetHandlerForWrite(u32 addr)
+  template <HandlerConstraint T>
+  WriteHandler<T>& GetHandlerForWrite(u32 addr)
   {
-    return GetWriteHandler<Unit>(UniqueID(addr) / sizeof(Unit));
+    return GetWriteHandler<T>(UniqueID(addr) / sizeof(T));
   }
 
 private:
@@ -167,11 +186,11 @@ private:
   // Each array contains NUM_MMIOS / sizeof (AccessType) because larger
   // access types mean less possible adresses (assuming aligned only
   // accesses).
-  template <typename Unit>
+  template <HandlerConstraint T>
   struct HandlerArray
   {
-    using Read = std::array<ReadHandler<Unit>, NUM_MMIOS / sizeof(Unit)>;
-    using Write = std::array<WriteHandler<Unit>, NUM_MMIOS / sizeof(Unit)>;
+    using Read = std::array<ReadHandler<T>, NUM_MMIOS / sizeof(T)>;
+    using Write = std::array<WriteHandler<T>, NUM_MMIOS / sizeof(T)>;
   };
 
   HandlerArray<u8>::Read m_read_handlers8;
@@ -183,45 +202,22 @@ private:
   HandlerArray<u32>::Write m_write_handlers32;
 
   // Getter functions for the handler arrays.
-  template <typename Unit>
-  ReadHandler<Unit>& GetReadHandler(size_t index)
+  template <HandlerConstraint T>
+  ReadHandler<T>& GetReadHandler(size_t index)
   {
-    static_assert(std::is_same<Unit, u8>() || std::is_same<Unit, u16>() ||
-                      std::is_same<Unit, u32>(),
-                  "Invalid unit used");
-
     auto handlers = std::tie(m_read_handlers8, m_read_handlers16, m_read_handlers32);
 
-    using ArrayType = typename HandlerArray<Unit>::Read;
+    using ArrayType = typename HandlerArray<T>::Read;
     return std::get<ArrayType&>(handlers)[index];
   }
 
-  template <typename Unit>
-  WriteHandler<Unit>& GetWriteHandler(size_t index)
+  template <HandlerConstraint T>
+  WriteHandler<T>& GetWriteHandler(size_t index)
   {
-    static_assert(std::is_same<Unit, u8>() || std::is_same<Unit, u16>() ||
-                      std::is_same<Unit, u32>(),
-                  "Invalid unit used");
-
     auto handlers = std::tie(m_write_handlers8, m_write_handlers16, m_write_handlers32);
 
-    using ArrayType = typename HandlerArray<Unit>::Write;
+    using ArrayType = typename HandlerArray<T>::Write;
     return std::get<ArrayType&>(handlers)[index];
   }
 };
-
-// Dummy 64 bits variants of these functions. While 64 bits MMIO access is
-// not supported, we need these in order to make the code compile.
-template <>
-inline u64 Mapping::Read<u64>(u32 addr)
-{
-  DEBUG_ASSERT(0);
-  return 0;
-}
-
-template <>
-inline void Mapping::Write(u32 addr, u64 val)
-{
-  DEBUG_ASSERT(0);
-}
 }  // namespace MMIO

--- a/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
+++ b/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
@@ -82,10 +82,10 @@ struct IncludeAccel : virtual DataReportManipulator
     result->value.x |= core.acc_bits & 0b11;
 
     // Y and Z only have 9 bits of precision. (convert them to 10)
-    result->value.y =
-        Common::ExpandValue<u16>(accel.y << 1 | Common::ExtractBit<0>(core.acc_bits2), 1);
-    result->value.z =
-        Common::ExpandValue<u16>(accel.z << 1 | Common::ExtractBit<1>(core.acc_bits2), 1);
+    result->value.y = Common::ExpandValue<u16>(
+        accel.y << 1 | static_cast<u8>(Common::ExtractBit<0>(core.acc_bits2)), 1);
+    result->value.z = Common::ExpandValue<u16>(
+        accel.z << 1 | static_cast<u8>(Common::ExtractBit<1>(core.acc_bits2)), 1);
   }
 
   void SetAccelData(const AccelData& new_accel) override

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
@@ -64,8 +64,8 @@ SerializedWiimoteState SerializeDesiredState(const DesiredWiimoteState& state)
     const u8 accel_x_high = u8(accel_x >> 2);
     const u8 accel_y_high = u8(accel_y >> 2);
     const u8 accel_z_high = u8(accel_z >> 2);
-    const u8 accel_low = u8((accel_x & 0b11) | (Common::ExtractBit<1>(accel_y) << 2) |
-                            (Common::ExtractBit<1>(accel_z) << 3));
+    const u8 accel_low = u8((accel_x & 0b11) | (u8(Common::ExtractBit<1>(accel_y)) << 2) |
+                            (u8(Common::ExtractBit<1>(accel_z)) << 3));
 
     if (has_buttons)
     {
@@ -252,10 +252,10 @@ bool DeserializeDesiredState(DesiredWiimoteState* state, const SerializedWiimote
     const u8 accel_y_high = d[pos + 2];
     const u8 accel_z_high = d[pos + 3];
     state->acceleration.value.x = (accel_x_high << 2) | (accel_low & 0b11);
-    state->acceleration.value.y =
-        Common::ExpandValue<u16>((accel_y_high << 1) | Common::ExtractBit<2>(accel_low), 1);
-    state->acceleration.value.z =
-        Common::ExpandValue<u16>((accel_z_high << 1) | Common::ExtractBit<3>(accel_low), 1);
+    state->acceleration.value.y = Common::ExpandValue<u16>(
+        (accel_y_high << 1) | static_cast<u8>(Common::ExtractBit<2>(accel_low)), 1);
+    state->acceleration.value.z = Common::ExpandValue<u16>(
+        (accel_z_high << 1) | static_cast<u8>(Common::ExtractBit<3>(accel_low)), 1);
     pos += 4;
   }
 

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
@@ -681,15 +681,15 @@ void MotionPlus::ApplyPassthroughModifications(PassthroughMode mode, u8* data)
     // Verified on real hardware via a test of every bit.
     // Data passing through drops the least significant bit of the three accelerometer values.
     // Bit 7 of byte 5 is moved to bit 6 of byte 5, overwriting it
-    Common::SetBit<6>(data[5], Common::ExtractBit<7>(data[5]));
+    Common::InsertBit<6>(data[5], Common::ExtractBit<7>(data[5]));
     // Bit 0 of byte 4 is moved to bit 7 of byte 5
-    Common::SetBit<7>(data[5], Common::ExtractBit<0>(data[4]));
+    Common::InsertBit<7>(data[5], Common::ExtractBit<0>(data[4]));
     // Bit 3 of byte 5 is moved to  bit 4 of byte 5, overwriting it
-    Common::SetBit<4>(data[5], Common::ExtractBit<3>(data[5]));
+    Common::InsertBit<4>(data[5], Common::ExtractBit<3>(data[5]));
     // Bit 1 of byte 5 is moved to bit 3 of byte 5
-    Common::SetBit<3>(data[5], Common::ExtractBit<1>(data[5]));
+    Common::InsertBit<3>(data[5], Common::ExtractBit<1>(data[5]));
     // Bit 0 of byte 5 is moved to bit 2 of byte 5, overwriting it
-    Common::SetBit<2>(data[5], Common::ExtractBit<0>(data[5]));
+    Common::InsertBit<2>(data[5], Common::ExtractBit<0>(data[5]));
   }
   else if (mode == PassthroughMode::Classic)
   {
@@ -698,8 +698,8 @@ void MotionPlus::ApplyPassthroughModifications(PassthroughMode mode, u8* data)
     // Data passing through drops the least significant bit of the axes of the left (or only)
     // joystick Bit 0 of Byte 4 is overwritten [by the 'extension_connected' flag] Bits 0 and
     // 1 of Byte 5 are moved to bit 0 of Bytes 0 and 1, overwriting what was there before.
-    Common::SetBit<0>(data[0], Common::ExtractBit<0>(data[5]));
-    Common::SetBit<0>(data[1], Common::ExtractBit<1>(data[5]));
+    Common::InsertBit<0>(data[0], Common::ExtractBit<0>(data[5]));
+    Common::InsertBit<0>(data[1], Common::ExtractBit<1>(data[5]));
   }
 }
 
@@ -708,30 +708,30 @@ void MotionPlus::ReversePassthroughModifications(PassthroughMode mode, u8* data)
   if (mode == PassthroughMode::Nunchuk)
   {
     // Undo M+'s "nunchuk passthrough" modifications.
-    Common::SetBit<0>(data[5], Common::ExtractBit<2>(data[5]));
-    Common::SetBit<1>(data[5], Common::ExtractBit<3>(data[5]));
-    Common::SetBit<3>(data[5], Common::ExtractBit<4>(data[5]));
-    Common::SetBit<0>(data[4], Common::ExtractBit<7>(data[5]));
-    Common::SetBit<7>(data[5], Common::ExtractBit<6>(data[5]));
+    Common::InsertBit<0>(data[5], Common::ExtractBit<2>(data[5]));
+    Common::InsertBit<1>(data[5], Common::ExtractBit<3>(data[5]));
+    Common::InsertBit<3>(data[5], Common::ExtractBit<4>(data[5]));
+    Common::InsertBit<0>(data[4], Common::ExtractBit<7>(data[5]));
+    Common::InsertBit<7>(data[5], Common::ExtractBit<6>(data[5]));
 
     // Set the overwritten bits from the next LSB.
-    Common::SetBit<2>(data[5], Common::ExtractBit<3>(data[5]));
-    Common::SetBit<4>(data[5], Common::ExtractBit<5>(data[5]));
-    Common::SetBit<6>(data[5], Common::ExtractBit<7>(data[5]));
+    Common::InsertBit<2>(data[5], Common::ExtractBit<3>(data[5]));
+    Common::InsertBit<4>(data[5], Common::ExtractBit<5>(data[5]));
+    Common::InsertBit<6>(data[5], Common::ExtractBit<7>(data[5]));
   }
   else if (mode == PassthroughMode::Classic)
   {
     // Undo M+'s "classic controller passthrough" modifications.
-    Common::SetBit<0>(data[5], Common::ExtractBit<0>(data[0]));
-    Common::SetBit<1>(data[5], Common::ExtractBit<0>(data[1]));
+    Common::InsertBit<0>(data[5], Common::ExtractBit<0>(data[0]));
+    Common::InsertBit<1>(data[5], Common::ExtractBit<0>(data[1]));
 
     // Set the overwritten bits from the next LSB.
-    Common::SetBit<0>(data[0], Common::ExtractBit<1>(data[0]));
-    Common::SetBit<0>(data[1], Common::ExtractBit<1>(data[1]));
+    Common::InsertBit<0>(data[0], Common::ExtractBit<1>(data[0]));
+    Common::InsertBit<0>(data[1], Common::ExtractBit<1>(data[1]));
 
     // This is an overwritten unused button bit on the Classic Controller.
     // Note it's a significant bit on the DJ Hero Turntable. (passthrough not feasible)
-    Common::SetBit<0>(data[4], 1);
+    Common::InsertBit<0>(data[4], 1);
   }
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -5,9 +5,9 @@
 
 #include <array>
 #include <cstddef>
-#include <type_traits>
 #include <variant>
 
+#include "Common/Concepts.h"
 #include "Common/x64Emitter.h"
 #include "Core/PowerPC/Jit64/RegCache/CachedReg.h"
 #include "Core/PowerPC/PPCAnalyst.h"
@@ -119,6 +119,9 @@ private:
   std::array<X64CachedReg, NUM_XREGS> m_xregs;
 };
 
+template <class T>
+concept RegCacheConstraint = Common::SameAsAnyOf<T, RCOpArg, RCX64Reg>;
+
 class RegCache
 {
 public:
@@ -135,17 +138,15 @@ public:
   void SetEmitter(Gen::XEmitter* emitter);
   bool SanityCheck() const;
 
-  template <typename... Ts>
+  template <RegCacheConstraint... Ts>
   static void Realize(Ts&... rc)
   {
-    static_assert(((std::is_same<Ts, RCOpArg>() || std::is_same<Ts, RCX64Reg>()) && ...));
     (rc.Realize(), ...);
   }
 
-  template <typename... Ts>
+  template <RegCacheConstraint... Ts>
   static void Unlock(Ts&... rc)
   {
-    static_assert(((std::is_same<Ts, RCOpArg>() || std::is_same<Ts, RCX64Reg>()) && ...));
     (rc.Unlock(), ...);
   }
 

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -10,6 +10,7 @@
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+#include "Common/Future/CppLibConcepts.h"
 #include "Common/Logging/Log.h"
 
 #include "Core/ConfigManager.h"
@@ -170,7 +171,7 @@ BatTable dbat_table;
 
 static void GenerateDSIException(u32 effective_address, bool write);
 
-template <XCheckTLBFlag flag, typename T, bool never_translate = false>
+template <XCheckTLBFlag flag, std::integral T, bool never_translate = false>
 static T ReadFromHardware(u32 em_address)
 {
   const u32 em_address_start_page = em_address & ~HW_PAGE_MASK;
@@ -581,7 +582,7 @@ float Read_F32(const u32 address)
   return Common::BitCast<float>(integral);
 }
 
-template <typename T>
+template <std::integral T>
 static std::optional<ReadResult<T>> HostTryReadUX(const u32 address, RequestedAddressSpace space)
 {
   if (!HostIsRAMAddress(address, space))

--- a/Source/Core/DiscIO/TGCBlob.cpp
+++ b/Source/Core/DiscIO/TGCBlob.cpp
@@ -6,10 +6,10 @@
 #include <algorithm>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
+#include "Common/Concepts.h"
 #include "Common/IOFile.h"
 #include "Common/Swap.h"
 
@@ -33,11 +33,9 @@ void Replace(u64 offset, u64 size, u8* out_ptr, u64 replace_offset, u64 replace_
   }
 }
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 void Replace(u64 offset, u64 size, u8* out_ptr, u64 replace_offset, const T& replace_value)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
-
   const u8* replace_ptr = reinterpret_cast<const u8*>(&replace_value);
   Replace(offset, size, out_ptr, replace_offset, sizeof(T), replace_ptr);
 }

--- a/Source/Core/DiscIO/Volume.cpp
+++ b/Source/Core/DiscIO/Volume.cpp
@@ -8,11 +8,11 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Crypto/SHA1.h"
 #include "Common/StringUtil.h"
 
@@ -31,10 +31,9 @@ const IOS::ES::TicketReader Volume::INVALID_TICKET{};
 const IOS::ES::TMDReader Volume::INVALID_TMD{};
 const std::vector<u8> Volume::INVALID_CERT_CHAIN{};
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 static void AddToSyncHash(Common::SHA1::Context* context, const T& data)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   context->Update(reinterpret_cast<const u8*>(&data), sizeof(data));
 }
 

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -20,6 +20,7 @@
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Crypto/SHA1.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -47,11 +48,9 @@ static void PushBack(std::vector<u8>* vector, const u8* begin, const u8* end)
   std::copy(begin, end, vector->data() + offset_in_vector);
 }
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 static void PushBack(std::vector<u8>* vector, const T& x)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
-
   const u8* x_ptr = reinterpret_cast<const u8*>(&x);
   PushBack(vector, x_ptr, x_ptr + sizeof(T));
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -16,21 +16,11 @@
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
 namespace ControllerEmu
 {
-class Control;
-
-class NumericSettingBase;
-struct NumericSettingDetails;
-
-template <typename T>
-class NumericSetting;
-
-template <typename T>
-class SettingValue;
-
 using InputOverrideFunction = std::function<std::optional<ControlState>(
     const std::string_view group_name, const std::string_view control_name, ControlState state)>;
 
@@ -79,7 +69,7 @@ public:
   void AddInput(Translatability translate, std::string name, std::string ui_name);
   void AddOutput(Translatability translate, std::string name);
 
-  template <typename T>
+  template <SettingConstraint T>
   void AddSetting(SettingValue<T>* value, const NumericSettingDetails& details,
                   std::common_type_t<T> default_value_, std::common_type_t<T> min_value = {},
                   std::common_type_t<T> max_value = T(100))

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -12,6 +12,7 @@
 
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
+#include "Common/Future/CppLibConcepts.h"
 #include "Common/IniFile.h"
 #include "Common/MathUtil.h"
 #include "InputCommon/ControlReference/ExpressionParser.h"
@@ -210,17 +211,10 @@ public:
   std::vector<std::unique_ptr<ControlGroup>> groups;
 
   // Maps a float from -1.0..+1.0 to an integer in the provided range.
-  template <typename T, typename F>
+  template <std::integral T, std::floating_point F>
   static T MapFloat(F input_value, T zero_value, T neg_1_value = std::numeric_limits<T>::min(),
                     T pos_1_value = std::numeric_limits<T>::max())
   {
-    static_assert(std::is_integral<T>(), "T is only sane for int types.");
-    static_assert(std::is_floating_point<F>(), "F is only sane for float types.");
-
-    static_assert(std::numeric_limits<long long>::min() <= std::numeric_limits<T>::min() &&
-                      std::numeric_limits<long long>::max() >= std::numeric_limits<T>::max(),
-                  "long long is not a superset of T. use of std::llround is not sane.");
-
     // Here we round when converting from float to int.
     // After applying our deadzone, resizing, and reshaping math
     // we sometimes have a near-zero value which is slightly negative. (e.g. -0.0001)

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/IniFile.h"
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
@@ -19,6 +20,10 @@ enum class SettingType
   Double,
   Bool,
 };
+
+// NumericSetting is only implemented for int, double, and bool.
+template <class T>
+concept SettingConstraint = Common::SameAsAnyOf<T, int, double, bool>;
 
 enum class SettingVisibility
 {
@@ -87,18 +92,14 @@ protected:
   NumericSettingDetails m_details;
 };
 
-template <typename T>
+template <SettingConstraint T>
 class SettingValue;
 
-template <typename T>
+template <SettingConstraint T>
 class NumericSetting final : public NumericSettingBase
 {
 public:
   using ValueType = T;
-
-  static_assert(std::is_same<ValueType, int>() || std::is_same<ValueType, double>() ||
-                    std::is_same<ValueType, bool>(),
-                "NumericSetting is only implemented for int, double, and bool.");
 
   NumericSetting(SettingValue<ValueType>* value, const NumericSettingDetails& details,
                  ValueType default_value, ValueType min_value, ValueType max_value)
@@ -169,7 +170,7 @@ private:
   const ValueType m_max_value;
 };
 
-template <typename T>
+template <SettingConstraint T>
 class SettingValue
 {
   using ValueType = T;

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
@@ -7,9 +7,11 @@
 #include "Common/StringUtil.h"
 #include "VideoCommon/TextureCacheBase.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace
 {
-template <typename T, std::enable_if_t<std::is_base_of_v<FBTarget, T>, int> = 0>
+template <std::derived_from<FBTarget> T>
 std::optional<T> DeserializeFBTargetFromConfig(const picojson::object& obj, std::string_view prefix)
 {
   T fb;

--- a/Source/Core/VideoCommon/OpcodeDecoding.h
+++ b/Source/Core/VideoCommon/OpcodeDecoding.h
@@ -3,11 +3,10 @@
 
 #pragma once
 
-#include <type_traits>
-
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/EnumFormatter.h"
+#include "Common/Future/CppLibConcepts.h"
 #include "Common/Inline.h"
 #include "Common/Swap.h"
 #include "VideoCommon/CPMemory.h"
@@ -118,7 +117,7 @@ public:
 namespace detail
 {
 // Main logic; split so that the main RunCommand can call OnCommand with the returned size.
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<Callback, T>>>
+template <std::derived_from<Callback> T>
 static DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& callback)
 {
   if (available < 1)
@@ -248,7 +247,7 @@ static DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& cal
 }
 }  // namespace detail
 
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<Callback, T>>>
+template <std::derived_from<Callback> T>
 DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& callback)
 {
   const u32 size = detail::RunCommand(data, available, callback);
@@ -259,7 +258,7 @@ DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& callback)
   return size;
 }
 
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<Callback, T>>>
+template <std::derived_from<Callback> T>
 DOLPHIN_FORCE_INLINE u32 Run(const u8* data, u32 available, T& callback)
 {
   u32 size = 0;

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -224,7 +224,7 @@ static void UnserializePipelineUid(const SerializedUidType& uid, UidType& real_u
   real_uid.blending_state.hex = uid.blending_state_bits;
 }
 
-template <ShaderStage stage, typename K, typename T>
+template <ShaderStage stage, Common::TriviallyCopyable K, typename T>
 void ShaderCache::LoadShaderCache(T& cache, APIType api_type, const char* type, bool include_gameid)
 {
   class CacheReader : public LinearDiskCacheReader<K, u8>
@@ -274,7 +274,7 @@ void ShaderCache::ClearShaderCache(T& cache)
   cache.shader_map.clear();
 }
 
-template <typename KeyType, typename DiskKeyType, typename T>
+template <typename KeyType, Common::TriviallyCopyable DiskKeyType, typename T>
 void ShaderCache::LoadPipelineCache(T& cache, LinearDiskCache<DiskKeyType, u8>& disk_cache,
                                     APIType api_type, const char* type, bool include_gameid)
 {

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -170,11 +170,11 @@ private:
   void QueueUberPipelineCompile(const GXUberPipelineUid& uid, u32 priority);
 
   // Populating various caches.
-  template <ShaderStage stage, typename K, typename T>
+  template <ShaderStage stage, Common::TriviallyCopyable K, typename T>
   void LoadShaderCache(T& cache, APIType api_type, const char* type, bool include_gameid);
   template <typename T>
   void ClearShaderCache(T& cache);
-  template <typename KeyType, typename DiskKeyType, typename T>
+  template <typename KeyType, Common::TriviallyCopyable DiskKeyType, typename T>
   void LoadPipelineCache(T& cache, LinearDiskCache<DiskKeyType, u8>& disk_cache, APIType api_type,
                          const char* type, bool include_gameid);
   template <typename T, typename Y>

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -12,6 +12,7 @@
 #include <fmt/format.h>
 
 #include "Common/BitField.h"
+#include "Common/BitFieldView.h"
 #include "Common/CommonTypes.h"
 #include "Common/Concepts.h"
 #include "Common/EnumMap.h"
@@ -213,6 +214,15 @@ std::string BitfieldExtract(std::string_view source)
   return fmt::format("bitfieldExtract({}({}), {}, {})", BitFieldT::IsSigned() ? "int" : "uint",
                      source, static_cast<u32>(BitFieldT::StartBit()),
                      static_cast<u32>(BitFieldT::NumBits()));
+}
+
+// bitfieldExtract generator for fixed-variant BitFieldView
+template <Common::FixedBitFieldView T>
+std::string BitfieldExtract(std::string_view source, T /*unused*/)
+{
+  return fmt::format("bitfieldExtract({}({}), {}, {})",
+                     std::is_signed_v<typename T::FieldType> ? "int" : "uint", source,
+                     static_cast<u32>(T::BitStart()), static_cast<u32>(T::BitWidth()));
 }
 
 template <auto last_member, typename = decltype(last_member)>

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -216,7 +216,7 @@ std::string BitfieldExtract(std::string_view source)
                      static_cast<u32>(BitFieldT::NumBits()));
 }
 
-// bitfieldExtract generator for fixed-variant BitFieldView
+// bitfieldExtract generator for FixedBitFieldViews
 template <Common::IntegralOrEnum field_t, std::size_t width, std::size_t start, class host_t>
 std::string BitfieldExtract(std::string_view source,
                             Common::FixedBitFieldView<field_t, width, start, host_t>

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -7,13 +7,13 @@
 #include <functional>
 #include <iterator>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 #include <fmt/format.h>
 
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/EnumMap.h"
 #include "Common/StringUtil.h"
 #include "Common/TypeUtils.h"
@@ -65,13 +65,10 @@ public:
  * NOTE: Because LinearDiskCache reads and writes the storage associated with a ShaderUid instance,
  * ShaderUid must be trivially copyable.
  */
-template <class uid_data>
+template <Common::TriviallyCopyable uid_data>
 class ShaderUid : public ShaderGeneratorInterface
 {
 public:
-  static_assert(std::is_trivially_copyable_v<uid_data>,
-                "uid_data must be a trivially copyable type");
-
   ShaderUid() { memset(GetUidData(), 0, GetUidDataSize()); }
 
   bool operator==(const ShaderUid& obj) const

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -219,7 +219,7 @@ std::string BitfieldExtract(std::string_view source)
 // bitfieldExtract generator for fixed-variant BitFieldView
 template <Common::IntegralOrEnum field_t, std::size_t width, std::size_t start, class host_t>
 std::string BitfieldExtract(std::string_view source,
-                            Common::MutFixedBitFieldView<field_t, width, start, host_t>
+                            Common::FixedBitFieldView<field_t, width, start, host_t>
                             /*unused*/)
 {
   return fmt::format("bitfieldExtract({}({}), {}, {})", std::is_signed_v<field_t> ? "int" : "uint",

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -217,12 +217,13 @@ std::string BitfieldExtract(std::string_view source)
 }
 
 // bitfieldExtract generator for fixed-variant BitFieldView
-template <Common::FixedBitFieldView T>
-std::string BitfieldExtract(std::string_view source, T /*unused*/)
+template <Common::IntegralOrEnum field_t, std::size_t width, std::size_t start, class host_t>
+std::string BitfieldExtract(std::string_view source,
+                            Common::MutFixedBitFieldView<field_t, width, start, host_t>
+                            /*unused*/)
 {
-  return fmt::format("bitfieldExtract({}({}), {}, {})",
-                     std::is_signed_v<typename T::FieldType> ? "int" : "uint", source,
-                     static_cast<u32>(T::BitStart()), static_cast<u32>(T::BitWidth()));
+  return fmt::format("bitfieldExtract({}({}), {}, {})", std::is_signed_v<field_t> ? "int" : "uint",
+                     source, static_cast<u32>(start), static_cast<u32>(width));
 }
 
 template <auto last_member, typename = decltype(last_member)>

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -8,6 +8,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/EnumMap.h"
+#include "Common/Future/CppLibConcepts.h"
 
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/VertexLoader.h"
@@ -70,11 +71,9 @@ void Normal_ReadDirect(VertexLoader* loader)
   DataSkip<N * 3 * sizeof(T)>();
 }
 
-template <typename I, typename T, u32 N, u32 Offset>
+template <std::unsigned_integral I, typename T, u32 N, u32 Offset>
 void Normal_ReadIndex_Offset(VertexLoader* loader)
 {
-  static_assert(std::is_unsigned_v<I>, "Only unsigned I is sane!");
-
   const auto index = DataRead<I>();
   const auto data = reinterpret_cast<const T*>(
       VertexLoaderManager::cached_arraybases[CPArray::Normal] +
@@ -82,13 +81,13 @@ void Normal_ReadIndex_Offset(VertexLoader* loader)
   ReadIndirect<T, N * 3>(loader, data);
 }
 
-template <typename I, typename T, u32 N>
+template <std::unsigned_integral I, typename T, u32 N>
 void Normal_ReadIndex(VertexLoader* loader)
 {
   Normal_ReadIndex_Offset<I, T, N, 0>(loader);
 }
 
-template <typename I, typename T>
+template <std::unsigned_integral I, typename T>
 void Normal_ReadIndex_Indices3(VertexLoader* loader)
 {
   Normal_ReadIndex_Offset<I, T, 1, 0>(loader);

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -4,10 +4,10 @@
 #include "VideoCommon/VertexLoader_Position.h"
 
 #include <limits>
-#include <type_traits>
 
 #include "Common/CommonTypes.h"
 #include "Common/EnumMap.h"
+#include "Common/Future/CppLibConcepts.h"
 #include "Common/Swap.h"
 
 #include "VideoCommon/DataReader.h"
@@ -51,10 +51,9 @@ void Pos_ReadDirect(VertexLoader* loader)
   LOG_VTX();
 }
 
-template <typename I, typename T, int N>
+template <std::unsigned_integral I, typename T, int N>
 void Pos_ReadIndex(VertexLoader* loader)
 {
-  static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
   static_assert(N <= 3, "N > 3 is not sane!");
 
   const auto index = DataRead<I>();

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -3,9 +3,8 @@
 
 #include "VideoCommon/VertexLoader_TextCoord.h"
 
-#include <type_traits>
-
 #include "Common/CommonTypes.h"
+#include "Common/Future/CppLibConcepts.h"
 #include "Common/Swap.h"
 
 #include "VideoCommon/DataReader.h"
@@ -48,11 +47,9 @@ void TexCoord_ReadDirect(VertexLoader* loader)
   ++loader->m_tcIndex;
 }
 
-template <typename I, typename T, int N>
+template <std::unsigned_integral I, typename T, int N>
 void TexCoord_ReadIndex(VertexLoader* loader)
 {
-  static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
-
   const auto index = DataRead<I>();
   const auto data = reinterpret_cast<const T*>(
       VertexLoaderManager::cached_arraybases[CPArray::TexCoord0 + loader->m_tcIndex] +

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -84,12 +84,12 @@ inline u32 CompressZ16(u32 z24depth, DepthFormat format)
 
   u32 leading_ones = Common::CountLeadingZeros((~z24depth) << 8);
   bool next_bit_is_one = false;  // AKA: Did we clamp leading_ones?
-  u32 exp_bits;
+  u32 exp_width;
 
   switch (format)
   {
   case DepthFormat::ZNEAR:
-    exp_bits = 2;
+    exp_width = 2;
     if (leading_ones >= 3u)
     {
       leading_ones = 3u;
@@ -97,7 +97,7 @@ inline u32 CompressZ16(u32 z24depth, DepthFormat format)
     }
     break;
   case DepthFormat::ZMID:
-    exp_bits = 3;
+    exp_width = 3;
     if (leading_ones >= 7u)
     {
       leading_ones = 7u;
@@ -105,7 +105,7 @@ inline u32 CompressZ16(u32 z24depth, DepthFormat format)
     }
     break;
   case DepthFormat::ZFAR:
-    exp_bits = 4;
+    exp_width = 4;
     if (leading_ones >= 12u)
     {
       // The hardware implementation only uses values 0 to 12 in the exponent
@@ -117,18 +117,18 @@ inline u32 CompressZ16(u32 z24depth, DepthFormat format)
     return z24depth >> 8;
   }
 
-  u32 mantissa_bits = 16 - exp_bits;
+  u32 mantissa_width = 16 - exp_width;
 
   // Calculate which bits we need to extract from z24depth for our mantissa
-  u32 top = std::max<u32>(24 - leading_ones, mantissa_bits);
+  u32 top = std::max<u32>(24 - leading_ones, mantissa_width);
   if (!next_bit_is_one)
   {
     top -= 1;  // We know the next bit is zero, so we don't need to include it.
   }
-  u32 bottom = top - mantissa_bits;
+  u32 bottom = top - mantissa_width;
 
-  u32 exponent = leading_ones << mantissa_bits;  // Upper bits contain exponent
-  u32 mantissa = Common::ExtractBits(z24depth, bottom, top - 1);
+  u32 exponent = leading_ones << mantissa_width;  // Upper bits contain exponent
+  u32 mantissa = Common::ExtractBitsU(mantissa_width, bottom, z24depth);
 
   return exponent | mantissa;
 }

--- a/Source/UnitTests/Common/BitFieldViewTest.cpp
+++ b/Source/UnitTests/Common/BitFieldViewTest.cpp
@@ -186,20 +186,20 @@ namespace test
 {
 // idk why, but std::assignable_from doesn't work.
 template <class field_t, class LHS>
-concept assignable_from_bfview = requires(::Common::MutFixedBitFieldView<field_t, 1, 0, u64> mf_bfv,
-                                          ::Common::MutLooseBitFieldView<field_t, 1, u64> ml_bfv,
+concept assignable_from_bfview = requires(::Common::FixedBitFieldView<field_t, 1, 0, u64> f_bfv,
+                                          ::Common::LooseBitFieldView<field_t, 1, u64> l_bfv,
                                           LHS lhs)
 {
-  lhs = mf_bfv;
-  lhs = ml_bfv;
+  lhs = f_bfv;
+  lhs = l_bfv;
 };
 
 template <class field_t, class TYPE>
-concept explicit_cast_bfview = requires(::Common::MutFixedBitFieldView<field_t, 1, 0, u64> mf_bfv,
-                                        ::Common::MutLooseBitFieldView<field_t, 1, u64> ml_bfv)
+concept explicit_cast_bfview = requires(::Common::FixedBitFieldView<field_t, 1, 0, u64> f_bfv,
+                                        ::Common::LooseBitFieldView<field_t, 1, u64> l_bfv)
 {
-  static_cast<TYPE>(mf_bfv);
-  static_cast<TYPE>(ml_bfv);
+  static_cast<TYPE>(f_bfv);
+  static_cast<TYPE>(l_bfv);
 };
 }  // namespace test
 

--- a/Source/UnitTests/Common/BitFieldViewTest.cpp
+++ b/Source/UnitTests/Common/BitFieldViewTest.cpp
@@ -1,0 +1,723 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "Common/BitFieldView.h"
+#include "Common/CommonTypes.h"
+#include "Common/EnumFormatter.h"
+
+enum class TestEnum : u64
+{
+  A,
+  B,
+  C,
+  D,
+};
+
+template <>
+struct fmt::formatter<TestEnum> : EnumFormatter<TestEnum::D>
+{
+  constexpr formatter() : EnumFormatter({"A", "B", "C", "D"}) {}
+};
+
+enum class TestBoolEnum : bool
+{
+  Falsy = false,
+  Truthy = true,
+};
+
+template <>
+struct fmt::formatter<TestBoolEnum> : EnumFormatter<TestBoolEnum::Truthy>
+{
+  constexpr formatter() : EnumFormatter({"Falsy", "Truthy"}) {}
+};
+
+enum TestNoScopeEnum
+{
+  MLG,
+  MtnDew,
+  AirHorn,
+  Doritos,
+};
+
+struct TestStruct
+{
+  u64 hex;
+
+  BFVIEW(u64, 64, 0, full_u64)  // spans whole storage
+  BFVIEW(s64, 64, 0, full_s64)  // spans whole storage
+
+  BFVIEW(u64, 3, 9, regular_field_unsigned)   // a plain bitfield
+  BFVIEW(u64, 3, 9, regular_field_unsigned2)  // Just the very same bitfield again
+  BFVIEW(s64, 3, 9, regular_field_signed)     // Same bitfield, but different sign
+
+  BFVIEW(s64, 4, 30, at_dword_boundary)  // goes over the boundary of two u32 values
+
+  BFVIEW(s64, 1, 15, signed_1bit)  // allowed values: -1 and 0
+
+  BFVIEW(bool, 1, 63, flag)
+  BFVIEW(TestBoolEnum, 1, 63, enum_flag)
+
+  BFVIEW(TestEnum, 2, 16, enum_1)
+  BFVIEW(TestEnum, 2, 48, enum_2)
+  BFVIEW(TestNoScopeEnum, 2, 32, enum_3)
+
+  TestStruct() = default;
+  constexpr TestStruct(u64 val) : hex(val) {}
+};
+
+// table of raw numbers to test with
+static u64 table[] = {
+    0x0000000000000000ull,  // all zero
+    0xffffffffffffffffull,  // all one
+    0x7fffffffffffffffull,  // all one apart from the sign bit
+    0x8000000000000000ull,  // all zero apart from the sign bit
+    0x8000000000000048ull,  // regular_field = 0b1001
+
+    // "random" numbers
+    0x0F7B8B1ABD9B8D3Full,
+    0xA8B86F73FDAADD2Dull,
+    0x1B17A557BFEB351Dull,
+    0xE3354268B0C2395Bull,
+};
+
+// Verify that bitfields in a union have the same underlying data
+TEST(MutLooseBitFieldView, Storage)
+{
+  TestStruct object;
+
+  // Now write some values to one field and check if this reflects properly
+  // in the others.
+  for (u64 val : table)
+  {
+    object = val;
+    EXPECT_EQ(object.hex, object.full_u64());
+    EXPECT_EQ(object.regular_field_unsigned(), object.regular_field_unsigned2());
+
+    object.regular_field_unsigned() = val & 0x3;
+    EXPECT_EQ(object.hex, object.full_u64());
+    EXPECT_EQ(object.regular_field_unsigned(), object.regular_field_unsigned2());
+  }
+}
+
+TEST(MutLooseBitFieldView, Read)
+{
+  TestStruct object;
+
+  for (u64 val : table)
+  {
+    object = val;
+
+    // Make sure reading/casting does not behave completely idiotic
+    EXPECT_EQ(object.full_u64(), (u64)object.full_u64());
+    EXPECT_EQ(object.full_s64(), (s64)object.full_s64());
+    EXPECT_EQ(object.regular_field_unsigned(), (u64)object.regular_field_unsigned());
+    EXPECT_EQ(object.regular_field_unsigned2(), (u64)object.regular_field_unsigned2());
+    EXPECT_EQ(object.regular_field_signed(), (s64)object.regular_field_signed());
+    EXPECT_EQ(object.at_dword_boundary(), (s64)object.at_dword_boundary());
+    EXPECT_EQ(object.signed_1bit(), (s64)object.signed_1bit());
+    EXPECT_EQ(object.flag(), (bool)object.flag());
+    EXPECT_EQ(object.enum_flag(), static_cast<TestBoolEnum>(object.enum_flag()));
+    EXPECT_EQ(object.enum_1(), static_cast<TestEnum>(object.enum_1()));
+    EXPECT_EQ(object.enum_2(), static_cast<TestEnum>(object.enum_2()));
+
+    // Now make sure the value is indeed correct
+    EXPECT_EQ(val, object.full_u64());
+    EXPECT_EQ(*(s64*)&val, object.full_s64());
+    EXPECT_EQ((val >> 9) & 0x7, object.regular_field_unsigned());
+    EXPECT_EQ((val >> 9) & 0x7, object.regular_field_unsigned2());
+    EXPECT_EQ(((s64)(val << 52)) >> 61, object.regular_field_signed());
+    EXPECT_EQ(((s64)(val << 30)) >> 60, object.at_dword_boundary());
+    EXPECT_EQ(((val >> 15) & 1) ? -1 : 0, object.signed_1bit());
+    EXPECT_EQ(((val >> 63) & 1) ? true : false, object.flag());
+    EXPECT_EQ(static_cast<TestBoolEnum>(((object.hex >> 63) & 1)), object.enum_flag());
+    EXPECT_EQ(static_cast<TestEnum>((object.hex >> 16) & 3), object.enum_1());
+    EXPECT_EQ(static_cast<TestEnum>((object.hex >> 48) & 3), object.enum_2());
+  }
+}
+
+TEST(MutLooseBitFieldView, Assignment)
+{
+  TestStruct object;
+
+  for (u64 val : table)
+  {
+    // Assignments with fixed values
+    object.full_u64() = val;
+    EXPECT_EQ(val, object.full_u64());
+
+    object.full_s64() = (s64)val;
+    EXPECT_EQ(val, object.full_u64());
+
+    object.regular_field_unsigned() = val;
+    EXPECT_EQ(val & 0x7, object.regular_field_unsigned());
+
+    object.at_dword_boundary() = val;
+    EXPECT_EQ(((s64)(val << 60)) >> 60, object.at_dword_boundary());
+
+    object.signed_1bit() = val;
+    EXPECT_EQ((val & 1) ? -1 : 0, object.signed_1bit());
+
+    object.regular_field_signed() = val;
+    EXPECT_EQ(((s64)(val << 61)) >> 61, object.regular_field_signed());
+
+    // Assignment from other BitField
+    object.at_dword_boundary() = object.regular_field_signed();
+    EXPECT_EQ(object.regular_field_signed(), object.at_dword_boundary());
+
+    // Assignment to field of a type with a size smaller than the underlying type
+    object.flag() = (val & 2);
+    EXPECT_EQ(object.flag(), (val & 2) != 0);
+
+    // Assigning Enums
+    object.enum_1() = TestEnum::C;
+    EXPECT_EQ(object.enum_1(), TestEnum::C);
+
+    // Assigning Bool Enums
+    object.enum_flag() = TestBoolEnum::Truthy;
+    EXPECT_EQ(object.enum_flag(), TestBoolEnum::Truthy);
+  }
+}
+
+// This is testing that the syntax-saving ScopedEnumBitFieldView variants compile
+TEST(MutLooseBitFieldView, EnumVariant)
+{
+  using TestEnumUnderlying = std::underlying_type_t<TestEnum>;
+  using TestBoolEnumUnderlying = std::underlying_type_t<TestBoolEnum>;
+  using TestNoScopeEnumUnderlying = std::underlying_type_t<TestNoScopeEnum>;
+
+  for (u64 val : table)
+  {
+    TestStruct object = val;
+
+    [[maybe_unused]] TestEnumUnderlying enum_1 = static_cast<TestEnumUnderlying>(object.enum_1());
+    [[maybe_unused]] TestEnumUnderlying enum_2 = static_cast<TestEnumUnderlying>(object.enum_2());
+    [[maybe_unused]] TestBoolEnumUnderlying enum_flag =
+        static_cast<TestBoolEnumUnderlying>(object.enum_flag());
+
+    // Unscoped enums compile fine, too!
+    [[maybe_unused]] TestNoScopeEnumUnderlying enum_3a =
+        static_cast<TestNoScopeEnumUnderlying>(object.enum_3());
+    [[maybe_unused]] TestNoScopeEnumUnderlying enum_3b = object.enum_3();
+  }
+}
+
+// Test behavior of using BitFields with fmt
+TEST(MutLooseBitFieldView, Fmt)
+{
+  TestStruct object;
+
+  for (u64 val : table)
+  {
+    object = val;
+
+    // Formatting the BitField should be the same as formatting its value
+    EXPECT_EQ(fmt::to_string(object.full_u64()), fmt::to_string(object.full_u64().Get()));
+    EXPECT_EQ(fmt::to_string(object.full_s64()), fmt::to_string(object.full_s64().Get()));
+    EXPECT_EQ(fmt::to_string(object.regular_field_unsigned()),
+              fmt::to_string(object.regular_field_unsigned().Get()));
+    EXPECT_EQ(fmt::to_string(object.regular_field_unsigned2()),
+              fmt::to_string(object.regular_field_unsigned2().Get()));
+    EXPECT_EQ(fmt::to_string(object.regular_field_signed()),
+              fmt::to_string(object.regular_field_signed().Get()));
+    EXPECT_EQ(fmt::to_string(object.at_dword_boundary()),
+              fmt::to_string(object.at_dword_boundary().Get()));
+    EXPECT_EQ(fmt::to_string(object.signed_1bit()), fmt::to_string(object.signed_1bit().Get()));
+    EXPECT_EQ(fmt::to_string(object.flag()), fmt::to_string(object.flag().Get()));
+    // The custom enum formatter should be used properly.
+    EXPECT_EQ(fmt::to_string(object.enum_flag()), fmt::to_string(object.enum_flag().Get()));
+    EXPECT_EQ(fmt::to_string(object.enum_1()), fmt::to_string(object.enum_1().Get()));
+    EXPECT_EQ(fmt::to_string(object.enum_2()), fmt::to_string(object.enum_2().Get()));
+
+    // Formatting the BitField should respect the format spec
+    EXPECT_EQ(fmt::format("{:02x}", object.full_u64()),
+              fmt::format("{:02x}", object.full_u64().Get()));
+    EXPECT_EQ(fmt::format("{:02x}", object.full_s64()),
+              fmt::format("{:02x}", object.full_s64().Get()));
+    EXPECT_EQ(fmt::format("{:02x}", object.regular_field_unsigned()),
+              fmt::format("{:02x}", object.regular_field_unsigned().Get()));
+    EXPECT_EQ(fmt::format("{:02x}", object.regular_field_unsigned2()),
+              fmt::format("{:02x}", object.regular_field_unsigned2().Get()));
+    EXPECT_EQ(fmt::format("{:02x}", object.regular_field_signed()),
+              fmt::format("{:02x}", object.regular_field_signed().Get()));
+    EXPECT_EQ(fmt::format("{:02x}", object.at_dword_boundary()),
+              fmt::format("{:02x}", object.at_dword_boundary().Get()));
+    EXPECT_EQ(fmt::format("{:02x}", object.signed_1bit()),
+              fmt::format("{:02x}", object.signed_1bit().Get()));
+    EXPECT_EQ(fmt::format("{:02x}", object.flag()), fmt::format("{:02x}", object.flag().Get()));
+    EXPECT_EQ(fmt::format("{:s}", object.enum_flag()),
+              fmt::format("{:s}", object.enum_flag().Get()));
+    EXPECT_EQ(fmt::format("{:s}", object.enum_1()), fmt::format("{:s}", object.enum_1().Get()));
+    EXPECT_EQ(fmt::format("{:s}", object.enum_2()), fmt::format("{:s}", object.enum_2().Get()));
+  }
+}
+
+struct TestStruct2
+{
+  u32 hex;
+
+  BFVIEW(u32, 2, 0, a)
+  BFVIEW(u32, 2, 2, b)
+  BFVIEW(u32, 2, 4, c)
+  BFVIEW(u32, 2, 0, arr, 3)  // array
+};
+
+TEST(BitFieldViewArray, Unsigned)
+{
+  TestStruct2 object{0};
+  const TestStruct2& objectc = object;
+
+  for (u32 value : object.arr())
+  {
+    EXPECT_EQ(value, 0u);
+  }
+
+  object.arr()[0] = 2;
+  EXPECT_EQ(object.arr()[0], 2u);
+  EXPECT_EQ(object.a(), 2u);
+  EXPECT_EQ(object.hex, 0b00'00'10u);
+
+  object.arr()[1] = 3;
+  EXPECT_EQ(object.arr()[1], 3u);
+  EXPECT_EQ(object.b(), 3u);
+  EXPECT_EQ(object.hex, 0b00'11'10u);
+
+  object.arr()[2] = object.arr()[1];
+  EXPECT_EQ(object.arr()[2], 3u);
+  EXPECT_EQ(object.c(), 3u);
+  EXPECT_EQ(object.hex, 0b11'11'10u);
+
+  object.arr()[1] = objectc.arr()[0];
+  EXPECT_EQ(object.arr()[1], 2u);
+  EXPECT_EQ(object.b(), 2u);
+  EXPECT_EQ(object.hex, 0b11'10'10u);
+
+  for (auto ref : object.arr())
+  {
+    ref = 1;
+  }
+  EXPECT_EQ(object.a(), 1u);
+  EXPECT_EQ(object.b(), 1u);
+  EXPECT_EQ(object.c(), 1u);
+  EXPECT_EQ(object.hex, 0b01'01'01u);
+
+  std::fill_n(object.arr().begin(), object.arr().size(), 3);
+  EXPECT_EQ(object.arr()[0], 3u);
+  EXPECT_EQ(object.arr()[1], 3u);
+  EXPECT_EQ(object.arr()[2], 3u);
+  EXPECT_EQ(object.hex, 0b11'11'11u);
+
+  for (u32 i = 0; i < object.arr().size(); i++)
+  {
+    object.arr()[i] = i;
+  }
+  EXPECT_EQ(object.hex, 0b10'01'00u);
+
+  EXPECT_EQ(objectc.arr()[0], 0u);
+  EXPECT_EQ(objectc.arr()[1], 1u);
+  EXPECT_EQ(objectc.arr()[2], 2u);
+
+  u32 counter = 0;
+  for (u32 value : objectc.arr())
+  {
+    EXPECT_EQ(value, counter);
+    counter++;
+  }
+
+  EXPECT_EQ("[0, 1, 2]", fmt::format("[{}]", fmt::join(object.arr(), ", ")));
+  EXPECT_EQ("[0b00, 0b01, 0b10]", fmt::format("[{:#04b}]", fmt::join(object.arr(), ", ")));
+}
+
+struct TestStruct3
+{
+  s32 hex;
+
+  BFVIEW(s32, 2, 5, a)
+  BFVIEW(s32, 2, 7, b)
+  BFVIEW(s32, 2, 9, c)
+  BFVIEW(s32, 2, 5, arr, 3)  // array
+};
+
+TEST(BitFieldViewArray, Signed)
+{
+  TestStruct3 object{0};
+  const TestStruct3& objectc = object;
+
+  for (s32 value : object.arr())
+  {
+    EXPECT_EQ(value, 0);
+  }
+
+  object.arr()[0] = -2;
+  EXPECT_EQ(object.arr()[0], -2);
+  EXPECT_EQ(object.a(), -2);
+  EXPECT_EQ(object.hex, 0b00'00'10'00000);
+
+  object.arr()[1] = -1;
+  EXPECT_EQ(object.arr()[1], -1);
+  EXPECT_EQ(object.b(), -1);
+  EXPECT_EQ(object.hex, 0b00'11'10'00000);
+
+  object.arr()[2] = object.arr()[1];
+  EXPECT_EQ(object.arr()[2], -1);
+  EXPECT_EQ(object.c(), -1);
+  EXPECT_EQ(object.hex, 0b11'11'10'00000);
+
+  object.arr()[1] = objectc.arr()[0];
+  EXPECT_EQ(object.arr()[1], -2);
+  EXPECT_EQ(object.b(), -2);
+  EXPECT_EQ(object.hex, 0b11'10'10'00000);
+
+  for (auto ref : object.arr())
+  {
+    ref = 1;
+  }
+  EXPECT_EQ(object.a(), 1);
+  EXPECT_EQ(object.b(), 1);
+  EXPECT_EQ(object.c(), 1);
+  EXPECT_EQ(object.hex, 0b01'01'01'00000);
+
+  std::fill_n(object.arr().begin(), object.arr().size(), -1);
+  EXPECT_EQ(object.arr()[0], -1);
+  EXPECT_EQ(object.arr()[1], -1);
+  EXPECT_EQ(object.arr()[2], -1);
+  EXPECT_EQ(object.hex, 0b11'11'11'00000);
+
+  for (u32 i = 0; i < object.arr().size(); i++)
+  {
+    object.arr()[i] = i;
+  }
+  EXPECT_EQ(object.hex, 0b10'01'00'00000);
+
+  EXPECT_EQ(objectc.arr()[0], 0);
+  EXPECT_EQ(objectc.arr()[1], 1);
+  EXPECT_EQ(objectc.arr()[2], -2);
+
+  u32 counter = 0;
+  for (s32 value : objectc.arr())
+  {
+    EXPECT_EQ(value, object.arr()[counter++]);
+  }
+
+  EXPECT_EQ("[0, 1, -2]", fmt::format("[{}]", fmt::join(object.arr(), ", ")));
+  EXPECT_EQ("[+0b00, +0b01, -0b10]", fmt::format("[{:+#05b}]", fmt::join(object.arr(), ", ")));
+}
+
+struct TestStruct4
+{
+  u64 hex;
+
+  BFVIEW(TestEnum, 2, 30, a)
+  BFVIEW(TestEnum, 2, 32, b)
+  BFVIEW(TestEnum, 2, 34, c)
+  BFVIEW(TestEnum, 2, 36, d)
+  BFVIEW(TestEnum, 2, 30, arr, 4)  // array
+};
+
+TEST(BitFieldViewArray, Enum)
+{
+  TestStruct4 object{0};
+  const TestStruct4& objectc = object;
+
+  for (TestEnum value : object.arr())
+  {
+    EXPECT_EQ(value, TestEnum::A);
+  }
+
+  object.arr()[0] = TestEnum::B;
+  EXPECT_EQ(object.arr()[0], TestEnum::B);
+  EXPECT_EQ(object.a(), TestEnum::B);
+  EXPECT_EQ(object.hex, 0b00'00'00'01ull << 30);
+
+  object.arr()[1] = TestEnum::C;
+  EXPECT_EQ(object.arr()[1], TestEnum::C);
+  EXPECT_EQ(object.b(), TestEnum::C);
+  EXPECT_EQ(object.hex, 0b00'00'10'01ull << 30);
+
+  object.arr()[2] = object.arr()[1];
+  EXPECT_EQ(object.arr()[2], TestEnum::C);
+  EXPECT_EQ(object.c(), TestEnum::C);
+  EXPECT_EQ(object.hex, 0b00'10'10'01ull << 30);
+
+  object.arr()[3] = objectc.arr()[0];
+  EXPECT_EQ(object.arr()[3], TestEnum::B);
+  EXPECT_EQ(object.d(), TestEnum::B);
+  EXPECT_EQ(object.hex, 0b01'10'10'01ull << 30);
+
+  for (auto ref : object.arr())
+  {
+    ref = TestEnum::D;
+  }
+  EXPECT_EQ(object.a(), TestEnum::D);
+  EXPECT_EQ(object.b(), TestEnum::D);
+  EXPECT_EQ(object.c(), TestEnum::D);
+  EXPECT_EQ(object.d(), TestEnum::D);
+  EXPECT_EQ(object.hex, 0b11'11'11'11ull << 30);
+
+  std::fill_n(object.arr().begin(), object.arr().size(), TestEnum::C);
+  EXPECT_EQ(object.a(), TestEnum::C);
+  EXPECT_EQ(object.b(), TestEnum::C);
+  EXPECT_EQ(object.c(), TestEnum::C);
+  EXPECT_EQ(object.d(), TestEnum::C);
+  EXPECT_EQ(object.hex, 0b10'10'10'10ull << 30);
+
+  for (u32 i = 0; i < object.arr().size(); i++)
+  {
+    object.arr()[i] = static_cast<TestEnum>(i);
+  }
+  EXPECT_EQ(object.hex, 0b11'10'01'00ull << 30);
+
+  EXPECT_EQ(objectc.arr()[0], TestEnum::A);
+  EXPECT_EQ(objectc.arr()[1], TestEnum::B);
+  EXPECT_EQ(objectc.arr()[2], TestEnum::C);
+  EXPECT_EQ(objectc.arr()[3], TestEnum::D);
+
+  u32 counter = 0;
+  for (TestEnum value : objectc.arr())
+  {
+    EXPECT_EQ(value, object.arr()[counter++]);
+  }
+
+  EXPECT_EQ("[A (0), B (1), C (2), D (3)]", fmt::format("[{}]", fmt::join(object.arr(), ", ")));
+  EXPECT_EQ("[0x0u /* A */, 0x1u /* B */, 0x2u /* C */, 0x3u /* D */]",
+            fmt::format("[{:s}]", fmt::join(object.arr(), ", ")));
+}
+
+// This is testing that the syntax-saving ScopedEnumBitFieldViewArray variants compile
+TEST(BitFieldViewArray, EnumVariant)
+{
+  using TestEnumUnderlying = std::underlying_type_t<TestEnum>;
+
+  for (u64 val : table)
+  {
+    TestStruct4 object{val};
+
+    [[maybe_unused]] TestEnumUnderlying temp0 = static_cast<TestEnumUnderlying>(object.arr()[0]);
+    [[maybe_unused]] TestEnumUnderlying temp1 = static_cast<TestEnumUnderlying>(object.arr()[1]);
+    [[maybe_unused]] TestEnumUnderlying temp2 = static_cast<TestEnumUnderlying>(object.arr()[2]);
+    [[maybe_unused]] TestEnumUnderlying temp3 = static_cast<TestEnumUnderlying>(object.arr()[3]);
+
+    for (const auto& view : object.arr())
+      [[maybe_unused]] TestEnumUnderlying temp = static_cast<TestEnumUnderlying>(view);
+  }
+}
+
+struct TestStruct5
+{
+  u64 hex;
+
+  BFVIEW(u8, 5, 0, arr1, 6)     // array
+  BFVIEW(bool, 1, 30, arr2, 4)  // array
+};
+
+TEST(BitFieldViewArray, StorageType)
+{
+  const u64 arr1_hex = 0b10000'01000'00100'00010'00001'00000;
+  const u64 arr2_hex_1 = 0b1010ull << 30;
+  const u64 arr2_hex_2 = 0b0101ull << 30;
+
+  TestStruct5 object{arr2_hex_1};
+  const TestStruct5& objectc = object;
+
+  EXPECT_FALSE(object.arr2()[0]);
+  EXPECT_TRUE(object.arr2()[1]);
+  EXPECT_FALSE(object.arr2()[2]);
+  EXPECT_TRUE(object.arr2()[3]);
+
+  object.arr1()[0] = 0;
+  object.arr1()[1] = 1;
+  object.arr1()[2] = 2;
+  object.arr1()[3] = 4;
+  object.arr1()[4] = 8;
+  object.arr1()[5] = 16;
+  EXPECT_EQ(object.hex, arr1_hex | arr2_hex_1);
+
+  object.arr2()[2] = object.arr2()[0] = true;
+  object.arr2()[3] = object.arr2()[1] = false;
+  EXPECT_EQ(object.hex, arr1_hex | arr2_hex_2);
+
+  object.arr2()[2] = object.arr2()[1];
+  object.arr2()[3] = objectc.arr2()[0];
+  const u64 arr2_hex_3 = 0b1001ull << 30;
+  EXPECT_EQ(object.hex, arr1_hex | arr2_hex_3);
+
+  u32 counter = 0;
+  for (u8 value : object.arr1())
+  {
+    EXPECT_EQ(value, object.arr1()[counter++]);
+  }
+  counter = 0;
+  for (bool value : object.arr2())
+  {
+    EXPECT_EQ(value, object.arr2()[counter++]);
+  }
+
+  counter = 0;
+  for (u8 value : objectc.arr1())
+  {
+    EXPECT_EQ(value, object.arr1()[counter++]);
+  }
+  counter = 0;
+  for (bool value : objectc.arr2())
+  {
+    EXPECT_EQ(value, object.arr2()[counter++]);
+  }
+}
+
+union TestStruct6
+{
+  float flt;
+  u32 hex;
+
+  BFVIEW_IN(flt, u32, 23, 0, mantissa)
+  BFVIEW_IN(flt, u8, 8, 23, exponent)
+  BFVIEW_IN(flt, bool, 1, 31, sign)
+};
+
+TEST(BitFieldViewArray, FloatHost)
+{
+  if (std::numeric_limits<float>::is_iec559)
+  {
+    TestStruct6 object1{0.0f};
+    EXPECT_EQ(0x00000000U, object1.hex);
+    EXPECT_EQ(false, object1.sign());
+    EXPECT_EQ(0, object1.exponent());
+    EXPECT_EQ(0, object1.mantissa());
+
+    TestStruct6 object2{-0.0f};
+    EXPECT_EQ(0x80000000U, object2.hex);
+    EXPECT_EQ(true, object2.sign());
+    EXPECT_EQ(0, object2.exponent());
+    EXPECT_EQ(0, object2.mantissa());
+
+    TestStruct6 object3{1.0f};
+    EXPECT_EQ(0x3f800000U, object3.hex);
+    EXPECT_EQ(false, object3.sign());
+    EXPECT_EQ(127U, object3.exponent());
+    EXPECT_EQ(0U, object3.mantissa());
+
+    TestStruct6 object4{std::numeric_limits<float>::max()};
+    EXPECT_EQ(0x7f7fffffU, object4.hex);
+    EXPECT_EQ(false, object4.sign());
+    EXPECT_EQ(254U, object4.exponent());
+    EXPECT_EQ(8388607U, object4.mantissa());
+
+    TestStruct6 object5{-1.83755838871002197265625f};
+    EXPECT_EQ(0xbfeb351dU, object5.hex);
+    EXPECT_EQ(true, object5.sign());
+    EXPECT_EQ(127U, object5.exponent());
+    EXPECT_EQ(7025949U, object5.mantissa());
+
+    TestStruct6 object6{0.075952999293804168701171875f};
+    EXPECT_EQ(0x3d9b8d3fU, object6.hex);
+    EXPECT_EQ(false, object6.sign());
+    EXPECT_EQ(123U, object6.exponent());
+    EXPECT_EQ(1805631U, object6.mantissa());
+  }
+}
+
+union TestStruct7
+{
+  double dbl;
+  u64 hex;
+
+  BFVIEW_IN(dbl, u64, 52, 0, mantissa)
+  BFVIEW_IN(dbl, u16, 11, 52, exponent)
+  BFVIEW_IN(dbl, bool, 1, 63, sign)
+};
+
+TEST(BitFieldViewArray, DoubleHost)
+{
+  if (std::numeric_limits<double>::is_iec559)
+  {
+    TestStruct7 object1{0.0};
+    EXPECT_EQ(0x0000000000000000U, object1.hex);
+    EXPECT_EQ(false, object1.sign());
+    EXPECT_EQ(0U, object1.exponent());
+    EXPECT_EQ(0U, object1.mantissa());
+
+    TestStruct7 object2{-0.0};
+    EXPECT_EQ(0x8000000000000000U, object2.hex);
+    EXPECT_EQ(true, object2.sign());
+    EXPECT_EQ(0U, object2.exponent());
+    EXPECT_EQ(0U, object2.mantissa());
+
+    TestStruct7 object3{1.0};
+    EXPECT_EQ(0x3ff0000000000000U, object3.hex);
+    EXPECT_EQ(false, object3.sign());
+    EXPECT_EQ(1023U, object3.exponent());
+    EXPECT_EQ(0U, object3.mantissa());
+
+    TestStruct7 object4{std::numeric_limits<double>::max()};
+    EXPECT_EQ(0x7fefffffffffffffU, object4.hex);
+    EXPECT_EQ(false, object4.sign());
+    EXPECT_EQ(2046U, object4.exponent());
+    EXPECT_EQ(4503599627370495U, object4.mantissa());
+
+    TestStruct7 object5{-1.83755838871};
+    EXPECT_EQ(0xbffd66a39fffff9dU, object5.hex);
+    EXPECT_EQ(true, object5.sign());
+    EXPECT_EQ(1023U, object5.exponent());
+    EXPECT_EQ(3772027647295389U, object5.mantissa());
+
+    TestStruct7 object6{0.0759529992938};
+    EXPECT_EQ(0x3fb371a7dffffed4U, object6.hex);
+    EXPECT_EQ(false, object6.sign());
+    EXPECT_EQ(1019U, object6.exponent());
+    EXPECT_EQ(969390761705172U, object6.mantissa());
+  }
+}
+
+struct TestStruct8
+{
+  u64 hex;
+
+  BFVIEW(u8, 4, 0, matrix2, 4, 4)  // 2-dimensional array
+};
+
+struct TestStruct9
+{
+  u64 hex;
+
+  BFVIEW(u8, 2, 0, matrix3, 2, 3, 4)  // 3-dimensional array
+};
+
+TEST(BitFieldViewArray, MultiDimensional)
+{
+  TestStruct8 object1{0};
+
+  object1.matrix2()[0][0] = 7u;
+  EXPECT_EQ(0b000000000000000000000000000000000000000000000000'0000'0000'0000'0111, object1.hex);
+  object1.matrix2()[0][1] = 5u;
+  EXPECT_EQ(0b000000000000000000000000000000000000000000000000'0000'0000'0101'0111, object1.hex);
+  object1.matrix2()[0][2] = 3u;
+  EXPECT_EQ(0b000000000000000000000000000000000000000000000000'0000'0011'0101'0111, object1.hex);
+  object1.matrix2()[0][3] = 2u;
+  EXPECT_EQ(0b000000000000000000000000000000000000000000000000'0010'0011'0101'0111, object1.hex);
+  object1.matrix2()[1][0] = 15u;
+  EXPECT_EQ(0b0000000000000000'0000000000000000'0000000000001111'0010001101010111, object1.hex);
+  object1.matrix2()[2][0] = 15u;
+  EXPECT_EQ(0b0000000000000000'0000000000001111'0000000000001111'0010001101010111, object1.hex);
+  object1.matrix2()[3][0] = 15u;
+  EXPECT_EQ(0b0000000000001111'0000000000001111'0000000000001111'0010001101010111, object1.hex);
+  object1.matrix2()[3][2] = 15u;
+  EXPECT_EQ(0b0000'1111'0000'1111'000000000000111100000000000011110010001101010111, object1.hex);
+
+  TestStruct9 object2{0};
+
+  object2.matrix3()[0][0][0] = 3u;
+  EXPECT_EQ(0b0000000000000000000000000000000000000000'00'00'00'11, object2.hex);
+  object2.matrix3()[0][0][3] = 3u;
+  EXPECT_EQ(0b0000000000000000000000000000000000000000'11'00'00'11, object2.hex);
+  object2.matrix3()[0][1][0] = 3u;
+  EXPECT_EQ(0b00000000000000000000000000000000'00000011'11000011, object2.hex);
+  object2.matrix3()[0][2][0] = 3u;
+  EXPECT_EQ(0b000000000000000000000000'00000011'0000001111000011, object2.hex);
+  object2.matrix3()[1][0][0] = 3u;
+  EXPECT_EQ(0b000000000000000000000011'000000110000001111000011, object2.hex);
+  object2.matrix3()[1][1][0] = 3u;
+  EXPECT_EQ(0b00000000'00000011'00000011000000110000001111000011, object2.hex);
+  object2.matrix3()[1][2][0] = 3u;
+  EXPECT_EQ(0b00000011'0000001100000011000000110000001111000011, object2.hex);
+}

--- a/Source/UnitTests/Common/BitFieldViewTest.cpp
+++ b/Source/UnitTests/Common/BitFieldViewTest.cpp
@@ -187,27 +187,19 @@ namespace test
 // idk why, but std::assignable_from doesn't work.
 template <class field_t, class LHS>
 concept assignable_from_bfview = requires(::Common::MutFixedBitFieldView<field_t, 1, 0, u64> mf_bfv,
-                                          ::Common::ConFixedBitFieldView<field_t, 1, 0, u64> cf_bfv,
                                           ::Common::MutLooseBitFieldView<field_t, 1, u64> ml_bfv,
-                                          ::Common::ConLooseBitFieldView<field_t, 1, u64> cl_bfv,
                                           LHS lhs)
 {
   lhs = mf_bfv;
-  lhs = cf_bfv;
   lhs = ml_bfv;
-  lhs = cl_bfv;
 };
 
 template <class field_t, class TYPE>
 concept explicit_cast_bfview = requires(::Common::MutFixedBitFieldView<field_t, 1, 0, u64> mf_bfv,
-                                        ::Common::ConFixedBitFieldView<field_t, 1, 0, u64> cf_bfv,
-                                        ::Common::MutLooseBitFieldView<field_t, 1, u64> ml_bfv,
-                                        ::Common::ConLooseBitFieldView<field_t, 1, u64> cl_bfv)
+                                        ::Common::MutLooseBitFieldView<field_t, 1, u64> ml_bfv)
 {
   static_cast<TYPE>(mf_bfv);
-  static_cast<TYPE>(cf_bfv);
   static_cast<TYPE>(ml_bfv);
-  static_cast<TYPE>(cl_bfv);
 };
 }  // namespace test
 

--- a/Source/UnitTests/Common/BitUtilsTest.cpp
+++ b/Source/UnitTests/Common/BitUtilsTest.cpp
@@ -40,21 +40,87 @@ TEST(BitUtils, ExtractBits)
   //       mangling the template function usages.
 
   constexpr s32 two_hundred_four_signed = 0b0011001100;
-  EXPECT_EQ((Common::ExtractBits<2, 3>(two_hundred_four_signed)), 3u);
-  EXPECT_EQ((Common::ExtractBits<2, 7>(two_hundred_four_signed)), 51u);
-  EXPECT_EQ((Common::ExtractBits<3, 6>(two_hundred_four_signed)), 9u);
+  EXPECT_EQ((Common::ExtractBitsU<2, 2>(two_hundred_four_signed)), 3u);
+  EXPECT_EQ((Common::ExtractBitsU<6, 2>(two_hundred_four_signed)), 51u);
+  EXPECT_EQ((Common::ExtractBitsU<4, 3>(two_hundred_four_signed)), 9u);
+  EXPECT_EQ((Common::ExtractBitsU<5, 5>(two_hundred_four_signed)), 6u);
+  EXPECT_EQ((Common::ExtractBitsS<2, 2>(two_hundred_four_signed)), -1);
+  EXPECT_EQ((Common::ExtractBitsS<6, 2>(two_hundred_four_signed)), -13);
+  EXPECT_EQ((Common::ExtractBitsS<4, 3>(two_hundred_four_signed)), -7);
+  EXPECT_EQ((Common::ExtractBitsS<5, 5>(two_hundred_four_signed)), 6);
 
   constexpr u32 two_hundred_four_unsigned = 0b0011001100;
-  EXPECT_EQ((Common::ExtractBits<2, 3>(two_hundred_four_unsigned)), 3u);
-  EXPECT_EQ((Common::ExtractBits<2, 7>(two_hundred_four_unsigned)), 51u);
-  EXPECT_EQ((Common::ExtractBits<3, 6>(two_hundred_four_unsigned)), 9u);
+  EXPECT_EQ((Common::ExtractBitsU<2, 2>(two_hundred_four_unsigned)), 3u);
+  EXPECT_EQ((Common::ExtractBitsU<6, 2>(two_hundred_four_unsigned)), 51u);
+  EXPECT_EQ((Common::ExtractBitsU<4, 3>(two_hundred_four_unsigned)), 9u);
+  EXPECT_EQ((Common::ExtractBitsU<5, 5>(two_hundred_four_unsigned)), 6u);
+  EXPECT_EQ((Common::ExtractBitsS<2, 2>(two_hundred_four_unsigned)), -1);
+  EXPECT_EQ((Common::ExtractBitsS<6, 2>(two_hundred_four_unsigned)), -13);
+  EXPECT_EQ((Common::ExtractBitsS<4, 3>(two_hundred_four_unsigned)), -7);
+  EXPECT_EQ((Common::ExtractBitsS<5, 5>(two_hundred_four_unsigned)), 6);
 
-  // Ensure bit extraction remains sign-independent even when signed types are used.
+  // Ensure the identity operation remains sign-independent.
   constexpr s32 negative_one = -1;
-  EXPECT_EQ((Common::ExtractBits<0, 31>(negative_one)), 0xFFFFFFFFU);
+  constexpr u32 unsigned_max = 0xFFFFFFFFU;
+  EXPECT_EQ((Common::ExtractBitsU<32, 0>(negative_one)), 0xFFFFFFFFU);
+  EXPECT_EQ((Common::ExtractBitsU<32, 0>(unsigned_max)), 0xFFFFFFFFU);
+  EXPECT_EQ((Common::ExtractBitsS<32, 0>(negative_one)), -1);
+  EXPECT_EQ((Common::ExtractBitsS<32, 0>(unsigned_max)), -1);
+}
 
-  // Ensure bit extraction with type overriding works as expected
-  EXPECT_EQ((Common::ExtractBits<0, 31, s32, s32>(negative_one)), -1);
+TEST(BitUtils, InsertBit)
+{
+  u32 host = 0;
+
+  Common::InsertBit<2>(host, true);
+  EXPECT_EQ(host, 0b0000000'1'00u);
+  Common::InsertBit<4>(host, true);
+  EXPECT_EQ(host, 0b00000'1'0100u);
+  Common::InsertBit<2>(host, true);  // true over true
+  EXPECT_EQ(host, 0b0000010'1'00u);
+  Common::InsertBit<2>(host, false);
+  EXPECT_EQ(host, 0b0000010'0'00u);
+  Common::InsertBit<4>(host, false);
+  EXPECT_EQ(host, 0b00000'0'0000u);
+  Common::InsertBit<2>(host, false);  // false over false
+  EXPECT_EQ(host, 0b0000000'0'00u);
+}
+
+TEST(BitUtils, InsertBits)
+{
+  u32 host;
+
+  host = 0;
+  // A typical field, a field larger than the value, and overwriting bits with 1s
+  Common::InsertBits<2, 2>(host, 3u);
+  EXPECT_EQ(host, 0b000000'11'00u);
+  Common::InsertBits<2 + 4, 2>(host, 3u);
+  EXPECT_EQ(host, 0b00'000011'00u);
+  Common::InsertBits<8, 1>(host, 255u);
+  EXPECT_EQ(host, 0b0'11111111'0u);
+
+  host = 0;
+  // Overflow by 1 (same as writing 0s)
+  Common::InsertBits<8, 1>(host, 256u);
+  EXPECT_EQ(host, 0b0'00000000'0u);
+
+  enum class TestEnum
+  {
+    A = 5,
+    B = 12,
+    C = -7,
+  };
+
+  host = 0;
+  // Negative value and enum values
+  Common::InsertBits<6, 1>(host, -7);
+  EXPECT_EQ(host, 0b000'111001'0u);
+  Common::InsertBits<6, 1>(host, TestEnum::A);
+  EXPECT_EQ(host, 0b000'000101'0u);
+  Common::InsertBits<6, 1>(host, TestEnum::B);
+  EXPECT_EQ(host, 0b000'001100'0u);
+  Common::InsertBits<6, 1>(host, TestEnum::C);
+  EXPECT_EQ(host, 0b000'111001'0u);
 }
 
 TEST(BitUtils, RotateLeft)
@@ -138,4 +204,40 @@ TEST(BitUtils, BitCast)
   EXPECT_EQ(0x8000000000000000ULL, Common::BitCast<u64>(-0.0));
   EXPECT_EQ(0x3FF0000000000000ULL, Common::BitCast<u64>(1.0));
   EXPECT_EQ(0xBFF0000000000000ULL, Common::BitCast<u64>(-1.0));
+}
+
+TEST(BitUtils, ShortCharLowMask)
+{
+  // Logical NOT takes place after integral promotion, but I didn't know that when I replaced
+  // std::numeric_limits<T>::max with ~T{0} (for unsigned types, of course).  To be absolutely
+  // certain low masks for short and char are never broken again, we shall check them all.
+
+  EXPECT_EQ(0b00000000, Common::CalcLowMaskSafe<u8>(0));
+  EXPECT_EQ(0b00000001, Common::CalcLowMaskSafe<u8>(1));
+  EXPECT_EQ(0b00000011, Common::CalcLowMaskSafe<u8>(2));
+  EXPECT_EQ(0b00000111, Common::CalcLowMaskSafe<u8>(3));
+  EXPECT_EQ(0b00001111, Common::CalcLowMaskSafe<u8>(4));
+  EXPECT_EQ(0b00011111, Common::CalcLowMaskSafe<u8>(5));
+  EXPECT_EQ(0b00111111, Common::CalcLowMaskSafe<u8>(6));
+  EXPECT_EQ(0b01111111, Common::CalcLowMaskSafe<u8>(7));
+  EXPECT_EQ(0b11111111, Common::CalcLowMaskSafe<u8>(8));
+
+  EXPECT_EQ(0b00000000'00000000, Common::CalcLowMaskSafe<u16>(0));
+  EXPECT_EQ(0b00000000'00000001, Common::CalcLowMaskSafe<u16>(1));
+  EXPECT_EQ(0b00000000'00000011, Common::CalcLowMaskSafe<u16>(2));
+  EXPECT_EQ(0b00000000'00000111, Common::CalcLowMaskSafe<u16>(3));
+  EXPECT_EQ(0b00000000'00001111, Common::CalcLowMaskSafe<u16>(4));
+  EXPECT_EQ(0b00000000'00011111, Common::CalcLowMaskSafe<u16>(5));
+  EXPECT_EQ(0b00000000'00111111, Common::CalcLowMaskSafe<u16>(6));
+  EXPECT_EQ(0b00000000'01111111, Common::CalcLowMaskSafe<u16>(7));
+  EXPECT_EQ(0b00000000'11111111, Common::CalcLowMaskSafe<u16>(8));
+
+  EXPECT_EQ(0b00000001'11111111, Common::CalcLowMaskSafe<u16>(9));
+  EXPECT_EQ(0b00000011'11111111, Common::CalcLowMaskSafe<u16>(10));
+  EXPECT_EQ(0b00000111'11111111, Common::CalcLowMaskSafe<u16>(11));
+  EXPECT_EQ(0b00001111'11111111, Common::CalcLowMaskSafe<u16>(12));
+  EXPECT_EQ(0b00011111'11111111, Common::CalcLowMaskSafe<u16>(13));
+  EXPECT_EQ(0b00111111'11111111, Common::CalcLowMaskSafe<u16>(14));
+  EXPECT_EQ(0b01111111'11111111, Common::CalcLowMaskSafe<u16>(15));
+  EXPECT_EQ(0b11111111'11111111, Common::CalcLowMaskSafe<u16>(16));
 }

--- a/Source/UnitTests/Common/CMakeLists.txt
+++ b/Source/UnitTests/Common/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_dolphin_test(BitFieldTest BitFieldTest.cpp)
+add_dolphin_test(BitFieldViewTest BitFieldViewTest.cpp)
 add_dolphin_test(BitSetTest BitSetTest.cpp)
 add_dolphin_test(BitUtilsTest BitUtilsTest.cpp)
 add_dolphin_test(BlockingLoopTest BlockingLoopTest.cpp)


### PR DESCRIPTION
BitFieldView.h is a C++23-ish library which supersedes C bit structs and Dolphin's former BitField.h library.  This commit serves as a base for upcoming pull requests which eradicate the aforementioned methods of handling bitfields.  It includes BitFieldView.h, its unit test, an update to specializations of EnumMap, and CMakeLists housekeeping.  This library was originally developed in PR #10610.