### PR TITLE
GameINI:  Enable slight CPU Overclock for Manhunt 2

### DIFF
--- a/Data/Sys/GameSettings/RHT.ini
+++ b/Data/Sys/GameSettings/RHT.ini
@@ -1,0 +1,23 @@
+# RHTP54, RHTE54 - Manhunt 2
+
+[Core]
+# HACK:  FMVs will lockup at the default CPU clock rate.
+# Enable a CPU clock override to allow the game to progress.
+
+OverclockEnable = True
+Overclock = 1.25
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+# Add video settings here.
+
+[Video_Hacks]
+# Add video hacks here.


### PR DESCRIPTION
Fixes video hangs in single core and unknown opcodes during FMVs in Dualcore.

Game is technically playable in Single Core without this, but you have to wait an absolute eternity during the opening cutscene, as it is unskippable.  Dualcore will usually crash with unknown opcodes.

This is 100% a hack, but until we have a CPU timing rewrite, maybe it'd be best to take care of the most extreme cases of games not running at all by default instead of forcing users to figure it out.