### PR TITLE
Introducing: Common Concepts and Future CppLibConcepts

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -34,6 +34,7 @@ BraceWrapping:
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false
+BreakBeforeConceptDeclarations: true
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit:     100
 CommentPragmas:  '^ (IWYU pragma:|NOLINT)'

--- a/Source/Core/Common/Align.h
+++ b/Source/Core/Common/Align.h
@@ -3,21 +3,20 @@
 #pragma once
 
 #include <cstddef>
-#include <type_traits>
+
+#include "Common/Future/CppLibConcepts.h"
 
 namespace Common
 {
-template <typename T>
+template <std::unsigned_integral T>
 constexpr T AlignUp(T value, size_t size)
 {
-  static_assert(std::is_unsigned<T>(), "T must be an unsigned value.");
   return static_cast<T>(value + (size - value % size) % size);
 }
 
-template <typename T>
+template <std::unsigned_integral T>
 constexpr T AlignDown(T value, size_t size)
 {
-  static_assert(std::is_unsigned<T>(), "T must be an unsigned value.");
   return static_cast<T>(value - value % size);
 }
 

--- a/Source/Core/Common/BitSet.h
+++ b/Source/Core/Common/BitSet.h
@@ -9,6 +9,8 @@
 
 #include "Common/CommonTypes.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace Common
 {
 // Similar to std::bitset, this is a class which encapsulates a bitset, i.e.
@@ -29,11 +31,9 @@ namespace Common
 //   operation.)
 // - Counting set bits using .Count() - see comment on that method.
 
-template <typename IntTy>
+template <std::unsigned_integral IntTy>
 class BitSet
 {
-  static_assert(!std::is_signed<IntTy>::value, "BitSet should not be used with signed types");
-
 public:
   // A reference to a particular bit, returned from operator[].
   class Ref

--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -11,6 +11,10 @@
 #include <initializer_list>
 #include <type_traits>
 
+#include "Common/Concepts.h"
+
+#include "Common/Future/CppLibConcepts.h"
+
 namespace Common
 {
 ///
@@ -113,11 +117,10 @@ constexpr Result ExtractBits(const T src) noexcept
 ///
 /// @return A bool indicating whether the mask is valid.
 ///
-template <typename T>
+template <std::unsigned_integral T>
 constexpr bool IsValidLowMask(const T mask) noexcept
 {
-  static_assert(std::is_integral<T>::value, "Mask must be an integral type.");
-  static_assert(std::is_unsigned<T>::value, "Signed masks can introduce hard to find bugs.");
+  // Signed masks can introduce hard to find bugs.
 
   // Can be efficiently determined without looping or bit counting. It's the counterpart
   // to https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
@@ -143,38 +146,28 @@ constexpr bool IsValidLowMask(const T mask) noexcept
 /// @pre Both To and From types must be the same size
 /// @pre Both To and From types must satisfy the TriviallyCopyable concept.
 ///
-template <typename To, typename From>
+template <TriviallyCopyable To, TriviallyCopyable From>
 inline To BitCast(const From& source) noexcept
 {
   static_assert(sizeof(From) == sizeof(To),
                 "BitCast source and destination types must be equal in size.");
-  static_assert(std::is_trivially_copyable<From>(),
-                "BitCast source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<To>(),
-                "BitCast destination type must be trivially copyable.");
 
   alignas(To) std::byte storage[sizeof(To)];
   std::memcpy(&storage, &source, sizeof(storage));
   return reinterpret_cast<To&>(storage);
 }
 
-template <typename T, typename PtrType>
+template <TriviallyCopyable T, TriviallyCopyable PtrType>
 class BitCastPtrType
 {
 public:
-  static_assert(std::is_trivially_copyable<PtrType>(),
-                "BitCastPtr source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastPtr destination type must be trivially copyable.");
-
   explicit BitCastPtrType(PtrType* ptr) : m_ptr(ptr) {}
 
   // Enable operator= only for pointers to non-const data
-  template <typename S>
-  inline typename std::enable_if<std::is_same<S, T>() && !std::is_const<PtrType>()>::type
-  operator=(const S& source)
+  inline BitCastPtrType& operator=(const T& source) requires NotConst<PtrType>
   {
     std::memcpy(m_ptr, &source, sizeof(source));
+    return *this;
   }
 
   inline operator T() const
@@ -199,46 +192,34 @@ inline auto BitCastPtr(PtrType* ptr) noexcept -> BitCastPtrType<T, PtrType>
 }
 
 // Similar to BitCastPtr, but specifically for aliasing structs to arrays.
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
+template <typename ArrayType, TriviallyCopyable T,
+          TriviallyCopyable Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
 inline auto BitCastToArray(const T& obj) noexcept -> Container
 {
   static_assert(sizeof(T) % sizeof(ArrayType) == 0,
                 "Size of array type must be a factor of size of source type.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastToArray source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastToArray array type must be trivially copyable.");
 
   Container result;
   std::memcpy(result.data(), &obj, sizeof(T));
   return result;
 }
 
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
+template <typename ArrayType, TriviallyCopyable T,
+          TriviallyCopyable Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
 inline void BitCastFromArray(const Container& array, T& obj) noexcept
 {
   static_assert(sizeof(T) % sizeof(ArrayType) == 0,
                 "Size of array type must be a factor of size of destination type.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastFromArray array type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastFromArray destination type must be trivially copyable.");
 
   std::memcpy(&obj, array.data(), sizeof(T));
 }
 
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
+template <typename ArrayType, TriviallyCopyable T,
+          TriviallyCopyable Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
 inline auto BitCastFromArray(const Container& array) noexcept -> T
 {
   static_assert(sizeof(T) % sizeof(ArrayType) == 0,
                 "Size of array type must be a factor of size of destination type.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastFromArray array type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastFromArray destination type must be trivially copyable.");
 
   T obj;
   std::memcpy(&obj, array.data(), sizeof(T));
@@ -304,11 +285,9 @@ public:
 
 // Left-shift a value and set new LSBs to that of the supplied LSB.
 // Converts a value from a N-bit range to an (N+X)-bit range. e.g. 0x101 -> 0x10111
-template <typename T>
+template <std::unsigned_integral T>
 T ExpandValue(T value, size_t left_shift_amount)
 {
-  static_assert(std::is_unsigned<T>(), "ExpandValue is only sane on unsigned types.");
-
   return (value << left_shift_amount) |
          (T(-ExtractBit<0>(value)) >> (BitSize<T>() - left_shift_amount));
 }

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(common
   CommonFuncs.h
   CommonPaths.h
   CommonTypes.h
+  Concepts.h
   Config/Config.cpp
   Config/Config.h
   Config/ConfigInfo.cpp
@@ -58,6 +59,7 @@ add_library(common
   FloatUtils.h
   FormatUtil.h
   FPURoundMode.h
+  Future/CppLibConcepts.h
   GekkoDisassembler.cpp
   GekkoDisassembler.h
   Hash.cpp

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -21,7 +21,6 @@
 #include <optional>
 #include <set>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -29,6 +28,7 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/EnumMap.h"
 #include "Common/Flag.h"
 #include "Common/Inline.h"
@@ -195,13 +195,13 @@ public:
     DoArray(x.data(), static_cast<u32>(x.size()));
   }
 
-  template <typename T, typename std::enable_if_t<std::is_trivially_copyable_v<T>, int> = 0>
+  template <Common::TriviallyCopyable T>
   void DoArray(T* x, u32 count)
   {
     DoVoid(x, count * sizeof(T));
   }
 
-  template <typename T, typename std::enable_if_t<!std::is_trivially_copyable_v<T>, int> = 0>
+  template <Common::NotTriviallyCopyable T>
   void DoArray(T* x, u32 count)
   {
     for (u32 i = 0; i < count; ++i)
@@ -262,10 +262,9 @@ public:
       atomic.store(temp, std::memory_order_relaxed);
   }
 
-  template <typename T>
+  template <Common::TriviallyCopyable T>
   void Do(T& x)
   {
-    static_assert(std::is_trivially_copyable_v<T>, "Only sane for trivially copyable types");
     // Note:
     // Usually we can just use x = **ptr, etc.  However, this doesn't work
     // for unions containing BitFields (long story, stupid language rules)

--- a/Source/Core/Common/Concepts.h
+++ b/Source/Core/Common/Concepts.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: CC0-1.0
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "Common/TypeUtils.h"
+
+#include "Common/Future/CppLibConcepts.h"
+
+namespace Common
+{
+template <class T>
+concept TriviallyCopyable = std::is_trivially_copyable<T>::value;
+
+template <class T>
+concept NotTriviallyCopyable = !TriviallyCopyable<T>;
+
+template <class T>
+concept Const = std::is_const<T>::value;
+
+template <class T>
+concept NotConst = !Const<T>;
+
+template <class T>
+concept Enumerated = std::is_enum<T>::value;
+
+template <class T>
+concept NotEnumerated = !Enumerated<T>;
+
+template <class T>
+concept Class = std::is_class<T>::value;
+
+template <class T>
+concept Union = std::is_union<T>::value;
+
+template <class T>
+concept Arithmetic = std::is_arithmetic<T>::value;
+
+template <class T>
+concept Pointer = std::is_pointer<T>::value;
+
+template <class T>
+concept Function = std::is_function<T>::value;
+
+template <class T>
+concept FunctionPointer = Function<std::remove_pointer_t<T>>;
+
+template <class T>
+concept IntegralOrEnum = std::integral<T> || Enumerated<T>;
+
+template <class T, class U>
+concept UnderlyingSameAs = std::same_as<std::underlying_type_t<T>, U>;
+
+template <class T, class U>
+concept SameAsOrUnderlyingSameAs = std::same_as<T, U> || UnderlyingSameAs<T, U>;
+
+template <size_t N, class... Ts>
+concept CountOfTypes = IsCountOfTypes<N, Ts...>::value;
+
+template <class T, class... Ts>
+concept ConvertibleFromAllOf = IsConvertibleFromAllOf<T, Ts...>::value;
+
+template <class T, class... Ts>
+concept SameAsAnyOf = IsSameAsAnyOf<T, Ts...>::value;
+};  // namespace Common

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -10,17 +10,11 @@
 #include <utility>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Config/Enums.h"
 
 namespace Config
 {
-namespace detail
-{
-// std::underlying_type may only be used with enum types, so make sure T is an enum type first.
-template <typename T>
-using UnderlyingType = typename std::enable_if_t<std::is_enum<T>{}, std::underlying_type<T>>::type;
-}  // namespace detail
-
 struct Location
 {
   System system{};
@@ -55,9 +49,8 @@ public:
 
   // Make it easy to convert Info<Enum> into Info<UnderlyingType<Enum>>
   // so that enum settings can still easily work with code that doesn't care about the enum values.
-  template <typename Enum,
-            std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
-  Info(const Info<Enum>& other)
+  template <Common::Enumerated Enum>
+  Info(const Info<Enum>& other) requires Common::UnderlyingSameAs<Enum, T>
   {
     *this = other;
   }
@@ -81,9 +74,8 @@ public:
 
   // Make it easy to convert Info<Enum> into Info<UnderlyingType<Enum>>
   // so that enum settings can still easily work with code that doesn't care about the enum values.
-  template <typename Enum,
-            std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
-  Info<T>& operator=(const Info<Enum>& other)
+  template <Common::Enumerated Enum>
+  Info<T>& operator=(const Info<Enum>& other) requires Common::UnderlyingSameAs<Enum, T>
   {
     m_location = other.GetLocation();
     m_default_value = static_cast<T>(other.GetDefaultValue());

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "Common/Concepts.h"
 #include "Common/Config/ConfigInfo.h"
 #include "Common/Config/Enums.h"
 #include "Common/StringUtil.h"
@@ -18,7 +19,7 @@ namespace Config
 {
 namespace detail
 {
-template <typename T, std::enable_if_t<!std::is_enum<T>::value>* = nullptr>
+template <Common::NotEnumerated T>
 std::optional<T> TryParse(const std::string& str_value)
 {
   T value;
@@ -27,7 +28,7 @@ std::optional<T> TryParse(const std::string& str_value)
   return value;
 }
 
-template <typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+template <Common::Enumerated T>
 std::optional<T> TryParse(const std::string& str_value)
 {
   const auto result = TryParse<std::underlying_type_t<T>>(str_value);

--- a/Source/Core/Common/Crypto/SHA1.h
+++ b/Source/Core/Common/Crypto/SHA1.h
@@ -7,11 +7,11 @@
 #include <limits>
 #include <memory>
 #include <string_view>
-#include <type_traits>
 #include <vector>
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 
 namespace Common::SHA1
 {
@@ -32,10 +32,9 @@ std::unique_ptr<Context> CreateContext();
 
 Digest CalculateDigest(const u8* msg, size_t len);
 
-template <typename T>
+template <TriviallyCopyable T>
 inline Digest CalculateDigest(const std::vector<T>& msg)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   ASSERT(std::numeric_limits<size_t>::max() / sizeof(T) >= msg.size());
   return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), sizeof(T) * msg.size());
 }
@@ -45,10 +44,9 @@ inline Digest CalculateDigest(const std::string_view& msg)
   return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), msg.size());
 }
 
-template <typename T, size_t Size>
+template <TriviallyCopyable T, size_t Size>
 inline Digest CalculateDigest(const std::array<T, Size>& msg)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), sizeof(msg));
 }
 }  // namespace Common::SHA1

--- a/Source/Core/Common/EnumMap.h
+++ b/Source/Core/Common/EnumMap.h
@@ -6,7 +6,7 @@
 #include <array>
 #include <type_traits>
 
-#include "Common/TypeUtils.h"
+#include "Common/Concepts.h"
 
 template <std::size_t position, std::size_t bits, typename T, typename StorageType>
 struct BitField;
@@ -36,9 +36,9 @@ public:
   constexpr EnumMap(EnumMap&& other) = default;
   constexpr EnumMap& operator=(EnumMap&& other) = default;
 
-  // Constructor that accepts exactly size Vs (enforcing that all must be specified).
-  template <typename... T, typename = std::enable_if_t<Common::IsNOf<V, s_size, T...>::value>>
-  constexpr EnumMap(T... values) : m_array{static_cast<V>(values)...}
+  template <typename... Ts>
+  constexpr EnumMap(Ts... values) requires CountOfTypes<s_size, Ts...> &&
+      ConvertibleFromAllOf<V, Ts...> : m_array{static_cast<V>(values)...}
   {
   }
 

--- a/Source/Core/Common/FormatUtil.h
+++ b/Source/Core/Common/FormatUtil.h
@@ -8,6 +8,13 @@
 
 namespace Common
 {
+template <class T>
+#if FMT_VERSION >= 90000
+concept FmtCompileString = fmt::detail::is_compile_string<T>::value;
+#else
+concept FmtCompileString = fmt::is_compile_string<T>::value;
+#endif
+
 constexpr std::size_t CountFmtReplacementFields(std::string_view s)
 {
   std::size_t count = 0;

--- a/Source/Core/Common/Future/CppLibConcepts.h
+++ b/Source/Core/Common/Future/CppLibConcepts.h
@@ -1,0 +1,40 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <version>
+
+// C++20 Standard Library support in the Android NDK is lacking.  However, the core language feature
+// of concepts works fine in all environments Dolphin Emulator currently supports.  Please replace
+// the usage of this header with the C++ Standard Library equivalent as soon as is possible.
+
+#ifdef __cpp_lib_concepts
+#include <concepts>
+#else
+#include <type_traits>
+namespace std
+{
+// Technically inaccurate because we haven't defined *all* of the standard concepts
+#define __cpp_lib_concepts 202002L
+
+template <class T, class U>
+concept same_as = std::is_same_v<T, U> && std::is_same_v<U, T>;
+
+template <class T>
+concept integral = std::is_integral_v<T>;
+
+template <class T>
+concept signed_integral = integral<T> && std::is_signed_v<T>;
+
+template <class T>
+concept unsigned_integral = integral<T> && std::is_unsigned_v<T>;
+
+template <class T>
+concept floating_point = std::is_floating_point_v<T>;
+
+template <class Derived, class Base>
+concept derived_from = std::is_base_of_v<Base, Derived> &&
+    std::is_convertible_v<const volatile Derived*, const volatile Base*>;
+};  // namespace std
+#endif

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -7,9 +7,9 @@
 #include <cstring>
 #include <memory>
 #include <string>
-#include <type_traits>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/IOFile.h"
 #include "Common/Version.h"
 
@@ -29,7 +29,7 @@
 
 namespace Common
 {
-template <typename K, typename V>
+template <Common::TriviallyCopyable K, typename V>
 class LinearDiskCacheReader
 {
 public:
@@ -48,17 +48,14 @@ public:
 // K and V are some POD type
 // K : the key type
 // V : value array type
-template <typename K, typename V>
+// Since we're reading/writing directly to the storage of K instances, K must be trivially copyable.
+template <Common::TriviallyCopyable K, typename V>
 class LinearDiskCache
 {
 public:
   // return number of read entries
   u32 OpenAndRead(const std::string& filename, LinearDiskCacheReader<K, V>& reader)
   {
-    // Since we're reading/writing directly to the storage of K instances,
-    // K must be trivially copyable.
-    static_assert(std::is_trivially_copyable<K>::value, "K must be a trivially copyable type");
-
     // close any currently opened file
     Close();
     m_num_entries = 0;

--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -91,7 +91,7 @@ static const char LOG_LEVEL_TO_CHAR[7] = "-NEWID";
 void GenericLogFmtImpl(LogLevel level, LogType type, const char* file, int line,
                        fmt::string_view format, const fmt::format_args& args);
 
-template <std::size_t NumFields, typename S, typename... Args>
+template <std::size_t NumFields, FmtCompileString S, typename... Args>
 void GenericLogFmt(LogLevel level, LogType type, const char* file, int line, const S& format,
                    const Args&... args)
 {

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -11,6 +11,8 @@
 
 #include "Common/CommonTypes.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace MathUtil
 {
 constexpr double TAU = 6.2831853071795865;
@@ -31,11 +33,9 @@ constexpr auto Lerp(const T& x, const T& y, const F& a) -> decltype(x + (y - x) 
 
 // Casts the specified value to a Dest. The value will be clamped to fit in the destination type.
 // Warning: The result of SaturatingCast(NaN) is undefined.
-template <typename Dest, typename T>
+template <std::integral Dest, typename T>
 constexpr Dest SaturatingCast(T value)
 {
-  static_assert(std::is_integral<Dest>());
-
   [[maybe_unused]] constexpr Dest lo = std::numeric_limits<Dest>::lowest();
   constexpr Dest hi = std::numeric_limits<Dest>::max();
 

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -34,23 +34,18 @@ void RegisterStringTranslator(StringTranslator translator);
 bool MsgAlertFmtImpl(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                      int line, fmt::string_view format, const fmt::format_args& args);
 
-template <std::size_t NumFields, typename S, typename... Args>
+template <std::size_t NumFields, FmtCompileString S, typename... Args>
 bool MsgAlertFmt(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                  int line, const S& format, const Args&... args)
 {
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
-  static_assert(fmt::detail::is_compile_string<S>::value);
-#else
-  static_assert(fmt::is_compile_string<S>::value);
-#endif
   return MsgAlertFmtImpl(yes_no, style, log_type, file, line, format,
                          fmt::make_format_args(args...));
 }
 
-template <std::size_t NumFields, bool has_non_positional_args, typename S, typename... Args>
+template <std::size_t NumFields, bool has_non_positional_args, FmtCompileString S, typename... Args>
 bool MsgAlertFmtT(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                   int line, const S& format, fmt::string_view translated_format,
                   const Args&... args)
@@ -60,11 +55,6 @@ bool MsgAlertFmtT(bool yes_no, MsgType style, Common::Log::LogType log_type, con
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
-  static_assert(fmt::detail::is_compile_string<S>::value);
-#else
-  static_assert(fmt::is_compile_string<S>::value);
-#endif
   auto arg_list = fmt::make_format_args(args...);
   return MsgAlertFmtImpl(yes_no, style, log_type, file, line, translated_format, arg_list);
 }

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 
 #include "Common/BitUtils.h"
+#include "Common/Concepts.h"
 #include "Common/Random.h"
 #include "Common/StringUtil.h"
 
@@ -315,10 +316,9 @@ u16 ComputeTCPNetworkChecksum(const IPAddress& from, const IPAddress& to, const 
   return htons(static_cast<u16>(tcp_checksum));
 }
 
-template <typename Container, typename T>
+template <typename Container, Common::TriviallyCopyable T>
 static inline void InsertObj(Container* container, const T& obj)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   const u8* const ptr = reinterpret_cast<const u8*>(&obj);
   container->insert(container->end(), ptr, ptr + sizeof(obj));
 }

--- a/Source/Core/Common/Random.h
+++ b/Source/Core/Common/Random.h
@@ -5,9 +5,9 @@
 
 #include <cstddef>
 #include <memory>
-#include <type_traits>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 
 namespace Common::Random
 {
@@ -15,10 +15,9 @@ namespace Common::Random
 void Generate(void* buffer, std::size_t size);
 
 /// Generates a random value of arithmetic type `T`
-template <typename T>
+template <Arithmetic T>
 T GenerateValue()
 {
-  static_assert(std::is_arithmetic<T>(), "T must be an arithmetic type in GenerateValue.");
   T value;
   Generate(&value, sizeof(value));
   return value;

--- a/Source/Core/Common/SFMLHelper.h
+++ b/Source/Core/Common/SFMLHelper.h
@@ -8,13 +8,14 @@
 #include <SFML/Network/Packet.hpp>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Swap.h"
 
 sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u16>& data);
 sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u32>& data);
 sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u64>& data);
 
-template <typename Enum, std::enable_if_t<std::is_enum_v<Enum>>* = nullptr>
+template <Common::Enumerated Enum>
 sf::Packet& operator<<(sf::Packet& packet, Enum e)
 {
   using Underlying = std::underlying_type_t<Enum>;
@@ -22,7 +23,7 @@ sf::Packet& operator<<(sf::Packet& packet, Enum e)
   return packet;
 }
 
-template <typename Enum, std::enable_if_t<std::is_enum_v<Enum>>* = nullptr>
+template <Common::Enumerated Enum>
 sf::Packet& operator>>(sf::Packet& packet, Enum& e)
 {
   using Underlying = std::underlying_type_t<Enum>;

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -16,6 +16,9 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
+
+#include "Common/Future/CppLibConcepts.h"
 
 std::string StringFromFormatV(const char* format, va_list args);
 
@@ -54,7 +57,7 @@ void TruncateToCString(std::string* s);
 
 bool TryParse(const std::string& str, bool* output);
 
-template <typename T, std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>* = nullptr>
+template <Common::IntegralOrEnum T>
 bool TryParse(const std::string& str, T* output, int base = 0)
 {
   char* end_ptr = nullptr;
@@ -92,7 +95,7 @@ bool TryParse(const std::string& str, T* output, int base = 0)
   return true;
 }
 
-template <typename T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
+template <std::floating_point T>
 bool TryParse(std::string str, T* const output)
 {
   // Replace commas with dots.
@@ -138,7 +141,7 @@ std::string ValueToString(double value);
 std::string ValueToString(int value);
 std::string ValueToString(s64 value);
 std::string ValueToString(bool value);
-template <typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+template <Common::Enumerated T>
 std::string ValueToString(T value)
 {
   return ValueToString(static_cast<std::underlying_type_t<T>>(value));

--- a/Source/Core/Common/Swap.h
+++ b/Source/Core/Common/Swap.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstring>
-#include <type_traits>
 
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
@@ -17,6 +16,7 @@
 #endif
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 
 namespace Common
 {
@@ -157,19 +157,16 @@ inline void swap<8>(u8* data)
   std::memcpy(data, &value, sizeof(u64));
 }
 
-template <typename T>
+template <Arithmetic T>
 inline T FromBigEndian(T data)
 {
-  static_assert(std::is_arithmetic<T>::value, "function only makes sense with arithmetic types");
-
   swap<sizeof(data)>(reinterpret_cast<u8*>(&data));
   return data;
 }
 
-template <typename value_type>
+template <Arithmetic value_type>
 struct BigEndianValue
 {
-  static_assert(std::is_arithmetic<value_type>(), "value_type must be an arithmetic type");
   BigEndianValue() = default;
   explicit BigEndianValue(value_type val) { *this = val; }
   operator value_type() const { return FromBigEndian(raw); }

--- a/Source/Core/Common/TypeUtils.h
+++ b/Source/Core/Common/TypeUtils.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <type_traits>
 
@@ -67,21 +68,23 @@ static_assert(std::is_same_v<ObjectType<&Bar::c>, Foo>);
 static_assert(!std::is_same_v<ObjectType<&Bar::c>, Bar>);
 }  // namespace detail
 
-// Template for checking if Types is count occurrences of T.
-template <typename T, size_t count, typename... Ts>
-struct IsNOf : std::integral_constant<bool, std::conjunction_v<std::is_convertible<Ts, T>...> &&
-                                                sizeof...(Ts) == count>
+// Type trait for checking if the size of Types is equal to N
+template <std::size_t N, typename... Ts>
+struct IsCountOfTypes : std::bool_constant<sizeof...(Ts) == N>
 {
 };
 
-static_assert(IsNOf<int, 0>::value);
-static_assert(!IsNOf<int, 0, int>::value);
-static_assert(IsNOf<int, 1, int>::value);
-static_assert(!IsNOf<int, 1>::value);
-static_assert(!IsNOf<int, 1, int, int>::value);
-static_assert(IsNOf<int, 2, int, int>::value);
-static_assert(IsNOf<int, 2, int, short>::value);  // Type conversions ARE allowed
-static_assert(!IsNOf<int, 2, int, char*>::value);
+// Type trait for checking if all of the given Types are convertible to T
+template <typename T, typename... Ts>
+struct IsConvertibleFromAllOf : std::conjunction<std::is_convertible<Ts, T>...>
+{
+};
+
+// Type trait for checking if any of the given Types are the same as T
+template <typename T, typename... Ts>
+struct IsSameAsAnyOf : std::disjunction<std::is_same<Ts, T>...>
+{
+};
 
 // TODO: This can be replaced with std::array's fill() once C++20 is fully supported.
 // Prior to C++20, std::array's fill() function is, unfortunately, not constexpr.

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -9,12 +9,12 @@
 #include <cstring>
 #include <functional>
 #include <tuple>
-#include <type_traits>
 
 #include "Common/Assert.h"
 #include "Common/BitSet.h"
 #include "Common/CodeBlock.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/x64ABI.h"
 
 namespace Gen
@@ -979,13 +979,9 @@ public:
   // Utility functions
   // The difference between this and CALL is that this aligns the stack
   // where appropriate.
-  template <typename FunctionPointer>
-  void ABI_CallFunction(FunctionPointer func)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunction(T func)
   {
-    static_assert(std::is_pointer<FunctionPointer>() &&
-                      std::is_function<std::remove_pointer_t<FunctionPointer>>(),
-                  "Supplied type must be a function pointer.");
-
     const void* ptr = reinterpret_cast<const void*>(func);
     const u64 address = reinterpret_cast<u64>(ptr);
     const u64 distance = address - (reinterpret_cast<u64>(code) + 5);
@@ -1002,46 +998,46 @@ public:
     }
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionC16(FunctionPointer func, u16 param1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionC16(T func, u16 param1)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCC16(FunctionPointer func, u32 param1, u16 param2)
-  {
-    MOV(32, R(ABI_PARAM1), Imm32(param1));
-    MOV(32, R(ABI_PARAM2), Imm32(param2));
-    ABI_CallFunction(func);
-  }
-
-  template <typename FunctionPointer>
-  void ABI_CallFunctionC(FunctionPointer func, u32 param1)
-  {
-    MOV(32, R(ABI_PARAM1), Imm32(param1));
-    ABI_CallFunction(func);
-  }
-
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCC(FunctionPointer func, u32 param1, u32 param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCC16(T func, u32 param1, u16 param2)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCP(FunctionPointer func, u32 param1, const void* param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionC(T func, u32 param1)
+  {
+    MOV(32, R(ABI_PARAM1), Imm32(param1));
+    ABI_CallFunction(func);
+  }
+
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCC(T func, u32 param1, u32 param2)
+  {
+    MOV(32, R(ABI_PARAM1), Imm32(param1));
+    MOV(32, R(ABI_PARAM2), Imm32(param2));
+    ABI_CallFunction(func);
+  }
+
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCP(T func, u32 param1, const void* param2)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(64, R(ABI_PARAM2), Imm64(reinterpret_cast<u64>(param2)));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCCC(FunctionPointer func, u32 param1, u32 param2, u32 param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCCC(T func, u32 param1, u32 param2, u32 param3)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
@@ -1049,8 +1045,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCCP(FunctionPointer func, u32 param1, u32 param2, const void* param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCCP(T func, u32 param1, u32 param2, const void* param3)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
@@ -1058,9 +1054,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCCCP(FunctionPointer func, u32 param1, u32 param2, u32 param3,
-                            const void* param4)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCCCP(T func, u32 param1, u32 param2, u32 param3, const void* param4)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
@@ -1069,23 +1064,23 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionP(FunctionPointer func, const void* param1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionP(T func, const void* param1)
   {
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(param1)));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPC(FunctionPointer func, const void* param1, u32 param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPC(T func, const void* param1, u32 param2)
   {
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(param1)));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPPC(FunctionPointer func, const void* param1, const void* param2, u32 param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPPC(T func, const void* param1, const void* param2, u32 param3)
   {
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(param1)));
     MOV(64, R(ABI_PARAM2), Imm64(reinterpret_cast<u64>(param2)));
@@ -1094,8 +1089,8 @@ public:
   }
 
   // Pass a register as a parameter.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionR(FunctionPointer func, X64Reg reg1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionR(T func, X64Reg reg1)
   {
     if (reg1 != ABI_PARAM1)
       MOV(32, R(ABI_PARAM1), R(reg1));
@@ -1103,8 +1098,8 @@ public:
   }
 
   // Pass a pointer and register as a parameter.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPR(FunctionPointer func, const void* ptr, X64Reg reg1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPR(T func, const void* ptr, X64Reg reg1)
   {
     if (reg1 != ABI_PARAM2)
       MOV(64, R(ABI_PARAM2), R(reg1));
@@ -1113,24 +1108,24 @@ public:
   }
 
   // Pass two registers as parameters.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionRR(FunctionPointer func, X64Reg reg1, X64Reg reg2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionRR(T func, X64Reg reg1, X64Reg reg2)
   {
     MOVTwo(64, ABI_PARAM1, reg1, 0, ABI_PARAM2, reg2);
     ABI_CallFunction(func);
   }
 
   // Pass a pointer and two registers as parameters.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPRR(FunctionPointer func, const void* ptr, X64Reg reg1, X64Reg reg2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPRR(T func, const void* ptr, X64Reg reg1, X64Reg reg2)
   {
     MOVTwo(64, ABI_PARAM2, reg1, 0, ABI_PARAM3, reg2);
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(ptr)));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionAC(int bits, FunctionPointer func, const Gen::OpArg& arg1, u32 param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionAC(int bits, T func, const Gen::OpArg& arg1, u32 param2)
   {
     if (!arg1.IsSimpleReg(ABI_PARAM1))
       MOV(bits, R(ABI_PARAM1), arg1);
@@ -1138,9 +1133,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPAC(int bits, FunctionPointer func, const void* ptr1, const Gen::OpArg& arg2,
-                           u32 param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPAC(int bits, T func, const void* ptr1, const Gen::OpArg& arg2, u32 param3)
   {
     if (!arg2.IsSimpleReg(ABI_PARAM2))
       MOV(bits, R(ABI_PARAM2), arg2);
@@ -1149,8 +1143,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionA(int bits, FunctionPointer func, const Gen::OpArg& arg1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionA(int bits, T func, const Gen::OpArg& arg1)
   {
     if (!arg1.IsSimpleReg(ABI_PARAM1))
       MOV(bits, R(ABI_PARAM1), arg1);

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -14,6 +14,7 @@
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
+#include "Common/Concepts.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Core.h"
@@ -59,10 +60,9 @@ Cheats::DataType Cheats::GetDataType(const Cheats::SearchValue& value)
   return static_cast<DataType>(value.m_value.index());
 }
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 static std::vector<u8> ToByteVector(const T& val)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   const auto* const begin = reinterpret_cast<const u8*>(&val);
   const auto* const end = begin + sizeof(T);
   return {begin, end};

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -5,9 +5,9 @@
 
 #include <array>
 #include <cstddef>
-#include <type_traits>
 #include <variant>
 
+#include "Common/Concepts.h"
 #include "Common/x64Emitter.h"
 #include "Core/PowerPC/Jit64/RegCache/CachedReg.h"
 #include "Core/PowerPC/PPCAnalyst.h"
@@ -119,6 +119,9 @@ private:
   std::array<X64CachedReg, NUM_XREGS> m_xregs;
 };
 
+template <class T>
+concept RegCacheConstraint = Common::SameAsAnyOf<T, RCOpArg, RCX64Reg>;
+
 class RegCache
 {
 public:
@@ -135,17 +138,15 @@ public:
   void SetEmitter(Gen::XEmitter* emitter);
   bool SanityCheck() const;
 
-  template <typename... Ts>
+  template <RegCacheConstraint... Ts>
   static void Realize(Ts&... rc)
   {
-    static_assert(((std::is_same<Ts, RCOpArg>() || std::is_same<Ts, RCX64Reg>()) && ...));
     (rc.Realize(), ...);
   }
 
-  template <typename... Ts>
+  template <RegCacheConstraint... Ts>
   static void Unlock(Ts&... rc)
   {
-    static_assert(((std::is_same<Ts, RCOpArg>() || std::is_same<Ts, RCX64Reg>()) && ...));
     (rc.Unlock(), ...);
   }
 

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -50,6 +50,8 @@
 
 #include "VideoCommon/VideoBackendBase.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace PowerPC
 {
 MMU::MMU(Core::System& system, Memory::MemoryManager& memory, PowerPC::PowerPCManager& power_pc)
@@ -145,7 +147,7 @@ static void EFB_Write(u32 data, u32 addr)
   }
 }
 
-template <XCheckTLBFlag flag, typename T, bool never_translate>
+template <XCheckTLBFlag flag, std::integral T, bool never_translate>
 T MMU::ReadFromHardware(u32 em_address)
 {
   const u32 em_address_start_page = em_address & ~HW_PAGE_MASK;
@@ -593,7 +595,7 @@ u64 MMU::Read_U64(const u32 address)
   return var;
 }
 
-template <typename T>
+template <std::integral T>
 std::optional<ReadResult<T>> MMU::HostTryReadUX(const Core::CPUThreadGuard& guard,
                                                 const u32 address, RequestedAddressSpace space)
 {

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -11,6 +11,8 @@
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace Core
 {
 class CPUThreadGuard;
@@ -303,14 +305,14 @@ private:
   void UpdateBATs(BatTable& bat_table, u32 base_spr);
   void UpdateFakeMMUBat(BatTable& bat_table, u32 start_addr);
 
-  template <XCheckTLBFlag flag, typename T, bool never_translate = false>
+  template <XCheckTLBFlag flag, std::integral T, bool never_translate = false>
   T ReadFromHardware(u32 em_address);
   template <XCheckTLBFlag flag, bool never_translate = false>
   void WriteToHardware(u32 em_address, const u32 data, const u32 size);
   template <XCheckTLBFlag flag>
   bool IsRAMAddress(u32 address, bool translate);
 
-  template <typename T>
+  template <std::integral T>
   static std::optional<ReadResult<T>> HostTryReadUX(const Core::CPUThreadGuard& guard,
                                                     const u32 address, RequestedAddressSpace space);
   static std::optional<WriteResult> HostTryWriteUX(const Core::CPUThreadGuard& guard, const u32 var,

--- a/Source/Core/DiscIO/TGCBlob.cpp
+++ b/Source/Core/DiscIO/TGCBlob.cpp
@@ -6,10 +6,10 @@
 #include <algorithm>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
+#include "Common/Concepts.h"
 #include "Common/IOFile.h"
 #include "Common/Swap.h"
 
@@ -33,11 +33,9 @@ void Replace(u64 offset, u64 size, u8* out_ptr, u64 replace_offset, u64 replace_
   }
 }
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 void Replace(u64 offset, u64 size, u8* out_ptr, u64 replace_offset, const T& replace_value)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
-
   const u8* replace_ptr = reinterpret_cast<const u8*>(&replace_value);
   Replace(offset, size, out_ptr, replace_offset, sizeof(T), replace_ptr);
 }

--- a/Source/Core/DiscIO/Volume.cpp
+++ b/Source/Core/DiscIO/Volume.cpp
@@ -8,11 +8,11 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Crypto/SHA1.h"
 #include "Common/StringUtil.h"
 
@@ -31,10 +31,9 @@ const IOS::ES::TicketReader Volume::INVALID_TICKET{};
 const IOS::ES::TMDReader Volume::INVALID_TMD{};
 const std::vector<u8> Volume::INVALID_CERT_CHAIN{};
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 static void AddToSyncHash(Common::SHA1::Context* context, const T& data)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   context->Update(reinterpret_cast<const u8*>(&data), sizeof(data));
 }
 

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -20,6 +20,7 @@
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Crypto/SHA1.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -47,11 +48,9 @@ static void PushBack(std::vector<u8>* vector, const u8* begin, const u8* end)
   std::copy(begin, end, vector->data() + offset_in_vector);
 }
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 static void PushBack(std::vector<u8>* vector, const T& x)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
-
   const u8* x_ptr = reinterpret_cast<const u8*>(&x);
   PushBack(vector, x_ptr, x_ptr + sizeof(T));
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -16,21 +16,11 @@
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
 namespace ControllerEmu
 {
-class Control;
-
-class NumericSettingBase;
-struct NumericSettingDetails;
-
-template <typename T>
-class NumericSetting;
-
-template <typename T>
-class SettingValue;
-
 using InputOverrideFunction = std::function<std::optional<ControlState>(
     const std::string_view group_name, const std::string_view control_name, ControlState state)>;
 
@@ -79,7 +69,7 @@ public:
   void AddInput(Translatability translate, std::string name, std::string ui_name);
   void AddOutput(Translatability translate, std::string name);
 
-  template <typename T>
+  template <SettingConstraint T>
   void AddSetting(SettingValue<T>* value, const NumericSettingDetails& details,
                   std::common_type_t<T> default_value_, std::common_type_t<T> min_value = {},
                   std::common_type_t<T> max_value = T(100))

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -18,6 +18,8 @@
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 class ControllerInterface;
 
 constexpr const char* DIRECTION_UP = _trans("Up");
@@ -210,17 +212,10 @@ public:
   std::vector<std::unique_ptr<ControlGroup>> groups;
 
   // Maps a float from -1.0..+1.0 to an integer in the provided range.
-  template <typename T, typename F>
+  template <std::integral T, std::floating_point F>
   static T MapFloat(F input_value, T zero_value, T neg_1_value = std::numeric_limits<T>::min(),
                     T pos_1_value = std::numeric_limits<T>::max())
   {
-    static_assert(std::is_integral<T>(), "T is only sane for int types.");
-    static_assert(std::is_floating_point<F>(), "F is only sane for float types.");
-
-    static_assert(std::numeric_limits<long long>::min() <= std::numeric_limits<T>::min() &&
-                      std::numeric_limits<long long>::max() >= std::numeric_limits<T>::max(),
-                  "long long is not a superset of T. use of std::llround is not sane.");
-
     // Here we round when converting from float to int.
     // After applying our deadzone, resizing, and reshaping math
     // we sometimes have a near-zero value which is slightly negative. (e.g. -0.0001)

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/IniFile.h"
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
@@ -19,6 +20,10 @@ enum class SettingType
   Double,
   Bool,
 };
+
+// NumericSetting is only implemented for int, double, and bool.
+template <class T>
+concept SettingConstraint = Common::SameAsAnyOf<T, int, double, bool>;
 
 enum class SettingVisibility
 {
@@ -90,18 +95,14 @@ protected:
   NumericSettingDetails m_details;
 };
 
-template <typename T>
+template <SettingConstraint T>
 class SettingValue;
 
-template <typename T>
+template <SettingConstraint T>
 class NumericSetting final : public NumericSettingBase
 {
 public:
   using ValueType = T;
-
-  static_assert(std::is_same<ValueType, int>() || std::is_same<ValueType, double>() ||
-                    std::is_same<ValueType, bool>(),
-                "NumericSetting is only implemented for int, double, and bool.");
 
   NumericSetting(SettingValue<ValueType>* value, const NumericSettingDetails& details,
                  ValueType default_value, ValueType min_value, ValueType max_value)
@@ -172,7 +173,7 @@ private:
   const ValueType m_max_value;
 };
 
-template <typename T>
+template <SettingConstraint T>
 class SettingValue
 {
   using ValueType = T;

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
@@ -7,9 +7,11 @@
 #include "Common/StringUtil.h"
 #include "VideoCommon/TextureCacheBase.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace
 {
-template <typename T, std::enable_if_t<std::is_base_of_v<FBTarget, T>, int> = 0>
+template <std::derived_from<FBTarget> T>
 std::optional<T> DeserializeFBTargetFromConfig(const picojson::object& obj, std::string_view prefix)
 {
   T fb;

--- a/Source/Core/VideoCommon/OpcodeDecoding.h
+++ b/Source/Core/VideoCommon/OpcodeDecoding.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <type_traits>
-
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/EnumFormatter.h"
@@ -12,6 +10,8 @@
 #include "Common/Swap.h"
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/VertexLoaderBase.h"
+
+#include "Common/Future/CppLibConcepts.h"
 
 struct CPState;
 class DataReader;
@@ -118,7 +118,7 @@ public:
 namespace detail
 {
 // Main logic; split so that the main RunCommand can call OnCommand with the returned size.
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<Callback, T>>>
+template <std::derived_from<Callback> T>
 static DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& callback)
 {
   if (available < 1)
@@ -248,7 +248,7 @@ static DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& cal
 }
 }  // namespace detail
 
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<Callback, T>>>
+template <std::derived_from<Callback> T>
 DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& callback)
 {
   const u32 size = detail::RunCommand(data, available, callback);
@@ -259,7 +259,7 @@ DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& callback)
   return size;
 }
 
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<Callback, T>>>
+template <std::derived_from<Callback> T>
 DOLPHIN_FORCE_INLINE u32 Run(const u8* data, u32 available, T& callback)
 {
   u32 size = 0;

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -225,7 +225,7 @@ static void UnserializePipelineUid(const SerializedUidType& uid, UidType& real_u
   real_uid.blending_state.hex = uid.blending_state_bits;
 }
 
-template <ShaderStage stage, typename K, typename T>
+template <ShaderStage stage, Common::TriviallyCopyable K, typename T>
 void ShaderCache::LoadShaderCache(T& cache, APIType api_type, const char* type, bool include_gameid)
 {
   class CacheReader : public Common::LinearDiskCacheReader<K, u8>
@@ -275,7 +275,7 @@ void ShaderCache::ClearShaderCache(T& cache)
   cache.shader_map.clear();
 }
 
-template <typename KeyType, typename DiskKeyType, typename T>
+template <typename KeyType, Common::TriviallyCopyable DiskKeyType, typename T>
 void ShaderCache::LoadPipelineCache(T& cache, Common::LinearDiskCache<DiskKeyType, u8>& disk_cache,
                                     APIType api_type, const char* type, bool include_gameid)
 {

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -171,11 +171,11 @@ private:
   void QueueUberPipelineCompile(const GXUberPipelineUid& uid, u32 priority);
 
   // Populating various caches.
-  template <ShaderStage stage, typename K, typename T>
+  template <ShaderStage stage, Common::TriviallyCopyable K, typename T>
   void LoadShaderCache(T& cache, APIType api_type, const char* type, bool include_gameid);
   template <typename T>
   void ClearShaderCache(T& cache);
-  template <typename KeyType, typename DiskKeyType, typename T>
+  template <typename KeyType, Common::TriviallyCopyable DiskKeyType, typename T>
   void LoadPipelineCache(T& cache, Common::LinearDiskCache<DiskKeyType, u8>& disk_cache,
                          APIType api_type, const char* type, bool include_gameid);
   template <typename T, typename Y>

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -7,13 +7,13 @@
 #include <functional>
 #include <iterator>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 #include <fmt/format.h>
 
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/EnumMap.h"
 #include "Common/StringUtil.h"
 #include "Common/TypeUtils.h"
@@ -65,13 +65,10 @@ public:
  * NOTE: Because LinearDiskCache reads and writes the storage associated with a ShaderUid instance,
  * ShaderUid must be trivially copyable.
  */
-template <class uid_data>
+template <Common::TriviallyCopyable uid_data>
 class ShaderUid : public ShaderGeneratorInterface
 {
 public:
-  static_assert(std::is_trivially_copyable_v<uid_data>,
-                "uid_data must be a trivially copyable type");
-
   ShaderUid() { memset(GetUidData(), 0, GetUidDataSize()); }
 
   bool operator==(const ShaderUid& obj) const

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -13,6 +13,8 @@
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderUtils.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 // warning: mapping buffer should be disabled to use this
 #define LOG_NORM()  // PRIM_LOG("norm: {} {} {}, ", ((float*)g_vertex_manager_write_ptr)[-3],
                     // ((float*)g_vertex_manager_write_ptr)[-2],
@@ -68,11 +70,9 @@ void Normal_ReadDirect(VertexLoader* loader)
   DataSkip<N * 3 * sizeof(T)>();
 }
 
-template <typename I, typename T, u32 N, u32 Offset>
+template <std::unsigned_integral I, typename T, u32 N, u32 Offset>
 void Normal_ReadIndex_Offset(VertexLoader* loader)
 {
-  static_assert(std::is_unsigned_v<I>, "Only unsigned I is sane!");
-
   const auto index = DataRead<I>();
   const auto data =
       reinterpret_cast<const T*>(VertexLoaderManager::cached_arraybases[CPArray::Normal] +
@@ -80,13 +80,13 @@ void Normal_ReadIndex_Offset(VertexLoader* loader)
   ReadIndirect<T, N * 3, Offset * 3>(loader, data);
 }
 
-template <typename I, typename T, u32 N>
+template <std::unsigned_integral I, typename T, u32 N>
 void Normal_ReadIndex(VertexLoader* loader)
 {
   Normal_ReadIndex_Offset<I, T, N, 0>(loader);
 }
 
-template <typename I, typename T>
+template <std::unsigned_integral I, typename T>
 void Normal_ReadIndex_Indices3(VertexLoader* loader)
 {
   Normal_ReadIndex_Offset<I, T, 1, 0>(loader);

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -4,7 +4,6 @@
 #include "VideoCommon/VertexLoader_Position.h"
 
 #include <limits>
-#include <type_traits>
 
 #include "Common/CommonTypes.h"
 #include "Common/EnumMap.h"
@@ -14,6 +13,8 @@
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderUtils.h"
 #include "VideoCommon/VideoCommon.h"
+
+#include "Common/Future/CppLibConcepts.h"
 
 namespace
 {
@@ -46,10 +47,9 @@ void Pos_ReadDirect(VertexLoader* loader)
   LOG_VTX();
 }
 
-template <typename I, typename T, int N>
+template <std::unsigned_integral I, typename T, int N>
 void Pos_ReadIndex(VertexLoader* loader)
 {
-  static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
   static_assert(N <= 3, "N > 3 is not sane!");
 
   const auto index = DataRead<I>();

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -3,14 +3,14 @@
 
 #include "VideoCommon/VertexLoader_TextCoord.h"
 
-#include <type_traits>
-
 #include "Common/CommonTypes.h"
 #include "Common/Swap.h"
 
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderUtils.h"
+
+#include "Common/Future/CppLibConcepts.h"
 
 namespace
 {
@@ -42,11 +42,9 @@ void TexCoord_ReadDirect(VertexLoader* loader)
   ++loader->m_tcIndex;
 }
 
-template <typename I, typename T, int N>
+template <std::unsigned_integral I, typename T, int N>
 void TexCoord_ReadIndex(VertexLoader* loader)
 {
-  static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
-
   const auto index = DataRead<I>();
   const auto data = reinterpret_cast<const T*>(
       VertexLoaderManager::cached_arraybases[CPArray::TexCoord0 + loader->m_tcIndex] +


### PR DESCRIPTION
As Dolphin Emulator upgrades to C++20, concepts ought to be applied around the codebase to clean up static assertions and primitive SFINAE. Also, a clang-format rule for concepts has been added.

Unfortunately, the Android NDK is woefully behind the times in regards to the C++20 Standard Library. We can work around this issue for the time being by wielding the other new header file introduced by this commit: 'Common/Future/CppLibConcepts.h'. See PR [#11080](https://github.com/dolphin-emu/dolphin/issues/11080) for how CppLibConcepts.h will be removed in the future.