### PR TITLE
HW: Pass System to MMIO handlers.

### DIFF
--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -1168,10 +1168,10 @@ public:
   }
 
   template <typename T, typename... Args>
-  void ABI_CallLambdaC(const std::function<T(Args...)>* f, u32 p1)
+  void ABI_CallLambdaPC(const std::function<T(Args...)>* f, void* p1, u32 p2)
   {
     auto trampoline = &XEmitter::CallLambdaTrampoline<T, Args...>;
-    ABI_CallFunctionPC(trampoline, reinterpret_cast<const void*>(f), p1);
+    ABI_CallFunctionPPC(trampoline, reinterpret_cast<const void*>(f), p1, p2);
   }
 };  // class XEmitter
 

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -640,8 +640,8 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base, bool is_wii)
 {
   auto& state = Core::System::GetInstance().GetDVDInterfaceState().GetData();
   mmio->Register(base | DI_STATUS_REGISTER, MMIO::DirectRead<u32>(&state.DISR.Hex),
-                 MMIO::ComplexWrite<u32>([](u32, u32 val) {
-                   auto& state = Core::System::GetInstance().GetDVDInterfaceState().GetData();
+                 MMIO::ComplexWrite<u32>([](Core::System& system, u32, u32 val) {
+                   auto& state = system.GetDVDInterfaceState().GetData();
                    const UDISR tmp_status_reg(val);
 
                    state.DISR.DEINTMASK = tmp_status_reg.DEINTMASK.Value();
@@ -667,8 +667,8 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base, bool is_wii)
                  }));
 
   mmio->Register(base | DI_COVER_REGISTER, MMIO::DirectRead<u32>(&state.DICVR.Hex),
-                 MMIO::ComplexWrite<u32>([](u32, u32 val) {
-                   auto& state = Core::System::GetInstance().GetDVDInterfaceState().GetData();
+                 MMIO::ComplexWrite<u32>([](Core::System& system, u32, u32 val) {
+                   auto& state = system.GetDVDInterfaceState().GetData();
                    const UDICVR tmp_cover_reg(val);
 
                    state.DICVR.CVRINTMASK = tmp_cover_reg.CVRINTMASK.Value();
@@ -705,8 +705,8 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base, bool is_wii)
   mmio->Register(base | DI_DMA_LENGTH_REGISTER, MMIO::DirectRead<u32>(&state.DILENGTH),
                  MMIO::DirectWrite<u32>(&state.DILENGTH, ~0x1F));
   mmio->Register(base | DI_DMA_CONTROL_REGISTER, MMIO::DirectRead<u32>(&state.DICR.Hex),
-                 MMIO::ComplexWrite<u32>([](u32, u32 val) {
-                   auto& state = Core::System::GetInstance().GetDVDInterfaceState().GetData();
+                 MMIO::ComplexWrite<u32>([](Core::System& system, u32, u32 val) {
+                   auto& state = system.GetDVDInterfaceState().GetData();
                    state.DICR.Hex = val & 7;
                    if (state.DICR.TSTART)
                    {

--- a/Source/Core/Core/HW/EXI/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.cpp
@@ -47,7 +47,7 @@ void CEXIChannel::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   // Warning: the base is not aligned on a page boundary here. We can't use |
   // to select a register address, instead we need to use +.
 
-  mmio->Register(base + EXI_STATUS, MMIO::ComplexRead<u32>([this](u32) {
+  mmio->Register(base + EXI_STATUS, MMIO::ComplexRead<u32>([this](Core::System&, u32) {
                    // check if external device is present
                    // pretty sure it is memcard only, not entirely sure
                    if (m_channel_id == 2)
@@ -61,7 +61,7 @@ void CEXIChannel::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 
                    return m_status.Hex;
                  }),
-                 MMIO::ComplexWrite<u32>([this](u32, u32 val) {
+                 MMIO::ComplexWrite<u32>([this](Core::System&, u32, u32 val) {
                    UEXI_STATUS new_status(val);
 
                    m_status.EXIINTMASK = new_status.EXIINTMASK;
@@ -98,7 +98,7 @@ void CEXIChannel::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   mmio->Register(base + EXI_DMA_LENGTH, MMIO::DirectRead<u32>(&m_dma_length),
                  MMIO::DirectWrite<u32>(&m_dma_length));
   mmio->Register(base + EXI_DMA_CONTROL, MMIO::DirectRead<u32>(&m_control.Hex),
-                 MMIO::ComplexWrite<u32>([this](u32, u32 val) {
+                 MMIO::ComplexWrite<u32>([this](Core::System&, u32, u32 val) {
                    m_control.Hex = val;
 
                    if (m_control.TSTART)

--- a/Source/Core/Core/HW/MMIO.cpp
+++ b/Source/Core/Core/HW/MMIO.cpp
@@ -112,12 +112,12 @@ template <typename T>
 class ComplexHandlingMethod : public ReadHandlingMethod<T>, public WriteHandlingMethod<T>
 {
 public:
-  explicit ComplexHandlingMethod(std::function<T(u32)> read_lambda)
+  explicit ComplexHandlingMethod(std::function<T(Core::System&, u32)> read_lambda)
       : read_lambda_(read_lambda), write_lambda_(InvalidWriteLambda())
   {
   }
 
-  explicit ComplexHandlingMethod(std::function<void(u32, T)> write_lambda)
+  explicit ComplexHandlingMethod(std::function<void(Core::System&, u32, T)> write_lambda)
       : read_lambda_(InvalidReadLambda()), write_lambda_(write_lambda)
   {
   }
@@ -134,9 +134,9 @@ public:
   }
 
 private:
-  std::function<T(u32)> InvalidReadLambda() const
+  std::function<T(Core::System&, u32)> InvalidReadLambda() const
   {
-    return [](u32) {
+    return [](Core::System&, u32) {
       DEBUG_ASSERT_MSG(MEMMAP, 0,
                        "Called the read lambda on a write "
                        "complex handler.");
@@ -144,25 +144,25 @@ private:
     };
   }
 
-  std::function<void(u32, T)> InvalidWriteLambda() const
+  std::function<void(Core::System&, u32, T)> InvalidWriteLambda() const
   {
-    return [](u32, T) {
+    return [](Core::System&, u32, T) {
       DEBUG_ASSERT_MSG(MEMMAP, 0,
                        "Called the write lambda on a read "
                        "complex handler.");
     };
   }
 
-  std::function<T(u32)> read_lambda_;
-  std::function<void(u32, T)> write_lambda_;
+  std::function<T(Core::System&, u32)> read_lambda_;
+  std::function<void(Core::System&, u32, T)> write_lambda_;
 };
 template <typename T>
-ReadHandlingMethod<T>* ComplexRead(std::function<T(u32)> lambda)
+ReadHandlingMethod<T>* ComplexRead(std::function<T(Core::System&, u32)> lambda)
 {
   return new ComplexHandlingMethod<T>(lambda);
 }
 template <typename T>
-WriteHandlingMethod<T>* ComplexWrite(std::function<void(u32, T)> lambda)
+WriteHandlingMethod<T>* ComplexWrite(std::function<void(Core::System&, u32, T)> lambda)
 {
   return new ComplexHandlingMethod<T>(lambda);
 }
@@ -172,7 +172,7 @@ WriteHandlingMethod<T>* ComplexWrite(std::function<void(u32, T)> lambda)
 template <typename T>
 ReadHandlingMethod<T>* InvalidRead()
 {
-  return ComplexRead<T>([](u32 addr) {
+  return ComplexRead<T>([](Core::System&, u32 addr) {
     ERROR_LOG_FMT(MEMMAP, "Trying to read {} bits from an invalid MMIO (addr={:08x})",
                   8 * sizeof(T), addr);
     return -1;
@@ -181,7 +181,7 @@ ReadHandlingMethod<T>* InvalidRead()
 template <typename T>
 WriteHandlingMethod<T>* InvalidWrite()
 {
-  return ComplexWrite<T>([](u32 addr, T val) {
+  return ComplexWrite<T>([](Core::System&, u32 addr, T val) {
     ERROR_LOG_FMT(MEMMAP, "Trying to write {} bits to an invalid MMIO (addr={:08x}, val={:08x})",
                   8 * sizeof(T), addr, val);
   });
@@ -229,8 +229,9 @@ ReadHandlingMethod<T>* ReadToSmaller(Mapping* mmio, u32 high_part_addr, u32 low_
   ReadHandler<ST>* low_part = &mmio->GetHandlerForRead<ST>(low_part_addr);
 
   // TODO(delroth): optimize
-  return ComplexRead<T>([=](u32 addr) {
-    return ((T)high_part->Read(high_part_addr) << (8 * sizeof(ST))) | low_part->Read(low_part_addr);
+  return ComplexRead<T>([=](Core::System& system, u32 addr) {
+    return ((T)high_part->Read(system, high_part_addr) << (8 * sizeof(ST))) |
+           low_part->Read(system, low_part_addr);
   });
 }
 
@@ -243,9 +244,9 @@ WriteHandlingMethod<T>* WriteToSmaller(Mapping* mmio, u32 high_part_addr, u32 lo
   WriteHandler<ST>* low_part = &mmio->GetHandlerForWrite<ST>(low_part_addr);
 
   // TODO(delroth): optimize
-  return ComplexWrite<T>([=](u32 addr, T val) {
-    high_part->Write(high_part_addr, val >> (8 * sizeof(ST)));
-    low_part->Write(low_part_addr, (ST)val);
+  return ComplexWrite<T>([=](Core::System& system, u32 addr, T val) {
+    high_part->Write(system, high_part_addr, val >> (8 * sizeof(ST)));
+    low_part->Write(system, low_part_addr, (ST)val);
   });
 }
 
@@ -257,8 +258,9 @@ ReadHandlingMethod<T>* ReadToLarger(Mapping* mmio, u32 larger_addr, u32 shift)
   ReadHandler<LT>* large = &mmio->GetHandlerForRead<LT>(larger_addr);
 
   // TODO(delroth): optimize
-  return ComplexRead<T>(
-      [large, shift](u32 addr) { return large->Read(addr & ~(sizeof(LT) - 1)) >> shift; });
+  return ComplexRead<T>([large, shift](Core::System& system, u32 addr) {
+    return large->Read(system, addr & ~(sizeof(LT) - 1)) >> shift;
+  });
 }
 
 // Inplementation of the ReadHandler and WriteHandler class. There is a lot of
@@ -290,7 +292,7 @@ void ReadHandler<T>::Visit(ReadHandlingMethodVisitor<T>& visitor)
 }
 
 template <typename T>
-T ReadHandler<T>::Read(u32 addr)
+T ReadHandler<T>::Read(Core::System& system, u32 addr)
 {
   // Check if the handler has already been initialized. For real
   // handlers, this will always be the case, so this branch should be
@@ -298,7 +300,7 @@ T ReadHandler<T>::Read(u32 addr)
   if (!m_Method)
     InitializeInvalid();
 
-  return m_ReadFunc(addr);
+  return m_ReadFunc(system, addr);
 }
 
 template <typename T>
@@ -310,19 +312,22 @@ void ReadHandler<T>::ResetMethod(ReadHandlingMethod<T>* method)
   {
     virtual ~FuncCreatorVisitor() = default;
 
-    std::function<T(u32)> ret;
+    std::function<T(Core::System&, u32)> ret;
 
     void VisitConstant(T value) override
     {
-      ret = [value](u32) { return value; };
+      ret = [value](Core::System&, u32) { return value; };
     }
 
     void VisitDirect(const T* addr, u32 mask) override
     {
-      ret = [addr, mask](u32) { return *addr & mask; };
+      ret = [addr, mask](Core::System&, u32) { return *addr & mask; };
     }
 
-    void VisitComplex(const std::function<T(u32)>* lambda) override { ret = *lambda; }
+    void VisitComplex(const std::function<T(Core::System&, u32)>* lambda) override
+    {
+      ret = *lambda;
+    }
   };
 
   FuncCreatorVisitor v;
@@ -362,7 +367,7 @@ void WriteHandler<T>::Visit(WriteHandlingMethodVisitor<T>& visitor)
 }
 
 template <typename T>
-void WriteHandler<T>::Write(u32 addr, T val)
+void WriteHandler<T>::Write(Core::System& system, u32 addr, T val)
 {
   // Check if the handler has already been initialized. For real
   // handlers, this will always be the case, so this branch should be
@@ -370,7 +375,7 @@ void WriteHandler<T>::Write(u32 addr, T val)
   if (!m_Method)
     InitializeInvalid();
 
-  m_WriteFunc(addr, val);
+  m_WriteFunc(system, addr, val);
 }
 
 template <typename T>
@@ -382,19 +387,22 @@ void WriteHandler<T>::ResetMethod(WriteHandlingMethod<T>* method)
   {
     virtual ~FuncCreatorVisitor() = default;
 
-    std::function<void(u32, T)> ret;
+    std::function<void(Core::System&, u32, T)> ret;
 
     void VisitNop() override
     {
-      ret = [](u32, T) {};
+      ret = [](Core::System&, u32, T) {};
     }
 
     void VisitDirect(T* ptr, u32 mask) override
     {
-      ret = [ptr, mask](u32, T val) { *ptr = val & mask; };
+      ret = [ptr, mask](Core::System&, u32, T val) { *ptr = val & mask; };
     }
 
-    void VisitComplex(const std::function<void(u32, T)>* lambda) override { ret = *lambda; }
+    void VisitComplex(const std::function<void(Core::System&, u32, T)>* lambda) override
+    {
+      ret = *lambda;
+    }
   };
 
   FuncCreatorVisitor v;

--- a/Source/Core/Core/HW/MMIO.h
+++ b/Source/Core/Core/HW/MMIO.h
@@ -15,6 +15,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/MMIOHandlers.h"
+#include "Core/System.h"
 
 namespace MMIO
 {
@@ -132,13 +133,13 @@ public:
   template <typename Unit>
   Unit Read(u32 addr)
   {
-    return GetHandlerForRead<Unit>(addr).Read(addr);
+    return GetHandlerForRead<Unit>(addr).Read(Core::System::GetInstance(), addr);
   }
 
   template <typename Unit>
   void Write(u32 addr, Unit val)
   {
-    GetHandlerForWrite<Unit>(addr).Write(addr, val);
+    GetHandlerForWrite<Unit>(addr).Write(Core::System::GetInstance(), addr, val);
   }
 
   // Handlers access interface.

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -82,13 +82,13 @@ void Init()
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 {
   mmio->Register(base | PI_INTERRUPT_CAUSE, MMIO::DirectRead<u32>(&m_InterruptCause),
-                 MMIO::ComplexWrite<u32>([](u32, u32 val) {
+                 MMIO::ComplexWrite<u32>([](Core::System&, u32, u32 val) {
                    m_InterruptCause &= ~val;
                    UpdateException();
                  }));
 
   mmio->Register(base | PI_INTERRUPT_MASK, MMIO::DirectRead<u32>(&m_InterruptMask),
-                 MMIO::ComplexWrite<u32>([](u32, u32 val) {
+                 MMIO::ComplexWrite<u32>([](Core::System&, u32, u32 val) {
                    m_InterruptMask = val;
                    UpdateException();
                  }));
@@ -103,7 +103,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::DirectWrite<u32>(&Fifo_CPUWritePointer, 0xFFFFFFE0));
 
   mmio->Register(base | PI_FIFO_RESET, MMIO::InvalidRead<u32>(),
-                 MMIO::ComplexWrite<u32>([](u32, u32 val) {
+                 MMIO::ComplexWrite<u32>([](Core::System&, u32, u32 val) {
                    // Used by GXAbortFrame
                    INFO_LOG_FMT(PROCESSORINTERFACE, "Wrote PI_FIFO_RESET: {:08x}", val);
                    if ((val & 1) != 0)
@@ -125,11 +125,11 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                    }
                  }));
 
-  mmio->Register(base | PI_RESET_CODE, MMIO::ComplexRead<u32>([](u32) {
+  mmio->Register(base | PI_RESET_CODE, MMIO::ComplexRead<u32>([](Core::System&, u32) {
                    DEBUG_LOG_FMT(PROCESSORINTERFACE, "Read PI_RESET_CODE: {:08x}", m_ResetCode);
                    return m_ResetCode;
                  }),
-                 MMIO::ComplexWrite<u32>([](u32, u32 val) {
+                 MMIO::ComplexWrite<u32>([](Core::System&, u32, u32 val) {
                    m_ResetCode = val;
                    INFO_LOG_FMT(PROCESSORINTERFACE, "Wrote PI_RESET_CODE: {:08x}", m_ResetCode);
                    if (!SConfig::GetInstance().bWii && ~m_ResetCode & 0x4)

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -490,14 +490,14 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   {
     const u32 address = base | static_cast<u32>(io_buffer_base + i);
 
-    mmio->Register(address, MMIO::ComplexRead<u32>([i](u32) {
-                     auto& state = Core::System::GetInstance().GetSerialInterfaceState().GetData();
+    mmio->Register(address, MMIO::ComplexRead<u32>([i](Core::System& system, u32) {
+                     auto& state = system.GetSerialInterfaceState().GetData();
                      u32 val;
                      std::memcpy(&val, &state.si_buffer[i], sizeof(val));
                      return Common::swap32(val);
                    }),
-                   MMIO::ComplexWrite<u32>([i](u32, u32 val) {
-                     auto& state = Core::System::GetInstance().GetSerialInterfaceState().GetData();
+                   MMIO::ComplexWrite<u32>([i](Core::System& system, u32, u32 val) {
+                     auto& state = system.GetSerialInterfaceState().GetData();
                      val = Common::swap32(val);
                      std::memcpy(&state.si_buffer[i], &val, sizeof(val));
                    }));
@@ -506,14 +506,14 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   {
     const u32 address = base | static_cast<u32>(io_buffer_base + i);
 
-    mmio->Register(address, MMIO::ComplexRead<u16>([i](u32) {
-                     auto& state = Core::System::GetInstance().GetSerialInterfaceState().GetData();
+    mmio->Register(address, MMIO::ComplexRead<u16>([i](Core::System& system, u32) {
+                     auto& state = system.GetSerialInterfaceState().GetData();
                      u16 val;
                      std::memcpy(&val, &state.si_buffer[i], sizeof(val));
                      return Common::swap16(val);
                    }),
-                   MMIO::ComplexWrite<u16>([i](u32, u16 val) {
-                     auto& state = Core::System::GetInstance().GetSerialInterfaceState().GetData();
+                   MMIO::ComplexWrite<u16>([i](Core::System& system, u32, u16 val) {
+                     auto& state = system.GetSerialInterfaceState().GetData();
                      val = Common::swap16(val);
                      std::memcpy(&state.si_buffer[i], &val, sizeof(val));
                    }));
@@ -533,16 +533,16 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                    MMIO::DirectRead<u32>(&state.channel[i].out.hex),
                    MMIO::DirectWrite<u32>(&state.channel[i].out.hex));
     mmio->Register(base | (SI_CHANNEL_0_IN_HI + 0xC * i),
-                   MMIO::ComplexRead<u32>([i, rdst_bit](u32) {
-                     auto& state = Core::System::GetInstance().GetSerialInterfaceState().GetData();
+                   MMIO::ComplexRead<u32>([i, rdst_bit](Core::System& system, u32) {
+                     auto& state = system.GetSerialInterfaceState().GetData();
                      state.status_reg.hex &= ~(1U << rdst_bit);
                      UpdateInterrupts();
                      return state.channel[i].in_hi.hex;
                    }),
                    MMIO::DirectWrite<u32>(&state.channel[i].in_hi.hex));
     mmio->Register(base | (SI_CHANNEL_0_IN_LO + 0xC * i),
-                   MMIO::ComplexRead<u32>([i, rdst_bit](u32) {
-                     auto& state = Core::System::GetInstance().GetSerialInterfaceState().GetData();
+                   MMIO::ComplexRead<u32>([i, rdst_bit](Core::System& system, u32) {
+                     auto& state = system.GetSerialInterfaceState().GetData();
                      state.status_reg.hex &= ~(1U << rdst_bit);
                      UpdateInterrupts();
                      return state.channel[i].in_lo.hex;
@@ -554,8 +554,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::DirectWrite<u32>(&state.poll.hex));
 
   mmio->Register(base | SI_COM_CSR, MMIO::DirectRead<u32>(&state.com_csr.hex),
-                 MMIO::ComplexWrite<u32>([](u32, u32 val) {
-                   auto& system = Core::System::GetInstance();
+                 MMIO::ComplexWrite<u32>([](Core::System& system, u32, u32 val) {
                    auto& state = system.GetSerialInterfaceState().GetData();
                    const USIComCSR tmp_com_csr(val);
 
@@ -584,8 +583,8 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  }));
 
   mmio->Register(base | SI_STATUS_REG, MMIO::DirectRead<u32>(&state.status_reg.hex),
-                 MMIO::ComplexWrite<u32>([](u32, u32 val) {
-                   auto& state = Core::System::GetInstance().GetSerialInterfaceState().GetData();
+                 MMIO::ComplexWrite<u32>([](Core::System& system, u32, u32 val) {
+                   auto& state = system.GetSerialInterfaceState().GetData();
                    const USIStatusReg tmp_status(val);
 
                    // clear bits ( if (tmp.bit) SISR.bit=0 )

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -19,6 +19,7 @@
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 using namespace Gen;
 
@@ -220,7 +221,7 @@ public:
   {
     LoadAddrMaskToReg(8 * sizeof(T), addr, mask);
   }
-  void VisitComplex(const std::function<T(u32)>* lambda) override
+  void VisitComplex(const std::function<T(Core::System&, u32)>* lambda) override
   {
     CallLambda(8 * sizeof(T), lambda);
   }
@@ -269,10 +270,10 @@ private:
     }
   }
 
-  void CallLambda(int sbits, const std::function<T(u32)>* lambda)
+  void CallLambda(int sbits, const std::function<T(Core::System&, u32)>* lambda)
   {
     m_code->ABI_PushRegistersAndAdjustStack(m_registers_in_use, 0);
-    m_code->ABI_CallLambdaC(lambda, m_address);
+    m_code->ABI_CallLambdaPC(lambda, &Core::System::GetInstance(), m_address);
     m_code->ABI_PopRegistersAndAdjustStack(m_registers_in_use, 0);
     MoveOpArgToReg(sbits, R(ABI_RETURN));
   }

--- a/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
@@ -7,8 +7,8 @@
 #include "Common/Common.h"
 
 #include "Core/HW/MMIO.h"
-
 #include "Core/PowerPC/JitArm64/Jit.h"
+#include "Core/System.h"
 
 using namespace Arm64Gen;
 
@@ -28,7 +28,7 @@ public:
     // Do nothing
   }
   void VisitDirect(T* addr, u32 mask) override { WriteRegToAddr(8 * sizeof(T), addr, mask); }
-  void VisitComplex(const std::function<void(u32, T)>* lambda) override
+  void VisitComplex(const std::function<void(Core::System&, u32, T)>* lambda) override
   {
     CallLambda(8 * sizeof(T), lambda);
   }
@@ -72,15 +72,15 @@ private:
     }
   }
 
-  void CallLambda(int sbits, const std::function<void(u32, T)>* lambda)
+  void CallLambda(int sbits, const std::function<void(Core::System&, u32, T)>* lambda)
   {
     ARM64FloatEmitter float_emit(m_emit);
 
     m_emit->ABI_PushRegisters(m_gprs_in_use);
     float_emit.ABI_PushRegisters(m_fprs_in_use, ARM64Reg::X1);
-
-    m_emit->MOVI2R(ARM64Reg::W1, m_address);
-    m_emit->MOV(ARM64Reg::W2, m_src_reg);
+    m_emit->MOVP2R(ARM64Reg::X1, &Core::System::GetInstance());
+    m_emit->MOVI2R(ARM64Reg::W2, m_address);
+    m_emit->MOV(ARM64Reg::W3, m_src_reg);
     m_emit->BLR(m_emit->ABI_SetupLambda(lambda));
 
     float_emit.ABI_PopRegisters(m_fprs_in_use, ARM64Reg::X1);
@@ -110,7 +110,7 @@ public:
   {
     LoadAddrMaskToReg(8 * sizeof(T), addr, mask);
   }
-  void VisitComplex(const std::function<T(u32)>* lambda) override
+  void VisitComplex(const std::function<T(Core::System&, u32)>* lambda) override
   {
     CallLambda(8 * sizeof(T), lambda);
   }
@@ -169,14 +169,14 @@ private:
     }
   }
 
-  void CallLambda(int sbits, const std::function<T(u32)>* lambda)
+  void CallLambda(int sbits, const std::function<T(Core::System&, u32)>* lambda)
   {
     ARM64FloatEmitter float_emit(m_emit);
 
     m_emit->ABI_PushRegisters(m_gprs_in_use);
     float_emit.ABI_PushRegisters(m_fprs_in_use, ARM64Reg::X1);
-
-    m_emit->MOVI2R(ARM64Reg::W1, m_address);
+    m_emit->MOVP2R(ARM64Reg::X1, &Core::System::GetInstance());
+    m_emit->MOVI2R(ARM64Reg::W2, m_address);
     m_emit->BLR(m_emit->ABI_SetupLambda(lambda));
     if (m_sign_extend)
       m_emit->SBFM(m_dst_reg, ARM64Reg::W0, 0, sbits - 1);

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -242,11 +242,11 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   };
   for (auto& pq_reg : pq_regs)
   {
-    mmio->Register(base | pq_reg.addr, MMIO::ComplexRead<u16>([pq_reg](u32) {
+    mmio->Register(base | pq_reg.addr, MMIO::ComplexRead<u16>([pq_reg](Core::System&, u32) {
                      return g_video_backend->Video_GetQueryResult(pq_reg.pqtype) & 0xFFFF;
                    }),
                    MMIO::InvalidWrite<u16>());
-    mmio->Register(base | (pq_reg.addr + 2), MMIO::ComplexRead<u16>([pq_reg](u32) {
+    mmio->Register(base | (pq_reg.addr + 2), MMIO::ComplexRead<u16>([pq_reg](Core::System&, u32) {
                      return g_video_backend->Video_GetQueryResult(pq_reg.pqtype) >> 16;
                    }),
                    MMIO::InvalidWrite<u16>());
@@ -254,7 +254,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 
   // Control register
   mmio->Register(base | PE_CTRL_REGISTER, MMIO::DirectRead<u16>(&m_Control.hex),
-                 MMIO::ComplexWrite<u16>([](u32, u16 val) {
+                 MMIO::ComplexWrite<u16>([](Core::System&, u32, u16 val) {
                    UPECtrlReg tmpCtrl{.hex = val};
 
                    if (tmpCtrl.pe_token)
@@ -278,7 +278,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   // BBOX registers, readonly and need to update a flag.
   for (int i = 0; i < 4; ++i)
   {
-    mmio->Register(base | (PE_BBOX_LEFT + 2 * i), MMIO::ComplexRead<u16>([i](u32) {
+    mmio->Register(base | (PE_BBOX_LEFT + 2 * i), MMIO::ComplexRead<u16>([i](Core::System&, u32) {
                      g_renderer->BBoxDisable();
                      return g_video_backend->Video_GetBoundingBox(i);
                    }),

--- a/Source/UnitTests/Core/MMIOTest.cpp
+++ b/Source/UnitTests/Core/MMIOTest.cpp
@@ -121,12 +121,12 @@ TEST_F(MappingTest, ReadWriteComplex)
 {
   bool read_called = false, write_called = false;
 
-  m_mapping->Register(0x0C001234, MMIO::ComplexRead<u8>([&read_called](u32 addr) {
+  m_mapping->Register(0x0C001234, MMIO::ComplexRead<u8>([&read_called](Core::System&, u32 addr) {
                         EXPECT_EQ(0x0C001234u, addr);
                         read_called = true;
                         return 0x12;
                       }),
-                      MMIO::ComplexWrite<u8>([&write_called](u32 addr, u8 val) {
+                      MMIO::ComplexWrite<u8>([&write_called](Core::System&, u32 addr, u8 val) {
                         EXPECT_EQ(0x0C001234u, addr);
                         EXPECT_EQ(0x34, val);
                         write_called = true;


### PR DESCRIPTION
De-globalizing the MMIO handlers.

I'd like some input here on if this is a good way to do it. The only other approach I can think of would be to capture the system instance in every single complex handler, which IMO is worse, but ymmv. 