### PR TITLE
Metal: Prevent usage of macOS-only APIs on non-macOS platforms

### DIFF
--- a/Source/Core/VideoBackends/Metal/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Metal/CMakeLists.txt
@@ -35,6 +35,7 @@ PUBLIC
   videocommon
 PRIVATE
   spirv_cross
+  ${FOUNDATION_LIBRARY}
   ${METAL_LIBRARY}
   ${QUARTZCORE_LIBRARY}
 )

--- a/Source/Core/VideoBackends/Metal/MTLMain.mm
+++ b/Source/Core/VideoBackends/Metal/MTLMain.mm
@@ -3,7 +3,10 @@
 
 #include "VideoBackends/Metal/VideoBackend.h"
 
+#if TARGET_OS_OSX
 #include <AppKit/AppKit.h>
+#endif
+
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h>
 
@@ -156,6 +159,7 @@ void Metal::VideoBackend::InitBackendInfo()
 
 void Metal::VideoBackend::PrepareWindow(WindowSystemInfo& wsi)
 {
+#if TARGET_OS_OSX
   if (wsi.type != WindowSystemType::MacOS)
     return;
   NSView* view = static_cast<NSView*>(wsi.render_surface);
@@ -163,4 +167,5 @@ void Metal::VideoBackend::PrepareWindow(WindowSystemInfo& wsi)
   [view setWantsLayer:YES];
   [view setLayer:layer];
   wsi.render_surface = layer;
+#endif
 }

--- a/Source/Core/VideoBackends/Metal/MTLMain.mm
+++ b/Source/Core/VideoBackends/Metal/MTLMain.mm
@@ -3,6 +3,9 @@
 
 #include "VideoBackends/Metal/VideoBackend.h"
 
+// This must be included before we use any TARGET_OS_* macros.
+#include <TargetConditionals.h>
+
 #if TARGET_OS_OSX
 #include <AppKit/AppKit.h>
 #endif

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -22,12 +22,15 @@ std::vector<MRCOwned<id<MTLDevice>>> Metal::Util::GetAdapterList()
   if (default_dev)
     list.push_back(MRCTransfer(default_dev));
 
+#if TARGET_OS_OSX
   auto devices = MRCTransfer(MTLCopyAllDevices());
   for (id<MTLDevice> device in devices.Get())
   {
     if (device != default_dev)
       list.push_back(MRCRetain(device));
   }
+#endif
+
   return list;
 }
 

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -241,13 +241,17 @@ AbstractTextureFormat Metal::Util::ToAbstract(MTLPixelFormat format)
   {
   case MTLPixelFormatRGBA8Unorm:            return AbstractTextureFormat::RGBA8;
   case MTLPixelFormatBGRA8Unorm:            return AbstractTextureFormat::BGRA8;
+#if TARGET_OS_OSX
   case MTLPixelFormatBC1_RGBA:              return AbstractTextureFormat::DXT1;
   case MTLPixelFormatBC2_RGBA:              return AbstractTextureFormat::DXT3;
   case MTLPixelFormatBC3_RGBA:              return AbstractTextureFormat::DXT5;
   case MTLPixelFormatBC7_RGBAUnorm:         return AbstractTextureFormat::BPTC;
+#endif
   case MTLPixelFormatR16Unorm:              return AbstractTextureFormat::R16;
   case MTLPixelFormatDepth16Unorm:          return AbstractTextureFormat::D16;
+#if TARGET_OS_OSX
   case MTLPixelFormatDepth24Unorm_Stencil8: return AbstractTextureFormat::D24_S8;
+#endif
   case MTLPixelFormatR32Float:              return AbstractTextureFormat::R32F;
   case MTLPixelFormatDepth32Float:          return AbstractTextureFormat::D32F;
   case MTLPixelFormatDepth32Float_Stencil8: return AbstractTextureFormat::D32F_S8;
@@ -261,17 +265,21 @@ MTLPixelFormat Metal::Util::FromAbstract(AbstractTextureFormat format)
   {
   case AbstractTextureFormat::RGBA8:     return MTLPixelFormatRGBA8Unorm;
   case AbstractTextureFormat::BGRA8:     return MTLPixelFormatBGRA8Unorm;
+#if TARGET_OS_OSX
   case AbstractTextureFormat::DXT1:      return MTLPixelFormatBC1_RGBA;
   case AbstractTextureFormat::DXT3:      return MTLPixelFormatBC2_RGBA;
   case AbstractTextureFormat::DXT5:      return MTLPixelFormatBC3_RGBA;
   case AbstractTextureFormat::BPTC:      return MTLPixelFormatBC7_RGBAUnorm;
+#endif
   case AbstractTextureFormat::R16:       return MTLPixelFormatR16Unorm;
   case AbstractTextureFormat::D16:       return MTLPixelFormatDepth16Unorm;
+#if TARGET_OS_OSX
   case AbstractTextureFormat::D24_S8:    return MTLPixelFormatDepth24Unorm_Stencil8;
+#endif
   case AbstractTextureFormat::R32F:      return MTLPixelFormatR32Float;
   case AbstractTextureFormat::D32F:      return MTLPixelFormatDepth32Float;
   case AbstractTextureFormat::D32F_S8:   return MTLPixelFormatDepth32Float_Stencil8;
-  case AbstractTextureFormat::Undefined: return MTLPixelFormatInvalid;
+  default:                               return MTLPixelFormatInvalid;
   }
 }
 

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <string>
 
+#include <TargetConditionals.h>
 #include <spirv_msl.hpp>
 
 #include "Common/MsgHandler.h"


### PR DESCRIPTION
In the spirit of keeping the differences between my iOS fork and upstream minimal (and since the Metal backend already has support for iOS), here's a bunch of changes to make sure Metal APIs that are unavailable on non-macOS platforms are not used when targeting non-macOS.