### PR TITLE
Added MemoryInterface variables to savestates

### DIFF
--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -19,6 +19,7 @@
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/HSP/HSP.h"
 #include "Core/HW/Memmap.h"
+#include "Core/HW/MemoryInterface.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/SystemTimers.h"
@@ -45,6 +46,7 @@ void Init(const Sram* override_sram)
   HSP::Init();
   Memory::Init();  // Needs to be initialized before AddressSpace
   AddressSpace::Init();
+  MemoryInterface::Init();
   DSP::Init(Config::Get(Config::MAIN_DSP_HLE));
   DVDInterface::Init();
   GPFifo::Init();
@@ -68,6 +70,7 @@ void Shutdown()
   CPU::Shutdown();
   DVDInterface::Shutdown();
   DSP::Shutdown();
+  MemoryInterface::Shutdown();
   AddressSpace::Shutdown();
   Memory::Shutdown();
   HSP::Shutdown();
@@ -83,6 +86,8 @@ void DoState(PointerWrap& p)
 {
   Memory::DoState(p);
   p.DoMarker("Memory");
+  MemoryInterface::DoState(p);
+  p.DoMarker("MemoryInterface");
   VideoInterface::DoState(p);
   p.DoMarker("VideoInterface");
   SerialInterface::DoState(p);

--- a/Source/Core/Core/HW/MemoryInterface.cpp
+++ b/Source/Core/Core/HW/MemoryInterface.cpp
@@ -4,6 +4,8 @@
 #include "Core/HW/MemoryInterface.h"
 
 #include <array>
+#include <cstring>
+#include <type_traits>
 
 #include "Common/BitField.h"
 #include "Common/ChunkFile.h"
@@ -134,6 +136,17 @@ struct MIMemStruct
 
 // STATE_TO_SAVE
 static MIMemStruct g_mi_mem;
+
+void Init()
+{
+  static_assert(std::is_trivially_copyable_v<MIMemStruct>);
+  std::memset(&g_mi_mem, 0, sizeof(MIMemStruct));
+}
+
+void Shutdown()
+{
+  Init();
+}
 
 void DoState(PointerWrap& p)
 {

--- a/Source/Core/Core/HW/MemoryInterface.h
+++ b/Source/Core/Core/HW/MemoryInterface.h
@@ -13,7 +13,9 @@ class PointerWrap;
 
 namespace MemoryInterface
 {
-void DoState(PointerWrap& p);
+void Init();
+void Shutdown();
 
+void DoState(PointerWrap& p);
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 }  // namespace MemoryInterface

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -94,7 +94,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 150;  // Last changed in PR 11124
+constexpr u32 STATE_VERSION = 151;  // Last changed in PR 11125
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This PR adds MemoryInterface variables to save states. Hopefully, this will reduce the frequency of desyncs in Dolphin - although it remains to be seen what effect this will have.