### PR TITLE
Move x64 DSP JIT into DolphinLib.x64.props

### DIFF
--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -214,9 +214,6 @@
     <ClInclude Include="Core\DSP\Interpreter\DSPIntTables.h" />
     <ClInclude Include="Core\DSP\Interpreter\DSPIntUtil.h" />
     <ClInclude Include="Core\DSP\Jit\DSPEmitterBase.h" />
-    <ClInclude Include="Core\DSP\Jit\x64\DSPEmitter.h" />
-    <ClInclude Include="Core\DSP\Jit\x64\DSPJitRegCache.h" />
-    <ClInclude Include="Core\DSP\Jit\x64\DSPJitTables.h" />
     <ClInclude Include="Core\DSP\LabelMap.h" />
     <ClInclude Include="Core\DSPEmulator.h" />
     <ClInclude Include="Core\FifoPlayer\FifoDataFile.h" />
@@ -835,17 +832,6 @@
     <ClCompile Include="Core\DSP\Interpreter\DSPIntMultiplier.cpp" />
     <ClCompile Include="Core\DSP\Interpreter\DSPIntTables.cpp" />
     <ClCompile Include="Core\DSP\Jit\DSPEmitterBase.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPEmitter.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitArithmetic.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitBranch.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitCCUtil.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitExtOps.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitLoadStore.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitMisc.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitMultiplier.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitRegCache.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitTables.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitUtil.cpp" />
     <ClCompile Include="Core\DSP\LabelMap.cpp" />
     <ClCompile Include="Core\DSPEmulator.cpp" />
     <ClCompile Include="Core\FifoPlayer\FifoDataFile.cpp" />

--- a/Source/Core/DolphinLib.x64.props
+++ b/Source/Core/DolphinLib.x64.props
@@ -4,6 +4,9 @@
     <ClInclude Include="Common\x64ABI.h" />
     <ClInclude Include="Common\x64Emitter.h" />
     <ClInclude Include="Common\x64Reg.h" />
+    <ClInclude Include="Core\DSP\Jit\x64\DSPEmitter.h" />
+    <ClInclude Include="Core\DSP\Jit\x64\DSPJitRegCache.h" />
+    <ClInclude Include="Core\DSP\Jit\x64\DSPJitTables.h" />
     <ClInclude Include="Core\PowerPC\Jit64\Jit.h" />
     <ClInclude Include="Core\PowerPC\Jit64\JitAsm.h" />
     <ClInclude Include="Core\PowerPC\Jit64\RegCache\CachedReg.h" />
@@ -27,6 +30,17 @@
     <ClCompile Include="Common\x64CPUDetect.cpp" />
     <ClCompile Include="Common\x64Emitter.cpp" />
     <ClCompile Include="Common\x64FPURoundMode.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPEmitter.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitArithmetic.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitBranch.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitCCUtil.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitExtOps.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitLoadStore.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitMisc.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitMultiplier.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitRegCache.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitTables.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitUtil.cpp" />
     <ClCompile Include="Core\PowerPC\Jit64\Jit_Branch.cpp" />
     <ClCompile Include="Core\PowerPC\Jit64\Jit_FloatingPoint.cpp" />
     <ClCompile Include="Core\PowerPC\Jit64\Jit_Integer.cpp" />


### PR DESCRIPTION
Before, it was also compiled on ARM builds, but since it was unused it wasn't linked (and thus its dependency on the nonexistent x64Emitter didn't cause any link issues).

https://github.com/dolphin-emu/dolphin/blob/7444f90e45928f15bcb7d6c4ccf98f06634062c5/Source/Core/Core/DSP/Jit/DSPEmitterBase.cpp#L14-L21