### PR TITLE
RetroAchievements - Badges

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -944,4 +944,30 @@ AchievementManager::ResponseType AchievementManager::Request(
   }
 }
 
+AchievementManager::ResponseType
+AchievementManager::RequestImage(rc_api_fetch_image_request_t rc_request, Badge* rc_response)
+{
+  rc_api_request_t api_request;
+  Common::HttpRequest http_request;
+  if (rc_api_init_fetch_image_request(&api_request, &rc_request) != RC_OK)
+  {
+    ERROR_LOG_FMT(ACHIEVEMENTS, "Invalid request for image.");
+    return ResponseType::INVALID_REQUEST;
+  }
+  auto http_response = http_request.Get(api_request.url);
+  if (http_response.has_value() && http_response->size() > 0)
+  {
+    rc_api_destroy_request(&api_request);
+    *rc_response = std::move(*http_response);
+    return ResponseType::SUCCESS;
+  }
+  else
+  {
+    WARN_LOG_FMT(ACHIEVEMENTS, "RetroAchievements connection failed on image request.\n URL: {}",
+                 api_request.url);
+    rc_api_destroy_request(&api_request);
+    return ResponseType::CONNECTION_FAILED;
+  }
+}
+
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -691,6 +691,8 @@ AchievementManager::GetUnlockStatus(AchievementId achievement_id) const
 void AchievementManager::GetAchievementProgress(AchievementId achievement_id, u32* value,
                                                 u32* target)
 {
+  if (!IsGameLoaded())
+    return;
   rc_runtime_get_achievement_measured(&m_runtime, achievement_id, value, target);
 }
 

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -56,6 +56,7 @@ public:
   using FormattedValue = std::array<char, FORMAT_SIZE>;
   static constexpr size_t RP_SIZE = 256;
   using RichPresence = std::array<char, RP_SIZE>;
+  using Badge = std::vector<u8>;
 
   struct UnlockStatus
   {
@@ -129,6 +130,7 @@ private:
   ResponseType Request(RcRequest rc_request, RcResponse* rc_response,
                        const std::function<int(rc_api_request_t*, const RcRequest*)>& init_request,
                        const std::function<int(RcResponse*, const char*)>& process_response);
+  ResponseType RequestImage(rc_api_fetch_image_request_t rc_request, Badge* rc_response);
 
   rc_runtime_t m_runtime{};
   Core::System* m_system{};

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -58,6 +58,12 @@ public:
   using RichPresence = std::array<char, RP_SIZE>;
   using Badge = std::vector<u8>;
 
+  struct BadgeStatus
+  {
+    std::string name = "";
+    Badge badge{};
+  };
+
   struct UnlockStatus
   {
     AchievementId game_data_index = 0;
@@ -69,6 +75,8 @@ public:
     } remote_unlock_status = UnlockType::LOCKED;
     u32 session_unlock_count = 0;
     u32 points = 0;
+    BadgeStatus locked_badge;
+    BadgeStatus unlocked_badge;
   };
 
   static AchievementManager* GetInstance();
@@ -84,6 +92,7 @@ public:
   void ActivateDeactivateAchievements();
   void ActivateDeactivateLeaderboards();
   void ActivateDeactivateRichPresence();
+  void FetchBadges();
 
   void DoFrame();
   u32 MemoryPeeker(u32 address, u32 num_bytes, void* ud);
@@ -92,10 +101,12 @@ public:
   std::recursive_mutex* GetLock();
   std::string GetPlayerDisplayName() const;
   u32 GetPlayerScore() const;
+  const BadgeStatus& GetPlayerBadge() const;
   std::string GetGameDisplayName() const;
   PointSpread TallyScore() const;
   rc_api_fetch_game_data_response_t* GetGameData();
-  UnlockStatus GetUnlockStatus(AchievementId achievement_id) const;
+  const BadgeStatus& GetGameBadge() const;
+  const UnlockStatus& GetUnlockStatus(AchievementId achievement_id) const;
   void GetAchievementProgress(AchievementId achievement_id, u32* value, u32* target);
   RichPresence GetRichPresence();
 
@@ -138,16 +149,19 @@ private:
   UpdateCallback m_update_callback;
   std::string m_display_name;
   u32 m_player_score = 0;
+  BadgeStatus m_player_badge;
   std::array<char, HASH_LENGTH> m_game_hash{};
   u32 m_game_id = 0;
   rc_api_fetch_game_data_response_t m_game_data{};
   bool m_is_game_loaded = false;
+  BadgeStatus m_game_badge;
   RichPresence m_rich_presence;
   time_t m_last_ping_time = 0;
 
   std::unordered_map<AchievementId, UnlockStatus> m_unlock_map;
 
   Common::WorkQueueThread<std::function<void()>> m_queue;
+  Common::WorkQueueThread<std::function<void()>> m_image_queue;
   std::recursive_mutex m_lock;
 };  // class AchievementManager
 

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -79,6 +79,10 @@ public:
     BadgeStatus unlocked_badge;
   };
 
+  static constexpr std::string_view GRAY = "transparent";
+  static constexpr std::string_view GOLD = "#FFD700";
+  static constexpr std::string_view BLUE = "#0B71C1";
+
   static AchievementManager* GetInstance();
   void Init();
   void SetUpdateCallback(UpdateCallback callback);

--- a/Source/Core/Core/Config/AchievementSettings.cpp
+++ b/Source/Core/Core/Config/AchievementSettings.cpp
@@ -19,6 +19,7 @@ const Info<bool> RA_LEADERBOARDS_ENABLED{
     {System::Achievements, "Achievements", "LeaderboardsEnabled"}, false};
 const Info<bool> RA_RICH_PRESENCE_ENABLED{
     {System::Achievements, "Achievements", "RichPresenceEnabled"}, false};
+const Info<bool> RA_BADGES_ENABLED{{System::Achievements, "Achievements", "BadgesEnabled"}, false};
 const Info<bool> RA_UNOFFICIAL_ENABLED{{System::Achievements, "Achievements", "UnofficialEnabled"},
                                        false};
 const Info<bool> RA_ENCORE_ENABLED{{System::Achievements, "Achievements", "EncoreEnabled"}, false};

--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -14,6 +14,7 @@ extern const Info<std::string> RA_API_TOKEN;
 extern const Info<bool> RA_ACHIEVEMENTS_ENABLED;
 extern const Info<bool> RA_LEADERBOARDS_ENABLED;
 extern const Info<bool> RA_RICH_PRESENCE_ENABLED;
+extern const Info<bool> RA_BADGES_ENABLED;
 extern const Info<bool> RA_UNOFFICIAL_ENABLED;
 extern const Info<bool> RA_ENCORE_ENABLED;
 }  // namespace Config

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -47,6 +47,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::RA_ACHIEVEMENTS_ENABLED.GetLocation(),
       &Config::RA_LEADERBOARDS_ENABLED.GetLocation(),
       &Config::RA_RICH_PRESENCE_ENABLED.GetLocation(),
+      &Config::RA_BADGES_ENABLED.GetLocation(),
       &Config::RA_UNOFFICIAL_ENABLED.GetLocation(),
       &Config::RA_ENCORE_ENABLED.GetLocation(),
   };

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -119,7 +119,13 @@ void AchievementHeaderWidget::UpdateData()
         m_game_icon->setPixmap(QPixmap::fromImage(i_game_icon)
                                    .scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
         m_game_icon->adjustSize();
-        m_game_icon->setStyleSheet(QStringLiteral("border: 4px solid transparent"));
+        std::string_view color = AchievementManager::GRAY;
+        if (point_spread.hard_unlocks == point_spread.total_count)
+          color = AchievementManager::GOLD;
+        else if (point_spread.hard_unlocks + point_spread.soft_unlocks == point_spread.total_count)
+          color = AchievementManager::BLUE;
+        m_game_icon->setStyleSheet(
+            QStringLiteral("border: 4px solid %1").arg(QString::fromStdString(std::string(color))));
         m_game_icon->setVisible(true);
       }
     }

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -30,45 +30,44 @@
 
 AchievementHeaderWidget::AchievementHeaderWidget(QWidget* parent) : QWidget(parent)
 {
-  m_user_name = new QLabel();
-  m_user_points = new QLabel();
-  m_game_name = new QLabel();
-  m_game_points = new QLabel();
+  m_user_icon = new QLabel();
+  m_game_icon = new QLabel();
+  m_name = new QLabel();
+  m_points = new QLabel();
   m_game_progress_hard = new QProgressBar();
   m_game_progress_soft = new QProgressBar();
   m_rich_presence = new QLabel();
 
-  QVBoxLayout* m_user_right_col = new QVBoxLayout();
-  m_user_right_col->addWidget(m_user_name);
-  m_user_right_col->addWidget(m_user_points);
-  QHBoxLayout* m_user_layout = new QHBoxLayout();
-  // TODO: player badge goes here
-  m_user_layout->addLayout(m_user_right_col);
-  m_user_box = new QGroupBox();
-  m_user_box->setLayout(m_user_layout);
+  QSizePolicy sp_retain = m_game_progress_hard->sizePolicy();
+  sp_retain.setRetainSizeWhenHidden(true);
+  m_game_progress_hard->setSizePolicy(sp_retain);
+  sp_retain = m_game_progress_soft->sizePolicy();
+  sp_retain.setRetainSizeWhenHidden(true);
+  m_game_progress_soft->setSizePolicy(sp_retain);
 
-  QVBoxLayout* m_game_right_col = new QVBoxLayout();
-  m_game_right_col->addWidget(m_game_name);
-  m_game_right_col->addWidget(m_game_points);
-  m_game_right_col->addWidget(m_game_progress_hard);
-  m_game_right_col->addWidget(m_game_progress_soft);
-  QHBoxLayout* m_game_upper_row = new QHBoxLayout();
-  // TODO: player badge and game badge go here
-  m_game_upper_row->addLayout(m_game_right_col);
-  QVBoxLayout* m_game_layout = new QVBoxLayout();
-  m_game_layout->addLayout(m_game_upper_row);
-  m_game_layout->addWidget(m_rich_presence);
-  m_game_box = new QGroupBox();
-  m_game_box->setLayout(m_game_layout);
+  QVBoxLayout* icon_col = new QVBoxLayout();
+  icon_col->addWidget(m_user_icon);
+  icon_col->addWidget(m_game_icon);
+  QVBoxLayout* text_col = new QVBoxLayout();
+  text_col->addWidget(m_name);
+  text_col->addWidget(m_points);
+  text_col->addWidget(m_game_progress_hard);
+  text_col->addWidget(m_game_progress_soft);
+  text_col->addWidget(m_rich_presence);
+  QHBoxLayout* header_layout = new QHBoxLayout();
+  header_layout->addLayout(icon_col);
+  header_layout->addLayout(text_col);
+  m_header_box = new QGroupBox();
+  m_header_box->setLayout(header_layout);
 
   QVBoxLayout* m_total = new QVBoxLayout();
-  m_total->addWidget(m_user_box);
-  m_total->addWidget(m_game_box);
+  m_total->addWidget(m_header_box);
 
   m_total->setContentsMargins(0, 0, 0, 0);
   m_total->setAlignment(Qt::AlignTop);
   setLayout(m_total);
 
+  std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
   UpdateData();
 }
 
@@ -76,38 +75,83 @@ void AchievementHeaderWidget::UpdateData()
 {
   if (!AchievementManager::GetInstance()->IsLoggedIn())
   {
-    m_user_box->setVisible(false);
-    m_game_box->setVisible(false);
-    return;
-  }
-
-  QString user_name =
-      QString::fromStdString(AchievementManager::GetInstance()->GetPlayerDisplayName());
-  m_user_name->setText(user_name);
-  m_user_points->setText(tr("%1 points").arg(AchievementManager::GetInstance()->GetPlayerScore()));
-
-  if (!AchievementManager::GetInstance()->IsGameLoaded())
-  {
-    m_user_box->setVisible(true);
-    m_game_box->setVisible(false);
+    m_header_box->setVisible(false);
     return;
   }
 
   AchievementManager::PointSpread point_spread = AchievementManager::GetInstance()->TallyScore();
-  m_game_name->setText(
-      QString::fromStdString(AchievementManager::GetInstance()->GetGameDisplayName()));
-  m_game_points->setText(GetPointsString(user_name, point_spread));
-  m_game_progress_hard = new QProgressBar();
-  m_game_progress_hard->setRange(0, point_spread.total_count);
-  m_game_progress_soft->setValue(point_spread.hard_unlocks);
-  m_game_progress_soft->setRange(0, point_spread.total_count);
-  m_game_progress_soft->setValue(point_spread.hard_unlocks + point_spread.soft_unlocks);
-  m_rich_presence->setText(
-      QString::fromUtf8(AchievementManager::GetInstance()->GetRichPresence().data()));
-  m_rich_presence->setVisible(Config::Get(Config::RA_RICH_PRESENCE_ENABLED));
+  QString user_name =
+      QString::fromStdString(AchievementManager::GetInstance()->GetPlayerDisplayName());
+  QString game_name =
+      QString::fromStdString(AchievementManager::GetInstance()->GetGameDisplayName());
+  AchievementManager::BadgeStatus player_badge =
+      AchievementManager::GetInstance()->GetPlayerBadge();
+  AchievementManager::BadgeStatus game_badge = AchievementManager::GetInstance()->GetGameBadge();
 
-  m_user_box->setVisible(false);
-  m_game_box->setVisible(true);
+  m_user_icon->setVisible(false);
+  m_user_icon->clear();
+  m_user_icon->setText({});
+  if (Config::Get(Config::RA_BADGES_ENABLED))
+  {
+    if (player_badge.name != "")
+    {
+      QImage i_user_icon{};
+      if (i_user_icon.loadFromData(&player_badge.badge.front(), (int)player_badge.badge.size()))
+      {
+        m_user_icon->setPixmap(QPixmap::fromImage(i_user_icon)
+                                   .scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+        m_user_icon->adjustSize();
+        m_user_icon->setStyleSheet(QStringLiteral("border: 4px solid transparent"));
+        m_user_icon->setVisible(true);
+      }
+    }
+  }
+  m_game_icon->setVisible(false);
+  m_game_icon->clear();
+  m_game_icon->setText({});
+  if (Config::Get(Config::RA_BADGES_ENABLED))
+  {
+    if (game_badge.name != "")
+    {
+      QImage i_game_icon{};
+      if (i_game_icon.loadFromData(&game_badge.badge.front(), (int)game_badge.badge.size()))
+      {
+        m_game_icon->setPixmap(QPixmap::fromImage(i_game_icon)
+                                   .scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+        m_game_icon->adjustSize();
+        m_game_icon->setStyleSheet(QStringLiteral("border: 4px solid transparent"));
+        m_game_icon->setVisible(true);
+      }
+    }
+  }
+
+  if (!game_name.isEmpty())
+  {
+    m_name->setText(tr("%1 is playing %2").arg(user_name).arg(game_name));
+    m_points->setText(GetPointsString(user_name, point_spread));
+
+    m_game_progress_hard->setRange(0, point_spread.total_count);
+    if (!m_game_progress_hard->isVisible())
+      m_game_progress_hard->setVisible(true);
+    m_game_progress_soft->setValue(point_spread.hard_unlocks);
+    m_game_progress_soft->setRange(0, point_spread.total_count);
+    m_game_progress_soft->setValue(point_spread.hard_unlocks + point_spread.soft_unlocks);
+    if (!m_game_progress_soft->isVisible())
+      m_game_progress_soft->setVisible(true);
+    m_rich_presence->setText(
+        QString::fromUtf8(AchievementManager::GetInstance()->GetRichPresence().data()));
+    if (!m_rich_presence->isVisible())
+      m_rich_presence->setVisible(Config::Get(Config::RA_RICH_PRESENCE_ENABLED));
+  }
+  else
+  {
+    m_name->setText(user_name);
+    m_points->setText(tr("%1 points").arg(AchievementManager::GetInstance()->GetPlayerScore()));
+
+    m_game_progress_hard->setVisible(false);
+    m_game_progress_soft->setVisible(false);
+    m_rich_presence->setVisible(false);
+  }
 }
 
 QString

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.h
@@ -27,16 +27,14 @@ private:
   QGroupBox* m_common_box;
   QVBoxLayout* m_common_layout;
 
-  QLabel* m_user_name;
-  QLabel* m_user_points;
-  QLabel* m_game_name;
-  QLabel* m_game_points;
+  QLabel* m_user_icon;
+  QLabel* m_game_icon;
+  QLabel* m_name;
+  QLabel* m_points;
   QProgressBar* m_game_progress_hard;
   QProgressBar* m_game_progress_soft;
   QLabel* m_rich_presence;
-
-  QGroupBox* m_user_box;
-  QGroupBox* m_game_box;
+  QGroupBox* m_header_box;
 };
 
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
@@ -30,6 +30,8 @@
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
+static constexpr bool hardcore_mode_enabled = false;
+
 AchievementProgressWidget::AchievementProgressWidget(QWidget* parent) : QWidget(parent)
 {
   m_common_box = new QGroupBox();
@@ -57,22 +59,27 @@ AchievementProgressWidget::CreateAchievementBox(const rc_api_achievement_definit
   QLabel* a_badge = new QLabel();
   const auto unlock_status = AchievementManager::GetInstance()->GetUnlockStatus(achievement->id);
   const AchievementManager::BadgeStatus* badge = &unlock_status.locked_badge;
+  std::string_view color = AchievementManager::GRAY;
   if (unlock_status.remote_unlock_status == AchievementManager::UnlockStatus::UnlockType::HARDCORE)
   {
     badge = &unlock_status.unlocked_badge;
+    color = AchievementManager::GOLD;
   }
   else if (hardcore_mode_enabled && unlock_status.session_unlock_count > 1)
   {
     badge = &unlock_status.unlocked_badge;
+    color = AchievementManager::GOLD;
   }
   else if (unlock_status.remote_unlock_status ==
            AchievementManager::UnlockStatus::UnlockType::SOFTCORE)
   {
     badge = &unlock_status.unlocked_badge;
+    color = AchievementManager::BLUE;
   }
   else if (unlock_status.session_unlock_count > 1)
   {
     badge = &unlock_status.unlocked_badge;
+    color = AchievementManager::BLUE;
   }
   if (Config::Get(Config::RA_BADGES_ENABLED) && badge->name != "")
   {
@@ -82,6 +89,8 @@ AchievementProgressWidget::CreateAchievementBox(const rc_api_achievement_definit
       a_badge->setPixmap(QPixmap::fromImage(i_badge).scaled(64, 64, Qt::KeepAspectRatio,
                                                             Qt::SmoothTransformation));
       a_badge->adjustSize();
+      a_badge->setStyleSheet(
+          QStringLiteral("border: 4px solid %1").arg(QString::fromStdString(std::string(color))));
     }
   }
 

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -75,6 +75,11 @@ void AchievementSettingsWidget::CreateLayout()
          "achievements.<br><br>Unofficial achievements may be optional or unfinished achievements "
          "that have not been deemed official by RetroAchievements and may be useful for testing or "
          "simply for fun."));
+  m_common_badges_enabled_input = new ToolTipCheckBox(tr("Enable Achievement Badges"));
+  m_common_badges_enabled_input->SetDescription(
+      tr("Enable achievement badges.<br><br>Displays icons for the player, game, and achievements. "
+         "Simple visual option, but will require a small amount of extra memory and time to "
+         "download the images."));
   m_common_encore_enabled_input = new ToolTipCheckBox(tr("Enable Encore Achievements"));
   m_common_encore_enabled_input->SetDescription(tr(
       "Enable unlocking achievements in Encore Mode.<br><br>Encore Mode re-enables achievements "
@@ -92,6 +97,7 @@ void AchievementSettingsWidget::CreateLayout()
   m_common_layout->addWidget(m_common_achievements_enabled_input);
   m_common_layout->addWidget(m_common_leaderboards_enabled_input);
   m_common_layout->addWidget(m_common_rich_presence_enabled_input);
+  m_common_layout->addWidget(m_common_badges_enabled_input);
   m_common_layout->addWidget(m_common_unofficial_enabled_input);
   m_common_layout->addWidget(m_common_encore_enabled_input);
 
@@ -111,6 +117,8 @@ void AchievementSettingsWidget::ConnectWidgets()
           &AchievementSettingsWidget::ToggleLeaderboards);
   connect(m_common_rich_presence_enabled_input, &QCheckBox::toggled, this,
           &AchievementSettingsWidget::ToggleRichPresence);
+  connect(m_common_badges_enabled_input, &QCheckBox::toggled, this,
+          &AchievementSettingsWidget::ToggleBadges);
   connect(m_common_unofficial_enabled_input, &QCheckBox::toggled, this,
           &AchievementSettingsWidget::ToggleUnofficial);
   connect(m_common_encore_enabled_input, &QCheckBox::toggled, this,
@@ -157,6 +165,9 @@ void AchievementSettingsWidget::LoadSettings()
       ->setChecked(Config::Get(Config::RA_RICH_PRESENCE_ENABLED));
   SignalBlocking(m_common_rich_presence_enabled_input)->setEnabled(enabled);
 
+  SignalBlocking(m_common_badges_enabled_input)->setChecked(Config::Get(Config::RA_BADGES_ENABLED));
+  SignalBlocking(m_common_badges_enabled_input)->setEnabled(enabled);
+
   SignalBlocking(m_common_unofficial_enabled_input)
       ->setChecked(Config::Get(Config::RA_UNOFFICIAL_ENABLED));
   SignalBlocking(m_common_unofficial_enabled_input)->setEnabled(enabled && achievements_enabled);
@@ -176,6 +187,7 @@ void AchievementSettingsWidget::SaveSettings()
                            m_common_leaderboards_enabled_input->isChecked());
   Config::SetBaseOrCurrent(Config::RA_RICH_PRESENCE_ENABLED,
                            m_common_rich_presence_enabled_input->isChecked());
+  Config::SetBaseOrCurrent(Config::RA_BADGES_ENABLED, m_common_badges_enabled_input->isChecked());
   Config::SetBaseOrCurrent(Config::RA_UNOFFICIAL_ENABLED,
                            m_common_unofficial_enabled_input->isChecked());
   Config::SetBaseOrCurrent(Config::RA_ENCORE_ENABLED, m_common_encore_enabled_input->isChecked());
@@ -222,6 +234,12 @@ void AchievementSettingsWidget::ToggleRichPresence()
 {
   SaveSettings();
   AchievementManager::GetInstance()->ActivateDeactivateRichPresence();
+}
+
+void AchievementSettingsWidget::ToggleBadges()
+{
+  SaveSettings();
+  AchievementManager::GetInstance()->FetchBadges();
 }
 
 void AchievementSettingsWidget::ToggleUnofficial()

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
@@ -36,7 +36,7 @@ private:
   void ToggleLeaderboards();
   void ToggleRichPresence();
   void ToggleHardcore();
-  void ToggleBadgeIcons();
+  void ToggleBadges();
   void ToggleUnofficial();
   void ToggleEncore();
 
@@ -55,6 +55,7 @@ private:
   ToolTipCheckBox* m_common_achievements_enabled_input;
   ToolTipCheckBox* m_common_leaderboards_enabled_input;
   ToolTipCheckBox* m_common_rich_presence_enabled_input;
+  ToolTipCheckBox* m_common_badges_enabled_input;
   ToolTipCheckBox* m_common_unofficial_enabled_input;
   ToolTipCheckBox* m_common_encore_enabled_input;
 };


### PR DESCRIPTION
This is a portion of an integration with the RetroAchievements tools and libraries for connecting to the website, downloading data, unlocking achievements and submitting to leaderboards for games running in Dolphin. In this PR, I add the functionality to download player, game, and achievement badges (icons) from the RetroAchievements server and display them in the Achievement dialog within the header and the Progress tab.