### PR TITLE
Tweak UpdateDisasmDialog and EmulationStateChanged.

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -931,7 +931,6 @@ void Callback_NewField(Core::System& system)
     {
       s_frame_step = false;
       system.GetCPU().Break();
-      CallOnStateChangedCallbacks(Core::GetState());
     }
   }
 

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -386,7 +386,6 @@ void PowerPCManager::SingleStep()
 void PowerPCManager::RunLoop()
 {
   m_cpu_core_base->Run();
-  Host_UpdateDisasmDialog();
 }
 
 u64 PowerPCManager::ReadFullTimeBaseValue() const

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -163,6 +163,10 @@ NetworkWidget::NetworkWidget(QWidget* parent) : QDockWidget(parent)
   ConnectWidgets();
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, &NetworkWidget::Update);
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
+    if (state == Core::State::Paused)
+      Update();
+  });
 
   connect(&Settings::Instance(), &Settings::NetworkVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -45,6 +45,10 @@ RegisterWidget::RegisterWidget(QWidget* parent)
   ConnectWidgets();
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, &RegisterWidget::Update);
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
+    if (state == Core::State::Paused)
+      Update();
+  });
 
   connect(&Settings::Instance(), &Settings::RegistersVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -40,6 +40,10 @@ ThreadWidget::ThreadWidget(QWidget* parent) : QDockWidget(parent)
   ConnectWidgets();
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, &ThreadWidget::Update);
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
+    if (state == Core::State::Paused)
+      Update();
+  });
 
   connect(&Settings::Instance(), &Settings::ThreadsVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -35,9 +35,6 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           [this](Core::State state) { OnEmulationStateChanged(state); });
 
-  connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this,
-          [this] { OnEmulationStateChanged(Core::GetState()); });
-
   connect(&Settings::Instance(), &Settings::DebugModeToggled, this, &ToolBar::OnDebugModeToggled);
 
   connect(&Settings::Instance(), &Settings::ToolBarVisibilityChanged, this, &ToolBar::setVisible);


### PR DESCRIPTION
Goal: Fix issues with frame advance spamming signals.  Decrease general signal spam (such as pausing triggering multiple signals that spam redundant UI updates. Fix erroneous UpdateDisasmDialog spam from PowerPC::RunLoop().

I'm not fully aware of what every widget needs, but I took inventory of them and made changes that seem ok.  At this point, getting ideas on what to test would be helpful. Hopefully I'm not overlooking something major.

**1.** Remove UpdateDisasmDialog from PowerPC RunLoop(). It's triggered by too much, such as RunAsCPUThread.
It appeared this was mostly used to report pauses/breaks. EmulationStateChanged does not report a pause triggered by a break. I figured seeing if I could get everything to work after removing it from RunLoop was a good place to start, and it doesn't appear to take much effort to accomplish.

**2.** Move Pause On Break reporting to EmulationStateChanged, via CPU break() if the State was running before the break. It was not reporting pause on break. Should correctly cover the pausing aspect of the removed RunLoop() trigger.

**3.** Add EmulationStateChanged slot to RegisterWidget, NetworkWidget, and ThreadWidget as they were relying on the RunLoop signal for pause on break.

**4.** Change Toolbar to EmulatiuonStateChanged, as it should now function properly with the break() change.

When I was looking at everything, most widgets using EmulationStateChanged fit into one of two categories.  Either they only care about Initialization state (from EmulationStateChanged, or they require UpdateDisasmDialog along with the EmulationStateChanged signal (which covers everything).  The only one that looks different is Toolbar, which used UpdateDisasmDialog only for receiving  a pause on break, as EmulationStateChanged was not doing so.  Therefore the changes don't affect much overall.

UpdateDisasmDialog was using RunLoop to trigger on quite a bit. Standard pause, pause from a break, etc.  I wanted to move pausing to EmulationStateChanged, since that's an obvious place for it.  Widgets that used UpdateDisasmDialog without also having  EmulationStateChanged (threadwidget) typically only wanted to be updated on a pause or actions that took place while paused (steps). By using 
```
connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
    if (state == Core::State::Paused)
      Update();
  });
```
Transitioning to a pause is covered, without causing new issues.  UpdateDisasmDialog is still there for other signals.