### PR TITLE
Common/Traversal: Move interface into Common namespace

### DIFF
--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -12,6 +12,8 @@
 #include "Common/Random.h"
 #include "Core/NetPlayProto.h"
 
+namespace Common
+{
 TraversalClient::TraversalClient(ENetHost* netHost, const std::string& server, const u16 port)
     : m_NetHost(netHost), m_Server(server), m_port(port)
 {
@@ -304,7 +306,7 @@ int ENET_CALLBACK TraversalClient::InterceptCallback(ENetHost* host, ENetEvent* 
 }
 
 std::unique_ptr<TraversalClient> g_TraversalClient;
-Common::ENet::ENetHostPtr g_MainNetHost;
+ENet::ENetHostPtr g_MainNetHost;
 
 // The settings at the previous TraversalClient reset - notably, we
 // need to know not just what port it's on, but whether it was
@@ -348,3 +350,4 @@ void ReleaseTraversalClient()
   g_TraversalClient.reset();
   g_MainNetHost.reset();
 }
+}  // namespace Common

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -15,6 +15,8 @@
 #include "Common/Thread.h"
 #include "Common/TraversalProto.h"
 
+namespace Common
+{
 class TraversalClientClient
 {
 public:
@@ -90,9 +92,12 @@ private:
   u16 m_port;
   u32 m_PingTime = 0;
 };
+
 extern std::unique_ptr<TraversalClient> g_TraversalClient;
 // the NetHost connected to the TraversalClient.
-extern Common::ENet::ENetHostPtr g_MainNetHost;
+extern ENet::ENetHostPtr g_MainNetHost;
+
 // Create g_TraversalClient and g_MainNetHost if necessary.
 bool EnsureTraversalClient(const std::string& server, u16 server_port, u16 listen_port = 0);
 void ReleaseTraversalClient();
+}  // namespace Common

--- a/Source/Core/Common/TraversalProto.h
+++ b/Source/Core/Common/TraversalProto.h
@@ -6,6 +6,8 @@
 #include <cstddef>
 #include "Common/CommonTypes.h"
 
+namespace Common
+{
 constexpr size_t NETPLAY_CODE_SIZE = 8;
 using TraversalHostId = std::array<char, NETPLAY_CODE_SIZE>;
 using TraversalRequestId = u64;
@@ -92,3 +94,4 @@ struct TraversalPacket
   };
 };
 #pragma pack(pop)
+}  // namespace Common

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -110,9 +110,9 @@ NetPlayClient::~NetPlayClient()
     Disconnect();
   }
 
-  if (g_MainNetHost.get() == m_client)
+  if (Common::g_MainNetHost.get() == m_client)
   {
-    g_MainNetHost.release();
+    Common::g_MainNetHost.release();
   }
   if (m_client)
   {
@@ -122,7 +122,7 @@ NetPlayClient::~NetPlayClient()
 
   if (m_traversal_client)
   {
-    ReleaseTraversalClient();
+    Common::ReleaseTraversalClient();
   }
 }
 
@@ -186,11 +186,14 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
       return;
     }
 
-    if (!EnsureTraversalClient(traversal_config.traversal_host, traversal_config.traversal_port))
+    if (!Common::EnsureTraversalClient(traversal_config.traversal_host,
+                                       traversal_config.traversal_port))
+    {
       return;
-    m_client = g_MainNetHost.get();
+    }
+    m_client = Common::g_MainNetHost.get();
 
-    m_traversal_client = g_TraversalClient.get();
+    m_traversal_client = Common::g_TraversalClient.get();
 
     // If we were disconnected in the background, reconnect.
     if (m_traversal_client->HasFailed())
@@ -1936,16 +1939,16 @@ void NetPlayClient::ClearBuffers()
 // called from ---NETPLAY--- thread
 void NetPlayClient::OnTraversalStateChanged()
 {
-  const TraversalClient::State state = m_traversal_client->GetState();
+  const Common::TraversalClient::State state = m_traversal_client->GetState();
 
   if (m_connection_state == ConnectionState::WaitingForTraversalClientConnection &&
-      state == TraversalClient::State::Connected)
+      state == Common::TraversalClient::State::Connected)
   {
     m_connection_state = ConnectionState::WaitingForTraversalClientConnectReady;
     m_traversal_client->ConnectToClient(m_host_spec);
   }
   else if (m_connection_state != ConnectionState::Failure &&
-           state == TraversalClient::State::Failure)
+           state == Common::TraversalClient::State::Failure)
   {
     Disconnect();
     m_dialog->OnTraversalError(m_traversal_client->GetFailureReason());

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -179,7 +179,7 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
   }
   else
   {
-    if (address.size() > NETPLAY_CODE_SIZE)
+    if (address.size() > Common::NETPLAY_CODE_SIZE)
     {
       m_dialog->OnConnectionError(
           _trans("The host code is too long.\nPlease recheck that you have the correct code."));
@@ -1967,19 +1967,19 @@ void NetPlayClient::OnConnectReady(ENetAddress addr)
 }
 
 // called from ---NETPLAY--- thread
-void NetPlayClient::OnConnectFailed(TraversalConnectFailedReason reason)
+void NetPlayClient::OnConnectFailed(Common::TraversalConnectFailedReason reason)
 {
   m_connecting = false;
   m_connection_state = ConnectionState::Failure;
   switch (reason)
   {
-  case TraversalConnectFailedReason::ClientDidntRespond:
+  case Common::TraversalConnectFailedReason::ClientDidntRespond:
     PanicAlertFmtT("Traversal server timed out connecting to the host");
     break;
-  case TraversalConnectFailedReason::ClientFailure:
+  case Common::TraversalConnectFailedReason::ClientFailure:
     PanicAlertFmtT("Server rejected traversal attempt");
     break;
-  case TraversalConnectFailedReason::NoSuchClient:
+  case Common::TraversalConnectFailedReason::NoSuchClient:
     PanicAlertFmtT("Invalid host");
     break;
   default:

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -68,8 +68,8 @@ public:
   virtual void OnDesync(u32 frame, const std::string& player) = 0;
   virtual void OnConnectionLost() = 0;
   virtual void OnConnectionError(const std::string& message) = 0;
-  virtual void OnTraversalError(TraversalClient::FailureReason error) = 0;
-  virtual void OnTraversalStateChanged(TraversalClient::State state) = 0;
+  virtual void OnTraversalError(Common::TraversalClient::FailureReason error) = 0;
+  virtual void OnTraversalStateChanged(Common::TraversalClient::State state) = 0;
   virtual void OnGameStartAborted() = 0;
   virtual void OnGolferChanged(bool is_golfer, const std::string& golfer_name) = 0;
 
@@ -107,7 +107,7 @@ public:
   bool IsHost() const { return pid == 1; }
 };
 
-class NetPlayClient : public TraversalClientClient
+class NetPlayClient : public Common::TraversalClientClient
 {
 public:
   void ThreadFunc();
@@ -325,7 +325,7 @@ private:
   std::string m_host_spec;
   std::string m_player_name;
   bool m_connecting = false;
-  TraversalClient* m_traversal_client = nullptr;
+  Common::TraversalClient* m_traversal_client = nullptr;
   std::thread m_game_digest_thread;
   bool m_should_compute_game_digest = false;
   Common::Event m_gc_pad_event;

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -147,7 +147,7 @@ public:
 
   void OnTraversalStateChanged() override;
   void OnConnectReady(ENetAddress addr) override;
-  void OnConnectFailed(TraversalConnectFailedReason reason) override;
+  void OnConnectFailed(Common::TraversalConnectFailedReason reason) override;
 
   bool IsFirstInGamePad(int ingame_pad) const;
   int NumLocalPads() const;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -98,15 +98,15 @@ NetPlayServer::~NetPlayServer()
     m_thread.join();
     enet_host_destroy(m_server);
 
-    if (g_MainNetHost.get() == m_server)
+    if (Common::g_MainNetHost.get() == m_server)
     {
-      g_MainNetHost.release();
+      Common::g_MainNetHost.release();
     }
 
     if (m_traversal_client)
     {
-      g_TraversalClient->m_Client = nullptr;
-      ReleaseTraversalClient();
+      Common::g_TraversalClient->m_Client = nullptr;
+      Common::ReleaseTraversalClient();
     }
   }
 
@@ -132,17 +132,19 @@ NetPlayServer::NetPlayServer(const u16 port, const bool forward_port, NetPlayUI*
 
   if (traversal_config.use_traversal)
   {
-    if (!EnsureTraversalClient(traversal_config.traversal_host, traversal_config.traversal_port,
-                               port))
+    if (!Common::EnsureTraversalClient(traversal_config.traversal_host,
+                                       traversal_config.traversal_port, port))
+    {
       return;
+    }
 
-    g_TraversalClient->m_Client = this;
-    m_traversal_client = g_TraversalClient.get();
+    Common::g_TraversalClient->m_Client = this;
+    m_traversal_client = Common::g_TraversalClient.get();
 
-    m_server = g_MainNetHost.get();
+    m_server = Common::g_MainNetHost.get();
 
-    if (g_TraversalClient->HasFailed())
-      g_TraversalClient->ReconnectToServer();
+    if (Common::g_TraversalClient->HasFailed())
+      Common::g_TraversalClient->ReconnectToServer();
   }
   else
   {
@@ -211,7 +213,7 @@ void NetPlayServer::SetupIndex()
     if (!m_traversal_client->IsConnected())
       return;
 
-    session.server_id = std::string(g_TraversalClient->GetHostID().data(), 8);
+    session.server_id = std::string(Common::g_TraversalClient->GetHostID().data(), 8);
   }
   else
   {
@@ -1248,15 +1250,15 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
 
 void NetPlayServer::OnTraversalStateChanged()
 {
-  const TraversalClient::State state = m_traversal_client->GetState();
+  const Common::TraversalClient::State state = m_traversal_client->GetState();
 
-  if (g_TraversalClient->GetHostID()[0] != '\0')
+  if (Common::g_TraversalClient->GetHostID()[0] != '\0')
     SetupIndex();
 
   if (!m_dialog)
     return;
 
-  if (state == TraversalClient::State::Failure)
+  if (state == Common::TraversalClient::State::Failure)
     m_dialog->OnTraversalError(m_traversal_client->GetFailureReason());
 
   m_dialog->OnTraversalStateChanged(state);

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -31,7 +31,7 @@ namespace NetPlay
 class NetPlayUI;
 struct SaveSyncInfo;
 
-class NetPlayServer : public TraversalClientClient
+class NetPlayServer : public Common::TraversalClientClient
 {
 public:
   void ThreadFunc();
@@ -210,7 +210,7 @@ private:
   bool m_abort_chunked_data = false;
 
   ENetHost* m_server = nullptr;
-  TraversalClient* m_traversal_client = nullptr;
+  Common::TraversalClient* m_traversal_client = nullptr;
   NetPlayUI* m_dialog = nullptr;
   NetPlayIndex m_index;
 };

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -143,7 +143,7 @@ private:
 
   void OnTraversalStateChanged() override;
   void OnConnectReady(ENetAddress) override {}
-  void OnConnectFailed(TraversalConnectFailedReason) override {}
+  void OnConnectFailed(Common::TraversalConnectFailedReason) override {}
   void UpdatePadMapping();
   void UpdateGBAConfig();
   void UpdateWiimoteMapping();

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -65,7 +65,7 @@
 
 namespace
 {
-QString InetAddressToString(const TraversalInetAddress& addr)
+QString InetAddressToString(const Common::TraversalInetAddress& addr)
 {
   QString ip;
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -321,7 +321,7 @@ void NetPlayDialog::ConnectWidgets()
           &NetPlayDialog::UpdateGUI);
   connect(m_hostcode_action_button, &QPushButton::clicked, [this] {
     if (m_is_copy_button_retry)
-      g_TraversalClient->ReconnectToServer();
+      Common::g_TraversalClient->ReconnectToServer();
     else
       QApplication::clipboard()->setText(m_hostcode_label->text());
   });
@@ -581,9 +581,9 @@ void NetPlayDialog::UpdateDiscordPresence()
 
   if (IsHosting())
   {
-    if (g_TraversalClient)
+    if (Common::g_TraversalClient)
     {
-      const auto host_id = g_TraversalClient->GetHostID();
+      const auto host_id = Common::g_TraversalClient->GetHostID();
       if (host_id[0] == '\0')
         return use_default();
 
@@ -706,26 +706,27 @@ void NetPlayDialog::UpdateGUI()
   }
   else if (m_use_traversal)
   {
-    switch (g_TraversalClient->GetState())
+    switch (Common::g_TraversalClient->GetState())
     {
-    case TraversalClient::State::Connecting:
+    case Common::TraversalClient::State::Connecting:
       m_hostcode_label->setText(tr("Connecting"));
       m_hostcode_action_button->setEnabled(false);
       m_hostcode_action_button->setText(tr("..."));
       break;
-    case TraversalClient::State::Connected:
+    case Common::TraversalClient::State::Connected:
     {
       if (m_room_box->currentIndex() == 0)
       {
         // Display Room ID.
-        const auto host_id = g_TraversalClient->GetHostID();
+        const auto host_id = Common::g_TraversalClient->GetHostID();
         m_hostcode_label->setText(
             QString::fromStdString(std::string(host_id.begin(), host_id.end())));
       }
       else
       {
         // Externally mapped IP and port are known when using the traversal server.
-        m_hostcode_label->setText(InetAddressToString(g_TraversalClient->GetExternalAddress()));
+        m_hostcode_label->setText(
+            InetAddressToString(Common::g_TraversalClient->GetExternalAddress()));
       }
 
       m_hostcode_action_button->setEnabled(true);
@@ -733,7 +734,7 @@ void NetPlayDialog::UpdateGUI()
       m_is_copy_button_retry = false;
       break;
     }
-    case TraversalClient::State::Failure:
+    case Common::TraversalClient::State::Failure:
       m_hostcode_label->setText(tr("Error"));
       m_hostcode_action_button->setText(tr("Retry"));
       m_hostcode_action_button->setEnabled(true);
@@ -981,35 +982,35 @@ void NetPlayDialog::OnConnectionError(const std::string& message)
   });
 }
 
-void NetPlayDialog::OnTraversalError(TraversalClient::FailureReason error)
+void NetPlayDialog::OnTraversalError(Common::TraversalClient::FailureReason error)
 {
   QueueOnObject(this, [this, error] {
     switch (error)
     {
-    case TraversalClient::FailureReason::BadHost:
+    case Common::TraversalClient::FailureReason::BadHost:
       ModalMessageBox::critical(this, tr("Traversal Error"), tr("Couldn't look up central server"));
       QDialog::reject();
       break;
-    case TraversalClient::FailureReason::VersionTooOld:
+    case Common::TraversalClient::FailureReason::VersionTooOld:
       ModalMessageBox::critical(this, tr("Traversal Error"),
                                 tr("Dolphin is too old for traversal server"));
       QDialog::reject();
       break;
-    case TraversalClient::FailureReason::ServerForgotAboutUs:
-    case TraversalClient::FailureReason::SocketSendError:
-    case TraversalClient::FailureReason::ResendTimeout:
+    case Common::TraversalClient::FailureReason::ServerForgotAboutUs:
+    case Common::TraversalClient::FailureReason::SocketSendError:
+    case Common::TraversalClient::FailureReason::ResendTimeout:
       UpdateGUI();
       break;
     }
   });
 }
 
-void NetPlayDialog::OnTraversalStateChanged(TraversalClient::State state)
+void NetPlayDialog::OnTraversalStateChanged(Common::TraversalClient::State state)
 {
   switch (state)
   {
-  case TraversalClient::State::Connected:
-  case TraversalClient::State::Failure:
+  case Common::TraversalClient::State::Connected:
+  case Common::TraversalClient::State::Failure:
     UpdateDiscordPresence();
     break;
   default:

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -67,8 +67,8 @@ public:
   void OnDesync(u32 frame, const std::string& player) override;
   void OnConnectionLost() override;
   void OnConnectionError(const std::string& message) override;
-  void OnTraversalError(TraversalClient::FailureReason error) override;
-  void OnTraversalStateChanged(TraversalClient::State state) override;
+  void OnTraversalError(Common::TraversalClient::FailureReason error) override;
+  void OnTraversalStateChanged(Common::TraversalClient::State state) override;
   void OnGameStartAborted() override;
   void OnGolferChanged(bool is_golfer, const std::string& golfer_name) override;
 


### PR DESCRIPTION
Moves the TraversalClient and TraversalProto interfaces into the Common namespace to make them consistent with the rest of Common and move them out of the global namespace