### PR TITLE
Support Right-to-Left layouts

### DIFF
--- a/Source/Core/DolphinQt/Translation.cpp
+++ b/Source/Core/DolphinQt/Translation.cpp
@@ -294,6 +294,7 @@ static bool TryInstallTranslator(const QString& exact_language_code)
 
       QLocale::setDefault(QLocale(exact_language_code));
       UICommon::SetLocale(exact_language_code.toStdString());
+      QApplication::setLayoutDirection(QLocale(exact_language_code).textDirection());
 
       return true;
     }


### PR DESCRIPTION
Qt does this all automatically, we just need to hook it up.

I'm not an expert in localisation, but I assume this is what users of right-to-left languages want. 

## Before:
![image](https://user-images.githubusercontent.com/138484/179461488-5a7e08c3-3312-443d-83c7-f62e0e865f43.png)

![image](https://user-images.githubusercontent.com/138484/179461606-7672504e-57ec-4f66-96b4-ee13f1588280.png)


## After:

![image](https://user-images.githubusercontent.com/138484/179461362-b091524c-bd57-412e-8149-9f4223d9cb7b.png)

![image](https://user-images.githubusercontent.com/138484/179461763-6526d89a-670c-446d-9f23-db87aaee02b7.png)

