### PR TITLE
Add NetworkPatchEngine

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -447,6 +447,8 @@ add_library(core
   NetPlayCommon.h
   NetPlayServer.cpp
   NetPlayServer.h
+  NetworkPatchEngine.cpp
+  NetworkPatchEngine.h
   NetworkCaptureLogger.cpp
   NetworkCaptureLogger.h
   PatchEngine.cpp

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -57,6 +57,7 @@
 #include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeWad.h"
+#include "NetworkPatchEngine.h"
 
 SConfig* SConfig::m_Instance;
 
@@ -206,6 +207,7 @@ void SConfig::OnNewTitleLoad(const Core::CPUThreadGuard& guard)
   HLE::Reload(system);
   PatchEngine::Reload();
   HiresTexture::Update();
+  NetworkPatchEngine::Reload();
 }
 
 void SConfig::LoadDefaults()

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Core/IOS/Network/IP/Top.h"
+#include "Core/NetworkPatchEngine.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -1056,6 +1057,9 @@ IPCReply NetIPTopDevice::HandleGetAddressInfoRequest(const IOCtlVRequest& reques
   if (!request.in_vectors.empty() && request.in_vectors[0].size > 0)
   {
     nodeNameStr = memory.GetString(request.in_vectors[0].address, request.in_vectors[0].size);
+    if (std::optional<NetworkPatchEngine::NetworkPatch> patch =
+            NetworkPatchEngine::GetNetworkPatch(nodeNameStr))
+      nodeNameStr = patch->replacement;
     pNodeName = nodeNameStr.c_str();
   }
 

--- a/Source/Core/Core/NetworkPatchEngine.cpp
+++ b/Source/Core/Core/NetworkPatchEngine.cpp
@@ -1,0 +1,104 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// NetworkPatchEngine
+// Allows for replacing URLs used in Network requests
+
+#include "Core/NetworkPatchEngine.h"
+#include <algorithm>
+#include <vector>
+#include "Common/StringUtil.h"
+#include "Core/CheatCodes.h"
+#include "Core/ConfigManager.h"
+
+namespace NetworkPatchEngine
+{
+static std::vector<NetworkPatch> s_patches;
+
+bool DeserializeLine(const std::string& line, NetworkPatch* patch)
+{
+  const std::vector<std::string> items = SplitString(line, ':');
+
+  if (items.size() != 3)
+    return false;
+
+  patch->source = items[0];
+  patch->replacement = items[1];
+
+  if (!TryParse(items[2], &patch->is_wc24))
+    return false;
+
+  return patch;
+}
+
+void LoadPatchSection(const Common::IniFile& globalIni, const Common::IniFile& localIni)
+{
+  for (const auto* ini : {&globalIni, &localIni})
+  {
+    std::vector<std::string> lines;
+    NetworkPatch patch;
+    ini->GetLines("NetworkPatch", &lines);
+
+    for (std::string& line : lines)
+    {
+      if (line.empty())
+        continue;
+
+      if (line[0] == '$')
+      {
+        patch.name = line.substr(1, line.size() - 1);
+      }
+      else
+      {
+        if (DeserializeLine(line, &patch))
+        {
+          s_patches.push_back(patch);
+        }
+      }
+    }
+
+    ReadEnabledAndDisabled(*ini, "NetworkPatch", &s_patches);
+  }
+}
+
+void LoadPatches()
+{
+  const auto& sconfig = SConfig::GetInstance();
+  Common::IniFile globalIni = sconfig.LoadDefaultGameIni();
+  Common::IniFile localIni = sconfig.LoadLocalGameIni();
+
+  LoadPatchSection(globalIni, localIni);
+}
+
+void Reload()
+{
+  s_patches.clear();
+  LoadPatches();
+}
+
+std::optional<NetworkPatch> GetNetworkPatch(const std::string& source)
+{
+  const auto patch =
+      std::find_if(s_patches.begin(), s_patches.end(), [&source](NetworkPatch& patch) {
+        return patch.source == source && !patch.is_wc24;
+      });
+  if (patch == s_patches.end())
+    return std::nullopt;
+
+  return *patch;
+}
+
+// When we patch for the Socket, we aren't given the URL. Instead, it is in a Host header
+// in the payload that the socket is going to send. We need to manually find which patch to apply.
+std::optional<NetworkPatch> GetNetworkPatchByPayload(std::string_view source)
+{
+  for (const NetworkPatch& patch : s_patches)
+  {
+    if (source.find(patch.source) != std::string::npos && !patch.is_wc24)
+      // We found the correct patch, return it!
+      return patch;
+  }
+
+  return std::nullopt;
+}
+}  // namespace NetworkPatchEngine

--- a/Source/Core/Core/NetworkPatchEngine.h
+++ b/Source/Core/Core/NetworkPatchEngine.h
@@ -1,0 +1,27 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "Common/IniFile.h"
+
+namespace NetworkPatchEngine
+{
+struct NetworkPatch final
+{
+  std::string name;
+  std::string source;
+  std::string replacement;
+  bool enabled = false;
+  bool is_wc24 = false;
+};
+
+void Reload();
+bool DeserializeLine(const std::string& line, NetworkPatch* patch);
+void LoadPatchSection(const Common::IniFile& globalIni, const Common::IniFile& localIni);
+std::optional<NetworkPatch> GetNetworkPatch(const std::string& source);
+std::optional<NetworkPatch> GetNetworkPatchByPayload(std::string_view source);
+}  // namespace NetworkPatchEngine

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -401,6 +401,7 @@
     <ClInclude Include="Core\NetPlayCommon.h" />
     <ClInclude Include="Core\NetPlayProto.h" />
     <ClInclude Include="Core\NetPlayServer.h" />
+    <ClInclude Include="Core\NetworkPatchEngine.h" />
     <ClInclude Include="Core\NetworkCaptureLogger.h" />
     <ClInclude Include="Core\PatchEngine.h" />
     <ClInclude Include="Core\PowerPC\BreakPoints.h" />
@@ -1032,6 +1033,7 @@
     <ClCompile Include="Core\NetPlayClient.cpp" />
     <ClCompile Include="Core\NetPlayCommon.cpp" />
     <ClCompile Include="Core\NetPlayServer.cpp" />
+    <ClCompile Include="Core\NetworkPatchEngine.cpp" />
     <ClCompile Include="Core\NetworkCaptureLogger.cpp" />
     <ClCompile Include="Core\PatchEngine.cpp" />
     <ClCompile Include="Core\PowerPC\BreakPoints.cpp" />


### PR DESCRIPTION
NetworkPatchEngine allows for replacing URL's within channels/games without the need of editing the executable binary. This is incredibly useful for developing services which require constant changing of URL's, or just accessing these services in general (Wiimmfi has a security patch, meaning accessing it without the patcher will not work at this time).

## What does a NetworkPatch look like?
```ini
[NetworkPatch]
$TestPatch
old.test.com:prod.wiilink24.com:0
```
Where: 
- `old.test.com` is the URL to be replaced
- `prod.wiilink24.com` is the new URL
- `0` is a boolean value, describing if this is a WC24 patch or not (Stub for now, support coming later)

## How does it work?
The `SO_GETADDRINFO` ioctlv is the first step. The original URL will first appear here, where we will replace it with the new URL. Next is the `SO_SENDTO` ioctlv. Here, the data is sent to the socket. If the data contains the `Host` header, the value will be replaced with the new URL.