### PR TITLE
Bring Android documentation up-to-date

### DIFF
--- a/AndroidSetup.md
+++ b/AndroidSetup.md
@@ -6,45 +6,21 @@ If you'd like to contribute to the Android project, but do not currently have a 
 
 * [Android Studio](https://developer.android.com/studio/)
 
-If you downloaded Android Studio, extract it and then see [Setting Up Android Studio](#setting-up-android-studio).
+If you downloaded Android Studio, install it with the default options and open the project located in `dolphin/Source/Android`
 
 ## Setting Up Android Studio
 
-1. Launch Android Studio, which will start a first-launch wizard.
-2. Choose a custom installation.
-3. If offered a choice of themes, select your preference.
-4. When offered a choice of components, uncheck the "Android Virtual Device" option. ![Android Studio Components][components]
-5. Accept all licenses, and click Finish. Android Studio will download the SDK Tools package automatically. (Ubuntu users, if you get an error running the `mksdcard` tool, make sure the `lib32stdc++6` package is installed.)
-6. At the Android Studio welcome screen, click "Configure", then "SDK Manager".
-7. Use the SDK Manager to get necessary dependencies, as described in [Getting Dependencies](#getting-dependencies).
-8. When done, follow the steps in [Readme.md](Readme.md#building-for-android) to compile and deploy the application.
+1. Wait for background tasks to complete on the bottom of the window.
+2. Launch the Android SDK Manager by clicking on its icon in Android Studio's main toolbar:
+![Android Studio Package Icon][package-icon]
+3. Install or update the SDK Platform. Choose the API level as defined in the app module's [build.gradle](Source/Android/app/build.gradle#L7) file.
+4. Install a CMake version as defined in the app module's [build.gradle](Source/Android/app/build.gradle#L99) file. The option won't appear until you select `Show Package Details`.
+5. Select `Build Variants` on the left side of the window to choose the build variant and ABI you would like to compile for the `:app` module.
+6. Select the green hammer icon in the main toolbar to build and create the apk in `Source/Android/app/build/outputs/apk`
 
-## Executing Gradle Tasks
-
-In Android Studio, you can find a list of possible Gradle tasks in a tray at the top right of the screen:
-
-![Gradle Tasks][gradle]
-
-Double clicking any of these tasks will execute it, and also add it to a short list in the main toolbar:
-
-![Gradle Task Shortcuts][shortcut]
-
-Clicking the green triangle next to this list will execute the currently selected task.
+## Compiling from the Command-Line
 
 For command-line users, any task may be executed with `cd Source/Android` followed by `gradlew <task-name>`. In particular, `gradlew assemble` builds debug and release versions of the application (which are placed in `Source/Android/app/build/outputs/apk`).
 
-## Getting Dependencies
-
-Most dependencies for the Android project are supplied by Gradle automatically. However, Android platform libraries (and a few Google-supplied supplementary libraries) must be downloaded through the Android package manager.
-
-1. Launch the Android SDK Manager by clicking on its icon in Android Studio's main toolbar:
-![Android Studio Package Icon][package-icon]
-2. Install or update the SDK Platform. Choose the API level selected as [compileSdkVersion](Source/Android/app/build.gradle#L4).
-3. Install or update the SDK Tools. CMake, LLDB, and NDK. If you don't use android-studio, please check out https://github.com/Commit451/android-cmake-installer.
-
-In the future, if the project targets a newer version of Android, or uses newer versions of the tools/build-tools packages, it will be necessary to use this tool to download updates.
-
-[components]: https://i.imgur.com/Oo1Fs93.png
-[package-icon]: https://i.imgur.com/NUpkAH8.png
-[gradle]: https://i.imgur.com/dXIH6o3.png
-[shortcut]: https://i.imgur.com/eCWP4Yy.png
+[package-icon]: https://i.imgur.com/hgmMlsM.png
+[code-style]: https://i.imgur.com/3b3UBhb.png

--- a/Contributing.md
+++ b/Contributing.md
@@ -7,7 +7,7 @@ If you make any contributions to Dolphin after December 1st, 2014, you are agree
 - [Introduction](#introduction)
 - [C++ coding style and formatting](#cpp-coding-style-and-formatting)
 - [C++ code-specific guidelines](#cpp-code-specific-guidelines)
-- [Android and Java](#android-and-java)
+- [Android](#android)
 - [Help](#help)
 
 
@@ -272,9 +272,15 @@ Summary:
   };
   ```
 
-# <a name="android-and-java"></a>Android and Java
+# <a name="android"></a>Android
 
-The Android project is currently written in Java. If you are using Android Studio to contribute, you can import the project's code style from `code-style-java.jar`, located in `[Dolphin Root]/Source/Android`. Please organize imports before committing.
+If you are using Kotlin, just use the built-in official Kotlin code style.
+
+To install the Java code style in Android Studio, select the gear icon in the Code Style settings as shown, select `Import Scheme...` and select `dolphin/Source/Android/code-style-java.xml`. The Code Style menu should look like this when complete. ![Code Style Window][code-style]
+
+You can now select any section of code and press `Ctrl + Alt + L` to automatically format it.
 
 # <a name="help"></a>Help
 If you have any questions about Dolphin's development or would like some help, Dolphin developers use `#dolphin-emu @ irc.libera.chat` to communicate. If you are new to IRC, [Libera.Chat has resources to get started chatting with IRC.](https://libera.chat/)
+
+[code-style]: https://i.imgur.com/3b3UBhb.png


### PR DESCRIPTION
This removes some of the old build instructions and adds better information about how to import the correct code style.