### PR TITLE
AndroidCommon: Make use of std::string_view where applicable

### DIFF
--- a/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
@@ -25,7 +25,7 @@ std::string GetJString(JNIEnv* env, jstring jstr)
   return converted_string;
 }
 
-jstring ToJString(JNIEnv* env, const std::string& str)
+jstring ToJString(JNIEnv* env, std::string_view str)
 {
   const std::u16string converted_string = UTF8ToUTF16(str);
   return env->NewString(reinterpret_cast<const jchar*>(converted_string.data()),
@@ -53,7 +53,7 @@ jobjectArray VectorToJStringArray(JNIEnv* env, const std::vector<std::string>& v
   return VectorToJObjectArray(env, vector, IDCache::GetStringClass(), ToJString);
 }
 
-bool IsPathAndroidContent(const std::string& uri)
+bool IsPathAndroidContent(std::string_view uri)
 {
   return uri.starts_with("content://");
 }
@@ -97,7 +97,7 @@ std::string OpenModeToAndroid(std::ios_base::openmode mode)
   return result;
 }
 
-int OpenAndroidContent(const std::string& uri, const std::string& mode)
+int OpenAndroidContent(std::string_view uri, std::string_view mode)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
@@ -113,7 +113,7 @@ int OpenAndroidContent(const std::string& uri, const std::string& mode)
   return result;
 }
 
-bool DeleteAndroidContent(const std::string& uri)
+bool DeleteAndroidContent(std::string_view uri)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
@@ -127,7 +127,7 @@ bool DeleteAndroidContent(const std::string& uri)
   return static_cast<bool>(result);
 }
 
-jlong GetAndroidContentSizeAndIsDirectory(const std::string& uri)
+jlong GetAndroidContentSizeAndIsDirectory(std::string_view uri)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
@@ -141,7 +141,7 @@ jlong GetAndroidContentSizeAndIsDirectory(const std::string& uri)
   return result;
 }
 
-std::string GetAndroidContentDisplayName(const std::string& uri)
+std::string GetAndroidContentDisplayName(std::string_view uri)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
@@ -162,7 +162,7 @@ std::string GetAndroidContentDisplayName(const std::string& uri)
   return result;
 }
 
-std::vector<std::string> GetAndroidContentChildNames(const std::string& uri)
+std::vector<std::string> GetAndroidContentChildNames(std::string_view uri)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
@@ -179,7 +179,7 @@ std::vector<std::string> GetAndroidContentChildNames(const std::string& uri)
   return result;
 }
 
-std::vector<std::string> DoFileSearchAndroidContent(const std::string& directory,
+std::vector<std::string> DoFileSearchAndroidContent(std::string_view directory,
                                                     const std::vector<std::string>& extensions,
                                                     bool recursive)
 {

--- a/Source/Android/jni/AndroidCommon/AndroidCommon.h
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.h
@@ -5,12 +5,13 @@
 
 #include <ios>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <jni.h>
 
 std::string GetJString(JNIEnv* env, jstring jstr);
-jstring ToJString(JNIEnv* env, const std::string& str);
+jstring ToJString(JNIEnv* env, std::string_view str);
 
 std::vector<std::string> JStringArrayToVector(JNIEnv* env, jobjectArray array);
 jobjectArray VectorToJStringArray(JNIEnv* env, const std::vector<std::string>& vector);
@@ -29,30 +30,30 @@ jobjectArray VectorToJObjectArray(JNIEnv* env, const std::vector<T>& vector, jcl
 }
 
 // Returns true if the given path should be opened as Android content instead of a normal file.
-bool IsPathAndroidContent(const std::string& uri);
+bool IsPathAndroidContent(std::string_view uri);
 
 // Turns a C/C++ style mode (e.g. "rb") into one which can be used with OpenAndroidContent.
 std::string OpenModeToAndroid(std::string mode);
 std::string OpenModeToAndroid(std::ios_base::openmode mode);
 
 // Opens a given file and returns a file descriptor.
-int OpenAndroidContent(const std::string& uri, const std::string& mode);
+int OpenAndroidContent(std::string_view uri, std::string_view mode);
 
 // Deletes a given file.
-bool DeleteAndroidContent(const std::string& uri);
+bool DeleteAndroidContent(std::string_view uri);
 // Returns -1 if not found, -2 if directory, file size otherwise.
-jlong GetAndroidContentSizeAndIsDirectory(const std::string& uri);
+jlong GetAndroidContentSizeAndIsDirectory(std::string_view uri);
 
 // An unmangled URI (one which the C++ code has not appended anything to) can't be relied on
 // to contain a file name at all. If a file name is desired, this function is the most reliable
 // way to get it, but the display name is not guaranteed to always actually be like a file name.
 // An empty string will be returned for files which do not exist.
-std::string GetAndroidContentDisplayName(const std::string& uri);
+std::string GetAndroidContentDisplayName(std::string_view uri);
 
 // Returns the display names of all children of a directory, non-recursively.
-std::vector<std::string> GetAndroidContentChildNames(const std::string& uri);
+std::vector<std::string> GetAndroidContentChildNames(std::string_view uri);
 
-std::vector<std::string> DoFileSearchAndroidContent(const std::string& directory,
+std::vector<std::string> DoFileSearchAndroidContent(std::string_view directory,
                                                     const std::vector<std::string>& extensions,
                                                     bool recursive);
 


### PR DESCRIPTION
Several of these can take a string_view rather than needing to specifically use std::string.