### PR TITLE
Input: Improve Controller Interface devices threading

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -89,6 +89,7 @@ public:
   // Can be called by any thread at any time (when initialized).
   void RefreshDevices(RefreshReason reason = RefreshReason::Other);
   void Shutdown();
+  std::shared_ptr<ciface::Core::Device> GetDeviceFromHandle(int handle) const;
   bool AddDevice(std::shared_ptr<ciface::Core::Device> device);
   // Removes all the devices the function returns true to.
   // If all the devices shared ptrs need to be destroyed immediately,

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -12,6 +12,7 @@
 
 #include <fmt/format.h>
 
+#include "Common/Assert.h"
 #include "Common/MathUtil.h"
 #include "Common/Thread.h"
 
@@ -52,6 +53,13 @@ private:
   const std::string m_name;
   const std::pair<Device::Input*, Device::Input*> m_inputs;
 };
+
+Device::Device()
+{
+  static std::atomic<int> device_handle_count = 0;
+  m_handle = device_handle_count.fetch_add(1);
+  ASSERT_MSG(CONTROLLERINTERFACE, m_handle != -1, "Run out of device handles");
+}
 
 Device::~Device()
 {

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -111,6 +111,7 @@ public:
     Output* ToOutput() override { return this; }
   };
 
+  Device();
   virtual ~Device();
 
   int GetId() const { return m_id; }
@@ -118,11 +119,14 @@ public:
   virtual std::string GetName() const = 0;
   virtual std::string GetSource() const = 0;
   std::string GetQualifiedName() const;
-  virtual void UpdateInput() {}
+  // Return false to remove the device
+  virtual bool UpdateInput() { return true; }
 
   // May be overridden to implement hotplug removal.
   // Currently handled on a per-backend basis but this could change.
   virtual bool IsValid() const { return true; }
+
+  int GetHandle() const { return m_handle; }
 
   // Returns true whether this device is "virtual/emulated", not linked
   // to any actual physical device. Mostly used by keyboard and mouse devices,
@@ -178,6 +182,7 @@ private:
   int m_id = 0;
   std::vector<Input*> m_inputs;
   std::vector<Output*> m_outputs;
+  int m_handle;
 };
 
 //

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -221,7 +221,7 @@ bool Joystick::IsValid() const
   return SUCCEEDED(m_device->Acquire());
 }
 
-void Joystick::UpdateInput()
+bool Joystick::UpdateInput()
 {
   HRESULT hr = 0;
 
@@ -260,6 +260,8 @@ void Joystick::UpdateInput()
   // try reacquire if input lost
   if (DIERR_INPUTLOST == hr || DIERR_NOTACQUIRED == hr)
     m_device->Acquire();
+
+  return true;
 }
 
 // get name

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
@@ -57,7 +57,7 @@ private:
   };
 
 public:
-  void UpdateInput() override;
+  bool UpdateInput() override;
 
   Joystick(const LPDIRECTINPUTDEVICE8 device);
   ~Joystick();

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -205,7 +205,7 @@ void KeyboardMouse::UpdateCursorInput()
   m_state_in.cursor.y = (ControlState(point.y) / win_height * 2 - 1) * window_scale.y;
 }
 
-void KeyboardMouse::UpdateInput()
+bool KeyboardMouse::UpdateInput()
 {
   UpdateCursorInput();
 
@@ -254,6 +254,8 @@ void KeyboardMouse::UpdateInput()
     else
       INFO_LOG_FMT(CONTROLLERINTERFACE, "Keyboard device failed to re-acquire, we'll retry later");
   }
+
+  return true;
 }
 
 std::string KeyboardMouse::GetName() const

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
@@ -94,7 +94,7 @@ private:
   };
 
 public:
-  void UpdateInput() override;
+  bool UpdateInput() override;
 
   KeyboardMouse(const LPDIRECTINPUTDEVICE8 kb_device, const LPDIRECTINPUTDEVICE8 mo_device);
   ~KeyboardMouse();

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -128,7 +128,7 @@ private:
   };
 
 public:
-  void UpdateInput() override;
+  bool UpdateInput() override;
 
   Device(std::string name, int index, std::string server_address, u16 server_port, u32 client_uid);
 
@@ -614,7 +614,7 @@ std::string Device::GetSource() const
   return std::string(DUALSHOCKUDP_SOURCE_NAME);
 }
 
-void Device::UpdateInput()
+bool Device::UpdateInput()
 {
   // Regularly tell the UDP server to feed us controller data
   const auto now = SteadyClock::now();
@@ -660,6 +660,8 @@ void Device::UpdateInput()
       m_prev_touch_valid = true;
     }
   }
+
+  return true;
 }
 
 std::optional<int> Device::GetPreferredId() const

--- a/Source/Core/InputCommon/ControllerInterface/InputBackend.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/InputBackend.cpp
@@ -12,7 +12,7 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
 
 InputBackend::~InputBackend() = default;
 
-void InputBackend::UpdateInput()
+void InputBackend::UpdateInput(std::vector<const ciface::Core::Device*>& devices_to_remove)
 {
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/InputBackend.h
+++ b/Source/Core/InputCommon/ControllerInterface/InputBackend.h
@@ -3,10 +3,18 @@
 
 #pragma once
 
+#include <vector>
+
 class ControllerInterface;
 
 namespace ciface
 {
+
+namespace Core
+{
+class Device;
+}
+
 class InputBackend
 {
 public:
@@ -15,7 +23,9 @@ public:
   virtual ~InputBackend();
 
   virtual void PopulateDevices() = 0;
-  virtual void UpdateInput();
+  // Do NOT directly add/remove devices from here,
+  // just add them to the removal list if necessary.
+  virtual void UpdateInput(std::vector<const ciface::Core::Device*>& devices_to_remove);
 
   ControllerInterface& GetControllerInterface();
 

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -86,7 +86,7 @@ PipeDevice::~PipeDevice()
   close(m_fd);
 }
 
-void PipeDevice::UpdateInput()
+bool PipeDevice::UpdateInput()
 {
   // Read any pending characters off the pipe. If we hit a newline,
   // then dequeue a command off the front of m_buf and parse it.
@@ -105,6 +105,7 @@ void PipeDevice::UpdateInput()
     m_buf.erase(0, newline + 1);
     newline = m_buf.find("\n");
   }
+  return true;
 }
 
 void PipeDevice::AddAxis(const std::string& name, double value)

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
@@ -29,7 +29,7 @@ public:
   PipeDevice(int fd, const std::string& name);
   ~PipeDevice();
 
-  void UpdateInput() override;
+  bool UpdateInput() override;
   std::string GetName() const override { return m_name; }
   std::string GetSource() const override { return "Pipe"; }
 

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
@@ -62,7 +62,7 @@ private:
   };
 
 public:
-  void UpdateInput() override;
+  bool UpdateInput() override;
 
   explicit KeyboardAndMouse(void* view);
   ~KeyboardAndMouse() override;

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -236,7 +236,7 @@ void KeyboardAndMouse::MainThreadInitialization(void* view)
   m_window_pos_observer = [[DolWindowPositionObserver alloc] initWithView:cocoa_view];
 }
 
-void KeyboardAndMouse::UpdateInput()
+bool KeyboardAndMouse::UpdateInput()
 {
   NSRect bounds = [m_window_pos_observer frame];
 
@@ -268,6 +268,8 @@ void KeyboardAndMouse::UpdateInput()
     m_cursor.x = (loc.x / window_width * 2 - 1.0) * window_scale.x;
     m_cursor.y = (loc.y / window_height * 2 - 1.0) * -window_scale.y;
   }
+
+  return true;
 }
 
 std::string KeyboardAndMouse::GetName() const

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -18,6 +18,11 @@
 #include <Windows.h>
 #endif
 
+namespace ciface::Core
+{
+class Device;
+}
+
 namespace ciface::SDL
 {
 static std::string GetJoystickName(int index)
@@ -35,7 +40,7 @@ public:
   InputBackend(ControllerInterface* controller_interface);
   ~InputBackend();
   void PopulateDevices() override;
-  void UpdateInput() override;
+  void UpdateInput(std::vector<const ciface::Core::Device*>& devices_to_remove) override;
 
 private:
   void OpenAndAddDevice(int index);
@@ -658,7 +663,7 @@ void Joystick::Motor::SetState(ControlState state)
 }
 #endif
 
-void InputBackend::UpdateInput()
+void InputBackend::UpdateInput(std::vector<const ciface::Core::Device*>& devices_to_remove)
 {
   SDL_JoystickUpdate();
 }

--- a/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp
@@ -113,7 +113,7 @@ public:
   Device(hid_device* device);
   std::string GetName() const final override;
   std::string GetSource() const final override;
-  void UpdateInput() override;
+  bool UpdateInput() override;
 
 private:
   hid_device* m_device;
@@ -278,7 +278,7 @@ std::string Device::GetSource() const
   return std::string(STEAMDECK_SOURCE_NAME);
 }
 
-void Device::UpdateInput()
+bool Device::UpdateInput()
 {
   DeckInputReport rpt;
   bool got_anything = false;
@@ -289,16 +289,18 @@ void Device::UpdateInput()
   }
   // In case there were no reports available to be read, bail early.
   if (!got_anything)
-    return;
+    return true;
 
   if (rpt.major_ver != 0x01 || rpt.minor_ver != 0x00 || rpt.report_type != 0x09 ||
       rpt.report_sz != sizeof(rpt))
   {
     ERROR_LOG_FMT(CONTROLLERINTERFACE, "Steam Deck bad report");
-    return;
+    return true;
   }
 
   m_latest_input = rpt;
+
+  return true;
 }
 
 }  // namespace ciface::SteamDeck

--- a/Source/Core/InputCommon/ControllerInterface/WGInput/WGInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/WGInput/WGInput.cpp
@@ -489,7 +489,7 @@ private:
 
   std::string GetSource() const override { return std::string(SOURCE_NAME); }
 
-  void UpdateInput() override
+  bool UpdateInput() override
   {
     // IRawGameController:
     static_assert(sizeof(bool) == sizeof(ButtonValueType));
@@ -526,6 +526,8 @@ private:
     // IGameControllerBatteryInfo:
     if (!UpdateBatteryLevel())
       DEBUG_LOG_FMT(CONTROLLERINTERFACE, "WGInput: UpdateBatteryLevel failed.");
+
+    return true;
   }
 
   void UpdateMotors()

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
@@ -1395,14 +1395,10 @@ void Device::UpdateRumble()
   QueueReport(OutputReportRumble{});
 }
 
-void Device::UpdateInput()
+bool Device::UpdateInput()
 {
   if (!m_wiimote->IsConnected())
-  {
-    g_controller_interface.RemoveDevice(
-        [this](const Core::Device* device) { return device == this; });
-    return;
-  }
+    return false;
 
   UpdateRumble();
   RunTasks();
@@ -1413,6 +1409,8 @@ void Device::UpdateInput()
     ProcessInputReport(report);
     RunTasks();
   }
+
+  return true;
 }
 
 void Device::MotionPlusState::ProcessData(const WiimoteEmu::MotionPlus::DataFormat& data)

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.h
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.h
@@ -35,7 +35,7 @@ public:
   std::string GetSource() const override;
   int GetSortPriority() const override;
 
-  void UpdateInput() override;
+  bool UpdateInput() override;
 
 private:
   using Clock = std::chrono::steady_clock;

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
@@ -264,7 +264,7 @@ std::string Device::GetSource() const
   return "XInput";
 }
 
-void Device::UpdateInput()
+bool Device::UpdateInput()
 {
   PXInputGetState(m_index, &m_state_in);
 
@@ -286,6 +286,8 @@ void Device::UpdateInput()
       break;
     }
   }
+
+  return true;
 }
 
 void Device::UpdateMotors()

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
@@ -33,7 +33,7 @@ public:
   std::optional<int> GetPreferredId() const override;
   int GetSortPriority() const override { return -2; }
 
-  void UpdateInput() override;
+  bool UpdateInput() override;
 
   void UpdateMotors();
 

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -284,7 +284,7 @@ void KeyboardMouse::UpdateCursor(bool should_center_mouse)
   m_state.cursor.y = (win_y / win_height * 2 - 1) * window_scale.y;
 }
 
-void KeyboardMouse::UpdateInput()
+bool KeyboardMouse::UpdateInput()
 {
   XFlush(m_display);
 
@@ -399,6 +399,8 @@ void KeyboardMouse::UpdateInput()
   XQueryKeymap(m_display, keyboard.data());
   for (size_t i = 0; i != keyboard.size(); ++i)
     m_state.keyboard[i] &= keyboard[i];
+
+  return true;
 }
 
 std::string KeyboardMouse::GetName() const

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -111,7 +111,7 @@ private:
   void UpdateCursor(bool should_center_mouse);
 
 public:
-  void UpdateInput() override;
+  bool UpdateInput() override;
 
   KeyboardMouse(Window window, int opcode, int pointer_deviceid, int keyboard_deviceid,
                 double scroll_increment);

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -674,7 +674,7 @@ void InputBackend::RemoveDevnodeObject(const std::string& node)
   m_devnode_objects.erase(node);
 }
 
-void evdevDevice::UpdateInput()
+bool evdevDevice::UpdateInput()
 {
   // Run through all evdev events
   // libevdev will keep track of the actual controller state internally which can be queried
@@ -691,6 +691,7 @@ void evdevDevice::UpdateInput()
         rc = libevdev_next_event(node.device, LIBEVDEV_READ_FLAG_NORMAL, &ev);
     }
   }
+  return true;
 }
 
 bool evdevDevice::IsValid() const

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
@@ -72,7 +72,7 @@ private:
   };
 
 public:
-  void UpdateInput() override;
+  bool UpdateInput() override;
   bool IsValid() const override;
 
   evdevDevice(InputBackend* input_backend);


### PR DESCRIPTION
This specific issue was already addressed by https://github.com/dolphin-emu/dolphin/pull/11635
though I felt like there was something more we could do, and wasn't too happy with the
likelihood of devices update calls being skipped (due to `m_devices_population_mutex` being locked).

Most importantly, this is the first step in getting rid of the fact that devices are stored as
shared pointers all across the code base, as this created many problems with handling their
lifetime and destructor (which needs to be called at a specific time for some device types).
Devices now hold a unique handle, and they can always be retrieved from it.

Currently there's only a way to retrieve them as shared pointer from the handle,
but in the future we might make a function like this:
`Device* GetDeviceFromHandle(int handle)` and asking to the calling site to lock
`m_devices_population_mutex` for the usage duration,
or add a new function like "PlatformPopulateDevices()" that takes a callback,
which could internally handle the specified device safely.

We can slowly adapt to the new "standard" when new input backends work is done,
for now this just adds the framework.