### PR TITLE
Android: Fix crash when attempting to change MEM2 size

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -300,7 +300,7 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     slider.setValue(mSeekbarProgress);
 
     // Sliders can get frustrating to use with a small step size and large ranges
-    int maxRange = item.getMax();
+    int maxRange = item.getMax() - item.getMin();
     if (maxRange <= 100)
     {
       slider.setStepSize(1);


### PR DESCRIPTION
The step size for the slider ended up being 10, but Android wanted it to be a divisor of the slider's range (which is 128 - 64 = 64).