### PR TITLE
Android: Use AfterDirectoryInitializationRunner on FAB press

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -26,7 +26,6 @@ import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner;
 import org.dolphinemu.dolphinemu.utils.BooleanSupplier;
 import org.dolphinemu.dolphinemu.utils.CompletableFuture;
 import org.dolphinemu.dolphinemu.utils.ContentHandler;
-import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 import org.dolphinemu.dolphinemu.utils.ThreadUtil;
 import org.dolphinemu.dolphinemu.utils.WiiUtils;
@@ -76,7 +75,8 @@ public final class MainPresenter
 
   public void onFabClick()
   {
-    mView.launchFileListActivity();
+    new AfterDirectoryInitializationRunner().runWithLifecycle(mActivity, true,
+            mView::launchFileListActivity);
   }
 
   public boolean handleOptionSelection(int itemId, ComponentActivity activity)


### PR DESCRIPTION
Without this, if the user finishes selecting a directory before directory initialization finishes, `MainPresenter.onDirectorySelected` will segfault when trying to read the `MAIN_RECURSIVE_ISO_PATHS` setting.

An alternative would be to use`AfterDirectoryInitializationRunner` after the user selects the directory instead of before, but it might be confusing for the user to deal with the usage statistics prompt when they were expecting to add a folder.