### PR TITLE
Android: Upgrade AGP to 7.3.1

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.dolphinemu.dolphinemu">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature
         android:name="android.hardware.touchscreen"

--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 


### PR DESCRIPTION
We're currently running AGP 7.0.4 because of broken incremental builds as documented here https://issuetracker.google.com/issues/232060576?pli=1

However, upgrading to the latest version comes with several benefits that should be considered even when dealing with this bug.
This release will allow us to -

- Upgrade to [MDC 1.7.0](https://github.com/material-components/material-components-android/releases/tag/1.7.0) with the new MaterialSwitch component and changes to navigation bars that will help in my work on larger layouts
- Use [Baseline Profiles](https://developer.android.com/topic/performance/baselineprofiles/overview) that will make initial app performance much more consistent (~30% faster launch times)
- Avoid undocumented behavior since AGP 7.0.4 only supports up to API 31 and we're compiling for API 33 now