### PR TITLE
NetKDTime: Use UTC instead of localtime.

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -91,7 +91,9 @@ u64 NetKDTimeDevice::GetAdjustedUTC() const
 {
   using namespace ExpansionInterface;
 
-  const u32 emulated_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
+  const time_t current_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
+  tm* const gm_time = gmtime(&current_time);
+  const u32 emulated_time = mktime(gm_time);
   return u64(s64(emulated_time) + utcdiff);
 }
 
@@ -99,7 +101,9 @@ void NetKDTimeDevice::SetAdjustedUTC(u64 wii_utc)
 {
   using namespace ExpansionInterface;
 
-  const u32 emulated_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
+  const time_t current_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
+  tm* const gm_time = gmtime(&current_time);
+  const u32 emulated_time = mktime(gm_time);
   utcdiff = s64(emulated_time - wii_utc);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/DolphinQt/TAS/GBATASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/GBATASInputWindow.cpp
@@ -36,8 +36,8 @@ GBATASInputWindow::GBATASInputWindow(QWidget* parent, int controller_id)
       CreateButton(QStringLiteral("&R"), GBAPad::BUTTONS_GROUP, GBAPad::R_BUTTON, &m_overrider);
   m_select_button = CreateButton(QStringLiteral("SELE&CT"), GBAPad::BUTTONS_GROUP,
                                  GBAPad::SELECT_BUTTON, &m_overrider);
-  m_start_button = m_start_button = CreateButton(QStringLiteral("&START"), GBAPad::BUTTONS_GROUP,
-                                                 GBAPad::START_BUTTON, &m_overrider);
+  m_start_button = CreateButton(QStringLiteral("&START"), GBAPad::BUTTONS_GROUP,
+                                GBAPad::START_BUTTON, &m_overrider);
 
   m_left_button =
       CreateButton(QStringLiteral("L&eft"), GBAPad::DPAD_GROUP, DIRECTION_LEFT, &m_overrider);


### PR DESCRIPTION
Related to [issue 9754](https://dolp.in/i9754).

Since GetEmulatedTime returns a timestamp based off the computer's timezone, it needs to be changed to UTC here. 
This allows for the News Channel to produce the correct "Last Updated" time.

This code is based off from a function in [Core/Movie.cpp](https://github.com/dolphin-emu/dolphin/blob/2ad92776c61cf126e933ca4c5c7c6237a310e193/Source/Core/Core/Movie.cpp#L204), which uses the same method.