### PR TITLE
Core: Add option to force linear texture filtering.

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -107,8 +107,8 @@ const Info<bool> GFX_MODS_ENABLE{{System::GFX, "Settings", "EnableMods"}, false}
 
 // Graphics.Enhancements
 
-const Info<bool> GFX_ENHANCE_FORCE_FILTERING{{System::GFX, "Enhancements", "ForceFiltering"},
-                                             false};
+const Info<TextureFilteringMode> GFX_ENHANCE_FORCE_TEXTURE_FILTERING{
+    {System::GFX, "Enhancements", "ForceTextureFiltering"}, TextureFilteringMode::Default};
 const Info<int> GFX_ENHANCE_MAX_ANISOTROPY{{System::GFX, "Enhancements", "MaxAnisotropy"}, 0};
 const Info<std::string> GFX_ENHANCE_POST_SHADER{
     {System::GFX, "Enhancements", "PostProcessingShader"}, ""};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -10,6 +10,7 @@
 enum class AspectMode : int;
 enum class ShaderCompilationMode : int;
 enum class StereoMode : int;
+enum class TextureFilteringMode : int;
 enum class TriState : int;
 
 namespace Config
@@ -92,7 +93,7 @@ extern const Info<bool> GFX_MODS_ENABLE;
 
 // Graphics.Enhancements
 
-extern const Info<bool> GFX_ENHANCE_FORCE_FILTERING;
+extern const Info<TextureFilteringMode> GFX_ENHANCE_FORCE_TEXTURE_FILTERING;
 extern const Info<int> GFX_ENHANCE_MAX_ANISOTROPY;  // NOTE - this is x in (1 << x)
 extern const Info<std::string> GFX_ENHANCE_POST_SHADER;
 extern const Info<bool> GFX_ENHANCE_FORCE_TRUE_COLOR;

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -104,7 +104,7 @@ public:
       layer->Set(Config::GFX_FAST_DEPTH_CALC, m_settings.fast_depth_calc);
       layer->Set(Config::GFX_ENABLE_PIXEL_LIGHTING, m_settings.enable_pixel_lighting);
       layer->Set(Config::GFX_WIDESCREEN_HACK, m_settings.widescreen_hack);
-      layer->Set(Config::GFX_ENHANCE_FORCE_FILTERING, m_settings.force_filtering);
+      layer->Set(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING, m_settings.force_texture_filtering);
       layer->Set(Config::GFX_ENHANCE_MAX_ANISOTROPY, m_settings.max_anisotropy);
       layer->Set(Config::GFX_ENHANCE_FORCE_TRUE_COLOR, m_settings.force_true_color);
       layer->Set(Config::GFX_ENHANCE_DISABLE_COPY_FILTER, m_settings.disable_copy_filter);

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -872,7 +872,7 @@ void NetPlayClient::OnStartGame(sf::Packet& packet)
     packet >> m_net_settings.fast_depth_calc;
     packet >> m_net_settings.enable_pixel_lighting;
     packet >> m_net_settings.widescreen_hack;
-    packet >> m_net_settings.force_filtering;
+    packet >> m_net_settings.force_texture_filtering;
     packet >> m_net_settings.max_anisotropy;
     packet >> m_net_settings.force_true_color;
     packet >> m_net_settings.disable_copy_filter;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -13,6 +13,7 @@
 #include "Core/HW/EXI/EXI.h"
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/HW/Sram.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace DiscIO
 {
@@ -82,7 +83,7 @@ struct NetSettings
   bool fast_depth_calc = false;
   bool enable_pixel_lighting = false;
   bool widescreen_hack = false;
-  bool force_filtering = false;
+  TextureFilteringMode force_texture_filtering = TextureFilteringMode::Default;
   int max_anisotropy = 0;
   bool force_true_color = false;
   bool disable_copy_filter = false;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1336,7 +1336,7 @@ bool NetPlayServer::SetupNetSettings()
   settings.fast_depth_calc = Config::Get(Config::GFX_FAST_DEPTH_CALC);
   settings.enable_pixel_lighting = Config::Get(Config::GFX_ENABLE_PIXEL_LIGHTING);
   settings.widescreen_hack = Config::Get(Config::GFX_WIDESCREEN_HACK);
-  settings.force_filtering = Config::Get(Config::GFX_ENHANCE_FORCE_FILTERING);
+  settings.force_texture_filtering = Config::Get(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING);
   settings.max_anisotropy = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);
   settings.force_true_color = Config::Get(Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
   settings.disable_copy_filter = Config::Get(Config::GFX_ENHANCE_DISABLE_COPY_FILTER);
@@ -1539,7 +1539,7 @@ bool NetPlayServer::StartGame()
   spac << m_settings.fast_depth_calc;
   spac << m_settings.enable_pixel_lighting;
   spac << m_settings.widescreen_hack;
-  spac << m_settings.force_filtering;
+  spac << m_settings.force_texture_filtering;
   spac << m_settings.max_anisotropy;
   spac << m_settings.force_true_color;
   spac << m_settings.disable_copy_filter;

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -40,6 +40,18 @@ EnhancementsWidget::EnhancementsWidget(GraphicsWindow* parent) : m_block_save(fa
           [this](const QString& backend) { LoadSettings(); });
 }
 
+constexpr int TEXTURE_FILTERING_DEFAULT = 0;
+constexpr int TEXTURE_FILTERING_ANISO_2X = 1;
+constexpr int TEXTURE_FILTERING_ANISO_4X = 2;
+constexpr int TEXTURE_FILTERING_ANISO_8X = 3;
+constexpr int TEXTURE_FILTERING_ANISO_16X = 4;
+constexpr int TEXTURE_FILTERING_FORCE_NEAREST = 5;
+constexpr int TEXTURE_FILTERING_FORCE_LINEAR = 6;
+constexpr int TEXTURE_FILTERING_FORCE_LINEAR_ANISO_2X = 7;
+constexpr int TEXTURE_FILTERING_FORCE_LINEAR_ANISO_4X = 8;
+constexpr int TEXTURE_FILTERING_FORCE_LINEAR_ANISO_8X = 9;
+constexpr int TEXTURE_FILTERING_FORCE_LINEAR_ANISO_16X = 10;
+
 void EnhancementsWidget::CreateWidgets()
 {
   auto* main_layout = new QVBoxLayout;
@@ -74,11 +86,23 @@ void EnhancementsWidget::CreateWidgets()
   m_ir_combo->setMaxVisibleItems(visible_resolution_option_count);
 
   m_aa_combo = new ToolTipComboBox();
-  m_af_combo = new GraphicsChoice({tr("1x"), tr("2x"), tr("4x"), tr("8x"), tr("16x")},
-                                  Config::GFX_ENHANCE_MAX_ANISOTROPY);
-  m_texture_filtering_combo =
-      new GraphicsChoice({tr("Default"), tr("Force Nearest"), tr("Force Linear")},
-                         Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING);
+
+  m_texture_filtering_combo = new ToolTipComboBox();
+  m_texture_filtering_combo->addItem(tr("Default"), TEXTURE_FILTERING_DEFAULT);
+  m_texture_filtering_combo->addItem(tr("2x Anisotropic"), TEXTURE_FILTERING_ANISO_2X);
+  m_texture_filtering_combo->addItem(tr("4x Anisotropic"), TEXTURE_FILTERING_ANISO_4X);
+  m_texture_filtering_combo->addItem(tr("8x Anisotropic"), TEXTURE_FILTERING_ANISO_8X);
+  m_texture_filtering_combo->addItem(tr("16x Anisotropic"), TEXTURE_FILTERING_ANISO_16X);
+  m_texture_filtering_combo->addItem(tr("Force Nearest"), TEXTURE_FILTERING_FORCE_NEAREST);
+  m_texture_filtering_combo->addItem(tr("Force Linear"), TEXTURE_FILTERING_FORCE_LINEAR);
+  m_texture_filtering_combo->addItem(tr("Force Linear and 2x Anisotropic"),
+                                     TEXTURE_FILTERING_FORCE_LINEAR_ANISO_2X);
+  m_texture_filtering_combo->addItem(tr("Force Linear and 4x Anisotropic"),
+                                     TEXTURE_FILTERING_FORCE_LINEAR_ANISO_4X);
+  m_texture_filtering_combo->addItem(tr("Force Linear and 8x Anisotropic"),
+                                     TEXTURE_FILTERING_FORCE_LINEAR_ANISO_8X);
+  m_texture_filtering_combo->addItem(tr("Force Linear and 16x Anisotropic"),
+                                     TEXTURE_FILTERING_FORCE_LINEAR_ANISO_16X);
 
   m_pp_effect = new ToolTipComboBox();
   m_configure_pp_effect = new NonDefaultQPushButton(tr("Configure"));
@@ -102,10 +126,6 @@ void EnhancementsWidget::CreateWidgets()
 
   enhancements_layout->addWidget(new QLabel(tr("Anti-Aliasing:")), row, 0);
   enhancements_layout->addWidget(m_aa_combo, row, 1, 1, -1);
-  ++row;
-
-  enhancements_layout->addWidget(new QLabel(tr("Anisotropic Filtering:")), row, 0);
-  enhancements_layout->addWidget(m_af_combo, row, 1, 1, -1);
   ++row;
 
   enhancements_layout->addWidget(new QLabel(tr("Texture Filtering:")), row, 0);
@@ -163,6 +183,8 @@ void EnhancementsWidget::CreateWidgets()
 void EnhancementsWidget::ConnectWidgets()
 {
   connect(m_aa_combo, qOverload<int>(&QComboBox::currentIndexChanged),
+          [this](int) { SaveSettings(); });
+  connect(m_texture_filtering_combo, qOverload<int>(&QComboBox::currentIndexChanged),
           [this](int) { SaveSettings(); });
   connect(m_pp_effect, qOverload<int>(&QComboBox::currentIndexChanged),
           [this](int) { SaveSettings(); });
@@ -238,8 +260,11 @@ void EnhancementsWidget::LoadSettings()
   m_block_save = true;
   // Anti-Aliasing
 
-  int aa_selection = Config::Get(Config::GFX_MSAA);
-  bool ssaa = Config::Get(Config::GFX_SSAA);
+  const int aa_selection = Config::Get(Config::GFX_MSAA);
+  const bool ssaa = Config::Get(Config::GFX_SSAA);
+  const int aniso = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);
+  const TextureFilteringMode tex_filter_mode =
+      Config::Get(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING);
 
   m_aa_combo->clear();
   for (const auto& option : VideoUtils::GetAvailableAntialiasingModes(m_msaa_modes))
@@ -248,6 +273,25 @@ void EnhancementsWidget::LoadSettings()
   m_aa_combo->setCurrentText(
       QString::fromStdString(std::to_string(aa_selection) + "x " + (ssaa ? "SSAA" : "MSAA")));
   m_aa_combo->setEnabled(m_aa_combo->count() > 1);
+
+  switch (tex_filter_mode)
+  {
+  case TextureFilteringMode::Default:
+    if (aniso >= 0 && aniso <= 4)
+      m_texture_filtering_combo->setCurrentIndex(aniso);
+    else
+      m_texture_filtering_combo->setCurrentIndex(TEXTURE_FILTERING_DEFAULT);
+    break;
+  case TextureFilteringMode::Nearest:
+    m_texture_filtering_combo->setCurrentIndex(TEXTURE_FILTERING_FORCE_NEAREST);
+    break;
+  case TextureFilteringMode::Linear:
+    if (aniso >= 0 && aniso <= 4)
+      m_texture_filtering_combo->setCurrentIndex(TEXTURE_FILTERING_FORCE_LINEAR + aniso);
+    else
+      m_texture_filtering_combo->setCurrentIndex(TEXTURE_FILTERING_FORCE_LINEAR);
+    break;
+  }
 
   // Post Processing Shader
   LoadPPShaders();
@@ -283,6 +327,66 @@ void EnhancementsWidget::SaveSettings()
   Config::SetBaseOrCurrent(Config::GFX_MSAA, static_cast<unsigned int>(aa_value));
 
   Config::SetBaseOrCurrent(Config::GFX_SSAA, is_ssaa);
+
+  const int texture_filtering_selection = m_texture_filtering_combo->currentData().toInt();
+  switch (texture_filtering_selection)
+  {
+  case TEXTURE_FILTERING_DEFAULT:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 0);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Default);
+    break;
+  case TEXTURE_FILTERING_ANISO_2X:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 1);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Default);
+    break;
+  case TEXTURE_FILTERING_ANISO_4X:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 2);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Default);
+    break;
+  case TEXTURE_FILTERING_ANISO_8X:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 3);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Default);
+    break;
+  case TEXTURE_FILTERING_ANISO_16X:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 4);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Default);
+    break;
+  case TEXTURE_FILTERING_FORCE_NEAREST:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 0);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Nearest);
+    break;
+  case TEXTURE_FILTERING_FORCE_LINEAR:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 0);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Linear);
+    break;
+  case TEXTURE_FILTERING_FORCE_LINEAR_ANISO_2X:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 1);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Linear);
+    break;
+  case TEXTURE_FILTERING_FORCE_LINEAR_ANISO_4X:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 2);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Linear);
+    break;
+  case TEXTURE_FILTERING_FORCE_LINEAR_ANISO_8X:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 3);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Linear);
+    break;
+  case TEXTURE_FILTERING_FORCE_LINEAR_ANISO_16X:
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 4);
+    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+                             TextureFilteringMode::Linear);
+    break;
+  }
 
   const bool anaglyph = g_Config.stereo_mode == StereoMode::Anaglyph;
   const bool passive = g_Config.stereo_mode == StereoMode::Passive;
@@ -320,10 +424,12 @@ void EnhancementsWidget::AddDescriptions()
       "geometry anti-aliasing and also applies anti-aliasing to lighting, shader "
       "effects, and textures.<br><br><dolphin_emphasis>If unsure, select "
       "None.</dolphin_emphasis>");
-  static const char TR_ANISOTROPIC_FILTERING_DESCRIPTION[] = QT_TR_NOOP(
-      "Enables anisotropic filtering, which enhances the visual quality of textures that "
-      "are at oblique viewing angles.<br><br>Might cause issues in a small "
-      "number of games.<br><br><dolphin_emphasis>If unsure, select 1x.</dolphin_emphasis>");
+  static const char TR_FORCE_TEXTURE_FILTERING_DESCRIPTION[] = QT_TR_NOOP(
+      "Adjust the texture filtering. Anisotropic filtering enhances the visual quality of textures "
+      "that are at oblique viewing angles. Force Nearest and Force Linear override the texture "
+      "scaling filter selected by the game.<br><br>Any option except 'Default' will alter the look "
+      "of the game's textures and might cause issues in a small number of "
+      "games.<br><br><dolphin_emphasis>If unsure, select 'Default'.</dolphin_emphasis>");
   static const char TR_POSTPROCESSING_DESCRIPTION[] =
       QT_TR_NOOP("Applies a post-processing effect after rendering a frame.<br><br "
                  "/><dolphin_emphasis>If unsure, select (off).</dolphin_emphasis>");
@@ -372,10 +478,6 @@ void EnhancementsWidget::AddDescriptions()
       "quality by reducing color banding.<br><br>Has no impact on performance and causes "
       "few graphical issues.<br><br><dolphin_emphasis>If unsure, leave this "
       "checked.</dolphin_emphasis>");
-  static const char TR_FORCE_TEXTURE_FILTERING_DESCRIPTION[] = QT_TR_NOOP(
-      "Override the texture scaling filter selected by the game.<br><br>Any option "
-      "except 'Default' will alter the look of the game's textures and may cause "
-      "issues.<br><br><dolphin_emphasis>If unsure, leave this on 'Default'.</dolphin_emphasis>");
   static const char TR_DISABLE_COPY_FILTER_DESCRIPTION[] = QT_TR_NOOP(
       "Disables the blending of adjacent rows when copying the EFB. This is known in "
       "some games as \"deflickering\" or \"smoothing\".<br><br>Disabling the filter has no "
@@ -396,9 +498,6 @@ void EnhancementsWidget::AddDescriptions()
 
   m_aa_combo->SetTitle(tr("Anti-Aliasing"));
   m_aa_combo->SetDescription(tr(TR_ANTIALIAS_DESCRIPTION));
-
-  m_af_combo->SetTitle(tr("Anisotropic Filtering"));
-  m_af_combo->SetDescription(tr(TR_ANISOTROPIC_FILTERING_DESCRIPTION));
 
   m_texture_filtering_combo->SetTitle(tr("Texture Filtering"));
   m_texture_filtering_combo->SetDescription(tr(TR_FORCE_TEXTURE_FILTERING_DESCRIPTION));

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -7,7 +7,6 @@
 
 #include <QGridLayout>
 #include <QGroupBox>
-#include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
 #include <QVBoxLayout>
@@ -77,24 +76,15 @@ void EnhancementsWidget::CreateWidgets()
   m_aa_combo = new ToolTipComboBox();
   m_af_combo = new GraphicsChoice({tr("1x"), tr("2x"), tr("4x"), tr("8x"), tr("16x")},
                                   Config::GFX_ENHANCE_MAX_ANISOTROPY);
+  m_texture_filtering_combo =
+      new GraphicsChoice({tr("Default"), tr("Force Nearest"), tr("Force Linear")},
+                         Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING);
 
   m_pp_effect = new ToolTipComboBox();
   m_configure_pp_effect = new NonDefaultQPushButton(tr("Configure"));
   m_scaled_efb_copy = new GraphicsBool(tr("Scaled EFB Copy"), Config::GFX_HACK_COPY_EFB_SCALED);
   m_per_pixel_lighting =
       new GraphicsBool(tr("Per-Pixel Lighting"), Config::GFX_ENABLE_PIXEL_LIGHTING);
-
-  const std::array<const char*, 3> texture_filtering_modes = {{
-      QT_TR_NOOP("Default"),
-      QT_TR_NOOP("Force Nearest"),
-      QT_TR_NOOP("Force Linear"),
-  }};
-  for (size_t i = 0; i < texture_filtering_modes.size(); ++i)
-  {
-    m_force_texture_filtering[i] =
-        new GraphicsRadioInt(tr(texture_filtering_modes[i]),
-                             Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING, static_cast<int>(i));
-  }
 
   m_widescreen_hack = new GraphicsBool(tr("Widescreen Hack"), Config::GFX_WIDESCREEN_HACK);
   m_disable_fog = new GraphicsBool(tr("Disable Fog"), Config::GFX_DISABLE_FOG);
@@ -119,10 +109,7 @@ void EnhancementsWidget::CreateWidgets()
   ++row;
 
   enhancements_layout->addWidget(new QLabel(tr("Texture Filtering:")), row, 0);
-  auto* force_filtering_box = new QHBoxLayout();
-  for (size_t i = 0; i < texture_filtering_modes.size(); ++i)
-    force_filtering_box->addWidget(m_force_texture_filtering[i]);
-  enhancements_layout->addLayout(force_filtering_box, row, 1, 1, -1);
+  enhancements_layout->addWidget(m_texture_filtering_combo, row, 1, 1, -1);
   ++row;
 
   enhancements_layout->addWidget(new QLabel(tr("Post-Processing Effect:")), row, 0);
@@ -413,6 +400,9 @@ void EnhancementsWidget::AddDescriptions()
   m_af_combo->SetTitle(tr("Anisotropic Filtering"));
   m_af_combo->SetDescription(tr(TR_ANISOTROPIC_FILTERING_DESCRIPTION));
 
+  m_texture_filtering_combo->SetTitle(tr("Texture Filtering"));
+  m_texture_filtering_combo->SetDescription(tr(TR_FORCE_TEXTURE_FILTERING_DESCRIPTION));
+
   m_pp_effect->SetTitle(tr("Post-Processing Effect"));
   m_pp_effect->SetDescription(tr(TR_POSTPROCESSING_DESCRIPTION));
 
@@ -425,9 +415,6 @@ void EnhancementsWidget::AddDescriptions()
   m_disable_fog->SetDescription(tr(TR_REMOVE_FOG_DESCRIPTION));
 
   m_force_24bit_color->SetDescription(tr(TR_FORCE_24BIT_DESCRIPTION));
-
-  for (size_t i = 0; i < m_force_texture_filtering.size(); ++i)
-    m_force_texture_filtering[i]->SetDescription(tr(TR_FORCE_TEXTURE_FILTERING_DESCRIPTION));
 
   m_disable_copy_filter->SetDescription(tr(TR_DISABLE_COPY_FILTER_DESCRIPTION));
 

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -3,10 +3,13 @@
 
 #pragma once
 
+#include <array>
+
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
 class GraphicsBool;
 class GraphicsChoice;
+class GraphicsRadioInt;
 class GraphicsSlider;
 class GraphicsWindow;
 class QCheckBox;
@@ -39,7 +42,7 @@ private:
   QPushButton* m_configure_pp_effect;
   GraphicsBool* m_scaled_efb_copy;
   GraphicsBool* m_per_pixel_lighting;
-  GraphicsBool* m_force_texture_filtering;
+  std::array<GraphicsRadioInt*, 3> m_force_texture_filtering;
   GraphicsBool* m_widescreen_hack;
   GraphicsBool* m_disable_fog;
   GraphicsBool* m_force_24bit_color;

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -36,8 +36,7 @@ private:
   // Enhancements
   GraphicsChoice* m_ir_combo;
   ToolTipComboBox* m_aa_combo;
-  GraphicsChoice* m_af_combo;
-  GraphicsChoice* m_texture_filtering_combo;
+  ToolTipComboBox* m_texture_filtering_combo;
   ToolTipComboBox* m_pp_effect;
   QPushButton* m_configure_pp_effect;
   GraphicsBool* m_scaled_efb_copy;

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -9,7 +9,6 @@
 
 class GraphicsBool;
 class GraphicsChoice;
-class GraphicsRadioInt;
 class GraphicsSlider;
 class GraphicsWindow;
 class QCheckBox;
@@ -38,11 +37,11 @@ private:
   GraphicsChoice* m_ir_combo;
   ToolTipComboBox* m_aa_combo;
   GraphicsChoice* m_af_combo;
+  GraphicsChoice* m_texture_filtering_combo;
   ToolTipComboBox* m_pp_effect;
   QPushButton* m_configure_pp_effect;
   GraphicsBool* m_scaled_efb_copy;
   GraphicsBool* m_per_pixel_lighting;
-  std::array<GraphicsRadioInt*, 3> m_force_texture_filtering;
   GraphicsBool* m_widescreen_hack;
   GraphicsBool* m_disable_fog;
   GraphicsBool* m_force_24bit_color;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -480,7 +480,7 @@ void Renderer::CheckForConfigChanges()
   const u32 old_multisamples = g_ActiveConfig.iMultisamples;
   const int old_anisotropy = g_ActiveConfig.iMaxAnisotropy;
   const int old_efb_access_tile_size = g_ActiveConfig.iEFBAccessTileSize;
-  const bool old_force_filtering = g_ActiveConfig.bForceFiltering;
+  const auto old_texture_filtering_mode = g_ActiveConfig.texture_filtering_mode;
   const bool old_vsync = g_ActiveConfig.bVSyncActive;
   const bool old_bbox = g_ActiveConfig.bBBoxEnable;
   const u32 old_game_mod_changes =
@@ -533,7 +533,7 @@ void Renderer::CheckForConfigChanges()
     changed_bits |= CONFIG_CHANGE_BIT_MULTISAMPLES;
   if (old_anisotropy != g_ActiveConfig.iMaxAnisotropy)
     changed_bits |= CONFIG_CHANGE_BIT_ANISOTROPY;
-  if (old_force_filtering != g_ActiveConfig.bForceFiltering)
+  if (old_texture_filtering_mode != g_ActiveConfig.texture_filtering_mode)
     changed_bits |= CONFIG_CHANGE_BIT_FORCE_TEXTURE_FILTERING;
   if (old_vsync != g_ActiveConfig.bVSyncActive)
     changed_bits |= CONFIG_CHANGE_BIT_VSYNC;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1001,7 +1001,13 @@ static void SetSamplerState(u32 index, float custom_tex_scale, bool custom_tex,
   state.Generate(bpmem, index);
 
   // Force texture filtering config option.
-  if (g_ActiveConfig.bForceFiltering)
+  if (g_ActiveConfig.texture_filtering_mode == TextureFilteringMode::Nearest)
+  {
+    state.tm0.min_filter = FilterMode::Near;
+    state.tm0.mag_filter = FilterMode::Near;
+    state.tm0.mipmap_filter = FilterMode::Near;
+  }
+  else if (g_ActiveConfig.texture_filtering_mode == TextureFilteringMode::Linear)
   {
     state.tm0.min_filter = FilterMode::Linear;
     state.tm0.mag_filter = FilterMode::Linear;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -111,7 +111,7 @@ void VideoConfig::Refresh()
   iShaderCompilerThreads = Config::Get(Config::GFX_SHADER_COMPILER_THREADS);
   iShaderPrecompilerThreads = Config::Get(Config::GFX_SHADER_PRECOMPILER_THREADS);
 
-  bForceFiltering = Config::Get(Config::GFX_ENHANCE_FORCE_FILTERING);
+  texture_filtering_mode = Config::Get(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING);
   iMaxAnisotropy = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);
   sPostProcessingShader = Config::Get(Config::GFX_ENHANCE_POST_SHADER);
   bForceTrueColor = Config::Get(Config::GFX_ENHANCE_FORCE_TRUE_COLOR);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -45,6 +45,13 @@ enum class ShaderCompilationMode : int
   AsynchronousSkipRendering
 };
 
+enum class TextureFilteringMode : int
+{
+  Default,
+  Nearest,
+  Linear,
+};
+
 enum class TriState : int
 {
   Off,
@@ -72,7 +79,7 @@ struct VideoConfig final
   u32 iMultisamples = 0;
   bool bSSAA = false;
   int iEFBScale = 0;
-  bool bForceFiltering = false;
+  TextureFilteringMode texture_filtering_mode = TextureFilteringMode::Default;
   int iMaxAnisotropy = 0;
   std::string sPostProcessingShader;
   bool bForceTrueColor = false;


### PR DESCRIPTION
A new attempt at #8645, reimplemented from scratch -- the implementation is pretty trivial anyway...

This got stuck in discussion hell last time because MayImilae was against placing the option in the Enhancement tab. I'll be frank, I completely disagree with that point (see below for why), but if that becomes a sticking point again I will move the option elsewhere (or just not show it in the GUI at all), since I'd rather have the option *somewhere* than not at all.

~~I tried out a Radio Button style for this, I'm not sure how much I like it. I can also change this to a dropdown if people think that's better.~~ see further down for the current state

---

The reason why I think this belongs in Enhancements is primarily one of user expectations: Not only has the option existed there in Dolphin for years if not decades, but also every other major emulator I could find that has an option like this has it in a roughly equivalent spot to our Enhancements tab. To show:

[Duckstation has it in Enhancement Settings -> Rendering Enhancements](https://user-images.githubusercontent.com/4522237/201581268-f19cf6aa-bb80-4399-87ff-f09f207a2cb0.png), right next to Internal Resolution Scale.
[PCSX2 has it in Graphics -> Rendering](https://user-images.githubusercontent.com/4522237/201581482-ab34d430-3331-43c3-b883-7310345d2c01.png), two steps down from Internal Resolution.
[PPSSPP has it in Game settings](https://user-images.githubusercontent.com/4522237/201581491-603db9dd-9b73-42e5-9cb6-e2fc42d42e9a.png) in the video settings part of the menu.
[Citra has it in Graphics -> Enhancements](https://user-images.githubusercontent.com/4522237/201581501-f42d7dcb-a1f6-40d3-94fc-87c4710e2055.png), though I'm admittedly not 100% sure if its option actually acts the same as the rest here.
[Flycast has it under Rendering Options](https://user-images.githubusercontent.com/4522237/201581506-c5992d99-3798-43dc-912b-ddcc48b4beb7.png), though admittedly this doesn't seem the most organized and user-friendly GUI here.

I have not been able to find a counterexample. As such, I think it would be a very strange decision to put it anywhere else, as a lot of users would spend extra time searching for it and possibly not find it at all.