### PR TITLE
GameSettings: Replace ForceFiltering with ForceTextureFiltering

### DIFF
--- a/Data/Sys/GameSettings/DD2.ini
+++ b/Data/Sys/GameSettings/DD2.ini
@@ -17,4 +17,4 @@ SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/F.ini
+++ b/Data/Sys/GameSettings/F.ini
@@ -19,4 +19,4 @@ EFBToTextureEnable = False
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/GMS.ini
+++ b/Data/Sys/GameSettings/GMS.ini
@@ -21,7 +21,7 @@ EFBAccessEnable = True
 MissingColorValue = 0x00000000
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 ArbitraryMipmapDetection = True
 
 [Video_Stereoscopy]

--- a/Data/Sys/GameSettings/GXG.ini
+++ b/Data/Sys/GameSettings/GXG.ini
@@ -9,4 +9,4 @@
 SafeTextureCacheColorSamples = 0
 [Video_Enhancements]
 # Texture filtering causes lines with Mega Man X 3
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/GXU.ini
+++ b/Data/Sys/GameSettings/GXU.ini
@@ -15,4 +15,4 @@ MMU = True
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/GZW.ini
+++ b/Data/Sys/GameSettings/GZW.ini
@@ -16,4 +16,4 @@
 SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/HA8.ini
+++ b/Data/Sys/GameSettings/HA8.ini
@@ -11,4 +11,4 @@ EFBToTextureEnable = False
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/HA9.ini
+++ b/Data/Sys/GameSettings/HA9.ini
@@ -11,4 +11,4 @@ EFBToTextureEnable = False
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/HBA.ini
+++ b/Data/Sys/GameSettings/HBA.ini
@@ -11,4 +11,4 @@ EFBToTextureEnable = False
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/HBB.ini
+++ b/Data/Sys/GameSettings/HBB.ini
@@ -11,4 +11,4 @@ EFBToTextureEnable = False
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/HBC.ini
+++ b/Data/Sys/GameSettings/HBC.ini
@@ -11,4 +11,4 @@ EFBToTextureEnable = False
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/HBD.ini
+++ b/Data/Sys/GameSettings/HBD.ini
@@ -11,4 +11,4 @@ EFBToTextureEnable = False
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/PZL.ini
+++ b/Data/Sys/GameSettings/PZL.ini
@@ -23,4 +23,4 @@ SafeTextureCacheColorSamples = 0
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/R3S.ini
+++ b/Data/Sys/GameSettings/R3S.ini
@@ -2,4 +2,4 @@
 
 [Video_Enhancements]
 # FMVs get messed up if this is on
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/R5I.ini
+++ b/Data/Sys/GameSettings/R5I.ini
@@ -16,5 +16,5 @@
 SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 

--- a/Data/Sys/GameSettings/R6B.ini
+++ b/Data/Sys/GameSettings/R6B.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/R9G.ini
+++ b/Data/Sys/GameSettings/R9G.ini
@@ -17,4 +17,4 @@
 
 [Video_Settings]
 # Fixes FMVs
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/RBO.ini
+++ b/Data/Sys/GameSettings/RBO.ini
@@ -16,7 +16,7 @@
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/RCJ.ini
+++ b/Data/Sys/GameSettings/RCJ.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/RG6.ini
+++ b/Data/Sys/GameSettings/RG6.ini
@@ -16,7 +16,7 @@
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/RGQ.ini
+++ b/Data/Sys/GameSettings/RGQ.ini
@@ -13,5 +13,5 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 

--- a/Data/Sys/GameSettings/RJ2.ini
+++ b/Data/Sys/GameSettings/RJ2.ini
@@ -17,7 +17,7 @@ SafeTextureCacheColorSamples = 0
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/RM8.ini
+++ b/Data/Sys/GameSettings/RM8.ini
@@ -6,6 +6,6 @@
 [OnFrame]
 [ActionReplay]
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RSN.ini
+++ b/Data/Sys/GameSettings/RSN.ini
@@ -15,7 +15,7 @@ CPUThread = False
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/S2C.ini
+++ b/Data/Sys/GameSettings/S2C.ini
@@ -13,4 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/S2E.ini
+++ b/Data/Sys/GameSettings/S2E.ini
@@ -13,4 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/S5D.ini
+++ b/Data/Sys/GameSettings/S5D.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SC7.ini
+++ b/Data/Sys/GameSettings/SC7.ini
@@ -14,4 +14,4 @@
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/SD2.ini
+++ b/Data/Sys/GameSettings/SD2.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 FastTextureSampling = False

--- a/Data/Sys/GameSettings/SD2J01.ini
+++ b/Data/Sys/GameSettings/SD2J01.ini
@@ -16,7 +16,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 FastTextureSampling = False

--- a/Data/Sys/GameSettings/SDB.ini
+++ b/Data/Sys/GameSettings/SDB.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/SDN.ini
+++ b/Data/Sys/GameSettings/SDN.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 FastTextureSampling = False

--- a/Data/Sys/GameSettings/SDZ.ini
+++ b/Data/Sys/GameSettings/SDZ.ini
@@ -14,4 +14,4 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/SE2.ini
+++ b/Data/Sys/GameSettings/SE2.ini
@@ -16,7 +16,7 @@
 SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 # Needed to correctly render clothing

--- a/Data/Sys/GameSettings/SEA.ini
+++ b/Data/Sys/GameSettings/SEA.ini
@@ -16,5 +16,5 @@
 SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 

--- a/Data/Sys/GameSettings/SEM.ini
+++ b/Data/Sys/GameSettings/SEM.ini
@@ -16,7 +16,7 @@
 SafeTextureCacheColorSamples = 0
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/SEP.ini
+++ b/Data/Sys/GameSettings/SEP.ini
@@ -13,4 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/SER.ini
+++ b/Data/Sys/GameSettings/SER.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -17,7 +17,7 @@ SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]
 # Enabling this causes Donkey Kong/Diddy Kong to have an outline.
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Stereoscopy]
 StereoConvergence = 26

--- a/Data/Sys/GameSettings/SJ6.ini
+++ b/Data/Sys/GameSettings/SJ6.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SJ7.ini
+++ b/Data/Sys/GameSettings/SJ7.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SJ9.ini
+++ b/Data/Sys/GameSettings/SJ9.ini
@@ -14,7 +14,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 FastTextureSampling = False

--- a/Data/Sys/GameSettings/SJD.ini
+++ b/Data/Sys/GameSettings/SJD.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 FastTextureSampling = False

--- a/Data/Sys/GameSettings/SJDJ01.ini
+++ b/Data/Sys/GameSettings/SJDJ01.ini
@@ -16,7 +16,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 FastTextureSampling = False

--- a/Data/Sys/GameSettings/SJHE41.ini
+++ b/Data/Sys/GameSettings/SJHE41.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 FastTextureSampling = False

--- a/Data/Sys/GameSettings/SJTP41.ini
+++ b/Data/Sys/GameSettings/SJTP41.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Hacks]
 FastTextureSampling = False

--- a/Data/Sys/GameSettings/SJX.ini
+++ b/Data/Sys/GameSettings/SJX.ini
@@ -14,4 +14,4 @@
 
 [Video_Enhancements]
 MaxAnisotropy = 0
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/SJZ.ini
+++ b/Data/Sys/GameSettings/SJZ.ini
@@ -14,7 +14,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SMO.ini
+++ b/Data/Sys/GameSettings/SMO.ini
@@ -13,4 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/SUO.ini
+++ b/Data/Sys/GameSettings/SUO.ini
@@ -13,4 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/SZB.ini
+++ b/Data/Sys/GameSettings/SZB.ini
@@ -13,7 +13,7 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
-ForceFiltering = False
+ForceTextureFiltering = False
 MaxAnisotropy = 0
 
 [Video_Hacks]


### PR DESCRIPTION
This setting was renamed when it was updated to also support forcing nearest neighbor filtering.