### PR TITLE
Externals: Update MoltenVK to 1.2.1

### DIFF
--- a/Externals/MoltenVK/CMakeLists.txt
+++ b/Externals/MoltenVK/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(MOLTENVK_VERSION "v1.2.0")
+set(MOLTENVK_VERSION "v1.2.1")
 
 ExternalProject_Add(MoltenVK
   GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git


### PR DESCRIPTION
The MoltenVK changelog can be found [here](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.1).