### PR TITLE
FatFsUtil: Add ability to provide callbacks for the FatFs code.

### DIFF
--- a/Source/Core/Common/FatFsUtil.h
+++ b/Source/Core/Common/FatFsUtil.h
@@ -3,10 +3,28 @@
 
 #pragma once
 
+#include <functional>
+
 #include "Common/CommonTypes.h"
 
 namespace Common
 {
 bool SyncSDFolderToSDImage(bool deterministic);
 bool SyncSDImageToSDFolder();
+
+class FatFsCallbacks
+{
+public:
+  FatFsCallbacks();
+  virtual ~FatFsCallbacks();
+
+  virtual u8 DiskInitialize(u8 pdrv);
+  virtual u8 DiskStatus(u8 pdrv);
+  virtual int DiskRead(u8 pdrv, u8* buff, u32 sector, unsigned int count) = 0;
+  virtual int DiskWrite(u8 pdrv, const u8* buff, u32 sector, unsigned int count) = 0;
+  virtual int DiskIOCtl(u8 pdrv, u8 cmd, void* buff) = 0;
+  virtual u32 GetCurrentTimeFAT();
+};
+
+void RunInFatFsContext(FatFsCallbacks& callbacks, const std::function<void()>& function);
 }  // namespace Common


### PR DESCRIPTION
FatFsUtil code refactoring so #11072 can be implemented without having to modify FatFs itself. See also #11107.