### PR TITLE
VideoCommon: move cached texture asset to 'CustomAsset' common code

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomAsset.h
+++ b/Source/Core/VideoCommon/Assets/CustomAsset.h
@@ -85,4 +85,18 @@ protected:
   std::shared_ptr<UnderlyingType> m_data;
 };
 
+// A helper struct that contains
+// an asset with a last cached write time
+// This can be used to determine if the asset
+// has diverged from the last known state
+// To know if it is time to update other dependencies
+// based on the asset data
+// TODO C++20: use a 'derived_from' concept against 'CustomAsset' when available
+template <typename AssetType>
+struct CachedAsset
+{
+  std::shared_ptr<AssetType> m_asset;
+  VideoCommon::CustomAssetLibrary::TimeType m_cached_write_time;
+};
+
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -267,7 +267,7 @@ bool TextureCacheBase::DidLinkedAssetsChange(const TCacheEntry& entry)
     return false;
 
   const auto last_asset_write_time = entry.linked_asset.m_asset->GetLastLoadedTime();
-  return last_asset_write_time > entry.linked_asset.m_last_write_time;
+  return last_asset_write_time > entry.linked_asset.m_cached_write_time;
 }
 
 RcTcacheEntry TextureCacheBase::ApplyPaletteToEntry(RcTcacheEntry& entry, const u8* palette,
@@ -1590,7 +1590,7 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
     InvalidateTexture(oldest_entry);
   }
 
-  CachedTextureAsset cached_texture_asset;
+  VideoCommon::CachedAsset<VideoCommon::GameTextureAsset> cached_texture_asset;
   std::shared_ptr<VideoCommon::CustomTextureData> data = nullptr;
   bool has_arbitrary_mipmaps = false;
   std::shared_ptr<HiresTexture> hires_texture;

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -22,6 +22,7 @@
 #include "Common/MathUtil.h"
 
 #include "VideoCommon/AbstractTexture.h"
+#include "VideoCommon/Assets/CustomAsset.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/TextureConfig.h"
 #include "VideoCommon/TextureDecoder.h"
@@ -115,12 +116,6 @@ struct fmt::formatter<EFBCopyParams>
   }
 };
 
-struct CachedTextureAsset
-{
-  std::shared_ptr<VideoCommon::GameTextureAsset> m_asset;
-  std::optional<std::filesystem::file_time_type> m_last_write_time;
-};
-
 struct TCacheEntry
 {
   // common members
@@ -172,7 +167,7 @@ struct TCacheEntry
 
   std::string texture_info_name = "";
 
-  CachedTextureAsset linked_asset;
+  VideoCommon::CachedAsset<VideoCommon::GameTextureAsset> linked_asset;
 
   explicit TCacheEntry(std::unique_ptr<AbstractTexture> tex,
                        std::unique_ptr<AbstractFramebuffer> fb);


### PR DESCRIPTION
(used in a future review)