### PR TITLE
DSPHLE: Support padded versions of libasnd and libaesnd uCodes

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
@@ -70,12 +70,14 @@ constexpr u32 ACCELERATOR_GAIN_16_BIT = 0x0800;
 
 bool AESndUCode::SwapLeftRight() const
 {
-  return m_crc == HASH_2012 || m_crc == HASH_EDUKE32 || m_crc == HASH_2020;
+  return m_crc == HASH_2012 || m_crc == HASH_EDUKE32 || m_crc == HASH_2020 ||
+         m_crc == HASH_2020_PAD || m_crc == HASH_2022_PAD;
 }
 
 bool AESndUCode::UseNewFlagMasks() const
 {
-  return m_crc == HASH_EDUKE32 || m_crc == HASH_2020;
+  return m_crc == HASH_EDUKE32 || m_crc == HASH_2020 || m_crc == HASH_2020_PAD ||
+         m_crc == HASH_2022_PAD;
 }
 
 AESndUCode::AESndUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
@@ -161,7 +163,7 @@ void AESndUCode::HandleMail(u32 mail)
       break;
     case MAIL_TERMINATE:
       INFO_LOG_FMT(DSPHLE, "AESndUCode - MAIL_TERMINATE: {:08x}", mail);
-      if (true)  // currently no mainline libogc uCode has this issue fixed
+      if (m_crc != HASH_2022_PAD)
       {
         // The relevant code looks like this:
         //

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
@@ -39,6 +39,16 @@ public:
   // First included with libogc 2.1.0 on June 15, 2020: https://devkitpro.org/viewtopic.php?t=9079
   // https://github.com/devkitPro/libogc/commit/eac8fe2c29aa790d552dd6166a1fb195dfdcb825
   static constexpr u32 HASH_2020 = 0x84c680a9;
+  // Padded version of the above (0x0400 bytes), added to libogc-rice on June 16, 2012 (that's the
+  // commit author date; the commit date is November 24, 2016) and libogc2 on 25 May 2020. Used by
+  // Not64 and OpenTTD (starting with the December 1, 2012 release).
+  // https://github.com/extremscorner/libogc-rice/commit/cfddd4f3bec77812d6d333954e39d401d2276cd8
+  // https://github.com/extremscorner/libogc2/commit/89ae39544e22f720a9c986af3524f7e6f20e7293
+  static constexpr u32 HASH_2020_PAD = 0xa02a6131;
+  // July 19, 2022 version (padded to 0x0400 bytes) - fixed MAIL_TERMINATE. This is not currently
+  // included in libogc, only in libogc2 and libogc-rice (which generate a padded header file).
+  // https://github.com/extremscorner/libogc2/commit/38edc9db93232faa612f680c91be1eb4d95dd1c6
+  static constexpr u32 HASH_2022_PAD = 0x2e5e4100;
 
 private:
   void DMAInParameterBlock();

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
@@ -54,6 +54,11 @@ constexpr u32 FLAGS_SAMPLE_FORMAT_BYTES_SHIFT = 16;
 
 constexpr u32 SAMPLE_RATE = 48000;
 
+bool ASndUCode::UseNewFlagMasks() const
+{
+  return m_crc == HASH_2011 || m_crc == HASH_2020 || m_crc == HASH_2020_PAD;
+}
+
 ASndUCode::ASndUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 {
 }
@@ -239,9 +244,8 @@ void ASndUCode::DoMixing(u32 return_mail)
 
   // start_main
 
-  const u32 sample_format_mask = (m_crc == HASH_2011 || m_crc == HASH_2020) ?
-                                     NEW_FLAGS_SAMPLE_FORMAT_MASK :
-                                     OLD_FLAGS_SAMPLE_FORMAT_MASK;
+  const u32 sample_format_mask =
+      UseNewFlagMasks() ? NEW_FLAGS_SAMPLE_FORMAT_MASK : OLD_FLAGS_SAMPLE_FORMAT_MASK;
   const u32 sample_format = m_current_voice.flags & sample_format_mask;
   const u32 sample_format_step =
       (m_current_voice.flags & FLAGS_SAMPLE_FORMAT_BYTES_MASK) >> FLAGS_SAMPLE_FORMAT_BYTES_SHIFT;
@@ -255,8 +259,7 @@ void ASndUCode::DoMixing(u32 return_mail)
   };
   const auto sample_function = sample_selector[sample_format];
 
-  const u32 pause_mask =
-      (m_crc == HASH_2011 || m_crc == HASH_2020) ? NEW_FLAGS_VOICE_PAUSE : OLD_FLAGS_VOICE_PAUSE;
+  const u32 pause_mask = UseNewFlagMasks() ? NEW_FLAGS_VOICE_PAUSE : OLD_FLAGS_VOICE_PAUSE;
 
   if ((m_current_voice.flags & pause_mask) == 0)
   {
@@ -417,8 +420,7 @@ void ASndUCode::ChangeBuffer()
   m_current_voice.start_addr = m_current_voice.start_addr2;
   m_current_voice.backup_addr = m_current_voice.start_addr2;
 
-  const u32 loop_mask =
-      (m_crc == HASH_2011 || m_crc == HASH_2020) ? NEW_FLAGS_VOICE_LOOP : OLD_FLAGS_VOICE_LOOP;
+  const u32 loop_mask = UseNewFlagMasks() ? NEW_FLAGS_VOICE_LOOP : OLD_FLAGS_VOICE_LOOP;
 
   if ((m_current_voice.flags & loop_mask) == 0)
   {

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
@@ -43,6 +43,14 @@ public:
   // provided in the repo. There appear to be no behavior differences from the 2011 version.
   // https://github.com/devkitPro/libogc/compare/bfb705fe1607a3031d18b65d603975b68a1cffd4~...d20f9bdcfb43260c6c759f4fb98d724931443f93
   static constexpr u32 HASH_2020 = 0xdbbeeb61;
+  // Variant of the above used in libogc-rice and libogc2 starting on December 11, 2020 and padded
+  // to 0x0620 bytes. These forks have gcdsptool generate a header file instead of a bin file
+  // (followed by bin2o), so padding is still applied (for libogc-rice, the header is manually
+  // generated, while libogc2 generates it as part of the build process).
+  // https://github.com/extremscorner/libogc2/commit/80e01cbd8ead0370d98e092b426f851f21175e60
+  // https://github.com/extremscorner/libogc2/commit/0b64f879808953d80ba06501a1c079b0fbf017d2
+  // https://github.com/extremscorner/libogc-rice/commit/ce22c3269699fdbd474f2f28ca2ffca211954659
+  static constexpr u32 HASH_2020_PAD = 0xbad876ef;
 
 private:
   void DMAInVoiceData();
@@ -51,6 +59,8 @@ private:
   void DMAInSampleDataAssumeAligned();
   void ChangeBuffer();
   void DoMixing(u32 return_mail);
+
+  bool UseNewFlagMasks() const;
 
   std::pair<s16, s16> ReadSampleMono8Bits() const;
   std::pair<s16, s16> ReadSampleStereo8Bits() const;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -296,6 +296,8 @@ std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
   case AESndUCode::HASH_2012:
   case AESndUCode::HASH_EDUKE32:
   case AESndUCode::HASH_2020:
+  case AESndUCode::HASH_2020_PAD:
+  case AESndUCode::HASH_2022_PAD:
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: AESnd chosen (Homebrew)", crc);
     return std::make_unique<AESndUCode>(dsphle, crc);
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -288,6 +288,7 @@ std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
   case ASndUCode::HASH_2009:
   case ASndUCode::HASH_2011:
   case ASndUCode::HASH_2020:
+  case ASndUCode::HASH_2020_PAD:
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: ASnd chosen (Homebrew)", crc);
     return std::make_unique<ASndUCode>(dsphle, crc);
 


### PR DESCRIPTION
Here are some tests with the current libogc and also extremscorner/libogc2@5cf525b151f3399a26176edaae23e9e037732c1d and extremscorner/libogc2@ac91c274586509d77244b9f225868164f7bb148d. `modplay` has been edited to call `AESND_Reset()` before `exit(0)`, which correctly results in a hang on DSP LLE and a warning log on DSP HLE for all versions other than the most recent libogc2 version. All have had their makefiles edited to have `LIBS` use `~/dkp/libogc2/lib/wii/libaesnd.a` or `~/dkp/libogc2/lib/wii/libasnd.a` instead of `-laesnd` or `-lasnd`. Before, the libogc2 versions would result in an unknown ucode CRC. [audio_examples.zip](https://github.com/dolphin-emu/dolphin/files/9194427/audio_examples.zip)

I also tested https://wiibrew.org/wiki/OpenTTD and confirmed that its audio plays correctly now. (This is a lot easier to install now that the SD card folder support exists.)

As with #10892/#10793/#10763, I have notes regarding the commits corresponding to these ucode versions: [asnd_ucode_pad_notes.zip](https://github.com/dolphin-emu/dolphin/files/9194458/asnd_ucode_pad_notes.zip) [aesnd_ucode_pad_notes.zip](https://github.com/dolphin-emu/dolphin/files/9194463/aesnd_ucode_pad_notes.zip)

<details><summary>Index of the above (for search)</summary>

Asnd:

```
Hashes of Extrems/compiled.bin: ector dbbeeb61 crc eb11e980 adler 4a12c76d fletcher ffc46bba; 0606 bytes (0303 words)
Hashes of Extrems/compiled_pad.bin: ector bad876ef crc 5629d6d3 adler 8c50c76d fletcher 783c6bba; 0620 bytes (0310 words)
Hashes of Extrems/dsp_mixer.bin: ector bad876ef crc 5629d6d3 adler 8c50c76d fletcher 783c6bba; 0620 bytes (0310 words)
Hashes of Extrems/dsp_mixer_nopad.bin: ector dbbeeb61 crc eb11e980 adler 4a12c76d fletcher ffc46bba; 0606 bytes (0303 words)
```

Aesnd:

```
Hashes of Extrems6/compiled.bin: ector 84c680a9 crc 1b1beb1d adler 2d952c7f fletcher 24058e0e; 03e6 bytes (01f3 words)
Hashes of Extrems6/compiled_pad.bin: ector a02a6131 crc a0872f31 adler b2b72c7f fletcher 5ac28e0e; 0400 bytes (0200 words)
Hashes of Extrems6/dspmixer.bin: ector a02a6131 crc a0872f31 adler b2b72c7f fletcher 5ac28e0e; 0400 bytes (0200 words)
Hashes of Extrems6/dspmixer_nopad.bin: ector 84c680a9 crc 1b1beb1d adler 2d952c7f fletcher 24058e0e; 03e6 bytes (01f3 words)
Hashes of Extrems/compiled.bin: ector 002e5e41 crc 5ba4fb19 adler 2dca2d5e fletcher 37a6ee8d; 03e8 bytes (01f4 words)
Hashes of Extrems/compiled_pad.bin: ector 2e5e4100 crc 8e2da39f adler 6ed62d5e fletcher 664dee8d; 0400 bytes (0200 words)
Hashes of Extrems/dspmixer.bin: ector 2e5e4100 crc 8e2da39f adler 6ed62d5e fletcher 664dee8d; 0400 bytes (0200 words)
Hashes of Extrems/dspmixer_nopad.bin: ector 002e5e41 crc 5ba4fb19 adler 2dca2d5e fletcher 37a6ee8d; 03e8 bytes (01f4 words)
```

</details>