### PR TITLE
Android: Improve documentation on command-line build

### DIFF
--- a/AndroidSetup.md
+++ b/AndroidSetup.md
@@ -31,7 +31,7 @@ Double clicking any of these tasks will execute it, and also add it to a short l
 
 Clicking the green triangle next to this list will execute the currently selected task.
 
-For command-line users, any task may be executed with `Source/Android/gradlew <task-name>`.
+For command-line users, any task may be executed with `cd Source/Android` followed by `gradlew <task-name>`. In particular, `gradlew assemble` builds debug and release versions of the application (which are placed in `Source/Android/app/build/outputs/apk`).
 
 ## Getting Dependencies
 


### PR DESCRIPTION
The old instructions would result in this:

```
C:\Users\Pokechu22\source\repos\dolphin>Source\Android\gradlew assemble
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.4.2/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build

FAILURE: Build failed with an exception.

* What went wrong:
Directory 'C:\Users\Pokechu22\source\repos\dolphin' does not contain a Gradle build.

A Gradle build should contain a 'settings.gradle' or 'settings.gradle.kts' file in its root directory. It may also contain a 'build.gradle' or 'build.gradle.kts' file.

To create a new Gradle build in this directory run 'gradlew init'

For more detail on the 'init' task see https://docs.gradle.org/7.4.2/userguide/build_init_plugin.html

For more detail on creating a Gradle build see https://docs.gradle.org/7.4.2/userguide/tutorial_using_tasks.html

* Try:
> Run gradlew init to create a new Gradle build in this directory.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
```

because `gradlew` executes in the current directory, which doesn't contain `build.gradle`. See also [buildbot configuration](https://github.com/dolphin-emu/sadm/blob/bc1e9a7a7da699fc6d7d37e42c20088ba3c03f62/buildbot/master.cfg#L548-L572).

Note that I didn't specify the exact filenames, partly because it's dependent on whether you want to use the debug build (`assembleDebug`) or the release build (`assembleRelease`), both of which are run by `assemble`. Also, for me, I get `Source/Android/app/build/outputs/apk/debug/app-debug.apk` and `Source/Android/app/build/outputs/apk/release/app-release-unsigned.apk`, but the buildbot gets `app-release.apk` (presumably because I don't have any keys set up, see #10938).