### PR TITLE
Qt: Color Correction window fixes

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Dolphin Emulator Project
+// Copyright 2023 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.h"
@@ -8,12 +8,14 @@
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QLabel>
+#include <QRadioButton>
 
 #include "Core/Config/GraphicsSettings.h"
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
 #include "DolphinQt/Config/ConfigControls/ConfigFloatSlider.h"
+#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include "VideoCommon/VideoConfig.h"
 
@@ -29,35 +31,38 @@ ColorCorrectionConfigWindow::ColorCorrectionConfigWindow(QWidget* parent) : QDia
 void ColorCorrectionConfigWindow::Create()
 {
   static const char TR_COLOR_SPACE_CORRECTION_DESCRIPTION[] = QT_TR_NOOP(
-      "Converts the colors to the color spaces that GC/Wii were meant to work with to sRGB/Rec.709."
-      "<br><br>There's no way of knowing what exact color space games were meant for,"
-      "<br>given there were multiple standards and most games didn't acknowledge them,"
-      "<br>so it's not correct to assume a format from the game disc region."
-      "<br>Just pick the one that looks more natural to you,"
-      " or match it with the region the game was developed in."
-      "<br><br>HDR output is required to show all the colors from the PAL and NTSC-J color spaces."
-      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
-  static const char TR_GAME_GAMMA_DESCRIPTION[] =
-      QT_TR_NOOP("NTSC-M and NTSC-J target gamma ~2.2. PAL targets gamma ~2.8."
-                 "<br>None of the two were necessarily followed by games or TVs. 2.35 is a good "
-                 "generic value for all regions."
-                 "<br>If a game allows you to chose a gamma value, match it here.");
+      "Converts the colors from the color spaces that GC/Wii were meant to work with to "
+      "sRGB/Rec.709.<br><br>There's no way of knowing what exact color space games were meant for, "
+      "given there were multiple standards and most games didn't acknowledge them, so it's not "
+      "correct to assume a format from the game disc region. Just pick the one that looks more "
+      "natural to you, or match it with the region the game was developed in.<br><br>HDR output is "
+      "required to show all the colors from the PAL and NTSC-J color "
+      "spaces.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+  static const char TR_GAME_GAMMA_DESCRIPTION[] = QT_TR_NOOP(
+      "NTSC-M and NTSC-J target gamma ~2.2. PAL targets gamma ~2.8.<br>None of the two were "
+      "necessarily followed by games or TVs.<br>2.35 is a good generic value for all "
+      "regions.<br><br>If a game allows you to chose a gamma value, match it "
+      "here.<br><br><dolphin_emphasis>If unsure, leave this at 2.35.</dolphin_emphasis>");
   static const char TR_GAMMA_CORRECTION_DESCRIPTION[] = QT_TR_NOOP(
-      "Converts the gamma from what the game targeted to what your current SDR display targets."
-      "<br>Monitors often target sRGB. TVs often target 2.2."
-      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+      "Converts the gamma from what the game targeted to what your current SDR display "
+      "targets.<br>Monitors often target sRGB. TVs often target 2.2.<br><br><dolphin_emphasis>If "
+      "unsure, leave this unchecked.</dolphin_emphasis>");
+  static const char TR_HDR_PAPER_WHITE_NITS_DESCRIPTION[] = QT_TR_NOOP(
+      "Controls the base luminance of a paper white surface in nits. Useful for adjusting to "
+      "different environmental lighting conditions when using a HDR display.<br><br>HDR output is "
+      "required for this setting to take effect.<br><br><dolphin_emphasis>If unsure, leave this at "
+      "200.</dolphin_emphasis>");
 
   // Color Space:
 
   auto* const color_space_box = new QGroupBox(tr("Color Space"));
   auto* const color_space_layout = new QGridLayout();
-  color_space_layout->setVerticalSpacing(7);
   color_space_layout->setColumnStretch(1, 1);
   color_space_box->setLayout(color_space_layout);
 
   m_correct_color_space =
       new ConfigBool(tr("Correct Color Space"), Config::GFX_CC_CORRECT_COLOR_SPACE);
-  color_space_layout->addWidget(m_correct_color_space, 0, 0);
+  color_space_layout->addWidget(m_correct_color_space, 0, 0, 1, 2);
   m_correct_color_space->SetDescription(tr(TR_COLOR_SPACE_CORRECTION_DESCRIPTION));
 
   // "ColorCorrectionRegion"
@@ -65,7 +70,7 @@ void ColorCorrectionConfigWindow::Create()
                                           tr("PAL (EBU)")};
 
   m_game_color_space = new ConfigChoice(game_color_space_enum, Config::GFX_CC_GAME_COLOR_SPACE);
-  color_space_layout->addWidget(new QLabel(tr("Game Color Space")), 1, 0);
+  color_space_layout->addWidget(new QLabel(tr("Game Color Space:")), 1, 0);
   color_space_layout->addWidget(m_game_color_space, 1, 1);
 
   m_game_color_space->setEnabled(m_correct_color_space->isChecked());
@@ -74,72 +79,85 @@ void ColorCorrectionConfigWindow::Create()
 
   auto* const gamma_box = new QGroupBox(tr("Gamma"));
   auto* const gamma_layout = new QGridLayout();
-  gamma_layout->setVerticalSpacing(7);
-  gamma_layout->setColumnStretch(1, 1);
   gamma_box->setLayout(gamma_layout);
 
   m_game_gamma = new ConfigFloatSlider(Config::GFX_CC_GAME_GAMMA_MIN, Config::GFX_CC_GAME_GAMMA_MAX,
                                        Config::GFX_CC_GAME_GAMMA, 0.01f);
-  gamma_layout->addWidget(new QLabel(tr("Game Gamma")), 0, 0);
+  gamma_layout->addWidget(new QLabel(tr("Game Gamma:")), 0, 0);
   gamma_layout->addWidget(m_game_gamma, 0, 1);
+  m_game_gamma->SetTitle(tr("Game Gamma"));
   m_game_gamma->SetDescription(tr(TR_GAME_GAMMA_DESCRIPTION));
   m_game_gamma_value = new QLabel();
   gamma_layout->addWidget(m_game_gamma_value, 0, 2);
 
   m_correct_gamma = new ConfigBool(tr("Correct SDR Gamma"), Config::GFX_CC_CORRECT_GAMMA);
-  gamma_layout->addWidget(m_correct_gamma, 1, 0);
+  gamma_layout->addWidget(m_correct_gamma, 1, 0, 1, 2);
   m_correct_gamma->SetDescription(tr(TR_GAMMA_CORRECTION_DESCRIPTION));
 
-  m_sdr_display_gamma_srgb =
-      new ConfigBool(tr("SDR Display Gamma sRGB"), Config::GFX_CC_SDR_DISPLAY_GAMMA_SRGB);
-  gamma_layout->addWidget(m_sdr_display_gamma_srgb, 2, 0);
+  auto* const gamma_target_box = new QGroupBox(tr("SDR Display Gamma Target"));
+  auto* const gamma_target_layout = new QGridLayout();
+  gamma_target_box->setLayout(gamma_target_layout);
 
+  m_sdr_display_target_srgb = new QRadioButton(tr("sRGB"));
+  m_sdr_display_target_custom = new QRadioButton(tr("Custom:"));
   m_sdr_display_custom_gamma =
       new ConfigFloatSlider(Config::GFX_CC_DISPLAY_GAMMA_MIN, Config::GFX_CC_DISPLAY_GAMMA_MAX,
                             Config::GFX_CC_SDR_DISPLAY_CUSTOM_GAMMA, 0.01f);
-  gamma_layout->addWidget(new QLabel(tr("SDR Display Custom Gamma")), 3, 0);
-  gamma_layout->addWidget(m_sdr_display_custom_gamma, 3, 1);
   m_sdr_display_custom_gamma_value = new QLabel();
-  gamma_layout->addWidget(m_sdr_display_custom_gamma_value, 3, 2);
 
-  m_sdr_display_gamma_srgb->setEnabled(m_correct_gamma->isChecked());
+  gamma_target_layout->addWidget(m_sdr_display_target_srgb, 0, 0);
+  gamma_target_layout->addWidget(m_sdr_display_target_custom, 1, 0);
+  gamma_target_layout->addWidget(m_sdr_display_custom_gamma, 1, 1);
+  gamma_target_layout->addWidget(m_sdr_display_custom_gamma_value, 1, 2);
+
+  gamma_layout->addWidget(gamma_target_box, 2, 0, 1, 3);
+
+  m_sdr_display_target_srgb->setEnabled(m_correct_gamma->isChecked());
+  m_sdr_display_target_srgb->setChecked(Config::Get(Config::GFX_CC_SDR_DISPLAY_GAMMA_SRGB));
+
+  m_sdr_display_target_custom->setEnabled(m_correct_gamma->isChecked());
+  m_sdr_display_target_custom->setChecked(!m_sdr_display_target_srgb->isChecked());
+
   m_sdr_display_custom_gamma->setEnabled(m_correct_gamma->isChecked() &&
-                                         !m_sdr_display_gamma_srgb->isChecked());
-  m_game_gamma_value->setText(QString::asprintf("%f", m_game_gamma->GetValue()));
+                                         m_sdr_display_target_custom->isChecked());
+
+  m_game_gamma_value->setText(QString::asprintf("%.2f", m_game_gamma->GetValue()));
   m_sdr_display_custom_gamma_value->setText(
-      QString::asprintf("%f", m_sdr_display_custom_gamma->GetValue()));
+      QString::asprintf("%.2f", m_sdr_display_custom_gamma->GetValue()));
 
   // HDR:
 
   auto* const hdr_box = new QGroupBox(tr("HDR"));
   auto* const hdr_layout = new QGridLayout();
-  hdr_layout->setVerticalSpacing(7);
-  hdr_layout->setColumnStretch(1, 1);
   hdr_box->setLayout(hdr_layout);
 
   m_hdr_paper_white_nits = new ConfigFloatSlider(Config::GFX_CC_HDR_PAPER_WHITE_NITS_MIN,
                                                  Config::GFX_CC_HDR_PAPER_WHITE_NITS_MAX,
                                                  Config::GFX_CC_HDR_PAPER_WHITE_NITS, 1.f);
-  hdr_layout->addWidget(new QLabel(tr("HDR Paper White Nits")), 0, 0);
+  hdr_layout->addWidget(new QLabel(tr("HDR Paper White Nits:")), 0, 0);
   hdr_layout->addWidget(m_hdr_paper_white_nits, 0, 1);
+  m_hdr_paper_white_nits->SetTitle(tr("HDR Paper White Nits"));
+  m_hdr_paper_white_nits->SetDescription(tr(TR_HDR_PAPER_WHITE_NITS_DESCRIPTION));
   m_hdr_paper_white_nits_value = new QLabel();
   hdr_layout->addWidget(m_hdr_paper_white_nits_value, 0, 2);
 
   m_hdr_paper_white_nits_value->setText(
-      QString::asprintf("%f", m_hdr_paper_white_nits->GetValue()));
+      QString::asprintf("%.0f", m_hdr_paper_white_nits->GetValue()));
 
   // Other:
 
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
   auto* layout = new QVBoxLayout(this);
-  layout->setContentsMargins(0, 0, 0, 0);
   layout->setAlignment(Qt::AlignTop);
   layout->addWidget(color_space_box);
   layout->addWidget(gamma_box);
   layout->addWidget(hdr_box);
+  layout->addStretch();
   layout->addWidget(m_button_box);
+
   setLayout(layout);
+  WrapInScrollArea(this, layout);
 }
 
 void ColorCorrectionConfigWindow::ConnectWidgets()
@@ -148,7 +166,7 @@ void ColorCorrectionConfigWindow::ConnectWidgets()
           [this] { m_game_color_space->setEnabled(m_correct_color_space->isChecked()); });
 
   connect(m_game_gamma, &ConfigFloatSlider::valueChanged, this, [this] {
-    m_game_gamma_value->setText(QString::asprintf("%f", m_game_gamma->GetValue()));
+    m_game_gamma_value->setText(QString::asprintf("%.2f", m_game_gamma->GetValue()));
   });
 
   connect(m_correct_gamma, &QCheckBox::toggled, this, [this] {
@@ -157,24 +175,26 @@ void ColorCorrectionConfigWindow::ConnectWidgets()
     // For the moment we leave this enabled even when we are outputting in HDR
     // (which means they'd have no influence on the final image),
     // mostly because we don't have a simple way to determine if HDR is engaged from here
-    m_sdr_display_gamma_srgb->setEnabled(m_correct_gamma->isChecked());
+    m_sdr_display_target_srgb->setEnabled(m_correct_gamma->isChecked());
+    m_sdr_display_target_custom->setEnabled(m_correct_gamma->isChecked());
     m_sdr_display_custom_gamma->setEnabled(m_correct_gamma->isChecked() &&
-                                           !m_sdr_display_gamma_srgb->isChecked());
+                                           m_sdr_display_target_custom->isChecked());
   });
 
-  connect(m_sdr_display_gamma_srgb, &QCheckBox::toggled, this, [this] {
-    m_sdr_display_custom_gamma->setEnabled(m_correct_gamma->isChecked() &&
-                                           !m_sdr_display_gamma_srgb->isChecked());
+  connect(m_sdr_display_target_srgb, &QRadioButton::toggled, this, [this] {
+    Config::SetBaseOrCurrent(Config::GFX_CC_SDR_DISPLAY_GAMMA_SRGB,
+                             m_sdr_display_target_srgb->isChecked());
+    m_sdr_display_custom_gamma->setEnabled(!m_sdr_display_target_srgb->isChecked());
   });
 
   connect(m_sdr_display_custom_gamma, &ConfigFloatSlider::valueChanged, this, [this] {
     m_sdr_display_custom_gamma_value->setText(
-        QString::asprintf("%f", m_sdr_display_custom_gamma->GetValue()));
+        QString::asprintf("%.2f", m_sdr_display_custom_gamma->GetValue()));
   });
 
   connect(m_hdr_paper_white_nits, &ConfigFloatSlider::valueChanged, this, [this] {
     m_hdr_paper_white_nits_value->setText(
-        QString::asprintf("%f", m_hdr_paper_white_nits->GetValue()));
+        QString::asprintf("%.0f", m_hdr_paper_white_nits->GetValue()));
   });
 
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);

--- a/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.h
+++ b/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.h
@@ -1,16 +1,17 @@
-// Copyright 2018 Dolphin Emulator Project
+// Copyright 2023 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 
 #include <QDialog>
 
-class QWidget;
-class QLabel;
 class ConfigBool;
 class ConfigChoice;
 class ConfigFloatSlider;
 class QDialogButtonBox;
+class QLabel;
+class QRadioButton;
+class QWidget;
 
 class ColorCorrectionConfigWindow final : public QDialog
 {
@@ -27,7 +28,8 @@ private:
   ConfigFloatSlider* m_game_gamma;
   QLabel* m_game_gamma_value;
   ConfigBool* m_correct_gamma;
-  ConfigBool* m_sdr_display_gamma_srgb;
+  QRadioButton* m_sdr_display_target_srgb;
+  QRadioButton* m_sdr_display_target_custom;
   ConfigFloatSlider* m_sdr_display_custom_gamma;
   QLabel* m_sdr_display_custom_gamma_value;
   ConfigFloatSlider* m_hdr_paper_white_nits;


### PR DESCRIPTION
This PR contains a collection of improvements and fixes for the Color Correction window, originally introduced in PR #11850:

* Restored default padding around the widgets
* Made the window resizable and made sure it doesn't fall apart during resizing
* Trimmed/Removed unnecessary fractional part of float numbers where applicable (visual only, they still have the same precision code side)
* Converted "SDR Display Gamma sRGB" checkbox and "SDR Display Custom Gamma" slider into a secondary group box with radio buttons to more explicitly show the relation between the two
* Various tooltip fixes
  * Added missing title to "Game Gamma" tooltip and mentioned default value in the tooltip description
  * Added tooltip to "HDR Paper White Nits" slider
  * Removed unnecessary line breaks where applicable
  * Removed empty tooltip from "SDR Display Custom Gamma"
* Fixed copyright date and include order on source files

<img width="300" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/8005966/5847c37b-a9e9-493f-b2fb-6770c640e3ac"><br/>

<img width="285" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/8005966/14c35152-e16f-4a68-9685-5aef12e9b733"><br/>

<img width="210" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/8005966/ad2035d9-34e4-49e0-8f5f-8bb3febd05ff">

Ready to review and merge.


