### PR TITLE
Data: Add run script for Steam runtime with workaround for Qt bug

### DIFF
--- a/Data/run_dolphin_steamrt.sh
+++ b/Data/run_dolphin_steamrt.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$(dirname "$0")/dolphin-emu "$@"

--- a/Data/run_dolphin_steamrt.sh
+++ b/Data/run_dolphin_steamrt.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-$(dirname "$0")/dolphin-emu "$@"
+# We define QT_XCB_NO_XI2 as a workaround for https://bugs.dolphin-emu.org/issues/12913.
+QT_XCB_NO_XI2=1 $(dirname "$0")/dolphin-emu "$@"

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -667,6 +667,12 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND STEAM)
   add_custom_command(TARGET dolphin-emu POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/Data/Sys" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sys"
   )
+
+  # Copy run_dolphin_steamrt.sh
+  target_sources(dolphin-emu PRIVATE "${CMAKE_SOURCE_DIR}/Data/run_dolphin_steamrt.sh")
+  add_custom_command(TARGET dolphin-emu POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/Data/run_dolphin_steamrt.sh" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_dolphin_steamrt.sh"
+  )
 endif()
 
 if(USE_MGBA)


### PR DESCRIPTION
The bug in question: https://bugs.dolphin-emu.org/issues/12913

Once merged, I'll change the default launch options in the Steam partner dashboard to use this script as the file to execute. (I have to use a script because it doesn't appear possible to set environment variables in launch options.)