### PR TITLE
JitArm64: Prefer MOVI with 64-bit elements for zeroing

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -832,7 +832,7 @@ void JitArm64::ConvertSingleToDoublePair(size_t guest_reg, ARM64Reg dest_reg, AR
   {
     // Set each 32-bit element of scratch_reg to 0x0000'0000 or 0xFFFF'FFFF depending on whether
     // the absolute value of the corresponding element in src_reg compares greater than 0
-    m_float_emit.MOVI(8, EncodeRegToDouble(scratch_reg), 0);
+    m_float_emit.MOVI(64, EncodeRegToDouble(scratch_reg), 0);
     m_float_emit.FACGT(32, EncodeRegToDouble(scratch_reg), EncodeRegToDouble(src_reg),
                        EncodeRegToDouble(scratch_reg));
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -254,7 +254,7 @@ void JitArm64::ps_arith(UGeckoInstruction inst)
 
     // Pick the right NaNs
 
-    m_float_emit.MOVI(8, zero_reg, 0);
+    m_float_emit.MOVI(64, zero_reg, 0);
 
     const auto check_input = [&](ARM64Reg input) {
       m_float_emit.FACGE(size, nan_temp_reg_paired, input, zero_reg);


### PR DESCRIPTION
The Cortex-X2 and Cortex-X3 (and possibly others) recognize MOVI with 64-bit elements as a zeroing idiom, but not MOVI with other sizes.