### PR TITLE
Rename IP_PROTOCOL

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -746,7 +746,7 @@ void CEXIETHERNET::BuiltInBBAInterface::ReadThreadHandler(CEXIETHERNET::BuiltInB
       u8* buffer = reinterpret_cast<u8*>(self->m_eth_ref->mRecvBuffer.get());
       Common::PacketView packet(buffer, datasize);
       const auto packet_type = packet.GetEtherType();
-      if (packet_type.has_value() && packet_type == IP_PROTOCOL)
+      if (packet_type.has_value() && packet_type == DOLPHIN_IP_PROTOCOL)
       {
         SetIPIdentification(buffer, datasize, ++self->m_ip_frame_id);
       }

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
@@ -20,7 +20,7 @@ constexpr u16 TCP_FLAG_PSH = 0x8;
 constexpr u16 TCP_FLAG_FIN = 0x1;
 constexpr u16 TCP_FLAG_RST = 0x4;
 
-constexpr u16 IP_PROTOCOL = 0x800;
+constexpr u16 DOLPHIN_IP_PROTOCOL = 0x800;
 constexpr u16 ARP_PROTOCOL = 0x806;
 
 constexpr u8 MAX_TCP_BUFFER = 4;


### PR DESCRIPTION
Linux headers define this, so there's a name collision. This just renames the expr to avoid this conflict.

Obviously another name can be chosen if desired, but the jist of it is that the Linux kernel C headers already have a #define with this name, which causes a name collision, confusing GCC, and causing a failure to build on newer Linux kernels.