### PR TITLE
Use std::fpclassify to guard against divisions by zero

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -399,8 +399,8 @@ Common::Quaternion GetRotationFromAcceleration(const Common::Vec3& accel)
 Common::Quaternion GetRotationFromGyroscope(const Common::Vec3& gyro)
 {
   const auto length = gyro.Length();
-  return (length != 0) ? Common::Quaternion::Rotate(length, gyro / length) :
-                         Common::Quaternion::Identity();
+  return (std::fpclassify(length) != FP_ZERO) ? Common::Quaternion::Rotate(length, gyro / length) :
+                                                Common::Quaternion::Identity();
 }
 
 Common::Matrix33 GetRotationalMatrix(const Common::Vec3& angle)

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -206,7 +206,7 @@ static inline void AddScaledIntegerColor(const u8* src, float scale, Vec3& dst)
 
 static inline float SafeDivide(float n, float d)
 {
-  return (d == 0) ? (n > 0 ? 1 : 0) : n / d;
+  return (std::fpclassify(d) == FP_ZERO) ? (n > 0 ? 1 : 0) : n / d;
 }
 
 static float CalculateLightAttn(const LightPointer* light, Vec3* _ldir, const Vec3& normal,

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -705,7 +705,7 @@ void VertexManagerBase::CalculateZSlope(NativeVertexFormat* format)
   float c = -dx12 * dy31 - dx31 * -dy12;
 
   // Sometimes we process de-generate triangles. Stop any divide by zeros
-  if (c == 0)
+  if (std::fpclassify(c) == FP_ZERO)
     return;
 
   m_zslope.dfdx = -a / c;


### PR DESCRIPTION
This is an old snippet of changes I made while playing with -Wfloat-equal in our CMakeLists.txt.  While there are other comparisons against zero in the codebase, these are ones I could tell were explicitly to avoid divisions by zero.  Is this at all valuable?