### PR TITLE
[WIP] IOS: Pass System to Kernel.

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -548,7 +548,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
         // Because there is no TMD to get the requested system (IOS) version from,
         // we default to IOS58, which is the version used by the Homebrew Channel.
         SetupWiiMemory(system, IOS::HLE::IOSC::ConsoleType::Retail);
-        IOS::HLE::GetIOS()->BootIOS(system, Titles::IOS(58));
+        IOS::HLE::GetIOS()->BootIOS(Titles::IOS(58));
       }
       else
       {

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -558,7 +558,7 @@ bool CBoot::EmulatedBS2_Wii(Core::System& system, const Core::CPUThreadGuard& gu
   const u64 ios = ios_override >= 0 ? Titles::IOS(static_cast<u32>(ios_override)) : tmd.GetIOSId();
 
   const auto console_type = volume.GetTicket(data_partition).GetConsoleType();
-  if (!SetupWiiMemory(system, console_type) || !IOS::HLE::GetIOS()->BootIOS(system, ios))
+  if (!SetupWiiMemory(system, console_type) || !IOS::HLE::GetIOS()->BootIOS(ios))
     return false;
 
   auto di =

--- a/Source/Core/Core/IOS/DI/DI.h
+++ b/Source/Core/Core/IOS/DI/DI.h
@@ -122,11 +122,12 @@ private:
   friend class ::CBoot;
   friend void ::IOS::HLE::Init();
 
-  void ProcessQueuedIOCtl();
-  std::optional<DIResult> StartIOCtl(const IOCtlRequest& request);
-  std::optional<DIResult> WriteIfFits(const IOCtlRequest& request, u32 value);
-  std::optional<DIResult> StartDMATransfer(u32 command_length, const IOCtlRequest& request);
-  std::optional<DIResult> StartImmediateTransfer(const IOCtlRequest& request,
+  void ProcessQueuedIOCtl(Core::System& system);
+  std::optional<DIResult> StartIOCtl(Core::System& system, const IOCtlRequest& request);
+  std::optional<DIResult> WriteIfFits(Core::System& system, const IOCtlRequest& request, u32 value);
+  std::optional<DIResult> StartDMATransfer(Core::System& system, u32 command_length,
+                                           const IOCtlRequest& request);
+  std::optional<DIResult> StartImmediateTransfer(Core::System& system, const IOCtlRequest& request,
                                                  bool write_to_buf = true);
 
   void ChangePartition(const DiscIO::Partition partition);

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -16,17 +16,15 @@
 
 namespace IOS::HLE
 {
-Request::Request(const u32 address_) : address(address_)
+Request::Request(Core::System& system, const u32 address_) : address(address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   command = static_cast<IPCCommandType>(memory.Read_U32(address));
   fd = memory.Read_U32(address + 8);
 }
 
-OpenRequest::OpenRequest(const u32 address_) : Request(address_)
+OpenRequest::OpenRequest(Core::System& system, const u32 address_) : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   path = memory.GetString(memory.Read_U32(address + 0xc));
   flags = static_cast<OpenMode>(memory.Read_U32(address + 0x10));
@@ -38,25 +36,23 @@ OpenRequest::OpenRequest(const u32 address_) : Request(address_)
   }
 }
 
-ReadWriteRequest::ReadWriteRequest(const u32 address_) : Request(address_)
+ReadWriteRequest::ReadWriteRequest(Core::System& system, const u32 address_)
+    : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   buffer = memory.Read_U32(address + 0xc);
   size = memory.Read_U32(address + 0x10);
 }
 
-SeekRequest::SeekRequest(const u32 address_) : Request(address_)
+SeekRequest::SeekRequest(Core::System& system, const u32 address_) : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   offset = memory.Read_U32(address + 0xc);
   mode = static_cast<SeekMode>(memory.Read_U32(address + 0x10));
 }
 
-IOCtlRequest::IOCtlRequest(const u32 address_) : Request(address_)
+IOCtlRequest::IOCtlRequest(Core::System& system, const u32 address_) : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   request = memory.Read_U32(address + 0x0c);
   buffer_in = memory.Read_U32(address + 0x10);
@@ -65,9 +61,8 @@ IOCtlRequest::IOCtlRequest(const u32 address_) : Request(address_)
   buffer_out_size = memory.Read_U32(address + 0x1c);
 }
 
-IOCtlVRequest::IOCtlVRequest(const u32 address_) : Request(address_)
+IOCtlVRequest::IOCtlVRequest(Core::System& system, const u32 address_) : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   request = memory.Read_U32(address + 0x0c);
   const u32 in_number = memory.Read_U32(address + 0x10);
@@ -114,10 +109,9 @@ void IOCtlRequest::Log(std::string_view device_name, Common::Log::LogType type,
                   device_name, fd, request, buffer_in_size, buffer_out_size);
 }
 
-void IOCtlRequest::Dump(const std::string& description, Common::Log::LogType type,
-                        Common::Log::LogLevel level) const
+void IOCtlRequest::Dump(Core::System& system, const std::string& description,
+                        Common::Log::LogType type, Common::Log::LogLevel level) const
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
   Log("===== " + description, type, level);
@@ -127,16 +121,15 @@ void IOCtlRequest::Dump(const std::string& description, Common::Log::LogType typ
                   HexDump(memory.GetPointer(buffer_out), buffer_out_size));
 }
 
-void IOCtlRequest::DumpUnknown(const std::string& description, Common::Log::LogType type,
-                               Common::Log::LogLevel level) const
+void IOCtlRequest::DumpUnknown(Core::System& system, const std::string& description,
+                               Common::Log::LogType type, Common::Log::LogLevel level) const
 {
-  Dump("Unknown IOCtl - " + description, type, level);
+  Dump(system, "Unknown IOCtl - " + description, type, level);
 }
 
-void IOCtlVRequest::Dump(std::string_view description, Common::Log::LogType type,
-                         Common::Log::LogLevel level) const
+void IOCtlVRequest::Dump(Core::System& system, std::string_view description,
+                         Common::Log::LogType type, Common::Log::LogLevel level) const
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
   GENERIC_LOG_FMT(type, level, "===== {} (fd {}) - IOCtlV {:#x} ({} in, {} io)", description, fd,
@@ -154,10 +147,10 @@ void IOCtlVRequest::Dump(std::string_view description, Common::Log::LogType type
     GENERIC_LOG_FMT(type, level, "io[{}] (size={:#x})", i++, vector.size);
 }
 
-void IOCtlVRequest::DumpUnknown(const std::string& description, Common::Log::LogType type,
-                                Common::Log::LogLevel level) const
+void IOCtlVRequest::DumpUnknown(Core::System& system, const std::string& description,
+                                Common::Log::LogType type, Common::Log::LogLevel level) const
 {
-  Dump("Unknown IOCtlV - " + description, type, level);
+  Dump(system, "Unknown IOCtlV - " + description, type, level);
 }
 
 Device::Device(Kernel& ios, const std::string& device_name, const DeviceType type)

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -13,6 +13,11 @@
 #include "Common/Logging/Log.h"
 #include "Core/IOS/IOS.h"
 
+namespace Core
+{
+class System;
+}
+
 namespace IOS::HLE
 {
 enum ReturnCode : s32
@@ -77,7 +82,7 @@ struct Request
   u32 address = 0;
   IPCCommandType command = IPC_CMD_OPEN;
   u32 fd = 0;
-  explicit Request(u32 address);
+  Request(Core::System& system, u32 address);
   virtual ~Request() = default;
 };
 
@@ -97,14 +102,14 @@ struct OpenRequest final : Request
   // but they are set after they reach IOS and are dispatched to the appropriate module.
   u32 uid = 0;
   u16 gid = 0;
-  explicit OpenRequest(u32 address);
+  OpenRequest(Core::System& system, u32 address);
 };
 
 struct ReadWriteRequest final : Request
 {
   u32 buffer = 0;
   u32 size = 0;
-  explicit ReadWriteRequest(u32 address);
+  ReadWriteRequest(Core::System& system, u32 address);
 };
 
 enum SeekMode : s32
@@ -118,7 +123,7 @@ struct SeekRequest final : Request
 {
   u32 offset = 0;
   SeekMode mode = IOS_SEEK_SET;
-  explicit SeekRequest(u32 address);
+  SeekRequest(Core::System& system, u32 address);
 };
 
 struct IOCtlRequest final : Request
@@ -129,12 +134,13 @@ struct IOCtlRequest final : Request
   // Contrary to the name, the output buffer can also be used for input.
   u32 buffer_out = 0;
   u32 buffer_out_size = 0;
-  explicit IOCtlRequest(u32 address);
+  IOCtlRequest(Core::System& system, u32 address);
   void Log(std::string_view description, Common::Log::LogType type = Common::Log::LogType::IOS,
            Common::Log::LogLevel level = Common::Log::LogLevel::LINFO) const;
-  void Dump(const std::string& description, Common::Log::LogType type = Common::Log::LogType::IOS,
+  void Dump(Core::System& system, const std::string& description,
+            Common::Log::LogType type = Common::Log::LogType::IOS,
             Common::Log::LogLevel level = Common::Log::LogLevel::LINFO) const;
-  void DumpUnknown(const std::string& description,
+  void DumpUnknown(Core::System& system, const std::string& description,
                    Common::Log::LogType type = Common::Log::LogType::IOS,
                    Common::Log::LogLevel level = Common::Log::LogLevel::LERROR) const;
 };
@@ -159,11 +165,12 @@ struct IOCtlVRequest final : Request
   /// Returns the specified vector or nullptr if the index is out of bounds.
   const IOVector* GetVector(size_t index) const;
 
-  explicit IOCtlVRequest(u32 address);
+  IOCtlVRequest(Core::System& system, u32 address);
   bool HasNumberOfValidVectors(size_t in_count, size_t io_count) const;
-  void Dump(std::string_view description, Common::Log::LogType type = Common::Log::LogType::IOS,
+  void Dump(Core::System& system, std::string_view description,
+            Common::Log::LogType type = Common::Log::LogType::IOS,
             Common::Log::LogLevel level = Common::Log::LogLevel::LINFO) const;
-  void DumpUnknown(const std::string& description,
+  void DumpUnknown(Core::System& system, const std::string& description,
                    Common::Log::LogType type = Common::Log::LogType::IOS,
                    Common::Log::LogLevel level = Common::Log::LogLevel::LERROR) const;
 };

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -331,7 +331,10 @@ std::optional<IPCReply> NetIPTopDevice::IOCtl(const IOCtlRequest& request)
   case IOCTL_SO_ICMPCANCEL:
     return HandleICMPCancelRequest(request);
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_NET);
+    if (m_ios.HasSystem())
+      request.DumpUnknown(m_ios.GetSystem(), GetDeviceName(), Common::Log::LogType::IOS_NET);
+    else
+      ERROR_LOG_FMT(IOS_NET, "Unknown IOCtl without System instance.");
     break;
   }
 
@@ -353,7 +356,10 @@ std::optional<IPCReply> NetIPTopDevice::IOCtlV(const IOCtlVRequest& request)
   case IOCTLV_SO_ICMPPING:
     return HandleICMPPingRequest(request);
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_NET);
+    if (m_ios.HasSystem())
+      request.DumpUnknown(m_ios.GetSystem(), GetDeviceName(), Common::Log::LogType::IOS_NET);
+    else
+      ERROR_LOG_FMT(IOS_NET, "Unknown IOCtlV without System instance.");
     break;
   }
 
@@ -1118,7 +1124,8 @@ IPCReply NetIPTopDevice::HandleGetAddressInfoRequest(const IOCtlVRequest& reques
     ret = SO_ERROR_HOST_NOT_FOUND;
   }
 
-  request.Dump(GetDeviceName(), Common::Log::LogType::IOS_NET, Common::Log::LogLevel::LINFO);
+  request.Dump(system, GetDeviceName(), Common::Log::LogType::IOS_NET,
+               Common::Log::LogLevel::LINFO);
   return IPCReply(ret);
 }
 

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -78,7 +78,7 @@ std::optional<IPCReply> NetKDTimeDevice::IOCtl(const IOCtlRequest& request)
     break;
 
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_WC24);
+    request.DumpUnknown(system, GetDeviceName(), Common::Log::LogType::IOS_WC24);
     break;
   }
 

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -619,7 +619,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     break;
   }
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_SSL);
+    request.DumpUnknown(system, GetDeviceName(), Common::Log::LogType::IOS_SSL);
   }
 
   // SSL return codes are written to BufferIn

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -256,7 +256,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
     IPCCommandType ct = it->request.command;
     if (!it->is_ssl && ct == IPC_CMD_IOCTL)
     {
-      IOCtlRequest ioctl{it->request.address};
+      IOCtlRequest ioctl{system, it->request.address};
       switch (it->net_type)
       {
       case IOCTL_SO_FCNTL:
@@ -347,7 +347,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
     }
     else if (ct == IPC_CMD_IOCTLV)
     {
-      IOCtlVRequest ioctlv{it->request.address};
+      IOCtlVRequest ioctlv{system, it->request.address};
       u32 BufferIn = 0, BufferIn2 = 0;
       u32 BufferInSize = 0, BufferInSize2 = 0;
       u32 BufferOut = 0, BufferOut2 = 0;
@@ -1038,8 +1038,8 @@ void WiiSockMan::UpdatePollCommands()
   pending_polls.erase(
       std::remove_if(
           pending_polls.begin(), pending_polls.end(),
-          [&memory, this](PollCommand& pcmd) {
-            const auto request = Request(pcmd.request_addr);
+          [&system, &memory, this](PollCommand& pcmd) {
+            const auto request = Request(system, pcmd.request_addr);
             auto& pfds = pcmd.wii_fds;
             int ret = 0;
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -87,7 +87,11 @@ static void DoStateForMessage(Kernel& ios, PointerWrap& p, std::unique_ptr<T>& m
   p.Do(request_address);
   if (request_address != 0)
   {
-    IOCtlVRequest request{request_address};
+    ASSERT(ios.HasSystem());
+    if (!ios.HasSystem())
+      return;
+
+    IOCtlVRequest request{ios.GetSystem(), request_address};
     message = std::make_unique<T>(ios, request);
   }
 }
@@ -209,7 +213,10 @@ std::optional<IPCReply> BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
   }
 
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_WIIMOTE);
+    if (m_ios.HasSystem())
+      request.DumpUnknown(m_ios.GetSystem(), GetDeviceName(), Common::Log::LogType::IOS_WIIMOTE);
+    else
+      ERROR_LOG_FMT(IOS_NET, "Unknown IOCtlV without System instance.");
   }
 
   if (!send_reply)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 #include <libusb.h>
 
+#include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -347,8 +348,13 @@ void BluetoothRealDevice::DoState(PointerWrap& p)
     // On load, discard any pending transfer to make sure the emulated software is not stuck
     // waiting for the previous request to complete. This is usually not an issue as long as
     // the Bluetooth state is the same (same Wii Remote connections).
-    for (const auto& address_to_discard : addresses_to_discard)
-      m_ios.EnqueueIPCReply(Request{address_to_discard}, 0);
+    ASSERT(m_ios.HasSystem());
+    if (m_ios.HasSystem())
+    {
+      auto& system = m_ios.GetSystem();
+      for (const auto& address_to_discard : addresses_to_discard)
+        m_ios.EnqueueIPCReply(Request{system, address_to_discard}, 0);
+    }
 
     // Prevent the callbacks from replying to a request that has already been discarded.
     m_current_transfers.clear();

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -50,15 +50,21 @@ std::optional<IPCReply> USB_HIDv5::IOCtl(const IOCtlRequest& request)
     return HandleDeviceIOCtl(request,
                              [&](USBV5Device& device) { return CancelEndpoint(device, request); });
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_USB,
-                        Common::Log::LogLevel::LERROR);
+    if (m_ios.HasSystem())
+    {
+      request.DumpUnknown(m_ios.GetSystem(), GetDeviceName(), Common::Log::LogType::IOS_USB,
+                          Common::Log::LogLevel::LERROR);
+    }
+    else
+    {
+      ERROR_LOG_FMT(IOS_NET, "Unknown IOCtl without System instance.");
+    }
     return IPCReply(IPC_SUCCESS);
   }
 }
 
 std::optional<IPCReply> USB_HIDv5::IOCtlV(const IOCtlVRequest& request)
 {
-  request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_USB);
   switch (request.request)
   {
   // TODO: HIDv5 seems to be able to queue transfers depending on the transfer length (unlike VEN).
@@ -82,6 +88,10 @@ std::optional<IPCReply> USB_HIDv5::IOCtlV(const IOCtlVRequest& request)
                           [&, this]() { return SubmitTransfer(*device, *host_device, request); });
   }
   default:
+    if (m_ios.HasSystem())
+      request.DumpUnknown(m_ios.GetSystem(), GetDeviceName(), Common::Log::LogType::IOS_USB);
+    else
+      ERROR_LOG_FMT(IOS_NET, "Unknown IOCtlV without System instance.");
     return IPCReply(IPC_EINVAL);
   }
 }

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -53,8 +53,15 @@ std::optional<IPCReply> USB_VEN::IOCtl(const IOCtlRequest& request)
     return HandleDeviceIOCtl(request,
                              [&](USBV5Device& device) { return CancelEndpoint(device, request); });
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_USB,
-                        Common::Log::LogLevel::LERROR);
+    if (m_ios.HasSystem())
+    {
+      request.DumpUnknown(m_ios.GetSystem(), GetDeviceName(), Common::Log::LogType::IOS_USB,
+                          Common::Log::LogLevel::LERROR);
+    }
+    else
+    {
+      ERROR_LOG_FMT(IOS_NET, "Unknown IOCtl without System instance.");
+    }
     return IPCReply(IPC_SUCCESS);
   }
 }

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -543,7 +543,7 @@ std::optional<IPCReply> WFSIDevice::IOCtl(const IOCtlRequest& request)
     // TODO(wfs): Should be returning an error. However until we have
     // everything properly stubbed it's easier to simulate the methods
     // succeeding.
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_WFS,
+    request.DumpUnknown(system, GetDeviceName(), Common::Log::LogType::IOS_WFS,
                         Common::Log::LogLevel::LWARNING);
     memory.Memset(request.buffer_out, 0, request.buffer_out_size);
     break;

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -577,7 +577,7 @@ bool VolumeVerifier::CheckPartition(const Partition& partition)
   {
     const auto console_type =
         IsDebugSigned() ? IOS::HLE::IOSC::ConsoleType::RVT : IOS::HLE::IOSC::ConsoleType::Retail;
-    IOS::HLE::Kernel ios(console_type);
+    IOS::HLE::Kernel ios(nullptr, console_type);
     const auto es = ios.GetES();
     const std::vector<u8>& cert_chain = m_volume.GetCertificateChain(partition);
 
@@ -981,7 +981,7 @@ void VolumeVerifier::CheckMisc()
 
   if (m_volume.GetVolumeType() == Platform::WiiWAD)
   {
-    IOS::HLE::Kernel ios(m_ticket.GetConsoleType());
+    IOS::HLE::Kernel ios(nullptr, m_ticket.GetConsoleType());
     const auto es = ios.GetES();
     const std::vector<u8>& cert_chain = m_volume.GetCertificateChain(PARTITION_NONE);
 


### PR DESCRIPTION
Starting to de-globalize the IOS classes. The reason I'm opening this now is because I'm not 100% what the best approach with the Kernel class is; it's used both as the actual IOS instance during emulation, but also as a helper class for various Wii-related operations outside of emulation. In the former case it needs the System, in the latter case it shouldn't have one, because one might not even exist at the time once we no longer have the global instance.

Right now I'm just storing a pointer to System in Kernel (instead of the usual reference) which is null in the helper class case, and then every emulation-related function `ASSERT`s that the pointer is non-null, and that probably *works*, but I'm wondering if there's a better way to handle this...