### PR TITLE
GraphicsSettings: Remove unused FreelookControlType enum forward declaration

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -10,7 +10,6 @@
 enum class AspectMode : int;
 enum class ShaderCompilationMode : int;
 enum class StereoMode : int;
-enum class FreelookControlType : int;
 enum class TriState : int;
 
 namespace Config


### PR DESCRIPTION
This enum doesn't even exist. The correct one is forward-declared in FreeLookSettings:

https://github.com/dolphin-emu/dolphin/blob/d367b3ec3bba9ca53deb3d08d636c75115a68b31/Source/Core/Core/Config/FreeLookSettings.h#L8-L11