### PR TITLE
DolphinQt/AdvancedPane: UI improvements.

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -236,9 +236,9 @@ void PowerPCManager::InitializeCPUCore(CPUCore cpu_core)
   m_mode = m_cpu_core_base == &interpreter ? CoreMode::Interpreter : CoreMode::JIT;
 }
 
-const std::vector<CPUCore>& AvailableCPUCores()
+std::span<const CPUCore> AvailableCPUCores()
 {
-  static const std::vector<CPUCore> cpu_cores = {
+  static constexpr auto cpu_cores = {
 #ifdef _M_X86_64
       CPUCore::JIT64,
 #elif defined(_M_ARM_64)

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <iosfwd>
+#include <span>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -238,7 +239,7 @@ static_assert(offsetof(PowerPC::PowerPCState, above_fits_in_first_0x100) <= 0x10
 #endif
 #endif
 
-const std::vector<CPUCore>& AvailableCPUCores();
+std::span<const CPUCore> AvailableCPUCores();
 CPUCore DefaultCPUCore();
 
 class PowerPCManager

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -190,9 +190,11 @@ void AdvancedPane::CreateLayout()
 
 void AdvancedPane::ConnectLayout()
 {
-  connect(m_cpu_emulation_engine_combobox,
-          static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [](int index) {
-            Config::SetBaseOrCurrent(Config::MAIN_CPU_CORE, PowerPC::AvailableCPUCores()[index]);
+  connect(m_cpu_emulation_engine_combobox, qOverload<int>(&QComboBox::currentIndexChanged),
+          [](int index) {
+            const auto cpu_cores = PowerPC::AvailableCPUCores();
+            if (index >= 0 && static_cast<size_t>(index) < cpu_cores.size())
+              Config::SetBaseOrCurrent(Config::MAIN_CPU_CORE, cpu_cores[index]);
           });
 
   connect(m_cpu_clock_override_checkbox, &QCheckBox::toggled, [this](bool enable_clock_override) {
@@ -243,7 +245,7 @@ void AdvancedPane::Update()
   const bool enable_ram_override_widgets = Config::Get(Config::MAIN_RAM_OVERRIDE_ENABLE);
   const bool enable_custom_rtc_widgets = Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE) && !running;
 
-  const std::vector<PowerPC::CPUCore>& available_cpu_cores = PowerPC::AvailableCPUCores();
+  const auto available_cpu_cores = PowerPC::AvailableCPUCores();
   const auto cpu_core = Config::Get(Config::MAIN_CPU_CORE);
   for (size_t i = 0; i < available_cpu_cores.size(); ++i)
   {

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -22,6 +22,7 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/PowerPC/PowerPC.h"
 
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Settings.h"
 
 static const std::map<PowerPC::CPUCore, const char*> CPU_CORE_NAMES = {
@@ -63,21 +64,25 @@ void AdvancedPane::CreateLayout()
     m_cpu_emulation_engine_combobox->addItem(tr(CPU_CORE_NAMES.at(cpu_core)));
   }
 
-  m_enable_mmu_checkbox = new QCheckBox(tr("Enable MMU"));
-  m_enable_mmu_checkbox->setToolTip(tr(
-      "Enables the Memory Management Unit, needed for some games. (ON = Compatible, OFF = Fast)"));
+  m_enable_mmu_checkbox = new ConfigBool(tr("Enable MMU"), Config::MAIN_MMU);
+  m_enable_mmu_checkbox->SetDescription(
+      tr("Enables the Memory Management Unit, needed for some games. (ON = Compatible, OFF = "
+         "Fast)<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
   cpu_options_group_layout->addWidget(m_enable_mmu_checkbox);
 
-  m_pause_on_panic_checkbox = new QCheckBox(tr("Pause on Panic"));
-  m_pause_on_panic_checkbox->setToolTip(
-      tr("Pauses the emulation if a Read/Write or Unknown Instruction panic occurs.\nEnabling will "
-         "affect performance.\nThe performance impact is the same as having Enable MMU on."));
+  m_pause_on_panic_checkbox = new ConfigBool(tr("Pause on Panic"), Config::MAIN_PAUSE_ON_PANIC);
+  m_pause_on_panic_checkbox->SetDescription(
+      tr("Pauses the emulation if a Read/Write or Unknown Instruction panic occurs.<br>Enabling "
+         "will affect performance.<br>The performance impact is the same as having Enable MMU "
+         "on.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
   cpu_options_group_layout->addWidget(m_pause_on_panic_checkbox);
 
-  m_accurate_cpu_cache_checkbox = new QCheckBox(tr("Enable Write-Back Cache (slow)"));
-  m_accurate_cpu_cache_checkbox->setToolTip(
-      tr("Enables emulation of the CPU write-back cache.\nEnabling will have a significant impact "
-         "on performance.\nThis should be left disabled unless absolutely needed."));
+  m_accurate_cpu_cache_checkbox =
+      new ConfigBool(tr("Enable Write-Back Cache (slow)"), Config::MAIN_ACCURATE_CPU_CACHE);
+  m_accurate_cpu_cache_checkbox->SetDescription(
+      tr("Enables emulation of the CPU write-back cache.<br>Enabling will have a significant "
+         "impact on performance.<br>This should be left disabled unless absolutely "
+         "needed.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
   cpu_options_group_layout->addWidget(m_accurate_cpu_cache_checkbox);
 
   auto* clock_override = new QGroupBox(tr("Clock Override"));
@@ -189,15 +194,6 @@ void AdvancedPane::ConnectLayout()
             Config::SetBaseOrCurrent(Config::MAIN_CPU_CORE, PowerPC::AvailableCPUCores()[index]);
           });
 
-  connect(m_enable_mmu_checkbox, &QCheckBox::toggled, this,
-          [](bool checked) { Config::SetBaseOrCurrent(Config::MAIN_MMU, checked); });
-
-  connect(m_pause_on_panic_checkbox, &QCheckBox::toggled, this,
-          [](bool checked) { Config::SetBaseOrCurrent(Config::MAIN_PAUSE_ON_PANIC, checked); });
-
-  connect(m_accurate_cpu_cache_checkbox, &QCheckBox::toggled, this,
-          [](bool checked) { Config::SetBaseOrCurrent(Config::MAIN_ACCURATE_CPU_CACHE, checked); });
-
   m_cpu_clock_override_checkbox->setChecked(Config::Get(Config::MAIN_OVERCLOCK_ENABLE));
   connect(m_cpu_clock_override_checkbox, &QCheckBox::toggled, [this](bool enable_clock_override) {
     Config::SetBaseOrCurrent(Config::MAIN_OVERCLOCK_ENABLE, enable_clock_override);
@@ -260,14 +256,8 @@ void AdvancedPane::Update()
       m_cpu_emulation_engine_combobox->setCurrentIndex(int(i));
   }
   m_cpu_emulation_engine_combobox->setEnabled(!running);
-
-  m_enable_mmu_checkbox->setChecked(Config::Get(Config::MAIN_MMU));
   m_enable_mmu_checkbox->setEnabled(!running);
-
-  m_pause_on_panic_checkbox->setChecked(Config::Get(Config::MAIN_PAUSE_ON_PANIC));
   m_pause_on_panic_checkbox->setEnabled(!running);
-
-  m_accurate_cpu_cache_checkbox->setChecked(Config::Get(Config::MAIN_ACCURATE_CPU_CACHE));
   m_accurate_cpu_cache_checkbox->setEnabled(!running);
 
   QFont bf = font();

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -7,6 +7,7 @@
 
 #include <QWidget>
 
+class ConfigBool;
 class QCheckBox;
 class QComboBox;
 class QLabel;
@@ -31,9 +32,9 @@ private:
   void Update();
 
   QComboBox* m_cpu_emulation_engine_combobox;
-  QCheckBox* m_enable_mmu_checkbox;
-  QCheckBox* m_pause_on_panic_checkbox;
-  QCheckBox* m_accurate_cpu_cache_checkbox;
+  ConfigBool* m_enable_mmu_checkbox;
+  ConfigBool* m_pause_on_panic_checkbox;
+  ConfigBool* m_accurate_cpu_cache_checkbox;
   QCheckBox* m_cpu_clock_override_checkbox;
   QSlider* m_cpu_clock_override_slider;
   QLabel* m_cpu_clock_override_slider_label;


### PR DESCRIPTION
- Use fancy tooltips for MMU, Pause on Panic, and Write-back Cache.
- Bold the three above mentioned settings when they are overridden by GameINI.
- The RAM Override and RTC Override checkboxes now correctly check themselves when overridden by GameINI.



Before:
![advanced-before](https://github.com/dolphin-emu/dolphin/assets/4522237/3f40efcf-450d-4594-8025-f1ed8925db3b)

After:
![advanced-after](https://github.com/dolphin-emu/dolphin/assets/4522237/27a2c1ec-4c03-4c5a-9f4e-5f000c74de45)
