### PR TITLE
Set VI Skip Activation to Half The Audio Buffer

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -386,7 +386,7 @@ void CoreTimingManager::Throttle(const s64 target_cycle)
   // It doesn't matter what amount of lag we skip VI at, as long as it's constant.
   const DT max_variance =
       std::chrono::duration_cast<DT>(DT_ms(Config::Get(Config::MAIN_TIMING_VARIANCE)));
-  const TimePoint vi_deadline = time - max_variance;
+  const TimePoint vi_deadline = time - max_variance / 2;
   m_throttle_disable_vi_int = 0.0 < speed && m_throttle_deadline < vi_deadline;
 
   // Only sleep if we are behind the deadline

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -386,7 +386,7 @@ void CoreTimingManager::Throttle(const s64 target_cycle)
   // It doesn't matter what amount of lag we skip VI at, as long as it's constant.
   const DT max_variance =
       std::chrono::duration_cast<DT>(DT_ms(Config::Get(Config::MAIN_TIMING_VARIANCE)));
-  const TimePoint vi_deadline = time - max_variance / 2;
+  const TimePoint vi_deadline = time - std::min(max_fallback, max_variance) / 2;
   m_throttle_disable_vi_int = 0.0 < speed && m_throttle_deadline < vi_deadline;
 
   // Only sleep if we are behind the deadline


### PR DESCRIPTION
It's kinda complicated to explain why I would want to do this but here it goes.

It does not actually matter where the VI Skip Activation is, all that matters is that:
1. It's not too close to 0 [on time] because that causes unnecessary sleeping
2. It's not too close to -100ms, because that causes slow down
3. It's shorter than the audio buffer (prevents skips when going from >100% to <100%)

The current VI Deadline is exactly the length of the audio buffer which CAN cause stutters when VI Skip begins to activate. This should get rid of that stutter. 