### PR TITLE
VideoCommon: Fix IsDualSrc check for dst blend factors

### DIFF
--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -32,16 +32,7 @@ static bool IsDualSrc(SrcBlendFactor factor)
 
 static bool IsDualSrc(DstBlendFactor factor)
 {
-  switch (factor)
-  {
-  case DstBlendFactor::SrcClr:
-  case DstBlendFactor::SrcAlpha:
-  case DstBlendFactor::InvSrcClr:
-  case DstBlendFactor::InvSrcAlpha:
-    return true;
-  default:
-    return false;
-  }
+  return factor == DstBlendFactor::SrcAlpha || factor == DstBlendFactor::InvSrcAlpha;
 }
 
 bool BlendingState::RequiresDualSrc() const


### PR DESCRIPTION
Small fix for #10747

We don't use dual source blend for SrcColor and InvSrcColor, only SrcAlpha and InvSrcAlpha.

Fixes gpus using the `BUG_BROKEN_DUAL_SOURCE_BLENDING` bug on games that draw using `SrcColor` as a blend factor without using any of the SrcAlpha-based factors.

Found this after I made the same mistake in the Metal renderer.  Don't know what games it affects (if any), as the game that broke in Metal (Mario Sunshine) also used Src1Alpha as its SrcBlendFactor (and therefore wouldn't be affected here).