### PR TITLE
GCMemcardUtils: Make use of std::span where applicable 

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcardUtils.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardUtils.cpp
@@ -75,7 +75,7 @@ bool HasSameIdentity(const DEntry& lhs, const DEntry& rhs)
   return true;
 }
 
-bool HasDuplicateIdentity(const std::vector<Savefile>& savefiles)
+bool HasDuplicateIdentity(std::span<const Savefile> savefiles)
 {
   for (size_t i = 0; i < savefiles.size(); ++i)
   {
@@ -338,7 +338,7 @@ std::string GetDefaultExtension(SavefileFormat format)
   }
 }
 
-std::vector<Savefile> GetSavefiles(const GCMemcard& card, const std::vector<u8>& file_indices)
+std::vector<Savefile> GetSavefiles(const GCMemcard& card, std::span<const u8> file_indices)
 {
   std::vector<Savefile> files;
   files.reserve(file_indices.size());
@@ -352,7 +352,7 @@ std::vector<Savefile> GetSavefiles(const GCMemcard& card, const std::vector<u8>&
   return files;
 }
 
-size_t GetBlockCount(const std::vector<Savefile>& savefiles)
+size_t GetBlockCount(std::span<const Savefile> savefiles)
 {
   size_t block_count = 0;
   for (const Savefile& savefile : savefiles)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardUtils.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardUtils.h
@@ -3,8 +3,11 @@
 
 #pragma once
 
+#include <cstddef>
+#include <span>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include "Core/HW/GCMemcard/GCMemcard.h"
 
@@ -13,7 +16,7 @@ namespace Memcard
 bool HasSameIdentity(const DEntry& lhs, const DEntry& rhs);
 
 // Check if any two given savefiles have the same identity.
-bool HasDuplicateIdentity(const std::vector<Savefile>& savefiles);
+bool HasDuplicateIdentity(std::span<const Savefile> savefiles);
 
 enum class ReadSavefileErrorCode
 {
@@ -43,8 +46,8 @@ std::string GenerateFilename(const DEntry& entry);
 std::string GetDefaultExtension(SavefileFormat format);
 
 // Reads multiple savefiles from a card. Returns empty vector if even a single file can't be read.
-std::vector<Savefile> GetSavefiles(const GCMemcard& card, const std::vector<u8>& file_indices);
+std::vector<Savefile> GetSavefiles(const GCMemcard& card, std::span<const u8> file_indices);
 
 // Gets the total amount of blocks the given saves use.
-size_t GetBlockCount(const std::vector<Savefile>& savefiles);
+size_t GetBlockCount(std::span<const Savefile> savefiles);
 }  // namespace Memcard

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -502,7 +502,7 @@ void GCMemcardManager::ExportFiles(Memcard::SavefileFormat format)
   }
 }
 
-void GCMemcardManager::ImportFiles(Slot slot, const std::vector<Memcard::Savefile>& savefiles)
+void GCMemcardManager::ImportFiles(Slot slot, std::span<const Memcard::Savefile> savefiles)
 {
   auto& card = m_slot_memcard[slot];
   if (!card)

--- a/Source/Core/DolphinQt/GCMemcardManager.h
+++ b/Source/Core/DolphinQt/GCMemcardManager.h
@@ -3,10 +3,9 @@
 
 #pragma once
 
-#include <array>
 #include <map>
 #include <memory>
-#include <utility>
+#include <span>
 #include <vector>
 
 #include <QDialog>
@@ -62,7 +61,7 @@ private:
 
   std::vector<u8> GetSelectedFileIndices();
 
-  void ImportFiles(ExpansionInterface::Slot slot, const std::vector<Memcard::Savefile>& savefiles);
+  void ImportFiles(ExpansionInterface::Slot slot, std::span<const Memcard::Savefile> savefiles);
 
   void CopyFiles();
   void ImportFile();

--- a/Source/Core/DolphinQt/GCMemcardManager.h
+++ b/Source/Core/DolphinQt/GCMemcardManager.h
@@ -88,16 +88,17 @@ private:
   QPushButton* m_fix_checksums_button;
 
   // Slots
-  Common::EnumMap<std::map<u8, IconAnimationData>, ExpansionInterface::MAX_MEMCARD_SLOT>
-      m_slot_active_icons;
-  Common::EnumMap<std::unique_ptr<Memcard::GCMemcard>, ExpansionInterface::MAX_MEMCARD_SLOT>
-      m_slot_memcard;
-  Common::EnumMap<QGroupBox*, ExpansionInterface::MAX_MEMCARD_SLOT> m_slot_group;
-  Common::EnumMap<QLineEdit*, ExpansionInterface::MAX_MEMCARD_SLOT> m_slot_file_edit;
-  Common::EnumMap<QPushButton*, ExpansionInterface::MAX_MEMCARD_SLOT> m_slot_open_button;
-  Common::EnumMap<QPushButton*, ExpansionInterface::MAX_MEMCARD_SLOT> m_slot_create_button;
-  Common::EnumMap<QTableWidget*, ExpansionInterface::MAX_MEMCARD_SLOT> m_slot_table;
-  Common::EnumMap<QLabel*, ExpansionInterface::MAX_MEMCARD_SLOT> m_slot_stat_label;
+  template <typename T>
+  using SlotEnumMap = Common::EnumMap<T, ExpansionInterface::MAX_MEMCARD_SLOT>;
+
+  SlotEnumMap<std::map<u8, IconAnimationData>> m_slot_active_icons;
+  SlotEnumMap<std::unique_ptr<Memcard::GCMemcard>> m_slot_memcard;
+  SlotEnumMap<QGroupBox*> m_slot_group;
+  SlotEnumMap<QLineEdit*> m_slot_file_edit;
+  SlotEnumMap<QPushButton*> m_slot_open_button;
+  SlotEnumMap<QPushButton*> m_slot_create_button;
+  SlotEnumMap<QTableWidget*> m_slot_table;
+  SlotEnumMap<QLabel*> m_slot_stat_label;
 
   ExpansionInterface::Slot m_active_slot;
   u64 m_current_frame = 0;


### PR DESCRIPTION
Generifies bits of the interface so that some functions aren't explicitly tied down to only using std::vector.

While we're in the area, we can tidy up the EnumMap definitions in the GCMemcardManager so that there's no duplication of the constant name over and over.