### PR TITLE
D3D12: Only use framebuffer integer descriptor if allocated

### DIFF
--- a/Source/Core/VideoBackends/D3D12/DX12Texture.h
+++ b/Source/Core/VideoBackends/D3D12/DX12Texture.h
@@ -75,10 +75,7 @@ public:
   {
     return m_render_targets_raw.data();
   }
-  const D3D12_CPU_DESCRIPTOR_HANDLE* GetIntRTVDescriptorArray() const
-  {
-    return m_color_attachment ? &m_int_rtv_descriptor.cpu_handle : nullptr;
-  }
+  const D3D12_CPU_DESCRIPTOR_HANDLE* GetIntRTVDescriptorArray() const;
   const D3D12_CPU_DESCRIPTOR_HANDLE* GetDSVDescriptorArray() const
   {
     return m_depth_attachment ? &m_dsv_descriptor.cpu_handle : nullptr;


### PR DESCRIPTION
Verify that DXFramebuffer's integer RTV descriptor's cpu_handle has been allocated before using it, and if it hasn't use the non-integer RTV descriptor instead. This fixes a Dolphin crash in Twilight Princess, and possibly other games (Issue [13312](https://bugs.dolphin-emu.org/issues/13312)).

As an optimization to save space in the descriptor heap, DXFramebuffer's integer descriptor is only initialized if the given abstract texture format has different integer and non-integer RTV formats. This previously wasn't accounted for by GetIntRTVDescriptorArray, which could cause DX12::Gfx::BindFramebuffer to call OMSetRenderTargets with an invalid descriptor which would lead to a crash.

Triggering the bug was fortunately rare because integer formats are only used when blending is disabled and logic ops are enabled. Furthermore, the standard integer abstract format is RGBA8 which has different integer and non-integer RTV formats, causing the integer descriptor to be initialized and avoiding the bug.

The crash started appearing in #11850 because it changed the swapchain's abstract texture format from RGBA8 to RGB10_A2. Unlike RGBA8, RGB10_A2 has the same integer and non-integer RTV formats and so the bug can be triggered if the other requirements are met.