### PR TITLE
Tools: fix perf-disassemble.sh.

### DIFF
--- a/Tools/perf-disassemble.sh
+++ b/Tools/perf-disassemble.sh
@@ -31,6 +31,9 @@ do
         --stop-address=*)
             stop="${1##--stop-address=}"
             ;;
+        --no-show-raw-insn)
+            raw=
+            ;;
         --no-show-raw)
             raw=
             ;;


### PR DESCRIPTION
perf now passes the proper no-show-raw-insn option instead of no-show-raw.

Keep no-show-raw as a fallback for older kernels/perf-toolings.

See also: https://github.com/torvalds/linux/commit/c5baf9089246c1356705c9ba36d767ee8ce43dd2