### PR TITLE
Common/UPnP: Move interface into Common namespace

### DIFF
--- a/Source/Core/Common/UPnP.cpp
+++ b/Source/Core/Common/UPnP.cpp
@@ -164,14 +164,14 @@ static void UnmapPortThread()
     UnmapPort(s_mapped);
 }
 
-void UPnP::TryPortmapping(u16 port)
+void Common::UPnP::TryPortmapping(u16 port)
 {
   if (s_thread.joinable())
     s_thread.join();
   s_thread = std::thread(&MapPortThread, port);
 }
 
-void UPnP::StopPortmapping()
+void Common::UPnP::StopPortmapping()
 {
   if (s_thread.joinable())
     s_thread.join();

--- a/Source/Core/Common/UPnP.h
+++ b/Source/Core/Common/UPnP.h
@@ -7,10 +7,10 @@
 
 #include "Common/CommonTypes.h"
 
-namespace UPnP
+namespace Common::UPnP
 {
 void TryPortmapping(u16 port);
 void StopPortmapping();
-}  // namespace UPnP
+}  // namespace Common::UPnP
 
 #endif

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -111,7 +111,7 @@ NetPlayServer::~NetPlayServer()
   }
 
 #ifdef USE_UPNP
-  UPnP::StopPortmapping();
+  Common::UPnP::StopPortmapping();
 #endif
 }
 
@@ -168,7 +168,7 @@ NetPlayServer::NetPlayServer(const u16 port, const bool forward_port, NetPlayUI*
 
 #ifdef USE_UPNP
     if (forward_port)
-      UPnP::TryPortmapping(port);
+      Common::UPnP::TryPortmapping(port);
 #endif
   }
 }


### PR DESCRIPTION
Keeps these utilities consistent with the rest of most of the Common library.