### PR TITLE
cubeb: Change name to "Dolphin Emulator"

### DIFF
--- a/Source/Core/AudioCommon/CubebUtils.cpp
+++ b/Source/Core/AudioCommon/CubebUtils.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<cubeb> CubebUtils::GetContext()
   }
 
   cubeb* ctx;
-  if (cubeb_init(&ctx, "Dolphin", nullptr) != CUBEB_OK)
+  if (cubeb_init(&ctx, "Dolphin Emulator", nullptr) != CUBEB_OK)
   {
     ERROR_LOG_FMT(AUDIO, "Error initializing cubeb library");
     return nullptr;


### PR DESCRIPTION
To avoid conflicts with KDE's file manager.

Before:
![image](https://github.com/dolphin-emu/dolphin/assets/40663462/aaa50d6f-3cbc-4a1f-a1ce-b86e03d6effd)

After:
![image](https://github.com/dolphin-emu/dolphin/assets/40663462/766ee774-affe-450d-b3ac-df61fc2542ed)
