### PR TITLE
spng: define SPNG_STATIC when compiling spng itself

### DIFF
--- a/Externals/libspng/spng.vcxproj
+++ b/Externals/libspng/spng.vcxproj
@@ -18,6 +18,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>libspng\spng;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>SPNG_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Previously was only defined for things including it. Not really a bug, but it was leaking symbols into exports.