### PR TITLE
Android: Remove notouch version of 'clear'

### DIFF
--- a/Source/Android/app/src/main/res/values-notouch/strings.xml
+++ b/Source/Android/app/src/main/res/values-notouch/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="clear">Hold back to clear</string>
-</resources>


### PR DESCRIPTION
No longer needed since we have a way to clear input expressions from the advanced mapping dialog.

Side note - @JosJuice This also makes me think about #11204 and how we're gonna have to prevent binding the back button relatively soon. Is there a nice way we could filter that out from the motion alert dialog and the advanced mapping dialog? (I wouldn't blame you if you wanted to wait until the motion part of the overhaul was done)