### PR TITLE
Correctly call CoUninitialize() on Cubeb helper class destruction.

### DIFF
--- a/Source/Core/AudioCommon/CubebStream.cpp
+++ b/Source/Core/AudioCommon/CubebStream.cpp
@@ -46,6 +46,7 @@ CubebStream::CubebStream()
     Common::ScopeGuard sync_event_guard([&sync_event] { sync_event.Set(); });
     auto result = ::CoInitializeEx(nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);
     m_coinit_success = result == S_OK;
+    m_should_couninit = result == S_OK || result == S_FALSE;
   });
   sync_event.Wait();
 }
@@ -137,11 +138,12 @@ CubebStream::~CubebStream()
     cubeb_stream_stop(m_stream);
     cubeb_stream_destroy(m_stream);
 #ifdef _WIN32
-    if (m_coinit_success)
+    if (m_should_couninit)
     {
-      m_coinit_success = false;
+      m_should_couninit = false;
       CoUninitialize();
     }
+    m_coinit_success = false;
   });
   sync_event.Wait();
 #endif

--- a/Source/Core/AudioCommon/CubebStream.h
+++ b/Source/Core/AudioCommon/CubebStream.h
@@ -37,6 +37,7 @@ private:
 #ifdef _WIN32
   Common::WorkQueueThread<std::function<void()>> m_work_queue;
   bool m_coinit_success = false;
+  bool m_should_couninit = false;
 #endif
 
   static long DataCallback(cubeb_stream* stream, void* user_data, const void* /*input_buffer*/,

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -104,6 +104,7 @@ private:
 #ifdef _WIN32
   Common::WorkQueueThread<std::function<void()>> m_work_queue;
   bool m_coinit_success = false;
+  bool m_should_couninit = false;
 #endif
 };
 }  // namespace ExpansionInterface


### PR DESCRIPTION
oops

(one should always re-check your code before merging, even if the code has been sitting there for ages unchanged...)