### PR TITLE
Android: Fix save state menu text color

### DIFF
--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -20,6 +20,7 @@
     </style>
 
     <style name="OverlayInGameMenuOption" parent="InGameMenuOption">
+        <item name="android:textColor">@android:color/white</item>
         <item name="android:padding">8dp</item>
         <item name="android:gravity">center</item>
         <item name="android:layout_gravity">center</item>


### PR DESCRIPTION
The text color would change based on dark/light mode but since it is always on a black background it would look bad.

Before - 
![old](https://user-images.githubusercontent.com/14132249/189507973-998756d4-6190-4d46-980b-59f80f28a505.png)

After -
![new](https://user-images.githubusercontent.com/14132249/189508014-eeb42c15-2c8d-4843-ba81-eaaba9d1d5ce.png)
