### PR TITLE
Jit: Handle imm msr in EmitStoreMembase

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -498,10 +498,18 @@ void Jit64::EmitUpdateMembase()
 void Jit64::EmitStoreMembase(const OpArg& msr, X64Reg scratch_reg)
 {
   auto& memory = m_system.GetMemory();
-  MOV(64, R(RMEM), ImmPtr(memory.GetLogicalBase()));
-  MOV(64, R(scratch_reg), ImmPtr(memory.GetPhysicalBase()));
-  TEST(32, msr, Imm32(1 << (31 - 27)));
-  CMOVcc(64, RMEM, R(scratch_reg), CC_Z);
+  if (msr.IsImm())
+  {
+    MOV(64, R(RMEM),
+        ImmPtr(UReg_MSR(msr.Imm32()).DR ? memory.GetLogicalBase() : memory.GetPhysicalBase()));
+  }
+  else
+  {
+    MOV(64, R(RMEM), ImmPtr(memory.GetLogicalBase()));
+    MOV(64, R(scratch_reg), ImmPtr(memory.GetPhysicalBase()));
+    TEST(32, msr, Imm32(1 << (31 - 27)));
+    CMOVcc(64, RMEM, R(scratch_reg), CC_Z);
+  }
   MOV(64, PPCSTATE(mem_ptr), R(RMEM));
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -439,7 +439,7 @@ void Jit64::mtmsr(UGeckoInstruction inst)
     RegCache::Realize(Rs);
     MOV(32, PPCSTATE(msr), Rs);
 
-    EmitStoreMembase(PPCSTATE(msr), RSCRATCH2);
+    EmitStoreMembase(Rs, RSCRATCH2);
   }
 
   gpr.Flush();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -361,6 +361,16 @@ void JitArm64::EmitUpdateMembase()
   LDR(IndexType::Unsigned, MEM_REG, PPC_REG, PPCSTATE_OFF(mem_ptr));
 }
 
+void JitArm64::EmitStoreMembase(u32 msr)
+{
+  auto& memory = m_system.GetMemory();
+  MOVP2R(MEM_REG,
+         UReg_MSR(msr).DR ?
+             (jo.fastmem_arena ? memory.GetLogicalBase() : memory.GetLogicalPageMappingsBase()) :
+             (jo.fastmem_arena ? memory.GetPhysicalBase() : memory.GetPhysicalPageMappingsBase()));
+  STR(IndexType::Unsigned, MEM_REG, PPC_REG, PPCSTATE_OFF(mem_ptr));
+}
+
 void JitArm64::EmitStoreMembase(const ARM64Reg& msr)
 {
   auto& memory = m_system.GetMemory();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -312,6 +312,7 @@ protected:
   void EndTimeProfile(JitBlock* b);
 
   void EmitUpdateMembase();
+  void EmitStoreMembase(u32 msr);
   void EmitStoreMembase(const Arm64Gen::ARM64Reg& msr);
 
   // Exits

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -95,7 +95,6 @@ void JitArm64::mtmsr(UGeckoInstruction inst)
   if (imm_value)
     EmitStoreMembase(gpr.GetImm(inst.RS));
 
-  gpr.BindToRegister(inst.RS, true);
   STR(IndexType::Unsigned, gpr.R(inst.RS), PPC_REG, PPCSTATE_OFF(msr));
 
   if (!imm_value)
@@ -176,7 +175,6 @@ void JitArm64::mtsr(UGeckoInstruction inst)
   INSTRUCTION_START
   JITDISABLE(bJITSystemRegistersOff);
 
-  gpr.BindToRegister(inst.RS, true);
   STR(IndexType::Unsigned, gpr.R(inst.RS), PPC_REG, PPCSTATE_OFF_SR(inst.SR));
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -91,10 +91,15 @@ void JitArm64::mtmsr(UGeckoInstruction inst)
   JITDISABLE(bJITSystemRegistersOff);
   FALLBACK_IF(jo.fp_exceptions);
 
+  const bool imm_value = gpr.IsImm(inst.RS);
+  if (imm_value)
+    EmitStoreMembase(gpr.GetImm(inst.RS));
+
   gpr.BindToRegister(inst.RS, true);
   STR(IndexType::Unsigned, gpr.R(inst.RS), PPC_REG, PPCSTATE_OFF(msr));
 
-  EmitStoreMembase(gpr.R(inst.RS));
+  if (!imm_value)
+    EmitStoreMembase(gpr.R(inst.RS));
 
   gpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
   fpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);


### PR DESCRIPTION
This makes Jit64::mtmsr more optimized in particular.