### PR TITLE
VideoCommon: fix regression with texture load order

### DIFF
--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -120,23 +120,26 @@ void HiresTexture::Update()
         if (has_arbitrary_mipmaps)
           filename.erase(arb_index, 4);
 
-        // Since this is just a texture (single file) the mapper doesn't really matter
-        // just provide a string
-        s_file_library->SetAssetIDMapData(filename,
-                                          std::map<std::string, std::filesystem::path>{{"", path}});
-
-        if (g_ActiveConfig.bCacheHiresTextures)
-        {
-          auto hires_texture = std::make_shared<HiresTexture>(
-              has_arbitrary_mipmaps,
-              system.GetCustomAssetLoader().LoadGameTexture(filename, s_file_library));
-          s_hires_texture_cache.try_emplace(filename, std::move(hires_texture));
-        }
         const auto [it, inserted] =
             s_hires_texture_id_to_arbmipmap.try_emplace(filename, has_arbitrary_mipmaps);
         if (!inserted)
         {
           failed_insert = true;
+        }
+        else
+        {
+          // Since this is just a texture (single file) the mapper doesn't really matter
+          // just provide a string
+          s_file_library->SetAssetIDMapData(
+              filename, std::map<std::string, std::filesystem::path>{{"", path}});
+
+          if (g_ActiveConfig.bCacheHiresTextures)
+          {
+            auto hires_texture = std::make_shared<HiresTexture>(
+                has_arbitrary_mipmaps,
+                system.GetCustomAssetLoader().LoadGameTexture(filename, s_file_library));
+            s_hires_texture_cache.try_emplace(filename, std::move(hires_texture));
+          }
         }
       }
     }


### PR DESCRIPTION
A user using a dynamic input texture pack notified me to let me know that the DIT texture pack's button textures were not taking precedence over another pack.  The reasoning for this is that when I [switched over texture packs to use the asset loader](https://github.com/dolphin-emu/dolphin/pull/11681), I accidentally updated the asset map with the latest texture asset, instead of choosing the initial value.  This caused the ordering of precedence for texture packs to be reversed, which caused the issue.