### PR TITLE
VideoCommon: call into graphics mods create texture callback

### DIFF
--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionData.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionData.h
@@ -4,9 +4,11 @@
 #pragma once
 
 #include <string_view>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/Matrix.h"
+#include "VideoCommon/Assets/TextureAsset.h"
 
 namespace GraphicsModActionData
 {
@@ -34,5 +36,12 @@ struct TextureLoad
 };
 struct TextureCreate
 {
+  std::string_view texture_name;
+  u32 texture_width;
+  u32 texture_height;
+  std::vector<VideoCommon::CachedAsset<VideoCommon::GameTextureAsset>>* custom_textures;
+
+  // Dependencies needed to reload the texture and trigger this create again
+  std::vector<VideoCommon::CachedAsset<VideoCommon::CustomAsset>>* additional_dependencies;
 };
 }  // namespace GraphicsModActionData

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -168,6 +168,7 @@ struct TCacheEntry
   std::string texture_info_name = "";
 
   std::vector<VideoCommon::CachedAsset<VideoCommon::GameTextureAsset>> linked_game_texture_assets;
+  std::vector<VideoCommon::CachedAsset<VideoCommon::CustomAsset>> linked_asset_dependencies;
 
   explicit TCacheEntry(std::unique_ptr<AbstractTexture> tex,
                        std::unique_ptr<AbstractFramebuffer> fb);


### PR DESCRIPTION
Previously, we defined our graphics mod callback for texture creates.  Now we can call into it.

A texture create is passed the texture name and the texture width/height as input.  As output it provides a list of additional textures to load and an additional list of dependencies that might influence that list of textures  (ex: a config file that says how many textures to load).