### PR TITLE
VideoCommon: add graphics mod unload texture hook

### DIFF
--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
@@ -187,6 +187,16 @@ std::optional<GraphicsTargetConfig> DeserializeTargetFromConfig(const picojson::
     target.m_texture_info_string = texture_info.value();
     return target;
   }
+  else if (type == "unload_texture")
+  {
+    std::optional<std::string> texture_info = ExtractTextureFilenameForConfig(obj);
+    if (!texture_info.has_value())
+      return std::nullopt;
+
+    UnloadTextureTarget target;
+    target.m_texture_info_string = texture_info.value();
+    return target;
+  }
   else if (type == "efb")
   {
     return DeserializeFBTargetFromConfig<EFBTarget>(obj, EFB_DUMP_PREFIX);

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.h
@@ -26,6 +26,10 @@ struct LoadTextureTarget final : public TextureTarget
 {
 };
 
+struct UnloadTextureTarget final : public TextureTarget
+{
+};
+
 struct FBTarget
 {
   u32 m_height = 0;
@@ -47,8 +51,9 @@ struct ProjectionTarget
   ProjectionType m_projection_type = ProjectionType::Perspective;
 };
 
-using GraphicsTargetConfig = std::variant<DrawStartedTextureTarget, LoadTextureTarget, EFBTarget,
-                                          XFBTarget, ProjectionTarget>;
+using GraphicsTargetConfig =
+    std::variant<DrawStartedTextureTarget, LoadTextureTarget, UnloadTextureTarget, EFBTarget,
+                 XFBTarget, ProjectionTarget>;
 
 std::optional<GraphicsTargetConfig> DeserializeTargetFromConfig(const picojson::object& obj);
 

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.cpp
@@ -42,3 +42,11 @@ void PrintAction::OnTextureLoad(GraphicsModActionData::TextureLoad* texture_load
 
   INFO_LOG_FMT(VIDEO, "OnTextureLoad Called.  Texture: {}", texture_load->texture_name);
 }
+
+void PrintAction::OnTextureUnload(GraphicsModActionData::TextureUnload* texture_unload)
+{
+  if (!texture_unload) [[unlikely]]
+    return;
+
+  INFO_LOG_FMT(VIDEO, "OnTextureUnload Called.  Texture: {}", texture_unload->texture_name);
+}

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.h
@@ -13,4 +13,5 @@ public:
   void OnProjection(GraphicsModActionData::Projection*) override;
   void OnProjectionAndTexture(GraphicsModActionData::Projection*) override;
   void OnTextureLoad(GraphicsModActionData::TextureLoad*) override;
+  void OnTextureUnload(GraphicsModActionData::TextureUnload*) override;
 };

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModAction.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModAction.h
@@ -21,5 +21,6 @@ public:
   virtual void OnProjection(GraphicsModActionData::Projection*) {}
   virtual void OnProjectionAndTexture(GraphicsModActionData::Projection*) {}
   virtual void OnTextureLoad(GraphicsModActionData::TextureLoad*) {}
+  virtual void OnTextureUnload(GraphicsModActionData::TextureUnload*) {}
   virtual void OnFrameEnd() {}
 };

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionData.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionData.h
@@ -32,4 +32,8 @@ struct TextureLoad
 {
   std::string_view texture_name;
 };
+struct TextureUnload
+{
+  std::string_view texture_name;
+};
 }  // namespace GraphicsModActionData

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
@@ -52,6 +52,12 @@ public:
       return;
     m_action_impl->OnTextureLoad(texture_load);
   }
+  void OnTextureUnload(GraphicsModActionData::TextureUnload* texture_unload) override
+  {
+    if (!m_mod.m_enabled)
+      return;
+    m_action_impl->OnTextureUnload(texture_unload);
+  }
   void OnFrameEnd() override
   {
     if (!m_mod.m_enabled)
@@ -107,6 +113,18 @@ GraphicsModManager::GetTextureLoadActions(const std::string& texture_name) const
 {
   if (const auto it = m_load_texture_target_to_actions.find(texture_name);
       it != m_load_texture_target_to_actions.end())
+  {
+    return it->second;
+  }
+
+  return m_default;
+}
+
+const std::vector<GraphicsModAction*>&
+GraphicsModManager::GetTextureUnloadActions(const std::string& texture_name) const
+{
+  if (const auto it = m_unload_texture_target_to_actions.find(texture_name);
+      it != m_unload_texture_target_to_actions.end())
   {
     return it->second;
   }
@@ -199,6 +217,10 @@ void GraphicsModManager::Load(const GraphicsModGroupConfig& config)
                   m_load_texture_target_to_actions[the_target.m_texture_info_string].push_back(
                       m_actions.back().get());
                 },
+                [&](const UnloadTextureTarget& the_target) {
+                  m_unload_texture_target_to_actions[the_target.m_texture_info_string].push_back(
+                      m_actions.back().get());
+                },
                 [&](const EFBTarget& the_target) {
                   FBInfo info;
                   info.m_height = the_target.m_height;
@@ -273,6 +295,7 @@ void GraphicsModManager::Reset()
   m_projection_texture_target_to_actions.clear();
   m_draw_started_target_to_actions.clear();
   m_load_texture_target_to_actions.clear();
+  m_unload_texture_target_to_actions.clear();
   m_efb_target_to_actions.clear();
   m_xfb_target_to_actions.clear();
 }

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.h
@@ -27,6 +27,8 @@ public:
   GetDrawStartedActions(const std::string& texture_name) const;
   const std::vector<GraphicsModAction*>&
   GetTextureLoadActions(const std::string& texture_name) const;
+  const std::vector<GraphicsModAction*>&
+  GetTextureUnloadActions(const std::string& texture_name) const;
   const std::vector<GraphicsModAction*>& GetEFBActions(const FBInfo& efb) const;
   const std::vector<GraphicsModAction*>& GetXFBActions(const FBInfo& xfb) const;
 
@@ -47,6 +49,8 @@ private:
       m_projection_texture_target_to_actions;
   std::unordered_map<std::string, std::vector<GraphicsModAction*>> m_draw_started_target_to_actions;
   std::unordered_map<std::string, std::vector<GraphicsModAction*>> m_load_texture_target_to_actions;
+  std::unordered_map<std::string, std::vector<GraphicsModAction*>>
+      m_unload_texture_target_to_actions;
   std::unordered_map<FBInfo, std::vector<GraphicsModAction*>, FBInfoHasher> m_efb_target_to_actions;
   std::unordered_map<FBInfo, std::vector<GraphicsModAction*>, FBInfoHasher> m_xfb_target_to_actions;
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -128,6 +128,15 @@ void TextureCacheBase::Invalidate()
   bound_textures.fill(nullptr);
   for (auto& tex : textures_by_address)
   {
+    if (g_ActiveConfig.bGraphicMods)
+    {
+      GraphicsModActionData::TextureUnload texture_unload{tex.second->texture_info_name};
+      for (const auto action : g_renderer->GetGraphicsModManager().GetTextureUnloadActions(
+               tex.second->texture_info_name))
+      {
+        action->OnTextureUnload(&texture_unload);
+      }
+    }
     delete tex.second;
   }
   textures_by_address.clear();
@@ -2634,6 +2643,16 @@ TextureCacheBase::InvalidateTexture(TexAddrCache::iterator iter, bool discard_pe
     return textures_by_address.end();
 
   TCacheEntry* entry = iter->second;
+
+  if (g_ActiveConfig.bGraphicMods)
+  {
+    GraphicsModActionData::TextureUnload texture_unload{entry->texture_info_name};
+    for (const auto action :
+         g_renderer->GetGraphicsModManager().GetTextureUnloadActions(entry->texture_info_name))
+    {
+      action->OnTextureUnload(&texture_unload);
+    }
+  }
 
   if (entry->textures_by_hash_iter != textures_by_hash.end())
   {


### PR DESCRIPTION
This may be used in a future PR.  At the moment, this mirrors the texture load event for graphics mods.