### PR TITLE
BBA/BuiltIn: Fix a crash during network stack exhaustion

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -520,6 +520,13 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleUPnPClient()
     return;
   }
 
+  if (m_current_ip == ref->from.sin_addr.s_addr)
+  {
+    ref->tcp_socket.disconnect();
+    WARN_LOG_FMT(SP1, "Ignoring UPnP request to itself");
+    return;
+  }
+
   ref->delay = GetTickCountStd();
   ref->ip = ref->from.sin_addr.s_addr;
   ref->local = ref->to.sin_port;

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -510,7 +510,7 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleUDPFrame(const Common::UDPPacket& 
 void CEXIETHERNET::BuiltInBBAInterface::HandleUPnPClient()
 {
   StackRef* ref = GetAvailableSlot(0);
-  if (m_upnp_httpd.accept(ref->tcp_socket) != sf::Socket::Done)
+  if (ref == nullptr || m_upnp_httpd.accept(ref->tcp_socket) != sf::Socket::Done)
     return;
 
   if (ref->tcp_socket.GetPeerName(&ref->from) != sf::Socket::Status::Done ||


### PR DESCRIPTION
This PR is an attempt to fix the following crash: https://bugs.dolphin-emu.org/issues/13032

This was the only part of the code I could find where a check was missing that could produce a crash of Dolphin. I'm unsure if it's related to the described issue. Regardless, I managed to exhaust the BBA network stack and crash Dolphin by requesting the UPnP URL with multiple tabs of a web browser.

The PR addresses these issues by:
 - checking the pointer to prevent the `nullptr` dereference crash
 - skipping UPnP requests to itself which _(shouldn't happen on real hardware and)_ are ignored but used to hold onto a network slot forever due to them being ignored.

Ready to be reviewed & merged.