### PR TITLE
Cache QueryPerformanceFrequency() result

### DIFF
--- a/Source/Core/Common/PerformanceCounter.h
+++ b/Source/Core/Common/PerformanceCounter.h
@@ -3,14 +3,16 @@
 
 #pragma once
 
-#if !defined(_WIN32)
-
-#include <cstdint>
-
 #include "Common/CommonTypes.h"
+
+#if defined(_WIN32)
+#include <profileapi.h>
+#else
 
 typedef u64 LARGE_INTEGER;
 bool QueryPerformanceCounter(u64* out);
 bool QueryPerformanceFrequency(u64* lpFrequency);
 
 #endif
+
+u64 QueryCachedPerformanceFrequency();

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -10,11 +10,6 @@
 #include <disasm.h>
 #include <fmt/format.h>
 
-// for the PROFILER stuff
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #include "Common/CommonTypes.h"
 #include "Common/GekkoDisassembler.h"
 #include "Common/IOFile.h"

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -8,12 +8,6 @@
 #include <string>
 #include <unordered_set>
 
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include "Common/PerformanceCounter.h"
-#endif
-
 #include <fmt/format.h>
 
 #include "Common/Assert.h"
@@ -21,6 +15,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"
 #include "Common/MsgHandler.h"
+#include "Common/PerformanceCounter.h"
 
 #include "Core/Core.h"
 #include "Core/PowerPC/CPUCoreBase.h"
@@ -120,7 +115,7 @@ void JitInterface::WriteProfileResults(const std::string& filename) const
                               stat.addr, name, stat.run_count, stat.cost, stat.tick_counter,
                               percent, timePercent,
                               static_cast<double>(stat.tick_counter) * 1000.0 /
-                                  static_cast<double>(prof_stats.countsPerSec),
+                                  static_cast<double>(QueryCachedPerformanceFrequency()),
                               stat.block_size));
   }
 }
@@ -136,7 +131,6 @@ void JitInterface::GetProfileResults(Profiler::ProfileStats* prof_stats) const
   prof_stats->block_stats.clear();
 
   Core::RunAsCPUThread([this, &prof_stats] {
-    QueryPerformanceFrequency((LARGE_INTEGER*)&prof_stats->countsPerSec);
     m_jit->GetBlockCache()->RunOnBlocks([&prof_stats](const JitBlock& block) {
       const auto& data = block.profile_data;
       u64 cost = data.downcountCounter;

--- a/Source/Core/Core/PowerPC/Profiler.h
+++ b/Source/Core/Core/PowerPC/Profiler.h
@@ -30,7 +30,6 @@ struct ProfileStats
   std::vector<BlockStat> block_stats;
   u64 cost_sum = 0;
   u64 timecost_sum = 0;
-  u64 countsPerSec = 0;
 };
 
 }  // namespace Profiler


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancefrequency
The result of QueryPerformanceFrequency will never change, according to this Win32 API documentation.  The non-windows result of QueryPerformanceFrequency is known at compile time.  I think it can be left out of the ProfileStats struct and cached elsewhere.