### PR TITLE
Core: Remove FPS, VPS and speed percentage from window title

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -386,7 +386,6 @@ const Info<ShowCursor> MAIN_SHOW_CURSOR{{System::Main, "Interface", "CursorVisib
                                         ShowCursor::OnMovement};
 const Info<bool> MAIN_LOCK_CURSOR{{System::Main, "Interface", "LockCursor"}, false};
 const Info<std::string> MAIN_INTERFACE_LANGUAGE{{System::Main, "Interface", "LanguageCode"}, ""};
-const Info<bool> MAIN_EXTENDED_FPS_INFO{{System::Main, "Interface", "ExtendedFPSInfo"}, false};
 const Info<bool> MAIN_SHOW_ACTIVE_TITLE{{System::Main, "Interface", "ShowActiveTitle"}, true};
 const Info<bool> MAIN_USE_BUILT_IN_TITLE_DATABASE{
     {System::Main, "Interface", "UseBuiltinTitleDatabase"}, true};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -237,7 +237,6 @@ extern const Info<ShowCursor> MAIN_SHOW_CURSOR;
 
 extern const Info<bool> MAIN_LOCK_CURSOR;
 extern const Info<std::string> MAIN_INTERFACE_LANGUAGE;
-extern const Info<bool> MAIN_EXTENDED_FPS_INFO;
 extern const Info<bool> MAIN_SHOW_ACTIVE_TITLE;
 extern const Info<bool> MAIN_USE_BUILT_IN_TITLE_DATABASE;
 extern const Info<std::string> MAIN_THEME_NAME;

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -12,6 +12,8 @@
 #include <string_view>
 #include <variant>
 
+#include <Core/Core.h>
+
 #include <fmt/format.h>
 
 #include "AudioCommon/AudioCommon.h"
@@ -177,6 +179,10 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   m_title_description = title_database.Describe(m_gametdb_id, language);
   NOTICE_LOG_FMT(CORE, "Active title: {}", m_title_description);
   Host_TitleChanged();
+  if (Core::IsRunning())
+  {
+    Core::UpdateTitle();
+  }
 
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
   Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -124,10 +124,6 @@ void DisplayMessage(std::string message, int time_in_ms);
 void FrameUpdateOnCPUThread();
 void OnFrameEnd();
 
-void VideoThrottle();
-
-void UpdateTitle();
-
 // Run a function as the CPU thread.
 //
 // If called from the Host thread, the CPU thread is paused and the current thread temporarily
@@ -170,5 +166,7 @@ void HostDispatchJobs();
 void DoFrameStep();
 
 void UpdateInputGate(bool require_focus, bool require_full_focus = false);
+
+void UpdateTitle();
 
 }  // namespace Core

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -13,6 +13,8 @@
 #include "Common/Config/Config.h"
 #include "Common/Logging/Log.h"
 
+#include "VideoCommon/PerformanceMetrics.h"
+
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
@@ -872,7 +874,7 @@ static void EndField(FieldType field, u64 ticks)
   if (!Config::Get(Config::GFX_HACK_EARLY_XFB_OUTPUT))
     OutputField(field, ticks);
 
-  Core::VideoThrottle();
+  g_perf_metrics.CountVBlank();
   Core::OnFrameEnd();
 }
 


### PR DESCRIPTION
Why?
- There's already an FPS widget that the user can enable.
- I don't think constantly updating values such as the FPS count should be in the title bar. 

~~I can also further clean it up while I'm already touching this code. For example, I could remove the DSP section (which displays either HLE or LLE).~~
EDIT: This will be done separately in another PR in the future. I want to keep it simple.


Screenshots
Before:
<img width="892" alt="image" src="https://user-images.githubusercontent.com/26326692/214144751-3645070c-6e22-4323-a11e-21501e86c4d2.png">
After:
<img width="884" alt="image" src="https://user-images.githubusercontent.com/26326692/214144934-129c9fee-da15-4339-9bc0-b031ed008d35.png">
