### PR TITLE
Update Transifex config for new client

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,8 @@
 [main]
 host = https://www.transifex.com
 
-[dolphin-emu.emulator]
+[o:delroth:p:dolphin-emu:r:emulator]
 file_filter = Languages/po/<lang>.po
 source_file = Languages/po/dolphin-emu.pot
 source_lang = en-US
-type = PO
+type        = PO


### PR DESCRIPTION
Transifex's old CLI client was deprecated in November 2022. This updates our config so it can be used with the new client.

I don't need this merged immediately, but I will need it merged within two weeks or so for the next round of translation syncing.