### PR TITLE
HookableEvent: Use std::recursive_mutex instead of std::mutex

### DIFF
--- a/Source/Core/Common/HookableEvent.h
+++ b/Source/Core/Common/HookableEvent.h
@@ -69,7 +69,7 @@ private:
 
   struct Storage
   {
-    std::mutex m_mutex;
+    std::recursive_mutex m_mutex;
     std::vector<HookImpl*> m_listeners;
   };
 


### PR DESCRIPTION
This fixes a crash when recording fifologs, as the mutex is [acquired](https://github.com/dolphin-emu/dolphin/blob/0cd70c2aa51ce09460a9027199b422f787d80ffe/Source/Core/Common/HookableEvent.h#L105-L108) when [`BPWritten` calls `AfterFrameEvent::Trigger`](https://github.com/dolphin-emu/dolphin/blob/0cd70c2aa51ce09460a9027199b422f787d80ffe/Source/Core/VideoCommon/BPStructs.cpp#L351), but then acquired again when [`FifoRecorder::EndFrame` calls `m_end_of_frame_event.reset()`](https://github.com/dolphin-emu/dolphin/blob/0cd70c2aa51ce09460a9027199b422f787d80ffe/Source/Core/Core/FifoPlayer/FifoRecorder.cpp#L437). [`std::mutex`](https://en.cppreference.com/w/cpp/thread/mutex) does not allow calling `lock()` if the thread already owns the mutex, while [`std::recursive_mutex`](https://en.cppreference.com/w/cpp/thread/recursive_mutex) does allow this.

This is a regression from #11522 (which introduced the HookableEvent system).