### PR TITLE
RetroAchievements - Fixed Leaderboard Scored message format

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -585,7 +585,7 @@ void AchievementManager::ActivateDeactivateAchievement(AchievementId id, bool en
     rc_runtime_deactivate_achievement(&m_runtime, id);
 }
 
-RichPresence AchievementManager::GenerateRichPresence()
+AchievementManager::RichPresence AchievementManager::GenerateRichPresence()
 {
   RichPresence rp_buffer;
   Core::RunAsCPUThread([&] {
@@ -716,9 +716,22 @@ void AchievementManager::HandleLeaderboardTriggeredEvent(const rc_runtime_event_
   {
     if (m_game_data.leaderboards[ix].id == runtime_event->id)
     {
-      OSD::AddMessage(fmt::format("Scored {} on leaderboard: {}", runtime_event->value,
-                                  m_game_data.leaderboards[ix].title),
-                      OSD::Duration::VERY_LONG, OSD::Color::YELLOW);
+      FormattedValue value{};
+      rc_runtime_format_lboard_value(value.data(), static_cast<int>(value.size()),
+                                     runtime_event->value, m_game_data.leaderboards[ix].format);
+      if (std::find(value.begin(), value.end(), '\0') == value.end())
+      {
+        OSD::AddMessage(fmt::format("Scored {} on leaderboard: {}",
+                                    std::string_view{value.data(), value.size()},
+                                    m_game_data.leaderboards[ix].title),
+                        OSD::Duration::VERY_LONG, OSD::Color::YELLOW);
+      }
+      else
+      {
+        OSD::AddMessage(fmt::format("Scored {} on leaderboard: {}", value.data(),
+                                    m_game_data.leaderboards[ix].title),
+                        OSD::Duration::VERY_LONG, OSD::Color::YELLOW);
+      }
       break;
     }
   }

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -19,10 +19,6 @@
 #include "Common/Event.h"
 #include "Common/WorkQueueThread.h"
 
-using AchievementId = u32;
-constexpr size_t RP_SIZE = 256;
-using RichPresence = std::array<char, RP_SIZE>;
-
 namespace Core
 {
 class System;
@@ -52,6 +48,12 @@ public:
     u32 soft_unlocks;
     u32 soft_points;
   };
+
+  using AchievementId = u32;
+  static constexpr size_t FORMAT_SIZE = 24;
+  using FormattedValue = std::array<char, FORMAT_SIZE>;
+  static constexpr size_t RP_SIZE = 256;
+  using RichPresence = std::array<char, RP_SIZE>;
 
   struct UnlockStatus
   {


### PR DESCRIPTION
Refactored the message displayed when a leaderboard is submitted to so that it properly generates and uses a FormattedValue.