### PR TITLE
Add Forecast Channel buffer patch

### DIFF
--- a/Data/Sys/GameSettings/HAF.ini
+++ b/Data/Sys/GameSettings/HAF.ini
@@ -1,5 +1,24 @@
 # HAFE01, HAFJ01, HAFP01 - Forecast Channel
 
+[OnFrame_Enabled]
+$BufferPatch
+
+[OnFrame]
+$BufferPatch
+0x8000AA9E:word:0x00000008
+0x8000AAC6:word:0x00007000
+0x8000AAD0:dword:0x3C600001
+0x8000AE08:dword:0x3C000001
+0x8000AE06:word:0x00000008
+0x8000AE0E:word:0x00007000
+0x8000AEEE:word:0x00000008
+0x8000AEFE:word:0x00007000
+0x8000AF5A:word:0x00000008
+0x8000AF6A:word:0x00007000
+0x8000AFEC:dword:0x3CC00001
+0x8000B08E:word:0x00000008
+0x8000B09E:word:0x00007000
+
 [WC24Patch]
 $Main
 weather.wapp.wii.com:fore.wiilink24.com:1


### PR DESCRIPTION
Adds a memory patch that extends the working buffer for the files the Forecast Channel downloads.

This is required as an update to the WiiLink Forecast Channel which adds a couple hundred more cities will cause the channel to break with a `WiiConnect24 service is currently unavailable error`.