### PR TITLE
Android: Pad menu fragment when expanding to cutout area

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -16,6 +16,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -25,6 +26,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.PopupMenu;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -342,6 +346,8 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
     ActivityEmulationBinding binding = ActivityEmulationBinding.inflate(getLayoutInflater());
     setContentView(binding.getRoot());
 
+    setInsets(binding.frameMenu);
+
     // Find or create the EmulationFragment
     mEmulationFragment = (EmulationFragment) getSupportFragmentManager()
             .findFragmentById(R.id.frame_emulation_fragment);
@@ -536,6 +542,28 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
               .commit();
       mMenuVisible = true;
     }
+  }
+
+  private void setInsets(View view)
+  {
+    ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) ->
+    {
+      Insets cutInsets = windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout());
+      ViewGroup.MarginLayoutParams mlpMenu =
+              (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+      int menuWidth = getResources().getDimensionPixelSize(R.dimen.menu_width);
+      if (ViewCompat.getLayoutDirection(v) == ViewCompat.LAYOUT_DIRECTION_LTR)
+      {
+        mlpMenu.width = cutInsets.left + menuWidth;
+      }
+      else
+      {
+        mlpMenu.width = cutInsets.right + menuWidth;
+      }
+      NativeLibrary.SetObscuredPixelsTop(cutInsets.top);
+      NativeLibrary.SetObscuredPixelsLeft(cutInsets.left);
+      return windowInsets;
+    });
   }
 
   public void showOverlayControlsMenu(@NonNull View anchor)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
@@ -1,7 +1,9 @@
 package org.dolphinemu.dolphinemu.utils;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
+import android.graphics.Rect;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
@@ -221,5 +223,25 @@ public class InsetsHelper
       return resources.getInteger(resourceId);
     }
     return 0;
+  }
+
+  public static int getNavigationBarHeight(Context context)
+  {
+    Resources resources = context.getResources();
+    int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+    if (resourceId > 0)
+    {
+      return resources.getDimensionPixelSize(resourceId);
+    }
+    return 0;
+  }
+
+  // This is primarily intended to account for any navigation bar at the bottom of the screen
+  public static int getBottomPaddingRequired(Activity activity)
+  {
+    Rect visibleFrame = new Rect();
+    activity.getWindow().getDecorView().getWindowVisibleDisplayFrame(visibleFrame);
+    return visibleFrame.bottom - visibleFrame.top -
+            activity.getResources().getDisplayMetrics().heightPixels;
   }
 }

--- a/Source/Android/app/src/main/res/layout/activity_emulation.xml
+++ b/Source/Android/app/src/main/res/layout/activity_emulation.xml
@@ -22,7 +22,7 @@
 
         <FrameLayout
             android:id="@+id/frame_menu"
-            android:layout_width="260dp"
+            android:layout_width="@dimen/menu_width"
             android:layout_height="match_parent"
             tools:layout="@layout/fragment_ingame_menu"/>
 

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:paddingBottom="16dp"
-              android:background="?attr/colorSurface"
-              tools:layout_width="250dp">
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface"
+    tools:layout_width="250dp">
 
     <TextView
         android:id="@+id/text_game_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
         android:layout_marginHorizontal="32dp"
-        android:layout_marginTop="32dp"
+        android:layout_marginVertical="24dp"
         android:ellipsize="end"
         android:letterSpacing="0"
         android:maxLines="@integer/game_title_lines"
@@ -22,11 +21,16 @@
         android:textColor="?attr/colorOnSurface"
         tools:text="The Legend of Zelda: The Wind Waker" />
 
+    <com.google.android.material.divider.MaterialDivider
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:scrollbarSize="8dp"
+        android:scrollbarSize="4dp"
         android:fadeScrollbars="false">
 
         <LinearLayout
@@ -38,73 +42,62 @@
             <Button
                 android:id="@+id/menu_pause_emulation"
                 style="@style/InGameMenuOption"
-                android:letterSpacing="0"
                 android:text="@string/pause_emulation" />
 
             <Button
                 android:id="@+id/menu_unpause_emulation"
                 style="@style/InGameMenuOption"
-                android:letterSpacing="0"
                 android:text="@string/unpause_emulation"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
             <Button
                 android:id="@+id/menu_take_screenshot"
                 style="@style/InGameMenuOption"
-                android:letterSpacing="0"
                 android:text="@string/emulation_screenshot" />
 
             <Button
                 android:id="@+id/menu_quicksave"
                 style="@style/InGameMenuOption"
-                android:letterSpacing="0"
                 android:text="@string/emulation_quicksave"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
             <Button
                 android:id="@+id/menu_quickload"
                 style="@style/InGameMenuOption"
-                android:letterSpacing="0"
                 android:text="@string/emulation_quickload"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
             <Button
                 android:id="@+id/menu_emulation_save_root"
                 style="@style/InGameMenuOption"
-                android:letterSpacing="0"
                 android:text="@string/emulation_savestate"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
             <Button
                 android:id="@+id/menu_emulation_load_root"
                 style="@style/InGameMenuOption"
-                android:letterSpacing="0"
                 android:text="@string/emulation_loadstate"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
             <Button
                 android:id="@+id/menu_settings"
                 style="@style/InGameMenuOption"
-                android:letterSpacing="0"
                 android:text="@string/grid_menu_settings" />
 
             <Button
                 android:id="@+id/menu_overlay_controls"
                 style="@style/InGameMenuOption"
-                android:letterSpacing="0"
                 android:text="@string/emulation_overlay_controls" />
 
             <Button
                 android:id="@+id/menu_refresh_wiimotes"
                 android:text="@string/emulation_refresh_wiimotes"
-                android:letterSpacing="0"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption" />
 
             <Button
                 android:id="@+id/menu_change_disc"
                 android:text="@string/emulation_change_disc"
-                android:letterSpacing="0"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption" />
 
         </LinearLayout>
 
@@ -113,14 +106,12 @@
     <com.google.android.material.divider.MaterialDivider
         android:id="@+id/divider_2"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:layout_marginBottom="16dp" />
+        android:layout_height="wrap_content" />
 
     <Button
         android:id="@+id/menu_exit"
         style="@style/InGameMenuOption"
-        android:letterSpacing="0"
+        android:layout_marginTop="@dimen/spacing_large"
         android:text="@string/emulation_exit" />
 
 </LinearLayout>

--- a/Source/Android/app/src/main/res/values/dimens.xml
+++ b/Source/Android/app/src/main/res/values/dimens.xml
@@ -2,5 +2,6 @@
     <dimen name="spacing_small">4dp</dimen>
     <dimen name="spacing_medlarge">12dp</dimen>
     <dimen name="spacing_large">16dp</dimen>
+    <dimen name="menu_width">256dp</dimen>
     <dimen name="card_width">135dp</dimen>
 </resources>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -2,16 +2,14 @@
 <resources>
     <!-- Custom button styles -->
     <style name="InGameMenuOption" parent="Widget.Material3.Button.TextButton">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">48dp</item>
         <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textSize">16sp</item>
         <item name="android:fontFamily">sans-serif-condensed</item>
-        <item name="android:textAllCaps">false</item>
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">48dp</item>
         <item name="android:gravity">center_vertical|left</item>
         <item name="android:paddingLeft">32dp</item>
         <item name="android:paddingRight">32dp</item>
-        <item name="android:layout_margin">0dp</item>
     </style>
 
     <style name="OverlayInGameMenuOption" parent="InGameMenuOption">


### PR DESCRIPTION
Previously mentioned in #11313 

Before when using the "Expand to Cutout Area" setting, camera notches/other device insets could get in the way of the ingame menu fragment. Now we apply padding based on inset and this accounts for RTL layouts.

Additionally, I've removed unused attributes from the xml and slightly tweaked the padding of the fragment itself to appear clearer.

Before (camera would appear in the way of text on the left) - 
![signal-2022-12-01-162921_003](https://user-images.githubusercontent.com/14132249/205163054-f43b0206-03f3-44b1-9893-4d116e3bd14e.png)

After - 
![signal-2022-12-01-162921_002](https://user-images.githubusercontent.com/14132249/205163122-b7e1cf54-fcd2-4d15-ba67-128bc08a0f7f.png)
