### PR TITLE
Allow shared zlib-ng

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,7 +676,7 @@ dolphin_make_imported_target_if_missing(LibLZMA::LibLZMA LIBLZMA)
 
 dolphin_find_optional_system_library_pkgconfig(ZSTD libzstd>=1.4.0 zstd::zstd Externals/zstd)
 
-add_subdirectory(Externals/zlib-ng)
+dolphin_find_optional_system_library_pkgconfig(ZLIB zlib-ng ZLIB::ZLIB Externals/zlib-ng)
 
 dolphin_find_optional_system_library_pkgconfig(MINIZIP minizip>=3.0.0 minizip::minizip Externals/minizip)
 


### PR DESCRIPTION
Should be self explanatory.

Allows for using shared zlib-ng if found by pkgconfig, similar to how zstd works.