### PR TITLE
Common/JitRegister: Move interface into Common namespace

### DIFF
--- a/Source/Core/Common/JitRegister.cpp
+++ b/Source/Core/Common/JitRegister.cpp
@@ -36,7 +36,7 @@ static op_agent_t s_agent = nullptr;
 
 static File::IOFile s_perf_map_file;
 
-namespace JitRegister
+namespace Common::JitRegister
 {
 static bool s_is_enabled = false;
 
@@ -108,4 +108,4 @@ void Register(const void* base_address, u32 code_size, const std::string& symbol
   const auto entry = fmt::format("{} {:x} {}\n", fmt::ptr(base_address), code_size, symbol_name);
   s_perf_map_file.WriteBytes(entry.data(), entry.size());
 }
-}  // namespace JitRegister
+}  // namespace Common::JitRegister

--- a/Source/Core/Common/JitRegister.h
+++ b/Source/Core/Common/JitRegister.h
@@ -9,7 +9,7 @@
 
 #include "Common/CommonTypes.h"
 
-namespace JitRegister
+namespace Common::JitRegister
 {
 void Init(const std::string& perf_dir);
 void Shutdown();
@@ -30,4 +30,4 @@ inline void Register(const void* start, const void* end, fmt::format_string<Args
   u32 code_size = (u32)((const char*)end - (const char*)start);
   Register(start, code_size, fmt::format(format, std::forward<Args>(args)...));
 }
-}  // namespace JitRegister
+}  // namespace Common::JitRegister

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -209,7 +209,7 @@ void Jit64AsmRoutineManager::Generate()
   ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8, 16);
   RET();
 
-  JitRegister::Register(enter_code, GetCodePtr(), "JIT_Loop");
+  Common::JitRegister::Register(enter_code, GetCodePtr(), "JIT_Loop");
 
   GenerateCommon();
 }

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -110,7 +110,7 @@ void CommonAsmRoutines::GenConvertDoubleToSingle()
   OR(32, R(RSCRATCH), R(RSCRATCH2));
   RET();
 
-  JitRegister::Register(start, GetCodePtr(), "JIT_cdts");
+  Common::JitRegister::Register(start, GetCodePtr(), "JIT_cdts");
 }
 
 void CommonAsmRoutines::GenFrsqrte()
@@ -213,7 +213,7 @@ void CommonAsmRoutines::GenFrsqrte()
   ABI_PopRegistersAndAdjustStack(QUANTIZED_REGS_TO_SAVE, 8);
   RET();
 
-  JitRegister::Register(start, GetCodePtr(), "JIT_Frsqrte");
+  Common::JitRegister::Register(start, GetCodePtr(), "JIT_Frsqrte");
 }
 
 void CommonAsmRoutines::GenFres()
@@ -284,7 +284,7 @@ void CommonAsmRoutines::GenFres()
   ABI_PopRegistersAndAdjustStack(QUANTIZED_REGS_TO_SAVE, 8);
   RET();
 
-  JitRegister::Register(start, GetCodePtr(), "JIT_Fres");
+  Common::JitRegister::Register(start, GetCodePtr(), "JIT_Fres");
 }
 
 void CommonAsmRoutines::GenMfcr()
@@ -325,7 +325,7 @@ void CommonAsmRoutines::GenMfcr()
   }
   RET();
 
-  JitRegister::Register(start, GetCodePtr(), "JIT_Mfcr");
+  Common::JitRegister::Register(start, GetCodePtr(), "JIT_Mfcr");
 }
 
 // Safe + Fast Quantizers, originally from JITIL by magumagu
@@ -369,8 +369,8 @@ const u8* CommonAsmRoutines::GenQuantizedStoreRuntime(bool single, EQuantizeType
   const u8* load = AlignCode4();
   GenQuantizedStore(single, type, -1);
   RET();
-  JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedStore_{}_{}", static_cast<u32>(type),
-                        single);
+  Common::JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedStore_{}_{}",
+                                static_cast<u32>(type), single);
 
   return load;
 }
@@ -401,8 +401,8 @@ const u8* CommonAsmRoutines::GenQuantizedLoadRuntime(bool single, EQuantizeType 
   const u8* load = AlignCode4();
   GenQuantizedLoad(single, type, -1);
   RET();
-  JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedLoad_{}_{}", static_cast<u32>(type),
-                        single);
+  Common::JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedLoad_{}_{}",
+                                static_cast<u32>(type), single);
 
   return load;
 }

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -48,7 +48,7 @@ const u8* TrampolineCache::GenerateReadTrampoline(const TrampolineInfo& info)
 
   JMP(info.start + info.len, true);
 
-  JitRegister::Register(trampoline, GetCodePtr(), "JIT_ReadTrampoline_{:x}", info.pc);
+  Common::JitRegister::Register(trampoline, GetCodePtr(), "JIT_ReadTrampoline_{:x}", info.pc);
   return trampoline;
 }
 
@@ -67,6 +67,6 @@ const u8* TrampolineCache::GenerateWriteTrampoline(const TrampolineInfo& info)
 
   JMP(info.start + info.len, true);
 
-  JitRegister::Register(trampoline, GetCodePtr(), "JIT_WriteTrampoline_{:x}", info.pc);
+  Common::JitRegister::Register(trampoline, GetCodePtr(), "JIT_WriteTrampoline_{:x}", info.pc);
   return trampoline;
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -205,7 +205,7 @@ void JitArm64::GenerateAsm()
   ABI_PopRegisters(regs_to_save);
   RET(ARM64Reg::X30);
 
-  JitRegister::Register(enter_code, GetCodePtr(), "JIT_Dispatcher");
+  Common::JitRegister::Register(enter_code, GetCodePtr(), "JIT_Dispatcher");
 
   GenerateCommonAsm();
 
@@ -216,25 +216,25 @@ void JitArm64::GenerateCommonAsm()
 {
   GetAsmRoutines()->fres = GetCodePtr();
   GenerateFres();
-  JitRegister::Register(GetAsmRoutines()->fres, GetCodePtr(), "JIT_fres");
+  Common::JitRegister::Register(GetAsmRoutines()->fres, GetCodePtr(), "JIT_fres");
 
   GetAsmRoutines()->frsqrte = GetCodePtr();
   GenerateFrsqrte();
-  JitRegister::Register(GetAsmRoutines()->frsqrte, GetCodePtr(), "JIT_frsqrte");
+  Common::JitRegister::Register(GetAsmRoutines()->frsqrte, GetCodePtr(), "JIT_frsqrte");
 
   GetAsmRoutines()->cdts = GetCodePtr();
   GenerateConvertDoubleToSingle();
-  JitRegister::Register(GetAsmRoutines()->cdts, GetCodePtr(), "JIT_cdts");
+  Common::JitRegister::Register(GetAsmRoutines()->cdts, GetCodePtr(), "JIT_cdts");
 
   GetAsmRoutines()->cstd = GetCodePtr();
   GenerateConvertSingleToDouble();
-  JitRegister::Register(GetAsmRoutines()->cstd, GetCodePtr(), "JIT_cstd");
+  Common::JitRegister::Register(GetAsmRoutines()->cstd, GetCodePtr(), "JIT_cstd");
 
   GetAsmRoutines()->fprf_single = GetCodePtr();
   GenerateFPRF(true);
   GetAsmRoutines()->fprf_double = GetCodePtr();
   GenerateFPRF(false);
-  JitRegister::Register(GetAsmRoutines()->fprf_single, GetCodePtr(), "JIT_FPRF");
+  Common::JitRegister::Register(GetAsmRoutines()->fprf_single, GetCodePtr(), "JIT_FPRF");
 
   GenerateQuantizedLoads();
   GenerateQuantizedStores();
@@ -677,7 +677,7 @@ void JitArm64::GenerateQuantizedLoads()
     RET(ARM64Reg::X30);
   }
 
-  JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedLoad");
+  Common::JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedLoad");
 
   paired_load_quantized = reinterpret_cast<const u8**>(AlignCode16());
   ReserveCodeSpace(8 * sizeof(u8*));
@@ -896,7 +896,7 @@ void JitArm64::GenerateQuantizedStores()
     RET(ARM64Reg::X30);
   }
 
-  JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedStore");
+  Common::JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedStore");
 
   paired_store_quantized = reinterpret_cast<const u8**>(AlignCode16());
   ReserveCodeSpace(8 * sizeof(u8*));

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -40,14 +40,14 @@ JitBaseBlockCache::~JitBaseBlockCache() = default;
 
 void JitBaseBlockCache::Init()
 {
-  JitRegister::Init(Config::Get(Config::MAIN_PERF_MAP_DIR));
+  Common::JitRegister::Init(Config::Get(Config::MAIN_PERF_MAP_DIR));
 
   Clear();
 }
 
 void JitBaseBlockCache::Shutdown()
 {
-  JitRegister::Shutdown();
+  Common::JitRegister::Shutdown();
 }
 
 // This clears the JIT cache. It's called from JitCache.cpp when the JIT cache
@@ -129,16 +129,16 @@ void JitBaseBlockCache::FinalizeBlock(JitBlock& block, bool block_link,
   }
 
   Common::Symbol* symbol = nullptr;
-  if (JitRegister::IsEnabled() &&
+  if (Common::JitRegister::IsEnabled() &&
       (symbol = g_symbolDB.GetSymbolFromAddr(block.effectiveAddress)) != nullptr)
   {
-    JitRegister::Register(block.checkedEntry, block.codeSize, "JIT_PPC_{}_{:08x}",
-                          symbol->function_name.c_str(), block.physicalAddress);
+    Common::JitRegister::Register(block.checkedEntry, block.codeSize, "JIT_PPC_{}_{:08x}",
+                                  symbol->function_name.c_str(), block.physicalAddress);
   }
   else
   {
-    JitRegister::Register(block.checkedEntry, block.codeSize, "JIT_PPC_{:08x}",
-                          block.physicalAddress);
+    Common::JitRegister::Register(block.checkedEntry, block.codeSize, "JIT_PPC_{:08x}",
+                                  block.physicalAddress);
   }
 }
 

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -51,8 +51,8 @@ VertexLoaderX64::VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att)
   GenerateVertexLoader();
   WriteProtect();
 
-  JitRegister::Register(region, GetCodePtr(), "VertexLoaderX64\nVtx desc: \n{}\nVAT:\n{}", vtx_desc,
-                        vtx_att);
+  Common::JitRegister::Register(region, GetCodePtr(), "VertexLoaderX64\nVtx desc: \n{}\nVAT:\n{}",
+                                vtx_desc, vtx_att);
 }
 
 OpArg VertexLoaderX64::GetVertexAddr(CPArray array, VertexComponentFormat attribute)


### PR DESCRIPTION
Makes the namespace consistent with other common utilities.