### PR TITLE
Remove old GCC version workarounds

### DIFF
--- a/Source/Core/Common/EnumFormatter.h
+++ b/Source/Core/Common/EnumFormatter.h
@@ -42,12 +42,9 @@
  *   constexpr formatter() : EnumFormatter(names) {}
  * };
  */
-template <auto last_member, typename = decltype(last_member)>
+template <auto last_member>
 class EnumFormatter
 {
-  // The second template argument is needed to avoid compile errors from ambiguity with multiple
-  // enums with the same number of members in GCC prior to 8.  See https://godbolt.org/z/xcKaW1seW
-  // and https://godbolt.org/z/hz7Yqq1P5
   using T = decltype(last_member);
   static_assert(std::is_enum_v<T>);
 

--- a/Source/Core/Common/EnumMap.h
+++ b/Source/Core/Common/EnumMap.h
@@ -15,12 +15,9 @@ namespace Common
 {
 // A type that allows lookup of values associated with an enum as the key.
 // Designed for enums whose numeric values start at 0 and increment continuously with few gaps.
-template <typename V, auto last_member, typename = decltype(last_member)>
+template <typename V, auto last_member>
 class EnumMap final
 {
-  // The third template argument is needed to avoid compile errors from ambiguity with multiple
-  // enums with the same number of members in GCC prior to 8.  See https://godbolt.org/z/xcKaW1seW
-  // and https://godbolt.org/z/hz7Yqq1P5
   using T = decltype(last_member);
   static_assert(std::is_enum_v<T>);
   static constexpr size_t s_size = static_cast<size_t>(last_member) + 1;

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -720,9 +720,6 @@ CertReader::CertReader(std::vector<u8>&& bytes) : SignedBlobReader(std::move(byt
   if (!IsSignatureValid())
     return;
 
-  // XXX: in old GCC versions, capturing 'this' does not work for some lambdas. The workaround
-  // is to not use auto for the parameter (even though the type is obvious).
-  // This can be dropped once we require GCC 7.
   using CertStructInfo = std::tuple<SignatureType, PublicKeyType, size_t>;
   static constexpr std::array<CertStructInfo, 4> types{{
       {SignatureType::RSA4096, PublicKeyType::RSA2048, sizeof(CertRSA4096RSA2048)},

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -227,14 +227,11 @@ std::string BitfieldExtract(std::string_view source)
                      static_cast<u32>(BitFieldT::NumBits()));
 }
 
-template <auto last_member, typename = decltype(last_member)>
+template <auto last_member>
 void WriteSwitch(ShaderCode& out, APIType ApiType, std::string_view variable,
                  const Common::EnumMap<std::string_view, last_member>& values, int indent,
                  bool break_)
 {
-  // The second template argument is needed to avoid compile errors from ambiguity with multiple
-  // enums with the same number of members in GCC prior to 8.  See https://godbolt.org/z/xcKaW1seW
-  // and https://godbolt.org/z/hz7Yqq1P5
   using enum_type = decltype(last_member);
 
   // Generate a tree of if statements recursively


### PR DESCRIPTION
The minimum GCC version is going to become GCC 10.  (#10969)