### PR TITLE
GZLP01.ini – Update Cheatcode to Remove Distance Blur

### DIFF
--- a/Data/Sys/GameSettings/GZLP01.ini
+++ b/Data/Sys/GameSettings/GZLP01.ini
@@ -20,6 +20,8 @@ $Snow test room
 
 [ActionReplay]
 # Add action replay cheats here.
+$Remove Distance Blur
+044043EC 00000000
 $Maximum Health
 003CC531 00000050
 $Infinite Health
@@ -36,9 +38,6 @@ $Massive Link
 423D1D38 010A4080
 423D1D38 010C4080
 423D1D38 010E4080
-$Remove Distance Blur
-04008FF0 60000000
-023FE0B6 0000FF00
 $Tiny Link
 423D1D38 010A3E80
 423D1D38 010C3E80


### PR DESCRIPTION
The old code caused the black and white effect in some rooms not to work. The new one works properly.