### PR TITLE
VideoCommon:VertexLoaderManager: Reduce CPConfig checks

### DIFF
--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -56,18 +56,26 @@ public:
     if constexpr (!is_preprocess)
     {
       if (sub_command == MATINDEX_A)
+      {
+        VertexLoaderManager::g_needs_cp_xf_consistency_check = true;
         VertexShaderManager::SetTexMatrixChangedA(value);
+      }
       else if (sub_command == MATINDEX_B)
+      {
+        VertexLoaderManager::g_needs_cp_xf_consistency_check = true;
         VertexShaderManager::SetTexMatrixChangedB(value);
+      }
       else if (sub_command == VCD_LO || sub_command == VCD_HI)
       {
         VertexLoaderManager::g_main_vat_dirty = BitSet8::AllTrue(CP_NUM_VAT_REG);
         VertexLoaderManager::g_bases_dirty = true;
+        VertexLoaderManager::g_needs_cp_xf_consistency_check = true;
       }
       else if (sub_command == CP_VAT_REG_A || sub_command == CP_VAT_REG_B ||
                sub_command == CP_VAT_REG_C)
       {
         VertexLoaderManager::g_main_vat_dirty[command & CP_VAT_MASK] = true;
+        VertexLoaderManager::g_needs_cp_xf_consistency_check = true;
       }
       else if (sub_command == ARRAY_BASE)
       {

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -76,6 +76,7 @@ extern BitSet8 g_preprocess_vat_dirty;
 extern bool g_bases_dirty;  // Main only
 extern std::array<VertexLoaderBase*, CP_NUM_VAT_REG> g_main_vertex_loaders;
 extern std::array<VertexLoaderBase*, CP_NUM_VAT_REG> g_preprocess_vertex_loaders;
+extern bool g_needs_cp_xf_consistency_check;
 
 template <bool IsPreprocess = false>
 VertexLoaderBase* RefreshLoader(int vtx_attr_group)

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -15,6 +15,7 @@
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/GeometryShaderManager.h"
 #include "VideoCommon/PixelShaderManager.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/XFMemory.h"
@@ -53,6 +54,7 @@ static void XFRegWritten(u32 address, u32 value)
     }
 
     case XFMEM_VTXSPECS:  //__GXXfVtxSpecs, wrote 0004
+      VertexLoaderManager::g_needs_cp_xf_consistency_check = true;
       break;
 
     case XFMEM_SETNUMCHAN:
@@ -102,9 +104,11 @@ static void XFRegWritten(u32 address, u32 value)
 
     case XFMEM_SETMATRIXINDA:
       VertexShaderManager::SetTexMatrixChangedA(value);
+      VertexLoaderManager::g_needs_cp_xf_consistency_check = true;
       break;
     case XFMEM_SETMATRIXINDB:
       VertexShaderManager::SetTexMatrixChangedB(value);
+      VertexLoaderManager::g_needs_cp_xf_consistency_check = true;
       break;
 
     case XFMEM_SETVIEWPORT:


### PR DESCRIPTION
A bit of a micro optimization:
With this PR CheckCPConfiguration runs 350 times instead of 35k times. (Mario Galaxy)