### PR TITLE
OGL: fix compute shader labels

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLShader.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLShader.cpp
@@ -33,7 +33,7 @@ OGLShader::OGLShader(ShaderStage stage, GLenum gl_type, GLuint gl_id, std::strin
 {
   if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
-    glObjectLabel(GL_SHADER, m_gl_id, -1, m_name.c_str());
+    glObjectLabel(GL_SHADER, m_gl_id, (GLsizei)m_name.size(), m_name.c_str());
   }
 }
 
@@ -44,7 +44,7 @@ OGLShader::OGLShader(GLuint gl_compute_program_id, std::string source, std::stri
 {
   if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
-    glObjectLabel(GL_PROGRAM, m_gl_compute_program_id, -1, m_name.c_str());
+    glObjectLabel(GL_PROGRAM, m_gl_compute_program_id, (GLsizei)m_name.size(), m_name.c_str());
   }
 }
 

--- a/Source/Core/VideoBackends/OGL/OGLShader.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLShader.cpp
@@ -44,7 +44,7 @@ OGLShader::OGLShader(GLuint gl_compute_program_id, std::string source, std::stri
 {
   if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
-    glObjectLabel(GL_SHADER, m_gl_compute_program_id, -1, m_name.c_str());
+    glObjectLabel(GL_PROGRAM, m_gl_compute_program_id, -1, m_name.c_str());
   }
 }
 

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -120,7 +120,7 @@ OGLTexture::OGLTexture(const TextureConfig& tex_config, std::string_view name)
 
   if (!m_name.empty() && g_ActiveConfig.backend_info.bSupportsSettingObjectNames)
   {
-    glObjectLabel(GL_TEXTURE, m_texId, -1, m_name.c_str());
+    glObjectLabel(GL_TEXTURE, m_texId, (GLsizei)m_name.size(), m_name.c_str());
   }
 
   glTexParameteri(target, GL_TEXTURE_MAX_LEVEL, m_config.levels - 1);


### PR DESCRIPTION
This fixes GL_INVALID_VALUE errors when using GPU texture decoding.