### PR TITLE
VideoCommon:FramebufferManager: Mark cache as valid after refresh

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -493,6 +493,9 @@ void FramebufferManager::RefreshPeekCache()
         flush_command_buffer = true;
       }
     }
+
+    m_efb_depth_cache.valid = true;
+    m_efb_color_cache.valid = true;
   }
   else
   {

--- a/Source/Core/VideoCommon/FramebufferManager.h
+++ b/Source/Core/VideoCommon/FramebufferManager.h
@@ -135,7 +135,8 @@ protected:
     std::unique_ptr<AbstractPipeline> copy_pipeline;
     std::vector<EFBCacheTile> tiles;
     bool out_of_date;
-    bool valid;
+    bool has_active_tiles;
+    bool needs_refresh;
     bool needs_flush;
   };
 


### PR DESCRIPTION
Small thing I noticed after #11098 got merged.

Otherwise we might never hit the early return if either depth or color doesnt have any active tiles.