### PR TITLE
Vulkan: Workaround slow vkCmdCopyImageToBuffer on QCom

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -84,8 +84,16 @@ private:
 
 class VKStagingTexture final : public AbstractStagingTexture
 {
+  struct PrivateTag
+  {
+  };
+
 public:
   VKStagingTexture() = delete;
+  VKStagingTexture(PrivateTag, StagingTextureType type, const TextureConfig& config,
+                   std::unique_ptr<StagingBuffer> buffer, VkImage linear_image,
+                   VkDeviceMemory linear_image_memory);
+
   ~VKStagingTexture();
 
   void CopyFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& src_rect,
@@ -102,11 +110,17 @@ public:
   static std::unique_ptr<VKStagingTexture> Create(StagingTextureType type,
                                                   const TextureConfig& config);
 
+  static std::pair<VkImage, VkDeviceMemory> CreateLinearImage(StagingTextureType type,
+                                                              const TextureConfig& config);
+
 private:
-  VKStagingTexture(StagingTextureType type, const TextureConfig& config,
-                   std::unique_ptr<StagingBuffer> buffer);
+  void CopyFromTextureToLinearImage(const VKTexture* src_tex,
+                                    const MathUtil::Rectangle<int>& src_rect, u32 src_layer,
+                                    u32 src_level, const MathUtil::Rectangle<int>& dst_rect);
 
   std::unique_ptr<StagingBuffer> m_staging_buffer;
+  VkImage m_linear_image = VK_NULL_HANDLE;
+  VkDeviceMemory m_linear_image_memory = VK_NULL_HANDLE;
   u64 m_flush_fence_counter = 0;
 };
 

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -152,6 +152,8 @@ constexpr BugInfo m_known_bugs[] = {
      BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING, -1.0, -1.0, true},
     {API_METAL, OS_OSX, VENDOR_INTEL, DRIVER_APPLE, Family::UNKNOWN,
      BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING, -1.0, -1.0, true},
+    {API_VULKAN, OS_ANDROID, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN,
+     BUG_SLOW_OPTIMAL_IMAGE_TO_BUFFER_COPY, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -329,6 +329,13 @@ enum Bug
   // Started version: -1
   // Ended version: -1
   BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING,
+
+  // BUG: vkCmdCopyImageToBuffer allocates a staging image when used to copy from
+  // an image with optimal tiling.
+  // Affected devices: Adreno
+  // Started Version: -1
+  // Ended Version: -1
+  BUG_SLOW_OPTIMAL_IMAGE_TO_BUFFER_COPY
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
After profiling Mario Galaxy on my Snapdragon 865 phone, I realized that the video thread spends a ridiculous amount of time in `vkCmdCopyImageToBuffer`.

Turns out the driver allocates a temporary image every single time. After playing around for a bit, I've noticed that it doesn't do that when copying from a linear tiled image. So we can just do that blit ourselves and reuse the image.

![image](https://user-images.githubusercontent.com/1131720/192053916-07b546a4-aec4-4090-aff9-66c7208ddfa6.png)

EDIT: I should clarify, this is mostly a problem when "Store EFB copies to texture only" is disabled.
