### PR TITLE
Android: Change top app bar color on scroll

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/ConvertActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/ConvertActivity.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import com.google.android.material.appbar.MaterialToolbar;
 
@@ -50,6 +51,9 @@ public class ConvertActivity extends AppCompatActivity
     ctb.setTitle(getString(R.string.convert_convert));
     setSupportActionBar(tb);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+    AppBarLayout appBarLayout = findViewById(R.id.appbar_convert);
+    ThemeHelper.enableScrollTint(tb, appBarLayout, this);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
@@ -17,6 +17,8 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.dolphinemu.dolphinemu.R;
@@ -85,9 +87,12 @@ public class UserDataActivity extends AppCompatActivity
 
     buttonExportUserData.setOnClickListener(view -> exportUserData());
 
-    Toolbar tb = findViewById(R.id.toolbar_user_data);
+    MaterialToolbar tb = findViewById(R.id.toolbar_user_data);
     setSupportActionBar(tb);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+    AppBarLayout appBarLayout = findViewById(R.id.appbar_user_data);
+    ThemeHelper.enableScrollTint(tb, appBarLayout, this);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/riivolution/ui/RiivolutionBootActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/riivolution/ui/RiivolutionBootActivity.java
@@ -12,6 +12,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import com.google.android.material.appbar.MaterialToolbar;
 
@@ -86,6 +87,9 @@ public class RiivolutionBootActivity extends AppCompatActivity
     ctb.setTitle(getString(R.string.riivolution_riivolution));
     setSupportActionBar(tb);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+    AppBarLayout appBarLayout = findViewById(R.id.appbar_riivolution);
+    ThemeHelper.enableScrollTint(tb, appBarLayout, this);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -14,11 +14,12 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.dolphinemu.dolphinemu.NativeLibrary;
@@ -88,10 +89,13 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     mPresenter = new SettingsActivityPresenter(this, getSettings());
     mPresenter.onCreate(savedInstanceState, menuTag, gameID, revision, isWii, this);
 
-    Toolbar tb = findViewById(R.id.toolbar_settings);
+    MaterialToolbar tb = findViewById(R.id.toolbar_settings);
     mToolbarLayout = findViewById(R.id.toolbar_settings_layout);
     setSupportActionBar(tb);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+    AppBarLayout appBarLayout = findViewById(R.id.appbar_settings);
+    ThemeHelper.enableScrollTint(tb, appBarLayout, this);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ThemeHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ThemeHelper.java
@@ -6,6 +6,12 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.preference.PreferenceManager;
 
+import androidx.annotation.ColorInt;
+
+import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.color.MaterialColors;
+
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.ui.main.ThemeProvider;
 
@@ -103,5 +109,38 @@ public class ThemeHelper
     {
       activity.recreate();
     }
+  }
+
+  private static void setStatusBarColor(@ColorInt int color, Activity activity)
+  {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
+    {
+      activity.getWindow()
+              .setStatusBarColor(activity.getResources().getColor(android.R.color.black));
+    }
+    else
+    {
+      activity.getWindow().setStatusBarColor(color);
+    }
+  }
+
+  public static void enableScrollTint(MaterialToolbar toolbar, AppBarLayout appBarLayout,
+          Activity activity)
+  {
+    appBarLayout.addOnOffsetChangedListener((layout, verticalOffset) ->
+    {
+      if (-verticalOffset >= (layout.getTotalScrollRange() / 2))
+      {
+        @ColorInt int color = MaterialColors.getColor(toolbar, R.attr.colorSurfaceVariant);
+        toolbar.setBackgroundColor(color);
+        setStatusBarColor(color, activity);
+      }
+      else
+      {
+        @ColorInt int color = MaterialColors.getColor(toolbar, R.attr.colorSurface);
+        toolbar.setBackgroundColor(color);
+        setStatusBarColor(color, activity);
+      }
+    });
   }
 }

--- a/Source/Android/app/src/main/res/layout/activity_cheats.xml
+++ b/Source/Android/app/src/main/res/layout/activity_cheats.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/coordinator_main"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -9,7 +9,8 @@
         android:id="@+id/appbar_cheats"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true">
+        android:layout_alignParentTop="true"
+        app:elevation="0dp">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_cheats"

--- a/Source/Android/app/src/main/res/layout/activity_main.xml
+++ b/Source/Android/app/src/main/res/layout/activity_main.xml
@@ -9,7 +9,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:elevation="0dp">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_main"

--- a/Source/Android/app/src/main/res/layout/activity_settings.xml
+++ b/Source/Android/app/src/main/res/layout/activity_settings.xml
@@ -10,7 +10,8 @@
         android:id="@+id/appbar_settings"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true">
+        android:layout_alignParentTop="true"
+        app:elevation="0dp">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             style="?attr/collapsingToolbarLayoutMediumStyle"


### PR DESCRIPTION
To create more visual separation between list contents and the top app bar, the color will slightly change when collapsing the top app bar on the settings activity. Additionally this fixes visual bugs where an incorrect color would flash when expanding the collapsed toolbar and on some API levels top app bars would have a shadow appear underneath which is now removed.

Every activity with a collapsing top app bar will now tint on scroll

Before - 
![before](https://user-images.githubusercontent.com/14132249/189540056-7113ab4a-3622-455b-9ea0-ab1b5cd75a71.gif)

After -
![after](https://user-images.githubusercontent.com/14132249/189540063-c4497781-03b6-470b-928b-163787d5a4b8.gif)

### Other Themes

Green
![image](https://user-images.githubusercontent.com/14132249/189649059-149c879e-37be-4978-be17-d6ea52f60160.png)

Pink
![image](https://user-images.githubusercontent.com/14132249/189649128-b8abcc1d-ca35-4e9e-a420-4ff5e70bb5eb.png)
