### PR TITLE
Android: Fix list_item_cheat text

### DIFF
--- a/Source/Android/app/src/main/res/layout/list_item_cheat.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_cheat.xml
@@ -17,8 +17,10 @@
         android:layout_height="64dp"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
-        android:gravity="center_vertical"
         android:layout_marginStart="@dimen/spacing_large"
+        android:layout_marginEnd="@dimen/spacing_large"
+        android:layout_toStartOf="@+id/checkbox"
+        android:gravity="center_vertical"
         android:textSize="16sp"
         tools:text="Hyrule Field Speed Hack" />
 


### PR DESCRIPTION
Sometimes a gecko code would have a title long enough to appear over the checkbox. This is now prevented by marking the text's boundary a 16dp before the start of the checkbox.