### PR TITLE
VolumeVerifier: Ignore case when looking for IOS on update partition

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -640,10 +640,12 @@ bool VolumeVerifier::CheckPartition(const Partition& partition)
       {
         const std::string ios_ver_str = std::to_string(ios_ver);
         const std::string correct_ios =
-            IsDebugSigned() ? ("firmware.64." + ios_ver_str + ".") : ("IOS" + ios_ver_str + "-");
+            IsDebugSigned() ? ("firmware.64." + ios_ver_str + ".") : ("ios" + ios_ver_str + "-");
         for (const FileInfo& f : *file_info)
         {
-          if (StringBeginsWith(f.GetName(), correct_ios))
+          std::string file_name = f.GetName();
+          Common::ToLower(&file_name);
+          if (StringBeginsWith(file_name, correct_ios))
           {
             has_correct_ios = true;
             break;


### PR DESCRIPTION
One of the Dragon Quest X expansions (S4SJGD) uses lowercase instead of the usual uppercase for the IOS59 file on its update partition.