### PR TITLE
IOS: Add IOSC::KeyEntry::misc_data to savestate.

### DIFF
--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -649,6 +649,7 @@ void IOSC::KeyEntry::DoState(PointerWrap& p)
   p.Do(type);
   p.Do(subtype);
   p.Do(data);
+  p.Do(misc_data);
   p.Do(owner_mask);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static std::recursive_mutex g_save_thread_mutex;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 144;  // Last changed in PR 10762
+constexpr u32 STATE_VERSION = 145;  // Last changed in PR 10879
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
See https://github.com/dolphin-emu/dolphin/commit/1f4ddea5f711a11df931d19f5b5d65264f8653a9#commitcomment-78962594