### PR TITLE
Common/Hash: use zlib-ng for adler32. small cleanups.

### DIFF
--- a/Source/Core/Common/Hash.h
+++ b/Source/Core/Common/Hash.h
@@ -10,14 +10,15 @@
 
 namespace Common
 {
-u32 HashFletcher(const u8* data_u8, size_t length);  // FAST. Length & 1 == 0.
-u32 HashAdler32(const u8* data, size_t len);         // Fairly accurate, slightly slower
-u32 HashEctor(const u8* ptr, size_t length);         // JUNK. DO NOT USE FOR NEW THINGS
-u64 GetHash64(const u8* src, u32 len, u32 samples);
-void SetHash64Function();
+u32 HashAdler32(const u8* data, size_t len);
+// JUNK. DO NOT USE FOR NEW THINGS
+u32 HashEctor(const u8* data, size_t len);
 
-u32 ComputeCRC32(std::string_view data);
-u32 ComputeCRC32(const u8* ptr, u32 length);
+// Specialized hash function used for the texture cache
+u64 GetHash64(const u8* src, u32 len, u32 samples);
+
 u32 StartCRC32();
-u32 UpdateCRC32(u32 crc, const u8* ptr, u32 length);
+u32 UpdateCRC32(u32 crc, const u8* data, size_t len);
+u32 ComputeCRC32(const u8* data, size_t len);
+u32 ComputeCRC32(std::string_view data);
 }  // namespace Common

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -1175,8 +1175,8 @@ void VolumeVerifier::Process()
     if (m_hashes_to_calculate.crc32)
     {
       m_crc32_future = std::async(std::launch::async, [this, byte_increment] {
-        m_crc32_context =
-            Common::UpdateCRC32(m_crc32_context, m_data.data(), static_cast<u32>(byte_increment));
+        m_crc32_context = Common::UpdateCRC32(m_crc32_context, m_data.data(),
+                                              static_cast<size_t>(byte_increment));
       });
     }
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -94,8 +94,6 @@ TextureCacheBase::TextureCacheBase()
 
   HiresTexture::Init();
 
-  Common::SetHash64Function();
-
   TMEM::InvalidateAll();
 }
 


### PR DESCRIPTION
For "larger" buffer sizes, like those used by `CompressedBlobReader`, I've seen it be up to 20x faster (smaller buffers are generally faster as well, but not by as large a margin). Admittedly it's still a really small amount of wall clock time either way. 


edit: actaully looking more, this seems to be a large speedup for `CompressedBlobReader` use cases that read larger chunks. Haven't measured exactly, but the adler32 call for netplay's 8MiB chunks goes from taking 12-13% of *total* time, to < 1% of it (zlib-ng has chosen `adler32_avx2` on my system, fwiw)