### PR TITLE
Debugger MemoryViewWidget: always highlight target address 

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -60,6 +60,7 @@ public:
   void SetDisplay(Type type, int bytes_per_row, int alignment, bool dual_view);
   void SetBPType(BPType type);
   void SetAddress(u32 address);
+  void SetFocus() const;
 
   void SetBPLoggingEnabled(bool enabled);
 
@@ -85,6 +86,7 @@ private:
   BPType m_bp_type = BPType::ReadWrite;
   bool m_do_log = true;
   u32 m_address = 0x80000000;
+  u32 m_address_highlight = 0;
   int m_font_width = 0;
   int m_font_vspace = 0;
   int m_bytes_per_row = 16;


### PR DESCRIPTION
![memviewselect](https://user-images.githubusercontent.com/10532806/198872569-9fef4987-dd0d-4524-9124-aa8c11e781e4.jpg)

Highlighting wasn't doing much before. Now it lets you know what address is being targeted. The colors can be changed, I just set it to normal.  A stylesheet needed to be used, or else the selected item coloring is removed when focus is lost, which isn't good. 

There is also a thin outline box on whatever cell you click, without changing the highlighting on the target. 

I'm not sure if set focus is needed anymore, but it seemed a little broken when the table was given the slider navbar, so I fixed that.  I think it was mostly a highlighting thing, but then I overrode the highlighting altogether.