### PR TITLE
JitArm64: Use one instruction for making NaNs quiet

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -180,10 +180,6 @@ public:
 
   void FloatCompare(UGeckoInstruction inst, bool upper = false);
 
-  // temp_gpr can be INVALID_REG if single is true
-  void EmitQuietNaNBitConstant(Arm64Gen::ARM64Reg dest_reg, bool single,
-                               Arm64Gen::ARM64Reg temp_gpr);
-
   bool IsFPRStoreSafe(size_t guest_reg) const;
 
 protected:


### PR DESCRIPTION
Instead of materializing the quiet bit in a register and ORing the NaN with it, we can perform an arithmetic operation on the NaN. This is a cycle or two slower on some CPUs in cases where generating the quiet bit pipelined well, but this is farcode that rarely runs, so instruction fetch latency is the bigger concern. And for non-SIMD cases, we also save a register.