### PR TITLE
Jit64: Use 5 byte jump in mtmsr for the CP interrupt check.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -460,7 +460,7 @@ void Jit64::mtmsr(UGeckoInstruction inst)
   auto& system = Core::System::GetInstance();
   MOV(64, R(RSCRATCH), ImmPtr(&system.GetProcessorInterface().m_interrupt_cause));
   TEST(32, MatR(RSCRATCH), Imm32(ProcessorInterface::INT_CAUSE_CP));
-  FixupBranch cpInt = J_CC(CC_NZ);
+  FixupBranch cpInt = J_CC(CC_NZ, true);
 
   MOV(32, PPCSTATE(pc), Imm32(js.compilerPC + 4));
   WriteExternalExceptionExit();


### PR DESCRIPTION
WriteExternalExceptionExit() can write more than the maximum offset of the small jump.

Fixes this issue in Resident Evil Archives (the REmake port for the Wii):
https://cdn.discordapp.com/attachments/521711075721478145/1075605414311374929/image.png