### PR TITLE
VideoCommon: store the configuration used to create the AbstractPipeline

### DIFF
--- a/Source/Core/VideoBackends/D3D/DXPipeline.cpp
+++ b/Source/Core/VideoBackends/D3D/DXPipeline.cpp
@@ -16,12 +16,12 @@
 
 namespace DX11
 {
-DXPipeline::DXPipeline(ID3D11InputLayout* input_layout, ID3D11VertexShader* vertex_shader,
-                       ID3D11GeometryShader* geometry_shader, ID3D11PixelShader* pixel_shader,
-                       ID3D11RasterizerState* rasterizer_state,
+DXPipeline::DXPipeline(const AbstractPipelineConfig& config, ID3D11InputLayout* input_layout,
+                       ID3D11VertexShader* vertex_shader, ID3D11GeometryShader* geometry_shader,
+                       ID3D11PixelShader* pixel_shader, ID3D11RasterizerState* rasterizer_state,
                        ID3D11DepthStencilState* depth_state, ID3D11BlendState* blend_state,
                        D3D11_PRIMITIVE_TOPOLOGY primitive_topology, bool use_logic_op)
-    : m_input_layout(input_layout), m_vertex_shader(vertex_shader),
+    : AbstractPipeline(config), m_input_layout(input_layout), m_vertex_shader(vertex_shader),
       m_geometry_shader(geometry_shader), m_pixel_shader(pixel_shader),
       m_rasterizer_state(rasterizer_state), m_depth_state(depth_state), m_blend_state(blend_state),
       m_primitive_topology(primitive_topology), m_use_logic_op(use_logic_op)
@@ -57,7 +57,7 @@ std::unique_ptr<DXPipeline> DXPipeline::Create(const AbstractPipelineConfig& con
   const bool use_logic_op =
       config.blending_state.logicopenable && g_ActiveConfig.backend_info.bSupportsLogicOp;
 
-  return std::make_unique<DXPipeline>(input_layout, vertex_shader->GetD3DVertexShader(),
+  return std::make_unique<DXPipeline>(config, input_layout, vertex_shader->GetD3DVertexShader(),
                                       geometry_shader ? geometry_shader->GetD3DGeometryShader() :
                                                         nullptr,
                                       pixel_shader->GetD3DPixelShader(), rasterizer_state,

--- a/Source/Core/VideoBackends/D3D/DXPipeline.h
+++ b/Source/Core/VideoBackends/D3D/DXPipeline.h
@@ -14,11 +14,11 @@ namespace DX11
 class DXPipeline final : public AbstractPipeline
 {
 public:
-  DXPipeline(ID3D11InputLayout* input_layout, ID3D11VertexShader* vertex_shader,
-             ID3D11GeometryShader* geometry_shader, ID3D11PixelShader* pixel_shader,
-             ID3D11RasterizerState* rasterizer_state, ID3D11DepthStencilState* depth_state,
-             ID3D11BlendState* blend_state, D3D11_PRIMITIVE_TOPOLOGY primitive_topology,
-             bool use_logic_op);
+  DXPipeline(const AbstractPipelineConfig& config, ID3D11InputLayout* input_layout,
+             ID3D11VertexShader* vertex_shader, ID3D11GeometryShader* geometry_shader,
+             ID3D11PixelShader* pixel_shader, ID3D11RasterizerState* rasterizer_state,
+             ID3D11DepthStencilState* depth_state, ID3D11BlendState* blend_state,
+             D3D11_PRIMITIVE_TOPOLOGY primitive_topology, bool use_logic_op);
   ~DXPipeline() override;
 
   ID3D11InputLayout* GetInputLayout() const { return m_input_layout.Get(); }

--- a/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
@@ -14,11 +14,11 @@
 
 namespace DX12
 {
-DXPipeline::DXPipeline(ID3D12PipelineState* pipeline, ID3D12RootSignature* root_signature,
-                       AbstractPipelineUsage usage, D3D12_PRIMITIVE_TOPOLOGY primitive_topology,
-                       bool use_integer_rtv)
-    : m_pipeline(pipeline), m_root_signature(root_signature), m_usage(usage),
-      m_primitive_topology(primitive_topology), m_use_integer_rtv(use_integer_rtv)
+DXPipeline::DXPipeline(const AbstractPipelineConfig& config, ID3D12PipelineState* pipeline,
+                       ID3D12RootSignature* root_signature, AbstractPipelineUsage usage,
+                       D3D12_PRIMITIVE_TOPOLOGY primitive_topology, bool use_integer_rtv)
+    : AbstractPipeline(config), m_pipeline(pipeline), m_root_signature(root_signature),
+      m_usage(usage), m_primitive_topology(primitive_topology), m_use_integer_rtv(use_integer_rtv)
 {
 }
 
@@ -218,7 +218,7 @@ std::unique_ptr<DXPipeline> DXPipeline::Create(const AbstractPipelineConfig& con
 
   const bool use_integer_rtv =
       !config.blending_state.blendenable && config.blending_state.logicopenable;
-  return std::make_unique<DXPipeline>(pso, desc.pRootSignature, config.usage,
+  return std::make_unique<DXPipeline>(config, pso, desc.pRootSignature, config.usage,
                                       GetD3DTopology(config.rasterization_state), use_integer_rtv);
 }
 

--- a/Source/Core/VideoBackends/D3D12/DX12Pipeline.h
+++ b/Source/Core/VideoBackends/D3D12/DX12Pipeline.h
@@ -13,9 +13,9 @@ namespace DX12
 class DXPipeline final : public AbstractPipeline
 {
 public:
-  DXPipeline(ID3D12PipelineState* pipeline, ID3D12RootSignature* root_signature,
-             AbstractPipelineUsage usage, D3D12_PRIMITIVE_TOPOLOGY primitive_topology,
-             bool use_integer_rtv);
+  DXPipeline(const AbstractPipelineConfig& config, ID3D12PipelineState* pipeline,
+             ID3D12RootSignature* root_signature, AbstractPipelineUsage usage,
+             D3D12_PRIMITIVE_TOPOLOGY primitive_topology, bool use_integer_rtv);
   ~DXPipeline() override;
 
   static std::unique_ptr<DXPipeline> Create(const AbstractPipelineConfig& config,

--- a/Source/Core/VideoBackends/Metal/MTLObjectCache.mm
+++ b/Source/Core/VideoBackends/Metal/MTLObjectCache.mm
@@ -496,9 +496,10 @@ Metal::ObjectCache::CreatePipeline(const AbstractPipelineConfig& config)
   Internal::StoredPipeline pipeline = m_internal->GetOrCreatePipeline(config);
   if (!pipeline.first)
     return nullptr;
-  return std::make_unique<Pipeline>(
-      std::move(pipeline.first), pipeline.second, Convert(config.rasterization_state.primitive),
-      Convert(config.rasterization_state.cullmode), config.depth_state, config.usage);
+  return std::make_unique<Pipeline>(config, std::move(pipeline.first), pipeline.second,
+                                    Convert(config.rasterization_state.primitive),
+                                    Convert(config.rasterization_state.cullmode),
+                                    config.depth_state, config.usage);
 }
 
 void Metal::ObjectCache::ShaderDestroyed(const Shader* shader)

--- a/Source/Core/VideoBackends/Metal/MTLPipeline.h
+++ b/Source/Core/VideoBackends/Metal/MTLPipeline.h
@@ -27,7 +27,8 @@ struct PipelineReflection
 class Pipeline final : public AbstractPipeline
 {
 public:
-  explicit Pipeline(MRCOwned<id<MTLRenderPipelineState>> pipeline,
+  explicit Pipeline(const AbstractPipelineConfig& config,
+                    MRCOwned<id<MTLRenderPipelineState>> pipeline,
                     const PipelineReflection& reflection, MTLPrimitiveType prim, MTLCullMode cull,
                     DepthState depth, AbstractPipelineUsage usage);
 

--- a/Source/Core/VideoBackends/Metal/MTLPipeline.mm
+++ b/Source/Core/VideoBackends/Metal/MTLPipeline.mm
@@ -53,11 +53,12 @@ Metal::PipelineReflection::PipelineReflection(MTLRenderPipelineReflection* refle
   GetArguments([reflection fragmentArguments], &textures, &samplers, &fragment_buffers);
 }
 
-Metal::Pipeline::Pipeline(MRCOwned<id<MTLRenderPipelineState>> pipeline,
+Metal::Pipeline::Pipeline(const AbstractPipelineConfig& config,
+                          MRCOwned<id<MTLRenderPipelineState>> pipeline,
                           const PipelineReflection& reflection, MTLPrimitiveType prim,
                           MTLCullMode cull, DepthState depth, AbstractPipelineUsage usage)
-    : m_pipeline(std::move(pipeline)), m_prim(prim), m_cull(cull), m_depth_stencil(depth),
-      m_usage(usage), m_reflection(reflection)
+    : AbstractPipeline(config), m_pipeline(std::move(pipeline)), m_prim(prim), m_cull(cull),
+      m_depth_stencil(depth), m_usage(usage), m_reflection(reflection)
 {
 }
 

--- a/Source/Core/VideoBackends/OGL/OGLPipeline.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLPipeline.cpp
@@ -28,13 +28,13 @@ static GLenum MapToGLPrimitive(PrimitiveType primitive_type)
     return 0;
   }
 }
-OGLPipeline::OGLPipeline(const GLVertexFormat* vertex_format,
+OGLPipeline::OGLPipeline(const AbstractPipelineConfig& config, const GLVertexFormat* vertex_format,
                          const RasterizationState& rasterization_state,
                          const DepthState& depth_state, const BlendingState& blending_state,
                          PipelineProgram* program, GLuint gl_primitive)
-    : m_vertex_format(vertex_format), m_rasterization_state(rasterization_state),
-      m_depth_state(depth_state), m_blending_state(blending_state), m_program(program),
-      m_gl_primitive(gl_primitive)
+    : AbstractPipeline(config), m_vertex_format(vertex_format),
+      m_rasterization_state(rasterization_state), m_depth_state(depth_state),
+      m_blending_state(blending_state), m_program(program), m_gl_primitive(gl_primitive)
 {
 }
 
@@ -90,7 +90,7 @@ std::unique_ptr<OGLPipeline> OGLPipeline::Create(const AbstractPipelineConfig& c
 
   const GLVertexFormat* vertex_format = static_cast<const GLVertexFormat*>(config.vertex_format);
   GLenum gl_primitive = MapToGLPrimitive(config.rasterization_state.primitive);
-  return std::make_unique<OGLPipeline>(vertex_format, config.rasterization_state,
+  return std::make_unique<OGLPipeline>(config, vertex_format, config.rasterization_state,
                                        config.depth_state, config.blending_state, program,
                                        gl_primitive);
 }

--- a/Source/Core/VideoBackends/OGL/OGLPipeline.h
+++ b/Source/Core/VideoBackends/OGL/OGLPipeline.h
@@ -15,7 +15,7 @@ namespace OGL
 class OGLPipeline final : public AbstractPipeline
 {
 public:
-  explicit OGLPipeline(const GLVertexFormat* vertex_format,
+  explicit OGLPipeline(const AbstractPipelineConfig& config, const GLVertexFormat* vertex_format,
                        const RasterizationState& rasterization_state, const DepthState& depth_state,
                        const BlendingState& blending_state, PipelineProgram* program,
                        GLenum gl_primitive);

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -18,9 +18,10 @@
 
 namespace Vulkan
 {
-VKPipeline::VKPipeline(VkPipeline pipeline, VkPipelineLayout pipeline_layout,
-                       AbstractPipelineUsage usage)
-    : m_pipeline(pipeline), m_pipeline_layout(pipeline_layout), m_usage(usage)
+VKPipeline::VKPipeline(const AbstractPipelineConfig& config, VkPipeline pipeline,
+                       VkPipelineLayout pipeline_layout, AbstractPipelineUsage usage)
+    : AbstractPipeline(config), m_pipeline(pipeline), m_pipeline_layout(pipeline_layout),
+      m_usage(usage)
 {
 }
 
@@ -403,6 +404,6 @@ std::unique_ptr<VKPipeline> VKPipeline::Create(const AbstractPipelineConfig& con
     return VK_NULL_HANDLE;
   }
 
-  return std::make_unique<VKPipeline>(pipeline, pipeline_layout, config.usage);
+  return std::make_unique<VKPipeline>(config, pipeline, pipeline_layout, config.usage);
 }
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.h
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.h
@@ -13,8 +13,8 @@ namespace Vulkan
 class VKPipeline final : public AbstractPipeline
 {
 public:
-  explicit VKPipeline(VkPipeline pipeline, VkPipelineLayout pipeline_layout,
-                      AbstractPipelineUsage usage);
+  explicit VKPipeline(const AbstractPipelineConfig& config, VkPipeline pipeline,
+                      VkPipelineLayout pipeline_layout, AbstractPipelineUsage usage);
   ~VKPipeline() override;
 
   VkPipeline GetVkPipeline() const { return m_pipeline; }

--- a/Source/Core/VideoCommon/AbstractPipeline.h
+++ b/Source/Core/VideoCommon/AbstractPipeline.h
@@ -76,7 +76,10 @@ class AbstractPipeline
 {
 public:
   AbstractPipeline() = default;
+  explicit AbstractPipeline(const AbstractPipelineConfig& config) : m_config(config) {}
   virtual ~AbstractPipeline() = default;
+
+  AbstractPipelineConfig m_config;
 
   // "Cache data" can be used to assist a driver with creating pipelines by using previously
   // compiled shader ISA. The abstract shaders and creation struct are still required to create


### PR DESCRIPTION
This allows us to re-create the pipeline easily (with tweaked changes).  used in #11300