### PR TITLE
Common: Move FixedSizeQueue into Common namespace

### DIFF
--- a/Source/Core/AudioCommon/SurroundDecoder.h
+++ b/Source/Core/AudioCommon/SurroundDecoder.h
@@ -29,7 +29,7 @@ private:
 
   std::unique_ptr<DPL2FSDecoder> m_fsdecoder;
   std::array<float, 32768> m_float_conversion_buffer;
-  FixedSizeQueue<float, 32768> m_decoded_fifo;
+  Common::FixedSizeQueue<float, 32768> m_decoded_fifo;
 };
 
 }  // namespace AudioCommon

--- a/Source/Core/Common/FixedSizeQueue.h
+++ b/Source/Core/Common/FixedSizeQueue.h
@@ -13,6 +13,8 @@
 //
 // Not fully featured, no safety checking yet. Add features as needed.
 
+namespace Common
+{
 template <class T, int N>
 class FixedSizeQueue
 {
@@ -84,3 +86,4 @@ private:
   // Sacrifice 4 bytes for a simpler implementation. may optimize away in the future.
   int count = 0;
 };
+}  // namespace Common

--- a/Source/Core/DolphinQt/Config/LogWidget.h
+++ b/Source/Core/DolphinQt/Config/LogWidget.h
@@ -52,5 +52,5 @@ private:
   static constexpr int MAX_LOG_LINES = 5000;
 
   std::mutex m_log_mutex;
-  FixedSizeQueue<LogEntry, MAX_LOG_LINES> m_log_ring_buffer;
+  Common::FixedSizeQueue<LogEntry, MAX_LOG_LINES> m_log_ring_buffer;
 };

--- a/Source/UnitTests/Common/FixedSizeQueueTest.cpp
+++ b/Source/UnitTests/Common/FixedSizeQueueTest.cpp
@@ -7,7 +7,7 @@
 
 TEST(FixedSizeQueue, Simple)
 {
-  FixedSizeQueue<int, 5> q;
+  Common::FixedSizeQueue<int, 5> q;
 
   EXPECT_EQ(0u, q.size());
 
@@ -34,7 +34,7 @@ TEST(FixedSizeQueue, Simple)
 TEST(FixedSizeQueue, RingBuffer)
 {
   // Testing if queue works when used as a ring buffer
-  FixedSizeQueue<int, 5> q;
+  Common::FixedSizeQueue<int, 5> q;
 
   EXPECT_EQ(0u, q.size());
 
@@ -84,7 +84,7 @@ public:
 TEST(FixedSizeQueue, NonTrivialTypes)
 {
   // Testing if construction/destruction of non-trivial types happens as expected
-  FixedSizeQueue<NonTrivialTypeTestData, 2> q;
+  Common::FixedSizeQueue<NonTrivialTypeTestData, 2> q;
 
   EXPECT_EQ(0u, q.size());
 


### PR DESCRIPTION
Gets this out of the global namespace.