### PR TITLE
VideoBackends: fix d3d12 error when validation layers enabled

### DIFF
--- a/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
@@ -204,21 +204,12 @@ std::unique_ptr<DXPipeline> DXPipeline::Create(const AbstractPipelineConfig& con
     desc.NumRenderTargets =
         static_cast<u8>(config.framebuffer_state.additional_color_attachment_count) + 1;
     desc.RTVFormats[0] = D3DCommon::GetRTVFormatForAbstractFormat(
-        config.framebuffer_state.color_texture_format, false);
+        config.framebuffer_state.color_texture_format, config.blending_state.logicopenable);
     for (u8 i = 0; i < static_cast<u8>(config.framebuffer_state.additional_color_attachment_count);
          i++)
     {
       // For now set all formats to be the same
-      desc.RTVFormats[i + 1] = D3DCommon::GetRTVFormatForAbstractFormat(
-          config.framebuffer_state.color_texture_format, false);
-    }
-    if (config.blending_state.logicopenable)
-    {
-      desc.NumRenderTargets++;
-      desc.RTVFormats[static_cast<u8>(config.framebuffer_state.additional_color_attachment_count) +
-                      1] =
-          D3DCommon::GetRTVFormatForAbstractFormat(config.framebuffer_state.color_texture_format,
-                                                   true);
+      desc.RTVFormats[i + 1] = desc.RTVFormats[0];
     }
   }
   if (config.framebuffer_state.depth_texture_format != AbstractTextureFormat::Undefined)


### PR DESCRIPTION
This was an oversight caused by my multi-output texture change.  This code was pulled from an older PR, I can't say why I did it this way.  Maybe multiple logic ops RTs are invalid or maybe it was that it would negatively impact users due to the integer format required? (am i remembering right?)  Anyway, this fixes a validation error that causes d3d12 to crash with the error:

> ERROR: ID3D12Device::CreateGraphicsPipelineState: The render target format at slot 0 is format (R8G8B8A8_UNORM).  This format does not support logic ops. The Pixel Shader output signature indicates this output could be written, and the Blend State indicates logic op is enabled for this slot.


When I get to using multiple-output textures, I will revisit