### PR TITLE
Android: Match navigation bar color to background

### DIFF
--- a/Source/Android/app/src/main/res/values-night/bools.xml
+++ b/Source/Android/app/src/main/res/values-night/bools.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="lightStatusBar">false</bool>
+    <bool name="lightSystemBars">false</bool>
 </resources>

--- a/Source/Android/app/src/main/res/values-v27/themes.xml
+++ b/Source/Android/app/src/main/res/values-v27/themes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.V27.Dolphin" parent="Theme.Dolphin">
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightNavigationBar">@bool/lightSystemBars</item>
+    </style>
+
+    <style name="Theme.Dolphin.Main" parent="Theme.V27.Dolphin" />
+</resources>

--- a/Source/Android/app/src/main/res/values/bools.xml
+++ b/Source/Android/app/src/main/res/values/bools.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="lightStatusBar">true</bool>
+    <bool name="lightSystemBars">true</bool>
 </resources>

--- a/Source/Android/app/src/main/res/values/themes.xml
+++ b/Source/Android/app/src/main/res/values/themes.xml
@@ -13,7 +13,7 @@
     </style>
 
     <!-- Base theme -->
-    <style name="Theme.Dolphin.Main" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Theme.Dolphin" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/dolphin_primary</item>
         <item name="colorOnPrimary">@color/dolphin_onPrimary</item>
         <item name="colorPrimaryContainer">@color/dolphin_primary</item>
@@ -52,12 +52,15 @@
 
         <item name="homeAsUpIndicator">@drawable/ic_back</item>
 
-        <item name="android:windowLightStatusBar" tools:targetApi="m">@bool/lightStatusBar</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">@bool/lightSystemBars</item>
 
         <item name="materialAlertDialogTheme">@style/DolphinMaterialDialog</item>
         <item name="popupTheme">@style/DolphinPopup</item>
         <item name="sliderStyle">@style/DolphinSlider</item>
     </style>
+
+    <!-- Trick for API >= 27 specific changes -->
+    <style name="Theme.Dolphin.Main" parent="Theme.Dolphin" />
 
     <style name="Theme.Dolphin.Main.Material" parent="Theme.Dolphin.Main">
         <item name="colorPrimaryContainer">@color/dolphin_primaryContainer</item>


### PR DESCRIPTION
Since you can change the color of the navigation bar background in APIs >= 27 I'm making it match the background.

APIs >= 27

Light - 
![image](https://user-images.githubusercontent.com/14132249/189500372-95f4b812-8e8c-4ce4-be33-9f2d5e2662a7.png)

Dark -
![Screenshot 2022-09-10 161535](https://user-images.githubusercontent.com/14132249/189500397-4105f378-3491-4745-8132-5550634683d2.png)

APIs < 27

![Screenshot 2022-09-10 161615](https://user-images.githubusercontent.com/14132249/189500419-31bef3db-e23a-47a1-9f56-3128dd707935.png)
