### PR TITLE
DolphinQt: RenderWidget fix heap-use-after-free

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -488,10 +488,11 @@ void RenderWidget::PassEventToPresenter(const QEvent* event)
     const u32 key = static_cast<u32>(key_event->key() & 0x1FF);
 
     const char* chars = nullptr;
+    QByteArray utf8;
 
     if (is_down)
     {
-      auto utf8 = key_event->text().toUtf8();
+      utf8 = key_event->text().toUtf8();
 
       if (utf8.size())
         chars = utf8.constData();


### PR DESCRIPTION
The `QByteArray` returned by `QString::toUtf8()` was being freed so the char pointer was pointing to freed memory.

Found via ASan, didn't notice any issues during normal runtime.

This was triggered after hitting a key combo with alt (ex. toggle fullscreen) probably happens with others

```
=================================================================
==411946==ERROR: AddressSanitizer: heap-use-after-free on address 0x603000401968 at pc 0x55fa9385d2f5 bp 0x7ffc5a78c790 sp 0x7ffc5a78c788
READ of size 1 at 0x603000401968 thread T0
    #0 0x55fa9385d2f4 in ImGuiIO::AddInputCharactersUTF8(char const*) /home/user/projects/dolphin/Externals/imgui/imgui.cpp:1176:12
    #1 0x55fa93e9d0ed in VideoCommon::OnScreenUI::SetKey(unsigned int, bool, char const*) /home/user/projects/dolphin/Source/Core/VideoCommon/OnScreenUI.cpp:383:20
    #2 0x55fa92e811f7 in RenderWidget::PassEventToPresenter(QEvent const*) /home/user/projects/dolphin/Source/Core/DolphinQt/RenderWidget.cpp:501:18
    #3 0x55fa92e8067b in RenderWidget::event(QEvent*) /home/user/projects/dolphin/Source/Core/DolphinQt/RenderWidget.cpp:340:3
    #4 0x7fafff71057d in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/lib64/libQt5Widgets.so.5+0x16357d)
    #5 0x7fafff718614 in QApplication::notify(QObject*, QEvent*) (/usr/lib64/libQt5Widgets.so.5+0x16b614)
    #6 0x7faffcd7c0b7 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (/usr/lib64/libQt5Core.so.5+0x2850b7)
    #7 0x7fafff771691  (/usr/lib64/libQt5Widgets.so.5+0x1c4691)
    #8 0x7fafff71057d in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/lib64/libQt5Widgets.so.5+0x16357d)
    #9 0x7faffcd7c0b7 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (/usr/lib64/libQt5Core.so.5+0x2850b7)
    #10 0x7faffd17e208 in QGuiApplicationPrivate::processKeyEvent(QWindowSystemInterfacePrivate::KeyEvent*) (/usr/lib64/libQt5Gui.so.5+0x124208)
    #11 0x7faffd16008a in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib64/libQt5Gui.so.5+0x10608a)
    #12 0x7fafe8a16999  (/usr/lib64/libQt5XcbQpa.so.5+0x68999)
    #13 0x7faff28f122b in g_main_context_dispatch (/usr/lib64/libglib-2.0.so.0+0x5c22b)
    #14 0x7faff28f14c7  (/usr/lib64/libglib-2.0.so.0+0x5c4c7)
    #15 0x7faff28f156b in g_main_context_iteration (/usr/lib64/libglib-2.0.so.0+0x5c56b)
    #16 0x7faffcdcf3a5 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib64/libQt5Core.so.5+0x2d83a5)
    #17 0x7faffcd7a9ea in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib64/libQt5Core.so.5+0x2839ea)
    #18 0x7faffcd82faf in QCoreApplication::exec() (/usr/lib64/libQt5Core.so.5+0x28bfaf)
    #19 0x55fa92d8ae22 in main /home/user/projects/dolphin/Source/Core/DolphinQt/Main.cpp:301:14
    #20 0x7faffc7dc911  (/lib64/libc.so.6+0x27911)
    #21 0x7faffc7dc9c4 in __libc_start_main (/lib64/libc.so.6+0x279c4)
    #22 0x55fa928b31d0 in _start (/home/user/projects/dolphin/Build/Binaries/dolphin-emu+0x5191d0)

0x603000401968 is located 24 bytes inside of 28-byte region [0x603000401950,0x60300040196c)
freed by thread T0 here:
    #0 0x55fa92a20666 in __interceptor_free (/home/user/projects/dolphin/Build/Binaries/dolphin-emu+0x686666)
    #1 0x55fa92e811b7 in QTypedArrayData<char>::deallocate(QArrayData*) /usr/include/qt5/QtCore/qarraydata.h:240:9
    #2 0x55fa92e811b7 in QByteArray::~QByteArray() /usr/include/qt5/QtCore/qbytearray.h:495:57
    #3 0x55fa92e811b7 in RenderWidget::PassEventToPresenter(QEvent const*) /home/user/projects/dolphin/Source/Core/DolphinQt/RenderWidget.cpp:498:5
    #4 0x55fa92e8067b in RenderWidget::event(QEvent*) /home/user/projects/dolphin/Source/Core/DolphinQt/RenderWidget.cpp:340:3
    #5 0x7fafff71057d in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/lib64/libQt5Widgets.so.5+0x16357d)

previously allocated by thread T0 here:
    #0 0x55fa92a2090e in malloc (/home/user/projects/dolphin/Build/Binaries/dolphin-emu+0x68690e)
    #1 0x7faffcbce7a1 in QArrayData::allocate(unsigned long, unsigned long, unsigned long, QFlags<QArrayData::AllocationOption>) (/usr/lib64/libQt5Core.so.5+0xd77a1)

SUMMARY: AddressSanitizer: heap-use-after-free /home/user/projects/dolphin/Externals/imgui/imgui.cpp:1176:12 in ImGuiIO::AddInputCharactersUTF8(char const*)
Shadow bytes around the buggy address:
  0x603000401680: fd fd fd fa fa fa fd fd fd fd fa fa fd fd fd fd
  0x603000401700: fa fa fd fd fd fd fa fa fd fd fd fa fa fa fd fd
  0x603000401780: fd fa fa fa fd fd fd fa fa fa fd fd fd fa fa fa
  0x603000401800: fd fd fd fa fa fa fd fd fd fd fa fa fd fd fd fa
  0x603000401880: fa fa fa fa fa fa fa fa fd fd fd fd fa fa fd fd
=>0x603000401900: fd fa fa fa fd fd fd fa fa fa fd fd fd[fd]fa fa
  0x603000401980: fa fa fa fa fa fa fd fd fd fd fa fa fa fa fa fa
  0x603000401a00: fa fa fd fd fd fa fa fa fa fa fa fa fa fa fd fd
  0x603000401a80: fd fd fa fa fd fd fd fd fa fa fd fd fd fa fa fa
  0x603000401b00: fd fd fd fd fa fa fd fd fd fa fa fa fd fd fd fd
  0x603000401b80: fa fa fd fd fd fa fa fa fd fd fd fd fa fa fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==411946==ABORTING
```