### PR TITLE
VideoCommon: skip the texture dump if a custom texture is available, regardless if it is loaded or not

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -351,7 +351,7 @@ private:
   CreateTextureEntry(const TextureCreationInfo& creation_info, const TextureInfo& texture_info,
                      int safety_color_sample_size,
                      std::vector<std::shared_ptr<VideoCommon::CustomTextureData>> assets_data,
-                     bool custom_arbitrary_mipmaps);
+                     bool custom_arbitrary_mipmaps, bool skip_texture_dump);
 
   RcTcacheEntry GetXFBFromCache(u32 address, u32 width, u32 height, u32 stride);
 


### PR DESCRIPTION
A user on the forums pointed this out.  Previously, we were still dumping textures for games if the custom texture hadn't asynchronously loaded yet.