### PR TITLE
Video Common: Fix Speed Counter Sample Size

### DIFF
--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -34,7 +34,7 @@ public:
 private:
   PerformanceTracker m_fps_counter{"render_times.txt"};
   PerformanceTracker m_vps_counter{"vblank_times.txt"};
-  PerformanceTracker m_speed_counter{nullptr, 6000000};
+  PerformanceTracker m_speed_counter{nullptr, 500000};
 };
 
 extern PerformanceMetrics g_perf_metrics;


### PR DESCRIPTION
A typo in the original commit made the speed counter sample the last 6 seconds (because of some smoothing it ends up being more like 10 seconds)

This commit reverts it back to its original 0.5s