### PR TITLE
VideoCommon: prevent potential data issue when reloading Asset data

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomAsset.h
+++ b/Source/Core/VideoCommon/Assets/CustomAsset.h
@@ -64,7 +64,11 @@ class CustomLoadableAsset : public CustomAsset
 public:
   using CustomAsset::CustomAsset;
 
-  const UnderlyingType* GetData() const
+  // Callees should understand that the type returned is
+  // a local copy and 'GetData()' needs to be called
+  // to ensure the latest copy is available if
+  // they want to handle reloads
+  [[nodiscard]] std::shared_ptr<UnderlyingType> GetData() const
   {
     std::lock_guard lk(m_lock);
     if (m_loaded)
@@ -75,7 +79,7 @@ public:
 protected:
   bool m_loaded = false;
   mutable std::mutex m_lock;
-  UnderlyingType m_data;
+  std::shared_ptr<UnderlyingType> m_data;
 };
 
 }  // namespace VideoCommon


### PR DESCRIPTION
I was looking back over the asset logic and wondered if there might be a problem.

If in the middle of an asset being reloaded, imagine that a callee has called `GetData()`.  This would give them a pointer to that data.  If they are still operating on that data when the asset is reloaded, then the data would be modified on the asset reload thread.  This could be potentially dangreous at worst or lead to incorrect data at best.  To avoid this, I return a `shared_ptr` ensuring that the callee will have access to the original data for the lifetime of the smart ptr.