### PR TITLE
Android: Use progress indicator in short loading scenarios

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatsActivity.java
@@ -208,7 +208,8 @@ public class CheatsActivity extends AppCompatActivity
   public void downloadGeckoCodes()
   {
     AlertDialog progressDialog = new MaterialAlertDialogBuilder(this)
-            .setMessage(R.string.cheats_downloading)
+            .setTitle(R.string.cheats_downloading)
+            .setView(R.layout.dialog_indeterminate_progress)
             .setCancelable(false)
             .show();
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -240,8 +240,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     {
       dialog = new MaterialAlertDialogBuilder(this)
               .setTitle(getString(R.string.load_settings))
-              .setView(getLayoutInflater().inflate(R.layout.dialog_indeterminate_progress, null,
-                      false))
+              .setView(R.layout.dialog_indeterminate_progress)
               .create();
     }
     dialog.show();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ThreadUtil.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ThreadUtil.java
@@ -31,6 +31,7 @@ public class ThreadUtil
     Resources resources = activity.getResources();
     AlertDialog progressDialog = new MaterialAlertDialogBuilder(activity)
             .setTitle(progressTitle)
+            .setView(R.layout.dialog_indeterminate_progress)
             .setCancelable(false)
             .create();
 

--- a/Source/Android/app/src/main/res/layout/dialog_indeterminate_progress.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_indeterminate_progress.xml
@@ -4,11 +4,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.progressindicator.CircularProgressIndicator
-        android:layout_width="wrap_content"
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
-        android:layout_margin="16dp"
+        android:layout_margin="24dp"
         android:indeterminate="true"
         app:trackCornerRadius="2dp" />
 


### PR DESCRIPTION
Always felt a bit off that we would just have text and not an indeterminate progress bar. This fixes that. (Also I checked, this does not crash the TvMainActivity)

Before - 
![signal-2022-12-02-215203_003](https://user-images.githubusercontent.com/14132249/205419053-60903c3c-6e4d-410a-8348-5db1418583a5.png)

After - 
https://user-images.githubusercontent.com/14132249/205419054-725106da-4594-41d8-9d6e-21592be7b883.mp4

