### PR TITLE
GameSettings: Use Safe Texture Cache and add patch for black screens for Gormiti: The Lords of Nature!

### DIFF
--- a/Data/Sys/GameSettings/SGL.ini
+++ b/Data/Sys/GameSettings/SGL.ini
@@ -1,0 +1,5 @@
+# SGLEA4, SGLPA4 - Gormiti: The Lords of Nature!
+
+[Video_Settings]
+# Needed to fix text in menus (medium isn't enough; it fixes some menus but not the new profile one)
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SGLEA4.ini
+++ b/Data/Sys/GameSettings/SGLEA4.ini
@@ -1,0 +1,8 @@
+# SGLEA4 - Gormiti: The Lords of Nature!
+
+[OnFrame]
+# Fixes black screen ingame, see https://bugs.dolphin-emu.org/issues/12436
+# This NOPs out UpdateFade's call to RenderFade. We are probably emulating the way the fade works
+# incorrectly, but for now this patch makes the game playable.
+$Fix black screen
+0x801D59AC:dword:0x60000000


### PR DESCRIPTION
See https://bugs.dolphin-emu.org/issues/12436 for the black screen issue. I only own a US copy, so the patch only exists for the US release, but (assuming the EU release has debug symbols too) it shouldn't be too hard to create one for it. The patch isn't enabled by default because ideally we'd instead fix the underlying issue instead.

The texture cache issue is only visible when the black screen issue is fixed.