### PR TITLE
Jit64: Jump to dispatcher_no_check from InitializeSpeculativeConstants

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -1282,7 +1282,7 @@ void Jit64::IntializeSpeculativeConstants()
         ABI_CallFunctionC(JitInterface::CompileExceptionCheck,
                           static_cast<u32>(JitInterface::ExceptionType::SpeculativeConstants));
         ABI_PopRegistersAndAdjustStack({}, 0);
-        JMP(asm_routines.dispatcher, true);
+        JMP(asm_routines.dispatcher_no_check, true);
         SwitchToNearCode();
       }
       CMP(32, PPCSTATE(gpr[i]), Imm32(compileTimeValue));


### PR DESCRIPTION
Jumping to `dispatcher` requires first subtracting the downcount, otherwise `dispatcher` may unpredictably jump to CoreTiming::Advance, which could break determinism compatibility with JitArm64. We should jump to `dispatcher_no_check` instead.