### PR TITLE
Fix build when using mGBA in unorthodox location

### DIFF
--- a/CMake/FindLIBMGBA.cmake
+++ b/CMake/FindLIBMGBA.cmake
@@ -1,4 +1,4 @@
-find_path(LIBMGBA_INCLUDE_DIR flags.h PATH_SUFFIXES mgba)
+find_path(LIBMGBA_INCLUDE_DIR mgba/flags.h)
 find_library(LIBMGBA_LIBRARY mgba)
 mark_as_advanced(LIBMGBA_INCLUDE_DIR LIBMGBA_LIBRARY)
 


### PR DESCRIPTION
Includes use `mgba/` and `mgba-util/` as part of path, making compilation fail when relying on include directory supplied here was actually needed.

Discovered by having both mGBA and dolphin installed in `~/.local`. Confirmed to fix the issue.