### PR TITLE
CMake: Set SKIP_INSTALL_ALL for zlib-ng to avoid installing it.

### DIFF
--- a/Externals/zlib-ng/CMakeLists.txt
+++ b/Externals/zlib-ng/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(ZLIB_ENABLE_TESTS OFF)
 set(ZLIB_COMPAT ON)
+set(SKIP_INSTALL_ALL ON)
 
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
 


### PR DESCRIPTION
This should hopefully fix https://github.com/dolphin-emu/dolphin/pull/10888#issuecomment-1196214126

@theofficialgman please verify.