### PR TITLE
String formatting improvements and optimizations

### DIFF
--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -6,6 +6,8 @@
 
 #include <string>
 
+#include <fmt/format.h>
+
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -159,9 +161,9 @@ void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count,
   {
     Stop();
     file_index++;
-    std::ostringstream filename;
-    filename << File::GetUserPath(D_DUMPAUDIO_IDX) << basename << file_index << ".wav";
-    Start(filename.str(), sample_rate_divisor);
+    const std::string filename =
+        fmt::format("{:s}{:s}{:d}.wav", File::GetUserPath(D_DUMPAUDIO_IDX), basename, file_index);
+    Start(filename, sample_rate_divisor);
     current_sample_rate_divisor = sample_rate_divisor;
   }
 

--- a/Source/Core/Common/Debug/Watches.cpp
+++ b/Source/Core/Common/Debug/Watches.cpp
@@ -7,6 +7,8 @@
 #include <locale>
 #include <sstream>
 
+#include <fmt/format.h>
+
 namespace Common::Debug
 {
 Watch::Watch(u32 address_, std::string name_, State is_enabled_)
@@ -107,13 +109,9 @@ void Watches::LoadFromStrings(const std::vector<std::string>& watches)
 std::vector<std::string> Watches::SaveToStrings() const
 {
   std::vector<std::string> watches;
+  watches.reserve(m_watches.size());
   for (const auto& watch : m_watches)
-  {
-    std::ostringstream ss;
-    ss.imbue(std::locale::classic());
-    ss << std::hex << watch.address << " " << watch.name;
-    watches.push_back(ss.str());
-  }
+    watches.emplace_back(fmt::format("{:x} {:s}", watch.address, watch.name));
   return watches;
 }
 

--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -12,6 +12,9 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
@@ -318,7 +321,7 @@ bool IniFile::Load(const std::string& filename, bool keep_current_data)
 bool IniFile::Save(const std::string& filename)
 {
   std::ofstream out;
-  std::string temp = File::GetTempFilenameForAtomicWrite(filename);
+  const std::string temp = File::GetTempFilenameForAtomicWrite(filename);
   File::OpenFStream(out, temp, std::ios::out);
 
   if (out.fail())
@@ -329,19 +332,19 @@ bool IniFile::Save(const std::string& filename)
   for (const Section& section : sections)
   {
     if (!section.keys_order.empty() || !section.m_lines.empty())
-      out << '[' << section.name << ']' << std::endl;
+      fmt::print(out, "[{:s}]\n", section.name);
 
     if (section.keys_order.empty())
     {
       for (const std::string& s : section.m_lines)
-        out << s << std::endl;
+        fmt::print(out, "{:s}\n", s);
     }
     else
     {
       for (const std::string& kvit : section.keys_order)
       {
         auto pair = section.values.find(kvit);
-        out << pair->first << " = " << pair->second << std::endl;
+        fmt::print(out, "{:s} = {:s}\n", pair->first, pair->second);
       }
     }
   }

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -139,7 +139,7 @@ std::string EscapePath(const std::string& path)
   std::vector<std::string> escaped_split_strings;
   escaped_split_strings.reserve(split_strings.size());
   for (const std::string& split_string : split_strings)
-    escaped_split_strings.push_back(EscapeFileName(split_string));
+    escaped_split_strings.emplace_back(EscapeFileName(split_string));
 
   return JoinStrings(escaped_split_strings, "/");
 }

--- a/Source/Core/Common/Profiler.h
+++ b/Source/Core/Common/Profiler.h
@@ -5,6 +5,7 @@
 
 #include <list>
 #include <mutex>
+#include <ostream>
 #include <string>
 
 #include "CommonTypes.h"
@@ -21,7 +22,7 @@ public:
 
   void Start();
   void Stop();
-  std::string Read();
+  void Print(std::ostream&);
 
   bool operator<(const Profiler& b) const;
 

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -239,25 +239,6 @@ inline char ToUpper(char ch)
   return std::toupper(ch, std::locale::classic());
 }
 
-// Thousand separator. Turns 12345678 into 12,345,678
-template <typename I>
-std::string ThousandSeparate(I value, int spaces = 0)
-{
-#ifdef _WIN32
-  std::wostringstream stream;
-#else
-  std::ostringstream stream;
-#endif
-
-  stream << std::setw(spaces) << value;
-
-#ifdef _WIN32
-  return WStringToUTF8(stream.str());
-#else
-  return stream.str();
-#endif
-}
-
 #ifdef _WIN32
 std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
 #endif

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "AudioCommon/AudioCommon.h"
 #include "Common/Assert.h"
@@ -537,8 +538,8 @@ static std::string SaveUSBWhitelistToString(const std::set<std::pair<u16, u16>>&
 {
   std::ostringstream oss;
   for (const auto& device : devices)
-    oss << fmt::format("{:04x}:{:04x}", device.first, device.second) << ',';
-  std::string devices_string = oss.str();
+    fmt::print(oss, "{:04x}:{:04x},", device.first, device.second);
+  std::string devices_string = std::move(oss).str();
   if (!devices_string.empty())
     devices_string.pop_back();
   return devices_string;

--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -77,13 +77,11 @@ void FileLogger::Log(const DiscIO::Volume& volume, const DiscIO::Partition& part
   if (m_previous_partition == partition && m_previous_file_offset == file_offset)
     return;
 
-  const std::string size_string = Common::ThousandSeparate(file_info->GetSize() / 1000, 7);
   const std::string path = file_info->GetPath();
-  const std::string log_string = fmt::format("{} kB {}", size_string, path);
   if (IsSoundFile(path))
-    INFO_LOG_FMT(FILEMON, "{}", log_string);
+    INFO_LOG_FMT(FILEMON, "{:>7s} kB {}", fmt::group_digits(file_info->GetSize() / 1000), path);
   else
-    WARN_LOG_FMT(FILEMON, "{}", log_string);
+    WARN_LOG_FMT(FILEMON, "{:>7s} kB {}", fmt::group_digits(file_info->GetSize() / 1000), path);
 
   // Update the last accessed file
   m_previous_partition = partition;

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -662,16 +662,16 @@ std::optional<IPCReply> EmulationKernel::OpenDevice(OpenRequest& request)
   request.fd = new_fd;
 
   std::shared_ptr<Device> device;
-  if (request.path.find("/dev/usb/oh0/") == 0 && !GetDeviceByName(request.path) &&
+  if (request.path.starts_with("/dev/usb/oh0/") && !GetDeviceByName(request.path) &&
       !HasFeature(GetVersion(), Feature::NewUSB))
   {
     device = std::make_shared<OH0Device>(*this, request.path);
   }
-  else if (request.path.find("/dev/") == 0)
+  else if (request.path.starts_with("/dev/"))
   {
     device = GetDeviceByName(request.path);
   }
-  else if (request.path.find('/') == 0)
+  else if (request.path.starts_with('/'))
   {
     device = GetDeviceByName("/dev/fs");
   }

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -630,7 +630,7 @@ void BluetoothRealDevice::SaveLinkKeys()
     }
     oss << std::dec << ',';
   }
-  std::string config_string = oss.str();
+  std::string config_string = std::move(oss).str();
   if (!config_string.empty())
     config_string.pop_back();
   Config::SetBase(Config::MAIN_BLUETOOTH_PASSTHROUGH_LINK_KEYS, config_string);

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -7,6 +7,10 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <utility>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <unistd.h>
 
 #include "Common/FileUtil.h"
@@ -82,23 +86,19 @@ u32 MemoryWatcher::ChasePointer(const Core::CPUThreadGuard& guard, const std::st
 std::string MemoryWatcher::ComposeMessages(const Core::CPUThreadGuard& guard)
 {
   std::ostringstream message_stream;
-  message_stream << std::hex;
 
-  for (auto& entry : m_values)
+  for (auto& [address, current_value] : m_values)
   {
-    std::string address = entry.first;
-    u32& current_value = entry.second;
-
     u32 new_value = ChasePointer(guard, address);
     if (new_value != current_value)
     {
       // Update the value
       current_value = new_value;
-      message_stream << address << '\n' << new_value << '\n';
+      fmt::print(message_stream, "{:s}\n{:x}\n", address, new_value);
     }
   }
 
-  return message_stream.str();
+  return std::move(message_stream).str();
 }
 
 void MemoryWatcher::Step(const Core::CPUThreadGuard& guard)

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -208,7 +208,7 @@ std::string GetRTCDisplay()
 
   std::ostringstream format_time;
   format_time << std::put_time(gm_time, "Date/Time: %c\n");
-  return format_time.str();
+  return std::move(format_time).str();
 }
 
 // NOTE: GPU Thread

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -11,7 +11,6 @@
 #include <memory>
 #include <mutex>
 #include <span>
-#include <sstream>
 #include <thread>
 #include <tuple>
 #include <type_traits>
@@ -535,10 +534,7 @@ void NetPlayClient::OnChatMessage(sf::Packet& packet)
   INFO_LOG_FMT(NETPLAY, "Player {} ({}) wrote: {}", player.name, player.pid, msg);
 
   // add to gui
-  std::ostringstream ss;
-  ss << player.name << '[' << char(pid + '0') << "]: " << msg;
-
-  m_dialog->AppendChat(ss.str());
+  m_dialog->AppendChat(fmt::format("{:s}[{:d}]: {:s}", player.name, pid, msg));
 }
 
 void NetPlayClient::OnChunkedDataStart(sf::Packet& packet)

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -301,8 +301,7 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& 
       constexpr auto is_hex_str = [](const std::string& s) {
         return !s.empty() && s.find_first_not_of("0123456789abcdefABCDEF") == std::string::npos;
       };
-      const std::string stripped_line(StripWhitespace(line));
-      std::istringstream iss(stripped_line);
+      std::istringstream iss(std::string{StripWhitespace(line)});
       iss.imbue(std::locale::classic());
       std::string word;
 

--- a/Source/Core/DiscIO/RiivolutionParser.cpp
+++ b/Source/Core/DiscIO/RiivolutionParser.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
@@ -473,9 +474,9 @@ std::string WriteConfigString(const Config& config)
     option_node.append_attribute("default").set_value(option.m_default);
   }
 
-  std::stringstream ss;
-  doc.print(ss, "  ");
-  return ss.str();
+  std::ostringstream oss;
+  doc.print(oss, "  ");
+  return std::move(oss).str();
 }
 
 bool WriteConfigFile(const std::string& filename, const Config& config)

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
@@ -4,6 +4,7 @@
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 #include <sstream>
+#include <utility>
 
 namespace ControllerEmu
 {
@@ -50,7 +51,7 @@ void NumericSetting<double>::SetExpressionFromValue()
   ss.imbue(std::locale::classic());
   ss << GetValue();
 
-  m_value.m_input.SetExpression(ss.str());
+  m_value.m_input.SetExpression(std::move(ss).str());
 }
 
 template <>

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -162,15 +162,12 @@ void Device::AddCombinedInput(std::string name, const std::pair<std::string, std
 std::string DeviceQualifier::ToString() const
 {
   if (source.empty() && (cid < 0) && name.empty())
-    return "";
+    return {};
 
-  std::ostringstream ss;
-  ss << source << '/';
   if (cid > -1)
-    ss << cid;
-  ss << '/' << name;
-
-  return ss.str();
+    return fmt::format("{:s}/{:d}/{:s}", source, cid, name);
+  else
+    return fmt::format("{:s}//{:s}", source, name);
 }
 
 //

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -7,8 +7,9 @@
 #include <limits>
 #include <mutex>
 #include <set>
-#include <sstream>
 #include <type_traits>
+
+#include <fmt/format.h>
 
 #include "Common/HRWrap.h"
 #include "Common/Logging/Log.h"
@@ -266,29 +267,16 @@ void Joystick::UpdateInput()
 
 std::string Joystick::Button::GetName() const
 {
-  std::ostringstream ss;
-  ss << "Button " << (int)m_index;
-  return ss.str();
+  return fmt::format("Button {:d}", m_index);
 }
 
 std::string Joystick::Axis::GetName() const
 {
-  std::ostringstream ss;
-  // axis
-  if (m_index < 6)
-  {
-    ss << "Axis " << (char)('X' + (m_index % 3));
-    if (m_index > 2)
-      ss << 'r';
-  }
-  // slider
-  else
-  {
-    ss << "Slider " << (int)(m_index - 6);
-  }
-
-  ss << (m_range < 0 ? '-' : '+');
-  return ss.str();
+  const char sign = m_range < 0 ? '-' : '+';
+  if (m_index < 6)  // axis
+    return fmt::format("Axis {:c}{:s}{:c}", 'X' + m_index % 3, m_index > 2 ? "r" : "", sign);
+  else  // slider
+    return fmt::format("Slider {:d}{:c}", m_index - 6, sign);
 }
 
 std::string Joystick::Hat::GetName() const

--- a/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.cpp
@@ -19,41 +19,30 @@
 #include "InputCommon/DynamicInputTextures/DITSpecification.h"
 #include "InputCommon/ImageOperations.h"
 
-namespace
-{
-std::string GetStreamAsString(std::ifstream& stream)
-{
-  std::stringstream ss;
-  ss << stream.rdbuf();
-  return ss.str();
-}
-}  // namespace
-
 namespace InputCommon::DynamicInputTextures
 {
-Configuration::Configuration(const std::string& json_file)
+Configuration::Configuration(const std::string& json_path)
 {
-  std::ifstream json_stream;
-  File::OpenFStream(json_stream, json_file, std::ios_base::in);
-  if (!json_stream.is_open())
+  std::string json_data;
+  if (!File::ReadFileToString(json_path, json_data))
   {
-    ERROR_LOG_FMT(VIDEO, "Failed to load dynamic input json file '{}'", json_file);
+    ERROR_LOG_FMT(VIDEO, "Failed to load dynamic input json file '{}'", json_path);
     m_valid = false;
     return;
   }
 
   picojson::value root;
-  const auto error = picojson::parse(root, GetStreamAsString(json_stream));
+  const auto error = picojson::parse(root, json_data);
 
   if (!error.empty())
   {
     ERROR_LOG_FMT(VIDEO, "Failed to load dynamic input json file '{}' due to parse error: {}",
-                  json_file, error);
+                  json_path, error);
     m_valid = false;
     return;
   }
 
-  SplitPath(json_file, &m_base_path, nullptr, nullptr);
+  SplitPath(json_path, &m_base_path, nullptr, nullptr);
 
   const picojson::value& specification_json = root.get("specification");
   u8 specification = 1;
@@ -66,7 +55,7 @@ Configuration::Configuration(const std::string& json_file)
       ERROR_LOG_FMT(
           VIDEO,
           "Failed to load dynamic input json file '{}', specification '{}' is not within bounds",
-          json_file, spec_from_json);
+          json_path, spec_from_json);
       m_valid = false;
       return;
     }
@@ -77,12 +66,12 @@ Configuration::Configuration(const std::string& json_file)
   {
     ERROR_LOG_FMT(VIDEO,
                   "Failed to load dynamic input json file '{}', specification '{}' is invalid",
-                  json_file, specification);
+                  json_path, specification);
     m_valid = false;
     return;
   }
 
-  m_valid = ProcessSpecificationV1(root, m_dynamic_input_textures, m_base_path, json_file);
+  m_valid = ProcessSpecificationV1(root, m_dynamic_input_textures, m_base_path, json_path);
 }
 
 Configuration::~Configuration() = default;

--- a/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.h
+++ b/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.h
@@ -19,7 +19,7 @@ namespace InputCommon::DynamicInputTextures
 class Configuration
 {
 public:
-  explicit Configuration(const std::string& json_file);
+  explicit Configuration(const std::string& json_path);
   ~Configuration();
   bool GenerateTextures(const Common::IniFile& file,
                         const std::vector<std::string>& controller_names) const;

--- a/Source/Core/UICommon/Disassembler.cpp
+++ b/Source/Core/UICommon/Disassembler.cpp
@@ -4,9 +4,12 @@
 #include "UICommon/Disassembler.h"
 
 #include <sstream>
+#include <utility>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #if defined(HAVE_LLVM)
-#include <fmt/format.h>
 #include <llvm-c/Disassembler.h>
 #include <llvm-c/Target.h>
 #elif defined(_M_X86)
@@ -77,37 +80,33 @@ std::string HostDisassemblerLLVM::DisassembleHostBlock(const u8* code_start, con
     size_t inst_size = LLVMDisasmInstruction(m_llvm_context, disasmPtr, (u64)(end - disasmPtr),
                                              starting_pc, inst_disasm, 256);
 
-    x86_disasm << "0x" << std::hex << starting_pc << "\t";
+    fmt::print(x86_disasm, "0x{:x}\t", starting_pc);
     if (!inst_size)
     {
-      x86_disasm << "Invalid inst:";
+      fmt::print(x86_disasm, "Invalid inst:");
 
       if (m_instruction_size != -1)
       {
         // If we are on an architecture that has a fixed instruction size
         // We can continue onward past this bad instruction.
-        std::string inst_str;
         for (int i = 0; i < m_instruction_size; ++i)
-          inst_str += fmt::format("{:02x}", disasmPtr[i]);
-
-        x86_disasm << inst_str << std::endl;
+          fmt::print(x86_disasm, "{:02x}", disasmPtr[i]);
+        x86_disasm.put('\n');
         disasmPtr += m_instruction_size;
       }
       else
       {
         // We can't continue if we are on an architecture that has flexible instruction sizes
         // Dump the rest of the block instead
-        std::string code_block;
         for (int i = 0; (disasmPtr + i) < end; ++i)
-          code_block += fmt::format("{:02x}", disasmPtr[i]);
-
-        x86_disasm << code_block << std::endl;
+          fmt::print(x86_disasm, "{:02x}", disasmPtr[i]);
+        x86_disasm.put('\n');
         break;
       }
     }
     else
     {
-      x86_disasm << inst_disasm << std::endl;
+      fmt::print(x86_disasm, "{:s}\n", inst_disasm);
       disasmPtr += inst_size;
       starting_pc += inst_size;
     }
@@ -115,7 +114,7 @@ std::string HostDisassemblerLLVM::DisassembleHostBlock(const u8* code_start, con
     (*host_instructions_count)++;
   }
 
-  return x86_disasm.str();
+  return std::move(x86_disasm).str();
 }
 #elif defined(_M_X86)
 class HostDisassemblerX86 : public HostDisassembler
@@ -146,11 +145,11 @@ std::string HostDisassemblerX86::DisassembleHostBlock(const u8* code_start, cons
   {
     char inst_disasm[256];
     disasmPtr += m_disasm.disasm64(disasmPtr, disasmPtr, (u8*)disasmPtr, inst_disasm);
-    x86_disasm << inst_disasm << std::endl;
+    fmt::print(x86_disasm, "{:s}\n", inst_disasm);
     (*host_instructions_count)++;
   }
 
-  return x86_disasm.str();
+  return std::move(x86_disasm).str();
 }
 #endif
 

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -16,6 +16,8 @@
 #include <wil/resource.h>
 #endif
 
+#include <fmt/format.h>
+
 #include "Common/Common.h"
 #include "Common/CommonPaths.h"
 #include "Common/Config/Config.h"
@@ -551,10 +553,8 @@ std::string FormatSize(u64 bytes, int decimals)
 
   // Don't need exact values, only 5 most significant digits
   const double unit_size = std::pow(2, unit * 10);
-  std::ostringstream ss;
-  ss << std::fixed << std::setprecision(decimals);
-  ss << bytes / unit_size << ' ' << Common::GetStringT(unit_symbols[unit]);
-  return ss.str();
+  return fmt::format("{:.{}f} {:s}", bytes / unit_size, decimals,
+                     Common::GetStringT(unit_symbols[unit]));
 }
 
 }  // namespace UICommon

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <wrl/client.h>
 #include "disassemble.h"
 #include "spirv_hlsl.hpp"
@@ -254,17 +255,15 @@ std::optional<Shader::BinaryData> Shader::CompileShader(D3D_FEATURE_LEVEL featur
     std::ofstream file;
     File::OpenFStream(file, filename, std::ios_base::out);
     file.write(hlsl->data(), hlsl->size());
-    file << "\n";
+    file.put('\n');
     file.write(static_cast<const char*>(errors->GetBufferPointer()), errors->GetBufferSize());
-    file << "\n";
-    file << "Dolphin Version: " + Common::GetScmRevStr() + "\n";
-    file << "Video Backend: " + g_video_backend->GetDisplayName();
+    file.put('\n');
+    fmt::print(file, "Dolphin Version: {:s}\n", Common::GetScmRevStr());
+    fmt::print(file, "Video Backend: {:s}", g_video_backend->GetDisplayName());
 
     if (const auto spirv = GetSpirv(stage, source))
     {
-      file << "\nOriginal Source: \n";
-      file << source << std::endl;
-      file << "SPIRV: \n";
+      fmt::print(file, "\nOriginal Source: \n{:s}\nSPIRV: \n", source);
       spv::Disassemble(file, *spirv);
     }
     file.close();

--- a/Source/Core/VideoBackends/Metal/MTLGfx.mm
+++ b/Source/Core/VideoBackends/Metal/MTLGfx.mm
@@ -18,6 +18,9 @@
 
 #include <fstream>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 Metal::Gfx::Gfx(MRCOwned<CAMetalLayer*> layer) : m_layer(std::move(layer))
 {
   UpdateActiveConfig();
@@ -165,26 +168,20 @@ std::unique_ptr<AbstractShader> Metal::Gfx::CreateShaderFromMSL(ShaderStage stag
       std::ofstream stream(filename);
       if (stream.good())
       {
-        stream << msl << std::endl;
-        stream << "/*" << std::endl;
-        stream << msg << std::endl;
-        stream << "Error:" << std::endl;
-        stream << [[err localizedDescription] UTF8String] << std::endl;
+        fmt::print(stream, "{:s}\n/*\n{:s}\nError:\n{:s}\n", msl, msg,
+                   [[err localizedDescription] UTF8String]);
         if (!glsl.empty())
         {
-          stream << "Original GLSL:" << std::endl;
-          stream << glsl << std::endl;
+          fmt::print(stream, "Original GLSL:\n{:s}\n", glsl);
         }
         else
         {
-          stream << "Shader was created with cached MSL so no GLSL is available." << std::endl;
+          fmt::print(stream, "Shader was created with cached MSL so no GLSL is available.\n");
         }
       }
 
-      stream << std::endl;
-      stream << "Dolphin Version: " << Common::GetScmRevStr() << std::endl;
-      stream << "Video Backend: " << g_video_backend->GetDisplayName() << std::endl;
-      stream << "*/" << std::endl;
+      fmt::print(stream, "\nDolphin Version: {:s}\nVideo Backend: {:s}\n*/\n",
+                 Common::GetScmRevStr(), g_video_backend->GetDisplayName());
       stream.close();
 
       PanicAlertFmt("{} (written to {})\n", msg, filename);

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "Common/Align.h"
 #include "Common/Assert.h"
@@ -376,10 +377,8 @@ bool ProgramShaderCache::CheckShaderCompileResult(GLuint id, GLenum type, std::s
       std::string filename = VideoBackendBase::BadShaderFilename(prefix, num_failures++);
       std::ofstream file;
       File::OpenFStream(file, filename, std::ios_base::out);
-      file << s_glsl_header << code << info_log;
-      file << "\n";
-      file << "Dolphin Version: " + Common::GetScmRevStr() + "\n";
-      file << "Video Backend: " + g_video_backend->GetDisplayName();
+      fmt::print(file, "{:s}{:s}{:s}\nDolphin Version: {:s}\nVideo Backend: {:s}", s_glsl_header,
+                 code, info_log, Common::GetScmRevStr(), g_video_backend->GetDisplayName());
       file.close();
 
       PanicAlertFmt("Failed to compile {} shader: {}\n"
@@ -415,16 +414,13 @@ bool ProgramShaderCache::CheckProgramLinkResult(GLuint id, std::string_view vcod
       std::ofstream file;
       File::OpenFStream(file, filename, std::ios_base::out);
       if (!vcode.empty())
-        file << s_glsl_header << vcode << '\n';
+        fmt::print(file, "{:s}{:s}\n", s_glsl_header, vcode);
       if (!gcode.empty())
-        file << s_glsl_header << gcode << '\n';
+        fmt::print(file, "{:s}{:s}\n", s_glsl_header, gcode);
       if (!pcode.empty())
-        file << s_glsl_header << pcode << '\n';
-
-      file << info_log;
-      file << "\n";
-      file << "Dolphin Version: " + Common::GetScmRevStr() + "\n";
-      file << "Video Backend: " + g_video_backend->GetDisplayName();
+        fmt::print(file, "{:s}{:s}\n", s_glsl_header, pcode);
+      fmt::print(file, "{:s}\nDolphin Version: {:s}\nVideo Backend: {:s}", info_log,
+                 Common::GetScmRevStr(), g_video_backend->GetDisplayName());
       file.close();
 
       PanicAlertFmt("Failed to link shaders: {}\n"

--- a/Source/Core/VideoCommon/PerformanceTracker.cpp
+++ b/Source/Core/VideoCommon/PerformanceTracker.cpp
@@ -8,6 +8,8 @@
 #include <iomanip>
 #include <mutex>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <implot.h>
 
 #include "Common/CommonTypes.h"
@@ -238,7 +240,7 @@ void PerformanceTracker::LogRenderTimeToFile(DT val)
                       std::ios_base::out);
   }
 
-  m_bench_file << std::fixed << std::setprecision(8) << DT_ms(val).count() << std::endl;
+  fmt::print(m_bench_file, "{:.8f}\n", DT_ms(val).count());
 }
 
 void PerformanceTracker::SetPaused(bool paused)

--- a/Source/Core/VideoCommon/Spirv.cpp
+++ b/Source/Core/VideoCommon/Spirv.cpp
@@ -3,6 +3,9 @@
 
 #include "VideoCommon/Spirv.h"
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 // glslang includes
 #include "GlslangToSpv.h"
 #include "ResourceLimits.h"
@@ -73,22 +76,17 @@ CompileShaderToSPV(EShLanguage stage, APIType api_type,
     File::OpenFStream(stream, filename, std::ios_base::out);
     if (stream.good())
     {
-      stream << source << std::endl;
-      stream << msg << std::endl;
-      stream << "Shader Info Log:" << std::endl;
-      stream << shader->getInfoLog() << std::endl;
-      stream << shader->getInfoDebugLog() << std::endl;
+      fmt::print(stream, "{:s}\n{:s}\nShader Info Log:\n{:s}\n{:s}\n", source, msg,
+                 shader->getInfoLog(), shader->getInfoDebugLog());
       if (program)
       {
-        stream << "Program Info Log:" << std::endl;
-        stream << program->getInfoLog() << std::endl;
-        stream << program->getInfoDebugLog() << std::endl;
+        fmt::print(stream, "Program Info Log:\n{:s}\n{:s}\n", program->getInfoLog(),
+                   program->getInfoDebugLog());
       }
     }
 
-    stream << "\n";
-    stream << "Dolphin Version: " + Common::GetScmRevStr() + "\n";
-    stream << "Video Backend: " + g_video_backend->GetDisplayName();
+    fmt::print(stream, "\nDolphin Version: {:s}\nVideo Backend: {:s}", Common::GetScmRevStr(),
+               g_video_backend->GetDisplayName());
     stream.close();
 
     PanicAlertFmt("{} (written to {})\nDebug info:\n{}", msg, filename, shader->getInfoLog());

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -6,6 +6,8 @@
 #include <array>
 #include <cmath>
 #include <memory>
+#include <sstream>
+#include <utility>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
@@ -988,13 +990,13 @@ void VertexManagerBase::OnEndFrame()
 #if 0
   {
     std::ostringstream ss;
+    // TODO: Waiting for GCC 11 and Clang 13 to use C++20's std::ostringstream::view()
     std::for_each(m_cpu_accesses_this_frame.begin(), m_cpu_accesses_this_frame.end(), [&ss](u32 idx) { ss << idx << ","; });
-    WARN_LOG_FMT(VIDEO, "CPU EFB accesses in last frame: {}", ss.str());
-  }
-  {
-    std::ostringstream ss;
+    WARN_LOG_FMT(VIDEO, "CPU EFB accesses in last frame: {}", std::move(ss).str());
+    // Underlying buffer is in a valid, but unspecified state.
+    ss.str(std::string{});
     std::for_each(m_scheduled_command_buffer_kicks.begin(), m_scheduled_command_buffer_kicks.end(), [&ss](u32 idx) { ss << idx << ","; });
-    WARN_LOG_FMT(VIDEO, "Scheduled command buffer kicks: {}", ss.str());
+    WARN_LOG_FMT(VIDEO, "Scheduled command buffer kicks: {}", std::move(ss).str());
   }
 #endif
 


### PR DESCRIPTION
Replace many uses of std::ostringstream with fmt::format, and many uses of the stream insertion operator with fmt::print(std::ostream&).  Use rvalue-ref qualified std::ostringstream::str() method whenever possible to avoid string copies.  In various shader generating functions, wasteful stream insertions have been improved.  Replace Common::ThousandsSeperate with fmt::groupdigits.  An unrelated modernization change in IOS.cpp.  Replace GetStreamAsString function in DITConfiguration.cpp with File::ReadFileToString.