### PR TITLE
VideoCommon: Remove unused swap chain functions

### DIFF
--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.h
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.h
@@ -29,9 +29,6 @@ public:
   AbstractTextureFormat GetFormat() const { return m_texture_format; }
   u32 GetWidth() const { return m_width; }
   u32 GetHeight() const { return m_height; }
-  u32 GetLayers() const { return m_stereo ? 2u : 1u; }
-  bool IsStereoEnabled() const { return m_stereo; }
-  bool HasExclusiveFullscreen() const { return m_has_fullscreen; }
 
   // Mode switches.
   bool GetFullscreen() const;

--- a/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
+++ b/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
@@ -34,8 +34,6 @@ public:
   VkSurfaceKHR GetSurface() const { return m_surface; }
   VkSurfaceFormatKHR GetSurfaceFormat() const { return m_surface_format; }
   AbstractTextureFormat GetTextureFormat() const { return m_texture_format; }
-  bool IsVSyncEnabled() const { return m_vsync_enabled; }
-  bool IsStereoEnabled() const { return m_layers == 2; }
   VkSwapchainKHR GetSwapChain() const { return m_swap_chain; }
   u32 GetWidth() const { return m_width; }
   u32 GetHeight() const { return m_height; }


### PR DESCRIPTION
See individual commit messages for details on when these were added/became unused.