### PR TITLE
Android: Check file name extensions locale-independently

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.kt
@@ -51,7 +51,7 @@ class CustomFilePickerFragment : FilePickerFragment() {
         // files if the files don't show up in the file picker when mode == MODE_DIR.
         // To avoid this, show files even when the user needs to select a directory.
         return (showHiddenItems || !file.isHidden) &&
-                (file.isDirectory || extensions!!.contains(fileExtension(file.name).lowercase(Locale.getDefault())))
+                (file.isDirectory || extensions!!.contains(fileExtension(file.name).lowercase(Locale.ENGLISH)))
     }
 
     override fun isCheckable(file: File): Boolean {


### PR DESCRIPTION
A very minor bug that became more obvious when this code was translated to Kotlin.