### PR TITLE
GameINI: Enable bounding box for "Solitaire & Mahjong"

### DIFF
--- a/Data/Sys/GameSettings/RSO.ini
+++ b/Data/Sys/GameSettings/RSO.ini
@@ -1,0 +1,17 @@
+# RSOE4Z, RSOP4Z - Solitaire & Mahjong
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+BBoxEnable = True
+ImmediateXFBEnable = False

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -136,7 +136,7 @@ void DolphinAnalytics::ReportGameStart()
 }
 
 // Keep in sync with enum class GameQuirk definition.
-constexpr std::array<const char*, 27> GAME_QUIRKS_NAMES{
+constexpr std::array<const char*, 28> GAME_QUIRKS_NAMES{
     "directly-reads-wiimote-input",
     "uses-DVDLowStopLaser",
     "uses-DVDLowOffset",
@@ -164,6 +164,7 @@ constexpr std::array<const char*, 27> GAME_QUIRKS_NAMES{
     "mismatched-gpu-normals-between-cp-and-xf",
     "mismatched-gpu-tex-coords-between-cp-and-xf",
     "mismatched-gpu-matrix-indices-between-cp-and-xf",
+    "reads-bounding-box",
 };
 static_assert(GAME_QUIRKS_NAMES.size() == static_cast<u32>(GameQuirk::COUNT),
               "Game quirks names and enum definition are out of sync.");

--- a/Source/Core/Core/DolphinAnalytics.h
+++ b/Source/Core/Core/DolphinAnalytics.h
@@ -89,6 +89,11 @@ enum class GameQuirk
   // but testing is needed to find out which of these is actually used for what.
   MISMATCHED_GPU_MATRIX_INDICES_BETWEEN_CP_AND_XF,
 
+  // Only a few games use the Bounding Box feature. Note that every game initializes the bounding
+  // box registers (using BPMEM_CLEARBBOX1/BPMEM_CLEARBBOX2) on startup, as part of the SDK, but
+  // only a few read them (from PE_BBOX_LEFT etc.)
+  READS_BOUNDING_BOX,
+
   COUNT,
 };
 

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -20,6 +20,7 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/DolphinAnalytics.h"
 #include "Core/System.h"
 
 // TODO: ugly
@@ -171,6 +172,8 @@ u32 VideoBackendBase::Video_GetQueryResult(PerfQueryType type)
 
 u16 VideoBackendBase::Video_GetBoundingBox(int index)
 {
+  DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::READS_BOUNDING_BOX);
+
   if (!g_ActiveConfig.bBBoxEnable)
   {
     static bool warn_once = true;


### PR DESCRIPTION
See https://bugs.dolphin-emu.org/issues/13248.

Before:
![RSOE4Z_2023-05-06_18-11-04](https://user-images.githubusercontent.com/8334194/236652801-c348d10c-92a5-4734-80dc-609513beb496.png)
![RSOE4Z_2023-05-06_18-11-37](https://user-images.githubusercontent.com/8334194/236652802-e6a7f141-8f2a-4fdc-92bb-f9934cd35d11.png)

After:
![RSOE4Z_2023-05-06_18-10-06](https://user-images.githubusercontent.com/8334194/236652798-50e4447a-b71d-4ad1-85ea-d6f85ba37d1e.png)
![RSOE4Z_2023-05-06_18-10-34](https://user-images.githubusercontent.com/8334194/236652800-387c9f22-9ff9-4174-8f66-afce0f3487c4.png)


You can also see the menu performance before in [this video](https://www.youtube.com/watch?v=mxlwQfDiQzg) (which was coincidentally uploaded a day ago).

This game is doing several weird rendering things which I'll need to investigate further. I *also* encountered the game hanging (though music still played) after I failed, but I haven't been able to consistently reproduce it.