### PR TITLE
Common/FileUtil: Rename Copy() to CopyRegularFile().

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -312,8 +312,7 @@ bool RenameSync(const std::string& srcFilename, const std::string& destFilename)
   return true;
 }
 
-// copies file source_path to destination_path, returns true on success
-bool Copy(const std::string& source_path, const std::string& destination_path)
+bool CopyRegularFile(std::string_view source_path, std::string_view destination_path)
 {
   DEBUG_LOG_FMT(COMMON, "{}: {} --> {}", __func__, source_path, destination_path);
 

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -169,8 +169,9 @@ bool Rename(const std::string& srcFilename, const std::string& destFilename);
 // ditto, but syncs the source file and, on Unix, syncs the directories after rename
 bool RenameSync(const std::string& srcFilename, const std::string& destFilename);
 
-// copies file srcFilename to destFilename, returns true on success
-bool Copy(const std::string& srcFilename, const std::string& destFilename);
+// Copies a file at source_path to destination_path, as if by std::filesystem::copy_file().
+// If a file already exists at destination_path it is overwritten. Returns true on success.
+bool CopyRegularFile(std::string_view source_path, std::string_view destination_path);
 
 // creates an empty file filename, returns true on success
 bool CreateEmptyFile(const std::string& filename);

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -589,7 +589,7 @@ ResultCode HostFileSystem::Rename(Uid uid, Gid gid, const std::string& old_path,
     {
       // If either path is a redirect, the source and target may be on a different partition or
       // device, so a simple rename may not work. Fall back to Copy & Delete and see if that works.
-      if (!File::Copy(host_old_path, host_new_path))
+      if (!File::CopyRegularFile(host_old_path, host_new_path))
       {
         ERROR_LOG_FMT(IOS_FS, "Copying {} to {} in Rename fallback failed", host_old_path,
                       host_new_path);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1432,7 +1432,7 @@ void SaveRecording(const std::string& filename)
   if (success && s_bRecordingFromSaveState)
   {
     std::string stateFilename = filename + ".sav";
-    success = File::Copy(File::GetUserPath(D_STATESAVES_IDX) + "dtm.sav", stateFilename);
+    success = File::CopyRegularFile(File::GetUserPath(D_STATESAVES_IDX) + "dtm.sav", stateFilename);
   }
 
   if (success)

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -59,7 +59,7 @@ static bool CopyBackupFile(const std::string& path_from, const std::string& path
 
   File::CreateFullPath(path_to);
 
-  return File::Copy(path_from, path_to);
+  return File::CopyRegularFile(path_from, path_to);
 }
 
 static void DeleteBackupFile(const std::string& file_name)

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -433,12 +433,12 @@ bool UpdateFiles(const std::vector<TodoList::UpdateOp>& to_update,
     // Unfortunately, there is a quirk in the kernel with how it handles the cache: if the file is
     // simply overwritten, the cache isn't invalidated and the old code signature is used to verify
     // the new file. This causes macOS to kill the process with a code signing error. To workaround
-    // this, we use File::Rename() instead of File::Copy(). However, this also means that if two
-    // files have the same hash, the first file will succeed, but the second file will fail because
-    // the source file no longer exists. To deal with this, we copy the content file to a temporary
-    // file and then rename the temporary file to the destination path.
+    // this, we use File::Rename() instead of File::CopyRegularFile(). However, this also means that
+    // if two files have the same hash, the first file will succeed, but the second file will fail
+    // because the source file no longer exists. To deal with this, we copy the content file to a
+    // temporary file and then rename the temporary file to the destination path.
     const std::string temporary_file = temp_path + DIR_SEP + "temporary_file";
-    if (!File::Copy(temp_path + DIR_SEP + content_filename, temporary_file))
+    if (!File::CopyRegularFile(temp_path + DIR_SEP + content_filename, temporary_file))
     {
       fprintf(log_fp, "Could not copy %s to %s.\n", content_filename.c_str(),
               temporary_file.c_str());
@@ -447,7 +447,7 @@ bool UpdateFiles(const std::vector<TodoList::UpdateOp>& to_update,
 
     if (!File::Rename(temporary_file, path))
 #else
-    if (!File::Copy(temp_path + DIR_SEP + content_filename, path))
+    if (!File::CopyRegularFile(temp_path + DIR_SEP + content_filename, path))
 #endif
     {
       fprintf(log_fp, "Could not update file %s.\n", op.filename.c_str());


### PR DESCRIPTION
It can only copy files, not directories, so make that clear in the name. (also so I can free up the name for a generic copy-any function)

I originally wanted to name this just `CopyFile()` but then realized that Windows.h has a `#define` for that, so that'd be probably more trouble than it's worth. If you have a better name suggestion feel free.