### PR TITLE
[RFC] HW/DVDInterface: Only add processed DTK samples to mixer.

### DIFF
--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -209,11 +209,11 @@ void DVDInterface::DTKStreamingCallback(DIInterruptType interrupt_type,
     std::array<s16, MAX_POSSIBLE_SAMPLES * 2> temp_pcm{};
     ASSERT(m_pending_blocks <= MAX_POSSIBLE_BLOCKS);
     const u32 pending_blocks = std::min(m_pending_blocks, MAX_POSSIBLE_BLOCKS);
-    ProcessDTKSamples(temp_pcm.data(), pending_blocks, audio_data);
+    const size_t blocks_processed = ProcessDTKSamples(temp_pcm.data(), pending_blocks, audio_data);
 
     SoundStream* sound_stream = m_system.GetSoundStream();
-    sound_stream->GetMixer()->PushStreamingSamples(temp_pcm.data(),
-                                                   pending_blocks * StreamADPCM::SAMPLES_PER_BLOCK);
+    sound_stream->GetMixer()->PushStreamingSamples(
+        temp_pcm.data(), static_cast<u32>(blocks_processed * StreamADPCM::SAMPLES_PER_BLOCK));
 
     if (m_stream && ai.IsPlaying())
     {


### PR DESCRIPTION
I noticed this while refactoring the DVDInterface to a class. It looks fishy to me that `ProcessDTKSamples()` can process less than `pending_blocks` blocks but they all get pushed into the mixer.

This got changed in https://github.com/dolphin-emu/dolphin/commit/a450e33fb3d59772817248e6d3721bb8c014f76e though it's unclear to me whether this was intentional or not. As such, I have no idea whether this is correct or not, but I figured I should at least throw it here for discussion.