### PR TITLE
Core: Never show panic alerts for host memory reads

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -270,11 +270,19 @@ static T ReadFromHardware(Memory::MemoryManager& memory, u32 em_address)
     return bswap(value);
   }
 
-  PanicAlertFmt("Unable to resolve read address {:x} PC {:x}", em_address, PowerPC::ppcState.pc);
-  if (Core::System::GetInstance().IsPauseOnPanicMode())
+  if (IsNoExceptionFlag(flag))
   {
-    CPU::Break();
-    ppcState.Exceptions |= EXCEPTION_DSI | EXCEPTION_FAKE_MEMCHECK_HIT;
+    ERROR_LOG_FMT(POWERPC, "Unable to resolve read address {:x} PC {:x}", em_address,
+                  PowerPC::ppcState.pc);
+  }
+  else
+  {
+    PanicAlertFmt("Unable to resolve read address {:x} PC {:x}", em_address, PowerPC::ppcState.pc);
+    if (Core::System::GetInstance().IsPauseOnPanicMode())
+    {
+      CPU::Break();
+      ppcState.Exceptions |= EXCEPTION_DSI | EXCEPTION_FAKE_MEMCHECK_HIT;
+    }
   }
   return 0;
 }
@@ -459,11 +467,19 @@ static void WriteToHardware(Core::System& system, Memory::MemoryManager& memory,
     return;
   }
 
-  PanicAlertFmt("Unable to resolve write address {:x} PC {:x}", em_address, PowerPC::ppcState.pc);
-  if (Core::System::GetInstance().IsPauseOnPanicMode())
+  if (IsNoExceptionFlag(flag))
   {
-    CPU::Break();
-    ppcState.Exceptions |= EXCEPTION_DSI | EXCEPTION_FAKE_MEMCHECK_HIT;
+    ERROR_LOG_FMT(POWERPC, "Unable to resolve write address {:x} PC {:x}", em_address,
+                  PowerPC::ppcState.pc);
+  }
+  else
+  {
+    PanicAlertFmt("Unable to resolve write address {:x} PC {:x}", em_address, PowerPC::ppcState.pc);
+    if (Core::System::GetInstance().IsPauseOnPanicMode())
+    {
+      CPU::Break();
+      ppcState.Exceptions |= EXCEPTION_DSI | EXCEPTION_FAKE_MEMCHECK_HIT;
+    }
   }
 }
 // =====================


### PR DESCRIPTION
Frame advancing with the debugger enabled often causes the memory view to read from an address that isn't mapped to anything (presumably because MSR.DR was changed), which without this change causes a panic alert to be shown regardless of whether you have MMU enabled. Very annoying.