### PR TITLE
Android: Make header padding appear even

### DIFF
--- a/Source/Android/app/src/main/res/layout/list_item_header.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_header.xml
@@ -8,12 +8,14 @@
 
     <TextView
         android:id="@+id/text_header_name"
-        android:layout_width="wrap_content"
-        android:layout_height="46dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
         android:layout_alignParentStart="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="@dimen/spacing_large"
+        android:layout_marginHorizontal="@dimen/spacing_large"
+        android:layout_marginTop="24dp"
+        android:layout_marginBottom="8dp"
         android:gravity="start|center_vertical"
         android:textColor="?attr/colorPrimary"
         android:textStyle="bold"


### PR DESCRIPTION
Before - 
![b4](https://user-images.githubusercontent.com/14132249/224813438-df324d1a-c83c-458a-83b3-162ad6be6b9e.png)

After - 
![after](https://user-images.githubusercontent.com/14132249/224813484-82122909-6079-4b72-bbef-1f6d852586ab.png)