### PR TITLE
VolumeVerifier: fix bogus "serial/version missing" error

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -238,14 +238,15 @@ std::vector<RedumpVerifier::PotentialMatch> RedumpVerifier::ScanDatfile(const st
 
     const int version = version_string.empty() ? 0 : std::stoi(version_string);
 
+    const std::string serials = game.child("serial").text().as_string();
+    if (!serials.empty())
+      serials_exist = true;
+
     // The revisions for Korean GameCube games whose four-char game IDs end in E are numbered from
     // 0x30 in ring codes and in disc headers, but Redump switched to numbering them from 0 in 2019.
     if (version % 0x30 != m_revision % 0x30)
       continue;
 
-    const std::string serials = game.child("serial").text().as_string();
-    if (!serials.empty())
-      serials_exist = true;
     if (serials.empty() || StringBeginsWith(serials, "DS"))
     {
       // GC Datel discs have no serials in Redump, Wii Datel discs have serials like "DS000101"


### PR DESCRIPTION
When searching for a disc where the revision doesn't match any disc in the datfile, the loop would never get to the part where serials_exist is set to true, leading to a bogus error message.