### PR TITLE
SConfig: Convert bool parameter to scoped enum

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -98,14 +98,14 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
   // Override out-of-region languages/countries to prevent games from crashing or behaving oddly
   if (!Config::Get(Config::MAIN_OVERRIDE_REGION_SETTINGS))
   {
-    Config::SetCurrent(
-        Config::MAIN_GC_LANGUAGE,
-        DiscIO::ToGameCubeLanguage(StartUp.GetLanguageAdjustedForRegion(false, StartUp.m_region)));
+    Config::SetCurrent(Config::MAIN_GC_LANGUAGE,
+                       DiscIO::ToGameCubeLanguage(StartUp.GetLanguageAdjustedForRegion(
+                           DiscIO::Platform::GameCubeDisc, StartUp.m_region)));
 
     if (StartUp.bWii)
     {
-      const u32 wii_language =
-          static_cast<u32>(StartUp.GetLanguageAdjustedForRegion(true, StartUp.m_region));
+      const u32 wii_language = static_cast<u32>(
+          StartUp.GetLanguageAdjustedForRegion(DiscIO::Platform::WiiDisc, StartUp.m_region));
       if (wii_language != Config::Get(Config::SYSCONF_LANGUAGE))
         Config::SetCurrent(Config::SYSCONF_LANGUAGE, wii_language);
 

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -99,13 +99,13 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
   if (!Config::Get(Config::MAIN_OVERRIDE_REGION_SETTINGS))
   {
     Config::SetCurrent(Config::MAIN_GC_LANGUAGE,
-                       DiscIO::ToGameCubeLanguage(StartUp.GetLanguageAdjustedForRegion(
+                       DiscIO::ToGameCubeLanguage(StartUp.GetAdjustedLanguage(
                            DiscIO::Platform::GameCubeDisc, StartUp.m_region)));
 
     if (StartUp.bWii)
     {
       const u32 wii_language = static_cast<u32>(
-          StartUp.GetLanguageAdjustedForRegion(DiscIO::Platform::WiiDisc, StartUp.m_region));
+          StartUp.GetAdjustedLanguage(DiscIO::Platform::WiiDisc, StartUp.m_region));
       if (wii_language != Config::Get(Config::SYSCONF_LANGUAGE))
         Config::SetCurrent(Config::SYSCONF_LANGUAGE, wii_language);
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -172,7 +172,9 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   }
 
   const Core::TitleDatabase title_database;
-  const DiscIO::Language language = GetLanguageAdjustedForRegion(bWii, region);
+  const DiscIO::Platform platform =
+      bWii ? DiscIO::Platform::WiiDisc : DiscIO::Platform::GameCubeDisc;
+  const DiscIO::Language language = GetLanguageAdjustedForRegion(platform, region);
   m_title_name = title_database.GetTitleName(m_gametdb_id, language);
   m_title_description = title_database.Describe(m_gametdb_id, language);
   NOTICE_LOG_FMT(CORE, "Active title: {}", m_title_description);
@@ -338,10 +340,10 @@ bool SConfig::SetPathsAndGameMetadata(const BootParameters& boot)
   return true;
 }
 
-DiscIO::Language SConfig::GetCurrentLanguage(bool wii) const
+DiscIO::Language SConfig::GetCurrentLanguage(const DiscIO::Platform platform) const
 {
   DiscIO::Language language;
-  if (wii)
+  if (DiscIO::IsWii(platform))
     language = static_cast<DiscIO::Language>(Config::Get(Config::SYSCONF_LANGUAGE));
   else
     language = DiscIO::FromGameCubeLanguage(Config::Get(Config::MAIN_GC_LANGUAGE));
@@ -352,9 +354,11 @@ DiscIO::Language SConfig::GetCurrentLanguage(bool wii) const
   return language;
 }
 
-DiscIO::Language SConfig::GetLanguageAdjustedForRegion(bool wii, DiscIO::Region region) const
+DiscIO::Language SConfig::GetLanguageAdjustedForRegion(const DiscIO::Platform platform,
+                                                       DiscIO::Region region) const
 {
-  const DiscIO::Language language = GetCurrentLanguage(wii);
+  const DiscIO::Language language = GetCurrentLanguage(platform);
+  const bool wii = DiscIO::IsWii(platform);
 
   if (!wii && region == DiscIO::Region::NTSC_K)
     region = DiscIO::Region::NTSC_J;  // NTSC-K only exists on Wii, so use a fallback

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -174,7 +174,7 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   const Core::TitleDatabase title_database;
   const DiscIO::Platform platform =
       bWii ? DiscIO::Platform::WiiDisc : DiscIO::Platform::GameCubeDisc;
-  const DiscIO::Language language = GetLanguageAdjustedForRegion(platform, region);
+  const DiscIO::Language language = GetAdjustedLanguage(platform, region);
   m_title_name = title_database.GetTitleName(m_gametdb_id, language);
   m_title_description = title_database.Describe(m_gametdb_id, language);
   NOTICE_LOG_FMT(CORE, "Active title: {}", m_title_description);
@@ -354,8 +354,8 @@ DiscIO::Language SConfig::GetCurrentLanguage(const DiscIO::Platform platform) co
   return language;
 }
 
-DiscIO::Language SConfig::GetLanguageAdjustedForRegion(const DiscIO::Platform platform,
-                                                       DiscIO::Region region) const
+DiscIO::Language SConfig::GetAdjustedLanguage(const DiscIO::Platform platform,
+                                              DiscIO::Region region) const
 {
   const DiscIO::Language language = GetCurrentLanguage(platform);
   const bool wii = DiscIO::IsWii(platform);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -74,8 +74,7 @@ struct SConfig
   static std::string MakeGameID(std::string_view file_name);
   bool SetPathsAndGameMetadata(const BootParameters& boot);
   DiscIO::Language GetCurrentLanguage(DiscIO::Platform platform) const;
-  DiscIO::Language GetLanguageAdjustedForRegion(DiscIO::Platform platform,
-                                                DiscIO::Region region) const;
+  DiscIO::Language GetAdjustedLanguage(DiscIO::Platform platform, DiscIO::Region region) const;
 
   IniFile LoadDefaultGameIni() const;
   IniFile LoadLocalGameIni() const;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -73,8 +73,9 @@ struct SConfig
   void LoadDefaults();
   static std::string MakeGameID(std::string_view file_name);
   bool SetPathsAndGameMetadata(const BootParameters& boot);
-  DiscIO::Language GetCurrentLanguage(bool wii) const;
-  DiscIO::Language GetLanguageAdjustedForRegion(bool wii, DiscIO::Region region) const;
+  DiscIO::Language GetCurrentLanguage(DiscIO::Platform platform) const;
+  DiscIO::Language GetLanguageAdjustedForRegion(DiscIO::Platform platform,
+                                                DiscIO::Region region) const;
 
   IniFile LoadDefaultGameIni() const;
   IniFile LoadLocalGameIni() const;

--- a/Source/Core/DolphinQt/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt/Config/InfoWidget.cpp
@@ -211,8 +211,8 @@ QLineEdit* InfoWidget::CreateValueDisplay(const std::string& value)
 
 void InfoWidget::CreateLanguageSelector()
 {
-  const bool is_wii = DiscIO::IsWii(m_game.GetPlatform());
-  const DiscIO::Language preferred_language = SConfig::GetInstance().GetCurrentLanguage(is_wii);
+  const DiscIO::Language preferred_language =
+      SConfig::GetInstance().GetCurrentLanguage(m_game.GetPlatform());
 
   m_language_selector = new QComboBox();
   for (DiscIO::Language language : m_game.GetLanguages())

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1119,7 +1119,7 @@ void MenuBar::ExportWiiSaves()
 void MenuBar::CheckNAND()
 {
   IOS::HLE::Kernel ios;
-  WiiUtils::NANDCheckResult result = WiiUtils::CheckNAND(ios);
+  const WiiUtils::NANDCheckResult result = WiiUtils::CheckNAND(ios);
   if (!result.bad)
   {
     ModalMessageBox::information(this, tr("NAND Check"), tr("No issues have been detected."));
@@ -1132,8 +1132,9 @@ void MenuBar::CheckNAND()
   if (!result.titles_to_remove.empty())
   {
     std::string title_listings;
-    Core::TitleDatabase title_db;
-    const DiscIO::Language language = SConfig::GetInstance().GetCurrentLanguage(true);
+    const Core::TitleDatabase title_db;
+    const DiscIO::Language language =
+        SConfig::GetInstance().GetCurrentLanguage(DiscIO::Platform::WiiDisc);
     for (const u64 title_id : result.titles_to_remove)
     {
       title_listings += StringFromFormat("%016" PRIx64, title_id);

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -67,7 +67,7 @@ bool UseGameCovers()
 
 DiscIO::Language GameFile::GetConfigLanguage() const
 {
-  return SConfig::GetInstance().GetLanguageAdjustedForRegion(DiscIO::IsWii(m_platform), m_region);
+  return SConfig::GetInstance().GetLanguageAdjustedForRegion(m_platform, m_region);
 }
 
 bool operator==(const GameBanner& lhs, const GameBanner& rhs)
@@ -260,7 +260,7 @@ void GameFile::DownloadDefaultCover()
     break;
   case DiscIO::Region::PAL:
   {
-    const auto user_lang = SConfig::GetInstance().GetCurrentLanguage(DiscIO::IsWii(GetPlatform()));
+    const auto user_lang = SConfig::GetInstance().GetCurrentLanguage(GetPlatform());
     switch (user_lang)
     {
     case DiscIO::Language::German:

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -67,7 +67,7 @@ bool UseGameCovers()
 
 DiscIO::Language GameFile::GetConfigLanguage() const
 {
-  return SConfig::GetInstance().GetLanguageAdjustedForRegion(m_platform, m_region);
+  return SConfig::GetInstance().GetAdjustedLanguage(m_platform, m_region);
 }
 
 bool operator==(const GameBanner& lhs, const GameBanner& rhs)


### PR DESCRIPTION
GetCurrentLanguage and GetLanguageAdjustedForRegion both take a bool representing whether the current platform is wii, which isn't very clear when called with true or false literals. This PR makes them use the DiscIO::Platform scoped enum instead.

GetLanguageAdjustedForRegion omitted the fact that it took a bool (now Platform) and GetLanguageAdjustedForPlatformAndRegion is rather cumbersome so I renamed it GetAdjustedLanguage. Now that both parameters are scoped enums describing the parameters in the name is redundant anyway.