### PR TITLE
DolphinQt: Allow mapping buttons to expand horizontally.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -75,14 +75,6 @@ bool MappingButton::IsInput() const
 MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref, bool indicator)
     : ElidedButton(RefToDisplayString(ref)), m_parent(parent), m_reference(ref)
 {
-  // Force all mapping buttons to stay at a minimal height.
-  setFixedHeight(minimumSizeHint().height());
-
-  // Make sure that long entries don't throw our layout out of whack.
-  setFixedWidth(WIDGET_MAX_WIDTH);
-
-  setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
-
   if (IsInput())
   {
     setToolTip(

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -9,8 +9,6 @@
 #include <QString>
 #include <QWidget>
 
-constexpr int WIDGET_MAX_WIDTH = 112;
-
 class ControlGroupBox;
 class InputConfig;
 class MappingButton;


### PR DESCRIPTION
The removed hacks are no longer needed now that the base-class, `ElidedButton`, overrides `sizeHint`.

This fixes: https://bugs.dolphin-emu.org/issues/11707

![image](https://user-images.githubusercontent.com/1768214/201458365-9240968c-21d8-4684-bc08-673d09cdab4a.png)