### PR TITLE
Netplay: Redesign Wiimote data exchange.

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -279,6 +279,7 @@ add_library(core
   HW/WiimoteCommon/WiimoteReport.h
   HW/WiimoteEmu/Camera.cpp
   HW/WiimoteEmu/Camera.h
+  HW/WiimoteEmu/DesiredWiimoteState.cpp
   HW/WiimoteEmu/DesiredWiimoteState.h
   HW/WiimoteEmu/Dynamics.cpp
   HW/WiimoteEmu/Dynamics.h

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -287,6 +287,7 @@ add_library(core
   HW/WiimoteEmu/Encryption.h
   HW/WiimoteEmu/Extension/Classic.cpp
   HW/WiimoteEmu/Extension/Classic.h
+  HW/WiimoteEmu/Extension/DesiredExtensionState.h
   HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
   HW/WiimoteEmu/Extension/DrawsomeTablet.h
   HW/WiimoteEmu/Extension/Drums.cpp

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -279,6 +279,7 @@ add_library(core
   HW/WiimoteCommon/WiimoteReport.h
   HW/WiimoteEmu/Camera.cpp
   HW/WiimoteEmu/Camera.h
+  HW/WiimoteEmu/DesiredWiimoteState.h
   HW/WiimoteEmu/Dynamics.cpp
   HW/WiimoteEmu/Dynamics.h
   HW/WiimoteEmu/EmuSubroutines.cpp

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -498,9 +498,6 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   if (core_parameter.bWii && !Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_ENABLED))
   {
     Wiimote::LoadConfig();
-
-    if (NetPlay::IsNetPlayRunning())
-      NetPlay::SetupWiimotes();
   }
 
   FreeLook::LoadInputConfig();

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -94,8 +94,6 @@ ControllerEmu::ControlGroup* GetDrawsomeTabletGroup(int number,
                                                     WiimoteEmu::DrawsomeTabletGroup group);
 ControllerEmu::ControlGroup* GetTaTaConGroup(int number, WiimoteEmu::TaTaConGroup group);
 ControllerEmu::ControlGroup* GetShinkansenGroup(int number, WiimoteEmu::ShinkansenGroup group);
-
-bool NetPlay_GetButtonPress(int wiimote, bool pressed);
 }  // namespace Wiimote
 
 namespace WiimoteReal

--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
@@ -7,6 +7,11 @@
 #include "Core/HW/WiimoteCommon/WiimoteConstants.h"
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
 
+namespace WiimoteEmu
+{
+struct DesiredWiimoteState;
+}
+
 namespace WiimoteCommon
 {
 // Source: HID_010_SPC_PFL/1.0 (official HID specification)
@@ -34,7 +39,8 @@ public:
   virtual void SetWiimoteDeviceIndex(u8 index) = 0;
 
   // Called every ~200hz after HID channels are established.
-  virtual void Update() = 0;
+  virtual void PrepareInput(WiimoteEmu::DesiredWiimoteState* target_state) = 0;
+  virtual void Update(const WiimoteEmu::DesiredWiimoteState& target_state) = 0;
 
   void SetInterruptCallback(InterruptCallbackType callback) { m_callback = std::move(callback); }
 
@@ -42,8 +48,10 @@ public:
   // Does not include HID-type header.
   virtual void InterruptDataOutput(const u8* data, u32 size) = 0;
 
-  // Used to connect a disconnected wii remote on button press.
-  virtual bool IsButtonPressed() = 0;
+  // Get a snapshot of the current state of the Wiimote's buttons.
+  // Note that only the button bits of the return value are meaningful, the rest should be ignored.
+  // This is used to query a disconnected Wiimote whether it wants to reconnect.
+  virtual ButtonData GetCurrentlyPressedButtons() = 0;
 
 protected:
   void InterruptDataInputCallback(const u8* data, u32 size)

--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
@@ -30,6 +30,9 @@ public:
   virtual void EventLinked() = 0;
   virtual void EventUnlinked() = 0;
 
+  virtual u8 GetWiimoteDeviceIndex() const = 0;
+  virtual void SetWiimoteDeviceIndex(u8 index) = 0;
+
   // Called every ~200hz after HID channels are established.
   virtual void Update() = 0;
 

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
@@ -1,0 +1,226 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <cstring>
+#include <optional>
+#include <type_traits>
+#include <variant>
+
+#include "Common/CommonTypes.h"
+
+#include "Core/HW/WiimoteEmu/DesiredWiimoteState.h"
+#include "Core/HW/WiimoteEmu/Extension/Classic.h"
+#include "Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h"
+#include "Core/HW/WiimoteEmu/Extension/Drums.h"
+#include "Core/HW/WiimoteEmu/Extension/Guitar.h"
+#include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
+#include "Core/HW/WiimoteEmu/Extension/Shinkansen.h"
+#include "Core/HW/WiimoteEmu/Extension/TaTaCon.h"
+#include "Core/HW/WiimoteEmu/Extension/Turntable.h"
+#include "Core/HW/WiimoteEmu/Extension/UDrawTablet.h"
+#include "Core/HW/WiimoteEmu/MotionPlus.h"
+
+namespace WiimoteEmu
+{
+SerializedWiimoteState SerializeDesiredState(const DesiredWiimoteState& state)
+{
+  // If no motion or extension data is present, we can serialize into a much smaller representation,
+  // which reduces data sent over the network.
+  const bool is_buttons_only =
+      (state.acceleration == DesiredWiimoteState::DEFAULT_ACCELERATION &&
+       state.camera_points == DesiredWiimoteState::DEFAULT_CAMERA &&
+       !state.motion_plus.has_value() && state.extension.data.index() == ExtensionNumber::NONE);
+
+  SerializedWiimoteState s;
+  s.length = 0;
+  s.data[s.length++] =
+      u8((state.buttons.a) | (state.buttons.b << 1) | (state.buttons.plus << 2) |
+         (state.buttons.minus << 3) | (state.buttons.one << 4) | (state.buttons.two << 5) |
+         (state.buttons.home << 6) | ((is_buttons_only ? 0 : 1) << 7));
+  const u8 dpad = u8((state.buttons.up) | (state.buttons.down << 1) | (state.buttons.left << 2) |
+                     (state.buttons.right << 3));
+  if (is_buttons_only)
+  {
+    // There's four unused bits here, which could be used to further optimize for common situations.
+    s.data[s.length++] = dpad;
+    return s;
+  }
+
+  const u16 accel_x = state.acceleration.value.x;             // 10 bits
+  const u16 accel_y = state.acceleration.value.y;             // 10 bits
+  const u16 accel_z = state.acceleration.value.z;             // 10 bits
+  const u16 camera_p0_x = state.camera_points[0].position.x;  // 10 bits
+  const u16 camera_p0_y = state.camera_points[0].position.y;  // 10 bits
+  const u16 camera_p1_x = state.camera_points[1].position.x;  // 10 bits
+  const u16 camera_p1_y = state.camera_points[1].position.y;  // 10 bits
+  const u8 camera_p0_size = state.camera_points[0].size;      // 4 bits
+  const u8 camera_p1_size = state.camera_points[1].size;      // 4 bits
+  static_assert(std::variant_size_v<DesiredExtensionState::ExtensionData> < (1 << 5));
+  const u8 extension = u8(state.extension.data.index());  // maximum of 5 bits
+  const u8 motion_plus = state.motion_plus.has_value() ? 1 : 0;
+  s.data[s.length++] = u8(dpad | (camera_p0_size << 4));
+  s.data[s.length++] = u8(camera_p0_x);
+  s.data[s.length++] = u8(camera_p0_y);
+  s.data[s.length++] = u8(camera_p1_x);
+  s.data[s.length++] = u8(camera_p1_y);
+  s.data[s.length++] = u8(((camera_p0_x >> 8) & 3) | (((camera_p0_y >> 8) & 3) << 2) |
+                          (((camera_p1_x >> 8) & 3) << 4) | (((camera_p1_y >> 8) & 3) << 6));
+  s.data[s.length++] =
+      u8(((accel_x >> 8) & 3) | (((accel_y >> 8) & 3) << 2) | (camera_p1_size << 4));
+  s.data[s.length++] = u8(accel_x);
+  s.data[s.length++] = u8(accel_y);
+  s.data[s.length++] = u8(accel_z);
+  s.data[s.length++] = u8(((accel_z >> 8) & 3) | (motion_plus << 2) | (extension << 3));
+
+  if (motion_plus)
+  {
+    const u16 pitch_slow = state.motion_plus->is_slow.x ? 1 : 0;
+    const u16 roll_slow = state.motion_plus->is_slow.y ? 1 : 0;
+    const u16 yaw_slow = state.motion_plus->is_slow.z ? 1 : 0;
+    const u16 pitch_value = state.motion_plus->gyro.value.x;  // 14 bits
+    const u16 roll_value = state.motion_plus->gyro.value.y;   // 14 bits
+    const u16 yaw_value = state.motion_plus->gyro.value.z;    // 14 bits
+    s.data[s.length++] = u8(pitch_value);
+    s.data[s.length++] = u8((pitch_value >> 8) | (pitch_slow << 7));
+    s.data[s.length++] = u8(roll_value);
+    s.data[s.length++] = u8((roll_value >> 8) | (roll_slow << 7));
+    s.data[s.length++] = u8(yaw_value);
+    s.data[s.length++] = u8((yaw_value >> 8) | (yaw_slow << 7));
+  }
+
+  if (extension)
+  {
+    std::visit(
+        [&s](const auto& arg) {
+          using T = std::decay_t<decltype(arg)>;
+          if constexpr (!std::is_same_v<std::monostate, T>)
+          {
+            static_assert(sizeof(arg) <= 6);
+            static_assert(std::is_trivially_copyable_v<T>);
+            std::memcpy(&s.data[s.length], &arg, sizeof(arg));
+            s.length += sizeof(arg);
+          }
+        },
+        state.extension.data);
+  }
+
+  return s;
+}
+
+template <typename T>
+static bool DeserializeExtensionState(DesiredWiimoteState* state,
+                                      const SerializedWiimoteState& serialized, size_t offset)
+{
+  if (serialized.length < offset + sizeof(T))
+    return false;
+  auto& e = state->extension.data.emplace<T>();
+  static_assert(std::is_trivially_copyable_v<T>);
+  std::memcpy(&e, &serialized.data[offset], sizeof(T));
+  return true;
+}
+
+bool DeserializeDesiredState(DesiredWiimoteState* state, const SerializedWiimoteState& serialized)
+{
+  // clear state
+  state->buttons.hex = 0;
+  state->acceleration = DesiredWiimoteState::DEFAULT_ACCELERATION;
+  state->camera_points = DesiredWiimoteState::DEFAULT_CAMERA;
+  state->motion_plus = std::nullopt;
+  state->extension.data = std::monostate();
+
+  if (serialized.length < 2)
+  {
+    // can't be valid
+    return false;
+  }
+
+  const auto& d = serialized.data;
+  state->buttons.a = d[0] & 1;
+  state->buttons.b = (d[0] >> 1) & 1;
+  state->buttons.plus = (d[0] >> 2) & 1;
+  state->buttons.minus = (d[0] >> 3) & 1;
+  state->buttons.one = (d[0] >> 4) & 1;
+  state->buttons.two = (d[0] >> 5) & 1;
+  state->buttons.home = (d[0] >> 6) & 1;
+  const u8 has_motion_or_extension_data = (d[0] >> 7) & 1;
+  state->buttons.up = d[1] & 1;
+  state->buttons.down = (d[1] >> 1) & 1;
+  state->buttons.left = (d[1] >> 2) & 1;
+  state->buttons.right = (d[1] >> 3) & 1;
+
+  if (!has_motion_or_extension_data)
+  {
+    // is button-only state, we're done
+    return true;
+  }
+
+  if (serialized.length < 12)
+  {
+    // if it's not a button-only state it needs to have at least 12 bytes for the basic Wiimote data
+    return false;
+  }
+
+  state->camera_points[0].size = d[1] >> 4;
+  state->camera_points[0].position.x = d[2] | ((d[6] & 3) << 8);
+  state->camera_points[0].position.y = d[3] | (((d[6] >> 2) & 3) << 8);
+  state->camera_points[1].position.x = d[4] | (((d[6] >> 4) & 3) << 8);
+  state->camera_points[1].position.y = d[5] | (((d[6] >> 6) & 3) << 8);
+  state->camera_points[1].size = d[7] >> 4;
+  state->acceleration.value.x = d[8] | ((d[7] & 3) << 8);
+  state->acceleration.value.y = d[9] | (((d[7] >> 2) & 3) << 8);
+  state->acceleration.value.z = d[10] | ((d[11] & 3) << 8);
+  const u8 has_motion_plus = (d[11] >> 2) & 1;
+  const u8 extension = d[11] >> 3;
+
+  if (has_motion_plus && serialized.length < 18)
+  {
+    // can't hold motion plus data
+    return false;
+  }
+
+  if (has_motion_plus)
+  {
+    const u16 pitch_value = d[12] | ((d[13] & 0x3f) << 8);
+    const u16 roll_value = d[14] | ((d[15] & 0x3f) << 8);
+    const u16 yaw_value = d[16] | ((d[17] & 0x3f) << 8);
+    const bool pitch_slow = (d[13] & 0x80) != 0;
+    const bool roll_slow = (d[15] & 0x80) != 0;
+    const bool yaw_slow = (d[17] & 0x80) != 0;
+    state->motion_plus = MotionPlus::DataFormat::Data{
+        MotionPlus::DataFormat::GyroRawValue{
+            MotionPlus::DataFormat::GyroType(pitch_value, roll_value, yaw_value)},
+        MotionPlus::DataFormat::SlowType(pitch_slow, roll_slow, yaw_slow)};
+  }
+
+  const size_t offset = has_motion_plus ? 18 : 12;
+  switch (extension)
+  {
+  case ExtensionNumber::NONE:
+    return true;
+  case ExtensionNumber::NUNCHUK:
+    return DeserializeExtensionState<Nunchuk::DataFormat>(state, serialized, offset);
+  case ExtensionNumber::CLASSIC:
+    return DeserializeExtensionState<Classic::DataFormat>(state, serialized, offset);
+  case ExtensionNumber::GUITAR:
+    return DeserializeExtensionState<Guitar::DataFormat>(state, serialized, offset);
+  case ExtensionNumber::DRUMS:
+    return DeserializeExtensionState<Drums::DesiredState>(state, serialized, offset);
+  case ExtensionNumber::TURNTABLE:
+    return DeserializeExtensionState<Turntable::DataFormat>(state, serialized, offset);
+  case ExtensionNumber::UDRAW_TABLET:
+    return DeserializeExtensionState<UDrawTablet::DataFormat>(state, serialized, offset);
+  case ExtensionNumber::DRAWSOME_TABLET:
+    return DeserializeExtensionState<DrawsomeTablet::DataFormat>(state, serialized, offset);
+  case ExtensionNumber::TATACON:
+    return DeserializeExtensionState<TaTaCon::DataFormat>(state, serialized, offset);
+  case ExtensionNumber::SHINKANSEN:
+    return DeserializeExtensionState<Shinkansen::DesiredState>(state, serialized, offset);
+  default:
+    break;
+  }
+
+  return false;
+}
+}  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
@@ -8,6 +8,7 @@
 
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
 #include "Core/HW/WiimoteEmu/Camera.h"
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/MotionPlus.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
@@ -26,5 +27,6 @@ struct DesiredWiimoteState
   WiimoteCommon::AccelData acceleration = DEFAULT_ACCELERATION;
   std::array<CameraPoint, 2> camera_points = DEFAULT_CAMERA;
   std::optional<MotionPlus::DataFormat::Data> motion_plus = std::nullopt;
+  DesiredExtensionState extension;
 };
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include <array>
+
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
+#include "Core/HW/WiimoteEmu/Camera.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 namespace WiimoteEmu
@@ -14,7 +17,11 @@ struct DesiredWiimoteState
   static constexpr WiimoteCommon::AccelData DEFAULT_ACCELERATION = WiimoteCommon::AccelData(
       {Wiimote::ACCEL_ZERO_G << 2, Wiimote::ACCEL_ZERO_G << 2, Wiimote::ACCEL_ONE_G << 2});
 
+  // No light detected by the IR camera.
+  static constexpr std::array<CameraPoint, 2> DEFAULT_CAMERA = {CameraPoint(), CameraPoint()};
+
   WiimoteCommon::ButtonData buttons{};  // non-button state in this is ignored
   WiimoteCommon::AccelData acceleration = DEFAULT_ACCELERATION;
+  std::array<CameraPoint, 2> camera_points = DEFAULT_CAMERA;
 };
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
@@ -4,9 +4,11 @@
 #pragma once
 
 #include <array>
+#include <optional>
 
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
 #include "Core/HW/WiimoteEmu/Camera.h"
+#include "Core/HW/WiimoteEmu/MotionPlus.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 namespace WiimoteEmu
@@ -23,5 +25,6 @@ struct DesiredWiimoteState
   WiimoteCommon::ButtonData buttons{};  // non-button state in this is ignored
   WiimoteCommon::AccelData acceleration = DEFAULT_ACCELERATION;
   std::array<CameraPoint, 2> camera_points = DEFAULT_CAMERA;
+  std::optional<MotionPlus::DataFormat::Data> motion_plus = std::nullopt;
 };
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
@@ -1,0 +1,14 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "Core/HW/WiimoteCommon/WiimoteReport.h"
+
+namespace WiimoteEmu
+{
+struct DesiredWiimoteState
+{
+  WiimoteCommon::ButtonData buttons{};  // non-button state in this is ignored
+};
+}  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
@@ -29,4 +29,14 @@ struct DesiredWiimoteState
   std::optional<MotionPlus::DataFormat::Data> motion_plus = std::nullopt;
   DesiredExtensionState extension;
 };
+
+// For Netplay.
+struct SerializedWiimoteState
+{
+  u8 length;
+  std::array<u8, 24> data;  // 12 bytes Wiimote, 6 bytes MotionPlus, 6 bytes Extension
+};
+
+SerializedWiimoteState SerializeDesiredState(const DesiredWiimoteState& state);
+bool DeserializeDesiredState(DesiredWiimoteState* state, const SerializedWiimoteState& serialized);
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.h
@@ -4,11 +4,17 @@
 #pragma once
 
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 namespace WiimoteEmu
 {
 struct DesiredWiimoteState
 {
+  // 1g in Z direction, which is the default returned by an unmoving emulated Wiimote.
+  static constexpr WiimoteCommon::AccelData DEFAULT_ACCELERATION = WiimoteCommon::AccelData(
+      {Wiimote::ACCEL_ZERO_G << 2, Wiimote::ACCEL_ZERO_G << 2, Wiimote::ACCEL_ONE_G << 2});
+
   WiimoteCommon::ButtonData buttons{};  // non-button state in this is ignored
+  WiimoteCommon::AccelData acceleration = DEFAULT_ACCELERATION;
 };
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -156,6 +156,9 @@ void Wiimote::HandleExtensionSwap(ExtensionNumber desired_extension_number,
 
   if (m_is_motion_plus_attached && !desired_motion_plus)
   {
+    INFO_LOG_FMT(WIIMOTE, "Detaching Motion Plus (Wiimote {} in slot {})", m_index,
+                 m_bt_device_index);
+
     // M+ is attached and it's not wanted, so remove it.
     m_extension_port.AttachExtension(GetNoneExtension());
     m_is_motion_plus_attached = false;
@@ -180,6 +183,9 @@ void Wiimote::HandleExtensionSwap(ExtensionNumber desired_extension_number,
     }
     else
     {
+      INFO_LOG_FMT(WIIMOTE, "Attaching Motion Plus (Wiimote {} in slot {})", m_index,
+                   m_bt_device_index);
+
       // No extension attached so attach M+.
       m_is_motion_plus_attached = true;
       m_extension_port.AttachExtension(&m_motion_plus);
@@ -194,12 +200,18 @@ void Wiimote::HandleExtensionSwap(ExtensionNumber desired_extension_number,
     // A different extension is wanted (either by user or by the M+ logic above)
     if (GetActiveExtensionNumber() != ExtensionNumber::NONE)
     {
+      INFO_LOG_FMT(WIIMOTE, "Detaching Extension (Wiimote {} in slot {})", m_index,
+                   m_bt_device_index);
+
       // First we must detach the current extension.
       // The next call will change to the new extension if needed.
       m_active_extension = ExtensionNumber::NONE;
     }
     else
     {
+      INFO_LOG_FMT(WIIMOTE, "Switching to Extension {} (Wiimote {} in slot {})",
+                   desired_extension_number, m_index, m_bt_device_index);
+
       m_active_extension = desired_extension_number;
     }
 

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -142,7 +142,8 @@ void Wiimote::SendAck(OutputReportID rpt_id, ErrorCode error_code)
   InterruptDataInputCallback(rpt.GetData(), rpt.GetSize());
 }
 
-void Wiimote::HandleExtensionSwap()
+void Wiimote::HandleExtensionSwap(ExtensionNumber desired_extension_number,
+                                  bool desired_motion_plus)
 {
   if (WIIMOTE_BALANCE_BOARD == m_index)
   {
@@ -150,11 +151,6 @@ void Wiimote::HandleExtensionSwap()
     // In the future if we support an emulated balance board we can force the BB "extension" here.
     return;
   }
-
-  ExtensionNumber desired_extension_number =
-      static_cast<ExtensionNumber>(m_attachments->GetSelectedAttachment());
-
-  const bool desired_motion_plus = m_motion_plus_setting.GetValue();
 
   // FYI: AttachExtension also connects devices to the i2c bus
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -10,6 +10,8 @@
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -105,7 +107,7 @@ Classic::Classic() : Extension1stParty("Classic", _trans("Classic Controller"))
   }
 }
 
-void Classic::Update()
+void Classic::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
   DataFormat classic_data = {};
 
@@ -149,7 +151,12 @@ void Classic::Update()
 
   classic_data.SetButtons(buttons);
 
-  Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = classic_data;
+  target_state->data = classic_data;
+}
+
+void Classic::Update(const DesiredExtensionState& target_state)
+{
+  DefaultExtensionUpdate<DataFormat>(&m_reg, target_state);
 }
 
 void Classic::Reset()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
@@ -178,7 +178,8 @@ public:
 
   Classic();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(ClassicGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h
@@ -1,0 +1,76 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <type_traits>
+#include <variant>
+
+#include "Common/BitUtils.h"
+
+#include "Core/HW/WiimoteEmu/Extension/Classic.h"
+#include "Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h"
+#include "Core/HW/WiimoteEmu/Extension/Drums.h"
+#include "Core/HW/WiimoteEmu/Extension/Extension.h"
+#include "Core/HW/WiimoteEmu/Extension/Guitar.h"
+#include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
+#include "Core/HW/WiimoteEmu/Extension/Shinkansen.h"
+#include "Core/HW/WiimoteEmu/Extension/TaTaCon.h"
+#include "Core/HW/WiimoteEmu/Extension/Turntable.h"
+#include "Core/HW/WiimoteEmu/Extension/UDrawTablet.h"
+#include "Core/HW/WiimoteEmu/ExtensionPort.h"
+
+namespace WiimoteEmu
+{
+struct DesiredExtensionState
+{
+  using ExtensionData =
+      std::variant<std::monostate, Nunchuk::DataFormat, Classic::DataFormat, Guitar::DataFormat,
+                   Drums::DesiredState, Turntable::DataFormat, UDrawTablet::DataFormat,
+                   DrawsomeTablet::DataFormat, TaTaCon::DataFormat, Shinkansen::DesiredState>;
+  ExtensionData data = std::monostate();
+
+  static_assert(std::is_same_v<std::monostate,
+                               std::variant_alternative_t<ExtensionNumber::NONE, ExtensionData>>);
+  static_assert(
+      std::is_same_v<Nunchuk::DataFormat,
+                     std::variant_alternative_t<ExtensionNumber::NUNCHUK, ExtensionData>>);
+  static_assert(
+      std::is_same_v<Classic::DataFormat,
+                     std::variant_alternative_t<ExtensionNumber::CLASSIC, ExtensionData>>);
+  static_assert(std::is_same_v<Guitar::DataFormat,
+                               std::variant_alternative_t<ExtensionNumber::GUITAR, ExtensionData>>);
+  static_assert(std::is_same_v<Drums::DesiredState,
+                               std::variant_alternative_t<ExtensionNumber::DRUMS, ExtensionData>>);
+  static_assert(
+      std::is_same_v<Turntable::DataFormat,
+                     std::variant_alternative_t<ExtensionNumber::TURNTABLE, ExtensionData>>);
+  static_assert(
+      std::is_same_v<UDrawTablet::DataFormat,
+                     std::variant_alternative_t<ExtensionNumber::UDRAW_TABLET, ExtensionData>>);
+  static_assert(
+      std::is_same_v<DrawsomeTablet::DataFormat,
+                     std::variant_alternative_t<ExtensionNumber::DRAWSOME_TABLET, ExtensionData>>);
+  static_assert(
+      std::is_same_v<TaTaCon::DataFormat,
+                     std::variant_alternative_t<ExtensionNumber::TATACON, ExtensionData>>);
+  static_assert(
+      std::is_same_v<Shinkansen::DesiredState,
+                     std::variant_alternative_t<ExtensionNumber::SHINKANSEN, ExtensionData>>);
+  static_assert(std::variant_size_v<DesiredExtensionState::ExtensionData> == ExtensionNumber::MAX);
+};
+
+template <typename T>
+void DefaultExtensionUpdate(EncryptedExtension::Register* reg,
+                            const DesiredExtensionState& target_state)
+{
+  if (std::holds_alternative<T>(target_state.data))
+  {
+    Common::BitCastPtr<T>(&reg->controller_data) = std::get<T>(target_state.data);
+  }
+  else
+  {
+    Common::BitCastPtr<T>(&reg->controller_data) = T{};
+  }
+}
+}  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
@@ -9,6 +9,8 @@
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -31,9 +33,9 @@ DrawsomeTablet::DrawsomeTablet() : Extension3rdParty("Drawsome", _trans("Drawsom
   m_touch->AddInput(ControllerEmu::Translate, _trans("Pressure"));
 }
 
-void DrawsomeTablet::Update()
+void DrawsomeTablet::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
-  DataFormat tablet_data = {};
+  DataFormat& tablet_data = target_state->data.emplace<DataFormat>();
 
   // Stylus X/Y (calibrated values):
   constexpr u16 MIN_X = 0x0000;
@@ -77,8 +79,11 @@ void DrawsomeTablet::Update()
 
   tablet_data.pressure1 = u8(pressure);
   tablet_data.pressure2 = u8(pressure >> 8);
+}
 
-  Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = tablet_data;
+void DrawsomeTablet::Update(const DesiredExtensionState& target_state)
+{
+  DefaultExtensionUpdate<DataFormat>(&m_reg, target_state);
 }
 
 void DrawsomeTablet::Reset()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h
@@ -27,7 +27,8 @@ class DrawsomeTablet : public Extension3rdParty
 public:
   DrawsomeTablet();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(DrawsomeTabletGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
@@ -9,6 +9,8 @@
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -77,8 +79,43 @@ Drums::Drums() : Extension1stParty("Drums", _trans("Drum Kit"))
   m_buttons->AddInput(ControllerEmu::DoNotTranslate, "+");
 }
 
-void Drums::Update()
+void Drums::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
+  DesiredState& state = target_state->data.emplace<DesiredState>();
+
+  {
+    const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
+
+    state.stick_x = MapFloat(stick_state.x, STICK_CENTER, STICK_MIN, STICK_MAX);
+    state.stick_y = MapFloat(stick_state.y, STICK_CENTER, STICK_MIN, STICK_MAX);
+  }
+
+  state.buttons = 0;
+  m_buttons->GetState(&state.buttons, drum_button_bitmasks.data());
+
+  state.drum_pads = 0;
+  m_pads->GetState(&state.drum_pads, drum_pad_bitmasks.data());
+
+  state.softness = u8(7 - std::lround(m_hit_strength_setting.GetValue() * 7 / 100));
+}
+
+void Drums::Update(const DesiredExtensionState& target_state)
+{
+  DesiredState desired_state;
+  if (std::holds_alternative<DesiredState>(target_state.data))
+  {
+    desired_state = std::get<DesiredState>(target_state.data);
+  }
+  else
+  {
+    // Set a sane default
+    desired_state.stick_x = STICK_CENTER;
+    desired_state.stick_y = STICK_CENTER;
+    desired_state.buttons = 0;
+    desired_state.drum_pads = 0;
+    desired_state.softness = 7;
+  }
+
   DataFormat drum_data = {};
 
   // The meaning of these bits are unknown but they are usually set.
@@ -94,20 +131,12 @@ void Drums::Update()
   drum_data.no_velocity_data_2 = 1;
   drum_data.softness = 7;
 
-  // Stick.
-  {
-    const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
-
-    drum_data.stick_x = MapFloat(stick_state.x, STICK_CENTER, STICK_MIN, STICK_MAX);
-    drum_data.stick_y = MapFloat(stick_state.y, STICK_CENTER, STICK_MIN, STICK_MAX);
-  }
-
-  // Buttons.
-  m_buttons->GetState(&drum_data.buttons, drum_button_bitmasks.data());
+  drum_data.stick_x = desired_state.stick_x;
+  drum_data.stick_y = desired_state.stick_y;
+  drum_data.buttons = desired_state.buttons;
 
   // Drum pads.
-  u8 current_pad_input = 0;
-  m_pads->GetState(&current_pad_input, drum_pad_bitmasks.data());
+  u8 current_pad_input = desired_state.drum_pads;
   m_new_pad_hits |= ~m_prev_pad_input & current_pad_input;
   m_prev_pad_input = current_pad_input;
 
@@ -130,8 +159,7 @@ void Drums::Update()
       drum_data.no_velocity_data_1 = 0;
       drum_data.no_velocity_data_2 = 0;
 
-      // Set softness from user-configured hit strength setting.
-      drum_data.softness = u8(7 - std::lround(m_hit_strength_setting.GetValue() * 7 / 100));
+      drum_data.softness = desired_state.softness;
 
       // A drum-pad hit causes the relevent bit to be triggered for the next 10 frames.
       constexpr u8 HIT_FRAME_COUNT = 10;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.h
@@ -28,6 +28,15 @@ enum class DrumsGroup
 class Drums : public Extension1stParty
 {
 public:
+  struct DesiredState
+  {
+    u8 stick_x;    // 6 bits
+    u8 stick_y;    // 6 bits
+    u8 buttons;    // 2 bits
+    u8 drum_pads;  // 6 bits
+    u8 softness;   // 3 bits
+  };
+
   struct DataFormat
   {
     u8 stick_x : 6;
@@ -77,7 +86,8 @@ public:
 
   Drums();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(DrumsGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
@@ -9,6 +9,8 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Inline.h"
+
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "Common/Logging/Log.h"
@@ -43,7 +45,12 @@ bool None::ReadDeviceDetectPin() const
   return false;
 }
 
-void None::Update()
+void None::BuildDesiredExtensionState(DesiredExtensionState* target_state)
+{
+  target_state->data.emplace<std::monostate>();
+}
+
+void None::Update(const DesiredExtensionState& target_state)
 {
   // Nothing needed.
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
@@ -16,6 +16,8 @@
 
 namespace WiimoteEmu
 {
+struct DesiredExtensionState;
+
 class Extension : public ControllerEmu::EmulatedController, public I2CSlave
 {
 public:
@@ -32,7 +34,8 @@ public:
 
   virtual void Reset() = 0;
   virtual void DoState(PointerWrap& p) = 0;
-  virtual void Update() = 0;
+  virtual void BuildDesiredExtensionState(DesiredExtensionState* target_state) = 0;
+  virtual void Update(const DesiredExtensionState& target_state) = 0;
 
 private:
   const char* const m_config_name;
@@ -46,7 +49,8 @@ public:
 
 private:
   bool ReadDeviceDetectPin() const override;
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
   void DoState(PointerWrap& p) override;
 
@@ -67,7 +71,6 @@ public:
   // TODO: TAS handles encryption poorly.
   EncryptionKey ext_key;
 
-protected:
   static constexpr int CALIBRATION_CHECKSUM_BYTES = 2;
 
 #pragma pack(push, 1)
@@ -97,6 +100,7 @@ protected:
 
   static_assert(0x100 == sizeof(Register));
 
+protected:
   Register m_reg = {};
 
   void Reset() override;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
@@ -11,6 +11,8 @@
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -93,7 +95,7 @@ Guitar::Guitar() : Extension1stParty(_trans("Guitar"))
   groups.emplace_back(m_slider_bar = new ControllerEmu::Slider(_trans("Slider Bar")));
 }
 
-void Guitar::Update()
+void Guitar::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
   DataFormat guitar_data = {};
 
@@ -135,7 +137,12 @@ void Guitar::Update()
   // flip button bits
   guitar_data.bt ^= 0xFFFF;
 
-  Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = guitar_data;
+  target_state->data = guitar_data;
+}
+
+void Guitar::Update(const DesiredExtensionState& target_state)
+{
+  DefaultExtensionUpdate<DataFormat>(&m_reg, target_state);
 }
 
 void Guitar::Reset()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.h
@@ -50,7 +50,8 @@ public:
 
   Guitar();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(GuitarGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -12,7 +12,9 @@
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
+
 #include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -60,7 +62,7 @@ Nunchuk::Nunchuk() : Extension1stParty(_trans("Nunchuk"))
                           "IMUAccelerometer", _trans("Accelerometer")));
 }
 
-void Nunchuk::Update()
+void Nunchuk::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
   DataFormat nc_data = {};
 
@@ -110,7 +112,12 @@ void Nunchuk::Update()
   const auto acc = ConvertAccelData(accel, ACCEL_ZERO_G << 2, ACCEL_ONE_G << 2);
   nc_data.SetAccel(acc.value);
 
-  Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = nc_data;
+  target_state->data = nc_data;
+}
+
+void Nunchuk::Update(const DesiredExtensionState& target_state)
+{
+  DefaultExtensionUpdate<DataFormat>(&m_reg, target_state);
 }
 
 void Nunchuk::Reset()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
@@ -149,7 +149,8 @@ public:
 
   Nunchuk();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
   void DoState(PointerWrap& p) override;
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.h
@@ -24,9 +24,17 @@ enum class ShinkansenGroup
 class Shinkansen : public Extension3rdParty
 {
 public:
+  struct DesiredState
+  {
+    u8 brake;
+    u8 power;
+    u16 buttons;
+  };
+
   Shinkansen();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
   ControllerEmu::ControlGroup* GetGroup(ShinkansenGroup group);
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
@@ -10,6 +10,8 @@
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -48,7 +50,7 @@ TaTaCon::TaTaCon() : Extension3rdParty("TaTaCon", _trans("Taiko Drum"))
     m_rim->AddInput(ControllerEmu::Translate, name);
 }
 
-void TaTaCon::Update()
+void TaTaCon::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
   DataFormat tatacon_data = {};
 
@@ -58,7 +60,12 @@ void TaTaCon::Update()
   // Flip button bits.
   tatacon_data.state ^= 0xff;
 
-  Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = tatacon_data;
+  target_state->data = tatacon_data;
+}
+
+void TaTaCon::Update(const DesiredExtensionState& target_state)
+{
+  DefaultExtensionUpdate<DataFormat>(&m_reg, target_state);
 }
 
 void TaTaCon::Reset()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.h
@@ -31,7 +31,8 @@ public:
 
   TaTaCon();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(TaTaConGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -10,6 +10,8 @@
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -78,7 +80,7 @@ Turntable::Turntable() : Extension1stParty("Turntable", _trans("DJ Turntable"))
   groups.emplace_back(m_crossfade = new ControllerEmu::Slider(_trans("Crossfade")));
 }
 
-void Turntable::Update()
+void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
   DataFormat tt_data = {};
 
@@ -133,7 +135,12 @@ void Turntable::Update()
   tt_data.bt ^= (BUTTON_L_GREEN | BUTTON_L_RED | BUTTON_L_BLUE | BUTTON_R_GREEN | BUTTON_R_RED |
                  BUTTON_R_BLUE | BUTTON_MINUS | BUTTON_PLUS | BUTTON_EUPHORIA);
 
-  Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = tt_data;
+  target_state->data = tt_data;
+}
+
+void Turntable::Update(const DesiredExtensionState& target_state)
+{
+  DefaultExtensionUpdate<DataFormat>(&m_reg, target_state);
 }
 
 void Turntable::Reset()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
@@ -56,7 +56,8 @@ public:
 
   Turntable();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(TurntableGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
@@ -9,6 +9,8 @@
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -48,7 +50,7 @@ UDrawTablet::UDrawTablet() : Extension3rdParty("uDraw", _trans("uDraw GameTablet
   m_touch->AddInput(ControllerEmu::Translate, _trans("Pressure"));
 }
 
-void UDrawTablet::Update()
+void UDrawTablet::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
   DataFormat tablet_data = {};
 
@@ -105,7 +107,12 @@ void UDrawTablet::Update()
   // Always 0xff
   tablet_data.unk = 0xff;
 
-  Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = tablet_data;
+  target_state->data = tablet_data;
+}
+
+void UDrawTablet::Update(const DesiredExtensionState& target_state)
+{
+  DefaultExtensionUpdate<DataFormat>(&m_reg, target_state);
 }
 
 void UDrawTablet::Reset()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.h
@@ -27,7 +27,8 @@ class UDrawTablet : public Extension3rdParty
 public:
   UDrawTablet();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(UDrawTabletGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
@@ -18,6 +18,7 @@
 
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/Dynamics.h"
+#include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 
 namespace
 {
@@ -387,7 +388,12 @@ bool MotionPlus::ReadDeviceDetectPin() const
   }
 }
 
-void MotionPlus::Update()
+void MotionPlus::BuildDesiredExtensionState(DesiredExtensionState* target_state)
+{
+  // MotionPlus is handled separately, nothing to do here.
+}
+
+void MotionPlus::Update(const DesiredExtensionState& target_state)
 {
   if (m_progress_timer)
     --m_progress_timer;

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
@@ -522,9 +522,56 @@ void MotionPlus::Update()
   }
 }
 
+MotionPlus::DataFormat::Data MotionPlus::GetGyroscopeData(const Common::Vec3& angular_velocity)
+{
+  // Conversion from radians to the calibrated values in degrees.
+  constexpr float VALUE_SCALE =
+      (CALIBRATION_SCALE_OFFSET >> (CALIBRATION_BITS - BITS_OF_PRECISION)) / float(MathUtil::TAU) *
+      360;
+
+  constexpr float SLOW_SCALE = VALUE_SCALE / CALIBRATION_SLOW_SCALE_DEGREES;
+  constexpr float FAST_SCALE = VALUE_SCALE / CALIBRATION_FAST_SCALE_DEGREES;
+
+  static_assert(ZERO_VALUE == 1 << (BITS_OF_PRECISION - 1),
+                "SLOW_MAX_RAD_PER_SEC assumes calibrated zero is at center of sensor values.");
+
+  constexpr u16 SENSOR_RANGE = 1 << (BITS_OF_PRECISION - 1);
+  constexpr float SLOW_MAX_RAD_PER_SEC = SENSOR_RANGE / SLOW_SCALE;
+
+  // Slow (high precision) scaling can be used if it fits in the sensor range.
+  const float yaw = angular_velocity.z;
+  const bool yaw_slow = (std::abs(yaw) < SLOW_MAX_RAD_PER_SEC);
+  const s32 yaw_value = yaw * (yaw_slow ? SLOW_SCALE : FAST_SCALE);
+
+  const float roll = angular_velocity.y;
+  const bool roll_slow = (std::abs(roll) < SLOW_MAX_RAD_PER_SEC);
+  const s32 roll_value = roll * (roll_slow ? SLOW_SCALE : FAST_SCALE);
+
+  const float pitch = angular_velocity.x;
+  const bool pitch_slow = (std::abs(pitch) < SLOW_MAX_RAD_PER_SEC);
+  const s32 pitch_value = pitch * (pitch_slow ? SLOW_SCALE : FAST_SCALE);
+
+  const u16 clamped_yaw_value = u16(std::clamp(yaw_value + ZERO_VALUE, 0, MAX_VALUE));
+  const u16 clamped_roll_value = u16(std::clamp(roll_value + ZERO_VALUE, 0, MAX_VALUE));
+  const u16 clamped_pitch_value = u16(std::clamp(pitch_value + ZERO_VALUE, 0, MAX_VALUE));
+
+  return MotionPlus::DataFormat::Data{
+      MotionPlus::DataFormat::GyroRawValue{MotionPlus::DataFormat::GyroType(
+          clamped_pitch_value, clamped_roll_value, clamped_yaw_value)},
+      MotionPlus::DataFormat::SlowType(pitch_slow, roll_slow, yaw_slow)};
+}
+
+MotionPlus::DataFormat::Data MotionPlus::GetDefaultGyroscopeData()
+{
+  return MotionPlus::DataFormat::Data{
+      MotionPlus::DataFormat::GyroRawValue{
+          MotionPlus::DataFormat::GyroType(u16(ZERO_VALUE), u16(ZERO_VALUE), u16(ZERO_VALUE))},
+      MotionPlus::DataFormat::SlowType(true, true, true)};
+}
+
 // This is something that is triggered by a read of 0x00 on real hardware.
 // But we do it here for determinism reasons.
-void MotionPlus::PrepareInput(const Common::Vec3& angular_velocity)
+void MotionPlus::PrepareInput(const MotionPlus::DataFormat::Data& gyroscope_data)
 {
   if (GetActivationStatus() != ActivationStatus::Active)
     return;
@@ -592,41 +639,16 @@ void MotionPlus::PrepareInput(const Common::Vec3& angular_velocity)
   // If the above logic determined this should be M+ data, update it here.
   if (mplus_data.is_mp_data)
   {
-    constexpr int BITS_OF_PRECISION = 14;
+    const bool pitch_slow = gyroscope_data.is_slow.x;
+    const bool roll_slow = gyroscope_data.is_slow.y;
+    const bool yaw_slow = gyroscope_data.is_slow.z;
+    const u16 pitch_value = gyroscope_data.gyro.value.x;
+    const u16 roll_value = gyroscope_data.gyro.value.y;
+    const u16 yaw_value = gyroscope_data.gyro.value.z;
 
-    // Conversion from radians to the calibrated values in degrees.
-    constexpr float VALUE_SCALE =
-        (CALIBRATION_SCALE_OFFSET >> (CALIBRATION_BITS - BITS_OF_PRECISION)) /
-        float(MathUtil::TAU) * 360;
-
-    constexpr float SLOW_SCALE = VALUE_SCALE / CALIBRATION_SLOW_SCALE_DEGREES;
-    constexpr float FAST_SCALE = VALUE_SCALE / CALIBRATION_FAST_SCALE_DEGREES;
-
-    constexpr s32 ZERO_VALUE = CALIBRATION_ZERO >> (CALIBRATION_BITS - BITS_OF_PRECISION);
-    constexpr s32 MAX_VALUE = (1 << BITS_OF_PRECISION) - 1;
-
-    static_assert(ZERO_VALUE == 1 << (BITS_OF_PRECISION - 1),
-                  "SLOW_MAX_RAD_PER_SEC assumes calibrated zero is at center of sensor values.");
-
-    constexpr u16 SENSOR_RANGE = 1 << (BITS_OF_PRECISION - 1);
-    constexpr float SLOW_MAX_RAD_PER_SEC = SENSOR_RANGE / SLOW_SCALE;
-
-    // Slow (high precision) scaling can be used if it fits in the sensor range.
-    const float yaw = angular_velocity.z;
-    mplus_data.yaw_slow = (std::abs(yaw) < SLOW_MAX_RAD_PER_SEC);
-    s32 yaw_value = yaw * (mplus_data.yaw_slow ? SLOW_SCALE : FAST_SCALE);
-
-    const float roll = angular_velocity.y;
-    mplus_data.roll_slow = (std::abs(roll) < SLOW_MAX_RAD_PER_SEC);
-    s32 roll_value = roll * (mplus_data.roll_slow ? SLOW_SCALE : FAST_SCALE);
-
-    const float pitch = angular_velocity.x;
-    mplus_data.pitch_slow = (std::abs(pitch) < SLOW_MAX_RAD_PER_SEC);
-    s32 pitch_value = pitch * (mplus_data.pitch_slow ? SLOW_SCALE : FAST_SCALE);
-
-    yaw_value = std::clamp(yaw_value + ZERO_VALUE, 0, MAX_VALUE);
-    roll_value = std::clamp(roll_value + ZERO_VALUE, 0, MAX_VALUE);
-    pitch_value = std::clamp(pitch_value + ZERO_VALUE, 0, MAX_VALUE);
+    mplus_data.yaw_slow = u8(yaw_slow);
+    mplus_data.roll_slow = u8(roll_slow);
+    mplus_data.pitch_slow = u8(pitch_slow);
 
     // Bits 0-7
     mplus_data.yaw1 = u8(yaw_value);

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.h
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.h
@@ -125,7 +125,10 @@ public:
   ExtensionPort& GetExtPort();
 
   // Vec3 is interpreted as radians/s about the x,y,z axes following the "right-hand rule".
-  void PrepareInput(const Common::Vec3& angular_velocity);
+  static MotionPlus::DataFormat::Data GetGyroscopeData(const Common::Vec3& angular_velocity);
+  static MotionPlus::DataFormat::Data GetDefaultGyroscopeData();
+
+  void PrepareInput(const MotionPlus::DataFormat::Data& gyroscope_data);
 
   // Pointer to 6 bytes is expected.
   static void ApplyPassthroughModifications(PassthroughMode, u8* data);
@@ -217,6 +220,10 @@ private:
   static constexpr u16 CALIBRATION_SCALE_OFFSET = 0x4400;
   static constexpr u16 CALIBRATION_FAST_SCALE_DEGREES = 0x4b0;
   static constexpr u16 CALIBRATION_SLOW_SCALE_DEGREES = 0x10e;
+
+  static constexpr int BITS_OF_PRECISION = 14;
+  static constexpr s32 ZERO_VALUE = CALIBRATION_ZERO >> (CALIBRATION_BITS - BITS_OF_PRECISION);
+  static constexpr s32 MAX_VALUE = (1 << BITS_OF_PRECISION) - 1;
 
   void Activate();
   void Deactivate();

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.h
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.h
@@ -118,7 +118,8 @@ public:
 
   MotionPlus();
 
-  void Update() override;
+  void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;
+  void Update(const DesiredExtensionState& target_state) override;
   void Reset() override;
   void DoState(PointerWrap& p) override;
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -449,6 +449,11 @@ DesiredWiimoteState Wiimote::BuildDesiredWiimoteState()
   m_dpad->GetState(&wiimote_state.buttons.hex,
                    IsSideways() ? dpad_sideways_bitmasks : dpad_bitmasks);
 
+  // Calculate accelerometer state.
+  // Calibration values are 8-bit but we want 10-bit precision, so << 2.
+  wiimote_state.acceleration =
+      ConvertAccelData(GetTotalAcceleration(), ACCEL_ZERO_G << 2, ACCEL_ONE_G << 2);
+
   return wiimote_state;
 }
 
@@ -493,10 +498,10 @@ void Wiimote::Update()
     return;
   }
 
-  SendDataReport();
+  SendDataReport(target_state);
 }
 
-void Wiimote::SendDataReport()
+void Wiimote::SendDataReport(const DesiredWiimoteState& target_state)
 {
   Movie::SetPolledDevice();
 
@@ -532,10 +537,7 @@ void Wiimote::SendDataReport()
     // Acceleration:
     if (rpt_builder.HasAccel())
     {
-      // Calibration values are 8-bit but we want 10-bit precision, so << 2.
-      AccelData accel =
-          ConvertAccelData(GetTotalAcceleration(), ACCEL_ZERO_G << 2, ACCEL_ONE_G << 2);
-      rpt_builder.SetAccelData(accel);
+      rpt_builder.SetAccelData(target_state.acceleration);
     }
 
     // IR Camera:

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -21,7 +21,6 @@
 #include "Core/Core.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/Movie.h"
-#include "Core/NetPlayClient.h"
 
 #include "Core/HW/WiimoteCommon/WiimoteConstants.h"
 #include "Core/HW/WiimoteCommon/WiimoteHid.h"
@@ -632,15 +631,6 @@ void Wiimote::SendDataReport(const DesiredWiimoteState& target_state)
 
     Movie::CallWiiInputManip(rpt_builder, m_bt_device_index, m_active_extension,
                              GetExtensionEncryptionKey());
-  }
-
-  if (NetPlay::IsNetPlayRunning())
-  {
-    NetPlay_GetWiimoteData(m_index, rpt_builder.GetDataPtr(), rpt_builder.GetDataSize(),
-                           u8(m_reporting_mode));
-
-    // TODO: clean up how m_status.buttons is updated.
-    rpt_builder.GetCoreData(&m_status.buttons);
   }
 
   Movie::CheckWiimoteStatus(m_bt_device_index, rpt_builder, m_active_extension,

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -209,7 +209,7 @@ void Wiimote::Reset()
   m_imu_cursor_state = {};
 }
 
-Wiimote::Wiimote(const unsigned int index) : m_index(index)
+Wiimote::Wiimote(const unsigned int index) : m_index(index), m_bt_device_index(index)
 {
   // Buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
@@ -489,6 +489,16 @@ DesiredWiimoteState Wiimote::BuildDesiredWiimoteState()
   return wiimote_state;
 }
 
+u8 Wiimote::GetWiimoteDeviceIndex() const
+{
+  return m_bt_device_index;
+}
+
+void Wiimote::SetWiimoteDeviceIndex(u8 index)
+{
+  m_bt_device_index = index;
+}
+
 // This is called every ::Wiimote::UPDATE_FREQ (200hz)
 void Wiimote::Update()
 {
@@ -551,7 +561,8 @@ void Wiimote::SendDataReport(const DesiredWiimoteState& target_state)
   DataReportBuilder rpt_builder(m_reporting_mode);
 
   if (Movie::IsPlayingInput() &&
-      Movie::PlayWiimote(m_index, rpt_builder, m_active_extension, GetExtensionEncryptionKey()))
+      Movie::PlayWiimote(m_bt_device_index, rpt_builder, m_active_extension,
+                         GetExtensionEncryptionKey()))
   {
     // Update buttons in status struct from movie:
     rpt_builder.GetCoreData(&m_status.buttons);
@@ -619,7 +630,8 @@ void Wiimote::SendDataReport(const DesiredWiimoteState& target_state)
       }
     }
 
-    Movie::CallWiiInputManip(rpt_builder, m_index, m_active_extension, GetExtensionEncryptionKey());
+    Movie::CallWiiInputManip(rpt_builder, m_bt_device_index, m_active_extension,
+                             GetExtensionEncryptionKey());
   }
 
   if (NetPlay::IsNetPlayRunning())
@@ -631,7 +643,8 @@ void Wiimote::SendDataReport(const DesiredWiimoteState& target_state)
     rpt_builder.GetCoreData(&m_status.buttons);
   }
 
-  Movie::CheckWiimoteStatus(m_index, rpt_builder, m_active_extension, GetExtensionEncryptionKey());
+  Movie::CheckWiimoteStatus(m_bt_device_index, rpt_builder, m_active_extension,
+                            GetExtensionEncryptionKey());
 
   // Send the report:
   InterruptDataInputCallback(rpt_builder.GetDataPtr(), rpt_builder.GetDataSize());

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -454,6 +454,12 @@ DesiredWiimoteState Wiimote::BuildDesiredWiimoteState()
   wiimote_state.acceleration =
       ConvertAccelData(GetTotalAcceleration(), ACCEL_ZERO_G << 2, ACCEL_ONE_G << 2);
 
+  // Calculate IR camera state.
+  wiimote_state.camera_points = CameraLogic::GetCameraPoints(
+      GetTotalTransformation(),
+      Common::Vec2(m_fov_x_setting.GetValue(), m_fov_y_setting.GetValue()) / 360 *
+          float(MathUtil::TAU));
+
   return wiimote_state;
 }
 
@@ -545,9 +551,7 @@ void Wiimote::SendDataReport(const DesiredWiimoteState& target_state)
     {
       // Note: Camera logic currently contains no changing state so we can just update it here.
       // If that changes this should be moved to Wiimote::Update();
-      m_camera_logic.Update(GetTotalTransformation(),
-                            Common::Vec2(m_fov_x_setting.GetValue(), m_fov_y_setting.GetValue()) /
-                                360 * float(MathUtil::TAU));
+      m_camera_logic.Update(target_state.camera_points);
 
       // The real wiimote reads camera data from the i2c bus starting at offset 0x37:
       const u8 camera_data_offset =

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -190,7 +190,7 @@ private:
   template <typename T, typename H>
   void InvokeHandler(H&& handler, const WiimoteCommon::OutputReportGeneric& rpt, u32 size);
 
-  void HandleExtensionSwap();
+  void HandleExtensionSwap(ExtensionNumber desired_extension_number, bool desired_motion_plus);
   bool ProcessExtensionPortEvent();
   void SendDataReport(const DesiredWiimoteState& target_state);
   bool ProcessReadDataRequest();

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -37,6 +37,8 @@ class Tilt;
 
 namespace WiimoteEmu
 {
+struct DesiredWiimoteState;
+
 enum class WiimoteGroup
 {
   Buttons,
@@ -150,7 +152,8 @@ private:
   void RefreshConfig();
 
   void StepDynamics();
-  void UpdateButtonsStatus();
+  void UpdateButtonsStatus(const DesiredWiimoteState& target_state);
+  DesiredWiimoteState BuildDesiredWiimoteState();
 
   // Returns simulated accelerometer data in m/s^2.
   Common::Vec3 GetAcceleration(

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -132,11 +132,12 @@ public:
   u8 GetWiimoteDeviceIndex() const override;
   void SetWiimoteDeviceIndex(u8 index) override;
 
-  void Update() override;
+  void PrepareInput(WiimoteEmu::DesiredWiimoteState* target_state) override;
+  void Update(const WiimoteEmu::DesiredWiimoteState& target_state) override;
   void EventLinked() override;
   void EventUnlinked() override;
   void InterruptDataOutput(const u8* data, u32 size) override;
-  bool IsButtonPressed() override;
+  WiimoteCommon::ButtonData GetCurrentlyPressedButtons() override;
 
   void Reset();
 
@@ -157,7 +158,7 @@ private:
 
   void StepDynamics();
   void UpdateButtonsStatus(const DesiredWiimoteState& target_state);
-  DesiredWiimoteState BuildDesiredWiimoteState();
+  void BuildDesiredWiimoteState(DesiredWiimoteState* target_state);
 
   // Returns simulated accelerometer data in m/s^2.
   Common::Vec3 GetAcceleration(

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -38,6 +38,7 @@ class Tilt;
 namespace WiimoteEmu
 {
 struct DesiredWiimoteState;
+struct DesiredExtensionState;
 
 enum class WiimoteGroup
 {

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -192,7 +192,7 @@ private:
 
   void HandleExtensionSwap();
   bool ProcessExtensionPortEvent();
-  void SendDataReport();
+  void SendDataReport(const DesiredWiimoteState& target_state);
   bool ProcessReadDataRequest();
 
   void SetRumble(bool on);

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -129,6 +129,9 @@ public:
   ControllerEmu::ControlGroup* GetTaTaConGroup(TaTaConGroup group) const;
   ControllerEmu::ControlGroup* GetShinkansenGroup(ShinkansenGroup group) const;
 
+  u8 GetWiimoteDeviceIndex() const override;
+  void SetWiimoteDeviceIndex(u8 index) override;
+
   void Update() override;
   void EventLinked() override;
   void EventUnlinked() override;
@@ -281,8 +284,14 @@ private:
 
   ExtensionPort m_extension_port{&m_i2c_bus};
 
-  // Wiimote index, 0-3
+  // Wiimote index, 0-3.
+  // Can also be 4 for Balance Board.
+  // This is used to look up the user button config.
   const u8 m_index;
+
+  // The Bluetooth 'slot' this device is connected to.
+  // This is usually the same as m_index, but can differ during Netplay.
+  u8 m_bt_device_index;
 
   WiimoteCommon::InputReportID m_reporting_mode;
   bool m_reporting_continuous;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -210,8 +210,6 @@ private:
   Extension* GetActiveExtension() const;
   Extension* GetNoneExtension() const;
 
-  bool NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size, u8 reporting_mode);
-
   // TODO: Kill this nonsensical function used for TAS:
   EncryptionKey GetExtensionEncryptionKey() const;
 

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -460,7 +460,12 @@ void Wiimote::SetWiimoteDeviceIndex(u8 index)
   m_bt_device_index = index;
 }
 
-void Wiimote::Update()
+void Wiimote::PrepareInput(WiimoteEmu::DesiredWiimoteState* target_state)
+{
+  // Nothing to do here on real Wiimotes.
+}
+
+void Wiimote::Update(const WiimoteEmu::DesiredWiimoteState& target_state)
 {
   // Wii remotes send input at 200hz once a Wii enables "sniff mode" on the connection.
   // PC bluetooth stacks do not enable sniff mode causing remotes to send input at only 100hz.
@@ -485,7 +490,7 @@ void Wiimote::Update()
                     u32(rpt.size() - REPORT_HID_HEADER_SIZE));
 }
 
-bool Wiimote::IsButtonPressed()
+ButtonData Wiimote::GetCurrentlyPressedButtons()
 {
   Report& rpt = m_last_input_report;
   if (rpt.size() >= 4)
@@ -499,10 +504,10 @@ bool Wiimote::IsButtonPressed()
       ButtonData buttons = {};
       builder->GetCoreData(&buttons);
 
-      return buttons.hex != 0;
+      return buttons;
     }
   }
-  return false;
+  return ButtonData{};
 }
 
 void Wiimote::Prepare()

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -450,6 +450,16 @@ Report& Wiimote::ProcessReadQueue(bool repeat_last_data_report)
   return m_last_input_report;
 }
 
+u8 Wiimote::GetWiimoteDeviceIndex() const
+{
+  return m_bt_device_index;
+}
+
+void Wiimote::SetWiimoteDeviceIndex(u8 index)
+{
+  m_bt_device_index = index;
+}
+
 void Wiimote::Update()
 {
   // Wii remotes send input at 200hz once a Wii enables "sniff mode" on the connection.

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -66,10 +66,11 @@ public:
   u8 GetWiimoteDeviceIndex() const override;
   void SetWiimoteDeviceIndex(u8 index) override;
 
-  void Update() override;
+  void PrepareInput(WiimoteEmu::DesiredWiimoteState* target_state) override;
+  void Update(const WiimoteEmu::DesiredWiimoteState& target_state) override;
   void EventLinked() override;
   void EventUnlinked() override;
-  bool IsButtonPressed() override;
+  WiimoteCommon::ButtonData GetCurrentlyPressedButtons() override;
 
   void EmuStop();
 

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -62,6 +62,10 @@ public:
   bool IsBalanceBoard();
 
   void InterruptDataOutput(const u8* data, const u32 size) override;
+
+  u8 GetWiimoteDeviceIndex() const override;
+  void SetWiimoteDeviceIndex(u8 index) override;
+
   void Update() override;
   void EventLinked() override;
   void EventUnlinked() override;
@@ -97,6 +101,8 @@ protected:
   // In any other case, data reporting is not paused to allow reconnecting on any button press.
   // This is not enabled on all platforms as connecting a Wiimote can be a pain on some platforms.
   bool m_really_disconnect = false;
+
+  u8 m_bt_device_index = 0;
 
 private:
   void Read();

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -58,7 +58,7 @@ BluetoothEmuDevice::BluetoothEmuDevice(Kernel& ios, const std::string& device_na
     DEBUG_LOG_FMT(IOS_WIIMOTE, "Wii Remote {} BT ID {:x},{:x},{:x},{:x},{:x},{:x}", i, tmp_bd[0],
                   tmp_bd[1], tmp_bd[2], tmp_bd[3], tmp_bd[4], tmp_bd[5]);
 
-    m_wiimotes.emplace_back(std::make_unique<WiimoteDevice>(this, i, tmp_bd));
+    m_wiimotes.emplace_back(std::make_unique<WiimoteDevice>(this, tmp_bd, i));
   }
 
   bt_dinf.num_registered = MAX_BBMOTES;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -60,7 +60,7 @@ public:
   void DoState(PointerWrap& p) override;
 
 private:
-  std::vector<std::unique_ptr<WiimoteDevice>> m_wiimotes;
+  std::array<std::unique_ptr<WiimoteDevice>, MAX_BBMOTES> m_wiimotes;
 
   bdaddr_t m_controller_bd{{0x11, 0x02, 0x19, 0x79, 0x00, 0xff}};
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -54,24 +54,28 @@ private:
 
 constexpr int CONNECTION_MESSAGE_TIME = 3000;
 
-WiimoteDevice::WiimoteDevice(BluetoothEmuDevice* host, int number, bdaddr_t bd)
+WiimoteDevice::WiimoteDevice(BluetoothEmuDevice* host, bdaddr_t bd, unsigned int hid_source_number)
     : m_host(host), m_bd(bd),
-      m_name(number == WIIMOTE_BALANCE_BOARD ? "Nintendo RVL-WBC-01" : "Nintendo RVL-CNT-01")
+      m_name(GetNumber() == WIIMOTE_BALANCE_BOARD ? "Nintendo RVL-WBC-01" : "Nintendo RVL-CNT-01")
 
 {
-  INFO_LOG_FMT(IOS_WIIMOTE, "Wiimote: #{} Constructed", number);
+  INFO_LOG_FMT(IOS_WIIMOTE, "Wiimote: #{} Constructed", GetNumber());
 
-  m_link_key.fill(0xa0 + number);
+  m_link_key.fill(0xa0 + GetNumber());
   m_class = {0x00, 0x04, 0x48};
   m_features = {0xBC, 0x02, 0x04, 0x38, 0x08, 0x00, 0x00, 0x00};
   m_lmp_version = 0x2;
   m_lmp_subversion = 0x229;
 
-  const auto hid_source = WiimoteCommon::GetHIDWiimoteSource(GetNumber());
+  const auto hid_source = WiimoteCommon::GetHIDWiimoteSource(hid_source_number);
 
-  // UGLY: This prevents an OSD message in SetSource -> Activate.
   if (hid_source)
+  {
+    hid_source->SetWiimoteDeviceIndex(GetNumber());
+
+    // UGLY: This prevents an OSD message in SetSource -> Activate.
     SetBasebandState(BasebandState::RequestConnection);
+  }
 
   SetSource(hid_source);
 }

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
@@ -24,7 +24,7 @@ public:
   using FeaturesType = std::array<u8, HCI_FEATURES_SIZE>;
   using LinkKeyType = std::array<u8, HCI_KEY_SIZE>;
 
-  WiimoteDevice(BluetoothEmuDevice* host, int number, bdaddr_t bd);
+  WiimoteDevice(BluetoothEmuDevice* host, bdaddr_t bd, unsigned int hid_source_number);
   ~WiimoteDevice();
 
   WiimoteDevice(const WiimoteDevice&) = delete;

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
@@ -13,6 +13,11 @@
 
 class PointerWrap;
 
+namespace WiimoteEmu
+{
+struct DesiredWiimoteState;
+}
+
 namespace IOS::HLE
 {
 class BluetoothEmuDevice;
@@ -38,7 +43,15 @@ public:
   void Update();
 
   // Called every ~200hz.
-  void UpdateInput();
+  enum class NextUpdateInputCall
+  {
+    None,
+    Activate,
+    Update
+  };
+  NextUpdateInputCall PrepareInput(WiimoteEmu::DesiredWiimoteState* wiimote_state);
+  void UpdateInput(NextUpdateInputCall next_call,
+                   const WiimoteEmu::DesiredWiimoteState& wiimote_state);
 
   void DoState(PointerWrap& p);
 

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -151,6 +151,7 @@ public:
 
   bool IsFirstInGamePad(int ingame_pad) const;
   int NumLocalPads() const;
+  int NumLocalWiimotes() const;
 
   int InGamePadToLocalPad(int ingame_pad) const;
   int LocalPadToInGamePad(int local_pad) const;

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <span>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -134,7 +135,12 @@ public:
   std::string GetCurrentGolfer();
 
   // Send and receive pads values
-  bool WiimoteUpdate(int wiimote_number, WiimoteEmu::SerializedWiimoteState* target_state);
+  struct WiimoteDataBatchEntry
+  {
+    int wiimote;
+    WiimoteEmu::SerializedWiimoteState* state;
+  };
+  bool WiimoteUpdate(const std::span<WiimoteDataBatchEntry>& entries);
   bool GetNetPads(int pad_nb, bool from_vi, GCPadStatus* pad_status);
 
   u64 GetInitialRTCValue() const;
@@ -345,6 +351,6 @@ private:
 
 void NetPlay_Enable(NetPlayClient* const np);
 void NetPlay_Disable();
-bool NetPlay_GetWiimoteData(int wiimote, WiimoteEmu::SerializedWiimoteState* target_state);
+bool NetPlay_GetWiimoteData(const std::span<NetPlayClient::WiimoteDataBatchEntry>& entries);
 unsigned int NetPlay_GetLocalWiimoteForSlot(unsigned int slot);
 }  // namespace NetPlay

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -35,6 +35,11 @@ namespace UICommon
 class GameFile;
 }
 
+namespace WiimoteEmu
+{
+struct SerializedWiimoteState;
+}
+
 namespace NetPlay
 {
 class NetPlayUI
@@ -129,7 +134,7 @@ public:
   std::string GetCurrentGolfer();
 
   // Send and receive pads values
-  bool WiimoteUpdate(int _number, u8* data, std::size_t size, u8 reporting_mode);
+  bool WiimoteUpdate(int wiimote_number, WiimoteEmu::SerializedWiimoteState* target_state);
   bool GetNetPads(int pad_nb, bool from_vi, GCPadStatus* pad_status);
 
   u64 GetInitialRTCValue() const;
@@ -142,11 +147,14 @@ public:
   int NumLocalPads() const;
 
   int InGamePadToLocalPad(int ingame_pad) const;
-  int LocalPadToInGamePad(int localPad) const;
+  int LocalPadToInGamePad(int local_pad) const;
+  int InGameWiimoteToLocalWiimote(int ingame_wiimote) const;
+  int LocalWiimoteToInGameWiimote(int local_wiimote) const;
 
   bool PlayerHasControllerMapped(PlayerId pid) const;
   bool LocalPlayerHasControllerMapped() const;
   bool IsLocalPlayer(PlayerId pid) const;
+  const PlayerId& GetLocalPlayerId() const;
 
   static void SendTimeBase();
   bool DoAllPlayersHaveGame();
@@ -182,7 +190,7 @@ protected:
   Common::SPSCQueue<AsyncQueueEntry, false> m_async_queue;
 
   std::array<Common::SPSCQueue<GCPadStatus>, 4> m_pad_buffer;
-  std::array<Common::SPSCQueue<WiimoteInput>, 4> m_wiimote_buffer;
+  std::array<Common::SPSCQueue<WiimoteEmu::SerializedWiimoteState>, 4> m_wiimote_buffer;
 
   std::array<GCPadStatus, 4> m_last_pad_status{};
   std::array<bool, 4> m_first_pad_status_received{};
@@ -242,9 +250,13 @@ private:
   bool PollLocalPad(int local_pad, sf::Packet& packet);
   void SendPadHostPoll(PadIndex pad_num);
 
+  bool AddLocalWiimoteToBuffer(int local_wiimote, const WiimoteEmu::SerializedWiimoteState& state,
+                               sf::Packet& packet);
+
   void UpdateDevices();
   void AddPadStateToPacket(int in_game_pad, const GCPadStatus& np, sf::Packet& packet);
-  void SendWiimoteState(int in_game_pad, const WiimoteInput& nw);
+  void AddWiimoteStateToPacket(int in_game_pad, const WiimoteEmu::SerializedWiimoteState& np,
+                               sf::Packet& packet);
   void Send(const sf::Packet& packet, u8 channel_id = DEFAULT_CHANNEL);
   void Disconnect();
   bool Connect();
@@ -252,8 +264,6 @@ private:
   void ComputeGameDigest(const SyncIdentifier& sync_identifier);
   void DisplayPlayersPing();
   u32 GetPlayersMaxPing() const;
-
-  bool WaitForWiimoteBuffer(int _number);
 
   void OnData(sf::Packet& packet);
   void OnPlayerJoin(sf::Packet& packet);
@@ -335,4 +345,6 @@ private:
 
 void NetPlay_Enable(NetPlayClient* const np);
 void NetPlay_Disable();
+bool NetPlay_GetWiimoteData(int wiimote, WiimoteEmu::SerializedWiimoteState* target_state);
+unsigned int NetPlay_GetLocalWiimoteForSlot(unsigned int slot);
 }  // namespace NetPlay

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -101,7 +101,6 @@ struct NetSettings
   bool strict_settings_sync = false;
   bool sync_codes = false;
   std::string save_data_region;
-  std::array<int, 4> wiimote_extension{};
   bool golf_mode = false;
   bool use_fma = false;
   bool hide_remote_gbas = false;
@@ -228,11 +227,6 @@ enum : u8
   CHANNEL_COUNT
 };
 
-struct WiimoteInput
-{
-  u8 report_id = 0;
-  std::vector<u8> data;
-};
 using PlayerId = u8;
 using FrameNum = u32;
 using PadIndex = s8;
@@ -260,7 +254,6 @@ std::string GetPlayerMappingString(PlayerId pid, const PadMappingArray& pad_map,
 bool IsNetPlayRunning();
 void SetSIPollBatching(bool state);
 void SendPowerButtonEvent();
-void SetupWiimotes();
 std::string GetGBASavePath(int pad_num);
 PadDetails GetPadDetails(int pad_num);
 }  // namespace NetPlay

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -256,4 +256,5 @@ void SetSIPollBatching(bool state);
 void SendPowerButtonEvent();
 std::string GetGBASavePath(int pad_num);
 PadDetails GetPadDetails(int pad_num);
+int NumLocalWiimotes();
 }  // namespace NetPlay

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -318,6 +318,7 @@
     <ClInclude Include="Core\HW\WiimoteEmu\DesiredWiimoteState.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Encryption.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\Classic.h" />
+    <ClInclude Include="Core\HW\WiimoteEmu\Extension\DesiredExtensionState.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\DrawsomeTablet.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\Drums.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\Extension.h" />

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -933,6 +933,7 @@
     <ClCompile Include="Core\HW\Wiimote.cpp" />
     <ClCompile Include="Core\HW\WiimoteCommon\DataReport.cpp" />
     <ClCompile Include="Core\HW\WiimoteEmu\Camera.cpp" />
+    <ClCompile Include="Core\HW\WiimoteEmu\DesiredWiimoteState.cpp" />
     <ClCompile Include="Core\HW\WiimoteEmu\Dynamics.cpp" />
     <ClCompile Include="Core\HW\WiimoteEmu\EmuSubroutines.cpp" />
     <ClCompile Include="Core\HW\WiimoteEmu\Encryption.cpp" />

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -315,6 +315,7 @@
     <ClInclude Include="Core\HW\WiimoteCommon\WiimoteReport.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Camera.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Dynamics.h" />
+    <ClInclude Include="Core\HW\WiimoteEmu\DesiredWiimoteState.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Encryption.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\Classic.h" />
     <ClInclude Include="Core\HW\WiimoteEmu\Extension\DrawsomeTablet.h" />

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.h
@@ -13,6 +13,11 @@ class QGridLayout;
 class QGroupBox;
 class QPushButton;
 
+namespace Core
+{
+enum class State;
+}
+
 class GamecubeControllersWidget final : public QWidget
 {
   Q_OBJECT
@@ -20,7 +25,7 @@ public:
   explicit GamecubeControllersWidget(QWidget* parent);
 
 private:
-  void LoadSettings();
+  void LoadSettings(Core::State state);
   void SaveSettings();
 
   void OnGCTypeChanged(size_t index);

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -27,6 +27,7 @@
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTReal.h"
+#include "Core/NetPlayProto.h"
 #include "Core/WiiUtils.h"
 
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
@@ -286,6 +287,7 @@ void WiimoteControllersWidget::LoadSettings(Core::State state)
   const bool running_gc = running && !SConfig::GetInstance().bWii;
   const bool enable_passthrough = m_wiimote_passthrough->isChecked() && !running_gc;
   const bool enable_emu_bt = !m_wiimote_passthrough->isChecked() && !running_gc;
+  const bool running_netplay = running && NetPlay::IsNetPlayRunning();
 
   m_wiimote_sync->setEnabled(enable_passthrough);
   m_wiimote_reset->setEnabled(enable_passthrough);
@@ -296,14 +298,14 @@ void WiimoteControllersWidget::LoadSettings(Core::State state)
   for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
     m_wiimote_labels[i]->setEnabled(enable_emu_bt);
-    m_wiimote_boxes[i]->setEnabled(enable_emu_bt);
+    m_wiimote_boxes[i]->setEnabled(enable_emu_bt && !running_netplay);
 
     const bool is_emu_wiimote = m_wiimote_boxes[i]->currentIndex() == 1;
     m_wiimote_buttons[i]->setEnabled(enable_emu_bt && is_emu_wiimote);
   }
 
-  m_wiimote_real_balance_board->setEnabled(enable_emu_bt);
-  m_wiimote_speaker_data->setEnabled(enable_emu_bt);
+  m_wiimote_real_balance_board->setEnabled(enable_emu_bt && !running_netplay);
+  m_wiimote_speaker_data->setEnabled(enable_emu_bt && !running_netplay);
 
   const bool ciface_wiimotes = m_wiimote_ciface->isChecked();
 

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -287,7 +287,8 @@ void WiimoteControllersWidget::LoadSettings(Core::State state)
   const bool running_gc = running && !SConfig::GetInstance().bWii;
   const bool enable_passthrough = m_wiimote_passthrough->isChecked() && !running_gc;
   const bool enable_emu_bt = !m_wiimote_passthrough->isChecked() && !running_gc;
-  const bool running_netplay = running && NetPlay::IsNetPlayRunning();
+  const bool is_netplay = NetPlay::IsNetPlayRunning();
+  const bool running_netplay = running && is_netplay;
 
   m_wiimote_sync->setEnabled(enable_passthrough);
   m_wiimote_reset->setEnabled(enable_passthrough);
@@ -295,13 +296,15 @@ void WiimoteControllersWidget::LoadSettings(Core::State state)
   for (auto* pt_label : m_wiimote_pt_labels)
     pt_label->setEnabled(enable_passthrough);
 
+  const int num_local_wiimotes = is_netplay ? NetPlay::NumLocalWiimotes() : 4;
   for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
     m_wiimote_labels[i]->setEnabled(enable_emu_bt);
     m_wiimote_boxes[i]->setEnabled(enable_emu_bt && !running_netplay);
 
     const bool is_emu_wiimote = m_wiimote_boxes[i]->currentIndex() == 1;
-    m_wiimote_buttons[i]->setEnabled(enable_emu_bt && is_emu_wiimote);
+    m_wiimote_buttons[i]->setEnabled(enable_emu_bt && is_emu_wiimote &&
+                                     static_cast<int>(i) < num_local_wiimotes);
   }
 
   m_wiimote_real_balance_board->setEnabled(enable_emu_bt && !running_netplay);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -360,8 +360,6 @@ void MainWindow::InitCoreCallbacks()
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     if (state == Core::State::Uninitialized)
       OnStopComplete();
-    if (state != Core::State::Uninitialized && NetPlay::IsNetPlayRunning() && m_controllers_window)
-      m_controllers_window->reject();
 
     if (state == Core::State::Running && m_fullscreen_requested)
     {

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -131,9 +131,6 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   m_recording_play->setEnabled(m_game_selected && !running);
   m_recording_start->setEnabled((m_game_selected || running) && !Movie::IsPlayingInput());
 
-  // Options
-  m_controllers_action->setEnabled(NetPlay::IsNetPlayRunning() ? !running : true);
-
   // JIT
   m_jit_interpreter_core->setEnabled(running);
   m_jit_block_linking->setEnabled(!running);

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -61,7 +61,6 @@ void ToolBar::OnEmulationStateChanged(Core::State state)
   m_stop_action->setEnabled(running);
   m_fullscreen_action->setEnabled(running);
   m_screenshot_action->setEnabled(running);
-  m_controllers_action->setEnabled(NetPlay::IsNetPlayRunning() ? !running : true);
 
   bool playing = running && state != Core::State::Paused;
   UpdatePausePlayButtonState(playing);
@@ -130,7 +129,6 @@ void ToolBar::MakeActions()
   m_config_action = addAction(tr("Config"), this, &ToolBar::SettingsPressed);
   m_graphics_action = addAction(tr("Graphics"), this, &ToolBar::GraphicsPressed);
   m_controllers_action = addAction(tr("Controllers"), this, &ToolBar::ControllersPressed);
-  m_controllers_action->setEnabled(true);
 
   // Ensure every button has about the same width
   std::vector<QWidget*> items;

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
@@ -1256,7 +1256,7 @@ void Device::IRState::ProcessData(const std::array<WiimoteEmu::IRBasic, 2>& data
   // A better implementation might extrapolate points when they fall out of camera view.
   // But just averaging visible points actually seems to work very well.
 
-  using IRObject = WiimoteEmu::IRBasic::IRObject;
+  using IRObject = WiimoteEmu::IRObject;
 
   MathUtil::RunningVariance<Common::Vec2> points;
 


### PR DESCRIPTION
Complete rewrite of how Wiimotes work in netplay. Should solve basically all the weird issues you can run into when using Wiimotes in netplay.

Feature set:
- Full syncing of button state, motion state, camera state, Motion Plus and all supported emulated Extensions.
- Automatic configuration; that is, no need to manually match the configured Wiimotes before starting netplay or anything like that.
- Successive local controller assignment (ie, all players use their own Wiimote 1 mappings)
- Changing button configuration mid-netplay, including the currently attached Wiimote extensions.
- Handling of Wiimote idle timeouts
- Handling of reconnecting a disconnected Wiimote, including cases where the game does not allow player 2 to connect a Wiimote before entering multiplayer mode
- Packet batching

Not implemented in this PR: (because it's not critical and the PR is already huge)
- Input Host Authority Mode
- Golf Mode
- Wiimote EEPROM syncing (always uses a default one, so no on-Wiimote stored Miis or whatever)