### PR TITLE
Workaround FreeBSD/clang/fmt bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,12 @@ if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD|NetBSD")
   set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};/usr/local")
   set(CMAKE_REQUIRED_INCLUDES "/usr/local/include")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/local/lib")
+
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0)
+    # Workaround: the llvm libc++ and versions of clang eariler than 14 have a bug with consteval
+    # so we define FMT_CONSTEVAL to blank to just disable consteval in fmt
+    add_definitions(-DFMT_CONSTEVAL=)
+  endif()
 endif()
 
 # Dolphin requires threads.


### PR DESCRIPTION
```
/usr/home/buildbot/freebsd/pr-freebsd-x64/build/Source/UnitTests/Common/BitFieldTest.cpp:234:27: error: call to consteval function 'fmt::basic_format_string<char, BitField<0, 64, unsigned long, unsigned long> &>::basic_format_string<char [7], 0>' is not a constant expression
    EXPECT_EQ(fmt::format("{:02x}", object.full_u64),
                          ^
/usr/home/buildbot/freebsd/pr-freebsd-x64/build/Source/UnitTests/Common/BitFieldTest.cpp:234:27: note: undefined constructor 'basic_format_string<char [7], 0>' cannot be used in a constant expression
/usr/home/buildbot/freebsd/pr-freebsd-x64/build/Externals/fmt/include/fmt/core.h:3115:28: note: declared here
  FMT_CONSTEVAL FMT_INLINE basic_format_string(const S& s) : str_(s) {
                           ^
/usr/home/buildbot/freebsd/pr-freebsd-x64/build/Source/UnitTests/Common/BitFieldTest.cpp:236:27: error: call to consteval function 'fmt::basic_format_string<char, BitField<0, 64, long, long> &>::basic_format_string<char [7], 0>' is not a constant expression
    EXPECT_EQ(fmt::format("{:02x}", object.full_s64),
```

This appears to be a re-appearance of https://github.com/fmtlib/fmt/issues/2455.

Except instead of being on AppleClang and MacOS, it's now on regular Clang and FreeBSD. Probably because the bug needs both clang13 and (some version of) llvm's libc++.

Our experiments showed that updating to Clang14 from ports appeared to fix it, but we would prefer to work with the stock freebsd 13.1. So, I've added a workaround to disable consteval on BSD with clang 13. 

This is the same workaround that libfmt are already doing, except [they detect AppleClang](https://github.com/fmtlib/fmt/commit/807ee5ec3152429f7103e825609f084c03a38ff4)