### PR TITLE
Android: Initialize TaskViewModel earlier in User Data Activity

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.kt
@@ -38,6 +38,8 @@ class UserDataActivity : AppCompatActivity() {
     private lateinit var mBinding: ActivityUserDataBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        taskViewModel = ViewModelProvider(this)[TaskViewModel::class.java]
+
         ThemeHelper.setTheme(this)
 
         super.onCreate(savedInstanceState)
@@ -81,7 +83,6 @@ class UserDataActivity : AppCompatActivity() {
     public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
-        taskViewModel = ViewModelProvider(this)[TaskViewModel::class.java]
         if (requestCode == REQUEST_CODE_IMPORT && resultCode == RESULT_OK) {
             val arguments = Bundle()
             arguments.putString(


### PR DESCRIPTION
Bug I noticed that happens if you try to do a config change while on the user data import warning dialog and then press `Yes` to start. The app crashes because it did not have the view model initialized properly.