### PR TITLE
docs/DSP: Trivial adjustment to BLOOP{,I} sub-operation order

### DIFF
--- a/Source/DSPSpy/main_spy.cpp
+++ b/Source/DSPSpy/main_spy.cpp
@@ -149,21 +149,17 @@ void print_reg_block(int x, int y, int sel, const u16* regs, const u16* compare_
   {
     for (int i = 0; i < 8; i++)
     {
-      // Do not even display the loop stack registers.
       const int reg = j * 8 + i;
+      u8 color1 = regs[reg] == compare_regs[reg] ? CON_BRIGHT_WHITE : CON_BRIGHT_RED;
       CON_SetColor(sel == reg ? CON_BRIGHT_YELLOW : CON_GREEN);
       CON_Printf(x + j * 9, i + y, "%s ", reg_names[reg]);
-      if (j != 1 || i < 4)
+      for (int k = 0; k < 4; k++)
       {
-        u8 color1 = regs[reg] == compare_regs[reg] ? CON_BRIGHT_WHITE : CON_BRIGHT_RED;
-        for (int k = 0; k < 4; k++)
-        {
-          if (sel == reg && k == small_cursor_x && ui_mode == UIM_EDIT_REG)
-            CON_SetColor(CON_BRIGHT_CYAN);
-          else
-            CON_SetColor(color1);
-          CON_Printf(x + 4 + j * 9 + k, i + y, "%01x", (regs[reg] >> ((3 - k) * 4)) & 0xf);
-        }
+        if (sel == reg && k == small_cursor_x && ui_mode == UIM_EDIT_REG)
+          CON_SetColor(CON_BRIGHT_CYAN);
+        else
+          CON_SetColor(color1);
+        CON_Printf(x + 4 + j * 9 + k, i + y, "%01x", (regs[reg] >> ((3 - k) * 4)) & 0xf);
       }
     }
   }

--- a/Source/DSPSpy/tests/st3_test.ds
+++ b/Source/DSPSpy/tests/st3_test.ds
@@ -1,0 +1,25 @@
+; This test checks when $st3 gets decremented during BLOOP{,I} iterations.
+; Expected $st3 values are: 2, 1, 0x0b88, 2, 1, 0x0b88.
+
+incdir  "tests"
+include "dsp_base.inc"
+
+test_main:
+	LRI $ac0.l, #2
+	BLOOP $ac0.l, last_of_bloop
+	CALL send_back
+	NOP
+	NOP
+last_of_bloop:
+	NOP
+	CALL send_back
+
+	BLOOPI #2, last_of_bloopi
+	CALL send_back
+	NOP
+	NOP
+last_of_bloopi:
+	NOP
+	CALL send_back
+
+	JMP end_of_test

--- a/docs/DSP/GameCube_DSP_Users_Manual/GameCube_DSP_Users_Manual.tex
+++ b/docs/DSP/GameCube_DSP_Users_Manual/GameCube_DSP_Users_Manual.tex
@@ -46,7 +46,7 @@
 % Document front page material
 \title{\textbf{\Huge GameCube DSP User's Manual}}
 \author{Reverse-engineered and documented by Duddie \\ \href{mailto:duddie@walla.com}{duddie@walla.com}}
-\date{\today\\v0.1.4}
+\date{\today\\v0.1.5}
 
 % Title formatting commands
 \newcommand{\OpcodeTitle}[1]{\subsection{#1}\label{instruction:#1}}
@@ -262,6 +262,7 @@ The purpose of this documentation is purely academic and it aims at understandin
 0.1.2            & 2022.05.21    & Pokechu22       & Fixed ``ILLR'' typo in Instruction Memory section                                        \\ \hline
 0.1.3            & 2022.05.27    & Pokechu22       & Renamed \texttt{CMPAR} instruction to \texttt{CMPAXH}                                    \\ \hline
 0.1.4            & 2022.06.02    & Pokechu22       & Fixed typos; added sections on 16-bit and 40-bit modes and on main and extended opcode writing to the same register. \\ \hline
+0.1.5            & 2022.09.29    & vpelletier      & Fixed \texttt{BLOOP} and \texttt{BLOOPI} suboperation order \\ \hline
 \end{tabular}
 \end{table}
 
@@ -1664,10 +1665,11 @@ A ``-'' indicates that the flag retains its previous value, a ``0'' indicates th
 
     // On real hardware, the below does not happen,
     // this opcode only sets stack registers
-    WHILE ($st3--)
+    WHILE ($st3)
         DO
             EXECUTE_OPCODE($pc)
         WHILE($pc != $st2)
+        $st3--
         $pc = $st0
     END
     $pc = addrA + 1
@@ -1702,10 +1704,11 @@ A ``-'' indicates that the flag retains its previous value, a ``0'' indicates th
 
     // On real hardware, the below does not happen,
     // this opcode only sets stack registers
-    WHILE ($st3--)
+    WHILE ($st3)
         DO
             EXECUTE_OPCODE($pc)
         WHILE($pc != $st2)
+        $st3--
         $pc = $st0
     END
     $pc = addrA + 1


### PR DESCRIPTION
Noticed while tracing in a BLOOP using DSPSpy with $st{0..3} unmasked. BLOOPI assumed to follow the pattern.