### PR TITLE
VideoBackends:Vulkan: Fix pipeline lifetime when changing settings.

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -537,5 +537,12 @@ void CommandBufferManager::DeferImageViewDestruction(VkImageView object)
       [object]() { vkDestroyImageView(g_vulkan_context->GetDevice(), object, nullptr); });
 }
 
+void CommandBufferManager::DeferPipelineDestruction(VkPipeline object)
+{
+  CmdBufferResources& cmd_buffer_resources = GetCurrentCmdBufferResources();
+  cmd_buffer_resources.cleanup_resources.push_back(
+      [object]() { vkDestroyPipeline(g_vulkan_context->GetDevice(), object, nullptr); });
+}
+
 std::unique_ptr<CommandBufferManager> g_command_buffer_mgr;
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -93,6 +93,7 @@ public:
   void DeferFramebufferDestruction(VkFramebuffer object);
   void DeferImageDestruction(VkImage object, VmaAllocation alloc);
   void DeferImageViewDestruction(VkImageView object);
+  void DeferPipelineDestruction(VkPipeline object);
 
 private:
   bool CreateCommandBuffers();

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -8,6 +8,7 @@
 #include "Common/Assert.h"
 #include "Common/MsgHandler.h"
 
+#include "VideoBackends/Vulkan/CommandBufferManager.h"
 #include "VideoBackends/Vulkan/ObjectCache.h"
 #include "VideoBackends/Vulkan/VKShader.h"
 #include "VideoBackends/Vulkan/VKTexture.h"
@@ -27,7 +28,7 @@ VKPipeline::VKPipeline(const AbstractPipelineConfig& config, VkPipeline pipeline
 
 VKPipeline::~VKPipeline()
 {
-  vkDestroyPipeline(g_vulkan_context->GetDevice(), m_pipeline, nullptr);
+  g_command_buffer_mgr->DeferPipelineDestruction(m_pipeline);
 }
 
 static bool IsStripPrimitiveTopology(VkPrimitiveTopology topology)
@@ -68,8 +69,8 @@ static VkPipelineMultisampleStateCreateInfo GetVulkanMultisampleState(const Fram
 {
   return {
       VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,  // VkStructureType sType
-      nullptr,  // const void*                              pNext
-      0,        // VkPipelineMultisampleStateCreateFlags    flags
+      nullptr,                                                   // const void* pNext
+      0,                           // VkPipelineMultisampleStateCreateFlags flags
       static_cast<VkSampleCountFlagBits>(
           state.samples.Value()),  // VkSampleCountFlagBits                    rasterizationSamples
       static_cast<bool>(state.per_sample_shading),  // VkBool32 sampleShadingEnable


### PR DESCRIPTION
Changing the MSAA setting while the game is running makes us compile a new set of pipelines and throw away the old ones. We need to make sure the GPU is done with the old set of pipelines. The easiest way to handle this is inside the Vulkan backend by extending the mechanism we use for other resources.