### PR TITLE
IOS/WiiSockMan: Move instance to IOS Kernel.

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -308,6 +308,7 @@ Kernel::~Kernel()
   {
     std::lock_guard lock(m_device_map_mutex);
     m_device_map.clear();
+    m_socket_manager.reset();
   }
 
   if (m_is_responsible_for_nand_root)
@@ -361,6 +362,11 @@ std::shared_ptr<FSDevice> Kernel::GetFSDevice()
 std::shared_ptr<ESDevice> Kernel::GetES()
 {
   return std::static_pointer_cast<ESDevice>(m_device_map.at("/dev/es"));
+}
+
+std::shared_ptr<WiiSockMan> Kernel::GetSocketManager()
+{
+  return m_socket_manager;
 }
 
 // Since we don't have actual processes, we keep track of only the PPC's UID/GID.
@@ -562,6 +568,11 @@ void Kernel::AddStaticDevices()
   AddDevice(std::make_unique<DeviceStub>(*this, "/dev/sdio/slot1"));
 
   // Network modules
+  if (HasFeature(features, Feature::KD) || HasFeature(features, Feature::SO) ||
+      HasFeature(features, Feature::SSL))
+  {
+    m_socket_manager = std::make_shared<IOS::HLE::WiiSockMan>();
+  }
   if (HasFeature(features, Feature::KD))
   {
     AddDevice(std::make_unique<NetKDRequestDevice>(*this, "/dev/net/kd/request"));
@@ -825,7 +836,8 @@ void Kernel::UpdateDevices()
 
 void Kernel::UpdateWantDeterminism(const bool new_want_determinism)
 {
-  WiiSockMan::GetInstance().UpdateWantDeterminism(new_want_determinism);
+  if (m_socket_manager)
+    m_socket_manager->UpdateWantDeterminism(new_want_determinism);
   for (const auto& device : m_device_map)
     device.second->UpdateWantDeterminism(new_want_determinism);
 }
@@ -845,6 +857,9 @@ void Kernel::DoState(PointerWrap& p)
 
   if (m_title_id == Titles::MIOS)
     return;
+
+  if (m_socket_manager)
+    m_socket_manager->DoState(p);
 
   for (const auto& entry : m_device_map)
     entry.second->DoState(p);

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -35,6 +35,7 @@ class FileSystem;
 class Device;
 class ESDevice;
 class FSDevice;
+class WiiSockMan;
 
 struct Request;
 struct OpenRequest;
@@ -130,6 +131,9 @@ public:
   std::shared_ptr<FSDevice> GetFSDevice();
   std::shared_ptr<ESDevice> GetES();
 
+  // This is only available on an EmulationKernel if the IOS features require it.
+  std::shared_ptr<WiiSockMan> GetSocketManager();
+
   void EnqueueIPCRequest(u32 address);
   void EnqueueIPCReply(const Request& request, s32 return_value, s64 cycles_in_future = 0,
                        CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
@@ -179,6 +183,7 @@ protected:
 
   IOSC m_iosc;
   std::shared_ptr<FS::FileSystem> m_fs;
+  std::shared_ptr<WiiSockMan> m_socket_manager;
 };
 
 // HLE for an IOS tied to emulation: base kernel which may have additional modules loaded.

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -161,7 +161,9 @@ NetKDRequestDevice::NetKDRequestDevice(Kernel& ios, const std::string& device_na
 
 NetKDRequestDevice::~NetKDRequestDevice()
 {
-  WiiSockMan::GetInstance().Clean();
+  auto socket_manager = m_ios.GetSocketManager();
+  if (socket_manager)
+    socket_manager->Clean();
 }
 
 void NetKDRequestDevice::Update()
@@ -348,7 +350,7 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
 
   case IOCTL_NWC24_CLEANUP_SOCKET:
     INFO_LOG_FMT(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_CLEANUP_SOCKET");
-    WiiSockMan::GetInstance().Clean();
+    m_ios.GetSocketManager()->Clean();
     break;
 
   case IOCTL_NWC24_LOCK_SOCKET:  // WiiMenu
@@ -452,7 +454,7 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
     // SOGetInterfaceOpt(0xfffe,0xc001);  // DHCP lease time remaining?
     // SOGetInterfaceOpt(0xfffe,0x1003);  // Error
     // Call /dev/net/ip/top 0x1b (SOCleanup), it closes all sockets
-    WiiSockMan::GetInstance().Clean();
+    m_ios.GetSocketManager()->Clean();
     return_value = IPC_SUCCESS;
     break;
   }

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -496,8 +496,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
       WII_SSL* ssl = &_SSL[sslID];
       mbedtls_ssl_setup(&ssl->ctx, &ssl->config);
       ssl->sockfd = memory.Read_U32(BufferOut2);
-      WiiSockMan& sm = WiiSockMan::GetInstance();
-      ssl->hostfd = sm.GetHostSocket(ssl->sockfd);
+      ssl->hostfd = m_ios.GetSocketManager()->GetHostSocket(ssl->sockfd);
       INFO_LOG_FMT(IOS_SSL, "IOCTLV_NET_SSL_CONNECT socket = {}", ssl->sockfd);
       mbedtls_ssl_set_bio(&ssl->ctx, ssl, SSLSendWithoutSNI, SSLRecv, nullptr);
       WriteReturnValue(SSL_OK, BufferIn);
@@ -520,8 +519,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
-      WiiSockMan& sm = WiiSockMan::GetInstance();
-      sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_DOHANDSHAKE);
+      m_ios.GetSocketManager()->DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_DOHANDSHAKE);
       return std::nullopt;
     }
     else
@@ -535,8 +533,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     const int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
-      WiiSockMan& sm = WiiSockMan::GetInstance();
-      sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_WRITE);
+      m_ios.GetSocketManager()->DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_WRITE);
       return std::nullopt;
     }
     else
@@ -559,8 +556,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
-      WiiSockMan& sm = WiiSockMan::GetInstance();
-      sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_READ);
+      m_ios.GetSocketManager()->DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_READ);
       return std::nullopt;
     }
     else

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -252,7 +252,6 @@ public:
   };
 
   static s32 GetNetErrorCode(s32 ret, std::string_view caller, bool is_rw);
-  static char* DecodeError(s32 ErrorCode);
 
   static WiiSockMan& GetInstance()
   {

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -174,10 +174,12 @@ struct WiiSockAddrIn
 };
 #pragma pack(pop)
 
+class WiiSockMan;
+
 class WiiSocket
 {
 public:
-  WiiSocket() = default;
+  explicit WiiSocket(WiiSockMan& socket_manager) : m_socket_manager(socket_manager) {}
   WiiSocket(const WiiSocket&) = delete;
   WiiSocket(WiiSocket&&) = default;
   ~WiiSocket();
@@ -225,6 +227,8 @@ private:
   bool IsValid() const { return fd >= 0; }
   bool IsTCP() const;
 
+  WiiSockMan& m_socket_manager;
+
   s32 fd = -1;
   s32 wii_fd = -1;
   bool nonBlock = false;
@@ -251,13 +255,15 @@ public:
     s64 timeout = 0;
   };
 
-  static s32 GetNetErrorCode(s32 ret, std::string_view caller, bool is_rw);
+  WiiSockMan();
+  WiiSockMan(const WiiSockMan&) = delete;
+  WiiSockMan& operator=(const WiiSockMan&) = delete;
+  WiiSockMan(WiiSockMan&&) = delete;
+  WiiSockMan& operator=(WiiSockMan&&) = delete;
+  ~WiiSockMan();
 
-  static WiiSockMan& GetInstance()
-  {
-    static WiiSockMan instance;  // Guaranteed to be destroyed.
-    return instance;             // Instantiated on first use.
-  }
+  s32 GetNetErrorCode(s32 ret, std::string_view caller, bool is_rw);
+
   void Update();
   static void ToNativeAddrIn(const u8* from, sockaddr_in* to);
   static void ToWiiAddrIn(const sockaddr_in& from, u8* to,
@@ -295,12 +301,6 @@ public:
   void UpdateWantDeterminism(bool want);
 
 private:
-  WiiSockMan() = default;
-  WiiSockMan(const WiiSockMan&) = delete;
-  WiiSockMan& operator=(const WiiSockMan&) = delete;
-  WiiSockMan(WiiSockMan&&) = delete;
-  WiiSockMan& operator=(WiiSockMan&&) = delete;
-
   void UpdatePollCommands();
 
   std::unordered_map<s32, WiiSocket> WiiSockets;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -96,7 +96,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 161;  // Last changed in PR 11655
+constexpr u32 STATE_VERSION = 162;  // Last changed in PR 11767
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -24,8 +24,10 @@
 
 #include "Common/FileUtil.h"
 #include "Core/Config/MainSettings.h"
+#include "Core/Core.h"
 #include "Core/IOS/Network/SSL.h"
 #include "Core/IOS/Network/Socket.h"
+#include "Core/System.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/Settings.h"
 
@@ -95,9 +97,8 @@ QTableWidgetItem* GetSocketState(s32 host_fd)
   return new QTableWidgetItem(QTableWidget::tr("Unbound"));
 }
 
-QTableWidgetItem* GetSocketBlocking(s32 wii_fd)
+static QTableWidgetItem* GetSocketBlocking(const IOS::HLE::WiiSockMan& socket_manager, s32 wii_fd)
 {
-  const auto& socket_manager = IOS::HLE::WiiSockMan::GetInstance();
   if (socket_manager.GetHostSocket(wii_fd) < 0)
     return new QTableWidgetItem();
   const bool is_blocking = socket_manager.IsSocketBlocking(wii_fd);
@@ -238,16 +239,27 @@ void NetworkWidget::Update()
   if (!isVisible())
     return;
 
+  // needed because there's a race condition on the IOS instance otherwise
+  Core::CPUThreadGuard guard(Core::System::GetInstance());
+
+  auto* ios = IOS::HLE::GetIOS();
+  if (!ios)
+    return;
+
+  auto socket_manager = ios->GetSocketManager();
+  if (!socket_manager)
+    return;
+
   m_socket_table->setRowCount(0);
   for (u32 wii_fd = 0; wii_fd < IOS::HLE::WII_SOCKET_FD_MAX; wii_fd++)
   {
     m_socket_table->insertRow(wii_fd);
-    const s32 host_fd = IOS::HLE::WiiSockMan::GetInstance().GetHostSocket(wii_fd);
+    const s32 host_fd = socket_manager->GetHostSocket(wii_fd);
     m_socket_table->setItem(wii_fd, 0, new QTableWidgetItem(QString::number(wii_fd)));
     m_socket_table->setItem(wii_fd, 1, GetSocketDomain(host_fd));
     m_socket_table->setItem(wii_fd, 2, GetSocketType(host_fd));
     m_socket_table->setItem(wii_fd, 3, GetSocketState(host_fd));
-    m_socket_table->setItem(wii_fd, 4, GetSocketBlocking(wii_fd));
+    m_socket_table->setItem(wii_fd, 4, GetSocketBlocking(*socket_manager, wii_fd));
     m_socket_table->setItem(wii_fd, 5, GetSocketName(host_fd));
   }
   m_socket_table->resizeColumnsToContents();


### PR DESCRIPTION
This was a global instance previously due to what seems to be legacy reasons.

I originally wanted to put this into one of the Network-related devices but there didn't seem to be a good single spot for it, so it just ended up in Kernel. I'm also not entirely sure why the Kernel uses `shared_ptr` for its device instances, can any of them actually outlive the Kernel itself? I've replicated this for the socket manager but I actually don't see any reason why it can't just be a `unique_ptr` instead.

@leoetlino Please review.

(As a side-note, I think I've noticed a logic error in the IOS savestating logic; nothing guarantees that devices in `m_device_map` are synced correctly with the ones in the savestate. You'd have to load a state from an IOS version than has different devices than the currently running one, which is unlikely in regular play, but I see nothing that actually prevents this...?)