### PR TITLE
JitArm64: Optimize multiplication

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -332,6 +332,7 @@ protected:
                void (ARM64XEmitter::*op)(Arm64Gen::ARM64Reg, Arm64Gen::ARM64Reg, u64,
                                          Arm64Gen::ARM64Reg),
                bool Rc = false);
+  bool MultiplyImmediate(u32 imm, int a, int d, bool rc);
 
   void SetFPRFIfNeeded(bool single, Arm64Gen::ARM64Reg reg);
   void Force25BitPrecision(Arm64Gen::ARM64Reg output, Arm64Gen::ARM64Reg input);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -876,6 +876,11 @@ void JitArm64::addic(UGeckoInstruction inst)
   }
 }
 
+bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
+{
+  return false;
+}
+
 void JitArm64::mulli(UGeckoInstruction inst)
 {
   INSTRUCTION_START

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -878,7 +878,19 @@ void JitArm64::addic(UGeckoInstruction inst)
 
 bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
 {
-  return false;
+  if (imm == 0)
+  {
+    gpr.SetImmediate(d, 0);
+    if (rc)
+      ComputeRC0(gpr.GetImm(d));
+  }
+  else
+  {
+    // Immediate did not match any known special cases.
+    return false;
+  }
+
+  return true;
 }
 
 void JitArm64::mulli(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -881,12 +881,14 @@ bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
 {
   if (imm == 0)
   {
+    // Multiplication by zero (0).
     gpr.SetImmediate(d, 0);
     if (rc)
       ComputeRC0(gpr.GetImm(d));
   }
   else if (imm == 1)
   {
+    // Multiplication by one (1).
     if (d != a)
     {
       gpr.BindToRegister(d, false);
@@ -897,6 +899,7 @@ bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
   }
   else if (MathUtil::IsPow2(imm))
   {
+    // Multiplication by a power of two (2^n).
     const int shift = IntLog2(imm);
 
     gpr.BindToRegister(d, d == a);
@@ -906,6 +909,7 @@ bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
   }
   else if (MathUtil::IsPow2(imm - 1))
   {
+    // Multiplication by a power of two plus one (2^n + 1).
     const int shift = IntLog2(imm - 1);
 
     gpr.BindToRegister(d, d == a);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -927,6 +927,16 @@ bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
     if (rc)
       ComputeRC0(gpr.R(d));
   }
+  else if (MathUtil::IsPow2(~imm + 2))
+  {
+    // Multiplication by a negative power of two plus one (-(2^n) + 1).
+    const int shift = IntLog2(~imm + 2);
+
+    gpr.BindToRegister(d, d == a);
+    SUB(gpr.R(d), gpr.R(a), gpr.R(a), ArithOption(gpr.R(a), ShiftType::LSL, shift));
+    if (rc)
+      ComputeRC0(gpr.R(d));
+  }
   else
   {
     // Immediate did not match any known special cases.

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -893,6 +893,10 @@ void JitArm64::mulli(UGeckoInstruction inst)
     s32 i = (s32)gpr.GetImm(a);
     gpr.SetImmediate(d, i * inst.SIMM_16);
   }
+  else if (MultiplyImmediate((u32)(s32)inst.SIMM_16, a, d, false))
+  {
+    // Code is generated inside MultiplyImmediate, nothing to be done here.
+  }
   else
   {
     gpr.BindToRegister(d, d == a);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -917,6 +917,16 @@ bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
     if (rc)
       ComputeRC0(gpr.R(d));
   }
+  else if (MathUtil::IsPow2(~imm + 1))
+  {
+    // Multiplication by a negative power of two (-(2^n)).
+    const int shift = IntLog2(~imm + 1);
+
+    gpr.BindToRegister(d, d == a);
+    NEG(gpr.R(d), gpr.R(a), ArithOption(gpr.R(a), ShiftType::LSL, shift));
+    if (rc)
+      ComputeRC0(gpr.R(d));
+  }
   else
   {
     // Immediate did not match any known special cases.

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -884,6 +884,16 @@ bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
     if (rc)
       ComputeRC0(gpr.GetImm(d));
   }
+  else if (imm == 1)
+  {
+    if (d != a)
+    {
+      gpr.BindToRegister(d, false);
+      MOV(gpr.R(d), gpr.R(a));
+    }
+    if (rc)
+      ComputeRC0(gpr.R(d));
+  }
   else
   {
     // Immediate did not match any known special cases.

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -7,6 +7,7 @@
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+#include "Common/MathUtil.h"
 
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -891,6 +892,15 @@ bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
       gpr.BindToRegister(d, false);
       MOV(gpr.R(d), gpr.R(a));
     }
+    if (rc)
+      ComputeRC0(gpr.R(d));
+  }
+  else if (MathUtil::IsPow2(imm))
+  {
+    const int shift = IntLog2(imm);
+
+    gpr.BindToRegister(d, d == a);
+    LSL(gpr.R(d), gpr.R(a), shift);
     if (rc)
       ComputeRC0(gpr.R(d));
   }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -944,11 +944,16 @@ void JitArm64::mulli(UGeckoInstruction inst)
   }
   else
   {
-    gpr.BindToRegister(d, d == a);
-    ARM64Reg WA = gpr.GetReg();
+    const bool allocate_reg = d == a;
+    gpr.BindToRegister(d, allocate_reg);
+
+    // Reuse d to hold the immediate if possible, allocate a register otherwise.
+    ARM64Reg WA = allocate_reg ? gpr.GetReg() : gpr.R(d);
+
     MOVI2R(WA, (u32)(s32)inst.SIMM_16);
     MUL(gpr.R(d), gpr.R(a), WA);
-    gpr.Unlock(WA);
+    if (allocate_reg)
+      gpr.Unlock(WA);
   }
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -904,6 +904,15 @@ bool JitArm64::MultiplyImmediate(u32 imm, int a, int d, bool rc)
     if (rc)
       ComputeRC0(gpr.R(d));
   }
+  else if (MathUtil::IsPow2(imm - 1))
+  {
+    const int shift = IntLog2(imm - 1);
+
+    gpr.BindToRegister(d, d == a);
+    ADD(gpr.R(d), gpr.R(a), gpr.R(a), ArithOption(gpr.R(a), ShiftType::LSL, shift));
+    if (rc)
+      ComputeRC0(gpr.R(d));
+  }
   else
   {
     // Immediate did not match any known special cases.

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -922,6 +922,11 @@ void JitArm64::mullwx(UGeckoInstruction inst)
     if (inst.Rc)
       ComputeRC0(gpr.GetImm(d));
   }
+  else if ((gpr.IsImm(a) && MultiplyImmediate(gpr.GetImm(a), b, d, inst.Rc)) ||
+           (gpr.IsImm(b) && MultiplyImmediate(gpr.GetImm(b), a, d, inst.Rc)))
+  {
+    // Code is generated inside MultiplyImmediate, nothing to be done here.
+  }
   else
   {
     gpr.BindToRegister(d, d == a || d == b);


### PR DESCRIPTION
Optimize multiplication for various constants. We introduce a `MultiplyImmediate` function, which contains the logic much like the one that exists for x86, and reuse it in both `mulli` and `mullwx`.

Also a minor register allocation improvement for `mulli`.

---

<details><summary>Multiplication by 0</summary>

Before:
```
0x52800019   mov    w25, #0x0
0x1b197f5b   mul    w27, w26, w25
```

After:
```
```
</details>
<details><summary>Multiplication by 1 (example 1)</summary>

Before:
```
0x52800038   mov    w24, #0x1
0x1b1a7f1b   mul    w27, w24, w26
```

After:
```
0x2a1a03fb   mov    w27, w26
```
</details>
<details><summary>Multiplication by 1 (example 2)</summary>

Before:
```
0x52800039   mov    w25, #0x1
0x1b1a7f3a   mul    w26, w25, w26
```

After:
```
```
</details>
<details><summary>Multiplication by -1</summary>

Before:
```
0x12800015   mov    w21, #-0x1
0x1b157f7b   mul    w27, w27, w21
```

After:
```
0x4b1b03fb   neg    w27, w27
```
</details>
<details><summary>Multiplication by 2^n</summary>

Before:
```
0x52800817   mov    w23, #0x40
0x1b167ef6   mul    w22, w23, w22
```

After:
```
0x531a66d6   lsl    w22, w22, #6
```
</details>
<details><summary>Multiplication by 2^n + 1</summary>

Before:
```
0x52800838   mov    w24, #0x41
0x1b187f7b   mul    w27, w27, w24
```

After:
```
0x0b1b1b7b   add    w27, w27, w27, lsl #6
```
</details>
<details><summary>mulli register allocation</summary>

Before:
```
0x52800659   mov    w25, #0x32
0x1b197f5b   mul    w27, w26, w25
```

After:
```
0x5280065b   mov    w27, #0x32
0x1b1b7f5b   mul    w27, w26, w27
```
</details>