### PR TITLE
Add emulated Shinkansen controller

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -296,6 +296,8 @@ add_library(core
   HW/WiimoteEmu/Extension/Guitar.h
   HW/WiimoteEmu/Extension/Nunchuk.cpp
   HW/WiimoteEmu/Extension/Nunchuk.h
+  HW/WiimoteEmu/Extension/Shinkansen.cpp
+  HW/WiimoteEmu/Extension/Shinkansen.h
   HW/WiimoteEmu/Extension/TaTaCon.cpp
   HW/WiimoteEmu/Extension/TaTaCon.h
   HW/WiimoteEmu/Extension/Turntable.cpp

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -152,6 +152,12 @@ ControllerEmu::ControlGroup* GetTaTaConGroup(int number, WiimoteEmu::TaTaConGrou
   return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetTaTaConGroup(group);
 }
 
+ControllerEmu::ControlGroup* GetShinkansenGroup(int number, WiimoteEmu::ShinkansenGroup group)
+{
+  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
+      ->GetShinkansenGroup(group);
+}
+
 void Shutdown()
 {
   s_config.UnregisterHotplugCallback();

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -28,6 +28,7 @@ enum class TurntableGroup;
 enum class UDrawTabletGroup;
 enum class DrawsomeTabletGroup;
 enum class TaTaConGroup;
+enum class ShinkansenGroup;
 }  // namespace WiimoteEmu
 
 enum
@@ -92,6 +93,7 @@ ControllerEmu::ControlGroup* GetUDrawTabletGroup(int number, WiimoteEmu::UDrawTa
 ControllerEmu::ControlGroup* GetDrawsomeTabletGroup(int number,
                                                     WiimoteEmu::DrawsomeTabletGroup group);
 ControllerEmu::ControlGroup* GetTaTaConGroup(int number, WiimoteEmu::TaTaConGroup group);
+ControllerEmu::ControlGroup* GetShinkansenGroup(int number, WiimoteEmu::ShinkansenGroup group);
 
 bool NetPlay_GetButtonPress(int wiimote, bool pressed);
 }  // namespace Wiimote

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.cpp
@@ -1,0 +1,114 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Core/HW/WiimoteEmu/Extension/Shinkansen.h"
+
+#include <array>
+
+#include "Common/Assert.h"
+#include "Common/Common.h"
+#include "Common/CommonTypes.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+
+#include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
+#include "InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h"
+
+namespace WiimoteEmu
+{
+// TODO: check this (only the last byte is known good)
+constexpr std::array<u8, 6> shinkansen_id{{0x00, 0x00, 0xa4, 0x20, 0x01, 0x10}};
+
+Shinkansen::Shinkansen() : Extension3rdParty("Shinkansen", _trans("Shinkansen Controller"))
+{
+  // Button layout on the controller:
+  //
+  //    Up      Select Start   D
+  // Left Right              A   C
+  //   Down                    B
+  //
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
+  m_buttons->AddInput(ControllerEmu::Translate, _trans("Left"));
+  m_buttons->AddInput(ControllerEmu::Translate, _trans("Down"));
+  m_buttons->AddInput(ControllerEmu::Translate, _trans("Right"));
+  m_buttons->AddInput(ControllerEmu::Translate, _trans("Up"));
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "A");
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "B");
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "C");
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "D");
+  m_buttons->AddInput(ControllerEmu::Translate, _trans("Select"));
+  m_buttons->AddInput(ControllerEmu::Translate, _trans("Start"));
+
+  // For easier axis mapping the right lever is inverted in Dolphin,
+  // so that the train coasts when no trigger is squeezed.
+  groups.emplace_back(m_levers = new ControllerEmu::MixedTriggers(_trans("Levers")));
+  m_levers->AddInput(ControllerEmu::Translate, _trans("L"));
+  m_levers->AddInput(ControllerEmu::Translate, _trans("R"));
+  m_levers->AddInput(ControllerEmu::Translate, _trans("L-Analog"));
+  m_levers->AddInput(ControllerEmu::Translate, _trans("R-Analog"));
+
+  groups.emplace_back(m_led = new ControllerEmu::ControlGroup(_trans("Light")));
+  m_led->AddOutput(ControllerEmu::Translate, _trans("Doors Locked"));
+}
+
+void Shinkansen::Update()
+{
+  DataFormat ext_data = {};
+
+  u16 digital = 0;
+  const u16 lever_bitmasks[2] = {};
+  double analog[2] = {};
+  m_levers->GetState(&digital, lever_bitmasks, analog);
+  // The game requires these specific values, all other values are treated like 0/255 (which are
+  // guesses).
+  const u8 brake_values[] = {0, 53, 79, 105, 132, 159, 187, 217, 250};
+  const u8 power_values[] = {255, 229, 208, 189, 170, 153, 135, 118, 101, 85, 68, 51, 35, 17};
+  ext_data.brake = brake_values[size_t(analog[0] * (sizeof(brake_values) - 1))];
+  ext_data.power = power_values[size_t(analog[1] * (sizeof(power_values) - 1))];
+
+  // Note: This currently assumes a little-endian host.
+  const u16 button_bitmasks[] = {
+      0x0200,  // Left
+      0x0040,  // Down
+      0x0080,  // Right
+      0x0100,  // Up
+      0x2000,  // A
+      0x4000,  // B
+      0x1000,  // C
+      0x0800,  // D
+      0x0010,  // Select
+      0x0004,  // Start
+  };
+  m_buttons->GetState(&ext_data.buttons, button_bitmasks);
+  ext_data.buttons ^= 0xFFFF;
+  Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = ext_data;
+
+  const auto lock = GetStateLock();
+  m_led->controls[0]->control_ref->State(m_reg.identifier[1]);
+}
+
+void Shinkansen::Reset()
+{
+  EncryptedExtension::Reset();
+
+  m_reg = {};
+  m_reg.identifier = shinkansen_id;
+  m_reg.calibration.fill(0xff);
+}
+
+ControllerEmu::ControlGroup* Shinkansen::GetGroup(ShinkansenGroup group)
+{
+  switch (group)
+  {
+  case ShinkansenGroup::Levers:
+    return m_levers;
+  case ShinkansenGroup::Buttons:
+    return m_buttons;
+  case ShinkansenGroup::Light:
+    return m_led;
+  default:
+    ASSERT(false);
+    return nullptr;
+  }
+}
+
+}  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.h
@@ -1,0 +1,50 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "Core/HW/WiimoteEmu/Extension/Extension.h"
+
+namespace ControllerEmu
+{
+class Buttons;
+class ControlGroup;
+class MixedTriggers;
+}  // namespace ControllerEmu
+
+namespace WiimoteEmu
+{
+enum class ShinkansenGroup
+{
+  Buttons,
+  Levers,
+  Light,
+};
+
+class Shinkansen : public Extension3rdParty
+{
+public:
+  Shinkansen();
+
+  void Update() override;
+  void Reset() override;
+  ControllerEmu::ControlGroup* GetGroup(ShinkansenGroup group);
+
+private:
+  ControllerEmu::Buttons* m_buttons;
+  ControllerEmu::MixedTriggers* m_levers;
+  ControllerEmu::ControlGroup* m_led;
+
+  struct DataFormat
+  {
+    u8 unk0;
+    u8 unk1;
+    u8 brake;
+    u8 power;
+    u8 unk4;
+    u8 unk5;
+    u16 buttons;
+  };
+};
+
+}  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/ExtensionPort.h
+++ b/Source/Core/Core/HW/WiimoteEmu/ExtensionPort.h
@@ -21,6 +21,7 @@ enum ExtensionNumber : u8
   UDRAW_TABLET,
   DRAWSOME_TABLET,
   TATACON,
+  SHINKANSEN,
 
   MAX
 };

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -30,6 +30,7 @@
 #include "Core/HW/WiimoteEmu/Extension/Drums.h"
 #include "Core/HW/WiimoteEmu/Extension/Guitar.h"
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
+#include "Core/HW/WiimoteEmu/Extension/Shinkansen.h"
 #include "Core/HW/WiimoteEmu/Extension/TaTaCon.h"
 #include "Core/HW/WiimoteEmu/Extension/Turntable.h"
 #include "Core/HW/WiimoteEmu/Extension/UDrawTablet.h"
@@ -247,6 +248,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
   m_attachments->AddAttachment(std::make_unique<WiimoteEmu::UDrawTablet>());
   m_attachments->AddAttachment(std::make_unique<WiimoteEmu::DrawsomeTablet>());
   m_attachments->AddAttachment(std::make_unique<WiimoteEmu::TaTaCon>());
+  m_attachments->AddAttachment(std::make_unique<WiimoteEmu::Shinkansen>());
 
   m_attachments->AddSetting(&m_motion_plus_setting, {_trans("Attach MotionPlus")}, true);
 
@@ -397,6 +399,13 @@ ControllerEmu::ControlGroup* Wiimote::GetDrawsomeTabletGroup(DrawsomeTabletGroup
 ControllerEmu::ControlGroup* Wiimote::GetTaTaConGroup(TaTaConGroup group) const
 {
   return static_cast<TaTaCon*>(m_attachments->GetAttachmentList()[ExtensionNumber::TATACON].get())
+      ->GetGroup(group);
+}
+
+ControllerEmu::ControlGroup* Wiimote::GetShinkansenGroup(ShinkansenGroup group) const
+{
+  return static_cast<Shinkansen*>(
+             m_attachments->GetAttachmentList()[ExtensionNumber::SHINKANSEN].get())
       ->GetGroup(group);
 }
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -62,6 +62,7 @@ enum class TurntableGroup;
 enum class UDrawTabletGroup;
 enum class DrawsomeTabletGroup;
 enum class TaTaConGroup;
+enum class ShinkansenGroup;
 
 template <typename T>
 void UpdateCalibrationDataChecksum(T& data, int cksum_bytes)
@@ -123,6 +124,7 @@ public:
   ControllerEmu::ControlGroup* GetUDrawTabletGroup(UDrawTabletGroup group) const;
   ControllerEmu::ControlGroup* GetDrawsomeTabletGroup(DrawsomeTabletGroup group) const;
   ControllerEmu::ControlGroup* GetTaTaConGroup(TaTaConGroup group) const;
+  ControllerEmu::ControlGroup* GetShinkansenGroup(ShinkansenGroup group) const;
 
   void Update() override;
   void EventLinked() override;

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -322,6 +322,7 @@
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\Extension.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\Guitar.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\Nunchuk.h" />
+    <ClInclude Include="Core\HW\WiimoteEmu\Extension\Shinkansen.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\TaTaCon.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\Turntable.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\UDrawTablet.h" />
@@ -940,6 +941,7 @@
     <ClCompile Include="Core\HW\WiimoteEmu\Extension\Extension.cpp" />
     <ClCompile Include="Core\HW\WiimoteEmu\Extension\Guitar.cpp" />
     <ClCompile Include="Core\HW\WiimoteEmu\Extension\Nunchuk.cpp" />
+    <ClCompile Include="Core\HW\WiimoteEmu\Extension\Shinkansen.cpp" />
     <ClCompile Include="Core\HW\WiimoteEmu\Extension\TaTaCon.cpp" />
     <ClCompile Include="Core\HW\WiimoteEmu\Extension\Turntable.cpp" />
     <ClCompile Include="Core\HW\WiimoteEmu\Extension\UDrawTablet.cpp" />

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
@@ -14,6 +14,7 @@
 #include "Core/HW/WiimoteEmu/Extension/Drums.h"
 #include "Core/HW/WiimoteEmu/Extension/Guitar.h"
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
+#include "Core/HW/WiimoteEmu/Extension/Shinkansen.h"
 #include "Core/HW/WiimoteEmu/Extension/TaTaCon.h"
 #include "Core/HW/WiimoteEmu/Extension/Turntable.h"
 #include "Core/HW/WiimoteEmu/Extension/UDrawTablet.h"
@@ -32,6 +33,7 @@ WiimoteEmuExtension::WiimoteEmuExtension(MappingWindow* window) : MappingWidget(
   CreateUDrawTabletLayout();
   CreateDrawsomeTabletLayout();
   CreateTaTaConLayout();
+  CreateShinkansenLayout();
   CreateMainLayout();
 
   ChangeExtensionType(WiimoteEmu::ExtensionNumber::NONE);
@@ -224,6 +226,21 @@ void WiimoteEmuExtension::CreateTaTaConLayout()
   m_tatacon_box->setLayout(hbox);
 }
 
+void WiimoteEmuExtension::CreateShinkansenLayout()
+{
+  auto* hbox = new QHBoxLayout();
+  m_shinkansen_box = new QGroupBox(tr("Shinkansen"), this);
+
+  hbox->addWidget(CreateGroupBox(
+      tr("Levers"), Wiimote::GetShinkansenGroup(GetPort(), WiimoteEmu::ShinkansenGroup::Levers)));
+  hbox->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetShinkansenGroup(GetPort(), WiimoteEmu::ShinkansenGroup::Buttons)));
+  hbox->addWidget(CreateGroupBox(
+      tr("Light"), Wiimote::GetShinkansenGroup(GetPort(), WiimoteEmu::ShinkansenGroup::Light)));
+
+  m_shinkansen_box->setLayout(hbox);
+}
+
 void WiimoteEmuExtension::CreateMainLayout()
 {
   m_main_layout = new QHBoxLayout();
@@ -237,6 +254,7 @@ void WiimoteEmuExtension::CreateMainLayout()
   m_main_layout->addWidget(m_udraw_tablet_box);
   m_main_layout->addWidget(m_drawsome_tablet_box);
   m_main_layout->addWidget(m_tatacon_box);
+  m_main_layout->addWidget(m_shinkansen_box);
 
   setLayout(m_main_layout);
 }
@@ -269,4 +287,5 @@ void WiimoteEmuExtension::ChangeExtensionType(u32 type)
   m_udraw_tablet_box->setHidden(type != ExtensionNumber::UDRAW_TABLET);
   m_drawsome_tablet_box->setHidden(type != ExtensionNumber::DRAWSOME_TABLET);
   m_tatacon_box->setHidden(type != ExtensionNumber::TATACON);
+  m_shinkansen_box->setHidden(type != ExtensionNumber::SHINKANSEN);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.h
@@ -33,6 +33,7 @@ private:
   void CreateUDrawTabletLayout();
   void CreateDrawsomeTabletLayout();
   void CreateTaTaConLayout();
+  void CreateShinkansenLayout();
   void CreateMainLayout();
 
   // Main
@@ -46,4 +47,5 @@ private:
   QGroupBox* m_udraw_tablet_box;
   QGroupBox* m_drawsome_tablet_box;
   QGroupBox* m_tatacon_box;
+  QGroupBox* m_shinkansen_box;
 };


### PR DESCRIPTION
This Wiimote extension is only compatible with Densha de Go! Shinkansen EX. I don't actually have access to the physical controller and the game doesn't have symbols, so this is all based on guesswork but it seems to work pretty well. We don't support LED outputs yet. All you can do with the door lockout light is map it to a rumble effect^^