### PR TITLE
PowerPC: reduce location assert cost

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/RegCache/CachedReg.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/CachedReg.h
@@ -51,7 +51,7 @@ public:
       if (location->IsImm())
         return LocationType::SpeculativeImmediate;
 
-      ASSERT(location == default_location);
+      ASSERT(*location == default_location);
       return LocationType::Default;
     }
 


### PR DESCRIPTION
This would normally be an incredibly unimportant change, but I discovered that `PPCCachedReg::GetLocationType` is the cause of the single hottest path on the CPU/GPU thread when repeatedly loading savestates, as TASers do. For whatever reason, the `==` operator comprises ~14% of the thread's CPU cycles during savestate loads. This caught my eye, so I looked further and noticed a small improvement.

`==` is acting on `std::optional<Gen::OpArg>` and `Gen::OpArg`. Thus this is scenario 21 from [this documentation](https://en.cppreference.com/w/cpp/utility/optional/operator_cmp). We see that this operator first checks to see if the optional object contains a value. Only after that does it call `Gen::OpArg::operator==`. However, the check to see if the optional object contains a value is redundant, as empty objects are handled earlier in the function with `if (!location.has_value())`.

Retrieving the object's value (which is safe to do so since we've already handled the opposite case) before calling the `==` operator seems to reduce this function's CPU cycles by as much as 3.5% on my end.

Someone else may have more insight to find true performance difference calculations (I imagine compiler optimizations in Release versions benefit less), but I figured this was still worth PR'ing.