### PR TITLE
Android: Fix submenus for Wii Remote 2-4

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.kt
@@ -85,6 +85,14 @@ enum class MenuTag {
     val isWiimoteMenu: Boolean
         get() = this == WIIMOTE_1 || this == WIIMOTE_2 || this == WIIMOTE_3 || this == WIIMOTE_4
 
+    val isWiimoteSubmenu: Boolean
+        get() = this == WIIMOTE_GENERAL_1 || this == WIIMOTE_GENERAL_2 ||
+                this == WIIMOTE_GENERAL_3 || this == WIIMOTE_GENERAL_4 ||
+                this == WIIMOTE_MOTION_SIMULATION_1 || this == WIIMOTE_MOTION_SIMULATION_2 ||
+                this == WIIMOTE_MOTION_SIMULATION_3 || this == WIIMOTE_MOTION_SIMULATION_4 ||
+                this == WIIMOTE_MOTION_INPUT_1 || this == WIIMOTE_MOTION_INPUT_2 ||
+                this == WIIMOTE_MOTION_INPUT_3 || this == WIIMOTE_MOTION_INPUT_4
+
     val isWiimoteExtensionMenu: Boolean
         get() = this == WIIMOTE_EXTENSION_1 || this == WIIMOTE_EXTENSION_2 || this == WIIMOTE_EXTENSION_3 || this == WIIMOTE_EXTENSION_4
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -52,7 +52,7 @@ class SettingsFragmentPresenter(
         if (menuTag.isGCPadMenu || menuTag.isWiimoteExtensionMenu) {
             controllerNumber = menuTag.subType
             controllerType = extras.getInt(ARG_CONTROLLER_TYPE)
-        } else if (menuTag.isWiimoteMenu) {
+        } else if (menuTag.isWiimoteMenu || menuTag.isWiimoteSubmenu) {
             controllerNumber = menuTag.subType
         } else if (menuTag.isSerialPort1Menu) {
             serialPort1Type = extras.getInt(ARG_SERIALPORT1_TYPE)


### PR DESCRIPTION
Accessing any of the submenus "Buttons", "Motion Simulation" or "Motion Input" for Wii Remotes 2-4 would actually lead to the corresponding submenu for Wii Remote 1.