### PR TITLE
Jit64: Correctly handle NaNs for ps_mulsX/ps_sumX

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -17,6 +17,8 @@
 // ----------
 #pragma once
 
+#include <optional>
+
 #include <rangeset/rangesizeset.h>
 
 #include "Common/CommonTypes.h"
@@ -127,7 +129,8 @@ public:
                             bool duplicate = false);
   void FinalizeDoubleResult(Gen::X64Reg output, const Gen::OpArg& input);
   void HandleNaNs(UGeckoInstruction inst, Gen::X64Reg xmm, Gen::X64Reg clobber,
-                  std::vector<int> inputs);
+                  std::optional<Gen::OpArg> Ra, std::optional<Gen::OpArg> Rb,
+                  std::optional<Gen::OpArg> Rc);
 
   void MultiplyImmediate(u32 imm, int a, int d, bool overflow);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -79,7 +79,8 @@ void Jit64::ps_sum(UGeckoInstruction inst)
   default:
     PanicAlertFmt("ps_sum WTF!!!");
   }
-  HandleNaNs(inst, tmp, tmp == XMM1 ? XMM0 : XMM1, Ra, Rb, Rc);
+  // We're intentionally not calling HandleNaNs here.
+  // For addition and subtraction specifically, x86's NaN behavior matches PPC's.
   FinalizeSingleResult(Rd, R(tmp));
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -3,6 +3,8 @@
 
 #include "Core/PowerPC/Jit64/Jit.h"
 
+#include <optional>
+
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
@@ -77,7 +79,7 @@ void Jit64::ps_sum(UGeckoInstruction inst)
   default:
     PanicAlertFmt("ps_sum WTF!!!");
   }
-  HandleNaNs(inst, tmp, tmp == XMM1 ? XMM0 : XMM1, {a, b, c});
+  HandleNaNs(inst, tmp, tmp == XMM1 ? XMM0 : XMM1, Ra, Rb, Rc);
   FinalizeSingleResult(Rd, R(tmp));
 }
 
@@ -112,7 +114,7 @@ void Jit64::ps_muls(UGeckoInstruction inst)
   if (round_input)
     Force25BitPrecision(XMM1, R(XMM1), XMM0);
   MULPD(XMM1, Ra);
-  HandleNaNs(inst, XMM1, XMM0, {a, c});
+  HandleNaNs(inst, XMM1, XMM0, Ra, std::nullopt, Rc);
   FinalizeSingleResult(Rd, R(XMM1));
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -98,23 +98,26 @@ void Jit64::ps_muls(UGeckoInstruction inst)
   RCOpArg Ra = fpr.Use(a, RCMode::Read);
   RCOpArg Rc = fpr.Use(c, RCMode::Read);
   RCX64Reg Rd = fpr.Bind(d, RCMode::Write);
-  RegCache::Realize(Ra, Rc, Rd);
+  RCX64Reg Rc_duplicated = m_accurate_nans ? fpr.Scratch() : fpr.Scratch(XMM1);
+  RegCache::Realize(Ra, Rc, Rd, Rc_duplicated);
 
   switch (inst.SUBOP5)
   {
   case 12:  // ps_muls0
-    MOVDDUP(XMM1, Rc);
+    MOVDDUP(Rc_duplicated, Rc);
     break;
   case 13:  // ps_muls1
-    avx_op(&XEmitter::VSHUFPD, &XEmitter::SHUFPD, XMM1, Rc, Rc, 3);
+    avx_op(&XEmitter::VSHUFPD, &XEmitter::SHUFPD, Rc_duplicated, Rc, Rc, 3);
     break;
   default:
     PanicAlertFmt("ps_muls WTF!!!");
   }
   if (round_input)
-    Force25BitPrecision(XMM1, R(XMM1), XMM0);
+    Force25BitPrecision(XMM1, R(Rc_duplicated), XMM0);
+  else if (XMM1 != Rc_duplicated)
+    MOVAPD(XMM1, Rc_duplicated);
   MULPD(XMM1, Ra);
-  HandleNaNs(inst, XMM1, XMM0, Ra, std::nullopt, Rc);
+  HandleNaNs(inst, XMM1, XMM0, Ra, std::nullopt, Rc_duplicated);
   FinalizeSingleResult(Rd, R(XMM1));
 }
 


### PR DESCRIPTION
HandleNaNs assumes that a NaN in a ps0 input always results in a NaN in the ps0 output, and correspondingly for ps1. This isn't the case for ps_mulsX and ps_sumX.