### PR TITLE
Boot: Fix handling of M3U file paths containing backslashes

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -205,6 +205,9 @@ std::unique_ptr<BootParameters> BootParameters::GenerateFromFile(std::vector<std
 {
   ASSERT(!paths.empty());
 
+  for (std::string& path : paths)
+    UnifyPathSeparators(path);
+
   const bool is_drive = Common::IsCDROMDevice(paths.front());
   // Check if the file exist, we may have gotten it from a --elf command line
   // that gave an incorrect file name
@@ -224,6 +227,9 @@ std::unique_ptr<BootParameters> BootParameters::GenerateFromFile(std::vector<std
     paths = ReadM3UFile(paths.front(), folder_path);
     if (paths.empty())
       return {};
+
+    for (std::string& path : paths)
+      UnifyPathSeparators(path);
 
     SplitPath(paths.front(), nullptr, nullptr, &extension);
     Common::ToLower(&extension);


### PR DESCRIPTION
Previously, if a user on Windows launched Dolphin from the command line and specified a path to an M3U file and included backslashes in this path, Dolphin would fail to resolve relative paths in the M3U file.

Thanks to Tartifless on Discord for managing to narrow down the conditions under which the problem happens. I've heard reports every now and then about relative paths not working in M3U files ever since the M3U feature was added, but never managed to reproduce it.