### PR TITLE
Enforce minimum supported versions of GCC and Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,9 @@ endif()
 
 # Enforce minimium compiler versions that support the c++20 features we use
 set (GCC_min_version 10)
-set (Clang_min_version 11)
-set (AppleClang_min_version 12.0.5)
-set (min_xcode_version "12.5.1") # corrosponding xcode version for AppleClang_min_version
+set (Clang_min_version 12)
+set (AppleClang_min_version 13.0.0)
+set (min_xcode_version "13.0") # corrosponding xcode version for AppleClang_min_version
 set (MSVC_min_version 14.32)
 set (min_vs_version "2022 17.2.3") # corrosponding Visual Studio version for MSVC_min_version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,31 @@ if (MSVC)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
+set(COMPILER ${CMAKE_CXX_COMPILER_ID})
+if (COMPILER STREQUAL "GNU")
+  set(COMPILER "GCC") # perfer printing GCC instead of GNU
+endif()
+
+# Enforce minimium compiler versions that support the c++20 features we use
+set (GCC_min_version 10)
+set (Clang_min_version 11)
+set (AppleClang_min_version 12.0.5)
+set (min_xcode_version "12.5.1") # corrosponding xcode version for AppleClang_min_version
+set (MSVC_min_version 14.32)
+set (min_vs_version "2022 17.2.3") # corrosponding Visual Studio version for MSVC_min_version
+
+message(STATUS "Using ${COMPILER} ${CMAKE_CXX_COMPILER_VERSION}")
+
+if ("-" STREQUAL "${${COMPILER}_min_version}-")
+  message(WARNING "Unknown compiler ${COMPILER}, assuming it is new enough")
+else()
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS  ${${COMPILER}_min_version})
+    message(FATAL_ERROR "Requires GCC ${GCC_min_version}, Clang ${Clang_min_version},"
+    " AppleClang ${AppleClang_min_version} (Xcode ${min_xcode_version}),"
+    " or MSVC ${MSVC_min_version} (Visual Studio ${min_vs_version}) or higher")
+  endif()
+endif()
+
 # Name of the Dolphin distributor. If you redistribute Dolphin builds (forks,
 # unofficial builds) please consider identifying your distribution with a
 # unique name here.
@@ -253,12 +278,6 @@ else()
   message(FATAL_ERROR "You're building on an unsupported platform: "
       "'${CMAKE_SYSTEM_PROCESSOR}' with ${CMAKE_SIZEOF_VOID_P}-byte pointers."
       " Enable generic build if you really want a JIT-less binary.")
-endif()
-
-
-# Enforce minimum GCC version
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-  message(FATAL_ERROR "Dolphin requires at least GCC 7.0 (found ${CMAKE_CXX_COMPILER_VERSION})")
 endif()
 
 if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/Contributing.md
+++ b/Contributing.md
@@ -173,7 +173,8 @@ Summary:
 - [Classes and Structs](#cpp-code-classes-and-structs)
 
 ## <a name="cpp-code-general"></a>General
-- The codebase currently uses C++17.
+- The codebase currently uses C++20, though not all compilers support all C++20 features.
+  - See CMakeLists.txt "Enforce minimium compiler versions" for the currently supported compilers.
 - Use the [nullptr](https://en.cppreference.com/w/cpp/language/nullptr) type over the macro `NULL`.
 - If a [range-based for loop](https://en.cppreference.com/w/cpp/language/range-for) can be used instead of container iterators, use it.
 - Obviously, try not to use `goto` unless you have a *really* good reason for it.

--- a/Readme.md
+++ b/Readme.md
@@ -53,10 +53,12 @@ The "Debug" solution configuration is significantly slower, more verbose and les
 
 ## Building for Linux and macOS
 
-Dolphin requires [CMake](https://cmake.org/) for systems other than Windows. Many libraries are
-bundled with Dolphin and used if they're not installed on your system. CMake
-will inform you if a bundled library is used or if you need to install any
-missing packages yourself. You may refer to the [wiki](https://github.com/dolphin-emu/dolphin/wiki/Building-for-Linux) for more information.
+Dolphin requires [CMake](https://cmake.org/) for systems other than Windows. 
+You need a recent version of GCC or Clang with decent c++20 support. CMake will
+inform you if your compiler is too old.
+Many libraries are bundled with Dolphin and used if they're not installed on 
+your system. CMake will inform you if a bundled library is used or if you need
+to install any missing packages yourself. You may refer to the [wiki](https://github.com/dolphin-emu/dolphin/wiki/Building-for-Linux) for more information.
 
 Make sure to pull submodules before building:
 ```sh


### PR DESCRIPTION
With the move to C++20, and various people wanting to clean up the codebase to use the fancy new features, many PRs have run into problems older versions of clang running on buildbots. 

It would be very helpful to actually define and enforce a minimum version of Clang/GCC so that it's clear what C++20 features contributors are allowed to use. Additionally... enforcing it in cmake gives users clear feedback about what's wrong before they even start, instead of random compile errors. 

We already have an explicit minimum required version of Visual Studio, so it's not too outrageous. And various implicit minimum requirements on other versions.

### Why not feature detection?

That doesn't really answer the question of "what C++20 features are we allowed to use", contributors would have to remember to add feature detection when using new C++20 features, and we would end up implicitly dropping support for versions of compilers without realising it. 

### What versions?

I've chosen Clang 11 as a minimum because that's the version in the latest stable release of FreeBSD. And we have a FreeBSD builder (which currently all the way back on Clang 6, released March 2018, so no wonder it's been unhappy about new C++20 syntax). It's also the minimum for (partial) support of `consteval`.

And GCC 10 seems to be roughly equivalent. Also the minimum for `consteval`. Both were released in 2020. 