### PR TITLE
Restrict OpenSLES to Android via CMake

### DIFF
--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -18,14 +18,17 @@ add_library(audiocommon
   WaveFile.h
 )
 
-find_package(OpenSLES)
-if(OPENSLES_FOUND)
-  message(STATUS "OpenSLES found, enabling OpenSLES sound backend")
-  target_sources(audiocommon PRIVATE
-    OpenSLESStream.cpp
-    OpenSLESStream.h
-  )
-  target_link_libraries(audiocommon PRIVATE OpenSLES::OpenSLES)
+if(ANDROID)
+  find_package(OpenSLES)
+  if(OPENSLES_FOUND)
+    message(STATUS "OpenSLES found, enabling OpenSLES sound backend")
+    target_sources(audiocommon PRIVATE
+      OpenSLESStream.cpp
+      OpenSLESStream.h
+    )
+    target_link_libraries(audiocommon PRIVATE OpenSLES::OpenSLES)
+    target_compile_definitions(audiocommon PRIVATE HAVE_OPENSL_ES=1)
+  endif()
 endif()
 
 if(ENABLE_ALSA)

--- a/Source/Core/AudioCommon/OpenSLESStream.cpp
+++ b/Source/Core/AudioCommon/OpenSLESStream.cpp
@@ -1,7 +1,7 @@
 // Copyright 2013 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#ifdef ANDROID
+#ifdef HAVE_OPENSL_ES
 #include "AudioCommon/OpenSLESStream.h"
 
 #include <cmath>
@@ -143,4 +143,4 @@ void OpenSLESStream::SetVolume(int volume)
       volume <= 0 ? SL_MILLIBEL_MIN : static_cast<SLmillibel>(2000 * std::log10(volume / 100.0f));
   (*bqPlayerVolume)->SetVolumeLevel(bqPlayerVolume, attenuation);
 }
-#endif
+#endif  // HAVE_OPENSL_ES

--- a/Source/Core/AudioCommon/OpenSLESStream.h
+++ b/Source/Core/AudioCommon/OpenSLESStream.h
@@ -10,7 +10,7 @@
 
 class OpenSLESStream final : public SoundStream
 {
-#ifdef ANDROID
+#ifdef HAVE_OPENSL_ES
 public:
   ~OpenSLESStream() override;
   bool Init() override;
@@ -21,5 +21,5 @@ public:
 private:
   std::thread thread;
   Common::Event soundSyncEvent;
-#endif  // HAVE_OPENSL
+#endif  // HAVE_OPENSL_ES
 };


### PR DESCRIPTION
OpenSLES code is only compiled on android, but instead of checking via CMake we search for OpenSLES on all platforms, and then compile that code if we find it. Just in case a non-android build finds OpenSLES, both of the files are wrapped in #ifdefs. Instead, this PR will only search for and compile the files on Android, thus not generating a false warning that OpenSLES was not found on regular builds.