### PR TITLE
BBA/BuiltIn: Add UPnP HTTP listener

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
@@ -5,6 +5,7 @@
 
 #ifdef _WIN32
 #include <WinSock2.h>
+using socklen_t = int;
 #else
 #include <netinet/in.h>
 #endif
@@ -45,6 +46,8 @@ public:
   BbaTcpSocket();
 
   sf::Socket::Status Connect(const sf::IpAddress& dest, u16 port, u32 net_ip);
+  sf::Socket::Status GetPeerName(sockaddr_in* addr) const;
+  sf::Socket::Status GetSockName(sockaddr_in* addr) const;
 };
 
 class BbaUdpSocket : public sf::UdpSocket

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -449,6 +449,7 @@ private:
     u32 m_router_ip = 0;
     Common::MACAddress m_router_mac{};
     std::map<u32, Common::MACAddress> m_arp_table;
+    sf::TcpListener m_upnp_httpd;
 #if defined(WIN32) || defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) ||          \
     defined(__OpenBSD__) || defined(__NetBSD__) || defined(__HAIKU__)
     std::array<StackRef, 10> network_ref{};  // max 10 at same time, i think most gc game had a
@@ -468,6 +469,7 @@ private:
     void HandleTCPFrame(const Common::TCPPacket& packet);
     void InitUDPPort(u16 port);
     void HandleUDPFrame(const Common::UDPPacket& packet);
+    void HandleUPnPClient();
     const Common::MACAddress& ResolveAddress(u32 inet_ip);
   };
 


### PR DESCRIPTION
This PR implements the UPnP HTTP listener used by Kirby Air Ride and Mario Kart Double Dash. If someone on the same network of these GC games visits the URL `http://<GameCube_IP>:1900/rootDesc.xml`, they can grab the UPnP XML file. I confirmed this behaviour using Nintendont on a real Wii (since I don't have a BBA adapter). **This URL can only be accessed from another IP (i.e. an IP other than the one used by Dolphin).**

@schthack @nolrinale 
This might also address this issue https://dolp.in/i12996 as this PR fixes an issue where partial data isn't sent when closing the connection. I touched the TCP emulation part so you might want to test this out to make sure it doesn't impact PSO servers.

This PR doesn't fix MKDD timer stuck at 172 when there are more than 2 players. Depends on https://github.com/dolphin-emu/dolphin/pull/10920.