### PR TITLE
SaveStates : Fix MainWindow.m_state_slot is not restored from Qt.ini Emulation/StateSlot.

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -280,6 +280,9 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
     }
   }
 
+  m_state_slot =
+      std::clamp(Settings::Instance().GetStateSlot(), 1, static_cast<int>(State::NUM_STATES));
+
   QSettings& settings = Settings::GetQSettings();
 
   restoreState(settings.value(QStringLiteral("mainwindow/state")).toByteArray());


### PR DESCRIPTION
- Select slot 2 and exit & launch Dolphin again. 
- Slot 2 is correctly selected in the menu, but saving from selected slot using a Hotkey saves to slot 1.
-> m_state_slot value is never reloaded from Qt.ini