### PR TITLE
Android: Fix controller float sliders crashing

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.kt
@@ -10,7 +10,11 @@ import java.math.BigDecimal
 import java.math.MathContext
 
 open class FloatSliderSetting : SliderSetting {
-    var floatSetting: AbstractFloatSetting
+    protected val floatSetting: AbstractFloatSetting
+
+    val min: Float
+    val max: Float
+    val stepSize: Float
 
     override val setting: AbstractSetting
         get() = floatSetting
@@ -25,8 +29,11 @@ open class FloatSliderSetting : SliderSetting {
         units: String?,
         stepSize: Float,
         showDecimal: Boolean
-    ) : super(context, titleId, descriptionId, min, max, units, stepSize, showDecimal) {
+    ) : super(context, titleId, descriptionId, units, showDecimal) {
         floatSetting = setting
+        this.min = min
+        this.max = max
+        this.stepSize = stepSize
     }
 
     constructor(
@@ -38,11 +45,14 @@ open class FloatSliderSetting : SliderSetting {
         units: String?,
         stepSize: Float,
         showDecimal: Boolean
-    ) : super(name, description, min, max, units, stepSize, showDecimal) {
+    ) : super(name, description, units, showDecimal) {
         floatSetting = setting
+        this.min = min
+        this.max = max
+        this.stepSize = stepSize
     }
 
-    override val selectedValue: Float
+    open val selectedValue: Float
         get() = floatSetting.float
 
     open fun setSelectedValue(settings: Settings?, selection: Float) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.kt
@@ -36,8 +36,9 @@ open class FloatSliderSetting : SliderSetting {
         min: Float,
         max: Float,
         units: String?,
+        stepSize: Float,
         showDecimal: Boolean
-    ) : super(name, description, min, max, units, showDecimal) {
+    ) : super(name, description, min, max, units, stepSize, showDecimal) {
         floatSetting = setting
     }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/IntSliderSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/IntSliderSetting.kt
@@ -12,15 +12,16 @@ class IntSliderSetting(
     private val intSetting: AbstractIntSetting,
     titleId: Int,
     descriptionId: Int,
-    min: Int,
-    max: Int,
+    val min: Int,
+    val max: Int,
     units: String?,
-    stepSize: Int
-) : SliderSetting(context, titleId, descriptionId, min, max, units, stepSize, false) {
+    val stepSize: Int
+) : SliderSetting(context, titleId, descriptionId, units, false) {
+
     override val setting: AbstractSetting
         get() = intSetting
 
-    override val selectedValue: Int
+    val selectedValue: Int
         get() = intSetting.int
 
     fun setSelectedValue(settings: Settings?, selection: Int) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SliderSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SliderSetting.kt
@@ -7,49 +7,27 @@ import android.content.Context
 sealed class SliderSetting : SettingsItem {
     override val type: Int = TYPE_SLIDER
 
-    var min: Any
-        private set
-    var max: Any
-        private set
-    var units: String?
-        private set
-    var stepSize: Any = 0
-        private set
-    var showDecimal: Boolean = false
-        private set
+    val units: String?
+    val showDecimal: Boolean
 
     constructor(
         context: Context,
         nameId: Int,
         descriptionId: Int,
-        min: Any,
-        max: Any,
         units: String?,
-        stepSize: Any,
         showDecimal: Boolean
     ) : super(context, nameId, descriptionId) {
-        this.min = min
-        this.max = max
         this.units = units
-        this.stepSize = stepSize
         this.showDecimal = showDecimal
     }
 
     constructor(
         name: CharSequence,
         description: CharSequence?,
-        min: Any,
-        max: Any,
         units: String?,
-        stepSize: Any,
         showDecimal: Boolean
     ) : super(name, description) {
-        this.min = min
-        this.max = max
         this.units = units
-        this.stepSize = stepSize
         this.showDecimal = showDecimal
     }
-
-    abstract val selectedValue: Any
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SliderSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SliderSetting.kt
@@ -41,11 +41,13 @@ sealed class SliderSetting : SettingsItem {
         min: Any,
         max: Any,
         units: String?,
+        stepSize: Any,
         showDecimal: Boolean
     ) : super(name, description) {
         this.min = min
         this.max = max
         this.units = units
+        this.stepSize = stepSize
         this.showDecimal = showDecimal
     }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.kt
@@ -249,14 +249,14 @@ class SettingsAdapter(
         val slider = binding.slider
         when (item) {
             is FloatSliderSetting -> {
-                slider.valueFrom = item.min as Float
-                slider.valueTo = item.max as Float
-                slider.stepSize = item.stepSize as Float
+                slider.valueFrom = item.min
+                slider.valueTo = item.max
+                slider.stepSize = item.stepSize
             }
             is IntSliderSetting -> {
-                slider.valueFrom = (item.min as Int).toFloat()
-                slider.valueTo = (item.max as Int).toFloat()
-                slider.stepSize = (item.stepSize as Int).toFloat()
+                slider.valueFrom = item.min.toFloat()
+                slider.valueTo = item.max.toFloat()
+                slider.stepSize = item.stepSize.toFloat()
             }
         }
         slider.value = seekbarProgress

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -2356,6 +2356,7 @@ class SettingsFragmentPresenter(
                     ceil(setting.getDoubleMin()).toFloat(),
                     floor(setting.getDoubleMax()).toFloat(),
                     setting.getUiSuffix(),
+                    1.0f,
                     false
                 )
             )

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SliderViewHolder.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SliderViewHolder.kt
@@ -7,6 +7,7 @@ import android.text.TextUtils
 import android.view.View
 import org.dolphinemu.dolphinemu.R
 import org.dolphinemu.dolphinemu.databinding.ListItemSettingBinding
+import org.dolphinemu.dolphinemu.features.settings.model.view.FloatSliderSetting
 import org.dolphinemu.dolphinemu.features.settings.model.view.IntSliderSetting
 import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem
 import org.dolphinemu.dolphinemu.features.settings.model.view.SliderSetting
@@ -29,10 +30,9 @@ class SliderViewHolder(
         if (!TextUtils.isEmpty(item.description)) {
             binding.textSettingDescription.text = item.description
         } else {
-            val selectedValue: Float = if (item is IntSliderSetting) {
-                (setting.selectedValue as Int).toFloat()
-            } else {
-                setting.selectedValue as Float
+            val selectedValue: Float = when (item) {
+                is FloatSliderSetting -> item.selectedValue
+                is IntSliderSetting -> item.selectedValue.toFloat()
             }
 
             if (setting.showDecimal) {


### PR DESCRIPTION
By not setting a stepSize, stepSize was getting set to the default value of 0, which is an Int. This later caused a crash when trying to cast it to Float.