### PR TITLE
Riivolution: Add Dolphin extension to specify CPU overclock and RAM size overrides.

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -48,6 +48,7 @@
 #include "Core/WiiRoot.h"
 
 #include "DiscIO/Enums.h"
+#include "DiscIO/RiivolutionPatcher.h"
 
 #include "VideoCommon/VideoBackendBase.h"
 
@@ -141,6 +142,8 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
   // Disable loading time emulation for Riivolution-patched games until we have proper emulation.
   if (!boot->riivolution_patches.empty())
     Config::SetCurrent(Config::MAIN_FAST_DISC_SPEED, true);
+
+  DiscIO::Riivolution::ApplyDolphinConfig(boot->riivolution_patches);
 
   Core::System::GetInstance().Initialize();
 

--- a/Source/Core/DiscIO/RiivolutionParser.cpp
+++ b/Source/Core/DiscIO/RiivolutionParser.cpp
@@ -213,6 +213,12 @@ std::optional<Disc> ParseString(std::string_view xml, std::string xml_path)
         memory.m_search = patch_subnode.attribute("search").as_bool(false);
         memory.m_align = patch_subnode.attribute("align").as_uint(1);
       }
+      else if (patch_name == "dolphin_config")
+      {
+        auto& config = patch.m_dolphin_configs.emplace_back();
+        config.m_setting = patch_subnode.attribute("setting").as_string();
+        config.m_value = patch_subnode.attribute("value").as_string();
+      }
     }
   }
 

--- a/Source/Core/DiscIO/RiivolutionParser.h
+++ b/Source/Core/DiscIO/RiivolutionParser.h
@@ -153,6 +153,16 @@ struct Memory
   u32 m_align = 1;
 };
 
+// Dolphin-specific exension to modify the emulated system configuration.
+struct DolphinConfig
+{
+  // The setting to adjust.
+  std::string m_setting;
+
+  // The value to set it to.
+  std::string m_value;
+};
+
 struct Patch
 {
   // Internal name of this patch.
@@ -170,6 +180,7 @@ struct Patch
   std::vector<Folder> m_sys_folder_patches;
   std::vector<Savegame> m_savegame_patches;
   std::vector<Memory> m_memory_patches;
+  std::vector<DolphinConfig> m_dolphin_configs;
 
   ~Patch();
 };

--- a/Source/Core/DiscIO/RiivolutionPatcher.h
+++ b/Source/Core/DiscIO/RiivolutionPatcher.h
@@ -79,4 +79,5 @@ void ApplyApploaderMemoryPatches(const std::vector<Patch>& patches, u32 ram_addr
                                  u32 ram_length);
 std::optional<SavegameRedirect>
 ExtractSavegameRedirect(const std::vector<Patch>& riivolution_patches);
+void ApplyDolphinConfig(const std::vector<Patch>& patches);
 }  // namespace DiscIO::Riivolution


### PR DESCRIPTION
I had this idea after noticing that some game mods like the Pikmin 2 Colossal Caverns one require the user to manually set the override options. It would be nice if they could just encode their desired CPU speed and RAM size into the Riivolution XML so the user doesn't have to do that. So with this, they can!

I'm not entirely sold on the way I've implemented this, maybe I'll refactor this a bit. Mainly opening this to get some comments if this is a good idea in the first place.