### PR TITLE
Qt: Prevent savestate load/save on empty filename

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1352,7 +1352,8 @@ void MainWindow::StateLoad()
   QString path =
       DolphinFileDialog::getOpenFileName(this, tr("Select a File"), QDir::currentPath(),
                                          tr("All Save States (*.sav *.s##);; All Files (*)"));
-  State::LoadAs(path.toStdString());
+  if (!path.isEmpty())
+    State::LoadAs(path.toStdString());
 }
 
 void MainWindow::StateSave()
@@ -1360,7 +1361,8 @@ void MainWindow::StateSave()
   QString path =
       DolphinFileDialog::getSaveFileName(this, tr("Select a File"), QDir::currentPath(),
                                          tr("All Save States (*.sav *.s##);; All Files (*)"));
-  State::SaveAs(path.toStdString());
+  if (!path.isEmpty())
+    State::SaveAs(path.toStdString());
 }
 
 void MainWindow::StateLoadSlot()


### PR DESCRIPTION
This fixes the following behavior I encountered.

1. Emulation > Save State > Save State to File. Close dialog without setting filename
2. Observe on-screen message "Saving state to " (no filepath given), and observe xxxxx.tmp file being created in main Dolphin directory
3. Repeat step 1 and 2 to observe more .tmp files being created
4. Start Movie Recording, repeat step 1 to now also see blank ".dtm" file present

Looks like Dolphin will always write savestate data to a temp file and then try to rename it. Ultimately when the provided filename is blank (because the QFileDialog was closed without the name being set) the rename will fail and the temp file will remain.

I figured this filename check should also be done for the load state scenario, as all this does is prevent a load failure in `LoadAs()`.