### PR TITLE
Disable Vertex Rounding in New Super Mario Bros. Wii

### DIFF
--- a/Data/Sys/GameSettings/SMN.ini
+++ b/Data/Sys/GameSettings/SMN.ini
@@ -1,4 +1,4 @@
-# SMNE01, SMNJ01, SMNK01, SMNP01, SMNW01 - New SUPER MARIO BROS. Wii
+# SMNE01, SMNJ01, SMNK01, SMNP01, SMNW01 - New Super Mario Bros. Wii
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -13,6 +13,8 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
+# Vertex Rounding being enabled causes animation issues.
+VertexRounding = False
 
 [Video_Stereoscopy]
 #Only affects overworld map


### PR DESCRIPTION
Vertex Rounding causes severe animation issues on 3D models, so let's disable it.  Also correct the game title to match the wiki.