### PR TITLE
Android: Don't show analytics dialog for destroyed activity

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.kt
@@ -20,7 +20,7 @@ object Analytics {
 
     @JvmStatic
     fun checkAnalyticsInit(activity: FragmentActivity) {
-        AfterDirectoryInitializationRunner().runWithoutLifecycle {
+        AfterDirectoryInitializationRunner().runWithLifecycle(activity) {
             if (!BooleanSetting.MAIN_ANALYTICS_PERMISSION_ASKED.boolean) {
                 AnalyticsDialog().show(activity.supportFragmentManager, AnalyticsDialog.TAG)
             }


### PR DESCRIPTION
Should fix one of the reported crashes on Google Play. The issue can happen if you leave the activity during directory initialization.