### PR TITLE
VideoBackends:Metal: Allocate bounding box uploads on a cpu buffer

### DIFF
--- a/Source/Core/VideoBackends/Metal/MTLBoundingBox.mm
+++ b/Source/Core/VideoBackends/Metal/MTLBoundingBox.mm
@@ -54,8 +54,7 @@ void Metal::BoundingBox::Write(u32 index, const std::vector<BBoxType>& values)
   {
     @autoreleasepool
     {
-      StateTracker::Map map = g_state_tracker->Allocate(StateTracker::UploadBuffer::Other, size,
-                                                        StateTracker::AlignMask::Other);
+      StateTracker::Map map = g_state_tracker->AllocateForTextureUpload(size);
       memcpy(map.cpu_buffer, values.data(), size);
       g_state_tracker->EndRenderPass();
       id<MTLBlitCommandEncoder> upload = [g_state_tracker->GetRenderCmdBuf() blitCommandEncoder];


### PR DESCRIPTION
AMD Metal drivers have a goofy bug where the bbox buffer stops being coherent with the cpu if you copy to it from a private (gpu) buffer and don't do anything else with it in that command buffer.

[Test case available here if anyone's curious](https://github.com/TellowKrinkle/MetalBugReproduction/releases/tag/BrokenSharedBufferCoherency)

The old way was actually missing a required fence wait on the upload fence (to prevent the GPU from attempting the copy before it uploaded the copy source), but that's not the actual cause of the breakage, as indicated by the above test case, which doesn't disable hazard tracking and therefore doesn't have any fence requirements.

Side note, if anyone has any AMD GPUs running not-Ventura, please run the linked test case and report back, I'd love to figure out if that bug is new or if it's been around for a while.