### PR TITLE
Common: Move FPU-related helpers into Common namespace

### DIFF
--- a/Source/Core/Common/ArmFPURoundMode.cpp
+++ b/Source/Core/Common/ArmFPURoundMode.cpp
@@ -11,6 +11,8 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
+namespace Common::FPU
+{
 static u64 GetFPCR()
 {
 #ifdef _MSC_VER
@@ -31,8 +33,6 @@ static void SetFPCR(u64 fpcr)
 #endif
 }
 
-namespace FPURoundMode
-{
 static const u64 default_fpcr = GetFPCR();
 static u64 saved_fpcr = default_fpcr;
 
@@ -87,4 +87,4 @@ void LoadDefaultSIMDState()
   SetFPCR(default_fpcr);
 }
 
-}  // namespace FPURoundMode
+}  // namespace Common::FPU

--- a/Source/Core/Common/FPURoundMode.h
+++ b/Source/Core/Common/FPURoundMode.h
@@ -5,7 +5,7 @@
 
 #include "Common/CommonTypes.h"
 
-namespace FPURoundMode
+namespace Common::FPU
 {
 enum RoundMode : u32
 {
@@ -27,4 +27,4 @@ void SetSIMDMode(RoundMode rounding_mode, bool non_ieee_mode);
 void SaveSIMDState();
 void LoadSIMDState();
 void LoadDefaultSIMDState();
-}  // namespace FPURoundMode
+}  // namespace Common::FPU

--- a/Source/Core/Common/GenericFPURoundMode.cpp
+++ b/Source/Core/Common/GenericFPURoundMode.cpp
@@ -6,7 +6,7 @@
 #include "Common/CommonTypes.h"
 
 // Generic, do nothing
-namespace FPURoundMode
+namespace Common::FPU
 {
 void SetSIMDMode(RoundMode rounding_mode, bool non_ieee_mode)
 {
@@ -20,4 +20,4 @@ void LoadSIMDState()
 void LoadDefaultSIMDState()
 {
 }
-}  // namespace FPURoundMode
+}  // namespace Common::FPU

--- a/Source/Core/Common/x64FPURoundMode.cpp
+++ b/Source/Core/Common/x64FPURoundMode.cpp
@@ -9,7 +9,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Intrinsics.h"
 
-namespace FPURoundMode
+namespace Common::FPU
 {
 // Get the default SSE states here.
 static u32 saved_sse_state = _mm_getcsr();
@@ -49,4 +49,4 @@ void LoadDefaultSIMDState()
 {
   _mm_setcsr(default_sse_state);
 }
-}  // namespace FPURoundMode
+}  // namespace Common::FPU

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -644,7 +644,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
     // thread, and then takes over and becomes the video thread
     Common::SetCurrentThreadName("Video thread");
     UndeclareAsCPUThread();
-    FPURoundMode::LoadDefaultSIMDState();
+    Common::FPU::LoadDefaultSIMDState();
 
     // Spawn the CPU thread. The CPU thread will signal the event that boot is complete.
     s_cpu_thread = std::thread(cpuThreadFunc, savestate_path, delete_savestate);

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -436,7 +436,7 @@ enum FPSCRExceptionFlag : u32
 union UReg_FPSCR
 {
   // Rounding mode (towards: nearest, zero, +inf, -inf)
-  BitField<0, 2, FPURoundMode::RoundMode> RN;
+  BitField<0, 2, Common::FPU::RoundMode> RN;
   // Non-IEEE mode enable (aka flush-to-zero)
   BitField<2, 1, u32> NI;
   // Inexact exception enable

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -686,7 +686,7 @@ void RoundingModeUpdated()
   // The rounding mode is separate for each thread, so this must run on the CPU thread
   ASSERT(Core::IsCPUThread());
 
-  FPURoundMode::SetSIMDMode(PowerPC::ppcState.fpscr.RN, PowerPC::ppcState.fpscr.NI);
+  Common::FPU::SetSIMDMode(PowerPC::ppcState.fpscr.RN, PowerPC::ppcState.fpscr.NI);
 }
 
 }  // namespace PowerPC

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -455,8 +455,8 @@ int FifoManager::RunGpuOnCpu(Core::System& system, int ticks)
     {
       if (!reset_simd_state)
       {
-        FPURoundMode::SaveSIMDState();
-        FPURoundMode::LoadDefaultSIMDState();
+        Common::FPU::SaveSIMDState();
+        Common::FPU::LoadDefaultSIMDState();
         reset_simd_state = true;
       }
       ReadDataFromFifo(system, fifo.CPReadPointer.load(std::memory_order_relaxed));
@@ -484,7 +484,7 @@ int FifoManager::RunGpuOnCpu(Core::System& system, int ticks)
 
   if (reset_simd_state)
   {
-    FPURoundMode::LoadSIMDState();
+    Common::FPU::LoadSIMDState();
   }
 
   // Discard all available ticks as there is nothing to do any more.

--- a/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
@@ -84,12 +84,12 @@ public:
 
     // Set the rounding mode to something that's as annoying as possible to handle
     // (flush-to-zero enabled, and rounding not symmetric about the origin)
-    FPURoundMode::SetSIMDMode(FPURoundMode::RoundMode::ROUND_UP, true);
+    Common::FPU::SetSIMDMode(Common::FPU::RoundMode::ROUND_UP, true);
   }
 
   ~TestConversion() override
   {
-    FPURoundMode::LoadDefaultSIMDState();
+    Common::FPU::LoadDefaultSIMDState();
 
     FreeCodeSpace();
   }


### PR DESCRIPTION
Makes these utilities' namespace consistent with the majority of the Common library.