### PR TITLE
DolphinQt: Add workaround for Qt 6.3+ bug on Linux

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -9,6 +9,10 @@
 #include <cstdio>
 #endif
 
+#ifdef __linux__
+#include <cstdlib>
+#endif
+
 #include <OptionParser.h>
 #include <QAbstractEventDispatcher>
 #include <QApplication>
@@ -131,6 +135,16 @@ int main(int argc, char* argv[])
   {
     argc--;
   }
+#endif
+
+#ifdef __linux__
+  // Qt 6.3+ has a bug which causes mouse inputs to not be registered in our XInput2 code.
+  // If we define QT_XCB_NO_XI2, Qt's xcb platform plugin no longer initializes its XInput
+  // code, which makes mouse inputs work again.
+  // For more information: https://bugs.dolphin-emu.org/issues/12913
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 3, 0))
+  putenv("QT_XCB_NO_XI2=1");
+#endif
 #endif
 
   auto parser = CommandLineParse::CreateParser(CommandLineParse::ParserOptions::IncludeGUIOptions);


### PR DESCRIPTION
See https://bugs.dolphin-emu.org/issues/12913 for more information.

I initially put this workaround in a launch script just for the Steam runtime, but now that I think about it, this bug affects *every* Linux build using Qt 6.3+. We should probably workaround this issue on those systems too.