### PR TITLE
BreakpointDialog: Mark breakpoint help text as translatable

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
@@ -323,7 +323,7 @@ void BreakpointDialog::accept()
 
 void BreakpointDialog::ShowConditionHelp()
 {
-  const auto message = QStringLiteral(
+  const auto message = tr(
       "Conditions:\n"
       "Sets an expression that is evaluated when a breakpoint is hit. If the expression is false "
       "or 0, the breakpoint is ignored until hit again. Statements should be separated by a comma. "


### PR DESCRIPTION
We already mark the title of the dialog box as translatable, so it would be a bit odd to not mark the containing text as translatable too.