### PR TITLE
UICommon/DiscordPresence: Use GameTDB covers for RPC

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -433,3 +433,38 @@ IniFile SConfig::LoadGameIni(const std::string& id, std::optional<u16> revision)
     game_ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + filename, true);
   return game_ini;
 }
+
+std::string SConfig::GetGameTDBImageRegionCode(bool wii, DiscIO::Region region) const
+{
+  switch (region)
+  {
+  case DiscIO::Region::NTSC_J:
+    return "JA";
+  case DiscIO::Region::NTSC_U:
+    return "US";
+  case DiscIO::Region::NTSC_K:
+    return "KO";
+  case DiscIO::Region::PAL:
+  {
+    const auto user_lang = GetCurrentLanguage(wii);
+    switch (user_lang)
+    {
+    case DiscIO::Language::German:
+      return "DE";
+    case DiscIO::Language::French:
+      return "FR";
+    case DiscIO::Language::Spanish:
+      return "ES";
+    case DiscIO::Language::Italian:
+      return "IT";
+    case DiscIO::Language::Dutch:
+      return "NL";
+    case DiscIO::Language::English:
+    default:
+      return "EN";
+    }
+  }
+  default:
+    return "EN";
+  }
+}

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -80,6 +80,7 @@ struct SConfig
   bool SetPathsAndGameMetadata(const BootParameters& boot);
   DiscIO::Language GetCurrentLanguage(bool wii) const;
   DiscIO::Language GetLanguageAdjustedForRegion(bool wii, DiscIO::Region region) const;
+  std::string GetGameTDBImageRegionCode(bool wii, DiscIO::Region region) const;
 
   IniFile LoadDefaultGameIni() const;
   IniFile LoadLocalGameIni() const;

--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 
 #include "Common/Hash.h"
+#include "Common/HttpRequest.h"
 #include "Common/StringUtil.h"
 
 #endif
@@ -91,88 +92,14 @@ void HandleDiscordJoin(const char* join_secret)
   event_handler->DiscordJoin();
 }
 
-std::string ArtworkForGameId(const std::string& gameid)
+std::string ArtworkForGameId()
 {
-  static const std::set<std::string> REGISTERED_GAMES{
-      "GAF",  // GAFE01: Animal Crossing
-      "RUU",  // RUUE01: Animal Crossing: City Folk
-      "SF8",  // SF8E01: Donkey Kong Country Returns
-      "RDB",  // RDBE70: Dragon Ball Z: Budokai Tenkaichi 2
-      "RDS",  // RDSE70: Dragon Ball Z: Budokai Tenkaichi 3
-      "GFZ",  // GFZE01: F-Zero GX
-      "GFE",  // GFEE01: Fire Emblem: Path of Radiance
-      "RFE",  // RFEE01: Fire Emblem: Radiant Dawn
-      "S5S",  // S5SJHF: Inazuma Eleven GO: Strikers 2013
-      "GKY",  // GKYE01: Kirby Air Ride
-      "SUK",  // SUKE01: Kirby's Return to Dream Land
-      "GLM",  // GLME01: Luigi's Mansion
-      "GFT",  // GFTE01: Mario Golf: Toadstool Tour
-      "RMC",  // RMCE01: Mario Kart Wii
-      "GM4",  // GM4E01: Mario Kart: Double Dash!!
-      "GMP",  // GMPE01: Mario Party 4
-      "GP5",  // GP5E01: Mario Party 5
-      "GP6",  // GP6E01: Mario Party 6
-      "GP7",  // GP7E01: Mario Party 7
-      "RM8",  // RM8E01: Mario Party 8
-      "SSQ",  // SSQE01: Mario Party 9
-      "GOM",  // GOME01: Mario Power Tennis
-      "GYQ",  // GYQE01: Mario Superstar Baseball
-      "GGS",  // GGSE01: Metal Gear Solid: The Twin Snakes
-      "GM8",  // GM8E01: Metroid Prime
-      "G2M",  // G2ME01: Metroid Prime 2: Echoes
-      "RM3",  // RM3E01: Metroid Prime 3: Corruption
-      "R3M",  // R3ME01: Metroid Prime: Trilogy
-      "SMN",  // SMNE01: New Super Mario Bros. Wii
-      "G8M",  // G8ME01: Paper Mario: The Thousand-Year Door
-      "GPI",  // GPIE01: Pikmin (GC)
-      "R9I",  // R9IE01: Pikmin (Wii)
-      "GPV",  // GPVE01: Pikmin 2 (GC)
-      "R92",  // R92E01: Pikmin 2 (Wii)
-      "GC6",  // GC6E01: Pokemon Colosseum
-      "GXX",  // GXXE01: Pokemon XD: Gale of Darkness
-      "GBI",  // GBIE08: Resident Evil
-      "GHA",  // GHAE08: Resident Evil 2
-      "GLE",  // GLEE08: Resident Evil 3: Nemesis
-      "G4B",  // G4BE08: Resident Evil 4
-      "GSN",  // GSNE8P: Sonic Adventure 2: Battle
-      "GXS",  // GXSE8P: Sonic Adventure DX: Director's Cut
-      "SNC",  // SNCE8P: Sonic Colors
-      "G9S",  // G9SE8P: Sonic Heroes
-      "GRS",  // GRSEAF: SoulCalibur II
-      "RSL",  // RSLEAF: SoulCalibur Legends
-      "GK2",  // GK2E52: Spider-Man 2
-      "GQP",  // GQPE78: SpongeBob SquarePants: Battle for Bikini Bottom
-      "SVM",  // SVME01: Super Mario All-Stars: 25th Anniversary Edition
-      "RMG",  // RMGE01: Super Mario Galaxy
-      "SB4",  // SB4E01: Super Mario Galaxy 2
-      "G4Q",  // G4QE01: Super Mario Strikers
-      "GMS",  // GMSE01: Super Mario Sunshine
-      "GMB",  // GMBE8P: Super Monkey Ball
-      "GM2",  // GM2E8P: Super Monkey Ball 2
-      "R8P",  // R8PE01: Super Paper Mario
-      "RSB",  // RSBE01: Super Smash Bros. Brawl
-      "GAL",  // GALE01: Super Smash Bros. Melee
-      "PZL",  // PZLE01: The Legend of Zelda: Collector's Edition
-      "G4S",  // G4SE01: The Legend of Zelda: Four Swords Adventures
-      "D43",  // D43E01: The Legend of Zelda: Ocarina of Time / Master Quest
-      "SOU",  // SOUE01: The Legend of Zelda: Skyward Sword
-      "GZL",  // GZLE01: The Legend of Zelda: The Wind Waker
-      "GZ2",  // GZ2E01: The Legend of Zelda: Twilight Princess (GC)
-      "RZD",  // RZDE01: The Legend of Zelda: Twilight Princess (Wii)
-      "GHQ",  // GHQE7D: The Simpsons: Hit & Run
-      "RSP",  // RSPE01: Wii Sports
-      "RZT",  // RZTE01: Wii Sports Resort
-      "SX4",  // SX4E01: Xenoblade Chronicles
-  };
+  const DiscIO::Region region = SConfig::GetInstance().m_region;
+  const bool is_wii = SConfig::GetInstance().bWii;
+  const std::string region_code = SConfig::GetInstance().GetGameTDBImageRegionCode(is_wii, region);
 
-  std::string region_neutral_gameid = gameid.substr(0, 3);
-  if (REGISTERED_GAMES.count(region_neutral_gameid) != 0)
-  {
-    // Discord asset keys can only be lowercase.
-    Common::ToLower(&region_neutral_gameid);
-    return "game_" + region_neutral_gameid;
-  }
-  return "";
+  static constexpr char cover_url[] = "https://discord.dolphin-emu.org/cover-art/{}/{}.png";
+  return fmt::format(cover_url, region_code, SConfig::GetInstance().GetGameTDBID());
 }
 
 }  // namespace
@@ -278,7 +205,8 @@ void UpdateDiscordPresence(int party_size, SecretType type, const std::string& s
 
   const std::string& title =
       current_game.empty() ? SConfig::GetInstance().GetTitleDescription() : current_game;
-  std::string game_artwork = ArtworkForGameId(SConfig::GetInstance().GetGameID());
+  std::string game_artwork =
+      SConfig::GetInstance().GetGameTDBID().empty() ? "" : ArtworkForGameId();
 
   DiscordRichPresence discord_presence = {};
   if (game_artwork.empty())

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -246,49 +246,8 @@ void GameFile::DownloadDefaultCover()
   if (File::Exists(png_path))
     return;
 
-  std::string region_code;
-  switch (m_region)
-  {
-  case DiscIO::Region::NTSC_J:
-    region_code = "JA";
-    break;
-  case DiscIO::Region::NTSC_U:
-    region_code = "US";
-    break;
-  case DiscIO::Region::NTSC_K:
-    region_code = "KO";
-    break;
-  case DiscIO::Region::PAL:
-  {
-    const auto user_lang = SConfig::GetInstance().GetCurrentLanguage(DiscIO::IsWii(GetPlatform()));
-    switch (user_lang)
-    {
-    case DiscIO::Language::German:
-      region_code = "DE";
-      break;
-    case DiscIO::Language::French:
-      region_code = "FR";
-      break;
-    case DiscIO::Language::Spanish:
-      region_code = "ES";
-      break;
-    case DiscIO::Language::Italian:
-      region_code = "IT";
-      break;
-    case DiscIO::Language::Dutch:
-      region_code = "NL";
-      break;
-    case DiscIO::Language::English:
-    default:
-      region_code = "EN";
-      break;
-    }
-    break;
-  }
-  case DiscIO::Region::Unknown:
-    region_code = "EN";
-    break;
-  }
+  const std::string region_code =
+      SConfig::GetInstance().GetGameTDBImageRegionCode(DiscIO::IsWii(GetPlatform()), m_region);
 
   Common::HttpRequest request;
   static constexpr char cover_url[] = "https://art.gametdb.com/wii/cover/{}/{}.png";


### PR DESCRIPTION
Rehash of #10390 but cleaner. Discord allows for using URL's for their RPC images. Documented as of this [PR](https://github.com/discord/discord-api-docs/pull/4371#event-6029119110).

The image will be the Dolphin logo if GameTDB does not have a cover for the current game.
<img width="338" alt="Screenshot 2023-04-11 at 10 12 21 PM" src="https://user-images.githubusercontent.com/75850871/231329801-e612d65d-2b5c-473c-8314-4580337fadaf.png">

Otherwise, the cover of the game will appear in the RPC.
<img width="497" alt="Screenshot 2023-04-11 at 10 16 42 PM" src="https://user-images.githubusercontent.com/75850871/231330484-3b0ea714-684b-40f9-8dbc-fca1fa0bb9ac.png">
