### PR TITLE
Android: Remove unused force filtering setting

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -225,8 +225,6 @@ public enum BooleanSetting implements AbstractBooleanSetting
   GFX_CPU_CULL(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "CPUCull", false),
   GFX_MODS_ENABLE(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "EnableMods", false),
 
-  GFX_ENHANCE_FORCE_FILTERING(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS,
-          "ForceFiltering", false),
   GFX_ENHANCE_FORCE_TRUE_COLOR(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS,
           "ForceTrueColor", true),
   GFX_ENHANCE_DISABLE_COPY_FILTER(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -892,37 +892,9 @@ public final class SettingsFragmentPresenter
     sl.add(new SingleChoiceSetting(mContext, IntSetting.GFX_ENHANCE_MAX_ANISOTROPY,
             R.string.anisotropic_filtering, R.string.anisotropic_filtering_description,
             R.array.anisotropicFilteringEntries, R.array.anisotropicFilteringValues));
-    AbstractIntSetting filteringSetting = new AbstractIntSetting()
-    {
-      @Override public int getInt(Settings settings)
-      {
-        return IntSetting.GFX_ENHANCE_FORCE_TEXTURE_FILTERING.getInt(settings);
-      }
-
-      @Override public void setInt(Settings settings, int newValue)
-      {
-        BooleanSetting.GFX_ENHANCE_FORCE_FILTERING.setBoolean(settings, (newValue > 0));
-        IntSetting.GFX_ENHANCE_FORCE_TEXTURE_FILTERING.setInt(settings, newValue);
-      }
-
-      @Override public boolean isOverridden(Settings settings)
-      {
-        return IntSetting.GFX_ENHANCE_FORCE_TEXTURE_FILTERING.isOverridden(settings);
-      }
-
-      @Override public boolean isRuntimeEditable()
-      {
-        return IntSetting.GFX_ENHANCE_FORCE_TEXTURE_FILTERING.isRuntimeEditable();
-      }
-
-      @Override public boolean delete(Settings settings)
-      {
-        return IntSetting.GFX_ENHANCE_FORCE_TEXTURE_FILTERING.delete(settings);
-      }
-    };
-    sl.add(new SingleChoiceSetting(mContext, filteringSetting, R.string.texture_filtering,
-            R.string.texture_filtering_description, R.array.textureFilteringEntries,
-            R.array.textureFilteringValues));
+    sl.add(new SingleChoiceSetting(mContext, IntSetting.GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
+            R.string.texture_filtering, R.string.texture_filtering_description,
+            R.array.textureFilteringEntries, R.array.textureFilteringValues));
 
     int stereoModeValue = IntSetting.GFX_STEREO_MODE.getInt(mSettings);
     final int anaglyphMode = 3;


### PR DESCRIPTION
I made a false assumption about this older boolean force filtering setting being used. It is no longer referenced in dolphin and has been removed for that reason.