### PR TITLE
CMake: Use generator expressions for codesign targets

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -616,18 +616,8 @@ if(APPLE)
 
   if(MACOS_CODE_SIGNING)
     # Code sign make file builds
-    add_custom_command(TARGET dolphin-emu
-      POST_BUILD COMMAND
-      /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu$<$<CONFIG:Debug>:Debug>.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Dolphin.app" || true)
-
-    # Code sign builds for build systems that do have release/debug variants (Xcode)
-    add_custom_command(TARGET dolphin-emu
-      POST_BUILD COMMAND
-      /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmuDebug.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/Dolphin.app" || true)
-
-    add_custom_command(TARGET dolphin-emu
-      POST_BUILD COMMAND
-      /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE}/Dolphin.app" || true)
+    add_custom_command(TARGET dolphin-emu POST_BUILD
+      COMMAND /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu$<$<CONFIG:Debug>:Debug>.entitlements" "$<TARGET_BUNDLE_DIR:dolphin-emu>")
   endif()
 else()
   install(TARGETS dolphin-emu RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/Source/Core/MacUpdater/CMakeLists.txt
+++ b/Source/Core/MacUpdater/CMakeLists.txt
@@ -47,17 +47,14 @@ if (${IBTOOL} STREQUAL "IBTOOL-NOTFOUND")
 endif()
 
 foreach(sb ${STORYBOARDS})
-  set(MacUpdater_BIN_DIR ${CMAKE_BINARY_DIR}/Binaries)
-
-  if (CMAKE_GENERATOR STREQUAL Xcode)
-    string(APPEND MacUpdater_BIN_DIR "/\${CONFIGURATION}")
-  endif()
-
-  add_custom_command(TARGET MacUpdater POST_BUILD
-                     COMMAND ${IBTOOL} --errors --warnings --notices --output-format human-readable-text
-                                       --compile ${MacUpdater_BUNDLE_PATH}/Contents/Resources/${sb}c
-                     ${CMAKE_CURRENT_SOURCE_DIR}/${sb}
-                     COMMENT "Compiling Storyboard ${sb}...")
+  set(output ${CMAKE_CURRENT_BINARY_DIR}/${sb}c)
+  set(input  ${CMAKE_CURRENT_SOURCE_DIR}/${sb})
+  add_custom_command(OUTPUT ${output}
+    COMMAND ${IBTOOL} --errors --warnings --notices --output-format human-readable-text --compile ${output} ${input}
+    DEPENDS ${input}
+    COMMENT "Compiling Storyboard ${sb}...")
+  target_sources(MacUpdater PRIVATE ${output})
+  set_source_files_properties(${output} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 endforeach()
 
 if(MACOS_CODE_SIGNING)

--- a/Source/Core/MacUpdater/CMakeLists.txt
+++ b/Source/Core/MacUpdater/CMakeLists.txt
@@ -65,14 +65,6 @@ if(MACOS_CODE_SIGNING)
     set(MACOS_CODE_SIGNING_IDENTITY_UPDATER "${MACOS_CODE_SIGNING_IDENTITY}")
   endif()
 
-  # Make file build code sign
   add_custom_command(TARGET MacUpdater POST_BUILD
-    COMMAND test ${MacUpdater_BUNDLE_PATH} || /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY_UPDATER}" --deep --options runtime ${MacUpdater_BUNDLE_PATH})
-  
-  # Xcode build code sign
-  add_custom_command(TARGET MacUpdater POST_BUILD
-    COMMAND test "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/${MacUpdater_NAME}.app" || /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY_UPDATER}" --deep --options runtime "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/${MacUpdater_NAME}.app")
-    
-  add_custom_command(TARGET MacUpdater POST_BUILD
-    COMMAND test "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE}/${MacUpdater_NAME}.app" || /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY_UPDATER}" --deep --options runtime "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE}/${MacUpdater_NAME}.app")
+    COMMAND /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY_UPDATER}" --deep --options runtime $<TARGET_BUNDLE_DIR:MacUpdater>)
 endif()


### PR DESCRIPTION
Switches codesign targets from blindly attempting to codesign the places where targets might be placed to using generator expressions so cmake inserts the actual location of the target.

Also changes storyboard compiling from a `POST_BUILD` step to using proper dependency tracking.  In addition to avoiding the above issue, this also means that if someone edits the `.storyboard`, it will properly be recompiled.