### PR TITLE
Netplay: Pass netplay settings via BootSessionData.

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -50,6 +50,7 @@ namespace fs = std::filesystem;
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/IOSC.h"
 #include "Core/IOS/Uids.h"
+#include "Core/NetPlayProto.h"
 #include "Core/PatchEngine.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
@@ -174,6 +175,16 @@ void BootSessionData::SetWiiSyncData(std::unique_ptr<IOS::HLE::FS::FileSystem> f
   m_wii_sync_titles = std::move(titles);
   m_wii_sync_redirect_folder = std::move(redirect_folder);
   m_wii_sync_cleanup = std::move(cleanup);
+}
+
+const NetPlay::NetSettings* BootSessionData::GetNetplaySettings() const
+{
+  return m_netplay_settings.get();
+}
+
+void BootSessionData::SetNetplaySettings(std::unique_ptr<NetPlay::NetSettings> netplay_settings)
+{
+  m_netplay_settings = std::move(netplay_settings);
 }
 
 BootParameters::BootParameters(Parameters&& parameters_, BootSessionData boot_session_data_)

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -39,6 +39,11 @@ struct RegionSetting
 
 class BootExecutableReader;
 
+namespace NetPlay
+{
+struct NetSettings;
+}
+
 enum class DeleteSavestateAfterBoot : u8
 {
   No,
@@ -71,6 +76,9 @@ public:
   void SetWiiSyncData(std::unique_ptr<IOS::HLE::FS::FileSystem> fs, std::vector<u64> titles,
                       std::string redirect_folder, WiiSyncCleanupFunction cleanup);
 
+  const NetPlay::NetSettings* GetNetplaySettings() const;
+  void SetNetplaySettings(std::unique_ptr<NetPlay::NetSettings> netplay_settings);
+
 private:
   std::optional<std::string> m_savestate_path;
   DeleteSavestateAfterBoot m_delete_savestate = DeleteSavestateAfterBoot::No;
@@ -79,6 +87,8 @@ private:
   std::vector<u64> m_wii_sync_titles;
   std::string m_wii_sync_redirect_folder;
   WiiSyncCleanupFunction m_wii_sync_cleanup;
+
+  std::unique_ptr<NetPlay::NetSettings> m_netplay_settings;
 };
 
 struct BootParameters

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -86,9 +86,12 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
 
   if (NetPlay::IsNetPlayRunning())
   {
-    const NetPlay::NetSettings& netplay_settings = NetPlay::GetNetSettings();
-    Config::AddLayer(ConfigLoaders::GenerateNetPlayConfigLoader(netplay_settings));
-    StartUp.bCopyWiiSaveNetplay = netplay_settings.m_CopyWiiSave;
+    const NetPlay::NetSettings* netplay_settings = boot->boot_session_data.GetNetplaySettings();
+    if (!netplay_settings)
+      return false;
+
+    Config::AddLayer(ConfigLoaders::GenerateNetPlayConfigLoader(*netplay_settings));
+    StartUp.bCopyWiiSaveNetplay = netplay_settings->m_CopyWiiSave;
   }
   else
   {

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1725,6 +1725,8 @@ bool NetPlayClient::StartGame(const std::string& path)
                                       if (File::Exists(redirect_path))
                                         File::DeleteDirRecursively(redirect_path);
                                     });
+  boot_session_data->SetNetplaySettings(std::make_unique<NetPlay::NetSettings>(m_net_settings));
+
   m_dialog->BootGame(path, std::move(boot_session_data));
 
   UpdateDevices();
@@ -2574,12 +2576,6 @@ bool IsNetPlayRunning()
   return netplay_client != nullptr;
 }
 
-const NetSettings& GetNetSettings()
-{
-  ASSERT(IsNetPlayRunning());
-  return netplay_client->GetNetSettings();
-}
-
 void SetSIPollBatching(bool state)
 {
   s_si_poll_batching = state;
@@ -2622,7 +2618,7 @@ std::string GetGBASavePath(int pad_num)
 {
   std::lock_guard lk(crit_netplay_client);
 
-  if (!netplay_client || NetPlay::GetNetSettings().m_IsHosting)
+  if (!netplay_client || netplay_client->GetNetSettings().m_IsHosting)
   {
 #ifdef HAS_LIBMGBA
     std::string rom_path = Config::Get(Config::MAIN_GBA_ROM_PATHS[pad_num]);
@@ -2632,7 +2628,7 @@ std::string GetGBASavePath(int pad_num)
 #endif
   }
 
-  if (!NetPlay::GetNetSettings().m_SyncSaveData)
+  if (!netplay_client->GetNetSettings().m_SyncSaveData)
     return {};
 
   return fmt::format("{}{}{}.sav", File::GetUserPath(D_GBAUSER_IDX), GBA_SAVE_NETPLAY, pad_num + 1);

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -257,9 +257,6 @@ std::string GetPlayerMappingString(PlayerId pid, const PadMappingArray& pad_map,
                                    const GBAConfigArray& gba_config,
                                    const PadMappingArray& wiimote_map);
 bool IsNetPlayRunning();
-// Precondition: A netplay client instance must be present. In other words,
-//               IsNetPlayRunning() must be true before calling this.
-const NetSettings& GetNetSettings();
 void SetSIPollBatching(bool state);
 void SendPowerButtonEvent();
 bool IsSyncingAllWiiSaves();


### PR DESCRIPTION
I realized this would be quite simple to do during #11047. Removes (or, well, reduces the scope of, I suppose) the weird thing where a global `netplay_client` stores the netplay settings.