### PR TITLE
implot: Don't compile `implot_demo.cpp`

### DIFF
--- a/Externals/implot/CMakeLists.txt
+++ b/Externals/implot/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 set(SRCS
   implot/implot.cpp
   implot/implot_items.cpp
-  implot/implot_demo.cpp
 )
 
 add_library(implot STATIC ${SRCS})

--- a/Externals/implot/implot.vcxproj
+++ b/Externals/implot/implot.vcxproj
@@ -24,7 +24,6 @@
     <ItemGroup>
         <ClCompile Include="implot/implot.cpp" />
         <ClCompile Include="implot/implot_items.cpp" />
-        <ClCompile Include="implot/implot_demo.cpp" />
     </ItemGroup>
     <ItemGroup>
         <ClInclude Include="implot/implot.h" />


### PR DESCRIPTION
`implot_demo.cpp` depends on functions from `imgui_demo.cpp`, which we do not have. Appears to cause linking errors only on my fork, but I figured I would upstream this anyway.