### PR TITLE
Jit: Replace "msrBits" with "featureFlags" and use for performance monitor

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -460,6 +460,9 @@ bool CBoot::Load_BS2(Core::System& system, const std::string& boot_rom_filename)
   SetupBAT(system, /*is_wii*/ false);
 
   ppc_state.pc = 0x81200150;
+
+  PowerPC::MSRUpdated(ppc_state);
+
   return true;
 }
 

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -74,6 +74,7 @@ void CBoot::SetupMSR(PowerPC::PowerPCState& ppc_state)
   ppc_state.msr.DR = 1;
   ppc_state.msr.IR = 1;
   ppc_state.msr.FP = 1;
+  PowerPC::MSRUpdated(ppc_state);
 }
 
 void CBoot::SetupHID(PowerPC::PowerPCState& ppc_state, bool is_wii)

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -651,6 +651,8 @@ void FifoPlayer::LoadMemory()
   ppc_state.spr[SPR_DBAT1U] = 0xc0001fff;
   ppc_state.spr[SPR_DBAT1L] = 0x0000002a;
 
+  PowerPC::MSRUpdated(ppc_state);
+
   auto& mmu = system.GetMMU();
   mmu.DBATUpdated();
   mmu.IBATUpdated();

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -84,10 +84,15 @@ bool Load()
   }
 
   auto& power_pc = system.GetPowerPC();
+
   const PowerPC::CoreMode core_mode = power_pc.GetMode();
   power_pc.SetMode(PowerPC::CoreMode::Interpreter);
-  power_pc.GetPPCState().msr.Hex = 0;
-  power_pc.GetPPCState().pc = 0x3400;
+
+  PowerPC::PowerPCState& ppc_state = power_pc.GetPPCState();
+  ppc_state.msr.Hex = 0;
+  ppc_state.pc = 0x3400;
+  PowerPC::MSRUpdated(ppc_state);
+
   NOTICE_LOG_FMT(IOS, "Loaded MIOS and bootstrapped PPC.");
 
   // IOS writes 0 to 0x30f8 before bootstrapping the PPC. Once started, the IPL eventually writes

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -661,6 +661,7 @@ static void WriteRegister()
       break;
     case 65:
       ppc_state.msr.Hex = re32hex(bufptr);
+      PowerPC::MSRUpdated(ppc_state);
       break;
     case 66:
       ppc_state.cr.Set(re32hex(bufptr));

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -761,6 +761,7 @@ static void WriteRegister()
       break;
     case 131:
       ppc_state.spr[SPR_MMCR0] = re32hex(bufptr);
+      PowerPC::MMCRUpdated(ppc_state);
       break;
     case 132:
       ppc_state.spr[SPR_PMC1] = re32hex(bufptr);
@@ -773,6 +774,7 @@ static void WriteRegister()
       break;
     case 135:
       ppc_state.spr[SPR_MMCR1] = re32hex(bufptr);
+      PowerPC::MMCRUpdated(ppc_state);
       break;
     case 136:
       ppc_state.spr[SPR_PMC3] = re32hex(bufptr);

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -930,6 +930,7 @@ enum CPUEmuFeatureFlags : u32
 {
   FEATURE_FLAG_MSR_DR = 1 << 0,
   FEATURE_FLAG_MSR_IR = 1 << 1,
+  FEATURE_FLAG_PERFMON = 1 << 2,
 };
 
 constexpr s32 SignExt16(s16 x)

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -926,6 +926,12 @@ enum
   EXCEPTION_FAKE_MEMCHECK_HIT = 0x00000200,
 };
 
+enum CPUEmuFeatureFlags : u32
+{
+  FEATURE_FLAG_MSR_DR = 1 << 0,
+  FEATURE_FLAG_MSR_IR = 1 << 1,
+};
+
 constexpr s32 SignExt16(s16 x)
 {
   return (s32)x;

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
@@ -134,6 +134,9 @@ void Interpreter::rfi(Interpreter& interpreter, UGeckoInstruction inst)
   // else
   // set NPC to saved offset and resume
   ppc_state.npc = SRR0(ppc_state);
+
+  PowerPC::MSRUpdated(ppc_state);
+
   interpreter.m_end_block = true;
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -181,6 +181,8 @@ void Interpreter::mtmsr(Interpreter& interpreter, UGeckoInstruction inst)
 
   ppc_state.msr.Hex = ppc_state.gpr[inst.RS];
 
+  PowerPC::MSRUpdated(ppc_state);
+
   // FE0/FE1 may have been set
   CheckFPExceptions(ppc_state);
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -491,6 +491,11 @@ void Interpreter::mtspr(Interpreter& interpreter, UGeckoInstruction inst)
     }
     break;
 
+  case SPR_MMCR0:
+  case SPR_MMCR1:
+    MMCRUpdated(ppc_state);
+    break;
+
   case SPR_THRM1:
   case SPR_THRM2:
   case SPR_THRM3:

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -483,8 +483,7 @@ void Jit64::FakeBLCall(u32 after)
 
   // We may need to fake the BLR stack on inlined CALL instructions.
   // Else we can't return to this location any more.
-  MOV(64, R(RSCRATCH2),
-      Imm64(u64(m_ppc_state.msr.Hex & JitBaseBlockCache::JIT_CACHE_MSR_MASK) << 32 | after));
+  MOV(64, R(RSCRATCH2), Imm64(u64(m_ppc_state.feature_flags) << 32 | after));
   PUSH(RSCRATCH2);
   FixupBranch skip_exit = CALL();
   POP(RSCRATCH2);
@@ -497,8 +496,11 @@ void Jit64::EmitUpdateMembase()
   MOV(64, R(RMEM), PPCSTATE(mem_ptr));
 }
 
-void Jit64::EmitStoreMembase(const OpArg& msr, X64Reg scratch_reg)
+void Jit64::MSRUpdated(const OpArg& msr, X64Reg scratch_reg)
 {
+  ASSERT(!msr.IsSimpleReg(scratch_reg));
+
+  // Update mem_ptr
   auto& memory = m_system.GetMemory();
   if (msr.IsImm())
   {
@@ -513,6 +515,26 @@ void Jit64::EmitStoreMembase(const OpArg& msr, X64Reg scratch_reg)
     CMOVcc(64, RMEM, R(scratch_reg), CC_Z);
   }
   MOV(64, PPCSTATE(mem_ptr), R(RMEM));
+
+  // Update feature_flags
+  static_assert(UReg_MSR{}.DR.StartBit() == 4);
+  static_assert(UReg_MSR{}.IR.StartBit() == 5);
+  static_assert(FEATURE_FLAG_MSR_DR == 1 << 0);
+  static_assert(FEATURE_FLAG_MSR_IR == 1 << 1);
+  const u32 other_feature_flags = m_ppc_state.feature_flags & ~0x3;
+  if (msr.IsImm())
+  {
+    MOV(32, PPCSTATE(feature_flags), Imm32(other_feature_flags | ((msr.Imm32() >> 4) & 0x3)));
+  }
+  else
+  {
+    MOV(32, R(scratch_reg), msr);
+    SHR(32, R(scratch_reg), Imm8(4));
+    AND(32, R(scratch_reg), Imm32(0x3));
+    if (other_feature_flags != 0)
+      OR(32, R(scratch_reg), Imm32(other_feature_flags));
+    MOV(32, PPCSTATE(feature_flags), R(scratch_reg));
+  }
 }
 
 void Jit64::WriteExit(u32 destination, bool bl, u32 after)
@@ -524,8 +546,7 @@ void Jit64::WriteExit(u32 destination, bool bl, u32 after)
 
   if (bl)
   {
-    MOV(64, R(RSCRATCH2),
-        Imm64(u64(m_ppc_state.msr.Hex & JitBaseBlockCache::JIT_CACHE_MSR_MASK) << 32 | after));
+    MOV(64, R(RSCRATCH2), Imm64(u64(m_ppc_state.feature_flags) << 32 | after));
     PUSH(RSCRATCH2);
   }
 
@@ -582,8 +603,7 @@ void Jit64::WriteExitDestInRSCRATCH(bool bl, u32 after)
 
   if (bl)
   {
-    MOV(64, R(RSCRATCH2),
-        Imm64(u64(m_ppc_state.msr.Hex & JitBaseBlockCache::JIT_CACHE_MSR_MASK) << 32 | after));
+    MOV(64, R(RSCRATCH2), Imm64(u64(m_ppc_state.feature_flags) << 32 | after));
     PUSH(RSCRATCH2);
   }
 
@@ -611,10 +631,9 @@ void Jit64::WriteBLRExit()
   bool disturbed = Cleanup();
   if (disturbed)
     MOV(32, R(RSCRATCH), PPCSTATE(pc));
-  const u64 msr_bits = m_ppc_state.msr.Hex & JitBaseBlockCache::JIT_CACHE_MSR_MASK;
-  if (msr_bits != 0)
+  if (m_ppc_state.feature_flags != 0)
   {
-    MOV(32, R(RSCRATCH2), Imm32(msr_bits));
+    MOV(32, R(RSCRATCH2), Imm32(m_ppc_state.feature_flags));
     SHL(64, R(RSCRATCH2), Imm8(32));
     OR(64, R(RSCRATCH), R(RSCRATCH2));
   }

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -445,7 +445,7 @@ bool Jit64::Cleanup()
     did_something = true;
   }
 
-  if (MMCR0(m_ppc_state).Hex || MMCR1(m_ppc_state).Hex)
+  if (m_ppc_state.feature_flags & FEATURE_FLAG_PERFMON)
   {
     ABI_PushRegistersAndAdjustStack({}, 0);
     ABI_CallFunctionCCCP(PowerPC::UpdatePerformanceMonitor, js.downcountAmount, js.numLoadStoreInst,

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -337,7 +337,7 @@ void Jit64::FallBackToInterpreter(UGeckoInstruction inst)
   gpr.Flush();
   fpr.Flush();
 
-  if (js.op->opinfo->flags & FL_ENDBLOCK)
+  if (js.op->canEndBlock)
   {
     MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
     MOV(32, PPCSTATE(npc), Imm32(js.compilerPC + 4));
@@ -353,7 +353,7 @@ void Jit64::FallBackToInterpreter(UGeckoInstruction inst)
   gpr.Reset(js.op->regsOut);
   fpr.Reset(js.op->GetFregsOut());
 
-  if (js.op->opinfo->flags & FL_ENDBLOCK)
+  if (js.op->canEndBlock)
   {
     if (js.isLastInstruction)
     {
@@ -445,7 +445,6 @@ bool Jit64::Cleanup()
     did_something = true;
   }
 
-  // SPEED HACK: MMCR0/MMCR1 should be checked at run-time, not at compile time.
   if (MMCR0(m_ppc_state).Hex || MMCR1(m_ppc_state).Hex)
   {
     ABI_PushRegistersAndAdjustStack({}, 0);

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -88,7 +88,7 @@ public:
   // Utilities for use by opcodes
 
   void EmitUpdateMembase();
-  void EmitStoreMembase(const Gen::OpArg& msr, Gen::X64Reg scratch_reg);
+  void MSRUpdated(const Gen::OpArg& msr, Gen::X64Reg scratch_reg);
   void FakeBLCall(u32 after);
   void WriteExit(u32 destination, bool bl = false, u32 after = 0);
   void JustWriteExit(u32 destination, bool bl, u32 after);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -47,6 +47,7 @@ void Jit64::rfi(UGeckoInstruction inst)
 
   gpr.Flush();
   fpr.Flush();
+
   // See Interpreter rfi for details
   const u32 mask = 0x87C0FFFF;
   const u32 clearMSR13 = 0xFFFBFFFF;  // Mask used to clear the bit MSR[13]
@@ -56,7 +57,9 @@ void Jit64::rfi(UGeckoInstruction inst)
   AND(32, R(RSCRATCH), Imm32(mask & clearMSR13));
   OR(32, PPCSTATE(msr), R(RSCRATCH));
 
-  EmitStoreMembase(R(RSCRATCH), RSCRATCH2);
+  // Call MSRUpdated to update feature_flags. Only the bits that come from SRR1
+  // are relevant for this, so it's fine to pass in RSCRATCH in place of msr.
+  MSRUpdated(R(RSCRATCH), RSCRATCH2);
 
   // NPC = SRR0;
   MOV(32, R(RSCRATCH), PPCSTATE_SRR0);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -320,7 +320,7 @@ void Jit64::dcbx(UGeckoInstruction inst)
   FixupBranch bat_lookup_failed;
   MOV(32, R(effective_address), R(addr));
   const u8* loop_start = GetCodePtr();
-  if (m_ppc_state.msr.IR)
+  if (m_ppc_state.feature_flags & FEATURE_FLAG_MSR_IR)
   {
     // Translate effective address to physical address.
     bat_lookup_failed = BATAddressLookup(addr, tmp, m_jit.m_mmu.GetIBATTable().data());
@@ -349,7 +349,7 @@ void Jit64::dcbx(UGeckoInstruction inst)
 
   SwitchToFarCode();
   SetJumpTarget(invalidate_needed);
-  if (m_ppc_state.msr.IR)
+  if (m_ppc_state.feature_flags & FEATURE_FLAG_MSR_IR)
     SetJumpTarget(bat_lookup_failed);
 
   BitSet32 registersInUse = CallerSavedRegistersInUse();
@@ -421,7 +421,7 @@ void Jit64::dcbz(UGeckoInstruction inst)
     end_dcbz_hack = J_CC(CC_L);
   }
 
-  bool emit_fast_path = m_ppc_state.msr.DR && m_jit.jo.fastmem_arena;
+  bool emit_fast_path = (m_ppc_state.feature_flags & FEATURE_FLAG_MSR_DR) && m_jit.jo.fastmem_arena;
 
   if (emit_fast_path)
   {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -23,7 +23,7 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
   JITDISABLE(bJITLoadStorePairedOff);
 
   // For performance, the AsmCommon routines assume address translation is on.
-  FALLBACK_IF(!m_ppc_state.msr.DR);
+  FALLBACK_IF(!(m_ppc_state.feature_flags & FEATURE_FLAG_MSR_DR));
 
   s32 offset = inst.SIMM_12;
   bool indexed = inst.OPCD == 4;
@@ -112,7 +112,7 @@ void Jit64::psq_lXX(UGeckoInstruction inst)
   JITDISABLE(bJITLoadStorePairedOff);
 
   // For performance, the AsmCommon routines assume address translation is on.
-  FALLBACK_IF(!m_ppc_state.msr.DR);
+  FALLBACK_IF(!(m_ppc_state.feature_flags & FEATURE_FLAG_MSR_DR));
 
   s32 offset = inst.SIMM_12;
   bool indexed = inst.OPCD == 4;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -439,7 +439,7 @@ void Jit64::mtmsr(UGeckoInstruction inst)
     RegCache::Realize(Rs);
     MOV(32, PPCSTATE(msr), Rs);
 
-    EmitStoreMembase(Rs, RSCRATCH2);
+    MSRUpdated(Rs, RSCRATCH2);
   }
 
   gpr.Flush();

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -371,7 +371,8 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, 
   }
 
   FixupBranch exit;
-  const bool dr_set = (flags & SAFE_LOADSTORE_DR_ON) || m_jit.m_ppc_state.msr.DR;
+  const bool dr_set =
+      (flags & SAFE_LOADSTORE_DR_ON) || (m_jit.m_ppc_state.feature_flags & FEATURE_FLAG_MSR_DR);
   const bool fast_check_address =
       !force_slow_access && dr_set && m_jit.jo.fastmem_arena && !m_jit.m_ppc_state.m_enable_dcache;
   if (fast_check_address)
@@ -544,7 +545,8 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
   }
 
   FixupBranch exit;
-  const bool dr_set = (flags & SAFE_LOADSTORE_DR_ON) || m_jit.m_ppc_state.msr.DR;
+  const bool dr_set =
+      (flags & SAFE_LOADSTORE_DR_ON) || (m_jit.m_ppc_state.feature_flags & FEATURE_FLAG_MSR_DR);
   const bool fast_check_address =
       !force_slow_access && dr_set && m_jit.jo.fastmem_arena && !m_jit.m_ppc_state.m_enable_dcache;
   if (fast_check_address)

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -187,7 +187,7 @@ void JitArm64::FallBackToInterpreter(UGeckoInstruction inst)
   gpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
   fpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
 
-  if (js.op->opinfo->flags & FL_ENDBLOCK)
+  if (js.op->canEndBlock)
   {
     // also flush the program counter
     ARM64Reg WA = gpr.GetReg();
@@ -207,7 +207,7 @@ void JitArm64::FallBackToInterpreter(UGeckoInstruction inst)
   fpr.ResetRegisters(js.op->GetFregsOut());
   gpr.ResetCRRegisters(js.op->crOut);
 
-  if (js.op->opinfo->flags & FL_ENDBLOCK)
+  if (js.op->canEndBlock)
   {
     if (js.isLastInstruction)
     {
@@ -276,7 +276,6 @@ void JitArm64::Cleanup()
     SetJumpTarget(exit);
   }
 
-  // SPEED HACK: MMCR0/MMCR1 should be checked at run-time, not at compile time.
   if (MMCR0(m_ppc_state).Hex || MMCR1(m_ppc_state).Hex)
   {
     ABI_CallFunction(&PowerPC::UpdatePerformanceMonitor, js.downcountAmount, js.numLoadStoreInst,

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -276,7 +276,7 @@ void JitArm64::Cleanup()
     SetJumpTarget(exit);
   }
 
-  if (MMCR0(m_ppc_state).Hex || MMCR1(m_ppc_state).Hex)
+  if (m_ppc_state.feature_flags & FEATURE_FLAG_PERFMON)
   {
     ABI_CallFunction(&PowerPC::UpdatePerformanceMonitor, js.downcountAmount, js.numLoadStoreInst,
                      js.numFloatingPointInst, &m_ppc_state);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -308,8 +308,8 @@ protected:
   void EndTimeProfile(JitBlock* b);
 
   void EmitUpdateMembase();
-  void EmitStoreMembase(u32 msr);
-  void EmitStoreMembase(const Arm64Gen::ARM64Reg& msr);
+  void MSRUpdated(u32 msr);
+  void MSRUpdated(Arm64Gen::ARM64Reg msr);
 
   // Exits
   void

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -64,11 +64,11 @@ void JitArm64::rfi(UGeckoInstruction inst)
   ORR(WA, WA, WC);                        // rB = Masked MSR OR masked SRR1
 
   STR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(msr));  // STR rB in to rA
+  gpr.Unlock(WB, WC);
 
-  EmitStoreMembase(WA);
+  MSRUpdated(WA);
 
   LDR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_SRR0));
-  gpr.Unlock(WB, WC);
 
   WriteExceptionExit(WA);
   gpr.Unlock(WA);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -727,7 +727,7 @@ void JitArm64::dcbx(UGeckoInstruction inst)
   // Translate effective address to physical address.
   const u8* loop_start = GetCodePtr();
   FixupBranch bat_lookup_failed;
-  if (m_ppc_state.msr.IR)
+  if (m_ppc_state.feature_flags & FEATURE_FLAG_MSR_IR)
   {
     bat_lookup_failed =
         BATAddressLookup(physical_addr, effective_addr, WA, m_mmu.GetIBATTable().data());
@@ -756,7 +756,7 @@ void JitArm64::dcbx(UGeckoInstruction inst)
 
   SwitchToFarCode();
   SetJumpTarget(invalidate_needed);
-  if (m_ppc_state.msr.IR)
+  if (m_ppc_state.feature_flags & FEATURE_FLAG_MSR_IR)
     SetJumpTarget(bat_lookup_failed);
 
   BitSet32 gprs_to_push = gpr.GetCallerSavedUsed();

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -23,7 +23,8 @@ void JitArm64::psq_lXX(UGeckoInstruction inst)
   JITDISABLE(bJITLoadStorePairedOff);
 
   // If fastmem is enabled, the asm routines assume address translation is on.
-  FALLBACK_IF(!js.assumeNoPairedQuantize && jo.fastmem && !m_ppc_state.msr.DR);
+  FALLBACK_IF(!js.assumeNoPairedQuantize && jo.fastmem &&
+              !(m_ppc_state.feature_flags & FEATURE_FLAG_MSR_DR));
 
   // X30 is LR
   // X0 is the address
@@ -153,7 +154,8 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
   JITDISABLE(bJITLoadStorePairedOff);
 
   // If fastmem is enabled, the asm routines assume address translation is on.
-  FALLBACK_IF(!js.assumeNoPairedQuantize && jo.fastmem && !m_ppc_state.msr.DR);
+  FALLBACK_IF(!js.assumeNoPairedQuantize && jo.fastmem &&
+              !(m_ppc_state.feature_flags & FEATURE_FLAG_MSR_DR));
 
   // X30 is LR
   // X0 contains the scale

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -94,12 +94,12 @@ void JitArm64::mtmsr(UGeckoInstruction inst)
 
   const bool imm_value = gpr.IsImm(inst.RS);
   if (imm_value)
-    EmitStoreMembase(gpr.GetImm(inst.RS));
+    MSRUpdated(gpr.GetImm(inst.RS));
 
   STR(IndexType::Unsigned, gpr.R(inst.RS), PPC_REG, PPCSTATE_OFF(msr));
 
   if (!imm_value)
-    EmitStoreMembase(gpr.R(inst.RS));
+    MSRUpdated(gpr.R(inst.RS));
 
   gpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
   fpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -17,6 +17,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Core/HW/Memmap.h"
+#include "Core/PowerPC/Gekko.h"
 
 class JitBase;
 
@@ -33,8 +34,8 @@ struct JitBlockData
   // The normal entry point for the block, returned by Dispatch().
   u8* normalEntry;
 
-  // The MSR bits expected for this block to be valid; see JIT_CACHE_MSR_MASK.
-  u32 msrBits;
+  // The features that this block was compiled with support for.
+  CPUEmuFeatureFlags feature_flags;
   // The effective address (PC) for the beginning of the block.
   u32 effectiveAddress;
   // The physical address of the code represented by this block.
@@ -48,8 +49,8 @@ struct JitBlockData
   // The number of PPC instructions represented by this block. Mostly
   // useful for logging.
   u32 originalSize;
-  // This tracks the position if this block within the fast block cache.
-  // We allow each block to have only one map entry.
+  // This tracks the position of this block within the fast block cache.
+  // We only allow each block to have one map entry.
   size_t fast_block_map_index;
 };
 static_assert(std::is_standard_layout_v<JitBlockData>, "JitBlockData must have a standard layout");
@@ -128,12 +129,8 @@ public:
 class JitBaseBlockCache
 {
 public:
-  // Mask for the MSR bits which determine whether a compiled block
-  // is valid (MSR.IR and MSR.DR, the address translation bits).
-  static constexpr u32 JIT_CACHE_MSR_MASK = 0x30;
-
-  // The value for the map is determined like this:
-  // ((4 GB guest memory space) / (4 bytes per address) * sizeof(JitBlock*)) * (4 for 2 bits of msr)
+  // The size of the fast map is determined like this:
+  // ((4 GiB guest memory space) / (4-byte alignment) * sizeof(JitBlock*)) << (2 feature flag bits)
   static constexpr u64 FAST_BLOCK_MAP_SIZE = 0x8'0000'0000;
   static constexpr u32 FAST_BLOCK_MAP_FALLBACK_ELEMENTS = 0x10000;
   static constexpr u32 FAST_BLOCK_MAP_FALLBACK_MASK = FAST_BLOCK_MAP_FALLBACK_ELEMENTS - 1;
@@ -157,7 +154,7 @@ public:
   // Look for the block in the slow but accurate way.
   // This function shall be used if FastLookupIndexForAddress() failed.
   // This might return nullptr if there is no such block.
-  JitBlock* GetBlockFromStartAddress(u32 em_address, u32 msr);
+  JitBlock* GetBlockFromStartAddress(u32 em_address, CPUEmuFeatureFlags feature_flags);
 
   // Get the normal entry for the block associated with the current program
   // counter. This will JIT code if necessary. (This is the reference
@@ -185,7 +182,7 @@ private:
   void UnlinkBlock(const JitBlock& block);
   void InvalidateICacheInternal(u32 physical_address, u32 address, u32 length, bool forced);
 
-  JitBlock* MoveBlockIntoFastCache(u32 em_address, u32 msr);
+  JitBlock* MoveBlockIntoFastCache(u32 em_address, CPUEmuFeatureFlags feature_flags);
 
   // Fast but risky block lookup based on fast_block_map.
   size_t FastLookupIndexForAddress(u32 address, u32 msr);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -130,8 +130,8 @@ class JitBaseBlockCache
 {
 public:
   // The size of the fast map is determined like this:
-  // ((4 GiB guest memory space) / (4-byte alignment) * sizeof(JitBlock*)) << (2 feature flag bits)
-  static constexpr u64 FAST_BLOCK_MAP_SIZE = 0x8'0000'0000;
+  // ((4 GiB guest memory space) / (4-byte alignment) * sizeof(JitBlock*)) << (3 feature flag bits)
+  static constexpr u64 FAST_BLOCK_MAP_SIZE = 0x10'0000'0000;
   static constexpr u32 FAST_BLOCK_MAP_FALLBACK_ELEMENTS = 0x10000;
   static constexpr u32 FAST_BLOCK_MAP_FALLBACK_MASK = FAST_BLOCK_MAP_FALLBACK_ELEMENTS - 1;
 

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -187,12 +187,14 @@ JitInterface::GetHostCode(u32 address) const
   }
 
   auto& ppc_state = m_system.GetPPCState();
-  JitBlock* block = m_jit->GetBlockCache()->GetBlockFromStartAddress(address, ppc_state.msr.Hex);
+  JitBlock* block =
+      m_jit->GetBlockCache()->GetBlockFromStartAddress(address, ppc_state.feature_flags);
   if (!block)
   {
     for (int i = 0; i < 500; i++)
     {
-      block = m_jit->GetBlockCache()->GetBlockFromStartAddress(address - 4 * i, ppc_state.msr.Hex);
+      block = m_jit->GetBlockCache()->GetBlockFromStartAddress(address - 4 * i,
+                                                               ppc_state.feature_flags);
       if (block)
         break;
     }

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -374,7 +374,7 @@ constexpr std::array<GekkoOPTemplate, 107> s_table31{{
     {210, "mtsr", OpType::System, 1, FL_IN_S | FL_PROGRAMEXCEPTION},
     {242, "mtsrin", OpType::System, 1, FL_IN_SB | FL_PROGRAMEXCEPTION},
     {339, "mfspr", OpType::SPR, 1, FL_OUT_D | FL_PROGRAMEXCEPTION},
-    {467, "mtspr", OpType::SPR, 2, FL_IN_S | FL_PROGRAMEXCEPTION},
+    {467, "mtspr", OpType::SPR, 2, FL_IN_S | FL_ENDBLOCK | FL_PROGRAMEXCEPTION},
     {371, "mftb", OpType::System, 1, FL_OUT_D | FL_TIMER | FL_PROGRAMEXCEPTION},
     {512, "mcrxr", OpType::System, 1, FL_SET_CRn | FL_READ_CA | FL_SET_CA},
     {595, "mfsr", OpType::System, 3, FL_OUT_D | FL_PROGRAMEXCEPTION},

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -137,6 +137,7 @@ void PowerPCManager::DoState(PointerWrap& p)
     }
 
     RoundingModeUpdated(m_ppc_state);
+    MSRUpdated(m_ppc_state);
 
     auto& mmu = m_system.GetMMU();
     mmu.IBATUpdated();
@@ -194,8 +195,6 @@ void PowerPCManager::ResetRegisters()
   }
   m_ppc_state.SetXER({});
 
-  RoundingModeUpdated(m_ppc_state);
-
   auto& mmu = m_system.GetMMU();
   mmu.DBATUpdated();
   mmu.IBATUpdated();
@@ -208,6 +207,9 @@ void PowerPCManager::ResetRegisters()
   m_ppc_state.msr.Hex = 0;
   m_ppc_state.spr[SPR_DEC] = 0xFFFFFFFF;
   SystemTimers::DecrementerSet();
+
+  RoundingModeUpdated(m_ppc_state);
+  MSRUpdated(m_ppc_state);
 }
 
 void PowerPCManager::InitializeCPUCore(CPUCore cpu_core)
@@ -581,15 +583,15 @@ void PowerPCManager::CheckExceptions()
     DEBUG_LOG_FMT(POWERPC, "EXCEPTION_ALIGNMENT");
     m_ppc_state.Exceptions &= ~EXCEPTION_ALIGNMENT;
   }
-
-  // EXTERNAL INTERRUPT
   else
   {
+    // EXTERNAL INTERRUPT
     CheckExternalExceptions();
     return;
   }
 
   m_system.GetJitInterface().UpdateMembase();
+  MSRUpdated(m_ppc_state);
 }
 
 void PowerPCManager::CheckExternalExceptions()
@@ -642,6 +644,7 @@ void PowerPCManager::CheckExternalExceptions()
       ERROR_LOG_FMT(POWERPC, "Unknown EXTERNAL INTERRUPT exception: Exceptions == {:08x}",
                     exceptions);
     }
+    MSRUpdated(m_ppc_state);
   }
 
   m_system.GetJitInterface().UpdateMembase();
@@ -698,6 +701,16 @@ void RoundingModeUpdated(PowerPCState& ppc_state)
   ASSERT(Core::IsCPUThread());
 
   Common::FPU::SetSIMDMode(ppc_state.fpscr.RN, ppc_state.fpscr.NI);
+}
+
+void MSRUpdated(PowerPCState& ppc_state)
+{
+  static_assert(UReg_MSR{}.DR.StartBit() == 4);
+  static_assert(UReg_MSR{}.IR.StartBit() == 5);
+  static_assert(FEATURE_FLAG_MSR_DR == 1 << 0);
+  static_assert(FEATURE_FLAG_MSR_IR == 1 << 1);
+
+  ppc_state.feature_flags = static_cast<CPUEmuFeatureFlags>((ppc_state.msr.Hex >> 4) & 0x3);
 }
 
 void CheckExceptionsFromJIT(PowerPCManager& power_pc)

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -141,6 +141,8 @@ struct PowerPCState
   UReg_MSR msr;      // machine state register
   UReg_FPSCR fpscr;  // floating point flags/status bits
 
+  CPUEmuFeatureFlags feature_flags;
+
   // Exception management.
   u32 Exceptions = 0;
 
@@ -346,5 +348,6 @@ void CheckBreakPointsFromJIT(PowerPCManager& power_pc);
 #define TU(ppc_state) (ppc_state).spr[SPR_TU]
 
 void RoundingModeUpdated(PowerPCState& ppc_state);
+void MSRUpdated(PowerPCState& ppc_state);
 
 }  // namespace PowerPC

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -349,5 +349,7 @@ void CheckBreakPointsFromJIT(PowerPCManager& power_pc);
 
 void RoundingModeUpdated(PowerPCState& ppc_state);
 void MSRUpdated(PowerPCState& ppc_state);
+void MMCRUpdated(PowerPCState& ppc_state);
+void RecalculateAllFeatureFlags(PowerPCState& ppc_state);
 
 }  // namespace PowerPC

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -448,7 +448,10 @@ void RegisterWidget::PopulateTable()
   // MSR
   AddRegister(
       23, 5, RegisterType::msr, "MSR", [this] { return m_system.GetPPCState().msr.Hex; },
-      [this](u64 value) { m_system.GetPPCState().msr.Hex = value; });
+      [this](u64 value) {
+        m_system.GetPPCState().msr.Hex = value;
+        PowerPC::MSRUpdated(m_system.GetPPCState());
+      });
 
   // SRR 0-1
   AddRegister(


### PR DESCRIPTION
By making the JIT cache check if the current state of MMCR0 and MMRC1 matches the state they had at the time the JIT block was compiled, we solve a correctness issue (marked in a comment as a speed hack).

Not known to affect any games.