### PR TITLE
Disable Wii Save Options When Emulation Is Running

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -466,8 +466,14 @@ void GameList::ShowContextMenu(const QPoint&)
     if (!is_mod_descriptor &&
         (platform == DiscIO::Platform::WiiWAD || platform == DiscIO::Platform::WiiDisc))
     {
-      menu->addAction(tr("Open Wii &Save Folder"), this, &GameList::OpenWiiSaveFolder);
-      menu->addAction(tr("Export Wii Save"), this, &GameList::ExportWiiSave);
+      QAction* open_wii_save_folder =
+          menu->addAction(tr("Open Wii &Save Folder"), this, &GameList::OpenWiiSaveFolder);
+      QAction* export_wii_save =
+          menu->addAction(tr("Export Wii Save"), this, &GameList::ExportWiiSave);
+
+      open_wii_save_folder->setEnabled(!Core::IsRunning());
+      export_wii_save->setEnabled(!Core::IsRunning());
+
       menu->addSeparator();
     }
 


### PR DESCRIPTION
This PR fixes an issue with export wii save files that is detailed [here](https://bugs.dolphin-emu.org/issues/13216).

Trying to export a wii save while emulation is running creates some error messages and then appears to export the wii save normally but these are options that, in the previous UI of dolphin, were disabled during emulation.