### PR TITLE
Android: Make button in the settings open user folder

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.kt
@@ -51,6 +51,7 @@ class UserDataActivity : AppCompatActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
+        val android7 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
         val android10 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
         val android11 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
         val legacy = DirectoryInitialization.isUsingLegacyUserDirectory()
@@ -58,6 +59,10 @@ class UserDataActivity : AppCompatActivity() {
         val userDataNewLocation =
             if (android10) R.string.user_data_new_location_android_10 else R.string.user_data_new_location
         mBinding.textType.setText(if (legacy) R.string.user_data_old_location else userDataNewLocation)
+
+        val openFileManagerStringId =
+            if (android7) R.string.user_data_open_user_folder else R.string.user_data_open_system_file_manager
+        mBinding.buttonOpenSystemFileManager.setText(openFileManagerStringId)
 
         mBinding.textPath.text = DirectoryInitialization.getUserDirectory()
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/DocumentProvider.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/DocumentProvider.kt
@@ -27,7 +27,7 @@ class DocumentProvider : DocumentsProvider() {
     private var rootDirectory: File? = null
 
     companion object {
-        private const val ROOT_ID = "root"
+        public const val ROOT_ID = "root"
 
         private val DEFAULT_ROOT_PROJECTION = arrayOf(
             DocumentsContract.Root.COLUMN_ROOT_ID,

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -401,8 +401,10 @@
     <string name="user_data_new_location">Your user data (settings, saves, etc.) is stored in a location which <b>will be deleted</b> when you uninstall the app:</string>
     <!-- Android 10 and up support android:hasFragileUserData -->
     <string name="user_data_new_location_android_10">Your user data (settings, saves, etc.) is stored in a location which by default <b>will be deleted</b> when you uninstall the app:</string>
-    <string name="user_data_new_location_android_11">Because you\'re using Android 11 or newer, file manager apps can\'t access this folder in the same way as regular folders. You might be able to access the folder using the system file manager (if present on your device), or by connecting your device to a PC.</string>
+    <string name="user_data_new_location_android_11">Because you\'re using Android 11 or newer, file manager apps can\'t access this folder in the same way as regular folders. Instead, Dolphin acts as a file provider.</string>
     <string name="user_data_open_system_file_manager">Open System File Manager</string>
+    <string name="user_data_open_user_folder">Open User Data Folder</string>
+
     <string name="user_data_import">Import User Data</string>
     <string name="user_data_export">Export User Data</string>
     <string name="user_data_open_system_file_manager_failed">Sorry, Dolphin couldn\'t find the system file manager on your device.</string>


### PR DESCRIPTION
Now that we have the DocumentsProvider, we can change the file manager button in the settings to directly open that.

cc @t895 @MayImilae 

![Screenshot_2023-03-24-16-40-02-29_c72eb4c8f207d9338cfe2ba1429ddbde.jpg](https://user-images.githubusercontent.com/1131720/227573081-ebbe05a9-c955-42e4-8f2c-3116aedcdc32.jpg)

