### PR TITLE
Revert "MenuBar: Tweak string for open user folder option"

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -217,7 +217,7 @@ void MenuBar::AddFileMenu()
   file_menu->addSeparator();
 
   m_open_user_folder =
-      file_menu->addAction(tr("Open Global &User Directory"), this, &MenuBar::OpenUserFolder);
+      file_menu->addAction(tr("Open &User Folder"), this, &MenuBar::OpenUserFolder);
 
   file_menu->addSeparator();
 


### PR DESCRIPTION
This reverts PR #11451.

The user folder can be either global or local. If it is local, we shouldn't call it global.

See also PR #10216.