### PR TITLE
Android: Add more game grid sizes for long displays

### DIFF
--- a/Source/Android/app/src/main/res/values-w300dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w300dp/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="game_grid_columns">2</integer>
+</resources>

--- a/Source/Android/app/src/main/res/values-w400dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w400dp/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="game_grid_columns">3</integer>
+</resources>

--- a/Source/Android/app/src/main/res/values/integers.xml
+++ b/Source/Android/app/src/main/res/values/integers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="game_title_lines">2</integer>
-    <integer name="game_grid_columns">3</integer>
+    <integer name="game_grid_columns">1</integer>
     <integer name="loadsave_state_columns">1</integer>
     <integer name="loadsave_state_rows">6</integer>
 


### PR DESCRIPTION
On some displays, the game cards could start to clip if the width of the display was small enough. This ensures that we can go down to as little as 1 card per row and in-between.

Before - 
![image](https://user-images.githubusercontent.com/14132249/199068409-81f574d2-3929-40ee-ad8d-ed8e0c981b3d.png)

After - 
![image](https://user-images.githubusercontent.com/14132249/199068007-656f5c37-9708-4dc8-83f1-5b06e6952407.png)
