### PR TITLE
ControllerInterface: Fix deadlock when Wii Remote disconnects

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -372,6 +372,14 @@ void ControllerInterface::UpdateInput()
 
   // TODO: if we are an emulation input channel, we should probably always lock
   // Prefer outdated values over blocking UI or CPU thread (avoids short but noticeable frame drop)
+
+  // Lock this first to avoid deadlock with m_devices_mutex in certain cases (such as a Wii Remote
+  // getting disconnected)
+  if (!m_devices_population_mutex.try_lock())
+    return;
+
+  std::lock_guard population_lock(m_devices_population_mutex, std::adopt_lock);
+
   if (!m_devices_mutex.try_lock())
     return;
 


### PR DESCRIPTION
Fixes the deadlock below, which is the same bug as [issue 13027](https://bugs.dolphin-emu.org/issues/13027) and (I think) [issue 13154](https://bugs.dolphin-emu.org/issues/13154).

The following steps will cause a deadlock which soon leads to a hang:
1. Set Wii Remote 1 to Emulated Wii Remote
2. Select Connect Wii Remotes for Emulated Controllers
3. Pair a physical Wii Remote, which gets assigned to Wii Remote 1
4. Use the Remote's power button to turn it off
5. Wait until the console prints the error "Wiimote::IORead failed. Disconnecting Wii Remote".

At this point the deadlock has already happened although the GUI is still responsive for the moment. Any number of things will trigger the actual hang, including:
- Changing a Wii Remote option
- Starting a game
- Quitting Dolphin

### Explanation: 
There are several ControllerInterface functions (including RemoveDevice) which lock both the m_devices_population_mutex and m_devices_mutex in that order. UpdateInput doesn't directly need m_devices_population_mutex and so previously only locked m_devices_mutex. 

Most of the time that doesn't cause any issues but ControllerInterface::UpdateInput calls WiimoteController::Device::UpdateInput, which calls ControllerInterface::RemoveDevice if a Wii Remote is disconnected. This tries to lock the two mutexes in the normal order, but because ControllerInterface::UpdateInput already locked m_devices_mutex a deadlock becomes possible. Worse, a number of input backends are trying to call RemoveDevice at the same time which makes it highly likely one of them will lock m_devices_population_mutex before the thread that locked m_devices_mutex (which is usually but not always the hotkey scheduler thread) manages to do so.