### PR TITLE
VideoCommon: add material asset

### DIFF
--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -637,6 +637,7 @@
     <ClInclude Include="VideoCommon\Assets\CustomAssetLoader.h" />
     <ClInclude Include="VideoCommon\Assets\CustomTextureData.h" />
     <ClInclude Include="VideoCommon\Assets\DirectFilesystemAssetLibrary.h" />
+    <ClInclude Include="VideoCommon\Assets\MaterialAsset.h" />
     <ClInclude Include="VideoCommon\Assets\ShaderAsset.h" />
     <ClInclude Include="VideoCommon\Assets\TextureAsset.h" />
     <ClInclude Include="VideoCommon\AsyncRequests.h" />
@@ -1253,6 +1254,7 @@
     <ClCompile Include="VideoCommon\Assets\CustomAssetLoader.cpp" />
     <ClCompile Include="VideoCommon\Assets\CustomTextureData.cpp" />
     <ClCompile Include="VideoCommon\Assets\DirectFilesystemAssetLibrary.cpp" />
+    <ClCompile Include="VideoCommon\Assets\MaterialAsset.cpp" />
     <ClCompile Include="VideoCommon\Assets\ShaderAsset.cpp" />
     <ClCompile Include="VideoCommon\Assets\TextureAsset.cpp" />
     <ClCompile Include="VideoCommon\AsyncRequests.cpp" />

--- a/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
@@ -11,6 +11,7 @@
 namespace VideoCommon
 {
 class CustomTextureData;
+struct MaterialData;
 struct PixelShaderData;
 
 // This class provides functionality to load
@@ -49,5 +50,8 @@ public:
 
   // Loads a pixel shader
   virtual LoadInfo LoadPixelShader(const AssetID& asset_id, PixelShaderData* data) = 0;
+
+  // Loads a material
+  virtual LoadInfo LoadMaterial(const AssetID& asset_id, MaterialData* data) = 0;
 };
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
@@ -97,4 +97,11 @@ CustomAssetLoader::LoadPixelShader(const CustomAssetLibrary::AssetID& asset_id,
 {
   return LoadOrCreateAsset<PixelShaderAsset>(asset_id, m_pixel_shaders, std::move(library));
 }
+
+std::shared_ptr<MaterialAsset>
+CustomAssetLoader::LoadMaterial(const CustomAssetLibrary::AssetID& asset_id,
+                                std::shared_ptr<CustomAssetLibrary> library)
+{
+  return LoadOrCreateAsset<MaterialAsset>(asset_id, m_materials, std::move(library));
+}
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/Assets/CustomAssetLoader.h
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLoader.h
@@ -12,6 +12,7 @@
 #include "Common/Flag.h"
 #include "Common/WorkQueueThread.h"
 #include "VideoCommon/Assets/CustomAsset.h"
+#include "VideoCommon/Assets/MaterialAsset.h"
 #include "VideoCommon/Assets/ShaderAsset.h"
 #include "VideoCommon/Assets/TextureAsset.h"
 
@@ -46,6 +47,9 @@ public:
   std::shared_ptr<PixelShaderAsset> LoadPixelShader(const CustomAssetLibrary::AssetID& asset_id,
                                                     std::shared_ptr<CustomAssetLibrary> library);
 
+  std::shared_ptr<MaterialAsset> LoadMaterial(const CustomAssetLibrary::AssetID& asset_id,
+                                              std::shared_ptr<CustomAssetLibrary> library);
+
 private:
   // TODO C++20: use a 'derived_from' concept against 'CustomAsset' when available
   template <typename AssetType>
@@ -79,6 +83,7 @@ private:
   std::map<CustomAssetLibrary::AssetID, std::weak_ptr<RawTextureAsset>> m_textures;
   std::map<CustomAssetLibrary::AssetID, std::weak_ptr<GameTextureAsset>> m_game_textures;
   std::map<CustomAssetLibrary::AssetID, std::weak_ptr<PixelShaderAsset>> m_pixel_shaders;
+  std::map<CustomAssetLibrary::AssetID, std::weak_ptr<MaterialAsset>> m_materials;
   std::thread m_asset_monitor_thread;
   Common::Flag m_asset_monitor_thread_shutdown;
 

--- a/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.h
+++ b/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.h
@@ -23,6 +23,7 @@ public:
 
   LoadInfo LoadTexture(const AssetID& asset_id, CustomTextureData* data) override;
   LoadInfo LoadPixelShader(const AssetID& asset_id, PixelShaderData* data) override;
+  LoadInfo LoadMaterial(const AssetID& asset_id, MaterialData* data) override;
 
   // Gets the latest time from amongst all the files in the asset map
   TimeType GetLastAssetWriteTime(const AssetID& asset_id) const override;

--- a/Source/Core/VideoCommon/Assets/MaterialAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/MaterialAsset.cpp
@@ -1,0 +1,166 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "VideoCommon/Assets/MaterialAsset.h"
+
+#include <vector>
+
+#include "Common/Logging/Log.h"
+#include "Common/StringUtil.h"
+#include "VideoCommon/Assets/CustomAssetLibrary.h"
+
+namespace VideoCommon
+{
+namespace
+{
+bool ParsePropertyValue(const CustomAssetLibrary::AssetID& asset_id, MaterialProperty::Type type,
+                        const picojson::value& json_value,
+                        std::optional<MaterialProperty::Value>* value)
+{
+  switch (type)
+  {
+  case MaterialProperty::Type::Type_TextureAsset:
+  {
+    if (json_value.is<std::string>())
+    {
+      *value = json_value.to_str();
+      return true;
+    }
+  }
+  break;
+  };
+
+  ERROR_LOG_FMT(VIDEO, "Asset '{}' failed to parse the json, value is not valid for type '{}'",
+                asset_id, type);
+  return false;
+}
+
+bool ParseMaterialProperties(const CustomAssetLibrary::AssetID& asset_id,
+                             const picojson::array& values_data,
+                             std::vector<MaterialProperty>* material_property)
+{
+  for (const auto& value_data : values_data)
+  {
+    VideoCommon::MaterialProperty property;
+    if (!value_data.is<picojson::object>())
+    {
+      ERROR_LOG_FMT(VIDEO, "Asset '{}' failed to parse the json, value is not the right json type",
+                    asset_id);
+      return false;
+    }
+    const auto& value_data_obj = value_data.get<picojson::object>();
+
+    const auto type_iter = value_data_obj.find("type");
+    if (type_iter == value_data_obj.end())
+    {
+      ERROR_LOG_FMT(VIDEO, "Asset '{}' failed to parse the json, value entry 'type' not found",
+                    asset_id);
+      return false;
+    }
+    if (!type_iter->second.is<std::string>())
+    {
+      ERROR_LOG_FMT(VIDEO,
+                    "Asset '{}' failed to parse the json, value entry 'type' is not "
+                    "the right json type",
+                    asset_id);
+      return false;
+    }
+    std::string type = type_iter->second.to_str();
+    Common::ToLower(&type);
+    if (type == "texture_asset")
+    {
+      property.m_type = MaterialProperty::Type::Type_TextureAsset;
+    }
+    else
+    {
+      ERROR_LOG_FMT(VIDEO,
+                    "Asset '{}' failed to parse the json, value entry 'type' is "
+                    "an invalid option",
+                    asset_id);
+      return false;
+    }
+
+    const auto code_name_iter = value_data_obj.find("code_name");
+    if (code_name_iter == value_data_obj.end())
+    {
+      ERROR_LOG_FMT(VIDEO,
+                    "Asset '{}' failed to parse the json, value entry "
+                    "'code_name' not found",
+                    asset_id);
+      return false;
+    }
+    if (!code_name_iter->second.is<std::string>())
+    {
+      ERROR_LOG_FMT(VIDEO,
+                    "Asset '{}' failed to parse the json, value entry 'code_name' is not "
+                    "the right json type",
+                    asset_id);
+      return false;
+    }
+    property.m_code_name = code_name_iter->second.to_str();
+
+    const auto value_iter = value_data_obj.find("value");
+    if (value_iter != value_data_obj.end())
+    {
+      if (!ParsePropertyValue(asset_id, property.m_type, value_iter->second, &property.m_value))
+        return false;
+    }
+
+    material_property->push_back(std::move(property));
+  }
+
+  return true;
+}
+}  // namespace
+bool MaterialData::FromJson(const CustomAssetLibrary::AssetID& asset_id,
+                            const picojson::object& json, MaterialData* data)
+{
+  const auto values_iter = json.find("values");
+  if (values_iter == json.end())
+  {
+    ERROR_LOG_FMT(VIDEO, "Asset '{}' failed to parse json, 'values' not found", asset_id);
+    return false;
+  }
+  if (!values_iter->second.is<picojson::array>())
+  {
+    ERROR_LOG_FMT(VIDEO, "Asset '{}' failed to parse json, 'values' is not the right json type",
+                  asset_id);
+    return false;
+  }
+  const auto& values_array = values_iter->second.get<picojson::array>();
+
+  if (!ParseMaterialProperties(asset_id, values_array, &data->properties))
+    return false;
+
+  const auto shader_asset_iter = json.find("shader_asset");
+  if (shader_asset_iter == json.end())
+  {
+    ERROR_LOG_FMT(VIDEO, "Asset '{}' failed to parse json, 'shader_asset' not found", asset_id);
+    return false;
+  }
+  if (!shader_asset_iter->second.is<std::string>())
+  {
+    ERROR_LOG_FMT(VIDEO,
+                  "Asset '{}' failed to parse json, 'shader_asset' is not the right json type",
+                  asset_id);
+    return false;
+  }
+  data->shader_asset = shader_asset_iter->second.to_str();
+
+  return true;
+}
+
+CustomAssetLibrary::LoadInfo MaterialAsset::LoadImpl(const CustomAssetLibrary::AssetID& asset_id)
+{
+  auto potential_data = std::make_shared<MaterialData>();
+  const auto loaded_info = m_owning_library->LoadMaterial(asset_id, potential_data.get());
+  if (loaded_info.m_bytes_loaded == 0)
+    return {};
+  {
+    std::lock_guard lk(m_data_lock);
+    m_loaded = true;
+    m_data = std::move(potential_data);
+  }
+  return loaded_info;
+}
+}  // namespace VideoCommon

--- a/Source/Core/VideoCommon/Assets/MaterialAsset.h
+++ b/Source/Core/VideoCommon/Assets/MaterialAsset.h
@@ -1,0 +1,61 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <picojson.h>
+
+#include "Common/CommonTypes.h"
+#include "Common/EnumFormatter.h"
+#include "VideoCommon/Assets/CustomAsset.h"
+
+namespace VideoCommon
+{
+struct MaterialProperty
+{
+  using Value = std::variant<std::string>;
+  enum class Type
+  {
+    Type_Undefined,
+    Type_TextureAsset,
+    Type_Max = Type_TextureAsset
+  };
+  std::string m_code_name;
+  Type m_type = Type::Type_Undefined;
+  std::optional<Value> m_value;
+};
+
+struct MaterialData
+{
+  static bool FromJson(const CustomAssetLibrary::AssetID& asset_id, const picojson::object& json,
+                       MaterialData* data);
+  std::string shader_asset;
+  std::vector<MaterialProperty> properties;
+};
+
+// Much like Unity and Unreal materials, a Dolphin material does very little on its own
+// Its sole purpose is to provide data (through properties) that are used in conjunction
+// with a shader asset that is provided by name.  It is up to user of this asset to
+// use the two together to create the relevant runtime data
+class MaterialAsset final : public CustomLoadableAsset<MaterialData>
+{
+public:
+  using CustomLoadableAsset::CustomLoadableAsset;
+
+private:
+  CustomAssetLibrary::LoadInfo LoadImpl(const CustomAssetLibrary::AssetID& asset_id) override;
+};
+
+}  // namespace VideoCommon
+
+template <>
+struct fmt::formatter<VideoCommon::MaterialProperty::Type>
+    : EnumFormatter<VideoCommon::MaterialProperty::Type::Type_Max>
+{
+  constexpr formatter() : EnumFormatter({"Undefined", "Texture"}) {}
+};

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(videocommon
   Assets/CustomTextureData.h
   Assets/DirectFilesystemAssetLibrary.cpp
   Assets/DirectFilesystemAssetLibrary.h
+  Assets/MaterialAsset.cpp
+  Assets/MaterialAsset.h
   Assets/ShaderAsset.cpp
   Assets/ShaderAsset.h
   Assets/TextureAsset.cpp


### PR DESCRIPTION
This is the last of my asset reviews (for now!).  This adds a material asset for pixel shaders.  As I mentioned in my shader asset review, a material provides the data for a shader.  Any shader input _values_ will be in the material asset.  This makes shaders reusable.  Ex: you can have a single shader that might draw an outline around an object with an exposed color, one material that says to make the outline red and another that says to make the outline blue.

At the moment, materials are very simple.  The only input is a named texture asset.  In the future, materials will also handle other forms of data (color, integers, booleans, etc) that will be passed to the runtime shader as uniforms.

In the short term, this will be used by the revamped #11300 .