### PR TITLE
Jit64: Fix trampolines after #11834.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -61,7 +61,7 @@ void EmuCodeBlock::MemoryExceptionCheck()
     if (js.trampolineExceptionHandler)
     {
       TEST(32, PPCSTATE(Exceptions), Gen::Imm32(EXCEPTION_DSI));
-      J_CC(CC_NZ, js.trampolineExceptionHandler ? Jump::Near : Jump::Short);
+      J_CC(CC_NZ, js.trampolineExceptionHandler);
     }
     return;
   }


### PR DESCRIPTION
Fixes RS2 again, probably among lots of other things. See also #11967.