### PR TITLE
VideoCommon: add cubemap to ShaderAsset and TextureAsset

### DIFF
--- a/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
@@ -49,6 +49,10 @@ bool ParseShaderProperties(const VideoCommon::CustomAssetLibrary::AssetID& asset
     {
       property.m_type = ShaderProperty::Type::Type_Sampler2D;
     }
+    else if (type == "samplercube")
+    {
+      property.m_type = ShaderProperty::Type::Type_SamplerCube;
+    }
     else if (type == "samplerarrayshared_main")
     {
       property.m_type = ShaderProperty::Type::Type_SamplerArrayShared_Main;

--- a/Source/Core/VideoCommon/Assets/ShaderAsset.h
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.h
@@ -26,7 +26,8 @@ struct ShaderProperty
     Type_SamplerArrayShared_Main,
     Type_SamplerArrayShared_Additional,
     Type_Sampler2D,
-    Type_Max = Type_Sampler2D
+    Type_SamplerCube,
+    Type_Max = Type_SamplerCube
   };
   Type m_type;
   std::string m_description;

--- a/Source/Core/VideoCommon/Assets/TextureAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/TextureAsset.cpp
@@ -136,6 +136,15 @@ bool TextureData::FromJson(const CustomAssetLibrary::AssetID& asset_id,
   if (type == "texture2d")
   {
     data->m_type = TextureData::Type::Type_Texture2D;
+
+    if (!ParseSampler(asset_id, json, &data->m_sampler))
+    {
+      return false;
+    }
+  }
+  else if (type == "texturecube")
+  {
+    data->m_type = TextureData::Type::Type_TextureCube;
   }
   else
   {
@@ -143,11 +152,6 @@ bool TextureData::FromJson(const CustomAssetLibrary::AssetID& asset_id,
                   "Asset '{}' failed to parse json, texture type '{}' "
                   "an invalid option",
                   asset_id, type);
-    return false;
-  }
-
-  if (!ParseSampler(asset_id, json, &data->m_sampler))
-  {
     return false;
   }
 

--- a/Source/Core/VideoCommon/Assets/TextureAsset.h
+++ b/Source/Core/VideoCommon/Assets/TextureAsset.h
@@ -28,7 +28,8 @@ struct TextureData
   {
     Type_Undefined,
     Type_Texture2D,
-    Type_Max = Type_Texture2D
+    Type_TextureCube,
+    Type_Max = Type_TextureCube
   };
   Type m_type;
   CustomTextureData m_data;


### PR DESCRIPTION
Exposes cubemap as a valid cubemap sampler and allows cubemap as a valid texture.  Getting a bit closer to cubemap being loadable (reproducing #11783 in the modern asset based system)