### PR TITLE
Remove ~/.dolphin-emu

### DIFF
--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -358,9 +358,7 @@ void SetUserDirectory(std::string custom_path)
     //    -> Use GetExeDirectory()/User
     // 2. $DOLPHIN_EMU_USERPATH is set
     //    -> Use $DOLPHIN_EMU_USERPATH
-    // 3. ~/.dolphin-emu directory exists
-    //    -> Use ~/.dolphin-emu
-    // 4. Default
+    // 3. Default
     //    -> Use XDG basedir, see
     //    http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
     //
@@ -389,32 +387,27 @@ void SetUserDirectory(std::string custom_path)
 #else
     else
     {
-      user_path = home_path + "." DOLPHIN_DATA_DIR DIR_SEP;
+      const char* data_home = getenv("XDG_DATA_HOME");
+      std::string data_path =
+          std::string(data_home && data_home[0] == '/' ? data_home :
+                                                         (home_path + ".local" DIR_SEP "share")) +
+          DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
 
-      if (!File::Exists(user_path))
-      {
-        const char* data_home = getenv("XDG_DATA_HOME");
-        std::string data_path =
-            std::string(data_home && data_home[0] == '/' ? data_home :
-                                                           (home_path + ".local" DIR_SEP "share")) +
-            DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
+      const char* config_home = getenv("XDG_CONFIG_HOME");
+      std::string config_path =
+          std::string(config_home && config_home[0] == '/' ? config_home :
+                                                             (home_path + ".config")) +
+          DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
 
-        const char* config_home = getenv("XDG_CONFIG_HOME");
-        std::string config_path =
-            std::string(config_home && config_home[0] == '/' ? config_home :
-                                                               (home_path + ".config")) +
-            DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
+      const char* cache_home = getenv("XDG_CACHE_HOME");
+      std::string cache_path =
+          std::string(cache_home && cache_home[0] == '/' ? cache_home : (home_path + ".cache")) +
+          DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
 
-        const char* cache_home = getenv("XDG_CACHE_HOME");
-        std::string cache_path =
-            std::string(cache_home && cache_home[0] == '/' ? cache_home : (home_path + ".cache")) +
-            DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
-
-        File::SetUserPath(D_USER_IDX, data_path);
-        File::SetUserPath(D_CONFIG_IDX, config_path);
-        File::SetUserPath(D_CACHE_IDX, cache_path);
-        return;
-      }
+      File::SetUserPath(D_USER_IDX, data_path);
+      File::SetUserPath(D_CONFIG_IDX, config_path);
+      File::SetUserPath(D_CACHE_IDX, cache_path);
+      return;
     }
 #endif
   }


### PR DESCRIPTION
`~/.dolphin-emu` is a relic of the past and should not be used anymore. Personally, I hate it when applications create dot files/folders in my home directory.

My motivation: This allows `dolphin-emu` (XDG Base Directory) and `dolphin-emu-triforce` (`~/.dolphin-emu`) to coexist on the same OS (without the use of helper scripts to move the directories around).