### PR TITLE
DSPLLE: Remove dead DSPSymbolDB.

### DIFF
--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -15,8 +15,6 @@
 
 namespace DSP::Symbols
 {
-DSPSymbolDB g_dsp_symbol_db;
-
 static std::map<u16, int> addr_to_line;
 static std::map<int, u16> line_to_addr;
 static std::vector<std::string> lines;
@@ -50,22 +48,6 @@ const char* GetLineText(int line)
   {
     return "----";
   }
-}
-
-Common::Symbol* DSPSymbolDB::GetSymbolFromAddr(u32 addr)
-{
-  auto it = m_functions.find(addr);
-
-  if (it != m_functions.end())
-    return &it->second;
-
-  for (auto& func : m_functions)
-  {
-    if (addr >= func.second.address && addr < func.second.address + func.second.size)
-      return &func.second;
-  }
-
-  return nullptr;
 }
 
 void AutoDisassembly(const SDSP& dsp, u16 start_addr, u16 end_addr)

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
@@ -15,16 +15,6 @@ struct SDSP;
 
 namespace DSP::Symbols
 {
-class DSPSymbolDB : public Common::SymbolDB
-{
-public:
-  DSPSymbolDB() {}
-  ~DSPSymbolDB() {}
-  Common::Symbol* GetSymbolFromAddr(u32 addr) override;
-};
-
-extern DSPSymbolDB g_dsp_symbol_db;
-
 void AutoDisassembly(const SDSP& dsp, u16 start_addr, u16 end_addr);
 
 void Clear();


### PR DESCRIPTION
Seems this was missed in #9348.