### PR TITLE
lint: Don't check for WSL2 host path on non-Linux OSes

### DIFF
--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -7,8 +7,10 @@ set -euo pipefail
 # use Windows' git when working under path mounted from host on wsl2
 # inspired by https://markentier.tech/posts/2020/10/faster-git-under-wsl2/#solution
 GIT=git
-if [ "$(stat --file-system --format=%T `pwd -P`)" == "v9fs" ]; then
-  GIT=git.exe
+if [ "$(uname -s)" == "Linux" ]; then
+  if [ "$(stat --file-system --format=%T `pwd -P`)" == "v9fs" ]; then
+    GIT=git.exe
+  fi
 fi
 
 if ! [ -x "$(command -v $GIT)" ]; then


### PR DESCRIPTION
The parameters used for the `stat` command are only valid when using GNU coreutils. On OSes that use BSD tools (for example, macOS), the command will fail and the script will exit.