### PR TITLE
Disable VI Skip in Wind Waker and Twilight Princess

### DIFF
--- a/Data/Sys/GameSettings/GZ2.ini
+++ b/Data/Sys/GameSettings/GZ2.ini
@@ -15,5 +15,11 @@
 [Video_Hacks]
 ImmediateXFBEnable = False
 
+# The game logic itself is ignoring VI interrupts 
+# and keeps updating shadow video registers.
+# Because of this, it is incompatible with VISkip.
+
+VISkip = False
+
 [Video_Enhancements]
 ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/GZL.ini
+++ b/Data/Sys/GameSettings/GZL.ini
@@ -16,6 +16,12 @@
 EFBAccessEnable = True
 EFBToTextureEnable = False
 
+# The game logic itself is ignoring VI interrupts 
+# and keeps updating shadow video registers.
+# Because of this, it is incompatible with VISkip.
+
+VISkip = False
+
 [Video_Enhancements]
 ArbitraryMipmapDetection = True
 

--- a/Data/Sys/GameSettings/RZD.ini
+++ b/Data/Sys/GameSettings/RZD.ini
@@ -15,5 +15,11 @@
 EFBAccessEnable = True
 ImmediateXFBEnable = False
 
+# The game logic itself is ignoring VI interrupts 
+# and keeps updating shadow video registers.
+# Because of this, it is incompatible with VISkip.
+
+VISkip = False
+
 [Video_Enhancements]
 ArbitraryMipmapDetection = True


### PR DESCRIPTION
These games do some funky VI stuff which causes VI Skip to be completely incompatible with them, so let's disable it.