### PR TITLE
CMake: Set --output-on-failure flag for unittests target.

### DIFF
--- a/Source/UnitTests/CMakeLists.txt
+++ b/Source/UnitTests/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_testing()
 add_custom_target(unittests)
-add_custom_command(TARGET unittests POST_BUILD COMMAND ${CMAKE_CTEST_COMMAND})
+add_custom_command(TARGET unittests POST_BUILD COMMAND ${CMAKE_CTEST_COMMAND} "--output-on-failure")
 
 string(APPEND CMAKE_RUNTIME_OUTPUT_DIRECTORY "/Tests")
 


### PR DESCRIPTION
So you can actually see which test case fails in the buildbot output.

https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-output-on-failure