### PR TITLE
Common/TraversalClient: Use correct deleter with g_MainNetHost

### DIFF
--- a/Source/Core/Common/ENet.h
+++ b/Source/Core/Common/ENet.h
@@ -3,14 +3,21 @@
 //
 #pragma once
 
-#include <enet/enet.h>
+#include <memory>
 
 #include <SFML/Network/Packet.hpp>
+#include <enet/enet.h>
 
 #include "Common/CommonTypes.h"
 
 namespace Common::ENet
 {
+struct ENetHostDeleter
+{
+  void operator()(ENetHost* host) const noexcept { enet_host_destroy(host); }
+};
+using ENetHostPtr = std::unique_ptr<ENetHost, ENetHostDeleter>;
+
 void WakeupThread(ENetHost* host);
 int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event);
 bool SendPacket(ENetPeer* socket, const sf::Packet& packet, u8 channel_id);

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -304,7 +304,7 @@ int ENET_CALLBACK TraversalClient::InterceptCallback(ENetHost* host, ENetEvent* 
 }
 
 std::unique_ptr<TraversalClient> g_TraversalClient;
-std::unique_ptr<ENetHost> g_MainNetHost;
+Common::ENet::ENetHostPtr g_MainNetHost;
 
 // The settings at the previous TraversalClient reset - notably, we
 // need to know not just what port it's on, but whether it was
@@ -323,18 +323,18 @@ bool EnsureTraversalClient(const std::string& server, u16 server_port, u16 liste
     g_OldListenPort = listen_port;
 
     ENetAddress addr = {ENET_HOST_ANY, listen_port};
-    ENetHost* host = enet_host_create(&addr,                   // address
-                                      50,                      // peerCount
-                                      NetPlay::CHANNEL_COUNT,  // channelLimit
-                                      0,                       // incomingBandwidth
-                                      0);                      // outgoingBandwidth
+    auto host = Common::ENet::ENetHostPtr{enet_host_create(&addr,                   // address
+                                                           50,                      // peerCount
+                                                           NetPlay::CHANNEL_COUNT,  // channelLimit
+                                                           0,    // incomingBandwidth
+                                                           0)};  // outgoingBandwidth
     if (!host)
     {
       g_MainNetHost.reset();
       return false;
     }
     host->mtu = std::min(host->mtu, NetPlay::MAX_ENET_MTU);
-    g_MainNetHost.reset(host);
+    g_MainNetHost = std::move(host);
     g_TraversalClient.reset(new TraversalClient(g_MainNetHost.get(), server, server_port));
   }
   return true;

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -11,6 +11,7 @@
 #include <enet/enet.h>
 
 #include "Common/CommonTypes.h"
+#include "Common/ENet.h"
 #include "Common/Thread.h"
 #include "Common/TraversalProto.h"
 
@@ -91,7 +92,7 @@ private:
 };
 extern std::unique_ptr<TraversalClient> g_TraversalClient;
 // the NetHost connected to the TraversalClient.
-extern std::unique_ptr<ENetHost> g_MainNetHost;
+extern Common::ENet::ENetHostPtr g_MainNetHost;
 // Create g_TraversalClient and g_MainNetHost if necessary.
 bool EnsureTraversalClient(const std::string& server, u16 server_port, u16 listen_port = 0);
 void ReleaseTraversalClient();


### PR DESCRIPTION
Previously this was using the default deleter (which just calls delete on the pointer), which is incorrect, since the ENetHost instance is allocated through ENet's C API, so we need to use its functions to deallocate the host instead.