### PR TITLE
Disable "Force Texture Filtering" in Owls of Ga'Hoole

### DIFF
--- a/Data/Sys/GameSettings/R9G.ini
+++ b/Data/Sys/GameSettings/R9G.ini
@@ -1,0 +1,20 @@
+# R9GEWR, R9GPWR - Legend of the Guardians: The Owls of Ga'Hoole
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+# Add video hacks here.
+
+[Video_Settings]
+# Fixes FMVs
+ForceFiltering = False


### PR DESCRIPTION
Fixes broken FMV visuals.