### PR TITLE
Use std::istrstream to save unnecessary string copies.

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -116,6 +116,7 @@ add_library(common
   StringLiteral.h
   StringUtil.cpp
   StringUtil.h
+  StrStream.h
   SymbolDB.cpp
   SymbolDB.h
   Thread.cpp

--- a/Source/Core/Common/Debug/Watches.cpp
+++ b/Source/Core/Common/Debug/Watches.cpp
@@ -7,6 +7,8 @@
 #include <locale>
 #include <sstream>
 
+#include "Common/StrStream.h"
+
 namespace Common::Debug
 {
 Watch::Watch(u32 address_, std::string name_, State is_enabled_)
@@ -93,7 +95,7 @@ void Watches::LoadFromStrings(const std::vector<std::string>& watches)
 {
   for (const std::string& watch : watches)
   {
-    std::istringstream ss(watch);
+    std::istrstream ss(watch.c_str(), std::ssize(watch));
     ss.imbue(std::locale::classic());
     u32 address;
     std::string name;

--- a/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
@@ -3,11 +3,11 @@
 
 #include "Common/GL/GLExtensions/GLExtensions.h"
 
-#include <sstream>
 #include <unordered_map>
 
 #include "Common/GL/GLContext.h"
 #include "Common/Logging/Log.h"
+#include "Common/StrStream.h"
 
 #if defined(__linux__) || defined(__APPLE__)
 #include <dlfcn.h>
@@ -2158,10 +2158,9 @@ bool InitFunctionPointers(GLContext* context);
 static void InitExtensionList21()
 {
   const char* extensions = (const char*)glGetString(GL_EXTENSIONS);
-  std::string tmp(extensions);
-  std::istringstream buffer(tmp);
+  std::istrstream buffer(extensions);
 
-  while (buffer >> tmp)
+  for (std::string tmp; buffer >> tmp;)
     s_extension_list[tmp] = true;
 }
 
@@ -2483,10 +2482,9 @@ bool Init(GLContext* context)
 static bool HasFeatures(const std::string& extensions)
 {
   bool result = true;
-  std::string tmp;
-  std::istringstream buffer(extensions);
+  std::istrstream buffer(extensions.c_str(), std::ssize(extensions));
 
-  while (buffer >> tmp)
+  for (std::string tmp; buffer >> tmp;)
   {
     if (tmp[0] == '!')
       result &= !s_extension_list[tmp.erase(0, 1)];

--- a/Source/Core/Common/GL/GLInterface/EGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGL.cpp
@@ -5,10 +5,10 @@
 
 #include <array>
 #include <cstdlib>
-#include <sstream>
 #include <vector>
 
 #include "Common/Logging/Log.h"
+#include "Common/StrStream.h"
 
 #ifndef EGL_KHR_create_context
 #define EGL_KHR_create_context 1
@@ -206,9 +206,8 @@ bool GLContextEGL::Initialize(const WindowSystemInfo& wsi, bool stereo, bool cor
   else
     eglBindAPI(EGL_OPENGL_ES_API);
 
-  std::string tmp;
-  std::istringstream buffer(eglQueryString(m_egl_display, EGL_EXTENSIONS));
-  while (buffer >> tmp)
+  std::istrstream buffer(eglQueryString(m_egl_display, EGL_EXTENSIONS));
+  for (std::string tmp; buffer >> tmp;)
   {
     if (tmp == "EGL_KHR_surfaceless_context")
       m_supports_surfaceless = true;

--- a/Source/Core/Common/GL/GLInterface/GLX.cpp
+++ b/Source/Core/Common/GL/GLInterface/GLX.cpp
@@ -4,9 +4,9 @@
 #include "Common/GL/GLInterface/GLX.h"
 
 #include <array>
-#include <sstream>
 
 #include "Common/Logging/Log.h"
+#include "Common/StrStream.h"
 
 #define GLX_CONTEXT_MAJOR_VERSION_ARB 0x2091
 #define GLX_CONTEXT_MINOR_VERSION_ARB 0x2092
@@ -194,9 +194,8 @@ bool GLContextGLX::Initialize(const WindowSystemInfo& wsi, bool stereo, bool cor
   glXDestroyGLXPbufferSGIX = nullptr;
   m_supports_pbuffer = false;
 
-  std::string tmp;
-  std::istringstream buffer(glXQueryExtensionsString(m_display, screen));
-  while (buffer >> tmp)
+  std::istrstream buffer(glXQueryExtensionsString(m_display, screen));
+  for (std::string tmp; buffer >> tmp;)
   {
     if (tmp == "GLX_SGIX_pbuffer")
     {

--- a/Source/Core/Common/StrStream.h
+++ b/Source/Core/Common/StrStream.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: CC0-1.0
+
+#pragma once
+
+// <strstream> is an often forgotten part of the C++ Standard Library. It was deprecated in C++98
+// due to the hidden dangers in its design. However, unlike std::(o)strstream, std::istrstream is
+// actually fairly safe, behaving similarly to C++23's std::ispanstream.
+
+// MSVC emits a warning any time std::(io)strstream is used.
+#ifdef _MSC_VER
+#define _SILENCE_CXX17_STRSTREAM_DEPRECATION_WARNING
+#if _HAS_CXX23 == true
+#pragma message("It's time to replace <strstream> usage with <spanstream>")
+#endif
+#else
+#include <version>
+#ifdef __cpp_lib_spanstream
+#warning "It's time to replace <strstream> usage with <spanstream>"
+#endif
+#endif
+
+// GCC and Clang emit a warning from simply including the <strstream> header.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-W#warnings"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-W#warnings"
+#endif
+#include <strstream>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
@@ -27,6 +28,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/StrStream.h"
 #include "Common/Swap.h"
 
 #ifdef _WIN32
@@ -379,13 +381,12 @@ std::string PathToFileName(std::string_view path)
 
 std::vector<std::string> SplitString(const std::string& str, const char delim)
 {
-  std::istringstream iss(str);
-  std::vector<std::string> output(1);
+  std::istrstream iss(str.c_str(), std::ssize(str));
+  std::vector<std::string> output;
 
-  while (std::getline(iss, *output.rbegin(), delim))
-    output.push_back("");
+  for (std::string s; std::getline(iss, s, delim);)
+    output.emplace_back(std::move(s));
 
-  output.pop_back();
   return output;
 }
 

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/StrStream.h"
 
 std::string StringFromFormatV(const char* format, va_list args);
 
@@ -117,7 +118,7 @@ template <typename N>
 bool TryParseVector(const std::string& str, std::vector<N>* output, const char delimiter = ',')
 {
   output->clear();
-  std::istringstream buffer(str);
+  std::istrstream buffer(str.c_str(), std::ssize(str));
   std::string variable;
 
   while (std::getline(buffer, variable, delimiter))

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -22,6 +22,7 @@
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+#include "Common/StrStream.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Config/MainSettings.h"
@@ -127,7 +128,7 @@ static Location MapINIToRealLocation(const std::string& section, const std::stri
 
   // Attempt to load it as a configuration option
   // It will be in the format of '<System>.<Section>'
-  std::istringstream buffer(section);
+  std::istrstream buffer(section.c_str(), std::ssize(section));
   std::string system_str, config_section;
 
   bool fail = false;

--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -11,7 +11,6 @@
 #include <cstring>
 #include <fstream>
 #include <map>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -20,6 +19,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/StrStream.h"
 #include "Common/StringUtil.h"
 
 #include "Core/DSP/DSPCore.h"
@@ -771,7 +771,7 @@ bool DSPAssembler::AssemblePass(const std::string& text, int pass)
 {
   bool disable_text = false;  // modified by Hermes
 
-  std::istringstream fsrc(text);
+  std::istrstream fsrc(text.c_str(), std::ssize(text));
 
   m_location.line_num = 0;
   m_cur_pass = pass;

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "Common/FileUtil.h"
+#include "Common/StrStream.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/PowerPC/MMU.h"
 
@@ -51,10 +52,9 @@ void MemoryWatcher::ParseLine(const std::string& line)
   m_values[line] = 0;
   m_addresses[line] = std::vector<u32>();
 
-  std::istringstream offsets(line);
+  std::istrstream offsets(line.c_str(), std::ssize(line));
   offsets >> std::hex;
-  u32 offset;
-  while (offsets >> offset)
+  for (u32 offset; offsets >> offset;)
     m_addresses[line].push_back(offset);
 }
 

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -12,6 +12,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
 #include "Common/Logging/Log.h"
+#include "Common/StrStream.h"
 #include "Core/Core.h"
 #include "Core/PowerPC/Expression.h"
 #include "Core/PowerPC/JitInterface.h"
@@ -86,16 +87,16 @@ void BreakPoints::AddFromStrings(const TBreakPointsStr& bp_strings)
   {
     TBreakPoint bp;
     std::string flags;
-    std::istringstream iss(bp_string);
+    std::istrstream iss(bp_string.c_str(), std::ssize(bp_string));
     iss.imbue(std::locale::classic());
 
     if (iss.peek() == '$')
       iss.ignore();
     iss >> std::hex >> bp.address;
     iss >> flags;
-    bp.is_enabled = flags.find('n') != flags.npos;
-    bp.log_on_hit = flags.find('l') != flags.npos;
-    bp.break_on_hit = flags.find('b') != flags.npos;
+    bp.is_enabled = flags.find('n') != std::string::npos;
+    bp.log_on_hit = flags.find('l') != std::string::npos;
+    bp.break_on_hit = flags.find('b') != std::string::npos;
     if (flags.find('c') != std::string::npos)
     {
       iss >> std::ws;
@@ -241,7 +242,7 @@ void MemChecks::AddFromStrings(const TMemChecksStr& mc_strings)
   for (const std::string& mc_string : mc_strings)
   {
     TMemCheck mc;
-    std::istringstream iss(mc_string);
+    std::istrstream iss(mc_string.c_str(), std::ssize(mc_string));
     iss.imbue(std::locale::classic());
 
     if (iss.peek() == '$')
@@ -251,11 +252,11 @@ void MemChecks::AddFromStrings(const TMemChecksStr& mc_strings)
     iss >> std::hex >> mc.start_address >> mc.end_address >> flags;
 
     mc.is_ranged = mc.start_address != mc.end_address;
-    mc.is_enabled = flags.find('n') != flags.npos;
-    mc.is_break_on_read = flags.find('r') != flags.npos;
-    mc.is_break_on_write = flags.find('w') != flags.npos;
-    mc.log_on_hit = flags.find('l') != flags.npos;
-    mc.break_on_hit = flags.find('b') != flags.npos;
+    mc.is_enabled = flags.find('n') != std::string::npos;
+    mc.is_break_on_read = flags.find('r') != std::string::npos;
+    mc.is_break_on_write = flags.find('w') != std::string::npos;
+    mc.log_on_hit = flags.find('l') != std::string::npos;
+    mc.break_on_hit = flags.find('b') != std::string::npos;
     if (flags.find('c') != std::string::npos)
     {
       iss >> std::ws;

--- a/Source/Core/Core/PowerPC/SignatureDB/CSVSignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/CSVSignatureDB.cpp
@@ -12,6 +12,7 @@
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
+#include "Common/StrStream.h"
 
 // CSV separated with tabs
 // Checksum | Size | Symbol | [Object Location |] Object Name
@@ -25,7 +26,7 @@ bool CSVSignatureDB::Load(const std::string& file_path)
     return false;
   for (size_t i = 1; std::getline(ifs, line); i += 1)
   {
-    std::istringstream iss(line);
+    std::istrstream iss(line.c_str(), std::ssize(line));
     u32 checksum, size;
     std::string tab, symbol, object_location, object_name;
 

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -13,6 +13,7 @@
 #include <fmt/format.h>
 
 #include "Common/MathUtil.h"
+#include "Common/StrStream.h"
 #include "Common/Thread.h"
 
 namespace ciface::Core
@@ -182,13 +183,13 @@ void DeviceQualifier::FromString(const std::string& str)
 {
   *this = {};
 
-  std::istringstream ss(str);
+  std::istrstream ss(str.c_str(), std::ssize(str));
 
   std::getline(ss, source, '/');
 
   // silly
   std::getline(ss, name, '/');
-  std::istringstream(name) >> cid;
+  std::istrstream(name.c_str(), std::ssize(name)) >> cid;
 
   std::getline(ss, name);
 }

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -10,13 +10,13 @@
 #include <iostream>
 #include <locale>
 #include <map>
-#include <sstream>
 #include <string>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <vector>
 
 #include "Common/FileUtil.h"
+#include "Common/StrStream.h"
 #include "Common/StringUtil.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
@@ -31,7 +31,7 @@ static const std::array<std::string, 2> s_axis_tokens{{"MAIN", "C"}};
 
 static double StringToDouble(const std::string& text)
 {
-  std::istringstream is(text);
+  std::istrstream is(text.c_str(), std::ssize(text));
   // ignore current locale
   is.imbue(std::locale::classic());
   double result;

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -5,13 +5,13 @@
 
 #include <list>
 #include <optional>
-#include <sstream>
 #include <string>
 #include <tuple>
 
 #include <OptionParser.h>
 
 #include "Common/Config/Config.h"
+#include "Common/StrStream.h"
 #include "Common/StringUtil.h"
 #include "Common/Version.h"
 #include "Core/Config/MainSettings.h"
@@ -45,7 +45,7 @@ public:
     // Arguments are in the format of <System>.<Section>.<Key>=Value
     for (const auto& arg : args)
     {
-      std::istringstream buffer(arg);
+      std::istrstream buffer(arg.c_str(), std::ssize(arg));
       std::string system_str, section, key, value;
       std::getline(buffer, system_str, '.');
       std::getline(buffer, section, '.');

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -17,6 +17,7 @@
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+#include "Common/StrStream.h"
 #include "Common/StringUtil.h"
 
 #include "VideoCommon/AbstractFramebuffer.h"
@@ -109,7 +110,7 @@ void PostProcessingConfiguration::LoadOptions(const std::string& code)
       code.substr(configuration_start + config_start_delimiter.size(),
                   configuration_end - configuration_start - config_start_delimiter.size());
 
-  std::istringstream in(configuration_string);
+  std::istrstream in(configuration_string.c_str(), std::ssize(configuration_string));
 
   struct GLSLStringOption
   {

--- a/Source/Core/WinUpdater/Platform.cpp
+++ b/Source/Core/WinUpdater/Platform.cpp
@@ -9,6 +9,7 @@
 #include "Common/HttpRequest.h"
 #include "Common/IOFile.h"
 #include "Common/ScopeGuard.h"
+#include "Common/StrStream.h"
 #include "Common/StringUtil.h"
 #include "Common/WindowsRegistry.h"
 
@@ -90,9 +91,8 @@ public:
 private:
   void Parse(const std::string& content)
   {
-    std::stringstream content_stream(content);
-    std::string line;
-    while (std::getline(content_stream, line))
+    std::istrstream content_stream(content.c_str(), std::ssize(content));
+    for (std::string line; std::getline(content_stream, line);)
     {
       if (line.starts_with("//"))
         continue;


### PR DESCRIPTION
The \<strstream\> header mostly deserves its deprecated status.  Mostly... except for std::istrstream.

Up until C++23's \<spanstream\>, there was no other non-owning array-backed iostream in the standard library.  Thus, \<strstream\> remained despite std::(o)strstream having error-prone design.  However, std::istrstream has no such dangers, effectively behaving like a proto std::ispanstream.

While I would love more than anything to use \<spanstream\> today, the reality is that we are currently still grappling with limited C++20 support from [*certain* vendors](https://developer.android.com/ndk/downloads).  I don't expect to be able to use C++23 features in Dolphin Emulator until at least the year 2026.  std::istrstream avoids unnecessary string copies, and is even arguably the most correct choice for three use-cases in OpenGL code.

Wrapping the \<strstream\> include in the "Common/StrStream.h" header achieves two things.  First, it simplifies silencing a nagging -Wdeprecated warning that GCC and Clang emit any time the \<strstream\> standard header is included.  Second, it makes it easy to set an alarm clock for Dolphin Emulator's eventual leap to C++23 by checking the __cpp_lib_spanstream feature-test macro.  Once that day comes, it is easy to drop-in replace std::istrstream (which still exists as of C++23) with std::ispanstream.