### PR TITLE
StringUtil: Replace Common::ThousandsSeperate with locale-dependent format specifier

### DIFF
--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -239,25 +239,6 @@ inline char ToUpper(char ch)
   return std::toupper(ch, std::locale::classic());
 }
 
-// Thousand separator. Turns 12345678 into 12,345,678
-template <typename I>
-std::string ThousandSeparate(I value, int spaces = 0)
-{
-#ifdef _WIN32
-  std::wostringstream stream;
-#else
-  std::ostringstream stream;
-#endif
-
-  stream << std::setw(spaces) << value;
-
-#ifdef _WIN32
-  return WStringToUTF8(stream.str());
-#else
-  return stream.str();
-#endif
-}
-
 #ifdef _WIN32
 std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
 #endif

--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -77,13 +77,11 @@ void FileLogger::Log(const DiscIO::Volume& volume, const DiscIO::Partition& part
   if (m_previous_partition == partition && m_previous_file_offset == file_offset)
     return;
 
-  const std::string size_string = Common::ThousandSeparate(file_info->GetSize() / 1000, 7);
   const std::string path = file_info->GetPath();
-  const std::string log_string = fmt::format("{} kB {}", size_string, path);
   if (IsSoundFile(path))
-    INFO_LOG_FMT(FILEMON, "{}", log_string);
+    INFO_LOG_FMT(FILEMON, "{:>7Ld} kB {}", file_info->GetSize() / 1000, path);
   else
-    WARN_LOG_FMT(FILEMON, "{}", log_string);
+    WARN_LOG_FMT(FILEMON, "{:>7Ld} kB {}", file_info->GetSize() / 1000, path);
 
   // Update the last accessed file
   m_previous_partition = partition;


### PR DESCRIPTION
Part B of splitting https://github.com/dolphin-emu/dolphin/pull/11913.
I suspect this will be debatable, as it adds yet another {fmt} dependency that cannot be replaced by standard library \<format\>.