### PR TITLE
Tie Speed to CPU Speed and not VPS

### DIFF
--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -139,9 +139,10 @@ void PerfTrackerCallback(Core::System& system, u64 userdata, s64 cyclesLate)
   auto& core_timing = system.GetCoreTiming();
   g_perf_metrics.CountPerformanceMarker(system, cyclesLate);
 
-  // Call this performance tracker again in 1/64th of a second.
-  // The tracker stores 256 values so this will let us summarize the last 4 seconds.
-  core_timing.ScheduleEvent(GetTicksPerSecond() / 64 - cyclesLate, et_perf_tracker);
+  // Call this performance tracker again in 1/100th of a second.
+  // The tracker stores 256 values so this will let us summarize the last 2.56 seconds.
+  // The performance metrics require this to be called at 100hz for the speed% is correct.
+  core_timing.ScheduleEvent(GetTicksPerSecond() / 100 - cyclesLate, et_perf_tracker);
 }
 
 void VICallback(Core::System& system, u64 userdata, s64 cyclesLate)

--- a/Source/Core/VideoCommon/PerformanceMetrics.cpp
+++ b/Source/Core/VideoCommon/PerformanceMetrics.cpp
@@ -34,7 +34,6 @@ void PerformanceMetrics::CountFrame()
 void PerformanceMetrics::CountVBlank()
 {
   m_vps_counter.Count();
-  m_speed_counter.Count();
 }
 
 void PerformanceMetrics::CountThrottleSleep(DT sleep)
@@ -46,6 +45,8 @@ void PerformanceMetrics::CountThrottleSleep(DT sleep)
 void PerformanceMetrics::CountPerformanceMarker(Core::System& system, s64 cyclesLate)
 {
   std::unique_lock lock(m_time_lock);
+  m_speed_counter.Count();
+
   m_real_times[m_time_index] = Clock::now() - m_time_sleeping;
   m_cpu_times[m_time_index] = system.GetCoreTiming().GetCPUTimePoint(cyclesLate);
   m_time_index += 1;
@@ -63,7 +64,7 @@ double PerformanceMetrics::GetVPS() const
 
 double PerformanceMetrics::GetSpeed() const
 {
-  return m_speed_counter.GetHzAvg() / VideoInterface::GetTargetRefreshRate();
+  return m_speed_counter.GetHzAvg() / 100.0;
 }
 
 double PerformanceMetrics::GetMaxSpeed() const
@@ -147,8 +148,8 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
       const DT frame_time = m_fps_counter.GetDtAvg() + 2 * m_fps_counter.GetDtStd();
       const double target_max_time = DT_ms(vblank_time + frame_time).count();
       const double a =
-          std::max(0.0, 1.0 - std::exp(-4.0 * (DT_s(m_vps_counter.GetLastRawDt()) /
-                                               DT_s(m_vps_counter.GetSampleWindow()))));
+          std::max(0.0, 1.0 - std::exp(-4.0 * (DT_s(m_fps_counter.GetLastRawDt()) /
+                                               DT_s(m_fps_counter.GetSampleWindow()))));
 
       if (std::isfinite(m_graph_max_time))
         m_graph_max_time += a * (target_max_time - m_graph_max_time);

--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -47,7 +47,7 @@ public:
 private:
   PerformanceTracker m_fps_counter{"render_times.txt"};
   PerformanceTracker m_vps_counter{"vblank_times.txt"};
-  PerformanceTracker m_speed_counter{std::nullopt, 500000};
+  PerformanceTracker m_speed_counter{std::nullopt, 1000000};
 
   double m_graph_max_time = 0.0;
 


### PR DESCRIPTION
This makes the speed % more useful, along with reducing the differences between the MAX Speed sample window and the normal speed sample window.