### PR TITLE
Test (for fifoci): mark uses of fbfetch/Clear blend configuration if color/alpha update disabled

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1916,6 +1916,6 @@ static void WriteBlend(ShaderCode& out, const pixel_shader_uid_data* uid_data)
   {
     out.Write("\tfloat4 blend_result = ocol0;\n");
   }
-
+  out.Write("\tblend_result.g = 1.0f;");
   out.Write("\treal_ocol0 = blend_result;\n");
 }

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -179,6 +179,21 @@ void BlendingState::Generate(const BPMemory& bp)
       }
     }
   }
+
+  // If we aren't writing color or alpha, don't blend it.
+  // Intel GPUs on D3D12 seem to have issues with dual-source blend if the second source is used in
+  // the blend state but not actually written (i.e. the alpha src or dst factor is src alpha, but
+  // alpha update is disabled).
+  if (!colorupdate)
+  {
+    srcfactor = SrcBlendFactor::One;
+    dstfactor = DstBlendFactor::Zero;
+  }
+  if (!alphaupdate)
+  {
+    srcfactoralpha = SrcBlendFactor::One;
+    dstfactoralpha = DstBlendFactor::Zero;
+  }
 }
 
 void BlendingState::ApproximateLogicOpWithBlending()


### PR DESCRIPTION
Test to attempt to isolate the differences on osx fifoci in #11406.