### PR TITLE
Remove Vestigial Preprocessor Block in Jit64/Jit.cpp

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -44,9 +44,6 @@
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/Profiler.h"
-#if defined(_DEBUG) || defined(DEBUGFAST)
-#include "Common/GekkoDisassembler.h"
-#endif
 
 using namespace Gen;
 using namespace PowerPC;


### PR DESCRIPTION
"Common/GekkoDisassembler.h" became used by Release builds with commit 77e9aa48bc217f9143d7ee2dca4b213a1505a02f, but this got left in by mistake.