### PR TITLE
UICommon/ResourcePack: Allow priority helpers to take arguments by const reference

### DIFF
--- a/Source/Core/UICommon/ResourcePack/Manager.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manager.cpp
@@ -82,7 +82,7 @@ std::vector<ResourcePack>& GetPacks()
   return packs;
 }
 
-std::vector<ResourcePack*> GetLowerPriorityPacks(ResourcePack& pack)
+std::vector<ResourcePack*> GetLowerPriorityPacks(const ResourcePack& pack)
 {
   std::vector<ResourcePack*> list;
   for (auto it = std::find(packs.begin(), packs.end(), pack) + 1; it != packs.end(); ++it)
@@ -97,7 +97,7 @@ std::vector<ResourcePack*> GetLowerPriorityPacks(ResourcePack& pack)
   return list;
 }
 
-std::vector<ResourcePack*> GetHigherPriorityPacks(ResourcePack& pack)
+std::vector<ResourcePack*> GetHigherPriorityPacks(const ResourcePack& pack)
 {
   std::vector<ResourcePack*> list;
   auto end = std::find(packs.begin(), packs.end(), pack);

--- a/Source/Core/UICommon/ResourcePack/Manager.h
+++ b/Source/Core/UICommon/ResourcePack/Manager.h
@@ -19,6 +19,6 @@ bool IsInstalled(const ResourcePack& pack);
 
 std::vector<ResourcePack>& GetPacks();
 
-std::vector<ResourcePack*> GetHigherPriorityPacks(ResourcePack& pack);
-std::vector<ResourcePack*> GetLowerPriorityPacks(ResourcePack& pack);
+std::vector<ResourcePack*> GetHigherPriorityPacks(const ResourcePack& pack);
+std::vector<ResourcePack*> GetLowerPriorityPacks(const ResourcePack& pack);
 }  // namespace ResourcePack


### PR DESCRIPTION
There's nothing going on with behavior here that would prevent these from being const qualified.

Also better communicates that this function isn't intended to modify the given resource pack.