### PR TITLE
PPCSymbolDB: Fix getting symbol for the last function

### DIFF
--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -92,18 +92,20 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
 Common::Symbol* PPCSymbolDB::GetSymbolFromAddr(u32 addr)
 {
   auto it = m_functions.lower_bound(addr);
-  if (it == m_functions.end())
-    return nullptr;
 
-  // If the address is exactly the start address of a symbol, we're done.
-  if (it->second.address == addr)
-    return &it->second;
-
-  // Otherwise, check whether the address is within the bounds of a symbol.
+  if (it != m_functions.end())
+  {
+    // If the address is exactly the start address of a symbol, we're done.
+    if (it->second.address == addr)
+      return &it->second;
+  }
   if (it != m_functions.begin())
+  {
+    // Otherwise, check whether the address is within the bounds of a symbol.
     --it;
-  if (addr >= it->second.address && addr < it->second.address + it->second.size)
-    return &it->second;
+    if (addr >= it->second.address && addr < it->second.address + it->second.size)
+      return &it->second;
+  }
 
   return nullptr;
 }


### PR DESCRIPTION
It's easiest to illustrate the bug that I fixed with an example from System Menu 4.3U (the functions I'm using here are arbitrary, chosen just because they're short):

|Step|Before|After|
|-|-|-|
|Set address to 815344f0|![image](https://user-images.githubusercontent.com/8334194/181865460-0cb29dd4-a104-43af-8bce-ff0f2d5c98fb.png)|![image](https://user-images.githubusercontent.com/8334194/181865464-1526c7f9-5e82-4cce-8973-bfe81a1e24d2.png)|
|Add function at 815344f4|![image](https://user-images.githubusercontent.com/8334194/181865465-38155fc7-56c4-47bd-b035-ec39114a0a46.png)|![image](https://user-images.githubusercontent.com/8334194/181865466-40752915-0fb1-46d5-8e56-92be2f86ead5.png)|
|Add function at 8153450c|![image](https://user-images.githubusercontent.com/8334194/181865468-f44addc1-9c86-4485-bdd9-cd2f2957567f.png)|![image](https://user-images.githubusercontent.com/8334194/181865469-cfd46f97-1029-467b-b5d9-0e2537835b14.png)|
|Add function at 81534548|![image](https://user-images.githubusercontent.com/8334194/181865470-2e5b1d90-d2f4-46c5-8acd-e7de1809f457.png)|![image](https://user-images.githubusercontent.com/8334194/181865471-66f3dc7e-3661-4889-822f-2dde223d1f42.png)|

(In the debugger, to set the address, use the top-left text field labeled search address, and to add a function, right-click the specified address and select "add function" (2nd entry in the bottom group, below "run to here").)

This is an issue I ran into on #10923, and doesn't just affect "add function".