### PR TITLE
Fix DJ Turntable extension's table range

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -96,7 +96,7 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   // left table
   {
     const ControllerEmu::Slider::StateData lt = m_left_table->GetState(m_input_override_function);
-    const s8 tt = MapFloat<u8>(lt.value, 0, 0, TABLE_RANGE);
+    const s8 tt = MapFloat<s8>(lt.value, 0, -TABLE_RANGE, TABLE_RANGE);
 
     tt_data.ltable1 = tt;
     tt_data.ltable2 = tt >> 5;
@@ -105,7 +105,7 @@ void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   // right table
   {
     const ControllerEmu::Slider::StateData rt = m_right_table->GetState(m_input_override_function);
-    const s8 tt = MapFloat<u8>(rt.value, 0, 0, TABLE_RANGE);
+    const s8 tt = MapFloat<s8>(rt.value, 0, -TABLE_RANGE, TABLE_RANGE);
 
     tt_data.rtable1 = tt;
     tt_data.rtable2 = tt >> 1;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
@@ -83,7 +83,7 @@ public:
   static constexpr u8 STICK_GATE_RADIUS = 0x16;
 
   static constexpr int TABLE_BIT_COUNT = 6;
-  static constexpr u8 TABLE_RANGE = (1 << STICK_BIT_COUNT) / 2 - 1;
+  static constexpr u8 TABLE_RANGE = (1 << TABLE_BIT_COUNT) / 2 - 1;
 
   static constexpr int EFFECT_DIAL_BIT_COUNT = 5;
   static constexpr u8 EFFECT_DIAL_CENTER = (1 << EFFECT_DIAL_BIT_COUNT) / 2;


### PR DESCRIPTION
The DJ Hero Turntable extension's table input previously output a signed integer ranging from -32 to 32, but the rewrite in 5.0-17536 accidentally changed it to output unsigned 0-32. This caused counterclockwise turntable input to not be detected ingame.
Fixed the turntable output range while keeping the style of the rewrite.

Fixes [issue #13152](https://bugs.dolphin-emu.org/issues/13152)