### PR TITLE
Android: Re-add host thread check

### DIFF
--- a/Source/Android/jni/CMakeLists.txt
+++ b/Source/Android/jni/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(main SHARED
   GameList/GameFile.cpp
   GameList/GameFile.h
   GameList/GameFileCache.cpp
+  Host.cpp
+  Host.h
   InfinityConfig.cpp
   Input/Control.cpp
   Input/Control.h

--- a/Source/Android/jni/Config/NativeConfig.cpp
+++ b/Source/Android/jni/Config/NativeConfig.cpp
@@ -11,6 +11,7 @@
 #include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
 #include "jni/AndroidCommon/AndroidCommon.h"
+#include "jni/Host.h"
 
 constexpr jint LAYER_BASE_OR_CURRENT = 0;
 constexpr jint LAYER_BASE = 1;
@@ -122,6 +123,7 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_loadGameInis
                                                                                  jstring jGameId,
                                                                                  jint jRevision)
 {
+  HostThreadLock guard;
   const std::string game_id = GetJString(env, jGameId);
   const u16 revision = static_cast<u16>(jRevision);
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
@@ -131,6 +133,7 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_loadGameInis
 JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_unloadGameInis(JNIEnv*, jclass)
 {
+  HostThreadLock guard;
   Config::RemoveLayer(Config::LayerType::GlobalGame);
   Config::RemoveLayer(Config::LayerType::LocalGame);
 }
@@ -138,6 +141,7 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_unloadGameIn
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_save(
     JNIEnv*, jclass, jint layer)
 {
+  HostThreadLock guard;
   return GetLayer(layer, {})->Save();
 }
 
@@ -145,6 +149,7 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_deleteAllKeys(JNIEnv*, jclass,
                                                                                   jint layer)
 {
+  HostThreadLock guard;
   return GetLayer(layer, {})->DeleteAllKeys();
 }
 
@@ -161,6 +166,7 @@ JNIEXPORT jboolean JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_deleteKey(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key)
 {
+  HostThreadLock guard;
   const Config::Location location = GetLocation(env, file, section, key);
   const bool had_value = GetLayer(layer, location)->DeleteKey(location);
   if (had_value)
@@ -214,6 +220,7 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setString(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jstring value)
 {
+  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), GetJString(env, value));
 }
 
@@ -221,18 +228,21 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setBoolean(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jboolean value)
 {
+  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), static_cast<bool>(value));
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setInt(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jint value)
 {
+  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), value);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setFloat(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jfloat value)
 {
+  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), value);
 }
 }

--- a/Source/Android/jni/Host.cpp
+++ b/Source/Android/jni/Host.cpp
@@ -1,0 +1,8 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "jni/Host.h"
+
+#include <mutex>
+
+std::mutex HostThreadLock::s_host_identity_mutex;

--- a/Source/Android/jni/Host.h
+++ b/Source/Android/jni/Host.h
@@ -1,0 +1,24 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <mutex>
+
+#include "Core/Core.h"
+
+// The Core only supports using a single Host thread.
+// If multiple threads want to call host functions then they need to queue
+// sequentially for access.
+struct HostThreadLock
+{
+  static std::mutex s_host_identity_mutex;
+  std::unique_lock<std::mutex> m_lock;
+
+  explicit HostThreadLock() : m_lock(s_host_identity_mutex) { Core::DeclareAsHostThread(); }
+  HostThreadLock(const HostThreadLock& other) = delete;
+  HostThreadLock(HostThreadLock&& other) = delete;
+  HostThreadLock& operator=(const HostThreadLock& other) = delete;
+  HostThreadLock& operator=(HostThreadLock&& other) = delete;
+  ~HostThreadLock() { Core::UndeclareAsHostThread(); }
+};

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -489,12 +489,14 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_RefreshWiimo
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ReloadConfig(JNIEnv*, jclass)
 {
+  HostThreadLock guard;
   SConfig::GetInstance().LoadSettings();
 }
 
 JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_NativeLibrary_UpdateGCAdapterScanThread(JNIEnv*, jclass)
 {
+  HostThreadLock guard;
   if (GCAdapter::UseAdapter())
   {
     GCAdapter::StartScanThread();
@@ -507,6 +509,9 @@ Java_org_dolphinemu_dolphinemu_NativeLibrary_UpdateGCAdapterScanThread(JNIEnv*, 
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Initialize(JNIEnv*, jclass)
 {
+  // InitControllers ends up calling config code, and some config callbacks use RunAsCPUThread
+  HostThreadLock guard;
+
   UICommon::CreateDirectories();
   Common::RegisterMsgAlertHandler(&MsgAlert);
   Common::AndroidSetReportHandler(&ReportSend);
@@ -621,6 +626,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_RunSystemMen
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ChangeDisc(JNIEnv* env, jclass,
                                                                                jstring jFile)
 {
+  HostThreadLock guard;
   const std::string path = GetJString(env, jFile);
   __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Change Disc: %s", path.c_str());
   Core::RunAsCPUThread([&path] { Core::System::GetInstance().GetDVDInterface().ChangeDisc(path); });

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -447,9 +447,9 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SurfaceDestr
     while (s_is_booting.IsSet())
     {
       // Need to wait for boot to finish before we can pause
-      host_identity_guard.m_lock.unlock();
+      host_identity_guard.Unlock();
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      host_identity_guard.m_lock.lock();
+      host_identity_guard.Lock();
     }
 
     if (Core::GetState() == Core::State::Running)
@@ -572,15 +572,15 @@ static void Run(JNIEnv* env, std::unique_ptr<BootParameters>&& boot, bool riivol
 
   while (Core::IsRunning())
   {
-    host_identity_guard.m_lock.unlock();
+    host_identity_guard.Unlock();
     s_update_main_frame_event.Wait();
-    host_identity_guard.m_lock.lock();
+    host_identity_guard.Lock();
     Core::HostDispatchJobs();
   }
 
   s_game_metadata_is_valid = false;
   Core::Shutdown();
-  host_identity_guard.m_lock.unlock();
+  host_identity_guard.Unlock();
 
   env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(),
                             IDCache::GetFinishEmulationActivity());

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -795,11 +795,8 @@ void SaveScreenShot(std::string_view name)
 
 static bool PauseAndLock(Core::System& system, bool do_lock, bool unpause_on_unlock)
 {
-// WARNING: PauseAndLock is not fully threadsafe so is only valid on the Host Thread
-// TODO: Fix Android
-#ifndef ANDROID
+  // WARNING: PauseAndLock is not fully threadsafe so is only valid on the Host Thread
   ASSERT(IsHostThread());
-#endif
 
   if (!IsRunningAndStarted())
     return true;


### PR DESCRIPTION
Not sure if I caught everything that needs a host lock, but at least now emulation and settings work with the host thread check enabled.