### PR TITLE
Add CPU Cull to Twilight Princess and Metroid Prime Series

### DIFF
--- a/Data/Sys/GameSettings/G2M.ini
+++ b/Data/Sys/GameSettings/G2M.ini
@@ -16,5 +16,10 @@ CPUThread = False
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+# Because the minimap has a lot of unused triangles, 
+# CPU Cull can greatly speed up demanding areas of the game.
+
+CPUCull = True
+
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GM8.ini
+++ b/Data/Sys/GameSettings/GM8.ini
@@ -15,4 +15,9 @@
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+# Because the minimap has a lot of unused triangles, 
+# CPU Cull can greatly speed up demanding areas of the game.
+
+CPUCull = True
+
 [Video_Hacks]

--- a/Data/Sys/GameSettings/GZ2.ini
+++ b/Data/Sys/GameSettings/GZ2.ini
@@ -21,5 +21,12 @@ ImmediateXFBEnable = False
 
 VISkip = False
 
+[Video_Settings]
+# Because the minimap in Hyrule Field and Faron Woods
+# has a ton of unused triangles, CPU Cull can greatly
+# speed up demanding areas of the game.
+
+CPUCull = True
+
 [Video_Enhancements]
 ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/R3M.ini
+++ b/Data/Sys/GameSettings/R3M.ini
@@ -12,6 +12,13 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+
+# Because the minimap has a lot of unused triangles, 
+# CPU Cull can greatly speed up demanding areas of the game.
+
+CPUCull = True
+
 [Video_Hacks]
 EFBToTextureEnable = False
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/RM3.ini
+++ b/Data/Sys/GameSettings/RM3.ini
@@ -15,5 +15,10 @@
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+# Because the minimap has a lot of unused triangles, 
+# CPU Cull can greatly speed up demanding areas of the game.
+
+CPUCull = True
+
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RZD.ini
+++ b/Data/Sys/GameSettings/RZD.ini
@@ -21,5 +21,12 @@ ImmediateXFBEnable = False
 
 VISkip = False
 
+[Video_Settings]
+# Because the minimap in Hyrule Field and Faron Woods
+# has a ton of unused triangles, CPU Cull can greatly
+# speed up demanding areas of the game.
+
+CPUCull = True
+
 [Video_Enhancements]
 ArbitraryMipmapDetection = True


### PR DESCRIPTION
These games greatly benefit from CPU Culling, and there isn't much reason not to just blanket enable it for all users.  There is no case where you'd want it disabled.