### PR TITLE
Qt/TASInputWindow: Fix controller input deadlock

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/QueueOnObject.h
+++ b/Source/Core/DolphinQt/QtUtils/QueueOnObject.h
@@ -17,11 +17,3 @@ static void QueueOnObject(T* obj, F&& func)
   QObject src;
   QObject::connect(&src, &QObject::destroyed, obj, std::forward<F>(func), Qt::QueuedConnection);
 }
-
-template <typename T, typename F>
-static void QueueOnObjectBlocking(T* obj, F&& func)
-{
-  QObject src;
-  QObject::connect(&src, &QObject::destroyed, obj, std::forward<F>(func),
-                   Qt::BlockingQueuedConnection);
-}


### PR DESCRIPTION
Use QueueOnObject again instead of QueueOnObjectBlocking when using controller inputs to update TAS input windows, and avoid reintroducing an input delay frame by returning the computed input value instead of the spinbox or checkbox value (which doesn't get updated until the next time the main thread handles pending Qt events).

Fixes a deadlock between 1) the main thread waiting for GetStateLock while opening a controller configuration window (and maybe other places) and 2) the CPU thread (which holds GetStateLock) waiting for QueueOnObjectBlocking to run on the main thread.

Context: Controller and keyboard inputs used to have a frame of input lag while TAS input windows were open (https://bugs.dolphin-emu.org/issues/12676). #10113 fixed that but introduced the deadlock above (https://bugs.dolphin-emu.org/issues/12893).