### PR TITLE
VideoCommon: allow graphics mods to have access to the file path where the config exists to load additional files

### DIFF
--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.cpp
@@ -10,7 +10,8 @@
 
 namespace GraphicsModActionFactory
 {
-std::unique_ptr<GraphicsModAction> Create(std::string_view name, const picojson::value& json_data)
+std::unique_ptr<GraphicsModAction> Create(std::string_view name, const picojson::value& json_data,
+                                          std::string_view path)
 {
   if (name == "print")
   {

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.h
@@ -12,5 +12,6 @@
 
 namespace GraphicsModActionFactory
 {
-std::unique_ptr<GraphicsModAction> Create(std::string_view name, const picojson::value& json_data);
+std::unique_ptr<GraphicsModAction> Create(std::string_view name, const picojson::value& json_data,
+                                          std::string_view path);
 }

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
@@ -8,6 +8,7 @@
 #include <variant>
 
 #include "Common/Logging/Log.h"
+#include "Common/StringUtil.h"
 #include "Common/VariantUtil.h"
 
 #include "Core/ConfigManager.h"
@@ -198,7 +199,10 @@ void GraphicsModManager::Load(const GraphicsModGroupConfig& config)
       const auto create_action =
           [](const std::string_view& action_name, const picojson::value& json_data,
              GraphicsModConfig mod_config) -> std::unique_ptr<GraphicsModAction> {
-        auto action = GraphicsModActionFactory::Create(action_name, json_data);
+        std::string base_path;
+        SplitPath(mod_config.GetAbsolutePath(), &base_path, nullptr, nullptr);
+
+        auto action = GraphicsModActionFactory::Create(action_name, json_data, base_path);
         if (action == nullptr)
         {
           return nullptr;


### PR DESCRIPTION
Used in #11300 and #10362 to load additional files next to the config files.