### PR TITLE
Fix missing GameINI for Japanese version of Sonic Adventure DX: Director's Cut

### DIFF
--- a/Data/Sys/GameSettings/GAS.ini
+++ b/Data/Sys/GameSettings/GAS.ini
@@ -1,0 +1,16 @@
+# GASJ8P - Sonic Adventure DX
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 512


### PR DESCRIPTION
Basically the same thing as #11643, but for Sonic Adventure DX: Director's Cut instead.