### PR TITLE
[WIP] Configurable Console Type per Game

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -235,7 +235,7 @@ void CBoot::SetupGCMemory(Core::System& system, const Core::CPUThreadGuard& guar
   // Console type - DevKit  (retail ID == 0x00000003) see YAGCD 4.2.1.1.2
   // TODO: determine why some games fail when using a retail ID.
   // (Seem to take different EXI paths, see Ikaruga for example)
-  const u32 console_type = static_cast<u32>(Core::ConsoleType::LatestDevkit);
+  const u32 console_type = static_cast<u32>(Config::GetConsoleType());
   PowerPC::MMU::HostWrite_U32(guard, console_type, 0x8000002C);
 
   // Fake the VI Init of the IPL (YAGCD 4.2.1.4)

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -210,6 +210,7 @@ const Info<u32> MAIN_ARAM_EXPANSION_SIZE{{System::Main, "Core", "ARAMExpansionSi
 
 const Info<std::string> MAIN_GPU_DETERMINISM_MODE{{System::Main, "Core", "GPUDeterminismMode"},
                                                   "auto"};
+const Info<std::string> MAIN_CONSOLE_TYPE{{System::Main, "Core", "ConsoleType"}, "Latest Devkit"};
 const Info<s32> MAIN_OVERRIDE_BOOT_IOS{{System::Main, "Core", "OverrideBootIOS"}, -1};
 
 GPUDeterminismMode GetGPUDeterminismMode()
@@ -224,6 +225,18 @@ GPUDeterminismMode GetGPUDeterminismMode()
 
   NOTICE_LOG_FMT(CORE, "Unknown GPU determinism mode {}", mode);
   return GPUDeterminismMode::Auto;
+}
+
+Core::ConsoleType GetConsoleType()
+{
+  auto console_type = Config::Get(Config::MAIN_CONSOLE_TYPE);
+  if (console_type == "Latest Devkit")
+    return Core::ConsoleType::LatestDevkit;
+  if (console_type == "Latest Production Board")
+    return Core::ConsoleType::LatestProductionBoard;
+
+  NOTICE_LOG_FMT(CORE, "Unknown Console Type {}", console_type);
+  return Core::ConsoleType::LatestDevkit;
 }
 
 const Info<std::string> MAIN_PERF_MAP_DIR{{System::Main, "Core", "PerfMapDir"}, ""};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -10,6 +10,7 @@
 
 #include "Common/Common.h"
 #include "Common/Config/Config.h"
+#include "Core/Core.h"
 #include "DiscIO/Enums.h"
 
 // DSP Backend Types
@@ -137,6 +138,9 @@ enum class GPUDeterminismMode
 };
 extern const Info<std::string> MAIN_GPU_DETERMINISM_MODE;
 GPUDeterminismMode GetGPUDeterminismMode();
+
+extern const Info<std::string> MAIN_CONSOLE_TYPE;
+Core::ConsoleType GetConsoleType();
 
 extern const Info<std::string> MAIN_PERF_MAP_DIR;
 extern const Info<bool> MAIN_CUSTOM_RTC_ENABLE;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -13,6 +13,8 @@
 
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+#include "Core/Core.h"
+
 
 namespace Common
 {
@@ -54,6 +56,7 @@ struct SConfig
   bool bWii = false;
   bool m_is_mios = false;
 
+  Core::ConsoleType m_gc_console_type;
   DiscIO::Region m_region;
 
   // files

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.h
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.h
@@ -56,6 +56,8 @@ private:
 
   QComboBox* m_deterministic_dual_core;
 
+  QComboBox* m_console_type;
+
   QSlider* m_depth_slider;
 
   QSpinBox* m_convergence_spin;


### PR DESCRIPTION
Quick and dirty hack just to get the discussion going.

## Why would you want this?
* Some games currently require Dolphin to be set to a dev unit. It has always been HW3 for GameCube as a default due to some compatibility issues. Different EXI paths can occur in Devkit vs Retail.
* Some games are less stable in DevKit mode (such as GUPE8P) - related: https://github.com/dolphin-emu/dolphin/pull/11025
* Even if all compatibility issues were resolved with Retail as a default, game modders/hackers would want the ability to change to DevKit as some games print debug messaging only if the console is detected as Devkit.

There are 29 total console types, which is a bit excessive when in most cases picking DevKit/Retail would be the likely use case.

In this wip branch I only applied the change to the GC MEM region.

![image](https://user-images.githubusercontent.com/14857235/230289011-5f475b41-bf3c-4792-b715-29462d9787bc.png)

Did some brief testing and works as expected for GC games.

A few things I want to sort out:
1. We should probably support all the types, even if we don't display them. Advanced users could overwrite with the expected values in the INI directly.
I propose only displaying:
-  Not Set
-  Wii DevKit
-  Wii Production Board (Maybe just shown as "Retail Wii")
-  GC DevKit
-  GC Production Board (Maybe just shown as "Retail GC")

2. Should GameCube Console Type and Wii Console Type be their own entries? In this wip I only changed the GC Mem console type.

3. If we want to list all types, is there a better way than explicitly mapping the enum -> string?

4. Maybe UI is scrapped completely, and instead only GameSettings (sys + user) control these values.

5. I wouldn't be opposed to hiding the UI option to only show when "show Debugging UI" is on