### PR TITLE
Android: Add option to disable game cover text

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -72,9 +72,7 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
   {
     Context context = holder.itemView.getContext();
     GameFile gameFile = mGameFiles.get(position);
-    PicassoUtils.loadGameCover(holder.imageScreenshot, gameFile);
-
-    holder.textGameTitle.setText(gameFile.getTitle());
+    PicassoUtils.loadGameCover(holder, holder.imageScreenshot, gameFile);
 
     if (GameFileCacheManager.findSecondDisc(gameFile) != null)
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
@@ -50,15 +50,14 @@ public final class GameRowPresenter extends Presenter
     GameFile gameFile = (GameFile) item;
 
     holder.imageScreenshot.setImageDrawable(null);
-    PicassoUtils.loadGameCover(holder.imageScreenshot, gameFile);
+    PicassoUtils.loadGameCover(null, holder.imageScreenshot, gameFile);
 
     holder.cardParent.setTitleText(gameFile.getTitle());
 
     if (GameFileCacheManager.findSecondDisc(gameFile) != null)
     {
-      holder.cardParent
-              .setContentText(
-                      context.getString(R.string.disc_number, gameFile.getDiscNumber() + 1));
+      holder.cardParent.setContentText(
+              context.getString(R.string.disc_number, gameFile.getDiscNumber() + 1));
     }
     else
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -79,6 +79,8 @@ public enum BooleanSetting implements AbstractBooleanSetting
   MAIN_DEBUG_JIT_REGISTER_CACHE_OFF(Settings.FILE_DOLPHIN, Settings.SECTION_DEBUG,
           "JitRegisterCacheOff", false),
 
+  MAIN_SHOW_GAME_TITLES(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
+          "ShowGameTitles", true),
   MAIN_JOYSTICK_REL_CENTER(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
           "JoystickRelCenter", true),
   MAIN_PHONE_RUMBLE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -321,6 +321,8 @@ public final class SettingsFragmentPresenter
             R.string.osd_messages_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_USE_GAME_COVERS,
             R.string.download_game_covers, 0));
+    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_SHOW_GAME_TITLES,
+            R.string.show_titles_in_game_list, R.string.show_titles_in_game_list_description));
   }
 
   private void addAudioSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
+import android.view.View;
 import android.widget.ImageView;
 
 import com.squareup.picasso.Callback;
@@ -14,6 +15,7 @@ import com.squareup.picasso.Picasso;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
 import org.dolphinemu.dolphinemu.model.GameFile;
+import org.dolphinemu.dolphinemu.viewholders.GameViewHolder;
 
 import java.io.File;
 
@@ -35,8 +37,23 @@ public class PicassoUtils
             .into(imageView);
   }
 
-  public static void loadGameCover(ImageView imageView, GameFile gameFile)
+  public static void loadGameCover(GameViewHolder gameViewHolder, ImageView imageView,
+          GameFile gameFile)
   {
+    if (BooleanSetting.MAIN_SHOW_GAME_TITLES.getBooleanGlobal() && gameViewHolder != null)
+    {
+      gameViewHolder.textGameTitle.setText(gameFile.getTitle());
+      gameViewHolder.textGameTitle.setVisibility(View.VISIBLE);
+      gameViewHolder.textGameTitleInner.setVisibility(View.GONE);
+      gameViewHolder.textGameCaption.setVisibility(View.VISIBLE);
+    }
+    else if (gameViewHolder != null)
+    {
+      gameViewHolder.textGameTitleInner.setText(gameFile.getTitle());
+      gameViewHolder.textGameTitle.setVisibility(View.GONE);
+      gameViewHolder.textGameCaption.setVisibility(View.GONE);
+    }
+
     Context context = imageView.getContext();
     File cover = new File(gameFile.getCustomCoverPath());
     if (cover.exists())
@@ -49,7 +66,18 @@ public class PicassoUtils
               .centerInside()
               .config(Bitmap.Config.ARGB_8888)
               .error(R.drawable.no_banner)
-              .into(imageView);
+              .into(imageView, new Callback()
+              {
+                @Override public void onSuccess()
+                {
+                  PicassoUtils.disableInnerTitle(gameViewHolder);
+                }
+
+                @Override public void onError(Exception e)
+                {
+                  PicassoUtils.enableInnerTitle(gameViewHolder, gameFile);
+                }
+              });
     }
     else if ((cover = new File(gameFile.getCoverPath(context))).exists())
     {
@@ -61,7 +89,18 @@ public class PicassoUtils
               .centerInside()
               .config(Bitmap.Config.ARGB_8888)
               .error(R.drawable.no_banner)
-              .into(imageView);
+              .into(imageView, new Callback()
+              {
+                @Override public void onSuccess()
+                {
+                  PicassoUtils.disableInnerTitle(gameViewHolder);
+                }
+
+                @Override public void onError(Exception e)
+                {
+                  PicassoUtils.enableInnerTitle(gameViewHolder, gameFile);
+                }
+              });
     }
     // GameTDB has a pretty close to complete collection for US/EN covers. First pass at getting
     // the cover will be by the disk's region, second will be the US cover, and third EN.
@@ -82,6 +121,7 @@ public class PicassoUtils
                 {
                   CoverHelper.saveCover(((BitmapDrawable) imageView.getDrawable()).getBitmap(),
                           gameFile.getCoverPath(context));
+                  PicassoUtils.disableInnerTitle(gameViewHolder);
                 }
 
                 @Override
@@ -104,6 +144,7 @@ public class PicassoUtils
                               CoverHelper.saveCover(
                                       ((BitmapDrawable) imageView.getDrawable()).getBitmap(),
                                       gameFile.getCoverPath(context));
+                              PicassoUtils.disableInnerTitle(gameViewHolder);
                             }
 
                             @Override
@@ -127,11 +168,13 @@ public class PicassoUtils
                                                   ((BitmapDrawable) imageView.getDrawable())
                                                           .getBitmap(),
                                                   gameFile.getCoverPath(context));
+                                          PicassoUtils.disableInnerTitle(gameViewHolder);
                                         }
 
                                         @Override
                                         public void onError(Exception ex)
                                         {
+                                          PicassoUtils.enableInnerTitle(gameViewHolder, gameFile);
                                         }
                                       });
                             }
@@ -148,7 +191,34 @@ public class PicassoUtils
               .fit()
               .centerInside()
               .config(Bitmap.Config.ARGB_8888)
-              .into(imageView);
+              .into(imageView, new Callback()
+              {
+                @Override public void onSuccess()
+                {
+                  PicassoUtils.disableInnerTitle(gameViewHolder);
+                }
+
+                @Override public void onError(Exception e)
+                {
+                  PicassoUtils.enableInnerTitle(gameViewHolder, gameFile);
+                }
+              });
+    }
+  }
+
+  private static void enableInnerTitle(GameViewHolder gameViewHolder, GameFile gameFile)
+  {
+    if (gameViewHolder != null && !BooleanSetting.MAIN_SHOW_GAME_TITLES.getBooleanGlobal())
+    {
+      gameViewHolder.textGameTitleInner.setVisibility(View.VISIBLE);
+    }
+  }
+
+  private static void disableInnerTitle(GameViewHolder gameViewHolder)
+  {
+    if (gameViewHolder != null && !BooleanSetting.MAIN_SHOW_GAME_TITLES.getBooleanGlobal())
+    {
+      gameViewHolder.textGameTitleInner.setVisibility(View.GONE);
     }
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/viewholders/GameViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/viewholders/GameViewHolder.java
@@ -19,6 +19,7 @@ public class GameViewHolder extends RecyclerView.ViewHolder
 {
   public ImageView imageScreenshot;
   public TextView textGameTitle;
+  public TextView textGameTitleInner;
   public TextView textGameCaption;
 
   public GameFile gameFile;
@@ -31,6 +32,7 @@ public class GameViewHolder extends RecyclerView.ViewHolder
 
     imageScreenshot = itemView.findViewById(R.id.image_game_screen);
     textGameTitle = itemView.findViewById(R.id.text_game_title);
+    textGameTitleInner = itemView.findViewById(R.id.text_game_title_inner);
     textGameCaption = itemView.findViewById(R.id.text_game_caption);
   }
 }

--- a/Source/Android/app/src/main/res/layout/card_game.xml
+++ b/Source/Android/app/src/main/res/layout/card_game.xml
@@ -19,6 +19,7 @@
         android:layout_width="115dp"
         android:layout_height="161dp"
         android:layout_gravity="center"
+        android:layout_marginBottom="8dp"
         app:cardCornerRadius="4dp">
 
         <ImageView
@@ -26,6 +27,21 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1"/>
+
+        <TextView
+            android:id="@+id/text_game_title_inner"
+            style="@android:style/TextAppearance.Material.Subhead"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingTop="8dp"
+            android:paddingLeft="2dp"
+            android:paddingRight="2dp"
+            android:ellipsize="end"
+            android:gravity="center|top"
+            android:maxLines="2"
+            android:visibility="visible"
+            tools:text="The Legend of Zelda: The Wind Waker" />
+
     </androidx.cardview.widget.CardView>
 
     <TextView
@@ -34,7 +50,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="start"
-        android:layout_marginTop="8dp"
         android:ellipsize="end"
         android:maxLines="2"
         tools:layout_width="140dp"

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -193,6 +193,8 @@
     <string name="osd_messages">Show On-Screen Display Messages</string>
     <string name="osd_messages_description">Display messages over the emulation screen area. These messages include memory card writes, video backend and CPU information, and JIT cache clearing.</string>
     <string name="download_game_covers">Download Game Covers from GameTDB.com</string>
+    <string name="show_titles_in_game_list">Show Titles in Game List</string>
+    <string name="show_titles_in_game_list_description">Show the title and creator below each game cover.</string>
 
     <!-- Online Update Region Select Fragment -->
     <string name="region_select_title">Please select a region</string>

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -39,10 +39,10 @@ bool IsSettingSaveable(const Config::Location& config_location)
     // TODO: Kill the current Android controller mappings system
     if (config_location.section == "Android")
     {
-      static constexpr std::array<const char*, 10> android_setting_saveable = {
-          "ControlScale",    "ControlOpacity",  "EmulationOrientation", "JoystickRelCenter",
-          "LastPlatformTab", "MotionControls",  "PhoneRumble",          "ShowInputOverlay",
-          "IRMode",          "IRAlwaysRecenter"};
+      static constexpr std::array<const char*, 11> android_setting_saveable = {
+          "ControlScale",    "ControlOpacity",   "EmulationOrientation", "JoystickRelCenter",
+          "LastPlatformTab", "MotionControls",   "PhoneRumble",          "ShowInputOverlay",
+          "IRMode",          "IRAlwaysRecenter", "ShowGameTitles"};
 
       return std::any_of(
           android_setting_saveable.cbegin(), android_setting_saveable.cend(),


### PR DESCRIPTION
Following a request from @MayImilae in #10600, you can now disable the text below game covers. Additionally there is a fallback to display the game title over the error image if an image is not found.

Setting - 
![image](https://user-images.githubusercontent.com/14132249/186016822-86c6b725-de1b-4104-b901-892106118907.png)

Enabled - 
![image](https://user-images.githubusercontent.com/14132249/185983493-9b5c4a81-972b-4942-ba61-f8f41ff8f3b2.png)

Fallback -
![image](https://user-images.githubusercontent.com/14132249/185983767-d96e87c0-abdf-46c8-a654-ccea38a7bd80.png)