### PR TITLE
DolphinQt: LogConfigWidget fix leak of unused widget

### DIFF
--- a/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
@@ -33,6 +33,10 @@ LogConfigWidget::LogConfigWidget(QWidget* parent) : QDockWidget(parent)
 LogConfigWidget::~LogConfigWidget()
 {
   SaveSettings();
+  if constexpr (Common::Log::MAX_LOGLEVEL != Common::Log::LogLevel::LDEBUG)
+  {
+    delete m_verbosity_debug;
+  }
 }
 
 void LogConfigWidget::CreateWidgets()


### PR DESCRIPTION
Since the `m_verbose_debug` is only conditionally set added as a widget, it will only conditionally be managed by the layout. So let's delete the `QRadioButton` if necessary.

```
Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x55b7bf3f427d in operator new(unsigned long) (/home/user/projects/dolphin/Build/Binaries/dolphin-emu+0x6c427d)
    #1 0x55b7bf4f4934 in LogConfigWidget::CreateWidgets() /home/user/projects/dolphin/Source/Core/DolphinQt/Config/LogConfigWidget.cpp:49:23
    #2 0x55b7bf4f420e in LogConfigWidget::LogConfigWidget(QWidget*) /home/user/projects/dolphin/Source/Core/DolphinQt/Config/LogConfigWidget.cpp:28:3
    #3 0x55b7bf7271c8 in MainWindow::CreateComponents() /home/user/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:416:29
    #4 0x55b7bf724cb2 in MainWindow::MainWindow(std::unique_ptr<BootParameters, std::default_delete<BootParameters>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/user/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:225:3
    #5 0x55b7bf72069a in main /home/user/projects/dolphin/Source/Core/DolphinQt/Main.cpp:258:16
    #6 0x7f37ba8c5911  (/lib64/libc.so.6+0x27911)
    #7 0x7f37ba8c59c4 in __libc_start_main (/lib64/libc.so.6+0x279c4)

```