### PR TITLE
NetKDTime: Use UTC based timestamp instead of localtime.

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -91,7 +91,9 @@ u64 NetKDTimeDevice::GetAdjustedUTC() const
 {
   using namespace ExpansionInterface;
 
-  const u32 emulated_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
+  const time_t current_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
+  tm* const gm_time = gmtime(&current_time);
+  const u32 emulated_time = mktime(gm_time);
   return u64(s64(emulated_time) + utcdiff);
 }
 
@@ -99,7 +101,9 @@ void NetKDTimeDevice::SetAdjustedUTC(u64 wii_utc)
 {
   using namespace ExpansionInterface;
 
-  const u32 emulated_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
+  const time_t current_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
+  tm* const gm_time = gmtime(&current_time);
+  const u32 emulated_time = mktime(gm_time);
   utcdiff = s64(emulated_time - wii_utc);
 }
 }  // namespace IOS::HLE


### PR DESCRIPTION
_From PR #11431_

Related to [issue 9754](https://dolp.in/i9754).

Since GetEmulatedTime returns a timestamp based off the computer's timezone, it needs to be changed to UTC here. 
This allows for the News Channel to produce the correct "Last Updated" time.

This code is based off from a function in [Core/Movie.cpp](https://github.com/dolphin-emu/dolphin/blob/2ad92776c61cf126e933ca4c5c7c6237a310e193/Source/Core/Core/Movie.cpp#L204), which uses the same method.

By using a NAND dump with the latest news data, the "last updated" time is accurate to the console's results. 