### PR TITLE
NetPlayServer: Prevent unnecessary copies in GetInterfaceSet()

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -2266,8 +2266,7 @@ u16 NetPlayServer::GetPort() const
 std::unordered_set<std::string> NetPlayServer::GetInterfaceSet() const
 {
   std::unordered_set<std::string> result;
-  auto lst = GetInterfaceListInternal();
-  for (auto list_entry : lst)
+  for (const auto& list_entry : GetInterfaceListInternal())
     result.emplace(list_entry.first);
   return result;
 }


### PR DESCRIPTION
This was previously copying each pair out of the vector returned by GetInterfaceListInternal() when we just need to emplace the first entry of each pair.

Noticed while doing #11748