### PR TITLE
Gecko/ARCode: Add sort by enabled state

### DIFF
--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "DolphinQt/Config/ARCodeWidget.h"
 
+#include <algorithm>
 #include <utility>
 
 #include <QCursor>
@@ -113,6 +114,8 @@ void ARCodeWidget::OnContextMenuRequested()
   QMenu menu;
 
   menu.addAction(tr("Sort Alphabetically"), this, &ARCodeWidget::SortAlphabetically);
+  menu.addAction(tr("Show Enabled Codes First"), this, &ARCodeWidget::SortEnabledCodesFirst);
+  menu.addAction(tr("Show Disabled Codes First"), this, &ARCodeWidget::SortDisabledCodesFirst);
 
   menu.exec(QCursor::pos());
 }
@@ -121,6 +124,26 @@ void ARCodeWidget::SortAlphabetically()
 {
   m_code_list->sortItems();
   OnListReordered();
+}
+
+void ARCodeWidget::SortEnabledCodesFirst()
+{
+  std::stable_sort(m_ar_codes.begin(), m_ar_codes.end(), [](const auto& a, const auto& b) {
+    return a.enabled && a.enabled != b.enabled;
+  });
+
+  UpdateList();
+  SaveCodes();
+}
+
+void ARCodeWidget::SortDisabledCodesFirst()
+{
+  std::stable_sort(m_ar_codes.begin(), m_ar_codes.end(), [](const auto& a, const auto& b) {
+    return !a.enabled && a.enabled != b.enabled;
+  });
+
+  UpdateList();
+  SaveCodes();
 }
 
 void ARCodeWidget::OnListReordered()

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.h
@@ -43,6 +43,8 @@ private:
   void UpdateList();
   void SaveCodes();
   void SortAlphabetically();
+  void SortEnabledCodesFirst();
+  void SortDisabledCodesFirst();
 
   void OnCodeAddClicked();
   void OnCodeEditClicked();

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "DolphinQt/Config/GeckoCodeWidget.h"
 
+#include <algorithm>
 #include <utility>
 
 #include <QCursor>
@@ -257,6 +258,8 @@ void GeckoCodeWidget::OnContextMenuRequested()
   QMenu menu;
 
   menu.addAction(tr("Sort Alphabetically"), this, &GeckoCodeWidget::SortAlphabetically);
+  menu.addAction(tr("Show Enabled Codes First"), this, &GeckoCodeWidget::SortEnabledCodesFirst);
+  menu.addAction(tr("Show Disabled Codes First"), this, &GeckoCodeWidget::SortDisabledCodesFirst);
 
   menu.exec(QCursor::pos());
 }
@@ -265,6 +268,26 @@ void GeckoCodeWidget::SortAlphabetically()
 {
   m_code_list->sortItems();
   OnListReordered();
+}
+
+void GeckoCodeWidget::SortEnabledCodesFirst()
+{
+  std::stable_sort(m_gecko_codes.begin(), m_gecko_codes.end(), [](const auto& a, const auto& b) {
+    return a.enabled && a.enabled != b.enabled;
+  });
+
+  UpdateList();
+  SaveCodes();
+}
+
+void GeckoCodeWidget::SortDisabledCodesFirst()
+{
+  std::stable_sort(m_gecko_codes.begin(), m_gecko_codes.end(), [](const auto& a, const auto& b) {
+    return !a.enabled && a.enabled != b.enabled;
+  });
+
+  UpdateList();
+  SaveCodes();
 }
 
 void GeckoCodeWidget::OnListReordered()

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
@@ -48,6 +48,8 @@ private:
   void DownloadCodes();
   void SaveCodes();
   void SortAlphabetically();
+  void SortEnabledCodesFirst();
+  void SortDisabledCodesFirst();
 
   std::string m_game_id;
   std::string m_gametdb_id;


### PR DESCRIPTION
This PR adds the ability to sort codes by enabled state which can be useful when you want to disable some codes but the code list is huge.

Ready to be reviewed & merged.