### PR TITLE
Announce RSCRATCH clobbering in Jit64::Cleanup() when profiling is enabled

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -469,6 +469,7 @@ bool Jit64::Cleanup()
         Imm32(js.downcountAmount));
     MOV(64, MDisp(RSCRATCH2, offsetof(JitBlock::ProfileData, ticCounter)), R(RSCRATCH));
     ABI_PopRegistersAndAdjustStack({}, 0);
+    did_something = true;
   }
 
   return did_something;


### PR DESCRIPTION
I am not sure what bugs this mistake may cause, but it seems like a mistake to me.