### PR TITLE
VideoCommon: add additional texture sampler types to ShaderAsset

### DIFF
--- a/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
@@ -49,6 +49,14 @@ bool ParseShaderProperties(const VideoCommon::CustomAssetLibrary::AssetID& asset
     {
       property.m_type = ShaderProperty::Type::Type_Sampler2D;
     }
+    else if (type == "samplerarrayshared_main")
+    {
+      property.m_type = ShaderProperty::Type::Type_SamplerArrayShared_Main;
+    }
+    else if (type == "samplerarrayshared_additional")
+    {
+      property.m_type = ShaderProperty::Type::Type_SamplerArrayShared_Additional;
+    }
     else
     {
       ERROR_LOG_FMT(VIDEO,

--- a/Source/Core/VideoCommon/Assets/ShaderAsset.h
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.h
@@ -14,9 +14,17 @@ namespace VideoCommon
 {
 struct ShaderProperty
 {
+  // "SamplerShared" denotes that the sampler
+  // already exists outside of the shader source
+  // (ex: in the Dolphin defined pixel shader)
+  // "Main" is the first entry in a shared sampler array
+  // and "Additional" denotes a subsequent entry
+  // in the array
   enum class Type
   {
     Type_Undefined,
+    Type_SamplerArrayShared_Main,
+    Type_SamplerArrayShared_Additional,
     Type_Sampler2D,
     Type_Max = Type_Sampler2D
   };


### PR DESCRIPTION
This adds a couple of additional sampler definitions to the ShaderAsset.  This allows for distinguishing between a 2d sampler defined by assets and a 2d sampler that was defined by an alternate source (ex: Dolphin has a definition for an array of samplers in `PixelShaderGen` for instance).  This distinction isn't super necessary at the moment but will be important later on if a user wants to add 2d textures with their own sampler information and independent resolution (needs #12136 )

I add two separate entries.  One called `Type_SamplerArrayShared_Main` that denotes the main texture, in a sampler array this is where the sampler would come from and also sets the requirement for the size of the texture.  `Type_SamplerArrayShared_Additional` is an additional texture which follows the sampler rules defined by `Type_SamplerArrayShared_Main`  (which isn't a new concept, that's how texture sampler arrays work!)