### PR TITLE
Updater: Check for write permissions in directory of Updater.exe.

### DIFF
--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -31,7 +31,15 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
   // Test for write permissions
   bool need_admin = false;
 
-  FILE* test_fh = fopen("Updater.log", "w");
+  auto path = GetModuleName(hInstance);
+  if (!path)
+  {
+    UI::Error("Failed to get updater filename.");
+    return 1;
+  }
+
+  FILE* test_fh =
+      _wfopen((std::filesystem::path(*path).parent_path() / "Updater.log").c_str(), L"w");
 
   if (test_fh == nullptr)
     need_admin = true;
@@ -44,13 +52,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     {
       MessageBox(nullptr, L"Failed to write to directory despite administrator priviliges.",
                  L"Error", MB_ICONERROR);
-      return 1;
-    }
-
-    auto path = GetModuleName(hInstance);
-    if (!path)
-    {
-      MessageBox(nullptr, L"Failed to get updater filename.", L"Error", MB_ICONERROR);
       return 1;
     }
 

--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -38,13 +38,15 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     return 1;
   }
 
-  FILE* test_fh =
-      _wfopen((std::filesystem::path(*path).parent_path() / "Updater.log").c_str(), L"w");
+  const auto test_fh = ::CreateFileW(
+      (std::filesystem::path(*path).parent_path() / "directory_writable_check.tmp").c_str(),
+      GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+      FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE, nullptr);
 
-  if (test_fh == nullptr)
+  if (test_fh == INVALID_HANDLE_VALUE)
     need_admin = true;
   else
-    fclose(test_fh);
+    CloseHandle(test_fh);
 
   if (need_admin)
   {


### PR DESCRIPTION
ie, don't blindly assume working directory is directory Updater.exe is in.

This should fix the weird issue where a chain of Dolphin.exe -> Updater.exe -> Dolphin.exe -> Updater.exe requests UAC because it tries to open `Updater.log` in `C:\Windows\System32` (which is the working directory inherited from the permissions downgrade via `explorer.exe`).

Technically the arguments *could* request a different path to write the update to, but that shouldn't really happen in practice I think...?