### PR TITLE
Fix GC Adapter breaking and burning a full CPU core after sleep-wake on Linux

### DIFF
--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -198,12 +198,11 @@ void GamecubeControllersWidget::SaveSettings()
                                                                       static_cast<s32>(i));
       }
     }
-
-    if (GCAdapter::UseAdapter())
-      GCAdapter::StartScanThread();
-    else
-      GCAdapter::StopScanThread();
   }
+  if (GCAdapter::UseAdapter())
+    GCAdapter::StartScanThread();
+  else
+    GCAdapter::StopScanThread();
 
   SConfig::GetInstance().SaveSettings();
 }

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -636,6 +636,7 @@ static void AddGCAdapter(libusb_device* device)
       }
     }
   }
+  libusb_free_config_descriptor(config);
 
   int size = 0;
   std::array<u8, CONTROLER_OUTPUT_INIT_PAYLOAD_SIZE> payload = {0x13};

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -211,6 +211,10 @@ static void ReadThreadFunc()
       ERROR_LOG_FMT(CONTROLLERINTERFACE, "Read: libusb_interrupt_transfer failed: {}",
                     LibusbUtils::ErrorWrap(error));
     }
+    if (error == LIBUSB_ERROR_IO)
+    {
+      break;
+    }
 
     ProcessInputPayload(input_buffer.data(), payload_size);
 

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -218,10 +218,9 @@ static void ReadThreadFunc()
       error = libusb_reset_device(s_handle);
       ERROR_LOG_FMT(CONTROLLERINTERFACE, "Read: libusb_reset_device: {}",
                     LibusbUtils::ErrorWrap(error));
-      if (error != 0)
-      {
-        break;
-      }
+
+      // If error is nonzero, try fixing it next loop iteration. We can't easily return
+      // and cleanup program state without getting another thread to call Reset().
     }
 
     ProcessInputPayload(input_buffer.data(), payload_size);


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/13284

After sleep-wake on Linux, talking to the GC USB adapter fails with `LIBUSB_ERROR_IO` because the kernel driver regains ownership over the adapter device. Previously Dolphin would continually try talking to the adapter in an infinite loop, burning a full CPU core and failing to receive new input from the adapter.

The minimal solution is to `libusb_detach_kernel_driver()` the adapter again, but I've been told that the best approach to handling `LIBUSB_ERROR_IO` is to instead call `libusb_reset_device` and reinitialize the device. This PR calls `libusb_reset_device` when the system sleep-wakes and talking to the GC adapter returns `LIBUSB_ERROR_IO`.

- [x] In "Fix memory leak in libusb code", should we instead use `MakeConfigDescriptor()` which wraps the error code and descriptor in an RAII handle?
- [ ] Should I reset the device on some/all other errors besides `LIBUSB_ERROR_IO`? I have not found any other ways to trigger an endless CPU-burning loop, but it may be a good idea to do so defensively.

Another bug I found:

- If you launch Dolphin with all GC controllers set to not Adapter, then pick Adapter, Dolphin fails to detect the adapter until you switch away and back. This does not happen if you launch Dolphin with GC Adapter already set.
	- If you enable logs, for whatever reason, "GC Adapter scanning thread started" only starts once you switch *away* from the GC Adapter as Controller 1. This is not related to the code I touched in this PR, and I could investigate or fix it here or defer it to a later PR.
