### PR TITLE
Qt/CodeViewWidget: Small fixes to Update().

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -295,9 +295,6 @@ void CodeViewWidget::Update(const Core::CPUThreadGuard* guard)
 
   u32 pc = PowerPC::ppcState.pc;
 
-  if (Core::GetState() != Core::State::Paused && PowerPC::debug_interface.IsBreakpoint(pc))
-    Core::SetState(Core::State::Paused);
-
   const bool dark_theme = qApp->palette().color(QPalette::Base).valueF() < 0.5;
 
   m_branches.clear();

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -293,7 +293,7 @@ void CodeViewWidget::Update(const Core::CPUThreadGuard* guard)
   for (int i = 0; i < rows; i++)
     setRowHeight(i, rowh);
 
-  u32 pc = PowerPC::ppcState.pc;
+  const std::optional<u32> pc = guard ? std::make_optional(PowerPC::ppcState.pc) : std::nullopt;
 
   const bool dark_theme = qApp->palette().color(QPalette::Base).valueF() < 0.5;
 


### PR DESCRIPTION
The Breakpoint check seems completely unnecessary and caused spurious breaks with conditional breakpoints (because `IsBreakpoint()` returns true for them even if the condition evaluates to false).

Reading `ppcState.pc` doesn't give meaningful results when the CPU is running so don't do that either.