### PR TITLE
VertexLoader: Remove unused functions

### DIFF
--- a/Source/Core/VideoCommon/VertexLoader_Color.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Color.cpp
@@ -186,10 +186,6 @@ f(EnumMap<TPipelineFunction, ColorFormat::RGBA8888> in)
 {
   return in;
 }
-constexpr EnumMap<u32, ColorFormat::RGBA8888> g(EnumMap<u32, ColorFormat::RGBA8888> in)
-{
-  return in;
-}
 
 template <typename T>
 using Table = EnumMap<EnumMap<T, ColorFormat::RGBA8888>, VertexComponentFormat::Index16>;

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -87,19 +87,9 @@ constexpr EnumMap<TPipelineFunction, CoordComponentCount::XYZ> e(TPipelineFuncti
 {
   return {xy, xyz};
 }
-constexpr EnumMap<u32, CoordComponentCount::XYZ> e(u32 xy, u32 xyz)
-{
-  return {xy, xyz};
-}
 
 constexpr EnumMap<EnumMap<TPipelineFunction, CoordComponentCount::XYZ>, ComponentFormat::Float>
 f(EnumMap<EnumMap<TPipelineFunction, CoordComponentCount::XYZ>, ComponentFormat::Float> in)
-{
-  return in;
-}
-
-constexpr EnumMap<EnumMap<u32, CoordComponentCount::XYZ>, ComponentFormat::Float>
-g(EnumMap<EnumMap<u32, CoordComponentCount::XYZ>, ComponentFormat::Float> in)
 {
   return in;
 }

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -76,19 +76,9 @@ constexpr EnumMap<TPipelineFunction, TexComponentCount::ST> e(TPipelineFunction 
 {
   return {s, st};
 }
-constexpr EnumMap<u32, TexComponentCount::ST> e(u32 s, u32 st)
-{
-  return {s, st};
-}
 
 constexpr EnumMap<EnumMap<TPipelineFunction, TexComponentCount::ST>, ComponentFormat::Float>
 f(EnumMap<EnumMap<TPipelineFunction, TexComponentCount::ST>, ComponentFormat::Float> in)
-{
-  return in;
-}
-
-constexpr EnumMap<EnumMap<u32, TexComponentCount::ST>, ComponentFormat::Float>
-g(EnumMap<EnumMap<u32, TexComponentCount::ST>, ComponentFormat::Float> in)
 {
   return in;
 }


### PR DESCRIPTION
These became obsolete in fdcd2b7d009cece6ad090143ce954aed713bb11c (#11066).