### PR TITLE
Core: Remove host thread assert in PauseAndLock().

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -796,7 +796,6 @@ void SaveScreenShot(std::string_view name)
 static bool PauseAndLock(Core::System& system, bool do_lock, bool unpause_on_unlock)
 {
   // WARNING: PauseAndLock is not fully threadsafe so is only valid on the Host Thread
-  ASSERT(IsHostThread());
 
   if (!IsRunningAndStarted())
     return true;


### PR DESCRIPTION
Fixing all the places it's used turned out to be a more complicated task than anticipated. So let's remove this for now so we don't confuse users with cryptic error messages...

(Seriously, I've been trying to fix the Wiimote Scanning Thread to comply with this for multiple days now and I cannot find a good solution for it.)

To be clear, I still think this should be fixed, but it's not great to annoy users with a popup whenever they want to use Wiimotes in the meantime.