### PR TITLE
JitCache: Erase address from noSpeculativeConstantsAddresses when block is invalidated.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -59,6 +59,7 @@ void JitBaseBlockCache::Clear()
 #endif
   m_jit.js.fifoWriteAddresses.clear();
   m_jit.js.pairedQuantizeAddresses.clear();
+  m_jit.js.noSpeculativeConstantsAddresses.clear();
   for (auto& e : block_map)
   {
     DestroyBlock(e.second);
@@ -255,6 +256,7 @@ void JitBaseBlockCache::InvalidateICacheInternal(u32 physical_address, u32 addre
       {
         m_jit.js.fifoWriteAddresses.erase(i);
         m_jit.js.pairedQuantizeAddresses.erase(i);
+        m_jit.js.noSpeculativeConstantsAddresses.erase(i);
       }
     }
   }


### PR DESCRIPTION
I'm not sure if there's any particular reason this isn't done? This looked wrong to me skimming over it the code, at least.