### PR TITLE
Android: Expose "Log Render Time to File" toggle

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -181,6 +181,8 @@ public enum BooleanSetting implements AbstractBooleanSetting
   GFX_SHOW_GRAPHS(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "ShowGraphs", false),
   GFX_SHOW_SPEED(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "ShowSpeed", false),
   GFX_SHOW_SPEED_COLORS(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "ShowSpeedColors", true),
+  GFX_LOG_RENDER_TIME_TO_FILE(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS,
+          "LogRenderTimeToFile", false),
   GFX_OVERLAY_STATS(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "OverlayStats", false),
   GFX_DUMP_TEXTURES(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "DumpTextures", false),
   GFX_DUMP_MIP_TEXTURES(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "DumpMipTextures", false),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -902,6 +902,9 @@ public final class SettingsFragmentPresenter
     sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_SHOW_SPEED_COLORS,
             R.string.show_speed_colors,
             R.string.show_speed_colors_description));
+    sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_LOG_RENDER_TIME_TO_FILE,
+            R.string.log_render_time_to_file,
+            R.string.log_render_time_to_file_description));
   }
 
   private void addAdvancedGraphicsSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -332,6 +332,8 @@
     <string name="show_speed_description">Shows the % speed of emulation compared to full speed.</string>
     <string name="show_speed_colors">Show Speed Color</string>
     <string name="show_speed_colors_description">Changes the color of the FPS counter depending on emulation speed.</string>
+    <string name="log_render_time_to_file">Log Render Time to File</string>
+    <string name="log_render_time_to_file_description">Logs the render time of every frame to User/Logs/render_time.txt. Use this feature to measure Dolphin\'s performance.</string>
 
     <string name="advanced_graphics_submenu">Advanced</string>
     <string name="gfx_mods_and_custom_textures">Graphics Mods and Custom Textures</string>


### PR DESCRIPTION
It's a little inconvenient to pull the statistics out from SAF, but it's useful for Android benchmarking.