### PR TITLE
Turn on manual texture sampling for Mario Party 4 by default to fix seams

### DIFF
--- a/Data/Sys/GameSettings/GMPE01.ini
+++ b/Data/Sys/GameSettings/GMPE01.ini
@@ -6,6 +6,9 @@
 [OnFrame]
 # Add memory patches to be applied every frame here.
 
+[Video_Hacks]
+FastTextureSampling = False
+
 [ActionReplay]
 # Add action replay cheats here.
 


### PR DESCRIPTION
Fixes the bug described in the wiki [here](https://wiki.dolphin-emu.org/index.php?title=Mario_Party_4#Texture_Seams).

![GMPE01_2023-08-22_09-21-24](https://github.com/dolphin-emu/dolphin/assets/69772986/e88bf8a5-af37-4939-96a1-15232f9db32e)
