### PR TITLE
gitattributes: set eol=clrf on *.sln

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sln text eol=crlf


### PR DESCRIPTION
modifying sln via VS always uses clrf, so let's just go with it