### PR TITLE
Do not try portmapping when using traversal server

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -169,7 +169,7 @@ NetPlayServer::NetPlayServer(const u16 port, const bool forward_port, NetPlayUI*
     m_chunked_data_thread = std::thread(&NetPlayServer::ChunkedDataThreadFunc, this);
 
 #ifdef USE_UPNP
-    if (forward_port)
+    if (forward_port && !traversal_config.use_traversal)
       Common::UPnP::TryPortmapping(port);
 #endif
   }


### PR DESCRIPTION
using portmapping with hosting while using traversal server (which is possible by checking the option while under "direct connect" and flipping back to traversal server) causes dolphin to request a mapping to external port 0.

In UPnP a mapping to external port 0 is actually the wildcard, which means that connection requests on all external ports (that are not otherwise mapped) will be forwarded to the client.

Additionally it seems like using port mapping with traversal server is probably not expected behavior, as the option checkbox disappears when traversal server is used.