### PR TITLE
PixelShaderGen: Clamp texture layer when using manual texture sampling with stereoscopic 3D

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -615,6 +615,7 @@ uint WrapCoord(int coord, uint wrap, int size) {{
   int3 size = textureSize(tex, 0);
   int size_s = size.x;
   int size_t = size.y;
+  int num_layers = size.z;
 )");
       if (g_ActiveConfig.backend_info.bSupportsTextureQueryLevels)
       {
@@ -633,6 +634,8 @@ uint WrapCoord(int coord, uint wrap, int size) {{
   // Rescale uv to account for the new texture size
   uv.x = (uv.x * size_s) / native_size_s;
   uv.y = (uv.y * size_t) / native_size_t;
+  // Clamp layer as well (texture() automatically clamps, but texelFetch() doesn't)
+  layer = clamp(layer, 0, num_layers - 1);
 )");
     }
     else

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -42,7 +42,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.enable_validation_layer = g_ActiveConfig.bEnableValidationLayer;
   bits.manual_texture_sampling = !g_ActiveConfig.bFastTextureSampling;
   bits.manual_texture_sampling_custom_texture_sizes =
-      g_ActiveConfig.ManualTextureSamplingWithHiResTextures();
+      g_ActiveConfig.ManualTextureSamplingWithCustomTextureSizes();
   bits.backend_sampler_lod_bias = g_ActiveConfig.backend_info.bSupportsLodBiasInSampler;
   bits.backend_dynamic_vertex_loader = g_ActiveConfig.backend_info.bSupportsDynamicVertexLoader;
   bits.backend_vs_point_line_expand = g_ActiveConfig.UseVSForLinePointExpand();


### PR DESCRIPTION
Fixes https://forums.dolphin-emu.org/Thread-manual-texture-sampling-does-not-work-with-stereoscopic-3d.

Otherwise, `texelFetch()` will use an out-of-bounds layer for game textures (that have 1 layer; EFB copies have 2 layers in stereoscopic 3D mode), which is undefined behavior (often resulting in a black image). The fast texture sampling path uses `texture()`, which always clamps (see https://www.khronos.org/opengl/wiki/Array_Texture#Access_in_shaders), so it was unaffected by this difference.
