### PR TITLE
Metroid Prime Trilogy ini, fix performance, outdated settings.

### DIFF
--- a/Data/Sys/GameSettings/R3M.ini
+++ b/Data/Sys/GameSettings/R3M.ini
@@ -14,6 +14,3 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
-ImmediateXFBEnable = False
-XFBToTextureEnable = False
-DeferEFBCopies = False


### PR DESCRIPTION
This reverts #8072 and removes an outdated setting.

Disabling `DeferEFBCopies` has a big performance cost. Corrupt loading screen it causes is only visible for half a second on initial load. Nothing is affected in game.

https://user-images.githubusercontent.com/126473/195886057-4206753b-2553-40a4-833b-1bcd0492a78b.mp4

These render times are from MP1 on Talon Over World just looking around. Staring at the sky with the rain fall is particularly taxing. MP2 is also stressed when looking at a dark portal.

`DeferEFBCopies` off:
```
1/3 metal.............11.793ms
Run completed. Sampled 3987 frames.
2/3 metal.............12.093ms
Run completed. Sampled 3987 frames.
3/3 metal.............12.058ms
Run completed. Sampled 3987 frames.
 3987 frames 11.793ms metal pass 1
 3987 frames 12.093ms metal pass 2
 3987 frames 12.058ms metal pass 3
11961 frames 11.981ms complete
```

`DeferEFBCopies` off:
```
1/3 metal..........8.746ms
Run completed. Sampled 3987 frames.
2/3 metal.........7.746ms
Run completed. Sampled 3987 frames.
3/3 metal..........8.713ms
Run completed. Sampled 3987 frames.
 3987 frames 8.746ms metal pass 1
 3987 frames 7.746ms metal pass 2
 3987 frames 8.713ms metal pass 3
11961 frames 8.402ms complete
```

It’s not worth fixing the small blip on the loading screen.

Enabling `XFBToTextureEnable` no longer causes a magenta loading screen.

Not from #8072 but `ImmediateXFBEnable` is outdated. No ill effects on or off.
