### PR TITLE
DolphinQt: use default dpi rounding mode (passthrough)

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -151,15 +151,6 @@ int main(int argc, char* argv[])
   const optparse::Values& options = CommandLineParse::ParseArguments(parser.get(), argc, argv);
   const std::vector<std::string> args = parser->args();
 
-  // setHighDpiScaleFactorRoundingPolicy was added in 5.14, but default behavior changed in 6.0
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-  // Set to the previous default behavior
-  QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
-#else
-  QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-  QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
-
   QCoreApplication::setOrganizationName(QStringLiteral("Dolphin Emulator"));
   QCoreApplication::setOrganizationDomain(QStringLiteral("dolphin-emu.org"));
   QCoreApplication::setApplicationName(QStringLiteral("dolphin-emu"));


### PR DESCRIPTION
Before this change, dolphin was using rounded mode, which rounds up to integer scale factor at .5 or down otherwise. This means that if dolphin was started on a screen with 150% scaling, dolphin would actually be at 200%, which causes it to be larger than expected/ other apps. However, dolphin would still react to dpi scaling changes - so changing to 150% after opening the app would cause it to change size in an odd way and look somewhat bad until it is restarted.

using pass through causes dolphin to always be at the screen’s actual dpi scaling.