### PR TITLE
Android: Fix condition where we set grid span too early

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
@@ -75,6 +75,11 @@ public final class PlatformGamesFragment extends Fragment implements PlatformGam
                 @Override
                 public void onGlobalLayout()
                 {
+                  if (mBinding.getRoot().getMeasuredWidth() == 0)
+                  {
+                    return;
+                  }
+
                   int columns = mBinding.getRoot().getMeasuredWidth() /
                           requireContext().getResources().getDimensionPixelSize(R.dimen.card_width);
                   if (columns == 0)


### PR DESCRIPTION
Sometimes getMeasuredWidth would report 0 when the layout is being inflated. This ensures that the grid waits until the correct measurement is reported before we set the grid span.