### PR TITLE
Debugger: Remove some trivial string copies

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
@@ -251,7 +251,7 @@ void BreakpointDialog::OnAddressTypeChanged()
 
 void BreakpointDialog::accept()
 {
-  auto invalid_input = [this](QString field) {
+  auto invalid_input = [this](const QString& field) {
     ModalMessageBox::critical(this, tr("Error"),
                               tr("Invalid input for the field \"%1\"").arg(field));
   };

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -168,7 +168,7 @@ void BreakpointWidget::Update()
   int i = 0;
   m_table->setRowCount(i);
 
-  const auto create_item = [](const QString string = {}) {
+  const auto create_item = [](const QString& string = {}) {
     QTableWidgetItem* item = new QTableWidgetItem(string);
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
     return item;

--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
@@ -361,7 +361,7 @@ void CodeDiffDialog::Update(bool include)
     OnExclude();
   }
 
-  const auto create_item = [](const QString string = {}, const u32 address = 0x00000000) {
+  const auto create_item = [](const QString& string = {}, const u32 address = 0x00000000) {
     QTableWidgetItem* item = new QTableWidgetItem(string);
     item->setData(Qt::UserRole, address);
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);

--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
@@ -279,7 +279,7 @@ void CodeDiffDialog::OnExclude()
   }
 }
 
-std::vector<Diff> CodeDiffDialog::CalculateSymbolsFromProfile()
+std::vector<Diff> CodeDiffDialog::CalculateSymbolsFromProfile() const
 {
   Profiler::ProfileStats prof_stats;
   auto& blockstats = prof_stats.block_stats;
@@ -288,23 +288,23 @@ std::vector<Diff> CodeDiffDialog::CalculateSymbolsFromProfile()
   current.reserve(20000);
 
   // Convert blockstats to smaller struct Diff. Exclude repeat functions via symbols.
-  for (auto& iter : blockstats)
+  for (const auto& iter : blockstats)
   {
-    Diff tmp_diff;
     std::string symbol = g_symbolDB.GetDescription(iter.addr);
     if (!std::any_of(current.begin(), current.end(),
-                     [&symbol](Diff& v) { return v.symbol == symbol; }))
+                     [&symbol](const Diff& v) { return v.symbol == symbol; }))
     {
-      tmp_diff.symbol = symbol;
-      tmp_diff.addr = iter.addr;
-      tmp_diff.hits = iter.run_count;
-      tmp_diff.total_hits = iter.run_count;
-      current.push_back(tmp_diff);
+      current.push_back(Diff{
+          .addr = iter.addr,
+          .symbol = std::move(symbol),
+          .hits = static_cast<u32>(iter.run_count),
+          .total_hits = static_cast<u32>(iter.run_count),
+      });
     }
   }
 
-  sort(current.begin(), current.end(),
-       [](const Diff& v1, const Diff& v2) { return (v1.symbol < v2.symbol); });
+  std::sort(current.begin(), current.end(),
+            [](const Diff& v1, const Diff& v2) { return (v1.symbol < v2.symbol); });
 
   return current;
 }

--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.h
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.h
@@ -38,7 +38,7 @@ private:
   void ClearBlockCache();
   void OnClickItem();
   void OnRecord(bool enabled);
-  std::vector<Diff> CalculateSymbolsFromProfile();
+  std::vector<Diff> CalculateSymbolsFromProfile() const;
   void OnInclude();
   void OnExclude();
   void RemoveMissingSymbolsFromIncludes(const std::vector<Diff>& symbol_diff);

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -609,7 +609,7 @@ AddressSpace::Type MemoryViewWidget::GetAddressSpace() const
   return m_address_space;
 }
 
-std::vector<u8> MemoryViewWidget::ConvertTextToBytes(Type type, QString input_text)
+std::vector<u8> MemoryViewWidget::ConvertTextToBytes(Type type, QStringView input_text) const
 {
   if (type == Type::Null)
     return {};

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -60,7 +60,7 @@ public:
   void UpdateFont();
   void ToggleBreakpoint(u32 addr, bool row);
 
-  std::vector<u8> ConvertTextToBytes(Type type, QString input_text);
+  std::vector<u8> ConvertTextToBytes(Type type, QStringView input_text) const;
   void SetAddressSpace(AddressSpace::Type address_space);
   AddressSpace::Type GetAddressSpace() const;
   void SetDisplay(Type type, int bytes_per_row, int alignment, bool dual_view);


### PR DESCRIPTION
Gets rid of some trivially removable string churn in Update()-related member functions. Most being accidentally passing by value rather than const reference.