### PR TITLE
AudioPane: Fix inconsistent initial state of audio stretching labels

### DIFF
--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -247,8 +247,10 @@ void AudioPane::LoadSettings()
 
   // Stretch
   m_stretching_enable->setChecked(Config::Get(Config::MAIN_AUDIO_STRETCH));
+  m_stretching_buffer_label->setEnabled(m_stretching_enable->isChecked());
   m_stretching_buffer_slider->setValue(Config::Get(Config::MAIN_AUDIO_STRETCH_LATENCY));
   m_stretching_buffer_slider->setEnabled(m_stretching_enable->isChecked());
+  m_stretching_buffer_indicator->setEnabled(m_stretching_enable->isChecked());
   m_stretching_buffer_indicator->setText(tr("%1 ms").arg(m_stretching_buffer_slider->value()));
 
 #ifdef _WIN32


### PR DESCRIPTION
This resulted in the labels being solid black even when audio stretching is disabled the first time the settings are opened, but then properly being greyed out after changing a setting (even the audio backend or DSP emulation engine, not just whether audio stretching is enabled).

<details><summary>Old:</summary>

![image](https://user-images.githubusercontent.com/8334194/219827989-5484e68d-e82d-4cbf-b9b1-795708e1ff09.png)

</details><details><summary>New:</summary>

![image](https://user-images.githubusercontent.com/8334194/219827994-8bfd67bf-51e3-4932-9ae2-8a3b1926aa83.png)

</details>

See the code in `SaveSettings`:

https://github.com/dolphin-emu/dolphin/blob/74abf482347e3073d2115a10ff72019567d03f3c/Source/Core/DolphinQt/Settings/AudioPane.cpp#L314-L321