### PR TITLE
Mixer: Add assertions regarding num_samples versus buffer length

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -282,9 +282,11 @@ void Mixer::PushStreamingSamples(const short* samples, unsigned int num_samples)
 void Mixer::PushWiimoteSpeakerSamples(const short* samples, unsigned int num_samples,
                                       unsigned int sample_rate_divisor)
 {
-  short samples_stereo[MAX_SAMPLES * 2];
+  // Max 20 bytes/speaker report, may be 4-bit ADPCM so multiply by 2
+  static constexpr u32 MAX_SPEAKER_SAMPLES = 20 * 2;
+  std::array<short, MAX_SPEAKER_SAMPLES * 2> samples_stereo;
 
-  if (num_samples < MAX_SAMPLES)
+  if (num_samples <= MAX_SPEAKER_SAMPLES)
   {
     m_wiimote_speaker_mixer.SetInputSampleRateDivisor(sample_rate_divisor);
 
@@ -294,7 +296,7 @@ void Mixer::PushWiimoteSpeakerSamples(const short* samples, unsigned int num_sam
       samples_stereo[i * 2 + 1] = samples[i];
     }
 
-    m_wiimote_speaker_mixer.PushSamples(samples_stereo, num_samples);
+    m_wiimote_speaker_mixer.PushSamples(samples_stereo.data(), num_samples);
   }
 }
 

--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -167,6 +167,11 @@ unsigned int Mixer::Mix(short* samples, unsigned int num_samples)
     unsigned int available_samples =
         std::min(m_dma_mixer.AvailableSamples(), m_streaming_mixer.AvailableSamples());
 
+    ASSERT_MSG(AUDIO, available_samples <= MAX_SAMPLES,
+               "Audio stretching would overflow m_scratch_buffer: min({}, {}) -> {} > {} ({})",
+               m_dma_mixer.AvailableSamples(), m_streaming_mixer.AvailableSamples(),
+               available_samples, MAX_SAMPLES, num_samples);
+
     m_scratch_buffer.fill(0);
 
     m_dma_mixer.Mix(m_scratch_buffer.data(), available_samples, false, emulation_speed,
@@ -213,10 +218,15 @@ unsigned int Mixer::MixSurround(float* samples, unsigned int num_samples)
 
   // Mix() may also use m_scratch_buffer internally, but is safe because it alternates reads
   // and writes.
+  ASSERT_MSG(AUDIO, needed_frames <= MAX_SAMPLES,
+             "needed_frames would overflow m_scratch_buffer: {} -> {} > {}", num_samples,
+             needed_frames, MAX_SAMPLES);
   size_t available_frames = Mix(m_scratch_buffer.data(), static_cast<u32>(needed_frames));
   if (available_frames != needed_frames)
   {
-    ERROR_LOG_FMT(AUDIO, "Error decoding surround frames.");
+    ERROR_LOG_FMT(AUDIO,
+                  "Error decoding surround frames: needed {} frames for {} samples but got {}",
+                  needed_frames, num_samples, available_frames);
     return 0;
   }
 
@@ -286,6 +296,9 @@ void Mixer::PushWiimoteSpeakerSamples(const short* samples, unsigned int num_sam
   static constexpr u32 MAX_SPEAKER_SAMPLES = 20 * 2;
   std::array<short, MAX_SPEAKER_SAMPLES * 2> samples_stereo;
 
+  ASSERT_MSG(AUDIO, num_samples <= MAX_SPEAKER_SAMPLES,
+             "num_samples would overflow samples_stereo: {} > {}", num_samples,
+             MAX_SPEAKER_SAMPLES);
   if (num_samples <= MAX_SPEAKER_SAMPLES)
   {
     m_wiimote_speaker_mixer.SetInputSampleRateDivisor(sample_rate_divisor);


### PR DESCRIPTION
Compare #10664. I haven't been able to reproduce any buffer overflows (other than the audio dumping one from #10741), but hopefully these assertions will make them more obvious when they happen.

(I didn't add any assertions to `Mixer::MixerFifo::PushSamples` because that code *should* already be free of overflows due to the masking.)