### PR TITLE
Android: Fix GameDetailsDialog on leanback

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GameDetailsDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GameDetailsDialog.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.DialogFragment;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -14,6 +15,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.databinding.DialogGameDetailsBinding;
+import org.dolphinemu.dolphinemu.databinding.DialogGameDetailsTvBinding;
 import org.dolphinemu.dolphinemu.model.GameFile;
 import org.dolphinemu.dolphinemu.services.GameFileCacheManager;
 import org.dolphinemu.dolphinemu.utils.GlideUtils;
@@ -39,66 +41,132 @@ public final class GameDetailsDialog extends DialogFragment
   {
     GameFile gameFile = GameFileCacheManager.addOrGet(getArguments().getString(ARG_GAME_PATH));
 
-    DialogGameDetailsBinding binding = DialogGameDetailsBinding.inflate(getLayoutInflater());
-
     String country = getResources().getStringArray(R.array.countryNames)[gameFile.getCountry()];
     String description = gameFile.getDescription();
     String fileSize = NativeLibrary.FormatSize(gameFile.getFileSize(), 2);
 
-    binding.textGameTitle.setText(gameFile.getTitle());
-    binding.textDescription.setText(gameFile.getDescription());
-    if (description.isEmpty())
+    // TODO: Remove dialog_game_details_tv if we switch to an AppCompatActivity for leanback
+    DialogGameDetailsBinding binding;
+    DialogGameDetailsTvBinding tvBinding;
+    MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(requireContext());
+    if (requireActivity() instanceof AppCompatActivity)
     {
-      binding.textDescription.setVisibility(View.GONE);
-    }
+      binding = DialogGameDetailsBinding.inflate(getLayoutInflater());
 
-    binding.textCountry.setText(country);
-    binding.textCompany.setText(gameFile.getCompany());
-    binding.textGameId.setText(gameFile.getGameId());
-    binding.textRevision.setText(String.valueOf(gameFile.getRevision()));
-
-    if (!gameFile.shouldShowFileFormatDetails())
-    {
-      binding.labelFileFormat.setText(R.string.game_details_file_size);
-      binding.textFileFormat.setText(fileSize);
-
-      binding.labelCompression.setVisibility(View.GONE);
-      binding.textCompression.setVisibility(View.GONE);
-      binding.labelBlockSize.setVisibility(View.GONE);
-      binding.textBlockSize.setVisibility(View.GONE);
-    }
-    else
-    {
-      long blockSize = gameFile.getBlockSize();
-      String compression = gameFile.getCompressionMethod();
-
-      binding.textFileFormat.setText(getResources().getString(R.string.game_details_size_and_format,
-              gameFile.getFileFormatName(), fileSize));
-
-      if (compression.isEmpty())
+      binding.textGameTitle.setText(gameFile.getTitle());
+      binding.textDescription.setText(gameFile.getDescription());
+      if (description.isEmpty())
       {
-        binding.textCompression.setText(R.string.game_details_no_compression);
-      }
-      else
-      {
-        binding.textCompression.setText(gameFile.getCompressionMethod());
+        binding.textDescription.setVisibility(View.GONE);
       }
 
-      if (blockSize > 0)
+      binding.textCountry.setText(country);
+      binding.textCompany.setText(gameFile.getCompany());
+      binding.textGameId.setText(gameFile.getGameId());
+      binding.textRevision.setText(String.valueOf(gameFile.getRevision()));
+
+      if (!gameFile.shouldShowFileFormatDetails())
       {
-        binding.textBlockSize.setText(NativeLibrary.FormatSize(blockSize, 0));
-      }
-      else
-      {
+        binding.labelFileFormat.setText(R.string.game_details_file_size);
+        binding.textFileFormat.setText(fileSize);
+
+        binding.labelCompression.setVisibility(View.GONE);
+        binding.textCompression.setVisibility(View.GONE);
         binding.labelBlockSize.setVisibility(View.GONE);
         binding.textBlockSize.setVisibility(View.GONE);
       }
+      else
+      {
+        long blockSize = gameFile.getBlockSize();
+        String compression = gameFile.getCompressionMethod();
+
+        binding.textFileFormat.setText(
+                getResources().getString(R.string.game_details_size_and_format,
+                        gameFile.getFileFormatName(), fileSize));
+
+        if (compression.isEmpty())
+        {
+          binding.textCompression.setText(R.string.game_details_no_compression);
+        }
+        else
+        {
+          binding.textCompression.setText(gameFile.getCompressionMethod());
+        }
+
+        if (blockSize > 0)
+        {
+          binding.textBlockSize.setText(NativeLibrary.FormatSize(blockSize, 0));
+        }
+        else
+        {
+          binding.labelBlockSize.setVisibility(View.GONE);
+          binding.textBlockSize.setVisibility(View.GONE);
+        }
+      }
+
+      GlideUtils.loadGameBanner(binding.banner, gameFile);
+
+      builder.setView(binding.getRoot());
     }
+    else
+    {
+      tvBinding = DialogGameDetailsTvBinding.inflate(getLayoutInflater());
 
-    GlideUtils.loadGameBanner(binding.banner, gameFile);
+      tvBinding.textGameTitle.setText(gameFile.getTitle());
+      tvBinding.textDescription.setText(gameFile.getDescription());
+      if (description.isEmpty())
+      {
+        tvBinding.textDescription.setVisibility(View.GONE);
+      }
 
-    return new MaterialAlertDialogBuilder(requireActivity())
-            .setView(binding.getRoot())
-            .create();
+      tvBinding.textCountry.setText(country);
+      tvBinding.textCompany.setText(gameFile.getCompany());
+      tvBinding.textGameId.setText(gameFile.getGameId());
+      tvBinding.textRevision.setText(String.valueOf(gameFile.getRevision()));
+
+      if (!gameFile.shouldShowFileFormatDetails())
+      {
+        tvBinding.labelFileFormat.setText(R.string.game_details_file_size);
+        tvBinding.textFileFormat.setText(fileSize);
+
+        tvBinding.labelCompression.setVisibility(View.GONE);
+        tvBinding.textCompression.setVisibility(View.GONE);
+        tvBinding.labelBlockSize.setVisibility(View.GONE);
+        tvBinding.textBlockSize.setVisibility(View.GONE);
+      }
+      else
+      {
+        long blockSize = gameFile.getBlockSize();
+        String compression = gameFile.getCompressionMethod();
+
+        tvBinding.textFileFormat.setText(
+                getResources().getString(R.string.game_details_size_and_format,
+                        gameFile.getFileFormatName(), fileSize));
+
+        if (compression.isEmpty())
+        {
+          tvBinding.textCompression.setText(R.string.game_details_no_compression);
+        }
+        else
+        {
+          tvBinding.textCompression.setText(gameFile.getCompressionMethod());
+        }
+
+        if (blockSize > 0)
+        {
+          tvBinding.textBlockSize.setText(NativeLibrary.FormatSize(blockSize, 0));
+        }
+        else
+        {
+          tvBinding.labelBlockSize.setVisibility(View.GONE);
+          tvBinding.textBlockSize.setVisibility(View.GONE);
+        }
+      }
+
+      GlideUtils.loadGameBanner(tvBinding.banner, gameFile);
+
+      builder.setView(tvBinding.getRoot());
+    }
+    return builder.create();
   }
 }

--- a/Source/Android/app/src/main/res/layout/dialog_game_details_tv.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_game_details_tv.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:transitionName="card_game">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="24dp">
+
+        <TextView
+            android:id="@+id/text_game_title"
+            style="@android:style/TextAppearance.Material.Headline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:ellipsize="end"
+            android:textColor="@android:color/black"
+            tools:text="Rhythm Heaven Fever"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/text_description"
+            style="@android:style/TextAppearance.Material.Caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="@android:color/black"
+            tools:text="Zany rhythm action!"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_game_title" />
+
+        <ImageView
+            android:id="@+id/banner"
+            android:layout_width="144dp"
+            android:layout_height="48dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:textColor="@android:color/black"
+            tools:src="@drawable/no_banner"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_description" />
+
+        <View
+            android:id="@+id/divider_1"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="32dp"
+            android:background="#1F000000"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/banner" />
+
+        <TextView
+            android:id="@+id/label_country"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:gravity="start"
+            android:text="@string/game_details_country"
+            android:textColor="@android:color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider_1" />
+
+        <TextView
+            android:id="@+id/label_company"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:gravity="start"
+            android:text="@string/game_details_company"
+            android:textColor="@android:color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_country" />
+
+        <TextView
+            android:id="@+id/label_game_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:gravity="start"
+            android:text="@string/game_details_game_id"
+            android:textColor="@android:color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_company" />
+
+        <TextView
+            android:id="@+id/label_revision"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:gravity="start"
+            android:text="@string/game_details_revision"
+            android:textColor="@android:color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_game_id" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/label_barrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="end"
+            app:constraint_referenced_ids="label_country,label_company,label_game_id,label_revision,label_file_format,label_compression,label_block_size" />
+
+        <TextView
+            android:id="@+id/text_country"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:gravity="end"
+            android:textColor="@android:color/black"
+            tools:text="United States"
+            app:layout_constraintStart_toEndOf="@id/label_barrier"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBaseline_toBaselineOf="@id/label_country" />
+
+        <TextView
+            android:id="@+id/text_company"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:gravity="end"
+            android:textColor="@android:color/black"
+            tools:text="Nintendo"
+            app:layout_constraintStart_toEndOf="@id/label_barrier"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBaseline_toBaselineOf="@id/label_company" />
+
+        <TextView
+            android:id="@+id/text_game_id"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:gravity="end"
+            android:textColor="@android:color/black"
+            tools:text="SOME01"
+            app:layout_constraintStart_toEndOf="@id/label_barrier"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBaseline_toBaselineOf="@id/label_game_id" />
+
+        <TextView
+            android:id="@+id/text_revision"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:gravity="end"
+            android:textColor="@android:color/black"
+            tools:text="0"
+            app:layout_constraintStart_toEndOf="@id/label_barrier"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBaseline_toBaselineOf="@id/label_revision" />
+
+        <View
+            android:id="@+id/divider_2"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="32dp"
+            android:background="#1F000000"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_revision" />
+
+        <TextView
+            android:id="@+id/label_file_format"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:gravity="start"
+            android:text="@string/game_details_file_format"
+            android:textColor="@android:color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider_2" />
+
+        <TextView
+            android:id="@+id/label_compression"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:gravity="start"
+            android:text="@string/game_details_compression"
+            android:textColor="@android:color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_file_format" />
+
+        <TextView
+            android:id="@+id/label_block_size"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:gravity="start"
+            android:text="@string/game_details_block_size"
+            android:textColor="@android:color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_compression" />
+
+        <TextView
+            android:id="@+id/text_file_format"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:gravity="end"
+            android:textColor="@android:color/black"
+            tools:text="ISO (4.38 GiB)"
+            app:layout_constraintStart_toEndOf="@id/label_barrier"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBaseline_toBaselineOf="@id/label_file_format" />
+
+        <TextView
+            android:id="@+id/text_compression"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:gravity="end"
+            android:textColor="@android:color/black"
+            tools:text="No Compression"
+            app:layout_constraintStart_toEndOf="@id/label_barrier"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBaseline_toBaselineOf="@id/label_compression" />
+
+        <TextView
+            android:id="@+id/text_block_size"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:gravity="end"
+            android:textColor="@android:color/black"
+            tools:text="0 B"
+            app:layout_constraintStart_toEndOf="@id/label_barrier"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBaseline_toBaselineOf="@id/label_block_size" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>


### PR DESCRIPTION
Previously the app would crash when opening the game details dialog because Material Dividers inherit from AppCompat and the leanback activity does not. This creates a new layout file with leanback-specific accommodations and code is duplicated in GameDetailsDialog to prevent inflation crashes.

I'm not happy with the amount of code I have to duplicate here, but it's the simplest fix I could think of given that I'd like to stick to data binding and keeping material components on the mobile version.