### PR TITLE
Config: Restore Bluetooth adapter missing message in Controller Settings

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -131,6 +131,11 @@ void ProcessWiimotePool()
   }
 }
 
+bool IsScannerReady()
+{
+  return s_wiimote_scanner.IsReady();
+}
+
 void AddWiimoteToPool(std::unique_ptr<Wiimote> wiimote)
 {
   // Our real wiimote class requires an index.

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -223,4 +223,5 @@ void InitAdapterClass();
 void HandleWiimotesInControllerInterfaceSettingChange();
 void PopulateDevices();
 void ProcessWiimotePool();
+bool IsScannerReady();
 }  // namespace WiimoteReal

--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -23,6 +23,12 @@ ControllersWindow::ControllersWindow(QWidget* parent) : QDialog(parent)
   ConnectWidgets();
 }
 
+void ControllersWindow::showEvent(QShowEvent* event)
+{
+  QDialog::showEvent(event);
+  m_wiimote_controllers->UpdateBluetoothAvailableStatus();
+}
+
 void ControllersWindow::CreateMainLayout()
 {
   auto* layout = new QVBoxLayout();

--- a/Source/Core/DolphinQt/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.h
@@ -8,6 +8,7 @@
 class CommonControllersWidget;
 class GamecubeControllersWidget;
 class QDialogButtonBox;
+class QShowEvent;
 class WiimoteControllersWidget;
 
 class ControllersWindow final : public QDialog
@@ -15,6 +16,9 @@ class ControllersWindow final : public QDialog
   Q_OBJECT
 public:
   explicit ControllersWindow(QWidget* parent);
+
+protected:
+  void showEvent(QShowEvent* event) override;
 
 private:
   void CreateMainLayout();

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -50,6 +50,11 @@ WiimoteControllersWidget::WiimoteControllersWidget(QWidget* parent) : QWidget(pa
   LoadSettings(Core::GetState());
 }
 
+void WiimoteControllersWidget::UpdateBluetoothAvailableStatus()
+{
+  m_bluetooth_unavailable->setHidden(WiimoteReal::IsScannerReady());
+}
+
 static int GetRadioButtonIndicatorWidth()
 {
   const QStyle* style = QApplication::style();
@@ -150,6 +155,10 @@ void WiimoteControllersWidget::CreateLayout()
   int continuous_scanning_row = m_wiimote_layout->rowCount();
   m_wiimote_layout->addWidget(m_wiimote_continuous_scanning, continuous_scanning_row, 0, 1, 3);
   m_wiimote_layout->addWidget(m_wiimote_refresh, continuous_scanning_row, 3);
+
+  m_bluetooth_unavailable = new QLabel(tr("A supported Bluetooth device could not be found.\n"
+                                          "You must manually connect your Wii Remote."));
+  m_wiimote_layout->addWidget(m_bluetooth_unavailable, m_wiimote_layout->rowCount(), 1, 1, -1);
 
   auto* layout = new QVBoxLayout;
   layout->setContentsMargins(0, 0, 0, 0);

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
@@ -27,6 +27,8 @@ class WiimoteControllersWidget final : public QWidget
 public:
   explicit WiimoteControllersWidget(QWidget* parent);
 
+  void UpdateBluetoothAvailableStatus();
+
 private:
   void SaveSettings();
   void OnBluetoothPassthroughSyncPressed();
@@ -55,4 +57,5 @@ private:
   QCheckBox* m_wiimote_speaker_data;
   QCheckBox* m_wiimote_ciface;
   QPushButton* m_wiimote_refresh;
+  QLabel* m_bluetooth_unavailable;
 };


### PR DESCRIPTION
In 5.0 an error message was displayed in the Controller Settings if a Bluetooth adapter wasn't found. That message was lost in the transition from wx to Qt, so this PR restores it.

I kept the 5.0 wording but removed the GroupBox since the current Controller layout doesn't have nested GroupBoxes.

Appearance:

![current_no_adapter](https://user-images.githubusercontent.com/73494713/221307403-43a2aa94-e7c1-4628-900e-d7185588a5b8.png)![current_normal](https://user-images.githubusercontent.com/73494713/221280231-67487a24-c04f-41fd-9878-9cf38fe26a80.png)

5.0 Appearance:
![5-0_no_adapter](https://user-images.githubusercontent.com/73494713/221279341-14ffe433-8be6-4ca0-a251-8c89a14203f8.png)![5-0_normal](https://user-images.githubusercontent.com/73494713/221279362-a57ca905-12ab-465b-ad69-d527e01d35d3.png)
