### PR TITLE
PowerPC/ConditionRegister: Mark PPCToInternal() as constexpr

### DIFF
--- a/Source/Core/Core/PowerPC/ConditionRegister.h
+++ b/Source/Core/Core/PowerPC/ConditionRegister.h
@@ -45,7 +45,7 @@ struct ConditionRegister
   u64 fields[8];
 
   // Convert between PPC and internal representation of CR.
-  static u64 PPCToInternal(u8 value)
+  static constexpr u64 PPCToInternal(u8 value)
   {
     u64 cr_val = 0x100000000;
     cr_val |= (u64) !!(value & CR_SO) << CR_EMU_SO_BIT;


### PR DESCRIPTION
This allows the compiler to eliminate a static constructor that initializes the table, and instead precompute all of the data ahead of time.

e.g. We get something like so on GCC without constexpr:

```asm
_GLOBAL__sub_I_PowerPC::ConditionRegister::s_crTable:
        movdqa  xmm0, XMMWORD PTR .LC0[rip]
        movaps  XMMWORD PTR PowerPC::ConditionRegister::s_crTable[rip], xmm0
        movdqa  xmm0, XMMWORD PTR .LC1[rip]
        movaps  XMMWORD PTR PowerPC::ConditionRegister::s_crTable[rip+16], xmm0
        movdqa  xmm0, XMMWORD PTR .LC2[rip]
        movaps  XMMWORD PTR PowerPC::ConditionRegister::s_crTable[rip+32], xmm0
        movdqa  xmm0, XMMWORD PTR .LC3[rip]
        movaps  XMMWORD PTR PowerPC::ConditionRegister::s_crTable[rip+48], xmm0
        movdqa  xmm0, XMMWORD PTR .LC4[rip]
        movaps  XMMWORD PTR PowerPC::ConditionRegister::s_crTable[rip+64], xmm0
        movdqa  xmm0, XMMWORD PTR .LC5[rip]
        movaps  XMMWORD PTR PowerPC::ConditionRegister::s_crTable[rip+80], xmm0
        movdqa  xmm0, XMMWORD PTR .LC6[rip]
        movaps  XMMWORD PTR PowerPC::ConditionRegister::s_crTable[rip+96], xmm0
        movdqa  xmm0, XMMWORD PTR .LC7[rip]
        movaps  XMMWORD PTR PowerPC::ConditionRegister::s_crTable[rip+112], xmm0
        ret
PowerPC::ConditionRegister::s_crTable:
        .zero   128
.LC0:
        .quad   -9223372032559808511
        .quad   -8646911280256385023
.LC1:
        .quad   -9223372032559808512
        .quad   -8646911280256385024
.LC2:
        .quad   4294967297
        .quad   576460756598390785
.LC3:
        .quad   4294967296
        .quad   576460756598390784
.LC4:
        .quad   -4611686014132420607
        .quad   -4035225261828997119
.LC5:
        .quad   -4611686014132420608
        .quad   -4035225261828997120
.LC6:
        .quad   4611686022722355201
        .quad   5188146775025778689
.LC7:
        .quad   4611686022722355200
        .quad   5188146775025778688
```

and with constexpr, this all gets collapsed into:

```asm
PowerPC::ConditionRegister::s_crTable:
        .quad   -9223372032559808511
        .quad   -8646911280256385023
        .quad   -9223372032559808512
        .quad   -8646911280256385024
        .quad   4294967297
        .quad   576460756598390785
        .quad   4294967296
        .quad   576460756598390784
        .quad   -4611686014132420607
        .quad   -4035225261828997119
        .quad   -4611686014132420608
        .quad   -4035225261828997120
        .quad   4611686022722355201
        .quad   5188146775025778689
        .quad   4611686022722355200
        .quad   5188146775025778688
```

completely eliminating the static constructor. MSVC also exhibits this, whereas clang is a little better and does this anyway, even without constexpr. So, an effectively "free" change that generates better code (i.e. none)