### PR TITLE
Arm64Emitter: Fix encoding of size for ADD (vector)

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -3026,7 +3026,7 @@ void ARM64FloatEmitter::FMOV(ARM64Reg Rd, uint8_t imm8)
 // Vector
 void ARM64FloatEmitter::ADD(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
-  EmitThreeSame(0, size >> 6, 0b10000, Rd, Rn, Rm);
+  EmitThreeSame(0, IntLog2(size) - 3, 0b10000, Rd, Rn, Rm);
 }
 void ARM64FloatEmitter::AND(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {


### PR DESCRIPTION
This was causing a bug in the rounding of paired single multiplication operands. If Force25BitPrecision was called for quad registers, the element size of its ADD instruction would get treated as if it was 16 instead of the intended 64, which would cause the result of the calculation to be incorrect if the carry had to pass a 16-bit boundary.

Fixes one of the two bugs reported in https://bugs.dolphin-emu.org/issues/12998.