### PR TITLE
RetroAchievements Hardcore Mode

### DIFF
--- a/Source/Core/Core/Config/AchievementSettings.cpp
+++ b/Source/Core/Core/Config/AchievementSettings.cpp
@@ -19,6 +19,8 @@ const Info<bool> RA_LEADERBOARDS_ENABLED{
     {System::Achievements, "Achievements", "LeaderboardsEnabled"}, false};
 const Info<bool> RA_RICH_PRESENCE_ENABLED{
     {System::Achievements, "Achievements", "RichPresenceEnabled"}, false};
+const Info<bool> RA_HARDCORE_ENABLED{
+    {System::Achievements, "Achievements", "HardcoreEnabled"}, false};
 const Info<bool> RA_UNOFFICIAL_ENABLED{{System::Achievements, "Achievements", "UnofficialEnabled"},
                                        false};
 const Info<bool> RA_ENCORE_ENABLED{{System::Achievements, "Achievements", "EncoreEnabled"}, false};

--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -14,6 +14,7 @@ extern const Info<std::string> RA_API_TOKEN;
 extern const Info<bool> RA_ACHIEVEMENTS_ENABLED;
 extern const Info<bool> RA_LEADERBOARDS_ENABLED;
 extern const Info<bool> RA_RICH_PRESENCE_ENABLED;
+extern const Info<bool> RA_HARDCORE_ENABLED;
 extern const Info<bool> RA_UNOFFICIAL_ENABLED;
 extern const Info<bool> RA_ENCORE_ENABLED;
 }  // namespace Config

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -47,6 +47,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::RA_ACHIEVEMENTS_ENABLED.GetLocation(),
       &Config::RA_LEADERBOARDS_ENABLED.GetLocation(),
       &Config::RA_RICH_PRESENCE_ENABLED.GetLocation(),
+      &Config::RA_HARDCORE_ENABLED.GetLocation(),
       &Config::RA_UNOFFICIAL_ENABLED.GetLocation(),
       &Config::RA_ENCORE_ENABLED.GetLocation(),
   };

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
@@ -36,7 +36,6 @@ private:
   void ToggleLeaderboards();
   void ToggleRichPresence();
   void ToggleHardcore();
-  void ToggleBadgeIcons();
   void ToggleUnofficial();
   void ToggleEncore();
 
@@ -55,6 +54,7 @@ private:
   ToolTipCheckBox* m_common_achievements_enabled_input;
   ToolTipCheckBox* m_common_leaderboards_enabled_input;
   ToolTipCheckBox* m_common_rich_presence_enabled_input;
+  ToolTipCheckBox* m_common_hardcore_enabled_input;
   ToolTipCheckBox* m_common_unofficial_enabled_input;
   ToolTipCheckBox* m_common_encore_enabled_input;
 };

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
@@ -9,6 +9,7 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
+#include "Core/Config/AchievementSettings.h"
 #include "Core/Config/FreeLookSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -31,7 +32,9 @@ void FreeLookWidget::CreateLayout()
   auto* layout = new QVBoxLayout();
 
   m_enable_freelook = new ToolTipCheckBox(tr("Enable"));
-  m_enable_freelook->setChecked(Config::Get(Config::FREE_LOOK_ENABLED));
+  m_enable_freelook->setEnabled(!Config::Get(Config::RA_HARDCORE_ENABLED));
+  m_enable_freelook->setChecked(Config::Get(Config::FREE_LOOK_ENABLED) &&
+                                m_enable_freelook->isEnabled());
   m_enable_freelook->SetDescription(
       tr("Allows manipulation of the in-game camera.<br><br><dolphin_emphasis>If unsure, "
          "leave this unchecked.</dolphin_emphasis>"));
@@ -102,7 +105,9 @@ void FreeLookWidget::OnFreeLookControllerConfigured()
 
 void FreeLookWidget::LoadSettings()
 {
-  const bool checked = Config::Get(Config::FREE_LOOK_ENABLED);
+  const bool checked =
+      Config::Get(Config::FREE_LOOK_ENABLED) && !Config::Get(Config::RA_HARDCORE_ENABLED);
+  m_enable_freelook->setEnabled(!Config::Get(Config::RA_HARDCORE_ENABLED));
   m_enable_freelook->setChecked(checked);
   m_freelook_control_type->setEnabled(checked);
   m_freelook_controller_configure_button->setEnabled(checked);

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -17,6 +17,7 @@
 #include "Common/Config/Config.h"
 #include "Common/Thread.h"
 
+#include "Core/Config/AchievementSettings.h"
 #include "Core/Config/FreeLookSettings.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
@@ -48,6 +49,170 @@
 
 constexpr const char* DUBOIS_ALGORITHM_SHADER = "dubois";
 
+static const std::set<Hotkey> hardcore_whitelist = {
+    HK_OPEN,
+    HK_CHANGE_DISC,
+    HK_EJECT_DISC,
+    HK_REFRESH_LIST,
+    HK_PLAY_PAUSE,
+    HK_STOP,
+    HK_RESET,
+    HK_FULLSCREEN,
+    HK_SCREENSHOT,
+    HK_EXIT,
+    HK_UNLOCK_CURSOR,
+    HK_CENTER_MOUSE,
+    HK_ACTIVATE_CHAT,
+    HK_REQUEST_GOLF_CONTROL,
+
+    HK_VOLUME_DOWN,
+    HK_VOLUME_UP,
+    HK_VOLUME_TOGGLE_MUTE,
+
+    HK_DECREASE_EMULATION_SPEED,
+    HK_INCREASE_EMULATION_SPEED,
+    // HK_TOGGLE_THROTTLE,
+
+    // HK_FRAME_ADVANCE,
+    // HK_FRAME_ADVANCE_DECREASE_SPEED,
+    // HK_FRAME_ADVANCE_INCREASE_SPEED,
+    // HK_FRAME_ADVANCE_RESET_SPEED,
+
+    HK_START_RECORDING,
+    HK_PLAY_RECORDING,
+    HK_EXPORT_RECORDING,
+    HK_READ_ONLY_MODE,
+
+    // HK_STEP,
+    // HK_STEP_OVER,
+    // HK_STEP_OUT,
+    // HK_SKIP,
+
+    HK_SHOW_PC,
+    // HK_SET_PC,
+
+    // HK_BP_TOGGLE,
+    // HK_BP_ADD,
+    // HK_MBP_ADD,
+
+    HK_TRIGGER_SYNC_BUTTON,
+    HK_WIIMOTE1_CONNECT,
+    HK_WIIMOTE2_CONNECT,
+    HK_WIIMOTE3_CONNECT,
+    HK_WIIMOTE4_CONNECT,
+    HK_BALANCEBOARD_CONNECT,
+    HK_TOGGLE_SD_CARD,
+    HK_TOGGLE_USB_KEYBOARD,
+
+    HK_NEXT_WIIMOTE_PROFILE_1,
+    HK_PREV_WIIMOTE_PROFILE_1,
+    HK_NEXT_GAME_WIIMOTE_PROFILE_1,
+    HK_PREV_GAME_WIIMOTE_PROFILE_1,
+    HK_NEXT_WIIMOTE_PROFILE_2,
+    HK_PREV_WIIMOTE_PROFILE_2,
+    HK_NEXT_GAME_WIIMOTE_PROFILE_2,
+    HK_PREV_GAME_WIIMOTE_PROFILE_2,
+    HK_NEXT_WIIMOTE_PROFILE_3,
+    HK_PREV_WIIMOTE_PROFILE_3,
+    HK_NEXT_GAME_WIIMOTE_PROFILE_3,
+    HK_PREV_GAME_WIIMOTE_PROFILE_3,
+    HK_NEXT_WIIMOTE_PROFILE_4,
+    HK_PREV_WIIMOTE_PROFILE_4,
+    HK_NEXT_GAME_WIIMOTE_PROFILE_4,
+    HK_PREV_GAME_WIIMOTE_PROFILE_4,
+
+    HK_TOGGLE_CROP,
+    HK_TOGGLE_AR,
+    HK_TOGGLE_SKIP_EFB_ACCESS,
+    HK_TOGGLE_EFBCOPIES,
+    HK_TOGGLE_XFBCOPIES,
+    HK_TOGGLE_IMMEDIATE_XFB,
+    // HK_TOGGLE_FOG,
+    HK_TOGGLE_DUMPTEXTURES,
+    HK_TOGGLE_TEXTURES,
+
+    HK_INCREASE_IR,
+    HK_DECREASE_IR,
+
+    // HK_FREELOOK_TOGGLE,
+
+    HK_TOGGLE_STEREO_SBS,
+    HK_TOGGLE_STEREO_TAB,
+    HK_TOGGLE_STEREO_ANAGLYPH,
+
+    HK_DECREASE_DEPTH,
+    HK_INCREASE_DEPTH,
+    HK_DECREASE_CONVERGENCE,
+    HK_INCREASE_CONVERGENCE,
+
+    // HK_LOAD_STATE_SLOT_1,
+    // HK_LOAD_STATE_SLOT_2,
+    // HK_LOAD_STATE_SLOT_3,
+    // HK_LOAD_STATE_SLOT_4,
+    // HK_LOAD_STATE_SLOT_5,
+    // HK_LOAD_STATE_SLOT_6,
+    // HK_LOAD_STATE_SLOT_7,
+    // HK_LOAD_STATE_SLOT_8,
+    // HK_LOAD_STATE_SLOT_9,
+    // HK_LOAD_STATE_SLOT_10,
+    // HK_LOAD_STATE_SLOT_SELECTED,
+
+    HK_SAVE_STATE_SLOT_1,
+    HK_SAVE_STATE_SLOT_2,
+    HK_SAVE_STATE_SLOT_3,
+    HK_SAVE_STATE_SLOT_4,
+    HK_SAVE_STATE_SLOT_5,
+    HK_SAVE_STATE_SLOT_6,
+    HK_SAVE_STATE_SLOT_7,
+    HK_SAVE_STATE_SLOT_8,
+    HK_SAVE_STATE_SLOT_9,
+    HK_SAVE_STATE_SLOT_10,
+    HK_SAVE_STATE_SLOT_SELECTED,
+
+    HK_SELECT_STATE_SLOT_1,
+    HK_SELECT_STATE_SLOT_2,
+    HK_SELECT_STATE_SLOT_3,
+    HK_SELECT_STATE_SLOT_4,
+    HK_SELECT_STATE_SLOT_5,
+    HK_SELECT_STATE_SLOT_6,
+    HK_SELECT_STATE_SLOT_7,
+    HK_SELECT_STATE_SLOT_8,
+    HK_SELECT_STATE_SLOT_9,
+    HK_SELECT_STATE_SLOT_10,
+
+    // HK_LOAD_LAST_STATE_1,
+    // HK_LOAD_LAST_STATE_2,
+    // HK_LOAD_LAST_STATE_3,
+    // HK_LOAD_LAST_STATE_4,
+    // HK_LOAD_LAST_STATE_5,
+    // HK_LOAD_LAST_STATE_6,
+    // HK_LOAD_LAST_STATE_7,
+    // HK_LOAD_LAST_STATE_8,
+    // HK_LOAD_LAST_STATE_9,
+    // HK_LOAD_LAST_STATE_10,
+
+    HK_SAVE_FIRST_STATE,
+    // HK_UNDO_LOAD_STATE,
+    HK_UNDO_SAVE_STATE,
+    HK_SAVE_STATE_FILE,
+    // HK_LOAD_STATE_FILE,
+    HK_INCREMENT_SELECTED_STATE_SLOT,
+    HK_DECREMENT_SELECTED_STATE_SLOT,
+
+    HK_GBA_LOAD,
+    HK_GBA_UNLOAD,
+    HK_GBA_RESET,
+
+    HK_GBA_VOLUME_DOWN,
+    HK_GBA_VOLUME_UP,
+    HK_GBA_TOGGLE_MUTE,
+
+    HK_GBA_1X,
+    HK_GBA_2X,
+    HK_GBA_3X,
+    HK_GBA_4X,
+};
+
 HotkeyScheduler::HotkeyScheduler() : m_stop_requested(false)
 {
   HotkeyManagerEmu::Enable(true);
@@ -74,6 +239,8 @@ void HotkeyScheduler::Stop()
 
 static bool IsHotkey(int id, bool held = false)
 {
+  if (Config::Get(Config::RA_HARDCORE_ENABLED) && hardcore_whitelist.count((Hotkey)id) == 0)
+    return false;
   return HotkeyManagerEmu::IsPressed(id, held);
 }
 
@@ -471,6 +638,8 @@ void HotkeyScheduler::Run()
       {
         auto speed = Config::Get(Config::MAIN_EMULATION_SPEED) - 0.1;
         speed = (speed <= 0 || (speed >= 0.95 && speed <= 1.05)) ? 1.0 : speed;
+        if (Config::Get(Config::RA_HARDCORE_ENABLED) && speed < 1.0)
+          speed = 1.0;
         Config::SetCurrent(Config::MAIN_EMULATION_SPEED, speed);
         ShowEmulationSpeed();
       }

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -42,6 +42,7 @@
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
 #include "Core/CommonTitles.h"
+#include <Core/Config/AchievementSettings.h>
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/NetplaySettings.h"
 #include "Core/Config/WiimoteSettings.h"
@@ -229,6 +230,8 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 #ifdef USE_RETRO_ACHIEVEMENTS
   // This has to be done before CreateComponents() so it's initialized.
   AchievementManager::GetInstance()->Init();
+  // If hardcore mode is enabled upon startup need to immediately disable cheats
+  Settings::Instance().SetHardcoreModeEnabled(Config::Get(Config::RA_HARDCORE_ENABLED));
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   CreateComponents();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -230,7 +230,7 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 #ifdef USE_RETRO_ACHIEVEMENTS
   // This has to be done before CreateComponents() so it's initialized.
   AchievementManager::GetInstance()->Init();
-  // If hardcore mode is enabled upon startup need to immediately disable cheats
+  // If hardcore mode is enabled upon startup need to immediately disable cheats and debug
   Settings::Instance().SetHardcoreModeEnabled(Config::Get(Config::RA_HARDCORE_ENABLED));
 #endif  // USE_RETRO_ACHIEVEMENTS
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -117,10 +117,10 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   m_stop_action->setVisible(running);
   m_reset_action->setEnabled(running);
   m_fullscreen_action->setEnabled(running);
-  m_frame_advance_action->setEnabled(running);
   m_screenshot_action->setEnabled(running);
   m_state_save_menu->setEnabled(running);
 
+  m_frame_advance_action->setEnabled(!Settings::Instance().IsHardcoreModeEnabled() && running);
   m_state_load_menu->setEnabled(!Settings::Instance().IsHardcoreModeEnabled() && running);
 
   // Movie

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -119,8 +119,9 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   m_fullscreen_action->setEnabled(running);
   m_frame_advance_action->setEnabled(running);
   m_screenshot_action->setEnabled(running);
-  m_state_load_menu->setEnabled(running);
   m_state_save_menu->setEnabled(running);
+
+  m_state_load_menu->setEnabled(!Settings::Instance().IsHardcoreModeEnabled() && running);
 
   // Movie
   m_recording_read_only->setEnabled(running);

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -473,6 +473,8 @@ void Settings::SetHardcoreModeEnabled(bool enabled)
   {
     SetCheatsEnabled(false);
     SetDebugModeEnabled(false);
+    if (Config::Get(Config::MAIN_EMULATION_SPEED) < 1.0f)
+      Config::SetBaseOrCurrent(Config::MAIN_EMULATION_SPEED, 1.0f);
   }
 }
 

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -29,6 +29,7 @@
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/AchievementSettings.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
@@ -457,6 +458,20 @@ void Settings::SetCheatsEnabled(bool enabled)
     Config::SetBaseOrCurrent(Config::MAIN_ENABLE_CHEATS, enabled);
     emit EnableCheatsChanged(enabled);
   }
+}
+
+void Settings::SetHardcoreModeEnabled(bool enabled)
+{
+  if (IsHardcoreModeEnabled() != enabled)
+  {
+    Config::SetBaseOrCurrent(Config::RA_HARDCORE_ENABLED, enabled);
+    emit HardcoreModeToggled(enabled);
+  }
+}
+
+bool Settings::IsHardcoreModeEnabled() const
+{
+  return Config::Get(Config::RA_HARDCORE_ENABLED);
 }
 
 void Settings::SetDebugModeEnabled(bool enabled)

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -472,6 +472,7 @@ void Settings::SetHardcoreModeEnabled(bool enabled)
   if (enabled)
   {
     SetCheatsEnabled(false);
+    SetDebugModeEnabled(false);
   }
 }
 
@@ -482,7 +483,9 @@ bool Settings::IsHardcoreModeEnabled() const
 
 void Settings::SetDebugModeEnabled(bool enabled)
 {
-  if (IsDebugModeEnabled() != enabled)
+  if (IsHardcoreModeEnabled())
+    enabled = false;
+  if (Config::Get(Config::MAIN_ENABLE_DEBUGGING) != enabled)
   {
     Config::SetBaseOrCurrent(Config::MAIN_ENABLE_DEBUGGING, enabled);
     emit DebugModeToggled(enabled);
@@ -493,7 +496,7 @@ void Settings::SetDebugModeEnabled(bool enabled)
 
 bool Settings::IsDebugModeEnabled() const
 {
-  return Config::Get(Config::MAIN_ENABLE_DEBUGGING);
+  return !IsHardcoreModeEnabled() && Config::Get(Config::MAIN_ENABLE_DEBUGGING);
 }
 
 void Settings::SetRegistersVisible(bool enabled)

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -30,6 +30,7 @@
 #include "Common/StringUtil.h"
 
 #include "Core/Config/AchievementSettings.h"
+#include "Core/Config/FreeLookSettings.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
@@ -475,6 +476,7 @@ void Settings::SetHardcoreModeEnabled(bool enabled)
     SetDebugModeEnabled(false);
     if (Config::Get(Config::MAIN_EMULATION_SPEED) < 1.0f)
       Config::SetBaseOrCurrent(Config::MAIN_EMULATION_SPEED, 1.0f);
+    Config::SetBaseOrCurrent(Config::FREE_LOOK_ENABLED, false);
   }
 }
 

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -448,11 +448,13 @@ void Settings::ResetNetPlayServer(NetPlay::NetPlayServer* server)
 
 bool Settings::GetCheatsEnabled() const
 {
-  return Config::Get(Config::MAIN_ENABLE_CHEATS);
+  return !IsHardcoreModeEnabled() && Config::Get(Config::MAIN_ENABLE_CHEATS);
 }
 
 void Settings::SetCheatsEnabled(bool enabled)
 {
+  if (IsHardcoreModeEnabled())
+    enabled = false;
   if (Config::Get(Config::MAIN_ENABLE_CHEATS) != enabled)
   {
     Config::SetBaseOrCurrent(Config::MAIN_ENABLE_CHEATS, enabled);
@@ -466,6 +468,10 @@ void Settings::SetHardcoreModeEnabled(bool enabled)
   {
     Config::SetBaseOrCurrent(Config::RA_HARDCORE_ENABLED, enabled);
     emit HardcoreModeToggled(enabled);
+  }
+  if (enabled)
+  {
+    SetCheatsEnabled(false);
   }
 }
 

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -127,6 +127,10 @@ public:
   bool GetCheatsEnabled() const;
   void SetCheatsEnabled(bool enabled);
 
+  // Achievements
+  void SetHardcoreModeEnabled(bool enabled);
+  bool IsHardcoreModeEnabled() const;
+
   // Debug
   void SetDebugModeEnabled(bool enabled);
   bool IsDebugModeEnabled() const;
@@ -203,6 +207,7 @@ signals:
   void SDCardInsertionChanged(bool inserted);
   void USBKeyboardConnectionChanged(bool connected);
   void EnableGfxModsChanged(bool enabled);
+  void HardcoreModeToggled(bool enabled);
 
 private:
   Settings();

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -55,6 +55,8 @@ GeneralPane::GeneralPane(QWidget* parent) : QWidget(parent)
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &GeneralPane::OnEmulationStateChanged);
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, &GeneralPane::LoadConfig);
+  connect(&Settings::Instance(), &Settings::HardcoreModeToggled, this,
+          &GeneralPane::OnHardcoreModeToggled);
 
   OnEmulationStateChanged(Core::GetState());
 }
@@ -83,12 +85,33 @@ void GeneralPane::OnEmulationStateChanged(Core::State state)
   const bool running = state != Core::State::Uninitialized;
 
   m_checkbox_dualcore->setEnabled(!running);
-  m_checkbox_cheats->setEnabled(!running);
   m_checkbox_override_region_settings->setEnabled(!running);
 #ifdef USE_DISCORD_PRESENCE
   m_checkbox_discord_presence->setEnabled(!running);
 #endif
   m_combobox_fallback_region->setEnabled(!running);
+
+  if (Settings::Instance().IsHardcoreModeEnabled())
+  {
+    m_checkbox_cheats->setEnabled(false);
+  }
+  else
+  {
+    m_checkbox_cheats->setEnabled(!running);
+  }
+}
+
+void GeneralPane::OnHardcoreModeToggled(bool enabled)
+{
+  if (enabled)
+  {
+    m_checkbox_cheats->setEnabled(false);
+    m_checkbox_cheats->setChecked(false);
+  }
+  else
+  {
+    m_checkbox_cheats->setEnabled(!Core::IsRunning());
+  }
 }
 
 void GeneralPane::ConnectLayout()

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -12,6 +12,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QSlider>
+#include <QStandardItemModel>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -107,9 +108,17 @@ void GeneralPane::OnHardcoreModeToggled(bool enabled)
   {
     m_checkbox_cheats->setEnabled(false);
     m_checkbox_cheats->setChecked(false);
+    auto* model = qobject_cast<QStandardItemModel*>(m_combobox_speedlimit->model());
+    for (int ix = 1; ix < 10; ix++)
+      model->item(ix)->setEnabled(false);
+    if (m_combobox_speedlimit->currentIndex() < 10 && m_combobox_speedlimit->currentIndex() > 0)
+      m_combobox_speedlimit->setCurrentIndex(10);
   }
   else
   {
+    auto* model = qobject_cast<QStandardItemModel*>(m_combobox_speedlimit->model());
+    for (int ix = 1; ix < 10; ix++)
+      model->item(ix)->setEnabled(true);
     m_checkbox_cheats->setEnabled(!Core::IsRunning());
   }
 }
@@ -194,6 +203,9 @@ void GeneralPane::CreateBasic()
 
     m_combobox_speedlimit->addItem(str);
   }
+  auto* model = qobject_cast<QStandardItemModel*>(m_combobox_speedlimit->model());
+  for (int ix = 1; ix < 10; ix++)
+    model->item(ix)->setEnabled(!Settings::Instance().IsHardcoreModeEnabled());
 
   speed_limit_layout->addRow(tr("&Speed Limit:"), m_combobox_speedlimit);
 }

--- a/Source/Core/DolphinQt/Settings/GeneralPane.h
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.h
@@ -34,6 +34,7 @@ private:
   void LoadConfig();
   void OnSaveConfig();
   void OnEmulationStateChanged(Core::State state);
+  void OnHardcoreModeToggled(bool enabled);
 
   // Widgets
   QVBoxLayout* m_main_layout;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -84,6 +84,9 @@ InterfacePane::InterfacePane(QWidget* parent) : QWidget(parent)
   CreateLayout();
   LoadConfig();
   ConnectLayout();
+
+  connect(&Settings::Instance(), &Settings::HardcoreModeToggled, this,
+          &InterfacePane::OnHardcoreModeToggled);
 }
 
 void InterfacePane::CreateLayout()
@@ -247,6 +250,8 @@ void InterfacePane::LoadConfig()
       ->setChecked(Config::Get(Config::MAIN_USE_BUILT_IN_TITLE_DATABASE));
   SignalBlocking(m_checkbox_show_debugging_ui)
       ->setChecked(Settings::Instance().IsDebugModeEnabled());
+  SignalBlocking(m_checkbox_show_debugging_ui)
+      ->setEnabled(!Settings::Instance().IsHardcoreModeEnabled());
   SignalBlocking(m_combobox_language)
       ->setCurrentIndex(m_combobox_language->findData(
           QString::fromStdString(Config::Get(Config::MAIN_INTERFACE_LANGUAGE))));
@@ -334,6 +339,15 @@ void InterfacePane::OnSaveConfig()
   Config::SetBase(Config::MAIN_DISABLE_SCREENSAVER, m_checkbox_disable_screensaver->isChecked());
 
   Config::Save();
+}
+
+void InterfacePane::OnHardcoreModeToggled(bool enabled)
+{
+  m_checkbox_show_debugging_ui->setEnabled(!enabled);
+  if (enabled)
+  {
+    m_checkbox_show_debugging_ui->setChecked(false);
+  }
 }
 
 void InterfacePane::OnCursorVisibleMovement()

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -24,6 +24,7 @@ private:
   void ConnectLayout();
   void LoadConfig();
   void OnSaveConfig();
+  void OnHardcoreModeToggled(bool enabled);
   void OnCursorVisibleMovement();
   void OnCursorVisibleNever();
   void OnCursorVisibleAlways();


### PR DESCRIPTION
This is a portion of an integration with the RetroAchievements tools and libraries for connecting to the website, downloading data, unlocking achievements and submitting to leaderboards for games running in Dolphin. In this PR, I add a switch for Hardcore Mode, which RetroAchievements uses as a marker that the player performs achievements and leaderboards in as similar of a configuration to the native hardware as possible. As such, this disables several emulator features that would give players an unusual advantage over the native hardware, such as the ability to load savestates, slow down the emulator speed, bypass visual restrictions, examine/modify memory, or apply cheats.