### PR TITLE
DolphinQt: Fix memory leaks

### DIFF
--- a/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
@@ -62,6 +62,7 @@ void FilesystemWidget::CreateWidgets()
   m_tree_view = new QTreeView(this);
   m_tree_view->setModel(m_tree_model);
   m_tree_view->setContextMenuPolicy(Qt::CustomContextMenu);
+  m_tree_model->setParent(m_tree_view);
 
   auto* header = m_tree_view->header();
 

--- a/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
@@ -47,6 +47,7 @@ void LogConfigWidget::CreateWidgets()
   m_verbosity_warning = new QRadioButton(tr("Warning"));
   m_verbosity_info = new QRadioButton(tr("Info"));
   m_verbosity_debug = new QRadioButton(tr("Debug"));
+  m_verbosity_debug->setVisible(Common::Log::MAX_LOGLEVEL == Common::Log::LogLevel::LDEBUG);
 
   auto* outputs = new QGroupBox(tr("Logger Outputs"));
   auto* outputs_layout = new QVBoxLayout;
@@ -77,10 +78,7 @@ void LogConfigWidget::CreateWidgets()
   verbosity_layout->addWidget(m_verbosity_error);
   verbosity_layout->addWidget(m_verbosity_warning);
   verbosity_layout->addWidget(m_verbosity_info);
-  if constexpr (Common::Log::MAX_LOGLEVEL == Common::Log::LogLevel::LDEBUG)
-  {
-    verbosity_layout->addWidget(m_verbosity_debug);
-  }
+  verbosity_layout->addWidget(m_verbosity_debug);
 
   layout->addWidget(outputs);
   outputs_layout->addWidget(m_out_file);

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -249,12 +249,12 @@ void MemoryWidget::CreateWidgets()
   QMenuBar* menubar = new QMenuBar(sidebar);
   menubar->setNativeMenuBar(false);
 
-  QMenu* menu_import = new QMenu(tr("&Import"));
+  QMenu* menu_import = new QMenu(tr("&Import"), menubar);
   menu_import->addAction(tr("&Load file to current address"), this,
                          &MemoryWidget::OnSetValueFromFile);
   menubar->addMenu(menu_import);
 
-  QMenu* menu_export = new QMenu(tr("&Export"));
+  QMenu* menu_export = new QMenu(tr("&Export"), menubar);
   menu_export->addAction(tr("Dump &MRAM"), this, &MemoryWidget::OnDumpMRAM);
   menu_export->addAction(tr("Dump &ExRAM"), this, &MemoryWidget::OnDumpExRAM);
   menu_export->addAction(tr("Dump &ARAM"), this, &MemoryWidget::OnDumpARAM);

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -189,7 +189,8 @@ void InterfacePane::CreateInGame()
   m_vboxlayout_hide_mouse->addWidget(m_radio_cursor_visible_never);
   m_vboxlayout_hide_mouse->addWidget(m_radio_cursor_visible_always);
 
-  m_checkbox_lock_mouse = new QCheckBox(tr("Lock Mouse Cursor"));
+  // this ends up not being managed unless _WIN32, so lets not leak
+  m_checkbox_lock_mouse = new QCheckBox(tr("Lock Mouse Cursor"), this);
   m_checkbox_lock_mouse->setToolTip(tr("Will lock the Mouse Cursor to the Render Widget as long as "
                                        "it has focus. You can set a hotkey to unlock it."));
 


### PR DESCRIPTION
Various objects didn't have expected parent management or only conditionally used, resulting in them not being managed and leaking


```
Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x559caf9473dd in operator new(unsigned long) (/home/user/projects/dolphin/Build/Binaries/dolphin-emu+0x6c73dd)
    #1 0x559caf9c48cf in FilesystemWidget::CreateWidgets() /home/user/projects/dolphin/Source/Core/DolphinQt/Config/FilesystemWidget.cpp:59:18
    #2 0x559caf9c453b in FilesystemWidget::FilesystemWidget(std::shared_ptr<DiscIO::Volume>) /home/user/projects/dolphin/Source/Core/DolphinQt/Config/FilesystemWidget.cpp:48:3
    #3 0x559cafabacb2 in PropertiesDialog::PropertiesDialog(QWidget*, UICommon::GameFile const&) /home/user/projects/dolphin/Source/Core/DolphinQt/Config/PropertiesDialog.cpp:81:44
    #4 0x559cafc101a0 in GameList::OpenProperties() /home/user/projects/dolphin/Source/Core/DolphinQt/GameList/GameList.cpp:540:38
    #5 0x7fddd30767db  (/usr/lib64/libQt5Core.so.5+0x2b97db)
    #6 0x7fddd59cf7e1 in QAction::triggered(bool) (/usr/lib64/libQt5Widgets.so.5+0x15c7e1)
```
```
Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x55b7bf3f427d in operator new(unsigned long) (/home/user/projects/dolphin/Build/Binaries/dolphin-emu+0x6c427d)
    #1 0x55b7bf4f4934 in LogConfigWidget::CreateWidgets() /home/user/projects/dolphin/Source/Core/DolphinQt/Config/LogConfigWidget.cpp:49:23
    #2 0x55b7bf4f420e in LogConfigWidget::LogConfigWidget(QWidget*) /home/user/projects/dolphin/Source/Core/DolphinQt/Config/LogConfigWidget.cpp:28:3
    #3 0x55b7bf7271c8 in MainWindow::CreateComponents() /home/user/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:416:29
    #4 0x55b7bf724cb2 in MainWindow::MainWindow(std::unique_ptr<BootParameters, std::default_delete<BootParameters>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/user/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:225:3
    #5 0x55b7bf72069a in main /home/user/projects/dolphin/Source/Core/DolphinQt/Main.cpp:258:16
    #6 0x7f37ba8c5911  (/lib64/libc.so.6+0x27911)
    #7 0x7f37ba8c59c4 in __libc_start_main (/lib64/libc.so.6+0x279c4)
```
```
Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x559d685823dd in operator new(unsigned long) (/home/user/projects/dolphin/Build/Binaries/dolphin-emu+0x6c73dd)
    #1 0x559d68a5c49e in InterfacePane::CreateInGame() /home/user/projects/dolphin/Source/Core/DolphinQt/Settings/InterfacePane.cpp:193:27
    #2 0x559d68a5491a in InterfacePane::CreateLayout() /home/user/projects/dolphin/Source/Core/DolphinQt/Settings/InterfacePane.cpp:94:3
    #3 0x559d68a5491a in InterfacePane::InterfacePane(QWidget*) /home/user/projects/dolphin/Source/Core/DolphinQt/Settings/InterfacePane.cpp:84:3
    #4 0x559d688ce5b1 in MainWindow::ShowSettingsWindow() /home/user/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:1225:29
    #5 0x7f3b6f9587db  (/usr/lib64/libQt5Core.so.5+0x2b97db)
    #6 0x7f3b722b17e1 in QAction::triggered(bool) (/usr/lib64/libQt5Widgets.so.5+0x15c7e1)
```
```
Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x5621ae3543dd in operator new(unsigned long) (/home/user/projects/dolphin/Build/Binaries/dolphin-emu+0x6c73dd)
    #1 0x5621ae59581a in MemoryWidget::CreateWidgets() /home/user/projects/dolphin/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp:252:24
    #2 0x5621ae590be3 in MemoryWidget::MemoryWidget(QWidget*) /home/user/projects/dolphin/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp:52:3
    #3 0x5621ae6872e2 in MainWindow::CreateComponents() /home/user/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:427:25
    #4 0x5621ae684d8f in MainWindow::MainWindow(std::unique_ptr<BootParameters, std::default_delete<BootParameters>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/user/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:231:3
    #5 0x5621ae68076a in main /home/user/projects/dolphin/Source/Core/DolphinQt/Main.cpp:258:16
    #6 0x7f987b61f911  (/lib64/libc.so.6+0x27911)
    #7 0x7f987b61f9c4 in __libc_start_main (/lib64/libc.so.6+0x279c4)
```
```
Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x5621ae3543dd in operator new(unsigned long) (/home/user/projects/dolphin/Build/Binaries/dolphin-emu+0x6c73dd)
    #1 0x5621ae595b7f in MemoryWidget::CreateWidgets() /home/user/projects/dolphin/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp:257:24
    #2 0x5621ae590be3 in MemoryWidget::MemoryWidget(QWidget*) /home/user/projects/dolphin/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp:52:3
    #3 0x5621ae6872e2 in MainWindow::CreateComponents() /home/user/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:427:25
    #4 0x5621ae684d8f in MainWindow::MainWindow(std::unique_ptr<BootParameters, std::default_delete<BootParameters>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/user/projects/dolphin/Source/Core/DolphinQt/MainWindow.cpp:231:3
    #5 0x5621ae68076a in main /home/user/projects/dolphin/Source/Core/DolphinQt/Main.cpp:258:16
    #6 0x7f987b61f911  (/lib64/libc.so.6+0x27911)
    #7 0x7f987b61f9c4 in __libc_start_main (/lib64/libc.so.6+0x279c4)
```