### PR TITLE
Common/LinearDiskCache: Move interface into Common namespace

### DIFF
--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -27,6 +27,8 @@
 // value_type[value_size]   value;
 //}
 
+namespace Common
+{
 template <typename K, typename V>
 class LinearDiskCacheReader
 {
@@ -163,3 +165,4 @@ private:
   File::IOFile m_file;
   u32 m_num_entries = 0;
 };
+}  // namespace Common

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -473,7 +473,7 @@ void ObjectCache::DestroyRenderPassCache()
   m_render_pass_cache.clear();
 }
 
-class PipelineCacheReadCallback : public LinearDiskCacheReader<u32, u8>
+class PipelineCacheReadCallback : public Common::LinearDiskCacheReader<u32, u8>
 {
 public:
   PipelineCacheReadCallback(std::vector<u8>* data) : m_data(data) {}
@@ -488,7 +488,7 @@ private:
   std::vector<u8>* m_data;
 };
 
-class PipelineCacheReadIgnoreCallback : public LinearDiskCacheReader<u32, u8>
+class PipelineCacheReadIgnoreCallback : public Common::LinearDiskCacheReader<u32, u8>
 {
 public:
   void Read(const u32& key, const u8* value, u32 value_size) override {}
@@ -525,7 +525,7 @@ bool ObjectCache::LoadPipelineCache()
   m_pipeline_cache_filename = GetDiskShaderCacheFileName(APIType::Vulkan, "Pipeline", false, true);
 
   std::vector<u8> disk_data;
-  LinearDiskCache<u32, u8> disk_cache;
+  Common::LinearDiskCache<u32, u8> disk_cache;
   PipelineCacheReadCallback read_callback(&disk_data);
   if (disk_cache.OpenAndRead(m_pipeline_cache_filename, read_callback) != 1)
     disk_data.clear();
@@ -651,7 +651,7 @@ void ObjectCache::SavePipelineCache()
   // We write a single key of 1, with the entire pipeline cache data.
   // Not ideal, but our disk cache class does not support just writing a single blob
   // of data without specifying a key.
-  LinearDiskCache<u32, u8> disk_cache;
+  Common::LinearDiskCache<u32, u8> disk_cache;
   PipelineCacheReadIgnoreCallback callback;
   disk_cache.OpenAndRead(m_pipeline_cache_filename, callback);
   disk_cache.Append(1, data.data(), static_cast<u32>(data.size()));

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -228,11 +228,11 @@ static void UnserializePipelineUid(const SerializedUidType& uid, UidType& real_u
 template <ShaderStage stage, typename K, typename T>
 void ShaderCache::LoadShaderCache(T& cache, APIType api_type, const char* type, bool include_gameid)
 {
-  class CacheReader : public LinearDiskCacheReader<K, u8>
+  class CacheReader : public Common::LinearDiskCacheReader<K, u8>
   {
   public:
     CacheReader(T& cache_) : cache(cache_) {}
-    void Read(const K& key, const u8* value, u32 value_size)
+    void Read(const K& key, const u8* value, u32 value_size) override
     {
       auto shader = g_gfx->CreateShaderFromBinary(stage, value, value_size);
       if (shader)
@@ -276,15 +276,15 @@ void ShaderCache::ClearShaderCache(T& cache)
 }
 
 template <typename KeyType, typename DiskKeyType, typename T>
-void ShaderCache::LoadPipelineCache(T& cache, LinearDiskCache<DiskKeyType, u8>& disk_cache,
+void ShaderCache::LoadPipelineCache(T& cache, Common::LinearDiskCache<DiskKeyType, u8>& disk_cache,
                                     APIType api_type, const char* type, bool include_gameid)
 {
-  class CacheReader : public LinearDiskCacheReader<DiskKeyType, u8>
+  class CacheReader : public Common::LinearDiskCacheReader<DiskKeyType, u8>
   {
   public:
     CacheReader(ShaderCache* this_ptr_, T& cache_) : this_ptr(this_ptr_), cache(cache_) {}
     bool AnyFailed() const { return failed; }
-    void Read(const DiskKeyType& key, const u8* value, u32 value_size)
+    void Read(const DiskKeyType& key, const u8* value, u32 value_size) override
     {
       KeyType real_uid;
       UnserializePipelineUid(key, real_uid);

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -176,8 +176,8 @@ private:
   template <typename T>
   void ClearShaderCache(T& cache);
   template <typename KeyType, typename DiskKeyType, typename T>
-  void LoadPipelineCache(T& cache, LinearDiskCache<DiskKeyType, u8>& disk_cache, APIType api_type,
-                         const char* type, bool include_gameid);
+  void LoadPipelineCache(T& cache, Common::LinearDiskCache<DiskKeyType, u8>& disk_cache,
+                         APIType api_type, const char* type, bool include_gameid);
   template <typename T, typename Y>
   void ClearPipelineCache(T& cache, Y& disk_cache);
 
@@ -216,7 +216,7 @@ private:
       bool pending = false;
     };
     std::map<Uid, Shader> shader_map;
-    LinearDiskCache<Uid, u8> disk_cache;
+    Common::LinearDiskCache<Uid, u8> disk_cache;
   };
   ShaderModuleCache<VertexShaderUid> m_vs_cache;
   ShaderModuleCache<GeometryShaderUid> m_gs_cache;
@@ -229,8 +229,8 @@ private:
   std::map<GXUberPipelineUid, std::pair<std::unique_ptr<AbstractPipeline>, bool>>
       m_gx_uber_pipeline_cache;
   File::IOFile m_gx_pipeline_uid_cache_file;
-  LinearDiskCache<SerializedGXPipelineUid, u8> m_gx_pipeline_disk_cache;
-  LinearDiskCache<SerializedGXUberPipelineUid, u8> m_gx_uber_pipeline_disk_cache;
+  Common::LinearDiskCache<SerializedGXPipelineUid, u8> m_gx_pipeline_disk_cache;
+  Common::LinearDiskCache<SerializedGXUberPipelineUid, u8> m_gx_uber_pipeline_disk_cache;
 
   // EFB copy to VRAM/RAM pipelines
   std::map<TextureConversionShaderGen::TCShaderUid, std::unique_ptr<AbstractPipeline>>


### PR DESCRIPTION
Gets the interface out of the global namespace.