### PR TITLE
InputCommon: Get rid of static strings.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -293,7 +293,7 @@ std::string Joystick::Axis::GetName() const
 
 std::string Joystick::Hat::GetName() const
 {
-  static char tmpstr[] = "Hat . .";
+  char tmpstr[] = "Hat . .";
   tmpstr[4] = (char)('0' + m_index);
   tmpstr[6] = "NESW"[m_direction];
   return tmpstr;

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -275,7 +275,7 @@ std::string KeyboardMouse::Button::GetName() const
 
 std::string KeyboardMouse::Axis::GetName() const
 {
-  static char tmpstr[] = "Axis ..";
+  char tmpstr[] = "Axis ..";
   tmpstr[5] = (char)('X' + m_index);
   tmpstr[6] = (m_range < 0 ? '-' : '+');
   return tmpstr;
@@ -283,7 +283,7 @@ std::string KeyboardMouse::Axis::GetName() const
 
 std::string KeyboardMouse::Cursor::GetName() const
 {
-  static char tmpstr[] = "Cursor ..";
+  char tmpstr[] = "Cursor ..";
   tmpstr[7] = (char)('X' + m_index);
   tmpstr[8] = (m_positive ? '+' : '-');
   return tmpstr;

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -226,7 +226,7 @@ ControlState KeyboardAndMouse::Button::GetState() const
 
 std::string KeyboardAndMouse::Cursor::GetName() const
 {
-  static char tmpstr[] = "Cursor ..";
+  char tmpstr[] = "Cursor ..";
   tmpstr[7] = (char)('X' + m_index);
   tmpstr[8] = (m_positive ? '+' : '-');
   return tmpstr;


### PR DESCRIPTION
This is both unnecessary and not threadsafe.