### PR TITLE
Android: Use progress bar that does not inherit from AppCompat on leanback

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/SystemUpdateProgressBarDialogFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/SystemUpdateProgressBarDialogFragment.java
@@ -10,6 +10,7 @@ import android.widget.Button;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -17,6 +18,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.databinding.DialogProgressBinding;
+import org.dolphinemu.dolphinemu.databinding.DialogProgressTvBinding;
 
 public class SystemUpdateProgressBarDialogFragment extends DialogFragment
 {
@@ -32,32 +34,58 @@ public class SystemUpdateProgressBarDialogFragment extends DialogFragment
     SystemUpdateViewModel viewModel =
             new ViewModelProvider(requireActivity()).get(SystemUpdateViewModel.class);
 
-    DialogProgressBinding dialogProgressBinding =
-            DialogProgressBinding.inflate(getLayoutInflater());
+    DialogProgressBinding dialogProgressBinding;
+    DialogProgressTvBinding dialogProgressTvBinding;
 
     // We need to set the message to something here, otherwise the text will not appear when we set it later.
-    AlertDialog progressDialog = new MaterialAlertDialogBuilder(requireContext())
-            .setTitle(getString(R.string.updating))
-            .setMessage("")
-            .setNegativeButton(getString(R.string.cancel), null)
-            .setView(dialogProgressBinding.getRoot())
-            .setCancelable(false)
-            .create();
+    MaterialAlertDialogBuilder progressDialogBuilder =
+            new MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(getString(R.string.updating))
+                    .setMessage("")
+                    .setNegativeButton(getString(R.string.cancel), null)
+                    .setCancelable(false);
 
-    viewModel.getProgressData()
-            .observe(this, (@Nullable
-                    Integer progress) -> dialogProgressBinding.updateProgress.setProgress(
-                    progress));
-
-    viewModel.getTotalData().observe(this, (@Nullable Integer total) ->
+    // TODO: Remove dialog_progress_tv if we switch to an AppCompatActivity for leanback
+    if (getActivity() instanceof AppCompatActivity)
     {
-      if (total == 0)
-      {
-        return;
-      }
+      dialogProgressBinding = DialogProgressBinding.inflate(getLayoutInflater());
+      progressDialogBuilder.setView(dialogProgressBinding.getRoot());
 
-      dialogProgressBinding.updateProgress.setMax(total);
-    });
+      viewModel.getProgressData().observe(this,
+              (@Nullable Integer progress) -> dialogProgressBinding.updateProgress.setProgress(
+                      progress));
+
+      viewModel.getTotalData().observe(this, (@Nullable Integer total) ->
+      {
+        if (total == 0)
+        {
+          return;
+        }
+
+        dialogProgressBinding.updateProgress.setMax(total);
+      });
+    }
+    else
+    {
+      dialogProgressTvBinding = DialogProgressTvBinding.inflate(getLayoutInflater());
+      progressDialogBuilder.setView(dialogProgressTvBinding.getRoot());
+
+      viewModel.getProgressData().observe(this,
+              (@Nullable Integer progress) -> dialogProgressTvBinding.updateProgress.setProgress(
+                      progress));
+
+      viewModel.getTotalData().observe(this, (@Nullable Integer total) ->
+      {
+        if (total == 0)
+        {
+          return;
+        }
+
+        dialogProgressTvBinding.updateProgress.setMax(total);
+      });
+    }
+
+    AlertDialog progressDialog = progressDialogBuilder.create();
 
     viewModel.getTitleIdData().observe(this, (@Nullable Long titleId) -> progressDialog.setMessage(
             getString(R.string.updating_message, titleId)));

--- a/Source/Android/app/src/main/res/layout/dialog_progress_tv.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_progress_tv.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/dialog_progress"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:id="@+id/update_progress"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="24dp"
+        android:indeterminate="false" />
+
+</androidx.appcompat.widget.LinearLayoutCompat>


### PR DESCRIPTION
Previously the TV activity would crash when attempting to update the wii system menu because components that inherit from AppCompat themes could not be inflated.