### PR TITLE
 VolumeVerifier: Add missing assignment to summary_text, and prevent such errors in the future by adding [[nodiscard]] to GetStringT().

### DIFF
--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -29,7 +29,7 @@ using StringTranslator = std::string (*)(const char* text);
 void RegisterMsgAlertHandler(MsgAlertHandler handler);
 void RegisterStringTranslator(StringTranslator translator);
 
-std::string GetStringT(const char* string);
+[[nodiscard]] std::string GetStringT(const char* string);
 
 bool MsgAlertFmtImpl(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                      int line, fmt::string_view format, const fmt::format_args& args);

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -1432,8 +1432,9 @@ void VolumeVerifier::Finish()
       }
       else
       {
-        Common::GetStringT("Problems with low severity were found. They will most "
-                           "likely not prevent the game from running.");
+        m_result.summary_text =
+            Common::GetStringT("Problems with low severity were found. They will most "
+                               "likely not prevent the game from running.");
       }
       break;
     case Severity::Medium:


### PR DESCRIPTION
See https://github.com/dolphin-emu/dolphin/pull/10932#discussion_r978568501