### PR TITLE
Add support for custom aspect ratios

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -21,6 +21,10 @@ const Info<int> GFX_ADAPTER{{System::GFX, "Hardware", "Adapter"}, 0};
 
 const Info<bool> GFX_WIDESCREEN_HACK{{System::GFX, "Settings", "wideScreenHack"}, false};
 const Info<AspectMode> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"}, AspectMode::Auto};
+const Info<int> GFX_CUSTOM_ASPECT_RATIO_WIDTH{{System::GFX, "Settings", "CustomAspectRatioWidth"},
+                                              1};
+const Info<int> GFX_CUSTOM_ASPECT_RATIO_HEIGHT{{System::GFX, "Settings", "CustomAspectRatioHeight"},
+                                               1};
 const Info<AspectMode> GFX_SUGGESTED_ASPECT_RATIO{{System::GFX, "Settings", "SuggestedAspectRatio"},
                                                   AspectMode::Auto};
 const Info<u32> GFX_WIDESCREEN_HEURISTIC_TRANSITION_THRESHOLD{

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -28,6 +28,8 @@ extern const Info<int> GFX_ADAPTER;
 
 extern const Info<bool> GFX_WIDESCREEN_HACK;
 extern const Info<AspectMode> GFX_ASPECT_RATIO;
+extern const Info<int> GFX_CUSTOM_ASPECT_RATIO_WIDTH;
+extern const Info<int> GFX_CUSTOM_ASPECT_RATIO_HEIGHT;
 extern const Info<AspectMode> GFX_SUGGESTED_ASPECT_RATIO;
 extern const Info<u32> GFX_WIDESCREEN_HEURISTIC_TRANSITION_THRESHOLD;
 extern const Info<float> GFX_WIDESCREEN_HEURISTIC_ASPECT_RATIO_SLOP;

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -477,7 +477,7 @@ float VideoInterfaceManager::GetAspectRatio() const
   // signal (which would be 4:3)
 
   // This function only deals with standard aspect ratios. For widescreen aspect ratios,
-  // multiply the result by 1.33333..
+  // multiply the result by 1.33333... (the ratio between 16:9 and 4:3)
 
   // 1. Get our active area in BT.601 samples (more or less pixels)
   int active_lines = m_vertical_timing_register.ACV;

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -388,9 +388,9 @@ public:
   u32 GetTicksPerHalfLine() const;
   u32 GetTicksPerField() const;
 
-  // Get the aspect ratio of VI's active area.
+  // Get the aspect ratio of VI's active area (rarely matching pure 4:3).
   // This function only deals with standard aspect ratios. For widescreen aspect ratios, multiply
-  // the result by 1.33333..
+  // the result by 1.33333... (the ratio between 16:9 and 4:3)
   float GetAspectRatio() const;
 
   // Create a fake VI mode for a fifolog

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -359,8 +359,9 @@ void AdvancedWidget::AddDescriptions()
                  "level 9 but finish in significantly less time.<br><br>"
                  "<dolphin_emphasis>If unsure, leave this at 6.</dolphin_emphasis>");
   static const char TR_CROPPING_DESCRIPTION[] = QT_TR_NOOP(
-      "Crops the picture from its native aspect ratio to 4:3 or "
-      "16:9.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+      "Crops the picture from its native aspect ratio (which rarely exactly matches 4:3 or 16:9),"
+      " to the specific user target aspect ratio (e.g. 4:3 or 16:9).<br><br>"
+      "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_PROGRESSIVE_SCAN_DESCRIPTION[] = QT_TR_NOOP(
       "Enables progressive scan if supported by the emulated software. Most games don't have "
       "any issue with this.<br><br><dolphin_emphasis>If unsure, leave this "

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -561,12 +561,11 @@ void EnhancementsWidget::AddDescriptions()
       "causes slowdowns or graphical issues.<br><br><dolphin_emphasis>If unsure, leave "
       "this unchecked.</dolphin_emphasis>");
   static const char TR_WIDESCREEN_HACK_DESCRIPTION[] = QT_TR_NOOP(
-      "Forces the game to output graphics for any aspect ratio. Use with \"Aspect Ratio\" set to "
-      "\"Force 16:9\" to force 4:3-only games to run at 16:9.<br><br>Rarely produces good "
-      "results and "
-      "often partially breaks graphics and game UIs. Unnecessary (and detrimental) if using any "
-      "AR/Gecko-code widescreen patches.<br><br><dolphin_emphasis>If unsure, leave "
-      "this unchecked.</dolphin_emphasis>");
+      "Forces the game to output graphics at any aspect ratio by expanding the view frustum "
+      "without stretching the image.<br>This is a hack, and its results will vary widely game "
+      "to game (it often causes the UI to stretch).<br>"
+      "Game-specific AR/Gecko-code aspect ratio patches are preferable over this if available."
+      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_REMOVE_FOG_DESCRIPTION[] =
       QT_TR_NOOP("Makes distant objects more visible by removing fog, thus increasing the overall "
                  "detail.<br><br>Disabling fog will break some games which rely on proper fog "

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -9,10 +9,12 @@
 
 class ConfigBool;
 class ConfigChoice;
+class ConfigInteger;
 class ConfigRadioInt;
 class GraphicsWindow;
 class QCheckBox;
 class QComboBox;
+class QLabel;
 class QRadioButton;
 class QGridLayout;
 class ToolTipComboBox;
@@ -41,6 +43,9 @@ private:
   ToolTipComboBox* m_backend_combo;
   ToolTipComboBox* m_adapter_combo;
   ConfigChoice* m_aspect_combo;
+  QLabel* m_custom_aspect_label;
+  ConfigInteger* m_custom_aspect_width;
+  ConfigInteger* m_custom_aspect_height;
   ConfigBool* m_enable_vsync;
   ConfigBool* m_enable_fullscreen;
 

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -402,11 +402,14 @@ void HotkeyScheduler::Run()
         case AspectMode::Stretch:
           OSD::AddMessage("Stretch");
           break;
-        case AspectMode::Analog:
+        case AspectMode::ForceStandard:
           OSD::AddMessage("Force 4:3");
           break;
-        case AspectMode::AnalogWide:
+        case AspectMode::ForceWide:
           OSD::AddMessage("Force 16:9");
+          break;
+        case AspectMode::Custom:
+          OSD::AddMessage("Custom");
           break;
         case AspectMode::Auto:
         default:

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -396,7 +396,7 @@ u32 Presenter::AutoIntegralScale() const
   return std::max((width - 1) / EFB_WIDTH + 1, (height - 1) / EFB_HEIGHT + 1);
 }
 
-void Presenter::SetWindowSize(int width, int height)
+void Presenter::SetSuggestedWindowSize(int width, int height)
 {
   // While trying to guess the best window resolution, we can't allow it to use the
   // "AspectMode::Stretch" setting because that would self influence the output result,
@@ -652,7 +652,7 @@ void Presenter::Present()
 
       // Update the window size based on the frame that was just rendered.
       // Due to depending on guest state, we need to call this every frame.
-      SetWindowSize(m_xfb_rect.GetWidth(), m_xfb_rect.GetHeight());
+      SetSuggestedWindowSize(m_xfb_rect.GetWidth(), m_xfb_rect.GetHeight());
     }
     return;
   }
@@ -694,7 +694,7 @@ void Presenter::Present()
   {
     // Update the window size based on the frame that was just rendered.
     // Due to depending on guest state, we need to call this every frame.
-    SetWindowSize(m_xfb_rect.GetWidth(), m_xfb_rect.GetHeight());
+    SetSuggestedWindowSize(m_xfb_rect.GetWidth(), m_xfb_rect.GetHeight());
   }
 
   if (m_onscreen_ui)

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -4,6 +4,7 @@
 #include "VideoCommon/Present.h"
 
 #include "Common/ChunkFile.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/HW/VideoInterface.h"
 #include "Core/Host.h"
 #include "Core/System.h"
@@ -417,7 +418,9 @@ u32 Presenter::AutoIntegralScale() const
       source_width > 0 ? ((target_width + (source_width - 1)) / source_width) : 1;
   const u32 height_scale =
       source_height > 0 ? ((target_height + (source_height - 1)) / source_height) : 1;
-  return std::max(width_scale, height_scale);
+  // Limit to the max to avoid creating textures larger than their max supported resolution.
+  return std::min(std::max(width_scale, height_scale),
+                  static_cast<u32>(Config::Get(Config::GFX_MAX_EFB_SCALE)));
 }
 
 void Presenter::SetSuggestedWindowSize(int width, int height)

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -28,9 +28,10 @@ static constexpr int VIDEO_ENCODER_LCM = 4;
 
 namespace VideoCommon
 {
-static float AspectToWidescreen(float aspect)
+// Stretches the native/internal analog resolution aspect ratio from ~4:3 to ~16:9
+static float SourceAspectRatioToWidescreen(float source_aspect)
 {
-  return aspect * ((16.0f / 9.0f) / (4.0f / 3.0f));
+  return source_aspect * ((16.0f / 9.0f) / (4.0f / 3.0f));
 }
 
 static std::tuple<int, int> FindClosestIntegerResolution(float width, float height,
@@ -292,15 +293,22 @@ float Presenter::CalculateDrawAspectRatio(bool allow_stretch) const
     return (static_cast<float>(m_backbuffer_width) / static_cast<float>(m_backbuffer_height));
 
   auto& vi = Core::System::GetInstance().GetVideoInterface();
-  const float aspect_ratio = vi.GetAspectRatio();
+  const float source_aspect_ratio = vi.GetAspectRatio();
 
-  if (aspect_mode == AspectMode::AnalogWide ||
+  // This will scale up the source ~4:3 resolution to its equivalent ~16:9 resolution
+  if (aspect_mode == AspectMode::ForceWide ||
       (aspect_mode == AspectMode::Auto && g_widescreen->IsGameWidescreen()))
   {
-    return AspectToWidescreen(aspect_ratio);
+    return SourceAspectRatioToWidescreen(source_aspect_ratio);
+  }
+  // For the "custom" mode, we force the exact target aspect ratio, without
+  // acknowleding the difference between the source aspect ratio and 4:3.
+  else if (aspect_mode == AspectMode::Custom)
+  {
+    return g_ActiveConfig.GetCustomAspectRatio();
   }
 
-  return aspect_ratio;
+  return source_aspect_ratio;
 }
 
 void Presenter::AdjustRectanglesToFitBounds(MathUtil::Rectangle<int>* target_rect,
@@ -414,7 +422,7 @@ void Presenter::SetSuggestedWindowSize(int width, int height)
   Host_RequestRenderWindowSize(out_width, out_height);
 }
 
-// Crop to exactly 16:9 or 4:3 if enabled and not AspectMode::Stretch.
+// Crop to exact forced aspect ratios if enabled and not AspectMode::Stretch.
 std::tuple<float, float> Presenter::ApplyStandardAspectCrop(float width, float height,
                                                             bool allow_stretch) const
 {
@@ -426,13 +434,28 @@ std::tuple<float, float> Presenter::ApplyStandardAspectCrop(float width, float h
   if (!g_ActiveConfig.bCrop || aspect_mode == AspectMode::Stretch)
     return {width, height};
 
-  // Force 4:3 or 16:9 by cropping the image.
+  // Force aspect ratios by cropping the image.
   const float current_aspect = width / height;
-  const float expected_aspect =
-      (aspect_mode == AspectMode::AnalogWide ||
-       (aspect_mode == AspectMode::Auto && g_widescreen->IsGameWidescreen())) ?
-          (16.0f / 9.0f) :
-          (4.0f / 3.0f);
+  float expected_aspect;
+  switch (aspect_mode)
+  {
+  default:
+  case AspectMode::Auto:
+    expected_aspect = g_widescreen->IsGameWidescreen() ? (16.0f / 9.0f) : (4.0f / 3.0f);
+    break;
+  case AspectMode::ForceWide:
+    expected_aspect = 16.0f / 9.0f;
+    break;
+  case AspectMode::ForceStandard:
+    expected_aspect = 4.0f / 3.0f;
+    break;
+  // There should be no cropping needed in the custom case,
+  // as output should always exactly match the target aspect ratio
+  case AspectMode::Custom:
+    expected_aspect = g_ActiveConfig.GetCustomAspectRatio();
+    break;
+  }
+
   if (current_aspect > expected_aspect)
   {
     // keep height, crop width
@@ -457,11 +480,13 @@ void Presenter::UpdateDrawRectangle()
   if (g_ActiveConfig.bWidescreenHack)
   {
     auto& vi = Core::System::GetInstance().GetVideoInterface();
-    float source_aspect = vi.GetAspectRatio();
+    float source_aspect_ratio = vi.GetAspectRatio();
+    // If the game is meant to be in widescreen (or forced to),
+    // scale the source aspect ratio to it.
     if (g_widescreen->IsGameWidescreen())
-      source_aspect = AspectToWidescreen(source_aspect);
+      source_aspect_ratio = SourceAspectRatioToWidescreen(source_aspect_ratio);
 
-    const float adjust = source_aspect / draw_aspect_ratio;
+    const float adjust = source_aspect_ratio / draw_aspect_ratio;
     if (adjust > 1)
     {
       // Vert+

--- a/Source/Core/VideoCommon/Present.h
+++ b/Source/Core/VideoCommon/Present.h
@@ -46,7 +46,7 @@ public:
 
   void ConfigChanged(u32 changed_bits);
 
-  // Display resolution
+  // Window resolution (display resolution if fullscreen)
   int GetBackbufferWidth() const { return m_backbuffer_width; }
   int GetBackbufferHeight() const { return m_backbuffer_height; }
   float GetBackbufferScale() const { return m_backbuffer_scale; }
@@ -58,6 +58,7 @@ public:
 
   void UpdateDrawRectangle();
 
+  // Returns the target aspect ratio the XFB output should be drawn with.
   float CalculateDrawAspectRatio(bool allow_stretch = true) const;
 
   // Crops the target rectangle to the framebuffer dimensions, reducing the size of the source
@@ -126,6 +127,9 @@ private:
   Common::Flag m_surface_changed;
   Common::Flag m_surface_resized;
 
+  // The presentation rectangle.
+  // Width and height correspond to the final output resolution.
+  // Offsets imply black borders (if the window aspect ratio doesn't match the game's one).
   MathUtil::Rectangle<int> m_target_rectangle = {};
 
   RcTcacheEntry m_xfb_entry;

--- a/Source/Core/VideoCommon/Present.h
+++ b/Source/Core/VideoCommon/Present.h
@@ -55,6 +55,7 @@ public:
   void SetSuggestedWindowSize(int width, int height);
   void SetBackbuffer(int backbuffer_width, int backbuffer_height);
   void SetBackbuffer(SurfaceInfo info);
+  void OnBackbufferSet(bool size_changed, bool is_first_set);
 
   void UpdateDrawRectangle();
 
@@ -104,6 +105,8 @@ private:
 
   void ProcessFrameDumping(u64 ticks) const;
 
+  void OnBackBufferSizeChanged();
+
   std::tuple<int, int> CalculateOutputDimensions(int width, int height,
                                                  bool allow_stretch = true) const;
   std::tuple<float, float> ApplyStandardAspectCrop(float width, float height,
@@ -131,6 +134,8 @@ private:
   // Width and height correspond to the final output resolution.
   // Offsets imply black borders (if the window aspect ratio doesn't match the game's one).
   MathUtil::Rectangle<int> m_target_rectangle = {};
+
+  u32 m_auto_resolution_scale = 1;
 
   RcTcacheEntry m_xfb_entry;
   MathUtil::Rectangle<int> m_xfb_rect;

--- a/Source/Core/VideoCommon/Present.h
+++ b/Source/Core/VideoCommon/Present.h
@@ -52,7 +52,7 @@ public:
   float GetBackbufferScale() const { return m_backbuffer_scale; }
   u32 AutoIntegralScale() const;
   AbstractTextureFormat GetBackbufferFormat() const { return m_backbuffer_format; }
-  void SetWindowSize(int width, int height);
+  void SetSuggestedWindowSize(int width, int height);
   void SetBackbuffer(int backbuffer_width, int backbuffer_height);
   void SetBackbuffer(SurfaceInfo info);
 
@@ -138,7 +138,7 @@ private:
   // Tracking of XFB textures so we don't render duplicate frames.
   u64 m_last_xfb_id = std::numeric_limits<u64>::max();
 
-  // These will be set on the first call to SetWindowSize.
+  // These will be set on the first call to SetSuggestedWindowSize.
   int m_last_window_request_width = 0;
   int m_last_window_request_height = 0;
 

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -91,8 +91,9 @@ static bool IsAnamorphicProjection(const Projection::Raw& projection, const View
                                    const VideoConfig& config)
 {
   // If ratio between our projection and viewport aspect ratios is similar to 16:9 / 4:3
-  // we have an anamorphic projection. This value can be overridden
-  // by a GameINI.
+  // we have an anamorphic projection. This value can be overridden by a GameINI.
+  // Game cheats that change the aspect ratio to natively unsupported ones
+  // won't be automatically recognized here.
 
   return std::abs(CalculateProjectionViewportRatio(projection, viewport) -
                   config.widescreen_heuristic_widescreen_ratio) <

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -85,6 +85,8 @@ void VideoConfig::Refresh()
 
   bWidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
   aspect_mode = Config::Get(Config::GFX_ASPECT_RATIO);
+  custom_aspect_width = Config::Get(Config::GFX_CUSTOM_ASPECT_RATIO_WIDTH);
+  custom_aspect_height = Config::Get(Config::GFX_CUSTOM_ASPECT_RATIO_HEIGHT);
   suggested_aspect_mode = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
   widescreen_heuristic_transition_threshold =
       Config::Get(Config::GFX_WIDESCREEN_HEURISTIC_TRANSITION_THRESHOLD);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -289,6 +289,7 @@ void CheckForConfigChanges()
   const u32 old_game_mod_changes =
       g_ActiveConfig.graphics_mod_config ? g_ActiveConfig.graphics_mod_config->GetChangeCount() : 0;
   const bool old_graphics_mods_enabled = g_ActiveConfig.bGraphicMods;
+  const AspectMode old_aspect_mode = g_ActiveConfig.aspect_mode;
   const AspectMode old_suggested_aspect_mode = g_ActiveConfig.suggested_aspect_mode;
   const bool old_widescreen_hack = g_ActiveConfig.bWidescreenHack;
   const auto old_post_processing_shader = g_ActiveConfig.sPostProcessingShader;
@@ -338,6 +339,8 @@ void CheckForConfigChanges()
     changed_bits |= CONFIG_CHANGE_BIT_BBOX;
   if (old_efb_scale != g_ActiveConfig.iEFBScale)
     changed_bits |= CONFIG_CHANGE_BIT_TARGET_SIZE;
+  if (old_aspect_mode != g_ActiveConfig.aspect_mode)
+    changed_bits |= CONFIG_CHANGE_BIT_ASPECT_RATIO;
   if (old_suggested_aspect_mode != g_ActiveConfig.suggested_aspect_mode)
     changed_bits |= CONFIG_CHANGE_BIT_ASPECT_RATIO;
   if (old_widescreen_hack != g_ActiveConfig.bWidescreenHack)

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -21,10 +21,11 @@ constexpr int EFB_SCALE_AUTO_INTEGRAL = 0;
 
 enum class AspectMode : int
 {
-  Auto,
-  AnalogWide,
-  Analog,
+  Auto,           // 4:3 or 16:9
+  ForceWide,      // 16:9
+  ForceStandard,  // 4:3
   Stretch,
+  Custom,
 };
 
 enum class StereoMode : int
@@ -105,6 +106,8 @@ struct VideoConfig final
   bool bVSyncActive = false;
   bool bWidescreenHack = false;
   AspectMode aspect_mode{};
+  int custom_aspect_width = 1;
+  int custom_aspect_height = 1;
   AspectMode suggested_aspect_mode{};
   u32 widescreen_heuristic_transition_threshold = 0;
   float widescreen_heuristic_aspect_ratio_slop = 0.f;
@@ -365,6 +368,8 @@ struct VideoConfig final
   bool UsingUberShaders() const;
   u32 GetShaderCompilerThreads() const;
   u32 GetShaderPrecompilerThreads() const;
+
+  float GetCustomAspectRatio() const { return (float)custom_aspect_width / custom_aspect_height; }
 };
 
 extern VideoConfig g_Config;

--- a/Source/Core/VideoCommon/Widescreen.cpp
+++ b/Source/Core/VideoCommon/Widescreen.cpp
@@ -53,6 +53,7 @@ void WidescreenManager::Update()
 }
 
 // Heuristic to detect if a GameCube game is in 16:9 anamorphic widescreen mode.
+// Cheats that change the game aspect ratio to natively unsupported ones won't be recognized here.
 void WidescreenManager::UpdateWidescreenHeuristic()
 {
   const auto flush_statistics = g_vertex_manager->ResetFlushAspectRatioCount();

--- a/Source/Core/VideoCommon/Widescreen.cpp
+++ b/Source/Core/VideoCommon/Widescreen.cpp
@@ -36,18 +36,18 @@ void WidescreenManager::Update()
     m_is_game_widescreen = Config::Get(Config::SYSCONF_WIDESCREEN);
 
   // suggested_aspect_mode overrides SYSCONF_WIDESCREEN
-  if (g_ActiveConfig.suggested_aspect_mode == AspectMode::Analog)
+  if (g_ActiveConfig.suggested_aspect_mode == AspectMode::ForceStandard)
     m_is_game_widescreen = false;
-  else if (g_ActiveConfig.suggested_aspect_mode == AspectMode::AnalogWide)
+  else if (g_ActiveConfig.suggested_aspect_mode == AspectMode::ForceWide)
     m_is_game_widescreen = true;
 
   // If widescreen hack is disabled override game's AR if UI is set to 4:3 or 16:9.
   if (!g_ActiveConfig.bWidescreenHack)
   {
     const auto aspect_mode = g_ActiveConfig.aspect_mode;
-    if (aspect_mode == AspectMode::Analog)
+    if (aspect_mode == AspectMode::ForceStandard)
       m_is_game_widescreen = false;
-    else if (aspect_mode == AspectMode::AnalogWide)
+    else if (aspect_mode == AspectMode::ForceWide)
       m_is_game_widescreen = true;
   }
 }
@@ -64,9 +64,10 @@ void WidescreenManager::UpdateWidescreenHeuristic()
 
   Update();
 
-  // If widescreen hack isn't active and aspect_mode (UI) is 4:3 or 16:9 don't use heuristic.
-  if (!g_ActiveConfig.bWidescreenHack && (g_ActiveConfig.aspect_mode == AspectMode::Analog ||
-                                          g_ActiveConfig.aspect_mode == AspectMode::AnalogWide))
+  // If widescreen hack isn't active and aspect_mode (user setting)
+  // is set to a forced aspect ratio, don't use heuristic.
+  if (!g_ActiveConfig.bWidescreenHack && (g_ActiveConfig.aspect_mode == AspectMode::ForceStandard ||
+                                          g_ActiveConfig.aspect_mode == AspectMode::ForceWide))
     return;
 
   // Modify the threshold based on which aspect ratio we're already using:

--- a/Source/Core/VideoCommon/Widescreen.h
+++ b/Source/Core/VideoCommon/Widescreen.h
@@ -11,11 +11,14 @@
 class PointerWrap;
 
 // This class is responsible for tracking the game's aspect ratio.
+// This exclusively supports 4:3 or 16:9 detection by default.
 class WidescreenManager
 {
 public:
   WidescreenManager();
 
+  // Just a helper to tell whether the game seems to be running in widescreen,
+  // or if it's being forced to.
   bool IsGameWidescreen() const { return m_is_game_widescreen; }
 
   void DoState(PointerWrap& p);


### PR DESCRIPTION
This PR adds support for a user specified aspect ratio.

The main purpose of this is to allow users to play at specific game aspect ratios that don't match their screen.
For example, to play Super Mario Galaxy with the 21:9 cheat/mod, unless I had a 21:9 monitor, under normal circumstances I'd have to use the "Stretch" aspect ratio mode and size the window myself, by making a rough guess, withought having the possiblity of making the window fullscreen (black borders).
With this change it's now be possible to play (e.g.) games at 21:9 on both a 16:9 screen or a 32:9 one.

Another advantage this PR gives is that users can use the 1:1 aspect ratio, or the XFB native output aspect ratio (e.g. 640x528, pixel perfect nearest neighbor with no stretching). It's my understanding that this feature has been requested for a long time.

This PR is NOT related with the widescreen hack, though it works well with it, just like the "Stretch" aspect ratio mode.
All of the code surrounding the aspect ratio managment have been polished a little bit (mostly commenting and naming wise).

As a plus I threw some fixes for the "Auto" Internal resolution mode, which wasn't always calculated as good as it could have after my last PR (https://github.com/dolphin-emu/dolphin/pull/12000), and also it wasn't updated when resizing the window, making it unreliable.

![Dolphin_IOg5SkIJ8r](https://github.com/dolphin-emu/dolphin/assets/7011366/891dd179-da2c-4e71-b45a-40cfdae2d91c)
![Dolphin_GTh1Ieie5L](https://github.com/dolphin-emu/dolphin/assets/7011366/b6494e38-e4f4-4799-aac0-a533468c9d73)

I suggest to review changes commit by commit, as they are mostly separate.