### PR TITLE
VideoCommon: add additional locks around asset access / usage

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAsset.cpp
@@ -16,6 +16,7 @@ bool CustomAsset::Load()
   const auto load_information = LoadImpl(m_asset_id);
   if (load_information.m_bytes_loaded > 0)
   {
+    std::lock_guard lk(m_info_lock);
     m_bytes_loaded = load_information.m_bytes_loaded;
     m_last_loaded_time = load_information.m_load_time;
   }
@@ -29,6 +30,7 @@ CustomAssetLibrary::TimeType CustomAsset::GetLastWriteTime() const
 
 const CustomAssetLibrary::TimeType& CustomAsset::GetLastLoadedTime() const
 {
+  std::lock_guard lk(m_info_lock);
   return m_last_loaded_time;
 }
 
@@ -39,6 +41,7 @@ const CustomAssetLibrary::AssetID& CustomAsset::GetAssetId() const
 
 std::size_t CustomAsset::GetByteSizeInMemory() const
 {
+  std::lock_guard lk(m_info_lock);
   return m_bytes_loaded;
 }
 

--- a/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.h
+++ b/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <filesystem>
 #include <map>
+#include <mutex>
 #include <string>
 
 #include "VideoCommon/Assets/CustomAssetLibrary.h"
@@ -18,6 +19,8 @@ class CustomTextureData;
 class DirectFilesystemAssetLibrary final : public CustomAssetLibrary
 {
 public:
+  using AssetMap = std::map<std::string, std::filesystem::path>;
+
   LoadInfo LoadTexture(const AssetID& asset_id, CustomTextureData* data) override;
 
   // Gets the latest time from amongst all the files in the asset map
@@ -26,12 +29,16 @@ public:
   // Assigns the asset id to a map of files, how this map is read is dependent on the data
   // For instance, a raw texture would expect the map to have a single entry and load that
   // file as the asset.  But a model file data might have its data spread across multiple files
-  void SetAssetIDMapData(const AssetID& asset_id,
-                         std::map<std::string, std::filesystem::path> asset_path_map);
+  void SetAssetIDMapData(const AssetID& asset_id, AssetMap asset_path_map);
 
 private:
   // Loads additional mip levels into the texture structure until _mip<N> texture is not found
   bool LoadMips(const std::filesystem::path& asset_path, CustomTextureData* data);
+
+  // Gets the asset map given an asset id
+  AssetMap GetAssetMapForID(const AssetID& asset_id) const;
+
+  mutable std::mutex m_lock;
   std::map<AssetID, std::map<std::string, std::filesystem::path>> m_assetid_to_asset_map_path;
 };
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/Assets/TextureAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/TextureAsset.cpp
@@ -9,31 +9,35 @@ namespace VideoCommon
 {
 CustomAssetLibrary::LoadInfo RawTextureAsset::LoadImpl(const CustomAssetLibrary::AssetID& asset_id)
 {
-  std::lock_guard lk(m_lock);
   auto potential_data = std::make_shared<CustomTextureData>();
   const auto loaded_info = m_owning_library->LoadTexture(asset_id, potential_data.get());
   if (loaded_info.m_bytes_loaded == 0)
     return {};
-  m_loaded = true;
-  m_data = std::move(potential_data);
+  {
+    std::lock_guard lk(m_data_lock);
+    m_loaded = true;
+    m_data = std::move(potential_data);
+  }
   return loaded_info;
 }
 
 CustomAssetLibrary::LoadInfo GameTextureAsset::LoadImpl(const CustomAssetLibrary::AssetID& asset_id)
 {
-  std::lock_guard lk(m_lock);
   auto potential_data = std::make_shared<CustomTextureData>();
   const auto loaded_info = m_owning_library->LoadGameTexture(asset_id, potential_data.get());
   if (loaded_info.m_bytes_loaded == 0)
     return {};
-  m_loaded = true;
-  m_data = std::move(potential_data);
+  {
+    std::lock_guard lk(m_data_lock);
+    m_loaded = true;
+    m_data = std::move(potential_data);
+  }
   return loaded_info;
 }
 
 bool GameTextureAsset::Validate(u32 native_width, u32 native_height) const
 {
-  std::lock_guard lk(m_lock);
+  std::lock_guard lk(m_data_lock);
 
   if (!m_loaded)
   {


### PR DESCRIPTION
For the most part, this review adds additional locks in place for thread safety.  There were a few places where locks were being held onto too long, that has been updated as well.