### PR TITLE
DolphinQt: Fix mouse lock checkbox appearing when it shouldn't

### DIFF
--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -204,6 +204,8 @@ void InterfacePane::CreateInGame()
   groupbox_layout->addWidget(mouse_groupbox);
 #ifdef _WIN32
   groupbox_layout->addWidget(m_checkbox_lock_mouse);
+#else
+  m_checkbox_lock_mouse->hide();
 #endif
 }
 


### PR DESCRIPTION
See https://bugs.dolphin-emu.org/issues/13232; this was introduced in 7dde0c3c319577fd913e4de72a6113a8998ada49 (#11726). Apparently, providing a parent for a widget that is not visible makes your new widget visible when the parent is later made visible, in addition to managing the deletion of the widget; [the documentation](https://doc.qt.io/qt-6/qwidget.html#QWidget) does not specify this (only that if the parent is visible you need to explicitly show it).

CC @mackal since this is weird behavior.