### PR TITLE
Follow-up fixes for "Properly lock CPU before accessing emulated memory"

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -754,7 +754,7 @@ void CodeViewWidget::OnCopyTargetAddress()
   const std::optional<u32> target_addr =
       PowerPC::debug_interface.GetMemoryAddressFromInstruction(code_line);
 
-  if (addr)
+  if (target_addr)
   {
     QApplication::clipboard()->setText(
         QStringLiteral("%1").arg(*target_addr, 8, 16, QLatin1Char('0')));
@@ -784,7 +784,7 @@ void CodeViewWidget::OnShowTargetInMemory()
   const std::optional<u32> target_addr =
       PowerPC::debug_interface.GetMemoryAddressFromInstruction(code_line);
 
-  if (addr)
+  if (target_addr)
     emit ShowMemory(*target_addr);
 }
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -18,7 +18,6 @@
 #include <fmt/printf.h>
 
 #include "Common/Align.h"
-#include "Common/Assert.h"
 #include "Common/FloatUtils.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"


### PR DESCRIPTION
This fixes a few mistakes that @Pokechu22 spotted in PR #11554.