### PR TITLE
VideoCommon: asset load time is now stored as a chrono system_clock time

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
@@ -20,14 +20,7 @@ struct PixelShaderData;
 class CustomAssetLibrary
 {
 public:
-  // TODO: this should be std::chrono::system_clock::time_point to
-  // support any type of loader where the time isn't from the filesystem
-  // but there's no way to convert filesystem times to system times
-  // without 'clock_cast', once our builders catch up
-  // to support 'clock_cast' we should update this
-  // For now, it's fine as a filesystem library is all that is
-  // available
-  using TimeType = std::filesystem::file_time_type;
+  using TimeType = std::chrono::system_clock::time_point;
 
   // The AssetID is a unique identifier for a particular asset
   using AssetID = std::string;


### PR DESCRIPTION
This allows me to fabricate times (without creating a file) in a future feature.

Unfortunately, only windows (VS) supports `clock_cast` which is needed to convert file times to a system clock.  I have implemented an approximation for other systems.  Users on Linux/Mac/Android would need to test texture packs to make sure this doesn't break existing behavior (in particular the auto reloading which is used for Dynamic Input Textures).