### PR TITLE
PageFaultTest: Use GTEST_SKIP instead of early return

### DIFF
--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -68,10 +68,8 @@ static void ASAN_DISABLE perform_invalid_access(void* data)
 TEST(PageFault, PageFault)
 {
   if (!EMM::IsExceptionHandlerSupported())
-  {
-    // TODO: Use GTEST_SKIP() instead when GTest is updated to 1.10+
-    return;
-  }
+    GTEST_SKIP() << "Skipping PageFault test because exception handler is unsupported.";
+
   EMM::InstallExceptionHandler();
   void* data = Common::AllocateMemoryPages(PAGE_GRAN);
   EXPECT_NE(data, nullptr);


### PR DESCRIPTION
Using GTEST_SKIP instead of just returning from the function shows that a test was skipped in the test summary. If GTEST_SKIP is called the rest of the function won't be run, just like with the return.

GTEST_SKIP wasn't available until gtest 1.10, and we updated to 1.12.1 in #11438.