### PR TITLE
Fix suspending screensaver on Linux using libsystemd sd-bus

### DIFF
--- a/Source/Core/DolphinNoGUI/PlatformX11.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformX11.cpp
@@ -109,7 +109,7 @@ bool PlatformX11::Init()
   ProcessEvents();
 
   if (Config::Get(Config::MAIN_DISABLE_SCREENSAVER))
-    X11Utils::InhibitScreensaver(m_window, true);
+    X11Utils::InhibitScreensaver(true);
 
 #ifdef HAVE_XRANDR
   m_xrr_config = new X11Utils::XRRConfiguration(m_display, m_window);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1635,12 +1635,7 @@ void MainWindow::UpdateScreenSaverInhibition()
 
   m_is_screensaver_inhibited = inhibit;
 
-#ifdef HAVE_X11
-  if (GetWindowSystemType() == WindowSystemType::X11)
-    UICommon::InhibitScreenSaver(winId(), inhibit);
-#else
   UICommon::InhibitScreenSaver(inhibit);
-#endif
 }
 
 bool MainWindow::eventFilter(QObject* object, QEvent* event)

--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -46,6 +46,10 @@ if(ENABLE_X11 AND X11_FOUND)
   target_include_directories(uicommon PRIVATE ${X11_INCLUDE_DIR})
   target_sources(uicommon PRIVATE X11Utils.cpp)
   target_link_libraries(uicommon PUBLIC ${XRANDR_LIBRARIES})
+
+  if(SYSTEMD_FOUND)
+    target_link_libraries(uicommon PRIVATE ${SYSTEMD_LIBRARIES})
+  endif()
 endif()
 
 if(TARGET LibUSB::LibUSB)

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -497,17 +497,13 @@ bool TriggerSTMPowerEvent()
   return true;
 }
 
-#ifdef HAVE_X11
-void InhibitScreenSaver(Window win, bool inhibit)
-#else
 void InhibitScreenSaver(bool inhibit)
-#endif
 {
   // Inhibit the screensaver. Depending on the operating system this may also
   // disable low-power states and/or screen dimming.
 
 #ifdef HAVE_X11
-  X11Utils::InhibitScreensaver(win, inhibit);
+  X11Utils::InhibitScreensaver(inhibit);
 #endif
 
 #ifdef _WIN32

--- a/Source/Core/UICommon/UICommon.h
+++ b/Source/Core/UICommon/UICommon.h
@@ -17,11 +17,7 @@ void Shutdown();
 void InitControllers(const WindowSystemInfo& wsi);
 void ShutdownControllers();
 
-#ifdef HAVE_X11
-void InhibitScreenSaver(unsigned long win, bool enable);
-#else
 void InhibitScreenSaver(bool enable);
-#endif
 
 // Calls std::locale::global, selecting a fallback locale if the
 // requested locale isn't available

--- a/Source/Core/UICommon/X11Utils.cpp
+++ b/Source/Core/UICommon/X11Utils.cpp
@@ -19,6 +19,17 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 
+#ifdef HAVE_LIBSYSTEMD
+#include <cstdint>
+#include <memory>  // std::unique_ptr
+#include <optional>
+#include <utility>  // std::move
+
+#include <systemd/sd-bus.h>
+
+#include "Common/ScopeGuard.h"
+#endif
+
 extern char** environ;
 
 namespace X11Utils
@@ -47,6 +58,109 @@ bool ToggleFullscreen(Display* dpy, Window win)
 
 void InhibitScreensaver(bool suspend)
 {
+#ifdef HAVE_LIBSYSTEMD
+  struct sd_bus_unref_t
+  {
+    void operator()(sd_bus* bus) { sd_bus_unref(bus); }
+  };
+
+  struct ScreensaverLock
+  {
+    uint32_t cookie;
+    std::unique_ptr<sd_bus, sd_bus_unref_t> bus;
+  };
+
+  static std::optional<ScreensaverLock> lock;
+  int ret;
+
+  if (suspend)
+  {
+    if (lock)
+    {
+      INFO_LOG_FMT(VIDEO, "Screensaver is already inhibited (cookie = {})", lock->cookie);
+      return;
+    }
+
+    // Connect to the D-Bus session bus
+    sd_bus* _bus;
+    ret = sd_bus_default_user(&_bus);
+    if (ret < 0)
+    {
+      WARN_LOG_FMT(VIDEO, "Cannot connect to the D-Bus session bus: {}", ret);
+      return;
+    }
+    std::unique_ptr<sd_bus, sd_bus_unref_t> bus{_bus};
+
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+    Common::ScopeGuard error_free([&error] { sd_bus_error_free(&error); });
+    sd_bus_message* _reply = nullptr;
+
+    // Prepare the method call
+    ret = sd_bus_call_method(bus.get(),
+                             "org.freedesktop.ScreenSaver",   // Service name
+                             "/org/freedesktop/ScreenSaver",  // Object path
+                             "org.freedesktop.ScreenSaver",   // Interface
+                             "Inhibit",                       // Method name
+                             &error, &_reply,
+                             "ss",                // Input signature: string, string
+                             "Dolphin",           // First argument: application name
+                             "Game is running");  // Second argument: reason
+    std::unique_ptr<sd_bus_message, decltype(&sd_bus_message_unref)> reply{_reply,
+                                                                           sd_bus_message_unref};
+
+    // Check for errors
+    if (ret < 0)
+    {
+      WARN_LOG_FMT(VIDEO, "Failed to call Inhibit: {}", error.message);
+      return;
+    }
+
+    // Store cookie to reenable screensaver.
+    uint32_t cookie;
+    ret = sd_bus_message_read(reply.get(), "u", &cookie);
+    if (ret < 0)
+    {
+      WARN_LOG_FMT(VIDEO, "Failed to read Inhibit reply: {}", strerror(-ret));
+      return;
+    }
+
+    INFO_LOG_FMT(VIDEO, "Inhibited screensaver (cookie = {})", cookie);
+    lock = ScreensaverLock{
+        .cookie = cookie,
+        .bus = std::move(bus),
+    };
+  }
+  else
+  {
+    if (!lock)
+    {
+      INFO_LOG_FMT(VIDEO, "Screensaver is already allowed");
+      return;
+    }
+
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+    Common::ScopeGuard error_free([&error] { sd_bus_error_free(&error); });
+    sd_bus_message* reply = nullptr;
+
+    // Cancel previous wake request.
+    ret = sd_bus_call_method(lock->bus.get(),
+                             "org.freedesktop.ScreenSaver",   // Service name
+                             "/org/freedesktop/ScreenSaver",  // Object path
+                             "org.freedesktop.ScreenSaver",   // Interface
+                             "UnInhibit",                     // Method name
+                             &error, &reply,
+                             "u",  // Input signature: uint32
+                             lock->cookie);
+
+    if (ret < 0)
+    {
+      WARN_LOG_FMT(VIDEO, "Failed to call UnInhibit: {}", error.message);
+    }
+
+    sd_bus_message_unref(reply);
+    lock.reset();
+  }
+#endif
 }
 
 #ifdef HAVE_XRANDR

--- a/Source/Core/UICommon/X11Utils.cpp
+++ b/Source/Core/UICommon/X11Utils.cpp
@@ -45,22 +45,8 @@ bool ToggleFullscreen(Display* dpy, Window win)
   return true;
 }
 
-void InhibitScreensaver(Window win, bool suspend)
+void InhibitScreensaver(bool suspend)
 {
-  char id[11];
-  snprintf(id, sizeof(id), "0x%lx", win);
-
-  // Call xdg-screensaver
-  char* argv[4] = {(char*)"xdg-screensaver", (char*)(suspend ? "suspend" : "resume"), id, nullptr};
-  pid_t pid;
-  if (!posix_spawnp(&pid, "xdg-screensaver", nullptr, nullptr, argv, environ))
-  {
-    int status;
-    while (waitpid(pid, &status, 0) == -1)
-      ;
-
-    INFO_LOG_FMT(VIDEO, "Started xdg-screensaver (PID = {})", pid);
-  }
 }
 
 #ifdef HAVE_XRANDR

--- a/Source/Core/UICommon/X11Utils.h
+++ b/Source/Core/UICommon/X11Utils.h
@@ -23,7 +23,7 @@ bool ToggleFullscreen(Display* dpy, Window win);
 Window XWindowFromHandle(void* Handle);
 Display* XDisplayFromHandle(void* Handle);
 
-void InhibitScreensaver(Window win, bool suspend);
+void InhibitScreensaver(bool suspend);
 
 #ifdef HAVE_XRANDR
 class XRRConfiguration


### PR DESCRIPTION
When running a game on Linux, this PR prevents the desktop environment from locking or turning off the screen, or sleeping the system. This is necessary when playing games with a controller, which doesn't count as keyboard/mouse activity to prevent screen locking.

## Technical details

This PR replaces the previous implementation which shells out to `xdg-screensaver`. That program didn't work, because `xdg-screensaver` terminates immediately after making D-Bus calls, but screensaver inhibition only lasts as long as the process and D-Bus connection remains open.

This PR adds a new use of libsystemd in `uicommon`, in addition to the existing `traversal_server` target. I did not change the CMake message saying "libsystemd found, enabling traversal server watchdog support" though.

The code works, but I'm new to d-bus and libsystemd (and largely based the code off copy-and-paste and googling), so it may have functional errors. I did run Dolphin in valgrind with this patch, and started/stopped F-Zero GX (GC) twice, and valgrind did not complain about any errors related to libsystemd, D-Bus, or X11Utils.cpp. (It did complain about errors elsewhere, like serialization.h and rpc_connection.cpp and Vulkan, which are probably worth digging into.)

- I'm pretty sure the C vs. C++ resource management wrapping is quite sloppy, and could be improved. D-Bus itself uses `#define _cleanup_(f) __attribute__((cleanup(f)))`, but Dolphin does not use `__attribute__((cleanup()))` and I'm not sure we should add it (even if it's ifdef'd to Unix-style platforms only).
- Should we use sd-bus rather than raw libdbus or (less popular) dbus-cxx?
	- Users on systemd-free distributions may not be happy that we're relying on a libsystemd library to perform init-independent tasks (leaving them worse off in a way that's not technically necessary, though more convenient than adding a new library dependency).
	- I verified that the build still works with `find_package(SYSTEMD)` commented out (so `HAVE_LIBSYSTEMD` is not defined). But we cannot block sleep without libsystemd in place. Is this acceptable?
	- I verified that screensaver blocking works in the dolphin-nogui target. I get an unrelated error when closing dolphin-nogui though (destroying a GC adapter libusb device in use?):

```
X Error of failed request:  BadCursor (invalid Cursor parameter)
  Major opcode of failed request:  95 (X_FreeCursor)
  Resource id in failed request:  0x0
  Serial number of failed request:  18915
  Current serial number in output stream:  18917
dolphin-emu-nogui: os/threads_posix.h:58: usbi_mutex_destroy: Assertion `pthread_mutex_destroy(mutex) == 0' failed.
dolphin-emu-nogui: os/threads_posix.h:46: usbi_mutex_lock: Assertion `pthread_mutex_lock(mutex) == 0' failed.
14:11:27: /home/nyanpasu64/code/dolphin/build-GCC_12_lld-RelWithDebInfo/Binaries/dolphin-emu-nogui crashed.
```

You may want to review my commits separately; the first one changes a bunch of function headers and calls (to remove the now-extraneous X11 Window parameter), and the second one implements the actual logic.

Fixes https://bugs.dolphin-emu.org/issues/10392.