### PR TITLE
MemoryPatches: Fix instruction patches

### DIFF
--- a/Source/Core/Common/Debug/MemoryPatches.cpp
+++ b/Source/Core/Common/Debug/MemoryPatches.cpp
@@ -32,6 +32,7 @@ void MemoryPatches::SetPatch(u32 address, u32 value)
 
 void MemoryPatches::SetPatch(u32 address, std::vector<u8> value)
 {
+  UnsetPatch(address);
   const std::size_t index = m_patches.size();
   m_patches.emplace_back(address, std::move(value));
   Patch(index);
@@ -45,7 +46,7 @@ const std::vector<MemoryPatch>& MemoryPatches::GetPatches() const
 void MemoryPatches::UnsetPatch(u32 address)
 {
   const auto it = std::find_if(m_patches.begin(), m_patches.end(),
-                                 [address](const auto& patch) { return patch.address == address; });
+                               [address](const auto& patch) { return patch.address == address; });
 
   if (it == m_patches.end())
     return;

--- a/Source/Core/Common/Debug/MemoryPatches.cpp
+++ b/Source/Core/Common/Debug/MemoryPatches.cpp
@@ -50,14 +50,8 @@ void MemoryPatches::UnsetPatch(u32 address)
   if (it == m_patches.end())
     return;
 
-  const std::size_t size = m_patches.size();
-  std::size_t index = size - std::distance(it, m_patches.end());
-  while (index < size)
-  {
-    DisablePatch(index);
-    ++index;
-  }
-  m_patches.erase(it, m_patches.end());
+  const std::size_t index = std::distance(m_patches.begin(), it);
+  RemovePatch(index);
 }
 
 void MemoryPatches::EnablePatch(std::size_t index)

--- a/Source/Core/Common/Debug/MemoryPatches.cpp
+++ b/Source/Core/Common/Debug/MemoryPatches.cpp
@@ -44,7 +44,7 @@ const std::vector<MemoryPatch>& MemoryPatches::GetPatches() const
 
 void MemoryPatches::UnsetPatch(u32 address)
 {
-  const auto it = std::remove_if(m_patches.begin(), m_patches.end(),
+  const auto it = std::find_if(m_patches.begin(), m_patches.end(),
                                  [address](const auto& patch) { return patch.address == address; });
 
   if (it == m_patches.end())

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -513,7 +513,6 @@ void CodeViewWidget::SetAddress(u32 address, SetAddressUpdate update)
 
 void CodeViewWidget::ReplaceAddress(u32 address, ReplaceWith replace)
 {
-  PowerPC::debug_interface.UnsetPatch(address);
   PowerPC::debug_interface.SetPatch(address, replace == ReplaceWith::BLR ? 0x4e800020 : 0x60000000);
   Update();
 }
@@ -823,7 +822,6 @@ void CodeViewWidget::OnReplaceInstruction()
 
   if (dialog.exec() == QDialog::Accepted)
   {
-    PowerPC::debug_interface.UnsetPatch(addr);
     PowerPC::debug_interface.SetPatch(addr, dialog.GetCode());
     Update();
   }


### PR DESCRIPTION
For a long while, multiple patched instructions at a time could only be restored in reverse order of patching. This PR fixes the oversight, allowing users to restore patched instructions in any order they like.