### PR TITLE
VideoCommon: Increase uniform stream buffer size to 64mb

### DIFF
--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -90,7 +90,7 @@ public:
   // Texel buffer will fit the maximum size of an encoded GX texture. 1024x1024, RGBA8 = 4MB.
   static constexpr u32 VERTEX_STREAM_BUFFER_SIZE = 48 * 1024 * 1024;
   static constexpr u32 INDEX_STREAM_BUFFER_SIZE = 8 * 1024 * 1024;
-  static constexpr u32 UNIFORM_STREAM_BUFFER_SIZE = 32 * 1024 * 1024;
+  static constexpr u32 UNIFORM_STREAM_BUFFER_SIZE = 64 * 1024 * 1024;
   static constexpr u32 TEXEL_STREAM_BUFFER_SIZE = 16 * 1024 * 1024;
 
   VertexManagerBase();


### PR DESCRIPTION
Densha de GO! Shinkansen EX uses 27mb per frame, and we want enough space for the CPU to be encoding one frame while the GPU is rendering the previous

Increases frame rate for Vulkan and DX12

In the scene mentioned on https://bugs.dolphin-emu.org/issues/12920
Vulkan (i7-4980HQ, GT 750M) 22fps → 35fps
Similar improvements on an AMD Radeon Pro 5600M but I'm too lazy to boot into Windows for an exact measurement right now