### PR TITLE
Core: Assert that only the Host thread may call PauseAndLock().

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -130,6 +130,7 @@ static Common::Event s_cpu_thread_job_finished;
 
 static thread_local bool tls_is_cpu_thread = false;
 static thread_local bool tls_is_gpu_thread = false;
+static thread_local bool tls_is_host_thread = false;
 
 static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi);
 
@@ -222,6 +223,11 @@ bool IsCPUThread()
 bool IsGPUThread()
 {
   return tls_is_gpu_thread;
+}
+
+bool IsHostThread()
+{
+  return tls_is_host_thread;
 }
 
 bool WantsDeterminism()
@@ -336,6 +342,16 @@ void DeclareAsGPUThread()
 void UndeclareAsGPUThread()
 {
   tls_is_gpu_thread = false;
+}
+
+void DeclareAsHostThread()
+{
+  tls_is_host_thread = true;
+}
+
+void UndeclareAsHostThread()
+{
+  tls_is_host_thread = false;
 }
 
 // For the CPU Thread only.
@@ -777,6 +793,8 @@ void SaveScreenShot(std::string_view name)
 static bool PauseAndLock(Core::System& system, bool do_lock, bool unpause_on_unlock)
 {
   // WARNING: PauseAndLock is not fully threadsafe so is only valid on the Host Thread
+  ASSERT(IsHostThread());
+
   if (!IsRunningAndStarted())
     return true;
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -132,6 +132,8 @@ void DeclareAsCPUThread();
 void UndeclareAsCPUThread();
 void DeclareAsGPUThread();
 void UndeclareAsGPUThread();
+void DeclareAsHostThread();
+void UndeclareAsHostThread();
 
 std::string StopMessage(bool main_thread, std::string_view message);
 
@@ -140,6 +142,7 @@ bool IsRunningAndStarted();       // is running and the CPU loop has been entere
 bool IsRunningInCurrentThread();  // this tells us whether we are running in the CPU thread.
 bool IsCPUThread();               // this tells us whether we are the CPU thread.
 bool IsGPUThread();
+bool IsHostThread();
 
 bool WantsDeterminism();
 

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -181,6 +181,8 @@ static std::unique_ptr<Platform> GetPlatform(const optparse::Values& options)
 
 int main(int argc, char* argv[])
 {
+  Core::DeclareAsHostThread();
+
   auto parser = CommandLineParse::CreateParser(CommandLineParse::ParserOptions::OmitGUIOptions);
   parser->add_option("-p", "--platform")
       .action("store")

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -59,16 +59,6 @@ Host* Host::GetInstance()
   return s_instance;
 }
 
-void Host::DeclareAsHostThread()
-{
-  tls_is_host_thread = true;
-}
-
-bool Host::IsHostThread()
-{
-  return tls_is_host_thread;
-}
-
 void Host::SetRenderHandle(void* handle)
 {
   m_render_to_main = Config::Get(Config::MAIN_RENDER_TO_MAIN);

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
   }
 #endif
 
-  Host::GetInstance()->DeclareAsHostThread();
+  Core::DeclareAsHostThread();
 
 #ifdef __APPLE__
   // On macOS, a command line option matching the format "-psn_X_XXXXXX" is passed when

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -71,7 +71,7 @@ Settings::Settings()
   });
 
   m_hotplug_callback_handle = g_controller_interface.RegisterDevicesChangedCallback([this] {
-    if (Host::GetInstance()->IsHostThread())
+    if (Core::IsHostThread())
     {
       emit DevicesChanged();
     }

--- a/Source/Core/DolphinTool/ToolMain.cpp
+++ b/Source/Core/DolphinTool/ToolMain.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Common/Version.h"
+#include "Core/Core.h"
 #include "DolphinTool/Command.h"
 #include "DolphinTool/ConvertCommand.h"
 #include "DolphinTool/HeaderCommand.h"
@@ -27,6 +28,8 @@ static int PrintUsage(int code)
 
 int main(int argc, char* argv[])
 {
+  Core::DeclareAsHostThread();
+
   if (argc < 2)
     return PrintUsage(1);
 

--- a/Source/UnitTests/UnitTestsMain.cpp
+++ b/Source/UnitTests/UnitTestsMain.cpp
@@ -6,6 +6,7 @@
 #include <fmt/format.h>
 
 #include "Common/MsgHandler.h"
+#include "Core/Core.h"
 
 #include "gtest/gtest.h"
 
@@ -24,6 +25,7 @@ int main(int argc, char** argv)
 {
   fmt::print(stderr, "Running main() from UnitTestsMain.cpp\n");
   Common::RegisterMsgAlertHandler(TestMsgHandler);
+  Core::DeclareAsHostThread();
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Core's `PauseAndLock()` states that `// WARNING: PauseAndLock is not fully threadsafe so is only valid on the Host Thread`, but there's absolutely no protection against doing this.

This adds an `ASSERT()` that we are indeed the host thread. To do that, this moves DolphinQt's `IsHostThread()` function into Core, and adds relevant `DeclareAsHostThread()` calls to all entry points.

This may expose erroneous usages of `Core::RunAsCPUThread()` and similar functions, which if found should be fixed before this is merged.