### PR TITLE
BBA/BuiltIn: Add minimal IGMP support

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -545,6 +545,18 @@ bool CEXIETHERNET::BuiltInBBAInterface::SendFrame(const u8* frame, u32 size)
       HandleTCPFrame(*tcp_packet);
       break;
     }
+
+    case IPPROTO_IGMP:
+    {
+      // Acknowledge IGMP packet
+      const std::vector<u8> data(frame, frame + size);
+      WriteToQueue(data);
+      break;
+    }
+
+    default:
+      ERROR_LOG_FMT(SP1, "Unsupported IP protocol {}", *ip_proto);
+      break;
     }
     break;
   }


### PR DESCRIPTION
This PR adds minimal IGMP support. It doesn't seem to provide any noticeable benefit. The IGMP packets are sent to the router to register to a multicast address. It's used just before the games start communicating via the SSDP multicast address.

Ready to be reviewed & merged.