### PR TITLE
Jit: Allow BLR optimization without fastmem

### DIFF
--- a/Source/Core/Common/MemoryUtil.h
+++ b/Source/Core/Common/MemoryUtil.h
@@ -27,12 +27,12 @@ struct ScopedJITPageWriteAndNoExecute
   ~ScopedJITPageWriteAndNoExecute() { JITPageWriteDisableExecuteEnable(); }
 };
 void* AllocateMemoryPages(size_t size);
-void FreeMemoryPages(void* ptr, size_t size);
+bool FreeMemoryPages(void* ptr, size_t size);
 void* AllocateAlignedMemory(size_t size, size_t alignment);
 void FreeAlignedMemory(void* ptr);
-void ReadProtectMemory(void* ptr, size_t size);
-void WriteProtectMemory(void* ptr, size_t size, bool executable = false);
-void UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute = false);
+bool ReadProtectMemory(void* ptr, size_t size);
+bool WriteProtectMemory(void* ptr, size_t size, bool executable = false);
+bool UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute = false);
 size_t MemPhysical();
 
 }  // namespace Common

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -18,6 +18,7 @@
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/CPU.h"
+#include "Core/MemTools.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
@@ -132,7 +133,8 @@ void JitBase::RefreshConfig()
   analyzer.SetDivByZeroExceptionsEnabled(m_enable_div_by_zero_exceptions);
 
   bool any_watchpoints = m_system.GetPowerPC().GetMemChecks().HasAny();
-  jo.fastmem = m_fastmem_enabled && jo.fastmem_arena && (m_ppc_state.msr.DR || !any_watchpoints);
+  jo.fastmem = m_fastmem_enabled && jo.fastmem_arena && (m_ppc_state.msr.DR || !any_watchpoints) &&
+               EMM::IsExceptionHandlerSupported();
   jo.memcheck = m_system.IsMMUMode() || m_system.IsPauseOnPanicMode() || any_watchpoints;
   jo.fp_exceptions = m_enable_float_exceptions;
   jo.div_by_zero_exceptions = m_enable_div_by_zero_exceptions;
@@ -140,7 +142,8 @@ void JitBase::RefreshConfig()
 
 void JitBase::InitBLROptimization()
 {
-  m_enable_blr_optimization = jo.enableBlocklink && m_fastmem_enabled && !m_enable_debugging;
+  m_enable_blr_optimization =
+      jo.enableBlocklink && !m_enable_debugging && EMM::IsExceptionHandlerSupported();
   m_cleanup_after_stackfault = false;
 }
 


### PR DESCRIPTION
While both fastmem and the BLR optimization depend on fault handling, the BLR optimization doesn't depend on fastmem, and there are cases where you might want the BLR optimization but not fastmem. For me personally, it's useful when I try to use a debugger on Android and have to disable fastmem so I don't get SIGSEGVs all the time, but it would be especially useful for iOS users.