### PR TITLE
RetroAchievements - Improved Game Loading

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -20,7 +20,7 @@
 #include "Core/Core.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/System.h"
-#include "DiscIO/Volume.h"
+#include "DiscIO/Blob.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoEvents.h"
 
@@ -91,8 +91,7 @@ bool AchievementManager::IsLoggedIn() const
   return !Config::Get(Config::RA_API_TOKEN).empty();
 }
 
-void AchievementManager::LoadGameByFilenameAsync(const std::string& iso_path,
-                                                 const ResponseCallback& callback)
+void AchievementManager::HashGame(const std::string& file_path, const ResponseCallback& callback)
 {
   if (!m_is_runtime_initialized)
   {
@@ -102,114 +101,147 @@ void AchievementManager::LoadGameByFilenameAsync(const std::string& iso_path,
     return;
   }
   m_system = &Core::System::GetInstance();
+  m_queue.EmplaceItem([this, callback, file_path] {
+    Hash new_hash;
+    {
+      std::lock_guard lg{m_filereader_lock};
+      rc_hash_filereader volume_reader{
+          .open = &AchievementManager::FilereaderOpenByFilepath,
+          .seek = &AchievementManager::FilereaderSeek,
+          .tell = &AchievementManager::FilereaderTell,
+          .read = &AchievementManager::FilereaderRead,
+          .close = &AchievementManager::FilereaderClose,
+      };
+      rc_hash_init_custom_filereader(&volume_reader);
+      if (!rc_hash_generate_from_file(new_hash.data(), RC_CONSOLE_GAMECUBE, file_path.c_str()))
+      {
+        ERROR_LOG_FMT(ACHIEVEMENTS, "Unable to generate achievement hash from game file {}.",
+                      file_path);
+        callback(AchievementManager::ResponseType::MALFORMED_OBJECT);
+      }
+    }
+    {
+      std::lock_guard lg{m_lock};
+      m_game_hash = std::move(new_hash);
+    }
+    LoadGameSync(callback);
+  });
+}
+
+void AchievementManager::HashGame(const DiscIO::Volume* volume, const ResponseCallback& callback)
+{
+  if (!m_is_runtime_initialized)
+  {
+    ERROR_LOG_FMT(ACHIEVEMENTS,
+                  "Attempted to load game achievements without Achievement Manager initialized.");
+    callback(AchievementManager::ResponseType::MANAGER_NOT_INITIALIZED);
+    return;
+  }
+  if (volume == nullptr)
+  {
+    INFO_LOG_FMT(ACHIEVEMENTS, "New volume is empty.");
+    return;
+  }
+  {
+    std::lock_guard lg{m_lock};
+    if (m_loading_volume.get() != nullptr)
+    {
+      return;
+    }
+    m_loading_volume = DiscIO::CreateVolume(volume->GetBlobReader().CopyReader());
+  }
+  m_system = &Core::System::GetInstance();
   struct FilereaderState
   {
     int64_t position = 0;
     std::unique_ptr<DiscIO::Volume> volume;
   };
-  rc_hash_filereader volume_reader{
-      .open = [](const char* path_utf8) -> void* {
-        auto state = std::make_unique<FilereaderState>();
-        state->volume = DiscIO::CreateVolume(path_utf8);
-        if (!state->volume)
-          return nullptr;
-        return state.release();
-      },
-      .seek =
-          [](void* file_handle, int64_t offset, int origin) {
-            switch (origin)
-            {
-            case SEEK_SET:
-              reinterpret_cast<FilereaderState*>(file_handle)->position = offset;
-              break;
-            case SEEK_CUR:
-              reinterpret_cast<FilereaderState*>(file_handle)->position += offset;
-              break;
-            case SEEK_END:
-              // Unused
-              break;
-            }
-          },
-      .tell =
-          [](void* file_handle) {
-            return reinterpret_cast<FilereaderState*>(file_handle)->position;
-          },
-      .read =
-          [](void* file_handle, void* buffer, size_t requested_bytes) {
-            FilereaderState* filereader_state = reinterpret_cast<FilereaderState*>(file_handle);
-            bool success = (filereader_state->volume->Read(
-                filereader_state->position, requested_bytes, reinterpret_cast<u8*>(buffer),
-                DiscIO::PARTITION_NONE));
-            if (success)
-            {
-              filereader_state->position += requested_bytes;
-              return requested_bytes;
-            }
-            else
-            {
-              return static_cast<size_t>(0);
-            }
-          },
-      .close = [](void* file_handle) { delete reinterpret_cast<FilereaderState*>(file_handle); }};
-  rc_hash_init_custom_filereader(&volume_reader);
-  if (!rc_hash_generate_from_file(m_game_hash.data(), RC_CONSOLE_GAMECUBE, iso_path.c_str()))
-  {
-    ERROR_LOG_FMT(ACHIEVEMENTS, "Unable to generate achievement hash from game file.");
-    return;
-  }
   m_queue.EmplaceItem([this, callback] {
-    const auto resolve_hash_response = ResolveHash(this->m_game_hash);
-    if (resolve_hash_response != ResponseType::SUCCESS || m_game_id == 0)
+    Hash new_hash;
     {
-      callback(resolve_hash_response);
-      INFO_LOG_FMT(ACHIEVEMENTS, "No RetroAchievements data found for this game.");
-      OSD::AddMessage("No RetroAchievements data found for this game.", OSD::Duration::VERY_LONG,
-                      OSD::Color::RED);
-      return;
+      std::lock_guard lg{m_filereader_lock};
+      rc_hash_filereader volume_reader{
+          .open = &AchievementManager::FilereaderOpenByVolume,
+          .seek = &AchievementManager::FilereaderSeek,
+          .tell = &AchievementManager::FilereaderTell,
+          .read = &AchievementManager::FilereaderRead,
+          .close = &AchievementManager::FilereaderClose,
+      };
+      rc_hash_init_custom_filereader(&volume_reader);
+      if (!rc_hash_generate_from_file(new_hash.data(), RC_CONSOLE_GAMECUBE, ""))
+      {
+        ERROR_LOG_FMT(ACHIEVEMENTS, "Unable to generate achievement hash from volume.");
+        callback(AchievementManager::ResponseType::MALFORMED_OBJECT);
+        return;
+      }
     }
-
-    const auto start_session_response = StartRASession();
-    if (start_session_response != ResponseType::SUCCESS)
-    {
-      callback(start_session_response);
-      WARN_LOG_FMT(ACHIEVEMENTS, "Failed to connect to RetroAchievements server.");
-      OSD::AddMessage("Failed to connect to RetroAchievements server.", OSD::Duration::VERY_LONG,
-                      OSD::Color::RED);
-      return;
-    }
-
-    const auto fetch_game_data_response = FetchGameData();
-    if (fetch_game_data_response != ResponseType::SUCCESS)
-    {
-      ERROR_LOG_FMT(ACHIEVEMENTS, "Unable to retrieve data from RetroAchievements server.");
-      OSD::AddMessage("Unable to retrieve data from RetroAchievements server.",
-                      OSD::Duration::VERY_LONG, OSD::Color::RED);
-      return;
-    }
-    INFO_LOG_FMT(ACHIEVEMENTS, "Loading achievements for {}.", m_game_data.title);
-
-    // Claim the lock, then queue the fetch unlock data calls, then initialize the unlock map in
-    // ActivateDeactiveAchievements. This allows the calls to process while initializing the
-    // unlock map but then forces them to wait until it's initialized before making modifications to
-    // it.
     {
       std::lock_guard lg{m_lock};
-      m_is_game_loaded = true;
-      m_framecount = 0;
-      LoadUnlockData([](ResponseType r_type) {});
-      ActivateDeactivateAchievements();
-      ActivateDeactivateLeaderboards();
-      ActivateDeactivateRichPresence();
+      m_game_hash = std::move(new_hash);
+      m_loading_volume.reset();
     }
-    FetchBadges();
-    // Reset this to zero so that RP immediately triggers on the first frame
-    m_last_ping_time = 0;
-    INFO_LOG_FMT(ACHIEVEMENTS, "RetroAchievements successfully loaded for {}.", m_game_data.title);
-
-    if (m_update_callback)
-      m_update_callback();
-    callback(fetch_game_data_response);
+    LoadGameSync(callback);
   });
+}
+
+void AchievementManager::LoadGameSync(const ResponseCallback& callback)
+{
+  Hash current_hash;
+  {
+    std::lock_guard lg{m_lock};
+    current_hash = m_game_hash;
+  }
+  const auto resolve_hash_response = ResolveHash(current_hash);
+  if (resolve_hash_response != ResponseType::SUCCESS || m_game_id == 0)
+  {
+    INFO_LOG_FMT(ACHIEVEMENTS, "No RetroAchievements data found for this game.");
+    OSD::AddMessage("No RetroAchievements data found for this game.", OSD::Duration::VERY_LONG,
+                    OSD::Color::RED);
+    callback(resolve_hash_response);
+    return;
+  }
+
+  const auto start_session_response = StartRASession();
+  if (start_session_response != ResponseType::SUCCESS)
+  {
+    WARN_LOG_FMT(ACHIEVEMENTS, "Failed to connect to RetroAchievements server.");
+    OSD::AddMessage("Failed to connect to RetroAchievements server.", OSD::Duration::VERY_LONG,
+                    OSD::Color::RED);
+    callback(start_session_response);
+    return;
+  }
+
+  const auto fetch_game_data_response = FetchGameData();
+  if (fetch_game_data_response != ResponseType::SUCCESS)
+  {
+    ERROR_LOG_FMT(ACHIEVEMENTS, "Unable to retrieve data from RetroAchievements server.");
+    OSD::AddMessage("Unable to retrieve data from RetroAchievements server.",
+                    OSD::Duration::VERY_LONG, OSD::Color::RED);
+    return;
+  }
+  INFO_LOG_FMT(ACHIEVEMENTS, "Loading achievements for {}.", m_game_data.title);
+
+  // Claim the lock, then queue the fetch unlock data calls, then initialize the unlock map in
+  // ActivateDeactiveAchievements. This allows the calls to process while initializing the
+  // unlock map but then forces them to wait until it's initialized before making modifications to
+  // it.
+  {
+    std::lock_guard lg{m_lock};
+    m_is_game_loaded = true;
+    m_framecount = 0;
+    LoadUnlockData([](ResponseType r_type) {});
+    ActivateDeactivateAchievements();
+    ActivateDeactivateLeaderboards();
+    ActivateDeactivateRichPresence();
+  }
+  FetchBadges();
+  // Reset this to zero so that RP immediately triggers on the first frame
+  m_last_ping_time = 0;
+  INFO_LOG_FMT(ACHIEVEMENTS, "RetroAchievements successfully loaded for {}.", m_game_data.title);
+
+  if (m_update_callback)
+    m_update_callback();
+  callback(fetch_game_data_response);
 }
 
 bool AchievementManager::IsGameLoaded() const
@@ -790,6 +822,69 @@ void AchievementManager::Shutdown()
   INFO_LOG_FMT(ACHIEVEMENTS, "Achievement Manager shut down.");
 }
 
+void* AchievementManager::FilereaderOpenByFilepath(const char* path_utf8)
+{
+  auto state = std::make_unique<FilereaderState>();
+  state->volume = DiscIO::CreateVolume(path_utf8);
+  if (!state->volume)
+    return nullptr;
+  return state.release();
+}
+
+void* AchievementManager::FilereaderOpenByVolume(const char* path_utf8)
+{
+  auto state = std::make_unique<FilereaderState>();
+  {
+    std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
+    state->volume = std::move(AchievementManager::GetInstance()->GetLoadingVolume());
+  }
+  if (!state->volume)
+    return nullptr;
+  return state.release();
+}
+
+void AchievementManager::FilereaderSeek(void* file_handle, int64_t offset, int origin)
+{
+  switch (origin)
+  {
+  case SEEK_SET:
+    static_cast<FilereaderState*>(file_handle)->position = offset;
+    break;
+  case SEEK_CUR:
+    static_cast<FilereaderState*>(file_handle)->position += offset;
+    break;
+  case SEEK_END:
+    // Unused
+    break;
+  }
+}
+
+int64_t AchievementManager::FilereaderTell(void* file_handle)
+{
+  return static_cast<FilereaderState*>(file_handle)->position;
+}
+
+size_t AchievementManager::FilereaderRead(void* file_handle, void* buffer, size_t requested_bytes)
+{
+  FilereaderState* filereader_state = static_cast<FilereaderState*>(file_handle);
+  bool success = (filereader_state->volume->Read(filereader_state->position, requested_bytes,
+                                                 static_cast<u8*>(buffer), DiscIO::PARTITION_NONE));
+  if (success)
+  {
+    filereader_state->position += requested_bytes;
+    return requested_bytes;
+  }
+  else
+  {
+    return 0;
+  }
+}
+
+void AchievementManager::FilereaderClose(void* file_handle)
+{
+  delete static_cast<FilereaderState*>(file_handle);
+}
+
 AchievementManager::ResponseType AchievementManager::VerifyCredentials(const std::string& password)
 {
   rc_api_login_response_t login_data{};
@@ -826,8 +921,7 @@ AchievementManager::ResponseType AchievementManager::VerifyCredentials(const std
   return r_type;
 }
 
-AchievementManager::ResponseType
-AchievementManager::ResolveHash(std::array<char, HASH_LENGTH> game_hash)
+AchievementManager::ResponseType AchievementManager::ResolveHash(Hash game_hash)
 {
   rc_api_resolve_hash_response_t hash_data{};
   std::string username, api_token;

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -160,7 +160,7 @@ private:
   static void FilereaderClose(void* file_handle);
 
   ResponseType VerifyCredentials(const std::string& password);
-  ResponseType ResolveHash(Hash game_hash);
+  ResponseType ResolveHash(const Hash& game_hash, u32* game_id);
   void LoadGameSync(const ResponseCallback& callback);
   ResponseType StartRASession();
   ResponseType FetchGameData();

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -136,6 +136,8 @@ public:
                                                           u32* target);
   const std::unordered_map<AchievementId, LeaderboardStatus>& GetLeaderboardsInfo() const;
   RichPresence GetRichPresence();
+  bool IsDisabled() const { return m_disabled; };
+  void SetDisabled(bool disabled);
 
   void CloseGame();
   void Logout();
@@ -193,6 +195,7 @@ private:
   bool m_is_runtime_initialized = false;
   UpdateCallback m_update_callback;
   std::unique_ptr<DiscIO::Volume> m_loading_volume;
+  bool m_disabled = false;
   std::string m_display_name;
   u32 m_player_score = 0;
   BadgeStatus m_player_badge;

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -25,6 +25,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#include "Core/AchievementManager.h"
 #include "Core/Boot/DolReader.h"
 #include "Core/Boot/ElfReader.h"
 #include "Core/CommonTitles.h"
@@ -557,6 +558,11 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
       {
         SetupGCMemory(system, guard);
       }
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+      AchievementManager::GetInstance()->HashGame(executable.path,
+                                                  [](AchievementManager::ResponseType r_type) {});
+#endif  // USE_RETRO_ACHIEVEMENTS
 
       if (!executable.reader->LoadIntoMemory(system))
       {

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -164,16 +164,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     }
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
-  std::string path = "";
-  if (std::holds_alternative<BootParameters::Disc>(boot->parameters))
-  {
-    path = std::get<BootParameters::Disc>(boot->parameters).path;
-  }
-  AchievementManager::GetInstance()->LoadGameByFilenameAsync(
-      path, [](AchievementManager::ResponseType r_type) {});
-#endif  // USE_RETRO_ACHIEVEMENTS
-
   const bool load_ipl = !StartUp.bWii && !Config::Get(Config::MAIN_SKIP_IPL) &&
                         std::holds_alternative<BootParameters::Disc>(boot->parameters);
   if (load_ipl)

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -164,6 +164,10 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     }
   }
 
+#ifdef USE_RETRO_ACHIEVEMENTS
+  AchievementManager::GetInstance()->SetDisabled(false);
+#endif  // USE_RETRO_ACHIEVEMENTS
+
   const bool load_ipl = !StartUp.bWii && !Config::Get(Config::MAIN_SKIP_IPL) &&
                         std::holds_alternative<BootParameters::Disc>(boot->parameters);
   if (load_ipl)

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -30,6 +30,7 @@
 #include "Common/StringUtil.h"
 #include "Common/Version.h"
 
+#include "Core/AchievementManager.h"
 #include "Core/Boot/Boot.h"
 #include "Core/CommonTitles.h"
 #include "Core/Config/DefaultLocale.h"
@@ -167,6 +168,10 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
 
   if (!was_changed)
     return;
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+  AchievementManager::GetInstance()->SetDisabled(true);
+#endif  // USE_RETRO_ACHIEVEMENTS
 
   if (game_id == "00000000")
   {

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -20,6 +20,7 @@
 #include "Common/Config/Config.h"
 #include "Common/Logging/Log.h"
 
+#include "Core/AchievementManager.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/SessionSettings.h"
 #include "Core/CoreTiming.h"
@@ -395,6 +396,11 @@ void DVDInterface::SetDisc(std::unique_ptr<DiscIO::VolumeDisc> disc,
     m_auto_disc_change_paths = *auto_disc_change_paths;
     m_auto_disc_change_index = 0;
   }
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+  AchievementManager::GetInstance()->HashGame(disc.get(),
+                                              [](AchievementManager::ResponseType r_type) {});
+#endif  // USE_RETRO_ACHIEVEMENTS
 
   // Assume that inserting a disc requires having an empty disc before
   if (had_disc != has_disc)

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -16,6 +16,7 @@
 #include "Common/NandPaths.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
+#include "Core/AchievementManager.h"
 #include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -475,6 +476,12 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
   m_pending_ppc_boot_content_path = m_core.GetContentPath(tmd.GetTitleId(), content);
   if (!Core::IsRunningAndStarted())
     return BootstrapPPC();
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+  INFO_LOG_FMT(ACHIEVEMENTS,
+               "WAD and NAND formats not currently supported by Achievement Manager.");
+  AchievementManager::GetInstance()->SetDisabled(true);
+#endif  // USE_RETRO_ACHIEVEMENTS
 
   core_timing.RemoveEvent(s_bootstrap_ppc_for_launch_event);
   core_timing.ScheduleEvent(ticks, s_bootstrap_ppc_for_launch_event);

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -37,6 +37,11 @@ AchievementHeaderWidget::AchievementHeaderWidget(QWidget* parent) : QWidget(pare
   m_game_progress_hard = new QProgressBar();
   m_game_progress_soft = new QProgressBar();
   m_rich_presence = new QLabel();
+  m_locked_warning = new QLabel();
+
+  m_locked_warning->setText(tr("Achievements have been disabled.<br>Please close all running "
+                               "games to re-enable achievements."));
+  m_locked_warning->setStyleSheet(QStringLiteral("QLabel { color : red; }"));
 
   QSizePolicy sp_retain = m_game_progress_hard->sizePolicy();
   sp_retain.setRetainSizeWhenHidden(true);
@@ -54,6 +59,7 @@ AchievementHeaderWidget::AchievementHeaderWidget(QWidget* parent) : QWidget(pare
   text_col->addWidget(m_game_progress_hard);
   text_col->addWidget(m_game_progress_soft);
   text_col->addWidget(m_rich_presence);
+  text_col->addWidget(m_locked_warning);
   QHBoxLayout* header_layout = new QHBoxLayout();
   header_layout->addLayout(icon_col);
   header_layout->addLayout(text_col);
@@ -148,6 +154,7 @@ void AchievementHeaderWidget::UpdateData()
         QString::fromUtf8(AchievementManager::GetInstance()->GetRichPresence().data()));
     if (!m_rich_presence->isVisible())
       m_rich_presence->setVisible(Config::Get(Config::RA_RICH_PRESENCE_ENABLED));
+    m_locked_warning->setVisible(false);
   }
   else
   {
@@ -157,6 +164,10 @@ void AchievementHeaderWidget::UpdateData()
     m_game_progress_hard->setVisible(false);
     m_game_progress_soft->setVisible(false);
     m_rich_presence->setVisible(false);
+    if (AchievementManager::GetInstance()->IsDisabled())
+    {
+      m_locked_warning->setVisible(true);
+    }
   }
 }
 

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.h
@@ -30,6 +30,7 @@ private:
   QProgressBar* m_game_progress_hard;
   QProgressBar* m_game_progress_soft;
   QLabel* m_rich_presence;
+  QLabel* m_locked_warning;
   QGroupBox* m_header_box;
 };
 


### PR DESCRIPTION
The changes in this PR are for improving when and how the AchievementManager loads games so it can properly protect against players switching apps and opening homebrews while properly allowing multi-disc or multi-file support. This will happen by calculating a new hash whenever the currently playing media changes, and shutting down the AchievementManager* if the new hash does not reference the same game as the previous hash.

*This does not load a new game, this closes the AchievementManager entirely and it will not be reopened until all games are closed and a new boot is performed.