### PR TITLE
Qt: Rename GraphicsInteger to ConfigInteger

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -39,6 +39,8 @@ add_executable(dolphin-emu
   Config/ConfigControls/ConfigBool.h
   Config/ConfigControls/ConfigChoice.cpp
   Config/ConfigControls/ConfigChoice.h
+  Config/ConfigControls/ConfigInteger.cpp
+  Config/ConfigControls/ConfigInteger.h
   Config/ConfigControls/ConfigRadio.cpp
   Config/ConfigControls/ConfigRadio.h
   Config/ConfigControls/ConfigSlider.cpp
@@ -75,8 +77,6 @@ add_executable(dolphin-emu
   Config/Graphics/EnhancementsWidget.h
   Config/Graphics/GeneralWidget.cpp
   Config/Graphics/GeneralWidget.h
-  Config/Graphics/GraphicsInteger.cpp
-  Config/Graphics/GraphicsInteger.h
   Config/Graphics/GraphicsWidget.h
   Config/Graphics/GraphicsWindow.cpp
   Config/Graphics/GraphicsWindow.h

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "DolphinQt/Config/Graphics/GraphicsInteger.h"
+#include "DolphinQt/Config/ConfigControls/ConfigInteger.h"
 
 #include <QSignalBlocker>
 
@@ -9,8 +9,7 @@
 
 #include "DolphinQt/Settings.h"
 
-GraphicsInteger::GraphicsInteger(int minimum, int maximum, const Config::Info<int>& setting,
-                                 int step)
+ConfigInteger::ConfigInteger(int minimum, int maximum, const Config::Info<int>& setting, int step)
     : ToolTipSpinBox(), m_setting(setting)
 {
   setMinimum(minimum);
@@ -19,7 +18,7 @@ GraphicsInteger::GraphicsInteger(int minimum, int maximum, const Config::Info<in
 
   setValue(Config::Get(setting));
 
-  connect(this, qOverload<int>(&GraphicsInteger::valueChanged), this, &GraphicsInteger::Update);
+  connect(this, qOverload<int>(&ConfigInteger::valueChanged), this, &ConfigInteger::Update);
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
@@ -30,7 +29,7 @@ GraphicsInteger::GraphicsInteger(int minimum, int maximum, const Config::Info<in
   });
 }
 
-void GraphicsInteger::Update(int value)
+void ConfigInteger::Update(int value)
 {
   Config::SetBaseOrCurrent(m_setting, value);
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
@@ -11,11 +11,11 @@ template <typename T>
 class Info;
 }
 
-class GraphicsInteger : public ToolTipSpinBox
+class ConfigInteger : public ToolTipSpinBox
 {
   Q_OBJECT
 public:
-  GraphicsInteger(int minimum, int maximum, const Config::Info<int>& setting, int step = 1);
+  ConfigInteger(int minimum, int maximum, const Config::Info<int>& setting, int step = 1);
   void Update(int value);
 
 private:

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -17,7 +17,7 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
-#include "DolphinQt/Config/Graphics/GraphicsInteger.h"
+#include "DolphinQt/Config/ConfigControls/ConfigInteger.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
@@ -57,7 +57,7 @@ void AdvancedWidget::CreateWidgets()
   m_show_graphs = new ConfigBool(tr("Show Performance Graphs"), Config::GFX_SHOW_GRAPHS);
   m_show_speed = new ConfigBool(tr("Show % Speed"), Config::GFX_SHOW_SPEED);
   m_show_speed_colors = new ConfigBool(tr("Show Speed Colors"), Config::GFX_SHOW_SPEED_COLORS);
-  m_perf_samp_window = new GraphicsInteger(0, 10000, Config::GFX_PERF_SAMP_WINDOW, 100);
+  m_perf_samp_window = new ConfigInteger(0, 10000, Config::GFX_PERF_SAMP_WINDOW, 100);
   m_perf_samp_window->SetTitle(tr("Performance Sample Window (ms)"));
   m_log_render_time =
       new ConfigBool(tr("Log Render Time to File"), Config::GFX_LOG_RENDER_TIME_TO_FILE);
@@ -134,8 +134,8 @@ void AdvancedWidget::CreateWidgets()
   m_use_fullres_framedumps = new ConfigBool(tr("Dump at Internal Resolution"),
                                             Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS);
   m_dump_use_ffv1 = new ConfigBool(tr("Use Lossless Codec (FFV1)"), Config::GFX_USE_FFV1);
-  m_dump_bitrate = new GraphicsInteger(0, 1000000, Config::GFX_BITRATE_KBPS, 1000);
-  m_png_compression_level = new GraphicsInteger(0, 9, Config::GFX_PNG_COMPRESSION_LEVEL);
+  m_dump_bitrate = new ConfigInteger(0, 1000000, Config::GFX_BITRATE_KBPS, 1000);
+  m_png_compression_level = new ConfigInteger(0, 9, Config::GFX_PNG_COMPRESSION_LEVEL);
 
   dump_layout->addWidget(m_use_fullres_framedumps, 0, 0);
 #if defined(HAVE_FFMPEG)

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -7,7 +7,7 @@
 
 class ConfigBool;
 class ConfigChoice;
-class GraphicsInteger;
+class ConfigInteger;
 class GraphicsWindow;
 class QCheckBox;
 class QComboBox;
@@ -42,7 +42,7 @@ private:
   ConfigBool* m_show_graphs;
   ConfigBool* m_show_speed;
   ConfigBool* m_show_speed_colors;
-  GraphicsInteger* m_perf_samp_window;
+  ConfigInteger* m_perf_samp_window;
   ConfigBool* m_log_render_time;
 
   // Utility
@@ -61,8 +61,8 @@ private:
   // Frame dumping
   ConfigBool* m_dump_use_ffv1;
   ConfigBool* m_use_fullres_framedumps;
-  GraphicsInteger* m_dump_bitrate;
-  GraphicsInteger* m_png_compression_level;
+  ConfigInteger* m_dump_bitrate;
+  ConfigInteger* m_png_compression_level;
 
   // Misc
   ConfigBool* m_enable_cropping;

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="Config\CommonControllersWidget.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigBool.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigChoice.cpp" />
+    <ClCompile Include="Config\ConfigControls\ConfigInteger.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigRadio.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigSlider.cpp" />
     <ClCompile Include="Config\ControllerInterface\ControllerInterfaceWindow.cpp" />
@@ -74,7 +75,6 @@
     <ClCompile Include="Config\Graphics\AdvancedWidget.cpp" />
     <ClCompile Include="Config\Graphics\EnhancementsWidget.cpp" />
     <ClCompile Include="Config\Graphics\GeneralWidget.cpp" />
-    <ClCompile Include="Config\Graphics\GraphicsInteger.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsWindow.cpp" />
     <ClCompile Include="Config\Graphics\HacksWidget.cpp" />
     <ClCompile Include="Config\Graphics\PostProcessingConfigWindow.cpp" />
@@ -255,6 +255,7 @@
     <QtMoc Include="Config\CommonControllersWidget.h" />
     <QtMoc Include="Config\ConfigControls\ConfigBool.h" />
     <QtMoc Include="Config\ConfigControls\ConfigChoice.h" />
+    <QtMoc Include="Config\ConfigControls\ConfigInteger.h" />
     <QtMoc Include="Config\ConfigControls\ConfigRadio.h" />
     <QtMoc Include="Config\ConfigControls\ConfigSlider.h" />
     <QtMoc Include="Config\ControllerInterface\ControllerInterfaceWindow.h" />
@@ -272,7 +273,6 @@
     <QtMoc Include="Config\Graphics\AdvancedWidget.h" />
     <QtMoc Include="Config\Graphics\EnhancementsWidget.h" />
     <QtMoc Include="Config\Graphics\GeneralWidget.h" />
-    <QtMoc Include="Config\Graphics\GraphicsInteger.h" />
     <QtMoc Include="Config\Graphics\GraphicsWidget.h" />
     <QtMoc Include="Config\Graphics\GraphicsWindow.h" />
     <QtMoc Include="Config\Graphics\HacksWidget.h" />


### PR DESCRIPTION
GraphicsInteger is used by the panes in the Graphics config window to create spin boxes that change their associated config setting, and update their own state when something else changes the config setting.

Despite its current name nothing about this class is particular to the Graphics window, so renaming it to ConfigInteger better reflects its purpose. This should also make it less confusing when ConfigIntegers are added to other config windows.