### PR TITLE
Video: Fix issues with the window presentation

### DIFF
--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -365,9 +365,34 @@ void* Presenter::GetNewSurfaceHandle()
 
 u32 Presenter::AutoIntegralScale() const
 {
-  // Calculate a scale based on the window size
-  u32 width = EFB_WIDTH * m_target_rectangle.GetWidth() / m_last_xfb_width;
-  u32 height = EFB_HEIGHT * m_target_rectangle.GetHeight() / m_last_xfb_height;
+  const float efb_aspect_ratio = static_cast<float>(EFB_WIDTH) / EFB_HEIGHT;
+  const float target_aspect_ratio =
+      static_cast<float>(m_target_rectangle.GetWidth()) / m_target_rectangle.GetHeight();
+
+  u32 target_width;
+  u32 target_height;
+
+  // Instead of using the entire window (back buffer) resolution,
+  // find the portion of it that will actually contain the EFB output,
+  // and ignore the portion that will likely have black bars.
+  if (target_aspect_ratio >= efb_aspect_ratio)
+  {
+    target_height = m_target_rectangle.GetHeight();
+    target_width = static_cast<u32>(
+        std::round((static_cast<float>(m_target_rectangle.GetWidth()) / target_aspect_ratio) *
+                   efb_aspect_ratio));
+  }
+  else
+  {
+    target_width = m_target_rectangle.GetWidth();
+    target_height = static_cast<u32>(
+        std::round((static_cast<float>(m_target_rectangle.GetHeight()) * target_aspect_ratio) /
+                   efb_aspect_ratio));
+  }
+
+  // Calculate a scale based on the adjusted window size
+  u32 width = EFB_WIDTH * target_width / m_last_xfb_width;
+  u32 height = EFB_HEIGHT * target_height / m_last_xfb_height;
   return std::max((width - 1) / EFB_WIDTH + 1, (height - 1) / EFB_HEIGHT + 1);
 }
 

--- a/Source/Core/VideoCommon/Present.h
+++ b/Source/Core/VideoCommon/Present.h
@@ -58,7 +58,7 @@ public:
 
   void UpdateDrawRectangle();
 
-  float CalculateDrawAspectRatio() const;
+  float CalculateDrawAspectRatio(bool allow_stretch = true) const;
 
   // Crops the target rectangle to the framebuffer dimensions, reducing the size of the source
   // rectangle if it is greater. Works even if the source and target rectangles don't have a
@@ -103,9 +103,12 @@ private:
 
   void ProcessFrameDumping(u64 ticks) const;
 
-  std::tuple<int, int> CalculateOutputDimensions(int width, int height) const;
-  std::tuple<float, float> ApplyStandardAspectCrop(float width, float height) const;
-  std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height) const;
+  std::tuple<int, int> CalculateOutputDimensions(int width, int height,
+                                                 bool allow_stretch = true) const;
+  std::tuple<float, float> ApplyStandardAspectCrop(float width, float height,
+                                                   bool allow_stretch = true) const;
+  std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height,
+                                                     bool allow_stretch = true) const;
 
   // Use this to convert a single target rectangle to two stereo rectangles
   std::tuple<MathUtil::Rectangle<int>, MathUtil::Rectangle<int>>


### PR DESCRIPTION
- There was always a black line around one of the 4 edges (top/left/bottom/right) of the window because the final output size wasn't calculated right (unless the aspect ratio was set to stretch)
- The `Auto-Adjust Window Size` setting was calculating the window size based on the resolution of the window in the previous frame if we used the "stretch" aspect ratio setting, so it's result would be self influence in a loop and behave unreliably (e.g. when changing resolution between Auto/Native/2x the automatic window scaling would behave randomly)
- The `Auto` internal resolution scaling wasn't working correctly if the window weird aspect ratios (e.g. 32:9), beacuse it would account for the the portion of the image that will show black bars into the calcuations to find the best matching resolution
- The `% 4` that was done on the rendering resolution was only meant to be done when recording videos (due to encoding limitations) but one case was missed (this had no consequences really, as it was just in the code that automatically resizes the window). The hardcoded `4` has been replaced with `VIDEO_ENCODER_LCM` for clarity.

Proof that there was always one black line around the edges of the window (right and bottom):
![Dolphin_LS909ueNW8](https://github.com/dolphin-emu/dolphin/assets/7011366/bae8ba75-0246-4dea-84c9-9b709f978642)
![Dolphin_ExIjNE7sxu](https://github.com/dolphin-emu/dolphin/assets/7011366/2c45de15-c2c9-4027-bce0-02affd0fdc4d)
because the resolution/aspect ratio correction code wasn't rounding correctly.