### PR TITLE
Revert "Remove Boot from DVD Backup"

### DIFF
--- a/Source/Core/Common/CDUtils.cpp
+++ b/Source/Core/Common/CDUtils.cpp
@@ -1,0 +1,230 @@
+// Copyright 2009 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Most of the code in this file was shamelessly ripped from libcdio With minor adjustments
+
+#include "Common/CDUtils.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#elif __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOBSD.h>
+#include <IOKit/IOKitLib.h>
+#include <IOKit/storage/IOCDMedia.h>
+#include <IOKit/storage/IOMedia.h>
+#include <paths.h>
+#else
+#include <climits>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif  // WIN32
+
+#ifdef __linux__
+#include <linux/cdrom.h>
+#endif
+
+#include "Common/Common.h"
+#include "Common/CommonTypes.h"
+#include "Common/StringUtil.h"
+
+namespace Common
+{
+#ifdef _WIN32
+// takes a root drive path, returns true if it is a cdrom drive
+static bool IsCDROM(const TCHAR* drive)
+{
+  return (DRIVE_CDROM == GetDriveType(drive));
+}
+
+// Returns a vector with the device names
+std::vector<std::string> GetCDDevices()
+{
+  std::vector<std::string> drives;
+
+  const DWORD buffsize = GetLogicalDriveStrings(0, nullptr);
+  std::vector<TCHAR> buff(buffsize);
+  if (GetLogicalDriveStrings(buffsize, buff.data()) == buffsize - 1)
+  {
+    auto drive = buff.data();
+    while (*drive)
+    {
+      if (IsCDROM(drive))
+      {
+        std::string str(TStrToUTF8(drive));
+        str.pop_back();  // we don't want the final backslash
+        drives.push_back(std::move(str));
+      }
+
+      // advance to next drive
+      while (*drive++)
+      {
+      }
+    }
+  }
+  return drives;
+}
+#elif defined __APPLE__
+// Returns a pointer to an array of strings with the device names
+std::vector<std::string> GetCDDevices()
+{
+  io_object_t next_media;
+  mach_port_t master_port;
+  kern_return_t kern_result;
+  io_iterator_t media_iterator;
+  CFMutableDictionaryRef classes_to_match;
+  std::vector<std::string> drives;
+
+  kern_result = IOMasterPort(MACH_PORT_NULL, &master_port);
+  if (kern_result != KERN_SUCCESS)
+    return drives;
+
+  classes_to_match = IOServiceMatching(kIOCDMediaClass);
+  if (classes_to_match == nullptr)
+    return drives;
+
+  CFDictionarySetValue(classes_to_match, CFSTR(kIOMediaEjectableKey), kCFBooleanTrue);
+
+  kern_result = IOServiceGetMatchingServices(master_port, classes_to_match, &media_iterator);
+  if (kern_result != KERN_SUCCESS)
+    return drives;
+
+  next_media = IOIteratorNext(media_iterator);
+  if (next_media != 0)
+  {
+    CFTypeRef str_bsd_path;
+
+    do
+    {
+      str_bsd_path =
+          IORegistryEntryCreateCFProperty(next_media, CFSTR(kIOBSDNameKey), kCFAllocatorDefault, 0);
+      if (str_bsd_path == nullptr)
+      {
+        IOObjectRelease(next_media);
+        continue;
+      }
+
+      if (CFGetTypeID(str_bsd_path) == CFStringGetTypeID())
+      {
+        size_t buf_size = CFStringGetLength((CFStringRef)str_bsd_path) * 4 + 1;
+        char* buf = new char[buf_size];
+
+        if (CFStringGetCString((CFStringRef)str_bsd_path, buf, buf_size, kCFStringEncodingUTF8))
+        {
+          // Below, by appending 'r' to the BSD node name, we indicate
+          // a raw disk. Raw disks receive I/O requests directly and
+          // don't go through a buffer cache.
+          drives.push_back(std::string(_PATH_DEV "r") + buf);
+        }
+
+        delete[] buf;
+      }
+      CFRelease(str_bsd_path);
+      IOObjectRelease(next_media);
+    } while ((next_media = IOIteratorNext(media_iterator)) != 0);
+  }
+  IOObjectRelease(media_iterator);
+  return drives;
+}
+#else
+// checklist: /dev/cdrom, /dev/dvd /dev/hd?, /dev/scd? /dev/sr?
+struct CheckListEntry
+{
+  const char* format;
+  unsigned int num_min;
+  unsigned int num_max;
+};
+
+constexpr CheckListEntry checklist[] = {
+#ifdef __linux__
+    {"/dev/cdrom", 0, 0},  {"/dev/dvd", 0, 0},   {"/dev/hd{}", 'a', 'z'},
+    {"/dev/scd{}", 0, 27}, {"/dev/sr{}", 0, 27},
+#else
+    {"/dev/acd{}", 0, 27},
+    {"/dev/cd{}", 0, 27},
+#endif
+    {nullptr, 0, 0},
+};
+
+// Returns true if a device is a block or char device and not a symbolic link
+static bool IsDevice(const std::string& source_name)
+{
+  struct stat buf;
+  if (0 != lstat(source_name.c_str(), &buf))
+    return false;
+
+  return ((S_ISBLK(buf.st_mode) || S_ISCHR(buf.st_mode)) && !S_ISLNK(buf.st_mode));
+}
+
+// Check a device to see if it is a DVD/CD-ROM drive
+static bool IsCDROM(const std::string& drive)
+{
+  // Check if the device exists
+  if (!IsDevice(drive))
+    return false;
+
+  bool is_cd = false;
+  // If it does exist, verify that it is a cdrom/dvd drive
+  int cdfd = open(drive.c_str(), (O_RDONLY | O_NONBLOCK), 0);
+  if (cdfd >= 0)
+  {
+#ifdef __linux__
+    if (ioctl(cdfd, CDROM_GET_CAPABILITY, 0) != -1)
+#endif
+      is_cd = true;
+    close(cdfd);
+  }
+  return is_cd;
+}
+
+// Returns a pointer to an array of strings with the device names
+std::vector<std::string> GetCDDevices()
+{
+  std::vector<std::string> drives;
+  // Scan the system for DVD/CD-ROM drives.
+  for (unsigned int i = 0; checklist[i].format; ++i)
+  {
+    for (unsigned int j = checklist[i].num_min; j <= checklist[i].num_max; ++j)
+    {
+      std::string drive = fmt::format(fmt::runtime(checklist[i].format), j);
+      if (IsCDROM(drive))
+      {
+        drives.push_back(std::move(drive));
+      }
+    }
+  }
+  return drives;
+}
+#endif
+
+// Returns true if device is a cdrom/dvd drive
+bool IsCDROMDevice(std::string device)
+{
+#ifndef _WIN32
+  // Resolve symbolic links. This allows symbolic links to valid
+  // drives to be passed from the command line with the -e flag.
+  char resolved_path[PATH_MAX];
+  char* devname = realpath(device.c_str(), resolved_path);
+  if (!devname)
+    return false;
+  device = devname;
+#endif
+
+  std::vector<std::string> devices = GetCDDevices();
+  for (const std::string& d : devices)
+  {
+    if (d == device)
+      return true;
+  }
+  return false;
+}
+}  // namespace Common

--- a/Source/Core/Common/CDUtils.h
+++ b/Source/Core/Common/CDUtils.h
@@ -1,0 +1,16 @@
+// Copyright 2009 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace Common
+{
+// Returns a pointer to an array of strings with the device names
+std::vector<std::string> GetCDDevices();
+
+// Returns true if device is cdrom/dvd
+bool IsCDROMDevice(std::string device);
+}  // namespace Common

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(common
   BitSet.h
   BitUtils.h
   BlockingLoop.h
+  CDUtils.cpp
+  CDUtils.h
   ChunkFile.h
   CodeBlock.h
   ColorUtil.cpp

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -19,6 +19,7 @@
 #include "AudioCommon/AudioCommon.h"
 
 #include "Common/Assert.h"
+#include "Common/CDUtils.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"

--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include "Common/CDUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"
 #include "Common/MsgHandler.h"

--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -18,6 +18,7 @@
 #include "DiscIO/CISOBlob.h"
 #include "DiscIO/CompressedBlob.h"
 #include "DiscIO/DirectoryBlob.h"
+#include "DiscIO/DriveBlob.h"
 #include "DiscIO/FileBlob.h"
 #include "DiscIO/NFSBlob.h"
 #include "DiscIO/TGCBlob.h"
@@ -214,6 +215,9 @@ u32 SectorReader::ReadChunk(u8* buffer, u64 chunk_num)
 
 std::unique_ptr<BlobReader> CreateBlobReader(const std::string& filename)
 {
+  if (Common::IsCDROMDevice(filename))
+    return DriveReader::Create(filename);
+
   File::IOFile file(filename, "rb");
   u32 magic;
   if (!file.ReadArray(&magic, 1))

--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(discio
   DiscScrubber.h
   DiscUtils.cpp
   DiscUtils.h
+  DriveBlob.cpp
+  DriveBlob.h
   Enums.cpp
   Enums.h
   FileBlob.cpp

--- a/Source/Core/DiscIO/DriveBlob.cpp
+++ b/Source/Core/DiscIO/DriveBlob.cpp
@@ -1,0 +1,161 @@
+// Copyright 2008 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DiscIO/DriveBlob.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+#include "Common/IOFile.h"
+#include "Common/Logging/Log.h"
+#include "DiscIO/Blob.h"
+
+#ifdef _WIN32
+#include "Common/StringUtil.h"
+#else
+#include <stdio.h>  // fileno
+#include <sys/ioctl.h>
+#if defined __linux__
+#include <linux/fs.h>  // BLKGETSIZE64
+#elif defined __FreeBSD__
+#include <sys/disk.h>  // DIOCGMEDIASIZE
+#elif defined __APPLE__
+#include <sys/disk.h>  // DKIOCGETBLOCKCOUNT / DKIOCGETBLOCKSIZE
+#endif
+#endif
+
+namespace DiscIO
+{
+DriveReader::DriveReader(const std::string& drive)
+{
+  // 32 sectors is roughly the optimal amount a CD Drive can read in
+  // a single IO cycle. Larger values yield no performance improvement
+  // and just cause IO stalls from the read delay. Smaller values allow
+  // the OS IO and seeking overhead to ourstrip the time actually spent
+  // transferring bytes from the media.
+  SetChunkSize(32);  // 32*2048 = 64KiB
+  SetSectorSize(2048);
+#ifdef _WIN32
+  auto const path = UTF8ToTStr(std::string("\\\\.\\") + drive);
+  m_disc_handle = CreateFile(path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                             nullptr, OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, nullptr);
+  if (IsOK())
+  {
+    // Do a test read to make sure everything is OK, since it seems you can get
+    // handles to empty drives.
+    DWORD not_used;
+    std::vector<u8> buffer(GetSectorSize());
+    if (!ReadFile(m_disc_handle, buffer.data(), GetSectorSize(), &not_used, nullptr))
+    {
+      // OK, something is wrong.
+      CloseHandle(m_disc_handle);
+      m_disc_handle = INVALID_HANDLE_VALUE;
+    }
+  }
+  if (IsOK())
+  {
+    // Initialize m_size by querying the volume capacity.
+    STORAGE_READ_CAPACITY storage_size;
+    storage_size.Version = sizeof(storage_size);
+    DWORD bytes = 0;
+    DeviceIoControl(m_disc_handle, IOCTL_STORAGE_READ_CAPACITY, nullptr, 0, &storage_size,
+                    sizeof(storage_size), &bytes, nullptr);
+    m_size = bytes ? storage_size.DiskLength.QuadPart : 0;
+
+#ifdef _LOCKDRIVE  // Do we want to lock the drive?
+    // Lock the compact disc in the CD-ROM drive to prevent accidental
+    // removal while reading from it.
+    m_lock_cdrom.PreventMediaRemoval = TRUE;
+    DeviceIoControl(m_disc_handle, IOCTL_CDROM_MEDIA_REMOVAL, &m_lock_cdrom, sizeof(m_lock_cdrom),
+                    nullptr, 0, &dwNotUsed, nullptr);
+#endif
+#else
+  m_file.Open(drive, "rb");
+  if (m_file)
+  {
+    int fd = fileno(m_file.GetHandle());
+#if defined __linux__
+    // NOTE: Doesn't matter if it fails, m_size was initialized to zero
+    ioctl(fd, BLKGETSIZE64, &m_size);  // u64*
+#elif defined __FreeBSD__
+    off_t size = 0;
+    ioctl(fd, DIOCGMEDIASIZE, &size);  // off_t*
+    m_size = size;
+#elif defined __APPLE__
+    u64 count = 0;
+    u32 block_size = 0;
+    ioctl(fd, DKIOCGETBLOCKCOUNT, &count);      // u64*
+    ioctl(fd, DKIOCGETBLOCKSIZE, &block_size);  // u32*
+    m_size = count * block_size;
+#endif
+#endif
+  }
+  else
+  {
+    NOTICE_LOG_FMT(DISCIO, "Load from DVD backup failed or no disc in drive {}", drive);
+  }
+}
+
+DriveReader::~DriveReader()
+{
+#ifdef _WIN32
+#ifdef _LOCKDRIVE  // Do we want to lock the drive?
+  // Unlock the disc in the CD-ROM drive.
+  m_lock_cdrom.PreventMediaRemoval = FALSE;
+  DeviceIoControl(m_disc_handle, IOCTL_CDROM_MEDIA_REMOVAL, &m_lock_cdrom, sizeof(m_lock_cdrom),
+                  nullptr, 0, &dwNotUsed, nullptr);
+#endif
+  if (m_disc_handle != INVALID_HANDLE_VALUE)
+  {
+    CloseHandle(m_disc_handle);
+    m_disc_handle = INVALID_HANDLE_VALUE;
+  }
+#else
+  m_file.Close();
+#endif
+}
+
+std::unique_ptr<DriveReader> DriveReader::Create(const std::string& drive)
+{
+  auto reader = std::unique_ptr<DriveReader>(new DriveReader(drive));
+
+  if (!reader->IsOK())
+    reader.reset();
+
+  return reader;
+}
+
+bool DriveReader::GetBlock(u64 block_num, u8* out_ptr)
+{
+  return DriveReader::ReadMultipleAlignedBlocks(block_num, 1, out_ptr);
+}
+
+bool DriveReader::ReadMultipleAlignedBlocks(u64 block_num, u64 num_blocks, u8* out_ptr)
+{
+#ifdef _WIN32
+  LARGE_INTEGER offset;
+  offset.QuadPart = GetSectorSize() * block_num;
+  DWORD bytes_read;
+  if (!SetFilePointerEx(m_disc_handle, offset, nullptr, FILE_BEGIN) ||
+      !ReadFile(m_disc_handle, out_ptr, static_cast<DWORD>(GetSectorSize() * num_blocks),
+                &bytes_read, nullptr))
+  {
+    ERROR_LOG_FMT(DISCIO, "Disc Read Error");
+    return false;
+  }
+  return bytes_read == GetSectorSize() * num_blocks;
+#else
+  m_file.Seek(GetSectorSize() * block_num, File::SeekOrigin::Begin);
+  if (m_file.ReadBytes(out_ptr, num_blocks * GetSectorSize()))
+    return true;
+  m_file.ClearError();
+  return false;
+#endif
+}
+
+}  // namespace DiscIO

--- a/Source/Core/DiscIO/DriveBlob.h
+++ b/Source/Core/DiscIO/DriveBlob.h
@@ -1,0 +1,54 @@
+// Copyright 2008 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "Common/CommonTypes.h"
+#include "Common/IOFile.h"
+#include "DiscIO/Blob.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winioctl.h>
+#endif
+
+namespace DiscIO
+{
+class DriveReader : public SectorReader
+{
+public:
+  static std::unique_ptr<DriveReader> Create(const std::string& drive);
+  ~DriveReader();
+
+  BlobType GetBlobType() const override { return BlobType::DRIVE; }
+
+  u64 GetRawSize() const override { return m_size; }
+  u64 GetDataSize() const override { return m_size; }
+  DataSizeType GetDataSizeType() const override { return DataSizeType::Accurate; }
+
+  u64 GetBlockSize() const override { return ECC_BLOCK_SIZE; }
+  bool HasFastRandomAccessInBlock() const override { return false; }
+  std::string GetCompressionMethod() const override { return {}; }
+  std::optional<int> GetCompressionLevel() const override { return std::nullopt; }
+
+private:
+  DriveReader(const std::string& drive);
+  bool GetBlock(u64 block_num, u8* out_ptr) override;
+  bool ReadMultipleAlignedBlocks(u64 block_num, u64 num_blocks, u8* out_ptr) override;
+
+#ifdef _WIN32
+  HANDLE m_disc_handle = INVALID_HANDLE_VALUE;
+  PREVENT_MEDIA_REMOVAL m_lock_cdrom;
+  bool IsOK() const { return m_disc_handle != INVALID_HANDLE_VALUE; }
+#else
+  File::IOFile m_file;
+  bool IsOK() const { return m_file.IsOpen() && m_file.IsGood(); }
+#endif
+  static constexpr u64 ECC_BLOCK_SIZE = 0x8000;
+  u64 m_size = 0;
+};
+
+}  // namespace DiscIO

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -440,6 +440,7 @@
     <ClInclude Include="DiscIO\DiscExtractor.h" />
     <ClInclude Include="DiscIO\DiscScrubber.h" />
     <ClInclude Include="DiscIO\DiscUtils.h" />
+    <ClInclude Include="DiscIO\DriveBlob.h" />
     <ClInclude Include="DiscIO\Enums.h" />
     <ClInclude Include="DiscIO\FileBlob.h" />
     <ClInclude Include="DiscIO\Filesystem.h" />
@@ -1056,6 +1057,7 @@
     <ClCompile Include="DiscIO\DiscExtractor.cpp" />
     <ClCompile Include="DiscIO\DiscScrubber.cpp" />
     <ClCompile Include="DiscIO\DiscUtils.cpp" />
+    <ClCompile Include="DiscIO\DriveBlob.cpp" />
     <ClCompile Include="DiscIO\Enums.cpp" />
     <ClCompile Include="DiscIO\FileBlob.cpp" />
     <ClCompile Include="DiscIO\Filesystem.cpp" />

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -20,6 +20,7 @@
     <ClInclude Include="Common\BitSet.h" />
     <ClInclude Include="Common\BitUtils.h" />
     <ClInclude Include="Common\BlockingLoop.h" />
+    <ClInclude Include="Common\CDUtils.h" />
     <ClInclude Include="Common\ChunkFile.h" />
     <ClInclude Include="Common\CodeBlock.h" />
     <ClInclude Include="Common\ColorUtil.h" />
@@ -723,6 +724,7 @@
     <ClCompile Include="AudioCommon\WASAPIStream.cpp" />
     <ClCompile Include="AudioCommon\WaveFile.cpp" />
     <ClCompile Include="Common\Analytics.cpp" />
+    <ClCompile Include="Common\CDUtils.cpp" />
     <ClCompile Include="Common\ColorUtil.cpp" />
     <ClCompile Include="Common\CommonFuncs.cpp" />
     <ClCompile Include="Common\CompatPatches.cpp" />

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -480,6 +480,8 @@ void MainWindow::ConnectMenuBar()
   connect(m_menu_bar, &MenuBar::Exit, this, &MainWindow::close);
   connect(m_menu_bar, &MenuBar::EjectDisc, this, &MainWindow::EjectDisc);
   connect(m_menu_bar, &MenuBar::ChangeDisc, this, &MainWindow::ChangeDisc);
+  connect(m_menu_bar, &MenuBar::BootDVDBackup, this,
+          [this](const QString& drive) { StartGame(drive, ScanForSecondDisc::No); });
   connect(m_menu_bar, &MenuBar::OpenUserFolder, this, &MainWindow::OpenUserFolder);
 
   // Emulation

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -19,6 +19,7 @@
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
+#include "Common/CDUtils.h"
 #include "Core/Boot/Boot.h"
 #include "Core/CommonTitles.h"
 #include "Core/Config/MainSettings.h"

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -189,6 +189,19 @@ void MenuBar::OnDebugModeToggled(bool enabled)
   }
 }
 
+void MenuBar::AddDVDBackupMenu(QMenu* file_menu)
+{
+  m_backup_menu = file_menu->addMenu(tr("&Boot from DVD Backup"));
+
+  const std::vector<std::string> drives = Common::GetCDDevices();
+  // Windows Limitation of 24 character drives
+  for (size_t i = 0; i < drives.size() && i < 24; i++)
+  {
+    auto drive = QString::fromStdString(drives[i]);
+    m_backup_menu->addAction(drive, this, [this, drive] { emit BootDVDBackup(drive); });
+  }
+}
+
 void MenuBar::AddFileMenu()
 {
   QMenu* file_menu = addMenu(tr("&File"));
@@ -198,6 +211,8 @@ void MenuBar::AddFileMenu()
 
   m_change_disc = file_menu->addAction(tr("Change &Disc..."), this, &MenuBar::ChangeDisc);
   m_eject_disc = file_menu->addAction(tr("&Eject Disc"), this, &MenuBar::EjectDisc);
+
+  AddDVDBackupMenu(file_menu);
 
   file_menu->addSeparator();
 

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -54,6 +54,7 @@ signals:
   void Open();
   void Exit();
   void ChangeDisc();
+  void BootDVDBackup(const QString& backup);
   void EjectDisc();
   void OpenUserFolder();
 
@@ -127,6 +128,7 @@ private:
   void OnEmulationStateChanged(Core::State state);
 
   void AddFileMenu();
+  void AddDVDBackupMenu(QMenu* file_menu);
 
   void AddEmulationMenu();
   void AddStateLoadMenu(QMenu* emu_menu);


### PR DESCRIPTION
This reverts PR #11456.

The ability to boot DVD backups is in my experience as a maintainer of DiscIO really not a maintenance burden at all, since it's very compartmentalized. I had assumed that few people would be disappointed about this feature going away, but we ended up receiving disappointed comments on GitHub from three different people not long after the removal was merged, which is quite a lot. Therefore I would like to bring back this feature.

I do agree with the argument that nobody who's maintaining Dolphin is testing this feature. But since it seems like there is a vocal minority actually using this feature, I'd say let's keep the feature until it actually breaks or actually becomes a maintenance burden.