### PR TITLE
DolphinAnalytics: Track support of framebuffer fetch

### DIFF
--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -421,6 +421,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("gpu-has-palette-conversion", g_Config.backend_info.bSupportsPaletteConversion);
   builder.AddData("gpu-has-clip-control", g_Config.backend_info.bSupportsClipControl);
   builder.AddData("gpu-has-ssaa", g_Config.backend_info.bSupportsSSAA);
+  builder.AddData("gpu-has-logic-ops", g_Config.backend_info.bSupportsLogicOp);
 
   // NetPlay / recording.
   builder.AddData("netplay", NetPlay::IsNetPlayRunning());

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -422,6 +422,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("gpu-has-clip-control", g_Config.backend_info.bSupportsClipControl);
   builder.AddData("gpu-has-ssaa", g_Config.backend_info.bSupportsSSAA);
   builder.AddData("gpu-has-logic-ops", g_Config.backend_info.bSupportsLogicOp);
+  builder.AddData("gpu-has-framebuffer-fetch", g_Config.backend_info.bSupportsFramebufferFetch);
 
   // NetPlay / recording.
   builder.AddData("netplay", NetPlay::IsNetPlayRunning());

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -428,8 +428,7 @@ void DolphinAnalytics::MakePerGameBuilder()
 
   // Controller information
   // We grab enough to tell what percentage of our users are playing with keyboard/mouse, some kind
-  // of gamepad
-  // or the official GameCube adapter.
+  // of gamepad, or the official GameCube adapter.
   builder.AddData("gcadapter-detected", GCAdapter::IsDetected(nullptr));
   builder.AddData("has-controller", Pad::GetConfig()->IsControllerControlledByGamepadDevice(0) ||
                                         GCAdapter::IsDetected(nullptr));

--- a/Source/Core/VideoBackends/OGL/OGLRender.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLRender.cpp
@@ -489,6 +489,21 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
   g_Config.backend_info.bSupportsTextureQueryLevels =
       GLExtensions::Supports("GL_ARB_texture_query_levels") || GLExtensions::Version() >= 430;
 
+  if (GLExtensions::Supports("GL_EXT_shader_framebuffer_fetch"))
+  {
+    g_ogl_config.SupportedFramebufferFetch = EsFbFetchType::FbFetchExt;
+  }
+  else if (GLExtensions::Supports("GL_ARM_shader_framebuffer_fetch"))
+  {
+    g_ogl_config.SupportedFramebufferFetch = EsFbFetchType::FbFetchArm;
+  }
+  else
+  {
+    g_ogl_config.SupportedFramebufferFetch = EsFbFetchType::FbFetchNone;
+  }
+  g_Config.backend_info.bSupportsFramebufferFetch =
+      g_ogl_config.SupportedFramebufferFetch != EsFbFetchType::FbFetchNone;
+
   if (m_main_gl_context->IsGLES())
   {
     g_ogl_config.SupportedESPointSize = GLExtensions::Supports("GL_OES_geometry_point_size") ? 1 :
@@ -516,21 +531,6 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
 
     // GL_TEXTURE_LOD_BIAS is not supported on GLES.
     g_Config.backend_info.bSupportsLodBiasInSampler = false;
-
-    if (GLExtensions::Supports("GL_EXT_shader_framebuffer_fetch"))
-    {
-      g_ogl_config.SupportedFramebufferFetch = EsFbFetchType::FbFetchExt;
-    }
-    else if (GLExtensions::Supports("GL_ARM_shader_framebuffer_fetch"))
-    {
-      g_ogl_config.SupportedFramebufferFetch = EsFbFetchType::FbFetchArm;
-    }
-    else
-    {
-      g_ogl_config.SupportedFramebufferFetch = EsFbFetchType::FbFetchNone;
-    }
-    g_Config.backend_info.bSupportsFramebufferFetch =
-        g_ogl_config.SupportedFramebufferFetch != EsFbFetchType::FbFetchNone;
 
     if (GLExtensions::Version() == 300)
     {


### PR DESCRIPTION
This PR adds the presence of fbfetch support to the analytics system. Based on #11387 it looks like fbfetch will be needed to accurately emulate blending behavior (impacting bloom in some games, as well as the menus in mario kart wii and a white box on fortune street, although we have a separate hack that fixes those), so it would be good to know how many users actually will have access to it.

This PR also checks for support of `GL_EXT_shader_framebuffer_fetch` on regular OpenGL, instead of just OpenGL ES. Intel GPUs support it. I think the only effects of this are that ubershaders will use fbfetch and the fbfetch fallback becomes available if logic ops or dual source blend aren't supported. (Side note: it looks like analytics also tracks dual source blend support, but doesn't track logic ops support. Is that something worth adding?)