### PR TITLE
Android: Replace Checkbox with MaterialSwitch

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -575,7 +575,7 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
     int id = wii ? R.menu.menu_overlay_controls_wii : R.menu.menu_overlay_controls_gc;
     popup.getMenuInflater().inflate(id, menu);
 
-    // Populate the checkbox value for joystick center on touch
+    // Populate the switch value for joystick center on touch
     menu.findItem(R.id.menu_emulation_joystick_rel_center)
             .setChecked(BooleanSetting.MAIN_JOYSTICK_REL_CENTER.getBoolean(mSettings));
     menu.findItem(R.id.menu_emulation_rumble)
@@ -599,7 +599,7 @@ public final class EmulationActivity extends AppCompatActivity implements ThemeP
     {
       if (item.isCheckable())
       {
-        // Need to pass a reference to the item to set the checkbox state, since it is not done automatically
+        // Need to pass a reference to the item to set the switch state, since it is not done automatically
         handleCheckableMenuAction(action, item);
       }
       else

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/cheats/ui/CheatViewHolder.java
@@ -3,9 +3,7 @@
 package org.dolphinemu.dolphinemu.features.cheats.ui;
 
 import android.view.View;
-import android.widget.CheckBox;
 import android.widget.CompoundButton;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModelProvider;
@@ -31,17 +29,17 @@ public class CheatViewHolder extends CheatItemViewHolder
 
   public void bind(CheatsActivity activity, CheatItem item, int position)
   {
-    mBinding.checkbox.setOnCheckedChangeListener(null);
+    mBinding.cheatSwitch.setOnCheckedChangeListener(null);
 
     mViewModel = new ViewModelProvider(activity).get(CheatsViewModel.class);
     mCheat = item.getCheat();
     mPosition = position;
 
     mBinding.textName.setText(mCheat.getName());
-    mBinding.checkbox.setChecked(mCheat.getEnabled());
+    mBinding.cheatSwitch.setChecked(mCheat.getEnabled());
 
     mBinding.root.setOnClickListener(this);
-    mBinding.checkbox.setOnCheckedChangeListener(this);
+    mBinding.cheatSwitch.setOnCheckedChangeListener(this);
   }
 
   public void onClick(View root)
@@ -53,6 +51,5 @@ public class CheatViewHolder extends CheatItemViewHolder
   public void onCheckedChanged(CompoundButton buttonView, boolean isChecked)
   {
     mCheat.setEnabled(isChecked);
-    mViewModel.notifyCheatChanged(mPosition);
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/InvertedSwitchSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/InvertedSwitchSetting.java
@@ -8,9 +8,9 @@ import org.dolphinemu.dolphinemu.features.settings.model.AbstractBooleanSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.AbstractSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 
-public final class InvertedCheckBoxSetting extends CheckBoxSetting
+public final class InvertedSwitchSetting extends SwitchSetting
 {
-  public InvertedCheckBoxSetting(Context context, AbstractBooleanSetting setting, int titleId,
+  public InvertedSwitchSetting(Context context, AbstractBooleanSetting setting, int titleId,
           int descriptionId)
   {
     super(context, setting, titleId, descriptionId);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/LogSwitchSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/LogSwitchSetting.java
@@ -5,11 +5,11 @@ package org.dolphinemu.dolphinemu.features.settings.model.view;
 import org.dolphinemu.dolphinemu.features.settings.model.AdHocBooleanSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 
-public class LogCheckBoxSetting extends CheckBoxSetting
+public class LogSwitchSetting extends SwitchSetting
 {
   String mKey;
 
-  public LogCheckBoxSetting(String key, CharSequence title, CharSequence description)
+  public LogSwitchSetting(String key, CharSequence title, CharSequence description)
   {
     super(new AdHocBooleanSetting(Settings.FILE_LOGGER, Settings.SECTION_LOGGER_LOGS, key, false),
             title, description);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.java
@@ -17,7 +17,7 @@ import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
 public abstract class SettingsItem
 {
   public static final int TYPE_HEADER = 0;
-  public static final int TYPE_CHECKBOX = 1;
+  public static final int TYPE_SWITCH = 1;
   public static final int TYPE_SINGLE_CHOICE = 2;
   public static final int TYPE_SLIDER = 3;
   public static final int TYPE_SUBMENU = 4;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SwitchSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SwitchSetting.java
@@ -8,18 +8,18 @@ import org.dolphinemu.dolphinemu.features.settings.model.AbstractBooleanSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.AbstractSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 
-public class CheckBoxSetting extends SettingsItem
+public class SwitchSetting extends SettingsItem
 {
   protected AbstractBooleanSetting mSetting;
 
-  public CheckBoxSetting(Context context, AbstractBooleanSetting setting, int titleId,
+  public SwitchSetting(Context context, AbstractBooleanSetting setting, int titleId,
           int descriptionId)
   {
     super(context, titleId, descriptionId);
     mSetting = setting;
   }
 
-  public CheckBoxSetting(AbstractBooleanSetting setting, CharSequence title,
+  public SwitchSetting(AbstractBooleanSetting setting, CharSequence title,
           CharSequence description)
   {
     super(title, description);
@@ -39,7 +39,7 @@ public class CheckBoxSetting extends SettingsItem
   @Override
   public int getType()
   {
-    return TYPE_CHECKBOX;
+    return TYPE_SWITCH;
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -30,11 +30,11 @@ import org.dolphinemu.dolphinemu.databinding.DialogInputStringBinding;
 import org.dolphinemu.dolphinemu.databinding.DialogSliderBinding;
 import org.dolphinemu.dolphinemu.databinding.ListItemHeaderBinding;
 import org.dolphinemu.dolphinemu.databinding.ListItemSettingBinding;
-import org.dolphinemu.dolphinemu.databinding.ListItemSettingCheckboxBinding;
+import org.dolphinemu.dolphinemu.databinding.ListItemSettingSwitchBinding;
 import org.dolphinemu.dolphinemu.databinding.ListItemSubmenuBinding;
 import org.dolphinemu.dolphinemu.dialogs.MotionAlertDialog;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
-import org.dolphinemu.dolphinemu.features.settings.model.view.CheckBoxSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.view.SwitchSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.FilePicker;
 import org.dolphinemu.dolphinemu.features.settings.model.view.FloatSliderSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.InputBindingSetting;
@@ -47,7 +47,6 @@ import org.dolphinemu.dolphinemu.features.settings.model.view.SliderSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.InputStringSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.StringSingleChoiceSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.SubmenuSetting;
-import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.CheckBoxSettingViewHolder;
 import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.FilePickerViewHolder;
 import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.HeaderHyperLinkViewHolder;
 import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.HeaderViewHolder;
@@ -59,6 +58,7 @@ import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.SettingViewHold
 import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.SingleChoiceViewHolder;
 import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.SliderViewHolder;
 import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.SubmenuViewHolder;
+import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.SwitchSettingViewHolder;
 import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 import org.dolphinemu.dolphinemu.utils.Log;
@@ -100,8 +100,8 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
       case SettingsItem.TYPE_HEADER:
         return new HeaderViewHolder(ListItemHeaderBinding.inflate(inflater), this);
 
-      case SettingsItem.TYPE_CHECKBOX:
-        return new CheckBoxSettingViewHolder(ListItemSettingCheckboxBinding.inflate(inflater),
+      case SettingsItem.TYPE_SWITCH:
+        return new SwitchSettingViewHolder(ListItemSettingSwitchBinding.inflate(inflater),
                 this);
 
       case SettingsItem.TYPE_STRING_SINGLE_CHOICE:
@@ -181,10 +181,9 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     notifyDataSetChanged();
   }
 
-  public void clearSetting(SettingsItem item, int position)
+  public void clearSetting(SettingsItem item)
   {
     item.clear(getSettings());
-    notifyItemChanged(position);
 
     mView.onSettingChanged();
   }
@@ -196,10 +195,9 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     mView.onSettingChanged();
   }
 
-  public void onBooleanClick(CheckBoxSetting item, int position, boolean checked)
+  public void onBooleanClick(SwitchSetting item, boolean checked)
   {
     item.setChecked(getSettings(), checked);
-    notifyItemChanged(position);
 
     mView.onSettingChanged();
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -24,15 +24,15 @@ import org.dolphinemu.dolphinemu.features.settings.model.PostProcessing;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.model.StringSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.WiimoteProfileStringSetting;
-import org.dolphinemu.dolphinemu.features.settings.model.view.CheckBoxSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.view.SwitchSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.FilePicker;
 import org.dolphinemu.dolphinemu.features.settings.model.view.HeaderSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.HyperLinkHeaderSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.InputBindingSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.InputStringSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.IntSliderSetting;
-import org.dolphinemu.dolphinemu.features.settings.model.view.InvertedCheckBoxSetting;
-import org.dolphinemu.dolphinemu.features.settings.model.view.LogCheckBoxSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.view.InvertedSwitchSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.view.LogSwitchSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.PercentSliderSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.RumbleBindingSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.RunRunnable;
@@ -278,24 +278,24 @@ public final class SettingsFragmentPresenter
 
   private void addGeneralSettings(ArrayList<SettingsItem> sl)
   {
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_CPU_THREAD, R.string.dual_core,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_CPU_THREAD, R.string.dual_core,
             R.string.dual_core_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_ENABLE_CHEATS, R.string.enable_cheats,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_ENABLE_CHEATS, R.string.enable_cheats,
             0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_OVERRIDE_REGION_SETTINGS,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_OVERRIDE_REGION_SETTINGS,
             R.string.override_region_settings, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_AUTO_DISC_CHANGE,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_AUTO_DISC_CHANGE,
             R.string.auto_disc_change, 0));
     sl.add(new PercentSliderSetting(mContext, FloatSetting.MAIN_EMULATION_SPEED,
             R.string.speed_limit, 0, 0, 200, "%"));
     sl.add(new SingleChoiceSetting(mContext, IntSetting.MAIN_FALLBACK_REGION,
             R.string.fallback_region, 0, R.array.regionEntries, R.array.regionValues));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_ANALYTICS_ENABLED, R.string.analytics,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_ANALYTICS_ENABLED, R.string.analytics,
             0));
     sl.add(new RunRunnable(mContext, R.string.analytics_new_id, 0,
             R.string.analytics_new_id_confirmation, 0, true,
             NativeLibrary::GenerateNewStatisticsId));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_ENABLE_SAVESTATES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_ENABLE_SAVESTATES,
             R.string.enable_save_states, R.string.enable_save_states_description));
   }
 
@@ -315,17 +315,17 @@ public final class SettingsFragmentPresenter
     // Only android 9+ supports this feature.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
     {
-      sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_EXPAND_TO_CUTOUT_AREA,
+      sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_EXPAND_TO_CUTOUT_AREA,
               R.string.expand_to_cutout_area, R.string.expand_to_cutout_area_description));
     }
 
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_USE_PANIC_HANDLERS,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_USE_PANIC_HANDLERS,
             R.string.panic_handlers, R.string.panic_handlers_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_OSD_MESSAGES, R.string.osd_messages,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_OSD_MESSAGES, R.string.osd_messages,
             R.string.osd_messages_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_USE_GAME_COVERS,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_USE_GAME_COVERS,
             R.string.download_game_covers, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_SHOW_GAME_TITLES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_SHOW_GAME_TITLES,
             R.string.show_titles_in_game_list, R.string.show_titles_in_game_list_description));
 
     AbstractIntSetting appTheme = new AbstractIntSetting()
@@ -499,7 +499,7 @@ public final class SettingsFragmentPresenter
     }
     sl.add(new SingleChoiceSetting(mContext, dspEmulationEngine, R.string.dsp_emulation_engine, 0,
             dspEngineEntries, dspEngineValues));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_AUDIO_STRETCH, R.string.audio_stretch,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_AUDIO_STRETCH, R.string.audio_stretch,
             R.string.audio_stretch_description));
     sl.add(new IntSliderSetting(mContext, IntSetting.MAIN_AUDIO_VOLUME, R.string.audio_volume, 0,
             0, 100, "%"));
@@ -507,7 +507,7 @@ public final class SettingsFragmentPresenter
 
   private void addPathsSettings(ArrayList<SettingsItem> sl)
   {
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_RECURSIVE_ISO_PATHS,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_RECURSIVE_ISO_PATHS,
             R.string.search_subfolders, 0));
     sl.add(new FilePicker(mContext, StringSetting.MAIN_DEFAULT_ISO, R.string.default_ISO, 0,
             MainPresenter.REQUEST_GAME_FILE, null));
@@ -542,21 +542,21 @@ public final class SettingsFragmentPresenter
     sl.add(new HeaderSetting(mContext, R.string.wii_misc_settings, 0));
     sl.add(new SingleChoiceSetting(mContext, IntSetting.SYSCONF_LANGUAGE, R.string.system_language,
             0, R.array.wiiSystemLanguageEntries, R.array.wiiSystemLanguageValues));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.SYSCONF_WIDESCREEN, R.string.wii_widescreen,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.SYSCONF_WIDESCREEN, R.string.wii_widescreen,
             R.string.wii_widescreen_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.SYSCONF_PAL60, R.string.wii_pal60,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.SYSCONF_PAL60, R.string.wii_pal60,
             R.string.wii_pal60_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.SYSCONF_SCREENSAVER,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.SYSCONF_SCREENSAVER,
             R.string.wii_screensaver, R.string.wii_screensaver_description));
     sl.add(new SingleChoiceSetting(mContext, IntSetting.SYSCONF_SOUND_MODE, R.string.sound_mode, 0,
             R.array.soundModeEntries, R.array.soundModeValues));
 
     sl.add(new HeaderSetting(mContext, R.string.wii_sd_card_settings, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_WII_SD_CARD, R.string.insert_sd_card,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_WII_SD_CARD, R.string.insert_sd_card,
             R.string.insert_sd_card_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_ALLOW_SD_WRITES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_ALLOW_SD_WRITES,
             R.string.wii_sd_card_allow_writes, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_WII_SD_CARD_ENABLE_FOLDER_SYNC,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_WII_SD_CARD_ENABLE_FOLDER_SYNC,
             R.string.wii_sd_card_sync, R.string.wii_sd_card_sync_description));
     // TODO: Hardcoding "Load" here is wrong, because the user may have changed the Load path.
     // The code structure makes this hard to fix, and with scoped storage active the Load path
@@ -573,7 +573,7 @@ public final class SettingsFragmentPresenter
             () -> convertOnThread(WiiUtils::syncSdImageToSdFolder)));
 
     sl.add(new HeaderSetting(mContext, R.string.wii_wiimote_settings, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.SYSCONF_WIIMOTE_MOTOR,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.SYSCONF_WIIMOTE_MOTOR,
             R.string.wiimote_rumble, 0));
     sl.add(new IntSliderSetting(mContext, IntSetting.SYSCONF_SPEAKER_VOLUME,
             R.string.wiimote_volume, 0, 0, 127, ""));
@@ -582,9 +582,9 @@ public final class SettingsFragmentPresenter
     sl.add(new SingleChoiceSetting(mContext, IntSetting.SYSCONF_SENSOR_BAR_POSITION,
             R.string.sensor_bar_position, 0, R.array.sensorBarPositionEntries,
             R.array.sensorBarPositionValues));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_WIIMOTE_CONTINUOUS_SCANNING,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_WIIMOTE_CONTINUOUS_SCANNING,
             R.string.wiimote_scanning, R.string.wiimote_scanning_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_WIIMOTE_ENABLE_SPEAKER,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_WIIMOTE_ENABLE_SPEAKER,
             R.string.wiimote_speaker, R.string.wiimote_speaker_description));
   }
 
@@ -678,9 +678,9 @@ public final class SettingsFragmentPresenter
     }
     sl.add(new SingleChoiceSetting(mContext, IntSetting.MAIN_CPU_CORE, R.string.cpu_core, 0,
             emuCoresEntries, emuCoresValues));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_MMU, R.string.mmu_enable,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_MMU, R.string.mmu_enable,
             R.string.mmu_enable_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_OVERCLOCK_ENABLE,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_OVERCLOCK_ENABLE,
             R.string.overclock_enable, R.string.overclock_enable_description));
     sl.add(new PercentSliderSetting(mContext, FloatSetting.MAIN_OVERCLOCK, R.string.overclock_title,
             R.string.overclock_title_description, 0, 400, "%"));
@@ -733,13 +733,13 @@ public final class SettingsFragmentPresenter
     sl.add(new HeaderSetting(mContext, R.string.graphics_general, 0));
     sl.add(new StringSingleChoiceSetting(mContext, StringSetting.MAIN_GFX_BACKEND,
             R.string.video_backend, 0, R.array.videoBackendEntries, R.array.videoBackendValues));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_SHOW_FPS, R.string.show_fps,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_FPS, R.string.show_fps,
             R.string.show_fps_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_SHOW_VPS, R.string.show_vps,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_VPS, R.string.show_vps,
             R.string.show_vps_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_SHOW_SPEED, R.string.show_speed,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_SPEED, R.string.show_speed,
             R.string.show_speed_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_SHOW_SPEED_COLORS,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_SPEED_COLORS,
             R.string.show_speed_colors,
             R.string.show_speed_colors_description));
     sl.add(new SingleChoiceSettingDynamicDescriptions(mContext,
@@ -747,7 +747,7 @@ public final class SettingsFragmentPresenter
             R.array.shaderCompilationModeEntries, R.array.shaderCompilationModeValues,
             R.array.shaderCompilationDescriptionEntries,
             R.array.shaderCompilationDescriptionValues));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_WAIT_FOR_SHADERS_BEFORE_STARTING,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_WAIT_FOR_SHADERS_BEFORE_STARTING,
             R.string.wait_for_shaders, R.string.wait_for_shaders_description));
     sl.add(new SingleChoiceSetting(mContext, IntSetting.GFX_ASPECT_RATIO, R.string.aspect_ratio, 0,
             R.array.aspectRatioEntries, R.array.aspectRatioValues));
@@ -786,21 +786,21 @@ public final class SettingsFragmentPresenter
     sl.add(new StringSingleChoiceSetting(mContext, StringSetting.GFX_ENHANCE_POST_SHADER,
             R.string.post_processing_shader, 0, shaderListEntries, shaderListValues));
 
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_COPY_EFB_SCALED,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HACK_COPY_EFB_SCALED,
             R.string.scaled_efb_copy, R.string.scaled_efb_copy_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENABLE_PIXEL_LIGHTING,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_ENABLE_PIXEL_LIGHTING,
             R.string.per_pixel_lighting, R.string.per_pixel_lighting_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENHANCE_FORCE_FILTERING,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_ENHANCE_FORCE_FILTERING,
             R.string.force_texture_filtering, R.string.force_texture_filtering_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENHANCE_FORCE_TRUE_COLOR,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_ENHANCE_FORCE_TRUE_COLOR,
             R.string.force_24bit_color, R.string.force_24bit_color_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_DISABLE_FOG, R.string.disable_fog,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_DISABLE_FOG, R.string.disable_fog,
             R.string.disable_fog_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENHANCE_DISABLE_COPY_FILTER,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_ENHANCE_DISABLE_COPY_FILTER,
             R.string.disable_copy_filter, R.string.disable_copy_filter_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION,
             R.string.arbitrary_mipmap_detection, R.string.arbitrary_mipmap_detection_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_WIDESCREEN_HACK,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_WIDESCREEN_HACK,
             R.string.wide_screen_hack, R.string.wide_screen_hack_description));
 
     // Check if we support stereo
@@ -819,94 +819,94 @@ public final class SettingsFragmentPresenter
   private void addHackSettings(ArrayList<SettingsItem> sl)
   {
     sl.add(new HeaderSetting(mContext, R.string.embedded_frame_buffer, 0));
-    sl.add(new InvertedCheckBoxSetting(mContext, BooleanSetting.GFX_HACK_EFB_ACCESS_ENABLE,
+    sl.add(new InvertedSwitchSetting(mContext, BooleanSetting.GFX_HACK_EFB_ACCESS_ENABLE,
             R.string.skip_efb_access, R.string.skip_efb_access_description));
-    sl.add(new InvertedCheckBoxSetting(mContext, BooleanSetting.GFX_HACK_EFB_EMULATE_FORMAT_CHANGES,
+    sl.add(new InvertedSwitchSetting(mContext, BooleanSetting.GFX_HACK_EFB_EMULATE_FORMAT_CHANGES,
             R.string.ignore_format_changes, R.string.ignore_format_changes_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_SKIP_EFB_COPY_TO_RAM,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HACK_SKIP_EFB_COPY_TO_RAM,
             R.string.efb_copy_method, R.string.efb_copy_method_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_DEFER_EFB_COPIES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HACK_DEFER_EFB_COPIES,
             R.string.defer_efb_copies, R.string.defer_efb_copies_description));
 
     sl.add(new HeaderSetting(mContext, R.string.texture_cache, 0));
     sl.add(new SingleChoiceSetting(mContext, IntSetting.GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES,
             R.string.texture_cache_accuracy, R.string.texture_cache_accuracy_description,
             R.array.textureCacheAccuracyEntries, R.array.textureCacheAccuracyValues));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENABLE_GPU_TEXTURE_DECODING,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_ENABLE_GPU_TEXTURE_DECODING,
             R.string.gpu_texture_decoding, R.string.gpu_texture_decoding_description));
 
     sl.add(new HeaderSetting(mContext, R.string.external_frame_buffer, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_SKIP_XFB_COPY_TO_RAM,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HACK_SKIP_XFB_COPY_TO_RAM,
             R.string.xfb_copy_method, R.string.xfb_copy_method_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_IMMEDIATE_XFB,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HACK_IMMEDIATE_XFB,
             R.string.immediate_xfb, R.string.immediate_xfb_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_SKIP_DUPLICATE_XFBS,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HACK_SKIP_DUPLICATE_XFBS,
             R.string.skip_duplicate_xfbs, R.string.skip_duplicate_xfbs_description));
 
     sl.add(new HeaderSetting(mContext, R.string.other, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_FAST_DEPTH_CALC,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_FAST_DEPTH_CALC,
             R.string.fast_depth_calculation, R.string.fast_depth_calculation_description));
-    sl.add(new InvertedCheckBoxSetting(mContext, BooleanSetting.GFX_HACK_BBOX_ENABLE,
+    sl.add(new InvertedSwitchSetting(mContext, BooleanSetting.GFX_HACK_BBOX_ENABLE,
             R.string.disable_bbox, R.string.disable_bbox_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_VERTEX_ROUNDING,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HACK_VERTEX_ROUNDING,
             R.string.vertex_rounding, R.string.vertex_rounding_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_SAVE_TEXTURE_CACHE_TO_STATE,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SAVE_TEXTURE_CACHE_TO_STATE,
             R.string.texture_cache_to_state, R.string.texture_cache_to_state_description));
   }
 
   private void addAdvancedGraphicsSettings(ArrayList<SettingsItem> sl)
   {
     sl.add(new HeaderSetting(mContext, R.string.gfx_mods_and_custom_textures, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_MODS_ENABLE,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_MODS_ENABLE,
             R.string.gfx_mods, R.string.gfx_mods_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HIRES_TEXTURES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HIRES_TEXTURES,
             R.string.load_custom_texture, R.string.load_custom_texture_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_CACHE_HIRES_TEXTURES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_CACHE_HIRES_TEXTURES,
             R.string.cache_custom_texture, R.string.cache_custom_texture_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_DUMP_TEXTURES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_DUMP_TEXTURES,
             R.string.dump_texture, R.string.dump_texture_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_DUMP_BASE_TEXTURES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_DUMP_BASE_TEXTURES,
             R.string.dump_base_texture, R.string.dump_base_texture_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_DUMP_MIP_TEXTURES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_DUMP_MIP_TEXTURES,
             R.string.dump_mip_texture, R.string.dump_mip_texture_description));
 
     sl.add(new HeaderSetting(mContext, R.string.misc, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_CROP, R.string.crop,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_CROP, R.string.crop,
             R.string.crop_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.SYSCONF_PROGRESSIVE_SCAN,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.SYSCONF_PROGRESSIVE_SCAN,
             R.string.progressive_scan, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_BACKEND_MULTITHREADING,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_BACKEND_MULTITHREADING,
             R.string.backend_multithreading, R.string.backend_multithreading_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION,
             R.string.prefer_vs_for_point_line_expansion,
             R.string.prefer_vs_for_point_line_expansion_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_EFB_DEFER_INVALIDATION,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HACK_EFB_DEFER_INVALIDATION,
             R.string.defer_efb_invalidation, R.string.defer_efb_invalidation_description));
-    sl.add(new InvertedCheckBoxSetting(mContext, BooleanSetting.GFX_HACK_FAST_TEXTURE_SAMPLING,
+    sl.add(new InvertedSwitchSetting(mContext, BooleanSetting.GFX_HACK_FAST_TEXTURE_SAMPLING,
             R.string.manual_texture_sampling, R.string.manual_texture_sampling_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_INTERNAL_RESOLUTION_FRAME_DUMPS,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_INTERNAL_RESOLUTION_FRAME_DUMPS,
             R.string.internal_resolution_dumps, R.string.internal_resolution_dumps_description));
 
     sl.add(new HeaderSetting(mContext, R.string.debugging, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENABLE_WIREFRAME,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_ENABLE_WIREFRAME,
             R.string.wireframe, R.string.leave_this_unchecked));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_OVERLAY_STATS,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_OVERLAY_STATS,
             R.string.show_stats, R.string.leave_this_unchecked));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_TEXFMT_OVERLAY_ENABLE,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_TEXFMT_OVERLAY_ENABLE,
             R.string.texture_format, R.string.leave_this_unchecked));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENABLE_VALIDATION_LAYER,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_ENABLE_VALIDATION_LAYER,
             R.string.validation_layer, R.string.leave_this_unchecked));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_DUMP_EFB_TARGET,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_DUMP_EFB_TARGET,
             R.string.dump_efb, R.string.leave_this_unchecked));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_DUMP_XFB_TARGET,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_DUMP_XFB_TARGET,
             R.string.dump_xfb, R.string.leave_this_unchecked));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_HACK_DISABLE_COPY_TO_VRAM,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_HACK_DISABLE_COPY_TO_VRAM,
             R.string.disable_vram_copies, R.string.leave_this_unchecked));
   }
 
   private void addLogConfigurationSettings(ArrayList<SettingsItem> sl)
   {
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.LOGGER_WRITE_TO_FILE, R.string.log_to_file,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.LOGGER_WRITE_TO_FILE, R.string.log_to_file,
             R.string.log_to_file_description));
     sl.add(new SingleChoiceSetting(mContext, IntSetting.LOGGER_VERBOSITY, R.string.log_verbosity, 0,
             getLogVerbosityEntries(), getLogVerbosityValues()));
@@ -920,36 +920,36 @@ public final class SettingsFragmentPresenter
     sl.add(new HeaderSetting(mContext, R.string.log_types, 0));
     for (Map.Entry<String, String> entry : LOG_TYPE_NAMES.entrySet())
     {
-      sl.add(new LogCheckBoxSetting(entry.getKey(), entry.getValue(), ""));
+      sl.add(new LogSwitchSetting(entry.getKey(), entry.getValue(), ""));
     }
   }
 
   private void addDebugSettings(ArrayList<SettingsItem> sl)
   {
     sl.add(new HeaderSetting(mContext, R.string.debug_warning, 0));
-    sl.add(new InvertedCheckBoxSetting(mContext, BooleanSetting.MAIN_FASTMEM,
+    sl.add(new InvertedSwitchSetting(mContext, BooleanSetting.MAIN_FASTMEM,
             R.string.debug_fastmem, 0));
 
     sl.add(new HeaderSetting(mContext, R.string.debug_jit_header, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_OFF, R.string.debug_jitoff,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_OFF, R.string.debug_jitoff,
             0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_LOAD_STORE_OFF,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_LOAD_STORE_OFF,
             R.string.debug_jitloadstoreoff, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_LOAD_STORE_FLOATING_OFF,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_LOAD_STORE_FLOATING_OFF,
             R.string.debug_jitloadstorefloatingoff, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_LOAD_STORE_PAIRED_OFF,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_LOAD_STORE_PAIRED_OFF,
             R.string.debug_jitloadstorepairedoff, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_FLOATING_POINT_OFF,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_FLOATING_POINT_OFF,
             R.string.debug_jitfloatingpointoff, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_INTEGER_OFF,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_INTEGER_OFF,
             R.string.debug_jitintegeroff, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_PAIRED_OFF,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_PAIRED_OFF,
             R.string.debug_jitpairedoff, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_SYSTEM_REGISTERS_OFF,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_SYSTEM_REGISTERS_OFF,
             R.string.debug_jitsystemregistersoff, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_BRANCH_OFF,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_BRANCH_OFF,
             R.string.debug_jitbranchoff, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_REGISTER_CACHE_OFF,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_DEBUG_JIT_REGISTER_CACHE_OFF,
             R.string.debug_jitregistercacheoff, 0));
   }
 
@@ -962,7 +962,7 @@ public final class SettingsFragmentPresenter
     sl.add(new IntSliderSetting(mContext, IntSetting.GFX_STEREO_CONVERGENCE_PERCENTAGE,
             R.string.stereoscopy_convergence, R.string.stereoscopy_convergence_description, 0, 200,
             "%"));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_STEREO_SWAP_EYES,
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_STEREO_SWAP_EYES,
             R.string.stereoscopy_swap_eyes, R.string.stereoscopy_swap_eyes_description));
   }
 
@@ -1029,9 +1029,9 @@ public final class SettingsFragmentPresenter
     }
     else if (gcPadType == 12) // Adapter
     {
-      sl.add(new CheckBoxSetting(mContext, BooleanSetting.getSettingForAdapterRumble(gcPadNumber),
+      sl.add(new SwitchSetting(mContext, BooleanSetting.getSettingForAdapterRumble(gcPadNumber),
               R.string.gc_adapter_rumble, R.string.gc_adapter_rumble_description));
-      sl.add(new CheckBoxSetting(mContext, BooleanSetting.getSettingForSimulateKonga(gcPadNumber),
+      sl.add(new SwitchSetting(mContext, BooleanSetting.getSettingForSimulateKonga(gcPadNumber),
               R.string.gc_adapter_bongos, R.string.gc_adapter_bongos_description));
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SettingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SettingViewHolder.java
@@ -92,7 +92,7 @@ public abstract class SettingViewHolder extends RecyclerView.ViewHolder
             .setMessage(R.string.setting_clear_confirm)
             .setPositiveButton(R.string.ok, (dialog, whichButton) ->
             {
-              getAdapter().clearSetting(item, getBindingAdapterPosition());
+              getAdapter().clearSetting(item);
               bind(item);
               Toast.makeText(context, R.string.setting_cleared, Toast.LENGTH_SHORT).show();
               dialog.dismiss();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SwitchSettingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SwitchSettingViewHolder.java
@@ -6,18 +6,18 @@ import android.view.View;
 
 import androidx.annotation.Nullable;
 
-import org.dolphinemu.dolphinemu.databinding.ListItemSettingCheckboxBinding;
-import org.dolphinemu.dolphinemu.features.settings.model.view.CheckBoxSetting;
+import org.dolphinemu.dolphinemu.databinding.ListItemSettingSwitchBinding;
+import org.dolphinemu.dolphinemu.features.settings.model.view.SwitchSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem;
 import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
 
-public final class CheckBoxSettingViewHolder extends SettingViewHolder
+public final class SwitchSettingViewHolder extends SettingViewHolder
 {
-  private CheckBoxSetting mItem;
+  private SwitchSetting mItem;
 
-  private final ListItemSettingCheckboxBinding mBinding;
+  private final ListItemSettingSwitchBinding mBinding;
 
-  public CheckBoxSettingViewHolder(ListItemSettingCheckboxBinding binding, SettingsAdapter adapter)
+  public SwitchSettingViewHolder(ListItemSettingSwitchBinding binding, SettingsAdapter adapter)
   {
     super(binding.getRoot(), adapter);
     mBinding = binding;
@@ -26,12 +26,12 @@ public final class CheckBoxSettingViewHolder extends SettingViewHolder
   @Override
   public void bind(SettingsItem item)
   {
-    mItem = (CheckBoxSetting) item;
+    mItem = (SwitchSetting) item;
 
     mBinding.textSettingName.setText(item.getName());
     mBinding.textSettingDescription.setText(item.getDescription());
 
-    mBinding.checkbox.setChecked(mItem.isChecked(getAdapter().getSettings()));
+    mBinding.settingSwitch.setChecked(mItem.isChecked(getAdapter().getSettings()));
 
     setStyle(mBinding.textSettingName, mItem);
   }
@@ -45,9 +45,9 @@ public final class CheckBoxSettingViewHolder extends SettingViewHolder
       return;
     }
 
-    mBinding.checkbox.toggle();
+    mBinding.settingSwitch.toggle();
 
-    getAdapter().onBooleanClick(mItem, getBindingAdapterPosition(), mBinding.checkbox.isChecked());
+    getAdapter().onBooleanClick(mItem, mBinding.settingSwitch.isChecked());
 
     setStyle(mBinding.textSettingName, mItem);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/ConvertFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/ConvertFragment.java
@@ -181,7 +181,7 @@ public class ConvertFragment extends Fragment implements View.OnClickListener
       setDropdownSelection(mBinding.dropdownCompressionLevel, mCompressionLevel,
               savedInstanceState.getInt(KEY_COMPRESSION_LEVEL));
 
-      mBinding.checkboxRemoveJunkData.setChecked(
+      mBinding.switchRemoveJunkData.setChecked(
               savedInstanceState.getBoolean(KEY_REMOVE_JUNK_DATA));
     }
   }
@@ -194,7 +194,7 @@ public class ConvertFragment extends Fragment implements View.OnClickListener
     outState.putInt(KEY_COMPRESSION, mCompression.getPosition());
     outState.putInt(KEY_COMPRESSION_LEVEL, mCompressionLevel.getPosition());
 
-    outState.putBoolean(KEY_REMOVE_JUNK_DATA, mBinding.checkboxRemoveJunkData.isChecked());
+    outState.putBoolean(KEY_REMOVE_JUNK_DATA, mBinding.switchRemoveJunkData.isChecked());
   }
 
   private void setDropdownSelection(MaterialAutoCompleteTextView dropdown,
@@ -365,15 +365,15 @@ public class ConvertFragment extends Fragment implements View.OnClickListener
     boolean scrubbingAllowed = mFormat.getValue(requireContext()) != BLOB_TYPE_RVZ &&
             !gameFile.isDatelDisc();
 
-    mBinding.checkboxRemoveJunkData.setEnabled(scrubbingAllowed);
+    mBinding.switchRemoveJunkData.setEnabled(scrubbingAllowed);
     if (!scrubbingAllowed)
-      mBinding.checkboxRemoveJunkData.setChecked(false);
+      mBinding.switchRemoveJunkData.setChecked(false);
   }
 
   @Override
   public void onClick(View view)
   {
-    boolean scrub = mBinding.checkboxRemoveJunkData.isChecked();
+    boolean scrub = mBinding.switchRemoveJunkData.isChecked();
     int format = mFormat.getValue(requireContext());
 
     Runnable action = this::showSavePrompt;
@@ -478,7 +478,7 @@ public class ConvertFragment extends Fragment implements View.OnClickListener
       boolean success = NativeLibrary.ConvertDiscImage(gameFile.getPath(), outPath,
               gameFile.getPlatform(), mFormat.getValue(context), mBlockSize.getValueOr(context, 0),
               mCompression.getValueOr(context, 0), mCompressionLevel.getValueOr(context, 0),
-              mBinding.checkboxRemoveJunkData.isChecked(), (text, completion) ->
+              mBinding.switchRemoveJunkData.isChecked(), (text, completion) ->
               {
                 requireActivity().runOnUiThread(() ->
                 {

--- a/Source/Android/app/src/main/res/layout-ldrtl/list_item_cheat.xml
+++ b/Source/Android/app/src/main/res/layout-ldrtl/list_item_cheat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Set nextFocusLeft so checkbox functionality is maintained in rtl layouts -->
+<!-- Set nextFocusLeft so switch functionality is maintained in rtl layouts -->
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
@@ -9,27 +9,29 @@
     android:focusable="true"
     android:clickable="true"
     android:background="?android:attr/selectableItemBackground"
-    android:nextFocusLeft="@id/checkbox">
+    android:nextFocusLeft="@id/cheat_switch">
 
     <TextView
         android:id="@+id/text_name"
         style="@style/TextAppearance.MaterialComponents.Headline5"
         android:layout_width="wrap_content"
-        android:layout_height="64dp"
+        android:layout_height="76dp"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
-        android:gravity="center_vertical"
+        android:layout_marginEnd="@dimen/spacing_large"
         android:layout_marginStart="@dimen/spacing_large"
+        android:layout_toStartOf="@+id/cheat_switch"
+        android:gravity="center_vertical|end"
         android:textSize="16sp"
         tools:text="Hyrule Field Speed Hack" />
 
-    <CheckBox
-        android:id="@+id/checkbox"
+    <com.google.android.material.materialswitch.MaterialSwitch
+        android:id="@+id/cheat_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
-        android:layout_marginEnd="@dimen/spacing_small"
+        android:layout_marginEnd="24dp"
         android:focusable="true"
         android:nextFocusRight="@id/root" />
 

--- a/Source/Android/app/src/main/res/layout/fragment_convert.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_convert.xml
@@ -77,20 +77,23 @@
 
     <TextView
         android:id="@+id/label_remove_junk_data"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="0dp"
+        android:layout_marginStart="@dimen/spacing_small"
+        android:layout_marginEnd="@dimen/spacing_large"
         android:gravity="center_vertical"
         android:text="@string/convert_remove_junk_data"
-        android:layout_marginStart="@dimen/spacing_small"
-        app:layout_constraintTop_toTopOf="@id/checkbox_remove_junk_data"
-        app:layout_constraintBottom_toBottomOf="@id/checkbox_remove_junk_data"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintBottom_toBottomOf="@id/switch_remove_junk_data"
+        app:layout_constraintEnd_toStartOf="@+id/switch_remove_junk_data"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/switch_remove_junk_data" />
 
-    <CheckBox
-        android:id="@+id/checkbox_remove_junk_data"
+    <com.google.android.material.materialswitch.MaterialSwitch
+        android:id="@+id/switch_remove_junk_data"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
+        android:layout_marginEnd="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintTop_toBottomOf="@id/compression_level" />

--- a/Source/Android/app/src/main/res/layout/list_item_cheat.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_cheat.xml
@@ -8,29 +8,29 @@
     android:focusable="true"
     android:clickable="true"
     android:background="?android:attr/selectableItemBackground"
-    android:nextFocusRight="@id/checkbox">
+    android:nextFocusRight="@id/cheat_switch">
 
     <TextView
         android:id="@+id/text_name"
         style="@style/TextAppearance.MaterialComponents.Headline5"
         android:layout_width="wrap_content"
-        android:layout_height="64dp"
+        android:layout_height="76dp"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
         android:layout_marginStart="@dimen/spacing_large"
         android:layout_marginEnd="@dimen/spacing_large"
-        android:layout_toStartOf="@+id/checkbox"
-        android:gravity="center_vertical"
+        android:layout_toStartOf="@id/cheat_switch"
+        android:gravity="center_vertical|start"
         android:textSize="16sp"
         tools:text="Hyrule Field Speed Hack" />
 
-    <CheckBox
-        android:id="@+id/checkbox"
+    <com.google.android.material.materialswitch.MaterialSwitch
+        android:id="@+id/cheat_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
-        android:layout_marginEnd="@dimen/spacing_small"
+        android:layout_marginEnd="20dp"
         android:focusable="true"
         android:nextFocusRight="@id/root" />
 

--- a/Source/Android/app/src/main/res/layout/list_item_setting_switch.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_setting_switch.xml
@@ -16,10 +16,10 @@
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_alignParentTop="true"
-        android:layout_marginEnd="@dimen/spacing_large"
+        android:layout_marginEnd="24dp"
         android:layout_marginStart="@dimen/spacing_large"
         android:layout_marginTop="@dimen/spacing_large"
-        android:layout_toStartOf="@+id/checkbox"
+        android:layout_toStartOf="@+id/setting_switch"
         android:textSize="16sp"
         tools:text="@string/overclock_enable"/>
 
@@ -31,19 +31,19 @@
         android:layout_alignStart="@+id/text_setting_name"
         android:layout_below="@+id/text_setting_name"
         android:layout_marginBottom="@dimen/spacing_large"
-        android:layout_marginEnd="@dimen/spacing_large"
+        android:layout_marginEnd="24dp"
         android:layout_marginStart="@dimen/spacing_large"
         android:layout_marginTop="@dimen/spacing_small"
-        android:layout_toStartOf="@+id/checkbox"
+        android:layout_toStartOf="@+id/setting_switch"
         tools:text="@string/overclock_enable_description"/>
 
-    <CheckBox
-        android:id="@+id/checkbox"
+    <com.google.android.material.materialswitch.MaterialSwitch
+        android:id="@+id/setting_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
-        android:layout_marginEnd="@dimen/spacing_large"
+        android:layout_marginEnd="24dp"
         android:clickable="false"
         android:focusable="false"
         android:minHeight="0dp"


### PR DESCRIPTION
This also removes some unnecessary calls to notifyItemChanged to preserve switch animations/interactions and some layout changes to make the switches avoid system gestures.

<details>

Before - 
![signal-2022-12-10-002719_002](https://user-images.githubusercontent.com/14132249/206830922-a7665e78-da5c-49e4-99a9-b42e7baa8c06.png)


After - 
![signal-2022-12-10-002719_003](https://user-images.githubusercontent.com/14132249/206830918-43656d28-3a10-4a0e-8520-bd99a3247378.png)

</details>