### PR TITLE
Android: Move game grid options to MainActivity

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -324,10 +324,6 @@ public final class SettingsFragmentPresenter
             R.string.panic_handlers, R.string.panic_handlers_description));
     sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_OSD_MESSAGES, R.string.osd_messages,
             R.string.osd_messages_description));
-    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_USE_GAME_COVERS,
-            R.string.download_game_covers, 0));
-    sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_SHOW_GAME_TITLES,
-            R.string.show_titles_in_game_list, R.string.show_titles_in_game_list_description));
 
     AbstractIntSetting appTheme = new AbstractIntSetting()
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/GridOptionDialogFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/GridOptionDialogFragment.kt
@@ -1,0 +1,124 @@
+package org.dolphinemu.dolphinemu.fragments
+
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.os.Bundle
+import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
+import android.widget.CompoundButton
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import org.dolphinemu.dolphinemu.databinding.FragmentGridOptionsBinding
+import org.dolphinemu.dolphinemu.databinding.FragmentGridOptionsTvBinding
+import org.dolphinemu.dolphinemu.features.settings.model.NativeConfig
+import org.dolphinemu.dolphinemu.ui.main.MainView
+
+class GridOptionDialogFragment : BottomSheetDialogFragment() {
+
+    private lateinit var mView: MainView
+
+    private var _mBindingMobile: FragmentGridOptionsBinding? = null
+    private var _mBindingTv: FragmentGridOptionsTvBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val mBindingMobile get() = _mBindingMobile!!
+    private val mBindingTv get() = _mBindingTv!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        mView = (activity as MainView)
+
+        if (activity is AppCompatActivity)
+        {
+            _mBindingMobile = FragmentGridOptionsBinding.inflate(inflater, container, false)
+            return mBindingMobile.root
+        }
+        _mBindingTv = FragmentGridOptionsTvBinding.inflate(inflater, container, false)
+        return mBindingTv.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        if (activity is AppCompatActivity) {
+            setUpCoverButtons()
+            setUpTitleButtons()
+
+            // Pins fragment to the top of the dialog ensures the dialog is expanded in landscape by default
+            BottomSheetBehavior.from<View>(mBindingMobile.gridSheet).state =
+                BottomSheetBehavior.STATE_EXPANDED
+            dialog?.setOnShowListener {
+                val dialog = it as BottomSheetDialog
+                mBindingMobile.gridSheet.let { sheet ->
+                    dialog.behavior.peekHeight = sheet.height
+                }
+            }
+        } else {
+            setUpCoverButtonsTv()
+
+            // Pins fragment to the top of the dialog ensures the dialog is expanded in landscape by default
+            BottomSheetBehavior.from<View>(mBindingTv.gridSheet).state =
+                BottomSheetBehavior.STATE_EXPANDED
+            dialog?.setOnShowListener {
+                val dialog = it as BottomSheetDialog
+                mBindingTv.gridSheet.let { sheet ->
+                    dialog.behavior.peekHeight = sheet.height
+                }
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _mBindingMobile = null
+        _mBindingTv = null
+    }
+
+    private fun setUpCoverButtons() {
+        mBindingMobile.switchDownloadCovers.isChecked =
+            BooleanSetting.MAIN_USE_GAME_COVERS.booleanGlobal
+        mBindingMobile.rootDownloadCovers.setOnClickListener {
+            mBindingMobile.switchDownloadCovers.isChecked = !mBindingMobile.switchDownloadCovers.isChecked
+        }
+        mBindingMobile.switchDownloadCovers.setOnCheckedChangeListener { _: CompoundButton, _: Boolean ->
+            BooleanSetting.MAIN_USE_GAME_COVERS.setBooleanGlobal(
+                NativeConfig.LAYER_BASE,
+                mBindingMobile.switchDownloadCovers.isChecked
+            )
+            mView.reloadGrid()
+        }
+    }
+
+    private fun setUpTitleButtons() {
+        mBindingMobile.switchShowTitles.isChecked = BooleanSetting.MAIN_SHOW_GAME_TITLES.booleanGlobal
+        mBindingMobile.rootShowTitles.setOnClickListener {
+            mBindingMobile.switchShowTitles.isChecked = !mBindingMobile.switchShowTitles.isChecked
+        }
+        mBindingMobile.switchShowTitles.setOnCheckedChangeListener { _: CompoundButton, _: Boolean ->
+            BooleanSetting.MAIN_SHOW_GAME_TITLES.setBooleanGlobal(
+                NativeConfig.LAYER_BASE,
+                mBindingMobile.switchShowTitles.isChecked
+            )
+            mView.reloadGrid()
+        }
+    }
+
+    // TODO: Remove this when leanback is removed
+    private fun setUpCoverButtonsTv() {
+        mBindingTv.switchDownloadCovers.isChecked =
+            BooleanSetting.MAIN_USE_GAME_COVERS.booleanGlobal
+        mBindingTv.rootDownloadCovers.setOnClickListener {
+            mBindingTv.switchDownloadCovers.isChecked = !mBindingTv.switchDownloadCovers.isChecked
+        }
+        mBindingTv.switchDownloadCovers.setOnCheckedChangeListener { _: CompoundButton, _: Boolean ->
+            BooleanSetting.MAIN_USE_GAME_COVERS.setBooleanGlobal(
+                NativeConfig.LAYER_BASE,
+                mBindingTv.switchDownloadCovers.isChecked
+            )
+            mView.reloadGrid()
+        }
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -24,6 +24,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.tabs.TabLayout;
 
+import org.dolphinemu.dolphinemu.fragments.GridOptionDialogFragment;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.adapters.PlatformPagerAdapter;
@@ -123,10 +124,6 @@ public final class MainActivity extends AppCompatActivity
     }
 
     mPresenter.onResume();
-
-    // In case the user changed a setting that affects how games are displayed,
-    // such as system language, cover downloading...
-    forEachPlatformGamesView(PlatformGamesView::refetchMetadata);
   }
 
   @Override
@@ -331,6 +328,18 @@ public final class MainActivity extends AppCompatActivity
   public void showGames()
   {
     forEachPlatformGamesView(PlatformGamesView::showGames);
+  }
+
+  @Override
+  public void reloadGrid()
+  {
+    forEachPlatformGamesView(PlatformGamesView::refetchMetadata);
+  }
+
+  @Override
+  public void showGridOptions()
+  {
+    new GridOptionDialogFragment().show(getSupportFragmentManager(), "gridOptions");
   }
 
   private void forEachPlatformGamesView(Action1<PlatformGamesView> action)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -94,6 +94,10 @@ public final class MainPresenter
         mView.launchSettingsActivity(MenuTag.SETTINGS);
         return true;
 
+      case R.id.menu_grid_options:
+        mView.showGridOptions();
+        return true;
+
       case R.id.menu_refresh:
         mView.setRefreshing(true);
         GameFileCacheManager.startRescan();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
@@ -34,4 +34,8 @@ public interface MainView
    * To be called when the game file cache is updated.
    */
   void showGames();
+
+  void reloadGrid();
+
+  void showGridOptions();
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -19,6 +19,7 @@ import androidx.leanback.widget.ListRow;
 import androidx.leanback.widget.ListRowPresenter;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import org.dolphinemu.dolphinemu.fragments.GridOptionDialogFragment;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.adapters.GameRowPresenter;
@@ -87,10 +88,6 @@ public final class TvMainActivity extends FragmentActivity
     }
 
     mPresenter.onResume();
-
-    // In case the user changed a setting that affects how games are displayed,
-    // such as system language, cover downloading...
-    refetchMetadata();
   }
 
   @Override
@@ -217,12 +214,19 @@ public final class TvMainActivity extends FragmentActivity
     buildRowsAdapter();
   }
 
-  private void refetchMetadata()
+  @Override
+  public void reloadGrid()
   {
     for (ArrayObjectAdapter row : mGameRows)
     {
       row.notifyArrayItemRangeChanged(0, row.size());
     }
+  }
+
+  @Override
+  public void showGridOptions()
+  {
+    new GridOptionDialogFragment().show(getSupportFragmentManager(), "gridOptions");
   }
 
   /**
@@ -369,6 +373,10 @@ public final class TvMainActivity extends FragmentActivity
     rowItems.add(new TvSettingsItem(R.id.button_add_directory,
             R.drawable.ic_add_tv,
             R.string.add_directory_title));
+
+    rowItems.add(new TvSettingsItem(R.id.menu_grid_options,
+            R.drawable.ic_list_tv,
+            R.string.grid_menu_grid_options));
 
     rowItems.add(new TvSettingsItem(R.id.menu_refresh,
             R.drawable.ic_refresh_tv,

--- a/Source/Android/app/src/main/res/drawable/ic_list.xml
+++ b/Source/Android/app/src/main/res/drawable/ic_list.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18L21,6L3,6zM6,13h12v-2L6,11v2z" />
+</vector>

--- a/Source/Android/app/src/main/res/drawable/ic_list_tv.xml
+++ b/Source/Android/app/src/main/res/drawable/ic_list_tv.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18L21,6L3,6zM6,13h12v-2L6,11v2z" />
+</vector>

--- a/Source/Android/app/src/main/res/layout/fragment_grid_options.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_grid_options.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/grid_sheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/spacing_xtralarge"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+        <com.google.android.material.bottomsheet.BottomSheetDragHandleView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"/>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/root_download_covers"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true">
+
+            <TextView
+                android:id="@+id/text_download_covers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="24dp"
+                android:text="@string/download_game_covers"
+                app:layout_constraintBottom_toBottomOf="@+id/switch_download_covers"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/switch_download_covers" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/switch_download_covers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/root_show_titles"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:layout_marginTop="16dp"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true">
+
+            <TextView
+                android:id="@+id/text_show_titles"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="24dp"
+                android:text="@string/show_titles_in_game_list"
+                app:layout_constraintBottom_toBottomOf="@+id/switch_show_titles"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/switch_show_titles" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/switch_show_titles"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_grid_options_tv.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_grid_options_tv.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/grid_sheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/root_download_covers"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:paddingTop="@dimen/spacing_xtralarge"
+            android:paddingBottom="@dimen/spacing_xtralarge"
+            android:clickable="true"
+            android:focusable="true">
+
+            <TextView
+                android:id="@+id/text_download_covers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="24dp"
+                android:text="@string/download_game_covers"
+                app:layout_constraintBottom_toBottomOf="@+id/switch_download_covers"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/switch_download_covers" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switch_download_covers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/menu/menu_game_grid.xml
+++ b/Source/Android/app/src/main/res/menu/menu_game_grid.xml
@@ -9,6 +9,12 @@
         app:showAsAction="ifRoom"/>
 
     <item
+        android:id="@+id/menu_grid_options"
+        android:title="@string/grid_menu_settings"
+        android:icon="@drawable/ic_list"
+        app:showAsAction="ifRoom"/>
+
+    <item
         android:id="@+id/menu_refresh"
         android:title="@string/grid_menu_refresh"
         android:icon="@drawable/ic_refresh"

--- a/Source/Android/app/src/main/res/values-night-v31/themes.xml
+++ b/Source/Android/app/src/main/res/values-night-v31/themes.xml
@@ -26,5 +26,6 @@
 
         <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
+        <item name="extendedFloatingActionButtonStyle">@style/Widget.Material3.ExtendedFloatingActionButton.Primary</item>
     </style>
 </resources>

--- a/Source/Android/app/src/main/res/values-v31/themes.xml
+++ b/Source/Android/app/src/main/res/values-v31/themes.xml
@@ -26,5 +26,6 @@
 
         <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
+        <item name="extendedFloatingActionButtonStyle">@style/Widget.Material3.ExtendedFloatingActionButton.Primary</item>
     </style>
 </resources>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -193,8 +193,7 @@
     <string name="osd_messages">Show On-Screen Display Messages</string>
     <string name="osd_messages_description">Display messages over the emulation screen area. These messages include memory card writes, video backend and CPU information, and JIT cache clearing.</string>
     <string name="download_game_covers">Download Game Covers from GameTDB.com</string>
-    <string name="show_titles_in_game_list">Show Titles in Game List</string>
-    <string name="show_titles_in_game_list_description">Show the title and creator below each game cover.</string>
+    <string name="show_titles_in_game_list">Show Titles</string>
     <string name="change_theme">Change App Theme</string>
     <string name="change_theme_mode">Change Theme Mode</string>
     <string name="use_black_backgrounds">Use Black Backgrounds</string>
@@ -442,6 +441,7 @@
     <string name="add_games">Add Games</string>
     <string name="add_directory_title">Add Folder to Library</string>
     <string name="grid_menu_settings">Settings</string>
+    <string name="grid_menu_grid_options">Grid Options</string>
     <string name="grid_menu_refresh">Refresh Library</string>
     <string name="grid_menu_open_file">Open File</string>
     <string name="grid_menu_install_wad">Install WAD</string>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -60,4 +60,17 @@
     <style name="DolphinDivider" parent="Widget.Material3.MaterialDivider">
         <item name="dividerColor">?attr/colorSurfaceVariant</item>
     </style>
+
+    <style name="ThemeOverlay.Dolphin.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
+
+    <style name="Widget.Dolphin.ExtendedFloatingActionButton" parent="Widget.Material3.ExtendedFloatingActionButton.Primary">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.Dolphin.ExtendedFloatingActionButton</item>
+    </style>
+
+    <style name="ThemeOverlay.Dolphin.ExtendedFloatingActionButton" parent="">
+        <item name="colorContainer">@color/dolphin_primary</item>
+        <item name="colorOnContainer">@color/dolphin_onPrimary</item>
+    </style>
 </resources>

--- a/Source/Android/app/src/main/res/values/themes.xml
+++ b/Source/Android/app/src/main/res/values/themes.xml
@@ -16,8 +16,8 @@
     <style name="Theme.Dolphin" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/dolphin_primary</item>
         <item name="colorOnPrimary">@color/dolphin_onPrimary</item>
-        <item name="colorPrimaryContainer">@color/dolphin_primary</item>
-        <item name="colorOnPrimaryContainer">@color/dolphin_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/dolphin_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/dolphin_onPrimaryContainer</item>
         <item name="colorSecondary">@color/dolphin_secondary</item>
         <item name="colorOnSecondary">@color/dolphin_onSecondary</item>
         <item name="colorSecondaryContainer">@color/dolphin_secondaryContainer</item>
@@ -53,17 +53,17 @@
         <item name="popupTheme">@style/DolphinPopup</item>
         <item name="sliderStyle">@style/DolphinSlider</item>
         <item name="materialDividerStyle">@style/DolphinDivider</item>
+        <item name="bottomSheetDialogTheme">@style/ThemeOverlay.Dolphin.BottomSheetDialog</item>
+        <item name="extendedFloatingActionButtonStyle">@style/Widget.Dolphin.ExtendedFloatingActionButton</item>
     </style>
 
     <!-- Trick for API >= 29 specific changes -->
     <style name="Theme.Dolphin.Main" parent="Theme.Dolphin" />
 
     <style name="Theme.Dolphin.Main.Material" parent="Theme.Dolphin.Main">
-        <item name="colorPrimaryContainer">@color/dolphin_primaryContainer</item>
-        <item name="colorOnPrimaryContainer">@color/dolphin_onPrimaryContainer</item>
-
         <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
+        <item name="extendedFloatingActionButtonStyle">@style/Widget.Material3.ExtendedFloatingActionButton.Primary</item>
     </style>
 
     <style name="Theme.Dolphin.Main.Green" parent="Theme.Dolphin.Main">
@@ -95,6 +95,7 @@
 
         <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
+        <item name="extendedFloatingActionButtonStyle">@style/Widget.Material3.ExtendedFloatingActionButton.Primary</item>
     </style>
 
     <style name="Theme.Dolphin.Main.Pink" parent="Theme.Dolphin.Main">
@@ -126,6 +127,7 @@
 
         <item name="materialAlertDialogTheme">@style/MaterialDialog</item>
         <item name="popupTheme">@style/ThemeOverlay.Material3</item>
+        <item name="extendedFloatingActionButtonStyle">@style/Widget.Material3.ExtendedFloatingActionButton.Primary</item>
     </style>
 
     <!-- Inherit from a base file picker theme that handles day/night -->


### PR DESCRIPTION
This moves the toggles for downloading covers and showing/hiding game titles to the Main/TvMainActivity. Since showing/hiding covers isn't possible on the TV version, that option is removed entirely. (I'm still working on a new layout to avoid duplicating code like this, but I need more changes like this first)

This also prevents unnecessary viewmodel updates whenever returning from another activity.

Mobile Demo - 
https://user-images.githubusercontent.com/14132249/206937250-db83eb8f-e0ae-4683-9da9-b015be7832f6.mp4

TV Demo - 
https://user-images.githubusercontent.com/14132249/206937272-3668c146-e308-4f0d-93f8-e27424016d4c.mp4
