### PR TITLE
Common/PointerWrap: Remove DoPOD

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -257,12 +257,6 @@ public:
     DoVoid((void*)&x, sizeof(x));
   }
 
-  template <typename T>
-  void DoPOD(T& x)
-  {
-    DoVoid((void*)&x, sizeof(x));
-  }
-
   void Do(bool& x)
   {
     // bool's size can vary depending on platform, which can

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -138,8 +138,8 @@ void DoState(PointerWrap& p)
   auto& system = Core::System::GetInstance();
   auto& state = system.GetAudioInterfaceState().GetData();
 
-  p.DoPOD(state.control);
-  p.DoPOD(state.volume);
+  p.Do(state.control);
+  p.Do(state.volume);
   p.Do(state.sample_counter);
   p.Do(state.interrupt_timing);
   p.Do(state.last_cpu_time);

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -164,9 +164,9 @@ void DoState(PointerWrap& p)
 
   if (!state.aram.wii_mode)
     p.DoArray(state.aram.ptr, state.aram.size);
-  p.DoPOD(state.dsp_control);
-  p.DoPOD(state.audio_dma);
-  p.DoPOD(state.aram_dma);
+  p.Do(state.dsp_control);
+  p.Do(state.audio_dma);
+  p.Do(state.aram_dma);
   p.Do(state.aram_info);
   p.Do(state.aram_mode);
   p.Do(state.aram_refresh);

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -105,9 +105,9 @@ void DSPHLE::DoState(PointerWrap& p)
     return;
   }
 
-  p.DoPOD(m_dsp_control);
+  p.Do(m_dsp_control);
   p.Do(m_control_reg_init_code_clear_time);
-  p.DoPOD(m_dsp_state);
+  p.Do(m_dsp_state);
 
   int ucode_crc = UCodeInterface::GetCRC(m_ucode.get());
   int ucode_crc_before_load = ucode_crc;

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -211,14 +211,14 @@ void DoState(PointerWrap& p)
 {
   auto& state = Core::System::GetInstance().GetDVDInterfaceState().GetData();
 
-  p.DoPOD(state.DISR);
-  p.DoPOD(state.DICVR);
+  p.Do(state.DISR);
+  p.Do(state.DICVR);
   p.DoArray(state.DICMDBUF);
   p.Do(state.DIMAR);
   p.Do(state.DILENGTH);
   p.Do(state.DICR);
   p.Do(state.DIIMMBUF);
-  p.DoPOD(state.DICFG);
+  p.Do(state.DICFG);
 
   p.Do(state.stream);
   p.Do(state.stop_at_track_end);

--- a/Source/Core/Core/HW/EXI/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.cpp
@@ -233,14 +233,14 @@ IEXIDevice* CEXIChannel::GetDevice(const u8 chip_select)
 
 void CEXIChannel::DoState(PointerWrap& p)
 {
-  p.DoPOD(m_status);
+  p.Do(m_status);
   p.Do(m_dma_memory_address);
   p.Do(m_dma_length);
   p.Do(m_control);
   p.Do(m_imm_data);
 
   Memcard::HeaderData old_header_data = m_memcard_header_data;
-  p.DoPOD(m_memcard_header_data);
+  p.Do(m_memcard_header_data);
 
   for (int device_index = 0; device_index < NUM_DEVICES; ++device_index)
   {

--- a/Source/Core/Core/HW/GCMemcard/GCIFile.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCIFile.cpp
@@ -87,7 +87,7 @@ int GCIFile::UsesBlock(u16 block_num)
 
 void GCIFile::DoState(PointerWrap& p)
 {
-  p.DoPOD<DEntry>(m_gci_header);
+  p.Do(m_gci_header);
   p.Do(m_dirty);
   p.Do(m_filename);
   int num_blocks = (int)m_save_data.size();
@@ -95,7 +95,7 @@ void GCIFile::DoState(PointerWrap& p)
   m_save_data.resize(num_blocks);
   for (auto itr = m_save_data.begin(); itr != m_save_data.end(); ++itr)
   {
-    p.DoPOD<GCMBlock>(*itr);
+    p.Do(*itr);
   }
   p.Do(m_used_blocks);
 }

--- a/Source/Core/Core/HW/GCMemcard/GCIFile.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCIFile.cpp
@@ -90,13 +90,7 @@ void GCIFile::DoState(PointerWrap& p)
   p.Do(m_gci_header);
   p.Do(m_dirty);
   p.Do(m_filename);
-  int num_blocks = (int)m_save_data.size();
-  p.Do(num_blocks);
-  m_save_data.resize(num_blocks);
-  for (auto itr = m_save_data.begin(); itr != m_save_data.end(); ++itr)
-  {
-    p.Do(*itr);
-  }
+  p.Do(m_save_data);
   p.Do(m_used_blocks);
 }
 }  // namespace Memcard

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -701,13 +701,7 @@ void GCMemcardDirectory::DoState(PointerWrap& p)
   p.Do(m_dir2);
   p.Do(m_bat1);
   p.Do(m_bat2);
-  int num_saves = (int)m_saves.size();
-  p.Do(num_saves);
-  m_saves.resize(num_saves);
-  for (Memcard::GCIFile& save : m_saves)
-  {
-    save.DoState(p);
-  }
+  p.DoEachElement(m_saves, [](PointerWrap& p, Memcard::GCIFile& save) { save.DoState(p); });
 }
 
 void MigrateFromMemcardFile(const std::string& directory_name, ExpansionInterface::Slot card_slot,

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -696,11 +696,11 @@ void GCMemcardDirectory::DoState(PointerWrap& p)
   m_last_block = -1;
   m_last_block_address = nullptr;
   p.Do(m_save_directory);
-  p.DoPOD<Memcard::Header>(m_hdr);
-  p.DoPOD<Memcard::Directory>(m_dir1);
-  p.DoPOD<Memcard::Directory>(m_dir2);
-  p.DoPOD<Memcard::BlockAlloc>(m_bat1);
-  p.DoPOD<Memcard::BlockAlloc>(m_bat2);
+  p.Do(m_hdr);
+  p.Do(m_dir1);
+  p.Do(m_dir2);
+  p.Do(m_bat1);
+  p.Do(m_bat2);
   int num_saves = (int)m_saves.size();
   p.Do(num_saves);
   m_saves.resize(num_saves);

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -351,8 +351,8 @@ void DoState(PointerWrap& p)
   }
 
   p.Do(s_poll);
-  p.DoPOD(s_com_csr);
-  p.DoPOD(s_status_reg);
+  p.Do(s_com_csr);
+  p.Do(s_status_reg);
   p.Do(s_exi_clock_count);
   p.Do(s_si_buffer);
 }

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -93,8 +93,8 @@ static constexpr u32 NUM_HALF_LINES_FOR_SI_POLL = (7 * 2) + 1;  // this is how l
 void DoState(PointerWrap& p)
 {
   auto& state = Core::System::GetInstance().GetVideoInterfaceState().GetData();
-  p.DoPOD(state.vertical_timing_register);
-  p.DoPOD(state.display_control_register);
+  p.Do(state.vertical_timing_register);
+  p.Do(state.display_control_register);
   p.Do(state.h_timing_0);
   p.Do(state.h_timing_1);
   p.Do(state.vblank_timing_odd);
@@ -108,7 +108,7 @@ void DoState(PointerWrap& p)
   p.DoArray(state.interrupt_register);
   p.DoArray(state.latch_register);
   p.Do(state.picture_configuration);
-  p.DoPOD(state.horizontal_scaling);
+  p.Do(state.horizontal_scaling);
   p.Do(state.filter_coef_tables);
   p.Do(state.unknown_aa_register);
   p.Do(state.clock);

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -118,7 +118,7 @@ void DoState(PointerWrap& p)
 {
   p.Do(ppc_msg);
   p.Do(arm_msg);
-  p.DoPOD(ctrl);
+  p.Do(ctrl);
   p.Do(ppc_irq_flags);
   p.Do(ppc_irq_masks);
   p.Do(arm_irq_flags);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -94,7 +94,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 149;  // Last changed in PR 10781
+constexpr u32 STATE_VERSION = 150;  // Last changed in PR 11124
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -107,9 +107,9 @@ void SCPFifoStruct::DoState(PointerWrap& p)
 
 void DoState(PointerWrap& p)
 {
-  p.DoPOD(m_CPStatusReg);
-  p.DoPOD(m_CPCtrlReg);
-  p.DoPOD(m_CPClearReg);
+  p.Do(m_CPStatusReg);
+  p.Do(m_CPCtrlReg);
+  p.Do(m_CPClearReg);
   p.Do(m_bboxleft);
   p.Do(m_bboxtop);
   p.Do(m_bboxright);

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -169,7 +169,7 @@ void DoState(PointerWrap& p)
   p.Do(m_DstAlphaConf);
   p.Do(m_AlphaModeConf);
   p.Do(m_AlphaRead);
-  p.DoPOD(m_Control);
+  p.Do(m_Control);
 
   p.Do(s_token);
   p.Do(s_token_pending);

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -440,7 +440,7 @@ void TextureCacheBase::SerializeTexture(AbstractTexture* tex, const TextureConfi
 {
   // If we're in measure mode, skip the actual readback to save some time.
   const bool skip_readback = p.IsMeasureMode();
-  p.DoPOD(config);
+  p.Do(config);
 
   if (skip_readback || CheckReadbackTexture(config.width, config.height, config.format))
   {


### PR DESCRIPTION
This was added in 385d8e2b15c8accce3b4e4b4f3dc90f63e3fbee4, but became somewhat redundant with Do in 4c7bbd96e435a7516b05d3e8c791ab41505e2e0f, and completely redundant now that `std::is_trivially_copyable_v` is well-supported.

