### PR TITLE
Disable right-click menu on main window

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1645,6 +1645,13 @@ bool MainWindow::eventFilter(QObject* object, QEvent* event)
   return false;
 }
 
+QMenu* MainWindow::createPopupMenu()
+{
+  // Disable the default popup menu as it exposes the debugger UI even when the debugger UI is
+  // disabled, which can lead to user confusion (see e.g. https://bugs.dolphin-emu.org/issues/13306)
+  return nullptr;
+}
+
 void MainWindow::dragEnterEvent(QDragEnterEvent* event)
 {
   if (event->mimeData()->hasUrls() && event->mimeData()->urls().size() == 1)

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -13,6 +13,7 @@
 
 #include "Core/Boot/Boot.h"
 
+class QMenu;
 class QStackedWidget;
 class QString;
 
@@ -80,6 +81,7 @@ public:
   WindowSystemInfo GetWindowSystemInfo() const;
 
   bool eventFilter(QObject* object, QEvent* event) override;
+  QMenu* createPopupMenu() override;
 
 signals:
   void ReadOnlyModeChanged(bool read_only);


### PR DESCRIPTION
Before, right-clicking on the toolbar would allow toggling all dock widgets, including the debugger ones even when they are disabled. (See https://doc.qt.io/qt-5/qmainwindow.html#createPopupMenu for this behavior, and https://bugs.dolphin-emu.org/issues/13306 for an example of where it caused issues.)