### PR TITLE
IOS::HLE::Kernel::InitIPC: Replace s_ios check with Core::IsRunning

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -481,7 +481,7 @@ bool Kernel::BootIOS(const u64 ios_title_id, HangPPC hang_ppc, const std::string
 
 void Kernel::InitIPC()
 {
-  if (s_ios == nullptr)
+  if (!Core::IsRunning())
     return;
 
   INFO_LOG_FMT(IOS, "IPC initialised.");


### PR DESCRIPTION
This avoids issues with devices relying on `s_ios`, which would be a `nullptr` while still in the constructor.
For example the ES device will call `InitIPC` which makes sure `s_ios` is not `nullptr`, which it always is while still in the constructor.