### PR TITLE
GameINI: Krome updates

### DIFF
--- a/Data/Sys/GameSettings/G6S.ini
+++ b/Data/Sys/GameSettings/G6S.ini
@@ -13,5 +13,9 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 0
+SafeTextureCacheColorSamples = 512
 
+[Video_Hacks]
+ImmediateXFBEnable = False
+# Fixes missing splash logo at boot.
+EFBAccessEnable = True

--- a/Data/Sys/GameSettings/GJF.ini
+++ b/Data/Sys/GameSettings/GJF.ini
@@ -1,4 +1,4 @@
-# GIZE52 - TY the Tasmanian Tiger 3: Night of the Quinkan
+# GJFE78, GJFP78 - The Adventures of Jimmy Neutron Boy Genius: Jet Fusion
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/GKH.ini
+++ b/Data/Sys/GameSettings/GKH.ini
@@ -12,9 +12,7 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False
+# Fixes missing splash logo at boot.
+EFBAccessEnable = True

--- a/Data/Sys/GameSettings/GTY.ini
+++ b/Data/Sys/GameSettings/GTY.ini
@@ -1,4 +1,4 @@
-# GIZE52 - TY the Tasmanian Tiger 3: Night of the Quinkan
+# GYTE69, GYTP69 - TY the Tasmanian Tiger
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,10 +12,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
 [Video_Hacks]
-ImmediateXFBEnable = False
+# Fixes visible lines in HUD.
+VertexRounding = True
 # Fixes missing splash logo at boot.
 EFBAccessEnable = True

--- a/Data/Sys/GameSettings/GYT.ini
+++ b/Data/Sys/GameSettings/GYT.ini
@@ -1,4 +1,4 @@
-# GYTE69, GYTP69 - TY the Tasmanian Tiger 2
+# GYTE69, GYTP69 - TY the Tasmanian Tiger 2: Bush Rescue
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,12 +12,7 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-
-[Video_Hacks]
-EFBToTextureEnable = False
-
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False
+# Fixes missing splash logo at boot.
+EFBAccessEnable = True

--- a/Data/Sys/GameSettings/R9G.ini
+++ b/Data/Sys/GameSettings/R9G.ini
@@ -12,9 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Hacks]
-# Add video hacks here.
-
-[Video_Settings]
+[Video_Enhancements]
 # Fixes FMVs
 ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/RO7.ini
+++ b/Data/Sys/GameSettings/RO7.ini
@@ -1,4 +1,4 @@
-# GIZE52 - TY the Tasmanian Tiger 3: Night of the Quinkan
+# RO7E7D, RO7P7D - The Legend of Spyro: The Eternal Night
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/RO8.ini
+++ b/Data/Sys/GameSettings/RO8.ini
@@ -1,4 +1,4 @@
-# GIZE52 - TY the Tasmanian Tiger 3: Night of the Quinkan
+# RO8E7D, RO8P7D, RO8X7D - The Legend of Spyro: Dawn of the Dragon
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,10 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-# Fixes missing splash logo at boot.
-EFBAccessEnable = True
+[Video_Enhancements]
+# Fixes FMVs
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/RQL.ini
+++ b/Data/Sys/GameSettings/RQL.ini
@@ -1,4 +1,4 @@
-# GIZE52 - TY the Tasmanian Tiger 3: Night of the Quinkan
+# RQLE64, RQLP64 - Star Wars: The Clone Wars - Republic Heroes
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,10 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-# Fixes missing splash logo at boot.
-EFBAccessEnable = True
+[Video_Enhancements]
+# Fixes FMVs
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/RST.ini
+++ b/Data/Sys/GameSettings/RST.ini
@@ -13,4 +13,5 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
-DeferEFBCopies = False
+# Fixes visible lines in HUD.
+VertexRounding = True

--- a/Data/Sys/GameSettings/RXI.ini
+++ b/Data/Sys/GameSettings/RXI.ini
@@ -1,4 +1,4 @@
-# GIZE52 - TY the Tasmanian Tiger 3: Night of the Quinkan
+# RXIE52, RXIP52 - Transformers: Revenge of the Fallen
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,10 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-# Fixes missing splash logo at boot.
-EFBAccessEnable = True
+[Video_Enhancements]
+# Fixes FMVs
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/SF2.ini
+++ b/Data/Sys/GameSettings/SF2.ini
@@ -1,4 +1,4 @@
-# GIZE52 - TY the Tasmanian Tiger 3: Night of the Quinkan
+# SF2P64 - Star Wars: The Force Unleashed II
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,10 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-# Fixes missing splash logo at boot.
-EFBAccessEnable = True
+[Video_Enhancements]
+# Fixes FMVs
+ForceTextureFiltering = False

--- a/Data/Sys/GameSettings/SF2.ini
+++ b/Data/Sys/GameSettings/SF2.ini
@@ -1,4 +1,4 @@
-# SF2P64 - Star Wars: The Force Unleashed II
+# SF2P64 - Star Wars: The Force Unleashed II (Europe)
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/SFU.ini
+++ b/Data/Sys/GameSettings/SFU.ini
@@ -1,4 +1,4 @@
-# SFUE64 - Star Wars: The Force Unleashed II
+# SFUE64 - Star Wars: The Force Unleashed II (USA)
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/SFU.ini
+++ b/Data/Sys/GameSettings/SFU.ini
@@ -1,4 +1,4 @@
-# GIZE52 - TY the Tasmanian Tiger 3: Night of the Quinkan
+# SFUE64 - Star Wars: The Force Unleashed II
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,10 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-# Fixes missing splash logo at boot.
-EFBAccessEnable = True
+[Video_Enhancements]
+# Fixes FMVs
+ForceTextureFiltering = False


### PR DESCRIPTION
This PR provides a batch of GameINI updates:

- Adds EFBAccessEnable = True to several games to fix an issue where a splash logo displayed at boot would be missing.
- Sets SafeTextureCacheColorSamples to 512 as the minimum for a few games to fix choppy/pixelated FMVs.
- Add vertex rounding to Star Wars: The Force Unleashed and Ty 1 to fix a few visible lines in the HUD of these games specifically. (I'll admit this one isn't that necessary and I can remove it if there are any concerns).
- Disable texture filtering for several games to prevent broken FMVs.

If anyone wonders why Force Unleashed II has 2 GameINIs, the game for some weird reason has 2 entirely different serials in the PAL and NTSC-U regions, no idea why. And also, Force Unleashed I had DeferEFBCopies = False removed, because I couldn't find any difference with this option disabled.