### PR TITLE
EXI_DeviceMemoryCard: Drop comment about ChipErase behaviour

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -295,8 +295,6 @@ void CEXIMemoryCard::SetCS(int cs)
     case Command::ChipErase:
       if (m_position > 2)
       {
-        // TODO: Investigate on HW, I (LPFaint99) believe that this only
-        // erases the system area (Blocks 0-4)
         m_memory_card->ClearAll();
         m_status &= ~MC_STATUS_BUSY;
       }


### PR DESCRIPTION
Tested on an official DOL-014 (251 blocks) memory card by executing the 0xf4 command on a card with content along its entire length and then dumping the whole card: it reads as 0xff all the way through. Therefor, the current implementation is already consistent with hardware.