### PR TITLE
Data: Add missing Super Mario Sunshine goop map texture to graphics mod

### DIFF
--- a/Data/Sys/Load/GraphicMods/Super Mario Sunshine/metadata.json
+++ b/Data/Sys/Load/GraphicMods/Super Mario Sunshine/metadata.json
@@ -49,6 +49,10 @@
 				{
 					"type": "efb",
 					"texture_filename": "efb1_n000000_256x256_1"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000000_512x512_1"
 				}
 			]
 		}


### PR DESCRIPTION
The native resolution goop graphics mod for Super Mario Sunshine was missing one of the textures which is used in the intro level.

Before:
![GMSP01_2023-06-08_20-04-16](https://github.com/dolphin-emu/dolphin/assets/43296291/69b5613a-a30e-4f83-b391-9afbb2054ba4)

And after:
![GMSP01_2023-06-08_20-06-23](https://github.com/dolphin-emu/dolphin/assets/43296291/92065dd4-d2bb-476b-804d-1b662a134936)
