### PR TITLE
Android: Ignore workaround view height if 0

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/InsetsHelper.java
@@ -31,9 +31,12 @@ public class InsetsHelper
   // navigation bar https://issuetracker.google.com/issues/248761842
   public static void applyNavbarWorkaround(int bottomInset, View workaroundView)
   {
-    ViewGroup.LayoutParams lpWorkaround = workaroundView.getLayoutParams();
-    lpWorkaround.height = bottomInset;
-    workaroundView.setLayoutParams(lpWorkaround);
+    if (bottomInset > 0)
+    {
+      ViewGroup.LayoutParams lpWorkaround = workaroundView.getLayoutParams();
+      lpWorkaround.height = bottomInset;
+      workaroundView.setLayoutParams(lpWorkaround);
+    }
   }
 
   public static int getSystemGestureType(Context context)


### PR DESCRIPTION
This partially reverts a change made in #11410 in hopes of fixing fullscreen modes on Samsung devices when using the cheats activity.