### PR TITLE
TextureCacheBase: Remove unused bitset include

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <array>
-#include <bitset>
 #include <fmt/format.h>
 #include <map>
 #include <memory>


### PR DESCRIPTION
It was used for `valid_bind_points`, which was removed in 88bd10cd30d487cc3efba20875b32df7cdacb686 (and the declaration was more recently removed in 606c18210dd4f651655b2c84e9e332e6c6c6e21b).