### PR TITLE
[GameSettings] Change remaining 0/1 bools to False/True

### DIFF
--- a/Data/Sys/GameSettings/DLS.ini
+++ b/Data/Sys/GameSettings/DLS.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/G3F.ini
+++ b/Data/Sys/GameSettings/G3F.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GDV.ini
+++ b/Data/Sys/GameSettings/GDV.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-UseDualCore = 0
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GFH.ini
+++ b/Data/Sys/GameSettings/GFH.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GH9.ini
+++ b/Data/Sys/GameSettings/GH9.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GIS.ini
+++ b/Data/Sys/GameSettings/GIS.ini
@@ -3,7 +3,7 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 CPUThread = False
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GK2.ini
+++ b/Data/Sys/GameSettings/GK2.ini
@@ -1,4 +1,4 @@
 # GK2D52, GK2E52, GK2F52, GK2I52, GK2P52 - Spider-Man 2
 
 [Core]
-MMU = 1
+MMU = True

--- a/Data/Sys/GameSettings/GLR.ini
+++ b/Data/Sys/GameSettings/GLR.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GNW.ini
+++ b/Data/Sys/GameSettings/GNW.ini
@@ -1,8 +1,7 @@
-# G3XE52, G3XP52 - X-Men: The Official Game
+# GNWE69, GNWP69 - Def Jam Fight For NY
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -10,9 +9,5 @@ MMU = True
 [OnFrame]
 # Add memory patches to be applied every frame here.
 
-[ActionReplay]
-# Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GNWE69.ini
+++ b/Data/Sys/GameSettings/GNWE69.ini
@@ -1,16 +1,10 @@
 # GNWE69 - Def Jam Fight For NY
 
-[Core]
-Patch Region = 0x7e000000
-
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 
 [OnFrame]
 # Add memory patches to be applied every frame here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
 
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/GOS.ini
+++ b/Data/Sys/GameSettings/GOS.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GQC.ini
+++ b/Data/Sys/GameSettings/GQC.ini
@@ -1,7 +1,7 @@
 # GQCD52, GQCE52, GQCF52, GQCI52, GQCP52, GQCS52 - Call of Duty 2: Big Red One
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 [OnFrame]

--- a/Data/Sys/GameSettings/GSW.ini
+++ b/Data/Sys/GameSettings/GSW.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GSX.ini
+++ b/Data/Sys/GameSettings/GSX.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GUM.ini
+++ b/Data/Sys/GameSettings/GUM.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GUT.ini
+++ b/Data/Sys/GameSettings/GUT.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GWJ.ini
+++ b/Data/Sys/GameSettings/GWJ.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GWY.ini
+++ b/Data/Sys/GameSettings/GWY.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/HCL.ini
+++ b/Data/Sys/GameSettings/HCL.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/R4Z.ini
+++ b/Data/Sys/GameSettings/R4Z.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RML.ini
+++ b/Data/Sys/GameSettings/RML.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = 0
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RQR.ini
+++ b/Data/Sys/GameSettings/RQR.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = 0
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/SCY.ini
+++ b/Data/Sys/GameSettings/SCY.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-LowDCBZHack = 1
+LowDCBZHack = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/SNT.ini
+++ b/Data/Sys/GameSettings/SNT.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-MMU = 1
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/SQI.ini
+++ b/Data/Sys/GameSettings/SQI.ini
@@ -2,7 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-LowDCBZHack = 1
+LowDCBZHack = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
Very minor PR to make game settings more consistent for some bools (MMU, CPUThread and LowDCBZHack), replacing 0/1 with False/True.

While searching for 0/1 bools I found 2 unused variables, `UseDualCore` and `Patch Region`, so:

Changed `UseDualCore = 0` to `CPUThread = False` in `GDV.ini` (not even sure if it's needed? Couldn't find any info on the initial commit, on the wiki or the forums, tried a single race and it seemed fine with and without Dual Core, so idk...).

And removed the `Patch Region` line from `GNWE69.ini`, while I was at it I moved `ImmediateXFBEnable = False` from that same file to a new `GNW.ini` (unless there's a good reason this is only applied to the USA version?).

Hope this is fine!