### PR TITLE
dolphin-emu.desktop: Add supported MIME types.

### DIFF
--- a/Data/dolphin-emu.desktop
+++ b/Data/dolphin-emu.desktop
@@ -1,10 +1,11 @@
 [Desktop Entry]
 Version=1.0
 Icon=dolphin-emu
-Exec=env QT_QPA_PLATFORM=xcb dolphin-emu
+Exec=env QT_QPA_PLATFORM=xcb dolphin-emu %f
 Terminal=false
 Type=Application
 Categories=Game;Emulator;
+MimeType=application/x-gamecube-rom;application/x-gamecube-iso-image;application/x-gamecube-tgc;application/x-wii-rom;application/x-wii-iso-image;application/x-wbfs;application/x-wia;application/x-wii-wad;
 Name=Dolphin Emulator
 GenericName=Wii/GameCube Emulator
 Comment=A Wii/GameCube Emulator


### PR DESCRIPTION
This allows users to open a supported disc image directly from the file browser.

Exec now has "%f" to pass the specified filename to dolphin-emu.