### PR TITLE
VideoCommon: Deinit Graphics Mod Manager explicitly

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -407,6 +407,7 @@ void VideoBackendBase::ShutdownShared()
 
   g_bounding_box.reset();
   g_perf_query.reset();
+  g_graphics_mod_manager.reset();
   g_texture_cache.reset();
   g_framebuffer_manager.reset();
   g_shader_cache.reset();


### PR DESCRIPTION
`g_graphics_mod_manager` wasn't shutdown in `VideoBackendBase::ShutdownShared` causing

```
libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
```
on macOS.

The cause of the error was `EventHook` in `GraphicsModManager` calling it's deconstructor, by which time the mutex in the static `Storage` was already destroyed. 