### PR TITLE
DSPLLE: Update more frequently

### DIFF
--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -26,6 +26,7 @@
 #include "Core/DSP/Interpreter/DSPInterpreter.h"
 #include "Core/DSP/Jit/DSPEmitterBase.h"
 #include "Core/HW/Memmap.h"
+#include "Core/HW/SystemTimers.h"
 #include "Core/Host.h"
 
 namespace DSP::LLE
@@ -285,7 +286,8 @@ void DSPLLE::DSP_Update(int cycles)
 
 u32 DSPLLE::DSP_UpdateRate()
 {
-  return 12600;  // TO BE TWEAKED
+  // Update every 10 microseconds
+  return SystemTimers::GetTicksPerSecond() / 100000;
 }
 
 void DSPLLE::PauseAndLock(bool do_lock, bool unpause_on_unlock)


### PR DESCRIPTION
This fixes the consistent hang when starting Super Mario Sunshine with the DSP LLE interpreter.  I don't think it fixes the random hang with the recompiler ([issue 11384](https://bugs.dolphin-emu.org/issues/11384)) as I'm fairly sure I ran into that during my testing.

I'm not sure what kind of performance impact this will have. The old value (12600) corresponds to 258 microseconds on GameCube or 172 microseconds on Wii, while the new value is always 10 microseconds (being 4860 on GameCube or 7290 on Wii). So, this is about 3 times more frequent on GameCube and twice as frequent on Wii. DSP HLE always uses 1 millisecond (1000 microseconds). 

The hang was introduced by #10762, which slightly changed DSP timings, but it seems like the DSP interpreter is just sensitive to differences in timing. The recompiler, for some reason, is much more tolerant to different timings; doubling or halving `Get32KHzSampleRateDivisor` (or `Get32KHzSampleRate` prior to that PR/with that PR [reverted](https://gist.github.com/Pokechu22/3f620aa1413726bf6fb7a318ad063de9)) resulted in hangs on the interpreter, but the recompiler handled it gracefully (at least for Super Mario Sunshine). With this change, both the interpreter and recompiler handle those dramatic differences properly (as well as the much smaller difference #10762 introduced). **I have no idea why the interpreter is so sensitive**; changing the recompiler to fall back to the interpreter on every instruction still maintains the recompiler's timing tolerance so it must be something else.

The old value is weird. It looks like 12000 was chosen in 8c3bb3796b807c3f69665b6fb07c19881054ea89 with the only explanation being "TO BE TWEAKED", then that was commented out in 98db1a0ca3084ec775152dca631570f2777d09a3, then restored in 68ea37f2fbd2a26e37fcb41f6114e3318f2d499e (with some confusion still), then in 2013 b76c7cf4f33a511fc5cf7a9f180208e4a41ceee4 changed it to 12600 "as it seemed to be a bit more stable" (note that this is _less_ frequent updates). That number was later moved out to be configurable for DSP HLE by ef4d59a21e4d921ff4a77d0614b46d52cf8def92, which is why `DSP_UpdateRate` exists, but it was changed so that all HLE uCodes use the same value in 896a02b3a8a635e064c17b1c22c6dbb1ee1e2191. So, overall, it's just confusing.

This is a draft because this change just seems dubious in general.