### PR TITLE
[[unlikely]] ASSERT and minor ASSERT usage changes

### DIFF
--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -11,7 +11,7 @@
 #define ASSERT_MSG(_t_, _a_, _fmt_, ...)                                                           \
   do                                                                                               \
   {                                                                                                \
-    if (!(_a_))                                                                                    \
+    if (!(_a_)) [[unlikely]]                                                                       \
     {                                                                                              \
       if (!PanicYesNoFmtAssert(_t_,                                                                \
                                "An error occurred.\n\n" _fmt_ "\n\n"                               \
@@ -32,7 +32,7 @@
 #define ASSERT(_a_)                                                                                \
   do                                                                                               \
   {                                                                                                \
-    if (!(_a_))                                                                                    \
+    if (!(_a_)) [[unlikely]]                                                                       \
     {                                                                                              \
       if (!PanicYesNoFmt("An error occurred.\n\n"                                                  \
                          "  Condition: {}\n  File: {}\n  Line: {}\n  Function: {}\n\n"             \

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -3,7 +3,6 @@
 
 #include "Core/CheatSearch.h"
 
-#include <cassert>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -13,6 +12,7 @@
 #include <vector>
 
 #include "Common/Align.h"
+#include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/StringUtil.h"
 
@@ -94,7 +94,7 @@ std::vector<u8> Cheats::GetValueAsByteVector(const Cheats::SearchValue& value)
   case Cheats::DataType::F64:
     return ToByteVector(Common::swap64(Common::BitCast<u64>(std::get<double>(value.m_value))));
   default:
-    assert(0);
+    DEBUG_ASSERT(false);
     return {};
   }
 }
@@ -412,7 +412,7 @@ MakeCompareFunctionForSpecificValue(Cheats::CompareType op, const T& old_value)
   case Cheats::CompareType::GreaterOrEqual:
     return [&](const T& new_value) { return new_value >= old_value; };
   default:
-    assert(0);
+    DEBUG_ASSERT(false);
     return nullptr;
   }
 }
@@ -436,7 +436,7 @@ MakeCompareFunctionForLastValue(Cheats::CompareType op)
   case Cheats::CompareType::GreaterOrEqual:
     return [](const T& new_value, const T& old_value) { return new_value >= old_value; };
   default:
-    assert(0);
+    DEBUG_ASSERT(false);
     return nullptr;
   }
 }
@@ -680,7 +680,7 @@ Cheats::MakeSession(std::vector<MemoryRange> memory_ranges,
     return std::make_unique<CheatSearchSession<double>>(std::move(memory_ranges), address_space,
                                                         aligned);
   default:
-    assert(0);
+    DEBUG_ASSERT(false);
     return nullptr;
   }
 }

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -666,7 +666,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base, bool is_wii)
 
                    if (state_.DISR.BREAK)
                    {
-                     DEBUG_ASSERT(0);
+                     DEBUG_ASSERT(false);
                    }
 
                    UpdateInterrupts();

--- a/Source/Core/Core/HW/MMIO.h
+++ b/Source/Core/Core/HW/MMIO.h
@@ -216,13 +216,13 @@ private:
 template <>
 inline u64 Mapping::Read<u64>(u32 addr)
 {
-  DEBUG_ASSERT(0);
+  DEBUG_ASSERT(false);
   return 0;
 }
 
 template <>
 inline void Mapping::Write(u32 addr, u64 val)
 {
-  DEBUG_ASSERT(0);
+  DEBUG_ASSERT(false);
 }
 }  // namespace MMIO

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -319,7 +319,7 @@ bool Jit64::BackPatch(SContext* ctx)
       *ptr = Common::swap64(static_cast<u64>(*ptr));
       break;
     default:
-      DEBUG_ASSERT(0);
+      DEBUG_ASSERT(false);
       break;
     }
   }

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -558,7 +558,7 @@ std::optional<ReadResult<u32>> HostTryReadInstruction(const Core::CPUThreadGuard
   }
   }
 
-  ASSERT(0);
+  ASSERT(false);
   return std::nullopt;
 }
 
@@ -679,7 +679,7 @@ static std::optional<ReadResult<T>> HostTryReadUX(const Core::CPUThreadGuard& gu
   }
   }
 
-  ASSERT(0);
+  ASSERT(false);
   return std::nullopt;
 }
 
@@ -900,7 +900,7 @@ static std::optional<WriteResult> HostTryWriteUX(const Core::CPUThreadGuard& gua
     return WriteResult(true);
   }
 
-  ASSERT(0);
+  ASSERT(false);
   return std::nullopt;
 }
 
@@ -1051,7 +1051,7 @@ bool HostIsRAMAddress(const Core::CPUThreadGuard& guard, u32 address, RequestedA
     return IsRAMAddress<XCheckTLBFlag::NoException>(memory, address, true);
   }
 
-  ASSERT(0);
+  ASSERT(false);
   return false;
 }
 
@@ -1078,7 +1078,7 @@ bool HostIsInstructionRAMAddress(const Core::CPUThreadGuard& guard, u32 address,
     return IsRAMAddress<XCheckTLBFlag::OpcodeNoException>(memory, address, true);
   }
 
-  ASSERT(0);
+  ASSERT(false);
   return false;
 }
 

--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -3,7 +3,6 @@
 
 #include "DolphinQt/CheatSearchWidget.h"
 
-#include <cassert>
 #include <functional>
 #include <optional>
 #include <string>

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -401,7 +401,7 @@ static QString GetFormatDescription(Memcard::SavefileFormat format)
   case Memcard::SavefileFormat::SAV:
     return QObject::tr("Datel MaxDrive/Pro files");
   default:
-    ASSERT(0);
+    ASSERT(false);
     return QObject::tr("Native GCI File");
   }
 }

--- a/Source/Core/VideoCommon/LightingShaderGen.cpp
+++ b/Source/Core/VideoCommon/LightingShaderGen.cpp
@@ -70,7 +70,7 @@ static void GenerateLightShader(ShaderCode& object, const LightingUidData& uid_d
                  swizzle_components, LIGHT_COL_PARAMS(index, swizzle));
     break;
   default:
-    ASSERT(0);
+    ASSERT(false);
   }
 
   object.Write("\n");

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -1088,7 +1088,7 @@ std::string GenerateDecodingShader(TextureFormat format, std::optional<TLUTForma
     ss << "#define TEXEL_BUFFER_FORMAT_R32G32 1\n";
     break;
   case NUM_TEXEL_BUFFER_FORMATS:
-    ASSERT(0);
+    ASSERT(false);
     break;
   }
 


### PR DESCRIPTION
This PR doubles as a way to ask what are Dolphin Emulator's plans for moving to C++20?  Is the issue that GCC still defaults to C++17 in version 12?  Other compiler support reasons?

And just how far should [[likely]] and [[unlikely]] be taken?  Nullptr checks seem like obvious candidates.  Any path that leads to a PanicAlert as well.  There are a lot of switch case defaults which only exist to catch stuff which should never happen.