### PR TITLE
IOS: Remove unused member variable from SharedContentMap and UIDSys

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -554,7 +554,7 @@ struct SharedContentMap::Entry
 };
 
 constexpr char CONTENT_MAP_PATH[] = "/shared1/content.map";
-SharedContentMap::SharedContentMap(HLE::FSCore& fs_core) : m_fs_core{fs_core}, m_fs{fs_core.GetFS()}
+SharedContentMap::SharedContentMap(HLE::FSCore& fs_core) : m_fs{fs_core.GetFS()}
 {
   static_assert(sizeof(Entry) == 28, "SharedContentMap::Entry has the wrong size");
 
@@ -650,7 +650,7 @@ static std::pair<u32, u64> ReadUidSysEntry(HLE::FSCore& fs, u64 fd, u64* ticks)
 }
 
 constexpr char UID_MAP_PATH[] = "/sys/uid.sys";
-UIDSys::UIDSys(HLE::FSCore& fs_core) : m_fs_core{fs_core}, m_fs{fs_core.GetFS()}
+UIDSys::UIDSys(HLE::FSCore& fs_core) : m_fs{fs_core.GetFS()}
 {
   if (const auto fd =
           fs_core.Open(PID_KERNEL, PID_KERNEL, UID_MAP_PATH, HLE::FS::Mode::Read, {}, &m_ticks);

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -296,7 +296,6 @@ private:
   struct Entry;
   u32 m_last_id = 0;
   std::vector<Entry> m_entries;
-  HLE::FSCore& m_fs_core;
   std::shared_ptr<HLE::FS::FileSystem> m_fs;
   u64 m_ticks = 0;
 };
@@ -313,7 +312,6 @@ public:
   u64 GetTicks() const { return m_ticks; }
 
 private:
-  HLE::FSCore& m_fs_core;
   std::shared_ptr<HLE::FS::FileSystem> m_fs;
   std::map<u32, u64> m_entries;
   u64 m_ticks = 0;


### PR DESCRIPTION
Remove unused member variable m_fs_core from SharedContentMap and UIDSys to resolve unused-private-field warnings on Android.