### PR TITLE
HostFileSystem: Set all NAND folders to be saved in save states

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -229,6 +229,22 @@ public:
     return current;
   }
 
+  // The reserved u32 is set to 0, and a pointer to it is returned.
+  // The caller needs to fill in the reserved u32 with the appropriate value later on, if they
+  // want a non-zero value there.
+  [[nodiscard]] u8* ReserveU32()
+  {
+    u32 temp = 0;
+    u8* previous_pointer = *m_ptr_current;
+    Do(temp);
+    return previous_pointer;
+  }
+
+  u32 GetOffsetFromPreviousPosition(u8* previous_pointer)
+  {
+    return static_cast<u32>((*m_ptr_current) - previous_pointer);
+  }
+
   void Do(Common::Flag& flag)
   {
     bool s = flag.IsSet();

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.h
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.h
@@ -59,10 +59,12 @@ public:
   void SetNandRedirects(std::vector<NandRedirect> nand_redirects) override;
 
 private:
+  void DoStateWriteOrMeasure(PointerWrap& p, std::string start_directory_path);
+  void DoStateRead(PointerWrap& p, std::string start_directory_path);
+
   struct FstEntry
   {
     bool CheckPermission(Uid uid, Gid gid, Mode requested_mode) const;
-
     std::string name;
     Metadata data{};
     /// Children of this FST entry. Only valid for directories.

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -94,7 +94,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 155;  // Last changed in PR 10890
+constexpr u32 STATE_VERSION = 156;  // Last changed in PR 11184
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This change makes all files and folders in NAND be recursively saved/loaded in save states. More specifically, when a movie is being created/played back, the full contents of the Dolphin Emulator/WiiSession folder will be saved/restored recursively.