### PR TITLE
Address c++20 TODO comments

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -178,11 +178,7 @@ void CEXIMemoryCard::SetupGciFolder(const Memcard::HeaderData& header_data)
     current_game_id = Common::swap32(reinterpret_cast<const u8*>(game_id.c_str()));
   }
 
-  // TODO(C++20): Use structured bindings when we can use C++20 and refer to structured bindings
-  // in lambda captures
-  const auto folder_path_pair = GetGCIFolderPath(m_card_slot, AllowMovieFolder::Yes);
-  const std::string& dir_path = folder_path_pair.first;
-  const bool migrate = folder_path_pair.second;
+  const auto [dir_path, migrate] = GetGCIFolderPath(m_card_slot, AllowMovieFolder::Yes);
 
   const File::FileInfo file_info(dir_path);
   if (!file_info.Exists())

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -276,14 +276,7 @@ static constexpr int DOUBLE_TIME_OFFSET = (38 * 365 * 24 * 60 * 60);
 
 static double GetSystemTimeAsDouble()
 {
-  // FYI: std::chrono::system_clock epoch is not required to be 1970 until c++20.
-  // We will however assume time_t IS unix time.
-  using Clock = std::chrono::system_clock;
-
-  // TODO: Use this on switch to c++20:
-  // const auto since_epoch = Clock::now().time_since_epoch();
-  const auto unix_epoch = Clock::from_time_t({});
-  const auto since_epoch = Clock::now() - unix_epoch;
+  const auto since_epoch = std::chrono::system_clock::now().time_since_epoch();
 
   const auto since_double_time_epoch = since_epoch - std::chrono::seconds(DOUBLE_TIME_OFFSET);
   return std::chrono::duration_cast<std::chrono::duration<double>>(since_double_time_epoch).count();


### PR DESCRIPTION
- Use a structured binding in a place that was previously a problem (see commit message for details).
- Use time_since_epoch now that the standard specifies it as Unix time.

This PR used to replace the workaround function FillWithFallbacks(table) in Jit64_Tables.cpp with table.fill(...) now that array.fill is constexpr, but the android and freebsd builders don't support constexpr fill. It also used to add make_unique_for_overwrite in a couple places, but most of the builders don't support that.