### PR TITLE
WiimoteReal: Add checks for proper incomming report sizes.

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -276,6 +276,7 @@ add_library(core
   HW/WiimoteCommon/DataReport.cpp
   HW/WiimoteCommon/DataReport.h
   HW/WiimoteCommon/WiimoteConstants.h
+	HW/WiimoteCommon/WiimoteHid.cpp
   HW/WiimoteCommon/WiimoteHid.h
   HW/WiimoteCommon/WiimoteReport.h
   HW/WiimoteEmu/Camera.cpp

--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.cpp
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.cpp
@@ -1,0 +1,41 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Core/HW/WiimoteCommon/WiimoteHid.h"
+
+namespace WiimoteCommon
+{
+u32 GetExpectedInputReportSize(InputReportID report_id)
+{
+  switch (report_id)
+  {
+  case InputReportID::ReportDisabled:
+    break;
+  case InputReportID::Status:
+    return sizeof(InputReportStatus);
+  case InputReportID::ReadDataReply:
+    return sizeof(InputReportReadDataReply);
+  case InputReportID::Ack:
+    return sizeof(InputReportAck);
+  case InputReportID::ReportCore:
+    return 2;
+  case InputReportID::ReportCoreAccel:
+    return 5;
+  case InputReportID::ReportCoreExt8:
+    return 10;
+  case InputReportID::ReportCoreAccelIR12:
+    return 17;
+  case InputReportID::ReportCoreExt19:
+  case InputReportID::ReportCoreAccelExt16:
+  case InputReportID::ReportCoreIR10Ext9:
+  case InputReportID::ReportCoreAccelIR10Ext6:
+  case InputReportID::ReportExt21:
+  case InputReportID::ReportInterleave1:
+  case InputReportID::ReportInterleave2:
+    return 21;
+  }
+
+  return 0;
+}
+
+}  // namespace WiimoteCommon

--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
@@ -88,4 +88,6 @@ struct TypedInputData
 
 #pragma pack(pop)
 
+u32 GetExpectedInputReportSize(InputReportID);
+
 }  // namespace WiimoteCommon

--- a/Source/Core/DolphinLib.vcxproj
+++ b/Source/Core/DolphinLib.vcxproj
@@ -68,9 +68,10 @@
   <ItemGroup>
     <Text Include="$(BuildInfoTemplate)" />
   </ItemGroup>
-  <UsingTask TaskName="GetProductVersion"
-    TaskFactory="CodeTaskFactory"
-    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+  <ItemGroup>
+    <ClCompile Include="Core\HW\WiimoteCommon\WiimoteHid.cpp" />
+  </ItemGroup>
+  <UsingTask TaskName="GetProductVersion" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <Path ParameterType="System.String" Required="true" />
       <ProductVersion ParameterType="System.String" Output="true" />


### PR DESCRIPTION
This is an attempt to fix off-brand wii remotes in some situations.