### PR TITLE
RetroAchievements - Progress Notifications

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -606,6 +606,9 @@ void AchievementManager::AchievementEventHandler(const rc_runtime_event_t* runti
     case RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED:
       HandleAchievementTriggeredEvent(runtime_event);
       break;
+    case RC_RUNTIME_EVENT_ACHIEVEMENT_PROGRESS_UPDATED:
+      HandleAchievementProgressUpdatedEvent(runtime_event);
+      break;
     case RC_RUNTIME_EVENT_LBOARD_STARTED:
       HandleLeaderboardStartedEvent(runtime_event);
       break;
@@ -1102,6 +1105,31 @@ void AchievementManager::HandleAchievementTriggeredEvent(const rc_runtime_event_
   ActivateDeactivateAchievement(runtime_event->id, Config::Get(Config::RA_ACHIEVEMENTS_ENABLED),
                                 Config::Get(Config::RA_UNOFFICIAL_ENABLED),
                                 Config::Get(Config::RA_ENCORE_ENABLED));
+}
+
+void AchievementManager::HandleAchievementProgressUpdatedEvent(
+    const rc_runtime_event_t* runtime_event)
+{
+  if (!Config::Get(Config::RA_PROGRESS_ENABLED))
+    return;
+  auto it = m_unlock_map.find(runtime_event->id);
+  if (it == m_unlock_map.end())
+  {
+    ERROR_LOG_FMT(ACHIEVEMENTS, "Invalid achievement progress updated event with id {}.",
+                  runtime_event->id);
+    return;
+  }
+  AchievementId game_data_index = it->second.game_data_index;
+  FormattedValue value{};
+  if (rc_runtime_format_achievement_measured(&m_runtime, runtime_event->id, value.data(),
+                                             FORMAT_SIZE) == 0)
+  {
+    ERROR_LOG_FMT(ACHIEVEMENTS, "Failed to format measured data {}.", value.data());
+    return;
+  }
+  OSD::AddMessage(
+      fmt::format("{} {}", m_game_data.achievements[game_data_index].title, value.data()),
+      OSD::Duration::VERY_LONG, OSD::Color::GREEN);
 }
 
 void AchievementManager::HandleLeaderboardStartedEvent(const rc_runtime_event_t* runtime_event)

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -137,6 +137,7 @@ private:
   ResponseType PingRichPresence(const RichPresence& rich_presence);
 
   void HandleAchievementTriggeredEvent(const rc_runtime_event_t* runtime_event);
+  void HandleAchievementProgressUpdatedEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardStartedEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardCanceledEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardTriggeredEvent(const rc_runtime_event_t* runtime_event);

--- a/Source/Core/Core/Config/AchievementSettings.cpp
+++ b/Source/Core/Core/Config/AchievementSettings.cpp
@@ -19,6 +19,8 @@ const Info<bool> RA_LEADERBOARDS_ENABLED{
     {System::Achievements, "Achievements", "LeaderboardsEnabled"}, false};
 const Info<bool> RA_RICH_PRESENCE_ENABLED{
     {System::Achievements, "Achievements", "RichPresenceEnabled"}, false};
+const Info<bool> RA_PROGRESS_ENABLED{{System::Achievements, "Achievements", "ProgressEnabled"},
+                                     false};
 const Info<bool> RA_BADGES_ENABLED{{System::Achievements, "Achievements", "BadgesEnabled"}, false};
 const Info<bool> RA_UNOFFICIAL_ENABLED{{System::Achievements, "Achievements", "UnofficialEnabled"},
                                        false};

--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -14,6 +14,7 @@ extern const Info<std::string> RA_API_TOKEN;
 extern const Info<bool> RA_ACHIEVEMENTS_ENABLED;
 extern const Info<bool> RA_LEADERBOARDS_ENABLED;
 extern const Info<bool> RA_RICH_PRESENCE_ENABLED;
+extern const Info<bool> RA_PROGRESS_ENABLED;
 extern const Info<bool> RA_BADGES_ENABLED;
 extern const Info<bool> RA_UNOFFICIAL_ENABLED;
 extern const Info<bool> RA_ENCORE_ENABLED;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -47,6 +47,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::RA_ACHIEVEMENTS_ENABLED.GetLocation(),
       &Config::RA_LEADERBOARDS_ENABLED.GetLocation(),
       &Config::RA_RICH_PRESENCE_ENABLED.GetLocation(),
+      &Config::RA_PROGRESS_ENABLED.GetLocation(),
       &Config::RA_BADGES_ENABLED.GetLocation(),
       &Config::RA_UNOFFICIAL_ENABLED.GetLocation(),
       &Config::RA_ENCORE_ENABLED.GetLocation(),

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -75,6 +75,11 @@ void AchievementSettingsWidget::CreateLayout()
          "achievements.<br><br>Unofficial achievements may be optional or unfinished achievements "
          "that have not been deemed official by RetroAchievements and may be useful for testing or "
          "simply for fun."));
+  m_common_progress_enabled_input = new ToolTipCheckBox(tr("Enable Progress Notifications"));
+  m_common_progress_enabled_input->SetDescription(
+      tr("Enable progress notifications on achievements.<br><br>Displays a brief popup message "
+         "whenever the player makes progress on an achievement that tracks an accumulated value, "
+         "such as 60 out of 120 stars."));
   m_common_badges_enabled_input = new ToolTipCheckBox(tr("Enable Achievement Badges"));
   m_common_badges_enabled_input->SetDescription(
       tr("Enable achievement badges.<br><br>Displays icons for the player, game, and achievements. "
@@ -97,6 +102,7 @@ void AchievementSettingsWidget::CreateLayout()
   m_common_layout->addWidget(m_common_achievements_enabled_input);
   m_common_layout->addWidget(m_common_leaderboards_enabled_input);
   m_common_layout->addWidget(m_common_rich_presence_enabled_input);
+  m_common_layout->addWidget(m_common_progress_enabled_input);
   m_common_layout->addWidget(m_common_badges_enabled_input);
   m_common_layout->addWidget(m_common_unofficial_enabled_input);
   m_common_layout->addWidget(m_common_encore_enabled_input);
@@ -117,6 +123,8 @@ void AchievementSettingsWidget::ConnectWidgets()
           &AchievementSettingsWidget::ToggleLeaderboards);
   connect(m_common_rich_presence_enabled_input, &QCheckBox::toggled, this,
           &AchievementSettingsWidget::ToggleRichPresence);
+  connect(m_common_progress_enabled_input, &QCheckBox::toggled, this,
+          &AchievementSettingsWidget::ToggleProgress);
   connect(m_common_badges_enabled_input, &QCheckBox::toggled, this,
           &AchievementSettingsWidget::ToggleBadges);
   connect(m_common_unofficial_enabled_input, &QCheckBox::toggled, this,
@@ -165,6 +173,10 @@ void AchievementSettingsWidget::LoadSettings()
       ->setChecked(Config::Get(Config::RA_RICH_PRESENCE_ENABLED));
   SignalBlocking(m_common_rich_presence_enabled_input)->setEnabled(enabled);
 
+  SignalBlocking(m_common_progress_enabled_input)
+      ->setChecked(Config::Get(Config::RA_PROGRESS_ENABLED));
+  SignalBlocking(m_common_progress_enabled_input)->setEnabled(enabled && achievements_enabled);
+
   SignalBlocking(m_common_badges_enabled_input)->setChecked(Config::Get(Config::RA_BADGES_ENABLED));
   SignalBlocking(m_common_badges_enabled_input)->setEnabled(enabled);
 
@@ -187,6 +199,8 @@ void AchievementSettingsWidget::SaveSettings()
                            m_common_leaderboards_enabled_input->isChecked());
   Config::SetBaseOrCurrent(Config::RA_RICH_PRESENCE_ENABLED,
                            m_common_rich_presence_enabled_input->isChecked());
+  Config::SetBaseOrCurrent(Config::RA_PROGRESS_ENABLED,
+                           m_common_unofficial_enabled_input->isChecked());
   Config::SetBaseOrCurrent(Config::RA_BADGES_ENABLED, m_common_badges_enabled_input->isChecked());
   Config::SetBaseOrCurrent(Config::RA_UNOFFICIAL_ENABLED,
                            m_common_unofficial_enabled_input->isChecked());
@@ -234,6 +248,11 @@ void AchievementSettingsWidget::ToggleRichPresence()
 {
   SaveSettings();
   AchievementManager::GetInstance()->ActivateDeactivateRichPresence();
+}
+
+void AchievementSettingsWidget::ToggleProgress()
+{
+  SaveSettings();
 }
 
 void AchievementSettingsWidget::ToggleBadges()

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
@@ -36,6 +36,7 @@ private:
   void ToggleLeaderboards();
   void ToggleRichPresence();
   void ToggleHardcore();
+  void ToggleProgress();
   void ToggleBadges();
   void ToggleUnofficial();
   void ToggleEncore();
@@ -55,6 +56,7 @@ private:
   ToolTipCheckBox* m_common_achievements_enabled_input;
   ToolTipCheckBox* m_common_leaderboards_enabled_input;
   ToolTipCheckBox* m_common_rich_presence_enabled_input;
+  ToolTipCheckBox* m_common_progress_enabled_input;
   ToolTipCheckBox* m_common_badges_enabled_input;
   ToolTipCheckBox* m_common_unofficial_enabled_input;
   ToolTipCheckBox* m_common_encore_enabled_input;


### PR DESCRIPTION
This is a portion of an integration with the RetroAchievements tools and libraries for connecting to the website, downloading data, unlocking achievements and submitting to leaderboards for games running in Dolphin. In this PR, I add event handling for achievement progress. If an achievement involves a measured value (for example, 120 stars), the achievement framework will throw an event every time the number of stars is updated. This PR will reflect that by popping a notification up on screen and by adding a progress bar to the Progress tab in the Achievements dialog.