### PR TITLE
CommonPaths: Add Steam-specific user directory and clean up

### DIFF
--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -11,20 +11,20 @@
 #define ROOT_DIR "."
 #ifdef _WIN32
 #define PORTABLE_USER_DIR "User"
-#define DOLPHIN_DATA_DIR "Dolphin"
+#define NORMAL_USER_DIR "Dolphin"
 #elif defined __APPLE__
 // On OS X, PORTABLE_USER_DIR exists within the .app, but *always* reference
 // the copy in Application Support instead! (Copied on first run)
 // You can use the File::GetUserPath() util for this
 #define PORTABLE_USER_DIR "Contents/Resources/User"
-#define DOLPHIN_DATA_DIR "Library/Application Support/Dolphin"
+#define NORMAL_USER_DIR "Library/Application Support/Dolphin"
 #elif defined ANDROID
 #define PORTABLE_USER_DIR "user"
-#define DOLPHIN_DATA_DIR "/sdcard/dolphin-emu"
+#define NORMAL_USER_DIR "/sdcard/dolphin-emu"
 #define NOMEDIA_FILE ".nomedia"
 #else
 #define PORTABLE_USER_DIR "user"
-#define DOLPHIN_DATA_DIR "dolphin-emu"
+#define NORMAL_USER_DIR "dolphin-emu"
 #endif
 
 // Dirs in both User and Sys

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -11,6 +11,7 @@
 #define ROOT_DIR "."
 
 // The normal user directory
+#ifndef STEAM
 #ifdef _WIN32
 #define NORMAL_USER_DIR "Dolphin Emulator"
 #elif defined(__APPLE__)
@@ -19,6 +20,15 @@
 #define NORMAL_USER_DIR "/sdcard/dolphin-emu"
 #else
 #define NORMAL_USER_DIR "dolphin-emu"
+#endif
+#else  // ifndef STEAM
+#ifdef _WIN32
+#define NORMAL_USER_DIR "Dolphin Emulator (Steam)"
+#elif defined(__APPLE__)
+#define NORMAL_USER_DIR "Library/Application Support/Dolphin (Steam)"
+#else
+#define NORMAL_USER_DIR "dolphin-emu-steam"
+#endif
 #endif
 
 // The portable user directory

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -7,23 +7,22 @@
 #define DIR_SEP "/"
 #define DIR_SEP_CHR '/'
 
-// The user data dir
 #define ROOT_DIR "."
 #ifdef _WIN32
 #define PORTABLE_USER_DIR "User"
 #define NORMAL_USER_DIR "Dolphin Emulator"
 #elif defined __APPLE__
-// On OS X, PORTABLE_USER_DIR exists within the .app, but *always* reference
-// the copy in Application Support instead! (Copied on first run)
-// You can use the File::GetUserPath() util for this
-#define PORTABLE_USER_DIR "Contents/Resources/User"
+#define PORTABLE_USER_DIR "User"
+#define EMBEDDED_USER_DIR "Contents/Resources/User"
 #define NORMAL_USER_DIR "Library/Application Support/Dolphin"
 #elif defined ANDROID
 #define PORTABLE_USER_DIR "user"
+#define EMBEDDED_USER_DIR PORTABLE_USER_DIR
 #define NORMAL_USER_DIR "/sdcard/dolphin-emu"
 #define NOMEDIA_FILE ".nomedia"
 #else
 #define PORTABLE_USER_DIR "user"
+#define EMBEDDED_USER_DIR PORTABLE_USER_DIR
 #define NORMAL_USER_DIR "dolphin-emu"
 #endif
 

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -11,7 +11,7 @@
 #define ROOT_DIR "."
 #ifdef _WIN32
 #define PORTABLE_USER_DIR "User"
-#define NORMAL_USER_DIR "Dolphin"
+#define NORMAL_USER_DIR "Dolphin Emulator"
 #elif defined __APPLE__
 // On OS X, PORTABLE_USER_DIR exists within the .app, but *always* reference
 // the copy in Application Support instead! (Copied on first run)

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -10,20 +10,20 @@
 // The user data dir
 #define ROOT_DIR "."
 #ifdef _WIN32
-#define USERDATA_DIR "User"
+#define PORTABLE_USER_DIR "User"
 #define DOLPHIN_DATA_DIR "Dolphin"
 #elif defined __APPLE__
-// On OS X, USERDATA_DIR exists within the .app, but *always* reference
+// On OS X, PORTABLE_USER_DIR exists within the .app, but *always* reference
 // the copy in Application Support instead! (Copied on first run)
 // You can use the File::GetUserPath() util for this
-#define USERDATA_DIR "Contents/Resources/User"
+#define PORTABLE_USER_DIR "Contents/Resources/User"
 #define DOLPHIN_DATA_DIR "Library/Application Support/Dolphin"
 #elif defined ANDROID
-#define USERDATA_DIR "user"
+#define PORTABLE_USER_DIR "user"
 #define DOLPHIN_DATA_DIR "/sdcard/dolphin-emu"
 #define NOMEDIA_FILE ".nomedia"
 #else
-#define USERDATA_DIR "user"
+#define PORTABLE_USER_DIR "user"
 #define DOLPHIN_DATA_DIR "dolphin-emu"
 #endif
 

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -7,24 +7,33 @@
 #define DIR_SEP "/"
 #define DIR_SEP_CHR '/'
 
+// The current working directory
 #define ROOT_DIR "."
+
+// The normal user directory
+#ifdef _WIN32
+#define NORMAL_USER_DIR "Dolphin Emulator"
+#elif defined(__APPLE__)
+#define NORMAL_USER_DIR "Library/Application Support/Dolphin"
+#elif defined(ANDROID)
+#define NORMAL_USER_DIR "/sdcard/dolphin-emu"
+#else
+#define NORMAL_USER_DIR "dolphin-emu"
+#endif
+
+// The portable user directory
 #ifdef _WIN32
 #define PORTABLE_USER_DIR "User"
-#define NORMAL_USER_DIR "Dolphin Emulator"
-#elif defined __APPLE__
+#elif defined(__APPLE__)
 #define PORTABLE_USER_DIR "User"
 #define EMBEDDED_USER_DIR "Contents/Resources/User"
-#define NORMAL_USER_DIR "Library/Application Support/Dolphin"
-#elif defined ANDROID
-#define PORTABLE_USER_DIR "user"
-#define EMBEDDED_USER_DIR PORTABLE_USER_DIR
-#define NORMAL_USER_DIR "/sdcard/dolphin-emu"
-#define NOMEDIA_FILE ".nomedia"
 #else
 #define PORTABLE_USER_DIR "user"
 #define EMBEDDED_USER_DIR PORTABLE_USER_DIR
-#define NORMAL_USER_DIR "dolphin-emu"
 #endif
+
+// Flag file to prevent media scanning from indexing a directory
+#define NOMEDIA_FILE ".nomedia"
 
 // Dirs in both User and Sys
 // Legacy setups used /JAP/ while newer setups use /JPN/ by default.

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -340,7 +340,7 @@ void SetUserDirectory(std::string custom_path)
   std::optional<std::string> old_user_folder;
   if (documents_found)
   {
-    old_user_folder = TStrToUTF8(documents) + DIR_SEP "Dolphin Emulator" DIR_SEP;
+    old_user_folder = TStrToUTF8(documents) + DIR_SEP NORMAL_USER_DIR DIR_SEP;
   }
 
   if (local)  // Case 1-2
@@ -357,7 +357,7 @@ void SetUserDirectory(std::string custom_path)
   }
   else if (appdata_found)  // Case 5
   {
-    user_path = TStrToUTF8(appdata) + DIR_SEP "Dolphin Emulator" DIR_SEP;
+    user_path = TStrToUTF8(appdata) + DIR_SEP NORMAL_USER_DIR DIR_SEP;
 
     // Set the UserConfigPath value in the registry for backwards compatibility with older Dolphin
     // builds, which will look for the default User directory in Documents. If we set this key,

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -376,9 +376,9 @@ void SetUserDirectory(std::string custom_path)
   CoTaskMemFree(appdata);
   CoTaskMemFree(documents);
 #else
-  if (File::IsDirectory(ROOT_DIR DIR_SEP PORTABLE_USER_DIR))
+  if (File::IsDirectory(ROOT_DIR DIR_SEP EMBEDDED_USER_DIR))
   {
-    user_path = ROOT_DIR DIR_SEP PORTABLE_USER_DIR DIR_SEP;
+    user_path = ROOT_DIR DIR_SEP EMBEDDED_USER_DIR DIR_SEP;
   }
   else
   {
@@ -412,7 +412,7 @@ void SetUserDirectory(std::string custom_path)
     std::string exe_path = File::GetExeDirectory();
     if (File::Exists(exe_path + DIR_SEP "portable.txt"))
     {
-      user_path = exe_path + DIR_SEP "User" DIR_SEP;
+      user_path = exe_path + DIR_SEP PORTABLE_USER_DIR DIR_SEP;
     }
     else if (env_path)
     {

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -421,12 +421,12 @@ void SetUserDirectory(std::string custom_path)
 #if defined(__APPLE__) || defined(ANDROID)
     else
     {
-      user_path = home_path + DOLPHIN_DATA_DIR DIR_SEP;
+      user_path = home_path + NORMAL_USER_DIR DIR_SEP;
     }
 #else
     else
     {
-      user_path = home_path + "." DOLPHIN_DATA_DIR DIR_SEP;
+      user_path = home_path + "." NORMAL_USER_DIR DIR_SEP;
 
       if (!File::Exists(user_path))
       {
@@ -434,18 +434,18 @@ void SetUserDirectory(std::string custom_path)
         std::string data_path =
             std::string(data_home && data_home[0] == '/' ? data_home :
                                                            (home_path + ".local" DIR_SEP "share")) +
-            DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
+            DIR_SEP NORMAL_USER_DIR DIR_SEP;
 
         const char* config_home = getenv("XDG_CONFIG_HOME");
         std::string config_path =
             std::string(config_home && config_home[0] == '/' ? config_home :
                                                                (home_path + ".config")) +
-            DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
+            DIR_SEP NORMAL_USER_DIR DIR_SEP;
 
         const char* cache_home = getenv("XDG_CACHE_HOME");
         std::string cache_path =
             std::string(cache_home && cache_home[0] == '/' ? cache_home : (home_path + ".cache")) +
-            DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
+            DIR_SEP NORMAL_USER_DIR DIR_SEP;
 
         File::SetUserPath(D_USER_IDX, data_path);
         File::SetUserPath(D_CONFIG_IDX, config_path);

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -345,7 +345,7 @@ void SetUserDirectory(std::string custom_path)
 
   if (local)  // Case 1-2
   {
-    user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
+    user_path = File::GetExeDirectory() + DIR_SEP PORTABLE_USER_DIR DIR_SEP;
   }
   else if (configPath)  // Case 3
   {
@@ -370,15 +370,15 @@ void SetUserDirectory(std::string custom_path)
   }
   else  // Case 6
   {
-    user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
+    user_path = File::GetExeDirectory() + DIR_SEP PORTABLE_USER_DIR DIR_SEP;
   }
 
   CoTaskMemFree(appdata);
   CoTaskMemFree(documents);
 #else
-  if (File::IsDirectory(ROOT_DIR DIR_SEP USERDATA_DIR))
+  if (File::IsDirectory(ROOT_DIR DIR_SEP PORTABLE_USER_DIR))
   {
-    user_path = ROOT_DIR DIR_SEP USERDATA_DIR DIR_SEP;
+    user_path = ROOT_DIR DIR_SEP PORTABLE_USER_DIR DIR_SEP;
   }
   else
   {


### PR DESCRIPTION
Having a Steam-specific user directory will allow us to enable Steam Cloud, so that users can have their save files synchronized across machines. The paths are as follows:

* Windows: `%appdata%\Dolphin Emulator (Steam)`
* macOS: `~/Library/Application Support/Dolphin (Steam)`
* Linux: `~/.config/dolphin-emu-steam`, `~/.local/share/dolphin-emu-steam`, and `~/.cache/dolphin-emu-steam`

In addition, the user directory logic has been simplified for Windows builds on Steam. Basically, the registry keys and the old user directory are ignored. (We cannot check the user directory registry key because it is set to the non-Steam path on newer installs.)

While I was here, I also took the opportunity to clean up `CommonPaths.h`, since the names used for the defines were a bit outdated.