### PR TITLE
DirectoryBlob: Fix partition size mixup for encrypted Wii discs.

### DIFF
--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -663,10 +663,14 @@ void DirectoryBlobReader::SetPartitions(std::vector<PartitionWithType>&& partiti
 
     SetPartitionHeader(&partitions[i].partition, partition_address);
 
-    const u64 data_size = partitions[i].partition.GetDataSize();
+    const u64 data_size =
+        Common::AlignUp(partitions[i].partition.GetDataSize(), VolumeWii::BLOCK_DATA_SIZE);
+    partitions[i].partition.SetDataSize(data_size);
+    const u64 encrypted_data_size =
+        (data_size / VolumeWii::BLOCK_DATA_SIZE) * VolumeWii::BLOCK_TOTAL_SIZE;
     const u64 partition_data_offset = partition_address + PARTITION_DATA_OFFSET;
     m_partitions.emplace(partition_data_offset, std::move(partitions[i].partition));
-    m_nonpartition_contents.Add(partition_data_offset, data_size,
+    m_nonpartition_contents.Add(partition_data_offset, encrypted_data_size,
                                 ContentPartition{this, 0, partition_data_offset});
     const u64 unaligned_next_partition_address = VolumeWii::OffsetInHashedPartitionToRawOffset(
         data_size, Partition(partition_address), PARTITION_DATA_OFFSET);

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -204,6 +204,7 @@ public:
 
   bool IsWii() const { return m_is_wii; }
   u64 GetDataSize() const { return m_data_size; }
+  void SetDataSize(u64 size) { m_data_size = size; }
   const std::string& GetRootDirectory() const { return m_root_directory; }
   const std::vector<u8>& GetHeader() const { return m_disc_header; }
   const DiscContentContainer& GetContents() const { return m_contents; }


### PR DESCRIPTION
I found this while trying to debug https://bugs.dolphin-emu.org/issues/12965, though this does not actually fix that issue.

What's happening here is that the `ContentPartition` chunks inside DirectoryBlob are designed to look from the outside as if they are encrypted/hashed, but present their filesize without the headers such a partition would actually have. This confuses non-`ReadWiiDecrypted()` reads near the end of the partition, because the offset with headers gets compared against the size without headers so the read is considered out of bounds and returns a failure.

~~I also round the size up to a full group because otherwise this read in `VolumeWii::EncryptGroup()` fails on the last not-full-group-sized chunk of the partition:~~
https://github.com/dolphin-emu/dolphin/blob/dcdba11ded671acff679b9183e0c3e1e52502a0f/Source/Core/DiscIO/VolumeWii.cpp#L595-L599
~~I'm not sure if on a real Wii disc a partition is always full group sized; this could be solved in other ways too if needed.~~ Just rounding to block size seems to work fine actually.

This shouldn't affect much in practice (I assume RawDump would produce incorrect results without this PR), but probably doesn't hurt to fix anyway. I've tested this by forcing `DirectoryBlobReader::SupportsReadWiiDecrypted()` to always return false and then checking if Properties -> Filesystem -> Extract Entire Disc on a DirectoryBlob survives a roundtrip; without this PR, files near the end of the disc end up corrupt, while with this PR it works fine (minus `boot.bin` and `fst.bin` which are affected by the difference in how we build the file system compared to whatever tool was used for official discs).

@JosJuice Please review.