### PR TITLE
VideoCommon: add the ability to load assets from graphics mods

### DIFF
--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -663,6 +663,7 @@
     <ClInclude Include="VideoCommon\GeometryShaderGen.h" />
     <ClInclude Include="VideoCommon\GeometryShaderManager.h" />
     <ClInclude Include="VideoCommon\GraphicsModSystem\Config\GraphicsMod.h" />
+    <ClInclude Include="VideoCommon\GraphicsModSystem\Config\GraphicsModAsset.h" />
     <ClInclude Include="VideoCommon\GraphicsModSystem\Config\GraphicsModFeature.h" />
     <ClInclude Include="VideoCommon\GraphicsModSystem\Config\GraphicsModGroup.h" />
     <ClInclude Include="VideoCommon\GraphicsModSystem\Config\GraphicsTarget.h" />
@@ -1276,6 +1277,7 @@
     <ClCompile Include="VideoCommon\GeometryShaderGen.cpp" />
     <ClCompile Include="VideoCommon\GeometryShaderManager.cpp" />
     <ClCompile Include="VideoCommon\GraphicsModSystem\Config\GraphicsMod.cpp" />
+    <ClCompile Include="VideoCommon\GraphicsModSystem\Config\GraphicsModAsset.cpp" />
     <ClCompile Include="VideoCommon\GraphicsModSystem\Config\GraphicsModFeature.cpp" />
     <ClCompile Include="VideoCommon\GraphicsModSystem\Config\GraphicsModGroup.cpp" />
     <ClCompile Include="VideoCommon\GraphicsModSystem\Config\GraphicsTarget.cpp" />

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -64,6 +64,8 @@ add_library(videocommon
   GeometryShaderManager.h
   GraphicsModSystem/Config/GraphicsMod.cpp
   GraphicsModSystem/Config/GraphicsMod.h
+  GraphicsModSystem/Config/GraphicsModAsset.cpp
+  GraphicsModSystem/Config/GraphicsModAsset.h
   GraphicsModSystem/Config/GraphicsModFeature.cpp
   GraphicsModSystem/Config/GraphicsModFeature.h
   GraphicsModSystem/Config/GraphicsModGroup.cpp

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsMod.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsMod.cpp
@@ -178,6 +178,27 @@ bool GraphicsModConfig::DeserializeFromConfig(const picojson::value& value)
     }
   }
 
+  const auto& assets = value.get("assets");
+  if (assets.is<picojson::array>())
+  {
+    for (const auto& asset_val : assets.get<picojson::array>())
+    {
+      if (!asset_val.is<picojson::object>())
+      {
+        ERROR_LOG_FMT(
+            VIDEO, "Failed to load mod configuration file, specified asset is not a json object");
+        return false;
+      }
+      GraphicsModAssetConfig asset;
+      if (!asset.DeserializeFromConfig(asset_val.get<picojson::object>()))
+      {
+        return false;
+      }
+
+      m_assets.push_back(std::move(asset));
+    }
+  }
+
   return true;
 }
 

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsMod.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsMod.h
@@ -9,6 +9,7 @@
 
 #include <picojson.h>
 
+#include "VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.h"
 #include "VideoCommon/GraphicsModSystem/Config/GraphicsModFeature.h"
 #include "VideoCommon/GraphicsModSystem/Config/GraphicsTargetGroup.h"
 
@@ -30,6 +31,7 @@ struct GraphicsModConfig
 
   std::vector<GraphicsTargetGroupConfig> m_groups;
   std::vector<GraphicsModFeatureConfig> m_features;
+  std::vector<GraphicsModAssetConfig> m_assets;
 
   static std::optional<GraphicsModConfig> Create(const std::string& file, Source source);
   static std::optional<GraphicsModConfig> Create(const picojson::object* obj);

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.cpp
@@ -1,0 +1,53 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.h"
+
+#include "Common/Logging/Log.h"
+
+bool GraphicsModAssetConfig::DeserializeFromConfig(const picojson::object& obj)
+{
+  auto name_iter = obj.find("name");
+  if (name_iter == obj.end())
+  {
+    ERROR_LOG_FMT(VIDEO, "Failed to load mod configuration file, specified asset has no name");
+    return false;
+  }
+  if (!name_iter->second.is<std::string>())
+  {
+    ERROR_LOG_FMT(VIDEO, "Failed to load mod configuration file, specified asset has a name "
+                         "that is not a string");
+    return false;
+  }
+  m_name = name_iter->second.to_str();
+
+  auto data_iter = obj.find("data");
+  if (data_iter == obj.end())
+  {
+    ERROR_LOG_FMT(VIDEO, "Failed to load mod configuration file, specified asset '{}' has no data",
+                  m_name);
+    return false;
+  }
+  if (!data_iter->second.is<picojson::object>())
+  {
+    ERROR_LOG_FMT(VIDEO,
+                  "Failed to load mod configuration file, specified asset '{}' has data "
+                  "that is not an object",
+                  m_name);
+    return false;
+  }
+  for (const auto& [key, value] : data_iter->second.get<picojson::object>())
+  {
+    if (!value.is<std::string>())
+    {
+      ERROR_LOG_FMT(VIDEO,
+                    "Failed to load mod configuration file, specified asset '{}' has data "
+                    "with a value for key '{}' that is not a string",
+                    m_name, key);
+      return false;
+    }
+    m_map[key] = value.to_str();
+  }
+
+  return true;
+}

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.h
@@ -1,0 +1,18 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+#include <picojson.h>
+
+#include "VideoCommon/Assets/DirectFilesystemAssetLibrary.h"
+
+struct GraphicsModAssetConfig
+{
+  std::string m_name;
+  VideoCommon::DirectFilesystemAssetLibrary::AssetMap m_map;
+
+  bool DeserializeFromConfig(const picojson::object& obj);
+};

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.cpp
@@ -11,7 +11,7 @@
 namespace GraphicsModActionFactory
 {
 std::unique_ptr<GraphicsModAction> Create(std::string_view name, const picojson::value& json_data,
-                                          std::string_view path)
+                                          std::shared_ptr<VideoCommon::CustomAssetLibrary> library)
 {
   if (name == "print")
   {

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.h
@@ -8,10 +8,11 @@
 
 #include <picojson.h>
 
+#include "VideoCommon/Assets/CustomAssetLibrary.h"
 #include "VideoCommon/GraphicsModSystem/Runtime/GraphicsModAction.h"
 
 namespace GraphicsModActionFactory
 {
 std::unique_ptr<GraphicsModAction> Create(std::string_view name, const picojson::value& json_data,
-                                          std::string_view path);
+                                          std::shared_ptr<VideoCommon::CustomAssetLibrary> library);
 }


### PR DESCRIPTION
Here's a review to add support to load assets that I've been defining from a graphics mod.  This will allow users to not only expose assets for their own game mods but also can release a graphics mod with just assets that allow for assets to be re-used by multiple game mods.

After doing this change, I do realize I will need to make some tweaks in the future to support compressed packs and handle any asset name conflicts (most likely will prefix with the pack name).

This is needed for the revamp of #11300 