### PR TITLE
IndexGenerator: Fix off-by-one in GetRemainingIndices

### DIFF
--- a/Source/Core/VideoCommon/IndexGenerator.cpp
+++ b/Source/Core/VideoCommon/IndexGenerator.cpp
@@ -328,13 +328,21 @@ void IndexGenerator::AddExternalIndices(const u16* indices, u32 num_indices, u32
 
 u32 IndexGenerator::GetRemainingIndices(OpcodeDecoder::Primitive primitive) const
 {
-  u32 max_index = USHRT_MAX;
+  u32 max_index = UINT16_MAX;
 
   if (g_Config.UseVSForLinePointExpand() && primitive >= OpcodeDecoder::Primitive::GX_DRAW_LINES)
     max_index >>= 2;
 
-  // -1 is reserved for primitive restart
-  max_index = max_index - 1;
+  // Although we reserve UINT16_MAX for primitive restart, we aren't allowed to use that as an
+  // actual index. But, the maximum number of vertices a game can send is UINT16_MAX, so up to
+  // 0xffff indices will be used by the game. These indices would be 0x0000 through 0xfffe,
+  // and since m_base_index gets incremented for each index used, after that m_base_index
+  // would be 0xffff and no indices remain. If a game uses 0xfffe vertices, assuming m_base_index
+  // started at 0 it would end at 0xfffe and one more index could be used. So, we do not need to
+  // subtract 1 from max_index to correctly reserve one index for primitive restart.
+  //
+  // Pocoyo Racing uses a draw command with 0xffff vertices, which previously caused issues; see
+  // https://bugs.dolphin-emu.org/issues/13136 for details.
 
   if (m_base_index > max_index) [[unlikely]]
   {

--- a/Source/Core/VideoCommon/IndexGenerator.cpp
+++ b/Source/Core/VideoCommon/IndexGenerator.cpp
@@ -334,6 +334,15 @@ u32 IndexGenerator::GetRemainingIndices(OpcodeDecoder::Primitive primitive) cons
     max_index >>= 2;
 
   // -1 is reserved for primitive restart
+  max_index = max_index - 1;
 
-  return max_index - m_base_index - 1;
+  if (m_base_index > max_index) [[unlikely]]
+  {
+    PanicAlertFmt("GetRemainingIndices would overflow; we've already written too many indices? "
+                  "base index {} > max index {}",
+                  m_base_index, max_index);
+    return 0;
+  }
+
+  return max_index - m_base_index;
 }


### PR DESCRIPTION
Fixes Pocoyo Racing ([issue 13136](https://bugs.dolphin-emu.org/issues/13136)), and also log spam about "Too little remaining index values. Use 32-bit or reset them on flush." on Super Mario Sunshine's grass special stage and some smash custom levels ([issue 10312](https://bugs.dolphin-emu.org/issues/10312)).

The problem with Pocoyo Racing is that it uses 65535 (0xffff) vertices in a single draw command, which caused `GetRemainingIndices` to overflow, acting as if there was space for more vertices even though there wasn't. Then the game draws 3681 more vertices, and the indices corresponding to those vertices are all messed up because of the overflow, resulting in vertex explosions. The index generator actually can handle 0xffff indices for vertices with one more value reserved for primitive restart, so the fix is just to let that work with `GetRemainingIndices`.

The logspam is misleading, as we already reset the index generator on flushes at the time that message was added (470c9ff08a79514f70666b0077ef5d2bedab8b3c); it's just that in 52feed04dbf9d487138944ed834bd877620eef74 the resetting was moved to after that log message.

There is still a situation where this could come up: if over 0x3fff vertices are used while drawing points or lines, and vertex shader point/line expansion is enabled, we will run out of indices. I don't know of any case where that happens in practice, though.

Pocoyo Racing still has some very weird behavior with fifologs, which is not addressed by this PR.