### PR TITLE
ControllerInterface: Add InputBackend interface.

### DIFF
--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -487,6 +487,7 @@
     <ClInclude Include="InputCommon\ControllerEmu\StickGate.h" />
     <ClInclude Include="InputCommon\ControllerInterface\ControllerInterface.h" />
     <ClInclude Include="InputCommon\ControllerInterface\CoreDevice.h" />
+    <ClInclude Include="InputCommon\ControllerInterface\InputBackend.h" />
     <ClInclude Include="InputCommon\ControllerInterface\DInput\DInput.h" />
     <ClInclude Include="InputCommon\ControllerInterface\DInput\DInput8.h" />
     <ClInclude Include="InputCommon\ControllerInterface\DInput\DInputJoystick.h" />
@@ -1111,6 +1112,7 @@
     <ClCompile Include="InputCommon\ControllerEmu\StickGate.cpp" />
     <ClCompile Include="InputCommon\ControllerInterface\ControllerInterface.cpp" />
     <ClCompile Include="InputCommon\ControllerInterface\CoreDevice.cpp" />
+    <ClCompile Include="InputCommon\ControllerInterface\InputBackend.cpp" />
     <ClCompile Include="InputCommon\ControllerInterface\DInput\DInput.cpp" />
     <ClCompile Include="InputCommon\ControllerInterface\DInput\DInputJoystick.cpp" />
     <ClCompile Include="InputCommon\ControllerInterface\DInput\DInputKeyboardMouse.cpp" />

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -56,6 +56,8 @@ add_library(inputcommon
   ControllerInterface/ControllerInterface.h
   ControllerInterface/CoreDevice.cpp
   ControllerInterface/CoreDevice.h
+  ControllerInterface/InputBackend.cpp
+  ControllerInterface/InputBackend.h
   ControllerInterface/MappingCommon.cpp
   ControllerInterface/MappingCommon.h
   ControllerInterface/Wiimote/WiimoteController.cpp

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -76,7 +76,7 @@ void ControllerInterface::Initialize(const WindowSystemInfo& wsi)
 // nothing needed
 #endif
 #ifdef CIFACE_USE_DUALSHOCKUDPCLIENT
-  ciface::DualShockUDPClient::Init();
+  m_input_backends.emplace_back(ciface::DualShockUDPClient::CreateInputBackend(this));
 #endif
 
   // Don't allow backends to add devices before the first RefreshDevices() as they will be cleaned
@@ -187,9 +187,6 @@ void ControllerInterface::RefreshDevices(RefreshReason reason)
 #ifdef CIFACE_USE_PIPES
   ciface::Pipes::PopulateDevices();
 #endif
-#ifdef CIFACE_USE_DUALSHOCKUDPCLIENT
-  ciface::DualShockUDPClient::PopulateDevices();
-#endif
 
   for (auto& backend : m_input_backends)
     backend->PopulateDevices();
@@ -241,9 +238,6 @@ void ControllerInterface::Shutdown()
 #endif
 #ifdef CIFACE_USE_ANDROID
 // nothing needed
-#endif
-#ifdef CIFACE_USE_DUALSHOCKUDPCLIENT
-  ciface::DualShockUDPClient::DeInit();
 #endif
 
   // Empty the container of input backends to deconstruct and deinitialize them.

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -70,7 +70,7 @@ void ControllerInterface::Initialize(const WindowSystemInfo& wsi)
 // nothing needed
 #endif
 #ifdef CIFACE_USE_EVDEV
-  ciface::evdev::Init();
+  m_input_backends.emplace_back(ciface::evdev::CreateInputBackend(this));
 #endif
 #ifdef CIFACE_USE_PIPES
 // nothing needed
@@ -184,9 +184,6 @@ void ControllerInterface::RefreshDevices(RefreshReason reason)
 #ifdef CIFACE_USE_ANDROID
   ciface::Android::PopulateDevices();
 #endif
-#ifdef CIFACE_USE_EVDEV
-  ciface::evdev::PopulateDevices();
-#endif
 #ifdef CIFACE_USE_PIPES
   ciface::Pipes::PopulateDevices();
 #endif
@@ -245,13 +242,11 @@ void ControllerInterface::Shutdown()
 #ifdef CIFACE_USE_ANDROID
 // nothing needed
 #endif
-#ifdef CIFACE_USE_EVDEV
-  ciface::evdev::Shutdown();
-#endif
 #ifdef CIFACE_USE_DUALSHOCKUDPCLIENT
   ciface::DualShockUDPClient::DeInit();
 #endif
 
+  // Empty the container of input backends to deconstruct and deinitialize them.
   m_input_backends.clear();
 
   // Make sure no devices had been added within Shutdown() in the time

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -12,6 +12,7 @@
 #include "Common/Matrix.h"
 #include "Common/WindowSystemInfo.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
+#include "InputCommon/ControllerInterface/InputBackend.h"
 
 // enable disable sources
 #ifdef _WIN32
@@ -133,6 +134,8 @@ private:
   WindowSystemInfo m_wsi;
   std::atomic<float> m_aspect_ratio_adjustment = 1;
   std::atomic<bool> m_requested_mouse_centering = false;
+
+  std::vector<std::unique_ptr<ciface::InputBackend>> m_input_backends;
 };
 
 namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Common/Config/Config.h"
+#include "InputCommon/ControllerInterface/InputBackend.h"
 
 namespace ciface::DualShockUDPClient
 {
@@ -20,7 +21,6 @@ extern const Config::Info<std::string> SERVERS;
 extern const Config::Info<bool> SERVERS_ENABLED;
 }  // namespace Settings
 
-void Init();
-void PopulateDevices();
-void DeInit();
+std::unique_ptr<ciface::InputBackend> CreateInputBackend(ControllerInterface* controller_interface);
+
 }  // namespace ciface::DualShockUDPClient

--- a/Source/Core/InputCommon/ControllerInterface/InputBackend.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/InputBackend.cpp
@@ -1,0 +1,24 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "InputCommon/ControllerInterface/InputBackend.h"
+
+namespace ciface
+{
+InputBackend::InputBackend(ControllerInterface* controller_interface)
+    : m_controller_interface(*controller_interface)
+{
+}
+
+InputBackend::~InputBackend() = default;
+
+void InputBackend::UpdateInput()
+{
+}
+
+ControllerInterface& InputBackend::GetControllerInterface()
+{
+  return m_controller_interface;
+}
+
+}  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/InputBackend.h
+++ b/Source/Core/InputCommon/ControllerInterface/InputBackend.h
@@ -1,0 +1,26 @@
+// Copyright 2022 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+class ControllerInterface;
+
+namespace ciface
+{
+class InputBackend
+{
+public:
+  InputBackend(ControllerInterface* controller_interface);
+
+  virtual ~InputBackend();
+
+  virtual void PopulateDevices() = 0;
+  virtual void UpdateInput();
+
+  ControllerInterface& GetControllerInterface();
+
+private:
+  ControllerInterface& m_controller_interface;
+};
+
+}  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -29,7 +29,33 @@ static std::string GetJoystickName(int index)
 #endif
 }
 
-static void OpenAndAddDevice(int index)
+class InputBackend final : public ciface::InputBackend
+{
+public:
+  InputBackend(ControllerInterface* controller_interface);
+  ~InputBackend();
+  void PopulateDevices() override;
+  void UpdateInput() override;
+
+private:
+  void OpenAndAddDevice(int index);
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+  bool HandleEventAndContinue(const SDL_Event& e);
+
+  Common::Event m_init_event;
+  Uint32 m_stop_event_type;
+  Uint32 m_populate_event_type;
+  std::thread m_hotplug_thread;
+#endif
+};
+
+std::unique_ptr<ciface::InputBackend> CreateInputBackend(ControllerInterface* controller_interface)
+{
+  return std::make_unique<InputBackend>(controller_interface);
+}
+
+void InputBackend::OpenAndAddDevice(int index)
 {
   SDL_Joystick* const dev = SDL_JoystickOpen(index);
   if (dev)
@@ -37,17 +63,13 @@ static void OpenAndAddDevice(int index)
     auto js = std::make_shared<Joystick>(dev, index);
     // only add if it has some inputs/outputs
     if (!js->Inputs().empty() || !js->Outputs().empty())
-      g_controller_interface.AddDevice(std::move(js));
+      GetControllerInterface().AddDevice(std::move(js));
   }
 }
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
-static Common::Event s_init_event;
-static Uint32 s_stop_event_type;
-static Uint32 s_populate_event_type;
-static std::thread s_hotplug_thread;
 
-static bool HandleEventAndContinue(const SDL_Event& e)
+bool InputBackend::HandleEventAndContinue(const SDL_Event& e)
 {
   if (e.type == SDL_JOYDEVICEADDED)
   {
@@ -55,20 +77,20 @@ static bool HandleEventAndContinue(const SDL_Event& e)
   }
   else if (e.type == SDL_JOYDEVICEREMOVED)
   {
-    g_controller_interface.RemoveDevice([&e](const auto* device) {
+    GetControllerInterface().RemoveDevice([&e](const auto* device) {
       return device->GetSource() == "SDL" &&
              SDL_JoystickInstanceID(static_cast<const Joystick*>(device)->GetSDLJoystick()) ==
                  e.jdevice.which;
     });
   }
-  else if (e.type == s_populate_event_type)
+  else if (e.type == m_populate_event_type)
   {
-    g_controller_interface.PlatformPopulateDevices([] {
+    GetControllerInterface().PlatformPopulateDevices([this] {
       for (int i = 0; i < SDL_NumJoysticks(); ++i)
         OpenAndAddDevice(i);
     });
   }
-  else if (e.type == s_stop_event_type)
+  else if (e.type == m_stop_event_type)
   {
     return false;
   }
@@ -144,7 +166,8 @@ static void EnableSDLLogging()
       nullptr);
 }
 
-void Init()
+InputBackend::InputBackend(ControllerInterface* controller_interface)
+    : ciface::InputBackend(controller_interface)
 {
 #if !SDL_VERSION_ATLEAST(2, 0, 0)
   if (SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC) != 0)
@@ -168,13 +191,13 @@ void Init()
   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
 #endif
 
-  s_hotplug_thread = std::thread([] {
+  m_hotplug_thread = std::thread([this] {
     Common::ScopeGuard quit_guard([] {
       // TODO: there seems to be some sort of memory leak with SDL, quit isn't freeing everything up
       SDL_Quit();
     });
     {
-      Common::ScopeGuard init_guard([] { s_init_event.Set(); });
+      Common::ScopeGuard init_guard([this] { m_init_event.Set(); });
 
       if (SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC | SDL_INIT_GAMECONTROLLER) != 0)
       {
@@ -188,8 +211,8 @@ void Init()
         ERROR_LOG_FMT(CONTROLLERINTERFACE, "SDL failed to register custom events");
         return;
       }
-      s_stop_event_type = custom_events_start;
-      s_populate_event_type = custom_events_start + 1;
+      m_stop_event_type = custom_events_start;
+      m_populate_event_type = custom_events_start + 1;
 
       // Drain all of the events and add the initial joysticks before returning. Otherwise, the
       // individual joystick events as well as the custom populate event will be handled _after_
@@ -235,26 +258,26 @@ void Init()
     }
   });
 
-  s_init_event.Wait();
+  m_init_event.Wait();
 #endif
 }
 
-void DeInit()
+InputBackend::~InputBackend()
 {
 #if !SDL_VERSION_ATLEAST(2, 0, 0)
   SDL_Quit();
 #else
-  if (!s_hotplug_thread.joinable())
+  if (!m_hotplug_thread.joinable())
     return;
 
-  SDL_Event stop_event{s_stop_event_type};
+  SDL_Event stop_event{m_stop_event_type};
   SDL_PushEvent(&stop_event);
 
-  s_hotplug_thread.join();
+  m_hotplug_thread.join();
 #endif
 }
 
-void PopulateDevices()
+void InputBackend::PopulateDevices()
 {
 #if !SDL_VERSION_ATLEAST(2, 0, 0)
   if (!SDL_WasInit(SDL_INIT_JOYSTICK))
@@ -263,10 +286,10 @@ void PopulateDevices()
   for (int i = 0; i < SDL_NumJoysticks(); ++i)
     OpenAndAddDevice(i);
 #else
-  if (!s_hotplug_thread.joinable())
+  if (!m_hotplug_thread.joinable())
     return;
 
-  SDL_Event populate_event{s_populate_event_type};
+  SDL_Event populate_event{m_populate_event_type};
   SDL_PushEvent(&populate_event);
 #endif
 }
@@ -617,9 +640,8 @@ void Joystick::Motor::SetState(ControlState state)
 }
 #endif
 
-void Joystick::UpdateInput()
+void InputBackend::UpdateInput()
 {
-  // TODO: Don't call this for every Joystick, only once per ControllerInterface::UpdateInput()
   SDL_JoystickUpdate();
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -22,12 +22,11 @@
 #endif
 
 #include "InputCommon/ControllerInterface/CoreDevice.h"
+#include "InputCommon/ControllerInterface/InputBackend.h"
 
 namespace ciface::SDL
 {
-void Init();
-void DeInit();
-void PopulateDevices();
+std::unique_ptr<ciface::InputBackend> CreateInputBackend(ControllerInterface* controller_interface);
 
 class Joystick : public Core::Device
 {
@@ -182,8 +181,6 @@ private:
 #endif
 
 public:
-  void UpdateInput() override;
-
   Joystick(SDL_Joystick* const joystick, const int sdl_index);
   ~Joystick();
 

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
@@ -11,9 +11,9 @@
 
 namespace ciface::evdev
 {
-void Init();
-void PopulateDevices();
-void Shutdown();
+class InputBackend;
+
+std::unique_ptr<ciface::InputBackend> CreateInputBackend(ControllerInterface* controller_interface);
 
 class evdevDevice : public Core::Device
 {
@@ -75,6 +75,7 @@ public:
   void UpdateInput() override;
   bool IsValid() const override;
 
+  evdevDevice(InputBackend* input_backend);
   ~evdevDevice();
 
   // Return true if node was "interesting".
@@ -97,5 +98,7 @@ private:
   };
 
   std::vector<Node> m_nodes;
+
+  InputBackend& m_input_backend;
 };
 }  // namespace ciface::evdev


### PR DESCRIPTION
This adds an `InputBackend` interface for `ControllerInterface` to use to init/deinit/populate the various input backends with fewer `#ifdefs`.

Moving the input backend code into classes also eliminates their global state.

I've only changed SDL, evdev, and DSU so far. Maybe that is enough for this PR.