### PR TITLE
DolphinQt: Add button to open graphics mod folder on settings

### DIFF
--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
@@ -4,15 +4,18 @@
 #include "DolphinQt/Config/GraphicsModListWidget.h"
 
 #include <QCheckBox>
+#include <QDesktopServices>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QListWidget>
 #include <QPushButton>
+#include <QUrl>
 #include <QVBoxLayout>
 #include <QWidget>
 
 #include <set>
 
+#include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "DolphinQt/Config/GraphicsModWarningWidget.h"
@@ -59,9 +62,10 @@ void GraphicsModListWidget::CreateWidgets()
   m_mod_list->setSelectionRectVisible(true);
   m_mod_list->setDragDropMode(QAbstractItemView::InternalMove);
 
+  m_open_directory_button = new QPushButton(tr("Open Directory..."));
   m_refresh = new QPushButton(tr("&Refresh List"));
   QHBoxLayout* hlayout = new QHBoxLayout;
-  hlayout->addStretch();
+  hlayout->addWidget(m_open_directory_button);
   hlayout->addWidget(m_refresh);
 
   left_v_layout->addWidget(m_mod_list);
@@ -98,6 +102,9 @@ void GraphicsModListWidget::ConnectWidgets()
 
   connect(m_mod_list->model(), &QAbstractItemModel::rowsMoved, this,
           &GraphicsModListWidget::SaveModList);
+
+  connect(m_open_directory_button, &QPushButton::clicked, this,
+          &GraphicsModListWidget::OpenGraphicsModDir);
 
   connect(m_refresh, &QPushButton::clicked, this, &GraphicsModListWidget::RefreshModList);
 
@@ -273,4 +280,10 @@ void GraphicsModListWidget::CalculateGameRunning(Core::State state)
 {
   m_loaded_game_is_running =
       state == Core::State::Running ? m_game_id == SConfig::GetInstance().GetGameID() : false;
+}
+
+void GraphicsModListWidget::OpenGraphicsModDir()
+{
+  QDesktopServices::openUrl(
+      QUrl::fromLocalFile(QString::fromStdString(File::GetUserPath(D_GRAPHICSMOD_IDX))));
 }

--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.h
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.h
@@ -58,6 +58,8 @@ private:
 
   void ClearLayoutRecursively(QLayout* layout);
 
+  void OpenGraphicsModDir();
+
   void CalculateGameRunning(Core::State state);
   bool m_loaded_game_is_running = false;
   bool m_needs_save = false;
@@ -67,6 +69,7 @@ private:
   QLabel* m_selected_mod_name;
   QVBoxLayout* m_mod_meta_layout;
 
+  QPushButton* m_open_directory_button;
   QPushButton* m_refresh;
   GraphicsModWarningWidget* m_warning;
 


### PR DESCRIPTION
Supersedes #11405.

![imagen](https://user-images.githubusercontent.com/121313710/212225848-32fd11c7-77f1-4f1a-8e1d-7726c4865855.png)

Adds an easier way to navigate to the graphics mod folder rather than manually sorting through possibly long and winding file structures. ("Abrir directorio"= Open Folder in Spanish).