### PR TITLE
Common/MemArenaWin: Improve file mapping logic.

### DIFF
--- a/Source/Core/Common/MemArena.h
+++ b/Source/Core/Common/MemArena.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string_view>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -34,8 +35,10 @@ public:
   /// CreateView() and ReleaseView(). Used to make a mappable region for emulated memory.
   ///
   /// @param size The amount of bytes that should be allocated in this region.
+  /// @param base_name A base name for the shared memory region, if applicable for this platform.
+  /// Will be extended with the process ID.
   ///
-  void GrabSHMSegment(size_t size);
+  void GrabSHMSegment(size_t size, std::string_view base_name);
 
   ///
   /// Release the memory segment previously allocated with GrabSHMSegment().

--- a/Source/Core/Common/MemArenaAndroid.cpp
+++ b/Source/Core/Common/MemArenaAndroid.cpp
@@ -10,6 +10,8 @@
 #include <set>
 #include <string>
 
+#include <fmt/format.h>
+
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <linux/ashmem.h>
@@ -62,9 +64,10 @@ static int AshmemCreateFileMapping(const char* name, size_t size)
 MemArena::MemArena() = default;
 MemArena::~MemArena() = default;
 
-void MemArena::GrabSHMSegment(size_t size)
+void MemArena::GrabSHMSegment(size_t size, std::string_view base_name)
 {
-  m_shm_fd = AshmemCreateFileMapping(("dolphin-emu." + std::to_string(getpid())).c_str(), size);
+  const std::string name = fmt::format("{}.{}", base_name, getpid());
+  m_shm_fd = AshmemCreateFileMapping(name.c_str(), size);
   if (m_shm_fd < 0)
     NOTICE_LOG_FMT(MEMMAP, "Ashmem allocation failed");
 }

--- a/Source/Core/Common/MemArenaUnix.cpp
+++ b/Source/Core/Common/MemArenaUnix.cpp
@@ -10,6 +10,8 @@
 #include <set>
 #include <string>
 
+#include <fmt/format.h>
+
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -25,9 +27,9 @@ namespace Common
 MemArena::MemArena() = default;
 MemArena::~MemArena() = default;
 
-void MemArena::GrabSHMSegment(size_t size)
+void MemArena::GrabSHMSegment(size_t size, std::string_view base_name)
 {
-  const std::string file_name = "/dolphin-emu." + std::to_string(getpid());
+  const std::string file_name = fmt::format("/{}.{}", base_name, getpid());
   m_shm_fd = shm_open(file_name.c_str(), O_RDWR | O_CREAT | O_EXCL, 0600);
   if (m_shm_fd == -1)
   {

--- a/Source/Core/Common/MemArenaWin.cpp
+++ b/Source/Core/Common/MemArenaWin.cpp
@@ -8,6 +8,8 @@
 #include <cstdlib>
 #include <string>
 
+#include <fmt/format.h>
+
 #include <windows.h>
 
 #include "Common/Assert.h"
@@ -107,9 +109,9 @@ static DWORD GetLowDWORD(u64 value)
   return static_cast<DWORD>(value);
 }
 
-void MemArena::GrabSHMSegment(size_t size)
+void MemArena::GrabSHMSegment(size_t size, std::string_view base_name)
 {
-  const std::string name = "dolphin-emu." + std::to_string(GetCurrentProcessId());
+  const std::string name = fmt::format("{}.{}", base_name, GetCurrentProcessId());
   m_memory_handle =
       CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, GetHighDWORD(size),
                         GetLowDWORD(size), UTF8ToTStr(name).c_str());

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -121,7 +121,7 @@ void MemoryManager::Init()
     region.active = true;
     mem_size += region.size;
   }
-  m_arena.GrabSHMSegment(mem_size);
+  m_arena.GrabSHMSegment(mem_size, "dolphin-emu");
 
   m_physical_page_mappings.fill(nullptr);
 


### PR DESCRIPTION
Noticed this while reviewing #11737.

First commit: Both [CreateFileMapping](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw) and [MapViewOfFileEx](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffileex) want their memory size/offset (respectively) as two separate high bits and low bits parameters, for what I assume are ancient legacy reasons.

Second commit: The last parameter of [CreateFileMapping](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw) is a name so that other functions can find this memory mapping using the same name. This is explicitly what we not want and it can be set to NULL to not give it a findable name, so let's just do that.

With these commits #11737 behaves correctly on Windows, before I was not seeing the supposed performance improvements (probably because something with the memory mapping failed).