### PR TITLE
AudioCommon: Pass Core::System to AudioCommon functions.

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -13,23 +13,28 @@
 
 class Mixer;
 
+namespace Core
+{
+class System;
+}
+
 namespace AudioCommon
 {
-void InitSoundStream();
-void PostInitSoundStream();
-void ShutdownSoundStream();
+void InitSoundStream(Core::System& system);
+void PostInitSoundStream(Core::System& system);
+void ShutdownSoundStream(Core::System& system);
 std::string GetDefaultSoundBackend();
 std::vector<std::string> GetSoundBackends();
 DPL2Quality GetDefaultDPL2Quality();
 bool SupportsDPL2Decoder(std::string_view backend);
 bool SupportsLatencyControl(std::string_view backend);
 bool SupportsVolumeChanges(std::string_view backend);
-void UpdateSoundStream();
-void SetSoundStreamRunning(bool running);
-void SendAIBuffer(const short* samples, unsigned int num_samples);
-void StartAudioDump();
-void StopAudioDump();
-void IncreaseVolume(unsigned short offset);
-void DecreaseVolume(unsigned short offset);
-void ToggleMuteVolume();
+void UpdateSoundStream(Core::System& system);
+void SetSoundStreamRunning(Core::System& system, bool running);
+void SendAIBuffer(Core::System& system, const short* samples, unsigned int num_samples);
+void StartAudioDump(Core::System& system);
+void StopAudioDump(Core::System& system);
+void IncreaseVolume(Core::System& system, unsigned short offset);
+void DecreaseVolume(Core::System& system, unsigned short offset);
+void ToggleMuteVolume(Core::System& system);
 }  // namespace AudioCommon

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -14,6 +14,7 @@
 #include "Core/Host.h"
 #include "Core/PowerPC/GDBStub.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 #include "VideoCommon/Fifo.h"
 
 namespace CPU
@@ -193,7 +194,7 @@ static void RunAdjacentSystems(bool running)
   Fifo::EmulatorState(running);
   // Core is responsible for shutting down the sound stream.
   if (s_state != State::PowerDown)
-    AudioCommon::SetSoundStreamRunning(running);
+    AudioCommon::SetSoundStreamRunning(Core::System::GetInstance(), running);
 }
 
 void Stop()

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -414,7 +414,8 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   mmio->Register(
       base | AUDIO_DMA_CONTROL_LEN, MMIO::DirectRead<u16>(&state.audio_dma.AudioDMAControl.Hex),
       MMIO::ComplexWrite<u16>([](u32, u16 val) {
-        auto& state = Core::System::GetInstance().GetDSPState().GetData();
+        auto& system = Core::System::GetInstance();
+        auto& state = system.GetDSPState().GetData();
         bool already_enabled = state.audio_dma.AudioDMAControl.Enable;
         state.audio_dma.AudioDMAControl.Hex = val;
 
@@ -512,7 +513,8 @@ void UpdateDSPSlice(int cycles)
 // This happens at 4 khz, since 32 bytes at 4khz = 4 bytes at 32 khz (16bit stereo pcm)
 void UpdateAudioDMA()
 {
-  auto& state = Core::System::GetInstance().GetDSPState().GetData();
+  auto& system = Core::System::GetInstance();
+  auto& state = system.GetDSPState().GetData();
 
   static short zero_samples[8 * 2] = {0};
   if (state.audio_dma.AudioDMAControl.Enable)
@@ -521,7 +523,7 @@ void UpdateAudioDMA()
     // external audio fifo in the emulator, to be mixed with the disc
     // streaming output.
     void* address = Memory::GetPointer(state.audio_dma.current_source_address);
-    AudioCommon::SendAIBuffer(reinterpret_cast<short*>(address), 8);
+    AudioCommon::SendAIBuffer(system, reinterpret_cast<short*>(address), 8);
 
     if (state.audio_dma.remaining_blocks_count != 0)
     {
@@ -539,7 +541,7 @@ void UpdateAudioDMA()
   }
   else
   {
-    AudioCommon::SendAIBuffer(&zero_samples[0], 8);
+    AudioCommon::SendAIBuffer(system, &zero_samples[0], 8);
   }
 }
 

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -30,6 +30,7 @@
 #include "Core/IOS/USB/Bluetooth/BTBase.h"
 #include "Core/IOS/USB/Bluetooth/BTReal.h"
 #include "Core/State.h"
+#include "Core/System.h"
 #include "Core/WiiUtils.h"
 
 #ifdef HAS_LIBMGBA
@@ -353,7 +354,7 @@ void HotkeyScheduler::Run()
 
       if (IsHotkey(HK_VOLUME_TOGGLE_MUTE))
       {
-        AudioCommon::ToggleMuteVolume();
+        AudioCommon::ToggleMuteVolume(Core::System::GetInstance());
         ShowVolume();
       }
 

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -36,6 +36,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/NetPlayClient.h"
 #include "Core/NetPlayServer.h"
+#include "Core/System.h"
 
 #include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
@@ -384,13 +385,13 @@ void Settings::SetVolume(int volume)
 
 void Settings::IncreaseVolume(int volume)
 {
-  AudioCommon::IncreaseVolume(volume);
+  AudioCommon::IncreaseVolume(Core::System::GetInstance(), volume);
   emit VolumeChanged(GetVolume());
 }
 
 void Settings::DecreaseVolume(int volume)
 {
-  AudioCommon::DecreaseVolume(volume);
+  AudioCommon::DecreaseVolume(Core::System::GetInstance(), volume);
   emit VolumeChanged(GetVolume());
 }
 

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -23,6 +23,7 @@
 
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
+#include "Core/System.h"
 
 #include "DolphinQt/Config/SettingsWindow.h"
 #include "DolphinQt/Settings.h"
@@ -328,7 +329,7 @@ void AudioPane::SaveSettings()
   Config::SetBaseOrCurrent(Config::MAIN_WASAPI_DEVICE, device);
 #endif
 
-  AudioCommon::UpdateSoundStream();
+  AudioCommon::UpdateSoundStream(Core::System::GetInstance());
 }
 
 void AudioPane::OnDspChanged()


### PR DESCRIPTION
The other side of the global state elimination, actually pass around the System class instead of fetching the global instance.