### PR TITLE
Check the input and destination paths before converting a game file onto itself

### DIFF
--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -4,6 +4,7 @@
 #include "DolphinQt/ConvertDialog.h"
 
 #include <algorithm>
+#include <filesystem>
 #include <functional>
 #include <future>
 #include <memory>
@@ -22,6 +23,7 @@
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
+#include "Common/StringUtil.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/DiscUtils.h"
 #include "DiscIO/ScrubbedBlob.h"
@@ -407,6 +409,21 @@ void ConvertDialog::Convert()
 
         if (confirm_replace.exec() == QMessageBox::No)
           continue;
+      }
+    }
+
+    if (std::filesystem::exists(StringToPath(dst_path.toStdString())))
+    {
+      std::error_code ec;
+      if (std::filesystem::equivalent(StringToPath(dst_path.toStdString()),
+                                      StringToPath(original_path), ec))
+      {
+        ModalMessageBox::critical(
+            this, tr("Error"),
+            tr("The destination file cannot be the same as the source file\n\n"
+               "Please select another destination path for \"%1\"")
+                .arg(QString::fromStdString(original_path)));
+        continue;
       }
     }
 

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -387,6 +387,8 @@ void ConvertDialog::Convert()
       return;
   }
 
+  int success_count = 0;
+
   for (const auto& file : m_files)
   {
     const auto original_path = file->GetFilePath();
@@ -524,11 +526,13 @@ void ConvertDialog::Convert()
                                   tr("Dolphin failed to complete the requested action."));
         return;
       }
+
+      success_count++;
     }
   }
 
   ModalMessageBox::information(this, tr("Success"),
-                               tr("Successfully converted %n image(s).", "", m_files.size()));
+                               tr("Successfully converted %n image(s).", "", success_count));
 
   close();
 }


### PR DESCRIPTION
Before these changes you could tell Dolphin to convert a game file into the same format it is already in, leading to the FileDialog using the input path as the default destination path

An unsuspecting user could then click Save and Dolphin would try to convert the input file by writing the destination file on top of it... leading to an I/O error and the input file being entirely removed

Instead of denying the user the ability to select the format already used by the input file (which would be annoying if someone wants to convert from RVZ to RVZ but with other compression settings), we can check if the input and destination paths are equal and error out before having the input file accidentally removed