### PR TITLE
Debugger: Add conditional breakpoints to memory BPs

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -335,7 +335,7 @@ void PPCDebugInterface::ToggleMemCheck(u32 address, bool read, bool write, bool 
     MemCheck.log_on_hit = log;
     MemCheck.break_on_hit = true;
 
-    PowerPC::memchecks.Add(MemCheck);
+    PowerPC::memchecks.Add(std::move(MemCheck));
   }
   else
   {

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -83,7 +83,6 @@ void BreakPoints::AddFromStrings(const TBreakPointsStr& bp_strings)
 
     if (iss.peek() == '$')
       iss.ignore();
-
     iss >> std::hex >> bp.address;
     iss >> flags;
     bp.is_enabled = flags.find('n') != flags.npos;
@@ -203,11 +202,21 @@ MemChecks::TMemChecksStr MemChecks::GetStrings() const
   {
     std::ostringstream ss;
     ss.imbue(std::locale::classic());
+    ss << fmt::format("${:08x} {:08x} ", mc.start_address, mc.end_address);
+    if (mc.is_enabled)
+      ss << 'n';
+    if (mc.is_break_on_read)
+      ss << 'r';
+    if (mc.is_break_on_write)
+      ss << 'w';
+    if (mc.log_on_hit)
+      ss << 'l';
+    if (mc.break_on_hit)
+      ss << 'b';
+    if (mc.condition)
+      ss << "c " << mc.condition->GetText();
 
-    ss << std::hex << mc.start_address << " " << mc.end_address << " " << (mc.is_enabled ? "n" : "")
-       << (mc.is_break_on_read ? "r" : "") << (mc.is_break_on_write ? "w" : "")
-       << (mc.log_on_hit ? "l" : "") << (mc.break_on_hit ? "b" : "");
-    mc_strings.push_back(ss.str());
+    mc_strings.emplace_back(ss.str());
   }
 
   return mc_strings;
@@ -221,6 +230,9 @@ void MemChecks::AddFromStrings(const TMemChecksStr& mc_strings)
     std::istringstream iss(mc_string);
     iss.imbue(std::locale::classic());
 
+    if (iss.peek() == '$')
+      iss.ignore();
+
     std::string flags;
     iss >> std::hex >> mc.start_address >> mc.end_address >> flags;
 
@@ -230,12 +242,19 @@ void MemChecks::AddFromStrings(const TMemChecksStr& mc_strings)
     mc.is_break_on_write = flags.find('w') != flags.npos;
     mc.log_on_hit = flags.find('l') != flags.npos;
     mc.break_on_hit = flags.find('b') != flags.npos;
+    if (flags.find('c') != std::string::npos)
+    {
+      iss >> std::ws;
+      std::string condition;
+      std::getline(iss, condition);
+      mc.condition = Expression::TryParse(condition);
+    }
 
-    Add(mc);
+    Add(std::move(mc));
   }
 }
 
-void MemChecks::Add(const TMemCheck& memory_check)
+void MemChecks::Add(TMemCheck memory_check)
 {
   bool had_any = HasAny();
   Core::RunAsCPUThread([&] {
@@ -254,7 +273,7 @@ void MemChecks::Add(const TMemCheck& memory_check)
     }
     else
     {
-      m_mem_checks.push_back(memory_check);
+      m_mem_checks.emplace_back(std::move(memory_check));
     }
     // If this is the first one, clear the JIT cache so it can switch to
     // watchpoint-compatible code.
@@ -338,7 +357,8 @@ bool TMemCheck::Action(Common::DebugInterface* debug_interface, u64 value, u32 a
   if (!is_enabled)
     return false;
 
-  if ((write && is_break_on_write) || (!write && is_break_on_read))
+  if (((write && is_break_on_write) || (!write && is_break_on_read)) &&
+      EvaluateCondition(this->condition))
   {
     if (log_on_hit)
     {

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -42,6 +42,8 @@ struct TMemCheck
 
   u32 num_hits = 0;
 
+  std::optional<Expression> condition;
+
   // returns whether to break
   bool Action(Common::DebugInterface* debug_interface, u64 value, u32 addr, bool write, size_t size,
               u32 pc);
@@ -93,7 +95,7 @@ public:
   TMemChecksStr GetStrings() const;
   void AddFromStrings(const TMemChecksStr& mc_strings);
 
-  void Add(const TMemCheck& memory_check);
+  void Add(TMemCheck memory_check);
 
   bool ToggleBreakPoint(u32 address);
 

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -865,7 +865,7 @@ static bool AddBreakpoint(BreakpointType type, u32 addr, u32 len)
     new_memcheck.break_on_hit = true;
     new_memcheck.log_on_hit = false;
     new_memcheck.is_enabled = true;
-    PowerPC::memchecks.Add(new_memcheck);
+    PowerPC::memchecks.Add(std::move(new_memcheck));
     INFO_LOG_FMT(GDB_STUB, "gdb: added {} memcheck: {:08x} bytes at {:08x}", static_cast<int>(type),
                  len, addr);
   }

--- a/Source/Core/DolphinQt/Debugger/BreakpointDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointDialog.h
@@ -16,6 +16,7 @@ class QGroupBox;
 class QLabel;
 class QLineEdit;
 class QRadioButton;
+class QPushButton;
 
 class BreakpointDialog : public QDialog
 {
@@ -46,8 +47,6 @@ private:
   QRadioButton* m_instruction_bp;
   QGroupBox* m_instruction_box;
   QLineEdit* m_instruction_address;
-  QLineEdit* m_instruction_condition;
-  QPushButton* m_cond_help_btn;
 
   // Memory BPs
   QRadioButton* m_memory_bp;
@@ -66,6 +65,9 @@ private:
   QRadioButton* m_do_log;
   QRadioButton* m_do_break;
   QRadioButton* m_do_log_and_break;
+
+  QLineEdit* m_conditional;
+  QPushButton* m_cond_help_btn;
 
   QDialogButtonBox* m_buttons;
   BreakpointWidget* m_parent;

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -255,6 +255,13 @@ void BreakpointWidget::Update()
 
     m_table->setItem(i, 4, create_item(flags));
 
+    QString condition;
+
+    if (mbp.condition)
+      condition = QString::fromStdString(mbp.condition->GetText());
+
+    m_table->setItem(i, 5, create_item(condition));
+
     i++;
   }
 }
@@ -430,7 +437,7 @@ void BreakpointWidget::AddBP(u32 addr, bool temp, bool break_on_hit, bool log_on
 }
 
 void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool do_log,
-                                     bool do_break)
+                                     bool do_break, const QString& condition)
 {
   TMemCheck check;
 
@@ -441,10 +448,11 @@ void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool
   check.is_break_on_write = on_write;
   check.log_on_hit = do_log;
   check.break_on_hit = do_break;
-
+  check.condition =
+      !condition.isEmpty() ? Expression::TryParse(condition.toUtf8().constData()) : std::nullopt;
   {
     const QSignalBlocker blocker(Settings::Instance());
-    PowerPC::memchecks.Add(check);
+    PowerPC::memchecks.Add(std::move(check));
   }
 
   emit BreakpointsChanged();
@@ -452,7 +460,7 @@ void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool
 }
 
 void BreakpointWidget::AddRangedMBP(u32 from, u32 to, bool on_read, bool on_write, bool do_log,
-                                    bool do_break)
+                                    bool do_break, const QString& condition)
 {
   TMemCheck check;
 
@@ -463,10 +471,11 @@ void BreakpointWidget::AddRangedMBP(u32 from, u32 to, bool on_read, bool on_writ
   check.is_break_on_write = on_write;
   check.log_on_hit = do_log;
   check.break_on_hit = do_break;
-
+  check.condition =
+      !condition.isEmpty() ? Expression::TryParse(condition.toUtf8().constData()) : std::nullopt;
   {
     const QSignalBlocker blocker(Settings::Instance());
-    PowerPC::memchecks.Add(check);
+    PowerPC::memchecks.Add(std::move(check));
   }
 
   emit BreakpointsChanged();

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -23,9 +23,9 @@ public:
   void AddBP(u32 addr);
   void AddBP(u32 addr, bool temp, bool break_on_hit, bool log_on_hit, const QString& condition);
   void AddAddressMBP(u32 addr, bool on_read = true, bool on_write = true, bool do_log = true,
-                     bool do_break = true);
+                     bool do_break = true, const QString& condition = {});
   void AddRangedMBP(u32 from, u32 to, bool do_read = true, bool do_write = true, bool do_log = true,
-                    bool do_break = true);
+                    bool do_break = true, const QString& condition = {});
   void UpdateButtonsEnabled();
   void Update();
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -797,7 +797,7 @@ void MemoryViewWidget::ToggleBreakpoint(u32 addr, bool row)
       check.log_on_hit = m_do_log;
       check.break_on_hit = true;
 
-      PowerPC::memchecks.Add(check);
+      PowerPC::memchecks.Add(std::move(check));
     }
     else if (check_ptr != nullptr)
     {


### PR DESCRIPTION
I think it's fairly straightforward. I copied the conditional instruction BP changes. 

![breakpointdialog](https://user-images.githubusercontent.com/10532806/204904167-d68a12aa-6878-485f-8821-2f7f553f8cd0.jpg)