### PR TITLE
VideoCommon: Clear blend configuration if color/alpha update disabled

### DIFF
--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -180,6 +180,22 @@ void BlendingState::Generate(const BPMemory& bp)
       }
     }
   }
+
+  // If we aren't writing color or alpha, don't blend it.
+  // Intel GPUs on D3D12 seem to have issues with dual-source blend if the second source is used in
+  // the blend state but not actually written (i.e. the alpha src or dst factor is src alpha, but
+  // alpha update is disabled). So, change the blending configuration to not use a dual-source
+  // factor. Note that in theory, disabling writing should render these irrelevant.
+  if (!colorupdate)
+  {
+    srcfactor = SrcBlendFactor::Zero;
+    dstfactor = DstBlendFactor::One;
+  }
+  if (!alphaupdate)
+  {
+    srcfactoralpha = SrcBlendFactor::Zero;
+    dstfactoralpha = DstBlendFactor::One;
+  }
 }
 
 void BlendingState::ApproximateLogicOpWithBlending()


### PR DESCRIPTION
This works around an Intel driver bug where, on D3D12 only, dual-source blending behaves incorrectly if the second source is unused on. This bug is visible in skyboxes in Super Mario Sunshine, which first draw clouds and sun flare in greyscale and then draw the sky afterwards with a source factor of 1 and a dest factor of 1-src_color (this results in the clouds being tinted blue). This process is done on an RGB888 framebuffer, so alpha update is disabled. (Color update is enabled; note that if you look at this in Dolphin's fifo analyzer, it won't be enabled because they use the BP mask functionality to only change the blending functions and not alpha/color update.)

Here are some examples of how this renders ([SMSSkyFifologs.zip](https://github.com/dolphin-emu/dolphin/files/10349115/SMSSkyFifologs.zip)):

<details><summary>SMSSky.dff</summary>

> ![00000000_2023-01-04_19-42-02](https://user-images.githubusercontent.com/8334194/210697046-6d15adfa-0d80-4a66-9bca-49569dde5437.png)
> Clouds (objects 0-30)

> ![00000000_2023-01-04_19-42-08](https://user-images.githubusercontent.com/8334194/210697048-7871fe89-dee7-49a9-be21-52cb79042f57.png)
> Sky only (object 31)

> ![00000000_2023-01-04_19-42-10](https://user-images.githubusercontent.com/8334194/210697049-a65738e1-4999-4213-8af9-2c8a2808a181.png)
> Sky with clouds (objects 0-31)

> ![00000000_2023-01-04_19-42-14](https://user-images.githubusercontent.com/8334194/210697050-69301c44-0a40-4c07-8445-6a5ac7be4ad0.png)
> Full scene

> ![00000000_2023-01-04_19-46-26](https://user-images.githubusercontent.com/8334194/210697662-69e23ef3-16b1-448e-93c9-481793a083f2.png)
> Broken version of scene

</details><details><summary>SMSTitle.dff</summary>

> ![00000000_2023-01-04_19-42-47](https://user-images.githubusercontent.com/8334194/210697051-6edeaa77-1005-4b10-9c5b-b9c10f56aa87.png)
> Clouds (objects 0-30)

> ![00000000_2023-01-04_19-42-51](https://user-images.githubusercontent.com/8334194/210697052-aa5d75fc-e48a-45a4-af90-8cbd492657de.png)
> Sky only (object 31)

> ![00000000_2023-01-04_19-42-55](https://user-images.githubusercontent.com/8334194/210697053-1d45908a-d699-4448-b922-1a79c031a5f0.png)
> Sky with clouds (objects 0-31)

> ![00000000_2023-01-04_19-43-09](https://user-images.githubusercontent.com/8334194/210697054-a2ebbf21-758c-44a8-bd4c-570a1fa75741.png)
> Full scene

> ![00000000_2023-01-04_19-45-35](https://user-images.githubusercontent.com/8334194/210697782-f35420de-d79f-4702-b8f8-4c11f2e744c7.png)
> Broken version of scene

</details><details><summary>MarioSunshineWater.dff (sms-water on fifoci)</summary>

> ![00000000_2023-01-04_19-41-00](https://user-images.githubusercontent.com/8334194/210697041-f8f956fa-b174-4c68-87ce-5f5bbc3af034.png)
> Clouds (objects 0-28)

> ![00000000_2023-01-04_19-41-05](https://user-images.githubusercontent.com/8334194/210697043-c290703b-665a-4467-9a8a-63e2dbc71bde.png)
> Sky only (object 29)

> ![00000000_2023-01-04_19-41-08](https://user-images.githubusercontent.com/8334194/210697044-a948b829-34ef-4634-8fe0-d0a03fe527b8.png)
> Sky with clouds (objects 0-29)

> ![00000000_2023-01-04_19-41-15](https://user-images.githubusercontent.com/8334194/210697045-ee2edf1a-0d12-4f14-aba6-e09943e22360.png)
> Full scene

> ![00000000_2023-01-04_19-45-50](https://user-images.githubusercontent.com/8334194/210697481-98336a98-535a-4a82-9925-36eb768aa456.png)
> Broken version of scene

</details>