### PR TITLE
Cleanup main_spy.cpp

### DIFF
--- a/Source/DSPSpy/main_spy.cpp
+++ b/Source/DSPSpy/main_spy.cpp
@@ -34,7 +34,7 @@
 #include <sdcard/wiisd_io.h>
 #include <wiiuse/wpad.h>
 #else
-#include <sdcard/gcsd.h> 
+#include <sdcard/gcsd.h>
 #endif
 
 #include "ConsoleHelper.h"

--- a/Source/DSPSpy/main_spy.cpp
+++ b/Source/DSPSpy/main_spy.cpp
@@ -4,8 +4,8 @@
 // This is a test program for running code on the Wii DSP, with full control over input
 // and automatic compare with output. VERY useful for figuring out what those little
 // ops actually do.
-// It's very unpolished though
-// Use Dolphin's dsptool to generate a new dsp_code.h.
+// It's very unpolished, though.
+// Use Dolphin's DSPTool to generate a new dsp_code.h.
 // Originally written by duddie and modified by FIRES. Then further modified by ector.
 
 #include <array>
@@ -34,7 +34,7 @@
 #include <sdcard/wiisd_io.h>
 #include <wiiuse/wpad.h>
 #else
-#include <sdcard/gcsd.h>
+#include <sdcard/gcsd.h> 
 #endif
 
 #include "ConsoleHelper.h"
@@ -48,7 +48,6 @@
 // Communication with the real DSP and with the DSP emulator.
 #include "dsp_interface.h"
 #include "real_dsp.h"
-// #include "virtual_dsp.h"
 
 // Used for communications with the DSP, such as dumping registers etc.
 u16 dspbuffer[16 * 1024] __attribute__((aligned(0x4000)));
@@ -69,58 +68,15 @@ u16 dspreg_in[32] = {
     0x0000, 0x0000, 0x0003, 0x0004, 0x8000, 0x000C, 0x0007, 0x0008, 0x0009, 0x000a,
 };  ///            ax_h_1   ax_h_1
 
-/* ttt ?
-
-u16 dspreg_in[32] = {
-0x0e4c, 0x03c0, 0x0bd9, 0x06a3, 0x0c06, 0x0240, 0x0010, 0x0ecc,
-0x0000, 0x0000, 0x0000, 0x0000, 0x0322, 0x0000, 0x0000, 0x0000,
-0x0000, 0x0000, 0x00ff, 0x1b41, 0x0000, 0x0040, 0x00ff, 0x0000,
-0x1000, 0x96cc, 0x0000, 0x0000, 0x3fc0, 0x96cc, 0x0000, 0x0000,
-}; */
-
-// if i set bit 0x4000 of SR my tests crashes :(
-
-/*
-// zelda 0x00da
-u16 dspreg_in[32] = {
-0x0a50, 0x0ca2, 0x04f8, 0x0ab0, 0x8039, 0x0000, 0x0000, 0x0000,
-0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x03d1, 0x0000, 0x0418, 0x0002,     // r08 must have a value ... no
-idea why (ector: it's the looped addressing regs)
-0x0000, 0x0000, 0x00ff, 0x1804, 0xdb70, 0x4ddb, 0x0000, 0x0000,
-0x0000, 0x0000, 0x0000, 0xde6d, 0x0000, 0x0000, 0x0000, 0x004e,
-};*/
-
 u16 dspreg_out[1000][32];
 
-/*
-// gba ucode dmas result here
-u32 SecParams_out[2] __attribute__ ((aligned (0x20))) = {
-  0x11223344, // key
-  0x55667788 // bootinfo
-};
-
-// ripped from demo
-u32 SecParams_in[8] __attribute__ ((aligned (0x20))) = {
-  0xDB967E0F, // key from gba
-  0x00000002,
-  0x00000002,
-  0x00001078,
-  (u32)SecParams_out, //0x80075060, // ptr to receiving buffer
-  // padding?
-  0x00000000,
-  0x00000000,
-  0x00000000
-};
-*/
-
-// UI (interactive register editing)
+// UI (interactive register editing.)
 u32 ui_mode;
 
 enum
 {
   UIM_SEL = 1,
   UIM_EDIT_REG = 2,
-  UIM_EDIT_BIN = 4,
 };
 
 // Currently selected register.
@@ -132,7 +88,7 @@ u16* reg_value;
 
 RealDSP real_dsp;
 
-// Currently running microcode
+// Currently running microcode.
 int curUcode = 0, runningUcode = 1;
 
 int dsp_steps = 0;
@@ -145,15 +101,15 @@ constexpr std::array reg_names = {
 
 void print_reg_block(int x, int y, int sel, const u16* regs, const u16* compare_regs)
 {
-  for (int j = 0; j < 4; j++)
+  for (int j = 0; j < 4; ++j)
   {
-    for (int i = 0; i < 8; i++)
+    for (int i = 0; i < 8; ++i)
     {
       const int reg = j * 8 + i;
       u8 color1 = regs[reg] == compare_regs[reg] ? CON_BRIGHT_WHITE : CON_BRIGHT_RED;
       CON_SetColor(sel == reg ? CON_BRIGHT_YELLOW : CON_GREEN);
       CON_Printf(x + j * 9, i + y, "%s ", reg_names[reg]);
-      for (int k = 0; k < 4; k++)
+      for (int k = 0; k < 4; ++k)
       {
         if (sel == reg && k == small_cursor_x && ui_mode == UIM_EDIT_REG)
           CON_SetColor(CON_BRIGHT_CYAN);
@@ -204,7 +160,7 @@ void print_regs(int _step, int _dsp_steps)
     CON_Clear();
   count = 0;
   CON_SetColor(CON_WHITE);
-  for (int i = 0x0; i < 0xf70; i++)
+  for (int i = 0x0; i < 0xf70; ++i)
   {
     if (dspbufC[i] != mem_dump[i])
     {
@@ -335,113 +291,80 @@ void handle_dsp_mail(void)
     {
       // DSP ready for task. Let's send one.
       // First, prepare data.
-      for (int n = 0; n < 32; n++)
+      for (int n = 0; n < 32; ++n)
         dspbufC[0x00 + n] = dspreg_in[n];
       DCFlushRange(dspbufC, 0x2000);
       // Then send the code.
       DCFlushRange((void*)dsp_code[curUcode], 0x2000);
       // DMA ucode to iram base, entry point is just after exception vectors...0x10
-      // NOTE: for any ucode made by dsptool, the block length will be 8191
+      // NOTE: for any ucode made by dsptool, the block length will be 8191.
       real_dsp.SendTask((void*)MEM_VIRTUAL_TO_PHYSICAL(dsp_code[curUcode]), 0,
                         sizeof(dsp_code[curUcode]) - 1, 0x10);
 
       runningUcode = curUcode + 1;
 
-      // Clear exception status since we've loaded a new ucode
+      // Clear exception status since we've loaded a new ucode.
       CON_BlankRow(25);
     }
     else if ((mail & 0xffff0000) == 0x8bad0000)
     {
-      // dsp_base.inc is reporting an exception happened
+      // dsp_base.inc is reporting an exception happened.
       CON_PrintRow(4, 25, "%s caused exception %x at step %i", UCODE_NAMES[curUcode], mail & 0xff,
                    dsp_steps);
     }
     else if (mail == 0x8888dead)
     {
       // Send memory dump (DSP DRAM from someone's GameCube?)
-      // not really sure why this is important - I guess just to try to keep tests predictable
+      // Not really sure why this is important - I guess just to try to keep tests predictable.
       u16* tmpBuf = (u16*)MEM_VIRTUAL_TO_PHYSICAL(mem_dump);
 
-      while (real_dsp.CheckMailTo())
-        ;
+      while (real_dsp.CheckMailTo()) {}
       real_dsp.SendMailTo((u32)tmpBuf);
-      while (real_dsp.CheckMailTo())
-        ;
+      while (real_dsp.CheckMailTo()) {}
     }
     else if (mail == 0x8888beef)
     {
-      // Provide register base to DSP (if using dsp_base.inc, it will DMA them to the correct place)
-      while (real_dsp.CheckMailTo())
-        ;
+      // Provide register base to DSP (if using dsp_base.inc, it will DMA them to the correct place.)
+      while (real_dsp.CheckMailTo()) {}
       real_dsp.SendMailTo((u32)dspbufP);
-      while (real_dsp.CheckMailTo())
-        ;
+      while (real_dsp.CheckMailTo()) {}
     }
     else if (mail == 0x8888feeb)
     {
       // We got a stepful of registers.
       DCInvalidateRange(dspbufC, 0x2000);
-      for (int i = 0; i < 32; i++)
+      for (int i = 0; i < 32; ++i)
         dspreg_out[dsp_steps][i] = dspbufC[0xf80 + i];
 
       dsp_steps++;
 
-      while (real_dsp.CheckMailTo())
-        ;
+      while (real_dsp.CheckMailTo()) {}
       real_dsp.SendMailTo(0x8000dead);
-      while (real_dsp.CheckMailTo())
-        ;
+      while (real_dsp.CheckMailTo()) {}
     }
     else if (mail == 0x80050000)
     {
       CON_PrintRow(4, 25, "ACCOV at step %i", dsp_steps);
     }
 
-    // ROM dumping mails
+    // ROM dumping mails.
     else if (mail == 0x8888c0de)
     {
-      // DSP has copied irom to its DRAM...send address so it can dma it back
-      while (real_dsp.CheckMailTo())
-        ;
+      // DSP has copied irom to its DRAM...send address so it can DMA it back.
+      while (real_dsp.CheckMailTo()) {}
       real_dsp.SendMailTo((u32)dspbufP);
-      while (real_dsp.CheckMailTo())
-        ;
+      while (real_dsp.CheckMailTo()) {}
     }
     else if (mail == 0x8888da7a)
     {
-      // DSP has copied coef to its DRAM...send address so it can DMA it back
-      while (real_dsp.CheckMailTo())
-        ;
+      // DSP has copied coef to its DRAM...send address so it can DMA it back. 
+      while (real_dsp.CheckMailTo()) {}
       real_dsp.SendMailTo((u32)&dspbufP[0x1000]);
-      while (real_dsp.CheckMailTo())
-        ;
+      while (real_dsp.CheckMailTo()) {}
 
       // Now we can do something useful with the buffer :)
       DumpDSP_ROMs(dspbufP, &dspbufP[0x1000]);
     }
-
-    // SDK status mails
-    /*
-    // GBA ucode
-    else if (mail == 0xdcd10000) // DSP_INIT
-    {
-      real_dsp.SendMailTo(0xabba0000);
-      while (real_dsp.CheckMailTo());
-      DCFlushRange(SecParams_in, sizeof(SecParams_in));
-      CON_PrintRow(4, 25, "SecParams_out = %x", SecParams_in[4]);
-      real_dsp.SendMailTo((u32)SecParams_in);
-      while (real_dsp.CheckMailTo());
-    }
-    else if (mail == 0xdcd10003) // DSP_DONE
-    {
-      real_dsp.SendMailTo(0xcdd1babe); // custom mail to tell DSP to halt (calls end_of_test)
-      while (real_dsp.CheckMailTo());
-
-      DCInvalidateRange(SecParams_out, sizeof(SecParams_out));
-      CON_PrintRow(4, 26, "SecParams_out: %08x %08x",
-      SecParams_out[0], SecParams_out[1]);
-    }
-    */
 
     CON_PrintRow(2, 1, "UCode: %d/%d %s, Last mail: %08x", curUcode + 1, NUM_UCODES,
                  UCODE_NAMES[curUcode], mail);
@@ -458,9 +381,9 @@ void dump_all_ucodes(bool fastmode)
   FILE* f2 = fopen(filename, "wb");
   fclose(f2);
 
-  for (int UCodeToDump = 0; UCodeToDump < NUM_UCODES; UCodeToDump++)
+  for (int UCodeToDump = 0; UCodeToDump < NUM_UCODES; ++UCodeToDump)
   {
-    // First, change the microcode
+    // First, change the microcode.
     dsp_steps = 0;
     curUcode = UCodeToDump;
     runningUcode = 0;
@@ -470,9 +393,9 @@ void dump_all_ucodes(bool fastmode)
 
     real_dsp.Reset();
 
-    // Loop over handling mail until we've stopped stepping
-    // dsp_steps-3 compensates for mails to setup the ucode
-    for (int steps_cache = dsp_steps - 3; steps_cache <= dsp_steps; steps_cache++)
+    // Loop over handling mail until we've stopped stepping.
+    // dsp_steps-3 compensates for mails to setup the ucode.
+    for (int steps_cache = dsp_steps - 3; steps_cache <= dsp_steps; ++steps_cache)
     {
       VIDEO_WaitVSync();
       handle_dsp_mail();
@@ -482,14 +405,14 @@ void dump_all_ucodes(bool fastmode)
     sprintf(filename, "sd:/dsp_dump_all.bin");
     FILE* f2 = fopen(filename, "ab");
 
-    if (fastmode == false)
+    if (!fastmode)
     {
-      // Then write microcode dump to file
+      // Then write microcode dump to file.
       sprintf(filename, "sd:/dsp_dump%d.bin", UCodeToDump);
       FILE* f = fopen(filename, "wb");
       if (f)
       {
-        // First write initial regs
+        // First write initial regs.
         written = fwrite(dspreg_in, 1, 32 * 2, f);
 
         // Then write all the dumps.
@@ -503,11 +426,11 @@ void dump_all_ucodes(bool fastmode)
       }
     }
 
-    if (f2)  // all in 1 dump file (extra)
+    if (f2)  // All in 1 dump file (extra)
     {
       if (UCodeToDump == 0)
       {
-        // First write initial regs
+        // First write initial regs.
         written = fwrite(dspreg_in, 1, 32 * 2, f2);
         written += fwrite(dspreg_out, 1, dsp_steps * 32 * 2, f2);
       }
@@ -537,39 +460,39 @@ void dump_all_ucodes(bool fastmode)
   }
 }
 
-// Shove common, un-dsp-ish init things here
+// Shove common, un-dsp-ish init things here.
 void InitGeneral()
 {
-  // Initialize the video system
+  // Initialize the video system.
   VIDEO_Init();
 
-  // This function initializes the attached controllers
+  // This function initializes the attached controllers.
   PAD_Init();
 #ifdef HW_RVL
   WPAD_Init();
 #endif
 
-  // Obtain the preferred video mode from the system
-  // This will correspond to the settings in the Wii Menu
+  // Obtain the preferred video mode from the system.
+  // This will correspond to the settings in the Wii Menu.
   rmode = VIDEO_GetPreferredMode(nullptr);
 
-  // Allocate memory for the display in the uncached region
+  // Allocate memory for the display in the uncached region.
   xfb = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
 
-  // Set up the video registers with the chosen mode
+  // Set up the video registers with the chosen mode.
   VIDEO_Configure(rmode);
-  // Tell the video hardware where our display memory is
+  // Tell the video hardware where our display memory is.
   VIDEO_SetNextFramebuffer(xfb);
-  // Make the display visible
+  // Make the display visible.
   VIDEO_SetBlack(FALSE);
-  // Flush the video register changes to the hardware
+  // Flush the video register changes to the hardware.
   VIDEO_Flush();
-  // Wait for Video setup to complete
+  // Wait for Video setup to complete.
   VIDEO_WaitVSync();
   if (rmode->viTVMode & VI_NON_INTERLACE)
     VIDEO_WaitVSync();
 
-  // Initialize the console, required for printf
+  // Initialize the console, required for printf.
   CON_Init(xfb, 20, 64, rmode->fbWidth, rmode->xfbHeight, rmode->fbWidth * VI_DISPLAY_PIX_SZ);
 
 #ifdef HW_RVL
@@ -580,7 +503,7 @@ void InitGeneral()
   // Initialize FAT so we can write to SD Gecko in slot B.
   fatMountSimple("sd", &__io_gcsdb);
 
-  // Init debug over BBA...change IPs to suite your needs
+  // Init debug over BBA...change IPs to suite your needs.
   tcp_localip = "192.168.1.103";
   tcp_netmask = "255.255.255.0";
   tcp_gateway = "192.168.1.2";
@@ -606,12 +529,12 @@ int main()
 
   ui_mode = UIM_SEL;
 
-  dspbufP = (u16*)MEM_VIRTUAL_TO_PHYSICAL(dspbuffer);  // physical
-  dspbufC = dspbuffer;                                 // cached
-  dspbufU = (u32*)(MEM_K0_TO_K1(dspbuffer));           // uncached
+  dspbufP = (u16*)MEM_VIRTUAL_TO_PHYSICAL(dspbuffer);  // Physical.
+  dspbufC = dspbuffer;                                 // Cached.
+  dspbufU = (u32*)(MEM_K0_TO_K1(dspbuffer));           // Uncached.
 
   DCInvalidateRange(dspbuffer, 0x2000);
-  for (int j = 0; j < 0x800; j++)
+  for (int j = 0; j < 0x800; ++j)
     dspbufU[j] = 0xffffffff;
 
   // Initialize DSP.
@@ -636,8 +559,7 @@ int main()
     CON_Printf(4, 19, "+/- (GC:'L'/'R') to move");
     CON_Printf(4, 20, "A (GC:'A') to edit register; B (GC:'B') to start over");
     CON_Printf(4, 21, "1 (GC:'Z') to move next microcode");
-    CON_Printf(4, 22,
-               "2 (GC:'X') dump results to SD; UP (GC:'Y') dump results to SD (SINGLE FILE)");
+    CON_Printf(4, 22, "2 (GC:'X') dump results to SD; UP (GC:'Y') dump results to SD (SINGLE FILE)");
     CON_Printf(4, 23, "Home (GC:'START') to exit");
 #else
     CON_Printf(2, 18, "Controls:");
@@ -657,9 +579,6 @@ int main()
     case UIM_EDIT_REG:
       ui_pad_edit_reg();
       break;
-    case UIM_EDIT_BIN:
-      // ui_pad_edit_bin();
-      break;
     default:
       break;
     }
@@ -672,8 +591,7 @@ int main()
     if (PAD_ButtonsDown(0) & PAD_BUTTON_B)
 #endif
     {
-      dsp_steps =
-          0;  // Let's not add the new steps after the original ones. That was just annoying.
+      dsp_steps = 0;  // Let's not add the new steps after the original ones. That was just annoying.
 
       DCInvalidateRange(dspbufC, 0x2000);
       DCFlushRange(dspbufC, 0x2000);
@@ -722,37 +640,32 @@ int main()
       dsp_steps = 0;
 
       DCInvalidateRange(dspbufC, 0x2000);
-      for (int n = 0; n < 0x2000; n++)
-      {
-        //	dspbufU[n/2] = 0; dspbufC[n] = 0;
-      }
       DCFlushRange(dspbufC, 0x2000);
 
       // Reset the DSP.
       real_dsp.Reset();
       UpdateLastMessage("OK");
 
-      // Waiting for video to synchronize (enough time to set our new microcode)
+      // Waiting for video to synchronize (enough time to set our new microcode.)
       VIDEO_WaitVSync();
     }
 
 #ifdef HW_RVL
-    // Probably could offer to save to sd gecko or something on gc...
+    // Probably could offer to save to SD Gecko or something on GC...
     // The future is web-based reporting ;)
     if ((WPAD_ButtonsDown(0) & WPAD_BUTTON_2) || (PAD_ButtonsDown(0) & PAD_BUTTON_X))
     {
       dump_all_ucodes(false);
     }
 
-    // Dump all results into 1 file (skip file per ucode part) = FAST because of LIBFAT filecreate
-    // bug
+    // Dump all results into 1 file (skip file per ucode part) = FAST because of LIBFAT filecreate bug.
     if ((WPAD_ButtonsDown(0) & WPAD_BUTTON_UP) || (PAD_ButtonsDown(0) & PAD_BUTTON_Y))
     {
       dump_all_ucodes(true);
     }
 #endif
 
-  }  // end main loop
+  }  // End of main loop.
 
   ExitToLoader();
 


### PR DESCRIPTION
A general cleanup of Source > DSPSpy > main_spy.cpp

The following changes have been made:

- Removed several instances of zombie code, some of which has been present ever since the initial commit of this file back in 2009 (https://github.com/dolphin-emu/dolphin/commit/6ec5d28eda80083b17ca33516932be0bc4eb1eff).
- Comments have been updated to be formatted more consistently (e.g. using capitals for acronyms, using periods.)
- Changed empty while loops to end with `{}` rather than `;` per the standards discussed in Contributing.md.
- Changed increment operators used in for loops to use prefix rather than postfix, per the standards discussed in Contributing.md.

Also, there is a seemingly random `return` statement at line 199 in the original file, right in the middle of `void print_regs()`
Wouldn't all of the code encapsulated within the function and written after the `return` be unreachable? 

If there's anything I misunderstood or changes that need to be made, please let me know. 

Signed-off-by: Joel Elrod [[joelelrod246@gmail.com](mailto:joelelrod246@gmail.com)]