### PR TITLE
Follow-up on a four-year-old Android NDK workaround

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoBackends/Vulkan/VKVertexManager.h"
 
+#include <algorithm>
+
 #include "Common/Align.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -87,11 +89,9 @@ bool VertexManager::Initialize()
 
   // Prefer an 8MB buffer if possible, but use less if the device doesn't support this.
   // This buffer is potentially going to be addressed as R8s in the future, so we assume
-  // that one element is one byte. This doesn't use min() because of a NDK compiler bug..
-  const u32 texel_buffer_size =
-      TEXEL_STREAM_BUFFER_SIZE > g_vulkan_context->GetDeviceLimits().maxTexelBufferElements ?
-          g_vulkan_context->GetDeviceLimits().maxTexelBufferElements :
-          TEXEL_STREAM_BUFFER_SIZE;
+  // that one element is one byte.
+  const u32 texel_buffer_size = std::min(
+      TEXEL_STREAM_BUFFER_SIZE, g_vulkan_context->GetDeviceLimits().maxTexelBufferElements);
   m_texel_stream_buffer =
       StreamBuffer::Create(VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, texel_buffer_size);
   if (!m_texel_stream_buffer)


### PR DESCRIPTION
I am looking at NDK releases from before f039149198657c1891e1c6462ed30c31ed4b8486, but cannot tell what has changed about std::min.  Still, surely this is fixed by now.  Was it a compile error, or a logic error?