### PR TITLE
Android: Move FPS-related settings to a submenu

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
@@ -22,6 +22,7 @@ public enum MenuTag
   ENHANCEMENTS("enhancements"),
   STEREOSCOPY("stereoscopy"),
   HACKS("hacks"),
+  STATISTICS("statistics"),
   ADVANCED_GRAPHICS("advanced_graphics"),
   GCPAD_TYPE("gc_pad_type"),
   WIIMOTE("wiimote"),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -57,6 +57,7 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
     titles.put(MenuTag.ENHANCEMENTS, R.string.enhancements_submenu);
     titles.put(MenuTag.STEREOSCOPY, R.string.stereoscopy_submenu);
     titles.put(MenuTag.HACKS, R.string.hacks_submenu);
+    titles.put(MenuTag.STATISTICS, R.string.statistics_submenu);
     titles.put(MenuTag.ADVANCED_GRAPHICS, R.string.advanced_graphics_submenu);
     titles.put(MenuTag.CONFIG_LOG, R.string.log_submenu);
     titles.put(MenuTag.GCPAD_TYPE, R.string.gcpad_settings);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -206,6 +206,10 @@ public final class SettingsFragmentPresenter
         addHackSettings(sl);
         break;
 
+      case STATISTICS:
+        addStatisticsSettings(sl);
+        break;
+
       case ADVANCED_GRAPHICS:
         addAdvancedGraphicsSettings(sl);
         break;
@@ -768,21 +772,6 @@ public final class SettingsFragmentPresenter
     sl.add(new HeaderSetting(mContext, R.string.graphics_general, 0));
     sl.add(new StringSingleChoiceSetting(mContext, StringSetting.MAIN_GFX_BACKEND,
             R.string.video_backend, 0, R.array.videoBackendEntries, R.array.videoBackendValues));
-    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_FPS, R.string.show_fps,
-            R.string.show_fps_description));
-    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_FTIMES, R.string.show_ftimes,
-            R.string.show_ftimes_description));
-    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_VPS, R.string.show_vps,
-            R.string.show_vps_description));
-    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_VTIMES, R.string.show_vtimes,
-            R.string.show_vtimes_description));
-    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_GRAPHS, R.string.show_graphs,
-            R.string.show_graphs_description));
-    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_SPEED, R.string.show_speed,
-            R.string.show_speed_description));
-    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_SPEED_COLORS,
-            R.string.show_speed_colors,
-            R.string.show_speed_colors_description));
     sl.add(new SingleChoiceSettingDynamicDescriptions(mContext,
             IntSetting.GFX_SHADER_COMPILATION_MODE, R.string.shader_compilation_mode, 0,
             R.array.shaderCompilationModeEntries, R.array.shaderCompilationModeValues,
@@ -796,6 +785,7 @@ public final class SettingsFragmentPresenter
     sl.add(new HeaderSetting(mContext, R.string.graphics_more_settings, 0));
     sl.add(new SubmenuSetting(mContext, R.string.enhancements_submenu, MenuTag.ENHANCEMENTS));
     sl.add(new SubmenuSetting(mContext, R.string.hacks_submenu, MenuTag.HACKS));
+    sl.add(new SubmenuSetting(mContext, R.string.statistics_submenu, MenuTag.STATISTICS));
     sl.add(new SubmenuSetting(mContext, R.string.advanced_graphics_submenu,
             MenuTag.ADVANCED_GRAPHICS));
   }
@@ -893,6 +883,25 @@ public final class SettingsFragmentPresenter
             R.string.vertex_rounding, R.string.vertex_rounding_description));
     sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SAVE_TEXTURE_CACHE_TO_STATE,
             R.string.texture_cache_to_state, R.string.texture_cache_to_state_description));
+  }
+
+  private void addStatisticsSettings(ArrayList<SettingsItem> sl)
+  {
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_FPS, R.string.show_fps,
+            R.string.show_fps_description));
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_FTIMES, R.string.show_ftimes,
+            R.string.show_ftimes_description));
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_VPS, R.string.show_vps,
+            R.string.show_vps_description));
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_VTIMES, R.string.show_vtimes,
+            R.string.show_vtimes_description));
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_GRAPHS, R.string.show_graphs,
+            R.string.show_graphs_description));
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_SPEED, R.string.show_speed,
+            R.string.show_speed_description));
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_SPEED_COLORS,
+            R.string.show_speed_colors,
+            R.string.show_speed_colors_description));
   }
 
   private void addAdvancedGraphicsSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -243,20 +243,6 @@
     <!-- Video Preference Fragment -->
     <string name="video_backend">Video Backend</string>
     <string name="video_backend_description">Select the API used for graphics rendering.</string>
-    <string name="show_fps">Show FPS</string>
-    <string name="show_fps_description">Shows the number of distinct frames rendered per second as a measure of visual smoothness.</string>
-    <string name="show_ftimes">Show Frame Times</string>
-    <string name="show_ftimes_description">Shows the average time in ms between each distinct rendered frame alongside the standard deviation.</string>
-    <string name="show_vps">Show VPS</string>
-    <string name="show_vps_description">Show the number of frames rendered per second as a measure of emulation speed.</string>
-    <string name="show_vtimes">Show VBlank Times</string>
-    <string name="show_vtimes_description">Shows the average time in ms between each rendered frame alongside the standard deviation.</string>
-    <string name="show_graphs">Show Performance Graphs</string>
-    <string name="show_graphs_description">Shows frametime graph along with statistics as a representation of emulation performance.</string>
-    <string name="show_speed">Show % Speed</string>
-    <string name="show_speed_description">Shows the % speed of emulation compared to full speed.</string>
-    <string name="show_speed_colors">Show Speed Color</string>
-    <string name="show_speed_colors_description">Changes the color of the FPS counter depending on emulation speed.</string>
     <string name="enhancements_submenu">Enhancements</string>
     <string name="internal_resolution">Internal Resolution</string>
     <string name="internal_resolution_description">Specifies the resolution used to render at. A high resolution will improve visual quality a lot but is also quite heavy on performance and might cause glitches in certain games.</string>
@@ -330,6 +316,22 @@
     <string name="shader_compilation_mode">Shader Compilation Mode</string>
     <string name="wait_for_shaders">Compile Shaders Before Starting</string>
     <string name="wait_for_shaders_description">This causes a delay when launching games, but will reduce stuttering early on.</string>
+
+    <string name="statistics_submenu">Statistics</string>
+    <string name="show_fps">Show FPS</string>
+    <string name="show_fps_description">Shows the number of distinct frames rendered per second as a measure of visual smoothness.</string>
+    <string name="show_ftimes">Show Frame Times</string>
+    <string name="show_ftimes_description">Shows the average time in ms between each distinct rendered frame alongside the standard deviation.</string>
+    <string name="show_vps">Show VPS</string>
+    <string name="show_vps_description">Show the number of frames rendered per second as a measure of emulation speed.</string>
+    <string name="show_vtimes">Show VBlank Times</string>
+    <string name="show_vtimes_description">Shows the average time in ms between each rendered frame alongside the standard deviation.</string>
+    <string name="show_graphs">Show Performance Graphs</string>
+    <string name="show_graphs_description">Shows frametime graph along with statistics as a representation of emulation performance.</string>
+    <string name="show_speed">Show % Speed</string>
+    <string name="show_speed_description">Shows the % speed of emulation compared to full speed.</string>
+    <string name="show_speed_colors">Show Speed Color</string>
+    <string name="show_speed_colors_description">Changes the color of the FPS counter depending on emulation speed.</string>
 
     <string name="advanced_graphics_submenu">Advanced</string>
     <string name="gfx_mods_and_custom_textures">Graphics Mods and Custom Textures</string>


### PR DESCRIPTION
Back when this was just the FPS setting, having it in the top level of the graphics settings was reasonable. But now it's seven settings. Let's add a new submenu for them.