### PR TITLE
Fix KillRenderer config changed regression

### DIFF
--- a/Source/Core/Common/HookableEvent.h
+++ b/Source/Core/Common/HookableEvent.h
@@ -91,7 +91,7 @@ private:
 
 public:
   // Returns a handle that will unregister the listener when destroyed.
-  static EventHook Register(CallbackType callback, std::string name)
+  [[nodiscard]] static EventHook Register(CallbackType callback, std::string name)
   {
     auto& storage = GetStorage();
     std::lock_guard lock(storage.m_mutex);

--- a/Source/Core/VideoCommon/AbstractGfx.cpp
+++ b/Source/Core/VideoCommon/AbstractGfx.cpp
@@ -18,7 +18,8 @@ std::unique_ptr<AbstractGfx> g_gfx;
 
 AbstractGfx::AbstractGfx()
 {
-  ConfigChangedEvent::Register([this](u32 bits) { OnConfigChanged(bits); }, "AbstractGfx");
+  m_config_changed =
+      ConfigChangedEvent::Register([this](u32 bits) { OnConfigChanged(bits); }, "AbstractGfx");
 }
 
 bool AbstractGfx::IsHeadless() const

--- a/Source/Core/VideoCommon/AbstractGfx.h
+++ b/Source/Core/VideoCommon/AbstractGfx.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Common/HookableEvent.h"
 #include "Common/MathUtil.h"
 
 #include "VideoCommon/RenderState.h"
@@ -166,6 +167,9 @@ public:
 protected:
   AbstractFramebuffer* m_current_framebuffer = nullptr;
   const AbstractPipeline* m_current_pipeline = nullptr;
+
+private:
+  Common::EventHook m_config_changed;
 };
 
 extern std::unique_ptr<AbstractGfx> g_gfx;


### PR DESCRIPTION
The callback handle was being discarded, resulting in the callback immediately unregistering. 

Should fix issues with vsync not disabling during fast-forwarding, along with a bunch of other regressions that probally haven't been reported. 

I also added `[[nodiscard]]` to `HookableEvent::Register` so we will get some warning about such mistakes in the future. 