### PR TITLE
InputCommon: Fix deadlock in EmulatedController::UpdateReferences().

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -40,7 +40,7 @@ std::unique_lock<std::recursive_mutex> EmulatedController::GetStateLock()
 
 void EmulatedController::UpdateReferences(const ControllerInterface& devi)
 {
-  const auto lock = GetStateLock();
+  std::scoped_lock lk(s_get_state_mutex, devi.GetDevicesMutex());
 
   m_default_device_is_connected = devi.HasConnectedDevice(m_default_device);
 

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -238,6 +238,8 @@ public:
                                           std::chrono::milliseconds confirmation_wait,
                                           std::chrono::milliseconds maximum_wait) const;
 
+  std::recursive_mutex& GetDevicesMutex() const { return m_devices_mutex; }
+
 protected:
   // Exclusively needed when reading/writing "m_devices"
   mutable std::recursive_mutex m_devices_mutex;


### PR DESCRIPTION
There's a deadlock here that can happen if thread A calls `UpdateReferences()` while thread B holds the `DeviceContainer::m_devices_mutex` and before releasing it also calls `UpdateReferences()`. The `UpdateReferences()` first locks the `s_get_state_mutex`, then locks the `m_devices_mutex` (indirectly first via the `HasConnectedDevice()` call, but also potentially later down the `UpdateReferences()` chain in eg. `ControlExpression::UpdateReferences()`). If `m_devices_mutex` is already locked by another thread that subsequently tries to acquire the `s_get_state_mutex` -- for example, the HotkeyScheduler thread calling `UpdateInput()` which in turn triggers a `InvokeDevicesChangedCallbacks()` which in turn also triggers `UpdateReferences()` -- they both try to lock the mutex the other thread already holds, deadlocking in the process.

This is the deadlock I mentioned in #11038.