### PR TITLE
DSPHLE: Add Desert Bus libasnd ucode variants

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
@@ -54,9 +54,15 @@ constexpr u32 FLAGS_SAMPLE_FORMAT_BYTES_SHIFT = 16;
 
 constexpr u32 SAMPLE_RATE = 48000;
 
+bool ASndUCode::SwapLeftRight() const
+{
+  return m_crc == HASH_DESERT_BUS_2011 || m_crc == HASH_DESERT_BUS_2012;
+}
+
 bool ASndUCode::UseNewFlagMasks() const
 {
-  return m_crc == HASH_2011 || m_crc == HASH_2020 || m_crc == HASH_2020_PAD;
+  return m_crc == HASH_2011 || m_crc == HASH_2020 || m_crc == HASH_2020_PAD ||
+         m_crc == HASH_DESERT_BUS_2011 || m_crc == HASH_DESERT_BUS_2012;
 }
 
 ASndUCode::ASndUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
@@ -383,7 +389,13 @@ void ASndUCode::DoMixing(u32 return_mail)
         }
         // Both paths jmpr $AR3, which is an index into sample_selector
 
-        const auto [new_r, new_l] = (this->*sample_function)();
+        auto [new_r, new_l] = (this->*sample_function)();
+        if (SwapLeftRight())
+        {
+          // The Desert Bus versions swapped the left and right input channels so that left
+          // comes first, and then right. Before, right came before left.
+          std::swap(new_r, new_l);
+        }
         // out_samp: "multiply sample x volume" - left is put in $ax0.h, right is put in $ax1.h
 
         // All functions jumped to from sample_selector jump or fall through here (zero_samples also

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
@@ -51,6 +51,14 @@ public:
   // https://github.com/extremscorner/libogc2/commit/0b64f879808953d80ba06501a1c079b0fbf017d2
   // https://github.com/extremscorner/libogc-rice/commit/ce22c3269699fdbd474f2f28ca2ffca211954659
   static constexpr u32 HASH_2020_PAD = 0xbad876ef;
+  // Variant used in Desert Bus v1.04 - this is based off of the code in libogc (as it existed in
+  // 2011, even though that code only became used in 2020), but the left and right channels are
+  // swapped. Padded to 0x0620 bytes.
+  static constexpr u32 HASH_DESERT_BUS_2011 = 0xfa9c576f;
+  // Variant used in Desert Bus v1.05 - this is the same as the previous version, except 4 junk
+  // instructions were added to the start, which do not change behavior in any way. Padded to 0x0620
+  // bytes.
+  static constexpr u32 HASH_DESERT_BUS_2012 = 0x614dd145;
 
 private:
   void DMAInVoiceData();
@@ -60,6 +68,7 @@ private:
   void ChangeBuffer();
   void DoMixing(u32 return_mail);
 
+  bool SwapLeftRight() const;
   bool UseNewFlagMasks() const;
 
   std::pair<s16, s16> ReadSampleMono8Bits() const;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -313,6 +313,8 @@ std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
   case ASndUCode::HASH_2011:
   case ASndUCode::HASH_2020:
   case ASndUCode::HASH_2020_PAD:
+  case ASndUCode::HASH_DESERT_BUS_2011:
+  case ASndUCode::HASH_DESERT_BUS_2012:
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: ASnd chosen (Homebrew)", crc);
     return std::make_unique<ASndUCode>(dsphle, crc);
 


### PR DESCRIPTION
The [Desert Bus homebrew](https://wiibrew.org/wiki/Desert_Bus) uses custom libasnd DSP ucode. Specifically, v1.0.4 and v1.0.5 are modified versions of the ucode that was added to the libogc repo in devkitpro/libogc@b1b8ecab3af3745c8df0b401abd512bdf5fcc011 (although the binary that was added in that commit does not match the code, and a matching binary only started being used in 2020 - see #10763 for my other notes). That libogc patch is attributed to the author of the homebrew, for what it's worth.

<details><summary>The difference between the libogc code and v1.0.4 is this, which swaps the left and right channels for stereo audio:</summary>

```diff
diff --git a/dsp_mixer.s b/dsp_mixer_desert_bus_v1.0.4.s
index 3b52614..9de5b84 100644
--- a/dsp_mixer.s
+++ b/dsp_mixer_v1.0.4.s
@@ -834,10 +834,10 @@ stereo_8bits:
        lrri $ACL0, @$AR2
        mrr  $ACM0, $ACL0
        andi $ACM0, #0xff00
-       mrr  $AXH1, $ACM0
+       mrr  $AXH0, $ACM0
        lsl  $ACC0, #8

-       mrr  $AXH0, $ACL0
+       mrr  $AXH1, $ACL0
        jmp     out_samp

 mono_16bits:
@@ -852,8 +852,8 @@ stereo_16bits:

 // 16 bits stereo

-       lrri $AXH1, @$AR2
        lrri $AXH0, @$AR2
+       lrri $AXH1, @$AR2
        jmp     out_samp

 mono_8bits_unsigned:
@@ -892,10 +892,10 @@ stereo_8bits_unsigned:
        xori $ACM0, #0x8080 // convert unsigned->signed
        mrr  $ACL0, $ACM0
        andi $ACM0, #0xff00
-       mrr  $AXH1, $ACM0
+       mrr  $AXH0, $ACM0
        lsl  $ACC0, #8

-       mrr  $AXH0, $ACL0
+       mrr  $AXH1, $ACL0
        jmp     out_samp

 stereo_16bits_le:
@@ -908,8 +908,8 @@ stereo_16bits_le:
        lsl  $ACC1, #8 // byteswap
        lsl  $ACC0, #8

-       mrr  $AXH1, $ACM1
-       mrr  $AXH0, $ACM0
+       mrr  $AXH0, $ACM1
+       mrr  $AXH1, $ACM0
        //jmp   out_samp

 out_samp:
```

</details><details><summary>The difference between v1.0.4 and v1.0.5 is this:</summary>

```diff
diff --git a/dsp_mixer_desert_bus_v1.0.4.s b/dsp_mixer_desert_bus_v1.0.5.s
index 9de5b84..9f5d428 100644
--- a/dsp_mixer_desert_bus_v1.0.4.s
+++ b/dsp_mixer_desert_bus_v1.0.5.s
@@ -190,6 +190,14 @@ MEM_SND:	equ	data_end ; it need 2048 words (4096 bytes)
 	jmp	exception6
 	jmp	exception7
 
+	; decodes as sbclr #0x04
+	; (note that sbclr has unused/ignored bits currently, and the canon version would be 1204)
+	cw 0x1234
+	; decodes as subr'l $ACC0, $AX1.H : $AC1.M, @$AR0
+	cw 0x5678
+	; decodes as bloopi #0x11, 0x2222
+	cw 0x1111
+	cw 0x2222
 	lri     $CONFIG, #0xff
 	lri	$SR,#0
 	s16         
```

</details>

v1.0.0 and v1.0.3 seem to be lost. They would have originally existed at https://wiibrew.org/wiki/Media:Desertbus.zip but this was not archived; [both versions were uploaded to this location](https://wiibrew.org/w/index.php?title=Special:Log&page=File%3ADesertbus.zip).

This change does not impact desert bus booting; see #11350 for that. I'm creating a separate PR so that it can be reviewed faster.