### PR TITLE
Android: Add theme mode switcher

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -96,7 +96,7 @@ android {
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
-    implementation 'androidx.appcompat:appcompat:1.5.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -34,6 +34,8 @@ public enum IntSetting implements AbstractIntSetting
   MAIN_EMULATION_ORIENTATION(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
           "EmulationOrientation", ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE),
   MAIN_INTERFACE_THEME(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "InterfaceTheme", 0),
+  MAIN_INTERFACE_THEME_MODE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
+          "InterfaceThemeMode", -1),
   MAIN_LAST_PLATFORM_TAB(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "LastPlatformTab", 0),
   MAIN_MOTION_CONTROLS(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "MotionControls", 1),
   MAIN_IR_MODE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "IRMode",

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -8,6 +8,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 
+import androidx.appcompat.app.AppCompatActivity;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.UserDataActivity;
@@ -328,33 +330,37 @@ public final class SettingsFragmentPresenter
 
     AbstractIntSetting appTheme = new AbstractIntSetting()
     {
-      @Override public boolean isOverridden(Settings settings)
+      @Override
+      public boolean isOverridden(Settings settings)
       {
         return IntSetting.MAIN_INTERFACE_THEME.isOverridden(settings);
       }
 
-      @Override public boolean isRuntimeEditable()
+      @Override
+      public boolean isRuntimeEditable()
       {
         // This only affects app UI
         return true;
       }
 
-      @Override public boolean delete(Settings settings)
+      @Override
+      public boolean delete(Settings settings)
       {
-        ThemeHelper.deleteThemeKey(mView.getActivity());
+        ThemeHelper.deleteThemeKey((AppCompatActivity) mView.getActivity());
         return IntSetting.MAIN_INTERFACE_THEME.delete(settings);
       }
 
-      @Override public int getInt(Settings settings)
+      @Override
+      public int getInt(Settings settings)
       {
         return IntSetting.MAIN_INTERFACE_THEME.getInt(settings);
       }
 
-      @Override public void setInt(Settings settings, int newValue)
+      @Override
+      public void setInt(Settings settings, int newValue)
       {
-        ThemeHelper.saveTheme(mView.getActivity(), newValue);
         IntSetting.MAIN_INTERFACE_THEME.setInt(settings, newValue);
-        mView.getActivity().recreate();
+        ThemeHelper.saveTheme((AppCompatActivity) mView.getActivity(), newValue);
       }
     };
 
@@ -369,6 +375,45 @@ public final class SettingsFragmentPresenter
       sl.add(new SingleChoiceSetting(mContext, appTheme, R.string.change_theme, 0,
               R.array.themeEntries, R.array.themeValues));
     }
+
+    AbstractIntSetting themeMode = new AbstractIntSetting()
+    {
+      @Override
+      public boolean isOverridden(Settings settings)
+      {
+        return IntSetting.MAIN_INTERFACE_THEME_MODE.isOverridden(settings);
+      }
+
+      @Override
+      public boolean isRuntimeEditable()
+      {
+        // This only affects app UI
+        return true;
+      }
+
+      @Override
+      public boolean delete(Settings settings)
+      {
+        ThemeHelper.deleteThemeModeKey((AppCompatActivity) mView.getActivity());
+        return IntSetting.MAIN_INTERFACE_THEME_MODE.delete(settings);
+      }
+
+      @Override
+      public int getInt(Settings settings)
+      {
+        return IntSetting.MAIN_INTERFACE_THEME_MODE.getInt(settings);
+      }
+
+      @Override
+      public void setInt(Settings settings, int newValue)
+      {
+        IntSetting.MAIN_INTERFACE_THEME_MODE.setInt(settings, newValue);
+        ThemeHelper.saveThemeMode((AppCompatActivity) mView.getActivity(), newValue);
+      }
+    };
+
+    sl.add(new SingleChoiceSetting(mContext, themeMode, R.string.change_theme_mode, 0,
+            R.array.themeModeEntries, R.array.themeModeValues));
   }
 
   private void addAudioSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -13,6 +13,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.preference.PreferenceManager;
@@ -84,6 +85,16 @@ public final class DirectoryInitialization
     {
       preferences.edit()
               .putInt(ThemeHelper.CURRENT_THEME, IntSetting.MAIN_INTERFACE_THEME.getIntGlobal())
+              .apply();
+    }
+
+    if (IntSetting.MAIN_INTERFACE_THEME_MODE.getIntGlobal() !=
+            preferences.getInt(ThemeHelper.CURRENT_THEME_MODE,
+                    AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM))
+    {
+      preferences.edit()
+              .putInt(ThemeHelper.CURRENT_THEME_MODE,
+                      IntSetting.MAIN_INTERFACE_THEME_MODE.getIntGlobal())
               .apply();
     }
 

--- a/Source/Android/app/src/main/res/drawable/ic_back.xml
+++ b/Source/Android/app/src/main/res/drawable/ic_back.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:fillColor="?attr/colorOnSurface"
-      android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
-</vector>

--- a/Source/Android/app/src/main/res/drawable/tv_card_background.xml
+++ b/Source/Android/app/src/main/res/drawable/tv_card_background.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:state_selected="true"
-        android:drawable="@color/dolphin_primary"/>
+        android:drawable="@color/dolphin_blue"/>
     <item
         android:drawable="@color/tv_card_unselected"/>
 </selector>

--- a/Source/Android/app/src/main/res/values-night/bools.xml
+++ b/Source/Android/app/src/main/res/values-night/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="lightSystemBars">false</bool>
-</resources>

--- a/Source/Android/app/src/main/res/values-v27/themes.xml
+++ b/Source/Android/app/src/main/res/values-v27/themes.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="Theme.V27.Dolphin" parent="Theme.Dolphin">
-        <item name="android:windowLightNavigationBar">@bool/lightSystemBars</item>
-    </style>
-
-    <style name="Theme.Dolphin.Main" parent="Theme.V27.Dolphin" />
-</resources>

--- a/Source/Android/app/src/main/res/values-v29/themes.xml
+++ b/Source/Android/app/src/main/res/values-v29/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.V29.Dolphin" parent="Theme.V27.Dolphin">
+    <style name="Theme.V29.Dolphin" parent="Theme.Dolphin">
         <item name="android:enforceStatusBarContrast">false</item>
         <item name="android:enforceNavigationBarContrast">false</item>
     </style>

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -507,6 +507,17 @@
         <item>4</item>
     </integer-array>
 
+    <string-array name="themeModeEntries">
+        <item>Follow System</item>
+        <item>Light</item>
+        <item>Dark</item>
+    </string-array>
+    <integer-array name="themeModeValues">
+        <item>-1</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
+
     <string-array name="synchronizeGpuThreadEntries">
         <item>Never</item>
         <item>On Idle Skipping</item>

--- a/Source/Android/app/src/main/res/values/bools.xml
+++ b/Source/Android/app/src/main/res/values/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="lightSystemBars">true</bool>
-</resources>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -196,6 +196,7 @@
     <string name="show_titles_in_game_list">Show Titles in Game List</string>
     <string name="show_titles_in_game_list_description">Show the title and creator below each game cover.</string>
     <string name="change_theme">Change App Theme</string>
+    <string name="change_theme_mode">Change Theme Mode</string>
 
     <!-- Online Update Region Select Fragment -->
     <string name="region_select_title">Please select a region</string>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -42,7 +42,7 @@
 
     <style name="DolphinTVDialog" parent="Theme.Material3.DayNight.Dialog.Alert">
         <item name="colorSurface">@color/dolphin_inverseOnSurface</item>
-        <item name="colorPrimary">@color/dolphin_primary</item>
+        <item name="colorPrimary">@color/dolphin_blue</item>
     </style>
 
     <style name="DolphinButton" parent="Widget.Material3.Button.TextButton.Dialog">

--- a/Source/Android/app/src/main/res/values/themes.xml
+++ b/Source/Android/app/src/main/res/values/themes.xml
@@ -47,9 +47,6 @@
         <item name="android:windowAllowEnterTransitionOverlap">true</item>
         <item name="android:windowAllowReturnTransitionOverlap">true</item>
 
-        <item name="homeAsUpIndicator">@drawable/ic_back</item>
-
-        <item name="android:windowLightStatusBar" tools:targetApi="m">@bool/lightSystemBars</item>
         <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="o_mr1">default</item>
 
         <item name="materialAlertDialogTheme">@style/DolphinMaterialDialog</item>
@@ -58,7 +55,7 @@
         <item name="materialDividerStyle">@style/DolphinDivider</item>
     </style>
 
-    <!-- Trick for API >= 27 specific changes -->
+    <!-- Trick for API >= 29 specific changes -->
     <style name="Theme.Dolphin.Main" parent="Theme.Dolphin" />
 
     <style name="Theme.Dolphin.Main.Material" parent="Theme.Dolphin.Main">

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -39,10 +39,12 @@ bool IsSettingSaveable(const Config::Location& config_location)
     // TODO: Kill the current Android controller mappings system
     if (config_location.section == "Android")
     {
-      static constexpr std::array<const char*, 12> android_setting_saveable = {
-          "ControlScale",    "ControlOpacity",   "EmulationOrientation", "JoystickRelCenter",
-          "LastPlatformTab", "MotionControls",   "PhoneRumble",          "ShowInputOverlay",
-          "IRMode",          "IRAlwaysRecenter", "ShowGameTitles",       "InterfaceTheme"};
+      static constexpr std::array<const char*, 13> android_setting_saveable = {
+          "ControlScale",      "ControlOpacity",   "EmulationOrientation",
+          "JoystickRelCenter", "LastPlatformTab",  "MotionControls",
+          "PhoneRumble",       "ShowInputOverlay", "IRMode",
+          "IRAlwaysRecenter",  "ShowGameTitles",   "InterfaceTheme",
+          "InterfaceThemeMode"};
 
       return std::any_of(
           android_setting_saveable.cbegin(), android_setting_saveable.cend(),


### PR DESCRIPTION
Now you can chose the theme mode independent of the system. This also allows all Android versions to use a dark theme now. The system-wide toggle was only introduced in Android 10 so users below that version can enjoy this now. This also includes AndroidTV users who used to be stuck with the mode mismatch between the main and settings UI.

Note - Similar to app themes, theme modes have to be loaded before directory initialization is ready. So we save the proper key the same way.

Demo - 
![theme-mode-demo](https://user-images.githubusercontent.com/14132249/201456371-eff6d1aa-e67d-4aa2-aabe-d7b5505f68d2.gif)
