### PR TITLE
VideoBackends: update SRVDescriptorTable size in DX12 to use pixel sampler constant

### DIFF
--- a/Source/Core/VideoBackends/D3D12/D3D12Gfx.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12Gfx.cpp
@@ -654,7 +654,7 @@ bool Gfx::UpdateSRVDescriptorTable()
   static constexpr std::array<UINT, VideoCommon::MAX_PIXEL_SHADER_SAMPLERS> src_sizes = {
       1, 1, 1, 1, 1, 1, 1, 1};
   DescriptorHandle dst_base_handle;
-  const UINT dst_handle_sizes = 8;
+  const UINT dst_handle_sizes = VideoCommon::MAX_PIXEL_SHADER_SAMPLERS;
   if (!g_dx_context->GetDescriptorAllocator()->Allocate(VideoCommon::MAX_PIXEL_SHADER_SAMPLERS,
                                                         &dst_base_handle))
     return false;


### PR DESCRIPTION
Pulled from #11783 an oversight from the original change where we switched over to using a constant ( #11550 )