### PR TITLE
Fix build of iconv code on OpenBSD

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -547,7 +547,7 @@ std::string CodeTo(const char* tocode, const char* fromcode, std::basic_string_v
     while (src_bytes != 0)
     {
       size_t const iconv_result =
-#if defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__NetBSD__)
           iconv(conv_desc, reinterpret_cast<const char**>(&src_buffer), &src_bytes, &dst_buffer,
                 &dst_bytes);
 #else


### PR DESCRIPTION
The ifdef'd path for OpenBSD was added with 2c355b81f20fe0d40ac825375073d21b211732b9 with the addition of NetBSD support, but it does not build on OpenBSD.

```
Source/Core/Common/StringUtil.cpp:551:11: error: no matching function for call to 'libiconv'
          iconv(conv_desc, reinterpret_cast<const char**>(&src_buffer), &src_bytes, &dst_buffer,
          ^~~~~
/usr/local/include/iconv.h:80:15: note: expanded from macro 'iconv'
#define iconv libiconv
              ^~~~~~~~
/usr/local/include/iconv.h:82:15: note: candidate function not viable: no known conversion from 'const char **' to 'char **' for 2nd argument
extern size_t iconv (iconv_t cd,  char* * inbuf, size_t *inbytesleft, char* * outbuf, size_t *outbytesleft);
              ^
/usr/local/include/iconv.h:80:15: note: expanded from macro 'iconv'
#define iconv libiconv
              ^
1 error generated.
```