### PR TITLE
Android: Use FrameLayout as root for notouch emulation layout

### DIFF
--- a/Source/Android/app/src/main/res/layout-notouch/fragment_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-notouch/fragment_emulation.xml
@@ -1,4 +1,4 @@
-<View
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/layout_emulation"
     android:layout_height="match_parent"
@@ -11,4 +11,4 @@
         android:focusable="false"
         android:focusableInTouchMode="false" />
 
-</View>
+</FrameLayout>

--- a/Source/Android/app/src/main/res/layout-port-notouch/fragment_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-port-notouch/fragment_emulation.xml
@@ -1,4 +1,4 @@
-<View
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/layout_emulation"
     android:layout_height="match_parent"
@@ -11,4 +11,4 @@
         android:focusable="false"
         android:focusableInTouchMode="false" />
 
-</View>
+</FrameLayout>


### PR DESCRIPTION
When inflating this layout, the layout inflater doesn't expect a View and rather a descendant of ViewGroup. This resulted in a crash which is resolved by using a FrameLayout instead.

Basically, running the emulation activity on an Nvidia Shield (or any device without a touchscreen) will crash without this fix.