### PR TITLE
Android: Don't enforce a particular CMake version

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -109,7 +109,6 @@ android {
     externalNativeBuild {
         cmake {
             path "../../../CMakeLists.txt"
-            version "3.18.1"
         }
     }
     namespace 'org.dolphinemu.dolphinemu'


### PR DESCRIPTION
This was initially opened as a proposal to fix the Android builders (which was found to actually be a problem with how the container image was created), but I'll leave this open in case not requiring a specific CMake version is something we want to do.