### PR TITLE
Convert CP/XF matrix indices mismatch panic alert to a warning

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -325,11 +325,11 @@ static void CheckCPConfiguration(int vtx_attr_group)
   if (g_main_cp_state.matrix_index_a.Hex != xfmem.MatrixIndexA.Hex ||
       g_main_cp_state.matrix_index_b.Hex != xfmem.MatrixIndexB.Hex)
   {
-    PanicAlertFmt("Mismatched matrix index configuration between CP and XF stages - "
-                  "index A: {:08x}/{:08x}, index B {:08x}/{:08x}. "
-                  "Please report on the issue tracker.",
-                  g_main_cp_state.matrix_index_a.Hex, xfmem.MatrixIndexA.Hex,
-                  g_main_cp_state.matrix_index_b.Hex, xfmem.MatrixIndexB.Hex);
+    WARN_LOG_FMT(VIDEO,
+                 "Mismatched matrix index configuration between CP and XF stages - "
+                 "index A: {:08x}/{:08x}, index B {:08x}/{:08x}.",
+                 g_main_cp_state.matrix_index_a.Hex, xfmem.MatrixIndexA.Hex,
+                 g_main_cp_state.matrix_index_b.Hex, xfmem.MatrixIndexB.Hex);
     DolphinAnalytics::Instance().ReportGameQuirk(
         GameQuirk::MISMATCHED_GPU_MATRIX_INDICES_BETWEEN_CP_AND_XF);
   }


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/12977 indicates that this happens on startup of Spider-Man 2, even in single-core. I don't have the game, so I can't directly determine why this is happening, but presumably real hardware does not hang in this case, so we can make it less obtrusive.