### PR TITLE
DolphinQt: Add settings to GBA TAS input window

### DIFF
--- a/Source/Core/DolphinQt/TAS/GBATASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/GBATASInputWindow.cpp
@@ -69,6 +69,7 @@ GBATASInputWindow::GBATASInputWindow(QWidget* parent, int controller_id)
 
   auto* layout = new QVBoxLayout;
   layout->addWidget(buttons_box);
+  layout->addWidget(m_settings_box);
 
   setLayout(layout);
 }


### PR DESCRIPTION
We should expose Enable Controller Input and the turbo settings for GBA just like we do for GameCube controllers and Wii Remotes. I just forgot about it when implementing the GBA TAS input window.

![image](https://user-images.githubusercontent.com/6716818/209432005-5561591d-9aff-4c77-982e-7b827737c74a.png)
