### PR TITLE
Jit64: Remove breakpoint check from JitAsm.cpp

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -92,15 +92,8 @@ void Jit64AsmRoutineManager::Generate()
   if (enable_debugging)
   {
     MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
-    TEST(32, MatR(RSCRATCH), Imm32(static_cast<u32>(CPU::State::Stepping)));
-    FixupBranch notStepping = J_CC(CC_Z);
-    ABI_PushRegistersAndAdjustStack({}, 0);
-    ABI_CallFunction(PowerPC::CheckBreakPoints);
-    ABI_PopRegistersAndAdjustStack({}, 0);
-    MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
     TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
     dbg_exit = J_CC(CC_NZ, true);
-    SetJumpTarget(notStepping);
   }
 
   SetJumpTarget(skipToRealDispatch);


### PR DESCRIPTION
The breakpoint check in Jit.cpp makes it redundant.

Normally this redundant check doesn't cause any issues, but if you create a breakpoint and enable logging without breaking, you get two log messages if the breakpoint is at the beginning of a block. See https://bugs.dolphin-emu.org/issues/13044.

This is also a tiny performance improvement for when debugging is active, since we no longer check for breakpoints for blocks that never had any breakpoints to begin with.