### PR TITLE
buildfix if discord isn't enabled

### DIFF
--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -258,6 +258,8 @@ bool UpdateDiscordPresenceRaw(const std::string& details, const std::string& sta
   Discord_UpdatePresence(&discord_presence);
 
   return true;
+#else
+  return false;
 #endif
 }
 


### PR DESCRIPTION
not entirely sure discord should be compiled-time decision, but make it build at least.