### PR TITLE
Jit: Don't use a second stack

### DIFF
--- a/Source/Core/Common/Thread.h
+++ b/Source/Core/Common/Thread.h
@@ -5,6 +5,10 @@
 
 #include <thread>
 
+#ifndef _WIN32
+#include <tuple>
+#endif
+
 // Don't include Common.h here as it will break LogManager
 #include "Common/CommonTypes.h"
 
@@ -34,5 +38,10 @@ inline void YieldCPU()
 }
 
 void SetCurrentThreadName(const char* name);
+
+#ifndef _WIN32
+// Returns the lowest address of the stack and the size of the stack
+std::tuple<void*, size_t> GetCurrentThreadStack();
+#endif
 
 }  // namespace Common

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -149,7 +149,7 @@ enum
   STACK_SIZE = 2 * 1024 * 1024,
   SAFE_STACK_SIZE = 512 * 1024,
   GUARD_SIZE = 0x10000,  // two guards - bottom (permanent) and middle (see above)
-  GUARD_OFFSET = STACK_SIZE - SAFE_STACK_SIZE - GUARD_SIZE,
+  GUARD_OFFSET = SAFE_STACK_SIZE - GUARD_SIZE,
 };
 
 Jit64::Jit64() : QuantizedMemoryRoutines(*this)

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -50,7 +50,6 @@ public:
   void Shutdown() override;
 
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
-  bool HandleStackFault() override;
   bool BackPatch(SContext* ctx);
 
   void EnableOptimization();
@@ -255,9 +254,6 @@ private:
 
   bool HandleFunctionHooking(u32 address);
 
-  void ProtectStack();
-  void UnprotectStack();
-
   void ResetFreeMemoryRanges();
 
   JitBlockCache blocks{*this};
@@ -267,10 +263,6 @@ private:
   FPURegCache fpr{*this};
 
   Jit64AsmRoutineManager asm_routines{*this};
-
-  bool m_enable_blr_optimization = false;
-  bool m_cleanup_after_stackfault = false;
-  u8* m_stack_guard = nullptr;
 
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_near;
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_far;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -255,8 +255,8 @@ private:
 
   bool HandleFunctionHooking(u32 address);
 
-  void AllocStack();
-  void FreeStack();
+  void ProtectStack();
+  void UnprotectStack();
 
   void ResetFreeMemoryRanges();
 
@@ -270,7 +270,7 @@ private:
 
   bool m_enable_blr_optimization = false;
   bool m_cleanup_after_stackfault = false;
-  u8* m_stack = nullptr;
+  u8* m_stack_guard = nullptr;
 
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_near;
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_far;

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.h
@@ -36,7 +36,7 @@ public:
 
   explicit Jit64AsmRoutineManager(Jit64& jit);
 
-  void Init(u8* stack_top);
+  void Init();
 
   void ResetStack(Gen::X64CodeBlock& emitter);
 
@@ -44,6 +44,5 @@ private:
   void Generate();
   void GenerateCommon();
 
-  u8* m_stack_top = nullptr;
   JitBase& m_jit;
 };

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -41,7 +41,7 @@ constexpr size_t FARCODE_SIZE_MMU = 1024 * 1024 * 64;
 constexpr size_t STACK_SIZE = 2 * 1024 * 1024;
 constexpr size_t SAFE_STACK_SIZE = 512 * 1024;
 constexpr size_t GUARD_SIZE = 64 * 1024;  // two guards - bottom (permanent) and middle (see above)
-constexpr size_t GUARD_OFFSET = STACK_SIZE - SAFE_STACK_SIZE - GUARD_SIZE;
+constexpr size_t GUARD_OFFSET = SAFE_STACK_SIZE - GUARD_SIZE;
 
 JitArm64::JitArm64() : m_float_emit(this)
 {

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -288,8 +288,8 @@ protected:
   void DoDownCount();
   void Cleanup();
   void ResetStack();
-  void AllocStack();
-  void FreeStack();
+  void ProtectStack();
+  void UnprotectStack();
 
   void ResetFreeMemoryRanges();
 
@@ -365,9 +365,7 @@ protected:
 
   bool m_enable_blr_optimization = false;
   bool m_cleanup_after_stackfault = false;
-  u8* m_stack_base = nullptr;
-  u8* m_stack_pointer = nullptr;
-  u8* m_saved_stack_pointer = nullptr;
+  u8* m_stack_guard = nullptr;
 
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_near;
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_far;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -32,7 +32,6 @@ public:
   bool IsInCodeSpace(const u8* ptr) const { return IsInSpace(ptr); }
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
   void DoBacktrace(uintptr_t access_address, SContext* ctx);
-  bool HandleStackFault() override;
   bool HandleFastmemFault(SContext* ctx);
 
   void ClearCache() override;
@@ -288,8 +287,6 @@ protected:
   void DoDownCount();
   void Cleanup();
   void ResetStack();
-  void ProtectStack();
-  void UnprotectStack();
 
   void ResetFreeMemoryRanges();
 
@@ -362,10 +359,6 @@ protected:
   u8* m_near_code = nullptr;
   u8* m_near_code_end = nullptr;
   bool m_near_code_write_failed = false;
-
-  bool m_enable_blr_optimization = false;
-  bool m_cleanup_after_stackfault = false;
-  u8* m_stack_guard = nullptr;
 
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_near;
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_far;

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -3,14 +3,52 @@
 
 #include "Core/PowerPC/JitCommon/JitBase.h"
 
+#include "Common/Align.h"
 #include "Common/CommonTypes.h"
+#include "Common/MemoryUtil.h"
+#include "Common/Thread.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/CoreTiming.h"
 #include "Core/HW/CPU.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <processthreadsapi.h>
+#else
+#include <unistd.h>
+#endif
+
+// The BLR optimization is nice, but it means that JITted code can overflow the
+// native stack by repeatedly running BL.  (The chance of this happening in any
+// retail game is close to 0, but correctness is correctness...) Also, the
+// overflow might not happen directly in the JITted code but in a C++ function
+// called from it, so we can't just adjust RSP in the case of a fault.
+// Instead, we have to have extra stack space preallocated under the fault
+// point which allows the code to continue, after wiping the JIT cache so we
+// can reset things at a safe point.  Once this condition trips, the
+// optimization is permanently disabled, under the assumption this will never
+// happen in practice.
+
+// On Unix, we just mark an appropriate region of the stack as PROT_NONE and
+// handle it the same way as fastmem faults.  It's safe to take a fault with a
+// bad RSP, because on Linux we can use sigaltstack and on OS X we're already
+// on a separate thread.
+
+// Windows is... under-documented.
+// It already puts guard pages so it can automatically grow the stack and it
+// doesn't look like there is a way to hook into a guard page fault and implement
+// our own logic.
+// But when windows reaches the last guard page, it raises a "Stack Overflow"
+// exception which we can hook into, however by default it leaves you with less
+// than 4kb of stack. So we use SetThreadStackGuarantee to trigger the Stack
+// Overflow early while we still have 256kb of stack remaining.
+// After resetting the stack to the top, we call _resetstkoflw() to restore
+// the guard page at the 256kb mark.
 
 const u8* JitBase::Dispatch(JitBase& jit)
 {
@@ -70,6 +108,107 @@ void JitBase::RefreshConfig()
   analyzer.SetBranchFollowingEnabled(Config::Get(Config::MAIN_JIT_FOLLOW_BRANCH));
   analyzer.SetFloatExceptionsEnabled(m_enable_float_exceptions);
   analyzer.SetDivByZeroExceptionsEnabled(m_enable_div_by_zero_exceptions);
+}
+
+void JitBase::InitBLROptimization()
+{
+  m_enable_blr_optimization = jo.enableBlocklink && m_fastmem_enabled && !m_enable_debugging;
+  m_cleanup_after_stackfault = false;
+}
+
+void JitBase::ProtectStack()
+{
+  if (!m_enable_blr_optimization)
+    return;
+
+#ifdef _WIN32
+  ULONG reserveSize = SAFE_STACK_SIZE;
+  SetThreadStackGuarantee(&reserveSize);
+#else
+  auto [stack_addr, stack_size] = Common::GetCurrentThreadStack();
+
+  const uintptr_t stack_base_addr = reinterpret_cast<uintptr_t>(stack_addr);
+  const uintptr_t stack_middle_addr = reinterpret_cast<uintptr_t>(&stack_addr);
+  if (stack_middle_addr < stack_base_addr || stack_middle_addr >= stack_base_addr + stack_size)
+  {
+    PanicAlertFmt("Failed to get correct stack base");
+    m_enable_blr_optimization = false;
+    return;
+  }
+
+  const long page_size = sysconf(_SC_PAGESIZE);
+  if (page_size <= 0)
+  {
+    PanicAlertFmt("Failed to get page size");
+    m_enable_blr_optimization = false;
+    return;
+  }
+
+  const uintptr_t stack_guard_addr = Common::AlignUp(stack_base_addr + GUARD_OFFSET, page_size);
+  if (stack_guard_addr >= stack_middle_addr ||
+      stack_middle_addr - stack_guard_addr < GUARD_SIZE + MIN_UNSAFE_STACK_SIZE)
+  {
+    PanicAlertFmt("Stack is too small for BLR optimization (size {:x}, base {:x}, current stack "
+                  "pointer {:x}, alignment {:x})",
+                  stack_size, stack_base_addr, stack_middle_addr, page_size);
+    m_enable_blr_optimization = false;
+    return;
+  }
+
+  m_stack_guard = reinterpret_cast<u8*>(stack_guard_addr);
+  Common::ReadProtectMemory(m_stack_guard, GUARD_SIZE);
+#endif
+}
+
+void JitBase::UnprotectStack()
+{
+#ifndef _WIN32
+  if (m_stack_guard)
+  {
+    Common::UnWriteProtectMemory(m_stack_guard, GUARD_SIZE);
+    m_stack_guard = nullptr;
+  }
+#endif
+}
+
+bool JitBase::HandleStackFault()
+{
+  // It's possible the stack fault might have been caused by something other than
+  // the BLR optimization. If the fault was triggered from another thread, or
+  // when BLR optimization isn't enabled then there is nothing we can do about the fault.
+  // Return false so the regular stack overflow handler can trigger (which crashes)
+  if (!m_enable_blr_optimization || !Core::IsCPUThread())
+    return false;
+
+  WARN_LOG_FMT(POWERPC, "BLR cache disabled due to excessive BL in the emulated program.");
+
+  UnprotectStack();
+  m_enable_blr_optimization = false;
+
+  // We're going to need to clear the whole cache to get rid of the bad
+  // CALLs, but we can't yet.  Fake the downcount so we're forced to the
+  // dispatcher (no block linking), and clear the cache so we're sent to
+  // Jit. In the case of Windows, we will also need to call _resetstkoflw()
+  // to reset the guard page.
+  // Yeah, it's kind of gross.
+  GetBlockCache()->InvalidateICache(0, 0xffffffff, true);
+  Core::System::GetInstance().GetCoreTiming().ForceExceptionCheck(0);
+  m_cleanup_after_stackfault = true;
+
+  return true;
+}
+
+void JitBase::CleanUpAfterStackFault()
+{
+  if (m_cleanup_after_stackfault)
+  {
+    ClearCache();
+    m_cleanup_after_stackfault = false;
+#ifdef _WIN32
+    // The stack is in an invalid state with no guard page, reset it.
+    _resetstkoflw();
+#endif
+  }
 }
 
 bool JitBase::CanMergeNextInstructions(int count) const

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -54,6 +54,12 @@ protected:
 #endif
   };
 
+  static constexpr size_t SAFE_STACK_SIZE = 256 * 1024;
+  static constexpr size_t MIN_UNSAFE_STACK_SIZE = 192 * 1024;
+  static constexpr size_t MIN_STACK_SIZE = SAFE_STACK_SIZE + MIN_UNSAFE_STACK_SIZE;
+  static constexpr size_t GUARD_SIZE = 64 * 1024;
+  static constexpr size_t GUARD_OFFSET = SAFE_STACK_SIZE - GUARD_SIZE;
+
   struct JitOptions
   {
     bool enableBlocklink;
@@ -138,7 +144,16 @@ protected:
   bool m_pause_on_panic_enabled = false;
   bool m_accurate_cpu_cache_enabled = false;
 
+  bool m_enable_blr_optimization = false;
+  bool m_cleanup_after_stackfault = false;
+  u8* m_stack_guard = nullptr;
+
   void RefreshConfig();
+
+  void InitBLROptimization();
+  void ProtectStack();
+  void UnprotectStack();
+  void CleanUpAfterStackFault();
 
   bool CanMergeNextInstructions(int count) const;
 
@@ -160,7 +175,7 @@ public:
   virtual const CommonAsmRoutinesBase* GetAsmRoutines() = 0;
 
   virtual bool HandleFault(uintptr_t access_address, SContext* ctx) = 0;
-  virtual bool HandleStackFault() { return false; }
+  bool HandleStackFault();
 
   static constexpr std::size_t code_buffer_size = 32000;
 


### PR DESCRIPTION
This second stack leads to JNI problems on Android, because ART fetches the address and size of the original stack using pthread functions (see [GetThreadStack in art/runtime/thread.cc](https://cs.android.com/android/platform/superproject/+/android-13.0.0_r18:art/runtime/thread.cc;l=1262)), and (presumably) treats stack addresses outside of the original stack as invalid. (What I don't understand is why some JNI operations on the CPU thread work fine despite this but others don't.)

Instead of creating a second stack, let's borrow the approach ART uses: Use pthread functions to find out the stack's address and size, then install guard pages at an appropriate location. This lets us get rid of a workaround we had in the MsgAlert function.

By the way, on Windows it was already the case that we didn't create a second stack... But there was a bug in the implementation! The code for protecting the stack has to run on the CPU thread, since it's the CPU thread's stack we want to protect, but it was actually running on EmuThread. This commit fixes that, since now this bug matters on other operating systems too.

An important question that will require some testing is: Is the stack size we get actually big enough on all platforms? On Android I'm getting a size just below 1 MiB. If that's the smallest we're dealing with, I'd be fine simply with dropping the requirement to that (which is what I've done for now), but if there are platforms that give us an even smaller stack, we should probably request a bigger stack in some way.