### PR TITLE
Disable SD card conversion while emulation is running

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/RunRunnable.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/RunRunnable.java
@@ -4,20 +4,23 @@ package org.dolphinemu.dolphinemu.features.settings.model.view;
 
 import android.content.Context;
 
+import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.features.settings.model.AbstractSetting;
 
 public final class RunRunnable extends SettingsItem
 {
   private final int mAlertText;
   private final int mToastTextAfterRun;
+  private final boolean mWorksDuringEmulation;
   private final Runnable mRunnable;
 
   public RunRunnable(Context context, int titleId, int descriptionId, int alertText,
-          int toastTextAfterRun, Runnable runnable)
+          int toastTextAfterRun, boolean worksDuringEmulation, Runnable runnable)
   {
     super(context, titleId, descriptionId);
     mAlertText = alertText;
     mToastTextAfterRun = toastTextAfterRun;
+    mWorksDuringEmulation = worksDuringEmulation;
     mRunnable = runnable;
   }
 
@@ -46,5 +49,11 @@ public final class RunRunnable extends SettingsItem
   public AbstractSetting getSetting()
   {
     return null;
+  }
+
+  @Override
+  public boolean isEditable()
+  {
+    return mWorksDuringEmulation || !NativeLibrary.IsRunning();
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -270,7 +270,7 @@ public final class SettingsFragmentPresenter
     sl.add(new SubmenuSetting(mContext, R.string.advanced_submenu, MenuTag.CONFIG_ADVANCED));
     sl.add(new SubmenuSetting(mContext, R.string.log_submenu, MenuTag.CONFIG_LOG));
     sl.add(new SubmenuSetting(mContext, R.string.debug_submenu, MenuTag.DEBUG));
-    sl.add(new RunRunnable(mContext, R.string.user_data_submenu, 0, 0, 0,
+    sl.add(new RunRunnable(mContext, R.string.user_data_submenu, 0, 0, 0, false,
             () -> UserDataActivity.launch(mContext)));
   }
 
@@ -291,7 +291,8 @@ public final class SettingsFragmentPresenter
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_ANALYTICS_ENABLED, R.string.analytics,
             0));
     sl.add(new RunRunnable(mContext, R.string.analytics_new_id, 0,
-            R.string.analytics_new_id_confirmation, 0, NativeLibrary::GenerateNewStatisticsId));
+            R.string.analytics_new_id_confirmation, 0, true,
+            NativeLibrary::GenerateNewStatisticsId));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_ENABLE_SAVESTATES,
             R.string.enable_save_states, R.string.enable_save_states_description));
   }
@@ -520,10 +521,10 @@ public final class SettingsFragmentPresenter
     sl.add(new FilePicker(mContext, StringSetting.MAIN_WII_SD_CARD_SYNC_FOLDER_PATH,
             R.string.wii_sd_sync_folder, 0, MainPresenter.REQUEST_DIRECTORY, "/Load/WiiSDSync/"));
     sl.add(new RunRunnable(mContext, R.string.wii_sd_card_folder_to_file, 0,
-            R.string.wii_sd_card_folder_to_file_confirmation, 0,
+            R.string.wii_sd_card_folder_to_file_confirmation, 0, false,
             () -> convertOnThread(WiiUtils::syncSdFolderToSdImage)));
     sl.add(new RunRunnable(mContext, R.string.wii_sd_card_file_to_folder, 0,
-            R.string.wii_sd_card_file_to_folder_confirmation, 0,
+            R.string.wii_sd_card_file_to_folder_confirmation, 0, false,
             () -> convertOnThread(WiiUtils::syncSdImageToSdFolder)));
 
     sl.add(new HeaderSetting(mContext, R.string.wii_wiimote_settings, 0));
@@ -858,11 +859,11 @@ public final class SettingsFragmentPresenter
     sl.add(new SingleChoiceSetting(mContext, IntSetting.LOGGER_VERBOSITY, R.string.log_verbosity, 0,
             getLogVerbosityEntries(), getLogVerbosityValues()));
     sl.add(new RunRunnable(mContext, R.string.log_enable_all, 0,
-            R.string.log_enable_all_confirmation, 0, () -> setAllLogTypes(true)));
+            R.string.log_enable_all_confirmation, 0, true, () -> setAllLogTypes(true)));
     sl.add(new RunRunnable(mContext, R.string.log_disable_all, 0,
-            R.string.log_disable_all_confirmation, 0, () -> setAllLogTypes(false)));
+            R.string.log_disable_all_confirmation, 0, true, () -> setAllLogTypes(false)));
     sl.add(new RunRunnable(mContext, R.string.log_clear, 0, R.string.log_clear_confirmation, 0,
-            SettingsAdapter::clearLog));
+            true, SettingsAdapter::clearLog));
 
     sl.add(new HeaderSetting(mContext, R.string.log_types, 0));
     for (Map.Entry<String, String> entry : LOG_TYPE_NAMES.entrySet())

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/RunRunnableViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/RunRunnableViewHolder.java
@@ -40,11 +40,19 @@ public final class RunRunnableViewHolder extends SettingViewHolder
 
     mBinding.textSettingName.setText(item.getName());
     mBinding.textSettingDescription.setText(item.getDescription());
+
+    setStyle(mBinding.textSettingName, mItem);
   }
 
   @Override
   public void onClick(View clicked)
   {
+    if (!mItem.isEditable())
+    {
+      showNotRuntimeEditableError();
+      return;
+    }
+
     int alertTextID = mItem.getAlertText();
 
     if (alertTextID > 0)

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -216,9 +216,9 @@ void WiiPane::CreateSDCard()
     ++row;
   }
 
-  QPushButton* pack_now = new NonDefaultQPushButton(tr("Convert Folder to File Now"));
-  QPushButton* unpack_now = new NonDefaultQPushButton(tr("Convert File to Folder Now"));
-  connect(pack_now, &QPushButton::clicked, [this] {
+  m_sd_pack_button = new NonDefaultQPushButton(tr("Convert Folder to File Now"));
+  m_sd_unpack_button = new NonDefaultQPushButton(tr("Convert File to Folder Now"));
+  connect(m_sd_pack_button, &QPushButton::clicked, [this] {
     auto result = ModalMessageBox::warning(
         this, tr("Convert Folder to File Now"),
         tr("You are about to convert the content of the folder at %1 into the file at %2. All "
@@ -232,7 +232,7 @@ void WiiPane::CreateSDCard()
         ModalMessageBox::warning(this, tr("Convert Folder to File Now"), tr("Conversion failed."));
     }
   });
-  connect(unpack_now, &QPushButton::clicked, [this] {
+  connect(m_sd_unpack_button, &QPushButton::clicked, [this] {
     auto result = ModalMessageBox::warning(
         this, tr("Convert File to Folder Now"),
         tr("You are about to convert the content of the file at %2 into the folder at %1. All "
@@ -246,8 +246,8 @@ void WiiPane::CreateSDCard()
         ModalMessageBox::warning(this, tr("Convert File to Folder Now"), tr("Conversion failed."));
     }
   });
-  sd_settings_group_layout->addWidget(pack_now, row, 0, 1, 1);
-  sd_settings_group_layout->addWidget(unpack_now, row, 1, 1, 1);
+  sd_settings_group_layout->addWidget(m_sd_pack_button, row, 0, 1, 1);
+  sd_settings_group_layout->addWidget(m_sd_unpack_button, row, 1, 1, 1);
   ++row;
 }
 
@@ -316,6 +316,8 @@ void WiiPane::OnEmulationStateChanged(bool running)
   m_system_language_choice->setEnabled(!running);
   m_aspect_ratio_choice->setEnabled(!running);
   m_sound_mode_choice->setEnabled(!running);
+  m_sd_pack_button->setEnabled(!running);
+  m_sd_unpack_button->setEnabled(!running);
   m_wiimote_motor->setEnabled(!running);
   m_wiimote_speaker_volume->setEnabled(!running);
   m_wiimote_ir_sensitivity->setEnabled(!running);

--- a/Source/Core/DolphinQt/Settings/WiiPane.h
+++ b/Source/Core/DolphinQt/Settings/WiiPane.h
@@ -64,6 +64,8 @@ private:
   QCheckBox* m_sync_sd_folder_checkbox;
   QLineEdit* m_sd_raw_edit;
   QLineEdit* m_sd_sync_folder_edit;
+  QPushButton* m_sd_pack_button;
+  QPushButton* m_sd_unpack_button;
 
   // Whitelisted USB Passthrough Devices
   QListWidget* m_whitelist_usb_list;


### PR DESCRIPTION
It won't work, since Dolphin is keeping the SD card file open.