### PR TITLE
VideoCommon: update NetplayChatUI's chat message to avoid imgui error

### DIFF
--- a/Source/Core/VideoCommon/NetPlayChatUI.cpp
+++ b/Source/Core/VideoCommon/NetPlayChatUI.cpp
@@ -57,7 +57,7 @@ void NetPlayChatUI::Display()
 
   ImGui::PushItemWidth(-50.0f * scale);
 
-  if (ImGui::InputText("", m_message_buf, IM_ARRAYSIZE(m_message_buf),
+  if (ImGui::InputText("##NetplayMessageBuffer", m_message_buf, IM_ARRAYSIZE(m_message_buf),
                        ImGuiInputTextFlags_EnterReturnsTrue))
   {
     SendMessage();


### PR DESCRIPTION
After updating imgui in #12065 , looks like I broke the netplay chat window.  A user on discord reported the following error:

![image](https://github.com/dolphin-emu/dolphin/assets/15224722/63ed911f-3fe7-4dbf-bed4-ff38df72c3c5)

This PR fixes that by using a hidden label for the `InputText` field.