### PR TITLE
Android: Use colorSurface attribute for cheats activity background

### DIFF
--- a/Source/Android/app/src/main/res/layout/activity_cheats.xml
+++ b/Source/Android/app/src/main/res/layout/activity_cheats.xml
@@ -35,6 +35,7 @@
         android:id="@+id/sliding_pane_layout"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:background="?attr/colorSurface"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Before the background wouldn't follow the black backgrounds setting and just use the default surface color for a given theme. Now it follows the theme settings corectly.