### PR TITLE
GameSettings: Add patch for Dead to Rights audio

### DIFF
--- a/Data/Sys/GameSettings/GDREAF.ini
+++ b/Data/Sys/GameSettings/GDREAF.ini
@@ -1,0 +1,11 @@
+# GDREAF - Dead to Rights
+
+[OnFrame]
+# This game follows the anti-pattern of calling memset on a buffer in the midst
+# of being DMA copied to ARAM, then calling a DVD read function that effectively
+# cancels the memset with dcbi instructions. Dolphin does not emulate dcache for
+# performance reasons, so this patch removes the offending memset call.
+$Fix audio issues
+0x8000AF34:dword:0x60000000
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GDRP69.ini
+++ b/Data/Sys/GameSettings/GDRP69.ini
@@ -1,0 +1,11 @@
+# GDRP69 - Dead to Rights
+
+[OnFrame]
+# This game follows the anti-pattern of calling memset on a buffer in the midst
+# of being DMA copied to ARAM, then calling a DVD read function that effectively
+# cancels the memset with dcbi instructions. Dolphin does not emulate dcache for
+# performance reasons, so this patch removes the offending memset call.
+$Fix audio issues
+0x8000B7EC:dword:0x60000000
+[OnFrame_Enabled]
+$Fix audio issues


### PR DESCRIPTION
This game follows the anti-pattern of calling memset on a buffer in the midst of being DMA copied to ARAM, then calling a DVD read function that effectively cancels the memset with dcbi instructions. Dolphin does not emulate dcache for performance reasons, so this patch removes the offending memset call.

Patches are included for two regions and are enabled by default.

https://bugs.dolphin-emu.org/issues/12759