### PR TITLE
Android: Float slider settings fix

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -2356,8 +2356,8 @@ class SettingsFragmentPresenter(
                     ceil(setting.getDoubleMin()).toFloat(),
                     floor(setting.getDoubleMax()).toFloat(),
                     setting.getUiSuffix(),
-                    1.0f,
-                    false
+                    0.5f,
+                    true
                 )
             )
 

--- a/Source/Android/app/src/main/res/layout/dialog_slider.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_slider.xml
@@ -1,41 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginTop="24dp">
+
+        <TextView
+            android:id="@+id/text_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            tools:text="10000" />
+
+        <TextView
+            android:id="@+id/text_units"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="%" />
+
+    </LinearLayout>
+
     <com.google.android.material.slider.Slider
         android:id="@+id/slider"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        app:layout_constraintEnd_toStartOf="@id/text_value"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginBottom="24dp" />
 
-    <TextView
-        android:id="@+id/text_value"
-        android:layout_width="40dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/spacing_medlarge"
-        android:gravity="end"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/text_units"
-        app:layout_constraintStart_toEndOf="@id/slider"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="10000" />
-
-    <TextView
-        android:id="@+id/text_units"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="24dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/text_value"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="%" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>


### PR DESCRIPTION
In some settings where the default value could not be evenly divided by the step size for the slider, there would be a crash. This increases the precision of all double numeric settings to 0.5 and now shows the decimal that you couldn't see before.
This is because we started tracking the value of the slider as a Float in #12095 instead of cutting off the decimal value with an Int.

Additionally, this moves the TextView from the right side of the slider to the top in the slider dialog. I really should've just kept this back in #10725

![image](https://github.com/dolphin-emu/dolphin/assets/14132249/926cd5a2-0f48-4b85-8233-30e13c005513)
