### PR TITLE
InputCommon:QuartzKB&M: Fix mouse y coordinates

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -259,16 +259,14 @@ void KeyboardAndMouse::UpdateInput()
   }
   else
   {
-    CGEventRef event = CGEventCreate(nil);
-    CGPoint loc = CGEventGetLocation(event);
-    CFRelease(event);
+    NSPoint loc = [NSEvent mouseLocation];
 
     const auto window_scale = g_controller_interface.GetWindowInputScale();
 
     loc.x -= bounds.origin.x;
     loc.y -= bounds.origin.y;
     m_cursor.x = (loc.x / window_width * 2 - 1.0) * window_scale.x;
-    m_cursor.y = (loc.y / window_height * 2 - 1.0) * window_scale.y;
+    m_cursor.y = (loc.y / window_height * 2 - 1.0) * -window_scale.y;
   }
 }
 


### PR DESCRIPTION
Fix a bug I introduced back in #10979

Cocoa uses a different coordinate system from Carbon (Carbon's origin is the top left while Cocoa's is the bottom left)

Switches to methods that use Cocoa's coordinate system