### PR TITLE
Skylanders: Implement Save States

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -146,6 +146,10 @@ void Host_UpdateDisasmDialog()
 {
 }
 
+void Host_UpdateSkylanderWindow()
+{
+}
+
 void Host_UpdateMainFrame()
 {
 }

--- a/Source/Android/jni/SkylanderConfig.cpp
+++ b/Source/Android/jni/SkylanderConfig.cpp
@@ -107,12 +107,12 @@ Java_org_dolphinemu_dolphinemu_features_skylanders_SkylanderConfig_loadSkylander
     name = it->second.name;
   }
 
-  return env->NewObject(
-      pair_class, pair_init,
-      env->NewObject(integer_class, int_init,
-                     system.GetSkylanderPortal().LoadSkylander(
-                         std::make_unique<IOS::HLE::USB::SkylanderFigure>(std::move(sky_file)))),
-      ToJString(env, name));
+  return env->NewObject(pair_class, pair_init,
+                        env->NewObject(integer_class, int_init,
+                                       system.GetSkylanderPortal().LoadSkylander(
+                                           std::make_unique<IOS::HLE::USB::SkylanderFigure>(
+                                               std::move(sky_file), GetJString(env, file_name)))),
+                        ToJString(env, name));
 }
 
 JNIEXPORT jobject JNICALL
@@ -159,11 +159,11 @@ Java_org_dolphinemu_dolphinemu_features_skylanders_SkylanderConfig_createSkyland
     name = it->second.name;
   }
 
-  return env->NewObject(
-      pair_class, pair_init,
-      env->NewObject(integer_class, integer_init,
-                     system.GetSkylanderPortal().LoadSkylander(
-                         std::make_unique<IOS::HLE::USB::SkylanderFigure>(std::move(sky_file)))),
-      ToJString(env, name));
+  return env->NewObject(pair_class, pair_init,
+                        env->NewObject(integer_class, integer_init,
+                                       system.GetSkylanderPortal().LoadSkylander(
+                                           std::make_unique<IOS::HLE::USB::SkylanderFigure>(
+                                               std::move(sky_file), GetJString(env, fileName)))),
+                        ToJString(env, name));
 }
 }

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -59,6 +59,7 @@ void Host_NotifyMapLoaded();
 void Host_RefreshDSPDebuggerWindow();
 void Host_RequestRenderWindowSize(int width, int height);
 void Host_UpdateDisasmDialog();
+void Host_UpdateSkylanderWindow();
 void Host_UpdateMainFrame();
 void Host_UpdateTitle(const std::string& title);
 void Host_YieldToUI();

--- a/Source/Core/Core/IOS/USB/Common.h
+++ b/Source/Core/Core/IOS/USB/Common.h
@@ -183,6 +183,8 @@ public:
   virtual int SubmitTransfer(std::unique_ptr<IntrMessage> message) = 0;
   virtual int SubmitTransfer(std::unique_ptr<IsoMessage> message) = 0;
 
+  virtual void DoState(PointerWrap& p) = 0;
+
 protected:
   u64 m_id = 0xFFFFFFFFFFFFFFFF;
 };

--- a/Source/Core/Core/IOS/USB/Emulated/Infinity.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Infinity.cpp
@@ -412,6 +412,11 @@ int InfinityUSB::SubmitTransfer(std::unique_ptr<IsoMessage> cmd)
   return 0;
 }
 
+void InfinityUSB::DoState(PointerWrap& p)
+{
+  // TODO: Should be similar to Skylander Portal
+}
+
 void InfinityUSB::ScheduleTransfer(std::unique_ptr<TransferCommand> command,
                                    const std::array<u8, 32>& data, u64 expected_time_us)
 {

--- a/Source/Core/Core/IOS/USB/Emulated/Infinity.h
+++ b/Source/Core/Core/IOS/USB/Emulated/Infinity.h
@@ -49,6 +49,8 @@ public:
   int SubmitTransfer(std::unique_ptr<IntrMessage> message) override;
   int SubmitTransfer(std::unique_ptr<IsoMessage> message) override;
 
+  void DoState(PointerWrap& p) override;
+
 private:
   void ScheduleTransfer(std::unique_ptr<TransferCommand> command, const std::array<u8, 32>& data,
                         u64 expected_time_us);

--- a/Source/Core/Core/IOS/USB/Emulated/Skylanders/Skylander.h
+++ b/Source/Core/Core/IOS/USB/Emulated/Skylanders/Skylander.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <deque>
 #include <map>
 #include <mutex>
 #include <queue>
@@ -91,6 +92,8 @@ public:
   void ScheduleTransfer(std::unique_ptr<TransferCommand> command, const std::array<u8, 64>& data,
                         s32 expected_count, u64 expected_time_us);
 
+  void DoState(PointerWrap& p) override;
+
 private:
   EmulationKernel& m_ios;
   u16 m_vid = 0;
@@ -101,14 +104,14 @@ private:
   std::vector<ConfigDescriptor> m_config_descriptor;
   std::vector<InterfaceDescriptor> m_interface_descriptor;
   std::vector<EndpointDescriptor> m_endpoint_descriptor;
-  std::queue<std::array<u8, 64>> m_queries;
+  std::deque<std::array<u8, 64>> m_queries;
 };
 
 struct Skylander final
 {
   std::unique_ptr<SkylanderFigure> figure;
   u8 status = 0;
-  std::queue<u8> queued_status;
+  std::deque<u8> queued_status;
   u32 last_id = 0;
 
   enum : u8
@@ -135,6 +138,7 @@ public:
   bool IsActivated();
   void UpdateStatus();
   void SetLEDs(u8 side, u8 r, u8 g, u8 b);
+  void InitSkylanderVector();
 
   std::array<u8, 64> GetStatus();
   void QueryBlock(u8 sky_num, u8 block, u8* reply_buf);
@@ -144,6 +148,9 @@ public:
   u8 LoadSkylander(std::unique_ptr<SkylanderFigure> figure);
   Skylander* GetSkylander(u8 slot);
   std::pair<u16, u16> CalculateIDs(const std::array<u8, 0x40 * 0x10>& file_data);
+  std::pair<u16, u16> GetSkylanderFromSlot(u8 slot);
+
+  void DoState(PointerWrap& p);
 
 private:
   static bool IsSkylanderNumberValid(u8 sky_num);
@@ -158,7 +165,7 @@ private:
   SkylanderLEDColor m_color_left = {};
   SkylanderLEDColor m_color_trap = {};
 
-  std::array<Skylander, MAX_SKYLANDERS> skylanders;
+  std::vector<Skylander> skylanders;
 };
 
 }  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/Emulated/Skylanders/SkylanderFigure.h
+++ b/Source/Core/Core/IOS/USB/Emulated/Skylanders/SkylanderFigure.h
@@ -10,6 +10,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/IOFile.h"
+#include "Core/IOS/USB/Common.h"
 
 namespace IOS::HLE::USB
 {
@@ -60,8 +61,9 @@ constexpr u32 FIGURE_SIZE = BLOCK_COUNT * BLOCK_SIZE;
 class SkylanderFigure
 {
 public:
+  SkylanderFigure();
   SkylanderFigure(const std::string& file_path);
-  SkylanderFigure(File::IOFile file);
+  SkylanderFigure(File::IOFile file, std::string file_path);
   bool Create(u16 sky_id, u16 sky_var,
               std::optional<std::array<u8, 4>> requested_nuid = std::nullopt);
   void Save();
@@ -73,6 +75,8 @@ public:
   FigureData GetData() const;
   void SetData(FigureData* data);
 
+  void DoState(PointerWrap& p);
+
 private:
   void PopulateSectorTrailers();
   void PopulateKeys();
@@ -81,5 +85,6 @@ private:
 
   File::IOFile m_sky_file;
   std::array<u8, FIGURE_SIZE> m_data;
+  std::string m_file_path = "";
 };
 }  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -320,6 +320,11 @@ int LibusbDevice::SubmitTransfer(std::unique_ptr<IsoMessage> cmd)
   return libusb_submit_transfer(transfer);
 }
 
+void LibusbDevice::DoState(PointerWrap& p)
+{
+  // TODO: Somehow get Libusb devices to save and load state
+}
+
 void LibusbDevice::CtrlTransferCallback(libusb_transfer* transfer)
 {
   auto* device = static_cast<LibusbDevice*>(transfer->user_data);

--- a/Source/Core/Core/IOS/USB/LibusbDevice.h
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.h
@@ -45,6 +45,8 @@ public:
   int SubmitTransfer(std::unique_ptr<IntrMessage> message) override;
   int SubmitTransfer(std::unique_ptr<IsoMessage> message) override;
 
+  void DoState(PointerWrap& p) override;
+
 private:
   EmulationKernel& m_ios;
 

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -153,6 +153,9 @@ void USB_HIDv4::DoState(PointerWrap& p)
   p.Do(m_ios_ids);
   p.Do(m_device_ids);
 
+  // Device ID of the Emulated Skylander Portal
+  GetDeviceById(22196413008129)->DoState(p);
+
   USBHost::DoState(p);
 }
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -46,6 +46,8 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 
+#include "IOS/USB/Emulated/Skylanders/Skylander.h"
+
 #include "VideoCommon/FrameDumpFFMpeg.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoBackendBase.h"
@@ -95,7 +97,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 166;  // Last changed in PR 12487
+constexpr u32 STATE_VERSION = 167;  // Last changed in PR 12202
 
 // Increase this if the StateExtendedHeader definition changes
 constexpr u32 EXTENDED_HEADER_VERSION = 1;  // Last changed in PR 12217
@@ -196,6 +198,10 @@ static void DoState(PointerWrap& p)
   p.DoMarker("Wiimote");
   Gecko::DoState(p);
   p.DoMarker("Gecko");
+
+  // Save the State of the Emulated Portal
+  system.GetSkylanderPortal().DoState(p);
+  p.DoMarker("SkylanderPortal");
 }
 
 void LoadFromBuffer(std::vector<u8>& buffer)

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -85,6 +85,10 @@ void Host_UpdateDisasmDialog()
 {
 }
 
+void Host_UpdateSkylanderWindow()
+{
+}
+
 void Host_UpdateMainFrame()
 {
   s_update_main_frame_event.Set();

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -238,6 +238,12 @@ void Host_UpdateDisasmDialog()
   QueueOnObject(QApplication::instance(), [] { emit Host::GetInstance()->UpdateDisasmDialog(); });
 }
 
+void Host_UpdateSkylanderWindow()
+{
+  QueueOnObject(QApplication::instance(),
+                [] { emit Host::GetInstance()->UpdateSkylanderWindow(); });
+}
+
 void Host::RequestNotifyMapLoaded()
 {
   QueueOnObject(QApplication::instance(), [this] { emit NotifyMapLoaded(); });

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -39,6 +39,7 @@ signals:
   void RequestStop();
   void RequestRenderSize(int w, int h);
   void UpdateDisasmDialog();
+  void UpdateSkylanderWindow();
   void NotifyMapLoaded();
 
 private:

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderModifyDialog.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderModifyDialog.cpp
@@ -336,9 +336,9 @@ void SkylanderModifyDialog::accept()
   if (m_allow_close)
   {
     auto* skylander = Core::System::GetInstance().GetSkylanderPortal().GetSkylander(m_slot);
-    skylander->queued_status.push(IOS::HLE::USB::Skylander::REMOVED);
-    skylander->queued_status.push(IOS::HLE::USB::Skylander::ADDED);
-    skylander->queued_status.push(IOS::HLE::USB::Skylander::READY);
+    skylander->queued_status.push_back(IOS::HLE::USB::Skylander::REMOVED);
+    skylander->queued_status.push_back(IOS::HLE::USB::Skylander::ADDED);
+    skylander->queued_status.push_back(IOS::HLE::USB::Skylander::READY);
     QDialog::accept();
   }
 }

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.h
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.h
@@ -69,6 +69,7 @@ private:
 
   // Behind the scenes
   void OnEmulationStateChanged(Core::State state);
+  void OnWindowLoad();
   void OnCollectionPathChanged();
   void UpdateCurrentIDs();
   void CreateSkyfile(const QString& path, bool load_after);

--- a/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
+++ b/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
@@ -61,6 +61,10 @@ void Host_UpdateDisasmDialog()
 {
 }
 
+void Host_UpdateSkylanderWindow()
+{
+}
+
 void Host_UpdateMainFrame()
 {
 }

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -41,6 +41,9 @@ bool Host_UpdateDiscordPresenceRaw(const std::string& details, const std::string
 void Host_UpdateDisasmDialog()
 {
 }
+void Host_UpdateSkylanderWindow()
+{
+}
 void Host_UpdateMainFrame()
 {
 }

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -41,6 +41,9 @@ bool Host_UpdateDiscordPresenceRaw(const std::string& details, const std::string
 void Host_UpdateDisasmDialog()
 {
 }
+void Host_UpdateSkylanderWindow()
+{
+}
 void Host_UpdateMainFrame()
 {
 }


### PR DESCRIPTION
Have been meaning to do this for a while, but have now implemented Save States for the Emulated Portal.

In order to use the p.DoEachElement method, I changed queues to deques to allow for resizing, as well as changing the skylander array to a vector (also allows resizing). I am not overly familiar with the Save State system, so if there is a better place for me to call the DoState methods from let me know.

Also added a change to the Portal Window, which will update the names displayed in the portal slots when it loads (if a save state has been loaded before the Window has been opened).