### PR TITLE
Jit64: Remove HandleNaNs's xmm_out parameter

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -126,8 +126,7 @@ public:
   void FinalizeSingleResult(Gen::X64Reg output, const Gen::OpArg& input, bool packed = true,
                             bool duplicate = false);
   void FinalizeDoubleResult(Gen::X64Reg output, const Gen::OpArg& input);
-  void HandleNaNs(UGeckoInstruction inst, Gen::X64Reg xmm_out, Gen::X64Reg xmm_in,
-                  Gen::X64Reg clobber);
+  void HandleNaNs(UGeckoInstruction inst, Gen::X64Reg xmm, Gen::X64Reg clobber);
 
   void MultiplyImmediate(u32 imm, int a, int d, bool overflow);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -77,8 +77,8 @@ void Jit64::ps_sum(UGeckoInstruction inst)
   default:
     PanicAlertFmt("ps_sum WTF!!!");
   }
-  HandleNaNs(inst, Rd, tmp, tmp == XMM1 ? XMM0 : XMM1);
-  FinalizeSingleResult(Rd, Rd);
+  HandleNaNs(inst, tmp, tmp == XMM1 ? XMM0 : XMM1);
+  FinalizeSingleResult(Rd, R(tmp));
 }
 
 void Jit64::ps_muls(UGeckoInstruction inst)
@@ -112,8 +112,8 @@ void Jit64::ps_muls(UGeckoInstruction inst)
   if (round_input)
     Force25BitPrecision(XMM1, R(XMM1), XMM0);
   MULPD(XMM1, Ra);
-  HandleNaNs(inst, Rd, XMM1, XMM0);
-  FinalizeSingleResult(Rd, Rd);
+  HandleNaNs(inst, XMM1, XMM0);
+  FinalizeSingleResult(Rd, R(XMM1));
 }
 
 void Jit64::ps_mergeXX(UGeckoInstruction inst)


### PR DESCRIPTION
All `HandleNaNs` does with the `xmm_out` parameter is emit `MOVAPD` at the end if `xmm_out != xmm`. The caller might as well do that themselves.