### PR TITLE
Move SmallVector to Common

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(common
   SettingsHandler.h
   SFMLHelper.cpp
   SFMLHelper.h
+  SmallVector.h
   SocketContext.cpp
   SocketContext.h
   SPSCQueue.h

--- a/Source/Core/Common/SmallVector.h
+++ b/Source/Core/Common/SmallVector.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: CC0-1.0
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <utility>
+
+namespace Common
+{
+
+// An std::vector-like container that uses no heap allocations but is limited to a maximum size.
+template <typename T, size_t MaxSize>
+class SmallVector final
+{
+public:
+  SmallVector() = default;
+  explicit SmallVector(size_t size) : m_size(size) {}
+
+  void push_back(const T& x) { m_array[m_size++] = x; }
+  void push_back(T&& x) { m_array[m_size++] = std::move(x); }
+
+  template <typename... Args>
+  T& emplace_back(Args&&... args)
+  {
+    return m_array[m_size++] = T{std::forward<Args>(args)...};
+  }
+
+  T& operator[](size_t i) { return m_array[i]; }
+  const T& operator[](size_t i) const { return m_array[i]; }
+
+  auto begin() { return m_array.begin(); }
+  auto end() { return m_array.begin() + m_size; }
+
+  auto begin() const { return m_array.begin(); }
+  auto end() const { return m_array.begin() + m_size; }
+
+  size_t size() const { return m_size; }
+  bool empty() const { return m_size == 0; }
+
+private:
+  std::array<T, MaxSize> m_array{};
+  size_t m_size = 0;
+};
+
+}  // namespace Common

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -143,6 +143,7 @@
     <ClInclude Include="Common\Semaphore.h" />
     <ClInclude Include="Common\SettingsHandler.h" />
     <ClInclude Include="Common\SFMLHelper.h" />
+    <ClInclude Include="Common\SmallVector.h" />
     <ClInclude Include="Common\SocketContext.h" />
     <ClInclude Include="Common\SPSCQueue.h" />
     <ClInclude Include="Common\StringLiteral.h" />


### PR DESCRIPTION
We had one implementation of this type of data structure in Arm64Emitter and one in VideoCommon. This moves the Arm64Emitter implementation to its own file and adds begin and end functions to it, so that VideoCommon can use it.

You may notice that the license header for the new file is CC0. I wrote the Arm64Emitter implementation of SmallVector, so this should be no problem.