### PR TITLE
Android: Update build tools and dependencies

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -13,12 +13,12 @@ android {
         // Flag to enable support for the new language APIs
         coreLibraryDesugaringEnabled true
 
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = "11"
+        targetCompatibility = "11"
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     lint {

--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -116,21 +116,21 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.0'
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
     implementation 'androidx.exifinterface:exifinterface:1.3.5'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-viewmodel:2.5.1'
-    implementation 'androidx.fragment:fragment:1.5.4'
+    implementation 'androidx.fragment:fragment:1.5.5'
     implementation 'androidx.slidingpanelayout:slidingpanelayout:1.2.0'
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.core:core-splashscreen:1.0.0'
     implementation 'androidx.preference:preference:1.2.0'
-    implementation 'androidx.profileinstaller:profileinstaller:1.2.1'
+    implementation 'androidx.profileinstaller:profileinstaller:1.2.2'
 
     // Force dependency version to solve build conflict with androidx preferences
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"

--- a/Source/Android/benchmark/build.gradle
+++ b/Source/Android/benchmark/build.gradle
@@ -60,8 +60,8 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.test.ext:junit:1.1.4'
-    implementation 'androidx.test.espresso:espresso-core:3.5.0'
+    implementation 'androidx.test.ext:junit:1.1.5'
+    implementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     implementation 'androidx.benchmark:benchmark-macro-junit4:1.1.1'
 }

--- a/Source/Android/benchmark/build.gradle
+++ b/Source/Android/benchmark/build.gradle
@@ -10,12 +10,12 @@ android {
     compileSdk 33
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = "11"
+        targetCompatibility = "11"
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     defaultConfig {

--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '7.4.0' apply false
+    id 'com.android.library' version '7.4.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
 }

--- a/Source/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Source/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Dec 08 14:08:30 EST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
In app module
Androidx Fragment 1.5.4 -> 1.5.5
Androidx AppCompat 1.5.1 -> 1.6.0
Androidx Profile Installer 1.2.1 -> 1.2.2
Core android library desugaring libraries 1.1.5 -> 2.0.0

In benchmark module
Androidx JUnit 1.1.4 -> 1.1.5
Androidx Espresso 3.5.0 -> 3.5.1

Java 11 bytecode is enabled across the project
AGP 7.3.1 -> 7.4.0
Gradle 7.5.1 -> 7.6