### PR TITLE
InputCommon:QuartzKB&M: Use KVO to watch window position

### DIFF
--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -124,6 +124,9 @@ elseif(APPLE)
     ${FORCEFEEDBACK_LIBRARY}
     ${IOK_LIBRARY}
   )
+  target_compile_options(inputcommon PRIVATE
+    -fobjc-arc
+  )
 elseif(X11_FOUND)
   target_sources(inputcommon PRIVATE
     ControllerInterface/Xlib/XInput2.cpp

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
@@ -8,6 +8,12 @@
 #include "Common/Matrix.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
+#ifdef __OBJC__
+@class DolWindowPositionObserver;
+#else
+class DolWindowPositionObserver;
+#endif
+
 namespace ciface::Quartz
 {
 std::string KeycodeToName(const CGKeyCode keycode);
@@ -59,13 +65,16 @@ public:
   void UpdateInput() override;
 
   explicit KeyboardAndMouse(void* view);
+  ~KeyboardAndMouse() override;
 
   std::string GetName() const override;
   std::string GetSource() const override;
 
 private:
+  void MainThreadInitialization(void* view);
+
   Common::Vec2 m_cursor;
 
-  uint32_t m_windowid;
+  DolWindowPositionObserver* m_window_pos_observer;
 };
 }  // namespace ciface::Quartz

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -23,6 +23,7 @@
 
 @implementation DolWindowPositionObserver
 {
+  NSView* _view;
   NSWindow* _window;
   NSRect _frame;
   std::mutex _mtx;
@@ -30,7 +31,7 @@
 
 - (NSRect)calcFrame
 {
-  return [_window frame];
+  return [_window convertRectToScreen:[_view frame]];
 }
 
 - (instancetype)initWithView:(NSView*)view
@@ -38,6 +39,7 @@
   self = [super init];
   if (self)
   {
+    _view = view;
     _window = [view window];
     _frame = [self calcFrame];
     [_window addObserver:self forKeyPath:@"frame" options:0 context:nil];

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -4,6 +4,7 @@
 #include "InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h"
 
 #include <map>
+#include <mutex>
 
 #include <Carbon/Carbon.h>
 #include <Cocoa/Cocoa.h>
@@ -11,6 +12,64 @@
 #include "Core/Host.h"
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
+
+/// Helper class to get window position data from threads other than the main thread
+@interface DolWindowPositionObserver : NSObject
+
+- (instancetype)initWithView:(NSView*)view;
+@property(readonly) NSRect frame;
+
+@end
+
+@implementation DolWindowPositionObserver
+{
+  NSWindow* _window;
+  NSRect _frame;
+  std::mutex _mtx;
+}
+
+- (NSRect)calcFrame
+{
+  return [_window frame];
+}
+
+- (instancetype)initWithView:(NSView*)view
+{
+  self = [super init];
+  if (self)
+  {
+    _window = [view window];
+    _frame = [self calcFrame];
+    [_window addObserver:self forKeyPath:@"frame" options:0 context:nil];
+  }
+  return self;
+}
+
+- (NSRect)frame
+{
+  std::lock_guard<std::mutex> guard(_mtx);
+  return _frame;
+}
+
+- (void)observeValueForKeyPath:(NSString*)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey, id>*)change
+                       context:(void*)context
+{
+  if (object == _window)
+  {
+    NSRect new_frame = [self calcFrame];
+    std::lock_guard<std::mutex> guard(_mtx);
+    _frame = new_frame;
+  }
+}
+
+- (void)dealloc
+{
+  [_window removeObserver:self forKeyPath:@"frame"];
+}
+
+@end
 
 namespace ciface::Quartz
 {
@@ -149,20 +208,12 @@ KeyboardAndMouse::KeyboardAndMouse(void* view)
   AddCombinedInput("Shift", {"Left Shift", "Right Shift"});
   AddCombinedInput("Ctrl", {"Left Control", "Right Control"});
 
-  NSView* cocoa_view = (__bridge NSView*)view;
-
   // PopulateDevices may be called on the Emuthread, so we need to ensure that
   // these UI APIs are only ever called on the main thread.
   if ([NSThread isMainThread])
-  {
-    m_windowid = [[cocoa_view window] windowNumber];
-  }
+    MainThreadInitialization(view);
   else
-  {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      m_windowid = [[cocoa_view window] windowNumber];
-    });
-  }
+    dispatch_sync(dispatch_get_main_queue(), [this, view] { MainThreadInitialization(view); });
 
   // cursor, with a hax for-loop
   for (unsigned int i = 0; i < 4; ++i)
@@ -173,26 +224,19 @@ KeyboardAndMouse::KeyboardAndMouse(void* view)
   AddInput(new Button(kCGMouseButtonCenter));
 }
 
+// Very important that this is here
+// C++ and ObjC++ have different views of the header, and only ObjC++'s will deallocate properly
+KeyboardAndMouse::~KeyboardAndMouse() = default;
+
+void KeyboardAndMouse::MainThreadInitialization(void* view)
+{
+  NSView* cocoa_view = (__bridge NSView*)view;
+  m_window_pos_observer = [[DolWindowPositionObserver alloc] initWithView:cocoa_view];
+}
+
 void KeyboardAndMouse::UpdateInput()
 {
-  CGRect bounds = CGRectZero;
-  CGWindowID windowid[1] = {m_windowid};
-  CFArrayRef windowArray = CFArrayCreate(nullptr, (const void**)windowid, 1, nullptr);
-  CFArrayRef windowDescriptions = CGWindowListCreateDescriptionFromArray(windowArray);
-  CFDictionaryRef windowDescription =
-      static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(windowDescriptions, 0));
-
-  if (CFDictionaryContainsKey(windowDescription, kCGWindowBounds))
-  {
-    CFDictionaryRef boundsDictionary =
-        static_cast<CFDictionaryRef>(CFDictionaryGetValue(windowDescription, kCGWindowBounds));
-
-    if (boundsDictionary != nullptr)
-      CGRectMakeWithDictionaryRepresentation(boundsDictionary, &bounds);
-  }
-
-  CFRelease(windowDescriptions);
-  CFRelease(windowArray);
+  NSRect bounds = [m_window_pos_observer frame];
 
   const double window_width = std::max(bounds.size.width, 1.0);
   const double window_height = std::max(bounds.size.height, 1.0);

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -149,7 +149,7 @@ KeyboardAndMouse::KeyboardAndMouse(void* view)
   AddCombinedInput("Shift", {"Left Shift", "Right Shift"});
   AddCombinedInput("Ctrl", {"Left Control", "Right Control"});
 
-  NSView* cocoa_view = reinterpret_cast<NSView*>(view);
+  NSView* cocoa_view = (__bridge NSView*)view;
 
   // PopulateDevices may be called on the Emuthread, so we need to ensure that
   // these UI APIs are only ever called on the main thread.


### PR DESCRIPTION
`CGWindowListCreateDescriptionFromArray` would send a request to WindowServer and block until it got a response.  This had two issues:
1. The call took ~200µs on average.  Dolphin's main emulation thread seems to call UpdateInput() about 5 times per frame during Wii emulation, wasting 1ms per frame
2. Since you're now waiting for WindowServer to get back to you, what if it just happens to be busy when you made your request?  About 5% of calls take >1ms, some upwards of 2ms.

Changes QuartzKeyboardAndMouse to use a KVO observer on the window to update a position variable under a mutex.

Also modifies QuartzKeyboardAndMouse to calculate mouse coordinates relative to the main view, rather than the entire window (which includes the window's titlebar).