### PR TITLE
GameSettings: Set MissingColorValue for Lego Indiana Jones 1

### DIFF
--- a/Data/Sys/GameSettings/RLI.ini
+++ b/Data/Sys/GameSettings/RLI.ini
@@ -1,0 +1,5 @@
+# RLIE64, RLIP64 - Lego Indiana Jones: The Original Adventures
+
+[Video_Settings]
+# Fixes the alpha value of glpyh puzzles; see https://bugs.dolphin-emu.org/issues/12987
+MissingColorValue = 0xFFFFFF82


### PR DESCRIPTION
See https://bugs.dolphin-emu.org/issues/12987. The alpha value of 0x82 was determined by disabling all objects other than the highlight (and object 0 which clears the screen) in the hardware fifoplayer ([image](https://user-images.githubusercontent.com/8334194/182483314-c85aa06b-5986-4fac-ba26-68137736c0c3.png)), and then checking the output color (which is 0xAAAAAB or 0xABABAB depending on the pixel). [0x82 gives the closest result](https://user-images.githubusercontent.com/8334194/182483706-a908cf56-517b-4989-9815-c709f562a7fb.png) (though it's not a perfect match for every pixel, likely due to other slight inaccuracies with lighting). After that I compared across all of the provided fifologs, and things seem to be a generally good match (some differences are a value of 3, but I think part of this is related to bloom and lighting; in any case it looks close enough and isn't broken anymore).

Like with the debug cube fix (#9532), this is a hack.

|Test|Dolphin old|Real hardware|Dolphin new|
|-|-|-|-|
|Hub|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484021-364f1dc7-4e43-4da1-8255-95b30746af8e.png)|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484117-81aea85f-b1a2-4713-8bce-57b5b27e1e16.png)|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484273-69a6ea88-7a1c-46a6-b6cb-ee71df4fe7d8.png)|
|1-5|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484024-e72648a6-b0ba-4c79-adea-d2464e092d0f.png)|![lego_indiana_jones_puzzle_1-5](https://user-images.githubusercontent.com/8334194/182484149-4bd44ccb-398a-45f2-9ad4-cb953226f553.png)|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484285-b52f2d97-70b9-47c9-b6f7-4340247c02d4.png)|
|2-1|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484029-bf398091-ce0c-44e3-9e88-8a0207b4b865.png)|![lego_indiana_jones_puzzle_2-1](https://user-images.githubusercontent.com/8334194/182484167-02706a77-7b28-40d7-a587-3bfeab996a4c.png)|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484301-69850668-7f4c-4a99-aa99-434fa34a164d.png)|
|2-5|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484035-d297f01b-78a9-4389-a374-4dddf28bfa3f.png)|![lego_indiana_jones_puzzle_2-5](https://user-images.githubusercontent.com/8334194/182484181-659ebc9e-127d-4465-8ce6-9f2549cd9d7a.png)|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484312-d0af3e01-c159-4354-84f2-cf496d6eb95b.png)|
|3-1a|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484044-66f5ecf6-c90a-4e80-8069-cf03eabd6c41.png)|![lego_indiana_jones_puzzle_3_1a](https://user-images.githubusercontent.com/8334194/182484192-63d29741-bddf-4ce2-b7fb-6d5da58ec873.png)|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484323-3cb35aee-3200-4f9e-8bd6-7e4cc2efaa07.png)|
|3-1b|![2_y0_x0](https://user-images.githubusercontent.com/8334194/182484055-a665dc2a-182a-4ad0-bf80-a87ba39e7407.png)|![2_y0_x0](https://user-images.githubusercontent.com/8334194/182484242-6c97a1cd-20ef-4972-848e-e79631374a07.png)|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484327-9d178de2-578b-4e94-ba85-dc054cc5efc9.png)|
|3-1c|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484063-24fbd65b-f1c4-4b9a-9c73-a68e9b42924e.png)|![lego_indiana_jones_puzzle_3_1c](https://user-images.githubusercontent.com/8334194/182484208-bf1d90ba-8898-4416-82d6-2d02685976bb.png)|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484337-ad270477-f401-4fd2-a772-1e5d4b3ede34.png)|
|3-5|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484069-17510ec5-752c-41c3-879c-6a779cd962c4.png)|![lego_indiana_jones_puzzle_3_5](https://user-images.githubusercontent.com/8334194/182484215-77c466dc-bf6f-4a1e-9621-7cc38178b6ea.png)|![1_y0_x0](https://user-images.githubusercontent.com/8334194/182484353-3225ce85-c201-4aad-83dc-7f8512dc0fba.png)|

(The other texture glitchyness in some of these is [a separate issue](https://bugs.dolphin-emu.org/issues/13000) and does not happen ingame.)