### PR TITLE
Use std::ssize when appropriate

### DIFF
--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -161,7 +161,7 @@ void HttpRequest::Impl::FollowRedirects(long max)
 
 std::string HttpRequest::Impl::EscapeComponent(const std::string& string)
 {
-  char* escaped = curl_easy_escape(m_curl.get(), string.c_str(), static_cast<int>(string.size()));
+  char* escaped = curl_easy_escape(m_curl.get(), string.c_str(), std::ssize(string));
   std::string escaped_str(escaped);
   curl_free(escaped);
 
@@ -229,7 +229,7 @@ HttpRequest::Response HttpRequest::Impl::Fetch(const std::string& url, Method me
     {
       ERROR_LOG_FMT(COMMON, "Failed to {} {}: server replied with code {} and body\n\x1b[0m{:.{}}",
                     type, url, response_code, reinterpret_cast<char*>(buffer.data()),
-                    static_cast<int>(buffer.size()));
+                    std::ssize(buffer));
     }
     return {};
   }

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -447,15 +447,13 @@ size_t StringUTF8CodePointCount(std::string_view str)
 
 std::wstring CPToUTF16(u32 code_page, std::string_view input)
 {
-  auto const size =
-      MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), nullptr, 0);
+  auto const size = MultiByteToWideChar(code_page, 0, input.data(), std::ssize(input), nullptr, 0);
 
   std::wstring output;
   output.resize(size);
 
-  if (size == 0 ||
-      size != MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()),
-                                  &output[0], static_cast<int>(output.size())))
+  if (size == 0 || size != MultiByteToWideChar(code_page, 0, input.data(), std::ssize(input),
+                                               &output[0], std::ssize(output)))
   {
     output.clear();
   }
@@ -469,13 +467,13 @@ std::string UTF16ToCP(u32 code_page, std::wstring_view input)
     return {};
 
   // "If cchWideChar [input buffer size] is set to 0, the function fails." -MSDN
-  auto const size = WideCharToMultiByte(code_page, 0, input.data(), static_cast<int>(input.size()),
-                                        nullptr, 0, nullptr, nullptr);
+  auto const size = WideCharToMultiByte(code_page, 0, input.data(), std::ssize(input), nullptr, 0,
+                                        nullptr, nullptr);
 
   std::string output(size, '\0');
 
-  if (size != WideCharToMultiByte(code_page, 0, input.data(), static_cast<int>(input.size()),
-                                  output.data(), static_cast<int>(output.size()), nullptr, nullptr))
+  if (size != WideCharToMultiByte(code_page, 0, input.data(), std::ssize(input), output.data(),
+                                  std::ssize(output), nullptr, nullptr))
   {
     const DWORD error_code = GetLastError();
     ERROR_LOG_FMT(COMMON, "WideCharToMultiByte Error in String '{}': {}", WStringToUTF8(input),

--- a/Source/Core/Common/UPnP.cpp
+++ b/Source/Core/Common/UPnP.cpp
@@ -78,12 +78,11 @@ static bool InitUPnP()
     std::unique_ptr<char, decltype(&std::free)> desc_xml(nullptr, std::free);
     int statusCode = 200;
 #if MINIUPNPC_API_VERSION >= 16
-    desc_xml.reset(
-        static_cast<char*>(miniwget_getaddr(dev->descURL, &desc_xml_size, s_our_ip.data(),
-                                            static_cast<int>(s_our_ip.size()), 0, &statusCode)));
-#else
     desc_xml.reset(static_cast<char*>(miniwget_getaddr(
-        dev->descURL, &desc_xml_size, s_our_ip.data(), static_cast<int>(s_our_ip.size()), 0)));
+        dev->descURL, &desc_xml_size, s_our_ip.data(), std::ssize(s_our_ip), 0, &statusCode)));
+#else
+    desc_xml.reset(static_cast<char*>(
+        miniwget_getaddr(dev->descURL, &desc_xml_size, s_our_ip.data(), std::ssize(s_our_ip), 0)));
 #endif
     if (desc_xml && statusCode == 200)
     {

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -386,7 +386,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-vertex-rounding", g_Config.UseVertexRounding());
 
   // GPU features.
-  if (g_Config.iAdapter < static_cast<int>(g_Config.backend_info.Adapters.size()))
+  if (g_Config.iAdapter < std::ssize(g_Config.backend_info.Adapters))
   {
     builder.AddData("gpu-adapter", g_Config.backend_info.Adapters[g_Config.iAdapter]);
   }

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -144,7 +144,7 @@ CEXIMemoryCard::CEXIMemoryCard(Core::System& system, const Slot slot, bool gci_f
 
   m_memory_card_size = m_memory_card->GetCardId() * SIZE_TO_Mb;
   std::array<u8, 20> header{};
-  m_memory_card->Read(0, static_cast<s32>(header.size()), header.data());
+  m_memory_card->Read(0, std::ssize(header), header.data());
   auto& sram = system.GetSRAM();
   SetCardFlashID(&sram, header.data(), m_card_slot);
 }

--- a/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.cpp
@@ -104,7 +104,7 @@ int CSIDevice_GBAEmu::RunBuffer(u8* buffer, int request_length)
                     response.size());
 #endif
 
-    return static_cast<int>(response.size());
+    return std::ssize(response);
   }
   }
 

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -1046,7 +1046,7 @@ void WiiSockMan::UpdatePollCommands()
             // Happens only on savestate load
             if (pfds[0].revents & error_event)
             {
-              ret = static_cast<int>(pfds.size());
+              ret = std::ssize(pfds);
             }
             else
             {

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -409,7 +409,7 @@ void BluetoothRealDevice::WaitForHCICommandComplete(const u16 opcode)
   for (int tries = 0; tries < 100; ++tries)
   {
     const int ret = libusb_interrupt_transfer(m_handle, HCI_EVENT, buffer.data(),
-                                              static_cast<int>(buffer.size()), &actual_length, 20);
+                                              std::ssize(buffer), &actual_length, 20);
     if (ret != LIBUSB_SUCCESS || actual_length < static_cast<int>(sizeof(packet)))
       continue;
     std::memcpy(&packet, buffer.data(), sizeof(packet));

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -199,7 +199,7 @@ void NetPlayServer::SetupIndex()
   session.has_password = !Config::Get(Config::NETPLAY_INDEX_PASSWORD).empty();
   session.method = m_traversal_client ? "traversal" : "direct";
   session.game_id = m_selected_game_name.empty() ? "UNKNOWN" : m_selected_game_name;
-  session.player_count = static_cast<int>(m_players.size());
+  session.player_count = std::ssize(m_players);
   session.in_game = m_is_running;
   session.port = GetPort();
 
@@ -254,7 +254,7 @@ void NetPlayServer::ThreadFunc()
       m_ping_timer.Start();
       SendToClients(spac);
 
-      m_index.SetPlayerCount(static_cast<int>(m_players.size()));
+      m_index.SetPlayerCount(std::ssize(m_players));
       m_index.SetGame(m_selected_game_name);
       m_index.SetInGame(m_is_running);
 

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -317,7 +317,7 @@ int main(int argc, char* argv[])
 int wmain(int, wchar_t*[], wchar_t*[])
 {
   std::vector<std::string> args = CommandLineToUtf8Argv(GetCommandLineW());
-  const int argc = static_cast<int>(args.size());
+  const int argc = std::ssize(args);
   std::vector<char*> argv(args.size());
   for (size_t i = 0; i < args.size(); ++i)
     argv[i] = args[i].data();

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -68,13 +68,13 @@ void EnhancementsWidget::CreateWidgets()
       tr("4x Native (2560x2112) for 1440p"), tr("5x Native (3200x2640)"),
       tr("6x Native (3840x3168) for 4K"),    tr("7x Native (4480x3696)"),
       tr("8x Native (5120x4224) for 5K")};
-  const int visible_resolution_option_count = static_cast<int>(resolution_options.size());
+  const int visible_resolution_option_count = std::ssize(resolution_options);
 
   // If the current scale is greater than the max scale in the ini, add sufficient options so that
   // when the settings are saved we don't lose the user-modified value from the ini.
   const int max_efb_scale =
       std::max(Config::Get(Config::GFX_EFB_SCALE), Config::Get(Config::GFX_MAX_EFB_SCALE));
-  for (int scale = static_cast<int>(resolution_options.size()); scale <= max_efb_scale; scale++)
+  for (int scale = std::ssize(resolution_options); scale <= max_efb_scale; scale++)
   {
     resolution_options.append(tr("%1x Native (%2x%3)")
                                   .arg(QString::number(scale),

--- a/Source/Core/DolphinQt/Config/LogWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogWidget.cpp
@@ -26,7 +26,7 @@ constexpr size_t TIMESTAMP_LENGTH = 10;
 // A helper function to construct QString from std::string_view in one line
 static QString QStringFromStringView(std::string_view str)
 {
-  return QString::fromUtf8(str.data(), static_cast<int>(str.size()));
+  return QString::fromUtf8(str.data(), std::ssize(str));
 }
 
 LogWidget::LogWidget(QWidget* parent) : QDockWidget(parent), m_timer(new QTimer(this))

--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -125,8 +125,8 @@ void VerifyWidget::ConnectWidgets()
 
 static void SetHash(QLineEdit* line_edit, const std::vector<u8>& hash)
 {
-  const QByteArray byte_array = QByteArray::fromRawData(reinterpret_cast<const char*>(hash.data()),
-                                                        static_cast<int>(hash.size()));
+  const QByteArray byte_array =
+      QByteArray::fromRawData(reinterpret_cast<const char*>(hash.data()), std::ssize(hash));
   line_edit->setText(QString::fromLatin1(byte_array.toHex()));
 }
 
@@ -188,7 +188,7 @@ void VerifyWidget::Verify()
 
   m_summary_text->setText(QString::fromStdString(result->summary_text));
 
-  m_problems->setRowCount(static_cast<int>(result->problems.size()));
+  m_problems->setRowCount(std::ssize(result->problems));
   for (int i = 0; i < m_problems->rowCount(); ++i)
   {
     const DiscIO::VolumeVerifier::Problem problem = result->problems[i];

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -169,7 +169,7 @@ void WatchWidget::Update()
 
   Core::CPUThreadGuard guard(Core::System::GetInstance());
 
-  int size = static_cast<int>(PowerPC::debug_interface.GetWatches().size());
+  int size = std::ssize(PowerPC::debug_interface.GetWatches());
 
   m_table->setRowCount(size + 1);
 

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -655,8 +655,8 @@ void GCMemcardManager::DeleteFiles()
   if (selected_indices.empty())
     return;
 
-  const QString text = tr("Do you want to delete the %n selected save file(s)?", "",
-                          static_cast<int>(selected_indices.size()));
+  const QString text =
+      tr("Do you want to delete the %n selected save file(s)?", "", std::ssize(selected_indices));
   const auto response = ModalMessageBox::question(this, tr("Question"), text);
   if (response != QMessageBox::Yes)
     return;

--- a/Source/Core/DolphinQt/GameList/GridProxyModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GridProxyModel.cpp
@@ -61,8 +61,8 @@ QVariant GridProxyModel::data(const QModelIndex& i, int role) const
     }
     else
     {
-      pixmap = QPixmap::fromImage(QImage::fromData(
-          reinterpret_cast<const unsigned char*>(&buffer[0]), static_cast<int>(buffer.size())));
+      pixmap = QPixmap::fromImage(
+          QImage::fromData(reinterpret_cast<const unsigned char*>(&buffer[0]), std::ssize(buffer)));
 
       return pixmap.scaled(QSize(160, 224) * model->GetScale() * pixmap.devicePixelRatio(),
                            Qt::KeepAspectRatio, Qt::SmoothTransformation);

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -312,7 +312,7 @@ int main(int argc, char* argv[])
 int WINAPI wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int)
 {
   std::vector<std::string> args = CommandLineToUtf8Argv(GetCommandLineW());
-  const int argc = static_cast<int>(args.size());
+  const int argc = std::ssize(args);
   std::vector<char*> argv(args.size());
   for (size_t i = 0; i < args.size(); ++i)
     argv[i] = args[i].data();

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -216,7 +216,7 @@ void NetPlayBrowser::RefreshLoop()
 
 void NetPlayBrowser::UpdateList()
 {
-  const int session_count = static_cast<int>(m_sessions.size());
+  const int session_count = std::ssize(m_sessions);
 
   m_table_widget->clear();
   m_table_widget->setColumnCount(7);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -619,10 +619,10 @@ void NetPlayDialog::UpdateGUI()
   // Update Player List
   const auto players = client->GetPlayers();
 
-  if (static_cast<int>(players.size()) != m_player_count && m_player_count != 0)
+  if (std::ssize(players) != m_player_count && m_player_count != 0)
     QApplication::alert(this);
 
-  m_player_count = static_cast<int>(players.size());
+  m_player_count = std::ssize(players);
 
   int selection_pid = m_players_list->currentItem() ?
                           m_players_list->currentItem()->data(Qt::UserRole).toInt() :

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -98,7 +98,7 @@ void ResourcePackManager::RepopulateTable()
   header->setStretchLastSection(true);
   header->setHighlightSections(false);
 
-  int size = static_cast<int>(ResourcePack::GetPacks().size());
+  int size = std::ssize(ResourcePack::GetPacks());
 
   m_table_widget->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_table_widget->setSelectionMode(QAbstractItemView::SingleSelection);

--- a/Source/Core/DolphinQt/Resources.cpp
+++ b/Source/Core/DolphinQt/Resources.cpp
@@ -24,7 +24,7 @@ QList<QPixmap> Resources::m_misc;
 
 QIcon Resources::GetIcon(std::string_view name, const QString& dir)
 {
-  QString name_owned = QString::fromLatin1(name.data(), static_cast<int>(name.size()));
+  QString name_owned = QString::fromLatin1(name.data(), std::ssize(name));
   QString base_path = dir + QLatin1Char{'/'} + name_owned;
 
   const auto dpr = QGuiApplication::primaryScreen()->devicePixelRatio();

--- a/Source/Core/DolphinTool/ToolMain.cpp
+++ b/Source/Core/DolphinTool/ToolMain.cpp
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
 int wmain(int, wchar_t*[], wchar_t*[])
 {
   std::vector<std::string> args = CommandLineToUtf8Argv(GetCommandLineW());
-  const int argc = static_cast<int>(args.size());
+  const int argc = std::ssize(args);
   std::vector<char*> argv(args.size());
   for (size_t i = 0; i < args.size(); ++i)
     argv[i] = args[i].data();

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -178,7 +178,7 @@ bool InputConfig::ControllersNeedToBeCreated() const
 
 int InputConfig::GetControllerCount() const
 {
-  return static_cast<int>(m_controllers.size());
+  return std::ssize(m_controllers);
 }
 
 void InputConfig::RegisterHotplugCallback()

--- a/Source/Core/InputCommon/InputProfile.cpp
+++ b/Source/Core/InputCommon/InputProfile.cpp
@@ -66,7 +66,7 @@ std::string ProfileCycler::GetProfile(CycleDirection cycle_direction, int& profi
   // update the index and bind it to the number of available strings
   auto positive_modulo = [](int& i, int n) { i = (i % n + n) % n; };
   profile_index += static_cast<int>(cycle_direction);
-  positive_modulo(profile_index, static_cast<int>(profiles.size()));
+  positive_modulo(profile_index, std::ssize(profiles));
 
   return profiles[profile_index];
 }

--- a/Source/Core/UICommon/ResourcePack/Manager.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manager.cpp
@@ -116,7 +116,7 @@ std::vector<ResourcePack*> GetHigherPriorityPacks(ResourcePack& pack)
 ResourcePack* Add(const std::string& path, int offset)
 {
   if (offset == -1)
-    offset = static_cast<int>(packs.size());
+    offset = std::ssize(packs);
 
   ResourcePack pack(path);
 
@@ -129,7 +129,7 @@ ResourcePack* Add(const std::string& path, int offset)
 
   order->Set(pack.GetManifest()->GetID(), offset);
 
-  for (int i = offset; i < static_cast<int>(packs.size()); i++)
+  for (int i = offset; i < std::ssize(packs); i++)
     order->Set(packs[i].GetManifest()->GetID(), i + 1);
 
   file.Save(packs_path);
@@ -158,7 +158,7 @@ bool Remove(ResourcePack& pack)
 
   int offset = pack_iterator - packs.begin();
 
-  for (int i = offset + 1; i < static_cast<int>(packs.size()); i++)
+  for (int i = offset + 1; i < std::ssize(packs); i++)
     order->Set(packs[i].GetManifest()->GetID(), i - 1);
 
   file.Save(packs_path);

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -211,7 +211,7 @@ bool DownloadContent(const std::vector<TodoList::DownloadOp>& to_download,
 
   for (size_t i = 0; i < to_download.size(); i++)
   {
-    UI::SetTotalProgress(static_cast<int>(i + 1), static_cast<int>(to_download.size()));
+    UI::SetTotalProgress(static_cast<int>(i + 1), std::ssize(to_download));
 
     auto& download = to_download[i];
 

--- a/Source/Core/VideoCommon/Spirv.cpp
+++ b/Source/Core/VideoCommon/Spirv.cpp
@@ -60,7 +60,7 @@ CompileShaderToSPV(EShLanguage stage, APIType api_type,
   int default_version = 450;
 
   const char* pass_source_code = source.data();
-  int pass_source_code_length = static_cast<int>(source.size());
+  int pass_source_code_length = std::ssize(source);
 
   shader->setEnvTarget(glslang::EShTargetSpv, language_version);
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1769,7 +1769,7 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
   }
 
   INCSTAT(g_stats.num_textures_uploaded);
-  SETSTAT(g_stats.num_textures_alive, static_cast<int>(textures_by_address.size()));
+  SETSTAT(g_stats.num_textures_alive, std::ssize(textures_by_address));
 
   entry = DoPartialTextureUpdates(iter->second, texture_info.GetTlutAddress(),
                                   texture_info.GetTlutFormat());
@@ -1848,7 +1848,7 @@ RcTcacheEntry TextureCacheBase::GetXFBTexture(u32 address, u32 width, u32 height
 
   // Insert into the texture cache so we can re-use it next frame, if needed.
   textures_by_address.emplace(entry->addr, entry);
-  SETSTAT(g_stats.num_textures_alive, static_cast<int>(textures_by_address.size()));
+  SETSTAT(g_stats.num_textures_alive, std::ssize(textures_by_address));
   INCSTAT(g_stats.num_textures_uploaded);
 
   if (g_ActiveConfig.bDumpXFBTarget || g_ActiveConfig.bGraphicMods)


### PR DESCRIPTION
C++20's new `std::ssize(const Container&)` helper is a decent concession for the lack of a std::ssize_t type or `Container::ssize()` method.  It looks nicer than a static_cast\<int\> of the `Container::size()` method of a container, imo.  That being said, I predict a similar response to the last time I made a find-and-replace coding style pull request.  Do your worst.