### PR TITLE
DolphinQt: Make "All Devices" mapping hopefully less confusing.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -23,6 +23,7 @@ class QGroupBox;
 class QVBoxLayout;
 class QPushButton;
 class QTabWidget;
+class QToolButton;
 class QWidget;
 
 class MappingWindow final : public QDialog
@@ -98,7 +99,7 @@ private:
   QGroupBox* m_devices_box;
   QHBoxLayout* m_devices_layout;
   QComboBox* m_devices_combo;
-  QPushButton* m_devices_refresh;
+  QAction* m_all_devices_action;
 
   // Profiles
   QGroupBox* m_profiles_box;


### PR DESCRIPTION
The "All devices" option in the device list is confusing.
It's not a device selection. It only changes the behavior for the mapping buttons, allowing them to produce "full-path" input expressions for the non-selected device.
e.g. With "Keyboard Mouse" selected you can press a button on your PS5 controller to create an `SDL/0/PS5 Controller:Button 2` input expression with "All devices" activated.

I've moved the feature to a menu of the "Refresh" button to hopefully make it more apparent that it is a configuration mode and not a device selection.
The feature is disabled every time the dialog is opened (same as old behavior).
![image](https://user-images.githubusercontent.com/1768214/194781906-5c30eceb-4014-4fa8-ac0b-15f21795db0f.png)
