### PR TITLE
Disable Vertex Rounding in Wii Play

### DIFF
--- a/Data/Sys/GameSettings/RHA.ini
+++ b/Data/Sys/GameSettings/RHA.ini
@@ -12,3 +12,7 @@ CPUThread = False
 
 [ActionReplay]
 # Add action replay cheats here.
+
+[Video_Hacks]
+VertexRounding = False
+


### PR DESCRIPTION
Prevents severe graphical issues in "Tanks" Minigame.