### PR TITLE
Android: Add a button for accessing controller mappings

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -305,27 +305,9 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   }
 
   @Override
-  public void onSerialPort1SettingChanged(MenuTag menuTag, int value)
+  public void onMenuTagAction(@NonNull MenuTag menuTag, int value)
   {
-    mPresenter.onSerialPort1SettingChanged(menuTag, value);
-  }
-
-  @Override
-  public void onGcPadSettingChanged(MenuTag key, int value)
-  {
-    mPresenter.onGcPadSettingChanged(key, value);
-  }
-
-  @Override
-  public void onWiimoteSettingChanged(MenuTag section, int value)
-  {
-    mPresenter.onWiimoteSettingChanged(section, value);
-  }
-
-  @Override
-  public void onExtensionSettingChanged(MenuTag menuTag, int value)
-  {
-    mPresenter.onExtensionSettingChanged(menuTag, value);
+    mPresenter.onMenuTagAction(menuTag, value);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -311,6 +311,12 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   }
 
   @Override
+  public boolean hasMenuTagActionForValue(@NonNull MenuTag menuTag, int value)
+  {
+    return mPresenter.hasMenuTagActionForValue(menuTag, value);
+  }
+
+  @Override
   public boolean onSupportNavigateUp()
   {
     onBackPressed();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -5,6 +5,7 @@ package org.dolphinemu.dolphinemu.features.settings.ui;
 import android.os.Bundle;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
 import androidx.core.app.ComponentActivity;
 
 import org.dolphinemu.dolphinemu.R;
@@ -128,47 +129,50 @@ public final class SettingsActivityPresenter
     return mShouldSave;
   }
 
-  public void onSerialPort1SettingChanged(MenuTag key, int value)
+  public void onMenuTagAction(@NonNull MenuTag menuTag, int value)
   {
-    if (value != 0 && value != 255) // Not disabled or dummy
+    if (menuTag.isSerialPort1Menu())
     {
-      Bundle bundle = new Bundle();
-      bundle.putInt(SettingsFragmentPresenter.ARG_SERIALPORT1_TYPE, value);
-      mView.showSettingsFragment(key, bundle, true, mGameId);
+      if (value != 0 && value != 255) // Not disabled or dummy
+      {
+        Bundle bundle = new Bundle();
+        bundle.putInt(SettingsFragmentPresenter.ARG_SERIALPORT1_TYPE, value);
+        mView.showSettingsFragment(menuTag, bundle, true, mGameId);
+      }
     }
-  }
 
-  public void onGcPadSettingChanged(MenuTag key, int value)
-  {
-    if (value != 0) // Not disabled
+    if (menuTag.isGCPadMenu())
     {
-      Bundle bundle = new Bundle();
-      bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
-      mView.showSettingsFragment(key, bundle, true, mGameId);
+      if (value != 0) // Not disabled
+      {
+        Bundle bundle = new Bundle();
+        bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
+        mView.showSettingsFragment(menuTag, bundle, true, mGameId);
+      }
     }
-  }
 
-  public void onWiimoteSettingChanged(MenuTag menuTag, int value)
-  {
-    switch (value)
+    if (menuTag.isWiimoteMenu())
     {
-      case 1:
-        mView.showSettingsFragment(menuTag, null, true, mGameId);
-        break;
+      switch (value)
+      {
+        case 1:
+          mView.showSettingsFragment(menuTag, null, true, mGameId);
+          break;
 
-      case 2:
-        mView.showToastMessage(mActivity.getString(R.string.make_sure_continuous_scan_enabled));
-        break;
+        case 2:
+          mView.showToastMessage(mActivity.getString(R.string.make_sure_continuous_scan_enabled));
+          break;
+      }
     }
-  }
 
-  public void onExtensionSettingChanged(MenuTag menuTag, int value)
-  {
-    if (value != 0) // None
+    if (menuTag.isWiimoteExtensionMenu())
     {
-      Bundle bundle = new Bundle();
-      bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
-      mView.showSettingsFragment(menuTag, bundle, true, mGameId);
+      if (value != 0) // None
+      {
+        Bundle bundle = new Bundle();
+        bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
+        mView.showSettingsFragment(menuTag, bundle, true, mGameId);
+      }
     }
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -153,26 +153,45 @@ public final class SettingsActivityPresenter
 
     if (menuTag.isWiimoteMenu())
     {
-      switch (value)
+      if (value == 1) // Emulated Wii Remote
       {
-        case 1:
-          mView.showSettingsFragment(menuTag, null, true, mGameId);
-          break;
-
-        case 2:
-          mView.showToastMessage(mActivity.getString(R.string.make_sure_continuous_scan_enabled));
-          break;
+        mView.showSettingsFragment(menuTag, null, true, mGameId);
       }
     }
 
     if (menuTag.isWiimoteExtensionMenu())
     {
-      if (value != 0) // None
+      if (value != 0) // Not disabled
       {
         Bundle bundle = new Bundle();
         bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
         mView.showSettingsFragment(menuTag, bundle, true, mGameId);
       }
     }
+  }
+
+  public boolean hasMenuTagActionForValue(@NonNull MenuTag menuTag, int value)
+  {
+    if (menuTag.isSerialPort1Menu())
+    {
+      return (value != 0 && value != 255); // Not disabled or dummy
+    }
+
+    if (menuTag.isGCPadMenu())
+    {
+      return (value != 0); // Not disabled
+    }
+
+    if (menuTag.isWiimoteMenu())
+    {
+      return (value == 1); // Emulated Wii Remote
+    }
+
+    if (menuTag.isWiimoteExtensionMenu())
+    {
+      return (value != 0); // Not disabled
+    }
+
+    return false;
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -64,10 +64,19 @@ public interface SettingsActivityView
    * Called by a containing Fragment to tell the containing Activity that the user wants to open the
    * MenuTag associated with a setting.
    *
-   * @param menuTag The MenuTag to open.
-   * @param value   The current value of the associated setting.
+   * @param menuTag The MenuTag of the setting.
+   * @param value   The current value of the setting.
    */
   void onMenuTagAction(@NonNull MenuTag menuTag, int value);
+
+  /**
+   * Returns whether anything will happen when the user wants to open the MenuTag associated with a
+   * setting, given the current value of the setting.
+   *
+   * @param menuTag The MenuTag of the setting.
+   * @param value   The current value of the setting.
+   */
+  boolean hasMenuTagActionForValue(@NonNull MenuTag menuTag, int value);
 
   /**
    * Show loading dialog while loading the settings

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -4,6 +4,8 @@ package org.dolphinemu.dolphinemu.features.settings.ui;
 
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 
 /**
@@ -59,40 +61,13 @@ public interface SettingsActivityView
   void onSettingChanged();
 
   /**
-   * Called by a containing Fragment to tell the containing Activity that the Serial Port 1 setting
-   * was modified.
+   * Called by a containing Fragment to tell the containing Activity that the user wants to open the
+   * MenuTag associated with a setting.
    *
-   * @param menuTag Identifier for the SerialPort that was modified.
-   * @param value   New setting for the SerialPort.
+   * @param menuTag The MenuTag to open.
+   * @param value   The current value of the associated setting.
    */
-  void onSerialPort1SettingChanged(MenuTag menuTag, int value);
-
-  /**
-   * Called by a containing Fragment to tell the containing Activity that a GCPad's setting
-   * was modified.
-   *
-   * @param menuTag Identifier for the GCPad that was modified.
-   * @param value   New setting for the GCPad.
-   */
-  void onGcPadSettingChanged(MenuTag menuTag, int value);
-
-  /**
-   * Called by a containing Fragment to tell the containing Activity that a Wiimote's setting
-   * was modified.
-   *
-   * @param menuTag Identifier for Wiimote that was modified.
-   * @param value   New setting for the Wiimote.
-   */
-  void onWiimoteSettingChanged(MenuTag menuTag, int value);
-
-  /**
-   * Called by a containing Fragment to tell the containing Activity that an extension setting
-   * was modified.
-   *
-   * @param menuTag Identifier for the extension that was modified.
-   * @param value   New setting for the extension.
-   */
-  void onExtensionSettingChanged(MenuTag menuTag, int value);
+  void onMenuTagAction(@NonNull MenuTag menuTag, int value);
 
   /**
    * Show loading dialog while loading the settings

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -467,7 +467,7 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     }
   }
 
-  private void handleMenuTag(MenuTag menuTag, int value)
+  public void handleMenuTag(MenuTag menuTag, int value)
   {
     if (menuTag != null)
     {
@@ -504,8 +504,6 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
       if (scSetting.getSelectedValue(getSettings()) != value)
         mView.onSettingChanged();
 
-      handleMenuTag(scSetting.getMenuTag(), value);
-
       scSetting.setSelectedValue(getSettings(), value);
 
       closeDialog();
@@ -529,8 +527,6 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
       String value = scSetting.getValueAt(which);
       if (!scSetting.getSelectedValue(getSettings()).equals(value))
         mView.onSettingChanged();
-
-      handleMenuTag(scSetting.getMenuTag(), which);
 
       scSetting.setSelectedValue(getSettings(), value);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -467,30 +467,9 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     }
   }
 
-  public void handleMenuTag(MenuTag menuTag, int value)
+  public void onMenuTagAction(@NonNull MenuTag menuTag, int value)
   {
-    if (menuTag != null)
-    {
-      if (menuTag.isSerialPort1Menu())
-      {
-        mView.onSerialPort1SettingChanged(menuTag, value);
-      }
-
-      if (menuTag.isGCPadMenu())
-      {
-        mView.onGcPadSettingChanged(menuTag, value);
-      }
-
-      if (menuTag.isWiimoteMenu())
-      {
-        mView.onWiimoteSettingChanged(menuTag, value);
-      }
-
-      if (menuTag.isWiimoteExtensionMenu())
-      {
-        mView.onExtensionSettingChanged(menuTag, value);
-      }
-    }
+    mView.onMenuTagAction(menuTag, value);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -472,6 +472,11 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     mView.onMenuTagAction(menuTag, value);
   }
 
+  public boolean hasMenuTagActionForValue(@NonNull MenuTag menuTag, int value)
+  {
+    return mView.hasMenuTagActionForValue(menuTag, value);
+  }
+
   @Override
   public void onClick(DialogInterface dialog, int which)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -231,6 +231,11 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
     mActivity.onMenuTagAction(menuTag, value);
   }
 
+  public boolean hasMenuTagActionForValue(@NonNull MenuTag menuTag, int value)
+  {
+    return mActivity.hasMenuTagActionForValue(menuTag, value);
+  }
+
   private void setInsets()
   {
     ViewCompat.setOnApplyWindowInsetsListener(mBinding.listSettings, (v, windowInsets) ->

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -226,27 +226,9 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   }
 
   @Override
-  public void onSerialPort1SettingChanged(MenuTag menuTag, int value)
+  public void onMenuTagAction(@NonNull MenuTag menuTag, int value)
   {
-    mActivity.onSerialPort1SettingChanged(menuTag, value);
-  }
-
-  @Override
-  public void onGcPadSettingChanged(MenuTag menuTag, int value)
-  {
-    mActivity.onGcPadSettingChanged(menuTag, value);
-  }
-
-  @Override
-  public void onWiimoteSettingChanged(MenuTag menuTag, int value)
-  {
-    mActivity.onWiimoteSettingChanged(menuTag, value);
-  }
-
-  @Override
-  public void onExtensionSettingChanged(MenuTag menuTag, int value)
-  {
-    mActivity.onExtensionSettingChanged(menuTag, value);
+    mActivity.onMenuTagAction(menuTag, value);
   }
 
   private void setInsets()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
@@ -2,6 +2,7 @@
 
 package org.dolphinemu.dolphinemu.features.settings.ui;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
@@ -72,35 +73,11 @@ public interface SettingsFragmentView
   void onSettingChanged();
 
   /**
-   * Called by a containing Fragment to tell the containing Activity that the Serial Port 1 setting
-   * was modified.
+   * Have the fragment tell the containing Activity that the user wants to open the MenuTag
+   * associated with a setting.
    *
-   * @param menuTag Identifier for the SerialPort that was modified.
-   * @param value   New setting for the SerialPort.
+   * @param menuTag The MenuTag to open.
+   * @param value   The current value of the associated setting.
    */
-  void onSerialPort1SettingChanged(MenuTag menuTag, int value);
-
-  /**
-   * Have the fragment tell the containing Activity that a GCPad's setting was modified.
-   *
-   * @param menuTag Identifier for the GCPad that was modified.
-   * @param value   New setting for the GCPad.
-   */
-  void onGcPadSettingChanged(MenuTag menuTag, int value);
-
-  /**
-   * Have the fragment tell the containing Activity that a Wiimote's setting was modified.
-   *
-   * @param menuTag Identifier for Wiimote that was modified.
-   * @param value   New setting for the Wiimote.
-   */
-  void onWiimoteSettingChanged(MenuTag menuTag, int value);
-
-  /**
-   * Have the fragment tell the containing Activity that an extension setting was modified.
-   *
-   * @param menuTag Identifier for the extension that was modified.
-   * @param value   New setting for the extension.
-   */
-  void onExtensionSettingChanged(MenuTag menuTag, int value);
+  void onMenuTagAction(@NonNull MenuTag menuTag, int value);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
@@ -76,8 +76,17 @@ public interface SettingsFragmentView
    * Have the fragment tell the containing Activity that the user wants to open the MenuTag
    * associated with a setting.
    *
-   * @param menuTag The MenuTag to open.
-   * @param value   The current value of the associated setting.
+   * @param menuTag The MenuTag of the setting.
+   * @param value   The current value of the setting.
    */
   void onMenuTagAction(@NonNull MenuTag menuTag, int value);
+
+  /**
+   * Returns whether anything will happen when the user wants to open the MenuTag associated with a
+   * setting, given the current value of the setting.
+   *
+   * @param menuTag The MenuTag of the setting.
+   * @param value   The current value of the setting.
+   */
+  boolean hasMenuTagActionForValue(@NonNull MenuTag menuTag, int value);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SingleChoiceViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SingleChoiceViewHolder.java
@@ -108,7 +108,7 @@ public final class SingleChoiceViewHolder extends SettingViewHolder
       final MenuTag finalMenuTag = menuTag;
       final Function<Settings, Integer> finalGetSelectedValue = getSelectedValue;
       mBinding.buttonMoreSettings.setOnClickListener((view) ->
-              adapter.handleMenuTag(finalMenuTag, finalGetSelectedValue.apply(settings)));
+              adapter.onMenuTagAction(finalMenuTag, finalGetSelectedValue.apply(settings)));
     }
     else
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SingleChoiceViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SingleChoiceViewHolder.java
@@ -101,7 +101,8 @@ public final class SingleChoiceViewHolder extends SettingViewHolder
       getSelectedValue = setting::getSelectedValueIndex;
     }
 
-    if (menuTag != null)
+    if (menuTag != null &&
+            adapter.hasMenuTagActionForValue(menuTag, getSelectedValue.apply(settings)))
     {
       mBinding.buttonMoreSettings.setVisibility(View.VISIBLE);
 

--- a/Source/Android/app/src/main/res/layout-ldrtl/list_item_setting.xml
+++ b/Source/Android/app/src/main/res/layout-ldrtl/list_item_setting.xml
@@ -8,15 +8,13 @@
     android:background="?android:attr/selectableItemBackground"
     android:clickable="true"
     android:focusable="true"
-    android:minHeight="72dp"
     android:nextFocusLeft="@id/button_more_settings">
 
     <TextView
         android:id="@+id/text_setting_name"
         style="@style/TextAppearance.MaterialComponents.Headline5"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
         android:layout_alignParentStart="true"
         android:layout_alignParentTop="true"
         android:layout_marginEnd="@dimen/spacing_large"
@@ -24,11 +22,12 @@
         android:layout_marginTop="@dimen/spacing_large"
         android:textSize="16sp"
         android:textAlignment="viewStart"
+        android:layout_toStartOf="@+id/button_more_settings"
         tools:text="Setting Name" />
 
     <TextView
         android:id="@+id/text_setting_description"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_alignStart="@+id/text_setting_name"
@@ -37,6 +36,7 @@
         android:layout_marginEnd="@dimen/spacing_large"
         android:layout_marginStart="@dimen/spacing_large"
         android:layout_marginTop="@dimen/spacing_small"
+        android:layout_toStartOf="@+id/button_more_settings"
         android:textAlignment="viewStart"
         tools:text="@string/overclock_enable_description" />
 

--- a/Source/Android/app/src/main/res/layout-ldrtl/list_item_setting.xml
+++ b/Source/Android/app/src/main/res/layout-ldrtl/list_item_setting.xml
@@ -9,7 +9,7 @@
     android:clickable="true"
     android:focusable="true"
     android:minHeight="72dp"
-    android:nextFocusRight="@id/button_more_settings">
+    android:nextFocusLeft="@id/button_more_settings">
 
     <TextView
         android:id="@+id/text_setting_name"
@@ -49,7 +49,7 @@
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         android:layout_marginEnd="@dimen/spacing_small"
-        android:nextFocusLeft="@id/root"
+        android:nextFocusRight="@id/root"
         android:visibility="gone"
         app:icon="@drawable/ic_settings"
         app:iconTint="?attr/colorOnPrimaryContainer" />

--- a/Source/Android/app/src/main/res/layout/list_item_setting.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_setting.xml
@@ -8,15 +8,13 @@
     android:background="?android:attr/selectableItemBackground"
     android:clickable="true"
     android:focusable="true"
-    android:minHeight="72dp"
     android:nextFocusRight="@id/button_more_settings">
 
     <TextView
         android:id="@+id/text_setting_name"
         style="@style/TextAppearance.MaterialComponents.Headline5"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
         android:layout_alignParentStart="true"
         android:layout_alignParentTop="true"
         android:layout_marginEnd="@dimen/spacing_large"
@@ -24,11 +22,12 @@
         android:layout_marginTop="@dimen/spacing_large"
         android:textSize="16sp"
         android:textAlignment="viewStart"
+        android:layout_toStartOf="@+id/button_more_settings"
         tools:text="Setting Name" />
 
     <TextView
         android:id="@+id/text_setting_description"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_alignStart="@+id/text_setting_name"
@@ -37,6 +36,7 @@
         android:layout_marginEnd="@dimen/spacing_large"
         android:layout_marginStart="@dimen/spacing_large"
         android:layout_marginTop="@dimen/spacing_small"
+        android:layout_toStartOf="@+id/button_more_settings"
         android:textAlignment="viewStart"
         tools:text="@string/overclock_enable_description" />
 

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -478,6 +478,7 @@
     <string name="disabled">Disabled</string>
     <string name="other">Other</string>
     <string name="continue_anyway">Continue Anyway</string>
+    <string name="more_settings">More Settings</string>
 
     <!-- Game Grid Screen-->
     <string name="platform_gamecube">GameCube Games</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -683,7 +683,6 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="replug_gc_adapter">GameCube Adapter couldn\'t be opened. Please re-plug the device.</string>
     <string name="disabled_gc_overlay_notice">GameCube Controller 1 is set to \"None\"</string>
     <string name="ignore_warning_alert_messages">Ignore for this session</string>
-    <string name="make_sure_continuous_scan_enabled">Please make sure Continuous Scanning is enabled in Core Settings.</string>
 
     <!-- UI CPU Core selection -->
     <string name="jit_recompiler_x86">JIT Recompiler for x86–64 (recommended)</string>


### PR DESCRIPTION
The settings GameCube Controller N and Wii Remote N (where N is a number) have two purposes: You can select what controller type you want to use, and also, when you select a controller type (even if you're selecting the one that already is selected), the mapping settings open. This second part is less discoverable than it ideally should be. I'm changing it so that there now is a button for opening the mapping settings instead.

<img src="https://user-images.githubusercontent.com/6716818/221408674-aa4be51a-5197-409e-87ed-9c98e57b2ea2.png" width="45%">
