### PR TITLE
HW: Use unsigned indices in RegisterMMIO where applicable

### DIFF
--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -453,7 +453,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::InvalidWrite<u16>());
 
   // 32 bit reads/writes are a combination of two 16 bit accesses.
-  for (int i = 0; i < 0x1000; i += 4)
+  for (u32 i = 0; i < 0x1000; i += 4)
   {
     mmio->Register(base | i, MMIO::ReadToSmaller<u32>(mmio, base | i, base | (i + 2)),
                    MMIO::WriteToSmaller<u32>(mmio, base | i, base | (i + 2)));

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -142,7 +142,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::InvalidWrite<u32>());
 
   // 16 bit reads are based on 32 bit reads.
-  for (int i = 0; i < 0x1000; i += 4)
+  for (u32 i = 0; i < 0x1000; i += 4)
   {
     mmio->Register(base | i, MMIO::ReadToLarger<u16>(mmio, base | i, 16),
                    MMIO::InvalidWrite<u16>());

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -433,7 +433,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  }));
 
   // Map 8 bit reads (not writes) to 16 bit reads.
-  for (int i = 0; i < 0x1000; i += 2)
+  for (u32 i = 0; i < 0x1000; i += 2)
   {
     mmio->Register(base | i, MMIO::ReadToLarger<u8>(mmio, base | i, 8), MMIO::InvalidWrite<u8>());
     mmio->Register(base | (i + 1), MMIO::ReadToLarger<u8>(mmio, base | i, 0),
@@ -441,7 +441,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   }
 
   // Map 32 bit reads and writes to 16 bit reads and writes.
-  for (int i = 0; i < 0x1000; i += 4)
+  for (u32 i = 0; i < 0x1000; i += 4)
   {
     mmio->Register(base | i, MMIO::ReadToSmaller<u32>(mmio, base | i, base | (i + 2)),
                    MMIO::WriteToSmaller<u32>(mmio, base | i, base | (i + 2)));


### PR DESCRIPTION
`base` is an unsigned variable, so we can make things little more consistent by making the loop index unsigned so we aren't doing bit arithmetic with signed types.

Some other RegisterMMIO calls already use unsigned values for this sort of thing, so those don't need to be touched

No behavioral changes, just a nitpicky consistency thing.