### PR TITLE
Avoid string copies with rvalue-ref qualified std::ostringstream::str()

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -12,6 +12,9 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
@@ -318,7 +321,7 @@ bool IniFile::Load(const std::string& filename, bool keep_current_data)
 bool IniFile::Save(const std::string& filename)
 {
   std::ofstream out;
-  std::string temp = File::GetTempFilenameForAtomicWrite(filename);
+  const std::string temp = File::GetTempFilenameForAtomicWrite(filename);
   File::OpenFStream(out, temp, std::ios::out);
 
   if (out.fail())
@@ -329,19 +332,19 @@ bool IniFile::Save(const std::string& filename)
   for (const Section& section : sections)
   {
     if (!section.keys_order.empty() || !section.m_lines.empty())
-      out << '[' << section.name << ']' << std::endl;
+      fmt::print(out, "[{:s}]\n", section.name);
 
     if (section.keys_order.empty())
     {
       for (const std::string& s : section.m_lines)
-        out << s << std::endl;
+        fmt::print(out, "{:s}\n", s);
     }
     else
     {
       for (const std::string& kvit : section.keys_order)
       {
         auto pair = section.values.find(kvit);
-        out << pair->first << " = " << pair->second << std::endl;
+        fmt::print(out, "{:s} = {:s}\n", pair->first, pair->second);
       }
     }
   }

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -139,7 +139,7 @@ std::string EscapePath(const std::string& path)
   std::vector<std::string> escaped_split_strings;
   escaped_split_strings.reserve(split_strings.size());
   for (const std::string& split_string : split_strings)
-    escaped_split_strings.push_back(EscapeFileName(split_string));
+    escaped_split_strings.emplace_back(EscapeFileName(split_string));
 
   return JoinStrings(escaped_split_strings, "/");
 }

--- a/Source/Core/Common/Profiler.cpp
+++ b/Source/Core/Common/Profiler.cpp
@@ -11,13 +11,16 @@
 #include <ios>
 #include <sstream>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include "Common/Timer.h"
 
 namespace Common
 {
-static const u32 PROFILER_FIELD_LENGTH = 8;
-static const u32 PROFILER_FIELD_LENGTH_FP = PROFILER_FIELD_LENGTH + 3;
-static const int PROFILER_LAZY_DELAY = 60;  // in frames
+static constexpr u32 PROFILER_FIELD_LENGTH = 8;
+static constexpr u32 PROFILER_FIELD_LENGTH_FP = PROFILER_FIELD_LENGTH + 3;
+static constexpr int PROFILER_LAZY_DELAY = 60;  // in frames
 
 std::list<Profiler*> Profiler::s_all_profilers;
 std::mutex Profiler::s_mutex;
@@ -69,30 +72,16 @@ std::string Profiler::ToString()
   s_frame_time = end;
 
   std::ostringstream buffer;
-  buffer << std::setw(s_max_length) << std::left << ""
-         << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH) << std::right << "calls"
-         << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH) << std::right << "sum"
-         << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH_FP) << std::right << "rel"
-         << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH) << std::right << "min"
-         << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH_FP) << std::right << "avg"
-         << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH_FP) << std::right << "stdev"
-         << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH) << std::right << "max"
-         << " ";
-  buffer << "/ usec" << std::endl;
+  fmt::print(buffer, "{:<{}s} {:>{}s} {:>{}s} {:>{}s} {:>{}s} {:>{}s} {:>{}s} {:>{}s} / usec\n", "",
+             s_max_length, "calls", PROFILER_FIELD_LENGTH, "sum", PROFILER_FIELD_LENGTH, "rel",
+             PROFILER_FIELD_LENGTH_FP, "min", PROFILER_FIELD_LENGTH, "avg",
+             PROFILER_FIELD_LENGTH_FP, "stdev", PROFILER_FIELD_LENGTH_FP, "max",
+             PROFILER_FIELD_LENGTH);
 
   s_all_profilers.sort([](Profiler* a, Profiler* b) { return *b < *a; });
 
-  for (auto profiler : s_all_profilers)
-  {
-    buffer << profiler->Read() << std::endl;
-  }
+  for (auto* profiler : s_all_profilers)
+    profiler->Print(buffer);
   s_lazy_result = buffer.str();
   return s_lazy_result;
 }
@@ -121,7 +110,7 @@ void Profiler::Stop()
   }
 }
 
-std::string Profiler::Read()
+void Profiler::Print(std::ostream& os)
 {
   double avg = 0;
   double stdev = 0;
@@ -140,25 +129,16 @@ std::string Profiler::Read()
     time_rel = double(m_usecs) * 100 / s_usecs_frame;
   }
 
-  std::ostringstream buffer;
-
-  buffer << std::setw(s_max_length) << std::left << m_name << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH) << std::right << m_calls << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH) << std::right << m_usecs << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH_FP) << std::right << time_rel << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH) << std::right << m_usecs_min << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH_FP) << std::right << std::fixed << std::setprecision(2)
-         << avg << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH_FP) << std::right << std::fixed << std::setprecision(2)
-         << stdev << " ";
-  buffer << std::setw(PROFILER_FIELD_LENGTH) << std::right << m_usecs_max;
+  fmt::print(os, "{:<{}s} {:>{}d} {:>{}d} {:>{}f} {:>{}d} {:>{}.2f} {:>{}.2f} {:>{}d}\n", m_name,
+             s_max_length, m_calls, PROFILER_FIELD_LENGTH, m_usecs, PROFILER_FIELD_LENGTH, time_rel,
+             PROFILER_FIELD_LENGTH_FP, m_usecs_min, PROFILER_FIELD_LENGTH, avg,
+             PROFILER_FIELD_LENGTH_FP, stdev, PROFILER_FIELD_LENGTH_FP, m_usecs_max,
+             PROFILER_FIELD_LENGTH);
 
   m_usecs = 0;
   m_usecs_min = UINT64_MAX;
   m_usecs_max = 0;
   m_usecs_quad = 0;
   m_calls = 0;
-
-  return buffer.str();
 }
 }  // namespace Common

--- a/Source/Core/Common/Profiler.cpp
+++ b/Source/Core/Common/Profiler.cpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <ios>
 #include <sstream>
+#include <utility>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -82,8 +83,8 @@ std::string Profiler::ToString()
 
   for (auto* profiler : s_all_profilers)
     profiler->Print(buffer);
-  s_lazy_result = buffer.str();
-  return s_lazy_result;
+
+  return s_lazy_result = std::move(buffer).str();
 }
 
 void Profiler::Start()

--- a/Source/Core/Common/Profiler.h
+++ b/Source/Core/Common/Profiler.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <iosfwd>
 #include <list>
 #include <mutex>
 #include <string>
@@ -21,7 +22,7 @@ public:
 
   void Start();
   void Stop();
-  std::string Read();
+  void Print(std::ostream&);
 
   bool operator<(const Profiler& b) const;
 

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "AudioCommon/AudioCommon.h"
 #include "Common/Assert.h"
@@ -537,7 +538,7 @@ static std::string SaveUSBWhitelistToString(const std::set<std::pair<u16, u16>>&
 {
   std::ostringstream oss;
   for (const auto& device : devices)
-    oss << fmt::format("{:04x}:{:04x}", device.first, device.second) << ',';
+    fmt::print(oss, "{:04x}:{:04x},", device.first, device.second);
   std::string devices_string = oss.str();
   if (!devices_string.empty())
     devices_string.pop_back();

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -4,6 +4,7 @@
 #include "Core/Config/MainSettings.h"
 
 #include <sstream>
+#include <utility>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -539,7 +540,7 @@ static std::string SaveUSBWhitelistToString(const std::set<std::pair<u16, u16>>&
   std::ostringstream oss;
   for (const auto& device : devices)
     fmt::print(oss, "{:04x}:{:04x},", device.first, device.second);
-  std::string devices_string = oss.str();
+  std::string devices_string = std::move(oss).str();
   if (!devices_string.empty())
     devices_string.pop_back();
   return devices_string;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -631,7 +631,7 @@ void BluetoothRealDevice::SaveLinkKeys()
     }
     oss << std::dec << ',';
   }
-  std::string config_string = oss.str();
+  std::string config_string = std::move(oss).str();
   if (!config_string.empty())
     config_string.pop_back();
   Config::SetBase(Config::MAIN_BLUETOOTH_PASSTHROUGH_LINK_KEYS, config_string);

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -7,6 +7,9 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <unistd.h>
 
 #include "Common/FileUtil.h"
@@ -82,19 +85,15 @@ u32 MemoryWatcher::ChasePointer(const Core::CPUThreadGuard& guard, const std::st
 std::string MemoryWatcher::ComposeMessages(const Core::CPUThreadGuard& guard)
 {
   std::ostringstream message_stream;
-  message_stream << std::hex;
 
-  for (auto& entry : m_values)
+  for (auto& [address, current_value] : m_values)
   {
-    std::string address = entry.first;
-    u32& current_value = entry.second;
-
     u32 new_value = ChasePointer(guard, address);
     if (new_value != current_value)
     {
       // Update the value
       current_value = new_value;
-      message_stream << address << '\n' << new_value << '\n';
+      fmt::print(message_stream, "{:s}\n{:x}\n", address, new_value);
     }
   }
 

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <utility>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -97,7 +98,7 @@ std::string MemoryWatcher::ComposeMessages(const Core::CPUThreadGuard& guard)
     }
   }
 
-  return message_stream.str();
+  return std::move(message_stream).str();
 }
 
 void MemoryWatcher::Step(const Core::CPUThreadGuard& guard)

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -208,7 +208,7 @@ std::string GetRTCDisplay()
 
   std::ostringstream format_time;
   format_time << std::put_time(gm_time, "Date/Time: %c\n");
-  return format_time.str();
+  return std::move(format_time).str();
 }
 
 // NOTE: GPU Thread

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -9,6 +9,9 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/Core.h"
@@ -64,15 +67,15 @@ BreakPoints::TBreakPointsStr BreakPoints::GetStrings() const
     {
       std::ostringstream ss;
       ss.imbue(std::locale::classic());
-      ss << fmt::format("${:08x} ", bp.address);
+      fmt::print(ss, "${:08x} ", bp.address);
       if (bp.is_enabled)
-        ss << "n";
+        ss.put('n');
       if (bp.log_on_hit)
-        ss << "l";
+        ss.put('l');
       if (bp.break_on_hit)
-        ss << "b";
+        ss.put('b');
       if (bp.condition)
-        ss << "c " << bp.condition->GetText();
+        fmt::print(ss, "c {:s}", bp.condition->GetText());
       bp_strings.emplace_back(ss.str());
     }
   }
@@ -216,19 +219,19 @@ MemChecks::TMemChecksStr MemChecks::GetStrings() const
   {
     std::ostringstream ss;
     ss.imbue(std::locale::classic());
-    ss << fmt::format("${:08x} {:08x} ", mc.start_address, mc.end_address);
+    fmt::print(ss, "${:08x} {:08x} ", mc.start_address, mc.end_address);
     if (mc.is_enabled)
-      ss << 'n';
+      ss.put('n');
     if (mc.is_break_on_read)
-      ss << 'r';
+      ss.put('r');
     if (mc.is_break_on_write)
-      ss << 'w';
+      ss.put('w');
     if (mc.log_on_hit)
-      ss << 'l';
+      ss.put('l');
     if (mc.break_on_hit)
-      ss << 'b';
+      ss.put('b');
     if (mc.condition)
-      ss << "c " << mc.condition->GetText();
+      fmt::print(ss, "c {:s}", mc.condition->GetText());
 
     mc_strings.emplace_back(ss.str());
   }

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -302,8 +302,7 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& 
       constexpr auto is_hex_str = [](const std::string& s) {
         return !s.empty() && s.find_first_not_of("0123456789abcdefABCDEF") == std::string::npos;
       };
-      const std::string stripped_line(StripWhitespace(line));
-      std::istringstream iss(stripped_line);
+      std::istringstream iss(std::string{StripWhitespace(line)});
       iss.imbue(std::locale::classic());
       std::string word;
 

--- a/Source/Core/DiscIO/RiivolutionParser.cpp
+++ b/Source/Core/DiscIO/RiivolutionParser.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
@@ -473,9 +474,9 @@ std::string WriteConfigString(const Config& config)
     option_node.append_attribute("default").set_value(option.m_default);
   }
 
-  std::stringstream ss;
-  doc.print(ss, "  ");
-  return ss.str();
+  std::ostringstream oss;
+  doc.print(oss, "  ");
+  return std::move(oss).str();
 }
 
 bool WriteConfigFile(const std::string& filename, const Config& config)

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
@@ -4,6 +4,7 @@
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 #include <sstream>
+#include <utility>
 
 namespace ControllerEmu
 {
@@ -50,7 +51,7 @@ void NumericSetting<double>::SetExpressionFromValue()
   ss.imbue(std::locale::classic());
   ss << GetValue();
 
-  m_value.m_input.SetExpression(ss.str());
+  m_value.m_input.SetExpression(std::move(ss).str());
 }
 
 template <>

--- a/Source/Core/UICommon/Disassembler.cpp
+++ b/Source/Core/UICommon/Disassembler.cpp
@@ -4,6 +4,7 @@
 #include "UICommon/Disassembler.h"
 
 #include <sstream>
+#include <utility>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -113,7 +114,7 @@ std::string HostDisassemblerLLVM::DisassembleHostBlock(const u8* code_start, con
     (*host_instructions_count)++;
   }
 
-  return x86_disasm.str();
+  return std::move(x86_disasm).str();
 }
 #elif defined(_M_X86)
 class HostDisassemblerX86 : public HostDisassembler
@@ -148,7 +149,7 @@ std::string HostDisassemblerX86::DisassembleHostBlock(const u8* code_start, cons
     (*host_instructions_count)++;
   }
 
-  return x86_disasm.str();
+  return std::move(x86_disasm).str();
 }
 #endif
 

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <wrl/client.h>
 #include "disassemble.h"
 #include "spirv_hlsl.hpp"
@@ -254,17 +255,15 @@ std::optional<Shader::BinaryData> Shader::CompileShader(D3D_FEATURE_LEVEL featur
     std::ofstream file;
     File::OpenFStream(file, filename, std::ios_base::out);
     file.write(hlsl->data(), hlsl->size());
-    file << "\n";
+    file.put('\n');
     file.write(static_cast<const char*>(errors->GetBufferPointer()), errors->GetBufferSize());
-    file << "\n";
-    file << "Dolphin Version: " + Common::GetScmRevStr() + "\n";
-    file << "Video Backend: " + g_video_backend->GetDisplayName();
+    file.put('\n');
+    fmt::print(file, "Dolphin Version: {:s}\n", Common::GetScmRevStr());
+    fmt::print(file, "Video Backend: {:s}", g_video_backend->GetDisplayName());
 
     if (const auto spirv = GetSpirv(stage, source))
     {
-      file << "\nOriginal Source: \n";
-      file << source << std::endl;
-      file << "SPIRV: \n";
+      fmt::print(file, "\nOriginal Source: \n{:s}\nSPIRV: \n", source);
       spv::Disassemble(file, *spirv);
     }
     file.close();

--- a/Source/Core/VideoBackends/Metal/MTLGfx.mm
+++ b/Source/Core/VideoBackends/Metal/MTLGfx.mm
@@ -18,6 +18,9 @@
 
 #include <fstream>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 Metal::Gfx::Gfx(MRCOwned<CAMetalLayer*> layer) : m_layer(std::move(layer))
 {
   UpdateActiveConfig();
@@ -165,26 +168,20 @@ std::unique_ptr<AbstractShader> Metal::Gfx::CreateShaderFromMSL(ShaderStage stag
       std::ofstream stream(filename);
       if (stream.good())
       {
-        stream << msl << std::endl;
-        stream << "/*" << std::endl;
-        stream << msg << std::endl;
-        stream << "Error:" << std::endl;
-        stream << [[err localizedDescription] UTF8String] << std::endl;
+        fmt::print(stream, "{:s}\n/*\n{:s}\nError:\n{:s}\n", msl, msg,
+                   [[err localizedDescription] UTF8String]);
         if (!glsl.empty())
         {
-          stream << "Original GLSL:" << std::endl;
-          stream << glsl << std::endl;
+          fmt::print(stream, "Original GLSL:\n{:s}\n", glsl);
         }
         else
         {
-          stream << "Shader was created with cached MSL so no GLSL is available." << std::endl;
+          fmt::print(stream, "Shader was created with cached MSL so no GLSL is available.\n");
         }
       }
 
-      stream << std::endl;
-      stream << "Dolphin Version: " << Common::GetScmRevStr() << std::endl;
-      stream << "Video Backend: " << g_video_backend->GetDisplayName() << std::endl;
-      stream << "*/" << std::endl;
+      fmt::print(stream, "\nDolphin Version: {:s}\nVideo Backend: {:s}\n*/\n",
+                 Common::GetScmRevStr(), g_video_backend->GetDisplayName());
       stream.close();
 
       PanicAlertFmt("{} (written to {})\n", msg, filename);

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "Common/Align.h"
 #include "Common/Assert.h"
@@ -376,10 +377,8 @@ bool ProgramShaderCache::CheckShaderCompileResult(GLuint id, GLenum type, std::s
       std::string filename = VideoBackendBase::BadShaderFilename(prefix, num_failures++);
       std::ofstream file;
       File::OpenFStream(file, filename, std::ios_base::out);
-      file << s_glsl_header << code << info_log;
-      file << "\n";
-      file << "Dolphin Version: " + Common::GetScmRevStr() + "\n";
-      file << "Video Backend: " + g_video_backend->GetDisplayName();
+      fmt::print(file, "{:s}{:s}{:s}\nDolphin Version: {:s}\nVideo Backend: {:s}", s_glsl_header,
+                 code, info_log, Common::GetScmRevStr(), g_video_backend->GetDisplayName());
       file.close();
 
       PanicAlertFmt("Failed to compile {} shader: {}\n"
@@ -415,16 +414,13 @@ bool ProgramShaderCache::CheckProgramLinkResult(GLuint id, std::string_view vcod
       std::ofstream file;
       File::OpenFStream(file, filename, std::ios_base::out);
       if (!vcode.empty())
-        file << s_glsl_header << vcode << '\n';
+        fmt::print(file, "{:s}{:s}\n", s_glsl_header, vcode);
       if (!gcode.empty())
-        file << s_glsl_header << gcode << '\n';
+        fmt::print(file, "{:s}{:s}\n", s_glsl_header, gcode);
       if (!pcode.empty())
-        file << s_glsl_header << pcode << '\n';
-
-      file << info_log;
-      file << "\n";
-      file << "Dolphin Version: " + Common::GetScmRevStr() + "\n";
-      file << "Video Backend: " + g_video_backend->GetDisplayName();
+        fmt::print(file, "{:s}{:s}\n", s_glsl_header, pcode);
+      fmt::print(file, "{:s}\nDolphin Version: {:s}\nVideo Backend: {:s}", info_log,
+                 Common::GetScmRevStr(), g_video_backend->GetDisplayName());
       file.close();
 
       PanicAlertFmt("Failed to link shaders: {}\n"

--- a/Source/Core/VideoCommon/PerformanceTracker.cpp
+++ b/Source/Core/VideoCommon/PerformanceTracker.cpp
@@ -8,6 +8,8 @@
 #include <iomanip>
 #include <mutex>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <implot.h>
 
 #include "Common/CommonTypes.h"
@@ -238,7 +240,7 @@ void PerformanceTracker::LogRenderTimeToFile(DT val)
                       std::ios_base::out);
   }
 
-  m_bench_file << std::fixed << std::setprecision(8) << DT_ms(val).count() << std::endl;
+  fmt::print(m_bench_file, "{:.8f}\n", DT_ms(val).count());
 }
 
 void PerformanceTracker::SetPaused(bool paused)

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "Common/Assert.h"
 #include "Common/CommonPaths.h"
@@ -463,41 +464,41 @@ std::string PostProcessing::GetUniformBufferHeader() const
   ss << "  int src_layer;\n";
   ss << "  uint time;\n";
   for (u32 i = 0; i < 2; i++)
-    ss << "  uint ubo_align_" << unused_counter++ << "_;\n";
-  ss << "\n";
+    fmt::print(ss, "  int ubo_align_{:d}_;\n", unused_counter++);
+  ss.put('\n');
 
   // Custom options/uniforms
   for (const auto& it : m_config.GetOptions())
   {
     if (it.second.m_type == PostProcessingConfiguration::ConfigurationOption::OptionType::Bool)
     {
-      ss << fmt::format("  int {};\n", it.first);
+      fmt::print(ss, "  int {};\n", it.first);
       for (u32 i = 0; i < 3; i++)
-        ss << "  int ubo_align_" << unused_counter++ << "_;\n";
+        fmt::print(ss, "  int ubo_align_{:d}_;\n", unused_counter++);
     }
     else if (it.second.m_type ==
              PostProcessingConfiguration::ConfigurationOption::OptionType::Integer)
     {
       u32 count = static_cast<u32>(it.second.m_integer_values.size());
       if (count == 1)
-        ss << fmt::format("  int {};\n", it.first);
+        fmt::print(ss, "  int {};\n", it.first);
       else
-        ss << fmt::format("  int{} {};\n", count, it.first);
+        fmt::print(ss, "  int{} {};\n", count, it.first);
 
       for (u32 i = count; i < 4; i++)
-        ss << "  int ubo_align_" << unused_counter++ << "_;\n";
+        fmt::print(ss, "  int ubo_align_{:d}_;\n", unused_counter++);
     }
     else if (it.second.m_type ==
              PostProcessingConfiguration::ConfigurationOption::OptionType::Float)
     {
       u32 count = static_cast<u32>(it.second.m_float_values.size());
       if (count == 1)
-        ss << fmt::format("  float {};\n", it.first);
+        fmt::print(ss, "  float {};\n", it.first);
       else
-        ss << fmt::format("  float{} {};\n", count, it.first);
+        fmt::print(ss, "  float{} {};\n", count, it.first);
 
       for (u32 i = count; i < 4; i++)
-        ss << "  float ubo_align_" << unused_counter++ << "_;\n";
+        fmt::print(ss, "  int ubo_align_{:d}_;\n", unused_counter++);
     }
   }
 

--- a/Source/Core/VideoCommon/Spirv.cpp
+++ b/Source/Core/VideoCommon/Spirv.cpp
@@ -3,6 +3,9 @@
 
 #include "VideoCommon/Spirv.h"
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 // glslang includes
 #include "GlslangToSpv.h"
 #include "ResourceLimits.h"
@@ -73,22 +76,17 @@ CompileShaderToSPV(EShLanguage stage, APIType api_type,
     File::OpenFStream(stream, filename, std::ios_base::out);
     if (stream.good())
     {
-      stream << source << std::endl;
-      stream << msg << std::endl;
-      stream << "Shader Info Log:" << std::endl;
-      stream << shader->getInfoLog() << std::endl;
-      stream << shader->getInfoDebugLog() << std::endl;
+      fmt::print(stream, "{:s}\n{:s}\nShader Info Log:\n{:s}\n{:s}\n", source, msg,
+                 shader->getInfoLog(), shader->getInfoDebugLog());
       if (program)
       {
-        stream << "Program Info Log:" << std::endl;
-        stream << program->getInfoLog() << std::endl;
-        stream << program->getInfoDebugLog() << std::endl;
+        fmt::print(stream, "Program Info Log:\n{:s}\n{:s}\n", program->getInfoLog(),
+                   program->getInfoDebugLog());
       }
     }
 
-    stream << "\n";
-    stream << "Dolphin Version: " + Common::GetScmRevStr() + "\n";
-    stream << "Video Backend: " + g_video_backend->GetDisplayName();
+    fmt::print(stream, "\nDolphin Version: {:s}\nVideo Backend: {:s}", Common::GetScmRevStr(),
+               g_video_backend->GetDisplayName());
     stream.close();
 
     PanicAlertFmt("{} (written to {})\nDebug info:\n{}", msg, filename, shader->getInfoLog());

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <sstream>
 #include <string_view>
+#include <utility>
 
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
@@ -1055,7 +1056,7 @@ std::string GenerateDecodingShader(TextureFormat format, std::optional<TLUTForma
 {
   const DecodingShaderInfo* info = GetDecodingShaderInfo(format);
   if (!info)
-    return "";
+    return {};
 
   std::ostringstream ss;
   if (palette_format.has_value())
@@ -1096,7 +1097,7 @@ std::string GenerateDecodingShader(TextureFormat format, std::optional<TLUTForma
   ss << decoding_shader_header;
   ss << info->shader_body;
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 std::string GeneratePaletteConversionShader(TLUTFormat palette_format, APIType api_type)
@@ -1178,7 +1179,7 @@ float4 DecodePixel(int val)
     break;
   }
 
-  ss << "\n";
+  ss.put('\n');
 
   if (api_type == APIType::Metal)
     ss << "SSBO_BINDING(0) readonly buffer Palette { uint16_t palette[]; };\n";
@@ -1214,7 +1215,7 @@ float4 DecodePixel(int val)
   ss << "  ocol0 = DecodePixel(src);\n";
   ss << "}\n";
 
-  return ss.str();
+  return std::move(ss).str();
 }
 
 }  // namespace TextureConversionShaderTiled

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -6,6 +6,8 @@
 #include <array>
 #include <cmath>
 #include <memory>
+#include <sstream>
+#include <utility>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
@@ -988,13 +990,13 @@ void VertexManagerBase::OnEndFrame()
 #if 0
   {
     std::ostringstream ss;
+    // TODO: Waiting for GCC 11 and Clang 13 to use C++20's std::ostringstream::view()
     std::for_each(m_cpu_accesses_this_frame.begin(), m_cpu_accesses_this_frame.end(), [&ss](u32 idx) { ss << idx << ","; });
-    WARN_LOG_FMT(VIDEO, "CPU EFB accesses in last frame: {}", ss.str());
-  }
-  {
-    std::ostringstream ss;
+    WARN_LOG_FMT(VIDEO, "CPU EFB accesses in last frame: {}", std::move(ss).str());
+    // Underlying buffer is in a valid, but unspecified state.
+    ss.str(std::string{});
     std::for_each(m_scheduled_command_buffer_kicks.begin(), m_scheduled_command_buffer_kicks.end(), [&ss](u32 idx) { ss << idx << ","; });
-    WARN_LOG_FMT(VIDEO, "Scheduled command buffer kicks: {}", ss.str());
+    WARN_LOG_FMT(VIDEO, "Scheduled command buffer kicks: {}", std::move(ss).str());
   }
 #endif
 


### PR DESCRIPTION
Part F of splitting https://github.com/dolphin-emu/dolphin/pull/11913.
Depends on https://github.com/dolphin-emu/dolphin/pull/11974 because they are a bit tangled up with what lines they change.