### PR TITLE
VideoCommon: fix some compiler warnings for CustomAsset

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomAsset.h
+++ b/Source/Core/VideoCommon/Assets/CustomAsset.h
@@ -20,10 +20,10 @@ public:
   CustomAsset(std::shared_ptr<CustomAssetLibrary> library,
               const CustomAssetLibrary::AssetID& asset_id);
   virtual ~CustomAsset() = default;
-  CustomAsset(const CustomAsset&) = default;
-  CustomAsset(CustomAsset&&) = default;
-  CustomAsset& operator=(const CustomAsset&) = default;
-  CustomAsset& operator=(CustomAsset&&) = default;
+  CustomAsset(const CustomAsset&) = delete;
+  CustomAsset(CustomAsset&&) = delete;
+  CustomAsset& operator=(const CustomAsset&) = delete;
+  CustomAsset& operator=(CustomAsset&&) = delete;
 
   // Loads the asset from the library returning a pass/fail result
   bool Load();


### PR DESCRIPTION
FreeBSD compiler was complaining about my usage of the defaulted copy/move constructor in `CustomAsset` (for good reason!).  This should silence those warnings.