### PR TITLE
PPCCache: Update PLRU on any cache access

### DIFF
--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -269,11 +269,11 @@ std::pair<u32, u32> Cache::GetCache(u32 addr, bool locked)
     addrs[set][way] = addr;
     valid[set] |= (1 << way);
     modified[set] &= ~(1 << way);
-
-    // update plru
-    if (way != 0xff)
-      plru[set] = (plru[set] & ~s_plru_mask[way]) | s_plru_value[way];
   }
+
+  // update plru
+  if (way != 0xff)
+    plru[set] = (plru[set] & ~s_plru_mask[way]) | s_plru_value[way];
 
   return {set, way};
 }


### PR DESCRIPTION
The previous code only updated the PLRU on cache misses, which made it so that the least recently inserted cache block was evicted, instead of the least recently used/hit one.

This regressed in 9d39647f9e3be1bdc2ee2cfc5ce6af2e560b4cc1 (part of #11183, but it was fine in e97d3804373b31724d0f092d8132e5ba23dec4a5), although beforehand it was only implemented for the instruction cache, and the instruction cache hit extremely infrequently when the JIT or cached interpreter is in use, which generally keeps it from behaving correctly (the pure interpreter behaves correctly with it).

I'm not aware of any games that are affected by this, though I did not do extensive testing.