### PR TITLE
Fix OpenGL error on M1 Mac.

### DIFF
--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -182,7 +182,7 @@ static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, A
                "                         dot(u_const, float4(texcol_raw.rgb, 256)),\n"
                "                         dot(v_const, float4(texcol_raw.rgb, 256)));\n"
                "  // Divide by 256 and round .5 and higher up\n"
-               "  texcol_raw.rgb = (texcol_raw.rgb >> 8) + ((texcol_raw.rgb >> 7) & 1);\n");
+               "  texcol_raw.rgb = (texcol_raw.rgb >> 8) + ((texcol_raw.rgb >> 7) & 1u);\n");
   }
 
   code.Write("  return float4(texcol_raw) / 255.0;\n");

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -161,7 +161,7 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
               "                         dot(u_const, float4(texcol_raw.rgb, 256)),\n"
               "                         dot(v_const, float4(texcol_raw.rgb, 256)));\n"
               "  // Divide by 256 and round .5 and higher up\n"
-              "  texcol_raw.rgb = (texcol_raw.rgb >> 8) + ((texcol_raw.rgb >> 7) & 1);\n");
+              "  texcol_raw.rgb = (texcol_raw.rgb >> 8) + ((texcol_raw.rgb >> 7) & 1u);\n");
   }
 
   switch (uid_data->dst_format)


### PR DESCRIPTION
Followup to #10466. Resolves the following error:

ERROR: 0:85: '&' does not operate on 'uvec3' and ‘int'

This is @tellowkrinkle’s fix.