### PR TITLE
Jit: Don't discard before gather pipe interrupt check

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -421,7 +421,9 @@ void RegCache::Flush(BitSet32 pregs)
     switch (m_regs[i].GetLocationType())
     {
     case PPCCachedReg::LocationType::Default:
+      break;
     case PPCCachedReg::LocationType::Discarded:
+      ASSERT_MSG(DYNA_REC, false, "Attempted to flush discarded PPC reg {}", i);
       break;
     case PPCCachedReg::LocationType::SpeculativeImmediate:
       // We can have a cached value without a host register through speculative constants.

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -245,11 +245,14 @@ void Arm64GPRCache::FlushRegisters(BitSet32 regs, bool maintain_state, ARM64Reg 
   {
     if (regs[i])
     {
+      ASSERT_MSG(DYNA_REC, m_guest_registers[GUEST_GPR_OFFSET + i].GetType() != RegType::Discarded,
+                 "Attempted to flush discarded register");
+
       if (i + 1 < GUEST_GPR_COUNT && regs[i + 1])
       {
         // We've got two guest registers in a row to store
-        OpArg& reg1 = m_guest_registers[i];
-        OpArg& reg2 = m_guest_registers[i + 1];
+        OpArg& reg1 = m_guest_registers[GUEST_GPR_OFFSET + i];
+        OpArg& reg2 = m_guest_registers[GUEST_GPR_OFFSET + i + 1];
         if (reg1.IsDirty() && reg2.IsDirty() && reg1.GetType() == RegType::Register &&
             reg2.GetType() == RegType::Register)
         {
@@ -283,6 +286,9 @@ void Arm64GPRCache::FlushCRRegisters(BitSet32 regs, bool maintain_state, ARM64Re
   {
     if (regs[i])
     {
+      ASSERT_MSG(DYNA_REC, m_guest_registers[GUEST_CR_OFFSET + i].GetType() != RegType::Discarded,
+                 "Attempted to flush discarded register");
+
       FlushRegister(GUEST_CR_OFFSET + i, maintain_state, tmp_reg);
     }
   }


### PR DESCRIPTION
This bug has been lurking in the code ever since I added the discard functionality. It doesn't seem to be triggered all that often, and on top of that the emitted code only runs conditionally, so I'm not sure if people have been affected by this bug in practice or not.