### PR TITLE
lint: replace egrep with grep -E

### DIFF
--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -103,17 +103,17 @@ function java_check() {
 # Loop through each modified file.
 for f in ${modified_files}; do
   # Filter them.
-  if echo "${f}" | egrep -q "[.]java$"; then
+  if echo "${f}" | grep -E -q "[.]java$"; then
     # Copy Java files to a temporary directory
     java_setup
     mkdir -p $(dirname "${java_temp_dir}/${f}")
     cp "${f}" "${java_temp_dir}/${f}"
     continue
   fi
-  if ! echo "${f}" | egrep -q "[.](cpp|h|mm)$"; then
+  if ! echo "${f}" | grep -E -q "[.](cpp|h|mm)$"; then
     continue
   fi
-  if ! echo "${f}" | egrep -q "^Source"; then
+  if ! echo "${f}" | grep -E -q "^Source"; then
     continue
   fi
 


### PR DESCRIPTION
Starting with grep 3.8, egrep throws the following warning
   egrep: warning: egrep is obsolescent; using grep -E

Whch is annoying... so we will use grep -E