### PR TITLE
FileUtil: Don't try to retrieve size for FIFO pipe

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -452,7 +452,7 @@ FSTEntry ScanDirectoryTree(std::string directory, bool recursive)
   auto dirent_to_fstent = [&](const fs::directory_entry& entry) {
     return FSTEntry{
         .isDirectory = entry.is_directory(),
-        .size = entry.is_directory() ? 0 : entry.file_size(),
+        .size = entry.is_directory() || entry.is_fifo() ? 0 : entry.file_size(),
         .physicalName = path_to_physical_name(entry.path()),
         .virtualName = PathToString(entry.path().filename()),
     };


### PR DESCRIPTION
This is an extremely small patch that fixes an exception thrown if you try to use POSIX pipes as control inputs (as detailed in [this wiki article](https://wiki.dolphin-emu.org/index.php?title=Pipe_Input)).

On the current `master`, if you have a POSIX pipe in Dolphin's "Pipes" folder, it will crash on startup with the following message:

```
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot get file size: Operation not supported [<filename>]
```

This happens because `ScanDirectoryTree` attempts to get the size of all non-directories, which as the exception explains is not valid for FIFO pipes.

This patch adds an additional check for `is_fifo()` in addition to the existing check for `is_directory()`, returning 0 for the size in both cases.