### PR TITLE
NetPlayClient: Treat power button event as a netplay stop.

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2244,8 +2244,7 @@ void NetPlayClient::SendPadHostPoll(const PadIndex pad_num)
   SendAsync(std::move(packet));
 }
 
-// called from ---GUI--- thread and ---NETPLAY--- thread (client side)
-bool NetPlayClient::StopGame()
+void NetPlayClient::InvokeStop()
 {
   m_is_running.Clear();
 
@@ -2254,6 +2253,12 @@ bool NetPlayClient::StopGame()
   m_wii_pad_event.Set();
   m_first_pad_status_received_event.Set();
   m_wait_on_input_event.Set();
+}
+
+// called from ---GUI--- thread and ---NETPLAY--- thread (client side)
+bool NetPlayClient::StopGame()
+{
+  InvokeStop();
 
   NetPlay_Disable();
 
@@ -2269,13 +2274,7 @@ void NetPlayClient::Stop()
   if (!m_is_running.IsSet())
     return;
 
-  m_is_running.Clear();
-
-  // stop waiting for input
-  m_gc_pad_event.Set();
-  m_wii_pad_event.Set();
-  m_first_pad_status_received_event.Set();
-  m_wait_on_input_event.Set();
+  InvokeStop();
 
   // Tell the server to stop if we have a pad mapped in game.
   if (LocalPlayerHasControllerMapped())

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -910,6 +910,7 @@ void NetPlayClient::OnStopGame(sf::Packet& packet)
 
 void NetPlayClient::OnPowerButton()
 {
+  InvokeStop();
   m_dialog->OnMsgPowerButton();
 }
 

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -252,6 +252,8 @@ private:
   void DisplayPlayersPing();
   u32 GetPlayersMaxPing() const;
 
+  bool WaitForWiimoteBuffer(int _number);
+
   void OnData(sf::Packet& packet);
   void OnPlayerJoin(sf::Packet& packet);
   void OnPlayerLeave(sf::Packet& packet);

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -117,6 +117,7 @@ public:
   // Called from the GUI thread.
   bool IsConnected() const { return m_is_connected; }
   bool StartGame(const std::string& path);
+  void InvokeStop();
   bool StopGame();
   void Stop();
   bool ChangeGame(const std::string& game);


### PR DESCRIPTION
Sending the power button event over netplay is completely unsynced, which means more likely than not two instances of Dolphin will start the graceful shutdown sequence at different points in time, desyncing in the process. This wouldn't be so bad -- we're shutting down anyway -- except that inputs may still be queried by the game during the shutdown. This can lead to a situation where one instance has fully shut down, but another instance is still waiting for an input.

By stopping Netplay as soon as the power button event is received, we can work around this; that means it won't wait for input that may never come.

@JMC47 Can you test if this fixes known cases of hangs on shutdown, especially when Wiimote disconnects are involved?