### PR TITLE
Force EFB2RAM in WWE WrestleMania XIX

### DIFF
--- a/Data/Sys/GameSettings/GW9.ini
+++ b/Data/Sys/GameSettings/GW9.ini
@@ -1,0 +1,17 @@
+# GW9E78, GW9P78, GW9JG2 - WWE WrestleMania XIX
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False
+


### PR DESCRIPTION
Fixes invisible character models in Revenge Mode.