### PR TITLE
Updater: Pass working directory through Updater on Windows.

### DIFF
--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -197,7 +197,7 @@ bool CopyDir(const std::string& source_path, const std::string& dest_path,
              bool destructive = false);
 
 // Set the current directory to given directory
-bool SetCurrentDir(const std::string& directory);
+bool SetCurrentDir(std::string_view directory);
 
 // Creates and returns the path to a new temporary directory.
 std::string CreateTempDir();

--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/CommonFuncs.h"
+#include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
 #include "UpdaterCommon/UI.h"
@@ -55,7 +56,8 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     }
 
     // Relaunch the updater as administrator
-    ShellExecuteW(nullptr, L"runas", path->c_str(), pCmdLine, NULL, SW_SHOW);
+    const auto working_dir = UTF8ToWString(File::GetCurrentDir());
+    ShellExecuteW(nullptr, L"runas", path->c_str(), pCmdLine, working_dir.c_str(), SW_SHOW);
     return 0;
   }
 

--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -13,6 +13,7 @@
 #include <wrl/client.h>
 
 #include "Common/Event.h"
+#include "Common/FileUtil.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
 
@@ -255,7 +256,9 @@ void LaunchApplication(std::string path)
 {
   // Indirectly start the application via explorer. This effectively drops admin priviliges because
   // explorer is running as current user.
-  ShellExecuteW(nullptr, nullptr, L"explorer.exe", UTF8ToWString(path).c_str(), nullptr, SW_SHOW);
+  const auto working_dir = UTF8ToWString(File::GetCurrentDir());
+  ShellExecuteW(nullptr, nullptr, L"explorer.exe", UTF8ToWString(path).c_str(), working_dir.c_str(),
+                SW_SHOW);
 }
 
 void Sleep(int sleep)


### PR DESCRIPTION
I've noticed that the Dolphin's working directory is not preserved through the updating process on Windows. This should fix that. Untested though, since I'm not sure how to test this...?

e: Tested it with the hash override, doesn't seem to work...