### PR TITLE
Android: Fix grid options menu string

### DIFF
--- a/Source/Android/app/src/main/res/menu/menu_game_grid.xml
+++ b/Source/Android/app/src/main/res/menu/menu_game_grid.xml
@@ -10,7 +10,7 @@
 
     <item
         android:id="@+id/menu_grid_options"
-        android:title="@string/grid_menu_settings"
+        android:title="@string/grid_menu_grid_options"
         android:icon="@drawable/ic_list"
         app:showAsAction="ifRoom"/>
 


### PR DESCRIPTION
Previously the string was "Settings" and not "Grid Options"