### PR TITLE
Qt: Add float config tooltip slider

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -47,6 +47,8 @@ add_executable(dolphin-emu
   Config/ConfigControls/ConfigInteger.h
   Config/ConfigControls/ConfigRadio.cpp
   Config/ConfigControls/ConfigRadio.h
+  Config/ConfigControls/ConfigFloatSlider.cpp
+  Config/ConfigControls/ConfigFloatSlider.h
   Config/ConfigControls/ConfigSlider.cpp
   Config/ConfigControls/ConfigSlider.h
   Config/ControllerInterface/ControllerInterfaceWindow.cpp

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.cpp
@@ -1,0 +1,48 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/Config/ConfigControls/ConfigFloatSlider.h"
+
+#include <QSignalBlocker>
+
+#include "Common/Config/Config.h"
+
+#include "DolphinQt/Settings.h"
+
+ConfigFloatSlider::ConfigFloatSlider(float minimum, float maximum,
+                                     const Config::Info<float>& setting, float step)
+    : ToolTipSlider(Qt::Horizontal), m_minimum(minimum), m_setting(setting), m_step(step)
+{
+  const float range = maximum - minimum;
+  const int steps = std::round(range / step);
+  const int interval = std::round(range / steps);
+  const int current_value = std::round((Config::Get(m_setting) - minimum) / step);
+
+  setMinimum(0);
+  setMaximum(steps);
+  setTickInterval(interval);
+  setValue(current_value);
+
+  connect(this, &ConfigFloatSlider::valueChanged, this, &ConfigFloatSlider::Update);
+
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
+    QFont bf = font();
+    bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
+    setFont(bf);
+
+    const QSignalBlocker blocker(this);
+    const int current_value = std::round((Config::Get(m_setting) - m_minimum) / m_step);
+    setValue(current_value);
+  });
+}
+
+void ConfigFloatSlider::Update(int value)
+{
+  const float current_value = (m_step * value) + m_minimum;
+  Config::SetBaseOrCurrent(m_setting, current_value);
+}
+
+float ConfigFloatSlider::GetValue() const
+{
+  return (m_step * value()) + m_minimum;
+}

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
@@ -1,0 +1,30 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
+
+namespace Config
+{
+template <typename T>
+class Info;
+}
+
+// Automatically converts an int slider into a float one.
+// Do not read the int values or ranges directly from it.
+class ConfigFloatSlider : public ToolTipSlider
+{
+  Q_OBJECT
+public:
+  ConfigFloatSlider(float minimum, float maximum, const Config::Info<float>& setting, float step);
+  void Update(int value);
+
+  // Returns the adjusted float value
+  float GetValue() const;
+
+private:
+  float m_minimum;
+  float m_step;
+  const Config::Info<float>& m_setting;
+};

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -60,6 +60,7 @@
     <ClCompile Include="Config\ConfigControls\ConfigChoice.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigInteger.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigRadio.cpp" />
+    <ClCompile Include="Config\ConfigControls\ConfigFloatSlider.cpp" />
     <ClCompile Include="Config\ConfigControls\ConfigSlider.cpp" />
     <ClCompile Include="Config\ControllerInterface\ControllerInterfaceWindow.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.cpp" />
@@ -263,6 +264,7 @@
     <QtMoc Include="Config\ConfigControls\ConfigChoice.h" />
     <QtMoc Include="Config\ConfigControls\ConfigInteger.h" />
     <QtMoc Include="Config\ConfigControls\ConfigRadio.h" />
+    <QtMoc Include="Config\ConfigControls\ConfigFloatSlider.h" />
     <QtMoc Include="Config\ConfigControls\ConfigSlider.h" />
     <QtMoc Include="Config\ControllerInterface\ControllerInterfaceWindow.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.h" />


### PR DESCRIPTION
Needed by:
https://github.com/dolphin-emu/dolphin/pull/11850

This is almost identical to `ConfigSlider` that was already there, though works with floats instead.

Screenshot:
![image](https://github.com/dolphin-emu/dolphin/assets/7011366/462f4258-ee5e-4989-973a-9ccbb6058f99)
