### PR TITLE
VideoBackends:Vulkan: Fix 0 size descriptor pools

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -161,7 +161,7 @@ private:
   Common::Flag m_last_present_failed;
   VkResult m_last_present_result = VK_SUCCESS;
   bool m_use_threaded_submission = false;
-  u32 m_descriptor_set_count = 0;
+  u32 m_descriptor_set_count = DESCRIPTOR_SETS_PER_POOL;
 };
 
 extern std::unique_ptr<CommandBufferManager> g_command_buffer_mgr;


### PR DESCRIPTION
Fixes:

```
35:01:531 VideoBackends/Vulkan/VulkanContext.cpp:745 E[Host GPU]: Vulkan debug report: (Validation) Validation Error: [ VUID-VkDescriptorPoolCreateInfo-maxSets-00301 ] Object 0: handle = 0x7f1,b8d,3cd,e70, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xa1,70e,236 | vkCreateDescriptorPool(): pCreateInfo->maxSets is not greater than 0. The Vulkan spec states: maxSets must be greater than 0 (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkDescriptorPoolCreateInfo-maxSets-00301)
```