### PR TITLE
Xinput2: use raw events and queries

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -441,8 +441,7 @@ ControlState KeyboardMouse::Key::GetState() const
   return (m_keyboard[m_keycode / 8] & (1 << (m_keycode % 8))) != 0;
 }
 
-KeyboardMouse::Button::Button(unsigned int index, unsigned int* buttons)
-    : m_buttons(buttons), m_index(index)
+KeyboardMouse::Button::Button(unsigned int index, u32* buttons) : m_buttons(buttons), m_index(index)
 {
   name = fmt::format("Click {}", m_index + 1);
 }

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -108,7 +108,6 @@ private:
   };
 
 private:
-  void SelectEventsForDevice(XIEventMask* mask, int deviceid);
   void UpdateCursor(bool should_center_mouse);
 
 public:

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -13,6 +13,7 @@ extern "C" {
 #include <X11/keysym.h>
 }
 
+#include "Common/CommonTypes.h"
 #include "Common/Matrix.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
@@ -26,7 +27,7 @@ private:
   struct State
   {
     std::array<char, 32> keyboard;
-    unsigned int buttons;
+    u32 buttons;
     Common::Vec2 cursor;
     Common::Vec3 axis;
     Common::Vec3 relative_mouse;
@@ -52,11 +53,11 @@ private:
   {
   public:
     std::string GetName() const override { return name; }
-    Button(unsigned int index, unsigned int* buttons);
+    Button(unsigned int index, u32* buttons);
     ControlState GetState() const override;
 
   private:
-    const unsigned int* m_buttons;
+    const u32* m_buttons;
     const unsigned int m_index;
     std::string name;
   };


### PR DESCRIPTION
This series reworks XInput2 to fix https://bugs.dolphin-emu.org/issues/10668 (and two duplicates).  The first commit in this series is the (only) commit in #11758.  GitHub won't let me make a pull request based off another pull request (it redirects me to my fork).  I thought I was helping by fixing one bug per PR, but actually I just created noise.  Sorry about that!

---

Bug 10668 is a complaint that while Dolphin is open, Openbox does not respond to clicks on the root window, and Dolphin only sees clicks on the root window or window decorations, not inside Dolphin's own windows.  The root cause of this conflict is special X server behavior that causes button press events to grant the receiving client an implicit passive grab on the pointer.  Because only one client can get the grab, the X server has special rules about button press event delivery across the core protocol and both XInput versions.  This series switches to using raw events, which are always delivered to all clients listening for them.  As an Openbox user, I can confirm this resolves the conflict between Dolphin and Openbox.  I also tested using Mutter running under X, where it continues to work as it did before.

- c6f9e61 fixes using two or more master keyboards at the same time, as you might do if you and a friend are playing a two-player game, each with your own mouse and keyboard.
- 7aeae81 replaces `unsigned int` with `u32` in the definition of a flag field.  No functional change.  Could be part of 323d08f, which cares that it's specifically 32 bits, but split here for ease of review.
- c5391c9 requests XInput 2.1, up from 2.0, to ensure we get raw events all the time.
- 323d09f switches from normal events to raw events for button presses and key movements.  Then to avoid manually applying mappings (e.g., swapping left and right buttons for a left-handed user), we ignore the event payload and just query the current state after the event loop if events were delivered.  Actually we were already querying the state, just not using it as the single source of truth.  Regarding performance, we were unconditionally querying the keyboard before, so we actually do fewer queries now.
- 2000f0b stops listening to slave devices to avoid processing each raw event twice (and also to delete some code).

This is my first nontrivial pull request, so I would appreciate general feedback or style nits.  I also have these specific questions for reviewers:

- 2000f0b is a user-visible change, because we were processing each raw motion event twice and now we process it only once.  I don't know what relative mouse input is generally used for, so I'm not sure if this is fixing a bug, or if we should multiply by 2 to restore the previous behavior, or tweak the smoothing constants, or...?
- In the controller mapping dialog, the (GUI) buttons don't update their boldness when other applications are focused.  If I start a GameCube game with background input enabled, then open the GameCube controller mapping dialog with GC buttons bound to clicks, then repeatedly click on another application's window, the game gets the GC button presses but the GUI buttons don't update.  Also, if stick inputs are bound to Cursor X/Y+/-, the stick calibration widget updates even when the pointer is over another application's focused window.  It's just the GUI buttons that don't update.
- Old commit 2b640a4f suggested that queries, being synchronous, are a performance problem, but bbb12a75 added an unconditional keyboard query.  We now query the pointer/keyboard only if a pointer/keyboard event arrived.  In limited testing, at native resolution, I saw no difference in frame times between no input and continual mouse movement and clicking.  Cranking the resolution up to drop to ~55 FPS, mouse input does increase frametime variance slightly, but also brings the framerate back up to 60 FPS, which I can't explain.  Any ideas on quantifying the performance impact of this change?
- Is the detail in the commit message for 323d09f appropriate?  Having lost important information in personal projects behind messages like "see discussion in # 40", I want commit messages to include all the information necessary to understand the commit, and whoever looks at this code next is unlikely to be an X expert (I sure wasn't).  On the other hand, it is a very long message.