### PR TITLE
VideoBackends:Metal: Fix perf queries

### DIFF
--- a/Source/Core/VideoBackends/Metal/MTLStateTracker.h
+++ b/Source/Core/VideoBackends/Metal/MTLStateTracker.h
@@ -267,6 +267,7 @@ private:
     u32 texel_buffer_offset0;
     u32 texel_buffer_offset1;
     PerfQueryGroup perf_query_group = static_cast<PerfQueryGroup>(-1);
+    u32 perf_query_id;
   } m_state;
 
   u32 m_perf_query_tracker_counter = 0;


### PR DESCRIPTION
In #11647, the user was also kind enough to give the first ever test of the Metal renderer's PerfQuery implementation and it was pretty broken: https://twitter.com/sup39x1207/status/1635115984108548096

Hopefully it's now less broken, but I still don't know how to get that test screen to verify