### PR TITLE
Vulkan: Call setSourceFile in addition to addSourceText

### DIFF
--- a/Source/Core/VideoCommon/Spirv.cpp
+++ b/Source/Core/VideoCommon/Spirv.cpp
@@ -124,6 +124,7 @@ CompileShaderToSPV(EShLanguage stage, APIType api_type,
   if (g_ActiveConfig.bEnableValidationLayer)
   {
     // Attach the source code to the SPIR-V for tools like RenderDoc.
+    intermediate->setSourceFile(stage_filename);
     intermediate->addSourceText(pass_source_code, pass_source_code_length);
 
     options.generateDebugInfo = true;


### PR DESCRIPTION
See baldurk/renderdoc#2673 (and baldurk/renderdoc#2337) for more context; this fixes viewing the shader source in renderdoc v1.21. `stage_filename` is "vs", "gs", "ps", or "cs" for vertex, geometry, fragment [i.e. pixel], and compute shaders respectively (see `CompileVertexShader` etc. in the same file).