### PR TITLE
Jit64: Inline avx_op into fp_arith

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -752,38 +752,35 @@ void EmuCodeBlock::avx_op(void (XEmitter::*avxOp)(X64Reg, X64Reg, const OpArg&),
   {
     (this->*avxOp)(regOp, arg1.GetSimpleReg(), arg2);
   }
-  else if (arg2.IsSimpleReg(regOp))
-  {
-    if (reversible)
-    {
-      (this->*sseOp)(regOp, arg1);
-    }
-    else
-    {
-      // The ugly case: regOp == arg2 without AVX, or with arg1 == memory
-      if (!arg1.IsSimpleReg(XMM0))
-        MOVAPD(XMM0, arg1);
-      if (cpu_info.bAVX)
-      {
-        (this->*avxOp)(regOp, XMM0, arg2);
-      }
-      else
-      {
-        (this->*sseOp)(XMM0, arg2);
-        if (packed)
-          MOVAPD(regOp, R(XMM0));
-        else
-          MOVSD(regOp, R(XMM0));
-      }
-    }
-  }
-  else
+  else if (!arg2.IsSimpleReg(regOp))
   {
     if (packed)
       MOVAPD(regOp, arg1);
     else
       MOVSD(regOp, arg1);
     (this->*sseOp)(regOp, arg1 == arg2 ? R(regOp) : arg2);
+  }
+  else if (reversible)
+  {
+    (this->*sseOp)(regOp, arg1);
+  }
+  else
+  {
+    // The ugly case: regOp == arg2 without AVX, or with arg1 == memory
+    if (!arg1.IsSimpleReg(XMM0))
+      MOVAPD(XMM0, arg1);
+    if (cpu_info.bAVX)
+    {
+      (this->*avxOp)(regOp, XMM0, arg2);
+    }
+    else
+    {
+      (this->*sseOp)(XMM0, arg2);
+      if (packed)
+        MOVAPD(regOp, R(XMM0));
+      else
+        MOVSD(regOp, R(XMM0));
+    }
   }
 }
 
@@ -800,7 +797,12 @@ void EmuCodeBlock::avx_op(void (XEmitter::*avxOp)(X64Reg, X64Reg, const OpArg&, 
   {
     (this->*avxOp)(regOp, arg1.GetSimpleReg(), arg2, imm);
   }
-  else if (arg2.IsSimpleReg(regOp))
+  else if (!arg2.IsSimpleReg(regOp))
+  {
+    MOVAPD(regOp, arg1);
+    (this->*sseOp)(regOp, arg1 == arg2 ? R(regOp) : arg2, imm);
+  }
+  else
   {
     // The ugly case: regOp == arg2 without AVX, or with arg1 == memory
     if (!arg1.IsSimpleReg(XMM0))
@@ -815,11 +817,6 @@ void EmuCodeBlock::avx_op(void (XEmitter::*avxOp)(X64Reg, X64Reg, const OpArg&, 
       if (regOp != XMM0)
         MOVAPD(regOp, R(XMM0));
     }
-  }
-  else
-  {
-    MOVAPD(regOp, arg1);
-    (this->*sseOp)(regOp, arg1 == arg2 ? R(regOp) : arg2, imm);
   }
 }
 


### PR DESCRIPTION
This lets us avoid `avx_op`'s "ugly" case.