### PR TITLE
MemoryView auto-update while running and color recently changed cells.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -8,6 +8,7 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QColorDialog>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLineEdit>
@@ -43,6 +44,7 @@ constexpr int MISC_COLUMNS = 2;
 constexpr auto USER_ROLE_IS_ROW_BREAKPOINT_CELL = Qt::UserRole;
 constexpr auto USER_ROLE_CELL_ADDRESS = Qt::UserRole + 1;
 constexpr auto USER_ROLE_VALUE_TYPE = Qt::UserRole + 2;
+constexpr auto USER_ROLE_VALID_ADDRESS = Qt::UserRole + 3;
 
 // Numbers for the scrollbar. These affect how much big the draggable part of the scrollbar is, how
 // smooth it scrolls, and how much memory it traverses while dragging.
@@ -483,6 +485,10 @@ void MemoryViewWidget::Update()
         item_address = row_address + c * GetTypeSize(m_type);
 
       item->setData(USER_ROLE_CELL_ADDRESS, item_address);
+
+      // Reset highlighting.
+      item->setBackground(Qt::transparent);
+      item->setData(USER_ROLE_VALID_ADDRESS, false);
     }
   }
 
@@ -521,12 +527,41 @@ void MemoryViewWidget::UpdateColumns()
       if (cell_address == m_address_highlight)
         cell_item->setSelected(true);
 
+      // Color recently changed items.
+      QColor bcolor = cell_item->background().color();
+      const bool valid = cell_item->data(USER_ROLE_VALID_ADDRESS).toBool();
+
       // It gets a bit complicated, because invalid addresses becoming valid should not be
       // colored.
       if (!new_text.has_value())
+      {
+        cell_item->setBackground(Qt::transparent);
+        cell_item->setData(USER_ROLE_VALID_ADDRESS, false);
         cell_item->setText(INVALID_MEMORY);
-      else
+      }
+      else if (!valid)
+      {
+        // Wasn't valid on last update, is valid now.
+        cell_item->setData(USER_ROLE_VALID_ADDRESS, true);
         cell_item->setText(new_text.value());
+      }
+      else if (bcolor.rgb() != m_highlight_color.rgb() && bcolor != Qt::transparent)
+      {
+        // Filter out colors that shouldn't change, such as breakpoints.
+        cell_item->setText(new_text.value());
+      }
+      else if (cell_item->text() != new_text.value())
+      {
+        // Cell changed, apply highlighting.
+        cell_item->setBackground(m_highlight_color);
+        cell_item->setText(new_text.value());
+      }
+      else if (bcolor.alpha() > 0)
+      {
+        // Fade out highlighting each frame.
+        bcolor.setAlpha(bcolor.alpha() - 1);
+        cell_item->setBackground(bcolor);
+      }
     }
   }
 }
@@ -577,11 +612,12 @@ void MemoryViewWidget::GetValues()
 }
 
 // May only be called if we have taken on the role of the CPU thread
-QString MemoryViewWidget::ValueToString(const Core::CPUThreadGuard& guard, u32 address, Type type)
+std::optional<QString> MemoryViewWidget::ValueToString(const Core::CPUThreadGuard& guard,
+                                                       u32 address, Type type)
 {
   const AddressSpace::Accessors* accessors = AddressSpace::GetAccessors(m_address_space);
   if (!accessors->IsValidAddress(guard, address))
-    return INVALID_MEMORY;
+    return std::nullopt;
 
   switch (type)
   {
@@ -643,7 +679,7 @@ QString MemoryViewWidget::ValueToString(const Core::CPUThreadGuard& guard, u32 a
     return string;
   }
   default:
-    return INVALID_MEMORY;
+    return std::nullopt;
   }
 }
 
@@ -871,6 +907,54 @@ void MemoryViewWidget::SetDisplay(Type type, int bytes_per_row, int alignment, b
     m_alignment = alignment;
 
   UpdateDispatcher(UpdateType::Full);
+}
+
+void MemoryViewWidget::ToggleHighlights(bool enabled)
+{
+  // m_highlight_color should hold the current highlight color even when disabled, so it can
+  // be used if re-enabled. If modifying the enabled alpha, change in .h file as well.
+  if (enabled)
+  {
+    m_highlight_color.setAlpha(100);
+  }
+  else
+  {
+    // Treated as being interchangable with Qt::transparent.
+    m_highlight_color.setAlpha(0);
+
+    // Immediately remove highlights when paused.
+    for (int i = 0; i < m_table->rowCount(); i++)
+    {
+      for (int c = 0; c < m_data_columns; c++)
+        m_table->item(i, c + MISC_COLUMNS)->setBackground(m_highlight_color);
+    }
+  }
+}
+
+void MemoryViewWidget::SetHighlightColor()
+{
+  // Could allow custom alphas to be set, which would change fade-out rate.
+  QColor color = QColorDialog::getColor(m_highlight_color);
+  if (!color.isValid())
+    return;
+
+  const bool enabled = m_highlight_color.alpha() != 0;
+  m_highlight_color = color;
+  m_highlight_color.setAlpha(enabled ? 100 : 0);
+  if (!enabled)
+    return;
+
+  // Immediately update colors. Only useful for playing with colors while paused.
+  for (int i = 0; i < m_table->rowCount(); i++)
+  {
+    for (int c = 0; c < m_data_columns; c++)
+    {
+      auto* item = m_table->item(i, c + MISC_COLUMNS);
+      // Get current cell alpha state.
+      color.setAlpha(item->background().color().alpha());
+      m_table->item(i, c + MISC_COLUMNS)->setBackground(color);
+    }
+  }
 }
 
 void MemoryViewWidget::SetBPType(BPType type)

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -10,10 +10,11 @@
 #include <QClipboard>
 #include <QHBoxLayout>
 #include <QHeaderView>
+#include <QLineEdit>
 #include <QMenu>
 #include <QMouseEvent>
 #include <QScrollBar>
-#include <QSignalBlocker>
+#include <QStyledItemDelegate>
 #include <QTableWidget>
 #include <QtGlobal>
 
@@ -52,6 +53,14 @@ constexpr int SCROLLBAR_CENTER = SCROLLBAR_MAXIMUM / 2;
 
 const QString INVALID_MEMORY = QStringLiteral("-");
 
+void TableEditDelegate::setModelData(QWidget* editor, QAbstractItemModel* model,
+                                     const QModelIndex& index) const
+{
+  // Triggers on placing data into a cell. Editor has the text to be input, index has the location.
+  const QString input = qobject_cast<QLineEdit*>(editor)->text();
+  emit editFinished(index.row(), index.column(), input);
+}
+
 class MemoryViewTable final : public QTableWidget
 {
 public:
@@ -66,6 +75,11 @@ public:
     setSelectionMode(NoSelection);
     setTextElideMode(Qt::TextElideMode::ElideNone);
 
+    // Route user's direct cell inputs to an editFinished signal. Much better than an itemChanged
+    // signal and QSignalBlock juggling.
+    TableEditDelegate* table_edit_delegate = new TableEditDelegate(this);
+    setItemDelegate(table_edit_delegate);
+
     // Prevent colors from changing based on focus.
     QPalette palette(m_view->palette());
     palette.setBrush(QPalette::Inactive, QPalette::Highlight, palette.brush(QPalette::Highlight));
@@ -78,7 +92,8 @@ public:
 
     connect(this, &MemoryViewTable::customContextMenuRequested, m_view,
             &MemoryViewWidget::OnContextMenu);
-    connect(this, &MemoryViewTable::itemChanged, this, &MemoryViewTable::OnItemChanged);
+    connect(table_edit_delegate, &TableEditDelegate::editFinished, this,
+            &MemoryViewTable::OnDirectTableEdit);
   }
 
   void resizeEvent(QResizeEvent* event) override
@@ -146,9 +161,9 @@ public:
     }
   }
 
-  void OnItemChanged(QTableWidgetItem* item)
+  void OnDirectTableEdit(const int row, const int column, const QString& text)
   {
-    QString text = item->text();
+    QTableWidgetItem* item = this->item(row, column);
     MemoryViewWidget::Type type =
         static_cast<MemoryViewWidget::Type>(item->data(USER_ROLE_VALUE_TYPE).toInt());
     std::vector<u8> bytes = m_view->ConvertTextToBytes(type, text);
@@ -156,16 +171,16 @@ public:
     u32 address = item->data(USER_ROLE_CELL_ADDRESS).toUInt();
     u32 end_address = address + static_cast<u32>(bytes.size()) - 1;
     AddressSpace::Accessors* accessors = AddressSpace::GetAccessors(m_view->GetAddressSpace());
-
-    const Core::CPUThreadGuard guard(m_view->m_system);
-
-    if (!bytes.empty() && accessors->IsValidAddress(guard, address) &&
-        accessors->IsValidAddress(guard, end_address))
     {
-      for (const u8 c : bytes)
-        accessors->WriteU8(guard, address++, c);
-    }
+      const Core::CPUThreadGuard guard(m_view->m_system);
 
+      if (!bytes.empty() && accessors->IsValidAddress(guard, address) &&
+          accessors->IsValidAddress(guard, end_address))
+      {
+        for (const u8 c : bytes)
+          accessors->WriteU8(guard, address++, c);
+      }
+    }
     m_view->Update();
   }
 
@@ -292,8 +307,6 @@ void MemoryViewWidget::CreateTable()
   m_table->verticalHeader()->setMinimumSectionSize(m_font_vspace);
   m_table->horizontalHeader()->setMinimumSectionSize(m_font_width * 2);
 
-  const QSignalBlocker blocker(m_table);
-
   // Set column and row parameters.
   // Span is the number of unique memory values covered in one row.
   const int data_span = m_bytes_per_row / GetTypeSize(m_type);
@@ -398,7 +411,6 @@ void MemoryViewWidget::Update()
   if (m_table->item(1, 1) == nullptr)
     return;
 
-  const QSignalBlocker blocker(m_table);
   m_table->clearSelection();
 
   // Update addresses
@@ -463,8 +475,6 @@ void MemoryViewWidget::UpdateColumns(const Core::CPUThreadGuard* guard)
   // Check if table is created
   if (m_table->item(1, 1) == nullptr)
     return;
-
-  const QSignalBlocker blocker(m_table);
 
   for (int i = 0; i < m_table->rowCount(); i++)
   {

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <QStyledItemDelegate>
 #include <QWidget>
 
 #include "Common/CommonTypes.h"
@@ -21,6 +22,21 @@ namespace Core
 class CPUThreadGuard;
 class System;
 }  // namespace Core
+
+// Captures direct editing of the table.
+class TableEditDelegate : public QStyledItemDelegate
+{
+  Q_OBJECT
+
+public:
+  explicit TableEditDelegate(QObject* parent) : QStyledItemDelegate(parent) {}
+
+  void setModelData(QWidget* editor, QAbstractItemModel* model,
+                    const QModelIndex& index) const override;
+
+signals:
+  void editFinished(const int row, const int column, const QString& text) const;
+};
 
 class MemoryViewTable;
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -84,6 +84,7 @@ public:
   void CreateTable();
   void UpdateDispatcher(UpdateType type = UpdateType::Addresses);
   void Update();
+  void UpdateOnFrameEnd();
   void GetValues();
   void UpdateFont(const QFont& font);
   void ToggleBreakpoint(u32 addr, bool row);
@@ -99,6 +100,7 @@ public:
   void SetBPLoggingEnabled(bool enabled);
 
 signals:
+  void AutoUpdate();
   void ShowCode(u32 address);
   void RequestWatch(QString name, u32 address);
 
@@ -131,6 +133,7 @@ private:
   int m_alignment = 16;
   int m_data_columns;
   bool m_dual_view = false;
+  std::mutex m_updating;
   QColor m_highlight_color = QColor(120, 255, 255, 100);
 
   friend class MemoryViewTable;

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -93,6 +93,8 @@ public:
   void SetAddressSpace(AddressSpace::Type address_space);
   AddressSpace::Type GetAddressSpace() const;
   void SetDisplay(Type type, int bytes_per_row, int alignment, bool dual_view);
+  void ToggleHighlights(bool enabled);
+  void SetHighlightColor();
   void SetBPType(BPType type);
   void SetAddress(u32 address);
   void SetFocus() const;
@@ -112,7 +114,7 @@ private:
   void UpdateColumns();
   void ScrollbarActionTriggered(int action);
   void ScrollbarSliderReleased();
-  QString ValueToString(const Core::CPUThreadGuard& guard, u32 address, Type type);
+  std::optional<QString> ValueToString(const Core::CPUThreadGuard& guard, u32 address, Type type);
 
   Core::System& m_system;
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
+#include <mutex>
 
 #include <QStyledItemDelegate>
 #include <QWidget>
@@ -70,10 +71,20 @@ public:
     WriteOnly
   };
 
+  enum class UpdateType
+  {
+    Full,
+    Addresses,
+    Values,
+    Auto,
+  };
+
   explicit MemoryViewWidget(Core::System& system, QWidget* parent = nullptr);
 
   void CreateTable();
+  void UpdateDispatcher(UpdateType type = UpdateType::Addresses);
   void Update();
+  void GetValues();
   void UpdateFont(const QFont& font);
   void ToggleBreakpoint(u32 addr, bool row);
 
@@ -97,7 +108,6 @@ private:
   void OnCopyHex(u32 addr);
   void UpdateBreakpointTags();
   void UpdateColumns();
-  void UpdateColumns(const Core::CPUThreadGuard* guard);
   void ScrollbarActionTriggered(int action);
   void ScrollbarSliderReleased();
   QString ValueToString(const Core::CPUThreadGuard& guard, u32 address, Type type);
@@ -111,6 +121,9 @@ private:
   BPType m_bp_type = BPType::ReadWrite;
   bool m_do_log = true;
   u32 m_address = 0x80000000;
+  std::pair<u32, u32> m_address_range;
+  std::map<u32, std::optional<QString>> m_values;
+  std::map<u32, std::optional<QString>> m_values_dual_view;
   u32 m_address_highlight = 0;
   int m_font_width = 0;
   int m_font_vspace = 0;
@@ -118,6 +131,7 @@ private:
   int m_alignment = 16;
   int m_data_columns;
   bool m_dual_view = false;
+  QColor m_highlight_color = QColor(120, 255, 255, 100);
 
   friend class MemoryViewTable;
 };

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -66,9 +66,6 @@ MemoryWidget::MemoryWidget(Core::System& system, QWidget* parent)
   connect(&Settings::Instance(), &Settings::DebugModeToggled, this,
           [this](bool enabled) { setHidden(!enabled || !Settings::Instance().IsMemoryVisible()); });
 
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, &MemoryWidget::Update);
-  connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, &MemoryWidget::Update);
-
   LoadSettings();
 
   ConnectWidgets();

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -340,11 +340,36 @@ void MemoryWidget::ConnectWidgets()
 void MemoryWidget::closeEvent(QCloseEvent*)
 {
   Settings::Instance().SetMemoryVisible(false);
+  RemoveAfterFrameEventCallback();
 }
 
 void MemoryWidget::showEvent(QShowEvent* event)
 {
+  RegisterAfterFrameEventCallback();
   Update();
+}
+
+void MemoryWidget::hideEvent(QHideEvent* event)
+{
+  RemoveAfterFrameEventCallback();
+}
+
+void MemoryWidget::RegisterAfterFrameEventCallback()
+{
+  m_vi_end_field_event = VIEndFieldEvent::Register([this] { AutoUpdateTable(); }, "MemoryWidget");
+}
+
+void MemoryWidget::RemoveAfterFrameEventCallback()
+{
+  m_vi_end_field_event.reset();
+}
+
+void MemoryWidget::AutoUpdateTable()
+{
+  if (!isVisible())
+    return;
+
+  m_memory_view->UpdateOnFrameEnd();
 }
 
 void MemoryWidget::Update()

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -352,7 +352,7 @@ void MemoryWidget::Update()
   if (!isVisible())
     return;
 
-  m_memory_view->Update();
+  m_memory_view->UpdateDispatcher(MemoryViewWidget::UpdateType::Addresses);
   update();
 }
 

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -66,6 +66,13 @@ MemoryWidget::MemoryWidget(Core::System& system, QWidget* parent)
   connect(&Settings::Instance(), &Settings::DebugModeToggled, this,
           [this](bool enabled) { setHidden(!enabled || !Settings::Instance().IsMemoryVisible()); });
 
+  connect(this, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+    // Stop auto-update if MemoryView is tabbed out.
+    if (visible && m_auto_update_enabled)
+      RegisterAfterFrameEventCallback();
+    else
+      RemoveAfterFrameEventCallback();
+  });
   LoadSettings();
 
   ConnectWidgets();
@@ -247,11 +254,33 @@ void MemoryWidget::CreateWidgets()
   // Sidebar top menu
   QMenuBar* menubar = new QMenuBar(sidebar);
   menubar->setNativeMenuBar(false);
+  QMenu* menu_views = new QMenu(tr("&View"), menubar);
+  menubar->addMenu(menu_views);
 
   QMenu* menu_import = new QMenu(tr("&Import"), menubar);
   menu_import->addAction(tr("&Load file to current address"), this,
                          &MemoryWidget::OnSetValueFromFile);
   menubar->addMenu(menu_import);
+
+  auto* auto_update_action =
+      menu_views->addAction(tr("Auto update memory values"), this, [this](bool checked) {
+        m_auto_update_enabled = checked;
+        if (checked)
+          RegisterAfterFrameEventCallback();
+        else
+          RemoveAfterFrameEventCallback();
+      });
+  auto_update_action->setCheckable(true);
+  auto_update_action->setChecked(true);
+
+  auto* highlight_update_action =
+      menu_views->addAction(tr("Highlight recently changed values"), this,
+                            [this](bool checked) { m_memory_view->ToggleHighlights(checked); });
+  highlight_update_action->setCheckable(true);
+  highlight_update_action->setChecked(true);
+
+  menu_views->addAction(tr("Highlight color"), this,
+                        [this] { m_memory_view->SetHighlightColor(); });
 
   QMenu* menu_export = new QMenu(tr("&Export"), menubar);
   menu_export->addAction(tr("Dump &MRAM"), this, &MemoryWidget::OnDumpMRAM);
@@ -342,7 +371,9 @@ void MemoryWidget::closeEvent(QCloseEvent*)
 
 void MemoryWidget::showEvent(QShowEvent* event)
 {
-  RegisterAfterFrameEventCallback();
+  if (m_auto_update_enabled)
+    RegisterAfterFrameEventCallback();
+
   Update();
 }
 
@@ -363,9 +394,6 @@ void MemoryWidget::RemoveAfterFrameEventCallback()
 
 void MemoryWidget::AutoUpdateTable()
 {
-  if (!isVisible())
-    return;
-
   m_memory_view->UpdateOnFrameEnd();
 }
 

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -115,4 +115,6 @@ private:
   QRadioButton* m_bp_write_only;
   QCheckBox* m_bp_log_check;
   Common::EventHook m_vi_end_field_event;
+
+  bool m_auto_update_enabled = true;
 };

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -9,6 +9,7 @@
 #include <QDockWidget>
 
 #include "Common/CommonTypes.h"
+#include "VideoCommon/VideoEvents.h"
 
 class MemoryViewWidget;
 class QCheckBox;
@@ -76,7 +77,11 @@ private:
   void FindValue(bool next);
 
   void closeEvent(QCloseEvent*) override;
+  void hideEvent(QHideEvent* event) override;
   void showEvent(QShowEvent* event) override;
+  void RegisterAfterFrameEventCallback();
+  void RemoveAfterFrameEventCallback();
+  void AutoUpdateTable();
 
   Core::System& m_system;
 
@@ -109,4 +114,5 @@ private:
   QRadioButton* m_bp_read_only;
   QRadioButton* m_bp_write_only;
   QCheckBox* m_bp_log_check;
+  Common::EventHook m_vi_end_field_event;
 };


### PR DESCRIPTION
Update 2023:

Add menu items to Memory Widget's mini-menu for auto updates.  I saw another PR saying the mini-menu is confusing, but we need some place for all these little options. New ideas welcome. Burger flyout menu?

I'm also not sure MemoryWidget needs to receive update calls, so I removed those to avoid any issues.

/Resurrect Bringing this back with @Dentomologist 's method.  Needs a bit more work.  The new guard stuff makes it easier to use.

Also came up with a stylesheet / dark mode compliant highlighting scheme for recently changed items.