### PR TITLE
AdvancedWidget: Add title for performance sample window tooltip

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -58,6 +58,7 @@ void AdvancedWidget::CreateWidgets()
   m_show_speed = new GraphicsBool(tr("Show % Speed"), Config::GFX_SHOW_SPEED);
   m_show_speed_colors = new GraphicsBool(tr("Show Speed Colors"), Config::GFX_SHOW_SPEED_COLORS);
   m_perf_samp_window = new GraphicsInteger(0, 10000, Config::GFX_PERF_SAMP_WINDOW, 100);
+  m_perf_samp_window->SetTitle(tr("Performance Sample Window (ms)"));
   m_log_render_time =
       new GraphicsBool(tr("Log Render Time to File"), Config::GFX_LOG_RENDER_TIME_TO_FILE);
 

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -275,7 +275,7 @@ void AdvancedWidget::AddDescriptions()
   static const char TR_PERF_SAMP_WINDOW_DESCRIPTION[] =
       QT_TR_NOOP("The amount of time the FPS and VPS counters will sample over."
                  "<br><br>The higher the value, the more stable the FPS/VPS counter will be, "
-                 "but the slower it will be slower to update."
+                 "but the slower it will be to update."
                  "<br><br><dolphin_emphasis>If unsure, leave this "
                  "at 1000ms.</dolphin_emphasis>");
   static const char TR_LOG_RENDERTIME_DESCRIPTION[] = QT_TR_NOOP(


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/8334194/209586219-0762232e-af17-4f39-8e74-4a5dd352498f.png)

After:

![image](https://user-images.githubusercontent.com/8334194/209586224-cd6ffa72-6d18-4276-ba86-00b478850075.png)

I have mixed feelings on this since it adds a second translatable string, although it looks like the same thing applies for combo boxes, not just input fields. It's still annoying that both need to be manually set, and I doubt they would ever have distinct translations beyond the colon.

The same thing already applies to PNG compression level (from #10143) for what it's worth.