### PR TITLE
Fix MemoryViewWidget background colour

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -549,7 +549,7 @@ void MemoryViewWidget::UpdateBreakpointTags()
       }
       else
       {
-        cell->setBackground(Qt::white);
+        cell->setBackground(Qt::transparent);
       }
     }
 


### PR DESCRIPTION
In commit 6f4f4e057e58d1720db7a68f80f6dcc24c686a3e on line 552, the background of the memory viewer was filled to be white. In dark mode this would make it impossible to see the contents of the viewer.

<img width="1093" alt="Screenshot 2022-12-16 at 5 46 08 PM" src="https://user-images.githubusercontent.com/75850871/208201159-76239572-fbe5-45fb-816d-5e6cefec537d.png">
