### PR TITLE
Set display_control_register.ENB Depending on _bNTSC

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -107,7 +107,7 @@ void Preset(bool _bNTSC)
   state.vertical_timing_register.EQU = 6;
   state.vertical_timing_register.ACV = 0;
 
-  state.display_control_register.ENB = 1;
+  state.display_control_register.ENB = _bNTSC ? 0 : 1;
   state.display_control_register.RST = 0;
   state.display_control_register.NIN = 0;
   state.display_control_register.DLR = 0;


### PR DESCRIPTION
Intending to fix [issue 9887](https://bugs.dolphin-emu.org/issues/9887) and [issue 10575](https://bugs.dolphin-emu.org/issues/10575) when booting without Gamecube Main Menu or Wii System Menu