### PR TITLE
Add support for resolutions multipliers up to 12x (~8k)

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -76,7 +76,7 @@ const Info<bool> GFX_FAST_DEPTH_CALC{{System::GFX, "Settings", "FastDepthCalc"},
 const Info<u32> GFX_MSAA{{System::GFX, "Settings", "MSAA"}, 1};
 const Info<bool> GFX_SSAA{{System::GFX, "Settings", "SSAA"}, false};
 const Info<int> GFX_EFB_SCALE{{System::GFX, "Settings", "InternalResolution"}, 1};
-const Info<int> GFX_MAX_EFB_SCALE{{System::GFX, "Settings", "MaxInternalResolution"}, 8};
+const Info<int> GFX_MAX_EFB_SCALE{{System::GFX, "Settings", "MaxInternalResolution"}, 12};
 const Info<bool> GFX_TEXFMT_OVERLAY_ENABLE{{System::GFX, "Settings", "TexFmtOverlayEnable"}, false};
 const Info<bool> GFX_TEXFMT_OVERLAY_CENTER{{System::GFX, "Settings", "TexFmtOverlayCenter"}, false};
 const Info<bool> GFX_ENABLE_WIREFRAME{{System::GFX, "Settings", "WireFrame"}, false};


### PR DESCRIPTION
Simple change to allow resolution multipliers up to 12x.
Qt UI also updated.
![Dolphin_T5KCvhD25h](https://github.com/dolphin-emu/dolphin/assets/7011366/3e6e2142-8ade-4cdf-a212-9624ac6c4081)
This has been tested on OpenGL, DX11, DX12 and Vulkan.

This especially makes more sense now that we have proper downsampling of the image (area resampling) (https://github.com/dolphin-emu/dolphin/pull/11999). When playing at 12x, the temporal stability is incredibly high, and texture show more detail if we had high resolution texture packs. The performance impact is minimal.

`GFX_MAX_EFB_SCALE` was not even respected by the "Auto Internal Resolution Scale" setting, so on 8k monitors resolution could already go beyond 8x (to 12x or 13x).
I've made the change to respect it in this PR `https://github.com/dolphin-emu/dolphin/pull/12170` so we can be sure we don't try to allocate textures bigger than the maximum supported (and/or tested) texture size.