### PR TITLE
Android: Remove TabLayout workaround

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
@@ -2,12 +2,6 @@
 
 package org.dolphinemu.dolphinemu.adapters;
 
-import android.content.Context;
-import android.graphics.drawable.Drawable;
-import android.text.Spannable;
-import android.text.SpannableString;
-import android.text.style.ImageSpan;
-
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -20,21 +14,19 @@ import org.dolphinemu.dolphinemu.ui.platform.PlatformGamesFragment;
 
 public class PlatformPagerAdapter extends FragmentPagerAdapter
 {
-  private Context mContext;
   private SwipeRefreshLayout.OnRefreshListener mOnRefreshListener;
 
-  private final static int[] TAB_ICONS =
+  public final static int[] TAB_ICONS =
           {
                   R.drawable.ic_gamecube,
                   R.drawable.ic_wii,
                   R.drawable.ic_folder
           };
 
-  public PlatformPagerAdapter(FragmentManager fm, Context context,
+  public PlatformPagerAdapter(FragmentManager fm,
           SwipeRefreshLayout.OnRefreshListener onRefreshListener)
   {
     super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
-    mContext = context;
     mOnRefreshListener = onRefreshListener;
   }
 
@@ -53,24 +45,5 @@ public class PlatformPagerAdapter extends FragmentPagerAdapter
   public int getCount()
   {
     return TAB_ICONS.length;
-  }
-
-  @Override
-  public CharSequence getPageTitle(int position)
-  {
-    // Hax from https://guides.codepath.com/android/Google-Play-Style-Tabs-using-TabLayout#design-support-library
-    // Apparently a workaround for TabLayout not supporting icons.
-    // TODO: This workaround will eventually not be necessary; switch to more legit methods when that is the case
-    // TODO: Also remove additional hax from styles.xml
-    Drawable drawable =
-            mContext.getResources().getDrawable(TAB_ICONS[position], mContext.getTheme());
-    drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
-
-    ImageSpan imageSpan = new ImageSpan(drawable, ImageSpan.ALIGN_BOTTOM);
-
-    SpannableString sb = new SpannableString(" ");
-    sb.setSpan(imageSpan, 0, 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-
-    return sb;
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -346,7 +346,7 @@ public final class MainActivity extends AppCompatActivity
   private void setPlatformTabsAndStartGameFileCacheService()
   {
     PlatformPagerAdapter platformPagerAdapter = new PlatformPagerAdapter(
-            getSupportFragmentManager(), this, this);
+            getSupportFragmentManager(), this);
     mViewPager.setAdapter(platformPagerAdapter);
     mViewPager.setOffscreenPageLimit(platformPagerAdapter.getCount());
     mTabLayout.setupWithViewPager(mViewPager);
@@ -359,6 +359,11 @@ public final class MainActivity extends AppCompatActivity
         IntSetting.MAIN_LAST_PLATFORM_TAB.setIntGlobal(NativeConfig.LAYER_BASE, tab.getPosition());
       }
     });
+
+    for (int i = 0; i < PlatformPagerAdapter.TAB_ICONS.length; i++)
+    {
+      mTabLayout.getTabAt(i).setIcon(PlatformPagerAdapter.TAB_ICONS[i]);
+    }
 
     mViewPager.setCurrentItem(IntSetting.MAIN_LAST_PLATFORM_TAB.getIntGlobal());
 

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Hax to make Tablayout render icons -->
-    <style name="MyCustomTextAppearance" parent="TextAppearance.Design.Tab">
-        <item name="textAllCaps">false</item>
-    </style>
-
     <!-- Custom button styles -->
     <style name="InGameMenuOption" parent="Widget.Material3.Button.TextButton">
         <item name="android:textColor">?attr/colorOnSurface</item>


### PR DESCRIPTION
This lets us use tab highlights

Before -
![image](https://user-images.githubusercontent.com/14132249/190205467-e80ca062-52bc-4007-b909-d6f50b87bb43.png)

After -
![image](https://user-images.githubusercontent.com/14132249/190205558-c0979a60-2ae1-44f1-bdb7-97e28ab961cb.png)
