### PR TITLE
windows: temporarily hardcode VCToolsVersion to 14.34.31931.0

### DIFF
--- a/Source/Core/Common/build_info.txt.in
+++ b/Source/Core/Common/build_info.txt.in
@@ -19,5 +19,5 @@ OSMinimumVersionWin11=10.0.22000.0
 //   VCToolsVersion=14.33.31629
 // We're really looking for "14.32.31332.0" (because that's what will appear in the registry once
 // installed), NOT the other values!
-VCToolsVersion=${VC_TOOLS_VERSION}
+VCToolsVersion=14.34.31931.0
 VCToolsUpdateURL=https://aka.ms/vs/17/release/vc_redist.x64.exe


### PR DESCRIPTION
this should be reverted after next beta is built
see https://bugs.dolphin-emu.org/issues/13206

i've paused updates on the buildbot to ensure it doesn't update in the interim (even tho it shouldn't cause a problem)