### PR TITLE
Qt: Rename GraphicsChoice to ConfigChoice

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(dolphin-emu
   Config/CommonControllersWidget.h
   Config/ConfigControls/ConfigBool.cpp
   Config/ConfigControls/ConfigBool.h
+  Config/ConfigControls/ConfigChoice.cpp
+  Config/ConfigControls/ConfigChoice.h
   Config/ControllerInterface/ControllerInterfaceWindow.cpp
   Config/ControllerInterface/ControllerInterfaceWindow.h
   Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
@@ -75,8 +77,6 @@ add_executable(dolphin-emu
   Config/Graphics/EnhancementsWidget.h
   Config/Graphics/GeneralWidget.cpp
   Config/Graphics/GeneralWidget.h
-  Config/Graphics/GraphicsChoice.cpp
-  Config/Graphics/GraphicsChoice.h
   Config/Graphics/GraphicsInteger.cpp
   Config/Graphics/GraphicsInteger.h
   Config/Graphics/GraphicsRadio.cpp

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
 
 #include <QSignalBlocker>
 
@@ -9,11 +9,11 @@
 
 #include "DolphinQt/Settings.h"
 
-GraphicsChoice::GraphicsChoice(const QStringList& options, const Config::Info<int>& setting)
+ConfigChoice::ConfigChoice(const QStringList& options, const Config::Info<int>& setting)
     : m_setting(setting)
 {
   addItems(options);
-  connect(this, qOverload<int>(&QComboBox::currentIndexChanged), this, &GraphicsChoice::Update);
+  connect(this, qOverload<int>(&QComboBox::currentIndexChanged), this, &ConfigChoice::Update);
   setCurrentIndex(Config::Get(m_setting));
 
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
@@ -26,7 +26,7 @@ GraphicsChoice::GraphicsChoice(const QStringList& options, const Config::Info<in
   });
 }
 
-void GraphicsChoice::Update(int choice)
+void ConfigChoice::Update(int choice)
 {
   Config::SetBaseOrCurrent(m_setting, choice);
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
@@ -7,11 +7,11 @@
 
 #include "Common/Config/Config.h"
 
-class GraphicsChoice : public ToolTipComboBox
+class ConfigChoice : public ToolTipComboBox
 {
   Q_OBJECT
 public:
-  GraphicsChoice(const QStringList& options, const Config::Info<int>& setting);
+  ConfigChoice(const QStringList& options, const Config::Info<int>& setting);
 
 private:
   void Update(int choice);

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
@@ -13,7 +13,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
-#include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
@@ -37,8 +37,8 @@ void FreeLookWidget::CreateLayout()
          "leave this unchecked.</dolphin_emphasis>"));
   m_freelook_controller_configure_button = new NonDefaultQPushButton(tr("Configure Controller"));
 
-  m_freelook_control_type = new GraphicsChoice({tr("Six Axis"), tr("First Person"), tr("Orbital")},
-                                               Config::FL1_CONTROL_TYPE);
+  m_freelook_control_type = new ConfigChoice({tr("Six Axis"), tr("First Person"), tr("Orbital")},
+                                             Config::FL1_CONTROL_TYPE);
   m_freelook_control_type->SetTitle(tr("Free Look Control Type"));
   m_freelook_control_type->SetDescription(tr(
       "Changes the in-game camera type during Free Look.<br><br>"

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.h
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.h
@@ -5,7 +5,7 @@
 
 #include <QWidget>
 
-class GraphicsChoice;
+class ConfigChoice;
 class QCheckBox;
 class QPushButton;
 class ToolTipCheckBox;
@@ -25,7 +25,7 @@ private:
   void SaveSettings();
 
   ToolTipCheckBox* m_enable_freelook;
-  GraphicsChoice* m_freelook_control_type;
+  ConfigChoice* m_freelook_control_type;
   QPushButton* m_freelook_controller_configure_button;
   QCheckBox* m_freelook_background_input;
 };

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -16,7 +16,7 @@
 #include "Core/Core.h"
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
-#include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
 #include "DolphinQt/Config/Graphics/GraphicsInteger.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -6,7 +6,7 @@
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
 class ConfigBool;
-class GraphicsChoice;
+class ConfigChoice;
 class GraphicsInteger;
 class GraphicsWindow;
 class QCheckBox;

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -15,7 +15,7 @@
 #include "Core/ConfigManager.h"
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
-#include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
 #include "DolphinQt/Config/Graphics/GraphicsRadio.h"
 #include "DolphinQt/Config/Graphics/GraphicsSlider.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
@@ -82,7 +82,7 @@ void EnhancementsWidget::CreateWidgets()
                                        QString::number(static_cast<int>(EFB_HEIGHT) * scale)));
   }
 
-  m_ir_combo = new GraphicsChoice(resolution_options, Config::GFX_EFB_SCALE);
+  m_ir_combo = new ConfigChoice(resolution_options, Config::GFX_EFB_SCALE);
   m_ir_combo->setMaxVisibleItems(visible_resolution_option_count);
 
   m_aa_combo = new ToolTipComboBox();
@@ -157,9 +157,9 @@ void EnhancementsWidget::CreateWidgets()
   auto* stereoscopy_layout = new QGridLayout();
   stereoscopy_box->setLayout(stereoscopy_layout);
 
-  m_3d_mode = new GraphicsChoice({tr("Off"), tr("Side-by-Side"), tr("Top-and-Bottom"),
-                                  tr("Anaglyph"), tr("HDMI 3D"), tr("Passive")},
-                                 Config::GFX_STEREO_MODE);
+  m_3d_mode = new ConfigChoice({tr("Off"), tr("Side-by-Side"), tr("Top-and-Bottom"), tr("Anaglyph"),
+                                tr("HDMI 3D"), tr("Passive")},
+                               Config::GFX_STEREO_MODE);
   m_3d_depth = new GraphicsSlider(0, Config::GFX_STEREO_DEPTH_MAXIMUM, Config::GFX_STEREO_DEPTH);
   m_3d_convergence = new GraphicsSlider(0, Config::GFX_STEREO_CONVERGENCE_MAXIMUM,
                                         Config::GFX_STEREO_CONVERGENCE, 100);

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -8,7 +8,7 @@
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
 class ConfigBool;
-class GraphicsChoice;
+class ConfigChoice;
 class GraphicsSlider;
 class GraphicsWindow;
 class QCheckBox;
@@ -34,7 +34,7 @@ private:
   void LoadPPShaders();
 
   // Enhancements
-  GraphicsChoice* m_ir_combo;
+  ConfigChoice* m_ir_combo;
   ToolTipComboBox* m_aa_combo;
   ToolTipComboBox* m_texture_filtering_combo;
   ToolTipComboBox* m_pp_effect;
@@ -48,7 +48,7 @@ private:
   ConfigBool* m_arbitrary_mipmap_detection;
 
   // Stereoscopy
-  GraphicsChoice* m_3d_mode;
+  ConfigChoice* m_3d_mode;
   GraphicsSlider* m_3d_depth;
   GraphicsSlider* m_3d_convergence;
   ConfigBool* m_3d_swap_eyes;

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -19,7 +19,7 @@
 #include "Core/Core.h"
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
-#include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
 #include "DolphinQt/Config/Graphics/GraphicsRadio.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
@@ -57,8 +57,8 @@ void GeneralWidget::CreateWidgets()
 
   m_backend_combo = new ToolTipComboBox();
   m_aspect_combo =
-      new GraphicsChoice({tr("Auto"), tr("Force 16:9"), tr("Force 4:3"), tr("Stretch to Window")},
-                         Config::GFX_ASPECT_RATIO);
+      new ConfigChoice({tr("Auto"), tr("Force 16:9"), tr("Force 4:3"), tr("Stretch to Window")},
+                       Config::GFX_ASPECT_RATIO);
   m_adapter_combo = new ToolTipComboBox;
   m_enable_vsync = new ConfigBool(tr("V-Sync"), Config::GFX_VSYNC);
   m_enable_fullscreen = new ConfigBool(tr("Start in Fullscreen"), Config::MAIN_FULLSCREEN);

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -7,7 +7,7 @@
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
 class ConfigBool;
-class GraphicsChoice;
+class ConfigChoice;
 class GraphicsRadioInt;
 class GraphicsWindow;
 class QCheckBox;
@@ -44,7 +44,7 @@ private:
   QGridLayout* m_video_layout;
   ToolTipComboBox* m_backend_combo;
   ToolTipComboBox* m_adapter_combo;
-  GraphicsChoice* m_aspect_combo;
+  ConfigChoice* m_aspect_combo;
   ConfigBool* m_enable_vsync;
   ConfigBool* m_enable_fullscreen;
 

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="Config\CheatWarningWidget.cpp" />
     <ClCompile Include="Config\CommonControllersWidget.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigBool.cpp" />
+    <ClCompile Include="Config\ConfigControls\ConfigChoice.cpp" />
     <ClCompile Include="Config\ControllerInterface\ControllerInterfaceWindow.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientWidget.cpp" />
@@ -71,7 +72,6 @@
     <ClCompile Include="Config\Graphics\AdvancedWidget.cpp" />
     <ClCompile Include="Config\Graphics\EnhancementsWidget.cpp" />
     <ClCompile Include="Config\Graphics\GeneralWidget.cpp" />
-    <ClCompile Include="Config\Graphics\GraphicsChoice.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsInteger.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsRadio.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsSlider.cpp" />
@@ -256,6 +256,7 @@
     <QtMoc Include="Config\CheatWarningWidget.h" />
     <QtMoc Include="Config\CommonControllersWidget.h" />
     <QtMoc Include="Config\ConfigControls\ConfigBool.h" />
+    <QtMoc Include="Config\ConfigControls\ConfigChoice.h" />
     <QtMoc Include="Config\ControllerInterface\ControllerInterfaceWindow.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientWidget.h" />
@@ -271,7 +272,6 @@
     <QtMoc Include="Config\Graphics\AdvancedWidget.h" />
     <QtMoc Include="Config\Graphics\EnhancementsWidget.h" />
     <QtMoc Include="Config\Graphics\GeneralWidget.h" />
-    <QtMoc Include="Config\Graphics\GraphicsChoice.h" />
     <QtMoc Include="Config\Graphics\GraphicsInteger.h" />
     <QtMoc Include="Config\Graphics\GraphicsRadio.h" />
     <QtMoc Include="Config\Graphics\GraphicsSlider.h" />


### PR DESCRIPTION
(Same as #11780 but for combo boxes)

GraphicsChoice is used by the panes in the Graphics config window to create combo boxes that change their associated config setting, and update their own state when something else changes the config setting.

Despite its current name nothing about this class is particular to the Graphics window, so renaming it to ConfigChoice better reflects its purpose. This should also make it less confusing when ConfigChoices are eventually added to the other config windows.