### PR TITLE
Revert "DolphinQt: use default dpi rounding mode (passthrough)"

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -147,6 +147,15 @@ int main(int argc, char* argv[])
 #endif
 #endif
 
+  // setHighDpiScaleFactorRoundingPolicy was added in 5.14, but default behavior changed in 6.0
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+  // Set to the previous default behavior
+  QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
+#else
+  QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+
   QCoreApplication::setOrganizationName(QStringLiteral("Dolphin Emulator"));
   QCoreApplication::setOrganizationDomain(QStringLiteral("dolphin-emu.org"));
   QCoreApplication::setApplicationName(QStringLiteral("dolphin-emu"));


### PR DESCRIPTION
This reverts commit cfe36836688ae21ae32383958504fbc5f6c21660 (PR #11788).

On Windows systems with 125% DPI scaling, this was causing both icons and the OSD to be upscaled by 25% using nearest neighbor scaling, which looks really bad. @shuffle2 has said that this will be improved later, but we should revert it for now for the sake of the upcoming beta build.