### PR TITLE
Add Force Progressive Patch for Egg Mania

### DIFF
--- a/Data/Sys/GameSettings/GEME7F.ini
+++ b/Data/Sys/GameSettings/GEME7F.ini
@@ -1,0 +1,12 @@
+# GEME7F - Egg Mania: Eggstreme Madness
+
+[OnFrame]
+# This game does not support Progressive Scan or Dolphin's
+# "Force Progressive" hack.  However this patch can be used 
+# to substitute field rendering with full frame rendering.
+$Force Progressive Scan
+0x800331BE:word:0x000001C0
+0x800331FC:dword:0x60000000
+0x806D0898:dword:0x801671CC
+[OnFrame_Enabled]
+$Force Progressive Scan

--- a/Data/Sys/GameSettings/GEMJ28.ini
+++ b/Data/Sys/GameSettings/GEMJ28.ini
@@ -1,0 +1,12 @@
+# GEMJ28 - Egg Mania: Eggstreme Madness
+
+[OnFrame]
+# This game does not support Progressive Scan or Dolphin's
+# "Force Progressive" hack.  However this patch can be used 
+# to substitute field rendering with full frame rendering.
+$Force Progressive Scan
+0x80033062:word:0x000001C0
+0x800330A0:dword:0x60000000
+0x806D0660:dword:0x801640A4
+[OnFrame_Enabled]
+$Force Progressive Scan


### PR DESCRIPTION
Allows the NTSC and NTSC-J versions to use full frame rendering.  This allows them to behave correctly with Dolphin's Force Progressive hack.  Without this patch, the game shake up and down 1 pixel every other frame.

Codes originally from Swiss, written by Extrems.