### PR TITLE
Android: Disable focus on non-actionable UI

### DIFF
--- a/Source/Android/app/src/main/res/layout-land/activity_user_data.xml
+++ b/Source/Android/app/src/main/res/layout-land/activity_user_data.xml
@@ -150,6 +150,7 @@
         android:layout_height="0dp"
         android:layout_gravity="bottom"
         android:clickable="true"
+        android:focusable="false"
         android:background="@android:color/transparent" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout-w680dp-land/activity_convert.xml
+++ b/Source/Android/app/src/main/res/layout-w680dp-land/activity_convert.xml
@@ -89,6 +89,7 @@
         android:layout_height="0dp"
         android:layout_gravity="bottom"
         android:clickable="true"
+        android:focusable="false"
         android:background="@android:color/transparent" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/activity_cheats.xml
+++ b/Source/Android/app/src/main/res/layout/activity_cheats.xml
@@ -69,6 +69,7 @@
         android:layout_gravity="bottom"
         android:background="@android:color/transparent"
         android:clickable="true"
+        android:focusable="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/Source/Android/app/src/main/res/layout/activity_convert.xml
+++ b/Source/Android/app/src/main/res/layout/activity_convert.xml
@@ -87,6 +87,7 @@
         android:layout_height="0dp"
         android:layout_gravity="bottom"
         android:clickable="true"
+        android:focusable="false"
         android:background="@android:color/transparent" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/activity_main.xml
+++ b/Source/Android/app/src/main/res/layout/activity_main.xml
@@ -48,6 +48,7 @@
         android:layout_height="0dp"
         android:layout_gravity="bottom"
         android:clickable="true"
+        android:focusable="false"
         android:background="@android:color/transparent" />
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton

--- a/Source/Android/app/src/main/res/layout/activity_riivolution_boot.xml
+++ b/Source/Android/app/src/main/res/layout/activity_riivolution_boot.xml
@@ -104,6 +104,7 @@
         android:layout_height="0dp"
         android:layout_gravity="bottom"
         android:clickable="true"
+        android:focusable="false"
         android:background="@android:color/transparent" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/activity_settings.xml
+++ b/Source/Android/app/src/main/res/layout/activity_settings.xml
@@ -45,6 +45,7 @@
         android:layout_height="0dp"
         android:layout_gravity="bottom"
         android:clickable="true"
+        android:focusable="false"
         android:background="@android:color/transparent" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/activity_user_data.xml
+++ b/Source/Android/app/src/main/res/layout/activity_user_data.xml
@@ -127,6 +127,7 @@
         android:layout_height="0dp"
         android:layout_gravity="bottom"
         android:clickable="true"
+        android:focusable="false"
         android:background="@android:color/transparent" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/list_item_header.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_header.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:focusable="true"
+    android:focusable="false"
     android:layout_height="wrap_content">
 
     <TextView


### PR DESCRIPTION
This disables focus on the workaround view and reverts and [old change](https://github.com/dolphin-emu/dolphin/commit/77e51ab5271f1d6db265feb1c41e1a14866d101c) that afaik isn't valid after testing on API 26 and 27.