### PR TITLE
Use CMAKE_C_COMPILER_LAUNCHER to provide automatic ccache support

### DIFF
--- a/CMake/CCache.cmake
+++ b/CMake/CCache.cmake
@@ -1,10 +1,20 @@
 find_program(CCACHE_BIN NAMES ccache sccache)
 if(CCACHE_BIN)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_BIN})
+    if (NOT CMAKE_C_COMPILER_LAUNCHER)
+        set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_BIN})
 
-    # ccache uses -I when compiling without preprocessor, which makes clang complain.
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -fcolor-diagnostics")
-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+        # ccache uses -I when compiling without preprocessor, which makes clang complain.
+        if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+            set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+        endif()
     endif()
+    if (NOT CMAKE_CXX_COMPILER_LAUNCHER)
+        set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_BIN})
+
+        # ccache uses -I when compiling without preprocessor, which makes clang complain.
+        if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+            set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+        endif()
+    endif()
+
 endif()


### PR DESCRIPTION
Setting the compiler launcher to "ccache" is the recommended way of enabling ccache for the build.

If cmake is run with it defined, it causes an error when ccache tries to run:

    ccache: error: Recursive invocation (the name of the ccache binary must be "ccache")

This was because the compiler was getting invoked as `ccache ccache [COMPILER]`

Reproduced by running cmake:

    mkdir BUILD && cd BUILD &&
    cmake \
        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
        ..
    make

This results in the following error:

    ccache: error: Recursive invocation (the name of the ccache binary must be "ccache")

(This patch also takes into account the fact there might be ccache alternatives in the future, or even crazy custom settings like `distcc` & `ccache` somehow working together via the compiler launcher)