### PR TITLE
Android: Adjust card_width

### DIFF
--- a/Source/Android/app/src/main/res/values/dimens.xml
+++ b/Source/Android/app/src/main/res/values/dimens.xml
@@ -2,5 +2,5 @@
     <dimen name="spacing_small">4dp</dimen>
     <dimen name="spacing_medlarge">12dp</dimen>
     <dimen name="spacing_large">16dp</dimen>
-    <dimen name="card_width">140dp</dimen>
+    <dimen name="card_width">135dp</dimen>
 </resources>


### PR DESCRIPTION
Spacing required by each card before was a little bit too much. The span of the list will appear more appropriately now. (6dp spacing on both sides instead of 8.5dp)