### PR TITLE
use std-provided randomness for JitArm64 unittests

### DIFF
--- a/Source/Core/Common/Random.cpp
+++ b/Source/Core/Common/Random.cpp
@@ -10,38 +10,6 @@
 
 namespace Common::Random
 {
-struct PRNG::Impl
-{
-  Impl(void* seed, std::size_t size)
-  {
-    mbedtls_hmac_drbg_init(&m_context);
-    const int ret = mbedtls_hmac_drbg_seed_buf(
-        &m_context, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), static_cast<u8*>(seed), size);
-    ASSERT(ret == 0);
-  }
-
-  ~Impl() { mbedtls_hmac_drbg_free(&m_context); }
-
-  void Generate(void* buffer, std::size_t size)
-  {
-    const int ret = mbedtls_hmac_drbg_random(&m_context, static_cast<u8*>(buffer), size);
-    ASSERT(ret == 0);
-  }
-
-  mbedtls_hmac_drbg_context m_context;
-};
-
-PRNG::PRNG(void* seed, std::size_t size) : m_impl(std::make_unique<Impl>(seed, size))
-{
-}
-
-PRNG::~PRNG() = default;
-
-void PRNG::Generate(void* buffer, std::size_t size)
-{
-  m_impl->Generate(buffer, size);
-}
-
 class EntropySeededPRNG final
 {
 public:

--- a/Source/Core/Common/Random.h
+++ b/Source/Core/Common/Random.h
@@ -11,30 +11,6 @@
 
 namespace Common::Random
 {
-/// Cryptographically secure pseudo-random number generator, with explicit seed.
-class PRNG final
-{
-public:
-  explicit PRNG(u64 seed) : PRNG(&seed, sizeof(u64)) {}
-  PRNG(void* seed, std::size_t size);
-  ~PRNG();
-
-  void Generate(void* buffer, std::size_t size);
-
-  template <typename T>
-  T GenerateValue()
-  {
-    static_assert(std::is_arithmetic<T>(), "T must be an arithmetic type in GenerateValue.");
-    T value;
-    Generate(&value, sizeof(value));
-    return value;
-  }
-
-private:
-  struct Impl;
-  std::unique_ptr<Impl> m_impl;
-};
-
 /// Fill `buffer` with random bytes using a cryptographically secure pseudo-random number generator.
 void Generate(void* buffer, std::size_t size);
 

--- a/Source/UnitTests/Core/PowerPC/JitArm64/MovI2R.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/MovI2R.cpp
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cstddef>
+#include <random>
 #include <type_traits>
 
 #include "Common/Arm64Emitter.h"
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
-#include "Common/Random.h"
 
 #include <gtest/gtest.h>
 
@@ -59,11 +59,12 @@ public:
 
 TEST(JitArm64, MovI2R_32BitValues)
 {
-  Common::Random::PRNG rng{0};
+  std::default_random_engine engine(0);
+  std::uniform_int_distribution<u32> dist;
   TestMovI2R test;
   for (u64 i = 0; i < 0x100000; i++)
   {
-    const u32 value = rng.GenerateValue<u32>();
+    const u32 value = dist(engine);
     test.Check32(value);
     test.Check64(value);
   }
@@ -71,11 +72,12 @@ TEST(JitArm64, MovI2R_32BitValues)
 
 TEST(JitArm64, MovI2R_Rand)
 {
-  Common::Random::PRNG rng{0};
+  std::default_random_engine engine(0);
+  std::uniform_int_distribution<u64> dist;
   TestMovI2R test;
   for (u64 i = 0; i < 0x100000; i++)
   {
-    test.Check64(rng.GenerateValue<u64>());
+    test.Check64(dist(engine));
   }
 }
 


### PR DESCRIPTION
decreases runtime significantly and lessens dependency on mbedtls

move to same construct used by https://github.com/dolphin-emu/dolphin/blob/master/Source/UnitTests/Common/FloatUtilsTest.cpp

the longest-running tests on my device (release build, surface pro x, SQ1):
before
```
   6.199 MovI2R_32BitValues
   5.756 MovI2R_Rand
   1.084 MultiThreaded
   0.505 LargeFloatVertexSpeed
   0.469 CrashMacro
   0.271 MultiThreaded
   0.182 SignAndVerify
   0.162 TexCoordSingleElement/0
   0.161 TexCoordSingleElement/2
   0.159 TexCoordSingleElement/1
```
after
```
   1.568 MultiThreaded
   1.564 MovI2R_32BitValues
   0.878 MovI2R_Rand
   0.528 CrashMacro
   0.488 LargeFloatVertexSpeed
   0.297 MultiThreaded
   0.184 SignAndVerify
   0.182 TexCoordSingleElement/2
   0.178 TexCoordSingleElement/3
   0.177 TexCoordSingleElement/0
```