### PR TITLE
Android: Fix settings being editable when marked otherwise

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SwitchSettingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SwitchSettingViewHolder.java
@@ -39,7 +39,7 @@ public final class SwitchSettingViewHolder extends SettingViewHolder
     mBinding.textSettingDescription.setText(item.getDescription());
 
     mBinding.settingSwitch.setChecked(mItem.isChecked(getAdapter().getSettings()));
-    mBinding.settingSwitch.setEnabled(true);
+    mBinding.settingSwitch.setEnabled(mItem.isEditable());
 
     // Check for IPL to make sure user can skip.
     if (mItem.getSetting() == BooleanSetting.MAIN_SKIP_IPL)


### PR DESCRIPTION
Seems like I accidentally deleted this in #11460 when preparing the guards around the IPL setting. Now this makes sure we don't have problems on recycle and can no longer change settings when marked as not editable during runtime.