### PR TITLE
Android: Letterbox content with display cutouts in landscape

### DIFF
--- a/Source/Android/app/src/main/res/values/themes.xml
+++ b/Source/Android/app/src/main/res/values/themes.xml
@@ -50,6 +50,7 @@
         <item name="homeAsUpIndicator">@drawable/ic_back</item>
 
         <item name="android:windowLightStatusBar" tools:targetApi="m">@bool/lightSystemBars</item>
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="o_mr1">default</item>
 
         <item name="materialAlertDialogTheme">@style/DolphinMaterialDialog</item>
         <item name="popupTheme">@style/DolphinPopup</item>


### PR DESCRIPTION
For some reason the default setting for display cutouts doesn't apply to the main activity. So this fixes the main activity getting cut off by display cutouts in landscape mode.

Before (Imagine there's a camera hole on the left side) - 
![signal-2022-12-01-012941_003](https://user-images.githubusercontent.com/14132249/204981811-765c3ccf-21b6-4851-8482-8166a1232f41.png)

After - 
![signal-2022-12-01-012941_002](https://user-images.githubusercontent.com/14132249/204981838-abd96b9e-8e18-4468-892a-5384ff1f3ec7.png)
