### PR TITLE
Common/FileUtil: Migrate CopyDir() to a more clear interface.

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -516,6 +516,31 @@ bool DeleteDirRecursively(const std::string& directory)
   return success;
 }
 
+bool Copy(std::string_view source_path, std::string_view dest_path, bool overwrite_existing)
+{
+  DEBUG_LOG_FMT(COMMON, "{}: {} --> {} ({})", __func__, source_path, dest_path,
+                overwrite_existing ? "overwrite" : "preserve");
+
+  auto src_path = StringToPath(source_path);
+  auto dst_path = StringToPath(dest_path);
+  std::error_code error;
+  auto options = fs::copy_options::recursive;
+  if (overwrite_existing)
+    options |= fs::copy_options::overwrite_existing;
+  fs::copy(src_path, dst_path, options, error);
+  if (error)
+  {
+    std::error_code error_ignored;
+    if (fs::equivalent(src_path, dst_path, error_ignored))
+      return true;
+
+    ERROR_LOG_FMT(COMMON, "{}: failed {} --> {} ({}): {}", __func__, source_path, dest_path,
+                  overwrite_existing ? "overwrite" : "preserve", error.message());
+    return false;
+  }
+  return true;
+}
+
 // Create directory and copy contents (optionally overwrites existing files)
 bool CopyDir(const std::string& source_path, const std::string& dest_path, const bool destructive)
 {

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -201,7 +201,8 @@ bool CreateDir(const std::string& path)
   auto native_path = StringToPath(path);
   bool success = fs::create_directory(native_path, error);
   // If the path was not created, check if it was a pre-existing directory
-  if (!success && fs::is_directory(native_path))
+  std::error_code error_ignored;
+  if (!success && fs::is_directory(native_path, error_ignored))
     success = true;
   if (!success)
     ERROR_LOG_FMT(COMMON, "{}: failed on {}: {}", __func__, path, error.message());
@@ -232,7 +233,8 @@ bool CreateFullPath(std::string_view fullPath)
   auto native_path = StringToPath(fullPath).parent_path();
   bool success = fs::create_directories(native_path, error);
   // If the path was not created, check if it was a pre-existing directory
-  if (!success && fs::is_directory(native_path))
+  std::error_code error_ignored;
+  if (!success && fs::is_directory(native_path, error_ignored))
     success = true;
   if (!success)
     ERROR_LOG_FMT(COMMON, "{}: failed on {}: {}", __func__, fullPath, error.message());

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -610,29 +610,6 @@ bool MoveWithOverwrite(std::string_view source_path, std::string_view dest_path)
   return true;
 }
 
-// Create directory and copy contents (optionally overwrites existing files)
-bool CopyDir(const std::string& source_path, const std::string& dest_path, const bool destructive)
-{
-  auto src_path = StringToPath(source_path);
-  auto dst_path = StringToPath(dest_path);
-  if (fs::equivalent(src_path, dst_path))
-    return true;
-
-  DEBUG_LOG_FMT(COMMON, "{}: {} --> {}", __func__, source_path, dest_path);
-
-  auto options = fs::copy_options::recursive;
-  if (destructive)
-    options |= fs::copy_options::overwrite_existing;
-  std::error_code error;
-  bool copied = fs::copy_file(src_path, dst_path, options, error);
-  if (!copied)
-  {
-    ERROR_LOG_FMT(COMMON, "{}: failed {} --> {}: {}", __func__, source_path, dest_path,
-                  error.message());
-  }
-  return copied;
-}
-
 // Returns the current directory
 std::string GetCurrentDir()
 {

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -193,7 +193,6 @@ bool Delete(const std::string& filename, IfAbsentBehavior behavior)
   return true;
 }
 
-// Returns true if successful, or path already exists.
 bool CreateDir(const std::string& path)
 {
   DEBUG_LOG_FMT(COMMON, "{}: directory {}", __func__, path);
@@ -203,6 +202,22 @@ bool CreateDir(const std::string& path)
   bool success = fs::create_directory(native_path, error);
   // If the path was not created, check if it was a pre-existing directory
   if (!success && fs::is_directory(native_path))
+    success = true;
+  if (!success)
+    ERROR_LOG_FMT(COMMON, "{}: failed on {}: {}", __func__, path, error.message());
+  return success;
+}
+
+bool CreateDirs(std::string_view path)
+{
+  DEBUG_LOG_FMT(COMMON, "{}: directory {}", __func__, path);
+
+  std::error_code error;
+  auto native_path = StringToPath(path);
+  bool success = fs::create_directories(native_path, error);
+  // If the path was not created, check if it was a pre-existing directory
+  std::error_code error_ignored;
+  if (!success && fs::is_directory(native_path, error_ignored))
     success = true;
   if (!success)
     ERROR_LOG_FMT(COMMON, "{}: failed on {}: {}", __func__, path, error.message());

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -193,6 +193,13 @@ std::string GetCurrentDir();
 bool Copy(std::string_view source_path, std::string_view dest_path,
           bool overwrite_existing = false);
 
+// Moves source_path to dest_path. On success, the source_path will no longer exist, and the
+// dest_path will contain the data previously in source_path. Files in dest_path will be overwritten
+// if they match files in source_path, but files that only exist in dest_path will be kept. No
+// guarantee on the state is given on failure; the move may have completely failed or partially
+// completed.
+bool MoveWithOverwrite(std::string_view source_path, std::string_view dest_path);
+
 // Create directory and copy contents (optionally overwrites existing files)
 bool CopyDir(const std::string& source_path, const std::string& dest_path,
              bool destructive = false);

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -185,6 +185,11 @@ bool DeleteDirRecursively(const std::string& directory);
 // Returns the current directory
 std::string GetCurrentDir();
 
+// Copies source_path to dest_path, as if by std::filesystem::copy(). Returns true on success or if
+// the source and destination are already the same (as determined by std::filesystem::equivalent()).
+bool Copy(std::string_view source_path, std::string_view dest_path,
+          bool overwrite_existing = false);
+
 // Create directory and copy contents (optionally overwrites existing files)
 bool CopyDir(const std::string& source_path, const std::string& dest_path,
              bool destructive = false);

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -200,10 +200,6 @@ bool Copy(std::string_view source_path, std::string_view dest_path,
 // completed.
 bool MoveWithOverwrite(std::string_view source_path, std::string_view dest_path);
 
-// Create directory and copy contents (optionally overwrites existing files)
-bool CopyDir(const std::string& source_path, const std::string& dest_path,
-             bool destructive = false);
-
 // Set the current directory to given directory
 bool SetCurrentDir(const std::string& directory);
 

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -140,8 +140,11 @@ u64 GetSize(const std::string& path);
 // Overloaded GetSize, accepts FILE*
 u64 GetSize(FILE* f);
 
-// Returns true if successful, or path already exists.
+// Creates a single directory. Returns true if successful or if the path already exists.
 bool CreateDir(const std::string& filename);
+
+// Creates directories recursively. Returns true if successful or if the path already exists.
+bool CreateDirs(std::string_view filename);
 
 // Creates the full path to the file given in fullPath.
 // That is, for path '/a/b/c.bin', creates folders '/a' and '/a/b'.

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -121,7 +121,7 @@ void WFSIDevice::FinalizePatchInstall()
   const std::string current_title_dir = fmt::format("/vol/{}/title/{}/{}", m_device_name,
                                                     m_current_group_id_str, m_current_title_id_str);
   const std::string patch_dir = current_title_dir + "/_patch";
-  File::CopyDir(WFS::NativePath(patch_dir), WFS::NativePath(current_title_dir), true);
+  File::MoveWithOverwrite(WFS::NativePath(patch_dir), WFS::NativePath(current_title_dir));
 }
 
 std::optional<IPCReply> WFSIDevice::IOCtl(const IOCtlRequest& request)

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -186,7 +186,10 @@ static void InitializeDeterministicWiiSaves(FS::FileSystem* session_fs,
 
     const auto& netplay_redirect_folder = boot_session_data.GetWiiSyncRedirectFolder();
     if (!netplay_redirect_folder.empty())
-      File::CopyDir(netplay_redirect_folder, s_temp_redirect_root + "/");
+    {
+      File::CreateDirs(s_temp_redirect_root);
+      File::Copy(netplay_redirect_folder, s_temp_redirect_root);
+    }
   }
 }
 
@@ -359,11 +362,11 @@ void InitializeWiiFileSystemContents(
 
     if (!File::IsDirectory(save_redirect->m_target_path))
     {
-      File::CreateFullPath(save_redirect->m_target_path + "/");
+      File::CreateDirs(save_redirect->m_target_path);
       if (save_redirect->m_clone)
       {
-        File::CopyDir(Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT),
-                      save_redirect->m_target_path);
+        File::Copy(Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT),
+                   save_redirect->m_target_path);
       }
     }
     s_nand_redirects.emplace_back(IOS::HLE::FS::NandRedirect{

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -197,7 +197,7 @@ static void MoveToBackupIfExists(const std::string& path)
 {
   if (File::Exists(path))
   {
-    const std::string backup_path = path.substr(0, path.size() - 1) + ".backup" DIR_SEP;
+    const std::string backup_path = path.substr(0, path.size() - 1) + ".backup";
     WARN_LOG_FMT(IOS_FS, "Temporary directory at {} exists, moving to backup...", path);
 
     // If backup exists, delete it as we don't want a mess
@@ -207,7 +207,7 @@ static void MoveToBackupIfExists(const std::string& path)
       File::DeleteDirRecursively(backup_path);
     }
 
-    File::CopyDir(path, backup_path, true);
+    File::MoveWithOverwrite(path, backup_path);
   }
 }
 
@@ -399,7 +399,10 @@ void CleanUpWiiFileSystemContents(const BootSessionData& boot_session_data)
 
   // copy back the temp nand redirected files to where they should normally be redirected to
   for (const auto& redirect : s_temp_nand_redirects)
-    File::CopyDir(redirect.temp_path, redirect.real_path + "/", true);
+  {
+    File::CreateFullPath(redirect.real_path);
+    File::MoveWithOverwrite(redirect.temp_path, redirect.real_path);
+  }
 
   IOS::HLE::EmulationKernel* ios = IOS::HLE::GetIOS();
 

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -248,7 +248,7 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
 #ifdef __APPLE__
   // Copy the updater so it can update itself if needed.
   const std::string reloc_updater_path = UpdaterPath(true);
-  if (!File::CopyDir(UpdaterPath(), reloc_updater_path))
+  if (!File::Copy(UpdaterPath(), reloc_updater_path))
   {
     CriticalAlertFmtT("Unable to create updater copy.");
     return;


### PR DESCRIPTION
Cleaning up some of the nonsense. @shuffle2 please check this. I moved the `equivalent()` check into the error case of `Copy()` because [std::filesystem::copy() is defined to fail instead of destroying files in this situation](https://en.cppreference.com/w/cpp/filesystem/copy) and it's pretty unlikely in the first place.

There's one behavior of `Copy()` that I don't quite like, which is that if the source is a file and the destination is a folder it copies the file into the folder instead of either failing or overwriting the folder, it kinda feels like a situation that could surprise. But that's just what std::filesystem::copy() does, so it's probably okay to keep as-is...?