### PR TITLE
windows: replace comdef dependency with winrt

### DIFF
--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -7,7 +7,6 @@
 
 // clang-format off
 #include <Audioclient.h>
-#include <comdef.h>
 #include <mmdeviceapi.h>
 #include <devpkey.h>
 #include <functiondiscoverykeys_devpkey.h>

--- a/Source/Core/Common/HRWrap.cpp
+++ b/Source/Core/Common/HRWrap.cpp
@@ -3,15 +3,13 @@
 
 #include "HRWrap.h"
 
-#include <comdef.h>
-#include "Common/StringUtil.h"
+#include <winrt/base.h>
 
 namespace Common
 {
 std::string GetHResultMessage(HRESULT hr)
 {
-  // See https://stackoverflow.com/a/7008111
-  _com_error err(hr);
-  return TStrToUTF8(err.ErrorMessage());
+  auto err = winrt::hresult_error(hr);
+  return winrt::to_string(err.message());
 }
 }  // namespace Common


### PR DESCRIPTION
comdef generates a link requirement which can't be used on uwp/xbox