### PR TITLE
Jit64: Add dispatcher_no_timing_check jump target

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -598,10 +598,6 @@ void Jit64::JustWriteExit(u32 destination, bool bl, u32 after)
 
   MOV(32, PPCSTATE(pc), Imm32(destination));
 
-  // Do not skip breakpoint check if debugging.
-  const u8* dispatcher =
-      m_enable_debugging ? asm_routines.dispatcher : asm_routines.dispatcher_no_check;
-
   // Perform downcount flag check, followed by the requested exit
   if (bl)
   {
@@ -613,7 +609,7 @@ void Jit64::JustWriteExit(u32 destination, bool bl, u32 after)
     SwitchToNearCode();
 
     linkData.exitPtrs = GetWritableCodePtr();
-    CALL(dispatcher);
+    CALL(asm_routines.dispatcher_no_timing_check);
 
     SetJumpTarget(after_fixup);
     POP(RSCRATCH);
@@ -624,7 +620,7 @@ void Jit64::JustWriteExit(u32 destination, bool bl, u32 after)
     J_CC(CC_LE, asm_routines.do_timing);
 
     linkData.exitPtrs = GetWritableCodePtr();
-    JMP(dispatcher, true);
+    JMP(asm_routines.dispatcher_no_timing_check, true);
   }
 
   b->linkData.push_back(linkData);

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -83,12 +83,14 @@ void Jit64AsmRoutineManager::Generate()
   SUB(32, PPCSTATE(downcount), R(RSCRATCH2));
 
   dispatcher = GetCodePtr();
+
   // Expected result of SUB(32, PPCSTATE(downcount), Imm32(block_cycles)) is in RFLAGS.
   // Branch if downcount is <= 0 (signed).
   FixupBranch bail = J_CC(CC_LE, true);
 
-  FixupBranch dbg_exit;
+  dispatcher_no_timing_check = GetCodePtr();
 
+  FixupBranch dbg_exit;
   if (enable_debugging)
   {
     MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));

--- a/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
@@ -13,12 +13,9 @@ JitBlockCache::JitBlockCache(JitBase& jit) : JitBaseBlockCache{jit}
 
 void JitBlockCache::WriteLinkBlock(const JitBlock::LinkData& source, const JitBlock* dest)
 {
-  // Do not skip breakpoint check if debugging.
-  const u8* dispatcher = m_jit.IsDebuggingEnabled() ? m_jit.GetAsmRoutines()->dispatcher :
-                                                      m_jit.GetAsmRoutines()->dispatcher_no_check;
-
   u8* location = source.exitPtrs;
-  const u8* address = dest ? dest->checkedEntry : dispatcher;
+  const u8* address =
+      dest ? dest->checkedEntry : m_jit.GetAsmRoutines()->dispatcher_no_timing_check;
   if (source.call)
   {
     Gen::XEmitter emit(location, location + 5);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -84,6 +84,7 @@ void JitArm64::GenerateAsm()
   // The result of slice decrementation should be in flags if somebody jumped here
   FixupBranch bail = B(CC_LE);
 
+  dispatcher_no_timing_check = GetCodePtr();
   dispatcher_no_check = GetCodePtr();
 
   bool assembly_dispatcher = true;

--- a/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
@@ -17,6 +17,7 @@ struct CommonAsmRoutinesBase
 
   const u8* dispatcher_mispredicted_blr;
   const u8* dispatcher;
+  const u8* dispatcher_no_timing_check;
   const u8* dispatcher_no_check;
 
   const u8* do_timing;


### PR DESCRIPTION
The new `dispatcher_no_timing_check` is the same as `dispatcher_no_check` except it includes the "stepping check" in debug mode. This lets us avoid the `m_enable_debugging ? dispatcher : dispatcher_no_check` dance.