### PR TITLE
MacUI: Add stub implementation of UI::IsTestMode()

### DIFF
--- a/Source/Core/MacUpdater/MacUI.mm
+++ b/Source/Core/MacUpdater/MacUI.mm
@@ -139,6 +139,12 @@ void UI::Init()
 {
 }
 
+// test-updater.py only works on Windows.
+bool UI::IsTestMode()
+{
+  return false;
+}
+
 bool Platform::VersionCheck(const std::vector<TodoList::UpdateOp>& to_update,
                             const std::string& install_base_path, const std::string& temp_dir)
 {


### PR DESCRIPTION
Fixes a regression from #11636.

#11636 never added an implementation of `UI::IsTestMode()` in `MacUI.m`, which causes a linker error. Bizarrely, the build never failed despite a linker error popping up in the log. This still needs to be investigated.

For now, just fix the error so that the updater can actually build again on macOS.