### PR TITLE
VideoCommon: add startup message to know if custom textures are installed

### DIFF
--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -147,6 +147,17 @@ void HiresTexture::Update()
                     texture_directory);
     }
   }
+
+  if (g_ActiveConfig.bCacheHiresTextures)
+  {
+    OSD::AddMessage(fmt::format("Loading '{}' custom textures", s_hires_texture_cache.size()),
+                    10000);
+  }
+  else
+  {
+    OSD::AddMessage(
+        fmt::format("Found '{}' custom textures", s_hires_texture_id_to_arbmipmap.size()), 10000);
+  }
 }
 
 void HiresTexture::Clear()


### PR DESCRIPTION
After designing the new asset loading system and integrating it to work with custom textures in #11681 , I had to remove the OSD message that came when textures were loaded.  This had the side effect of making it hard for our support staff to diagnose if a user had custom textures installed correctly.

I knew this would be an issue but didn't see a way around it.  The asset system can constantly load assets, either at startup or other times.  How do we know we're done?  We don't.

But then it came to me, do we need to know that?  No!  Users just want to know if things are installed properly.  A simple message when building up the asset list (either the list directly handed to the asset system or the list of assets to watch for during the course of the game) will suffice.

And that's exactly what this PR does.