### PR TITLE
WinUpdater: fix typo, add troubleshooting help

### DIFF
--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -182,7 +182,7 @@ void Error(const std::string& text)
   auto wide_text = UTF8ToWString(text);
 
   MessageBox(nullptr,
-             (L"A fatal error occured and the updater cannot continue:\n " + wide_text).c_str(),
+             (L"A fatal error occurred and the updater cannot continue. If this persists, please redownload the latest update manually:\n " + wide_text).c_str(),
              L"Error", MB_ICONERROR);
 
   if (taskbar_list)

--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -182,7 +182,7 @@ void Error(const std::string& text)
   auto wide_text = UTF8ToWString(text);
 
   MessageBox(nullptr,
-             (L"A fatal error occurred and the updater cannot continue. If this persists, please redownload the latest update manually:\n " + wide_text).c_str(),
+             (L"A fatal error occurred and the updater cannot continue:\n" + wide_text + "\nIf this persists, please redownload the latest update manually.").c_str(),
              L"Error", MB_ICONERROR);
 
   if (taskbar_list)

--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -181,8 +181,10 @@ void Error(const std::string& text)
 {
   auto wide_text = UTF8ToWString(text);
 
-  MessageBox(nullptr,
-             (L"A fatal error occurred and the updater cannot continue:\n" + wide_text + "\nIf this persists, please redownload the latest update manually.").c_str(),
+    MessageBox(nullptr,
+             (L"A fatal error occurred and the updater cannot continue:\n" + wide_text +
+              L"\nIf this persists, please redownload the latest update manually.")
+                 .c_str(),
              L"Error", MB_ICONERROR);
 
   if (taskbar_list)


### PR DESCRIPTION
For reasons I can't really explain, the updater randomly failing every so often has been a recurring issue for a lot of people - users will just get stuck and be unable to update until they download the latest version themselves, at which point the problem magically resolves itself.