### PR TITLE
VideoCommon: use 'TextureData' for texture assets to support texture metadata

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomAssetLibrary.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLibrary.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 
 #include "Common/Logging/Log.h"
-#include "VideoCommon/Assets/CustomTextureData.h"
+#include "VideoCommon/Assets/TextureAsset.h"
 
 namespace VideoCommon
 {
@@ -26,16 +26,26 @@ std::size_t GetAssetSize(const CustomTextureData& data)
 }
 }  // namespace
 CustomAssetLibrary::LoadInfo CustomAssetLibrary::LoadGameTexture(const AssetID& asset_id,
-                                                                 CustomTextureData* data)
+                                                                 TextureData* data)
 {
   const auto load_info = LoadTexture(asset_id, data);
   if (load_info.m_bytes_loaded == 0)
     return {};
 
-  // Note: 'LoadTexture()' ensures we have a level loaded
-  for (std::size_t slice_index = 0; slice_index < data->m_slices.size(); slice_index++)
+  if (data->m_type != TextureData::Type::Type_Texture2D)
   {
-    auto& slice = data->m_slices[slice_index];
+    ERROR_LOG_FMT(
+        VIDEO,
+        "Custom asset '{}' is not a valid game texture, it is expected to be a 2d texture "
+        "but was a '{}'.",
+        asset_id, data->m_type);
+    return {};
+  }
+
+  // Note: 'LoadTexture()' ensures we have a level loaded
+  for (std::size_t slice_index = 0; slice_index < data->m_texture.m_slices.size(); slice_index++)
+  {
+    auto& slice = data->m_texture.m_slices[slice_index];
     const auto& first_mip = slice.m_levels[0];
 
     // Verify that each mip level is the correct size (divide by 2 each time).

--- a/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
@@ -10,9 +10,9 @@
 
 namespace VideoCommon
 {
-class CustomTextureData;
 struct MaterialData;
 struct PixelShaderData;
+struct TextureData;
 
 // This class provides functionality to load
 // specific data (like textures).  Where this data
@@ -32,14 +32,14 @@ public:
   };
 
   // Loads a texture, if there are no levels, bytes loaded will be empty
-  virtual LoadInfo LoadTexture(const AssetID& asset_id, CustomTextureData* data) = 0;
+  virtual LoadInfo LoadTexture(const AssetID& asset_id, TextureData* data) = 0;
 
   // Gets the last write time for a given asset id
   virtual TimeType GetLastAssetWriteTime(const AssetID& asset_id) const = 0;
 
   // Loads a texture as a game texture, providing additional checks like confirming
   // each mip level size is correct and that the format is consistent across the data
-  LoadInfo LoadGameTexture(const AssetID& asset_id, CustomTextureData* data);
+  LoadInfo LoadGameTexture(const AssetID& asset_id, TextureData* data);
 
   // Loads a pixel shader
   virtual LoadInfo LoadPixelShader(const AssetID& asset_id, PixelShaderData* data) = 0;

--- a/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
@@ -77,13 +77,6 @@ void CustomAssetLoader ::Shutdown()
   m_total_bytes_loaded = 0;
 }
 
-std::shared_ptr<RawTextureAsset>
-CustomAssetLoader::LoadTexture(const CustomAssetLibrary::AssetID& asset_id,
-                               std::shared_ptr<CustomAssetLibrary> library)
-{
-  return LoadOrCreateAsset<RawTextureAsset>(asset_id, m_textures, std::move(library));
-}
-
 std::shared_ptr<GameTextureAsset>
 CustomAssetLoader::LoadGameTexture(const CustomAssetLibrary::AssetID& asset_id,
                                    std::shared_ptr<CustomAssetLibrary> library)

--- a/Source/Core/VideoCommon/Assets/CustomAssetLoader.h
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLoader.h
@@ -38,9 +38,6 @@ public:
   // Loads happen asynchronously where the data will be set now or in the future
   // Callees are expected to query the underlying data with 'GetData()'
   // from the 'CustomLoadableAsset' class to determine if the data is ready for use
-  std::shared_ptr<RawTextureAsset> LoadTexture(const CustomAssetLibrary::AssetID& asset_id,
-                                               std::shared_ptr<CustomAssetLibrary> library);
-
   std::shared_ptr<GameTextureAsset> LoadGameTexture(const CustomAssetLibrary::AssetID& asset_id,
                                                     std::shared_ptr<CustomAssetLibrary> library);
 
@@ -80,7 +77,6 @@ private:
 
   static constexpr auto TIME_BETWEEN_ASSET_MONITOR_CHECKS = std::chrono::milliseconds{500};
 
-  std::map<CustomAssetLibrary::AssetID, std::weak_ptr<RawTextureAsset>> m_textures;
   std::map<CustomAssetLibrary::AssetID, std::weak_ptr<GameTextureAsset>> m_game_textures;
   std::map<CustomAssetLibrary::AssetID, std::weak_ptr<PixelShaderAsset>> m_pixel_shaders;
   std::map<CustomAssetLibrary::AssetID, std::weak_ptr<MaterialAsset>> m_materials;

--- a/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.h
+++ b/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.h
@@ -20,7 +20,7 @@ class DirectFilesystemAssetLibrary final : public CustomAssetLibrary
 public:
   using AssetMap = std::map<std::string, std::filesystem::path>;
 
-  LoadInfo LoadTexture(const AssetID& asset_id, CustomTextureData* data) override;
+  LoadInfo LoadTexture(const AssetID& asset_id, TextureData* data) override;
   LoadInfo LoadPixelShader(const AssetID& asset_id, PixelShaderData* data) override;
   LoadInfo LoadMaterial(const AssetID& asset_id, MaterialData* data) override;
 

--- a/Source/Core/VideoCommon/Assets/TextureAsset.h
+++ b/Source/Core/VideoCommon/Assets/TextureAsset.h
@@ -3,23 +3,16 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <picojson.h>
 
+#include "Common/EnumFormatter.h"
 #include "VideoCommon/Assets/CustomAsset.h"
 #include "VideoCommon/Assets/CustomTextureData.h"
 #include "VideoCommon/RenderState.h"
 
 namespace VideoCommon
 {
-class RawTextureAsset final : public CustomLoadableAsset<CustomTextureData>
-{
-public:
-  using CustomLoadableAsset::CustomLoadableAsset;
-
-private:
-  CustomAssetLibrary::LoadInfo LoadImpl(const CustomAssetLibrary::AssetID& asset_id) override;
-};
-
 struct TextureData
 {
   static bool FromJson(const CustomAssetLibrary::AssetID& asset_id, const picojson::object& json,
@@ -32,11 +25,11 @@ struct TextureData
     Type_Max = Type_TextureCube
   };
   Type m_type;
-  CustomTextureData m_data;
+  CustomTextureData m_texture;
   SamplerState m_sampler;
 };
 
-class GameTextureAsset final : public CustomLoadableAsset<CustomTextureData>
+class GameTextureAsset final : public CustomLoadableAsset<TextureData>
 {
 public:
   using CustomLoadableAsset::CustomLoadableAsset;
@@ -49,3 +42,10 @@ private:
   CustomAssetLibrary::LoadInfo LoadImpl(const CustomAssetLibrary::AssetID& asset_id) override;
 };
 }  // namespace VideoCommon
+
+template <>
+struct fmt::formatter<VideoCommon::TextureData::Type>
+    : EnumFormatter<VideoCommon::TextureData::Type::Type_Max>
+{
+  constexpr formatter() : EnumFormatter({"Undefined", "Texture2D", "TextureCube"}) {}
+};

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/CustomPipelineAction.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/CustomPipelineAction.cpp
@@ -423,7 +423,7 @@ void CustomPipelineAction::OnTextureCreate(GraphicsModActionData::TextureCreate*
       auto data = game_texture.m_asset->GetData();
       if (data)
       {
-        if (data->m_slices.empty() || data->m_slices[0].m_levels.empty())
+        if (data->m_texture.m_slices.empty() || data->m_texture.m_slices[0].m_levels.empty())
         {
           ERROR_LOG_FMT(
               VIDEO,
@@ -431,15 +431,16 @@ void CustomPipelineAction::OnTextureCreate(GraphicsModActionData::TextureCreate*
               create->texture_name, game_texture.m_asset->GetAssetId());
           m_valid = false;
         }
-        else if (create->texture_width != data->m_slices[0].m_levels[0].width ||
-                 create->texture_height != data->m_slices[0].m_levels[0].height)
+        else if (create->texture_width != data->m_texture.m_slices[0].m_levels[0].width ||
+                 create->texture_height != data->m_texture.m_slices[0].m_levels[0].height)
         {
           ERROR_LOG_FMT(VIDEO,
                         "Custom pipeline for texture '{}' has asset '{}' that does not match "
                         "the width/height of the texture loaded.  Texture {}x{} vs asset {}x{}",
                         create->texture_name, game_texture.m_asset->GetAssetId(),
                         create->texture_width, create->texture_height,
-                        data->m_slices[0].m_levels[0].width, data->m_slices[0].m_levels[0].height);
+                        data->m_texture.m_slices[0].m_levels[0].width,
+                        data->m_texture.m_slices[0].m_levels[0].height);
           m_valid = false;
         }
       }

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -130,8 +130,8 @@ void HiresTexture::Update()
         {
           // Since this is just a texture (single file) the mapper doesn't really matter
           // just provide a string
-          s_file_library->SetAssetIDMapData(
-              filename, std::map<std::string, std::filesystem::path>{{"", StringToPath(path)}});
+          s_file_library->SetAssetIDMapData(filename, std::map<std::string, std::filesystem::path>{
+                                                          {"texture", StringToPath(path)}});
 
           if (g_ActiveConfig.bCacheHiresTextures)
           {

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -346,11 +346,10 @@ private:
 
   void SetBackupConfig(const VideoConfig& config);
 
-  RcTcacheEntry
-  CreateTextureEntry(const TextureCreationInfo& creation_info, const TextureInfo& texture_info,
-                     int safety_color_sample_size,
-                     std::vector<std::shared_ptr<VideoCommon::CustomTextureData>> assets_data,
-                     bool custom_arbitrary_mipmaps, bool skip_texture_dump);
+  RcTcacheEntry CreateTextureEntry(const TextureCreationInfo& creation_info,
+                                   const TextureInfo& texture_info, int safety_color_sample_size,
+                                   std::vector<VideoCommon::CustomTextureData*> assets_data,
+                                   bool custom_arbitrary_mipmaps, bool skip_texture_dump);
 
   RcTcacheEntry GetXFBFromCache(u32 address, u32 width, u32 height, u32 stride);
 

--- a/docs/CustomPipelineGraphicsMod.md
+++ b/docs/CustomPipelineGraphicsMod.md
@@ -44,7 +44,7 @@ A full example is given below:
             "name": "normal_texture",
             "data":
             {
-                "": "normal_texture.png"
+                "texture": "normal_texture.png"
             }
         }
     ],


### PR DESCRIPTION
Previously we used the raw texture data ( `CustomTextureData` ) for texture assets.  There may be times where we want additional metadata for our assets, examples include:

* The type information, to [distinguish cube maps](https://github.com/dolphin-emu/dolphin/pull/11783)
* Custom sampler information to [change the sampler](https://github.com/dolphin-emu/dolphin/pull/11235) that Dolphin uses or create a new sampler altogether!
* Whether the texture uses arbitrary mipmaps

Now textures use `TextureData` which includes `CustomTextureData` but also allows for other metadata as well.  The names are confusing, I need to update `CustomTextureData` to something else..

While this is standalone, if #12140 is merged, this will need to be updated.

**Testing** - simply make sure custom texture packs don't break.  (I've tested custom pipeline graphics mod as well)