### PR TITLE
Update and Re-License BitUtils.h

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -34,6 +34,7 @@ BraceWrapping:
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false
+BreakBeforeConceptDeclarations: true
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit:     100
 CommentPragmas:  '^ (IWYU pragma:|NOLINT)'

--- a/Source/Core/Common/Align.h
+++ b/Source/Core/Common/Align.h
@@ -3,21 +3,20 @@
 #pragma once
 
 #include <cstddef>
-#include <type_traits>
+
+#include "Common/Future/CppLibConcepts.h"
 
 namespace Common
 {
-template <typename T>
+template <std::unsigned_integral T>
 constexpr T AlignUp(T value, size_t size)
 {
-  static_assert(std::is_unsigned<T>(), "T must be an unsigned value.");
   return static_cast<T>(value + (size - value % size) % size);
 }
 
-template <typename T>
+template <std::unsigned_integral T>
 constexpr T AlignDown(T value, size_t size)
 {
-  static_assert(std::is_unsigned<T>(), "T must be an unsigned value.");
   return static_cast<T>(value - value % size);
 }
 

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -3786,7 +3786,7 @@ void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
       ASSERT_MSG(DYNA_REC, tmp == 0xFF || tmp == 0, "size64 Invalid immediate! ({} -> {})", imm,
                  tmp);
       if (tmp == 0xFF)
-        abcdefgh |= (1 << i);
+        Common::SetBit(i, abcdefgh);
     }
   }
   EncodeModImm(Q, op, cmode, 0, Rd, abcdefgh);

--- a/Source/Core/Common/BitSet.h
+++ b/Source/Core/Common/BitSet.h
@@ -5,8 +5,8 @@
 #include <bit>
 #include <cstddef>
 #include <initializer_list>
-#include <type_traits>
 
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 
 #include "Common/Future/CppLibConcepts.h"
@@ -73,7 +73,7 @@ public:
       else
       {
         int bit = std::countr_zero(m_val);
-        m_val &= ~(1 << bit);
+        ClearBit(bit, m_val);
         m_bit = bit;
       }
       return *this;
@@ -98,7 +98,7 @@ public:
   constexpr BitSet(std::initializer_list<int> init)
   {
     for (int bit : init)
-      m_val |= (IntTy)1 << bit;
+      SetBit(bit, m_val);
   }
 
   constexpr static BitSet AllTrue(size_t count)

--- a/Source/Core/Common/BitSet.h
+++ b/Source/Core/Common/BitSet.h
@@ -9,6 +9,8 @@
 
 #include "Common/CommonTypes.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace Common
 {
 // Similar to std::bitset, this is a class which encapsulates a bitset, i.e.
@@ -29,11 +31,9 @@ namespace Common
 //   operation.)
 // - Counting set bits using .Count() - see comment on that method.
 
-template <typename IntTy>
+template <std::unsigned_integral IntTy>
 class BitSet
 {
-  static_assert(!std::is_signed<IntTy>::value, "BitSet should not be used with signed types");
-
 public:
   // A reference to a particular bit, returned from operator[].
   class Ref

--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -405,6 +405,34 @@ inline auto BitCastFromArray(const Container& array) noexcept -> T
   return obj;
 }
 
+template <std::integral T>
+constexpr void SetBit(const size_t start, T& host)
+{
+  DEBUG_ASSERT(start < BitSize<T>());  // Bit out of range
+  host |= (T{1} << start);
+}
+
+template <size_t start, std::integral T>
+constexpr void SetBit(T& host)
+{
+  static_assert(start < BitSize<T>(), "Bit out of range");
+  SetBit(start, host);
+}
+
+template <std::integral T>
+constexpr void ClearBit(const size_t start, T& host)
+{
+  DEBUG_ASSERT(start < BitSize<T>());  // Bit out of range
+  host &= ~(T{1} << start);
+}
+
+template <size_t start, std::integral T>
+constexpr void ClearBit(T& host)
+{
+  static_assert(start < BitSize<T>(), "Bit out of range");
+  ClearBit(start, host);
+}
+
 template <typename T>
 class FlagBit
 {

--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -11,6 +11,10 @@
 #include <initializer_list>
 #include <type_traits>
 
+#include "Common/Concepts.h"
+
+#include "Common/Future/CppLibConcepts.h"
+
 namespace Common
 {
 ///
@@ -113,11 +117,10 @@ constexpr Result ExtractBits(const T src) noexcept
 ///
 /// @return A bool indicating whether the mask is valid.
 ///
-template <typename T>
+template <std::unsigned_integral T>
 constexpr bool IsValidLowMask(const T mask) noexcept
 {
-  static_assert(std::is_integral<T>::value, "Mask must be an integral type.");
-  static_assert(std::is_unsigned<T>::value, "Signed masks can introduce hard to find bugs.");
+  // Signed masks can introduce hard to find bugs.
 
   // Can be efficiently determined without looping or bit counting. It's the counterpart
   // to https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
@@ -143,38 +146,28 @@ constexpr bool IsValidLowMask(const T mask) noexcept
 /// @pre Both To and From types must be the same size
 /// @pre Both To and From types must satisfy the TriviallyCopyable concept.
 ///
-template <typename To, typename From>
+template <TriviallyCopyable To, TriviallyCopyable From>
 inline To BitCast(const From& source) noexcept
 {
   static_assert(sizeof(From) == sizeof(To),
                 "BitCast source and destination types must be equal in size.");
-  static_assert(std::is_trivially_copyable<From>(),
-                "BitCast source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<To>(),
-                "BitCast destination type must be trivially copyable.");
 
   alignas(To) std::byte storage[sizeof(To)];
   std::memcpy(&storage, &source, sizeof(storage));
   return reinterpret_cast<To&>(storage);
 }
 
-template <typename T, typename PtrType>
+template <TriviallyCopyable T, TriviallyCopyable PtrType>
 class BitCastPtrType
 {
 public:
-  static_assert(std::is_trivially_copyable<PtrType>(),
-                "BitCastPtr source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastPtr destination type must be trivially copyable.");
-
   explicit BitCastPtrType(PtrType* ptr) : m_ptr(ptr) {}
 
   // Enable operator= only for pointers to non-const data
-  template <typename S>
-  inline typename std::enable_if<std::is_same<S, T>() && !std::is_const<PtrType>()>::type
-  operator=(const S& source)
+  inline BitCastPtrType& operator=(const T& source) requires NotConst<PtrType>
   {
     std::memcpy(m_ptr, &source, sizeof(source));
+    return *this;
   }
 
   inline operator T() const
@@ -199,46 +192,34 @@ inline auto BitCastPtr(PtrType* ptr) noexcept -> BitCastPtrType<T, PtrType>
 }
 
 // Similar to BitCastPtr, but specifically for aliasing structs to arrays.
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
+template <typename ArrayType, TriviallyCopyable T,
+          TriviallyCopyable Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
 inline auto BitCastToArray(const T& obj) noexcept -> Container
 {
   static_assert(sizeof(T) % sizeof(ArrayType) == 0,
                 "Size of array type must be a factor of size of source type.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastToArray source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastToArray array type must be trivially copyable.");
 
   Container result;
   std::memcpy(result.data(), &obj, sizeof(T));
   return result;
 }
 
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
+template <typename ArrayType, TriviallyCopyable T,
+          TriviallyCopyable Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
 inline void BitCastFromArray(const Container& array, T& obj) noexcept
 {
   static_assert(sizeof(T) % sizeof(ArrayType) == 0,
                 "Size of array type must be a factor of size of destination type.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastFromArray array type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastFromArray destination type must be trivially copyable.");
 
   std::memcpy(&obj, array.data(), sizeof(T));
 }
 
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
+template <typename ArrayType, TriviallyCopyable T,
+          TriviallyCopyable Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
 inline auto BitCastFromArray(const Container& array) noexcept -> T
 {
   static_assert(sizeof(T) % sizeof(ArrayType) == 0,
                 "Size of array type must be a factor of size of destination type.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastFromArray array type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastFromArray destination type must be trivially copyable.");
 
   T obj;
   std::memcpy(&obj, array.data(), sizeof(T));
@@ -304,11 +285,9 @@ public:
 
 // Left-shift a value and set new LSBs to that of the supplied LSB.
 // Converts a value from a N-bit range to an (N+X)-bit range. e.g. 0x101 -> 0x10111
-template <typename T>
+template <std::unsigned_integral T>
 T ExpandValue(T value, size_t left_shift_amount)
 {
-  static_assert(std::is_unsigned<T>(), "ExpandValue is only sane on unsigned types.");
-
   return (value << left_shift_amount) |
          (T(-ExtractBit<0>(value)) >> (BitSize<T>() - left_shift_amount));
 }

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(common
   CommonFuncs.h
   CommonPaths.h
   CommonTypes.h
+  Concepts.h
   Config/Config.cpp
   Config/Config.h
   Config/ConfigInfo.cpp
@@ -58,6 +59,7 @@ add_library(common
   FloatUtils.h
   FormatUtil.h
   FPURoundMode.h
+  Future/CppLibConcepts.h
   GekkoDisassembler.cpp
   GekkoDisassembler.h
   Hash.cpp

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -21,7 +21,6 @@
 #include <optional>
 #include <set>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -29,6 +28,7 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/EnumMap.h"
 #include "Common/Flag.h"
 #include "Common/Inline.h"
@@ -195,13 +195,13 @@ public:
     DoArray(x.data(), static_cast<u32>(x.size()));
   }
 
-  template <typename T, typename std::enable_if_t<std::is_trivially_copyable_v<T>, int> = 0>
+  template <Common::TriviallyCopyable T>
   void DoArray(T* x, u32 count)
   {
     DoVoid(x, count * sizeof(T));
   }
 
-  template <typename T, typename std::enable_if_t<!std::is_trivially_copyable_v<T>, int> = 0>
+  template <Common::NotTriviallyCopyable T>
   void DoArray(T* x, u32 count)
   {
     for (u32 i = 0; i < count; ++i)
@@ -262,10 +262,9 @@ public:
       atomic.store(temp, std::memory_order_relaxed);
   }
 
-  template <typename T>
+  template <Common::TriviallyCopyable T>
   void Do(T& x)
   {
-    static_assert(std::is_trivially_copyable_v<T>, "Only sane for trivially copyable types");
     // Note:
     // Usually we can just use x = **ptr, etc.  However, this doesn't work
     // for unions containing BitFields (long story, stupid language rules)

--- a/Source/Core/Common/Concepts.h
+++ b/Source/Core/Common/Concepts.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: CC0-1.0
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "Common/TypeUtils.h"
+
+#include "Common/Future/CppLibConcepts.h"
+
+namespace Common
+{
+template <class T>
+concept TriviallyCopyable = std::is_trivially_copyable<T>::value;
+
+template <class T>
+concept NotTriviallyCopyable = !TriviallyCopyable<T>;
+
+template <class T>
+concept Const = std::is_const<T>::value;
+
+template <class T>
+concept NotConst = !Const<T>;
+
+template <class T>
+concept Enumerated = std::is_enum<T>::value;
+
+template <class T>
+concept NotEnumerated = !Enumerated<T>;
+
+template <class T>
+concept Class = std::is_class<T>::value;
+
+template <class T>
+concept Union = std::is_union<T>::value;
+
+template <class T>
+concept Arithmetic = std::is_arithmetic<T>::value;
+
+template <class T>
+concept Pointer = std::is_pointer<T>::value;
+
+template <class T>
+concept Function = std::is_function<T>::value;
+
+template <class T>
+concept FunctionPointer = Function<std::remove_pointer_t<T>>;
+
+template <class T>
+concept IntegralOrEnum = std::integral<T> || Enumerated<T>;
+
+template <class T, class U>
+concept UnderlyingSameAs = std::same_as<std::underlying_type_t<T>, U>;
+
+template <class T, class U>
+concept SameAsOrUnderlyingSameAs = std::same_as<T, U> || UnderlyingSameAs<T, U>;
+
+template <size_t N, class... Ts>
+concept CountOfTypes = IsCountOfTypes<N, Ts...>::value;
+
+template <class T, class... Ts>
+concept ConvertibleFromAllOf = IsConvertibleFromAllOf<T, Ts...>::value;
+
+template <class T, class... Ts>
+concept SameAsAnyOf = IsSameAsAnyOf<T, Ts...>::value;
+};  // namespace Common

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -10,17 +10,11 @@
 #include <utility>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Config/Enums.h"
 
 namespace Config
 {
-namespace detail
-{
-// std::underlying_type may only be used with enum types, so make sure T is an enum type first.
-template <typename T>
-using UnderlyingType = typename std::enable_if_t<std::is_enum<T>{}, std::underlying_type<T>>::type;
-}  // namespace detail
-
 struct Location
 {
   System system{};
@@ -55,12 +49,8 @@ public:
 
   // Make it easy to convert Info<Enum> into Info<UnderlyingType<Enum>>
   // so that enum settings can still easily work with code that doesn't care about the enum values.
-  template <typename Enum,
-            std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
-  Info(const Info<Enum>& other)
-  {
-    *this = other;
-  }
+  template <Common::Enumerated Enum>
+  requires Common::UnderlyingSameAs<Enum, T> Info(const Info<Enum>& other) { *this = other; }
 
   Info<T>& operator=(const Info<T>& other)
   {
@@ -81,9 +71,9 @@ public:
 
   // Make it easy to convert Info<Enum> into Info<UnderlyingType<Enum>>
   // so that enum settings can still easily work with code that doesn't care about the enum values.
-  template <typename Enum,
-            std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
-  Info<T>& operator=(const Info<Enum>& other)
+  template <Common::Enumerated Enum>
+  requires Common::UnderlyingSameAs<Enum, T> Info<T>
+  &operator=(const Info<Enum>& other)
   {
     m_location = other.GetLocation();
     m_default_value = static_cast<T>(other.GetDefaultValue());

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "Common/Concepts.h"
 #include "Common/Config/ConfigInfo.h"
 #include "Common/Config/Enums.h"
 #include "Common/StringUtil.h"
@@ -18,7 +19,7 @@ namespace Config
 {
 namespace detail
 {
-template <typename T, std::enable_if_t<!std::is_enum<T>::value>* = nullptr>
+template <Common::NotEnumerated T>
 std::optional<T> TryParse(const std::string& str_value)
 {
   T value;
@@ -27,7 +28,7 @@ std::optional<T> TryParse(const std::string& str_value)
   return value;
 }
 
-template <typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+template <Common::Enumerated T>
 std::optional<T> TryParse(const std::string& str_value)
 {
   const auto result = TryParse<std::underlying_type_t<T>>(str_value);

--- a/Source/Core/Common/Crypto/SHA1.h
+++ b/Source/Core/Common/Crypto/SHA1.h
@@ -7,11 +7,11 @@
 #include <limits>
 #include <memory>
 #include <string_view>
-#include <type_traits>
 #include <vector>
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 
 namespace Common::SHA1
 {
@@ -32,10 +32,9 @@ std::unique_ptr<Context> CreateContext();
 
 Digest CalculateDigest(const u8* msg, size_t len);
 
-template <typename T>
+template <TriviallyCopyable T>
 inline Digest CalculateDigest(const std::vector<T>& msg)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   ASSERT(std::numeric_limits<size_t>::max() / sizeof(T) >= msg.size());
   return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), sizeof(T) * msg.size());
 }
@@ -45,10 +44,9 @@ inline Digest CalculateDigest(const std::string_view& msg)
   return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), msg.size());
 }
 
-template <typename T, size_t Size>
+template <TriviallyCopyable T, size_t Size>
 inline Digest CalculateDigest(const std::array<T, Size>& msg)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), sizeof(msg));
 }
 }  // namespace Common::SHA1

--- a/Source/Core/Common/EnumMap.h
+++ b/Source/Core/Common/EnumMap.h
@@ -6,7 +6,7 @@
 #include <array>
 #include <type_traits>
 
-#include "Common/TypeUtils.h"
+#include "Common/Concepts.h"
 
 template <std::size_t position, std::size_t bits, typename T, typename StorageType>
 struct BitField;
@@ -36,11 +36,9 @@ public:
   constexpr EnumMap(EnumMap&& other) = default;
   constexpr EnumMap& operator=(EnumMap&& other) = default;
 
-  // Constructor that accepts exactly size Vs (enforcing that all must be specified).
-  template <typename... T, typename = std::enable_if_t<Common::IsNOf<V, s_size, T...>::value>>
-  constexpr EnumMap(T... values) : m_array{static_cast<V>(values)...}
-  {
-  }
+  template <typename... Ts>
+  requires CountOfTypes<s_size, Ts...> && ConvertibleFromAllOf<V, Ts...>
+  constexpr EnumMap(Ts... values) : m_array{static_cast<V>(values)...} {}
 
   constexpr const V& operator[](T key) const { return m_array[static_cast<std::size_t>(key)]; }
   constexpr V& operator[](T key) { return m_array[static_cast<std::size_t>(key)]; }

--- a/Source/Core/Common/FormatUtil.h
+++ b/Source/Core/Common/FormatUtil.h
@@ -8,6 +8,13 @@
 
 namespace Common
 {
+template <class T>
+#if FMT_VERSION >= 90000
+concept FmtCompileString = fmt::detail::is_compile_string<T>::value;
+#else
+concept FmtCompileString = fmt::is_compile_string<T>::value;
+#endif
+
 constexpr std::size_t CountFmtReplacementFields(std::string_view s)
 {
   std::size_t count = 0;

--- a/Source/Core/Common/Future/CppLibConcepts.h
+++ b/Source/Core/Common/Future/CppLibConcepts.h
@@ -1,0 +1,40 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <version>
+
+// C++20 Standard Library support in the Android NDK is lacking.  However, the core language feature
+// of concepts works fine in all environments Dolphin Emulator currently supports.  Please replace
+// the usage of this header with the C++ Standard Library equivalent as soon as is possible.
+
+#ifdef __cpp_lib_concepts
+#include <concepts>
+#else
+#include <type_traits>
+namespace std
+{
+// Technically inaccurate because we haven't defined *all* of the standard concepts
+#define __cpp_lib_concepts 202002L
+
+template <class T, class U>
+concept same_as = std::is_same_v<T, U> && std::is_same_v<U, T>;
+
+template <class T>
+concept integral = std::is_integral_v<T>;
+
+template <class T>
+concept signed_integral = integral<T> && std::is_signed_v<T>;
+
+template <class T>
+concept unsigned_integral = integral<T> && std::is_unsigned_v<T>;
+
+template <class T>
+concept floating_point = std::is_floating_point_v<T>;
+
+template <class Derived, class Base>
+concept derived_from = std::is_base_of_v<Base, Derived> &&
+    std::is_convertible_v<const volatile Derived*, const volatile Base*>;
+};  // namespace std
+#endif

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -7,9 +7,9 @@
 #include <cstring>
 #include <memory>
 #include <string>
-#include <type_traits>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/IOFile.h"
 #include "Common/Version.h"
 
@@ -27,7 +27,7 @@
 // value_type[value_size]   value;
 //}
 
-template <typename K, typename V>
+template <Common::TriviallyCopyable K, typename V>
 class LinearDiskCacheReader
 {
 public:
@@ -46,17 +46,14 @@ public:
 // K and V are some POD type
 // K : the key type
 // V : value array type
-template <typename K, typename V>
+// Since we're reading/writing directly to the storage of K instances, K must be trivially copyable.
+template <Common::TriviallyCopyable K, typename V>
 class LinearDiskCache
 {
 public:
   // return number of read entries
   u32 OpenAndRead(const std::string& filename, LinearDiskCacheReader<K, V>& reader)
   {
-    // Since we're reading/writing directly to the storage of K instances,
-    // K must be trivially copyable.
-    static_assert(std::is_trivially_copyable<K>::value, "K must be a trivially copyable type");
-
     // close any currently opened file
     Close();
     m_num_entries = 0;

--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -91,7 +91,7 @@ static const char LOG_LEVEL_TO_CHAR[7] = "-NEWID";
 void GenericLogFmtImpl(LogLevel level, LogType type, const char* file, int line,
                        fmt::string_view format, const fmt::format_args& args);
 
-template <std::size_t NumFields, typename S, typename... Args>
+template <std::size_t NumFields, FmtCompileString S, typename... Args>
 void GenericLogFmt(LogLevel level, LogType type, const char* file, int line, const S& format,
                    const Args&... args)
 {

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -12,6 +12,8 @@
 
 #include "Common/CommonTypes.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace MathUtil
 {
 constexpr double TAU = 6.2831853071795865;
@@ -32,11 +34,9 @@ constexpr auto Lerp(const T& x, const T& y, const F& a) -> decltype(x + (y - x) 
 
 // Casts the specified value to a Dest. The value will be clamped to fit in the destination type.
 // Warning: The result of SaturatingCast(NaN) is undefined.
-template <typename Dest, typename T>
+template <std::integral Dest, typename T>
 constexpr Dest SaturatingCast(T value)
 {
-  static_assert(std::is_integral<Dest>());
-
   [[maybe_unused]] constexpr Dest lo = std::numeric_limits<Dest>::lowest();
   constexpr Dest hi = std::numeric_limits<Dest>::max();
 

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -34,23 +34,18 @@ void RegisterStringTranslator(StringTranslator translator);
 bool MsgAlertFmtImpl(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                      int line, fmt::string_view format, const fmt::format_args& args);
 
-template <std::size_t NumFields, typename S, typename... Args>
+template <std::size_t NumFields, FmtCompileString S, typename... Args>
 bool MsgAlertFmt(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                  int line, const S& format, const Args&... args)
 {
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
-  static_assert(fmt::detail::is_compile_string<S>::value);
-#else
-  static_assert(fmt::is_compile_string<S>::value);
-#endif
   return MsgAlertFmtImpl(yes_no, style, log_type, file, line, format,
                          fmt::make_format_args(args...));
 }
 
-template <std::size_t NumFields, bool has_non_positional_args, typename S, typename... Args>
+template <std::size_t NumFields, bool has_non_positional_args, FmtCompileString S, typename... Args>
 bool MsgAlertFmtT(bool yes_no, MsgType style, Common::Log::LogType log_type, const char* file,
                   int line, const S& format, fmt::string_view translated_format,
                   const Args&... args)
@@ -60,11 +55,6 @@ bool MsgAlertFmtT(bool yes_no, MsgType style, Common::Log::LogType log_type, con
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
-  static_assert(fmt::detail::is_compile_string<S>::value);
-#else
-  static_assert(fmt::is_compile_string<S>::value);
-#endif
   auto arg_list = fmt::make_format_args(args...);
   return MsgAlertFmtImpl(yes_no, style, log_type, file, line, translated_format, arg_list);
 }

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 
 #include "Common/BitUtils.h"
+#include "Common/Concepts.h"
 #include "Common/Random.h"
 #include "Common/StringUtil.h"
 
@@ -315,10 +316,9 @@ u16 ComputeTCPNetworkChecksum(const IPAddress& from, const IPAddress& to, const 
   return htons(static_cast<u16>(tcp_checksum));
 }
 
-template <typename Container, typename T>
+template <typename Container, Common::TriviallyCopyable T>
 static inline void InsertObj(Container* container, const T& obj)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   const u8* const ptr = reinterpret_cast<const u8*>(&obj);
   container->insert(container->end(), ptr, ptr + sizeof(obj));
 }

--- a/Source/Core/Common/Random.h
+++ b/Source/Core/Common/Random.h
@@ -5,9 +5,9 @@
 
 #include <cstddef>
 #include <memory>
-#include <type_traits>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 
 namespace Common::Random
 {
@@ -15,10 +15,9 @@ namespace Common::Random
 void Generate(void* buffer, std::size_t size);
 
 /// Generates a random value of arithmetic type `T`
-template <typename T>
+template <Arithmetic T>
 T GenerateValue()
 {
-  static_assert(std::is_arithmetic<T>(), "T must be an arithmetic type in GenerateValue.");
   T value;
   Generate(&value, sizeof(value));
   return value;

--- a/Source/Core/Common/SFMLHelper.h
+++ b/Source/Core/Common/SFMLHelper.h
@@ -8,13 +8,14 @@
 #include <SFML/Network/Packet.hpp>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Swap.h"
 
 sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u16>& data);
 sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u32>& data);
 sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u64>& data);
 
-template <typename Enum, std::enable_if_t<std::is_enum_v<Enum>>* = nullptr>
+template <Common::Enumerated Enum>
 sf::Packet& operator<<(sf::Packet& packet, Enum e)
 {
   using Underlying = std::underlying_type_t<Enum>;
@@ -22,7 +23,7 @@ sf::Packet& operator<<(sf::Packet& packet, Enum e)
   return packet;
 }
 
-template <typename Enum, std::enable_if_t<std::is_enum_v<Enum>>* = nullptr>
+template <Common::Enumerated Enum>
 sf::Packet& operator>>(sf::Packet& packet, Enum& e)
 {
   using Underlying = std::underlying_type_t<Enum>;

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -16,6 +16,9 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
+
+#include "Common/Future/CppLibConcepts.h"
 
 std::string StringFromFormatV(const char* format, va_list args);
 
@@ -54,7 +57,7 @@ void TruncateToCString(std::string* s);
 
 bool TryParse(const std::string& str, bool* output);
 
-template <typename T, std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>* = nullptr>
+template <Common::IntegralOrEnum T>
 bool TryParse(const std::string& str, T* output, int base = 0)
 {
   char* end_ptr = nullptr;
@@ -92,7 +95,7 @@ bool TryParse(const std::string& str, T* output, int base = 0)
   return true;
 }
 
-template <typename T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
+template <std::floating_point T>
 bool TryParse(std::string str, T* const output)
 {
   // Replace commas with dots.
@@ -138,7 +141,7 @@ std::string ValueToString(double value);
 std::string ValueToString(int value);
 std::string ValueToString(s64 value);
 std::string ValueToString(bool value);
-template <typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+template <Common::Enumerated T>
 std::string ValueToString(T value)
 {
   return ValueToString(static_cast<std::underlying_type_t<T>>(value));

--- a/Source/Core/Common/Swap.h
+++ b/Source/Core/Common/Swap.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstring>
-#include <type_traits>
 
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
@@ -17,6 +16,7 @@
 #endif
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 
 namespace Common
 {
@@ -157,19 +157,16 @@ inline void swap<8>(u8* data)
   std::memcpy(data, &value, sizeof(u64));
 }
 
-template <typename T>
+template <Arithmetic T>
 inline T FromBigEndian(T data)
 {
-  static_assert(std::is_arithmetic<T>::value, "function only makes sense with arithmetic types");
-
   swap<sizeof(data)>(reinterpret_cast<u8*>(&data));
   return data;
 }
 
-template <typename value_type>
+template <Arithmetic value_type>
 struct BigEndianValue
 {
-  static_assert(std::is_arithmetic<value_type>(), "value_type must be an arithmetic type");
   BigEndianValue() = default;
   explicit BigEndianValue(value_type val) { *this = val; }
   operator value_type() const { return FromBigEndian(raw); }

--- a/Source/Core/Common/TypeUtils.h
+++ b/Source/Core/Common/TypeUtils.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <type_traits>
 
@@ -67,21 +68,23 @@ static_assert(std::is_same_v<ObjectType<&Bar::c>, Foo>);
 static_assert(!std::is_same_v<ObjectType<&Bar::c>, Bar>);
 }  // namespace detail
 
-// Template for checking if Types is count occurrences of T.
-template <typename T, size_t count, typename... Ts>
-struct IsNOf : std::integral_constant<bool, std::conjunction_v<std::is_convertible<Ts, T>...> &&
-                                                sizeof...(Ts) == count>
+// Type trait for checking if the size of Types is equal to N
+template <std::size_t N, typename... Ts>
+struct IsCountOfTypes : std::bool_constant<sizeof...(Ts) == N>
 {
 };
 
-static_assert(IsNOf<int, 0>::value);
-static_assert(!IsNOf<int, 0, int>::value);
-static_assert(IsNOf<int, 1, int>::value);
-static_assert(!IsNOf<int, 1>::value);
-static_assert(!IsNOf<int, 1, int, int>::value);
-static_assert(IsNOf<int, 2, int, int>::value);
-static_assert(IsNOf<int, 2, int, short>::value);  // Type conversions ARE allowed
-static_assert(!IsNOf<int, 2, int, char*>::value);
+// Type trait for checking if all of the given Types are convertible to T
+template <typename T, typename... Ts>
+struct IsConvertibleFromAllOf : std::conjunction<std::is_convertible<Ts, T>...>
+{
+};
+
+// Type trait for checking if any of the given Types are the same as T
+template <typename T, typename... Ts>
+struct IsSameAsAnyOf : std::disjunction<std::is_same<Ts, T>...>
+{
+};
 
 // TODO: This can be replaced with std::array's fill() once C++20 is fully supported.
 // Prior to C++20, std::array's fill() function is, unfortunately, not constexpr.

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -9,12 +9,12 @@
 #include <cstring>
 #include <functional>
 #include <tuple>
-#include <type_traits>
 
 #include "Common/Assert.h"
 #include "Common/BitSet.h"
 #include "Common/CodeBlock.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/x64ABI.h"
 
 namespace Gen
@@ -979,13 +979,9 @@ public:
   // Utility functions
   // The difference between this and CALL is that this aligns the stack
   // where appropriate.
-  template <typename FunctionPointer>
-  void ABI_CallFunction(FunctionPointer func)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunction(T func)
   {
-    static_assert(std::is_pointer<FunctionPointer>() &&
-                      std::is_function<std::remove_pointer_t<FunctionPointer>>(),
-                  "Supplied type must be a function pointer.");
-
     const void* ptr = reinterpret_cast<const void*>(func);
     const u64 address = reinterpret_cast<u64>(ptr);
     const u64 distance = address - (reinterpret_cast<u64>(code) + 5);
@@ -1002,46 +998,46 @@ public:
     }
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionC16(FunctionPointer func, u16 param1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionC16(T func, u16 param1)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCC16(FunctionPointer func, u32 param1, u16 param2)
-  {
-    MOV(32, R(ABI_PARAM1), Imm32(param1));
-    MOV(32, R(ABI_PARAM2), Imm32(param2));
-    ABI_CallFunction(func);
-  }
-
-  template <typename FunctionPointer>
-  void ABI_CallFunctionC(FunctionPointer func, u32 param1)
-  {
-    MOV(32, R(ABI_PARAM1), Imm32(param1));
-    ABI_CallFunction(func);
-  }
-
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCC(FunctionPointer func, u32 param1, u32 param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCC16(T func, u32 param1, u16 param2)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCP(FunctionPointer func, u32 param1, const void* param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionC(T func, u32 param1)
+  {
+    MOV(32, R(ABI_PARAM1), Imm32(param1));
+    ABI_CallFunction(func);
+  }
+
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCC(T func, u32 param1, u32 param2)
+  {
+    MOV(32, R(ABI_PARAM1), Imm32(param1));
+    MOV(32, R(ABI_PARAM2), Imm32(param2));
+    ABI_CallFunction(func);
+  }
+
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCP(T func, u32 param1, const void* param2)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(64, R(ABI_PARAM2), Imm64(reinterpret_cast<u64>(param2)));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCCC(FunctionPointer func, u32 param1, u32 param2, u32 param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCCC(T func, u32 param1, u32 param2, u32 param3)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
@@ -1049,8 +1045,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCCP(FunctionPointer func, u32 param1, u32 param2, const void* param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCCP(T func, u32 param1, u32 param2, const void* param3)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
@@ -1058,9 +1054,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionCCCP(FunctionPointer func, u32 param1, u32 param2, u32 param3,
-                            const void* param4)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionCCCP(T func, u32 param1, u32 param2, u32 param3, const void* param4)
   {
     MOV(32, R(ABI_PARAM1), Imm32(param1));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
@@ -1069,23 +1064,23 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionP(FunctionPointer func, const void* param1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionP(T func, const void* param1)
   {
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(param1)));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPC(FunctionPointer func, const void* param1, u32 param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPC(T func, const void* param1, u32 param2)
   {
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(param1)));
     MOV(32, R(ABI_PARAM2), Imm32(param2));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPPC(FunctionPointer func, const void* param1, const void* param2, u32 param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPPC(T func, const void* param1, const void* param2, u32 param3)
   {
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(param1)));
     MOV(64, R(ABI_PARAM2), Imm64(reinterpret_cast<u64>(param2)));
@@ -1094,8 +1089,8 @@ public:
   }
 
   // Pass a register as a parameter.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionR(FunctionPointer func, X64Reg reg1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionR(T func, X64Reg reg1)
   {
     if (reg1 != ABI_PARAM1)
       MOV(32, R(ABI_PARAM1), R(reg1));
@@ -1103,8 +1098,8 @@ public:
   }
 
   // Pass a pointer and register as a parameter.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPR(FunctionPointer func, const void* ptr, X64Reg reg1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPR(T func, const void* ptr, X64Reg reg1)
   {
     if (reg1 != ABI_PARAM2)
       MOV(64, R(ABI_PARAM2), R(reg1));
@@ -1113,24 +1108,24 @@ public:
   }
 
   // Pass two registers as parameters.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionRR(FunctionPointer func, X64Reg reg1, X64Reg reg2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionRR(T func, X64Reg reg1, X64Reg reg2)
   {
     MOVTwo(64, ABI_PARAM1, reg1, 0, ABI_PARAM2, reg2);
     ABI_CallFunction(func);
   }
 
   // Pass a pointer and two registers as parameters.
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPRR(FunctionPointer func, const void* ptr, X64Reg reg1, X64Reg reg2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPRR(T func, const void* ptr, X64Reg reg1, X64Reg reg2)
   {
     MOVTwo(64, ABI_PARAM2, reg1, 0, ABI_PARAM3, reg2);
     MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(ptr)));
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionAC(int bits, FunctionPointer func, const Gen::OpArg& arg1, u32 param2)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionAC(int bits, T func, const Gen::OpArg& arg1, u32 param2)
   {
     if (!arg1.IsSimpleReg(ABI_PARAM1))
       MOV(bits, R(ABI_PARAM1), arg1);
@@ -1138,9 +1133,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionPAC(int bits, FunctionPointer func, const void* ptr1, const Gen::OpArg& arg2,
-                           u32 param3)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionPAC(int bits, T func, const void* ptr1, const Gen::OpArg& arg2, u32 param3)
   {
     if (!arg2.IsSimpleReg(ABI_PARAM2))
       MOV(bits, R(ABI_PARAM2), arg2);
@@ -1149,8 +1143,8 @@ public:
     ABI_CallFunction(func);
   }
 
-  template <typename FunctionPointer>
-  void ABI_CallFunctionA(int bits, FunctionPointer func, const Gen::OpArg& arg1)
+  template <Common::FunctionPointer T>
+  void ABI_CallFunctionA(int bits, T func, const Gen::OpArg& arg1)
   {
     if (!arg1.IsSimpleReg(ABI_PARAM1))
       MOV(bits, R(ABI_PARAM1), arg1);

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -14,6 +14,7 @@
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
+#include "Common/Concepts.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Core.h"
@@ -59,10 +60,9 @@ Cheats::DataType Cheats::GetDataType(const Cheats::SearchValue& value)
   return static_cast<DataType>(value.m_value.index());
 }
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 static std::vector<u8> ToByteVector(const T& val)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   const auto* const begin = reinterpret_cast<const u8*>(&val);
   const auto* const end = begin + sizeof(T);
   return {begin, end};

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -195,7 +195,8 @@ void SDSP::FreeMemoryPages()
 
 void SDSP::SetException(ExceptionType exception)
 {
-  exceptions |= 1 << static_cast<std::underlying_type_t<ExceptionType>>(exception);
+  // C++23 TODO: std::to_underlying would be nice
+  Common::SetBit(static_cast<std::underlying_type_t<ExceptionType>>(exception), exceptions);
 }
 
 void SDSP::SetExternalInterrupt(bool val)
@@ -232,7 +233,7 @@ void SDSP::CheckExceptions()
         StoreStack(StackRegister::Data, r.sr);
 
         pc = static_cast<u16>(i * 2);
-        exceptions &= ~(1 << i);
+        Common::ClearBit(i, exceptions);
         if (i == 7)
           r.sr &= ~SR_EXT_INT_ENABLE;
         else

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <type_traits>
 
+#include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
@@ -222,7 +223,7 @@ void SDSP::CheckExceptions()
   for (int i = 7; i > 0; i--)
   {
     // Seems exp int are not masked by sr_int_enable
-    if ((exceptions & (1U << i)) != 0)
+    if (Common::ExtractBit(i, exceptions))
     {
       if (IsSRFlagSet(SR_INT_ENABLE) || i == static_cast<int>(ExceptionType::ExternalInterrupt))
       {

--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstring>
 
+#include "Common/BitUtils.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/Intrinsics.h"
@@ -113,12 +114,12 @@ void SDSP::WriteIFX(u32 address, u16 value)
 
   case DSP_DSBL:
     m_ifx_regs[DSP_DSBL] = value;
-    m_ifx_regs[DSP_DSCR] |= 4;  // Doesn't really matter since we do DMA instantly
+    Common::SetBit<2>(m_ifx_regs[DSP_DSCR]);  // Doesn't really matter since we do DMA instantly
     if (!m_ifx_regs[DSP_AMDM])
       DoDMA();
     else
       NOTICE_LOG_FMT(DSPLLE, "Masked DMA skipped");
-    m_ifx_regs[DSP_DSCR] &= ~4;
+    Common::ClearBit<2>(m_ifx_regs[DSP_DSCR]);
     m_ifx_regs[DSP_DSBL] = 0;
     break;
 

--- a/Source/Core/Core/DSP/Interpreter/DSPIntMisc.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntMisc.cpp
@@ -9,6 +9,8 @@
 #include "Core/DSP/DSPTables.h"
 #include "Core/DSP/Interpreter/DSPIntUtil.h"
 
+#include "Common/BitUtils.h"
+
 namespace DSP::Interpreter
 {
 // MRR $D, $S
@@ -127,7 +129,7 @@ void Interpreter::sbclr(const UDSPInstruction opc)
   auto& state = m_dsp_core.DSPState();
   const u8 bit = (opc & 0x7) + 6;
 
-  state.r.sr &= ~(1U << bit);
+  Common::ClearBit(bit, state.r.sr);
 }
 
 // SBSET #I
@@ -139,7 +141,7 @@ void Interpreter::sbset(const UDSPInstruction opc)
   auto& state = m_dsp_core.DSPState();
   const u8 bit = (opc & 0x7) + 6;
 
-  state.r.sr |= (1U << bit);
+  Common::SetBit(bit, state.r.sr);
 }
 
 // This is a bunch of flag setters, flipping bits in SR.

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <map>
 
+#include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -639,7 +640,7 @@ void ZeldaUCode::RenderAudio()
       // Test the sync flag for this voice, skip it if not set.
       u16 flags = m_sync_voice_skip_flags[m_rendering_curr_voice >> 4];
       u8 bit = 0xF - (m_rendering_curr_voice & 0xF);
-      if (flags & (1 << bit))
+      if (Common::ExtractBit(bit, flags))
         m_renderer.AddVoice(m_rendering_curr_voice);
 
       m_rendering_curr_voice++;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -1394,12 +1394,8 @@ void ZeldaAudioRenderer::LoadInputSamples(MixingBuffer* buffer, VPB* vpb)
   case VPB::SRC_SQUARE_WAVE:
   case VPB::SRC_SQUARE_WAVE_25PCT:
   {
-    u32 shift;
-    if (vpb->samples_source_type == VPB::SRC_SQUARE_WAVE)
-      shift = 1;
-    else
-      shift = 2;
-    u32 mask = (1 << shift) - 1;
+    const u32 shift = (vpb->samples_source_type == VPB::SRC_SQUARE_WAVE ? 1u : 2u);
+    u32 mask = Common::CalcLowMaskFast<u32>(shift);
 
     u32 pos = vpb->current_pos_frac << shift;
     for (s16& sample : *buffer)

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -15,6 +15,7 @@
 
 #include "Common/Align.h"
 #include "Common/BitField.h"
+#include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
@@ -1068,8 +1069,8 @@ void DVDInterface::ExecuteCommand(ReplyType reply_type)
   // Used by both GC and Wii
   case DICommand::StopMotor:
   {
-    const bool eject = (m_DICMDBUF[0] & (1 << 17));
-    const bool kill = (m_DICMDBUF[0] & (1 << 20));
+    const bool eject = Common::ExtractBit<17>(m_DICMDBUF[0]);
+    const bool kill = Common::ExtractBit<20>(m_DICMDBUF[0]);
     INFO_LOG_FMT(DVDINTERFACE, "DVDLowStopMotor{}{}", eject ? " eject" : "", kill ? " kill!" : "");
 
     if (m_drive_state == DriveState::Ready || m_drive_state == DriveState::ReadyNoReadsMade ||

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -260,12 +260,12 @@ void CEXIETHERNET::DoState(PointerWrap& p)
 
 bool CEXIETHERNET::IsMXCommand(u32 const data)
 {
-  return !!(data & (1 << 31));
+  return Common::ExtractBit<31>(data);
 }
 
 bool CEXIETHERNET::IsWriteCommand(u32 const data)
 {
-  return IsMXCommand(data) ? !!(data & (1 << 30)) : !!(data & (1 << 14));
+  return IsMXCommand(data) ? Common::ExtractBit<30>(data) : Common::ExtractBit<14>(data);
 }
 
 const char* CEXIETHERNET::GetRegisterName() const
@@ -521,7 +521,7 @@ inline bool CEXIETHERNET::RecvMACFilter()
   {
     // Lookup the dest eth address in the hashmap
     u16 index = HashIndex(mRecvBuffer.get());
-    return !!(mBbaMem[BBA_NAFR_MAR0 + index / 8] & (1 << (index % 8)));
+    return Common::ExtractBit(index % 8, mBbaMem[BBA_NAFR_MAR0 + index / 8]);
   }
 }
 

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 
 #include "Common/BitField.h"
+#include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -368,7 +369,7 @@ void SerialInterfaceManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
     mmio->Register(base | (SI_CHANNEL_0_IN_HI + 0xC * i),
                    MMIO::ComplexRead<u32>([i, rdst_bit](Core::System& system, u32) {
                      auto& si = system.GetSerialInterface();
-                     si.m_status_reg.hex &= ~(1U << rdst_bit);
+                     Common::ClearBit(rdst_bit, si.m_status_reg.hex);
                      si.UpdateInterrupts();
                      return si.m_channel[i].in_hi.hex;
                    }),
@@ -376,7 +377,7 @@ void SerialInterfaceManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
     mmio->Register(base | (SI_CHANNEL_0_IN_LO + 0xC * i),
                    MMIO::ComplexRead<u32>([i, rdst_bit](Core::System& system, u32) {
                      auto& si = system.GetSerialInterface();
-                     si.m_status_reg.hex &= ~(1U << rdst_bit);
+                     Common::ClearBit(rdst_bit, si.m_status_reg.hex);
                      si.UpdateInterrupts();
                      return si.m_channel[i].in_lo.hex;
                    }),

--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -22,6 +22,7 @@
 #include <fmt/format.h>
 
 #include "Common/Align.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Crypto/SHA1.h"
 #include "Common/Crypto/ec.h"
@@ -123,7 +124,7 @@ public:
       return {};
     header.permissions = mode;
     // remove nocopy flag
-    header.banner[7] &= ~1;
+    Common::ClearBit<0>(header.banner[7]);
 
     Md5 md5_calc;
     mbedtls_md5_ret(reinterpret_cast<const u8*>(&header), sizeof(Header), md5_calc.data());

--- a/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
+++ b/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
@@ -82,10 +82,10 @@ struct IncludeAccel : virtual DataReportManipulator
     result->value.x |= core.acc_bits & 0b11;
 
     // Y and Z only have 9 bits of precision. (convert them to 10)
-    result->value.y =
-        Common::ExpandValue<u16>(accel.y << 1 | Common::ExtractBit<0>(core.acc_bits2), 1);
-    result->value.z =
-        Common::ExpandValue<u16>(accel.z << 1 | Common::ExtractBit<1>(core.acc_bits2), 1);
+    result->value.y = Common::ExpandValue<u16>(
+        accel.y << 1 | static_cast<u8>(Common::ExtractBit<0>(core.acc_bits2)), 1);
+    result->value.z = Common::ExpandValue<u16>(
+        accel.z << 1 | static_cast<u8>(Common::ExtractBit<1>(core.acc_bits2)), 1);
   }
 
   void SetAccelData(const AccelData& new_accel) override

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
@@ -62,8 +62,8 @@ SerializedWiimoteState SerializeDesiredState(const DesiredWiimoteState& state)
     const u8 accel_x_high = u8(accel_x >> 2);
     const u8 accel_y_high = u8(accel_y >> 2);
     const u8 accel_z_high = u8(accel_z >> 2);
-    const u8 accel_low = u8((accel_x & 0b11) | (Common::ExtractBit<1>(accel_y) << 2) |
-                            (Common::ExtractBit<1>(accel_z) << 3));
+    const u8 accel_low = u8((accel_x & 0b11) | (u8(Common::ExtractBit<1>(accel_y)) << 2) |
+                            (u8(Common::ExtractBit<1>(accel_z)) << 3));
 
     if (has_buttons)
     {
@@ -251,10 +251,10 @@ bool DeserializeDesiredState(DesiredWiimoteState* state, const SerializedWiimote
     const u8 accel_y_high = d[pos + 2];
     const u8 accel_z_high = d[pos + 3];
     state->acceleration.value.x = (accel_x_high << 2) | (accel_low & 0b11);
-    state->acceleration.value.y =
-        Common::ExpandValue<u16>((accel_y_high << 1) | Common::ExtractBit<2>(accel_low), 1);
-    state->acceleration.value.z =
-        Common::ExpandValue<u16>((accel_z_high << 1) | Common::ExtractBit<3>(accel_low), 1);
+    state->acceleration.value.y = Common::ExpandValue<u16>(
+        (accel_y_high << 1) | static_cast<u8>(Common::ExtractBit<2>(accel_low)), 1);
+    state->acceleration.value.z = Common::ExpandValue<u16>(
+        (accel_z_high << 1) | static_cast<u8>(Common::ExtractBit<3>(accel_low)), 1);
     pos += 4;
   }
 

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
@@ -669,15 +669,15 @@ void MotionPlus::ApplyPassthroughModifications(PassthroughMode mode, u8* data)
     // Verified on real hardware via a test of every bit.
     // Data passing through drops the least significant bit of the three accelerometer values.
     // Bit 7 of byte 5 is moved to bit 6 of byte 5, overwriting it
-    Common::SetBit<6>(data[5], Common::ExtractBit<7>(data[5]));
+    Common::InsertBit<6>(data[5], Common::ExtractBit<7>(data[5]));
     // Bit 0 of byte 4 is moved to bit 7 of byte 5
-    Common::SetBit<7>(data[5], Common::ExtractBit<0>(data[4]));
+    Common::InsertBit<7>(data[5], Common::ExtractBit<0>(data[4]));
     // Bit 3 of byte 5 is moved to  bit 4 of byte 5, overwriting it
-    Common::SetBit<4>(data[5], Common::ExtractBit<3>(data[5]));
+    Common::InsertBit<4>(data[5], Common::ExtractBit<3>(data[5]));
     // Bit 1 of byte 5 is moved to bit 3 of byte 5
-    Common::SetBit<3>(data[5], Common::ExtractBit<1>(data[5]));
+    Common::InsertBit<3>(data[5], Common::ExtractBit<1>(data[5]));
     // Bit 0 of byte 5 is moved to bit 2 of byte 5, overwriting it
-    Common::SetBit<2>(data[5], Common::ExtractBit<0>(data[5]));
+    Common::InsertBit<2>(data[5], Common::ExtractBit<0>(data[5]));
   }
   else if (mode == PassthroughMode::Classic)
   {
@@ -686,8 +686,8 @@ void MotionPlus::ApplyPassthroughModifications(PassthroughMode mode, u8* data)
     // Data passing through drops the least significant bit of the axes of the left (or only)
     // joystick Bit 0 of Byte 4 is overwritten [by the 'extension_connected' flag] Bits 0 and
     // 1 of Byte 5 are moved to bit 0 of Bytes 0 and 1, overwriting what was there before.
-    Common::SetBit<0>(data[0], Common::ExtractBit<0>(data[5]));
-    Common::SetBit<0>(data[1], Common::ExtractBit<1>(data[5]));
+    Common::InsertBit<0>(data[0], Common::ExtractBit<0>(data[5]));
+    Common::InsertBit<0>(data[1], Common::ExtractBit<1>(data[5]));
   }
 }
 
@@ -696,30 +696,30 @@ void MotionPlus::ReversePassthroughModifications(PassthroughMode mode, u8* data)
   if (mode == PassthroughMode::Nunchuk)
   {
     // Undo M+'s "nunchuk passthrough" modifications.
-    Common::SetBit<0>(data[5], Common::ExtractBit<2>(data[5]));
-    Common::SetBit<1>(data[5], Common::ExtractBit<3>(data[5]));
-    Common::SetBit<3>(data[5], Common::ExtractBit<4>(data[5]));
-    Common::SetBit<0>(data[4], Common::ExtractBit<7>(data[5]));
-    Common::SetBit<7>(data[5], Common::ExtractBit<6>(data[5]));
+    Common::InsertBit<0>(data[5], Common::ExtractBit<2>(data[5]));
+    Common::InsertBit<1>(data[5], Common::ExtractBit<3>(data[5]));
+    Common::InsertBit<3>(data[5], Common::ExtractBit<4>(data[5]));
+    Common::InsertBit<0>(data[4], Common::ExtractBit<7>(data[5]));
+    Common::InsertBit<7>(data[5], Common::ExtractBit<6>(data[5]));
 
     // Set the overwritten bits from the next LSB.
-    Common::SetBit<2>(data[5], Common::ExtractBit<3>(data[5]));
-    Common::SetBit<4>(data[5], Common::ExtractBit<5>(data[5]));
-    Common::SetBit<6>(data[5], Common::ExtractBit<7>(data[5]));
+    Common::InsertBit<2>(data[5], Common::ExtractBit<3>(data[5]));
+    Common::InsertBit<4>(data[5], Common::ExtractBit<5>(data[5]));
+    Common::InsertBit<6>(data[5], Common::ExtractBit<7>(data[5]));
   }
   else if (mode == PassthroughMode::Classic)
   {
     // Undo M+'s "classic controller passthrough" modifications.
-    Common::SetBit<0>(data[5], Common::ExtractBit<0>(data[0]));
-    Common::SetBit<1>(data[5], Common::ExtractBit<0>(data[1]));
+    Common::InsertBit<0>(data[5], Common::ExtractBit<0>(data[0]));
+    Common::InsertBit<1>(data[5], Common::ExtractBit<0>(data[1]));
 
     // Set the overwritten bits from the next LSB.
-    Common::SetBit<0>(data[0], Common::ExtractBit<1>(data[0]));
-    Common::SetBit<0>(data[1], Common::ExtractBit<1>(data[1]));
+    Common::InsertBit<0>(data[0], Common::ExtractBit<1>(data[0]));
+    Common::InsertBit<0>(data[1], Common::ExtractBit<1>(data[1]));
 
     // This is an overwritten unused button bit on the Classic Controller.
     // Note it's a significant bit on the DJ Hero Turntable. (passthrough not feasible)
-    Common::SetBit<0>(data[4], 1);
+    Common::InsertBit<0>(data[4], 1);
   }
 }
 

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -235,14 +235,14 @@ bool IsPressed(int id, bool held)
       static_cast<HotkeyManager*>(s_config.GetController(0))->GetIndexForGroup(group, id);
   if (Common::ExtractBit(group_key, s_hotkey.button[group]))
   {
-    s_hotkey_down[group] |= (1 << group_key);
     const bool pressed = Common::ExtractBit(group_key, s_hotkey_down[group]);
+    Common::SetBit(group_key, s_hotkey_down[group]);
     if (!pressed || held)
       return true;
   }
   else
   {
-    s_hotkey_down[group] &= ~(1 << group_key);
+    Common::ClearBit(group_key, s_hotkey_down[group]);
   }
 
   return false;
@@ -391,7 +391,7 @@ void HotkeyManager::GetInput(HotkeyStatus* kb, bool ignore_focus)
     const int group_count = (s_groups_info[group].last - s_groups_info[group].first) + 1;
     std::vector<u32> bitmasks(group_count);
     for (size_t key = 0; key < bitmasks.size(); key++)
-      bitmasks[key] = static_cast<u32>(1 << key);
+      Common::SetBit(key, bitmasks[key]);
 
     kb->button[group] = 0;
     m_keys[group]->GetState(&kb->button[group], bitmasks.data());

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -10,6 +10,7 @@
 
 #include <fmt/format.h>
 
+#include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
@@ -232,10 +233,10 @@ bool IsPressed(int id, bool held)
   unsigned int group = static_cast<HotkeyManager*>(s_config.GetController(0))->FindGroupByID(id);
   unsigned int group_key =
       static_cast<HotkeyManager*>(s_config.GetController(0))->GetIndexForGroup(group, id);
-  if (s_hotkey.button[group] & (1 << group_key))
+  if (Common::ExtractBit(group_key, s_hotkey.button[group]))
   {
-    const bool pressed = !!(s_hotkey_down[group] & (1 << group_key));
     s_hotkey_down[group] |= (1 << group_key);
+    const bool pressed = Common::ExtractBit(group_key, s_hotkey_down[group]);
     if (!pressed || held)
       return true;
   }

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -16,6 +16,7 @@
 #include <mbedtls/rsa.h>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/Crypto/AES.h"
 #include "Common/Crypto/SHA1.h"
@@ -690,7 +691,7 @@ bool IOSC::HasOwnership(Handle handle, u32 pid) const
 {
   u32 owner_mask;
   return handle == HANDLE_ROOT_KEY ||
-         (GetOwnership(handle, &owner_mask) == IPC_SUCCESS && ((1 << pid) & owner_mask) != 0);
+         (GetOwnership(handle, &owner_mask) == IPC_SUCCESS && Common::ExtractBit(pid, owner_mask));
 }
 
 bool IOSC::IsDefaultHandle(Handle handle) const

--- a/Source/Core/Core/IOS/USB/Bluetooth/hci.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/hci.h
@@ -2511,7 +2511,7 @@ static __inline void hci_filter_set(uint8_t bit, struct hci_filter* filter)
   uint8_t off = bit - 1;
 
   off >>= 5;
-  filter->mask[off] |= (1 << ((bit - 1) & 0x1f));
+  Common::SetBit((bit - 1) & 0x1f, filter->mask[off]);
 }
 
 static __inline void hci_filter_clr(uint8_t bit, struct hci_filter* filter)
@@ -2519,7 +2519,7 @@ static __inline void hci_filter_clr(uint8_t bit, struct hci_filter* filter)
   uint8_t off = bit - 1;
 
   off >>= 5;
-  filter->mask[off] &= ~(1 << ((bit - 1) & 0x1f));
+  Common::ClearBit((bit - 1) & 0x1f, filter->mask[off]);
 }
 
 static __inline int hci_filter_test(uint8_t bit, const struct hci_filter* filter)

--- a/Source/Core/Core/IOS/USB/Bluetooth/hci.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/hci.h
@@ -85,6 +85,7 @@
 #include <array>
 #include <cstdint>
 
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 
 // All structs in this file are packed
@@ -2526,7 +2527,7 @@ static __inline int hci_filter_test(uint8_t bit, const struct hci_filter* filter
   uint8_t off = bit - 1;
 
   off >>= 5;
-  return (filter->mask[off] & (1 << ((bit - 1) & 0x1f)));
+  return Common::ExtractBit((bit - 1) & 0x1f, filter->mask[off]);
 }
 
 /*

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -575,7 +575,7 @@ bool BeginRecordingInput(const ControllerTypeArray& controllers,
     {
       const SerialInterface::SIDevices si_device = Config::Get(Config::GetInfoForSIDevice(i));
       if (si_device == SerialInterface::SIDEVICE_GC_TARUKONGA)
-        s_bongos |= (1 << i);
+        Common::SetBit(i, s_bongos);
     }
 
     if (Core::IsRunningAndStarted())
@@ -1400,11 +1400,11 @@ void SaveRecording(const std::string& filename)
   for (int i = 0; i < 4; ++i)
   {
     if (IsUsingGBA(i))
-      header.GBAControllers |= 1 << i;
+      Common::SetBit(i, header.GBAControllers);
     if (IsUsingPad(i))
-      header.controllers |= 1 << i;
+      Common::SetBit(i, header.controllers);
     if (IsUsingWiimote(i) && SConfig::GetInstance().bWii)
-      header.controllers |= 1 << (i + 4);
+      Common::SetBit(i + 4, header.controllers);
   }
 
   header.bFromSaveState = s_bRecordingFromSaveState;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -21,6 +21,7 @@
 #include <fmt/format.h>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonPaths.h"
 #include "Common/Config/Config.h"
@@ -422,7 +423,7 @@ bool IsUsingPad(int controller)
 
 bool IsUsingBongo(int controller)
 {
-  return ((s_bongos & (1 << controller)) != 0);
+  return Common::ExtractBit(controller, s_bongos);
 }
 
 bool IsUsingGBA(int controller)
@@ -922,13 +923,13 @@ void ReadHeader()
 {
   for (int i = 0; i < 4; ++i)
   {
-    if (tmpHeader.GBAControllers & (1 << i))
+    if (Common::ExtractBit(i, tmpHeader.GBAControllers))
       s_controllers[i] = ControllerType::GBA;
-    else if (tmpHeader.controllers & (1 << i))
+    else if (Common::ExtractBit(i, tmpHeader.controllers))
       s_controllers[i] = ControllerType::GC;
     else
       s_controllers[i] = ControllerType::None;
-    s_wiimotes[i] = (tmpHeader.controllers & (1 << (i + 4))) != 0;
+    s_wiimotes[i] = Common::ExtractBit(i + 4, tmpHeader.controllers);
   }
   s_recordingStartTime = tmpHeader.recordingStartTime;
   if (s_rerecords < tmpHeader.numRerecords)
@@ -1493,8 +1494,8 @@ void GetSettings()
                    !(slot_a_has_gci_folder && gci_folder_has_saves(ExpansionInterface::Slot::A)) &&
                    !(slot_b_has_gci_folder && gci_folder_has_saves(ExpansionInterface::Slot::B));
   }
-  s_memcards |= (slot_a_has_raw_memcard || slot_a_has_gci_folder) << 0;
-  s_memcards |= (slot_b_has_raw_memcard || slot_b_has_gci_folder) << 1;
+  Common::InsertBit<0>(s_memcards, slot_a_has_raw_memcard || slot_a_has_gci_folder);
+  Common::InsertBit<1>(s_memcards, slot_b_has_raw_memcard || slot_b_has_gci_folder);
 
   s_revision = ConvertGitRevisionToBytes(Common::GetScmRevGitStr());
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -16,8 +16,8 @@ void Interpreter::Helper_UpdateCR0(PowerPC::PowerPCState& ppc_state, u32 value)
 {
   const s64 sign_extended = s64{s32(value)};
   u64 cr_val = u64(sign_extended);
-  cr_val = (cr_val & ~(1ULL << PowerPC::CR_EMU_SO_BIT)) |
-           (u64{ppc_state.GetXER_SO()} << PowerPC::CR_EMU_SO_BIT);
+
+  Common::InsertBit<PowerPC::CR_EMU_SO_BIT>(cr_val, ppc_state.GetXER_SO());
 
   ppc_state.cr.fields[0] = cr_val;
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -1081,13 +1081,13 @@ void Interpreter::stwcxd(Interpreter& interpreter, UGeckoInstruction inst)
       if (!(ppc_state.Exceptions & EXCEPTION_DSI))
       {
         ppc_state.reserve = false;
-        ppc_state.cr.SetField(0, 2 | ppc_state.GetXER_SO());
+        ppc_state.cr.SetField(0, 2 | static_cast<u32>(ppc_state.GetXER_SO()));
         return;
       }
     }
   }
 
-  ppc_state.cr.SetField(0, ppc_state.GetXER_SO());
+  ppc_state.cr.SetField(0, static_cast<u32>(ppc_state.GetXER_SO()));
 }
 
 void Interpreter::stwux(Interpreter& interpreter, UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -4,6 +4,7 @@
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/GPFifo.h"
@@ -85,7 +86,7 @@ void Interpreter::mtfsfx(Interpreter& interpreter, UGeckoInstruction inst)
   u32 m = 0;
   for (u32 i = 0; i < 8; i++)
   {
-    if ((fm & (1U << i)) != 0)
+    if (Common::ExtractBit(i, fm))
       m |= (0xFU << (i * 4));
   }
 
@@ -125,7 +126,7 @@ void Interpreter::mtcrf(Interpreter& interpreter, UGeckoInstruction inst)
     u32 mask = 0;
     for (u32 i = 0; i < 8; i++)
     {
-      if ((crm & (1U << i)) != 0)
+      if (Common::ExtractBit(i, crm))
         mask |= 0xFU << (i * 4);
     }
 
@@ -260,10 +261,7 @@ void Interpreter::mfspr(Interpreter& interpreter, UGeckoInstruction inst)
     // GPFifo::GATHER_PIPE_PHYSICAL_ADDRESS)).
     // Currently, we always treat the buffer as not empty, as the exact behavior is unclear
     // (and games that use display lists will hang if the bit doesn't eventually become zero).
-    if (interpreter.m_system.GetGPFifo().IsBNE())
-      ppc_state.spr[index] |= 1;
-    else
-      ppc_state.spr[index] &= ~1;
+    Common::InsertBit<0>(ppc_state.spr[index], interpreter.m_system.GetGPFifo().IsBNE());
   }
   break;
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
@@ -700,9 +701,9 @@ void Jit64::FloatCompare(UGeckoInstruction inst, bool upper)
     js.skipInstructions = 1;
     js.downcountAmount++;
     int dst = 3 - (next.CRBD & 3);
-    output[3 - (next.CRBD & 3)] &= ~(1 << dst);
-    output[3 - (next.CRBA & 3)] |= 1 << dst;
-    output[3 - (next.CRBB & 3)] |= 1 << dst;
+    Common::ClearBit(dst, output[3 - (next.CRBD & 3)]);
+    Common::SetBit(dst, output[3 - (next.CRBA & 3)]);
+    Common::SetBit(dst, output[3 - (next.CRBB & 3)]);
   }
 
   RCOpArg Ra = upper ? fpr.Bind(a, RCMode::Read) : fpr.Use(a, RCMode::Read);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1096,7 +1096,7 @@ void Jit64::subfx(UGeckoInstruction inst)
   INSTRUCTION_START
   JITDISABLE(bJITIntegerOff);
   int a = inst.RA, b = inst.RB, d = inst.RD;
-  const bool carry = !(inst.SUBOP10 & (1 << 5));
+  const bool carry = !Common::ExtractBit<5>(inst.SUBOP10);
 
   if (a == b)
   {
@@ -1402,7 +1402,7 @@ void Jit64::divwux(UGeckoInstruction inst)
     else
     {
       u32 shift = 31;
-      while (!(divisor & (1 << shift)))
+      while (!Common::ExtractBit(shift, divisor))
         shift--;
 
       if (divisor == (u32)(1 << shift))
@@ -1833,7 +1833,7 @@ void Jit64::addx(UGeckoInstruction inst)
   INSTRUCTION_START
   JITDISABLE(bJITIntegerOff);
   int a = inst.RA, b = inst.RB, d = inst.RD;
-  bool carry = !(inst.SUBOP10 & (1 << 8));
+  bool carry = !Common::ExtractBit<8>(inst.SUBOP10);
 
   if (gpr.IsImm(a, b))
   {
@@ -2714,7 +2714,7 @@ void Jit64::twX(UGeckoInstruction inst)
 
   for (size_t i = 0; i < conditions.size(); i++)
   {
-    if (inst.TO & (1 << i))
+    if (Common::ExtractBit(i, inst.TO))
     {
       FixupBranch f = J_CC(conditions[i], true);
       fixups.push_back(f);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -4,6 +4,7 @@
 #include "Core/PowerPC/Jit64/Jit.h"
 
 #include "Common/BitSet.h"
+#include "Common/BitUtils.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
@@ -860,7 +861,7 @@ void Jit64::mtfsfx(UGeckoInstruction inst)
   u32 mask = 0;
   for (int i = 0; i < 8; i++)
   {
-    if (inst.FM & (1 << i))
+    if (Common::ExtractBit(i, inst.FM))
       mask |= 0xF << (4 * i);
   }
 

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -5,9 +5,9 @@
 
 #include <array>
 #include <cstddef>
-#include <type_traits>
 #include <variant>
 
+#include "Common/Concepts.h"
 #include "Common/x64Emitter.h"
 #include "Core/PowerPC/Jit64/RegCache/CachedReg.h"
 #include "Core/PowerPC/PPCAnalyst.h"
@@ -119,6 +119,9 @@ private:
   std::array<X64CachedReg, NUM_XREGS> m_xregs;
 };
 
+template <class T>
+concept RegCacheConstraint = Common::SameAsAnyOf<T, RCOpArg, RCX64Reg>;
+
 class RegCache
 {
 public:
@@ -135,17 +138,15 @@ public:
   void SetEmitter(Gen::XEmitter* emitter);
   bool SanityCheck() const;
 
-  template <typename... Ts>
+  template <RegCacheConstraint... Ts>
   static void Realize(Ts&... rc)
   {
-    static_assert(((std::is_same<Ts, RCOpArg>() || std::is_same<Ts, RCX64Reg>()) && ...));
     (rc.Realize(), ...);
   }
 
-  template <typename... Ts>
+  template <RegCacheConstraint... Ts>
   static void Unlock(Ts&... rc)
   {
-    static_assert(((std::is_same<Ts, RCOpArg>() || std::is_same<Ts, RCX64Reg>()) && ...));
     (rc.Unlock(), ...);
   }
 

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CPUDetect.h"
 #include "Common/FloatUtils.h"
 #include "Common/Intrinsics.h"
@@ -234,7 +235,7 @@ private:
   {
     if (m_sign_extend)
     {
-      u32 sign = !!(value & (1 << (sbits - 1)));
+      const bool sign = Common::ExtractBit(sbits - 1, value);
       value |= sign * ((0xFFFFFFFF >> sbits) << sbits);
     }
     m_code->MOV(32, R(m_dst_reg), Gen::Imm32(value));

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -5,6 +5,7 @@
 
 #include "Common/Arm64Emitter.h"
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 
@@ -234,7 +235,7 @@ void JitArm64::twx(UGeckoInstruction inst)
 
   for (int i = 0; i < 5; i++)
   {
-    if (inst.TO & (1 << i))
+    if (Common::ExtractBit(i, inst.TO))
     {
       FixupBranch f = B(conditions[i]);
       fixups.push_back(f);
@@ -913,7 +914,7 @@ void JitArm64::mtfsfx(UGeckoInstruction inst)
   u32 mask = 0;
   for (int i = 0; i < 8; i++)
   {
-    if (inst.FM & (1 << i))
+    if (Common::ExtractBit(i, inst.FM))
       mask |= 0xFU << (4 * i);
   }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -119,8 +119,8 @@ public:
     ClearAll();
   }
 
-  void Set(u32 bit) { m_valid_block[bit / 32] |= 1u << (bit % 32); }
-  void Clear(u32 bit) { m_valid_block[bit / 32] &= ~(1u << (bit % 32)); }
+  void Set(u32 bit) { Common::SetBit(bit % 32, m_valid_block[bit / 32]); }
+  void Clear(u32 bit) { Common::ClearBit(bit % 32, m_valid_block[bit / 32]); }
   void ClearAll() { memset(m_valid_block.get(), 0, sizeof(u32) * VALID_BLOCK_ALLOC_ELEMENTS); }
   bool Test(u32 bit) const { return Common::ExtractBit(bit % 32, m_valid_block[bit / 32]); }
 };

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -15,6 +15,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 
 class JitBase;
@@ -121,7 +122,7 @@ public:
   void Set(u32 bit) { m_valid_block[bit / 32] |= 1u << (bit % 32); }
   void Clear(u32 bit) { m_valid_block[bit / 32] &= ~(1u << (bit % 32)); }
   void ClearAll() { memset(m_valid_block.get(), 0, sizeof(u32) * VALID_BLOCK_ALLOC_ELEMENTS); }
-  bool Test(u32 bit) const { return (m_valid_block[bit / 32] & (1u << (bit % 32))) != 0; }
+  bool Test(u32 bit) const { return Common::ExtractBit(bit % 32, m_valid_block[bit / 32]); }
 };
 
 class JitBaseBlockCache

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -50,6 +50,8 @@
 
 #include "VideoCommon/VideoBackendBase.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace PowerPC
 {
 MMU::MMU(Core::System& system, Memory::MemoryManager& memory, PowerPC::PowerPCManager& power_pc)
@@ -145,7 +147,7 @@ static void EFB_Write(u32 data, u32 addr)
   }
 }
 
-template <XCheckTLBFlag flag, typename T, bool never_translate>
+template <XCheckTLBFlag flag, std::integral T, bool never_translate>
 T MMU::ReadFromHardware(u32 em_address)
 {
   const u32 em_address_start_page = em_address & ~HW_PAGE_MASK;
@@ -593,7 +595,7 @@ u64 MMU::Read_U64(const u32 address)
   return var;
 }
 
-template <typename T>
+template <std::integral T>
 std::optional<ReadResult<T>> MMU::HostTryReadUX(const Core::CPUThreadGuard& guard,
                                                 const u32 address, RequestedAddressSpace space)
 {

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -11,6 +11,8 @@
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace Core
 {
 class CPUThreadGuard;
@@ -303,14 +305,14 @@ private:
   void UpdateBATs(BatTable& bat_table, u32 base_spr);
   void UpdateFakeMMUBat(BatTable& bat_table, u32 start_addr);
 
-  template <XCheckTLBFlag flag, typename T, bool never_translate = false>
+  template <XCheckTLBFlag flag, std::integral T, bool never_translate = false>
   T ReadFromHardware(u32 em_address);
   template <XCheckTLBFlag flag, bool never_translate = false>
   void WriteToHardware(u32 em_address, const u32 data, const u32 size);
   template <XCheckTLBFlag flag>
   bool IsRAMAddress(u32 address, bool translate);
 
-  template <typename T>
+  template <std::integral T>
   static std::optional<ReadResult<T>> HostTryReadUX(const Core::CPUThreadGuard& guard,
                                                     const u32 address, RequestedAddressSpace space);
   static std::optional<WriteResult> HostTryWriteUX(const Core::CPUThreadGuard& guard, const u32 var,

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -268,8 +268,8 @@ std::pair<u32, u32> Cache::GetCache(u32 addr, bool locked)
       lookup_table[(addr >> 5) & 0xfffff] = way;
 
     addrs[set][way] = addr;
-    valid[set] |= (1 << way);
-    modified[set] &= ~(1 << way);
+    Common::SetBit(way, valid[set]);
+    Common::ClearBit(way, modified[set]);
   }
 
   // update plru

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 
+#include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/Swap.h"
 #include "Core/Config/MainSettings.h"
@@ -242,7 +243,7 @@ std::pair<u32, u32> Cache::GetCache(u32 addr, bool locked)
     else
       way = s_way_from_plru[plru[set]];
 
-    if (valid[set] & (1 << way))
+    if (Common::ExtractBit(way, valid[set]))
     {
       // store the cache back to main memory
       if (modified[set] & (1 << way))
@@ -349,7 +350,7 @@ void Cache::DoState(PointerWrap& p)
     {
       for (u32 way = 0; way < CACHE_WAYS; way++)
       {
-        if ((valid[set] & (1 << way)) != 0)
+        if (Common::ExtractBit(way, valid[set]))
         {
           if (addrs[set][way] & CACHE_VMEM_BIT)
             lookup_table_vmem[(addrs[set][way] >> 5) & 0xfffff] = 0xff;
@@ -375,7 +376,7 @@ void Cache::DoState(PointerWrap& p)
     {
       for (u32 way = 0; way < CACHE_WAYS; way++)
       {
-        if ((valid[set] & (1 << way)) != 0)
+        if (Common::ExtractBit(way, valid[set]))
         {
           if (addrs[set][way] & CACHE_VMEM_BIT)
             lookup_table_vmem[(addrs[set][way] >> 5) & 0xfffff] = 0xff;

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/Debugger/PPCDebugInterface.h"
@@ -210,15 +211,15 @@ struct PowerPCState
     xer_so_ov = (new_xer.SO << 1) + new_xer.OV;
   }
 
-  u32 GetXER_SO() const { return xer_so_ov >> 1; }
+  bool GetXER_SO() const { return Common::ExtractBit<1>(xer_so_ov); }
 
-  void SetXER_SO(bool value) { xer_so_ov |= static_cast<u32>(value) << 1; }
+  void SetXER_SO(bool value) { Common::InsertBit<1>(xer_so_ov, value); }
 
-  u32 GetXER_OV() const { return xer_so_ov & 1; }
+  bool GetXER_OV() const { return Common::ExtractBit<0>(xer_so_ov); }
 
   void SetXER_OV(bool value)
   {
-    xer_so_ov = (xer_so_ov & 0xFE) | static_cast<u32>(value);
+    Common::InsertBit<0>(xer_so_ov, value);
     SetXER_SO(value);
   }
 

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Hash.h"
@@ -93,7 +94,7 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
   u32 comp_block_size = (u32)GetBlockCompressedSize(block_num);
   u64 offset = m_block_pointers[block_num] + m_data_offset;
 
-  if (offset & (1ULL << 63))
+  if (Common::ExtractBit<63>(offset))
   {
     if (comp_block_size != m_header.block_size)
       ERROR_LOG_FMT(DISCIO, "Uncompressed block with wrong size");

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -99,7 +99,7 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
     if (comp_block_size != m_header.block_size)
       ERROR_LOG_FMT(DISCIO, "Uncompressed block with wrong size");
     uncompressed = true;
-    offset &= ~(1ULL << 63);
+    Common::ClearBit<63>(offset);
   }
 
   // clear unused part of zlib buffer. maybe this can be deleted when it works fully.

--- a/Source/Core/DiscIO/TGCBlob.cpp
+++ b/Source/Core/DiscIO/TGCBlob.cpp
@@ -6,10 +6,10 @@
 #include <algorithm>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
+#include "Common/Concepts.h"
 #include "Common/IOFile.h"
 #include "Common/Swap.h"
 
@@ -33,11 +33,9 @@ void Replace(u64 offset, u64 size, u8* out_ptr, u64 replace_offset, u64 replace_
   }
 }
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 void Replace(u64 offset, u64 size, u8* out_ptr, u64 replace_offset, const T& replace_value)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
-
   const u8* replace_ptr = reinterpret_cast<const u8*>(&replace_value);
   Replace(offset, size, out_ptr, replace_offset, sizeof(T), replace_ptr);
 }

--- a/Source/Core/DiscIO/Volume.cpp
+++ b/Source/Core/DiscIO/Volume.cpp
@@ -8,11 +8,11 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Crypto/SHA1.h"
 #include "Common/StringUtil.h"
 
@@ -31,10 +31,9 @@ const IOS::ES::TicketReader Volume::INVALID_TICKET{};
 const IOS::ES::TMDReader Volume::INVALID_TMD{};
 const std::vector<u8> Volume::INVALID_CERT_CHAIN{};
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 static void AddToSyncHash(Common::SHA1::Context* context, const T& data)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
   context->Update(reinterpret_cast<const u8*>(&data), sizeof(data));
 }
 

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -20,6 +20,7 @@
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/Crypto/SHA1.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -47,11 +48,9 @@ static void PushBack(std::vector<u8>* vector, const u8* begin, const u8* end)
   std::copy(begin, end, vector->data() + offset_in_vector);
 }
 
-template <typename T>
+template <Common::TriviallyCopyable T>
 static void PushBack(std::vector<u8>* vector, const T& x)
 {
-  static_assert(std::is_trivially_copyable_v<T>);
-
   const u8* x_ptr = reinterpret_cast<const u8*>(&x);
   PushBack(vector, x_ptr, x_ptr + sizeof(T));
 }

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -23,6 +23,8 @@
 #include "Core/Core.h"
 #include "Core/State.h"
 
+#include "Common/BitUtils.h"
+
 #include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Resources.h"

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -16,21 +16,11 @@
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
 namespace ControllerEmu
 {
-class Control;
-
-class NumericSettingBase;
-struct NumericSettingDetails;
-
-template <typename T>
-class NumericSetting;
-
-template <typename T>
-class SettingValue;
-
 using InputOverrideFunction = std::function<std::optional<ControlState>(
     const std::string_view group_name, const std::string_view control_name, ControlState state)>;
 
@@ -79,7 +69,7 @@ public:
   void AddInput(Translatability translate, std::string name, std::string ui_name);
   void AddOutput(Translatability translate, std::string name);
 
-  template <typename T>
+  template <SettingConstraint T>
   void AddSetting(SettingValue<T>* value, const NumericSettingDetails& details,
                   std::common_type_t<T> default_value_, std::common_type_t<T> min_value = {},
                   std::common_type_t<T> max_value = T(100))

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -18,6 +18,8 @@
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 class ControllerInterface;
 
 constexpr const char* DIRECTION_UP = _trans("Up");
@@ -210,17 +212,10 @@ public:
   std::vector<std::unique_ptr<ControlGroup>> groups;
 
   // Maps a float from -1.0..+1.0 to an integer in the provided range.
-  template <typename T, typename F>
+  template <std::integral T, std::floating_point F>
   static T MapFloat(F input_value, T zero_value, T neg_1_value = std::numeric_limits<T>::min(),
                     T pos_1_value = std::numeric_limits<T>::max())
   {
-    static_assert(std::is_integral<T>(), "T is only sane for int types.");
-    static_assert(std::is_floating_point<F>(), "F is only sane for float types.");
-
-    static_assert(std::numeric_limits<long long>::min() <= std::numeric_limits<T>::min() &&
-                      std::numeric_limits<long long>::max() >= std::numeric_limits<T>::max(),
-                  "long long is not a superset of T. use of std::llround is not sane.");
-
     // Here we round when converting from float to int.
     // After applying our deadzone, resizing, and reshaping math
     // we sometimes have a near-zero value which is slightly negative. (e.g. -0.0001)

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/IniFile.h"
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
@@ -19,6 +20,10 @@ enum class SettingType
   Double,
   Bool,
 };
+
+// NumericSetting is only implemented for int, double, and bool.
+template <class T>
+concept SettingConstraint = Common::SameAsAnyOf<T, int, double, bool>;
 
 enum class SettingVisibility
 {
@@ -88,18 +93,14 @@ protected:
   NumericSettingDetails m_details;
 };
 
-template <typename T>
+template <SettingConstraint T>
 class SettingValue;
 
-template <typename T>
+template <SettingConstraint T>
 class NumericSetting final : public NumericSettingBase
 {
 public:
   using ValueType = T;
-
-  static_assert(std::is_same<ValueType, int>() || std::is_same<ValueType, double>() ||
-                    std::is_same<ValueType, bool>(),
-                "NumericSetting is only implemented for int, double, and bool.");
 
   NumericSetting(SettingValue<ValueType>* value, const NumericSettingDetails& details,
                  ValueType default_value, ValueType min_value, ValueType max_value)
@@ -170,7 +171,7 @@ private:
   const ValueType m_max_value;
 };
 
-template <typename T>
+template <SettingConstraint T>
 class SettingValue
 {
   using ValueType = T;

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -8,6 +8,7 @@
 
 #include <SDL_events.h>
 
+#include "Common/BitUtils.h"
 #include "Common/Event.h"
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
@@ -705,7 +706,7 @@ ControlState Joystick::Axis::GetState() const
 
 ControlState Joystick::Hat::GetState() const
 {
-  return (SDL_JoystickGetHat(m_js, m_index) & (1 << m_direction)) > 0;
+  return Common::ExtractBit(m_direction, SDL_JoystickGetHat(m_js, m_index));
 }
 #ifdef USE_SDL_GAMECONTROLLER
 

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -11,6 +11,7 @@
 
 #include <fmt/format.h>
 
+#include "Common/BitUtils.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Host.h"
@@ -430,7 +431,7 @@ KeyboardMouse::Key::Key(Display* const display, KeyCode keycode, const char* key
 
 ControlState KeyboardMouse::Key::GetState() const
 {
-  return (m_keyboard[m_keycode / 8] & (1 << (m_keycode % 8))) != 0;
+  return Common::ExtractBit(m_keycode % 8, m_keyboard[m_keycode / 8]);
 }
 
 KeyboardMouse::Button::Button(unsigned int index, unsigned int* buttons)
@@ -441,7 +442,7 @@ KeyboardMouse::Button::Button(unsigned int index, unsigned int* buttons)
 
 ControlState KeyboardMouse::Button::GetState() const
 {
-  return ((*m_buttons & (1 << m_index)) != 0);
+  return Common::ExtractBit(m_index, *m_buttons);
 }
 
 KeyboardMouse::Cursor::Cursor(u8 index, bool positive, const float* cursor)

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -311,16 +311,16 @@ void KeyboardMouse::UpdateInput()
     switch (event.xcookie.evtype)
     {
     case XI_ButtonPress:
-      m_state.buttons |= 1 << (dev_event->detail - 1);
+      Common::SetBit(dev_event->detail - 1, m_state.buttons);
       break;
     case XI_ButtonRelease:
-      m_state.buttons &= ~(1 << (dev_event->detail - 1));
+      Common::ClearBit(dev_event->detail - 1, m_state.buttons);
       break;
     case XI_KeyPress:
-      m_state.keyboard[dev_event->detail / 8] |= 1 << (dev_event->detail % 8);
+      Common::SetBit(dev_event->detail % 8, m_state.keyboard[dev_event->detail / 8]);
       break;
     case XI_KeyRelease:
-      m_state.keyboard[dev_event->detail / 8] &= ~(1 << (dev_event->detail % 8));
+      Common::ClearBit(dev_event->detail % 8, m_state.keyboard[dev_event->detail / 8]);
       break;
     case XI_RawMotion:
     {

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -8,6 +8,7 @@
 #include <bit>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -204,7 +205,7 @@ u32 StateManager::UnsetTexture(ID3D11ShaderResourceView* srv)
     if (m_current.textures[index] == srv)
     {
       SetTexture(index, nullptr);
-      mask |= 1 << index;
+      Common::SetBit(index, mask);
     }
   }
 
@@ -217,7 +218,7 @@ void StateManager::SetTextureByMask(u32 textureSlotMask, ID3D11ShaderResourceVie
   {
     const int index = std::countr_zero(textureSlotMask);
     SetTexture(index, srv);
-    textureSlotMask &= ~(1 << index);
+    Common::ClearBit(index, textureSlotMask);
   }
 }
 

--- a/Source/Core/VideoBackends/Metal/MTLPipeline.h
+++ b/Source/Core/VideoBackends/Metal/MTLPipeline.h
@@ -5,6 +5,8 @@
 
 #include <Metal/Metal.h>
 
+#include "Common/BitUtils.h"
+
 #include "VideoBackends/Metal/MRCHelpers.h"
 #include "VideoBackends/Metal/MTLObjectCache.h"
 #include "VideoBackends/Metal/MTLShader.h"
@@ -41,8 +43,14 @@ public:
   u32 GetSamplers() const { return m_reflection.samplers; }
   u32 GetVertexBuffers() const { return m_reflection.vertex_buffers; }
   u32 GetFragmentBuffers() const { return m_reflection.fragment_buffers; }
-  bool UsesVertexBuffer(u32 index) const { return m_reflection.vertex_buffers & (1 << index); }
-  bool UsesFragmentBuffer(u32 index) const { return m_reflection.fragment_buffers & (1 << index); }
+  bool UsesVertexBuffer(u32 index) const
+  {
+    return Common::ExtractBit(index, m_reflection.vertex_buffers);
+  }
+  bool UsesFragmentBuffer(u32 index) const
+  {
+    return Common::ExtractBit(index, m_reflection.fragment_buffers);
+  }
 
 private:
   MRCOwned<id<MTLRenderPipelineState>> m_pipeline;
@@ -61,8 +69,8 @@ public:
                            MRCOwned<id<MTLComputePipelineState>> pipeline);
 
   id<MTLComputePipelineState> GetComputePipeline() const { return m_compute_pipeline; }
-  bool UsesTexture(u32 index) const { return m_textures & (1 << index); }
-  bool UsesBuffer(u32 index) const { return m_buffers & (1 << index); }
+  bool UsesTexture(u32 index) const { return Common::ExtractBit(index, m_textures); }
+  bool UsesBuffer(u32 index) const { return Common::ExtractBit(index, m_buffers); }
 
 private:
   MRCOwned<id<MTLComputePipelineState>> m_compute_pipeline;

--- a/Source/Core/VideoBackends/Metal/MTLPipeline.mm
+++ b/Source/Core/VideoBackends/Metal/MTLPipeline.mm
@@ -4,11 +4,12 @@
 #include "VideoBackends/Metal/MTLPipeline.h"
 
 #include "Common/MsgHandler.h"
+#include "Common/BitUtils.h"
 
 static void MarkAsUsed(u32* list, u32 start, u32 length)
 {
   for (u32 i = start; i < start + length; ++i)
-    *list |= 1 << i;
+    Common::SetBit(i, *list);
 }
 
 static void GetArguments(NSArray<MTLArgument*>* arguments, u32* textures, u32* samplers,

--- a/Source/Core/VideoBackends/Metal/MTLStateTracker.mm
+++ b/Source/Core/VideoBackends/Metal/MTLStateTracker.mm
@@ -8,6 +8,7 @@
 #include <mutex>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 
 #include "Core/System.h"
 
@@ -542,7 +543,7 @@ void Metal::StateTracker::SetTexture(u32 idx, id<MTLTexture> texture)
   if (m_state.textures[idx] != texture)
   {
     m_state.textures[idx] = texture;
-    m_dirty_textures |= 1 << idx;
+    Common::SetBit(idx, m_dirty_textures);
   }
 }
 
@@ -552,7 +553,7 @@ void Metal::StateTracker::SetSamplerForce(u32 idx, const SamplerState& sampler)
   m_state.sampler_min_lod[idx] = sampler.tm1.min_lod;
   m_state.sampler_max_lod[idx] = sampler.tm1.max_lod;
   m_state.sampler_states[idx] = sampler;
-  m_dirty_samplers |= 1 << idx;
+  Common::SetBit(idx, m_dirty_samplers);
 }
 
 void Metal::StateTracker::SetSampler(u32 idx, const SamplerState& sampler)
@@ -578,7 +579,7 @@ void Metal::StateTracker::UnbindTexture(id<MTLTexture> texture)
     if (m_state.textures[i] == texture)
     {
       m_state.textures[i] = m_dummy_texture;
-      m_dirty_textures |= 1 << i;
+      Common::SetBit(i, m_dirty_textures);
     }
   }
 }

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -344,7 +345,7 @@ void TransformColor(const InputVertexData* src, OutputVertexData* dst)
       u8 mask = colorchan.GetFullLightMask();
       for (int i = 0; i < 8; ++i)
       {
-        if (mask & (1 << i))
+        if (Common::ExtractBit(i, mask))
           LightColor(dst->mvPosition, dst->normal[0], i, colorchan, lightCol);
       }
 
@@ -378,7 +379,7 @@ void TransformColor(const InputVertexData* src, OutputVertexData* dst)
       u8 mask = alphachan.GetFullLightMask();
       for (int i = 0; i < 8; ++i)
       {
-        if (mask & (1 << i))
+        if (Common::ExtractBit(i, mask))
           LightAlpha(dst->mvPosition, dst->normal[0], i, alphachan, lightCol);
       }
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonFuncs.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -5,6 +5,7 @@
 
 #include <cstring>
 
+#include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "VideoCommon/BPMemory.h"
@@ -113,11 +114,8 @@ void GeometryShaderManager::SetLinePtWidthChanged()
 void GeometryShaderManager::SetTexCoordChanged(u8 texmapid)
 {
   TCoordInfo& tc = bpmem.texcoords[texmapid];
-  int bitmask = 1 << texmapid;
-  constants.texoffset[0] &= ~bitmask;
-  constants.texoffset[0] |= tc.s.line_offset << texmapid;
-  constants.texoffset[1] &= ~bitmask;
-  constants.texoffset[1] |= tc.s.point_offset << texmapid;
+  Common::InsertBit(texmapid, constants.texoffset[0], tc.s.line_offset);
+  Common::InsertBit(texmapid, constants.texoffset[1], tc.s.point_offset);
   dirty = true;
 }
 

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
@@ -7,9 +7,11 @@
 #include "Common/StringUtil.h"
 #include "VideoCommon/TextureCacheBase.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 namespace
 {
-template <typename T, std::enable_if_t<std::is_base_of_v<FBTarget, T>, int> = 0>
+template <std::derived_from<FBTarget> T>
 std::optional<T> DeserializeFBTargetFromConfig(const picojson::object& obj, std::string_view prefix)
 {
   T fb;

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -3,6 +3,7 @@
 
 #include "VideoCommon/OnScreenUI.h"
 
+#include "Common/BitUtils.h"
 #include "Common/EnumMap.h"
 #include "Common/Profiler.h"
 #include "Common/Timer.h"
@@ -396,7 +397,7 @@ void OnScreenUI::SetMousePress(u32 button_mask)
   auto lock = GetImGuiLock();
 
   for (size_t i = 0; i < std::size(ImGui::GetIO().MouseDown); i++)
-    ImGui::GetIO().MouseDown[i] = (button_mask & (1u << i)) != 0;
+    ImGui::GetIO().MouseDown[i] = Common::ExtractBit(i, button_mask);
 }
 
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/OpcodeDecoding.h
+++ b/Source/Core/VideoCommon/OpcodeDecoding.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <type_traits>
-
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/EnumFormatter.h"
@@ -12,6 +10,8 @@
 #include "Common/Swap.h"
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/VertexLoaderBase.h"
+
+#include "Common/Future/CppLibConcepts.h"
 
 struct CPState;
 class DataReader;
@@ -118,7 +118,7 @@ public:
 namespace detail
 {
 // Main logic; split so that the main RunCommand can call OnCommand with the returned size.
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<Callback, T>>>
+template <std::derived_from<Callback> T>
 static DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& callback)
 {
   if (available < 1)
@@ -248,7 +248,7 @@ static DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& cal
 }
 }  // namespace detail
 
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<Callback, T>>>
+template <std::derived_from<Callback> T>
 DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& callback)
 {
   const u32 size = detail::RunCommand(data, available, callback);
@@ -259,7 +259,7 @@ DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& callback)
   return size;
 }
 
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<Callback, T>>>
+template <std::derived_from<Callback> T>
 DOLPHIN_FORCE_INLINE u32 Run(const u8* data, u32 available, T& callback)
 {
   u32 size = 0;

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -225,7 +225,7 @@ static void UnserializePipelineUid(const SerializedUidType& uid, UidType& real_u
   real_uid.blending_state.hex = uid.blending_state_bits;
 }
 
-template <ShaderStage stage, typename K, typename T>
+template <ShaderStage stage, Common::TriviallyCopyable K, typename T>
 void ShaderCache::LoadShaderCache(T& cache, APIType api_type, const char* type, bool include_gameid)
 {
   class CacheReader : public LinearDiskCacheReader<K, u8>
@@ -275,7 +275,7 @@ void ShaderCache::ClearShaderCache(T& cache)
   cache.shader_map.clear();
 }
 
-template <typename KeyType, typename DiskKeyType, typename T>
+template <typename KeyType, Common::TriviallyCopyable DiskKeyType, typename T>
 void ShaderCache::LoadPipelineCache(T& cache, LinearDiskCache<DiskKeyType, u8>& disk_cache,
                                     APIType api_type, const char* type, bool include_gameid)
 {

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -171,11 +171,11 @@ private:
   void QueueUberPipelineCompile(const GXUberPipelineUid& uid, u32 priority);
 
   // Populating various caches.
-  template <ShaderStage stage, typename K, typename T>
+  template <ShaderStage stage, Common::TriviallyCopyable K, typename T>
   void LoadShaderCache(T& cache, APIType api_type, const char* type, bool include_gameid);
   template <typename T>
   void ClearShaderCache(T& cache);
-  template <typename KeyType, typename DiskKeyType, typename T>
+  template <typename KeyType, Common::TriviallyCopyable DiskKeyType, typename T>
   void LoadPipelineCache(T& cache, LinearDiskCache<DiskKeyType, u8>& disk_cache, APIType api_type,
                          const char* type, bool include_gameid);
   template <typename T, typename Y>

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -7,13 +7,13 @@
 #include <functional>
 #include <iterator>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 #include <fmt/format.h>
 
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
+#include "Common/Concepts.h"
 #include "Common/EnumMap.h"
 #include "Common/StringUtil.h"
 #include "Common/TypeUtils.h"
@@ -65,13 +65,10 @@ public:
  * NOTE: Because LinearDiskCache reads and writes the storage associated with a ShaderUid instance,
  * ShaderUid must be trivially copyable.
  */
-template <class uid_data>
+template <Common::TriviallyCopyable uid_data>
 class ShaderUid : public ShaderGeneratorInterface
 {
 public:
-  static_assert(std::is_trivially_copyable_v<uid_data>,
-                "uid_data must be a trivially copyable type");
-
   ShaderUid() { memset(GetUidData(), 0, GetUidDataSize()); }
 
   bool operator==(const ShaderUid& obj) const

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -13,6 +13,8 @@
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderUtils.h"
 
+#include "Common/Future/CppLibConcepts.h"
+
 // warning: mapping buffer should be disabled to use this
 #define LOG_NORM()  // PRIM_LOG("norm: {} {} {}, ", ((float*)g_vertex_manager_write_ptr)[-3],
                     // ((float*)g_vertex_manager_write_ptr)[-2],
@@ -68,11 +70,9 @@ void Normal_ReadDirect(VertexLoader* loader)
   DataSkip<N * 3 * sizeof(T)>();
 }
 
-template <typename I, typename T, u32 N, u32 Offset>
+template <std::unsigned_integral I, typename T, u32 N, u32 Offset>
 void Normal_ReadIndex_Offset(VertexLoader* loader)
 {
-  static_assert(std::is_unsigned_v<I>, "Only unsigned I is sane!");
-
   const auto index = DataRead<I>();
   const auto data =
       reinterpret_cast<const T*>(VertexLoaderManager::cached_arraybases[CPArray::Normal] +
@@ -80,13 +80,13 @@ void Normal_ReadIndex_Offset(VertexLoader* loader)
   ReadIndirect<T, N * 3, Offset * 3>(loader, data);
 }
 
-template <typename I, typename T, u32 N>
+template <std::unsigned_integral I, typename T, u32 N>
 void Normal_ReadIndex(VertexLoader* loader)
 {
   Normal_ReadIndex_Offset<I, T, N, 0>(loader);
 }
 
-template <typename I, typename T>
+template <std::unsigned_integral I, typename T>
 void Normal_ReadIndex_Indices3(VertexLoader* loader)
 {
   Normal_ReadIndex_Offset<I, T, 1, 0>(loader);

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -4,7 +4,6 @@
 #include "VideoCommon/VertexLoader_Position.h"
 
 #include <limits>
-#include <type_traits>
 
 #include "Common/CommonTypes.h"
 #include "Common/EnumMap.h"
@@ -14,6 +13,8 @@
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderUtils.h"
 #include "VideoCommon/VideoCommon.h"
+
+#include "Common/Future/CppLibConcepts.h"
 
 namespace
 {
@@ -46,10 +47,9 @@ void Pos_ReadDirect(VertexLoader* loader)
   LOG_VTX();
 }
 
-template <typename I, typename T, int N>
+template <std::unsigned_integral I, typename T, int N>
 void Pos_ReadIndex(VertexLoader* loader)
 {
-  static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
   static_assert(N <= 3, "N > 3 is not sane!");
 
   const auto index = DataRead<I>();

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -3,14 +3,14 @@
 
 #include "VideoCommon/VertexLoader_TextCoord.h"
 
-#include <type_traits>
-
 #include "Common/CommonTypes.h"
 #include "Common/Swap.h"
 
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderUtils.h"
+
+#include "Common/Future/CppLibConcepts.h"
 
 namespace
 {
@@ -42,11 +42,9 @@ void TexCoord_ReadDirect(VertexLoader* loader)
   ++loader->m_tcIndex;
 }
 
-template <typename I, typename T, int N>
+template <std::unsigned_integral I, typename T, int N>
 void TexCoord_ReadIndex(VertexLoader* loader)
 {
-  static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
-
   const auto index = DataRead<I>();
   const auto data = reinterpret_cast<const T*>(
       VertexLoaderManager::cached_arraybases[CPArray::TexCoord0 + loader->m_tcIndex] +

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -85,12 +85,12 @@ inline u32 CompressZ16(u32 z24depth, DepthFormat format)
 
   u32 leading_ones = static_cast<u32>(std::countl_one(z24depth << 8));
   bool next_bit_is_one = false;  // AKA: Did we clamp leading_ones?
-  u32 exp_bits;
+  u32 exp_width;
 
   switch (format)
   {
   case DepthFormat::ZNEAR:
-    exp_bits = 2;
+    exp_width = 2;
     if (leading_ones >= 3u)
     {
       leading_ones = 3u;
@@ -98,7 +98,7 @@ inline u32 CompressZ16(u32 z24depth, DepthFormat format)
     }
     break;
   case DepthFormat::ZMID:
-    exp_bits = 3;
+    exp_width = 3;
     if (leading_ones >= 7u)
     {
       leading_ones = 7u;
@@ -106,7 +106,7 @@ inline u32 CompressZ16(u32 z24depth, DepthFormat format)
     }
     break;
   case DepthFormat::ZFAR:
-    exp_bits = 4;
+    exp_width = 4;
     if (leading_ones >= 12u)
     {
       // The hardware implementation only uses values 0 to 12 in the exponent
@@ -118,18 +118,18 @@ inline u32 CompressZ16(u32 z24depth, DepthFormat format)
     return z24depth >> 8;
   }
 
-  u32 mantissa_bits = 16 - exp_bits;
+  u32 mantissa_width = 16 - exp_width;
 
   // Calculate which bits we need to extract from z24depth for our mantissa
-  u32 top = std::max<u32>(24 - leading_ones, mantissa_bits);
+  u32 top = std::max<u32>(24 - leading_ones, mantissa_width);
   if (!next_bit_is_one)
   {
     top -= 1;  // We know the next bit is zero, so we don't need to include it.
   }
-  u32 bottom = top - mantissa_bits;
+  u32 bottom = top - mantissa_width;
 
-  u32 exponent = leading_ones << mantissa_bits;  // Upper bits contain exponent
-  u32 mantissa = Common::ExtractBits(z24depth, bottom, top - 1);
+  u32 exponent = leading_ones << mantissa_width;  // Upper bits contain exponent
+  u32 mantissa = Common::ExtractBitsU(mantissa_width, bottom, z24depth);
 
   return exponent | mantissa;
 }


### PR DESCRIPTION
In preparation for PR #10846, I have updated BitUtils.h and will be attempting to re-license it under the Creative Commons Zero 1.0 public-domain-equivalent license.  This header is a home to many "best practice" and/or "common sense" functions which are useful in a multitude of places across the Dolphin Emulator project.  Some implementations even outright state they originate from, or can be found verbatim on sources such as the public domain https://graphics.stanford.edu/~seander/bithacks.html, http://aggregate.org/MAGIC, or http://www.open-std.org (in the case of the BitCast idiom).

I have found the following individuals to have made notable contributions to this header, and would appreciate their cooperation in this re-licensing:

@lioncash 
 - BitSize
   - Common-sense implementation
   - Can subjectively be improved as a std::integral_constant
 - ExtractBit (variable)
   - Common-sense implementation
   - Added DEBUG_ASSERT, now returns bool
 - ExtractBit (constant)
   - Common-sense implementation
 - ExtractBits (variable)
   - Replaced with ExtractBitsU (new implementation)
 - ExtractBits (constant)
   - Replaced with ExtractBitsU (new implementation)
 - RotateLeft
   - To be removed with transition to C++20
 - RotateRight
   - To be removed with transition to C++20
 - BitCast
   - To be removed with transition to C++20

@jordan-woyak 
 - SetBit (variable)
   - Replaced with InsertBit (new implementation)
 - SetBit (constant)
   - Replaced with InsertBit (new implementation)
 - BitCastPtrType
 - BitCastPtr
 - ExpandValue

@Techjar 
 - BitCastToArray
 - BitCastFromArray
 
@blubberdiblub 
 - IsValidLowMask
 
@Pokechu22 
 - FlagBit
 - Flags

@merryhime 
 - CountTrailingZerosConst
   - To be removed with transition to C++20
 - CountTrailingZeros (64-bit)
   - To be removed with transition to C++20
 - CountTrailingZeros (32-bit)
   - To be removed with transition to C++20

@MerryMage 
 - CountLeadingZeros (64-bit)
   - To be removed with transition to C++20
 - CountLeadingZeros (32-bit)
   - To be removed with transition to C++20

Misc.
 - jordan-woyak for the probable originator of CountLeadingZeros implementation
 - @shuffle2 for further abstracting things with CountLeadingZerosConst function (moved code)
 - @Tilka for fixing C++23 deprecation in BitCast implementation
 - @tellowkrinkle and @iWeaker for minor contributions
 
Though not strictly necessary, it may also be worth changing BitUtilsTest.cpp to be a CC0-1.0 licensed file as well.  In that case, I will also need cooperation from @spycrab and @ligfx, among other duplicate contributors.

For a more long form analysis of the [history of this file](https://github.com/dolphin-emu/dolphin/commits/master/Source/Core/Common/BitUtils.h), I have compiled the following:

=========================================================================

Jan 14, 2017 - lioncash - Common: Add bit utility header
 - BitSize
 - ExtractBit (variable)
 - ExtractBit (constant)
 - ExtractBits (variable)
 - ExtractBits (constant)

Jun 22, 2017 - blubberdiblub - Add function testing whether a bitmask is valid.
 - IsValidLowMask

Mar 31, 2018 - lioncache - CommonFuncs: Generify rotation functions and move them to BitUtils.h
 - RotateLeft (moved and rewritten, but common-sense implementation)
 - RotateRight (moved and rewritten, but common-sense implementation)

May 10, 2018 - lioncache - BitUtils: Add C++14/C++17 compatible equivalent of std::bit_cast from C++2a
 - BitCast (the implementation of which heavily borrows from https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0476r2.html)

Feb 2, 2019 - jordan-woyak - WiimoteEmu: Major renaming and cleanup.
 - SetBit (variable) (moved from Core/HW/WiimoteEmu/WiimoteEmu.cpp : line 1213.  Originally implemented in commit 42b9392784b5aae840d818c7c4d349c184e6f035, also by jordan-woyak.)

Feb 2, 2019 - jordan-woyak - WiimoteEmu: Code cleanups.
 - BitCastPtrType
 - BitCastPtr
 - Fixed SetBit bug if sizeof(T) > sizeof(int)

Dec 22, 2019 - Techjar - Common/BitUtils: Implement BitCast(To|From)Array
 - BitCastToArray
 - BitCastFromArray

Jan 4, 2020 - Pokechu22 - Implement Broadway GPIOs
 - FlagBit
 - Flags

Feb 17, 2020 - jordan-woyak - InputCommon: Add types to ControllerEmu that represent raw controller inputs and calibration data to calculate normalized input values.
 - SetBit (constant)
 - ExpandValue

Dec 27, 2020 - MerryMage - BitUtils: Add CountLeadingZeros
 - CountLeadingZeros (64-bit)
   - \_\_GNUC\_\_ preprocessor blocks used \_\_builtin_clzll (common sense)
   - \_MSC\_VER && \_M\_ARM64 preprocessor blocks used \_CountLeadingZeros (common sense)
   - \_MSC\_VER && \_M\_x86_64 preprocessor blocks used an inverted \_BitScanReverse64 (common sense)
   - Fallback implementation clearly more inspired by existing implementation in "Core/Common/MathUtil.h : line 157".  Implementation in "Core/Common/Arm64Emitter.cpp : line 29" is similar, but un-optimal, thus discarded.
     - Core/Common/MathUtil.h's implementation of CountLeadingZeros history
       - 10d57a3402cc698cffc4bf3299113073264eb314 - Mar 5, 2013 - jordan-woyak - Use standard binary multiple unit symbols for game size display.
       - fe3a54d7fd8c85960fed04d28d5dedbc1d94845d - Mar 5, 2013 - jordan-woyak - Buildfix!
       - b34991c4c344832d92183a5cd9d7b591e99e74be - Mar 5, 2013 - jordan-woyak - Buildfix for real.
       - 2095641af0348b40befe91f4f36d81d992f822e2 - Mar 5, 2013 - jordan-woyak - OK, seriously, buildfix. I shouldn't even have commit access!
       - edd9d0e0ef6898a0528ac6389e93e9fca6132ff6 - Mar 19, 2013 - lioncash - Clean up more space/tab mismatches in AudioCommon, Common, and VideoCommon.
       - 94da4e1aa29a68cb723898a63bd01568bbbd8c4f - Feb 26, 2014 - degasus - MathUtil: Change Log2 return value to int
       - 4f02132f9323a147c68b7dc1a79a62be33c1f170 - Mar 4, 2014 - Sonicadvance1 - Make our architecture defines less stupid.
       - f69e6ef16f1d27059e524a537f0b685081091b97 - Sep 3, 2014 - lioncash - Common: Remove unnecessary define check in Log2
       - 94c20db36968bfcef67d43203ad19c4876f439d3 - Sep 8, 2014 - FioraAeterna - Rename Log2 and add IsPow2 to MathUtils for future use
       - 3570c7f03a2aa90aa634f96c0af1969af610f14d - Jun 24, 2016 - delroth - Reformat all the things. Have fun with merge conflicts.
       - e1a3e41bf33bf6a366760ede17c2e3bd2b106116 - Jun 7, 2017 - shuffle2 - fix various instances of -1 being assigned to unsigned types
     - Core/Common/Arm64Emitter.cpp's implementation of CountLeadingZeros history
       - 05b72c5d31f8c3b04744e62626594847ab1d68c2 - Jun 7, 2015 - Sonicadvance1 - [AArch64] Upstream PPSSPP's emitter changes.
       - 3570c7f03a2aa90aa634f96c0af1969af610f14d - Jun 24, 2016 - delroth - Reformat all the things. Have fun with merge conflicts.
       - 91cefe6c8a4e42498573a12fce4c6633ba4ae780 - Mar 23, 2018 - lioncash - Arm64Emitter: Make IsImmArithmetic, IsImmLogical, FPImm8ToFloat, and FPImm8FromFloat internally linked
 - CountLeadingZeros (32-bit)

Dec 28, 2020 - iWeaker authored and leoetlino committed - BitUtils: Fix uint64_t gcc compile (Linux)
  - Fixes exactly what the commit title says

Jan 3, 2021 - MerryMage - BitUtils: __builtin_clz is undefined when value == 0
  - Fixes exactly what the commit title says

Jan 10, 2021 - shuffle2 - BitUtils: initialize variables
  - Fixes exactly what the commit title says

Jan 10, 2021 - shuffle2 - BitUtils: loosen clz to inline on msvc/arm64
  - CONSTEXPR_FROM_INTRINSIC (now removed)

Jan 10, 2021 - shuffle2 - BitUtils: cleanup constexpr usage for msvc clz
  - CountLeadingZerosConst
  - Reworked CountLeadingZeros fallback method

Jul 4, 2021 - delroth - treewide: convert GPLv2+ license info to SPDX tags
  - Fixes exactly what the commit title says

Jul 10, 2021 - JosJuice - JitArm64: Turn IsImmLogical into a constexpr constructor
  - LargestPowerOf2Divisor (tweaked and moved from Arm64Emitter.cpp) (now removed)
    - Core/Common/Arm64Emitter.cpp's implementation history
      - 05b72c5d31f8c3b04744e62626594847ab1d68c2 - Jun 7, 2015 - Sonicadvance1 - [AArch64] Upstream PPSSPP's emitter changes.
      - 91cefe6c8a4e42498573a12fce4c6633ba4ae780 - Mar 23, 2018 - lioncash - Arm64Emitter: Make IsImmArithmetic, IsImmLogical, FPImm8ToFloat, and FPImm8FromFloat internally linked

Jun 12, 2022 - Tilka - Common: replace std::aligned_storage_t with alignas
  - Modifies BitCast

Jul 10, 2022 - merryhime - BitUtils: Implement CountTrailingZeros
  - CountTrailingZerosConst
  - CountTrailingZeros (64-bit)
  - CountTrailingZeros (32-bit)

Jul 10, 2022 - tellowkrinkle - Common: Fix CountTrailingZeros for weird compilers
  - Modifies CountTrailingZeros (32-bit)

Aug 5, 2022 - JosJuice - Common: Remove unused stuff from BitUtils.h
  - Removes LargestPowerOf2Divisor