### PR TITLE
InfinityBaseWindow: Remove unnecessary system instance accessor

### DIFF
--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
@@ -193,7 +193,7 @@ CreateFigureDialog::CreateFigureDialog(QWidget* parent, u8 slot) : QDialog(paren
   auto* combo_figlist = new QComboBox();
   QStringList filterlist;
   u32 first_entry = 0;
-  for (const auto& entry : Core::System::GetInstance().GetInfinityBase().GetFigureList())
+  for (const auto& entry : IOS::HLE::USB::InfinityBase::GetFigureList())
   {
     const auto figure = entry.second;
     // Only display entry if it is a piece appropriate for the slot


### PR DESCRIPTION
GetFigureList() is a static member function, so we can just call it directly instead of going through the system instance.