### PR TITLE
Common: Better AlignUp implementation

### DIFF
--- a/Source/Core/Common/Align.h
+++ b/Source/Core/Common/Align.h
@@ -7,18 +7,19 @@
 
 namespace Common
 {
-template <typename T>
-constexpr T AlignUp(T value, size_t size)
-{
-  static_assert(std::is_unsigned<T>(), "T must be an unsigned value.");
-  return static_cast<T>(value + (size - value % size) % size);
-}
 
 template <typename T>
 constexpr T AlignDown(T value, size_t size)
 {
   static_assert(std::is_unsigned<T>(), "T must be an unsigned value.");
   return static_cast<T>(value - value % size);
+}
+
+template <typename T>
+constexpr T AlignUp(T value, size_t size)
+{
+  static_assert(std::is_unsigned<T>(), "T must be an unsigned value.");
+  return AlignDown<T>(static_cast<T>(value + (size - 1)), size);
 }
 
 }  // namespace Common


### PR DESCRIPTION
Small optimization to `AlignUp`, [optimizers did not like the old one](https://gcc.godbolt.org/z/e3YxhreMd)
Saves ~1 instruction, except on clang where it saves ~4 instructions