### PR TITLE
EnumUtils: Add Common::ToUnderlying

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(common
   ENet.h
   EnumFormatter.h
   EnumMap.h
+  EnumUtils.h
   Event.h
   FatFsUtil.cpp
   FatFsUtil.h

--- a/Source/Core/Common/EnumUtils.h
+++ b/Source/Core/Common/EnumUtils.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: CC0-1.0
+
+#pragma once
+
+#include <type_traits>
+
+namespace Common
+{
+// TODO: Replace with std::to_underlying in C++23
+template <typename Enum>
+constexpr std::underlying_type_t<Enum> ToUnderlying(Enum e) noexcept
+{
+  return static_cast<std::underlying_type_t<Enum>>(e);
+}
+}  // namespace Common

--- a/Source/Core/Core/DSP/DSPDisassembler.cpp
+++ b/Source/Core/Core/DSP/DSPDisassembler.cpp
@@ -12,6 +12,7 @@
 #include <fmt/format.h>
 
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 
@@ -132,7 +133,8 @@ std::string DSPDisassembler::DisassembleParameters(const DSPOPCTemplate& opc, u1
       break;
 
     default:
-      ERROR_LOG_FMT(DSPLLE, "Unknown parameter type: {:x}", static_cast<u32>(opc.params[j].type));
+      ERROR_LOG_FMT(DSPLLE, "Unknown parameter type: {:x}",
+                    Common::ToUnderlying(opc.params[j].type));
       break;
     }
   }

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "Common/Assert.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 
 #include "Core/DSP/DSPCore.h"
@@ -366,38 +367,38 @@ void DSPJitRegCache::FlushRegs()
   }
 
   ASSERT_MSG(DSPLLE, m_xregs[RSP].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}",
-             static_cast<u32>(RSP));
+             Common::ToUnderlying(RSP));
   ASSERT_MSG(DSPLLE, m_xregs[RBX].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}",
-             static_cast<u32>(RBX));
+             Common::ToUnderlying(RBX));
   ASSERT_MSG(DSPLLE, m_xregs[RBP].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(RBP));
+             Common::ToUnderlying(RBP));
   ASSERT_MSG(DSPLLE, m_xregs[RSI].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(RSI));
+             Common::ToUnderlying(RSI));
   ASSERT_MSG(DSPLLE, m_xregs[RDI].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(RDI));
+             Common::ToUnderlying(RDI));
 #ifdef STATIC_REG_ACCS
   ASSERT_MSG(DSPLLE, m_xregs[R8].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}",
-             static_cast<u32>(R8));
+             Common::ToUnderlying(R8));
   ASSERT_MSG(DSPLLE, m_xregs[R9].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}",
-             static_cast<u32>(R9));
+             Common::ToUnderlying(R9));
 #else
   ASSERT_MSG(DSPLLE, m_xregs[R8].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(R8));
+             Common::ToUnderlying(R8));
   ASSERT_MSG(DSPLLE, m_xregs[R9].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(R9));
+             Common::ToUnderlying(R9));
 #endif
   ASSERT_MSG(DSPLLE, m_xregs[R10].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(R10));
+             Common::ToUnderlying(R10));
   ASSERT_MSG(DSPLLE, m_xregs[R11].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(R11));
+             Common::ToUnderlying(R11));
   ASSERT_MSG(DSPLLE, m_xregs[R12].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(R12));
+             Common::ToUnderlying(R12));
   ASSERT_MSG(DSPLLE, m_xregs[R13].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(R13));
+             Common::ToUnderlying(R13));
   ASSERT_MSG(DSPLLE, m_xregs[R14].guest_reg == DSP_REG_NONE, "wrong xreg state for {}",
-             static_cast<u32>(R14));
+             Common::ToUnderlying(R14));
   ASSERT_MSG(DSPLLE, m_xregs[R15].guest_reg == DSP_REG_STATIC, "wrong xreg state for {}",
-             static_cast<u32>(R15));
+             Common::ToUnderlying(R15));
 
   m_use_ctr = 0;
 }
@@ -984,14 +985,14 @@ void DSPJitRegCache::SpillXReg(X64Reg reg)
   {
     ASSERT_MSG(DSPLLE, !m_regs[m_xregs[reg].guest_reg].used,
                "to be spilled host reg {:#x} (guest reg {:#x}) still in use!",
-               static_cast<u32>(reg), m_xregs[reg].guest_reg);
+               Common::ToUnderlying(reg), m_xregs[reg].guest_reg);
 
     MovToMemory(m_xregs[reg].guest_reg);
   }
   else
   {
     ASSERT_MSG(DSPLLE, m_xregs[reg].guest_reg == DSP_REG_NONE,
-               "to be spilled host reg {:#x} still in use!", static_cast<u32>(reg));
+               "to be spilled host reg {:#x} still in use!", Common::ToUnderlying(reg));
   }
 }
 
@@ -1036,7 +1037,7 @@ void DSPJitRegCache::GetXReg(X64Reg reg)
 {
   if (m_xregs[reg].guest_reg == DSP_REG_STATIC)
   {
-    ERROR_LOG_FMT(DSPLLE, "Trying to get statically used XReg {}", static_cast<u32>(reg));
+    ERROR_LOG_FMT(DSPLLE, "Trying to get statically used XReg {}", Common::ToUnderlying(reg));
     return;
   }
 
@@ -1052,7 +1053,7 @@ void DSPJitRegCache::PutXReg(X64Reg reg)
 {
   if (m_xregs[reg].guest_reg == DSP_REG_STATIC)
   {
-    ERROR_LOG_FMT(DSPLLE, "Trying to put statically used XReg {}", static_cast<u32>(reg));
+    ERROR_LOG_FMT(DSPLLE, "Trying to put statically used XReg {}", Common::ToUnderlying(reg));
     return;
   }
 

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -10,6 +10,7 @@
 #include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -210,7 +211,7 @@ void Wiimote::HandleExtensionSwap(ExtensionNumber desired_extension_number,
     else
     {
       INFO_LOG_FMT(WIIMOTE, "Switching to Extension {} (Wiimote {} in slot {})",
-                   static_cast<u8>(desired_extension_number), m_index, m_bt_device_index);
+                   Common::ToUnderlying(desired_extension_number), m_index, m_bt_device_index);
 
       m_active_extension = desired_extension_number;
     }

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/ChunkFile.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
@@ -92,7 +93,7 @@ ESCore::ESCore(Kernel& ios) : m_ios(ios)
     if (result != FS::ResultCode::Success && result != FS::ResultCode::AlreadyExists)
     {
       ERROR_LOG_FMT(IOS_ES, "Failed to create {}: error {}", directory.path,
-                    static_cast<s32>(FS::ConvertResult(result)));
+                    Common::ToUnderlying(FS::ConvertResult(result)));
     }
 
     // Now update the UID/GID and other attributes.
@@ -1101,7 +1102,7 @@ ReturnCode ESCore::VerifyContainer(VerifyContainerType type, VerifyMode mode,
   if (ret != IPC_SUCCESS)
   {
     ERROR_LOG_FMT(IOS_ES, "VerifyContainer: IOSC_ImportCertificate(ca) failed with error {}",
-                  static_cast<s32>(ret));
+                  Common::ToUnderlying(ret));
     return ret;
   }
 
@@ -1116,7 +1117,7 @@ ReturnCode ESCore::VerifyContainer(VerifyContainerType type, VerifyMode mode,
   if (ret != IPC_SUCCESS)
   {
     ERROR_LOG_FMT(IOS_ES, "VerifyContainer: IOSC_ImportCertificate(issuer) failed with error {}",
-                  static_cast<s32>(ret));
+                  Common::ToUnderlying(ret));
     return ret;
   }
 
@@ -1126,7 +1127,7 @@ ReturnCode ESCore::VerifyContainer(VerifyContainerType type, VerifyMode mode,
   if (ret != IPC_SUCCESS)
   {
     ERROR_LOG_FMT(IOS_ES, "VerifyContainer: IOSC_VerifyPublicKeySign failed with error {}",
-                  static_cast<s32>(ret));
+                  Common::ToUnderlying(ret));
     return ret;
   }
 
@@ -1136,13 +1137,13 @@ ReturnCode ESCore::VerifyContainer(VerifyContainerType type, VerifyMode mode,
     if (ret != IPC_SUCCESS)
     {
       ERROR_LOG_FMT(IOS_ES, "VerifyContainer: Writing the issuer cert failed with return code {}",
-                    static_cast<s32>(ret));
+                    Common::ToUnderlying(ret));
     }
 
     ret = WriteNewCertToStore(ca_cert);
     if (ret != IPC_SUCCESS)
       ERROR_LOG_FMT(IOS_ES, "VerifyContainer: Writing the CA cert failed with return code {}",
-                    static_cast<s32>(ret));
+                    Common::ToUnderlying(ret));
   }
 
   if (ret == IPC_SUCCESS && issuer_handle_out)

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/Crypto/SHA1.h"
 #include "Common/Crypto/ec.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
@@ -162,7 +163,7 @@ ReturnCode ESCore::VerifySign(const std::vector<u8>& hash, const std::vector<u8>
   if (ret != IPC_SUCCESS)
   {
     ERROR_LOG_FMT(IOS_ES, "VerifySign: VerifyContainer(ng) failed with error {}",
-                  static_cast<s32>(ret));
+                  Common::ToUnderlying(ret));
     return ret;
   }
 
@@ -170,7 +171,7 @@ ReturnCode ESCore::VerifySign(const std::vector<u8>& hash, const std::vector<u8>
   if (ret != IPC_SUCCESS)
   {
     ERROR_LOG_FMT(IOS_ES, "VerifySign: IOSC_VerifyPublicKeySign(ap) failed with error {}",
-                  static_cast<s32>(ret));
+                  Common::ToUnderlying(ret));
     return ret;
   }
 
@@ -184,7 +185,7 @@ ReturnCode ESCore::VerifySign(const std::vector<u8>& hash, const std::vector<u8>
   if (ret != IPC_SUCCESS)
   {
     ERROR_LOG_FMT(IOS_ES, "VerifySign: IOSC_ImportPublicKey(ap) failed with error {}",
-                  static_cast<s32>(ret));
+                  Common::ToUnderlying(ret));
     return ret;
   }
 
@@ -193,7 +194,7 @@ ReturnCode ESCore::VerifySign(const std::vector<u8>& hash, const std::vector<u8>
   if (ret != IPC_SUCCESS)
   {
     ERROR_LOG_FMT(IOS_ES, "VerifySign: IOSC_VerifyPublicKeySign(data) failed with error {}",
-                  static_cast<s32>(ret));
+                  Common::ToUnderlying(ret));
     return ret;
   }
 

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -12,6 +12,7 @@
 
 #include "Common/Align.h"
 #include "Common/Crypto/SHA1.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
 #include "Core/CommonTitles.h"
@@ -72,7 +73,7 @@ ReturnCode ESCore::ImportTicket(const std::vector<u8>& ticket_bytes,
     if (ret < 0)
     {
       ERROR_LOG_FMT(IOS_ES, "ImportTicket: Failed to unpersonalise ticket for {:016x} ({})",
-                    ticket.GetTitleId(), static_cast<s32>(ret));
+                    ticket.GetTitleId(), Common::ToUnderlying(ret));
       return ret;
     }
   }
@@ -160,7 +161,8 @@ ReturnCode ESCore::ImportTmd(Context& context, const std::vector<u8>& tmd_bytes,
                         context.title_import_export.tmd, cert_store);
   if (ret != IPC_SUCCESS)
   {
-    ERROR_LOG_FMT(IOS_ES, "ImportTmd: VerifyContainer failed with error {}", static_cast<s32>(ret));
+    ERROR_LOG_FMT(IOS_ES, "ImportTmd: VerifyContainer failed with error {}",
+                  Common::ToUnderlying(ret));
     return ret;
   }
 
@@ -174,7 +176,8 @@ ReturnCode ESCore::ImportTmd(Context& context, const std::vector<u8>& tmd_bytes,
                       &context.title_import_export.key_handle);
   if (ret != IPC_SUCCESS)
   {
-    ERROR_LOG_FMT(IOS_ES, "ImportTmd: InitBackupKey failed with error {}", static_cast<s32>(ret));
+    ERROR_LOG_FMT(IOS_ES, "ImportTmd: InitBackupKey failed with error {}",
+                  Common::ToUnderlying(ret));
     return ret;
   }
 

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -10,6 +10,7 @@
 #include <fmt/format.h>
 
 #include "Common/ChunkFile.h"
+#include "Common/EnumUtils.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
 #include "Core/HW/Memmap.h"
@@ -119,7 +120,7 @@ static void LogResult(ResultCode code, fmt::format_string<Args...> format, Args&
       code == ResultCode::Success ? Common::Log::LogLevel::LINFO : Common::Log::LogLevel::LERROR;
 
   GENERIC_LOG_FMT(Common::Log::LogType::IOS_FS, type, "Command: {}: Result {}", command,
-                  static_cast<s32>(ConvertResult(code)));
+                  Common::ToUnderlying(ConvertResult(code)));
 }
 
 template <typename T, typename... Args>

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -14,6 +14,7 @@
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Common/Timer.h"
 
@@ -652,8 +653,8 @@ std::shared_ptr<Device> EmulationKernel::GetDeviceByName(std::string_view device
 std::optional<IPCReply> EmulationKernel::OpenDevice(OpenRequest& request)
 {
   const s32 new_fd = GetFreeDeviceID();
-  INFO_LOG_FMT(IOS, "Opening {} (mode {}, fd {})", request.path, static_cast<u32>(request.flags),
-               new_fd);
+  INFO_LOG_FMT(IOS, "Opening {} (mode {}, fd {})", request.path,
+               Common::ToUnderlying(request.flags), new_fd);
   if (new_fd < 0 || new_fd >= IPC_MAX_FDS)
   {
     ERROR_LOG_FMT(IOS, "Couldn't get a free fd, too many open files");
@@ -731,7 +732,7 @@ std::optional<IPCReply> EmulationKernel::HandleIPCCommand(const Request& request
     ret = device->IOCtlV(IOCtlVRequest{GetSystem(), request.address});
     break;
   default:
-    ASSERT_MSG(IOS, false, "Unexpected command: {:#x}", static_cast<u32>(request.command));
+    ASSERT_MSG(IOS, false, "Unexpected command: {:#x}", Common::ToUnderlying(request.command));
     ret = IPCReply{IPC_EINVAL, 978_tbticks};
     break;
   }

--- a/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
+++ b/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
@@ -17,6 +17,7 @@
 // clang-format on
 
 #include "Common/Align.h"
+#include "Common/EnumUtils.h"
 #include "Common/FatFsUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
@@ -211,7 +212,7 @@ static ErrorCode WriteFile(const std::string& filename, const std::vector<u8>& t
     if (write_error_code != FR_OK)
     {
       ERROR_LOG_FMT(IOS_WC24, "Failed to write file {} to VFF: {}", filename,
-                    static_cast<u32>(write_error_code));
+                    Common::ToUnderlying(write_error_code));
       return WC24_ERR_FILE_WRITE;
     }
 

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -52,6 +52,7 @@ typedef struct pollfd pollfd_t;
 #include <utility>
 
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/IOS.h"
@@ -289,7 +290,7 @@ public:
     if (socket_entry == WiiSockets.end())
     {
       ERROR_LOG_FMT(IOS_NET, "DoSock: Error, fd not found ({:08x}, {:08X}, {:08X})", sock,
-                    request.address, static_cast<u32>(type));
+                    request.address, Common::ToUnderlying(type));
       GetIOS()->EnqueueIPCReply(request, -SO_EBADF);
     }
     else

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -19,6 +19,7 @@
 #include <libusb.h>
 
 #include "Common/ChunkFile.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/Network.h"
@@ -683,7 +684,7 @@ void BluetoothRealDevice::HandleCtrlTransfer(libusb_transfer* tr)
   if (tr->status != LIBUSB_TRANSFER_COMPLETED && tr->status != LIBUSB_TRANSFER_NO_DEVICE)
   {
     ERROR_LOG_FMT(IOS_WIIMOTE, "libusb command transfer failed, status: {:#04x}",
-                  static_cast<u32>(tr->status));
+                  Common::ToUnderlying(tr->status));
     if (!m_showed_failed_transfer.IsSet())
     {
       Core::DisplayMessage("Failed to send a command to the Bluetooth adapter.", 10000);
@@ -712,7 +713,7 @@ void BluetoothRealDevice::HandleBulkOrIntrTransfer(libusb_transfer* tr)
       tr->status != LIBUSB_TRANSFER_NO_DEVICE)
   {
     ERROR_LOG_FMT(IOS_WIIMOTE, "libusb transfer failed, status: {:#04x}",
-                  static_cast<u32>(tr->status));
+                  Common::ToUnderlying(tr->status));
     if (!m_showed_failed_transfer.IsSet())
     {
       Core::DisplayMessage("Failed to transfer to or from to the Bluetooth adapter.", 10000);

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -12,6 +12,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Crypto/AES.h"
+#include "Common/EnumUtils.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
@@ -143,7 +144,7 @@ std::optional<IPCReply> WFSIDevice::IOCtl(const IOCtlRequest& request)
     m_continue_install = memory.Read_U32(request.buffer_in + 36);
 
     INFO_LOG_FMT(IOS_WFS, "IOCTL_WFSI_IMPORT_TITLE_INIT: patch type {}, continue install: {}",
-                 static_cast<u32>(m_patch_type), m_continue_install ? "true" : "false");
+                 Common::ToUnderlying(m_patch_type), m_continue_install ? "true" : "false");
 
     if (m_patch_type == PatchType::PATCH_TYPE_2)
     {

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -12,6 +12,7 @@
 #include "Common/Assert.h"
 #include "Common/BitSet.h"
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/MsgHandler.h"
 #include "Common/VariantUtil.h"
 #include "Common/x64Emitter.h"
@@ -389,7 +390,7 @@ void RegCache::Discard(BitSet32 pregs)
   for (preg_t i : pregs)
   {
     ASSERT_MSG(DYNA_REC, !m_regs[i].IsLocked(), "Someone forgot to unlock PPC reg {} (X64 reg {}).",
-               i, static_cast<u32>(RX(i)));
+               i, Common::ToUnderlying(RX(i)));
     ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction is in progress for {}!",
                i);
 
@@ -413,7 +414,7 @@ void RegCache::Flush(BitSet32 pregs)
   for (preg_t i : pregs)
   {
     ASSERT_MSG(DYNA_REC, !m_regs[i].IsLocked(), "Someone forgot to unlock PPC reg {} (X64 reg {}).",
-               i, static_cast<u32>(RX(i)));
+               i, Common::ToUnderlying(RX(i)));
     ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction is in progress for {}!",
                i);
 
@@ -497,7 +498,8 @@ BitSet32 RegCache::RegistersInUse() const
 
 void RegCache::FlushX(X64Reg reg)
 {
-  ASSERT_MSG(DYNA_REC, reg < m_xregs.size(), "Flushing non-existent reg {}", static_cast<u32>(reg));
+  ASSERT_MSG(DYNA_REC, reg < m_xregs.size(), "Flushing non-existent reg {}",
+             Common::ToUnderlying(reg));
   ASSERT(!m_xregs[reg].IsLocked());
   if (!m_xregs[reg].IsFree())
   {
@@ -521,7 +523,7 @@ void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
   {
     X64Reg xr = GetFreeXReg();
 
-    ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsDirty(), "Xreg {} already dirty", static_cast<u32>(xr));
+    ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsDirty(), "Xreg {} already dirty", Common::ToUnderlying(xr));
     ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsLocked(), "GetFreeXReg returned locked register");
     ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Invalid transaction state");
 
@@ -538,7 +540,7 @@ void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
                             [xr](const auto& r) {
                               return r.Location().has_value() && r.Location()->IsSimpleReg(xr);
                             }),
-               "Xreg {} already bound", static_cast<u32>(xr));
+               "Xreg {} already bound", Common::ToUnderlying(xr));
 
     m_regs[i].SetBoundTo(xr);
   }
@@ -551,7 +553,7 @@ void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
   }
 
   ASSERT_MSG(DYNA_REC, !m_xregs[RX(i)].IsLocked(),
-             "WTF, this reg ({} -> {}) should have been flushed", i, static_cast<u32>(RX(i)));
+             "WTF, this reg ({} -> {}) should have been flushed", i, Common::ToUnderlying(RX(i)));
 }
 
 void RegCache::StoreFromRegister(preg_t i, FlushMode mode)

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/FloatUtils.h"
 #include "Common/Intrinsics.h"
 #include "Common/JitRegister.h"
@@ -370,7 +371,7 @@ const u8* CommonAsmRoutines::GenQuantizedStoreRuntime(bool single, EQuantizeType
   GenQuantizedStore(single, type, -1);
   RET();
   Common::JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedStore_{}_{}",
-                                static_cast<u32>(type), single);
+                                Common::ToUnderlying(type), single);
 
   return load;
 }
@@ -402,7 +403,7 @@ const u8* CommonAsmRoutines::GenQuantizedLoadRuntime(bool single, EQuantizeType 
   GenQuantizedLoad(single, type, -1);
   RET();
   Common::JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedLoad_{}_{}",
-                                static_cast<u32>(type), single);
+                                Common::ToUnderlying(type), single);
 
   return load;
 }

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -21,6 +21,7 @@
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/FileUtil.h"
 #include "Common/HttpRequest.h"
 #include "Common/Logging/Log.h"
@@ -76,7 +77,7 @@ static bool ImportWAD(IOS::HLE::Kernel& ios, const DiscIO::VolumeWAD& wad,
     if (ret != IOS::HLE::IOSC_FAIL_CHECKVALUE)
     {
       PanicAlertFmtT("WAD installation failed: Could not initialise title import (error {0}).",
-                     static_cast<u32>(ret));
+                     Common::ToUnderlying(ret));
     }
     return false;
   }
@@ -548,7 +549,7 @@ UpdateResult OnlineSystemUpdater::InstallTitleFromNUS(const std::string& prefix_
   auto& es = m_ios.GetESCore();
   if ((ret = es.ImportTicket(ticket.first, ticket.second)) < 0)
   {
-    ERROR_LOG_FMT(CORE, "Failed to import ticket: error {}", static_cast<u32>(ret));
+    ERROR_LOG_FMT(CORE, "Failed to import ticket: error {}", Common::ToUnderlying(ret));
     return UpdateResult::ImportFailed;
   }
 
@@ -580,7 +581,7 @@ UpdateResult OnlineSystemUpdater::InstallTitleFromNUS(const std::string& prefix_
   IOS::HLE::ESCore::Context context;
   if ((ret = es.ImportTitleInit(context, tmd.first.GetBytes(), tmd.second)) < 0)
   {
-    ERROR_LOG_FMT(CORE, "Failed to initialise title import: error {}", static_cast<u32>(ret));
+    ERROR_LOG_FMT(CORE, "Failed to initialise title import: error {}", Common::ToUnderlying(ret));
     return UpdateResult::ImportFailed;
   }
 
@@ -601,7 +602,7 @@ UpdateResult OnlineSystemUpdater::InstallTitleFromNUS(const std::string& prefix_
       if ((ret = es.ImportContentBegin(context, title.id, content.id)) < 0)
       {
         ERROR_LOG_FMT(CORE, "Failed to initialise import for content {:08x}: error {}", content.id,
-                      static_cast<u32>(ret));
+                      Common::ToUnderlying(ret));
         return UpdateResult::ImportFailed;
       }
 
@@ -626,7 +627,7 @@ UpdateResult OnlineSystemUpdater::InstallTitleFromNUS(const std::string& prefix_
   if ((all_contents_imported && (ret = es.ImportTitleDone(context)) < 0) ||
       (!all_contents_imported && (ret = es.ImportTitleCancel(context)) < 0))
   {
-    ERROR_LOG_FMT(CORE, "Failed to finalise title import: error {}", static_cast<u32>(ret));
+    ERROR_LOG_FMT(CORE, "Failed to finalise title import: error {}", Common::ToUnderlying(ret));
     return UpdateResult::ImportFailed;
   }
 

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -43,6 +43,7 @@
     <ClInclude Include="Common\ENet.h" />
     <ClInclude Include="Common\EnumFormatter.h" />
     <ClInclude Include="Common\EnumMap.h" />
+    <ClInclude Include="Common\EnumUtils.h" />
     <ClInclude Include="Common\Event.h" />
     <ClInclude Include="Common\FatFsUtil.h" />
     <ClInclude Include="Common\FileSearch.h" />

--- a/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
@@ -12,6 +12,7 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 
@@ -277,13 +278,13 @@ void VKGfx::BindBackbuffer(const ClearColor& clear_color)
     else
     {
       ERROR_LOG_FMT(VIDEO, "Unknown present error {:#010X} {}, please report.",
-                    static_cast<u32>(res), VkResultToString(res));
+                    Common::ToUnderlying(res), VkResultToString(res));
       m_swap_chain->RecreateSwapChain();
     }
 
     res = m_swap_chain->AcquireNextImage();
     if (res != VK_SUCCESS)
-      PanicAlertFmt("Failed to grab image from swap chain: {:#010X} {}", static_cast<u32>(res),
+      PanicAlertFmt("Failed to grab image from swap chain: {:#010X} {}", Common::ToUnderlying(res),
                     VkResultToString(res));
   }
 

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 
 #include "Common/ChunkFile.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Core/DolphinAnalytics.h"
 #include "VideoCommon/CommandProcessor.h"
@@ -110,7 +111,7 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
       WARN_LOG_FMT(VIDEO,
                    "CP MATINDEX_A: an exact value of {:02x} was expected "
                    "but instead a value of {:02x} was seen",
-                   static_cast<u16>(MATINDEX_A), sub_cmd);
+                   Common::ToUnderlying(MATINDEX_A), sub_cmd);
     }
 
     matrix_index_a.Hex = value;
@@ -123,7 +124,7 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
       WARN_LOG_FMT(VIDEO,
                    "CP MATINDEX_B: an exact value of {:02x} was expected "
                    "but instead a value of {:02x} was seen",
-                   static_cast<u16>(MATINDEX_B), sub_cmd);
+                   Common::ToUnderlying(MATINDEX_B), sub_cmd);
     }
 
     matrix_index_b.Hex = value;
@@ -136,7 +137,7 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
       WARN_LOG_FMT(VIDEO,
                    "CP VCD_LO: an exact value of {:02x} was expected "
                    "but instead a value of {:02x} was seen",
-                   static_cast<u16>(VCD_LO), sub_cmd);
+                   Common::ToUnderlying(VCD_LO), sub_cmd);
     }
 
     vtx_desc.low.Hex = value;
@@ -149,7 +150,7 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
       WARN_LOG_FMT(VIDEO,
                    "CP VCD_HI: an exact value of {:02x} was expected "
                    "but instead a value of {:02x} was seen",
-                   static_cast<u16>(VCD_HI), sub_cmd);
+                   Common::ToUnderlying(VCD_HI), sub_cmd);
     }
 
     vtx_desc.high.Hex = value;

--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -10,7 +10,7 @@
 #include "VideoCommon/CPMemory.h"
 
 // m_components
-enum
+enum : u32
 {
   VB_HAS_POSMTXIDX = (1 << 1),
   VB_HAS_TEXMTXIDX0 = (1 << 2),

--- a/Source/Core/VideoCommon/UberShaderCommon.cpp
+++ b/Source/Core/VideoCommon/UberShaderCommon.cpp
@@ -3,6 +3,7 @@
 
 #include "VideoCommon/UberShaderCommon.h"
 
+#include "Common/EnumUtils.h"
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/VideoCommon.h"
@@ -119,11 +120,11 @@ void WriteVertexLighting(ShaderCode& out, APIType api_type, std::string_view wor
   out.Write("  if ({} != 0u) {{\n", BitfieldExtract<&LitChannel::enablelighting>("alphareg"));
   out.Write("    if ({} != 0u) {{\n", BitfieldExtract<&LitChannel::ambsource>("alphareg"));
   out.Write("      if ((components & ({}u << chan)) != 0u) // VB_HAS_COL0\n",
-            static_cast<u32>(VB_HAS_COL0));
+            Common::ToUnderlying(VB_HAS_COL0));
   out.Write("        lacc.w = int(round(((chan == 0u) ? {}.w : {}.w) * 255.0));\n", in_color_0_var,
             in_color_1_var);
   out.Write("      else if ((components & {}u) != 0u) // VB_HAS_COLO0\n",
-            static_cast<u32>(VB_HAS_COL0));
+            Common::ToUnderlying(VB_HAS_COL0));
   out.Write("        lacc.w = int(round({}.w * 255.0));\n", in_color_0_var);
   out.Write("      else\n"
             "        lacc.w = 255;\n"

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -3,6 +3,7 @@
 
 #include "VideoCommon/UberShaderVertex.h"
 
+#include "Common/EnumUtils.h"
 #include "VideoCommon/ConstantManager.h"
 #include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/NativeVertexFormat.h"
@@ -223,7 +224,7 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
             "float3 N2;\n"
             "\n"
             "if ((components & {}u) != 0u) {{ // VB_HAS_POSMTXIDX\n",
-            static_cast<u32>(VB_HAS_POSMTXIDX));
+            Common::ToUnderlying(VB_HAS_POSMTXIDX));
   LoadVertexAttribute(out, host_config, 2, "posmtx", "uint4", "ubyte4");
   out.Write("  // Vertex format has a per-vertex matrix\n"
             "  int posidx = int(posmtx.r);\n"
@@ -258,7 +259,7 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
             "float3 _normal = float3(0.0, 0.0, 0.0);\n"
             "if ((components & {}u) != 0u) // VB_HAS_NORMAL\n"
             "{{\n",
-            static_cast<u32>(VB_HAS_NORMAL));
+            Common::ToUnderlying(VB_HAS_NORMAL));
   LoadVertexAttribute(out, host_config, 2, "rawnormal", "float3", "float3");
   out.Write("  _normal = normalize(float3(dot(N0, rawnormal), dot(N1, rawnormal), dot(N2, "
             "rawnormal)));\n"
@@ -267,7 +268,7 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
             "float3 _tangent = float3(0.0, 0.0, 0.0);\n"
             "if ((components & {}u) != 0u) // VB_HAS_TANGENT\n"
             "{{\n",
-            static_cast<u32>(VB_HAS_TANGENT));
+            Common::ToUnderlying(VB_HAS_TANGENT));
   LoadVertexAttribute(out, host_config, 2, "rawtangent", "float3", "float3");
   out.Write("  _tangent = float3(dot(N0, rawtangent), dot(N1, rawtangent), dot(N2, rawtangent));\n"
             "}}\n"
@@ -280,7 +281,7 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
             "float3 _binormal = float3(0.0, 0.0, 0.0);\n"
             "if ((components & {}u) != 0u) // VB_HAS_BINORMAL\n"
             "{{\n",
-            static_cast<u32>(VB_HAS_BINORMAL));
+            Common::ToUnderlying(VB_HAS_BINORMAL));
   LoadVertexAttribute(out, host_config, 2, "rawbinormal", "float3", "float3");
   out.Write("  _binormal = float3(dot(N0, rawbinormal), dot(N1, rawbinormal), dot(N2, "
             "rawbinormal));\n"
@@ -313,14 +314,14 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
             "}}\n"
             "else if ((components & {}u) != 0u) // VB_HAS_COL0\n"
             "{{\n",
-            static_cast<u32>(VB_HAS_COL0));
+            Common::ToUnderlying(VB_HAS_COL0));
   LoadVertexAttribute(out, host_config, 2, "rawcolor0", "float4", "ubyte4");
   out.Write("  vertex_color_0 = rawcolor0;\n"
             "  vertex_color_1 = rawcolor0;\n"
             "}}\n"
             "else if ((components & {}u) != 0u) // VB_HAS_COL1\n"
             "{{\n",
-            static_cast<u32>(VB_HAS_COL1));
+            Common::ToUnderlying(VB_HAS_COL1));
   LoadVertexAttribute(out, host_config, 2, "rawcolor1", "float4", "ubyte4");
   out.Write("  vertex_color_0 = rawcolor1;\n"
             "  vertex_color_1 = rawcolor1;\n"
@@ -340,7 +341,7 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
 
   if (host_config.backend_vs_point_line_expand)
   {
-    out.Write("if (vs_expand == {}u) {{ // Line\n", static_cast<u32>(VSExpand::Line));
+    out.Write("if (vs_expand == {}u) {{ // Line\n", Common::ToUnderlying(VSExpand::Line));
     out.Write("  bool is_bottom = (gl_VertexID & 2) != 0;\n"
               "  bool is_right = (gl_VertexID & 1) != 0;\n"
               "  uint other_base_offset = vertex_base_offset;\n"
@@ -355,7 +356,7 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
               "  float4 other_p1 = P1;\n"
               "  float4 other_p2 = P2;\n"
               "  if ((components & {}u) != 0u) {{ // VB_HAS_POSMTXIDX\n",
-              static_cast<u32>(VB_HAS_POSMTXIDX));
+              Common::ToUnderlying(VB_HAS_POSMTXIDX));
     out.Write("    uint other_posidx = load_input_uint4_ubyte4(other_base_offset, "
               "vertex_offset_posmtx).r;\n"
               "    other_p0 = " I_TRANSFORMMATRICES "[other_posidx];\n"
@@ -365,7 +366,7 @@ float3 load_input_float3_rawtex(uint vtx_offset, uint attr_offset) {{
               "  float4 other_pos = float4(dot(other_p0, other_rawpos), "
               "dot(other_p1, other_rawpos), dot(other_p2, other_rawpos), 1.0);\n");
     GenerateVSLineExpansion(out, "  ", num_texgen);
-    out.Write("}} else if (vs_expand == {}u) {{ // Point\n", static_cast<u32>(VSExpand::Point));
+    out.Write("}} else if (vs_expand == {}u) {{ // Point\n", Common::ToUnderlying(VSExpand::Point));
     out.Write("  bool is_bottom = (gl_VertexID & 2) != 0;\n"
               "  bool is_right = (gl_VertexID & 1) != 0;\n");
     GenerateVSPointExpansion(out, "  ", num_texgen);
@@ -545,7 +546,7 @@ static void GenVertexShaderTexGens(APIType api_type, const ShaderHostConfig& hos
   out.Write("  case {:s}:\n", SourceRow::Normal);
   out.Write("    if ((components & {}u) != 0u) // VB_HAS_NORMAL\n"
             "    {{\n",
-            static_cast<u32>(VB_HAS_NORMAL));
+            Common::ToUnderlying(VB_HAS_NORMAL));
   LoadVertexAttribute(out, host_config, 6, "rawnormal", "float3", "float3");
   out.Write("      coord.xyz = rawnormal.xyz;\n"
             "    }}\n"
@@ -553,7 +554,7 @@ static void GenVertexShaderTexGens(APIType api_type, const ShaderHostConfig& hos
   out.Write("  case {:s}:\n", SourceRow::BinormalT);
   out.Write("    if ((components & {}u) != 0u) // VB_HAS_TANGENT\n"
             "    {{\n",
-            static_cast<u32>(VB_HAS_TANGENT));
+            Common::ToUnderlying(VB_HAS_TANGENT));
   LoadVertexAttribute(out, host_config, 6, "rawtangent", "float3", "float3");
   out.Write("      coord.xyz = rawtangent.xyz;\n"
             "    }}\n"
@@ -561,14 +562,14 @@ static void GenVertexShaderTexGens(APIType api_type, const ShaderHostConfig& hos
   out.Write("  case {:s}:\n", SourceRow::BinormalB);
   out.Write("    if ((components & {}u) != 0u) // VB_HAS_BINORMAL\n"
             "    {{\n",
-            static_cast<u32>(VB_HAS_BINORMAL));
+            Common::ToUnderlying(VB_HAS_BINORMAL));
   LoadVertexAttribute(out, host_config, 6, "rawbinormal", "float3", "float3");
   out.Write("      coord.xyz = rawbinormal.xyz;\n"
             "    }}\n"
             "    break;\n\n");
   for (u32 i = 0; i < 8; i++)
   {
-    out.Write("  case {:s}:\n", static_cast<SourceRow>(static_cast<u32>(SourceRow::Tex0) + i));
+    out.Write("  case {:s}:\n", static_cast<SourceRow>(Common::ToUnderlying(SourceRow::Tex0) + i));
     out.Write("    if ((components & {}u) != 0u) // VB_HAS_UV{}\n"
               "    {{\n",
               VB_HAS_UV0 << i, i);
@@ -625,7 +626,7 @@ static void GenVertexShaderTexGens(APIType api_type, const ShaderHostConfig& hos
   out.Write("  default:\n"
             "    {{\n");
   out.Write("      if ((components & ({}u /* VB_HAS_TEXMTXIDX0 */ << texgen)) != 0u) {{\n",
-            static_cast<u32>(VB_HAS_TEXMTXIDX0));
+            Common::ToUnderlying(VB_HAS_TEXMTXIDX0));
   if (host_config.backend_dynamic_vertex_loader || host_config.backend_vs_point_line_expand)
   {
     out.Write("        int tmp = int(load_input_float3_rawtex(vertex_base_offset, "


### PR DESCRIPTION
Mirrors the C++23 \<utility\> function, `std::to_underlying`.
This is an extract of changes from https://github.com/dolphin-emu/dolphin/pull/11932.