### PR TITLE
ParallelProgressDialog: Initialize all data members 

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
+++ b/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
@@ -45,7 +45,7 @@ public:
   void SetValue(int progress) { emit SetValueSignal(progress); }
 
   // Can be called from any thread
-  bool WasCanceled() { return m_was_cancelled.IsSet(); }
+  bool WasCanceled() const { return m_was_cancelled.IsSet(); }
 
 signals:
   void CancelSignal();

--- a/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
+++ b/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
@@ -126,6 +126,6 @@ private:
 
   QProgressDialog m_dialog;
   Common::Flag m_was_cancelled;
-  int m_last_received_progress;
+  int m_last_received_progress = 0;
   bool m_is_setting_value = false;
 };


### PR DESCRIPTION
Ensures we always have a deterministic state. While we're in the same area, we can mark `WasCanceled()` as const.