### PR TITLE
Add Enable WiiLink checkbox to Android GUI

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -128,6 +128,7 @@ enum class BooleanSetting(
         "EnableSaveStates",
         false
     ),
+    MAIN_WII_WIILINK_ENABLE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "EnableWiiLink", false),
     MAIN_DSP_JIT(Settings.FILE_DOLPHIN, Settings.SECTION_INI_DSP, "EnableJIT", true),
     MAIN_EXPAND_TO_CUTOUT_AREA(
         Settings.FILE_DOLPHIN,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -713,6 +713,14 @@ class SettingsFragmentPresenter(
             )
         )
         sl.add(
+          SwitchSetting(
+            context,
+            BooleanSetting.MAIN_WII_WIILINK_ENABLE,
+            R.string.wii_enable_wiilink,
+            R.string.wii_enable_wiilink_description
+          )
+        )
+        sl.add(
             SingleChoiceSetting(
                 context,
                 IntSetting.SYSCONF_SOUND_MODE,

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -92,6 +92,8 @@
     <string name="wii_pal60_description">Changes refresh rate from 50 Hz to 60 Hz in PAL games that support it.</string>
     <string name="wii_screensaver">Enable Screen Saver</string>
     <string name="wii_screensaver_description">Dims the screen after five minutes of inactivity.</string>
+    <string name="wii_enable_wiilink">Enable WiiConnect24 via WiiLink</string>
+    <string name="wii_enable_wiilink_description">Enables the WiiLink service for WiiConnect24 channels. Read the Terms of Service at https://www.wiilink24.com/tos</string>
     <string name="sound_mode">Sound</string>
     <string name="insert_sd_card">Insert SD Card</string>
     <string name="insert_sd_card_description">Supports SD and SDHC. Default size is 128 MB.</string>


### PR DESCRIPTION
Adds the `Enable WiiConnect24 via WiiLink` checkbox. Allows for the onboard WiiLink patches to function if enabled.

![](https://cdn.discordapp.com/attachments/1049400262302912593/1131739138949922836/Screenshot_2023-07-20_200637.png)
