### PR TITLE
MemoryViewWidget: Fix some characters being truncated

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -208,7 +208,7 @@ MemoryViewWidget::MemoryViewWidget(QWidget* parent)
 void MemoryViewWidget::UpdateFont()
 {
   const QFontMetrics fm(Settings::Instance().GetDebugFont());
-  m_font_vspace = fm.lineSpacing();
+  m_font_vspace = fm.lineSpacing() + 4;
   // BoundingRect is too unpredictable, a custom one would be needed for each view type. Different
   // fonts have wildly different spacing between two characters and horizontalAdvance includes
   // spacing.
@@ -283,8 +283,8 @@ void MemoryViewWidget::CreateTable()
 
   // This sets all row heights and determines horizontal ascii spacing.
   // Could be placed in UpdateFont() but doesn't apply correctly unless called more.
-  m_table->verticalHeader()->setDefaultSectionSize(m_font_vspace - 1);
-  m_table->verticalHeader()->setMinimumSectionSize(m_font_vspace - 1);
+  m_table->verticalHeader()->setDefaultSectionSize(m_font_vspace);
+  m_table->verticalHeader()->setMinimumSectionSize(m_font_vspace);
   m_table->horizontalHeader()->setMinimumSectionSize(m_font_width * 2);
 
   const QSignalBlocker blocker(m_table);


### PR DESCRIPTION
This PR fixes some ASCII characters not being drawn properly on the memory view.

Without this PR, underscores aren't drawn on my system. Removing the `-1` from `(m_font_vspace - 1)` fixes the underscore issue. However, it was drawn under the table cell's border and couldn't be seen unless I changed the address and move the cursor elsewhere. Adding 1~2 (pixels?) allows the underscore character to be drawn right above the cell border but without spacing between it. That's why I added an extra 2 (i.e. 4 in total) to have at least a bit of spacing between the underscore and the cell's (dotted) border.

Before this PR:
![image](https://github.com/dolphin-emu/dolphin/assets/7890055/60629a7d-22e4-4406-86ba-7e6cebb44408)

This PR:
![image](https://github.com/dolphin-emu/dolphin/assets/7890055/5b3c629f-6783-433b-8128-626c4cff7c0a)

I'm open to suggestions if you've better ways to address this.

Ready to be reviewed & merged.