### PR TITLE
Android: Create ScaledIntSetting class

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractBooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractBooleanSetting.java
@@ -2,9 +2,11 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public interface AbstractBooleanSetting extends AbstractSetting
 {
-  boolean getBoolean(Settings settings);
+  boolean getBoolean(@NonNull Settings settings);
 
-  void setBoolean(Settings settings, boolean newValue);
+  void setBoolean(@NonNull Settings settings, boolean newValue);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractFloatSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractFloatSetting.java
@@ -2,9 +2,11 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public interface AbstractFloatSetting extends AbstractSetting
 {
-  float getFloat(Settings settings);
+  float getFloat(@NonNull Settings settings);
 
-  void setFloat(Settings settings, float newValue);
+  void setFloat(@NonNull Settings settings, float newValue);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractIntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractIntSetting.java
@@ -2,9 +2,11 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public interface AbstractIntSetting extends AbstractSetting
 {
-  int getInt(Settings settings);
+  int getInt(@NonNull Settings settings);
 
-  void setInt(Settings settings, int newValue);
+  void setInt(@NonNull Settings settings, int newValue);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractLegacySetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractLegacySetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public class AbstractLegacySetting implements AbstractSetting
 {
   protected final String mFile;
@@ -16,7 +18,7 @@ public class AbstractLegacySetting implements AbstractSetting
   }
 
   @Override
-  public boolean isOverridden(Settings settings)
+  public boolean isOverridden(@NonNull Settings settings)
   {
     return settings.isGameSpecific() && settings.getSection(mFile, mSection).exists(mKey);
   }
@@ -28,7 +30,7 @@ public class AbstractLegacySetting implements AbstractSetting
   }
 
   @Override
-  public boolean delete(Settings settings)
+  public boolean delete(@NonNull Settings settings)
   {
     return settings.getSection(mFile, mSection).delete(mKey);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractSetting.java
@@ -2,11 +2,13 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public interface AbstractSetting
 {
-  boolean isOverridden(Settings settings);
+  boolean isOverridden(@NonNull Settings settings);
 
   boolean isRuntimeEditable();
 
-  boolean delete(Settings settings);
+  boolean delete(@NonNull Settings settings);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractStringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AbstractStringSetting.java
@@ -2,9 +2,12 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public interface AbstractStringSetting extends AbstractSetting
 {
-  String getString(Settings settings);
+  @NonNull
+  String getString(@NonNull Settings settings);
 
-  void setString(Settings settings, String newValue);
+  void setString(@NonNull Settings settings, @NonNull String newValue);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AdHocBooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AdHocBooleanSetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public class AdHocBooleanSetting implements AbstractBooleanSetting
 {
   private final String mFile;
@@ -23,7 +25,7 @@ public class AdHocBooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public boolean isOverridden(Settings settings)
+  public boolean isOverridden(@NonNull Settings settings)
   {
     return NativeConfig.isOverridden(mFile, mSection, mKey);
   }
@@ -35,19 +37,19 @@ public class AdHocBooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public boolean delete(Settings settings)
+  public boolean delete(@NonNull Settings settings)
   {
     return NativeConfig.deleteKey(settings.getWriteLayer(), mFile, mSection, mKey);
   }
 
   @Override
-  public boolean getBoolean(Settings settings)
+  public boolean getBoolean(@NonNull Settings settings)
   {
     return NativeConfig.getBoolean(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
   }
 
   @Override
-  public void setBoolean(Settings settings, boolean newValue)
+  public void setBoolean(@NonNull Settings settings, boolean newValue)
   {
     NativeConfig.setBoolean(settings.getWriteLayer(), mFile, mSection, mKey, newValue);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AdHocStringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AdHocStringSetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public class AdHocStringSetting implements AbstractStringSetting
 {
   private final String mFile;
@@ -23,7 +25,7 @@ public class AdHocStringSetting implements AbstractStringSetting
   }
 
   @Override
-  public boolean isOverridden(Settings settings)
+  public boolean isOverridden(@NonNull Settings settings)
   {
     return NativeConfig.isOverridden(mFile, mSection, mKey);
   }
@@ -35,19 +37,19 @@ public class AdHocStringSetting implements AbstractStringSetting
   }
 
   @Override
-  public boolean delete(Settings settings)
+  public boolean delete(@NonNull Settings settings)
   {
     return NativeConfig.deleteKey(settings.getWriteLayer(), mFile, mSection, mKey);
   }
 
-  @Override
-  public String getString(Settings settings)
+  @NonNull @Override
+  public String getString(@NonNull Settings settings)
   {
     return NativeConfig.getString(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
   }
 
   @Override
-  public void setString(Settings settings, String newValue)
+  public void setString(@NonNull Settings settings, @NonNull String newValue)
   {
     NativeConfig.setString(settings.getWriteLayer(), mFile, mSection, mKey, newValue);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -290,7 +292,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public boolean isOverridden(Settings settings)
+  public boolean isOverridden(@NonNull Settings settings)
   {
     if (settings.isGameSpecific() && !NativeConfig.isSettingSaveable(mFile, mSection, mKey))
       return settings.getSection(mFile, mSection).exists(mKey);
@@ -314,7 +316,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public boolean delete(Settings settings)
+  public boolean delete(@NonNull Settings settings)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
@@ -327,7 +329,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public boolean getBoolean(Settings settings)
+  public boolean getBoolean(@NonNull Settings settings)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
@@ -341,7 +343,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public void setBoolean(Settings settings, boolean newValue)
+  public void setBoolean(@NonNull Settings settings, boolean newValue)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public enum FloatSetting implements AbstractFloatSetting
 {
   // These entries have the same names and order as in C++, just for consistency.
@@ -23,7 +25,7 @@ public enum FloatSetting implements AbstractFloatSetting
   }
 
   @Override
-  public boolean isOverridden(Settings settings)
+  public boolean isOverridden(@NonNull Settings settings)
   {
     if (settings.isGameSpecific() && !NativeConfig.isSettingSaveable(mFile, mSection, mKey))
       return settings.getSection(mFile, mSection).exists(mKey);
@@ -38,7 +40,7 @@ public enum FloatSetting implements AbstractFloatSetting
   }
 
   @Override
-  public boolean delete(Settings settings)
+  public boolean delete(@NonNull Settings settings)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
@@ -51,7 +53,7 @@ public enum FloatSetting implements AbstractFloatSetting
   }
 
   @Override
-  public float getFloat(Settings settings)
+  public float getFloat(@NonNull Settings settings)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
@@ -64,7 +66,7 @@ public enum FloatSetting implements AbstractFloatSetting
   }
 
   @Override
-  public void setFloat(Settings settings, float newValue)
+  public void setFloat(@NonNull Settings settings, float newValue)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -4,6 +4,8 @@ package org.dolphinemu.dolphinemu.features.settings.model;
 
 import android.content.pm.ActivityInfo;
 
+import androidx.annotation.NonNull;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.overlay.InputOverlayPointer;
 
@@ -116,7 +118,7 @@ public enum IntSetting implements AbstractIntSetting
   }
 
   @Override
-  public boolean isOverridden(Settings settings)
+  public boolean isOverridden(@NonNull Settings settings)
   {
     if (settings.isGameSpecific() && !NativeConfig.isSettingSaveable(mFile, mSection, mKey))
       return settings.getSection(mFile, mSection).exists(mKey);
@@ -140,7 +142,7 @@ public enum IntSetting implements AbstractIntSetting
   }
 
   @Override
-  public boolean delete(Settings settings)
+  public boolean delete(@NonNull Settings settings)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
@@ -153,7 +155,7 @@ public enum IntSetting implements AbstractIntSetting
   }
 
   @Override
-  public int getInt(Settings settings)
+  public int getInt(@NonNull Settings settings)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
@@ -166,7 +168,7 @@ public enum IntSetting implements AbstractIntSetting
   }
 
   @Override
-  public void setInt(Settings settings, int newValue)
+  public void setInt(@NonNull Settings settings, int newValue)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/LegacyFloatSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/LegacyFloatSetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public class LegacyFloatSetting extends AbstractLegacySetting implements AbstractFloatSetting
 {
   private final float mDefaultValue;
@@ -13,13 +15,13 @@ public class LegacyFloatSetting extends AbstractLegacySetting implements Abstrac
   }
 
   @Override
-  public float getFloat(Settings settings)
+  public float getFloat(@NonNull Settings settings)
   {
     return settings.getSection(mFile, mSection).getFloat(mKey, mDefaultValue);
   }
 
   @Override
-  public void setFloat(Settings settings, float newValue)
+  public void setFloat(@NonNull Settings settings, float newValue)
   {
     settings.getSection(mFile, mSection).setFloat(mKey, newValue);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/LegacyStringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/LegacyStringSetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 public class LegacyStringSetting extends AbstractLegacySetting implements AbstractStringSetting
 {
   private final String mDefaultValue;
@@ -12,14 +14,14 @@ public class LegacyStringSetting extends AbstractLegacySetting implements Abstra
     mDefaultValue = defaultValue;
   }
 
-  @Override
-  public String getString(Settings settings)
+  @NonNull @Override
+  public String getString(@NonNull Settings settings)
   {
     return settings.getSection(mFile, mSection).getString(mKey, mDefaultValue);
   }
 
   @Override
-  public void setString(Settings settings, String newValue)
+  public void setString(@NonNull Settings settings, @NonNull String newValue)
   {
     settings.getSection(mFile, mSection).setString(mKey, newValue);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/ScaledIntSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/ScaledIntSetting.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.settings.model
+
+class ScaledIntSetting(
+    private val scale: Int,
+    private val setting: AbstractIntSetting
+) : AbstractIntSetting {
+    override fun isOverridden(settings: Settings): Boolean {
+        return setting.isOverridden(settings)
+    }
+
+    override fun isRuntimeEditable(): Boolean {
+        return setting.isRuntimeEditable
+    }
+
+    override fun delete(settings: Settings): Boolean {
+        return setting.delete(settings)
+    }
+
+    override fun getInt(settings: Settings): Int {
+        return setting.getInt(settings) / scale
+    }
+
+    override fun setInt(settings: Settings, newValue: Int) {
+        return setting.setInt(settings, newValue * scale)
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 
 import java.util.Arrays;
@@ -63,7 +65,7 @@ public enum StringSetting implements AbstractStringSetting
   }
 
   @Override
-  public boolean isOverridden(Settings settings)
+  public boolean isOverridden(@NonNull Settings settings)
   {
     if (settings.isGameSpecific() && !NativeConfig.isSettingSaveable(mFile, mSection, mKey))
       return settings.getSection(mFile, mSection).exists(mKey);
@@ -84,7 +86,7 @@ public enum StringSetting implements AbstractStringSetting
   }
 
   @Override
-  public boolean delete(Settings settings)
+  public boolean delete(@NonNull Settings settings)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
@@ -96,8 +98,8 @@ public enum StringSetting implements AbstractStringSetting
     }
   }
 
-  @Override
-  public String getString(Settings settings)
+  @NonNull @Override
+  public String getString(@NonNull Settings settings)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
@@ -111,7 +113,7 @@ public enum StringSetting implements AbstractStringSetting
   }
 
   @Override
-  public void setString(Settings settings, String newValue)
+  public void setString(@NonNull Settings settings, @NonNull String newValue)
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/WiimoteProfileBooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/WiimoteProfileBooleanSetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
 // This stuff is pretty ugly. It's a kind of workaround for certain controller settings
@@ -32,7 +34,7 @@ public class WiimoteProfileBooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public boolean isOverridden(Settings settings)
+  public boolean isOverridden(@NonNull Settings settings)
   {
     return settings.isWiimoteProfileEnabled(settings, mProfile, mProfileKey);
   }
@@ -44,13 +46,13 @@ public class WiimoteProfileBooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public boolean delete(Settings settings)
+  public boolean delete(@NonNull Settings settings)
   {
     return settings.disableWiimoteProfile(settings, mProfileKey);
   }
 
   @Override
-  public boolean getBoolean(Settings settings)
+  public boolean getBoolean(@NonNull Settings settings)
   {
     if (settings.isWiimoteProfileEnabled(settings, mProfile, mProfileKey))
       return settings.getWiimoteProfile(mProfile, mPadID).getBoolean(mSection, mKey, mDefaultValue);
@@ -59,7 +61,7 @@ public class WiimoteProfileBooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public void setBoolean(Settings settings, boolean newValue)
+  public void setBoolean(@NonNull Settings settings, boolean newValue)
   {
     settings.getWiimoteProfile(mProfile, mPadID).setBoolean(mSection, mKey, newValue);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/WiimoteProfileStringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/WiimoteProfileStringSetting.java
@@ -2,6 +2,8 @@
 
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import androidx.annotation.NonNull;
+
 import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
 // This stuff is pretty ugly. It's a kind of workaround for certain controller settings
@@ -32,7 +34,7 @@ public class WiimoteProfileStringSetting implements AbstractStringSetting
   }
 
   @Override
-  public boolean isOverridden(Settings settings)
+  public boolean isOverridden(@NonNull Settings settings)
   {
     return settings.isWiimoteProfileEnabled(settings, mProfile, mProfileKey);
   }
@@ -44,13 +46,13 @@ public class WiimoteProfileStringSetting implements AbstractStringSetting
   }
 
   @Override
-  public boolean delete(Settings settings)
+  public boolean delete(@NonNull Settings settings)
   {
     return settings.disableWiimoteProfile(settings, mProfileKey);
   }
 
-  @Override
-  public String getString(Settings settings)
+  @NonNull @Override
+  public String getString(@NonNull Settings settings)
   {
     if (settings.isWiimoteProfileEnabled(settings, mProfile, mProfileKey))
       return settings.getWiimoteProfile(mProfile, mPadID).getString(mSection, mKey, mDefaultValue);
@@ -59,7 +61,7 @@ public class WiimoteProfileStringSetting implements AbstractStringSetting
   }
 
   @Override
-  public void setString(Settings settings, String newValue)
+  public void setString(@NonNull Settings settings, @NonNull String newValue)
   {
     settings.getWiimoteProfile(mProfile, mPadID).setString(mSection, mKey, newValue);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/DateTimeChoiceSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/DateTimeChoiceSetting.kt
@@ -21,7 +21,7 @@ class DateTimeChoiceSetting(
         return setting
     }
 
-    fun setSelectedValue(settings: Settings?, selection: String) {
+    fun setSelectedValue(settings: Settings, selection: String) {
         setting.setString(settings, selection)
     }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import org.dolphinemu.dolphinemu.NativeLibrary;
@@ -22,6 +23,7 @@ import org.dolphinemu.dolphinemu.features.settings.model.FloatSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.IntSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.LegacyStringSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.PostProcessing;
+import org.dolphinemu.dolphinemu.features.settings.model.ScaledIntSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.model.StringSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.WiimoteProfileStringSetting;
@@ -333,7 +335,7 @@ public final class SettingsFragmentPresenter
     AbstractIntSetting appTheme = new AbstractIntSetting()
     {
       @Override
-      public boolean isOverridden(Settings settings)
+      public boolean isOverridden(@NonNull Settings settings)
       {
         return IntSetting.MAIN_INTERFACE_THEME.isOverridden(settings);
       }
@@ -346,20 +348,20 @@ public final class SettingsFragmentPresenter
       }
 
       @Override
-      public boolean delete(Settings settings)
+      public boolean delete(@NonNull Settings settings)
       {
         ThemeHelper.deleteThemeKey((AppCompatActivity) mView.getActivity());
         return IntSetting.MAIN_INTERFACE_THEME.delete(settings);
       }
 
       @Override
-      public int getInt(Settings settings)
+      public int getInt(@NonNull Settings settings)
       {
         return IntSetting.MAIN_INTERFACE_THEME.getInt(settings);
       }
 
       @Override
-      public void setInt(Settings settings, int newValue)
+      public void setInt(@NonNull Settings settings, int newValue)
       {
         IntSetting.MAIN_INTERFACE_THEME.setInt(settings, newValue);
         ThemeHelper.saveTheme((AppCompatActivity) mView.getActivity(), newValue);
@@ -381,7 +383,7 @@ public final class SettingsFragmentPresenter
     AbstractIntSetting themeMode = new AbstractIntSetting()
     {
       @Override
-      public boolean isOverridden(Settings settings)
+      public boolean isOverridden(@NonNull Settings settings)
       {
         return IntSetting.MAIN_INTERFACE_THEME_MODE.isOverridden(settings);
       }
@@ -394,20 +396,20 @@ public final class SettingsFragmentPresenter
       }
 
       @Override
-      public boolean delete(Settings settings)
+      public boolean delete(@NonNull Settings settings)
       {
         ThemeHelper.deleteThemeModeKey((AppCompatActivity) mView.getActivity());
         return IntSetting.MAIN_INTERFACE_THEME_MODE.delete(settings);
       }
 
       @Override
-      public int getInt(Settings settings)
+      public int getInt(@NonNull Settings settings)
       {
         return IntSetting.MAIN_INTERFACE_THEME_MODE.getInt(settings);
       }
 
       @Override
-      public void setInt(Settings settings, int newValue)
+      public void setInt(@NonNull Settings settings, int newValue)
       {
         IntSetting.MAIN_INTERFACE_THEME_MODE.setInt(settings, newValue);
         ThemeHelper.saveThemeMode((AppCompatActivity) mView.getActivity(), newValue);
@@ -420,7 +422,7 @@ public final class SettingsFragmentPresenter
     AbstractBooleanSetting blackBackgrounds = new AbstractBooleanSetting()
     {
       @Override
-      public boolean isOverridden(Settings settings)
+      public boolean isOverridden(@NonNull Settings settings)
       {
         return BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.isOverridden(settings);
       }
@@ -432,20 +434,20 @@ public final class SettingsFragmentPresenter
       }
 
       @Override
-      public boolean delete(Settings settings)
+      public boolean delete(@NonNull Settings settings)
       {
         ThemeHelper.deleteBackgroundSetting((AppCompatActivity) mView.getActivity());
         return BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.delete(settings);
       }
 
       @Override
-      public boolean getBoolean(Settings settings)
+      public boolean getBoolean(@NonNull Settings settings)
       {
         return BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.getBoolean(settings);
       }
 
       @Override
-      public void setBoolean(Settings settings, boolean newValue)
+      public void setBoolean(@NonNull Settings settings, boolean newValue)
       {
         BooleanSetting.MAIN_USE_BLACK_BACKGROUNDS.setBoolean(settings, newValue);
         ThemeHelper.saveBackgroundSetting((AppCompatActivity) mView.getActivity(), newValue);
@@ -465,7 +467,7 @@ public final class SettingsFragmentPresenter
     AbstractIntSetting dspEmulationEngine = new AbstractIntSetting()
     {
       @Override
-      public int getInt(Settings settings)
+      public int getInt(@NonNull Settings settings)
       {
         if (BooleanSetting.MAIN_DSP_HLE.getBoolean(settings))
         {
@@ -479,7 +481,7 @@ public final class SettingsFragmentPresenter
       }
 
       @Override
-      public void setInt(Settings settings, int newValue)
+      public void setInt(@NonNull Settings settings, int newValue)
       {
         switch (newValue)
         {
@@ -501,7 +503,7 @@ public final class SettingsFragmentPresenter
       }
 
       @Override
-      public boolean isOverridden(Settings settings)
+      public boolean isOverridden(@NonNull Settings settings)
       {
         return BooleanSetting.MAIN_DSP_HLE.isOverridden(settings) ||
                 BooleanSetting.MAIN_DSP_JIT.isOverridden(settings);
@@ -515,7 +517,7 @@ public final class SettingsFragmentPresenter
       }
 
       @Override
-      public boolean delete(Settings settings)
+      public boolean delete(@NonNull Settings settings)
       {
         // Not short circuiting
         return BooleanSetting.MAIN_DSP_HLE.delete(settings) &
@@ -642,7 +644,7 @@ public final class SettingsFragmentPresenter
     AbstractIntSetting synchronizeGpuThread = new AbstractIntSetting()
     {
       @Override
-      public int getInt(Settings settings)
+      public int getInt(@NonNull Settings settings)
       {
         if (BooleanSetting.MAIN_SYNC_GPU.getBoolean(settings))
         {
@@ -656,7 +658,7 @@ public final class SettingsFragmentPresenter
       }
 
       @Override
-      public void setInt(Settings settings, int newValue)
+      public void setInt(@NonNull Settings settings, int newValue)
       {
         switch (newValue)
         {
@@ -678,7 +680,7 @@ public final class SettingsFragmentPresenter
       }
 
       @Override
-      public boolean isOverridden(Settings settings)
+      public boolean isOverridden(@NonNull Settings settings)
       {
         return BooleanSetting.MAIN_SYNC_ON_SKIP_IDLE.isOverridden(settings) ||
                 BooleanSetting.MAIN_SYNC_GPU.isOverridden(settings);
@@ -692,7 +694,7 @@ public final class SettingsFragmentPresenter
       }
 
       @Override
-      public boolean delete(Settings settings)
+      public boolean delete(@NonNull Settings settings)
       {
         // Not short circuiting
         return BooleanSetting.MAIN_SYNC_ON_SKIP_IDLE.delete(settings) &
@@ -737,78 +739,15 @@ public final class SettingsFragmentPresenter
     sl.add(new PercentSliderSetting(mContext, FloatSetting.MAIN_OVERCLOCK, R.string.overclock_title,
             R.string.overclock_title_description, 0, 400, "%", 1));
 
-    AbstractIntSetting mem1Setting = new AbstractIntSetting()
-    {
-      @Override
-      public int getInt(Settings settings)
-      {
-        return IntSetting.MAIN_MEM1_SIZE.getInt(settings) / 1024 / 1024;
-      }
+    ScaledIntSetting mem1Size = new ScaledIntSetting(1024 * 1024, IntSetting.MAIN_MEM1_SIZE);
+    ScaledIntSetting mem2Size = new ScaledIntSetting(1024 * 1024, IntSetting.MAIN_MEM2_SIZE);
 
-      @Override
-      public void setInt(Settings settings, int newValue)
-      {
-        IntSetting.MAIN_MEM1_SIZE.setInt(settings, newValue * 1024 * 1024);
-      }
-
-      @Override
-      public boolean isOverridden(Settings settings)
-      {
-        return IntSetting.MAIN_MEM1_SIZE.isOverridden(settings);
-      }
-
-      @Override
-      public boolean isRuntimeEditable()
-      {
-        return IntSetting.MAIN_MEM1_SIZE.isRuntimeEditable();
-      }
-
-      @Override
-      public boolean delete(Settings settings)
-      {
-        return IntSetting.MAIN_MEM1_SIZE.delete(settings);
-      }
-    };
-    AbstractIntSetting mem2Setting = new AbstractIntSetting()
-    {
-      @Override
-      public int getInt(Settings settings)
-      {
-        return IntSetting.MAIN_MEM2_SIZE.getInt(settings) / 1024 / 1024;
-      }
-
-      @Override
-      public void setInt(Settings settings, int newValue)
-      {
-        IntSetting.MAIN_MEM2_SIZE.setInt(settings, newValue * 1024 * 1024);
-      }
-
-      @Override
-      public boolean isOverridden(Settings settings)
-      {
-        return IntSetting.MAIN_MEM2_SIZE.isOverridden(settings);
-      }
-
-      @Override
-      public boolean isRuntimeEditable()
-      {
-        return IntSetting.MAIN_MEM2_SIZE.isRuntimeEditable();
-      }
-
-      @Override
-      public boolean delete(Settings settings)
-      {
-        return IntSetting.MAIN_MEM2_SIZE.delete(settings);
-      }
-    };
     sl.add(new HeaderSetting(mContext, R.string.memory_override, 0));
     sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_RAM_OVERRIDE_ENABLE,
             R.string.enable_memory_size_override,
             R.string.enable_memory_size_override_description));
-    sl.add(new IntSliderSetting(mContext, mem1Setting, R.string.main_mem1_size, 0, 24, 64, "MB",
-            1));
-    sl.add(new IntSliderSetting(mContext, mem2Setting, R.string.main_mem2_size, 0, 64, 128, "MB",
-            1));
+    sl.add(new IntSliderSetting(mContext, mem1Size, R.string.main_mem1_size, 0, 24, 64, "MB", 1));
+    sl.add(new IntSliderSetting(mContext, mem2Size, R.string.main_mem2_size, 0, 64, 128, "MB", 1));
 
     sl.add(new HeaderSetting(mContext, R.string.gpu_options, 0));
     sl.add(new SingleChoiceSetting(mContext, synchronizeGpuThread, R.string.synchronize_gpu_thread,


### PR DESCRIPTION
A little refactoring to cut down on the size of the very big SettingsFragmentPresenter class.

I ended up adding a bunch of @NonNull annotations in various settings classes so I could make the parameters `Settings` instead of `Settings?` in the new Kotlin code.