### PR TITLE
VideoBackends: Query fixes and cleanups

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DPerfQuery.h
+++ b/Source/Core/VideoBackends/D3D/D3DPerfQuery.h
@@ -15,8 +15,8 @@ public:
   PerfQuery();
   ~PerfQuery();
 
-  void EnableQuery(PerfQueryGroup type) override;
-  void DisableQuery(PerfQueryGroup type) override;
+  void EnableQuery(PerfQueryGroup group) override;
+  void DisableQuery(PerfQueryGroup group) override;
   void ResetQuery() override;
   u32 GetQueryResult(PerfQueryType type) override;
   void FlushResults() override;
@@ -26,7 +26,7 @@ private:
   struct ActiveQuery
   {
     ComPtr<ID3D11Query> query;
-    PerfQueryGroup query_type{};
+    PerfQueryGroup query_group{};
   };
 
   void WeakFlush();

--- a/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.cpp
@@ -71,6 +71,7 @@ void PerfQuery::EnableQuery(PerfQueryGroup type)
     ActiveQuery& entry = m_query_buffer[m_query_next_pos];
     ASSERT(!entry.has_value && !entry.resolved);
     entry.has_value = true;
+    entry.query_type = type;
 
     g_dx_context->GetCommandList()->BeginQuery(m_query_heap.Get(), D3D12_QUERY_TYPE_OCCLUSION,
                                                m_query_next_pos);

--- a/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.h
+++ b/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.h
@@ -31,7 +31,7 @@ private:
   struct ActiveQuery
   {
     u64 fence_value;
-    PerfQueryType query_type;
+    PerfQueryGroup query_type;
     bool has_value;
     bool resolved;
   };

--- a/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.h
+++ b/Source/Core/VideoBackends/D3D12/D3D12PerfQuery.h
@@ -20,8 +20,8 @@ public:
   bool Initialize();
   void ResolveQueries();
 
-  void EnableQuery(PerfQueryGroup type) override;
-  void DisableQuery(PerfQueryGroup type) override;
+  void EnableQuery(PerfQueryGroup group) override;
+  void DisableQuery(PerfQueryGroup group) override;
   void ResetQuery() override;
   u32 GetQueryResult(PerfQueryType type) override;
   void FlushResults() override;
@@ -31,7 +31,7 @@ private:
   struct ActiveQuery
   {
     u64 fence_value;
-    PerfQueryGroup query_type;
+    PerfQueryGroup query_group;
     bool has_value;
     bool resolved;
   };

--- a/Source/Core/VideoBackends/OGL/OGLPerfQuery.h
+++ b/Source/Core/VideoBackends/OGL/OGLPerfQuery.h
@@ -19,8 +19,8 @@ class PerfQuery : public PerfQueryBase
 public:
   PerfQuery();
   ~PerfQuery() {}
-  void EnableQuery(PerfQueryGroup type) override;
-  void DisableQuery(PerfQueryGroup type) override;
+  void EnableQuery(PerfQueryGroup group) override;
+  void DisableQuery(PerfQueryGroup group) override;
   void ResetQuery() override;
   u32 GetQueryResult(PerfQueryType type) override;
   void FlushResults() override;
@@ -30,7 +30,7 @@ protected:
   struct ActiveQuery
   {
     GLuint query_id;
-    PerfQueryGroup query_type;
+    PerfQueryGroup query_group;
   };
 
   // when testing in SMS: 64 was too small, 128 was ok
@@ -52,8 +52,8 @@ public:
   PerfQueryGL(GLenum query_type);
   ~PerfQueryGL();
 
-  void EnableQuery(PerfQueryGroup type) override;
-  void DisableQuery(PerfQueryGroup type) override;
+  void EnableQuery(PerfQueryGroup group) override;
+  void DisableQuery(PerfQueryGroup group) override;
   void FlushResults() override;
 
 private:
@@ -70,8 +70,8 @@ public:
   PerfQueryGLESNV();
   ~PerfQueryGLESNV();
 
-  void EnableQuery(PerfQueryGroup type) override;
-  void DisableQuery(PerfQueryGroup type) override;
+  void EnableQuery(PerfQueryGroup group) override;
+  void DisableQuery(PerfQueryGroup group) override;
   void FlushResults() override;
 
 private:

--- a/Source/Core/VideoBackends/Vulkan/VKPerfQuery.h
+++ b/Source/Core/VideoBackends/Vulkan/VKPerfQuery.h
@@ -40,7 +40,7 @@ private:
   struct ActiveQuery
   {
     u64 fence_counter;
-    PerfQueryType query_type;
+    PerfQueryGroup query_type;
     bool has_value;
   };
 

--- a/Source/Core/VideoBackends/Vulkan/VKPerfQuery.h
+++ b/Source/Core/VideoBackends/Vulkan/VKPerfQuery.h
@@ -22,8 +22,8 @@ public:
 
   bool Initialize();
 
-  void EnableQuery(PerfQueryGroup type) override;
-  void DisableQuery(PerfQueryGroup type) override;
+  void EnableQuery(PerfQueryGroup group) override;
+  void DisableQuery(PerfQueryGroup group) override;
   void ResetQuery() override;
   u32 GetQueryResult(PerfQueryType type) override;
   void FlushResults() override;
@@ -40,7 +40,7 @@ private:
   struct ActiveQuery
   {
     u64 fence_counter;
-    PerfQueryGroup query_type;
+    PerfQueryGroup query_group;
     bool has_value;
   };
 


### PR DESCRIPTION
Queries in the Vulkan renderer are completely broken right now:

- We're trying to access the results before the queries have executed.
- Query results get attributed to the wrong query type.
- The query pool isn't properly reset before reusing the queries.

This seems to have be a regression caused by 604ab67c7f28dc03a82ee7aa1bcc487d39ea6f8c. 

The last commit is somewhat unrelated but it's something I noticed.