### PR TITLE
DSPHLE: Support EDuke32 Wii libaesnd uCode

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
@@ -26,19 +26,6 @@ constexpr u32 MAIL_GET_PB_ADDRESS = MAIL_PREFIX | 0x0080;
 constexpr u32 MAIL_SEND_SAMPLES = MAIL_PREFIX | 0x0100;
 constexpr u32 MAIL_TERMINATE = MAIL_PREFIX | 0xdead;
 
-// June 5, 2010 version (padded to 0x03e0 bytes) - initial release
-// First included with libogc 1.8.4 on October 3, 2010: https://devkitpro.org/viewtopic.php?t=2249
-// https://github.com/devkitPro/libogc/blob/b5fdbdb069c45584aa4dfd950a136a8db9b1144c/libaesnd/dspcode/dspmixer.s
-constexpr u32 HASH_2010 = 0x008366af;
-// April 11, 2012 version (padded to 0x03e0 bytes) - swapped input channels
-// First included with libogc 1.8.11 on April 22, 2012: https://devkitpro.org/viewtopic.php?t=3094
-// https://github.com/devkitPro/libogc/commit/8f188e12b6a3d8b5a0d49a109fe6a3e4e1702aab
-constexpr u32 HASH_2012 = 0x078066ab;
-// June 14, 2020 version (0x03e6 bytes) - added unsigned formats
-// First included with libogc 2.1.0 on June 15, 2020: https://devkitpro.org/viewtopic.php?t=9079
-// https://github.com/devkitPro/libogc/commit/eac8fe2c29aa790d552dd6166a1fb195dfdcb825
-constexpr u32 HASH_2020 = 0x84c680a9;
-
 constexpr u32 VOICE_MONO8 = 0x00000000;
 constexpr u32 VOICE_STEREO8 = 0x00000001;
 constexpr u32 VOICE_MONO16 = 0x00000002;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
@@ -133,25 +133,25 @@ void AESndUCode::HandleMail(u32 mail)
     switch (mail)
     {
     case MAIL_PROCESS_FIRST_VOICE:
-      DEBUG_LOG_FMT(DSPHLE, "ASndUCode - MAIL_PROCESS_FIRST_VOICE");
+      DEBUG_LOG_FMT(DSPHLE, "AESndUCode - MAIL_PROCESS_FIRST_VOICE");
       DMAInParameterBlock();  // dma_pb_block
       m_output_buffer.fill(0);
       DoMixing();  // fall through to dsp_mixer
       // Mail is handled by DoMixing()
       break;
     case MAIL_PROCESS_NEXT_VOICE:
-      DEBUG_LOG_FMT(DSPHLE, "ASndUCode - MAIL_PROCESS_NEXT_VOICE");
+      DEBUG_LOG_FMT(DSPHLE, "AESndUCode - MAIL_PROCESS_NEXT_VOICE");
       DMAInParameterBlock();  // dma_pb_block
       DoMixing();             // jump to dsp_mixer
       // Mail is handled by DoMixing()
       break;
     case MAIL_GET_PB_ADDRESS:
-      DEBUG_LOG_FMT(DSPHLE, "ASndUCode - MAIL_GET_PB_ADDRESS");
+      DEBUG_LOG_FMT(DSPHLE, "AESndUCode - MAIL_GET_PB_ADDRESS");
       m_next_mail_is_parameter_block_addr = true;
       // No mail is sent in response
       break;
     case MAIL_SEND_SAMPLES:
-      DEBUG_LOG_FMT(DSPHLE, "ASndUCode - MAIL_SEND_SAMPLES");
+      DEBUG_LOG_FMT(DSPHLE, "AESndUCode - MAIL_SEND_SAMPLES");
       // send_samples
       for (u32 i = 0; i < NUM_OUTPUT_SAMPLES * 2; i++)
       {
@@ -160,7 +160,7 @@ void AESndUCode::HandleMail(u32 mail)
       m_mail_handler.PushMail(DSP_SYNC, true);
       break;
     case MAIL_TERMINATE:
-      INFO_LOG_FMT(DSPHLE, "ASndUCode - MAIL_TERMINATE: {:08x}", mail);
+      INFO_LOG_FMT(DSPHLE, "AESndUCode - MAIL_TERMINATE: {:08x}", mail);
       // This doesn't actually change the state of the system.
       m_mail_handler.PushMail(DSP_DONE, true);
       break;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
@@ -23,6 +23,19 @@ public:
   void Update() override;
   void DoState(PointerWrap& p) override;
 
+  // June 5, 2010 version (padded to 0x03e0 bytes) - initial release
+  // First included with libogc 1.8.4 on October 3, 2010: https://devkitpro.org/viewtopic.php?t=2249
+  // https://github.com/devkitPro/libogc/blob/b5fdbdb069c45584aa4dfd950a136a8db9b1144c/libaesnd/dspcode/dspmixer.s
+  static constexpr u32 HASH_2010 = 0x008366af;
+  // April 11, 2012 version (padded to 0x03e0 bytes) - swapped input channels
+  // First included with libogc 1.8.11 on April 22, 2012: https://devkitpro.org/viewtopic.php?t=3094
+  // https://github.com/devkitPro/libogc/commit/8f188e12b6a3d8b5a0d49a109fe6a3e4e1702aab
+  static constexpr u32 HASH_2012 = 0x078066ab;
+  // June 14, 2020 version (0x03e6 bytes) - added unsigned formats
+  // First included with libogc 2.1.0 on June 15, 2020: https://devkitpro.org/viewtopic.php?t=9079
+  // https://github.com/devkitPro/libogc/commit/eac8fe2c29aa790d552dd6166a1fb195dfdcb825
+  static constexpr u32 HASH_2020 = 0x84c680a9;
+
 private:
   void DMAInParameterBlock();
   void DMAOutParameterBlock();

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
@@ -31,6 +31,10 @@ public:
   // First included with libogc 1.8.11 on April 22, 2012: https://devkitpro.org/viewtopic.php?t=3094
   // https://github.com/devkitPro/libogc/commit/8f188e12b6a3d8b5a0d49a109fe6a3e4e1702aab
   static constexpr u32 HASH_2012 = 0x078066ab;
+  // Modified version used by EDuke32 Wii (padded to 0x03e0 bytes) - added unsigned 8-bit formats;
+  // broke the mono formats. The patch is based on the 2010 version, but it also includes the 2012
+  // input channel swap change. https://dukeworld.duke4.net/eduke32/wii/library_source_code/
+  static constexpr u32 HASH_EDUKE32 = 0x5ad4d933;
   // June 14, 2020 version (0x03e6 bytes) - added unsigned formats
   // First included with libogc 2.1.0 on June 15, 2020: https://devkitpro.org/viewtopic.php?t=9079
   // https://github.com/devkitPro/libogc/commit/eac8fe2c29aa790d552dd6166a1fb195dfdcb825
@@ -41,6 +45,9 @@ private:
   void DMAOutParameterBlock();
   void SetUpAccelerator(u16 format, u16 gain);
   void DoMixing();
+
+  bool SwapLeftRight() const;
+  bool UseNewFlagMasks() const;
 
   // Copied from libaesnd/aesndlib.c's aesndpb_t (specifically the first 64 bytes)
 #pragma pack(1)
@@ -83,5 +90,7 @@ private:
   static constexpr u32 NUM_OUTPUT_SAMPLES = 96;
 
   std::array<s16, NUM_OUTPUT_SAMPLES * 2> m_output_buffer{};
+
+  bool m_has_shown_unsupported_sample_format_warning = false;
 };
 }  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
@@ -52,27 +52,6 @@ constexpr u32 NEW_FLAGS_SAMPLE_FORMAT_MASK = 7;
 constexpr u32 FLAGS_SAMPLE_FORMAT_BYTES_MASK = 0xffff0000;
 constexpr u32 FLAGS_SAMPLE_FORMAT_BYTES_SHIFT = 16;
 
-// November 14, 2008 version (padded to 0x05a0 bytes) - initial release
-// https://github.com/devkitPro/libogc/compare/c76d8b851fafc11b0a5debc0b40842929d5a5825~...353a44f038e75e5982eb550173ec8127ab35e3e3
-constexpr u32 HASH_2008 = 0x8d69a19b;
-// February 5, 2009 version (padded to 0x05c0 bytes) - added MAIL_TERMINATE
-// https://github.com/devkitPro/libogc/compare/1925217ffb4c97cbee5cf21fa3c0231029b340e2~...3b1f018dbe372859a43bff8560e2525f6efa4433
-constexpr u32 HASH_2009 = 0xcc2fd441;
-// June 11, 2011 version (padded to 0x0620 bytes) - added new sample formats, which shifted flags
-// Note that the source include in the repo does not match the compiled binary exactly; the compiled
-// version differs by using asl instead of lsl, $acc1 instead of $acc0, and $ac0.l instead of $ac0.m
-// in various locations, as well as having the "jmp out_samp" line uncommented in stereo_16bits_le.
-// None of these result in a behavior difference, from the source, though.
-// Note that gcdsptool was also updated, which results in some differences in the source that don't
-// actually correspond to different instructions (e.g. s40 was renamed to s16)
-// https://github.com/devkitPro/libogc/commit/b1b8ecab3af3745c8df0b401abd512bdf5fcc011
-constexpr u32 HASH_2011 = 0xa81582e2;
-// June 12, 2020 version (0x0606 bytes) - libogc switched to compiling the ucode at build time
-// instead of including a pre-compiled version in the repo, so this now corresponds to the code
-// provided in the repo. There appear to be no behavior differences from the 2011 version.
-// https://github.com/devkitPro/libogc/compare/bfb705fe1607a3031d18b65d603975b68a1cffd4~...d20f9bdcfb43260c6c759f4fb98d724931443f93
-constexpr u32 HASH_2020 = 0xdbbeeb61;
-
 constexpr u32 SAMPLE_RATE = 48000;
 
 ASndUCode::ASndUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
@@ -23,6 +23,27 @@ public:
   void Update() override;
   void DoState(PointerWrap& p) override;
 
+  // November 14, 2008 version (padded to 0x05a0 bytes) - initial release
+  // https://github.com/devkitPro/libogc/compare/c76d8b851fafc11b0a5debc0b40842929d5a5825~...353a44f038e75e5982eb550173ec8127ab35e3e3
+  static constexpr u32 HASH_2008 = 0x8d69a19b;
+  // February 5, 2009 version (padded to 0x05c0 bytes) - added MAIL_TERMINATE
+  // https://github.com/devkitPro/libogc/compare/1925217ffb4c97cbee5cf21fa3c0231029b340e2~...3b1f018dbe372859a43bff8560e2525f6efa4433
+  static constexpr u32 HASH_2009 = 0xcc2fd441;
+  // June 11, 2011 version (padded to 0x0620 bytes) - added new sample formats, which shifted flags
+  // Note that the source include in the repo does not match the compiled binary exactly; the
+  // compiled version differs by using asl instead of lsl, $acc1 instead of $acc0, and $ac0.l
+  // instead of $ac0.m in various locations, as well as having the "jmp out_samp" line uncommented
+  // in stereo_16bits_le. None of these result in a behavior difference, from the source, though.
+  // Note that gcdsptool was also updated, which results in some differences in the source that
+  // don't actually correspond to different instructions (e.g. s40 was renamed to s16)
+  // https://github.com/devkitPro/libogc/commit/b1b8ecab3af3745c8df0b401abd512bdf5fcc011
+  static constexpr u32 HASH_2011 = 0xa81582e2;
+  // June 12, 2020 version (0x0606 bytes) - libogc switched to compiling the ucode at build time
+  // instead of including a pre-compiled version in the repo, so this now corresponds to the code
+  // provided in the repo. There appear to be no behavior differences from the 2011 version.
+  // https://github.com/devkitPro/libogc/compare/bfb705fe1607a3031d18b65d603975b68a1cffd4~...d20f9bdcfb43260c6c759f4fb98d724931443f93
+  static constexpr u32 HASH_2020 = 0xdbbeeb61;
+
 private:
   void DMAInVoiceData();
   void DMAOutVoiceData();

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -291,9 +291,9 @@ std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: ASnd chosen (Homebrew)", crc);
     return std::make_unique<ASndUCode>(dsphle, crc);
 
-  case 0x008366af:
-  case 0x078066ab:
-  case 0x84c680a9:
+  case AESndUCode::HASH_2010:
+  case AESndUCode::HASH_2012:
+  case AESndUCode::HASH_2020:
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: AESnd chosen (Homebrew)", crc);
     return std::make_unique<AESndUCode>(dsphle, crc);
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -284,10 +284,10 @@ std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: Wii - AXWii chosen", crc);
     return std::make_unique<AXWiiUCode>(dsphle, crc);
 
-  case 0x8d69a19b:
-  case 0xcc2fd441:
-  case 0xa81582e2:
-  case 0xdbbeeb61:
+  case ASndUCode::HASH_2008:
+  case ASndUCode::HASH_2009:
+  case ASndUCode::HASH_2011:
+  case ASndUCode::HASH_2020:
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: ASnd chosen (Homebrew)", crc);
     return std::make_unique<ASndUCode>(dsphle, crc);
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -293,6 +293,7 @@ std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
 
   case AESndUCode::HASH_2010:
   case AESndUCode::HASH_2012:
+  case AESndUCode::HASH_EDUKE32:
   case AESndUCode::HASH_2020:
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: AESnd chosen (Homebrew)", crc);
     return std::make_unique<AESndUCode>(dsphle, crc);


### PR DESCRIPTION
The first version is exclusive to [EDuke32 Wii](https://wiibrew.org/wiki/EDuke32_Wii) (see https://bugs.dolphin-emu.org/issues/12990). The second version fixes a bug with `MAIL_TERMINATE` (that hasn't been merged into libogc, and currently only exists in Extrems' libogc2). Like with #10793, I did some checking to confirm that the source and binaries matched, and also checked padding behavior (see [aesnd_ucode_versions_extra.zip](https://github.com/dolphin-emu/dolphin/files/9185568/aesnd_ucode_versions_extra.zip)).

<details><summary>Hashes of various possible versions for search purposes</summary>

```
Hashes of EDuke32/compiled.bin: ector cd6b5364 crc 09f1147b adler f50b2b12 fletcher 5bc2a588; 03de bytes (01ef words)
Hashes of EDuke32/compiled_pad.bin: ector 5ad4d933 crc 97c86f4e adler 4b3e2b12 fletcher 014ba588; 03e0 bytes (01f0 words)
Hashes of EDuke32/dspmixer.bin: ector 5ad4d933 crc 97c86f4e adler 4b3e2b12 fletcher 014ba588; 03e0 bytes (01f0 words)
Hashes of EDuke32/dspmixer_nopad.bin: ector cd6b5364 crc 09f1147b adler f50b2b12 fletcher 5bc2a588; 03de bytes (01ef words)
Hashes of Extrems/compiled.bin: ector 002e5e41 crc 5ba4fb19 adler 2dca2d5e fletcher 37a6ee8d; 03e8 bytes (01f4 words)
Hashes of Extrems/compiled_pad.bin: ector 2e5e4100 crc 8e2da39f adler 6ed62d5e fletcher 664dee8d; 0400 bytes (0200 words)
```

</details>
