### PR TITLE
Fix compile error with musl libc

### DIFF
--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -18,11 +18,11 @@
 
 #include <fmt/format.h>
 
-#ifdef __linux__ // features.h is only available on Linux
-#define _GNU_SOURCE // We have to define this to use macros in features.h
+#ifdef __linux__     // features.h is only available on Linux
+#define _GNU_SOURCE  // We have to define this to use macros in features.h
 #include <features.h>
 #ifndef __USE_GNU
-#define __MUSL__ 
+#define __MUSL__
 #endif
 #undef _GNU_SOURCE
 #endif

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -22,7 +22,7 @@
 #define _GNU_SOURCE  // We have to define this to use macros in features.h
 #include <features.h>
 #ifndef __USE_GNU
-#define __MUSL__
+#define __NO_GLIBC__
 #endif
 #undef _GNU_SOURCE
 #endif
@@ -561,8 +561,8 @@ const char* DecodeNetworkError(s32 error_code)
   thread_local char buffer[1024];
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(ANDROID) ||     \
-    defined(__APPLE__)
-#define IS_BSD_STRERROR
+    defined(__APPLE__) || defined(__NO_GLIBC__)
+#define USE_XSI_STRERROR
 #endif
 
 #ifdef _WIN32
@@ -571,8 +571,8 @@ const char* DecodeNetworkError(s32 error_code)
                  nullptr, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer,
                  sizeof(buffer), nullptr);
   return buffer;
-#elif defined(IS_BSD_STRERROR) ||                                                                  \
-    ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE) || defined(__MUSL__)
+#elif defined(USE_XSI_STRERROR) ||                                                                  \
+    ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE)
   strerror_r(error_code, buffer, sizeof(buffer));
   return buffer;
 #else

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -18,6 +18,13 @@
 
 #include <fmt/format.h>
 
+#define _GNU_SOURCE
+#include <features.h>
+#ifndef __USE_GNU
+    #define __MUSL__ 
+#endif
+#undef _GNU_SOURCE
+
 #include "Common/BitUtils.h"
 #include "Common/Random.h"
 #include "Common/StringUtil.h"
@@ -563,7 +570,7 @@ const char* DecodeNetworkError(s32 error_code)
                  sizeof(buffer), nullptr);
   return buffer;
 #elif defined(IS_BSD_STRERROR) ||                                                                  \
-    ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE)
+    ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE) || defined(__MUSL__)
   strerror_r(error_code, buffer, sizeof(buffer));
   return buffer;
 #else

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -18,6 +18,7 @@
 
 #include <fmt/format.h>
 
+// https://stackoverflow.com/a/70211227
 #ifdef __linux__     // features.h is only available on Linux
 #define _GNU_SOURCE  // We have to define this to use macros in features.h
 #include <features.h>

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -18,12 +18,14 @@
 
 #include <fmt/format.h>
 
-#define _GNU_SOURCE
+#ifdef __linux__ // features.h is only available on Linux
+#define _GNU_SOURCE // We have to define this to use macros in features.h
 #include <features.h>
 #ifndef __USE_GNU
-    #define __MUSL__ 
+#define __MUSL__ 
 #endif
 #undef _GNU_SOURCE
+#endif
 
 #include "Common/BitUtils.h"
 #include "Common/Random.h"


### PR DESCRIPTION
This PR fixes the following compile-time error when compiling Dolphin with the musl libc:

```
../Source/Core/Common/Network.cpp: In function 'const char* Common::DecodeNetworkError(s32)':
../Source/Core/Common/Network.cpp:570:20: error: invalid conversion from 'int' to 'const char*' [-fpermissive]
  570 |   return strerror_r(error_code, buffer, sizeof(buffer));
      |          ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                    |
      |                    int
```