### PR TITLE
DSPLLE: Add assertion for bad DMA alignment

### DIFF
--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Hash.h"
 #include "Common/Logging/Log.h"
@@ -40,6 +41,11 @@ void WriteHostMemory(u8 value, u32 addr)
 
 void DMAToDSP(u16* dst, u32 addr, u32 size)
 {
+  // Hardware testing indicates that a misaligned DMA address does not work properly (it's unclear
+  // exactly what goes wrong currently). A size that's not a multiple of 32 is allowed, though
+  // (and occurs with modern libogc homebrew uCode, including the oggpalyer (asnd uCode) and
+  // modplay (aesnd uCode) examples). It's untested whether extra bytes are copied in that case.
+  ASSERT_MSG(DSPLLE, (addr & 0x1f) == 0, "DSP DMA addr must be 32-byte aligned (was {:08x})", addr);
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   memory.CopyFromEmuSwapped(dst, addr, size);
@@ -47,6 +53,8 @@ void DMAToDSP(u16* dst, u32 addr, u32 size)
 
 void DMAFromDSP(const u16* src, u32 addr, u32 size)
 {
+  // See comment in DMAToDSP
+  ASSERT_MSG(DSPLLE, (addr & 0x1f) == 0, "DSP DMA addr must be 32-byte aligned (was {:08x})", addr);
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   memory.CopyToEmuSwapped(addr, src, size);

--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -68,7 +68,7 @@ static std::string CodeToHeader(const std::vector<u16>& code, const std::string&
   SplitPath(filename, nullptr, &filename_without_extension, nullptr);
   header.append(fmt::format("const char* UCODE_NAMES[NUM_UCODES] = {{\"{}\"}};\n\n",
                             filename_without_extension));
-  header.append("const unsigned short dsp_code[NUM_UCODES][0x1000] = {\n");
+  header.append("alignas(0x20) const unsigned short dsp_code[NUM_UCODES][0x1000] = {\n");
 
   header.append("\t{\n\t\t");
   for (u32 j = 0; j < code_padded.size(); j++)


### PR DESCRIPTION
This caused me a lot of trouble, as DSPSpy was breaking when compiled with `-O0`. It ended up being the case that `dsp_code` was placed at `0x800ba400` at `-O2`, `0x800ba320` at `-O1`, and `0x800bb3ee` at `-O0`.  I don't know if the alignment at `-O1` and higher was just a coincidence or not.

The symptom of misaligned code was either no mail at all from the DSP (instead showing the DSP ROM's `0x8071feed` mail) or the appearance of an exception occuring (instead showing dspspy exception handler's `0x8bad0001` mail). I also sometimes got hangs. My guess is that it just rounded the address up or down, but I'm not 100% sure of this and don't want to investigate it currently since I'm busy investigating edge cases that things actually rely on (somewhat). This behavior can be investigated further later.

DSPTool forced 64 byte alignment starting early on (f6474b98a85877aae2b7c0c8485e280bbf68053a), but that was removed fairly quickly (6e61c3249545ea67ed746f078b3f696823ec1955). In comparison, libogc's gcdsptool has had 32 byte alignment from early on too (2cea6d99ad518c963e24c3e28834473ff5312e69), and still does (although I'm not 100% sure whether that still applies, as they use `bin2s` instead of generating a header, and that change did result in the *length* not always being a multiple of 32). The [libogc documentation](https://github.com/devkitPro/libogc/blob/4ec9a84931534b9ec2aaa8f8553be44b27950d42/gc/ogc/dsp.h#L102-L107) says that pointers "have" to be aligned while lengths "should" be a multiple of 32, for what it's worth.