### PR TITLE
Android: Improve checking in MainPresenter.launchWiiSystemMenu

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -317,20 +317,20 @@ public final class MainPresenter
 
   private void launchWiiSystemMenu()
   {
-    if (WiiUtils.isSystemMenuInstalled())
+    new AfterDirectoryInitializationRunner().runWithLifecycle(mActivity, () ->
     {
-      EmulationActivity.launchSystemMenu(mActivity);
-    }
-    else
-    {
-      new AfterDirectoryInitializationRunner().runWithLifecycle(mActivity, () ->
+      if (WiiUtils.isSystemMenuInstalled())
+      {
+        EmulationActivity.launchSystemMenu(mActivity);
+      }
+      else
       {
         SystemMenuNotInstalledDialogFragment dialogFragment =
                 new SystemMenuNotInstalledDialogFragment();
         dialogFragment
                 .show(mActivity.getSupportFragmentManager(),
                         "SystemMenuNotInstalledDialogFragment");
-      });
-    }
+      }
+    });
   }
 }


### PR DESCRIPTION
Not only SystemMenuNotInstalledDialogFragment requires directory initialization to have completed, but also isSystemMenuInstalled.