### PR TITLE
Replace most remaining global ppcState references.

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -16,6 +16,7 @@
 #include "Core/PowerPC/Expression.h"
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/MMU.h"
+#include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 
 bool BreakPoints::IsAddressBreakPoint(u32 address) const
@@ -352,14 +353,14 @@ bool MemChecks::OverlapsMemcheck(u32 address, u32 length) const
   });
 }
 
-bool TMemCheck::Action(Common::DebugInterface* debug_interface, u64 value, u32 addr, bool write,
-                       size_t size, u32 pc)
+bool TMemCheck::Action(Core::System& system, Common::DebugInterface* debug_interface, u64 value,
+                       u32 addr, bool write, size_t size, u32 pc)
 {
   if (!is_enabled)
     return false;
 
   if (((write && is_break_on_write) || (!write && is_break_on_read)) &&
-      EvaluateCondition(this->condition))
+      EvaluateCondition(system, this->condition))
   {
     if (log_on_hit)
     {

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -45,8 +45,8 @@ struct TMemCheck
   std::optional<Expression> condition;
 
   // returns whether to break
-  bool Action(Common::DebugInterface* debug_interface, u64 value, u32 addr, bool write, size_t size,
-              u32 pc);
+  bool Action(Core::System& system, Common::DebugInterface* debug_interface, u64 value, u32 addr,
+              bool write, size_t size, u32 pc);
 };
 
 // Code breakpoints.

--- a/Source/Core/Core/PowerPC/Expression.h
+++ b/Source/Core/Core/PowerPC/Expression.h
@@ -15,7 +15,8 @@ struct expr_var_list;
 namespace Core
 {
 class CPUThreadGuard;
-}
+class System;
+}  // namespace Core
 
 struct ExprDeleter
 {
@@ -36,7 +37,7 @@ class Expression
 public:
   static std::optional<Expression> TryParse(std::string_view text);
 
-  double Evaluate() const;
+  double Evaluate(Core::System& system) const;
 
   std::string GetText() const;
 
@@ -64,7 +65,7 @@ private:
 
   Expression(std::string_view text, ExprPointer ex, ExprVarListPointer vars);
 
-  void SynchronizeBindings(SynchronizeDirection dir) const;
+  void SynchronizeBindings(Core::System& system, SynchronizeDirection dir) const;
   void Reporting(const double result) const;
 
   std::string m_text;
@@ -73,7 +74,7 @@ private:
   std::vector<VarBinding> m_binds;
 };
 
-inline bool EvaluateCondition(const std::optional<Expression>& condition)
+inline bool EvaluateCondition(Core::System& system, const std::optional<Expression>& condition)
 {
-  return !condition || condition->Evaluate() != 0.0;
+  return !condition || condition->Evaluate(system) != 0.0;
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -120,13 +120,13 @@ int Interpreter::SingleStepInner()
     // TODO: Does it make sense to use m_prev_inst here?
     // It seems like we should use the num_cycles for the instruction at PC instead
     // (m_prev_inst has not yet been updated)
-    return PPCTables::GetOpInfo(m_prev_inst)->num_cycles;
+    return PPCTables::GetOpInfo(m_prev_inst, m_ppc_state.pc)->num_cycles;
   }
 
   m_ppc_state.npc = m_ppc_state.pc + sizeof(UGeckoInstruction);
   m_prev_inst.hex = m_mmu.Read_Opcode(m_ppc_state.pc);
 
-  const GekkoOPInfo* opinfo = PPCTables::GetOpInfo(m_prev_inst);
+  const GekkoOPInfo* opinfo = PPCTables::GetOpInfo(m_prev_inst, m_ppc_state.pc);
 
   // Uncomment to trace the interpreter
   // if ((m_ppc_state.pc & 0x00FFFFFF) >= 0x000AB54C &&

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -32,7 +32,7 @@ struct PowerPCState;
 
 // Use these to control the instruction selection
 // #define INSTRUCTION_START FallBackToInterpreter(inst); return;
-// #define INSTRUCTION_START PPCTables::CountInstruction(inst);
+// #define INSTRUCTION_START PPCTables::CountInstruction(inst, m_ppc_state.pc);
 #define INSTRUCTION_START
 
 #define FALLBACK_IF(cond)                                                                          \

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -297,7 +297,7 @@ void JitInterface::CompileExceptionCheck(ExceptionType type)
 
       // Check in case the code has been replaced since: do we need to do this?
       const OpType optype =
-          PPCTables::GetOpInfo(PowerPC::MMU::HostRead_U32(guard, ppc_state.pc))->type;
+          PPCTables::GetOpInfo(PowerPC::MMU::HostRead_U32(guard, ppc_state.pc), ppc_state.pc)->type;
       if (optype != OpType::Store && optype != OpType::StoreFP && optype != OpType::StorePS)
         return;
     }

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -163,14 +163,13 @@ JitInterface::GetHostCode(u32 address) const
     return GetHostCodeError::NoJitActive;
   }
 
-  JitBlock* block =
-      m_jit->GetBlockCache()->GetBlockFromStartAddress(address, PowerPC::ppcState.msr.Hex);
+  auto& ppc_state = m_system.GetPPCState();
+  JitBlock* block = m_jit->GetBlockCache()->GetBlockFromStartAddress(address, ppc_state.msr.Hex);
   if (!block)
   {
     for (int i = 0; i < 500; i++)
     {
-      block = m_jit->GetBlockCache()->GetBlockFromStartAddress(address - 4 * i,
-                                                               PowerPC::ppcState.msr.Hex);
+      block = m_jit->GetBlockCache()->GetBlockFromStartAddress(address - 4 * i, ppc_state.msr.Hex);
       if (block)
         break;
     }
@@ -287,25 +286,26 @@ void JitInterface::CompileExceptionCheck(ExceptionType type)
     break;
   }
 
-  if (PowerPC::ppcState.pc != 0 &&
-      (exception_addresses->find(PowerPC::ppcState.pc)) == (exception_addresses->end()))
+  auto& ppc_state = m_system.GetPPCState();
+  if (ppc_state.pc != 0 &&
+      (exception_addresses->find(ppc_state.pc)) == (exception_addresses->end()))
   {
     if (type == ExceptionType::FIFOWrite)
     {
       ASSERT(Core::IsCPUThread());
-      Core::CPUThreadGuard guard(Core::System::GetInstance());
+      Core::CPUThreadGuard guard(m_system);
 
       // Check in case the code has been replaced since: do we need to do this?
       const OpType optype =
-          PPCTables::GetOpInfo(PowerPC::MMU::HostRead_U32(guard, PowerPC::ppcState.pc))->type;
+          PPCTables::GetOpInfo(PowerPC::MMU::HostRead_U32(guard, ppc_state.pc))->type;
       if (optype != OpType::Store && optype != OpType::StoreFP && optype != OpType::StorePS)
         return;
     }
-    exception_addresses->insert(PowerPC::ppcState.pc);
+    exception_addresses->insert(ppc_state.pc);
 
     // Invalidate the JIT block so that it gets recompiled with the external exception check
     // included.
-    m_jit->GetBlockCache()->InvalidateICache(PowerPC::ppcState.pc, 4, true);
+    m_jit->GetBlockCache()->InvalidateICache(ppc_state.pc, 4, true);
   }
 }
 

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -545,7 +545,8 @@ void MMU::Memcheck(u32 address, u64 var, bool write, size_t size)
 
   mc->num_hits++;
 
-  const bool pause = mc->Action(&debug_interface, var, address, write, size, m_ppc_state.pc);
+  const bool pause =
+      mc->Action(m_system, &debug_interface, var, address, write, size, m_ppc_state.pc);
   if (!pause)
     return;
 

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -114,7 +114,7 @@ bool AnalyzeFunction(const Core::CPUThreadGuard& guard, u32 startAddr, Common::S
     }
     const PowerPC::TryReadInstResult read_result = mmu.TryReadInstruction(addr);
     const UGeckoInstruction instr = read_result.hex;
-    if (read_result.valid && PPCTables::IsValidInstruction(instr))
+    if (read_result.valid && PPCTables::IsValidInstruction(instr, addr))
     {
       // BLR or RFI
       // 4e800021 is blrl, not the end of a function
@@ -274,7 +274,7 @@ static void FindFunctionsFromBranches(const Core::CPUThreadGuard& guard, u32 sta
     const PowerPC::TryReadInstResult read_result = mmu.TryReadInstruction(addr);
     const UGeckoInstruction instr = read_result.hex;
 
-    if (read_result.valid && PPCTables::IsValidInstruction(instr))
+    if (read_result.valid && PPCTables::IsValidInstruction(instr, addr))
     {
       switch (instr.OPCD)
       {
@@ -323,7 +323,7 @@ static void FindFunctionsFromHandlers(const Core::CPUThreadGuard& guard, PPCSymb
   for (const auto& entry : handlers)
   {
     const PowerPC::TryReadInstResult read_result = mmu.TryReadInstruction(entry.first);
-    if (read_result.valid && PPCTables::IsValidInstruction(read_result.hex))
+    if (read_result.valid && PPCTables::IsValidInstruction(read_result.hex, entry.first))
     {
       // Check if this function is already mapped
       Common::Symbol* f = func_db->AddFunction(guard, entry.first);
@@ -357,7 +357,7 @@ static void FindFunctionsAfterReturnInstruction(const Core::CPUThreadGuard& guar
         location += 4;
         read_result = mmu.TryReadInstruction(location);
       }
-      if (read_result.valid && PPCTables::IsValidInstruction(read_result.hex))
+      if (read_result.valid && PPCTables::IsValidInstruction(read_result.hex, location))
       {
         // check if this function is already mapped
         Common::Symbol* f = func_db->AddFunction(guard, location);
@@ -778,7 +778,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
     num_inst++;
 
     const UGeckoInstruction inst = result.hex;
-    const GekkoOPInfo* opinfo = PPCTables::GetOpInfo(inst);
+    const GekkoOPInfo* opinfo = PPCTables::GetOpInfo(inst, address);
     code[i] = {};
     code[i].opinfo = opinfo;
     code[i].address = address;

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -392,19 +392,21 @@ void Cache::DoState(PointerWrap& p)
 u32 InstructionCache::ReadInstruction(u32 addr)
 {
   auto& system = Core::System::GetInstance();
-  auto& memory = system.GetMemory();
+  auto& ppc_state = system.GetPPCState();
 
-  if (!HID0(PowerPC::ppcState).ICE || m_disable_icache)  // instruction cache is disabled
-    return memory.Read_U32(addr);
+  if (!HID0(ppc_state).ICE || m_disable_icache)  // instruction cache is disabled
+    return system.GetMemory().Read_U32(addr);
 
   u32 value;
-  Read(addr, &value, sizeof(value), HID0(PowerPC::ppcState).ILOCK);
+  Read(addr, &value, sizeof(value), HID0(ppc_state).ILOCK);
   return Common::swap32(value);
 }
 
 void InstructionCache::Invalidate(u32 addr)
 {
-  if (!HID0(PowerPC::ppcState).ICE || m_disable_icache)
+  auto& system = Core::System::GetInstance();
+  auto& ppc_state = system.GetPPCState();
+  if (!HID0(ppc_state).ICE || m_disable_icache)
     return;
 
   // Invalidates the whole set
@@ -424,7 +426,7 @@ void InstructionCache::Invalidate(u32 addr)
   valid[set] = 0;
   modified[set] = 0;
 
-  Core::System::GetInstance().GetJitInterface().InvalidateICacheLine(addr);
+  system.GetJitInterface().InvalidateICacheLine(addr);
 }
 
 void InstructionCache::RefreshConfig()

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -613,7 +613,7 @@ constexpr Tables s_tables = []() consteval
 }
 ();
 
-const GekkoOPInfo* GetOpInfo(UGeckoInstruction inst)
+const GekkoOPInfo* GetOpInfo(UGeckoInstruction inst, u32 pc)
 {
   const GekkoOPInfo* info = &s_tables.all_instructions[s_tables.primary_table[inst.OPCD]];
   if (info->type == OpType::Subtable)
@@ -631,8 +631,7 @@ const GekkoOPInfo* GetOpInfo(UGeckoInstruction inst)
     case 63:
       return &s_tables.all_instructions[s_tables.table63[inst.SUBOP10]];
     default:
-      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid subtable op {:08x} @ {:08x}", inst.hex,
-                 PowerPC::ppcState.pc);
+      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid subtable op {:08x} @ {:08x}", inst.hex, pc);
       return &s_tables.all_instructions[s_tables.unknown_op_info];
     }
   }
@@ -640,8 +639,7 @@ const GekkoOPInfo* GetOpInfo(UGeckoInstruction inst)
   {
     if (info->type == OpType::Invalid)
     {
-      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid op {:08x} @ {:08x}", inst.hex,
-                 PowerPC::ppcState.pc);
+      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid op {:08x} @ {:08x}", inst.hex, pc);
       return &s_tables.all_instructions[s_tables.unknown_op_info];
     }
     return info;
@@ -658,21 +656,21 @@ std::vector<u32> rsplocations;
 }
 #endif
 
-const char* GetInstructionName(UGeckoInstruction inst)
+const char* GetInstructionName(UGeckoInstruction inst, u32 pc)
 {
-  const GekkoOPInfo* info = GetOpInfo(inst);
+  const GekkoOPInfo* info = GetOpInfo(inst, pc);
   return info->opname;
 }
 
-bool IsValidInstruction(UGeckoInstruction inst)
+bool IsValidInstruction(UGeckoInstruction inst, u32 pc)
 {
-  const GekkoOPInfo* info = GetOpInfo(inst);
+  const GekkoOPInfo* info = GetOpInfo(inst, pc);
   return info->type != OpType::Invalid && info->type != OpType::Unknown;
 }
 
-void CountInstruction(UGeckoInstruction inst)
+void CountInstruction(UGeckoInstruction inst, u32 pc)
 {
-  const GekkoOPInfo* info = GetOpInfo(inst);
+  const GekkoOPInfo* info = GetOpInfo(inst, pc);
   info->stats->run_count++;
 }
 

--- a/Source/Core/Core/PowerPC/PPCTables.h
+++ b/Source/Core/Core/PowerPC/PPCTables.h
@@ -118,13 +118,13 @@ struct GekkoOPInfo
 
 namespace PPCTables
 {
-const GekkoOPInfo* GetOpInfo(UGeckoInstruction inst);
+const GekkoOPInfo* GetOpInfo(UGeckoInstruction inst, u32 pc);
 
-bool IsValidInstruction(UGeckoInstruction inst);
+bool IsValidInstruction(UGeckoInstruction inst, u32 pc);
 
-void CountInstruction(UGeckoInstruction inst);
+void CountInstruction(UGeckoInstruction inst, u32 pc);
 void CountInstructionCompile(const GekkoOPInfo* info, u32 pc);
 void PrintInstructionRunCounts();
 void LogCompiledInstructions();
-const char* GetInstructionName(UGeckoInstruction inst);
+const char* GetInstructionName(UGeckoInstruction inst, u32 pc);
 }  // namespace PPCTables

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -645,7 +645,7 @@ void CheckBreakPoints()
 {
   const TBreakPoint* bp = PowerPC::breakpoints.GetBreakpoint(PowerPC::ppcState.pc);
 
-  if (!bp || !bp->is_enabled || !EvaluateCondition(bp->condition))
+  if (!bp || !bp->is_enabled || !EvaluateCondition(Core::System::GetInstance(), bp->condition))
     return;
 
   if (bp->break_on_hit)

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -18,7 +18,8 @@ class QShowEvent;
 namespace Core
 {
 class CPUThreadGuard;
-};
+class System;
+}  // namespace Core
 
 struct CodeViewBranch;
 class BranchDisplayDelegate;
@@ -97,6 +98,8 @@ private:
   void OnRestoreInstruction();
 
   void CalculateBranchIndentation();
+
+  Core::System& m_system;
 
   bool m_updating = false;
 

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -22,6 +22,10 @@ namespace Common
 {
 struct Symbol;
 }
+namespace Core
+{
+class System;
+}
 
 class CodeWidget : public QDockWidget
 {
@@ -65,6 +69,8 @@ private:
 
   void closeEvent(QCloseEvent*) override;
   void showEvent(QShowEvent* event) override;
+
+  Core::System& m_system;
 
   CodeDiffDialog* m_diff_dialog = nullptr;
   QLineEdit* m_search_address;

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -20,7 +20,8 @@
 #include "DolphinQt/Host.h"
 #include "DolphinQt/Settings.h"
 
-RegisterWidget::RegisterWidget(QWidget* parent) : QDockWidget(parent)
+RegisterWidget::RegisterWidget(QWidget* parent)
+    : QDockWidget(parent), m_system(Core::System::GetInstance())
 {
   setWindowTitle(tr("Registers"));
   setObjectName(QStringLiteral("registers"));
@@ -295,8 +296,8 @@ void RegisterWidget::AutoStep(const std::string& reg) const
 
   while (true)
   {
-    const AutoStepResults results = [&trace] {
-      Core::CPUThreadGuard guard(Core::System::GetInstance());
+    const AutoStepResults results = [this, &trace] {
+      Core::CPUThreadGuard guard(m_system);
       return trace.AutoStepping(guard, true);
     }();
 
@@ -318,18 +319,19 @@ void RegisterWidget::PopulateTable()
   {
     // General purpose registers (int)
     AddRegister(
-        i, 0, RegisterType::gpr, "r" + std::to_string(i), [i] { return PowerPC::ppcState.gpr[i]; },
-        [i](u64 value) { PowerPC::ppcState.gpr[i] = value; });
+        i, 0, RegisterType::gpr, "r" + std::to_string(i),
+        [this, i] { return m_system.GetPPCState().gpr[i]; },
+        [this, i](u64 value) { m_system.GetPPCState().gpr[i] = value; });
 
     // Floating point registers (double)
     AddRegister(
         i, 2, RegisterType::fpr, "f" + std::to_string(i),
-        [i] { return PowerPC::ppcState.ps[i].PS0AsU64(); },
-        [i](u64 value) { PowerPC::ppcState.ps[i].SetPS0(value); });
+        [this, i] { return m_system.GetPPCState().ps[i].PS0AsU64(); },
+        [this, i](u64 value) { m_system.GetPPCState().ps[i].SetPS0(value); });
 
     AddRegister(
-        i, 4, RegisterType::fpr, "", [i] { return PowerPC::ppcState.ps[i].PS1AsU64(); },
-        [i](u64 value) { PowerPC::ppcState.ps[i].SetPS1(value); });
+        i, 4, RegisterType::fpr, "", [this, i] { return m_system.GetPPCState().ps[i].PS1AsU64(); },
+        [this, i](u64 value) { m_system.GetPPCState().ps[i].SetPS1(value); });
   }
 
   // The IBAT and DBAT registers have a large gap between
@@ -340,32 +342,36 @@ void RegisterWidget::PopulateTable()
     // IBAT registers
     AddRegister(
         i, 5, RegisterType::ibat, "IBAT" + std::to_string(i),
-        [i] {
-          return (static_cast<u64>(PowerPC::ppcState.spr[SPR_IBAT0U + i * 2]) << 32) +
-                 PowerPC::ppcState.spr[SPR_IBAT0L + i * 2];
+        [this, i] {
+          const auto& ppc_state = m_system.GetPPCState();
+          return (static_cast<u64>(ppc_state.spr[SPR_IBAT0U + i * 2]) << 32) +
+                 ppc_state.spr[SPR_IBAT0L + i * 2];
         },
         nullptr);
     AddRegister(
         i + 4, 5, RegisterType::ibat, "IBAT" + std::to_string(4 + i),
-        [i] {
-          return (static_cast<u64>(PowerPC::ppcState.spr[SPR_IBAT4U + i * 2]) << 32) +
-                 PowerPC::ppcState.spr[SPR_IBAT4L + i * 2];
+        [this, i] {
+          const auto& ppc_state = m_system.GetPPCState();
+          return (static_cast<u64>(ppc_state.spr[SPR_IBAT4U + i * 2]) << 32) +
+                 ppc_state.spr[SPR_IBAT4L + i * 2];
         },
         nullptr);
 
     // DBAT registers
     AddRegister(
         i + 8, 5, RegisterType::dbat, "DBAT" + std::to_string(i),
-        [i] {
-          return (static_cast<u64>(PowerPC::ppcState.spr[SPR_DBAT0U + i * 2]) << 32) +
-                 PowerPC::ppcState.spr[SPR_DBAT0L + i * 2];
+        [this, i] {
+          const auto& ppc_state = m_system.GetPPCState();
+          return (static_cast<u64>(ppc_state.spr[SPR_DBAT0U + i * 2]) << 32) +
+                 ppc_state.spr[SPR_DBAT0L + i * 2];
         },
         nullptr);
     AddRegister(
         i + 12, 5, RegisterType::dbat, "DBAT" + std::to_string(4 + i),
-        [i] {
-          return (static_cast<u64>(PowerPC::ppcState.spr[SPR_DBAT4U + i * 2]) << 32) +
-                 PowerPC::ppcState.spr[SPR_DBAT4L + i * 2];
+        [this, i] {
+          const auto& ppc_state = m_system.GetPPCState();
+          return (static_cast<u64>(ppc_state.spr[SPR_DBAT4U + i * 2]) << 32) +
+                 ppc_state.spr[SPR_DBAT4L + i * 2];
         },
         nullptr);
   }
@@ -375,29 +381,30 @@ void RegisterWidget::PopulateTable()
     // Graphics quantization registers
     AddRegister(
         i + 16, 7, RegisterType::gqr, "GQR" + std::to_string(i),
-        [i] { return PowerPC::ppcState.spr[SPR_GQR0 + i]; }, nullptr);
+        [this, i] { return m_system.GetPPCState().spr[SPR_GQR0 + i]; }, nullptr);
   }
 
   // HID registers
   AddRegister(
-      24, 7, RegisterType::hid, "HID0", [] { return PowerPC::ppcState.spr[SPR_HID0]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_HID0] = static_cast<u32>(value); });
+      24, 7, RegisterType::hid, "HID0", [this] { return m_system.GetPPCState().spr[SPR_HID0]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_HID0] = static_cast<u32>(value); });
   AddRegister(
-      25, 7, RegisterType::hid, "HID1", [] { return PowerPC::ppcState.spr[SPR_HID1]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_HID1] = static_cast<u32>(value); });
+      25, 7, RegisterType::hid, "HID1", [this] { return m_system.GetPPCState().spr[SPR_HID1]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_HID1] = static_cast<u32>(value); });
   AddRegister(
-      26, 7, RegisterType::hid, "HID2", [] { return PowerPC::ppcState.spr[SPR_HID2]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_HID2] = static_cast<u32>(value); });
+      26, 7, RegisterType::hid, "HID2", [this] { return m_system.GetPPCState().spr[SPR_HID2]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_HID2] = static_cast<u32>(value); });
   AddRegister(
-      27, 7, RegisterType::hid, "HID4", [] { return PowerPC::ppcState.spr[SPR_HID4]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_HID4] = static_cast<u32>(value); });
+      27, 7, RegisterType::hid, "HID4", [this] { return m_system.GetPPCState().spr[SPR_HID4]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_HID4] = static_cast<u32>(value); });
 
   for (int i = 0; i < 16; i++)
   {
     // SR registers
     AddRegister(
-        i, 7, RegisterType::sr, "SR" + std::to_string(i), [i] { return PowerPC::ppcState.sr[i]; },
-        [i](u64 value) { PowerPC::ppcState.sr[i] = value; });
+        i, 7, RegisterType::sr, "SR" + std::to_string(i),
+        [this, i] { return m_system.GetPPCState().sr[i]; },
+        [this, i](u64 value) { m_system.GetPPCState().sr[i] = value; });
   }
 
   // Special registers
@@ -406,83 +413,79 @@ void RegisterWidget::PopulateTable()
 
   // PC
   AddRegister(
-      17, 5, RegisterType::pc, "PC", [] { return PowerPC::ppcState.pc; },
-      [](u64 value) { PowerPC::ppcState.pc = value; });
+      17, 5, RegisterType::pc, "PC", [this] { return m_system.GetPPCState().pc; },
+      [this](u64 value) { m_system.GetPPCState().pc = value; });
 
   // LR
   AddRegister(
-      18, 5, RegisterType::lr, "LR", [] { return PowerPC::ppcState.spr[SPR_LR]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_LR] = value; });
+      18, 5, RegisterType::lr, "LR", [this] { return m_system.GetPPCState().spr[SPR_LR]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_LR] = value; });
 
   // CTR
   AddRegister(
-      19, 5, RegisterType::ctr, "CTR", [] { return PowerPC::ppcState.spr[SPR_CTR]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_CTR] = value; });
+      19, 5, RegisterType::ctr, "CTR", [this] { return m_system.GetPPCState().spr[SPR_CTR]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_CTR] = value; });
 
   // CR
   AddRegister(
-      20, 5, RegisterType::cr, "CR", [] { return PowerPC::ppcState.cr.Get(); },
-      [](u64 value) { PowerPC::ppcState.cr.Set(value); });
+      20, 5, RegisterType::cr, "CR", [this] { return m_system.GetPPCState().cr.Get(); },
+      [this](u64 value) { m_system.GetPPCState().cr.Set(value); });
 
   // XER
   AddRegister(
-      21, 5, RegisterType::xer, "XER", [] { return PowerPC::ppcState.GetXER().Hex; },
-      [](u64 value) { PowerPC::ppcState.SetXER(UReg_XER(value)); });
+      21, 5, RegisterType::xer, "XER", [this] { return m_system.GetPPCState().GetXER().Hex; },
+      [this](u64 value) { m_system.GetPPCState().SetXER(UReg_XER(value)); });
 
   // FPSCR
   AddRegister(
-      22, 5, RegisterType::fpscr, "FPSCR", [] { return PowerPC::ppcState.fpscr.Hex; },
-      [](u64 value) { PowerPC::ppcState.fpscr = static_cast<u32>(value); });
+      22, 5, RegisterType::fpscr, "FPSCR", [this] { return m_system.GetPPCState().fpscr.Hex; },
+      [this](u64 value) { m_system.GetPPCState().fpscr = static_cast<u32>(value); });
 
   // MSR
   AddRegister(
-      23, 5, RegisterType::msr, "MSR", [] { return PowerPC::ppcState.msr.Hex; },
-      [](u64 value) { PowerPC::ppcState.msr.Hex = value; });
+      23, 5, RegisterType::msr, "MSR", [this] { return m_system.GetPPCState().msr.Hex; },
+      [this](u64 value) { m_system.GetPPCState().msr.Hex = value; });
 
   // SRR 0-1
   AddRegister(
-      24, 5, RegisterType::srr, "SRR0", [] { return PowerPC::ppcState.spr[SPR_SRR0]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_SRR0] = value; });
+      24, 5, RegisterType::srr, "SRR0", [this] { return m_system.GetPPCState().spr[SPR_SRR0]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_SRR0] = value; });
   AddRegister(
-      25, 5, RegisterType::srr, "SRR1", [] { return PowerPC::ppcState.spr[SPR_SRR1]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_SRR1] = value; });
+      25, 5, RegisterType::srr, "SRR1", [this] { return m_system.GetPPCState().spr[SPR_SRR1]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_SRR1] = value; });
 
   // Exceptions
   AddRegister(
-      26, 5, RegisterType::exceptions, "Exceptions", [] { return PowerPC::ppcState.Exceptions; },
-      [](u64 value) { PowerPC::ppcState.Exceptions = value; });
+      26, 5, RegisterType::exceptions, "Exceptions",
+      [this] { return m_system.GetPPCState().Exceptions; },
+      [this](u64 value) { m_system.GetPPCState().Exceptions = value; });
 
   // Int Mask
   AddRegister(
       27, 5, RegisterType::int_mask, "Int Mask",
-      [] {
-        auto& system = Core::System::GetInstance();
-        return system.GetProcessorInterface().GetMask();
-      },
-      nullptr);
+      [this] { return m_system.GetProcessorInterface().GetMask(); }, nullptr);
 
   // Int Cause
   AddRegister(
       28, 5, RegisterType::int_cause, "Int Cause",
-      [] {
-        auto& system = Core::System::GetInstance();
-        return system.GetProcessorInterface().GetCause();
-      },
-      nullptr);
+      [this] { return m_system.GetProcessorInterface().GetCause(); }, nullptr);
 
   // DSISR
   AddRegister(
-      29, 5, RegisterType::dsisr, "DSISR", [] { return PowerPC::ppcState.spr[SPR_DSISR]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_DSISR] = value; });
+      29, 5, RegisterType::dsisr, "DSISR", [this] { return m_system.GetPPCState().spr[SPR_DSISR]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_DSISR] = value; });
   // DAR
   AddRegister(
-      30, 5, RegisterType::dar, "DAR", [] { return PowerPC::ppcState.spr[SPR_DAR]; },
-      [](u64 value) { PowerPC::ppcState.spr[SPR_DAR] = value; });
+      30, 5, RegisterType::dar, "DAR", [this] { return m_system.GetPPCState().spr[SPR_DAR]; },
+      [this](u64 value) { m_system.GetPPCState().spr[SPR_DAR] = value; });
 
   // Hash Mask
   AddRegister(
       31, 5, RegisterType::pt_hashmask, "Hash Mask",
-      [] { return (PowerPC::ppcState.pagetable_hashmask << 6) | PowerPC::ppcState.pagetable_base; },
+      [this] {
+        const auto& ppc_state = m_system.GetPPCState();
+        return (ppc_state.pagetable_hashmask << 6) | ppc_state.pagetable_base;
+      },
       nullptr);
 
   emit RequestTableUpdate();

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.h
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.h
@@ -13,6 +13,10 @@
 class QTableWidget;
 class QCloseEvent;
 class QShowEvent;
+namespace Core
+{
+class System;
+}
 
 class RegisterWidget : public QDockWidget
 {
@@ -48,6 +52,8 @@ private:
 
   void AutoStep(const std::string& reg) const;
   void Update();
+
+  Core::System& m_system;
 
   QTableWidget* m_table;
   bool m_updating = false;

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1699,7 +1699,7 @@ void MenuBar::SearchInstruction()
        addr += 4)
   {
     const auto ins_name = QString::fromStdString(
-        PPCTables::GetInstructionName(PowerPC::MMU::HostRead_U32(guard, addr)));
+        PPCTables::GetInstructionName(PowerPC::MMU::HostRead_U32(guard, addr), addr));
     if (op == ins_name)
     {
       NOTICE_LOG_FMT(POWERPC, "Found {} at {:08x}", op.toStdString(), addr);

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -637,7 +637,8 @@ void CommandProcessorManager::SetCpClearRegister()
 {
 }
 
-void CommandProcessorManager::HandleUnknownOpcode(u8 cmd_byte, const u8* buffer, bool preprocess)
+void CommandProcessorManager::HandleUnknownOpcode(Core::System& system, u8 cmd_byte,
+                                                  const u8* buffer, bool preprocess)
 {
   const auto& fifo = m_fifo;
 
@@ -665,6 +666,7 @@ void CommandProcessorManager::HandleUnknownOpcode(u8 cmd_byte, const u8* buffer,
   // PC and LR are meaningless when using the fifoplayer, and will generally not be helpful if the
   // unknown opcode is inside of a display list.  Also note that the changes in GPFifo.h are not
   // accurate and may introduce timing issues.
+  const auto& ppc_state = system.GetPPCState();
   GENERIC_LOG_FMT(
       Common::Log::LogType::VIDEO, log_level,
       "FIFO: Unknown Opcode {:#04x} @ {}, preprocessing = {}, CPBase: {:#010x}, CPEnd: "
@@ -686,8 +688,8 @@ void CommandProcessorManager::HandleUnknownOpcode(u8 cmd_byte, const u8* buffer,
       fifo.bFF_Breakpoint.load(std::memory_order_relaxed) ? "true" : "false",
       fifo.bFF_GPLinkEnable.load(std::memory_order_relaxed) ? "true" : "false",
       fifo.bFF_HiWatermarkInt.load(std::memory_order_relaxed) ? "true" : "false",
-      fifo.bFF_LoWatermarkInt.load(std::memory_order_relaxed) ? "true" : "false",
-      PowerPC::ppcState.pc, LR(PowerPC::ppcState));
+      fifo.bFF_LoWatermarkInt.load(std::memory_order_relaxed) ? "true" : "false", ppc_state.pc,
+      LR(ppc_state));
 
   if (!m_is_fifo_error_seen && !suppress_panic_alert)
   {

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -177,7 +177,7 @@ public:
   void SetCpControlRegister(Core::System& system);
   void SetCpStatusRegister(Core::System& system);
 
-  void HandleUnknownOpcode(u8 cmd_byte, const u8* buffer, bool preprocess);
+  void HandleUnknownOpcode(Core::System& system, u8 cmd_byte, const u8* buffer, bool preprocess);
 
   // This one is shared between gfx thread and emulator thread.
   // It is only used by the Fifo and by the CommandProcessor.

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -219,8 +219,8 @@ public:
     }
     else
     {
-      Core::System::GetInstance().GetCommandProcessor().HandleUnknownOpcode(opcode, data,
-                                                                            is_preprocess);
+      auto& system = Core::System::GetInstance();
+      system.GetCommandProcessor().HandleUnknownOpcode(system, opcode, data, is_preprocess);
       m_cycles += 1;
     }
   }

--- a/Source/UnitTests/Core/PowerPC/JitArm64/Fres.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/Fres.cpp
@@ -34,7 +34,7 @@ public:
     fres = Common::BitCast<u64 (*)(u64)>(GetCodePtr());
     MOV(ARM64Reg::X15, ARM64Reg::X30);
     MOV(ARM64Reg::X14, PPC_REG);
-    MOVP2R(PPC_REG, &PowerPC::ppcState);
+    MOVP2R(PPC_REG, &system.GetPPCState());
     MOV(ARM64Reg::X1, ARM64Reg::X0);
     m_float_emit.FMOV(ARM64Reg::D0, ARM64Reg::X0);
     m_float_emit.FRECPE(ARM64Reg::D0, ARM64Reg::D0);

--- a/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
@@ -34,7 +34,7 @@ public:
     frsqrte = Common::BitCast<u64 (*)(u64)>(GetCodePtr());
     MOV(ARM64Reg::X15, ARM64Reg::X30);
     MOV(ARM64Reg::X14, PPC_REG);
-    MOVP2R(PPC_REG, &PowerPC::ppcState);
+    MOVP2R(PPC_REG, &system.GetPPCState());
     MOV(ARM64Reg::X1, ARM64Reg::X0);
     m_float_emit.FMOV(ARM64Reg::D0, ARM64Reg::X0);
     m_float_emit.FRSQRTE(ARM64Reg::D0, ARM64Reg::D0);


### PR DESCRIPTION
The only remaining one are the reference in `System` and the references in `PowerPC.cpp`, which will be replaced when refactoring `PowerPC.cpp` to a class.