### PR TITLE
IOS: Simplify IOS::HLE::Device savestate method

### DIFF
--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -53,7 +53,7 @@ DIDevice::DIDevice(Kernel& ios, const std::string& device_name) : Device(ios, de
 
 void DIDevice::DoState(PointerWrap& p)
 {
-  DoStateShared(p);
+  Device::DoState(p);
   p.Do(m_commands_to_execute);
   p.Do(m_executing_command);
   p.Do(m_current_partition);

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -148,12 +148,6 @@ Device::Device(Kernel& ios, const std::string& device_name, const DeviceType typ
 
 void Device::DoState(PointerWrap& p)
 {
-  DoStateShared(p);
-  p.Do(m_is_active);
-}
-
-void Device::DoStateShared(PointerWrap& p)
-{
   p.Do(m_name);
   p.Do(m_device_type);
   p.Do(m_is_active);

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -181,7 +181,6 @@ public:
 
   virtual ~Device() = default;
   virtual void DoState(PointerWrap& p);
-  void DoStateShared(PointerWrap& p);
 
   const std::string& GetDeviceName() const { return m_name; }
   // Replies to Open and Close requests are sent by the IPC request handler (HandleCommand),

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -93,6 +93,7 @@ FSDevice::FSDevice(Kernel& ios, const std::string& device_name) : Device(ios, de
 
 void FSDevice::DoState(PointerWrap& p)
 {
+  Device::DoState(p);
   p.Do(m_dirty_cache);
   p.Do(m_cache_chain_index);
   p.Do(m_cache_fd);

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -75,7 +75,7 @@ NetIPTopDevice::NetIPTopDevice(Kernel& ios, const std::string& device_name)
 
 void NetIPTopDevice::DoState(PointerWrap& p)
 {
-  DoStateShared(p);
+  Device::DoState(p);
   WiiSockMan::GetInstance().DoState(p);
 }
 

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -56,7 +56,7 @@ void SDIOSlot0Device::RefreshConfig()
 
 void SDIOSlot0Device::DoState(PointerWrap& p)
 {
-  DoStateShared(p);
+  Device::DoState(p);
   if (p.IsReadMode())
   {
     OpenInternal();

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -81,13 +81,13 @@ std::optional<IPCReply> STMEventHookDevice::IOCtl(const IOCtlRequest& request)
 
 void STMEventHookDevice::DoState(PointerWrap& p)
 {
+  Device::DoState(p);
   u32 address = s_event_hook_request ? s_event_hook_request->address : 0;
   p.Do(address);
   if (address != 0)
     s_event_hook_request = std::make_unique<IOCtlRequest>(address);
   else
     s_event_hook_request.reset();
-  Device::DoState(p);
 }
 
 bool STMEventHookDevice::HasHookInstalled() const

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -102,7 +102,7 @@ void BluetoothEmuDevice::DoState(PointerWrap& p)
     return;
   }
 
-  p.Do(m_is_active);
+  Device::DoState(p);
   p.Do(m_controller_bd);
   DoStateForMessage(m_ios, p, m_hci_endpoint);
   DoStateForMessage(m_ios, p, m_acl_endpoint);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -323,6 +323,7 @@ void BluetoothRealDevice::DoState(PointerWrap& p)
     return;
   }
 
+  Device::DoState(p);
   // Prevent the transfer callbacks from messing with m_current_transfers after we have started
   // writing a savestate. We cannot use a scoped lock here because DoState is called twice and
   // we would lose the lock between the two calls.

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -55,6 +55,7 @@ void USBHost::UpdateWantDeterminism(const bool new_want_determinism)
 
 void USBHost::DoState(PointerWrap& p)
 {
+  Device::DoState(p);
   if (IsOpened() && p.IsReadMode())
   {
     // After a state has loaded, there may be insertion hooks for devices that were

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -44,7 +44,7 @@ OH0Device::OH0Device(Kernel& ios, const std::string& name) : Device(ios, name, D
 void OH0Device::DoState(PointerWrap& p)
 {
   m_oh0 = std::static_pointer_cast<OH0>(GetIOS()->GetDeviceByName("/dev/usb/oh0"));
-  p.Do(m_name);
+  Device::DoState(p);
   p.Do(m_vid);
   p.Do(m_pid);
   p.Do(m_device_id);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -94,7 +94,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 153;  // Last changed in PR 11137
+constexpr u32 STATE_VERSION = 154;  // Last changed in PR 11177
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
There was an extra call to p.do(m_is_active) in IOS::HLE::Device::DoState(). This PR eliminates that extra call, and simplifies the DoState() method for the Device class.