### PR TITLE
Jit64: Fix the offsetAddedToAddress correction

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -329,7 +329,7 @@ bool Jit64::BackPatch(SContext* ctx)
   if (info.offsetAddedToAddress)
   {
     u64* ptr = ContextRN(ctx, info.op_arg.GetSimpleReg());
-    *ptr -= static_cast<u32>(info.offset);
+    *ptr = static_cast<u32>(*ptr - info.offset);
   }
 
   ctx->CTX_PC = reinterpret_cast<u64>(trampoline);


### PR DESCRIPTION
x86 address displacements are treated as signed, not unsigned.