### PR TITLE
HLE_OS: Manually handle printfs from emulated software to prevent emulated software from crashing Dolphin with an invalid printf formatting string.

### DIFF
--- a/Source/Core/Core/HLE/HLE_OS.h
+++ b/Source/Core/Core/HLE/HLE_OS.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+#include <optional>
+#include <string>
+
+#include "Common/CommonTypes.h"
+
 namespace Core
 {
 class CPUThreadGuard;
@@ -10,6 +15,18 @@ class CPUThreadGuard;
 
 namespace HLE_OS
 {
+class HLEPrintArgs
+{
+public:
+  virtual u32 GetU32() = 0;
+  virtual u64 GetU64() = 0;
+  virtual double GetF64() = 0;
+  virtual std::string GetString(std::optional<u32> max_length) = 0;
+  virtual std::u16string GetU16String(std::optional<u32> max_length) = 0;
+};
+
+std::string GetStringVA(HLEPrintArgs* args, std::string_view string);
+
 void HLE_GeneralDebugPrint(const Core::CPUThreadGuard& guard);
 void HLE_GeneralDebugVPrint(const Core::CPUThreadGuard& guard);
 void HLE_write_console(const Core::CPUThreadGuard& guard);

--- a/Source/Core/Core/HLE/HLE_VarArgs.cpp
+++ b/Source/Core/Core/HLE/HLE_VarArgs.cpp
@@ -2,29 +2,29 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Core/HLE/HLE_VarArgs.h"
+#include "Core/Core.h"
 #include "Core/System.h"
 
 #include "Common/Logging/Log.h"
 
 HLE::SystemVABI::VAList::~VAList() = default;
 
-u32 HLE::SystemVABI::VAList::GetGPR(const Core::CPUThreadGuard&, u32 gpr) const
+u32 HLE::SystemVABI::VAList::GetGPR(u32 gpr) const
 {
-  return m_system.GetPPCState().gpr[gpr];
+  return m_guard.GetSystem().GetPPCState().gpr[gpr];
 }
 
-double HLE::SystemVABI::VAList::GetFPR(const Core::CPUThreadGuard&, u32 fpr) const
+double HLE::SystemVABI::VAList::GetFPR(u32 fpr) const
 {
-  return m_system.GetPPCState().ps[fpr].PS0AsDouble();
+  return m_guard.GetSystem().GetPPCState().ps[fpr].PS0AsDouble();
 }
 
-HLE::SystemVABI::VAListStruct::VAListStruct(Core::System& system, const Core::CPUThreadGuard& guard,
-                                            u32 address)
-    : VAList(system, 0), m_va_list{PowerPC::MMU::HostRead_U8(guard, address),
-                                   PowerPC::MMU::HostRead_U8(guard, address + 1),
-                                   PowerPC::MMU::HostRead_U32(guard, address + 4),
-                                   PowerPC::MMU::HostRead_U32(guard, address + 8)},
-      m_address(address), m_has_fpr_area(system.GetPPCState().cr.GetBit(6) == 1)
+HLE::SystemVABI::VAListStruct::VAListStruct(const Core::CPUThreadGuard& guard, u32 address)
+    : VAList(guard, 0), m_va_list{PowerPC::MMU::HostRead_U8(guard, address),
+                                  PowerPC::MMU::HostRead_U8(guard, address + 1),
+                                  PowerPC::MMU::HostRead_U32(guard, address + 4),
+                                  PowerPC::MMU::HostRead_U32(guard, address + 8)},
+      m_address(address), m_has_fpr_area(guard.GetSystem().GetPPCState().cr.GetBit(6) == 1)
 {
   m_stack = m_va_list.overflow_arg_area;
   m_gpr += m_va_list.gpr;
@@ -41,7 +41,7 @@ u32 HLE::SystemVABI::VAListStruct::GetFPRArea() const
   return GetGPRArea() + 4 * 8;
 }
 
-u32 HLE::SystemVABI::VAListStruct::GetGPR(const Core::CPUThreadGuard& guard, u32 gpr) const
+u32 HLE::SystemVABI::VAListStruct::GetGPR(u32 gpr) const
 {
   if (gpr < 3 || gpr > 10)
   {
@@ -49,10 +49,10 @@ u32 HLE::SystemVABI::VAListStruct::GetGPR(const Core::CPUThreadGuard& guard, u32
     return 0;
   }
   const u32 gpr_address = Common::AlignUp(GetGPRArea() + 4 * (gpr - 3), 4);
-  return PowerPC::MMU::HostRead_U32(guard, gpr_address);
+  return PowerPC::MMU::HostRead_U32(m_guard, gpr_address);
 }
 
-double HLE::SystemVABI::VAListStruct::GetFPR(const Core::CPUThreadGuard& guard, u32 fpr) const
+double HLE::SystemVABI::VAListStruct::GetFPR(u32 fpr) const
 {
   if (!m_has_fpr_area || fpr < 1 || fpr > 8)
   {
@@ -60,5 +60,5 @@ double HLE::SystemVABI::VAListStruct::GetFPR(const Core::CPUThreadGuard& guard, 
     return 0.0;
   }
   const u32 fpr_address = Common::AlignUp(GetFPRArea() + 8 * (fpr - 1), 8);
-  return PowerPC::MMU::HostRead_F64(guard, fpr_address);
+  return PowerPC::MMU::HostRead_F64(m_guard, fpr_address);
 }

--- a/Source/Core/Core/HLE/HLE_VarArgs.h
+++ b/Source/Core/Core/HLE/HLE_VarArgs.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "Common/Align.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
-
-#include <type_traits>
 
 namespace Core
 {
@@ -38,9 +38,9 @@ constexpr bool IS_ARG_REAL = std::is_floating_point<T>();
 class VAList
 {
 public:
-  explicit VAList(Core::System& system, u32 stack, u32 gpr = 3, u32 fpr = 1, u32 gpr_max = 10,
-                  u32 fpr_max = 8)
-      : m_system(system), m_gpr(gpr), m_fpr(fpr), m_gpr_max(gpr_max), m_fpr_max(fpr_max),
+  explicit VAList(const Core::CPUThreadGuard& guard, u32 stack, u32 gpr = 3, u32 fpr = 1,
+                  u32 gpr_max = 10, u32 fpr_max = 8)
+      : m_guard(guard), m_gpr(gpr), m_fpr(fpr), m_gpr_max(gpr_max), m_fpr_max(fpr_max),
         m_stack(stack)
   {
   }
@@ -48,14 +48,14 @@ public:
 
   // 0 - arg_ARGPOINTER
   template <typename T, typename std::enable_if_t<IS_ARG_POINTER<T>>* = nullptr>
-  T GetArg(const Core::CPUThreadGuard& guard)
+  T GetArg()
   {
     T obj;
-    u32 addr = GetArg<u32>(guard);
+    u32 addr = GetArg<u32>();
 
     for (size_t i = 0; i < sizeof(T); i += 1, addr += 1)
     {
-      reinterpret_cast<u8*>(&obj)[i] = PowerPC::MMU::HostRead_U8(guard, addr);
+      reinterpret_cast<u8*>(&obj)[i] = PowerPC::MMU::HostRead_U8(m_guard, addr);
     }
 
     return obj;
@@ -63,20 +63,20 @@ public:
 
   // 1 - arg_WORD
   template <typename T, typename std::enable_if_t<IS_WORD<T>>* = nullptr>
-  T GetArg(const Core::CPUThreadGuard& guard)
+  T GetArg()
   {
     static_assert(!std::is_pointer<T>(), "VAList doesn't support pointers");
     u64 value;
 
     if (m_gpr <= m_gpr_max)
     {
-      value = GetGPR(guard, m_gpr);
+      value = GetGPR(m_gpr);
       m_gpr += 1;
     }
     else
     {
       m_stack = Common::AlignUp(m_stack, 4);
-      value = PowerPC::MMU::HostRead_U32(guard, m_stack);
+      value = PowerPC::MMU::HostRead_U32(m_guard, m_stack);
       m_stack += 4;
     }
 
@@ -85,7 +85,7 @@ public:
 
   // 2 - arg_DOUBLEWORD
   template <typename T, typename std::enable_if_t<IS_DOUBLE_WORD<T>>* = nullptr>
-  T GetArg(const Core::CPUThreadGuard& guard)
+  T GetArg()
   {
     u64 value;
 
@@ -93,13 +93,13 @@ public:
       m_gpr += 1;
     if (m_gpr < m_gpr_max)
     {
-      value = static_cast<u64>(GetGPR(guard, m_gpr)) << 32 | GetGPR(guard, m_gpr + 1);
+      value = static_cast<u64>(GetGPR(m_gpr)) << 32 | GetGPR(m_gpr + 1);
       m_gpr += 2;
     }
     else
     {
       m_stack = Common::AlignUp(m_stack, 8);
-      value = PowerPC::MMU::HostRead_U64(guard, m_stack);
+      value = PowerPC::MMU::HostRead_U64(m_guard, m_stack);
       m_stack += 8;
     }
 
@@ -108,19 +108,19 @@ public:
 
   // 3 - arg_ARGREAL
   template <typename T, typename std::enable_if_t<IS_ARG_REAL<T>>* = nullptr>
-  T GetArg(const Core::CPUThreadGuard& guard)
+  T GetArg()
   {
     double value;
 
     if (m_fpr <= m_fpr_max)
     {
-      value = GetFPR(guard, m_fpr);
+      value = GetFPR(m_fpr);
       m_fpr += 1;
     }
     else
     {
       m_stack = Common::AlignUp(m_stack, 8);
-      value = PowerPC::MMU::HostRead_F64(guard, m_stack);
+      value = PowerPC::MMU::HostRead_F64(m_guard, m_stack);
       m_stack += 8;
     }
 
@@ -129,13 +129,13 @@ public:
 
   // Helper
   template <typename T>
-  T GetArgT(const Core::CPUThreadGuard& guard)
+  T GetArgT()
   {
-    return static_cast<T>(GetArg<T>(guard));
+    return static_cast<T>(GetArg<T>());
   }
 
 protected:
-  Core::System& m_system;
+  const Core::CPUThreadGuard& m_guard;
   u32 m_gpr = 3;
   u32 m_fpr = 1;
   const u32 m_gpr_max = 10;
@@ -143,8 +143,8 @@ protected:
   u32 m_stack;
 
 private:
-  virtual u32 GetGPR(const Core::CPUThreadGuard& guard, u32 gpr) const;
-  virtual double GetFPR(const Core::CPUThreadGuard& guard, u32 fpr) const;
+  virtual u32 GetGPR(u32 gpr) const;
+  virtual double GetFPR(u32 fpr) const;
 };
 
 // See System V ABI (SVR4) for more details
@@ -156,7 +156,7 @@ private:
 class VAListStruct : public VAList
 {
 public:
-  explicit VAListStruct(Core::System& system, const Core::CPUThreadGuard& guard, u32 address);
+  explicit VAListStruct(const Core::CPUThreadGuard& guard, u32 address);
   ~VAListStruct() = default;
 
 private:
@@ -174,8 +174,8 @@ private:
   u32 GetGPRArea() const;
   u32 GetFPRArea() const;
 
-  u32 GetGPR(const Core::CPUThreadGuard& guard, u32 gpr) const override;
-  double GetFPR(const Core::CPUThreadGuard& guard, u32 fpr) const override;
+  u32 GetGPR(u32 gpr) const override;
+  double GetFPR(u32 fpr) const override;
 };
 
 }  // namespace HLE::SystemVABI

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -867,6 +867,22 @@ std::string MMU::HostGetString(const Core::CPUThreadGuard& guard, u32 address, s
   return s;
 }
 
+std::u16string MMU::HostGetU16String(const Core::CPUThreadGuard& guard, u32 address, size_t size)
+{
+  std::u16string s;
+  do
+  {
+    if (!HostIsRAMAddress(guard, address) || !HostIsRAMAddress(guard, address + 1))
+      break;
+    const u16 res = HostRead_U16(guard, address);
+    if (!res)
+      break;
+    s += static_cast<char16_t>(res);
+    address += 2;
+  } while (size == 0 || s.length() < size);
+  return s;
+}
+
 std::optional<ReadResult<std::string>> MMU::HostTryReadString(const Core::CPUThreadGuard& guard,
                                                               u32 address, size_t size,
                                                               RequestedAddressSpace space)

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -132,6 +132,8 @@ public:
   static double HostRead_F64(const Core::CPUThreadGuard& guard, u32 address);
   static u32 HostRead_Instruction(const Core::CPUThreadGuard& guard, u32 address);
   static std::string HostGetString(const Core::CPUThreadGuard& guard, u32 address, size_t size = 0);
+  static std::u16string HostGetU16String(const Core::CPUThreadGuard& guard, u32 address,
+                                         size_t size = 0);
 
   // Try to read a value from emulated memory at the given address in the given memory space.
   // If the read succeeds, the returned value will be present and the ReadResult contains the read


### PR DESCRIPTION
This is incomplete and not tested, I just was reminded that I had this. I may or may not come back to this, someone else is free to take this over if they want...

For reference, I'm unsure of the exact circumstances, but I *have* seen Dolphin crash from a game invoking a HLE-hooked `printf()`, which is what triggered me going down this path.