### PR TITLE
VideoBackends:Metal: Default to presentDrawable when vsync is on

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -89,8 +89,8 @@ const Info<bool> GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION{
 
 const Info<TriState> GFX_MTL_MANUALLY_UPLOAD_BUFFERS{
     {System::GFX, "Settings", "ManuallyUploadBuffers"}, TriState::Auto};
-const Info<bool> GFX_MTL_USE_PRESENT_DRAWABLE{{System::GFX, "Settings", "MTLUsePresentDrawable"},
-                                              false};
+const Info<TriState> GFX_MTL_USE_PRESENT_DRAWABLE{
+    {System::GFX, "Settings", "MTLUsePresentDrawable"}, TriState::Auto};
 
 const Info<bool> GFX_SW_DUMP_OBJECTS{{System::GFX, "Settings", "SWDumpObjects"}, false};
 const Info<bool> GFX_SW_DUMP_TEV_STAGES{{System::GFX, "Settings", "SWDumpTevStages"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -77,7 +77,7 @@ extern const Info<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE;
 extern const Info<bool> GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION;
 
 extern const Info<TriState> GFX_MTL_MANUALLY_UPLOAD_BUFFERS;
-extern const Info<bool> GFX_MTL_USE_PRESENT_DRAWABLE;
+extern const Info<TriState> GFX_MTL_USE_PRESENT_DRAWABLE;
 
 extern const Info<bool> GFX_SW_DUMP_OBJECTS;
 extern const Info<bool> GFX_SW_DUMP_TEV_STAGES;

--- a/Source/Core/VideoBackends/Metal/MTLRenderer.mm
+++ b/Source/Core/VideoBackends/Metal/MTLRenderer.mm
@@ -459,7 +459,9 @@ void Metal::Renderer::PresentBackbuffer()
       // when windowed (or fullscreen with vsync enabled, but that's more understandable).
       // On the other hand, it helps Xcode's GPU captures start and stop on frame boundaries
       // which is convenient.  Put it here as a default-off config, which we can override in Xcode.
-      if (g_ActiveConfig.bUsePresentDrawable)
+      // It also seems to improve frame pacing, so enable it by default with vsync
+      if (g_ActiveConfig.iUsePresentDrawable == TriState::On ||
+          (g_ActiveConfig.iUsePresentDrawable == TriState::Auto && g_ActiveConfig.bVSyncActive))
         [g_state_tracker->GetRenderCmdBuf() presentDrawable:m_drawable];
       else
         [g_state_tracker->GetRenderCmdBuf()

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -56,7 +56,7 @@ void VideoConfig::Refresh()
   bVSync = Config::Get(Config::GFX_VSYNC);
   iAdapter = Config::Get(Config::GFX_ADAPTER);
   iManuallyUploadBuffers = Config::Get(Config::GFX_MTL_MANUALLY_UPLOAD_BUFFERS);
-  bUsePresentDrawable = Config::Get(Config::GFX_MTL_USE_PRESENT_DRAWABLE);
+  iUsePresentDrawable = Config::Get(Config::GFX_MTL_USE_PRESENT_DRAWABLE);
 
   bWidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
   aspect_mode = Config::Get(Config::GFX_ASPECT_RATIO);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -158,7 +158,7 @@ struct VideoConfig final
 
   // Metal only config
   TriState iManuallyUploadBuffers = TriState::Auto;
-  bool bUsePresentDrawable = false;
+  TriState iUsePresentDrawable = TriState::Auto;
 
   // Enable API validation layers, currently only supported with Vulkan.
   bool bEnableValidationLayer = false;


### PR DESCRIPTION
I added the presentDrawable option in #11028 and it looks like it improves frame pacing on 60hz displays, so default it on when vsync is on, since it looks like we disable vsync during fast forward

@dvessel could you test and see if it works without the special config option now?  (You'll still need to force 59.94hz)

And then make sure fast forward still works

Note: This means users of <60hz displays will have to set `MTLUsePresentDrawable=0` in their configs.  Hopefully most people have ≥60hz displays.