### PR TITLE
Goldeneye 007 (Wii) - Disable Defer EFB Copies

### DIFF
--- a/Data/Sys/GameSettings/SJB.ini
+++ b/Data/Sys/GameSettings/SJB.ini
@@ -14,4 +14,4 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
-
+DeferEFBCopies = False


### PR DESCRIPTION
Defer EFB Copies causes visual issues in this game, so let's disable it.