### PR TITLE
Android: Simplify the grid options dialog fragment

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/GridOptionDialogFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/GridOptionDialogFragment.kt
@@ -9,7 +9,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
 import android.widget.CompoundButton
 import androidx.appcompat.app.AppCompatActivity
-import com.google.android.material.bottomsheet.BottomSheetDialog
+import org.dolphinemu.dolphinemu.R
 import org.dolphinemu.dolphinemu.databinding.FragmentGridOptionsBinding
 import org.dolphinemu.dolphinemu.databinding.FragmentGridOptionsTvBinding
 import org.dolphinemu.dolphinemu.features.settings.model.NativeConfig
@@ -43,31 +43,17 @@ class GridOptionDialogFragment : BottomSheetDialogFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        // Pins fragment to the top of the dialog ensures the dialog is expanded in landscape by default
+        if (!resources.getBoolean(R.bool.hasTouch)) {
+            BottomSheetBehavior.from<View>(view.parent as View).state =
+                BottomSheetBehavior.STATE_EXPANDED
+        }
+
         if (activity is AppCompatActivity) {
             setUpCoverButtons()
             setUpTitleButtons()
-
-            // Pins fragment to the top of the dialog ensures the dialog is expanded in landscape by default
-            BottomSheetBehavior.from<View>(mBindingMobile.gridSheet).state =
-                BottomSheetBehavior.STATE_EXPANDED
-            dialog?.setOnShowListener {
-                val dialog = it as BottomSheetDialog
-                mBindingMobile.gridSheet.let { sheet ->
-                    dialog.behavior.peekHeight = sheet.height
-                }
-            }
         } else {
             setUpCoverButtonsTv()
-
-            // Pins fragment to the top of the dialog ensures the dialog is expanded in landscape by default
-            BottomSheetBehavior.from<View>(mBindingTv.gridSheet).state =
-                BottomSheetBehavior.STATE_EXPANDED
-            dialog?.setOnShowListener {
-                val dialog = it as BottomSheetDialog
-                mBindingTv.gridSheet.let { sheet ->
-                    dialog.behavior.peekHeight = sheet.height
-                }
-            }
         }
     }
 

--- a/Source/Android/app/src/main/res/layout/fragment_grid_options.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_grid_options.xml
@@ -10,8 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingBottom="@dimen/spacing_xtralarge"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+        android:paddingBottom="@dimen/spacing_xtralarge">
 
         <com.google.android.material.bottomsheet.BottomSheetDragHandleView
             android:layout_width="wrap_content"

--- a/Source/Android/app/src/main/res/layout/fragment_grid_options_tv.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_grid_options_tv.xml
@@ -3,14 +3,14 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="@color/dolphin_surface">
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/grid_sheet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+        android:orientation="vertical">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/root_download_covers"
@@ -30,6 +30,7 @@
                 android:layout_marginEnd="24dp"
                 android:text="@string/download_game_covers"
                 android:textAlignment="viewStart"
+                android:textColor="@color/dolphin_onSurface"
                 app:layout_constraintBottom_toBottomOf="@+id/switch_download_covers"
                 app:layout_constraintEnd_toStartOf="@+id/switch_download_covers"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
This makes the bottom sheet dialog fragments more consistent and solves a bug where the view inside the bottom sheet could move independently from the background.