### PR TITLE
static const std::regex

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -443,7 +443,7 @@ std::string PPCDebugInterface::GetDescription(u32 address) const
 std::optional<u32>
 PPCDebugInterface::GetMemoryAddressFromInstruction(const std::string& instruction) const
 {
-  std::regex re(",[^r0-]*(-?)(0[xX]?[0-9a-fA-F]*|r\\d+)[^r^s]*.(p|toc|\\d+)");
+  static const std::regex re(",[^r0-]*(-?)(0[xX]?[0-9a-fA-F]*|r\\d+)[^r^s]*.(p|toc|\\d+)");
   std::smatch match;
 
   // Instructions should be identified as a load or store before using this function. This error

--- a/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.cpp
@@ -100,7 +100,9 @@ void BroadbandAdapterSettingsDialog::SaveAddress()
   switch (m_bba_type)
   {
   case Type::Ethernet:
-    if (!std::regex_match(bba_new_address, std::regex("([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})")))
+  {
+    static const std::regex re_mac_address("([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})");
+    if (!std::regex_match(bba_new_address, re_mac_address))
     {
       ModalMessageBox::critical(
           this, tr("Broadband Adapter Error"),
@@ -111,7 +113,7 @@ void BroadbandAdapterSettingsDialog::SaveAddress()
     }
     Config::SetBaseOrCurrent(Config::MAIN_BBA_MAC, bba_new_address);
     break;
-
+  }
   case Type::BuiltIn:
     Config::SetBaseOrCurrent(Config::MAIN_BBA_BUILTIN_DNS, bba_new_address);
     break;

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -102,10 +102,10 @@ std::string Lexer::FetchDelimString(char delim)
 
 std::string Lexer::FetchWordChars()
 {
-  // Valid word characters:
-  std::regex rx(R"([a-z\d_])", std::regex_constants::icase);
-
-  return FetchCharsWhile([&rx](char c) { return std::regex_match(std::string(1, c), rx); });
+  return FetchCharsWhile([](char c) {
+    return std::isalpha(c, std::locale::classic()) || std::isdigit(c, std::locale::classic()) ||
+           c == '_';
+  });
 }
 
 Token Lexer::GetDelimitedLiteral()
@@ -134,7 +134,8 @@ Token Lexer::GetRealLiteral(char first_char)
   value += first_char;
   value += FetchCharsWhile([](char c) { return isdigit(c, std::locale::classic()) || ('.' == c); });
 
-  if (std::regex_match(value, std::regex(R"(\d+(\.\d+)?)")))
+  static const std::regex re(R"(\d+(\.\d+)?)");
+  if (std::regex_match(value, re))
     return Token(TOK_LITERAL, value);
 
   return Token(TOK_INVALID);


### PR DESCRIPTION
I noticed that a few usages of std::regex in the codebase were suboptimal.  I would prefer to make these static const *globals* in their respective compilation units, but that is sometimes hard to sell despite the performance savings.
Also, a lot of std::regex usage comes from baffling design decisions in the debugger parts of Dolphin.  Hopefully in the future I or someone else can rework the debugger to use raw UGeckoInstructions rather than disassembled instructions, but it seems like a huge task.