### PR TITLE
InputCommon: Fix ControlGroup::SaveConfig with DefaultValue::Disabled

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -57,7 +57,7 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
 
   // enabled
   if (default_value != DefaultValue::AlwaysEnabled)
-    sec->Get(group + "Enabled", &enabled, default_value == DefaultValue::Enabled);
+    sec->Get(group + "Enabled", &enabled, default_value != DefaultValue::Disabled);
 
   for (auto& setting : numeric_settings)
     setting->LoadFromIni(*sec, group);
@@ -109,7 +109,7 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
   const std::string group(base + name + "/");
 
   // enabled
-  sec->Set(group + "Enabled", enabled, true);
+  sec->Set(group + "Enabled", enabled, default_value != DefaultValue::Disabled);
 
   for (auto& setting : numeric_settings)
     setting->SaveToIni(*sec, group);


### PR DESCRIPTION
I also changed LoadConfig, but that change doesn't affect correctness, it's only so it looks neat by matching SaveConfig.

This bug was added in PR #8729, the PR that introduced DefaultValue::Disabled. The bug can't actually be triggered in master, but it can be triggered in PR #11385.