### PR TITLE
Add hotkey to open Skylanders and Infinity Menus

### DIFF
--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -194,6 +194,9 @@ constexpr std::array<const char*, NUM_HOTKEYS> s_hotkey_labels{{
     _trans("2x"),
     _trans("3x"),
     _trans("4x"),
+
+    _trans("Show Skylanders Portal"),
+    _trans("Show Infinity Base")
 }};
 // clang-format on
 static_assert(NUM_HOTKEYS == s_hotkey_labels.size(), "Wrong count of hotkey_labels");
@@ -354,7 +357,8 @@ constexpr std::array<HotkeyGroupInfo, NUM_HOTKEY_GROUPS> s_groups_info = {
      {_trans("Other State Hotkeys"), HK_SAVE_FIRST_STATE, HK_DECREMENT_SELECTED_STATE_SLOT},
      {_trans("GBA Core"), HK_GBA_LOAD, HK_GBA_RESET, true},
      {_trans("GBA Volume"), HK_GBA_VOLUME_DOWN, HK_GBA_TOGGLE_MUTE, true},
-     {_trans("GBA Window Size"), HK_GBA_1X, HK_GBA_4X, true}}};
+     {_trans("GBA Window Size"), HK_GBA_1X, HK_GBA_4X, true},
+     {_trans("USB Emulation Devices"), HK_SKYLANDERS_PORTAL, HK_INFINITY_BASE}}};
 
 HotkeyManager::HotkeyManager()
 {
@@ -490,4 +494,7 @@ void HotkeyManager::LoadDefaults(const ControllerInterface& ciface)
   set_key_expression(HK_GBA_3X, "`KP_3`");
   set_key_expression(HK_GBA_4X, "`KP_4`");
 #endif
+
+  set_key_expression(HK_SKYLANDERS_PORTAL, hotkey_string({"Ctrl", "P"}));
+  set_key_expression(HK_INFINITY_BASE, hotkey_string({"Ctrl", "I"}));
 }

--- a/Source/Core/Core/HotkeyManager.h
+++ b/Source/Core/Core/HotkeyManager.h
@@ -180,6 +180,9 @@ enum Hotkey
   HK_GBA_3X,
   HK_GBA_4X,
 
+  HK_SKYLANDERS_PORTAL,
+  HK_INFINITY_BASE,
+
   NUM_HOTKEYS,
 };
 
@@ -211,6 +214,7 @@ enum HotkeyGroup : int
   HKGP_GBA_CORE,
   HKGP_GBA_VOLUME,
   HKGP_GBA_SIZE,
+  HKGP_USB_EMU,
 
   NUM_HOTKEY_GROUPS,
 };

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -125,6 +125,8 @@ add_executable(dolphin-emu
   Config/Mapping/HotkeyStatesOther.h
   Config/Mapping/HotkeyTAS.cpp
   Config/Mapping/HotkeyTAS.h
+  Config/Mapping/HotkeyUSBEmu.cpp
+  Config/Mapping/HotkeyUSBEmu.h
   Config/Mapping/HotkeyWii.cpp
   Config/Mapping/HotkeyWii.h
   Config/Mapping/IOWindow.cpp

--- a/Source/Core/DolphinQt/Config/Mapping/HotkeyUSBEmu.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/HotkeyUSBEmu.cpp
@@ -1,0 +1,39 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/Config/Mapping/HotkeyUSBEmu.h"
+
+#include <QGroupBox>
+#include <QHBoxLayout>
+
+#include "Core/HotkeyManager.h"
+
+HotkeyUSBEmu::HotkeyUSBEmu(MappingWindow* window) : MappingWidget(window)
+{
+  CreateMainLayout();
+}
+
+void HotkeyUSBEmu::CreateMainLayout()
+{
+  m_main_layout = new QHBoxLayout();
+
+  m_main_layout->addWidget(
+      CreateGroupBox(tr("USB Device Emulation"), HotkeyManagerEmu::GetHotkeyGroup(HKGP_USB_EMU)));
+
+  setLayout(m_main_layout);
+}
+
+InputConfig* HotkeyUSBEmu::GetConfig()
+{
+  return HotkeyManagerEmu::GetConfig();
+}
+
+void HotkeyUSBEmu::LoadSettings()
+{
+  HotkeyManagerEmu::LoadConfig();
+}
+
+void HotkeyUSBEmu::SaveSettings()
+{
+  HotkeyManagerEmu::GetConfig()->SaveConfig();
+}

--- a/Source/Core/DolphinQt/Config/Mapping/HotkeyUSBEmu.h
+++ b/Source/Core/DolphinQt/Config/Mapping/HotkeyUSBEmu.h
@@ -1,0 +1,26 @@
+#pragma once
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "DolphinQt/Config/Mapping/MappingWidget.h"
+
+class QHBoxLayout;
+
+class HotkeyUSBEmu final : public MappingWidget
+{
+  Q_OBJECT
+public:
+  explicit HotkeyUSBEmu(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+  void CreateMainLayout();
+
+  // Main
+  QHBoxLayout* m_main_layout;
+};

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -39,6 +39,7 @@
 #include "DolphinQt/Config/Mapping/HotkeyStates.h"
 #include "DolphinQt/Config/Mapping/HotkeyStatesOther.h"
 #include "DolphinQt/Config/Mapping/HotkeyTAS.h"
+#include "DolphinQt/Config/Mapping/HotkeyUSBEmu.h"
 #include "DolphinQt/Config/Mapping/HotkeyWii.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtension.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.h"
@@ -450,6 +451,7 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
     AddWidget(tr("Wii and Wii Remote"), new HotkeyWii(this));
     AddWidget(tr("Controller Profile"), new HotkeyControllerProfile(this));
     AddWidget(tr("Graphics"), new HotkeyGraphics(this));
+    AddWidget(tr("USB Emulation"), new HotkeyUSBEmu(this));
     // i18n: Stereoscopic 3D
     AddWidget(tr("3D"), new Hotkey3D(this));
     AddWidget(tr("Save and Load State"), new HotkeyStates(this));

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="Config\Mapping\HotkeyStates.cpp" />
     <ClCompile Include="Config\Mapping\HotkeyStatesOther.cpp" />
     <ClCompile Include="Config\Mapping\HotkeyTAS.cpp" />
+    <ClCompile Include="Config\Mapping\HotkeyUSBEmu.cpp" />
     <ClCompile Include="Config\Mapping\HotkeyWii.cpp" />
     <ClCompile Include="Config\Mapping\IOWindow.cpp" />
     <ClCompile Include="Config\Mapping\MappingButton.cpp" />
@@ -298,6 +299,7 @@
     <QtMoc Include="Config\Mapping\HotkeyStates.h" />
     <QtMoc Include="Config\Mapping\HotkeyStatesOther.h" />
     <QtMoc Include="Config\Mapping\HotkeyTAS.h" />
+    <QtMoc Include="Config\Mapping\HotkeyUSBEmu.h" />
     <QtMoc Include="Config\Mapping\HotkeyWii.h" />
     <QtMoc Include="Config\Mapping\IOWindow.h" />
     <QtMoc Include="Config\Mapping\MappingButton.h" />

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -483,6 +483,13 @@ void HotkeyScheduler::Run()
         ShowEmulationSpeed();
       }
 
+      // USB Device Emulation
+      if (IsHotkey(HK_SKYLANDERS_PORTAL))
+        emit SkylandersPortalHotkey();
+
+      if (IsHotkey(HK_INFINITY_BASE))
+        emit InfinityBaseHotkey();
+
       // Slot Saving / Loading
       if (IsHotkey(HK_SAVE_STATE_SLOT_SELECTED))
         emit StateSaveSlotHotkey();

--- a/Source/Core/DolphinQt/HotkeyScheduler.h
+++ b/Source/Core/DolphinQt/HotkeyScheduler.h
@@ -65,6 +65,9 @@ signals:
   void ToggleBreakpoint();
   void AddBreakpoint();
 
+  void SkylandersPortalHotkey();
+  void InfinityBaseHotkey();
+
 private:
   void Run();
   void CheckDebuggingHotkeys();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -642,6 +642,11 @@ void MainWindow::ConnectHotkeys()
           &CodeWidget::ToggleBreakpoint);
   connect(m_hotkey_scheduler, &HotkeyScheduler::AddBreakpoint, m_code_widget,
           &CodeWidget::AddBreakpoint);
+
+  connect(m_hotkey_scheduler, &HotkeyScheduler::SkylandersPortalHotkey, this,
+          &MainWindow::ShowSkylanderPortal);
+  connect(m_hotkey_scheduler, &HotkeyScheduler::InfinityBaseHotkey, this,
+          &MainWindow::ShowInfinityBase);
 }
 
 void MainWindow::ConnectToolBar()


### PR DESCRIPTION
### Status
Ready to merge. 

## Skylanders and Infinity Menu Hotkeys
Creating two new hotkeys that open the Skylanders Portal and Infinity Base menus, so the game doesn't need to be exited each time. Added a tab in the hotkey settings menu for "USB Emulation" to set the hotkeys. 

Default hotkeys:
Skylanders Portal of Power: `Ctrl+P`
Infinity Base: `Ctrl+I`

## Note
This commit is not dependent on the Skylanders menu overhaul, can be merged with the current USB emulation menus.