### PR TITLE
Embrace nullptr over NULL and 0

### DIFF
--- a/Source/Core/Common/GL/GLInterface/GLX.cpp
+++ b/Source/Core/Common/GL/GLInterface/GLX.cpp
@@ -155,7 +155,8 @@ bool GLContextGLX::Initialize(const WindowSystemInfo& wsi, bool stereo, bool cor
            GLX_CONTEXT_FLAGS_ARB, GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB, None}};
 
       s_glxError = false;
-      m_context = glXCreateContextAttribs(m_display, m_fbconfig, 0, True, &context_attribs[0]);
+      m_context =
+          glXCreateContextAttribs(m_display, m_fbconfig, nullptr, True, &context_attribs[0]);
       XSync(m_display, False);
       if (!m_context || s_glxError)
         continue;
@@ -174,7 +175,8 @@ bool GLContextGLX::Initialize(const WindowSystemInfo& wsi, bool stereo, bool cor
     std::array<int, 5> context_attribs_legacy = {
         {GLX_CONTEXT_MAJOR_VERSION_ARB, 1, GLX_CONTEXT_MINOR_VERSION_ARB, 0, None}};
     s_glxError = false;
-    m_context = glXCreateContextAttribs(m_display, m_fbconfig, 0, True, &context_attribs_legacy[0]);
+    m_context =
+        glXCreateContextAttribs(m_display, m_fbconfig, nullptr, True, &context_attribs_legacy[0]);
     XSync(m_display, False);
     m_attribs.clear();
     m_attribs.insert(m_attribs.end(), context_attribs_legacy.begin(), context_attribs_legacy.end());

--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -250,7 +250,7 @@ size_t MemPhysical()
   mib[1] = HW_PHYSMEM64;
 #endif
   size_t length = sizeof(size_t);
-  sysctl(mib, 2, &physical_memory, &length, NULL, 0);
+  sysctl(mib, 2, &physical_memory, &length, nullptr, 0);
   return physical_memory;
 #elif defined __HAIKU__
   system_info sysinfo;

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -103,7 +103,7 @@ std::optional<IPCReply> USB_HIDv4::GetDeviceChange(const IOCtlRequest& request)
 IPCReply USB_HIDv4::Shutdown(const IOCtlRequest& request)
 {
   std::lock_guard lk{m_devicechange_hook_address_mutex};
-  if (m_devicechange_hook_request != 0)
+  if (m_devicechange_hook_request != nullptr)
   {
     auto& system = Core::System::GetInstance();
     auto& memory = system.GetMemory();

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -1052,7 +1052,7 @@ void InitLocal(const char* socket)
   addr.sun_family = AF_UNIX;
   strcpy(addr.sun_path, socket);
 
-  InitGeneric(PF_LOCAL, (const sockaddr*)&addr, sizeof(addr), NULL, NULL);
+  InitGeneric(PF_LOCAL, (const sockaddr*)&addr, sizeof(addr), nullptr, nullptr);
 }
 #endif
 

--- a/Source/Core/DolphinNoGUI/PlatformWin32.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformWin32.cpp
@@ -62,12 +62,12 @@ bool PlatformWin32::RegisterRenderWindowClass()
   wc.cbClsExtra = 0;
   wc.cbWndExtra = 0;
   wc.hInstance = GetModuleHandle(nullptr);
-  wc.hIcon = LoadIcon(NULL, IDI_ICON1);
-  wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+  wc.hIcon = LoadIcon(nullptr, IDI_ICON1);
+  wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
   wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
-  wc.lpszMenuName = NULL;
+  wc.lpszMenuName = nullptr;
   wc.lpszClassName = WINDOW_CLASS_NAME;
-  wc.hIconSm = LoadIcon(NULL, IDI_ICON1);
+  wc.hIconSm = LoadIcon(nullptr, IDI_ICON1);
 
   if (!RegisterClassEx(&wc))
   {

--- a/Source/Core/DolphinQt/QtUtils/FlowLayout.cpp
+++ b/Source/Core/DolphinQt/QtUtils/FlowLayout.cpp
@@ -75,7 +75,7 @@ QLayoutItem* FlowLayout::takeAt(int index)
   if (index >= 0 && index < m_item_list.size())
     return m_item_list.takeAt(index);
   else
-    return 0;
+    return nullptr;
 }
 
 Qt::Orientations FlowLayout::expandingDirections() const
@@ -167,7 +167,7 @@ int FlowLayout::smartSpacing(QStyle::PixelMetric pm) const
   else if (parent->isWidgetType())
   {
     QWidget* pw = static_cast<QWidget*>(parent);
-    return pw->style()->pixelMetric(pm, 0, pw);
+    return pw->style()->pixelMetric(pm, nullptr, pw);
   }
   else
   {

--- a/Source/Core/DolphinQt/QtUtils/WinIconHelper.cpp
+++ b/Source/Core/DolphinQt/QtUtils/WinIconHelper.cpp
@@ -42,7 +42,7 @@ static QPixmap PixmapFromHICON(HICON icon)
   const int h = iconinfo.yHotspot * 2;
   BITMAPINFO bitmapInfo = GetBMI(w, h, false);
   DWORD* bits;
-  HBITMAP winBitmap = CreateDIBSection(hdc, &bitmapInfo, DIB_RGB_COLORS, (VOID**)&bits, NULL, 0);
+  HBITMAP winBitmap = CreateDIBSection(hdc, &bitmapInfo, DIB_RGB_COLORS, (VOID**)&bits, nullptr, 0);
   HGDIOBJ oldhdc = reinterpret_cast<HBITMAP>(SelectObject(hdc, winBitmap));
   DrawIconEx(hdc, 0, 0, icon, iconinfo.xHotspot * 2, iconinfo.yHotspot * 2, 0, 0, DI_NORMAL);
 

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -410,7 +410,7 @@ void GameCubePane::BrowseMemcard(ExpansionInterface::Slot slot)
   const QString filename = DolphinFileDialog::getSaveFileName(
       this, tr("Choose a file to open or create"),
       QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)),
-      tr("GameCube Memory Cards (*.raw *.gcp)"), 0, QFileDialog::DontConfirmOverwrite);
+      tr("GameCube Memory Cards (*.raw *.gcp)"), nullptr, QFileDialog::DontConfirmOverwrite);
 
   if (!filename.isEmpty())
     SetMemcard(slot, filename);
@@ -618,7 +618,7 @@ void GameCubePane::BrowseAGPRom(ExpansionInterface::Slot slot)
 
   QString filename = DolphinFileDialog::getSaveFileName(
       this, tr("Choose a file to open"), QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)),
-      tr("Game Boy Advance Carts (*.gba)"), 0, QFileDialog::DontConfirmOverwrite);
+      tr("Game Boy Advance Carts (*.gba)"), nullptr, QFileDialog::DontConfirmOverwrite);
 
   if (!filename.isEmpty())
     SetAGPRom(slot, filename);

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -154,14 +154,14 @@ void ToolBar::UpdatePausePlayButtonState(const bool playing_state)
 {
   if (playing_state)
   {
-    disconnect(m_pause_play_action, 0, 0, 0);
+    disconnect(m_pause_play_action, nullptr, nullptr, nullptr);
     m_pause_play_action->setText(tr("Pause"));
     m_pause_play_action->setIcon(Resources::GetScaledThemeIcon("pause"));
     connect(m_pause_play_action, &QAction::triggered, this, &ToolBar::PausePressed);
   }
   else
   {
-    disconnect(m_pause_play_action, 0, 0, 0);
+    disconnect(m_pause_play_action, nullptr, nullptr, nullptr);
     m_pause_play_action->setText(tr("Play"));
     m_pause_play_action->setIcon(Resources::GetScaledThemeIcon("play"));
     connect(m_pause_play_action, &QAction::triggered, this, &ToolBar::PlayPressed);

--- a/Source/Core/UICommon/Disassembler.cpp
+++ b/Source/Core/UICommon/Disassembler.cpp
@@ -47,7 +47,8 @@ HostDisassemblerLLVM::HostDisassemblerLLVM(const std::string& host_disasm, int i
   LLVMInitializeAllTargetMCs();
   LLVMInitializeAllDisassemblers();
 
-  m_llvm_context = LLVMCreateDisasmCPU(host_disasm.c_str(), cpu.c_str(), nullptr, 0, 0, nullptr);
+  m_llvm_context =
+      LLVMCreateDisasmCPU(host_disasm.c_str(), cpu.c_str(), nullptr, 0, nullptr, nullptr);
 
   // Couldn't create llvm context
   if (!m_llvm_context)

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -36,7 +36,7 @@ ResourcePack::ResourcePack(const std::string& path) : m_path(path)
     return;
   }
 
-  if (unzLocateFile(file, "manifest.json", 0) == UNZ_END_OF_LIST_OF_FILE)
+  if (unzLocateFile(file, "manifest.json", nullptr) == UNZ_END_OF_LIST_OF_FILE)
   {
     m_valid = false;
     m_error = "Resource pack is missing a manifest.";
@@ -63,7 +63,7 @@ ResourcePack::ResourcePack(const std::string& path) : m_path(path)
     return;
   }
 
-  if (unzLocateFile(file, "logo.png", 0) != UNZ_END_OF_LIST_OF_FILE)
+  if (unzLocateFile(file, "logo.png", nullptr) != UNZ_END_OF_LIST_OF_FILE)
   {
     unz_file_info64 logo_info{};
     unzGetCurrentFileInfo64(file, &logo_info, nullptr, 0, nullptr, 0, nullptr, 0);

--- a/Source/Core/VideoBackends/D3D12/DX12Context.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Context.cpp
@@ -221,7 +221,7 @@ bool DXContext::CreateFence()
     return false;
 
   m_fence_event = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-  ASSERT_MSG(VIDEO, m_fence_event != NULL, "Failed to create fence event");
+  ASSERT_MSG(VIDEO, m_fence_event != nullptr, "Failed to create fence event");
   if (!m_fence_event)
     return false;
 

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -296,7 +296,7 @@ OGLStagingTexture::OGLStagingTexture(StagingTextureType type, const TextureConfi
 
 OGLStagingTexture::~OGLStagingTexture()
 {
-  if (m_fence != 0)
+  if (m_fence != nullptr)
     glDeleteSync(m_fence);
   if (m_map_pointer)
   {
@@ -418,7 +418,7 @@ void OGLStagingTexture::CopyFromTexture(const AbstractTexture* src,
   // If we support buffer storage, create a fence for synchronization.
   if (UsePersistentStagingBuffers())
   {
-    if (m_fence != 0)
+    if (m_fence != nullptr)
       glDeleteSync(m_fence);
 
     glMemoryBarrier(GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT);
@@ -479,7 +479,7 @@ void OGLStagingTexture::CopyToTexture(const MathUtil::Rectangle<int>& src_rect,
   // If we support buffer storage, create a fence for synchronization.
   if (UsePersistentStagingBuffers())
   {
-    if (m_fence != 0)
+    if (m_fence != nullptr)
       glDeleteSync(m_fence);
 
     m_fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
@@ -493,7 +493,7 @@ void OGLStagingTexture::Flush()
 {
   // No-op when not using buffer storage, as the transfers happen on Map().
   // m_fence will always be zero in this case.
-  if (m_fence == 0)
+  if (m_fence == nullptr)
   {
     m_needs_flush = false;
     return;
@@ -501,7 +501,7 @@ void OGLStagingTexture::Flush()
 
   glClientWaitSync(m_fence, 0, GL_TIMEOUT_IGNORED);
   glDeleteSync(m_fence);
-  m_fence = 0;
+  m_fence = nullptr;
   m_needs_flush = false;
 }
 

--- a/Source/Core/VideoBackends/OGL/OGLTexture.h
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.h
@@ -75,7 +75,7 @@ private:
   GLenum m_target;
   GLuint m_buffer_name;
   size_t m_buffer_size;
-  GLsync m_fence = 0;
+  GLsync m_fence = nullptr;
 };
 
 class OGLFramebuffer final : public AbstractFramebuffer

--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -58,7 +58,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     }
 
     // Relaunch the updater as administrator
-    ShellExecuteW(nullptr, L"runas", path->c_str(), pCmdLine, NULL, SW_SHOW);
+    ShellExecuteW(nullptr, L"runas", path->c_str(), pCmdLine, nullptr, SW_SHOW);
     return 0;
   }
 

--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -77,7 +77,7 @@ bool InitWindow()
   if (!window_handle)
     return false;
 
-  if (SUCCEEDED(CoCreateInstance(CLSID_TaskbarList, NULL, CLSCTX_INPROC_SERVER,
+  if (SUCCEEDED(CoCreateInstance(CLSID_TaskbarList, nullptr, CLSCTX_INPROC_SERVER,
                                  IID_PPV_ARGS(taskbar_list.GetAddressOf()))))
   {
     if (FAILED(taskbar_list->HrInit()))
@@ -88,8 +88,8 @@ bool InitWindow()
 
   int y = PADDING_HEIGHT;
 
-  label_handle = CreateWindow(L"STATIC", NULL, WS_VISIBLE | WS_CHILD, 5, y, 500, 25, window_handle,
-                              nullptr, nullptr, 0);
+  label_handle = CreateWindow(L"STATIC", nullptr, WS_VISIBLE | WS_CHILD, 5, y, 500, 25,
+                              window_handle, nullptr, nullptr, 0);
 
   if (!label_handle)
     return false;
@@ -106,7 +106,7 @@ bool InitWindow()
 
   y += GetWindowHeight(label_handle) + PADDING_HEIGHT;
 
-  total_progressbar_handle = CreateWindow(PROGRESS_CLASS, NULL, PROGRESSBAR_FLAGS, 5, y, 470, 25,
+  total_progressbar_handle = CreateWindow(PROGRESS_CLASS, nullptr, PROGRESSBAR_FLAGS, 5, y, 470, 25,
                                           window_handle, nullptr, nullptr, 0);
 
   y += GetWindowHeight(total_progressbar_handle) + PADDING_HEIGHT;
@@ -114,8 +114,8 @@ bool InitWindow()
   if (!total_progressbar_handle)
     return false;
 
-  current_progressbar_handle = CreateWindow(PROGRESS_CLASS, NULL, PROGRESSBAR_FLAGS, 5, y, 470, 25,
-                                            window_handle, nullptr, nullptr, 0);
+  current_progressbar_handle = CreateWindow(PROGRESS_CLASS, nullptr, PROGRESSBAR_FLAGS, 5, y, 470,
+                                            25, window_handle, nullptr, nullptr, 0);
 
   y += GetWindowHeight(current_progressbar_handle) + PADDING_HEIGHT;
 


### PR DESCRIPTION
This PR extracts the functional changes to Dolphin's source code from PR #11709, as that PR is held up by [requiring CMake 3.25 support](https://github.com/dolphin-emu/dolphin/pull/11716) on all platforms.  Preferring nullptr over zero as a null pointer constant is a [coding guideline](https://github.com/dolphin-emu/dolphin/blob/master/Contributing.md#general-1) for the Dolphin Emulator project, as well as a [C++ Core Guideline](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-nullptr), though I'm sure I don't have to tell you this.