### PR TITLE
StringUtil improvements and further application

### DIFF
--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -39,8 +39,8 @@ inline void CharArrayFromFormat(char (&out)[Count], const char* format, ...)
   va_end(args);
 }
 
-// Good
-std::string ArrayToString(const u8* data, u32 size, int line_len = 20, bool spaces = true);
+std::string MemToHexString(const void* data, std::size_t size, std::size_t bytes_per_line = 20,
+                           bool spaces = true);
 
 std::string_view StripWhitespace(std::string_view s);
 std::string_view StripSpaces(std::string_view s);

--- a/Source/Core/Core/HW/EXI/BBA/TAPServer_Apple.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAPServer_Apple.cpp
@@ -58,10 +58,7 @@ bool CEXIETHERNET::TAPServerNetworkInterface::Activate()
 
 bool CEXIETHERNET::TAPServerNetworkInterface::SendFrame(const u8* frame, u32 size)
 {
-  {
-    const std::string s = ArrayToString(frame, size, 0x10);
-    INFO_LOG_FMT(SP1, "SendFrame {}\n{}", size, s);
-  }
+  INFO_LOG_FMT(SP1, "SendFrame {}\n{}", size, MemToHexString(frame, size, 0x10));
 
   auto size16 = u16(size);
   if (write(fd, &size16, 2) != 2)
@@ -111,8 +108,8 @@ void CEXIETHERNET::TAPServerNetworkInterface::ReadThreadHandler()
       }
       else if (readEnabled.IsSet())
       {
-        std::string data_string = ArrayToString(m_eth_ref->mRecvBuffer.get(), read_bytes, 0x10);
-        INFO_LOG_FMT(SP1, "Read data: {}", data_string);
+        INFO_LOG_FMT(SP1, "Read data: {}",
+                     MemToHexString(m_eth_ref->mRecvBuffer.get(), read_bytes, 0x10));
         m_eth_ref->mRecvBufferLength = read_bytes;
         m_eth_ref->RecvHandlePacket();
       }

--- a/Source/Core/Core/HW/EXI/BBA/TAP_Apple.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAP_Apple.cpp
@@ -48,7 +48,7 @@ bool CEXIETHERNET::TAPNetworkInterface::IsActivated()
 
 bool CEXIETHERNET::TAPNetworkInterface::SendFrame(const u8* frame, u32 size)
 {
-  INFO_LOG_FMT(SP1, "SendFrame {}\n{}", size, ArrayToString(frame, size, 0x10));
+  INFO_LOG_FMT(SP1, "SendFrame {}\n{}", size, MemToHexString(frame, size, 0x10));
 
   const int written_bytes = write(fd, frame, size);
   if (u32(written_bytes) != size)
@@ -86,7 +86,7 @@ void CEXIETHERNET::TAPNetworkInterface::ReadThreadHandler(TAPNetworkInterface* s
     else if (self->readEnabled.IsSet())
     {
       INFO_LOG_FMT(SP1, "Read data: {}",
-                   ArrayToString(self->m_eth_ref->mRecvBuffer.get(), read_bytes, 0x10));
+                   MemToHexString(self->m_eth_ref->mRecvBuffer.get(), read_bytes, 0x10));
       self->m_eth_ref->mRecvBufferLength = read_bytes;
       self->m_eth_ref->RecvHandlePacket();
     }

--- a/Source/Core/Core/HW/EXI/BBA/TAP_Unix.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAP_Unix.cpp
@@ -107,7 +107,7 @@ bool CEXIETHERNET::TAPNetworkInterface::IsActivated()
 bool CEXIETHERNET::TAPNetworkInterface::SendFrame(const u8* frame, u32 size)
 {
 #ifdef __linux__
-  DEBUG_LOG_FMT(SP1, "SendFrame {}\n{}", size, ArrayToString(frame, size, 0x10));
+  DEBUG_LOG_FMT(SP1, "SendFrame {}\n{}", size, MemToHexString(frame, size, 0x10));
 
   int writtenBytes = write(fd, frame, size);
   if ((u32)writtenBytes != size)
@@ -150,7 +150,7 @@ void CEXIETHERNET::TAPNetworkInterface::ReadThreadHandler(TAPNetworkInterface* s
     else if (self->readEnabled.IsSet())
     {
       DEBUG_LOG_FMT(SP1, "Read data: {}",
-                    ArrayToString(self->m_eth_ref->mRecvBuffer.get(), readBytes, 0x10));
+                    MemToHexString(self->m_eth_ref->mRecvBuffer.get(), readBytes, 0x10));
       self->m_eth_ref->mRecvBufferLength = readBytes;
       self->m_eth_ref->RecvHandlePacket();
     }

--- a/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
@@ -308,7 +308,7 @@ void CEXIETHERNET::TAPNetworkInterface::ReadThreadHandler(TAPNetworkInterface* s
 
     // Copy to BBA buffer, and fire interrupt if enabled.
     DEBUG_LOG_FMT(SP1, "Received {} bytes:\n {}", transferred,
-                  ArrayToString(self->m_eth_ref->mRecvBuffer.get(), transferred, 0x10));
+                  MemToHexString(self->m_eth_ref->mRecvBuffer.get(), transferred, 0x10));
     if (self->readEnabled.IsSet())
     {
       self->m_eth_ref->mRecvBufferLength = transferred;
@@ -319,7 +319,7 @@ void CEXIETHERNET::TAPNetworkInterface::ReadThreadHandler(TAPNetworkInterface* s
 
 bool CEXIETHERNET::TAPNetworkInterface::SendFrame(const u8* frame, u32 size)
 {
-  DEBUG_LOG_FMT(SP1, "SendFrame {} bytes:\n{}", size, ArrayToString(frame, size, 0x10));
+  DEBUG_LOG_FMT(SP1, "SendFrame {} bytes:\n{}", size, MemToHexString(frame, size, 0x10));
 
   // Check for a background write. We can't issue another one until this one has completed.
   DWORD transferred;

--- a/Source/Core/Core/HW/EXI/BBA/XLINK_KAI_BBA.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/XLINK_KAI_BBA.cpp
@@ -43,7 +43,7 @@ bool CEXIETHERNET::XLinkNetworkInterface::Activate()
   const auto size = u32(cmd.length());
   memmove(buffer, cmd.c_str(), size);
 
-  DEBUG_LOG_FMT(SP1, "SendCommandPayload {:x}\n{}", size, ArrayToString(buffer, size, 0x10));
+  DEBUG_LOG_FMT(SP1, "SendCommandPayload {:x}\n{}", size, MemToHexString(buffer, size, 0x10));
 
   if (m_sf_socket.send(buffer, size, m_sf_recipient_ip, m_dest_port) != sf::Socket::Done)
   {
@@ -69,7 +69,7 @@ void CEXIETHERNET::XLinkNetworkInterface::Deactivate()
   u8 buffer[255] = {};
   memmove(buffer, cmd.c_str(), size);
 
-  DEBUG_LOG_FMT(SP1, "SendCommandPayload {:x}\n{}", size, ArrayToString(buffer, size, 0x10));
+  DEBUG_LOG_FMT(SP1, "SendCommandPayload {:x}\n{}", size, MemToHexString(buffer, size, 0x10));
 
   if (m_sf_socket.send(buffer, size, m_sf_recipient_ip, m_dest_port) != sf::Socket::Done)
   {
@@ -121,7 +121,7 @@ bool CEXIETHERNET::XLinkNetworkInterface::SendFrame(const u8* frame, u32 size)
   size += 4;
 
   // Only uncomment for debugging, the performance hit is too big otherwise
-  // INFO_LOG_FMT(SP1, "SendFrame {}\n{}", size, ArrayToString(m_out_frame, size, 0x10)));
+  // INFO_LOG_FMT(SP1, "SendFrame {}\n{}", size, MemToHexString(m_out_frame, size, 0x10)));
 
   if (m_sf_socket.send(m_out_frame, size, m_sf_recipient_ip, m_dest_port) != sf::Socket::Done)
   {
@@ -183,8 +183,8 @@ void CEXIETHERNET::XLinkNetworkInterface::ReadThreadHandler(
         else if (self->m_read_enabled.IsSet())
         {
           // Only uncomment for debugging, the performance hit is too big otherwise
-          // DEBUG_LOG_FMT(SP1, "Read data: {}", ArrayToString(self->m_eth_ref->mRecvBuffer.get(),
-          // u32(bytes_read - 4), 0x10));
+          // DEBUG_LOG_FMT(SP1, "Read data: {}",
+          //             MemToHexString(self->m_eth_ref->mRecvBuffer.get(), bytes_read - 4u, 0x10));
           self->m_eth_ref->mRecvBufferLength = u32(bytes_read - 4);
           self->m_eth_ref->RecvHandlePacket();
         }
@@ -215,7 +215,7 @@ void CEXIETHERNET::XLinkNetworkInterface::ReadThreadHandler(
           memmove(buffer, cmd.data(), size);
 
           DEBUG_LOG_FMT(SP1, "SendCommandPayload {:x}\n{}", size,
-                        ArrayToString(buffer, size, 0x10));
+                        MemToHexString(buffer, size, 0x10));
 
           if (self->m_sf_socket.send(buffer, size, self->m_sf_recipient_ip, self->m_dest_port) !=
               sf::Socket::Done)
@@ -252,7 +252,7 @@ void CEXIETHERNET::XLinkNetworkInterface::ReadThreadHandler(
         DEBUG_LOG_FMT(SP1, "XLink Kai BBA keepalive");
 
         // Only uncomment for debugging, just clogs the log otherwise
-        // INFO_LOG_FMT(SP1, "SendCommandPayload {:x}\n{}", 2, ArrayToString(m_in_frame, 2, 0x10));
+        // INFO_LOG_FMT(SP1, "SendCommandPayload {:x}\n{}", 2, MemToHexString(m_in_frame, 2, 0x10));
 
         // Reply (using the message that came in!)
         if (self->m_sf_socket.send(self->m_in_frame, 10, self->m_sf_recipient_ip,

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -556,7 +556,7 @@ bool CEXIETHERNET::RecvHandlePacket()
 
 #ifdef BBA_TRACK_PAGE_PTRS
   INFO_LOG_FMT(SP1, "RecvHandlePacket {:x}\n{}", mRecvBufferLength,
-               ArrayToString(mRecvBuffer.get(), mRecvBufferLength, 16));
+               MemToHexString(mRecvBuffer.get(), mRecvBufferLength, 16));
 
   INFO_LOG_FMT(SP1, "{:x} {:x} {:x} {:x}", page_ptr(BBA_BP), page_ptr(BBA_RRP), page_ptr(BBA_RWP),
                page_ptr(BBA_RHBP));

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -6,15 +6,16 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <climits>
 #include <cstring>
 #include <iomanip>
 #include <memory>
-#include <sstream>
 
 #include "Common/BitField.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/StringUtil.h"
 #include "Common/Swap.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
@@ -153,15 +154,11 @@ void SerialInterfaceManager::RunSIBuffer(u64 user_data, s64 cycles_late)
                   actual_response_length);
     if (actual_response_length > 0 && expected_response_length != actual_response_length)
     {
-      std::ostringstream ss;
-      for (u8 b : request_copy)
-      {
-        ss << std::hex << std::setw(2) << std::setfill('0') << (int)b << ' ';
-      }
       DEBUG_LOG_FMT(
           SERIALINTERFACE,
           "RunSIBuffer: expected_response_length({}) != actual_response_length({}): request: {}",
-          expected_response_length, actual_response_length, ss.str());
+          expected_response_length, actual_response_length,
+          MemToHexString(request_copy.data(), request_copy.size(), SIZE_MAX, true));
     }
 
     // TODO:

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
@@ -234,7 +234,7 @@ int MotionPlus::BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in)
       return m_i2c_bus.BusWrite(slave_addr, addr, count, data_in);
     }
 
-    DEBUG_LOG_FMT(WIIMOTE, "Inactive M+ write {:#x} : {}", addr, ArrayToString(data_in, count));
+    DEBUG_LOG_FMT(WIIMOTE, "Inactive M+ write {:#x} : {}", addr, MemToHexString(data_in, count));
 
     auto const result = RawWrite(&m_reg_data, addr, count, data_in);
 
@@ -255,7 +255,7 @@ int MotionPlus::BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in)
       return 0;
     }
 
-    DEBUG_LOG_FMT(WIIMOTE, "Active M+ write {:#x} : {}", addr, ArrayToString(data_in, count));
+    DEBUG_LOG_FMT(WIIMOTE, "Active M+ write {:#x} : {}", addr, MemToHexString(data_in, count));
 
     auto const result = RawWrite(&m_reg_data, addr, count, data_in);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -3,6 +3,7 @@
 
 #include "Core/PowerPC/Jit64/Jit.h"
 
+#include <climits>
 #include <map>
 #include <sstream>
 #include <string>
@@ -1251,14 +1252,7 @@ void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer& code_buffer, con
 
   if (b->codeSize <= 250)
   {
-    std::ostringstream ss;
-    ss << std::hex;
-    for (u8 i = 0; i <= b->codeSize; i++)
-    {
-      ss.width(2);
-      ss.fill('0');
-      ss << static_cast<u32>(*(normalEntry + i));
-    }
-    DEBUG_LOG_FMT(DYNA_REC, "IR_X86 bin: {}\n\n\n", ss.str());
+    DEBUG_LOG_FMT(DYNA_REC, "IR_X86 bin: {}\n\n\n",
+                  MemToHexString(normalEntry, b->codeSize + 1u, SIZE_MAX, false));
   }
 }

--- a/Source/Core/DolphinTool/VerifyCommand.cpp
+++ b/Source/Core/DolphinTool/VerifyCommand.cpp
@@ -3,6 +3,7 @@
 
 #include "DolphinTool/VerifyCommand.h"
 
+#include <climits>
 #include <cstdlib>
 #include <string>
 #include <vector>
@@ -18,13 +19,7 @@ namespace DolphinTool
 {
 static std::string HashToHexString(const std::vector<u8>& hash)
 {
-  std::stringstream ss;
-  ss << std::hex;
-  for (int i = 0; i < static_cast<int>(hash.size()); ++i)
-  {
-    ss << std::setw(2) << std::setfill('0') << static_cast<int>(hash[i]);
-  }
-  return ss.str();
+  return MemToHexString(hash.data(), hash.size(), SIZE_MAX, false);
 }
 
 static void PrintFullReport(const DiscIO::VolumeVerifier::Result& result)

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
@@ -1117,7 +1117,7 @@ void Device::ProcessInputReport(WiimoteReal::Report& report)
       else if (report_id < InputReportID::ReportCore)
       {
         WARN_LOG_FMT(WIIMOTE, "WiiRemote: Unhandled input report: {}.",
-                     ArrayToString(report.data(), u32(report.size())));
+                     MemToHexString(report.data(), report.size()));
       }
 
       break;

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -10,7 +10,6 @@
 #include <iterator>
 #include <map>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -580,10 +579,7 @@ std::string GameFile::GetNetPlayName(const Core::TitleDatabase& title_database) 
   }
   if (info.empty())
     return name;
-  std::ostringstream ss;
-  std::copy(info.begin(), info.end() - 1, std::ostream_iterator<std::string>(ss, ", "));
-  ss << info.back();
-  return name + " (" + ss.str() + ")";
+  return fmt::format("{:s} ({:s})", name, JoinStrings(info, ", "));
 }
 
 static Common::SHA1::Digest GetHash(u32 value)

--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <gtest/gtest.h>
+
+#include <array>
+#include <climits>
 #include <string>
 #include <vector>
 
@@ -89,4 +92,18 @@ TEST(StringUtil, GetEscapedHtml)
   EXPECT_EQ(Common::GetEscapedHtml(no_escape_needed), no_escape_needed);
   EXPECT_EQ(Common::GetEscapedHtml("&<>'\""), "&amp;&lt;&gt;&apos;&quot;");
   EXPECT_EQ(Common::GetEscapedHtml("&&&"), "&amp;&amp;&amp;");
+}
+
+TEST(StringUtil, MemToHexString)
+{
+  static constexpr std::array<u8, 9> arr = {0x00, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xFF};
+  // The four usages. Note the lack of trailing whitespace/newline
+  EXPECT_EQ(MemToHexString(arr.data(), arr.size(), SIZE_MAX, false), "00123456789ABCDEFF");
+  EXPECT_EQ(MemToHexString(arr.data(), arr.size(), SIZE_MAX, true), "00 12 34 56 78 9A BC DE FF");
+  EXPECT_EQ(MemToHexString(arr.data(), arr.size(), 3, false), "001234\n56789A\nBCDEFF");
+  EXPECT_EQ(MemToHexString(arr.data(), arr.size(), 3, true), "00 12 34\n56 78 9A\nBC DE FF");
+  // size == 0 returns a default constructed string
+  EXPECT_EQ(MemToHexString(arr.data(), 0, SIZE_MAX), std::string{}.c_str());
+  // bytes_per_row == 0 returns a default constructed string
+  EXPECT_EQ(MemToHexString(arr.data(), arr.size(), 0), std::string{}.c_str());
 }


### PR DESCRIPTION
This PR improves the StringUtil functions "JoinStrings" and "MemToHexString" (formerly known as "ArrayToBytes").

Questions:
 - Should MemToHexString and JoinStrings be moved to the Common namespace?  Is this in scope for this PR?
 - Did my adaptation of the code in Jit64/Jit.cpp reveal an off-by-one error?