### PR TITLE
Android: Elevate ingame menu fragment with color

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.Insets;
@@ -18,12 +19,17 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 
+import com.google.android.material.color.MaterialColors;
+import com.google.android.material.elevation.ElevationOverlayProvider;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.databinding.FragmentIngameMenuBinding;
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.IntSetting;
 import org.dolphinemu.dolphinemu.utils.InsetsHelper;
+import org.dolphinemu.dolphinemu.utils.ThemeHelper;
 
 public final class MenuFragment extends Fragment implements View.OnClickListener
 {
@@ -85,6 +91,14 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
   @Override
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState)
   {
+    if (IntSetting.MAIN_INTERFACE_THEME.getIntGlobal() != ThemeHelper.DEFAULT)
+    {
+      @ColorInt int color = new ElevationOverlayProvider(view.getContext()).compositeOverlay(
+              MaterialColors.getColor(view, R.attr.colorSurface),
+              view.getElevation());
+      view.setBackgroundColor(color);
+    }
+
     setInsets();
     updatePauseUnpauseVisibility();
 

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/colorSurface"
+    android:elevation="3dp"
     tools:layout_width="250dp">
 
     <TextView


### PR DESCRIPTION
Whenever the app is not using the default theme, the ingame menu fragment will get a new elevation color like an alert dialog.

This is following an old suggestion from @JosJuice but I can't remember where they mentioned it.

Before - 
![before](https://user-images.githubusercontent.com/14132249/208772527-35d31a40-f624-4b47-ac5f-68bc2c0f03b8.png)

After - 
![after](https://user-images.githubusercontent.com/14132249/208772538-7e4dceb7-bce6-4255-a9a8-cc7dd6daa116.png)
