### PR TITLE
VideoCommon: Add vertex shader point/line expansion

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -84,6 +84,8 @@ const Info<int> GFX_SHADER_PRECOMPILER_THREADS{
     {System::GFX, "Settings", "ShaderPrecompilerThreads"}, -1};
 const Info<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE{
     {System::GFX, "Settings", "SaveTextureCacheToState"}, true};
+const Info<bool> GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION{
+    {System::GFX, "Settings", "PreferVSForLinePointExpansion"}, false};
 
 const Info<bool> GFX_SW_DUMP_OBJECTS{{System::GFX, "Settings", "SWDumpObjects"}, false};
 const Info<bool> GFX_SW_DUMP_TEV_STAGES{{System::GFX, "Settings", "SWDumpTevStages"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -73,6 +73,7 @@ extern const Info<ShaderCompilationMode> GFX_SHADER_COMPILATION_MODE;
 extern const Info<int> GFX_SHADER_COMPILER_THREADS;
 extern const Info<int> GFX_SHADER_PRECOMPILER_THREADS;
 extern const Info<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE;
+extern const Info<bool> GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION;
 
 extern const Info<bool> GFX_SW_DUMP_OBJECTS;
 extern const Info<bool> GFX_SW_DUMP_TEV_STAGES;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -94,7 +94,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 154;  // Last changed in PR 11177
+constexpr u32 STATE_VERSION = 155;  // Last changed in PR 10890
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -202,7 +202,6 @@ void AdvancedWidget::OnBackendChanged()
 {
   m_backend_multithreading->setEnabled(g_Config.backend_info.bSupportsMultithreading);
   m_prefer_vs_for_point_line_expansion->setEnabled(
-      Core::GetState() == Core::State::Uninitialized &&
       g_Config.backend_info.bSupportsGeometryShaders &&
       g_Config.backend_info.bSupportsVSLinePointExpand);
   AddDescriptions();
@@ -211,10 +210,6 @@ void AdvancedWidget::OnBackendChanged()
 void AdvancedWidget::OnEmulationStateChanged(bool running)
 {
   m_enable_prog_scan->setEnabled(!running);
-  m_prefer_vs_for_point_line_expansion->setEnabled(
-      !running &&
-      g_Config.backend_info.bSupportsGeometryShaders &&
-      g_Config.backend_info.bSupportsVSLinePointExpand);
 }
 
 void AdvancedWidget::AddDescriptions()

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -205,6 +205,7 @@ void AdvancedWidget::OnBackendChanged()
       Core::GetState() == Core::State::Uninitialized &&
       g_Config.backend_info.bSupportsGeometryShaders &&
       g_Config.backend_info.bSupportsVSLinePointExpand);
+  AddDescriptions();
 }
 
 void AdvancedWidget::OnEmulationStateChanged(bool running)
@@ -304,7 +305,7 @@ void AdvancedWidget::AddDescriptions()
       QT_TR_NOOP("On backends that support both using the geometry shader and the vertex shader "
                  "for expanding points and lines, selects the vertex shader for the job.  May "
                  "affect performance."
-                 "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+                 "<br><br>%1");
   static const char TR_DEFER_EFB_ACCESS_INVALIDATION_DESCRIPTION[] = QT_TR_NOOP(
       "Defers invalidation of the EFB access cache until a GPU synchronization command "
       "is executed. If disabled, the cache will be invalidated with every draw call. "
@@ -332,6 +333,9 @@ void AdvancedWidget::AddDescriptions()
       "unchecked.</dolphin_emphasis>");
 #endif
 
+  static const char IF_UNSURE_UNCHECKED[] =
+      QT_TR_NOOP("<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+
   m_enable_wireframe->SetDescription(tr(TR_WIREFRAME_DESCRIPTION));
   m_show_statistics->SetDescription(tr(TR_SHOW_STATS_DESCRIPTION));
   m_enable_format_overlay->SetDescription(tr(TR_TEXTURE_FORMAT_DESCRIPTION));
@@ -353,8 +357,17 @@ void AdvancedWidget::AddDescriptions()
   m_enable_cropping->SetDescription(tr(TR_CROPPING_DESCRIPTION));
   m_enable_prog_scan->SetDescription(tr(TR_PROGRESSIVE_SCAN_DESCRIPTION));
   m_backend_multithreading->SetDescription(tr(TR_BACKEND_MULTITHREADING_DESCRIPTION));
+  QString vsexpand_extra;
+  if (!g_Config.backend_info.bSupportsGeometryShaders)
+    vsexpand_extra = tr("Forced on because %1 doesn't support geometry shaders.")
+                         .arg(tr(g_Config.backend_info.DisplayName.c_str()));
+  else if (!g_Config.backend_info.bSupportsVSLinePointExpand)
+    vsexpand_extra = tr("Forced off because %1 doesn't support VS expansion.")
+                         .arg(tr(g_Config.backend_info.DisplayName.c_str()));
+  else
+    vsexpand_extra = tr(IF_UNSURE_UNCHECKED);
   m_prefer_vs_for_point_line_expansion->SetDescription(
-      tr(TR_PREFER_VS_FOR_POINT_LINE_EXPANSION_DESCRIPTION));
+      tr(TR_PREFER_VS_FOR_POINT_LINE_EXPANSION_DESCRIPTION).arg(vsexpand_extra));
 #ifdef _WIN32
   m_borderless_fullscreen->SetDescription(tr(TR_BORDERLESS_FULLSCREEN_DESCRIPTION));
 #endif

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -59,6 +59,7 @@ private:
   GraphicsBool* m_enable_cropping;
   ToolTipCheckBox* m_enable_prog_scan;
   GraphicsBool* m_backend_multithreading;
+  GraphicsBool* m_prefer_vs_for_point_line_expansion;
   GraphicsBool* m_borderless_fullscreen;
 
   // Experimental

--- a/Source/Core/VideoBackends/D3D12/DX12Context.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Context.cpp
@@ -358,7 +358,7 @@ bool DXContext::CreateGXRootSignature()
   SetRootParamTable(&params[param_count], &ranges[param_count], D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3,
                     1, D3D12_SHADER_VISIBILITY_VERTEX);
   param_count++;
-  SetRootParamConstant(&params[param_count], 2, 1, D3D12_SHADER_VISIBILITY_VERTEX);
+  SetRootParamConstant(&params[param_count], 3, 1, D3D12_SHADER_VISIBILITY_VERTEX);
   param_count++;
 
   // Since these must be contiguous, pixel lighting goes to bbox if not enabled.

--- a/Source/Core/VideoBackends/D3D12/DX12Context.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Context.cpp
@@ -353,7 +353,10 @@ bool DXContext::CreateGXRootSignature()
   param_count++;
   SetRootParamCBV(&params[param_count], 1, D3D12_SHADER_VISIBILITY_VERTEX);
   param_count++;
-  SetRootParamCBV(&params[param_count], 0, D3D12_SHADER_VISIBILITY_GEOMETRY);
+  if (g_ActiveConfig.UseVSForLinePointExpand())
+    SetRootParamCBV(&params[param_count], 2, D3D12_SHADER_VISIBILITY_VERTEX);
+  else
+    SetRootParamCBV(&params[param_count], 0, D3D12_SHADER_VISIBILITY_GEOMETRY);
   param_count++;
   SetRootParamTable(&params[param_count], &ranges[param_count], D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3,
                     1, D3D12_SHADER_VISIBILITY_VERTEX);

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -88,6 +88,7 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsSettingObjectNames = true;
   g_Config.backend_info.bSupportsPartialMultisampleResolve = true;
   g_Config.backend_info.bSupportsDynamicVertexLoader = true;
+  g_Config.backend_info.bSupportsVSLinePointExpand = true;
 
   // We can only check texture support once we have a device.
   if (g_dx_context)

--- a/Source/Core/VideoBackends/Metal/MTLStateTracker.h
+++ b/Source/Core/VideoBackends/Metal/MTLStateTracker.h
@@ -83,7 +83,7 @@ public:
   void SetTexture(u32 idx, id<MTLTexture> texture);
   void SetSampler(u32 idx, const SamplerState& sampler);
   void SetComputeTexture(const Texture* texture);
-  void InvalidateUniforms(bool vertex, bool fragment);
+  void InvalidateUniforms(bool vertex, bool geometry, bool fragment);
   void SetUtilityUniform(const void* buffer, size_t size);
   void SetTexelBuffer(id<MTLBuffer> buffer, u32 offset0, u32 offset1);
   void SetVerticesAndIndices(id<MTLBuffer> vertices, id<MTLBuffer> indices);
@@ -180,6 +180,7 @@ private:
     {
       // clang-format off
       bool has_gx_vs_uniform      : 1;
+      bool has_gx_gs_uniform      : 1;
       bool has_gx_ps_uniform      : 1;
       bool has_utility_vs_uniform : 1;
       bool has_utility_ps_uniform : 1;

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -75,6 +75,7 @@ void Metal::Util::PopulateBackendInfo(VideoConfig* config)
   // Metal requires multisample resolve to be done on a render pass
   config->backend_info.bSupportsPartialMultisampleResolve = false;
   config->backend_info.bSupportsDynamicVertexLoader = true;
+  config->backend_info.bSupportsVSLinePointExpand = true;
 }
 
 void Metal::Util::PopulateBackendInfoAdapters(VideoConfig* config,
@@ -427,6 +428,7 @@ std::optional<std::string> Metal::Util::TranslateShaderToMSL(ShaderStage stage,
   static const spirv_cross::MSLResourceBinding resource_bindings[] = {
       MakeResourceBinding(spv::ExecutionModelVertex,    0, 0, 1, 0, 0), // vs/ubo
       MakeResourceBinding(spv::ExecutionModelVertex,    0, 1, 1, 0, 0), // vs/ubo
+      MakeResourceBinding(spv::ExecutionModelVertex,    0, 2, 2, 0, 0), // vs/ubo
       MakeResourceBinding(spv::ExecutionModelVertex,    2, 1, 0, 0, 0), // vs/ssbo
       MakeResourceBinding(spv::ExecutionModelFragment,  0, 0, 0, 0, 0), // vs/ubo
       MakeResourceBinding(spv::ExecutionModelFragment,  0, 1, 1, 0, 0), // vs/ubo

--- a/Source/Core/VideoBackends/Metal/MTLVertexManager.mm
+++ b/Source/Core/VideoBackends/Metal/MTLVertexManager.mm
@@ -5,6 +5,7 @@
 
 #include "VideoBackends/Metal/MTLStateTracker.h"
 
+#include "VideoCommon/GeometryShaderManager.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexShaderManager.h"
@@ -88,7 +89,9 @@ void Metal::VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32
 
 void Metal::VertexManager::UploadUniforms()
 {
-  g_state_tracker->InvalidateUniforms(VertexShaderManager::dirty, PixelShaderManager::dirty);
+  g_state_tracker->InvalidateUniforms(VertexShaderManager::dirty, GeometryShaderManager::dirty,
+                                      PixelShaderManager::dirty);
   VertexShaderManager::dirty = false;
+  GeometryShaderManager::dirty = false;
   PixelShaderManager::dirty = false;
 }

--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -423,6 +423,8 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
       ((GLExtensions::Version() >= 310) || GLExtensions::Supports("GL_NV_primitive_restart"));
   g_Config.backend_info.bSupportsFragmentStoresAndAtomics =
       GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
+  g_Config.backend_info.bSupportsVSLinePointExpand =
+      GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
   g_Config.backend_info.bSupportsGSInstancing = GLExtensions::Supports("GL_ARB_gpu_shader5");
   g_Config.backend_info.bSupportsSSAA = GLExtensions::Supports("GL_ARB_gpu_shader5") &&
                                         GLExtensions::Supports("GL_ARB_sample_shading");

--- a/Source/Core/VideoBackends/OGL/OGLVertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLVertexManager.cpp
@@ -58,6 +58,11 @@ bool VertexManager::Initialize()
 
   m_vertex_buffer = StreamBuffer::Create(GL_ARRAY_BUFFER, VERTEX_STREAM_BUFFER_SIZE);
   m_index_buffer = StreamBuffer::Create(GL_ELEMENT_ARRAY_BUFFER, INDEX_STREAM_BUFFER_SIZE);
+  if (g_ActiveConfig.UseVSForLinePointExpand() ||
+      g_ActiveConfig.backend_info.bSupportsDynamicVertexLoader)
+  {
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, m_vertex_buffer->GetGLBufferId());
+  }
 
   if (g_ActiveConfig.backend_info.bSupportsPaletteConversion)
   {

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -156,9 +156,11 @@ bool ObjectCache::CreateDescriptorSetLayouts()
       {5, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT},
   }};
 
+  std::array<VkDescriptorSetLayoutBinding, 3> ubo_bindings = standard_ubo_bindings;
+
   std::array<VkDescriptorSetLayoutCreateInfo, NUM_DESCRIPTOR_SET_LAYOUTS> create_infos{{
       {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr, 0,
-       static_cast<u32>(standard_ubo_bindings.size()), standard_ubo_bindings.data()},
+       static_cast<u32>(ubo_bindings.size()), ubo_bindings.data()},
       {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr, 0,
        static_cast<u32>(standard_sampler_bindings.size()), standard_sampler_bindings.data()},
       {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr, 0,
@@ -172,8 +174,17 @@ bool ObjectCache::CreateDescriptorSetLayouts()
   }};
 
   // Don't set the GS bit if geometry shaders aren't available.
-  if (!g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+  if (g_ActiveConfig.UseVSForLinePointExpand())
+  {
+    if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+      ubo_bindings[UBO_DESCRIPTOR_SET_BINDING_GS].stageFlags |= VK_SHADER_STAGE_VERTEX_BIT;
+    else
+      ubo_bindings[UBO_DESCRIPTOR_SET_BINDING_GS].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+  }
+  else if (!g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+  {
     create_infos[DESCRIPTOR_SET_LAYOUT_STANDARD_UNIFORM_BUFFERS].bindingCount--;
+  }
 
   // Remove the dynamic vertex loader's buffer if it'll never be needed
   if (!g_ActiveConfig.backend_info.bSupportsDynamicVertexLoader)
@@ -244,12 +255,14 @@ bool ObjectCache::CreatePipelineLayouts()
        static_cast<u32>(compute_sets.size()), compute_sets.data(), 0, nullptr},
   }};
 
+  const bool ssbos_in_standard =
+      g_ActiveConfig.backend_info.bSupportsBBox || g_ActiveConfig.UseVSForLinePointExpand();
+
   // If bounding box is unsupported, don't bother with the SSBO descriptor set.
-  if (!g_ActiveConfig.backend_info.bSupportsBBox)
+  if (!ssbos_in_standard)
     pipeline_layout_info[PIPELINE_LAYOUT_STANDARD].setLayoutCount--;
   // If neither SSBO-using feature is supported, skip in ubershaders too
-  if (!g_ActiveConfig.backend_info.bSupportsBBox &&
-      !g_ActiveConfig.backend_info.bSupportsDynamicVertexLoader)
+  if (!ssbos_in_standard && !g_ActiveConfig.backend_info.bSupportsDynamicVertexLoader)
     pipeline_layout_info[PIPELINE_LAYOUT_UBER].setLayoutCount--;
 
   for (size_t i = 0; i < pipeline_layout_info.size(); i++)

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -299,6 +299,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsSettingObjectNames = false;        // Dependent on features.
   config->backend_info.bSupportsPartialMultisampleResolve = true;  // Assumed support.
   config->backend_info.bSupportsDynamicVertexLoader = true;        // Assumed support.
+  config->backend_info.bSupportsVSLinePointExpand = true;          // Assumed support.
 }
 
 void VulkanContext::PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list)

--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -102,9 +102,18 @@ struct VertexShaderConstants
   std::array<u32, 8> vertex_offset_texcoords;
 };
 
+enum class VSExpand : u32
+{
+  None = 0,
+  Point,
+  Line,
+};
+
 struct GeometryShaderConstants
 {
   float4 stereoparams;
   float4 lineptparams;
   int4 texoffset;
+  VSExpand vs_expand;  // Used by VS point/line expansion in ubershaders
+  u32 pad[3];
 };

--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -19,7 +19,7 @@ namespace VideoCommon
 // As pipelines encompass both shader UIDs and render states, changes to either of these should
 // also increment the pipeline UID version. Incrementing the UID version will cause all UID
 // caches to be invalidated.
-constexpr u32 GX_PIPELINE_UID_VERSION = 5;  // Last changed in PR 10747
+constexpr u32 GX_PIPELINE_UID_VERSION = 6;  // Last changed in PR 10890
 
 struct GXPipelineUid
 {

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -169,22 +169,7 @@ ShaderCode GenerateGeometryShaderCode(APIType api_type, const ShaderHostConfig& 
                 "\tVS_OUTPUT end = o[1];\n");
     }
 
-    // GameCube/Wii's line drawing algorithm is a little quirky. It does not
-    // use the correct line caps. Instead, the line caps are vertical or
-    // horizontal depending the slope of the line.
-    out.Write("\tfloat2 offset;\n"
-              "\tfloat2 to = abs(end.pos.xy / end.pos.w - start.pos.xy / start.pos.w);\n"
-              // FIXME: What does real hardware do when line is at a 45-degree angle?
-              // FIXME: Lines aren't drawn at the correct width. See Twilight Princess map.
-              "\tif (" I_LINEPTPARAMS ".y * to.y > " I_LINEPTPARAMS ".x * to.x) {{\n"
-              // Line is more tall. Extend geometry left and right.
-              // Lerp LineWidth/2 from [0..VpWidth] to [-1..1]
-              "\t\toffset = float2(" I_LINEPTPARAMS ".z / " I_LINEPTPARAMS ".x, 0);\n"
-              "\t}} else {{\n"
-              // Line is more wide. Extend geometry up and down.
-              // Lerp LineWidth/2 from [0..VpHeight] to [1..-1]
-              "\t\toffset = float2(0, -" I_LINEPTPARAMS ".z / " I_LINEPTPARAMS ".y);\n"
-              "\t}}\n");
+    GenerateLineOffset(out, "\t", "\t\t", "end.pos", "start.pos", "");
   }
   else if (primitive_type == PrimitiveType::Points)
   {

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -97,10 +97,8 @@ ShaderCode GenerateGeometryShaderCode(APIType api_type, const ShaderHostConfig& 
   else
     out.Write("cbuffer GSBlock {{\n");
 
-  out.Write("\tfloat4 " I_STEREOPARAMS ";\n"
-            "\tfloat4 " I_LINEPTPARAMS ";\n"
-            "\tint4 " I_TEXOFFSET ";\n"
-            "}};\n");
+  out.Write("{}", s_geometry_shader_uniforms);
+  out.Write("}};\n");
 
   out.Write("struct VS_OUTPUT {{\n");
   GenerateVSOutputMembers(out, api_type, uid_data->numTexGens, host_config, "",

--- a/Source/Core/VideoCommon/GeometryShaderManager.h
+++ b/Source/Core/VideoCommon/GeometryShaderManager.h
@@ -7,6 +7,7 @@
 #include "VideoCommon/ConstantManager.h"
 
 class PointerWrap;
+enum class PrimitiveType : u32;
 
 // The non-API dependent parts.
 class GeometryShaderManager
@@ -16,7 +17,7 @@ public:
   static void Dirty();
   static void DoState(PointerWrap& p);
 
-  static void SetConstants();
+  static void SetConstants(PrimitiveType prim);
   static void SetViewportChanged();
   static void SetProjectionChanged();
   static void SetLinePtWidthChanged();

--- a/Source/Core/VideoCommon/IndexGenerator.h
+++ b/Source/Core/VideoCommon/IndexGenerator.h
@@ -23,7 +23,7 @@ public:
   // returns numprimitives
   u32 GetNumVerts() const { return m_base_index; }
   u32 GetIndexLen() const { return static_cast<u32>(m_index_buffer_current - m_base_index_ptr); }
-  u32 GetRemainingIndices() const;
+  u32 GetRemainingIndices(OpcodeDecoder::Primitive primitive) const;
 
 private:
   u16* m_index_buffer_current = nullptr;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -488,6 +488,7 @@ void Renderer::CheckForConfigChanges()
 
   UpdateActiveConfig();
   FreeLook::UpdateActiveConfig();
+  g_vertex_manager->OnConfigChange();
 
   g_freelook_camera.SetControlType(FreeLook::GetActiveConfig().camera_config.control_type);
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -254,6 +254,78 @@ void AssignVSOutputMembers(ShaderCode& object, std::string_view a, std::string_v
   }
 }
 
+void GenerateLineOffset(ShaderCode& object, std::string_view indent0, std::string_view indent1,
+                        std::string_view pos_a, std::string_view pos_b, std::string_view sign)
+{
+  // GameCube/Wii's line drawing algorithm is a little quirky. It does not
+  // use the correct line caps. Instead, the line caps are vertical or
+  // horizontal depending the slope of the line.
+  object.Write("{indent0}float2 offset;\n"
+               "{indent0}float2 to = abs({pos_a}.xy / {pos_a}.w - {pos_b}.xy / {pos_b}.w);\n"
+               // FIXME: What does real hardware do when line is at a 45-degree angle?
+               // FIXME: Lines aren't drawn at the correct width. See Twilight Princess map.
+               "{indent0}if (" I_LINEPTPARAMS ".y * to.y > " I_LINEPTPARAMS ".x * to.x) {{\n"
+               // Line is more tall. Extend geometry left and right.
+               // Lerp LineWidth/2 from [0..VpWidth] to [-1..1]
+               "{indent1}offset = float2({sign}" I_LINEPTPARAMS ".z / " I_LINEPTPARAMS ".x, 0);\n"
+               "{indent0}}} else {{\n"
+               // Line is more wide. Extend geometry up and down.
+               // Lerp LineWidth/2 from [0..VpHeight] to [1..-1]
+               "{indent1}offset = float2(0, {sign}-" I_LINEPTPARAMS ".z / " I_LINEPTPARAMS ".y);\n"
+               "{indent0}}}\n",
+               fmt::arg("indent0", indent0), fmt::arg("indent1", indent1),  //
+               fmt::arg("pos_a", pos_a), fmt::arg("pos_b", pos_b), fmt::arg("sign", sign));
+}
+
+void GenerateVSLineExpansion(ShaderCode& object, std::string_view indent, u32 texgens)
+{
+  std::string indent1 = std::string(indent) + "  ";
+  object.Write("{0}other_pos = float4(dot(" I_PROJECTION "[0], other_pos), dot(" I_PROJECTION
+               "[1], other_pos), dot(" I_PROJECTION "[2], other_pos), dot(" I_PROJECTION
+               "[3], other_pos));\n"
+               "\n"
+               "{0}float expand_sign = is_right ? 1.0f : -1.0f;\n",
+               indent);
+  GenerateLineOffset(object, indent, indent1, "o.pos", "other_pos", "expand_sign * ");
+  object.Write("\n"
+               "{}o.pos.xy += offset * o.pos.w;\n",
+               indent);
+  if (texgens > 0)
+  {
+    object.Write("{}if ((" I_TEXOFFSET "[2] != 0) && is_right) {{\n", indent);
+    object.Write("{}  float texOffset = 1.0 / float(" I_TEXOFFSET "[2]);\n", indent);
+    for (u32 i = 0; i < texgens; i++)
+    {
+      object.Write("{}  if (((" I_TEXOFFSET "[0] >> {}) & 0x1) != 0)\n", indent, i);
+      object.Write("{}    o.tex{}.x += texOffset;\n", indent, i);
+    }
+    object.Write("{}}}\n", indent);
+  }
+}
+
+void GenerateVSPointExpansion(ShaderCode& object, std::string_view indent, u32 texgens)
+{
+  object.Write(
+      "{0}float2 expand_sign = float2(is_right ? 1.0f : -1.0f, is_bottom ? -1.0f : 1.0f);\n"
+      "{0}float2 offset = expand_sign * " I_LINEPTPARAMS ".ww / " I_LINEPTPARAMS ".xy;\n"
+      "{0}o.pos.xy += offset * o.pos.w;\n",
+      indent);
+  if (texgens > 0)
+  {
+    object.Write("{0}if (" I_TEXOFFSET "[3] != 0) {{\n"
+                 "{0}  float texOffsetMagnitude = 1.0f / float(" I_TEXOFFSET "[3]);\n"
+                 "{0}  float2 texOffset = float2(is_right ? texOffsetMagnitude : 0.0f, "
+                 "is_bottom ? texOffsetMagnitude : 0.0f);",
+                 indent);
+    for (u32 i = 0; i < texgens; i++)
+    {
+      object.Write("{}  if (((" I_TEXOFFSET "[1] >> {}) & 0x1) != 0)\n", indent, i);
+      object.Write("{}    o.tex{}.xy += texOffset;\n", indent, i);
+    }
+    object.Write("{}}}\n", indent);
+  }
+}
+
 const char* GetInterpolationQualifier(bool msaa, bool ssaa, bool in_glsl_interface_block, bool in)
 {
   if (!msaa)

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -5,6 +5,7 @@
 
 #include <fmt/format.h>
 
+#include "Common/Assert.h"
 #include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
 #include "VideoCommon/VideoCommon.h"
@@ -44,6 +45,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
       g_ActiveConfig.ManualTextureSamplingWithHiResTextures();
   bits.backend_sampler_lod_bias = g_ActiveConfig.backend_info.bSupportsLodBiasInSampler;
   bits.backend_dynamic_vertex_loader = g_ActiveConfig.backend_info.bSupportsDynamicVertexLoader;
+  bits.backend_vs_point_line_expand = g_ActiveConfig.UseVSForLinePointExpand();
   return bits;
 }
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -198,6 +198,13 @@ void GenerateVSOutputMembers(ShaderCode& object, APIType api_type, u32 texgens,
 void AssignVSOutputMembers(ShaderCode& object, std::string_view a, std::string_view b, u32 texgens,
                            const ShaderHostConfig& host_config);
 
+void GenerateLineOffset(ShaderCode& object, std::string_view indent0, std::string_view indent1,
+                        std::string_view pos_a, std::string_view pos_b, std::string_view sign);
+
+void GenerateVSLineExpansion(ShaderCode& object, std::string_view indent, u32 texgens);
+
+void GenerateVSPointExpansion(ShaderCode& object, std::string_view indent, u32 texgens);
+
 // We use the flag "centroid" to fix some MSAA rendering bugs. With MSAA, the
 // pixel shader will be executed for each pixel which has at least one passed sample.
 // So there may be rendered pixels where the center of the pixel isn't in the primitive.

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -178,6 +178,7 @@ union ShaderHostConfig
   BitField<25, 1, bool, u32> manual_texture_sampling_custom_texture_sizes;
   BitField<26, 1, bool, u32> backend_sampler_lod_bias;
   BitField<27, 1, bool, u32> backend_dynamic_vertex_loader;
+  BitField<28, 1, bool, u32> backend_vs_point_line_expand;
 
   static ShaderHostConfig GetCurrent();
 };
@@ -316,3 +317,8 @@ static const char s_shader_uniforms[] = "\tuint    components;\n"
                                         "\t#define xfmem_postMtxInfo(i) (xfmem_pack1[(i)].y)\n"
                                         "\t#define xfmem_color(i) (xfmem_pack1[(i)].z)\n"
                                         "\t#define xfmem_alpha(i) (xfmem_pack1[(i)].w)\n";
+
+static const char s_geometry_shader_uniforms[] = "\tfloat4 " I_STEREOPARAMS ";\n"
+                                                 "\tfloat4 " I_LINEPTPARAMS ";\n"
+                                                 "\tint4 " I_TEXOFFSET ";\n"
+                                                 "\tuint vs_expand;\n";

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -3,6 +3,7 @@
 
 #include "VideoCommon/UberShaderVertex.h"
 
+#include "VideoCommon/ConstantManager.h"
 #include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/UberShaderCommon.h"
@@ -35,6 +36,8 @@ ShaderCode GenVertexShader(APIType api_type, const ShaderHostConfig& host_config
   const bool ssaa = host_config.ssaa;
   const bool per_pixel_lighting = host_config.per_pixel_lighting;
   const bool vertex_rounding = host_config.vertex_rounding;
+  const bool vertex_loader =
+      host_config.backend_dynamic_vertex_loader || host_config.backend_vs_point_line_expand;
   const u32 num_texgen = uid_data->num_texgens;
   ShaderCode out;
 
@@ -46,6 +49,13 @@ ShaderCode GenVertexShader(APIType api_type, const ShaderHostConfig& host_config
   out.Write("{}", s_shader_uniforms);
   out.Write("}};\n");
 
+  if (vertex_loader)
+  {
+    out.Write("UBO_BINDING(std140, 3) uniform GSBlock {{\n");
+    out.Write("{}", s_geometry_shader_uniforms);
+    out.Write("}};\n");
+  }
+
   out.Write("struct VS_OUTPUT {{\n");
   GenerateVSOutputMembers(out, api_type, num_texgen, host_config, "", ShaderStage::Vertex);
   out.Write("}};\n\n");
@@ -54,7 +64,7 @@ ShaderCode GenVertexShader(APIType api_type, const ShaderHostConfig& host_config
   WriteBitfieldExtractHeader(out, api_type, host_config);
   WriteLightingFunction(out);
 
-  if (host_config.backend_dynamic_vertex_loader)
+  if (vertex_loader)
   {
     out.Write(R"(
 SSBO_BINDING(1) readonly restrict buffer Vertices {{
@@ -73,17 +83,17 @@ SSBO_BINDING(1) readonly restrict buffer Vertices {{
       // D3D12 uses a root constant for this uniform, since it changes with every draw.
       // D3D11 doesn't currently support dynamic vertex loader, and we'll have to figure something
       // out for it if we want to support it in the future.
-      out.Write("UBO_BINDING(std140, 3) uniform DX_Constants {{\n"
+      out.Write("UBO_BINDING(std140, 4) uniform DX_Constants {{\n"
                 "  uint base_vertex;\n"
                 "}};\n\n"
-                "uint GetVertexBaseOffset() {{\n"
-                "  return (gl_VertexID + base_vertex) * vertex_stride;\n"
+                "uint GetVertexBaseOffset(uint vertex_id) {{\n"
+                "  return (vertex_id + base_vertex) * vertex_stride;\n"
                 "}}\n");
     }
     else
     {
-      out.Write("uint GetVertexBaseOffset() {{\n"
-                "  return gl_VertexID * vertex_stride;\n"
+      out.Write("uint GetVertexBaseOffset(uint vertex_id) {{\n"
+                "  return vertex_id * vertex_stride;\n"
                 "}}\n");
     }
 
@@ -187,9 +197,17 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
 
   out.Write("VS_OUTPUT o;\n"
             "\n");
-  if (host_config.backend_dynamic_vertex_loader)
+  if (host_config.backend_vs_point_line_expand)
   {
-    out.Write("uint vertex_base_offset = GetVertexBaseOffset();\n");
+    out.Write("uint vertex_id = gl_VertexID;\n"
+              "if (vs_expand != 0u) {{\n"
+              "  vertex_id = vertex_id >> 2;\n"
+              "}}\n"
+              "uint vertex_base_offset = GetVertexBaseOffset(vertex_id);\n");
+  }
+  else if (host_config.backend_dynamic_vertex_loader)
+  {
+    out.Write("uint vertex_base_offset = GetVertexBaseOffset(gl_VertexID);\n");
   }
   // rawpos is always needed
   LoadVertexAttribute(out, host_config, 0, "rawpos", "float4", "rawpos");
@@ -319,6 +337,88 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
   // Texture Coordinates
   if (num_texgen > 0)
     GenVertexShaderTexGens(api_type, host_config, num_texgen, out);
+
+  if (host_config.backend_vs_point_line_expand)
+  {
+    out.Write("if (vs_expand == {}u) {{ // Line\n", static_cast<u32>(VSExpand::Line));
+    out.Write("  bool is_bottom = (gl_VertexID & 2) != 0;\n"
+              "  bool is_right = (gl_VertexID & 1) != 0;\n"
+              "  uint other_base_offset = vertex_base_offset;\n"
+              "  if (is_bottom) {{\n"
+              "    other_base_offset -= vertex_stride;\n"
+              "  }} else {{\n"
+              "    other_base_offset += vertex_stride;\n"
+              "  }}\n"
+              "  float4 other_rawpos = load_input_float4_rawpos(other_base_offset, "
+              "vertex_offset_rawpos);\n"
+              "  float4 other_p0 = P0;\n"
+              "  float4 other_p1 = P1;\n"
+              "  float4 other_p2 = P2;\n"
+              "  if ((components & {}u) != 0u) {{ // VB_HAS_POSMTXIDX\n",
+              VB_HAS_POSMTXIDX);
+    out.Write("    uint other_posidx = int(load_input_uint4_ubyte4(other_base_offset, "
+              "vertex_offset_posmtx).r);\n"
+              "    other_p0 = " I_TRANSFORMMATRICES "[other_posidx];\n"
+              "    other_p1 = " I_TRANSFORMMATRICES "[other_posidx+1];\n"
+              "    other_p2 = " I_TRANSFORMMATRICES "[other_posidx+2];\n"
+              "  }}\n"
+              "  float4 other_pos = float4(dot(other_p0, other_rawpos), "
+              "dot(other_p1, other_rawpos), dot(other_p2, other_rawpos), 1.0);\n"
+              "  other_pos = float4(dot(" I_PROJECTION "[0], other_pos), dot(" I_PROJECTION
+              "[1], other_pos), dot(" I_PROJECTION "[2], other_pos), dot(" I_PROJECTION
+              "[3], other_pos));\n"
+              "\n"
+              "  float sign = is_right ? 1.0f : -1.0f;\n"
+              // GameCube/Wii's line drawing algorithm is a little quirky. It does not
+              // use the correct line caps. Instead, the line caps are vertical or
+              // horizontal depending the slope of the line.
+              "  float2 offset;\n"
+              "  float2 to = abs(o.pos.xy / o.pos.w - other_pos.xy / other_pos.w);\n"
+              // FIXME: What does real hardware do when line is at a 45-degree angle?
+              // FIXME: Lines aren't drawn at the correct width. See Twilight Princess map.
+              "  if (" I_LINEPTPARAMS ".y * to.y > " I_LINEPTPARAMS ".x * to.x) {{\n"
+              // Line is more tall. Extend geometry left and right.
+              // Lerp LineWidth/2 from [0..VpWidth] to [-1..1]
+              "    offset = float2(sign * " I_LINEPTPARAMS ".z / " I_LINEPTPARAMS ".x, 0);\n"
+              "  }} else {{\n"
+              // Line is more wide. Extend geometry up and down.
+              // Lerp LineWidth/2 from [0..VpHeight] to [1..-1]
+              "    offset = float2(0, sign * " I_LINEPTPARAMS ".z / " I_LINEPTPARAMS ".y);\n"
+              "  }}\n"
+              "\n"
+              "  o.pos.xy += offset * o.pos.w;\n");
+    if (num_texgen > 0)
+    {
+      out.Write("  if ((" I_TEXOFFSET "[2] != 0) && is_right) {{\n"
+                "    float texOffset = 1.0 / float(" I_TEXOFFSET "[2]);\n");
+      for (u32 i = 0; i < num_texgen; i++)
+      {
+        out.Write("    if (((" I_TEXOFFSET "[0] >> {}) & 0x1) != 0)\n", i);
+        out.Write("      o.tex{}.x += texOffset;\n", i);
+      }
+      out.Write("  }}\n");
+    }
+    out.Write("}} else if (vs_expand == {}u) {{ // Point\n", static_cast<u32>(VSExpand::Point));
+    out.Write("  bool is_bottom = (gl_VertexID & 2) != 0;\n"
+              "  bool is_right = (gl_VertexID & 1) != 0;\n"
+              "  float2 sign = float2(is_right ? 1.0f : -1.0f, is_bottom ? 1.0f : -1.0f);\n"
+              "  float2 offset = sign * " I_LINEPTPARAMS ".ww / " I_LINEPTPARAMS ".xy;\n"
+              "  o.pos.xy += offset * o.pos.w;\n");
+    if (num_texgen > 0)
+    {
+      out.Write("  if (" I_TEXOFFSET "[3] != 0) {{\n"
+                "    float texOffsetMagnitude = 1.0f / float(" I_TEXOFFSET "[3]);\n"
+                "    float2 texOffset = float2(is_right ? texOffsetMagnitude : 0.0f, "
+                "is_bottom ? texOffsetMagnitude : 0.0f);");
+      for (u32 i = 0; i < num_texgen; i++)
+      {
+        out.Write("    if (((" I_TEXOFFSET "[1] >> {}) & 0x1) != 0)\n", i);
+        out.Write("      o.tex{}.xy += texOffset;\n", i);
+      }
+      out.Write("  }}\n");
+    }
+    out.Write("}}\n");
+  }
 
   if (per_pixel_lighting)
   {
@@ -574,7 +674,7 @@ static void GenVertexShaderTexGens(APIType api_type, const ShaderHostConfig& hos
             "    {{\n");
   out.Write("      if ((components & ({}u /* VB_HAS_TEXMTXIDX0 */ << texgen)) != 0u) {{\n",
             VB_HAS_TEXMTXIDX0);
-  if (host_config.backend_dynamic_vertex_loader)
+  if (host_config.backend_dynamic_vertex_loader || host_config.backend_vs_point_line_expand)
   {
     out.Write("        int tmp = int(load_input_float3_rawtex(vertex_base_offset, "
               "vertex_offset_rawtex[texgen / 4][texgen % 4]).z);\n"
@@ -655,7 +755,7 @@ static void LoadVertexAttribute(ShaderCode& code, const ShaderHostConfig& host_c
                                 std::string_view name, std::string_view shader_type,
                                 std::string_view stored_type, std::string_view offset_name)
 {
-  if (host_config.backend_dynamic_vertex_loader)
+  if (host_config.backend_dynamic_vertex_loader || host_config.backend_vs_point_line_expand)
   {
     code.Write("{:{}}{} {} = load_input_{}_{}(vertex_base_offset, vertex_offset_{});\n", "", indent,
                shader_type, name, shader_type, stored_type,

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -826,6 +826,12 @@ void VertexManagerBase::UpdatePipelineObject()
   }
 }
 
+void VertexManagerBase::OnConfigChange()
+{
+  // Reload index generator function tables in case VS expand config changed
+  m_index_generator.Init();
+}
+
 void VertexManagerBase::OnDraw()
 {
   m_draw_counter++;

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -140,12 +140,12 @@ DataReader VertexManagerBase::PrepareForAdditionalData(OpcodeDecoder::Primitive 
 
   // Check for size in buffer, if the buffer gets full, call Flush()
   if (!m_is_flushed &&
-      (count > m_index_generator.GetRemainingIndices() || count > GetRemainingIndices(primitive) ||
-       needed_vertex_bytes > GetRemainingSize()))
+      (count > m_index_generator.GetRemainingIndices(primitive) ||
+       count > GetRemainingIndices(primitive) || needed_vertex_bytes > GetRemainingSize()))
   {
     Flush();
 
-    if (count > m_index_generator.GetRemainingIndices())
+    if (count > m_index_generator.GetRemainingIndices(primitive))
     {
       ERROR_LOG_FMT(VIDEO, "Too little remaining index values. Use 32-bit or reset them on flush.");
     }
@@ -193,7 +193,55 @@ u32 VertexManagerBase::GetRemainingIndices(OpcodeDecoder::Primitive primitive) c
 {
   const u32 index_len = MAXIBUFFERSIZE - m_index_generator.GetIndexLen();
 
-  if (g_Config.backend_info.bSupportsPrimitiveRestart)
+  if (primitive >= Primitive::GX_DRAW_LINES)
+  {
+    if (g_Config.UseVSForLinePointExpand())
+    {
+      if (g_Config.backend_info.bSupportsPrimitiveRestart)
+      {
+        switch (primitive)
+        {
+        case Primitive::GX_DRAW_LINES:
+          return index_len / 5 * 2;
+        case Primitive::GX_DRAW_LINE_STRIP:
+          return index_len / 5 + 1;
+        case Primitive::GX_DRAW_POINTS:
+          return index_len / 5;
+        default:
+          return 0;
+        }
+      }
+      else
+      {
+        switch (primitive)
+        {
+        case Primitive::GX_DRAW_LINES:
+          return index_len / 6 * 2;
+        case Primitive::GX_DRAW_LINE_STRIP:
+          return index_len / 6 + 1;
+        case Primitive::GX_DRAW_POINTS:
+          return index_len / 6;
+        default:
+          return 0;
+        }
+      }
+    }
+    else
+    {
+      switch (primitive)
+      {
+      case Primitive::GX_DRAW_LINES:
+        return index_len;
+      case Primitive::GX_DRAW_LINE_STRIP:
+        return index_len / 2 + 1;
+      case Primitive::GX_DRAW_POINTS:
+        return index_len;
+      default:
+        return 0;
+      }
+    }
+  }
+  else if (g_Config.backend_info.bSupportsPrimitiveRestart)
   {
     switch (primitive)
     {
@@ -206,15 +254,6 @@ u32 VertexManagerBase::GetRemainingIndices(OpcodeDecoder::Primitive primitive) c
       return index_len / 1 - 1;
     case Primitive::GX_DRAW_TRIANGLE_FAN:
       return index_len / 6 * 4 + 1;
-
-    case Primitive::GX_DRAW_LINES:
-      return index_len;
-    case Primitive::GX_DRAW_LINE_STRIP:
-      return index_len / 2 + 1;
-
-    case Primitive::GX_DRAW_POINTS:
-      return index_len;
-
     default:
       return 0;
     }
@@ -232,15 +271,6 @@ u32 VertexManagerBase::GetRemainingIndices(OpcodeDecoder::Primitive primitive) c
       return index_len / 3 + 2;
     case Primitive::GX_DRAW_TRIANGLE_FAN:
       return index_len / 3 + 2;
-
-    case Primitive::GX_DRAW_LINES:
-      return index_len;
-    case Primitive::GX_DRAW_LINE_STRIP:
-      return index_len / 2 + 1;
-
-    case Primitive::GX_DRAW_POINTS:
-      return index_len;
-
     default:
       return 0;
     }
@@ -511,13 +541,24 @@ void VertexManagerBase::Flush()
                  VertexLoaderManager::GetCurrentVertexFormat()->GetVertexStride(), num_indices,
                  &base_vertex, &base_index);
 
+    if (g_ActiveConfig.backend_info.api_type != APIType::D3D &&
+        g_ActiveConfig.UseVSForLinePointExpand() &&
+        (m_current_primitive_type == PrimitiveType::Points ||
+         m_current_primitive_type == PrimitiveType::Lines))
+    {
+      // VS point/line expansion puts the vertex id at gl_VertexID << 2
+      // That means the base vertex has to be adjusted to match
+      // (The shader adds this after shifting right on D3D, so no need to do this)
+      base_vertex <<= 2;
+    }
+
     // Texture loading can cause palettes to be applied (-> uniforms -> draws).
     // Palette application does not use vertices, only a full-screen quad, so this is okay.
     // Same with GPU texture decoding, which uses compute shaders.
     g_texture_cache->BindTextures(used_textures);
 
     // Now we can upload uniforms, as nothing else will override them.
-    GeometryShaderManager::SetConstants();
+    GeometryShaderManager::SetConstants(m_current_primitive_type);
     PixelShaderManager::SetConstants();
     UploadUniforms();
 

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -140,6 +140,9 @@ public:
                                  u32* out_offset, const void* palette_data, u32 palette_size,
                                  TexelBufferFormat palette_format, u32* out_palette_offset);
 
+  // Call if active config changes
+  void OnConfigChange();
+
   // CPU access tracking - call after a draw call is made.
   void OnDraw();
 

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -6,6 +6,7 @@
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "VideoCommon/BPMemory.h"
+#include "VideoCommon/ConstantManager.h"
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/VertexLoaderManager.h"
@@ -83,6 +84,8 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   const bool ssaa = host_config.ssaa;
   const bool vertex_rounding = host_config.vertex_rounding;
 
+  ShaderCode input_extract;
+
   out.Write("{}", s_lighting_struct);
 
   // uniforms
@@ -91,6 +94,21 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   out.Write("{}", s_shader_uniforms);
   out.Write("}};\n");
 
+  if (uid_data->vs_expand != VSExpand::None)
+  {
+    out.Write("UBO_BINDING(std140, 3) uniform GSBlock {{\n");
+    out.Write("{}", s_geometry_shader_uniforms);
+    out.Write("}};\n");
+
+    if (api_type == APIType::D3D)
+    {
+      // D3D doesn't include the base vertex in SV_VertexID
+      out.Write("UBO_BINDING(std140, 4) uniform DX_Constants {{\n"
+                "  uint base_vertex;\n"
+                "}};\n\n");
+    }
+  }
+
   out.Write("struct VS_OUTPUT {{\n");
   GenerateVSOutputMembers(out, api_type, uid_data->numTexGens, host_config, "",
                           ShaderStage::Vertex);
@@ -98,30 +116,113 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
 
   WriteIsNanHeader(out, api_type);
 
-  out.Write("ATTRIBUTE_LOCATION({}) in float4 rawpos;\n", SHADER_POSITION_ATTRIB);
-  if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
-    out.Write("ATTRIBUTE_LOCATION({}) in uint4 posmtx;\n", SHADER_POSMTX_ATTRIB);
-  if ((uid_data->components & VB_HAS_NORMAL) != 0)
-    out.Write("ATTRIBUTE_LOCATION({}) in float3 rawnormal;\n", SHADER_NORMAL_ATTRIB);
-  if ((uid_data->components & VB_HAS_TANGENT) != 0)
-    out.Write("ATTRIBUTE_LOCATION({}) in float3 rawtangent;\n", SHADER_TANGENT_ATTRIB);
-  if ((uid_data->components & VB_HAS_BINORMAL) != 0)
-    out.Write("ATTRIBUTE_LOCATION({}) in float3 rawbinormal;\n", SHADER_BINORMAL_ATTRIB);
-
-  if ((uid_data->components & VB_HAS_COL0) != 0)
-    out.Write("ATTRIBUTE_LOCATION({}) in float4 rawcolor0;\n", SHADER_COLOR0_ATTRIB);
-  if ((uid_data->components & VB_HAS_COL1) != 0)
-    out.Write("ATTRIBUTE_LOCATION({}) in float4 rawcolor1;\n", SHADER_COLOR1_ATTRIB);
-
-  for (u32 i = 0; i < 8; ++i)
+  if (uid_data->vs_expand == VSExpand::None)
   {
-    const u32 has_texmtx = (uid_data->components & (VB_HAS_TEXMTXIDX0 << i));
+    out.Write("ATTRIBUTE_LOCATION({}) in float4 rawpos;\n", SHADER_POSITION_ATTRIB);
+    if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
+      out.Write("ATTRIBUTE_LOCATION({}) in uint4 posmtx;\n", SHADER_POSMTX_ATTRIB);
+    if ((uid_data->components & VB_HAS_NORMAL) != 0)
+      out.Write("ATTRIBUTE_LOCATION({}) in float3 rawnormal;\n", SHADER_NORMAL_ATTRIB);
+    if ((uid_data->components & VB_HAS_TANGENT) != 0)
+      out.Write("ATTRIBUTE_LOCATION({}) in float3 rawtangent;\n", SHADER_TANGENT_ATTRIB);
+    if ((uid_data->components & VB_HAS_BINORMAL) != 0)
+      out.Write("ATTRIBUTE_LOCATION({}) in float3 rawbinormal;\n", SHADER_BINORMAL_ATTRIB);
 
-    if ((uid_data->components & (VB_HAS_UV0 << i)) != 0 || has_texmtx != 0)
+    if ((uid_data->components & VB_HAS_COL0) != 0)
+      out.Write("ATTRIBUTE_LOCATION({}) in float4 rawcolor0;\n", SHADER_COLOR0_ATTRIB);
+    if ((uid_data->components & VB_HAS_COL1) != 0)
+      out.Write("ATTRIBUTE_LOCATION({}) in float4 rawcolor1;\n", SHADER_COLOR1_ATTRIB);
+
+    for (u32 i = 0; i < 8; ++i)
     {
-      out.Write("ATTRIBUTE_LOCATION({}) in float{} rawtex{};\n", SHADER_TEXTURE0_ATTRIB + i,
-                has_texmtx != 0 ? 3 : 2, i);
+      const u32 has_texmtx = (uid_data->components & (VB_HAS_TEXMTXIDX0 << i));
+
+      if ((uid_data->components & (VB_HAS_UV0 << i)) != 0 || has_texmtx != 0)
+      {
+        out.Write("ATTRIBUTE_LOCATION({}) in float{} rawtex{};\n", SHADER_TEXTURE0_ATTRIB + i,
+                  has_texmtx != 0 ? 3 : 2, i);
+      }
     }
+  }
+  else
+  {
+    // Can't use float3, etc because we want 4-byte alignment
+    out.Write(
+        "uint4 unpack_ubyte4(uint value) {{\n"
+        "  return uint4(value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, value >> 24);\n"
+        "}}\n\n"
+        "struct InputData {{\n");
+    if (uid_data->components & VB_HAS_POSMTXIDX)
+    {
+      out.Write("  uint posmtx;\n");
+      input_extract.Write("uint4 posmtx = unpack_ubyte4(i.posmtx);\n");
+    }
+    if (uid_data->position_has_3_elems)
+    {
+      out.Write("  float pos0;\n"
+                "  float pos1;\n"
+                "  float pos2;\n");
+      input_extract.Write("float4 rawpos = float4(i.pos0, i.pos1, i.pos2, 1.0f);\n");
+    }
+    else
+    {
+      out.Write("  float pos0;\n"
+                "  float pos1;\n");
+      input_extract.Write("float4 rawpos = float4(i.pos0, i.pos1, 0.0f, 1.0f);\n");
+    }
+    std::array<std::string_view, 3> names = {"normal", "binormal", "tangent"};
+    for (int i = 0; i < 3; i++)
+    {
+      if (uid_data->components & (VB_HAS_NORMAL << i))
+      {
+        out.Write("  float {0}0;\n"
+                  "  float {0}1;\n"
+                  "  float {0}2;\n",
+                  names[i]);
+        input_extract.Write("float3 raw{0} = float3(i.{0}0, i.{0}1, i.{0}2);\n", names[i]);
+      }
+    }
+    for (int i = 0; i < 2; i++)
+    {
+      if (uid_data->components & (VB_HAS_COL0 << i))
+      {
+        out.Write("  uint color{};\n", i);
+        input_extract.Write("float4 rawcolor{0} = float4(unpack_ubyte4(i.color{0})) / 255.0f;\n",
+                            i);
+      }
+    }
+    for (int i = 0; i < 8; i++)
+    {
+      if (uid_data->components & (VB_HAS_UV0 << i))
+      {
+        u32 ncomponents = (uid_data->texcoord_elem_count >> (2 * i)) & 3;
+        if (ncomponents < 2)
+        {
+          out.Write("  float tex{};\n", i);
+          input_extract.Write("float3 rawtex{0} = float3(i.tex{0}, 0.0f, 0.0f);\n", i);
+        }
+        else if (ncomponents == 2)
+        {
+          out.Write("  float tex{0}_0;\n"
+                    "  float tex{0}_1;\n",
+                    i);
+          input_extract.Write("float3 rawtex{0} = float3(i.tex{0}_0, i.tex{0}_1, 0.0f);\n", i);
+        }
+        else
+        {
+          out.Write("  float tex{0}_0;\n"
+                    "  float tex{0}_1;\n"
+                    "  float tex{0}_2;\n",
+                    i);
+          input_extract.Write("float3 rawtex{0} = float3(i.tex{0}_0, i.tex{0}_1, i.tex{0}_2);\n",
+                              i);
+        }
+      }
+    }
+    out.Write("}};\n\n"
+              "SSBO_BINDING(1) readonly restrict buffer InputBuffer {{\n"
+              "  InputData input_buffer[];\n"
+              "}};\n\n");
   }
 
   if (host_config.backend_geometry_shaders)
@@ -160,6 +261,21 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   }
 
   out.Write("void main()\n{{\n");
+
+  if (uid_data->vs_expand != VSExpand::None)
+  {
+    out.Write("bool is_bottom = (gl_VertexID & 2) != 0;\n"
+              "bool is_right = (gl_VertexID & 1) != 0;\n");
+    // D3D doesn't include the base vertex in SV_VertexID
+    // See comment in UberShaderVertex for details
+    if (api_type == APIType::D3D)
+      out.Write("uint vertex_id = (gl_VertexID >> 2) + base_vertex;\n");
+    else
+      out.Write("uint vertex_id = gl_VertexID >> 2;\n");
+    out.Write("InputData i = input_buffer[vertex_id];\n"
+              "{}",
+              input_extract.GetBuffer());
+  }
 
   out.Write("VS_OUTPUT o;\n");
 
@@ -401,6 +517,86 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     }
 
     out.Write("}}\n");
+  }
+
+  if (uid_data->vs_expand == VSExpand::Line)
+  {
+    out.Write("// Line expansion\n"
+              "uint other_id = vertex_id;\n"
+              "if (is_bottom) {{\n"
+              "  other_id -= 1;\n"
+              "}} else {{\n"
+              "  other_id += 1;\n"
+              "}}\n"
+              "InputData other = input_buffer[other_id];\n");
+    if (uid_data->position_has_3_elems)
+      out.Write("float4 other_pos = float4(other.pos0, other.pos1, other.pos2, 1.0f);\n");
+    else
+      out.Write("float4 other_pos = float4(other.pos0, other.pos1, 0.0f, 1.0f);\n");
+    if (uid_data->components & VB_HAS_POSMTXIDX)
+    {
+      out.Write("uint other_posidx = other.posmtx & 0xff;\n"
+                "float4 other_p0 = " I_TRANSFORMMATRICES "[other_posidx];\n"
+                "float4 other_p1 = " I_TRANSFORMMATRICES "[other_posidx + 1];\n"
+                "float4 other_p2 = " I_TRANSFORMMATRICES "[other_posidx + 2];\n"
+                "other_pos = float4(dot(other_p0, other_pos), dot(other_p1, other_pos), "
+                "dot(other_p2, other_pos), 1.0f);\n");
+    }
+    else
+    {
+      out.Write("other_pos = float4(dot(P0, other_pos), dot(P1, other_pos), dot(P2, other_pos), "
+                "1.0f);\n");
+    }
+    out.Write("other_pos = float4(dot(" I_PROJECTION "[0], other_pos), dot(" I_PROJECTION
+              "[1], other_pos), dot(" I_PROJECTION "[2], other_pos), dot(" I_PROJECTION
+              "[3], other_pos));\n"
+              "float expand_sign = is_right ? 1.0f : -1.0f;\n"
+              "float2 offset;\n"
+              "float2 to = abs(o.pos.xy / o.pos.w - other_pos.xy / other_pos.w);\n"
+              // FIXME: What does real hardware do when line is at a 45-degree angle?
+              // FIXME: Lines aren't drawn at the correct width. See Twilight Princess map.
+              "if (" I_LINEPTPARAMS ".y * to.y > " I_LINEPTPARAMS ".x * to.x) {{\n"
+              // Line is more tall. Extend geometry left and right.
+              // Lerp LineWidth/2 from [0..VpWidth] to [-1..1]
+              "  offset = float2(expand_sign * " I_LINEPTPARAMS ".z / " I_LINEPTPARAMS ".x, 0);\n"
+              "}} else {{\n"
+              // Line is more wide. Extend geometry up and down.
+              // Lerp LineWidth/2 from [0..VpHeight] to [1..-1]
+              "  offset = float2(0, expand_sign * " I_LINEPTPARAMS ".z / " I_LINEPTPARAMS ".y);\n"
+              "}}\n"
+              "\n"
+              "o.pos.xy += offset * o.pos.w;\n");
+    if (uid_data->numTexGens > 0)
+    {
+      out.Write("if ((" I_TEXOFFSET "[2] != 0) && is_right) {{\n"
+                "  float texOffset = 1.0 / float(" I_TEXOFFSET "[2]);\n");
+      for (u32 i = 0; i < uid_data->numTexGens; i++)
+      {
+        out.Write("  if (((" I_TEXOFFSET "[0] >> {}) & 0x1) != 0)\n", i);
+        out.Write("    o.tex{}.x += texOffset;\n", i);
+      }
+      out.Write("}}\n");
+    }
+  }
+  else if (uid_data->vs_expand == VSExpand::Point)
+  {
+    out.Write("// Point expansion\n"
+              "float2 expand_sign = float2(is_right ? 1.0f : -1.0f, is_bottom ? 1.0f : -1.0f);\n"
+              "float2 offset = expand_sign * " I_LINEPTPARAMS ".ww / " I_LINEPTPARAMS ".xy;\n"
+              "o.pos.xy += offset * o.pos.w;\n");
+    if (uid_data->numTexGens > 0)
+    {
+      out.Write("if (" I_TEXOFFSET "[3] != 0) {{\n"
+                "  float texOffsetMagnitude = 1.0f / float(" I_TEXOFFSET "[3]);\n"
+                "  float2 texOffset = float2(is_right ? texOffsetMagnitude : 0.0f, "
+                "is_bottom ? texOffsetMagnitude : 0.0f);");
+      for (u32 i = 0; i < uid_data->numTexGens; i++)
+      {
+        out.Write("  if (((" I_TEXOFFSET "[1] >> {}) & 0x1) != 0)\n", i);
+        out.Write("    o.tex{}.xy += texOffset;\n", i);
+      }
+      out.Write("}}\n");
+    }
   }
 
   if (per_pixel_lighting)

--- a/Source/Core/VideoCommon/VertexShaderGen.h
+++ b/Source/Core/VideoCommon/VertexShaderGen.h
@@ -11,6 +11,7 @@ enum class APIType;
 enum class TexInputForm : u32;
 enum class TexGenType : u32;
 enum class SourceRow : u32;
+enum class VSExpand : u32;
 
 // TODO should be reordered
 enum : int
@@ -42,10 +43,12 @@ struct vertex_shader_uid_data
   u32 numTexGens : 4;
   u32 numColorChans : 2;
   u32 dualTexTrans_enabled : 1;
+  VSExpand vs_expand : 2;
+  u32 position_has_3_elems : 1;
 
-  u32 texMtxInfo_n_projection : 16;  // Stored separately to guarantee that the texMtxInfo struct is
-                                     // 8 bits wide
-  u32 pad : 18;
+  u16 texcoord_elem_count;      // 2 bits per texcoord input
+  u16 texMtxInfo_n_projection;  // Stored separately to guarantee that the texMtxInfo struct is
+                                // 8 bits wide
 
   struct
   {

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -274,6 +274,7 @@ void VideoBackendBase::PopulateBackendInfo()
   // a value from the previously used renderer
   g_Config.backend_info = {};
   ActivateBackend(Config::Get(Config::MAIN_GFX_BACKEND));
+  g_Config.backend_info.DisplayName = g_video_backend->GetDisplayName();
   g_video_backend->InitBackendInfo();
   // We validate the config after initializing the backend info, as system-specific settings
   // such as anti-aliasing, or the selected adapter may be invalid, and should be checked.

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -85,6 +85,7 @@ void VideoConfig::Refresh()
   iBitrateKbps = Config::Get(Config::GFX_BITRATE_KBPS);
   bInternalResolutionFrameDumps = Config::Get(Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS);
   bEnableGPUTextureDecoding = Config::Get(Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
+  bPreferVSForLinePointExpansion = Config::Get(Config::GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION);
   bEnablePixelLighting = Config::Get(Config::GFX_ENABLE_PIXEL_LIGHTING);
   bFastDepthCalc = Config::Get(Config::GFX_FAST_DEPTH_CALC);
   iMultisamples = Config::Get(Config::GFX_MSAA);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -106,6 +106,7 @@ struct VideoConfig final
   bool bInternalResolutionFrameDumps = false;
   bool bBorderlessFullscreen = false;
   bool bEnableGPUTextureDecoding = false;
+  bool bPreferVSForLinePointExpansion = false;
   int iBitrateKbps = 0;
   bool bGraphicMods = false;
   std::optional<GraphicsModGroupConfig> graphics_mod_config;
@@ -230,7 +231,9 @@ struct VideoConfig final
   {
     if (!backend_info.bSupportsVSLinePointExpand)
       return false;
-    return !backend_info.bSupportsGeometryShaders;
+    if (!backend_info.bSupportsGeometryShaders)
+      return true;
+    return bPreferVSForLinePointExpansion;
   }
   bool MultisamplingEnabled() const { return iMultisamples > 1; }
   bool ExclusiveFullscreenEnabled() const

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -222,9 +222,16 @@ struct VideoConfig final
     bool bSupportsSettingObjectNames = false;
     bool bSupportsPartialMultisampleResolve = false;
     bool bSupportsDynamicVertexLoader = false;
+    bool bSupportsVSLinePointExpand = false;
   } backend_info;
 
   // Utility
+  bool UseVSForLinePointExpand() const
+  {
+    if (!backend_info.bSupportsVSLinePointExpand)
+      return false;
+    return !backend_info.bSupportsGeometryShaders;
+  }
   bool MultisamplingEnabled() const { return iMultisamples > 1; }
   bool ExclusiveFullscreenEnabled() const
   {

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -174,6 +174,7 @@ struct VideoConfig final
   struct
   {
     APIType api_type = APIType::Nothing;
+    std::string DisplayName;
 
     std::vector<std::string> Adapters;  // for D3D
     std::vector<u32> AAModes;


### PR DESCRIPTION
Adds support for expanding lines and points using the vertex shader to the Vulkan and Metal backends

(~~Didn't bother with the other backends since they're guaranteed to have geometry shaders.  If someone else wants to port to those for the speed benefits, they're welcome to do so, but I don't currently have any plans to do it.  DX12 should just need some messing with the root descriptor, but DX11 and OGL will need to get dynamic vertex loader support added as well.~~ Now implemented everywhere but DX11.)

This finally adds wide points/lines for Metal and MoltenVK!
<details>
<summary>Before and after screenshots</summary>

Metroid Prime 2 map before:
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/3315070/180710560-f218fc64-9b56-41ca-86f9-17267f8458c1.png">

After:
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/3315070/180710961-d00fd86b-6b52-4572-94fb-c16cac94e7a6.png">
</details>

I also added an option in the config to use it even on GPUs that support geometry shaders.  It's noticeably faster in Metroid Prime 2's map on my AMD Radeon Pro 5600M.

<details>
<summary>Random profiling results</summary>

Radeon Pro 5600M execution of polygons from Metroid Prime 2's map in VS expand:
![RGP profile of VS Expand](https://user-images.githubusercontent.com/3315070/180714233-ecb58fae-0b8b-4a4a-be3c-33bf8b8bdf0f.png)

Same set of polygons in GS expand (graph scale is approximately the same number of µs):
![RGP profile of GS Expand](https://user-images.githubusercontent.com/3315070/180714323-af54e0ee-06c1-42f2-9ce8-94353fd6c65d.png)

[Docs on what these graphs mean](https://radeon-gpuprofiler.readthedocs.io/en/latest/#the-anatomy-of-an-event)

The VS expand one seems limited by how quickly the command processor can queue up work, which is mostly limited by the large number of context rolls (caused by pipeline changes).  On the other hand, in GS expand, work is being queued way earlier than executed.  Something somewhere else in the GPU is delaying execution.

</details>

#### Implementation details
When VS expansion is enabled, indices are modified to use the bottom two bits for details about which point in the point/line expanded to a quad they represent.  The vertex shader then loads and transforms the position for all associated vertices and uses it to calculate the appropriate offset to add.

Note: Requires #10781

Does anyone have any games that use points/lines with texture offsets?  I haven't tested that because I don't know what games to test.