### PR TITLE
MemoryViewWidget refactor memory table

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -49,6 +49,7 @@ public:
 
   explicit MemoryViewWidget(QWidget* parent = nullptr);
 
+  void CreateTable();
   void Update();
   void UpdateFont();
   void ToggleBreakpoint(u32 addr, bool row);
@@ -72,9 +73,10 @@ private:
   void OnCopyAddress(u32 addr);
   void OnCopyHex(u32 addr);
   void UpdateBreakpointTags();
-  void UpdateColumns(Type type, int first_column);
+  void UpdateColumns();
   void ScrollbarActionTriggered(int action);
   void ScrollbarSliderReleased();
+  QString ValueToString(u32 address, Type type);
 
   MemoryViewTable* m_table;
   QScrollBar* m_scrollbar;
@@ -82,11 +84,12 @@ private:
   Type m_type = Type::Hex32;
   BPType m_bp_type = BPType::ReadWrite;
   bool m_do_log = true;
-  u32 m_address = 0;
+  u32 m_address = 0x80000000;
   int m_font_width = 0;
   int m_font_vspace = 0;
   int m_bytes_per_row = 16;
   int m_alignment = 16;
+  int m_data_columns;
   bool m_dual_view = false;
 
   friend class MemoryViewTable;


### PR DESCRIPTION
Everything in the table was being re-created on every update. Future work needs the table to persist.

Added CreateTable(), move all constants and semi-constants into it. It is called when the table size changes, font changes, or the displayed data type changes. 

Update() now updates address values and calls other update functions. Ideally it would only be called when addresses change (scroll, setting a different target address, etc) and after CreateTable(). Cleaning up update logic can be done in another PR, as it depends on MemoryWidget.

UpdateColumns() could be renamed to UpdateDataColumnValues() because it's for updating displayed memory values. This function is smaller than before, which is useful for future PRs. Many constants being re-created were moved. The address is now pulled from previous calculated and updated addresses.  It also seemed easier to move the switch section to a new function, because it didn't need to share as much as before.

MISC_COLUMNS is a new constexpr which was being used in many places. It may change in the future, so good to keep track of it.

constexpr auto USER_ROLE_IS_ROW_BREAKPOINT_CELL = Qt::UserRole; -- Feels a bit overkill.  It's synonymous with item->column() == 0; But I didn't change it. It could be constexpr int BREAKPOINT_COLUMN = 0;  then column() == BREAKPOINT_COLUMN so it wouldn't need to be set on every item.