### PR TITLE
VideoCommon: don't reject game textures which have the wrong size

### DIFF
--- a/Source/Core/VideoCommon/Assets/TextureAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/TextureAsset.cpp
@@ -60,24 +60,28 @@ bool GameTextureAsset::Validate(u32 native_width, u32 native_height) const
   const VideoCommon::CustomTextureData::Level& first_mip = m_data->m_levels[0];
   if (first_mip.width * native_height != first_mip.height * native_width)
   {
-    ERROR_LOG_FMT(
+    // Note: this feels like this should return an error but
+    // for legacy reasons this is only a notice that something *could*
+    // go wrong
+    WARN_LOG_FMT(
         VIDEO,
         "Invalid custom texture size {}x{} for game texture asset '{}'. The aspect differs "
         "from the native size {}x{}.",
         first_mip.width, first_mip.height, GetAssetId(), native_width, native_height);
-    return false;
   }
 
   // Same deal if the custom texture isn't a multiple of the native size.
   if (native_width != 0 && native_height != 0 &&
       (first_mip.width % native_width || first_mip.height % native_height))
   {
-    ERROR_LOG_FMT(
+    // Note: this feels like this should return an error but
+    // for legacy reasons this is only a notice that something *could*
+    // go wrong
+    WARN_LOG_FMT(
         VIDEO,
         "Invalid custom texture size {}x{} for game texture asset '{}'. Please use an integer "
         "upscaling factor based on the native size {}x{}.",
         first_mip.width, first_mip.height, GetAssetId(), native_width, native_height);
-    return false;
   }
 
   return true;


### PR DESCRIPTION
This was a regression from the asset system being used for texture packs.  Apparently, despite the log message, an incorrect texture aspect ratio or having the texture size not being a multiple of the original does not reject the texture from being used.

A user was reporting that they were not able to see some textures or use a dynamic input texture pack because the textures broke one or both of these rules.

Since the errors aren't fatal, I downgraded them to a warning