### PR TITLE
Jit64: Fix single FPRF when !jo.accurateSinglePrecision

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -80,7 +80,7 @@ void Jit64::FinalizeSingleResult(X64Reg output, const OpArg& input, bool packed,
         MOVAPD(output, input);
     }
 
-    SetFPRFIfNeeded(input, true);
+    SetFPRFIfNeeded(input, false);
   }
 }
 


### PR DESCRIPTION
`jo.accurateSinglePrecision` is always true, so it's not like this matters much...