### PR TITLE
Ensure constructor initializer order matches initialization order

### DIFF
--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
@@ -61,8 +61,8 @@ public:
   }
 
 private:
-  GraphicsModConfig m_mod;
   std::unique_ptr<GraphicsModAction> m_action_impl;
+  GraphicsModConfig m_mod;
 };
 
 const std::vector<GraphicsModAction*>&

--- a/Source/Core/VideoCommon/TextureInfo.cpp
+++ b/Source/Core/VideoCommon/TextureInfo.cpp
@@ -52,9 +52,9 @@ TextureInfo::TextureInfo(u32 stage, const u8* ptr, const u8* tlut_ptr, u32 addre
                          TextureFormat texture_format, TLUTFormat tlut_format, u32 width,
                          u32 height, bool from_tmem, const u8* tmem_odd, const u8* tmem_even,
                          std::optional<u32> mip_count)
-    : m_stage(stage), m_ptr(ptr), m_tlut_ptr(tlut_ptr), m_address(address), m_from_tmem(from_tmem),
+    : m_ptr(ptr), m_tlut_ptr(tlut_ptr), m_address(address), m_from_tmem(from_tmem),
       m_tmem_odd(tmem_odd), m_texture_format(texture_format), m_tlut_format(tlut_format),
-      m_raw_width(width), m_raw_height(height)
+      m_raw_width(width), m_raw_height(height), m_stage(stage)
 {
   const bool is_palette_texture = IsColorIndexed(m_texture_format);
   if (is_palette_texture)


### PR DESCRIPTION
ref: clang `-Wreorder-ctor` warning