### PR TITLE
Interpreter: Remove remaining System::GetInstance() and global ppcState.

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/ExceptionUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/ExceptionUtils.h
@@ -15,20 +15,20 @@ enum class ProgramExceptionCause : u32
   Trap = 1 << (31 - 14),
 };
 
-inline void GenerateAlignmentException(u32 address)
+inline void GenerateAlignmentException(PowerPC::PowerPCState& ppc_state, u32 address)
 {
-  PowerPC::ppcState.Exceptions |= EXCEPTION_ALIGNMENT;
-  PowerPC::ppcState.spr[SPR_DAR] = address;
+  ppc_state.Exceptions |= EXCEPTION_ALIGNMENT;
+  ppc_state.spr[SPR_DAR] = address;
 }
 
-inline void GenerateDSIException(u32 address)
+inline void GenerateDSIException(PowerPC::PowerPCState& ppc_state, u32 address)
 {
-  PowerPC::ppcState.Exceptions |= EXCEPTION_DSI;
-  PowerPC::ppcState.spr[SPR_DAR] = address;
+  ppc_state.Exceptions |= EXCEPTION_DSI;
+  ppc_state.spr[SPR_DAR] = address;
 }
 
-inline void GenerateProgramException(ProgramExceptionCause cause)
+inline void GenerateProgramException(PowerPC::PowerPCState& ppc_state, ProgramExceptionCause cause)
 {
-  PowerPC::ppcState.Exceptions |= EXCEPTION_PROGRAM;
-  PowerPC::ppcState.spr[SPR_SRR1] = static_cast<u32>(cause);
+  ppc_state.Exceptions |= EXCEPTION_PROGRAM;
+  ppc_state.spr[SPR_SRR1] = static_cast<u32>(cause);
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -148,7 +148,7 @@ int Interpreter::SingleStepInner()
   {
     if (IsInvalidPairedSingleExecution(m_prev_inst))
     {
-      GenerateProgramException(ProgramExceptionCause::IllegalInstruction);
+      GenerateProgramException(m_ppc_state, ProgramExceptionCause::IllegalInstruction);
       CheckExceptions();
     }
     else if (m_ppc_state.msr.FP)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
@@ -117,7 +117,7 @@ void Interpreter::rfi(Interpreter& interpreter, UGeckoInstruction inst)
 
   if (ppc_state.msr.PR)
   {
-    GenerateProgramException(ProgramExceptionCause::PrivilegedInstruction);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::PrivilegedInstruction);
     return;
   }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -25,29 +25,29 @@ enum class FPCC
   FU = 1,  // ?
 };
 
-inline void CheckFPExceptions(UReg_FPSCR fpscr)
+inline void CheckFPExceptions(PowerPC::PowerPCState& ppc_state)
 {
-  if (fpscr.FEX && (PowerPC::ppcState.msr.FE0 || PowerPC::ppcState.msr.FE1))
-    GenerateProgramException(ProgramExceptionCause::FloatingPoint);
+  if (ppc_state.fpscr.FEX && (ppc_state.msr.FE0 || ppc_state.msr.FE1))
+    GenerateProgramException(ppc_state, ProgramExceptionCause::FloatingPoint);
 }
 
-inline void UpdateFPExceptionSummary(UReg_FPSCR* fpscr)
+inline void UpdateFPExceptionSummary(PowerPC::PowerPCState& ppc_state)
 {
-  fpscr->VX = (fpscr->Hex & FPSCR_VX_ANY) != 0;
-  fpscr->FEX = ((fpscr->Hex >> 22) & (fpscr->Hex & FPSCR_ANY_E)) != 0;
+  ppc_state.fpscr.VX = (ppc_state.fpscr.Hex & FPSCR_VX_ANY) != 0;
+  ppc_state.fpscr.FEX = ((ppc_state.fpscr.Hex >> 22) & (ppc_state.fpscr.Hex & FPSCR_ANY_E)) != 0;
 
-  CheckFPExceptions(*fpscr);
+  CheckFPExceptions(ppc_state);
 }
 
-inline void SetFPException(UReg_FPSCR* fpscr, u32 mask)
+inline void SetFPException(PowerPC::PowerPCState& ppc_state, u32 mask)
 {
-  if ((fpscr->Hex & mask) != mask)
+  if ((ppc_state.fpscr.Hex & mask) != mask)
   {
-    fpscr->FX = 1;
+    ppc_state.fpscr.FX = 1;
   }
 
-  fpscr->Hex |= mask;
-  UpdateFPExceptionSummary(fpscr);
+  ppc_state.fpscr.Hex |= mask;
+  UpdateFPExceptionSummary(ppc_state);
 }
 
 inline float ForceSingle(const UReg_FPSCR& fpscr, double value)
@@ -111,17 +111,17 @@ struct FPResult
 {
   bool HasNoInvalidExceptions() const { return (exception & FPSCR_VX_ANY) == 0; }
 
-  void SetException(UReg_FPSCR* fpscr, FPSCRExceptionFlag flag)
+  void SetException(PowerPC::PowerPCState& ppc_state, FPSCRExceptionFlag flag)
   {
     exception = flag;
-    SetFPException(fpscr, flag);
+    SetFPException(ppc_state, flag);
   }
 
   double value = 0.0;
   FPSCRExceptionFlag exception{};
 };
 
-inline FPResult NI_mul(UReg_FPSCR* fpscr, double a, double b)
+inline FPResult NI_mul(PowerPC::PowerPCState& ppc_state, double a, double b)
 {
   FPResult result{a * b};
 
@@ -129,10 +129,10 @@ inline FPResult NI_mul(UReg_FPSCR* fpscr, double a, double b)
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
     {
-      result.SetException(fpscr, FPSCR_VXSNAN);
+      result.SetException(ppc_state, FPSCR_VXSNAN);
     }
 
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
     if (std::isnan(a))
     {
@@ -146,14 +146,14 @@ inline FPResult NI_mul(UReg_FPSCR* fpscr, double a, double b)
     }
 
     result.value = PPC_NAN;
-    result.SetException(fpscr, FPSCR_VXIMZ);
+    result.SetException(ppc_state, FPSCR_VXIMZ);
     return result;
   }
 
   return result;
 }
 
-inline FPResult NI_div(UReg_FPSCR* fpscr, double a, double b)
+inline FPResult NI_div(PowerPC::PowerPCState& ppc_state, double a, double b)
 {
   FPResult result{a / b};
 
@@ -161,16 +161,16 @@ inline FPResult NI_div(UReg_FPSCR* fpscr, double a, double b)
   {
     if (b == 0.0)
     {
-      result.SetException(fpscr, FPSCR_ZX);
+      result.SetException(ppc_state, FPSCR_ZX);
       return result;
     }
   }
   else if (std::isnan(result.value))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
-      result.SetException(fpscr, FPSCR_VXSNAN);
+      result.SetException(ppc_state, FPSCR_VXSNAN);
 
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
     if (std::isnan(a))
     {
@@ -184,9 +184,9 @@ inline FPResult NI_div(UReg_FPSCR* fpscr, double a, double b)
     }
 
     if (b == 0.0)
-      result.SetException(fpscr, FPSCR_VXZDZ);
+      result.SetException(ppc_state, FPSCR_VXZDZ);
     else if (std::isinf(a) && std::isinf(b))
-      result.SetException(fpscr, FPSCR_VXIDI);
+      result.SetException(ppc_state, FPSCR_VXIDI);
 
     result.value = PPC_NAN;
     return result;
@@ -195,16 +195,16 @@ inline FPResult NI_div(UReg_FPSCR* fpscr, double a, double b)
   return result;
 }
 
-inline FPResult NI_add(UReg_FPSCR* fpscr, double a, double b)
+inline FPResult NI_add(PowerPC::PowerPCState& ppc_state, double a, double b)
 {
   FPResult result{a + b};
 
   if (std::isnan(result.value))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
-      result.SetException(fpscr, FPSCR_VXSNAN);
+      result.SetException(ppc_state, FPSCR_VXSNAN);
 
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
     if (std::isnan(a))
     {
@@ -217,27 +217,27 @@ inline FPResult NI_add(UReg_FPSCR* fpscr, double a, double b)
       return result;
     }
 
-    result.SetException(fpscr, FPSCR_VXISI);
+    result.SetException(ppc_state, FPSCR_VXISI);
     result.value = PPC_NAN;
     return result;
   }
 
   if (std::isinf(a) || std::isinf(b))
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
   return result;
 }
 
-inline FPResult NI_sub(UReg_FPSCR* fpscr, double a, double b)
+inline FPResult NI_sub(PowerPC::PowerPCState& ppc_state, double a, double b)
 {
   FPResult result{a - b};
 
   if (std::isnan(result.value))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
-      result.SetException(fpscr, FPSCR_VXSNAN);
+      result.SetException(ppc_state, FPSCR_VXSNAN);
 
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
     if (std::isnan(a))
     {
@@ -250,13 +250,13 @@ inline FPResult NI_sub(UReg_FPSCR* fpscr, double a, double b)
       return result;
     }
 
-    result.SetException(fpscr, FPSCR_VXISI);
+    result.SetException(ppc_state, FPSCR_VXISI);
     result.value = PPC_NAN;
     return result;
   }
 
   if (std::isinf(a) || std::isinf(b))
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
   return result;
 }
@@ -264,16 +264,16 @@ inline FPResult NI_sub(UReg_FPSCR* fpscr, double a, double b)
 // FMA instructions on PowerPC are weird:
 // They calculate (a * c) + b, but the order in which
 // inputs are checked for NaN is still a, b, c.
-inline FPResult NI_madd(UReg_FPSCR* fpscr, double a, double c, double b)
+inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
 {
   FPResult result{std::fma(a, c, b)};
 
   if (std::isnan(result.value))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b) || Common::IsSNAN(c))
-      result.SetException(fpscr, FPSCR_VXSNAN);
+      result.SetException(ppc_state, FPSCR_VXSNAN);
 
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
     if (std::isnan(a))
     {
@@ -291,27 +291,27 @@ inline FPResult NI_madd(UReg_FPSCR* fpscr, double a, double c, double b)
       return result;
     }
 
-    result.SetException(fpscr, std::isnan(a * c) ? FPSCR_VXIMZ : FPSCR_VXISI);
+    result.SetException(ppc_state, std::isnan(a * c) ? FPSCR_VXIMZ : FPSCR_VXISI);
     result.value = PPC_NAN;
     return result;
   }
 
   if (std::isinf(a) || std::isinf(b) || std::isinf(c))
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
   return result;
 }
 
-inline FPResult NI_msub(UReg_FPSCR* fpscr, double a, double c, double b)
+inline FPResult NI_msub(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
 {
   FPResult result{std::fma(a, c, -b)};
 
   if (std::isnan(result.value))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b) || Common::IsSNAN(c))
-      result.SetException(fpscr, FPSCR_VXSNAN);
+      result.SetException(ppc_state, FPSCR_VXSNAN);
 
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
     if (std::isnan(a))
     {
@@ -329,13 +329,13 @@ inline FPResult NI_msub(UReg_FPSCR* fpscr, double a, double c, double b)
       return result;
     }
 
-    result.SetException(fpscr, std::isnan(a * c) ? FPSCR_VXIMZ : FPSCR_VXISI);
+    result.SetException(ppc_state, std::isnan(a * c) ? FPSCR_VXIMZ : FPSCR_VXISI);
     result.value = PPC_NAN;
     return result;
   }
 
   if (std::isinf(a) || std::isinf(b) || std::isinf(c))
-    fpscr->ClearFIFR();
+    ppc_state.fpscr.ClearFIFR();
 
   return result;
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -149,7 +149,7 @@ void Interpreter::twi(Interpreter& interpreter, UGeckoInstruction inst)
   if ((a < b && (TO & 0x10) != 0) || (a > b && (TO & 0x08) != 0) || (a == b && (TO & 0x04) != 0) ||
       (u32(a) < u32(b) && (TO & 0x02) != 0) || (u32(a) > u32(b) && (TO & 0x01) != 0))
   {
-    GenerateProgramException(ProgramExceptionCause::Trap);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::Trap);
     PowerPC::CheckExceptions();
     interpreter.m_end_block = true;  // Dunno about this
   }
@@ -380,7 +380,7 @@ void Interpreter::tw(Interpreter& interpreter, UGeckoInstruction inst)
   if ((a < b && (TO & 0x10) != 0) || (a > b && (TO & 0x08) != 0) || (a == b && (TO & 0x04) != 0) ||
       ((u32(a) < u32(b)) && (TO & 0x02) != 0) || ((u32(a) > u32(b)) && (TO & 0x01) != 0))
   {
-    GenerateProgramException(ProgramExceptionCause::Trap);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::Trap);
     PowerPC::CheckExceptions();
     interpreter.m_end_block = true;  // Dunno about this
   }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -66,7 +66,7 @@ void Interpreter::lfd(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -83,7 +83,7 @@ void Interpreter::lfdu(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -103,7 +103,7 @@ void Interpreter::lfdux(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -123,7 +123,7 @@ void Interpreter::lfdx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -140,7 +140,7 @@ void Interpreter::lfs(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -160,7 +160,7 @@ void Interpreter::lfsu(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -181,7 +181,7 @@ void Interpreter::lfsux(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -202,7 +202,7 @@ void Interpreter::lfsx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -271,7 +271,7 @@ void Interpreter::lmw(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0 || ppc_state.msr.LE)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -300,7 +300,7 @@ void Interpreter::stmw(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0 || ppc_state.msr.LE)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -366,7 +366,7 @@ void Interpreter::stfd(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -380,7 +380,7 @@ void Interpreter::stfdu(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -398,7 +398,7 @@ void Interpreter::stfs(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -412,7 +412,7 @@ void Interpreter::stfsu(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -485,7 +485,7 @@ void Interpreter::dcbi(Interpreter& interpreter, UGeckoInstruction inst)
   auto& ppc_state = interpreter.m_ppc_state;
   if (ppc_state.msr.PR)
   {
-    GenerateProgramException(ProgramExceptionCause::PrivilegedInstruction);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::PrivilegedInstruction);
     return;
   }
 
@@ -537,7 +537,7 @@ void Interpreter::dcbz(Interpreter& interpreter, UGeckoInstruction inst)
 
   if (!HID0(ppc_state).DCE)
   {
-    GenerateAlignmentException(dcbz_addr);
+    GenerateAlignmentException(ppc_state, dcbz_addr);
     return;
   }
 
@@ -560,7 +560,7 @@ void Interpreter::dcbz_l(Interpreter& interpreter, UGeckoInstruction inst)
   auto& ppc_state = interpreter.m_ppc_state;
   if (!HID2(ppc_state).LCE)
   {
-    GenerateProgramException(ProgramExceptionCause::IllegalInstruction);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::IllegalInstruction);
     return;
   }
 
@@ -568,7 +568,7 @@ void Interpreter::dcbz_l(Interpreter& interpreter, UGeckoInstruction inst)
 
   if (!HID0(ppc_state).DCE)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -584,13 +584,13 @@ void Interpreter::eciwx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((ppc_state.spr[SPR_EAR] & 0x80000000) == 0)
   {
-    GenerateDSIException(EA);
+    GenerateDSIException(ppc_state, EA);
     return;
   }
 
   if ((EA & 0b11) != 0)
   {
-    GenerateAlignmentException(EA);
+    GenerateAlignmentException(ppc_state, EA);
     return;
   }
 
@@ -604,13 +604,13 @@ void Interpreter::ecowx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((ppc_state.spr[SPR_EAR] & 0x80000000) == 0)
   {
-    GenerateDSIException(EA);
+    GenerateDSIException(ppc_state, EA);
     return;
   }
 
   if ((EA & 0b11) != 0)
   {
-    GenerateAlignmentException(EA);
+    GenerateAlignmentException(ppc_state, EA);
     return;
   }
 
@@ -724,7 +724,7 @@ void Interpreter::lswx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if (ppc_state.msr.LE)
   {
-    GenerateAlignmentException(EA);
+    GenerateAlignmentException(ppc_state, EA);
     return;
   }
 
@@ -811,7 +811,7 @@ void Interpreter::stfdux(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -829,7 +829,7 @@ void Interpreter::stfdx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -844,7 +844,7 @@ void Interpreter::stfiwx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -858,7 +858,7 @@ void Interpreter::stfsux(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -876,7 +876,7 @@ void Interpreter::stfsx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -918,7 +918,7 @@ void Interpreter::lswi(Interpreter& interpreter, UGeckoInstruction inst)
 
   if (ppc_state.msr.LE)
   {
-    GenerateAlignmentException(EA);
+    GenerateAlignmentException(ppc_state, EA);
     return;
   }
 
@@ -966,7 +966,7 @@ void Interpreter::stswi(Interpreter& interpreter, UGeckoInstruction inst)
 
   if (ppc_state.msr.LE)
   {
-    GenerateAlignmentException(EA);
+    GenerateAlignmentException(ppc_state, EA);
     return;
   }
 
@@ -1005,7 +1005,7 @@ void Interpreter::stswx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if (ppc_state.msr.LE)
   {
-    GenerateAlignmentException(EA);
+    GenerateAlignmentException(ppc_state, EA);
     return;
   }
 
@@ -1046,7 +1046,7 @@ void Interpreter::lwarx(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -1068,7 +1068,7 @@ void Interpreter::stwcxd(Interpreter& interpreter, UGeckoInstruction inst)
 
   if ((address & 0b11) != 0)
   {
-    GenerateAlignmentException(address);
+    GenerateAlignmentException(ppc_state, address);
     return;
   }
 
@@ -1119,7 +1119,7 @@ void Interpreter::tlbie(Interpreter& interpreter, UGeckoInstruction inst)
   auto& ppc_state = interpreter.m_ppc_state;
   if (ppc_state.msr.PR)
   {
-    GenerateProgramException(ProgramExceptionCause::PrivilegedInstruction);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::PrivilegedInstruction);
     return;
   }
 
@@ -1134,7 +1134,7 @@ void Interpreter::tlbsync(Interpreter& interpreter, UGeckoInstruction inst)
   auto& ppc_state = interpreter.m_ppc_state;
   if (ppc_state.msr.PR)
   {
-    GenerateProgramException(ProgramExceptionCause::PrivilegedInstruction);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::PrivilegedInstruction);
   }
 
   // Ignored

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
@@ -313,7 +313,7 @@ void Interpreter::psq_l(Interpreter& interpreter, UGeckoInstruction inst)
   auto& ppc_state = interpreter.m_ppc_state;
   if (HID2(ppc_state).LSQE == 0)
   {
-    GenerateProgramException(ProgramExceptionCause::IllegalInstruction);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::IllegalInstruction);
     return;
   }
 
@@ -326,7 +326,7 @@ void Interpreter::psq_lu(Interpreter& interpreter, UGeckoInstruction inst)
   auto& ppc_state = interpreter.m_ppc_state;
   if (HID2(ppc_state).LSQE == 0)
   {
-    GenerateProgramException(ProgramExceptionCause::IllegalInstruction);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::IllegalInstruction);
     return;
   }
 
@@ -346,7 +346,7 @@ void Interpreter::psq_st(Interpreter& interpreter, UGeckoInstruction inst)
   auto& ppc_state = interpreter.m_ppc_state;
   if (HID2(ppc_state).LSQE == 0)
   {
-    GenerateProgramException(ProgramExceptionCause::IllegalInstruction);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::IllegalInstruction);
     return;
   }
 
@@ -359,7 +359,7 @@ void Interpreter::psq_stu(Interpreter& interpreter, UGeckoInstruction inst)
   auto& ppc_state = interpreter.m_ppc_state;
   if (HID2(ppc_state).LSQE == 0)
   {
-    GenerateProgramException(ProgramExceptionCause::IllegalInstruction);
+    GenerateProgramException(ppc_state, ProgramExceptionCause::IllegalInstruction);
     return;
   }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -126,10 +126,10 @@ void Interpreter::ps_div(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& a = ppc_state.ps[inst.FA];
   const auto& b = ppc_state.ps[inst.FB];
 
-  const float ps0 = ForceSingle(ppc_state.fpscr,
-                                NI_div(&ppc_state.fpscr, a.PS0AsDouble(), b.PS0AsDouble()).value);
-  const float ps1 = ForceSingle(ppc_state.fpscr,
-                                NI_div(&ppc_state.fpscr, a.PS1AsDouble(), b.PS1AsDouble()).value);
+  const float ps0 =
+      ForceSingle(ppc_state.fpscr, NI_div(ppc_state, a.PS0AsDouble(), b.PS0AsDouble()).value);
+  const float ps1 =
+      ForceSingle(ppc_state.fpscr, NI_div(ppc_state, a.PS1AsDouble(), b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -147,7 +147,7 @@ void Interpreter::ps_res(Interpreter& interpreter, UGeckoInstruction inst)
 
   if (a == 0.0 || b == 0.0)
   {
-    SetFPException(&ppc_state.fpscr, FPSCR_ZX);
+    SetFPException(ppc_state, FPSCR_ZX);
     ppc_state.fpscr.ClearFIFR();
   }
 
@@ -155,7 +155,7 @@ void Interpreter::ps_res(Interpreter& interpreter, UGeckoInstruction inst)
     ppc_state.fpscr.ClearFIFR();
 
   if (Common::IsSNAN(a) || Common::IsSNAN(b))
-    SetFPException(&ppc_state.fpscr, FPSCR_VXSNAN);
+    SetFPException(ppc_state, FPSCR_VXSNAN);
 
   const double ps0 = Common::ApproximateReciprocal(a);
   const double ps1 = Common::ApproximateReciprocal(b);
@@ -175,13 +175,13 @@ void Interpreter::ps_rsqrte(Interpreter& interpreter, UGeckoInstruction inst)
 
   if (ps0 == 0.0 || ps1 == 0.0)
   {
-    SetFPException(&ppc_state.fpscr, FPSCR_ZX);
+    SetFPException(ppc_state, FPSCR_ZX);
     ppc_state.fpscr.ClearFIFR();
   }
 
   if (ps0 < 0.0 || ps1 < 0.0)
   {
-    SetFPException(&ppc_state.fpscr, FPSCR_VXSQRT);
+    SetFPException(ppc_state, FPSCR_VXSQRT);
     ppc_state.fpscr.ClearFIFR();
   }
 
@@ -189,7 +189,7 @@ void Interpreter::ps_rsqrte(Interpreter& interpreter, UGeckoInstruction inst)
     ppc_state.fpscr.ClearFIFR();
 
   if (Common::IsSNAN(ps0) || Common::IsSNAN(ps1))
-    SetFPException(&ppc_state.fpscr, FPSCR_VXSNAN);
+    SetFPException(ppc_state, FPSCR_VXSNAN);
 
   const float dst_ps0 = ForceSingle(ppc_state.fpscr, Common::ApproximateReciprocalSquareRoot(ps0));
   const float dst_ps1 = ForceSingle(ppc_state.fpscr, Common::ApproximateReciprocalSquareRoot(ps1));
@@ -207,10 +207,10 @@ void Interpreter::ps_sub(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& a = ppc_state.ps[inst.FA];
   const auto& b = ppc_state.ps[inst.FB];
 
-  const float ps0 = ForceSingle(ppc_state.fpscr,
-                                NI_sub(&ppc_state.fpscr, a.PS0AsDouble(), b.PS0AsDouble()).value);
-  const float ps1 = ForceSingle(ppc_state.fpscr,
-                                NI_sub(&ppc_state.fpscr, a.PS1AsDouble(), b.PS1AsDouble()).value);
+  const float ps0 =
+      ForceSingle(ppc_state.fpscr, NI_sub(ppc_state, a.PS0AsDouble(), b.PS0AsDouble()).value);
+  const float ps1 =
+      ForceSingle(ppc_state.fpscr, NI_sub(ppc_state, a.PS1AsDouble(), b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -225,10 +225,10 @@ void Interpreter::ps_add(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& a = ppc_state.ps[inst.FA];
   const auto& b = ppc_state.ps[inst.FB];
 
-  const float ps0 = ForceSingle(ppc_state.fpscr,
-                                NI_add(&ppc_state.fpscr, a.PS0AsDouble(), b.PS0AsDouble()).value);
-  const float ps1 = ForceSingle(ppc_state.fpscr,
-                                NI_add(&ppc_state.fpscr, a.PS1AsDouble(), b.PS1AsDouble()).value);
+  const float ps0 =
+      ForceSingle(ppc_state.fpscr, NI_add(ppc_state, a.PS0AsDouble(), b.PS0AsDouble()).value);
+  const float ps1 =
+      ForceSingle(ppc_state.fpscr, NI_add(ppc_state, a.PS1AsDouble(), b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -246,10 +246,8 @@ void Interpreter::ps_mul(Interpreter& interpreter, UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const float ps0 =
-      ForceSingle(ppc_state.fpscr, NI_mul(&ppc_state.fpscr, a.PS0AsDouble(), c0).value);
-  const float ps1 =
-      ForceSingle(ppc_state.fpscr, NI_mul(&ppc_state.fpscr, a.PS1AsDouble(), c1).value);
+  const float ps0 = ForceSingle(ppc_state.fpscr, NI_mul(ppc_state, a.PS0AsDouble(), c0).value);
+  const float ps1 = ForceSingle(ppc_state.fpscr, NI_mul(ppc_state, a.PS1AsDouble(), c1).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -268,10 +266,10 @@ void Interpreter::ps_msub(Interpreter& interpreter, UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const float ps0 = ForceSingle(
-      ppc_state.fpscr, NI_msub(&ppc_state.fpscr, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const float ps1 = ForceSingle(
-      ppc_state.fpscr, NI_msub(&ppc_state.fpscr, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+  const float ps0 =
+      ForceSingle(ppc_state.fpscr, NI_msub(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+  const float ps1 =
+      ForceSingle(ppc_state.fpscr, NI_msub(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -290,10 +288,10 @@ void Interpreter::ps_madd(Interpreter& interpreter, UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const float ps0 = ForceSingle(
-      ppc_state.fpscr, NI_madd(&ppc_state.fpscr, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const float ps1 = ForceSingle(
-      ppc_state.fpscr, NI_madd(&ppc_state.fpscr, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+  const float ps0 =
+      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+  const float ps1 =
+      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -312,10 +310,10 @@ void Interpreter::ps_nmsub(Interpreter& interpreter, UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const float tmp0 = ForceSingle(
-      ppc_state.fpscr, NI_msub(&ppc_state.fpscr, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const float tmp1 = ForceSingle(
-      ppc_state.fpscr, NI_msub(&ppc_state.fpscr, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+  const float tmp0 =
+      ForceSingle(ppc_state.fpscr, NI_msub(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+  const float tmp1 =
+      ForceSingle(ppc_state.fpscr, NI_msub(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   const float ps0 = std::isnan(tmp0) ? tmp0 : -tmp0;
   const float ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
@@ -337,10 +335,10 @@ void Interpreter::ps_nmadd(Interpreter& interpreter, UGeckoInstruction inst)
   const double c0 = Force25Bit(c.PS0AsDouble());
   const double c1 = Force25Bit(c.PS1AsDouble());
 
-  const float tmp0 = ForceSingle(
-      ppc_state.fpscr, NI_madd(&ppc_state.fpscr, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const float tmp1 = ForceSingle(
-      ppc_state.fpscr, NI_madd(&ppc_state.fpscr, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+  const float tmp0 =
+      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+  const float tmp1 =
+      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   const float ps0 = std::isnan(tmp0) ? tmp0 : -tmp0;
   const float ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
@@ -359,8 +357,8 @@ void Interpreter::ps_sum0(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const float ps0 = ForceSingle(ppc_state.fpscr,
-                                NI_add(&ppc_state.fpscr, a.PS0AsDouble(), b.PS1AsDouble()).value);
+  const float ps0 =
+      ForceSingle(ppc_state.fpscr, NI_add(ppc_state, a.PS0AsDouble(), b.PS1AsDouble()).value);
   const float ps1 = ForceSingle(ppc_state.fpscr, c.PS1AsDouble());
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
@@ -378,8 +376,8 @@ void Interpreter::ps_sum1(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& c = ppc_state.ps[inst.FC];
 
   const float ps0 = ForceSingle(ppc_state.fpscr, c.PS0AsDouble());
-  const float ps1 = ForceSingle(ppc_state.fpscr,
-                                NI_add(&ppc_state.fpscr, a.PS0AsDouble(), b.PS1AsDouble()).value);
+  const float ps1 =
+      ForceSingle(ppc_state.fpscr, NI_add(ppc_state, a.PS0AsDouble(), b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps1);
@@ -395,10 +393,8 @@ void Interpreter::ps_muls0(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& c = ppc_state.ps[inst.FC];
 
   const double c0 = Force25Bit(c.PS0AsDouble());
-  const float ps0 =
-      ForceSingle(ppc_state.fpscr, NI_mul(&ppc_state.fpscr, a.PS0AsDouble(), c0).value);
-  const float ps1 =
-      ForceSingle(ppc_state.fpscr, NI_mul(&ppc_state.fpscr, a.PS1AsDouble(), c0).value);
+  const float ps0 = ForceSingle(ppc_state.fpscr, NI_mul(ppc_state, a.PS0AsDouble(), c0).value);
+  const float ps1 = ForceSingle(ppc_state.fpscr, NI_mul(ppc_state, a.PS1AsDouble(), c0).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -414,10 +410,8 @@ void Interpreter::ps_muls1(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& c = ppc_state.ps[inst.FC];
 
   const double c1 = Force25Bit(c.PS1AsDouble());
-  const float ps0 =
-      ForceSingle(ppc_state.fpscr, NI_mul(&ppc_state.fpscr, a.PS0AsDouble(), c1).value);
-  const float ps1 =
-      ForceSingle(ppc_state.fpscr, NI_mul(&ppc_state.fpscr, a.PS1AsDouble(), c1).value);
+  const float ps0 = ForceSingle(ppc_state.fpscr, NI_mul(ppc_state, a.PS0AsDouble(), c1).value);
+  const float ps1 = ForceSingle(ppc_state.fpscr, NI_mul(ppc_state, a.PS1AsDouble(), c1).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -434,10 +428,10 @@ void Interpreter::ps_madds0(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& c = ppc_state.ps[inst.FC];
 
   const double c0 = Force25Bit(c.PS0AsDouble());
-  const float ps0 = ForceSingle(
-      ppc_state.fpscr, NI_madd(&ppc_state.fpscr, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
-  const float ps1 = ForceSingle(
-      ppc_state.fpscr, NI_madd(&ppc_state.fpscr, a.PS1AsDouble(), c0, b.PS1AsDouble()).value);
+  const float ps0 =
+      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+  const float ps1 =
+      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS1AsDouble(), c0, b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -454,10 +448,10 @@ void Interpreter::ps_madds1(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& c = ppc_state.ps[inst.FC];
 
   const double c1 = Force25Bit(c.PS1AsDouble());
-  const float ps0 = ForceSingle(
-      ppc_state.fpscr, NI_madd(&ppc_state.fpscr, a.PS0AsDouble(), c1, b.PS0AsDouble()).value);
-  const float ps1 = ForceSingle(
-      ppc_state.fpscr, NI_madd(&ppc_state.fpscr, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+  const float ps0 =
+      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS0AsDouble(), c1, b.PS0AsDouble()).value);
+  const float ps1 =
+      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);


### PR DESCRIPTION
I missed these the last time around.

95% of this is just making the `ExceptionUtils.h` and `Interpreter_FPUtils.h` global-free, this just propagates around quite a bit.