### PR TITLE
Externals: Exclude libcurl.rc from the build

### DIFF
--- a/Externals/curl/curl.vcxproj
+++ b/Externals/curl/curl.vcxproj
@@ -357,9 +357,6 @@
     <ClInclude Include="lib\wildcard.h" />
     <ClInclude Include="lib\x509asn1.h" />
   </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="lib\libcurl.rc" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
For some reason, when this is included, the linking step creates a temporary file in %TEMP% with a random name; the file is deleted afterwards and a new random name is used on a later build. Because this file doesn't exist on a later build, curl gets re-linked each time, and then all of the projects that depend on curl also get re-linked. This adds around 10 seconds to the build time even for small changes.

To make things worse, I don't think libcurl.rc does anything useful since we statically link curl; I believe the metadata contained in it only applies when building a dll. (It does seem to be included in curl.lib, but gets discarded when linking Dolphin.exe.)

See Build\x64\Release\curl\curl.tlog\Lib-link-cvtres.write.1.tlog for the log that shows this path (the file is also mentioned after setting Tools -> Options... -> Projects and Solutions -> Build and Run -> MSBuild project build output verbosity to diagnostic, but not in a useful way).