### PR TITLE
MenuBar: Tweak string for open user folder option

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -217,7 +217,7 @@ void MenuBar::AddFileMenu()
   file_menu->addSeparator();
 
   m_open_user_folder =
-      file_menu->addAction(tr("Open &User Folder"), this, &MenuBar::OpenUserFolder);
+      file_menu->addAction(tr("Open Global &User Directory"), this, &MenuBar::OpenUserFolder);
 
   file_menu->addSeparator();
 


### PR DESCRIPTION
Last minute change: "Open User Folder" -> "Open Global User Directory", since the latter is what we've used in the past.

<img width="368" alt="image" src="https://user-images.githubusercontent.com/11504941/212645155-5717f4d6-8f8f-4b16-8fea-2652accf45b1.png">
