### PR TITLE
Android: Document Provider improvements

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -40,7 +40,6 @@ android {
     }
 
     defaultConfig {
-        // TODO If this is ever modified, change application_id in strings.xml
         applicationId "org.dolphinemu.dolphinemu"
         minSdkVersion 21
         targetSdkVersion 33
@@ -74,6 +73,7 @@ android {
                 signingConfig signingConfigs.release
             }
 
+            resValue 'string', 'app_name_suffixed', 'Dolphin Emulator'
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile(
@@ -86,13 +86,14 @@ android {
         // Signed by debug key disallowing distribution on Play Store.
         // Attaches 'debug' suffix to version and package name, allowing installation alongside the release build.
         debug {
-            // TODO If this is ever modified, change application_id in debug/strings.xml
+            resValue 'string', 'app_name_suffixed', 'Dolphin Debug'
             applicationIdSuffix ".debug"
             versionNameSuffix '-debug'
             jniDebuggable true
         }
 
         benchmark {
+            resValue 'string', 'app_name_suffixed', 'Dolphin Benchmark'
             signingConfig signingConfigs.debug
             matchingFallbacks = ['release']
             debuggable false

--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
 
     <application
         android:name=".DolphinApplication"
-        android:label="@string/app_name"
+        android:label="@string/app_name_suffixed"
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true"
         android:preserveLegacyExternalStorage="true"
@@ -97,7 +97,7 @@
         <activity
             android:name=".activities.CustomFilePickerActivity"
             android:exported="false"
-            android:label="@string/app_name"
+            android:label="@string/app_name_suffixed"
             android:theme="@style/Theme.Dolphin.FilePicker">
 
             <intent-filter>

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/DocumentProvider.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/DocumentProvider.kt
@@ -59,7 +59,7 @@ class DocumentProvider : DocumentsProvider() {
 
         result.newRow().apply {
             add(DocumentsContract.Root.COLUMN_ROOT_ID, ROOT_ID)
-            add(DocumentsContract.Root.COLUMN_TITLE, context!!.getString(R.string.app_name))
+            add(DocumentsContract.Root.COLUMN_TITLE, context!!.getString(R.string.app_name_suffixed))
             add(DocumentsContract.Root.COLUMN_ICON, R.drawable.ic_dolphin)
             add(
                 DocumentsContract.Root.COLUMN_FLAGS,
@@ -171,7 +171,7 @@ class DocumentProvider : DocumentsProvider() {
         }
 
         val name = if (file == rootDirectory) {
-            context!!.getString(R.string.app_name)
+            context!!.getString(R.string.app_name_suffixed)
         } else {
             file.name
         }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -77,6 +77,7 @@ public final class MainActivity extends AppCompatActivity
     setInsets();
     ThemeHelper.enableStatusBarScrollTint(this, mBinding.appbarMain);
 
+    mBinding.toolbarMain.setTitle(R.string.app_name);
     setSupportActionBar(mBinding.toolbarMain);
 
     // Set up the FAB.


### PR DESCRIPTION
Fixes a bunch of bugs with the DocumentProvider and adds the ability to copy, delete and move folders.

I've also changed the app names of debug and release builds to avoid confusion for developers who have multiple versions of Dolphin (such as the Play Store release build + DEBUG) installed.