### PR TITLE
Use Vertex Depth Range when zRange Exceeds farZ

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -168,8 +168,14 @@ bool VertexShaderManager::UseVertexDepthRange()
     return true;
 
   // If an inverted depth range is unsupported, we also need to check if the range is inverted.
-  if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange && xfmem.viewport.zRange < 0.0f)
-    return true;
+  if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange)
+  {
+    if (xfmem.viewport.zRange < 0.0f)
+      return true;
+
+    if (xfmem.viewport.zRange > xfmem.viewport.farZ)
+      return true;
+  }
 
   // If an oversized depth range or a ztexture is used, we need to calculate the depth range
   // in the vertex shader.


### PR DESCRIPTION
When the inverted depth range is unsupported and zRange is greater than farZ then min_depth becomes a negative value and far_depth will then exceed a depth of 1.0 (which is outside the scope of most backends and greater than GX_MAX_DEPTH of the console).

This happens when the backend supports depth clamping the min_depth is not clamped to zero.

Solves most of the issues in Direct3D 11 I've found, specifically this fixes all the depth issues present in [#11720](https://bugs.dolphin-emu.org/issues/11720)