### PR TITLE
JitArm64: boolX constant optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -319,6 +319,98 @@ void JitArm64::boolX(UGeckoInstruction inst)
       PanicAlertFmt("WTF!");
     }
   }
+  else if ((gpr.IsImm(s) && (gpr.GetImm(s) == 0 || gpr.GetImm(s) == 0xFFFFFFFF)) ||
+           (gpr.IsImm(b) && (gpr.GetImm(b) == 0 || gpr.GetImm(b) == 0xFFFFFFFF)))
+  {
+    const auto [i, j] = gpr.IsImm(s) ? std::pair(s, b) : std::pair(b, s);
+    bool is_zero = gpr.GetImm(i) == 0;
+
+    bool complement_b = (inst.SUBOP10 == 60 /* andcx */) || (inst.SUBOP10 == 412 /* orcx */);
+    const bool final_not = (inst.SUBOP10 == 476 /* nandx */) || (inst.SUBOP10 == 124 /* norx */);
+    const bool is_and = (inst.SUBOP10 == 28 /* andx */) || (inst.SUBOP10 == 60 /* andcx */) ||
+                        (inst.SUBOP10 == 476 /* nandx */);
+    const bool is_or = (inst.SUBOP10 == 444 /* orx */) || (inst.SUBOP10 == 412 /* orcx */) ||
+                       (inst.SUBOP10 == 124 /* norx */);
+    const bool is_xor = (inst.SUBOP10 == 316 /* xorx */) || (inst.SUBOP10 == 284 /* eqvx */);
+
+    if ((complement_b && i == b) || (inst.SUBOP10 == 284 /* eqvx */))
+    {
+      is_zero = !is_zero;
+      complement_b = false;
+    }
+
+    if (is_xor)
+    {
+      if (!is_zero)
+      {
+        gpr.BindToRegister(a, a == j);
+        MVN(gpr.R(a), gpr.R(j));
+      }
+      else if (a != j)
+      {
+        gpr.BindToRegister(a, false);
+        MOV(gpr.R(a), gpr.R(j));
+      }
+      if (inst.Rc)
+        ComputeRC0(gpr.R(a));
+    }
+    else if (is_and)
+    {
+      if (is_zero)
+      {
+        gpr.SetImmediate(a, final_not ? 0xFFFFFFFF : 0);
+        if (inst.Rc)
+          ComputeRC0(gpr.GetImm(a));
+      }
+      else if (final_not || complement_b)
+      {
+        gpr.BindToRegister(a, a == j);
+        MVN(gpr.R(a), gpr.R(j));
+        if (inst.Rc)
+          ComputeRC0(gpr.R(a));
+      }
+      else
+      {
+        if (a != j)
+        {
+          gpr.BindToRegister(a, false);
+          MOV(gpr.R(a), gpr.R(j));
+        }
+        if (inst.Rc)
+          ComputeRC0(gpr.R(a));
+      }
+    }
+    else if (is_or)
+    {
+      if (!is_zero)
+      {
+        gpr.SetImmediate(a, final_not ? 0 : 0xFFFFFFFF);
+        if (inst.Rc)
+          ComputeRC0(gpr.GetImm(a));
+      }
+      else if (final_not || complement_b)
+      {
+        gpr.BindToRegister(a, a == j);
+        MVN(gpr.R(a), gpr.R(j));
+        if (inst.Rc)
+          ComputeRC0(gpr.R(a));
+      }
+      else
+      {
+        if (a != j)
+        {
+          gpr.BindToRegister(a, false);
+          MOV(gpr.R(a), gpr.R(j));
+        }
+        if (inst.Rc)
+          ComputeRC0(gpr.R(a));
+      }
+    }
+    else
+    {
+      PanicAlertFmt("WTF!");
+    }
+  }
   else
   {
     gpr.BindToRegister(a, (a == s) || (a == b));


### PR DESCRIPTION
A (partial) port of #9481 to ARM64. This commit adds special cases for immediate values equal to 0 or 0xFFFFFFFF, allowing for more efficient or no code to be generated.

The 'after' examples showcase the generated code after applying both this PR and #11094.

---

**and**

<details><summary>Special case 0</summary>

Before:
```
0x52800017   mov    w23, #0x0
0x0a170319   and    w25, w24, w23
```

After:
Nothing, register is set to constant zero.
</details>
<details><summary>Special case 0xFFFFFFFF</summary>

Before:
```
0x1280001a   mov    w26, #-0x1
0x0a1a033a   and    w26, w25, w26
```

After:
```
0x2a1903fa   mov    w26, w25
```
</details>

---

**or**

<details><summary>Special case 0 (a != j)</summary>

Before:
```
0x52800004   mov    w4, #0x0
0x2a0a0084   orr    w4, w4, w10
```

After:
```
0x2a0a03e4   mov    w4, w10
```
</details>
<details><summary>Special case 0 (a == j)</summary>

Before:
```
0x52800017   mov    w23, #0x0
0x2a17037b   orr    w27, w27, w23
```

After:
Nothing.
</details>

---

**xor**

<details><summary>Special case 0 (a != j)</summary>

Before:
```
0x52800013   mov    w19, #0x0
0x4a130355   eor    w21, w26, w19
```

After:
```
0x2a1a03f5   mov    w21, w26
```
</details>
<details><summary>Special case 0 (a == j)</summary>

Before:
```
0x52800017   mov    w23, #0x0
0x4a17037b   eor    w27, w27, w23
```

After:
Nothing.
</details>