### PR TITLE
NandPaths: Resolve Android tautological comparison warning

### DIFF
--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -107,7 +107,7 @@ static bool IsIllegalCharacter(char c)
 {
   static const std::unordered_set<char> illegal_chars = {'\"', '*', '/',  ':', '<',
                                                          '>',  '?', '\\', '|', '\x7f'};
-  return (c >= 0 && c <= 0x1F) || illegal_chars.find(c) != illegal_chars.end();
+  return static_cast<unsigned char>(c) <= 0x1F || illegal_chars.find(c) != illegal_chars.end();
 }
 
 std::string EscapeFileName(const std::string& filename)

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include <fmt/format.h>
@@ -105,9 +104,9 @@ bool IsTitlePath(const std::string& path, std::optional<FromWhichRoot> from, u64
 
 static bool IsIllegalCharacter(char c)
 {
-  static const std::unordered_set<char> illegal_chars = {'\"', '*', '/',  ':', '<',
-                                                         '>',  '?', '\\', '|', '\x7f'};
-  return static_cast<unsigned char>(c) <= 0x1F || illegal_chars.find(c) != illegal_chars.end();
+  static constexpr auto illegal_chars = {'\"', '*', '/', ':', '<', '>', '?', '\\', '|', '\x7f'};
+  return static_cast<unsigned char>(c) <= 0x1F ||
+         std::find(illegal_chars.begin(), illegal_chars.end(), c) != illegal_chars.end();
 }
 
 std::string EscapeFileName(const std::string& filename)


### PR DESCRIPTION
Android interprets char as unsigned char, so comparing the char parameter in IsIllegalCharacter with 0 triggers a tautological-unsigned-char-zero-compare warning.

Casting the parameter to an unsigned char and removing the comparison with 0 resolves the warning while needing one less comparison on all platforms.