### PR TITLE
DolphinQt: Fix decrease emulation speed hotkey rollover

### DIFF
--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -470,8 +470,11 @@ void HotkeyScheduler::Run()
       if (IsHotkey(HK_DECREASE_EMULATION_SPEED))
       {
         auto speed = Config::Get(Config::MAIN_EMULATION_SPEED) - 0.1;
-        speed = (speed <= 0 || (speed >= 0.95 && speed <= 1.05)) ? 1.0 : speed;
-        Config::SetCurrent(Config::MAIN_EMULATION_SPEED, speed);
+        if (speed > 0)
+        {
+          speed = (speed >= 0.95 && speed <= 1.05) ? 1.0 : speed;
+          Config::SetCurrent(Config::MAIN_EMULATION_SPEED, speed);
+        }
         ShowEmulationSpeed();
       }
 


### PR DESCRIPTION
Current behavior of the Decrease Emulation Speed hotkey results in an unintended resetting of speed. Pressing the hotkey allows speed to go from 100% to 90% all the way to 10%. A subsequent press of the hotkey will then cause a rollover back to 100% speed. Subsequent presses will bring speed down to 10% again, repeating the cycle. This does not match the behavior prior to the Qt migration, and I personally don't think it should act this way!