### PR TITLE
Android: Set each slider step size manually

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.java
@@ -13,9 +13,9 @@ public class FloatSliderSetting extends SliderSetting
   protected AbstractFloatSetting mSetting;
 
   public FloatSliderSetting(Context context, AbstractFloatSetting setting, int titleId,
-          int descriptionId, int min, int max, String units)
+          int descriptionId, int min, int max, String units, int stepSize)
   {
-    super(context, titleId, descriptionId, min, max, units);
+    super(context, titleId, descriptionId, min, max, units, stepSize);
     mSetting = setting;
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/IntSliderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/IntSliderSetting.java
@@ -13,9 +13,9 @@ public final class IntSliderSetting extends SliderSetting
   private AbstractIntSetting mSetting;
 
   public IntSliderSetting(Context context, AbstractIntSetting setting, int titleId,
-          int descriptionId, int min, int max, String units)
+          int descriptionId, int min, int max, String units, int stepSize)
   {
-    super(context, titleId, descriptionId, min, max, units);
+    super(context, titleId, descriptionId, min, max, units, stepSize);
     mSetting = setting;
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/PercentSliderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/PercentSliderSetting.java
@@ -11,9 +11,9 @@ import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 public final class PercentSliderSetting extends FloatSliderSetting
 {
   public PercentSliderSetting(Context context, AbstractFloatSetting setting, int titleId,
-          int descriptionId, int min, int max, String units)
+          int descriptionId, int min, int max, String units, int stepSize)
   {
-    super(context, setting, titleId, descriptionId, min, max, units);
+    super(context, setting, titleId, descriptionId, min, max, units, stepSize);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SliderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SliderSetting.java
@@ -11,14 +11,16 @@ public abstract class SliderSetting extends SettingsItem
   private int mMin;
   private int mMax;
   private String mUnits;
+  private int mStepSize;
 
   public SliderSetting(Context context, int nameId, int descriptionId, int min, int max,
-          String units)
+          String units, int stepSize)
   {
     super(context, nameId, descriptionId);
     mMin = min;
     mMax = max;
     mUnits = units;
+    mStepSize = stepSize;
   }
 
   public abstract int getSelectedValue(Settings settings);
@@ -36,6 +38,11 @@ public abstract class SliderSetting extends SettingsItem
   public String getUnits()
   {
     return mUnits;
+  }
+
+  public int getStepSize()
+  {
+    return mStepSize;
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -298,17 +298,7 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     slider.setValueFrom(item.getMin());
     slider.setValueTo(item.getMax());
     slider.setValue(mSeekbarProgress);
-
-    // Sliders can get frustrating to use with a small step size and large ranges
-    int maxRange = item.getMax() - item.getMin();
-    if (maxRange <= 100)
-    {
-      slider.setStepSize(1);
-    }
-    else
-    {
-      slider.setStepSize((int) Math.pow(10, Math.ceil(Math.log10(maxRange)) - 2));
-    }
+    slider.setStepSize(item.getStepSize());
 
     slider.addOnChangeListener(this);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -293,7 +293,7 @@ public final class SettingsFragmentPresenter
     sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_AUTO_DISC_CHANGE,
             R.string.auto_disc_change, 0));
     sl.add(new PercentSliderSetting(mContext, FloatSetting.MAIN_EMULATION_SPEED,
-            R.string.speed_limit, 0, 0, 200, "%"));
+            R.string.speed_limit, 0, 0, 200, "%", 1));
     sl.add(new SingleChoiceSetting(mContext, IntSetting.MAIN_FALLBACK_REGION,
             R.string.fallback_region, 0, R.array.regionEntries, R.array.regionValues));
     sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_ANALYTICS_ENABLED, R.string.analytics,
@@ -542,7 +542,7 @@ public final class SettingsFragmentPresenter
     sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_AUDIO_STRETCH, R.string.audio_stretch,
             R.string.audio_stretch_description));
     sl.add(new IntSliderSetting(mContext, IntSetting.MAIN_AUDIO_VOLUME, R.string.audio_volume, 0,
-            0, 100, "%"));
+            0, 100, "%", 1));
   }
 
   private void addPathsSettings(ArrayList<SettingsItem> sl)
@@ -621,9 +621,9 @@ public final class SettingsFragmentPresenter
     sl.add(new SwitchSetting(mContext, BooleanSetting.SYSCONF_WIIMOTE_MOTOR,
             R.string.wiimote_rumble, 0));
     sl.add(new IntSliderSetting(mContext, IntSetting.SYSCONF_SPEAKER_VOLUME,
-            R.string.wiimote_volume, 0, 0, 127, ""));
+            R.string.wiimote_volume, 0, 0, 127, "", 1));
     sl.add(new IntSliderSetting(mContext, IntSetting.SYSCONF_SENSOR_BAR_SENSITIVITY,
-            R.string.sensor_bar_sensitivity, 0, 1, 5, ""));
+            R.string.sensor_bar_sensitivity, 0, 1, 5, "", 1));
     sl.add(new SingleChoiceSetting(mContext, IntSetting.SYSCONF_SENSOR_BAR_POSITION,
             R.string.sensor_bar_position, 0, R.array.sensorBarPositionEntries,
             R.array.sensorBarPositionValues));
@@ -735,7 +735,7 @@ public final class SettingsFragmentPresenter
     sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_OVERCLOCK_ENABLE,
             R.string.overclock_enable, R.string.overclock_enable_description));
     sl.add(new PercentSliderSetting(mContext, FloatSetting.MAIN_OVERCLOCK, R.string.overclock_title,
-            R.string.overclock_title_description, 0, 400, "%"));
+            R.string.overclock_title_description, 0, 400, "%", 1));
 
     AbstractIntSetting mem1Setting = new AbstractIntSetting()
     {
@@ -805,8 +805,10 @@ public final class SettingsFragmentPresenter
     sl.add(new SwitchSetting(mContext, BooleanSetting.MAIN_RAM_OVERRIDE_ENABLE,
             R.string.enable_memory_size_override,
             R.string.enable_memory_size_override_description));
-    sl.add(new IntSliderSetting(mContext, mem1Setting, R.string.main_mem1_size, 0, 24, 64, "MB"));
-    sl.add(new IntSliderSetting(mContext, mem2Setting, R.string.main_mem2_size, 0, 64, 128, "MB"));
+    sl.add(new IntSliderSetting(mContext, mem1Setting, R.string.main_mem1_size, 0, 24, 64, "MB",
+            1));
+    sl.add(new IntSliderSetting(mContext, mem2Setting, R.string.main_mem2_size, 0, 64, 128, "MB",
+            1));
 
     sl.add(new HeaderSetting(mContext, R.string.gpu_options, 0));
     sl.add(new SingleChoiceSetting(mContext, synchronizeGpuThread, R.string.synchronize_gpu_thread,
@@ -1030,7 +1032,7 @@ public final class SettingsFragmentPresenter
             R.string.log_render_time_to_file_description));
     sl.add(new IntSliderSetting(mContext, IntSetting.GFX_PERF_SAMP_WINDOW,
             R.string.performance_sample_window, R.string.performance_sample_window_description, 0,
-            10000, "ms"));
+            10000, "ms", 100));
   }
 
   private void addAdvancedGraphicsSettings(ArrayList<SettingsItem> sl)
@@ -1070,7 +1072,7 @@ public final class SettingsFragmentPresenter
     sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_INTERNAL_RESOLUTION_FRAME_DUMPS,
             R.string.internal_resolution_dumps, R.string.internal_resolution_dumps_description));
     sl.add(new IntSliderSetting(mContext, IntSetting.GFX_PNG_COMPRESSION_LEVEL,
-            R.string.png_compression_level, 0, 0, 9, ""));
+            R.string.png_compression_level, 0, 0, 9, "", 1));
 
     sl.add(new HeaderSetting(mContext, R.string.debugging, 0));
     sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_ENABLE_WIREFRAME,
@@ -1143,10 +1145,10 @@ public final class SettingsFragmentPresenter
     sl.add(new SingleChoiceSetting(mContext, IntSetting.GFX_STEREO_MODE, R.string.stereoscopy_mode,
             0, R.array.stereoscopyEntries, R.array.stereoscopyValues));
     sl.add(new IntSliderSetting(mContext, IntSetting.GFX_STEREO_DEPTH, R.string.stereoscopy_depth,
-            R.string.stereoscopy_depth_description, 0, 100, "%"));
+            R.string.stereoscopy_depth_description, 0, 100, "%", 1));
     sl.add(new IntSliderSetting(mContext, IntSetting.GFX_STEREO_CONVERGENCE_PERCENTAGE,
             R.string.stereoscopy_convergence, R.string.stereoscopy_convergence_description, 0, 200,
-            "%"));
+            "%", 1));
     sl.add(new SwitchSetting(mContext, BooleanSetting.GFX_STEREO_SWAP_EYES,
             R.string.stereoscopy_swap_eyes, R.string.stereoscopy_swap_eyes_description));
   }


### PR DESCRIPTION
This reverts part of #11413 where we tried to calculate the appropriate slider step size based on the given range. This turned out to be inappropriate because there can be settings like Emulated CPU Clock Speed % that go up to 400%. Users would like to have the ability to change that by a step size of 1. Seeing as we could get caught in a cycle of constantly adjusting section of a slider that can be stepped by 1, changing the step for each slider individually seemed like a better solution.