### PR TITLE
VI: Prevent out-of-bounds access when clock register is a nonstandard value.

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -717,7 +717,7 @@ u32 VideoInterfaceManager::GetTargetRefreshRateDenominator() const
 
 u32 VideoInterfaceManager::GetTicksPerSample() const
 {
-  return 2 * SystemTimers::GetTicksPerSecond() / CLOCK_FREQUENCIES[m_clock];
+  return 2 * SystemTimers::GetTicksPerSecond() / CLOCK_FREQUENCIES[m_clock & 1];
 }
 
 u32 VideoInterfaceManager::GetTicksPerHalfLine() const


### PR DESCRIPTION
The emulated system has full access to this register so it could potentially write garbage in there. Garbage could also be loaded from a savestate.

YAGCD says only the lowest bit is used so that's what I've done here, but someone would have to actually test this on hardware to be sure.