### PR TITLE
Improve FPS Counter to use Euler Average

### DIFF
--- a/Source/Core/VideoCommon/FPSCounter.h
+++ b/Source/Core/VideoCommon/FPSCounter.h
@@ -20,20 +20,20 @@ public:
   // Called when a frame is rendered (updated every second).
   void Update();
 
-  float GetFPS() const { return m_fps; }
-  double GetDeltaTime() const { return m_time_diff_secs; }
+  double GetFPS() const { return m_avg_fps; }
+  double GetDeltaTime() const { return m_raw_dt; }
 
 private:
+  void LogRenderTimeToFile(u64 val);
   void SetPaused(bool paused);
 
-  u64 m_last_time = 0;
-  u64 m_time_since_update = 0;
-  u64 m_last_time_pause = 0;
-  u32 m_frame_counter = 0;
-  int m_on_state_changed_handle = -1;
-  float m_fps = 0.f;
   std::ofstream m_bench_file;
-  double m_time_diff_secs = 0.0;
 
-  void LogRenderTimeToFile(u64 val);
+  s64 m_last_time = 0;
+
+  double m_avg_fps = 0.0;
+  double m_raw_dt = 0.0;
+
+  int m_on_state_changed_handle = -1;
+  s64 m_last_time_pause = 0;
 };

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -595,7 +595,7 @@ void Renderer::DrawDebugText()
     ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - (10.0f * m_backbuffer_scale),
                                    10.0f * m_backbuffer_scale),
                             ImGuiCond_Always, ImVec2(1.0f, 0.0f));
-    ImGui::SetNextWindowSize(ImVec2(100.0f * m_backbuffer_scale, 30.0f * m_backbuffer_scale));
+    ImGui::SetNextWindowSize(ImVec2(75.0f * m_backbuffer_scale, 30.0f * m_backbuffer_scale));
 
     if (ImGui::Begin("FPS", nullptr,
                      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
@@ -603,7 +603,8 @@ void Renderer::DrawDebugText()
                          ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |
                          ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing))
     {
-      ImGui::TextColored(ImVec4(0.0f, 1.0f, 1.0f, 1.0f), "FPS: %.2f", m_fps_counter.GetFPS());
+      const double fps = m_fps_counter.GetFPS();
+      ImGui::TextColored(ImVec4(0.0, 1.0, 1.0, 1.0f), "FPS: %.0lf", std::round(fps));
     }
     ImGui::End();
   }


### PR DESCRIPTION
Replace the previous method of calculating FPS (count number of frames every 0.25 seconds and average them) and replace it with a much more accurate method (a real time Euler Average with an RC of 1.0).

This Euler Average, also known as exponential moving average, is a really good moving average that only requires knowing the time between samples (which is easy because this is an FPS counter) and the previous value. This allows us to get a much nicer FPS counter that not only updates faster, but reports more accurate values. 

<img width="95" alt="image" src="https://user-images.githubusercontent.com/28713194/184892470-64c8b0f6-d1f5-4acc-bc52-b1b17ba06211.png">

I know it looks like the FPS counter shows less information now, but because it updates faster, it actually shows more because it will let you know EXACTLY when there is a dip in performance.  It is also very stable, so it does not flicker very much.

You can adjust how quickly this counter updates by changing `FPS_COUNTER_RC`. The higher this is, the slower it updates, but the less flickering there will be. `0.8` is a good balance between telling you when there are dips in performance and having a not very distracting FPS counter.
