### PR TITLE
Android: Change alert dialog button ripple color for default theme

### DIFF
--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -47,7 +47,7 @@
 
     <style name="DolphinButton" parent="Widget.Material3.Button.TextButton.Dialog">
         <item name="android:textColor">@color/dolphin_primary</item>
-        <item name="rippleColor">@color/dolphin_secondary</item>
+        <item name="rippleColor">@color/dolphin_secondaryContainer</item>
     </style>
 
     <style name="DolphinPopup" parent="ThemeOverlay.Material3">


### PR DESCRIPTION
This brings the ripple color for the default theme more in line with the other themes.

Before - 
![image](https://user-images.githubusercontent.com/14132249/201253739-b850de61-29ec-4218-8757-9be63be7933d.png)


After -
![image](https://user-images.githubusercontent.com/14132249/201253680-ade8f2d7-a6c8-4b70-b7d9-adae6a5eb405.png)

Button Ripple in another theme - 
![image](https://user-images.githubusercontent.com/14132249/201253862-9a8735d7-b316-45dc-ab9b-175069eb125a.png)
