### PR TITLE
PPCSymbolDB: Use emplace() where applicable

### DIFF
--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -37,6 +37,9 @@ struct Symbol
     Data,
   };
 
+  Symbol() = default;
+  explicit Symbol(const std::string& name) { Rename(name); }
+
   void Rename(const std::string& symbol_name);
 
   std::string name;

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -67,12 +67,9 @@ void PPCSymbolDB::AddKnownSymbol(const Core::CPUThreadGuard& guard, u32 startAdd
   else
   {
     // new symbol. run analyze.
-    Common::Symbol tf;
-    tf.Rename(name);
-    tf.type = type;
-    tf.address = startAddr;
-
-    auto& new_symbol = m_functions.emplace(startAddr, std::move(tf)).first->second;
+    auto& new_symbol = m_functions.emplace(startAddr, name).first->second;
+    new_symbol.type = type;
+    new_symbol.address = startAddr;
 
     if (new_symbol.type == Common::Symbol::Type::Function)
     {


### PR DESCRIPTION
Avoids default constructing an entry in the map that just gets immediately overwritten. Also gets rid of some redundant map lookups.