### PR TITLE
GCAdapter: Code cleanups.

### DIFF
--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -17,7 +17,11 @@ void Shutdown();
 void SetAdapterCallback(std::function<void(void)> func);
 void StartScanThread();
 void StopScanThread();
+
+// Buttons have PAD_GET_ORIGIN set on new connection
+// Netplay and CSIDevice_GCAdapter make use of this.
 GCPadStatus Input(int chan);
+
 void Output(int chan, u8 rumble_command);
 bool IsDetected(const char** error_message);
 bool DeviceConnected(int chan);


### PR DESCRIPTION
This is in preparation for #10489 (GCAdapter ControllerInterface support).

The main thing is processing input in the read thread rather than the `Input` function so device changes and input work when a game isn't running.
I also did some other general cleanups.