### PR TITLE
Jit: Fix fastmem initialization order

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -82,7 +82,7 @@ CachedInterpreter::~CachedInterpreter() = default;
 
 void CachedInterpreter::Init()
 {
-  RefreshConfig();
+  RefreshConfig(InitFastmemArena::No);
 
   m_code.reserve(CODE_SIZE / sizeof(Instruction));
 
@@ -384,5 +384,5 @@ void CachedInterpreter::ClearCache()
 {
   m_code.clear();
   m_block_cache.Clear();
-  RefreshConfig();
+  RefreshConfig(InitFastmemArena::No);
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -251,13 +251,10 @@ bool Jit64::BackPatch(SContext* ctx)
 
 void Jit64::Init()
 {
-  RefreshConfig();
+  RefreshConfig(InitFastmemArena::Yes);
 
   EnableBlockLink();
 
-  auto& memory = m_system.GetMemory();
-
-  jo.fastmem_arena = m_fastmem_enabled && memory.InitFastmemArena();
   jo.optimizeGatherPipe = true;
   jo.accurateSinglePrecision = true;
   js.fastmemLoadStore = nullptr;
@@ -307,7 +304,7 @@ void Jit64::ClearCache()
   m_const_pool.Clear();
   ClearCodeSpace();
   Clear();
-  RefreshConfig();
+  RefreshConfig(InitFastmemArena::No);
   ResetFreeMemoryRanges();
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -47,15 +47,12 @@ JitArm64::~JitArm64() = default;
 
 void JitArm64::Init()
 {
-  RefreshConfig();
+  RefreshConfig(InitFastmemArena::Yes);
 
   const size_t child_code_size = jo.memcheck ? FARCODE_SIZE_MMU : FARCODE_SIZE;
   AllocCodeSpace(CODE_SIZE + child_code_size);
   AddChildCodeSpace(&m_far_code, child_code_size);
 
-  auto& memory = m_system.GetMemory();
-
-  jo.fastmem_arena = m_fastmem_enabled && memory.InitFastmemArena();
   jo.optimizeGatherPipe = true;
   SetBlockLinkingEnabled(true);
   SetOptimizationEnabled(true);
@@ -158,7 +155,7 @@ void JitArm64::ClearCache()
   const Common::ScopedJITPageWriteAndNoExecute enable_jit_page_writes;
   ClearCodeSpace();
   m_far_code.ClearCodeSpace();
-  RefreshConfig();
+  RefreshConfig(InitFastmemArena::No);
 
   GenerateAsm();
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -115,7 +115,7 @@ bool JitBase::DoesConfigNeedRefresh()
   });
 }
 
-void JitBase::RefreshConfig()
+void JitBase::RefreshConfig(InitFastmemArena init_fastmem_arena)
 {
   for (const auto& [member, config_info] : JIT_SETTINGS)
     this->*member = Config::Get(*config_info);
@@ -131,6 +131,12 @@ void JitBase::RefreshConfig()
   analyzer.SetBranchFollowingEnabled(m_enable_branch_following);
   analyzer.SetFloatExceptionsEnabled(m_enable_float_exceptions);
   analyzer.SetDivByZeroExceptionsEnabled(m_enable_div_by_zero_exceptions);
+
+  if (init_fastmem_arena != InitFastmemArena::No)
+  {
+    auto& memory = m_system.GetMemory();
+    jo.fastmem_arena = m_fastmem_enabled && memory.InitFastmemArena();
+  }
 
   bool any_watchpoints = m_system.GetPowerPC().GetMemChecks().HasAny();
   jo.fastmem = m_fastmem_enabled && jo.fastmem_arena && (m_ppc_state.msr.DR || !any_watchpoints) &&

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -163,8 +163,14 @@ protected:
 
   static const std::array<std::pair<bool JitBase::*, const Config::Info<bool>*>, 22> JIT_SETTINGS;
 
+  enum class InitFastmemArena
+  {
+    No,
+    Yes,
+  };
+
   bool DoesConfigNeedRefresh();
-  void RefreshConfig();
+  void RefreshConfig(InitFastmemArena init_fastmem_arena);
 
   void InitBLROptimization();
   void ProtectStack();


### PR DESCRIPTION
When evaluating whether jo.fastmem should be set to true, we check the value of jo.fastmem_arena. However, due to a change made in 28e8117b90, jo.fastmem_arena wasn't set until after the first time we set jo.fastmem, so jo.fastmem would end up always being false until the next time RefreshConfig was called.

Fixes https://bugs.dolphin-emu.org/issues/13364.