### PR TITLE
JitArm64: Optimize cmp

### DIFF
--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -309,6 +309,18 @@ enum class ShiftType
   ROR = 3,
 };
 
+enum class ExtendSpecifier
+{
+  UXTB = 0x0,
+  UXTH = 0x1,
+  UXTW = 0x2, /* Also LSL on 32bit width */
+  UXTX = 0x3, /* Also LSL on 64bit width */
+  SXTB = 0x4,
+  SXTH = 0x5,
+  SXTW = 0x6,
+  SXTX = 0x7,
+};
+
 enum class IndexType
 {
   Unsigned,
@@ -405,18 +417,6 @@ private:
     Width64Bit,
   };
 
-  enum class ExtendSpecifier
-  {
-    UXTB = 0x0,
-    UXTH = 0x1,
-    UXTW = 0x2, /* Also LSL on 32bit width */
-    UXTX = 0x3, /* Also LSL on 64bit width */
-    SXTB = 0x4,
-    SXTH = 0x5,
-    SXTW = 0x6,
-    SXTX = 0x7,
-  };
-
   enum class TypeSpecifier
   {
     ExtendedReg,
@@ -462,6 +462,15 @@ public:
       m_extend = ExtendSpecifier::UXTW;
     }
     m_shifttype = ShiftType::LSL;
+  }
+  ArithOption(ARM64Reg Rd, ExtendSpecifier extend_type, u32 shift = 0)
+  {
+    m_destReg = Rd;
+    m_width = Is64Bit(Rd) ? WidthSpecifier::Width64Bit : WidthSpecifier::Width32Bit;
+    m_extend = extend_type;
+    m_type = TypeSpecifier::ExtendedReg;
+    m_shifttype = ShiftType::LSL;
+    m_shift = shift;
   }
   ArithOption(ARM64Reg Rd, ShiftType shift_type, u32 shift)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -595,16 +595,11 @@ void JitArm64::cmp(UGeckoInstruction inst)
   }
   else
   {
-    ARM64Reg WA = gpr.GetReg();
-    ARM64Reg XA = EncodeRegTo64(WA);
     ARM64Reg RA = gpr.R(a);
     ARM64Reg RB = gpr.R(b);
 
-    SXTW(XA, RA);
-    SXTW(CR, RB);
-    SUB(CR, XA, CR);
-
-    gpr.Unlock(WA);
+    SXTW(CR, RA);
+    SUB(CR, CR, RB, ArithOption(RB, ExtendSpecifier::SXTW));
   }
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -584,6 +584,11 @@ void JitArm64::cmp(UGeckoInstruction inst)
     NEG(EncodeRegTo32(CR), gpr.R(b));
     SXTW(CR, EncodeRegTo32(CR));
   }
+  else if (gpr.IsImm(a) && gpr.GetImm(a) == 0xFFFFFFFF)
+  {
+    MVN(EncodeRegTo32(CR), gpr.R(b));
+    SXTW(CR, EncodeRegTo32(CR));
+  }
   else if (gpr.IsImm(b) && !gpr.GetImm(b))
   {
     SXTW(CR, gpr.R(a));

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -578,25 +578,24 @@ void JitArm64::cmp(UGeckoInstruction inst)
     s64 A = static_cast<s32>(gpr.GetImm(a));
     s64 B = static_cast<s32>(gpr.GetImm(b));
     MOVI2R(CR, A - B);
-    return;
   }
-
-  if (gpr.IsImm(b) && !gpr.GetImm(b))
+  else if (gpr.IsImm(b) && !gpr.GetImm(b))
   {
     SXTW(CR, gpr.R(a));
-    return;
   }
+  else
+  {
+    ARM64Reg WA = gpr.GetReg();
+    ARM64Reg XA = EncodeRegTo64(WA);
+    ARM64Reg RA = gpr.R(a);
+    ARM64Reg RB = gpr.R(b);
 
-  ARM64Reg WA = gpr.GetReg();
-  ARM64Reg XA = EncodeRegTo64(WA);
-  ARM64Reg RA = gpr.R(a);
-  ARM64Reg RB = gpr.R(b);
+    SXTW(XA, RA);
+    SXTW(CR, RB);
+    SUB(CR, XA, CR);
 
-  SXTW(XA, RA);
-  SXTW(CR, RB);
-  SUB(CR, XA, CR);
-
-  gpr.Unlock(WA);
+    gpr.Unlock(WA);
+  }
 }
 
 void JitArm64::cmpl(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -615,16 +615,19 @@ void JitArm64::cmpl(UGeckoInstruction inst)
     u64 A = gpr.GetImm(a);
     u64 B = gpr.GetImm(b);
     MOVI2R(CR, A - B);
-    return;
   }
-
-  if (gpr.IsImm(b) && !gpr.GetImm(b))
+  else if (gpr.IsImm(a) && !gpr.GetImm(a))
+  {
+    NEG(CR, EncodeRegTo64(gpr.R(b)));
+  }
+  else if (gpr.IsImm(b) && !gpr.GetImm(b))
   {
     MOV(EncodeRegTo32(CR), gpr.R(a));
-    return;
   }
-
-  SUB(gpr.CR(crf), EncodeRegTo64(gpr.R(a)), EncodeRegTo64(gpr.R(b)));
+  else
+  {
+    SUB(CR, EncodeRegTo64(gpr.R(a)), EncodeRegTo64(gpr.R(b)));
+  }
 }
 
 void JitArm64::cmpi(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -579,6 +579,11 @@ void JitArm64::cmp(UGeckoInstruction inst)
     s64 B = static_cast<s32>(gpr.GetImm(b));
     MOVI2R(CR, A - B);
   }
+  else if (gpr.IsImm(a) && !gpr.GetImm(a))
+  {
+    NEG(EncodeRegTo32(CR), gpr.R(b));
+    SXTW(CR, EncodeRegTo32(CR));
+  }
   else if (gpr.IsImm(b) && !gpr.GetImm(b))
   {
     SXTW(CR, gpr.R(a));


### PR DESCRIPTION
Optimize generated code for `cmp`/`cmpl`, mostly by introducing handling for specific constant values.

---

**cmpl**

<details><summary>a == 0</summary>

Before:
```
0x52800019   mov    w25, #0x0
0xb94087b6   ldr    w22, [x29, #0x84]
0xcb16033b   sub    x27, x25, x22
```

After:
```
0xb94087b9   ldr    w25, [x29, #0x84]
0xcb1903fb   neg    x27, x25
```
</details>

---

**cmp**

<details><summary>a == 0</summary>

Before:
```
0x52800016   mov    w22, #0x0
0xb94093b5   ldr    w21, [x29, #0x90]
0x93407ed7   sxtw   x23, w22
0x93407eb9   sxtw   x25, w21
0xcb1902f9   sub    x25, x23, x25
```

After:
```
0xb94093b7   ldr    w23, [x29, #0x90]
0x4b1703f9   neg    w25, w23
0x93407f39   sxtw   x25, w25
```
</details>

<details><summary>a == -1</summary>

Before:
```
0x12800015   mov    w21, #-0x1
0x93407eb9   sxtw   x25, w21
0x93407ef8   sxtw   x24, w23
0xcb180338   sub    x24, x25, x24
```

After:
```
0x2a3703f8   mvn    w24, w23
0x93407f18   sxtw   x24, w24
```
</details>


<details><summary>general case</summary>

Before:
```
0x93407f59   sxtw   x25, w26
0x93407ebb   sxtw   x27, w21
0xcb1b033b   sub    x27, x25, x27
```

After:
```
0x93407f5b   sxtw   x27, w26
0xcb35c37b   sub    x27, x27, w21, sxtw
```
</details>