### PR TITLE
Fixed minor bugs with reference smart pointers and access var after moving

### DIFF
--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -393,7 +393,7 @@ std::string ESDevice::GetContentPath(const u64 title_id, const ES::Content& cont
 
 s32 ESDevice::WriteSystemFile(const std::string& path, const std::vector<u8>& data, Ticks ticks)
 {
-  auto& fs = *m_ios.GetFSDevice();
+  auto fs(std::move(*m_ios.GetFSDevice()));
   const std::string tmp_path = "/tmp/" + PathToFileName(path);
 
   auto result = fs.CreateFile(PID_KERNEL, PID_KERNEL, tmp_path, {},

--- a/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
@@ -96,7 +96,6 @@ bool GetRefs(MEGASignature* sig, std::istringstream* iss)
 
     ref_count += 1;
     num.clear();
-    ref.clear();
   }
   return true;
 }


### PR DESCRIPTION
Fixed fs reference when shared_ptr returned by GetFSDevice() is destroyed and access ref after std::move()