### PR TITLE
Improve and Apply More Common/Intrinsics.h

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -145,6 +145,7 @@ if(MSVC AND _M_ARM_64)
 endif()
 
 if(NOT MSVC AND _M_ARM_64)
+  # Workaround Clang's AArch64 Target Function Attributes being lame compared to GCC
   set_source_files_properties(
     Crypto/AES.cpp
     Crypto/SHA1.cpp

--- a/Source/Core/Common/Crypto/SHA1.cpp
+++ b/Source/Core/Common/Crypto/SHA1.cpp
@@ -11,24 +11,8 @@
 #include "Common/Assert.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
+#include "Common/Intrinsics.h"
 #include "Common/Swap.h"
-
-#ifdef _MSC_VER
-#include <intrin.h>
-#else
-#ifdef _M_X86_64
-#include <immintrin.h>
-#elif defined(_M_ARM_64)
-#include <arm_acle.h>
-#include <arm_neon.h>
-#endif
-#endif
-
-#ifdef _MSC_VER
-#define ATTRIBUTE_TARGET(x)
-#else
-#define ATTRIBUTE_TARGET(x) [[gnu::target(x)]]
-#endif
 
 namespace Common::SHA1
 {
@@ -168,15 +152,14 @@ public:
 private:
   using WorkBlock = CyclicArray<__m128i, 4>;
 
-  ATTRIBUTE_TARGET("ssse3")
+  TARGET_X86_SSSE3
   static inline __m128i byterev_16B(__m128i x)
   {
     return _mm_shuffle_epi8(x, _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
   }
 
   template <size_t I>
-  ATTRIBUTE_TARGET("sha")
-  static inline __m128i MsgSchedule(WorkBlock* wblock)
+  TARGET_X86_SHA static inline __m128i MsgSchedule(WorkBlock* wblock)
   {
     auto& w = *wblock;
     // Update and return this location
@@ -188,7 +171,7 @@ private:
     return wx;
   }
 
-  ATTRIBUTE_TARGET("sha")
+  TARGET_X86_SHA
   virtual void ProcessBlock(const u8* msg) override
   {
     // There are 80 rounds with 4 bytes per round, giving 0x140 byte work space, but we can keep

--- a/Source/Core/Common/Hash.cpp
+++ b/Source/Core/Common/Hash.cpp
@@ -318,7 +318,7 @@ static u64 GetMurmurHash3(const u8* src, u32 len, u32 samples)
 
 #if defined(_M_X86_64)
 
-FUNCTION_TARGET_SSE42
+TARGET_X86_SSE42
 static u64 GetHash64_SSE42_CRC32(const u8* src, u32 len, u32 samples)
 {
   u64 h[4] = {len, 0, 0, 0};
@@ -359,7 +359,7 @@ static u64 GetHash64_SSE42_CRC32(const u8* src, u32 len, u32 samples)
 
 #elif defined(_M_X86)
 
-FUNCTION_TARGET_SSE42
+TARGET_X86_SSE42
 static u64 GetHash64_SSE42_CRC32(const u8* src, u32 len, u32 samples)
 {
   u32 h = len;

--- a/Source/Core/Common/Intrinsics.h
+++ b/Source/Core/Common/Intrinsics.h
@@ -3,69 +3,80 @@
 
 #pragma once
 
-#if defined(_M_X86)
-
-/**
- * It is assumed that all compilers used to build Dolphin support intrinsics up to and including
- * SSE 4.2 on x86/x64.
- */
-
 #if defined(__GNUC__) || defined(__clang__)
+// Due to limitations in GCC, intrinsics are only available when compiling with the corresponding
+// instruction set enabled. However, using the target attribute, we can compile single functions
+// with a different target instruction set, while still creating a generic build.
+//
+// Since this instruction set is enabled per-function, any callers should verify that the
+// instruction set is supported at runtime before calling it, and provide a fallback implementation
+// when not supported.
+//
+// When building with -march=native, or enabling the instruction sets in the compile flags, permit
+// usage of the instrinsics without any function attributes. If the command-line architecture does
+// not support this instruction set, enable it via function targeting.
 
-/**
- * Due to limitations in GCC, SSE intrinsics are only available when compiling with the
- * corresponding instruction set enabled. However, using the target attribute, we can compile
- * single functions with a different target instruction set, while still creating a generic build.
- *
- * Since this instruction set is enabled per-function, any callers should verify that the
- * instruction set is supported at runtime before calling it, and provide a fallback implementation
- * when not supported.
- *
- * When building with -march=native, or enabling the instruction sets in the compile flags, permit
- * usage of the instrinsics without any function attributes. If the command-line architecture does
- * not support this instruction set, enable it via function targeting.
- */
-
+#if defined(_M_X86)
 #include <x86intrin.h>
-#ifndef __SSE4_2__
-#define FUNCTION_TARGET_SSE42 [[gnu::target("sse4.2")]]
+#ifndef __SSE4_2__  // (-msse4.2) Streaming SIMD Extensions 4.2
+#define TARGET_X86_SSE42 [[gnu::target("sse4.2")]]
 #endif
-#ifndef __SSE4_1__
-#define FUNCTION_TARGET_SSR41 [[gnu::target("sse4.1")]]
+#ifndef __SSE4_1__  // (-msse4.1) Streaming SIMD Extensions 4.1
+#define TARGET_X86_SSR41 [[gnu::target("sse4.1")]]
 #endif
-#ifndef __SSSE3__
-#define FUNCTION_TARGET_SSSE3 [[gnu::target("ssse3")]]
+#ifndef __SSSE3__  // (-mssse3) Supplemental Streaming SIMD Extensions 3
+#define TARGET_X86_SSSE3 [[gnu::target("ssse3")]]
 #endif
-#ifndef __SSE3__
-#define FUNCTION_TARGET_SSE3 [[gnu::target("sse3")]]
+#ifndef __SSE3__  // (-msse3) Streaming SIMD Extensions 3
+#define TARGET_X86_SSE3 [[gnu::target("sse3")]]
+#endif
+#ifndef __SHA__  // (-msha) Intel SHA Extensions
+#define TARGET_X86_SHA [[gnu::target("sha")]]
+#endif
+#ifndef __AES__  // (-maes) Advanced Encryption Standard Instruction Set
+#define TARGET_X86_AES [[gnu::target("aes")]]
+#endif
+
+#elif defined(_M_ARM_64)
+#include <arm_acle.h>
+#include <arm_neon.h>
+// This would be where some TARGET_ARMV8 macros would go... if only Clang didn't have broken support
+// for AArch64 target function attributes. [[gnu::target("arch=armv8-a+crypto")]] works on GCC, but
+// not Clang. As well, [[gnu::target("crypto")]] also fails to do anything on Clang, and would need
+// to be [[gnu::target("+crypto")]] for GCC (annoying). To work around this, use -march targetting
+// for a source file in CMakeLists.txt when needed. This runs the risk of cross-pollination, but it
+// seems to be the only way.
 #endif
 
 #elif defined(_MSC_VER) || defined(__INTEL_COMPILER)
-
-/**
- * MSVC and ICC support intrinsics for any instruction set without any function attributes.
- */
+// MSVC and ICC support intrinsics for any instruction set without any function attributes.
 #include <intrin.h>
 
-#endif  // defined(_MSC_VER) || defined(__INTEL_COMPILER)
+#endif
 
-#endif  // _M_X86
+// Define the TARGET macros as nothing if they are not needed, or are unavailable on a given
+// platform. This way, a function compiled on multiple architectures can still target, say, an
+// x86 extension, so long as the relevant code is contained within an #ifdef _M_X86 guard.
 
-/**
- * Define the FUNCTION_TARGET macros to nothing if they are not needed, or not on an X86 platform.
- * This way when a function is defined with FUNCTION_TARGET you don't need to define a second
- * version without the macro around a #ifdef guard. Be careful when using intrinsics, as all use
- * should still be placed around a #ifdef _M_X86 if the file is compiled on all architectures.
- */
-#ifndef FUNCTION_TARGET_SSE42
-#define FUNCTION_TARGET_SSE42
+#ifndef TARGET_X86_SSE42
+#define TARGET_X86_SSE42
 #endif
-#ifndef FUNCTION_TARGET_SSR41
-#define FUNCTION_TARGET_SSR41
+#ifndef TARGET_X86_SSR41
+#define TARGET_X86_SSR41
 #endif
-#ifndef FUNCTION_TARGET_SSSE3
-#define FUNCTION_TARGET_SSSE3
+#ifndef TARGET_X86_SSSE3
+#define TARGET_X86_SSSE3
 #endif
-#ifndef FUNCTION_TARGET_SSE3
-#define FUNCTION_TARGET_SSE3
+#ifndef TARGET_X86_SSE3
+#define TARGET_X86_SSE3
+#endif
+#ifndef TARGET_X86_AES
+#define TARGET_X86_AES
+#endif
+#ifndef TARGET_X86_SHA
+#define TARGET_X86_SHA
+#endif
+
+#ifndef TARGET_ARMV8_SHA1
+#define TARGET_ARMV8_SHA1
 #endif

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -254,7 +254,7 @@ static void TexDecoder_DecodeImpl_C4(u32* dst, const u8* src, int width, int hei
   }
 }
 
-FUNCTION_TARGET_SSSE3
+TARGET_X86_SSSE3
 static void TexDecoder_DecodeImpl_I4_SSSE3(u32* dst, const u8* src, int width, int height,
                                            TextureFormat texformat, const u8* tlut,
                                            TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
@@ -394,7 +394,7 @@ static void TexDecoder_DecodeImpl_I4(u32* dst, const u8* src, int width, int hei
   }
 }
 
-FUNCTION_TARGET_SSSE3
+TARGET_X86_SSSE3
 static void TexDecoder_DecodeImpl_I8_SSSE3(u32* dst, const u8* src, int width, int height,
                                            TextureFormat texformat, const u8* tlut,
                                            TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
@@ -579,7 +579,7 @@ static void TexDecoder_DecodeImpl_IA4(u32* dst, const u8* src, int width, int he
   }
 }
 
-FUNCTION_TARGET_SSSE3
+TARGET_X86_SSSE3
 static void TexDecoder_DecodeImpl_IA8_SSSE3(u32* dst, const u8* src, int width, int height,
                                             TextureFormat texformat, const u8* tlut,
                                             TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
@@ -774,7 +774,7 @@ static void TexDecoder_DecodeImpl_RGB565(u32* dst, const u8* src, int width, int
   }
 }
 
-FUNCTION_TARGET_SSSE3
+TARGET_X86_SSSE3
 static void TexDecoder_DecodeImpl_RGB5A3_SSSE3(u32* dst, const u8* src, int width, int height,
                                                TextureFormat texformat, const u8* tlut,
                                                TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
@@ -1001,7 +1001,7 @@ static void TexDecoder_DecodeImpl_RGB5A3(u32* dst, const u8* src, int width, int
   }
 }
 
-FUNCTION_TARGET_SSSE3
+TARGET_X86_SSSE3
 static void TexDecoder_DecodeImpl_RGBA8_SSSE3(u32* dst, const u8* src, int width, int height,
                                               TextureFormat texformat, const u8* tlut,
                                               TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)


### PR DESCRIPTION
Inverted the layering of preprocessor blocks in Intrinsics.h, since it is more compiler-specific than machine-specific.  Added ARMv8 machine targets macros to replace home-spun examples in AES.cpp and SHA1.cpp.  Renamed x86-64 machine target macros to reflect which machine they are for.