### PR TITLE
Android: Move DirectoryInitialization toast to UI thread

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -14,6 +14,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.content.ContextCompat;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.preference.PreferenceManager;
@@ -73,8 +74,12 @@ public final class DirectoryInitialization
 
     if (!setDolphinUserDirectory(context))
     {
-      Toast.makeText(context, R.string.external_storage_not_mounted, Toast.LENGTH_LONG).show();
-      System.exit(1);
+      ContextCompat.getMainExecutor(context).execute(() ->
+      {
+        Toast.makeText(context, R.string.external_storage_not_mounted, Toast.LENGTH_LONG).show();
+        System.exit(1);
+      });
+      return;
     }
 
     extractSysDirectory(context);


### PR DESCRIPTION
You're not allowed to just show toasts on any thread you want.