### PR TITLE
GameSettings: Restore HAT.ini

### DIFF
--- a/Data/Sys/GameSettings/HAF.ini
+++ b/Data/Sys/GameSettings/HAF.ini
@@ -1,4 +1,4 @@
-# HAFx01 - Forecast Channel
+# HAFE01, HAFJ01, HAFP01 - Forecast Channel
 
 [WC24Patch]
 $Main

--- a/Data/Sys/GameSettings/HAT.ini
+++ b/Data/Sys/GameSettings/HAT.ini
@@ -1,0 +1,20 @@
+# HATE01, HATJ01, HATP01 - Nintendo Channel
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video]
+
+[Video_Settings]
+
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/HATE01.ini
+++ b/Data/Sys/GameSettings/HATE01.ini
@@ -1,24 +1,5 @@
 # HATE01 - Nintendo Channel (NTSC-U)
 
-[Core]
-# Values set here will override the main Dolphin settings.
-
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
-[Video]
-
-[Video_Settings]
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-
 [Gecko]
 $SSL Patch [Palapeli]
 2A35AB5C 00003A2F

--- a/Data/Sys/GameSettings/HATJ01.ini
+++ b/Data/Sys/GameSettings/HATJ01.ini
@@ -1,24 +1,5 @@
 # HATJ01 - Nintendo Channel (NTSC-J)
 
-[Core]
-# Values set here will override the main Dolphin settings.
-
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
-[Video]
-
-[Video_Settings]
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-
 [Gecko]
 $SSL Patch [Palapeli]
 2A390014 00003A2F

--- a/Data/Sys/GameSettings/HATP01.ini
+++ b/Data/Sys/GameSettings/HATP01.ini
@@ -1,24 +1,5 @@
 # HATP01 - Nintendo Channel (PAL)
 
-[Core]
-# Values set here will override the main Dolphin settings.
-
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
-[Video]
-
-[Video_Settings]
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-
 [Gecko]
 $SSL Patch [Palapeli]
 2A357D3C 00003A2F


### PR DESCRIPTION
We only use six-character INIs for settings that have to be set on a per-version basis.