### PR TITLE
Android: Add slider for Performance Sample Window

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -67,6 +67,8 @@ public enum IntSetting implements AbstractIntSetting
   GFX_STEREO_CONVERGENCE_PERCENTAGE(Settings.FILE_GFX, Settings.SECTION_STEREOSCOPY,
           "StereoConvergencePercentage", 100),
 
+  GFX_PERF_SAMP_WINDOW(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "PerfSampWindowMS", 1000),
+
   LOGGER_VERBOSITY(Settings.FILE_LOGGER, Settings.SECTION_LOGGER_OPTIONS, "Verbosity", 1),
 
   WIIMOTE_1_SOURCE(Settings.FILE_WIIMOTE, "Wiimote1", "Source", 1),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -286,7 +286,18 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     slider.setValueFrom(item.getMin());
     slider.setValueTo(item.getMax());
     slider.setValue(mSeekbarProgress);
-    slider.setStepSize(1);
+
+    // Sliders can get frustrating to use with a small step size and large ranges
+    int maxRange = item.getMax();
+    if (maxRange <= 100)
+    {
+      slider.setStepSize(1);
+    }
+    else
+    {
+      slider.setStepSize((int) Math.pow(10, Math.ceil(Math.log10(maxRange)) - 2));
+    }
+
     slider.addOnChangeListener(this);
 
     mDialog = new MaterialAlertDialogBuilder(mView.getActivity())

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -905,6 +905,9 @@ public final class SettingsFragmentPresenter
     sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_LOG_RENDER_TIME_TO_FILE,
             R.string.log_render_time_to_file,
             R.string.log_render_time_to_file_description));
+    sl.add(new IntSliderSetting(mContext, IntSetting.GFX_PERF_SAMP_WINDOW,
+            R.string.performance_sample_window, R.string.performance_sample_window_description, 0,
+            10000, "ms"));
   }
 
   private void addAdvancedGraphicsSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/res/layout/dialog_slider.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_slider.xml
@@ -17,7 +17,7 @@
 
     <TextView
         android:id="@+id/text_value"
-        android:layout_width="26dp"
+        android:layout_width="40dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/spacing_medlarge"
         android:gravity="end"
@@ -25,7 +25,7 @@
         app:layout_constraintEnd_toStartOf="@id/text_units"
         app:layout_constraintStart_toEndOf="@id/slider"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="100" />
+        tools:text="10000" />
 
     <TextView
         android:id="@+id/text_units"

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -328,6 +328,8 @@
     <string name="show_vtimes_description">Shows the average time in ms between each rendered frame alongside the standard deviation.</string>
     <string name="show_graphs">Show Performance Graphs</string>
     <string name="show_graphs_description">Shows frametime graph along with statistics as a representation of emulation performance.</string>
+    <string name="performance_sample_window">Performance Sample Window</string>
+    <string name="performance_sample_window_description">The amount of time the FPS and VPS counters will sample over. The higher the value, the more stable the FPS/VPS counter will be, but the slower it will be to update.</string>
     <string name="show_speed">Show % Speed</string>
     <string name="show_speed_description">Shows the % speed of emulation compared to full speed.</string>
     <string name="show_speed_colors">Show Speed Color</string>


### PR DESCRIPTION
Additionally I changed the slider step size based on how large the total range is. This makes large ranges like the one used for this sample window much easier to control. Since we haven't had to control values greater than 100 before, I've also increased the size of the value text field.

Audio Slider -
![100-slider](https://user-images.githubusercontent.com/14132249/211130774-42e9a75a-d060-4e13-8c20-aca92bc4588b.gif)

Sample Window Slider - 
![10000-slider](https://user-images.githubusercontent.com/14132249/211130777-e9116e5c-c578-4d23-b09b-e92bc547f6fa.gif)
