### PR TITLE
TypeUtils: Add ToPointer function

### DIFF
--- a/Source/Android/jni/RiivolutionPatches.cpp
+++ b/Source/Android/jni/RiivolutionPatches.cpp
@@ -11,6 +11,7 @@
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
+#include "Common/TypeUtils.h"
 #include "DiscIO/RiivolutionParser.h"
 #include "jni/AndroidCommon/AndroidCommon.h"
 #include "jni/AndroidCommon/IDCache.h"
@@ -159,7 +160,7 @@ Java_org_dolphinemu_dolphinemu_features_riivolution_model_RiivolutionPatches_loa
     if (!parsed || !parsed->IsValidForGame(game_id, revision, disc_number))
       continue;
     if (config)
-      DiscIO::Riivolution::ApplyConfigDefaults(&*parsed, *config);
+      DiscIO::Riivolution::ApplyConfigDefaults(Common::ToPointer(parsed), *config);
     discs.emplace_back(std::move(*parsed));
   }
 }

--- a/Source/Core/Common/MemArenaWin.cpp
+++ b/Source/Core/Common/MemArenaWin.cpp
@@ -19,6 +19,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
+#include "Common/TypeUtils.h"
 
 using PVirtualAlloc2 = PVOID(WINAPI*)(HANDLE Process, PVOID BaseAddress, SIZE_T Size,
                                       ULONG AllocationType, ULONG PageProtection,
@@ -240,7 +241,7 @@ WindowsMemoryRegion* MemArena::EnsureSplitRegionForMapping(void* start_address, 
   {
     // if this region is already split up correctly we don't have to do anything
     if (mapping_size == size)
-      return &*it;
+      return Common::ToPointer(it);
 
     // if this region is smaller than the requested size we can't map
     if (mapping_size < size)

--- a/Source/Core/Core/DSP/DSPTables.cpp
+++ b/Source/Core/Core/DSP/DSPTables.cpp
@@ -12,6 +12,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/TypeUtils.h"
 
 #include "Core/DSP/DSPCore.h"
 
@@ -537,7 +538,7 @@ const DSPOPCTemplate* FindOpInfoByOpcode(UDSPInstruction opcode)
   if (iter == s_opcodes.cend())
     return nullptr;
 
-  return &*iter;
+  return Common::ToPointer(iter);
 }
 
 const DSPOPCTemplate* FindOpInfoByName(std::string_view name)
@@ -546,7 +547,7 @@ const DSPOPCTemplate* FindOpInfoByName(std::string_view name)
   if (iter == s_opcodes.cend())
     return nullptr;
 
-  return &*iter;
+  return Common::ToPointer(iter);
 }
 
 const DSPOPCTemplate* FindExtOpInfoByOpcode(UDSPInstruction opcode)
@@ -555,7 +556,7 @@ const DSPOPCTemplate* FindExtOpInfoByOpcode(UDSPInstruction opcode)
   if (iter == s_opcodes_ext.cend())
     return nullptr;
 
-  return &*iter;
+  return Common::ToPointer(iter);
 }
 
 const DSPOPCTemplate* FindExtOpInfoByName(std::string_view name)
@@ -564,7 +565,7 @@ const DSPOPCTemplate* FindExtOpInfoByName(std::string_view name)
   if (iter == s_opcodes_ext.cend())
     return nullptr;
 
-  return &*iter;
+  return Common::ToPointer(iter);
 }
 
 const DSPOPCTemplate* GetOpTemplate(UDSPInstruction inst)
@@ -597,7 +598,7 @@ void InitInstructionTable()
 
     if (s_ext_op_table[i] == &cw)
     {
-      s_ext_op_table[i] = &*iter;
+      s_ext_op_table[i] = Common::ToPointer(iter);
     }
     else
     {
@@ -620,7 +621,7 @@ void InitInstructionTable()
       continue;
 
     if (s_op_table[i] == &cw)
-      s_op_table[i] = &*iter;
+      s_op_table[i] = Common::ToPointer(iter);
     else
       ERROR_LOG_FMT(DSPLLE, "opcode table place {} already in use for {}", i, iter->name);
   }

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -20,6 +20,7 @@
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
+#include "Common/TypeUtils.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/IOS.h"
 #include "Core/Movie.h"
@@ -136,7 +137,7 @@ static u64 FixupDirectoryEntries(File::FSTEntry* dir, bool is_root)
     }
 
     if (dir->isDirectory)
-      removed_entries += FixupDirectoryEntries(&*it, false);
+      removed_entries += FixupDirectoryEntries(Common::ToPointer(it), false);
 
     ++it;
   }
@@ -272,7 +273,7 @@ HostFileSystem::FstEntry* HostFileSystem::GetFstEntryForPath(const std::string& 
         std::find_if(entry->children.begin(), entry->children.end(), GetNamePredicate(component));
     if (next != entry->children.end())
     {
-      entry = &*next;
+      entry = Common::ToPointer(next);
     }
     else
     {

--- a/Source/Core/Core/IOS/FS/HostBackend/File.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/File.cpp
@@ -10,6 +10,7 @@
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+#include "Common/TypeUtils.h"
 
 namespace IOS::HLE::FS
 {
@@ -208,7 +209,7 @@ HostFileSystem::Handle* HostFileSystem::AssignFreeHandle()
 
   *it = Handle{};
   it->opened = true;
-  return &*it;
+  return Common::ToPointer(it);
 }
 
 HostFileSystem::Handle* HostFileSystem::GetHandleFromFd(Fd fd)

--- a/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
+++ b/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
@@ -21,6 +21,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
 #include "Common/Swap.h"
+#include "Common/TypeUtils.h"
 
 #include "Core/IOS/Uids.h"
 
@@ -271,7 +272,7 @@ ErrorCode OpenVFF(const std::string& path, const std::string& filename,
       return;
     }
 
-    callbacks.m_vff = &*temp;
+    callbacks.m_vff = Common::ToPointer(temp);
 
     Common::ScopeGuard vff_delete_guard{[&] { fs->Delete(PID_KD, PID_KD, path); }};
 

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -10,6 +10,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/TypeUtils.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/USB/Common.h"
 #include "Core/System.h"
@@ -177,7 +178,7 @@ IPCReply USB_HIDv5::GetDeviceInfo(USBV5Device& device, const IOCtlRequest& reque
   if (it == interfaces.end())
     return IPCReply(IPC_EINVAL);
   it->Swap();
-  memory.CopyToEmu(request.buffer_out + 68, &*it, sizeof(*it));
+  memory.CopyToEmu(request.buffer_out + 68, Common::ToPointer(it), sizeof(*it));
 
   auto endpoints = host_device->GetEndpoints(0, it->bInterfaceNumber, it->bAlternateSetting);
   for (auto& endpoint : endpoints)

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -10,6 +10,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/TypeUtils.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/USB/Common.h"
 #include "Core/System.h"
@@ -160,7 +161,7 @@ IPCReply USB_VEN::GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request
   if (it == interfaces.end())
     return IPCReply(IPC_EINVAL);
   it->Swap();
-  memory.CopyToEmu(request.buffer_out + 52, &*it, sizeof(*it));
+  memory.CopyToEmu(request.buffer_out + 52, Common::ToPointer(it), sizeof(*it));
 
   auto endpoints = host_device->GetEndpoints(0, it->bInterfaceNumber, it->bAlternateSetting);
   for (size_t i = 0; i < endpoints.size(); ++i)

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -11,6 +11,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/TypeUtils.h"
 #include "Core/Core.h"
 #include "Core/Debugger/DebugInterface.h"
 #include "Core/PowerPC/Expression.h"
@@ -52,7 +53,7 @@ const TBreakPoint* BreakPoints::GetBreakpoint(u32 address) const
   if (bp == m_breakpoints.end())
     return nullptr;
 
-  return &*bp;
+  return Common::ToPointer(bp);
 }
 
 BreakPoints::TBreakPointsStr BreakPoints::GetStrings() const
@@ -346,7 +347,7 @@ TMemCheck* MemChecks::GetMemCheck(u32 address, size_t size)
   if (iter == m_mem_checks.cend())
     return nullptr;
 
-  return &*iter;
+  return Common::ToPointer(iter);
 }
 
 bool MemChecks::OverlapsMemcheck(u32 address, u32 length) const

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -13,6 +13,7 @@
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
+#include "Common/TypeUtils.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/Uids.h"
 
@@ -133,7 +134,7 @@ static void AppendToBuffer(std::vector<u8>* vector, T value)
 {
   const T swapped_value = Common::FromBigEndian(value);
   vector->resize(vector->size() + sizeof(T));
-  std::memcpy(&*(vector->end() - sizeof(T)), &swapped_value, sizeof(T));
+  std::memcpy(Common::ToPointer(vector->end() - sizeof(T)), &swapped_value, sizeof(T));
 }
 
 bool SysConf::Save() const
@@ -230,14 +231,14 @@ SysConf::Entry* SysConf::GetEntry(std::string_view key)
 {
   const auto iterator = std::find_if(m_entries.begin(), m_entries.end(),
                                      [&key](const auto& entry) { return entry.name == key; });
-  return iterator != m_entries.end() ? &*iterator : nullptr;
+  return iterator != m_entries.end() ? Common::ToPointer(iterator) : nullptr;
 }
 
 const SysConf::Entry* SysConf::GetEntry(std::string_view key) const
 {
   const auto iterator = std::find_if(m_entries.begin(), m_entries.end(),
                                      [&key](const auto& entry) { return entry.name == key; });
-  return iterator != m_entries.end() ? &*iterator : nullptr;
+  return iterator != m_entries.end() ? Common::ToPointer(iterator) : nullptr;
 }
 
 SysConf::Entry* SysConf::GetOrAddEntry(std::string_view key, Entry::Type type)

--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -13,6 +13,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"
 #include "Common/MsgHandler.h"
+#include "Common/TypeUtils.h"
 
 #include "DiscIO/CISOBlob.h"
 #include "DiscIO/CompressedBlob.h"
@@ -90,7 +91,7 @@ const SectorReader::Cache* SectorReader::FindCacheLine(u64 block_num)
     return nullptr;
 
   itr->MarkUsed();
-  return &*itr;
+  return Common::ToPointer(itr);
 }
 
 SectorReader::Cache* SectorReader::GetEmptyCacheLine()

--- a/Source/Core/DiscIO/RiivolutionParser.cpp
+++ b/Source/Core/DiscIO/RiivolutionParser.cpp
@@ -16,6 +16,7 @@
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
 #include "Common/StringUtil.h"
+#include "Common/TypeUtils.h"
 #include "DiscIO/GameModDescriptor.h"
 #include "DiscIO/RiivolutionPatcher.h"
 
@@ -407,7 +408,7 @@ std::vector<Patch> GenerateRiivolutionPatchesFromConfig(const std::string root_d
     if (!parsed || !parsed->IsValidForGame(game_id, revision, disc_number))
       continue;
     if (config)
-      ApplyConfigDefaults(&*parsed, *config);
+      ApplyConfigDefaults(Common::ToPointer(parsed), *config);
 
     for (auto& patch : parsed->GeneratePatches(game_id))
     {

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -14,6 +14,7 @@
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
 #include "Common/StringUtil.h"
+#include "Common/TypeUtils.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/FS/FileSystem.h"
@@ -379,7 +380,7 @@ static FSTBuilderNode* FindFileNodeInFST(std::string_view path, std::vector<FSTB
   if (is_file != is_existing_node_file)
     return nullptr;
   if (is_file)
-    return &*it;
+    return Common::ToPointer(it);
 
   return FindFileNodeInFST(path.substr(path_separator + 1),
                            &std::get<std::vector<FSTBuilderNode>>(it->m_content),

--- a/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
+++ b/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
@@ -23,6 +23,7 @@
 
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
+#include "Common/TypeUtils.h"
 #include "DiscIO/GameModDescriptor.h"
 #include "DiscIO/RiivolutionParser.h"
 #include "DiscIO/RiivolutionPatcher.h"
@@ -98,7 +99,7 @@ void RiivolutionBootWidget::LoadMatchingXMLs()
     if (!parsed || !parsed->IsValidForGame(m_game_id, m_revision, m_disc_number))
       continue;
     if (config)
-      DiscIO::Riivolution::ApplyConfigDefaults(&*parsed, *config);
+      DiscIO::Riivolution::ApplyConfigDefaults(Common::ToPointer(parsed), *config);
     MakeGUIForParsedFile(path, riivolution_dir, *parsed);
   }
 }
@@ -145,7 +146,7 @@ void RiivolutionBootWidget::OpenXML()
     auto root = FindRoot(p);
     const auto config = LoadConfigXML(root);
     if (config)
-      DiscIO::Riivolution::ApplyConfigDefaults(&*parsed, *config);
+      DiscIO::Riivolution::ApplyConfigDefaults(Common::ToPointer(parsed), *config);
     MakeGUIForParsedFile(p, std::move(root), *parsed);
   }
 }

--- a/Source/Core/UICommon/ResourcePack/Manager.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manager.cpp
@@ -7,6 +7,7 @@
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
+#include "Common/TypeUtils.h"
 
 #include <algorithm>
 
@@ -135,7 +136,7 @@ ResourcePack* Add(const std::string& path, int offset)
   file.Save(packs_path);
 
   auto it = packs.insert(packs.begin() + offset, std::move(pack));
-  return &*it;
+  return Common::ToPointer(it);
 }
 
 bool Remove(ResourcePack& pack)


### PR DESCRIPTION
This esoteric use of operator overloads is a better way to convert iterators into raw pointers when applicable.