### PR TITLE
Android: Use $applicationId for DocmentProvider authority

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -157,7 +157,7 @@
 
         <provider
             android:name=".features.DocumentProvider"
-            android:authorities="org.dolphinemu.dolphinemu.user"
+            android:authorities="${applicationId}.user"
             android:grantUriPermissions="true"
             android:exported="true"
             android:permission="android.permission.MANAGE_DOCUMENTS"


### PR DESCRIPTION
Fixes side by side installation of debug, benchmark and release builds.