### PR TITLE
Enable BCn texture support on iOS where available

### DIFF
--- a/Externals/mbedtls/CMakeLists.txt
+++ b/Externals/mbedtls/CMakeLists.txt
@@ -48,7 +48,8 @@ option(ENABLE_ZLIB_SUPPORT "Build mbed TLS with zlib library." OFF)
 option(ENABLE_PROGRAMS "Build mbed TLS programs." OFF)
 
 option(UNSAFE_BUILD "Allow unsafe builds. These builds ARE NOT SECURE." OFF)
-option(MBEDTLS_FATAL_WARNINGS "Compiler warnings treated as errors" ON)
+# Dolphin: werror makes updating compilers painful
+option(MBEDTLS_FATAL_WARNINGS "Compiler warnings treated as errors" OFF)
 
 string(REGEX MATCH "Clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER_ID}")
 string(REGEX MATCH "GNU" CMAKE_COMPILER_IS_GNU "${CMAKE_C_COMPILER_ID}")
@@ -233,8 +234,7 @@ endif(CMAKE_COMPILER_IS_MSVC)
 
 if(MBEDTLS_FATAL_WARNINGS)
     if(CMAKE_COMPILER_IS_MSVC)
-        # Dolphin/MSVC: we want to disable all warnings for externals
-        #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
     endif(CMAKE_COMPILER_IS_MSVC)
 
     if(CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNU)

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -193,20 +193,18 @@ void Metal::Util::PopulateBackendInfoFeatures(VideoConfig* config, id<MTLDevice>
   config->backend_info.bSupportsST3CTextures = true;
   config->backend_info.bSupportsBPTCTextures = true;
 #else
-  bool supports_mac1 = false;
   bool supports_apple4 = false;
+  bool supports_bcn = false;
   if (@available(iOS 13, *))
-  {
-    supports_mac1 = [device supportsFamily:MTLGPUFamilyMac1];
     supports_apple4 = [device supportsFamily:MTLGPUFamilyApple4];
-  }
   else
-  {
     supports_apple4 = [device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily4_v1];
-  }
-  config->backend_info.bSupportsDepthClamp = supports_mac1 || supports_apple4;
-  config->backend_info.bSupportsST3CTextures = supports_mac1;
-  config->backend_info.bSupportsBPTCTextures = supports_mac1;
+  if (@available(iOS 16.4, *))
+    supports_bcn = [device supportsBCTextureCompression];
+  config->backend_info.bSupportsDepthClamp = supports_apple4;
+  config->backend_info.bSupportsST3CTextures = supports_bcn;
+  config->backend_info.bSupportsBPTCTextures = supports_bcn;
+
   config->backend_info.bSupportsFramebufferFetch = true;
 #endif
 
@@ -265,12 +263,10 @@ AbstractTextureFormat Metal::Util::ToAbstract(MTLPixelFormat format)
   {
   case MTLPixelFormatRGBA8Unorm:            return AbstractTextureFormat::RGBA8;
   case MTLPixelFormatBGRA8Unorm:            return AbstractTextureFormat::BGRA8;
-#if TARGET_OS_OSX
   case MTLPixelFormatBC1_RGBA:              return AbstractTextureFormat::DXT1;
   case MTLPixelFormatBC2_RGBA:              return AbstractTextureFormat::DXT3;
   case MTLPixelFormatBC3_RGBA:              return AbstractTextureFormat::DXT5;
   case MTLPixelFormatBC7_RGBAUnorm:         return AbstractTextureFormat::BPTC;
-#endif
   case MTLPixelFormatR16Unorm:              return AbstractTextureFormat::R16;
   case MTLPixelFormatDepth16Unorm:          return AbstractTextureFormat::D16;
 #if TARGET_OS_OSX
@@ -283,18 +279,20 @@ AbstractTextureFormat Metal::Util::ToAbstract(MTLPixelFormat format)
   }
 }
 
+// Don't complain about BCn formats requiring iOS 16.4, these are just enum conversions
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+
 MTLPixelFormat Metal::Util::FromAbstract(AbstractTextureFormat format)
 {
   switch (format)
   {
   case AbstractTextureFormat::RGBA8:     return MTLPixelFormatRGBA8Unorm;
   case AbstractTextureFormat::BGRA8:     return MTLPixelFormatBGRA8Unorm;
-#if TARGET_OS_OSX
   case AbstractTextureFormat::DXT1:      return MTLPixelFormatBC1_RGBA;
   case AbstractTextureFormat::DXT3:      return MTLPixelFormatBC2_RGBA;
   case AbstractTextureFormat::DXT5:      return MTLPixelFormatBC3_RGBA;
   case AbstractTextureFormat::BPTC:      return MTLPixelFormatBC7_RGBAUnorm;
-#endif
   case AbstractTextureFormat::R16:       return MTLPixelFormatR16Unorm;
   case AbstractTextureFormat::D16:       return MTLPixelFormatDepth16Unorm;
 #if TARGET_OS_OSX
@@ -306,6 +304,8 @@ MTLPixelFormat Metal::Util::FromAbstract(AbstractTextureFormat format)
   default:                               return MTLPixelFormatInvalid;
   }
 }
+
+#pragma clang diagnostic pop
 
 // clang-format on
 


### PR DESCRIPTION
So all those M1 iPads can enjoy their high res texture packs

Note: This means Xcode 14.3 will be required for anyone compiling for iOS.  Should I add anything to cmake for that?