### PR TITLE
Android: Use system file picker for custom covers

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GamePropertiesDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GamePropertiesDialog.java
@@ -4,11 +4,13 @@ package org.dolphinemu.dolphinemu.dialogs;
 
 import android.app.Dialog;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
+import androidx.preference.PreferenceManager;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -23,6 +25,7 @@ import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag;
 import org.dolphinemu.dolphinemu.features.settings.ui.SettingsActivity;
 import org.dolphinemu.dolphinemu.model.GameFile;
 import org.dolphinemu.dolphinemu.ui.main.MainPresenter;
+import org.dolphinemu.dolphinemu.ui.main.MainView;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.utils.AlertDialogItemsBuilder;
 import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
@@ -101,6 +104,22 @@ public class GamePropertiesDialog extends DialogFragment
     {
       itemsBuilder.add(R.string.properties_convert, (dialog, i) ->
               ConvertActivity.launch(getContext(), path));
+    }
+
+    itemsBuilder.add(R.string.properties_set_custom_cover, (dialog, i) ->
+            ((MainView) requireActivity()).launchCustomImagePicker(gameId));
+
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
+    String customCover = preferences.getString(gameId, null);
+    if (customCover != null)
+    {
+      itemsBuilder.add(R.string.properties_remove_custom_cover, (dialog, i) ->
+      {
+        preferences.edit()
+                .remove(gameId)
+                .apply();
+        ((MainView) requireActivity()).showGames();
+      });
     }
 
     if (isDisc && isWii)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -50,6 +50,7 @@ public final class MainPresenter
   private final MainView mView;
   private final FragmentActivity mActivity;
   private String mDirToAdd;
+  public static String mCustomCoverGameId;
 
   public MainPresenter(MainView view, FragmentActivity activity)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
@@ -25,6 +25,8 @@ public interface MainView
 
   void launchOpenFileActivity(int requestCode);
 
+  void launchCustomImagePicker(String gameId);
+
   /**
    * Shows or hides the loading indicator.
    */

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -462,6 +462,8 @@
     <string name="properties_details">Details</string>
     <string name="properties_start_with_riivolution">Start with Riivolution Patches</string>
     <string name="properties_set_default_iso">Set as Default ISO</string>
+    <string name="properties_set_custom_cover">Set Custom Cover</string>
+    <string name="properties_remove_custom_cover">Remove Custom Cover</string>
     <string name="properties_convert">Convert File</string>
     <string name="properties_system_update">Perform System Update</string>
     <string name="properties_edit_game_settings">Edit Game Settings</string>


### PR DESCRIPTION
The current unmangling method we've been using for getting custom covers has a pretty costly performance penalty and I didn't want to create a whole caching system for it. This way we save persistent custom cover URIs to SharedPreferences and do a much more lightweight check to see if a given file exists.

NOTE - This currently doesn't support per file cover changes. Only per game id. So if you have more than one copy of a given game with the same game id, they will all take on the newly set custom cover. Additionally, this is different from the existing functionality for the other Dolphin versions so it's potentially unintuitive to users that have known the previous method.

Demo - 
![customcoverdemo](https://user-images.githubusercontent.com/14132249/199637638-a7e789c6-0fb8-48c1-9651-a77950d01312.gif)

GlideUtils.loadGameCover
Performance before - 
![image](https://user-images.githubusercontent.com/14132249/199638070-e36abb85-a0a6-4e62-a9aa-0bd688e7e809.png)

Performance after - 
![image](https://user-images.githubusercontent.com/14132249/199637299-f5f67707-2af5-4b7f-835b-b95286dc8f4e.png)
