### PR TITLE
DolphinQt: Prevent MemoryViewWidget updates when hidden

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -437,6 +437,9 @@ void MemoryViewWidget::Update()
 
 void MemoryViewWidget::UpdateColumns()
 {
+  if (!isVisible())
+    return;
+
   // Check if table is created
   if (m_table->item(1, 1) == nullptr)
     return;


### PR DESCRIPTION
This fixes a minor issue introduced by [PR#11554](https://github.com/dolphin-emu/dolphin/pull/11554).

In the constructor of `MemoryViewWidget` we connect the `Settings::EmulationStateChanged` signal to `MemoryViewWidget::UpdateColumns()`. This poses a problem with TASing because a frame advance step implicitly changes the emulation state. When we hold down the frame advance key, this signal is then fired multiple times in quick succession.

On every instance that this signal is fired, it turns out that `UpdateColumns()` would wait to acquire the CPU lock and begin re-writing data in the memory view table, even if the debugging UI was not enabled. This extra time spent acquiring the CPU lock would cause TAS Input windows to become unresponsive and laggy.

Simply checking for widget visibility before continuing seems to solve this perfectly. In the case where the widget is enabled, the `UpdateColumns()` function progresses as normal. I obviously still encounter the TAS Input latency with this widget enabled, but that's inevitable and not really a concern.