### PR TITLE
Remove GCI Folder Path from the Wrote to OSD Message

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -666,7 +666,7 @@ void GCMemcardDirectory::FlushToFile()
 
           if (gci.IsGood())
           {
-            Core::DisplayMessage(fmt::format("Wrote save contents to {}", save.m_filename), 4000);
+            Core::DisplayMessage("Wrote save contents to GCI Folder", 4000);
           }
           else
           {


### PR DESCRIPTION
This is a follow up to #11470. In that one I only did Memory Cards, and forgot to do the GCI Folder as well. Whoops.

This removes the GCI Folder path from the wrote to OSD message, to make it less likely that streamers will get dox'd from Dolphin. That is all.

Before:
![gcifolder-before](https://user-images.githubusercontent.com/6551020/227770074-422edb0d-8585-4e1a-9438-3c4a9fabe404.png)

After:
![gcifolder-after](https://user-images.githubusercontent.com/6551020/227770085-3049176f-45b3-4097-a8a4-4564a17ce4b0.png)
