### PR TITLE
DolphinQt: Fix typo in GBA TAS input window

### DIFF
--- a/Source/Core/DolphinQt/TAS/GBATASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/GBATASInputWindow.cpp
@@ -36,8 +36,8 @@ GBATASInputWindow::GBATASInputWindow(QWidget* parent, int controller_id)
       CreateButton(QStringLiteral("&R"), GBAPad::BUTTONS_GROUP, GBAPad::R_BUTTON, &m_overrider);
   m_select_button = CreateButton(QStringLiteral("SELE&CT"), GBAPad::BUTTONS_GROUP,
                                  GBAPad::SELECT_BUTTON, &m_overrider);
-  m_start_button = m_start_button = CreateButton(QStringLiteral("&START"), GBAPad::BUTTONS_GROUP,
-                                                 GBAPad::START_BUTTON, &m_overrider);
+  m_start_button = CreateButton(QStringLiteral("&START"), GBAPad::BUTTONS_GROUP,
+                                GBAPad::START_BUTTON, &m_overrider);
 
   m_left_button =
       CreateButton(QStringLiteral("L&eft"), GBAPad::DPAD_GROUP, DIRECTION_LEFT, &m_overrider);


### PR DESCRIPTION
This generated a warning on GCC about the operation being potentially undefined (-Wsequence-point). I'm not sure if that was actually the case, but either way it is a mistake.