### PR TITLE
Jit64: Use utility function for function calls in dcbx.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -361,16 +361,13 @@ void Jit64::dcbx(UGeckoInstruction inst)
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
   if (make_loop)
   {
-    MOV(32, R(ABI_PARAM1), R(effective_address));
-    MOV(32, R(ABI_PARAM2), R(loop_counter));
-    MOV(64, R(ABI_PARAM3), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
-    ABI_CallFunction(JitInterface::InvalidateICacheLinesFromJIT);
+    ABI_CallFunctionPRR(JitInterface::InvalidateICacheLinesFromJit64, &m_system.GetJitInterface(),
+                        effective_address, loop_counter);
   }
   else
   {
-    MOV(32, R(ABI_PARAM1), R(effective_address));
-    MOV(64, R(ABI_PARAM3), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
-    ABI_CallFunction(JitInterface::InvalidateICacheLineFromJIT);
+    ABI_CallFunctionPR(JitInterface::InvalidateICacheLineFromJit64, &m_system.GetJitInterface(),
+                       effective_address);
   }
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);
   asm_routines.ResetStack(*this);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -773,9 +773,9 @@ void JitArm64::dcbx(UGeckoInstruction inst)
   // The first two function call arguments are already in the correct registers
   MOVP2R(ARM64Reg::X2, &m_system.GetJitInterface());
   if (make_loop)
-    MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLinesFromJIT);
+    MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLinesFromJitArm64);
   else
-    MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLineFromJIT);
+    MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLineFromJitArm64);
   BLR(ARM64Reg::X8);
 
   m_float_emit.ABI_PopRegisters(fprs_to_push, WA);

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -257,12 +257,25 @@ void JitInterface::InvalidateICacheLines(u32 address, u32 count)
     InvalidateICache(address & ~0x1f, 32 * count, false);
 }
 
-void JitInterface::InvalidateICacheLineFromJIT(u32 address, u32 dummy, JitInterface& jit_interface)
+void JitInterface::InvalidateICacheLineFromJit64(JitInterface& jit_interface, u32 address)
 {
   jit_interface.InvalidateICacheLine(address);
 }
 
-void JitInterface::InvalidateICacheLinesFromJIT(u32 address, u32 count, JitInterface& jit_interface)
+void JitInterface::InvalidateICacheLinesFromJit64(JitInterface& jit_interface, u32 address,
+                                                  u32 count)
+{
+  jit_interface.InvalidateICacheLines(address, count);
+}
+
+void JitInterface::InvalidateICacheLineFromJitArm64(u32 address, u32 dummy,
+                                                    JitInterface& jit_interface)
+{
+  jit_interface.InvalidateICacheLine(address);
+}
+
+void JitInterface::InvalidateICacheLinesFromJitArm64(u32 address, u32 count,
+                                                     JitInterface& jit_interface)
 {
   jit_interface.InvalidateICacheLines(address, count);
 }

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -82,8 +82,11 @@ public:
   void InvalidateICache(u32 address, u32 size, bool forced);
   void InvalidateICacheLine(u32 address);
   void InvalidateICacheLines(u32 address, u32 count);
-  static void InvalidateICacheLineFromJIT(u32 address, u32 dummy, JitInterface& jit_interface);
-  static void InvalidateICacheLinesFromJIT(u32 address, u32 count, JitInterface& jit_interface);
+  static void InvalidateICacheLineFromJit64(JitInterface& jit_interface, u32 address);
+  static void InvalidateICacheLinesFromJit64(JitInterface& jit_interface, u32 address, u32 count);
+  static void InvalidateICacheLineFromJitArm64(u32 address, u32 dummy, JitInterface& jit_interface);
+  static void InvalidateICacheLinesFromJitArm64(u32 address, u32 count,
+                                                JitInterface& jit_interface);
 
   enum class ExceptionType
   {


### PR DESCRIPTION
We have these for a reason. I think this also fixes a theoretical problem when `ABI_PARAM1 == loop_counter` where the first MOV destroys the second's value; I'm not sure if this can actually happen in practice though.

I'll leave the equivalent JitArm64 change to someone who can actually test the result.