### PR TITLE
GameList: Check Wii save path

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -694,7 +694,14 @@ void GameList::OpenWiiSaveFolder()
   if (!game)
     return;
 
-  QUrl url = QUrl::fromLocalFile(QString::fromStdString(game->GetWiiFSPath()));
+  const std::string path = game->GetWiiFSPath();
+  if (!File::Exists(path))
+  {
+    ModalMessageBox::information(this, tr("Information"), tr("No save data found."));
+    return;
+  }
+
+  const QUrl url = QUrl::fromLocalFile(QString::fromStdString(path));
   QDesktopServices::openUrl(url);
 }
 


### PR DESCRIPTION
When right-clicking a game in the game list and choosing `Open Wii Save Folder` for game without save data, nothing happen. This PR checks the Wii save path and show a message box when no save is found (making the behaviour consistent with GC save).

Ready to be reviewed & merged.