### PR TITLE
VideoInterface: Simplify saving VideoInterface

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -92,34 +92,7 @@ static constexpr u32 NUM_HALF_LINES_FOR_SI_POLL = (7 * 2) + 1;  // this is how l
 
 void DoState(PointerWrap& p)
 {
-  auto& state = Core::System::GetInstance().GetVideoInterfaceState().GetData();
-  p.Do(state.vertical_timing_register);
-  p.Do(state.display_control_register);
-  p.Do(state.h_timing_0);
-  p.Do(state.h_timing_1);
-  p.Do(state.vblank_timing_odd);
-  p.Do(state.vblank_timing_even);
-  p.Do(state.burst_blanking_odd);
-  p.Do(state.burst_blanking_even);
-  p.Do(state.xfb_info_top);
-  p.Do(state.xfb_info_bottom);
-  p.Do(state.xfb_3d_info_top);
-  p.Do(state.xfb_3d_info_bottom);
-  p.DoArray(state.interrupt_register);
-  p.DoArray(state.latch_register);
-  p.Do(state.picture_configuration);
-  p.Do(state.horizontal_scaling);
-  p.Do(state.filter_coef_tables);
-  p.Do(state.unknown_aa_register);
-  p.Do(state.clock);
-  p.Do(state.dtv_status);
-  p.Do(state.fb_width);
-  p.Do(state.border_hblank);
-  p.Do(state.ticks_last_line_start);
-  p.Do(state.half_line_count);
-  p.Do(state.half_line_of_next_si_poll);
-
-  UpdateParameters();
+  p.Do(Core::System::GetInstance().GetVideoInterfaceState().GetData());
 }
 
 // Executed after Init, before game boot

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -94,7 +94,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 152;  // Last changed in PR 11131
+constexpr u32 STATE_VERSION = 153;  // Last changed in PR 11137
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This PR simplifies the DoState() method of VideoInterface by saving/loading everything in 1 line (since all of the variables in the namespace are now contained in one struct that can be written to with p.do()).