### PR TITLE
VideoBackends:OGL: Creating vertex formats shouldn't unbind anything

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLNativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLNativeVertexFormat.cpp
@@ -59,7 +59,6 @@ GLVertexFormat::GLVertexFormat(const PortableVertexDeclaration& vtx_decl)
 
   glGenVertexArrays(1, &VAO);
   glBindVertexArray(VAO);
-  ProgramShaderCache::BindVertexFormat(this);
 
   // the element buffer is bound directly to the vao, so we must it set for every vao
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vm->GetIndexBufferHandle());
@@ -77,6 +76,9 @@ GLVertexFormat::GLVertexFormat(const PortableVertexDeclaration& vtx_decl)
     SetPointer(ShaderAttrib::TexCoord0 + i, vertex_stride, vtx_decl.texcoords[i]);
 
   SetPointer(ShaderAttrib::PositionMatrix, vertex_stride, vtx_decl.posmtx);
+
+  // Other code shouldn't have to worry about its vertex formats being randomly unbound
+  ProgramShaderCache::ReBindVertexFormat();
 }
 
 GLVertexFormat::~GLVertexFormat()

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -496,6 +496,12 @@ void ProgramShaderCache::BindVertexFormat(const GLVertexFormat* vertex_format)
   s_last_VAO = new_VAO;
 }
 
+void ProgramShaderCache::ReBindVertexFormat()
+{
+  if (s_last_VAO)
+    glBindVertexArray(s_last_VAO);
+}
+
 bool ProgramShaderCache::IsValidVertexFormatBound()
 {
   return s_last_VAO != 0 && s_last_VAO != s_attributeless_VAO;

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -69,6 +69,7 @@ class ProgramShaderCache
 {
 public:
   static void BindVertexFormat(const GLVertexFormat* vertex_format);
+  static void ReBindVertexFormat();
   static bool IsValidVertexFormatBound();
   static void InvalidateVertexFormat();
   static void InvalidateVertexFormatIfBound(GLuint vao);


### PR DESCRIPTION
Should make #11208 not break half the fifoci traces

(Note: The full issue is that [`OGL::Renderer` only sets the pipeline if it changed](https://github.com/dolphin-emu/dolphin/blob/d7593dd7215d92ea0b5eb8fa8b592f3ed758b2ea/Source/Core/VideoBackends/OGL/OGLRender.cpp#L1236-L1237), not expecting it to be partially unbound.  This doesn't affect anything by itself because without CPUCull, we never create a vertex format without immediately using it in a pipeline, but with CPUCull, we can create a vertex loader and then cull all the triangles that used it before switching back to the previous pipeline, completely skipping it.)