### PR TITLE
CoreTiming: Zero initialize all CoreTimingManager throttle members

### DIFF
--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -183,8 +183,8 @@ private:
 
   s64 m_throttle_last_cycle = 0;
   TimePoint m_throttle_deadline = Clock::now();
-  s64 m_throttle_clock_per_sec;
-  s64 m_throttle_min_clock_per_sleep;
+  s64 m_throttle_clock_per_sec = 0;
+  s64 m_throttle_min_clock_per_sleep = 0;
   bool m_throttle_disable_vi_int = false;
 
   void ResetThrottle(s64 cycle);


### PR DESCRIPTION
Gives two members without explicit initialization default values to be consistent with the rest of the class and also ensuring deterministic values on construction.