### PR TITLE
Core/Boot: Pass System instance to BootUp() and related.

### DIFF
--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -19,6 +19,11 @@
 #include "DiscIO/VolumeDisc.h"
 #include "DiscIO/VolumeWad.h"
 
+namespace Core
+{
+class System;
+}
+
 namespace File
 {
 class IOFile;
@@ -143,7 +148,7 @@ struct BootParameters
 class CBoot
 {
 public:
-  static bool BootUp(std::unique_ptr<BootParameters> boot);
+  static bool BootUp(Core::System& system, std::unique_ptr<BootParameters> boot);
 
   // Tries to find a map file for the current game by looking first in the
   // local user directory, then in the shared user directory.
@@ -166,24 +171,24 @@ private:
 
   static void UpdateDebugger_MapLoaded();
 
-  static bool Boot_WiiWAD(const DiscIO::VolumeWAD& wad);
-  static bool BootNANDTitle(u64 title_id);
+  static bool Boot_WiiWAD(Core::System& system, const DiscIO::VolumeWAD& wad);
+  static bool BootNANDTitle(Core::System& system, u64 title_id);
 
   static void SetupMSR();
   static void SetupHID(bool is_wii);
   static void SetupBAT(bool is_wii);
   static bool RunApploader(bool is_wii, const DiscIO::VolumeDisc& volume,
                            const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
-  static bool EmulatedBS2_GC(const DiscIO::VolumeDisc& volume,
+  static bool EmulatedBS2_GC(Core::System& system, const DiscIO::VolumeDisc& volume,
                              const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
-  static bool EmulatedBS2_Wii(const DiscIO::VolumeDisc& volume,
+  static bool EmulatedBS2_Wii(Core::System& system, const DiscIO::VolumeDisc& volume,
                               const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
-  static bool EmulatedBS2(bool is_wii, const DiscIO::VolumeDisc& volume,
+  static bool EmulatedBS2(Core::System& system, bool is_wii, const DiscIO::VolumeDisc& volume,
                           const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
-  static bool Load_BS2(const std::string& boot_rom_filename);
+  static bool Load_BS2(Core::System& system, const std::string& boot_rom_filename);
 
-  static void SetupGCMemory();
-  static bool SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type);
+  static void SetupGCMemory(Core::System& system);
+  static bool SetupWiiMemory(Core::System& system, IOS::HLE::IOSC::ConsoleType console_type);
 };
 
 class BootExecutableReader

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -211,9 +211,8 @@ bool CBoot::RunApploader(bool is_wii, const DiscIO::VolumeDisc& volume,
   return true;
 }
 
-void CBoot::SetupGCMemory()
+void CBoot::SetupGCMemory(Core::System& system)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
   // Booted from bootrom. 0xE5207C22 = booted from jtag
@@ -251,18 +250,16 @@ void CBoot::SetupGCMemory()
 // GameCube Bootstrap 2 HLE:
 // copy the apploader to 0x81200000
 // execute the apploader, function by function, using the above utility.
-bool CBoot::EmulatedBS2_GC(const DiscIO::VolumeDisc& volume,
+bool CBoot::EmulatedBS2_GC(Core::System& system, const DiscIO::VolumeDisc& volume,
                            const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches)
 {
   INFO_LOG_FMT(BOOT, "Faking GC BS2...");
-
-  auto& system = Core::System::GetInstance();
 
   SetupMSR();
   SetupHID(/*is_wii*/ false);
   SetupBAT(/*is_wii*/ false);
 
-  SetupGCMemory();
+  SetupGCMemory(system);
 
   // Datel titles don't initialize the postMatrices, but they have dual-texture coordinate
   // transformation enabled. We initialize all of xfmem to 0, which results in everything using
@@ -332,7 +329,7 @@ static DiscIO::Region CodeRegion(char c)
   }
 }
 
-bool CBoot::SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type)
+bool CBoot::SetupWiiMemory(Core::System& system, IOS::HLE::IOSC::ConsoleType console_type)
 {
   static const std::map<DiscIO::Region, const RegionSetting> region_settings = {
       {DiscIO::Region::NTSC_J, {"JPN", "NTSC", "JP", "LJH"}},
@@ -420,7 +417,6 @@ bool CBoot::SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type)
     return false;
   }
 
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
   // Write the 256 byte setting.txt to memory.
@@ -504,7 +500,7 @@ static void WriteEmptyPlayRecord()
 // Wii Bootstrap 2 HLE:
 // copy the apploader to 0x81200000
 // execute the apploader
-bool CBoot::EmulatedBS2_Wii(const DiscIO::VolumeDisc& volume,
+bool CBoot::EmulatedBS2_Wii(Core::System& system, const DiscIO::VolumeDisc& volume,
                             const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches)
 {
   INFO_LOG_FMT(BOOT, "Faking Wii BS2...");
@@ -524,7 +520,6 @@ bool CBoot::EmulatedBS2_Wii(const DiscIO::VolumeDisc& volume,
     state->discstate = 0x01;
   });
 
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
   // The system menu clears the RTC flags.
@@ -547,7 +542,7 @@ bool CBoot::EmulatedBS2_Wii(const DiscIO::VolumeDisc& volume,
   const u64 ios = ios_override >= 0 ? Titles::IOS(static_cast<u32>(ios_override)) : tmd.GetIOSId();
 
   const auto console_type = volume.GetTicket(data_partition).GetConsoleType();
-  if (!SetupWiiMemory(console_type) || !IOS::HLE::GetIOS()->BootIOS(ios))
+  if (!SetupWiiMemory(system, console_type) || !IOS::HLE::GetIOS()->BootIOS(ios))
     return false;
 
   auto di =
@@ -589,9 +584,9 @@ bool CBoot::EmulatedBS2_Wii(const DiscIO::VolumeDisc& volume,
 
 // Returns true if apploader has run successfully. If is_wii is true, the disc
 // that volume refers to must currently be inserted into the emulated disc drive.
-bool CBoot::EmulatedBS2(bool is_wii, const DiscIO::VolumeDisc& volume,
+bool CBoot::EmulatedBS2(Core::System& system, bool is_wii, const DiscIO::VolumeDisc& volume,
                         const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches)
 {
-  return is_wii ? EmulatedBS2_Wii(volume, riivolution_patches) :
-                  EmulatedBS2_GC(volume, riivolution_patches);
+  return is_wii ? EmulatedBS2_Wii(system, volume, riivolution_patches) :
+                  EmulatedBS2_GC(system, volume, riivolution_patches);
 }

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -15,7 +15,7 @@
 #include "Core/WiiUtils.h"
 #include "DiscIO/VolumeWad.h"
 
-bool CBoot::BootNANDTitle(const u64 title_id)
+bool CBoot::BootNANDTitle(Core::System& system, const u64 title_id)
 {
   UpdateStateFlags([](StateFlags* state) {
     state->type = 0x04;  // TYPE_NANDBOOT
@@ -28,16 +28,16 @@ bool CBoot::BootNANDTitle(const u64 title_id)
     console_type = ticket.GetConsoleType();
   else
     ERROR_LOG_FMT(BOOT, "No ticket was found for {:016x}", title_id);
-  SetupWiiMemory(console_type);
+  SetupWiiMemory(system, console_type);
   return es->LaunchTitle(title_id);
 }
 
-bool CBoot::Boot_WiiWAD(const DiscIO::VolumeWAD& wad)
+bool CBoot::Boot_WiiWAD(Core::System& system, const DiscIO::VolumeWAD& wad)
 {
   if (!WiiUtils::InstallWAD(*IOS::HLE::GetIOS(), wad, WiiUtils::InstallType::Temporary))
   {
     PanicAlertFmtT("Cannot boot this WAD because it could not be installed to the NAND.");
     return false;
   }
-  return BootNANDTitle(wad.GetTMD().GetTitleId());
+  return BootNANDTitle(system, wad.GetTMD().GetTitleId());
 }

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -585,7 +585,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   if (SConfig::GetInstance().bWii)
     savegame_redirect = DiscIO::Riivolution::ExtractSavegameRedirect(boot->riivolution_patches);
 
-  if (!CBoot::BootUp(std::move(boot)))
+  if (!CBoot::BootUp(system, std::move(boot)))
     return;
 
   // Initialise Wii filesystem contents.


### PR DESCRIPTION
Removing a bit of `Core::System::GetInstance()`.