### PR TITLE
Rename "Keyboard" to "Keyboard Controller"

### DIFF
--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -75,9 +75,6 @@ GCKeyboard::GCKeyboard(const unsigned int index) : m_index(index)
   groups.emplace_back(m_keys5x = new ControllerEmu::Buttons(_trans("Keys")));
   for (const char* key : named_keys5)
     m_keys5x->AddInput(ControllerEmu::DoNotTranslate, key);
-
-  // options
-  groups.emplace_back(m_options = new ControllerEmu::ControlGroup(_trans("Options")));
 }
 
 std::string GCKeyboard::GetName() const
@@ -101,8 +98,6 @@ ControllerEmu::ControlGroup* GCKeyboard::GetGroup(KeyboardGroup group)
     return m_keys4x;
   case KeyboardGroup::Kb5x:
     return m_keys5x;
-  case KeyboardGroup::Options:
-    return m_options;
   default:
     return nullptr;
   }

--- a/Source/Core/Core/HW/GCKeyboardEmu.h
+++ b/Source/Core/Core/HW/GCKeyboardEmu.h
@@ -23,8 +23,6 @@ enum class KeyboardGroup
   Kb3x,
   Kb4x,
   Kb5x,
-
-  Options
 };
 
 class GCKeyboard : public ControllerEmu::EmulatedController
@@ -43,7 +41,6 @@ private:
   ControllerEmu::Buttons* m_keys3x;
   ControllerEmu::Buttons* m_keys4x;
   ControllerEmu::Buttons* m_keys5x;
-  ControllerEmu::ControlGroup* m_options;
 
   const unsigned int m_index;
 };

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -40,7 +40,7 @@ static constexpr std::array s_gc_types = {
     SIDeviceName{SerialInterface::SIDEVICE_GC_GBA_EMULATED, _trans("GBA (Integrated)")},
 #endif
     SIDeviceName{SerialInterface::SIDEVICE_GC_GBA, _trans("GBA (TCP)")},
-    SIDeviceName{SerialInterface::SIDEVICE_GC_KEYBOARD, _trans("Keyboard")},
+    SIDeviceName{SerialInterface::SIDEVICE_GC_KEYBOARD, _trans("Keyboard Controller")},
 };
 
 static std::optional<int> ToGCMenuIndex(const SerialInterface::SIDevices sidevice)

--- a/Source/Core/DolphinQt/Config/Mapping/GCKeyboardEmu.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/GCKeyboardEmu.cpp
@@ -6,6 +6,8 @@
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
+#include <QLabel>
+#include <QStyle>
 #include <QVBoxLayout>
 
 #include "InputCommon/InputConfig.h"
@@ -20,26 +22,32 @@ GCKeyboardEmu::GCKeyboardEmu(MappingWindow* window) : MappingWidget(window)
 
 void GCKeyboardEmu::CreateMainLayout()
 {
-  m_main_layout = new QHBoxLayout();
+  const auto vbox_layout = new QVBoxLayout;
 
-  m_main_layout->addWidget(
-      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb0x)));
-  m_main_layout->addWidget(
-      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb1x)));
-  m_main_layout->addWidget(
-      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb2x)));
-  m_main_layout->addWidget(
-      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb3x)));
-  m_main_layout->addWidget(
-      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb4x)));
+  const auto warning_layout = new QHBoxLayout;
+  vbox_layout->addLayout(warning_layout);
 
-  auto* vbox_layout = new QVBoxLayout();
-  vbox_layout->addWidget(
-      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb5x)));
+  const auto warning_icon = new QLabel;
+  const auto size = QFontMetrics(font()).height() * 3 / 2;
+  warning_icon->setPixmap(style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(size, size));
+  warning_layout->addWidget(warning_icon);
 
-  m_main_layout->addLayout(vbox_layout);
+  const auto warning_text =
+      new QLabel(tr("You are configuring a \"Keyboard Controller\". "
+                    "This device is exclusively for \"Phantasy Star Online Episode I & II\". "
+                    "If you are unsure, turn back now and configure a \"Standard Controller\"."));
+  warning_text->setWordWrap(true);
+  warning_layout->addWidget(warning_text, 1);
 
-  setLayout(m_main_layout);
+  const auto layout = new QHBoxLayout;
+
+  using KG = KeyboardGroup;
+  for (auto kbg : {KG::Kb0x, KG::Kb1x, KG::Kb2x, KG::Kb3x, KG::Kb4x, KG::Kb5x})
+    layout->addWidget(CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), kbg)));
+
+  vbox_layout->addLayout(layout);
+
+  setLayout(vbox_layout);
 }
 
 void GCKeyboardEmu::LoadSettings()

--- a/Source/Core/DolphinQt/Config/Mapping/GCKeyboardEmu.h
+++ b/Source/Core/DolphinQt/Config/Mapping/GCKeyboardEmu.h
@@ -5,13 +5,6 @@
 
 #include "DolphinQt/Config/Mapping/MappingWidget.h"
 
-class QCheckBox;
-class QFormLayout;
-class QGroupBox;
-class QHBoxLayout;
-class QLabel;
-class QVBoxLayout;
-
 class GCKeyboardEmu final : public MappingWidget
 {
   Q_OBJECT
@@ -24,7 +17,4 @@ private:
   void LoadSettings() override;
   void SaveSettings() override;
   void CreateMainLayout();
-
-  // Main
-  QHBoxLayout* m_main_layout;
 };


### PR DESCRIPTION
Some confused users choose "Keyboard" instead of "Standard Controller" when then intend to play with a keyboard.

This renames "Keyboard" to "Keyboard Controller" and adds some warning text to the mapping dialog.
![image](https://user-images.githubusercontent.com/1768214/201456989-7a329512-55de-4579-9d75-90eff56ec299.png)


