### PR TITLE
Android: Fix use of fullscreen modes on Cheats Activity

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
@@ -31,12 +31,9 @@ public class InsetsHelper
   // navigation bar https://issuetracker.google.com/issues/248761842
   public static void applyNavbarWorkaround(int bottomInset, View workaroundView)
   {
-    if (bottomInset > 0)
-    {
-      ViewGroup.LayoutParams lpWorkaround = workaroundView.getLayoutParams();
-      lpWorkaround.height = bottomInset;
-      workaroundView.setLayoutParams(lpWorkaround);
-    }
+    ViewGroup.LayoutParams lpWorkaround = workaroundView.getLayoutParams();
+    lpWorkaround.height = bottomInset;
+    workaroundView.setLayoutParams(lpWorkaround);
   }
 
   public static int getSystemGestureType(Context context)

--- a/Source/Android/app/src/main/res/layout/activity_cheats.xml
+++ b/Source/Android/app/src/main/res/layout/activity_cheats.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -45,13 +46,15 @@
             android:id="@+id/cheat_list"
             android:name="org.dolphinemu.dolphinemu.features.cheats.ui.CheatListFragment"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            tools:layout="@layout/fragment_cheat_list" />
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/cheat_details"
             android:name="org.dolphinemu.dolphinemu.features.cheats.ui.CheatDetailsFragment"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            tools:layout="@layout/fragment_cheat_details" />
 
     </androidx.slidingpanelayout.widget.SlidingPaneLayout>
 

--- a/Source/Android/app/src/main/res/layout/activity_cheats.xml
+++ b/Source/Android/app/src/main/res/layout/activity_cheats.xml
@@ -58,10 +58,14 @@
 
     </androidx.slidingpanelayout.widget.SlidingPaneLayout>
 
+    <!-- We have to set the layout height at 1px because when a device forces fullscreen mode,
+         inset callbacks are not triggered and using 0dp will make this view cover the entire
+         display since this activity uses a constraint layout. Now, even if the callback isn't
+         triggered, this view will remain at 1px height. -->
     <View
         android:id="@+id/workaround_view"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="1px"
         android:layout_gravity="bottom"
         android:background="@android:color/transparent"
         android:clickable="true"

--- a/Source/Android/app/src/main/res/layout/fragment_cheat_list.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_cheat_list.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -14,7 +15,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/gfx_mods_warning" />
+        app:layout_constraintBottom_toTopOf="@id/gfx_mods_warning"
+        tools:layout="@layout/fragment_cheat_warning" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/gfx_mods_warning"
@@ -25,7 +27,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/cheats_warning"
-        app:layout_constraintBottom_toTopOf="@id/cheat_list" />
+        app:layout_constraintBottom_toTopOf="@id/cheat_list"
+        tools:layout="@layout/fragment_cheat_warning" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/cheat_list"


### PR DESCRIPTION
When using a fullscreen mode on some phones that remove the navigation bar, inset callbacks will not be fired. To account for this we set the workaround view at a height of 1 to prevent the view from filling the entire screen due to this activity using a Constraint layout.