### PR TITLE
IOS/KD: Check if a file has an RSA signature

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NWC24DL.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NWC24DL.cpp
@@ -120,6 +120,11 @@ bool NWC24Dl::IsEncrypted(u16 entry_index) const
   return !!Common::ExtractBit(Common::swap32(m_data.entries[entry_index].flags), 3);
 }
 
+bool NWC24Dl::IsRSASigned(u16 entry_index) const
+{
+  return !Common::ExtractBit(Common::swap32(m_data.entries[entry_index].flags), 2);
+}
+
 u32 NWC24Dl::Magic() const
 {
   return Common::swap32(m_data.header.magic);

--- a/Source/Core/Core/IOS/Network/KD/NWC24DL.h
+++ b/Source/Core/Core/IOS/Network/KD/NWC24DL.h
@@ -29,6 +29,7 @@ public:
 
   bool DoesEntryExist(u16 entry_index);
   bool IsEncrypted(u16 entry_index) const;
+  bool IsRSASigned(u16 entry_index) const;
   std::string GetVFFContentName(u16 entry_index, std::optional<u8> subtask_id) const;
   std::string GetDownloadURL(u16 entry_index, std::optional<u8> subtask_id) const;
   std::string GetVFFPath(u16 entry_index) const;


### PR DESCRIPTION
The flag in an application's `nwc24dl.bin` entry can have a bit set which signifies that the downloaded file will not have an RSA signature. Along with not having the signature, it will also not have the `NWC24::WC24File` header, or 320 null bytes before the actual data.