### PR TITLE
qt: defer writing gamelist cache until EndRefresh

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt/GameList/GameTracker.h
@@ -94,6 +94,7 @@ private:
   bool m_initial_games_emitted = false;
   bool m_started = false;
   bool m_needs_purge = false;
+  bool m_refresh_in_progress = false;
   std::atomic_bool m_processing_halted = false;
 };
 


### PR DESCRIPTION
when refreshing gamelist, `GameFileCache::Save` took up 70% of entire runtime, and populating the list was slow.

with this change, `GameFileCache::Save` takes up near zero of overall runtime, and list updates quickly.