### PR TITLE
Common: Move DebugInterface.h into Core

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -36,7 +36,6 @@ add_library(common
   Debug/Threads.h
   Debug/Watches.cpp
   Debug/Watches.h
-  DebugInterface.h
   DynamicLibrary.cpp
   DynamicLibrary.h
   ENet.cpp

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(core
   CoreTiming.h
   Debugger/CodeTrace.cpp
   Debugger/CodeTrace.h
+  Debugger/DebugInterface.h
   Debugger/Debugger_SymbolMap.cpp
   Debugger/Debugger_SymbolMap.h
   Debugger/Dump.cpp

--- a/Source/Core/Core/Debugger/DebugInterface.h
+++ b/Source/Core/Core/Debugger/DebugInterface.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -19,10 +20,7 @@ struct Watch;
 namespace Core
 {
 class CPUThreadGuard;
-}  // namespace Core
 
-namespace Common
-{
 class DebugInterface
 {
 protected:
@@ -31,8 +29,8 @@ protected:
 public:
   // Watches
   virtual std::size_t SetWatch(u32 address, std::string name = "") = 0;
-  virtual const Debug::Watch& GetWatch(std::size_t index) const = 0;
-  virtual const std::vector<Debug::Watch>& GetWatches() const = 0;
+  virtual const Common::Debug::Watch& GetWatch(std::size_t index) const = 0;
+  virtual const std::vector<Common::Debug::Watch>& GetWatches() const = 0;
   virtual void UnsetWatch(u32 address) = 0;
   virtual void UpdateWatch(std::size_t index, u32 address, std::string name) = 0;
   virtual void UpdateWatchAddress(std::size_t index, u32 address) = 0;
@@ -47,28 +45,27 @@ public:
   virtual void ClearWatches() = 0;
 
   // Memory Patches
-  virtual void SetPatch(const Core::CPUThreadGuard& guard, u32 address, u32 value) = 0;
-  virtual void SetPatch(const Core::CPUThreadGuard& guard, u32 address, std::vector<u8> value) = 0;
-  virtual void SetFramePatch(const Core::CPUThreadGuard& guard, u32 address, u32 value) = 0;
-  virtual void SetFramePatch(const Core::CPUThreadGuard& guard, u32 address,
-                             std::vector<u8> value) = 0;
-  virtual const std::vector<Debug::MemoryPatch>& GetPatches() const = 0;
-  virtual void UnsetPatch(const Core::CPUThreadGuard& guard, u32 address) = 0;
-  virtual void EnablePatch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
-  virtual void DisablePatch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
+  virtual void SetPatch(const CPUThreadGuard& guard, u32 address, u32 value) = 0;
+  virtual void SetPatch(const CPUThreadGuard& guard, u32 address, std::vector<u8> value) = 0;
+  virtual void SetFramePatch(const CPUThreadGuard& guard, u32 address, u32 value) = 0;
+  virtual void SetFramePatch(const CPUThreadGuard& guard, u32 address, std::vector<u8> value) = 0;
+  virtual const std::vector<Common::Debug::MemoryPatch>& GetPatches() const = 0;
+  virtual void UnsetPatch(const CPUThreadGuard& guard, u32 address) = 0;
+  virtual void EnablePatch(const CPUThreadGuard& guard, std::size_t index) = 0;
+  virtual void DisablePatch(const CPUThreadGuard& guard, std::size_t index) = 0;
   virtual bool HasEnabledPatch(u32 address) const = 0;
-  virtual void RemovePatch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
-  virtual void ClearPatches(const Core::CPUThreadGuard& guard) = 0;
-  virtual void ApplyExistingPatch(const Core::CPUThreadGuard& guard, std::size_t index) = 0;
+  virtual void RemovePatch(const CPUThreadGuard& guard, std::size_t index) = 0;
+  virtual void ClearPatches(const CPUThreadGuard& guard) = 0;
+  virtual void ApplyExistingPatch(const CPUThreadGuard& guard, std::size_t index) = 0;
 
   // Threads
-  virtual Debug::Threads GetThreads(const Core::CPUThreadGuard& guard) const = 0;
+  virtual Common::Debug::Threads GetThreads(const CPUThreadGuard& guard) const = 0;
 
-  virtual std::string Disassemble(const Core::CPUThreadGuard* /*guard*/, u32 /*address*/) const
+  virtual std::string Disassemble(const CPUThreadGuard* /*guard*/, u32 /*address*/) const
   {
     return "NODEBUGGER";
   }
-  virtual std::string GetRawMemoryString(const Core::CPUThreadGuard& /*guard*/, int /*memory*/,
+  virtual std::string GetRawMemoryString(const CPUThreadGuard& /*guard*/, int /*memory*/,
                                          u32 /*address*/) const
   {
     return "NODEBUGGER";
@@ -82,20 +79,17 @@ public:
   virtual void ClearAllMemChecks() {}
   virtual bool IsMemCheck(u32 /*address*/, size_t /*size*/) const { return false; }
   virtual void ToggleMemCheck(u32 /*address*/, bool /*read*/, bool /*write*/, bool /*log*/) {}
-  virtual u32 ReadMemory(const Core::CPUThreadGuard& /*guard*/, u32 /*address*/) const { return 0; }
-  virtual void WriteExtraMemory(const Core::CPUThreadGuard& /*guard*/, int /*memory*/,
-                                u32 /*value*/, u32 /*address*/)
+  virtual u32 ReadMemory(const CPUThreadGuard& /*guard*/, u32 /*address*/) const { return 0; }
+  virtual void WriteExtraMemory(const CPUThreadGuard& /*guard*/, int /*memory*/, u32 /*value*/,
+                                u32 /*address*/)
   {
   }
-  virtual u32 ReadExtraMemory(const Core::CPUThreadGuard& /*guard*/, int /*memory*/,
+  virtual u32 ReadExtraMemory(const CPUThreadGuard& /*guard*/, int /*memory*/,
                               u32 /*address*/) const
   {
     return 0;
   }
-  virtual u32 ReadInstruction(const Core::CPUThreadGuard& /*guard*/, u32 /*address*/) const
-  {
-    return 0;
-  }
+  virtual u32 ReadInstruction(const CPUThreadGuard& /*guard*/, u32 /*address*/) const { return 0; }
   virtual std::optional<u32>
   GetMemoryAddressFromInstruction(const std::string& /*instruction*/) const
   {
@@ -105,11 +99,11 @@ public:
   virtual void SetPC(u32 /*address*/) {}
   virtual void Step() {}
   virtual void RunToBreakpoint() {}
-  virtual u32 GetColor(const Core::CPUThreadGuard* /*guard*/, u32 /*address*/) const
+  virtual u32 GetColor(const CPUThreadGuard* /*guard*/, u32 /*address*/) const
   {
     return 0xFFFFFFFF;
   }
   virtual std::string GetDescription(u32 /*address*/) const = 0;
-  virtual void Clear(const Core::CPUThreadGuard& guard) = 0;
+  virtual void Clear(const CPUThreadGuard& guard) = 0;
 };
-}  // namespace Common
+}  // namespace Core

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -9,7 +9,7 @@
 
 #include "Common/Debug/MemoryPatches.h"
 #include "Common/Debug/Watches.h"
-#include "Common/DebugInterface.h"
+#include "Core/Debugger/DebugInterface.h"
 #include "Core/NetworkCaptureLogger.h"
 
 namespace Core
@@ -33,7 +33,7 @@ private:
 
 // wrapper between disasm control and Dolphin debugger
 
-class PPCDebugInterface final : public Common::DebugInterface
+class PPCDebugInterface final : public Core::DebugInterface
 {
 public:
   explicit PPCDebugInterface(Core::System& system);

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -10,9 +10,9 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Common/DebugInterface.h"
 #include "Common/Logging/Log.h"
 #include "Core/Core.h"
+#include "Core/Debugger/DebugInterface.h"
 #include "Core/PowerPC/Expression.h"
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/MMU.h"
@@ -365,7 +365,7 @@ bool MemChecks::OverlapsMemcheck(u32 address, u32 length) const
   });
 }
 
-bool TMemCheck::Action(Core::System& system, Common::DebugInterface* debug_interface, u64 value,
+bool TMemCheck::Action(Core::System& system, Core::DebugInterface* debug_interface, u64 value,
                        u32 addr, bool write, size_t size, u32 pc)
 {
   if (!is_enabled)

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -11,7 +11,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/PowerPC/Expression.h"
 
-namespace Common
+namespace Core
 {
 class DebugInterface;
 }
@@ -49,7 +49,7 @@ struct TMemCheck
   std::optional<Expression> condition;
 
   // returns whether to break
-  bool Action(Core::System& system, Common::DebugInterface* debug_interface, u64 value, u32 addr,
+  bool Action(Core::System& system, Core::DebugInterface* debug_interface, u64 value, u32 addr,
               bool write, size_t size, u32 pc);
 };
 

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -19,6 +19,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/Core.h"
+#include "Core/Debugger/DebugInterface.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PowerPC.h"

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -3,19 +3,16 @@
 
 #pragma once
 
-#include <map>
 #include <string>
-#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/SymbolDB.h"
 
-#include "Core/Debugger/PPCDebugInterface.h"
-
 namespace Core
 {
 class CPUThreadGuard;
-}
+class DebugInterface;
+}  // namespace Core
 
 // This has functionality overlapping Debugger_Symbolmap. Should merge that stuff in here later.
 class PPCSymbolDB : public Common::SymbolDB
@@ -44,7 +41,7 @@ public:
   void LogFunctionCall(u32 addr);
 
 private:
-  Common::DebugInterface* debugger;
+  Core::DebugInterface* debugger;
 };
 
 extern PPCSymbolDB g_symbolDB;

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -39,7 +39,6 @@
     <ClInclude Include="Common\Debug\MemoryPatches.h" />
     <ClInclude Include="Common\Debug\Threads.h" />
     <ClInclude Include="Common\Debug\Watches.h" />
-    <ClInclude Include="Common\DebugInterface.h" />
     <ClInclude Include="Common\DynamicLibrary.h" />
     <ClInclude Include="Common\ENet.h" />
     <ClInclude Include="Common\EnumFormatter.h" />
@@ -191,6 +190,7 @@
     <ClInclude Include="Core\Core.h" />
     <ClInclude Include="Core\CoreTiming.h" />
     <ClInclude Include="Core\Debugger\CodeTrace.h" />
+    <ClInclude Include="Core\Debugger\DebugInterface.h" />
     <ClInclude Include="Core\Debugger\Debugger_SymbolMap.h" />
     <ClInclude Include="Core\Debugger\Dump.h" />
     <ClInclude Include="Core\Debugger\GCELF.h" />


### PR DESCRIPTION
The base DebugInterface now depends on the Core's CPUThreadGuard, and utilities in Common shouldn't be depending on Core facilities. So, we can move this into the core library instead.