### PR TITLE
Android: Add black backgrounds toggle

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -81,6 +81,8 @@ public enum BooleanSetting implements AbstractBooleanSetting
 
   MAIN_SHOW_GAME_TITLES(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
           "ShowGameTitles", true),
+  MAIN_USE_BLACK_BACKGROUNDS(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
+          "UseBlackBackgrounds", false),
   MAIN_JOYSTICK_REL_CENTER(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
           "JoystickRelCenter", true),
   MAIN_PHONE_RUMBLE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -13,6 +13,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.UserDataActivity;
+import org.dolphinemu.dolphinemu.features.settings.model.AbstractBooleanSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.AbstractIntSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.AbstractStringSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.AdHocBooleanSetting;
@@ -414,6 +415,44 @@ public final class SettingsFragmentPresenter
 
     sl.add(new SingleChoiceSetting(mContext, themeMode, R.string.change_theme_mode, 0,
             R.array.themeModeEntries, R.array.themeModeValues));
+
+    AbstractBooleanSetting blackBackgrounds = new AbstractBooleanSetting()
+    {
+      @Override
+      public boolean isOverridden(Settings settings)
+      {
+        return BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.isOverridden(settings);
+      }
+
+      @Override
+      public boolean isRuntimeEditable()
+      {
+        return true;
+      }
+
+      @Override
+      public boolean delete(Settings settings)
+      {
+        ThemeHelper.deleteBackgroundSetting((AppCompatActivity) mView.getActivity());
+        return BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.delete(settings);
+      }
+
+      @Override
+      public boolean getBoolean(Settings settings)
+      {
+        return BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.getBoolean(settings);
+      }
+
+      @Override
+      public void setBoolean(Settings settings, boolean newValue)
+      {
+        BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.setBoolean(settings, newValue);
+        ThemeHelper.saveBackgroundSetting((AppCompatActivity) mView.getActivity(), newValue);
+      }
+    };
+
+    sl.add(new CheckBoxSetting(mContext, blackBackgrounds, R.string.use_black_backgrounds,
+            R.string.use_black_backgrounds_description));
   }
 
   private void addAudioSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -21,6 +21,7 @@ import androidx.preference.PreferenceManager;
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.IntSetting;
 
 import java.io.File;
@@ -79,24 +80,7 @@ public final class DirectoryInitialization
 
     areDirectoriesAvailable = true;
 
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    if (IntSetting.MAIN_INTERFACE_THEME.getIntGlobal() !=
-            preferences.getInt(ThemeHelper.CURRENT_THEME, ThemeHelper.DEFAULT))
-    {
-      preferences.edit()
-              .putInt(ThemeHelper.CURRENT_THEME, IntSetting.MAIN_INTERFACE_THEME.getIntGlobal())
-              .apply();
-    }
-
-    if (IntSetting.MAIN_INTERFACE_THEME_MODE.getIntGlobal() !=
-            preferences.getInt(ThemeHelper.CURRENT_THEME_MODE,
-                    AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM))
-    {
-      preferences.edit()
-              .putInt(ThemeHelper.CURRENT_THEME_MODE,
-                      IntSetting.MAIN_INTERFACE_THEME_MODE.getIntGlobal())
-              .apply();
-    }
+    checkThemeSettings(context);
 
     if (wiimoteIniWritten)
     {
@@ -416,6 +400,37 @@ public final class DirectoryInitialization
       return false;
 
     return preferLegacyUserDirectory(context) && !PermissionsHandler.hasWriteAccess(context);
+  }
+
+  private static void checkThemeSettings(Context context)
+  {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    if (IntSetting.MAIN_INTERFACE_THEME.getIntGlobal() !=
+            preferences.getInt(ThemeHelper.CURRENT_THEME, ThemeHelper.DEFAULT))
+    {
+      preferences.edit()
+              .putInt(ThemeHelper.CURRENT_THEME, IntSetting.MAIN_INTERFACE_THEME.getIntGlobal())
+              .apply();
+    }
+
+    if (IntSetting.MAIN_INTERFACE_THEME_MODE.getIntGlobal() !=
+            preferences.getInt(ThemeHelper.CURRENT_THEME_MODE,
+                    AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM))
+    {
+      preferences.edit()
+              .putInt(ThemeHelper.CURRENT_THEME_MODE,
+                      IntSetting.MAIN_INTERFACE_THEME_MODE.getIntGlobal())
+              .apply();
+    }
+
+    if (BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.getBooleanGlobal() !=
+            preferences.getBoolean(ThemeHelper.USE_BLACK_BACKGROUNDS, false))
+    {
+      preferences.edit()
+              .putBoolean(ThemeHelper.USE_BLACK_BACKGROUNDS,
+                      BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.getBooleanGlobal())
+              .apply();
+    }
   }
 
   private static native void CreateUserDirectories();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ThemeHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ThemeHelper.java
@@ -27,6 +27,7 @@ public class ThemeHelper
 {
   public static final String CURRENT_THEME = "current_theme";
   public static final String CURRENT_THEME_MODE = "current_theme_mode";
+  public static final String USE_BLACK_BACKGROUNDS = "use_black_backgrounds";
 
   public static final int DEFAULT = 0;
   public static final int MONET = 1;
@@ -64,6 +65,11 @@ public class ThemeHelper
       case PINK:
         activity.setTheme(R.style.Theme_Dolphin_Main_Pink);
         break;
+    }
+
+    if (preferences.getBoolean(USE_BLACK_BACKGROUNDS, false))
+    {
+      activity.setTheme(R.style.ThemeOverlay_Dolphin_Dark);
     }
 
     // Since the top app bar matches the color of the status bar, devices below API 23 have to get a
@@ -155,6 +161,24 @@ public class ThemeHelper
             .remove(CURRENT_THEME_MODE)
             .apply();
     setThemeMode(activity);
+  }
+
+  public static void saveBackgroundSetting(AppCompatActivity activity, boolean backgroundValue)
+  {
+    PreferenceManager.getDefaultSharedPreferences(activity.getApplicationContext())
+            .edit()
+            .putBoolean(USE_BLACK_BACKGROUNDS, backgroundValue)
+            .apply();
+    activity.recreate();
+  }
+
+  public static void deleteBackgroundSetting(AppCompatActivity activity)
+  {
+    PreferenceManager.getDefaultSharedPreferences(activity.getApplicationContext())
+            .edit()
+            .remove(USE_BLACK_BACKGROUNDS)
+            .apply();
+    activity.recreate();
   }
 
   public static void setCorrectTheme(AppCompatActivity activity)

--- a/Source/Android/app/src/main/res/values-night/themes.xml
+++ b/Source/Android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="ThemeOverlay.Dolphin.Dark" parent="">
+        <item name="colorSurface">@color/background_black</item>
+        <item name="android:colorBackground">@color/background_black</item>
+    </style>
+</resources>

--- a/Source/Android/app/src/main/res/values/dolphin_colors.xml
+++ b/Source/Android/app/src/main/res/values/dolphin_colors.xml
@@ -39,4 +39,6 @@
     <color name="tv_card_unselected">#444444</color>
 
     <color name="invalid_setting_overlay">#36ff0000</color>
+
+    <color name="background_black">#000000</color>
 </resources>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -197,6 +197,8 @@
     <string name="show_titles_in_game_list_description">Show the title and creator below each game cover.</string>
     <string name="change_theme">Change App Theme</string>
     <string name="change_theme_mode">Change Theme Mode</string>
+    <string name="use_black_backgrounds">Use Black Backgrounds</string>
+    <string name="use_black_backgrounds_description">When using the dark theme, apply black backgrounds.</string>
 
     <!-- Online Update Region Select Fragment -->
     <string name="region_select_title">Please select a region</string>

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -39,12 +39,12 @@ bool IsSettingSaveable(const Config::Location& config_location)
     // TODO: Kill the current Android controller mappings system
     if (config_location.section == "Android")
     {
-      static constexpr std::array<const char*, 13> android_setting_saveable = {
-          "ControlScale",      "ControlOpacity",   "EmulationOrientation",
-          "JoystickRelCenter", "LastPlatformTab",  "MotionControls",
-          "PhoneRumble",       "ShowInputOverlay", "IRMode",
-          "IRAlwaysRecenter",  "ShowGameTitles",   "InterfaceTheme",
-          "InterfaceThemeMode"};
+      static constexpr std::array<const char*, 14> android_setting_saveable = {
+          "ControlScale",       "ControlOpacity",     "EmulationOrientation",
+          "JoystickRelCenter",  "LastPlatformTab",    "MotionControls",
+          "PhoneRumble",        "ShowInputOverlay",   "IRMode",
+          "IRAlwaysRecenter",   "ShowGameTitles",     "InterfaceTheme",
+          "InterfaceThemeMode", "UseBlackBackgrounds"};
 
       return std::any_of(
           android_setting_saveable.cbegin(), android_setting_saveable.cend(),


### PR DESCRIPTION
Makes all background colors black in dark mode when enabled through a ThemeOverlay. Applied the same way as a theme/mode.

Demo - 
![background-demo](https://user-images.githubusercontent.com/14132249/205533645-256dbffd-9b9d-4cf0-ab3a-21b977f4bd6b.gif)
