### PR TITLE
Android: Change color control highlight to system default

### DIFF
--- a/Source/Android/app/src/main/res/values/themes.xml
+++ b/Source/Android/app/src/main/res/values/themes.xml
@@ -42,9 +42,6 @@
         <item name="colorPrimaryInverse">@color/dolphin_inversePrimary</item>
         <item name="android:shadowColor">@color/dolphin_shadow</item>
 
-        <item name="android:colorControlHighlight">@color/dolphin_secondary</item>
-        <item name="android:colorEdgeEffect">@color/dolphin_onSurfaceVariant</item>
-
         <!-- Enable window content transitions -->
         <item name="android:windowContentTransitions">true</item>
         <item name="android:windowAllowEnterTransitionOverlap">true</item>


### PR DESCRIPTION
These lines that were originally used to change the color edge effect and color control highlight for the dedicated Emulation Activity theme are no longer necessary. I also didn't really like how the color control highlight (this applied to all clickable objects in the app) looked when so dark.

Before - 
![image](https://user-images.githubusercontent.com/14132249/189503291-b7afd618-ab23-44e3-8f3f-c01b9a85ce49.png)

After -
![image](https://user-images.githubusercontent.com/14132249/189503264-35739a02-831d-4cb4-97bf-174c46da52b6.png)
