### PR TITLE
Silence AES warning

### DIFF
--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -51,7 +51,6 @@ private:
   std::string m_device_name;
 
   std::unique_ptr<Common::AES::Context> m_aes_ctx{};
-  u8 m_aes_key[0x10] = {};
   u8 m_aes_iv[0x10] = {};
 
   ES::TMDReader m_tmd;


### PR DESCRIPTION
This warning came about after 46ad8b9d68b7eff720a6f33e6029ddd36ab8edaa

```
In file included from /home/ports/pobj/dolphin-5.0.0.20230429/dolphin-5.0.0.20230429/Source/Core/Core/IOS/WFS/WFSI.cpp:4: /home/ports/pobj/dolphin-5.0.0.20230429/dolphin-5.0.0.20230429/Source/Core/Core/IOS/WFS/WFSI.h:54:6: warning: private field 'm_aes_key' is not used [-Wunused-private-field]
  u8 m_aes_key[0x10] = {};
     ^
```