### PR TITLE
Qt: Rename GraphicsSlider to ConfigSlider

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -41,6 +41,8 @@ add_executable(dolphin-emu
   Config/ConfigControls/ConfigChoice.h
   Config/ConfigControls/ConfigRadio.cpp
   Config/ConfigControls/ConfigRadio.h
+  Config/ConfigControls/ConfigSlider.cpp
+  Config/ConfigControls/ConfigSlider.h
   Config/ControllerInterface/ControllerInterfaceWindow.cpp
   Config/ControllerInterface/ControllerInterfaceWindow.h
   Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
@@ -75,8 +77,6 @@ add_executable(dolphin-emu
   Config/Graphics/GeneralWidget.h
   Config/Graphics/GraphicsInteger.cpp
   Config/Graphics/GraphicsInteger.h
-  Config/Graphics/GraphicsSlider.cpp
-  Config/Graphics/GraphicsSlider.h
   Config/Graphics/GraphicsWidget.h
   Config/Graphics/GraphicsWindow.cpp
   Config/Graphics/GraphicsWindow.h

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "DolphinQt/Config/Graphics/GraphicsSlider.h"
+#include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
 
 #include <QSignalBlocker>
 
@@ -9,7 +9,7 @@
 
 #include "DolphinQt/Settings.h"
 
-GraphicsSlider::GraphicsSlider(int minimum, int maximum, const Config::Info<int>& setting, int tick)
+ConfigSlider::ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting, int tick)
     : ToolTipSlider(Qt::Horizontal), m_setting(setting)
 {
   setMinimum(minimum);
@@ -18,7 +18,7 @@ GraphicsSlider::GraphicsSlider(int minimum, int maximum, const Config::Info<int>
 
   setValue(Config::Get(setting));
 
-  connect(this, &GraphicsSlider::valueChanged, this, &GraphicsSlider::Update);
+  connect(this, &ConfigSlider::valueChanged, this, &ConfigSlider::Update);
 
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     QFont bf = font();
@@ -30,7 +30,7 @@ GraphicsSlider::GraphicsSlider(int minimum, int maximum, const Config::Info<int>
   });
 }
 
-void GraphicsSlider::Update(int value)
+void ConfigSlider::Update(int value)
 {
   Config::SetBaseOrCurrent(m_setting, value);
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
@@ -11,11 +11,11 @@ template <typename T>
 class Info;
 }
 
-class GraphicsSlider : public ToolTipSlider
+class ConfigSlider : public ToolTipSlider
 {
   Q_OBJECT
 public:
-  GraphicsSlider(int minimum, int maximum, const Config::Info<int>& setting, int tick = 0);
+  ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting, int tick = 0);
   void Update(int value);
 
 private:

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -19,8 +19,8 @@
 #include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/ConfigManager.h"
 
+#include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
 #include "DolphinQt/Config/GameConfigEdit.h"
-#include "DolphinQt/Config/Graphics/GraphicsSlider.h"
 
 #include "UICommon/GameFile.h"
 

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -17,7 +17,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
 #include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
-#include "DolphinQt/Config/Graphics/GraphicsSlider.h"
+#include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/Graphics/PostProcessingConfigWindow.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
@@ -160,9 +160,9 @@ void EnhancementsWidget::CreateWidgets()
   m_3d_mode = new ConfigChoice({tr("Off"), tr("Side-by-Side"), tr("Top-and-Bottom"), tr("Anaglyph"),
                                 tr("HDMI 3D"), tr("Passive")},
                                Config::GFX_STEREO_MODE);
-  m_3d_depth = new GraphicsSlider(0, Config::GFX_STEREO_DEPTH_MAXIMUM, Config::GFX_STEREO_DEPTH);
-  m_3d_convergence = new GraphicsSlider(0, Config::GFX_STEREO_CONVERGENCE_MAXIMUM,
-                                        Config::GFX_STEREO_CONVERGENCE, 100);
+  m_3d_depth = new ConfigSlider(0, Config::GFX_STEREO_DEPTH_MAXIMUM, Config::GFX_STEREO_DEPTH);
+  m_3d_convergence = new ConfigSlider(0, Config::GFX_STEREO_CONVERGENCE_MAXIMUM,
+                                      Config::GFX_STEREO_CONVERGENCE, 100);
   m_3d_swap_eyes = new ConfigBool(tr("Swap Eyes"), Config::GFX_STEREO_SWAP_EYES);
 
   stereoscopy_layout->addWidget(new QLabel(tr("Stereoscopic 3D Mode:")), 0, 0);

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -9,7 +9,7 @@
 
 class ConfigBool;
 class ConfigChoice;
-class GraphicsSlider;
+class ConfigSlider;
 class GraphicsWindow;
 class QCheckBox;
 class QComboBox;
@@ -49,8 +49,8 @@ private:
 
   // Stereoscopy
   ConfigChoice* m_3d_mode;
-  GraphicsSlider* m_3d_depth;
-  GraphicsSlider* m_3d_convergence;
+  ConfigSlider* m_3d_depth;
+  ConfigSlider* m_3d_convergence;
   ConfigBool* m_3d_swap_eyes;
 
   int m_msaa_modes;

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -14,7 +14,7 @@
 #include "Core/ConfigManager.h"
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
-#include "DolphinQt/Config/Graphics/GraphicsSlider.h"
+#include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
 #include "DolphinQt/Settings.h"

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -57,6 +57,7 @@
     <ClCompile Include="Config\ConfigControls\ConfigBool.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigChoice.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigRadio.cpp" />
+    <ClCompile Include="Config\ConfigControls\ConfigSlider.cpp" />
     <ClCompile Include="Config\ControllerInterface\ControllerInterfaceWindow.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientWidget.cpp" />
@@ -74,7 +75,6 @@
     <ClCompile Include="Config\Graphics\EnhancementsWidget.cpp" />
     <ClCompile Include="Config\Graphics\GeneralWidget.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsInteger.cpp" />
-    <ClCompile Include="Config\Graphics\GraphicsSlider.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsWindow.cpp" />
     <ClCompile Include="Config\Graphics\HacksWidget.cpp" />
     <ClCompile Include="Config\Graphics\PostProcessingConfigWindow.cpp" />
@@ -258,6 +258,7 @@
     <QtMoc Include="Config\ConfigControls\ConfigBool.h" />
     <QtMoc Include="Config\ConfigControls\ConfigChoice.h" />
     <QtMoc Include="Config\ConfigControls\ConfigRadio.h" />
+    <QtMoc Include="Config\ConfigControls\ConfigSlider.h" />
     <QtMoc Include="Config\ControllerInterface\ControllerInterfaceWindow.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientWidget.h" />
@@ -274,7 +275,6 @@
     <QtMoc Include="Config\Graphics\EnhancementsWidget.h" />
     <QtMoc Include="Config\Graphics\GeneralWidget.h" />
     <QtMoc Include="Config\Graphics\GraphicsInteger.h" />
-    <QtMoc Include="Config\Graphics\GraphicsSlider.h" />
     <QtMoc Include="Config\Graphics\GraphicsWidget.h" />
     <QtMoc Include="Config\Graphics\GraphicsWindow.h" />
     <QtMoc Include="Config\Graphics\HacksWidget.h" />


### PR DESCRIPTION
GraphicsSlider is used by the panes in the Graphics config window to create sliders that change their associated config setting, and update their own state when something else changes the config setting.

Despite its current name nothing about this class is particular to the Graphics window, so renaming it to ConfigSlider better reflects its purpose. This should also make it less confusing when ConfigSliders are added to other config panes.