### PR TITLE
HW: Move DSP variables to Core::System.

### DIFF
--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Common/CommonTypes.h"
 
 class PointerWrap;
@@ -14,6 +16,23 @@ class Mapping;
 
 namespace DSP
 {
+class DSPState
+{
+public:
+  DSPState();
+  DSPState(const DSPState&) = delete;
+  DSPState(DSPState&&) = delete;
+  DSPState& operator=(const DSPState&) = delete;
+  DSPState& operator=(DSPState&&) = delete;
+  ~DSPState();
+
+  struct Data;
+  Data& GetData() { return *m_data; }
+
+private:
+  std::unique_ptr<Data> m_data;
+};
+
 enum DSPInterruptType
 {
   INT_DSP = 0x80,

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -8,6 +8,7 @@
 #include "AudioCommon/SoundStream.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/HW/AudioInterface.h"
+#include "Core/HW/DSP.h"
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/DVD/DVDThread.h"
 #include "Core/HW/Sram.h"
@@ -21,6 +22,7 @@ struct System::Impl
   bool m_audio_dump_started = false;
 
   AudioInterface::AudioInterfaceState m_audio_interface_state;
+  DSP::DSPState m_dsp_state;
   DVDInterface::DVDInterfaceState m_dvd_interface_state;
   DVDThread::DVDThreadState m_dvd_thread_state;
   Sram m_sram;
@@ -72,6 +74,11 @@ void System::SetAudioDumpStarted(bool started)
 AudioInterface::AudioInterfaceState& System::GetAudioInterfaceState() const
 {
   return m_impl->m_audio_interface_state;
+}
+
+DSP::DSPState& System::GetDSPState() const
+{
+  return m_impl->m_dsp_state;
 }
 
 DVDInterface::DVDInterfaceState& System::GetDVDInterfaceState() const

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -12,6 +12,10 @@ namespace AudioInterface
 {
 class AudioInterfaceState;
 };
+namespace DSP
+{
+class DSPState;
+}
 namespace DVDInterface
 {
 class DVDInterfaceState;
@@ -56,6 +60,7 @@ public:
   void SetAudioDumpStarted(bool started);
 
   AudioInterface::AudioInterfaceState& GetAudioInterfaceState() const;
+  DSP::DSPState& GetDSPState() const;
   DVDInterface::DVDInterfaceState& GetDVDInterfaceState() const;
   DVDThread::DVDThreadState& GetDVDThreadState() const;
   Sram& GetSRAM() const;


### PR DESCRIPTION
I also tried to make the variables actually fit our current coding style guidelines while I was here.

(this file needs a bit more naming cleanup in general though, why the heck is there both a `ARAMInfo` and a `ARAM_Info` struct that have different stuff)