### PR TITLE
RetroAchievements Memory, Events, and Awarding

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -382,6 +382,25 @@ AchievementManager::ResponseType AchievementManager::AwardAchievement(Achievemen
   return r_type;
 }
 
+AchievementManager::ResponseType AchievementManager::SubmitLeaderboard(AchievementId leaderboard_id,
+                                                                       int value)
+{
+  std::string username = Config::Get(Config::RA_USERNAME);
+  std::string api_token = Config::Get(Config::RA_API_TOKEN);
+  rc_api_submit_lboard_entry_request_t submit_request = {.username = username.c_str(),
+                                                         .api_token = api_token.c_str(),
+                                                         .leaderboard_id = leaderboard_id,
+                                                         .score = value,
+                                                         .game_hash = m_game_hash.data()};
+  rc_api_submit_lboard_entry_response_t submit_response = {};
+  ResponseType r_type =
+      Request<rc_api_submit_lboard_entry_request_t, rc_api_submit_lboard_entry_response_t>(
+          submit_request, &submit_response, rc_api_init_submit_lboard_entry_request,
+          rc_api_process_submit_lboard_entry_response);
+  rc_api_destroy_submit_lboard_entry_response(&submit_response);
+  return r_type;
+}
+
 // Every RetroAchievements API call, with only a partial exception for fetch_image, follows
 // the same design pattern (here, X is the name of the call):
 //   Create a specific rc_api_X_request_t struct and populate with the necessary values

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -409,6 +409,20 @@ void AchievementManager::ActivateDeactivateAchievement(AchievementId id, bool en
     rc_runtime_deactivate_achievement(&m_runtime, id);
 }
 
+RichPresence AchievementManager::GenerateRichPresence()
+{
+  RichPresence rp_buffer;
+  Core::RunAsCPUThread([&] {
+    rc_runtime_get_richpresence(
+        &m_runtime, rp_buffer.data(), RP_SIZE,
+        [](unsigned address, unsigned num_bytes, void* ud) {
+          return static_cast<AchievementManager*>(ud)->MemoryPeeker(address, num_bytes, ud);
+        },
+        this, nullptr);
+  });
+  return rp_buffer;
+}
+
 AchievementManager::ResponseType AchievementManager::AwardAchievement(AchievementId achievement_id)
 {
   std::string username = Config::Get(Config::RA_USERNAME);

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -417,6 +417,18 @@ AchievementManager::PingRichPresence(const RichPresence& rich_presence)
   return r_type;
 }
 
+void AchievementManager::HandleAchievementTriggeredEvent(const rc_runtime_event_t* runtime_event)
+{
+  auto it = m_unlock_map.find(runtime_event->id);
+  if (it == m_unlock_map.end())
+    return;
+  it->second.session_unlock_count++;
+  m_queue.EmplaceItem([this, runtime_event] { AwardAchievement(runtime_event->id); });
+  ActivateDeactivateAchievement(runtime_event->id, Config::Get(Config::RA_ACHIEVEMENTS_ENABLED),
+                                Config::Get(Config::RA_UNOFFICIAL_ENABLED),
+                                Config::Get(Config::RA_ENCORE_ENABLED));
+}
+
 // Every RetroAchievements API call, with only a partial exception for fetch_image, follows
 // the same design pattern (here, X is the name of the call):
 //   Create a specific rc_api_X_request_t struct and populate with the necessary values

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -202,6 +202,19 @@ void AchievementManager::ActivateDeactivateRichPresence()
       nullptr, 0);
 }
 
+void AchievementManager::AchievementEventHandler(const rc_runtime_event_t* runtime_event)
+{
+  switch (runtime_event->type)
+  {
+  case RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED:
+    HandleAchievementTriggeredEvent(runtime_event);
+    break;
+  case RC_RUNTIME_EVENT_LBOARD_TRIGGERED:
+    HandleLeaderboardTriggeredEvent(runtime_event);
+    break;
+  }
+}
+
 void AchievementManager::CloseGame()
 {
   m_is_game_loaded = false;

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -401,6 +401,22 @@ AchievementManager::ResponseType AchievementManager::SubmitLeaderboard(Achieveme
   return r_type;
 }
 
+AchievementManager::ResponseType
+AchievementManager::PingRichPresence(const RichPresence& rich_presence)
+{
+  std::string username = Config::Get(Config::RA_USERNAME);
+  std::string api_token = Config::Get(Config::RA_API_TOKEN);
+  rc_api_ping_request_t ping_request = {.username = username.c_str(),
+                                        .api_token = api_token.c_str(),
+                                        .game_id = m_game_id,
+                                        .rich_presence = rich_presence.data()};
+  rc_api_ping_response_t ping_response = {};
+  ResponseType r_type = Request<rc_api_ping_request_t, rc_api_ping_response_t>(
+      ping_request, &ping_response, rc_api_init_ping_request, rc_api_process_ping_response);
+  rc_api_destroy_ping_response(&ping_response);
+  return r_type;
+}
+
 // Every RetroAchievements API call, with only a partial exception for fetch_image, follows
 // the same design pattern (here, X is the name of the call):
 //   Create a specific rc_api_X_request_t struct and populate with the necessary values

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -429,6 +429,12 @@ void AchievementManager::HandleAchievementTriggeredEvent(const rc_runtime_event_
                                 Config::Get(Config::RA_ENCORE_ENABLED));
 }
 
+void AchievementManager::HandleLeaderboardTriggeredEvent(const rc_runtime_event_t* runtime_event)
+{
+  m_queue.EmplaceItem(
+      [this, runtime_event] { SubmitLeaderboard(runtime_event->id, runtime_event->value); });
+}
+
 // Every RetroAchievements API call, with only a partial exception for fetch_image, follows
 // the same design pattern (here, X is the name of the call):
 //   Create a specific rc_api_X_request_t struct and populate with the necessary values

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -48,6 +48,8 @@ public:
   void ActivateDeactivateLeaderboards();
   void ActivateDeactivateRichPresence();
 
+  void AchievementEventHandler(const rc_runtime_event_t* runtime_event);
+
   void CloseGame();
   void Logout();
   void Shutdown();

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -70,6 +70,7 @@ private:
   ResponseType PingRichPresence(const RichPresence& rich_presence);
 
   void HandleAchievementTriggeredEvent(const rc_runtime_event_t* runtime_event);
+  void HandleLeaderboardTriggeredEvent(const rc_runtime_event_t* runtime_event);
 
   template <typename RcRequest, typename RcResponse>
   ResponseType Request(RcRequest rc_request, RcResponse* rc_response,

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -22,6 +22,11 @@ using AchievementId = u32;
 constexpr size_t RP_SIZE = 256;
 using RichPresence = std::array<char, RP_SIZE>;
 
+namespace Core
+{
+class System;
+}
+
 class AchievementManager
 {
 public:
@@ -48,6 +53,7 @@ public:
   void ActivateDeactivateLeaderboards();
   void ActivateDeactivateRichPresence();
 
+  u32 MemoryPeeker(u32 address, u32 num_bytes, void* ud);
   void AchievementEventHandler(const rc_runtime_event_t* runtime_event);
 
   void CloseGame();
@@ -80,6 +86,7 @@ private:
                        const std::function<int(RcResponse*, const char*)>& process_response);
 
   rc_runtime_t m_runtime{};
+  Core::System* m_system{};
   bool m_is_runtime_initialized = false;
   std::array<char, HASH_LENGTH> m_game_hash{};
   u32 m_game_id = 0;

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -53,6 +53,7 @@ public:
   void ActivateDeactivateLeaderboards();
   void ActivateDeactivateRichPresence();
 
+  void DoFrame();
   u32 MemoryPeeker(u32 address, u32 num_bytes, void* ud);
   void AchievementEventHandler(const rc_runtime_event_t* runtime_event);
 
@@ -93,6 +94,7 @@ private:
   u32 m_game_id = 0;
   rc_api_fetch_game_data_response_t m_game_data{};
   bool m_is_game_loaded = false;
+  u64 m_last_ping_time = 0;
 
   struct UnlockStatus
   {

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -69,6 +69,8 @@ private:
   ResponseType SubmitLeaderboard(AchievementId leaderboard_id, int value);
   ResponseType PingRichPresence(const RichPresence& rich_presence);
 
+  void HandleAchievementTriggeredEvent(const rc_runtime_event_t* runtime_event);
+
   template <typename RcRequest, typename RcResponse>
   ResponseType Request(RcRequest rc_request, RcResponse* rc_response,
                        const std::function<int(rc_api_request_t*, const RcRequest*)>& init_request,

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -72,6 +72,7 @@ private:
   ResponseType FetchUnlockData(bool hardcore);
 
   void ActivateDeactivateAchievement(AchievementId id, bool enabled, bool unofficial, bool encore);
+  RichPresence GenerateRichPresence();
 
   ResponseType AwardAchievement(AchievementId achievement_id);
   ResponseType SubmitLeaderboard(AchievementId leaderboard_id, int value);

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -19,6 +19,8 @@
 #include "Common/WorkQueueThread.h"
 
 using AchievementId = u32;
+constexpr size_t RP_SIZE = 256;
+using RichPresence = std::array<char, RP_SIZE>;
 
 class AchievementManager
 {
@@ -65,6 +67,8 @@ private:
 
   ResponseType AwardAchievement(AchievementId achievement_id);
   ResponseType SubmitLeaderboard(AchievementId leaderboard_id, int value);
+  ResponseType PingRichPresence(const RichPresence& rich_presence);
+
   template <typename RcRequest, typename RcResponse>
   ResponseType Request(RcRequest rc_request, RcResponse* rc_response,
                        const std::function<int(rc_api_request_t*, const RcRequest*)>& init_request,

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -64,6 +64,7 @@ private:
   void ActivateDeactivateAchievement(AchievementId id, bool enabled, bool unofficial, bool encore);
 
   ResponseType AwardAchievement(AchievementId achievement_id);
+  ResponseType SubmitLeaderboard(AchievementId leaderboard_id, int value);
   template <typename RcRequest, typename RcResponse>
   ResponseType Request(RcRequest rc_request, RcResponse* rc_response,
                        const std::function<int(rc_api_request_t*, const RcRequest*)>& init_request,

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #ifdef USE_RETRO_ACHIEVEMENTS
+#include <array>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -62,6 +63,7 @@ private:
 
   void ActivateDeactivateAchievement(AchievementId id, bool enabled, bool unofficial, bool encore);
 
+  ResponseType AwardAchievement(AchievementId achievement_id);
   template <typename RcRequest, typename RcResponse>
   ResponseType Request(RcRequest rc_request, RcResponse* rc_response,
                        const std::function<int(rc_api_request_t*, const RcRequest*)>& init_request,
@@ -69,7 +71,8 @@ private:
 
   rc_runtime_t m_runtime{};
   bool m_is_runtime_initialized = false;
-  unsigned int m_game_id = 0;
+  std::array<char, HASH_LENGTH> m_game_hash{};
+  u32 m_game_id = 0;
   rc_api_fetch_game_data_response_t m_game_data{};
   bool m_is_game_loaded = false;
 


### PR DESCRIPTION
This is a portion of an integration with the RetroAchievements tools and libraries for connecting to the website, downloading data, unlocking achievements and submitting to leaderboards for games running in Dolphin. In this PR, the AchievementsManager created in a previous PR is further implemented to peek into game memory, process that within the rcheevos library, and handle achievement events that occur, resulting in the API calls to award achievements, submit scores/times to leaderboards, and generate and post Rich Presence for the currently played game.