### PR TITLE
Common/StringUtil: Move some utilities into the Common namespace

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -77,7 +77,7 @@ std::string HexDump(const u8* data, size_t size)
       if (row_start + i < size)
       {
         char c = static_cast<char>(data[row_start + i]);
-        out += IsPrintableCharacter(c) ? c : '.';
+        out += Common::IsPrintableCharacter(c) ? c : '.';
       }
     }
     out += "\n";

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -675,6 +675,8 @@ std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line)
 }
 #endif
 
+namespace Common
+{
 std::string GetEscapedHtml(std::string html)
 {
   static constexpr std::array<std::array<const char*, 2>, 5> replacements{{
@@ -693,8 +695,6 @@ std::string GetEscapedHtml(std::string html)
   return html;
 }
 
-namespace Common
-{
 void ToLower(std::string* str)
 {
   std::transform(str->begin(), str->end(), str->begin(), [](char c) { return Common::ToLower(c); });

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -656,6 +656,8 @@ std::string PathToString(const std::filesystem::path& path)
 #endif
 }
 
+namespace Common
+{
 #ifdef _WIN32
 std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line)
 {
@@ -675,8 +677,6 @@ std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line)
 }
 #endif
 
-namespace Common
-{
 std::string GetEscapedHtml(std::string html)
 {
   static constexpr std::array<std::array<const char*, 2>, 5> replacements{{

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -238,14 +238,6 @@ inline bool IsPrintableCharacter(char c)
   return std::isprint(c, std::locale::classic());
 }
 
-/// Returns whether a character is a letter, i.e. whether 'a' <= c <= 'z' || 'A' <= c <= 'Z'
-/// is true. Use this instead of calling std::isalpha directly to ensure
-/// the C locale is being used and to avoid possibly undefined behaviour.
-inline bool IsAlpha(char c)
-{
-  return std::isalpha(c, std::locale::classic());
-}
-
 #ifdef _WIN32
 std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
 #endif
@@ -254,14 +246,24 @@ std::string GetEscapedHtml(std::string html);
 
 namespace Common
 {
+/// Returns whether a character is a letter, i.e. whether 'a' <= c <= 'z' || 'A' <= c <= 'Z'
+/// is true. Use this instead of calling std::isalpha directly to ensure
+/// the C locale is being used and to avoid possibly undefined behaviour.
+inline bool IsAlpha(char c)
+{
+  return std::isalpha(c, std::locale::classic());
+}
+
 inline char ToLower(char ch)
 {
   return std::tolower(ch, std::locale::classic());
 }
+
 inline char ToUpper(char ch)
 {
   return std::toupper(ch, std::locale::classic());
 }
+
 void ToLower(std::string* str);
 void ToUpper(std::string* str);
 bool CaseInsensitiveEquals(std::string_view a, std::string_view b);

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -230,10 +230,6 @@ std::string ThousandSeparate(I value, int spaces = 0)
 #endif
 }
 
-#ifdef _WIN32
-std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
-#endif
-
 namespace Common
 {
 /// Returns whether a character is printable, i.e. whether 0x20 <= c <= 0x7e is true.
@@ -261,6 +257,10 @@ inline char ToUpper(char ch)
 {
   return std::toupper(ch, std::locale::classic());
 }
+
+#ifdef _WIN32
+std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
+#endif
 
 std::string GetEscapedHtml(std::string html);
 

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -230,14 +230,6 @@ std::string ThousandSeparate(I value, int spaces = 0)
 #endif
 }
 
-/// Returns whether a character is printable, i.e. whether 0x20 <= c <= 0x7e is true.
-/// Use this instead of calling std::isprint directly to ensure
-/// the C locale is being used and to avoid possibly undefined behaviour.
-inline bool IsPrintableCharacter(char c)
-{
-  return std::isprint(c, std::locale::classic());
-}
-
 #ifdef _WIN32
 std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
 #endif
@@ -246,6 +238,14 @@ std::string GetEscapedHtml(std::string html);
 
 namespace Common
 {
+/// Returns whether a character is printable, i.e. whether 0x20 <= c <= 0x7e is true.
+/// Use this instead of calling std::isprint directly to ensure
+/// the C locale is being used and to avoid possibly undefined behaviour.
+inline bool IsPrintableCharacter(char c)
+{
+  return std::isprint(c, std::locale::classic());
+}
+
 /// Returns whether a character is a letter, i.e. whether 'a' <= c <= 'z' || 'A' <= c <= 'Z'
 /// is true. Use this instead of calling std::isalpha directly to ensure
 /// the C locale is being used and to avoid possibly undefined behaviour.

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -234,8 +234,6 @@ std::string ThousandSeparate(I value, int spaces = 0)
 std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
 #endif
 
-std::string GetEscapedHtml(std::string html);
-
 namespace Common
 {
 /// Returns whether a character is printable, i.e. whether 0x20 <= c <= 0x7e is true.
@@ -263,6 +261,8 @@ inline char ToUpper(char ch)
 {
   return std::toupper(ch, std::locale::classic());
 }
+
+std::string GetEscapedHtml(std::string html);
 
 void ToLower(std::string* str);
 void ToUpper(std::string* str);

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -211,25 +211,6 @@ inline std::string UTF8ToTStr(std::string_view str)
 std::filesystem::path StringToPath(std::string_view path);
 std::string PathToString(const std::filesystem::path& path);
 
-// Thousand separator. Turns 12345678 into 12,345,678
-template <typename I>
-std::string ThousandSeparate(I value, int spaces = 0)
-{
-#ifdef _WIN32
-  std::wostringstream stream;
-#else
-  std::ostringstream stream;
-#endif
-
-  stream << std::setw(spaces) << value;
-
-#ifdef _WIN32
-  return WStringToUTF8(stream.str());
-#else
-  return stream.str();
-#endif
-}
-
 namespace Common
 {
 /// Returns whether a character is printable, i.e. whether 0x20 <= c <= 0x7e is true.
@@ -256,6 +237,25 @@ inline char ToLower(char ch)
 inline char ToUpper(char ch)
 {
   return std::toupper(ch, std::locale::classic());
+}
+
+// Thousand separator. Turns 12345678 into 12,345,678
+template <typename I>
+std::string ThousandSeparate(I value, int spaces = 0)
+{
+#ifdef _WIN32
+  std::wostringstream stream;
+#else
+  std::ostringstream stream;
+#endif
+
+  stream << std::setw(spaces) << value;
+
+#ifdef _WIN32
+  return WStringToUTF8(stream.str());
+#else
+  return stream.str();
+#endif
 }
 
 #ifdef _WIN32

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -193,7 +193,7 @@ void DisplayMessage(std::string message, int time_in_ms)
     return;
 
   // Actually displaying non-ASCII could cause things to go pear-shaped
-  if (!std::all_of(message.begin(), message.end(), IsPrintableCharacter))
+  if (!std::all_of(message.begin(), message.end(), Common::IsPrintableCharacter))
     return;
 
   OSD::AddMessage(std::move(message), time_in_ms);

--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -77,7 +77,7 @@ void FileLogger::Log(const DiscIO::Volume& volume, const DiscIO::Partition& part
   if (m_previous_partition == partition && m_previous_file_offset == file_offset)
     return;
 
-  const std::string size_string = ThousandSeparate(file_info->GetSize() / 1000, 7);
+  const std::string size_string = Common::ThousandSeparate(file_info->GetSize() / 1000, 7);
   const std::string path = file_info->GetPath();
   const std::string log_string = fmt::format("{} kB {}", size_string, path);
   if (IsSoundFile(path))

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -302,7 +302,7 @@ std::string TMDReader::GetGameID() const
   std::memcpy(game_id, m_bytes.data() + offsetof(TMDHeader, title_id) + 4, 4);
   std::memcpy(game_id + 4, m_bytes.data() + offsetof(TMDHeader, group_id), 2);
 
-  if (std::all_of(std::begin(game_id), std::end(game_id), IsPrintableCharacter))
+  if (std::all_of(std::begin(game_id), std::end(game_id), Common::IsPrintableCharacter))
     return std::string(game_id, sizeof(game_id));
 
   return fmt::format("{:016x}", GetTitleId());
@@ -313,7 +313,7 @@ std::string TMDReader::GetGameTDBID() const
   const u8* begin = m_bytes.data() + offsetof(TMDHeader, title_id) + 4;
   const u8* end = begin + 4;
 
-  if (std::all_of(begin, end, IsPrintableCharacter))
+  if (std::all_of(begin, end, Common::IsPrintableCharacter))
     return std::string(begin, end);
 
   return fmt::format("{:016x}", GetTitleId());

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -474,8 +474,11 @@ ResultCode HostFileSystem::Format(Uid uid)
 ResultCode HostFileSystem::CreateFileOrDirectory(Uid uid, Gid gid, const std::string& path,
                                                  FileAttribute attr, Modes modes, bool is_file)
 {
-  if (!IsValidNonRootPath(path) || !std::all_of(path.begin(), path.end(), IsPrintableCharacter))
+  if (!IsValidNonRootPath(path) ||
+      !std::all_of(path.begin(), path.end(), Common::IsPrintableCharacter))
+  {
     return ResultCode::Invalid;
+  }
 
   if (!is_file && std::count(path.begin(), path.end(), '/') > int(MaxPathDepth))
     return ResultCode::TooManyPathComponents;

--- a/Source/Core/Core/IOS/USB/USBV4.cpp
+++ b/Source/Core/Core/IOS/USB/USBV4.cpp
@@ -87,7 +87,7 @@ void V4GetUSStringMessage::OnTransferComplete(s32 return_value) const
   auto& memory = system.GetMemory();
 
   std::string message = memory.GetString(data_address);
-  std::replace_if(message.begin(), message.end(), std::not_fn(IsPrintableCharacter), '?');
+  std::replace_if(message.begin(), message.end(), std::not_fn(Common::IsPrintableCharacter), '?');
   memory.CopyToEmu(data_address, message.c_str(), message.size());
   TransferCommand::OnTransferComplete(return_value);
 }

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -256,7 +256,7 @@ std::string VolumeWAD::GetMakerID(const Partition& partition) const
     return "00";
 
   // Some weird channels use 0x0000 in place of the MakerID, so we need a check here
-  if (!IsPrintableCharacter(temp[0]) || !IsPrintableCharacter(temp[1]))
+  if (!Common::IsPrintableCharacter(temp[0]) || !Common::IsPrintableCharacter(temp[1]))
     return "00";
 
   return DecodeString(temp);

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -316,7 +316,7 @@ int main(int argc, char* argv[])
 #ifdef _WIN32
 int wmain(int, wchar_t*[], wchar_t*[])
 {
-  std::vector<std::string> args = CommandLineToUtf8Argv(GetCommandLineW());
+  std::vector<std::string> args = Common::CommandLineToUtf8Argv(GetCommandLineW());
   const int argc = static_cast<int>(args.size());
   std::vector<char*> argv(args.size());
   for (size_t i = 0; i < args.size(); ++i)

--- a/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
@@ -168,7 +168,7 @@ void FilesystemWidget::PopulateDirectory(int partition_id, QStandardItem* root,
     for (u32 i = 0; i < 4; i++)
     {
       char c = static_cast<char>(title_id.value() >> 8 * (3 - i));
-      if (IsPrintableCharacter(c))
+      if (Common::IsPrintableCharacter(c))
         text += QLatin1Char(c);
       else
         text += QLatin1Char('.');

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -495,8 +495,8 @@ QString MemoryViewWidget::ValueToString(const Core::CPUThreadGuard& guard, u32 a
   case Type::ASCII:
   {
     const char value = accessors->ReadU8(guard, address);
-    return IsPrintableCharacter(value) ? QString{QChar::fromLatin1(value)} :
-                                         QString{QChar::fromLatin1('.')};
+    return Common::IsPrintableCharacter(value) ? QString{QChar::fromLatin1(value)} :
+                                                 QString{QChar::fromLatin1('.')};
   }
   case Type::Hex16:
   {

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -306,7 +306,7 @@ int main(int argc, char* argv[])
 #ifdef _WIN32
 int WINAPI wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int)
 {
-  std::vector<std::string> args = CommandLineToUtf8Argv(GetCommandLineW());
+  std::vector<std::string> args = Common::CommandLineToUtf8Argv(GetCommandLineW());
   const int argc = static_cast<int>(args.size());
   std::vector<char*> argv(args.size());
   for (size_t i = 0; i < args.size(); ++i)

--- a/Source/Core/DolphinTool/ToolMain.cpp
+++ b/Source/Core/DolphinTool/ToolMain.cpp
@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
 #ifdef _WIN32
 int wmain(int, wchar_t*[], wchar_t*[])
 {
-  std::vector<std::string> args = CommandLineToUtf8Argv(GetCommandLineW());
+  std::vector<std::string> args = Common::CommandLineToUtf8Argv(GetCommandLineW());
   const int argc = static_cast<int>(args.size());
   std::vector<char*> argv(args.size());
   for (size_t i = 0; i < args.size(); ++i)

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -43,7 +43,7 @@ std::string GetExpressionForControl(const std::string& control_name,
   {
     // If our expression contains any non-alpha characters
     // we should quote it
-    if (!std::all_of(expr.begin(), expr.end(), IsAlpha))
+    if (!std::all_of(expr.begin(), expr.end(), Common::IsAlpha))
       expr = fmt::format("`{}`", expr);
   }
 

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -118,7 +118,7 @@ std::string GenerateChangelog(const picojson::array& versions)
         changelog += ver_obj["shortrev"].get<std::string>();
       }
       const std::string escaped_description =
-          GetEscapedHtml(ver_obj["short_descr"].get<std::string>());
+          Common::GetEscapedHtml(ver_obj["short_descr"].get<std::string>());
       changelog += " by <a href = \"" + ver_obj["author_url"].get<std::string>() + "\">" +
                    ver_obj["author"].get<std::string>() + "</a> &mdash; " + escaped_description;
     }

--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -62,7 +62,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     return 0;
   }
 
-  std::vector<std::string> args = CommandLineToUtf8Argv(pCmdLine);
+  std::vector<std::string> args = Common::CommandLineToUtf8Argv(pCmdLine);
 
   return RunUpdater(args) ? 0 : 1;
 }

--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -86,7 +86,7 @@ TEST(StringUtil, GetEscapedHtml)
   static constexpr auto no_escape_needed =
       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
       "!@#$%^*()-_=+,./?;:[]{}| \\\t\n";
-  EXPECT_EQ(GetEscapedHtml(no_escape_needed), no_escape_needed);
-  EXPECT_EQ(GetEscapedHtml("&<>'\""), "&amp;&lt;&gt;&apos;&quot;");
-  EXPECT_EQ(GetEscapedHtml("&&&"), "&amp;&amp;&amp;");
+  EXPECT_EQ(Common::GetEscapedHtml(no_escape_needed), no_escape_needed);
+  EXPECT_EQ(Common::GetEscapedHtml("&<>'\""), "&amp;&lt;&gt;&apos;&quot;");
+  EXPECT_EQ(Common::GetEscapedHtml("&&&"), "&amp;&amp;&amp;");
 }


### PR DESCRIPTION
Moves a few of the lightly used utilities into the Common namespace to get them out of global scope. This doesn't touch all of the utility functions, since a few are heavily used and best suited to their own PR