### PR TITLE
DolphinQt/TASInputWindow: Make 'Enable Controller Input' translatable.

### DIFF
--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -50,7 +50,7 @@ TASInputWindow::TASInputWindow(QWidget* parent) : QDialog(parent)
 
   QGridLayout* settings_layout = new QGridLayout;
 
-  m_use_controller = new QCheckBox(QStringLiteral("Enable Controller Inpu&t"));
+  m_use_controller = new QCheckBox(tr("Enable Controller Inpu&t"));
   m_use_controller->setToolTip(tr("Warning: Analog inputs may reset to controller values at "
                                   "random. In some cases this can be fixed by adding a deadzone."));
   settings_layout->addWidget(m_use_controller, 0, 0, 1, 2);


### PR DESCRIPTION
From #12072, no reply to suggested change.