### PR TITLE
WinUpdater: Quote path for args when relaunching Dolphin.

### DIFF
--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -271,7 +271,7 @@ void LaunchApplication(std::string path)
   }
   else
   {
-    std::wstring cmdline = wpath;
+    std::wstring cmdline = L"\"" + wpath + L"\"";
     STARTUPINFOW startup_info{.cb = sizeof(startup_info)};
     PROCESS_INFORMATION process_info;
     if (IsTestMode())


### PR DESCRIPTION
This should fix https://forums.dolphin-emu.org/Thread-recent-update-triggering-this-error-on-auto-update

I *think* just adding quotes on both ends is enough, because a valid path on Windows cannot contain quotes by itself.