### PR TITLE
Android: Use Glide for cover caching

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
@@ -2,8 +2,6 @@
 
 package org.dolphinemu.dolphinemu.model;
 
-import android.content.Context;
-
 import androidx.annotation.Keep;
 
 public class GameFile
@@ -67,11 +65,6 @@ public class GameFile
   public native int getBannerWidth();
 
   public native int getBannerHeight();
-
-  public String getCoverPath(Context context)
-  {
-    return context.getExternalCacheDir().getPath() + "/GameCovers/" + getGameTdbId() + ".png";
-  }
 
   public String getCustomCoverPath()
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CoverHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CoverHelper.java
@@ -2,11 +2,7 @@
 
 package org.dolphinemu.dolphinemu.utils;
 
-import android.graphics.Bitmap;
-
 import org.dolphinemu.dolphinemu.model.GameFile;
-
-import java.io.FileOutputStream;
 
 public final class CoverHelper
 {
@@ -66,18 +62,5 @@ public final class CoverHelper
         break;
     }
     return region;
-  }
-
-  public static void saveCover(Bitmap cover, String path)
-  {
-    try
-    {
-      FileOutputStream out = new FileOutputStream(path);
-      cover.compress(Bitmap.CompressFormat.PNG, 100, out);
-      out.close();
-    }
-    catch (Exception ignored)
-    {
-    }
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
@@ -186,9 +186,9 @@ public class TvUtil
         }
       }
 
-      if (contentUri == null && (cover = new File(game.getCoverPath(context))).exists())
+      if (contentUri == null)
       {
-        contentUri = getUriForFile(context, getFileProvider(context), cover);
+        contentUri = Uri.parse(CoverHelper.buildGameTDBUrl(game, CoverHelper.getRegion(game)));
       }
 
       context.grantUriPermission(LEANBACK_PACKAGE, contentUri, FLAG_GRANT_READ_URI_PERMISSION);


### PR DESCRIPTION
Glide has a built-in system for caching images so we don't have to use the custom caching system. Only downside is the TV channels will be loading covers from a URL instead of a local file.