### PR TITLE
DolphinQt: Properly lock CPU before accessing emulated memory

### DIFF
--- a/Source/Core/Common/Debug/CodeTrace.cpp
+++ b/Source/Core/Common/Debug/CodeTrace.cpp
@@ -122,14 +122,14 @@ InstructionAttributes CodeTrace::GetInstructionAttributes(const TraceOutput& ins
   return tmp_attributes;
 }
 
-TraceOutput CodeTrace::SaveCurrentInstruction() const
+TraceOutput CodeTrace::SaveCurrentInstruction(const Core::CPUThreadGuard* guard) const
 {
   auto& system = Core::System::GetInstance();
   auto& ppc_state = system.GetPPCState();
 
   // Quickly save instruction and memory target for fast logging.
   TraceOutput output;
-  const std::string instr = PowerPC::debug_interface.Disassemble(ppc_state.pc);
+  const std::string instr = PowerPC::debug_interface.Disassemble(guard, ppc_state.pc);
   output.instruction = instr;
   output.address = ppc_state.pc;
 
@@ -139,14 +139,15 @@ TraceOutput CodeTrace::SaveCurrentInstruction() const
   return output;
 }
 
-AutoStepResults CodeTrace::AutoStepping(bool continue_previous, AutoStop stop_on)
+AutoStepResults CodeTrace::AutoStepping(const Core::CPUThreadGuard& guard, bool continue_previous,
+                                        AutoStop stop_on)
 {
   AutoStepResults results;
 
-  if (!CPU::IsStepping() || m_recording)
+  if (m_recording)
     return results;
 
-  TraceOutput pc_instr = SaveCurrentInstruction();
+  TraceOutput pc_instr = SaveCurrentInstruction(&guard);
   const InstructionAttributes instr = GetInstructionAttributes(pc_instr);
 
   // Not an instruction we should start autostepping from (ie branches).
@@ -187,7 +188,6 @@ AutoStepResults CodeTrace::AutoStepping(bool continue_previous, AutoStop stop_on
   else if (stop_on == AutoStop::Changed)
     stop_condition = HitType::ACTIVE;
 
-  CPU::PauseAndLock(true, false);
   PowerPC::breakpoints.ClearAllTemporary();
   using clock = std::chrono::steady_clock;
   clock::time_point timeout = clock::now() + std::chrono::seconds(4);
@@ -199,7 +199,7 @@ AutoStepResults CodeTrace::AutoStepping(bool continue_previous, AutoStop stop_on
   {
     PowerPC::SingleStep();
 
-    pc_instr = SaveCurrentInstruction();
+    pc_instr = SaveCurrentInstruction(&guard);
     hit = TraceLogic(pc_instr);
     results.count += 1;
   } while (clock::now() < timeout && hit < stop_condition &&
@@ -210,7 +210,6 @@ AutoStepResults CodeTrace::AutoStepping(bool continue_previous, AutoStop stop_on
     results.timed_out = true;
 
   PowerPC::SetMode(old_mode);
-  CPU::PauseAndLock(false, false);
   m_recording = false;
 
   results.reg_tracked = m_reg_autotrack;

--- a/Source/Core/Common/Debug/CodeTrace.h
+++ b/Source/Core/Common/Debug/CodeTrace.h
@@ -10,6 +10,11 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 struct InstructionAttributes
 {
   u32 address = 0;
@@ -63,11 +68,12 @@ public:
   };
 
   void SetRegTracked(const std::string& reg);
-  AutoStepResults AutoStepping(bool continue_previous = false, AutoStop stop_on = AutoStop::Always);
+  AutoStepResults AutoStepping(const Core::CPUThreadGuard& guard, bool continue_previous = false,
+                               AutoStop stop_on = AutoStop::Always);
 
 private:
   InstructionAttributes GetInstructionAttributes(const TraceOutput& line) const;
-  TraceOutput SaveCurrentInstruction() const;
+  TraceOutput SaveCurrentInstruction(const Core::CPUThreadGuard* guard) const;
   HitType TraceLogic(const TraceOutput& current_instr, bool first_hit = false);
 
   bool m_recording = false;

--- a/Source/Core/Common/Debug/MemoryPatches.h
+++ b/Source/Core/Common/Debug/MemoryPatches.h
@@ -9,6 +9,11 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 namespace Common::Debug
 {
 struct MemoryPatch
@@ -40,21 +45,21 @@ public:
   MemoryPatches();
   virtual ~MemoryPatches();
 
-  void SetPatch(u32 address, u32 value);
-  void SetPatch(u32 address, std::vector<u8> value);
-  void SetFramePatch(u32 address, u32 value);
-  void SetFramePatch(u32 address, std::vector<u8> value);
+  void SetPatch(const Core::CPUThreadGuard& guard, u32 address, u32 value);
+  void SetPatch(const Core::CPUThreadGuard& guard, u32 address, std::vector<u8> value);
+  void SetFramePatch(const Core::CPUThreadGuard& guard, u32 address, u32 value);
+  void SetFramePatch(const Core::CPUThreadGuard& guard, u32 address, std::vector<u8> value);
   const std::vector<MemoryPatch>& GetPatches() const;
-  void UnsetPatch(u32 address);
-  void EnablePatch(std::size_t index);
-  void DisablePatch(std::size_t index);
+  void UnsetPatch(const Core::CPUThreadGuard& guard, u32 address);
+  void EnablePatch(const Core::CPUThreadGuard& guard, std::size_t index);
+  void DisablePatch(const Core::CPUThreadGuard& guard, std::size_t index);
   bool HasEnabledPatch(u32 address) const;
-  void RemovePatch(std::size_t index);
-  void ClearPatches();
-  virtual void ApplyExistingPatch(std::size_t index) = 0;
+  void RemovePatch(const Core::CPUThreadGuard& guard, std::size_t index);
+  void ClearPatches(const Core::CPUThreadGuard& guard);
+  virtual void ApplyExistingPatch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
 
 protected:
-  virtual void Patch(std::size_t index) = 0;
+  virtual void Patch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
   virtual void UnPatch(std::size_t index) = 0;
 
   std::vector<MemoryPatch> m_patches;

--- a/Source/Core/Common/Debug/Threads.h
+++ b/Source/Core/Common/Debug/Threads.h
@@ -11,6 +11,11 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 namespace Common::Debug
 {
 struct PartialContext
@@ -41,7 +46,7 @@ public:
     LWPThread,  // devkitPro libogc thread
   };
 
-  virtual PartialContext GetContext() const = 0;
+  virtual PartialContext GetContext(const Core::CPUThreadGuard& guard) const = 0;
   virtual u32 GetAddress() const = 0;
   virtual u16 GetState() const = 0;
   virtual bool IsSuspended() const = 0;
@@ -53,8 +58,8 @@ public:
   virtual std::size_t GetStackSize() const = 0;
   virtual s32 GetErrno() const = 0;
   // Implementation specific, used to store arbitrary data
-  virtual std::string GetSpecific() const = 0;
-  virtual bool IsValid() const = 0;
+  virtual std::string GetSpecific(const Core::CPUThreadGuard& guard) const = 0;
+  virtual bool IsValid(const Core::CPUThreadGuard& guard) const = 0;
 };
 
 using Threads = std::vector<std::unique_ptr<ThreadView>>;

--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -16,6 +16,11 @@ struct MemoryPatch;
 struct Watch;
 }  // namespace Common::Debug
 
+namespace Core
+{
+class CPUThreadGuard;
+}  // namespace Core
+
 namespace Common
 {
 class DebugInterface
@@ -42,24 +47,29 @@ public:
   virtual void ClearWatches() = 0;
 
   // Memory Patches
-  virtual void SetPatch(u32 address, u32 value) = 0;
-  virtual void SetPatch(u32 address, std::vector<u8> value) = 0;
-  virtual void SetFramePatch(u32 address, u32 value) = 0;
-  virtual void SetFramePatch(u32 address, std::vector<u8> value) = 0;
+  virtual void SetPatch(const Core::CPUThreadGuard& guard, u32 address, u32 value) = 0;
+  virtual void SetPatch(const Core::CPUThreadGuard& guard, u32 address, std::vector<u8> value) = 0;
+  virtual void SetFramePatch(const Core::CPUThreadGuard& guard, u32 address, u32 value) = 0;
+  virtual void SetFramePatch(const Core::CPUThreadGuard& guard, u32 address,
+                             std::vector<u8> value) = 0;
   virtual const std::vector<Debug::MemoryPatch>& GetPatches() const = 0;
-  virtual void UnsetPatch(u32 address) = 0;
-  virtual void EnablePatch(std::size_t index) = 0;
-  virtual void DisablePatch(std::size_t index) = 0;
+  virtual void UnsetPatch(const Core::CPUThreadGuard& guard, u32 address) = 0;
+  virtual void EnablePatch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
+  virtual void DisablePatch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
   virtual bool HasEnabledPatch(u32 address) const = 0;
-  virtual void RemovePatch(std::size_t index) = 0;
-  virtual void ClearPatches() = 0;
-  virtual void ApplyExistingPatch(std::size_t index) = 0;
+  virtual void RemovePatch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
+  virtual void ClearPatches(const Core::CPUThreadGuard& guard) = 0;
+  virtual void ApplyExistingPatch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
 
   // Threads
-  virtual Debug::Threads GetThreads() const = 0;
+  virtual Debug::Threads GetThreads(const Core::CPUThreadGuard& guard) const = 0;
 
-  virtual std::string Disassemble(u32 /*address*/) const { return "NODEBUGGER"; }
-  virtual std::string GetRawMemoryString(int /*memory*/, u32 /*address*/) const
+  virtual std::string Disassemble(const Core::CPUThreadGuard* /*guard*/, u32 /*address*/) const
+  {
+    return "NODEBUGGER";
+  }
+  virtual std::string GetRawMemoryString(const Core::CPUThreadGuard& /*guard*/, int /*memory*/,
+                                         u32 /*address*/) const
   {
     return "NODEBUGGER";
   }
@@ -72,10 +82,20 @@ public:
   virtual void ClearAllMemChecks() {}
   virtual bool IsMemCheck(u32 /*address*/, size_t /*size*/) const { return false; }
   virtual void ToggleMemCheck(u32 /*address*/, bool /*read*/, bool /*write*/, bool /*log*/) {}
-  virtual u32 ReadMemory(u32 /*address*/) const { return 0; }
-  virtual void WriteExtraMemory(int /*memory*/, u32 /*value*/, u32 /*address*/) {}
-  virtual u32 ReadExtraMemory(int /*memory*/, u32 /*address*/) const { return 0; }
-  virtual u32 ReadInstruction(u32 /*address*/) const { return 0; }
+  virtual u32 ReadMemory(const Core::CPUThreadGuard& /*guard*/, u32 /*address*/) const { return 0; }
+  virtual void WriteExtraMemory(const Core::CPUThreadGuard& /*guard*/, int /*memory*/,
+                                u32 /*value*/, u32 /*address*/)
+  {
+  }
+  virtual u32 ReadExtraMemory(const Core::CPUThreadGuard& /*guard*/, int /*memory*/,
+                              u32 /*address*/) const
+  {
+    return 0;
+  }
+  virtual u32 ReadInstruction(const Core::CPUThreadGuard& /*guard*/, u32 /*address*/) const
+  {
+    return 0;
+  }
   virtual std::optional<u32>
   GetMemoryAddressFromInstruction(const std::string& /*instruction*/) const
   {
@@ -85,8 +105,11 @@ public:
   virtual void SetPC(u32 /*address*/) {}
   virtual void Step() {}
   virtual void RunToBreakpoint() {}
-  virtual u32 GetColor(u32 /*address*/) const { return 0xFFFFFFFF; }
+  virtual u32 GetColor(const Core::CPUThreadGuard* /*guard*/, u32 /*address*/) const
+  {
+    return 0xFFFFFFFF;
+  }
   virtual std::string GetDescription(u32 /*address*/) const = 0;
-  virtual void Clear() = 0;
+  virtual void Clear(const Core::CPUThreadGuard& guard) = 0;
 };
 }  // namespace Common

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -15,6 +15,11 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 namespace Common
 {
 struct SCall
@@ -68,7 +73,7 @@ public:
   virtual ~SymbolDB();
 
   virtual Symbol* GetSymbolFromAddr(u32 addr) { return nullptr; }
-  virtual Symbol* AddFunction(u32 start_addr) { return nullptr; }
+  virtual Symbol* AddFunction(const Core::CPUThreadGuard& guard, u32 start_addr) { return nullptr; }
   void AddCompleteSymbol(const Symbol& symbol);
 
   Symbol* GetSymbolFromName(std::string_view name);

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -12,6 +12,11 @@
 
 class IniFile;
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 namespace ActionReplay
 {
 struct AREntry
@@ -35,7 +40,7 @@ struct ARCode
   bool user_defined = false;
 };
 
-void RunAllActive();
+void RunAllActive(const Core::CPUThreadGuard& cpu_guard);
 
 void ApplyCodes(std::span<const ARCode> codes);
 void SetSyncedCodesAsActive();

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -375,11 +375,11 @@ bool CBoot::FindMapFile(std::string* existing_map_file, std::string* writable_ma
   return false;
 }
 
-bool CBoot::LoadMapFromFilename()
+bool CBoot::LoadMapFromFilename(const Core::CPUThreadGuard& guard)
 {
   std::string strMapFilename;
   bool found = FindMapFile(&strMapFilename, nullptr);
-  if (found && g_symbolDB.LoadMap(strMapFilename))
+  if (found && g_symbolDB.LoadMap(guard, strMapFilename))
   {
     UpdateDebugger_MapLoaded();
     return true;
@@ -486,7 +486,8 @@ static void CopyDefaultExceptionHandlers(Core::System& system)
 }
 
 // Third boot step after BootManager and Core. See Call schedule in BootManager.cpp
-bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
+bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
+                   std::unique_ptr<BootParameters> boot)
 {
   SConfig& config = SConfig::GetInstance();
 
@@ -502,8 +503,10 @@ bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
 
   struct BootTitle
   {
-    BootTitle(Core::System& system_, const std::vector<DiscIO::Riivolution::Patch>& patches)
-        : system(system_), config(SConfig::GetInstance()), riivolution_patches(patches)
+    BootTitle(Core::System& system_, const Core::CPUThreadGuard& guard_,
+              const std::vector<DiscIO::Riivolution::Patch>& patches)
+        : system(system_), guard(guard_), config(SConfig::GetInstance()),
+          riivolution_patches(patches)
     {
     }
     bool operator()(BootParameters::Disc& disc) const
@@ -515,10 +518,10 @@ bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
       if (!volume)
         return false;
 
-      if (!EmulatedBS2(system, config.bWii, *volume, riivolution_patches))
+      if (!EmulatedBS2(system, guard, config.bWii, *volume, riivolution_patches))
         return false;
 
-      SConfig::OnNewTitleLoad();
+      SConfig::OnNewTitleLoad(guard);
       return true;
     }
 
@@ -551,7 +554,7 @@ bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
       }
       else
       {
-        SetupGCMemory(system);
+        SetupGCMemory(system, guard);
       }
 
       if (!executable.reader->LoadIntoMemory())
@@ -560,11 +563,11 @@ bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
         return false;
       }
 
-      SConfig::OnNewTitleLoad();
+      SConfig::OnNewTitleLoad(guard);
 
       ppc_state.pc = executable.reader->GetEntryPoint();
 
-      if (executable.reader->LoadSymbols())
+      if (executable.reader->LoadSymbols(guard))
       {
         UpdateDebugger_MapLoaded();
         HLE::PatchFunctions(system);
@@ -578,7 +581,7 @@ bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
       if (!Boot_WiiWAD(system, wad))
         return false;
 
-      SConfig::OnNewTitleLoad();
+      SConfig::OnNewTitleLoad(guard);
       return true;
     }
 
@@ -588,7 +591,7 @@ bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
       if (!BootNANDTitle(system, nand_title.id))
         return false;
 
-      SConfig::OnNewTitleLoad();
+      SConfig::OnNewTitleLoad(guard);
       return true;
     }
 
@@ -613,7 +616,7 @@ bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
         SetDisc(DiscIO::CreateDisc(ipl.disc->path), ipl.disc->auto_disc_change_paths);
       }
 
-      SConfig::OnNewTitleLoad();
+      SConfig::OnNewTitleLoad(guard);
       return true;
     }
 
@@ -625,14 +628,15 @@ bool CBoot::BootUp(Core::System& system, std::unique_ptr<BootParameters> boot)
 
   private:
     Core::System& system;
+    const Core::CPUThreadGuard& guard;
     const SConfig& config;
     const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches;
   };
 
-  if (!std::visit(BootTitle(system, boot->riivolution_patches), boot->parameters))
+  if (!std::visit(BootTitle(system, guard, boot->riivolution_patches), boot->parameters))
     return false;
 
-  DiscIO::Riivolution::ApplyGeneralMemoryPatches(boot->riivolution_patches);
+  DiscIO::Riivolution::ApplyGeneralMemoryPatches(guard, boot->riivolution_patches);
 
   return true;
 }

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -21,8 +21,9 @@
 
 namespace Core
 {
+class CPUThreadGuard;
 class System;
-}
+}  // namespace Core
 
 namespace File
 {
@@ -153,7 +154,8 @@ struct BootParameters
 class CBoot
 {
 public:
-  static bool BootUp(Core::System& system, std::unique_ptr<BootParameters> boot);
+  static bool BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
+                     std::unique_ptr<BootParameters> boot);
 
   // Tries to find a map file for the current game by looking first in the
   // local user directory, then in the shared user directory.
@@ -166,7 +168,7 @@ public:
   //
   // Returns true if a map file exists, false if none could be found.
   static bool FindMapFile(std::string* existing_map_file, std::string* writable_map_file);
-  static bool LoadMapFromFilename();
+  static bool LoadMapFromFilename(const Core::CPUThreadGuard& guard);
 
 private:
   static bool DVDRead(const DiscIO::VolumeDisc& disc, u64 dvd_offset, u32 output_address,
@@ -182,17 +184,21 @@ private:
   static void SetupMSR(PowerPC::PowerPCState& ppc_state);
   static void SetupHID(PowerPC::PowerPCState& ppc_state, bool is_wii);
   static void SetupBAT(Core::System& system, bool is_wii);
-  static bool RunApploader(Core::System& system, bool is_wii, const DiscIO::VolumeDisc& volume,
+  static bool RunApploader(Core::System& system, const Core::CPUThreadGuard& guard, bool is_wii,
+                           const DiscIO::VolumeDisc& volume,
                            const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
-  static bool EmulatedBS2_GC(Core::System& system, const DiscIO::VolumeDisc& volume,
+  static bool EmulatedBS2_GC(Core::System& system, const Core::CPUThreadGuard& guard,
+                             const DiscIO::VolumeDisc& volume,
                              const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
-  static bool EmulatedBS2_Wii(Core::System& system, const DiscIO::VolumeDisc& volume,
+  static bool EmulatedBS2_Wii(Core::System& system, const Core::CPUThreadGuard& guard,
+                              const DiscIO::VolumeDisc& volume,
                               const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
-  static bool EmulatedBS2(Core::System& system, bool is_wii, const DiscIO::VolumeDisc& volume,
+  static bool EmulatedBS2(Core::System& system, const Core::CPUThreadGuard& guard, bool is_wii,
+                          const DiscIO::VolumeDisc& volume,
                           const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
   static bool Load_BS2(Core::System& system, const std::string& boot_rom_filename);
 
-  static void SetupGCMemory(Core::System& system);
+  static void SetupGCMemory(Core::System& system, const Core::CPUThreadGuard& guard);
   static bool SetupWiiMemory(Core::System& system, IOS::HLE::IOSC::ConsoleType console_type);
 };
 
@@ -208,7 +214,7 @@ public:
   virtual bool IsValid() const = 0;
   virtual bool IsWii() const = 0;
   virtual bool LoadIntoMemory(bool only_in_mem1 = false) const = 0;
-  virtual bool LoadSymbols() const = 0;
+  virtual bool LoadSymbols(const Core::CPUThreadGuard& guard) const = 0;
 
 protected:
   std::vector<u8> m_bytes;

--- a/Source/Core/Core/Boot/DolReader.h
+++ b/Source/Core/Core/Boot/DolReader.h
@@ -27,7 +27,7 @@ public:
   bool IsAncast() const { return m_is_ancast; };
   u32 GetEntryPoint() const override { return m_dolheader.entryPoint; }
   bool LoadIntoMemory(bool only_in_mem1 = false) const override;
-  bool LoadSymbols() const override { return false; }
+  bool LoadSymbols(const Core::CPUThreadGuard& guard) const override { return false; }
 
 private:
   enum

--- a/Source/Core/Core/Boot/ElfReader.cpp
+++ b/Source/Core/Core/Boot/ElfReader.cpp
@@ -181,7 +181,7 @@ SectionID ElfReader::GetSectionByName(const char* name, int firstSection) const
   return -1;
 }
 
-bool ElfReader::LoadSymbols() const
+bool ElfReader::LoadSymbols(const Core::CPUThreadGuard& guard) const
 {
   bool hasSymbols = false;
   SectionID sec = GetSectionByName(".symtab");
@@ -219,7 +219,7 @@ bool ElfReader::LoadSymbols() const
       default:
         continue;
       }
-      g_symbolDB.AddKnownSymbol(value, size, name, symtype);
+      g_symbolDB.AddKnownSymbol(guard, value, size, name, symtype);
       hasSymbols = true;
     }
   }

--- a/Source/Core/Core/Boot/ElfReader.h
+++ b/Source/Core/Core/Boot/ElfReader.h
@@ -36,7 +36,7 @@ public:
   u32 GetEntryPoint() const override { return entryPoint; }
   u32 GetFlags() const { return (u32)(header->e_flags); }
   bool LoadIntoMemory(bool only_in_mem1 = false) const override;
-  bool LoadSymbols() const override;
+  bool LoadSymbols(const Core::CPUThreadGuard& guard) const override;
   // TODO: actually check for validity.
   bool IsValid() const override { return true; }
   bool IsWii() const override;

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -103,41 +103,47 @@ namespace
 {
 template <typename T>
 static std::optional<PowerPC::ReadResult<T>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space);
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space);
 
 template <>
 std::optional<PowerPC::ReadResult<u8>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  return PowerPC::HostTryReadU8(addr, space);
+  return PowerPC::HostTryReadU8(guard, addr, space);
 }
 
 template <>
 std::optional<PowerPC::ReadResult<u16>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  return PowerPC::HostTryReadU16(addr, space);
+  return PowerPC::HostTryReadU16(guard, addr, space);
 }
 
 template <>
 std::optional<PowerPC::ReadResult<u32>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  return PowerPC::HostTryReadU32(addr, space);
+  return PowerPC::HostTryReadU32(guard, addr, space);
 }
 
 template <>
 std::optional<PowerPC::ReadResult<u64>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  return PowerPC::HostTryReadU64(addr, space);
+  return PowerPC::HostTryReadU64(guard, addr, space);
 }
 
 template <>
 std::optional<PowerPC::ReadResult<s8>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  auto tmp = PowerPC::HostTryReadU8(addr, space);
+  auto tmp = PowerPC::HostTryReadU8(guard, addr, space);
   if (!tmp)
     return std::nullopt;
   return PowerPC::ReadResult<s8>(tmp->translated, Common::BitCast<s8>(tmp->value));
@@ -145,9 +151,10 @@ TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
 
 template <>
 std::optional<PowerPC::ReadResult<s16>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  auto tmp = PowerPC::HostTryReadU16(addr, space);
+  auto tmp = PowerPC::HostTryReadU16(guard, addr, space);
   if (!tmp)
     return std::nullopt;
   return PowerPC::ReadResult<s16>(tmp->translated, Common::BitCast<s16>(tmp->value));
@@ -155,9 +162,10 @@ TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
 
 template <>
 std::optional<PowerPC::ReadResult<s32>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  auto tmp = PowerPC::HostTryReadU32(addr, space);
+  auto tmp = PowerPC::HostTryReadU32(guard, addr, space);
   if (!tmp)
     return std::nullopt;
   return PowerPC::ReadResult<s32>(tmp->translated, Common::BitCast<s32>(tmp->value));
@@ -165,9 +173,10 @@ TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
 
 template <>
 std::optional<PowerPC::ReadResult<s64>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  auto tmp = PowerPC::HostTryReadU64(addr, space);
+  auto tmp = PowerPC::HostTryReadU64(guard, addr, space);
   if (!tmp)
     return std::nullopt;
   return PowerPC::ReadResult<s64>(tmp->translated, Common::BitCast<s64>(tmp->value));
@@ -175,22 +184,25 @@ TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
 
 template <>
 std::optional<PowerPC::ReadResult<float>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  return PowerPC::HostTryReadF32(addr, space);
+  return PowerPC::HostTryReadF32(guard, addr, space);
 }
 
 template <>
 std::optional<PowerPC::ReadResult<double>>
-TryReadValueFromEmulatedMemory(u32 addr, PowerPC::RequestedAddressSpace space)
+TryReadValueFromEmulatedMemory(const Core::CPUThreadGuard& guard, u32 addr,
+                               PowerPC::RequestedAddressSpace space)
 {
-  return PowerPC::HostTryReadF64(addr, space);
+  return PowerPC::HostTryReadF64(guard, addr, space);
 }
 }  // namespace
 
 template <typename T>
 Common::Result<Cheats::SearchErrorCode, std::vector<Cheats::SearchResult<T>>>
-Cheats::NewSearch(const std::vector<Cheats::MemoryRange>& memory_ranges,
+Cheats::NewSearch(const Core::CPUThreadGuard& guard,
+                  const std::vector<Cheats::MemoryRange>& memory_ranges,
                   PowerPC::RequestedAddressSpace address_space, bool aligned,
                   const std::function<bool(const T& value)>& validator)
 {
@@ -229,7 +241,7 @@ Cheats::NewSearch(const std::vector<Cheats::MemoryRange>& memory_ranges,
       for (u64 i = 0; i < length; i += increment_per_loop)
       {
         const u32 addr = start_address + i;
-        const auto current_value = TryReadValueFromEmulatedMemory<T>(addr, address_space);
+        const auto current_value = TryReadValueFromEmulatedMemory<T>(guard, addr, address_space);
         if (!current_value)
           continue;
 
@@ -252,7 +264,8 @@ Cheats::NewSearch(const std::vector<Cheats::MemoryRange>& memory_ranges,
 
 template <typename T>
 Common::Result<Cheats::SearchErrorCode, std::vector<Cheats::SearchResult<T>>>
-Cheats::NextSearch(const std::vector<Cheats::SearchResult<T>>& previous_results,
+Cheats::NextSearch(const Core::CPUThreadGuard& guard,
+                   const std::vector<Cheats::SearchResult<T>>& previous_results,
                    PowerPC::RequestedAddressSpace address_space,
                    const std::function<bool(const T& new_value, const T& old_value)>& validator)
 {
@@ -277,7 +290,7 @@ Cheats::NextSearch(const std::vector<Cheats::SearchResult<T>>& previous_results,
     for (const auto& previous_result : previous_results)
     {
       const u32 addr = previous_result.m_address;
-      const auto current_value = TryReadValueFromEmulatedMemory<T>(addr, address_space);
+      const auto current_value = TryReadValueFromEmulatedMemory<T>(guard, addr, address_space);
       if (!current_value)
       {
         auto& r = results.emplace_back();
@@ -429,7 +442,7 @@ MakeCompareFunctionForLastValue(Cheats::CompareType op)
 }
 
 template <typename T>
-Cheats::SearchErrorCode Cheats::CheatSearchSession<T>::RunSearch()
+Cheats::SearchErrorCode Cheats::CheatSearchSession<T>::RunSearch(const Core::CPUThreadGuard& guard)
 {
   Common::Result<SearchErrorCode, std::vector<SearchResult<T>>> result =
       Cheats::SearchErrorCode::InvalidParameters;
@@ -442,12 +455,12 @@ Cheats::SearchErrorCode Cheats::CheatSearchSession<T>::RunSearch()
     if (m_first_search_done)
     {
       result = Cheats::NextSearch<T>(
-          m_search_results, m_address_space,
+          guard, m_search_results, m_address_space,
           [&func](const T& new_value, const T& old_value) { return func(new_value); });
     }
     else
     {
-      result = Cheats::NewSearch<T>(m_memory_ranges, m_address_space, m_aligned, func);
+      result = Cheats::NewSearch<T>(guard, m_memory_ranges, m_address_space, m_aligned, func);
     }
   }
   else if (m_filter_type == FilterType::CompareAgainstLastValue)
@@ -455,19 +468,19 @@ Cheats::SearchErrorCode Cheats::CheatSearchSession<T>::RunSearch()
     if (!m_first_search_done)
       return Cheats::SearchErrorCode::InvalidParameters;
 
-    result = Cheats::NextSearch<T>(m_search_results, m_address_space,
+    result = Cheats::NextSearch<T>(guard, m_search_results, m_address_space,
                                    MakeCompareFunctionForLastValue<T>(m_compare_type));
   }
   else if (m_filter_type == FilterType::DoNotFilter)
   {
     if (m_first_search_done)
     {
-      result = Cheats::NextSearch<T>(m_search_results, m_address_space,
+      result = Cheats::NextSearch<T>(guard, m_search_results, m_address_space,
                                      [](const T& v1, const T& v2) { return true; });
     }
     else
     {
-      result = Cheats::NewSearch<T>(m_memory_ranges, m_address_space, m_aligned,
+      result = Cheats::NewSearch<T>(guard, m_memory_ranges, m_address_space, m_aligned,
                                     [](const T& v) { return true; });
     }
   }

--- a/Source/Core/Core/CheatSearch.h
+++ b/Source/Core/Core/CheatSearch.h
@@ -14,6 +14,11 @@
 #include "Common/Result.h"
 #include "Core/PowerPC/MMU.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 namespace Cheats
 {
 enum class CompareType
@@ -108,7 +113,7 @@ std::vector<u8> GetValueAsByteVector(const SearchValue& value);
 // for which the given validator returns true.
 template <typename T>
 Common::Result<SearchErrorCode, std::vector<SearchResult<T>>>
-NewSearch(const std::vector<MemoryRange>& memory_ranges,
+NewSearch(const Core::CPUThreadGuard& guard, const std::vector<MemoryRange>& memory_ranges,
           PowerPC::RequestedAddressSpace address_space, bool aligned,
           const std::function<bool(const T& value)>& validator);
 
@@ -116,7 +121,7 @@ NewSearch(const std::vector<MemoryRange>& memory_ranges,
 // which the given validator returns true.
 template <typename T>
 Common::Result<SearchErrorCode, std::vector<SearchResult<T>>>
-NextSearch(const std::vector<SearchResult<T>>& previous_results,
+NextSearch(const Core::CPUThreadGuard& guard, const std::vector<SearchResult<T>>& previous_results,
            PowerPC::RequestedAddressSpace address_space,
            const std::function<bool(const T& new_value, const T& old_value)>& validator);
 
@@ -138,7 +143,7 @@ public:
   virtual void ResetResults() = 0;
 
   // Run either a new search or a next search based on the current state of this session.
-  virtual SearchErrorCode RunSearch() = 0;
+  virtual SearchErrorCode RunSearch(const Core::CPUThreadGuard& guard) = 0;
 
   virtual size_t GetMemoryRangeCount() const = 0;
   virtual MemoryRange GetMemoryRange(size_t index) const = 0;
@@ -184,7 +189,7 @@ public:
   bool SetValueFromString(const std::string& value_as_string, bool force_parse_as_hex) override;
 
   void ResetResults() override;
-  SearchErrorCode RunSearch() override;
+  SearchErrorCode RunSearch(const Core::CPUThreadGuard& guard) override;
 
   size_t GetMemoryRangeCount() const override;
   MemoryRange GetMemoryRange(size_t index) const override;

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -191,7 +191,7 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
     DolphinAnalytics::Instance().ReportGameStart();
 }
 
-void SConfig::OnNewTitleLoad()
+void SConfig::OnNewTitleLoad(const Core::CPUThreadGuard& guard)
 {
   if (!Core::IsRunning())
     return;
@@ -201,7 +201,7 @@ void SConfig::OnNewTitleLoad()
     g_symbolDB.Clear();
     Host_NotifyMapLoaded();
   }
-  CBoot::LoadMapFromFilename();
+  CBoot::LoadMapFromFilename(guard);
   auto& system = Core::System::GetInstance();
   HLE::Reload(system);
   PatchEngine::Reload();

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -16,6 +16,11 @@
 
 class IniFile;
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 namespace DiscIO
 {
 enum class Language;
@@ -68,7 +73,7 @@ struct SConfig
   void SetRunningGameMetadata(const std::string& game_id);
   // Reloads title-specific map files, patches, custom textures, etc.
   // This should only be called after the new title has been loaded into memory.
-  static void OnNewTitleLoad();
+  static void OnNewTitleLoad(const Core::CPUThreadGuard& guard);
 
   void LoadDefaults();
   static std::string MakeGameID(std::string_view file_name);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -166,7 +166,12 @@ void OnFrameEnd()
 {
 #ifdef USE_MEMORYWATCHER
   if (s_memory_watcher)
-    s_memory_watcher->Step();
+  {
+    ASSERT(IsCPUThread());
+    CPUThreadGuard guard;
+
+    s_memory_watcher->Step(guard);
+  }
 #endif
 }
 
@@ -537,7 +542,9 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
 
     PatchEngine::Shutdown();
     HLE::Clear();
-    PowerPC::debug_interface.Clear();
+
+    CPUThreadGuard guard;
+    PowerPC::debug_interface.Clear(guard);
   }};
 
   VideoBackendBase::PopulateBackendInfo();
@@ -587,8 +594,12 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   if (SConfig::GetInstance().bWii)
     savegame_redirect = DiscIO::Riivolution::ExtractSavegameRedirect(boot->riivolution_patches);
 
-  if (!CBoot::BootUp(system, std::move(boot)))
-    return;
+  {
+    ASSERT(IsCPUThread());
+    CPUThreadGuard guard;
+    if (!CBoot::BootUp(system, guard, std::move(boot)))
+      return;
+  }
 
   // Initialise Wii filesystem contents.
   // This is done here after Boot and not in BootManager to ensure that we operate
@@ -1034,6 +1045,18 @@ void UpdateInputGate(bool require_focus, bool require_full_focus)
   const bool full_focus_passes =
       !require_focus || !require_full_focus || (focus_passes && Host_RendererHasFullFocus());
   ControlReference::SetInputGate(focus_passes && full_focus_passes);
+}
+
+CPUThreadGuard::CPUThreadGuard() : m_was_cpu_thread(IsCPUThread())
+{
+  if (!m_was_cpu_thread)
+    m_was_unpaused = PauseAndLock(true, true);
+}
+
+CPUThreadGuard::~CPUThreadGuard()
+{
+  if (!m_was_cpu_thread)
+    PauseAndLock(false, m_was_unpaused);
 }
 
 }  // namespace Core

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -92,6 +92,33 @@ enum class ConsoleType : u32
   ReservedTDEVSystem = 0x20000007,
 };
 
+// Run a function as the CPU thread. This is an RAII alternative to the RunAsCPUThread function.
+//
+// If constructed from the Host thread, the CPU thread is paused and the current thread temporarily
+// becomes the CPU thread.
+// If constructed from the CPU thread, nothing special happens.
+//
+// This should only be constructed from the CPU thread or the host thread.
+//
+// Some functions use a parameter of this type to indicate that the function should only be called
+// from the CPU thread. If the parameter is a pointer, the function has a fallback for being called
+// from the wrong thread (with the argument being set to nullptr).
+class CPUThreadGuard final
+{
+public:
+  CPUThreadGuard();
+  ~CPUThreadGuard();
+
+  CPUThreadGuard(const CPUThreadGuard&) = delete;
+  CPUThreadGuard(CPUThreadGuard&&) = delete;
+  CPUThreadGuard& operator=(const CPUThreadGuard&) = delete;
+  CPUThreadGuard& operator=(CPUThreadGuard&&) = delete;
+
+private:
+  const bool m_was_cpu_thread;
+  bool m_was_unpaused = false;
+};
+
 bool Init(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi);
 void Stop();
 void Shutdown();

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.h
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.h
@@ -12,8 +12,9 @@
 
 namespace Core
 {
+class CPUThreadGuard;
 class System;
-}
+}  // namespace Core
 
 namespace Dolphin_Debugger
 {
@@ -23,8 +24,10 @@ struct CallstackEntry
   u32 vAddress = 0;
 };
 
-bool GetCallstack(Core::System& system, std::vector<CallstackEntry>& output);
-void PrintCallstack(Core::System& system, Common::Log::LogType type, Common::Log::LogLevel level);
+bool GetCallstack(Core::System& system, const Core::CPUThreadGuard& guard,
+                  std::vector<CallstackEntry>& output);
+void PrintCallstack(Core::System& system, const Core::CPUThreadGuard& guard,
+                    Common::Log::LogType type, Common::Log::LogLevel level);
 void PrintDataBuffer(Common::Log::LogType type, const u8* data, size_t size,
                      std::string_view title);
 void AddAutoBreakpoints();

--- a/Source/Core/Core/Debugger/OSThread.cpp
+++ b/Source/Core/Core/Debugger/OSThread.cpp
@@ -16,40 +16,40 @@ namespace Core::Debug
 //  - OSDumpContext
 //  - OSClearContext
 //  - OSExceptionVector
-void OSContext::Read(u32 addr)
+void OSContext::Read(const Core::CPUThreadGuard& guard, u32 addr)
 {
   for (std::size_t i = 0; i < gpr.size(); i++)
-    gpr[i] = PowerPC::HostRead_U32(addr + u32(i * sizeof(int)));
-  cr = PowerPC::HostRead_U32(addr + 0x80);
-  lr = PowerPC::HostRead_U32(addr + 0x84);
-  ctr = PowerPC::HostRead_U32(addr + 0x88);
-  xer = PowerPC::HostRead_U32(addr + 0x8C);
+    gpr[i] = PowerPC::HostRead_U32(guard, addr + u32(i * sizeof(int)));
+  cr = PowerPC::HostRead_U32(guard, addr + 0x80);
+  lr = PowerPC::HostRead_U32(guard, addr + 0x84);
+  ctr = PowerPC::HostRead_U32(guard, addr + 0x88);
+  xer = PowerPC::HostRead_U32(guard, addr + 0x8C);
   for (std::size_t i = 0; i < fpr.size(); i++)
-    fpr[i] = PowerPC::HostRead_F64(addr + 0x90 + u32(i * sizeof(double)));
-  fpscr = PowerPC::HostRead_U64(addr + 0x190);
-  srr0 = PowerPC::HostRead_U32(addr + 0x198);
-  srr1 = PowerPC::HostRead_U32(addr + 0x19c);
-  dummy = PowerPC::HostRead_U16(addr + 0x1a0);
-  state = static_cast<OSContext::State>(PowerPC::HostRead_U16(addr + 0x1a2));
+    fpr[i] = PowerPC::HostRead_F64(guard, addr + 0x90 + u32(i * sizeof(double)));
+  fpscr = PowerPC::HostRead_U64(guard, addr + 0x190);
+  srr0 = PowerPC::HostRead_U32(guard, addr + 0x198);
+  srr1 = PowerPC::HostRead_U32(guard, addr + 0x19c);
+  dummy = PowerPC::HostRead_U16(guard, addr + 0x1a0);
+  state = static_cast<OSContext::State>(PowerPC::HostRead_U16(guard, addr + 0x1a2));
   for (std::size_t i = 0; i < gqr.size(); i++)
-    gqr[i] = PowerPC::HostRead_U32(addr + 0x1a4 + u32(i * sizeof(int)));
+    gqr[i] = PowerPC::HostRead_U32(guard, addr + 0x1a4 + u32(i * sizeof(int)));
   psf_padding = 0;
   for (std::size_t i = 0; i < psf.size(); i++)
-    psf[i] = PowerPC::HostRead_F64(addr + 0x1c8 + u32(i * sizeof(double)));
+    psf[i] = PowerPC::HostRead_F64(guard, addr + 0x1c8 + u32(i * sizeof(double)));
 }
 
 // Mutex offsets based on the following functions:
 //  - OSInitMutex
 //  - OSLockMutex
 //  - __OSUnlockAllMutex
-void OSMutex::Read(u32 addr)
+void OSMutex::Read(const Core::CPUThreadGuard& guard, u32 addr)
 {
-  thread_queue.head = PowerPC::HostRead_U32(addr);
-  thread_queue.tail = PowerPC::HostRead_U32(addr + 0x4);
-  owner_addr = PowerPC::HostRead_U32(addr + 0x8);
-  lock_count = PowerPC::HostRead_U32(addr + 0xc);
-  link.next = PowerPC::HostRead_U32(addr + 0x10);
-  link.prev = PowerPC::HostRead_U32(addr + 0x14);
+  thread_queue.head = PowerPC::HostRead_U32(guard, addr);
+  thread_queue.tail = PowerPC::HostRead_U32(guard, addr + 0x4);
+  owner_addr = PowerPC::HostRead_U32(guard, addr + 0x8);
+  lock_count = PowerPC::HostRead_U32(guard, addr + 0xc);
+  link.next = PowerPC::HostRead_U32(guard, addr + 0x10);
+  link.prev = PowerPC::HostRead_U32(guard, addr + 0x14);
 }
 
 // Thread offsets based on the following functions:
@@ -64,46 +64,47 @@ void OSMutex::Read(u32 addr)
 //  - __OSThreadInit
 //  - OSSetThreadSpecific
 //  - SOInit (for errno)
-void OSThread::Read(u32 addr)
+void OSThread::Read(const Core::CPUThreadGuard& guard, u32 addr)
 {
-  context.Read(addr);
-  state = PowerPC::HostRead_U16(addr + 0x2c8);
-  is_detached = PowerPC::HostRead_U16(addr + 0x2ca);
-  suspend = PowerPC::HostRead_U32(addr + 0x2cc);
-  effective_priority = PowerPC::HostRead_U32(addr + 0x2d0);
-  base_priority = PowerPC::HostRead_U32(addr + 0x2d4);
-  exit_code_addr = PowerPC::HostRead_U32(addr + 0x2d8);
+  context.Read(guard, addr);
+  state = PowerPC::HostRead_U16(guard, addr + 0x2c8);
+  is_detached = PowerPC::HostRead_U16(guard, addr + 0x2ca);
+  suspend = PowerPC::HostRead_U32(guard, addr + 0x2cc);
+  effective_priority = PowerPC::HostRead_U32(guard, addr + 0x2d0);
+  base_priority = PowerPC::HostRead_U32(guard, addr + 0x2d4);
+  exit_code_addr = PowerPC::HostRead_U32(guard, addr + 0x2d8);
 
-  queue_addr = PowerPC::HostRead_U32(addr + 0x2dc);
-  queue_link.next = PowerPC::HostRead_U32(addr + 0x2e0);
-  queue_link.prev = PowerPC::HostRead_U32(addr + 0x2e4);
+  queue_addr = PowerPC::HostRead_U32(guard, addr + 0x2dc);
+  queue_link.next = PowerPC::HostRead_U32(guard, addr + 0x2e0);
+  queue_link.prev = PowerPC::HostRead_U32(guard, addr + 0x2e4);
 
-  join_queue.head = PowerPC::HostRead_U32(addr + 0x2e8);
-  join_queue.tail = PowerPC::HostRead_U32(addr + 0x2ec);
+  join_queue.head = PowerPC::HostRead_U32(guard, addr + 0x2e8);
+  join_queue.tail = PowerPC::HostRead_U32(guard, addr + 0x2ec);
 
-  mutex_addr = PowerPC::HostRead_U32(addr + 0x2f0);
-  mutex_queue.head = PowerPC::HostRead_U32(addr + 0x2f4);
-  mutex_queue.tail = PowerPC::HostRead_U32(addr + 0x2f8);
+  mutex_addr = PowerPC::HostRead_U32(guard, addr + 0x2f0);
+  mutex_queue.head = PowerPC::HostRead_U32(guard, addr + 0x2f4);
+  mutex_queue.tail = PowerPC::HostRead_U32(guard, addr + 0x2f8);
 
-  thread_link.next = PowerPC::HostRead_U32(addr + 0x2fc);
-  thread_link.prev = PowerPC::HostRead_U32(addr + 0x300);
+  thread_link.next = PowerPC::HostRead_U32(guard, addr + 0x2fc);
+  thread_link.prev = PowerPC::HostRead_U32(guard, addr + 0x300);
 
-  stack_addr = PowerPC::HostRead_U32(addr + 0x304);
-  stack_end = PowerPC::HostRead_U32(addr + 0x308);
-  error = PowerPC::HostRead_U32(addr + 0x30c);
-  specific[0] = PowerPC::HostRead_U32(addr + 0x310);
-  specific[1] = PowerPC::HostRead_U32(addr + 0x314);
+  stack_addr = PowerPC::HostRead_U32(guard, addr + 0x304);
+  stack_end = PowerPC::HostRead_U32(guard, addr + 0x308);
+  error = PowerPC::HostRead_U32(guard, addr + 0x30c);
+  specific[0] = PowerPC::HostRead_U32(guard, addr + 0x310);
+  specific[1] = PowerPC::HostRead_U32(guard, addr + 0x314);
 }
 
-bool OSThread::IsValid() const
+bool OSThread::IsValid(const Core::CPUThreadGuard& guard) const
 {
-  return PowerPC::HostIsRAMAddress(stack_end) && PowerPC::HostRead_U32(stack_end) == STACK_MAGIC;
+  return PowerPC::HostIsRAMAddress(guard, stack_end) &&
+         PowerPC::HostRead_U32(guard, stack_end) == STACK_MAGIC;
 }
 
-OSThreadView::OSThreadView(u32 addr)
+OSThreadView::OSThreadView(const Core::CPUThreadGuard& guard, u32 addr)
 {
   m_address = addr;
-  m_thread.Read(addr);
+  m_thread.Read(guard, addr);
 }
 
 const OSThread& OSThreadView::Data() const
@@ -111,11 +112,11 @@ const OSThread& OSThreadView::Data() const
   return m_thread;
 }
 
-Common::Debug::PartialContext OSThreadView::GetContext() const
+Common::Debug::PartialContext OSThreadView::GetContext(const Core::CPUThreadGuard& guard) const
 {
   Common::Debug::PartialContext context;
 
-  if (!IsValid())
+  if (!IsValid(guard))
     return context;
 
   context.gpr = m_thread.context.gpr;
@@ -185,23 +186,23 @@ s32 OSThreadView::GetErrno() const
   return m_thread.error;
 }
 
-std::string OSThreadView::GetSpecific() const
+std::string OSThreadView::GetSpecific(const Core::CPUThreadGuard& guard) const
 {
   std::string specific;
 
   for (u32 addr : m_thread.specific)
   {
-    if (!PowerPC::HostIsRAMAddress(addr))
+    if (!PowerPC::HostIsRAMAddress(guard, addr))
       break;
-    specific += fmt::format("{:08x} \"{}\"\n", addr, PowerPC::HostGetString(addr));
+    specific += fmt::format("{:08x} \"{}\"\n", addr, PowerPC::HostGetString(guard, addr));
   }
 
   return specific;
 }
 
-bool OSThreadView::IsValid() const
+bool OSThreadView::IsValid(const Core::CPUThreadGuard& guard) const
 {
-  return m_thread.IsValid();
+  return m_thread.IsValid(guard);
 }
 
 }  // namespace Core::Debug

--- a/Source/Core/Core/Debugger/OSThread.h
+++ b/Source/Core/Core/Debugger/OSThread.h
@@ -10,6 +10,11 @@
 #include "Common/CommonTypes.h"
 #include "Common/Debug/Threads.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 namespace Core::Debug
 {
 template <class C>
@@ -56,7 +61,7 @@ struct OSContext
   u32 psf_padding;
   std::array<double, 32> psf;
 
-  void Read(u32 addr);
+  void Read(const Core::CPUThreadGuard& guard, u32 addr);
 };
 
 static_assert(std::is_trivially_copyable_v<OSContext>);
@@ -96,8 +101,8 @@ struct OSThread
   std::array<u32, 2> specific;  // Pointers to data (can be used to store thread names)
 
   static constexpr u32 STACK_MAGIC = 0xDEADBABE;
-  void Read(u32 addr);
-  bool IsValid() const;
+  void Read(const Core::CPUThreadGuard& guard, u32 addr);
+  bool IsValid(const Core::CPUThreadGuard& guard) const;
 };
 
 static_assert(std::is_trivially_copyable_v<OSThread>);
@@ -115,7 +120,7 @@ struct OSMutex
   OSMutexLink link;            // Used to traverse the thread's mutex queue
   // OSLockMutex uses it to insert the acquired mutex at the end of the queue
 
-  void Read(u32 addr);
+  void Read(const Core::CPUThreadGuard& guard, u32 addr);
 };
 
 static_assert(std::is_trivially_copyable_v<OSMutex>);
@@ -126,12 +131,12 @@ static_assert(offsetof(OSMutex, link) == 0x10);
 class OSThreadView : public Common::Debug::ThreadView
 {
 public:
-  explicit OSThreadView(u32 addr);
+  explicit OSThreadView(const Core::CPUThreadGuard& guard, u32 addr);
   ~OSThreadView() = default;
 
   const OSThread& Data() const;
 
-  Common::Debug::PartialContext GetContext() const override;
+  Common::Debug::PartialContext GetContext(const Core::CPUThreadGuard& guard) const override;
   u32 GetAddress() const override;
   u16 GetState() const override;
   bool IsSuspended() const override;
@@ -142,8 +147,8 @@ public:
   u32 GetStackEnd() const override;
   std::size_t GetStackSize() const override;
   s32 GetErrno() const override;
-  std::string GetSpecific() const override;
-  bool IsValid() const override;
+  std::string GetSpecific(const Core::CPUThreadGuard& guard) const override;
+  bool IsValid(const Core::CPUThreadGuard& guard) const override;
 
 private:
   u32 m_address = 0;

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -25,27 +25,28 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 
-void ApplyMemoryPatch(Common::Debug::MemoryPatch& patch, bool store_existing_value)
+void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, Common::Debug::MemoryPatch& patch,
+                      bool store_existing_value)
 {
   if (patch.value.empty())
     return;
 
   const u32 address = patch.address;
   const std::size_t size = patch.value.size();
-  if (!PowerPC::HostIsRAMAddress(address))
+  if (!PowerPC::HostIsRAMAddress(guard, address))
     return;
 
   for (u32 offset = 0; offset < size; ++offset)
   {
     if (store_existing_value)
     {
-      const u8 value = PowerPC::HostRead_U8(address + offset);
-      PowerPC::HostWrite_U8(patch.value[offset], address + offset);
+      const u8 value = PowerPC::HostRead_U8(guard, address + offset);
+      PowerPC::HostWrite_U8(guard, patch.value[offset], address + offset);
       patch.value[offset] = value;
     }
     else
     {
-      PowerPC::HostWrite_U8(patch.value[offset], address + offset);
+      PowerPC::HostWrite_U8(guard, patch.value[offset], address + offset);
     }
 
     if (((address + offset) % 4) == 3)
@@ -58,17 +59,17 @@ void ApplyMemoryPatch(Common::Debug::MemoryPatch& patch, bool store_existing_val
   }
 }
 
-void PPCPatches::ApplyExistingPatch(std::size_t index)
+void PPCPatches::ApplyExistingPatch(const Core::CPUThreadGuard& guard, std::size_t index)
 {
   auto& patch = m_patches[index];
-  ApplyMemoryPatch(patch, false);
+  ApplyMemoryPatch(guard, patch, false);
 }
 
-void PPCPatches::Patch(std::size_t index)
+void PPCPatches::Patch(const Core::CPUThreadGuard& guard, std::size_t index)
 {
   auto& patch = m_patches[index];
   if (patch.type == Common::Debug::MemoryPatch::ApplyType::Once)
-    ApplyMemoryPatch(patch);
+    ApplyMemoryPatch(guard, patch);
   else
     PatchEngine::AddMemoryPatch(index);
 }
@@ -163,24 +164,26 @@ void PPCDebugInterface::ClearWatches()
   m_watches.Clear();
 }
 
-void PPCDebugInterface::SetPatch(u32 address, u32 value)
+void PPCDebugInterface::SetPatch(const Core::CPUThreadGuard& guard, u32 address, u32 value)
 {
-  m_patches.SetPatch(address, value);
+  m_patches.SetPatch(guard, address, value);
 }
 
-void PPCDebugInterface::SetPatch(u32 address, std::vector<u8> value)
+void PPCDebugInterface::SetPatch(const Core::CPUThreadGuard& guard, u32 address,
+                                 std::vector<u8> value)
 {
-  m_patches.SetPatch(address, std::move(value));
+  m_patches.SetPatch(guard, address, std::move(value));
 }
 
-void PPCDebugInterface::SetFramePatch(u32 address, u32 value)
+void PPCDebugInterface::SetFramePatch(const Core::CPUThreadGuard& guard, u32 address, u32 value)
 {
-  m_patches.SetFramePatch(address, value);
+  m_patches.SetFramePatch(guard, address, value);
 }
 
-void PPCDebugInterface::SetFramePatch(u32 address, std::vector<u8> value)
+void PPCDebugInterface::SetFramePatch(const Core::CPUThreadGuard& guard, u32 address,
+                                      std::vector<u8> value)
 {
-  m_patches.SetFramePatch(address, std::move(value));
+  m_patches.SetFramePatch(guard, address, std::move(value));
 }
 
 const std::vector<Common::Debug::MemoryPatch>& PPCDebugInterface::GetPatches() const
@@ -188,19 +191,19 @@ const std::vector<Common::Debug::MemoryPatch>& PPCDebugInterface::GetPatches() c
   return m_patches.GetPatches();
 }
 
-void PPCDebugInterface::UnsetPatch(u32 address)
+void PPCDebugInterface::UnsetPatch(const Core::CPUThreadGuard& guard, u32 address)
 {
-  m_patches.UnsetPatch(address);
+  m_patches.UnsetPatch(guard, address);
 }
 
-void PPCDebugInterface::EnablePatch(std::size_t index)
+void PPCDebugInterface::EnablePatch(const Core::CPUThreadGuard& guard, std::size_t index)
 {
-  m_patches.EnablePatch(index);
+  m_patches.EnablePatch(guard, index);
 }
 
-void PPCDebugInterface::DisablePatch(std::size_t index)
+void PPCDebugInterface::DisablePatch(const Core::CPUThreadGuard& guard, std::size_t index)
 {
-  m_patches.DisablePatch(index);
+  m_patches.DisablePatch(guard, index);
 }
 
 bool PPCDebugInterface::HasEnabledPatch(u32 address) const
@@ -208,45 +211,45 @@ bool PPCDebugInterface::HasEnabledPatch(u32 address) const
   return m_patches.HasEnabledPatch(address);
 }
 
-void PPCDebugInterface::RemovePatch(std::size_t index)
+void PPCDebugInterface::RemovePatch(const Core::CPUThreadGuard& guard, std::size_t index)
 {
-  m_patches.RemovePatch(index);
+  m_patches.RemovePatch(guard, index);
 }
 
-void PPCDebugInterface::ClearPatches()
+void PPCDebugInterface::ClearPatches(const Core::CPUThreadGuard& guard)
 {
-  m_patches.ClearPatches();
+  m_patches.ClearPatches(guard);
 }
 
-void PPCDebugInterface::ApplyExistingPatch(std::size_t index)
+void PPCDebugInterface::ApplyExistingPatch(const Core::CPUThreadGuard& guard, std::size_t index)
 {
-  m_patches.ApplyExistingPatch(index);
+  m_patches.ApplyExistingPatch(guard, index);
 }
 
-Common::Debug::Threads PPCDebugInterface::GetThreads() const
+Common::Debug::Threads PPCDebugInterface::GetThreads(const Core::CPUThreadGuard& guard) const
 {
   Common::Debug::Threads threads;
 
   constexpr u32 ACTIVE_QUEUE_HEAD_ADDR = 0x800000dc;
-  if (!PowerPC::HostIsRAMAddress(ACTIVE_QUEUE_HEAD_ADDR))
+  if (!PowerPC::HostIsRAMAddress(guard, ACTIVE_QUEUE_HEAD_ADDR))
     return threads;
-  const u32 active_queue_head = PowerPC::HostRead_U32(ACTIVE_QUEUE_HEAD_ADDR);
-  if (!PowerPC::HostIsRAMAddress(active_queue_head))
+  const u32 active_queue_head = PowerPC::HostRead_U32(guard, ACTIVE_QUEUE_HEAD_ADDR);
+  if (!PowerPC::HostIsRAMAddress(guard, active_queue_head))
     return threads;
 
-  auto active_thread = std::make_unique<Core::Debug::OSThreadView>(active_queue_head);
-  if (!active_thread->IsValid())
+  auto active_thread = std::make_unique<Core::Debug::OSThreadView>(guard, active_queue_head);
+  if (!active_thread->IsValid(guard))
     return threads;
 
   std::vector<u32> visited_addrs{active_thread->GetAddress()};
-  const auto insert_threads = [&threads, &visited_addrs](u32 addr, auto get_next_addr) {
-    while (addr != 0 && PowerPC::HostIsRAMAddress(addr))
+  const auto insert_threads = [&guard, &threads, &visited_addrs](u32 addr, auto get_next_addr) {
+    while (addr != 0 && PowerPC::HostIsRAMAddress(guard, addr))
     {
       if (std::find(visited_addrs.begin(), visited_addrs.end(), addr) != visited_addrs.end())
         break;
       visited_addrs.push_back(addr);
-      auto thread = std::make_unique<Core::Debug::OSThreadView>(addr);
-      if (!thread->IsValid())
+      auto thread = std::make_unique<Core::Debug::OSThreadView>(guard, addr);
+      if (!thread->IsValid(guard))
         break;
       addr = get_next_addr(*thread);
       threads.emplace_back(std::move(thread));
@@ -264,20 +267,16 @@ Common::Debug::Threads PPCDebugInterface::GetThreads() const
   return threads;
 }
 
-std::string PPCDebugInterface::Disassemble(u32 address) const
+std::string PPCDebugInterface::Disassemble(const Core::CPUThreadGuard* guard, u32 address) const
 {
-  // PowerPC::HostRead_U32 seemed to crash on shutdown
-  if (!IsAlive())
-    return "";
-
-  if (Core::GetState() == Core::State::Paused)
+  if (guard)
   {
-    if (!PowerPC::HostIsRAMAddress(address))
+    if (!PowerPC::HostIsRAMAddress(*guard, address))
     {
       return "(No RAM here)";
     }
 
-    const u32 op = PowerPC::HostRead_Instruction(address);
+    const u32 op = PowerPC::HostRead_Instruction(*guard, address);
     std::string disasm = Common::GekkoDisassembler::Disassemble(op, address);
     const UGeckoInstruction inst{op};
 
@@ -294,14 +293,18 @@ std::string PPCDebugInterface::Disassemble(u32 address) const
   }
 }
 
-std::string PPCDebugInterface::GetRawMemoryString(int memory, u32 address) const
+std::string PPCDebugInterface::GetRawMemoryString(const Core::CPUThreadGuard& guard, int memory,
+                                                  u32 address) const
 {
   if (IsAlive())
   {
     const bool is_aram = memory != 0;
 
-    if (is_aram || PowerPC::HostIsRAMAddress(address))
-      return fmt::format("{:08X}{}", ReadExtraMemory(memory, address), is_aram ? " (ARAM)" : "");
+    if (is_aram || PowerPC::HostIsRAMAddress(guard, address))
+    {
+      return fmt::format("{:08X}{}", ReadExtraMemory(guard, memory, address),
+                         is_aram ? " (ARAM)" : "");
+    }
 
     return is_aram ? "--ARAM--" : "--------";
   }
@@ -309,17 +312,18 @@ std::string PPCDebugInterface::GetRawMemoryString(int memory, u32 address) const
   return "<unknwn>";  // bad spelling - 8 chars
 }
 
-u32 PPCDebugInterface::ReadMemory(u32 address) const
+u32 PPCDebugInterface::ReadMemory(const Core::CPUThreadGuard& guard, u32 address) const
 {
-  return PowerPC::HostRead_U32(address);
+  return PowerPC::HostRead_U32(guard, address);
 }
 
-u32 PPCDebugInterface::ReadExtraMemory(int memory, u32 address) const
+u32 PPCDebugInterface::ReadExtraMemory(const Core::CPUThreadGuard& guard, int memory,
+                                       u32 address) const
 {
   switch (memory)
   {
   case 0:
-    return PowerPC::HostRead_U32(address);
+    return PowerPC::HostRead_U32(guard, address);
   case 1:
     return (DSP::ReadARAM(address) << 24) | (DSP::ReadARAM(address + 1) << 16) |
            (DSP::ReadARAM(address + 2) << 8) | (DSP::ReadARAM(address + 3));
@@ -328,9 +332,9 @@ u32 PPCDebugInterface::ReadExtraMemory(int memory, u32 address) const
   }
 }
 
-u32 PPCDebugInterface::ReadInstruction(u32 address) const
+u32 PPCDebugInterface::ReadInstruction(const Core::CPUThreadGuard& guard, u32 address) const
 {
-  return PowerPC::HostRead_Instruction(address);
+  return PowerPC::HostRead_Instruction(guard, address);
 }
 
 bool PPCDebugInterface::IsAlive() const
@@ -401,11 +405,11 @@ void PPCDebugInterface::ToggleMemCheck(u32 address, bool read, bool write, bool 
 // =======================================================
 // Separate the blocks with colors.
 // -------------
-u32 PPCDebugInterface::GetColor(u32 address) const
+u32 PPCDebugInterface::GetColor(const Core::CPUThreadGuard* guard, u32 address) const
 {
-  if (!IsAlive())
+  if (!guard || !IsAlive())
     return 0xFFFFFF;
-  if (!PowerPC::HostIsRAMAddress(address))
+  if (!PowerPC::HostIsRAMAddress(*guard, address))
     return 0xeeeeee;
 
   Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
@@ -525,11 +529,11 @@ std::shared_ptr<Core::NetworkCaptureLogger> PPCDebugInterface::NetworkLogger()
   return m_network_logger;
 }
 
-void PPCDebugInterface::Clear()
+void PPCDebugInterface::Clear(const Core::CPUThreadGuard& guard)
 {
   ClearAllBreakpoints();
   ClearAllMemChecks();
-  ClearPatches();
+  ClearPatches(guard);
   ClearWatches();
   m_network_logger.reset();
 }

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -14,18 +14,20 @@
 
 namespace Core
 {
+class CPUThreadGuard;
 class System;
-}
+}  // namespace Core
 
-void ApplyMemoryPatch(Common::Debug::MemoryPatch& patch, bool store_existing_value = true);
+void ApplyMemoryPatch(const Core::CPUThreadGuard&, Common::Debug::MemoryPatch& patch,
+                      bool store_existing_value = true);
 
 class PPCPatches final : public Common::Debug::MemoryPatches
 {
 public:
-  void ApplyExistingPatch(std::size_t index) override;
+  void ApplyExistingPatch(const Core::CPUThreadGuard& guard, std::size_t index) override;
 
 private:
-  void Patch(std::size_t index) override;
+  void Patch(const Core::CPUThreadGuard& guard, std::size_t index) override;
   void UnPatch(std::size_t index) override;
 };
 
@@ -55,24 +57,26 @@ public:
   void ClearWatches() override;
 
   // Memory Patches
-  void SetPatch(u32 address, u32 value) override;
-  void SetPatch(u32 address, std::vector<u8> value) override;
-  void SetFramePatch(u32 address, u32 value) override;
-  void SetFramePatch(u32 address, std::vector<u8> value) override;
+  void SetPatch(const Core::CPUThreadGuard& guard, u32 address, u32 value) override;
+  void SetPatch(const Core::CPUThreadGuard& guard, u32 address, std::vector<u8> value) override;
+  void SetFramePatch(const Core::CPUThreadGuard& guard, u32 address, u32 value) override;
+  void SetFramePatch(const Core::CPUThreadGuard& guard, u32 address,
+                     std::vector<u8> value) override;
   const std::vector<Common::Debug::MemoryPatch>& GetPatches() const override;
-  void UnsetPatch(u32 address) override;
-  void EnablePatch(std::size_t index) override;
-  void DisablePatch(std::size_t index) override;
+  void UnsetPatch(const Core::CPUThreadGuard& guard, u32 address) override;
+  void EnablePatch(const Core::CPUThreadGuard& guard, std::size_t index) override;
+  void DisablePatch(const Core::CPUThreadGuard& guard, std::size_t index) override;
   bool HasEnabledPatch(u32 address) const override;
-  void RemovePatch(std::size_t index) override;
-  void ClearPatches() override;
-  void ApplyExistingPatch(std::size_t index) override;
+  void RemovePatch(const Core::CPUThreadGuard& guard, std::size_t index) override;
+  void ClearPatches(const Core::CPUThreadGuard& guard) override;
+  void ApplyExistingPatch(const Core::CPUThreadGuard& guard, std::size_t index) override;
 
   // Threads
-  Common::Debug::Threads GetThreads() const override;
+  Common::Debug::Threads GetThreads(const Core::CPUThreadGuard& guard) const override;
 
-  std::string Disassemble(u32 address) const override;
-  std::string GetRawMemoryString(int memory, u32 address) const override;
+  std::string Disassemble(const Core::CPUThreadGuard* guard, u32 address) const override;
+  std::string GetRawMemoryString(const Core::CPUThreadGuard& guard, int memory,
+                                 u32 address) const override;
   bool IsAlive() const override;
   bool IsBreakpoint(u32 address) const override;
   void SetBreakpoint(u32 address) override;
@@ -82,26 +86,26 @@ public:
   void ClearAllMemChecks() override;
   bool IsMemCheck(u32 address, size_t size = 1) const override;
   void ToggleMemCheck(u32 address, bool read = true, bool write = true, bool log = true) override;
-  u32 ReadMemory(u32 address) const override;
+  u32 ReadMemory(const Core::CPUThreadGuard& guard, u32 address) const override;
 
   enum
   {
     EXTRAMEM_ARAM = 1,
   };
 
-  u32 ReadExtraMemory(int memory, u32 address) const override;
-  u32 ReadInstruction(u32 address) const override;
+  u32 ReadExtraMemory(const Core::CPUThreadGuard& guard, int memory, u32 address) const override;
+  u32 ReadInstruction(const Core::CPUThreadGuard& guard, u32 address) const override;
   std::optional<u32> GetMemoryAddressFromInstruction(const std::string& instruction) const override;
   u32 GetPC() const override;
   void SetPC(u32 address) override;
   void Step() override {}
   void RunToBreakpoint() override;
-  u32 GetColor(u32 address) const override;
+  u32 GetColor(const Core::CPUThreadGuard* guard, u32 address) const override;
   std::string GetDescription(u32 address) const override;
 
   std::shared_ptr<Core::NetworkCaptureLogger> NetworkLogger();
 
-  void Clear() override;
+  void Clear(const Core::CPUThreadGuard& guard) override;
 
 private:
   Common::Debug::Watches m_watches;

--- a/Source/Core/Core/Debugger/RSO.cpp
+++ b/Source/Core/Core/Debugger/RSO.cpp
@@ -14,40 +14,40 @@
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 
-void RSOHeaderView::Load(u32 address)
+void RSOHeaderView::Load(const Core::CPUThreadGuard& guard, u32 address)
 {
   m_address = address;
-  m_header.entry.next_entry = PowerPC::HostRead_U32(address);
-  m_header.entry.prev_entry = PowerPC::HostRead_U32(address + 0x04);
-  m_header.entry.section_count = PowerPC::HostRead_U32(address + 0x08);
-  m_header.entry.section_table_offset = PowerPC::HostRead_U32(address + 0xC);
-  m_header.entry.name_offset = PowerPC::HostRead_U32(address + 0x10);
-  m_header.entry.name_size = PowerPC::HostRead_U32(address + 0x14);
-  m_header.entry.version = PowerPC::HostRead_U32(address + 0x18);
-  m_header.entry.bss_size = PowerPC::HostRead_U32(address + 0x1C);
-  m_header.section_info.prolog_section_index = PowerPC::HostRead_U8(address + 0x20);
-  m_header.section_info.epilog_section_index = PowerPC::HostRead_U8(address + 0x21);
-  m_header.section_info.unresolved_section_index = PowerPC::HostRead_U8(address + 0x22);
-  m_header.section_info.bss_section_index = PowerPC::HostRead_U8(address + 0x23);
-  m_header.section_info.prolog_offset = PowerPC::HostRead_U32(address + 0x24);
-  m_header.section_info.epilog_offset = PowerPC::HostRead_U32(address + 0x28);
-  m_header.section_info.unresolved_offset = PowerPC::HostRead_U32(address + 0x2C);
-  m_header.relocation_tables.internals_offset = PowerPC::HostRead_U32(address + 0x30);
-  m_header.relocation_tables.internals_size = PowerPC::HostRead_U32(address + 0x34);
-  m_header.relocation_tables.externals_offset = PowerPC::HostRead_U32(address + 0x38);
-  m_header.relocation_tables.externals_size = PowerPC::HostRead_U32(address + 0x3C);
-  m_header.symbol_tables.exports_offset = PowerPC::HostRead_U32(address + 0x40);
-  m_header.symbol_tables.exports_size = PowerPC::HostRead_U32(address + 0x44);
-  m_header.symbol_tables.exports_name_table = PowerPC::HostRead_U32(address + 0x48);
-  m_header.symbol_tables.imports_offset = PowerPC::HostRead_U32(address + 0x4C);
-  m_header.symbol_tables.imports_size = PowerPC::HostRead_U32(address + 0x50);
-  m_header.symbol_tables.imports_name_table = PowerPC::HostRead_U32(address + 0x54);
+  m_header.entry.next_entry = PowerPC::HostRead_U32(guard, address);
+  m_header.entry.prev_entry = PowerPC::HostRead_U32(guard, address + 0x04);
+  m_header.entry.section_count = PowerPC::HostRead_U32(guard, address + 0x08);
+  m_header.entry.section_table_offset = PowerPC::HostRead_U32(guard, address + 0xC);
+  m_header.entry.name_offset = PowerPC::HostRead_U32(guard, address + 0x10);
+  m_header.entry.name_size = PowerPC::HostRead_U32(guard, address + 0x14);
+  m_header.entry.version = PowerPC::HostRead_U32(guard, address + 0x18);
+  m_header.entry.bss_size = PowerPC::HostRead_U32(guard, address + 0x1C);
+  m_header.section_info.prolog_section_index = PowerPC::HostRead_U8(guard, address + 0x20);
+  m_header.section_info.epilog_section_index = PowerPC::HostRead_U8(guard, address + 0x21);
+  m_header.section_info.unresolved_section_index = PowerPC::HostRead_U8(guard, address + 0x22);
+  m_header.section_info.bss_section_index = PowerPC::HostRead_U8(guard, address + 0x23);
+  m_header.section_info.prolog_offset = PowerPC::HostRead_U32(guard, address + 0x24);
+  m_header.section_info.epilog_offset = PowerPC::HostRead_U32(guard, address + 0x28);
+  m_header.section_info.unresolved_offset = PowerPC::HostRead_U32(guard, address + 0x2C);
+  m_header.relocation_tables.internals_offset = PowerPC::HostRead_U32(guard, address + 0x30);
+  m_header.relocation_tables.internals_size = PowerPC::HostRead_U32(guard, address + 0x34);
+  m_header.relocation_tables.externals_offset = PowerPC::HostRead_U32(guard, address + 0x38);
+  m_header.relocation_tables.externals_size = PowerPC::HostRead_U32(guard, address + 0x3C);
+  m_header.symbol_tables.exports_offset = PowerPC::HostRead_U32(guard, address + 0x40);
+  m_header.symbol_tables.exports_size = PowerPC::HostRead_U32(guard, address + 0x44);
+  m_header.symbol_tables.exports_name_table = PowerPC::HostRead_U32(guard, address + 0x48);
+  m_header.symbol_tables.imports_offset = PowerPC::HostRead_U32(guard, address + 0x4C);
+  m_header.symbol_tables.imports_size = PowerPC::HostRead_U32(guard, address + 0x50);
+  m_header.symbol_tables.imports_name_table = PowerPC::HostRead_U32(guard, address + 0x54);
 
   // Prevent an invalid name going wild
   if (m_header.entry.name_size < 0x100)
-    m_name = PowerPC::HostGetString(m_header.entry.name_offset, m_header.entry.name_size);
+    m_name = PowerPC::HostGetString(guard, m_header.entry.name_offset, m_header.entry.name_size);
   else
-    m_name = PowerPC::HostGetString(m_header.entry.name_offset, 0x100);
+    m_name = PowerPC::HostGetString(guard, m_header.entry.name_offset, 0x100);
 }
 
 u32 RSOHeaderView::GetNextEntry() const
@@ -170,14 +170,14 @@ u32 RSOHeaderView::GetImportsNameTable() const
   return m_header.symbol_tables.imports_name_table;
 }
 
-void RSOSectionsView::Load(u32 address, std::size_t count)
+void RSOSectionsView::Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count)
 {
   m_address = address;
   for (std::size_t i = 0; i < count; ++i)
   {
     RSOSection section;
-    section.offset = PowerPC::HostRead_U32(address);
-    section.size = PowerPC::HostRead_U32(address + 4);
+    section.offset = PowerPC::HostRead_U32(guard, address);
+    section.size = PowerPC::HostRead_U32(guard, address + 4);
     m_sections.emplace_back(std::move(section));
     address += sizeof(RSOSection);
   }
@@ -198,15 +198,15 @@ const std::vector<RSOSection>& RSOSectionsView::GetSections() const
   return m_sections;
 }
 
-void RSOImportsView::Load(u32 address, std::size_t count)
+void RSOImportsView::Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count)
 {
   m_address = address;
   for (std::size_t i = 0; i < count; ++i)
   {
     RSOImport rso_import;
-    rso_import.name_offset = PowerPC::HostRead_U32(address);
-    rso_import.code_offset = PowerPC::HostRead_U32(address + 4);
-    rso_import.entry_offset = PowerPC::HostRead_U32(address + 8);
+    rso_import.name_offset = PowerPC::HostRead_U32(guard, address);
+    rso_import.code_offset = PowerPC::HostRead_U32(guard, address + 4);
+    rso_import.entry_offset = PowerPC::HostRead_U32(guard, address + 8);
     m_imports.emplace_back(std::move(rso_import));
     address += sizeof(RSOImport);
   }
@@ -227,16 +227,16 @@ const std::vector<RSOImport>& RSOImportsView::GetImports() const
   return m_imports;
 }
 
-void RSOExportsView::Load(u32 address, std::size_t count)
+void RSOExportsView::Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count)
 {
   m_address = address;
   for (std::size_t i = 0; i < count; ++i)
   {
     RSOExport rso_export;
-    rso_export.name_offset = PowerPC::HostRead_U32(address);
-    rso_export.code_offset = PowerPC::HostRead_U32(address + 4);
-    rso_export.section_index = PowerPC::HostRead_U32(address + 8);
-    rso_export.hash = PowerPC::HostRead_U32(address + 12);
+    rso_export.name_offset = PowerPC::HostRead_U32(guard, address);
+    rso_export.code_offset = PowerPC::HostRead_U32(guard, address + 4);
+    rso_export.section_index = PowerPC::HostRead_U32(guard, address + 8);
+    rso_export.hash = PowerPC::HostRead_U32(guard, address + 12);
     m_exports.emplace_back(std::move(rso_export));
     address += sizeof(RSOExport);
   }
@@ -257,15 +257,15 @@ const std::vector<RSOExport>& RSOExportsView::GetExports() const
   return m_exports;
 }
 
-void RSOInternalsView::Load(u32 address, std::size_t count)
+void RSOInternalsView::Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count)
 {
   m_address = address;
   for (std::size_t i = 0; i < count; ++i)
   {
     RSOInternalsEntry entry;
-    entry.r_offset = PowerPC::HostRead_U32(address);
-    entry.r_info = PowerPC::HostRead_U32(address + 4);
-    entry.r_addend = PowerPC::HostRead_U32(address + 8);
+    entry.r_offset = PowerPC::HostRead_U32(guard, address);
+    entry.r_info = PowerPC::HostRead_U32(guard, address + 4);
+    entry.r_addend = PowerPC::HostRead_U32(guard, address + 8);
     m_entries.emplace_back(std::move(entry));
     address += sizeof(RSOInternalsEntry);
   }
@@ -286,15 +286,15 @@ const std::vector<RSOInternalsEntry>& RSOInternalsView::GetEntries() const
   return m_entries;
 }
 
-void RSOExternalsView::Load(u32 address, std::size_t count)
+void RSOExternalsView::Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count)
 {
   m_address = address;
   for (std::size_t i = 0; i < count; ++i)
   {
     RSOExternalsEntry entry;
-    entry.r_offset = PowerPC::HostRead_U32(address);
-    entry.r_info = PowerPC::HostRead_U32(address + 4);
-    entry.r_addend = PowerPC::HostRead_U32(address + 8);
+    entry.r_offset = PowerPC::HostRead_U32(guard, address);
+    entry.r_info = PowerPC::HostRead_U32(guard, address + 4);
+    entry.r_addend = PowerPC::HostRead_U32(guard, address + 8);
     m_entries.emplace_back(std::move(entry));
     address += sizeof(RSOExternalsEntry);
   }
@@ -315,71 +315,71 @@ const std::vector<RSOExternalsEntry>& RSOExternalsView::GetEntries() const
   return m_entries;
 }
 
-void RSOView::LoadHeader(u32 address)
+void RSOView::LoadHeader(const Core::CPUThreadGuard& guard, u32 address)
 {
   m_address = address;
-  m_header.Load(address);
+  m_header.Load(guard, address);
 }
 
-void RSOView::LoadSections()
+void RSOView::LoadSections(const Core::CPUThreadGuard& guard)
 {
-  m_sections.Load(m_header.GetSectionTableOffset(), m_header.GetSectionCount());
+  m_sections.Load(guard, m_header.GetSectionTableOffset(), m_header.GetSectionCount());
 }
 
-void RSOView::LoadImports()
+void RSOView::LoadImports(const Core::CPUThreadGuard& guard)
 {
   const std::size_t size = m_header.GetImportsSize();
   if (size % sizeof(RSOImport) != 0)
     WARN_LOG_FMT(SYMBOLS, "RSO Imports Table has an incoherent size ({:08x})", size);
-  m_imports.Load(m_header.GetImportsOffset(), size / sizeof(RSOImport));
+  m_imports.Load(guard, m_header.GetImportsOffset(), size / sizeof(RSOImport));
 }
 
-void RSOView::LoadExports()
+void RSOView::LoadExports(const Core::CPUThreadGuard& guard)
 {
   const std::size_t size = m_header.GetExportsSize();
   if (size % sizeof(RSOExport) != 0)
     WARN_LOG_FMT(SYMBOLS, "RSO Exports Table has an incoherent size ({:08x})", size);
-  m_exports.Load(m_header.GetExportsOffset(), size / sizeof(RSOExport));
+  m_exports.Load(guard, m_header.GetExportsOffset(), size / sizeof(RSOExport));
 }
 
-void RSOView::LoadInternals()
+void RSOView::LoadInternals(const Core::CPUThreadGuard& guard)
 {
   const std::size_t size = m_header.GetInternalsSize();
   if (size % sizeof(RSOInternalsEntry) != 0)
     WARN_LOG_FMT(SYMBOLS, "RSO Internals Relocation Table has an incoherent size ({:08x})", size);
-  m_imports.Load(m_header.GetInternalsOffset(), size / sizeof(RSOInternalsEntry));
+  m_imports.Load(guard, m_header.GetInternalsOffset(), size / sizeof(RSOInternalsEntry));
 }
 
-void RSOView::LoadExternals()
+void RSOView::LoadExternals(const Core::CPUThreadGuard& guard)
 {
   const std::size_t size = m_header.GetExternalsSize();
   if (size % sizeof(RSOExternalsEntry) != 0)
     WARN_LOG_FMT(SYMBOLS, "RSO Externals Relocation Table has an incoherent size ({:08x})", size);
-  m_imports.Load(m_header.GetExternalsOffset(), size / sizeof(RSOExternalsEntry));
+  m_imports.Load(guard, m_header.GetExternalsOffset(), size / sizeof(RSOExternalsEntry));
 }
 
-void RSOView::LoadAll(u32 address)
+void RSOView::LoadAll(const Core::CPUThreadGuard& guard, u32 address)
 {
-  LoadHeader(address);
-  LoadSections();
-  LoadImports();
-  LoadExports();
-  LoadInternals();
-  LoadExternals();
+  LoadHeader(guard, address);
+  LoadSections(guard);
+  LoadImports(guard);
+  LoadExports(guard);
+  LoadInternals(guard);
+  LoadExternals(guard);
 }
 
-void RSOView::Apply(PPCSymbolDB* symbol_db) const
+void RSOView::Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) const
 {
   for (const RSOExport& rso_export : GetExports())
   {
     u32 address = GetExportAddress(rso_export);
     if (address != 0)
     {
-      Common::Symbol* symbol = symbol_db->AddFunction(address);
+      Common::Symbol* symbol = symbol_db->AddFunction(guard, address);
       if (!symbol)
         symbol = symbol_db->GetSymbolFromAddr(address);
 
-      const std::string export_name = GetExportName(rso_export);
+      const std::string export_name = GetExportName(guard, rso_export);
       if (symbol)
       {
         // Function symbol
@@ -388,7 +388,7 @@ void RSOView::Apply(PPCSymbolDB* symbol_db) const
       else
       {
         // Data symbol
-        symbol_db->AddKnownSymbol(address, 0, export_name, Common::Symbol::Type::Data);
+        symbol_db->AddKnownSymbol(guard, address, 0, export_name, Common::Symbol::Type::Data);
       }
     }
   }
@@ -440,9 +440,10 @@ const RSOImport& RSOView::GetImport(std::size_t index) const
   return m_imports.GetImport(index);
 }
 
-std::string RSOView::GetImportName(const RSOImport& rso_import) const
+std::string RSOView::GetImportName(const Core::CPUThreadGuard& guard,
+                                   const RSOImport& rso_import) const
 {
-  return PowerPC::HostGetString(m_header.GetImportsNameTable() + rso_import.name_offset);
+  return PowerPC::HostGetString(guard, m_header.GetImportsNameTable() + rso_import.name_offset);
 }
 
 const std::vector<RSOImport>& RSOView::GetImports() const
@@ -460,9 +461,10 @@ const RSOExport& RSOView::GetExport(std::size_t index) const
   return m_exports.GetExport(index);
 }
 
-std::string RSOView::GetExportName(const RSOExport& rso_export) const
+std::string RSOView::GetExportName(const Core::CPUThreadGuard& guard,
+                                   const RSOExport& rso_export) const
 {
-  return PowerPC::HostGetString(m_header.GetExportsNameTable() + rso_export.name_offset);
+  return PowerPC::HostGetString(guard, m_header.GetExportsNameTable() + rso_export.name_offset);
 }
 
 u32 RSOView::GetExportAddress(const RSOExport& rso_export) const
@@ -515,14 +517,14 @@ const std::string& RSOView::GetName() const
   return m_header.GetName();
 }
 
-std::string RSOView::GetName(const RSOImport& rso_import) const
+std::string RSOView::GetName(const Core::CPUThreadGuard& guard, const RSOImport& rso_import) const
 {
-  return GetImportName(rso_import);
+  return GetImportName(guard, rso_import);
 }
 
-std::string RSOView::GetName(const RSOExport& rso_export) const
+std::string RSOView::GetName(const Core::CPUThreadGuard& guard, const RSOExport& rso_export) const
 {
-  return GetExportName(rso_export);
+  return GetExportName(guard, rso_export);
 }
 
 u32 RSOView::GetProlog() const
@@ -561,33 +563,33 @@ u32 RSOView::GetUnresolved() const
   return 0;
 }
 
-bool RSOChainView::Load(u32 address)
+bool RSOChainView::Load(const Core::CPUThreadGuard& guard, u32 address)
 {
   // Load node
   RSOView node;
-  node.LoadHeader(address);
+  node.LoadHeader(guard, address);
   DEBUG_LOG_FMT(SYMBOLS, "RSOChain node name: {}", node.GetName());
   m_chain.emplace_front(std::move(node));
 
-  if (LoadNextChain(m_chain.front()) && LoadPrevChain(m_chain.front()))
+  if (LoadNextChain(guard, m_chain.front()) && LoadPrevChain(guard, m_chain.front()))
   {
     for (RSOView& view : m_chain)
     {
-      view.LoadSections();
-      view.LoadExports();
-      view.LoadImports();
-      view.LoadExternals();
-      view.LoadInternals();
+      view.LoadSections(guard);
+      view.LoadExports(guard);
+      view.LoadImports(guard);
+      view.LoadExternals(guard);
+      view.LoadInternals(guard);
     }
     return true;
   }
   return false;
 }
 
-void RSOChainView::Apply(PPCSymbolDB* symbol_db) const
+void RSOChainView::Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) const
 {
   for (const RSOView& rso_view : m_chain)
-    rso_view.Apply(symbol_db);
+    rso_view.Apply(guard, symbol_db);
 }
 
 void RSOChainView::Clear()
@@ -600,7 +602,7 @@ const std::list<RSOView>& RSOChainView::GetChain() const
   return m_chain;
 }
 
-bool RSOChainView::LoadNextChain(const RSOView& view)
+bool RSOChainView::LoadNextChain(const Core::CPUThreadGuard& guard, const RSOView& view)
 {
   u32 prev_address = view.GetAddress();
   u32 next_address = view.GetNextEntry();
@@ -608,7 +610,7 @@ bool RSOChainView::LoadNextChain(const RSOView& view)
   while (next_address != 0)
   {
     RSOView next_node;
-    next_node.LoadHeader(next_address);
+    next_node.LoadHeader(guard, next_address);
 
     if (prev_address != next_node.GetPrevEntry())
     {
@@ -625,7 +627,7 @@ bool RSOChainView::LoadNextChain(const RSOView& view)
   return true;
 }
 
-bool RSOChainView::LoadPrevChain(const RSOView& view)
+bool RSOChainView::LoadPrevChain(const Core::CPUThreadGuard& guard, const RSOView& view)
 {
   u32 prev_address = view.GetPrevEntry();
   u32 next_address = view.GetAddress();
@@ -633,7 +635,7 @@ bool RSOChainView::LoadPrevChain(const RSOView& view)
   while (prev_address != 0)
   {
     RSOView prev_node;
-    prev_node.LoadHeader(prev_address);
+    prev_node.LoadHeader(guard, prev_address);
 
     if (next_address != prev_node.GetNextEntry())
     {

--- a/Source/Core/Core/Debugger/RSO.h
+++ b/Source/Core/Core/Debugger/RSO.h
@@ -13,6 +13,11 @@
 
 class PPCSymbolDB;
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 struct RSOEntry
 {
   u32 next_entry;
@@ -103,7 +108,7 @@ using RSOExternalsEntry = RSORelocationTableEntry<RSORelocationTableType::Extern
 class RSOHeaderView
 {
 public:
-  void Load(u32 address);
+  void Load(const Core::CPUThreadGuard& guard, u32 address);
 
   u32 GetNextEntry() const;
   u32 GetPrevEntry() const;
@@ -139,7 +144,7 @@ private:
 class RSOSectionsView
 {
 public:
-  void Load(u32 address, std::size_t count = 1);
+  void Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count = 1);
   std::size_t Count() const;
 
   const RSOSection& GetSection(std::size_t index) const;
@@ -153,7 +158,7 @@ private:
 class RSOImportsView
 {
 public:
-  void Load(u32 address, std::size_t count = 1);
+  void Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count = 1);
   std::size_t Count() const;
 
   const RSOImport& GetImport(std::size_t index) const;
@@ -167,7 +172,7 @@ private:
 class RSOExportsView
 {
 public:
-  void Load(u32 address, std::size_t count = 1);
+  void Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count = 1);
   std::size_t Count() const;
 
   const RSOExport& GetExport(std::size_t index) const;
@@ -181,7 +186,7 @@ private:
 class RSOInternalsView
 {
 public:
-  void Load(u32 address, std::size_t count = 1);
+  void Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count = 1);
   std::size_t Count() const;
 
   const RSOInternalsEntry& GetEntry(std::size_t index) const;
@@ -195,7 +200,7 @@ private:
 class RSOExternalsView
 {
 public:
-  void Load(u32 address, std::size_t count = 1);
+  void Load(const Core::CPUThreadGuard& guard, u32 address, std::size_t count = 1);
   std::size_t Count() const;
 
   const RSOExternalsEntry& GetEntry(std::size_t index) const;
@@ -209,15 +214,15 @@ private:
 class RSOView
 {
 public:
-  void LoadHeader(u32 address);
-  void LoadSections();
-  void LoadImports();
-  void LoadExports();
-  void LoadInternals();
-  void LoadExternals();
-  void LoadAll(u32 address);
+  void LoadHeader(const Core::CPUThreadGuard& guard, u32 address);
+  void LoadSections(const Core::CPUThreadGuard& guard);
+  void LoadImports(const Core::CPUThreadGuard& guard);
+  void LoadExports(const Core::CPUThreadGuard& guard);
+  void LoadInternals(const Core::CPUThreadGuard& guard);
+  void LoadExternals(const Core::CPUThreadGuard& guard);
+  void LoadAll(const Core::CPUThreadGuard& guard, u32 address);
 
-  void Apply(PPCSymbolDB* symbol_db) const;
+  void Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) const;
 
   u32 GetNextEntry() const;
   u32 GetPrevEntry() const;
@@ -230,12 +235,12 @@ public:
 
   std::size_t GetImportsCount() const;
   const RSOImport& GetImport(std::size_t index) const;
-  std::string GetImportName(const RSOImport& rso_import) const;
+  std::string GetImportName(const Core::CPUThreadGuard& guard, const RSOImport& rso_import) const;
   const std::vector<RSOImport>& GetImports() const;
 
   std::size_t GetExportsCount() const;
   const RSOExport& GetExport(std::size_t index) const;
-  std::string GetExportName(const RSOExport& rso_export) const;
+  std::string GetExportName(const Core::CPUThreadGuard& guard, const RSOExport& rso_export) const;
   u32 GetExportAddress(const RSOExport& rso_export) const;
   const std::vector<RSOExport>& GetExports() const;
 
@@ -248,8 +253,8 @@ public:
   const std::vector<RSOExternalsEntry>& GetExternals() const;
 
   const std::string& GetName() const;
-  std::string GetName(const RSOImport& rso_import) const;
-  std::string GetName(const RSOExport& rso_export) const;
+  std::string GetName(const Core::CPUThreadGuard& guard, const RSOImport& rso_import) const;
+  std::string GetName(const Core::CPUThreadGuard& guard, const RSOExport& rso_export) const;
 
   u32 GetProlog() const;
   u32 GetEpilog() const;
@@ -268,14 +273,14 @@ private:
 class RSOChainView
 {
 public:
-  bool Load(u32 address);
-  void Apply(PPCSymbolDB* symbol_db) const;
+  bool Load(const Core::CPUThreadGuard& guard, u32 address);
+  void Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) const;
   void Clear();
   const std::list<RSOView>& GetChain() const;
 
 private:
-  bool LoadNextChain(const RSOView& view);
-  bool LoadPrevChain(const RSOView& view);
+  bool LoadNextChain(const Core::CPUThreadGuard& guard, const RSOView& view);
+  bool LoadPrevChain(const Core::CPUThreadGuard& guard, const RSOView& view);
 
   std::list<RSOView> m_chain;
 };

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -11,6 +11,11 @@
 
 class PointerWrap;
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 namespace Gecko
 {
 class GeckoCode
@@ -63,7 +68,7 @@ void SetActiveCodes(std::span<const GeckoCode> gcodes);
 void SetSyncedCodesAsActive();
 void UpdateSyncedCodes(std::span<const GeckoCode> gcodes);
 std::vector<GeckoCode> SetAndReturnActiveCodes(std::span<const GeckoCode> gcodes);
-void RunCodeHandler();
+void RunCodeHandler(const Core::CPUThreadGuard& guard);
 void Shutdown();
 void DoState(PointerWrap&);
 

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -152,12 +152,12 @@ void Reload(Core::System& system)
   PatchFunctions(system);
 }
 
-void Execute(u32 current_pc, u32 hook_index)
+void Execute(const Core::CPUThreadGuard& guard, u32 current_pc, u32 hook_index)
 {
   hook_index &= 0xFFFFF;
   if (hook_index > 0 && hook_index < os_patches.size())
   {
-    os_patches[hook_index].function();
+    os_patches[hook_index].function(guard);
   }
   else
   {

--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -9,12 +9,13 @@
 
 namespace Core
 {
+class CPUThreadGuard;
 class System;
-}
+}  // namespace Core
 
 namespace HLE
 {
-using HookFunction = void (*)();
+using HookFunction = void (*)(const Core::CPUThreadGuard&);
 
 enum class HookType
 {
@@ -46,7 +47,7 @@ void Reload(Core::System& system);
 void Patch(Core::System& system, u32 pc, std::string_view func_name);
 u32 UnPatch(Core::System& system, std::string_view patch_name);
 u32 UnpatchRange(Core::System& system, u32 start_addr, u32 end_addr);
-void Execute(u32 current_pc, u32 hook_index);
+void Execute(const Core::CPUThreadGuard& guard, u32 current_pc, u32 hook_index);
 
 // Returns the HLE hook index of the address
 u32 GetHookByAddress(u32 address);

--- a/Source/Core/Core/HLE/HLE_Misc.h
+++ b/Source/Core/Core/HLE/HLE_Misc.h
@@ -3,10 +3,15 @@
 
 #pragma once
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 namespace HLE_Misc
 {
-void UnimplementedFunction();
-void HBReload();
-void GeckoCodeHandlerICacheFlush();
-void GeckoReturnTrampoline();
+void UnimplementedFunction(const Core::CPUThreadGuard& guard);
+void HBReload(const Core::CPUThreadGuard& guard);
+void GeckoCodeHandlerICacheFlush(const Core::CPUThreadGuard& guard);
+void GeckoReturnTrampoline(const Core::CPUThreadGuard& guard);
 }  // namespace HLE_Misc

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -23,19 +23,19 @@ enum class ParameterType : bool
   VariableArgumentList = true
 };
 
-std::string GetStringVA(Core::System& system, u32 str_reg = 3,
+std::string GetStringVA(Core::System& system, const Core::CPUThreadGuard& guard, u32 str_reg = 3,
                         ParameterType parameter_type = ParameterType::ParameterList);
-void HLE_GeneralDebugPrint(ParameterType parameter_type);
-void HLE_LogDPrint(ParameterType parameter_type);
-void HLE_LogFPrint(ParameterType parameter_type);
+void HLE_GeneralDebugPrint(const Core::CPUThreadGuard& guard, ParameterType parameter_type);
+void HLE_LogDPrint(const Core::CPUThreadGuard& guard, ParameterType parameter_type);
+void HLE_LogFPrint(const Core::CPUThreadGuard& guard, ParameterType parameter_type);
 
-void HLE_OSPanic()
+void HLE_OSPanic(const Core::CPUThreadGuard& guard)
 {
   auto& system = Core::System::GetInstance();
   auto& ppc_state = system.GetPPCState();
 
-  std::string error = GetStringVA(system);
-  std::string msg = GetStringVA(system, 5);
+  std::string error = GetStringVA(system, guard);
+  std::string msg = GetStringVA(system, guard, 5);
 
   StringPopBackIf(&error, '\n');
   StringPopBackIf(&msg, '\n');
@@ -48,7 +48,7 @@ void HLE_OSPanic()
 }
 
 // Generalized function for printing formatted string.
-void HLE_GeneralDebugPrint(ParameterType parameter_type)
+void HLE_GeneralDebugPrint(const Core::CPUThreadGuard& guard, ParameterType parameter_type)
 {
   auto& system = Core::System::GetInstance();
   auto& ppc_state = system.GetPPCState();
@@ -56,32 +56,32 @@ void HLE_GeneralDebugPrint(ParameterType parameter_type)
   std::string report_message;
 
   // Is gpr3 pointing to a pointer (including nullptr) rather than an ASCII string
-  if (PowerPC::HostIsRAMAddress(ppc_state.gpr[3]) &&
-      (PowerPC::HostIsRAMAddress(PowerPC::HostRead_U32(ppc_state.gpr[3])) ||
-       PowerPC::HostRead_U32(ppc_state.gpr[3]) == 0))
+  if (PowerPC::HostIsRAMAddress(guard, ppc_state.gpr[3]) &&
+      (PowerPC::HostIsRAMAddress(guard, PowerPC::HostRead_U32(guard, ppc_state.gpr[3])) ||
+       PowerPC::HostRead_U32(guard, ppc_state.gpr[3]) == 0))
   {
-    if (PowerPC::HostIsRAMAddress(ppc_state.gpr[4]))
+    if (PowerPC::HostIsRAMAddress(guard, ppc_state.gpr[4]))
     {
       // ___blank(void* this, const char* fmt, ...);
-      report_message = GetStringVA(system, 4, parameter_type);
+      report_message = GetStringVA(system, guard, 4, parameter_type);
     }
     else
     {
       // ___blank(void* this, int log_type, const char* fmt, ...);
-      report_message = GetStringVA(system, 5, parameter_type);
+      report_message = GetStringVA(system, guard, 5, parameter_type);
     }
   }
   else
   {
-    if (PowerPC::HostIsRAMAddress(ppc_state.gpr[3]))
+    if (PowerPC::HostIsRAMAddress(guard, ppc_state.gpr[3]))
     {
       // ___blank(const char* fmt, ...);
-      report_message = GetStringVA(system, 3, parameter_type);
+      report_message = GetStringVA(system, guard, 3, parameter_type);
     }
     else
     {
       // ___blank(int log_type, const char* fmt, ...);
-      report_message = GetStringVA(system, 4, parameter_type);
+      report_message = GetStringVA(system, guard, 4, parameter_type);
     }
   }
 
@@ -92,25 +92,25 @@ void HLE_GeneralDebugPrint(ParameterType parameter_type)
 }
 
 // Generalized function for printing formatted string using parameter list.
-void HLE_GeneralDebugPrint()
+void HLE_GeneralDebugPrint(const Core::CPUThreadGuard& guard)
 {
-  HLE_GeneralDebugPrint(ParameterType::ParameterList);
+  HLE_GeneralDebugPrint(guard, ParameterType::ParameterList);
 }
 
 // Generalized function for printing formatted string using va_list.
-void HLE_GeneralDebugVPrint()
+void HLE_GeneralDebugVPrint(const Core::CPUThreadGuard& guard)
 {
-  HLE_GeneralDebugPrint(ParameterType::VariableArgumentList);
+  HLE_GeneralDebugPrint(guard, ParameterType::VariableArgumentList);
 }
 
 // __write_console(int fd, const void* buffer, const u32* size)
-void HLE_write_console()
+void HLE_write_console(const Core::CPUThreadGuard& guard)
 {
   auto& system = Core::System::GetInstance();
   auto& ppc_state = system.GetPPCState();
 
-  std::string report_message = GetStringVA(system, 4);
-  if (PowerPC::HostIsRAMAddress(ppc_state.gpr[5]))
+  std::string report_message = GetStringVA(system, guard, 4);
+  if (PowerPC::HostIsRAMAddress(guard, ppc_state.gpr[5]))
   {
     const u32 size = PowerPC::Read_U32(ppc_state.gpr[5]);
     if (size > report_message.size())
@@ -132,7 +132,7 @@ void HLE_write_console()
 }
 
 // Log (v)dprintf message if fd is 1 (stdout) or 2 (stderr)
-void HLE_LogDPrint(ParameterType parameter_type)
+void HLE_LogDPrint(const Core::CPUThreadGuard& guard, ParameterType parameter_type)
 {
   auto& system = Core::System::GetInstance();
   auto& ppc_state = system.GetPPCState();
@@ -140,7 +140,7 @@ void HLE_LogDPrint(ParameterType parameter_type)
   if (ppc_state.gpr[3] != 1 && ppc_state.gpr[3] != 2)
     return;
 
-  std::string report_message = GetStringVA(system, 4, parameter_type);
+  std::string report_message = GetStringVA(system, guard, 4, parameter_type);
   StringPopBackIf(&report_message, '\n');
   NOTICE_LOG_FMT(OSREPORT_HLE, "{:08x}->{:08x}| {}", LR(ppc_state), ppc_state.pc,
                  SHIFTJISToUTF8(report_message));
@@ -148,20 +148,20 @@ void HLE_LogDPrint(ParameterType parameter_type)
 
 // Log dprintf message
 //  -> int dprintf(int fd, const char* format, ...);
-void HLE_LogDPrint()
+void HLE_LogDPrint(const Core::CPUThreadGuard& guard)
 {
-  HLE_LogDPrint(ParameterType::ParameterList);
+  HLE_LogDPrint(guard, ParameterType::ParameterList);
 }
 
 // Log vdprintf message
 //  -> int vdprintf(int fd, const char* format, va_list ap);
-void HLE_LogVDPrint()
+void HLE_LogVDPrint(const Core::CPUThreadGuard& guard)
 {
-  HLE_LogDPrint(ParameterType::VariableArgumentList);
+  HLE_LogDPrint(guard, ParameterType::VariableArgumentList);
 }
 
 // Log (v)fprintf message if FILE is stdout or stderr
-void HLE_LogFPrint(ParameterType parameter_type)
+void HLE_LogFPrint(const Core::CPUThreadGuard& guard, ParameterType parameter_type)
 {
   auto& system = Core::System::GetInstance();
   auto& ppc_state = system.GetPPCState();
@@ -169,21 +169,21 @@ void HLE_LogFPrint(ParameterType parameter_type)
   // The structure FILE is implementation defined.
   // Both libogc and Dolphin SDK seem to store the fd at the same address.
   int fd = -1;
-  if (PowerPC::HostIsRAMAddress(ppc_state.gpr[3]) &&
-      PowerPC::HostIsRAMAddress(ppc_state.gpr[3] + 0xF))
+  if (PowerPC::HostIsRAMAddress(guard, ppc_state.gpr[3]) &&
+      PowerPC::HostIsRAMAddress(guard, ppc_state.gpr[3] + 0xF))
   {
     // The fd is stored as a short at FILE+0xE.
-    fd = static_cast<short>(PowerPC::HostRead_U16(ppc_state.gpr[3] + 0xE));
+    fd = static_cast<short>(PowerPC::HostRead_U16(guard, ppc_state.gpr[3] + 0xE));
   }
   if (fd != 1 && fd != 2)
   {
     // On RVL SDK it seems stored at FILE+0x2.
-    fd = static_cast<short>(PowerPC::HostRead_U16(ppc_state.gpr[3] + 0x2));
+    fd = static_cast<short>(PowerPC::HostRead_U16(guard, ppc_state.gpr[3] + 0x2));
   }
   if (fd != 1 && fd != 2)
     return;
 
-  std::string report_message = GetStringVA(system, 4, parameter_type);
+  std::string report_message = GetStringVA(system, guard, 4, parameter_type);
   StringPopBackIf(&report_message, '\n');
   NOTICE_LOG_FMT(OSREPORT_HLE, "{:08x}->{:08x}| {}", LR(ppc_state), ppc_state.pc,
                  SHIFTJISToUTF8(report_message));
@@ -191,28 +191,30 @@ void HLE_LogFPrint(ParameterType parameter_type)
 
 // Log fprintf message
 //  -> int fprintf(FILE* stream, const char* format, ...);
-void HLE_LogFPrint()
+void HLE_LogFPrint(const Core::CPUThreadGuard& guard)
 {
-  HLE_LogFPrint(ParameterType::ParameterList);
+  HLE_LogFPrint(guard, ParameterType::ParameterList);
 }
 
 // Log vfprintf message
 //  -> int vfprintf(FILE* stream, const char* format, va_list ap);
-void HLE_LogVFPrint()
+void HLE_LogVFPrint(const Core::CPUThreadGuard& guard)
 {
-  HLE_LogFPrint(ParameterType::VariableArgumentList);
+  HLE_LogFPrint(guard, ParameterType::VariableArgumentList);
 }
 
-std::string GetStringVA(Core::System& system, u32 str_reg, ParameterType parameter_type)
+std::string GetStringVA(Core::System& system, const Core::CPUThreadGuard& guard, u32 str_reg,
+                        ParameterType parameter_type)
 {
   auto& ppc_state = system.GetPPCState();
 
   std::string ArgumentBuffer;
   std::string result;
-  std::string string = PowerPC::HostGetString(ppc_state.gpr[str_reg]);
+  std::string string = PowerPC::HostGetString(guard, ppc_state.gpr[str_reg]);
   auto ap =
       parameter_type == ParameterType::VariableArgumentList ?
-          std::make_unique<HLE::SystemVABI::VAListStruct>(system, ppc_state.gpr[str_reg + 1]) :
+          std::make_unique<HLE::SystemVABI::VAListStruct>(system, guard,
+                                                          ppc_state.gpr[str_reg + 1]) :
           std::make_unique<HLE::SystemVABI::VAList>(system, ppc_state.gpr[1] + 0x8, str_reg + 1);
 
   for (size_t i = 0; i < string.size(); i++)
@@ -241,7 +243,7 @@ std::string GetStringVA(Core::System& system, u32 str_reg, ParameterType paramet
       {
       case 's':
         result += StringFromFormat(ArgumentBuffer.c_str(),
-                                   PowerPC::HostGetString(ap->GetArgT<u32>()).c_str());
+                                   PowerPC::HostGetString(guard, ap->GetArgT<u32>(guard)).c_str());
         break;
 
       case 'a':
@@ -252,12 +254,12 @@ std::string GetStringVA(Core::System& system, u32 str_reg, ParameterType paramet
       case 'F':
       case 'g':
       case 'G':
-        result += StringFromFormat(ArgumentBuffer.c_str(), ap->GetArgT<double>());
+        result += StringFromFormat(ArgumentBuffer.c_str(), ap->GetArgT<double>(guard));
         break;
 
       case 'p':
         // Override, so 64bit Dolphin prints 32bit pointers, since the ppc is 32bit :)
-        result += StringFromFormat("%x", ap->GetArgT<u32>());
+        result += StringFromFormat("%x", ap->GetArgT<u32>(guard));
         break;
 
       case 'n':
@@ -267,9 +269,9 @@ std::string GetStringVA(Core::System& system, u32 str_reg, ParameterType paramet
 
       default:
         if (string[i - 1] == 'l' && string[i - 2] == 'l')
-          result += StringFromFormat(ArgumentBuffer.c_str(), ap->GetArgT<u64>());
+          result += StringFromFormat(ArgumentBuffer.c_str(), ap->GetArgT<u64>(guard));
         else
-          result += StringFromFormat(ArgumentBuffer.c_str(), ap->GetArgT<u32>());
+          result += StringFromFormat(ArgumentBuffer.c_str(), ap->GetArgT<u32>(guard));
         break;
       }
     }

--- a/Source/Core/Core/HLE/HLE_OS.h
+++ b/Source/Core/Core/HLE/HLE_OS.h
@@ -3,14 +3,19 @@
 
 #pragma once
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 namespace HLE_OS
 {
-void HLE_GeneralDebugPrint();
-void HLE_GeneralDebugVPrint();
-void HLE_write_console();
-void HLE_OSPanic();
-void HLE_LogDPrint();
-void HLE_LogVDPrint();
-void HLE_LogFPrint();
-void HLE_LogVFPrint();
+void HLE_GeneralDebugPrint(const Core::CPUThreadGuard& guard);
+void HLE_GeneralDebugVPrint(const Core::CPUThreadGuard& guard);
+void HLE_write_console(const Core::CPUThreadGuard& guard);
+void HLE_OSPanic(const Core::CPUThreadGuard& guard);
+void HLE_LogDPrint(const Core::CPUThreadGuard& guard);
+void HLE_LogVDPrint(const Core::CPUThreadGuard& guard);
+void HLE_LogFPrint(const Core::CPUThreadGuard& guard);
+void HLE_LogVFPrint(const Core::CPUThreadGuard& guard);
 }  // namespace HLE_OS

--- a/Source/Core/Core/HW/AddressSpace.cpp
+++ b/Source/Core/Core/HW/AddressSpace.cpp
@@ -14,48 +14,48 @@
 
 namespace AddressSpace
 {
-u16 Accessors::ReadU16(u32 address) const
+u16 Accessors::ReadU16(const Core::CPUThreadGuard& guard, u32 address) const
 {
-  u32 result = ReadU8(address);
-  result = result << 8 | ReadU8(address + 1);
+  u32 result = ReadU8(guard, address);
+  result = result << 8 | ReadU8(guard, address + 1);
   return result;
 }
 
-void Accessors::WriteU16(u32 address, u16 value)
+void Accessors::WriteU16(const Core::CPUThreadGuard& guard, u32 address, u16 value)
 {
-  WriteU8(address, value & 0xff);
-  WriteU8(address + 1, (value >> 8) & 0xff);
+  WriteU8(guard, address, value & 0xff);
+  WriteU8(guard, address + 1, (value >> 8) & 0xff);
 }
 
-u32 Accessors::ReadU32(u32 address) const
+u32 Accessors::ReadU32(const Core::CPUThreadGuard& guard, u32 address) const
 {
-  u32 result = ReadU16(address);
-  result = result << 16 | ReadU16(address + 2);
+  u32 result = ReadU16(guard, address);
+  result = result << 16 | ReadU16(guard, address + 2);
   return result;
 }
 
-void Accessors::WriteU32(u32 address, u32 value)
+void Accessors::WriteU32(const Core::CPUThreadGuard& guard, u32 address, u32 value)
 {
-  WriteU16(address, value & 0xffff);
-  WriteU16(address + 2, (value >> 16) & 0xffff);
+  WriteU16(guard, address, value & 0xffff);
+  WriteU16(guard, address + 2, (value >> 16) & 0xffff);
 }
 
-u64 Accessors::ReadU64(u32 address) const
+u64 Accessors::ReadU64(const Core::CPUThreadGuard& guard, u32 address) const
 {
-  u64 result = ReadU32(address);
-  result = result << 32 | ReadU32(address + 4);
+  u64 result = ReadU32(guard, address);
+  result = result << 32 | ReadU32(guard, address + 4);
   return result;
 }
 
-void Accessors::WriteU64(u32 address, u64 value)
+void Accessors::WriteU64(const Core::CPUThreadGuard& guard, u32 address, u64 value)
 {
-  WriteU32(address, value & 0xffffffff);
-  WriteU32(address + 4, (value >> 32) & 0xffffffff);
+  WriteU32(guard, address, value & 0xffffffff);
+  WriteU32(guard, address + 4, (value >> 32) & 0xffffffff);
 }
 
-float Accessors::ReadF32(u32 address) const
+float Accessors::ReadF32(const Core::CPUThreadGuard& guard, u32 address) const
 {
-  return Common::BitCast<float>(ReadU32(address));
+  return Common::BitCast<float>(ReadU32(guard, address));
 }
 
 Accessors::iterator Accessors::begin() const
@@ -68,8 +68,9 @@ Accessors::iterator Accessors::end() const
   return nullptr;
 }
 
-std::optional<u32> Accessors::Search(u32 haystack_start, const u8* needle_start,
-                                     std::size_t needle_size, bool forwards) const
+std::optional<u32> Accessors::Search(const Core::CPUThreadGuard& guard, u32 haystack_start,
+                                     const u8* needle_start, std::size_t needle_size,
+                                     bool forwards) const
 {
   return std::nullopt;
 }
@@ -80,18 +81,49 @@ Accessors::~Accessors()
 
 struct EffectiveAddressSpaceAccessors : Accessors
 {
-  bool IsValidAddress(u32 address) const override { return PowerPC::HostIsRAMAddress(address); }
-  u8 ReadU8(u32 address) const override { return PowerPC::HostRead_U8(address); }
-  void WriteU8(u32 address, u8 value) override { PowerPC::HostWrite_U8(value, address); }
-  u16 ReadU16(u32 address) const override { return PowerPC::HostRead_U16(address); }
-  void WriteU16(u32 address, u16 value) override { PowerPC::HostWrite_U16(value, address); }
-  u32 ReadU32(u32 address) const override { return PowerPC::HostRead_U32(address); }
-  void WriteU32(u32 address, u32 value) override { PowerPC::HostWrite_U32(value, address); }
-  u64 ReadU64(u32 address) const override { return PowerPC::HostRead_U64(address); }
-  void WriteU64(u32 address, u64 value) override { PowerPC::HostWrite_U64(value, address); }
-  float ReadF32(u32 address) const override { return PowerPC::HostRead_F32(address); };
+  bool IsValidAddress(const Core::CPUThreadGuard& guard, u32 address) const override
+  {
+    return PowerPC::HostIsRAMAddress(guard, address);
+  }
+  u8 ReadU8(const Core::CPUThreadGuard& guard, u32 address) const override
+  {
+    return PowerPC::HostRead_U8(guard, address);
+  }
+  void WriteU8(const Core::CPUThreadGuard& guard, u32 address, u8 value) override
+  {
+    PowerPC::HostWrite_U8(guard, value, address);
+  }
+  u16 ReadU16(const Core::CPUThreadGuard& guard, u32 address) const override
+  {
+    return PowerPC::HostRead_U16(guard, address);
+  }
+  void WriteU16(const Core::CPUThreadGuard& guard, u32 address, u16 value) override
+  {
+    PowerPC::HostWrite_U16(guard, value, address);
+  }
+  u32 ReadU32(const Core::CPUThreadGuard& guard, u32 address) const override
+  {
+    return PowerPC::HostRead_U32(guard, address);
+  }
+  void WriteU32(const Core::CPUThreadGuard& guard, u32 address, u32 value) override
+  {
+    PowerPC::HostWrite_U32(guard, value, address);
+  }
+  u64 ReadU64(const Core::CPUThreadGuard& guard, u32 address) const override
+  {
+    return PowerPC::HostRead_U64(guard, address);
+  }
+  void WriteU64(const Core::CPUThreadGuard& guard, u32 address, u64 value) override
+  {
+    PowerPC::HostWrite_U64(guard, value, address);
+  }
+  float ReadF32(const Core::CPUThreadGuard& guard, u32 address) const override
+  {
+    return PowerPC::HostRead_F32(guard, address);
+  };
 
-  bool Matches(u32 haystack_start, const u8* needle_start, std::size_t needle_size) const
+  bool Matches(const Core::CPUThreadGuard& guard, u32 haystack_start, const u8* needle_start,
+               std::size_t needle_size) const
   {
     auto& system = Core::System::GetInstance();
     auto& memory = system.GetMemory();
@@ -100,7 +132,7 @@ struct EffectiveAddressSpaceAccessors : Accessors
     u32 offset = haystack_start & 0x0000fff;
     do
     {
-      if (!PowerPC::HostIsRAMAddress(page_base))
+      if (!PowerPC::HostIsRAMAddress(guard, page_base))
       {
         return false;
       }
@@ -137,7 +169,8 @@ struct EffectiveAddressSpaceAccessors : Accessors
     return (needle_size == 0);
   }
 
-  std::optional<u32> Search(u32 haystack_start, const u8* needle_start, std::size_t needle_size,
+  std::optional<u32> Search(const Core::CPUThreadGuard& guard, u32 haystack_start,
+                            const u8* needle_start, std::size_t needle_size,
                             bool forward) const override
   {
     u32 haystack_address = haystack_start;
@@ -150,11 +183,11 @@ struct EffectiveAddressSpaceAccessors : Accessors
     const u32 haystack_offset_change = forward ? 1 : -1;
     do
     {
-      if (PowerPC::HostIsRAMAddress(haystack_address))
+      if (PowerPC::HostIsRAMAddress(guard, haystack_address))
       {
         do
         {
-          if (Matches(haystack_address, needle_start, needle_size))
+          if (Matches(guard, haystack_address, needle_start, needle_size))
           {
             return std::optional<u32>(haystack_address);
           }
@@ -173,17 +206,17 @@ struct EffectiveAddressSpaceAccessors : Accessors
 struct AuxiliaryAddressSpaceAccessors : Accessors
 {
   static constexpr u32 aram_base_address = 0;
-  bool IsValidAddress(u32 address) const override
+  bool IsValidAddress(const Core::CPUThreadGuard& guard, u32 address) const override
   {
     return !SConfig::GetInstance().bWii && (address - aram_base_address) < GetSize();
   }
-  u8 ReadU8(u32 address) const override
+  u8 ReadU8(const Core::CPUThreadGuard& guard, u32 address) const override
   {
     const u8* base = DSP::GetARAMPtr();
     return base[address];
   }
 
-  void WriteU8(u32 address, u8 value) override
+  void WriteU8(const Core::CPUThreadGuard& guard, u32 address, u8 value) override
   {
     u8* base = DSP::GetARAMPtr();
     base[address] = value;
@@ -193,10 +226,11 @@ struct AuxiliaryAddressSpaceAccessors : Accessors
 
   iterator end() const override { return DSP::GetARAMPtr() + GetSize(); }
 
-  std::optional<u32> Search(u32 haystack_offset, const u8* needle_start, std::size_t needle_size,
+  std::optional<u32> Search(const Core::CPUThreadGuard& guard, u32 haystack_offset,
+                            const u8* needle_start, std::size_t needle_size,
                             bool forward) const override
   {
-    if (!IsValidAddress(haystack_offset))
+    if (!IsValidAddress(guard, haystack_offset))
     {
       return std::nullopt;
     }
@@ -243,42 +277,44 @@ struct CompositeAddressSpaceAccessors : Accessors
   {
   }
 
-  bool IsValidAddress(u32 address) const override
+  bool IsValidAddress(const Core::CPUThreadGuard& guard, u32 address) const override
   {
-    return FindAppropriateAccessor(address) != m_accessor_mappings.end();
+    return FindAppropriateAccessor(guard, address) != m_accessor_mappings.end();
   }
 
-  u8 ReadU8(u32 address) const override
+  u8 ReadU8(const Core::CPUThreadGuard& guard, u32 address) const override
   {
-    auto mapping = FindAppropriateAccessor(address);
+    auto mapping = FindAppropriateAccessor(guard, address);
     if (mapping == m_accessor_mappings.end())
     {
       return 0;
     }
-    return mapping->accessors->ReadU8(address - mapping->base);
+    return mapping->accessors->ReadU8(guard, address - mapping->base);
   }
 
-  void WriteU8(u32 address, u8 value) override
+  void WriteU8(const Core::CPUThreadGuard& guard, u32 address, u8 value) override
   {
-    auto mapping = FindAppropriateAccessor(address);
+    auto mapping = FindAppropriateAccessor(guard, address);
     if (mapping == m_accessor_mappings.end())
     {
       return;
     }
-    return mapping->accessors->WriteU8(address - mapping->base, value);
+    return mapping->accessors->WriteU8(guard, address - mapping->base, value);
   }
 
-  std::optional<u32> Search(u32 haystack_offset, const u8* needle_start, std::size_t needle_size,
+  std::optional<u32> Search(const Core::CPUThreadGuard& guard, u32 haystack_offset,
+                            const u8* needle_start, std::size_t needle_size,
                             bool forward) const override
   {
     for (const AccessorMapping& mapping : m_accessor_mappings)
     {
       u32 mapping_offset = haystack_offset - mapping.base;
-      if (!mapping.accessors->IsValidAddress(mapping_offset))
+      if (!mapping.accessors->IsValidAddress(guard, mapping_offset))
       {
         continue;
       }
-      auto result = mapping.accessors->Search(mapping_offset, needle_start, needle_size, forward);
+      auto result =
+          mapping.accessors->Search(guard, mapping_offset, needle_start, needle_size, forward);
       if (result.has_value())
       {
         return std::optional<u32>(*result + mapping.base);
@@ -289,18 +325,20 @@ struct CompositeAddressSpaceAccessors : Accessors
 
 private:
   std::vector<AccessorMapping> m_accessor_mappings;
-  std::vector<AccessorMapping>::iterator FindAppropriateAccessor(u32 address)
+  std::vector<AccessorMapping>::iterator FindAppropriateAccessor(const Core::CPUThreadGuard& guard,
+                                                                 u32 address)
   {
     return std::find_if(m_accessor_mappings.begin(), m_accessor_mappings.end(),
-                        [address](const AccessorMapping& a) {
-                          return a.accessors->IsValidAddress(address - a.base);
+                        [&guard, address](const AccessorMapping& a) {
+                          return a.accessors->IsValidAddress(guard, address - a.base);
                         });
   }
-  std::vector<AccessorMapping>::const_iterator FindAppropriateAccessor(u32 address) const
+  std::vector<AccessorMapping>::const_iterator
+  FindAppropriateAccessor(const Core::CPUThreadGuard& guard, u32 address) const
   {
     return std::find_if(m_accessor_mappings.begin(), m_accessor_mappings.end(),
-                        [address](const AccessorMapping& a) {
-                          return a.accessors->IsValidAddress(address - a.base);
+                        [&guard, address](const AccessorMapping& a) {
+                          return a.accessors->IsValidAddress(guard, address - a.base);
                         });
   }
 };
@@ -310,13 +348,19 @@ struct SmallBlockAccessors : Accessors
   SmallBlockAccessors() = default;
   SmallBlockAccessors(u8** alloc_base_, u32 size_) : alloc_base{alloc_base_}, size{size_} {}
 
-  bool IsValidAddress(u32 address) const override
+  bool IsValidAddress(const Core::CPUThreadGuard& guard, u32 address) const override
   {
     return (*alloc_base != nullptr) && (address < size);
   }
-  u8 ReadU8(u32 address) const override { return (*alloc_base)[address]; }
+  u8 ReadU8(const Core::CPUThreadGuard& guard, u32 address) const override
+  {
+    return (*alloc_base)[address];
+  }
 
-  void WriteU8(u32 address, u8 value) override { (*alloc_base)[address] = value; }
+  void WriteU8(const Core::CPUThreadGuard& guard, u32 address, u8 value) override
+  {
+    (*alloc_base)[address] = value;
+  }
 
   iterator begin() const override { return *alloc_base; }
 
@@ -325,11 +369,12 @@ struct SmallBlockAccessors : Accessors
     return (*alloc_base == nullptr) ? nullptr : (*alloc_base + size);
   }
 
-  std::optional<u32> Search(u32 haystack_offset, const u8* needle_start, std::size_t needle_size,
+  std::optional<u32> Search(const Core::CPUThreadGuard& guard, u32 haystack_offset,
+                            const u8* needle_start, std::size_t needle_size,
                             bool forward) const override
   {
-    if (!IsValidAddress(haystack_offset) ||
-        !IsValidAddress(haystack_offset + static_cast<u32>(needle_size) - 1))
+    if (!IsValidAddress(guard, haystack_offset) ||
+        !IsValidAddress(guard, haystack_offset + static_cast<u32>(needle_size) - 1))
     {
       return std::nullopt;
     }
@@ -364,9 +409,12 @@ private:
 
 struct NullAccessors : Accessors
 {
-  bool IsValidAddress(u32 address) const override { return false; }
-  u8 ReadU8(u32 address) const override { return 0; }
-  void WriteU8(u32 address, u8 value) override {}
+  bool IsValidAddress(const Core::CPUThreadGuard& guard, u32 address) const override
+  {
+    return false;
+  }
+  u8 ReadU8(const Core::CPUThreadGuard& guard, u32 address) const override { return 0; }
+  void WriteU8(const Core::CPUThreadGuard& guard, u32 address, u8 value) override {}
 };
 
 static EffectiveAddressSpaceAccessors s_effective_address_space_accessors;

--- a/Source/Core/Core/HW/AddressSpace.h
+++ b/Source/Core/Core/HW/AddressSpace.h
@@ -7,6 +7,11 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 namespace AddressSpace
 {
 enum class Type
@@ -23,24 +28,25 @@ struct Accessors
 {
   using iterator = const u8*;
 
-  virtual bool IsValidAddress(u32 address) const = 0;
-  virtual u8 ReadU8(u32 address) const = 0;
-  virtual void WriteU8(u32 address, u8 value) = 0;
+  virtual bool IsValidAddress(const Core::CPUThreadGuard& guard, u32 address) const = 0;
+  virtual u8 ReadU8(const Core::CPUThreadGuard& guard, u32 address) const = 0;
+  virtual void WriteU8(const Core::CPUThreadGuard& guard, u32 address, u8 value) = 0;
 
   // overrideable naive implementations of below are defined
-  virtual u16 ReadU16(u32 address) const;
-  virtual void WriteU16(u32 address, u16 value);
-  virtual u32 ReadU32(u32 address) const;
-  virtual void WriteU32(u32 address, u32 value);
-  virtual u64 ReadU64(u32 address) const;
-  virtual void WriteU64(u32 address, u64 value);
-  virtual float ReadF32(u32 address) const;
+  virtual u16 ReadU16(const Core::CPUThreadGuard& guard, u32 address) const;
+  virtual void WriteU16(const Core::CPUThreadGuard& guard, u32 address, u16 value);
+  virtual u32 ReadU32(const Core::CPUThreadGuard& guard, u32 address) const;
+  virtual void WriteU32(const Core::CPUThreadGuard& guard, u32 address, u32 value);
+  virtual u64 ReadU64(const Core::CPUThreadGuard& guard, u32 address) const;
+  virtual void WriteU64(const Core::CPUThreadGuard& guard, u32 address, u64 value);
+  virtual float ReadF32(const Core::CPUThreadGuard& guard, u32 address) const;
 
   virtual iterator begin() const;
   virtual iterator end() const;
 
-  virtual std::optional<u32> Search(u32 haystack_offset, const u8* needle_start,
-                                    std::size_t needle_size, bool forward) const;
+  virtual std::optional<u32> Search(const Core::CPUThreadGuard& guard, u32 haystack_offset,
+                                    const u8* needle_start, std::size_t needle_size,
+                                    bool forward) const;
   virtual ~Accessors();
 };
 

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -17,6 +17,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/Timer.h"
+
 #include "Core/Boot/AncastTypes.h"
 #include "Core/Boot/DolReader.h"
 #include "Core/Boot/ElfReader.h"
@@ -912,7 +913,10 @@ static void FinishPPCBootstrap(Core::System& system, u64 userdata, s64 cycles_la
   else
     ReleasePPC();
 
-  SConfig::OnNewTitleLoad();
+  ASSERT(Core::IsCPUThread());
+  Core::CPUThreadGuard guard;
+  SConfig::OnNewTitleLoad(guard);
+
   INFO_LOG_FMT(IOS, "Bootstrapping done.");
 }
 

--- a/Source/Core/Core/MemoryWatcher.h
+++ b/Source/Core/Core/MemoryWatcher.h
@@ -11,6 +11,11 @@
 #include <sys/un.h>
 #include <vector>
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 // MemoryWatcher reads a file containing in-game memory addresses and outputs
 // changes to those memory addresses to a unix domain socket as the game runs.
 //
@@ -24,15 +29,15 @@ class MemoryWatcher final
 public:
   MemoryWatcher();
   ~MemoryWatcher();
-  void Step();
+  void Step(const Core::CPUThreadGuard& guard);
 
 private:
   bool LoadAddresses(const std::string& path);
   bool OpenSocket(const std::string& path);
 
   void ParseLine(const std::string& line);
-  u32 ChasePointer(const std::string& line);
-  std::string ComposeMessages();
+  u32 ChasePointer(const Core::CPUThreadGuard& guard, const std::string& line);
+  std::string ComposeMessages(const Core::CPUThreadGuard& guard);
 
   bool m_running = false;
 

--- a/Source/Core/Core/PowerPC/Expression.h
+++ b/Source/Core/Core/PowerPC/Expression.h
@@ -12,6 +12,11 @@
 struct expr;
 struct expr_var_list;
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 struct ExprDeleter
 {
   void operator()(expr* expression) const;

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -14,6 +14,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/Config/MainSettings.h"
+#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/Debugger/Debugger_SymbolMap.h"
 #include "Core/HLE/HLE.h"
@@ -339,11 +340,14 @@ void Interpreter::Run()
 
 void Interpreter::unknown_instruction(UGeckoInstruction inst)
 {
-  const u32 opcode = PowerPC::HostRead_U32(last_pc);
+  ASSERT(Core::IsCPUThread());
+  Core::CPUThreadGuard guard;
+
+  const u32 opcode = PowerPC::HostRead_U32(guard, last_pc);
   const std::string disasm = Common::GekkoDisassembler::Disassemble(opcode, last_pc);
   NOTICE_LOG_FMT(POWERPC, "Last PC = {:08x} : {}", last_pc, disasm);
-  Dolphin_Debugger::PrintCallstack(Core::System::GetInstance(), Common::Log::LogType::POWERPC,
-                                   Common::Log::LogLevel::LNOTICE);
+  Dolphin_Debugger::PrintCallstack(Core::System::GetInstance(), guard,
+                                   Common::Log::LogType::POWERPC, Common::Log::LogLevel::LNOTICE);
   NOTICE_LOG_FMT(
       POWERPC,
       "\nIntCPU: Unknown instruction {:08x} at PC = {:08x}  last_PC = {:08x}  LR = {:08x}\n",

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
@@ -6,6 +6,7 @@
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/HLE/HLE.h"
 #include "Core/PowerPC/Interpreter/ExceptionUtils.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -95,7 +96,11 @@ void Interpreter::bclrx(UGeckoInstruction inst)
 void Interpreter::HLEFunction(UGeckoInstruction inst)
 {
   m_end_block = true;
-  HLE::Execute(PowerPC::ppcState.pc, inst.hex);
+
+  ASSERT(Core::IsCPUThread());
+  Core::CPUThreadGuard guard;
+
+  HLE::Execute(guard, PowerPC::ppcState.pc, inst.hex);
 }
 
 void Interpreter::rfi(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"
@@ -271,8 +272,12 @@ void CompileExceptionCheck(ExceptionType type)
   {
     if (type == ExceptionType::FIFOWrite)
     {
+      ASSERT(Core::IsCPUThread());
+      Core::CPUThreadGuard guard;
+
       // Check in case the code has been replaced since: do we need to do this?
-      const OpType optype = PPCTables::GetOpInfo(PowerPC::HostRead_U32(PowerPC::ppcState.pc))->type;
+      const OpType optype =
+          PPCTables::GetOpInfo(PowerPC::HostRead_U32(guard, PowerPC::ppcState.pc))->type;
       if (optype != OpType::Store && optype != OpType::StoreFP && optype != OpType::StorePS)
         return;
     }

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -10,6 +10,11 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 namespace PowerPC
 {
 // Routines for debugger UI, cheats, etc. to access emulated memory from the
@@ -27,14 +32,14 @@ enum class RequestedAddressSpace
 // If the read fails (eg. address does not correspond to a mapped address in the current address
 // space), a PanicAlert will be shown to the user and zero (or an empty string for the string case)
 // will be returned.
-u8 HostRead_U8(u32 address);
-u16 HostRead_U16(u32 address);
-u32 HostRead_U32(u32 address);
-u64 HostRead_U64(u32 address);
-float HostRead_F32(u32 address);
-double HostRead_F64(u32 address);
-u32 HostRead_Instruction(u32 address);
-std::string HostGetString(u32 address, size_t size = 0);
+u8 HostRead_U8(const Core::CPUThreadGuard& guard, u32 address);
+u16 HostRead_U16(const Core::CPUThreadGuard& guard, u32 address);
+u32 HostRead_U32(const Core::CPUThreadGuard& guard, u32 address);
+u64 HostRead_U64(const Core::CPUThreadGuard& guard, u32 address);
+float HostRead_F32(const Core::CPUThreadGuard& guard, u32 address);
+double HostRead_F64(const Core::CPUThreadGuard& guard, u32 address);
+u32 HostRead_Instruction(const Core::CPUThreadGuard& guard, u32 address);
+std::string HostGetString(const Core::CPUThreadGuard& guard, u32 address, size_t size = 0);
 
 template <typename T>
 struct ReadResult
@@ -57,32 +62,39 @@ struct ReadResult
 // value and information on whether the given address had to be translated or not. Unlike the
 // HostRead functions, this does not raise a user-visible alert on failure.
 std::optional<ReadResult<u8>>
-HostTryReadU8(u32 address, RequestedAddressSpace space = RequestedAddressSpace::Effective);
+HostTryReadU8(const Core::CPUThreadGuard& guard, u32 address,
+              RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<ReadResult<u16>>
-HostTryReadU16(u32 address, RequestedAddressSpace space = RequestedAddressSpace::Effective);
+HostTryReadU16(const Core::CPUThreadGuard& guard, u32 address,
+               RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<ReadResult<u32>>
-HostTryReadU32(u32 address, RequestedAddressSpace space = RequestedAddressSpace::Effective);
+HostTryReadU32(const Core::CPUThreadGuard& guard, u32 address,
+               RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<ReadResult<u64>>
-HostTryReadU64(u32 address, RequestedAddressSpace space = RequestedAddressSpace::Effective);
+HostTryReadU64(const Core::CPUThreadGuard& guard, u32 address,
+               RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<ReadResult<float>>
-HostTryReadF32(u32 address, RequestedAddressSpace space = RequestedAddressSpace::Effective);
+HostTryReadF32(const Core::CPUThreadGuard& guard, u32 address,
+               RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<ReadResult<double>>
-HostTryReadF64(u32 address, RequestedAddressSpace space = RequestedAddressSpace::Effective);
+HostTryReadF64(const Core::CPUThreadGuard& guard, u32 address,
+               RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<ReadResult<u32>>
-HostTryReadInstruction(u32 address, RequestedAddressSpace space = RequestedAddressSpace::Effective);
+HostTryReadInstruction(const Core::CPUThreadGuard& guard, u32 address,
+                       RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<ReadResult<std::string>>
-HostTryReadString(u32 address, size_t size = 0,
+HostTryReadString(const Core::CPUThreadGuard& guard, u32 address, size_t size = 0,
                   RequestedAddressSpace space = RequestedAddressSpace::Effective);
 
 // Writes a value to emulated memory using the currently active MMU settings.
 // If the write fails (eg. address does not correspond to a mapped address in the current address
 // space), a PanicAlert will be shown to the user.
-void HostWrite_U8(u32 var, u32 address);
-void HostWrite_U16(u32 var, u32 address);
-void HostWrite_U32(u32 var, u32 address);
-void HostWrite_U64(u64 var, u32 address);
-void HostWrite_F32(float var, u32 address);
-void HostWrite_F64(double var, u32 address);
+void HostWrite_U8(const Core::CPUThreadGuard& guard, u32 var, u32 address);
+void HostWrite_U16(const Core::CPUThreadGuard& guard, u32 var, u32 address);
+void HostWrite_U32(const Core::CPUThreadGuard& guard, u32 var, u32 address);
+void HostWrite_U64(const Core::CPUThreadGuard& guard, u64 var, u32 address);
+void HostWrite_F32(const Core::CPUThreadGuard& guard, float var, u32 address);
+void HostWrite_F64(const Core::CPUThreadGuard& guard, double var, u32 address);
 
 struct WriteResult
 {
@@ -98,30 +110,31 @@ struct WriteResult
 // address had to be translated or not. Unlike the HostWrite functions, this does not raise a
 // user-visible alert on failure.
 std::optional<WriteResult>
-HostTryWriteU8(u32 var, const u32 address,
+HostTryWriteU8(const Core::CPUThreadGuard& guard, u32 var, const u32 address,
                RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<WriteResult>
-HostTryWriteU16(u32 var, const u32 address,
+HostTryWriteU16(const Core::CPUThreadGuard& guard, u32 var, const u32 address,
                 RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<WriteResult>
-HostTryWriteU32(u32 var, const u32 address,
+HostTryWriteU32(const Core::CPUThreadGuard& guard, u32 var, const u32 address,
                 RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<WriteResult>
-HostTryWriteU64(u64 var, const u32 address,
+HostTryWriteU64(const Core::CPUThreadGuard& guard, u64 var, const u32 address,
                 RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<WriteResult>
-HostTryWriteF32(float var, const u32 address,
+HostTryWriteF32(const Core::CPUThreadGuard& guard, float var, const u32 address,
                 RequestedAddressSpace space = RequestedAddressSpace::Effective);
 std::optional<WriteResult>
-HostTryWriteF64(double var, const u32 address,
+HostTryWriteF64(const Core::CPUThreadGuard& guard, double var, const u32 address,
                 RequestedAddressSpace space = RequestedAddressSpace::Effective);
 
 // Returns whether a read or write to the given address will resolve to a RAM access in the given
 // address space.
-bool HostIsRAMAddress(u32 address, RequestedAddressSpace space = RequestedAddressSpace::Effective);
+bool HostIsRAMAddress(const Core::CPUThreadGuard& guard, u32 address,
+                      RequestedAddressSpace space = RequestedAddressSpace::Effective);
 
 // Same as HostIsRAMAddress, but uses IBAT instead of DBAT.
-bool HostIsInstructionRAMAddress(u32 address,
+bool HostIsInstructionRAMAddress(const Core::CPUThreadGuard& guard, u32 address,
                                  RequestedAddressSpace space = RequestedAddressSpace::Effective);
 
 // Routines for the CPU core to access memory.

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -19,6 +19,11 @@ namespace Common
 struct Symbol;
 }
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 namespace PPCAnalyst
 {
 struct CodeOp  // 16B
@@ -201,8 +206,11 @@ private:
   bool m_enable_div_by_zero_exceptions = false;
 };
 
-void FindFunctions(u32 startAddr, u32 endAddr, PPCSymbolDB* func_db);
-bool AnalyzeFunction(u32 startAddr, Common::Symbol& func, u32 max_size = 0);
-bool ReanalyzeFunction(u32 start_addr, Common::Symbol& func, u32 max_size = 0);
+void FindFunctions(const Core::CPUThreadGuard& guard, u32 startAddr, u32 endAddr,
+                   PPCSymbolDB* func_db);
+bool AnalyzeFunction(const Core::CPUThreadGuard& guard, u32 startAddr, Common::Symbol& func,
+                     u32 max_size = 0);
+bool ReanalyzeFunction(const Core::CPUThreadGuard& guard, u32 start_addr, Common::Symbol& func,
+                       u32 max_size = 0);
 
 }  // namespace PPCAnalyst

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -32,14 +32,14 @@ PPCSymbolDB::PPCSymbolDB() : debugger{&PowerPC::debug_interface}
 PPCSymbolDB::~PPCSymbolDB() = default;
 
 // Adds the function to the list, unless it's already there
-Common::Symbol* PPCSymbolDB::AddFunction(u32 start_addr)
+Common::Symbol* PPCSymbolDB::AddFunction(const Core::CPUThreadGuard& guard, u32 start_addr)
 {
   // It's already in the list
   if (m_functions.find(start_addr) != m_functions.end())
     return nullptr;
 
   Common::Symbol symbol;
-  if (!PPCAnalyst::AnalyzeFunction(start_addr, symbol))
+  if (!PPCAnalyst::AnalyzeFunction(guard, start_addr, symbol))
     return nullptr;
 
   m_functions[start_addr] = std::move(symbol);
@@ -49,8 +49,8 @@ Common::Symbol* PPCSymbolDB::AddFunction(u32 start_addr)
   return ptr;
 }
 
-void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& name,
-                                 Common::Symbol::Type type)
+void PPCSymbolDB::AddKnownSymbol(const Core::CPUThreadGuard& guard, u32 startAddr, u32 size,
+                                 const std::string& name, Common::Symbol::Type type)
 {
   auto iter = m_functions.find(startAddr);
   if (iter != m_functions.end())
@@ -58,7 +58,7 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
     // already got it, let's just update name, checksum & size to be sure.
     Common::Symbol* tempfunc = &iter->second;
     tempfunc->Rename(name);
-    tempfunc->hash = HashSignatureDB::ComputeCodeChecksum(startAddr, startAddr + size - 4);
+    tempfunc->hash = HashSignatureDB::ComputeCodeChecksum(guard, startAddr, startAddr + size - 4);
     tempfunc->type = type;
     tempfunc->size = size;
   }
@@ -71,7 +71,7 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
     tf.address = startAddr;
     if (tf.type == Common::Symbol::Type::Function)
     {
-      PPCAnalyst::AnalyzeFunction(startAddr, tf, size);
+      PPCAnalyst::AnalyzeFunction(guard, startAddr, tf, size);
       // Do not truncate symbol when a size is expected
       if (size != 0 && tf.size != size)
       {
@@ -224,7 +224,7 @@ void PPCSymbolDB::LogFunctionCall(u32 addr)
 // This one can load both leftover map files on game discs (like Zelda), and mapfiles
 // produced by SaveSymbolMap below.
 // bad=true means carefully load map files that might not be from exactly the right version
-bool PPCSymbolDB::LoadMap(const std::string& filename, bool bad)
+bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& filename, bool bad)
 {
   File::IOFile f(filename, "r");
   if (!f)
@@ -407,8 +407,8 @@ bool PPCSymbolDB::LoadMap(const std::string& filename, bool bad)
     if (strlen(name) > 0)
     {
       // Can't compute the checksum if not in RAM
-      bool good = !bad && PowerPC::HostIsInstructionRAMAddress(vaddress) &&
-                  PowerPC::HostIsInstructionRAMAddress(vaddress + size - 4);
+      bool good = !bad && PowerPC::HostIsInstructionRAMAddress(guard, vaddress) &&
+                  PowerPC::HostIsInstructionRAMAddress(guard, vaddress + size - 4);
       if (!good)
       {
         // check for BLR before function
@@ -423,10 +423,10 @@ bool PPCSymbolDB::LoadMap(const std::string& filename, bool bad)
       if (good)
       {
         ++good_count;
-        if (section_name == ".text" || section_name == ".init")
-          AddKnownSymbol(vaddress, size, name, Common::Symbol::Type::Function);
-        else
-          AddKnownSymbol(vaddress, size, name, Common::Symbol::Type::Data);
+        const Common::Symbol::Type type = section_name == ".text" || section_name == ".init" ?
+                                              Common::Symbol::Type::Function :
+                                              Common::Symbol::Type::Data;
+        AddKnownSymbol(guard, vaddress, size, name, type);
       }
       else
       {
@@ -485,7 +485,7 @@ bool PPCSymbolDB::SaveSymbolMap(const std::string& filename) const
 // Notes:
 //  - Dolphin doesn't load back code maps
 //  - It's a custom code map format
-bool PPCSymbolDB::SaveCodeMap(const std::string& filename) const
+bool PPCSymbolDB::SaveCodeMap(const Core::CPUThreadGuard& guard, const std::string& filename) const
 {
   constexpr int SYMBOL_NAME_LIMIT = 30;
   File::IOFile f(filename, "w");
@@ -515,7 +515,7 @@ bool PPCSymbolDB::SaveCodeMap(const std::string& filename) const
     // Write the code
     for (u32 address = symbol.address; address < next_address; address += 4)
     {
-      const std::string disasm = debugger->Disassemble(address);
+      const std::string disasm = debugger->Disassemble(&guard, address);
       f.WriteString(fmt::format("{0:08x} {1:<{2}.{3}} {4}\n", address, symbol.name,
                                 SYMBOL_NAME_LIMIT, SYMBOL_NAME_LIMIT, disasm));
     }

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -12,6 +12,11 @@
 
 #include "Core/Debugger/PPCDebugInterface.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 // This has functionality overlapping Debugger_Symbolmap. Should merge that stuff in here later.
 class PPCSymbolDB : public Common::SymbolDB
 {
@@ -19,8 +24,9 @@ public:
   PPCSymbolDB();
   ~PPCSymbolDB() override;
 
-  Common::Symbol* AddFunction(u32 start_addr) override;
-  void AddKnownSymbol(u32 startAddr, u32 size, const std::string& name,
+  Common::Symbol* AddFunction(const Core::CPUThreadGuard& guard, u32 start_addr) override;
+  void AddKnownSymbol(const Core::CPUThreadGuard& guard, u32 startAddr, u32 size,
+                      const std::string& name,
                       Common::Symbol::Type type = Common::Symbol::Type::Function);
 
   Common::Symbol* GetSymbolFromAddr(u32 addr) override;
@@ -29,9 +35,9 @@ public:
 
   void FillInCallers();
 
-  bool LoadMap(const std::string& filename, bool bad = false);
+  bool LoadMap(const Core::CPUThreadGuard& guard, const std::string& filename, bool bad = false);
   bool SaveSymbolMap(const std::string& filename) const;
-  bool SaveCodeMap(const std::string& filename) const;
+  bool SaveCodeMap(const Core::CPUThreadGuard& guard, const std::string& filename) const;
 
   void PrintCalls(u32 funcAddr) const;
   void PrintCallers(u32 funcAddr) const;

--- a/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
@@ -101,7 +101,7 @@ bool GetRefs(MEGASignature* sig, std::istringstream* iss)
   return true;
 }
 
-bool Compare(u32 address, u32 size, const MEGASignature& sig)
+bool Compare(const Core::CPUThreadGuard& guard, u32 address, u32 size, const MEGASignature& sig)
 {
   if (size != sig.code.size() * sizeof(u32))
     return false;
@@ -109,8 +109,10 @@ bool Compare(u32 address, u32 size, const MEGASignature& sig)
   for (size_t i = 0; i < sig.code.size(); ++i)
   {
     if (sig.code[i] != 0 &&
-        PowerPC::HostRead_U32(static_cast<u32>(address + i * sizeof(u32))) != sig.code[i])
+        PowerPC::HostRead_U32(guard, static_cast<u32>(address + i * sizeof(u32))) != sig.code[i])
+    {
       return false;
+    }
   }
   return true;
 }
@@ -156,14 +158,14 @@ bool MEGASignatureDB::Save(const std::string& file_path) const
   return false;
 }
 
-void MEGASignatureDB::Apply(PPCSymbolDB* symbol_db) const
+void MEGASignatureDB::Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) const
 {
   for (auto& it : symbol_db->AccessSymbols())
   {
     auto& symbol = it.second;
     for (const auto& sig : m_signatures)
     {
-      if (Compare(symbol.address, symbol.size, sig))
+      if (Compare(guard, symbol.address, symbol.size, sig))
       {
         symbol.name = sig.name;
         INFO_LOG_FMT(SYMBOLS, "Found {} at {:08x} (size: {:08x})!", sig.name, symbol.address,
@@ -180,7 +182,8 @@ void MEGASignatureDB::Populate(const PPCSymbolDB* func_db, const std::string& fi
   ERROR_LOG_FMT(SYMBOLS, "MEGA database can't be populated yet.");
 }
 
-bool MEGASignatureDB::Add(u32 startAddr, u32 size, const std::string& name)
+bool MEGASignatureDB::Add(const Core::CPUThreadGuard& guard, u32 startAddr, u32 size,
+                          const std::string& name)
 {
   ERROR_LOG_FMT(SYMBOLS, "Can't add symbol to MEGA database yet.");
   return false;

--- a/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.h
+++ b/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.h
@@ -9,6 +9,11 @@
 #include "Common/CommonTypes.h"
 #include "Core/PowerPC/SignatureDB/SignatureDB.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 class PPCSymbolDB;
 
 struct MEGASignatureReference
@@ -46,10 +51,11 @@ public:
   bool Save(const std::string& file_path) const override;
   void List() const override;
 
-  void Apply(PPCSymbolDB* symbol_db) const override;
+  void Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) const override;
   void Populate(const PPCSymbolDB* func_db, const std::string& filter = "") override;
 
-  bool Add(u32 startAddr, u32 size, const std::string& name) override;
+  bool Add(const Core::CPUThreadGuard& guard, u32 startAddr, u32 size,
+           const std::string& name) override;
 
 private:
   std::vector<MEGASignature> m_signatures;

--- a/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.h
+++ b/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.h
@@ -11,6 +11,11 @@
 
 // You're not meant to keep around SignatureDB objects persistently. Use 'em, throw them away.
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 class PPCSymbolDB;
 class SignatureDBFormatHandler;
 
@@ -33,9 +38,9 @@ public:
   void List() const;
 
   void Populate(const PPCSymbolDB* func_db, const std::string& filter = "");
-  void Apply(PPCSymbolDB* func_db) const;
+  void Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* func_db) const;
 
-  bool Add(u32 start_addr, u32 size, const std::string& name);
+  bool Add(const Core::CPUThreadGuard& guard, u32 start_addr, u32 size, const std::string& name);
 
 private:
   std::unique_ptr<SignatureDBFormatHandler> m_handler;
@@ -52,9 +57,10 @@ public:
   virtual void List() const = 0;
 
   virtual void Populate(const PPCSymbolDB* func_db, const std::string& filter = "") = 0;
-  virtual void Apply(PPCSymbolDB* func_db) const = 0;
+  virtual void Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* func_db) const = 0;
 
-  virtual bool Add(u32 startAddr, u32 size, const std::string& name) = 0;
+  virtual bool Add(const Core::CPUThreadGuard& guard, u32 startAddr, u32 size,
+                   const std::string& name) = 0;
 };
 
 class HashSignatureDB : public SignatureDBFormatHandler
@@ -69,15 +75,16 @@ public:
   };
   using FuncDB = std::map<u32, DBFunc>;
 
-  static u32 ComputeCodeChecksum(u32 offsetStart, u32 offsetEnd);
+  static u32 ComputeCodeChecksum(const Core::CPUThreadGuard& guard, u32 offsetStart, u32 offsetEnd);
 
   void Clear() override;
   void List() const override;
 
   void Populate(const PPCSymbolDB* func_db, const std::string& filter = "") override;
-  void Apply(PPCSymbolDB* func_db) const override;
+  void Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* func_db) const override;
 
-  bool Add(u32 startAddr, u32 size, const std::string& name) override;
+  bool Add(const Core::CPUThreadGuard& guard, u32 startAddr, u32 size,
+           const std::string& name) override;
 
 protected:
   // Map from signature to function. We store the DB in this map because it optimizes the

--- a/Source/Core/DiscIO/RiivolutionPatcher.h
+++ b/Source/Core/DiscIO/RiivolutionPatcher.h
@@ -11,6 +11,11 @@
 #include "DiscIO/DirectoryBlob.h"
 #include "DiscIO/RiivolutionParser.h"
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 namespace DiscIO::Riivolution
 {
 struct SavegameRedirect
@@ -74,8 +79,10 @@ enum class PatchIndex
 void ApplyPatchesToFiles(const std::vector<Patch>& patches, PatchIndex index,
                          std::vector<DiscIO::FSTBuilderNode>* fst,
                          DiscIO::FSTBuilderNode* dol_node);
-void ApplyGeneralMemoryPatches(const std::vector<Patch>& patches);
-void ApplyApploaderMemoryPatches(const std::vector<Patch>& patches, u32 ram_address,
+void ApplyGeneralMemoryPatches(const Core::CPUThreadGuard& guard,
+                               const std::vector<Patch>& patches);
+void ApplyApploaderMemoryPatches(const Core::CPUThreadGuard& guard,
+                                 const std::vector<Patch>& patches, u32 ram_address,
                                  u32 ram_length);
 std::optional<SavegameRedirect>
 ExtractSavegameRedirect(const std::vector<Patch>& riivolution_patches);

--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
@@ -483,7 +483,11 @@ void CodeDiffDialog::OnSetBLR()
   Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(item->data(Qt::UserRole).toUInt());
   if (!symbol)
     return;
-  PowerPC::debug_interface.SetPatch(symbol->address, 0x4E800020);
+
+  {
+    Core::CPUThreadGuard guard;
+    PowerPC::debug_interface.SetPatch(guard, symbol->address, 0x4E800020);
+  }
 
   int row = item->row();
   m_matching_results_table->item(row, 0)->setForeground(QBrush(Qt::red));

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -15,6 +15,11 @@ class QMouseEvent;
 class QResizeEvent;
 class QShowEvent;
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 struct CodeViewBranch;
 class BranchDisplayDelegate;
 
@@ -39,6 +44,7 @@ public:
   // Set tighter row height. Set BP column sizing. This needs to run when font type changes.
   void FontBasedSizing();
   void Update();
+  void Update(const Core::CPUThreadGuard* guard);
 
   void ToggleBreakpoint();
   void AddBreakpoint();

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -322,10 +322,10 @@ void CodeWidget::Update()
 
 void CodeWidget::UpdateCallstack()
 {
-  if (Core::GetState() == Core::State::Starting)
-    return;
-
   m_callstack_list->clear();
+
+  if (Core::GetState() != Core::State::Paused)
+    return;
 
   std::vector<Dolphin_Debugger::CallstackEntry> stack;
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -15,6 +15,11 @@ namespace AddressSpace
 enum class Type;
 }
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 class MemoryViewTable;
 
 class MemoryViewWidget final : public QWidget
@@ -75,9 +80,10 @@ private:
   void OnCopyHex(u32 addr);
   void UpdateBreakpointTags();
   void UpdateColumns();
+  void UpdateColumns(const Core::CPUThreadGuard* guard);
   void ScrollbarActionTriggered(int action);
   void ScrollbarSliderReleased();
-  QString ValueToString(u32 address, Type type);
+  QString ValueToString(const Core::CPUThreadGuard& guard, u32 address, Type type);
 
   MemoryViewTable* m_table;
   QScrollBar* m_scrollbar;

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -20,6 +20,11 @@ class QRadioButton;
 class QShowEvent;
 class QSplitter;
 
+namespace Core
+{
+class CPUThreadGuard;
+}
+
 class MemoryWidget : public QDockWidget
 {
   Q_OBJECT

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -295,7 +295,11 @@ void RegisterWidget::AutoStep(const std::string& reg) const
 
   while (true)
   {
-    const AutoStepResults results = trace.AutoStepping(true);
+    const AutoStepResults results = [&trace] {
+      Core::CPUThreadGuard guard;
+      return trace.AutoStepping(guard, true);
+    }();
+
     emit Host::GetInstance()->UpdateDisasmDialog();
 
     if (!results.timed_out)

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -256,7 +256,9 @@ void ThreadWidget::Update()
   {
     m_thread_table->setRowCount(0);
     UpdateThreadContext({});
-    UpdateThreadCallstack({});
+
+    Core::CPUThreadGuard guard;
+    UpdateThreadCallstack(guard, {});
   }
   if (emu_state != Core::State::Paused)
     return;
@@ -264,8 +266,8 @@ void ThreadWidget::Update()
   const auto format_hex = [](u32 value) {
     return QStringLiteral("%1").arg(value, 8, 16, QLatin1Char('0'));
   };
-  const auto format_hex_from = [&format_hex](u32 addr) {
-    addr = PowerPC::HostIsRAMAddress(addr) ? PowerPC::HostRead_U32(addr) : 0;
+  const auto format_hex_from = [&format_hex](const Core::CPUThreadGuard& guard, u32 addr) {
+    addr = PowerPC::HostIsRAMAddress(guard, addr) ? PowerPC::HostRead_U32(guard, addr) : 0;
     return format_hex(addr);
   };
   const auto get_state = [](u16 thread_state) {
@@ -298,35 +300,41 @@ void ThreadWidget::Update()
         .arg(start, 8, 16, QLatin1Char('0'));
   };
 
-  // YAGCD - Section 4.2.1.4 Dolphin OS Globals
-  m_current_context->setText(format_hex_from(0x800000D4));
-  m_current_thread->setText(format_hex_from(0x800000E4));
-  m_default_thread->setText(format_hex_from(0x800000D8));
-
-  m_queue_head->setText(format_hex_from(0x800000DC));
-  m_queue_tail->setText(format_hex_from(0x800000E0));
-
-  // Thread group
-  m_threads = PowerPC::debug_interface.GetThreads();
-  int i = 0;
-  m_thread_table->setRowCount(i);
-  for (const auto& thread : m_threads)
   {
-    m_thread_table->insertRow(i);
-    m_thread_table->setItem(i, 0, new QTableWidgetItem(format_hex(thread->GetAddress())));
-    m_thread_table->setItem(i, 1, new QTableWidgetItem(get_state(thread->GetState())));
-    m_thread_table->setItem(i, 2, new QTableWidgetItem(QString::number(thread->IsDetached())));
-    m_thread_table->setItem(i, 3, new QTableWidgetItem(QString::number(thread->IsSuspended())));
-    m_thread_table->setItem(i, 4,
-                            new QTableWidgetItem(get_priority(thread->GetBasePriority(),
-                                                              thread->GetEffectivePriority())));
-    m_thread_table->setItem(
-        i, 5, new QTableWidgetItem(get_stack(thread->GetStackEnd(), thread->GetStackStart())));
-    m_thread_table->setItem(i, 6, new QTableWidgetItem(QString::number(thread->GetErrno())));
-    m_thread_table->setItem(i, 7,
-                            new QTableWidgetItem(QString::fromStdString(thread->GetSpecific())));
-    i += 1;
+    Core::CPUThreadGuard guard;
+
+    // YAGCD - Section 4.2.1.4 Dolphin OS Globals
+    m_current_context->setText(format_hex_from(guard, 0x800000D4));
+    m_current_thread->setText(format_hex_from(guard, 0x800000E4));
+    m_default_thread->setText(format_hex_from(guard, 0x800000D8));
+
+    m_queue_head->setText(format_hex_from(guard, 0x800000DC));
+    m_queue_tail->setText(format_hex_from(guard, 0x800000E0));
+
+    // Thread group
+    m_threads = PowerPC::debug_interface.GetThreads(guard);
+
+    int i = 0;
+    m_thread_table->setRowCount(i);
+    for (const auto& thread : m_threads)
+    {
+      m_thread_table->insertRow(i);
+      m_thread_table->setItem(i, 0, new QTableWidgetItem(format_hex(thread->GetAddress())));
+      m_thread_table->setItem(i, 1, new QTableWidgetItem(get_state(thread->GetState())));
+      m_thread_table->setItem(i, 2, new QTableWidgetItem(QString::number(thread->IsDetached())));
+      m_thread_table->setItem(i, 3, new QTableWidgetItem(QString::number(thread->IsSuspended())));
+      m_thread_table->setItem(i, 4,
+                              new QTableWidgetItem(get_priority(thread->GetBasePriority(),
+                                                                thread->GetEffectivePriority())));
+      m_thread_table->setItem(
+          i, 5, new QTableWidgetItem(get_stack(thread->GetStackEnd(), thread->GetStackStart())));
+      m_thread_table->setItem(i, 6, new QTableWidgetItem(QString::number(thread->GetErrno())));
+      m_thread_table->setItem(
+          i, 7, new QTableWidgetItem(QString::fromStdString(thread->GetSpecific(guard))));
+      i += 1;
+    }
   }
+
   m_thread_table->resizeColumnsToContents();
   m_thread_table->resizeRowsToContents();
 
@@ -425,7 +433,8 @@ void ThreadWidget::UpdateThreadContext(const Common::Debug::PartialContext& cont
   m_context_table->resizeColumnsToContents();
 }
 
-void ThreadWidget::UpdateThreadCallstack(const Common::Debug::PartialContext& context)
+void ThreadWidget::UpdateThreadCallstack(const Core::CPUThreadGuard& guard,
+                                         const Common::Debug::PartialContext& context)
 {
   m_callstack_table->setRowCount(0);
 
@@ -439,13 +448,13 @@ void ThreadWidget::UpdateThreadCallstack(const Common::Debug::PartialContext& co
   u32 sp = context.gpr->at(1);
   for (int i = 0; i < 16; i++)
   {
-    if (sp == 0 || sp == 0xffffffff || !PowerPC::HostIsRAMAddress(sp))
+    if (sp == 0 || sp == 0xffffffff || !PowerPC::HostIsRAMAddress(guard, sp))
       break;
     m_callstack_table->insertRow(i);
     m_callstack_table->setItem(i, 0, new QTableWidgetItem(format_hex(sp)));
-    if (PowerPC::HostIsRAMAddress(sp + 4))
+    if (PowerPC::HostIsRAMAddress(guard, sp + 4))
     {
-      const u32 lr_save = PowerPC::HostRead_U32(sp + 4);
+      const u32 lr_save = PowerPC::HostRead_U32(guard, sp + 4);
       m_callstack_table->setItem(i, 2, new QTableWidgetItem(format_hex(lr_save)));
       m_callstack_table->setItem(i, 3,
                                  new QTableWidgetItem(QString::fromStdString(
@@ -455,18 +464,19 @@ void ThreadWidget::UpdateThreadCallstack(const Common::Debug::PartialContext& co
     {
       m_callstack_table->setItem(i, 2, new QTableWidgetItem(QStringLiteral("--------")));
     }
-    sp = PowerPC::HostRead_U32(sp);
+    sp = PowerPC::HostRead_U32(guard, sp);
     m_callstack_table->setItem(i, 1, new QTableWidgetItem(format_hex(sp)));
   }
 }
 
 void ThreadWidget::OnSelectionChanged(int row)
 {
+  Core::CPUThreadGuard guard;
   Common::Debug::PartialContext context;
 
   if (row >= 0 && size_t(row) < m_threads.size())
-    context = m_threads[row]->GetContext();
+    context = m_threads[row]->GetContext(guard);
 
   UpdateThreadContext(context);
-  UpdateThreadCallstack(context);
+  UpdateThreadCallstack(guard, context);
 }

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.h
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.h
@@ -47,7 +47,8 @@ private:
 
   void Update();
   void UpdateThreadContext(const Common::Debug::PartialContext& context);
-  void UpdateThreadCallstack(const Common::Debug::PartialContext& context);
+  void UpdateThreadCallstack(const Core::CPUThreadGuard& guard,
+                             const Common::Debug::PartialContext& context);
   void OnSelectionChanged(int row);
 
   QGroupBox* m_state;

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.h
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.h
@@ -14,6 +14,11 @@ class QTableWidget;
 class QTableWidgetItem;
 class QToolBar;
 
+namespace Core
+{
+class CPUThreadGuard;
+};
+
 class WatchWidget : public QDockWidget
 {
   Q_OBJECT
@@ -46,9 +51,9 @@ private:
 
   void ShowContextMenu();
   void OnItemChanged(QTableWidgetItem* item);
-  void LockWatchAddress(u32 address);
+  void LockWatchAddress(const Core::CPUThreadGuard& guard, u32 address);
   void DeleteSelectedWatches();
-  void DeleteWatch(int row);
+  void DeleteWatch(const Core::CPUThreadGuard& guard, int row);
   void DeleteWatchAndUpdate(int row);
   void AddWatchBreakpoint(int row);
   void ShowInMemory(int row);

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1186,25 +1186,29 @@ void MenuBar::ClearSymbols()
 
 void MenuBar::GenerateSymbolsFromAddress()
 {
+  Core::CPUThreadGuard guard;
+
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
-  PPCAnalyst::FindFunctions(Memory::MEM1_BASE_ADDR,
+  PPCAnalyst::FindFunctions(guard, Memory::MEM1_BASE_ADDR,
                             Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal(), &g_symbolDB);
   emit NotifySymbolsUpdated();
 }
 
 void MenuBar::GenerateSymbolsFromSignatureDB()
 {
+  Core::CPUThreadGuard guard;
+
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
-  PPCAnalyst::FindFunctions(Memory::MEM1_BASE_ADDR,
+  PPCAnalyst::FindFunctions(guard, Memory::MEM1_BASE_ADDR,
                             Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal(), &g_symbolDB);
   SignatureDB db(SignatureDB::HandlerType::DSY);
   if (db.Load(File::GetSysDirectory() + TOTALDB))
   {
-    db.Apply(&g_symbolDB);
+    db.Apply(guard, &g_symbolDB);
     ModalMessageBox::information(
         this, tr("Information"),
         tr("Generated symbol names from '%1'").arg(QString::fromStdString(TOTALDB)));
@@ -1240,10 +1244,12 @@ void MenuBar::GenerateSymbolsFromRSO()
     return;
   }
 
+  Core::CPUThreadGuard guard;
+
   RSOChainView rso_chain;
-  if (rso_chain.Load(static_cast<u32>(address)))
+  if (rso_chain.Load(guard, static_cast<u32>(address)))
   {
-    rso_chain.Apply(&g_symbolDB);
+    rso_chain.Apply(guard, &g_symbolDB);
     emit NotifySymbolsUpdated();
   }
   else
@@ -1293,9 +1299,12 @@ void MenuBar::GenerateSymbolsFromRSOAuto()
 
   RSOChainView rso_chain;
   const u32 address = item.mid(0, item.indexOf(QLatin1Char(' '))).toUInt(nullptr, 16);
-  if (rso_chain.Load(address))
+
+  Core::CPUThreadGuard guard;
+
+  if (rso_chain.Load(guard, address))
   {
-    rso_chain.Apply(&g_symbolDB);
+    rso_chain.Apply(guard, &g_symbolDB);
     emit NotifySymbolsUpdated();
   }
   else
@@ -1306,6 +1315,8 @@ void MenuBar::GenerateSymbolsFromRSOAuto()
 
 RSOVector MenuBar::DetectRSOModules(ParallelProgressDialog& progress)
 {
+  Core::CPUThreadGuard guard;
+
   constexpr std::array<std::string_view, 2> search_for = {".elf", ".plf"};
 
   const AddressSpace::Accessors* accessors =
@@ -1324,8 +1335,8 @@ RSOVector MenuBar::DetectRSOModules(ParallelProgressDialog& progress)
         return matches;
       }
 
-      auto found_addr =
-          accessors->Search(next, reinterpret_cast<const u8*>(str.data()), str.size() + 1, true);
+      auto found_addr = accessors->Search(guard, next, reinterpret_cast<const u8*>(str.data()),
+                                          str.size() + 1, true);
 
       if (!found_addr.has_value())
         break;
@@ -1334,13 +1345,13 @@ RSOVector MenuBar::DetectRSOModules(ParallelProgressDialog& progress)
 
       // Non-null data can precede the module name.
       // Get the maximum name length that a module could have.
-      auto get_max_module_name_len = [found_addr] {
+      auto get_max_module_name_len = [&guard, found_addr] {
         constexpr u32 MODULE_NAME_MAX_LENGTH = 260;
         u32 len = 0;
 
         for (; len < MODULE_NAME_MAX_LENGTH; ++len)
         {
-          const auto res = PowerPC::HostRead_U8(*found_addr - (len + 1));
+          const auto res = PowerPC::HostRead_U8(guard, *found_addr - (len + 1));
           if (!std::isprint(res))
           {
             break;
@@ -1375,12 +1386,12 @@ RSOVector MenuBar::DetectRSOModules(ParallelProgressDialog& progress)
 
         // Get the field (Module Name Offset) that point to the string
         const auto module_name_offset_addr =
-            accessors->Search(lookup_addr, ref.data(), ref.size(), false);
+            accessors->Search(guard, lookup_addr, ref.data(), ref.size(), false);
         if (!module_name_offset_addr.has_value())
           continue;
 
         // The next 4 bytes should be the module name length
-        module_name_length = accessors->ReadU32(*module_name_offset_addr + 4);
+        module_name_length = accessors->ReadU32(guard, *module_name_offset_addr + 4);
         if (module_name_length == max_name_length - i + str.length())
         {
           found_addr = module_name_offset_addr;
@@ -1392,11 +1403,11 @@ RSOVector MenuBar::DetectRSOModules(ParallelProgressDialog& progress)
       if (!found)
         continue;
 
-      const auto module_name_offset = accessors->ReadU32(*found_addr);
+      const auto module_name_offset = accessors->ReadU32(guard, *found_addr);
 
       // Go to the beginning of the RSO header
       matches.emplace_back(*found_addr - 16,
-                           PowerPC::HostGetString(module_name_offset, module_name_length));
+                           PowerPC::HostGetString(guard, module_name_offset, module_name_length));
 
       progress.SetLabelText(tr("Modules found: %1").arg(matches.size()));
     }
@@ -1416,11 +1427,16 @@ void MenuBar::LoadSymbolMap()
   if (!map_exists)
   {
     g_symbolDB.Clear();
-    PPCAnalyst::FindFunctions(Memory::MEM1_BASE_ADDR + 0x1300000,
-                              Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal(), &g_symbolDB);
-    SignatureDB db(SignatureDB::HandlerType::DSY);
-    if (db.Load(File::GetSysDirectory() + TOTALDB))
-      db.Apply(&g_symbolDB);
+
+    {
+      Core::CPUThreadGuard guard;
+
+      PPCAnalyst::FindFunctions(guard, Memory::MEM1_BASE_ADDR + 0x1300000,
+                                Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal(), &g_symbolDB);
+      SignatureDB db(SignatureDB::HandlerType::DSY);
+      if (db.Load(File::GetSysDirectory() + TOTALDB))
+        db.Apply(guard, &g_symbolDB);
+    }
 
     ModalMessageBox::warning(this, tr("Warning"),
                              tr("'%1' not found, scanning for common functions instead")
@@ -1505,7 +1521,13 @@ void MenuBar::SaveCode()
   const std::string path =
       writable_map_file.substr(0, writable_map_file.find_last_of('.')) + "_code.map";
 
-  if (!g_symbolDB.SaveCodeMap(path))
+  bool success;
+  {
+    Core::CPUThreadGuard guard;
+    success = g_symbolDB.SaveCodeMap(guard, path);
+  }
+
+  if (!success)
   {
     ModalMessageBox::warning(
         this, tr("Error"),
@@ -1515,7 +1537,9 @@ void MenuBar::SaveCode()
 
 bool MenuBar::TryLoadMapFile(const QString& path, const bool bad)
 {
-  if (!g_symbolDB.LoadMap(path.toStdString(), bad))
+  Core::CPUThreadGuard guard;
+
+  if (!g_symbolDB.LoadMap(guard, path.toStdString(), bad))
   {
     ModalMessageBox::warning(this, tr("Error"), tr("Failed to load map file '%1'").arg(path));
     return false;
@@ -1596,7 +1620,10 @@ void MenuBar::ApplySignatureFile()
   const std::string load_path = file.toStdString();
   SignatureDB db(load_path);
   db.Load(load_path);
-  db.Apply(&g_symbolDB);
+  {
+    Core::CPUThreadGuard guard;
+    db.Apply(guard, &g_symbolDB);
+  }
   db.List();
   auto& system = Core::System::GetInstance();
   HLE::PatchFunctions(system);
@@ -1665,12 +1692,14 @@ void MenuBar::SearchInstruction()
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
+  Core::CPUThreadGuard guard;
+
   bool found = false;
   for (u32 addr = Memory::MEM1_BASE_ADDR; addr < Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal();
        addr += 4)
   {
     const auto ins_name =
-        QString::fromStdString(PPCTables::GetInstructionName(PowerPC::HostRead_U32(addr)));
+        QString::fromStdString(PPCTables::GetInstructionName(PowerPC::HostRead_U32(guard, addr)));
     if (op == ins_name)
     {
       NOTICE_LOG_FMT(POWERPC, "Found {} at {:08x}", op.toStdString(), addr);


### PR DESCRIPTION
This fixes a problem I was having where using frame advance with the debugger open would frequently cause panic alerts about invalid addresses due to the CPU thread changing MSR.DR while the host thread was trying to access memory.

To aid in tracking down all the places where we weren't properly locking the CPU, I've created a new type (in Core.h) that you have to pass as a reference or pointer to functions that require running as the CPU thread.