### PR TITLE
Remove Filepath from State Save/Load OSD Messages

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -458,7 +459,8 @@ static void CompressAndDumpState(CompressAndDumpState_args& save_args)
     File::Rename(temp_filename, filename);
   }
 
-  Core::DisplayMessage(fmt::format("Saved State to {}", filename), 2000);
+  std::filesystem::path tempfilename(filename);
+  Core::DisplayMessage(fmt::format("Saved State to {}", tempfilename.filename().string()), 2000);
   Host_UpdateMainFrame();
 }
 
@@ -688,7 +690,9 @@ void LoadAs(const std::string& filename)
         {
           if (loadedSuccessfully)
           {
-            Core::DisplayMessage(fmt::format("Loaded state from {}", filename), 2000);
+            std::filesystem::path tempfilename(filename);
+            Core::DisplayMessage(
+                fmt::format("Loaded State from {}", tempfilename.filename().string()), 2000);
             if (File::Exists(filename + ".dtm"))
               Movie::LoadInput(filename + ".dtm");
             else if (!Movie::IsJustStartingRecordingInputFromSaveState() &&


### PR DESCRIPTION
Though less important compared to #11470, save states also show the full path in the OSD message and could potentially dox a streamer who is playing a game in Dolphin. This is a simple fix - it removes the path from the OSD message so only the name of the state file is revealed.

Also makes the state messages less intrusive.

Before -
![savestate2-before](https://user-images.githubusercontent.com/6551020/214278954-7b3b9ab5-cae7-4478-93da-b5778f1849ff.png)
![loadstate2-before](https://user-images.githubusercontent.com/6551020/214278972-f65ce47c-6962-4c37-806a-0b9182e6d9c2.png)

After -
![savestate2-after](https://user-images.githubusercontent.com/6551020/214278988-f8cba06b-46bb-4196-8067-a93105f088c7.png)
![loadstate2-after](https://user-images.githubusercontent.com/6551020/214279011-c5e5c865-ed91-46d1-b675-b07eed3c1e44.png)

