### PR TITLE
Android: Fix saved list state bug

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
@@ -79,7 +79,7 @@ public final class PlatformGamesFragment extends Fragment implements PlatformGam
                           requireContext().getResources().getDimensionPixelSize(R.dimen.card_width);
                   if (columns == 0)
                   {
-                    columns = 1;
+                    return;
                   }
                   view.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                   GridLayoutManager layoutManager = new GridLayoutManager(getActivity(), columns);


### PR DESCRIPTION
Sometimes when restoring the app's state, the game list span would become 1 even though the screen has space for more list items.