### PR TITLE
Tone down auto scaling.

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -400,7 +400,7 @@ bool Renderer::CalculateTargetSize()
     // Set a scale based on the window size
     int width = EFB_WIDTH * m_target_rectangle.GetWidth() / m_last_xfb_width;
     int height = EFB_HEIGHT * m_target_rectangle.GetHeight() / m_last_xfb_height;
-    m_efb_scale = std::max((width - 1) / EFB_WIDTH + 1, (height - 1) / EFB_HEIGHT + 1);
+    m_efb_scale = std::max((width - 1) / EFB_WIDTH, (height - 1) / EFB_HEIGHT + 1);
   }
   else
   {


### PR DESCRIPTION
When using auto for scaling, it will go one step beyond the appropriate resolution when in 16:9. My screen resolution is `4112` × `2658` and the following example shows the closest matches running F-Zero in full screen.

Resolution scaling for F-Zero in 16:9
```
  6x = 4668  ×  2688
  7x = 5444  ×  3136
```

It should be 6x since it’s above the screen resolution but it selects 7x instead.

```
before:
  7.4234375 [width]  = (4112 - 1) / 640 + 1
  6.2821969 [height] = (2790 - 1) / 528 + 1
  7 = result

after:
  6.4234375 [width]  = (4112 - 1) / 640
  6.2821969 [height] = (2790 - 1) / 528 + 1
  6 = result
```

And this is for SoulCalibur 2 at 4:3:
```
  5x = 3200  ×  2456
  6x = 3840  ×  2948
```

At 4:3 the scaling doesn’t change and stays at 6x for the full screen `4112` × `2658` resolution and stays beyond the vertical resolution.

```
before:
  6.2296875 [width]  = (3348 - 1) / 640 + 1
  6.7386363 [height] = (3031 - 1) / 528 + 1
  6 = result

after:
  5.2296875 [width]  = (3348 - 1) / 640
  6.7386363 [height] = (3031 - 1) / 528 + 1
  6 = result
```

Checked with SMG and the behavior is consistent and picks the closest resolution. This also applies in windowed mode.
