### PR TITLE
Debugger BreakpointWidget: Edit breakpoints dialog

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -612,7 +612,7 @@ void CheckBreakPoints()
 {
   const TBreakPoint* bp = PowerPC::breakpoints.GetBreakpoint(PC);
 
-  if (bp == nullptr)
+  if (!bp || !bp->is_enabled || !EvaluateCondition(bp->condition))
     return;
 
   if (bp->break_on_hit)

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -186,6 +186,8 @@ add_executable(dolphin-emu
   Config/WiimoteControllersWidget.h
   ConvertDialog.cpp
   ConvertDialog.h
+  Debugger/BreakpointDialog.cpp
+  Debugger/BreakpointDialog.h
   Debugger/BreakpointWidget.cpp
   Debugger/BreakpointWidget.h
   Debugger/CodeDiffDialog.cpp
@@ -202,8 +204,6 @@ add_executable(dolphin-emu
   Debugger/MemoryWidget.h
   Debugger/NetworkWidget.cpp
   Debugger/NetworkWidget.h
-  Debugger/NewBreakpointDialog.cpp
-  Debugger/NewBreakpointDialog.h
   Debugger/PatchInstructionDialog.cpp
   Debugger/PatchInstructionDialog.h
   Debugger/RegisterColumn.cpp

--- a/Source/Core/DolphinQt/Debugger/BreakpointDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointDialog.h
@@ -6,6 +6,8 @@
 #include <QDialog>
 
 #include "Common/CommonTypes.h"
+#include "Core/PowerPC/BreakPoints.h"
+#include "Core/PowerPC/PowerPC.h"
 
 class BreakpointWidget;
 class QCheckBox;
@@ -15,11 +17,20 @@ class QLabel;
 class QLineEdit;
 class QRadioButton;
 
-class NewBreakpointDialog : public QDialog
+class BreakpointDialog : public QDialog
 {
   Q_OBJECT
 public:
-  explicit NewBreakpointDialog(BreakpointWidget* parent);
+  enum class OpenMode
+  {
+    New,
+    EditBreakPoint,
+    EditMemCheck
+  };
+
+  explicit BreakpointDialog(BreakpointWidget* parent);
+  BreakpointDialog(BreakpointWidget* parent, const TBreakPoint* breakpoint);
+  BreakpointDialog(BreakpointWidget* parent, const TMemCheck* memcheck);
 
   void accept() override;
 
@@ -58,4 +69,6 @@ private:
 
   QDialogButtonBox* m_buttons;
   BreakpointWidget* m_parent;
+
+  OpenMode m_open_mode;
 };

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -19,8 +19,8 @@
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 
+#include "DolphinQt/Debugger/BreakpointDialog.h"
 #include "DolphinQt/Debugger/MemoryWidget.h"
-#include "DolphinQt/Debugger/NewBreakpointDialog.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
@@ -299,8 +299,25 @@ void BreakpointWidget::OnClear()
 
 void BreakpointWidget::OnNewBreakpoint()
 {
-  NewBreakpointDialog* dialog = new NewBreakpointDialog(this);
+  BreakpointDialog* dialog = new BreakpointDialog(this);
   dialog->exec();
+}
+
+void BreakpointWidget::OnEditBreakpoint(u32 address, bool is_instruction_bp)
+{
+  if (is_instruction_bp)
+  {
+    auto* dialog = new BreakpointDialog(this, PowerPC::breakpoints.GetBreakpoint(address));
+    dialog->exec();
+  }
+  else
+  {
+    auto* dialog = new BreakpointDialog(this, PowerPC::memchecks.GetMemCheck(address));
+    dialog->exec();
+  }
+
+  emit BreakpointsChanged();
+  Update();
 }
 
 void BreakpointWidget::OnLoad()
@@ -389,6 +406,9 @@ void BreakpointWidget::OnContextMenu()
       Update();
     });
   }
+  menu->addAction(tr("Edit..."), [this, bp_address, is_memory_breakpoint] {
+    OnEditBreakpoint(bp_address, !is_memory_breakpoint);
+  });
 
   menu->exec(QCursor::pos());
 }

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -44,6 +44,7 @@ private:
   void OnDelete();
   void OnClear();
   void OnNewBreakpoint();
+  void OnEditBreakpoint(u32 address, bool is_instruction_bp);
   void OnLoad();
   void OnSave();
   void OnContextMenu();

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -126,6 +126,7 @@
     <ClCompile Include="Config\VerifyWidget.cpp" />
     <ClCompile Include="Config\WiimoteControllersWidget.cpp" />
     <ClCompile Include="ConvertDialog.cpp" />
+    <ClCompile Include="Debugger\BreakpointDialog.cpp" />
     <ClCompile Include="Debugger\BreakpointWidget.cpp" />
     <ClCompile Include="Debugger\CodeDiffDialog.cpp" />
     <ClCompile Include="Debugger\CodeViewWidget.cpp" />
@@ -134,7 +135,6 @@
     <ClCompile Include="Debugger\MemoryViewWidget.cpp" />
     <ClCompile Include="Debugger\MemoryWidget.cpp" />
     <ClCompile Include="Debugger\NetworkWidget.cpp" />
-    <ClCompile Include="Debugger\NewBreakpointDialog.cpp" />
     <ClCompile Include="Debugger\PatchInstructionDialog.cpp" />
     <ClCompile Include="Debugger\RegisterColumn.cpp" />
     <ClCompile Include="Debugger\RegisterWidget.cpp" />
@@ -319,6 +319,7 @@
     <QtMoc Include="Config\VerifyWidget.h" />
     <QtMoc Include="Config\WiimoteControllersWidget.h" />
     <QtMoc Include="ConvertDialog.h" />
+    <QtMoc Include="Debugger\BreakpointDialog.h" />
     <QtMoc Include="Debugger\BreakpointWidget.h" />
     <QtMoc Include="Debugger\CodeDiffDialog.h" />
     <QtMoc Include="Debugger\CodeViewWidget.h" />
@@ -327,7 +328,6 @@
     <QtMoc Include="Debugger\MemoryViewWidget.h" />
     <QtMoc Include="Debugger\MemoryWidget.h" />
     <QtMoc Include="Debugger\NetworkWidget.h" />
-    <QtMoc Include="Debugger\NewBreakpointDialog.h" />
     <QtMoc Include="Debugger\PatchInstructionDialog.h" />
     <QtMoc Include="Debugger\RegisterWidget.h" />
     <QtMoc Include="Debugger\ThreadWidget.h" />


### PR DESCRIPTION
This PR allows users to edit existing breakpoints by opening the context menu of a breakpoint and clicking `Edit...`. This also makes it so when you add a new breakpoint that shares the same address as an existing one, the existing breakpoint becomes the new one that the user has just created.