### PR TITLE
Android: Allocate GameFileCache on GUI thread

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/AppLinkActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/AppLinkActivity.java
@@ -74,7 +74,7 @@ public class AppLinkActivity extends FragmentActivity
     });
 
     DirectoryInitialization.start(this);
-    GameFileCacheManager.startLoad(this);
+    GameFileCacheManager.startLoad();
   }
 
   /**

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -233,7 +233,7 @@ public class Settings implements Closeable
       if (mLoadedRecursiveIsoPathsValue != BooleanSetting.MAIN_RECURSIVE_ISO_PATHS.getBoolean(this))
       {
         // Refresh game library
-        GameFileCacheManager.startRescan(context);
+        GameFileCacheManager.startRescan();
       }
     }
     else

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
@@ -109,11 +109,11 @@ public class GameFileCache
 
   public static native String[] getAllGamePaths(String[] folderPaths, boolean recursiveScan);
 
-  public native int getSize();
+  public synchronized native int getSize();
 
-  public native GameFile[] getAllGames();
+  public synchronized native GameFile[] getAllGames();
 
-  public native GameFile addOrGet(String gamePath);
+  public synchronized native GameFile addOrGet(String gamePath);
 
   /**
    * Sets the list of games to cache.
@@ -123,7 +123,7 @@ public class GameFileCache
    *
    * @return true if the cache was modified
    */
-  public native boolean update(String[] gamePaths);
+  public synchronized native boolean update(String[] gamePaths);
 
   /**
    * For each game that already is in the cache, scans the folder that contains the game
@@ -131,9 +131,9 @@ public class GameFileCache
    *
    * @return true if the cache was modified
    */
-  public native boolean updateAdditionalMetadata();
+  public synchronized native boolean updateAdditionalMetadata();
 
-  public native boolean load();
+  public synchronized native boolean load();
 
-  public native boolean save();
+  public synchronized native boolean save();
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.java
@@ -227,25 +227,24 @@ public final class GameFileCacheManager
     {
       String[] gamePaths = GameFileCache.getAllGamePaths();
 
-      boolean changed;
       synchronized (sGameFileCache)
       {
-        changed = sGameFileCache.update(gamePaths);
-      }
-      if (changed)
-      {
-        updateGameFileArray();
-      }
+        boolean changed = sGameFileCache.update(gamePaths);
+        if (changed)
+        {
+          updateGameFileArray();
+        }
 
-      boolean additionalMetadataChanged = sGameFileCache.updateAdditionalMetadata();
-      if (additionalMetadataChanged)
-      {
-        updateGameFileArray();
-      }
+        boolean additionalMetadataChanged = sGameFileCache.updateAdditionalMetadata();
+        if (additionalMetadataChanged)
+        {
+          updateGameFileArray();
+        }
 
-      if (changed || additionalMetadataChanged)
-      {
-        sGameFileCache.save();
+        if (changed || additionalMetadataChanged)
+        {
+          sGameFileCache.save();
+        }
       }
     }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.java
@@ -2,8 +2,6 @@
 
 package org.dolphinemu.dolphinemu.services;
 
-import android.content.Context;
-
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
@@ -124,7 +122,7 @@ public final class GameFileCacheManager
    * if the games are still present in the user's configured folders.
    * If this has already been called, calling it again has no effect.
    */
-  public static void startLoad(Context context)
+  public static void startLoad()
   {
     createGameFileCacheIfNeeded();
 
@@ -142,7 +140,7 @@ public final class GameFileCacheManager
    * If loading the game file cache hasn't started or hasn't finished,
    * the execution of this will be postponed until it finishes.
    */
-  public static void startRescan(Context context)
+  public static void startRescan()
   {
     createGameFileCacheIfNeeded();
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -301,7 +301,7 @@ public final class MainActivity extends AppCompatActivity
   public void onRefresh()
   {
     setRefreshing(true);
-    GameFileCacheManager.startRescan(this);
+    GameFileCacheManager.startRescan();
   }
 
   /**
@@ -368,7 +368,7 @@ public final class MainActivity extends AppCompatActivity
     mViewPager.setCurrentItem(IntSetting.MAIN_LAST_PLATFORM_TAB.getIntGlobal());
 
     showGames();
-    GameFileCacheManager.startLoad(this);
+    GameFileCacheManager.startLoad();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -96,7 +96,7 @@ public final class MainPresenter
 
       case R.id.menu_refresh:
         mView.setRefreshing(true);
-        GameFileCacheManager.startRescan(activity);
+        GameFileCacheManager.startRescan();
         return true;
 
       case R.id.button_add_directory:
@@ -146,7 +146,7 @@ public final class MainPresenter
 
     if (sShouldRescanLibrary)
     {
-      GameFileCacheManager.startRescan(mActivity);
+      GameFileCacheManager.startRescan();
     }
 
     sShouldRescanLibrary = true;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -79,7 +79,7 @@ public final class TvMainActivity extends FragmentActivity
     if (DirectoryInitialization.shouldStart(this))
     {
       DirectoryInitialization.start(this);
-      GameFileCacheManager.startLoad(this);
+      GameFileCacheManager.startLoad();
     }
 
     mPresenter.onResume();
@@ -292,7 +292,7 @@ public final class TvMainActivity extends FragmentActivity
       }
 
       DirectoryInitialization.start(this);
-      GameFileCacheManager.startLoad(this);
+      GameFileCacheManager.startLoad();
     }
   }
 
@@ -303,7 +303,7 @@ public final class TvMainActivity extends FragmentActivity
   public void onRefresh()
   {
     setRefreshing(true);
-    GameFileCacheManager.startRescan(this);
+    GameFileCacheManager.startRescan();
   }
 
   private void buildRowsAdapter()
@@ -313,7 +313,7 @@ public final class TvMainActivity extends FragmentActivity
 
     if (!DirectoryInitialization.isWaitingForWriteAccess(this))
     {
-      GameFileCacheManager.startLoad(this);
+      GameFileCacheManager.startLoad();
     }
 
     for (Platform platform : Platform.values())

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -13,8 +13,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
   add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
   add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
-  # The replacement for the old atomic shared_ptr functions was added in C++20, so we can't use it yet
-  add_definitions(-D_SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
 endif()
 
 if (NOT MSVC)

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -4,7 +4,6 @@
 #include "UICommon/GameFileCache.h"
 
 #include <algorithm>
-#include <atomic>
 #include <cstddef>
 #include <functional>
 #include <list>
@@ -204,7 +203,7 @@ bool GameFileCache::UpdateAdditionalMetadata(std::shared_ptr<GameFile>* game_fil
   if (custom_cover_changed)
     copy->CustomCoverCommit();
 
-  std::atomic_store(game_file, std::move(copy));
+  *game_file = std::move(copy);
 
   return true;
 }

--- a/Source/VSProps/Base.Dolphin.props
+++ b/Source/VSProps/Base.Dolphin.props
@@ -29,8 +29,6 @@
       <PreprocessorDefinitions>_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!--Currently needed for some code in StringUtil used only on Android-->
       <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <!--The replacement for the old atomic shared_ptr functions was added in C++20, so we can't use it yet-->
-      <PreprocessorDefinitions>_SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 
       <!--Dolphin-specific definitions-->
       <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">_ARCH_64=1;_M_X86=1;_M_X86_64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
This is intended to fix https://bugs.dolphin-emu.org/issues/13053, which is a crash caused by `sGameFileCache` being null when `addOrGet` is called.

I've also included some other changes related to `GameFileCacheManager`. Please read the commits for details.