### PR TITLE
JitArm64: Avoid System::GetInstance() and ppcState.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -145,10 +145,8 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
     regs_in_use[DecodeReg(ARM64Reg::W0)] = 0;
     regs_in_use[DecodeReg(ARM64Reg::W30)] = 0;
     regs_in_use[DecodeReg(dest_reg)] = 0;
-    auto& system = Core::System::GetInstance();
-    auto& memory = system.GetMemory();
-    MMIOLoadToReg(memory.GetMMIOMapping(), this, &m_float_emit, regs_in_use, fprs_in_use, dest_reg,
-                  mmio_address, flags);
+    MMIOLoadToReg(m_system, m_system.GetMemory().GetMMIOMapping(), this, &m_float_emit, regs_in_use,
+                  fprs_in_use, dest_reg, mmio_address, flags);
     addr_reg_set = false;
   }
   else
@@ -319,10 +317,8 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
     regs_in_use[DecodeReg(ARM64Reg::W1)] = 0;
     regs_in_use[DecodeReg(ARM64Reg::W30)] = 0;
     regs_in_use[DecodeReg(RS)] = 0;
-    auto& system = Core::System::GetInstance();
-    auto& memory = system.GetMemory();
-    MMIOWriteRegToAddr(memory.GetMMIOMapping(), this, &m_float_emit, regs_in_use, fprs_in_use, RS,
-                       mmio_address, flags);
+    MMIOWriteRegToAddr(m_system, m_system.GetMemory().GetMMIOMapping(), this, &m_float_emit,
+                       regs_in_use, fprs_in_use, RS, mmio_address, flags);
     addr_reg_set = false;
   }
   else
@@ -731,7 +727,7 @@ void JitArm64::dcbx(UGeckoInstruction inst)
   // Translate effective address to physical address.
   const u8* loop_start = GetCodePtr();
   FixupBranch bat_lookup_failed;
-  if (PowerPC::ppcState.msr.IR)
+  if (m_ppc_state.msr.IR)
   {
     bat_lookup_failed =
         BATAddressLookup(physical_addr, effective_addr, WA, PowerPC::ibat_table.data());
@@ -760,7 +756,7 @@ void JitArm64::dcbx(UGeckoInstruction inst)
 
   SwitchToFarCode();
   SetJumpTarget(invalidate_needed);
-  if (PowerPC::ppcState.msr.IR)
+  if (m_ppc_state.msr.IR)
     SetJumpTarget(bat_lookup_failed);
 
   BitSet32 gprs_to_push = gpr.GetCallerSavedUsed();

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -23,7 +23,7 @@ void JitArm64::psq_lXX(UGeckoInstruction inst)
   JITDISABLE(bJITLoadStorePairedOff);
 
   // If we have a fastmem arena, the asm routines assume address translation is on.
-  FALLBACK_IF(!js.assumeNoPairedQuantize && jo.fastmem_arena && !PowerPC::ppcState.msr.DR);
+  FALLBACK_IF(!js.assumeNoPairedQuantize && jo.fastmem_arena && !m_ppc_state.msr.DR);
 
   // X30 is LR
   // X0 is the address
@@ -148,7 +148,7 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
   JITDISABLE(bJITLoadStorePairedOff);
 
   // If we have a fastmem arena, the asm routines assume address translation is on.
-  FALLBACK_IF(!js.assumeNoPairedQuantize && jo.fastmem_arena && !PowerPC::ppcState.msr.DR);
+  FALLBACK_IF(!js.assumeNoPairedQuantize && jo.fastmem_arena && !m_ppc_state.msr.DR);
 
   // X30 is LR
   // X0 contains the scale

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -307,7 +307,7 @@ void JitArm64::mfspr(UGeckoInstruction inst)
     // An inline implementation of CoreTiming::GetFakeTimeBase, since in timer-heavy games the
     // cost of calling out to C for this is actually significant.
 
-    auto& core_timing_globals = Core::System::GetInstance().GetCoreTiming().GetGlobals();
+    auto& core_timing_globals = m_system.GetCoreTiming().GetGlobals();
     MOVP2R(Xg, &core_timing_globals);
 
     LDR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(downcount));

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -43,7 +43,7 @@ void JitArm64::GenerateAsm()
   ABI_PushRegisters(regs_to_save);
   m_float_emit.ABI_PushRegisters(regs_to_save_fpr, ARM64Reg::X30);
 
-  MOVP2R(PPC_REG, &PowerPC::ppcState);
+  MOVP2R(PPC_REG, &m_ppc_state);
 
   // Store the stack pointer, so we can reset it if the BLR optimization fails.
   ADD(ARM64Reg::X0, ARM64Reg::SP, 0);
@@ -67,7 +67,7 @@ void JitArm64::GenerateAsm()
   // dispatcher_no_check:
   //     ExecuteBlock(JitBase::Dispatch());
   // dispatcher:
-  //   } while (PowerPC::ppcState.downcount > 0);
+  //   } while (m_ppc_state.downcount > 0);
   // do_timing:
   //   NPC = PC = DISPATCHER_PC;
   // } while (CPU::GetState() == CPU::State::Running);
@@ -81,8 +81,7 @@ void JitArm64::GenerateAsm()
 
   dispatcher_no_timing_check = GetCodePtr();
 
-  auto& system = Core::System::GetInstance();
-  auto& cpu = system.GetCPU();
+  auto& cpu = m_system.GetCPU();
 
   FixupBranch debug_exit;
   if (enable_debugging)
@@ -96,7 +95,7 @@ void JitArm64::GenerateAsm()
 
   bool assembly_dispatcher = true;
 
-  auto& memory = system.GetMemory();
+  auto& memory = m_system.GetMemory();
 
   if (assembly_dispatcher)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
@@ -16,10 +16,10 @@ template <typename T>
 class MMIOWriteCodeGenerator : public MMIO::WriteHandlingMethodVisitor<T>
 {
 public:
-  MMIOWriteCodeGenerator(ARM64XEmitter* emit, BitSet32 gprs_in_use, BitSet32 fprs_in_use,
-                         ARM64Reg src_reg, u32 address)
-      : m_emit(emit), m_gprs_in_use(gprs_in_use), m_fprs_in_use(fprs_in_use), m_src_reg(src_reg),
-        m_address(address)
+  MMIOWriteCodeGenerator(Core::System* system, ARM64XEmitter* emit, BitSet32 gprs_in_use,
+                         BitSet32 fprs_in_use, ARM64Reg src_reg, u32 address)
+      : m_system(system), m_emit(emit), m_gprs_in_use(gprs_in_use), m_fprs_in_use(fprs_in_use),
+        m_src_reg(src_reg), m_address(address)
   {
   }
 
@@ -78,7 +78,7 @@ private:
 
     m_emit->ABI_PushRegisters(m_gprs_in_use);
     float_emit.ABI_PushRegisters(m_fprs_in_use, ARM64Reg::X1);
-    m_emit->MOVP2R(ARM64Reg::X1, &Core::System::GetInstance());
+    m_emit->MOVP2R(ARM64Reg::X1, m_system);
     m_emit->MOVI2R(ARM64Reg::W2, m_address);
     m_emit->MOV(ARM64Reg::W3, m_src_reg);
     m_emit->BLR(m_emit->ABI_SetupLambda(lambda));
@@ -87,6 +87,7 @@ private:
     m_emit->ABI_PopRegisters(m_gprs_in_use);
   }
 
+  Core::System* m_system;
   ARM64XEmitter* m_emit;
   BitSet32 m_gprs_in_use;
   BitSet32 m_fprs_in_use;
@@ -98,10 +99,10 @@ template <typename T>
 class MMIOReadCodeGenerator : public MMIO::ReadHandlingMethodVisitor<T>
 {
 public:
-  MMIOReadCodeGenerator(ARM64XEmitter* emit, BitSet32 gprs_in_use, BitSet32 fprs_in_use,
-                        ARM64Reg dst_reg, u32 address, bool sign_extend)
-      : m_emit(emit), m_gprs_in_use(gprs_in_use), m_fprs_in_use(fprs_in_use), m_dst_reg(dst_reg),
-        m_address(address), m_sign_extend(sign_extend)
+  MMIOReadCodeGenerator(Core::System* system, ARM64XEmitter* emit, BitSet32 gprs_in_use,
+                        BitSet32 fprs_in_use, ARM64Reg dst_reg, u32 address, bool sign_extend)
+      : m_system(system), m_emit(emit), m_gprs_in_use(gprs_in_use), m_fprs_in_use(fprs_in_use),
+        m_dst_reg(dst_reg), m_address(address), m_sign_extend(sign_extend)
   {
   }
 
@@ -175,7 +176,7 @@ private:
 
     m_emit->ABI_PushRegisters(m_gprs_in_use);
     float_emit.ABI_PushRegisters(m_fprs_in_use, ARM64Reg::X1);
-    m_emit->MOVP2R(ARM64Reg::X1, &Core::System::GetInstance());
+    m_emit->MOVP2R(ARM64Reg::X1, m_system);
     m_emit->MOVI2R(ARM64Reg::W2, m_address);
     m_emit->BLR(m_emit->ABI_SetupLambda(lambda));
     if (m_sign_extend)
@@ -187,6 +188,7 @@ private:
     m_emit->ABI_PopRegisters(m_gprs_in_use);
   }
 
+  Core::System* m_system;
   ARM64XEmitter* m_emit;
   BitSet32 m_gprs_in_use;
   BitSet32 m_fprs_in_use;
@@ -293,27 +295,27 @@ ARM64Reg ByteswapBeforeStore(ARM64XEmitter* emit, ARM64FloatEmitter* float_emit,
   return dst_reg;
 }
 
-void MMIOLoadToReg(MMIO::Mapping* mmio, ARM64XEmitter* emit, ARM64FloatEmitter* float_emit,
-                   BitSet32 gprs_in_use, BitSet32 fprs_in_use, ARM64Reg dst_reg, u32 address,
-                   u32 flags)
+void MMIOLoadToReg(Core::System& system, MMIO::Mapping* mmio, ARM64XEmitter* emit,
+                   ARM64FloatEmitter* float_emit, BitSet32 gprs_in_use, BitSet32 fprs_in_use,
+                   ARM64Reg dst_reg, u32 address, u32 flags)
 {
   ASSERT(!(flags & BackPatchInfo::FLAG_FLOAT));
 
   if (flags & BackPatchInfo::FLAG_SIZE_8)
   {
-    MMIOReadCodeGenerator<u8> gen(emit, gprs_in_use, fprs_in_use, dst_reg, address,
+    MMIOReadCodeGenerator<u8> gen(&system, emit, gprs_in_use, fprs_in_use, dst_reg, address,
                                   flags & BackPatchInfo::FLAG_EXTEND);
     mmio->GetHandlerForRead<u8>(address).Visit(gen);
   }
   else if (flags & BackPatchInfo::FLAG_SIZE_16)
   {
-    MMIOReadCodeGenerator<u16> gen(emit, gprs_in_use, fprs_in_use, dst_reg, address,
+    MMIOReadCodeGenerator<u16> gen(&system, emit, gprs_in_use, fprs_in_use, dst_reg, address,
                                    flags & BackPatchInfo::FLAG_EXTEND);
     mmio->GetHandlerForRead<u16>(address).Visit(gen);
   }
   else if (flags & BackPatchInfo::FLAG_SIZE_32)
   {
-    MMIOReadCodeGenerator<u32> gen(emit, gprs_in_use, fprs_in_use, dst_reg, address,
+    MMIOReadCodeGenerator<u32> gen(&system, emit, gprs_in_use, fprs_in_use, dst_reg, address,
                                    flags & BackPatchInfo::FLAG_EXTEND);
     mmio->GetHandlerForRead<u32>(address).Visit(gen);
   }
@@ -321,9 +323,9 @@ void MMIOLoadToReg(MMIO::Mapping* mmio, ARM64XEmitter* emit, ARM64FloatEmitter* 
   ByteswapAfterLoad(emit, float_emit, dst_reg, dst_reg, flags, false, true);
 }
 
-void MMIOWriteRegToAddr(MMIO::Mapping* mmio, ARM64XEmitter* emit, ARM64FloatEmitter* float_emit,
-                        BitSet32 gprs_in_use, BitSet32 fprs_in_use, ARM64Reg src_reg, u32 address,
-                        u32 flags)
+void MMIOWriteRegToAddr(Core::System& system, MMIO::Mapping* mmio, ARM64XEmitter* emit,
+                        ARM64FloatEmitter* float_emit, BitSet32 gprs_in_use, BitSet32 fprs_in_use,
+                        ARM64Reg src_reg, u32 address, u32 flags)
 {
   ASSERT(!(flags & BackPatchInfo::FLAG_FLOAT));
 
@@ -331,17 +333,17 @@ void MMIOWriteRegToAddr(MMIO::Mapping* mmio, ARM64XEmitter* emit, ARM64FloatEmit
 
   if (flags & BackPatchInfo::FLAG_SIZE_8)
   {
-    MMIOWriteCodeGenerator<u8> gen(emit, gprs_in_use, fprs_in_use, src_reg, address);
+    MMIOWriteCodeGenerator<u8> gen(&system, emit, gprs_in_use, fprs_in_use, src_reg, address);
     mmio->GetHandlerForWrite<u8>(address).Visit(gen);
   }
   else if (flags & BackPatchInfo::FLAG_SIZE_16)
   {
-    MMIOWriteCodeGenerator<u16> gen(emit, gprs_in_use, fprs_in_use, src_reg, address);
+    MMIOWriteCodeGenerator<u16> gen(&system, emit, gprs_in_use, fprs_in_use, src_reg, address);
     mmio->GetHandlerForWrite<u16>(address).Visit(gen);
   }
   else if (flags & BackPatchInfo::FLAG_SIZE_32)
   {
-    MMIOWriteCodeGenerator<u32> gen(emit, gprs_in_use, fprs_in_use, src_reg, address);
+    MMIOWriteCodeGenerator<u32> gen(&system, emit, gprs_in_use, fprs_in_use, src_reg, address);
     mmio->GetHandlerForWrite<u32>(address).Visit(gen);
   }
 }

--- a/Source/Core/Core/PowerPC/JitArm64/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit_Util.h
@@ -8,6 +8,11 @@
 
 #include "Core/HW/MMIO.h"
 
+namespace Core
+{
+class System;
+}
+
 void SwapPairs(Arm64Gen::ARM64XEmitter* emit, Arm64Gen::ARM64Reg dst_reg,
                Arm64Gen::ARM64Reg src_reg, u32 flags);
 
@@ -20,10 +25,10 @@ Arm64Gen::ARM64Reg ByteswapBeforeStore(Arm64Gen::ARM64XEmitter* emit,
                                        Arm64Gen::ARM64Reg tmp_reg, Arm64Gen::ARM64Reg src_reg,
                                        u32 flags, bool want_reversed);
 
-void MMIOLoadToReg(MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit,
+void MMIOLoadToReg(Core::System& system, MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit,
                    Arm64Gen::ARM64FloatEmitter* float_emit, BitSet32 gprs_in_use,
                    BitSet32 fprs_in_use, Arm64Gen::ARM64Reg dst_reg, u32 address, u32 flags);
 
-void MMIOWriteRegToAddr(MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit,
+void MMIOWriteRegToAddr(Core::System& system, MMIO::Mapping* mmio, Arm64Gen::ARM64XEmitter* emit,
                         Arm64Gen::ARM64FloatEmitter* float_emit, BitSet32 gprs_in_use,
                         BitSet32 fprs_in_use, Arm64Gen::ARM64Reg src_reg, u32 address, u32 flags);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -96,7 +96,7 @@ JitBlock* JitBaseBlockCache::AllocateBlock(u32 em_address)
   JitBlock& b = block_map.emplace(physical_address, JitBlock())->second;
   b.effectiveAddress = em_address;
   b.physicalAddress = physical_address;
-  b.msrBits = PowerPC::ppcState.msr.Hex & JIT_CACHE_MSR_MASK;
+  b.msrBits = m_jit.m_ppc_state.msr.Hex & JIT_CACHE_MSR_MASK;
   b.linkData.clear();
   b.fast_block_map_index = 0;
   return &b;
@@ -168,13 +168,13 @@ JitBlock* JitBaseBlockCache::GetBlockFromStartAddress(u32 addr, u32 msr)
 
 const u8* JitBaseBlockCache::Dispatch()
 {
-  JitBlock* block = fast_block_map[FastLookupIndexForAddress(PowerPC::ppcState.pc)];
+  const auto& ppc_state = m_jit.m_ppc_state;
+  JitBlock* block = fast_block_map[FastLookupIndexForAddress(ppc_state.pc)];
 
-  if (!block || block->effectiveAddress != PowerPC::ppcState.pc ||
-      block->msrBits != (PowerPC::ppcState.msr.Hex & JIT_CACHE_MSR_MASK))
+  if (!block || block->effectiveAddress != ppc_state.pc ||
+      block->msrBits != (ppc_state.msr.Hex & JIT_CACHE_MSR_MASK))
   {
-    block = MoveBlockIntoFastCache(PowerPC::ppcState.pc,
-                                   PowerPC::ppcState.msr.Hex & JIT_CACHE_MSR_MASK);
+    block = MoveBlockIntoFastCache(ppc_state.pc, ppc_state.msr.Hex & JIT_CACHE_MSR_MASK);
   }
 
   if (!block)


### PR DESCRIPTION
*Completely untested* because I have no 64-bit ARM device to test this on. Please actually try this before merging.