### PR TITLE
Simplified check for MacOS in Externals > mdbetls > library > CMakeLists.txt

### DIFF
--- a/Externals/mbedtls/library/CMakeLists.txt
+++ b/Externals/mbedtls/library/CMakeLists.txt
@@ -129,7 +129,7 @@ if(WIN32)
     set(libs ${libs} ws2_32)
 endif(WIN32)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(APPLE)
     SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
     SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
     SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")


### PR DESCRIPTION
Hey there, junior developer here.

Did some reading in the docs for CMake and found there's a boolean called "APPLE" that can be used to check the OS. From what I can tell, it should be able to be used to do this check and make it look much simpler.

Let me know if there's anything I misunderstood, your feedback is invaluable to me. 