### PR TITLE
Disable Store EFB Copies to Texture Only for Mystery Case Files: The Malgrave Incident

### DIFF
--- a/Data/Sys/GameSettings/SFI.ini
+++ b/Data/Sys/GameSettings/SFI.ini
@@ -12,9 +12,9 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
 [Video_Hacks]
+# Needed for cutscenes and the book to work properly (https://bugs.dolphin-emu.org/issues/4723)
 ImmediateXFBEnable = False
+# Needed for the book to work properly (https://bugs.dolphin-emu.org/issues/13356)
+EFBToTextureEnable = False
 


### PR DESCRIPTION
See https://bugs.dolphin-emu.org/issues/13356. Testing there determined that forcing a specific value for SafeTextureCacheColorSamples is not needed.