### PR TITLE
IOS/FS: More accurate emulation of GetDirectoryStats() and GetNandStats().

### DIFF
--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -134,10 +134,13 @@ struct FileStatus
 constexpr size_t MaxPathDepth = 8;
 /// The maximum number of characters a path can have.
 constexpr size_t MaxPathLength = 64;
+/// The maximum number of characters a filename can have.
+constexpr size_t MaxFilenameLength = 12;
 
 /// Returns whether a Wii path is valid.
 bool IsValidPath(std::string_view path);
 bool IsValidNonRootPath(std::string_view path);
+bool IsValidFilename(std::string_view filename);
 
 struct SplitPathResult
 {

--- a/Source/Core/Core/IOS/FS/FileSystemCommon.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemCommon.cpp
@@ -3,6 +3,8 @@
 
 #include "Core/IOS/FS/FileSystem.h"
 
+#include <algorithm>
+
 #include "Common/Assert.h"
 #include "Common/FileUtil.h"
 #include "Core/IOS/Device.h"
@@ -19,6 +21,12 @@ bool IsValidNonRootPath(std::string_view path)
 {
   return path.length() > 1 && path.length() <= MaxPathLength && path[0] == '/' &&
          path.back() != '/';
+}
+
+bool IsValidFilename(std::string_view filename)
+{
+  return filename.length() <= MaxFilenameLength &&
+         !std::any_of(filename.begin(), filename.end(), [](char c) { return c == '/'; });
 }
 
 SplitPathResult SplitPathAndBasename(std::string_view path)

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -771,7 +771,12 @@ Result<DirectoryStats> HostFileSystem::GetDirectoryStats(const std::string& wii_
 
   DirectoryStats stats{};
   std::string path(BuildFilename(wii_path).host_path);
-  if (File::IsDirectory(path))
+  File::FileInfo info(path);
+  if (!info.Exists())
+  {
+    return ResultCode::NotFound;
+  }
+  if (info.IsDirectory())
   {
     File::FSTEntry parent_dir = File::ScanDirectoryTree(path, true);
     // add one for the folder itself
@@ -783,7 +788,7 @@ Result<DirectoryStats> HostFileSystem::GetDirectoryStats(const std::string& wii_
   }
   else
   {
-    WARN_LOG_FMT(IOS_FS, "fsBlock failed, cannot find directory: {}", path);
+    return ResultCode::Invalid;
   }
   return stats;
 }


### PR DESCRIPTION
The stats should actually match console now, which means block sizes for saves, channels and free blocks according to the Wii Menu should now match console too.

I've tested this by taking a NAND dump, importing that in Dolphin into an empty Wii folder, and then running [this self-written homebrew](https://gist.github.com/AdmiralCurtiss/6468753cebe9277e16a0f50370cb3ebd) ([binary](https://github.com/dolphin-emu/dolphin/files/11125202/dir-stats.zip)) and comparing the output.

[console-stats.txt](https://github.com/dolphin-emu/dolphin/files/11125211/console-stats.txt)
[dolphin-stats-before.txt](https://github.com/dolphin-emu/dolphin/files/11125212/dolphin-stats-before.txt)
[dolphin-stats-after.txt](https://github.com/dolphin-emu/dolphin/files/11125213/dolphin-stats-after.txt)

The log output of my homebrew to test this is still noticeably different because we don't seem to correctly implement permissions for ReadDirectory() -- or maybe that's because I'm launching the homebrew directly on Dolphin instead of through the Homebrew Channel? File order also doesn't seem to be preserved when importing a NAND dump.

---

For reference:

Console:
![console-stats](https://user-images.githubusercontent.com/4522237/229210029-1a8e7c4a-4b1b-42d3-9181-28b4a0eee4f7.jpg)
![console-free-blocks](https://user-images.githubusercontent.com/4522237/229210221-68113144-4672-470c-835e-d9dcb69540d3.jpg)

Imported NAND:
![nand](https://user-images.githubusercontent.com/4522237/229209505-d405b3c1-84bc-4409-8d9c-f2e035beceb7.png)

Dolphin before:
![dolphin-stats-before](https://user-images.githubusercontent.com/4522237/229209793-d07d54a3-3e78-4dfa-9b46-92ad3dd8c921.png)
![dolphin-free-blocks-before](https://user-images.githubusercontent.com/4522237/229209848-850c3969-be5e-4a27-84d6-25312b41b447.jpg)

Dolphin after:
![dolphin-stats-after](https://user-images.githubusercontent.com/4522237/229209832-62784643-bb3b-4571-a102-3de8c5a88f45.png)
![dolphin-free-blocks-after](https://user-images.githubusercontent.com/4522237/229209864-7213d997-0937-4556-836d-c35ce8af6bc8.jpg)