### PR TITLE
Don't call RunAsCPUThread in config callbacks

### DIFF
--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -10,6 +10,7 @@
 #include "AudioCommon/SurroundDecoder.h"
 #include "AudioCommon/WaveFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 
 class PointerWrap;
 
@@ -120,5 +121,5 @@ private:
   int m_config_timing_variance;
   bool m_config_audio_stretch;
 
-  size_t m_config_changed_callback_id;
+  Config::ConfigChangedCallbackID m_config_changed_callback_id;
 };

--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -16,7 +16,7 @@ namespace Config
 using Layers = std::map<LayerType, std::shared_ptr<Layer>>;
 
 static Layers s_layers;
-static std::vector<std::pair<size_t, ConfigChangedCallback>> s_callbacks;
+static std::vector<std::pair<ConfigChangedCallbackID, ConfigChangedCallback>> s_callbacks;
 static size_t s_next_callback_id = 0;
 static u32 s_callback_guards = 0;
 static std::atomic<u64> s_config_version = 0;
@@ -65,15 +65,15 @@ void RemoveLayer(LayerType layer)
   OnConfigChanged();
 }
 
-size_t AddConfigChangedCallback(ConfigChangedCallback func)
+ConfigChangedCallbackID AddConfigChangedCallback(ConfigChangedCallback func)
 {
-  const size_t callback_id = s_next_callback_id;
+  const ConfigChangedCallbackID callback_id{s_next_callback_id};
   ++s_next_callback_id;
   s_callbacks.emplace_back(std::make_pair(callback_id, std::move(func)));
   return callback_id;
 }
 
-void RemoveConfigChangedCallback(size_t callback_id)
+void RemoveConfigChangedCallback(ConfigChangedCallbackID callback_id)
 {
   for (auto it = s_callbacks.begin(); it != s_callbacks.end(); ++it)
   {

--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -138,7 +138,6 @@ void Shutdown()
   WriteLock lock(s_layers_rw_lock);
 
   s_layers.clear();
-  s_callbacks.clear();
 }
 
 void ClearCurrentRunLayer()

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -15,6 +15,14 @@
 
 namespace Config
 {
+struct ConfigChangedCallbackID
+{
+  size_t id = -1;
+
+  bool operator==(const ConfigChangedCallbackID&) const = default;
+  bool operator!=(const ConfigChangedCallbackID&) const = default;
+};
+
 using ConfigChangedCallback = std::function<void()>;
 
 // Layer management
@@ -24,8 +32,8 @@ void RemoveLayer(LayerType layer);
 
 // Returns an ID that can be passed to RemoveConfigChangedCallback().
 // The callback may be called from any thread.
-size_t AddConfigChangedCallback(ConfigChangedCallback func);
-void RemoveConfigChangedCallback(size_t callback_id);
+ConfigChangedCallbackID AddConfigChangedCallback(ConfigChangedCallback func);
+void RemoveConfigChangedCallback(ConfigChangedCallbackID callback_id);
 void OnConfigChanged();
 
 // Returns the number of times the config has changed in the current execution of the program

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -22,7 +22,8 @@ void AddLayer(std::unique_ptr<ConfigLayerLoader> loader);
 std::shared_ptr<Layer> GetLayer(LayerType layer);
 void RemoveLayer(LayerType layer);
 
-// returns an ID that can be passed to RemoveConfigChangedCallback()
+// Returns an ID that can be passed to RemoveConfigChangedCallback().
+// The callback may be called from any thread.
 size_t AddConfigChangedCallback(ConfigChangedCallback func);
 void RemoveConfigChangedCallback(size_t callback_id);
 void OnConfigChanged();

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -59,6 +59,8 @@ add_library(core
   Core.h
   CoreTiming.cpp
   CoreTiming.h
+  CPUThreadConfigCallback.cpp
+  CPUThreadConfigCallback.h
   Debugger/CodeTrace.cpp
   Debugger/CodeTrace.h
   Debugger/DebugInterface.h

--- a/Source/Core/Core/CPUThreadConfigCallback.cpp
+++ b/Source/Core/Core/CPUThreadConfigCallback.cpp
@@ -13,7 +13,10 @@ namespace
 {
 std::atomic<bool> s_should_run_callbacks = false;
 
-static std::vector<std::pair<size_t, Config::ConfigChangedCallback>> s_callbacks;
+static std::vector<
+    std::pair<CPUThreadConfigCallback::ConfigChangedCallbackID, Config::ConfigChangedCallback>>
+    s_callbacks;
+
 static size_t s_next_callback_id = 0;
 
 void RunCallbacks()
@@ -39,19 +42,19 @@ void OnConfigChanged()
 
 namespace CPUThreadConfigCallback
 {
-size_t AddConfigChangedCallback(Config::ConfigChangedCallback func)
+ConfigChangedCallbackID AddConfigChangedCallback(Config::ConfigChangedCallback func)
 {
   DEBUG_ASSERT(Core::IsCPUThread());
 
-  static size_t s_config_changed_callback_id = Config::AddConfigChangedCallback(&OnConfigChanged);
+  static auto s_config_changed_callback_id = Config::AddConfigChangedCallback(&OnConfigChanged);
 
-  const size_t callback_id = s_next_callback_id;
+  const ConfigChangedCallbackID callback_id{s_next_callback_id};
   ++s_next_callback_id;
   s_callbacks.emplace_back(std::make_pair(callback_id, std::move(func)));
   return callback_id;
 }
 
-void RemoveConfigChangedCallback(size_t callback_id)
+void RemoveConfigChangedCallback(ConfigChangedCallbackID callback_id)
 {
   DEBUG_ASSERT(Core::IsCPUThread());
 

--- a/Source/Core/Core/CPUThreadConfigCallback.cpp
+++ b/Source/Core/Core/CPUThreadConfigCallback.cpp
@@ -44,8 +44,6 @@ namespace CPUThreadConfigCallback
 {
 ConfigChangedCallbackID AddConfigChangedCallback(Config::ConfigChangedCallback func)
 {
-  DEBUG_ASSERT(Core::IsCPUThread());
-
   static auto s_config_changed_callback_id = Config::AddConfigChangedCallback(&OnConfigChanged);
 
   const ConfigChangedCallbackID callback_id{s_next_callback_id};
@@ -56,8 +54,6 @@ ConfigChangedCallbackID AddConfigChangedCallback(Config::ConfigChangedCallback f
 
 void RemoveConfigChangedCallback(ConfigChangedCallbackID callback_id)
 {
-  DEBUG_ASSERT(Core::IsCPUThread());
-
   for (auto it = s_callbacks.begin(); it != s_callbacks.end(); ++it)
   {
     if (it->first == callback_id)

--- a/Source/Core/Core/CPUThreadConfigCallback.cpp
+++ b/Source/Core/Core/CPUThreadConfigCallback.cpp
@@ -1,0 +1,76 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Core/CPUThreadConfigCallback.h"
+
+#include <atomic>
+
+#include "Common/Assert.h"
+#include "Common/Config/Config.h"
+#include "Core/Core.h"
+
+namespace
+{
+std::atomic<bool> s_should_run_callbacks = false;
+
+static std::vector<std::pair<size_t, Config::ConfigChangedCallback>> s_callbacks;
+static size_t s_next_callback_id = 0;
+
+void RunCallbacks()
+{
+  for (const auto& callback : s_callbacks)
+    callback.second();
+}
+
+void OnConfigChanged()
+{
+  if (Core::IsCPUThread())
+  {
+    s_should_run_callbacks.store(false, std::memory_order_relaxed);
+    RunCallbacks();
+  }
+  else
+  {
+    s_should_run_callbacks.store(true, std::memory_order_relaxed);
+  }
+}
+
+};  // namespace
+
+namespace CPUThreadConfigCallback
+{
+size_t AddConfigChangedCallback(Config::ConfigChangedCallback func)
+{
+  DEBUG_ASSERT(Core::IsCPUThread());
+
+  static size_t s_config_changed_callback_id = Config::AddConfigChangedCallback(&OnConfigChanged);
+
+  const size_t callback_id = s_next_callback_id;
+  ++s_next_callback_id;
+  s_callbacks.emplace_back(std::make_pair(callback_id, std::move(func)));
+  return callback_id;
+}
+
+void RemoveConfigChangedCallback(size_t callback_id)
+{
+  DEBUG_ASSERT(Core::IsCPUThread());
+
+  for (auto it = s_callbacks.begin(); it != s_callbacks.end(); ++it)
+  {
+    if (it->first == callback_id)
+    {
+      s_callbacks.erase(it);
+      return;
+    }
+  }
+}
+
+void CheckForConfigChanges()
+{
+  DEBUG_ASSERT(Core::IsCPUThread());
+
+  if (s_should_run_callbacks.exchange(false, std::memory_order_relaxed))
+    RunCallbacks();
+}
+
+};  // namespace CPUThreadConfigCallback

--- a/Source/Core/Core/CPUThreadConfigCallback.h
+++ b/Source/Core/Core/CPUThreadConfigCallback.h
@@ -1,0 +1,22 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "Common/Config/Config.h"
+
+// This file lets you register callbacks like in Common/Config/Config.h, with the difference that
+// callbacks registered here are guaranteed to run on the CPU thread. Callbacks registered here may
+// run with a slight delay compared to regular config callbacks.
+
+namespace CPUThreadConfigCallback
+{
+// returns an ID that can be passed to RemoveConfigChangedCallback()
+size_t AddConfigChangedCallback(Config::ConfigChangedCallback func);
+
+void RemoveConfigChangedCallback(size_t callback_id);
+
+// Should be called regularly from the CPU thread
+void CheckForConfigChanges();
+
+};  // namespace CPUThreadConfigCallback

--- a/Source/Core/Core/CPUThreadConfigCallback.h
+++ b/Source/Core/Core/CPUThreadConfigCallback.h
@@ -11,10 +11,18 @@
 
 namespace CPUThreadConfigCallback
 {
-// returns an ID that can be passed to RemoveConfigChangedCallback()
-size_t AddConfigChangedCallback(Config::ConfigChangedCallback func);
+struct ConfigChangedCallbackID
+{
+  size_t id = -1;
 
-void RemoveConfigChangedCallback(size_t callback_id);
+  bool operator==(const ConfigChangedCallbackID&) const = default;
+  bool operator!=(const ConfigChangedCallbackID&) const = default;
+};
+
+// returns an ID that can be passed to RemoveConfigChangedCallback()
+ConfigChangedCallbackID AddConfigChangedCallback(Config::ConfigChangedCallback func);
+
+void RemoveConfigChangedCallback(ConfigChangedCallbackID callback_id);
 
 // Should be called regularly from the CPU thread
 void CheckForConfigChanges();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -41,6 +41,7 @@
 #include "Core/AchievementManager.h"
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
+#include "Core/CPUThreadConfigCallback.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
@@ -510,6 +511,9 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   // For a time this acts as the CPU thread...
   DeclareAsCPUThread();
   s_frame_step = false;
+
+  // If settings have changed since the previous run, notify callbacks.
+  CPUThreadConfigCallback::CheckForConfigChanges();
 
   // Switch the window used for inputs to the render window. This way, the cursor position
   // is relative to the render window, instead of the main window.

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -23,6 +23,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/SPSCQueue.h"
+#include "Core/CPUThreadConfigCallback.h"
 
 class PointerWrap;
 
@@ -182,7 +183,7 @@ private:
 
   EventType* m_ev_lost = nullptr;
 
-  size_t m_registered_config_callback_id = 0;
+  CPUThreadConfigCallback::ConfigChangedCallbackID m_registered_config_callback_id;
   float m_config_oc_factor = 0.0f;
   float m_config_oc_inv_factor = 0.0f;
   bool m_config_sync_on_skip_idle = false;

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/Assert.h"
+#include "Common/Config/Config.h"
 #include "Core/FifoPlayer/FifoDataFile.h"
 #include "Core/PowerPC/CPUCoreBase.h"
 #include "VideoCommon/CPMemory.h"
@@ -189,7 +190,7 @@ private:
 
   CallbackFunc m_FileLoadedCb = nullptr;
   CallbackFunc m_FrameWrittenCb = nullptr;
-  size_t m_config_changed_callback_id;
+  Config::ConfigChangedCallbackID m_config_changed_callback_id;
 
   std::unique_ptr<FifoDataFile> m_File;
 

--- a/Source/Core/Core/FreeLookConfig.cpp
+++ b/Source/Core/Core/FreeLookConfig.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Core/FreeLookConfig.h"
+
+#include "Core/CPUThreadConfigCallback.h"
 #include "Core/Config/FreeLookSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -37,7 +39,7 @@ void Config::Refresh()
 {
   if (!s_has_registered_callback)
   {
-    ::Config::AddConfigChangedCallback([] { Core::RunAsCPUThread([] { s_config.Refresh(); }); });
+    CPUThreadConfigCallback::AddConfigChangedCallback([] { s_config.Refresh(); });
     s_has_registered_callback = true;
   }
 

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -10,6 +10,7 @@
 #include "AudioCommon/AudioCommon.h"
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
+#include "Core/CPUThreadConfigCallback.h"
 #include "Core/Core.h"
 #include "Core/Host.h"
 #include "Core/PowerPC/GDBStub.h"
@@ -75,6 +76,7 @@ void CPUManager::Run()
   {
     m_state_cpu_cvar.wait(state_lock, [this] { return !m_state_paused_and_locked; });
     ExecutePendingJobs(state_lock);
+    CPUThreadConfigCallback::CheckForConfigChanges();
 
     Common::Event gdb_step_sync_event;
     switch (m_state)
@@ -113,6 +115,7 @@ void CPUManager::Run()
       // Wait for step command.
       m_state_cpu_cvar.wait(state_lock, [this, &state_lock, &gdb_step_sync_event] {
         ExecutePendingJobs(state_lock);
+        CPUThreadConfigCallback::CheckForConfigChanges();
         state_lock.unlock();
         if (GDBStub::IsActive() && GDBStub::HasControl())
         {

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -30,7 +30,7 @@ static std::array<u8, MAX_BBMOTES> s_last_connect_request_counter;
 namespace
 {
 static std::array<std::atomic<WiimoteSource>, MAX_BBMOTES> s_wiimote_sources;
-static std::optional<size_t> s_config_callback_id = std::nullopt;
+static std::optional<Config::ConfigChangedCallbackID> s_config_callback_id = std::nullopt;
 
 WiimoteSource GetSource(unsigned int index)
 {

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "Common/Common.h"
+#include "Common/Config/Config.h"
 
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
 
@@ -343,6 +344,6 @@ private:
 
   IMUCursorState m_imu_cursor_state;
 
-  size_t m_config_changed_callback_id;
+  Config::ConfigChangedCallbackID m_config_changed_callback_id;
 };
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Common/Common.h"
+#include "Common/Config/Config.h"
 #include "Common/Event.h"
 #include "Common/Flag.h"
 #include "Common/SPSCQueue.h"
@@ -157,7 +158,7 @@ private:
   bool m_speaker_enabled_in_dolphin_config = false;
   int m_balance_board_dump_port = 0;
 
-  size_t m_config_changed_callback_id;
+  Config::ConfigChangedCallbackID m_config_changed_callback_id;
 };
 
 class WiimoteScannerBackend

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -10,6 +10,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"
+#include "Core/CPUThreadConfigCallback.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 
@@ -166,7 +167,7 @@ private:
 
   File::IOFile m_card;
 
-  size_t m_config_callback_id;
+  CPUThreadConfigCallback::ConfigChangedCallbackID m_config_callback_id;
   bool m_sd_card_inserted = false;
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -7,6 +7,8 @@
 #include "Common/CommonTypes.h"
 #include "Common/MemoryUtil.h"
 #include "Common/Thread.h"
+
+#include "Core/CPUThreadConfigCallback.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -64,14 +66,14 @@ JitBase::JitBase(Core::System& system)
     : m_code_buffer(code_buffer_size), m_system(system), m_ppc_state(system.GetPPCState()),
       m_mmu(system.GetMMU())
 {
-  m_registered_config_callback_id = Config::AddConfigChangedCallback(
-      [this] { Core::RunAsCPUThread([this] { RefreshConfig(); }); });
+  m_registered_config_callback_id =
+      CPUThreadConfigCallback::AddConfigChangedCallback([this] { RefreshConfig(); });
   RefreshConfig();
 }
 
 JitBase::~JitBase()
 {
-  Config::RemoveConfigChangedCallback(m_registered_config_callback_id);
+  CPUThreadConfigCallback::RemoveConfigChangedCallback(m_registered_config_callback_id);
 }
 
 void JitBase::RefreshConfig()

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -10,6 +10,7 @@
 #include "Common/BitSet.h"
 #include "Common/CommonTypes.h"
 #include "Common/x64Emitter.h"
+#include "Core/CPUThreadConfigCallback.h"
 #include "Core/ConfigManager.h"
 #include "Core/MachineContext.h"
 #include "Core/PowerPC/CPUCoreBase.h"
@@ -129,7 +130,7 @@ protected:
   PPCAnalyst::CodeBuffer m_code_buffer;
   PPCAnalyst::PPCAnalyzer analyzer;
 
-  size_t m_registered_config_callback_id;
+  CPUThreadConfigCallback::ConfigChangedCallbackID m_registered_config_callback_id;
   bool bJITOff = false;
   bool bJITLoadStoreOff = false;
   bool bJITLoadStorelXzOff = false;

--- a/Source/Core/Core/PowerPC/PPCCache.h
+++ b/Source/Core/Core/PowerPC/PPCCache.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 
 class PointerWrap;
 
@@ -61,7 +62,7 @@ struct Cache
 
 struct InstructionCache : public Cache
 {
-  std::optional<size_t> m_config_callback_id = std::nullopt;
+  std::optional<Config::ConfigChangedCallbackID> m_config_callback_id = std::nullopt;
 
   bool m_disable_icache = false;
 

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -190,6 +190,7 @@
     <ClInclude Include="Core\ConfigManager.h" />
     <ClInclude Include="Core\Core.h" />
     <ClInclude Include="Core\CoreTiming.h" />
+    <ClInclude Include="Core\CPUThreadConfigCallback.h" />
     <ClInclude Include="Core\Debugger\CodeTrace.h" />
     <ClInclude Include="Core\Debugger\DebugInterface.h" />
     <ClInclude Include="Core\Debugger\Debugger_SymbolMap.h" />
@@ -833,6 +834,7 @@
     <ClCompile Include="Core\ConfigManager.cpp" />
     <ClCompile Include="Core\Core.cpp" />
     <ClCompile Include="Core\CoreTiming.cpp" />
+    <ClCompile Include="Core\CPUThreadConfigCallback.cpp" />
     <ClCompile Include="Core\Debugger\CodeTrace.cpp" />
     <ClCompile Include="Core\Debugger\Debugger_SymbolMap.cpp" />
     <ClCompile Include="Core\Debugger\Dump.cpp" />

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -219,7 +219,7 @@ private:
   SteadyClock::time_point m_next_listports_time;
   std::thread m_hotplug_thread;
   Common::Flag m_hotplug_thread_running;
-  std::size_t m_config_change_callback_id;
+  Config::ConfigChangedCallbackID m_config_change_callback_id;
 };
 
 std::unique_ptr<ciface::InputBackend> CreateInputBackend(ControllerInterface* controller_interface)

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include "Common/BitUtils.h"
+#include "Common/Config/Config.h"
 #include "Common/Event.h"
 #include "Common/Flag.h"
 #include "Common/Logging/Log.h"
@@ -158,7 +159,7 @@ static u8 s_endpoint_out = 0;
 
 static u64 s_last_init = 0;
 
-static std::optional<size_t> s_config_callback_id = std::nullopt;
+static std::optional<Config::ConfigChangedCallbackID> s_config_callback_id = std::nullopt;
 
 static bool s_is_adapter_wanted = false;
 static std::array<bool, SerialInterface::MAX_SI_CHANNELS> s_config_rumble_enabled{};

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -62,7 +62,7 @@
 
 namespace UICommon
 {
-static size_t s_config_changed_callback_id;
+static Config::ConfigChangedCallbackID s_config_changed_callback_id;
 
 static void CreateDumpPath(std::string path)
 {

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -9,6 +9,7 @@
 
 #include "Common/BlockingLoop.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/Event.h"
 #include "Common/Flag.h"
 
@@ -121,7 +122,7 @@ private:
   bool m_syncing_suspended = false;
   Common::Event m_sync_wakeup_event;
 
-  std::optional<size_t> m_config_callback_id = std::nullopt;
+  std::optional<Config::ConfigChangedCallbackID> m_config_callback_id = std::nullopt;
   bool m_config_sync_gpu = false;
   int m_config_sync_gpu_max_distance = 0;
   int m_config_sync_gpu_min_distance = 0;

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -5,7 +5,9 @@
 #include <fmt/format.h>
 
 #include "Common/CommonTypes.h"
+#include "Common/ScopeGuard.h"
 #include "Common/Timer.h"
+#include "Core/Core.h"
 #include "Core/MemTools.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/JitInterface.h"
@@ -74,6 +76,9 @@ TEST(PageFault, PageFault)
   void* data = Common::AllocateMemoryPages(PAGE_GRAN);
   EXPECT_NE(data, nullptr);
   Common::WriteProtectMemory(data, PAGE_GRAN, false);
+
+  Core::DeclareAsCPUThread();
+  Common::ScopeGuard cpu_thread_guard([] { Core::UndeclareAsCPUThread(); });
 
   auto& system = Core::System::GetInstance();
   auto unique_pfjit = std::make_unique<PageFaultFakeJit>(system);

--- a/Source/UnitTests/Core/PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
+++ b/Source/UnitTests/Core/PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
@@ -5,7 +5,9 @@
 #include <tuple>
 
 #include "Common/CommonTypes.h"
+#include "Common/ScopeGuard.h"
 #include "Common/x64ABI.h"
+#include "Core/Core.h"
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/Jit64/Jit.h"
@@ -52,6 +54,9 @@ public:
 
 TEST(Jit64, ConvertDoubleToSingle)
 {
+  Core::DeclareAsCPUThread();
+  Common::ScopeGuard cpu_thread_guard([] { Core::UndeclareAsCPUThread(); });
+
   TestCommonAsmRoutines routines(Core::System::GetInstance());
 
   for (const u64 input : double_test_values)

--- a/Source/UnitTests/Core/PowerPC/Jit64Common/Frsqrte.cpp
+++ b/Source/UnitTests/Core/PowerPC/Jit64Common/Frsqrte.cpp
@@ -6,7 +6,9 @@
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/FloatUtils.h"
+#include "Common/ScopeGuard.h"
 #include "Common/x64ABI.h"
+#include "Core/Core.h"
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64Common/Jit64AsmCommon.h"
@@ -59,6 +61,9 @@ public:
 
 TEST(Jit64, Frsqrte)
 {
+  Core::DeclareAsCPUThread();
+  Common::ScopeGuard cpu_thread_guard([] { Core::UndeclareAsCPUThread(); });
+
   TestCommonAsmRoutines routines(Core::System::GetInstance());
 
   UReg_FPSCR fpscr;

--- a/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
@@ -7,6 +7,8 @@
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/FPURoundMode.h"
+#include "Common/ScopeGuard.h"
+#include "Core/Core.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/JitArm64/Jit.h"
 #include "Core/System.h"
@@ -120,6 +122,9 @@ private:
 
 TEST(JitArm64, ConvertDoubleToSingle)
 {
+  Core::DeclareAsCPUThread();
+  Common::ScopeGuard cpu_thread_guard([] { Core::UndeclareAsCPUThread(); });
+
   TestConversion test(Core::System::GetInstance());
 
   for (const u64 input : double_test_values)
@@ -155,6 +160,9 @@ TEST(JitArm64, ConvertDoubleToSingle)
 
 TEST(JitArm64, ConvertSingleToDouble)
 {
+  Core::DeclareAsCPUThread();
+  Common::ScopeGuard cpu_thread_guard([] { Core::UndeclareAsCPUThread(); });
+
   TestConversion test(Core::System::GetInstance());
 
   for (const u32 input : single_test_values)

--- a/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/FPRF.cpp
@@ -7,6 +7,8 @@
 #include "Common/Arm64Emitter.h"
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+#include "Common/ScopeGuard.h"
+#include "Core/Core.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/JitArm64/Jit.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -70,6 +72,9 @@ static u32 RunUpdateFPRF(PowerPC::PowerPCState& ppc_state, const std::function<v
 
 TEST(JitArm64, FPRF)
 {
+  Core::DeclareAsCPUThread();
+  Common::ScopeGuard cpu_thread_guard([] { Core::UndeclareAsCPUThread(); });
+
   auto& system = Core::System::GetInstance();
   auto& ppc_state = system.GetPPCState();
   TestFPRF test(system);

--- a/Source/UnitTests/Core/PowerPC/JitArm64/Fres.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/Fres.cpp
@@ -6,6 +6,8 @@
 #include "Common/Arm64Emitter.h"
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+#include "Common/ScopeGuard.h"
+#include "Core/Core.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/JitArm64/Jit.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -51,6 +53,9 @@ public:
 
 TEST(JitArm64, Fres)
 {
+  Core::DeclareAsCPUThread();
+  Common::ScopeGuard cpu_thread_guard([] { Core::UndeclareAsCPUThread(); });
+
   TestFres test(Core::System::GetInstance());
 
   for (const u64 ivalue : double_test_values)

--- a/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
@@ -6,6 +6,8 @@
 #include "Common/Arm64Emitter.h"
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+#include "Common/ScopeGuard.h"
+#include "Core/Core.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/JitArm64/Jit.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -51,6 +53,9 @@ public:
 
 TEST(JitArm64, Frsqrte)
 {
+  Core::DeclareAsCPUThread();
+  Common::ScopeGuard cpu_thread_guard([] { Core::UndeclareAsCPUThread(); });
+
   TestFrsqrte test(Core::System::GetInstance());
 
   for (const u64 ivalue : double_test_values)


### PR DESCRIPTION
In theory, our config system supports calling `Set` from any thread. But because we have config callbacks that call `RunAsCPUThread`, it's a lot more restricted in practice. Calling `Set` from any thread other than the host thread or the CPU thread is formally thread unsafe, and calling `Set` on the host thread while the CPU thread is showing a panic alert causes a deadlock. This is especially a problem because 04072f0 made the "Ignore for this session" button in panic alerts call `Set`.

Because so many of our config callbacks want their code to run on the CPU thread, I thought it would make sense to have a centralized way to move execution to the CPU thread for config callbacks. To solve the deadlock problem, this new way is non-blocking. This means that threads other than the CPU thread might continue executing before the CPU thread is informed of the new config, but I don't think there's any problem with that.

Intends to fix https://bugs.dolphin-emu.org/issues/13108.