### PR TITLE
Android: Add more top app bars

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/ConvertActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/ConvertActivity.java
@@ -8,6 +8,9 @@ import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.material.appbar.CollapsingToolbarLayout;
+import com.google.android.material.appbar.MaterialToolbar;
+
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.fragments.ConvertFragment;
 import org.dolphinemu.dolphinemu.utils.ThemeHelper;
@@ -41,5 +44,18 @@ public class ConvertActivity extends AppCompatActivity
       fragment = ConvertFragment.newInstance(path);
       getSupportFragmentManager().beginTransaction().add(R.id.fragment_convert, fragment).commit();
     }
+
+    MaterialToolbar tb = findViewById(R.id.toolbar_convert);
+    CollapsingToolbarLayout ctb = findViewById(R.id.toolbar_convert_layout);
+    ctb.setTitle(getString(R.string.convert_convert));
+    setSupportActionBar(tb);
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+  }
+
+  @Override
+  public boolean onSupportNavigateUp()
+  {
+    onBackPressed();
+    return true;
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/riivolution/ui/RiivolutionBootActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/riivolution/ui/RiivolutionBootActivity.java
@@ -12,6 +12,9 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.appbar.CollapsingToolbarLayout;
+import com.google.android.material.appbar.MaterialToolbar;
+
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.features.riivolution.model.RiivolutionPatches;
@@ -77,6 +80,12 @@ public class RiivolutionBootActivity extends AppCompatActivity
       patches.loadConfig();
       runOnUiThread(() -> populateList(patches));
     }).start();
+
+    MaterialToolbar tb = findViewById(R.id.toolbar_riivolution);
+    CollapsingToolbarLayout ctb = findViewById(R.id.toolbar_riivolution_layout);
+    ctb.setTitle(getString(R.string.riivolution_riivolution));
+    setSupportActionBar(tb);
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
   }
 
   @Override
@@ -86,6 +95,13 @@ public class RiivolutionBootActivity extends AppCompatActivity
 
     if (mPatches != null)
       mPatches.saveConfig();
+  }
+
+  @Override
+  public boolean onSupportNavigateUp()
+  {
+    onBackPressed();
+    return true;
   }
 
   private void populateList(RiivolutionPatches patches)

--- a/Source/Android/app/src/main/res/layout-land/activity_user_data.xml
+++ b/Source/Android/app/src/main/res/layout-land/activity_user_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -10,116 +10,135 @@
         android:id="@+id/appbar_user_data"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_alignParentTop="true"
+        app:elevation="0dp">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar_user_data"
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            style="?attr/collapsingToolbarLayoutMediumStyle"
+            android:id="@+id/toolbar_user_data_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?attr/colorSurface" />
+            android:layout_height="?attr/collapsingToolbarLayoutMediumSize"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_user_data"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorSurface"
+                app:layout_collapseMode="pin"
+                app:elevation="0dp" />
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <TextView
-        android:id="@+id/text_type"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_medlarge"
-        app:layout_constraintBottom_toTopOf="@id/text_path"
-        app:layout_constraintEnd_toStartOf="@id/divider"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/appbar_user_data"
-        app:layout_constraintVertical_chainStyle="packed"
-        app:layout_constraintWidth_max="400dp"
-        tools:text="@string/user_data_new_location" />
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <TextView
-        android:id="@+id/text_path"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_medlarge"
-        tools:text="/storage/emulated/0/Android/data/org.dolphinemu.dolphinemu/files"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/divider"
-        app:layout_constraintTop_toBottomOf="@id/text_type"
-        app:layout_constraintBottom_toTopOf="@id/text_android_11"
-        app:layout_constraintWidth_max="400dp" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingTop="16dp">
 
-    <TextView
-        android:id="@+id/text_android_11"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_medlarge"
-        android:text="@string/user_data_new_location_android_11"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/divider"
-        app:layout_constraintTop_toBottomOf="@id/text_path"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintWidth_max="400dp" />
+            <TextView
+                android:id="@+id/text_type"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toTopOf="@id/text_path"
+                app:layout_constraintWidth_max="400dp"
+                app:layout_constraintEnd_toStartOf="@id/divider"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/divider"
+                tools:text="@string/user_data_new_location" />
 
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/barrier_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="end"
-        app:constraint_referenced_ids="text_type,text_path,text_android_11" />
+            <TextView
+                android:id="@+id/text_path"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                tools:text="/storage/emulated/0/Android/data/org.dolphinemu.dolphinemu/files"
+                app:layout_constraintWidth_max="400dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/divider"
+                app:layout_constraintTop_toBottomOf="@id/text_type"
+                app:layout_constraintBottom_toTopOf="@id/text_android_11" />
 
-    <View
-        android:id="@+id/divider"
-        android:layout_width="1dp"
-        android:layout_height="0dp"
-        android:background="#1F000000"
-        android:layout_marginStart="24dp"
-        android:layout_marginEnd="24dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@id/barrier_text"
-        app:layout_constraintEnd_toStartOf="@id/barrier_buttons" />
+            <TextView
+                android:id="@+id/text_android_11"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/user_data_new_location_android_11"
+                app:layout_constraintWidth_max="400dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/divider"
+                app:layout_constraintTop_toBottomOf="@id/text_path"
+                app:layout_constraintBottom_toBottomOf="parent" />
 
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/barrier_buttons"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="start"
-        app:constraint_referenced_ids="button_open_system_file_manager,button_import_user_data,button_export_user_data" />
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/barrier_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="end"
+                app:constraint_referenced_ids="text_type,text_path,text_android_11" />
 
-    <Button
-        android:id="@+id/button_open_system_file_manager"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/user_data_open_system_file_manager"
-        app:layout_constraintBottom_toTopOf="@id/button_import_user_data"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/barrier_text"
-        app:layout_constraintTop_toBottomOf="@+id/appbar_user_data"
-        app:layout_constraintVertical_chainStyle="packed"
-        app:layout_constraintWidth_max="400dp" />
+            <View
+                android:id="@+id/divider"
+                android:layout_width="1dp"
+                android:layout_height="0dp"
+                android:background="#1F000000"
+                android:layout_marginStart="24dp"
+                android:layout_marginEnd="24dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/barrier_text"
+                app:layout_constraintEnd_toStartOf="@id/barrier_buttons" />
 
-    <Button
-        android:id="@+id/button_import_user_data"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/user_data_import"
-        app:layout_constraintStart_toEndOf="@id/barrier_text"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button_open_system_file_manager"
-        app:layout_constraintBottom_toTopOf="@id/button_export_user_data"
-        app:layout_constraintWidth_max="400dp" />
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/barrier_buttons"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="start"
+                app:constraint_referenced_ids="button_open_system_file_manager,button_import_user_data,button_export_user_data" />
 
-    <Button
-        android:id="@+id/button_export_user_data"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/user_data_export"
-        app:layout_constraintStart_toEndOf="@id/barrier_text"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button_import_user_data"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintWidth_max="400dp" />
+            <Button
+                android:id="@+id/button_open_system_file_manager"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:text="@string/user_data_open_system_file_manager"
+                app:layout_constraintBottom_toTopOf="@id/button_import_user_data"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/barrier_text"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_chainStyle="packed" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <Button
+                android:id="@+id/button_import_user_data"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:text="@string/user_data_import"
+                app:layout_constraintStart_toEndOf="@id/barrier_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/button_open_system_file_manager"
+                app:layout_constraintBottom_toTopOf="@id/button_export_user_data" />
+
+            <Button
+                android:id="@+id/button_export_user_data"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:text="@string/user_data_export"
+                app:layout_constraintStart_toEndOf="@id/barrier_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/button_import_user_data"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout-w680dp-land/activity_convert.xml
+++ b/Source/Android/app/src/main/res/layout-w680dp-land/activity_convert.xml
@@ -1,50 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fillViewport="true"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_convert"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:layout_alignParentTop="true"
+        app:elevation="0dp">
 
-        <TextView
-            android:id="@+id/label_format_info"
-            android:layout_width="0dp"
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            style="?attr/collapsingToolbarLayoutMediumStyle"
+            android:id="@+id/toolbar_convert_layout"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/collapsingToolbarLayoutMediumSize"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_convert"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorSurface"
+                app:layout_collapseMode="pin"
+                app:elevation="0dp" />
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/convert_format_info"
-            app:layout_constraintWidth_max="400dp"
-            app:layout_constraintHorizontal_bias="1.0"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/divider" />
+            android:padding="16dp">
 
-        <View
-            android:id="@+id/divider"
-            android:layout_width="1dp"
-            android:layout_height="0dp"
-            android:background="#1F000000"
-            android:layout_marginStart="24dp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@id/label_format_info"
-            app:layout_constraintEnd_toStartOf="@id/fragment_convert" />
+            <TextView
+                android:id="@+id/label_format_info"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/convert_format_info"
+                app:layout_constraintWidth_max="400dp"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/divider" />
 
-        <FrameLayout
-            android:id="@+id/fragment_convert"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="24dp"
-            app:layout_constraintWidth_max="400dp"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@id/divider"
-            app:layout_constraintEnd_toEndOf="parent" />
+            <View
+                android:id="@+id/divider"
+                android:layout_width="1dp"
+                android:layout_height="0dp"
+                android:background="#1F000000"
+                android:layout_marginStart="24dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/label_format_info"
+                app:layout_constraintEnd_toStartOf="@id/fragment_convert" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <FrameLayout
+                android:id="@+id/fragment_convert"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="24dp"
+                app:layout_constraintWidth_max="400dp"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/divider"
+                app:layout_constraintEnd_toEndOf="parent" />
 
-</ScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/activity_convert.xml
+++ b/Source/Android/app/src/main/res/layout/activity_convert.xml
@@ -1,48 +1,81 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fillViewport="true"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_convert"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:layout_alignParentTop="true"
+        app:elevation="0dp">
 
-        <FrameLayout
-            android:id="@+id/fragment_convert"
-            android:layout_width="0dp"
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            style="?attr/collapsingToolbarLayoutMediumStyle"
+            android:id="@+id/toolbar_convert_layout"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/collapsingToolbarLayoutMediumSize"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_convert"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorSurface"
+                app:layout_collapseMode="pin"
+                app:elevation="0dp" />
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintWidth_max="400dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@id/divider" />
+            android:padding="16dp">
 
-        <View
-            android:id="@+id/divider"
-            android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:background="#1F000000"
-            android:layout_marginTop="24dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/fragment_convert"
-            app:layout_constraintBottom_toTopOf="@id/label_format_info" />
+            <FrameLayout
+                android:id="@+id/fragment_convert"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintWidth_max="400dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/divider" />
 
-        <TextView
-            android:id="@+id/label_format_info"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:text="@string/convert_format_info"
-            app:layout_constraintWidth_max="400dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/divider"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            <View
+                android:id="@+id/divider"
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:background="#1F000000"
+                android:layout_marginTop="24dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/fragment_convert"
+                app:layout_constraintBottom_toTopOf="@id/label_format_info" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/label_format_info"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/convert_format_info"
+                app:layout_constraintWidth_max="400dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/divider"
+                app:layout_constraintBottom_toBottomOf="parent" />
 
-</ScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/activity_riivolution_boot.xml
+++ b/Source/Android/app/src/main/res/layout/activity_riivolution_boot.xml
@@ -1,60 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/text_sd_root"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_riivolution"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_large"
-        tools:text="@string/riivolution_sd_root"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/divider" />
+        android:layout_alignParentTop="true"
+        app:elevation="0dp">
 
-    <View
-        android:id="@+id/divider"
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="#1F000000"
-        android:layout_marginHorizontal="@dimen/spacing_large"
-        android:layout_marginVertical="@dimen/spacing_small"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text_sd_root"
-        app:layout_constraintBottom_toTopOf="@id/scroll_view" />
-
-    <ScrollView
-        android:id="@+id/scroll_view"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/divider"
-        app:layout_constraintBottom_toTopOf="@id/button_start">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_view"
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            style="?attr/collapsingToolbarLayoutMediumStyle"
+            android:id="@+id/toolbar_riivolution_layout"
             android:layout_width="match_parent"
-            android:layout_height="0dp" />
+            android:layout_height="?attr/collapsingToolbarLayoutMediumSize"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
 
-    </ScrollView>
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_riivolution"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorSurface"
+                app:layout_collapseMode="pin"
+                app:elevation="0dp" />
 
-    <Button
-        android:id="@+id/button_start"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_large"
-        android:text="@string/riivolution_start"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/scroll_view"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/text_sd_root"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_large"
+                tools:text="@string/riivolution_sd_root"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/divider" />
+
+            <View
+                android:id="@+id/divider"
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:background="#1F000000"
+                android:layout_marginHorizontal="@dimen/spacing_large"
+                android:layout_marginVertical="@dimen/spacing_small"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/text_sd_root"
+                app:layout_constraintBottom_toTopOf="@id/scroll_view" />
+
+            <androidx.core.widget.NestedScrollView
+                android:id="@+id/scroll_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/divider"
+                app:layout_constraintBottom_toTopOf="@id/button_start">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recycler_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp" />
+
+            </androidx.core.widget.NestedScrollView>
+
+            <Button
+                android:id="@+id/button_start"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_large"
+                android:text="@string/riivolution_start"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/scroll_view"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/activity_user_data.xml
+++ b/Source/Android/app/src/main/res/layout/activity_user_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -10,88 +10,111 @@
         android:id="@+id/appbar_user_data"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_alignParentTop="true"
+        app:elevation="0dp">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar_user_data"
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            style="?attr/collapsingToolbarLayoutMediumStyle"
+            android:id="@+id/toolbar_user_data_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?attr/colorSurface" />
+            android:layout_height="?attr/collapsingToolbarLayoutMediumSize"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_user_data"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorSurface"
+                app:layout_collapseMode="pin"
+                app:elevation="0dp" />
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <TextView
-        android:id="@+id/text_type"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_medlarge"
-        app:layout_constraintBottom_toTopOf="@id/text_path"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/appbar_user_data"
-        app:layout_constraintVertical_chainStyle="packed"
-        app:layout_constraintWidth_max="400dp"
-        tools:text="@string/user_data_new_location" />
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <TextView
-        android:id="@+id/text_path"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_medlarge"
-        tools:text="/storage/emulated/0/Android/data/org.dolphinemu.dolphinemu/files"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text_type"
-        app:layout_constraintBottom_toTopOf="@id/text_android_11"
-        app:layout_constraintWidth_max="400dp" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingTop="20dp"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp">
 
-    <TextView
-        android:id="@+id/text_android_11"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/spacing_medlarge"
-        android:layout_marginTop="@dimen/spacing_medlarge"
-        android:layout_marginBottom="24dp"
-        android:text="@string/user_data_new_location_android_11"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text_path"
-        app:layout_constraintBottom_toTopOf="@id/button_open_system_file_manager"
-        app:layout_constraintWidth_max="400dp" />
+            <TextView
+                android:id="@+id/text_type"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_medlarge"
+                app:layout_constraintBottom_toTopOf="@id/text_path"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="parent"
+                app:layout_constraintVertical_chainStyle="packed"
+                tools:text="@string/user_data_new_location" />
 
-    <Button
-        android:id="@+id/button_open_system_file_manager"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/user_data_open_system_file_manager"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text_android_11"
-        app:layout_constraintBottom_toTopOf="@id/button_import_user_data" />
+            <TextView
+                android:id="@+id/text_path"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_medlarge"
+                android:layout_marginBottom="@dimen/spacing_medlarge"
+                tools:text="/storage/emulated/0/Android/data/org.dolphinemu.dolphinemu/files"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/text_type"
+                app:layout_constraintBottom_toTopOf="@id/text_android_11" />
 
-    <Button
-        android:id="@+id/button_import_user_data"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/user_data_import"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button_open_system_file_manager"
-        app:layout_constraintBottom_toTopOf="@id/button_export_user_data" />
+            <TextView
+                android:id="@+id/text_android_11"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_medlarge"
+                android:layout_marginBottom="@dimen/spacing_medlarge"
+                android:text="@string/user_data_new_location_android_11"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/text_path"
+                app:layout_constraintBottom_toTopOf="@id/button_open_system_file_manager" />
 
-    <Button
-        android:id="@+id/button_export_user_data"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/user_data_export"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button_import_user_data"
-        app:layout_constraintBottom_toBottomOf="parent" />
+            <Button
+                android:id="@+id/button_open_system_file_manager"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/user_data_open_system_file_manager"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/text_android_11"
+                app:layout_constraintBottom_toTopOf="@id/button_import_user_data" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <Button
+                android:id="@+id/button_import_user_data"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/user_data_import"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/button_open_system_file_manager"
+                app:layout_constraintBottom_toTopOf="@id/button_export_user_data" />
+
+            <Button
+                android:id="@+id/button_export_user_data"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/user_data_export"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/button_import_user_data"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -543,6 +543,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     </string>
 
     <!-- Riivolution Boot Screen -->
+    <string name="riivolution_riivolution">Riivolution</string>
     <string name="riivolution_sd_root">SD Root: %1$s</string>
     <string name="riivolution_disabled">Disabled</string>
     <string name="riivolution_start">Start</string>


### PR DESCRIPTION
This adds collapsing top app bars to make each activity more consistent with one another. CheatsActivity still isn't really compatible with collapsing top app bars but hopefully I could introduce that later.

### **UserDataActivity**

Landscape

Before - 
![image](https://user-images.githubusercontent.com/14132249/189570317-2bfd1fdc-8725-4ebb-9a6b-2f0b1deb4efd.png)

After -
![image](https://user-images.githubusercontent.com/14132249/189570550-6f627ec0-b4c6-4c98-aaa0-2252fb395087.png)

Portrait

Before -
![image](https://user-images.githubusercontent.com/14132249/189570652-54ac62e1-0408-4e23-88c7-d2a3453d5acd.png)

After -
![image](https://user-images.githubusercontent.com/14132249/189570610-712bdb60-bec4-4c6b-8532-84171e954ba7.png)

### **ConvertActivity**

Before -
![image](https://user-images.githubusercontent.com/14132249/189571133-c5d012c8-6f83-4ff5-b957-c62385f5c1d5.png)

After -
![image](https://user-images.githubusercontent.com/14132249/189571110-eeb23f25-106b-4a1c-b9e3-3a5ee851d8c9.png)

### **RiivolutionBootActivity**

Before -
![image](https://user-images.githubusercontent.com/14132249/189570981-9e0ac6c1-eae7-40e2-8239-1e72c644a5b3.png)

After -
![image](https://user-images.githubusercontent.com/14132249/189571266-9f7fdab5-b342-44e2-9bde-89e17c139050.png)
