### PR TITLE
VideoCommon/GraphicsModAsset: Error out if config key is not a string.

### DIFF
--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.cpp
@@ -44,6 +44,7 @@ bool GraphicsModAssetConfig::DeserializeFromConfig(const picojson::object& obj)
                     "Failed to load mod configuration file, specified asset '{}' has data "
                     "with a value for key '{}' that is not a string",
                     m_name, key);
+      return false;
     }
     m_map[key] = value.to_str();
   }


### PR DESCRIPTION
This was in #12040 but not in #11300 and probably should be there.