### PR TITLE
Fix uninitialized variable warnings (C26495)

### DIFF
--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -484,12 +484,14 @@ public:
       m_width = WidthSpecifier::Width64Bit;
       if (shift == 64)
         m_shift = 0;
+      m_extend = ExtendSpecifier::UXTX;
     }
     else
     {
       m_width = WidthSpecifier::Width32Bit;
       if (shift == 32)
         m_shift = 0;
+      m_extend = ExtendSpecifier::UXTW;
     }
   }
   ARM64Reg GetReg() const { return m_destReg; }

--- a/Source/Core/Common/Debug/CodeTrace.h
+++ b/Source/Core/Common/Debug/CodeTrace.h
@@ -31,7 +31,7 @@ struct InstructionAttributes
 
 struct TraceOutput
 {
-  u32 address;
+  u32 address = 0;
   std::optional<u32> memory_target = std::nullopt;
   std::string instruction;
 };

--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -160,8 +160,8 @@ public:
     return GetSystemTimeFAT();
   }
 
-  File::IOFile* m_image;
-  bool m_deterministic;
+  File::IOFile* m_image = nullptr;
+  bool m_deterministic = false;
 };
 }  // namespace
 

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -124,7 +124,7 @@ struct AudioInterfaceState::Data
   u32 ais_sample_rate_divisor = Mixer::FIXED_SAMPLE_RATE_DIVIDEND / 48000;
   u32 aid_sample_rate_divisor = Mixer::FIXED_SAMPLE_RATE_DIVIDEND / 32000;
 
-  CoreTiming::EventType* event_type_ai;
+  CoreTiming::EventType* event_type_ai = nullptr;
 };
 
 AudioInterfaceState::AudioInterfaceState() : m_data(std::make_unique<Data>())

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -137,16 +137,16 @@ struct DSPState::Data
   // Contains bitfields for some stuff we don't care about (and nothing ever reads):
   //  CAS latency/burst length/addressing mode/write mode
   // We care about the LSB tho. It indicates that the ARAM controller has finished initializing
-  u16 aram_mode;
-  u16 aram_refresh;
+  u16 aram_mode = 0;
+  u16 aram_refresh = 0;
   int dsp_slice = 0;
 
   std::unique_ptr<DSPEmulator> dsp_emulator;
 
   bool is_lle = false;
 
-  CoreTiming::EventType* event_type_generate_dsp_interrupt;
-  CoreTiming::EventType* event_type_complete_aram;
+  CoreTiming::EventType* event_type_generate_dsp_interrupt = nullptr;
+  CoreTiming::EventType* event_type_complete_aram = nullptr;
 };
 
 DSPState::DSPState() : m_data(std::make_unique<Data>())

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -138,11 +138,11 @@ struct DVDInterfaceState::Data
   // Hardware registers
   UDISR DISR;
   UDICVR DICVR;
-  u32 DICMDBUF[3];
-  u32 DIMAR;
-  u32 DILENGTH;
+  std::array<u32, 3> DICMDBUF{};
+  u32 DIMAR = 0;
+  u32 DILENGTH = 0;
   UDICR DICR;
-  u32 DIIMMBUF;
+  u32 DIIMMBUF = 0;
   UDICFG DICFG;
 
   StreamADPCM::ADPCMDecoder adpcm_decoder;
@@ -150,36 +150,36 @@ struct DVDInterfaceState::Data
   // DTK
   bool stream = false;
   bool stop_at_track_end = false;
-  u64 audio_position;
-  u64 current_start;
-  u32 current_length;
-  u64 next_start;
-  u32 next_length;
-  u32 pending_samples;
+  u64 audio_position = 0;
+  u64 current_start = 0;
+  u32 current_length = 0;
+  u64 next_start = 0;
+  u32 next_length = 0;
+  u32 pending_samples = 0;
   bool enable_dtk = false;
   u8 dtk_buffer_length = 0;  // TODO: figure out how this affects the regular buffer
 
   // Disc drive state
-  DriveState drive_state;
-  DriveError error_code;
-  u64 disc_end_offset;
+  DriveState drive_state = DriveState::Ready;
+  DriveError error_code = DriveError::None;
+  u64 disc_end_offset = 0;
 
   // Disc drive timing
-  u64 read_buffer_start_time;
-  u64 read_buffer_end_time;
-  u64 read_buffer_start_offset;
-  u64 read_buffer_end_offset;
+  u64 read_buffer_start_time = 0;
+  u64 read_buffer_end_time = 0;
+  u64 read_buffer_start_offset = 0;
+  u64 read_buffer_end_offset = 0;
 
   // Disc changing
   std::string disc_path_to_insert;
   std::vector<std::string> auto_disc_change_paths;
-  size_t auto_disc_change_index;
+  size_t auto_disc_change_index = 0;
 
   // Events
-  CoreTiming::EventType* finish_executing_command;
-  CoreTiming::EventType* auto_change_disc;
-  CoreTiming::EventType* eject_disc;
-  CoreTiming::EventType* insert_disc;
+  CoreTiming::EventType* finish_executing_command = nullptr;
+  CoreTiming::EventType* auto_change_disc = nullptr;
+  CoreTiming::EventType* eject_disc = nullptr;
+  CoreTiming::EventType* insert_disc = nullptr;
 };
 
 DVDInterfaceState::DVDInterfaceState() : m_data(std::make_unique<Data>())

--- a/Source/Core/Core/HW/DVD/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVD/DVDThread.cpp
@@ -76,7 +76,7 @@ static void FinishRead(Core::System& system, u64 id, s64 cycles_late);
 
 struct DVDThreadState::Data
 {
-  CoreTiming::EventType* finish_read;
+  CoreTiming::EventType* finish_read = nullptr;
 
   u64 next_id = 0;
 

--- a/Source/Core/Core/HW/DVD/FileMonitor.h
+++ b/Source/Core/Core/HW/DVD/FileMonitor.h
@@ -18,6 +18,6 @@ public:
 
 private:
   DiscIO::Partition m_previous_partition;
-  u64 m_previous_file_offset;
+  u64 m_previous_file_offset = 0;
 };
 }  // namespace FileMonitor

--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -29,10 +29,10 @@ namespace ExpansionInterface
 {
 struct ExpansionInterfaceState::Data
 {
-  CoreTiming::EventType* event_type_change_device;
-  CoreTiming::EventType* event_type_update_interrupts;
+  CoreTiming::EventType* event_type_change_device = nullptr;
+  CoreTiming::EventType* event_type_update_interrupts = nullptr;
 
-  std::array<std::unique_ptr<CEXIChannel>, MAX_EXI_CHANNELS> channels;
+  std::array<std::unique_ptr<CEXIChannel>, MAX_EXI_CHANNELS> channels{};
 
   bool using_overridden_sram = false;
 };

--- a/Source/Core/Core/HW/GPFifo.h
+++ b/Source/Core/Core/HW/GPFifo.h
@@ -57,7 +57,7 @@ private:
   void SetGatherPipeCount(size_t size);
 
   // More room for the fastmodes
-  alignas(GATHER_PIPE_SIZE) u8 m_gather_pipe[GATHER_PIPE_EXTRA_SIZE];
+  alignas(GATHER_PIPE_SIZE) u8 m_gather_pipe[GATHER_PIPE_EXTRA_SIZE]{};
 
   Core::System& m_system;
 };

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -201,19 +201,19 @@ union USIEXIClockCount
 
 struct SerialInterfaceState::Data
 {
-  CoreTiming::EventType* event_type_change_device;
-  CoreTiming::EventType* event_type_tranfer_pending;
-  std::array<CoreTiming::EventType*, MAX_SI_CHANNELS> event_types_device;
+  CoreTiming::EventType* event_type_change_device = nullptr;
+  CoreTiming::EventType* event_type_tranfer_pending = nullptr;
+  std::array<CoreTiming::EventType*, MAX_SI_CHANNELS> event_types_device{};
 
   // User-configured device type. possibly overridden by TAS/Netplay
-  std::array<std::atomic<SIDevices>, MAX_SI_CHANNELS> desired_device_types;
+  std::array<std::atomic<SIDevices>, MAX_SI_CHANNELS> desired_device_types{};
 
-  std::array<SSIChannel, MAX_SI_CHANNELS> channel;
+  std::array<SSIChannel, MAX_SI_CHANNELS> channel{};
   USIPoll poll;
   USIComCSR com_csr;
   USIStatusReg status_reg;
   USIEXIClockCount exi_clock_count;
-  std::array<u8, 128> si_buffer;
+  std::array<u8, 128> si_buffer{};
 };
 
 SerialInterfaceState::SerialInterfaceState() : m_data(std::make_unique<Data>())

--- a/Source/Core/Core/HW/Sram.h
+++ b/Source/Core/Core/HW/Sram.h
@@ -122,9 +122,9 @@ struct SramSettingsEx
 
 struct Sram
 {
-  Common::BigEndianValue<u32> rtc;
-  SramSettings settings;
-  SramSettingsEx settings_ex;
+  Common::BigEndianValue<u32> rtc{};
+  SramSettings settings{};
+  SramSettingsEx settings_ex{};
   // Allow access to this entire structure as a raw blob
   // Typical union-with-byte-array method can't be used here on GCC
   u8& operator[](size_t offset) { return reinterpret_cast<u8*>(&rtc)[offset]; }

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -51,8 +51,8 @@ struct VideoInterfaceState::Data
   UVIFBInfoRegister xfb_info_bottom;
   UVIFBInfoRegister xfb_3d_info_top;  // Start making your stereoscopic demos! :p
   UVIFBInfoRegister xfb_3d_info_bottom;
-  std::array<UVIInterruptRegister, 4> interrupt_register;
-  std::array<UVILatchRegister, 2> latch_register;
+  std::array<UVIInterruptRegister, 4> interrupt_register{};
+  std::array<UVILatchRegister, 2> latch_register{};
   PictureConfigurationRegister picture_configuration;
   UVIHorizontalScaling horizontal_scaling;
   SVIFilterCoefTables filter_coef_tables;
@@ -68,15 +68,15 @@ struct VideoInterfaceState::Data
   u32 target_refresh_rate_numerator = 0;
   u32 target_refresh_rate_denominator = 1;
 
-  u64 ticks_last_line_start;      // number of ticks when the current full scanline started
-  u32 half_line_count;            // number of halflines that have occurred for this full frame
-  u32 half_line_of_next_si_poll;  // halfline when next SI poll results should be available
+  u64 ticks_last_line_start = 0;      // number of ticks when the current full scanline started
+  u32 half_line_count = 0;            // number of halflines that have occurred for this full frame
+  u32 half_line_of_next_si_poll = 0;  // halfline when next SI poll results should be available
 
   // below indexes are 0-based
-  u32 even_field_first_hl;  // index first halfline of the even field
-  u32 odd_field_first_hl;   // index first halfline of the odd field
-  u32 even_field_last_hl;   // index last halfline of the even field
-  u32 odd_field_last_hl;    // index last halfline of the odd field
+  u32 even_field_first_hl = 0;  // index first halfline of the even field
+  u32 odd_field_first_hl = 0;   // index first halfline of the odd field
+  u32 even_field_last_hl = 0;   // index last halfline of the even field
+  u32 odd_field_last_hl = 0;    // index last halfline of the odd field
 };
 
 VideoInterfaceState::VideoInterfaceState() : m_data(std::make_unique<Data>())

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -133,7 +133,7 @@ union UVIDisplayControlRegister
 
 union UVIHorizontalTiming0
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -151,7 +151,7 @@ union UVIHorizontalTiming0
 
 union UVIHorizontalTiming1
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -168,7 +168,7 @@ union UVIHorizontalTiming1
 // Exists for both odd and even fields
 union UVIVBlankTimingRegister
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -185,7 +185,7 @@ union UVIVBlankTimingRegister
 // Exists for both odd and even fields
 union UVIBurstBlankingRegister
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -201,7 +201,7 @@ union UVIBurstBlankingRegister
 
 union UVIFBInfoRegister
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -221,7 +221,7 @@ union UVIFBInfoRegister
 // VI Interrupt Register
 union UVIInterruptRegister
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -240,7 +240,7 @@ union UVIInterruptRegister
 
 union UVILatchRegister
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -257,7 +257,7 @@ union UVILatchRegister
 
 union PictureConfigurationRegister
 {
-  u16 Hex;
+  u16 Hex = 0;
   struct
   {
     u16 STD : 8;
@@ -284,7 +284,7 @@ union UVIHorizontalScaling
 // Used for tables 0-2
 union UVIFilterCoefTable3
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -301,7 +301,7 @@ union UVIFilterCoefTable3
 // Used for tables 3-6
 union UVIFilterCoefTable4
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -324,7 +324,7 @@ struct SVIFilterCoefTables
 // Debug video mode only, probably never used in Dolphin...
 union UVIBorderBlankRegister
 {
-  u32 Hex;
+  u32 Hex = 0;
   struct
   {
     u16 Lo, Hi;
@@ -341,7 +341,7 @@ union UVIBorderBlankRegister
 // ntsc-j and component cable bits
 union UVIDTVStatus
 {
-  u16 Hex;
+  u16 Hex = 0;
   struct
   {
     u16 component_plugged : 1;
@@ -352,7 +352,7 @@ union UVIDTVStatus
 
 union UVIHorizontalStepping
 {
-  u16 Hex;
+  u16 Hex = 0;
   struct
   {
     u16 srcwidth : 10;

--- a/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
+++ b/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
@@ -253,7 +253,7 @@ public:
 
   int DiskIOCtl(u8 pdrv, u8 cmd, void* buff) override { return vff_ioctl(m_vff, pdrv, cmd, buff); }
 
-  IOS::HLE::FS::FileHandle* m_vff;
+  IOS::HLE::FS::FileHandle* m_vff = nullptr;
 };
 }  // namespace
 

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -40,7 +40,7 @@ struct CachedInterpreter::Instruction
 
   union
   {
-    const CommonCallback common_callback;
+    const CommonCallback common_callback = nullptr;
     const ConditionalCallback conditional_callback;
   };
 

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineInfo.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineInfo.h
@@ -13,37 +13,37 @@
 struct TrampolineInfo final
 {
   // The start of the store operation that failed -- we will patch a JMP here
-  u8* start;
+  u8* start = nullptr;
 
   // The start + len = end of the store operation (points to the next instruction)
-  u32 len;
+  u32 len = 0;
 
   // The PPC PC for the current load/store block
-  u32 pc;
+  u32 pc = 0;
 
   // Saved because we need these to make the ABI call in the trampoline
-  BitSet32 registersInUse;
+  BitSet32 registersInUse{};
 
   // The MOV operation
-  Gen::X64Reg nonAtomicSwapStoreSrc;
+  Gen::X64Reg nonAtomicSwapStoreSrc{};
 
   // src/dest for load/store
-  s32 offset;
-  Gen::X64Reg op_reg;
-  Gen::OpArg op_arg;
+  s32 offset = 0;
+  Gen::X64Reg op_reg{};
+  Gen::OpArg op_arg{};
 
   // Original SafeLoadXXX/SafeStoreXXX flags
-  u8 flags;
+  u8 flags = 0;
 
   // Memory access size (in bytes)
-  u8 accessSize : 4;
+  u8 accessSize : 4 = 0;
 
   // true if this is a read op vs a write
-  bool read : 1;
+  bool read : 1 = false;
 
   // for read operations, true if needs sign-extension after load
-  bool signExtend : 1;
+  bool signExtend : 1 = false;
 
   // Set to true if we added the offset to the address and need to undo it
-  bool offsetAddedToAddress : 1;
+  bool offsetAddedToAddress : 1 = false;
 };

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -347,7 +347,7 @@ protected:
   void Force25BitPrecision(Arm64Gen::ARM64Reg output, Arm64Gen::ARM64Reg input);
 
   // <Fastmem fault location, slowmem handler location>
-  std::map<const u8*, FastmemArea> m_fault_to_handler;
+  std::map<const u8*, FastmemArea> m_fault_to_handler{};
   Arm64GPRCache gpr;
   Arm64FPRCache fpr;
 
@@ -359,11 +359,11 @@ protected:
   bool m_in_far_code = false;
 
   // Backed up when we switch to far code.
-  u8* m_near_code;
-  u8* m_near_code_end;
-  bool m_near_code_write_failed;
+  u8* m_near_code = nullptr;
+  u8* m_near_code_end = nullptr;
+  bool m_near_code_write_failed = false;
 
-  bool m_enable_blr_optimization;
+  bool m_enable_blr_optimization = false;
   bool m_cleanup_after_stackfault = false;
   u8* m_stack_base = nullptr;
   u8* m_stack_pointer = nullptr;

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -43,7 +43,7 @@ struct ContentFile
   std::string m_filename;
 
   // Offset from the start of the file where the first byte of this content chunk is.
-  u64 m_offset;
+  u64 m_offset = 0;
 };
 
 // Content chunk that loads data from a DirectoryBlobReader.
@@ -54,20 +54,20 @@ struct ContentPartition
   DirectoryBlobReader* m_reader;
 
   // Offset from the start of the partition for the first byte represented by this chunk.
-  u64 m_offset;
+  u64 m_offset = 0;
 
   // The value passed as partition_data_offset to EncryptPartitionData().
-  u64 m_partition_data_offset;
+  u64 m_partition_data_offset = 0;
 };
 
 // Content chunk that loads data from a Volume.
 struct ContentVolume
 {
   // Offset from the start of the volume for the first byte represented by this chunk.
-  u64 m_offset;
+  u64 m_offset = 0;
 
   // The volume to read data from.
-  const Volume* m_volume;
+  const Volume* m_volume = nullptr;
 
   // The partition passed to the Volume's Read() method.
   Partition m_partition;
@@ -77,7 +77,7 @@ struct ContentVolume
 // Useful for padding between chunks within a file.
 struct ContentFixedByte
 {
-  u8 m_byte;
+  u8 m_byte = 0;
 };
 
 // Content chunk representing an arbitrary byte sequence that's stored within the struct itself.
@@ -96,15 +96,15 @@ using ContentSource = std::variant<ContentFile,       // File
 
 struct BuilderContentSource
 {
-  u64 m_offset;
-  u64 m_size;
+  u64 m_offset = 0;
+  u64 m_size = 0;
   ContentSource m_source;
 };
 
 struct FSTBuilderNode
 {
   std::string m_filename;
-  u64 m_size;
+  u64 m_size = 0;
   std::variant<std::vector<BuilderContentSource>, std::vector<FSTBuilderNode>> m_content;
   void* m_user_data = nullptr;
 

--- a/Source/Core/DiscIO/RiivolutionParser.h
+++ b/Source/Core/DiscIO/RiivolutionParser.h
@@ -54,7 +54,7 @@ struct Option
 
   // The currently selected patch choice in the m_choices vector.
   // Note that this index is 1-based; 0 means no choice is selected and this Option is disabled.
-  u32 m_selected_choice;
+  u32 m_selected_choice = 0;
 };
 
 // A single page of options presented to the user in the Riivolution GUI.
@@ -177,7 +177,7 @@ struct Patch
 struct Disc
 {
   // Riivolution version. Only '1' exists at time of writing.
-  int m_version;
+  int m_version = 0;
 
   // Info about which game and revision these patches are for.
   GameFilter m_game_filter;
@@ -209,7 +209,7 @@ struct ConfigOption
   std::string m_id;
 
   // The selected Choice index.
-  u32 m_default;
+  u32 m_default = 0;
 };
 
 struct Config

--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.h
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.h
@@ -15,10 +15,10 @@ class QTableWidget;
 
 struct Diff
 {
-  u32 addr;
+  u32 addr = 0;
   std::string symbol;
-  u32 hits;
-  u32 total_hits;
+  u32 hits = 0;
+  u32 total_hits = 0;
 
   bool operator<(const std::string& val) const { return symbol < val; }
 };

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -153,10 +153,10 @@ private:
   const std::string m_server_address;
   const u16 m_server_port;
 
-  s16 m_touch_x_min;
-  s16 m_touch_y_min;
-  s16 m_touch_x_max;
-  s16 m_touch_y_max;
+  s16 m_touch_x_min = 0;
+  s16 m_touch_y_min = 0;
+  s16 m_touch_x_max = 0;
+  s16 m_touch_y_max = 0;
 
   const u32 m_client_uid;
 };
@@ -192,7 +192,7 @@ struct Server
 
   std::string m_description;
   std::string m_address;
-  u16 m_port;
+  u16 m_port = 0;
   std::array<Proto::MessageType::PortInfo, Proto::PORT_COUNT> m_port_info{};
   sf::UdpSocket m_socket;
   SteadyClock::time_point m_disconnect_time = SteadyClock::now();
@@ -213,9 +213,9 @@ private:
   void StartHotplugThread();
   void StopHotplugThread();
 
-  bool m_servers_enabled;
+  bool m_servers_enabled = false;
   std::vector<Server> m_servers;
-  u32 m_client_uid;
+  u32 m_client_uid = 0;
   SteadyClock::time_point m_next_listports_time;
   std::thread m_hotplug_thread;
   Common::Flag m_hotplug_thread_running;

--- a/Source/Core/UICommon/Disassembler.h
+++ b/Source/Core/UICommon/Disassembler.h
@@ -21,9 +21,9 @@ public:
 struct DisassembleResult
 {
   std::string text;
-  u32 entry_address;
-  u32 instruction_count;
-  u32 code_size;
+  u32 entry_address = 0;
+  u32 instruction_count = 0;
+  u32 code_size = 0;
 };
 
 std::unique_ptr<HostDisassembler> GetNewDisassembler(const std::string& arch);

--- a/Source/Core/VideoBackends/Software/Tev.h
+++ b/Source/Core/VideoBackends/Software/Tev.h
@@ -122,9 +122,9 @@ class Tev
   static constexpr s16 V7_8 = 223;
   static constexpr s16 V1 = 255;
 
-  u8 AlphaBump;
-  u8 IndirectTex[4][4];
-  TextureCoordinateType TexCoord;
+  u8 AlphaBump = 0;
+  u8 IndirectTex[4][4]{};
+  TextureCoordinateType TexCoord{};
 
   const Common::EnumMap<TevColorRef, TevColorArg::Zero> m_ColorInputLUT{
       TevColorRef::Color(Reg[TevOutput::Prev]),    // prev.rgb
@@ -213,13 +213,13 @@ class Tev
   void Indirect(unsigned int stageNum, s32 s, s32 t);
 
 public:
-  s32 Position[3];
-  u8 Color[2][4];  // must be RGBA for correct swap table ordering
-  TextureCoordinateType Uv[8];
-  s32 IndirectLod[4];
-  bool IndirectLinear[4];
-  s32 TextureLod[16];
-  bool TextureLinear[16];
+  s32 Position[3]{};
+  u8 Color[2][4]{};  // must be RGBA for correct swap table ordering
+  TextureCoordinateType Uv[8]{};
+  s32 IndirectLod[4]{};
+  bool IndirectLinear[4]{};
+  s32 TextureLod[16]{};
+  bool TextureLinear[16]{};
 
   enum
   {

--- a/Source/Core/VideoCommon/AbstractPipeline.h
+++ b/Source/Core/VideoCommon/AbstractPipeline.h
@@ -40,16 +40,16 @@ enum class AbstractPipelineUsage
 
 struct AbstractPipelineConfig
 {
-  const NativeVertexFormat* vertex_format;
-  const AbstractShader* vertex_shader;
-  const AbstractShader* geometry_shader;
-  const AbstractShader* pixel_shader;
+  const NativeVertexFormat* vertex_format = nullptr;
+  const AbstractShader* vertex_shader = nullptr;
+  const AbstractShader* geometry_shader = nullptr;
+  const AbstractShader* pixel_shader = nullptr;
   RasterizationState rasterization_state;
   DepthState depth_state;
   BlendingState blending_state;
   FramebufferState framebuffer_state;
 
-  AbstractPipelineUsage usage;
+  AbstractPipelineUsage usage = AbstractPipelineUsage::GX;
 
   bool operator==(const AbstractPipelineConfig& rhs) const
   {

--- a/Source/Core/VideoCommon/CPUCull.h
+++ b/Source/Core/VideoCommon/CPUCull.h
@@ -29,10 +29,10 @@ private:
   {
     void operator()(T* ptr);
   };
-  std::unique_ptr<TransformedVertex[], BufferDeleter<TransformedVertex>> m_transform_buffer;
+  std::unique_ptr<TransformedVertex[], BufferDeleter<TransformedVertex>> m_transform_buffer{};
   u32 m_transform_buffer_size = 0;
-  std::array<std::array<TransformFunction, 2>, 2> m_transform_table;
+  std::array<std::array<TransformFunction, 2>, 2> m_transform_table{};
   Common::EnumMap<Common::EnumMap<CullFunction, CullMode::All>,
                   OpcodeDecoder::Primitive::GX_DRAW_TRIANGLE_FAN>
-      m_cull_table;
+      m_cull_table{};
 };

--- a/Source/Core/VideoCommon/OnScreenUI.h
+++ b/Source/Core/VideoCommon/OnScreenUI.h
@@ -59,9 +59,6 @@ public:
   void SetMousePress(u32 button_mask);
 
 private:
-  // Destroys all ImGui GPU resources, must do before shutdown.
-  void ShutdownImGui();
-
   void DrawDebugText();
 
   // ImGui resources.

--- a/Source/Core/VideoCommon/OnScreenUI.h
+++ b/Source/Core/VideoCommon/OnScreenUI.h
@@ -69,7 +69,7 @@ private:
   std::vector<std::unique_ptr<AbstractTexture>> m_imgui_textures;
   std::unique_ptr<AbstractPipeline> m_imgui_pipeline;
   std::mutex m_imgui_mutex;
-  u64 m_imgui_last_frame_time;
+  u64 m_imgui_last_frame_time = 0;
 
   u32 m_backbuffer_width = 1;
   u32 m_backbuffer_height = 1;

--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -54,9 +54,9 @@ private:
   mutable std::shared_mutex m_time_lock;
 
   u8 m_time_index = 0;
-  std::array<TimePoint, 256> m_real_times;
-  std::array<TimePoint, 256> m_cpu_times;
-  DT m_time_sleeping;
+  std::array<TimePoint, 256> m_real_times{};
+  std::array<TimePoint, 256> m_cpu_times{};
+  DT m_time_sleeping{};
 };
 
 extern PerformanceMetrics g_perf_metrics;

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -53,7 +53,7 @@ union RasterizationState
   BitField<0, 2, CullMode> cullmode;
   BitField<3, 2, PrimitiveType> primitive;
 
-  u32 hex;
+  u32 hex = 0;
 };
 
 union FramebufferState
@@ -80,7 +80,7 @@ union FramebufferState
   BitField<16, 8, u32> samples;
   BitField<24, 1, u32> per_sample_shading;
 
-  u32 hex;
+  u32 hex = 0;
 };
 
 union DepthState
@@ -109,7 +109,7 @@ union DepthState
   BitField<1, 1, u32> updateenable;
   BitField<2, 3, CompareMode> func;
 
-  u32 hex;
+  u32 hex = 0;
 };
 
 union BlendingState
@@ -155,7 +155,7 @@ union BlendingState
 
   bool RequiresDualSrc() const;
 
-  u32 hex;
+  u32 hex = 0;
 };
 
 struct SamplerState
@@ -200,14 +200,14 @@ struct SamplerState
     BitField<8, 16, s32> lod_bias;         // multiplied by 256, higher precision than normal
     BitField<24, 1, bool, u32> lod_clamp;  // TODO: This isn't currently implemented
     BitField<25, 1, bool, u32> anisotropic_filtering;  // TODO: This doesn't use the BP one yet
-    u32 hex;
+    u32 hex = 0;
   };
   union TM1
   {
     // Min is guaranteed to be less than or equal to max
     BitField<0, 8, u32> min_lod;  // multiplied by 16
     BitField<8, 8, u32> max_lod;  // multiplied by 16
-    u32 hex;
+    u32 hex = 0;
   };
 
   TM0 tm0;

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -10,22 +10,22 @@
 
 struct Statistics
 {
-  int num_pixel_shaders_created;
-  int num_pixel_shaders_alive;
-  int num_vertex_shaders_created;
-  int num_vertex_shaders_alive;
+  int num_pixel_shaders_created = 0;
+  int num_pixel_shaders_alive = 0;
+  int num_vertex_shaders_created = 0;
+  int num_vertex_shaders_alive = 0;
 
-  int num_textures_created;
-  int num_textures_uploaded;
-  int num_textures_alive;
+  int num_textures_created = 0;
+  int num_textures_uploaded = 0;
+  int num_textures_alive = 0;
 
-  int num_vertex_loaders;
+  int num_vertex_loaders = 0;
 
-  std::array<float, 6> proj;
-  std::array<float, 16> gproj;
-  std::array<float, 16> g2proj;
+  std::array<float, 6> proj{};
+  std::array<float, 16> gproj{};
+  std::array<float, 16> g2proj{};
 
-  std::vector<BPFunctions::ScissorResult> scissors;
+  std::vector<BPFunctions::ScissorResult> scissors{};
   size_t current_scissor = 0;  // 0 => all, otherwise index + 1
   int scissor_scale = 10;
   int scissor_expected_count = 0;
@@ -37,44 +37,44 @@ struct Statistics
 
   struct ThisFrame
   {
-    int num_bp_loads;
-    int num_cp_loads;
-    int num_xf_loads;
+    int num_bp_loads = 0;
+    int num_cp_loads = 0;
+    int num_xf_loads = 0;
 
-    int num_bp_loads_in_dl;
-    int num_cp_loads_in_dl;
-    int num_xf_loads_in_dl;
+    int num_bp_loads_in_dl = 0;
+    int num_cp_loads_in_dl = 0;
+    int num_xf_loads_in_dl = 0;
 
-    int num_prims;
-    int num_dl_prims;
-    int num_shader_changes;
+    int num_prims = 0;
+    int num_dl_prims = 0;
+    int num_shader_changes = 0;
 
-    int num_primitive_joins;
-    int num_draw_calls;
+    int num_primitive_joins = 0;
+    int num_draw_calls = 0;
 
-    int num_dlists_called;
+    int num_dlists_called = 0;
 
-    int bytes_vertex_streamed;
-    int bytes_index_streamed;
-    int bytes_uniform_streamed;
+    int bytes_vertex_streamed = 0;
+    int bytes_index_streamed = 0;
+    int bytes_uniform_streamed = 0;
 
-    int num_triangles_clipped;
-    int num_triangles_in;
-    int num_triangles_rejected;
-    int num_triangles_culled;
-    int num_drawn_objects;
-    int rasterized_pixels;
-    int num_triangles_drawn;
-    int num_vertices_loaded;
-    int tev_pixels_in;
-    int tev_pixels_out;
+    int num_triangles_clipped = 0;
+    int num_triangles_in = 0;
+    int num_triangles_rejected = 0;
+    int num_triangles_culled = 0;
+    int num_drawn_objects = 0;
+    int rasterized_pixels = 0;
+    int num_triangles_drawn = 0;
+    int num_vertices_loaded = 0;
+    int tev_pixels_in = 0;
+    int tev_pixels_out = 0;
 
-    int num_efb_peeks;
-    int num_efb_pokes;
+    int num_efb_peeks = 0;
+    int num_efb_pokes = 0;
 
-    int num_draw_done;
-    int num_token;
-    int num_token_int;
+    int num_draw_done = 0;
+    int num_token = 0;
+    int num_token_int = 0;
   };
   ThisFrame this_frame;
   void ResetFrame();

--- a/Source/Core/VideoCommon/VideoEvents.h
+++ b/Source/Core/VideoCommon/VideoEvents.h
@@ -28,21 +28,21 @@ struct PresentInfo
   };
 
   // The number of (unique) frames since the emulated console booted
-  u64 frame_count;
+  u64 frame_count = 0;
 
   // The number of presents since the video backend was initialized.
   // never goes backwards.
-  u64 present_count;
+  u64 present_count = 0;
 
   // The frame is identical to the previous frame
-  PresentReason reason;
+  PresentReason reason = PresentReason::Immediate;
 
   // The exact emulated time of the when real hardware would have presented this frame
   // FIXME: Immediate should predict the timestamp of this present
-  u64 emulated_timestamp;
+  u64 emulated_timestamp = 0;
 
   // TODO:
-  // u64 intended_present_time;
+  // u64 intended_present_time = 0;
 
   // AfterPresent only: The actual time the frame was presented
   u64 actual_present_time = 0;


### PR DESCRIPTION
Similar to #10085, this fixes occurrences of [C26495](https://docs.microsoft.com/en-us/cpp/code-quality/c26495?view=msvc-160) in Dolphin code found by Visual Studio's analyzer, along with a few other issues not found by it.

Several of these were caused by things that were previously static variables being converted to class members. Others are just from new code.