### PR TITLE
DSPTool: Fix missing error when redefining labels

### DIFF
--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -912,7 +912,10 @@ bool DSPAssembler::AssemblePass(const std::string& text, int pass)
         }
       }
       if (pass == 1)
-        m_labels.RegisterLabel(label, lval);
+      {
+        if (!m_labels.RegisterLabel(label, lval))
+          ShowError(AssemblerError::LabelAlreadyExists);
+      }
     }
 
     if (opcode == nullptr)

--- a/Source/Core/Core/DSP/LabelMap.cpp
+++ b/Source/Core/Core/DSP/LabelMap.cpp
@@ -42,16 +42,23 @@ void LabelMap::RegisterDefaults()
   }
 }
 
-void LabelMap::RegisterLabel(std::string label, u16 lval, LabelType type)
+bool LabelMap::RegisterLabel(std::string label, u16 lval, LabelType type)
 {
   const std::optional<u16> old_value = GetLabelValue(label);
-  if (old_value && old_value != lval)
+  if (old_value)
   {
-    WARN_LOG_FMT(AUDIO, "Redefined label {} to {:04x} - old value {:04x}\n", label, lval,
-                 *old_value);
-    DeleteLabel(label);
+    if (old_value != lval)
+    {
+      fmt::print("Attempted to redefine label {} from {:04x} to {:04x}\n", label, lval, *old_value);
+      return false;
+    }
+    else
+    {
+      return true;
+    }
   }
   labels.emplace_back(std::move(label), lval, type);
+  return true;
 }
 
 void LabelMap::DeleteLabel(std::string_view label)
@@ -77,7 +84,7 @@ std::optional<u16> LabelMap::GetLabelValue(std::string_view name, LabelType type
       }
       else
       {
-        WARN_LOG_FMT(AUDIO, "Wrong label type requested. {}\n", name);
+        fmt::print("Wrong label type requested. {}\n", name);
       }
     }
   }

--- a/Source/Core/Core/DSP/LabelMap.h
+++ b/Source/Core/Core/DSP/LabelMap.h
@@ -27,7 +27,7 @@ public:
   ~LabelMap();
 
   void RegisterDefaults();
-  void RegisterLabel(std::string label, u16 lval, LabelType type = LABEL_VALUE);
+  bool RegisterLabel(std::string label, u16 lval, LabelType type = LABEL_VALUE);
   void DeleteLabel(std::string_view label);
   std::optional<u16> GetLabelValue(std::string_view name, LabelType type = LABEL_ANY) const;
   void Clear();


### PR DESCRIPTION
The logging was broken in 958cbf38a44d4092934e51266b5aa88d224df6e6 (DSPTool doesn't use dolphin's logging system, so it just produced nothing; the same thing affected comparing before 693a29f8ceeb1166658d9c0752b6e84660077374).

AssemblerError::LabelAlreadyExists (previously ERR_LABEL_EXISTS) simply was never used.