### PR TITLE
AudioCommon: Move sound stream variables to Core::System.

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -13,8 +13,6 @@
 
 class Mixer;
 
-extern std::unique_ptr<SoundStream> g_sound_stream;
-
 namespace AudioCommon
 {
 void InitSoundStream();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -956,10 +956,12 @@ void UpdateTitle(u64 elapsed_ms)
   }
 
   // Update the audio timestretcher with the current speed
-  if (g_sound_stream)
+  auto& system = Core::System::GetInstance();
+  SoundStream* sound_stream = system.GetSoundStream();
+  if (sound_stream)
   {
-    Mixer* pMixer = g_sound_stream->GetMixer();
-    pMixer->UpdateSpeed((float)Speed / 100);
+    Mixer* mixer = sound_stream->GetMixer();
+    mixer->UpdateSpeed((float)Speed / 100);
   }
 
   Host_UpdateTitle(message);

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -34,6 +34,7 @@
 #include "Core/IOS/DI/DI.h"
 #include "Core/IOS/IOS.h"
 #include "Core/Movie.h"
+#include "Core/System.h"
 
 #include "DiscIO/Blob.h"
 #include "DiscIO/DiscUtils.h"
@@ -312,7 +313,10 @@ static void DTKStreamingCallback(DIInterruptType interrupt_type, const std::vect
     // Send audio to the mixer.
     std::vector<s16> temp_pcm(s_pending_samples * 2, 0);
     ProcessDTKSamples(&temp_pcm, audio_data);
-    g_sound_stream->GetMixer()->PushStreamingSamples(temp_pcm.data(), s_pending_samples);
+
+    auto& system = Core::System::GetInstance();
+    SoundStream* sound_stream = system.GetSoundStream();
+    sound_stream->GetMixer()->PushStreamingSamples(temp_pcm.data(), s_pending_samples);
 
     if (s_stream && AudioInterface::IsPlaying())
     {

--- a/Source/Core/Core/HW/GBACore.cpp
+++ b/Source/Core/Core/HW/GBACore.cpp
@@ -30,6 +30,7 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/Host.h"
 #include "Core/NetPlayProto.h"
+#include "Core/System.h"
 
 namespace HW::GBA
 {
@@ -403,7 +404,10 @@ void Core::SetSampleRates()
   m_core->setAudioBufferSize(m_core, SAMPLES);
   blip_set_rates(m_core->getAudioChannel(m_core, 0), m_core->frequency(m_core), SAMPLE_RATE);
   blip_set_rates(m_core->getAudioChannel(m_core, 1), m_core->frequency(m_core), SAMPLE_RATE);
-  g_sound_stream->GetMixer()->SetGBAInputSampleRateDivisors(
+
+  auto& system = ::Core::System::GetInstance();
+  SoundStream* sound_stream = system.GetSoundStream();
+  sound_stream->GetMixer()->SetGBAInputSampleRateDivisors(
       m_device_number, Mixer::FIXED_SAMPLE_RATE_DIVIDEND / SAMPLE_RATE);
 }
 
@@ -436,7 +440,10 @@ void Core::SetAVStream()
     std::vector<s16> buffer(SAMPLES * 2);
     blip_read_samples(left, &buffer[0], SAMPLES, 1);
     blip_read_samples(right, &buffer[1], SAMPLES, 1);
-    g_sound_stream->GetMixer()->PushGBASamples(core->m_device_number, &buffer[0], SAMPLES);
+
+    auto& system = ::Core::System::GetInstance();
+    SoundStream* sound_stream = system.GetSoundStream();
+    sound_stream->GetMixer()->PushGBASamples(core->m_device_number, &buffer[0], SAMPLES);
   };
   m_core->setAVStream(m_core, &m_stream);
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -11,6 +11,7 @@
 #include "Common/MathUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "Core/System.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
@@ -141,11 +142,14 @@ void SpeakerLogic::SpeakerData(const u8* data, int length, float speaker_pan)
   const u32 l_volume = std::min(u32(std::min(1.f - speaker_pan, 1.f) * volume), 255u);
   const u32 r_volume = std::min(u32(std::min(1.f + speaker_pan, 1.f) * volume), 255u);
 
-  g_sound_stream->GetMixer()->SetWiimoteSpeakerVolume(l_volume, r_volume);
+  auto& system = Core::System::GetInstance();
+  SoundStream* sound_stream = system.GetSoundStream();
+
+  sound_stream->GetMixer()->SetWiimoteSpeakerVolume(l_volume, r_volume);
 
   // ADPCM sample rate is thought to be x2.(3000 x2 = 6000).
   const unsigned int sample_rate = sample_rate_dividend / reg_data.sample_rate;
-  g_sound_stream->GetMixer()->PushWiimoteSpeakerSamples(
+  sound_stream->GetMixer()->PushWiimoteSpeakerSamples(
       samples.get(), sample_length, Mixer::FIXED_SAMPLE_RATE_DIVIDEND / (sample_rate * 2));
 
 #ifdef WIIMOTE_SPEAKER_DUMP

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -3,12 +3,18 @@
 
 #include "Core/System.h"
 
+#include <memory>
+
+#include "AudioCommon/SoundStream.h"
 #include "Core/Config/MainSettings.h"
 
 namespace Core
 {
 struct System::Impl
 {
+  std::unique_ptr<SoundStream> m_sound_stream;
+  bool m_sound_stream_running = false;
+  bool m_audio_dump_started = false;
 };
 
 System::System() : m_impl{std::make_unique<Impl>()}
@@ -21,5 +27,35 @@ void System::Initialize()
 {
   m_separate_cpu_and_gpu_threads = Config::Get(Config::MAIN_CPU_THREAD);
   m_mmu_enabled = Config::Get(Config::MAIN_MMU);
+}
+
+SoundStream* System::GetSoundStream() const
+{
+  return m_impl->m_sound_stream.get();
+}
+
+void System::SetSoundStream(std::unique_ptr<SoundStream> sound_stream)
+{
+  m_impl->m_sound_stream = std::move(sound_stream);
+}
+
+bool System::IsSoundStreamRunning() const
+{
+  return m_impl->m_sound_stream_running;
+}
+
+void System::SetSoundStreamRunning(bool running)
+{
+  m_impl->m_sound_stream_running = running;
+}
+
+bool System::IsAudioDumpStarted() const
+{
+  return m_impl->m_audio_dump_started;
+}
+
+void System::SetAudioDumpStarted(bool started)
+{
+  m_impl->m_audio_dump_started = started;
 }
 }  // namespace Core

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -5,6 +5,8 @@
 
 #include <memory>
 
+class SoundStream;
+
 namespace Core
 {
 // Central class that encapsulates the running system.
@@ -30,6 +32,13 @@ public:
 
   bool IsDualCoreMode() const { return m_separate_cpu_and_gpu_threads; }
   bool IsMMUMode() const { return m_mmu_enabled; }
+
+  SoundStream* GetSoundStream() const;
+  void SetSoundStream(std::unique_ptr<SoundStream> sound_stream);
+  bool IsSoundStreamRunning() const;
+  void SetSoundStreamRunning(bool running);
+  bool IsAudioDumpStarted() const;
+  void SetAudioDumpStarted(bool started);
 
 private:
   System();

--- a/Source/Core/DolphinQt/GBAWidget.cpp
+++ b/Source/Core/DolphinQt/GBAWidget.cpp
@@ -26,6 +26,7 @@
 #include "Core/HW/SI/SI_Device.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
+#include "Core/System.h"
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Resources.h"
@@ -325,7 +326,8 @@ void GBAWidget::UpdateTitle()
 void GBAWidget::UpdateVolume()
 {
   int volume = m_muted ? 0 : m_volume * 256 / 100;
-  g_sound_stream->GetMixer()->SetGBAVolume(m_core_info.device_number, volume, volume);
+  auto& system = Core::System::GetInstance();
+  system.GetSoundStream()->GetMixer()->SetGBAVolume(m_core_info.device_number, volume, volume);
   UpdateTitle();
 }
 


### PR DESCRIPTION
Global state elimination, part 1 of too many.

I'm not 100% sure if this is the correct approach? It does require later refactoring out all the `Core::System::GetInstance()` calls into passing the class around, but that seems easier than just going directly there from the current state.