### PR TITLE
CoreTiming: Throttle Before Every Event Using std::chrono

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -162,7 +162,7 @@ unsigned int Mixer::Mix(short* samples, unsigned int num_samples)
   memset(samples, 0, num_samples * 2 * sizeof(short));
 
   // TODO: Determine how emulation speed will be used in audio
-  // const float emulation_speed = std::roundf(g_perf_metrics.GetSpeed()) / 100.f;
+  // const float emulation_speed = g_perf_metrics.GetSpeed();
   const float emulation_speed = m_config_emulation_speed;
   const int timing_variance = m_config_timing_variance;
   if (m_config_audio_stretch)

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -891,9 +891,9 @@ void Callback_NewField()
 
 void UpdateTitle()
 {
-  float FPS = g_perf_metrics.GetFPS();
-  float VPS = g_perf_metrics.GetVPS();
-  float Speed = g_perf_metrics.GetSpeed();
+  const double FPS = g_perf_metrics.GetFPS();
+  const double VPS = g_perf_metrics.GetVPS();
+  const double Speed = 100.0 * g_perf_metrics.GetSpeed();
 
   // Settings are shown the same for both extended and summary info
   const std::string SSettings = fmt::format(

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -331,9 +331,6 @@ void CoreTimingManager::Advance()
 
 void CoreTimingManager::Throttle(const s64 target_cycle)
 {
-  if (target_cycle <= m_throttle_last_cycle)
-    return;
-
   const double speed =
       Core::GetIsThrottlerTempDisabled() ? 0.0 : Config::Get(Config::MAIN_EMULATION_SPEED);
 

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -339,7 +339,7 @@ void CoreTimingManager::Throttle(const s64 target_cycle)
   const s64 cycles = target_cycle - m_throttle_last_cycle;
 
   // Prevent any throttling code if the amount of time passed is < ~0.122ms
-  if (cycles < (m_throttle_clock_per_sec >> 13))
+  if (cycles < m_throttle_min_clock_per_sleep)
     return;
 
   m_throttle_last_cycle = target_cycle;
@@ -403,6 +403,7 @@ void CoreTimingManager::LogPendingEvents() const
 void CoreTimingManager::AdjustEventQueueTimes(u32 new_ppc_clock, u32 old_ppc_clock)
 {
   m_throttle_clock_per_sec = new_ppc_clock;
+  m_throttle_min_clock_per_sleep = new_ppc_clock / 1200;
 
   for (Event& ev : m_event_queue)
   {

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -335,12 +335,17 @@ void CoreTimingManager::Advance()
 
 void CoreTimingManager::Throttle(const s64 target_cycle)
 {
-  const double speed =
-      Core::GetIsThrottlerTempDisabled() ? 0.0 : Config::Get(Config::MAIN_EMULATION_SPEED);
-
   // Based on number of cycles and emulation speed, increase the target deadline
   const s64 cycles = target_cycle - m_throttle_last_cycle;
+
+  // Prevent any throttling code if the amount of time passed is < ~0.122ms
+  if (cycles < (m_throttle_clock_per_sec >> 13))
+    return;
+
   m_throttle_last_cycle = target_cycle;
+
+  const double speed =
+      Core::GetIsThrottlerTempDisabled() ? 0.0 : Config::Get(Config::MAIN_EMULATION_SPEED);
 
   if (0.0 < speed)
     m_throttle_deadline +=

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -140,6 +140,11 @@ public:
   // Directly accessed by the JIT.
   Globals& GetGlobals() { return m_globals; }
 
+  // Throttle the CPU to the specified target cycle.
+  // Never used outside of CoreTiming, however it remains public
+  // in order to allow custom throttling implementations to be tested.
+  void Throttle(const s64 target_cycle);
+
   TimePoint GetCPUTimePoint(s64 cyclesLate) const;  // Used by Dolphin Analytics
 
 private:
@@ -178,8 +183,7 @@ private:
   s64 m_throttle_last_cycle = 0;
   TimePoint m_throttle_deadline = Clock::now();
   s64 m_throttle_clock_per_sec;
-
-  void Throttle(const s64 target_cycle);
+  s64 m_throttle_min_clock_per_sleep;
 
   int DowncountToCycles(int downcount) const;
   int CyclesToDowncount(int cycles) const;

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -177,7 +177,7 @@ private:
 
   s64 m_throttle_last_cycle = 0;
   TimePoint m_throttle_deadline = Clock::now();
-  DT_s m_throttle_per_clock = DT_s();
+  s64 m_throttle_clock_per_sec;
 
   void Throttle(const s64 target_cycle);
 

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -140,6 +140,8 @@ public:
   // Directly accessed by the JIT.
   Globals& GetGlobals() { return m_globals; }
 
+  TimePoint GetCPUTimePoint(s64 cyclesLate) const;  // Used by Dolphin Analytics
+
 private:
   Globals m_globals;
 
@@ -172,6 +174,12 @@ private:
   float m_config_oc_factor = 0.0f;
   float m_config_oc_inv_factor = 0.0f;
   bool m_config_sync_on_skip_idle = false;
+
+  s64 m_throttle_last_cycle = 0;
+  TimePoint m_throttle_deadline = Clock::now();
+  DT_s m_throttle_per_clock = DT_s();
+
+  void Throttle(const s64 target_cycle);
 
   int DowncountToCycles(int downcount) const;
   int CyclesToDowncount(int cycles) const;

--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -3,7 +3,16 @@
 
 #pragma once
 
+#include <array>
+#include <shared_mutex>
+
+#include "Common/CommonTypes.h"
 #include "VideoCommon/PerformanceTracker.h"
+
+namespace Core
+{
+class System;
+}
 
 class PerformanceMetrics
 {
@@ -21,20 +30,33 @@ public:
   void CountFrame();
   void CountVBlank();
 
+  void CountThrottleSleep(DT sleep);
+  void CountPerformanceMarker(Core::System& system, s64 cyclesLate);
+
   // Getter Functions
   double GetFPS() const;
   double GetVPS() const;
   double GetSpeed() const;
+  double GetMaxSpeed() const;
 
   double GetLastSpeedDenominator() const;
 
   // ImGui Functions
-  void DrawImGuiStats(const float backbuffer_scale) const;
+  void DrawImGuiStats(const float backbuffer_scale);
 
 private:
   PerformanceTracker m_fps_counter{"render_times.txt"};
   PerformanceTracker m_vps_counter{"vblank_times.txt"};
   PerformanceTracker m_speed_counter{std::nullopt, 500000};
+
+  double m_graph_max_time = 0.0;
+
+  mutable std::shared_mutex m_time_lock;
+
+  u8 m_time_index = 0;
+  std::array<TimePoint, 256> m_real_times;
+  std::array<TimePoint, 256> m_cpu_times;
+  DT m_time_sleeping;
 };
 
 extern PerformanceMetrics g_perf_metrics;


### PR DESCRIPTION
## What it does
- Throttles before every single event with `std::this_thread::sleep_until`
  - If the sleep function over sleeps, then the next few calls to sleep will be skipped until it maintains timings again. So this whole system will remain relatively stable regardless of the way that sleep is implemented.
  - This means that events schedules in the `CoreTimingManager` now happen the instant they are supposed to
    - New Timings +/- 10µs (tested on macOS)
    - Old Timings +/- 1000µs (on every operating system due to design)

## Comparisons

This commit can turn these frame times (Wii Sports Resort):
<img width="500" alt="image" src="https://user-images.githubusercontent.com/28713194/207979840-51bb697d-ceea-4b56-8fe6-8faaf79ffa61.png">

Into these frame times (Wii Sports Resort - Immediate XMB ON): (just stunning)
<img width="500" alt="image" src="https://user-images.githubusercontent.com/28713194/208010038-f19bd9f9-d15e-454d-9e32-3c60e59511e2.png">

Wii Sports Resort - Immediate XMB OFF: (notice that vblanks have an std of 0ms)
<img width="500" alt="image" src="https://user-images.githubusercontent.com/28713194/208010301-69f8b1a5-c109-4d4a-9af4-126d92afc5fa.png">

---
Here is with the metal frame time viewer:

Before:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/28713194/208981517-cc8eba71-6fa5-4dc4-b271-1f991228ac11.png">


After:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/28713194/208981392-c1bbe553-6ede-4bc3-82ca-8324f1340e60.png">
