### PR TITLE
DolphinQt: Fix window focus from unpausing after a manual pause.

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -397,8 +397,10 @@ bool RenderWidget::event(QEvent* event)
   // Note that this event in Windows is not always aligned to the window that is highlighted,
   // it's the window that has keyboard and mouse focus
   case QEvent::WindowActivate:
-    if (Config::Get(Config::MAIN_PAUSE_ON_FOCUS_LOST) && Core::GetState() == Core::State::Paused)
+    if (m_should_unpause_on_focus && Core::GetState() == Core::State::Paused)
       Core::SetState(Core::State::Running);
+
+    m_should_unpause_on_focus = false;
 
     UpdateCursor();
 
@@ -425,7 +427,10 @@ bool RenderWidget::event(QEvent* event)
       // is waiting for us to finish showing a panic alert (with that panic alert likely being
       // the cause of this event), so trying to pause the core would cause a deadlock
       if (!Core::IsCPUThread() && !Core::IsGPUThread())
+      {
+        m_should_unpause_on_focus = true;
         Core::SetState(Core::State::Paused);
+      }
     }
 
     emit FocusChanged(false);

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -51,4 +51,5 @@ private:
   bool m_lock_cursor_on_next_activation = false;
   bool m_dont_lock_cursor_on_show = false;
   bool m_waiting_for_message_box = false;
+  bool m_should_unpause_on_focus = false;
 };


### PR DESCRIPTION
Now the "Pause on Focus Loss" setting will not unpause unless it actually performed the pause.
This fixes issue: https://bugs.dolphin-emu.org/issues/13071

I've purposely removed the `Config::Get(Config::MAIN_PAUSE_ON_FOCUS_LOST)` check in the `WindowActivate` event to produce the following desirable behavior:

The user notices the emulator is pausing on focus loss but they don't want this.
They open the config (causing the emulator to automatically pause).
They disable the "Pause on Focus Loss" setting and close the config window.
The emulator automatically resumes, despite the setting now being disabled, because it was automatically paused previously.
This is what they want. They want the game to be running now.