### PR TITLE
Include tangent/binormal cache in savestates and simplify saving CP state

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -94,7 +94,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 151;  // Last changed in PR 11125
+constexpr u32 STATE_VERSION = 152;  // Last changed in PR 11131
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -15,24 +15,6 @@
 CPState g_main_cp_state;
 CPState g_preprocess_cp_state;
 
-void DoCPState(PointerWrap& p)
-{
-  // We don't save g_preprocess_cp_state separately because the GPU should be
-  // synced around state save/load.
-  p.DoArray(g_main_cp_state.array_bases);
-  p.DoArray(g_main_cp_state.array_strides);
-  p.Do(g_main_cp_state.matrix_index_a);
-  p.Do(g_main_cp_state.matrix_index_b);
-  p.Do(g_main_cp_state.vtx_desc);
-  p.DoArray(g_main_cp_state.vtx_attr);
-  p.DoMarker("CP Memory");
-  if (p.IsReadMode())
-  {
-    CopyPreprocessCPStateFromMain();
-    VertexLoaderManager::g_bases_dirty = true;
-  }
-}
-
 void CopyPreprocessCPStateFromMain()
 {
   std::memcpy(&g_preprocess_cp_state, &g_main_cp_state, sizeof(CPState));

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -658,8 +658,6 @@ class PointerWrap;
 extern CPState g_main_cp_state;
 extern CPState g_preprocess_cp_state;
 
-void DoCPState(PointerWrap& p);
-
 void CopyPreprocessCPStateFromMain();
 
 std::pair<std::string, std::string> GetCPRegInfo(u8 cmd, u32 value);

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -123,6 +123,7 @@ struct entry
 
 void MarkAllDirty()
 {
+  g_bases_dirty = true;
   g_main_vat_dirty = BitSet8::AllTrue(8);
   g_preprocess_vat_dirty = BitSet8::AllTrue(8);
 }

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -557,10 +557,6 @@ void VertexManagerBase::DoState(PointerWrap& p)
   {
     // Flush old vertex data before loading state.
     Flush();
-
-    // Clear all caches that touch RAM
-    // (? these don't appear to touch any emulation state that gets saved. moved to on load only.)
-    VertexLoaderManager::MarkAllDirty();
   }
 
   p.Do(m_zslope);

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -564,6 +564,8 @@ void VertexManagerBase::DoState(PointerWrap& p)
   }
 
   p.Do(m_zslope);
+  p.Do(VertexLoaderManager::tangent_cache);
+  p.Do(VertexLoaderManager::binormal_cache);
 }
 
 void VertexManagerBase::CalculateZSlope(NativeVertexFormat* format)

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -18,6 +18,7 @@
 #include "VideoCommon/TMEM.h"
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/TextureDecoder.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/XFMemory.h"
@@ -38,7 +39,12 @@ void VideoCommon_DoState(PointerWrap& p)
   p.DoMarker("BP Memory");
 
   // CP Memory
-  DoCPState(p);
+  // We don't save g_preprocess_cp_state separately because the GPU should be
+  // synced around state save/load.
+  p.Do(g_main_cp_state);
+  p.DoMarker("CP Memory");
+  if (p.IsReadMode())
+    CopyPreprocessCPStateFromMain();
 
   // XF Memory
   p.Do(xfmem);
@@ -90,5 +96,6 @@ void VideoCommon_DoState(PointerWrap& p)
   {
     // Inform backend of new state from registers.
     BPReload();
+    VertexLoaderManager::MarkAllDirty();
   }
 }


### PR DESCRIPTION
The tangent/binormal cache theoretically matters for RS2/RS3 (see #10584), although in practice these games reconfigure it each frame so it shouldn't matter for savestates.

The CP state part is simplification only; there should be no change in behavior from it.