### PR TITLE
Improve the data in the first data block of the skylanders figures

### DIFF
--- a/Source/Core/Core/IOS/USB/Emulated/Skylander.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Skylander.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Common/Logging/Log.h"
+#include "Common/Random.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
 #include "Core/Core.h"
@@ -747,11 +748,24 @@ bool SkylanderPortal::CreateSkylander(const std::string& file_path, u16 sky_id, 
   {
     memcpy(&file_data[(index * 0x40) + 0x36], &other_blocks, sizeof(other_blocks));
   }
+
+  // Set the NUID of the figure
+  Common::Random::Generate(&file_data[0], 4);
+
+  // The BCC (Block Check Character)
+  file_data[4] = file_data[0] ^ file_data[1] ^ file_data[2] ^ file_data[3];
+
+  // ATQA
+  file_data[5] = 0x81;
+  file_data[6] = 0x01;
+
+  // SAK
+  file_data[7] = 0x0F;
+
   // Set the skylander info
-  u16 sky_info = (sky_id | sky_var) + 1;
-  memcpy(&file_data[0], &sky_info, sizeof(sky_info));
   memcpy(&file_data[0x10], &sky_id, sizeof(sky_id));
   memcpy(&file_data[0x1C], &sky_var, sizeof(sky_var));
+
   // Set checksum
   u16 checksum = SkylanderCRC16(0xFFFF, file_data, 0x1E);
   memcpy(&file_data[0x1E], &checksum, sizeof(checksum));

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
@@ -29,6 +29,7 @@
 #include "Core/System.h"
 
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
+#include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
 // Qt is not guaranteed to keep track of file paths using native file pickers, so we use this
@@ -521,6 +522,7 @@ const std::map<const std::pair<const u16, const u16>, const char*> list_skylande
 SkylanderPortalWindow::SkylanderPortalWindow(QWidget* parent) : QWidget(parent)
 {
   setWindowTitle(tr("Skylanders Manager"));
+  setWindowIcon(Resources::GetAppIcon());
   setObjectName(QString::fromStdString("skylanders_manager"));
   setMinimumSize(QSize(700, 200));
 


### PR DESCRIPTION
The real Skylanders cards are Mifare 1K classic cards with a 4-byte NUID so this mimics the real cards. The calculation used before could cause duplicate NUIDs very easily.

Added an icon to the Skylanders portal window