### PR TITLE
Retroachievements activate

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -142,6 +142,7 @@ void AchievementManager::LoadGameByFilenameAsync(const std::string& iso_path,
       ActivateDeactivateAchievements();
     }
     ActivateDeactivateLeaderboards();
+    ActivateDeactivateRichPresence();
 
     callback(fetch_game_data_response);
   });
@@ -191,6 +192,16 @@ void AchievementManager::ActivateDeactivateLeaderboards()
   }
 }
 
+void AchievementManager::ActivateDeactivateRichPresence()
+{
+  rc_runtime_activate_richpresence(
+      &m_runtime,
+      (m_is_game_loaded && Config::Get(Config::RA_RICH_PRESENCE_ENABLED)) ?
+          m_game_data.rich_presence_script :
+          "",
+      nullptr, 0);
+}
+
 void AchievementManager::CloseGame()
 {
   m_is_game_loaded = false;
@@ -199,6 +210,7 @@ void AchievementManager::CloseGame()
   m_unlock_map.clear();
   ActivateDeactivateAchievements();
   ActivateDeactivateLeaderboards();
+  ActivateDeactivateRichPresence();
 }
 
 void AchievementManager::Logout()

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -141,6 +141,7 @@ void AchievementManager::LoadGameByFilenameAsync(const std::string& iso_path,
       LoadUnlockData([](ResponseType r_type) {});
       ActivateDeactivateAchievements();
     }
+    ActivateDeactivateLeaderboards();
 
     callback(fetch_game_data_response);
   });
@@ -173,6 +174,23 @@ void AchievementManager::ActivateDeactivateAchievements()
   }
 }
 
+void AchievementManager::ActivateDeactivateLeaderboards()
+{
+  bool leaderboards_enabled = Config::Get(Config::RA_LEADERBOARDS_ENABLED);
+  for (u32 ix = 0; ix < m_game_data.num_leaderboards; ix++)
+  {
+    auto leaderboard = m_game_data.leaderboards[ix];
+    if (m_is_game_loaded && leaderboards_enabled && hardcore_mode_enabled)
+    {
+      rc_runtime_activate_lboard(&m_runtime, leaderboard.id, leaderboard.definition, nullptr, 0);
+    }
+    else
+    {
+      rc_runtime_deactivate_lboard(&m_runtime, m_game_data.leaderboards[ix].id);
+    }
+  }
+}
+
 void AchievementManager::CloseGame()
 {
   m_is_game_loaded = false;
@@ -180,6 +198,7 @@ void AchievementManager::CloseGame()
   m_queue.Cancel();
   m_unlock_map.clear();
   ActivateDeactivateAchievements();
+  ActivateDeactivateLeaderboards();
 }
 
 void AchievementManager::Logout()

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -42,6 +42,8 @@ public:
   void LoadUnlockData(const ResponseCallback& callback);
   void ActivateDeactivateAchievements();
   void ActivateDeactivateLeaderboards();
+  void ActivateDeactivateRichPresence();
+
   void CloseGame();
   void Logout();
   void Shutdown();

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 
 #include <rcheevos/include/rc_api_runtime.h>
 #include <rcheevos/include/rc_api_user.h>
@@ -15,6 +16,8 @@
 
 #include "Common/Event.h"
 #include "Common/WorkQueueThread.h"
+
+using AchievementId = u32;
 
 class AchievementManager
 {
@@ -50,6 +53,8 @@ private:
   ResponseType StartRASession();
   ResponseType FetchGameData();
 
+  void ActivateDeactivateAchievement(AchievementId id, bool enabled, bool unofficial, bool encore);
+
   template <typename RcRequest, typename RcResponse>
   ResponseType Request(RcRequest rc_request, RcResponse* rc_response,
                        const std::function<int(rc_api_request_t*, const RcRequest*)>& init_request,
@@ -60,6 +65,19 @@ private:
   unsigned int m_game_id = 0;
   rc_api_fetch_game_data_response_t m_game_data{};
   bool m_is_game_loaded = false;
+
+  struct UnlockStatus
+  {
+    AchievementId game_data_index = 0;
+    enum class UnlockType
+    {
+      LOCKED,
+      SOFTCORE,
+      HARDCORE
+    } remote_unlock_status = UnlockType::LOCKED;
+    int session_unlock_count = 0;
+  };
+  std::unordered_map<AchievementId, UnlockStatus> m_unlock_map;
 
   Common::WorkQueueThread<std::function<void()>> m_queue;
 };  // class AchievementManager

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -41,6 +41,7 @@ public:
 
   void LoadUnlockData(const ResponseCallback& callback);
   void ActivateDeactivateAchievements();
+  void ActivateDeactivateLeaderboards();
   void CloseGame();
   void Logout();
   void Shutdown();

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -39,6 +39,8 @@ public:
   bool IsLoggedIn() const;
   void LoadGameByFilenameAsync(const std::string& iso_path, const ResponseCallback& callback);
 
+  void LoadUnlockData(const ResponseCallback& callback);
+  void ActivateDeactivateAchievements();
   void CloseGame();
   void Logout();
   void Shutdown();

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -52,6 +52,7 @@ private:
   ResponseType ResolveHash(std::array<char, HASH_LENGTH> game_hash);
   ResponseType StartRASession();
   ResponseType FetchGameData();
+  ResponseType FetchUnlockData(bool hardcore);
 
   void ActivateDeactivateAchievement(AchievementId id, bool enabled, bool unofficial, bool encore);
 
@@ -80,6 +81,7 @@ private:
   std::unordered_map<AchievementId, UnlockStatus> m_unlock_map;
 
   Common::WorkQueueThread<std::function<void()>> m_queue;
+  std::recursive_mutex m_lock;
 };  // class AchievementManager
 
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/Core/Config/AchievementSettings.cpp
+++ b/Source/Core/Core/Config/AchievementSettings.cpp
@@ -15,6 +15,8 @@ const Info<std::string> RA_USERNAME{{System::Achievements, "Achievements", "User
 const Info<std::string> RA_API_TOKEN{{System::Achievements, "Achievements", "ApiToken"}, ""};
 const Info<bool> RA_ACHIEVEMENTS_ENABLED{
     {System::Achievements, "Achievements", "AchievementsEnabled"}, false};
+const Info<bool> RA_LEADERBOARDS_ENABLED{
+    {System::Achievements, "Achievements", "LeaderboardsEnabled"}, false};
 const Info<bool> RA_UNOFFICIAL_ENABLED{{System::Achievements, "Achievements", "UnofficialEnabled"},
                                        false};
 const Info<bool> RA_ENCORE_ENABLED{{System::Achievements, "Achievements", "EncoreEnabled"}, false};

--- a/Source/Core/Core/Config/AchievementSettings.cpp
+++ b/Source/Core/Core/Config/AchievementSettings.cpp
@@ -13,4 +13,9 @@ namespace Config
 const Info<bool> RA_ENABLED{{System::Achievements, "Achievements", "Enabled"}, false};
 const Info<std::string> RA_USERNAME{{System::Achievements, "Achievements", "Username"}, ""};
 const Info<std::string> RA_API_TOKEN{{System::Achievements, "Achievements", "ApiToken"}, ""};
+const Info<bool> RA_ACHIEVEMENTS_ENABLED{
+    {System::Achievements, "Achievements", "AchievementsEnabled"}, false};
+const Info<bool> RA_UNOFFICIAL_ENABLED{{System::Achievements, "Achievements", "UnofficialEnabled"},
+                                       false};
+const Info<bool> RA_ENCORE_ENABLED{{System::Achievements, "Achievements", "EncoreEnabled"}, false};
 }  // namespace Config

--- a/Source/Core/Core/Config/AchievementSettings.cpp
+++ b/Source/Core/Core/Config/AchievementSettings.cpp
@@ -17,6 +17,8 @@ const Info<bool> RA_ACHIEVEMENTS_ENABLED{
     {System::Achievements, "Achievements", "AchievementsEnabled"}, false};
 const Info<bool> RA_LEADERBOARDS_ENABLED{
     {System::Achievements, "Achievements", "LeaderboardsEnabled"}, false};
+const Info<bool> RA_RICH_PRESENCE_ENABLED{
+    {System::Achievements, "Achievements", "RichPresenceEnabled"}, false};
 const Info<bool> RA_UNOFFICIAL_ENABLED{{System::Achievements, "Achievements", "UnofficialEnabled"},
                                        false};
 const Info<bool> RA_ENCORE_ENABLED{{System::Achievements, "Achievements", "EncoreEnabled"}, false};

--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -12,6 +12,7 @@ extern const Info<bool> RA_ENABLED;
 extern const Info<std::string> RA_USERNAME;
 extern const Info<std::string> RA_API_TOKEN;
 extern const Info<bool> RA_ACHIEVEMENTS_ENABLED;
+extern const Info<bool> RA_LEADERBOARDS_ENABLED;
 extern const Info<bool> RA_UNOFFICIAL_ENABLED;
 extern const Info<bool> RA_ENCORE_ENABLED;
 }  // namespace Config

--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -11,4 +11,7 @@ namespace Config
 extern const Info<bool> RA_ENABLED;
 extern const Info<std::string> RA_USERNAME;
 extern const Info<std::string> RA_API_TOKEN;
+extern const Info<bool> RA_ACHIEVEMENTS_ENABLED;
+extern const Info<bool> RA_UNOFFICIAL_ENABLED;
+extern const Info<bool> RA_ENCORE_ENABLED;
 }  // namespace Config

--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -13,6 +13,7 @@ extern const Info<std::string> RA_USERNAME;
 extern const Info<std::string> RA_API_TOKEN;
 extern const Info<bool> RA_ACHIEVEMENTS_ENABLED;
 extern const Info<bool> RA_LEADERBOARDS_ENABLED;
+extern const Info<bool> RA_RICH_PRESENCE_ENABLED;
 extern const Info<bool> RA_UNOFFICIAL_ENABLED;
 extern const Info<bool> RA_ENCORE_ENABLED;
 }  // namespace Config


### PR DESCRIPTION
This is a portion of an integration with the RetroAchievements tools and libraries for connecting to the website, downloading data, unlocking achievements and submitting to leaderboards for games running in Dolphin. In this PR, the AchievementsManager created in a previous PR is further implemented to activate achievements, leaderboards, and rich presence within the achievement runtime as retrieved from the RetroAchievements API, preparing them to be compared to memory.