### PR TITLE
PPCCache: Stop storing lookup table in savestates

### DIFF
--- a/Source/Core/Core/PowerPC/PPCCache.h
+++ b/Source/Core/Core/PowerPC/PPCCache.h
@@ -27,6 +27,8 @@ struct InstructionCache
   std::array<u32, ICACHE_SETS> plru{};
   std::array<u32, ICACHE_SETS> valid{};
 
+  // Note: This is only for performance purposes; this same data could be computed at runtime
+  // from the tags and valid fields (and that's how it's done on the actual cache)
   std::array<u8, 1 << 20> lookup_table{};
   std::array<u8, 1 << 21> lookup_table_ex{};
   std::array<u8, 1 << 20> lookup_table_vmem{};

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static std::recursive_mutex g_save_thread_mutex;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 146;  // Last changed in PR 10883
+constexpr u32 STATE_VERSION = 147;  // Last changed in PR 10935
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
These lookup tables total 4 megabytes, and contain data that's entirely redundant to the actual cache state (as part of an optimization, though I'm not sure whether the optimization actually is useful). This change instead recomputes these lookup tables when loading the state (which involves filling the lookup table with a marker (0xff), and then setting the 128 * 8 valid entries (1 kilobyte)).

This is intended to be a simplified version of #10826 (which I have further plans for, and which currently removes the lookup table entirely).