### PR TITLE
D3D: Remove Windows 7 mention in logic ops warning

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DMain.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DMain.cpp
@@ -42,7 +42,7 @@ std::optional<std::string> VideoBackend::GetWarningMessage() const
 {
   std::optional<std::string> result;
 
-  // If user is on Win7, show a warning about partial DX11.1 support
+  // If relevant, show a warning about partial DX11.1 support
   // This is being called BEFORE FillBackendInfo is called for this backend,
   // so query for logic op support manually
   bool supportsLogicOp = false;
@@ -54,10 +54,11 @@ std::optional<std::string> VideoBackend::GetWarningMessage() const
 
   if (!supportsLogicOp)
   {
-    result = _trans("Direct3D 11 renderer requires support for features not supported by your "
-                    "system configuration. This is most likely because you are using Windows 7. "
-                    "You may still use this backend, but you might encounter graphical artifacts."
-                    "\n\nDo you really want to switch to Direct3D 11? If unsure, select 'No'.");
+    result = _trans("The Direct3D 11 renderer requires support for features not supported by your "
+                    "system configuration. You may still use this backend, but you will encounter "
+                    "graphical artifacts in certain games.\n"
+                    "\n"
+                    "Do you really want to switch to Direct3D 11? If unsure, select 'No'.");
   }
 
   return result;


### PR DESCRIPTION
Dolphin no longer supports Windows 7, so the fact that there are (were?) more people who use Windows 7 than who use a GPU that doesn't support the required feature is no longer relevant.