### PR TITLE
Core: Allocate 2 GiB of guard pages below fastmem area

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -104,13 +104,8 @@ void MemoryManager::Init()
   const bool wii = SConfig::GetInstance().bWii;
   const bool mmu = Core::System::GetInstance().IsMMUMode();
 
-  bool fake_vmem = false;
-#ifndef _ARCH_32
   // If MMU is turned off in GameCube mode, turn on fake VMEM hack.
-  // The fake VMEM hack's address space is above the memory space that we
-  // allocate on 32bit targets, so disable it there.
-  fake_vmem = !wii && !mmu;
-#endif
+  const bool fake_vmem = !wii && !mmu;
 
   u32 mem_size = 0;
   for (PhysicalMemoryRegion& region : m_physical_regions)
@@ -164,11 +159,7 @@ void MemoryManager::Init()
 
 bool MemoryManager::InitFastmemArena()
 {
-#if _ARCH_32
-  const size_t memory_size = 0x31000000;
-#else
-  const size_t memory_size = 0x400000000;
-#endif
+  constexpr size_t memory_size = 0x400000000;
   m_physical_base = m_arena.ReserveMemoryRegion(memory_size);
 
   if (!m_physical_base)
@@ -194,9 +185,7 @@ bool MemoryManager::InitFastmemArena()
     }
   }
 
-#ifndef _ARCH_32
   m_logical_base = m_physical_base + 0x200000000;
-#endif
 
   m_is_fastmem_arena_initialized = true;
   return true;

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -218,16 +218,14 @@ private:
   // with address translation turned on.  This mapping is computed based
   // on the BAT registers.
   //
-  // Each of these 4GB regions is followed by 4GB of empty space so overflows
-  // in address computation in the JIT don't access the wrong memory.
+  // Each of these 4GB regions is surrounded by 2GB of empty space so overflows
+  // in address computation in the JIT don't access unrelated memory.
   //
   // The neighboring mirrors of RAM ([0x02000000, 0x08000000), etc.) exist because
   // the bus masks off the bits in question for RAM accesses; using them is a
   // terrible idea because the CPU cache won't handle them correctly, but a
   // few buggy games (notably Rogue Squadron 2) use them by accident. They
   // aren't backed by memory mappings because they are used very rarely.
-  //
-  // Dolphin doesn't emulate the difference between cached and uncached access.
   //
   // TODO: The actual size of RAM is 24MB; the other 8MB shouldn't be backed by actual memory.
   // TODO: Do we want to handle the mirrors of the GC RAM?


### PR DESCRIPTION
See the comment added by this pull request. We were previously guarding against overshooting in address calculations, but not against undershooting. Perhaps someone assumed that the displacement of an x86 loadstore was treated as unsigned?

Note: While the comment says we can undershoot by up to 2 GiB, in practice Jit64 as it currently behaves won't actually undershoot by more than 0x8000 if my analysis is correct. But address space is cheap, so let's guard the full 2 GiB.