### PR TITLE
Zero-initialize structures passed to FatFs functions.

### DIFF
--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -360,7 +360,7 @@ static bool Pack(const File::FSTEntry& entry, bool is_root, std::vector<u8>& tmp
       return false;
     }
 
-    FIL dst;
+    FIL dst{};
     const auto open_error_code =
         f_open(&dst, entry.virtualName.c_str(), FA_CREATE_ALWAYS | FA_WRITE);
     if (open_error_code != FR_OK)
@@ -549,7 +549,7 @@ bool SyncSDFolderToSDImage(bool deterministic)
     return false;
   }
 
-  FATFS fs;
+  FATFS fs{};
   const auto mount_error_code = f_mount(&fs, "", 0);
   if (mount_error_code != FR_OK)
   {
@@ -591,7 +591,7 @@ static bool Unpack(const std::string path, bool is_directory, const char* name,
 {
   if (!is_directory)
   {
-    FIL src;
+    FIL src{};
     const auto open_error_code = f_open(&src, name, FA_READ);
     if (open_error_code != FR_OK)
     {
@@ -667,7 +667,7 @@ static bool Unpack(const std::string path, bool is_directory, const char* name,
     return false;
   }
 
-  DIR directory;
+  DIR directory{};
   const auto opendir_error_code = f_opendir(&directory, ".");
   if (opendir_error_code != FR_OK)
   {
@@ -676,7 +676,7 @@ static bool Unpack(const std::string path, bool is_directory, const char* name,
     return false;
   }
 
-  FILINFO entry;
+  FILINFO entry{};
   while (true)
   {
     const auto readdir_error_code = f_readdir(&directory, &entry);
@@ -767,7 +767,7 @@ bool SyncSDImageToSDFolder()
     return false;
   }
 
-  FATFS fs;
+  FATFS fs{};
   const auto mount_error_code = f_mount(&fs, "", 0);
   if (mount_error_code != FR_OK)
   {

--- a/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
+++ b/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include <fmt/format.h>
@@ -96,6 +97,10 @@ static DRESULT read_vff_header(IOS::HLE::FS::FileHandle* vff, FATFS* fs)
 
   fs->id = 0;
   fs->cdir = 0;
+
+  // invalidate window
+  fs->wflag = 0;
+  fs->winsect = std::numeric_limits<LBA_t>::max();
 
   return RES_OK;
 }

--- a/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
+++ b/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
@@ -185,7 +185,7 @@ namespace IOS::HLE::NWC24
 {
 static ErrorCode WriteFile(const std::string& filename, const std::vector<u8>& tmp_buffer)
 {
-  FIL dst;
+  FIL dst{};
   const auto open_error_code = f_open(&dst, filename.c_str(), FA_CREATE_ALWAYS | FA_WRITE);
   if (open_error_code != FR_OK)
   {
@@ -269,7 +269,7 @@ ErrorCode OpenVFF(const std::string& path, const std::string& filename,
 
     Common::ScopeGuard vff_delete_guard{[&] { fs->Delete(PID_KD, PID_KD, path); }};
 
-    FATFS fatfs;
+    FATFS fatfs{};
     const FRESULT fatfs_mount_error_code = f_mount(&fatfs, "", 0);
     if (fatfs_mount_error_code != FR_OK)
     {


### PR DESCRIPTION
Lack of zero-initialization on the `FATFS` struct causes https://github.com/dolphin-emu/dolphin/pull/11072#issuecomment-1279971536 because it tries to flush a sector it hasn't written to (because the dirty bit happens to initialize nonzero and FatFs doesn't clear it on mount...). Doesn't actually fix the News and Forecast channels though.