### PR TITLE
Fix white bars in Ice Age 2: The Meltdown (GC)

### DIFF
--- a/Data/Sys/GameSettings/GIA.ini
+++ b/Data/Sys/GameSettings/GIA.ini
@@ -14,3 +14,4 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
+DeferEFBCopies = False


### PR DESCRIPTION
Defer EFB Copies to RAM is necessary in order to avoid white bars obscuring the screen: see [https://wiki.dolphin-emu.org/index.php?title=Ice_Age_2:\_The_Meltdown_(GC)#White_Bars](https://wiki.dolphin-emu.org/index.php?title=Ice_Age_2:_The_Meltdown_(GC)#White_Bars)