### PR TITLE
JitArm64: Add flush/discard support for condition registers

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -205,6 +205,7 @@ void JitArm64::FallBackToInterpreter(UGeckoInstruction inst)
   // we must mark them as no longer discarded
   gpr.ResetRegisters(js.op->regsOut);
   fpr.ResetRegisters(js.op->GetFregsOut());
+  gpr.ResetCRRegisters(js.op->crOut);
 
   if (js.op->opinfo->flags & FL_ENDBLOCK)
   {
@@ -1199,9 +1200,11 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       {
         gpr.DiscardRegisters(op.gprDiscardable);
         fpr.DiscardRegisters(op.fprDiscardable);
+        gpr.DiscardCRRegisters(op.crDiscardable);
       }
       gpr.StoreRegisters(~op.gprInUse & (op.regsIn | op.regsOut));
       fpr.StoreRegisters(~op.fprInUse & (op.fregsIn | op.GetFregsOut()));
+      gpr.StoreCRRegisters(~op.crInUse & (op.crIn | op.crOut));
 
       if (opinfo->flags & FL_LOADSTORE)
         ++js.numLoadStoreInst;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -335,6 +335,9 @@ public:
     FlushCRRegisters(regs, false, tmp_reg);
   }
 
+  void DiscardCRRegisters(BitSet8 regs);
+  void ResetCRRegisters(BitSet8 regs);
+
 protected:
   // Get the order of the host registers
   void GetAllocationOrder() override;

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -32,10 +32,12 @@ struct CodeOp  // 16B
   const GekkoOPInfo* opinfo = nullptr;
   u32 address = 0;
   u32 branchTo = 0;  // if UINT32_MAX, not a branch
-  BitSet32 regsOut;
   BitSet32 regsIn;
+  BitSet32 regsOut;
   BitSet32 fregsIn;
   s8 fregOut = 0;
+  BitSet8 crIn;
+  BitSet8 crOut;
   bool isBranchTarget = false;
   bool branchUsesCtr = false;
   bool branchIsIdleLoop = false;
@@ -50,6 +52,8 @@ struct CodeOp  // 16B
   bool canCauseException = false;
   bool skipLRStack = false;
   bool skip = false;  // followed BL-s for example
+  BitSet8 crInUse;
+  BitSet8 crDiscardable;
   // which registers are still needed after this instruction in this block
   BitSet32 fprInUse;
   BitSet32 gprInUse;


### PR DESCRIPTION
By flushing the condition registers as soon as we no longer need them, we reduce the register pressure.

Split out from PR #9857 for ease of review.