### PR TITLE
Jit64: Properly handle backpatching overflowed address calculations

### DIFF
--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -72,6 +72,7 @@ public:
   u32 GetExRamSize() const { return m_exram_size; }
   u32 GetExRamMask() const { return m_exram_mask; }
 
+  bool IsAddressInFastmemArea(const u8* address) const;
   u8* GetPhysicalBase() const { return m_physical_base; }
   u8* GetLogicalBase() const { return m_logical_base; }
   u8* GetPhysicalPageMappingsBase() const { return m_physical_page_mappings_base; }
@@ -146,6 +147,8 @@ private:
   // are used to set up a full GC or Wii memory map in process memory.
   // In 64-bit, this might point to "high memory" (above the 32-bit limit),
   // so be sure to load it into a 64-bit register.
+  u8* m_fastmem_arena = nullptr;
+  size_t m_fastmem_arena_size = 0;
   u8* m_physical_base = nullptr;
   u8* m_logical_base = nullptr;
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -51,7 +51,7 @@ public:
 
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
   bool HandleStackFault() override;
-  bool BackPatch(u32 emAddress, SContext* ctx);
+  bool BackPatch(SContext* ctx);
 
   void EnableOptimization();
   void EnableBlockLink();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -33,7 +33,7 @@ public:
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
   void DoBacktrace(uintptr_t access_address, SContext* ctx);
   bool HandleStackFault() override;
-  bool HandleFastmemFault(uintptr_t access_address, SContext* ctx);
+  bool HandleFastmemFault(SContext* ctx);
 
   void ClearCache() override;
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -16,13 +16,11 @@
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
 
-#include "Core/HW/Memmap.h"
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/JitArm64/Jit_Util.h"
 #include "Core/PowerPC/JitArmCommon/BackPatch.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
-#include "Core/System.h"
 
 using namespace Arm64Gen;
 
@@ -304,22 +302,8 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, MemAccessMode mode, ARM64Reg RS, 
   }
 }
 
-bool JitArm64::HandleFastmemFault(uintptr_t access_address, SContext* ctx)
+bool JitArm64::HandleFastmemFault(SContext* ctx)
 {
-  auto& system = Core::System::GetInstance();
-  auto& memory = system.GetMemory();
-
-  if (!(access_address >= (uintptr_t)memory.GetPhysicalBase() &&
-        access_address < (uintptr_t)memory.GetPhysicalBase() + 0x100010000) &&
-      !(access_address >= (uintptr_t)memory.GetLogicalBase() &&
-        access_address < (uintptr_t)memory.GetLogicalBase() + 0x100010000))
-  {
-    ERROR_LOG_FMT(DYNA_REC,
-                  "Exception handler - access below memory space. PC: {:#018x} {:#018x} < {:#018x}",
-                  ctx->CTX_PC, access_address, (uintptr_t)memory.GetPhysicalBase());
-    return false;
-  }
-
   const u8* pc = reinterpret_cast<const u8*>(ctx->CTX_PC);
   auto slow_handler_iter = m_fault_to_handler.upper_bound(pc);
 


### PR DESCRIPTION
Previously we would only backpatch overflowed address calculations if the overflow was 0x1000 or less. Now we can handle the full 2 GiB of overflow in both directions.

I'm also making equivalent changes to JitArm64's code. This isn't because it needs it – JitArm64 address calculations should never overflow – but because I wanted to get rid of the 0x100001000 inherited from Jit64 that makes even less sense for JitArm64 than for Jit64.