### PR TITLE
Check return values of ENet functions when sending packet.

### DIFF
--- a/Source/Core/Common/ENetUtil.cpp
+++ b/Source/Core/Common/ENetUtil.cpp
@@ -35,4 +35,11 @@ int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event)
   }
   return 0;
 }
+
+void SendPacket(ENetPeer* socket, const sf::Packet& packet, u8 channel_id)
+{
+  ENetPacket* epac =
+      enet_packet_create(packet.getData(), packet.getDataSize(), ENET_PACKET_FLAG_RELIABLE);
+  enet_peer_send(socket, channel_id, epac);
+}
 }  // namespace ENetUtil

--- a/Source/Core/Common/ENetUtil.h
+++ b/Source/Core/Common/ENetUtil.h
@@ -5,8 +5,13 @@
 
 #include <enet/enet.h>
 
+#include <SFML/Network/Packet.hpp>
+
+#include "Common/CommonTypes.h"
+
 namespace ENetUtil
 {
 void WakeupThread(ENetHost* host);
 int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event);
+void SendPacket(ENetPeer* socket, const sf::Packet& packet, u8 channel_id);
 }  // namespace ENetUtil

--- a/Source/Core/Common/ENetUtil.h
+++ b/Source/Core/Common/ENetUtil.h
@@ -13,5 +13,5 @@ namespace ENetUtil
 {
 void WakeupThread(ENetHost* host);
 int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event);
-void SendPacket(ENetPeer* socket, const sf::Packet& packet, u8 channel_id);
+bool SendPacket(ENetPeer* socket, const sf::Packet& packet, u8 channel_id);
 }  // namespace ENetUtil

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1465,9 +1465,7 @@ void NetPlayClient::OnGameDigestAbort()
 
 void NetPlayClient::Send(const sf::Packet& packet, const u8 channel_id)
 {
-  ENetPacket* epac =
-      enet_packet_create(packet.getData(), packet.getDataSize(), ENET_PACKET_FLAG_RELIABLE);
-  enet_peer_send(m_server, channel_id, epac);
+  ENetUtil::SendPacket(m_server, packet, channel_id);
 }
 
 void NetPlayClient::DisplayPlayersPing()

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -2008,9 +2008,7 @@ void NetPlayServer::SendToClients(const sf::Packet& packet, const PlayerId skip_
 
 void NetPlayServer::Send(ENetPeer* socket, const sf::Packet& packet, const u8 channel_id)
 {
-  ENetPacket* epac =
-      enet_packet_create(packet.getData(), packet.getDataSize(), ENET_PACKET_FLAG_RELIABLE);
-  enet_peer_send(socket, channel_id, epac);
+  ENetUtil::SendPacket(socket, packet, channel_id);
 }
 
 void NetPlayServer::KickPlayer(PlayerId player)


### PR DESCRIPTION
Someone on Discord said they had a crash in `enet_peer_send()`. I don't quite see how that would happen, but I suppose we should check the return values anyway and at least log errors.