### PR TITLE
GameINI: Heavy Iron updates

### DIFF
--- a/Data/Sys/GameSettings/GIC.ini
+++ b/Data/Sys/GameSettings/GIC.ini
@@ -18,4 +18,3 @@ CPUThread = False
 # Fixes shadows at higher resolution.
 # Option has no effect at 1x IR, so no reason not to enable.
 VertexRounding = True
-EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GIQ.ini
+++ b/Data/Sys/GameSettings/GIQ.ini
@@ -14,8 +14,6 @@ CPUThread = False
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-
 [Video_Hacks]
 # Fixes shadows at higher resolution.
 # Option has no effect at 1x IR, so no reason not to enable.

--- a/Data/Sys/GameSettings/GU2.ini
+++ b/Data/Sys/GameSettings/GU2.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# Dual Core mode causes FIFO error
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,4 +18,5 @@
 # Fixes shadows at higher resolution on disc 1.
 # Option has no effect at 1x IR, so no reason not to enable.
 VertexRounding = True
-
+# Needed for disc 2.
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GU3.ini
+++ b/Data/Sys/GameSettings/GU3.ini
@@ -1,7 +1,9 @@
-# GU3D78, GU3X78 - 2 Games in 1: The Incredibles / Finding Nemo
+# GU3D78, GU3X78 - 2 Games in 1: The SpongeBob SquarePants Movie / Tak 2: The Staff of Dreams
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# Dual Core mode causes FIFO error
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,4 +18,5 @@
 # Fixes shadows at higher resolution on disc 1.
 # Option has no effect at 1x IR, so no reason not to enable.
 VertexRounding = True
-
+# Needed for some FMVs on disc 1.
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GU4.ini
+++ b/Data/Sys/GameSettings/GU4.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# Dual Core mode causes FIFO error
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
This PR provides a small batch of GameINI updates:

- **The Incredibles**: Removes EFBToTextureEnable = False because there is no noticeable difference with this option enabled/disabled after testing several times, seems like it might have been added by mistake?

- **2-in-1 compilations**: Updated game settings to match the single-game releases and fixed an incorrectly named game entry (GU3.ini).