### PR TITLE
Android: fix compile error

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -451,7 +451,7 @@ public final class SettingsFragmentPresenter
       }
     };
 
-    sl.add(new CheckBoxSetting(mContext, blackBackgrounds, R.string.use_black_backgrounds,
+    sl.add(new SwitchSetting(mContext, blackBackgrounds, R.string.use_black_backgrounds,
             R.string.use_black_backgrounds_description));
   }
 


### PR DESCRIPTION
I'm not sure how this passed through our automated checks but PR #11325 got merged with a semantic error that breaks the Android port. This PR fixes that and allows the Android port to be built again...