### PR TITLE
Externals/FreeSurround: Fix pointer created through new[] being freed via delete

### DIFF
--- a/Externals/FreeSurround/source/FreeSurroundDecoder.cpp
+++ b/Externals/FreeSurround/source/FreeSurroundDecoder.cpp
@@ -31,10 +31,8 @@ DPL2FSDecoder::DPL2FSDecoder() {
 }
 
 DPL2FSDecoder::~DPL2FSDecoder() {
-#pragma warning(suppress : 4150)
-  delete forward;
-#pragma warning(suppress : 4150)
-  delete inverse;
+  kiss_fftr_free(forward);
+  kiss_fftr_free(inverse);
 }
 
 void DPL2FSDecoder::Init(channel_setup chsetup, unsigned int blsize,

--- a/Externals/FreeSurround/source/KissFFTR.cpp
+++ b/Externals/FreeSurround/source/KissFFTR.cpp
@@ -65,7 +65,7 @@ kiss_fftr_cfg kiss_fftr_alloc(int nfft, int inverse_fft, void *mem,
               sizeof(kiss_fft_cpx) * (nfft * 3 / 2);
 
   if (lenmem == NULL) {
-    st = (kiss_fftr_cfg) new char[memneeded];
+    st = (kiss_fftr_cfg)malloc(memneeded);
   } else {
     if (*lenmem >= memneeded)
       st = (kiss_fftr_cfg)mem;


### PR DESCRIPTION
Doing so is not allowed (presumably because compilers are allowed to use a different algorithm for allocating between the two/store extra data such as the length of the array before the pointer).

This bug existed in the original implementation at https://web.archive.org/web/20140708092159/http://www.hydrogenaud.io/forums/index.php?showtopic=52235 and causes Valgrind to emit a warning. Note that this ended up happening even if DSPLLE and the DPL decoder are not enabled in Dolphin.

<details><summary>Here's the warning in question:</summary>

```
==115== Thread 12 Emuthread - Sta:
==115== Mismatched free() / delete / delete []
==115==    at 0x483CFBF: operator delete(void*) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==115==    by 0xBBA07B: DPL2FSDecoder::~DPL2FSDecoder() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBAFAB5: AudioCommon::SurroundDecoder::~SurroundDecoder() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBAF9D7: Mixer::~Mixer() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBB1370: AlsaSound::~AlsaSound() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBB13BC: AlsaSound::~AlsaSound() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBABE7C: AudioCommon::InitSoundStream(Core::System&) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0x560699: Core::EmuThread(std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0x56203A: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo), std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo> > >::_M_run() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xA574DE3: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==115==    by 0xA483608: start_thread (pthread_create.c:477)
==115==    by 0xA8EE132: clone (clone.S:95)
==115==  Address 0x1d863110 is 0 bytes inside a block of size 41,248 alloc'd
==115==    at 0x483C583: operator new[](unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==115==    by 0xBC0DB4: kiss_fftr_alloc (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBBABF9: DPL2FSDecoder::Init(channel_setup, unsigned int, unsigned int) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBAF736: Mixer::Mixer(unsigned int) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBB1620: AlsaSound::AlsaSound() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBAAE65: AudioCommon::CreateSoundStreamForBackend(std::basic_string_view<char, std::char_traits<char> >) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBABB60: AudioCommon::InitSoundStream(Core::System&) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0x560699: Core::EmuThread(std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0x56203A: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo), std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo> > >::_M_run() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xA574DE3: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==115==    by 0xA483608: start_thread (pthread_create.c:477)
==115==    by 0xA8EE132: clone (clone.S:95)
==115==
==115== Mismatched free() / delete / delete []
==115==    at 0x483CFBF: operator delete(void*) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==115==    by 0xBBA08C: DPL2FSDecoder::~DPL2FSDecoder() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBAFAB5: AudioCommon::SurroundDecoder::~SurroundDecoder() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBAF9D7: Mixer::~Mixer() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBB1370: AlsaSound::~AlsaSound() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBB13BC: AlsaSound::~AlsaSound() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBABE7C: AudioCommon::InitSoundStream(Core::System&) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0x560699: Core::EmuThread(std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0x56203A: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo), std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo> > >::_M_run() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xA574DE3: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==115==    by 0xA483608: start_thread (pthread_create.c:477)
==115==    by 0xA8EE132: clone (clone.S:95)
==115==  Address 0xdd08330 is 0 bytes inside a block of size 41,248 alloc'd
==115==    at 0x483C583: operator new[](unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==115==    by 0xBC0DB4: kiss_fftr_alloc (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBBAC11: DPL2FSDecoder::Init(channel_setup, unsigned int, unsigned int) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBAF736: Mixer::Mixer(unsigned int) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBB1620: AlsaSound::AlsaSound() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBAAE65: AudioCommon::CreateSoundStreamForBackend(std::basic_string_view<char, std::char_traits<char> >) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xBABB60: AudioCommon::InitSoundStream(Core::System&) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0x560699: Core::EmuThread(std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo) (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0x56203A: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo), std::unique_ptr<BootParameters, std::default_delete<BootParameters> >, WindowSystemInfo> > >::_M_run() (in /mnt/c/users/pokechu22/source/repos/dolphin/WSL/Binaries/dolphin-emu)
==115==    by 0xA574DE3: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==115==    by 0xA483608: start_thread (pthread_create.c:477)
==115==    by 0xA8EE132: clone (clone.S:95)
```

</details>

As far as I can tell, there isn't really an upstream for FreeSurround anymore, and we've already modified it a fair bit (#5235 modified it). So perhaps we should move it out of externals and into the main codebase?