### PR TITLE
VideoCommon: don't do pointer copies during graphics mod callback iteration

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1322,7 +1322,7 @@ TCacheEntry* TextureCacheBase::LoadImpl(const TextureInfo& texture_info, bool fo
     entry->texture_info_name = texture_info.CalculateTextureName().GetFullName();
 
     GraphicsModActionData::TextureLoad texture_load{entry->texture_info_name};
-    for (const auto action :
+    for (const auto& action :
          g_graphics_mod_manager->GetTextureLoadActions(entry->texture_info_name))
     {
       action->OnTextureLoad(&texture_load);
@@ -2274,7 +2274,7 @@ void TextureCacheBase::CopyRenderTargetToTexture(
     info.m_texture_format = baseFormat;
     if (is_xfb_copy)
     {
-      for (const auto action : g_graphics_mod_manager->GetXFBActions(info))
+      for (const auto& action : g_graphics_mod_manager->GetXFBActions(info))
       {
         action->OnXFB();
       }
@@ -2283,7 +2283,7 @@ void TextureCacheBase::CopyRenderTargetToTexture(
     {
       bool skip = false;
       GraphicsModActionData::EFB efb{tex_w, tex_h, &skip, &scaled_tex_w, &scaled_tex_h};
-      for (const auto action : g_graphics_mod_manager->GetEFBActions(info))
+      for (const auto& action : g_graphics_mod_manager->GetEFBActions(info))
       {
         action->OnEFB(&efb);
       }

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -566,7 +566,7 @@ void VertexManagerBase::Flush()
     {
       bool skip = false;
       GraphicsModActionData::DrawStarted draw_started{&skip};
-      for (const auto action : g_graphics_mod_manager->GetDrawStartedActions(texture_name))
+      for (const auto& action : g_graphics_mod_manager->GetDrawStartedActions(texture_name))
       {
         action->OnDrawStarted(&draw_started);
       }

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -406,14 +406,14 @@ void VertexShaderManager::SetConstants(const std::vector<std::string>& textures)
   std::vector<GraphicsModAction*> projection_actions;
   if (g_ActiveConfig.bGraphicMods)
   {
-    for (const auto action : g_graphics_mod_manager->GetProjectionActions(xfmem.projection.type))
+    for (const auto& action : g_graphics_mod_manager->GetProjectionActions(xfmem.projection.type))
     {
       projection_actions.push_back(action);
     }
 
     for (const auto& texture : textures)
     {
-      for (const auto action :
+      for (const auto& action :
            g_graphics_mod_manager->GetProjectionTextureActions(xfmem.projection.type, texture))
       {
         projection_actions.push_back(action);
@@ -430,7 +430,7 @@ void VertexShaderManager::SetConstants(const std::vector<std::string>& textures)
     auto corrected_matrix = LoadProjectionMatrix();
 
     GraphicsModActionData::Projection projection{&corrected_matrix};
-    for (auto action : projection_actions)
+    for (const auto& action : projection_actions)
     {
       action->OnProjection(&projection);
     }


### PR DESCRIPTION
Noticed this when looking over my texture create callback.  The graphics mod iteration was actually copying each action.  Granted just a pointer so probably negligible but still worth fixing I think!