### PR TITLE
VideoCommon: Remove old iLog field

### DIFF
--- a/Source/Core/VideoCommon/Spirv.cpp
+++ b/Source/Core/VideoCommon/Spirv.cpp
@@ -155,31 +155,6 @@ CompileShaderToSPV(EShLanguage stage, APIType api_type,
   if (!spv_messages.empty())
     WARN_LOG_FMT(VIDEO, "SPIR-V conversion messages: {}", spv_messages);
 
-  // Dump source code of shaders out to file if enabled.
-  if (g_ActiveConfig.iLog & CONF_SAVESHADERS)
-  {
-    static int counter = 0;
-    std::string filename = StringFromFormat("%s%s_%04i.txt", File::GetUserPath(D_DUMP_IDX).c_str(),
-                                            stage_filename, counter++);
-
-    std::ofstream stream;
-    File::OpenFStream(stream, filename, std::ios_base::out);
-    if (stream.good())
-    {
-      stream << source << std::endl;
-      stream << "Shader Info Log:" << std::endl;
-      stream << shader->getInfoLog() << std::endl;
-      stream << shader->getInfoDebugLog() << std::endl;
-      stream << "Program Info Log:" << std::endl;
-      stream << program->getInfoLog() << std::endl;
-      stream << program->getInfoDebugLog() << std::endl;
-      stream << "SPIR-V conversion messages: " << std::endl;
-      stream << spv_messages;
-      stream << "SPIR-V:" << std::endl;
-      spv::Disassemble(stream, out_code);
-    }
-  }
-
   return out_code;
 }
 }  // namespace

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -17,12 +17,6 @@
 #include "VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.h"
 #include "VideoCommon/VideoCommon.h"
 
-// Log in two categories, and save three other options in the same byte
-#define CONF_LOG 1
-#define CONF_PRIMLOG 2
-#define CONF_SAVETARGETS 8
-#define CONF_SAVESHADERS 16
-
 constexpr int EFB_SCALE_AUTO_INTEGRAL = 0;
 
 enum class AspectMode : int
@@ -138,7 +132,6 @@ struct VideoConfig final
   bool bFastDepthCalc = false;
   bool bVertexRounding = false;
   int iEFBAccessTileSize = 0;
-  int iLog = 0;           // CONF_ bits
   int iSaveTargetId = 0;  // TODO: Should be dropped
   u32 iMissingColorValue = 0;
   bool bFastTextureSampling = false;


### PR DESCRIPTION
Prior to 7854bd71098fe556ddc9839ad08d27fab7ecba33, this was used by the debugger for the OpenGL and D3D9 plugins to control logging (via PRIM_LOG and INFO_LOG/DEBUG_LOG in VideoCommon code; PRIM_LOG was changed in 77215fd27ccb7cdeb82fed24a7a8d4d4ad4c33a4), and also framedumping (removed in 64927a2f81fe64503060c949ead525995fd63a2a and 2d8515c0cf754806dc38222c4461053e12df1194), shader dumping (removed in 2d8515c0cf754806dc38222c4461053e12df1194 and this commit), and texture dumping (removed in 54aeec7a8ff6b6e5d050637b6cce8df6d9a8b633). Apart from shader dumping, all of these features have modern alternatives, and shader source code can be seen in RenderDoc if "Enable API Validation Layers" is checked (which also enables source attachment), so there's no point in keeping this around.