### PR TITLE
JitAsm64: Reorder instructions in routines to allow macro-op fusion

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -314,7 +314,7 @@ void JitArm64::GenerateFrsqrte()
   LSR(ARM64Reg::X2, ARM64Reg::X2, 48);
   AND(ARM64Reg::X2, ARM64Reg::X2, LogicalImm(0x10, 64));
   MOVP2R(ARM64Reg::X1, &Common::frsqrte_expected);
-  ORR(ARM64Reg::X2, ARM64Reg::X2, ARM64Reg::X3, ArithOption(ARM64Reg::X8, ShiftType::LSR, 48));
+  ORR(ARM64Reg::X2, ARM64Reg::X2, ARM64Reg::X3, ArithOption(ARM64Reg::X3, ShiftType::LSR, 48));
   EOR(ARM64Reg::X2, ARM64Reg::X2, LogicalImm(0x10, 64));
   ADD(ARM64Reg::X2, ARM64Reg::X1, ARM64Reg::X2, ArithOption(ARM64Reg::X2, ShiftType::LSL, 3));
   LDP(IndexType::Signed, ARM64Reg::W1, ARM64Reg::W2, ARM64Reg::X2, 0);


### PR DESCRIPTION
Micro-optimization. Some CPUs can fuse CMP+B, TST+B, arith+CBZ, etc.

I also moved things around for CMP+CSET and TST+CSET – which I'm not sure if any CPUs support – but it doesn't hurt anything, so I might as well.