### PR TITLE
Improved DPI change handling

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -47,6 +47,9 @@ private:
   static constexpr int MOUSE_HIDE_DELAY = 3000;
   QTimer* m_mouse_timer;
   QPoint m_last_mouse{};
+  int m_last_window_width = 0;
+  int m_last_window_height = 0;
+  float m_last_window_scale = 0;
   bool m_cursor_locked = false;
   bool m_lock_cursor_on_next_activation = false;
   bool m_dont_lock_cursor_on_show = false;

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -55,7 +55,6 @@ bool OnScreenUI::Initialize(u32 width, u32 height, float scale)
   // Don't create an ini file. TODO: Do we want this in the future?
   ImGui::GetIO().IniFilename = nullptr;
   SetScale(scale);
-  ImGui::GetStyle().WindowRounding = 7.0f;
 
   PortableVertexDeclaration vdecl = {};
   vdecl.position = {ComponentFormat::Float, 2, offsetof(ImDrawVert, pos), true, false};
@@ -343,6 +342,10 @@ void OnScreenUI::SetScale(float backbuffer_scale)
   ImGui::GetIO().DisplayFramebufferScale.x = backbuffer_scale;
   ImGui::GetIO().DisplayFramebufferScale.y = backbuffer_scale;
   ImGui::GetIO().FontGlobalScale = backbuffer_scale;
+  // ScaleAllSizes scales in-place, so calling it twice will double-apply the scale
+  // Reset the style first so that the scale is applied to the base style, not an already-scaled one
+  ImGui::GetStyle() = {};
+  ImGui::GetStyle().WindowRounding = 7.0f;
   ImGui::GetStyle().ScaleAllSizes(backbuffer_scale);
 
   m_backbuffer_scale = backbuffer_scale;

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -176,6 +176,8 @@ void Presenter::SetBackbuffer(SurfaceInfo info)
   m_backbuffer_height = info.height;
   m_backbuffer_scale = info.scale;
   m_backbuffer_format = info.format;
+  if (m_onscreen_ui)
+    m_onscreen_ui->SetScale(info.scale);
   UpdateDrawRectangle();
 }
 


### PR DESCRIPTION
- Windows now get notified when they move between monitors with different DPIs
  - MoltenVK no longer gets squished into a tiny corner of the window or expanded to 2x the window size when moving
- DPI changes are now reflected in imgui, and imgui no longer explodes if you set its dpi more than once
  - Metal is currently the only renderer that fully notices DPI changes and tells imgui about it.  I'll deal with the others some other time.