### PR TITLE
Android: Add LeakCanary debug dependency

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -128,6 +128,8 @@ android {
 }
 
 dependencies {
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
+
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.0'
 
     implementation 'androidx.core:core-ktx:1.9.0'


### PR DESCRIPTION
This is a dependency only added in our debug builds where we get a notification and description for memory leaks in the app. Really useful for finding old cases where we would leak contexts/views/etc.