### PR TITLE
GameSettings: Add patch for Ten Pin Alley 2 (RLEEFS)

### DIFF
--- a/Data/Sys/GameSettings/RLEEFS.ini
+++ b/Data/Sys/GameSettings/RLEEFS.ini
@@ -1,0 +1,11 @@
+# RLEEFS - Ten Pin Alley 2
+
+[OnFrame]
+# This call to GXCopyDisp(), made once before the title screen for no apparent
+# purpose, is causing heap corruption, but it isn't observed on real hardware
+# thanks to the data cache. Skipping the call works too.
+$Fix crash on main menu
+0x80037864:dword:0x60000000
+
+[OnFrame_Enabled]
+$Fix crash on main menu


### PR DESCRIPTION
A call to GXCopyDisp(), made once before the title screen for no apparent purpose, is causing heap corruption, but it isn't observed on real hardware thanks to the data cache. Skipping the call works too, preventing a crash on the main menu.

Fixes https://bugs.dolphin-emu.org/issues/12699

My investigation was prompted by this comment: https://github.com/dolphin-emu/dolphin/pull/11183#issuecomment-1288432004

For reference, this is virtually the same bug found in Monster High: #9316