### PR TITLE
DolphinQt: Fix TAS widgets not updating with enable controller input

### DIFF
--- a/Source/Core/DolphinQt/TAS/TASSpinBox.cpp
+++ b/Source/Core/DolphinQt/TAS/TASSpinBox.cpp
@@ -28,6 +28,5 @@ void TASSpinBox::OnUIValueChanged(int new_value)
 
 void TASSpinBox::ApplyControllerValueChange()
 {
-  const QSignalBlocker blocker(this);
   setValue(m_state.ApplyControllerValueChange());
 }


### PR DESCRIPTION
This regressed in 0300b44d23b149a0b93dd0aa2e77d20a02882ddf. Specifically, the sliders and the stick/IR widgets did not update, but the spin boxes did update.

This was based on @JosJuice's suggestion. It doesn't seem to cause any infinite loops of widgets updating the spin boxes updating widgets. For what it's worth #8268 had an infinite loop at some point which I solved using my own `ReentranceBlocker` that allows 2 levels of recursion, but there was more complication there with 4 sliders and a total weight value compared to just x and y values.