### PR TITLE
AbstractFramebuffer: Fix Android reorder-ctor warning

### DIFF
--- a/Source/Core/VideoCommon/AbstractFramebuffer.h
+++ b/Source/Core/VideoCommon/AbstractFramebuffer.h
@@ -44,9 +44,9 @@ public:
 protected:
   AbstractTexture* m_color_attachment;
   AbstractTexture* m_depth_attachment;
+  std::vector<AbstractTexture*> m_additional_color_attachments;
   AbstractTextureFormat m_color_format;
   AbstractTextureFormat m_depth_format;
-  std::vector<AbstractTexture*> m_additional_color_attachments;
   u32 m_width;
   u32 m_height;
   u32 m_layers;


### PR DESCRIPTION
Move the declaration of m_additional_color_attachments so its initialization order matches that of the constructor.

This was the simplest way to fix the warning, but if someone wants to argue the declaration should be somewhere else I could reorder the constructor initializers instead.