### PR TITLE
Qt/EnhancementsWidget: Fix size of resolution dropdown.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -73,7 +73,8 @@ void EnhancementsWidget::CreateWidgets()
       tr("720p"),         tr("1080p"),        tr("1440p"), QStringLiteral(""),
       tr("4K"),           QStringLiteral(""), tr("5K"),    QStringLiteral(""),
       QStringLiteral(""), QStringLiteral(""), tr("8K")};
-  const int visible_resolution_option_count = static_cast<int>(resolution_options.size());
+  const int visible_resolution_option_count = static_cast<int>(resolution_options.size()) +
+                                              static_cast<int>(resolution_extra_options.size());
 
   // If the current scale is greater than the max scale in the ini, add sufficient options so that
   // when the settings are saved we don't lose the user-modified value from the ini.


### PR DESCRIPTION
This got broken in #12171.

Currently this only shows two items by default, which is rather inconvenient:
https://cdn.discordapp.com/attachments/549875374327332884/1161284935747907594/image.png