### PR TITLE
Android: Have each activity manage insets separately

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/ConvertActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/ConvertActivity.java
@@ -7,7 +7,12 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import com.google.android.material.color.MaterialColors;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.databinding.ActivityConvertBinding;
@@ -18,6 +23,8 @@ import org.dolphinemu.dolphinemu.utils.ThemeHelper;
 public class ConvertActivity extends AppCompatActivity
 {
   private static final String ARG_GAME_PATH = "game_path";
+
+  private ActivityConvertBinding mBinding;
 
   public static void launch(Context context, String gamePath)
   {
@@ -33,8 +40,8 @@ public class ConvertActivity extends AppCompatActivity
 
     super.onCreate(savedInstanceState);
 
-    ActivityConvertBinding binding = ActivityConvertBinding.inflate(getLayoutInflater());
-    setContentView(binding.getRoot());
+    mBinding = ActivityConvertBinding.inflate(getLayoutInflater());
+    setContentView(mBinding.getRoot());
 
     WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
 
@@ -48,13 +55,12 @@ public class ConvertActivity extends AppCompatActivity
       getSupportFragmentManager().beginTransaction().add(R.id.fragment_convert, fragment).commit();
     }
 
-    binding.toolbarConvertLayout.setTitle(getString(R.string.convert_convert));
-    setSupportActionBar(binding.toolbarConvert);
+    mBinding.toolbarConvertLayout.setTitle(getString(R.string.convert_convert));
+    setSupportActionBar(mBinding.toolbarConvert);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-    InsetsHelper.setUpAppBarWithScrollView(this, binding.appbarConvert, binding.scrollViewConvert,
-            binding.workaroundView);
-    ThemeHelper.enableScrollTint(this, binding.toolbarConvert, binding.appbarConvert);
+    setInsets();
+    ThemeHelper.enableScrollTint(this, mBinding.toolbarConvert, mBinding.appbarConvert);
   }
 
   @Override
@@ -62,5 +68,23 @@ public class ConvertActivity extends AppCompatActivity
   {
     onBackPressed();
     return true;
+  }
+
+  private void setInsets()
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(mBinding.appbarConvert, (v, windowInsets) ->
+    {
+      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+
+      InsetsHelper.insetAppBar(insets, mBinding.appbarConvert);
+
+      mBinding.scrollViewConvert.setPadding(insets.left, 0, insets.right, insets.bottom);
+
+      InsetsHelper.applyNavbarWorkaround(insets.bottom, mBinding.workaroundView);
+      ThemeHelper.setNavigationBarColor(this,
+              MaterialColors.getColor(mBinding.appbarConvert, R.attr.colorSurface));
+
+      return windowInsets;
+    });
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.java
@@ -13,8 +13,12 @@ import android.view.View;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 
+import com.google.android.material.color.MaterialColors;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.dolphinemu.dolphinemu.R;
@@ -44,6 +48,8 @@ public class UserDataActivity extends AppCompatActivity
 
   private boolean sMustRestartApp = false;
 
+  private ActivityUserDataBinding mBinding;
+
   public static void launch(Context context)
   {
     Intent launcher = new Intent(context, UserDataActivity.class);
@@ -57,8 +63,8 @@ public class UserDataActivity extends AppCompatActivity
 
     super.onCreate(savedInstanceState);
 
-    ActivityUserDataBinding binding = ActivityUserDataBinding.inflate(getLayoutInflater());
-    setContentView(binding.getRoot());
+    mBinding = ActivityUserDataBinding.inflate(getLayoutInflater());
+    setContentView(mBinding.getRoot());
 
     WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
 
@@ -68,25 +74,24 @@ public class UserDataActivity extends AppCompatActivity
 
     int user_data_new_location = android_10 ?
             R.string.user_data_new_location_android_10 : R.string.user_data_new_location;
-    binding.textType.setText(legacy ? R.string.user_data_old_location : user_data_new_location);
+    mBinding.textType.setText(legacy ? R.string.user_data_old_location : user_data_new_location);
 
-    binding.textPath.setText(DirectoryInitialization.getUserDirectory());
+    mBinding.textPath.setText(DirectoryInitialization.getUserDirectory());
 
-    binding.textAndroid11.setVisibility(android_11 && !legacy ? View.VISIBLE : View.GONE);
+    mBinding.textAndroid11.setVisibility(android_11 && !legacy ? View.VISIBLE : View.GONE);
 
-    binding.buttonOpenSystemFileManager.setVisibility(android_11 ? View.VISIBLE : View.GONE);
-    binding.buttonOpenSystemFileManager.setOnClickListener(view -> openFileManager());
+    mBinding.buttonOpenSystemFileManager.setVisibility(android_11 ? View.VISIBLE : View.GONE);
+    mBinding.buttonOpenSystemFileManager.setOnClickListener(view -> openFileManager());
 
-    binding.buttonImportUserData.setOnClickListener(view -> importUserData());
+    mBinding.buttonImportUserData.setOnClickListener(view -> importUserData());
 
-    binding.buttonExportUserData.setOnClickListener(view -> exportUserData());
+    mBinding.buttonExportUserData.setOnClickListener(view -> exportUserData());
 
-    setSupportActionBar(binding.toolbarUserData);
+    setSupportActionBar(mBinding.toolbarUserData);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-    InsetsHelper.setUpAppBarWithScrollView(this, binding.appbarUserData,
-            binding.scrollViewUserData, binding.workaroundView);
-    ThemeHelper.enableScrollTint(this, binding.toolbarUserData, binding.appbarUserData);
+    setInsets();
+    ThemeHelper.enableScrollTint(this, mBinding.toolbarUserData, mBinding.appbarUserData);
   }
 
   @Override
@@ -352,5 +357,23 @@ public class UserDataActivity extends AppCompatActivity
         }
       }
     }
+  }
+
+  private void setInsets()
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(mBinding.appbarUserData, (v, windowInsets) ->
+    {
+      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+
+      InsetsHelper.insetAppBar(insets, mBinding.appbarUserData);
+
+      mBinding.scrollViewUserData.setPadding(insets.left, 0, insets.right, insets.bottom);
+
+      InsetsHelper.applyNavbarWorkaround(insets.bottom, mBinding.workaroundView);
+      ThemeHelper.setNavigationBarColor(this,
+              MaterialColors.getColor(mBinding.appbarUserData, R.attr.colorSurface));
+
+      return windowInsets;
+    });
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatListFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatListFragment.java
@@ -9,15 +9,18 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
 import com.google.android.material.divider.MaterialDividerItemDecoration;
 
+import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.databinding.FragmentCheatListBinding;
 import org.dolphinemu.dolphinemu.features.cheats.model.CheatsViewModel;
-import org.dolphinemu.dolphinemu.utils.InsetsHelper;
 
 public class CheatListFragment extends Fragment
 {
@@ -46,7 +49,7 @@ public class CheatListFragment extends Fragment
     divider.setLastItemDecorated(false);
     mBinding.cheatList.addItemDecoration(divider);
 
-    InsetsHelper.setUpList(getContext(), mBinding.cheatList);
+    setInsets();
   }
 
   @Override
@@ -54,5 +57,16 @@ public class CheatListFragment extends Fragment
   {
     super.onDestroyView();
     mBinding = null;
+  }
+
+  private void setInsets()
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(mBinding.cheatList, (v, windowInsets) ->
+    {
+      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(0, 0, 0,
+              insets.bottom + getResources().getDimensionPixelSize(R.dimen.spacing_xtralarge));
+      return windowInsets;
+    });
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatsActivity.java
@@ -14,8 +14,11 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsAnimationCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.slidingpanelayout.widget.SlidingPaneLayout;
 
@@ -32,6 +35,8 @@ import org.dolphinemu.dolphinemu.ui.TwoPaneOnBackPressedCallback;
 import org.dolphinemu.dolphinemu.ui.main.MainPresenter;
 import org.dolphinemu.dolphinemu.utils.InsetsHelper;
 import org.dolphinemu.dolphinemu.utils.ThemeHelper;
+
+import java.util.List;
 
 public class CheatsActivity extends AppCompatActivity
         implements SlidingPaneLayout.PanelSlideListener
@@ -104,9 +109,7 @@ public class CheatsActivity extends AppCompatActivity
     setSupportActionBar(mBinding.toolbarCheats);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-    InsetsHelper.setUpCheatsLayout(this, mBinding.appbarCheats, mBinding.slidingPaneLayout,
-            mBinding.cheatDetails,
-            mBinding.workaroundView);
+    setInsets();
 
     @ColorInt int color =
             MaterialColors.getColor(mBinding.toolbarCheats, R.attr.colorSurfaceVariant);
@@ -262,6 +265,75 @@ public class CheatsActivity extends AppCompatActivity
         View child = viewGroup.getChildAt(i);
         setOnFocusChangeListenerRecursively(child, listener);
       }
+    }
+  }
+
+  private void setInsets()
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(mBinding.appbarCheats, (v, windowInsets) ->
+    {
+      Insets barInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+      Insets keyboardInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime());
+
+      InsetsHelper.insetAppBar(barInsets, mBinding.appbarCheats);
+
+      mBinding.slidingPaneLayout.setPadding(barInsets.left, 0, barInsets.right, 0);
+
+      // Set keyboard insets if the system supports smooth keyboard animations
+      ViewGroup.MarginLayoutParams mlpDetails =
+              (ViewGroup.MarginLayoutParams) mBinding.cheatDetails.getLayoutParams();
+      if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R)
+      {
+        if (keyboardInsets.bottom > 0)
+        {
+          mlpDetails.bottomMargin = keyboardInsets.bottom;
+        }
+        else
+        {
+          mlpDetails.bottomMargin = barInsets.bottom;
+        }
+      }
+      else
+      {
+        if (mlpDetails.bottomMargin == 0)
+        {
+          mlpDetails.bottomMargin = barInsets.bottom;
+        }
+      }
+      mBinding.cheatDetails.setLayoutParams(mlpDetails);
+
+      InsetsHelper.applyNavbarWorkaround(barInsets.bottom, mBinding.workaroundView);
+
+      ThemeHelper.setNavigationBarColor(this,
+              MaterialColors.getColor(mBinding.appbarCheats, R.attr.colorSurface));
+
+      return windowInsets;
+    });
+
+    // Update the layout for every frame that the keyboard animates in
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R)
+    {
+      ViewCompat.setWindowInsetsAnimationCallback(mBinding.cheatDetails,
+              new WindowInsetsAnimationCompat.Callback(
+                      WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP)
+              {
+                int keyboardInsets = 0;
+                int barInsets = 0;
+
+                @NonNull
+                @Override
+                public WindowInsetsCompat onProgress(@NonNull WindowInsetsCompat insets,
+                        @NonNull List<WindowInsetsAnimationCompat> runningAnimations)
+                {
+                  ViewGroup.MarginLayoutParams mlpDetails =
+                          (ViewGroup.MarginLayoutParams) mBinding.cheatDetails.getLayoutParams();
+                  keyboardInsets = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+                  barInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+                  mlpDetails.bottomMargin = Math.max(keyboardInsets, barInsets);
+                  mBinding.cheatDetails.setLayoutParams(mlpDetails);
+                  return insets;
+                }
+              });
     }
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/riivolution/ui/RiivolutionBootActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/riivolution/ui/RiivolutionBootActivity.java
@@ -7,8 +7,13 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
+
+import com.google.android.material.color.MaterialColors;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
@@ -81,12 +86,11 @@ public class RiivolutionBootActivity extends AppCompatActivity
       runOnUiThread(() -> populateList(patches));
     }).start();
 
-    mBinding.toolbarRiivolutionLayout.setTitle(getString(R.string.riivolution_riivolution));
+    mBinding.toolbarRiivolution.setTitle(getString(R.string.riivolution_riivolution));
     setSupportActionBar(mBinding.toolbarRiivolution);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-    InsetsHelper.setUpAppBarWithScrollView(this, mBinding.appbarRiivolution,
-            mBinding.scrollViewRiivolution, mBinding.workaroundView);
+    setInsets();
     ThemeHelper.enableScrollTint(this, mBinding.toolbarRiivolution, mBinding.appbarRiivolution);
   }
 
@@ -112,5 +116,23 @@ public class RiivolutionBootActivity extends AppCompatActivity
 
     mBinding.recyclerView.setAdapter(new RiivolutionAdapter(this, patches));
     mBinding.recyclerView.setLayoutManager(new LinearLayoutManager(this));
+  }
+
+  private void setInsets()
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(mBinding.appbarRiivolution, (v, windowInsets) ->
+    {
+      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+
+      InsetsHelper.insetAppBar(insets, mBinding.appbarRiivolution);
+
+      mBinding.scrollViewRiivolution.setPadding(insets.left, 0, insets.right, insets.bottom);
+
+      InsetsHelper.applyNavbarWorkaround(insets.bottom, mBinding.workaroundView);
+      ThemeHelper.setNavigationBarColor(this,
+              MaterialColors.getColor(mBinding.appbarRiivolution, R.attr.colorSurface));
+
+      return windowInsets;
+    });
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -9,21 +9,20 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.View;
-import android.widget.FrameLayout;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
 
-import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
-import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.color.MaterialColors;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.dolphinemu.dolphinemu.NativeLibrary;
@@ -48,6 +47,8 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   private AlertDialog dialog;
 
   private CollapsingToolbarLayout mToolbarLayout;
+
+  private ActivitySettingsBinding mBinding;
 
   public static void launch(Context context, MenuTag menuTag, String gameId, int revision,
           boolean isWii)
@@ -82,8 +83,8 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
       MainPresenter.skipRescanningLibrary();
     }
 
-    ActivitySettingsBinding binding = ActivitySettingsBinding.inflate(getLayoutInflater());
-    setContentView(binding.getRoot());
+    mBinding = ActivitySettingsBinding.inflate(getLayoutInflater());
+    setContentView(mBinding.getRoot());
 
     WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
 
@@ -98,17 +99,16 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     mPresenter = new SettingsActivityPresenter(this, getSettings());
     mPresenter.onCreate(savedInstanceState, menuTag, gameID, revision, isWii, this);
 
-    mToolbarLayout = binding.toolbarSettingsLayout;
-    setSupportActionBar(binding.toolbarSettings);
+    mToolbarLayout = mBinding.toolbarSettingsLayout;
+    setSupportActionBar(mBinding.toolbarSettings);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
     // TODO: Remove this when CollapsingToolbarLayouts are fixed by Google
     // https://github.com/material-components/material-components-android/issues/1310
     ViewCompat.setOnApplyWindowInsetsListener(mToolbarLayout, null);
 
-    InsetsHelper.setUpSettingsLayout(this, binding.appbarSettings, binding.frameContentSettings,
-            binding.workaroundView);
-    ThemeHelper.enableScrollTint(this, binding.toolbarSettings, binding.appbarSettings);
+    setInsets();
+    ThemeHelper.enableScrollTint(this, mBinding.toolbarSettings, mBinding.appbarSettings);
   }
 
   @Override
@@ -343,5 +343,23 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   public void setToolbarTitle(String title)
   {
     mToolbarLayout.setTitle(title);
+  }
+
+  private void setInsets()
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(mBinding.appbarSettings, (v, windowInsets) ->
+    {
+      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+
+      InsetsHelper.insetAppBar(insets, mBinding.appbarSettings);
+
+      mBinding.frameContentSettings.setPadding(insets.left, 0, insets.right, 0);
+
+      InsetsHelper.applyNavbarWorkaround(insets.bottom, mBinding.workaroundView);
+      ThemeHelper.setNavigationBarColor(this,
+              MaterialColors.getColor(mBinding.appbarSettings, R.attr.colorSurface));
+
+      return windowInsets;
+    });
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -10,6 +10,9 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -20,8 +23,6 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.databinding.FragmentSettingsBinding;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem;
-import org.dolphinemu.dolphinemu.utils.InsetsHelper;
-import org.dolphinemu.dolphinemu.utils.Log;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -149,7 +150,7 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
     divider.setLastItemDecorated(false);
     recyclerView.addItemDecoration(divider);
 
-    InsetsHelper.setUpList(getContext(), recyclerView);
+    setInsets();
 
     SettingsActivityView activity = (SettingsActivityView) getActivity();
     mPresenter.onViewCreated(menuTag, activity.getSettings());
@@ -245,5 +246,16 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   public void onExtensionSettingChanged(MenuTag menuTag, int value)
   {
     mActivity.onExtensionSettingChanged(menuTag, value);
+  }
+
+  private void setInsets()
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(mBinding.listSettings, (v, windowInsets) ->
+    {
+      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(0, 0, 0,
+              insets.bottom + getResources().getDimensionPixelSize(R.dimen.spacing_list));
+      return windowInsets;
+    });
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -9,14 +9,19 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
 import androidx.core.splashscreen.SplashScreen;
+import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import com.google.android.material.color.MaterialColors;
 import com.google.android.material.tabs.TabLayout;
 
 import org.dolphinemu.dolphinemu.R;
@@ -68,8 +73,7 @@ public final class MainActivity extends AppCompatActivity
     setContentView(mBinding.getRoot());
 
     WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
-    InsetsHelper.setUpMainLayout(this, mBinding.appbarMain, mBinding.buttonAddDirectory,
-            mBinding.pagerPlatforms, mBinding.workaroundView);
+    setInsets();
     ThemeHelper.enableStatusBarScrollTint(this, mBinding.appbarMain);
 
     setSupportActionBar(mBinding.toolbarMain);
@@ -397,5 +401,31 @@ public final class MainActivity extends AppCompatActivity
   private void checkTheme()
   {
     ThemeHelper.setCorrectTheme(this);
+  }
+
+  private void setInsets()
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(mBinding.appbarMain, (v, windowInsets) ->
+    {
+      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+
+      InsetsHelper.insetAppBar(insets, mBinding.appbarMain);
+
+      ViewGroup.MarginLayoutParams mlpFab =
+              (ViewGroup.MarginLayoutParams) mBinding.buttonAddDirectory.getLayoutParams();
+      int fabPadding = getResources().getDimensionPixelSize(R.dimen.spacing_large);
+      mlpFab.leftMargin = insets.left + fabPadding;
+      mlpFab.bottomMargin = insets.bottom + fabPadding;
+      mlpFab.rightMargin = insets.right + fabPadding;
+      mBinding.buttonAddDirectory.setLayoutParams(mlpFab);
+
+      mBinding.pagerPlatforms.setPadding(insets.left, 0, insets.right, 0);
+
+      InsetsHelper.applyNavbarWorkaround(insets.bottom, mBinding.workaroundView);
+      ThemeHelper.setNavigationBarColor(this,
+              MaterialColors.getColor(mBinding.appbarMain, R.attr.colorSurface));
+
+      return windowInsets;
+    });
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
@@ -10,6 +10,9 @@ import android.view.ViewTreeObserver;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -20,7 +23,6 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.adapters.GameAdapter;
 import org.dolphinemu.dolphinemu.databinding.FragmentGridBinding;
 import org.dolphinemu.dolphinemu.services.GameFileCacheManager;
-import org.dolphinemu.dolphinemu.utils.InsetsHelper;
 
 public final class PlatformGamesFragment extends Fragment implements PlatformGamesView
 {
@@ -102,7 +104,7 @@ public final class PlatformGamesFragment extends Fragment implements PlatformGam
 
     mSwipeRefresh.setOnRefreshListener(mOnRefreshListener);
 
-    InsetsHelper.setUpList(getContext(), mBinding.gridGames);
+    setInsets();
 
     setRefreshing(GameFileCacheManager.isLoadingOrRescanning());
 
@@ -157,5 +159,17 @@ public final class PlatformGamesFragment extends Fragment implements PlatformGam
   public void setRefreshing(boolean refreshing)
   {
     mBinding.swipeRefresh.setRefreshing(refreshing);
+  }
+
+  private void setInsets()
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(mBinding.gridGames, (v, windowInsets) ->
+    {
+      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+      v.setPadding(0, 0, 0,
+              insets.bottom + getResources().getDimensionPixelSize(R.dimen.spacing_list) +
+                      getResources().getDimensionPixelSize(R.dimen.spacing_fab));
+      return windowInsets;
+    });
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
@@ -4,195 +4,20 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Rect;
-import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.FrameLayout;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.graphics.Insets;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsAnimationCompat;
-import androidx.core.view.WindowInsetsCompat;
-import androidx.core.widget.NestedScrollView;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.slidingpanelayout.widget.SlidingPaneLayout;
-import androidx.viewpager.widget.ViewPager;
 
 import com.google.android.material.appbar.AppBarLayout;
-import com.google.android.material.color.MaterialColors;
-import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton;
-
-import org.dolphinemu.dolphinemu.R;
-
-import java.util.List;
 
 public class InsetsHelper
 {
-  public static final int FAB_INSET = 16;
-  public static final int EXTRA_NAV_INSET = 32;
-
   public static final int THREE_BUTTON_NAVIGATION = 0;
   public static final int TWO_BUTTON_NAVIGATION = 1;
   public static final int GESTURE_NAVIGATION = 2;
 
-  public static int dpToPx(Context context, int dp)
-  {
-    return (int) (dp * ((float) context.getResources().getDisplayMetrics().densityDpi /
-            DisplayMetrics.DENSITY_DEFAULT) + 0.5f);
-  }
-
-  public static void setUpAppBarWithScrollView(AppCompatActivity activity,
-          AppBarLayout appBarLayout, NestedScrollView nestedScrollView, View workaroundView)
-  {
-    ViewCompat.setOnApplyWindowInsetsListener(appBarLayout, (v, windowInsets) ->
-    {
-      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-
-      insetAppBar(insets, appBarLayout);
-
-      nestedScrollView.setPadding(insets.left, 0, insets.right, insets.bottom);
-
-      applyWorkaround(insets.bottom, workaroundView);
-
-      ThemeHelper.setNavigationBarColor(activity,
-              MaterialColors.getColor(appBarLayout, R.attr.colorSurface));
-
-      return windowInsets;
-    });
-  }
-
-  public static void setUpList(Context context, RecyclerView recyclerView)
-  {
-    ViewCompat.setOnApplyWindowInsetsListener(recyclerView, (v, windowInsets) ->
-    {
-      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-      v.setPadding(0, 0, 0, insets.bottom + dpToPx(context, EXTRA_NAV_INSET));
-
-      return windowInsets;
-    });
-  }
-
-  public static void setUpMainLayout(AppCompatActivity activity, AppBarLayout appBarLayout,
-          ExtendedFloatingActionButton fab, ViewPager viewPager, View workaroundView)
-  {
-    ViewCompat.setOnApplyWindowInsetsListener(appBarLayout, (v, windowInsets) ->
-    {
-      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-
-      insetAppBar(insets, appBarLayout);
-
-      ViewGroup.MarginLayoutParams mlpFab = (ViewGroup.MarginLayoutParams) fab.getLayoutParams();
-      int fabPadding =
-              InsetsHelper.dpToPx(activity.getApplicationContext(), FAB_INSET);
-      mlpFab.leftMargin = insets.left + fabPadding;
-      mlpFab.bottomMargin = insets.bottom + fabPadding;
-      mlpFab.rightMargin = insets.right + fabPadding;
-      fab.setLayoutParams(mlpFab);
-
-      viewPager.setPadding(insets.left, 0, insets.right, 0);
-
-      applyWorkaround(insets.bottom, workaroundView);
-
-      ThemeHelper.setNavigationBarColor(activity,
-              MaterialColors.getColor(appBarLayout, R.attr.colorSurface));
-
-      return windowInsets;
-    });
-  }
-
-  public static void setUpSettingsLayout(AppCompatActivity activity,
-          AppBarLayout appBarLayout, FrameLayout frameLayout, View workaroundView)
-  {
-    ViewCompat.setOnApplyWindowInsetsListener(appBarLayout, (v, windowInsets) ->
-    {
-      Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-
-      insetAppBar(insets, appBarLayout);
-
-      frameLayout.setPadding(insets.left, 0, insets.right, 0);
-
-      applyWorkaround(insets.bottom, workaroundView);
-
-      ThemeHelper.setNavigationBarColor(activity,
-              MaterialColors.getColor(appBarLayout, R.attr.colorSurface));
-
-      return windowInsets;
-    });
-  }
-
-  public static void setUpCheatsLayout(AppCompatActivity activity, AppBarLayout appBarLayout,
-          SlidingPaneLayout slidingPaneLayout, View cheatDetails, View workaroundView)
-  {
-    ViewCompat.setOnApplyWindowInsetsListener(appBarLayout, (v, windowInsets) ->
-    {
-      Insets barInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-      Insets keyboardInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime());
-
-      insetAppBar(barInsets, appBarLayout);
-
-      slidingPaneLayout.setPadding(barInsets.left, 0, barInsets.right, 0);
-
-      // Set keyboard insets if the system supports smooth keyboard animations
-      ViewGroup.MarginLayoutParams mlpDetails =
-              (ViewGroup.MarginLayoutParams) cheatDetails.getLayoutParams();
-      if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R)
-      {
-        if (keyboardInsets.bottom > 0)
-        {
-          mlpDetails.bottomMargin = keyboardInsets.bottom;
-        }
-        else
-        {
-          mlpDetails.bottomMargin = barInsets.bottom;
-        }
-      }
-      else
-      {
-        if (mlpDetails.bottomMargin == 0)
-        {
-          mlpDetails.bottomMargin = barInsets.bottom;
-        }
-      }
-      cheatDetails.setLayoutParams(mlpDetails);
-
-      applyWorkaround(barInsets.bottom, workaroundView);
-
-      ThemeHelper.setNavigationBarColor(activity,
-              MaterialColors.getColor(appBarLayout, R.attr.colorSurface));
-
-      return windowInsets;
-    });
-
-    // Update the layout for every frame that the keyboard animates in
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R)
-    {
-      ViewCompat.setWindowInsetsAnimationCallback(cheatDetails,
-              new WindowInsetsAnimationCompat.Callback(
-                      WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP)
-              {
-                int keyboardInsets = 0;
-                int barInsets = 0;
-
-                @NonNull
-                @Override
-                public WindowInsetsCompat onProgress(@NonNull WindowInsetsCompat insets,
-                        @NonNull List<WindowInsetsAnimationCompat> runningAnimations)
-                {
-                  ViewGroup.MarginLayoutParams mlpDetails =
-                          (ViewGroup.MarginLayoutParams) cheatDetails.getLayoutParams();
-                  keyboardInsets = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
-                  barInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
-                  mlpDetails.bottomMargin = Math.max(keyboardInsets, barInsets);
-                  cheatDetails.setLayoutParams(mlpDetails);
-                  return insets;
-                }
-              });
-    }
-  }
-
-  private static void insetAppBar(Insets insets, AppBarLayout appBarLayout)
+  public static void insetAppBar(Insets insets, AppBarLayout appBarLayout)
   {
     ViewGroup.MarginLayoutParams mlpAppBar =
             (ViewGroup.MarginLayoutParams) appBarLayout.getLayoutParams();
@@ -204,7 +29,7 @@ public class InsetsHelper
 
   // Workaround for a bug on Android 13 that allows users to interact with UI behind the
   // navigation bar https://issuetracker.google.com/issues/248761842
-  private static void applyWorkaround(int bottomInset, View workaroundView)
+  public static void applyNavbarWorkaround(int bottomInset, View workaroundView)
   {
     if (bottomInset > 0)
     {

--- a/Source/Android/app/src/main/res/values/dimens.xml
+++ b/Source/Android/app/src/main/res/values/dimens.xml
@@ -2,6 +2,9 @@
     <dimen name="spacing_small">4dp</dimen>
     <dimen name="spacing_medlarge">12dp</dimen>
     <dimen name="spacing_large">16dp</dimen>
+    <dimen name="spacing_xtralarge">32dp</dimen>
+    <dimen name="spacing_list">64dp</dimen>
+    <dimen name="spacing_fab">72dp</dimen>
     <dimen name="menu_width">256dp</dimen>
     <dimen name="card_width">135dp</dimen>
 </resources>


### PR DESCRIPTION
This pulls the activity-specific code out of InsetsHelper. I think I prefer it this way so if there's a change to an activity's insets, we could just change the specific activity's setInsets method and not worry about having to split up more methods in InsetsHelper.

Nothing functional is changed here, the organization is just different.