### PR TITLE
UICommon: Fix localized number

### DIFF
--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -77,13 +77,12 @@ void FileLogger::Log(const DiscIO::Volume& volume, const DiscIO::Partition& part
   if (m_previous_partition == partition && m_previous_file_offset == file_offset)
     return;
 
-  const std::string size_string = Common::ThousandSeparate(file_info->GetSize() / 1000, 7);
+  const std::string size_string = Common::ThousandSeparate(file_info->GetSize() / 1000);
   const std::string path = file_info->GetPath();
-  const std::string log_string = fmt::format("{} kB {}", size_string, path);
   if (IsSoundFile(path))
-    INFO_LOG_FMT(FILEMON, "{}", log_string);
+    INFO_LOG_FMT(FILEMON, "{:>7s} kB {}", size_string, path);
   else
-    WARN_LOG_FMT(FILEMON, "{}", log_string);
+    WARN_LOG_FMT(FILEMON, "{:>7s} kB {}", size_string, path);
 
   // Update the last accessed file
   m_previous_partition = partition;

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -553,7 +553,7 @@ std::string FormatSize(u64 bytes, int decimals)
 
   // Don't need exact values, only 5 most significant digits
   const double unit_size = std::pow(2, unit * 10);
-  return fmt::format("{:.{}Lf} {}", bytes / unit_size, decimals,
+  return fmt::format("{} {}", Common::ThousandSeparate(bytes / unit_size, std::fixed, decimals),
                      Common::GetStringT(unit_symbols[unit]));
 }
 


### PR DESCRIPTION
Diving in the opposite direction of https://github.com/dolphin-emu/dolphin/pull/11971: build upon ThousandSeparate to support floating point types to fix an encoding issue in UICommon::FormatSize.  For the record, this was already broken before my changes in https://github.com/dolphin-emu/dolphin/pull/11972.
Before:
![before](https://github.com/dolphin-emu/dolphin/assets/45425365/0ef362ae-458a-4756-bd4a-710fa496a2c8)
After:
![after](https://github.com/dolphin-emu/dolphin/assets/45425365/67462857-75c7-46d8-9114-5390400781fe)
