### PR TITLE
Debugger/Memory: Fix mem2 search

### DIFF
--- a/Source/Core/Core/HW/AddressSpace.cpp
+++ b/Source/Core/Core/HW/AddressSpace.cpp
@@ -146,8 +146,7 @@ struct EffectiveAddressSpaceAccessors : Accessors
 
       // For now, limit to only mem1 and mem2 regions
       // GetPointer can get confused by the locked dcache region that dolphin pins at 0xe0000000
-      u32 memory_area = (*page_physical_address) >> 24;
-      if ((memory_area != 0x00) && (memory_area != 0x01))
+      if (page_physical_address >= 0xE0000000)
       {
         return false;
       }


### PR DESCRIPTION
Memory widget search functionality would not work for MEM2 region. `Match()` restricts our physical address from exceeding 0x01FFFFFF. This means that we can access cached/uncache MEM1 as our physical addresses are 0x00000000 - 0x017FFFFF. However, this logic does not work for MEM2, as our physical address is 0x10000000 to 0x117FFFFF (I believe). Searching starting from MEM2 does not show a match until 0xC0000000.

At first I assumed we would just modify `memory_area`, however, the call to `MMU::HostIsRAMAddress()` in `EffectiveAddressSpaceAccessors::Search()` appears to sufficiently check for valid memory bounds. Notably, we want to allow RAM searches for instances where you increase the size of MEM1 or MEM2 via Config->Advanced tab. In these instances, the current code does not allow for the upper bound to increase, whereas `HostIsRAMAddress()` eventually retrieves the `m_memory.GetRamSizeReal()` which factors in the possibly larger mem allocation.

The comment in `Match()` implies concern regarding the dcache. In testing, we either pagefault in `MMU::IsRAMAddress()` after the call to `TranslateAddress()` OR we reach `EffectiveAddressSpaceAccessors::Matches()`. In cases where we reach `Matches()`, we can just change the physical address check to require that we are not at or beyond dcache.