### PR TITLE
[Minor Bugfix]  Extremely rare HostID collision bugfix

### DIFF
--- a/Source/Core/Common/TraversalServer.cpp
+++ b/Source/Core/Common/TraversalServer.cpp
@@ -312,9 +312,9 @@ static void HandlePacket(Common::TraversalPacket* packet, sockaddr_in6* addr)
       Common::TraversalInetAddress* iaddr{};
       // not that there is any significant change of
       // duplication, but...
-      GetRandomHostId(&hostId);
       while (true)
       {
+        GetRandomHostId(&hostId);
         auto r = EvictFind(connectedClients, hostId);
         if (!r.found)
         {


### PR DESCRIPTION
Fixed a bug where in the extremely unlikely change that HostIDs collide, a new HostID is generated to be used. I'm not sure what the full impact would be if there was a collision, but I imagine it'd be stuck in this while loop until the HostID that collided got old enough to be reused. So 30s + however long the code is refreshed for.