### PR TITLE
VideoBackends: fix d3d12 subresource calculation

### DIFF
--- a/Source/Core/VideoBackends/D3D12/DX12Texture.h
+++ b/Source/Core/VideoBackends/D3D12/DX12Texture.h
@@ -37,7 +37,7 @@ public:
   const DescriptorHandle& GetSRVDescriptor() const { return m_srv_descriptor; }
   const DescriptorHandle& GetUAVDescriptor() const { return m_uav_descriptor; }
   D3D12_RESOURCE_STATES GetState() const { return m_state; }
-  u32 CalcSubresource(u32 level, u32 layer) const { return level + layer * m_config.layers; }
+  u32 CalcSubresource(u32 level, u32 layer) const { return level + layer * m_config.levels; }
 
   void TransitionToState(D3D12_RESOURCE_STATES state) const;
 


### PR DESCRIPTION
This pulls out the D3D12 fix for calculating the subresource from my post processing overhaul.

See section "subresource indexing" in https://learn.microsoft.com/en-us/windows/win32/direct3d12/subresources

Example, if our level count is 2 and our layer count is 3.  We want to access the 2nd level and the 2nd layer.

We'd have this in master:

`CalcSubresources(1, 1) => 4`

vs this with the change:

`CalcSubresources(1, 1) => 3`