### PR TITLE
RetroAchievements - Add Rich Presence to Achievement Dialog Header

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -94,6 +94,7 @@ public:
   rc_api_fetch_game_data_response_t* GetGameData();
   UnlockStatus GetUnlockStatus(AchievementId achievement_id) const;
   void GetAchievementProgress(AchievementId achievement_id, u32* value, u32* target);
+  RichPresence GetRichPresence();
 
   void CloseGame();
   void Logout();
@@ -111,7 +112,7 @@ private:
   ResponseType FetchUnlockData(bool hardcore);
 
   void ActivateDeactivateAchievement(AchievementId id, bool enabled, bool unofficial, bool encore);
-  RichPresence GenerateRichPresence();
+  void GenerateRichPresence();
 
   ResponseType AwardAchievement(AchievementId achievement_id);
   ResponseType SubmitLeaderboard(AchievementId leaderboard_id, int value);
@@ -137,6 +138,7 @@ private:
   u32 m_game_id = 0;
   rc_api_fetch_game_data_response_t m_game_data{};
   bool m_is_game_loaded = false;
+  RichPresence m_rich_presence;
   time_t m_last_ping_time = 0;
 
   std::unordered_map<AchievementId, UnlockStatus> m_unlock_map;

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -20,6 +20,7 @@
 #include <rcheevos/include/rc_runtime.h>
 
 #include "Core/AchievementManager.h"
+#include "Core/Config/AchievementSettings.h"
 #include "Core/Core.h"
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
@@ -101,11 +102,9 @@ void AchievementHeaderWidget::UpdateData()
   m_game_progress_soft->setValue(point_spread.hard_unlocks);
   m_game_progress_soft->setRange(0, point_spread.total_count);
   m_game_progress_soft->setValue(point_spread.hard_unlocks + point_spread.soft_unlocks);
-  // TODO: RP needs a minor refactor to work here, will be a future PR
-  // m_rich_presence->setText(QString::fromStdString(AchievementManager::GetInstance()->GenerateRichPresence()));
-  // m_rich_presence->setVisible(Config::Get(Config::RA_RICH_PRESENCE_ENABLED));
-  m_rich_presence->setText(QString{});
-  m_rich_presence->setVisible(false);
+  m_rich_presence->setText(
+      QString::fromUtf8(AchievementManager::GetInstance()->GetRichPresence().data()));
+  m_rich_presence->setVisible(Config::Get(Config::RA_RICH_PRESENCE_ENABLED));
 
   m_user_box->setVisible(false);
   m_game_box->setVisible(true);


### PR DESCRIPTION
This refactors the Rich Presence generation to store to a member field that can be exposed to the UI to display the Rich Presence in the achievement header. It still updates at its original rate of once per two minutes, but calls an update on the dialog when that ticks.