### PR TITLE
SDL: Set SDL_HINT_JOYSTICK_HIDAPI_VERTICAL_JOY_CONS hint.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -191,6 +191,10 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
 #endif
 
+#if SDL_VERSION_ATLEAST(2, 26, 0)
+  SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_VERTICAL_JOY_CONS, "1");
+#endif
+
   m_hotplug_thread = std::thread([this] {
     Common::ScopeGuard quit_guard([] {
       // TODO: there seems to be some sort of memory leak with SDL, quit isn't freeing everything up


### PR DESCRIPTION
The `SDL_HINT_JOYSTICK_HIDAPI_VERTICAL_JOY_CONS` hint should put the Accel/Gyro inputs in the orientation most people would expect when using joycons to replace a Wii Remote + Nunchuk.

This will break some existing configs. I plan to add a setting to enable this, maybe under "Alternate Input Sources".

For now, lets see if it works, I have no joy cons available to test.