### PR TITLE
Don't Write OSD Messages to the Titlebar

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -180,7 +180,6 @@ void DisplayMessage(std::string message, int time_in_ms)
   if (!std::all_of(message.begin(), message.end(), IsPrintableCharacter))
     return;
 
-  Host_UpdateTitle(message);
   OSD::AddMessage(std::move(message), time_in_ms);
 }
 


### PR DESCRIPTION
It turns out all OSD messages, _every single one_, are written to the titlebar. We've just never seen them because the FPS/VPS etc display is in the title bar and it replaces it in a fraction of a second. This was only visible when saving savestates because it halts emulation for a moment while writing.

This is dumb, let's not do that anymore. Fixes [issue 12604](https://bugs.dolphin-emu.org/issues/12604).

Before -
![before-11471](https://user-images.githubusercontent.com/6551020/213908083-22587181-3525-482b-961a-3ec8634e9df4.png)

After - 
![after-11471](https://user-images.githubusercontent.com/6551020/213908088-d04e34c9-0753-4711-ade0-c7d28d1a8341.png)

There is still dox potential in the saving states from the OSD but that's for a separate PR.