### PR TITLE
update to VS 17.6

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,9 +39,10 @@ Dolphin can only be installed on devices that satisfy the above requirements. At
 ## Building for Windows
 
 Use the solution file `Source/dolphin-emu.sln` to build Dolphin on Windows.
-Visual Studio 2022 17.2.3 or later is a hard requirement. Other compilers might be
-able to build Dolphin on Windows but have not been tested and are not
-recommended to be used. Git and Windows 11 SDK must be installed when building.
+Dolphin targets the latest MSVC shipped with Visual Studio or Build Tools.
+Other compilers might be able to build Dolphin on Windows but have not been
+tested and are not recommended to be used. Git and latest Windows SDK must be
+installed when building.
 
 Make sure to pull submodules before building:
 ```sh

--- a/Source/Core/Common/build_info.txt.in
+++ b/Source/Core/Common/build_info.txt.in
@@ -19,5 +19,5 @@ OSMinimumVersionWin11=10.0.22000.0
 //   VCToolsVersion=14.33.31629
 // We're really looking for "14.32.31332.0" (because that's what will appear in the registry once
 // installed), NOT the other values!
-VCToolsVersion=14.34.31931.0
+VCToolsVersion=${VC_TOOLS_VERSION}
 VCToolsUpdateURL=https://aka.ms/vs/17/release/vc_redist.x64.exe

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -1355,9 +1355,7 @@ void ZeldaAudioRenderer::FetchVPB(u16 voice_id, VPB* vpb)
 void ZeldaAudioRenderer::StoreVPB(u16 voice_id, VPB* vpb)
 {
   u16* vpb_words = (u16*)vpb;
-  // volatile is a workaround for msvc optimizer bug, see
-  // https://developercommunity.visualstudio.com/t/VS-175-bad-codegen-optimizing-loop-with/10291620
-  volatile u16* ram_vpbs = (u16*)HLEMemory_Get_Pointer(m_vpb_base_addr);
+  u16* ram_vpbs = (u16*)HLEMemory_Get_Pointer(m_vpb_base_addr);
 
   size_t vpb_size = (m_flags & TINY_VPB) ? 0x80 : 0xC0;
   size_t base_idx = voice_id * vpb_size;

--- a/Source/PCH/pch.h
+++ b/Source/PCH/pch.h
@@ -6,7 +6,7 @@
 #define STRINGIFY_HELPER(x) #x
 #define STRINGIFY(x) STRINGIFY_HELPER(x)
 
-#if defined _MSC_FULL_VER && _MSC_FULL_VER < 193532215
+#if defined _MSC_FULL_VER && _MSC_FULL_VER < 193632532
 #pragma message("Current _MSC_FULL_VER: " STRINGIFY(_MSC_FULL_VER))
 #error Please update your build environment to the latest Visual Studio 2022!
 #endif


### PR DESCRIPTION
bump minimum VS version to 17.6 and rollback some workarounds

I'll re-enable auto updates on the buildbot once beta is built (is it built already?)