### PR TITLE
RetroAchievements Bugfix: Fixed Missing DoFrame Call

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -304,6 +304,9 @@ void AchievementManager::AchievementEventHandler(const rc_runtime_event_t* runti
   case RC_RUNTIME_EVENT_LBOARD_STARTED:
     HandleLeaderboardStartedEvent(runtime_event);
     break;
+  case RC_RUNTIME_EVENT_LBOARD_CANCELED:
+    HandleLeaderboardCanceledEvent(runtime_event);
+    break;
   case RC_RUNTIME_EVENT_LBOARD_TRIGGERED:
     HandleLeaderboardTriggeredEvent(runtime_event);
     break;

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -176,6 +176,8 @@ void AchievementManager::LoadGameByFilenameAsync(const std::string& iso_path,
     }
     ActivateDeactivateLeaderboards();
     ActivateDeactivateRichPresence();
+    // Reset this to zero so that RP immediately triggers on the first frame
+    m_last_ping_time = 0;
 
     callback(fetch_game_data_response);
   });
@@ -255,9 +257,13 @@ void AchievementManager::DoFrame()
   });
   if (!m_system)
     return;
-  u64 current_time = m_system->GetCoreTiming().GetTicks();
-  if (current_time - m_last_ping_time > SystemTimers::GetTicksPerSecond() * 120)
-    m_queue.EmplaceItem([this] { PingRichPresence(GenerateRichPresence()); });
+  time_t current_time = std::time(nullptr);
+  if (difftime(current_time, m_last_ping_time) > 120)
+  {
+    RichPresence rp = GenerateRichPresence();
+    m_queue.EmplaceItem([this, rp] { PingRichPresence(rp); });
+    m_last_ping_time = current_time;
+  }
 }
 
 u32 AchievementManager::MemoryPeeker(u32 address, u32 num_bytes, void* ud)

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -5,6 +5,7 @@
 
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include <array>
+#include <ctime>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -109,7 +110,7 @@ private:
   u32 m_game_id = 0;
   rc_api_fetch_game_data_response_t m_game_data{};
   bool m_is_game_loaded = false;
-  u64 m_last_ping_time = 0;
+  time_t m_last_ping_time = 0;
 
   struct UnlockStatus
   {

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -900,6 +900,10 @@ void Callback_NewField(Core::System& system)
       CallOnStateChangedCallbacks(Core::GetState());
     }
   }
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+  AchievementManager::GetInstance()->DoFrame();
+#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 void UpdateTitle()


### PR DESCRIPTION
Somewhere in the process of getting the memory peeking right for achievements, the AchievementManager call to DoFrame went missing. This restores it properly.