### PR TITLE
Android: Don't set the signingConfig if keystore property isn't set

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -48,7 +48,9 @@ android {
     buildTypes {
         // Signed by release key, allowing for upload to Play Store.
         release {
-            signingConfig signingConfigs.release
+            if (project.hasProperty('keystore')) {
+                signingConfig signingConfigs.release
+            }
 
             minifyEnabled true
             shrinkResources true


### PR DESCRIPTION
If the property isn't set, we don't initialize the release config, so we shouldn't use it. This fixes building issues for me.

https://github.com/dolphin-emu/dolphin/blob/7d2d5d914bf3cacbecbb0bf8a642b616744aad54/Source/Android/app/build.gradle#L36-L45

Before, I was getting this message when running `gradlew assemble`:

```
> Task :app:packageRelease FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:packageRelease'.
> A failure occurred while executing com.android.build.gradle.tasks.PackageAndroidArtifact$IncrementalSplitterRunnable
   > SigningConfig "release" is missing required property "storeFile".
```

I haven't tested this change in a setup which has an actual signing config (and don't really want to set one up myself).