### PR TITLE
Netplay: Fix traversal connections occasionally not working

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -248,7 +248,12 @@ bool NetPlayClient::Connect()
   sf::Packet rpac;
   // TODO: make this not hang
   ENetEvent netEvent;
-  if (enet_host_service(m_client, &netEvent, 5000) > 0 && netEvent.type == ENET_EVENT_TYPE_RECEIVE)
+  int net;
+  while ((net = enet_host_service(m_client, &netEvent, 5000)) > 0 && netEvent.type == 42)
+  {
+    // ignore packets from traversal server
+  }
+  if (net > 0 && netEvent.type == ENET_EVENT_TYPE_RECEIVE)
   {
     rpac.append(netEvent.packet->data, netEvent.packet->dataLength);
     enet_packet_destroy(netEvent.packet);


### PR DESCRIPTION
In the NetPlayClient::Connect function, a packet is sent to the host, and the next received packet is treated as the response. However, sometimes, a ping response from the traversal server will arrive in-between, which breaks everything. In certain high-latency situations, it may even occur every time. This PR simply ignores any packets from the traversal server during this interaction.