### PR TITLE
Software/Rasterizer: Fix indirect stage using texture coordinates/maps >= 4

### DIFF
--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -291,9 +291,9 @@ static void BuildBlock(s32 blockX, s32 blockY)
   u32 indref = bpmem.tevindref.hex;
   for (unsigned int i = 0; i < bpmem.genMode.numindstages; i++)
   {
-    u32 texmap = indref & 3;
+    u32 texmap = indref & 7;
     indref >>= 3;
-    u32 texcoord = indref & 3;
+    u32 texcoord = indref & 7;
     indref >>= 3;
 
     CalculateLOD(&rasterBlock.IndirectLod[i], &rasterBlock.IndirectLinear[i], texmap, texcoord);


### PR DESCRIPTION
The masking was incorrect. This affects the main menu of The Last Avatar, though that menu also relies on copy filter functionality that is not correctly handled in the software renderer so the difference is not obvious; that game shuffles textures across all indices for some reason, so this issue would presumably result in subtle flickering.

This was originally implemented in #10549; see comments there for some hacked-together visualizations of what's going on. I've created a separate pull request just to isolate the fifoci difference (and provide an obvious minimal change that fixes the bug).