### PR TITLE
StringUtil: Replace JoinStrings with fmt::join

### DIFF
--- a/Source/Android/jni/Cheats/GeckoCheat.cpp
+++ b/Source/Android/jni/Cheats/GeckoCheat.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
 #include <jni.h>
 
 #include "Common/FileUtil.h"
@@ -58,7 +59,7 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_GeckoCheat_getCreator(JNIEn
 JNIEXPORT jstring JNICALL
 Java_org_dolphinemu_dolphinemu_features_cheats_model_GeckoCheat_getNotes(JNIEnv* env, jobject obj)
 {
-  return ToJString(env, JoinStrings(GetPointer(env, obj)->notes, "\n"));
+  return ToJString(env, fmt::to_string(fmt::join(GetPointer(env, obj)->notes, "\n")));
 }
 
 JNIEXPORT jstring JNICALL

--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -300,5 +300,5 @@ std::string CPUInfo::Summarize()
   if (bSHA2)
     sum.push_back("SHA2");
 
-  return JoinStrings(sum, ",");
+  return fmt::to_string(fmt::join(sum, ","));
 }

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -141,7 +141,7 @@ std::string EscapePath(const std::string& path)
   for (const std::string& split_string : split_strings)
     escaped_split_strings.push_back(EscapeFileName(split_string));
 
-  return JoinStrings(escaped_split_strings, "/");
+  return fmt::to_string(fmt::join(escaped_split_strings, "/"));
 }
 
 std::string UnescapeFileName(const std::string& filename)

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -389,21 +389,6 @@ std::vector<std::string> SplitString(const std::string& str, const char delim)
   return output;
 }
 
-std::string JoinStrings(const std::vector<std::string>& strings, const std::string& delimiter)
-{
-  // Check if we can return early, just for speed
-  if (strings.empty())
-    return "";
-
-  std::ostringstream res;
-  std::copy(strings.begin(), strings.end(),
-            std::ostream_iterator<std::string>(res, delimiter.c_str()));
-
-  // Drop the trailing delimiter.
-  std::string joined = res.str();
-  return joined.substr(0, joined.length() - delimiter.length());
-}
-
 std::string TabsToSpaces(int tab_size, std::string str)
 {
   const std::string spaces(tab_size, ' ');

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -153,7 +153,6 @@ bool AsciiToHex(const std::string& _szValue, u32& result);
 std::string TabsToSpaces(int tab_size, std::string str);
 
 std::vector<std::string> SplitString(const std::string& str, char delim);
-std::string JoinStrings(const std::vector<std::string>& strings, const std::string& delimiter);
 
 // "C:/Windows/winhelp.exe" to "C:/Windows/", "winhelp", ".exe"
 // This requires forward slashes to be used for the path separators, even on Windows.

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -275,5 +275,5 @@ std::string CPUInfo::Summarize()
   if (bSHA2)
     sum.push_back("SHA2");
 
-  return JoinStrings(sum, ",");
+  return fmt::to_string(fmt::join(sum, ","));
 }

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -88,7 +88,7 @@ static std::vector<std::string> ReadM3UFile(const std::string& m3u_path,
   if (!nonexistent.empty())
   {
     PanicAlertFmtT("Files specified in the M3U file \"{0}\" were not found:\n{1}", m3u_path,
-                   JoinStrings(nonexistent, "\n"));
+                   fmt::join(nonexistent, "\n"));
     return {};
   }
 

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -3,6 +3,8 @@
 
 #include "Core/FreeLookManager.h"
 
+#include <fmt/format.h>
+
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
@@ -124,7 +126,7 @@ void FreeLookController::LoadDefaults(const ControllerInterface& ciface)
 
 #ifndef ANDROID
   auto hotkey_string = [](std::vector<std::string> inputs) {
-    return "@(" + JoinStrings(inputs, "+") + ')';
+    return fmt::format("@({})", fmt::join(inputs, "+"));
   };
 
   m_move_buttons->SetControlExpression(MoveButtons::Up, hotkey_string({"Shift", "E"}));

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -14,7 +14,6 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
-#include "Common/StringUtil.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
@@ -430,7 +429,7 @@ void HotkeyManager::LoadDefaults(const ControllerInterface& ciface)
   };
 
   auto hotkey_string = [](std::vector<std::string> inputs) {
-    return "@(" + JoinStrings(inputs, "+") + ')';
+    return fmt::format("@({})", fmt::join(inputs, "+"));
   };
 
   // General hotkeys

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -423,7 +423,7 @@ std::string WFSSRVDevice::NormalizePath(const std::string& path) const
       normalized_components.push_back(component);
     }
   }
-  return "/" + JoinStrings(normalized_components, "/");
+  return fmt::format("/{}", fmt::join(normalized_components, "/"));
 }
 
 WFSSRVDevice::FileDescriptor* WFSSRVDevice::FindFileDescriptor(u16 fd)

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -279,7 +279,8 @@ void ReshapableInput::SaveConfig(Common::IniFile::Section* section,
   std::transform(
       m_calibration.begin(), m_calibration.end(), save_data.begin(),
       [](ControlState val) { return fmt::format("{:.2f}", val * CALIBRATION_CONFIG_SCALE); });
-  section->Set(group + CALIBRATION_CONFIG_NAME, JoinStrings(save_data, " "), "");
+  section->Set(fmt::format("{}{}{}", group, CALIBRATION_CONFIG_NAME, fmt::join(save_data, " ")),
+               "");
 
   // Save center value.
   static constexpr char center_format[] = "{:.2f} {:.2f}";

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -87,8 +87,9 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
     new_alternation = false;
 
     std::vector<std::string> alternation;
+    alternation.reserve(pressed_inputs.size());
     for (auto* input : pressed_inputs)
-      alternation.push_back(get_control_expression(*input));
+      alternation.emplace_back(get_control_expression(*input));
 
     const bool is_hotkey = pressed_inputs.size() >= 2 &&
                            (pressed_inputs[1]->press_time - pressed_inputs[0]->press_time) >
@@ -96,12 +97,12 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
 
     if (is_hotkey)
     {
-      alternations.push_back(fmt::format("@({})", JoinStrings(alternation, "+")));
+      alternations.emplace_back(fmt::format("@({})", fmt::join(alternation, "+")));
     }
     else
     {
       std::sort(alternation.begin(), alternation.end());
-      alternations.push_back(JoinStrings(alternation, "&"));
+      alternations.emplace_back(fmt::to_string(fmt::join(alternation, "&")));
     }
   };
 
@@ -130,7 +131,7 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
   std::sort(alternations.begin(), alternations.end());
   alternations.erase(std::unique(alternations.begin(), alternations.end()), alternations.end());
 
-  return JoinStrings(alternations, "|");
+  return fmt::to_string(fmt::join(alternations, "|"));
 }
 
 void RemoveSpuriousTriggerCombinations(

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -10,7 +10,6 @@
 #include <iterator>
 #include <map>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -580,10 +579,7 @@ std::string GameFile::GetNetPlayName(const Core::TitleDatabase& title_database) 
   }
   if (info.empty())
     return name;
-  std::ostringstream ss;
-  std::copy(info.begin(), info.end() - 1, std::ostream_iterator<std::string>(ss, ", "));
-  ss << info.back();
-  return name + " (" + ss.str() + ")";
+  return fmt::format("{:s} ({:s})", name, fmt::join(info, ", "));
 }
 
 static Common::SHA1::Digest GetHash(u32 value)

--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -7,15 +7,6 @@
 
 #include "Common/StringUtil.h"
 
-TEST(StringUtil, JoinStrings)
-{
-  EXPECT_EQ("", JoinStrings({}, ", "));
-  EXPECT_EQ("a", JoinStrings({"a"}, ","));
-  EXPECT_EQ("ab", JoinStrings({"a", "b"}, ""));
-  EXPECT_EQ("a, bb, c", JoinStrings({"a", "bb", "c"}, ", "));
-  EXPECT_EQ("???", JoinStrings({"?", "?"}, "?"));
-}
-
 TEST(StringUtil, StringPopBackIf)
 {
   std::string abc = "abc";


### PR DESCRIPTION
Following an observation by @AdmiralCurtiss on https://github.com/dolphin-emu/dolphin/pull/11914
[This](https://github.com/dolphin-emu/dolphin/commit/39314ac16264cacf4802c81ae79715700b96951b) [is](https://github.com/dolphin-emu/dolphin/commit/a1563f2defe1cbc96853bc475b5442c610c01417) [not](https://github.com/dolphin-emu/dolphin/commit/403f3693da03f6211a9c04f947f22aed34bdb8a5) [the](https://github.com/dolphin-emu/dolphin/commit/45f2461a530150d0b7b7c0899a927666c80fa203) [first](https://github.com/dolphin-emu/dolphin/commit/aade5841809374730adf2456bf6e3e756a740cff) [time](https://github.com/dolphin-emu/dolphin/commit/bfe0940bbd2720bbf8b0446d106ce096285ae0e7) [fmt::join](https://github.com/dolphin-emu/dolphin/commit/fb79c04cf1aa95ed4c0d55dc840dafb16319f49b) [has](https://github.com/dolphin-emu/dolphin/commit/b246a634d42bc50d5b3ba1c97891e195c37293fe) [been](https://github.com/dolphin-emu/dolphin/commit/2d53b7364363b8d32f62905dbdbff01531ebe06d) [used](https://github.com/dolphin-emu/dolphin/commit/f697e17dd1005eeea172f6a34497cae47bdfc8d6), so it's probably fine.