### PR TITLE
PPCAnalyst: Remove unused variables and methods in BlockStats and BlockRegStats.

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -88,49 +88,7 @@ struct BlockStats
 
 struct BlockRegStats
 {
-  short firstRead[32];
-  short firstWrite[32];
-  short lastRead[32];
-  short lastWrite[32];
-  short numReads[32];
-  short numWrites[32];
-
   bool any;
-  bool anyTimer;
-
-  int GetTotalNumAccesses(int reg) const { return numReads[reg] + numWrites[reg]; }
-  int GetUseRange(int reg) const
-  {
-    return std::max(lastRead[reg], lastWrite[reg]) - std::min(firstRead[reg], firstWrite[reg]);
-  }
-
-  bool IsUsed(int reg) const { return (numReads[reg] + numWrites[reg]) > 0; }
-  void SetInputRegister(int reg, short opindex)
-  {
-    if (firstRead[reg] == -1)
-      firstRead[reg] = opindex;
-    lastRead[reg] = opindex;
-    numReads[reg]++;
-  }
-
-  void SetOutputRegister(int reg, short opindex)
-  {
-    if (firstWrite[reg] == -1)
-      firstWrite[reg] = opindex;
-    lastWrite[reg] = opindex;
-    numWrites[reg]++;
-  }
-
-  void Clear()
-  {
-    for (int i = 0; i < 32; ++i)
-    {
-      firstRead[i] = -1;
-      firstWrite[i] = -1;
-      numReads[i] = 0;
-      numWrites[i] = 0;
-    }
-  }
 };
 
 using CodeBuffer = std::vector<CodeOp>;
@@ -233,8 +191,7 @@ private:
   void ReorderInstructionsCore(u32 instructions, CodeOp* code, bool reverse,
                                ReorderType type) const;
   void ReorderInstructions(u32 instructions, CodeOp* code) const;
-  void SetInstructionStats(CodeBlock* block, CodeOp* code, const GekkoOPInfo* opinfo,
-                           u32 index) const;
+  void SetInstructionStats(CodeBlock* block, CodeOp* code, const GekkoOPInfo* opinfo) const;
   bool IsBusyWaitLoop(CodeBlock* block, CodeOp* code, size_t instructions) const;
 
   // Options

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -81,8 +81,6 @@ struct CodeOp  // 16B
 
 struct BlockStats
 {
-  bool isFirstBlockOfFunction;
-  bool isLastBlockOfFunction;
   int numCycles;
 };
 

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -181,12 +181,6 @@ void JITWidget::Update()
     // Add stats to the end of the ppc box since it's generally the shortest.
     ppc_disasm << std::dec << std::endl;
 
-    // Add some generic analysis
-    if (st.isFirstBlockOfFunction)
-      ppc_disasm << "(first block of function)" << std::endl;
-    if (st.isLastBlockOfFunction)
-      ppc_disasm << "(last block of function)" << std::endl;
-
     ppc_disasm << st.numCycles << " estimated cycles" << std::endl;
 
     ppc_disasm << "Num instr: PPC: " << code_block.m_num_instructions


### PR DESCRIPTION
None of this seems to be used for anything. I'm guessing it was used at some point in the past?