### PR TITLE
Common/MemArena: Set MAP_NORESERVE in LazyMemoryRegion on Linux.

### DIFF
--- a/Source/Core/Common/MemArenaUnix.cpp
+++ b/Source/Core/Common/MemArenaUnix.cpp
@@ -117,6 +117,12 @@ LazyMemoryRegion::~LazyMemoryRegion()
   Release();
 }
 
+#if !defined MAP_NORESERVE && (defined __FreeBSD__ || defined __OpenBSD__ || defined __NetBSD__)
+// BSD does not implement MAP_NORESERVE, so define the flag to nothing.
+// See https://reviews.freebsd.org/rS273250
+#define MAP_NORESERVE 0
+#endif
+
 void* LazyMemoryRegion::Create(size_t size)
 {
   ASSERT(!m_memory);
@@ -124,7 +130,8 @@ void* LazyMemoryRegion::Create(size_t size)
   if (size == 0)
     return nullptr;
 
-  void* memory = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  void* memory =
+      mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
   if (memory == MAP_FAILED)
   {
     NOTICE_LOG_FMT(MEMMAP, "Memory allocation of {} bytes failed.", size);
@@ -142,7 +149,7 @@ void LazyMemoryRegion::Clear()
   ASSERT(m_memory);
 
   void* new_memory = mmap(m_memory, m_size, PROT_READ | PROT_WRITE,
-                          MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+                          MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED, -1, 0);
   ASSERT(new_memory == m_memory);
 }
 


### PR DESCRIPTION
This came up during the discussion that led to the #12173 fixes.

In short: When `/proc/sys/vm/overcommit_memory` is 0 (which appears to be the default in the Linux kernel), Linux refuses `mmap` requests of private anonymous memory that it knows cannot actually be fulfilled by the current amount of free RAM and swap. This causes the fast block lookup optimization to fail on low-memory (<= 4 GB) devices. This behavior makes sense (more or less) if you assume that all the allocated memory will actually be written to, but with our LazyMemoryRegion here, we assume that only a tiny amount will actually be touched before the memory will be reset or free'd. So the suggestion came up to just set `MAP_NORESERVE` -- which supresses the check and allows the allocation anyway.

I think this is reasonable and basically matches what Windows and Android do, so might as well. (For reference, on Android, the default of `/proc/sys/vm/overcommit_memory` is 1, so it never checks for anything and just allows the request to go through. We could set `MAP_NORESERVE` there too but it wouldn't really change anything unless someone messed with that setting.)