### PR TITLE
LogManager: Dynamically get last log type

### DIFF
--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -68,6 +68,9 @@ enum class LogType : int
   NUMBER_OF_LOGS  // Must be last
 };
 
+constexpr LogType LAST_LOG_TYPE =
+    static_cast<LogType>(static_cast<int>(LogType::NUMBER_OF_LOGS) - 1);
+
 enum class LogLevel : int
 {
   LNOTICE = 1,   // VERY important information that is NOT errors. Like startup and OSReports.

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -76,7 +76,7 @@ private:
   LogManager& operator=(LogManager&&) = delete;
 
   LogLevel m_level;
-  EnumMap<LogContainer, LogType::WIIMOTE> m_log{};
+  EnumMap<LogContainer, LAST_LOG_TYPE> m_log{};
   std::array<LogListener*, LogListener::NUMBER_OF_LISTENERS> m_listeners{};
   BitSet32 m_listener_ids;
   size_t m_path_cutoff_point = 0;


### PR DESCRIPTION
Adding this due to 14 days of on and off debugging all because of the last log type being wrong, this will just grab that last type automatically.