### PR TITLE
Android: Fix grid options text borders

### DIFF
--- a/Source/Android/app/src/main/res/layout/fragment_grid_options.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_grid_options.xml
@@ -28,11 +28,13 @@
 
             <TextView
                 android:id="@+id/text_download_covers"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
                 android:layout_marginStart="24dp"
                 android:text="@string/download_game_covers"
                 app:layout_constraintBottom_toBottomOf="@+id/switch_download_covers"
+                app:layout_constraintEnd_toStartOf="@+id/switch_download_covers"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/switch_download_covers" />
 
@@ -59,11 +61,13 @@
 
             <TextView
                 android:id="@+id/text_show_titles"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
                 android:layout_marginStart="24dp"
                 android:text="@string/show_titles_in_game_list"
                 app:layout_constraintBottom_toBottomOf="@+id/switch_show_titles"
+                app:layout_constraintEnd_toStartOf="@+id/switch_show_titles"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/switch_show_titles" />
 


### PR DESCRIPTION
Previously on displays with a small width, text would appear under the switch. Now the text will break into a new line.