### PR TITLE
Qt: Fix some Post Process Configuration Widget issues

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
@@ -93,12 +93,17 @@ void PostProcessingConfigWindow::Create()
 
   u32 row = 0;
   bool add_general_page = false;
-  for (const auto& it : m_config_groups)
+  for (auto& it : m_config_groups)
   {
     if (it->HasSubGroups())
     {
       auto* const tab = CreateDependentTab(it);
       m_tabs->addTab(tab, QString::fromStdString(it->GetGUIName()));
+
+      if (it->GetConfigurationOption()->m_type == OptionType::Bool)
+      {
+        it->EnableSuboptions(it->GetCheckboxValue());
+      }
     }
     else
     {
@@ -213,6 +218,12 @@ bool PostProcessingConfigWindow::ConfigGroup::HasSubGroups() const noexcept
   return !m_subgroups.empty();
 }
 
+const ConfigurationOption*
+PostProcessingConfigWindow::ConfigGroup::GetConfigurationOption() const noexcept
+{
+  return m_config_option;
+}
+
 const std::vector<std::unique_ptr<PostProcessingConfigWindow::ConfigGroup>>&
 PostProcessingConfigWindow::ConfigGroup::GetSubGroups() const noexcept
 {
@@ -300,11 +311,12 @@ u32 PostProcessingConfigWindow::ConfigGroup::AddFloat(PostProcessingConfigWindow
 
   for (size_t i = 0; i < vector_size; ++i)
   {
-    const int current_value =
-        m_config_option->m_float_values[i] / m_config_option->m_float_step_values[i];
     const float range =
         m_config_option->m_float_max_values[i] - m_config_option->m_float_min_values[i];
     const int steps = std::ceil(range / m_config_option->m_float_step_values[i]);
+    const int current_value =
+        std::round((m_config_option->m_float_values[i] - m_config_option->m_float_min_values[i]) /
+                   m_config_option->m_float_step_values[i]);
 
     auto* const slider = new QSlider(Qt::Orientation::Horizontal);
     slider->setMinimum(0);
@@ -349,6 +361,11 @@ void PostProcessingConfigWindow::ConfigGroup::EnableSuboptions(const bool state)
     }
     it->EnableSuboptions(state);
   }
+}
+
+int PostProcessingConfigWindow::ConfigGroup::GetCheckboxValue() const
+{
+  return m_checkbox->isChecked();
 }
 
 int PostProcessingConfigWindow::ConfigGroup::GetSliderValue(size_t index) const

--- a/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.h
+++ b/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.h
@@ -41,9 +41,12 @@ private:
     const std::string& GetOptionName() const noexcept;
     void AddSubGroup(std::unique_ptr<ConfigGroup>&& subgroup);
     bool HasSubGroups() const noexcept;
+    const VideoCommon::PostProcessingConfiguration::ConfigurationOption*
+    GetConfigurationOption() const noexcept;
     const std::vector<std::unique_ptr<ConfigGroup>>& GetSubGroups() const noexcept;
     u32 AddWidgets(PostProcessingConfigWindow* parent, QGridLayout* grid, u32 row);
     void EnableSuboptions(bool state);
+    int GetCheckboxValue() const;
     int GetSliderValue(size_t index) const;
     void SetSliderText(size_t index, const QString& text);
 


### PR DESCRIPTION
-The float sliders initial value wasn't calculated correctly
-Fix the checkbox dependencies not being applied until a setting was changed for the first time