### PR TITLE
InputCommon: Don't treat two analog inputs as a spurious trigger combo

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -138,8 +138,8 @@ void RemoveSpuriousTriggerCombinations(
 {
   const auto is_spurious = [&](auto& detection) {
     return std::any_of(detections->begin(), detections->end(), [&](auto& d) {
-      // This is a suprious digital detection if a "smooth" (analog) detection is temporally near.
-      return &d != &detection && d.smoothness > 1 &&
+      // This is a spurious digital detection if a "smooth" (analog) detection is temporally near.
+      return &d != &detection && d.smoothness > 1 && d.smoothness > detection.smoothness &&
              abs(d.press_time - detection.press_time) < SPURIOUS_TRIGGER_COMBO_THRESHOLD;
     });
   };


### PR DESCRIPTION
I've received a report from an Android user with a gamepad (a "BSP-D3") where one physical trigger is controlling two analog axes at the same time. This was causing RemoveSpuriousTriggerCombinations to delete both axes, which is clearly not a desireable outcome.

With this change, now the axis with the greatest smoothness is kept, or both in case they have the same smoothness.