### PR TITLE
Jit64: Always calculate RMEM offsets safely

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -321,7 +321,7 @@ bool Jit64::BackPatch(u32 emAddress, SContext* ctx)
   if (info.offsetAddedToAddress)
   {
     u64* ptr = ContextRN(ctx, info.op_arg.GetSimpleReg());
-    *ptr -= static_cast<u32>(info.offset);
+    *ptr = static_cast<u32>(static_cast<u32>(*ptr) - static_cast<u32>(info.offset));
   }
 
   ctx->CTX_PC = reinterpret_cast<u64>(trampoline);

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -316,14 +316,6 @@ bool Jit64::BackPatch(u32 emAddress, SContext* ctx)
     }
   }
 
-  // This is special code to undo the LEA in SafeLoadToReg if it clobbered the address
-  // register in the case where reg_value shared the same location as opAddress.
-  if (info.offsetAddedToAddress)
-  {
-    u64* ptr = ContextRN(ctx, info.op_arg.GetSimpleReg());
-    *ptr = static_cast<u32>(static_cast<u32>(*ptr) - static_cast<u32>(info.offset));
-  }
-
   ctx->CTX_PC = reinterpret_cast<u64>(trampoline);
 
   return true;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -153,7 +153,6 @@ void Jit64::stfXXX(UGeckoInstruction inst)
     return;
   }
 
-  s32 offset = 0;
   RCOpArg Ra = update ? gpr.Bind(a, RCMode::ReadWrite) : gpr.Use(a, RCMode::Read);
   RegCache::Realize(Ra);
   if (indexed)
@@ -164,23 +163,15 @@ void Jit64::stfXXX(UGeckoInstruction inst)
   }
   else
   {
-    if (update)
-    {
-      MOV_sum(32, RSCRATCH2, Ra, Imm32(imm));
-    }
-    else
-    {
-      offset = imm;
-      MOV(32, R(RSCRATCH2), Ra);
-    }
+    MOV_sum(32, RSCRATCH2, Ra, Imm32(imm));
   }
 
   BitSet32 registersInUse = CallerSavedRegistersInUse();
-  // We need to save the (usually scratch) address register for the update.
+  // We need to save the address register for the update.
   if (update)
     registersInUse[RSCRATCH2] = true;
 
-  SafeWriteRegToReg(RSCRATCH, RSCRATCH2, accessSize, offset, registersInUse);
+  SafeWriteRegToReg(RSCRATCH, RSCRATCH2, accessSize, CallerSavedRegistersInUse());
 
   if (update)
     MOV(32, Ra, R(RSCRATCH2));
@@ -207,5 +198,5 @@ void Jit64::stfiwx(UGeckoInstruction inst)
     MOVD_xmm(R(RSCRATCH), Rs.GetSimpleReg());
   else
     MOV(32, R(RSCRATCH), Rs);
-  SafeWriteRegToReg(RSCRATCH, RSCRATCH2, 32, 0, CallerSavedRegistersInUse());
+  SafeWriteRegToReg(RSCRATCH, RSCRATCH2, 32, CallerSavedRegistersInUse());
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -58,7 +58,7 @@ void Jit64::lfXXX(UGeckoInstruction inst)
   }
   else
   {
-    RCOpArg Ra = gpr.Bind(a, update ? RCMode::ReadWrite : RCMode::Read);
+    RCOpArg Ra = update ? gpr.UseNoImm(a, RCMode::ReadWrite) : gpr.Use(a, RCMode::Read);
     RegCache::Realize(Ra);
 
     if (indexed)
@@ -161,7 +161,7 @@ void Jit64::stfXXX(UGeckoInstruction inst)
     return;
   }
 
-  RCOpArg Ra = update ? gpr.Bind(a, RCMode::ReadWrite) : gpr.Use(a, RCMode::Read);
+  RCOpArg Ra = update ? gpr.UseNoImm(a, RCMode::ReadWrite) : gpr.Use(a, RCMode::Read);
   RegCache::Realize(Ra);
   if (indexed)
   {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -36,7 +36,7 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
   FALLBACK_IF(!a);
 
   RCX64Reg scratch_guard = gpr.Scratch(RSCRATCH_EXTRA);
-  RCOpArg Ra = update ? gpr.Bind(a, RCMode::ReadWrite) : gpr.Use(a, RCMode::Read);
+  RCOpArg Ra = update ? gpr.UseNoImm(a, RCMode::ReadWrite) : gpr.Use(a, RCMode::Read);
   RCOpArg Rb = indexed ? gpr.Use(b, RCMode::Read) : RCOpArg::Imm32((u32)offset);
   RCOpArg Rs = fpr.Use(s, RCMode::Read);
   RegCache::Realize(scratch_guard, Ra, Rb, Rs);
@@ -125,7 +125,7 @@ void Jit64::psq_lXX(UGeckoInstruction inst)
   FALLBACK_IF(!a);
 
   RCX64Reg scratch_guard = gpr.Scratch(RSCRATCH_EXTRA);
-  RCX64Reg Ra = gpr.Bind(a, update ? RCMode::ReadWrite : RCMode::Read);
+  RCOpArg Ra = update ? gpr.UseNoImm(a, RCMode::ReadWrite) : gpr.Use(a, RCMode::Read);
   RCOpArg Rb = indexed ? gpr.Use(b, RCMode::Read) : RCOpArg::Imm32((u32)offset);
   RCX64Reg Rs = fpr.Bind(s, RCMode::Write);
   RegCache::Realize(scratch_guard, Ra, Rb, Rs);

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -61,9 +61,8 @@ public:
   void UnsafeWriteRegToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize,
                            bool swap = true, Gen::MovInfo* info = nullptr);
 
-  // Returns whether the offset was added to the address register
-  bool UnsafeLoadToReg(Gen::X64Reg reg_value, Gen::OpArg opAddress, int accessSize, s32 offset,
-                       bool signExtend, Gen::MovInfo* info = nullptr);
+  void UnsafeLoadToReg(Gen::X64Reg reg_value, Gen::OpArg opAddress, int accessSize, bool signExtend,
+                       Gen::MovInfo* info = nullptr);
 
   // Generate a load/write from the MMIO handler for a given address. Only
   // call for known addresses in MMIO range (MMIO::IsMMIOAddress).
@@ -83,9 +82,11 @@ public:
     SAFE_LOADSTORE_NO_UPDATE_PC = 32,
   };
 
-  void SafeLoadToReg(Gen::X64Reg reg_value, const Gen::OpArg& opAddress, int accessSize, s32 offset,
+  void SafeLoadToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize,
                      BitSet32 registersInUse, bool signExtend, int flags = 0);
-  void SafeLoadToRegImmediate(Gen::X64Reg reg_value, u32 address, int accessSize,
+
+  // returns true if an exception could have been caused
+  bool SafeLoadToRegImmediate(Gen::X64Reg reg_value, u32 address, int accessSize,
                               BitSet32 registersInUse, bool signExtend);
 
   // Clobbers RSCRATCH or reg_addr depending on the relevant flag.  Preserves

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -55,12 +55,13 @@ public:
 
   Gen::FixupBranch CheckIfSafeAddress(const Gen::OpArg& reg_value, Gen::X64Reg reg_addr,
                                       BitSet32 registers_in_use);
-  // these return the address of the MOV, for backpatching
-  void UnsafeWriteRegToReg(Gen::OpArg reg_value, Gen::X64Reg reg_addr, int accessSize,
-                           s32 offset = 0, bool swap = true, Gen::MovInfo* info = nullptr);
-  void UnsafeWriteRegToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize,
-                           s32 offset = 0, bool swap = true, Gen::MovInfo* info = nullptr);
 
+  void UnsafeWriteRegToReg(Gen::OpArg reg_value, Gen::X64Reg reg_addr, int accessSize,
+                           bool swap = true, Gen::MovInfo* info = nullptr);
+  void UnsafeWriteRegToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize,
+                           bool swap = true, Gen::MovInfo* info = nullptr);
+
+  // Returns whether the offset was added to the address register
   bool UnsafeLoadToReg(Gen::X64Reg reg_value, Gen::OpArg opAddress, int accessSize, s32 offset,
                        bool signExtend, Gen::MovInfo* info = nullptr);
 
@@ -75,12 +76,11 @@ public:
     SAFE_LOADSTORE_NO_PROLOG = 2,
     // This indicates that the write being generated cannot be patched (and thus can't use fastmem)
     SAFE_LOADSTORE_NO_FASTMEM = 4,
-    SAFE_LOADSTORE_CLOBBER_RSCRATCH_INSTEAD_OF_ADDR = 8,
     // Force slowmem (used when generating fallbacks in trampolines)
-    SAFE_LOADSTORE_FORCE_SLOWMEM = 16,
-    SAFE_LOADSTORE_DR_ON = 32,
+    SAFE_LOADSTORE_FORCE_SLOWMEM = 8,
+    SAFE_LOADSTORE_DR_ON = 16,
     // Generated from a context that doesn't have the PC of the instruction that caused it
-    SAFE_LOADSTORE_NO_UPDATE_PC = 64,
+    SAFE_LOADSTORE_NO_UPDATE_PC = 32,
   };
 
   void SafeLoadToReg(Gen::X64Reg reg_value, const Gen::OpArg& opAddress, int accessSize, s32 offset,
@@ -91,9 +91,9 @@ public:
   // Clobbers RSCRATCH or reg_addr depending on the relevant flag.  Preserves
   // reg_value if the load fails and js.memcheck is enabled.
   // Works with immediate inputs and simple registers only.
-  void SafeWriteRegToReg(Gen::OpArg reg_value, Gen::X64Reg reg_addr, int accessSize, s32 offset,
+  void SafeWriteRegToReg(Gen::OpArg reg_value, Gen::X64Reg reg_addr, int accessSize,
                          BitSet32 registersInUse, int flags = 0);
-  void SafeWriteRegToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize, s32 offset,
+  void SafeWriteRegToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize,
                          BitSet32 registersInUse, int flags = 0);
 
   // applies to safe and unsafe WriteRegToReg

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -541,7 +541,7 @@ void QuantizedMemoryRoutines::GenQuantizedStore(bool single, EQuantizeType type,
   if (!single)
     flags |= SAFE_LOADSTORE_NO_SWAP;
 
-  SafeWriteRegToReg(RSCRATCH, RSCRATCH_EXTRA, size, 0, QUANTIZED_REGS_TO_SAVE, flags);
+  SafeWriteRegToReg(RSCRATCH, RSCRATCH_EXTRA, size, QUANTIZED_REGS_TO_SAVE, flags);
 }
 
 void QuantizedMemoryRoutines::GenQuantizedStoreFloat(bool single, bool isInline)

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -596,7 +596,7 @@ void QuantizedMemoryRoutines::GenQuantizedLoad(bool single, EQuantizeType type, 
   int flags = isInline ? 0 :
                          SAFE_LOADSTORE_NO_FASTMEM | SAFE_LOADSTORE_NO_PROLOG |
                              SAFE_LOADSTORE_DR_ON | SAFE_LOADSTORE_NO_UPDATE_PC;
-  SafeLoadToReg(RSCRATCH_EXTRA, R(RSCRATCH_EXTRA), size, 0, regsToSave, extend, flags);
+  SafeLoadToReg(RSCRATCH_EXTRA, RSCRATCH_EXTRA, size, regsToSave, extend, flags);
   if (!single && (type == QUANTIZE_U8 || type == QUANTIZE_S8))
   {
     // TODO: Support not swapping in safeLoadToReg to avoid bswapping twice
@@ -704,7 +704,7 @@ void QuantizedMemoryRoutines::GenQuantizedLoadFloat(bool single, bool isInline)
   int flags = isInline ? 0 :
                          SAFE_LOADSTORE_NO_FASTMEM | SAFE_LOADSTORE_NO_PROLOG |
                              SAFE_LOADSTORE_DR_ON | SAFE_LOADSTORE_NO_UPDATE_PC;
-  SafeLoadToReg(RSCRATCH_EXTRA, R(RSCRATCH_EXTRA), size, 0, regsToSave, extend, flags);
+  SafeLoadToReg(RSCRATCH_EXTRA, RSCRATCH_EXTRA, size, regsToSave, extend, flags);
 
   if (single)
   {

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -62,8 +62,8 @@ const u8* TrampolineCache::GenerateWriteTrampoline(const TrampolineInfo& info)
   // Don't treat FIFO writes specially for now because they require a burst
   // check anyway.
 
-  SafeWriteRegToReg(info.op_arg, info.op_reg, info.accessSize << 3, info.offset,
-                    info.registersInUse, info.flags | SAFE_LOADSTORE_FORCE_SLOWMEM);
+  SafeWriteRegToReg(info.op_arg, info.op_reg, info.accessSize << 3, info.registersInUse,
+                    info.flags | SAFE_LOADSTORE_FORCE_SLOWMEM);
 
   JMP(info.start + info.len, true);
 

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -43,8 +43,8 @@ const u8* TrampolineCache::GenerateReadTrampoline(const TrampolineInfo& info)
 
   const u8* trampoline = GetCodePtr();
 
-  SafeLoadToReg(info.op_reg, info.op_arg, info.accessSize << 3, info.offset, info.registersInUse,
-                info.signExtend, info.flags | SAFE_LOADSTORE_FORCE_SLOWMEM);
+  SafeLoadToReg(info.op_value.GetSimpleReg(), info.reg_addr, info.accessSize << 3,
+                info.registersInUse, info.signExtend, info.flags | SAFE_LOADSTORE_FORCE_SLOWMEM);
 
   JMP(info.start + info.len, true);
 
@@ -62,7 +62,7 @@ const u8* TrampolineCache::GenerateWriteTrampoline(const TrampolineInfo& info)
   // Don't treat FIFO writes specially for now because they require a burst
   // check anyway.
 
-  SafeWriteRegToReg(info.op_arg, info.op_reg, info.accessSize << 3, info.registersInUse,
+  SafeWriteRegToReg(info.op_value, info.reg_addr, info.accessSize << 3, info.registersInUse,
                     info.flags | SAFE_LOADSTORE_FORCE_SLOWMEM);
 
   JMP(info.start + info.len, true);

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineInfo.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineInfo.h
@@ -28,9 +28,8 @@ struct TrampolineInfo final
   Gen::X64Reg nonAtomicSwapStoreSrc;
 
   // src/dest for load/store
-  s32 offset;
-  Gen::X64Reg op_reg;
-  Gen::OpArg op_arg;
+  Gen::OpArg op_value;
+  Gen::X64Reg reg_addr;
 
   // Original SafeLoadXXX/SafeStoreXXX flags
   u8 flags;
@@ -43,7 +42,4 @@ struct TrampolineInfo final
 
   // for read operations, true if needs sign-extension after load
   bool signExtend : 1;
-
-  // Set to true if we added the offset to the address and need to undo it
-  bool offsetAddedToAddress : 1;
 };


### PR DESCRIPTION
When performing a fastmem operation, Jit64 effectively computes `RMEM + guest_addr`. In some cases this is implemented as `RMEM + guest_addr_base + guest_addr_offset` rather than the more correct `RMEM + u32(guest_addr_base + guest_addr_offset)`. I don't know of any games that rely on the address being correctly wrapped, but wrapping incorrectly causes Dolphin to crash, so I think this would be nice to have fixed. (Fortunately, there's no security issue, because when setting up memory we allocate a 4 GiB guard arena after the normal arena. I guess whoever wrote this code originally was well aware of the problem.)