### PR TITLE
GCMemcardDirectory: GCI filename cleanup and fixes.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -304,7 +304,7 @@ void GCMemcard::UpdateBat(const BlockAlloc& bat)
 
 bool GCMemcard::IsShiftJIS() const
 {
-  return m_header_block.m_data.m_encoding != 0;
+  return m_header_block.IsShiftJIS();
 }
 
 bool GCMemcard::Save()
@@ -1274,15 +1274,6 @@ DEntry::DEntry()
   memset(reinterpret_cast<u8*>(this), 0xFF, DENTRY_SIZE);
 }
 
-std::string DEntry::GCI_FileName() const
-{
-  std::string filename =
-      std::string(reinterpret_cast<const char*>(m_makercode.data()), m_makercode.size()) + '-' +
-      std::string(reinterpret_cast<const char*>(m_gamecode.data()), m_gamecode.size()) + '-' +
-      reinterpret_cast<const char*>(m_filename.data()) + ".gci";
-  return Common::EscapeFileName(filename);
-}
-
 void Header::FixChecksums()
 {
   std::tie(m_checksum, m_checksum_inv) = CalculateChecksums();
@@ -1322,6 +1313,11 @@ GCMemcardErrorCode Header::CheckForErrors(u16 card_size_mbits) const
     error_code.Set(GCMemcardValidityIssues::INVALID_CHECKSUM);
 
   return error_code;
+}
+
+bool Header::IsShiftJIS() const
+{
+  return m_data.m_encoding != 0;
 }
 
 Directory::Directory()

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -420,51 +420,6 @@ std::optional<u8> GCMemcard::TitlePresent(const DEntry& d) const
   return std::nullopt;
 }
 
-bool GCMemcard::GCI_FileName(u8 index, std::string& filename) const
-{
-  if (!m_valid || index >= DIRLEN ||
-      GetActiveDirectory().m_dir_entries[index].m_gamecode == DEntry::UNINITIALIZED_GAMECODE)
-    return false;
-
-  filename = GetActiveDirectory().m_dir_entries[index].GCI_FileName();
-  return true;
-}
-
-std::string GCMemcard::DEntry_GameCode(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return "";
-
-  return std::string(
-      reinterpret_cast<const char*>(GetActiveDirectory().m_dir_entries[index].m_gamecode.data()),
-      GetActiveDirectory().m_dir_entries[index].m_gamecode.size());
-}
-
-std::string GCMemcard::DEntry_Makercode(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return "";
-
-  return std::string(
-      reinterpret_cast<const char*>(GetActiveDirectory().m_dir_entries[index].m_makercode.data()),
-      GetActiveDirectory().m_dir_entries[index].m_makercode.size());
-}
-
-std::string GCMemcard::DEntry_BIFlags(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return "";
-
-  std::string flags;
-  int x = GetActiveDirectory().m_dir_entries[index].m_banner_and_icon_flags;
-  for (int i = 0; i < 8; i++)
-  {
-    flags.push_back((x & 0x80) ? '1' : '0');
-    x = x << 1;
-  }
-  return flags;
-}
-
 bool GCMemcard::DEntry_IsPingPong(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
@@ -472,81 +427,6 @@ bool GCMemcard::DEntry_IsPingPong(u8 index) const
 
   const int flags = GetActiveDirectory().m_dir_entries[index].m_banner_and_icon_flags;
   return (flags & 0b0000'0100) != 0;
-}
-
-std::string GCMemcard::DEntry_FileName(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return "";
-
-  return std::string(
-      reinterpret_cast<const char*>(GetActiveDirectory().m_dir_entries[index].m_filename.data()),
-      GetActiveDirectory().m_dir_entries[index].m_filename.size());
-}
-
-u32 GCMemcard::DEntry_ModTime(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return 0xFFFFFFFF;
-
-  return GetActiveDirectory().m_dir_entries[index].m_modification_time;
-}
-
-u32 GCMemcard::DEntry_ImageOffset(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return 0xFFFFFFFF;
-
-  return GetActiveDirectory().m_dir_entries[index].m_image_offset;
-}
-
-std::string GCMemcard::DEntry_IconFmt(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return "";
-
-  u16 x = GetActiveDirectory().m_dir_entries[index].m_icon_format;
-  std::string format;
-  for (size_t i = 0; i < 16; ++i)
-  {
-    format.push_back(Common::ExtractBit(x, 15 - i) ? '1' : '0');
-  }
-  return format;
-}
-
-std::string GCMemcard::DEntry_AnimSpeed(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return "";
-
-  u16 x = GetActiveDirectory().m_dir_entries[index].m_animation_speed;
-  std::string speed;
-  for (size_t i = 0; i < 16; ++i)
-  {
-    speed.push_back(Common::ExtractBit(x, 15 - i) ? '1' : '0');
-  }
-  return speed;
-}
-
-std::string GCMemcard::DEntry_Permissions(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return "";
-
-  u8 Permissions = GetActiveDirectory().m_dir_entries[index].m_file_permissions;
-  std::string permissionsString;
-  permissionsString.push_back((Permissions & 16) ? 'x' : 'M');
-  permissionsString.push_back((Permissions & 8) ? 'x' : 'C');
-  permissionsString.push_back((Permissions & 4) ? 'P' : 'x');
-  return permissionsString;
-}
-
-u8 GCMemcard::DEntry_CopyCounter(u8 index) const
-{
-  if (!m_valid || index >= DIRLEN)
-    return 0xFF;
-
-  return GetActiveDirectory().m_dir_entries[index].m_copy_counter;
 }
 
 u16 GCMemcard::DEntry_FirstBlock(u8 index) const

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -453,19 +453,8 @@ public:
   // with that identity exists in this card.
   std::optional<u8> TitlePresent(const DEntry& d) const;
 
-  bool GCI_FileName(u8 index, std::string& filename) const;
   // DEntry functions, all take u8 index < DIRLEN (127)
-  std::string DEntry_GameCode(u8 index) const;
-  std::string DEntry_Makercode(u8 index) const;
-  std::string DEntry_BIFlags(u8 index) const;
   bool DEntry_IsPingPong(u8 index) const;
-  std::string DEntry_FileName(u8 index) const;
-  u32 DEntry_ModTime(u8 index) const;
-  u32 DEntry_ImageOffset(u8 index) const;
-  std::string DEntry_IconFmt(u8 index) const;
-  std::string DEntry_AnimSpeed(u8 index) const;
-  std::string DEntry_Permissions(u8 index) const;
-  u8 DEntry_CopyCounter(u8 index) const;
   // get first block for file
   u16 DEntry_FirstBlock(u8 index) const;
   // get file length in blocks

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -231,6 +231,8 @@ struct Header
   std::pair<u16, u16> CalculateChecksums() const;
 
   GCMemcardErrorCode CheckForErrors(u16 card_size_mbits) const;
+
+  bool IsShiftJIS() const;
 };
 static_assert(sizeof(Header) == BLOCK_SIZE);
 static_assert(std::is_trivially_copyable_v<Header>);
@@ -238,9 +240,6 @@ static_assert(std::is_trivially_copyable_v<Header>);
 struct DEntry
 {
   DEntry();
-
-  // TODO: This probably shouldn't be here at all?
-  std::string GCI_FileName() const;
 
   static constexpr std::array<u8, 4> UNINITIALIZED_GAMECODE{{0xFF, 0xFF, 0xFF, 0xFF}};
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -44,7 +44,7 @@ bool GCMemcardDirectory::LoadGCI(Memcard::GCIFile gci)
   // check if any already loaded file has the same internal name as the new file
   for (const Memcard::GCIFile& already_loaded_gci : m_saves)
   {
-    if (gci.m_gci_header.GCI_FileName() == already_loaded_gci.m_gci_header.GCI_FileName())
+    if (HasSameIdentity(gci.m_gci_header, already_loaded_gci.m_gci_header))
     {
       ERROR_LOG_FMT(EXPANSIONINTERFACE,
                     "{}\nwas not loaded because it has the same internal filename as previously "

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -32,7 +32,8 @@ public:
   GCMemcardDirectory& operator=(GCMemcardDirectory&&) = delete;
 
   static std::vector<std::string> GetFileNamesForGameID(const std::string& directory,
-                                                        const std::string& game_id);
+                                                        const std::string& game_id,
+                                                        bool card_encoding_is_shift_jis);
   void FlushToFile();
   void FlushThread();
   s32 Read(u32 src_address, s32 length, u8* dest_address) override;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -32,8 +32,7 @@ public:
   GCMemcardDirectory& operator=(GCMemcardDirectory&&) = delete;
 
   static std::vector<std::string> GetFileNamesForGameID(const std::string& directory,
-                                                        const std::string& game_id,
-                                                        bool card_encoding_is_shift_jis);
+                                                        const std::string& game_id);
   void FlushToFile();
   void FlushThread();
   s32 Read(u32 src_address, s32 length, u8* dest_address) override;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1686,7 +1686,8 @@ bool NetPlayServer::SyncSaveData(const SaveSyncInfo& sync_info)
     return true;
 
   const auto game_region = sync_info.game->GetRegion();
-  const std::string region = Config::GetDirectoryForRegion(Config::ToGameCubeRegion(game_region));
+  const auto gamecube_region = Config::ToGameCubeRegion(game_region);
+  const std::string region = Config::GetDirectoryForRegion(gamecube_region);
 
   for (ExpansionInterface::Slot slot : ExpansionInterface::MEMCARD_SLOTS)
   {
@@ -1733,8 +1734,8 @@ bool NetPlayServer::SyncSaveData(const SaveSyncInfo& sync_info)
 
       if (File::IsDirectory(path))
       {
-        std::vector<std::string> files =
-            GCMemcardDirectory::GetFileNamesForGameID(path + DIR_SEP, sync_info.game->GetGameID());
+        std::vector<std::string> files = GCMemcardDirectory::GetFileNamesForGameID(
+            path + DIR_SEP, sync_info.game->GetGameID(), gamecube_region == DiscIO::Region::NTSC_J);
 
         pac << static_cast<u8>(files.size());
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1734,8 +1734,8 @@ bool NetPlayServer::SyncSaveData(const SaveSyncInfo& sync_info)
 
       if (File::IsDirectory(path))
       {
-        std::vector<std::string> files = GCMemcardDirectory::GetFileNamesForGameID(
-            path + DIR_SEP, sync_info.game->GetGameID(), gamecube_region == DiscIO::Region::NTSC_J);
+        std::vector<std::string> files =
+            GCMemcardDirectory::GetFileNamesForGameID(path + DIR_SEP, sync_info.game->GetGameID());
 
         pac << static_cast<u8>(files.size());
 


### PR DESCRIPTION
Intended to fix [issue 12999](https://bugs.dolphin-emu.org/issues/12999), though I don't know whether it actually does.