### PR TITLE
JitInterface: Refactor to class, move to System.

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -397,8 +397,9 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetProfiling
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
   Core::SetState(Core::State::Paused);
-  JitInterface::ClearCache();
-  JitInterface::SetProfilingState(enable ? JitInterface::ProfilingState::Enabled :
+  auto& jit_interface = Core::System::GetInstance().GetJitInterface();
+  jit_interface.ClearCache();
+  jit_interface.SetProfilingState(enable ? JitInterface::ProfilingState::Enabled :
                                            JitInterface::ProfilingState::Disabled);
   Core::SetState(Core::State::Running);
 }
@@ -409,7 +410,8 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_WriteProfile
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
   std::string filename = File::GetUserPath(D_DUMP_IDX) + "Debug/profiler.txt";
   File::CreateFullPath(filename);
-  JitInterface::WriteProfileResults(filename);
+  auto& jit_interface = Core::System::GetInstance().GetJitInterface();
+  jit_interface.WriteProfileResults(filename);
 }
 
 // Surface Handling

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -986,7 +986,7 @@ void UpdateWantDeterminism(bool initial)
 
       // We need to clear the cache because some parts of the JIT depend on want_determinism,
       // e.g. use of FMA.
-      JitInterface::ClearCache();
+      system.GetJitInterface().ClearCache();
     });
   }
 }

--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -132,7 +132,7 @@ void GPFifoManager::CheckGatherPipe()
     UpdateGatherPipe();
 
     // Profile where slow FIFO writes are occurring.
-    JitInterface::CompileExceptionCheck(JitInterface::ExceptionType::FIFOWrite);
+    m_system.GetJitInterface().CompileExceptionCheck(JitInterface::ExceptionType::FIFOWrite);
   }
 }
 

--- a/Source/Core/Core/MemTools.cpp
+++ b/Source/Core/Core/MemTools.cpp
@@ -16,6 +16,7 @@
 
 #include "Core/MachineContext.h"
 #include "Core/PowerPC/JitInterface.h"
+#include "Core/System.h"
 
 #if defined(__FreeBSD__) || defined(__NetBSD__)
 #include <signal.h>
@@ -60,7 +61,7 @@ static LONG NTAPI Handler(PEXCEPTION_POINTERS pPtrs)
     uintptr_t fault_address = (uintptr_t)pPtrs->ExceptionRecord->ExceptionInformation[1];
     SContext* ctx = pPtrs->ContextRecord;
 
-    if (JitInterface::HandleFault(fault_address, ctx))
+    if (Core::System::GetInstance().GetJitInterface().HandleFault(fault_address, ctx))
     {
       return EXCEPTION_CONTINUE_EXECUTION;
     }
@@ -72,7 +73,7 @@ static LONG NTAPI Handler(PEXCEPTION_POINTERS pPtrs)
   }
 
   case EXCEPTION_STACK_OVERFLOW:
-    if (JitInterface::HandleStackFault())
+    if (Core::System::GetInstance().GetJitInterface().HandleStackFault())
       return EXCEPTION_CONTINUE_EXECUTION;
     else
       return EXCEPTION_CONTINUE_SEARCH;
@@ -190,7 +191,8 @@ static void ExceptionThread(mach_port_t port)
 
     thread_state64_t* state = (thread_state64_t*)msg_in.old_state;
 
-    bool ok = JitInterface::HandleFault((uintptr_t)msg_in.code[1], state);
+    bool ok =
+        Core::System::GetInstance().GetJitInterface().HandleFault((uintptr_t)msg_in.code[1], state);
 
     // Set up the reply.
     msg_out.Head.msgh_bits = MACH_MSGH_BITS(MACH_MSGH_BITS_REMOTE(msg_in.Head.msgh_bits), 0);
@@ -281,13 +283,13 @@ static void sigsegv_handler(int sig, siginfo_t* info, void* raw_context)
   mcontext_t* ctx = &context->uc_mcontext;
 #endif
   // assume it's not a write
-  if (!JitInterface::HandleFault(bad_address,
+  if (!Core::System::GetInstance().GetJitInterface().HandleFault(bad_address,
 #ifdef __APPLE__
-                                 *ctx
+                                                                 *ctx
 #else
-                                 ctx
+                                                                 ctx
 #endif
-                                 ))
+                                                                 ))
   {
     // retry and crash
     // According to the sigaction man page, if sa_flags "SA_SIGINFO" is set to the sigaction

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -16,6 +16,7 @@
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 static u32 Helper_Get_EA(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
 {
@@ -473,7 +474,7 @@ void Interpreter::dcbf(Interpreter& interpreter, UGeckoInstruction inst)
     // Invalidate the JIT cache here as a heuristic to compensate for
     // the lack of precise L1 icache emulation in the JIT. (Portable software
     // should use icbi consistently, but games aren't portable.)
-    JitInterface::InvalidateICacheLine(address);
+    interpreter.m_system.GetJitInterface().InvalidateICacheLine(address);
     return;
   }
 
@@ -495,7 +496,7 @@ void Interpreter::dcbi(Interpreter& interpreter, UGeckoInstruction inst)
     // Invalidate the JIT cache here as a heuristic to compensate for
     // the lack of precise L1 icache emulation in the JIT. (Portable software
     // should use icbi consistently, but games aren't portable.)
-    JitInterface::InvalidateICacheLine(address);
+    interpreter.m_system.GetJitInterface().InvalidateICacheLine(address);
     return;
   }
 
@@ -511,7 +512,7 @@ void Interpreter::dcbst(Interpreter& interpreter, UGeckoInstruction inst)
     // Invalidate the JIT cache here as a heuristic to compensate for
     // the lack of precise L1 icache emulation in the JIT. (Portable software
     // should use icbi consistently, but games aren't portable.)
-    JitInterface::InvalidateICacheLine(address);
+    interpreter.m_system.GetJitInterface().InvalidateICacheLine(address);
     return;
   }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -877,8 +877,8 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       const u8* target = GetCodePtr();
       MOV(32, PPCSTATE(pc), Imm32(js.blockStart));
       ABI_PushRegistersAndAdjustStack({}, 0);
-      ABI_CallFunctionC(JitInterface::CompileExceptionCheck,
-                        static_cast<u32>(JitInterface::ExceptionType::PairedQuantize));
+      ABI_CallFunctionPC(JitInterface::CompileExceptionCheckFromJIT, &m_system.GetJitInterface(),
+                         static_cast<u32>(JitInterface::ExceptionType::PairedQuantize));
       ABI_PopRegistersAndAdjustStack({}, 0);
       JMP(asm_routines.dispatcher_no_check, true);
       SwitchToNearCode();
@@ -1193,8 +1193,8 @@ void Jit64::IntializeSpeculativeConstants()
         target = GetCodePtr();
         MOV(32, PPCSTATE(pc), Imm32(js.blockStart));
         ABI_PushRegistersAndAdjustStack({}, 0);
-        ABI_CallFunctionC(JitInterface::CompileExceptionCheck,
-                          static_cast<u32>(JitInterface::ExceptionType::SpeculativeConstants));
+        ABI_CallFunctionPC(JitInterface::CompileExceptionCheckFromJIT, &m_system.GetJitInterface(),
+                           static_cast<u32>(JitInterface::ExceptionType::SpeculativeConstants));
         ABI_PopRegistersAndAdjustStack({}, 0);
         JMP(asm_routines.dispatcher_no_check, true);
         SwitchToNearCode();

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -22,6 +22,7 @@
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 using namespace Gen;
 
@@ -362,12 +363,14 @@ void Jit64::dcbx(UGeckoInstruction inst)
   {
     MOV(32, R(ABI_PARAM1), R(effective_address));
     MOV(32, R(ABI_PARAM2), R(loop_counter));
-    ABI_CallFunction(JitInterface::InvalidateICacheLines);
+    MOV(64, R(ABI_PARAM3), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
+    ABI_CallFunction(JitInterface::InvalidateICacheLinesFromJIT);
   }
   else
   {
     MOV(32, R(ABI_PARAM1), R(effective_address));
-    ABI_CallFunction(JitInterface::InvalidateICacheLine);
+    MOV(64, R(ABI_PARAM3), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
+    ABI_CallFunction(JitInterface::InvalidateICacheLineFromJIT);
   }
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);
   asm_routines.ResetStack(*this);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -327,8 +327,9 @@ void JitArm64::IntializeSpeculativeConstants()
         fail = GetCodePtr();
         MOVI2R(DISPATCHER_PC, js.blockStart);
         STR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
-        MOVP2R(ARM64Reg::X8, &JitInterface::CompileExceptionCheck);
-        MOVI2R(ARM64Reg::W0, static_cast<u32>(JitInterface::ExceptionType::SpeculativeConstants));
+        MOVP2R(ARM64Reg::X8, &JitInterface::CompileExceptionCheckFromJIT);
+        MOVP2R(ARM64Reg::X0, &m_system.GetJitInterface());
+        MOVI2R(ARM64Reg::W1, static_cast<u32>(JitInterface::ExceptionType::SpeculativeConstants));
         BLR(ARM64Reg::X8);
         B(dispatcher_no_check);
         SwitchToNearCode();
@@ -866,9 +867,10 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       SetJumpTarget(fail);
       MOVI2R(DISPATCHER_PC, js.blockStart);
       STR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
-      MOVI2R(ARM64Reg::W0, static_cast<u32>(JitInterface::ExceptionType::PairedQuantize));
-      MOVP2R(ARM64Reg::X1, &JitInterface::CompileExceptionCheck);
-      BLR(ARM64Reg::X1);
+      MOVP2R(ARM64Reg::X0, &m_system.GetJitInterface());
+      MOVI2R(ARM64Reg::W1, static_cast<u32>(JitInterface::ExceptionType::PairedQuantize));
+      MOVP2R(ARM64Reg::X2, &JitInterface::CompileExceptionCheckFromJIT);
+      BLR(ARM64Reg::X2);
       B(dispatcher_no_check);
       SwitchToNearCode();
       SetJumpTarget(no_fail);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -770,11 +770,12 @@ void JitArm64::dcbx(UGeckoInstruction inst)
   ABI_PushRegisters(gprs_to_push);
   m_float_emit.ABI_PushRegisters(fprs_to_push, WA);
 
-  // The function call arguments are already in the correct registers
+  // The first two function call arguments are already in the correct registers
+  MOVP2R(ARM64Reg::X2, &m_system.GetJitInterface());
   if (make_loop)
-    MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLines);
+    MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLinesFromJIT);
   else
-    MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLine);
+    MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLineFromJIT);
   BLR(ARM64Reg::X8);
 
   m_float_emit.ABI_PopRegisters(fprs_to_push, WA);

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -13,6 +13,10 @@ class CPUCoreBase;
 class PointerWrap;
 class JitBase;
 
+namespace Core
+{
+class System;
+}
 namespace PowerPC
 {
 enum class CPUCore;
@@ -23,65 +27,78 @@ namespace Profiler
 struct ProfileStats;
 }
 
-namespace JitInterface
+class JitInterface
 {
-enum class ExceptionType
-{
-  FIFOWrite,
-  PairedQuantize,
-  SpeculativeConstants
+public:
+  explicit JitInterface(Core::System& system);
+  JitInterface(const JitInterface&) = delete;
+  JitInterface(JitInterface&&) = delete;
+  JitInterface& operator=(const JitInterface&) = delete;
+  JitInterface& operator=(JitInterface&&) = delete;
+  ~JitInterface();
+
+  void DoState(PointerWrap& p);
+
+  CPUCoreBase* InitJitCore(PowerPC::CPUCore core);
+  CPUCoreBase* GetCore() const;
+
+  // Debugging
+  enum class ProfilingState
+  {
+    Enabled,
+    Disabled
+  };
+  enum class GetHostCodeError
+  {
+    NoJitActive,
+    NoTranslation,
+  };
+  struct GetHostCodeResult
+  {
+    const u8* code;
+    u32 code_size;
+    u32 entry_address;
+  };
+
+  void SetProfilingState(ProfilingState state);
+  void WriteProfileResults(const std::string& filename) const;
+  void GetProfileResults(Profiler::ProfileStats* prof_stats) const;
+  std::variant<GetHostCodeError, GetHostCodeResult> GetHostCode(u32 address) const;
+
+  // Memory Utilities
+  bool HandleFault(uintptr_t access_address, SContext* ctx);
+  bool HandleStackFault();
+
+  // Clearing CodeCache
+  void ClearCache();
+
+  // This clear is "safe" in the sense that it's okay to run from
+  // inside a JIT'ed block: it clears the instruction cache, but not
+  // the JIT'ed code.
+  void ClearSafe();
+
+  // If "forced" is true, a recompile is being requested on code that hasn't been modified.
+  void InvalidateICache(u32 address, u32 size, bool forced);
+  void InvalidateICacheLine(u32 address);
+  void InvalidateICacheLines(u32 address, u32 count);
+  static void InvalidateICacheLineFromJIT(u32 address, u32 dummy, JitInterface& jit_interface);
+  static void InvalidateICacheLinesFromJIT(u32 address, u32 count, JitInterface& jit_interface);
+
+  enum class ExceptionType
+  {
+    FIFOWrite,
+    PairedQuantize,
+    SpeculativeConstants
+  };
+  void CompileExceptionCheck(ExceptionType type);
+  static void CompileExceptionCheckFromJIT(JitInterface& jit_interface, ExceptionType type);
+
+  /// used for the page fault unit test, don't use outside of tests!
+  void SetJit(JitBase* jit);
+
+  void Shutdown();
+
+private:
+  JitBase* m_jit = nullptr;
+  Core::System& m_system;
 };
-
-void DoState(PointerWrap& p);
-
-CPUCoreBase* InitJitCore(PowerPC::CPUCore core);
-CPUCoreBase* GetCore();
-
-// Debugging
-enum class ProfilingState
-{
-  Enabled,
-  Disabled
-};
-
-enum class GetHostCodeError
-{
-  NoJitActive,
-  NoTranslation,
-};
-struct GetHostCodeResult
-{
-  const u8* code;
-  u32 code_size;
-  u32 entry_address;
-};
-
-void SetProfilingState(ProfilingState state);
-void WriteProfileResults(const std::string& filename);
-void GetProfileResults(Profiler::ProfileStats* prof_stats);
-std::variant<GetHostCodeError, GetHostCodeResult> GetHostCode(u32 address);
-
-// Memory Utilities
-bool HandleFault(uintptr_t access_address, SContext* ctx);
-bool HandleStackFault();
-
-// Clearing CodeCache
-void ClearCache();
-
-// This clear is "safe" in the sense that it's okay to run from
-// inside a JIT'ed block: it clears the instruction cache, but not
-// the JIT'ed code.
-void ClearSafe();
-
-// If "forced" is true, a recompile is being requested on code that hasn't been modified.
-void InvalidateICache(u32 address, u32 size, bool forced);
-void InvalidateICacheLine(u32 address);
-void InvalidateICacheLines(u32 address, u32 count);
-
-void CompileExceptionCheck(ExceptionType type);
-
-/// used for the page fault unit test, don't use outside of tests!
-void SetJit(JitBase* jit);
-
-void Shutdown();
-}  // namespace JitInterface

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <variant>
 
@@ -94,11 +95,11 @@ public:
   static void CompileExceptionCheckFromJIT(JitInterface& jit_interface, ExceptionType type);
 
   /// used for the page fault unit test, don't use outside of tests!
-  void SetJit(JitBase* jit);
+  void SetJit(std::unique_ptr<JitBase> jit);
 
   void Shutdown();
 
 private:
-  JitBase* m_jit = nullptr;
+  std::unique_ptr<JitBase> m_jit;
   Core::System& m_system;
 };

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1770,7 +1770,7 @@ void DBATUpdated()
 #endif
 
   // IsOptimizable*Address and dcbz depends on the BAT mapping, so we need a flush here.
-  JitInterface::ClearSafe();
+  system.GetJitInterface().ClearSafe();
 }
 
 void IBATUpdated()
@@ -1789,7 +1789,7 @@ void IBATUpdated()
     UpdateFakeMMUBat(ibat_table, 0x40000000);
     UpdateFakeMMUBat(ibat_table, 0x70000000);
   }
-  JitInterface::ClearSafe();
+  system.GetJitInterface().ClearSafe();
 }
 
 // Translate effective address using BAT or PAT.  Returns 0 if the address cannot be translated.

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -107,7 +107,7 @@ void Cache::Reset()
 void InstructionCache::Reset()
 {
   Cache::Reset();
-  JitInterface::ClearSafe();
+  Core::System::GetInstance().GetJitInterface().ClearSafe();
 }
 
 void Cache::Init()
@@ -424,7 +424,7 @@ void InstructionCache::Invalidate(u32 addr)
   valid[set] = 0;
   modified[set] = 0;
 
-  JitInterface::InvalidateICacheLine(addr);
+  Core::System::GetInstance().GetJitInterface().InvalidateICacheLine(addr);
 }
 
 void InstructionCache::RefreshConfig()

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -23,6 +23,7 @@
 #include "Core/HW/Sram.h"
 #include "Core/HW/VideoInterface.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
+#include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "IOS/USB/Emulated/Skylander.h"
 #include "VideoCommon/CommandProcessor.h"
@@ -40,7 +41,7 @@ struct System::Impl
       : m_audio_interface(system), m_core_timing(system), m_dsp(system), m_dvd_interface(system),
         m_dvd_thread(system), m_expansion_interface(system), m_gp_fifo(system), m_memory(system),
         m_ppc_state(PowerPC::ppcState), m_processor_interface(system), m_serial_interface(system),
-        m_video_interface(system), m_interpreter(system, m_ppc_state)
+        m_video_interface(system), m_interpreter(system, m_ppc_state), m_jit_interface(system)
   {
   }
 
@@ -72,6 +73,7 @@ struct System::Impl
   VertexShaderManager m_vertex_shader_manager;
   VideoInterface::VideoInterfaceManager m_video_interface;
   Interpreter m_interpreter;
+  JitInterface m_jit_interface;
 };
 
 System::System() : m_impl{std::make_unique<Impl>(*this)}
@@ -180,6 +182,11 @@ HSP::HSPManager& System::GetHSP() const
 Interpreter& System::GetInterpreter() const
 {
   return m_impl->m_interpreter;
+}
+
+JitInterface& System::GetJitInterface() const
+{
+  return m_impl->m_jit_interface;
 }
 
 IOS::HLE::USB::SkylanderPortal& System::GetSkylanderPortal() const

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -7,6 +7,7 @@
 
 class GeometryShaderManager;
 class Interpreter;
+class JitInterface;
 class PixelShaderManager;
 class SoundStream;
 struct Sram;
@@ -133,6 +134,7 @@ public:
   GPFifo::GPFifoManager& GetGPFifo() const;
   HSP::HSPManager& GetHSP() const;
   Interpreter& GetInterpreter() const;
+  JitInterface& GetJitInterface() const;
   IOS::HLE::USB::SkylanderPortal& GetSkylanderPortal() const;
   Memory::MemoryManager& GetMemory() const;
   MemoryInterface::MemoryInterfaceManager& GetMemoryInterface() const;

--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
@@ -140,7 +140,8 @@ void CodeDiffDialog::ClearData()
   // Swap is used instead of clear for efficiency in the case of huge m_include/m_exclude
   std::vector<Diff>().swap(m_include);
   std::vector<Diff>().swap(m_exclude);
-  JitInterface::SetProfilingState(JitInterface::ProfilingState::Disabled);
+  Core::System::GetInstance().GetJitInterface().SetProfilingState(
+      JitInterface::ProfilingState::Disabled);
 }
 
 void CodeDiffDialog::ClearBlockCache()
@@ -150,7 +151,7 @@ void CodeDiffDialog::ClearBlockCache()
   if (old_state == Core::State::Running)
     Core::SetState(Core::State::Paused);
 
-  JitInterface::ClearCache();
+  Core::System::GetInstance().GetJitInterface().ClearCache();
 
   if (old_state == Core::State::Running)
     Core::SetState(Core::State::Running);
@@ -205,7 +206,7 @@ void CodeDiffDialog::OnRecord(bool enabled)
   }
 
   m_record_btn->update();
-  JitInterface::SetProfilingState(state);
+  Core::System::GetInstance().GetJitInterface().SetProfilingState(state);
 }
 
 void CodeDiffDialog::OnInclude()
@@ -271,7 +272,7 @@ std::vector<Diff> CodeDiffDialog::CalculateSymbolsFromProfile()
 {
   Profiler::ProfileStats prof_stats;
   auto& blockstats = prof_stats.block_stats;
-  JitInterface::GetProfileResults(&prof_stats);
+  Core::System::GetInstance().GetJitInterface().GetProfileResults(&prof_stats);
   std::vector<Diff> current;
   current.reserve(20000);
 
@@ -391,7 +392,7 @@ void CodeDiffDialog::Update(bool include)
   m_exclude_size_label->setText(tr("Excluded: %1").arg(m_exclude.size()));
   m_include_size_label->setText(tr("Included: %1").arg(m_include.size()));
 
-  JitInterface::ClearCache();
+  Core::System::GetInstance().GetJitInterface().ClearCache();
   if (old_state == Core::State::Running)
     Core::SetState(Core::State::Running);
 }

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1671,7 +1671,7 @@ void MenuBar::PatchHLEFunctions()
 
 void MenuBar::ClearCache()
 {
-  Core::RunAsCPUThread(JitInterface::ClearCache);
+  Core::RunAsCPUThread([] { Core::System::GetInstance().GetJitInterface().ClearCache(); });
 }
 
 void MenuBar::LogInstructions()

--- a/Source/Core/UICommon/Disassembler.cpp
+++ b/Source/Core/UICommon/Disassembler.cpp
@@ -16,6 +16,7 @@
 #include "Common/Assert.h"
 #include "Common/VariantUtil.h"
 #include "Core/PowerPC/JitInterface.h"
+#include "Core/System.h"
 
 #if defined(HAVE_LLVM)
 class HostDisassemblerLLVM : public HostDisassembler
@@ -170,7 +171,7 @@ std::unique_ptr<HostDisassembler> GetNewDisassembler(const std::string& arch)
 
 DisassembleResult DisassembleBlock(HostDisassembler* disasm, u32 address)
 {
-  auto res = JitInterface::GetHostCode(address);
+  auto res = Core::System::GetInstance().GetJitInterface().GetHostCode(address);
 
   return std::visit(overloaded{[&](JitInterface::GetHostCodeError error) {
                                  DisassembleResult result;

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -76,7 +76,7 @@ TEST(PageFault, PageFault)
   Common::WriteProtectMemory(data, PAGE_GRAN, false);
 
   PageFaultFakeJit pfjit(Core::System::GetInstance());
-  JitInterface::SetJit(&pfjit);
+  Core::System::GetInstance().GetJitInterface().SetJit(&pfjit);
   pfjit.m_data = data;
 
   auto start = std::chrono::high_resolution_clock::now();
@@ -88,7 +88,7 @@ TEST(PageFault, PageFault)
   };
 
   EMM::UninstallExceptionHandler();
-  JitInterface::SetJit(nullptr);
+  Core::System::GetInstance().GetJitInterface().SetJit(nullptr);
 
   fmt::print("page fault timing:\n");
   fmt::print("start->HandleFault     {} ns\n",


### PR DESCRIPTION
`InvalidateICacheLineFromJIT()` has a weird signature so we don't have to rewrite the JIT function that calls it, but I think that's fine for now -- I might do a follow-up PR on that one, since the Jit64 should really use `ABI_CallFunctionPRR()` instead of the manual stuff it's doing... Otherwise pretty straightforward.