### PR TITLE
WALL•E - Use 'Safe' Texture Cache Accuracy

### DIFF
--- a/Data/Sys/GameSettings/RWA.ini
+++ b/Data/Sys/GameSettings/RWA.ini
@@ -2,3 +2,4 @@
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
Prevents missing characters in text in menus.

Example in the main menu on medium and Fast settings:
![RWAE78_2023-05-30_15-12-31](https://github.com/dolphin-emu/dolphin/assets/14845347/771b30fd-eebc-479e-96ba-47dd50fb3ced)

Main menu on Safe:
![RWAE78_2023-05-30_15-13-21](https://github.com/dolphin-emu/dolphin/assets/14845347/40d82432-9b98-4870-a8ba-5fb2298cf65d)
