### PR TITLE
Rename "Speed up Disc Transfer Rate" to "Emulate Disc Speed"

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -43,6 +43,8 @@ public enum BooleanSetting implements AbstractBooleanSetting
   MAIN_ACCURATE_CPU_CACHE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "AccurateCPUCache",
           false),
   MAIN_SYNC_GPU(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SyncGPU", false),
+  MAIN_FAST_DISC_SPEED(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "FastDiscSpeed",
+          false),
   MAIN_OVERCLOCK_ENABLE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "OverclockEnable", false),
   MAIN_RAM_OVERRIDE_ENABLE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "RAMOverrideEnable",
           false),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -765,6 +765,11 @@ public final class SettingsFragmentPresenter
             R.string.custom_rtc_enable, R.string.custom_rtc_description));
     sl.add(new DateTimeChoiceSetting(mContext, StringSetting.MAIN_CUSTOM_RTC_VALUE,
             R.string.set_custom_rtc, 0));
+
+    sl.add(new HeaderSetting(mContext, R.string.misc_settings, 0));
+    sl.add(new InvertedSwitchSetting(mContext, BooleanSetting.MAIN_FAST_DISC_SPEED,
+            R.string.emulate_disc_speed,
+            R.string.emulate_disc_speed_description));
   }
 
   private void addSerialPortSubSettings(ArrayList<SettingsItem> sl, int serialPort1Type)

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -416,6 +416,9 @@
     <string name="set_custom_rtc">Set Custom RTC</string>
     <string name="select_rtc_date">Select RTC Date</string>
     <string name="select_rtc_time">Select RTC Time</string>
+    <string name="misc_settings">Misc Settings</string>
+    <string name="emulate_disc_speed">Emulate Disc Speed</string>
+    <string name="emulate_disc_speed_description">Enable emulated disc speed. Disabling this can cause crashes and other problems in some games.</string>
 
     <!-- Log Configuration -->
     <string name="log_submenu">Log</string>

--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -38,8 +38,8 @@ GameConfigEdit::GameConfigEdit(QWidget* parent, QString path, bool read_only)
                                                  "cause issues. Defaults to <b>True</b>"));
 
   AddDescription(QStringLiteral("FastDiscSpeed"),
-                 tr("Shortens loading times but may break some games. Can have negative effects on "
-                    "performance. Defaults to <b>False</b>"));
+                 tr("Emulate the disc speed of real hardware. Disabling can cause instability. "
+                    "Defaults to <b>True</b>"));
 
   AddDescription(QStringLiteral("MMU"), tr("Controls whether or not the Memory Management Unit "
                                            "should be emulated fully. Few games require it."));


### PR DESCRIPTION
Following a suggestion from @mbc07, this renames the "Speed up Disc Transfer Rate" option to "Emulate Disc Speed" and inverts the setting. Since we have no guarantee as to whether or not the improved version of instant reads will ever be created, this allows us to keep the current implementation in a way that will hopefully reduce encourage reckless user behavior.

Additionally, this PR exposes the option in the Android GUI.