### PR TITLE
Disable Force Texture Filtering in DKCR

### DIFF
--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -15,5 +15,9 @@
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+[Video_Enhancements]
+# Enabling this causes Donkey Kong/Diddy Kong to have an outline.
+ForceFiltering = False
+
 [Video_Stereoscopy]
 StereoConvergence = 26


### PR DESCRIPTION
This enhancement causes a rather distracting outline around the main characters.  Let's disable it for users who use this setting in other games so they don't have to go hunting around to figure out what is breaking rendering.