### PR TITLE
Jit64: Convert constantGqr to std::array.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -948,7 +948,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   js.downcountAmount = 0;
   js.skipInstructions = 0;
   js.carryFlag = CarryFlag::InPPCState;
-  js.constantGqr.clear();
+  js.constantGqrValid = BitSet8();
 
   // Assume that GQR values don't change often at runtime. Many paired-heavy games use largely float
   // loads and stores,
@@ -979,6 +979,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
         CMP_or_TEST(32, PPCSTATE(spr[SPR_GQR0 + gqr]), Imm32(value));
         J_CC(CC_NZ, target);
       }
+      js.constantGqrValid = gqr_static;
     }
   }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -83,7 +83,8 @@ protected:
     Gen::FixupBranch exceptionHandler;
 
     bool assumeNoPairedQuantize;
-    std::map<u8, u32> constantGqr;
+    BitSet8 constantGqrValid;
+    std::array<u32, 8> constantGqr;
     bool firstFPInstructionFound;
     bool isLastInstruction;
     int skipInstructions;


### PR DESCRIPTION
This being an std::map is completely unnecessary.