### PR TITLE
HIDv4: Check Device Not Null Before Attaching

### DIFF
--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -59,6 +59,8 @@ std::optional<IPCReply> USB_HIDv4::IOCtl(const IOCtlRequest& request)
     if (request.buffer_in == 0 || request.buffer_in_size != 32)
       return IPCReply(IPC_EINVAL);
     const auto device = GetDeviceByIOSID(memory.Read_U32(request.buffer_in + 16));
+    if (!device)
+      return IPCReply(IPC_ENOENT);
     if (!device->Attach())
       return IPCReply(IPC_EINVAL);
     return HandleTransfer(device, request.request,


### PR DESCRIPTION
Fairly self-explanatory PR - the GetDeviceByIOSID method can return null, and I have noticed this happening when a usb device is removed during gameplay (for Skylanders or Disney Infinity for example) where the core still attempts to read from the USB device while the remove hooks are being thrown. Will prevent crashes when doing this in-game.