### PR TITLE
ImGui render context race condition fix: Lock context during Init/Shutdown.

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -554,6 +554,9 @@ void RenderWidget::SetImGuiKeyMap()
   }};
   auto lock = g_renderer->GetImGuiLock();
 
+  if (!ImGui::GetCurrentContext())
+    return;
+
   for (auto [imgui_key, qt_key] : key_map)
     ImGui::GetIO().KeyMap[imgui_key] = (qt_key & 0x1FF);
 }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -303,6 +303,9 @@ protected:
   // This function itself acquires the ImGui lock, so it should not be held.
   void BeginImGuiFrame();
 
+  // Same as above but without locking the ImGui lock.
+  void BeginImGuiFrameUnlocked();
+
   // Destroys all ImGui GPU resources, must do before shutdown.
   void ShutdownImGui();
 


### PR DESCRIPTION
Fix for https://bugs.dolphin-emu.org/issues/12652. Includes the commit from #10458.

@Pokechu22 As far as I can tell this works fine, can you see if you can figure out why you thought you couldn't acquire the lock during shutdown?