### PR TITLE
DiscIO/FileBlob: Make m_size unsigned.

### DIFF
--- a/Source/Core/DiscIO/FileBlob.h
+++ b/Source/Core/DiscIO/FileBlob.h
@@ -35,7 +35,7 @@ private:
   PlainFileReader(File::IOFile file);
 
   File::IOFile m_file;
-  s64 m_size;
+  u64 m_size;
 };
 
 }  // namespace DiscIO


### PR DESCRIPTION
Randomly noticed this. I think this is just wrong, if harmless.