### PR TITLE
Revert "DSPLLE: Add assertion for bad DMA alignment"

### DIFF
--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -5,7 +5,6 @@
 
 #include <string>
 
-#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Hash.h"
 #include "Common/Logging/Log.h"
@@ -41,11 +40,6 @@ void WriteHostMemory(u8 value, u32 addr)
 
 void DMAToDSP(u16* dst, u32 addr, u32 size)
 {
-  // Hardware testing indicates that a misaligned DMA address does not work properly (it's unclear
-  // exactly what goes wrong currently). A size that's not a multiple of 32 is allowed, though
-  // (and occurs with modern libogc homebrew uCode, including the oggpalyer (asnd uCode) and
-  // modplay (aesnd uCode) examples). It's untested whether extra bytes are copied in that case.
-  ASSERT_MSG(DSPLLE, (addr & 0x1f) == 0, "DSP DMA addr must be 32-byte aligned (was {:08x})", addr);
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   memory.CopyFromEmuSwapped(dst, addr, size);
@@ -53,8 +47,6 @@ void DMAToDSP(u16* dst, u32 addr, u32 size)
 
 void DMAFromDSP(const u16* src, u32 addr, u32 size)
 {
-  // See comment in DMAToDSP
-  ASSERT_MSG(DSPLLE, (addr & 0x1f) == 0, "DSP DMA addr must be 32-byte aligned (was {:08x})", addr);
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   memory.CopyToEmuSwapped(addr, src, size);


### PR DESCRIPTION
This reverts commit e140516130f18b118f5b258d366379af72cefc70. This assert triggers for AX and AXWii uCode games (including the Wii System Menu) for various addresses that seem to be 4-byte aligned. Worse still, if the DSP thread is in use (i.e. for DSP LLE recompiler, but not for DSP LLE interpreter), Dolphin completely hangs after the panic alert. Perhaps the data DMA has fewer restrictions compared to the instruction DMA?

The change to DSPTool (e391a281024a8f8283160b03aa3703405e037ed7) has not been reverted, as it still fixes broken behavior for DSPSpy at -O0 on real hardware.