### PR TITLE
WinUpdater: Fix Updater permissions check

### DIFF
--- a/Source/Core/MacUpdater/AppDelegate.mm
+++ b/Source/Core/MacUpdater/AppDelegate.mm
@@ -27,9 +27,16 @@
         args.push_back(std::string([obj UTF8String]));
       }];
 
+  std::optional<Options> maybe_opts = ParseCommandLine(args);
+  if (!maybe_opts)
+  {
+    return;
+  }
+  const Options options = std::move(*maybe_opts);
+
   dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul);
   dispatch_async(queue, ^{
-    RunUpdater(args);
+    RunUpdater(options);
     [NSApp performSelector:@selector(terminate:) withObject:nil afterDelay:0.0];
   });
 }

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -49,6 +49,11 @@ static constexpr char UPDATER_COPY_FILENAME[] = ".Dolphin Updater.2.app";
 #ifdef OS_SUPPORTS_UPDATER
 static constexpr char UPDATER_LOG_FILENAME[] = "Updater.log";
 
+std::string GetUpdaterPath()
+{
+  return File::GetExeDirectory() + DIR_SEP_CHR + UPDATER_FILENAME;
+}
+
 std::string GetUpdaterCopyPath()
 {
   return File::GetExeDirectory() + DIR_SEP_CHR + UPDATER_COPY_FILENAME;
@@ -237,7 +242,7 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
     updater_flags["binary-to-restart"] = File::GetExePath();
 
   // Copy the updater so it can update itself if needed.
-  const std::string updater_path = File::GetExeDirectory() + DIR_SEP + UPDATER_FILENAME;
+  const std::string updater_path = GetUpdaterPath();
   const std::string updater_copy_path = GetUpdaterCopyPath();
 
 #ifdef __APPLE__

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -247,7 +247,9 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
   if (restart_mode == RestartMode::RESTART_AFTER_UPDATE)
     updater_flags["binary-to-restart"] = File::GetExePath();
 
-  // Copy the updater so it can update itself if needed.
+  // The updater may need to update itself, but an application can't modify its own exe. To handle
+  // this create a copy of the updater and run the update process from the copy. Dolphin deletes the
+  // updater copy (if it exists) on startup.
   const std::string updater_path = GetUpdaterPath();
   const std::string updater_copy_path = GetUpdaterCopyPath();
 

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -49,13 +49,17 @@ static constexpr char UPDATER_COPY_FILENAME[] = ".Dolphin Updater.2.app";
 #ifdef OS_SUPPORTS_UPDATER
 static constexpr char UPDATER_LOG_FILENAME[] = "Updater.log";
 
+std::string GetUpdaterCopyPath()
+{
+  return File::GetExeDirectory() + DIR_SEP_CHR + UPDATER_COPY_FILENAME;
+}
+
 std::string MakeUpdaterCommandLine(const std::map<std::string, std::string>& flags)
 {
 #ifdef __APPLE__
-  std::string cmdline = "\"" + File::GetExeDirectory() + DIR_SEP + UPDATER_COPY_FILENAME +
-                        "/Contents/MacOS/Dolphin Updater\"";
+  std::string cmdline = "\"" + GetUpdaterCopyPath() + "/Contents/MacOS/Dolphin Updater\"";
 #else
-  std::string cmdline = File::GetExeDirectory() + DIR_SEP + UPDATER_COPY_FILENAME;
+  std::string cmdline = GetUpdaterCopyPath();
 #endif
 
   cmdline += " ";
@@ -73,12 +77,10 @@ std::string MakeUpdaterCommandLine(const std::map<std::string, std::string>& fla
 // Used to remove the relocated updater file once we don't need it anymore.
 void CleanupFromPreviousUpdate()
 {
-  std::string updater_copy_path = File::GetExeDirectory() + DIR_SEP + UPDATER_COPY_FILENAME;
-
 #ifdef __APPLE__
-  File::DeleteDirRecursively(updater_copy_path);
+  File::DeleteDirRecursively(GetUpdaterCopyPath());
 #else
-  File::Delete(updater_copy_path);
+  File::Delete(GetUpdaterCopyPath(), File::IfAbsentBehavior::NoConsoleWarning);
 #endif
 }
 #endif
@@ -235,8 +237,8 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
     updater_flags["binary-to-restart"] = File::GetExePath();
 
   // Copy the updater so it can update itself if needed.
-  std::string updater_path = File::GetExeDirectory() + DIR_SEP + UPDATER_FILENAME;
-  std::string updater_copy_path = File::GetExeDirectory() + DIR_SEP + UPDATER_COPY_FILENAME;
+  const std::string updater_path = File::GetExeDirectory() + DIR_SEP + UPDATER_FILENAME;
+  const std::string updater_copy_path = GetUpdaterCopyPath();
 
 #ifdef __APPLE__
   File::CopyDir(updater_path, updater_copy_path);

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -36,18 +36,18 @@ namespace
 bool s_update_triggered = false;
 #ifdef _WIN32
 
-const char UPDATER_FILENAME[] = "Updater.exe";
-const char UPDATER_RELOC_FILENAME[] = "Updater.2.exe";
+static constexpr char UPDATER_FILENAME[] = "Updater.exe";
+static constexpr char UPDATER_RELOC_FILENAME[] = "Updater.2.exe";
 
 #elif defined(__APPLE__)
 
-const char UPDATER_FILENAME[] = "Dolphin Updater.app";
-const char UPDATER_RELOC_FILENAME[] = ".Dolphin Updater.2.app";
+static constexpr char UPDATER_FILENAME[] = "Dolphin Updater.app";
+static constexpr char UPDATER_RELOC_FILENAME[] = ".Dolphin Updater.2.app";
 
 #endif
 
 #ifdef OS_SUPPORTS_UPDATER
-const char UPDATER_LOG_FILE[] = "Updater.log";
+static constexpr char UPDATER_LOG_FILE[] = "Updater.log";
 
 std::string MakeUpdaterCommandLine(const std::map<std::string, std::string>& flags)
 {

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -59,6 +59,11 @@ std::string GetUpdaterCopyPath()
   return File::GetExeDirectory() + DIR_SEP_CHR + UPDATER_COPY_FILENAME;
 }
 
+std::string GetUpdaterLogPath()
+{
+  return File::GetUserPath(D_LOGS_IDX) + UPDATER_LOG_FILENAME;
+}
+
 std::string MakeUpdaterCommandLine(const std::map<std::string, std::string>& flags)
 {
 #ifdef __APPLE__
@@ -236,7 +241,7 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
   updater_flags["parent-pid"] = std::to_string(getpid());
 #endif
   updater_flags["install-base-path"] = File::GetExeDirectory();
-  updater_flags["log-file"] = File::GetUserPath(D_LOGS_IDX) + UPDATER_LOG_FILENAME;
+  updater_flags["log-file"] = GetUpdaterLogPath();
 
   if (restart_mode == RestartMode::RESTART_AFTER_UPDATE)
     updater_flags["binary-to-restart"] = File::GetExePath();

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -37,12 +37,14 @@ bool s_update_triggered = false;
 #ifdef _WIN32
 
 static constexpr char UPDATER_FILENAME[] = "Updater.exe";
-static constexpr char UPDATER_COPY_FILENAME[] = "Updater.2.exe";
+static constexpr char UPDATER_COPY_FILENAME[] = "DolphinUpdater.exe";
+static constexpr char UPDATER_COPY_LEGACY_FILENAME[] = "Updater.2.exe";
 
 #elif defined(__APPLE__)
 
 static constexpr char UPDATER_FILENAME[] = "Dolphin Updater.app";
-static constexpr char UPDATER_COPY_FILENAME[] = ".Dolphin Updater.2.app";
+static constexpr char UPDATER_COPY_FILENAME[] = "Dolphin Updater.app";
+static constexpr char UPDATER_COPY_LEGACY_FILENAME[] = ".Dolphin Updater.2.app";
 static constexpr char UPDATER_BUNDLE_EXE_SUBPATH[] = "/Contents/MacOS/Dolphin Updater";
 
 #endif
@@ -57,7 +59,12 @@ std::string GetUpdaterPath()
 
 std::string GetUpdaterCopyPath()
 {
-  return File::GetExeDirectory() + DIR_SEP_CHR + UPDATER_COPY_FILENAME;
+  return File::GetUserPath(D_USER_IDX) + UPDATER_COPY_FILENAME;
+}
+
+std::string GetUpdaterCopyLegacyPath()
+{
+  return File::GetExeDirectory() + DIR_SEP_CHR + UPDATER_COPY_LEGACY_FILENAME;
 }
 
 std::string GetUpdaterLogPath()
@@ -90,8 +97,10 @@ void CleanupFromPreviousUpdate()
 {
 #ifdef __APPLE__
   File::DeleteDirRecursively(GetUpdaterCopyPath());
+  File::DeleteDirRecursively(GetUpdaterCopyLegacyPath());
 #else
   File::Delete(GetUpdaterCopyPath(), File::IfAbsentBehavior::NoConsoleWarning);
+  File::Delete(GetUpdaterCopyLegacyPath(), File::IfAbsentBehavior::NoConsoleWarning);
 #endif
 }
 #endif

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -43,6 +43,7 @@ static constexpr char UPDATER_COPY_FILENAME[] = "Updater.2.exe";
 
 static constexpr char UPDATER_FILENAME[] = "Dolphin Updater.app";
 static constexpr char UPDATER_COPY_FILENAME[] = ".Dolphin Updater.2.app";
+static constexpr char UPDATER_BUNDLE_EXE_SUBPATH[] = "/Contents/MacOS/Dolphin Updater";
 
 #endif
 
@@ -67,7 +68,7 @@ std::string GetUpdaterLogPath()
 std::string MakeUpdaterCommandLine(const std::map<std::string, std::string>& flags)
 {
 #ifdef __APPLE__
-  std::string cmdline = "\"" + GetUpdaterCopyPath() + "/Contents/MacOS/Dolphin Updater\"";
+  std::string cmdline = "\"" + GetUpdaterCopyPath() + UPDATER_BUNDLE_EXE_SUBPATH + "\"";
 #else
   std::string cmdline = GetUpdaterCopyPath();
 #endif
@@ -252,7 +253,7 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
 
 #ifdef __APPLE__
   File::CopyDir(updater_path, updater_copy_path);
-  chmod((updater_copy_path + "/Contents/MacOS/Dolphin Updater").c_str(), 0700);
+  chmod((updater_copy_path + UPDATER_BUNDLE_EXE_SUBPATH).c_str(), 0700);
 #else
   File::Copy(updater_path, updater_copy_path);
 #endif

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -584,19 +584,9 @@ std::optional<Manifest> FetchAndParseManifest(const std::string& url)
 
   return ParseManifest(decompressed);
 }
+};  // namespace
 
-struct Options
-{
-  std::string this_manifest_url;
-  std::string next_manifest_url;
-  std::string content_store_url;
-  std::string install_base_path;
-  std::optional<std::string> binary_to_restart;
-  std::optional<u32> parent_pid;
-  std::optional<std::string> log_file;
-};
-
-std::optional<Options> ParseCommandLine(std::vector<std::string>& args)
+std::optional<Options> ParseCommandLine(const std::vector<std::string>& args)
 {
   using optparse::OptionParser;
 
@@ -664,22 +654,13 @@ std::optional<Options> ParseCommandLine(std::vector<std::string>& args)
 
   return opts;
 }
-};  // namespace
 
-bool RunUpdater(std::vector<std::string> args)
+bool RunUpdater(const Options& opts)
 {
-  std::optional<Options> maybe_opts = ParseCommandLine(args);
-
-  if (!maybe_opts)
-  {
-    return false;
-  }
-
   UI::Init();
   UI::SetVisible(false);
 
   Common::ScopeGuard ui_guard{[] { UI::Stop(); }};
-  Options opts = std::move(*maybe_opts);
 
   if (opts.log_file)
   {

--- a/Source/Core/UpdaterCommon/UpdaterCommon.h
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.h
@@ -14,4 +14,16 @@
 
 // Refer to docs/autoupdate_overview.md for a detailed overview of the autoupdate process
 
-bool RunUpdater(std::vector<std::string> args);
+struct Options
+{
+  std::string this_manifest_url;
+  std::string next_manifest_url;
+  std::string content_store_url;
+  std::string install_base_path;
+  std::optional<std::string> binary_to_restart;
+  std::optional<u32> parent_pid;
+  std::optional<std::string> log_file;
+};
+
+bool RunUpdater(const Options& options);
+std::optional<Options> ParseCommandLine(const std::vector<std::string>& args);

--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -10,6 +10,8 @@
 #include <vector>
 
 #include "Common/CommonFuncs.h"
+#include "Common/CommonPaths.h"
+#include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
 #include "UpdaterCommon/UI.h"
@@ -28,22 +30,19 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     return 1;
   }
 
-  // Test for write permissions
-  bool need_admin = false;
   std::vector<std::string> args = CommandLineToUtf8Argv(pCmdLine);
   std::optional<Options> maybe_opts = ParseCommandLine(args);
 
-  FILE* test_fh = fopen("Updater.log", "w");
   if (!maybe_opts)
   {
     return false;
   }
   const Options options = std::move(*maybe_opts);
 
-  if (test_fh == nullptr)
-    need_admin = true;
-  else
-    fclose(test_fh);
+  const std::string test_file_path = options.install_base_path + DIR_SEP_CHR + "test.tmp";
+  const bool file_creation_failed = !File::CreateEmptyFile(test_file_path);
+  const bool file_deletion_failed = !File::Delete(test_file_path);
+  const bool need_admin = file_creation_failed || file_deletion_failed;
 
   if (need_admin)
   {

--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -30,8 +30,15 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
 
   // Test for write permissions
   bool need_admin = false;
+  std::vector<std::string> args = CommandLineToUtf8Argv(pCmdLine);
+  std::optional<Options> maybe_opts = ParseCommandLine(args);
 
   FILE* test_fh = fopen("Updater.log", "w");
+  if (!maybe_opts)
+  {
+    return false;
+  }
+  const Options options = std::move(*maybe_opts);
 
   if (test_fh == nullptr)
     need_admin = true;
@@ -59,7 +66,5 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     return 0;
   }
 
-  std::vector<std::string> args = CommandLineToUtf8Argv(pCmdLine);
-
-  return RunUpdater(args) ? 0 : 1;
+  return RunUpdater(options) ? 0 : 1;
 }


### PR DESCRIPTION
[Draft because it's not quite ready, but I want to get feedback on the basic idea. In particular, I haven't tested it on macOS yet]

Copy the Updater to the User directory instead of the Exe directory. This allows the Updater to run when the user doesn't have write access to the Exe directory; the User directory needs to be writable in order for Dolphin to function, so if it isn't we have bigger problems.

Background: A process can't overwrite its own executable which is why we have a separate Updater. In order to update both Dolphin and the Updater, the update process is run from a copy of the Updater instead of the original. Until now this copy has been created in the same folder as Dolphin.exe but this fails when the user doesn't have write access to the directory. A notable instance of this is when a Standard user account tries to update a copy of Dolphin located in Program Files.

The existing permissions check didn't work because it was run from the Updater process, while the error occurred before the process ever launched. Ironically this made it so the check happened if and only if it wasn't needed.

Fixes https://bugs.dolphin-emu.org/issues/12151

Some related changes:
- The copied updater is now named "Dolphin Updater.exe" (or .app) because an admin prompt for "Updater.2.exe" looked kind of sketchy and the copy and original no longer need different names since they're in different directories.
- CleanupFromPreviousUpdate cleans up both the old and new copy paths.
- Various refactoring to simplify the commit that actually makes the change, and for general cleanup.