### PR TITLE
Android: Fix cheats layout

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
@@ -130,7 +130,7 @@ public class InsetsHelper
 
       insetAppBar(barInsets, appBarLayout);
 
-      slidingPaneLayout.setPadding(barInsets.left, barInsets.top, barInsets.right, 0);
+      slidingPaneLayout.setPadding(barInsets.left, 0, barInsets.right, 0);
 
       // Set keyboard insets if the system supports smooth keyboard animations
       ViewGroup.MarginLayoutParams mlpDetails =

--- a/Source/Android/app/src/main/res/layout/activity_cheats.xml
+++ b/Source/Android/app/src/main/res/layout/activity_cheats.xml
@@ -1,44 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/coordinator_main"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?attr/colorSurface">
+    android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/appbar_cheats"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinator_main"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        app:liftOnScroll="false"
-        app:elevation="0dp">
+        android:background="?attr/colorSurface"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar_cheats"
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appbar_cheats"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?attr/colorSurface" />
+            app:elevation="0dp"
+            app:liftOnScroll="false">
 
-    </com.google.android.material.appbar.AppBarLayout>
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_cheats"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/colorSurface" />
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <androidx.slidingpanelayout.widget.SlidingPaneLayout
         android:id="@+id/sliding_pane_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="64dp">
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/coordinator_main">
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/cheat_list"
+            android:name="org.dolphinemu.dolphinemu.features.cheats.ui.CheatListFragment"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:name="org.dolphinemu.dolphinemu.features.cheats.ui.CheatListFragment" />
+            android:layout_height="match_parent" />
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/cheat_details"
+            android:name="org.dolphinemu.dolphinemu.features.cheats.ui.CheatDetailsFragment"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:name="org.dolphinemu.dolphinemu.features.cheats.ui.CheatDetailsFragment" />
+            android:layout_height="match_parent" />
 
     </androidx.slidingpanelayout.widget.SlidingPaneLayout>
 
@@ -47,7 +59,10 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_gravity="bottom"
+        android:background="@android:color/transparent"
         android:clickable="true"
-        android:background="@android:color/transparent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The sliding panel layout was in the way of the top app bar and prevented the up button from being pressed. This anchors the panel to the bottom of the top app bar and removed unnecessary hardcoded padding.

Before - 
![image](https://user-images.githubusercontent.com/14132249/205506290-ee16b385-d3bf-4e03-b364-4f771a41a489.png)

After - 
![image](https://user-images.githubusercontent.com/14132249/205506235-16cefc86-5727-4ec9-841f-8751841c9073.png)
