### PR TITLE
Jit: Change argument order for InvalidateICacheLine(s)FromJIT

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -361,15 +361,15 @@ void Jit64::dcbx(UGeckoInstruction inst)
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
   if (make_loop)
   {
-    MOV(32, R(ABI_PARAM1), R(effective_address));
-    MOV(32, R(ABI_PARAM2), R(loop_counter));
-    MOV(64, R(ABI_PARAM3), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
+    MOV(32, R(ABI_PARAM2), R(effective_address));
+    MOV(32, R(ABI_PARAM3), R(loop_counter));
+    MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
     ABI_CallFunction(JitInterface::InvalidateICacheLinesFromJIT);
   }
   else
   {
-    MOV(32, R(ABI_PARAM1), R(effective_address));
-    MOV(64, R(ABI_PARAM3), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
+    MOV(32, R(ABI_PARAM2), R(effective_address));
+    MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
     ABI_CallFunction(JitInterface::InvalidateICacheLineFromJIT);
   }
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -361,16 +361,13 @@ void Jit64::dcbx(UGeckoInstruction inst)
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
   if (make_loop)
   {
-    MOV(32, R(ABI_PARAM2), R(effective_address));
-    MOV(32, R(ABI_PARAM3), R(loop_counter));
-    MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
-    ABI_CallFunction(JitInterface::InvalidateICacheLinesFromJIT);
+    ABI_CallFunctionPRR(JitInterface::InvalidateICacheLinesFromJIT, &m_system.GetJitInterface(),
+                        effective_address, loop_counter);
   }
   else
   {
-    MOV(32, R(ABI_PARAM2), R(effective_address));
-    MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(&m_system.GetJitInterface())));
-    ABI_CallFunction(JitInterface::InvalidateICacheLineFromJIT);
+    ABI_CallFunctionPR(JitInterface::InvalidateICacheLineFromJIT, &m_system.GetJitInterface(),
+                       effective_address);
   }
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);
   asm_routines.ResetStack(*this);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -647,11 +647,11 @@ void JitArm64::dcbx(UGeckoInstruction inst)
                          js.op[1].inst.RA_6 == b && js.op[1].inst.RD_2 == b &&
                          js.op[2].inst.hex == 0x4200fff8;
 
-  gpr.Lock(ARM64Reg::W0);
+  gpr.Lock(ARM64Reg::W0, ARM64Reg::W1);
   if (make_loop)
-    gpr.Lock(ARM64Reg::W1);
+    gpr.Lock(ARM64Reg::W2);
 
-  ARM64Reg WA = gpr.GetReg();
+  ARM64Reg WA = ARM64Reg::W0;
 
   if (make_loop)
     gpr.BindToRegister(b, true);
@@ -668,8 +668,8 @@ void JitArm64::dcbx(UGeckoInstruction inst)
 
     ARM64Reg reg_cycle_count = gpr.GetReg();
     ARM64Reg reg_downcount = gpr.GetReg();
-    loop_counter = ARM64Reg::W1;
-    ARM64Reg WB = ARM64Reg::W0;
+    loop_counter = ARM64Reg::W2;
+    ARM64Reg WB = ARM64Reg::W1;
 
     // Figure out how many loops we want to do.
     const u8 cycle_count_per_loop =
@@ -709,7 +709,7 @@ void JitArm64::dcbx(UGeckoInstruction inst)
     gpr.Unlock(reg_cycle_count, reg_downcount);
   }
 
-  ARM64Reg effective_addr = ARM64Reg::W0;
+  ARM64Reg effective_addr = ARM64Reg::W1;
   ARM64Reg physical_addr = gpr.GetReg();
 
   if (a)
@@ -770,8 +770,8 @@ void JitArm64::dcbx(UGeckoInstruction inst)
   ABI_PushRegisters(gprs_to_push);
   m_float_emit.ABI_PushRegisters(fprs_to_push, WA);
 
-  // The first two function call arguments are already in the correct registers
-  MOVP2R(ARM64Reg::X2, &m_system.GetJitInterface());
+  MOVP2R(ARM64Reg::X0, &m_system.GetJitInterface());
+  // effective_address and loop_counter are already in W1 and W2 respectively
   if (make_loop)
     MOVP2R(ARM64Reg::X8, &JitInterface::InvalidateICacheLinesFromJIT);
   else

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -257,12 +257,12 @@ void JitInterface::InvalidateICacheLines(u32 address, u32 count)
     InvalidateICache(address & ~0x1f, 32 * count, false);
 }
 
-void JitInterface::InvalidateICacheLineFromJIT(u32 address, u32 dummy, JitInterface& jit_interface)
+void JitInterface::InvalidateICacheLineFromJIT(JitInterface& jit_interface, u32 address)
 {
   jit_interface.InvalidateICacheLine(address);
 }
 
-void JitInterface::InvalidateICacheLinesFromJIT(u32 address, u32 count, JitInterface& jit_interface)
+void JitInterface::InvalidateICacheLinesFromJIT(JitInterface& jit_interface, u32 address, u32 count)
 {
   jit_interface.InvalidateICacheLines(address, count);
 }

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -82,8 +82,8 @@ public:
   void InvalidateICache(u32 address, u32 size, bool forced);
   void InvalidateICacheLine(u32 address);
   void InvalidateICacheLines(u32 address, u32 count);
-  static void InvalidateICacheLineFromJIT(u32 address, u32 dummy, JitInterface& jit_interface);
-  static void InvalidateICacheLinesFromJIT(u32 address, u32 count, JitInterface& jit_interface);
+  static void InvalidateICacheLineFromJIT(JitInterface& jit_interface, u32 address);
+  static void InvalidateICacheLinesFromJIT(JitInterface& jit_interface, u32 address, u32 count);
 
   enum class ExceptionType
   {


### PR DESCRIPTION
This is an updated version of PR #11701 that also changes the argument order for JitArm64.