### PR TITLE
Require system library fmt >= 10.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,7 +630,7 @@ if (_M_X86)
 endif()
 add_subdirectory(Externals/cpp-optparse)
 
-dolphin_find_optional_system_library(fmt Externals/fmt 8)
+dolphin_find_optional_system_library(fmt Externals/fmt 10.1)
 
 add_subdirectory(Externals/imgui)
 add_subdirectory(Externals/implot)


### PR DESCRIPTION
After code changes made in #12190, compile errors occur if system library version fmt < 10 is installed.