### PR TITLE
DolphinQt: Add ToolTipPushButton.

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -181,6 +181,8 @@ add_executable(dolphin-emu
   Config/ToolTipControls/ToolTipCheckBox.h
   Config/ToolTipControls/ToolTipComboBox.cpp
   Config/ToolTipControls/ToolTipComboBox.h
+  Config/ToolTipControls/ToolTipPushButton.cpp
+  Config/ToolTipControls/ToolTipPushButton.h
   Config/ToolTipControls/ToolTipRadioButton.cpp
   Config/ToolTipControls/ToolTipRadioButton.h
   Config/ToolTipControls/ToolTipSlider.cpp

--- a/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipPushButton.cpp
+++ b/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipPushButton.cpp
@@ -1,0 +1,14 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/Config/ToolTipControls/ToolTipPushButton.h"
+
+ToolTipPushButton::ToolTipPushButton(const QString& text, QWidget* parent)
+    : ToolTipWidget(text, parent)
+{
+}
+
+QPoint ToolTipPushButton::GetToolTipPosition() const
+{
+  return pos() + QPoint(width() / 2, height() / 2);
+}

--- a/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipPushButton.h
+++ b/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipPushButton.h
@@ -1,0 +1,19 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "DolphinQt/Config/ToolTipControls/ToolTipWidget.h"
+
+#include <QPushButton>
+
+#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
+
+class ToolTipPushButton : public ToolTipWidget<NonDefaultQPushButton>
+{
+public:
+  explicit ToolTipPushButton(const QString& text = {}, QWidget* parent = nullptr);
+
+private:
+  QPoint GetToolTipPosition() const override;
+};

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -127,6 +127,7 @@
     <ClCompile Include="Config\ToolTipControls\BalloonTip.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipCheckBox.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipComboBox.cpp" />
+    <ClCompile Include="Config\ToolTipControls\ToolTipPushButton.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipRadioButton.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipSlider.cpp" />
     <ClCompile Include="Config\ToolTipControls\ToolTipSpinBox.cpp" />
@@ -327,6 +328,7 @@
     <QtMoc Include="Config\ToolTipControls\BalloonTip.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipCheckBox.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipComboBox.h" />
+    <ClInclude Include="Config\ToolTipControls\ToolTipPushButton.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipRadioButton.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipSlider.h" />
     <ClInclude Include="Config\ToolTipControls\ToolTipSpinBox.h" />


### PR DESCRIPTION
I noticed the 'Configure' button for Color Correction doesn't use our fancy tooltips and when I went to add it I realized we didn't have a class for that. So here it is.