### PR TITLE
JitArm64: Use 64-bit register for pointer when falling back to interpreter.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -199,7 +199,7 @@ void JitArm64::FallBackToInterpreter(UGeckoInstruction inst)
 
   Interpreter::Instruction instr = Interpreter::GetInterpreterOp(inst);
   MOVP2R(ARM64Reg::X8, instr);
-  MOVP2R(ARM64Reg::W0, &Core::System::GetInstance().GetInterpreter());
+  MOVP2R(ARM64Reg::X0, &Core::System::GetInstance().GetInterpreter());
   MOVI2R(ARM64Reg::W1, inst.hex);
   BLR(ARM64Reg::X8);
 


### PR DESCRIPTION
Should fix https://github.com/dolphin-emu/dolphin/pull/11671#discussion_r1142821268, I think?