### PR TITLE
Add Bloom Definitions for Skylanders: Spyro's Adventure

### DIFF
--- a/Data/Sys/Load/GraphicMods/Skylanders Spyro's Adventure/metadata.json
+++ b/Data/Sys/Load/GraphicMods/Skylanders Spyro's Adventure/metadata.json
@@ -1,0 +1,19 @@
+{
+	"meta":
+	{
+		"title": "Bloom Texture Definitions",
+		"author": "SuperSamus"
+	},
+	"groups":
+	[
+		{
+			"name": "Bloom",
+			"targets": [
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000008_80x57_6"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
With all these Portal additions, this was kinda missing...
Tested on the American version of the game (SSPE52).

Before (6x resolution)
![SSPE52_2023-06-30_21-56-42](https://github.com/dolphin-emu/dolphin/assets/40663462/f0bd5f4d-5c41-440b-b5f6-73f6b5952d2f)

Native resolution bloom
![SSPE52_2023-06-30_21-56-53](https://github.com/dolphin-emu/dolphin/assets/40663462/66adbb49-2984-484b-9e6f-8954e0cf5699)

Bloom removal
![SSPE52_2023-06-30_22-04-34](https://github.com/dolphin-emu/dolphin/assets/40663462/9dbeb22b-f4b0-480b-aaec-51ace63c66a6)
