### PR TITLE
DSPHLE/AX: Set state to WaitingForCmdListSize when switching uCodes

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -701,6 +701,10 @@ void AXUCode::HandleMail(u32 mail)
 
     case MAIL_NEW_UCODE:
       m_upload_setup_in_progress = true;
+      // Relevant when this uCode is resumed after switching.
+      // The resume mail is sent via the NeedsResumeMail() check above
+      // (and the flag corresponding to it is set by PrepareBootUCode).
+      m_mail_state = MailState::WaitingForCmdListSize;
       break;
 
     case MAIL_RESET:


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/13017. With uCode switching, the existing instance of AXUCode is re-activated when GBAUCode is done, but if the state remains as WaitingForNextTask, it won't be able to do anything. Instead, it needs to be in WaitingForCmdListSize.

(When the AX uCode is resumed, startpc is set to 0x0030, at least for 0x07f88145; this is the same location as MAIL_RESUME jumps to, so DSP_RESUME should be sent when the resuming happens; that's already handled by AXUCode::Update.)

The Zelda uCode already handled this, as it already tracked states prior to #10768:

https://github.com/dolphin-emu/dolphin/blob/86d760b8143989627bdff1be4474ce2fe59db8e9/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp#L208-L214

I don't actually have a game that uses uCode switching with the GBA uCode (the only game I have that uses the GBA uCode is the [Preview Disc](https://wiki.dolphin-emu.org/index.php?title=Nintendo_GameCube_Preview_Disc), as both [Doubutsu no Mori e+](https://wiki.dolphin-emu.org/index.php?title=Doubutsu_no_Mori_e%2B) and [Pokémon Channel](https://wiki.dolphin-emu.org/index.php?title=Pok%C3%A9mon_Channel) use the CPU for GBA encryption. I instead tested this using my experimental [CARD uCode implementation](https://github.com/pokechu22/dolphin/tree/archive/dsp-hle-card-ucode-3), which had the same issue (since both the GBA uCode and CARD uCode use uCode switching). (I actually have Rogue Squadron III, which apparently supports GBAs; I haven't tested that yet.)