### PR TITLE
WGInput: Work around crash with Steam overlay.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/WGInput/WGInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/WGInput/WGInput.cpp
@@ -544,8 +544,12 @@ private:
   {
     try
     {
+      // Workaround for Steam. If Steam's GameOverlayRenderer64.dll is loaded, battery_info is null.
+      auto battery_info = m_raw_controller.try_as<WGI::IGameControllerBatteryInfo>();
+      if (!battery_info)
+        return false;
       const winrt::Windows::Devices::Power::BatteryReport report =
-          m_raw_controller.TryGetBatteryReport();
+          battery_info.TryGetBatteryReport();
       if (!report)
         return false;
 


### PR DESCRIPTION
@shuffle2 This fixes the crash. As far as I can tell this is a bug with the Steam overlay but I have no idea how to verify that or how to report this.

The code is just the existing `TryGetBatteryReport()` function from the winrt headers rolled out and with a null check in the right place, which is, for reference:

```
#define WINRT_IMPL_SHIM(...) (*(abi_t<__VA_ARGS__>**)&static_cast<__VA_ARGS__ const&>(static_cast<D const&>(*this)))

    template <typename D> WINRT_IMPL_AUTO(winrt::Windows::Devices::Power::BatteryReport) consume_Windows_Gaming_Input_IGameControllerBatteryInfo<D>::TryGetBatteryReport() const
    {
        void* value{};
        check_hresult(WINRT_IMPL_SHIM(winrt::Windows::Gaming::Input::IGameControllerBatteryInfo)->TryGetBatteryReport(&value));
        return winrt::Windows::Devices::Power::BatteryReport{ value, take_ownership_from_abi };
    }
```

Note: There's an extra deadlock that happens after this when the Steam overlay is running, but this fixes the crash at least.