### PR TITLE
Fix missing GameINI for Japanese version of Sonic Adventure 2: Battle

### DIFF
--- a/Data/Sys/GameSettings/GSB.ini
+++ b/Data/Sys/GameSettings/GSB.ini
@@ -1,0 +1,20 @@
+# GSBJ8P - Sonic Adventure 2 Battle
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 512
+
+[Video_Hacks]
+DeferEFBCopies = False


### PR DESCRIPTION
For some reason the Japanese version of Sonic Adventure 2: Battle has a different first three letters of the GameID than the other versions, meaning that it wasn't properly applied. (The Japanese version is GSBJ8P, whereas the other versions are GSNP8P, and GSNE8P.)