### PR TITLE
SI: Ignore non-standard setGameID command

### DIFF
--- a/Source/Core/Core/HW/SI/SI_Device.h
+++ b/Source/Core/Core/HW/SI/SI_Device.h
@@ -47,6 +47,7 @@ enum class EBufferCommands : u8
   CMD_STATUS = 0x00,
   CMD_READ_GBA = 0x14,
   CMD_WRITE_GBA = 0x15,
+  CMD_SET_GAME_ID = 0x1d,
   CMD_DIRECT = 0x40,
   CMD_ORIGIN = 0x41,
   CMD_RECALIBRATE = 0x42,

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -105,6 +105,14 @@ int CSIDevice_GCController::RunBuffer(u8* buffer, int request_length)
     return sizeof(SOrigin);
   }
 
+  // GameID packet, no response needed, nothing to do
+  // On real hardware, this is used to configure the BlueRetro controler
+  // adapter, while licensed accessories ignore this command.
+  case EBufferCommands::CMD_SET_GAME_ID:
+  {
+    return 0;
+  }
+
   // DEFAULT
   default:
   {


### PR DESCRIPTION
Avoids a panic when loading recent swiss. Not enough to have it run, unfortunately.