### PR TITLE
Qt/GraphicsWindow: Remove unnecessary member variables

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
@@ -37,32 +37,31 @@ GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindo
 
 void GraphicsWindow::CreateMainLayout()
 {
-  auto* main_layout = new QVBoxLayout();
-  m_tab_widget = new QTabWidget();
-  m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
+  auto* const main_layout = new QVBoxLayout();
+  auto* const tab_widget = new QTabWidget();
+  auto* const button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
-  connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
-  main_layout->addWidget(m_tab_widget);
-  main_layout->addWidget(m_button_box);
+  main_layout->addWidget(tab_widget);
+  main_layout->addWidget(button_box);
 
-  m_general_widget = new GeneralWidget(m_xrr_config, this);
-  m_enhancements_widget = new EnhancementsWidget(this);
-  m_hacks_widget = new HacksWidget(this);
-  m_advanced_widget = new AdvancedWidget(this);
+  auto* const general_widget = new GeneralWidget(m_xrr_config, this);
+  auto* const enhancements_widget = new EnhancementsWidget(this);
+  auto* const hacks_widget = new HacksWidget(this);
+  auto* const advanced_widget = new AdvancedWidget(this);
 
-  connect(m_general_widget, &GeneralWidget::BackendChanged, this,
-          &GraphicsWindow::OnBackendChanged);
+  connect(general_widget, &GeneralWidget::BackendChanged, this, &GraphicsWindow::OnBackendChanged);
 
-  m_wrapped_general = GetWrappedWidget(m_general_widget, this, 50, 100);
-  m_wrapped_enhancements = GetWrappedWidget(m_enhancements_widget, this, 50, 100);
-  m_wrapped_hacks = GetWrappedWidget(m_hacks_widget, this, 50, 100);
-  m_wrapped_advanced = GetWrappedWidget(m_advanced_widget, this, 50, 100);
+  QWidget* const wrapped_general = GetWrappedWidget(general_widget, this, 50, 100);
+  QWidget* const wrapped_enhancements = GetWrappedWidget(enhancements_widget, this, 50, 100);
+  QWidget* const wrapped_hacks = GetWrappedWidget(hacks_widget, this, 50, 100);
+  QWidget* const wrapped_advanced = GetWrappedWidget(advanced_widget, this, 50, 100);
 
-  m_tab_widget->addTab(m_wrapped_general, tr("General"));
-  m_tab_widget->addTab(m_wrapped_enhancements, tr("Enhancements"));
-  m_tab_widget->addTab(m_wrapped_hacks, tr("Hacks"));
-  m_tab_widget->addTab(m_wrapped_advanced, tr("Advanced"));
+  tab_widget->addTab(wrapped_general, tr("General"));
+  tab_widget->addTab(wrapped_enhancements, tr("Enhancements"));
+  tab_widget->addTab(wrapped_hacks, tr("Hacks"));
+  tab_widget->addTab(wrapped_advanced, tr("Advanced"));
 
   setLayout(main_layout);
 }

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.h
@@ -34,20 +34,5 @@ private:
   void CreateMainLayout();
   void OnBackendChanged(const QString& backend);
 
-  QTabWidget* m_tab_widget;
-  QDialogButtonBox* m_button_box;
-
-  AdvancedWidget* m_advanced_widget;
-  EnhancementsWidget* m_enhancements_widget;
-  HacksWidget* m_hacks_widget;
-  GeneralWidget* m_general_widget;
-  SoftwareRendererWidget* m_software_renderer;
-
-  QWidget* m_wrapped_advanced;
-  QWidget* m_wrapped_enhancements;
-  QWidget* m_wrapped_hacks;
-  QWidget* m_wrapped_general;
-  QWidget* m_wrapped_software;
-
   X11Utils::XRRConfiguration* m_xrr_config;
 };


### PR DESCRIPTION
These variables are only used in CreateMainLayout and so can be removed from the header and replaced with local variables.

Some of these were necessary until #11100 to switch between showing the normal graphics settings vs the software renderer settings.