### PR TITLE
Software: Remove alpha=1 blending special-case

### DIFF
--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -544,19 +544,6 @@ void Tev::Draw()
   if (!TevAlphaTest(output[ALP_C]))
     return;
 
-  // Hardware testing indicates that an alpha of 1 can pass an alpha test,
-  // but doesn't do anything in blending
-  // This situation is important for Mario Kart Wii's menus (they will render incorrectly if the
-  // alpha test for the FMV in the background fails, since they depend on depth for drawing a yellow
-  // border) and Fortune Street's gameplay (where a rectangle with an alpha value of 1 is drawn over
-  // the center of the screen several times, but those rectangles shouldn't be visible).
-  // Blending seems to result in no changes to the output with an alpha of 1, even if the input
-  // color is white.
-  // TODO: Investigate this further: we might be handling blending incorrectly in general (though
-  // there might not be any good way of changing blending behavior)
-  if (output[ALP_C] == 1)
-    output[ALP_C] = 0;
-
   // z texture
   if (bpmem.ztex2.op != ZTexOp::Disabled)
   {


### PR DESCRIPTION
This was added in #10394 for both the hardware and software backends to work around an issue with Mario Kart Wii, Fortune Street, and Baten Kaitos. However, it seems like the software renderer handles blending well enough that we don't need this (and in any case, it's easy to change blending in the software renderer).

Some experimentation with #11387 (not pushed) showed that the software renderer's logic would also produce correct results on the hardware backends with this hack removed, but would require fbfetch (currently); if a better solution is found the hack can also be removed from the hardware backends.