### PR TITLE
Boot: Load DOL/ELF after memory setup

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -540,12 +540,6 @@ bool CBoot::BootUp(std::unique_ptr<BootParameters> boot)
       if (!executable.reader->IsValid())
         return false;
 
-      if (!executable.reader->LoadIntoMemory())
-      {
-        PanicAlertFmtT("Failed to load the executable to memory.");
-        return false;
-      }
-
       SetDefaultDisc();
 
       SetupMSR();
@@ -567,6 +561,12 @@ bool CBoot::BootUp(std::unique_ptr<BootParameters> boot)
       else
       {
         SetupGCMemory();
+      }
+
+      if (!executable.reader->LoadIntoMemory())
+      {
+        PanicAlertFmtT("Failed to load the executable to memory.");
+        return false;
       }
 
       SConfig::OnNewTitleLoad();


### PR DESCRIPTION
I recently talked to a homebrew developer who was trying to add exception handlers at link time but found out that Dolphin was overwriting their exception handlers. I figure that's not the usual way to do exception handlers, but... making us load the executable after setting up memory rather than before is easy, and matches what we do when booting discs, so I suppose there's no reason not to do it. It also matches the intent of why Dolphin is writing default exception handlers – we're writing them because some homebrew relies on exception handlers being left around from whatever program was running before it (see PR #6247).