### PR TITLE
Qt: Get/Set combobox enums directly from/to USER_ROLE.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -129,8 +129,7 @@ public:
   void OnItemChanged(QTableWidgetItem* item)
   {
     QString text = item->text();
-    MemoryViewWidget::Type type =
-        static_cast<MemoryViewWidget::Type>(item->data(USER_ROLE_VALUE_TYPE).toInt());
+    MemoryViewWidget::Type type = item->data(USER_ROLE_VALUE_TYPE).value<MemoryViewWidget::Type>();
     std::vector<u8> bytes = m_view->ConvertTextToBytes(type, text);
 
     u32 address = item->data(USER_ROLE_CELL_ADDRESS).toUInt();
@@ -299,7 +298,7 @@ void MemoryViewWidget::Update()
     bp_item->setFlags(Qt::ItemIsEnabled);
     bp_item->setData(USER_ROLE_IS_ROW_BREAKPOINT_CELL, true);
     bp_item->setData(USER_ROLE_CELL_ADDRESS, row_address);
-    bp_item->setData(USER_ROLE_VALUE_TYPE, static_cast<int>(Type::Null));
+    bp_item->setData(USER_ROLE_VALUE_TYPE, QVariant::fromValue(Type::Null));
 
     m_table->setItem(i, 0, bp_item);
 
@@ -309,7 +308,7 @@ void MemoryViewWidget::Update()
     row_item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
     row_item->setData(USER_ROLE_IS_ROW_BREAKPOINT_CELL, false);
     row_item->setData(USER_ROLE_CELL_ADDRESS, row_address);
-    row_item->setData(USER_ROLE_VALUE_TYPE, static_cast<int>(Type::Null));
+    row_item->setData(USER_ROLE_VALUE_TYPE, QVariant::fromValue(Type::Null));
 
     m_table->setItem(i, 1, row_item);
 
@@ -324,7 +323,7 @@ void MemoryViewWidget::Update()
         item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setData(USER_ROLE_IS_ROW_BREAKPOINT_CELL, false);
         item->setData(USER_ROLE_CELL_ADDRESS, row_address);
-        item->setData(USER_ROLE_VALUE_TYPE, static_cast<int>(Type::Null));
+        item->setData(USER_ROLE_VALUE_TYPE, QVariant::fromValue(Type::Null));
 
         m_table->setItem(i, c, item);
       }
@@ -411,14 +410,14 @@ void MemoryViewWidget::UpdateColumns(Type type, int first_column)
           cell_item->setText(value_to_string(cell_address));
           cell_item->setData(USER_ROLE_IS_ROW_BREAKPOINT_CELL, false);
           cell_item->setData(USER_ROLE_CELL_ADDRESS, cell_address);
-          cell_item->setData(USER_ROLE_VALUE_TYPE, static_cast<int>(type));
+          cell_item->setData(USER_ROLE_VALUE_TYPE, QVariant::fromValue(type));
         }
         else
         {
           cell_item->setText(QStringLiteral("-"));
           cell_item->setData(USER_ROLE_IS_ROW_BREAKPOINT_CELL, false);
           cell_item->setData(USER_ROLE_CELL_ADDRESS, cell_address);
-          cell_item->setData(USER_ROLE_VALUE_TYPE, static_cast<int>(Type::Null));
+          cell_item->setData(USER_ROLE_VALUE_TYPE, QVariant::fromValue(type));
         }
       }
     };
@@ -815,8 +814,7 @@ void MemoryViewWidget::OnContextMenu(const QPoint& pos)
   if (!item_selected || item_selected->data(USER_ROLE_IS_ROW_BREAKPOINT_CELL).toBool())
     return;
 
-  const bool item_has_value =
-      item_selected->data(USER_ROLE_VALUE_TYPE).toInt() != static_cast<int>(Type::Null);
+  const bool item_has_value = item_selected->data(USER_ROLE_VALUE_TYPE).value<Type>() != Type::Null;
   const u32 addr = item_selected->data(USER_ROLE_CELL_ADDRESS).toUInt();
 
   auto* menu = new QMenu(this);
@@ -832,7 +830,7 @@ void MemoryViewWidget::OnContextMenu(const QPoint& pos)
   auto* copy_value = menu->addAction(tr("Copy Value"), this, [this, &pos] {
     // Re-fetch the item in case the underlying table has refreshed since the menu was opened.
     auto* item = m_table->itemAt(pos);
-    if (item && item->data(USER_ROLE_VALUE_TYPE).toInt() != static_cast<int>(Type::Null))
+    if (item && item->data(USER_ROLE_VALUE_TYPE).value<Type>() != Type::Null)
       QApplication::clipboard()->setText(item->text());
   });
   copy_value->setEnabled(item_has_value);

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -21,10 +21,10 @@ class MemoryViewWidget final : public QWidget
 {
   Q_OBJECT
 public:
-  enum class Type : int
+  enum class Type
   {
-    Null = 0,
-    Hex8 = 1,
+    Null,
+    Hex8,
     Hex16,
     Hex32,
     Hex64,

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -129,16 +129,16 @@ void MemoryWidget::CreateWidgets()
   m_input_combo = new QComboBox;
   m_input_combo->setMaxVisibleItems(20);
   // Order here determines combo list order.
-  m_input_combo->addItem(tr("Hex Byte String"), int(Type::HexString));
-  m_input_combo->addItem(tr("ASCII"), int(Type::ASCII));
-  m_input_combo->addItem(tr("Float"), int(Type::Float32));
-  m_input_combo->addItem(tr("Double"), int(Type::Double));
-  m_input_combo->addItem(tr("Unsigned 8"), int(Type::Unsigned8));
-  m_input_combo->addItem(tr("Unsigned 16"), int(Type::Unsigned16));
-  m_input_combo->addItem(tr("Unsigned 32"), int(Type::Unsigned32));
-  m_input_combo->addItem(tr("Signed 8"), int(Type::Signed8));
-  m_input_combo->addItem(tr("Signed 16"), int(Type::Signed16));
-  m_input_combo->addItem(tr("Signed 32"), int(Type::Signed32));
+  m_input_combo->addItem(tr("Hex Byte String"), QVariant::fromValue(Type::HexString));
+  m_input_combo->addItem(tr("ASCII"), QVariant::fromValue(Type::ASCII));
+  m_input_combo->addItem(tr("Float"), QVariant::fromValue(Type::Float32));
+  m_input_combo->addItem(tr("Double"), QVariant::fromValue(Type::Double));
+  m_input_combo->addItem(tr("Unsigned 8"), QVariant::fromValue(Type::Unsigned8));
+  m_input_combo->addItem(tr("Unsigned 16"), QVariant::fromValue(Type::Unsigned16));
+  m_input_combo->addItem(tr("Unsigned 32"), QVariant::fromValue(Type::Unsigned32));
+  m_input_combo->addItem(tr("Signed 8"), QVariant::fromValue(Type::Signed8));
+  m_input_combo->addItem(tr("Signed 16"), QVariant::fromValue(Type::Signed16));
+  m_input_combo->addItem(tr("Signed 32"), QVariant::fromValue(Type::Signed32));
 
   // Dump
   auto* dump_group = new QGroupBox(tr("Dump"));
@@ -194,18 +194,18 @@ void MemoryWidget::CreateWidgets()
 
   m_display_combo = new QComboBox;
   m_display_combo->setMaxVisibleItems(20);
-  m_display_combo->addItem(tr("Hex 8"), int(Type::Hex8));
-  m_display_combo->addItem(tr("Hex 16"), int(Type::Hex16));
-  m_display_combo->addItem(tr("Hex 32"), int(Type::Hex32));
-  m_display_combo->addItem(tr("Unsigned 8"), int(Type::Unsigned8));
-  m_display_combo->addItem(tr("Unsigned 16"), int(Type::Unsigned16));
-  m_display_combo->addItem(tr("Unsigned 32"), int(Type::Unsigned32));
-  m_display_combo->addItem(tr("Signed 8"), int(Type::Signed8));
-  m_display_combo->addItem(tr("Signed 16"), int(Type::Signed16));
-  m_display_combo->addItem(tr("Signed 32"), int(Type::Signed32));
-  m_display_combo->addItem(tr("ASCII"), int(Type::ASCII));
-  m_display_combo->addItem(tr("Float"), int(Type::Float32));
-  m_display_combo->addItem(tr("Double"), int(Type::Double));
+  m_display_combo->addItem(tr("Hex 8"), QVariant::fromValue(Type::Hex8));
+  m_display_combo->addItem(tr("Hex 16"), QVariant::fromValue(Type::Hex16));
+  m_display_combo->addItem(tr("Hex 32"), QVariant::fromValue(Type::Hex32));
+  m_display_combo->addItem(tr("Unsigned 8"), QVariant::fromValue(Type::Unsigned8));
+  m_display_combo->addItem(tr("Unsigned 16"), QVariant::fromValue(Type::Unsigned16));
+  m_display_combo->addItem(tr("Unsigned 32"), QVariant::fromValue(Type::Unsigned32));
+  m_display_combo->addItem(tr("Signed 8"), QVariant::fromValue(Type::Signed8));
+  m_display_combo->addItem(tr("Signed 16"), QVariant::fromValue(Type::Signed16));
+  m_display_combo->addItem(tr("Signed 32"), QVariant::fromValue(Type::Signed32));
+  m_display_combo->addItem(tr("ASCII"), QVariant::fromValue(Type::ASCII));
+  m_display_combo->addItem(tr("Float"), QVariant::fromValue(Type::Float32));
+  m_display_combo->addItem(tr("Double"), QVariant::fromValue(Type::Double));
 
   m_align_combo = new QComboBox;
   m_align_combo->addItem(tr("Fixed Alignment"));
@@ -437,7 +437,7 @@ void MemoryWidget::OnAddressSpaceChanged()
 
 void MemoryWidget::OnDisplayChanged()
 {
-  const auto type = static_cast<Type>(m_display_combo->currentData().toInt());
+  const auto type = m_display_combo->currentData().value<Type>();
   int bytes_per_row = m_row_length_combo->currentData().toInt();
   int alignment;
   bool dual_view = m_dual_check->isChecked();
@@ -524,7 +524,7 @@ void MemoryWidget::ValidateAndPreviewInputValue()
 {
   m_data_preview->clear();
   QString input_text = m_data_edit->text();
-  const auto input_type = static_cast<Type>(m_input_combo->currentData().toInt());
+  const auto input_type = m_input_combo->currentData().value<Type>();
 
   m_base_check->setEnabled(input_type == Type::Unsigned32 || input_type == Type::Signed32 ||
                            input_type == Type::Unsigned16 || input_type == Type::Signed16 ||
@@ -588,7 +588,7 @@ QByteArray MemoryWidget::GetInputData() const
   if (m_data_preview->text().isEmpty())
     return QByteArray();
 
-  const auto input_type = static_cast<Type>(m_input_combo->currentData().toInt());
+  const auto input_type = m_input_combo->currentData().value<Type>();
 
   // Ascii might be truncated, pull from data edit box.
   if (input_type == Type::ASCII)


### PR DESCRIPTION
Removes need to static_cast<int> enums.

I thought this needed Q_ENUM support, but it's working without it. I'm not sure which version of Qt this starts to work with, but should probably be used with Qt6+ only. I haven't tested on earlier versions.

Not sure if our Enums should still have the `Type : int` property.

Looking for thoughts on this. If we want it, I will do the other QWidgets that use enums too.

/edit I think the failed builds are from qt5?