### PR TITLE
JitArm64: Avoid loading compilerPC multiple times if it's already in a register.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -315,8 +315,12 @@ protected:
   void EmitStoreMembase(const Arm64Gen::ARM64Reg& msr);
 
   // Exits
-  void WriteExit(u32 destination, bool LK = false, u32 exit_address_after_return = 0);
-  void WriteExit(Arm64Gen::ARM64Reg dest, bool LK = false, u32 exit_address_after_return = 0);
+  void
+  WriteExit(u32 destination, bool LK = false, u32 exit_address_after_return = 0,
+            Arm64Gen::ARM64Reg exit_address_after_return_reg = Arm64Gen::ARM64Reg::INVALID_REG);
+  void
+  WriteExit(Arm64Gen::ARM64Reg dest, bool LK = false, u32 exit_address_after_return = 0,
+            Arm64Gen::ARM64Reg exit_address_after_return_reg = Arm64Gen::ARM64Reg::INVALID_REG);
   void WriteExceptionExit(u32 destination, bool only_external = false,
                           bool always_exception = false);
   void WriteExceptionExit(Arm64Gen::ARM64Reg dest, bool only_external = false,
@@ -325,7 +329,9 @@ protected:
   void WriteConditionalExceptionExit(int exception, Arm64Gen::ARM64Reg temp_gpr,
                                      Arm64Gen::ARM64Reg temp_fpr = Arm64Gen::ARM64Reg::INVALID_REG,
                                      u64 increment_sp_on_exit = 0);
-  void FakeLKExit(u32 exit_address_after_return);
+  void
+  FakeLKExit(u32 exit_address_after_return,
+             Arm64Gen::ARM64Reg exit_address_after_return_reg = Arm64Gen::ARM64Reg::INVALID_REG);
   void WriteBLRExit(Arm64Gen::ARM64Reg dest);
 
   Arm64Gen::FixupBranch JumpIfCRFieldBit(int field, int bit, bool jump_if_set);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -79,12 +79,12 @@ void JitArm64::bx(UGeckoInstruction inst)
   INSTRUCTION_START
   JITDISABLE(bJITBranchOff);
 
+  ARM64Reg WA = ARM64Reg::INVALID_REG;
   if (inst.LK)
   {
-    ARM64Reg WA = gpr.GetReg();
+    WA = gpr.GetReg();
     MOVI2R(WA, js.compilerPC + 4);
     STR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_LR));
-    gpr.Unlock(WA);
   }
 
   if (!js.isLastInstruction)
@@ -94,8 +94,12 @@ void JitArm64::bx(UGeckoInstruction inst)
       // We have to fake the stack as the RET instruction was not
       // found in the same block. This is a big overhead, but still
       // better than calling the dispatcher.
-      FakeLKExit(js.compilerPC + 4);
+      FakeLKExit(js.compilerPC + 4, WA);
     }
+
+    if (WA != ARM64Reg::INVALID_REG)
+      gpr.Unlock(WA);
+
     return;
   }
 
@@ -104,19 +108,24 @@ void JitArm64::bx(UGeckoInstruction inst)
 
   if (js.op->branchIsIdleLoop)
   {
-    // make idle loops go faster
-    ARM64Reg WA = gpr.GetReg();
-    ARM64Reg XA = EncodeRegTo64(WA);
+    if (WA != ARM64Reg::INVALID_REG)
+      gpr.Unlock(WA);
 
-    MOVP2R(XA, &CoreTiming::GlobalIdle);
-    BLR(XA);
-    gpr.Unlock(WA);
+    // make idle loops go faster
+    ARM64Reg WB = gpr.GetReg();
+    ARM64Reg XB = EncodeRegTo64(WB);
+
+    MOVP2R(XB, &CoreTiming::GlobalIdle);
+    BLR(XB);
+    gpr.Unlock(WB);
 
     WriteExceptionExit(js.op->branchTo);
     return;
   }
 
-  WriteExit(js.op->branchTo, inst.LK, js.compilerPC + 4);
+  WriteExit(js.op->branchTo, inst.LK, js.compilerPC + 4, inst.LK ? WA : ARM64Reg::INVALID_REG);
+  if (WA != ARM64Reg::INVALID_REG)
+    gpr.Unlock(WA);
 }
 
 void JitArm64::bcx(UGeckoInstruction inst)
@@ -125,6 +134,8 @@ void JitArm64::bcx(UGeckoInstruction inst)
   JITDISABLE(bJITBranchOff);
 
   ARM64Reg WA = gpr.GetReg();
+  ARM64Reg WB = inst.LK ? gpr.GetReg() : WA;
+
   FixupBranch pCTRDontBranch;
   if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
   {
@@ -156,7 +167,7 @@ void JitArm64::bcx(UGeckoInstruction inst)
     STR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_LR));
   }
 
-  gpr.Flush(FlushMode::MaintainState, WA);
+  gpr.Flush(FlushMode::MaintainState, WB);
   fpr.Flush(FlushMode::MaintainState, ARM64Reg::INVALID_REG);
 
   if (js.op->branchIsIdleLoop)
@@ -171,7 +182,7 @@ void JitArm64::bcx(UGeckoInstruction inst)
   }
   else
   {
-    WriteExit(js.op->branchTo, inst.LK, js.compilerPC + 4);
+    WriteExit(js.op->branchTo, inst.LK, js.compilerPC + 4, inst.LK ? WA : ARM64Reg::INVALID_REG);
   }
 
   SwitchToNearCode();
@@ -189,6 +200,8 @@ void JitArm64::bcx(UGeckoInstruction inst)
   }
 
   gpr.Unlock(WA);
+  if (WB != WA)
+    gpr.Unlock(WB);
 }
 
 void JitArm64::bcctrx(UGeckoInstruction inst)
@@ -211,12 +224,12 @@ void JitArm64::bcctrx(UGeckoInstruction inst)
   gpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
   fpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
 
+  ARM64Reg WB = ARM64Reg::INVALID_REG;
   if (inst.LK_3)
   {
-    ARM64Reg WB = gpr.GetReg();
+    WB = gpr.GetReg();
     MOVI2R(WB, js.compilerPC + 4);
     STR(IndexType::Unsigned, WB, PPC_REG, PPCSTATE_OFF_SPR(SPR_LR));
-    gpr.Unlock(WB);
   }
 
   ARM64Reg WA = gpr.GetReg();
@@ -224,8 +237,10 @@ void JitArm64::bcctrx(UGeckoInstruction inst)
   LDR(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
   AND(WA, WA, LogicalImm(~0x3, 32));
 
-  WriteExit(WA, inst.LK_3, js.compilerPC + 4);
+  WriteExit(WA, inst.LK_3, js.compilerPC + 4, inst.LK_3 ? WB : ARM64Reg::INVALID_REG);
 
+  if (WB != ARM64Reg::INVALID_REG)
+    gpr.Unlock(WB);
   gpr.Unlock(WA);
 }
 


### PR DESCRIPTION
Makes the generated code slightly less redundant in some cases.