### PR TITLE
Android 12: Support motion control for external gamepad

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -434,8 +434,9 @@ public final class EmulationActivity extends AppCompatActivity
 
   private void updateMotionListener()
   {
-    if (NativeLibrary.IsEmulatingWii() && IntSetting.MAIN_MOTION_CONTROLS.getInt(mSettings) != 2)
-      mMotionListener.enable();
+    int motionSource = IntSetting.MAIN_MOTION_CONTROLS.getInt(mSettings);
+    if (NativeLibrary.IsEmulatingWii() && motionSource != 2)
+      mMotionListener.enable(motionSource);
     else
       mMotionListener.disable();
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/MotionListener.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/MotionListener.java
@@ -110,8 +110,8 @@ public class MotionListener implements SensorEventListener
 
   public void enable(int motionSource)
   {
-    if (mEnabled)
-      return;
+    //if (mEnabled)
+      //return;
 
     MotionSource = motionSource;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && motionSource == 3){

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -494,6 +494,7 @@
         <item>Use Device Sensors (With Pointer Emulation)</item>
         <item>Use Device Sensors (Without Pointer Emulation)</item>
         <item>Don\'t Use Device Sensors</item>
+        <item>Use GamePad Sensors</item>
     </string-array>
 
     <string-array name="convertFormatEntries" translatable="false">


### PR DESCRIPTION
As android 12 this gamepad sensor can be used.
i have knockoff cheap ds4 and has ability for gyro and accel sensor. It work, using Poco X3 pro with MIUI 13/Android 12.
This code is only for testing, enable from Overlay > Motion Control > Use gamepad sensor.

Only 1 listener (device/gamepad) be registered so the only way to change to is by choosing disable first then choosing gamepad sensor or restart game after choosing.
I hope someone will make better code than this, and close this req