### PR TITLE
RetroAchievements - Achievement Progress Tab

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -52,12 +52,26 @@ public:
     u32 soft_points;
   };
 
+  struct UnlockStatus
+  {
+    AchievementId game_data_index = 0;
+    enum class UnlockType
+    {
+      LOCKED,
+      SOFTCORE,
+      HARDCORE
+    } remote_unlock_status = UnlockType::LOCKED;
+    u32 session_unlock_count = 0;
+    u32 points = 0;
+  };
+
   static AchievementManager* GetInstance();
   void Init();
   ResponseType Login(const std::string& password);
   void LoginAsync(const std::string& password, const ResponseCallback& callback);
   bool IsLoggedIn() const;
   void LoadGameByFilenameAsync(const std::string& iso_path, const ResponseCallback& callback);
+  bool IsGameLoaded() const;
 
   void LoadUnlockData(const ResponseCallback& callback);
   void ActivateDeactivateAchievements();
@@ -67,6 +81,14 @@ public:
   void DoFrame();
   u32 MemoryPeeker(u32 address, u32 num_bytes, void* ud);
   void AchievementEventHandler(const rc_runtime_event_t* runtime_event);
+
+  std::string GetPlayerDisplayName() const;
+  u32 GetPlayerScore() const;
+  std::string GetGameDisplayName() const;
+  PointSpread TallyScore() const;
+  rc_api_fetch_game_data_response_t* GetGameData();
+  UnlockStatus GetUnlockStatus(AchievementId achievement_id) const;
+  void GetAchievementProgress(AchievementId achievement_id, u32* value, u32* target);
 
   void CloseGame();
   void Logout();
@@ -95,8 +117,6 @@ private:
   void HandleLeaderboardCanceledEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardTriggeredEvent(const rc_runtime_event_t* runtime_event);
 
-  PointSpread TallyScore() const;
-
   template <typename RcRequest, typename RcResponse>
   ResponseType Request(RcRequest rc_request, RcResponse* rc_response,
                        const std::function<int(rc_api_request_t*, const RcRequest*)>& init_request,
@@ -106,24 +126,13 @@ private:
   Core::System* m_system{};
   bool m_is_runtime_initialized = false;
   std::string m_display_name;
+  u32 m_player_score = 0;
   std::array<char, HASH_LENGTH> m_game_hash{};
   u32 m_game_id = 0;
   rc_api_fetch_game_data_response_t m_game_data{};
   bool m_is_game_loaded = false;
   time_t m_last_ping_time = 0;
 
-  struct UnlockStatus
-  {
-    AchievementId game_data_index = 0;
-    enum class UnlockType
-    {
-      LOCKED,
-      SOFTCORE,
-      HARDCORE
-    } remote_unlock_status = UnlockType::LOCKED;
-    u32 session_unlock_count = 0;
-    u32 points = 0;
-  };
   std::unordered_map<AchievementId, UnlockStatus> m_unlock_map;
 
   Common::WorkQueueThread<std::function<void()>> m_queue;

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -41,6 +41,7 @@ public:
     UNKNOWN_FAILURE
   };
   using ResponseCallback = std::function<void(ResponseType)>;
+  using UpdateCallback = std::function<void()>;
 
   struct PointSpread
   {
@@ -67,6 +68,7 @@ public:
 
   static AchievementManager* GetInstance();
   void Init();
+  void SetUpdateCallback(UpdateCallback callback);
   ResponseType Login(const std::string& password);
   void LoginAsync(const std::string& password, const ResponseCallback& callback);
   bool IsLoggedIn() const;
@@ -125,6 +127,7 @@ private:
   rc_runtime_t m_runtime{};
   Core::System* m_system{};
   bool m_is_runtime_initialized = false;
+  UpdateCallback m_update_callback;
   std::string m_display_name;
   u32 m_player_score = 0;
   std::array<char, HASH_LENGTH> m_game_hash{};

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -84,6 +84,7 @@ public:
   u32 MemoryPeeker(u32 address, u32 num_bytes, void* ud);
   void AchievementEventHandler(const rc_runtime_event_t* runtime_event);
 
+  std::recursive_mutex* GetLock();
   std::string GetPlayerDisplayName() const;
   u32 GetPlayerScore() const;
   std::string GetGameDisplayName() const;

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -1,0 +1,140 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+#include "DolphinQt/Achievements/AchievementHeaderWidget.h"
+
+#include <QCheckBox>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QString>
+#include <QVBoxLayout>
+
+#include <fmt/format.h>
+
+#include <rcheevos/include/rc_api_runtime.h>
+#include <rcheevos/include/rc_api_user.h>
+#include <rcheevos/include/rc_runtime.h>
+
+#include "Core/AchievementManager.h"
+#include "Core/Core.h"
+
+#include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
+#include "DolphinQt/QtUtils/SignalBlocking.h"
+#include "DolphinQt/Settings.h"
+
+AchievementHeaderWidget::AchievementHeaderWidget(QWidget* parent) : QWidget(parent)
+{
+  m_user_name = new QLabel();
+  m_user_points = new QLabel();
+  m_game_name = new QLabel();
+  m_game_points = new QLabel();
+  m_game_progress_hard = new QProgressBar();
+  m_game_progress_soft = new QProgressBar();
+  m_rich_presence = new QLabel();
+
+  QVBoxLayout* m_user_right_col = new QVBoxLayout();
+  m_user_right_col->addWidget(m_user_name);
+  m_user_right_col->addWidget(m_user_points);
+  QHBoxLayout* m_user_layout = new QHBoxLayout();
+  // TODO: player badge goes here
+  m_user_layout->addLayout(m_user_right_col);
+  m_user_box = new QGroupBox();
+  m_user_box->setLayout(m_user_layout);
+
+  QVBoxLayout* m_game_right_col = new QVBoxLayout();
+  m_game_right_col->addWidget(m_game_name);
+  m_game_right_col->addWidget(m_game_points);
+  m_game_right_col->addWidget(m_game_progress_hard);
+  m_game_right_col->addWidget(m_game_progress_soft);
+  QHBoxLayout* m_game_upper_row = new QHBoxLayout();
+  // TODO: player badge and game badge go here
+  m_game_upper_row->addLayout(m_game_right_col);
+  QVBoxLayout* m_game_layout = new QVBoxLayout();
+  m_game_layout->addLayout(m_game_upper_row);
+  m_game_layout->addWidget(m_rich_presence);
+  m_game_box = new QGroupBox();
+  m_game_box->setLayout(m_game_layout);
+
+  QVBoxLayout* m_total = new QVBoxLayout();
+  m_total->addWidget(m_user_box);
+  m_total->addWidget(m_game_box);
+
+  UpdateData();
+
+  m_total->setContentsMargins(0, 0, 0, 0);
+  m_total->setAlignment(Qt::AlignTop);
+  setLayout(m_total);
+}
+
+void AchievementHeaderWidget::UpdateData()
+{
+  if (!AchievementManager::GetInstance()->IsLoggedIn())
+  {
+    m_user_box->setVisible(false);
+    m_game_box->setVisible(false);
+    return;
+  }
+
+  QString user_name =
+      QString::fromStdString(AchievementManager::GetInstance()->GetPlayerDisplayName());
+  m_user_name->setText(user_name);
+  m_user_points->setText(tr("%1 points").arg(AchievementManager::GetInstance()->GetPlayerScore()));
+
+  if (!AchievementManager::GetInstance()->IsGameLoaded())
+  {
+    m_user_box->setVisible(true);
+    m_game_box->setVisible(false);
+    return;
+  }
+
+  AchievementManager::PointSpread point_spread = AchievementManager::GetInstance()->TallyScore();
+  m_game_name->setText(
+      QString::fromStdString(AchievementManager::GetInstance()->GetGameDisplayName()));
+  m_game_points->setText(GetPointsString(user_name, point_spread));
+  m_game_progress_hard = new QProgressBar();
+  m_game_progress_hard->setRange(0, point_spread.total_count);
+  m_game_progress_soft->setValue(point_spread.hard_unlocks);
+  m_game_progress_soft->setRange(0, point_spread.total_count);
+  m_game_progress_soft->setValue(point_spread.hard_unlocks + point_spread.soft_unlocks);
+  // TODO: RP needs a minor refactor to work here, will be a future PR
+  // m_rich_presence->setText(QString::fromStdString(AchievementManager::GetInstance()->GenerateRichPresence()));
+  // m_rich_presence->setVisible(Config::Get(Config::RA_RICH_PRESENCE_ENABLED));
+  m_rich_presence->setText(QString{});
+  m_rich_presence->setVisible(false);
+
+  m_user_box->setVisible(false);
+  m_game_box->setVisible(true);
+}
+
+QString
+AchievementHeaderWidget::GetPointsString(const QString& user_name,
+                                         const AchievementManager::PointSpread& point_spread) const
+{
+  if (point_spread.soft_points > 0)
+  {
+    return tr("%1 has unlocked %2/%3 achievements (%4 hardcore) worth %5/%6 points (%7 hardcore)")
+        .arg(user_name)
+        .arg(point_spread.hard_unlocks + point_spread.soft_unlocks)
+        .arg(point_spread.total_count)
+        .arg(point_spread.hard_unlocks)
+        .arg(point_spread.hard_points + point_spread.soft_points)
+        .arg(point_spread.total_points)
+        .arg(point_spread.hard_points);
+  }
+  else
+  {
+    return tr("%1 has unlocked %2/%3 achievements worth %4/%5 points")
+        .arg(user_name)
+        .arg(point_spread.hard_unlocks)
+        .arg(point_spread.total_count)
+        .arg(point_spread.hard_points)
+        .arg(point_spread.total_points);
+  }
+}
+
+#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.h
@@ -1,0 +1,42 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+#include <QWidget>
+
+#include "Core/AchievementManager.h"
+
+class QGroupBox;
+class QLabel;
+class QProgressBar;
+class QVBoxLayout;
+
+class AchievementHeaderWidget final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit AchievementHeaderWidget(QWidget* parent);
+  void UpdateData();
+
+private:
+  QString GetPointsString(const QString& user_name,
+                          const AchievementManager::PointSpread& point_spread) const;
+
+  QGroupBox* m_common_box;
+  QVBoxLayout* m_common_layout;
+
+  QLabel* m_user_name;
+  QLabel* m_user_points;
+  QLabel* m_game_name;
+  QLabel* m_game_points;
+  QProgressBar* m_game_progress_hard;
+  QProgressBar* m_game_progress_soft;
+  QLabel* m_rich_presence;
+
+  QGroupBox* m_user_box;
+  QGroupBox* m_game_box;
+};
+
+#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
@@ -1,0 +1,124 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+#include "DolphinQt/Achievements/AchievementProgressWidget.h"
+
+#include <QCheckBox>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QString>
+#include <QVBoxLayout>
+
+#include <fmt/format.h>
+
+#include <rcheevos/include/rc_api_runtime.h>
+#include <rcheevos/include/rc_api_user.h>
+#include <rcheevos/include/rc_runtime.h>
+
+#include "Core/AchievementManager.h"
+#include "Core/Config/AchievementSettings.h"
+#include "Core/Config/MainSettings.h"
+#include "Core/Core.h"
+
+#include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
+#include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
+#include "DolphinQt/QtUtils/SignalBlocking.h"
+#include "DolphinQt/Settings.h"
+
+AchievementProgressWidget::AchievementProgressWidget(QWidget* parent) : QWidget(parent)
+{
+  m_common_box = new QGroupBox();
+  m_common_layout = new QVBoxLayout();
+
+  UpdateData();
+
+  m_common_box->setLayout(m_common_layout);
+
+  auto* layout = new QVBoxLayout;
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->setAlignment(Qt::AlignTop);
+  layout->addWidget(m_common_box);
+  setLayout(layout);
+}
+
+QGroupBox*
+AchievementProgressWidget::CreateAchievementBox(const rc_api_achievement_definition_t* achievement)
+{
+  QLabel* a_title = new QLabel(QString::fromUtf8(achievement->title, strlen(achievement->title)));
+  QLabel* a_description =
+      new QLabel(QString::fromUtf8(achievement->description, strlen(achievement->description)));
+  QLabel* a_points = new QLabel(tr("%1 points").arg(achievement->points));
+  QLabel* a_status = new QLabel(GetStatusString(achievement->id));
+  QProgressBar* a_progress_bar = new QProgressBar();
+  unsigned int value = 0;
+  unsigned int target = 0;
+  AchievementManager::GetInstance()->GetAchievementProgress(achievement->id, &value, &target);
+  if (target > 0)
+  {
+    a_progress_bar->setRange(0, target);
+    a_progress_bar->setValue(value);
+  }
+  else
+  {
+    a_progress_bar->setVisible(false);
+  }
+
+  QVBoxLayout* a_col_right = new QVBoxLayout();
+  a_col_right->addWidget(a_title);
+  a_col_right->addWidget(a_description);
+  a_col_right->addWidget(a_points);
+  a_col_right->addWidget(a_status);
+  a_col_right->addWidget(a_progress_bar);
+  QHBoxLayout* a_total = new QHBoxLayout();
+  // TODO: achievement badge goes here
+  a_total->addLayout(a_col_right);
+  QGroupBox* a_group_box = new QGroupBox();
+  a_group_box->setLayout(a_total);
+  return a_group_box;
+}
+
+void AchievementProgressWidget::UpdateData()
+{
+  QLayoutItem* item;
+  while ((item = m_common_layout->layout()->takeAt(0)) != nullptr)
+  {
+    delete item->widget();
+    delete item;
+  }
+
+  const auto* game_data = AchievementManager::GetInstance()->GetGameData();
+  for (u32 ix = 0; ix < game_data->num_achievements; ix++)
+  {
+    m_common_layout->addWidget(CreateAchievementBox(game_data->achievements + ix));
+  }
+}
+
+QString AchievementProgressWidget::GetStatusString(u32 achievement_id) const
+{
+  const auto unlock_status = AchievementManager::GetInstance()->GetUnlockStatus(achievement_id);
+  if (unlock_status.session_unlock_count > 0)
+  {
+    if (Config::Get(Config::RA_ENCORE_ENABLED))
+    {
+      return tr("Unlocked %1 times this session").arg(unlock_status.session_unlock_count);
+    }
+    return tr("Unlocked this session");
+  }
+  switch (unlock_status.remote_unlock_status)
+  {
+  case AchievementManager::UnlockStatus::UnlockType::LOCKED:
+    return tr("Locked");
+  case AchievementManager::UnlockStatus::UnlockType::SOFTCORE:
+    return tr("Unlocked (Casual)");
+  case AchievementManager::UnlockStatus::UnlockType::HARDCORE:
+    return tr("Unlocked");
+  }
+  return {};
+}
+
+#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.h
@@ -1,0 +1,34 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+#include <QWidget>
+
+#include "Common/CommonTypes.h"
+
+class QCheckBox;
+class QGroupBox;
+class QLineEdit;
+class QPushButton;
+class QVBoxLayout;
+
+struct rc_api_achievement_definition_t;
+
+class AchievementProgressWidget final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit AchievementProgressWidget(QWidget* parent);
+  void UpdateData();
+
+private:
+  QGroupBox* CreateAchievementBox(const rc_api_achievement_definition_t* achievement);
+  QString GetStatusString(u32 achievement_id) const;
+
+  QGroupBox* m_common_box;
+  QVBoxLayout* m_common_layout;
+};
+
+#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -8,6 +8,7 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 
+#include "DolphinQt/Achievements/AchievementHeaderWidget.h"
 #include "DolphinQt/Achievements/AchievementSettingsWidget.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
@@ -30,6 +31,7 @@ void AchievementsWindow::CreateMainLayout()
 {
   auto* layout = new QVBoxLayout();
 
+  m_header_widget = new AchievementHeaderWidget(this);
   m_tab_widget = new QTabWidget();
   m_tab_widget->addTab(
       GetWrappedWidget(new AchievementSettingsWidget(m_tab_widget, this), this, 125, 100),
@@ -37,6 +39,7 @@ void AchievementsWindow::CreateMainLayout()
 
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
+  layout->addWidget(m_header_widget);
   layout->addWidget(m_tab_widget);
   layout->addWidget(m_button_box);
 
@@ -50,6 +53,8 @@ void AchievementsWindow::ConnectWidgets()
 
 void AchievementsWindow::UpdateData()
 {
+  m_header_widget->UpdateData();
+  m_header_widget->setVisible(AchievementManager::GetInstance()->IsLoggedIn());
   update();
 }
 

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -11,6 +11,7 @@
 #include "DolphinQt/Achievements/AchievementHeaderWidget.h"
 #include "DolphinQt/Achievements/AchievementProgressWidget.h"
 #include "DolphinQt/Achievements/AchievementSettingsWidget.h"
+#include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 AchievementsWindow::AchievementsWindow(QWidget* parent) : QDialog(parent)
@@ -20,6 +21,8 @@ AchievementsWindow::AchievementsWindow(QWidget* parent) : QDialog(parent)
 
   CreateMainLayout();
   ConnectWidgets();
+  AchievementManager::GetInstance()->SetUpdateCallback(
+      [this] { QueueOnObject(this, &AchievementsWindow::UpdateData); });
 }
 
 void AchievementsWindow::showEvent(QShowEvent* event)

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -4,6 +4,8 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include "DolphinQt/Achievements/AchievementsWindow.h"
 
+#include <mutex>
+
 #include <QDialogButtonBox>
 #include <QTabWidget>
 #include <QVBoxLayout>
@@ -60,11 +62,14 @@ void AchievementsWindow::ConnectWidgets()
 
 void AchievementsWindow::UpdateData()
 {
-  m_header_widget->UpdateData();
-  m_header_widget->setVisible(AchievementManager::GetInstance()->IsLoggedIn());
-  // Settings tab handles its own updates ... indeed, that calls this
-  m_progress_widget->UpdateData();
-  m_tab_widget->setTabVisible(1, AchievementManager::GetInstance()->IsGameLoaded());
+  {
+    std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
+    m_header_widget->UpdateData();
+    m_header_widget->setVisible(AchievementManager::GetInstance()->IsLoggedIn());
+    // Settings tab handles its own updates ... indeed, that calls this
+    m_progress_widget->UpdateData();
+    m_tab_widget->setTabVisible(1, AchievementManager::GetInstance()->IsGameLoaded());
+  }
   update();
 }
 

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -9,6 +9,7 @@
 #include <QVBoxLayout>
 
 #include "DolphinQt/Achievements/AchievementHeaderWidget.h"
+#include "DolphinQt/Achievements/AchievementProgressWidget.h"
 #include "DolphinQt/Achievements/AchievementSettingsWidget.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
@@ -33,9 +34,12 @@ void AchievementsWindow::CreateMainLayout()
 
   m_header_widget = new AchievementHeaderWidget(this);
   m_tab_widget = new QTabWidget();
+  m_progress_widget = new AchievementProgressWidget(m_tab_widget);
   m_tab_widget->addTab(
       GetWrappedWidget(new AchievementSettingsWidget(m_tab_widget, this), this, 125, 100),
       tr("Settings"));
+  m_tab_widget->addTab(GetWrappedWidget(m_progress_widget, this, 125, 100), tr("Progress"));
+  m_tab_widget->setTabVisible(1, AchievementManager::GetInstance()->IsGameLoaded());
 
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
@@ -55,6 +59,9 @@ void AchievementsWindow::UpdateData()
 {
   m_header_widget->UpdateData();
   m_header_widget->setVisible(AchievementManager::GetInstance()->IsLoggedIn());
+  // Settings tab handles its own updates ... indeed, that calls this
+  m_progress_widget->UpdateData();
+  m_tab_widget->setTabVisible(1, AchievementManager::GetInstance()->IsGameLoaded());
   update();
 }
 

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
@@ -6,7 +6,10 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include <QDialog>
 
+#include "Core/AchievementManager.h"
+
 class AchievementHeaderWidget;
+class AchievementProgressWidget;
 class QTabWidget;
 class QDialogButtonBox;
 
@@ -24,6 +27,7 @@ private:
 
   AchievementHeaderWidget* m_header_widget;
   QTabWidget* m_tab_widget;
+  AchievementProgressWidget* m_progress_widget;
   QDialogButtonBox* m_button_box;
 };
 

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
@@ -6,6 +6,7 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include <QDialog>
 
+class AchievementHeaderWidget;
 class QTabWidget;
 class QDialogButtonBox;
 
@@ -21,6 +22,7 @@ private:
   void showEvent(QShowEvent* event);
   void ConnectWidgets();
 
+  AchievementHeaderWidget* m_header_widget;
   QTabWidget* m_tab_widget;
   QDialogButtonBox* m_button_box;
 };

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
@@ -7,11 +7,13 @@
 #include <QDialog>
 
 #include "Core/AchievementManager.h"
+#include "DolphinQt/QtUtils/QueueOnObject.h"
 
 class AchievementHeaderWidget;
 class AchievementProgressWidget;
-class QTabWidget;
 class QDialogButtonBox;
+class QTabWidget;
+class UpdateCallback;
 
 class AchievementsWindow : public QDialog
 {

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -29,6 +29,8 @@ add_executable(dolphin-emu
   CheatsManager.h
   Achievements/AchievementHeaderWidget.cpp
   Achievements/AchievementHeaderWidget.h
+  Achievements/AchievementProgressWidget.cpp
+  Achievements/AchievementProgressWidget.h
   Achievements/AchievementSettingsWidget.cpp
   Achievements/AchievementSettingsWidget.h
   Achievements/AchievementsWindow.cpp

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -27,6 +27,8 @@ add_executable(dolphin-emu
   CheatSearchWidget.h
   CheatsManager.cpp
   CheatsManager.h
+  Achievements/AchievementHeaderWidget.cpp
+  Achievements/AchievementHeaderWidget.h
   Achievements/AchievementSettingsWidget.cpp
   Achievements/AchievementSettingsWidget.h
   Achievements/AchievementsWindow.cpp

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -50,6 +50,7 @@
     <ClCompile Include="CheatSearchFactoryWidget.cpp" />
     <ClCompile Include="CheatSearchWidget.cpp" />
     <ClCompile Include="CheatsManager.cpp" />
+    <ClCompile Include="Achievements\AchievementHeaderWidget.cpp" />
     <ClCompile Include="Achievements\AchievementSettingsWidget.cpp" />
     <ClCompile Include="Achievements\AchievementsWindow.cpp" />
     <ClCompile Include="Config\ARCodeWidget.cpp" />
@@ -256,6 +257,7 @@
     <QtMoc Include="CheatSearchFactoryWidget.h" />
     <QtMoc Include="CheatSearchWidget.h" />
     <QtMoc Include="CheatsManager.h" />
+    <QtMoc Include="Achievements\AchievementHeaderWidget.h" />
     <QtMoc Include="Achievements\AchievementSettingsWidget.h" />
     <QtMoc Include="Achievements\AchievementsWindow.h" />
     <QtMoc Include="Config\ARCodeWidget.h" />

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -51,6 +51,7 @@
     <ClCompile Include="CheatSearchWidget.cpp" />
     <ClCompile Include="CheatsManager.cpp" />
     <ClCompile Include="Achievements\AchievementHeaderWidget.cpp" />
+    <ClCompile Include="Achievements\AchievementProgressWidget.cpp" />
     <ClCompile Include="Achievements\AchievementSettingsWidget.cpp" />
     <ClCompile Include="Achievements\AchievementsWindow.cpp" />
     <ClCompile Include="Config\ARCodeWidget.cpp" />
@@ -258,6 +259,7 @@
     <QtMoc Include="CheatSearchWidget.h" />
     <QtMoc Include="CheatsManager.h" />
     <QtMoc Include="Achievements\AchievementHeaderWidget.h" />
+    <QtMoc Include="Achievements\AchievementProgressWidget.h" />
     <QtMoc Include="Achievements\AchievementSettingsWidget.h" />
     <QtMoc Include="Achievements\AchievementsWindow.h" />
     <QtMoc Include="Config\ARCodeWidget.h" />


### PR DESCRIPTION
This is a portion of an integration with the RetroAchievements tools and libraries for connecting to the website, downloading data, unlocking achievements and submitting to leaderboards for games running in Dolphin. In this PR, I add an AchievementsProgressWidget and an AchievementsHeaderWidget to be added to AchievementsWindow, for the player to view data about their current progress and points.