### PR TITLE
InputConfig: Update IsControllerControlledByGamepadDevice for Android input overhaul

### DIFF
--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -203,11 +203,14 @@ bool InputConfig::IsControllerControlledByGamepadDevice(int index) const
 
   const auto& controller = m_controllers.at(index).get()->GetDefaultDevice();
 
+  // By default on Android, no device is selected
+  if (controller.source == "")
+    return false;
+
   // Filter out anything which obviously not a gamepad
   return !((controller.source == "Quartz")      // OSX Quartz Keyboard/Mouse
            || (controller.source == "XInput2")  // Linux and BSD Keyboard/Mouse
-           || (controller.source == "Android" &&
-               controller.name == "Touchscreen")  // Android Touchscreen
+           || (controller.source == "Android" && controller.cid <= 0)  // Android non-gamepad device
            || (controller.source == "DInput" &&
                controller.name == "Keyboard Mouse"));  // Windows Keyboard/Mouse
 }


### PR DESCRIPTION
This only matters for analytics, but still.