### PR TITLE
Android: Prevent app lockup when revoking write access

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -26,7 +26,9 @@ import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner;
 import org.dolphinemu.dolphinemu.utils.BooleanSupplier;
 import org.dolphinemu.dolphinemu.utils.CompletableFuture;
 import org.dolphinemu.dolphinemu.utils.ContentHandler;
+import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
+import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
 import org.dolphinemu.dolphinemu.utils.ThreadUtil;
 import org.dolphinemu.dolphinemu.utils.WiiUtils;
 
@@ -56,6 +58,10 @@ public final class MainPresenter
 
   public void onCreate()
   {
+    // Ask the user to grant write permission if relevant and not already granted
+    if (DirectoryInitialization.isWaitingForWriteAccess(mActivity))
+      PermissionsHandler.requestWritePermission(mActivity);
+
     String versionName = BuildConfig.VERSION_NAME;
     mView.setVersionString(versionName);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -26,10 +26,6 @@ public final class StartupHandler
 
   public static void HandleInit(FragmentActivity parent)
   {
-    // Ask the user to grant write permission if relevant and not already granted
-    if (DirectoryInitialization.isWaitingForWriteAccess(parent))
-      PermissionsHandler.requestWritePermission(parent);
-
     // Ask the user if he wants to enable analytics if we haven't yet.
     Analytics.checkAnalyticsInit(parent);
 


### PR DESCRIPTION
Previously if write access was given, revoked, and the user returned to the app, the UI will lock up and not load completely. Now the user is prompted for write access after revoking and the UI will load correctly now.