### PR TITLE
VideoCommon: Zero PortableVertexDeclarations on initialization

### DIFF
--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -63,6 +63,9 @@ struct PortableVertexDeclaration
   std::array<AttributeFormat, 8> texcoords;
   AttributeFormat posmtx;
 
+  // Make sure we initialize padding to 0 since padding is included in the == memcmp
+  PortableVertexDeclaration() { memset(this, 0, sizeof(*this)); }
+
   inline bool operator<(const PortableVertexDeclaration& b) const
   {
     return memcmp(this, &b, sizeof(PortableVertexDeclaration)) < 0;
@@ -72,6 +75,9 @@ struct PortableVertexDeclaration
     return memcmp(this, &b, sizeof(PortableVertexDeclaration)) == 0;
   }
 };
+
+static_assert(std::is_trivially_copyable_v<PortableVertexDeclaration>,
+              "Make sure we can memset-initialize");
 
 namespace std
 {


### PR DESCRIPTION
The default compiler-generated initializer isn't required to initialize padding, making for fun non-determinism when playing back fifologs

See: https://gcc.godbolt.org/z/vev3n47d9

Note: I'm not sure the compiler-generated copy constructor is required to copy padding either, but all notable C++ compilers do, and we static_assert that PortableVertexDeclaration is trivially copyable

(Fixes the random missing textures on the M1 fifoplayer)