### PR TITLE
Network/Socket: Enable broadcast permissions in socket requests

### DIFF
--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -872,6 +872,9 @@ s32 WiiSockMan::AddSocket(s32 fd, bool is_rw)
     if (setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &opt_no_sigpipe, sizeof(opt_no_sigpipe)) < 0)
       ERROR_LOG_FMT(IOS_NET, "Failed to set SO_NOSIGPIPE on socket");
 #endif
+
+    BOOL opt_broadcast = TRUE;
+    setsockopt(fd, SOL_SOCKET, SO_BROADCAST, (char*)&opt_broadcast, sizeof(opt_broadcast));
   }
 
   SetLastNetError(wii_fd);

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -873,7 +873,7 @@ s32 WiiSockMan::AddSocket(s32 fd, bool is_rw)
       ERROR_LOG_FMT(IOS_NET, "Failed to set SO_NOSIGPIPE on socket");
 #endif
 
-    BOOL opt_broadcast = TRUE;
+    int opt_broadcast = 1;
     setsockopt(fd, SOL_SOCKET, SO_BROADCAST, (char*)&opt_broadcast, sizeof(opt_broadcast));
   }
 

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -873,8 +873,25 @@ s32 WiiSockMan::AddSocket(s32 fd, bool is_rw)
       ERROR_LOG_FMT(IOS_NET, "Failed to set SO_NOSIGPIPE on socket");
 #endif
 
-    int opt_broadcast = 1;
-    setsockopt(fd, SOL_SOCKET, SO_BROADCAST, (char*)&opt_broadcast, sizeof(opt_broadcast));
+    // Wii UDP sockets can use broadcast address by default
+    if (!is_rw)
+    {
+      const auto state = Common::SaveNetworkErrorState();
+      Common::ScopeGuard guard([&state] { Common::RestoreNetworkErrorState(state); });
+
+      int socket_type;
+      socklen_t option_length = sizeof(socket_type);
+      const bool is_udp = getsockopt(fd, SOL_SOCKET, SO_TYPE, reinterpret_cast<char*>(&socket_type),
+                                     &option_length) == 0 &&
+                          socket_type == SOCK_DGRAM;
+      const int opt_broadcast = 1;
+      if (is_udp &&
+          setsockopt(fd, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<const char*>(&opt_broadcast),
+                     sizeof(opt_broadcast)) != 0)
+      {
+        ERROR_LOG_FMT(IOS_NET, "Failed to set SO_BROADCAST on socket");
+      }
+    }
   }
 
   SetLastNetError(wii_fd);


### PR DESCRIPTION
This fixes a longstanding issue where Dolphin could not host or connect to LAN rooms when using the Mario Kart Wii [LAN Multiplayer mod](https://wiki.tockdom.com/wiki/LAN_Multiplayer), available both standalone and in some custom track distributions. I have been unable to identify unmodified commercial games that benefit from this change. 
I understand that Dolphin supports setting socket options when requested, but it seems that a real Wii console supports sending broadcast packets even without the permission being explicitly set. To be more specific, I do not see these permissions being requested by the mod, but I admit that I am no Wii networking expert. 
I do not do error logging here, as it is a best-effort approach, and sockets not meant to broadcast seemingly fail to apply this option. 