### PR TITLE
JitArm64: Move MMIO handler result before popping stack

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -141,8 +141,12 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
   }
   else if (mmio_address)
   {
+    regs_in_use[DecodeReg(ARM64Reg::W0)] = 0;
+    regs_in_use[DecodeReg(ARM64Reg::W30)] = 0;
+    regs_in_use[DecodeReg(dest_reg)] = 0;
     MMIOLoadToReg(Memory::mmio_mapping.get(), this, &m_float_emit, regs_in_use, fprs_in_use,
                   dest_reg, mmio_address, flags);
+    addr_reg_set = false;
   }
   else
   {
@@ -308,8 +312,13 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
   }
   else if (mmio_address)
   {
+    regs_in_use[DecodeReg(ARM64Reg::W0)] = 0;
+    regs_in_use[DecodeReg(ARM64Reg::W1)] = 0;
+    regs_in_use[DecodeReg(ARM64Reg::W30)] = 0;
+    regs_in_use[DecodeReg(RS)] = 0;
     MMIOWriteRegToAddr(Memory::mmio_mapping.get(), this, &m_float_emit, regs_in_use, fprs_in_use,
                        RS, mmio_address, flags);
+    addr_reg_set = false;
   }
   else
   {

--- a/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
@@ -78,9 +78,11 @@ private:
 
     m_emit->ABI_PushRegisters(m_gprs_in_use);
     float_emit.ABI_PushRegisters(m_fprs_in_use, ARM64Reg::X1);
+
     m_emit->MOVI2R(ARM64Reg::W1, m_address);
     m_emit->MOV(ARM64Reg::W2, m_src_reg);
     m_emit->BLR(m_emit->ABI_SetupLambda(lambda));
+
     float_emit.ABI_PopRegisters(m_fprs_in_use, ARM64Reg::X1);
     m_emit->ABI_PopRegisters(m_gprs_in_use);
   }
@@ -173,15 +175,16 @@ private:
 
     m_emit->ABI_PushRegisters(m_gprs_in_use);
     float_emit.ABI_PushRegisters(m_fprs_in_use, ARM64Reg::X1);
+
     m_emit->MOVI2R(ARM64Reg::W1, m_address);
     m_emit->BLR(m_emit->ABI_SetupLambda(lambda));
-    float_emit.ABI_PopRegisters(m_fprs_in_use, ARM64Reg::X1);
-    m_emit->ABI_PopRegisters(m_gprs_in_use);
-
     if (m_sign_extend)
       m_emit->SBFM(m_dst_reg, ARM64Reg::W0, 0, sbits - 1);
     else
       m_emit->UBFM(m_dst_reg, ARM64Reg::W0, 0, sbits - 1);
+
+    float_emit.ABI_PopRegisters(m_fprs_in_use, ARM64Reg::X1);
+    m_emit->ABI_PopRegisters(m_gprs_in_use);
   }
 
   ARM64XEmitter* m_emit;


### PR DESCRIPTION
Otherwise we might throw the result away. Fixes https://bugs.dolphin-emu.org/issues/13083.