### PR TITLE
VideoCommon: Update EFB peek cache on draw done and tokens

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -181,6 +181,7 @@ static void BPWritten(const BPCmd& bp, int cycles_into_future)
       INCSTAT(g_stats.this_frame.num_draw_done);
       g_texture_cache->FlushEFBCopies();
       g_framebuffer_manager->InvalidatePeekCache(false);
+      g_framebuffer_manager->RefreshPeekCache();
       if (!Fifo::UseDeterministicGPUThread())
         PixelEngine::SetFinish(cycles_into_future);  // may generate interrupt
       DEBUG_LOG_FMT(VIDEO, "GXSetDrawDone SetPEFinish (value: {:#04X})", bp.newvalue & 0xFFFF);
@@ -195,6 +196,7 @@ static void BPWritten(const BPCmd& bp, int cycles_into_future)
     INCSTAT(g_stats.this_frame.num_token);
     g_texture_cache->FlushEFBCopies();
     g_framebuffer_manager->InvalidatePeekCache(false);
+    g_framebuffer_manager->RefreshPeekCache();
     if (!Fifo::UseDeterministicGPUThread())
       PixelEngine::SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), false, cycles_into_future);
     DEBUG_LOG_FMT(VIDEO, "SetPEToken {:#06X}", bp.newvalue & 0xFFFF);
@@ -203,6 +205,7 @@ static void BPWritten(const BPCmd& bp, int cycles_into_future)
     INCSTAT(g_stats.this_frame.num_token_int);
     g_texture_cache->FlushEFBCopies();
     g_framebuffer_manager->InvalidatePeekCache(false);
+    g_framebuffer_manager->RefreshPeekCache();
     if (!Fifo::UseDeterministicGPUThread())
       PixelEngine::SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), true, cycles_into_future);
     DEBUG_LOG_FMT(VIDEO, "SetPEToken + INT {:#06X}", bp.newvalue & 0xFFFF);

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -26,6 +26,7 @@
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/DataReader.h"
+#include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
@@ -415,6 +416,7 @@ void RunGpuLoop()
           // The fifo is empty and it's unlikely we will get any more work in the near future.
           // Make sure VertexManager finishes drawing any primitives it has stored in it's buffer.
           g_vertex_manager->Flush();
+          g_framebuffer_manager->RefreshPeekCache();
         }
       },
       100);

--- a/Source/Core/VideoCommon/FramebufferManager.h
+++ b/Source/Core/VideoCommon/FramebufferManager.h
@@ -99,7 +99,9 @@ public:
   float PeekEFBDepth(u32 x, u32 y);
   void SetEFBCacheTileSize(u32 size);
   void InvalidatePeekCache(bool forced = true);
+  void RefreshPeekCache();
   void FlagPeekCacheAsOutOfDate();
+  void EndOfFrame();
 
   // Writes a value to the framebuffer. This will never block, and writes will be batched.
   void PokeEFBColor(u32 x, u32 y, u32 color);
@@ -117,6 +119,12 @@ protected:
   };
   static_assert(std::is_standard_layout<EFBPokeVertex>::value, "EFBPokeVertex is standard-layout");
 
+  struct EFBCacheTile
+  {
+    bool present;
+    u8 frame_access_mask;
+  };
+
   // EFB cache - for CPU EFB access
   // Tiles are ordered left-to-right, then top-to-bottom
   struct EFBCacheData
@@ -125,9 +133,10 @@ protected:
     std::unique_ptr<AbstractFramebuffer> framebuffer;
     std::unique_ptr<AbstractStagingTexture> readback_texture;
     std::unique_ptr<AbstractPipeline> copy_pipeline;
-    std::vector<bool> tiles;
+    std::vector<EFBCacheTile> tiles;
     bool out_of_date;
     bool valid;
+    bool needs_flush;
   };
 
   bool CreateEFBFramebuffer();
@@ -151,7 +160,7 @@ protected:
   bool IsUsingTiledEFBCache() const;
   bool IsEFBCacheTilePresent(bool depth, u32 x, u32 y, u32* tile_index) const;
   MathUtil::Rectangle<int> GetEFBCacheTileRect(u32 tile_index) const;
-  void PopulateEFBCache(bool depth, u32 tile_index);
+  void PopulateEFBCache(bool depth, u32 tile_index, bool async = false);
 
   void CreatePokeVertices(std::vector<EFBPokeVertex>* destination_list, u32 x, u32 y, float z,
                           u32 color);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1346,6 +1346,8 @@ void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u6
     m_graphics_mod_manager.EndOfFrame();
   }
 
+  g_framebuffer_manager->EndOfFrame();
+
   if (xfb_addr && fb_width && fb_stride && fb_height)
   {
     // Get the current XFB from texture cache


### PR DESCRIPTION
I assume DrawDone and or Tokens are used to synchronize with the GPU before reading back data from the EFB.
So instead of just invalidating the EFB peek cache, I take it as a hint and queue an update to all previously used EFB tiles.
If there is work between DrawDone/Token and the actual EFB read, the read hits a prepopulated cache and doesn't stall both threads and the GPU.

It helps Super Mario Galaxy, getting the game up to 60 FPS on my Snapdragon 865 phone (instead of ~40) in some scenes. Unfortunately Galaxy also likes to invalidate the peek cache after a DrawDone/Token and even if I enable DeferEFBInvalidations, the GPU still doesn't finish in time.
This is the sort of change that probably needs a lot more testing as it could impact other games. Perhabs it should be a config option?

I'm looking forward to some feedback.