### PR TITLE
VideoCommon: split cache entry creation into a separate function

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -32,6 +32,11 @@ class AbstractStagingTexture;
 class PointerWrap;
 struct VideoConfig;
 
+namespace VideoCommon
+{
+class CustomTextureData;
+}
+
 constexpr std::string_view EFB_DUMP_PREFIX = "efb1";
 constexpr std::string_view XFB_DUMP_PREFIX = "xfb1";
 
@@ -242,6 +247,14 @@ public:
     TexPoolEntry(std::unique_ptr<AbstractTexture> tex, std::unique_ptr<AbstractFramebuffer> fb);
   };
 
+  struct TextureCreationInfo
+  {
+    u64 base_hash;
+    u64 full_hash;
+    u32 bytes_per_block;
+    u32 palette_size;
+  };
+
   TextureCacheBase();
   virtual ~TextureCacheBase();
 
@@ -327,6 +340,11 @@ private:
   bool CreateUtilityTextures();
 
   void SetBackupConfig(const VideoConfig& config);
+
+  RcTcacheEntry CreateTextureEntry(const TextureCreationInfo& creation_info,
+                                   const TextureInfo& texture_info, int safety_color_sample_size,
+                                   VideoCommon::CustomTextureData* custom_texture_data,
+                                   bool custom_arbitrary_mipmaps);
 
   RcTcacheEntry GetXFBFromCache(u32 address, u32 width, u32 height, u32 stride);
 


### PR DESCRIPTION
This splits 'GetTexture()' in `TextureCacheBase` into two functions.  'GetTexture()' remains the way we look up a texture entry but a new function 'CreateTextureEntry()' is defined to handle the creation.  In addition, this cleans up the hi res texture logic so that it's all in one place.

There are a few advantages:

  * Code is a bit cleaner
  * Less branching for hi res textures (possibly compiler would optimize this but still)
  * Allows for a `CustomTextureData` to be replaced or enhanced later (used in my PRs)