### PR TITLE
Updater: Check OS version

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -324,6 +324,10 @@ if(UNIX)
     target_link_libraries(traversal_server PRIVATE ${SYSTEMD_LIBRARIES})
   endif()
 elseif(WIN32)
+  add_custom_command(TARGET common POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/build_info.txt" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/build_info.txt"
+  )
+
   target_link_libraries(common PRIVATE "-INCLUDE:enableCompatPatches")
 endif()
 

--- a/Source/Core/Common/build_info.txt
+++ b/Source/Core/Common/build_info.txt
@@ -1,0 +1,5 @@
+// Indicate the minimum OS version required for the binary to run properly.
+// Updater will fail the update if the user does not meet this requirement.
+OSMinimumVersionWin10=10.0.15063.0
+OSMinimumVersionWin11=10.0.22000.0
+OSMinimumVersionMacOS=10.14

--- a/Source/Core/DolphinLib.vcxproj
+++ b/Source/Core/DolphinLib.vcxproj
@@ -60,4 +60,13 @@
   <Import Project="$(ExternalsDir)zstd\exports.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
+  <ItemGroup>
+    <BuildInfoFiles Include="Common\build_info.txt" />
+  </ItemGroup>
+  <Target Name="CopyBuildInfo" AfterTargets="Build"
+    Inputs="@(BuildInfoFiles)"
+    Outputs="@(BuildInfoFiles -> '$(BinaryOutputDir)%(RecursiveDir)%(Filename)%(Extension)')">
+    <Message Text="Copy: @(BuildInfoFiles) -&gt; $(BinaryOutputDir)" Importance="High" />
+    <Copy SourceFiles="@(BuildInfoFiles)" DestinationFolder="$(BinaryOutputDir)" />
+  </Target>
 </Project>

--- a/Source/Core/MacUpdater/MacUI.mm
+++ b/Source/Core/MacUpdater/MacUI.mm
@@ -3,6 +3,7 @@
 
 #include "MacUpdater/ViewController.h"
 
+#include "UpdaterCommon/Platform.h"
 #include "UpdaterCommon/UI.h"
 
 #include <Cocoa/Cocoa.h>
@@ -135,4 +136,22 @@ void UI::Stop()
 // Stub. Only needed on Windows
 void UI::Init()
 {
+}
+
+Platform::BuildInfo::BuildInfo(const std::string& content)
+{
+  map = {{"OSMinimumVersionMacOS", ""}};
+  Parse(content);
+}
+
+bool Platform::VersionCheck(const BuildInfo& next_build_info)
+{
+  // TODO implement OS Minimum Version check
+  // It should go something like this:
+  // auto target_version = next_build_info.GetVersion("OSMinimumVersionMacOS");
+  // if (!target_version.has_value() || current_version >= target_version)
+  //   return true;
+  // show error
+  // return false;
+  return true;
 }

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -246,11 +246,11 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
 #endif
 
   // Run the updater!
-  const std::string command_line = MakeUpdaterCommandLine(updater_flags);
+  std::string command_line = MakeUpdaterCommandLine(updater_flags);
   INFO_LOG_FMT(COMMON, "Updater command line: {}", command_line);
 
 #ifdef _WIN32
-  STARTUPINFO sinfo = {sizeof(sinfo)};
+  STARTUPINFO sinfo{.cb = sizeof(sinfo)};
   sinfo.dwFlags = STARTF_FORCEOFFFEEDBACK;  // No hourglass cursor after starting the process.
   PROCESS_INFORMATION pinfo;
   if (CreateProcessW(UTF8ToWString(reloc_updater_path).c_str(), UTF8ToWString(command_line).data(),

--- a/Source/Core/UpdaterCommon/Platform.h
+++ b/Source/Core/UpdaterCommon/Platform.h
@@ -1,0 +1,100 @@
+// Copyright 2018 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <map>
+#include <optional>
+#include <sstream>
+
+#include "Common/CommonTypes.h"
+#include "Common/StringUtil.h"
+
+namespace Platform
+{
+struct BuildVersion
+{
+  u32 major{};
+  u32 minor{};
+  u32 build{};
+  auto operator<=>(BuildVersion const& rhs) const = default;
+  static std::optional<BuildVersion> from_string(const std::string& str)
+  {
+    auto components = SplitString(str, '.');
+    // Allow variable number of components (truncating after "build"), but not
+    // empty.
+    if (components.size() == 0)
+      return {};
+    BuildVersion version;
+    if (!TryParse(components[0], &version.major, 10))
+      return {};
+    if (components.size() > 1 && !TryParse(components[1], &version.minor, 10))
+      return {};
+    if (components.size() > 2 && !TryParse(components[2], &version.build, 10))
+      return {};
+    return version;
+  }
+};
+
+enum class VersionCheckStatus
+{
+  NothingToDo,
+  UpdateOptional,
+  UpdateRequired,
+};
+
+struct VersionCheckResult
+{
+  VersionCheckStatus status{VersionCheckStatus::NothingToDo};
+  std::optional<BuildVersion> current_version{};
+  std::optional<BuildVersion> target_version{};
+};
+
+class BuildInfo
+{
+  using Map = std::map<std::string, std::string>;
+
+public:
+  BuildInfo() = default;
+  BuildInfo(const std::string& content);
+
+  std::optional<std::string> GetString(const std::string& name) const
+  {
+    auto it = map.find(name);
+    if (it == map.end() || it->second.size() == 0)
+      return {};
+    return it->second;
+  }
+
+  std::optional<BuildVersion> GetVersion(const std::string& name) const
+  {
+    auto str = GetString(name);
+    if (!str.has_value())
+      return {};
+    return BuildVersion::from_string(str.value());
+  }
+
+private:
+  void Parse(const std::string& content)
+  {
+    std::stringstream content_stream(content);
+    std::string line;
+    while (std::getline(content_stream, line))
+    {
+      if (line.starts_with("//"))
+        continue;
+      const size_t equals_index = line.find('=');
+      if (equals_index == line.npos)
+        continue;
+      auto key = line.substr(0, equals_index);
+      auto key_it = map.find(key);
+      if (key_it == map.end())
+        continue;
+      key_it->second = line.substr(equals_index + 1);
+    }
+  }
+  Map map;
+};
+
+bool VersionCheck(const BuildInfo& next_build_info);
+}  // namespace Platform

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -17,6 +17,7 @@
 #include "Common/HttpRequest.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
+#include "UpdaterCommon/Platform.h"
 #include "UpdaterCommon/UI.h"
 
 #ifndef _WIN32
@@ -276,6 +277,31 @@ bool DownloadContent(const std::vector<TodoList::DownloadOp>& to_download,
   return true;
 }
 
+bool PlatformVersionCheck(const std::vector<TodoList::UpdateOp>& to_update,
+                          const std::string& temp_dir)
+{
+  UI::SetDescription("Checking platform...");
+
+  const auto op_it = std::find_if(to_update.cbegin(), to_update.cend(),
+                                  [&](const auto& op) { return op.filename == "build_info.txt"; });
+  if (op_it == to_update.cend())
+    return true;
+
+  const auto op = *op_it;
+  std::string build_info_path =
+      temp_dir + DIR_SEP + HexEncode(op.new_hash.data(), op.new_hash.size());
+  std::string build_info_content;
+  if (!File::ReadFileToString(build_info_path, build_info_content) ||
+      op.new_hash != ComputeHash(build_info_content))
+  {
+    fprintf(log_fp, "Failed to read %s\n.", build_info_path.c_str());
+    return false;
+  }
+  auto next_build_info = Platform::BuildInfo(build_info_content);
+
+  return Platform::VersionCheck(next_build_info);
+}
+
 TodoList ComputeActionsToDo(Manifest this_manifest, Manifest next_manifest)
 {
   TodoList todo;
@@ -471,6 +497,11 @@ bool PerformUpdate(const TodoList& todo, const std::string& install_base_path,
   if (!DownloadContent(todo.to_download, content_base_url, temp_path))
     return false;
   fprintf(log_fp, "Download step completed.\n");
+
+  fprintf(log_fp, "Starting platform version check step...\n");
+  if (!PlatformVersionCheck(todo.to_update, temp_path))
+    return false;
+  fprintf(log_fp, "Platform version check step completed.\n");
 
   fprintf(log_fp, "Starting update step...\n");
   if (!UpdateFiles(todo.to_update, install_base_path, temp_path))

--- a/Source/Core/WinUpdater/CMakeLists.txt
+++ b/Source/Core/WinUpdater/CMakeLists.txt
@@ -2,6 +2,7 @@ set (MANIFEST_FILE Updater.exe.manifest)
 
 add_executable(winupdater WIN32
   Main.cpp
+  Platform.cpp
   WinUI.cpp
   ${MANIFEST_FILE})
 

--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -21,10 +21,10 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
 {
   if (lstrlenW(pCmdLine) == 0)
   {
-    MessageBox(nullptr,
-               L"This updater is not meant to be launched directly. Configure Auto-Update in "
-               "Dolphin's settings instead.",
-               L"Error", MB_ICONERROR);
+    MessageBoxW(nullptr,
+                L"This updater is not meant to be launched directly. Configure Auto-Update in "
+                "Dolphin's settings instead.",
+                L"Error", MB_ICONERROR);
     return 1;
   }
 

--- a/Source/Core/WinUpdater/Platform.cpp
+++ b/Source/Core/WinUpdater/Platform.cpp
@@ -1,0 +1,54 @@
+#include <Windows.h>
+
+#include <optional>
+
+#include "UpdaterCommon/Platform.h"
+#include "UpdaterCommon/UI.h"
+
+namespace Platform
+{
+BuildInfo::BuildInfo(const std::string& content)
+{
+  map = {{"OSMinimumVersionWin10", ""}, {"OSMinimumVersionWin11", ""}};
+  Parse(content);
+}
+
+static BuildVersion CurrentOSVersion()
+{
+  typedef DWORD(WINAPI * RtlGetVersion_t)(PRTL_OSVERSIONINFOW);
+  auto RtlGetVersion =
+      (RtlGetVersion_t)GetProcAddress(GetModuleHandle(TEXT("ntdll")), "RtlGetVersion");
+  RTL_OSVERSIONINFOW info{.dwOSVersionInfoSize = sizeof(info)};
+  RtlGetVersion(&info);
+  return {.major = info.dwMajorVersion, .minor = info.dwMinorVersion, .build = info.dwBuildNumber};
+}
+
+static VersionCheckResult OSVersionCheck(const BuildInfo& build_info)
+{
+  VersionCheckResult result;
+  result.current_version = CurrentOSVersion();
+
+  constexpr BuildVersion WIN11_BASE{10, 0, 22000};
+  const char* version_name =
+      (result.current_version >= WIN11_BASE) ? "OSMinimumVersionWin11" : "OSMinimumVersionWin10";
+  result.target_version = build_info.GetVersion(version_name);
+
+  if (!result.target_version.has_value() || result.current_version >= result.target_version)
+    result.status = VersionCheckStatus::NothingToDo;
+  else
+    result.status = VersionCheckStatus::UpdateRequired;
+  return result;
+}
+
+bool VersionCheck(const BuildInfo& next_build_info)
+{
+  // If the binary requires more recent OS, inform the user.
+  auto os_check = OSVersionCheck(next_build_info);
+  if (os_check.status == VersionCheckStatus::UpdateRequired)
+  {
+    UI::Error("Please update Windows in order to update Dolphin.");
+    return false;
+  }
+  return true;
+}
+}  // namespace Platform

--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -253,8 +253,8 @@ void Stop()
 
 void LaunchApplication(std::string path)
 {
-  // Hack: Launching the updater over the explorer ensures that admin priviliges are dropped. Why?
-  // Ask Microsoft.
+  // Indirectly start the application via explorer. This effectively drops admin priviliges because
+  // explorer is running as current user.
   ShellExecuteW(nullptr, nullptr, L"explorer.exe", UTF8ToWString(path).c_str(), nullptr, SW_SHOW);
 }
 

--- a/Source/Core/WinUpdater/WinUpdater.vcxproj
+++ b/Source/Core/WinUpdater/WinUpdater.vcxproj
@@ -25,8 +25,14 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\UpdaterCommon\Platform.h" />
+    <ClInclude Include="..\UpdaterCommon\UI.h" />
+    <ClInclude Include="..\UpdaterCommon\UpdaterCommon.h" />
+  </ItemGroup>
+  <ItemGroup>
     <ClCompile Include="..\UpdaterCommon\UpdaterCommon.cpp" />
     <ClCompile Include="Main.cpp" />
+    <ClCompile Include="Platform.cpp" />
     <ClCompile Include="WinUI.cpp" />
   </ItemGroup>
   <Import Project="$(ExternalsDir)cpp-optparse\exports.props" />


### PR DESCRIPTION
Same as #11051 but without the VC++ redist stuff.

MacOS implementation is to be done in separate PR. It can use build_info.txt or opt to use some native API to fetch the min OS version from the plist, or whatever.