### PR TITLE
Qt: Rename GraphicsRadioInt to ConfigRadioInt

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -39,6 +39,8 @@ add_executable(dolphin-emu
   Config/ConfigControls/ConfigBool.h
   Config/ConfigControls/ConfigChoice.cpp
   Config/ConfigControls/ConfigChoice.h
+  Config/ConfigControls/ConfigRadio.cpp
+  Config/ConfigControls/ConfigRadio.h
   Config/ControllerInterface/ControllerInterfaceWindow.cpp
   Config/ControllerInterface/ControllerInterfaceWindow.h
   Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
@@ -73,8 +75,6 @@ add_executable(dolphin-emu
   Config/Graphics/GeneralWidget.h
   Config/Graphics/GraphicsInteger.cpp
   Config/Graphics/GraphicsInteger.h
-  Config/Graphics/GraphicsRadio.cpp
-  Config/Graphics/GraphicsRadio.h
   Config/Graphics/GraphicsSlider.cpp
   Config/Graphics/GraphicsSlider.h
   Config/Graphics/GraphicsWidget.h

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
@@ -1,7 +1,7 @@
 // Copyright 2018 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "DolphinQt/Config/Graphics/GraphicsRadio.h"
+#include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
 
 #include <QSignalBlocker>
 
@@ -9,12 +9,11 @@
 
 #include "DolphinQt/Settings.h"
 
-GraphicsRadioInt::GraphicsRadioInt(const QString& label, const Config::Info<int>& setting,
-                                   int value)
+ConfigRadioInt::ConfigRadioInt(const QString& label, const Config::Info<int>& setting, int value)
     : ToolTipRadioButton(label), m_setting(setting), m_value(value)
 {
   setChecked(Config::Get(m_setting) == m_value);
-  connect(this, &QRadioButton::toggled, this, &GraphicsRadioInt::Update);
+  connect(this, &QRadioButton::toggled, this, &ConfigRadioInt::Update);
 
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     QFont bf = font();
@@ -26,7 +25,7 @@ GraphicsRadioInt::GraphicsRadioInt(const QString& label, const Config::Info<int>
   });
 }
 
-void GraphicsRadioInt::Update()
+void ConfigRadioInt::Update()
 {
   if (!isChecked())
     return;

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
@@ -7,11 +7,11 @@
 
 #include "Common/Config/Config.h"
 
-class GraphicsRadioInt : public ToolTipRadioButton
+class ConfigRadioInt : public ToolTipRadioButton
 {
   Q_OBJECT
 public:
-  GraphicsRadioInt(const QString& label, const Config::Info<int>& setting, int value);
+  ConfigRadioInt(const QString& label, const Config::Info<int>& setting, int value);
 
 private:
   void Update();

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -16,7 +16,7 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
-#include "DolphinQt/Config/Graphics/GraphicsRadio.h"
+#include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
 #include "DolphinQt/Config/Graphics/GraphicsSlider.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/Graphics/PostProcessingConfigWindow.h"

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -20,7 +20,7 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
-#include "DolphinQt/Config/Graphics/GraphicsRadio.h"
+#include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
@@ -110,8 +110,8 @@ void GeneralWidget::CreateWidgets()
   }};
   for (size_t i = 0; i < modes.size(); i++)
   {
-    m_shader_compilation_mode[i] = new GraphicsRadioInt(
-        tr(modes[i]), Config::GFX_SHADER_COMPILATION_MODE, static_cast<int>(i));
+    m_shader_compilation_mode[i] =
+        new ConfigRadioInt(tr(modes[i]), Config::GFX_SHADER_COMPILATION_MODE, static_cast<int>(i));
     shader_compilation_layout->addWidget(m_shader_compilation_mode[i], static_cast<int>(i / 2),
                                          static_cast<int>(i % 2));
   }

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -8,7 +8,7 @@
 
 class ConfigBool;
 class ConfigChoice;
-class GraphicsRadioInt;
+class ConfigRadioInt;
 class GraphicsWindow;
 class QCheckBox;
 class QComboBox;
@@ -48,6 +48,6 @@ private:
   ConfigBool* m_autoadjust_window_size;
   ConfigBool* m_show_messages;
   ConfigBool* m_render_main_window;
-  std::array<GraphicsRadioInt*, 4> m_shader_compilation_mode{};
+  std::array<ConfigRadioInt*, 4> m_shader_compilation_mode{};
   ConfigBool* m_wait_for_shaders;
 };

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="Config\CommonControllersWidget.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigBool.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigChoice.cpp" />
+    <ClCompile Include="Config\ConfigControls\ConfigRadio.cpp" />
     <ClCompile Include="Config\ControllerInterface\ControllerInterfaceWindow.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientWidget.cpp" />
@@ -73,7 +74,6 @@
     <ClCompile Include="Config\Graphics\EnhancementsWidget.cpp" />
     <ClCompile Include="Config\Graphics\GeneralWidget.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsInteger.cpp" />
-    <ClCompile Include="Config\Graphics\GraphicsRadio.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsSlider.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsWindow.cpp" />
     <ClCompile Include="Config\Graphics\HacksWidget.cpp" />
@@ -257,6 +257,7 @@
     <QtMoc Include="Config\CommonControllersWidget.h" />
     <QtMoc Include="Config\ConfigControls\ConfigBool.h" />
     <QtMoc Include="Config\ConfigControls\ConfigChoice.h" />
+    <QtMoc Include="Config\ConfigControls\ConfigRadio.h" />
     <QtMoc Include="Config\ControllerInterface\ControllerInterfaceWindow.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientWidget.h" />
@@ -273,7 +274,6 @@
     <QtMoc Include="Config\Graphics\EnhancementsWidget.h" />
     <QtMoc Include="Config\Graphics\GeneralWidget.h" />
     <QtMoc Include="Config\Graphics\GraphicsInteger.h" />
-    <QtMoc Include="Config\Graphics\GraphicsRadio.h" />
     <QtMoc Include="Config\Graphics\GraphicsSlider.h" />
     <QtMoc Include="Config\Graphics\GraphicsWidget.h" />
     <QtMoc Include="Config\Graphics\GraphicsWindow.h" />


### PR DESCRIPTION
(Continuing the Graphics* to Config* conversion)

GraphicsRadioInt is used by the panes in the Graphics config window to create radio buttons that change their associated config setting, and update their own state when something else changes the config setting.

Despite its current name nothing about this class is particular to the Graphics window, so renaming it to ConfigRadioInt better reflects its purpose. This should also make it less confusing when ConfigRadioInts are added to other config panes.