### PR TITLE
msvc: update c++ conformance flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,23 +318,13 @@ if(MSVC)
   add_compile_options(/Oi)
   # Enable buffer security check on Debug, disable otherwise
   add_compile_options($<IF:$<CONFIG:Debug>,/GS,/GS->)
-  # Enforce C++ standard conforming conversion rules to catch possible bugs
-  add_compile_options(/permissive-)
   # Remove unreferenced inline functions/data to reduce link time and catch bugs
+  # Note: In msbuild build, this gets set by msbuild by default
   add_compile_options(/Zc:inline)
-  # Assume `new` (w/o std::nothrow) throws to reduce binary size
-  add_compile_options(/Zc:throwingNew)
+  # Fix various other non-conformant behaviors
+  add_compile_options(/Zc:__cplusplus,enumTypes,externConstexpr,preprocessor,throwingNew)
   # Enforce strict volatile semantics as per ISO C++
   add_compile_options(/volatile:iso)
-  # Fix non-conformant lambda behavior (constexpr variables shouldn't need capturing)
-  add_compile_options(/experimental:newLambdaProcessor)
-  # Fix various other non-conformant behaviors
-  add_compile_options(/Zc:__cplusplus,externConstexpr,lambda,preprocessor)
-
-  # Temporarily disable warnings to enable /Zc:preprocessor compatibility with WinSDK headers.
-  add_compile_options(
-    /wd5105 # macro expansion producing 'defined' has undefined behavior
-  )
 
   # Use 'precise' floating point model
   add_compile_options(/fp:precise)

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -33,7 +33,7 @@
       <!--Enable Standard Conformance-->
       <ConformanceMode>true</ConformanceMode>
       <!--Enforce some behaviors as standards-conformant when they don't default as such.-->
-      <AdditionalOptions>/Zc:__cplusplus,externConstexpr,preprocessor,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus,enumTypes,externConstexpr,preprocessor,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
       <!--Enable detailed debug info-->
       <AdditionalOptions>/Zo %(AdditionalOptions)</AdditionalOptions>
       <!--Treat sources as utf-8-->

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -33,7 +33,7 @@
       <!--Enable Standard Conformance-->
       <ConformanceMode>true</ConformanceMode>
       <!--Enforce some behaviors as standards-conformant when they don't default as such.-->
-      <AdditionalOptions>/Zc:__cplusplus,externConstexpr,lambda,preprocessor,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus,externConstexpr,preprocessor,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
       <!--Enable detailed debug info-->
       <AdditionalOptions>/Zo %(AdditionalOptions)</AdditionalOptions>
       <!--Treat sources as utf-8-->

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -33,6 +33,7 @@
       <!--Enable Standard Conformance-->
       <ConformanceMode>true</ConformanceMode>
       <!--Enforce some behaviors as standards-conformant when they don't default as such.-->
+      <!--TODO on VS 17.5: templateScope-->
       <AdditionalOptions>/Zc:__cplusplus,enumTypes,externConstexpr,preprocessor,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
       <!--Enable detailed debug info-->
       <AdditionalOptions>/Zo %(AdditionalOptions)</AdditionalOptions>
@@ -73,6 +74,7 @@
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <!--TODO on VS 17.5: /Zc:checkGwOdr-->
       <AdditionalOptions>/Gw %(AdditionalOptions)</AdditionalOptions>
       <WholeProgramOptimization Condition="'$(DolphinRelease)'=='true'">true</WholeProgramOptimization>
     </ClCompile>


### PR DESCRIPTION
The only effective change is enabling [/Zc:enumTypes](https://learn.microsoft.com/en-us/cpp/build/reference/zc-enumtypes?view=msvc-170) (pls read)

This has the possibility to change binary representation of enums. However, Dolphin compiles and (seems to) run fine, so I don't see this introducing issues at the moment. IMO it only modifies behavior in weird edge cases, which probably aren't in use in the codebase, anyway.