### PR TITLE
Remove Memory Card Path from the Wrote to OSD Message

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
@@ -156,9 +156,8 @@ void MemoryCard::FlushThread()
     if (do_exit)
       return;
 
-    Core::DisplayMessage(fmt::format("Wrote memory card {} contents to {}",
-                                     m_card_slot == ExpansionInterface::Slot::A ? 'A' : 'B',
-                                     m_filename),
+    Core::DisplayMessage(fmt::format("Wrote to Memory Card {}",
+                                     m_card_slot == ExpansionInterface::Slot::A ? 'A' : 'B'),
                          4000);
   }
 }


### PR DESCRIPTION
A few weeks ago, a vtuber tweeted that they had to remove a vod of their stream because Dolphin Emulator showed some personal information during the steam, and left a warning to everyone else that Dolphin shows the account name of the computer. And yea, we do, we show the full directory of the memory card every time a memory card is written, and due to mandatory Microsoft account nonsense, that is very likely to contain someone’s real name.

Fortunately this is very easy for us to solve. This change simply removes the filename from wrote memory card contents string. That’s it. All functionality of the wrote memory card OSD message remains the same, it just doesn’t say where the memory card is anymore. This also has the benefit of shrinking our wrote to memory card message so it's much less intrusive.

Before -
![before](https://user-images.githubusercontent.com/6551020/213902545-40357322-fd0a-4402-9000-c985046dba24.png)

After -
![after](https://user-images.githubusercontent.com/6551020/213902548-a4a5964c-97e2-4c0a-9666-b9570f68fb60.png)


There are lots of other potential solutions to this but after talking on IRC it seems the simplest one is the best.