### PR TITLE
Add AutoHDR post process shader

### DIFF
--- a/Data/Sys/Shaders/AutoHDR.glsl
+++ b/Data/Sys/Shaders/AutoHDR.glsl
@@ -1,0 +1,64 @@
+// Based on https://github.com/Filoppi/PumboAutoHDR
+
+/*
+[configuration]
+
+[OptionRangeFloat]
+GUIName = HDR Display Max Nits
+OptionName = HDR_DISPLAY_MAX_NITS
+MinValue = 80
+MaxValue = 2000
+StepAmount = 1
+DefaultValue = 400
+
+[OptionRangeFloat]
+GUIName = Shoulder Start Alpha
+OptionName = AUTO_HDR_SHOULDER_START_ALPHA
+MinValue = 0
+MaxValue = 1
+StepAmount = 0.01
+DefaultValue = 0
+
+[OptionRangeFloat]
+GUIName = Shoulder Pow
+OptionName = AUTO_HDR_SHOULDER_POW
+MinValue = 1
+MaxValue = 10
+StepAmount = 0.05
+DefaultValue = 2.5
+
+[/configuration]
+*/
+
+void main()
+{
+	float4 color = Sample();
+
+	// Nothing to do here, we are in SDR
+	if (!OptionEnabled(hdr_output) || !OptionEnabled(linear_space_output))
+	{
+		SetOutput(color);
+		return;
+	}
+
+	const float hdr_paper_white = hdr_paper_white_nits / hdr_sdr_white_nits;
+
+	// Restore the original SDR (0-1) brightness (we might or might not restore it later)
+	color.rgb /= hdr_paper_white;
+
+	// Find the color average
+	float sdr_ratio = (color.r + color.g + color.b) / 3.0;
+
+	const float auto_hdr_max_white = max(HDR_DISPLAY_MAX_NITS / (hdr_paper_white_nits / hdr_sdr_white_nits), hdr_sdr_white_nits) / hdr_sdr_white_nits;
+	if (sdr_ratio > AUTO_HDR_SHOULDER_START_ALPHA && AUTO_HDR_SHOULDER_START_ALPHA < 1.0)
+	{
+		const float auto_hdr_shoulder_ratio = 1.0 - (max(1.0 - sdr_ratio, 0.0) / (1.0 - AUTO_HDR_SHOULDER_START_ALPHA));
+		const float auto_hdr_extra_ratio = pow(auto_hdr_shoulder_ratio, AUTO_HDR_SHOULDER_POW) * (auto_hdr_max_white - 1.0);
+		const float auto_hdr_total_ratio = sdr_ratio + auto_hdr_extra_ratio;
+		color.rgb *= auto_hdr_total_ratio / sdr_ratio;
+	}
+
+	color.rgb *= hdr_paper_white;
+
+	SetOutput(color);
+}

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -117,7 +117,7 @@ static constexpr float GFX_CC_DISPLAY_GAMMA_MIN = 2.2f;
 static constexpr float GFX_CC_DISPLAY_GAMMA_MAX = 2.4f;
 
 static constexpr float GFX_CC_HDR_PAPER_WHITE_NITS_MIN = 80.f;
-static constexpr float GFX_CC_HDR_PAPER_WHITE_NITS_MAX = 400.f;
+static constexpr float GFX_CC_HDR_PAPER_WHITE_NITS_MAX = 500.f;
 
 extern const Info<bool> GFX_CC_CORRECT_COLOR_SPACE;
 extern const Info<ColorCorrectionRegion> GFX_CC_GAME_COLOR_SPACE;


### PR DESCRIPTION
Follow up to:
https://github.com/dolphin-emu/dolphin/pull/11850

This is based on my AutoHDR ReShade shader (https://github.com/Filoppi/PumboAutoHDR/tree/master), which has been developed as an alternative to SpecialK HDR and Windows 11 HDR. For the purpose of Dolphin, I simplified it a lot and only kept the most popular AutoHDR algorithm.

Screenshots are HDR (you can't see the difference in SDR screenshots):
[AutoHDR comaprison 1.zip](https://github.com/dolphin-emu/dolphin/files/11888114/AutoHDR.comaprison.1.zip)
[AutoHDR comaprison 2.zip](https://github.com/dolphin-emu/dolphin/files/11888117/AutoHDR.comaprison.2.zip)
[AutoHDR comaprison 3.zip](https://github.com/dolphin-emu/dolphin/files/11888118/AutoHDR.comaprison.3.zip)

I wouldn't say it's mind blowing, it's not magic, but if you have a good HDR screen and want to take advantage of its increased brightness and dynamic range, this is a decent way of doing it.
The shader aims to keep the original look of the image, and exclusively "boost" the highlights.
Each game will likely need different settings to look great (e.g. many Nintendo games are super bright so they don't work well with AutoHDR, unless it's set to have a very light effect).