### PR TITLE
Move a SetEnableAlert call to UICommon

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -511,59 +511,54 @@ public final class NativeLibrary
     Log.error("[NativeLibrary] Alert: " + text);
     final EmulationActivity emulationActivity = sEmulationActivity.get();
     boolean result = false;
-    if (isWarning && emulationActivity != null && emulationActivity.isIgnoringWarnings())
+
+    // We can't use AlertMessages unless we have a non-null activity reference
+    // and are allowed to block. As a fallback, we can use toasts.
+    if (emulationActivity == null || nonBlocking)
     {
-      return true;
+      new Handler(Looper.getMainLooper()).post(
+              () -> Toast.makeText(DolphinApplication.getAppContext(), text, Toast.LENGTH_LONG)
+                      .show());
     }
     else
     {
-      // We can't use AlertMessages unless we have a non-null activity reference
-      // and are allowed to block. As a fallback, we can use toasts.
-      if (emulationActivity == null || nonBlocking)
+      sIsShowingAlertMessage = true;
+
+      emulationActivity.runOnUiThread(() ->
       {
-        new Handler(Looper.getMainLooper()).post(
-                () -> Toast.makeText(DolphinApplication.getAppContext(), text, Toast.LENGTH_LONG)
-                        .show());
+        FragmentManager fragmentManager = emulationActivity.getSupportFragmentManager();
+        if (fragmentManager.isStateSaved())
+        {
+          // The activity is being destroyed, so we can't use it to display an AlertMessage.
+          // Fall back to a toast.
+          Toast.makeText(emulationActivity, text, Toast.LENGTH_LONG).show();
+          NotifyAlertMessageLock();
+        }
+        else
+        {
+          AlertMessage.newInstance(caption, text, yesNo, isWarning)
+                  .show(fragmentManager, "AlertMessage");
+        }
+      });
+
+      // Wait for the lock to notify that it is complete.
+      synchronized (sAlertMessageLock)
+      {
+        try
+        {
+          sAlertMessageLock.wait();
+        }
+        catch (Exception ignored)
+        {
+        }
       }
-      else
+
+      if (yesNo)
       {
-        sIsShowingAlertMessage = true;
-
-        emulationActivity.runOnUiThread(() ->
-        {
-          FragmentManager fragmentManager = emulationActivity.getSupportFragmentManager();
-          if (fragmentManager.isStateSaved())
-          {
-            // The activity is being destroyed, so we can't use it to display an AlertMessage.
-            // Fall back to a toast.
-            Toast.makeText(emulationActivity, text, Toast.LENGTH_LONG).show();
-            NotifyAlertMessageLock();
-          }
-          else
-          {
-            AlertMessage.newInstance(caption, text, yesNo, isWarning)
-                    .show(fragmentManager, "AlertMessage");
-          }
-        });
-
-        // Wait for the lock to notify that it is complete.
-        synchronized (sAlertMessageLock)
-        {
-          try
-          {
-            sAlertMessageLock.wait();
-          }
-          catch (Exception ignored)
-          {
-          }
-        }
-
-        if (yesNo)
-        {
-          result = AlertMessage.getAlertResult();
-        }
+        result = AlertMessage.getAlertResult();
       }
     }
+
     sIsShowingAlertMessage = false;
     return result;
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -88,14 +88,12 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
   private String[] mPaths;
   private boolean mRiivolution;
   private boolean mLaunchSystemMenu;
-  private boolean mIgnoreWarnings;
   private static boolean sUserPausedEmulation;
   private boolean mMenuToastShown;
 
   public static final String EXTRA_SELECTED_GAMES = "SelectedGames";
   public static final String EXTRA_RIIVOLUTION = "Riivolution";
   public static final String EXTRA_SYSTEM_MENU = "SystemMenu";
-  public static final String EXTRA_IGNORE_WARNINGS = "IgnoreWarnings";
   public static final String EXTRA_USER_PAUSED_EMULATION = "sUserPausedEmulation";
   public static final String EXTRA_MENU_TOAST_SHOWN = "MenuToastShown";
 
@@ -316,7 +314,6 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
       mPaths = gameToEmulate.getStringArrayExtra(EXTRA_SELECTED_GAMES);
       mRiivolution = gameToEmulate.getBooleanExtra(EXTRA_RIIVOLUTION, false);
       mLaunchSystemMenu = gameToEmulate.getBooleanExtra(EXTRA_SYSTEM_MENU, false);
-      mIgnoreWarnings = gameToEmulate.getBooleanExtra(EXTRA_IGNORE_WARNINGS, false);
       sUserPausedEmulation = gameToEmulate.getBooleanExtra(EXTRA_USER_PAUSED_EMULATION, false);
       mMenuToastShown = false;
       activityRecreated = false;
@@ -366,7 +363,6 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
       mEmulationFragment.saveTemporaryState();
     }
     outState.putStringArray(EXTRA_SELECTED_GAMES, mPaths);
-    outState.putBoolean(EXTRA_IGNORE_WARNINGS, mIgnoreWarnings);
     outState.putBoolean(EXTRA_USER_PAUSED_EMULATION, sUserPausedEmulation);
     outState.putBoolean(EXTRA_MENU_TOAST_SHOWN, mMenuToastShown);
     super.onSaveInstanceState(outState);
@@ -375,7 +371,6 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
   protected void restoreState(Bundle savedInstanceState)
   {
     mPaths = savedInstanceState.getStringArray(EXTRA_SELECTED_GAMES);
-    mIgnoreWarnings = savedInstanceState.getBoolean(EXTRA_IGNORE_WARNINGS);
     sUserPausedEmulation = savedInstanceState.getBoolean(EXTRA_USER_PAUSED_EMULATION);
     mMenuToastShown = savedInstanceState.getBoolean(EXTRA_MENU_TOAST_SHOWN);
   }
@@ -752,16 +747,6 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
         mEmulationFragment.stopEmulation();
         break;
     }
-  }
-
-  public boolean isIgnoringWarnings()
-  {
-    return mIgnoreWarnings;
-  }
-
-  public void setIgnoreWarnings(boolean value)
-  {
-    mIgnoreWarnings = value;
   }
 
   public static boolean getHasUserPausedEmulation()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/AlertMessage.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/AlertMessage.java
@@ -13,6 +13,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.NativeConfig;
 
 public final class AlertMessage extends DialogFragment
 {
@@ -82,7 +84,7 @@ public final class AlertMessage extends DialogFragment
     {
       builder.setNeutralButton(R.string.ignore_warning_alert_messages, (dialog, which) ->
       {
-        emulationActivity.setIgnoreWarnings(true);
+        BooleanSetting.MAIN_USE_PANIC_HANDLERS.setBoolean(NativeConfig.LAYER_CURRENT, false);
         dialog.dismiss();
         NativeLibrary.NotifyAlertMessageLock();
       });

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -329,6 +329,18 @@ public enum BooleanSetting implements AbstractBooleanSetting
     }
   }
 
+  public void setBoolean(int layerType, boolean newValue)
+  {
+    if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
+    {
+      NativeConfig.setBoolean(layerType, mFile, mSection, mKey, newValue);
+    }
+    else
+    {
+      throw new UnsupportedOperationException("The old config system doesn't support layers");
+    }
+  }
+
   public boolean getBooleanGlobal()
   {
     return NativeConfig.getBoolean(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/NativeConfig.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/NativeConfig.java
@@ -8,6 +8,7 @@ public class NativeConfig
   public static final int LAYER_BASE = 1;
   public static final int LAYER_LOCAL_GAME = 2;
   public static final int LAYER_ACTIVE = 3;
+  public static final int LAYER_CURRENT = 4;
 
   public static native boolean isSettingSaveable(String file, String section, String key);
 

--- a/Source/Android/jni/Config/NativeConfig.cpp
+++ b/Source/Android/jni/Config/NativeConfig.cpp
@@ -16,6 +16,7 @@ constexpr jint LAYER_BASE_OR_CURRENT = 0;
 constexpr jint LAYER_BASE = 1;
 constexpr jint LAYER_LOCAL_GAME = 2;
 constexpr jint LAYER_ACTIVE = 3;
+constexpr jint LAYER_CURRENT = 4;
 
 static Config::Location GetLocation(JNIEnv* env, jstring file, jstring section, jstring key)
 {
@@ -74,6 +75,10 @@ static std::shared_ptr<Config::Layer> GetLayer(jint layer, const Config::Locatio
 
   case LAYER_ACTIVE:
     layer_type = Config::GetActiveLayerForConfig(location);
+    break;
+
+  case LAYER_CURRENT:
+    layer_type = Config::LayerType::CurrentRun;
     break;
 
   default:

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -120,6 +120,13 @@ void SetBaseOrCurrent(const Info<T>& info, const std::common_type_t<T>& value)
     Set<T>(LayerType::CurrentRun, info, value);
 }
 
+template <typename T>
+void DeleteKey(LayerType layer, const Info<T>& info)
+{
+  if (GetLayer(layer)->DeleteKey(info.GetLocation()))
+    OnConfigChanged();
+}
+
 // Used to defer OnConfigChanged until after the completion of many config changes.
 class ConfigChangeCallbackGuard
 {

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -92,7 +92,7 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
 
     if (button == QMessageBox::Ignore)
     {
-      Common::SetEnableAlert(false);
+      Config::SetCurrent(Config::MAIN_USE_PANIC_HANDLERS, false);
       return true;
     }
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -548,8 +548,7 @@ void MenuBar::AddOptionsMenu()
   m_reset_ignore_panic_handler = options_menu->addAction(tr("Reset Ignore Panic Handler"));
 
   connect(m_reset_ignore_panic_handler, &QAction::triggered, this, []() {
-    if (Config::Get(Config::MAIN_USE_PANIC_HANDLERS))
-      Common::SetEnableAlert(true);
+    Config::DeleteKey(Config::LayerType::CurrentRun, Config::MAIN_USE_PANIC_HANDLERS);
   });
 
   m_change_font = options_menu->addAction(tr("&Font..."), this, &MenuBar::ChangeDebugFont);

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -309,8 +309,6 @@ void InterfacePane::OnSaveConfig()
   Config::SetBase(Config::MAIN_SHOW_ACTIVE_TITLE, m_checkbox_show_active_title->isChecked());
   Config::SetBase(Config::MAIN_PAUSE_ON_FOCUS_LOST, m_checkbox_pause_on_focus_lost->isChecked());
 
-  Common::SetEnableAlert(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
-
   auto new_language = m_combobox_language->currentData().toString().toStdString();
   if (new_language != Config::Get(Config::MAIN_INTERFACE_LANGUAGE))
   {

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -57,6 +57,8 @@
 
 namespace UICommon
 {
+static size_t s_config_changed_callback_id;
+
 static void CreateDumpPath(std::string path)
 {
   if (!path.empty())
@@ -108,6 +110,12 @@ static void InitCustomPaths()
 #endif
 }
 
+static void RefreshConfig()
+{
+  Common::SetEnableAlert(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
+  Common::SetAbortOnPanicAlert(Config::Get(Config::MAIN_ABORT_ON_PANIC_ALERT));
+}
+
 void Init()
 {
   Core::RestoreWiiSettings(Core::RestoreReason::CrashRecovery);
@@ -120,12 +128,14 @@ void Init()
   Common::Log::LogManager::Init();
   VideoBackendBase::ActivateBackend(Config::Get(Config::MAIN_GFX_BACKEND));
 
-  Common::SetEnableAlert(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
-  Common::SetAbortOnPanicAlert(Config::Get(Config::MAIN_ABORT_ON_PANIC_ALERT));
+  s_config_changed_callback_id = Config::AddConfigChangedCallback(RefreshConfig);
+  RefreshConfig();
 }
 
 void Shutdown()
 {
+  Config::RemoveConfigChangedCallback(s_config_changed_callback_id);
+
   GCAdapter::Shutdown();
   WiimoteReal::Shutdown();
   Common::Log::LogManager::Shutdown();


### PR DESCRIPTION
This fixes a problem where changing the Use Panic Handlers setting on Android wouldn't take effect until the app was restarted.