### PR TITLE
Video: Fix lens_distortion post process shader not compiling

### DIFF
--- a/Data/Sys/Shaders/lens_distortion.glsl
+++ b/Data/Sys/Shaders/lens_distortion.glsl
@@ -81,7 +81,7 @@ void main()
   float2 uv = (widenedRadial/2.0f) + float2(0.5f, 0.5f) + float2(offsetAdd, 0.0f);
 
   // Sample the texture at the source location
-  if(any(clamp(uv, 0.0, 1.0) != uv))
+  if (clamp(uv, 0.0, 1.0) != uv)
   {
     // black if beyond bounds
     SetOutput(float4(0.0, 0.0, 0.0, 0.0));


### PR DESCRIPTION
`any()` failed to build on my machine, but it doesn't seem to be necessary