### PR TITLE
WiimoteReal/IOWin: Use correct error type in the default case.

### DIFF
--- a/Source/Core/Common/CommonFuncs.cpp
+++ b/Source/Core/Common/CommonFuncs.cpp
@@ -53,9 +53,15 @@ std::string LastStrerrorString()
 // This function might change the error code.
 std::string GetLastErrorString()
 {
+  return GetWin32ErrorString(GetLastError());
+}
+
+// Like GetLastErrorString() but if you have already queried the error code.
+std::string GetWin32ErrorString(DWORD error_code)
+{
   char error_message[BUFFER_SIZE];
 
-  FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, GetLastError(),
+  FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, error_code,
                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), error_message, BUFFER_SIZE, nullptr);
   return std::string(error_message);
 }

--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -53,6 +53,9 @@ std::string LastStrerrorString();
 // This function might change the error code.
 std::string GetLastErrorString();
 
+// Like GetLastErrorString() but if you have already queried the error code.
+std::string GetWin32ErrorString(unsigned long error_code);
+
 // Obtains a full path to the specified module.
 std::optional<std::wstring> GetModuleName(void* hInstance);
 #endif

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -298,17 +298,8 @@ int IOWritePerWriteFile(HANDLE& dev_handle, OVERLAPPED& hid_overlap_write,
       // Pending is no error!
       break;
     default:
-      if (FAILED(error))
-      {
-        WARN_LOG_FMT(WIIMOTE, "IOWrite[WWM_WRITE_FILE]: Error on WriteFile: {}",
-                     Common::HRWrap(error));
-      }
-      else
-      {
-        WARN_LOG_FMT(WIIMOTE,
-                     "IOWrite[WWM_WRITE_FILE]: Unexpected error code from WriteFile: 0x{:08x}",
-                     error);
-      }
+      WARN_LOG_FMT(WIIMOTE, "IOWrite[WWM_WRITE_FILE]: Error on WriteFile: {}",
+                   Common::GetWin32ErrorString(error));
       CancelIo(dev_handle);
       return 0;
     }


### PR DESCRIPTION
See https://github.com/dolphin-emu/dolphin/pull/11978#issuecomment-1619856382