### PR TITLE
DolphinQt: StickWidget and IRWidget check for changed x/y before signaling change

### DIFF
--- a/Source/Core/DolphinQt/TAS/IRWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/IRWidget.cpp
@@ -79,6 +79,9 @@ void IRWidget::mouseMoveEvent(QMouseEvent* event)
 
 void IRWidget::handleMouseEvent(QMouseEvent* event)
 {
+  u16 prev_x = m_x;
+  u16 prev_y = m_y;
+
   if (event->button() == Qt::RightButton)
   {
     m_x = std::round(ir_max_x / 2.);
@@ -94,7 +97,18 @@ void IRWidget::handleMouseEvent(QMouseEvent* event)
     m_y = std::max(0, std::min(static_cast<int>(ir_max_y), new_y));
   }
 
-  emit ChangedX(m_x);
-  emit ChangedY(m_y);
-  update();
+  bool changed = false;
+  if (prev_x != m_x)
+  {
+    emit ChangedX(m_x);
+    changed = true;
+  }
+  if (prev_y != m_y)
+  {
+    emit ChangedY(m_y);
+    changed = true;
+  }
+
+  if (changed)
+    update();
 }

--- a/Source/Core/DolphinQt/TAS/StickWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/StickWidget.cpp
@@ -82,6 +82,9 @@ void StickWidget::mouseMoveEvent(QMouseEvent* event)
 
 void StickWidget::handleMouseEvent(QMouseEvent* event)
 {
+  u16 prev_x = m_x;
+  u16 prev_y = m_y;
+
   if (event->button() == Qt::RightButton)
   {
     m_x = std::round(m_max_x / 2.);
@@ -97,7 +100,18 @@ void StickWidget::handleMouseEvent(QMouseEvent* event)
     m_y = std::max(0, std::min(static_cast<int>(m_max_y), new_y));
   }
 
-  emit ChangedX(m_x);
-  emit ChangedY(m_y);
-  update();
+  bool changed = false;
+  if (prev_x != m_x)
+  {
+    emit ChangedX(m_x);
+    changed = true;
+  }
+  if (prev_y != m_y)
+  {
+    emit ChangedY(m_y);
+    changed = true;
+  }
+
+  if (changed)
+    update();
 }


### PR DESCRIPTION
This is a pretty inconsequential change, I just noticed this as I was skimming TAS-related code.

Even if your mouse moved ever-so-slightly as to not change the x/y position of the stick, or if you held down left-click and dragged your mouse off of the stick widget, it would continuously fire the ChangedX/Y signal as well as queue up a Qt re-draw for the widget.

~~I have no idea if this actually helps performance to any noticeable degree, but I just figured this is likely more beneficial than it could be harmful.~~
This appears to reduce window latency issues encountered when holding down frame advance and rotating the stick at the same time. It does not get rid of the latency, but definitely reduces it.