### PR TITLE
Fix heap buffer overflow in GCMemcardRaw

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
@@ -169,7 +169,7 @@ void MemoryCard::MakeDirty()
 
 s32 MemoryCard::Read(u32 src_address, s32 length, u8* dest_address)
 {
-  if (!IsAddressInBounds(src_address))
+  if (!IsAddressInBounds(src_address, length))
   {
     PanicAlertFmtT("MemoryCard: Read called with invalid source address ({0:#x})", src_address);
     return -1;
@@ -181,7 +181,7 @@ s32 MemoryCard::Read(u32 src_address, s32 length, u8* dest_address)
 
 s32 MemoryCard::Write(u32 dest_address, s32 length, const u8* src_address)
 {
-  if (!IsAddressInBounds(dest_address))
+  if (!IsAddressInBounds(dest_address, length))
   {
     PanicAlertFmtT("MemoryCard: Write called with invalid destination address ({0:#x})",
                    dest_address);
@@ -198,7 +198,7 @@ s32 MemoryCard::Write(u32 dest_address, s32 length, const u8* src_address)
 
 void MemoryCard::ClearBlock(u32 address)
 {
-  if (address & (Memcard::BLOCK_SIZE - 1) || !IsAddressInBounds(address))
+  if (address & (Memcard::BLOCK_SIZE - 1) || !IsAddressInBounds(address, Memcard::BLOCK_SIZE))
   {
     PanicAlertFmtT("MemoryCard: ClearBlock called on invalid address ({0:#x})", address);
     return;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.h
@@ -30,7 +30,7 @@ public:
   void DoState(PointerWrap& p) override;
 
 private:
-  bool IsAddressInBounds(u32 address) const { return address <= (m_memory_card_size - 1); }
+  bool IsAddressInBounds(u32 address, u32 length) const { return address + length <= (m_memory_card_size - 1); }
 
   std::string m_filename;
   std::unique_ptr<u8[]> m_memcard_data;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.h
@@ -30,7 +30,11 @@ public:
   void DoState(PointerWrap& p) override;
 
 private:
-  bool IsAddressInBounds(u32 address, u32 length) const { return address + length <= (m_memory_card_size - 1); }
+  bool IsAddressInBounds(u32 address, u32 length) const
+  {
+    u64 end_address = static_cast<u64>(address) + static_cast<u64>(length);
+    return end_address <= static_cast<u64>(m_memory_card_size);
+  }
 
   std::string m_filename;
   std::unique_ptr<u8[]> m_memcard_data;


### PR DESCRIPTION
The current implementation of [MemoryCard::IsAddressInBounds](https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.h#L33) only checks that the provided address  is in bounds, without checking that also address+length is in bounds.
This leads to heap buffer overflow in MemoryCard::{Read/Write/ClearBlock} functions.
This can be exploited to achieve RCE on the host.