### PR TITLE
ENetUtil: Add check for valid socket in SendPacket().

### DIFF
--- a/Source/Core/Common/ENetUtil.cpp
+++ b/Source/Core/Common/ENetUtil.cpp
@@ -39,6 +39,12 @@ int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event)
 
 bool SendPacket(ENetPeer* socket, const sf::Packet& packet, u8 channel_id)
 {
+  if (!socket)
+  {
+    ERROR_LOG_FMT(NETPLAY, "Target socket is null.");
+    return false;
+  }
+
   ENetPacket* epac =
       enet_packet_create(packet.getData(), packet.getDataSize(), ENET_PACKET_FLAG_RELIABLE);
   if (!epac)


### PR DESCRIPTION
I got a crash report on Discord yesterday that I traced back to here.

Unfortunately this isn't a real fix, more like a bandaid. I'm guessing what actually happens is that `m_server` in `NetPlayClient` becomes null through a disconnect but something is still trying to send stuff afterwards, but the stack in the crashdump I have looks borked so I'm not actually sure.

![enetcrash](https://user-images.githubusercontent.com/4522237/215988470-3163512e-a8a4-4a1c-9100-829c0c1c9092.png)
![enetcrash2](https://user-images.githubusercontent.com/4522237/215988486-b58de415-c1ed-4dc2-a9ee-0f1679279943.png)
