### PR TITLE
Android: Enable predictive back gesture

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -143,6 +143,7 @@ dependencies {
     implementation 'androidx.core:core-splashscreen:1.0.0'
     implementation 'androidx.preference:preference:1.2.0'
     implementation 'androidx.profileinstaller:profileinstaller:1.2.2'
+    implementation 'androidx.activity:activity:1.6.1'
 
     // Force dependency version to solve build conflict with androidx preferences
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"

--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -41,7 +41,8 @@
         android:supportsRtl="true"
         android:isGame="true"
         android:banner="@drawable/banner_tv"
-        android:hasFragileUserData="true">
+        android:hasFragileUserData="true"
+        android:enableOnBackInvokedCallback="true">
         <meta-data
             android:name="android.max_aspect"
             android:value="2.1"/>

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -22,6 +22,7 @@ import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -385,6 +386,18 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
     if (NativeLibrary.IsGameMetadataValid())
       setTitle(NativeLibrary.GetCurrentTitleDescription());
 
+    getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true)
+    {
+      @Override
+      public void handleOnBackPressed()
+      {
+        if (!closeSubmenu())
+        {
+          toggleMenu();
+        }
+      }
+    });
+
     if (sSkylanderSlots.isEmpty())
     {
       for (int i = 0; i < 8; i++)
@@ -499,26 +512,6 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
   {
     super.onDestroy();
     mSettings.close();
-  }
-
-  @Override
-  public void onBackPressed()
-  {
-    if (!closeSubmenu())
-    {
-      toggleMenu();
-    }
-  }
-
-  @Override
-  public boolean onKeyLongPress(int keyCode, @NonNull KeyEvent event)
-  {
-    if (keyCode == KeyEvent.KEYCODE_BACK)
-    {
-      mEmulationFragment.stopEmulation();
-      return true;
-    }
-    return super.onKeyLongPress(keyCode, event);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/MotionAlertDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/MotionAlertDialog.java
@@ -62,19 +62,6 @@ public final class MotionAlertDialog extends AlertDialog
   }
 
   @Override
-  public boolean onKeyLongPress(int keyCode, @NonNull KeyEvent event)
-  {
-    // Intended for devices with no touchscreen or mouse
-    if (keyCode == KeyEvent.KEYCODE_BACK)
-    {
-      setting.clearValue(mAdapter.getSettings());
-      dismiss();
-      return true;
-    }
-    return super.onKeyLongPress(keyCode, event);
-  }
-
-  @Override
   public boolean dispatchKeyEvent(KeyEvent event)
   {
     // Handle this key if we care about it, otherwise pass it down the framework

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -627,7 +627,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="emulation_control_joystick_rel_center">Relative Stick Center</string>
     <string name="emulation_control_rumble">Rumble</string>
     <string name="emulation_choose_controller">Choose Controller</string>
-    <string name="emulation_menu_help">Press Back to access the menu.\nLong press Back to exit emulation.</string>
+    <string name="emulation_menu_help">Press Back to access the menu.</string>
     <string name="emulation_touch_overlay_reset">Reset Overlay</string>
     <string name="emulation_ir_group">Touch IR Pointer</string>
     <string name="emulation_ir_recenter">Always recenter</string>


### PR DESCRIPTION
This prepares the app for future changes to the back gesture. Not visible unless you enable a developer option for now, but it will be enabled by default in future android versions. API explained [here](https://developer.android.com/guide/navigation/predictive-back-gesture)

![demo](https://user-images.githubusercontent.com/14132249/197571171-80f4d226-8e0a-48be-92c7-f04d6eb69635.gif)
