### PR TITLE
Android: Change system update dialog title/message when cancelling

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/SystemUpdateProgressBarDialogFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/SystemUpdateProgressBarDialogFragment.java
@@ -95,6 +95,11 @@ public class SystemUpdateProgressBarDialogFragment extends DialogFragment
     SystemUpdateViewModel viewModel =
             new ViewModelProvider(requireActivity()).get(SystemUpdateViewModel.class);
     Button negativeButton = alertDialog.getButton(Dialog.BUTTON_NEGATIVE);
-    negativeButton.setOnClickListener(v -> viewModel.setCanceled());
+    negativeButton.setOnClickListener(v ->
+    {
+      alertDialog.setTitle(getString(R.string.cancelling));
+      alertDialog.setMessage(getString(R.string.update_cancelling));
+      viewModel.setCanceled();
+    });
   }
 }

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -216,6 +216,7 @@
     <string name="download_failed">Could not download update files from Nintendo. Please check your Internet connection and try again.</string>
     <string name="import_failed">"Could not install an update to the Wii system memory. Please refer to logs for more information.</string>
     <string name="update_cancelled">The update has been cancelled. It is strongly recommended to finish it in order to avoid inconsistent system software versions.</string>
+    <string name="update_cancelling">Please wait for the update to cancel.</string>
     <string name="update_success_title">Update completed</string>
     <string name="update_failed_title">Update failed</string>
     <string name="update_cancelled_title">Update cancelled</string>
@@ -424,6 +425,7 @@
     <string name="ok">OK</string>
     <string name="off">Off</string>
     <string name="cancel">Cancel</string>
+    <string name="cancelling">Cancelling…</string>
     <string name="clear">Clear</string>
     <string name="disabled">Disabled</string>
     <string name="other">Other</string>


### PR DESCRIPTION
This PR doesn't affect the speed of cancelling updates. It's just better UX since the update can take a while to cancel at times.

Before - 
![cancel-demo](https://user-images.githubusercontent.com/14132249/201259776-432e37cd-0e48-4142-aef4-c5a95936a62a.gif)

After - 
![cancel-demo-new](https://user-images.githubusercontent.com/14132249/201259797-e1fbe33c-1ec7-4f98-8858-3a967e6e7b55.gif)
