### PR TITLE
StringUtil: Make StringUTF8CodePointCount take string_view

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -437,7 +437,7 @@ void StringPopBackIf(std::string* s, char c)
     s->pop_back();
 }
 
-size_t StringUTF8CodePointCount(const std::string& str)
+size_t StringUTF8CodePointCount(std::string_view str)
 {
   return str.size() -
          std::count_if(str.begin(), str.end(), [](char c) -> bool { return (c & 0xC0) == 0x80; });

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -170,7 +170,7 @@ std::string WithUnifiedPathSeparators(std::string path);
 std::string PathToFileName(std::string_view path);
 
 void StringPopBackIf(std::string* s, char c);
-size_t StringUTF8CodePointCount(const std::string& str);
+size_t StringUTF8CodePointCount(std::string_view str);
 
 std::string CP1252ToUTF8(std::string_view str);
 std::string SHIFTJISToUTF8(std::string_view str);


### PR DESCRIPTION
There's nothing really about this that would require constraining it to only std::string instances.