### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/Source/Core/Common/Thread.cpp
+++ b/Source/Core/Common/Thread.cpp
@@ -200,8 +200,8 @@ std::tuple<void*, size_t> GetCurrentThreadStack()
   stack_t stack;
   pthread_stackseg_np(self, &stack);
 
-  stack_addr = reinterpret_cast<u8*>(stack->ss_sp) - stack->ss_size;
-  stack_size = stack->ss_size;
+  stack_addr = reinterpret_cast<u8*>(stack.ss_sp) - stack.ss_size;
+  stack_size = stack.ss_size;
 #else
   pthread_attr_t attr;
 


### PR DESCRIPTION
86c1f6e1e7e2abcc3f42e1182134e632b218b6d3 introduced code that had not been build tested on OpenBSD.

https://bugs.dolphin-emu.org/issues/13241