### PR TITLE
Minor fix: Rename Symbol constructor parameter to prevent shadowing

### DIFF
--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -38,7 +38,7 @@ struct Symbol
   };
 
   Symbol() = default;
-  explicit Symbol(const std::string& name) { Rename(name); }
+  explicit Symbol(const std::string& symbol_name) { Rename(symbol_name); }
 
   void Rename(const std::string& symbol_name);
 


### PR DESCRIPTION
This saves ~25% of warnings on Ubuntu / GCC 11.

```
../Source/Core/Common/SymbolDB.h:41:38: warning: declaration of ‘name’ shadows a member of ‘Common::Symbol’ [-Wshadow]
   41 |   explicit Symbol(const std::string& name) { Rename(name); }
      |                   ~~~~~~~~~~~~~~~~~~~^~~~
../Source/Core/Common/SymbolDB.h:45:15: note: shadowed declaration is here
   45 |   std::string name;
      |               ^~~~
```

```bash
$ git checkout 27db8d4123
$ cmake . -G Ninja -B build/vanilla -DLINUX_LOCAL_DEV=true
$ cmake --build build/vanilla 2>&1 | grep ": warning:" | wc -l
273

$ git checkout 4ef2f2c710
$ cmake . -G Ninja -B build/patch -DLINUX_LOCAL_DEV=true
$ cmake --build build/patch 2>&1 | grep ": warning:" | wc -l
204
```