### PR TITLE
msvc: disable building std modules

### DIFF
--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -30,6 +30,7 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <!--Enable latest C++ standard-->
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <BuildStlModules>false</BuildStlModules>
       <!--Enable Standard Conformance-->
       <ConformanceMode>true</ConformanceMode>
       <!--Enforce some behaviors as standards-conformant when they don't default as such.-->


### PR DESCRIPTION
fixes build failures related to pch (supposedly, i haven't noticed the error locally)

https://stackoverflow.com/a/76316717/375416