### PR TITLE
Android: Temporarily disable host thread check

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -792,8 +792,11 @@ void SaveScreenShot(std::string_view name)
 
 static bool PauseAndLock(Core::System& system, bool do_lock, bool unpause_on_unlock)
 {
-  // WARNING: PauseAndLock is not fully threadsafe so is only valid on the Host Thread
+// WARNING: PauseAndLock is not fully threadsafe so is only valid on the Host Thread
+// TODO: Fix Android
+#ifndef ANDROID
   ASSERT(IsHostThread());
+#endif
 
   if (!IsRunningAndStarted())
     return true;


### PR DESCRIPTION
Very broken. Will investigate, but let's revert it for the time being.