### PR TITLE
Android: Ignore input from invalid pointer identifier

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
@@ -108,20 +108,21 @@ public class InputOverlayPointer
         break;
     }
 
-    if (trackId == -1)
+    int eventPointerIndex = event.findPointerIndex(trackId);
+    if (trackId == -1 || eventPointerIndex == -1)
       return;
 
     if (mMode == MODE_FOLLOW)
     {
-      mCurrentX = (event.getX(event.findPointerIndex(trackId)) - mGameCenterX) * mGameWidthHalfInv;
-      mCurrentY = (event.getY(event.findPointerIndex(trackId)) - mGameCenterY) * mGameHeightHalfInv;
+      mCurrentX = (event.getX(eventPointerIndex) - mGameCenterX) * mGameWidthHalfInv;
+      mCurrentY = (event.getY(eventPointerIndex) - mGameCenterY) * mGameHeightHalfInv;
     }
     else if (mMode == MODE_DRAG)
     {
       mCurrentX = mOldX +
-              (event.getX(event.findPointerIndex(trackId)) - mTouchStartX) * mGameWidthHalfInv;
+              (event.getX(eventPointerIndex) - mTouchStartX) * mGameWidthHalfInv;
       mCurrentY = mOldY +
-              (event.getY(event.findPointerIndex(trackId)) - mTouchStartY) * mGameHeightHalfInv;
+              (event.getY(eventPointerIndex) - mTouchStartY) * mGameHeightHalfInv;
     }
   }
 


### PR DESCRIPTION
Potential fix to this crash detected in the play console.

```
Exception java.lang.IllegalArgumentException: pointerIndex out of range
  at android.view.MotionEvent.nativeGetAxisValue (MotionEvent.java)
  at android.view.MotionEvent.getX (MotionEvent.java:2412)
  at org.dolphinemu.dolphinemu.overlay.InputOverlayPointer.onTouch (InputOverlayPointer.java:116)
  at org.dolphinemu.dolphinemu.overlay.InputOverlay.onTouch (InputOverlay.java:345)
  at android.view.View.dispatchTouchEvent (View.java:14385)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2814)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2814)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2814)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2814)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2814)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2814)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2814)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2814)
  at com.android.internal.policy.DecorView.superDispatchTouchEvent (DecorView.java:517)
  at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent (PhoneWindow.java:1894)
  at android.app.Activity.dispatchTouchEvent (Activity.java:4131)
  at org.dolphinemu.dolphinemu.activities.EmulationActivity.dispatchTouchEvent (EmulationActivity.java:1116)
  at androidx.appcompat.view.WindowCallbackWrapper.dispatchTouchEvent (WindowCallbackWrapper.java:70)
  at com.android.internal.policy.DecorView.dispatchTouchEvent (DecorView.java:475)
  at android.view.View.dispatchPointerEvent (View.java:14648)
  at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent (ViewRootImpl.java:6531)
  at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess (ViewRootImpl.java:6302)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:5768)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:5825)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:5791)
  at android.view.ViewRootImpl$AsyncInputStage.forward (ViewRootImpl.java:5943)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:5799)
  at android.view.ViewRootImpl$AsyncInputStage.apply (ViewRootImpl.java:6000)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:5772)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:5825)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:5791)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:5799)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:5772)
  at android.view.ViewRootImpl.deliverInputEvent (ViewRootImpl.java:8672)
  at android.view.ViewRootImpl.doProcessInputEvents (ViewRootImpl.java:8623)
  at android.view.ViewRootImpl.enqueueInputEvent (ViewRootImpl.java:8521)
  at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent (ViewRootImpl.java:8795)
  at android.view.InputEventReceiver.dispatchInputEvent (InputEventReceiver.java:231)
  at android.view.InputEventReceiver.nativeConsumeBatchedInputEvents (InputEventReceiver.java)
  at android.view.InputEventReceiver.consumeBatchedInputEvents (InputEventReceiver.java:211)
  at android.view.ViewRootImpl.doConsumeBatchedInput (ViewRootImpl.java:8752)
  at android.view.ViewRootImpl$ConsumeBatchedInputRunnable.run (ViewRootImpl.java:8834)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1352)
  at android.view.Choreographer.doCallbacks (Choreographer.java:1149)
  at android.view.Choreographer.doFrame (Choreographer.java:1015)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:1333)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:233)
  at android.app.ActivityThread.main (ActivityThread.java:8068)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:631)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:978)
```