### PR TITLE
VideoCommon: avoid segfault when loading a PNG with no custom texture data levels

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomTextureData.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomTextureData.cpp
@@ -515,11 +515,6 @@ bool LoadDDSTexture(CustomTextureData::Level* level, const std::string& filename
                       info.first_mip_row_length, info.first_mip_size);
 }
 
-bool LoadPNGTexture(CustomTextureData* texture, const std::string& filename)
-{
-  return LoadPNGTexture(&texture->m_levels[0], filename);
-}
-
 bool LoadPNGTexture(CustomTextureData::Level* level, const std::string& filename)
 {
   if (!level) [[unlikely]]

--- a/Source/Core/VideoCommon/Assets/CustomTextureData.h
+++ b/Source/Core/VideoCommon/Assets/CustomTextureData.h
@@ -27,6 +27,5 @@ public:
 
 bool LoadDDSTexture(CustomTextureData* texture, const std::string& filename);
 bool LoadDDSTexture(CustomTextureData::Level* level, const std::string& filename, u32 mip_level);
-bool LoadPNGTexture(CustomTextureData* texture, const std::string& filename);
 bool LoadPNGTexture(CustomTextureData::Level* level, const std::string& filename);
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.cpp
+++ b/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.cpp
@@ -72,8 +72,11 @@ CustomAssetLibrary::LoadInfo DirectFilesystemAssetLibrary::LoadTexture(const Ass
     }
     else if (ext == ".png")
     {
-      LoadPNGTexture(data, asset_path.string());
-      if (data->m_levels.empty()) [[unlikely]]
+      // If we have no levels, create one to pass into LoadPNGTexture
+      if (data->m_levels.empty())
+        data->m_levels.push_back({});
+
+      if (!LoadPNGTexture(&data->m_levels[0], asset_path.string()))
         return {};
       if (!LoadMips(asset_path, data))
         return {};


### PR DESCRIPTION
This can't actually happen in our code today but it was split out of #11681 