### PR TITLE
VideoCommon: fix nibble order of 4-bit paletted textures (C4)

### DIFF
--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -379,7 +379,7 @@ static void WriteC4Encoder(ShaderCode& code, std::string_view comp, APIType api_
   WriteToBitDepth(code, 4, "color0", "color0");
   WriteToBitDepth(code, 4, "color1", "color1");
 
-  code.Write("  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
+  code.Write("  ocol0 = (color1 * 16.0 + color0) / 255.0;\n");
 }
 
 static void WriteC8Encoder(ShaderCode& code, std::string_view comp, APIType api_type,
@@ -969,7 +969,7 @@ static const std::map<TextureFormat, DecodingShaderInfo> s_decoding_shader_info{
 
         // Select high nibble for odd texels, low for even.
         uint val = FETCH(buffer_pos);
-        uint index = ((coords.x & 1u) == 0u) ? (val >> 4) : (val & 0x0Fu);
+        uint index = ((coords.x & 1u) == 0u) ? (val & 0x0Fu) : (val >> 4);
         float4 norm_color = GetPaletteColorNormalized(index);
         imageStore(output_image, int3(int2(coords), 0), norm_color);
       }

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -382,7 +382,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     u16 blkT = t & 7;
     u32 blkOff = (blkT << 3) + blkS;
 
-    int rs = (blkOff & 1) ? 0 : 4;
+    int rs = (blkOff & 1) ? 4 : 0;
     u32 offset = base + (blkOff >> 1);
 
     u8 val = (*(src + offset) >> rs) & 0xF;

--- a/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
@@ -77,8 +77,8 @@ static inline void DecodeBytes_C4(u32* dst, const u8* src, const u8* tlut_, TLUT
   for (int x = 0; x < 4; x++)
   {
     u8 val = src[x];
-    *dst++ = DecodePixel_Paletted(tlut[val >> 4], tlutfmt);
     *dst++ = DecodePixel_Paletted(tlut[val & 0xF], tlutfmt);
+    *dst++ = DecodePixel_Paletted(tlut[val >> 4], tlutfmt);
   }
 }
 

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -68,8 +68,8 @@ static inline void DecodeBytes_C4_IA8(u32* dst, const u8* src, const u8* tlut_)
   for (int x = 0; x < 4; x++)
   {
     u8 val = src[x];
-    *dst++ = DecodePixel_IA8(tlut[val >> 4]);
     *dst++ = DecodePixel_IA8(tlut[val & 0xF]);
+    *dst++ = DecodePixel_IA8(tlut[val >> 4]);
   }
 }
 
@@ -79,8 +79,8 @@ static inline void DecodeBytes_C4_RGB565(u32* dst, const u8* src, const u8* tlut
   for (int x = 0; x < 4; x++)
   {
     u8 val = src[x];
-    *dst++ = DecodePixel_RGB565(Common::swap16(tlut[val >> 4]));
     *dst++ = DecodePixel_RGB565(Common::swap16(tlut[val & 0xF]));
+    *dst++ = DecodePixel_RGB565(Common::swap16(tlut[val >> 4]));
   }
 }
 
@@ -90,8 +90,8 @@ static inline void DecodeBytes_C4_RGB5A3(u32* dst, const u8* src, const u8* tlut
   for (int x = 0; x < 4; x++)
   {
     u8 val = src[x];
-    *dst++ = DecodePixel_RGB5A3(Common::swap16(tlut[val >> 4]));
     *dst++ = DecodePixel_RGB5A3(Common::swap16(tlut[val & 0xF]));
+    *dst++ = DecodePixel_RGB5A3(Common::swap16(tlut[val >> 4]));
   }
 }
 


### PR DESCRIPTION
The low nibble is used for even texels. Funnily, the comment in the shader code was correct but the code didn't match.

This fixes https://bugs.dolphin-emu.org/issues/13370.