### PR TITLE
MemoryWidget: Make search address a combobox that holds address history.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -75,7 +75,7 @@ private:
 
   MemoryViewWidget* m_memory_view;
   QSplitter* m_splitter;
-  QLineEdit* m_search_address;
+  QComboBox* m_search_address;
   QLineEdit* m_search_offset;
   QLineEdit* m_data_edit;
   QCheckBox* m_base_check;


### PR DESCRIPTION
Always update the combobox when a new target address is sent.

The main problem was that navigating to an address from another widget wouldn't update the address box.  It worked for peeking at a section, then going back to the original, unchanged search address, but not much else.  I added a 10 slot history of addresses so you could keep your old address. All navigated to addresses (from other widgets) will go into the text box and history box automatically and the original address that gets overwritten will be saved in the combo box too.

Two issues in doing this were the offset box and typed addresses.  The offset box is too cumbersome to worry about imo, selecting an address from the combobox will add the offset box to it.  Typed addresses don't feel like they should immediately be added to the history box.  If you press ENTER it will go into the history.