### PR TITLE
Enable MMU in Pokemon XD

### DIFF
--- a/Data/Sys/GameSettings/GXX.ini
+++ b/Data/Sys/GameSettings/GXX.ini
@@ -1,8 +1,11 @@
-# GXXE01, GXXP01 - POKeMON XD
+# GXXE01, GXXP01, GXXJ01 - POKeMON XD
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Prevents crash when Greevil's henchman and Zook show up
 CPUThread = False
+# Prevents various invalid read errors, especially during
+# normal (multiplayer) battles when doing multiple battles in a row.
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -14,4 +17,5 @@ CPUThread = False
 # Add action replay cheats here.
 
 [Video_Settings]
+# Fixes garbled text.
 SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
Fixes invalid read spam during normal battles and Pokemon Bingo.  Also reannotated the INI file to say what each setting fixed for future reference.