### PR TITLE
Gcadapter: fix Android unused constant warning

### DIFF
--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -100,7 +100,9 @@ enum class ControllerType : u8
 static std::array<u8, SerialInterface::MAX_SI_CHANNELS> s_controller_rumble;
 
 constexpr size_t CONTROLLER_INPUT_PAYLOAD_EXPECTED_SIZE = 37;
+#if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
 constexpr size_t CONTROLLER_OUTPUT_INIT_PAYLOAD_SIZE = 1;
+#endif
 constexpr size_t CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE = 5;
 
 struct PortState

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -99,9 +99,9 @@ enum class ControllerType : u8
 
 static std::array<u8, SerialInterface::MAX_SI_CHANNELS> s_controller_rumble;
 
-constexpr size_t CONTROLER_INPUT_PAYLOAD_EXPECTED_SIZE = 37;
-constexpr size_t CONTROLER_OUTPUT_INIT_PAYLOAD_SIZE = 1;
-constexpr size_t CONTROLER_OUTPUT_RUMBLE_PAYLOAD_SIZE = 5;
+constexpr size_t CONTROLLER_INPUT_PAYLOAD_EXPECTED_SIZE = 37;
+constexpr size_t CONTROLLER_OUTPUT_INIT_PAYLOAD_SIZE = 1;
+constexpr size_t CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE = 5;
 
 struct PortState
 {
@@ -115,7 +115,7 @@ struct PortState
 // Only access with s_mutex held!
 static std::array<PortState, SerialInterface::MAX_SI_CHANNELS> s_port_states;
 
-static std::array<u8, CONTROLER_OUTPUT_RUMBLE_PAYLOAD_SIZE> s_controller_write_payload;
+static std::array<u8, CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE> s_controller_write_payload;
 static std::atomic<int> s_controller_write_payload_size{0};
 
 static std::thread s_read_adapter_thread;
@@ -200,7 +200,7 @@ static void ReadThreadFunc()
   while (s_read_adapter_thread_running.IsSet())
   {
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
-    std::array<u8, CONTROLER_INPUT_PAYLOAD_EXPECTED_SIZE> input_buffer;
+    std::array<u8, CONTROLLER_INPUT_PAYLOAD_EXPECTED_SIZE> input_buffer;
 
     int payload_size = 0;
     int error = libusb_interrupt_transfer(s_handle, s_endpoint_in, input_buffer.data(),
@@ -289,7 +289,7 @@ static void WriteThreadFunc()
                       LibusbUtils::ErrorWrap(error));
       }
 #elif GCADAPTER_USE_ANDROID_IMPLEMENTATION
-      const jbyteArray jrumble_array = env->NewByteArray(CONTROLER_OUTPUT_RUMBLE_PAYLOAD_SIZE);
+      const jbyteArray jrumble_array = env->NewByteArray(CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE);
       jbyte* const jrumble = env->GetByteArrayElements(jrumble_array, nullptr);
 
       {
@@ -650,9 +650,9 @@ static void AddGCAdapter(libusb_device* device)
   config.reset();
 
   int size = 0;
-  std::array<u8, CONTROLER_OUTPUT_INIT_PAYLOAD_SIZE> payload = {0x13};
+  std::array<u8, CONTROLLER_OUTPUT_INIT_PAYLOAD_SIZE> payload = {0x13};
   error = libusb_interrupt_transfer(s_handle, s_endpoint_out, payload.data(),
-                                    CONTROLER_OUTPUT_INIT_PAYLOAD_SIZE, &size, USB_TIMEOUT_MS);
+                                    CONTROLLER_OUTPUT_INIT_PAYLOAD_SIZE, &size, USB_TIMEOUT_MS);
   if (error != LIBUSB_SUCCESS)
   {
     WARN_LOG_FMT(CONTROLLERINTERFACE, "AddGCAdapter: libusb_interrupt_transfer failed: {}",
@@ -776,7 +776,7 @@ static ControllerType IdentifyControllerType(u8 data)
 
 void ProcessInputPayload(const u8* data, std::size_t size)
 {
-  if (size != CONTROLER_INPUT_PAYLOAD_EXPECTED_SIZE
+  if (size != CONTROLLER_INPUT_PAYLOAD_EXPECTED_SIZE
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
       || data[0] != LIBUSB_DT_HID
 #endif
@@ -891,11 +891,11 @@ void ResetRumble()
     return;
   ResetRumbleLockNeeded();
 #elif GCADAPTER_USE_ANDROID_IMPLEMENTATION
-  std::array<u8, CONTROLER_OUTPUT_RUMBLE_PAYLOAD_SIZE> rumble = {0x11, 0, 0, 0, 0};
+  std::array<u8, CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE> rumble = {0x11, 0, 0, 0, 0};
   {
     std::lock_guard lk(s_write_mutex);
     s_controller_write_payload = rumble;
-    s_controller_write_payload_size.store(CONTROLER_OUTPUT_RUMBLE_PAYLOAD_SIZE);
+    s_controller_write_payload_size.store(CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE);
   }
   s_write_happened.Set();
 #endif
@@ -913,14 +913,14 @@ static void ResetRumbleLockNeeded()
 
   std::fill(std::begin(s_controller_rumble), std::end(s_controller_rumble), 0);
 
-  std::array<u8, CONTROLER_OUTPUT_RUMBLE_PAYLOAD_SIZE> rumble = {
+  std::array<u8, CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE> rumble = {
       0x11, s_controller_rumble[0], s_controller_rumble[1], s_controller_rumble[2],
       s_controller_rumble[3]};
 
   int size = 0;
   const int error =
       libusb_interrupt_transfer(s_handle, s_endpoint_out, rumble.data(),
-                                CONTROLER_OUTPUT_RUMBLE_PAYLOAD_SIZE, &size, USB_TIMEOUT_MS);
+                                CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE, &size, USB_TIMEOUT_MS);
   if (error != LIBUSB_SUCCESS)
   {
     WARN_LOG_FMT(CONTROLLERINTERFACE, "ResetRumbleLockNeeded: libusb_interrupt_transfer failed: {}",
@@ -949,7 +949,7 @@ void Output(int chan, u8 rumble_command)
       s_port_states[chan].controller_type != ControllerType::Wireless)
   {
     s_controller_rumble[chan] = rumble_command;
-    std::array<u8, CONTROLER_OUTPUT_RUMBLE_PAYLOAD_SIZE> rumble = {
+    std::array<u8, CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE> rumble = {
         0x11, s_controller_rumble[0], s_controller_rumble[1], s_controller_rumble[2],
         s_controller_rumble[3]};
     {
@@ -957,7 +957,7 @@ void Output(int chan, u8 rumble_command)
       std::lock_guard lk(s_write_mutex);
 #endif
       s_controller_write_payload = rumble;
-      s_controller_write_payload_size.store(CONTROLER_OUTPUT_RUMBLE_PAYLOAD_SIZE);
+      s_controller_write_payload_size.store(CONTROLLER_OUTPUT_RUMBLE_PAYLOAD_SIZE);
     }
     s_write_happened.Set();
   }


### PR DESCRIPTION
CONTROLLER_OUTPUT_INIT_PAYLOAD_SIZE is only used by the libusb implementation, so put the appropriate ifdefs around it.

Also fixes the spelling of some constants while I'm there.
