### PR TITLE
Qt/NetworkWidget: Don't update if not paused.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -239,6 +239,16 @@ void NetworkWidget::Update()
   if (!isVisible())
     return;
 
+  if (Core::GetState() != Core::State::Paused)
+  {
+    m_socket_table->setDisabled(true);
+    m_ssl_table->setDisabled(true);
+    return;
+  }
+
+  m_socket_table->setDisabled(false);
+  m_ssl_table->setDisabled(false);
+
   // needed because there's a race condition on the IOS instance otherwise
   Core::CPUThreadGuard guard(Core::System::GetInstance());
 


### PR DESCRIPTION
This is similar to https://github.com/dolphin-emu/dolphin/pull/11623 where the Core state change invoked by the CPUThreadGuard does indirectly cause another Update() call.

I really think we need a better system here -- maybe the state change from the CPUThreadGuard/RunAsCPUThread shouldn't actually send any state change events? But this works around the problem in the meantime...