### PR TITLE
Fix ESDevice::GetTitlesWithTickets always returning 0 titles owned

### DIFF
--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -163,8 +163,8 @@ std::vector<u64> ESDevice::GetTitlesWithTickets() const
       const std::string name_without_ext = file_name.substr(0, 8);
       if (fs->ReadDirectory(PID_KERNEL, PID_KERNEL,
                             fmt::format("/ticket/{}/{}", title_type, file_name)) ||
-          !IsValidPartOfTitleID(name_without_ext) || name_without_ext + ".tik" != file_name ||
-          name_without_ext + ".tv1" != file_name)
+          !IsValidPartOfTitleID(name_without_ext) ||
+          (name_without_ext + ".tik" != file_name && name_without_ext + ".tv1" != file_name))
       {
         continue;
       }


### PR DESCRIPTION
An incorrectly made if statement would cause `ESDevice::GetTitlesWithTickets` to always return 0 titles owned.