### PR TITLE
XInput2: Accept input from keyboards other than the first master

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -166,6 +166,10 @@ KeyboardMouse::KeyboardMouse(Window window, int opcode, int pointer, int keyboar
   name = std::string(pointer_device->name);
   XIFreeDeviceInfo(pointer_device);
 
+  // Tell core X functions which keyboard is "the" keyboard for this
+  // X connection.
+  XISetClientPointer(m_display, None, pointer_deviceid);
+
   {
     unsigned char mask_buf[(XI_LASTEVENT + 7) / 8] = {};
     XISetMask(mask_buf, XI_ButtonPress);
@@ -387,6 +391,10 @@ void KeyboardMouse::UpdateInput()
   // KeyRelease and FocusOut events are sometimes not received.
   // Cycling Alt-Tab and landing on the same window results in a stuck "Alt" key.
   // Unpressed keys are released here.
+  // Because we called XISetClientPointer in the constructor, XQueryKeymap
+  // will return the state of the associated keyboard, even if it isn't the
+  // first master keyboard.  (XInput2 doesn't provide a function to query
+  // keyboard state.)
   std::array<char, 32> keyboard;
   XQueryKeymap(m_display, keyboard.data());
   for (size_t i = 0; i != keyboard.size(); ++i)


### PR DESCRIPTION
This is a fix for a bug I found while putting together a series that reworks XInput2 to fix https://bugs.dolphin-emu.org/issues/10668 (and two duplicates).  Because this fix is necessary regardless of whether you take that series, I've sent it as its own pull request for ease of review and merging.  

---

XInput2 was created to support multiple pointer/keyboard pairs (often called MPX for multi-pointer X).  Dolphin's XInput2 implementation has always supported MPX by creating a KeyboardMouse object per master pointer.  Since commit bbb12a7, Dolphin's keyboard state is filtered by the output of XQueryKeymap.  As a core X function, XQueryKeymap queries "the" keyboard, which by default is the first master keyboard.  As a result, Dolphin will ignore keys pressed on other master keyboards unless the first master is simultaneously pressing the same keys.

XInput2 doesn't provide a function to query the keyboard state.  There is no XIQueryKeymap and the current state is not a member of the XIKeyClassInfo returned by XIQueryDevice.  Instead, XInput2 allows a master pointer to be nominated as "the" pointer on a per-client basis, with "the" keyboard automatically becoming the associated master keyboard.  The "documentation" [1] says passing None for the window is only for debugging purposes, but it is documented in the XISetClientPointer man page and seems to be the only way to query keyboards beyond the first.

With this commit, Dolphin correctly reads keys from keyboards other than the first master keyboard.  To test, use the xinput command-line utility to create a master pointer and reattach a keyboard to the associated master keyboard.

[1]: https://who-t.blogspot.com/2009/07/xi2-recipes-part-6.html
     (the XInput2 developer's blog)