### PR TITLE
Android: Dynamically adapt grid span to card_game size

### DIFF
--- a/Source/Android/app/src/main/res/layout/fragment_grid.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_grid.xml
@@ -7,9 +7,7 @@
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_refresh"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/activity_horizontal_margin"
-        android:layout_marginRight="@dimen/activity_horizontal_margin">
+        android:layout_height="wrap_content">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/grid_games"

--- a/Source/Android/app/src/main/res/values-w1000dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w1000dp/integers.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <integer name="game_grid_columns">8</integer>
-</resources>

--- a/Source/Android/app/src/main/res/values-w1050dp/dimens.xml
+++ b/Source/Android/app/src/main/res/values-w1050dp/dimens.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- Example customization of dimensions originally defined in res/values/dimens.xml
-         (such as screen margins) for screens with more than 1024dp of available width.  -->
-    <dimen name="activity_horizontal_margin">96dp</dimen>
-</resources>

--- a/Source/Android/app/src/main/res/values-w300dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w300dp/integers.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <integer name="game_grid_columns">2</integer>
-</resources>

--- a/Source/Android/app/src/main/res/values-w400dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w400dp/integers.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <integer name="game_grid_columns">3</integer>
-</resources>

--- a/Source/Android/app/src/main/res/values-w500dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w500dp/integers.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <integer name="game_grid_columns">4</integer>
-</resources>

--- a/Source/Android/app/src/main/res/values-w750dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w750dp/integers.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <integer name="game_grid_columns">6</integer>
-</resources>

--- a/Source/Android/app/src/main/res/values-w820dp/dimens.xml
+++ b/Source/Android/app/src/main/res/values-w820dp/dimens.xml
@@ -1,5 +1,0 @@
-<resources>
-    <!-- Example customization of dimensions originally defined in res/values/dimens.xml
-         (such as screen margins) for screens with more than 820dp of available width.  -->
-    <dimen name="activity_horizontal_margin">64dp</dimen>
-</resources>

--- a/Source/Android/app/src/main/res/values/dimens.xml
+++ b/Source/Android/app/src/main/res/values/dimens.xml
@@ -1,8 +1,6 @@
 <resources>
-    <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-
     <dimen name="spacing_small">4dp</dimen>
     <dimen name="spacing_medlarge">12dp</dimen>
     <dimen name="spacing_large">16dp</dimen>
+    <dimen name="card_width">140dp</dimen>
 </resources>

--- a/Source/Android/app/src/main/res/values/integers.xml
+++ b/Source/Android/app/src/main/res/values/integers.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="game_title_lines">2</integer>
-    <integer name="game_grid_columns">1</integer>
     <integer name="loadsave_state_columns">1</integer>
     <integer name="loadsave_state_rows">6</integer>
 


### PR DESCRIPTION
In order to avoid getting stuck making a new dimension file every time a new device is found we take a known value for how large the game card will be, take the screen size, and adjust the grid accordingly.

![dynamicspan](https://user-images.githubusercontent.com/14132249/200185041-424bbae3-31ea-45a2-8551-8e6393713a22.gif)
