### PR TITLE
Add DolphinDevice::GetSystemTime to allow for accurate Unix timestamp generation

### DIFF
--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -241,7 +241,10 @@ IPCReply DolphinDevice::GetSystemTime(const IOCtlVRequest& request) const
     return IPCReply(IPC_EINVAL);
   }
 
-  const u64 milliseconds = std::time(nullptr);
+  // Write Unix timestamp in milliseconds to memory address
+  const u64 milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::system_clock::now().time_since_epoch())
+                               .count();
   Memory::Write_U64(milliseconds, request.io_vectors[0].address);
   return IPCReply(IPC_SUCCESS);
 }

--- a/Source/Core/Core/IOS/DolphinDevice.h
+++ b/Source/Core/Core/IOS/DolphinDevice.h
@@ -15,6 +15,7 @@ public:
   std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
 private:
+  IPCReply GetElapsedTime(const IOCtlVRequest& request) const;
   IPCReply GetSystemTime(const IOCtlVRequest& request) const;
 
   Common::Timer m_timer;

--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -290,7 +290,9 @@ void UpdateDiscordPresence(int party_size, SecretType type, const std::string& s
     discord_presence.smallImageText = "Dolphin is an emulator for the GameCube and the Wii.";
   }
   discord_presence.details = title.empty() ? "Not in-game" : title.c_str();
-  discord_presence.startTimestamp = std::time(nullptr);
+  discord_presence.startTimestamp = std::chrono::duration_cast<std::chrono::seconds>(
+                                        std::chrono::system_clock::now().time_since_epoch())
+                                        .count();
 
   if (party_size > 0)
   {


### PR DESCRIPTION
Upstream's current `GetSystemTime` function returns the elapsed time. According to the comment, the change was made with the goal of making "buggy emulated code less likely to have issues". However, the old functionality is applicable when generating Unix timestamps for Discord rich presence.

If this implementation of generating these timestamps is not preferred, I am open to suggestions on alternative methods.