### PR TITLE
Android: Allow users to interact with switches in settings

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SwitchSettingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SwitchSettingViewHolder.java
@@ -33,6 +33,15 @@ public final class SwitchSettingViewHolder extends SettingViewHolder
 
     mBinding.settingSwitch.setChecked(mItem.isChecked(getAdapter().getSettings()));
 
+    mBinding.settingSwitch.setEnabled(mItem.isEditable());
+
+    mBinding.settingSwitch.setOnCheckedChangeListener((buttonView, isChecked) ->
+    {
+      getAdapter().onBooleanClick(mItem, mBinding.settingSwitch.isChecked());
+
+      setStyle(mBinding.textSettingName, mItem);
+    });
+
     setStyle(mBinding.textSettingName, mItem);
   }
 
@@ -46,10 +55,6 @@ public final class SwitchSettingViewHolder extends SettingViewHolder
     }
 
     mBinding.settingSwitch.toggle();
-
-    getAdapter().onBooleanClick(mItem, mBinding.settingSwitch.isChecked());
-
-    setStyle(mBinding.textSettingName, mItem);
   }
 
   @Nullable @Override

--- a/Source/Android/app/src/main/res/layout/list_item_setting_switch.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_setting_switch.xml
@@ -44,7 +44,6 @@
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         android:layout_marginEnd="24dp"
-        android:clickable="false"
         android:focusable="false"
         android:minHeight="0dp"
         android:minWidth="0dp" />


### PR DESCRIPTION
Before you couldn't grab and flick a switch. This is now consistent with the rest of the UX.

Before - 
![switch-old](https://user-images.githubusercontent.com/14132249/209418298-f5e69a29-513d-4337-98cb-20e6dca802df.gif)

After -
![switch-new](https://user-images.githubusercontent.com/14132249/209418301-cd152bd1-3452-4e50-bd54-7771cb395813.gif) 
