### PR TITLE
RetroAchievements - Rearranged startup process

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -42,6 +42,7 @@
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
 #include "Core/CommonTitles.h"
+#include "Core/Config/AchievementSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/NetplaySettings.h"
 #include "Core/Config/WiimoteSettings.h"
@@ -227,11 +228,6 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 
   InitControllers();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
-  // This has to be done before CreateComponents() so it's initialized.
-  AchievementManager::GetInstance()->Init();
-#endif  // USE_RETRO_ACHIEVEMENTS
-
   CreateComponents();
 
   ConnectGameList();
@@ -255,6 +251,10 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
   InitCoreCallbacks();
 
   NetPlayInit();
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+  AchievementManager::GetInstance()->Init();
+#endif  // USE_RETRO_ACHIEVEMENTS
 
 #if defined(__unix__) || defined(__unix) || defined(__APPLE__)
   auto* daemon = new SignalDaemon(this);


### PR DESCRIPTION
Moved AchievementManager Init further down in the MainWindow constructor; its original position was because it had an impact on the contents of the menu bar, and this is no longer the case. On top of this, if achievements are enabled and there's an API token already in the config (meaning the emulator will attempt to verify credentials and "log in"), it opens the Achievements dialog as a way of notifying the player that the achievements are active.