### PR TITLE
Replace Common::BitCast with std::bit_cast

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cstring>
 #include <optional>
 #include <tuple>
@@ -15,7 +16,6 @@
 
 #include "Common/Align.h"
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Common/SmallVector.h"
@@ -51,12 +51,12 @@ float FPImm8ToFloat(u8 bits)
   const u32 mantissa = (bits & 0xF) << 19;
   const u32 f = (sign << 31) | (exp << 23) | mantissa;
 
-  return Common::BitCast<float>(f);
+  return std::bit_cast<float>(f);
 }
 
 std::optional<u8> FPImm8FromFloat(float value)
 {
-  const u32 f = Common::BitCast<u32>(value);
+  const u32 f = std::bit_cast<u32>(value);
   const u32 mantissa4 = (f & 0x7FFFFF) >> 19;
   const u32 exponent = (f >> 23) & 0xFF;
   const u32 sign = f >> 31;
@@ -4410,7 +4410,7 @@ void ARM64FloatEmitter::MOVI2F(ARM64Reg Rd, float value, ARM64Reg scratch, bool 
     if (negate)
       value = -value;
 
-    const u32 ival = Common::BitCast<u32>(value);
+    const u32 ival = std::bit_cast<u32>(value);
     m_emit->MOVI2R(scratch, ival);
     FMOV(Rd, scratch);
   }

--- a/Source/Core/Common/Assembler/GekkoIRGen.cpp
+++ b/Source/Core/Common/Assembler/GekkoIRGen.cpp
@@ -3,6 +3,7 @@
 
 #include "Common/Assembler/GekkoIRGen.h"
 
+#include <bit>
 #include <functional>
 #include <map>
 #include <numeric>
@@ -436,13 +437,13 @@ void GekkoIRPlugin::AddBytes(T val)
   else if constexpr (std::is_same_v<T, float>)
   {
     static_assert(sizeof(double) == sizeof(u64));
-    AddBytes(BitCast<u32>(val));
+    AddBytes(std::bit_cast<u32>(val));
   }
   else
   {
     // std::is_same_v<T, double>
     static_assert(sizeof(double) == sizeof(u64));
-    AddBytes(BitCast<u64>(val));
+    AddBytes(std::bit_cast<u64>(val));
   }
 }
 

--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -125,39 +125,6 @@ constexpr bool IsValidLowMask(const T mask) noexcept
   return (mask & (mask + 1)) == 0;
 }
 
-///
-/// Reinterpret objects of one type as another by bit-casting between object representations.
-///
-/// @remark This is the example implementation of std::bit_cast which is to be included
-///         in C++2a. See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0476r2.html
-///         for more details. The only difference is this variant is not constexpr,
-///         as the mechanism for bit_cast requires a compiler built-in to have that quality.
-///
-/// @param source The source object to convert to another representation.
-///
-/// @tparam To   The type to reinterpret source as.
-/// @tparam From The initial type representation of source.
-///
-/// @return The representation of type From as type To.
-///
-/// @pre Both To and From types must be the same size
-/// @pre Both To and From types must satisfy the TriviallyCopyable concept.
-///
-template <typename To, typename From>
-inline To BitCast(const From& source) noexcept
-{
-  static_assert(sizeof(From) == sizeof(To),
-                "BitCast source and destination types must be equal in size.");
-  static_assert(std::is_trivially_copyable<From>(),
-                "BitCast source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<To>(),
-                "BitCast destination type must be trivially copyable.");
-
-  alignas(To) std::byte storage[sizeof(To)];
-  std::memcpy(&storage, &source, sizeof(storage));
-  return reinterpret_cast<To&>(storage);
-}
-
 template <typename T, typename PtrType>
 class BitCastPtrType
 {

--- a/Source/Core/Common/FloatUtils.cpp
+++ b/Source/Core/Common/FloatUtils.cpp
@@ -3,15 +3,14 @@
 
 #include "Common/FloatUtils.h"
 
+#include <bit>
 #include <cmath>
-
-#include "Common/BitUtils.h"
 
 namespace Common
 {
 u32 ClassifyDouble(double dvalue)
 {
-  const u64 ivalue = BitCast<u64>(dvalue);
+  const u64 ivalue = std::bit_cast<u64>(dvalue);
   const u64 sign = ivalue & DOUBLE_SIGN;
   const u64 exp = ivalue & DOUBLE_EXP;
 
@@ -43,7 +42,7 @@ u32 ClassifyDouble(double dvalue)
 
 u32 ClassifyFloat(float fvalue)
 {
-  const u32 ivalue = BitCast<u32>(fvalue);
+  const u32 ivalue = std::bit_cast<u32>(fvalue);
   const u32 sign = ivalue & FLOAT_SIGN;
   const u32 exp = ivalue & FLOAT_EXP;
 
@@ -86,7 +85,7 @@ const std::array<BaseAndDec, 32> frsqrte_expected = {{
 
 double ApproximateReciprocalSquareRoot(double val)
 {
-  s64 integral = BitCast<s64>(val);
+  s64 integral = std::bit_cast<s64>(val);
   s64 mantissa = integral & ((1LL << 52) - 1);
   const s64 sign = integral & (1ULL << 63);
   s64 exponent = integral & (0x7FFLL << 52);
@@ -136,7 +135,7 @@ double ApproximateReciprocalSquareRoot(double val)
   const auto& entry = frsqrte_expected[i / 2048];
   integral |= static_cast<s64>(entry.m_base + entry.m_dec * (i % 2048)) << 26;
 
-  return BitCast<double>(integral);
+  return std::bit_cast<double>(integral);
 }
 
 const std::array<BaseAndDec, 32> fres_expected = {{
@@ -152,7 +151,7 @@ const std::array<BaseAndDec, 32> fres_expected = {{
 // Used by fres and ps_res.
 double ApproximateReciprocal(double val)
 {
-  s64 integral = BitCast<s64>(val);
+  s64 integral = std::bit_cast<s64>(val);
   const s64 mantissa = integral & ((1LL << 52) - 1);
   const s64 sign = integral & (1ULL << 63);
   s64 exponent = integral & (0x7FFLL << 52);
@@ -184,7 +183,7 @@ double ApproximateReciprocal(double val)
   integral = sign | exponent;
   integral |= static_cast<s64>(entry.m_base - (entry.m_dec * (i % 1024) + 1) / 2) << 29;
 
-  return BitCast<double>(integral);
+  return std::bit_cast<double>(integral);
 }
 
 }  // namespace Common

--- a/Source/Core/Common/FloatUtils.h
+++ b/Source/Core/Common/FloatUtils.h
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <array>
+#include <bit>
 #include <limits>
 
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 
 namespace Common
@@ -35,37 +35,37 @@ static constexpr int FLOAT_FRAC_WIDTH = 23;
 
 inline bool IsQNAN(double d)
 {
-  const u64 i = BitCast<u64>(d);
+  const u64 i = std::bit_cast<u64>(d);
   return ((i & DOUBLE_EXP) == DOUBLE_EXP) && ((i & DOUBLE_QBIT) == DOUBLE_QBIT);
 }
 
 inline bool IsSNAN(double d)
 {
-  const u64 i = BitCast<u64>(d);
+  const u64 i = std::bit_cast<u64>(d);
   return ((i & DOUBLE_EXP) == DOUBLE_EXP) && ((i & DOUBLE_FRAC) != DOUBLE_ZERO) &&
          ((i & DOUBLE_QBIT) == DOUBLE_ZERO);
 }
 
 inline float FlushToZero(float f)
 {
-  u32 i = BitCast<u32>(f);
+  u32 i = std::bit_cast<u32>(f);
   if ((i & FLOAT_EXP) == 0)
   {
     // Turn into signed zero
     i &= FLOAT_SIGN;
   }
-  return BitCast<float>(i);
+  return std::bit_cast<float>(i);
 }
 
 inline double FlushToZero(double d)
 {
-  u64 i = BitCast<u64>(d);
+  u64 i = std::bit_cast<u64>(d);
   if ((i & DOUBLE_EXP) == 0)
   {
     // Turn into signed zero
     i &= DOUBLE_SIGN;
   }
-  return BitCast<double>(i);
+  return std::bit_cast<double>(i);
 }
 
 enum PPCFpClass

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -4,6 +4,7 @@
 #include "Common/Network.h"
 
 #include <algorithm>
+#include <bit>
 #include <string_view>
 #include <vector>
 
@@ -307,8 +308,8 @@ u16 ComputeNetworkChecksum(const void* data, u16 length, u32 initial_value)
 u16 ComputeTCPNetworkChecksum(const IPAddress& from, const IPAddress& to, const void* data,
                               u16 length, u8 protocol)
 {
-  const u32 source_addr = ntohl(Common::BitCast<u32>(from));
-  const u32 destination_addr = ntohl(Common::BitCast<u32>(to));
+  const u32 source_addr = ntohl(std::bit_cast<u32>(from));
+  const u32 destination_addr = ntohl(std::bit_cast<u32>(to));
   const u32 initial_value = (source_addr >> 16) + (source_addr & 0xFFFF) +
                             (destination_addr >> 16) + (destination_addr & 0xFFFF) + protocol +
                             length;

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <bit>
 #include <iterator>
 #include <mutex>
 #include <string>
@@ -31,7 +32,6 @@
 
 #include <fmt/format.h>
 
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
 #include "Common/IniFile.h"
@@ -519,10 +519,10 @@ static bool Subtype_AddCode(const Core::CPUThreadGuard& guard, const ARAddr& add
     LogInfo("--------");
 
     const u32 read = PowerPC::MMU::HostRead_U32(guard, new_addr);
-    const float read_float = Common::BitCast<float>(read);
+    const float read_float = std::bit_cast<float>(read);
     // data contains an (unsigned?) integer value
     const float fread = read_float + static_cast<float>(data);
-    const u32 newval = Common::BitCast<u32>(fread);
+    const u32 newval = std::bit_cast<u32>(fread);
     PowerPC::MMU::HostWrite_U32(guard, newval, new_addr);
     LogInfo("Old Value {:08x}", read);
     LogInfo("Increment {:08x}", data);

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -3,6 +3,7 @@
 
 #include "Core/CheatSearch.h"
 
+#include <bit>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -13,7 +14,6 @@
 
 #include "Common/Align.h"
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/StringUtil.h"
 
 #include "Core/AchievementManager.h"
@@ -83,17 +83,17 @@ std::vector<u8> Cheats::GetValueAsByteVector(const Cheats::SearchValue& value)
   case Cheats::DataType::U64:
     return ToByteVector(Common::swap64(std::get<u64>(value.m_value)));
   case Cheats::DataType::S8:
-    return {Common::BitCast<u8>(std::get<s8>(value.m_value))};
+    return {std::bit_cast<u8>(std::get<s8>(value.m_value))};
   case Cheats::DataType::S16:
-    return ToByteVector(Common::swap16(Common::BitCast<u16>(std::get<s16>(value.m_value))));
+    return ToByteVector(Common::swap16(std::bit_cast<u16>(std::get<s16>(value.m_value))));
   case Cheats::DataType::S32:
-    return ToByteVector(Common::swap32(Common::BitCast<u32>(std::get<s32>(value.m_value))));
+    return ToByteVector(Common::swap32(std::bit_cast<u32>(std::get<s32>(value.m_value))));
   case Cheats::DataType::S64:
-    return ToByteVector(Common::swap64(Common::BitCast<u64>(std::get<s64>(value.m_value))));
+    return ToByteVector(Common::swap64(std::bit_cast<u64>(std::get<s64>(value.m_value))));
   case Cheats::DataType::F32:
-    return ToByteVector(Common::swap32(Common::BitCast<u32>(std::get<float>(value.m_value))));
+    return ToByteVector(Common::swap32(std::bit_cast<u32>(std::get<float>(value.m_value))));
   case Cheats::DataType::F64:
-    return ToByteVector(Common::swap64(Common::BitCast<u64>(std::get<double>(value.m_value))));
+    return ToByteVector(Common::swap64(std::bit_cast<u64>(std::get<double>(value.m_value))));
   default:
     DEBUG_ASSERT(false);
     return {};
@@ -147,7 +147,7 @@ TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
   auto tmp = PowerPC::MMU::HostTryReadU8(guard, addr, space);
   if (!tmp)
     return std::nullopt;
-  return PowerPC::ReadResult<s8>(tmp->translated, Common::BitCast<s8>(tmp->value));
+  return PowerPC::ReadResult<s8>(tmp->translated, std::bit_cast<s8>(tmp->value));
 }
 
 template <>
@@ -158,7 +158,7 @@ TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
   auto tmp = PowerPC::MMU::HostTryReadU16(guard, addr, space);
   if (!tmp)
     return std::nullopt;
-  return PowerPC::ReadResult<s16>(tmp->translated, Common::BitCast<s16>(tmp->value));
+  return PowerPC::ReadResult<s16>(tmp->translated, std::bit_cast<s16>(tmp->value));
 }
 
 template <>
@@ -169,7 +169,7 @@ TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
   auto tmp = PowerPC::MMU::HostTryReadU32(guard, addr, space);
   if (!tmp)
     return std::nullopt;
-  return PowerPC::ReadResult<s32>(tmp->translated, Common::BitCast<s32>(tmp->value));
+  return PowerPC::ReadResult<s32>(tmp->translated, std::bit_cast<s32>(tmp->value));
 }
 
 template <>
@@ -180,7 +180,7 @@ TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
   auto tmp = PowerPC::MMU::HostTryReadU64(guard, addr, space);
   if (!tmp)
     return std::nullopt;
-  return PowerPC::ReadResult<s64>(tmp->translated, Common::BitCast<s64>(tmp->value));
+  return PowerPC::ReadResult<s64>(tmp->translated, std::bit_cast<s64>(tmp->value));
 }
 
 template <>
@@ -573,16 +573,16 @@ std::string Cheats::CheatSearchSession<T>::GetResultValueAsString(size_t index, 
   {
     if constexpr (std::is_same_v<T, float>)
     {
-      return fmt::format("0x{0:08x}", Common::BitCast<s32>(m_search_results[index].m_value));
+      return fmt::format("0x{0:08x}", std::bit_cast<s32>(m_search_results[index].m_value));
     }
     else if constexpr (std::is_same_v<T, double>)
     {
-      return fmt::format("0x{0:016x}", Common::BitCast<s64>(m_search_results[index].m_value));
+      return fmt::format("0x{0:016x}", std::bit_cast<s64>(m_search_results[index].m_value));
     }
     else
     {
       return fmt::format("0x{0:0{1}x}",
-                         Common::BitCast<std::make_unsigned_t<T>>(m_search_results[index].m_value),
+                         std::bit_cast<std::make_unsigned_t<T>>(m_search_results[index].m_value),
                          sizeof(T) * 2);
     }
   }

--- a/Source/Core/Core/Debugger/BranchWatch.h
+++ b/Source/Core/Core/Debugger/BranchWatch.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
+#include <bit>
 #include <cstddef>
 #include <cstdio>
 #include <functional>
 #include <unordered_map>
 #include <vector>
 
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/EnumUtils.h"
 #include "Core/PowerPC/Gekko.h"
@@ -26,8 +26,7 @@ struct FakeBranchWatchCollectionKey
   u32 origin_addr;
   u32 destin_addr;
 
-  // TODO C++20: constexpr w/ std::bit_cast
-  inline operator u64() const { return Common::BitCast<u64>(*this); }
+  constexpr operator u64() const { return std::bit_cast<u64>(*this); }
 };
 struct BranchWatchCollectionKey : FakeBranchWatchCollectionKey
 {
@@ -155,37 +154,37 @@ public:
   // but also increment the total_hits by N (see dcbx JIT code).
   static void HitVirtualTrue_fk(BranchWatch* branch_watch, u64 fake_key, u32 inst)
   {
-    branch_watch->m_collection_vt[{Common::BitCast<FakeBranchWatchCollectionKey>(fake_key), inst}]
+    branch_watch->m_collection_vt[{std::bit_cast<FakeBranchWatchCollectionKey>(fake_key), inst}]
         .total_hits += 1;
   }
 
   static void HitPhysicalTrue_fk(BranchWatch* branch_watch, u64 fake_key, u32 inst)
   {
-    branch_watch->m_collection_pt[{Common::BitCast<FakeBranchWatchCollectionKey>(fake_key), inst}]
+    branch_watch->m_collection_pt[{std::bit_cast<FakeBranchWatchCollectionKey>(fake_key), inst}]
         .total_hits += 1;
   }
 
   static void HitVirtualFalse_fk(BranchWatch* branch_watch, u64 fake_key, u32 inst)
   {
-    branch_watch->m_collection_vf[{Common::BitCast<FakeBranchWatchCollectionKey>(fake_key), inst}]
+    branch_watch->m_collection_vf[{std::bit_cast<FakeBranchWatchCollectionKey>(fake_key), inst}]
         .total_hits += 1;
   }
 
   static void HitPhysicalFalse_fk(BranchWatch* branch_watch, u64 fake_key, u32 inst)
   {
-    branch_watch->m_collection_pf[{Common::BitCast<FakeBranchWatchCollectionKey>(fake_key), inst}]
+    branch_watch->m_collection_pf[{std::bit_cast<FakeBranchWatchCollectionKey>(fake_key), inst}]
         .total_hits += 1;
   }
 
   static void HitVirtualTrue_fk_n(BranchWatch* branch_watch, u64 fake_key, u32 inst, u32 n)
   {
-    branch_watch->m_collection_vt[{Common::BitCast<FakeBranchWatchCollectionKey>(fake_key), inst}]
+    branch_watch->m_collection_vt[{std::bit_cast<FakeBranchWatchCollectionKey>(fake_key), inst}]
         .total_hits += n;
   }
 
   static void HitPhysicalTrue_fk_n(BranchWatch* branch_watch, u64 fake_key, u32 inst, u32 n)
   {
-    branch_watch->m_collection_pt[{Common::BitCast<FakeBranchWatchCollectionKey>(fake_key), inst}]
+    branch_watch->m_collection_pt[{std::bit_cast<FakeBranchWatchCollectionKey>(fake_key), inst}]
         .total_hits += n;
   }
 

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -303,7 +303,7 @@ std::string GetStringVA(HLEPrintArgs* args, std::string_view string)
       if (string[i] == '*')
       {
         ++i;
-        const s32 result_tmp = Common::BitCast<s32>(args->GetU32());
+        const s32 result_tmp = std::bit_cast<s32>(args->GetU32());
         if (result_tmp >= 0)
           return static_cast<u32>(result_tmp);
 
@@ -415,7 +415,7 @@ std::string GetStringVA(HLEPrintArgs* args, std::string_view string)
     }
     case 'c':
     {
-      const s32 value = Common::BitCast<s32>(args->GetU32());
+      const s32 value = std::bit_cast<s32>(args->GetU32());
       if (length_modifier == LengthModifier::l)
       {
         // Same problem as with wide strings here.
@@ -443,12 +443,12 @@ std::string GetStringVA(HLEPrintArgs* args, std::string_view string)
           precision ? fmt::format(".{}", *precision) : "");
       if (length_modifier == LengthModifier::ll)
       {
-        const s64 value = Common::BitCast<s64>(args->GetU64());
+        const s64 value = std::bit_cast<s64>(args->GetU64());
         result += fmt::sprintf(fmt::format("%{}" PRId64, options).c_str(), value);
       }
       else
       {
-        s32 value = Common::BitCast<s32>(args->GetU32());
+        s32 value = std::bit_cast<s32>(args->GetU32());
         if (length_modifier == LengthModifier::h)
           value = static_cast<s16>(value);
         else if (length_modifier == LengthModifier::hh)

--- a/Source/Core/Core/HW/AddressSpace.cpp
+++ b/Source/Core/Core/HW/AddressSpace.cpp
@@ -4,8 +4,8 @@
 #include "Core/HW/AddressSpace.h"
 
 #include <algorithm>
+#include <bit>
 
-#include "Common/BitUtils.h"
 #include "Core/Core.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/Memmap.h"
@@ -55,7 +55,7 @@ void Accessors::WriteU64(const Core::CPUThreadGuard& guard, u32 address, u64 val
 
 float Accessors::ReadF32(const Core::CPUThreadGuard& guard, u32 address) const
 {
-  return Common::BitCast<float>(ReadU32(guard, address));
+  return std::bit_cast<float>(ReadU32(guard, address));
 }
 
 Accessors::iterator Accessors::begin() const

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -3,6 +3,8 @@
 
 #include "Core/HW/EXI/BBA/BuiltIn.h"
 
+#include <bit>
+
 #ifdef _WIN32
 #include <ws2ipdef.h>
 #else
@@ -303,7 +305,7 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleTCPFrame(const Common::TCPPacket& 
   const auto& [hwdata, ip_header, tcp_header, ip_options, tcp_options, data] = packet;
   sf::IpAddress target;
   StackRef* ref = m_network_ref.GetTCPSlot(tcp_header.source_port, tcp_header.destination_port,
-                                           Common::BitCast<u32>(ip_header.destination_addr));
+                                           std::bit_cast<u32>(ip_header.destination_addr));
   const u16 flags = ntohs(tcp_header.properties) & 0xfff;
   if (flags & (TCP_FLAG_FIN | TCP_FLAG_RST))
   {
@@ -344,16 +346,16 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleTCPFrame(const Common::TCPPacket& 
     ref->type = IPPROTO_TCP;
     for (auto& tcp_buf : ref->tcp_buffers)
       tcp_buf.used = false;
-    const u32 destination_ip = Common::BitCast<u32>(ip_header.destination_addr);
+    const u32 destination_ip = std::bit_cast<u32>(ip_header.destination_addr);
     ref->from.sin_addr.s_addr = destination_ip;
     ref->from.sin_port = tcp_header.destination_port;
-    ref->to.sin_addr.s_addr = Common::BitCast<u32>(ip_header.source_addr);
+    ref->to.sin_addr.s_addr = std::bit_cast<u32>(ip_header.source_addr);
     ref->to.sin_port = tcp_header.source_port;
     ref->bba_mac = m_current_mac;
     ref->my_mac = ResolveAddress(destination_ip);
     ref->tcp_socket.setBlocking(false);
     ref->ready = false;
-    ref->ip = Common::BitCast<u32>(ip_header.destination_addr);
+    ref->ip = std::bit_cast<u32>(ip_header.destination_addr);
 
     target = sf::IpAddress(ntohl(destination_ip));
     ref->tcp_socket.Connect(target, ntohs(tcp_header.destination_port), m_current_ip);
@@ -450,7 +452,7 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleUDPFrame(const Common::UDPPacket& 
   sf::IpAddress target;
   const u32 destination_addr = ip_header.destination_addr == Common::IP_ADDR_ANY ?
                                    m_router_ip :  // dns request
-                                   Common::BitCast<u32>(ip_header.destination_addr);
+                                   std::bit_cast<u32>(ip_header.destination_addr);
 
   StackRef* ref = m_network_ref.GetAvailableSlot(udp_header.source_port);
   if (ref->ip == 0)
@@ -463,7 +465,7 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleUDPFrame(const Common::UDPPacket& 
     ref->my_mac = m_router_mac;
     ref->from.sin_addr.s_addr = destination_addr;
     ref->from.sin_port = udp_header.destination_port;
-    ref->to.sin_addr.s_addr = Common::BitCast<u32>(ip_header.source_addr);
+    ref->to.sin_addr.s_addr = std::bit_cast<u32>(ip_header.source_addr);
     ref->to.sin_port = udp_header.source_port;
     ref->udp_socket.setBlocking(false);
     if (ref->udp_socket.Bind(ntohs(udp_header.source_port), m_current_ip) != sf::Socket::Done)
@@ -483,7 +485,7 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleUDPFrame(const Common::UDPPacket& 
         reply.eth_header.destination = hwdata.source;
         reply.eth_header.source = hwdata.destination;
         reply.ip_header.destination_addr = ip_header.source_addr;
-        reply.ip_header.source_addr = Common::BitCast<Common::IPAddress>(destination_addr);
+        reply.ip_header.source_addr = std::bit_cast<Common::IPAddress>(destination_addr);
         WriteToQueue(reply.Build());
       }
     }
@@ -491,7 +493,7 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleUDPFrame(const Common::UDPPacket& 
   if (ntohs(udp_header.destination_port) == 53)
     target = sf::IpAddress(m_dns_ip.c_str());  // dns server ip
   else
-    target = sf::IpAddress(ntohl(Common::BitCast<u32>(ip_header.destination_addr)));
+    target = sf::IpAddress(ntohl(std::bit_cast<u32>(ip_header.destination_addr)));
   ref->udp_socket.send(data.data(), data.size(), target, ntohs(udp_header.destination_port));
 }
 
@@ -921,7 +923,7 @@ sf::Socket::Status BbaUdpSocket::Bind(u16 port, u32 net_ip)
   // Subscribe to the SSDP multicast group
   // NB: Other groups aren't supported because of HLE
   struct ip_mreq mreq;
-  mreq.imr_multiaddr.s_addr = Common::BitCast<u32>(Common::IP_ADDR_SSDP);
+  mreq.imr_multiaddr.s_addr = std::bit_cast<u32>(Common::IP_ADDR_SSDP);
   mreq.imr_interface.s_addr = net_ip;
   if (setsockopt(getHandle(), IPPROTO_IP, IP_ADD_MEMBERSHIP, reinterpret_cast<const char*>(&mreq),
                  sizeof(mreq)) != 0)

--- a/Source/Core/Core/HW/MMIO.h
+++ b/Source/Core/Core/HW/MMIO.h
@@ -5,12 +5,12 @@
 
 #include <array>
 #include <atomic>
+#include <bit>
 #include <string>
 #include <tuple>
 #include <type_traits>
 
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/MMIOHandlers.h"
@@ -88,7 +88,7 @@ inline u16* LowPart(u32* ptr)
 inline u16* LowPart(std::atomic<u32>* ptr)
 {
   static_assert(std::atomic<u32>::is_always_lock_free && sizeof(std::atomic<u32>) == sizeof(u32));
-  return LowPart(Common::BitCast<u32*>(ptr));
+  return LowPart(std::bit_cast<u32*>(ptr));
 }
 inline u16* HighPart(u32* ptr)
 {
@@ -97,7 +97,7 @@ inline u16* HighPart(u32* ptr)
 inline u16* HighPart(std::atomic<u32>* ptr)
 {
   static_assert(std::atomic<u32>::is_always_lock_free && sizeof(std::atomic<u32>) == sizeof(u32));
-  return HighPart(Common::BitCast<u32*>(ptr));
+  return HighPart(std::bit_cast<u32*>(ptr));
 }
 }  // namespace Utils
 

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -120,7 +120,7 @@ static std::optional<u32> inet_pton(const char* src)
   }
   if (octets < 4)
     return std::nullopt;
-  return Common::BitCast<u32>(tmp);
+  return std::bit_cast<u32>(tmp);
 }
 
 // Maps SOCKOPT level from Wii to native

--- a/Source/Core/Core/PowerPC/Expression.cpp
+++ b/Source/Core/Core/PowerPC/Expression.cpp
@@ -13,7 +13,6 @@
 
 #include <expr.h>
 
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/Core.h"
@@ -84,7 +83,7 @@ static double HostReadFunc(expr_func* f, vec_expr_t* args, void* c)
   const u32 address = static_cast<u32>(expr_eval(&vec_nth(args, 0)));
 
   Core::CPUThreadGuard guard(Core::System::GetInstance());
-  return Common::BitCast<T>(HostRead<U>(guard, address));
+  return std::bit_cast<T>(HostRead<U>(guard, address));
 }
 
 template <typename T, typename U = T>
@@ -96,7 +95,7 @@ static double HostWriteFunc(expr_func* f, vec_expr_t* args, void* c)
   const u32 address = static_cast<u32>(expr_eval(&vec_nth(args, 1)));
 
   Core::CPUThreadGuard guard(Core::System::GetInstance());
-  HostWrite<U>(guard, Common::BitCast<U>(var), address);
+  HostWrite<U>(guard, std::bit_cast<U>(var), address);
   return var;
 }
 
@@ -105,7 +104,7 @@ static double CastFunc(expr_func* f, vec_expr_t* args, void* c)
 {
   if (vec_len(args) != 1)
     return 0;
-  return Common::BitCast<T>(static_cast<U>(expr_eval(&vec_nth(args, 0))));
+  return std::bit_cast<T>(static_cast<U>(expr_eval(&vec_nth(args, 0))));
 }
 
 static double CallstackFunc(expr_func* f, vec_expr_t* args, void* c)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
+#include <bit>
 #include <cmath>
 #include <limits>
 
-#include "Common/BitUtils.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/FloatUtils.h"
@@ -59,13 +59,13 @@ inline float ForceSingle(const UReg_FPSCR& fpscr, double value)
 
     constexpr u64 smallest_normal_single = 0x3810000000000000;
     const u64 value_without_sign =
-        Common::BitCast<u64>(value) & (Common::DOUBLE_EXP | Common::DOUBLE_FRAC);
+        std::bit_cast<u64>(value) & (Common::DOUBLE_EXP | Common::DOUBLE_FRAC);
 
     if (value_without_sign < smallest_normal_single)
     {
-      const u64 flushed_double = Common::BitCast<u64>(value) & Common::DOUBLE_SIGN;
+      const u64 flushed_double = std::bit_cast<u64>(value) & Common::DOUBLE_SIGN;
       const u32 flushed_single = static_cast<u32>(flushed_double >> 32);
-      return Common::BitCast<float>(flushed_single);
+      return std::bit_cast<float>(flushed_single);
     }
   }
 
@@ -90,18 +90,18 @@ inline double ForceDouble(const UReg_FPSCR& fpscr, double d)
 
 inline double Force25Bit(double d)
 {
-  u64 integral = Common::BitCast<u64>(d);
+  u64 integral = std::bit_cast<u64>(d);
 
   integral = (integral & 0xFFFFFFFFF8000000ULL) + (integral & 0x8000000);
 
-  return Common::BitCast<double>(integral);
+  return std::bit_cast<double>(integral);
 }
 
 inline double MakeQuiet(double d)
 {
-  const u64 integral = Common::BitCast<u64>(d) | Common::DOUBLE_QBIT;
+  const u64 integral = std::bit_cast<u64>(d) | Common::DOUBLE_QBIT;
 
-  return Common::BitCast<double>(integral);
+  return std::bit_cast<double>(integral);
 }
 
 // these functions allow globally modify operations behaviour

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
@@ -4,12 +4,12 @@
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 
 #include <algorithm>
+#include <bit>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Core/PowerPC/Interpreter/ExceptionUtils.h"
@@ -186,7 +186,7 @@ static void Helper_Quantize(PowerPC::MMU& mmu, const PowerPC::PowerPCState* ppcs
   {
   case QUANTIZE_FLOAT:
   {
-    const u64 integral_ps0 = Common::BitCast<u64>(ps0);
+    const u64 integral_ps0 = std::bit_cast<u64>(ps0);
     const u32 conv_ps0 = ConvertToSingleFTZ(integral_ps0);
 
     if (instW != 0)
@@ -195,7 +195,7 @@ static void Helper_Quantize(PowerPC::MMU& mmu, const PowerPC::PowerPCState* ppcs
     }
     else
     {
-      const u64 integral_ps1 = Common::BitCast<u64>(ps1);
+      const u64 integral_ps1 = std::bit_cast<u64>(ps1);
       const u32 conv_ps1 = ConvertToSingleFTZ(integral_ps1);
 
       WritePair<u32>(mmu, conv_ps0, conv_ps1, addr);
@@ -265,14 +265,14 @@ static void Helper_Dequantize(PowerPC::MMU& mmu, PowerPC::PowerPCState* ppcs, u3
     if (instW != 0)
     {
       const u32 value = ReadUnpaired<u32>(mmu, addr);
-      ps0 = Common::BitCast<double>(ConvertToDouble(value));
+      ps0 = std::bit_cast<double>(ConvertToDouble(value));
       ps1 = 1.0;
     }
     else
     {
       const auto [first, second] = ReadPair<u32>(mmu, addr);
-      ps0 = Common::BitCast<double>(ConvertToDouble(first));
-      ps1 = Common::BitCast<double>(ConvertToDouble(second));
+      ps0 = std::bit_cast<double>(ConvertToDouble(first));
+      ps1 = std::bit_cast<double>(ConvertToDouble(second));
     }
     break;
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -3,10 +3,10 @@
 
 #include "Core/PowerPC/JitArm64/Jit.h"
 
+#include <bit>
 #include <limits>
 
 #include "Common/Arm64Emitter.h"
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
 #include "Common/FloatUtils.h"
@@ -300,8 +300,7 @@ void JitArm64::GenerateFres()
   SetJumpTarget(small_exponent);
   TST(ARM64Reg::X1, LogicalImm(Common::DOUBLE_EXP | Common::DOUBLE_FRAC, GPRSize::B64));
   FixupBranch zero = B(CCFlags::CC_EQ);
-  MOVI2R(ARM64Reg::X4,
-         Common::BitCast<u64>(static_cast<double>(std::numeric_limits<float>::max())));
+  MOVI2R(ARM64Reg::X4, std::bit_cast<u64>(static_cast<double>(std::numeric_limits<float>::max())));
   ORR(ARM64Reg::X0, ARM64Reg::X3, ARM64Reg::X4);
   RET();
 
@@ -374,7 +373,7 @@ void JitArm64::GenerateFrsqrte()
   B(positive_normal);
 
   SetJumpTarget(nan_or_inf);
-  MOVI2R(ARM64Reg::X2, Common::BitCast<u64>(-std::numeric_limits<double>::infinity()));
+  MOVI2R(ARM64Reg::X2, std::bit_cast<u64>(-std::numeric_limits<double>::infinity()));
   CMP(ARM64Reg::X1, ARM64Reg::X2);
   B(CCFlags::CC_NEQ, done);
 

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -668,7 +668,7 @@ std::optional<ReadResult<float>> MMU::HostTryReadF32(const Core::CPUThreadGuard&
   const auto result = HostTryReadUX<u32>(guard, address, space);
   if (!result)
     return std::nullopt;
-  return ReadResult<float>(result->translated, Common::BitCast<float>(result->value));
+  return ReadResult<float>(result->translated, std::bit_cast<float>(result->value));
 }
 
 std::optional<ReadResult<double>> MMU::HostTryReadF64(const Core::CPUThreadGuard& guard,
@@ -677,7 +677,7 @@ std::optional<ReadResult<double>> MMU::HostTryReadF64(const Core::CPUThreadGuard
   const auto result = HostTryReadUX<u64>(guard, address, space);
   if (!result)
     return std::nullopt;
-  return ReadResult<double>(result->translated, Common::BitCast<double>(result->value));
+  return ReadResult<double>(result->translated, std::bit_cast<double>(result->value));
 }
 
 void MMU::Write_U8(const u32 var, const u32 address)
@@ -745,14 +745,14 @@ float MMU::HostRead_F32(const Core::CPUThreadGuard& guard, const u32 address)
 {
   const u32 integral = HostRead_U32(guard, address);
 
-  return Common::BitCast<float>(integral);
+  return std::bit_cast<float>(integral);
 }
 
 double MMU::HostRead_F64(const Core::CPUThreadGuard& guard, const u32 address)
 {
   const u64 integral = HostRead_U64(guard, address);
 
-  return Common::BitCast<double>(integral);
+  return std::bit_cast<double>(integral);
 }
 
 void MMU::HostWrite_U8(const Core::CPUThreadGuard& guard, const u32 var, const u32 address)
@@ -782,14 +782,14 @@ void MMU::HostWrite_U64(const Core::CPUThreadGuard& guard, const u64 var, const 
 
 void MMU::HostWrite_F32(const Core::CPUThreadGuard& guard, const float var, const u32 address)
 {
-  const u32 integral = Common::BitCast<u32>(var);
+  const u32 integral = std::bit_cast<u32>(var);
 
   HostWrite_U32(guard, integral, address);
 }
 
 void MMU::HostWrite_F64(const Core::CPUThreadGuard& guard, const double var, const u32 address)
 {
-  const u64 integral = Common::BitCast<u64>(var);
+  const u64 integral = std::bit_cast<u64>(var);
 
   HostWrite_U64(guard, integral, address);
 }
@@ -852,14 +852,14 @@ std::optional<WriteResult> MMU::HostTryWriteU64(const Core::CPUThreadGuard& guar
 std::optional<WriteResult> MMU::HostTryWriteF32(const Core::CPUThreadGuard& guard, const float var,
                                                 const u32 address, RequestedAddressSpace space)
 {
-  const u32 integral = Common::BitCast<u32>(var);
+  const u32 integral = std::bit_cast<u32>(var);
   return HostTryWriteU32(guard, integral, address, space);
 }
 
 std::optional<WriteResult> MMU::HostTryWriteF64(const Core::CPUThreadGuard& guard, const double var,
                                                 const u32 address, RequestedAddressSpace space)
 {
-  const u64 integral = Common::BitCast<u64>(var);
+  const u64 integral = std::bit_cast<u64>(var);
   return HostTryWriteU64(guard, integral, address, space);
 }
 

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -4,6 +4,7 @@
 #include "Core/PowerPC/PowerPC.h"
 
 #include <algorithm>
+#include <bit>
 #include <cstring>
 #include <istream>
 #include <ostream>
@@ -11,7 +12,6 @@
 #include <vector>
 
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/FPURoundMode.h"
@@ -37,22 +37,22 @@ namespace PowerPC
 {
 double PairedSingle::PS0AsDouble() const
 {
-  return Common::BitCast<double>(ps0);
+  return std::bit_cast<double>(ps0);
 }
 
 double PairedSingle::PS1AsDouble() const
 {
-  return Common::BitCast<double>(ps1);
+  return std::bit_cast<double>(ps1);
 }
 
 void PairedSingle::SetPS0(double value)
 {
-  ps0 = Common::BitCast<u64>(value);
+  ps0 = std::bit_cast<u64>(value);
 }
 
 void PairedSingle::SetPS1(double value)
 {
-  ps1 = Common::BitCast<u64>(value);
+  ps1 = std::bit_cast<u64>(value);
 }
 
 static void InvalidateCacheThreadSafe(Core::System& system, u64 userdata, s64 cyclesLate)

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -3,6 +3,9 @@
 
 #include "DolphinQt/Debugger/MemoryViewWidget.h"
 
+#include <bit>
+#include <cmath>
+
 #include <QApplication>
 #include <QClipboard>
 #include <QHBoxLayout>
@@ -14,10 +17,10 @@
 #include <QTableWidget>
 #include <QtGlobal>
 
-#include <cmath>
 #include <fmt/printf.h>
 
 #include "Common/Align.h"
+#include "Common/BitUtils.h"
 #include "Common/FloatUtils.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
@@ -520,11 +523,11 @@ QString MemoryViewWidget::ValueToString(const Core::CPUThreadGuard& guard, u32 a
   case Type::Unsigned32:
     return QString::number(accessors->ReadU32(guard, address));
   case Type::Signed8:
-    return QString::number(Common::BitCast<s8>(accessors->ReadU8(guard, address)));
+    return QString::number(std::bit_cast<s8>(accessors->ReadU8(guard, address)));
   case Type::Signed16:
-    return QString::number(Common::BitCast<s16>(accessors->ReadU16(guard, address)));
+    return QString::number(std::bit_cast<s16>(accessors->ReadU16(guard, address)));
   case Type::Signed32:
-    return QString::number(Common::BitCast<s32>(accessors->ReadU32(guard, address)));
+    return QString::number(std::bit_cast<s32>(accessors->ReadU32(guard, address)));
   case Type::Float32:
   {
     QString string = QString::number(accessors->ReadF32(guard, address), 'g', 4);
@@ -537,7 +540,7 @@ QString MemoryViewWidget::ValueToString(const Core::CPUThreadGuard& guard, u32 a
   case Type::Double:
   {
     QString string =
-        QString::number(Common::BitCast<double>(accessors->ReadU64(guard, address)), 'g', 4);
+        QString::number(std::bit_cast<double>(accessors->ReadU64(guard, address)), 'g', 4);
     // Align to first digit.
     if (!string.startsWith(QLatin1Char('-')))
       string.prepend(QLatin1Char(' '));
@@ -635,7 +638,7 @@ std::vector<u8> MemoryViewWidget::ConvertTextToBytes(Type type, QStringView inpu
 
     if (good)
     {
-      const u32 value = Common::BitCast<u32>(float_value);
+      const u32 value = std::bit_cast<u32>(float_value);
       auto std_array = Common::BitCastToArray<u8>(Common::swap32(value));
       return std::vector<u8>(std_array.begin(), std_array.end());
     }
@@ -647,7 +650,7 @@ std::vector<u8> MemoryViewWidget::ConvertTextToBytes(Type type, QStringView inpu
 
     if (good)
     {
-      const u64 value = Common::BitCast<u64>(double_value);
+      const u64 value = std::bit_cast<u64>(double_value);
       auto std_array = Common::BitCastToArray<u8>(Common::swap64(value));
       return std::vector<u8>(std_array.begin(), std_array.end());
     }

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -3,6 +3,8 @@
 
 #include "DolphinQt/Debugger/ThreadWidget.h"
 
+#include <bit>
+
 #include <QGroupBox>
 #include <QHeaderView>
 #include <QLabel>
@@ -11,7 +13,6 @@
 #include <QTableWidget>
 #include <QVBoxLayout>
 
-#include "Common/BitUtils.h"
 #include "Core/Core.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -363,8 +364,7 @@ void ThreadWidget::UpdateThreadContext(const Common::Debug::PartialContext& cont
   const auto format_f64_as_u64_idx = [](const auto& table, std::size_t index) {
     if (!table || index >= table->size())
       return QString{};
-    return QStringLiteral("%1").arg(Common::BitCast<u64>(table->at(index)), 16, 16,
-                                    QLatin1Char('0'));
+    return QStringLiteral("%1").arg(std::bit_cast<u64>(table->at(index)), 16, 16, QLatin1Char('0'));
   };
 
   m_context_table->setRowCount(0);

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -4,6 +4,7 @@
 #include "DolphinQt/FIFO/FIFOAnalyzer.h"
 
 #include <algorithm>
+#include <bit>
 
 #include <QGroupBox>
 #include <QHBoxLayout>
@@ -646,7 +647,7 @@ public:
         }
         if (format == ComponentFormat::Float)
         {
-          const float value = Common::BitCast<float>(Common::swap32(&vertex_data[i]));
+          const float value = std::bit_cast<float>(Common::swap32(&vertex_data[i]));
           text += QStringLiteral(" (%1)").arg(value);
         }
         i += component_size;

--- a/Source/Core/VideoCommon/BPMemory.cpp
+++ b/Source/Core/VideoCommon/BPMemory.cpp
@@ -3,7 +3,7 @@
 
 #include "VideoCommon/BPMemory.h"
 
-#include "Common/BitUtils.h"
+#include <bit>
 
 // BP state
 // STATE_TO_SAVE
@@ -50,14 +50,14 @@ float FogParam0::FloatValue() const
 {
   // scale mantissa from 11 to 23 bits
   const u32 integral = (sign << 31) | (exp << 23) | (mant << 12);
-  return Common::BitCast<float>(integral);
+  return std::bit_cast<float>(integral);
 }
 
 float FogParam3::FloatValue() const
 {
   // scale mantissa from 11 to 23 bits
   const u32 integral = (c_sign << 31) | (c_exp << 23) | (c_mant << 12);
-  return Common::BitCast<float>(integral);
+  return std::bit_cast<float>(integral);
 }
 
 float FogParams::GetA() const

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -113,7 +113,7 @@ public:
     // Some games (e.g. Donkey Kong Country Returns) have a few draws that contain NaN.
     // Since NaN != NaN, we need to compare the bits instead.
     const auto bit_equal = [](float val_a, float val_b) {
-      return Common::BitCast<u32>(val_a) == Common::BitCast<u32>(val_b);
+      return std::bit_cast<u32>(val_a) == std::bit_cast<u32>(val_b);
     };
 
     // The last element is allowed to be garbage for SIMD overwrites.

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -3,7 +3,8 @@
 
 #include "VideoCommon/XFStructs.h"
 
-#include "Common/BitUtils.h"
+#include <bit>
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
@@ -379,42 +380,42 @@ std::pair<std::string, std::string> GetXFRegInfo(u32 address, u32 value)
 
   case XFMEM_SETVIEWPORT:
     return std::make_pair(RegName(XFMEM_SETVIEWPORT + 0),
-                          fmt::format("Viewport width: {}", Common::BitCast<float>(value)));
+                          fmt::format("Viewport width: {}", std::bit_cast<float>(value)));
   case XFMEM_SETVIEWPORT + 1:
     return std::make_pair(RegName(XFMEM_SETVIEWPORT + 1),
-                          fmt::format("Viewport height: {}", Common::BitCast<float>(value)));
+                          fmt::format("Viewport height: {}", std::bit_cast<float>(value)));
   case XFMEM_SETVIEWPORT + 2:
     return std::make_pair(RegName(XFMEM_SETVIEWPORT + 2),
-                          fmt::format("Viewport z range: {}", Common::BitCast<float>(value)));
+                          fmt::format("Viewport z range: {}", std::bit_cast<float>(value)));
   case XFMEM_SETVIEWPORT + 3:
     return std::make_pair(RegName(XFMEM_SETVIEWPORT + 3),
-                          fmt::format("Viewport x origin: {}", Common::BitCast<float>(value)));
+                          fmt::format("Viewport x origin: {}", std::bit_cast<float>(value)));
   case XFMEM_SETVIEWPORT + 4:
     return std::make_pair(RegName(XFMEM_SETVIEWPORT + 4),
-                          fmt::format("Viewport y origin: {}", Common::BitCast<float>(value)));
+                          fmt::format("Viewport y origin: {}", std::bit_cast<float>(value)));
   case XFMEM_SETVIEWPORT + 5:
     return std::make_pair(RegName(XFMEM_SETVIEWPORT + 5),
-                          fmt::format("Viewport far z: {}", Common::BitCast<float>(value)));
+                          fmt::format("Viewport far z: {}", std::bit_cast<float>(value)));
     break;
 
   case XFMEM_SETPROJECTION:
     return std::make_pair(RegName(XFMEM_SETPROJECTION + 0),
-                          fmt::format("Projection[0]: {}", Common::BitCast<float>(value)));
+                          fmt::format("Projection[0]: {}", std::bit_cast<float>(value)));
   case XFMEM_SETPROJECTION + 1:
     return std::make_pair(RegName(XFMEM_SETPROJECTION + 1),
-                          fmt::format("Projection[1]: {}", Common::BitCast<float>(value)));
+                          fmt::format("Projection[1]: {}", std::bit_cast<float>(value)));
   case XFMEM_SETPROJECTION + 2:
     return std::make_pair(RegName(XFMEM_SETPROJECTION + 2),
-                          fmt::format("Projection[2]: {}", Common::BitCast<float>(value)));
+                          fmt::format("Projection[2]: {}", std::bit_cast<float>(value)));
   case XFMEM_SETPROJECTION + 3:
     return std::make_pair(RegName(XFMEM_SETPROJECTION + 3),
-                          fmt::format("Projection[3]: {}", Common::BitCast<float>(value)));
+                          fmt::format("Projection[3]: {}", std::bit_cast<float>(value)));
   case XFMEM_SETPROJECTION + 4:
     return std::make_pair(RegName(XFMEM_SETPROJECTION + 4),
-                          fmt::format("Projection[4]: {}", Common::BitCast<float>(value)));
+                          fmt::format("Projection[4]: {}", std::bit_cast<float>(value)));
   case XFMEM_SETPROJECTION + 5:
     return std::make_pair(RegName(XFMEM_SETPROJECTION + 5),
-                          fmt::format("Projection[5]: {}", Common::BitCast<float>(value)));
+                          fmt::format("Projection[5]: {}", std::bit_cast<float>(value)));
   case XFMEM_SETPROJECTION + 6:
     return std::make_pair(RegName(XFMEM_SETPROJECTION + 6),
                           fmt::to_string(static_cast<ProjectionType>(value)));
@@ -546,7 +547,7 @@ std::string GetXFMemDescription(u32 address, u32 value)
       (address >= XFMEM_POSTMATRICES && address < XFMEM_POSTMATRICES_END))
   {
     // The matrices all use floats
-    return fmt::format("{} = {}", GetXFMemName(address), Common::BitCast<float>(value));
+    return fmt::format("{} = {}", GetXFMemName(address), std::bit_cast<float>(value));
   }
   else if (address >= XFMEM_LIGHTS && address < XFMEM_LIGHTS_END)
   {
@@ -560,7 +561,7 @@ std::string GetXFMemDescription(u32 address, u32 value)
     else
     {
       // Everything else is a float
-      return fmt::format("{} = {}", GetXFMemName(address), Common::BitCast<float>(value));
+      return fmt::format("{} = {}", GetXFMemName(address), std::bit_cast<float>(value));
     }
   }
   else

--- a/Source/UnitTests/Common/Arm64EmitterTest.cpp
+++ b/Source/UnitTests/Common/Arm64EmitterTest.cpp
@@ -1,9 +1,10 @@
 // Copyright 2023 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <bit>
+
 #include "Common/Arm64Emitter.h"
 #include "Common/BitSet.h"
-#include "Common/BitUtils.h"
 
 #include <gtest/gtest.h>
 
@@ -62,7 +63,7 @@ public:
 
   void Run()
   {
-    const u64 actual = Common::BitCast<u64 (*)()>(m_code_pointer)();
+    const u64 actual = std::bit_cast<u64 (*)()>(m_code_pointer)();
     constexpr u64 expected = 123;
     EXPECT_EQ(expected, actual);
   }

--- a/Source/UnitTests/Common/BitUtilsTest.cpp
+++ b/Source/UnitTests/Common/BitUtilsTest.cpp
@@ -88,16 +88,3 @@ TEST(BitUtils, IsValidLowMask)
   EXPECT_FALSE(Common::IsValidLowMask((u64) ~(0b10000)));
   EXPECT_FALSE(Common::IsValidLowMask((u64)(~((u64)(~0b0) >> 1) | 0b1111)));
 }
-
-TEST(BitUtils, BitCast)
-{
-  EXPECT_EQ(0x00000000U, Common::BitCast<u32>(0.0f));
-  EXPECT_EQ(0x80000000U, Common::BitCast<u32>(-0.0f));
-  EXPECT_EQ(0x3F800000U, Common::BitCast<u32>(1.0f));
-  EXPECT_EQ(0xBF800000U, Common::BitCast<u32>(-1.0f));
-
-  EXPECT_EQ(0x0000000000000000ULL, Common::BitCast<u64>(0.0));
-  EXPECT_EQ(0x8000000000000000ULL, Common::BitCast<u64>(-0.0));
-  EXPECT_EQ(0x3FF0000000000000ULL, Common::BitCast<u64>(1.0));
-  EXPECT_EQ(0xBFF0000000000000ULL, Common::BitCast<u64>(-1.0));
-}

--- a/Source/UnitTests/Common/FloatUtilsTest.cpp
+++ b/Source/UnitTests/Common/FloatUtilsTest.cpp
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <array>
+#include <bit>
 #include <limits>
 #include <random>
 
 #include <gtest/gtest.h>
 
-#include "Common/BitUtils.h"
 #include "Common/FloatUtils.h"
 
 #include "../Core/PowerPC/TestValues.h"
@@ -53,16 +53,16 @@ TEST(FloatUtils, FlushToZero)
   for (u32 i = 0; i <= 0x007fffffu; ++i)
   {
     u32 i_tmp = i;
-    EXPECT_EQ(+0.f, Common::FlushToZero(Common::BitCast<float>(i_tmp)));
+    EXPECT_EQ(+0.f, Common::FlushToZero(std::bit_cast<float>(i_tmp)));
 
     i_tmp |= 0x80000000u;
-    EXPECT_EQ(-0.f, Common::FlushToZero(Common::BitCast<float>(i_tmp)));
+    EXPECT_EQ(-0.f, Common::FlushToZero(std::bit_cast<float>(i_tmp)));
 
     i_tmp = dist(engine);
-    EXPECT_EQ(i_tmp, Common::BitCast<u32>(Common::FlushToZero(Common::BitCast<float>(i_tmp))));
+    EXPECT_EQ(i_tmp, std::bit_cast<u32>(Common::FlushToZero(std::bit_cast<float>(i_tmp))));
 
     i_tmp |= 0x80000000u;
-    EXPECT_EQ(i_tmp, Common::BitCast<u32>(Common::FlushToZero(Common::BitCast<float>(i_tmp))));
+    EXPECT_EQ(i_tmp, std::bit_cast<u32>(Common::FlushToZero(std::bit_cast<float>(i_tmp))));
   }
 }
 
@@ -88,11 +88,11 @@ TEST(FloatUtils, ApproximateReciprocalSquareRoot)
   for (size_t i = 0; i < double_test_values.size(); ++i)
   {
     u64 ivalue = double_test_values[i];
-    double dvalue = Common::BitCast<double>(ivalue);
+    double dvalue = std::bit_cast<double>(ivalue);
 
     u64 expected = expected_values[i];
 
-    u64 actual = Common::BitCast<u64>(Common::ApproximateReciprocalSquareRoot(dvalue));
+    u64 actual = std::bit_cast<u64>(Common::ApproximateReciprocalSquareRoot(dvalue));
 
     EXPECT_EQ(expected, actual);
   }

--- a/Source/UnitTests/Core/PowerPC/Jit64Common/Frsqrte.cpp
+++ b/Source/UnitTests/Core/PowerPC/Jit64Common/Frsqrte.cpp
@@ -1,9 +1,9 @@
 // Copyright 2018 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <bit>
 #include <cstring>
 
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/FloatUtils.h"
 #include "Common/ScopeGuard.h"
@@ -70,9 +70,9 @@ TEST(Jit64, Frsqrte)
 
   for (const u64 ivalue : double_test_values)
   {
-    double dvalue = Common::BitCast<double>(ivalue);
+    double dvalue = std::bit_cast<double>(ivalue);
 
-    u64 expected = Common::BitCast<u64>(Common::ApproximateReciprocalSquareRoot(dvalue));
+    u64 expected = std::bit_cast<u64>(Common::ApproximateReciprocalSquareRoot(dvalue));
 
     u64 actual = routines.wrapped_frsqrte(ivalue, fpscr);
 

--- a/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
@@ -3,8 +3,9 @@
 
 #include <functional>
 
+#include <bit>
+
 #include "Common/Arm64Emitter.h"
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/FPURoundMode.h"
 #include "Common/ScopeGuard.h"
@@ -53,13 +54,13 @@ public:
     gpr.Lock(ARM64Reg::W30);
     fpr.Lock(ARM64Reg::Q0, ARM64Reg::Q1);
 
-    convert_single_to_double_lower = Common::BitCast<u64 (*)(u32)>(GetCodePtr());
+    convert_single_to_double_lower = std::bit_cast<u64 (*)(u32)>(GetCodePtr());
     m_float_emit.INS(32, ARM64Reg::S0, 0, ARM64Reg::W0);
     ConvertSingleToDoubleLower(0, ARM64Reg::D0, ARM64Reg::S0, ARM64Reg::Q1);
     m_float_emit.UMOV(64, ARM64Reg::X0, ARM64Reg::D0, 0);
     RET();
 
-    convert_single_to_double_pair = Common::BitCast<Pair<u64> (*)(u32, u32)>(GetCodePtr());
+    convert_single_to_double_pair = std::bit_cast<Pair<u64> (*)(u32, u32)>(GetCodePtr());
     m_float_emit.INS(32, ARM64Reg::D0, 0, ARM64Reg::W0);
     m_float_emit.INS(32, ARM64Reg::D0, 1, ARM64Reg::W1);
     ConvertSingleToDoublePair(0, ARM64Reg::Q0, ARM64Reg::D0, ARM64Reg::Q1);
@@ -67,13 +68,13 @@ public:
     m_float_emit.UMOV(64, ARM64Reg::X1, ARM64Reg::Q0, 1);
     RET();
 
-    convert_double_to_single_lower = Common::BitCast<u32 (*)(u64)>(GetCodePtr());
+    convert_double_to_single_lower = std::bit_cast<u32 (*)(u64)>(GetCodePtr());
     m_float_emit.INS(64, ARM64Reg::D0, 0, ARM64Reg::X0);
     ConvertDoubleToSingleLower(0, ARM64Reg::S0, ARM64Reg::D0);
     m_float_emit.UMOV(32, ARM64Reg::W0, ARM64Reg::S0, 0);
     RET();
 
-    convert_double_to_single_pair = Common::BitCast<Pair<u32> (*)(u64, u64)>(GetCodePtr());
+    convert_double_to_single_pair = std::bit_cast<Pair<u32> (*)(u64, u64)>(GetCodePtr());
     m_float_emit.INS(64, ARM64Reg::Q0, 0, ARM64Reg::X0);
     m_float_emit.INS(64, ARM64Reg::Q0, 1, ARM64Reg::X1);
     ConvertDoubleToSinglePair(0, ARM64Reg::D0, ARM64Reg::Q0);

--- a/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
@@ -1,11 +1,11 @@
 // Copyright 2021 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <bit>
 #include <functional>
 #include <vector>
 
 #include "Common/Arm64Emitter.h"
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/ScopeGuard.h"
 #include "Core/Core.h"
@@ -38,7 +38,7 @@ public:
 
     auto& ppc_state = system.GetPPCState();
 
-    fprf_single = Common::BitCast<void (*)(u32)>(GetCodePtr());
+    fprf_single = std::bit_cast<void (*)(u32)>(GetCodePtr());
     MOV(ARM64Reg::X15, ARM64Reg::X30);
     MOV(ARM64Reg::X14, PPC_REG);
     MOVP2R(PPC_REG, &ppc_state);
@@ -47,7 +47,7 @@ public:
     MOV(PPC_REG, ARM64Reg::X14);
     RET();
 
-    fprf_double = Common::BitCast<void (*)(u64)>(GetCodePtr());
+    fprf_double = std::bit_cast<void (*)(u64)>(GetCodePtr());
     MOV(ARM64Reg::X15, ARM64Reg::X30);
     MOV(ARM64Reg::X14, PPC_REG);
     MOVP2R(PPC_REG, &ppc_state);
@@ -82,7 +82,7 @@ TEST(JitArm64, FPRF)
   for (const u64 double_input : double_test_values)
   {
     const u32 expected_double = RunUpdateFPRF(
-        ppc_state, [&] { ppc_state.UpdateFPRFDouble(Common::BitCast<double>(double_input)); });
+        ppc_state, [&] { ppc_state.UpdateFPRFDouble(std::bit_cast<double>(double_input)); });
     const u32 actual_double = RunUpdateFPRF(ppc_state, [&] { test.fprf_double(double_input); });
     if (expected_double != actual_double)
       fmt::print("{:016x} -> {:08x} == {:08x}\n", double_input, actual_double, expected_double);
@@ -91,7 +91,7 @@ TEST(JitArm64, FPRF)
     const u32 single_input = ConvertToSingle(double_input);
 
     const u32 expected_single = RunUpdateFPRF(
-        ppc_state, [&] { ppc_state.UpdateFPRFSingle(Common::BitCast<float>(single_input)); });
+        ppc_state, [&] { ppc_state.UpdateFPRFSingle(std::bit_cast<float>(single_input)); });
     const u32 actual_single = RunUpdateFPRF(ppc_state, [&] { test.fprf_single(single_input); });
     if (expected_single != actual_single)
       fmt::print("{:08x} -> {:08x} == {:08x}\n", single_input, actual_single, expected_single);

--- a/Source/UnitTests/Core/PowerPC/JitArm64/Fres.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/Fres.cpp
@@ -1,10 +1,10 @@
 // Copyright 2021 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <bit>
 #include <functional>
 
 #include "Common/Arm64Emitter.h"
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/ScopeGuard.h"
 #include "Core/Core.h"
@@ -33,7 +33,7 @@ public:
     const u8* raw_fres = GetCodePtr();
     GenerateFres();
 
-    fres = Common::BitCast<u64 (*)(u64)>(GetCodePtr());
+    fres = std::bit_cast<u64 (*)(u64)>(GetCodePtr());
     MOV(ARM64Reg::X15, ARM64Reg::X30);
     MOV(ARM64Reg::X14, PPC_REG);
     MOVP2R(PPC_REG, &system.GetPPCState());
@@ -60,9 +60,9 @@ TEST(JitArm64, Fres)
 
   for (const u64 ivalue : double_test_values)
   {
-    const double dvalue = Common::BitCast<double>(ivalue);
+    const double dvalue = std::bit_cast<double>(ivalue);
 
-    const u64 expected = Common::BitCast<u64>(Common::ApproximateReciprocal(dvalue));
+    const u64 expected = std::bit_cast<u64>(Common::ApproximateReciprocal(dvalue));
     const u64 actual = test.fres(ivalue);
 
     if (expected != actual)

--- a/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
@@ -1,6 +1,7 @@
 // Copyright 2021 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <bit>
 #include <functional>
 
 #include "Common/Arm64Emitter.h"
@@ -33,7 +34,7 @@ public:
     const u8* raw_frsqrte = GetCodePtr();
     GenerateFrsqrte();
 
-    frsqrte = Common::BitCast<u64 (*)(u64)>(GetCodePtr());
+    frsqrte = std::bit_cast<u64 (*)(u64)>(GetCodePtr());
     MOV(ARM64Reg::X15, ARM64Reg::X30);
     MOV(ARM64Reg::X14, PPC_REG);
     MOVP2R(PPC_REG, &system.GetPPCState());
@@ -60,9 +61,9 @@ TEST(JitArm64, Frsqrte)
 
   for (const u64 ivalue : double_test_values)
   {
-    const double dvalue = Common::BitCast<double>(ivalue);
+    const double dvalue = std::bit_cast<double>(ivalue);
 
-    const u64 expected = Common::BitCast<u64>(Common::ApproximateReciprocalSquareRoot(dvalue));
+    const u64 expected = std::bit_cast<u64>(Common::ApproximateReciprocalSquareRoot(dvalue));
     const u64 actual = test.frsqrte(ivalue);
 
     if (expected != actual)

--- a/Source/UnitTests/Core/PowerPC/JitArm64/MovI2R.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/MovI2R.cpp
@@ -1,13 +1,13 @@
 // Copyright 2021 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <bit>
 #include <cstddef>
 #include <random>
 #include <type_traits>
 
 #include "Common/Arm64Emitter.h"
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 
 #include <gtest/gtest.h>
 
@@ -33,7 +33,7 @@ public:
 
     FlushIcacheSection(const_cast<u8*>(fn), const_cast<u8*>(GetCodePtr()));
 
-    const u64 result = Common::BitCast<u64 (*)()>(fn)();
+    const u64 result = std::bit_cast<u64 (*)()>(fn)();
     EXPECT_EQ(value, result);
   }
 
@@ -50,7 +50,7 @@ public:
 
     FlushIcacheSection(const_cast<u8*>(fn), const_cast<u8*>(GetCodePtr()));
 
-    const u64 result = Common::BitCast<u64 (*)()>(fn)();
+    const u64 result = std::bit_cast<u64 (*)()>(fn)();
     EXPECT_EQ(value, result);
   }
 };
@@ -115,7 +115,7 @@ TEST(JitArm64, MovI2R_LogImm)
 TEST(JitArm64, MovI2R_ADP)
 {
   TestMovI2R test;
-  const u64 base = Common::BitCast<u64>(test.GetCodePtr());
+  const u64 base = std::bit_cast<u64>(test.GetCodePtr());
 
   // Test offsets around 0
   for (s64 i = -0x20000; i < 0x20000; i++)
@@ -138,7 +138,7 @@ TEST(JitArm64, MovI2R_ADP)
 TEST(JitArm64, MovI2R_ADRP)
 {
   TestMovI2R test;
-  const u64 base = Common::BitCast<u64>(test.GetCodePtr()) & ~0xFFF;
+  const u64 base = std::bit_cast<u64>(test.GetCodePtr()) & ~0xFFF;
 
   // Test offsets around 0
   for (s64 i = -0x20000; i < 0x20000; i++)

--- a/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
+++ b/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
@@ -1,6 +1,7 @@
 // Copyright 2014 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <bit>
 #include <limits>
 #include <memory>
 #include <tuple>
@@ -9,7 +10,6 @@
 
 #include <gtest/gtest.h>  // NOLINT
 
-#include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/MathUtil.h"
 #include "VideoCommon/CPMemory.h"
@@ -81,7 +81,7 @@ protected:
     const float actual = m_dst.Read<float, false>();
 
     if (!actual || actual != actual)
-      EXPECT_EQ(Common::BitCast<u32>(expected), Common::BitCast<u32>(actual));
+      EXPECT_EQ(std::bit_cast<u32>(expected), std::bit_cast<u32>(actual));
     else
       EXPECT_EQ(expected, actual);
   }


### PR DESCRIPTION
Now that we're using C++20, we can use `std::bit_cast` instead. See #10737 for a bit of other context.