### PR TITLE
VideoCommon: call texture load graphics mod hook when textures are loaded

### DIFF
--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.cpp
@@ -35,7 +35,10 @@ void PrintAction::OnProjectionAndTexture(GraphicsModActionData::Projection*)
   INFO_LOG_FMT(VIDEO, "OnProjectionAndTexture Called");
 }
 
-void PrintAction::OnTextureLoad()
+void PrintAction::OnTextureLoad(GraphicsModActionData::TextureLoad* texture_load)
 {
-  INFO_LOG_FMT(VIDEO, "OnTextureLoad Called");
+  if (!texture_load) [[unlikely]]
+    return;
+
+  INFO_LOG_FMT(VIDEO, "OnTextureLoad Called.  Texture: {}", texture_load->texture_name);
 }

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.h
@@ -12,5 +12,5 @@ public:
   void OnEFB(GraphicsModActionData::EFB*) override;
   void OnProjection(GraphicsModActionData::Projection*) override;
   void OnProjectionAndTexture(GraphicsModActionData::Projection*) override;
-  void OnTextureLoad() override;
+  void OnTextureLoad(GraphicsModActionData::TextureLoad*) override;
 };

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModAction.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModAction.h
@@ -20,6 +20,6 @@ public:
   virtual void OnXFB() {}
   virtual void OnProjection(GraphicsModActionData::Projection*) {}
   virtual void OnProjectionAndTexture(GraphicsModActionData::Projection*) {}
-  virtual void OnTextureLoad() {}
+  virtual void OnTextureLoad(GraphicsModActionData::TextureLoad*) {}
   virtual void OnFrameEnd() {}
 };

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionData.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionData.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "Common/CommonTypes.h"
 #include "Common/Matrix.h"
 
@@ -25,5 +27,9 @@ struct EFB
 struct Projection
 {
   Common::Matrix44* matrix;
+};
+struct TextureLoad
+{
+  std::string_view texture_name;
 };
 }  // namespace GraphicsModActionData

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
@@ -46,11 +46,11 @@ public:
       return;
     m_action_impl->OnProjectionAndTexture(projection);
   }
-  void OnTextureLoad() override
+  void OnTextureLoad(GraphicsModActionData::TextureLoad* texture_load) override
   {
     if (!m_mod.m_enabled)
       return;
-    m_action_impl->OnTextureLoad();
+    m_action_impl->OnTextureLoad(texture_load);
   }
   void OnFrameEnd() override
   {
@@ -105,8 +105,8 @@ GraphicsModManager::GetDrawStartedActions(const std::string& texture_name) const
 const std::vector<GraphicsModAction*>&
 GraphicsModManager::GetTextureLoadActions(const std::string& texture_name) const
 {
-  if (const auto it = m_load_target_to_actions.find(texture_name);
-      it != m_load_target_to_actions.end())
+  if (const auto it = m_load_texture_target_to_actions.find(texture_name);
+      it != m_load_texture_target_to_actions.end())
   {
     return it->second;
   }
@@ -196,7 +196,7 @@ void GraphicsModManager::Load(const GraphicsModGroupConfig& config)
                       m_actions.back().get());
                 },
                 [&](const LoadTextureTarget& the_target) {
-                  m_load_target_to_actions[the_target.m_texture_info_string].push_back(
+                  m_load_texture_target_to_actions[the_target.m_texture_info_string].push_back(
                       m_actions.back().get());
                 },
                 [&](const EFBTarget& the_target) {
@@ -272,7 +272,7 @@ void GraphicsModManager::Reset()
   m_projection_target_to_actions.clear();
   m_projection_texture_target_to_actions.clear();
   m_draw_started_target_to_actions.clear();
-  m_load_target_to_actions.clear();
+  m_load_texture_target_to_actions.clear();
   m_efb_target_to_actions.clear();
   m_xfb_target_to_actions.clear();
 }

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.h
@@ -46,7 +46,7 @@ private:
   std::unordered_map<std::string, std::vector<GraphicsModAction*>>
       m_projection_texture_target_to_actions;
   std::unordered_map<std::string, std::vector<GraphicsModAction*>> m_draw_started_target_to_actions;
-  std::unordered_map<std::string, std::vector<GraphicsModAction*>> m_load_target_to_actions;
+  std::unordered_map<std::string, std::vector<GraphicsModAction*>> m_load_texture_target_to_actions;
   std::unordered_map<FBInfo, std::vector<GraphicsModAction*>, FBInfoHasher> m_efb_target_to_actions;
   std::unordered_map<FBInfo, std::vector<GraphicsModAction*>, FBInfoHasher> m_xfb_target_to_actions;
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1243,6 +1243,13 @@ TextureCacheBase::TCacheEntry* TextureCacheBase::Load(const TextureInfo& texture
   if (entry->texture_info_name.empty() && g_ActiveConfig.bGraphicMods)
   {
     entry->texture_info_name = texture_info.CalculateTextureName().GetFullName();
+
+    GraphicsModActionData::TextureLoad texture_load{entry->texture_info_name};
+    for (const auto action :
+         g_renderer->GetGraphicsModManager().GetTextureLoadActions(entry->texture_info_name))
+    {
+      action->OnTextureLoad(&texture_load);
+    }
   }
   bound_textures[texture_info.GetStage()] = entry;
 


### PR DESCRIPTION
I missed this in my initial graphics mod review.  I created a texture load hook but never called into it!  This fixes that.

This change will be used in a couple upcoming graphics mod PRs.