### PR TITLE
Qt: Rename GraphicsBool to ConfigBool

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -41,6 +41,8 @@ add_executable(dolphin-emu
   Config/CheatWarningWidget.h
   Config/CommonControllersWidget.cpp
   Config/CommonControllersWidget.h
+  Config/ConfigControls/ConfigBool.cpp
+  Config/ConfigControls/ConfigBool.h
   Config/ControllerInterface/ControllerInterfaceWindow.cpp
   Config/ControllerInterface/ControllerInterfaceWindow.h
   Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
@@ -73,8 +75,6 @@ add_executable(dolphin-emu
   Config/Graphics/EnhancementsWidget.h
   Config/Graphics/GeneralWidget.cpp
   Config/Graphics/GeneralWidget.h
-  Config/Graphics/GraphicsBool.cpp
-  Config/Graphics/GraphicsBool.h
   Config/Graphics/GraphicsChoice.cpp
   Config/Graphics/GraphicsChoice.h
   Config/Graphics/GraphicsInteger.cpp

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "DolphinQt/Config/Graphics/GraphicsBool.h"
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 
 #include <QEvent>
 #include <QFont>
@@ -11,10 +11,10 @@
 
 #include "DolphinQt/Settings.h"
 
-GraphicsBool::GraphicsBool(const QString& label, const Config::Info<bool>& setting, bool reverse)
+ConfigBool::ConfigBool(const QString& label, const Config::Info<bool>& setting, bool reverse)
     : ToolTipCheckBox(label), m_setting(setting), m_reverse(reverse)
 {
-  connect(this, &QCheckBox::toggled, this, &GraphicsBool::Update);
+  connect(this, &QCheckBox::toggled, this, &ConfigBool::Update);
   setChecked(Config::Get(m_setting) ^ reverse);
 
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
@@ -27,7 +27,7 @@ GraphicsBool::GraphicsBool(const QString& label, const Config::Info<bool>& setti
   });
 }
 
-void GraphicsBool::Update()
+void ConfigBool::Update()
 {
   Config::SetBaseOrCurrent(m_setting, static_cast<bool>(isChecked() ^ m_reverse));
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.h
@@ -11,11 +11,11 @@ template <typename T>
 class Info;
 }
 
-class GraphicsBool : public ToolTipCheckBox
+class ConfigBool : public ToolTipCheckBox
 {
   Q_OBJECT
 public:
-  GraphicsBool(const QString& label, const Config::Info<bool>& setting, bool reverse = false);
+  ConfigBool(const QString& label, const Config::Info<bool>& setting, bool reverse = false);
 
 private:
   void Update();

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -15,7 +15,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
-#include "DolphinQt/Config/Graphics/GraphicsBool.h"
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt/Config/Graphics/GraphicsInteger.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
@@ -50,17 +50,17 @@ void AdvancedWidget::CreateWidgets()
   auto* performance_layout = new QGridLayout();
   performance_box->setLayout(performance_layout);
 
-  m_show_fps = new GraphicsBool(tr("Show FPS"), Config::GFX_SHOW_FPS);
-  m_show_ftimes = new GraphicsBool(tr("Show Frame Times"), Config::GFX_SHOW_FTIMES);
-  m_show_vps = new GraphicsBool(tr("Show VPS"), Config::GFX_SHOW_VPS);
-  m_show_vtimes = new GraphicsBool(tr("Show VBlank Times"), Config::GFX_SHOW_VTIMES);
-  m_show_graphs = new GraphicsBool(tr("Show Performance Graphs"), Config::GFX_SHOW_GRAPHS);
-  m_show_speed = new GraphicsBool(tr("Show % Speed"), Config::GFX_SHOW_SPEED);
-  m_show_speed_colors = new GraphicsBool(tr("Show Speed Colors"), Config::GFX_SHOW_SPEED_COLORS);
+  m_show_fps = new ConfigBool(tr("Show FPS"), Config::GFX_SHOW_FPS);
+  m_show_ftimes = new ConfigBool(tr("Show Frame Times"), Config::GFX_SHOW_FTIMES);
+  m_show_vps = new ConfigBool(tr("Show VPS"), Config::GFX_SHOW_VPS);
+  m_show_vtimes = new ConfigBool(tr("Show VBlank Times"), Config::GFX_SHOW_VTIMES);
+  m_show_graphs = new ConfigBool(tr("Show Performance Graphs"), Config::GFX_SHOW_GRAPHS);
+  m_show_speed = new ConfigBool(tr("Show % Speed"), Config::GFX_SHOW_SPEED);
+  m_show_speed_colors = new ConfigBool(tr("Show Speed Colors"), Config::GFX_SHOW_SPEED_COLORS);
   m_perf_samp_window = new GraphicsInteger(0, 10000, Config::GFX_PERF_SAMP_WINDOW, 100);
   m_perf_samp_window->SetTitle(tr("Performance Sample Window (ms)"));
   m_log_render_time =
-      new GraphicsBool(tr("Log Render Time to File"), Config::GFX_LOG_RENDER_TIME_TO_FILE);
+      new ConfigBool(tr("Log Render Time to File"), Config::GFX_LOG_RENDER_TIME_TO_FILE);
 
   performance_layout->addWidget(m_show_fps, 0, 0);
   performance_layout->addWidget(m_show_ftimes, 0, 1);
@@ -78,12 +78,12 @@ void AdvancedWidget::CreateWidgets()
   auto* debugging_layout = new QGridLayout();
   debugging_box->setLayout(debugging_layout);
 
-  m_enable_wireframe = new GraphicsBool(tr("Enable Wireframe"), Config::GFX_ENABLE_WIREFRAME);
-  m_show_statistics = new GraphicsBool(tr("Show Statistics"), Config::GFX_OVERLAY_STATS);
+  m_enable_wireframe = new ConfigBool(tr("Enable Wireframe"), Config::GFX_ENABLE_WIREFRAME);
+  m_show_statistics = new ConfigBool(tr("Show Statistics"), Config::GFX_OVERLAY_STATS);
   m_enable_format_overlay =
-      new GraphicsBool(tr("Texture Format Overlay"), Config::GFX_TEXFMT_OVERLAY_ENABLE);
+      new ConfigBool(tr("Texture Format Overlay"), Config::GFX_TEXFMT_OVERLAY_ENABLE);
   m_enable_api_validation =
-      new GraphicsBool(tr("Enable API Validation Layers"), Config::GFX_ENABLE_VALIDATION_LAYER);
+      new ConfigBool(tr("Enable API Validation Layers"), Config::GFX_ENABLE_VALIDATION_LAYER);
 
   debugging_layout->addWidget(m_enable_wireframe, 0, 0);
   debugging_layout->addWidget(m_show_statistics, 0, 1);
@@ -95,13 +95,13 @@ void AdvancedWidget::CreateWidgets()
   auto* utility_layout = new QGridLayout();
   utility_box->setLayout(utility_layout);
 
-  m_load_custom_textures = new GraphicsBool(tr("Load Custom Textures"), Config::GFX_HIRES_TEXTURES);
+  m_load_custom_textures = new ConfigBool(tr("Load Custom Textures"), Config::GFX_HIRES_TEXTURES);
   m_prefetch_custom_textures =
-      new GraphicsBool(tr("Prefetch Custom Textures"), Config::GFX_CACHE_HIRES_TEXTURES);
-  m_dump_efb_target = new GraphicsBool(tr("Dump EFB Target"), Config::GFX_DUMP_EFB_TARGET);
-  m_dump_xfb_target = new GraphicsBool(tr("Dump XFB Target"), Config::GFX_DUMP_XFB_TARGET);
+      new ConfigBool(tr("Prefetch Custom Textures"), Config::GFX_CACHE_HIRES_TEXTURES);
+  m_dump_efb_target = new ConfigBool(tr("Dump EFB Target"), Config::GFX_DUMP_EFB_TARGET);
+  m_dump_xfb_target = new ConfigBool(tr("Dump XFB Target"), Config::GFX_DUMP_XFB_TARGET);
   m_disable_vram_copies =
-      new GraphicsBool(tr("Disable EFB VRAM Copies"), Config::GFX_HACK_DISABLE_COPY_TO_VRAM);
+      new ConfigBool(tr("Disable EFB VRAM Copies"), Config::GFX_HACK_DISABLE_COPY_TO_VRAM);
   m_enable_graphics_mods = new ToolTipCheckBox(tr("Enable Graphics Mods"));
 
   utility_layout->addWidget(m_load_custom_textures, 0, 0);
@@ -117,9 +117,9 @@ void AdvancedWidget::CreateWidgets()
   auto* texture_dump_box = new QGroupBox(tr("Texture Dumping"));
   auto* texture_dump_layout = new QGridLayout();
   texture_dump_box->setLayout(texture_dump_layout);
-  m_dump_textures = new GraphicsBool(tr("Enable"), Config::GFX_DUMP_TEXTURES);
-  m_dump_base_textures = new GraphicsBool(tr("Dump Base Textures"), Config::GFX_DUMP_BASE_TEXTURES);
-  m_dump_mip_textures = new GraphicsBool(tr("Dump Mip Maps"), Config::GFX_DUMP_MIP_TEXTURES);
+  m_dump_textures = new ConfigBool(tr("Enable"), Config::GFX_DUMP_TEXTURES);
+  m_dump_base_textures = new ConfigBool(tr("Dump Base Textures"), Config::GFX_DUMP_BASE_TEXTURES);
+  m_dump_mip_textures = new ConfigBool(tr("Dump Mip Maps"), Config::GFX_DUMP_MIP_TEXTURES);
 
   texture_dump_layout->addWidget(m_dump_textures, 0, 0);
 
@@ -131,9 +131,9 @@ void AdvancedWidget::CreateWidgets()
   auto* dump_layout = new QGridLayout();
   dump_box->setLayout(dump_layout);
 
-  m_use_fullres_framedumps = new GraphicsBool(tr("Dump at Internal Resolution"),
-                                              Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS);
-  m_dump_use_ffv1 = new GraphicsBool(tr("Use Lossless Codec (FFV1)"), Config::GFX_USE_FFV1);
+  m_use_fullres_framedumps = new ConfigBool(tr("Dump at Internal Resolution"),
+                                            Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS);
+  m_dump_use_ffv1 = new ConfigBool(tr("Use Lossless Codec (FFV1)"), Config::GFX_USE_FFV1);
   m_dump_bitrate = new GraphicsInteger(0, 1000000, Config::GFX_BITRATE_KBPS, 1000);
   m_png_compression_level = new GraphicsInteger(0, 9, Config::GFX_PNG_COMPRESSION_LEVEL);
 
@@ -152,14 +152,14 @@ void AdvancedWidget::CreateWidgets()
   auto* misc_layout = new QGridLayout();
   misc_box->setLayout(misc_layout);
 
-  m_enable_cropping = new GraphicsBool(tr("Crop"), Config::GFX_CROP);
+  m_enable_cropping = new ConfigBool(tr("Crop"), Config::GFX_CROP);
   m_enable_prog_scan = new ToolTipCheckBox(tr("Enable Progressive Scan"));
   m_backend_multithreading =
-      new GraphicsBool(tr("Backend Multithreading"), Config::GFX_BACKEND_MULTITHREADING);
-  m_prefer_vs_for_point_line_expansion = new GraphicsBool(
+      new ConfigBool(tr("Backend Multithreading"), Config::GFX_BACKEND_MULTITHREADING);
+  m_prefer_vs_for_point_line_expansion = new ConfigBool(
       // i18n: VS is short for vertex shaders.
       tr("Prefer VS for Point/Line Expansion"), Config::GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION);
-  m_cpu_cull = new GraphicsBool(tr("Cull Vertices on the CPU"), Config::GFX_CPU_CULL);
+  m_cpu_cull = new ConfigBool(tr("Cull Vertices on the CPU"), Config::GFX_CPU_CULL);
 
   misc_layout->addWidget(m_enable_cropping, 0, 0);
   misc_layout->addWidget(m_enable_prog_scan, 0, 1);
@@ -168,7 +168,7 @@ void AdvancedWidget::CreateWidgets()
   misc_layout->addWidget(m_cpu_cull, 2, 0);
 #ifdef _WIN32
   m_borderless_fullscreen =
-      new GraphicsBool(tr("Borderless Fullscreen"), Config::GFX_BORDERLESS_FULLSCREEN);
+      new ConfigBool(tr("Borderless Fullscreen"), Config::GFX_BORDERLESS_FULLSCREEN);
 
   misc_layout->addWidget(m_borderless_fullscreen, 2, 1);
 #endif
@@ -179,9 +179,9 @@ void AdvancedWidget::CreateWidgets()
   experimental_box->setLayout(experimental_layout);
 
   m_defer_efb_access_invalidation =
-      new GraphicsBool(tr("Defer EFB Cache Invalidation"), Config::GFX_HACK_EFB_DEFER_INVALIDATION);
+      new ConfigBool(tr("Defer EFB Cache Invalidation"), Config::GFX_HACK_EFB_DEFER_INVALIDATION);
   m_manual_texture_sampling =
-      new GraphicsBool(tr("Manual Texture Sampling"), Config::GFX_HACK_FAST_TEXTURE_SAMPLING, true);
+      new ConfigBool(tr("Manual Texture Sampling"), Config::GFX_HACK_FAST_TEXTURE_SAMPLING, true);
 
   experimental_layout->addWidget(m_defer_efb_access_invalidation, 0, 0);
   experimental_layout->addWidget(m_manual_texture_sampling, 0, 1);

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -5,7 +5,7 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
-class GraphicsBool;
+class ConfigBool;
 class GraphicsChoice;
 class GraphicsInteger;
 class GraphicsWindow;
@@ -31,48 +31,48 @@ private:
   void OnEmulationStateChanged(bool running);
 
   // Debugging
-  GraphicsBool* m_enable_wireframe;
-  GraphicsBool* m_show_statistics;
-  GraphicsBool* m_enable_format_overlay;
-  GraphicsBool* m_enable_api_validation;
-  GraphicsBool* m_show_fps;
-  GraphicsBool* m_show_ftimes;
-  GraphicsBool* m_show_vps;
-  GraphicsBool* m_show_vtimes;
-  GraphicsBool* m_show_graphs;
-  GraphicsBool* m_show_speed;
-  GraphicsBool* m_show_speed_colors;
+  ConfigBool* m_enable_wireframe;
+  ConfigBool* m_show_statistics;
+  ConfigBool* m_enable_format_overlay;
+  ConfigBool* m_enable_api_validation;
+  ConfigBool* m_show_fps;
+  ConfigBool* m_show_ftimes;
+  ConfigBool* m_show_vps;
+  ConfigBool* m_show_vtimes;
+  ConfigBool* m_show_graphs;
+  ConfigBool* m_show_speed;
+  ConfigBool* m_show_speed_colors;
   GraphicsInteger* m_perf_samp_window;
-  GraphicsBool* m_log_render_time;
+  ConfigBool* m_log_render_time;
 
   // Utility
-  GraphicsBool* m_prefetch_custom_textures;
-  GraphicsBool* m_dump_efb_target;
-  GraphicsBool* m_dump_xfb_target;
-  GraphicsBool* m_disable_vram_copies;
-  GraphicsBool* m_load_custom_textures;
+  ConfigBool* m_prefetch_custom_textures;
+  ConfigBool* m_dump_efb_target;
+  ConfigBool* m_dump_xfb_target;
+  ConfigBool* m_disable_vram_copies;
+  ConfigBool* m_load_custom_textures;
   ToolTipCheckBox* m_enable_graphics_mods;
 
   // Texture dumping
-  GraphicsBool* m_dump_textures;
-  GraphicsBool* m_dump_mip_textures;
-  GraphicsBool* m_dump_base_textures;
+  ConfigBool* m_dump_textures;
+  ConfigBool* m_dump_mip_textures;
+  ConfigBool* m_dump_base_textures;
 
   // Frame dumping
-  GraphicsBool* m_dump_use_ffv1;
-  GraphicsBool* m_use_fullres_framedumps;
+  ConfigBool* m_dump_use_ffv1;
+  ConfigBool* m_use_fullres_framedumps;
   GraphicsInteger* m_dump_bitrate;
   GraphicsInteger* m_png_compression_level;
 
   // Misc
-  GraphicsBool* m_enable_cropping;
+  ConfigBool* m_enable_cropping;
   ToolTipCheckBox* m_enable_prog_scan;
-  GraphicsBool* m_backend_multithreading;
-  GraphicsBool* m_prefer_vs_for_point_line_expansion;
-  GraphicsBool* m_cpu_cull;
-  GraphicsBool* m_borderless_fullscreen;
+  ConfigBool* m_backend_multithreading;
+  ConfigBool* m_prefer_vs_for_point_line_expansion;
+  ConfigBool* m_cpu_cull;
+  ConfigBool* m_borderless_fullscreen;
 
   // Experimental
-  GraphicsBool* m_defer_efb_access_invalidation;
-  GraphicsBool* m_manual_texture_sampling;
+  ConfigBool* m_defer_efb_access_invalidation;
+  ConfigBool* m_manual_texture_sampling;
 };

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -14,7 +14,7 @@
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
 
-#include "DolphinQt/Config/Graphics/GraphicsBool.h"
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt/Config/Graphics/GraphicsRadio.h"
 #include "DolphinQt/Config/Graphics/GraphicsSlider.h"
@@ -106,18 +106,18 @@ void EnhancementsWidget::CreateWidgets()
 
   m_pp_effect = new ToolTipComboBox();
   m_configure_pp_effect = new NonDefaultQPushButton(tr("Configure"));
-  m_scaled_efb_copy = new GraphicsBool(tr("Scaled EFB Copy"), Config::GFX_HACK_COPY_EFB_SCALED);
+  m_scaled_efb_copy = new ConfigBool(tr("Scaled EFB Copy"), Config::GFX_HACK_COPY_EFB_SCALED);
   m_per_pixel_lighting =
-      new GraphicsBool(tr("Per-Pixel Lighting"), Config::GFX_ENABLE_PIXEL_LIGHTING);
+      new ConfigBool(tr("Per-Pixel Lighting"), Config::GFX_ENABLE_PIXEL_LIGHTING);
 
-  m_widescreen_hack = new GraphicsBool(tr("Widescreen Hack"), Config::GFX_WIDESCREEN_HACK);
-  m_disable_fog = new GraphicsBool(tr("Disable Fog"), Config::GFX_DISABLE_FOG);
+  m_widescreen_hack = new ConfigBool(tr("Widescreen Hack"), Config::GFX_WIDESCREEN_HACK);
+  m_disable_fog = new ConfigBool(tr("Disable Fog"), Config::GFX_DISABLE_FOG);
   m_force_24bit_color =
-      new GraphicsBool(tr("Force 24-Bit Color"), Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
+      new ConfigBool(tr("Force 24-Bit Color"), Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
   m_disable_copy_filter =
-      new GraphicsBool(tr("Disable Copy Filter"), Config::GFX_ENHANCE_DISABLE_COPY_FILTER);
-  m_arbitrary_mipmap_detection = new GraphicsBool(tr("Arbitrary Mipmap Detection"),
-                                                  Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
+      new ConfigBool(tr("Disable Copy Filter"), Config::GFX_ENHANCE_DISABLE_COPY_FILTER);
+  m_arbitrary_mipmap_detection = new ConfigBool(tr("Arbitrary Mipmap Detection"),
+                                                Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
 
   int row = 0;
   enhancements_layout->addWidget(new QLabel(tr("Internal Resolution:")), row, 0);
@@ -163,7 +163,7 @@ void EnhancementsWidget::CreateWidgets()
   m_3d_depth = new GraphicsSlider(0, Config::GFX_STEREO_DEPTH_MAXIMUM, Config::GFX_STEREO_DEPTH);
   m_3d_convergence = new GraphicsSlider(0, Config::GFX_STEREO_CONVERGENCE_MAXIMUM,
                                         Config::GFX_STEREO_CONVERGENCE, 100);
-  m_3d_swap_eyes = new GraphicsBool(tr("Swap Eyes"), Config::GFX_STEREO_SWAP_EYES);
+  m_3d_swap_eyes = new ConfigBool(tr("Swap Eyes"), Config::GFX_STEREO_SWAP_EYES);
 
   stereoscopy_layout->addWidget(new QLabel(tr("Stereoscopic 3D Mode:")), 0, 0);
   stereoscopy_layout->addWidget(m_3d_mode, 0, 1);

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -7,7 +7,7 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
-class GraphicsBool;
+class ConfigBool;
 class GraphicsChoice;
 class GraphicsSlider;
 class GraphicsWindow;
@@ -39,19 +39,19 @@ private:
   ToolTipComboBox* m_texture_filtering_combo;
   ToolTipComboBox* m_pp_effect;
   QPushButton* m_configure_pp_effect;
-  GraphicsBool* m_scaled_efb_copy;
-  GraphicsBool* m_per_pixel_lighting;
-  GraphicsBool* m_widescreen_hack;
-  GraphicsBool* m_disable_fog;
-  GraphicsBool* m_force_24bit_color;
-  GraphicsBool* m_disable_copy_filter;
-  GraphicsBool* m_arbitrary_mipmap_detection;
+  ConfigBool* m_scaled_efb_copy;
+  ConfigBool* m_per_pixel_lighting;
+  ConfigBool* m_widescreen_hack;
+  ConfigBool* m_disable_fog;
+  ConfigBool* m_force_24bit_color;
+  ConfigBool* m_disable_copy_filter;
+  ConfigBool* m_arbitrary_mipmap_detection;
 
   // Stereoscopy
   GraphicsChoice* m_3d_mode;
   GraphicsSlider* m_3d_depth;
   GraphicsSlider* m_3d_convergence;
-  GraphicsBool* m_3d_swap_eyes;
+  ConfigBool* m_3d_swap_eyes;
 
   int m_msaa_modes;
   bool m_block_save;

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -18,7 +18,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
-#include "DolphinQt/Config/Graphics/GraphicsBool.h"
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt/Config/Graphics/GraphicsRadio.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
@@ -60,8 +60,8 @@ void GeneralWidget::CreateWidgets()
       new GraphicsChoice({tr("Auto"), tr("Force 16:9"), tr("Force 4:3"), tr("Stretch to Window")},
                          Config::GFX_ASPECT_RATIO);
   m_adapter_combo = new ToolTipComboBox;
-  m_enable_vsync = new GraphicsBool(tr("V-Sync"), Config::GFX_VSYNC);
-  m_enable_fullscreen = new GraphicsBool(tr("Start in Fullscreen"), Config::MAIN_FULLSCREEN);
+  m_enable_vsync = new ConfigBool(tr("V-Sync"), Config::GFX_VSYNC);
+  m_enable_fullscreen = new ConfigBool(tr("Start in Fullscreen"), Config::MAIN_FULLSCREEN);
 
   m_video_box->setLayout(m_video_layout);
 
@@ -87,12 +87,11 @@ void GeneralWidget::CreateWidgets()
   auto* m_options_box = new QGroupBox(tr("Other"));
   auto* m_options_layout = new QGridLayout();
 
-  m_show_ping = new GraphicsBool(tr("Show NetPlay Ping"), Config::GFX_SHOW_NETPLAY_PING);
+  m_show_ping = new ConfigBool(tr("Show NetPlay Ping"), Config::GFX_SHOW_NETPLAY_PING);
   m_autoadjust_window_size =
-      new GraphicsBool(tr("Auto-Adjust Window Size"), Config::MAIN_RENDER_WINDOW_AUTOSIZE);
-  m_show_messages =
-      new GraphicsBool(tr("Show NetPlay Messages"), Config::GFX_SHOW_NETPLAY_MESSAGES);
-  m_render_main_window = new GraphicsBool(tr("Render to Main Window"), Config::MAIN_RENDER_TO_MAIN);
+      new ConfigBool(tr("Auto-Adjust Window Size"), Config::MAIN_RENDER_WINDOW_AUTOSIZE);
+  m_show_messages = new ConfigBool(tr("Show NetPlay Messages"), Config::GFX_SHOW_NETPLAY_MESSAGES);
+  m_render_main_window = new ConfigBool(tr("Render to Main Window"), Config::MAIN_RENDER_TO_MAIN);
 
   m_options_box->setLayout(m_options_layout);
 
@@ -119,8 +118,8 @@ void GeneralWidget::CreateWidgets()
     shader_compilation_layout->addWidget(m_shader_compilation_mode[i], static_cast<int>(i / 2),
                                          static_cast<int>(i % 2));
   }
-  m_wait_for_shaders = new GraphicsBool(tr("Compile Shaders Before Starting"),
-                                        Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING);
+  m_wait_for_shaders = new ConfigBool(tr("Compile Shaders Before Starting"),
+                                      Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING);
   shader_compilation_layout->addWidget(m_wait_for_shaders);
   shader_compilation_box->setLayout(shader_compilation_layout);
 

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -6,7 +6,7 @@
 #include <array>
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
-class GraphicsBool;
+class ConfigBool;
 class GraphicsChoice;
 class GraphicsRadioInt;
 class GraphicsWindow;
@@ -45,16 +45,16 @@ private:
   ToolTipComboBox* m_backend_combo;
   ToolTipComboBox* m_adapter_combo;
   GraphicsChoice* m_aspect_combo;
-  GraphicsBool* m_enable_vsync;
-  GraphicsBool* m_enable_fullscreen;
+  ConfigBool* m_enable_vsync;
+  ConfigBool* m_enable_fullscreen;
 
   // Options
-  GraphicsBool* m_show_ping;
-  GraphicsBool* m_autoadjust_window_size;
-  GraphicsBool* m_show_messages;
-  GraphicsBool* m_render_main_window;
+  ConfigBool* m_show_ping;
+  ConfigBool* m_autoadjust_window_size;
+  ConfigBool* m_show_messages;
+  ConfigBool* m_render_main_window;
   std::array<GraphicsRadioInt*, 4> m_shader_compilation_mode{};
-  GraphicsBool* m_wait_for_shaders;
+  ConfigBool* m_wait_for_shaders;
 
   X11Utils::XRRConfiguration* m_xrr_config;
 };

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -13,7 +13,7 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 
-#include "DolphinQt/Config/Graphics/GraphicsBool.h"
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/Graphics/GraphicsSlider.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
@@ -42,13 +42,13 @@ void HacksWidget::CreateWidgets()
   auto* efb_layout = new QGridLayout();
   efb_box->setLayout(efb_layout);
   m_skip_efb_cpu =
-      new GraphicsBool(tr("Skip EFB Access from CPU"), Config::GFX_HACK_EFB_ACCESS_ENABLE, true);
-  m_ignore_format_changes = new GraphicsBool(tr("Ignore Format Changes"),
-                                             Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES, true);
-  m_store_efb_copies = new GraphicsBool(tr("Store EFB Copies to Texture Only"),
-                                        Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);
+      new ConfigBool(tr("Skip EFB Access from CPU"), Config::GFX_HACK_EFB_ACCESS_ENABLE, true);
+  m_ignore_format_changes = new ConfigBool(tr("Ignore Format Changes"),
+                                           Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES, true);
+  m_store_efb_copies =
+      new ConfigBool(tr("Store EFB Copies to Texture Only"), Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);
   m_defer_efb_copies =
-      new GraphicsBool(tr("Defer EFB Copies to RAM"), Config::GFX_HACK_DEFER_EFB_COPIES);
+      new ConfigBool(tr("Defer EFB Copies to RAM"), Config::GFX_HACK_DEFER_EFB_COPIES);
 
   efb_layout->addWidget(m_skip_efb_cpu, 0, 0);
   efb_layout->addWidget(m_ignore_format_changes, 0, 1);
@@ -66,7 +66,7 @@ void HacksWidget::CreateWidgets()
   m_accuracy->setPageStep(1);
   m_accuracy->setTickPosition(QSlider::TicksBelow);
   m_gpu_texture_decoding =
-      new GraphicsBool(tr("GPU Texture Decoding"), Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
+      new ConfigBool(tr("GPU Texture Decoding"), Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
 
   auto* safe_label = new QLabel(tr("Safe"));
   safe_label->setAlignment(Qt::AlignRight);
@@ -84,11 +84,11 @@ void HacksWidget::CreateWidgets()
   auto* xfb_layout = new QVBoxLayout();
   xfb_box->setLayout(xfb_layout);
 
-  m_store_xfb_copies = new GraphicsBool(tr("Store XFB Copies to Texture Only"),
-                                        Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM);
-  m_immediate_xfb = new GraphicsBool(tr("Immediately Present XFB"), Config::GFX_HACK_IMMEDIATE_XFB);
-  m_skip_duplicate_xfbs = new GraphicsBool(tr("Skip Presenting Duplicate Frames"),
-                                           Config::GFX_HACK_SKIP_DUPLICATE_XFBS);
+  m_store_xfb_copies =
+      new ConfigBool(tr("Store XFB Copies to Texture Only"), Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM);
+  m_immediate_xfb = new ConfigBool(tr("Immediately Present XFB"), Config::GFX_HACK_IMMEDIATE_XFB);
+  m_skip_duplicate_xfbs =
+      new ConfigBool(tr("Skip Presenting Duplicate Frames"), Config::GFX_HACK_SKIP_DUPLICATE_XFBS);
 
   xfb_layout->addWidget(m_store_xfb_copies);
   xfb_layout->addWidget(m_immediate_xfb);
@@ -100,13 +100,13 @@ void HacksWidget::CreateWidgets()
   other_box->setLayout(other_layout);
 
   m_fast_depth_calculation =
-      new GraphicsBool(tr("Fast Depth Calculation"), Config::GFX_FAST_DEPTH_CALC);
+      new ConfigBool(tr("Fast Depth Calculation"), Config::GFX_FAST_DEPTH_CALC);
   m_disable_bounding_box =
-      new GraphicsBool(tr("Disable Bounding Box"), Config::GFX_HACK_BBOX_ENABLE, true);
-  m_vertex_rounding = new GraphicsBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUNDING);
+      new ConfigBool(tr("Disable Bounding Box"), Config::GFX_HACK_BBOX_ENABLE, true);
+  m_vertex_rounding = new ConfigBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUNDING);
   m_save_texture_cache_state =
-      new GraphicsBool(tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE);
-  m_vi_skip = new GraphicsBool(tr("VBI Skip"), Config::GFX_HACK_VI_SKIP);
+      new ConfigBool(tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE);
+  m_vi_skip = new ConfigBool(tr("VBI Skip"), Config::GFX_HACK_VI_SKIP);
 
   other_layout->addWidget(m_fast_depth_calculation, 0, 0);
   other_layout->addWidget(m_disable_bounding_box, 0, 1);

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -5,7 +5,7 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
-class GraphicsBool;
+class ConfigBool;
 class GraphicsWindow;
 class QLabel;
 class ToolTipSlider;
@@ -23,27 +23,27 @@ private:
   void OnBackendChanged(const QString& backend_name);
 
   // EFB
-  GraphicsBool* m_skip_efb_cpu;
-  GraphicsBool* m_ignore_format_changes;
-  GraphicsBool* m_store_efb_copies;
-  GraphicsBool* m_defer_efb_copies;
+  ConfigBool* m_skip_efb_cpu;
+  ConfigBool* m_ignore_format_changes;
+  ConfigBool* m_store_efb_copies;
+  ConfigBool* m_defer_efb_copies;
 
   // Texture Cache
   QLabel* m_accuracy_label;
   ToolTipSlider* m_accuracy;
-  GraphicsBool* m_gpu_texture_decoding;
+  ConfigBool* m_gpu_texture_decoding;
 
   // External Framebuffer
-  GraphicsBool* m_store_xfb_copies;
-  GraphicsBool* m_immediate_xfb;
-  GraphicsBool* m_skip_duplicate_xfbs;
+  ConfigBool* m_store_xfb_copies;
+  ConfigBool* m_immediate_xfb;
+  ConfigBool* m_skip_duplicate_xfbs;
 
   // Other
-  GraphicsBool* m_fast_depth_calculation;
-  GraphicsBool* m_disable_bounding_box;
-  GraphicsBool* m_vertex_rounding;
-  GraphicsBool* m_vi_skip;
-  GraphicsBool* m_save_texture_cache_state;
+  ConfigBool* m_fast_depth_calculation;
+  ConfigBool* m_disable_bounding_box;
+  ConfigBool* m_vertex_rounding;
+  ConfigBool* m_vi_skip;
+  ConfigBool* m_save_texture_cache_state;
 
   void CreateWidgets();
   void ConnectWidgets();

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -54,6 +54,7 @@
     <ClCompile Include="Config\CheatCodeEditor.cpp" />
     <ClCompile Include="Config\CheatWarningWidget.cpp" />
     <ClCompile Include="Config\CommonControllersWidget.cpp" />
+    <ClCompile Include="Config\ConfigControls\ConfigBool.cpp" />
     <ClCompile Include="Config\ControllerInterface\ControllerInterfaceWindow.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientWidget.cpp" />
@@ -70,7 +71,6 @@
     <ClCompile Include="Config\Graphics\AdvancedWidget.cpp" />
     <ClCompile Include="Config\Graphics\EnhancementsWidget.cpp" />
     <ClCompile Include="Config\Graphics\GeneralWidget.cpp" />
-    <ClCompile Include="Config\Graphics\GraphicsBool.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsChoice.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsInteger.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsRadio.cpp" />
@@ -255,6 +255,7 @@
     <QtMoc Include="Config\ARCodeWidget.h" />
     <QtMoc Include="Config\CheatWarningWidget.h" />
     <QtMoc Include="Config\CommonControllersWidget.h" />
+    <QtMoc Include="Config\ConfigControls\ConfigBool.h" />
     <QtMoc Include="Config\ControllerInterface\ControllerInterfaceWindow.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientWidget.h" />
@@ -270,7 +271,6 @@
     <QtMoc Include="Config\Graphics\AdvancedWidget.h" />
     <QtMoc Include="Config\Graphics\EnhancementsWidget.h" />
     <QtMoc Include="Config\Graphics\GeneralWidget.h" />
-    <QtMoc Include="Config\Graphics\GraphicsBool.h" />
     <QtMoc Include="Config\Graphics\GraphicsChoice.h" />
     <QtMoc Include="Config\Graphics\GraphicsInteger.h" />
     <QtMoc Include="Config\Graphics\GraphicsRadio.h" />


### PR DESCRIPTION
GraphicsBool is used by the panes in the Graphics config window to create checkboxes that change their associated config setting, and update their own state when something else changes the config setting.

Despite its current name nothing about this class is particular to the Graphics window, so renaming it to ConfigBool better reflects its purpose. This should also make it less confusing when ConfigBools are eventually added to the other config windows.

I'll convert the other Graphics controls in other PRs; I figure it'll be simpler to review this one if everything's the same type.