### PR TITLE
JIT: Fix calls to HLE::Execute.

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -12,6 +12,7 @@
 
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/GeckoCode.h"
 #include "Core/HLE/HLE_Misc.h"
 #include "Core/HLE/HLE_OS.h"
@@ -163,6 +164,13 @@ void Execute(const Core::CPUThreadGuard& guard, u32 current_pc, u32 hook_index)
   {
     PanicAlertFmt("HLE system tried to call an undefined HLE function {}.", hook_index);
   }
+}
+
+void ExecuteFromJIT(u32 current_pc, u32 hook_index)
+{
+  ASSERT(Core::IsCPUThread());
+  Core::CPUThreadGuard guard;
+  Execute(guard, current_pc, hook_index);
 }
 
 u32 GetHookByAddress(u32 address)

--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -48,6 +48,7 @@ void Patch(Core::System& system, u32 pc, std::string_view func_name);
 u32 UnPatch(Core::System& system, std::string_view patch_name);
 u32 UnpatchRange(Core::System& system, u32 start_addr, u32 end_addr);
 void Execute(const Core::CPUThreadGuard& guard, u32 current_pc, u32 hook_index);
+void ExecuteFromJIT(u32 current_pc, u32 hook_index);
 
 // Returns the HLE hook index of the address
 u32 GetHookByAddress(u32 address);

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -483,7 +483,7 @@ void Jit64::HLEFunction(u32 hook_index)
   gpr.Flush();
   fpr.Flush();
   ABI_PushRegistersAndAdjustStack({}, 0);
-  ABI_CallFunctionCC(HLE::Execute, js.compilerPC, hook_index);
+  ABI_CallFunctionCC(HLE::ExecuteFromJIT, js.compilerPC, hook_index);
   ABI_PopRegistersAndAdjustStack({}, 0);
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -254,7 +254,7 @@ void JitArm64::HLEFunction(u32 hook_index)
   gpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
   fpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
 
-  MOVP2R(ARM64Reg::X8, &HLE::Execute);
+  MOVP2R(ARM64Reg::X8, &HLE::ExecuteFromJIT);
   MOVI2R(ARM64Reg::W0, js.compilerPC);
   MOVI2R(ARM64Reg::W1, hook_index);
   BLR(ARM64Reg::X8);


### PR DESCRIPTION
This got broken in 7cecb28bdf6443362a6ab20e0042ddb3b407ebec.

Fixes Gecko codes, probably among other things.