### PR TITLE
JitArm64: Enforce correct alignment of SPR_TL

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -336,6 +336,7 @@ void JitArm64::mfspr(UGeckoInstruction inst)
 
     ADD(Xresult, XA, Xresult, ArithOption(Xresult, ShiftType::LSR, 3));
     STR(IndexType::Unsigned, Xresult, PPC_REG, PPCSTATE_OFF_SPR(SPR_TL));
+    static_assert((PPCSTATE_OFF_SPR(SPR_TL) & 0x7) == 0);
 
     if (CanMergeNextInstructions(1))
     {

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -160,7 +160,8 @@ struct PowerPCState
 
   // special purpose registers - controls quantizers, DMA, and lots of other misc extensions.
   // also for power management, but we don't care about that.
-  u32 spr[1024]{};
+  // JitArm64 needs 64-bit alignment for SPR_TL.
+  alignas(8) u32 spr[1024]{};
 
   // Storage for the stack pointer of the BLR optimization.
   u8* stored_stack_pointer = nullptr;


### PR DESCRIPTION
@dvessel Could you check if this solves the issue you described in https://github.com/dolphin-emu/dolphin/pull/10808#issuecomment-1252614711?