### PR TITLE
Add bloom definitions for Metroid Prime 3

### DIFF
--- a/Data/Sys/Load/GraphicMods/Metroid Prime 3 - Corruption/metadata.json
+++ b/Data/Sys/Load/GraphicMods/Metroid Prime 3 - Corruption/metadata.json
@@ -1,0 +1,23 @@
+{
+	"meta":
+	{
+		"title": "Bloom Texture Definitions",
+    "author": "autofire372"
+  },
+	"groups":
+	[
+		{
+			"name": "Bloom",
+			"targets": [
+				{
+					"type": "efb",
+          "texture_filename": "efb1_n000023_320x224_4"
+        },
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000024_320x224_4"
+				}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
3x IR, mods disabled:
![RM3E01_2022-09-04_18-57-24](https://user-images.githubusercontent.com/8486750/188336688-b5036fe8-1f60-4c50-9f8a-1f0df558ecb8.png)

3x IR, native resolution bloom:
![RM3E01_2022-09-04_18-57-59](https://user-images.githubusercontent.com/8486750/188336703-0cddcc31-fbe2-4f18-9056-f2a58ee8613f.png)

3x IR, bloom disabled:
![RM3E01_2022-09-04_18-58-11](https://user-images.githubusercontent.com/8486750/188336727-fcbf3e0d-ad1d-4e71-9d94-36d35b8e247c.png)

Only tested with the standalone version of Metroid Prime 3; this may or may not work for Trilogy.