### PR TITLE
VideoCommon: Treat invalid normal count as NormalTangentBinormal

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -270,10 +270,8 @@ static void CheckCPConfiguration(int vtx_attr_group)
     num_xf_normals = 1;
     break;
   case NormalCount::NormalTangentBinormal:
+  case NormalCount::Invalid:  // see https://bugs.dolphin-emu.org/issues/13070
     num_xf_normals = 3;
-    break;
-  default:
-    PanicAlertFmt("xfmem.invtxspec.numnormals is invalid: {}", xfmem.invtxspec.numnormals);
     break;
   }
 

--- a/Source/Core/VideoCommon/XFMemory.h
+++ b/Source/Core/VideoCommon/XFMemory.h
@@ -45,12 +45,21 @@ enum class NormalCount : u32
 {
   None = 0,
   Normal = 1,
-  NormalTangentBinormal = 2
+  NormalTangentBinormal = 2,
+  // Hardware testing indicates that this beahves the same as NormalTangentBinormal.
+  // Call of Duty: Black Ops uses this in some cases; see https://bugs.dolphin-emu.org/issues/13070
+  Invalid = 3,
 };
 template <>
-struct fmt::formatter<NormalCount> : EnumFormatter<NormalCount::NormalTangentBinormal>
+struct fmt::formatter<NormalCount> : EnumFormatter<NormalCount::Invalid>
 {
-  constexpr formatter() : EnumFormatter({"None", "Normal only", "Normal, tangent, and binormal"}) {}
+  static constexpr array_type names = {
+      "None",
+      "Normal only",
+      "Normal, tangent, and binormal",
+      "Invalid (Normal, tangent, and binormal)",
+  };
+  constexpr formatter() : EnumFormatter(names) {}
 };
 
 // Texture generation type


### PR DESCRIPTION
See https://bugs.dolphin-emu.org/issues/13070.

I hardware tested this using the `codcamp.dff` fifolog from that issue, along with a version I hex-edited, using the [hardware fifoplayer](https://github.com/pokechu22/fifoplayer/tree/improved): [codcamp.7z.zip](https://github.com/dolphin-emu/dolphin/files/9857430/codcamp.7z.zip). Note that the last object in this fifolog needs to be disabled to get rid of a white screen (and the one before it can be removed to disable bloom). Specifically, I edited object 476 on frame 0, at offsets 00175d49 and 00175d54. The default version uses XFMEM_VTXSPECS with Num normals: Invalid (3) and CP_VAT_REG_A with Normal elements: 3 (normal, tangent, binormal) (1), while my hex-edited version uses Num normals: Normal only (1) and Normal elements: 1 (normal) (0). (I had to hex-edit it so that I had working base versions, as changing two fields at once could result in hangs if a frame gets drawn when only one of them is changed).

Here are my results (rows XFMEM_VTXSPECS, columns CP_VAT_REG_A):

||Normal|Normal, Tangent, Binormal|
|-|-|-|
|None (10)|Hang|Hang|
|Normal only (14)|Works|Hang|
|NTB (18)|Hang|Works|
|Invalid (1C)|Hang|Works|

The hardware fifoplayer didn't make it easy to test no normals enabled at all (since that would involve editing primitive data). I assume that it hangs if XFMEM_VTXSPECS isn't set to None, though.

I also confirmed that Dolphin is rendering the scene (particularly the reflections on the bag) correctly.