### PR TITLE
VideoCommon: migrate texture packs to use the asset loader system

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -83,10 +83,10 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCAdapter.h"
 
+#include "VideoCommon/Assets/CustomAssetLoader.h"
 #include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/FrameDumper.h"
-#include "VideoCommon/HiresTextures.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PerformanceMetrics.h"
 #include "VideoCommon/Present.h"
@@ -530,6 +530,9 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
 
   FreeLook::LoadInputConfig();
 
+  system.GetCustomAssetLoader().Init();
+  Common::ScopeGuard asset_loader_guard([&system] { system.GetCustomAssetLoader().Shutdown(); });
+
   Movie::Init(*boot);
   Common::ScopeGuard movie_guard{&Movie::Shutdown};
 
@@ -580,10 +583,6 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
     PanicAlertFmt("Failed to initialize DSP emulation!");
     return;
   }
-
-  // Inputs loading may have generated custom dynamic textures
-  // it's now ok to initialize any custom textures
-  HiresTexture::Update();
 
   AudioCommon::PostInitSoundStream(system);
 

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -27,6 +27,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "IOS/USB/Emulated/Infinity.h"
 #include "IOS/USB/Emulated/Skylander.h"
+#include "VideoCommon/Assets/CustomAssetLoader.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/GeometryShaderManager.h"
@@ -79,6 +80,7 @@ struct System::Impl
   VideoInterface::VideoInterfaceManager m_video_interface;
   Interpreter m_interpreter;
   JitInterface m_jit_interface;
+  VideoCommon::CustomAssetLoader m_custom_asset_loader;
 };
 
 System::System() : m_impl{std::make_unique<Impl>(*this)}
@@ -262,5 +264,10 @@ VertexShaderManager& System::GetVertexShaderManager() const
 VideoInterface::VideoInterfaceManager& System::GetVideoInterface() const
 {
   return m_impl->m_video_interface;
+}
+
+VideoCommon::CustomAssetLoader& System::GetCustomAssetLoader() const
+{
+  return m_impl->m_custom_asset_loader;
 }
 }  // namespace Core

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -85,6 +85,10 @@ namespace SerialInterface
 {
 class SerialInterfaceManager;
 };
+namespace VideoCommon
+{
+class CustomAssetLoader;
+}
 namespace VideoInterface
 {
 class VideoInterfaceManager;
@@ -152,6 +156,7 @@ public:
   Sram& GetSRAM() const;
   VertexShaderManager& GetVertexShaderManager() const;
   VideoInterface::VideoInterfaceManager& GetVideoInterface() const;
+  VideoCommon::CustomAssetLoader& GetCustomAssetLoader() const;
 
 private:
   System();

--- a/Source/Core/InputCommon/DynamicInputTextureManager.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextureManager.cpp
@@ -42,13 +42,9 @@ void DynamicInputTextureManager::Load()
 void DynamicInputTextureManager::GenerateTextures(const Common::IniFile& file,
                                                   const std::vector<std::string>& controller_names)
 {
-  bool any_dirty = false;
   for (const auto& configuration : m_configuration)
   {
-    any_dirty |= configuration.GenerateTextures(file, controller_names);
+    (void)configuration.GenerateTextures(file, controller_names);
   }
-
-  if (any_dirty && g_texture_cache && Core::GetState() != Core::State::Starting)
-    g_texture_cache->ForceReloadTextures();
 }
 }  // namespace InputCommon

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -19,38 +19,67 @@
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
-#include "Common/Flag.h"
-#include "Common/IOFile.h"
-#include "Common/Image.h"
 #include "Common/Logging/Log.h"
-#include "Common/MemoryUtil.h"
 #include "Common/StringUtil.h"
-#include "Common/Swap.h"
-#include "Common/Thread.h"
-#include "Common/Timer.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
+#include "Core/System.h"
+#include "VideoCommon/Assets/CustomAsset.h"
+#include "VideoCommon/Assets/CustomAssetLoader.h"
+#include "VideoCommon/Assets/DirectFilesystemAssetLibrary.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoConfig.h"
 
-struct DiskTexture
-{
-  std::string path;
-  bool has_arbitrary_mipmaps;
-};
-
 constexpr std::string_view s_format_prefix{"tex1_"};
 
-static std::unordered_map<std::string, DiskTexture> s_textureMap;
-static std::unordered_map<std::string, std::shared_ptr<HiresTexture>> s_textureCache;
-static std::mutex s_textureCacheMutex;
-static Common::Flag s_textureCacheAbortLoading;
+static std::unordered_map<std::string, std::shared_ptr<HiresTexture>> s_hires_texture_cache;
+static std::unordered_map<std::string, bool> s_hires_texture_id_to_arbmipmap;
 
-static std::thread s_prefetcher;
+static auto s_file_library = std::make_shared<VideoCommon::DirectFilesystemAssetLibrary>();
+
+namespace
+{
+std::pair<std::string, bool> GetNameArbPair(const TextureInfo& texture_info)
+{
+  if (s_hires_texture_id_to_arbmipmap.empty())
+    return {"", false};
+
+  const auto texture_name_details = texture_info.CalculateTextureName();
+  // look for an exact match first
+  const std::string full_name = texture_name_details.GetFullName();
+  if (auto iter = s_hires_texture_id_to_arbmipmap.find(full_name);
+      iter != s_hires_texture_id_to_arbmipmap.end())
+  {
+    return {full_name, iter->second};
+  }
+
+  // Single wildcard ignoring the tlut hash
+  const std::string texture_name_single_wildcard_tlut =
+      fmt::format("{}_{}_$_{}", texture_name_details.base_name, texture_name_details.texture_name,
+                  texture_name_details.format_name);
+  if (auto iter = s_hires_texture_id_to_arbmipmap.find(texture_name_single_wildcard_tlut);
+      iter != s_hires_texture_id_to_arbmipmap.end())
+  {
+    return {texture_name_single_wildcard_tlut, iter->second};
+  }
+
+  // Single wildcard ignoring the texture hash
+  const std::string texture_name_single_wildcard_tex =
+      fmt::format("{}_${}_{}", texture_name_details.base_name, texture_name_details.tlut_name,
+                  texture_name_details.format_name);
+  if (auto iter = s_hires_texture_id_to_arbmipmap.find(texture_name_single_wildcard_tex);
+      iter != s_hires_texture_id_to_arbmipmap.end())
+  {
+    return {texture_name_single_wildcard_tex, iter->second};
+  }
+
+  return {"", false};
+}
+}  // namespace
 
 void HiresTexture::Init()
 {
-  // Note: Update is not called here so that we handle dynamic textures on startup more gracefully
+  Update();
 }
 
 void HiresTexture::Shutdown()
@@ -60,27 +89,18 @@ void HiresTexture::Shutdown()
 
 void HiresTexture::Update()
 {
-  if (s_prefetcher.joinable())
-  {
-    s_textureCacheAbortLoading.Set();
-    s_prefetcher.join();
-  }
-
   if (!g_ActiveConfig.bHiresTextures)
   {
     Clear();
     return;
   }
 
-  if (!g_ActiveConfig.bCacheHiresTextures)
-  {
-    s_textureCache.clear();
-  }
-
   const std::string& game_id = SConfig::GetInstance().GetGameID();
   const std::set<std::string> texture_directories =
       GetTextureDirectoriesWithGameId(File::GetUserPath(D_HIRESTEXTURES_IDX), game_id);
   const std::vector<std::string> extensions{".png", ".dds"};
+
+  auto& system = Core::System::GetInstance();
 
   for (const auto& texture_directory : texture_directories)
   {
@@ -100,8 +120,20 @@ void HiresTexture::Update()
         if (has_arbitrary_mipmaps)
           filename.erase(arb_index, 4);
 
+        // Since this is just a texture (single file) the mapper doesn't really matter
+        // just provide a string
+        s_file_library->SetAssetIDMapData(filename,
+                                          std::map<std::string, std::filesystem::path>{{"", path}});
+
+        if (g_ActiveConfig.bCacheHiresTextures)
+        {
+          auto hires_texture = std::make_shared<HiresTexture>(
+              has_arbitrary_mipmaps,
+              system.GetCustomAssetLoader().LoadGameTexture(filename, s_file_library));
+          s_hires_texture_cache.try_emplace(filename, std::move(hires_texture));
+        }
         const auto [it, inserted] =
-            s_textureMap.try_emplace(filename, DiskTexture{path, has_arbitrary_mipmaps});
+            s_hires_texture_id_to_arbmipmap.try_emplace(filename, has_arbitrary_mipmaps);
         if (!inserted)
         {
           failed_insert = true;
@@ -115,269 +147,43 @@ void HiresTexture::Update()
                     texture_directory);
     }
   }
-
-  if (g_ActiveConfig.bCacheHiresTextures)
-  {
-    // remove cached but deleted textures
-    auto iter = s_textureCache.begin();
-    while (iter != s_textureCache.end())
-    {
-      if (s_textureMap.find(iter->first) == s_textureMap.end())
-      {
-        iter = s_textureCache.erase(iter);
-      }
-      else
-      {
-        iter++;
-      }
-    }
-
-    s_textureCacheAbortLoading.Clear();
-    s_prefetcher = std::thread(Prefetch);
-  }
 }
 
 void HiresTexture::Clear()
 {
-  if (s_prefetcher.joinable())
-  {
-    s_textureCacheAbortLoading.Set();
-    s_prefetcher.join();
-  }
-  s_textureMap.clear();
-  s_textureCache.clear();
-}
-
-void HiresTexture::Prefetch()
-{
-  Common::SetCurrentThreadName("Prefetcher");
-
-  size_t size_sum = 0;
-  const size_t sys_mem = Common::MemPhysical();
-  const size_t recommended_min_mem = 2 * size_t(1024 * 1024 * 1024);
-  // keep 2GB memory for system stability if system RAM is 4GB+ - use half of memory in other cases
-  const size_t max_mem =
-      (sys_mem / 2 < recommended_min_mem) ? (sys_mem / 2) : (sys_mem - recommended_min_mem);
-
-  Common::Timer timer;
-  timer.Start();
-  for (const auto& entry : s_textureMap)
-  {
-    const std::string& base_filename = entry.first;
-
-    if (base_filename.find("_mip") == std::string::npos)
-    {
-      std::unique_lock<std::mutex> lk(s_textureCacheMutex);
-
-      auto iter = s_textureCache.find(base_filename);
-      if (iter == s_textureCache.end())
-      {
-        // unlock while loading a texture. This may result in a race condition where
-        // we'll load a texture twice, but it reduces the stuttering a lot.
-        lk.unlock();
-        std::unique_ptr<HiresTexture> texture = Load(base_filename, 0, 0);
-        lk.lock();
-        if (texture)
-        {
-          std::shared_ptr<HiresTexture> ptr(std::move(texture));
-          iter = s_textureCache.insert(iter, std::make_pair(base_filename, ptr));
-        }
-      }
-      if (iter != s_textureCache.end())
-      {
-        for (const VideoCommon::CustomTextureData::Level& l : iter->second->m_data.m_levels)
-          size_sum += l.data.size();
-      }
-    }
-
-    if (s_textureCacheAbortLoading.IsSet())
-    {
-      return;
-    }
-
-    if (size_sum > max_mem)
-    {
-      Config::SetCurrent(Config::GFX_HIRES_TEXTURES, false);
-
-      OSD::AddMessage(
-          fmt::format(
-              "Custom Textures prefetching after {:.1f} MB aborted, not enough RAM available",
-              size_sum / (1024.0 * 1024.0)),
-          10000);
-      return;
-    }
-  }
-
-  OSD::AddMessage(fmt::format("Custom Textures loaded, {:.1f} MB in {:.1f}s",
-                              size_sum / (1024.0 * 1024.0), timer.ElapsedMs() / 1000.0),
-                  10000);
-}
-
-std::string HiresTexture::GenBaseName(const TextureInfo& texture_info, bool dump)
-{
-  if (!dump && s_textureMap.empty())
-    return "";
-
-  const auto texture_name_details = texture_info.CalculateTextureName();
-
-  // look for an exact match first
-  const std::string full_name = texture_name_details.GetFullName();
-  if (dump || s_textureMap.find(full_name) != s_textureMap.end())
-    return full_name;
-
-  // else try and find a wildcard
-  if (!dump)
-  {
-    // Single wildcard ignoring the tlut hash
-    const std::string texture_name_single_wildcard_tlut =
-        fmt::format("{}_{}_$_{}", texture_name_details.base_name, texture_name_details.texture_name,
-                    texture_name_details.format_name);
-    if (s_textureMap.find(texture_name_single_wildcard_tlut) != s_textureMap.end())
-      return texture_name_single_wildcard_tlut;
-
-    // Single wildcard ignoring the texture hash
-    const std::string texture_name_single_wildcard_tex =
-        fmt::format("{}_${}_{}", texture_name_details.base_name, texture_name_details.tlut_name,
-                    texture_name_details.format_name);
-    if (s_textureMap.find(texture_name_single_wildcard_tex) != s_textureMap.end())
-      return texture_name_single_wildcard_tex;
-  }
-
-  return "";
+  s_hires_texture_cache.clear();
+  s_hires_texture_id_to_arbmipmap.clear();
+  s_file_library = std::make_shared<VideoCommon::DirectFilesystemAssetLibrary>();
 }
 
 std::shared_ptr<HiresTexture> HiresTexture::Search(const TextureInfo& texture_info)
 {
-  const std::string base_filename = GenBaseName(texture_info);
+  const auto [base_filename, has_arb_mipmaps] = GetNameArbPair(texture_info);
+  if (base_filename == "")
+    return nullptr;
 
-  std::lock_guard<std::mutex> lk(s_textureCacheMutex);
-
-  auto iter = s_textureCache.find(base_filename);
-  if (iter != s_textureCache.end())
+  if (auto iter = s_hires_texture_cache.find(base_filename); iter != s_hires_texture_cache.end())
   {
     return iter->second;
   }
-
-  std::shared_ptr<HiresTexture> ptr(
-      Load(base_filename, texture_info.GetRawWidth(), texture_info.GetRawHeight()));
-
-  if (ptr && g_ActiveConfig.bCacheHiresTextures)
+  else
   {
-    s_textureCache[base_filename] = ptr;
+    auto& system = Core::System::GetInstance();
+    auto hires_texture = std::make_shared<HiresTexture>(
+        has_arb_mipmaps,
+        system.GetCustomAssetLoader().LoadGameTexture(base_filename, s_file_library));
+    if (g_ActiveConfig.bCacheHiresTextures)
+    {
+      s_hires_texture_cache.try_emplace(base_filename, hires_texture);
+    }
+    return hires_texture;
   }
-
-  return ptr;
 }
 
-std::unique_ptr<HiresTexture> HiresTexture::Load(const std::string& base_filename, u32 width,
-                                                 u32 height)
+HiresTexture::HiresTexture(bool has_arbitrary_mipmaps,
+                           std::shared_ptr<VideoCommon::GameTextureAsset> asset)
+    : m_has_arbitrary_mipmaps(has_arbitrary_mipmaps), m_game_texture(std::move(asset))
 {
-  // We need to have a level 0 custom texture to even consider loading.
-  auto filename_iter = s_textureMap.find(base_filename);
-  if (filename_iter == s_textureMap.end())
-    return nullptr;
-
-  // Try to load level 0 (and any mipmaps) from a DDS file.
-  // If this fails, it's fine, we'll just load level0 again using SOIL.
-  // Can't use make_unique due to private constructor.
-  std::unique_ptr<HiresTexture> ret = std::unique_ptr<HiresTexture>(new HiresTexture());
-  const DiskTexture& first_mip_file = filename_iter->second;
-  ret->m_has_arbitrary_mipmaps = first_mip_file.has_arbitrary_mipmaps;
-  VideoCommon::LoadDDSTexture(&ret->m_data, first_mip_file.path);
-
-  // Load remaining mip levels, or from the start if it's not a DDS texture.
-  for (u32 mip_level = static_cast<u32>(ret->m_data.m_levels.size());; mip_level++)
-  {
-    std::string filename = base_filename;
-    if (mip_level != 0)
-      filename += fmt::format("_mip{}", mip_level);
-
-    filename_iter = s_textureMap.find(filename);
-    if (filename_iter == s_textureMap.end())
-      break;
-
-    // Try loading DDS textures first, that way we maintain compression of DXT formats.
-    // TODO: Reduce the number of open() calls here. We could use one fd.
-    VideoCommon::CustomTextureData::Level level;
-    if (!LoadDDSTexture(&level, filename_iter->second.path, mip_level))
-    {
-      if (!LoadPNGTexture(&level, filename_iter->second.path))
-      {
-        ERROR_LOG_FMT(VIDEO, "Custom texture {} failed to load", filename);
-        break;
-      }
-    }
-
-    ret->m_data.m_levels.push_back(std::move(level));
-  }
-
-  // If we failed to load any mip levels, we can't use this texture at all.
-  if (ret->m_data.m_levels.empty())
-    return nullptr;
-
-  // Verify that the aspect ratio of the texture hasn't changed, as this could have side-effects.
-  const VideoCommon::CustomTextureData::Level& first_mip = ret->m_data.m_levels[0];
-  if (first_mip.width * height != first_mip.height * width)
-  {
-    ERROR_LOG_FMT(VIDEO,
-                  "Invalid custom texture size {}x{} for texture {}. The aspect differs "
-                  "from the native size {}x{}.",
-                  first_mip.width, first_mip.height, first_mip_file.path, width, height);
-  }
-
-  // Same deal if the custom texture isn't a multiple of the native size.
-  if (width != 0 && height != 0 && (first_mip.width % width || first_mip.height % height))
-  {
-    ERROR_LOG_FMT(VIDEO,
-                  "Invalid custom texture size {}x{} for texture {}. Please use an integer "
-                  "upscaling factor based on the native size {}x{}.",
-                  first_mip.width, first_mip.height, first_mip_file.path, width, height);
-  }
-
-  // Verify that each mip level is the correct size (divide by 2 each time).
-  u32 current_mip_width = first_mip.width;
-  u32 current_mip_height = first_mip.height;
-  for (u32 mip_level = 1; mip_level < static_cast<u32>(ret->m_data.m_levels.size()); mip_level++)
-  {
-    if (current_mip_width != 1 || current_mip_height != 1)
-    {
-      current_mip_width = std::max(current_mip_width / 2, 1u);
-      current_mip_height = std::max(current_mip_height / 2, 1u);
-
-      const VideoCommon::CustomTextureData::Level& level = ret->m_data.m_levels[mip_level];
-      if (current_mip_width == level.width && current_mip_height == level.height)
-        continue;
-
-      ERROR_LOG_FMT(
-          VIDEO, "Invalid custom texture size {}x{} for texture {}. Mipmap level {} must be {}x{}.",
-          level.width, level.height, first_mip_file.path, mip_level, current_mip_width,
-          current_mip_height);
-    }
-    else
-    {
-      // It is invalid to have more than a single 1x1 mipmap.
-      ERROR_LOG_FMT(VIDEO, "Custom texture {} has too many 1x1 mipmaps. Skipping extra levels.",
-                    first_mip_file.path);
-    }
-
-    // Drop this mip level and any others after it.
-    while (ret->m_data.m_levels.size() > mip_level)
-      ret->m_data.m_levels.pop_back();
-  }
-
-  // All levels have to have the same format.
-  if (std::any_of(ret->m_data.m_levels.begin(), ret->m_data.m_levels.end(),
-                  [&ret](const VideoCommon::CustomTextureData::Level& l) {
-                    return l.format != ret->m_data.m_levels[0].format;
-                  }))
-  {
-    ERROR_LOG_FMT(VIDEO, "Custom texture {} has inconsistent formats across mip levels.",
-                  first_mip_file.path);
-
-    return nullptr;
-  }
-
-  return ret;
 }
 
 std::set<std::string> GetTextureDirectoriesWithGameId(const std::string& root_directory,
@@ -424,18 +230,4 @@ std::set<std::string> GetTextureDirectoriesWithGameId(const std::string& root_di
   }
 
   return result;
-}
-
-HiresTexture::~HiresTexture()
-{
-}
-
-AbstractTextureFormat HiresTexture::GetFormat() const
-{
-  return m_data.m_levels.at(0).format;
-}
-
-bool HiresTexture::HasArbitraryMipmaps() const
-{
-  return m_has_arbitrary_mipmaps;
 }

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -10,6 +10,7 @@
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/Assets/CustomTextureData.h"
+#include "VideoCommon/Assets/TextureAsset.h"
 #include "VideoCommon/TextureConfig.h"
 #include "VideoCommon/TextureInfo.h"
 
@@ -25,26 +26,14 @@ public:
   static void Update();
   static void Clear();
   static void Shutdown();
-
   static std::shared_ptr<HiresTexture> Search(const TextureInfo& texture_info);
 
-  static std::string GenBaseName(const TextureInfo& texture_info, bool dump = false);
+  HiresTexture(bool has_arbitrary_mipmaps, std::shared_ptr<VideoCommon::GameTextureAsset> asset);
 
-  ~HiresTexture();
-
-  AbstractTextureFormat GetFormat() const;
-  bool HasArbitraryMipmaps() const;
-
-  VideoCommon::CustomTextureData& GetData() { return m_data; }
-  const VideoCommon::CustomTextureData& GetData() const { return m_data; }
+  bool HasArbitraryMipmaps() const { return m_has_arbitrary_mipmaps; }
+  const std::shared_ptr<VideoCommon::GameTextureAsset>& GetAsset() const { return m_game_texture; }
 
 private:
-  static std::unique_ptr<HiresTexture> Load(const std::string& base_filename, u32 width,
-                                            u32 height);
-  static void Prefetch();
-
-  HiresTexture() = default;
-
-  VideoCommon::CustomTextureData m_data;
   bool m_has_arbitrary_mipmaps = false;
+  std::shared_ptr<VideoCommon::GameTextureAsset> m_game_texture;
 };

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -272,6 +272,15 @@ void TextureCacheBase::SetBackupConfig(const VideoConfig& config)
       config.graphics_mod_config ? config.graphics_mod_config->GetChangeCount() : 0;
 }
 
+bool TextureCacheBase::DidLinkedAssetsChange(const TCacheEntry& entry)
+{
+  if (!entry.linked_asset.m_asset)
+    return false;
+
+  const auto last_asset_write_time = entry.linked_asset.m_asset->GetLastLoadedTime();
+  return last_asset_write_time > entry.linked_asset.m_last_write_time;
+}
+
 RcTcacheEntry TextureCacheBase::ApplyPaletteToEntry(RcTcacheEntry& entry, const u8* palette,
                                                     TLUTFormat tlutfmt)
 {
@@ -1272,8 +1281,25 @@ private:
 
 TCacheEntry* TextureCacheBase::Load(const TextureInfo& texture_info)
 {
+  if (auto entry = LoadImpl(texture_info, false))
+  {
+    if (!DidLinkedAssetsChange(*entry))
+    {
+      return entry;
+    }
+
+    InvalidateTexture(GetTexCacheIter(entry));
+    return LoadImpl(texture_info, true);
+  }
+
+  return nullptr;
+}
+
+TCacheEntry* TextureCacheBase::LoadImpl(const TextureInfo& texture_info, bool force_reload)
+{
   // if this stage was not invalidated by changes to texture registers, keep the current texture
-  if (TMEM::IsValid(texture_info.GetStage()) && bound_textures[texture_info.GetStage()])
+  if (!force_reload && TMEM::IsValid(texture_info.GetStage()) &&
+      bound_textures[texture_info.GetStage()])
   {
     TCacheEntry* entry = bound_textures[texture_info.GetStage()].get();
     // If the TMEM configuration is such that this texture is more or less guaranteed to still
@@ -1582,6 +1608,7 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
     InvalidateTexture(oldest_entry);
   }
 
+  CachedTextureAsset cached_texture_asset;
   std::shared_ptr<VideoCommon::CustomTextureData> data = nullptr;
   bool has_arbitrary_mipmaps = false;
   std::shared_ptr<HiresTexture> hires_texture;
@@ -1591,6 +1618,8 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
     if (hires_texture)
     {
       data = hires_texture->GetAsset()->GetData();
+      cached_texture_asset = {hires_texture->GetAsset(),
+                              hires_texture->GetAsset()->GetLastLoadedTime()};
       has_arbitrary_mipmaps = hires_texture->HasArbitraryMipmaps();
       if (data)
       {
@@ -1603,9 +1632,11 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
     }
   }
 
-  return CreateTextureEntry(
+  auto entry = CreateTextureEntry(
       TextureCreationInfo{base_hash, full_hash, bytes_per_block, palette_size}, texture_info,
       textureCacheSafetyColorSampleSize, data.get(), has_arbitrary_mipmaps);
+  entry->linked_asset = std::move(cached_texture_asset);
+  return entry;
 }
 
 RcTcacheEntry TextureCacheBase::CreateTextureEntry(

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -145,17 +145,6 @@ void TextureCacheBase::Invalidate()
   texture_pool.clear();
 }
 
-void TextureCacheBase::ForceReload()
-{
-  Invalidate();
-
-  // Clear all current hires textures, they are invalid
-  HiresTexture::Clear();
-
-  // Load fresh
-  HiresTexture::Update();
-}
-
 void TextureCacheBase::OnConfigChanged(const VideoConfig& config)
 {
   if (config.bHiresTextures != backup_config.hires_textures ||
@@ -781,17 +770,10 @@ void TextureCacheBase::DoLoadState(PointerWrap& p)
 
 void TextureCacheBase::OnFrameEnd()
 {
-  if (m_force_reload_textures.TestAndClear())
-  {
-    ForceReload();
-  }
-  else
-  {
-    // Flush any outstanding EFB copies to RAM, in case the game is running at an uncapped frame
-    // rate and not waiting for vblank. Otherwise, we'd end up with a huge list of pending
-    // copies.
-    FlushEFBCopies();
-  }
+  // Flush any outstanding EFB copies to RAM, in case the game is running at an uncapped frame
+  // rate and not waiting for vblank. Otherwise, we'd end up with a huge list of pending
+  // copies.
+  FlushEFBCopies();
 
   Cleanup(g_presenter->FrameCount());
 }

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -272,7 +272,6 @@ public:
   void Shutdown();
 
   void OnConfigChanged(const VideoConfig& config);
-  void ForceReload();
 
   // Removes textures which aren't used for more than TEXTURE_KILL_THRESHOLD frames,
   // frameCount is the current frame number.
@@ -312,9 +311,6 @@ public:
 
   static bool AllCopyFilterCoefsNeeded(const std::array<u32, 3>& coefficients);
   static bool CopyFilterCanOverflow(const std::array<u32, 3>& coefficients);
-
-  // Will forcibly reload all textures when the frame next ends
-  void ForceReloadTextures() { m_force_reload_textures.Set(); }
 
 protected:
   // Decodes the specified data to the GPU texture specified by entry.
@@ -468,7 +464,6 @@ private:
 
   void OnFrameEnd();
 
-  Common::Flag m_force_reload_textures;
   Common::EventHook m_frame_event =
       AfterFrameEvent::Register([this] { OnFrameEnd(); }, "TextureCache");
 };

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -343,7 +343,7 @@ private:
 
   RcTcacheEntry CreateTextureEntry(const TextureCreationInfo& creation_info,
                                    const TextureInfo& texture_info, int safety_color_sample_size,
-                                   VideoCommon::CustomTextureData* custom_texture_data,
+                                   const VideoCommon::CustomTextureData* custom_texture_data,
                                    bool custom_arbitrary_mipmaps);
 
   RcTcacheEntry GetXFBFromCache(u32 address, u32 width, u32 height, u32 stride);


### PR DESCRIPTION
This moves high resolution textures to be loaded as assets by the asset loader system.  This makes the high resolution textures load in an asynchronous manner and also allows for them to be reloaded automatically:

![asset_management_auto_reload](https://user-images.githubusercontent.com/15224722/226804671-90c68087-37ff-4ad2-a3f6-100a04cc6e2e.gif)

High resolution textures did have some particular behaviors that didn't fit very well in the asset loader system, I've listed them below.

**Change**:  The OSD messages about all textures being loaded was removed.
**Response**:  I know that this message is useful for debugging.  This doesn't make sense for the asset loader though because an asset can be loaded at any time (not just on start up).  My idea is to add an imgui window that lists a count of every asset type loaded.  I haven't done this yet.  If this is a blocker, I can implement it in a separate review before merging this.

**Change**:  High resolution textures no longer block the game when they need to load.  This eliminates stutter at the cost of textures "popping in". 
**Response**:  On a higher fidelity machine, this doesn't seem distracting and all textures seem to be loaded just as quickly as on master.  At least one or two users I've spoken with said they'd prefer pop-in over stutter if given the choice.  And at least one other emulator offers this option (while also mentioning this is the preferred approach) so moving to this wouldn't surprise users.

**Change**: Previously, if the high resolution textures exceeded the memory limit Dolphin calculated, high resolution textures would be turned off completely and aborted.  Now the system will just reject future assets, logging that the memory cap has been reached.
**Response**:  I think the previous solution was a poor decision and think that users which are memory capped would rather see _some_ of the textures then none at all.  In the future a smarter memory management system would possibly alleviate this.

**Change**: Previously, mip textures were more flexible and could be anywhere in the texture pack.
**Response**:  This made sense given the solution but is now difficult to do.  I could introduce a separate library system just for high-resolution textures but in practice most packs I've seen keep their mip textures next to the main textures _or_ are using DDS textures with the mips included.  Most packs seem to use the same file type for the mip as they do the main texture too.  The odd packs that don't should be updated to one of the aforementioned solutions.

-----

TODO:

- [x] Support the "_mip" textures
- [x] Cleanup DynamicInputTexture logic to no longer force the texture cache to reload when input changes occur