### PR TITLE
Added file path field to BlobReader and IOFile

### DIFF
--- a/Source/Core/Common/IOFile.cpp
+++ b/Source/Core/Common/IOFile.cpp
@@ -27,16 +27,17 @@
 
 namespace File
 {
-IOFile::IOFile() : m_file(nullptr), m_good(true)
+IOFile::IOFile() : m_file(nullptr), m_path(""), m_good(true)
 {
 }
 
-IOFile::IOFile(std::FILE* file) : m_file(file), m_good(true)
+IOFile::IOFile(std::FILE* file, const std::string& filename)
+    : m_file(file), m_path(filename), m_good(true)
 {
 }
 
 IOFile::IOFile(const std::string& filename, const char openmode[], SharedAccess sh)
-    : m_file(nullptr), m_good(true)
+    : m_file(nullptr), m_path(filename), m_good(true)
 {
   Open(filename, openmode, sh);
 }

--- a/Source/Core/Common/IOFile.h
+++ b/Source/Core/Common/IOFile.h
@@ -33,7 +33,7 @@ class IOFile
 {
 public:
   IOFile();
-  IOFile(std::FILE* file);
+  IOFile(std::FILE* file, const std::string& filename);
   IOFile(const std::string& filename, const char openmode[],
          SharedAccess sh = SharedAccess::Default);
 
@@ -102,6 +102,7 @@ public:
   bool IsGood() const { return m_good; }
   explicit operator bool() const { return IsGood() && IsOpen(); }
   std::FILE* GetHandle() { return m_file; }
+  const std::string& GetPath() { return m_path; }
   void SetHandle(std::FILE* file);
 
   bool Seek(s64 offset, SeekOrigin origin);
@@ -119,6 +120,7 @@ public:
 
 private:
   std::FILE* m_file;
+  std::string m_path;
   bool m_good;
 };
 

--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -64,6 +64,7 @@ public:
   virtual ~BlobReader() {}
 
   virtual BlobType GetBlobType() const = 0;
+  virtual const std::string& GetFilePath() const { return m_file_path; }
 
   virtual u64 GetRawSize() const = 0;
   virtual u64 GetDataSize() const = 0;
@@ -96,8 +97,11 @@ public:
     return false;
   }
 
+private:
+  const std::string m_file_path;
+
 protected:
-  BlobReader() {}
+  BlobReader(std::string file_path) : m_file_path(file_path) {}
 };
 
 // Provides caching and byte-operation-to-block-operations facilities.
@@ -186,6 +190,9 @@ private:
   u32 m_block_size = 0;    // Bytes in a sector/block
   u32 m_chunk_blocks = 1;  // Number of sectors/blocks in a chunk
   std::array<Cache, CACHE_LINES> m_cache;
+
+protected:
+  SectorReader(std::string file_path) : BlobReader(file_path) {}
 };
 
 // Factory function - examines the path to choose the right type of BlobReader, and returns one.

--- a/Source/Core/DiscIO/CISOBlob.cpp
+++ b/Source/Core/DiscIO/CISOBlob.cpp
@@ -13,7 +13,8 @@
 
 namespace DiscIO
 {
-CISOFileReader::CISOFileReader(File::IOFile file) : m_file(std::move(file))
+CISOFileReader::CISOFileReader(File::IOFile file)
+    : BlobReader(file.GetPath()), m_file(std::move(file))
 {
   m_size = m_file.GetSize();
 

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -35,7 +35,7 @@ namespace DiscIO
 bool IsGCZBlob(File::IOFile& file);
 
 CompressedBlobReader::CompressedBlobReader(File::IOFile file, const std::string& filename)
-    : m_file(std::move(file)), m_file_name(filename)
+    : SectorReader(filename), m_file(std::move(file)), m_file_name(filename)
 {
   m_file_size = m_file.GetSize();
   m_file.Seek(0, File::SeekOrigin::Begin);

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -375,7 +375,7 @@ std::unique_ptr<DirectoryBlobReader> DirectoryBlobReader::Create(
 
 DirectoryBlobReader::DirectoryBlobReader(const std::string& game_partition_root,
                                          const std::string& true_root)
-    : m_encryption_cache(this)
+    : BlobReader(true_root), m_encryption_cache(this)
 {
   DirectoryBlobPartition game_partition(game_partition_root, {});
   m_is_wii = game_partition.IsWii();
@@ -422,7 +422,8 @@ DirectoryBlobReader::DirectoryBlobReader(
     const std::function<void(std::vector<FSTBuilderNode>* fst_nodes)>& sys_callback,
     const std::function<void(std::vector<FSTBuilderNode>* fst_nodes, FSTBuilderNode* dol_node)>&
         fst_callback)
-    : m_encryption_cache(this), m_wrapped_volume(std::move(volume))
+    : BlobReader(volume->GetBlobReader()), m_encryption_cache(this),
+      m_wrapped_volume(std::move(volume))
 {
   DirectoryBlobPartition game_partition(m_wrapped_volume.get(),
                                         m_wrapped_volume->GetGamePartition(), std::nullopt,

--- a/Source/Core/DiscIO/FileBlob.cpp
+++ b/Source/Core/DiscIO/FileBlob.cpp
@@ -15,7 +15,8 @@
 
 namespace DiscIO
 {
-PlainFileReader::PlainFileReader(File::IOFile file) : m_file(std::move(file))
+PlainFileReader::PlainFileReader(File::IOFile file)
+    : BlobReader(file.GetPath()), m_file(std::move(file))
 {
   m_size = m_file.GetSize();
 }

--- a/Source/Core/DiscIO/NFSBlob.cpp
+++ b/Source/Core/DiscIO/NFSBlob.cpp
@@ -159,8 +159,9 @@ std::unique_ptr<NFSFileReader> NFSFileReader::Create(File::IOFile first_file,
 
 NFSFileReader::NFSFileReader(std::vector<NFSLBARange> lba_ranges, std::vector<File::IOFile> files,
                              Key key, u64 raw_size)
-    : m_lba_ranges(std::move(lba_ranges)), m_files(std::move(files)),
-      m_aes_context(Common::AES::CreateContextDecrypt(key.data())), m_raw_size(raw_size)
+    : BlobReader(files.begin()->GetPath()), m_lba_ranges(std::move(lba_ranges)),
+      m_files(std::move(files)), m_aes_context(Common::AES::CreateContextDecrypt(key.data())),
+      m_raw_size(raw_size)
 {
   m_data_size = CalculateExpectedDataSize(m_lba_ranges);
 }

--- a/Source/Core/DiscIO/ScrubbedBlob.cpp
+++ b/Source/Core/DiscIO/ScrubbedBlob.cpp
@@ -16,7 +16,8 @@
 namespace DiscIO
 {
 ScrubbedBlob::ScrubbedBlob(std::unique_ptr<BlobReader> blob_reader, DiscScrubber scrubber)
-    : m_blob_reader(std::move(blob_reader)), m_scrubber(std::move(scrubber))
+    : BlobReader(blob_reader->GetFilePath()), m_blob_reader(std::move(blob_reader)),
+      m_scrubber(std::move(scrubber))
 {
 }
 

--- a/Source/Core/DiscIO/SplitFileBlob.cpp
+++ b/Source/Core/DiscIO/SplitFileBlob.cpp
@@ -18,7 +18,7 @@
 namespace DiscIO
 {
 SplitPlainFileReader::SplitPlainFileReader(std::vector<SingleFile> files)
-    : m_files(std::move(files))
+    : BlobReader(files.begin()->file.GetPath()), m_files(std::move(files))
 {
   m_size = 0;
   for (const auto& f : m_files)

--- a/Source/Core/DiscIO/TGCBlob.cpp
+++ b/Source/Core/DiscIO/TGCBlob.cpp
@@ -57,7 +57,8 @@ std::unique_ptr<TGCFileReader> TGCFileReader::Create(File::IOFile file)
   return nullptr;
 }
 
-TGCFileReader::TGCFileReader(File::IOFile file) : m_file(std::move(file))
+TGCFileReader::TGCFileReader(File::IOFile file)
+    : BlobReader(file.GetPath()), m_file(std::move(file))
 {
   m_file.Seek(0, File::SeekOrigin::Begin);
   m_file.ReadArray(&m_header, 1);

--- a/Source/Core/DiscIO/VolumeFileBlobReader.cpp
+++ b/Source/Core/DiscIO/VolumeFileBlobReader.cpp
@@ -29,7 +29,8 @@ std::unique_ptr<VolumeFileBlobReader> VolumeFileBlobReader::Create(const Volume&
 
 VolumeFileBlobReader::VolumeFileBlobReader(const Volume& volume, const Partition& partition,
                                            std::unique_ptr<FileInfo> file_info)
-    : m_volume(volume), m_partition(partition), m_file_info(std::move(file_info))
+    : BlobReader(volume.GetBlobReader().GetFilePath()), m_volume(volume), m_partition(partition),
+      m_file_info(std::move(file_info))
 {
 }
 

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -79,7 +79,7 @@ std::pair<int, int> GetAllowedCompressionLevels(WIARVZCompressionType compressio
 
 template <bool RVZ>
 WIARVZFileReader<RVZ>::WIARVZFileReader(File::IOFile file, const std::string& path)
-    : m_file(std::move(file)), m_encryption_cache(this)
+    : BlobReader(path), m_file(std::move(file)), m_encryption_cache(this)
 {
   m_valid = Initialize(path);
 }

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -25,7 +25,7 @@ static const u64 WII_SECTOR_COUNT = 143432 * 2;
 static const u64 WII_DISC_HEADER_SIZE = 256;
 
 WbfsFileReader::WbfsFileReader(File::IOFile file, const std::string& path)
-    : m_size(0), m_good(false)
+    : BlobReader(path), m_size(0), m_good(false)
 {
   if (!AddFileToList(std::move(file)))
     return;


### PR DESCRIPTION
BlobReader and all its sub-objects, along with IOFile, will now contain a file path field, set at construction, accessible through a GetFilePath() method. This is useful if anything needs to create a second volume file with the same path as the first.