### PR TITLE
IOS: Leverage Kernel/EmulationKernel difference for passing System to most IOS devices.

### DIFF
--- a/Source/Core/Core/IOS/DI/DI.h
+++ b/Source/Core/Core/IOS/DI/DI.h
@@ -35,10 +35,10 @@ void Init();
 
 namespace IOS::HLE
 {
-class DIDevice : public Device
+class DIDevice : public EmulationDevice
 {
 public:
-  DIDevice(Kernel& ios, const std::string& device_name);
+  DIDevice(EmulationKernel& ios, const std::string& device_name);
 
   static void InterruptFromDVDInterface(DVD::DIInterruptType interrupt_type);
   static DiscIO::Partition GetCurrentPartition();

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -16,17 +16,15 @@
 
 namespace IOS::HLE
 {
-Request::Request(const u32 address_) : address(address_)
+Request::Request(Core::System& system, const u32 address_) : address(address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   command = static_cast<IPCCommandType>(memory.Read_U32(address));
   fd = memory.Read_U32(address + 8);
 }
 
-OpenRequest::OpenRequest(const u32 address_) : Request(address_)
+OpenRequest::OpenRequest(Core::System& system, const u32 address_) : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   path = memory.GetString(memory.Read_U32(address + 0xc));
   flags = static_cast<OpenMode>(memory.Read_U32(address + 0x10));
@@ -38,25 +36,23 @@ OpenRequest::OpenRequest(const u32 address_) : Request(address_)
   }
 }
 
-ReadWriteRequest::ReadWriteRequest(const u32 address_) : Request(address_)
+ReadWriteRequest::ReadWriteRequest(Core::System& system, const u32 address_)
+    : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   buffer = memory.Read_U32(address + 0xc);
   size = memory.Read_U32(address + 0x10);
 }
 
-SeekRequest::SeekRequest(const u32 address_) : Request(address_)
+SeekRequest::SeekRequest(Core::System& system, const u32 address_) : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   offset = memory.Read_U32(address + 0xc);
   mode = static_cast<SeekMode>(memory.Read_U32(address + 0x10));
 }
 
-IOCtlRequest::IOCtlRequest(const u32 address_) : Request(address_)
+IOCtlRequest::IOCtlRequest(Core::System& system, const u32 address_) : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   request = memory.Read_U32(address + 0x0c);
   buffer_in = memory.Read_U32(address + 0x10);
@@ -65,9 +61,8 @@ IOCtlRequest::IOCtlRequest(const u32 address_) : Request(address_)
   buffer_out_size = memory.Read_U32(address + 0x1c);
 }
 
-IOCtlVRequest::IOCtlVRequest(const u32 address_) : Request(address_)
+IOCtlVRequest::IOCtlVRequest(Core::System& system, const u32 address_) : Request(system, address_)
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   request = memory.Read_U32(address + 0x0c);
   const u32 in_number = memory.Read_U32(address + 0x10);
@@ -114,10 +109,9 @@ void IOCtlRequest::Log(std::string_view device_name, Common::Log::LogType type,
                   device_name, fd, request, buffer_in_size, buffer_out_size);
 }
 
-void IOCtlRequest::Dump(const std::string& description, Common::Log::LogType type,
-                        Common::Log::LogLevel level) const
+void IOCtlRequest::Dump(Core::System& system, const std::string& description,
+                        Common::Log::LogType type, Common::Log::LogLevel level) const
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
   Log("===== " + description, type, level);
@@ -127,16 +121,15 @@ void IOCtlRequest::Dump(const std::string& description, Common::Log::LogType typ
                   HexDump(memory.GetPointer(buffer_out), buffer_out_size));
 }
 
-void IOCtlRequest::DumpUnknown(const std::string& description, Common::Log::LogType type,
-                               Common::Log::LogLevel level) const
+void IOCtlRequest::DumpUnknown(Core::System& system, const std::string& description,
+                               Common::Log::LogType type, Common::Log::LogLevel level) const
 {
-  Dump("Unknown IOCtl - " + description, type, level);
+  Dump(system, "Unknown IOCtl - " + description, type, level);
 }
 
-void IOCtlVRequest::Dump(std::string_view description, Common::Log::LogType type,
-                         Common::Log::LogLevel level) const
+void IOCtlVRequest::Dump(Core::System& system, std::string_view description,
+                         Common::Log::LogType type, Common::Log::LogLevel level) const
 {
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
   GENERIC_LOG_FMT(type, level, "===== {} (fd {}) - IOCtlV {:#x} ({} in, {} io)", description, fd,
@@ -154,10 +147,10 @@ void IOCtlVRequest::Dump(std::string_view description, Common::Log::LogType type
     GENERIC_LOG_FMT(type, level, "io[{}] (size={:#x})", i++, vector.size);
 }
 
-void IOCtlVRequest::DumpUnknown(const std::string& description, Common::Log::LogType type,
-                                Common::Log::LogLevel level) const
+void IOCtlVRequest::DumpUnknown(Core::System& system, const std::string& description,
+                                Common::Log::LogType type, Common::Log::LogLevel level) const
 {
-  Dump("Unknown IOCtlV - " + description, type, level);
+  Dump(system, "Unknown IOCtlV - " + description, type, level);
 }
 
 Device::Device(Kernel& ios, const std::string& device_name, const DeviceType type)

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -13,6 +13,11 @@
 #include "Common/Logging/Log.h"
 #include "Core/IOS/IOS.h"
 
+namespace Core
+{
+class System;
+}
+
 namespace IOS::HLE
 {
 enum ReturnCode : s32
@@ -77,7 +82,7 @@ struct Request
   u32 address = 0;
   IPCCommandType command = IPC_CMD_OPEN;
   u32 fd = 0;
-  explicit Request(u32 address);
+  Request(Core::System& system, u32 address);
   virtual ~Request() = default;
 };
 
@@ -97,14 +102,14 @@ struct OpenRequest final : Request
   // but they are set after they reach IOS and are dispatched to the appropriate module.
   u32 uid = 0;
   u16 gid = 0;
-  explicit OpenRequest(u32 address);
+  OpenRequest(Core::System& system, u32 address);
 };
 
 struct ReadWriteRequest final : Request
 {
   u32 buffer = 0;
   u32 size = 0;
-  explicit ReadWriteRequest(u32 address);
+  ReadWriteRequest(Core::System& system, u32 address);
 };
 
 enum SeekMode : s32
@@ -118,7 +123,7 @@ struct SeekRequest final : Request
 {
   u32 offset = 0;
   SeekMode mode = IOS_SEEK_SET;
-  explicit SeekRequest(u32 address);
+  SeekRequest(Core::System& system, u32 address);
 };
 
 struct IOCtlRequest final : Request
@@ -129,12 +134,13 @@ struct IOCtlRequest final : Request
   // Contrary to the name, the output buffer can also be used for input.
   u32 buffer_out = 0;
   u32 buffer_out_size = 0;
-  explicit IOCtlRequest(u32 address);
+  IOCtlRequest(Core::System& system, u32 address);
   void Log(std::string_view description, Common::Log::LogType type = Common::Log::LogType::IOS,
            Common::Log::LogLevel level = Common::Log::LogLevel::LINFO) const;
-  void Dump(const std::string& description, Common::Log::LogType type = Common::Log::LogType::IOS,
+  void Dump(Core::System& system, const std::string& description,
+            Common::Log::LogType type = Common::Log::LogType::IOS,
             Common::Log::LogLevel level = Common::Log::LogLevel::LINFO) const;
-  void DumpUnknown(const std::string& description,
+  void DumpUnknown(Core::System& system, const std::string& description,
                    Common::Log::LogType type = Common::Log::LogType::IOS,
                    Common::Log::LogLevel level = Common::Log::LogLevel::LERROR) const;
 };
@@ -159,11 +165,12 @@ struct IOCtlVRequest final : Request
   /// Returns the specified vector or nullptr if the index is out of bounds.
   const IOVector* GetVector(size_t index) const;
 
-  explicit IOCtlVRequest(u32 address);
+  IOCtlVRequest(Core::System& system, u32 address);
   bool HasNumberOfValidVectors(size_t in_count, size_t io_count) const;
-  void Dump(std::string_view description, Common::Log::LogType type = Common::Log::LogType::IOS,
+  void Dump(Core::System& system, std::string_view description,
+            Common::Log::LogType type = Common::Log::LogType::IOS,
             Common::Log::LogLevel level = Common::Log::LogLevel::LINFO) const;
-  void DumpUnknown(const std::string& description,
+  void DumpUnknown(Core::System& system, const std::string& description,
                    Common::Log::LogType type = Common::Log::LogType::IOS,
                    Common::Log::LogLevel level = Common::Log::LogLevel::LERROR) const;
 };
@@ -213,5 +220,23 @@ protected:
 
 private:
   std::optional<IPCReply> Unsupported(const Request& request);
+};
+
+// Helper class for Devices that we know are only ever instantiated under an EmulationKernel.
+// Deriving a Device from this allows it to access EmulationKernel-only features without runtime
+// overhead, since it will know that the m_ios instance is an EmulationKernel.
+class EmulationDevice : public Device
+{
+public:
+  EmulationDevice(EmulationKernel& ios, const std::string& device_name,
+                  DeviceType type = DeviceType::Static)
+      : Device(ios, device_name, type)
+  {
+  }
+
+protected:
+  EmulationKernel& GetEmulationKernel() const { return static_cast<EmulationKernel&>(m_ios); }
+
+  Core::System& GetSystem() const { return GetEmulationKernel().GetSystem(); }
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -40,7 +40,7 @@ enum
 
 };
 
-IPCReply GetVersion(const IOCtlVRequest& request)
+IPCReply GetVersion(Core::System& system, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1))
   {
@@ -49,7 +49,6 @@ IPCReply GetVersion(const IOCtlVRequest& request)
 
   const auto length = std::min(size_t(request.io_vectors[0].size), Common::GetScmDescStr().size());
 
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   memory.Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
   memory.CopyToEmu(request.io_vectors[0].address, Common::GetScmDescStr().data(), length);
@@ -57,7 +56,7 @@ IPCReply GetVersion(const IOCtlVRequest& request)
   return IPCReply(IPC_SUCCESS);
 }
 
-IPCReply GetCPUSpeed(const IOCtlVRequest& request)
+IPCReply GetCPUSpeed(Core::System& system, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1))
   {
@@ -74,14 +73,13 @@ IPCReply GetCPUSpeed(const IOCtlVRequest& request)
 
   const u32 core_clock = u32(float(SystemTimers::GetTicksPerSecond()) * oc);
 
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   memory.Write_U32(core_clock, request.io_vectors[0].address);
 
   return IPCReply(IPC_SUCCESS);
 }
 
-IPCReply GetSpeedLimit(const IOCtlVRequest& request)
+IPCReply GetSpeedLimit(Core::System& system, const IOCtlVRequest& request)
 {
   // get current speed limit
   if (!request.HasNumberOfValidVectors(0, 1))
@@ -96,14 +94,13 @@ IPCReply GetSpeedLimit(const IOCtlVRequest& request)
 
   const u32 speed_percent = Config::Get(Config::MAIN_EMULATION_SPEED) * 100;
 
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   memory.Write_U32(speed_percent, request.io_vectors[0].address);
 
   return IPCReply(IPC_SUCCESS);
 }
 
-IPCReply SetSpeedLimit(const IOCtlVRequest& request)
+IPCReply SetSpeedLimit(Core::System& system, const IOCtlVRequest& request)
 {
   // set current speed limit
   if (!request.HasNumberOfValidVectors(1, 0))
@@ -116,7 +113,6 @@ IPCReply SetSpeedLimit(const IOCtlVRequest& request)
     return IPCReply(IPC_EINVAL);
   }
 
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   const float speed = float(memory.Read_U32(request.in_vectors[0].address)) / 100.0f;
   Config::SetCurrent(Config::MAIN_EMULATION_SPEED, speed);
@@ -124,7 +120,7 @@ IPCReply SetSpeedLimit(const IOCtlVRequest& request)
   return IPCReply(IPC_SUCCESS);
 }
 
-IPCReply GetRealProductCode(const IOCtlVRequest& request)
+IPCReply GetRealProductCode(Core::System& system, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1))
   {
@@ -150,14 +146,13 @@ IPCReply GetRealProductCode(const IOCtlVRequest& request)
   if (length == 0)
     return IPCReply(IPC_ENOENT);
 
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   memory.Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
   memory.CopyToEmu(request.io_vectors[0].address, code.c_str(), length);
   return IPCReply(IPC_SUCCESS);
 }
 
-IPCReply SetDiscordClient(const IOCtlVRequest& request)
+IPCReply SetDiscordClient(Core::System& system, const IOCtlVRequest& request)
 {
   if (!Config::Get(Config::MAIN_USE_DISCORD_PRESENCE))
     return IPCReply(IPC_EACCES);
@@ -165,7 +160,6 @@ IPCReply SetDiscordClient(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(1, 0))
     return IPCReply(IPC_EINVAL);
 
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
   std::string new_client_id =
       memory.GetString(request.in_vectors[0].address, request.in_vectors[0].size);
@@ -175,7 +169,7 @@ IPCReply SetDiscordClient(const IOCtlVRequest& request)
   return IPCReply(IPC_SUCCESS);
 }
 
-IPCReply SetDiscordPresence(const IOCtlVRequest& request)
+IPCReply SetDiscordPresence(Core::System& system, const IOCtlVRequest& request)
 {
   if (!Config::Get(Config::MAIN_USE_DISCORD_PRESENCE))
     return IPCReply(IPC_EACCES);
@@ -183,7 +177,6 @@ IPCReply SetDiscordPresence(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(10, 0))
     return IPCReply(IPC_EINVAL);
 
-  auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
   std::string details = memory.GetString(request.in_vectors[0].address, request.in_vectors[0].size);
@@ -242,7 +235,7 @@ IPCReply DolphinDevice::GetElapsedTime(const IOCtlVRequest& request) const
   // have issues.
   const u32 milliseconds = static_cast<u32>(m_timer.ElapsedMs());
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
   memory.Write_U32(milliseconds, request.io_vectors[0].address);
 
@@ -261,7 +254,7 @@ IPCReply DolphinDevice::GetSystemTime(const IOCtlVRequest& request) const
     return IPCReply(IPC_EINVAL);
   }
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   // Write Unix timestamp in milliseconds to memory address
@@ -272,7 +265,8 @@ IPCReply DolphinDevice::GetSystemTime(const IOCtlVRequest& request) const
   return IPCReply(IPC_SUCCESS);
 }
 
-DolphinDevice::DolphinDevice(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+DolphinDevice::DolphinDevice(EmulationKernel& ios, const std::string& device_name)
+    : EmulationDevice(ios, device_name)
 {
   m_timer.Start();
 }
@@ -287,19 +281,19 @@ std::optional<IPCReply> DolphinDevice::IOCtlV(const IOCtlVRequest& request)
   case IOCTL_DOLPHIN_GET_ELAPSED_TIME:
     return GetElapsedTime(request);
   case IOCTL_DOLPHIN_GET_VERSION:
-    return GetVersion(request);
+    return GetVersion(GetSystem(), request);
   case IOCTL_DOLPHIN_GET_SPEED_LIMIT:
-    return GetSpeedLimit(request);
+    return GetSpeedLimit(GetSystem(), request);
   case IOCTL_DOLPHIN_SET_SPEED_LIMIT:
-    return SetSpeedLimit(request);
+    return SetSpeedLimit(GetSystem(), request);
   case IOCTL_DOLPHIN_GET_CPU_SPEED:
-    return GetCPUSpeed(request);
+    return GetCPUSpeed(GetSystem(), request);
   case IOCTL_DOLPHIN_GET_REAL_PRODUCTCODE:
-    return GetRealProductCode(request);
+    return GetRealProductCode(GetSystem(), request);
   case IOCTL_DOLPHIN_DISCORD_SET_CLIENT:
-    return SetDiscordClient(request);
+    return SetDiscordClient(GetSystem(), request);
   case IOCTL_DOLPHIN_DISCORD_SET_PRESENCE:
-    return SetDiscordPresence(request);
+    return SetDiscordPresence(GetSystem(), request);
   case IOCTL_DOLPHIN_DISCORD_RESET:
     return ResetDiscord(request);
   case IOCTL_DOLPHIN_GET_SYSTEM_TIME:

--- a/Source/Core/Core/IOS/DolphinDevice.h
+++ b/Source/Core/Core/IOS/DolphinDevice.h
@@ -8,10 +8,10 @@
 
 namespace IOS::HLE
 {
-class DolphinDevice final : public Device
+class DolphinDevice final : public EmulationDevice
 {
 public:
-  DolphinDevice(Kernel& ios, const std::string& device_name);
+  DolphinDevice(EmulationKernel& ios, const std::string& device_name);
   std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 
 private:

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -702,7 +702,7 @@ std::optional<IPCReply> ESDevice::IOCtlV(const IOCtlVRequest& request)
   case IOCTL_ES_UNKNOWN_42:
     PanicAlertFmt("IOS-ES: Unimplemented ioctlv {:#x} ({} in vectors, {} io vectors)",
                   request.request, request.in_vectors.size(), request.io_vectors.size());
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_ES,
+    request.DumpUnknown(Core::System::GetInstance(), GetDeviceName(), Common::Log::LogType::IOS_ES,
                         Common::Log::LogLevel::LERROR);
     return IPCReply(IPC_EINVAL);
 

--- a/Source/Core/Core/IOS/Network/IP/Top.h
+++ b/Source/Core/Core/IOS/Network/IP/Top.h
@@ -63,10 +63,10 @@ enum NET_IOCTL
   IOCTL_SO_ICMPCLOSE
 };
 
-class NetIPTopDevice : public Device
+class NetIPTopDevice : public EmulationDevice
 {
 public:
-  NetIPTopDevice(Kernel& ios, const std::string& device_name);
+  NetIPTopDevice(EmulationKernel& ios, const std::string& device_name);
 
   void DoState(PointerWrap& p) override;
   std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
@@ -21,10 +21,10 @@ constexpr const char DL_CNT_PATH[] = "/" WII_WC24CONF_DIR "/dlcnt.bin";
 // KD is the IOS module responsible for implementing WiiConnect24 functionality.
 // It can perform HTTPS downloads, send and receive mail via SMTP, and execute a
 // JavaScript-like language while the Wii is in standby mode.
-class NetKDRequestDevice : public Device
+class NetKDRequestDevice : public EmulationDevice
 {
 public:
-  NetKDRequestDevice(Kernel& ios, const std::string& device_name);
+  NetKDRequestDevice(EmulationKernel& ios, const std::string& device_name);
   IPCReply HandleNWC24DownloadNowEx(const IOCtlRequest& request);
   NWC24::ErrorCode KDDownload(const u16 entry_index, const std::optional<u8> subtask_id);
   ~NetKDRequestDevice() override;

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -12,8 +12,8 @@
 
 namespace IOS::HLE
 {
-NetKDTimeDevice::NetKDTimeDevice(Kernel& ios, const std::string& device_name)
-    : Device(ios, device_name)
+NetKDTimeDevice::NetKDTimeDevice(EmulationKernel& ios, const std::string& device_name)
+    : EmulationDevice(ios, device_name)
 {
 }
 
@@ -35,7 +35,7 @@ std::optional<IPCReply> NetKDTimeDevice::IOCtl(const IOCtlRequest& request)
   // TODO Writes stuff to /shared2/nwc24/misc.bin
   u32 update_misc = 0;
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   switch (request.request)
@@ -78,7 +78,7 @@ std::optional<IPCReply> NetKDTimeDevice::IOCtl(const IOCtlRequest& request)
     break;
 
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_WC24);
+    request.DumpUnknown(system, GetDeviceName(), Common::Log::LogType::IOS_WC24);
     break;
   }
 
@@ -91,8 +91,7 @@ u64 NetKDTimeDevice::GetAdjustedUTC() const
 {
   using namespace ExpansionInterface;
 
-  const time_t current_time =
-      CEXIIPL::GetEmulatedTime(Core::System::GetInstance(), CEXIIPL::UNIX_EPOCH);
+  const time_t current_time = CEXIIPL::GetEmulatedTime(GetSystem(), CEXIIPL::UNIX_EPOCH);
   tm* const gm_time = gmtime(&current_time);
   const u32 emulated_time = mktime(gm_time);
   return u64(s64(emulated_time) + utcdiff);
@@ -102,8 +101,7 @@ void NetKDTimeDevice::SetAdjustedUTC(u64 wii_utc)
 {
   using namespace ExpansionInterface;
 
-  const time_t current_time =
-      CEXIIPL::GetEmulatedTime(Core::System::GetInstance(), CEXIIPL::UNIX_EPOCH);
+  const time_t current_time = CEXIIPL::GetEmulatedTime(GetSystem(), CEXIIPL::UNIX_EPOCH);
   tm* const gm_time = gmtime(&current_time);
   const u32 emulated_time = mktime(gm_time);
   utcdiff = s64(emulated_time - wii_utc);

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.h
@@ -10,10 +10,10 @@
 
 namespace IOS::HLE
 {
-class NetKDTimeDevice : public Device
+class NetKDTimeDevice : public EmulationDevice
 {
 public:
-  NetKDTimeDevice(Kernel& ios, const std::string& device_name);
+  NetKDTimeDevice(EmulationKernel& ios, const std::string& device_name);
   ~NetKDTimeDevice() override;
 
   std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;

--- a/Source/Core/Core/IOS/Network/NCD/Manage.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.cpp
@@ -15,8 +15,8 @@
 
 namespace IOS::HLE
 {
-NetNCDManageDevice::NetNCDManageDevice(Kernel& ios, const std::string& device_name)
-    : Device(ios, device_name)
+NetNCDManageDevice::NetNCDManageDevice(EmulationKernel& ios, const std::string& device_name)
+    : EmulationDevice(ios, device_name)
 {
   config.ReadConfig(ios.GetFS().get());
 }
@@ -33,7 +33,7 @@ std::optional<IPCReply> NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
   u32 common_result = 0;
   u32 common_vector = 0;
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   switch (request.request)

--- a/Source/Core/Core/IOS/Network/NCD/Manage.h
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.h
@@ -12,10 +12,10 @@
 namespace IOS::HLE
 {
 // Interface for reading and changing network configuration (probably some other stuff as well)
-class NetNCDManageDevice : public Device
+class NetNCDManageDevice : public EmulationDevice
 {
 public:
-  NetNCDManageDevice(Kernel& ios, const std::string& device_name);
+  NetNCDManageDevice(EmulationKernel& ios, const std::string& device_name);
 
   std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
 

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -88,7 +88,8 @@ int SSLRecv(void* ctx, unsigned char* buf, size_t len)
 }
 }  // namespace
 
-NetSSLDevice::NetSSLDevice(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+NetSSLDevice::NetSSLDevice(EmulationKernel& ios, const std::string& device_name)
+    : EmulationDevice(ios, device_name)
 {
   for (WII_SSL& ssl : _SSL)
   {
@@ -496,7 +497,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
       WII_SSL* ssl = &_SSL[sslID];
       mbedtls_ssl_setup(&ssl->ctx, &ssl->config);
       ssl->sockfd = memory.Read_U32(BufferOut2);
-      ssl->hostfd = m_ios.GetSocketManager()->GetHostSocket(ssl->sockfd);
+      ssl->hostfd = GetEmulationKernel().GetSocketManager()->GetHostSocket(ssl->sockfd);
       INFO_LOG_FMT(IOS_SSL, "IOCTLV_NET_SSL_CONNECT socket = {}", ssl->sockfd);
       mbedtls_ssl_set_bio(&ssl->ctx, ssl, SSLSendWithoutSNI, SSLRecv, nullptr);
       WriteReturnValue(SSL_OK, BufferIn);
@@ -519,7 +520,8 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
-      m_ios.GetSocketManager()->DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_DOHANDSHAKE);
+      GetEmulationKernel().GetSocketManager()->DoSock(_SSL[sslID].sockfd, request,
+                                                      IOCTLV_NET_SSL_DOHANDSHAKE);
       return std::nullopt;
     }
     else
@@ -533,7 +535,8 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     const int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
-      m_ios.GetSocketManager()->DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_WRITE);
+      GetEmulationKernel().GetSocketManager()->DoSock(_SSL[sslID].sockfd, request,
+                                                      IOCTLV_NET_SSL_WRITE);
       return std::nullopt;
     }
     else
@@ -556,7 +559,8 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
-      m_ios.GetSocketManager()->DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_READ);
+      GetEmulationKernel().GetSocketManager()->DoSock(_SSL[sslID].sockfd, request,
+                                                      IOCTLV_NET_SSL_READ);
       return std::nullopt;
     }
     else
@@ -615,7 +619,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     break;
   }
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_SSL);
+    request.DumpUnknown(system, GetDeviceName(), Common::Log::LogType::IOS_SSL);
   }
 
   // SSL return codes are written to BufferIn

--- a/Source/Core/Core/IOS/Network/SSL.h
+++ b/Source/Core/Core/IOS/Network/SSL.h
@@ -79,10 +79,10 @@ struct WII_SSL
   bool active = false;
 };
 
-class NetSSLDevice : public Device
+class NetSSLDevice : public EmulationDevice
 {
 public:
-  NetSSLDevice(Kernel& ios, const std::string& device_name);
+  NetSSLDevice(EmulationKernel& ios, const std::string& device_name);
 
   virtual ~NetSSLDevice();
 

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -260,7 +260,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
     IPCCommandType ct = it->request.command;
     if (!it->is_ssl && ct == IPC_CMD_IOCTL)
     {
-      IOCtlRequest ioctl{it->request.address};
+      IOCtlRequest ioctl{system, it->request.address};
       switch (it->net_type)
       {
       case IOCTL_SO_FCNTL:
@@ -351,7 +351,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
     }
     else if (ct == IPC_CMD_IOCTLV)
     {
-      IOCtlVRequest ioctlv{it->request.address};
+      IOCtlVRequest ioctlv{system, it->request.address};
       u32 BufferIn = 0, BufferIn2 = 0;
       u32 BufferInSize = 0, BufferInSize2 = 0;
       u32 BufferOut = 0, BufferOut2 = 0;
@@ -1042,8 +1042,8 @@ void WiiSockMan::UpdatePollCommands()
   pending_polls.erase(
       std::remove_if(
           pending_polls.begin(), pending_polls.end(),
-          [&memory, this](PollCommand& pcmd) {
-            const auto request = Request(pcmd.request_addr);
+          [&system, &memory, this](PollCommand& pcmd) {
+            const auto request = Request(system, pcmd.request_addr);
             auto& pfds = pcmd.wii_fds;
             int ret = 0;
 

--- a/Source/Core/Core/IOS/Network/WD/Command.h
+++ b/Source/Core/Core/IOS/Network/WD/Command.h
@@ -39,7 +39,7 @@ constexpr bool IsValidMode(Mode mode)
 
 namespace IOS::HLE
 {
-class NetWDCommandDevice : public Device
+class NetWDCommandDevice : public EmulationDevice
 {
 public:
   enum class ResultCode : u32
@@ -50,7 +50,7 @@ public:
     DriverError = 0x80008003,
   };
 
-  NetWDCommandDevice(Kernel& ios, const std::string& device_name);
+  NetWDCommandDevice(EmulationKernel& ios, const std::string& device_name);
 
   std::optional<IPCReply> Open(const OpenRequest& request) override;
   std::optional<IPCReply> Close(u32 fd) override;

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -25,8 +25,9 @@
 
 namespace IOS::HLE
 {
-SDIOSlot0Device::SDIOSlot0Device(Kernel& ios, const std::string& device_name)
-    : Device(ios, device_name), m_sdhc_supported(HasFeature(ios.GetVersion(), Feature::SDv2))
+SDIOSlot0Device::SDIOSlot0Device(EmulationKernel& ios, const std::string& device_name)
+    : EmulationDevice(ios, device_name),
+      m_sdhc_supported(HasFeature(ios.GetVersion(), Feature::SDv2))
 {
   if (!Config::Get(Config::MAIN_ALLOW_SD_WRITES))
     INFO_LOG_FMT(IOS_SD, "Writes to SD card disabled by user");
@@ -83,7 +84,7 @@ void SDIOSlot0Device::EventNotify()
     else
       INFO_LOG_FMT(IOS_SD, "Notifying PPC of SD card removal");
 
-    m_ios.EnqueueIPCReply(m_event->request, m_event->type);
+    GetEmulationKernel().EnqueueIPCReply(m_event->request, m_event->type);
     m_event.reset();
   }
 }
@@ -129,7 +130,7 @@ std::optional<IPCReply> SDIOSlot0Device::Close(u32 fd)
 
 std::optional<IPCReply> SDIOSlot0Device::IOCtl(const IOCtlRequest& request)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
   memory.Memset(request.buffer_out, 0, request.buffer_out_size);
 
@@ -190,7 +191,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
     u32 pad0;
   } req;
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   req.command = memory.Read_U32(buffer_in + 0);
@@ -345,7 +346,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
     // release returns 0
     // unknown sd int
     // technically we do it out of order, oh well
-    m_ios.EnqueueIPCReply(m_event->request, EVENT_INVALID);
+    GetEmulationKernel().EnqueueIPCReply(m_event->request, EVENT_INVALID);
     m_event.reset();
     break;
   }
@@ -360,7 +361,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
 
 IPCReply SDIOSlot0Device::WriteHCRegister(const IOCtlRequest& request)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   const u32 reg = memory.Read_U32(request.buffer_in);
@@ -395,7 +396,7 @@ IPCReply SDIOSlot0Device::WriteHCRegister(const IOCtlRequest& request)
 
 IPCReply SDIOSlot0Device::ReadHCRegister(const IOCtlRequest& request)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   const u32 reg = memory.Read_U32(request.buffer_in);
@@ -418,7 +419,7 @@ IPCReply SDIOSlot0Device::ResetCard(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_RESETCARD");
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   // Returns 16bit RCA and 16bit 0s (meaning success)
@@ -431,7 +432,7 @@ IPCReply SDIOSlot0Device::SetClk(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_SETCLK");
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   // libogc only sets it to 1 and makes sure the return isn't negative...
@@ -445,7 +446,7 @@ IPCReply SDIOSlot0Device::SetClk(const IOCtlRequest& request)
 
 std::optional<IPCReply> SDIOSlot0Device::SendCommand(const IOCtlRequest& request)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   INFO_LOG_FMT(IOS_SD, "IOCTL_SENDCMD {:x} IPC:{:08x}", memory.Read_U32(request.buffer_in),
@@ -497,7 +498,7 @@ IPCReply SDIOSlot0Device::GetStatus(const IOCtlRequest& request)
                (status & CARD_INSERTED) ? "inserted" : "not present",
                (status & CARD_INITIALIZED) ? " and initialized" : "");
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
   memory.Write_U32(status, request.buffer_out);
   return IPCReply(IPC_SUCCESS);
@@ -505,7 +506,7 @@ IPCReply SDIOSlot0Device::GetStatus(const IOCtlRequest& request)
 
 IPCReply SDIOSlot0Device::GetOCRegister(const IOCtlRequest& request)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   const u32 ocr = GetOCRegister();
@@ -517,7 +518,7 @@ IPCReply SDIOSlot0Device::GetOCRegister(const IOCtlRequest& request)
 
 IPCReply SDIOSlot0Device::SendCommand(const IOCtlVRequest& request)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   DEBUG_LOG_FMT(IOS_SD, "IOCTLV_SENDCMD {:#010x}", memory.Read_U32(request.in_vectors[0].address));

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -18,10 +18,10 @@ class PointerWrap;
 namespace IOS::HLE
 {
 // The front SD slot
-class SDIOSlot0Device : public Device
+class SDIOSlot0Device : public EmulationDevice
 {
 public:
-  SDIOSlot0Device(Kernel& ios, const std::string& device_name);
+  SDIOSlot0Device(EmulationKernel& ios, const std::string& device_name);
   ~SDIOSlot0Device() override;
 
   void DoState(PointerWrap& p) override;

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -38,18 +38,18 @@ enum
 };
 
 // The /dev/stm/immediate
-class STMImmediateDevice final : public Device
+class STMImmediateDevice final : public EmulationDevice
 {
 public:
-  using Device::Device;
+  using EmulationDevice::EmulationDevice;
   std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
 };
 
 // The /dev/stm/eventhook
-class STMEventHookDevice final : public Device
+class STMEventHookDevice final : public EmulationDevice
 {
 public:
-  using Device::Device;
+  using EmulationDevice::EmulationDevice;
   ~STMEventHookDevice() override;
   std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
   void DoState(PointerWrap& p) override;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.h
@@ -18,10 +18,10 @@ namespace IOS::HLE
 void BackUpBTInfoSection(const SysConf* sysconf);
 void RestoreBTInfoSection(SysConf* sysconf);
 
-class BluetoothBaseDevice : public Device
+class BluetoothBaseDevice : public EmulationDevice
 {
 public:
-  using Device::Device;
+  using EmulationDevice::EmulationDevice;
   virtual void UpdateSyncButtonState(bool is_held) {}
   virtual void TriggerSyncButtonPressedEvent() {}
   virtual void TriggerSyncButtonHeldEvent() {}

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -36,7 +36,7 @@ SQueuedEvent::SQueuedEvent(u32 size_, u16 handle) : size(size_), connection_hand
     PanicAlertFmt("SQueuedEvent: The size is too large.");
 }
 
-BluetoothEmuDevice::BluetoothEmuDevice(Kernel& ios, const std::string& device_name)
+BluetoothEmuDevice::BluetoothEmuDevice(EmulationKernel& ios, const std::string& device_name)
     : BluetoothBaseDevice(ios, device_name)
 {
   SysConf sysconf{ios.GetFS()};
@@ -81,13 +81,13 @@ BluetoothEmuDevice::BluetoothEmuDevice(Kernel& ios, const std::string& device_na
 BluetoothEmuDevice::~BluetoothEmuDevice() = default;
 
 template <typename T>
-static void DoStateForMessage(Kernel& ios, PointerWrap& p, std::unique_ptr<T>& message)
+static void DoStateForMessage(EmulationKernel& ios, PointerWrap& p, std::unique_ptr<T>& message)
 {
   u32 request_address = (message != nullptr) ? message->ios_request.address : 0;
   p.Do(request_address);
   if (request_address != 0)
   {
-    IOCtlVRequest request{request_address};
+    IOCtlVRequest request{ios.GetSystem(), request_address};
     message = std::make_unique<T>(ios, request);
   }
 }
@@ -105,8 +105,8 @@ void BluetoothEmuDevice::DoState(PointerWrap& p)
 
   Device::DoState(p);
   p.Do(m_controller_bd);
-  DoStateForMessage(m_ios, p, m_hci_endpoint);
-  DoStateForMessage(m_ios, p, m_acl_endpoint);
+  DoStateForMessage(GetEmulationKernel(), p, m_hci_endpoint);
+  DoStateForMessage(GetEmulationKernel(), p, m_acl_endpoint);
   p.Do(m_last_ticks);
   p.DoArray(m_packet_count);
   p.Do(m_scan_enable);
@@ -152,19 +152,19 @@ std::optional<IPCReply> BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
   case USB::IOCTLV_USBV0_CTRLMSG:  // HCI command is received from the stack
   {
     // Replies are generated inside
-    ExecuteHCICommandMessage(USB::V0CtrlMessage(m_ios, request));
+    ExecuteHCICommandMessage(USB::V0CtrlMessage(GetEmulationKernel(), request));
     send_reply = false;
     break;
   }
 
   case USB::IOCTLV_USBV0_BLKMSG:
   {
-    const USB::V0BulkMessage ctrl{m_ios, request};
+    const USB::V0BulkMessage ctrl{GetEmulationKernel(), request};
     switch (ctrl.endpoint)
     {
     case ACL_DATA_OUT:  // ACL data is received from the stack
     {
-      auto& system = Core::System::GetInstance();
+      auto& system = GetSystem();
       auto& memory = system.GetMemory();
 
       // This is the ACL datapath from CPU to Wii Remote
@@ -181,7 +181,7 @@ std::optional<IPCReply> BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
     }
     case ACL_DATA_IN:  // We are given an ACL buffer to fill
     {
-      m_acl_endpoint = std::make_unique<USB::V0BulkMessage>(m_ios, request);
+      m_acl_endpoint = std::make_unique<USB::V0BulkMessage>(GetEmulationKernel(), request);
       DEBUG_LOG_FMT(IOS_WIIMOTE, "ACL_DATA_IN: {:#010x}", request.address);
       send_reply = false;
       break;
@@ -194,10 +194,10 @@ std::optional<IPCReply> BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
 
   case USB::IOCTLV_USBV0_INTRMSG:
   {
-    const USB::V0IntrMessage ctrl{m_ios, request};
+    const USB::V0IntrMessage ctrl{GetEmulationKernel(), request};
     if (ctrl.endpoint == HCI_EVENT)  // We are given a HCI buffer to fill
     {
-      m_hci_endpoint = std::make_unique<USB::V0IntrMessage>(m_ios, request);
+      m_hci_endpoint = std::make_unique<USB::V0IntrMessage>(GetEmulationKernel(), request);
       DEBUG_LOG_FMT(IOS_WIIMOTE, "HCI_EVENT: {:#010x}", request.address);
       send_reply = false;
     }
@@ -209,7 +209,7 @@ std::optional<IPCReply> BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
   }
 
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_WIIMOTE);
+    request.DumpUnknown(GetSystem(), GetDeviceName(), Common::Log::LogType::IOS_WIIMOTE);
   }
 
   if (!send_reply)
@@ -247,7 +247,7 @@ void BluetoothEmuDevice::SendACLPacket(const bdaddr_t& source, const u8* data, u
     DEBUG_LOG_FMT(IOS_WIIMOTE, "ACL endpoint valid, sending packet to {:08x}",
                   m_acl_endpoint->ios_request.address);
 
-    auto& system = Core::System::GetInstance();
+    auto& system = GetSystem();
     auto& memory = system.GetMemory();
 
     hci_acldata_hdr_t* header =
@@ -258,7 +258,8 @@ void BluetoothEmuDevice::SendACLPacket(const bdaddr_t& source, const u8* data, u
     // Write the packet to the buffer
     memcpy(reinterpret_cast<u8*>(header) + sizeof(hci_acldata_hdr_t), data, header->length);
 
-    m_ios.EnqueueIPCReply(m_acl_endpoint->ios_request, sizeof(hci_acldata_hdr_t) + size);
+    GetEmulationKernel().EnqueueIPCReply(m_acl_endpoint->ios_request,
+                                         sizeof(hci_acldata_hdr_t) + size);
     m_acl_endpoint.reset();
   }
   else
@@ -287,7 +288,7 @@ void BluetoothEmuDevice::AddEventToQueue(const SQueuedEvent& event)
       m_hci_endpoint->FillBuffer(event.buffer, event.size);
 
       // Send a reply to indicate HCI buffer is filled
-      m_ios.EnqueueIPCReply(m_hci_endpoint->ios_request, event.size);
+      GetEmulationKernel().EnqueueIPCReply(m_hci_endpoint->ios_request, event.size);
       m_hci_endpoint.reset();
     }
     else  // push new one, pop oldest
@@ -304,7 +305,7 @@ void BluetoothEmuDevice::AddEventToQueue(const SQueuedEvent& event)
       m_hci_endpoint->FillBuffer(queued_event.buffer, queued_event.size);
 
       // Send a reply to indicate HCI buffer is filled
-      m_ios.EnqueueIPCReply(m_hci_endpoint->ios_request, queued_event.size);
+      GetEmulationKernel().EnqueueIPCReply(m_hci_endpoint->ios_request, queued_event.size);
       m_hci_endpoint.reset();
       m_event_queue.pop_front();
     }
@@ -330,7 +331,7 @@ void BluetoothEmuDevice::Update()
     m_hci_endpoint->FillBuffer(event.buffer, event.size);
 
     // Send a reply to indicate HCI buffer is filled
-    m_ios.EnqueueIPCReply(m_hci_endpoint->ios_request, event.size);
+    GetEmulationKernel().EnqueueIPCReply(m_hci_endpoint->ios_request, event.size);
     m_hci_endpoint.reset();
     m_event_queue.pop_front();
   }
@@ -346,7 +347,7 @@ void BluetoothEmuDevice::Update()
     wiimote->Update();
 
   const u64 interval = SystemTimers::GetTicksPerSecond() / Wiimote::UPDATE_FREQ;
-  const u64 now = Core::System::GetInstance().GetCoreTiming().GetTicks();
+  const u64 now = GetSystem().GetCoreTiming().GetTicks();
 
   if (now - m_last_ticks > interval)
   {
@@ -427,7 +428,7 @@ void BluetoothEmuDevice::ACLPool::WriteToEndpoint(const USB::V0BulkMessage& endp
   DEBUG_LOG_FMT(IOS_WIIMOTE, "ACL packet being written from queue to {:08x}",
                 endpoint.ios_request.address);
 
-  auto& system = Core::System::GetInstance();
+  auto& system = m_ios.GetSystem();
   auto& memory = system.GetMemory();
 
   hci_acldata_hdr_t* header = (hci_acldata_hdr_t*)memory.GetPointer(endpoint.data_address);
@@ -966,7 +967,7 @@ bool BluetoothEmuDevice::SendEventConPacketTypeChange(u16 connection_handle, u16
 // This is called from the USB::IOCTLV_USBV0_CTRLMSG Ioctlv
 void BluetoothEmuDevice::ExecuteHCICommandMessage(const USB::V0CtrlMessage& ctrl_message)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   const u8* input = memory.GetPointer(ctrl_message.data_address + 3);
@@ -1149,7 +1150,7 @@ void BluetoothEmuDevice::ExecuteHCICommandMessage(const USB::V0CtrlMessage& ctrl
   }
 
   // HCI command is finished, send a reply to command
-  m_ios.EnqueueIPCReply(ctrl_message.ios_request, ctrl_message.length);
+  GetEmulationKernel().EnqueueIPCReply(ctrl_message.ios_request, ctrl_message.length);
 }
 
 //

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -39,7 +39,7 @@ struct SQueuedEvent
 class BluetoothEmuDevice final : public BluetoothBaseDevice
 {
 public:
-  BluetoothEmuDevice(Kernel& ios, const std::string& device_name);
+  BluetoothEmuDevice(EmulationKernel& ios, const std::string& device_name);
 
   virtual ~BluetoothEmuDevice();
 
@@ -74,7 +74,7 @@ private:
   class ACLPool
   {
   public:
-    explicit ACLPool(Kernel& ios) : m_ios(ios), m_queue() {}
+    explicit ACLPool(EmulationKernel& ios) : m_ios(ios), m_queue() {}
     void Store(const u8* data, const u16 size, const u16 conn_handle);
 
     void WriteToEndpoint(const USB::V0BulkMessage& endpoint);
@@ -91,9 +91,9 @@ private:
       u16 conn_handle;
     };
 
-    Kernel& m_ios;
+    EmulationKernel& m_ios;
     std::deque<Packet> m_queue;
-  } m_acl_pool{m_ios};
+  } m_acl_pool{GetEmulationKernel()};
 
   u32 m_packet_count[MAX_BBMOTES] = {};
   u64 m_last_ticks = 0;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -60,7 +60,7 @@ static bool IsBluetoothDevice(const libusb_interface_descriptor& descriptor)
          descriptor.bInterfaceProtocol == PROTOCOL_BLUETOOTH;
 }
 
-BluetoothRealDevice::BluetoothRealDevice(Kernel& ios, const std::string& device_name)
+BluetoothRealDevice::BluetoothRealDevice(EmulationKernel& ios, const std::string& device_name)
     : BluetoothBaseDevice(ios, device_name)
 {
   LoadLinkKeys();
@@ -214,11 +214,11 @@ std::optional<IPCReply> BluetoothRealDevice::IOCtlV(const IOCtlVRequest& request
   // HCI commands to the Bluetooth adapter
   case USB::IOCTLV_USBV0_CTRLMSG:
   {
-    auto& system = Core::System::GetInstance();
+    auto& system = GetSystem();
     auto& memory = system.GetMemory();
 
     std::lock_guard lk(m_transfers_mutex);
-    auto cmd = std::make_unique<USB::V0CtrlMessage>(m_ios, request);
+    auto cmd = std::make_unique<USB::V0CtrlMessage>(GetEmulationKernel(), request);
     const u16 opcode = Common::swap16(memory.Read_U16(cmd->data_address));
     if (opcode == HCI_CMD_READ_BUFFER_SIZE)
     {
@@ -263,7 +263,7 @@ std::optional<IPCReply> BluetoothRealDevice::IOCtlV(const IOCtlVRequest& request
   case USB::IOCTLV_USBV0_INTRMSG:
   {
     std::lock_guard lk(m_transfers_mutex);
-    auto cmd = std::make_unique<USB::V0IntrMessage>(m_ios, request);
+    auto cmd = std::make_unique<USB::V0IntrMessage>(GetEmulationKernel(), request);
     if (request.request == USB::IOCTLV_USBV0_INTRMSG)
     {
       if (m_sync_button_state == SyncButtonState::Pressed)
@@ -347,8 +347,9 @@ void BluetoothRealDevice::DoState(PointerWrap& p)
     // On load, discard any pending transfer to make sure the emulated software is not stuck
     // waiting for the previous request to complete. This is usually not an issue as long as
     // the Bluetooth state is the same (same Wii Remote connections).
+    auto& system = GetSystem();
     for (const auto& address_to_discard : addresses_to_discard)
-      m_ios.EnqueueIPCReply(Request{address_to_discard}, 0);
+      GetEmulationKernel().EnqueueIPCReply(Request{system, address_to_discard}, 0);
 
     // Prevent the callbacks from replying to a request that has already been discarded.
     m_current_transfers.clear();
@@ -494,7 +495,7 @@ bool BluetoothRealDevice::SendHCIStoreLinkKeyCommand()
 
 void BluetoothRealDevice::FakeVendorCommandReply(USB::V0IntrMessage& ctrl)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   SHCIEventCommand hci_event;
@@ -504,7 +505,7 @@ void BluetoothRealDevice::FakeVendorCommandReply(USB::V0IntrMessage& ctrl)
   hci_event.PacketIndicator = 0x01;
   hci_event.Opcode = m_fake_vendor_command_reply_opcode;
   memory.CopyToEmu(ctrl.data_address, &hci_event, sizeof(hci_event));
-  m_ios.EnqueueIPCReply(ctrl.ios_request, static_cast<s32>(sizeof(hci_event)));
+  GetEmulationKernel().EnqueueIPCReply(ctrl.ios_request, static_cast<s32>(sizeof(hci_event)));
 }
 
 // Due to how the widcomm stack which Nintendo uses is coded, we must never
@@ -514,7 +515,7 @@ void BluetoothRealDevice::FakeVendorCommandReply(USB::V0IntrMessage& ctrl)
 // (including Wiimote disconnects and "event mismatch" warning messages).
 void BluetoothRealDevice::FakeReadBufferSizeReply(USB::V0IntrMessage& ctrl)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   SHCIEventCommand hci_event;
@@ -532,13 +533,14 @@ void BluetoothRealDevice::FakeReadBufferSizeReply(USB::V0IntrMessage& ctrl)
   reply.max_sco_size = SCO_PKT_SIZE;
   reply.num_sco_pkts = SCO_PKT_NUM;
   memory.CopyToEmu(ctrl.data_address + sizeof(hci_event), &reply, sizeof(reply));
-  m_ios.EnqueueIPCReply(ctrl.ios_request, static_cast<s32>(sizeof(hci_event) + sizeof(reply)));
+  GetEmulationKernel().EnqueueIPCReply(ctrl.ios_request,
+                                       static_cast<s32>(sizeof(hci_event) + sizeof(reply)));
 }
 
 void BluetoothRealDevice::FakeSyncButtonEvent(USB::V0IntrMessage& ctrl, const u8* payload,
                                               const u8 size)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   hci_event_hdr_t hci_event;
@@ -547,7 +549,8 @@ void BluetoothRealDevice::FakeSyncButtonEvent(USB::V0IntrMessage& ctrl, const u8
   hci_event.length = size;
   memory.CopyToEmu(ctrl.data_address, &hci_event, sizeof(hci_event));
   memory.CopyToEmu(ctrl.data_address + sizeof(hci_event), payload, size);
-  m_ios.EnqueueIPCReply(ctrl.ios_request, static_cast<s32>(sizeof(hci_event) + size));
+  GetEmulationKernel().EnqueueIPCReply(ctrl.ios_request,
+                                       static_cast<s32>(sizeof(hci_event) + size));
 }
 
 // When the red sync button is pressed, a HCI event is generated:
@@ -694,7 +697,8 @@ void BluetoothRealDevice::HandleCtrlTransfer(libusb_transfer* tr)
   }
   const auto& command = m_current_transfers.at(tr).command;
   command->FillBuffer(libusb_control_transfer_get_data(tr), tr->actual_length);
-  m_ios.EnqueueIPCReply(command->ios_request, tr->actual_length, 0, CoreTiming::FromThread::ANY);
+  GetEmulationKernel().EnqueueIPCReply(command->ios_request, tr->actual_length, 0,
+                                       CoreTiming::FromThread::ANY);
   m_current_transfers.erase(tr);
 }
 
@@ -743,7 +747,8 @@ void BluetoothRealDevice::HandleBulkOrIntrTransfer(libusb_transfer* tr)
 
   const auto& command = m_current_transfers.at(tr).command;
   command->FillBuffer(tr->buffer, tr->actual_length);
-  m_ios.EnqueueIPCReply(command->ios_request, tr->actual_length, 0, CoreTiming::FromThread::ANY);
+  GetEmulationKernel().EnqueueIPCReply(command->ios_request, tr->actual_length, 0,
+                                       CoreTiming::FromThread::ANY);
   m_current_transfers.erase(tr);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -42,7 +42,7 @@ using linkkey_t = std::array<u8, 16>;
 class BluetoothRealDevice final : public BluetoothBaseDevice
 {
 public:
-  BluetoothRealDevice(Kernel& ios, const std::string& device_name);
+  BluetoothRealDevice(EmulationKernel& ios, const std::string& device_name);
   ~BluetoothRealDevice() override;
 
   std::optional<IPCReply> Open(const OpenRequest& request) override;

--- a/Source/Core/Core/IOS/USB/Common.cpp
+++ b/Source/Core/Core/IOS/USB/Common.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<u8[]> TransferCommand::MakeBuffer(const size_t size) const
 {
   ASSERT_MSG(IOS_USB, data_address != 0, "Invalid data_address");
   auto buffer = std::make_unique<u8[]>(size);
-  auto& system = Core::System::GetInstance();
+  auto& system = m_ios.GetSystem();
   auto& memory = system.GetMemory();
   memory.CopyFromEmu(buffer.get(), data_address, size);
   return buffer;
@@ -28,7 +28,7 @@ std::unique_ptr<u8[]> TransferCommand::MakeBuffer(const size_t size) const
 void TransferCommand::FillBuffer(const u8* src, const size_t size) const
 {
   ASSERT_MSG(IOS_USB, size == 0 || data_address != 0, "Invalid data_address");
-  auto& system = Core::System::GetInstance();
+  auto& system = m_ios.GetSystem();
   auto& memory = system.GetMemory();
   memory.CopyToEmu(data_address, src, size);
 }
@@ -47,7 +47,7 @@ void TransferCommand::ScheduleTransferCompletion(s32 return_value, u32 expected_
 
 void IsoMessage::SetPacketReturnValue(const size_t packet_num, const u16 return_value) const
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = m_ios.GetSystem();
   auto& memory = system.GetMemory();
   memory.Write_U16(return_value, static_cast<u32>(packet_sizes_addr + packet_num * sizeof(u16)));
 }

--- a/Source/Core/Core/IOS/USB/Common.h
+++ b/Source/Core/Core/IOS/USB/Common.h
@@ -101,7 +101,7 @@ struct TransferCommand
   Request ios_request;
   u32 data_address = 0;
 
-  TransferCommand(Kernel& ios, const Request& ios_request_, u32 data_address_)
+  TransferCommand(EmulationKernel& ios, const Request& ios_request_, u32 data_address_)
       : ios_request(ios_request_), data_address(data_address_), m_ios(ios)
   {
   }
@@ -113,8 +113,8 @@ struct TransferCommand
   std::unique_ptr<u8[]> MakeBuffer(size_t size) const;
   void FillBuffer(const u8* src, size_t size) const;
 
-private:
-  Kernel& m_ios;
+protected:
+  EmulationKernel& m_ios;
 };
 
 struct CtrlMessage : TransferCommand

--- a/Source/Core/Core/IOS/USB/Emulated/Skylander.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Skylander.cpp
@@ -471,7 +471,7 @@ const std::map<const std::pair<const u16, const u16>, const char*> list_skylande
     {{3503, 0x0000}, "Kaos Trophy"},
 };
 
-SkylanderUSB::SkylanderUSB(Kernel& ios, const std::string& device_name) : m_ios(ios)
+SkylanderUSB::SkylanderUSB(EmulationKernel& ios, const std::string& device_name) : m_ios(ios)
 {
   m_vid = 0x1430;
   m_pid = 0x150;
@@ -600,7 +600,7 @@ int SkylanderUSB::SubmitTransfer(std::unique_ptr<CtrlMessage> cmd)
   else
   {
     // Skylander Portal Requests
-    auto& system = Core::System::GetInstance();
+    auto& system = m_ios.GetSystem();
     auto& memory = system.GetMemory();
     u8* buf = memory.GetPointerForRange(cmd->data_address, cmd->length);
     if (cmd->length == 0 || buf == nullptr)
@@ -892,7 +892,7 @@ int SkylanderUSB::SubmitTransfer(std::unique_ptr<IntrMessage> cmd)
   DEBUG_LOG_FMT(IOS_USB, "[{:04x}:{:04x} {}] Interrupt: length={} endpoint={}", m_vid, m_pid,
                 m_active_interface, cmd->length, cmd->endpoint);
 
-  auto& system = Core::System::GetInstance();
+  auto& system = m_ios.GetSystem();
   auto& memory = system.GetMemory();
   u8* buf = memory.GetPointerForRange(cmd->data_address, cmd->length);
   if (cmd->length == 0 || buf == nullptr)

--- a/Source/Core/Core/IOS/USB/Emulated/Skylander.h
+++ b/Source/Core/Core/IOS/USB/Emulated/Skylander.h
@@ -23,7 +23,7 @@ extern const std::map<const std::pair<const u16, const u16>, const char*> list_s
 class SkylanderUSB final : public Device
 {
 public:
-  SkylanderUSB(Kernel& ios, const std::string& device_name);
+  SkylanderUSB(EmulationKernel& ios, const std::string& device_name);
   ~SkylanderUSB();
   DeviceDescriptor GetDeviceDescriptor() const override;
   std::vector<ConfigDescriptor> GetConfigurations() const override;
@@ -43,7 +43,7 @@ public:
                         s32 expected_count, u64 expected_time_us);
 
 private:
-  Kernel& m_ios;
+  EmulationKernel& m_ios;
   u16 m_vid = 0;
   u16 m_pid = 0;
   u8 m_active_interface = 0;

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -29,7 +29,8 @@
 
 namespace IOS::HLE
 {
-USBHost::USBHost(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+USBHost::USBHost(EmulationKernel& ios, const std::string& device_name)
+    : EmulationDevice(ios, device_name)
 {
 }
 
@@ -137,7 +138,8 @@ bool USBHost::AddNewDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks
         if (whitelist.count({descriptor.idVendor, descriptor.idProduct}) == 0)
           return true;
 
-        auto usb_device = std::make_unique<USB::LibusbDevice>(m_ios, device, descriptor);
+        auto usb_device =
+            std::make_unique<USB::LibusbDevice>(GetEmulationKernel(), device, descriptor);
         if (!ShouldAddDevice(*usb_device))
           return true;
 
@@ -190,7 +192,8 @@ void USBHost::AddEmulatedDevices(std::set<u64>& new_devices, DeviceChangeHooks& 
 {
   if (Config::Get(Config::MAIN_EMULATE_SKYLANDER_PORTAL) && !NetPlay::IsNetPlayRunning())
   {
-    auto skylanderportal = std::make_unique<USB::SkylanderUSB>(m_ios, "Skylander Portal");
+    auto skylanderportal =
+        std::make_unique<USB::SkylanderUSB>(GetEmulationKernel(), "Skylander Portal");
     if (ShouldAddDevice(*skylanderportal))
     {
       const u64 skyid = skylanderportal->GetId();

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -26,10 +26,10 @@ class PointerWrap;
 namespace IOS::HLE
 {
 // Common base class for USB host devices (such as /dev/usb/oh0 and /dev/usb/ven).
-class USBHost : public Device
+class USBHost : public EmulationDevice
 {
 public:
-  USBHost(Kernel& ios, const std::string& device_name);
+  USBHost(EmulationKernel& ios, const std::string& device_name);
   virtual ~USBHost();
 
   std::optional<IPCReply> Open(const OpenRequest& request) override;

--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -25,7 +25,7 @@
 
 namespace IOS::HLE::USB
 {
-LibusbDevice::LibusbDevice(Kernel& ios, libusb_device* device,
+LibusbDevice::LibusbDevice(EmulationKernel& ios, libusb_device* device,
                            const libusb_device_descriptor& descriptor)
     : m_ios(ios), m_device(device)
 {
@@ -249,7 +249,7 @@ int LibusbDevice::SubmitTransfer(std::unique_ptr<CtrlMessage> cmd)
   libusb_fill_control_setup(buffer.get(), cmd->request_type, cmd->request, cmd->value, cmd->index,
                             cmd->length);
 
-  auto& system = Core::System::GetInstance();
+  auto& system = m_ios.GetSystem();
   auto& memory = system.GetMemory();
   memory.CopyFromEmu(buffer.get() + LIBUSB_CONTROL_SETUP_SIZE, cmd->data_address, cmd->length);
 

--- a/Source/Core/Core/IOS/USB/LibusbDevice.h
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.h
@@ -26,7 +26,7 @@ namespace IOS::HLE::USB
 class LibusbDevice final : public Device
 {
 public:
-  LibusbDevice(Kernel& ios, libusb_device* device,
+  LibusbDevice(EmulationKernel& ios, libusb_device* device,
                const libusb_device_descriptor& device_descriptor);
   ~LibusbDevice();
   DeviceDescriptor GetDeviceDescriptor() const override;
@@ -46,7 +46,7 @@ public:
   int SubmitTransfer(std::unique_ptr<IsoMessage> message) override;
 
 private:
-  Kernel& m_ios;
+  EmulationKernel& m_ios;
 
   std::vector<LibusbUtils::ConfigDescriptor> m_config_descriptors;
   u16 m_vid = 0;

--- a/Source/Core/Core/IOS/USB/OH0/OH0.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.h
@@ -33,7 +33,7 @@ struct DeviceInfo
 class OH0 final : public USBHost
 {
 public:
-  OH0(Kernel& ios, const std::string& device_name);
+  OH0(EmulationKernel& ios, const std::string& device_name);
   ~OH0() override;
 
   std::optional<IPCReply> Open(const OpenRequest& request) override;

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -35,7 +35,8 @@ static void GetVidPidFromDevicePath(const std::string& device_path, u16& vid, u1
   ss >> pid;
 }
 
-OH0Device::OH0Device(Kernel& ios, const std::string& name) : Device(ios, name, DeviceType::OH0)
+OH0Device::OH0Device(EmulationKernel& ios, const std::string& name)
+    : EmulationDevice(ios, name, DeviceType::OH0)
 {
   if (!name.empty())
     GetVidPidFromDevicePath(name, m_vid, m_pid);
@@ -43,7 +44,7 @@ OH0Device::OH0Device(Kernel& ios, const std::string& name) : Device(ios, name, D
 
 void OH0Device::DoState(PointerWrap& p)
 {
-  m_oh0 = std::static_pointer_cast<OH0>(GetIOS()->GetDeviceByName("/dev/usb/oh0"));
+  m_oh0 = std::static_pointer_cast<OH0>(GetEmulationKernel().GetDeviceByName("/dev/usb/oh0"));
   Device::DoState(p);
   p.Do(m_vid);
   p.Do(m_pid);
@@ -55,7 +56,7 @@ std::optional<IPCReply> OH0Device::Open(const OpenRequest& request)
   if (m_vid == 0 && m_pid == 0)
     return IPCReply(IPC_ENOENT);
 
-  m_oh0 = std::static_pointer_cast<OH0>(GetIOS()->GetDeviceByName("/dev/usb/oh0"));
+  m_oh0 = std::static_pointer_cast<OH0>(GetEmulationKernel().GetDeviceByName("/dev/usb/oh0"));
 
   ReturnCode return_code;
   std::tie(return_code, m_device_id) = m_oh0->DeviceOpen(m_vid, m_pid);

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.h
@@ -14,10 +14,10 @@ class PointerWrap;
 namespace IOS::HLE
 {
 class OH0;
-class OH0Device final : public Device
+class OH0Device final : public EmulationDevice
 {
 public:
-  OH0Device(Kernel& ios, const std::string& device_name);
+  OH0Device(EmulationKernel& ios, const std::string& device_name);
 
   std::optional<IPCReply> Open(const OpenRequest& request) override;
   std::optional<IPCReply> Close(u32 fd) override;

--- a/Source/Core/Core/IOS/USB/USBV0.cpp
+++ b/Source/Core/Core/IOS/USB/USBV0.cpp
@@ -13,10 +13,10 @@
 
 namespace IOS::HLE::USB
 {
-V0CtrlMessage::V0CtrlMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
+V0CtrlMessage::V0CtrlMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv)
     : CtrlMessage(ios, ioctlv, ioctlv.io_vectors[0].address)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = ios.GetSystem();
   auto& memory = system.GetMemory();
   request_type = memory.Read_U8(ioctlv.in_vectors[0].address);
   request = memory.Read_U8(ioctlv.in_vectors[1].address);
@@ -25,10 +25,10 @@ V0CtrlMessage::V0CtrlMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
   length = Common::swap16(memory.Read_U16(ioctlv.in_vectors[4].address));
 }
 
-V0BulkMessage::V0BulkMessage(Kernel& ios, const IOCtlVRequest& ioctlv, bool long_length)
+V0BulkMessage::V0BulkMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv, bool long_length)
     : BulkMessage(ios, ioctlv, ioctlv.io_vectors[0].address)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = ios.GetSystem();
   auto& memory = system.GetMemory();
   endpoint = memory.Read_U8(ioctlv.in_vectors[0].address);
   if (long_length)
@@ -37,19 +37,19 @@ V0BulkMessage::V0BulkMessage(Kernel& ios, const IOCtlVRequest& ioctlv, bool long
     length = memory.Read_U16(ioctlv.in_vectors[1].address);
 }
 
-V0IntrMessage::V0IntrMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
+V0IntrMessage::V0IntrMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv)
     : IntrMessage(ios, ioctlv, ioctlv.io_vectors[0].address)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = ios.GetSystem();
   auto& memory = system.GetMemory();
   endpoint = memory.Read_U8(ioctlv.in_vectors[0].address);
   length = memory.Read_U16(ioctlv.in_vectors[1].address);
 }
 
-V0IsoMessage::V0IsoMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
+V0IsoMessage::V0IsoMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv)
     : IsoMessage(ios, ioctlv, ioctlv.io_vectors[1].address)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = ios.GetSystem();
   auto& memory = system.GetMemory();
   endpoint = memory.Read_U8(ioctlv.in_vectors[0].address);
   length = memory.Read_U16(ioctlv.in_vectors[1].address);

--- a/Source/Core/Core/IOS/USB/USBV0.h
+++ b/Source/Core/Core/IOS/USB/USBV0.h
@@ -38,22 +38,22 @@ enum V0Requests
 
 struct V0CtrlMessage final : CtrlMessage
 {
-  V0CtrlMessage(Kernel& ios, const IOCtlVRequest& ioctlv);
+  V0CtrlMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv);
 };
 
 struct V0BulkMessage final : BulkMessage
 {
-  V0BulkMessage(Kernel& ios, const IOCtlVRequest& ioctlv, bool long_length = false);
+  V0BulkMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv, bool long_length = false);
 };
 
 struct V0IntrMessage final : IntrMessage
 {
-  V0IntrMessage(Kernel& ios, const IOCtlVRequest& ioctlv);
+  V0IntrMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv);
 };
 
 struct V0IsoMessage final : IsoMessage
 {
-  V0IsoMessage(Kernel& ios, const IOCtlVRequest& ioctlv);
+  V0IsoMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv);
 };
 }  // namespace USB
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBV4.cpp
+++ b/Source/Core/Core/IOS/USB/USBV4.cpp
@@ -46,9 +46,10 @@ struct HIDRequest
 };
 #pragma pack(pop)
 
-V4CtrlMessage::V4CtrlMessage(Kernel& ios, const IOCtlRequest& ioctl) : CtrlMessage(ios, ioctl, 0)
+V4CtrlMessage::V4CtrlMessage(EmulationKernel& ios, const IOCtlRequest& ioctl)
+    : CtrlMessage(ios, ioctl, 0)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = ios.GetSystem();
   auto& memory = system.GetMemory();
 
   HIDRequest hid_request;
@@ -64,10 +65,10 @@ V4CtrlMessage::V4CtrlMessage(Kernel& ios, const IOCtlRequest& ioctl) : CtrlMessa
 // Since this is just a standard control request, but with additional requirements
 // (US for the language and replacing non-ASCII characters with '?'),
 // we can simply submit it as a usual control request.
-V4GetUSStringMessage::V4GetUSStringMessage(Kernel& ios, const IOCtlRequest& ioctl)
+V4GetUSStringMessage::V4GetUSStringMessage(EmulationKernel& ios, const IOCtlRequest& ioctl)
     : CtrlMessage(ios, ioctl, 0)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = ios.GetSystem();
   auto& memory = system.GetMemory();
 
   HIDRequest hid_request;
@@ -82,7 +83,7 @@ V4GetUSStringMessage::V4GetUSStringMessage(Kernel& ios, const IOCtlRequest& ioct
 
 void V4GetUSStringMessage::OnTransferComplete(s32 return_value) const
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = m_ios.GetSystem();
   auto& memory = system.GetMemory();
 
   std::string message = memory.GetString(data_address);
@@ -91,9 +92,10 @@ void V4GetUSStringMessage::OnTransferComplete(s32 return_value) const
   TransferCommand::OnTransferComplete(return_value);
 }
 
-V4IntrMessage::V4IntrMessage(Kernel& ios, const IOCtlRequest& ioctl) : IntrMessage(ios, ioctl, 0)
+V4IntrMessage::V4IntrMessage(EmulationKernel& ios, const IOCtlRequest& ioctl)
+    : IntrMessage(ios, ioctl, 0)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = ios.GetSystem();
   auto& memory = system.GetMemory();
 
   HIDRequest hid_request;

--- a/Source/Core/Core/IOS/USB/USBV4.h
+++ b/Source/Core/Core/IOS/USB/USBV4.h
@@ -29,18 +29,18 @@ enum V4Requests
 
 struct V4CtrlMessage final : CtrlMessage
 {
-  V4CtrlMessage(Kernel& ios, const IOCtlRequest& ioctl);
+  V4CtrlMessage(EmulationKernel& ios, const IOCtlRequest& ioctl);
 };
 
 struct V4GetUSStringMessage final : CtrlMessage
 {
-  V4GetUSStringMessage(Kernel& ios, const IOCtlRequest& ioctl);
+  V4GetUSStringMessage(EmulationKernel& ios, const IOCtlRequest& ioctl);
   void OnTransferComplete(s32 return_value) const override;
 };
 
 struct V4IntrMessage final : IntrMessage
 {
-  V4IntrMessage(Kernel& ios, const IOCtlRequest& ioctl);
+  V4IntrMessage(EmulationKernel& ios, const IOCtlRequest& ioctl);
 };
 }  // namespace USB
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBV5.h
+++ b/Source/Core/Core/IOS/USB/USBV5.h
@@ -43,22 +43,22 @@ enum V5Requests
 
 struct V5CtrlMessage final : CtrlMessage
 {
-  V5CtrlMessage(Kernel& ios, const IOCtlVRequest& ioctlv);
+  V5CtrlMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv);
 };
 
 struct V5BulkMessage final : BulkMessage
 {
-  V5BulkMessage(Kernel& ios, const IOCtlVRequest& ioctlv);
+  V5BulkMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv);
 };
 
 struct V5IntrMessage final : IntrMessage
 {
-  V5IntrMessage(Kernel& ios, const IOCtlVRequest& ioctlv);
+  V5IntrMessage(EmulationKernel& ios, const IOCtlVRequest& ioctlv);
 };
 
 struct V5IsoMessage final : IsoMessage
 {
-  V5IsoMessage(Kernel& ios, const IOCtlVRequest& cmd_buffer);
+  V5IsoMessage(EmulationKernel& ios, const IOCtlVRequest& cmd_buffer);
 };
 }  // namespace USB
 

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -22,7 +22,8 @@
 
 namespace IOS::HLE
 {
-USB_HIDv4::USB_HIDv4(Kernel& ios, const std::string& device_name) : USBHost(ios, device_name)
+USB_HIDv4::USB_HIDv4(EmulationKernel& ios, const std::string& device_name)
+    : USBHost(ios, device_name)
 {
 }
 
@@ -33,7 +34,7 @@ USB_HIDv4::~USB_HIDv4()
 
 std::optional<IPCReply> USB_HIDv4::IOCtl(const IOCtlRequest& request)
 {
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   request.Log(GetDeviceName(), Common::Log::LogType::IOS_USB);
@@ -64,7 +65,7 @@ std::optional<IPCReply> USB_HIDv4::IOCtl(const IOCtlRequest& request)
                           [&, this]() { return SubmitTransfer(*device, request); });
   }
   default:
-    request.DumpUnknown(GetDeviceName(), Common::Log::LogType::IOS_USB);
+    request.DumpUnknown(GetSystem(), GetDeviceName(), Common::Log::LogType::IOS_USB);
     return IPCReply(IPC_SUCCESS);
   }
 }
@@ -74,7 +75,7 @@ IPCReply USB_HIDv4::CancelInterrupt(const IOCtlRequest& request)
   if (request.buffer_in == 0 || request.buffer_in_size != 8)
     return IPCReply(IPC_EINVAL);
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   auto device = GetDeviceByIOSID(memory.Read_U32(request.buffer_in));
@@ -90,7 +91,7 @@ std::optional<IPCReply> USB_HIDv4::GetDeviceChange(const IOCtlRequest& request)
   if (request.buffer_out == 0 || request.buffer_out_size != 0x600)
     return IPCReply(IPC_EINVAL);
 
-  m_devicechange_hook_request = std::make_unique<IOCtlRequest>(request.address);
+  m_devicechange_hook_request = std::make_unique<IOCtlRequest>(GetSystem(), request.address);
   // On the first call, the reply is sent immediately (instead of on device insertion/removal)
   if (m_devicechange_first_call)
   {
@@ -105,10 +106,10 @@ IPCReply USB_HIDv4::Shutdown(const IOCtlRequest& request)
   std::lock_guard lk{m_devicechange_hook_address_mutex};
   if (m_devicechange_hook_request != nullptr)
   {
-    auto& system = Core::System::GetInstance();
+    auto& system = GetSystem();
     auto& memory = system.GetMemory();
     memory.Write_U32(0xffffffff, m_devicechange_hook_request->buffer_out);
-    m_ios.EnqueueIPCReply(*m_devicechange_hook_request, -1);
+    GetEmulationKernel().EnqueueIPCReply(*m_devicechange_hook_request, -1);
     m_devicechange_hook_request.reset();
   }
   return IPCReply(IPC_SUCCESS);
@@ -119,12 +120,15 @@ s32 USB_HIDv4::SubmitTransfer(USB::Device& device, const IOCtlRequest& request)
   switch (request.request)
   {
   case USB::IOCTL_USBV4_CTRLMSG:
-    return device.SubmitTransfer(std::make_unique<USB::V4CtrlMessage>(m_ios, request));
+    return device.SubmitTransfer(
+        std::make_unique<USB::V4CtrlMessage>(GetEmulationKernel(), request));
   case USB::IOCTL_USBV4_GET_US_STRING:
-    return device.SubmitTransfer(std::make_unique<USB::V4GetUSStringMessage>(m_ios, request));
+    return device.SubmitTransfer(
+        std::make_unique<USB::V4GetUSStringMessage>(GetEmulationKernel(), request));
   case USB::IOCTL_USBV4_INTRMSG_IN:
   case USB::IOCTL_USBV4_INTRMSG_OUT:
-    return device.SubmitTransfer(std::make_unique<USB::V4IntrMessage>(m_ios, request));
+    return device.SubmitTransfer(
+        std::make_unique<USB::V4IntrMessage>(GetEmulationKernel(), request));
   default:
     return IPC_EINVAL;
   }
@@ -136,9 +140,13 @@ void USB_HIDv4::DoState(PointerWrap& p)
   u32 hook_address = m_devicechange_hook_request ? m_devicechange_hook_request->address : 0;
   p.Do(hook_address);
   if (hook_address != 0)
-    m_devicechange_hook_request = std::make_unique<IOCtlRequest>(hook_address);
+  {
+    m_devicechange_hook_request = std::make_unique<IOCtlRequest>(GetSystem(), hook_address);
+  }
   else
+  {
     m_devicechange_hook_request.reset();
+  }
 
   p.Do(m_ios_ids);
   p.Do(m_device_ids);
@@ -191,7 +199,7 @@ void USB_HIDv4::TriggerDeviceChangeReply()
   if (!m_devicechange_hook_request)
     return;
 
-  auto& system = Core::System::GetInstance();
+  auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
   {
@@ -213,7 +221,8 @@ void USB_HIDv4::TriggerDeviceChangeReply()
     memory.Write_U32(0xffffffff, dest + offset);
   }
 
-  m_ios.EnqueueIPCReply(*m_devicechange_hook_request, IPC_SUCCESS, 0, CoreTiming::FromThread::ANY);
+  GetEmulationKernel().EnqueueIPCReply(*m_devicechange_hook_request, IPC_SUCCESS, 0,
+                                       CoreTiming::FromThread::ANY);
   m_devicechange_hook_request.reset();
 }
 

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
@@ -20,7 +20,7 @@ namespace IOS::HLE
 class USB_HIDv4 final : public USBHost
 {
 public:
-  USB_HIDv4(Kernel& ios, const std::string& device_name);
+  USB_HIDv4(EmulationKernel& ios, const std::string& device_name);
   ~USB_HIDv4() override;
 
   std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -184,7 +184,8 @@ USB_KBD::MessageData::MessageData(MessageType type, u8 modifiers_, PressedKeyDat
 
 // TODO: support in netplay/movies.
 
-USB_KBD::USB_KBD(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+USB_KBD::USB_KBD(EmulationKernel& ios, const std::string& device_name)
+    : EmulationDevice(ios, device_name)
 {
 }
 
@@ -214,7 +215,7 @@ std::optional<IPCReply> USB_KBD::IOCtl(const IOCtlRequest& request)
   if (Config::Get(Config::MAIN_WII_KEYBOARD) && !Core::WantsDeterminism() &&
       ControlReference::GetInputGate() && !m_message_queue.empty())
   {
-    auto& system = Core::System::GetInstance();
+    auto& system = GetSystem();
     auto& memory = system.GetMemory();
     memory.CopyToEmu(request.buffer_out, &m_message_queue.front(), sizeof(MessageData));
     m_message_queue.pop();

--- a/Source/Core/Core/IOS/USB/USB_KBD.h
+++ b/Source/Core/Core/IOS/USB/USB_KBD.h
@@ -14,10 +14,10 @@
 
 namespace IOS::HLE
 {
-class USB_KBD : public Device
+class USB_KBD : public EmulationDevice
 {
 public:
-  USB_KBD(Kernel& ios, const std::string& device_name);
+  USB_KBD(EmulationKernel& ios, const std::string& device_name);
 
   std::optional<IPCReply> Open(const OpenRequest& request) override;
   std::optional<IPCReply> Write(const ReadWriteRequest& request) override;

--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -31,10 +31,10 @@ private:
   std::vector<u8> m_whole_file;
 };
 
-class WFSIDevice : public Device
+class WFSIDevice : public EmulationDevice
 {
 public:
-  WFSIDevice(Kernel& ios, const std::string& device_name);
+  WFSIDevice(EmulationKernel& ios, const std::string& device_name);
 
   std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
 

--- a/Source/Core/Core/IOS/WFS/WFSSRV.h
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.h
@@ -28,10 +28,10 @@ enum
   WFS_FILE_IS_OPENED = -10032,  // Cannot perform operation on an opened file.
 };
 
-class WFSSRVDevice : public Device
+class WFSSRVDevice : public EmulationDevice
 {
 public:
-  WFSSRVDevice(Kernel& ios, const std::string& device_name);
+  WFSSRVDevice(EmulationKernel& ios, const std::string& device_name);
 
   std::optional<IPCReply> IOCtl(const IOCtlRequest& request) override;
 


### PR DESCRIPTION
@leoetlino I assume you had something along these lines in mind over in #11743?

I've added a `EmulationDevice` interface that slots between the `Device` interface and the actual device classes that doesn't do anything but enforces that the IOS instance is an `EmulationKernel` instead of a plain `Kernel`. This allows all subclasses to know that they will only be constructed on an `EmulationKernel`, which allows them to safely access the `m_ios` reference as an `EmulationKernel&`. I think this looks quite nice and should have no runtime overhead.