### PR TITLE
Fix Aspect Ratio Swapping in Metroid Prime 2

### DIFF
--- a/Data/Sys/GameSettings/G2M.ini
+++ b/Data/Sys/GameSettings/G2M.ini
@@ -16,6 +16,11 @@ CPUThread = False
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+# Using a widescreen heuristic modification
+# fixes the game changing aspect ratios during gameplay.
+
+WidescreenHeuristicTransitionThreshold = 20
+
 # Because the minimap has a lot of unused triangles, 
 # CPU Cull can greatly speed up demanding areas of the game.
 


### PR DESCRIPTION
Tested this in the areas I know cause aspect ratio swapping.  Also verified the Widescreen codes still work properly even with this modification.