### PR TITLE
IOS/Network/KD: Reload DLList on call to DownloadNowEx

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -233,6 +233,7 @@ NWC24::ErrorCode NetKDRequestDevice::KDDownload(const u16 entry_index,
 
 IPCReply NetKDRequestDevice::HandleNWC24DownloadNowEx(const IOCtlRequest& request)
 {
+  m_dl_list.ReadDlList();
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   const u32 flags = memory.Read_U32(request.buffer_in);


### PR DESCRIPTION
WiiConnect24 Channels will correct their entry in the DLList if needed before their call to `DownloadNowEx`.

Since we load the DLList on IOS reload, these changes are not reflected until next IOS reload.