### PR TITLE
Skylander Portal: Clearing and Reloading fix

### DIFF
--- a/Source/Core/Core/IOS/USB/Emulated/Skylander.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Skylander.cpp
@@ -1236,6 +1236,12 @@ bool SkylanderPortal::RemoveSkylander(u8 sky_num)
   std::lock_guard lock(sky_mutex);
   auto& skylander = skylanders[sky_num];
 
+  if (skylander.sky_file.IsOpen())
+  {
+    skylander.Save();
+    skylander.sky_file.Close();
+  }
+
   if (skylander.status & 1)
   {
     skylander.status = Skylander::REMOVING;

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
@@ -332,7 +332,6 @@ void SkylanderPortalWindow::ClearSkylander(u8 slot)
                            QMessageBox::Ok);
       return;
     }
-    system.GetSkylanderPortal().RemoveSkylander(slot_infos->portal_slot);
     m_sky_slots[slot].reset();
     UpdateEdits();
   }


### PR DESCRIPTION
This change fixes bug [#13193](https://bugs.dolphin-emu.org/issues/13193), by ensuring the file is closed when clearing the Skylander from the Window via the QT tool