### PR TITLE
Ignore nullability-completeness warnings in VMA

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -48,6 +48,7 @@
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wnullability-completeness"
 #endif  // #ifdef __clang__
 
 #ifdef __GNUC__


### PR DESCRIPTION
These cause a lot of warnings when compiling with clang. 

And the [example VmaUsage.h](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/master/src/VmaUsage.h#L94) appears to disable them

