### PR TITLE
EXI: Remove pointless PauseAndLock functions

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -809,8 +809,6 @@ static bool PauseAndLock(Core::System& system, bool do_lock, bool unpause_on_unl
     was_unpaused = system.GetCPU().PauseAndLock(true);
   }
 
-  system.GetExpansionInterface().PauseAndLock(do_lock, false);
-
   // audio has to come after CPU, because CPU thread can wait for audio thread (m_throttle).
   system.GetDSP().GetDSPEmulator()->PauseAndLock(do_lock, false);
 

--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -169,12 +169,6 @@ void ExpansionInterfaceManager::DoState(PointerWrap& p)
     channel->DoState(p);
 }
 
-void ExpansionInterfaceManager::PauseAndLock(bool doLock, bool unpauseOnUnlock)
-{
-  for (auto& channel : m_channels)
-    channel->PauseAndLock(doLock, unpauseOnUnlock);
-}
-
 void ExpansionInterfaceManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 {
   for (int i = 0; i < MAX_EXI_CHANNELS; ++i)

--- a/Source/Core/Core/HW/EXI/EXI.h
+++ b/Source/Core/Core/HW/EXI/EXI.h
@@ -72,7 +72,6 @@ public:
   void Init(const Sram* override_sram);
   void Shutdown();
   void DoState(PointerWrap& p);
-  void PauseAndLock(bool doLock, bool unpauseOnUnlock);
 
   void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 

--- a/Source/Core/Core/HW/EXI/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.cpp
@@ -286,12 +286,6 @@ void CEXIChannel::DoState(PointerWrap& p)
   }
 }
 
-void CEXIChannel::PauseAndLock(bool do_lock, bool resume_on_unlock)
-{
-  for (auto& device : m_devices)
-    device->PauseAndLock(do_lock, resume_on_unlock);
-}
-
 void CEXIChannel::SetEXIINT(bool exiint)
 {
   m_status.EXIINT = !!exiint;

--- a/Source/Core/Core/HW/EXI/EXI_Channel.h
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.h
@@ -45,7 +45,6 @@ public:
 
   bool IsCausingInterrupt();
   void DoState(PointerWrap& p);
-  void PauseAndLock(bool do_lock, bool resume_on_unlock);
 
   // This should only be used to transition interrupts from SP1 to Channel 2
   void SetEXIINT(bool exiint);

--- a/Source/Core/Core/HW/EXI/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Device.cpp
@@ -89,10 +89,6 @@ void IEXIDevice::DoState(PointerWrap& p)
 {
 }
 
-void IEXIDevice::PauseAndLock(bool do_lock, bool resume_on_unlock)
-{
-}
-
 bool IEXIDevice::IsInterruptSet()
 {
   return false;

--- a/Source/Core/Core/HW/EXI/EXI_Device.h
+++ b/Source/Core/Core/HW/EXI/EXI_Device.h
@@ -64,7 +64,6 @@ public:
   virtual bool IsPresent() const;
   virtual void SetCS(int cs);
   virtual void DoState(PointerWrap& p);
-  virtual void PauseAndLock(bool do_lock, bool resume_on_unlock = true);
 
   // Is generating interrupt ?
   virtual bool IsInterruptSet();


### PR DESCRIPTION
The ExpansionInterfaceManager::PauseAndLock function does nothing but call other functions that have no effect.

ExpansionInterfaceManager::PauseAndLock calls CEXIChannel::PauseAndLock, which in turn calls IEXIDevice::PauseAndLock. None of the classes deriving from IEXIDevice override PauseAndLock, and the implementation in IEXIDevice does nothing.