### PR TITLE
VideoCommon: Show average projection to viewport ratio for widescreen heursitic game ini values.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -86,6 +86,8 @@ void AdvancedWidget::CreateWidgets()
 
   m_enable_wireframe = new ConfigBool(tr("Enable Wireframe"), Config::GFX_ENABLE_WIREFRAME);
   m_show_statistics = new ConfigBool(tr("Show Statistics"), Config::GFX_OVERLAY_STATS);
+  m_show_proj_statistics =
+      new ConfigBool(tr("Show Projection Statistics"), Config::GFX_OVERLAY_PROJ_STATS);
   m_enable_format_overlay =
       new ConfigBool(tr("Texture Format Overlay"), Config::GFX_TEXFMT_OVERLAY_ENABLE);
   m_enable_api_validation =
@@ -94,7 +96,8 @@ void AdvancedWidget::CreateWidgets()
   debugging_layout->addWidget(m_enable_wireframe, 0, 0);
   debugging_layout->addWidget(m_show_statistics, 0, 1);
   debugging_layout->addWidget(m_enable_format_overlay, 1, 0);
-  debugging_layout->addWidget(m_enable_api_validation, 1, 1);
+  debugging_layout->addWidget(m_show_proj_statistics, 1, 1);
+  debugging_layout->addWidget(m_enable_api_validation, 2, 0);
 
   // Utility
   auto* utility_box = new QGroupBox(tr("Utility"));
@@ -299,6 +302,9 @@ void AdvancedWidget::AddDescriptions()
   static const char TR_SHOW_STATS_DESCRIPTION[] =
       QT_TR_NOOP("Shows various rendering statistics.<br><br><dolphin_emphasis>If unsure, "
                  "leave this unchecked.</dolphin_emphasis>");
+  static const char TR_SHOW_PROJ_STATS_DESCRIPTION[] =
+      QT_TR_NOOP("Shows various projection statistics.<br><br><dolphin_emphasis>If unsure, "
+                 "leave this unchecked.</dolphin_emphasis>");
   static const char TR_TEXTURE_FORMAT_DESCRIPTION[] =
       QT_TR_NOOP("Modifies textures to show the format they're encoded in.<br><br>May require "
                  "an emulation reset to apply.<br><br><dolphin_emphasis>If unsure, leave this "
@@ -436,6 +442,7 @@ void AdvancedWidget::AddDescriptions()
 
   m_enable_wireframe->SetDescription(tr(TR_WIREFRAME_DESCRIPTION));
   m_show_statistics->SetDescription(tr(TR_SHOW_STATS_DESCRIPTION));
+  m_show_proj_statistics->SetDescription(tr(TR_SHOW_PROJ_STATS_DESCRIPTION));
   m_enable_format_overlay->SetDescription(tr(TR_TEXTURE_FORMAT_DESCRIPTION));
   m_enable_api_validation->SetDescription(tr(TR_VALIDATION_LAYER_DESCRIPTION));
   m_perf_samp_window->SetDescription(tr(TR_PERF_SAMP_WINDOW_DESCRIPTION));

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -33,6 +33,7 @@ private:
   // Debugging
   ConfigBool* m_enable_wireframe;
   ConfigBool* m_show_statistics;
+  ConfigBool* m_show_proj_statistics;
   ConfigBool* m_enable_format_overlay;
   ConfigBool* m_enable_api_validation;
   ConfigBool* m_show_fps;

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -147,6 +147,9 @@ void Statistics::DisplayProj() const
   ImGui::Text("Projection 13: %f (%f)", gproj[13], g2proj[13]);
   ImGui::Text("Projection 14: %f (%f)", gproj[14], g2proj[14]);
   ImGui::Text("Projection 15: %f (%f)", gproj[15], g2proj[15]);
+  ImGui::NewLine();
+  ImGui::Text("Avg Projection Viewport Ratio Persp(3D): %f", avg_persp_proj_viewport_ratio);
+  ImGui::Text("Avg Projection Viewport Ratio Ortho(2D): %f", avg_ortho_proj_viewport_ratio);
 
   ImGui::End();
 }

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -120,7 +120,6 @@ void Statistics::Display() const
   ImGui::End();
 }
 
-// Is this really needed?
 void Statistics::DisplayProj() const
 {
   if (!ImGui::Begin("Projection Statistics", nullptr, ImGuiWindowFlags_NoNavInputs))

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -25,6 +25,10 @@ struct Statistics
   std::array<float, 16> gproj{};
   std::array<float, 16> g2proj{};
 
+  // For widescreen heuristic.
+  float avg_persp_proj_viewport_ratio = 0;
+  float avg_ortho_proj_viewport_ratio = 0;
+
   std::vector<BPFunctions::ScissorResult> scissors{};
   size_t current_scissor = 0;  // 0 => all, otherwise index + 1
   int scissor_scale = 10;

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -520,15 +520,21 @@ void VertexManagerBase::Flush()
     auto& counts =
         is_perspective ? m_flush_statistics.perspective : m_flush_statistics.orthographic;
 
+    const auto& projection = xfmem.projection.rawProjection;
     // TODO: Potentially the viewport size could be used as weight for the flush count average.
     // This way a small minimap would have less effect than a fullscreen projection.
+    const auto& viewport = xfmem.viewport;
 
-    if (IsAnamorphicProjection(xfmem.projection.rawProjection, xfmem.viewport, g_ActiveConfig))
+    // FYI: This average is based on flushes.
+    // It doesn't look at vertex counts like the heuristic does.
+    counts.average_ratio.Push(CalculateProjectionViewportRatio(projection, viewport));
+
+    if (IsAnamorphicProjection(projection, viewport, g_ActiveConfig))
     {
       ++counts.anamorphic_flush_count;
       counts.anamorphic_vertex_count += m_index_generator.GetIndexLen();
     }
-    else if (IsNormalProjection(xfmem.projection.rawProjection, xfmem.viewport, g_ActiveConfig))
+    else if (IsNormalProjection(projection, viewport, g_ActiveConfig))
     {
       ++counts.normal_flush_count;
       counts.normal_vertex_count += m_index_generator.GetIndexLen();

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -79,6 +79,8 @@ private:
       {
         return normal_vertex_count + anamorphic_vertex_count + other_vertex_count;
       }
+
+      MathUtil::RunningMean<float> average_ratio;
     };
 
     ProjectionCounts perspective;

--- a/Source/Core/VideoCommon/Widescreen.cpp
+++ b/Source/Core/VideoCommon/Widescreen.cpp
@@ -8,6 +8,7 @@
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/System.h"
 
+#include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexManagerBase.h"
 
 std::unique_ptr<WidescreenManager> g_widescreen;
@@ -116,6 +117,9 @@ void WidescreenManager::UpdateWidescreenHeuristic()
 
     const auto& persp = flush_statistics.perspective;
     const auto& ortho = flush_statistics.orthographic;
+
+    g_stats.avg_persp_proj_viewport_ratio = persp.average_ratio.Mean();
+    g_stats.avg_ortho_proj_viewport_ratio = ortho.average_ratio.Mean();
 
     const auto ortho_looks_anamorphic = looks_anamorphic(ortho);
     const auto persp_looks_normal = looks_normal(persp);


### PR DESCRIPTION
This is useful to find widescreen heuristic game ini values after PR #11419 and #12169.

![image](https://github.com/dolphin-emu/dolphin/assets/1768214/a67fe956-404a-4000-ac4e-f88e96314c74)

![image](https://github.com/dolphin-emu/dolphin/assets/1768214/f76e4d60-d284-43fe-bf68-fab80821c988)