### PR TITLE
Qt: Remove unused class GraphicsBoolEx

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.cpp
@@ -32,23 +32,3 @@ void GraphicsBool::Update()
 {
   Config::SetBaseOrCurrent(m_setting, static_cast<bool>(isChecked() ^ m_reverse));
 }
-
-GraphicsBoolEx::GraphicsBoolEx(const QString& label, const Config::Info<bool>& setting,
-                               bool reverse)
-    : ToolTipRadioButton(label), m_setting(setting), m_reverse(reverse)
-{
-  connect(this, &QCheckBox::toggled, this, &GraphicsBoolEx::Update);
-  setChecked(Config::Get(m_setting) ^ reverse);
-
-  if (Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base)
-  {
-    QFont bf = font();
-    bf.setBold(true);
-    setFont(bf);
-  }
-}
-
-void GraphicsBoolEx::Update()
-{
-  Config::SetBaseOrCurrent(m_setting, static_cast<bool>(isChecked() ^ m_reverse));
-}

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
-#include "DolphinQt/Config/ToolTipControls/ToolTipRadioButton.h"
 
 namespace Config
 {
@@ -17,19 +16,6 @@ class GraphicsBool : public ToolTipCheckBox
   Q_OBJECT
 public:
   GraphicsBool(const QString& label, const Config::Info<bool>& setting, bool reverse = false);
-
-private:
-  void Update();
-
-  const Config::Info<bool>& m_setting;
-  bool m_reverse;
-};
-
-class GraphicsBoolEx : public ToolTipRadioButton
-{
-  Q_OBJECT
-public:
-  GraphicsBoolEx(const QString& label, const Config::Info<bool>& setting, bool reverse = false);
 
 private:
   void Update();


### PR DESCRIPTION
In older versions of Dolphin GraphicsBoolEx was used to create a pair of radio buttons selecting one of Virtual XFB and Real XFB, but this was removed with the introduction of Hybrid XFB in #5498.

In the meantime GraphicsRadioInt was introduced to allow for Graphics radio buttons with multiple options, and boolean options should use checkboxes, so GraphicsBoolEx is now redundant.