### PR TITLE
Override FastTextureSampling for Skylanders: Trap Team

### DIFF
--- a/Data/Sys/GameSettings/SK8.ini
+++ b/Data/Sys/GameSettings/SK8.ini
@@ -1,0 +1,4 @@
+# SK8E52, SK8I52, SK8P52, SK8V52, SK8X52 - Skylanders: Trap Team
+
+[Video_Hacks]
+FastTextureSampling = False


### PR DESCRIPTION
This makes it so pre-recorded cutscenes and other videos display correctly in Skylanders: Trap Team instead of having a lot of weird lines