### PR TITLE
DolphinQt: reset stylesheets on colorSchemeChanged

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
@@ -7,10 +7,12 @@
 #include <string>
 #include <vector>
 
+#include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMenu>
 #include <QPushButton>
+#include <QStyleHints>
 #include <QTableWidget>
 #include <QVBoxLayout>
 
@@ -29,6 +31,10 @@
 #include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Settings.h"
+
+static const QString RECORD_BUTTON_STYLESHEET =
+    QStringLiteral("QPushButton:checked { background-color: rgb(150, 0, 0); border-style: solid; "
+                   "border-width: 3px; border-color: rgb(150,0,0); color: rgb(255, 255, 255);}");
 
 CodeDiffDialog::CodeDiffDialog(CodeWidget* parent) : QDialog(parent), m_code_widget(parent)
 {
@@ -54,9 +60,7 @@ void CodeDiffDialog::CreateWidgets()
   m_include_btn = new QPushButton(tr("Code has been executed"));
   m_record_btn = new QPushButton(tr("Start Recording"));
   m_record_btn->setCheckable(true);
-  m_record_btn->setStyleSheet(
-      QStringLiteral("QPushButton:checked { background-color: rgb(150, 0, 0); border-style: solid; "
-                     "border-width: 3px; border-color: rgb(150,0,0); color: rgb(255, 255, 255);}"));
+  m_record_btn->setStyleSheet(RECORD_BUTTON_STYLESHEET);
 
   m_exclude_btn->setEnabled(false);
   m_include_btn->setEnabled(false);
@@ -105,6 +109,13 @@ void CodeDiffDialog::CreateWidgets()
 
 void CodeDiffDialog::ConnectWidgets()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [this](Qt::ColorScheme colorScheme) {
+            m_record_btn->setStyleSheet(RECORD_BUTTON_STYLESHEET);
+          });
+#endif
+
   connect(m_record_btn, &QPushButton::toggled, this, &CodeDiffDialog::OnRecord);
   connect(m_include_btn, &QPushButton::pressed, [this]() { Update(true); });
   connect(m_exclude_btn, &QPushButton::pressed, [this]() { Update(false); });

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -19,6 +19,7 @@
 #include <QPainter>
 #include <QResizeEvent>
 #include <QScrollBar>
+#include <QStyleHints>
 #include <QStyledItemDelegate>
 #include <QTableWidgetItem>
 #include <QWheelEvent>
@@ -160,6 +161,11 @@ CodeViewWidget::CodeViewWidget() : m_system(Core::System::GetInstance())
   setItemDelegateForColumn(CODE_VIEW_COLUMN_BRANCH_ARROWS, new BranchDisplayDelegate(this));
 
   FontBasedSizing();
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [this](Qt::ColorScheme colorScheme) { OnSelectionChanged(); });
+#endif
 
   connect(this, &CodeViewWidget::customContextMenuRequested, this, &CodeViewWidget::OnContextMenu);
   connect(this, &CodeViewWidget::itemSelectionChanged, this, &CodeViewWidget::OnSelectionChanged);

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -9,11 +9,13 @@
 
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QGuiApplication>
 #include <QLabel>
 #include <QLineEdit>
 #include <QListWidget>
 #include <QPushButton>
 #include <QSplitter>
+#include <QStyleHints>
 #include <QTableWidget>
 #include <QWidget>
 
@@ -27,6 +29,10 @@
 #include "Core/System.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/Settings.h"
+
+static const QString BOX_SPLITTER_STYLESHEET = QStringLiteral(
+    "QSplitter::handle { border-top: 1px dashed black; width: 1px; margin-left: 10px; "
+    "margin-right: 10px; }");
 
 CodeWidget::CodeWidget(QWidget* parent) : QDockWidget(parent), m_system(Core::System::GetInstance())
 {
@@ -104,9 +110,7 @@ void CodeWidget::CreateWidgets()
   m_search_address->setPlaceholderText(tr("Search Address"));
 
   m_box_splitter = new QSplitter(Qt::Vertical);
-  m_box_splitter->setStyleSheet(QStringLiteral(
-      "QSplitter::handle { border-top: 1px dashed black; width: 1px; margin-left: 10px; "
-      "margin-right: 10px; }"));
+  m_box_splitter->setStyleSheet(BOX_SPLITTER_STYLESHEET);
 
   auto add_search_line_edit = [this](const QString& name, QListWidget* list_widget) {
     auto* widget = new QWidget;
@@ -154,6 +158,13 @@ void CodeWidget::CreateWidgets()
 
 void CodeWidget::ConnectWidgets()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [this](Qt::ColorScheme colorScheme) {
+            m_box_splitter->setStyleSheet(BOX_SPLITTER_STYLESHEET);
+          });
+#endif
+
   connect(m_search_address, &QLineEdit::textChanged, this, &CodeWidget::OnSearchAddress);
   connect(m_search_address, &QLineEdit::returnPressed, this, &CodeWidget::OnSearchAddress);
   connect(m_search_symbols, &QLineEdit::textChanged, this, &CodeWidget::OnSearchSymbols);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -14,6 +14,7 @@
 #include <QIcon>
 #include <QMimeData>
 #include <QStackedWidget>
+#include <QStyleHints>
 #include <QVBoxLayout>
 #include <QWindow>
 
@@ -237,6 +238,13 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
   ConnectStack();
   ConnectMenuBar();
   ConnectHotkeys();
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [](Qt::ColorScheme colorScheme) {
+            Settings::Instance().SetCurrentUserStyle(Settings::Instance().GetCurrentUserStyle());
+          });
+#endif
 
   connect(m_cheats_manager, &CheatsManager::OpenGeneralSettings, this,
           &MainWindow::ShowGeneralWindow);


### PR DESCRIPTION
This is required for switching system color scheme (dark/light) dynamically at runtime.

see https://github.com/dolphin-emu/dolphin/pull/11789#issuecomment-1521211807