### PR TITLE
Add style chooser in settings, refactor user style code

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -247,7 +247,7 @@ int main(int argc, char* argv[])
 
     Settings::Instance().InitDefaultPalette();
     Settings::Instance().UpdateSystemDark();
-    Settings::Instance().SetCurrentUserStyle(Settings::Instance().GetCurrentUserStyle());
+    Settings::Instance().UpdateStyle();
 
     MainWindow win{std::move(boot), static_cast<const char*>(options.get("movie"))};
     win.Show();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -241,7 +241,7 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
           [](Qt::ColorScheme colorScheme) {
-            Settings::Instance().SetCurrentUserStyle(Settings::Instance().GetCurrentUserStyle());
+            Settings::Instance().UpdateStyle();
           });
 #endif
 
@@ -1736,7 +1736,7 @@ bool MainWindow::nativeEvent(const QByteArray& eventType, void* message, qintptr
     settings.UpdateSystemDark();
     if (settings.IsSystemDark() != was_dark_before)
     {
-      settings.SetCurrentUserStyle(settings.GetCurrentUserStyle());
+      settings.UpdateStyle();
 
       // force the colors in the Skylander window to update
       if (m_skylander_window)

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -240,9 +240,7 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
-          [](Qt::ColorScheme colorScheme) {
-            Settings::Instance().UpdateStyle();
-          });
+          [](Qt::ColorScheme colorScheme) { Settings::Instance().UpdateStyle(); });
 #endif
 
   connect(m_cheats_manager, &CheatsManager::OpenGeneralSettings, this,

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -201,10 +201,11 @@ void Settings::UpdateStyle()
     qApp->setStyleSheet(QStringLiteral(""));
   };
 
+#ifdef Q_OS_WIN
   auto LoadDarkStyle = [] {
-#ifdef _WIN32
     QFile file(QStringLiteral(":/dolphin_dark_win/dark.qss"));
-    if (file.open(QFile::ReadOnly)) {
+    if (file.open(QFile::ReadOnly))
+    {
       QString stylesheet_contents;
       stylesheet_contents = QString::fromUtf8(file.readAll().data());
 
@@ -225,21 +226,27 @@ void Settings::UpdateStyle()
       qApp->setPalette(palette);
       qApp->setStyleSheet(stylesheet_contents);
     }
-#else
-    LoadLightStyle();
-    // Something else should be done for other platforms.
-#endif
   };
-
+#elif Q_OS_MAC
+  // Something else should be done on macOS
+  auto LoadDarkStyle = [&LoadLightStyle] { LoadLightStyle(); };
+#else
+  // Don't try for Linux or BSD because on those platforms, dark theme is defined by a
+  // user-chosen style
+  auto LoadDarkStyle = [&LoadLightStyle] { LoadLightStyle(); };
+#endif
   auto LoadSystemStyle = [this, &LoadLightStyle, &LoadDarkStyle] {
-    if(IsSystemDark()) LoadDarkStyle();
-    else LoadLightStyle();
+    if (IsSystemDark())
+      LoadDarkStyle();
+    else
+      LoadLightStyle();
   };
 
   auto LoadUserStyle = [this, &LoadSystemStyle] {
     // If we haven't found one, we continue with an empty (default) style
     QString stylesheet_name = GetUserStyle();
-    if (stylesheet_name.isEmpty()) {
+    if (stylesheet_name.isEmpty())
+    {
       LoadSystemStyle();
       return;
     }
@@ -251,8 +258,10 @@ void Settings::UpdateStyle()
     if (stylesheet.open(QFile::ReadOnly))
       stylesheet_contents = QString::fromUtf8(stylesheet.readAll().data());
 
-    // We also continue with the default style if it's empty or unreadable (can't check for invalid unfortunately)
-    if(stylesheet_contents.isEmpty()) {
+    // We also continue with the default style if it's empty or unreadable (can't check for invalid
+    // unfortunately)
+    if (stylesheet_contents.isEmpty())
+    {
       LoadSystemStyle();
       return;
     }
@@ -282,7 +291,8 @@ void Settings::UpdateStyle()
     GetQSettings().setValue(QStringLiteral("userstyle/name"), stylesheet_name);
   };
 
-  switch(GetStyleType()) {
+  switch (GetStyleType())
+  {
   case StyleType::System:
     [[fallthrough]];
   default:

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -53,15 +53,27 @@ public:
   // UI
   void SetThemeName(const QString& theme_name);
   void InitDefaultPalette();
-  void UpdateSystemDark();
-  void SetSystemDark(bool dark);
-  bool IsSystemDark();
-  bool IsThemeDark();
-  void SetCurrentUserStyle(const QString& stylesheet_name);
-  QString GetCurrentUserStyle() const;
 
-  void SetUserStylesEnabled(bool enabled);
-  bool AreUserStylesEnabled() const;
+  void UpdateSystemDark();
+  bool IsSystemDark();
+  void SetSystemDark(bool dark);
+  bool IsThemeDark();
+
+  enum StyleType : uint8_t
+  {  // Move somewhere more appropriate? Dunno
+    System = 0,
+    Light,
+    Dark,
+    User
+  };
+
+  StyleType GetStyleType();
+  void SetStyleType(StyleType type);
+
+  QString GetUserStyle() const;
+  void SetUserStyle(const QString& name);
+
+  void UpdateStyle();
 
   void GetToolTipStyle(QColor& window_color, QColor& text_color, QColor& emphasis_text_color,
                        QColor& border_color, const QPalette& palette,

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -260,7 +260,8 @@ void InterfacePane::LoadConfig()
   if (index > 0)
     SignalBlocking(m_combobox_userstyle)->setCurrentIndex(index);
 
-  SignalBlocking(m_combobox_style)->setCurrentIndex(static_cast<int>(Settings::Instance().GetStyleType()));
+  SignalBlocking(m_combobox_style)
+      ->setCurrentIndex(static_cast<int>(Settings::Instance().GetStyleType()));
   SignalBlocking(m_combobox_userstyle)->setCurrentText(Settings::Instance().GetUserStyle());
 
   bool combobox_userstyle_visible =
@@ -298,7 +299,8 @@ void InterfacePane::OnSaveConfig()
   Config::SetBase(Config::MAIN_USE_BUILT_IN_TITLE_DATABASE,
                   m_checkbox_use_builtin_title_database->isChecked());
   Settings::Instance().SetDebugModeEnabled(m_checkbox_show_debugging_ui->isChecked());
-  Settings::Instance().SetStyleType(static_cast<Settings::StyleType>(m_combobox_style->currentIndex()));
+  Settings::Instance().SetStyleType(
+      static_cast<Settings::StyleType>(m_combobox_style->currentIndex()));
   Settings::Instance().SetUserStyle(m_combobox_userstyle->currentData().toString());
   Settings::Instance().UpdateStyle();
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -133,13 +133,14 @@ void InterfacePane::CreateUI()
 
   // User Style Combobox
   m_combobox_userstyle = new QComboBox;
+  m_label_userstyle = new QLabel(tr("User Style:"));
   auto userstyle_search_results = Common::DoFileSearch({File::GetUserPath(D_STYLES_IDX)});
   for (const std::string& path : userstyle_search_results)
   {
     const QFileInfo file_info(QString::fromStdString(path));
     m_combobox_userstyle->addItem(file_info.completeBaseName(), file_info.fileName());
   }
-  combobox_layout->addRow(tr("User Style:"), m_combobox_userstyle);
+  combobox_layout->addRow(m_label_userstyle, m_combobox_userstyle);
 
   // Checkboxes
   m_checkbox_use_builtin_title_database = new QCheckBox(tr("Use Built-In Database of Game Names"));
@@ -261,7 +262,11 @@ void InterfacePane::LoadConfig()
 
   SignalBlocking(m_combobox_style)->setCurrentIndex(static_cast<int>(Settings::Instance().GetStyleType()));
   SignalBlocking(m_combobox_userstyle)->setCurrentText(Settings::Instance().GetUserStyle());
-  m_combobox_userstyle->setEnabled(Settings::Instance().GetStyleType() == Settings::StyleType::User);
+
+  bool combobox_userstyle_visible =
+      Settings::Instance().GetStyleType() == Settings::StyleType::User;
+  m_label_userstyle->setVisible(combobox_userstyle_visible);
+  m_combobox_userstyle->setVisible(combobox_userstyle_visible);
 
   // Render Window Options
   SignalBlocking(m_checkbox_top_window)
@@ -297,7 +302,10 @@ void InterfacePane::OnSaveConfig()
   Settings::Instance().SetUserStyle(m_combobox_userstyle->currentData().toString());
   Settings::Instance().UpdateStyle();
 
-  m_combobox_userstyle->setEnabled(Settings::Instance().GetStyleType() == Settings::StyleType::User);
+  bool combobox_userstyle_visible =
+      Settings::Instance().GetStyleType() == Settings::StyleType::User;
+  m_label_userstyle->setVisible(combobox_userstyle_visible);
+  m_combobox_userstyle->setVisible(combobox_userstyle_visible);
 
   // Render Window Options
   Settings::Instance().SetKeepWindowOnTop(m_checkbox_top_window->isChecked());

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -34,6 +34,7 @@ private:
   QComboBox* m_combobox_theme;
   QComboBox* m_combobox_style;
   QComboBox* m_combobox_userstyle;
+  QLabel* m_label_userstyle;
   QCheckBox* m_checkbox_top_window;
   QCheckBox* m_checkbox_use_builtin_title_database;
   QCheckBox* m_checkbox_show_debugging_ui;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -32,11 +32,10 @@ private:
   QComboBox* m_combobox_language;
 
   QComboBox* m_combobox_theme;
+  QComboBox* m_combobox_style;
   QComboBox* m_combobox_userstyle;
-  QLabel* m_label_userstyle;
   QCheckBox* m_checkbox_top_window;
   QCheckBox* m_checkbox_use_builtin_title_database;
-  QCheckBox* m_checkbox_use_userstyle;
   QCheckBox* m_checkbox_show_debugging_ui;
   QCheckBox* m_checkbox_focused_hotkeys;
   QCheckBox* m_checkbox_use_covers;


### PR DESCRIPTION
![image](https://github.com/dolphin-emu/dolphin/assets/36348486/8e854761-e82d-4319-b2a3-227112ddcde5)
![image](https://github.com/dolphin-emu/dolphin/assets/36348486/99df9d33-3cc4-4cd6-856f-f78f67b446e0)
![image](https://github.com/dolphin-emu/dolphin/assets/36348486/e728179d-4260-4556-b7da-51c83c99b07d)
![image](https://github.com/dolphin-emu/dolphin/assets/36348486/29e8187a-9b2f-4f63-8799-4dae4d9a0372)

User style combo box is invisible when user styles are not in use.