### PR TITLE
Android: Fix reading custom covers with SAF

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
@@ -61,7 +61,7 @@ public class GameFileCache
       String path = dolphinIni.getString(Settings.SECTION_INI_GENERAL,
               SettingsFile.KEY_ISO_PATH_BASE + i, "");
 
-      if (path.startsWith("content://") ? ContentHandler.exists(path) : new File(path).exists())
+      if (ContentHandler.isContentUri(path) ? ContentHandler.exists(path) : new File(path).exists())
       {
         pathSet.add(path);
       }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ContentHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ContentHandler.java
@@ -37,6 +37,11 @@ import java.util.function.Predicate;
 
 public class ContentHandler
 {
+  public static boolean isContentUri(@NonNull String pathOrUri)
+  {
+    return pathOrUri.startsWith("content://");
+  }
+
   @Keep
   public static int openFd(@NonNull String uri, @NonNull String mode)
   {
@@ -336,7 +341,7 @@ public class ContentHandler
    * provider to use URIs without any % characters.
    */
   @NonNull
-  private static Uri unmangle(@NonNull String uri) throws FileNotFoundException, SecurityException
+  public static Uri unmangle(@NonNull String uri) throws FileNotFoundException, SecurityException
   {
     int lastComponentEnd = getLastComponentEnd(uri);
     int lastComponentStart = getLastComponentStart(uri, lastComponentEnd);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.java
@@ -82,9 +82,16 @@ public final class FileBrowserHelper
     return isPathEmptyOrValid(path.getStringGlobal());
   }
 
+  /**
+   * Returns true if at least one of the following applies:
+   *
+   * 1. The input is empty.
+   * 2. The input is something which is not a content URI.
+   * 3. The input is a content URI that points to a file that exists and we're allowed to access.
+   */
   public static boolean isPathEmptyOrValid(String path)
   {
-    return !path.startsWith("content://") || ContentHandler.exists(path);
+    return !ContentHandler.isContentUri(path) || ContentHandler.exists(path);
   }
 
   public static void runAfterExtensionCheck(Context context, Uri uri, Set<String> validExtensions,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
@@ -18,6 +18,7 @@ import org.dolphinemu.dolphinemu.model.GameFile;
 import org.dolphinemu.dolphinemu.viewholders.GameViewHolder;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 
 public class PicassoUtils
 {
@@ -54,12 +55,33 @@ public class PicassoUtils
       gameViewHolder.textGameCaption.setVisibility(View.GONE);
     }
 
+    String customCoverPath = gameFile.getCustomCoverPath();
+    Uri customCoverUri = null;
+    boolean customCoverExists = false;
+    if (ContentHandler.isContentUri(customCoverPath))
+    {
+      try
+      {
+        customCoverUri = ContentHandler.unmangle(customCoverPath);
+        customCoverExists = true;
+      }
+      catch (FileNotFoundException | SecurityException ignored)
+      {
+        // Let customCoverExists remain false
+      }
+    }
+    else
+    {
+      customCoverUri = Uri.parse(customCoverPath);
+      customCoverExists = new File(customCoverPath).exists();
+    }
+
     Context context = imageView.getContext();
-    File cover = new File(gameFile.getCustomCoverPath());
-    if (cover.exists())
+    File cover;
+    if (customCoverExists)
     {
       Picasso.get()
-              .load(cover)
+              .load(customCoverUri)
               .noFade()
               .noPlaceholder()
               .fit()


### PR DESCRIPTION
If `GameFile.getCustomCoverPath` returns a mangled URI, we need to unmangle it before passing it to Picasso, since Picasso has no concept of Dolphin's mangled URIs.