### PR TITLE
Fix s_using_custom_client warning with DiscordPresence

### DIFF
--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -25,9 +25,9 @@
 
 namespace Discord
 {
+#ifdef USE_DISCORD_PRESENCE
 static bool s_using_custom_client = false;
 
-#ifdef USE_DISCORD_PRESENCE
 namespace
 {
 Handler* event_handler = nullptr;


### PR DESCRIPTION
```
/home/ports/pobj/dolphin-5.0.0.20230429/dolphin-5.0.0.20230429/Source/Core/UICommon/DiscordPresence.cpp:27:13: warning: unused variable 's_using_custom_client' [-Wunused-variable]
static bool s_using_custom_client = false;
            ^
```