### PR TITLE
Remove most uses of StringFromFormat in favor of fmt

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/TAP_Unix.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAP_Unix.cpp
@@ -9,6 +9,8 @@
 #include <unistd.h>
 #endif
 
+#include <fmt/format.h>
+
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/HW/EXI/EXI_Device.h"
@@ -50,7 +52,7 @@ bool CEXIETHERNET::TAPNetworkInterface::Activate()
   const int MAX_INTERFACES = 32;
   for (int i = 0; i < MAX_INTERFACES; ++i)
   {
-    strncpy(ifr.ifr_name, StringFromFormat("Dolphin%d", i).c_str(), IFNAMSIZ);
+    fmt::format_to_n(ifr.ifr_name, IFNAMSIZ, "Dolphin{}", i);
 
     int err;
     if ((err = ioctl(fd, TUNSETIFF, (void*)&ifr)) < 0)

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <cmath>
 
+#include <fmt/format.h>
+
 #include <QApplication>
 #include <QClipboard>
 #include <QHeaderView>
@@ -656,7 +658,7 @@ void CodeViewWidget::OnCopyFunction()
   for (u32 addr = start; addr != end; addr += 4)
   {
     const std::string disasm = PowerPC::debug_interface.Disassemble(addr);
-    text += StringFromFormat("%08x: ", addr) + disasm + "\r\n";
+    fmt::format_to(std::back_inserter(text), "{:08x}: {}\r\n", addr, disasm);
   }
 
   QApplication::clipboard()->setText(QString::fromStdString(text));

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -5,6 +5,8 @@
 
 #include <chrono>
 
+#include <fmt/format.h>
+
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QLabel>
@@ -16,7 +18,6 @@
 #include <QWidget>
 
 #include "Common/Event.h"
-#include "Common/StringUtil.h"
 #include "Core/Core.h"
 #include "Core/Debugger/Debugger_SymbolMap.h"
 #include "Core/HW/CPU.h"
@@ -389,7 +390,7 @@ void CodeWidget::UpdateFunctionCalls(const Common::Symbol* symbol)
     if (call_symbol)
     {
       const QString name =
-          QString::fromStdString(StringFromFormat("> %s (%08x)", call_symbol->name.c_str(), addr));
+          QString::fromStdString(fmt::format("> {} ({:08x})", call_symbol->name, addr));
 
       if (name.toUpper().indexOf(filter.toUpper()) == -1)
         continue;
@@ -413,8 +414,8 @@ void CodeWidget::UpdateFunctionCallers(const Common::Symbol* symbol)
 
     if (caller_symbol)
     {
-      const QString name = QString::fromStdString(
-          StringFromFormat("< %s (%08x)", caller_symbol->name.c_str(), addr));
+      const QString name =
+          QString::fromStdString(fmt::format("< {} ({:08x})", caller_symbol->name, addr));
 
       if (name.toUpper().indexOf(filter.toUpper()) == -1)
         continue;

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -9,8 +9,9 @@
 #include <QTextBrowser>
 #include <QVBoxLayout>
 
+#include <fmt/format.h>
+
 #include "Common/GekkoDisassembler.h"
-#include "Common/StringUtil.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "UICommon/Disassembler.h"
 
@@ -214,7 +215,7 @@ void JITWidget::Update()
   {
     m_host_asm_widget->setHtml(
         QStringLiteral("<pre>%1</pre>")
-            .arg(QString::fromStdString(StringFromFormat("(non-code address: %08x)", m_address))));
+            .arg(QString::fromStdString(fmt::format("(non-code address: {:08x})", m_address))));
     m_ppc_asm_widget->setHtml(QStringLiteral("<i>---</i>"));
   }
 }

--- a/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
+++ b/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
@@ -11,9 +11,9 @@
 #include <QPushButton>
 
 #include <discord_rpc.h>
+#include <fmt/format.h>
 
 #include "Common/HttpRequest.h"
-#include "Common/StringUtil.h"
 
 DiscordJoinRequestDialog::DiscordJoinRequestDialog(QWidget* parent, const std::string& id,
                                                    const std::string& discord_tag,
@@ -27,8 +27,8 @@ DiscordJoinRequestDialog::DiscordJoinRequestDialog(QWidget* parent, const std::s
 
   if (!avatar.empty())
   {
-    const std::string avatar_endpoint = StringFromFormat(
-        "https://cdn.discordapp.com/avatars/%s/%s.png", id.c_str(), avatar.c_str());
+    const std::string avatar_endpoint =
+        fmt::format("https://cdn.discordapp.com/avatars/{}/{}.png", id, avatar);
 
     Common::HttpRequest request;
     Common::HttpRequest::Response response = request.Get(avatar_endpoint);

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -22,6 +22,8 @@
 #include <cmath>
 #include <utility>
 
+#include <fmt/format.h>
+
 #include <QDesktopServices>
 #include <QDir>
 #include <QErrorMessage>
@@ -714,9 +716,9 @@ void GameList::OpenGCSaveFolder()
     {
     case ExpansionInterface::EXIDeviceType::MemoryCardFolder:
     {
-      std::string path = StringFromFormat("%s/%s/%s", File::GetUserPath(D_GCUSER_IDX).c_str(),
-                                          Config::GetDirectoryForRegion(game->GetRegion()),
-                                          slot == Slot::A ? "Card A" : "Card B");
+      std::string path = fmt::format("{}/{}/{}", File::GetUserPath(D_GCUSER_IDX),
+                                     Config::GetDirectoryForRegion(game->GetRegion()),
+                                     slot == Slot::A ? "Card A" : "Card B");
 
       std::string override_path = Config::Get(Config::GetInfoForGCIPathOverride(slot));
 

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -7,6 +7,8 @@
 #include <cmath>
 #include <thread>
 
+#include <fmt/format.h>
+
 #include <QApplication>
 #include <QCoreApplication>
 
@@ -367,7 +369,7 @@ void HotkeyScheduler::Run()
           OSD::AddMessage("Internal Resolution: Native");
           break;
         default:
-          OSD::AddMessage(StringFromFormat("Internal Resolution: %dx", g_Config.iEFBScale));
+          OSD::AddMessage(fmt::format("Internal Resolution: {}x", g_Config.iEFBScale));
           break;
         }
       };
@@ -415,20 +417,19 @@ void HotkeyScheduler::Run()
       {
         const bool new_value = !Config::Get(Config::GFX_HACK_EFB_ACCESS_ENABLE);
         Config::SetCurrent(Config::GFX_HACK_EFB_ACCESS_ENABLE, new_value);
-        OSD::AddMessage(
-            StringFromFormat("%s EFB Access from CPU", new_value ? "Skip" : "Don't skip"));
+        OSD::AddMessage(fmt::format("{} EFB Access from CPU", new_value ? "Skip" : "Don't skip"));
       }
 
       if (IsHotkey(HK_TOGGLE_EFBCOPIES))
       {
         const bool new_value = !Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);
         Config::SetCurrent(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, new_value);
-        OSD::AddMessage(StringFromFormat("Copy EFB: %s", new_value ? "to Texture" : "to RAM"));
+        OSD::AddMessage(fmt::format("Copy EFB: {}", new_value ? "to Texture" : "to RAM"));
       }
 
       auto ShowXFBCopies = []() {
-        OSD::AddMessage(StringFromFormat(
-            "Copy XFB: %s%s", Config::Get(Config::GFX_HACK_IMMEDIATE_XFB) ? " (Immediate)" : "",
+        OSD::AddMessage(fmt::format(
+            "Copy XFB: {}{}", Config::Get(Config::GFX_HACK_IMMEDIATE_XFB) ? " (Immediate)" : "",
             Config::Get(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM) ? "to Texture" : "to RAM"));
       };
 
@@ -448,7 +449,7 @@ void HotkeyScheduler::Run()
       {
         const bool new_value = !Config::Get(Config::GFX_DISABLE_FOG);
         Config::SetCurrent(Config::GFX_DISABLE_FOG, new_value);
-        OSD::AddMessage(StringFromFormat("Fog: %s", new_value ? "Enabled" : "Disabled"));
+        OSD::AddMessage(fmt::format("Fog: {}", new_value ? "Enabled" : "Disabled"));
       }
 
       if (IsHotkey(HK_TOGGLE_DUMPTEXTURES))
@@ -461,10 +462,9 @@ void HotkeyScheduler::Run()
 
       auto ShowEmulationSpeed = []() {
         const float emulation_speed = Config::Get(Config::MAIN_EMULATION_SPEED);
-        OSD::AddMessage(
-            emulation_speed <= 0 ?
-                "Speed Limit: Unlimited" :
-                StringFromFormat("Speed Limit: %li%%", std::lround(emulation_speed * 100.f)));
+        OSD::AddMessage(emulation_speed <= 0 ?
+                            "Speed Limit: Unlimited" :
+                            fmt::format("Speed Limit: {}%", std::lround(emulation_speed * 100.f)));
       };
 
       if (IsHotkey(HK_DECREASE_EMULATION_SPEED))
@@ -569,7 +569,7 @@ void HotkeyScheduler::Run()
     {
       const bool new_value = !Config::Get(Config::FREE_LOOK_ENABLED);
       Config::SetCurrent(Config::FREE_LOOK_ENABLED, new_value);
-      OSD::AddMessage(StringFromFormat("Free Look: %s", new_value ? "Enabled" : "Disabled"));
+      OSD::AddMessage(fmt::format("Free Look: {}", new_value ? "Enabled" : "Disabled"));
     }
 
     // Savestates

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -16,6 +16,8 @@
 #include <QVBoxLayout>
 #include <QWindow>
 
+#include <fmt/format.h>
+
 #include <future>
 #include <optional>
 #include <variant>
@@ -1346,8 +1348,8 @@ void MainWindow::SetStateSlot(int slot)
   Settings::Instance().SetStateSlot(slot);
   m_state_slot = slot;
 
-  Core::DisplayMessage(StringFromFormat("Selected slot %d - %s", m_state_slot,
-                                        State::GetInfoStringOfSlot(m_state_slot, false).c_str()),
+  Core::DisplayMessage(fmt::format("Selected slot {} - {}", m_state_slot,
+                                   State::GetInfoStringOfSlot(m_state_slot, false)),
                        2500);
 }
 

--- a/Source/Core/DolphinQt/NetPlay/ChunkedProgressDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/ChunkedProgressDialog.cpp
@@ -7,14 +7,14 @@
 #include <cmath>
 #include <functional>
 
+#include <fmt/format.h>
+
 #include <QDialogButtonBox>
 #include <QGroupBox>
 #include <QLabel>
 #include <QProgressBar>
 #include <QPushButton>
 #include <QVBoxLayout>
-
-#include "Common/StringUtil.h"
 
 #include "Core/NetPlayClient.h"
 #include "Core/NetPlayServer.h"
@@ -134,8 +134,8 @@ void ChunkedProgressDialog::SetProgress(const int pid, const u64 progress)
 
   m_status_labels[pid]->setText(tr("%1[%2]: %3/%4 MiB")
                                     .arg(player_name, QString::number(pid),
-                                         QString::fromStdString(StringFromFormat("%.2f", acquired)),
-                                         QString::fromStdString(StringFromFormat("%.2f", total))));
+                                         QString::fromStdString(fmt::format("{:.2f}", acquired)),
+                                         QString::fromStdString(fmt::format("{:.2f}", total))));
   m_progress_bars[pid]->setValue(prog);
 }
 

--- a/Source/Core/DolphinQt/Translation.cpp
+++ b/Source/Core/DolphinQt/Translation.cpp
@@ -3,13 +3,16 @@
 
 #include "DolphinQt/Translation.h"
 
-#include <QApplication>
-#include <QLocale>
-#include <QTranslator>
 #include <algorithm>
 #include <cstring>
 #include <iterator>
 #include <string>
+
+#include <fmt/format.h>
+
+#include <QApplication>
+#include <QLocale>
+#include <QTranslator>
 
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -275,15 +278,14 @@ static bool TryInstallTranslator(const QString& exact_language_code)
     std::string lang = qlang.toStdString();
     auto filename =
 #if defined _WIN32
-        File::GetExeDirectory() + StringFromFormat("/Languages/%s.mo", lang.c_str())
+        fmt::format("{}/Languages/{}.mo", File::GetExeDirectory(), lang)
 #elif defined __APPLE__
-        File::GetBundleDirectory() +
-        StringFromFormat("/Contents/Resources/%s.lproj/dolphin-emu.mo", lang.c_str())
+        fmt::format("{}/Contents/Resources/{}.lproj/dolphin-emu.mo", File::GetBundleDirectory(),
+                    lang)
 #elif defined LINUX_LOCAL_DEV
-        File::GetExeDirectory() +
-        StringFromFormat("/../Source/Core/DolphinQt/%s/dolphin-emu.mo", lang.c_str())
+        fmt::format("{}/../Source/Core/DolphinQt/{}/dolphin-emu.mo", File::GetExeDirectory(), lang)
 #else
-        StringFromFormat(DATA_DIR "/../locale/%s/LC_MESSAGES/dolphin-emu.mo", lang.c_str())
+        fmt::format("{}/../locale/{}/LC_MESSAGES/dolphin-emu.mo", DATA_DIR, lang)
 #endif
         ;
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
@@ -205,17 +205,10 @@ const char* VkResultToString(VkResult res)
 }
 
 void LogVulkanResult(Common::Log::LogLevel level, const char* func_name, VkResult res,
-                     const char* msg, ...)
+                     const char* msg)
 {
-  std::va_list ap;
-  va_start(ap, msg);
-  std::string real_msg = StringFromFormatV(msg, ap);
-  va_end(ap);
-
-  real_msg = fmt::format("({}) {} ({}: {})", func_name, real_msg, static_cast<int>(res),
-                         VkResultToString(res));
-
-  GENERIC_LOG_FMT(Common::Log::LogType::VIDEO, level, "{}", real_msg);
+  GENERIC_LOG_FMT(Common::Log::LogType::VIDEO, level, "({}) {} ({}: {})", func_name, msg,
+                  static_cast<int>(res), VkResultToString(res));
 }
 
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -48,9 +48,9 @@ void UnloadVulkanLibrary();
 
 const char* VkResultToString(VkResult res);
 void LogVulkanResult(Common::Log::LogLevel level, const char* func_name, VkResult res,
-                     const char* msg, ...);
+                     const char* msg);
 
-#define LOG_VULKAN_ERROR(res, ...)                                                                 \
-  LogVulkanResult(Common::Log::LogLevel::LERROR, __func__, res __VA_OPT__(, ) __VA_ARGS__)
+#define LOG_VULKAN_ERROR(res, msg)                                                                 \
+  LogVulkanResult(Common::Log::LogLevel::LERROR, __func__, res, msg)
 
 }  // namespace Vulkan

--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -5,6 +5,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
@@ -64,8 +66,8 @@ static std::string CodeToHeader(const std::vector<u16>& code, const std::string&
   header.append("#define NUM_UCODES 1\n\n");
   std::string filename_without_extension;
   SplitPath(filename, nullptr, &filename_without_extension, nullptr);
-  header.append(StringFromFormat("const char* UCODE_NAMES[NUM_UCODES] = {\"%s\"};\n\n",
-                                 filename_without_extension.c_str()));
+  header.append(fmt::format("const char* UCODE_NAMES[NUM_UCODES] = {{\"{}\"}};\n\n",
+                            filename_without_extension));
   header.append("const unsigned short dsp_code[NUM_UCODES][0x1000] = {\n");
 
   header.append("\t{\n\t\t");
@@ -73,7 +75,7 @@ static std::string CodeToHeader(const std::vector<u16>& code, const std::string&
   {
     if (j && ((j & 15) == 0))
       header.append("\n\t\t");
-    header.append(StringFromFormat("0x%04x, ", code_padded[j]));
+    header.append(fmt::format("{:#06x}, ", code_padded[j]));
   }
   header.append("\n\t},\n");
 
@@ -98,14 +100,14 @@ static std::string CodesToHeader(const std::vector<std::vector<u16>>& codes,
 
   std::string header;
   header.reserve(reserve_size * 4);
-  header.append(StringFromFormat("#define NUM_UCODES %zu\n\n", codes.size()));
+  header.append(fmt::format("#define NUM_UCODES {}\n\n", codes.size()));
   header.append("const char* UCODE_NAMES[NUM_UCODES] = {\n");
   for (const std::string& in_filename : filenames)
   {
     std::string filename;
     if (!SplitPath(in_filename, nullptr, &filename, nullptr))
       filename = in_filename;
-    header.append(StringFromFormat("\t\"%s\",\n", filename.c_str()));
+    header.append(fmt::format("\t\"{}\",\n", filename));
   }
   header.append("};\n\n");
   header.append("const unsigned short dsp_code[NUM_UCODES][0x1000] = {\n");
@@ -120,7 +122,7 @@ static std::string CodesToHeader(const std::vector<std::vector<u16>>& codes,
     {
       if (j && ((j & 15) == 0))
         header.append("\n\t\t");
-      header.append(StringFromFormat("0x%04x, ", codes_padded[i][j]));
+      header.append(fmt::format("{:#06x}, ", codes_padded[i][j]));
     }
     header.append("\n\t},\n");
   }
@@ -152,7 +154,7 @@ static void PrintResults(const std::string& input_name, const std::string& outpu
   std::string results("Start:\n");
   for (int initial_reg = 0; initial_reg < 32; initial_reg++)
   {
-    results.append(StringFromFormat("%02x %04x ", initial_reg, reg_vector.at(initial_reg)));
+    results.append(fmt::format("{:02x} {:04x} ", initial_reg, reg_vector.at(initial_reg)));
     if ((initial_reg + 1) % 8 == 0)
       results.append("\n");
   }
@@ -166,9 +168,9 @@ static void PrintResults(const std::string& input_name, const std::string& outpu
     u16 current_reg;
     u16 last_reg;
     u32 htemp;
-    // results.append(StringFromFormat("Step %3d: (CW 0x%04x) UC:%03d\n", step, 0x8fff+step,
+    // results.append(fmt::format("Step {:3d}: (CW {:#06x}) UC:{:03d}\n", step, 0x8fff+step,
     // (step-1)/32));
-    results.append(StringFromFormat("Step %3d:\n", step));
+    results.append(fmt::format("Step {:3d}:\n", step));
     for (int reg = 0; reg < 32; reg++)
     {
       if (reg >= 0x0c && reg <= 0x0f)
@@ -210,8 +212,8 @@ static void PrintResults(const std::string& input_name, const std::string& outpu
       }
       if (last_reg != current_reg)
       {
-        results.append(StringFromFormat("%02x %-7s: %04x %04x\n", reg, DSP::pdregname(reg),
-                                        last_reg, current_reg));
+        results.append(fmt::format("{:02x} {:7s}: {:04x} {:04x}\n", reg, DSP::pdregname(reg),
+                                   last_reg, current_reg));
         changed = true;
       }
     }


### PR DESCRIPTION
`StringFromFormat` uses `printf` strings.  There are still 2 remaining places where it is used: CubebUtils.cpp (where it's formatting a printf-style message from a library) and HLE_OS.cpp (where it's formatting a printf-style message from games).