### PR TITLE
Vulkan: Raise number of command buffers

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -43,11 +43,7 @@ public:
     const CmdBufferResources& cmd_buffer_resources = m_command_buffers[m_current_cmd_buffer];
     return cmd_buffer_resources.command_buffers[1];
   }
-  VkDescriptorPool GetCurrentDescriptorPool() const
-  {
-    const CmdBufferResources& cmd_buffer_resources = m_command_buffers[m_current_cmd_buffer];
-    return cmd_buffer_resources.descriptor_pool;
-  }
+  VkDescriptorPool GetCurrentDescriptorPool() const { return m_descriptor_pools[m_current_frame]; }
   // Allocates a descriptors set from the pool reserved for the current frame.
   VkDescriptorSet AllocateDescriptorSet(VkDescriptorSetLayout set_layout);
 
@@ -114,7 +110,6 @@ private:
     // [0] - Init (upload) command buffer, [1] - draw command buffer
     VkCommandPool command_pool = VK_NULL_HANDLE;
     std::array<VkCommandBuffer, 2> command_buffers = {};
-    VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
     VkFence fence = VK_NULL_HANDLE;
     VkSemaphore semaphore = VK_NULL_HANDLE;
     u64 fence_counter = 0;
@@ -133,6 +128,7 @@ private:
   u64 m_next_fence_counter = 1;
   u64 m_completed_fence_counter = 0;
 
+  std::array<VkDescriptorPool, NUM_FRAMES_IN_FLIGHT> m_descriptor_pools;
   std::array<CmdBufferResources, NUM_COMMAND_BUFFERS> m_command_buffers;
   u32 m_current_frame = 0;
   u32 m_current_cmd_buffer = 0;

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -123,8 +123,6 @@ private:
   u32 m_current_frame = 0;
 
   // Threaded command buffer execution
-  // Semaphore determines when a command buffer can be queued
-  Common::Semaphore m_submit_semaphore;
   std::thread m_submit_thread;
   std::unique_ptr<Common::BlockingLoop> m_submit_loop;
   struct PendingCommandBufferSubmit
@@ -136,6 +134,8 @@ private:
   VkSemaphore m_present_semaphore = VK_NULL_HANDLE;
   std::deque<PendingCommandBufferSubmit> m_pending_submits;
   std::mutex m_pending_submit_lock;
+  std::condition_variable m_submit_worker_condvar;
+  bool m_submit_worker_idle = true;
   Common::Flag m_last_present_failed;
   VkResult m_last_present_result = VK_SUCCESS;
   bool m_use_threaded_submission = false;

--- a/Source/Core/VideoBackends/Vulkan/Constants.h
+++ b/Source/Core/VideoBackends/Vulkan/Constants.h
@@ -12,7 +12,7 @@
 namespace Vulkan
 {
 // Number of command buffers.
-constexpr size_t NUM_COMMAND_BUFFERS = 2;
+constexpr size_t NUM_COMMAND_BUFFERS = 8;
 
 // Number of frames in flight, will be used to decide how many descriptor pools are used
 constexpr size_t NUM_FRAMES_IN_FLIGHT = 2;

--- a/Source/Core/VideoBackends/Vulkan/Constants.h
+++ b/Source/Core/VideoBackends/Vulkan/Constants.h
@@ -11,9 +11,11 @@
 
 namespace Vulkan
 {
-// Number of command buffers. Having two allows one buffer to be
-// executed whilst another is being built.
+// Number of command buffers.
 constexpr size_t NUM_COMMAND_BUFFERS = 2;
+
+// Number of frames in flight, will be used to decide how many descriptor pools are used
+constexpr size_t NUM_FRAMES_IN_FLIGHT = 2;
 
 // Staging buffer usage - optimize for uploads or readbacks
 enum STAGING_BUFFER_TYPE

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -223,7 +223,10 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
     WARN_LOG_FMT(VIDEO, "Vulkan: Debug report requested, but extension is not available.");
 
   AddExtension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, false);
-  AddExtension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, false);
+  if (wstype != WindowSystemType::Headless)
+  {
+    AddExtension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, false);
+  }
 
   if (AddExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME, false))
   {


### PR DESCRIPTION
In order to keep the GPU busy when Dolphin does EFB readbacks, there's the option to automatically flush the command buffer at specific points instead of just before a readback or at the end of the frame.

The problem with this is that Dolphin currently only has 2 Vulkan command buffers and when both of those are in use, it will just wait for one to become available. So flushing more often could make CPU-GPU parallelism worse if the GPU didn't finish the command buffers faster than Dolphin was flushing.

My Snapdragon 865 phone sits at <30% GPU utilization with Mario Galaxy (1x res) while the CPU spends most of its time waiting for the CPU to finish. So flushing more often is definitely beneficial because it allows the GPU to start working sooner.

This PR raises the number of command buffers to 8. We could easily use a higher number here but 8 seems fine in my very limited testing. Mario Galaxy for example uses ~22 command buffers but 8 is enough here because it stalls before exceeding 8, so we can just reuse the earlier ones.
Dolphins VkDescriptorPools are huge, so I've separated those from the command buffer. The number of VkDescriptorPools is still 2 and they are associated with a frame rather than a command buffer. 

I've also tweaked the synchronization logic with the submission thread. Before, it would sync on every submission, now it only syncs on submits which need to finish immediately.