### PR TITLE
MTLObjectCache: Correct signature of equality operator

### DIFF
--- a/Source/Core/VideoBackends/Metal/MTLObjectCache.h
+++ b/Source/Core/VideoBackends/Metal/MTLObjectCache.h
@@ -37,8 +37,8 @@ struct DepthStencilSelector
   bool UpdateEnable() const { return value & 1; }
   enum CompareMode CompareMode() const { return static_cast<enum CompareMode>(value >> 1); }
 
-  bool operator==(const DepthStencilSelector& other) { return value == other.value; }
-  bool operator!=(const DepthStencilSelector& other) { return !(*this == other); }
+  bool operator==(const DepthStencilSelector& other) const { return value == other.value; }
+  bool operator!=(const DepthStencilSelector& other) const { return !(*this == other); }
   static constexpr size_t N_VALUES = 1 << 4;
 };
 
@@ -63,8 +63,8 @@ struct SamplerSelector
   WrapMode WrapV() const { return static_cast<WrapMode>((value >> 4) / 3); }
   bool AnisotropicFiltering() const { return ((value >> 3) & 1); }
 
-  bool operator==(const SamplerSelector& other) { return value == other.value; }
-  bool operator!=(const SamplerSelector& other) { return !(*this == other); }
+  bool operator==(const SamplerSelector& other) const { return value == other.value; }
+  bool operator!=(const SamplerSelector& other) const { return !(*this == other); }
   static constexpr size_t N_VALUES = (1 << 4) * 9;
 };
 


### PR DESCRIPTION
In C++20, the expression `DepthStencilSelector{} == DepthStencilSelector{}` is non-conforming code without this change.

The underlying reason for this reversed operators in C++20 results in two candidates being produced:
```cpp
bool operator==(DepthStencilSelector& /*this*/, DepthStencilSelector const& other);
bool operator==(DepthStencilSelector const& other, DepthStencilSelector& /*this*/);
```

This results in an ambiguity due to there being two viable candidates.

Making `this` a `const` reference solves this problem.