### PR TITLE
Android: Fix large strings in save/load savestate fragment

### DIFF
--- a/Source/Android/app/src/main/res/layout/fragment_saveload_state.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_saveload_state.xml
@@ -9,38 +9,38 @@
 
     <Button
         android:id="@+id/loadsave_state_button_1"
-        android:layout_width="128dp"
-        android:layout_height="96dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         style="@style/OverlayInGameMenuOption"/>
 
     <Button
         android:id="@+id/loadsave_state_button_2"
-        android:layout_width="128dp"
-        android:layout_height="96dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         style="@style/OverlayInGameMenuOption"/>
 
     <Button
         android:id="@+id/loadsave_state_button_3"
-        android:layout_width="128dp"
-        android:layout_height="96dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         style="@style/OverlayInGameMenuOption"/>
 
     <Button
         android:id="@+id/loadsave_state_button_4"
-        android:layout_width="128dp"
-        android:layout_height="96dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         style="@style/OverlayInGameMenuOption"/>
 
     <Button
         android:id="@+id/loadsave_state_button_5"
-        android:layout_width="128dp"
-        android:layout_height="96dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         style="@style/OverlayInGameMenuOption"/>
 
     <Button
         android:id="@+id/loadsave_state_button_6"
-        android:layout_width="128dp"
-        android:layout_height="96dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         style="@style/OverlayInGameMenuOption"/>
 
 </GridLayout>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -14,7 +14,7 @@
 
     <style name="OverlayInGameMenuOption" parent="InGameMenuOption">
         <item name="android:textColor">@android:color/white</item>
-        <item name="android:padding">8dp</item>
+        <item name="android:padding">@dimen/spacing_medlarge</item>
         <item name="android:gravity">center</item>
         <item name="android:layout_gravity">center</item>
     </style>


### PR DESCRIPTION
Previously each button had its size hardcoded. Now the button will follow the size of the internal textview and avoid cutting off text.