### PR TITLE
HW: Convert FileMonitor::Log into a class.

### DIFF
--- a/Source/Core/Core/HW/DVD/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVD/DVDThread.cpp
@@ -90,6 +90,8 @@ struct DVDThreadState::Data
   std::map<u64, ReadResult> result_map;
 
   std::unique_ptr<DiscIO::Volume> disc;
+
+  FileMonitor::FileLogger file_logger;
 };
 
 DVDThreadState::DVDThreadState() : m_data(std::make_unique<Data>())
@@ -411,7 +413,7 @@ static void DVDThread()
     ReadRequest request;
     while (state.request_queue.Pop(request))
     {
-      FileMonitor::Log(*state.disc, request.partition, request.dvd_offset);
+      state.file_logger.Log(*state.disc, request.partition, request.dvd_offset);
 
       std::vector<u8> buffer(request.length);
       if (!state.disc->Read(request.dvd_offset, request.length, buffer.data(), request.partition))

--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -20,9 +20,6 @@
 
 namespace FileMonitor
 {
-static DiscIO::Partition s_previous_partition;
-static u64 s_previous_file_offset;
-
 // Filtered files
 static bool IsSoundFile(const std::string& filename)
 {
@@ -49,7 +46,11 @@ static bool IsSoundFile(const std::string& filename)
   return extensions.find(extension) != extensions.end();
 }
 
-void Log(const DiscIO::Volume& volume, const DiscIO::Partition& partition, u64 offset)
+FileLogger::FileLogger() = default;
+
+FileLogger::~FileLogger() = default;
+
+void FileLogger::Log(const DiscIO::Volume& volume, const DiscIO::Partition& partition, u64 offset)
 {
   // Do nothing if the log isn't selected
   if (!Common::Log::LogManager::GetInstance()->IsEnabled(Common::Log::LogType::FILEMON,
@@ -73,7 +74,7 @@ void Log(const DiscIO::Volume& volume, const DiscIO::Partition& partition, u64 o
   const u64 file_offset = file_info->GetOffset();
 
   // Do nothing if we found the same file again
-  if (s_previous_partition == partition && s_previous_file_offset == file_offset)
+  if (m_previous_partition == partition && m_previous_file_offset == file_offset)
     return;
 
   const std::string size_string = ThousandSeparate(file_info->GetSize() / 1000, 7);
@@ -85,8 +86,8 @@ void Log(const DiscIO::Volume& volume, const DiscIO::Partition& partition, u64 o
     WARN_LOG_FMT(FILEMON, "{}", log_string);
 
   // Update the last accessed file
-  s_previous_partition = partition;
-  s_previous_file_offset = file_offset;
+  m_previous_partition = partition;
+  m_previous_file_offset = file_offset;
 }
 
 }  // namespace FileMonitor

--- a/Source/Core/Core/HW/DVD/FileMonitor.h
+++ b/Source/Core/Core/HW/DVD/FileMonitor.h
@@ -4,14 +4,20 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
-
-namespace DiscIO
-{
-struct Partition;
-class Volume;
-}  // namespace DiscIO
+#include "DiscIO/Volume.h"
 
 namespace FileMonitor
 {
-void Log(const DiscIO::Volume& volume, const DiscIO::Partition& partition, u64 offset);
-}
+class FileLogger
+{
+public:
+  FileLogger();
+  ~FileLogger();
+
+  void Log(const DiscIO::Volume& volume, const DiscIO::Partition& partition, u64 offset);
+
+private:
+  DiscIO::Partition m_previous_partition;
+  u64 m_previous_file_offset;
+};
+}  // namespace FileMonitor


### PR DESCRIPTION
Removes global state in FileMonitor.cpp.