### PR TITLE
Use getCacheDir if getExternalCacheDir returns null.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -297,6 +297,8 @@ public final class NativeLibrary
 
   public static native void SetCacheDirectory(String directory);
 
+  public static native String GetCacheDirectory();
+
   public static native int DefaultCPUCore();
 
   public static native String GetDefaultGraphicsBackendName();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -122,7 +122,12 @@ public final class DirectoryInitialization
 
     File cacheDir = context.getExternalCacheDir();
     if (cacheDir == null)
-      return false;
+    {
+      // In some custom ROMs getExternalCacheDir might return null for some reasons. If that is the case, fallback to getCacheDir which seems to work just fine.
+      cacheDir = context.getCacheDir();
+      if (cacheDir == null)
+        return false;
+    }
 
     Log.debug("[DirectoryInitialization] Cache Dir: " + cacheDir.getPath());
     NativeLibrary.SetCacheDirectory(cacheDir.getPath());
@@ -236,7 +241,7 @@ public final class DirectoryInitialization
 
   public static File getGameListCache(Context context)
   {
-    return new File(context.getExternalCacheDir(), "gamelist.cache");
+    return new File(NativeLibrary.GetCacheDirectory(), "gamelist.cache");
   }
 
   private static boolean copyAsset(String asset, File output, Context context)

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -400,6 +400,12 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetCacheDire
   File::SetUserPath(D_CACHE_IDX, GetJString(env, jDirectory));
 }
 
+JNIEXPORT jstring JNICALL
+Java_org_dolphinemu_dolphinemu_NativeLibrary_GetCacheDirectory(JNIEnv* env, jclass)
+{
+  return ToJString(env, File::GetUserPath(D_CACHE_IDX));
+}
+
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_DefaultCPUCore(JNIEnv*, jclass)
 {
   return static_cast<jint>(PowerPC::DefaultCPUCore());


### PR DESCRIPTION
Fixes a weird problem encountered in certain custom ROMs where the getExternalCacheDir method occasionally returns a null value.