### PR TITLE
Android: Add custom window animation to alert dialogs

### DIFF
--- a/Source/Android/app/src/main/res/anim/fade_in.xml
+++ b/Source/Android/app/src/main/res/anim/fade_in.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+<alpha
+    android:duration="@android:integer/config_shortAnimTime"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:fromAlpha="0"
+    android:toAlpha="1" />
+
+<scale
+    android:duration="@android:integer/config_shortAnimTime"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:fromXScale="0.95"
+    android:fromYScale="0.95"
+    android:pivotX="50%"
+    android:pivotY="50%"
+    android:toXScale="1.0"
+    android:toYScale="1.0" />
+</set>

--- a/Source/Android/app/src/main/res/anim/fade_out.xml
+++ b/Source/Android/app/src/main/res/anim/fade_out.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+<alpha
+    android:duration="@android:integer/config_shortAnimTime"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:fromAlpha="1"
+    android:toAlpha="0" />
+
+<scale
+    android:duration="@android:integer/config_shortAnimTime"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:fromXScale="1.0"
+    android:fromYScale="1.0"
+    android:pivotX="50%"
+    android:pivotY="50%"
+    android:toXScale="0.95"
+    android:toYScale="0.95" />
+</set>

--- a/Source/Android/app/src/main/res/values-night-v31/themes.xml
+++ b/Source/Android/app/src/main/res/values-night-v31/themes.xml
@@ -27,7 +27,7 @@
         <item name="android:colorControlHighlight">@color/m3_sys_color_dynamic_dark_on_surface_variant</item>
         <item name="android:colorEdgeEffect">@color/m3_sys_color_dynamic_dark_secondary</item>
 
-        <item name="materialAlertDialogTheme">@style/ThemeOverlay.Material3.MaterialAlertDialog</item>
+        <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
     </style>
 </resources>

--- a/Source/Android/app/src/main/res/values-v31/themes.xml
+++ b/Source/Android/app/src/main/res/values-v31/themes.xml
@@ -27,7 +27,7 @@
         <item name="android:colorControlHighlight">@color/m3_sys_color_dynamic_light_on_surface_variant</item>
         <item name="android:colorEdgeEffect">@color/m3_sys_color_dynamic_light_secondary</item>
 
-        <item name="materialAlertDialogTheme">@style/ThemeOverlay.Material3.MaterialAlertDialog</item>
+        <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
     </style>
 </resources>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -32,6 +32,16 @@
         <item name="buttonBarPositiveButtonStyle">@style/DolphinButton</item>
         <item name="buttonBarNegativeButtonStyle">@style/DolphinButton</item>
         <item name="buttonBarNeutralButtonStyle">@style/DolphinButton</item>
+        <item name="android:windowAnimationStyle">@style/DialogAnimation</item>
+    </style>
+
+    <style name="MaterialDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="android:windowAnimationStyle">@style/DialogAnimation</item>
+    </style>
+
+    <style name="DialogAnimation">
+        <item name="android:windowEnterAnimation">@anim/fade_in</item>
+        <item name="android:windowExitAnimation">@anim/fade_out</item>
     </style>
 
     <style name="DolphinTVDialog" parent="Theme.Material3.DayNight.Dialog.Alert">

--- a/Source/Android/app/src/main/res/values/themes.xml
+++ b/Source/Android/app/src/main/res/values/themes.xml
@@ -63,7 +63,7 @@
         <item name="colorPrimaryContainer">@color/dolphin_primaryContainer</item>
         <item name="colorOnPrimaryContainer">@color/dolphin_onPrimaryContainer</item>
 
-        <item name="materialAlertDialogTheme">@style/ThemeOverlay.Material3.MaterialAlertDialog</item>
+        <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
     </style>
 
@@ -97,7 +97,7 @@
         <item name="android:colorControlHighlight">@color/green_onSurfaceVariant</item>
         <item name="android:colorEdgeEffect">@color/green_secondary</item>
 
-        <item name="materialAlertDialogTheme">@style/ThemeOverlay.Material3.MaterialAlertDialog</item>
+        <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
     </style>
 
@@ -131,7 +131,7 @@
         <item name="android:colorControlHighlight">@color/pink_onSurfaceVariant</item>
         <item name="android:colorEdgeEffect">@color/pink_secondary</item>
 
-        <item name="materialAlertDialogTheme">@style/ThemeOverlay.Material3.MaterialAlertDialog</item>
+        <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
     </style>
 


### PR DESCRIPTION
Since we have so many alert dialogs throughout the app, I thought it would look nice to have animations for zooming and fading in.

Before - 
![before](https://user-images.githubusercontent.com/14132249/189502034-84a1dd3d-5e50-4034-800a-05026ba0dbab.gif)

After -
![after](https://user-images.githubusercontent.com/14132249/189502037-e888f572-2c7b-48ed-9470-ac32d1fed2cd.gif)
