### PR TITLE
DolphinAnalytics: Add version-source field to identify Steam builds

### DIFF
--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -256,6 +256,12 @@ void DolphinAnalytics::MakeBaseBuilder()
   builder.AddData("version-branch", Common::GetScmBranchStr());
   builder.AddData("version-dist", Common::GetScmDistributorStr());
 
+#ifdef STEAM
+  builder.AddData("version-source", "steam");
+#else
+  builder.AddData("version-source", "other");
+#endif
+
   // Auto-Update information.
   builder.AddData("update-track", Config::Get(Config::MAIN_AUTOUPDATE_UPDATE_TRACK));
 


### PR DESCRIPTION
Adds a new field so we can identify Steam versions in the analytics.

(Technically, I think Google Play could also count as a "source", but I'm not sure how to distinguish between a sideloaded APK and Google Play, so I just left that out for now.)