### PR TITLE
VideoBackends:Metal: Enable shouldMaximizeConcurrentCompilation when available

### DIFF
--- a/Source/Core/VideoBackends/Metal/MTLMain.mm
+++ b/Source/Core/VideoBackends/Metal/MTLMain.mm
@@ -95,6 +95,11 @@ bool Metal::VideoBackend::Initialize(const WindowSystemInfo& wsi)
     MRCOwned<id<MTLDevice>> adapter = std::move(devs[selected_adapter_index]);
     Util::PopulateBackendInfoFeatures(&g_Config, adapter);
 
+#if TARGET_OS_OSX
+    if (@available(macOS 13.3, *))
+      [adapter setShouldMaximizeConcurrentCompilation:YES];
+#endif
+
     UpdateActiveConfig();
 
     MRCOwned<CAMetalLayer*> layer = MRCRetain(static_cast<CAMetalLayer*>(wsi.render_surface));


### PR DESCRIPTION
macOS 13.3 finally lets us use all our cores when compiling shaders, turn that on

Improves launch time with Compile Shaders Before Starting + Ubershaders

For anyone who wants to test, clear your Metal shader cache with
```sh
rm -r $TMPDIR/../C/org.dolphin-emu.dolphin/com.apple.metal
```