### PR TITLE
Video: implement color correction to match the Wii/GC NTSC/PAL color spaces (and gamma)

### DIFF
--- a/Data/Sys/Shaders/default_pre_post_process.glsl
+++ b/Data/Sys/Shaders/default_pre_post_process.glsl
@@ -1,0 +1,86 @@
+// References:
+// https://www.unravel.com.au/understanding-color-spaces
+
+// SMPTE 170M - BT.601 (NTSC-M) -> BT.709
+mat3 from_NTSCM = transpose(mat3(
+	0.939497225737661,		0.0502268452914346,		0.0102759289709032,
+	0.0177558637510127,		0.965824605885027,		0.0164195303639603,
+	-0.00162163209967010,	-0.00437400622653655,	1.00599563832621));
+
+// ARIB TR-B9 (9300K+27MPCD with chromatic adaptation) (NTSC-J) -> BT.709
+mat3 from_NTSCJ = transpose(mat3(
+	0.823613036967492,		-0.0943227111084757,	0.00799341532931119,
+	0.0289258355537324,		1.02310733489462,			0.00243547111576797,
+	-0.00569501554980891,	0.0161828357559315,		1.22328453915712));
+
+// EBU - BT.470BG/BT.601 (PAL) -> BT.709
+mat3 from_PAL = transpose(mat3(
+	1.04408168421813,		-0.0440816842181253,	0.000000000000000,
+	0.000000000000000,	1.00000000000000,			0.000000000000000,
+	0.000000000000000,	0.0118044782106489,		0.988195521789351));
+
+float3 LinearTosRGBGamma(float3 color)
+{
+	float a = 0.055;
+	
+	for (int i = 0; i < 3; ++i)
+	{
+		float x = color[i];
+		if (x <= 0.0031308)
+			x = x * 12.92;
+		else
+			x = (1.0 + a) * pow(x, 1.0 / 2.4) - a;
+		color[i] = x;
+	}
+
+	return color;
+}
+
+void main()
+{
+	// Note: sampling in gamma space is "wrong" if the source
+	// and target resolution don't match exactly.
+	// Fortunately at the moment here they always should but to do this correctly,
+	// we'd need to sample from 4 pixels, de-apply the gamma from each of these,
+	// and then do linear sampling on their corrected value.
+	float4 color = Sample();
+
+	// Convert to linear space to do any other kind of operation
+	color.rgb = pow(color.rgb, game_gamma.xxx);
+
+	if (OptionEnabled(correct_color_space))
+	{
+		if (game_color_space == 0)
+			color.rgb = color.rgb * from_NTSCM;
+		else if (game_color_space == 1)
+			color.rgb = color.rgb * from_NTSCJ;
+		else if (game_color_space == 2)
+			color.rgb = color.rgb * from_PAL;
+	}
+	
+	if (OptionEnabled(hdr_output))
+	{
+		const float hdr_paper_white = hdr_paper_white_nits / hdr_sdr_white_nits;
+		color.rgb *= hdr_paper_white;
+	}
+	
+	if (OptionEnabled(linear_space_output))
+	{
+		// Nothing to do here
+	}
+	// Correct the SDR gamma for sRGB (PC/Monitor) or ~2.2 (Common TV gamma)
+	else if (OptionEnabled(correct_gamma))
+	{
+		if (OptionEnabled(sdr_display_gamma_sRGB))
+			color.rgb = LinearTosRGBGamma(color.rgb);
+		else
+			color.rgb = pow(color.rgb, (1.0 / sdr_display_custom_gamma).xxx);
+	}
+	// Restore the original gamma without changes
+	else
+	{
+			color.rgb = pow(color.rgb, (1.0 / game_gamma).xxx);
+	}
+
+	SetOutput(color);
+}

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -128,6 +128,22 @@ const Info<bool> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION{
     {System::GFX, "Enhancements", "ArbitraryMipmapDetection"}, true};
 const Info<float> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD{
     {System::GFX, "Enhancements", "ArbitraryMipmapDetectionThreshold"}, 14.0f};
+const Info<bool> GFX_ENHANCE_HDR_OUTPUT{{System::GFX, "Enhancements", "HDROutput"}, false};
+
+// Color.Correction
+
+const Info<bool> GFX_CC_CORRECT_COLOR_SPACE{{System::GFX, "ColorCorrection", "CorrectColorSpace"},
+                                            false};
+const Info<ColorCorrectionRegion> GFX_CC_GAME_COLOR_SPACE{
+    {System::GFX, "ColorCorrection", "GameColorSpace"}, ColorCorrectionRegion::SMPTE_NTSCM};
+const Info<bool> GFX_CC_CORRECT_GAMMA{{System::GFX, "ColorCorrection", "CorrectGamma"}, false};
+const Info<float> GFX_CC_GAME_GAMMA{{System::GFX, "ColorCorrection", "GameGamma"}, 2.35f};
+const Info<bool> GFX_CC_SDR_DISPLAY_GAMMA_SRGB{
+    {System::GFX, "ColorCorrection", "SDRDisplayGammaSRGB"}, true};
+const Info<float> GFX_CC_SDR_DISPLAY_CUSTOM_GAMMA{
+    {System::GFX, "ColorCorrection", "SDRDisplayCustomGamma"}, 2.2f};
+const Info<float> GFX_CC_HDR_PAPER_WHITE_NITS{{System::GFX, "ColorCorrection", "HDRPaperWhiteNits"},
+                                              200.f};
 
 // Graphics.Stereoscopy
 

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -11,6 +11,7 @@ enum class AspectMode : int;
 enum class ShaderCompilationMode : int;
 enum class StereoMode : int;
 enum class TextureFilteringMode : int;
+enum class ColorCorrectionRegion : int;
 enum class TriState : int;
 
 namespace Config
@@ -105,6 +106,26 @@ extern const Info<bool> GFX_ENHANCE_FORCE_TRUE_COLOR;
 extern const Info<bool> GFX_ENHANCE_DISABLE_COPY_FILTER;
 extern const Info<bool> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION;
 extern const Info<float> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD;
+extern const Info<bool> GFX_ENHANCE_HDR_OUTPUT;
+
+// Color.Correction
+
+static constexpr float GFX_CC_GAME_GAMMA_MIN = 2.2f;
+static constexpr float GFX_CC_GAME_GAMMA_MAX = 2.8f;
+
+static constexpr float GFX_CC_DISPLAY_GAMMA_MIN = 2.2f;
+static constexpr float GFX_CC_DISPLAY_GAMMA_MAX = 2.4f;
+
+static constexpr float GFX_CC_HDR_PAPER_WHITE_NITS_MIN = 80.f;
+static constexpr float GFX_CC_HDR_PAPER_WHITE_NITS_MAX = 400.f;
+
+extern const Info<bool> GFX_CC_CORRECT_COLOR_SPACE;
+extern const Info<ColorCorrectionRegion> GFX_CC_GAME_COLOR_SPACE;
+extern const Info<bool> GFX_CC_CORRECT_GAMMA;
+extern const Info<float> GFX_CC_GAME_GAMMA;
+extern const Info<bool> GFX_CC_SDR_DISPLAY_GAMMA_SRGB;
+extern const Info<float> GFX_CC_SDR_DISPLAY_CUSTOM_GAMMA;
+extern const Info<float> GFX_CC_HDR_PAPER_WHITE_NITS;
 
 // Graphics.Stereoscopy
 

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -380,6 +380,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-internal-resolution", g_Config.iEFBScale);
   builder.AddData("cfg-gfx-tc-samples", g_Config.iSafeTextureCache_ColorSamples);
   builder.AddData("cfg-gfx-stereo-mode", static_cast<int>(g_Config.stereo_mode));
+  builder.AddData("cfg-gfx-hdr", static_cast<int>(g_Config.bHDR));
   builder.AddData("cfg-gfx-per-pixel-lighting", g_Config.bEnablePixelLighting);
   builder.AddData("cfg-gfx-shader-compilation-mode", GetShaderCompilationMode(g_Config));
   builder.AddData("cfg-gfx-wait-for-shaders", g_Config.bWaitForShadersBeforeStarting);

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -87,6 +87,8 @@ add_executable(dolphin-emu
   Config/Graphics/GraphicsWindow.h
   Config/Graphics/HacksWidget.cpp
   Config/Graphics/HacksWidget.h
+  Config/Graphics/ColorCorrectionConfigWindow.cpp
+  Config/Graphics/ColorCorrectionConfigWindow.h
   Config/Graphics/PostProcessingConfigWindow.cpp
   Config/Graphics/PostProcessingConfigWindow.h
   Config/GraphicsModListWidget.cpp

--- a/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.cpp
@@ -1,0 +1,181 @@
+// Copyright 2018 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.h"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QLabel>
+
+#include "Core/Config/GraphicsSettings.h"
+
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
+#include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
+#include "DolphinQt/Config/ConfigControls/ConfigFloatSlider.h"
+
+#include "VideoCommon/VideoConfig.h"
+
+ColorCorrectionConfigWindow::ColorCorrectionConfigWindow(QWidget* parent) : QDialog(parent)
+{
+  setWindowTitle(tr("Color Correction Configuration"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+  Create();
+  ConnectWidgets();
+}
+
+void ColorCorrectionConfigWindow::Create()
+{
+  static const char TR_COLOR_SPACE_CORRECTION_DESCRIPTION[] = QT_TR_NOOP(
+      "Converts the colors to the color spaces that GC/Wii were meant to work with to sRGB/Rec.709."
+      "<br><br>There's no way of knowing what exact color space games were meant for,"
+      "<br>given there were multiple standards and most games didn't acknowledge them,"
+      "<br>so it's not correct to assume a format from the game disc region."
+      "<br>Just pick the one that looks more natural to you,"
+      " or match it with the region the game was developed in."
+      "<br><br>HDR output is required to show all the colors from the PAL and NTSC-J color spaces."
+      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+  static const char TR_GAME_GAMMA_DESCRIPTION[] =
+      QT_TR_NOOP("NTSC-M and NTSC-J target gamma ~2.2. PAL targets gamma ~2.8."
+                 "<br>None of the two were necessarily followed by games or TVs. 2.35 is a good "
+                 "generic value for all regions."
+                 "<br>If a game allows you to chose a gamma value, match it here.");
+  static const char TR_GAMMA_CORRECTION_DESCRIPTION[] = QT_TR_NOOP(
+      "Converts the gamma from what the game targeted to what your current SDR display targets."
+      "<br>Monitors often target sRGB. TVs often target 2.2."
+      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+
+  // Color Space:
+
+  auto* const color_space_box = new QGroupBox(tr("Color Space"));
+  auto* const color_space_layout = new QGridLayout();
+  color_space_layout->setVerticalSpacing(7);
+  color_space_layout->setColumnStretch(1, 1);
+  color_space_box->setLayout(color_space_layout);
+
+  m_correct_color_space =
+      new ConfigBool(tr("Correct Color Space"), Config::GFX_CC_CORRECT_COLOR_SPACE);
+  color_space_layout->addWidget(m_correct_color_space, 0, 0);
+  m_correct_color_space->SetDescription(tr(TR_COLOR_SPACE_CORRECTION_DESCRIPTION));
+
+  // "ColorCorrectionRegion"
+  const QStringList game_color_space_enum{tr("NTSC-M (SMPTE 170M)"), tr("NTSC-J (ARIB TR-B9)"),
+                                          tr("PAL (EBU)")};
+
+  m_game_color_space = new ConfigChoice(game_color_space_enum, Config::GFX_CC_GAME_COLOR_SPACE);
+  color_space_layout->addWidget(new QLabel(tr("Game Color Space")), 1, 0);
+  color_space_layout->addWidget(m_game_color_space, 1, 1);
+
+  m_game_color_space->setEnabled(m_correct_color_space->isChecked());
+
+  // Gamma:
+
+  auto* const gamma_box = new QGroupBox(tr("Gamma"));
+  auto* const gamma_layout = new QGridLayout();
+  gamma_layout->setVerticalSpacing(7);
+  gamma_layout->setColumnStretch(1, 1);
+  gamma_box->setLayout(gamma_layout);
+
+  m_game_gamma = new ConfigFloatSlider(Config::GFX_CC_GAME_GAMMA_MIN, Config::GFX_CC_GAME_GAMMA_MAX,
+                                       Config::GFX_CC_GAME_GAMMA, 0.01f);
+  gamma_layout->addWidget(new QLabel(tr("Game Gamma")), 0, 0);
+  gamma_layout->addWidget(m_game_gamma, 0, 1);
+  m_game_gamma->SetDescription(tr(TR_GAME_GAMMA_DESCRIPTION));
+  m_game_gamma_value = new QLabel(tr(""));
+  gamma_layout->addWidget(m_game_gamma_value, 0, 2);
+
+  m_correct_gamma = new ConfigBool(tr("Correct SDR Gamma"), Config::GFX_CC_CORRECT_GAMMA);
+  gamma_layout->addWidget(m_correct_gamma, 1, 0);
+  m_correct_gamma->SetDescription(tr(TR_GAMMA_CORRECTION_DESCRIPTION));
+
+  m_sdr_display_gamma_srgb =
+      new ConfigBool(tr("SDR Display Gamma sRGB"), Config::GFX_CC_SDR_DISPLAY_GAMMA_SRGB);
+  gamma_layout->addWidget(m_sdr_display_gamma_srgb, 2, 0);
+
+  m_sdr_display_custom_gamma =
+      new ConfigFloatSlider(Config::GFX_CC_DISPLAY_GAMMA_MIN, Config::GFX_CC_DISPLAY_GAMMA_MAX,
+                            Config::GFX_CC_SDR_DISPLAY_CUSTOM_GAMMA, 0.01f);
+  gamma_layout->addWidget(new QLabel(tr("SDR Display Custom Gamma")), 3, 0);
+  gamma_layout->addWidget(m_sdr_display_custom_gamma, 3, 1);
+  m_sdr_display_custom_gamma_value = new QLabel(tr(""));
+  gamma_layout->addWidget(m_sdr_display_custom_gamma_value, 3, 2);
+
+  m_sdr_display_gamma_srgb->setEnabled(m_correct_gamma->isChecked());
+  m_sdr_display_custom_gamma->setEnabled(m_correct_gamma->isChecked() &&
+                                         !m_sdr_display_gamma_srgb->isChecked());
+  m_game_gamma_value->setText(QString::asprintf("%f", m_game_gamma->GetValue()));
+  m_sdr_display_custom_gamma_value->setText(
+      QString::asprintf("%f", m_sdr_display_custom_gamma->GetValue()));
+
+  // HDR:
+
+  auto* const hdr_box = new QGroupBox(tr("HDR"));
+  auto* const hdr_layout = new QGridLayout();
+  hdr_layout->setVerticalSpacing(7);
+  hdr_layout->setColumnStretch(1, 1);
+  hdr_box->setLayout(hdr_layout);
+
+  m_hdr_paper_white_nits = new ConfigFloatSlider(Config::GFX_CC_HDR_PAPER_WHITE_NITS_MIN,
+                                                 Config::GFX_CC_HDR_PAPER_WHITE_NITS_MAX,
+                                                 Config::GFX_CC_HDR_PAPER_WHITE_NITS, 1.f);
+  hdr_layout->addWidget(new QLabel(tr("HDR Paper White Nits")), 0, 0);
+  hdr_layout->addWidget(m_hdr_paper_white_nits, 0, 1);
+  m_hdr_paper_white_nits_value = new QLabel(tr(""));
+  hdr_layout->addWidget(m_hdr_paper_white_nits_value, 0, 2);
+
+  m_hdr_paper_white_nits_value->setText(
+      QString::asprintf("%f", m_hdr_paper_white_nits->GetValue()));
+
+  // Other:
+
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
+
+  auto* layout = new QVBoxLayout(this);
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->setAlignment(Qt::AlignTop);
+  layout->addWidget(color_space_box);
+  layout->addWidget(gamma_box);
+  layout->addWidget(hdr_box);
+  layout->addWidget(m_button_box);
+  setLayout(layout);
+}
+
+void ColorCorrectionConfigWindow::ConnectWidgets()
+{
+  connect(m_correct_color_space, &QCheckBox::toggled, this,
+          [this] { m_game_color_space->setEnabled(m_correct_color_space->isChecked()); });
+
+  connect(m_game_gamma, &ConfigFloatSlider::valueChanged, this, [this] {
+    m_game_gamma_value->setText(QString::asprintf("%f", m_game_gamma->GetValue()));
+  });
+
+  connect(m_correct_gamma, &QCheckBox::toggled, this, [this] {
+    // The "m_game_gamma" shouldn't be grayed out as it can still affect the color space correction
+
+    // For the moment we leave this enabled even when we are outputting in HDR
+    // (which means they'd have no influence on the final image),
+    // mostly because we don't have a simple way to determine if HDR is engaged from here
+    m_sdr_display_gamma_srgb->setEnabled(m_correct_gamma->isChecked());
+    m_sdr_display_custom_gamma->setEnabled(m_correct_gamma->isChecked() &&
+                                           !m_sdr_display_gamma_srgb->isChecked());
+  });
+
+  connect(m_sdr_display_gamma_srgb, &QCheckBox::toggled, this, [this] {
+    m_sdr_display_custom_gamma->setEnabled(m_correct_gamma->isChecked() &&
+                                           !m_sdr_display_gamma_srgb->isChecked());
+  });
+
+  connect(m_sdr_display_custom_gamma, &ConfigFloatSlider::valueChanged, this, [this] {
+    m_sdr_display_custom_gamma_value->setText(
+        QString::asprintf("%f", m_sdr_display_custom_gamma->GetValue()));
+  });
+
+  connect(m_hdr_paper_white_nits, &ConfigFloatSlider::valueChanged, this, [this] {
+    m_hdr_paper_white_nits_value->setText(
+        QString::asprintf("%f", m_hdr_paper_white_nits->GetValue()));
+  });
+
+  connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}

--- a/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.h
+++ b/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.h
@@ -1,0 +1,36 @@
+// Copyright 2018 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QDialog>
+
+class QWidget;
+class QLabel;
+class ConfigBool;
+class ConfigChoice;
+class ConfigFloatSlider;
+class QDialogButtonBox;
+
+class ColorCorrectionConfigWindow final : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit ColorCorrectionConfigWindow(QWidget* parent);
+
+private:
+  void Create();
+  void ConnectWidgets();
+
+  ConfigBool* m_correct_color_space;
+  ConfigChoice* m_game_color_space;
+  ConfigFloatSlider* m_game_gamma;
+  QLabel* m_game_gamma_value;
+  ConfigBool* m_correct_gamma;
+  ConfigBool* m_sdr_display_gamma_srgb;
+  ConfigFloatSlider* m_sdr_display_custom_gamma;
+  QLabel* m_sdr_display_custom_gamma_value;
+  ConfigFloatSlider* m_hdr_paper_white_nits;
+  QLabel* m_hdr_paper_white_nits_value;
+  QDialogButtonBox* m_button_box;
+};

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -18,6 +18,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
 #include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
 #include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
+#include "DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/Graphics/PostProcessingConfigWindow.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
@@ -102,6 +103,8 @@ void EnhancementsWidget::CreateWidgets()
   m_texture_filtering_combo->addItem(tr("Force Linear and 16x Anisotropic"),
                                      TEXTURE_FILTERING_FORCE_LINEAR_ANISO_16X);
 
+  m_configure_color_correction = new NonDefaultQPushButton(tr("Configure"));
+
   m_pp_effect = new ToolTipComboBox();
   m_configure_pp_effect = new NonDefaultQPushButton(tr("Configure"));
   m_scaled_efb_copy = new ConfigBool(tr("Scaled EFB Copy"), Config::GFX_HACK_COPY_EFB_SCALED);
@@ -116,6 +119,7 @@ void EnhancementsWidget::CreateWidgets()
       new ConfigBool(tr("Disable Copy Filter"), Config::GFX_ENHANCE_DISABLE_COPY_FILTER);
   m_arbitrary_mipmap_detection = new ConfigBool(tr("Arbitrary Mipmap Detection"),
                                                 Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
+  m_hdr = new ConfigBool(tr("HDR Post-Processing"), Config::GFX_ENHANCE_HDR_OUTPUT);
 
   int row = 0;
   enhancements_layout->addWidget(new QLabel(tr("Internal Resolution:")), row, 0);
@@ -128,6 +132,10 @@ void EnhancementsWidget::CreateWidgets()
 
   enhancements_layout->addWidget(new QLabel(tr("Texture Filtering:")), row, 0);
   enhancements_layout->addWidget(m_texture_filtering_combo, row, 1, 1, -1);
+  ++row;
+
+  enhancements_layout->addWidget(new QLabel(tr("Color Correction:")), row, 0);
+  enhancements_layout->addWidget(m_configure_color_correction, row, 1, 1, -1);
   ++row;
 
   enhancements_layout->addWidget(new QLabel(tr("Post-Processing Effect:")), row, 0);
@@ -148,6 +156,7 @@ void EnhancementsWidget::CreateWidgets()
   ++row;
 
   enhancements_layout->addWidget(m_disable_copy_filter, row, 0);
+  enhancements_layout->addWidget(m_hdr, row, 1, 1, -1);
   ++row;
 
   // Stereoscopy
@@ -188,11 +197,14 @@ void EnhancementsWidget::ConnectWidgets()
           [this](int) { SaveSettings(); });
   connect(m_3d_mode, qOverload<int>(&QComboBox::currentIndexChanged), [this] {
     m_block_save = true;
+    m_configure_color_correction->setEnabled(g_Config.backend_info.bSupportsPostProcessing);
     LoadPPShaders();
     m_block_save = false;
 
     SaveSettings();
   });
+  connect(m_configure_color_correction, &QPushButton::clicked, this,
+          &EnhancementsWidget::ConfigureColorCorrection);
   connect(m_configure_pp_effect, &QPushButton::clicked, this,
           &EnhancementsWidget::ConfigurePostProcessingShader);
 }
@@ -311,6 +323,8 @@ void EnhancementsWidget::LoadSettings()
     break;
   }
 
+  m_configure_color_correction->setEnabled(g_Config.backend_info.bSupportsPostProcessing);
+
   // Post Processing Shader
   LoadPPShaders();
 
@@ -320,6 +334,9 @@ void EnhancementsWidget::LoadSettings()
   m_3d_convergence->setEnabled(supports_stereoscopy);
   m_3d_depth->setEnabled(supports_stereoscopy);
   m_3d_swap_eyes->setEnabled(supports_stereoscopy);
+
+  m_hdr->setEnabled(g_Config.backend_info.bSupportsHDROutput);
+
   m_block_save = false;
 }
 
@@ -436,6 +453,9 @@ void EnhancementsWidget::AddDescriptions()
       "scaling filter selected by the game.<br><br>Any option except 'Default' will alter the look "
       "of the game's textures and might cause issues in a small number of "
       "games.<br><br><dolphin_emphasis>If unsure, select 'Default'.</dolphin_emphasis>");
+  static const char TR_COLOR_CORRECTION_DESCRIPTION[] =
+      QT_TR_NOOP("A group of features to make the colors more accurate,"
+                 " matching the color space Wii and GC games were meant for.");
   static const char TR_POSTPROCESSING_DESCRIPTION[] =
       QT_TR_NOOP("Applies a post-processing effect after rendering a frame.<br><br "
                  "/><dolphin_emphasis>If unsure, select (off).</dolphin_emphasis>");
@@ -498,6 +518,13 @@ void EnhancementsWidget::AddDescriptions()
       "reduce stutter in games that frequently load new textures. This feature is not compatible "
       "with GPU Texture Decoding.<br><br><dolphin_emphasis>If unsure, leave this "
       "checked.</dolphin_emphasis>");
+  static const char TR_HDR_DESCRIPTION[] = QT_TR_NOOP(
+      "Enables scRGB HDR output (if supported by your graphics backend and monitor)."
+      " Fullscreen might be required."
+      "<br><br>This gives post process shaders more room for accuracy, allows \"AutoHDR\" "
+      "post-process shaders to work, and allows to fully display the PAL and NTSC-J color spaces."
+      "<br><br>Note that games still render in SDR internally."
+      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
   m_ir_combo->SetTitle(tr("Internal Resolution"));
   m_ir_combo->SetDescription(tr(TR_INTERNAL_RESOLUTION_DESCRIPTION));
@@ -507,6 +534,8 @@ void EnhancementsWidget::AddDescriptions()
 
   m_texture_filtering_combo->SetTitle(tr("Texture Filtering"));
   m_texture_filtering_combo->SetDescription(tr(TR_FORCE_TEXTURE_FILTERING_DESCRIPTION));
+
+  m_configure_color_correction->setToolTip(tr(TR_COLOR_CORRECTION_DESCRIPTION));
 
   m_pp_effect->SetTitle(tr("Post-Processing Effect"));
   m_pp_effect->SetDescription(tr(TR_POSTPROCESSING_DESCRIPTION));
@@ -525,6 +554,8 @@ void EnhancementsWidget::AddDescriptions()
 
   m_arbitrary_mipmap_detection->SetDescription(tr(TR_ARBITRARY_MIPMAP_DETECTION_DESCRIPTION));
 
+  m_hdr->SetDescription(tr(TR_HDR_DESCRIPTION));
+
   m_3d_mode->SetTitle(tr("Stereoscopic 3D Mode"));
   m_3d_mode->SetDescription(tr(TR_3D_MODE_DESCRIPTION));
 
@@ -535,6 +566,11 @@ void EnhancementsWidget::AddDescriptions()
   m_3d_convergence->SetDescription(tr(TR_3D_CONVERGENCE_DESCRIPTION));
 
   m_3d_swap_eyes->SetDescription(tr(TR_3D_SWAP_EYES_DESCRIPTION));
+}
+
+void EnhancementsWidget::ConfigureColorCorrection()
+{
+  ColorCorrectionConfigWindow(this).exec();
 }
 
 void EnhancementsWidget::ConfigurePostProcessingShader()

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -30,6 +30,7 @@ private:
   void CreateWidgets();
   void ConnectWidgets();
   void AddDescriptions();
+  void ConfigureColorCorrection();
   void ConfigurePostProcessingShader();
   void LoadPPShaders();
 
@@ -38,6 +39,7 @@ private:
   ToolTipComboBox* m_aa_combo;
   ToolTipComboBox* m_texture_filtering_combo;
   ToolTipComboBox* m_pp_effect;
+  QPushButton* m_configure_color_correction;
   QPushButton* m_configure_pp_effect;
   ConfigBool* m_scaled_efb_copy;
   ConfigBool* m_per_pixel_lighting;
@@ -46,6 +48,7 @@ private:
   ConfigBool* m_force_24bit_color;
   ConfigBool* m_disable_copy_filter;
   ConfigBool* m_arbitrary_mipmap_detection;
+  ConfigBool* m_hdr;
 
   // Stereoscopy
   ConfigChoice* m_3d_mode;

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="Config\Graphics\GeneralWidget.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsWindow.cpp" />
     <ClCompile Include="Config\Graphics\HacksWidget.cpp" />
+    <ClCompile Include="Config\Graphics\ColorCorrectionConfigWindow.cpp" />
     <ClCompile Include="Config\Graphics\PostProcessingConfigWindow.cpp" />
     <ClCompile Include="Config\GraphicsModListWidget.cpp" />
     <ClCompile Include="Config\GraphicsModWarningWidget.cpp" />
@@ -283,6 +284,7 @@
     <QtMoc Include="Config\Graphics\GeneralWidget.h" />
     <QtMoc Include="Config\Graphics\GraphicsWindow.h" />
     <QtMoc Include="Config\Graphics\HacksWidget.h" />
+    <QtMoc Include="Config\Graphics\ColorCorrectionConfigWindow.h" />
     <QtMoc Include="Config\Graphics\PostProcessingConfigWindow.h" />
     <QtMoc Include="Config\GraphicsModListWidget.h" />
     <QtMoc Include="Config\GraphicsModWarningWidget.h" />

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -15,6 +15,7 @@
 #include "VideoBackends/D3D/D3DState.h"
 #include "VideoBackends/D3D/DXTexture.h"
 #include "VideoBackends/D3DCommon/D3DCommon.h"
+#include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace DX11
@@ -202,12 +203,14 @@ std::vector<u32> GetAAModes(u32 adapter_index)
   if (temp_feature_level == D3D_FEATURE_LEVEL_10_0)
     return {};
 
+  const DXGI_FORMAT target_format =
+      D3DCommon::GetDXGIFormatForAbstractFormat(FramebufferManager::GetEFBColorFormat(), false);
   std::vector<u32> aa_modes;
   for (u32 samples = 1; samples <= D3D11_MAX_MULTISAMPLE_SAMPLE_COUNT; ++samples)
   {
     UINT quality_levels = 0;
-    if (SUCCEEDED(temp_device->CheckMultisampleQualityLevels(DXGI_FORMAT_R8G8B8A8_UNORM, samples,
-                                                             &quality_levels)) &&
+    if (SUCCEEDED(
+            temp_device->CheckMultisampleQualityLevels(target_format, samples, &quality_levels)) &&
         quality_levels > 0)
     {
       aa_modes.push_back(samples);

--- a/Source/Core/VideoBackends/D3D/D3DGfx.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DGfx.cpp
@@ -175,6 +175,9 @@ void Gfx::OnConfigChanged(u32 bits)
   // Quad-buffer changes require swap chain recreation.
   if (bits & CONFIG_CHANGE_BIT_STEREO_MODE && m_swap_chain)
     m_swap_chain->SetStereo(SwapChain::WantsStereo());
+
+  if (bits & CONFIG_CHANGE_BIT_HDR && m_swap_chain)
+    m_swap_chain->SetHDR(SwapChain::WantsHDR());
 }
 
 void Gfx::CheckForSwapChainChanges()

--- a/Source/Core/VideoBackends/D3D/D3DMain.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DMain.cpp
@@ -114,6 +114,7 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsSettingObjectNames = true;
   g_Config.backend_info.bSupportsPartialMultisampleResolve = true;
   g_Config.backend_info.bSupportsDynamicVertexLoader = false;
+  g_Config.backend_info.bSupportsHDROutput = true;
 
   g_Config.backend_info.Adapters = D3DCommon::GetAdapterNames();
   g_Config.backend_info.AAModes = D3D::GetAAModes(g_Config.iAdapter);

--- a/Source/Core/VideoBackends/D3D/D3DSwapChain.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DSwapChain.cpp
@@ -21,7 +21,7 @@ std::unique_ptr<SwapChain> SwapChain::Create(const WindowSystemInfo& wsi)
 {
   std::unique_ptr<SwapChain> swap_chain =
       std::make_unique<SwapChain>(wsi, D3D::dxgi_factory.Get(), D3D::device.Get());
-  if (!swap_chain->CreateSwapChain(WantsStereo()))
+  if (!swap_chain->CreateSwapChain(WantsStereo(), WantsHDR()))
     return nullptr;
 
   return swap_chain;

--- a/Source/Core/VideoBackends/D3D12/D3D12Gfx.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12Gfx.cpp
@@ -421,6 +421,12 @@ void Gfx::OnConfigChanged(u32 bits)
     m_swap_chain->SetStereo(SwapChain::WantsStereo());
   }
 
+  if (m_swap_chain && bits & CONFIG_CHANGE_BIT_HDR)
+  {
+    ExecuteCommandList(true);
+    m_swap_chain->SetHDR(SwapChain::WantsHDR());
+  }
+
   // Wipe sampler cache if force texture filtering or anisotropy changes.
   if (bits & (CONFIG_CHANGE_BIT_ANISOTROPY | CONFIG_CHANGE_BIT_FORCE_TEXTURE_FILTERING))
   {

--- a/Source/Core/VideoBackends/D3D12/D3D12SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12SwapChain.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<SwapChain> SwapChain::Create(const WindowSystemInfo& wsi)
 {
   std::unique_ptr<SwapChain> swap_chain = std::make_unique<SwapChain>(
       wsi, g_dx_context->GetDXGIFactory(), g_dx_context->GetCommandQueue());
-  if (!swap_chain->CreateSwapChain(WantsStereo()))
+  if (!swap_chain->CreateSwapChain(WantsStereo(), WantsHDR()))
     return nullptr;
 
   return swap_chain;

--- a/Source/Core/VideoBackends/D3D12/DX12Context.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Context.cpp
@@ -16,6 +16,7 @@
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3D12/D3D12StreamBuffer.h"
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"
+#include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace DX12
@@ -65,11 +66,13 @@ std::vector<u32> DXContext::GetAAModes(u32 adapter_index)
       return {};
   }
 
+  const DXGI_FORMAT target_format =
+      D3DCommon::GetDXGIFormatForAbstractFormat(FramebufferManager::GetEFBColorFormat(), false);
   std::vector<u32> aa_modes;
   for (u32 samples = 1; samples < D3D12_MAX_MULTISAMPLE_SAMPLE_COUNT; ++samples)
   {
     D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS multisample_quality_levels = {};
-    multisample_quality_levels.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    multisample_quality_levels.Format = target_format;
     multisample_quality_levels.SampleCount = samples;
 
     temp_device->CheckFeatureSupport(D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -90,6 +90,7 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsPartialMultisampleResolve = true;
   g_Config.backend_info.bSupportsDynamicVertexLoader = true;
   g_Config.backend_info.bSupportsVSLinePointExpand = true;
+  g_Config.backend_info.bSupportsHDROutput = true;
 
   // We can only check texture support once we have a device.
   if (g_dx_context)

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.h
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.h
@@ -25,8 +25,13 @@ public:
   // Returns true if the stereo mode is quad-buffering.
   static bool WantsStereo();
 
+  static bool WantsHDR();
+
   IDXGISwapChain* GetDXGISwapChain() const { return m_swap_chain.Get(); }
-  AbstractTextureFormat GetFormat() const { return m_texture_format; }
+  AbstractTextureFormat GetFormat() const
+  {
+    return m_hdr ? m_texture_format_hdr : m_texture_format;
+  }
   u32 GetWidth() const { return m_width; }
   u32 GetHeight() const { return m_height; }
 
@@ -43,10 +48,11 @@ public:
   bool ChangeSurface(void* native_handle);
   bool ResizeSwapChain();
   void SetStereo(bool stereo);
+  void SetHDR(bool hdr);
 
 protected:
   u32 GetSwapChainFlags() const;
-  bool CreateSwapChain(bool stereo);
+  bool CreateSwapChain(bool stereo = false, bool hdr = false);
   void DestroySwapChain();
 
   virtual bool CreateSwapChainBuffers() = 0;
@@ -56,12 +62,14 @@ protected:
   Microsoft::WRL::ComPtr<IDXGIFactory> m_dxgi_factory;
   Microsoft::WRL::ComPtr<IDXGISwapChain> m_swap_chain;
   Microsoft::WRL::ComPtr<IUnknown> m_d3d_device;
-  AbstractTextureFormat m_texture_format = AbstractTextureFormat::RGBA8;
+  const AbstractTextureFormat m_texture_format = AbstractTextureFormat::RGB10_A2;
+  const AbstractTextureFormat m_texture_format_hdr = AbstractTextureFormat::RGBA16F;
 
   u32 m_width = 1;
   u32 m_height = 1;
 
   bool m_stereo = false;
+  bool m_hdr = false;
   bool m_allow_tearing_supported = false;
   bool m_has_fullscreen = false;
   bool m_fullscreen_request = false;

--- a/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
@@ -399,7 +399,7 @@ void VKGfx::OnConfigChanged(u32 bits)
   }
 
   // For quad-buffered stereo we need to change the layer count, so recreate the swap chain.
-  if (m_swap_chain && bits & CONFIG_CHANGE_BIT_STEREO_MODE)
+  if (m_swap_chain && (bits & CONFIG_CHANGE_BIT_STEREO_MODE) || (bits & CONFIG_CHANGE_BIT_HDR))
   {
     ExecuteCommandBuffer(false, true);
     m_swap_chain->RecreateSwapChain();

--- a/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
@@ -154,7 +154,7 @@ bool SwapChain::SelectSurfaceFormat()
                                              &format_count, surface_formats.data());
   ASSERT(res == VK_SUCCESS);
 
-  // If there is a single undefined surface format, the device doesn't care, so we'll just use RGBA
+  // If there is a single undefined surface format, the device doesn't care, so we'll just use RGBA8
   if (surface_formats[0].format == VK_FORMAT_UNDEFINED)
   {
     m_surface_format.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -162,22 +162,61 @@ bool SwapChain::SelectSurfaceFormat()
     return true;
   }
 
-  // Try to find a suitable format.
+  const VkSurfaceFormatKHR* surface_format_RGBA8 = nullptr;
+  const VkSurfaceFormatKHR* surface_format_BGRA8 = nullptr;
+  const VkSurfaceFormatKHR* surface_format_RGB10_A2 = nullptr;
+  const VkSurfaceFormatKHR* surface_format_RGBA16F_scRGB = nullptr;
+
+  // Try to find all suitable formats.
   for (const VkSurfaceFormatKHR& surface_format : surface_formats)
   {
-    // Some drivers seem to return a SRGB format here (Intel Mesa).
-    // This results in gamma correction when presenting to the screen, which we don't want.
-    // Use a linear format instead, if this is the case.
+    // Some drivers seem to return a RGBA8 SRGB format here (Intel Mesa).
+    // Some other drivers return both a RGBA8 SRGB and UNORM formats (Nvidia).
+    // This results in gamma correction when presenting to the screen, which we don't want,
+    // because we already apply gamma ourselves, and we might not use sRGB gamma.
+    // Force using a linear format instead, if this is the case.
     VkFormat format = VKTexture::GetLinearFormat(surface_format.format);
+    if (format == VK_FORMAT_R8G8B8A8_UNORM)
+      surface_format_RGBA8 = &surface_format;
+    else if (format == VK_FORMAT_B8G8R8A8_UNORM)
+      surface_format_BGRA8 = &surface_format;
+    else if (format == VK_FORMAT_A2B10G10R10_UNORM_PACK32 &&
+             surface_format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+      surface_format_RGB10_A2 = &surface_format;
+    else if (format == VK_FORMAT_R16G16B16A16_SFLOAT &&
+             surface_format.colorSpace == VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT)
+      surface_format_RGBA16F_scRGB = &surface_format;
+    else
+      continue;
+  }
+
+  const VkSurfaceFormatKHR* surface_format = nullptr;
+
+  // Pick the best format.
+  // "g_ActiveConfig" might not have been been updated yet.
+  if (g_Config.bHDR && surface_format_RGBA16F_scRGB)
+    surface_format = surface_format_RGBA16F_scRGB;
+  else if (surface_format_RGB10_A2)
+    surface_format = surface_format_RGB10_A2;
+  else if (surface_format_RGBA8)
+    surface_format = surface_format_RGBA8;
+  else if (surface_format_BGRA8)
+    surface_format = surface_format_BGRA8;
+
+  if (surface_format)
+  {
+    const VkFormat format = VKTexture::GetLinearFormat(surface_format->format);
     if (format == VK_FORMAT_R8G8B8A8_UNORM)
       m_texture_format = AbstractTextureFormat::RGBA8;
     else if (format == VK_FORMAT_B8G8R8A8_UNORM)
       m_texture_format = AbstractTextureFormat::BGRA8;
-    else
-      continue;
+    else if (format == VK_FORMAT_A2B10G10R10_UNORM_PACK32)
+      m_texture_format = AbstractTextureFormat::RGB10_A2;
+    else if (format == VK_FORMAT_R16G16B16A16_SFLOAT)
+      m_texture_format = AbstractTextureFormat::RGBA16F;
 
     m_surface_format.format = format;
-    m_surface_format.colorSpace = surface_format.colorSpace;
+    m_surface_format.colorSpace = surface_format->colorSpace;
     return true;
   }
 

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -190,7 +190,7 @@ VkFormat VKTexture::GetVkFormatForHostTextureFormat(AbstractTextureFormat format
     return VK_FORMAT_B8G8R8A8_UNORM;
 
   case AbstractTextureFormat::RGB10_A2:
-    return VK_FORMAT_A2R10G10B10_UNORM_PACK32;
+    return VK_FORMAT_A2B10G10R10_UNORM_PACK32;
 
   case AbstractTextureFormat::RGBA16F:
     return VK_FORMAT_R16G16B16A16_SFLOAT;

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -382,6 +382,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsPartialMultisampleResolve = true;  // Assumed support.
   config->backend_info.bSupportsDynamicVertexLoader = true;        // Assumed support.
   config->backend_info.bSupportsVSLinePointExpand = true;          // Assumed support.
+  config->backend_info.bSupportsHDROutput = true;                  // Assumed support.
 }
 
 void VulkanContext::PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list)

--- a/Source/Core/VideoCommon/AbstractGfx.cpp
+++ b/Source/Core/VideoCommon/AbstractGfx.cpp
@@ -177,5 +177,5 @@ bool AbstractGfx::UseGeometryShaderForUI() const
   // OpenGL doesn't render to a 2-layer backbuffer like D3D/Vulkan for quad-buffered stereo,
   // instead drawing twice and the eye selected by glDrawBuffer() (see Presenter::RenderXFBToScreen)
   return g_ActiveConfig.stereo_mode == StereoMode::QuadBuffer &&
-         g_ActiveConfig.backend_info.api_type != APIType::OpenGL;
+         !g_ActiveConfig.backend_info.bUsesExplictQuadBuffering;
 }

--- a/Source/Core/VideoCommon/AbstractGfx.h
+++ b/Source/Core/VideoCommon/AbstractGfx.h
@@ -159,8 +159,8 @@ public:
   // Called when the configuration changes, and backend structures need to be updated.
   virtual void OnConfigChanged(u32 changed_bits);
 
-  // Returns true if a layer-expanding geometry shader should be used when rendering the user
-  // interface and final XFB.
+  // Returns true if a layer-expanding geometry shader should be used when rendering
+  // the user interface on the output buffer.
   bool UseGeometryShaderForUI() const;
 
   // Returns info about the main surface (aka backbuffer)

--- a/Source/Core/VideoCommon/FramebufferShaderGen.cpp
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.cpp
@@ -672,7 +672,7 @@ std::string GenerateImGuiVertexShader()
   return code.GetBuffer();
 }
 
-std::string GenerateImGuiPixelShader()
+std::string GenerateImGuiPixelShader(bool linear_space_output)
 {
   ShaderCode code;
   EmitSamplerDeclarations(code, 0, 1, false);
@@ -680,8 +680,13 @@ std::string GenerateImGuiPixelShader()
   code.Write("{{\n"
              "  ocol0 = ");
   EmitSampleTexture(code, 0, "float3(v_tex0.xy, 0.0)");
-  code.Write(" * v_col0;\n"
-             "}}\n");
+  // We approximate to gamma 2.2 instead of sRGB as it barely matters for this case.
+  // Note that if HDR is enabled, ideally we should multiply by
+  // the paper white brightness for readability.
+  if (linear_space_output)
+    code.Write(" * pow(v_col0, float4(2.2f, 2.2f, 2.2f, 1.0f));\n}}\n");
+  else
+    code.Write(" * v_col0;\n}}\n");
 
   return code.GetBuffer();
 }

--- a/Source/Core/VideoCommon/FramebufferShaderGen.h
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.h
@@ -24,6 +24,6 @@ std::string GenerateFormatConversionShader(EFBReinterpretType convtype, u32 samp
 std::string GenerateTextureReinterpretShader(TextureFormat from_format, TextureFormat to_format);
 std::string GenerateEFBRestorePixelShader();
 std::string GenerateImGuiVertexShader();
-std::string GenerateImGuiPixelShader();
+std::string GenerateImGuiPixelShader(bool linear_space_output = false);
 
 }  // namespace FramebufferShaderGen

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -120,11 +120,15 @@ bool OnScreenUI::RecompileImGuiPipeline()
     return true;
   }
 
+  const bool linear_space_output =
+      g_presenter->GetBackbufferFormat() == AbstractTextureFormat::RGBA16F;
+
   std::unique_ptr<AbstractShader> vertex_shader = g_gfx->CreateShaderFromSource(
       ShaderStage::Vertex, FramebufferShaderGen::GenerateImGuiVertexShader(),
       "ImGui vertex shader");
   std::unique_ptr<AbstractShader> pixel_shader = g_gfx->CreateShaderFromSource(
-      ShaderStage::Pixel, FramebufferShaderGen::GenerateImGuiPixelShader(), "ImGui pixel shader");
+      ShaderStage::Pixel, FramebufferShaderGen::GenerateImGuiPixelShader(linear_space_output),
+      "ImGui pixel shader");
   if (!vertex_shader || !pixel_shader)
   {
     PanicAlertFmt("Failed to compile ImGui shaders");

--- a/Source/Core/VideoCommon/PostProcessing.h
+++ b/Source/Core/VideoCommon/PostProcessing.h
@@ -16,12 +16,14 @@
 class AbstractPipeline;
 class AbstractShader;
 class AbstractTexture;
+class AbstractFramebuffer;
 
 namespace VideoCommon
 {
 class PostProcessingConfiguration
 {
 public:
+  // User defined post process
   struct ConfigurationOption
   {
     enum class OptionType
@@ -105,29 +107,43 @@ public:
   void RecompilePipeline();
 
   void BlitFromTexture(const MathUtil::Rectangle<int>& dst, const MathUtil::Rectangle<int>& src,
-                       const AbstractTexture* src_tex, int src_layer);
+                       const AbstractTexture* src_tex, int src_layer = -1);
+
+  bool IsColorCorrectionActive() const;
+  bool NeedsIntermediaryBuffer() const;
 
 protected:
-  std::string GetUniformBufferHeader() const;
-  std::string GetHeader() const;
+  std::string GetUniformBufferHeader(bool user_post_process) const;
+  std::string GetHeader(bool user_post_process) const;
   std::string GetFooter() const;
 
   bool CompileVertexShader();
   bool CompilePixelShader();
   bool CompilePipeline();
 
-  size_t CalculateUniformsSize() const;
+  size_t CalculateUniformsSize(bool user_post_process) const;
   void FillUniformBuffer(const MathUtil::Rectangle<int>& src, const AbstractTexture* src_tex,
-                         int src_layer);
+                         int src_layer, const MathUtil::Rectangle<int>& dst,
+                         const MathUtil::Rectangle<int>& wnd, u8* buffer, bool user_post_process);
 
   // Timer for determining our time value
   Common::Timer m_timer;
-  PostProcessingConfiguration m_config;
 
+  // Dolphin fixed post process:
+  PostProcessingConfiguration::ConfigMap m_default_options;
+  std::unique_ptr<AbstractShader> m_default_vertex_shader;
+  std::unique_ptr<AbstractShader> m_default_pixel_shader;
+  std::unique_ptr<AbstractPipeline> m_default_pipeline;
+  std::unique_ptr<AbstractFramebuffer> m_intermediary_frame_buffer;
+  std::unique_ptr<AbstractTexture> m_intermediary_color_texture;
+  std::vector<u8> m_default_uniform_staging_buffer;
+  // User post process:
+  PostProcessingConfiguration m_config;
   std::unique_ptr<AbstractShader> m_vertex_shader;
   std::unique_ptr<AbstractShader> m_pixel_shader;
   std::unique_ptr<AbstractPipeline> m_pipeline;
-  AbstractTextureFormat m_framebuffer_format = AbstractTextureFormat::Undefined;
   std::vector<u8> m_uniform_staging_buffer;
+
+  AbstractTextureFormat m_framebuffer_format = AbstractTextureFormat::Undefined;
 };
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -514,9 +514,11 @@ void Presenter::RenderXFBToScreen(const MathUtil::Rectangle<int>& target_rc,
     m_post_processor->BlitFromTexture(left_rc, source_rc, source_texture, 0);
     m_post_processor->BlitFromTexture(right_rc, source_rc, source_texture, 1);
   }
+  // Every other case will be treated the same (stereo or not).
+  // If there's multiple source layers, they should all be copied.
   else
   {
-    m_post_processor->BlitFromTexture(target_rc, source_rc, source_texture, 0);
+    m_post_processor->BlitFromTexture(target_rc, source_rc, source_texture);
   }
 }
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -139,6 +139,15 @@ void VideoConfig::Refresh()
   bArbitraryMipmapDetection = Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
   fArbitraryMipmapDetectionThreshold =
       Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD);
+  bHDR = Config::Get(Config::GFX_ENHANCE_HDR_OUTPUT);
+
+  color_correction.bCorrectColorSpace = Config::Get(Config::GFX_CC_CORRECT_COLOR_SPACE);
+  color_correction.game_color_space = Config::Get(Config::GFX_CC_GAME_COLOR_SPACE);
+  color_correction.bCorrectGamma = Config::Get(Config::GFX_CC_CORRECT_GAMMA);
+  color_correction.fGameGamma = Config::Get(Config::GFX_CC_GAME_GAMMA);
+  color_correction.bSDRDisplayGammaSRGB = Config::Get(Config::GFX_CC_SDR_DISPLAY_GAMMA_SRGB);
+  color_correction.fSDRDisplayCustomGamma = Config::Get(Config::GFX_CC_SDR_DISPLAY_CUSTOM_GAMMA);
+  color_correction.fHDRPaperWhiteNits = Config::Get(Config::GFX_CC_HDR_PAPER_WHITE_NITS);
 
   stereo_mode = Config::Get(Config::GFX_STEREO_MODE);
   iStereoDepth = Config::Get(Config::GFX_STEREO_DEPTH);
@@ -263,6 +272,7 @@ void CheckForConfigChanges()
   const AspectMode old_suggested_aspect_mode = g_ActiveConfig.suggested_aspect_mode;
   const bool old_widescreen_hack = g_ActiveConfig.bWidescreenHack;
   const auto old_post_processing_shader = g_ActiveConfig.sPostProcessingShader;
+  const auto old_hdr = g_ActiveConfig.bHDR;
 
   UpdateActiveConfig();
   FreeLook::UpdateActiveConfig();
@@ -314,6 +324,8 @@ void CheckForConfigChanges()
     changed_bits |= CONFIG_CHANGE_BIT_ASPECT_RATIO;
   if (old_post_processing_shader != g_ActiveConfig.sPostProcessingShader)
     changed_bits |= CONFIG_CHANGE_BIT_POST_PROCESSING_SHADER;
+  if (old_hdr != g_ActiveConfig.bHDR)
+    changed_bits |= CONFIG_CHANGE_BIT_HDR;
 
   // No changes?
   if (changed_bits == 0)
@@ -323,7 +335,7 @@ void CheckForConfigChanges()
 
   // Framebuffer changed?
   if (changed_bits & (CONFIG_CHANGE_BIT_MULTISAMPLES | CONFIG_CHANGE_BIT_STEREO_MODE |
-                      CONFIG_CHANGE_BIT_TARGET_SIZE))
+                      CONFIG_CHANGE_BIT_TARGET_SIZE | CONFIG_CHANGE_BIT_HDR))
   {
     g_framebuffer_manager->RecreateEFBFramebuffer();
   }

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -52,6 +52,13 @@ enum class TextureFilteringMode : int
   Linear,
 };
 
+enum class ColorCorrectionRegion : int
+{
+  SMPTE_NTSCM,
+  SYSTEMJ_NTSCJ,
+  EBU_PAL,
+};
+
 enum class TriState : int
 {
   Off,
@@ -72,6 +79,7 @@ enum ConfigChangeBits : u32
   CONFIG_CHANGE_BIT_BBOX = (1 << 7),
   CONFIG_CHANGE_BIT_ASPECT_RATIO = (1 << 8),
   CONFIG_CHANGE_BIT_POST_PROCESSING_SHADER = (1 << 9),
+  CONFIG_CHANGE_BIT_HDR = (1 << 10),
 };
 
 // NEVER inherit from this class.
@@ -101,6 +109,26 @@ struct VideoConfig final
   bool bDisableCopyFilter = false;
   bool bArbitraryMipmapDetection = false;
   float fArbitraryMipmapDetectionThreshold = 0;
+  bool bHDR = false;
+
+  // Color Correction
+  struct
+  {
+    // Color Space Correction:
+    bool bCorrectColorSpace = false;
+    ColorCorrectionRegion game_color_space = ColorCorrectionRegion::SMPTE_NTSCM;
+
+    // Gamma Correction:
+    bool bCorrectGamma = false;
+    float fGameGamma = 2.35f;
+    bool bSDRDisplayGammaSRGB = true;
+    // Custom gamma when the display is not sRGB
+    float fSDRDisplayCustomGamma = 2.2f;
+
+    // HDR:
+    // 200 is a good default value that matches the brightness of many SDR screens
+    float fHDRPaperWhiteNits = 200.f;
+  } color_correction;
 
   // Information
   bool bShowFPS = false;
@@ -275,6 +303,7 @@ struct VideoConfig final
     bool bSupportsDynamicVertexLoader = false;
     bool bSupportsVSLinePointExpand = false;
     bool bSupportsGLLayerInFS = true;
+    bool bSupportsHDROutput = false;
   } backend_info;
 
   // Utility


### PR DESCRIPTION
This PR implements:
- Color correction to match the NTSC and PAL color spaces that the GC and Wii targeted (this does NOT emulate actual features that CRT TVs had, it just users their color primaries)
- Gamma correction to also match the NTSC/PAL gamma (instead of outputting in sRGB, which was never used by consoles)
- HDR output (scRGB, 16 bit float)
- SDR output quality (R10G10B10A2 instead of R8G8B8A8, the alpha bits were wasted)

The advantages of having a "native" HDR implementation within Dolphin are the following:
- We can sample textures in linear space correctly, so linear sampling works correctly and isn't influenced by gamma.
- Allows Dolphin to add its own AutoHDR shader. This is especially relevant because the lighting of older games doesn't really play nice with Windows AutoHDR. Additionally, this implementation would be supported by Windows 10 and Linux.
- Allows to display the whole EBU/PAL and NTSC-J color spaces, which are more extended than Rec.709.
- It avoids loosing quality if doing multiple post process passes, like we might now do if we have color correction enabled.

All features are optional and disabled by default. Dolpin's default behaviour is unchanged (with the exception of outputting in a R10G10B10A2 if supported). Tooltips have been provided to explain all new features in the most user friendly way I could.

This has been carefully tested and there should be no regression in any of the different features that Dolphin
offers, like multisampling, stereo rendering, other post processes, etc etc.

Fixes: https://bugs.dolphin-emu.org/issues/8941

Credit to @EndlesslyFlowering and @Dogway for helping with the NTSC/PAL video "standards" information and conversion matrices.

Color Correction Settings:
![Dolphin_eC9WZMcQeO](https://github.com/dolphin-emu/dolphin/assets/7011366/8b6e5c56-5893-43f9-ab2f-292c888c5c3e)

Untouched Dolphin output:
![Untouched Dolphin output](https://github.com/dolphin-emu/dolphin/assets/7011366/451acf62-4a19-435d-8586-c505090a607e)

Interpreted as NTSC-M:
![Interpreted as NTSC-M](https://github.com/dolphin-emu/dolphin/assets/7011366/6ecf15d2-8d54-4669-9d90-68e93b66e6bb)

Interpreted as 2.35 gamma:
![Interpreted as 2 35 gamma](https://github.com/dolphin-emu/dolphin/assets/7011366/9c0a8d4b-80fb-4c96-bbb6-40ea7dff1bf4)

Non gamma corrected sampling (low resolutition emulation into high res window):
![Non gamma corrected sampling](https://github.com/dolphin-emu/dolphin/assets/7011366/d143a067-226d-4124-ae86-6dd035428337)

Gamma corrected sampling (low resolutition emulation into high res window):
![Gamma corrected sampling](https://github.com/dolphin-emu/dolphin/assets/7011366/9383e95e-d9c7-464d-a6c2-b1c2a09108da)

HDR screenshots comparions (BT.2020 is needed to show all the colors from PAL and NTSC-J):
[HDR Color Space Correction Comparison.zip](https://github.com/dolphin-emu/dolphin/files/11645369/HDR.Color.Space.Correction.Comparison.zip)
[HDR Non Corrected.zip](https://github.com/dolphin-emu/dolphin/files/11645371/HDR.Non.Corrected.zip)

Follow up PRs will add:
- Different texture sampling (upscaling and downscaling) modes, similar to Cemu
- My own AutoHDR shader, which has a set of different AutoHDR logics, given that the best one usually depends on the game.