### PR TITLE
Jit: Load the memory register only when the msr bits have changed and do not use jumps to load it.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -87,6 +87,8 @@ public:
 
   // Utilities for use by opcodes
 
+  void EmitUpdateMembase();
+  void EmitStoreMembase(const Gen::OpArg& msr, Gen::X64Reg scratch_reg);
   void FakeBLCall(u32 after);
   void WriteExit(u32 destination, bool bl = false, u32 after = 0);
   void JustWriteExit(u32 destination, bool bl, u32 after);

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -65,6 +65,11 @@ void Jit64AsmRoutineManager::Generate()
   ABI_CallFunction(CoreTiming::GlobalAdvance);
   ABI_PopRegistersAndAdjustStack({}, 0);
 
+  // When we've just entered the jit we need to update the membase
+  // GlobalAdvance also checks exceptions after which we need to
+  // update the membase so it makes sense to do this here.
+  m_jit.EmitUpdateMembase();
+
   // skip the sync and compare first time
   FixupBranch skipToRealDispatch = J(enable_debugging ? Jump::Near : Jump::Short);
 
@@ -103,8 +108,6 @@ void Jit64AsmRoutineManager::Generate()
   SetJumpTarget(skipToRealDispatch);
 
   dispatcher_no_check = GetCodePtr();
-
-  auto& memory = system.GetMemory();
 
   // The following is a translation of JitBaseBlockCache::Dispatch into assembly.
   const bool assembly_dispatcher = true;
@@ -165,13 +168,6 @@ void Jit64AsmRoutineManager::Generate()
     FixupBranch state_mismatch = J_CC(CC_NE);
 
     // Success; branch to the block we found.
-    // Switch to the correct memory base, in case MSR.DR has changed.
-    TEST(32, PPCSTATE(msr), Imm32(1 << (31 - 27)));
-    FixupBranch physmem = J_CC(CC_Z);
-    MOV(64, R(RMEM), ImmPtr(memory.GetLogicalBase()));
-    JMPptr(MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlockData, normalEntry))));
-    SetJumpTarget(physmem);
-    MOV(64, R(RMEM), ImmPtr(memory.GetPhysicalBase()));
     JMPptr(MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlockData, normalEntry))));
 
     SetJumpTarget(not_found);
@@ -189,13 +185,7 @@ void Jit64AsmRoutineManager::Generate()
   TEST(64, R(ABI_RETURN), R(ABI_RETURN));
   FixupBranch no_block_available = J_CC(CC_Z);
 
-  // Switch to the correct memory base, in case MSR.DR has changed.
-  TEST(32, PPCSTATE(msr), Imm32(1 << (31 - 27)));
-  FixupBranch physmem = J_CC(CC_Z);
-  MOV(64, R(RMEM), ImmPtr(memory.GetLogicalBase()));
-  JMPptr(R(ABI_RETURN));
-  SetJumpTarget(physmem);
-  MOV(64, R(RMEM), ImmPtr(memory.GetPhysicalBase()));
+  // Jump to the block
   JMPptr(R(ABI_RETURN));
 
   SetJumpTarget(no_block_available);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -12,6 +12,7 @@
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 // The branches are known good, or at least reasonably good.
 // No need for a disable-mechanism.
@@ -54,6 +55,9 @@ void Jit64::rfi(UGeckoInstruction inst)
   MOV(32, R(RSCRATCH), PPCSTATE_SRR1);
   AND(32, R(RSCRATCH), Imm32(mask & clearMSR13));
   OR(32, PPCSTATE(msr), R(RSCRATCH));
+
+  EmitStoreMembase(R(RSCRATCH), RSCRATCH2);
+
   // NPC = SRR0;
   MOV(32, R(RSCRATCH), PPCSTATE_SRR0);
   WriteRfiExitDestInRSCRATCH();

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -438,7 +438,10 @@ void Jit64::mtmsr(UGeckoInstruction inst)
     RCOpArg Rs = gpr.BindOrImm(inst.RS, RCMode::Read);
     RegCache::Realize(Rs);
     MOV(32, PPCSTATE(msr), Rs);
+
+    EmitStoreMembase(PPCSTATE(msr), RSCRATCH2);
   }
+
   gpr.Flush();
   fpr.Flush();
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -311,6 +311,9 @@ protected:
   void BeginTimeProfile(JitBlock* b);
   void EndTimeProfile(JitBlock* b);
 
+  void EmitUpdateMembase();
+  void EmitStoreMembase(const Arm64Gen::ARM64Reg& msr);
+
   // Exits
   void WriteExit(u32 destination, bool LK = false, u32 exit_address_after_return = 0);
   void WriteExit(Arm64Gen::ARM64Reg dest, bool LK = false, u32 exit_address_after_return = 0);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -11,6 +11,7 @@
 #include "Core/PowerPC/JitArm64/JitArm64_RegCache.h"
 #include "Core/PowerPC/PPCTables.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 using namespace Arm64Gen;
 
@@ -63,6 +64,8 @@ void JitArm64::rfi(UGeckoInstruction inst)
   ORR(WA, WA, WC);                        // rB = Masked MSR OR masked SRR1
 
   STR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(msr));  // STR rB in to rA
+
+  EmitStoreMembase(WA);
 
   LDR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_SRR0));
   gpr.Unlock(WB, WC);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -94,6 +94,8 @@ void JitArm64::mtmsr(UGeckoInstruction inst)
   gpr.BindToRegister(inst.RS, true);
   STR(IndexType::Unsigned, gpr.R(inst.RS), PPC_REG, PPCSTATE_OFF(msr));
 
+  EmitStoreMembase(gpr.R(inst.RS));
+
   gpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
   fpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
 

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -98,6 +98,25 @@ void JitInterface::SetProfilingState(ProfilingState state)
   m_jit->jo.profile_blocks = state == ProfilingState::Enabled;
 }
 
+void JitInterface::UpdateMembase()
+{
+  if (!m_jit)
+    return;
+
+  auto& ppc_state = m_system.GetPPCState();
+  auto& memory = m_system.GetMemory();
+  if (ppc_state.msr.DR)
+  {
+    ppc_state.mem_ptr =
+        m_jit->jo.fastmem_arena ? memory.GetLogicalBase() : memory.GetLogicalPageMappingsBase();
+  }
+  else
+  {
+    ppc_state.mem_ptr =
+        m_jit->jo.fastmem_arena ? memory.GetPhysicalBase() : memory.GetPhysicalPageMappingsBase();
+  }
+}
+
 void JitInterface::WriteProfileResults(const std::string& filename) const
 {
   Profiler::ProfileStats prof_stats;

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -61,6 +61,7 @@ public:
     u32 entry_address;
   };
 
+  void UpdateMembase();
   void SetProfilingState(ProfilingState state);
   void WriteProfileResults(const std::string& filename) const;
   void GetProfileResults(Profiler::ProfileStats* prof_stats) const;

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -569,7 +569,10 @@ void PowerPCManager::CheckExceptions()
   else
   {
     CheckExternalExceptions();
+    return;
   }
+
+  m_system.GetJitInterface().UpdateMembase();
 }
 
 void PowerPCManager::CheckExternalExceptions()
@@ -623,6 +626,8 @@ void PowerPCManager::CheckExternalExceptions()
                     exceptions);
     }
   }
+
+  m_system.GetJitInterface().UpdateMembase();
 }
 
 void PowerPCManager::CheckBreakPoints()

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -169,6 +169,7 @@ struct PowerPCState
 
   // Storage for the stack pointer of the BLR optimization.
   u8* stored_stack_pointer = nullptr;
+  u8* mem_ptr = nullptr;
 
   std::array<std::array<TLBEntry, TLB_SIZE / TLB_WAYS>, NUM_TLBS> tlb;
 


### PR DESCRIPTION
Not sure if this is worth the time, but i made it so here we go.

Basically turns the membase switch into a single instruction (except when msr changes, then it's more).