### PR TITLE
Rename VI Skip to VBI Skip

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -315,8 +315,8 @@
     <string name="disable_bbox_description">Disables bounding box emulation. This may improve GPU performance significantly, but some games will break. If unsure, leave this checked.</string>
     <string name="vertex_rounding">Vertex Rounding</string>
     <string name="vertex_rounding_description">Rounds 2D vertices to whole pixels and rounds the viewport size to a whole number. Fixes graphical problems in some games at higher internal resolutions. This setting has no effect when native internal resolution is used. If unsure, leave this unchecked.</string>
-    <string name="vi_skip">VI Skip</string>
-    <string name="vi_skip_description">Skips VI interrupts when lag is detected, allowing for smooth audio playback when emulation speed is not 100%. Can cause freezes and compatibility issues.</string>
+    <string name="vi_skip">VBI Skip</string>
+    <string name="vi_skip_description">Skips Vertical Blank Interrupts when lag is detected, allowing for smooth audio playback when emulation speed is not 100%. Can cause freezes and compatibility issues.</string>
     <string name="texture_cache_to_state">Save Texture Cache to State</string>
     <string name="texture_cache_to_state_description">Includes the contents of the embedded frame buffer (EFB) and upscaled EFB copies in save states. Fixes missing and/or non-upscaled textures/objects when loading states at the cost of additional save/load time.</string>
     <string name="aspect_ratio">Aspect Ratio</string>

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -106,7 +106,7 @@ void HacksWidget::CreateWidgets()
   m_vertex_rounding = new GraphicsBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUNDING);
   m_save_texture_cache_state =
       new GraphicsBool(tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE);
-  m_vi_skip = new GraphicsBool(tr("VI Skip"), Config::GFX_HACK_VI_SKIP);
+  m_vi_skip = new GraphicsBool(tr("VBI Skip"), Config::GFX_HACK_VI_SKIP);
 
   other_layout->addWidget(m_fast_depth_calculation, 0, 0);
   other_layout->addWidget(m_disable_bounding_box, 0, 1);
@@ -285,7 +285,7 @@ void HacksWidget::AddDescriptions()
       "effect when native internal resolution is used.<br><br>"
       "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_VI_SKIP_DESCRIPTION[] =
-      QT_TR_NOOP("Skips VI interrupts when lag is detected, allowing for "
+      QT_TR_NOOP("Skips Vertical Blank Interrupts when lag is detected, allowing for "
                  "smooth audio playback when emulation speed is not 100%. <br><br>"
                  "<dolphin_emphasis>WARNING: Can cause freezes and compatibility "
                  "issues.</dolphin_emphasis> <br><br>"


### PR DESCRIPTION
The fact that VI Skip used "VI" made it very difficult to explain on the blog. There are SO many things called VI already! This small changes clarifies what VI Skip is to resolve that issue, and makes it not use the "VI" anymore so it no longer conflicts with the other VI things.

I only changed the Qt and Android GUIs, not the INI or internal options. Since there was already some consensus in favour of this on discord and samb gave it a +1, the goal is to get this merged fast so we can get it into the report and publish. And not break anything.

I'll need someone else to test on Android, but here is the change on Linux.

![vbiskip1](https://user-images.githubusercontent.com/6551020/218293255-3fd2523f-291f-4897-91f2-ac8d396d247f.png)

![vbiskip2](https://user-images.githubusercontent.com/6551020/218293258-d04e83da-2223-42b6-9987-6b1348b85f55.png)
