### PR TITLE
Add updater error messages

### DIFF
--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -193,7 +193,7 @@ bool DeleteDirRecursively(const std::string& directory);
 std::string GetCurrentDir();
 
 // Create directory and copy contents (optionally overwrites existing files)
-void CopyDir(const std::string& source_path, const std::string& dest_path,
+bool CopyDir(const std::string& source_path, const std::string& dest_path,
              bool destructive = false);
 
 // Set the current directory to given directory

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -558,12 +558,7 @@ void MenuBar::InstallUpdateManually()
   auto* const updater = new Updater(this->parentWidget(), manual_track,
                                     Config::Get(Config::MAIN_AUTOUPDATE_HASH_OVERRIDE));
 
-  if (!updater->CheckForUpdate())
-  {
-    ModalMessageBox::information(
-        this, tr("Update"),
-        tr("You are running the latest version available on this update track."));
-  }
+  updater->CheckForUpdate();
 }
 
 void MenuBar::AddHelpMenu()

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -29,21 +29,19 @@ Updater::Updater(QWidget* parent, std::string update_track, std::string hash_ove
 
 void Updater::run()
 {
-  AutoUpdateChecker::CheckForUpdate(m_update_track, m_hash_override);
+  AutoUpdateChecker::CheckForUpdate(m_update_track, m_hash_override,
+                                    AutoUpdateChecker::CheckType::Automatic);
 }
 
-bool Updater::CheckForUpdate()
+void Updater::CheckForUpdate()
 {
-  m_update_available = false;
-  AutoUpdateChecker::CheckForUpdate(m_update_track, m_hash_override);
-
-  return m_update_available;
+  AutoUpdateChecker::CheckForUpdate(m_update_track, m_hash_override,
+                                    AutoUpdateChecker::CheckType::Manual);
 }
 
 void Updater::OnUpdateAvailable(const NewVersionInformation& info)
 {
   bool later = false;
-  m_update_available = true;
 
   std::optional<int> choice = RunOnObject(m_parent, [&] {
     QDialog* dialog = new QDialog(m_parent);

--- a/Source/Core/DolphinQt/Updater.h
+++ b/Source/Core/DolphinQt/Updater.h
@@ -27,5 +27,4 @@ private:
   QWidget* m_parent;
   std::string m_update_track;
   std::string m_hash_override;
-  bool m_update_available = false;
 };

--- a/Source/Core/DolphinQt/Updater.h
+++ b/Source/Core/DolphinQt/Updater.h
@@ -21,7 +21,7 @@ public:
 
   void run() override;
   void OnUpdateAvailable(const NewVersionInformation& info) override;
-  bool CheckForUpdate();
+  void CheckForUpdate();
 
 private:
   QWidget* m_parent;

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -8,10 +8,12 @@
 #include <fmt/format.h>
 #include <picojson.h>
 
+#include "Common/CommonFuncs.h"
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/HttpRequest.h"
 #include "Common/Logging/Log.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Common/Version.h"
 
@@ -159,7 +161,7 @@ static std::string GetPlatformID()
 }
 
 void AutoUpdateChecker::CheckForUpdate(std::string_view update_track,
-                                       std::string_view hash_override)
+                                       std::string_view hash_override, const CheckType check_type)
 {
   // Don't bother checking if updates are not supported or not enabled.
   if (!SystemSupportsAutoUpdates() || update_track.empty())
@@ -173,11 +175,14 @@ void AutoUpdateChecker::CheckForUpdate(std::string_view update_track,
   std::string url = fmt::format("https://dolphin-emu.org/update/check/v1/{}/{}/{}", update_track,
                                 version_hash, GetPlatformID());
 
+  const bool is_manual_check = check_type == CheckType::Manual;
+
   Common::HttpRequest req{std::chrono::seconds{10}};
   auto resp = req.Get(url);
   if (!resp)
   {
-    ERROR_LOG_FMT(COMMON, "Auto-update request failed");
+    if (is_manual_check)
+      CriticalAlertFmtT("Unable to contact update server.");
     return;
   }
   const std::string contents(reinterpret_cast<char*>(resp->data()), resp->size());
@@ -187,13 +192,15 @@ void AutoUpdateChecker::CheckForUpdate(std::string_view update_track,
   const std::string err = picojson::parse(json, contents);
   if (!err.empty())
   {
-    ERROR_LOG_FMT(COMMON, "Invalid JSON received from auto-update service: {}", err);
+    CriticalAlertFmtT("Invalid JSON received from auto-update service : {0}", err);
     return;
   }
   picojson::object obj = json.get<picojson::object>();
 
   if (obj["status"].get<std::string>() != "outdated")
   {
+    if (is_manual_check)
+      SuccessAlertFmtT("You are running the latest version available on this update track.");
     INFO_LOG_FMT(COMMON, "Auto-update status: we are up to date.");
     return;
   }
@@ -212,7 +219,7 @@ void AutoUpdateChecker::CheckForUpdate(std::string_view update_track,
 }
 
 void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInformation& info,
-                                      AutoUpdateChecker::RestartMode restart_mode)
+                                      const AutoUpdateChecker::RestartMode restart_mode)
 {
   // Check to make sure we don't already have an update triggered
   if (s_update_triggered)
@@ -241,8 +248,16 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
 #ifdef __APPLE__
   // Copy the updater so it can update itself if needed.
   const std::string reloc_updater_path = UpdaterPath(true);
-  File::CopyDir(UpdaterPath(), reloc_updater_path);
-  chmod((reloc_updater_path + UPDATER_CONTENT_PATH).c_str(), 0700);
+  if (!File::CopyDir(UpdaterPath(), reloc_updater_path))
+  {
+    CriticalAlertFmtT("Unable to create updater copy.");
+    return;
+  }
+  if (chmod((reloc_updater_path + UPDATER_CONTENT_PATH).c_str(), 0700) != 0)
+  {
+    CriticalAlertFmtT("Unable to set permissions on updater copy.");
+    return;
+  }
 #endif
 
   // Run the updater!
@@ -261,12 +276,14 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
   }
   else
   {
-    ERROR_LOG_FMT(COMMON, "Could not start updater process: error={}", GetLastError());
+    const std::string error = GetLastErrorString();
+    CriticalAlertFmtT("Could not start updater process: {0}", error);
   }
 #else
   if (popen(command_line.c_str(), "r") == nullptr)
   {
-    ERROR_LOG_FMT(COMMON, "Could not start updater process: error={}", errno);
+    const std::string error = LastStrerrorString();
+    CriticalAlertFmtT("Could not start updater process: {0}", error);
   }
 #endif
 

--- a/Source/Core/UICommon/AutoUpdate.h
+++ b/Source/Core/UICommon/AutoUpdate.h
@@ -13,9 +13,15 @@
 class AutoUpdateChecker
 {
 public:
+  enum class CheckType
+  {
+    Automatic,
+    Manual,
+  };
   // Initiates a check for updates in the background. Calls the OnUpdateAvailable callback if an
   // update is available, does "nothing" otherwise.
-  void CheckForUpdate(std::string_view update_track, std::string_view hash_override);
+  void CheckForUpdate(std::string_view update_track, std::string_view hash_override,
+                      CheckType check_type);
 
   static bool SystemSupportsAutoUpdates();
 


### PR DESCRIPTION
Fixes error reporting during update checks and adds error messages for several things that can go wrong while triggering an update.

On master, any error during an update check either incorrectly reports Dolphin is up to date (for manual checks) or is just logged (for automatic checks). This PR reports the correct errors, and also shows a message box for all manual check results and certain automatic results to make issues more visible.

Event details:
- Up to date: (Unchanged from master, only shown for manual checks):
   "You are running the latest version available on this update track."
- Check request failed: (Error, manual):
   "Unable to contact update server."
- Invalid JSON in server response: (error, manual and automatic):
   "Invalid JSON received from auto-update service: {error description}."
- Updater copy failed: (error, manual and automatic)
  "Unable to create updater copy."
- Failed to set permissions: (error, manual and automatic)
  "Unable to set permissions on updater copy."
- Updater launch failed: (error, manual and automatic)
  "Could not start updater process: {error description}."

Discussion items:

- Wording of error messages.
- Which errors during automatic checks should generate an alert.