### PR TITLE
Add CPUCull to Pokemon Colosseum and Pokemon XD inis.

### DIFF
--- a/Data/Sys/GameSettings/GC6.ini
+++ b/Data/Sys/GameSettings/GC6.ini
@@ -14,3 +14,7 @@
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
+# Many areas of the game have unused vertexes, especially with cutscenes
+# involving Shadow Pokémon, such as the purification cutscene.
+# CPU Cull ends up greatly boosting performance for these cases. 
+CPUCull = True

--- a/Data/Sys/GameSettings/GXX.ini
+++ b/Data/Sys/GameSettings/GXX.ini
@@ -19,3 +19,7 @@ MMU = True
 [Video_Settings]
 # Fixes garbled text.
 SafeTextureCacheColorSamples = 0
+# Many areas of the game have unused vertexes, especially with cutscenes
+# involving Shadow Pokémon, such as the purification cutscene.
+# CPU Cull ends up greatly boosting performance for these cases. 
+CPUCull = True


### PR DESCRIPTION
These games seem to constantly have unused vertices, and this is worst shown in the Shadow Pokemon purification cutscene. The Shadow Pokemon purification cutscene is even worse on XD with forced single core mode, as instead of having FPS dropping with VPS staying 60ish, it will drop both, resulting in audio stuttering. Turning on CPUCall seems to have a 7/8 reduction of draw calls for that cutscene (~800 -> ~100), doubling performance (~70% max to ~150% max on my setup). Many other areas of the game seem to benefit from this setting too, having some kind of performance boost (although this is best seen in 60 FPS areas as the 30 FPS areas generally don't struggle)