### PR TITLE
Fix formatting in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -148,7 +148,8 @@ Additionally, you'll want to remove the global user directory if you don't plan 
 
 ## Command Line Usage
 
-```Usage: Dolphin.exe [options]... [FILE]...
+```
+Usage: Dolphin.exe [options]... [FILE]...
 
 Options:
   --version             show program's version number and exit
@@ -192,7 +193,8 @@ usage: dolphin-tool COMMAND -h
 commands supported: [convert, verify, header]
 ```
 
-```Usage: convert [options]... [FILE]...
+```
+Usage: convert [options]... [FILE]...
 
 Options:
   -h, --help            show this help message and exit


### PR DESCRIPTION
This unhides the dolphin-emu and dolphin-tool convert usage, which were hidden because the backticks preceding them were not on their own line.