### PR TITLE
Qt: Fix some Post Process Configuration Widget issues #3-4

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
@@ -279,7 +279,7 @@ u32 PostProcessingConfigWindow::ConfigGroup::AddInteger(PostProcessingConfigWind
         std::ceil(range / static_cast<double>(m_config_option->m_integer_step_values[i]));
     const int current_value = std::round(
         (m_config_option->m_integer_values[i] - m_config_option->m_integer_min_values[i]) /
-        static_cast<double>(m_config_option->m_integer_max_values[i]));
+        static_cast<double>(m_config_option->m_integer_step_values[i]));
 
     auto* const slider = new QSlider(Qt::Orientation::Horizontal);
     slider->setMinimum(0);
@@ -289,7 +289,7 @@ u32 PostProcessingConfigWindow::ConfigGroup::AddInteger(PostProcessingConfigWind
     QObject::connect(slider, &QSlider::valueChanged,
                      [this, parent](int value) { parent->UpdateInteger(this, value); });
 
-    auto* const value_box = new QLineEdit(QString::number(current_value));
+    auto* const value_box = new QLineEdit(QString::number(m_config_option->m_integer_values[i]));
     value_box->setEnabled(false);
 
     grid->addWidget(slider, row, 1);


### PR DESCRIPTION
1 ) When first opened, the (user selected) post process shader config widget would print the wrong values on the text label next to int range sliders. For example if the range was from 1 to 6, and the value loaded from the config was 1, the label would print 0 when first opened, to then start showing the correct value once the slider was first moved.

This mirrors the behaviour of the float slider code below:
```auto* const value_box = new QLineEdit(QString::asprintf("%f", m_config_option->m_float_values[i]));```

2 ) The defautl int slider value would also be set wrong on first load, as it was being divided by the slider max instead of the slider step amount (again, just like for the float implementation). This is a mistake I had made with my previous submission.