### PR TITLE
BBA/BuiltIn: Fix random network errors

### DIFF
--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -8,17 +8,27 @@
 #include <vector>
 
 #ifndef _WIN32
+#include <arpa/inet.h>
+#include <ifaddrs.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <unistd.h>
 #else
 #include <WinSock2.h>
+#include <iphlpapi.h>
+#include <ws2tcpip.h>
+#endif
+
+#ifdef __ANDROID__
+#include "jni/AndroidCommon/AndroidCommon.h"
 #endif
 
 #include <fmt/format.h>
 
 #include "Common/BitUtils.h"
 #include "Common/Random.h"
+#include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
 
 namespace Common
@@ -544,5 +554,117 @@ void RestoreNetworkErrorState(const NetworkErrorState& state)
 #ifdef _WIN32
   WSASetLastError(state.wsa_error);
 #endif
+}
+
+std::optional<DefaultInterface> GetSystemDefaultInterface()
+{
+#ifdef _WIN32
+  std::unique_ptr<MIB_IPFORWARDTABLE> forward_table;
+  DWORD forward_table_size = 0;
+  if (GetIpForwardTable(nullptr, &forward_table_size, FALSE) == ERROR_INSUFFICIENT_BUFFER)
+  {
+    forward_table =
+        std::unique_ptr<MIB_IPFORWARDTABLE>((PMIB_IPFORWARDTABLE) operator new(forward_table_size));
+  }
+
+  std::unique_ptr<MIB_IPADDRTABLE> ip_table;
+  DWORD ip_table_size = 0;
+  if (GetIpAddrTable(nullptr, &ip_table_size, FALSE) == ERROR_INSUFFICIENT_BUFFER)
+  {
+    ip_table = std::unique_ptr<MIB_IPADDRTABLE>((PMIB_IPADDRTABLE) operator new(ip_table_size));
+  }
+
+  // find the interface IP used for the default route and use that
+  NET_IFINDEX ifIndex = NET_IFINDEX_UNSPECIFIED;
+  DWORD result = GetIpForwardTable(forward_table.get(), &forward_table_size, FALSE);
+  // can return ERROR_MORE_DATA on XP even after the first call
+  while (result == NO_ERROR || result == ERROR_MORE_DATA)
+  {
+    for (DWORD i = 0; i < forward_table->dwNumEntries; ++i)
+    {
+      if (forward_table->table[i].dwForwardDest == 0)
+      {
+        ifIndex = forward_table->table[i].dwForwardIfIndex;
+        break;
+      }
+    }
+
+    if (result == NO_ERROR || ifIndex != NET_IFINDEX_UNSPECIFIED)
+      break;
+
+    result = GetIpForwardTable(forward_table.get(), &forward_table_size, FALSE);
+  }
+
+  if (ifIndex != NET_IFINDEX_UNSPECIFIED &&
+      GetIpAddrTable(ip_table.get(), &ip_table_size, FALSE) == NO_ERROR)
+  {
+    for (DWORD i = 0; i < ip_table->dwNumEntries; ++i)
+    {
+      const auto& entry = ip_table->table[i];
+      if (entry.dwIndex == ifIndex)
+        return DefaultInterface{entry.dwAddr, entry.dwMask, entry.dwBCastAddr};
+    }
+  }
+#elif defined(__ANDROID__)
+  const u32 addr = GetNetworkIpAddress();
+  const u32 prefix_length = GetNetworkPrefixLength();
+  const u32 netmask = (1 << prefix_length) - 1;
+  const u32 gateway = GetNetworkGateway();
+  if (addr || netmask || gateway)
+    return DefaultInterface{addr, netmask, gateway};
+#else
+  // Assume that the address that is used to access the Internet corresponds
+  // to the default interface.
+  auto get_default_address = []() -> std::optional<in_addr> {
+    const int sock = socket(AF_INET, SOCK_DGRAM, 0);
+    Common::ScopeGuard sock_guard{[sock] { close(sock); }};
+
+    sockaddr_in addr{};
+    socklen_t length = sizeof(addr);
+    addr.sin_family = AF_INET;
+    // The address and port are irrelevant -- no packet is actually sent. These just need to be set
+    // to a valid IP and port.
+    addr.sin_addr.s_addr = inet_addr("8.8.8.8");
+    addr.sin_port = htons(53);
+    if (connect(sock, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) == -1)
+      return {};
+    if (getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &length) == -1)
+      return {};
+    return addr.sin_addr;
+  };
+
+  auto get_addr = [](const sockaddr* addr) {
+    return reinterpret_cast<const sockaddr_in*>(addr)->sin_addr.s_addr;
+  };
+
+  const auto default_interface_address = get_default_address();
+  if (!default_interface_address)
+    return {};
+
+  ifaddrs* iflist;
+  if (getifaddrs(&iflist) != 0)
+    return {};
+  Common::ScopeGuard iflist_guard{[iflist] { freeifaddrs(iflist); }};
+
+  for (const ifaddrs* iface = iflist; iface; iface = iface->ifa_next)
+  {
+    if (iface->ifa_addr && iface->ifa_addr->sa_family == AF_INET &&
+        get_addr(iface->ifa_addr) == default_interface_address->s_addr)
+    {
+      return DefaultInterface{get_addr(iface->ifa_addr), get_addr(iface->ifa_netmask),
+                              get_addr(iface->ifa_broadaddr)};
+    }
+  }
+#endif
+  return std::nullopt;
+}
+
+DefaultInterface GetSystemDefaultInterfaceOrFallback()
+{
+  static const u32 FALLBACK_IP = inet_addr("10.0.1.30");
+  static const u32 FALLBACK_NETMASK = inet_addr("255.255.255.0");
+  static const u32 FALLBACK_GATEWAY = inet_addr("10.0.255.255");
+  static const DefaultInterface FALLBACK_VALUES{FALLBACK_IP, FALLBACK_NETMASK, FALLBACK_GATEWAY};
+  return GetSystemDefaultInterface().value_or(FALLBACK_VALUES);
 }
 }  // namespace Common

--- a/Source/Core/Common/Network.h
+++ b/Source/Core/Common/Network.h
@@ -257,6 +257,14 @@ struct NetworkErrorState
 #endif
 };
 
+// u32 values are in network endian
+struct DefaultInterface
+{
+  u32 inet;       // IPv4 address
+  u32 netmask;    // IPv4 subnet mask
+  u32 broadcast;  // IPv4 broadcast address
+};
+
 MACAddress GenerateMacAddress(MACConsumer type);
 std::string MacAddressToString(const MACAddress& mac);
 std::optional<MACAddress> StringToMacAddress(std::string_view mac_string);
@@ -265,4 +273,6 @@ u16 ComputeTCPNetworkChecksum(const IPAddress& from, const IPAddress& to, const 
                               u16 length, u8 protocol);
 NetworkErrorState SaveNetworkErrorState();
 void RestoreNetworkErrorState(const NetworkErrorState& state);
+std::optional<DefaultInterface> GetSystemDefaultInterface();
+DefaultInterface GetSystemDefaultInterfaceOrFallback();
 }  // namespace Common

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -468,23 +468,18 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleUDPFrame(const Common::UDPPacket& 
         ERROR_LOG_FMT(SP1, "Couldn't open UDP socket");
         return;
       }
-      if (ntohs(udp_header.destination_port) == 1900)
+      if (ntohs(udp_header.destination_port) == 1900 && udp_header.length > 150)
       {
-        InitUDPPort(26512);  // MK DD and 1080
-        InitUDPPort(26502);  // Air Ride
-        if (udp_header.length > 150)
-        {
-          // Quick hack to unlock the connection, throw it back at him
-          Common::UDPPacket reply = packet;
-          reply.eth_header.destination = hwdata.source;
-          reply.eth_header.source = hwdata.destination;
-          reply.ip_header.destination_addr = ip_header.source_addr;
-          if (ip_header.destination_addr == Common::IP_ADDR_SSDP)
-            reply.ip_header.source_addr = Common::IP_ADDR_BROADCAST;
-          else
-            reply.ip_header.source_addr = Common::BitCast<Common::IPAddress>(destination_addr);
-          WriteToQueue(reply.Build());
-        }
+        // Quick hack to unlock the connection, throw it back at him
+        Common::UDPPacket reply = packet;
+        reply.eth_header.destination = hwdata.source;
+        reply.eth_header.source = hwdata.destination;
+        reply.ip_header.destination_addr = ip_header.source_addr;
+        if (ip_header.destination_addr == Common::IP_ADDR_SSDP)
+          reply.ip_header.source_addr = Common::IP_ADDR_BROADCAST;
+        else
+          reply.ip_header.source_addr = Common::BitCast<Common::IPAddress>(destination_addr);
+        WriteToQueue(reply.Build());
       }
     }
   }
@@ -674,6 +669,8 @@ bool CEXIETHERNET::BuiltInBBAInterface::RecvInit()
 
 void CEXIETHERNET::BuiltInBBAInterface::RecvStart()
 {
+  InitUDPPort(26512);  // MK DD and 1080
+  InitUDPPort(26502);  // Air Ride
   m_read_enabled.Set();
 }
 

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -1,12 +1,16 @@
 // Copyright 2022 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <SFML/Network.hpp>
+#include "Core/HW/EXI/BBA/BuiltIn.h"
+
+#ifndef _WIN32
+#include <sys/socket.h>
+#include <sys/types.h>
+#endif
 
 #include "Common/BitUtils.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
-#include "Core/HW/EXI/BBA/BuiltIn.h"
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/HW/EXI/EXI_DeviceEthernet.h"
 

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -342,7 +342,7 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleTCPFrame(const Common::TCPPacket& 
 
     ref->seq_num++;
     target = sf::IpAddress(ntohl(Common::BitCast<u32>(ip_header.destination_addr)));
-    ref->tcp_socket.connect(target, ntohs(tcp_header.destination_port));
+    ref->tcp_socket.Connect(target, ntohs(tcp_header.destination_port));
     ref->ready = false;
     ref->ip = Common::BitCast<u32>(ip_header.destination_addr);
 
@@ -428,7 +428,7 @@ void CEXIETHERNET::BuiltInBBAInterface::InitUDPPort(u16 port)
   ref->to.sin_addr.s_addr = m_current_ip;
   ref->to.sin_port = htons(port);
   ref->udp_socket.setBlocking(false);
-  if (ref->udp_socket.bind(port) != sf::Socket::Done)
+  if (ref->udp_socket.Bind(port) != sf::Socket::Done)
   {
     ERROR_LOG_FMT(SP1, "Couldn't open UDP socket");
     PanicAlertFmt("Could't open port {:x}, this game might not work proprely in LAN mode.", port);
@@ -458,12 +458,12 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleUDPFrame(const Common::UDPPacket& 
     ref->to.sin_addr.s_addr = Common::BitCast<u32>(ip_header.source_addr);
     ref->to.sin_port = udp_header.source_port;
     ref->udp_socket.setBlocking(false);
-    if (ref->udp_socket.bind(htons(udp_header.source_port)) != sf::Socket::Done)
+    if (ref->udp_socket.Bind(ntohs(udp_header.source_port)) != sf::Socket::Done)
     {
       PanicAlertFmt(
           "Port {:x} is already in use, this game might not work as intented in LAN Mode.",
           htons(udp_header.source_port));
-      if (ref->udp_socket.bind(sf::Socket::AnyPort) != sf::Socket::Done)
+      if (ref->udp_socket.Bind(sf::Socket::AnyPort) != sf::Socket::Done)
       {
         ERROR_LOG_FMT(SP1, "Couldn't open UDP socket");
         return;
@@ -692,3 +692,24 @@ void CEXIETHERNET::BuiltInBBAInterface::RecvStop()
   m_queue_write = 0;
 }
 }  // namespace ExpansionInterface
+
+BbaTcpSocket::BbaTcpSocket() = default;
+
+sf::Socket::Status BbaTcpSocket::Connect(const sf::IpAddress& ip, u16 port, sf::Time timeout)
+{
+  const auto net_interface = Common::GetSystemDefaultInterfaceOrFallback();
+  sockaddr_in addr;
+  addr.sin_addr.s_addr = net_interface.inet;
+  addr.sin_family = AF_INET;
+  addr.sin_port = 0;
+  ::bind(getHandle(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+  return this->connect(ip, port, timeout);
+}
+
+BbaUdpSocket::BbaUdpSocket() = default;
+
+sf::Socket::Status BbaUdpSocket::Bind(u16 port)
+{
+  const auto net_interface = Common::GetSystemDefaultInterfaceOrFallback();
+  return this->bind(port, sf::IpAddress(ntohl(net_interface.inet)));
+}

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
@@ -50,6 +50,11 @@ public:
   BbaUdpSocket();
 
   sf::Socket::Status Bind(u16 port);
+  sf::Socket::Status Send(const void* data, std::size_t size, const sf::IpAddress& addr,
+                          unsigned short port);
+
+private:
+  bool m_bind_any = false;
 };
 
 struct StackRef

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
@@ -34,6 +34,24 @@ struct TcpBuffer
   std::vector<u8> data;
 };
 
+// Socket helper class to ensure network interface consistency
+class BbaTcpSocket : public sf::TcpSocket
+{
+public:
+  BbaTcpSocket();
+
+  sf::Socket::Status Connect(const sf::IpAddress& addr, u16 port,
+                             sf::Time timeout = sf::Time::Zero);
+};
+
+class BbaUdpSocket : public sf::UdpSocket
+{
+public:
+  BbaUdpSocket();
+
+  sf::Socket::Status Bind(u16 port);
+};
+
 struct StackRef
 {
   u32 ip;
@@ -52,7 +70,7 @@ struct StackRef
   sockaddr_in to;
   Common::MACAddress bba_mac{};
   Common::MACAddress my_mac{};
-  sf::UdpSocket udp_socket;
-  sf::TcpSocket tcp_socket;
+  BbaUdpSocket udp_socket;
+  BbaTcpSocket tcp_socket;
   u64 poke_time;
 };


### PR DESCRIPTION
This PR fixes Kirby Air Ride LAN mode not working for me. I had several issues. The first one being, for some weird reasons Dolphin was switching back and forth between my WiFi and VM networks. The second one, there was a timing issue where an instance of Dolphin send an UDP packet to the other one but it didn't have enough time to open the UDP port.

I addressed the first issue by binding the socket to the right network interface. The second issue is addressed by reserving the UDP ports during the initialisation rather than waiting to receive the right SSDP packet.

@JMC47 
Does it solve your connection issue?

@schthack @nolrinale
You might want to check that this PR doesn't introduce regression regarding the PSO games.

_One last thing regarding Windows 10. Testing this was a **nightmare**, I think the issue is Windows not my router but I had to do more thorough testing to confirm that. Often, my Windows 10 laptop blacklists (temporarily) my other devices (broadcasting UDP packets via Dolphin, namely Android and Linux) even with most protections (AV, Firewall, ...) turned off and then drop all packets from them. I had to manually send packets from my Windows 10 to the other devices to removed them (temporarily... it seems ><') from this blacklist. This is a standard Windows 10 Home edition install, I'm unsure what is causing this network issue but when sorted and Dolphin issues addressed, the BuiltIn adapter worked as expected._

Ready to be reviewed & tested.