### PR TITLE
Android: Make more meticulous use of DeleteLocalRef

### DIFF
--- a/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
@@ -107,40 +107,64 @@ std::string OpenModeToAndroid(std::ios_base::openmode mode)
 int OpenAndroidContent(const std::string& uri, const std::string& mode)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
-  return env->CallStaticIntMethod(IDCache::GetContentHandlerClass(),
-                                  IDCache::GetContentHandlerOpenFd(), ToJString(env, uri),
-                                  ToJString(env, mode));
+
+  jstring j_uri = ToJString(env, uri);
+  jstring j_mode = ToJString(env, mode);
+
+  jint result = env->CallStaticIntMethod(IDCache::GetContentHandlerClass(),
+                                         IDCache::GetContentHandlerOpenFd(), j_uri, j_mode);
+
+  env->DeleteLocalRef(j_uri);
+  env->DeleteLocalRef(j_mode);
+
+  return result;
 }
 
 bool DeleteAndroidContent(const std::string& uri)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
-  return env->CallStaticBooleanMethod(IDCache::GetContentHandlerClass(),
-                                      IDCache::GetContentHandlerDelete(), ToJString(env, uri));
+
+  jstring j_uri = ToJString(env, uri);
+
+  jboolean result = env->CallStaticBooleanMethod(IDCache::GetContentHandlerClass(),
+                                                 IDCache::GetContentHandlerDelete(), j_uri);
+
+  env->DeleteLocalRef(j_uri);
+
+  return static_cast<bool>(result);
 }
 
 jlong GetAndroidContentSizeAndIsDirectory(const std::string& uri)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
-  return env->CallStaticLongMethod(IDCache::GetContentHandlerClass(),
-                                   IDCache::GetContentHandlerGetSizeAndIsDirectory(),
-                                   ToJString(env, uri));
+
+  jstring j_uri = ToJString(env, uri);
+
+  jlong result = env->CallStaticLongMethod(
+      IDCache::GetContentHandlerClass(), IDCache::GetContentHandlerGetSizeAndIsDirectory(), j_uri);
+
+  env->DeleteLocalRef(j_uri);
+
+  return result;
 }
 
 std::string GetAndroidContentDisplayName(const std::string& uri)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
-  jstring jresult = reinterpret_cast<jstring>(
-      env->CallStaticObjectMethod(IDCache::GetContentHandlerClass(),
-                                  IDCache::GetContentHandlerGetDisplayName(), ToJString(env, uri)));
+  jstring j_uri = ToJString(env, uri);
 
-  if (!jresult)
+  jstring j_result = reinterpret_cast<jstring>(env->CallStaticObjectMethod(
+      IDCache::GetContentHandlerClass(), IDCache::GetContentHandlerGetDisplayName(), j_uri));
+
+  env->DeleteLocalRef(j_uri);
+
+  if (!j_result)
     return "";
 
-  std::string result = GetJString(env, jresult);
+  std::string result = GetJString(env, j_result);
 
-  env->DeleteLocalRef(jresult);
+  env->DeleteLocalRef(j_result);
 
   return result;
 }
@@ -149,13 +173,15 @@ std::vector<std::string> GetAndroidContentChildNames(const std::string& uri)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
-  jobjectArray jresult = reinterpret_cast<jobjectArray>(env->CallStaticObjectMethod(
-      IDCache::GetContentHandlerClass(), IDCache::GetContentHandlerGetChildNames(),
-      ToJString(env, uri), false));
+  jstring j_uri = ToJString(env, uri);
 
-  std::vector<std::string> result = JStringArrayToVector(env, jresult);
+  jobjectArray j_result = reinterpret_cast<jobjectArray>(env->CallStaticObjectMethod(
+      IDCache::GetContentHandlerClass(), IDCache::GetContentHandlerGetChildNames(), j_uri, false));
 
-  env->DeleteLocalRef(jresult);
+  std::vector<std::string> result = JStringArrayToVector(env, j_result);
+
+  env->DeleteLocalRef(j_uri);
+  env->DeleteLocalRef(j_result);
 
   return result;
 }
@@ -166,13 +192,18 @@ std::vector<std::string> DoFileSearchAndroidContent(const std::string& directory
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
-  jobjectArray jresult = reinterpret_cast<jobjectArray>(env->CallStaticObjectMethod(
-      IDCache::GetContentHandlerClass(), IDCache::GetContentHandlerDoFileSearch(),
-      ToJString(env, directory), VectorToJStringArray(env, extensions), recursive));
+  jstring j_directory = ToJString(env, directory);
+  jobjectArray j_extensions = VectorToJStringArray(env, extensions);
 
-  std::vector<std::string> result = JStringArrayToVector(env, jresult);
+  jobjectArray j_result = reinterpret_cast<jobjectArray>(env->CallStaticObjectMethod(
+      IDCache::GetContentHandlerClass(), IDCache::GetContentHandlerDoFileSearch(), j_directory,
+      j_extensions, recursive));
 
-  env->DeleteLocalRef(jresult);
+  std::vector<std::string> result = JStringArrayToVector(env, j_result);
+
+  env->DeleteLocalRef(j_directory);
+  env->DeleteLocalRef(j_extensions);
+  env->DeleteLocalRef(j_result);
 
   return result;
 }

--- a/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
@@ -20,7 +20,7 @@ std::string GetJString(JNIEnv* env, jstring jstr)
   const jchar* jchars = env->GetStringChars(jstr, nullptr);
   const jsize length = env->GetStringLength(jstr);
   const std::u16string_view string_view(reinterpret_cast<const char16_t*>(jchars), length);
-  const std::string converted_string = UTF16ToUTF8(string_view);
+  std::string converted_string = UTF16ToUTF8(string_view);
   env->ReleaseStringChars(jstr, jchars);
   return converted_string;
 }
@@ -48,16 +48,9 @@ std::vector<std::string> JStringArrayToVector(JNIEnv* env, jobjectArray array)
   return result;
 }
 
-jobjectArray VectorToJStringArray(JNIEnv* env, std::vector<std::string> vector)
+jobjectArray VectorToJStringArray(JNIEnv* env, const std::vector<std::string>& vector)
 {
-  jobjectArray result = env->NewObjectArray(vector.size(), IDCache::GetStringClass(), nullptr);
-  for (jsize i = 0; i < vector.size(); ++i)
-  {
-    jstring str = ToJString(env, vector[i]);
-    env->SetObjectArrayElement(result, i, str);
-    env->DeleteLocalRef(str);
-  }
-  return result;
+  return VectorToJObjectArray(env, vector, IDCache::GetStringClass(), ToJString);
 }
 
 bool IsPathAndroidContent(const std::string& uri)

--- a/Source/Android/jni/AndroidCommon/AndroidCommon.h
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.h
@@ -13,7 +13,20 @@ std::string GetJString(JNIEnv* env, jstring jstr);
 jstring ToJString(JNIEnv* env, const std::string& str);
 
 std::vector<std::string> JStringArrayToVector(JNIEnv* env, jobjectArray array);
-jobjectArray VectorToJStringArray(JNIEnv* env, std::vector<std::string> vector);
+jobjectArray VectorToJStringArray(JNIEnv* env, const std::vector<std::string>& vector);
+
+template <typename T, typename F>
+jobjectArray VectorToJObjectArray(JNIEnv* env, const std::vector<T>& vector, jclass clazz, F f)
+{
+  jobjectArray result = env->NewObjectArray(vector.size(), clazz, nullptr);
+  for (jsize i = 0; i < vector.size(); ++i)
+  {
+    jobject obj = f(env, vector[i]);
+    env->SetObjectArrayElement(result, i, obj);
+    env->DeleteLocalRef(obj);
+  }
+  return result;
+}
 
 // Returns true if the given path should be opened as Android content instead of a normal file.
 bool IsPathAndroidContent(const std::string& uri);

--- a/Source/Android/jni/Cheats/ARCheat.cpp
+++ b/Source/Android/jni/Cheats/ARCheat.cpp
@@ -147,14 +147,7 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_ARCheat_loadCodes(JNIEnv* e
   const std::vector<ActionReplay::ARCode> codes =
       ActionReplay::LoadCodes(game_ini_default, game_ini_local);
 
-  const jobjectArray array =
-      env->NewObjectArray(static_cast<jsize>(codes.size()), IDCache::GetARCheatClass(), nullptr);
-
-  jsize i = 0;
-  for (const ActionReplay::ARCode& code : codes)
-    env->SetObjectArrayElement(array, i++, ARCheatToJava(env, code));
-
-  return array;
+  return VectorToJObjectArray(env, codes, IDCache::GetARCheatClass(), ARCheatToJava);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_cheats_model_ARCheat_saveCodes(

--- a/Source/Android/jni/Cheats/GeckoCheat.cpp
+++ b/Source/Android/jni/Cheats/GeckoCheat.cpp
@@ -155,14 +155,7 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_GeckoCheat_loadCodes(JNIEnv
 
   const std::vector<Gecko::GeckoCode> codes = Gecko::LoadCodes(game_ini_default, game_ini_local);
 
-  const jobjectArray array =
-      env->NewObjectArray(static_cast<jsize>(codes.size()), IDCache::GetGeckoCheatClass(), nullptr);
-
-  jsize i = 0;
-  for (const Gecko::GeckoCode& code : codes)
-    env->SetObjectArrayElement(array, i++, GeckoCheatToJava(env, code));
-
-  return array;
+  return VectorToJObjectArray(env, codes, IDCache::GetGeckoCheatClass(), GeckoCheatToJava);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_cheats_model_GeckoCheat_saveCodes(

--- a/Source/Android/jni/Cheats/GraphicsModGroup.cpp
+++ b/Source/Android/jni/Cheats/GraphicsModGroup.cpp
@@ -62,14 +62,9 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_GraphicsModGroup_getMods(JN
     mods.push_back(&mod);
   }
 
-  const jobjectArray array =
-      env->NewObjectArray(static_cast<jsize>(mods.size()), IDCache::GetGraphicsModClass(), nullptr);
-
-  jsize i = 0;
-  for (GraphicsModConfig* mod : mods)
-    env->SetObjectArrayElement(array, i++, GraphicsModToJava(env, mod, obj));
-
-  return array;
+  return VectorToJObjectArray(
+      env, mods, IDCache::GetGraphicsModClass(),
+      [obj](JNIEnv* env, GraphicsModConfig* mod) { return GraphicsModToJava(env, mod, obj); });
 }
 
 JNIEXPORT void JNICALL

--- a/Source/Android/jni/Cheats/PatchCheat.cpp
+++ b/Source/Android/jni/Cheats/PatchCheat.cpp
@@ -134,14 +134,7 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_PatchCheat_loadCodes(JNIEnv
   std::vector<PatchEngine::Patch> patches;
   PatchEngine::LoadPatchSection("OnFrame", &patches, game_ini_default, game_ini_local);
 
-  const jobjectArray array = env->NewObjectArray(static_cast<jsize>(patches.size()),
-                                                 IDCache::GetPatchCheatClass(), nullptr);
-
-  jsize i = 0;
-  for (const PatchEngine::Patch& patch : patches)
-    env->SetObjectArrayElement(array, i++, PatchCheatToJava(env, patch));
-
-  return array;
+  return VectorToJObjectArray(env, patches, IDCache::GetPatchCheatClass(), PatchCheatToJava);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_cheats_model_PatchCheat_saveCodes(

--- a/Source/Android/jni/GameList/GameFileCache.cpp
+++ b/Source/Android/jni/GameList/GameFileCache.cpp
@@ -52,7 +52,9 @@ Java_org_dolphinemu_dolphinemu_model_GameFileCache_getAllGames(JNIEnv* env, jobj
       env->NewObjectArray(static_cast<jsize>(ptr->GetSize()), IDCache::GetGameFileClass(), nullptr);
   jsize i = 0;
   GetPointer(env, obj)->ForEach([env, array, &i](const auto& game_file) {
-    env->SetObjectArrayElement(array, i++, GameFileToJava(env, game_file));
+    jobject j_game_file = GameFileToJava(env, game_file);
+    env->SetObjectArrayElement(array, i++, j_game_file);
+    env->DeleteLocalRef(j_game_file);
   });
   return array;
 }


### PR DESCRIPTION
If we're in a function that isn't just going to immediately return to Java, leaking local references can lead to problems eventually.