### PR TITLE
Qt/Controllers: Refresh GUI on settings change.

### DIFF
--- a/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
@@ -13,12 +13,17 @@
 
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
+#include "DolphinQt/QtUtils/SignalBlocking.h"
+#include "DolphinQt/Settings.h"
 
 CommonControllersWidget::CommonControllersWidget(QWidget* parent) : QWidget(parent)
 {
   CreateLayout();
   LoadSettings();
   ConnectWidgets();
+
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this,
+          &CommonControllersWidget::LoadSettings);
 }
 
 void CommonControllersWidget::CreateLayout()
@@ -59,7 +64,7 @@ void CommonControllersWidget::OnControllerInterfaceConfigure()
 
 void CommonControllersWidget::LoadSettings()
 {
-  m_common_bg_input->setChecked(Config::Get(Config::MAIN_INPUT_BACKGROUND_INPUT));
+  SignalBlocking(m_common_bg_input)->setChecked(Config::Get(Config::MAIN_INPUT_BACKGROUND_INPUT));
 }
 
 void CommonControllersWidget::SaveSettings()

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.h
@@ -23,8 +23,8 @@ private:
   void LoadSettings();
   void SaveSettings();
 
-  void OnGCTypeChanged(int state);
-  void OnGCPadConfigure();
+  void OnGCTypeChanged(size_t index);
+  void OnGCPadConfigure(size_t index);
 
   void CreateLayout();
   void ConnectWidgets();

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -32,6 +32,7 @@
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
+#include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
 #include "UICommon/UICommon.h"
@@ -39,8 +40,13 @@
 WiimoteControllersWidget::WiimoteControllersWidget(QWidget* parent) : QWidget(parent)
 {
   CreateLayout();
-  LoadSettings();
   ConnectWidgets();
+
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this,
+          [this] { LoadSettings(Core::GetState()); });
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
+          [this](Core::State state) { LoadSettings(state); });
+  LoadSettings(Core::GetState());
 }
 
 static int GetRadioButtonIndicatorWidth()
@@ -153,20 +159,20 @@ void WiimoteControllersWidget::CreateLayout()
 
 void WiimoteControllersWidget::ConnectWidgets()
 {
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
-          &WiimoteControllersWidget::UpdateDisabledWiimoteControls);
+  connect(m_wiimote_passthrough, &QRadioButton::toggled, this, [this] {
+    SaveSettings();
+    LoadSettings(Core::GetState());
+  });
+  connect(m_wiimote_ciface, &QCheckBox::toggled, this, [this] {
+    SaveSettings();
+    LoadSettings(Core::GetState());
+    WiimoteReal::HandleWiimotesInControllerInterfaceSettingChange();
+  });
+  connect(m_wiimote_continuous_scanning, &QCheckBox::toggled, this, [this] {
+    SaveSettings();
+    LoadSettings(Core::GetState());
+  });
 
-  connect(m_wiimote_passthrough, &QRadioButton::toggled, this,
-          &WiimoteControllersWidget::OnWiimoteModeChanged);
-  connect(m_wiimote_ciface, &QCheckBox::toggled, this,
-          &WiimoteControllersWidget::OnWiimoteModeChanged);
-  connect(m_wiimote_ciface, &QCheckBox::toggled, this,
-          &WiimoteReal::HandleWiimotesInControllerInterfaceSettingChange);
-  connect(m_wiimote_continuous_scanning, &QCheckBox::toggled, this,
-          &WiimoteControllersWidget::OnWiimoteModeChanged);
-
-  connect(m_wiimote_continuous_scanning, &QCheckBox::toggled, this,
-          &WiimoteControllersWidget::SaveSettings);
   connect(m_wiimote_real_balance_board, &QCheckBox::toggled, this,
           &WiimoteControllersWidget::SaveSettings);
   connect(m_wiimote_speaker_data, &QCheckBox::toggled, this,
@@ -180,59 +186,13 @@ void WiimoteControllersWidget::ConnectWidgets()
 
   for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
-    connect(m_wiimote_boxes[i], qOverload<int>(&QComboBox::currentIndexChanged), this,
-            &WiimoteControllersWidget::SaveSettings);
-    connect(m_wiimote_boxes[i], qOverload<int>(&QComboBox::currentIndexChanged), this,
-            &WiimoteControllersWidget::OnWiimoteModeChanged);
+    connect(m_wiimote_boxes[i], qOverload<int>(&QComboBox::currentIndexChanged), this, [this] {
+      SaveSettings();
+      LoadSettings(Core::GetState());
+    });
     connect(m_wiimote_buttons[i], &QPushButton::clicked, this,
-            &WiimoteControllersWidget::OnWiimoteConfigure);
+            [this, i] { OnWiimoteConfigure(i); });
   }
-}
-
-void WiimoteControllersWidget::OnWiimoteModeChanged()
-{
-  SaveSettings();
-
-  // Make sure continuous scanning setting is applied.
-  WiimoteReal::Initialize(::Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
-
-  UpdateDisabledWiimoteControls();
-}
-
-void WiimoteControllersWidget::UpdateDisabledWiimoteControls()
-{
-  const bool running = Core::GetState() != Core::State::Uninitialized;
-
-  m_wiimote_emu->setEnabled(!running);
-  m_wiimote_passthrough->setEnabled(!running);
-
-  const bool running_gc = running && !SConfig::GetInstance().bWii;
-  const bool enable_passthrough = m_wiimote_passthrough->isChecked() && !running_gc;
-  const bool enable_emu_bt = !m_wiimote_passthrough->isChecked() && !running_gc;
-
-  m_wiimote_sync->setEnabled(enable_passthrough);
-  m_wiimote_reset->setEnabled(enable_passthrough);
-
-  for (auto* pt_label : m_wiimote_pt_labels)
-    pt_label->setEnabled(enable_passthrough);
-
-  for (size_t i = 0; i < m_wiimote_groups.size(); i++)
-  {
-    m_wiimote_labels[i]->setEnabled(enable_emu_bt);
-    m_wiimote_boxes[i]->setEnabled(enable_emu_bt);
-
-    const bool is_emu_wiimote = m_wiimote_boxes[i]->currentIndex() == 1;
-    m_wiimote_buttons[i]->setEnabled(enable_emu_bt && is_emu_wiimote);
-  }
-
-  m_wiimote_real_balance_board->setEnabled(enable_emu_bt);
-  m_wiimote_speaker_data->setEnabled(enable_emu_bt);
-
-  const bool ciface_wiimotes = m_wiimote_ciface->isChecked();
-
-  m_wiimote_refresh->setEnabled((enable_emu_bt || ciface_wiimotes) &&
-                                !m_wiimote_continuous_scanning->isChecked());
-  m_wiimote_continuous_scanning->setEnabled(enable_emu_bt || ciface_wiimotes);
 }
 
 void WiimoteControllersWidget::OnBluetoothPassthroughResetPressed()
@@ -273,15 +233,8 @@ void WiimoteControllersWidget::OnWiimoteRefreshPressed()
   WiimoteReal::Refresh();
 }
 
-void WiimoteControllersWidget::OnWiimoteConfigure()
+void WiimoteControllersWidget::OnWiimoteConfigure(size_t index)
 {
-  size_t index;
-  for (index = 0; index < m_wiimote_groups.size(); index++)
-  {
-    if (m_wiimote_buttons[index] == QObject::sender())
-      break;
-  }
-
   MappingWindow::Type type;
   switch (m_wiimote_boxes[index]->currentIndex())
   {
@@ -301,45 +254,86 @@ void WiimoteControllersWidget::OnWiimoteConfigure()
   window->show();
 }
 
-void WiimoteControllersWidget::LoadSettings()
+void WiimoteControllersWidget::LoadSettings(Core::State state)
 {
   for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
-    m_wiimote_boxes[i]->setCurrentIndex(int(Config::Get(Config::GetInfoForWiimoteSource(int(i)))));
+    SignalBlocking(m_wiimote_boxes[i])
+        ->setCurrentIndex(int(Config::Get(Config::GetInfoForWiimoteSource(int(i)))));
   }
-  m_wiimote_real_balance_board->setChecked(Config::Get(Config::WIIMOTE_BB_SOURCE) ==
-                                           WiimoteSource::Real);
-  m_wiimote_speaker_data->setChecked(Config::Get(Config::MAIN_WIIMOTE_ENABLE_SPEAKER));
-  m_wiimote_ciface->setChecked(Config::Get(Config::MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE));
-  m_wiimote_continuous_scanning->setChecked(Config::Get(Config::MAIN_WIIMOTE_CONTINUOUS_SCANNING));
+  SignalBlocking(m_wiimote_real_balance_board)
+      ->setChecked(Config::Get(Config::WIIMOTE_BB_SOURCE) == WiimoteSource::Real);
+  SignalBlocking(m_wiimote_speaker_data)
+      ->setChecked(Config::Get(Config::MAIN_WIIMOTE_ENABLE_SPEAKER));
+  SignalBlocking(m_wiimote_ciface)
+      ->setChecked(Config::Get(Config::MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE));
+  SignalBlocking(m_wiimote_continuous_scanning)
+      ->setChecked(Config::Get(Config::MAIN_WIIMOTE_CONTINUOUS_SCANNING));
 
   if (Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_ENABLED))
-    m_wiimote_passthrough->setChecked(true);
+    SignalBlocking(m_wiimote_passthrough)->setChecked(true);
   else
-    m_wiimote_emu->setChecked(true);
+    SignalBlocking(m_wiimote_emu)->setChecked(true);
 
-  OnWiimoteModeChanged();
+  // Make sure continuous scanning setting is applied.
+  WiimoteReal::Initialize(::Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
+
+  const bool running = state != Core::State::Uninitialized;
+
+  m_wiimote_emu->setEnabled(!running);
+  m_wiimote_passthrough->setEnabled(!running);
+
+  const bool running_gc = running && !SConfig::GetInstance().bWii;
+  const bool enable_passthrough = m_wiimote_passthrough->isChecked() && !running_gc;
+  const bool enable_emu_bt = !m_wiimote_passthrough->isChecked() && !running_gc;
+
+  m_wiimote_sync->setEnabled(enable_passthrough);
+  m_wiimote_reset->setEnabled(enable_passthrough);
+
+  for (auto* pt_label : m_wiimote_pt_labels)
+    pt_label->setEnabled(enable_passthrough);
+
+  for (size_t i = 0; i < m_wiimote_groups.size(); i++)
+  {
+    m_wiimote_labels[i]->setEnabled(enable_emu_bt);
+    m_wiimote_boxes[i]->setEnabled(enable_emu_bt);
+
+    const bool is_emu_wiimote = m_wiimote_boxes[i]->currentIndex() == 1;
+    m_wiimote_buttons[i]->setEnabled(enable_emu_bt && is_emu_wiimote);
+  }
+
+  m_wiimote_real_balance_board->setEnabled(enable_emu_bt);
+  m_wiimote_speaker_data->setEnabled(enable_emu_bt);
+
+  const bool ciface_wiimotes = m_wiimote_ciface->isChecked();
+
+  m_wiimote_refresh->setEnabled((enable_emu_bt || ciface_wiimotes) &&
+                                !m_wiimote_continuous_scanning->isChecked());
+  m_wiimote_continuous_scanning->setEnabled(enable_emu_bt || ciface_wiimotes);
 }
 
 void WiimoteControllersWidget::SaveSettings()
 {
-  Config::SetBaseOrCurrent(Config::MAIN_WIIMOTE_ENABLE_SPEAKER,
-                           m_wiimote_speaker_data->isChecked());
-  Config::SetBaseOrCurrent(Config::MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE,
-                           m_wiimote_ciface->isChecked());
-  Config::SetBaseOrCurrent(Config::MAIN_WIIMOTE_CONTINUOUS_SCANNING,
-                           m_wiimote_continuous_scanning->isChecked());
-  Config::SetBaseOrCurrent(Config::MAIN_BLUETOOTH_PASSTHROUGH_ENABLED,
-                           m_wiimote_passthrough->isChecked());
-
-  const WiimoteSource bb_source =
-      m_wiimote_real_balance_board->isChecked() ? WiimoteSource::Real : WiimoteSource::None;
-  Config::SetBaseOrCurrent(Config::WIIMOTE_BB_SOURCE, bb_source);
-
-  for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
-    const int index = m_wiimote_boxes[i]->currentIndex();
-    Config::SetBaseOrCurrent(Config::GetInfoForWiimoteSource(int(i)), WiimoteSource(index));
+    Config::ConfigChangeCallbackGuard config_guard;
+    Config::SetBaseOrCurrent(Config::MAIN_WIIMOTE_ENABLE_SPEAKER,
+                             m_wiimote_speaker_data->isChecked());
+    Config::SetBaseOrCurrent(Config::MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE,
+                             m_wiimote_ciface->isChecked());
+    Config::SetBaseOrCurrent(Config::MAIN_WIIMOTE_CONTINUOUS_SCANNING,
+                             m_wiimote_continuous_scanning->isChecked());
+    Config::SetBaseOrCurrent(Config::MAIN_BLUETOOTH_PASSTHROUGH_ENABLED,
+                             m_wiimote_passthrough->isChecked());
+
+    const WiimoteSource bb_source =
+        m_wiimote_real_balance_board->isChecked() ? WiimoteSource::Real : WiimoteSource::None;
+    Config::SetBaseOrCurrent(Config::WIIMOTE_BB_SOURCE, bb_source);
+
+    for (size_t i = 0; i < m_wiimote_groups.size(); i++)
+    {
+      const int index = m_wiimote_boxes[i]->currentIndex();
+      Config::SetBaseOrCurrent(Config::GetInfoForWiimoteSource(int(i)), WiimoteSource(index));
+    }
   }
 
   SConfig::GetInstance().SaveSettings();

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
@@ -16,6 +16,11 @@ class QLabel;
 class QPushButton;
 class QRadioButton;
 
+namespace Core
+{
+enum class State;
+}
+
 class WiimoteControllersWidget final : public QWidget
 {
   Q_OBJECT
@@ -23,17 +28,15 @@ public:
   explicit WiimoteControllersWidget(QWidget* parent);
 
 private:
-  void OnWiimoteModeChanged();
-  void UpdateDisabledWiimoteControls();
   void SaveSettings();
   void OnBluetoothPassthroughSyncPressed();
   void OnBluetoothPassthroughResetPressed();
   void OnWiimoteRefreshPressed();
-  void OnWiimoteConfigure();
+  void OnWiimoteConfigure(size_t index);
 
   void CreateLayout();
   void ConnectWidgets();
-  void LoadSettings();
+  void LoadSettings(Core::State state);
 
   QGroupBox* m_wiimote_box;
   QGridLayout* m_wiimote_layout;


### PR DESCRIPTION
(without triggering signals)

Prep work for allowing opening the Controller settings mid-Netplay without everything breaking. See https://github.com/dolphin-emu/dolphin/pull/11070#issuecomment-1251600186.

To be clear, the intent of this PR is having the Controller GUI properly reflect the current state if it's changed programmatically by Netplay (or anything else). The eventual target (not in this PR) is that during Netplay, the dropdowns for the GC controller ports and Wiimotes will be greyed out (because we don't support them changing mid-session), but the Configure buttons next to them will still work so you can change your mappings, along with harmless-to-Netplay settings like Background Input.