### PR TITLE
Android: Remove other color edge effect definitions

### DIFF
--- a/Source/Android/app/src/main/res/values-night-v31/themes.xml
+++ b/Source/Android/app/src/main/res/values-night-v31/themes.xml
@@ -24,9 +24,6 @@
         <item name="colorSurfaceInverse">@color/m3_sys_color_dynamic_dark_surface_variant</item>
         <item name="colorPrimaryInverse">@color/m3_sys_color_dynamic_dark_inverse_primary</item>
 
-        <item name="android:colorControlHighlight">@color/m3_sys_color_dynamic_dark_on_surface_variant</item>
-        <item name="android:colorEdgeEffect">@color/m3_sys_color_dynamic_dark_secondary</item>
-
         <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
     </style>

--- a/Source/Android/app/src/main/res/values-v31/themes.xml
+++ b/Source/Android/app/src/main/res/values-v31/themes.xml
@@ -24,9 +24,6 @@
         <item name="colorSurfaceInverse">@color/m3_sys_color_dynamic_light_surface_variant</item>
         <item name="colorPrimaryInverse">@color/m3_sys_color_dynamic_light_inverse_primary</item>
 
-        <item name="android:colorControlHighlight">@color/m3_sys_color_dynamic_light_on_surface_variant</item>
-        <item name="android:colorEdgeEffect">@color/m3_sys_color_dynamic_light_secondary</item>
-
         <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
     </style>

--- a/Source/Android/app/src/main/res/values/themes.xml
+++ b/Source/Android/app/src/main/res/values/themes.xml
@@ -91,9 +91,6 @@
         <item name="colorSurfaceInverse">@color/green_inverseSurface</item>
         <item name="colorPrimaryInverse">@color/green_inversePrimary</item>
 
-        <item name="android:colorControlHighlight">@color/green_onSurfaceVariant</item>
-        <item name="android:colorEdgeEffect">@color/green_secondary</item>
-
         <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
     </style>
@@ -124,9 +121,6 @@
         <item name="colorOnSurfaceInverse">@color/pink_inverseOnSurface</item>
         <item name="colorSurfaceInverse">@color/pink_inverseSurface</item>
         <item name="colorPrimaryInverse">@color/pink_inversePrimary</item>
-
-        <item name="android:colorControlHighlight">@color/pink_onSurfaceVariant</item>
-        <item name="android:colorEdgeEffect">@color/pink_secondary</item>
 
         <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>


### PR DESCRIPTION
Looks like I missed these in the previous PR. Now all themes will not have the dark color edge effect.