### PR TITLE
GameSettings: Properly set MissingColorValue for Lego Indiana Jones 1

### DIFF
--- a/Data/Sys/GameSettings/RLI.ini
+++ b/Data/Sys/GameSettings/RLI.ini
@@ -1,5 +1,5 @@
 # RLIE64, RLIP64 - Lego Indiana Jones: The Original Adventures
 
-[Video_Settings]
+[Video_Hacks]
 # Fixes the alpha value of glpyh puzzles; see https://bugs.dolphin-emu.org/issues/12987
 MissingColorValue = 0xFFFFFF82


### PR DESCRIPTION
In 3465b2af2717ea1e54f866c2857c455b1761efe0 (#10937) I incorrectly put it under [Video_Settings] instead of [Video_Hacks], so it didn't work. https://bugs.dolphin-emu.org/issues/12987 should now properly be fixed.