### PR TITLE
Resolve GCC/Clang Warnings

### DIFF
--- a/Source/Core/Common/Crypto/bn.cpp
+++ b/Source/Core/Common/Crypto/bn.cpp
@@ -3,42 +3,45 @@
 
 #include "Common/Crypto/bn.h"
 
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 
 #include "Common/CommonTypes.h"
 
-static void bn_zero(u8* d, int n)
+static void bn_zero(u8* d, const size_t n)
 {
   std::memset(d, 0, n);
 }
 
-static void bn_copy(u8* d, const u8* a, int n)
+static void bn_copy(u8* d, const u8* a, const size_t n)
 {
   std::memcpy(d, a, n);
 }
 
-int bn_compare(const u8* a, const u8* b, int n)
+int bn_compare(const u8* a, const u8* b, const size_t n)
 {
   return std::memcmp(a, b, n);
 }
 
-void bn_sub_modulus(u8* a, const u8* N, int n)
+void bn_sub_modulus(u8* a, const u8* N, const size_t n)
 {
   u8 c = 0;
-  for (int i = n - 1; i >= 0; --i)
+  for (size_t i = n; i > 0;)
   {
+    --i;
     u32 dig = N[i] + c;
     c = (a[i] < dig);
     a[i] -= dig;
   }
 }
 
-void bn_add(u8* d, const u8* a, const u8* b, const u8* N, int n)
+void bn_add(u8* d, const u8* a, const u8* b, const u8* N, const size_t n)
 {
   u8 c = 0;
-  for (int i = n - 1; i >= 0; --i)
+  for (size_t i = n; i > 0;)
   {
+    --i;
     u32 dig = a[i] + b[i] + c;
     c = (dig >= 0x100);
     d[i] = dig;
@@ -51,11 +54,11 @@ void bn_add(u8* d, const u8* a, const u8* b, const u8* N, int n)
     bn_sub_modulus(d, N, n);
 }
 
-void bn_mul(u8* d, const u8* a, const u8* b, const u8* N, int n)
+void bn_mul(u8* d, const u8* a, const u8* b, const u8* N, const size_t n)
 {
   bn_zero(d, n);
 
-  for (int i = 0; i < n; i++)
+  for (size_t i = 0; i < n; i++)
   {
     for (u8 mask = 0x80; mask != 0; mask >>= 1)
     {
@@ -66,13 +69,13 @@ void bn_mul(u8* d, const u8* a, const u8* b, const u8* N, int n)
   }
 }
 
-void bn_exp(u8* d, const u8* a, const u8* N, int n, const u8* e, int en)
+void bn_exp(u8* d, const u8* a, const u8* N, const size_t n, const u8* e, const size_t en)
 {
   u8 t[512];
 
   bn_zero(d, n);
   d[n - 1] = 1;
-  for (int i = 0; i < en; i++)
+  for (size_t i = 0; i < en; i++)
   {
     for (u8 mask = 0x80; mask != 0; mask >>= 1)
     {
@@ -86,7 +89,7 @@ void bn_exp(u8* d, const u8* a, const u8* N, int n, const u8* e, int en)
 }
 
 // only for prime N -- stupid but lazy, see if I care
-void bn_inv(u8* d, const u8* a, const u8* N, int n)
+void bn_inv(u8* d, const u8* a, const u8* N, const size_t n)
 {
   u8 t[512], s[512];
 

--- a/Source/Core/Common/Crypto/bn.h
+++ b/Source/Core/Common/Crypto/bn.h
@@ -3,13 +3,15 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "Common/CommonTypes.h"
 
 // bignum arithmetic
 
-int bn_compare(const u8* a, const u8* b, int n);
-void bn_sub_modulus(u8* a, const u8* N, int n);
-void bn_add(u8* d, const u8* a, const u8* b, const u8* N, int n);
-void bn_mul(u8* d, const u8* a, const u8* b, const u8* N, int n);
-void bn_inv(u8* d, const u8* a, const u8* N, int n);  // only for prime N
-void bn_exp(u8* d, const u8* a, const u8* N, int n, const u8* e, int en);
+int bn_compare(const u8* a, const u8* b, size_t n);
+void bn_sub_modulus(u8* a, const u8* N, size_t n);
+void bn_add(u8* d, const u8* a, const u8* b, const u8* N, size_t n);
+void bn_mul(u8* d, const u8* a, const u8* b, const u8* N, size_t n);
+void bn_inv(u8* d, const u8* a, const u8* N, size_t n);  // only for prime N
+void bn_exp(u8* d, const u8* a, const u8* N, size_t n, const u8* e, size_t en);

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -486,7 +486,7 @@ FSTEntry ScanDirectoryTree(std::string directory, bool recursive)
       }
       else if (cur_depth < prev_depth)
       {
-        while (dir_fsts.size() - 1 != cur_depth)
+        while (dir_fsts.size() != static_cast<size_t>(cur_depth) + 1u)
         {
           calc_dir_size(dir_fsts.top());
           dir_fsts.pop();

--- a/Source/Core/Common/HttpRequest.h
+++ b/Source/Core/Common/HttpRequest.h
@@ -25,8 +25,7 @@ public:
   };
 
   // Return false to abort the request
-  using ProgressCallback =
-      std::function<bool(double dlnow, double dltotal, double ulnow, double ultotal)>;
+  using ProgressCallback = std::function<bool(s64 dltotal, s64 dlnow, s64 ultotal, s64 ulnow)>;
 
   explicit HttpRequest(std::chrono::milliseconds timeout_ms = std::chrono::milliseconds{3000},
                        ProgressCallback callback = nullptr);

--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -70,12 +70,10 @@ std::string SettingsHandler::GetValue(std::string_view key) const
 
 void SettingsHandler::Decrypt()
 {
-  const u8* str = m_buffer.data();
   while (m_position < m_buffer.size())
   {
     decoded.push_back((u8)(m_buffer[m_position] ^ m_key));
     m_position++;
-    str++;
     m_key = (m_key >> 31) | (m_key << 1);
   }
 

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstring>
 #include <mutex>
+#include <type_traits>
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
@@ -101,14 +102,9 @@ void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file,
         part_start = offset;
         // Copy cpmem now, because end_of_primitives isn't triggered until the first opcode after
         // primitive data, and the first opcode might update cpmem
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-        std::memcpy(&cpmem, &analyzer.m_cpmem, sizeof(CPState));
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+        static_assert(std::is_trivially_copyable_v<CPState>);
+        std::memcpy(static_cast<void*>(&cpmem), static_cast<const void*>(&analyzer.m_cpmem),
+                    sizeof(CPState));
       }
       if (analyzer.m_end_of_primitives)
       {

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -268,9 +268,7 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
           RecordInitialVideoMemory();
         }
 
-        auto& system = Core::System::GetInstance();
-        auto& command_processor = system.GetCommandProcessor();
-        const auto& fifo = command_processor.GetFifo();
+        const auto& fifo = Core::System::GetInstance().GetCommandProcessor().GetFifo();
         EndFrame(fifo.CPBase.load(std::memory_order_relaxed),
                  fifo.CPEnd.load(std::memory_order_relaxed));
       },

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
@@ -44,21 +44,21 @@ constexpr u32 VOICE_16_BIT_FLAG = 2;
 
 // These are used in the pre-2020 versions version
 constexpr u32 VOICE_PAUSE_OLD = 0x00000004;
-constexpr u32 VOICE_LOOP_OLD = 0x00000008;    // not used by the DSP
-constexpr u32 VOICE_ONCE_OLD = 0x00000010;    // not used by the DSP
-constexpr u32 VOICE_STREAM_OLD = 0x00000020;  // not used by the DSP
+constexpr u32 VOICE_LOOP_OLD [[maybe_unused]] = 0x00000008;    // not used by the DSP
+constexpr u32 VOICE_ONCE_OLD [[maybe_unused]] = 0x00000010;    // not used by the DSP
+constexpr u32 VOICE_STREAM_OLD [[maybe_unused]] = 0x00000020;  // not used by the DSP
 
 // These were changed in the 2020 version to account for the different flags
 constexpr u32 VOICE_PAUSE_NEW = 0x00000008;
-constexpr u32 VOICE_LOOP_NEW = 0x00000010;    // not used by the DSP
-constexpr u32 VOICE_ONCE_NEW = 0x00000020;    // not used by the DSP
-constexpr u32 VOICE_STREAM_NEW = 0x00000040;  // not used by the DSP
+constexpr u32 VOICE_LOOP_NEW [[maybe_unused]] = 0x00000010;    // not used by the DSP
+constexpr u32 VOICE_ONCE_NEW [[maybe_unused]] = 0x00000020;    // not used by the DSP
+constexpr u32 VOICE_STREAM_NEW [[maybe_unused]] = 0x00000040;  // not used by the DSP
 
 // These did not change between versions
 constexpr u32 VOICE_FINISHED = 0x00100000;
-constexpr u32 VOICE_STOPPED = 0x00200000;  // not used by the DSP
+constexpr u32 VOICE_STOPPED [[maybe_unused]] = 0x00200000;  // not used by the DSP
 constexpr u32 VOICE_RUNNING = 0x40000000;
-constexpr u32 VOICE_USED = 0x80000000;  // not used by the DSP
+constexpr u32 VOICE_USED [[maybe_unused]] = 0x80000000;  // not used by the DSP
 
 // 1<<4 = scale gain by 1/1,    2<<2 = PCM decoding from ARAM, 1<<0 = 8-bit reads
 constexpr u32 ACCELERATOR_FORMAT_8_BIT = 0x0019;

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -384,7 +384,8 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleTCPFrame(const Common::TCPPacket& 
     if (size > 0)
     {
       // only if contain data
-      if (static_cast<int>(this_seq - ref->ack_num) >= 0 && data.size() >= size)
+      if (static_cast<int>(this_seq - ref->ack_num) >= 0 &&
+          data.size() >= static_cast<size_t>(size))
       {
         ref->tcp_socket.send(data.data(), size);
         ref->ack_num += size;

--- a/Source/Core/Core/HW/MemoryInterface.cpp
+++ b/Source/Core/Core/HW/MemoryInterface.cpp
@@ -61,14 +61,7 @@ MemoryInterfaceManager::~MemoryInterfaceManager() = default;
 void MemoryInterfaceManager::Init()
 {
   static_assert(std::is_trivially_copyable_v<MIMemStruct>);
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-  std::memset(&m_mi_mem, 0, sizeof(MIMemStruct));
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+  std::memset(static_cast<void*>(&m_mi_mem), 0, sizeof(MIMemStruct));
 }
 
 void MemoryInterfaceManager::Shutdown()

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -24,8 +24,8 @@
 
 namespace ProcessorInterface
 {
-constexpr u32 FLIPPER_REV_A = 0x046500B0;
-constexpr u32 FLIPPER_REV_B = 0x146500B1;
+constexpr u32 FLIPPER_REV_A [[maybe_unused]] = 0x046500B0;
+constexpr u32 FLIPPER_REV_B [[maybe_unused]] = 0x146500B1;
 constexpr u32 FLIPPER_REV_C = 0x246500B1;
 
 ProcessorInterfaceManager::ProcessorInterfaceManager(Core::System& system) : m_system(system)

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
@@ -136,14 +136,8 @@ static bool DeserializeExtensionState(DesiredWiimoteState* state,
     return false;
   auto& e = state->extension.data.emplace<T>();
   static_assert(std::is_trivially_copyable_v<T>);
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-  std::memcpy(&e, &serialized.data[offset], sizeof(T));
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+  std::memcpy(static_cast<void*>(&e), static_cast<const void*>(&serialized.data[offset]),
+              sizeof(T));
   return true;
 }
 

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -254,7 +254,8 @@ bool NetPlayClient::Connect()
   // TODO: make this not hang
   ENetEvent netEvent;
   int net;
-  while ((net = enet_host_service(m_client, &netEvent, 5000)) > 0 && netEvent.type == 42)
+  while ((net = enet_host_service(m_client, &netEvent, 5000)) > 0 &&
+         netEvent.type == ENetEventType(42))  // See PR #11381 and ENetUtil::InterceptCallback
   {
     // ignore packets from traversal server
   }

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -885,7 +885,7 @@ void MemoryViewWidget::OnContextMenu(const QPoint& pos)
   auto* copy_hex = menu->addAction(tr("Copy Hex"), this, [this, addr] { OnCopyHex(addr); });
   copy_hex->setEnabled(item_has_value);
 
-  auto* copy_value = menu->addAction(tr("Copy Value"), this, [this, item_selected] {
+  auto* copy_value = menu->addAction(tr("Copy Value"), this, [item_selected] {
     QApplication::clipboard()->setText(item_selected->text());
   });
   copy_value->setEnabled(item_has_value);

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -143,7 +143,7 @@ int main(int argc, char* argv[])
   // code, which makes mouse inputs work again.
   // For more information: https://bugs.dolphin-emu.org/issues/12913
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 3, 0))
-  putenv("QT_XCB_NO_XI2=1");
+  setenv("QT_XCB_NO_XI2", "1", true);
 #endif
 #endif
 

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -3,10 +3,8 @@
 
 #include "InputCommon/ControllerInterface/Xlib/XInput2.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wregister"
 #include <X11/XKBlib.h>
-#pragma GCC diagnostic pop
+
 #include <cmath>
 #include <cstdlib>
 #include <cstring>

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -58,7 +58,7 @@ void LogToFile(const char* fmt, ...)
   va_end(args);
 }
 
-bool ProgressCallback(double total, double now, double, double)
+bool ProgressCallback(s64 total, s64 now, s64, s64)
 {
   UI::SetCurrentProgress(static_cast<int>(now), static_cast<int>(total));
   return true;

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -4,6 +4,7 @@
 #include "VideoCommon/CPMemory.h"
 
 #include <cstring>
+#include <type_traits>
 
 #include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"
@@ -17,14 +18,9 @@ CPState g_preprocess_cp_state;
 
 void CopyPreprocessCPStateFromMain()
 {
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-  std::memcpy(&g_preprocess_cp_state, &g_main_cp_state, sizeof(CPState));
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+  static_assert(std::is_trivially_copyable_v<CPState>);
+  std::memcpy(static_cast<void*>(&g_preprocess_cp_state),
+              static_cast<const void*>(&g_main_cp_state), sizeof(CPState));
 }
 
 std::pair<std::string, std::string> GetCPRegInfo(u8 cmd, u32 value)

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -608,14 +608,10 @@ AbstractPipelineConfig ShaderCache::GetGXPipelineConfig(
 static GXPipelineUid ApplyDriverBugs(const GXPipelineUid& in)
 {
   GXPipelineUid out;
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-  memcpy(&out, &in, sizeof(out));  // copy padding
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+  // TODO: static_assert(std::is_trivially_copyable_v<GXPipelineUid>);
+  // GXPipelineUid is not trivially copyable because RasterizationState and BlendingState aren't
+  // either, but we can pretend it is for now. This will be improved after PR #10848 is finished.
+  memcpy(static_cast<void*>(&out), static_cast<const void*>(&in), sizeof(out));  // copy padding
   pixel_shader_uid_data* ps = out.ps_uid.GetUidData();
   BlendingState& blend = out.blending_state;
 
@@ -785,14 +781,10 @@ ShaderCache::GetGXPipelineConfig(const GXPipelineUid& config_in)
 static GXUberPipelineUid ApplyDriverBugs(const GXUberPipelineUid& in)
 {
   GXUberPipelineUid out;
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-  memcpy(&out, &in, sizeof(out));  // Copy padding
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+  // TODO: static_assert(std::is_trivially_copyable_v<GXUberPipelineUid>);
+  // GXUberPipelineUid is not trivially copyable because RasterizationState and BlendingState aren't
+  // either, but we can pretend it is for now. This will be improved after PR #10848 is finished.
+  memcpy(static_cast<void*>(&out), static_cast<const void*>(&in), sizeof(out));  // Copy padding
   if (g_ActiveConfig.backend_info.bSupportsDynamicVertexLoader)
     out.vertex_format = nullptr;
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -656,8 +656,8 @@ void TextureCacheBase::DoSaveState(PointerWrap& p)
   }
 
   auto doList = [&p](auto list) {
-    u32 size = static_cast<u32>(list.size());
-    p.Do(size);
+    u32 list_size = static_cast<u32>(list.size());
+    p.Do(list_size);
     for (const auto& it : list)
     {
       p.Do(it.first);

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -153,14 +154,8 @@ NativeVertexFormat* GetUberVertexFormat(const PortableVertexDeclaration& decl)
   // The padding in the structs can cause the memcmp() in the map to create duplicates.
   // Avoid this by initializing the padding to zero.
   PortableVertexDeclaration new_decl;
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-  std::memset(&new_decl, 0, sizeof(new_decl));
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+  static_assert(std::is_trivially_copyable_v<PortableVertexDeclaration>);
+  std::memset(static_cast<void*>(&new_decl), 0, sizeof(new_decl));
   new_decl.stride = decl.stride;
 
   auto MakeDummyAttribute = [](AttributeFormat& attr, ComponentFormat type, int components,


### PR DESCRIPTION
I could not get the three `-Wignored-attributes` warnings across AES.cpp and SHA1.cpp to go away.  I even briefly tried editing libstdc++, but it did not work.  For GCC, the `-Wunknown-pragmas` warning is still happening in CPUCull.cpp despite the pragmas trying to ignore that diagnostic.  I tried moving them out of the #if #else #endif block to see if that would fix it, but it did not.  There is room for debate whether the changes for `-Wunused-const-variable` are best.  It's either that or changing to an unscoped enum.

I am not situated to test MSVC quickly, so I have not bothered with it.