### PR TITLE
ActionReplay/GeckoCode: Make use of std::span where applicable

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -112,7 +112,7 @@ struct ARAddr
 
 // ----------------------
 // AR Remote Functions
-void ApplyCodes(const std::vector<ARCode>& codes)
+void ApplyCodes(std::span<const ARCode> codes)
 {
   if (!Config::Get(Config::MAIN_ENABLE_CHEATS))
     return;
@@ -132,7 +132,7 @@ void SetSyncedCodesAsActive()
   s_active_codes = s_synced_codes;
 }
 
-void UpdateSyncedCodes(const std::vector<ARCode>& codes)
+void UpdateSyncedCodes(std::span<const ARCode> codes)
 {
   s_synced_codes.clear();
   s_synced_codes.reserve(codes.size());
@@ -141,7 +141,7 @@ void UpdateSyncedCodes(const std::vector<ARCode>& codes)
   s_synced_codes.shrink_to_fit();
 }
 
-std::vector<ARCode> ApplyAndReturnCodes(const std::vector<ARCode>& codes)
+std::vector<ARCode> ApplyAndReturnCodes(std::span<const ARCode> codes)
 {
   if (Config::Get(Config::MAIN_ENABLE_CHEATS))
   {
@@ -250,7 +250,7 @@ std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_in
   return codes;
 }
 
-void SaveCodes(IniFile* local_ini, const std::vector<ARCode>& codes)
+void SaveCodes(IniFile* local_ini, std::span<const ARCode> codes)
 {
   std::vector<std::string> lines;
   std::vector<std::string> enabled_lines;

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
+#include <span>
 #include <string>
-#include <utility>
 #include <variant>
 #include <vector>
 
@@ -37,15 +37,15 @@ struct ARCode
 
 void RunAllActive();
 
-void ApplyCodes(const std::vector<ARCode>& codes);
+void ApplyCodes(std::span<const ARCode> codes);
 void SetSyncedCodesAsActive();
-void UpdateSyncedCodes(const std::vector<ARCode>& codes);
-std::vector<ARCode> ApplyAndReturnCodes(const std::vector<ARCode>& codes);
+void UpdateSyncedCodes(std::span<const ARCode> codes);
+std::vector<ARCode> ApplyAndReturnCodes(std::span<const ARCode> codes);
 void AddCode(ARCode new_code);
 void LoadAndApplyCodes(const IniFile& global_ini, const IniFile& local_ini);
 
 std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_ini);
-void SaveCodes(IniFile* local_ini, const std::vector<ARCode>& codes);
+void SaveCodes(IniFile* local_ini, std::span<const ARCode> codes);
 
 using EncryptedLine = std::string;
 std::variant<std::monostate, AREntry, EncryptedLine> DeserializeLine(const std::string& line);

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -66,7 +66,7 @@ static std::vector<GeckoCode> s_active_codes;
 static std::vector<GeckoCode> s_synced_codes;
 static std::mutex s_active_codes_lock;
 
-void SetActiveCodes(const std::vector<GeckoCode>& gcodes)
+void SetActiveCodes(std::span<const GeckoCode> gcodes)
 {
   std::lock_guard lk(s_active_codes_lock);
 
@@ -89,7 +89,7 @@ void SetSyncedCodesAsActive()
   s_active_codes = s_synced_codes;
 }
 
-void UpdateSyncedCodes(const std::vector<GeckoCode>& gcodes)
+void UpdateSyncedCodes(std::span<const GeckoCode> gcodes)
 {
   s_synced_codes.clear();
   s_synced_codes.reserve(gcodes.size());
@@ -98,7 +98,7 @@ void UpdateSyncedCodes(const std::vector<GeckoCode>& gcodes)
   s_synced_codes.shrink_to_fit();
 }
 
-std::vector<GeckoCode> SetAndReturnActiveCodes(const std::vector<GeckoCode>& gcodes)
+std::vector<GeckoCode> SetAndReturnActiveCodes(std::span<const GeckoCode> gcodes)
 {
   std::lock_guard lk(s_active_codes_lock);
 

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <span>
 #include <string>
 #include <vector>
 
@@ -58,10 +59,10 @@ constexpr u32 HLE_TRAMPOLINE_ADDRESS = INSTALLER_END_ADDRESS - 4;
 // preserve the emulation performance.
 constexpr u32 MAGIC_GAMEID = 0xD01F1BAD;
 
-void SetActiveCodes(const std::vector<GeckoCode>& gcodes);
+void SetActiveCodes(std::span<const GeckoCode> gcodes);
 void SetSyncedCodesAsActive();
-void UpdateSyncedCodes(const std::vector<GeckoCode>& gcodes);
-std::vector<GeckoCode> SetAndReturnActiveCodes(const std::vector<GeckoCode>& gcodes);
+void UpdateSyncedCodes(std::span<const GeckoCode> gcodes);
+std::vector<GeckoCode> SetAndReturnActiveCodes(std::span<const GeckoCode> gcodes);
 void RunCodeHandler();
 void Shutdown();
 void DoState(PointerWrap&);


### PR DESCRIPTION
Some functions in these interfaces just require a range of GeckoCodes and don't depend on the container type, so we can make these a little more flexible by using spans