### PR TITLE
Revert "windows: distribute vcredist loose files"

### DIFF
--- a/Data/license.txt
+++ b/Data/license.txt
@@ -337,8 +337,3 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
-
-
-This program uses VC++ Redistributable code. The license for those object
-files can be found at:
-https://visualstudio.microsoft.com/license-terms/vs2022-ga-community/

--- a/LICENSES/MSVC-Redist.txt
+++ b/LICENSES/MSVC-Redist.txt
@@ -1,3 +1,0 @@
-This program uses VC++ Redistributable code. The license for those object
-files can be found at:
-https://visualstudio.microsoft.com/license-terms/vs2022-ga-community/

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -440,28 +440,6 @@ if(WIN32)
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/qt.conf.win" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/qt.conf"
   )
 
-  # Copy VC++ Redist.
-  # NOTE This *intentionally* does not copy debug redist files.
-  # TODO This should really occur for any executable target.
-  # TODO Actually use cmake 'install' and InstallRequiredSystemLibraries.
-  if(MSVC_C_ARCHITECTURE_ID)
-    string(TOLOWER "${MSVC_C_ARCHITECTURE_ID}" CMAKE_MSVC_ARCH)
-  elseif(MSVC_CXX_ARCHITECTURE_ID)
-    string(TOLOWER "${MSVC_CXX_ARCHITECTURE_ID}" CMAKE_MSVC_ARCH)
-  else()
-    set(CMAKE_MSVC_ARCH x86)
-  endif()
-  set(MSVC_REDIST_NAME VC${MSVC_TOOLSET_VERSION})
-  find_path(MSVC_REDIST_DIR NAMES ${CMAKE_MSVC_ARCH}/Microsoft.${MSVC_REDIST_NAME}.CRT)
-  mark_as_advanced(MSVC_REDIST_DIR)
-  set(MSVC_CRT_DIR "${MSVC_REDIST_DIR}/${CMAKE_MSVC_ARCH}/Microsoft.${MSVC_REDIST_NAME}.CRT")
-  file(GLOB MSVC_REDIST_DLLS "${MSVC_CRT_DIR}/*.dll")
-  foreach(MsvcRedistDll IN LISTS MSVC_REDIST_DLLS)
-    add_custom_command(TARGET dolphin-emu POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${MsvcRedistDll}" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
-    )
-  endforeach()
-
   # Delegate to Qt's official deployment binary on Windows to copy over the necessary Qt-specific libraries, etc.
   get_target_property(MOC_EXECUTABLE_LOCATION Qt${QT_VERSION_MAJOR}::moc IMPORTED_LOCATION)
   get_filename_component(QT_BINARY_DIRECTORY "${MOC_EXECUTABLE_LOCATION}" DIRECTORY)

--- a/Source/VSProps/Base.Dolphin.props
+++ b/Source/VSProps/Base.Dolphin.props
@@ -84,16 +84,4 @@
       <AdditionalOptions>/NODEFAULTLIB:msvcrt %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
-
-  <Target Name="CopyVCRedist" AfterTargets="Build" Condition="'$(ConfigurationType)'=='Application'">
-    <ItemGroup>
-      <VCRedistSourceFiles
-        Include="$(VCToolsRedistInstallDir)$(Platform)\Microsoft.VC$(PlatformToolsetVersion).CRT\*.dll" />
-    </ItemGroup>
-    <Copy
-      SourceFiles="@(VCRedistSourceFiles)"
-      DestinationFolder="$(BinaryOutputDir)"
-      SkipUnchangedFiles="true"
-    />
-  </Target>
 </Project>


### PR DESCRIPTION
From the GPLv2 (emphasis added):

> The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, **unless that component itself accompanies the executable**.

By shipping the Visual C++ DLLs with the executable, the system library exception no longer applies, meaning we're obligated to provide source code for the DLLs. This is of course impossible.

Text to the same effect is also present in the GPLv3.