### PR TITLE
Set checksum for NWC24Config during creation

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
@@ -40,20 +40,21 @@ void NWC24Config::ReadConfig()
 
 void NWC24Config::WriteCBK() const
 {
-  constexpr FS::Modes public_modes{FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite};
-  m_fs->CreateFullPath(PID_KD, PID_KD, CBK_PATH, 0, public_modes);
-  const auto file = m_fs->CreateAndOpenFile(PID_KD, PID_KD, CBK_PATH, public_modes);
-  if (!file || !file->Write(&m_data, 1))
-    ERROR_LOG_FMT(IOS_WC24, "Failed to open or write WC24 config file");
+  WriteConfigToPath(CBK_PATH);
 }
 
 void NWC24Config::WriteConfig() const
 {
+  WriteConfigToPath(CONFIG_PATH);
+}
+
+void NWC24Config::WriteConfigToPath(const std::string& path) const
+{
   constexpr FS::Modes public_modes{FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite};
-  m_fs->CreateFullPath(PID_KD, PID_KD, CONFIG_PATH, 0, public_modes);
-  const auto file = m_fs->CreateAndOpenFile(PID_KD, PID_KD, CONFIG_PATH, public_modes);
+  m_fs->CreateFullPath(PID_KD, PID_KD, path, 0, public_modes);
+  const auto file = m_fs->CreateAndOpenFile(PID_KD, PID_KD, path, public_modes);
   if (!file || !file->Write(&m_data, 1))
-    ERROR_LOG_FMT(IOS_WC24, "Failed to open or write WC24 config file");
+    ERROR_LOG_FMT(IOS_WC24, "Failed to open or write WC24 config file at {}", path);
 }
 
 void NWC24Config::ResetConfig()

--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
@@ -15,6 +15,7 @@
 namespace IOS::HLE::NWC24
 {
 constexpr const char CONFIG_PATH[] = "/" WII_WC24CONF_DIR "/nwc24msg.cfg";
+constexpr const char CBK_PATH[] = "/" WII_WC24CONF_DIR "/nwc24msg.cbk";
 
 NWC24Config::NWC24Config(std::shared_ptr<FS::FileSystem> fs) : m_fs{std::move(fs)}
 {
@@ -35,6 +36,15 @@ void NWC24Config::ReadConfig()
     }
   }
   ResetConfig();
+}
+
+void NWC24Config::WriteCBK() const
+{
+  constexpr FS::Modes public_modes{FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite};
+  m_fs->CreateFullPath(PID_KD, PID_KD, CBK_PATH, 0, public_modes);
+  const auto file = m_fs->CreateAndOpenFile(PID_KD, PID_KD, CBK_PATH, public_modes);
+  if (!file || !file->Write(&m_data, 1))
+    ERROR_LOG_FMT(IOS_WC24, "Failed to open or write WC24 config file");
 }
 
 void NWC24Config::WriteConfig() const

--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.h
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.h
@@ -48,6 +48,7 @@ public:
   void ReadConfig();
   void WriteCBK() const;
   void WriteConfig() const;
+  void WriteConfigToPath(const std::string& path) const;
   void ResetConfig();
 
   u32 CalculateNwc24ConfigChecksum() const;

--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.h
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.h
@@ -46,6 +46,7 @@ public:
   explicit NWC24Config(std::shared_ptr<FS::FileSystem> fs);
 
   void ReadConfig();
+  void WriteCBK() const;
   void WriteConfig() const;
   void ResetConfig();
 

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -397,7 +397,9 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
         config.SetId(user_id);
         config.IncrementIdGen();
         config.SetCreationStage(NWC24::NWC24CreationStage::Generated);
+        config.SetChecksum(config.CalculateNwc24ConfigChecksum());
         config.WriteConfig();
+        config.WriteCBK();
 
         WriteReturnValue(ret, request.buffer_out);
       }


### PR DESCRIPTION
In the KD request `IOCTL_NWC24_REQUEST_GENERATED_USER_ID`, the nwc24msg.cfg and nwc24msg.cbk have many of their fields edited, such as the Wii Friend Code and creation stage.

However, the checksum was not being written, causing whatever calls the request to delete the edited data and revert back to the default files.

By writing the checksum, the Wii Number is properly written along with the creation stage and increment id, which should allow for `IOCTL_NWC24_REQUEST_REGISTER_USER_ID` to properly be handled with the default Wii NAND in the future.