### PR TITLE
Implement tapserver BBA type on all platforms

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
@@ -23,6 +23,12 @@ enum class StringSetting(
         "BBA_BUILTIN_DNS",
         "3.18.217.27"
     ),
+    MAIN_BBA_TAPSERVER_DESTINATION(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_CORE,
+        "BBA_TAPSERVER_DESTINATION",
+        "/tmp/dolphin-tap"
+    ),
     MAIN_CUSTOM_RTC_VALUE(
         Settings.FILE_DOLPHIN,
         Settings.SECTION_INI_CORE,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1111,7 +1111,6 @@ class SettingsFragmentPresenter(
                     R.string.bba_tapserver_destination_description
                 )
             )
-        }
         } else if (serialPort1Type == 12) {
             // Broadband Adapter (Built In)
             sl.add(

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1101,6 +1101,17 @@ class SettingsFragmentPresenter(
                     R.string.xlink_kai_bba_ip_description
                 )
             )
+        } else if (serialPort1Type == 11) {
+            // Broadband Adapter (tapserver)
+            sl.add(
+                InputStringSetting(
+                    context,
+                    StringSetting.MAIN_BBA_TAPSERVER_DESTINATION,
+                    R.string.bba_tapserver_destination,
+                    R.string.bba_tapserver_destination_description
+                )
+            )
+        }
         } else if (serialPort1Type == 12) {
             // Broadband Adapter (Built In)
             sl.add(

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -133,6 +133,8 @@
     <string name="xlink_kai_guide_header">For setup instructions, <a href="https://www.teamxlink.co.uk/wiki/Dolphin">refer to this page.</a></string>
     <string name="xlink_kai_bba_ip">XLink Kai IP Address/hostname</string>
     <string name="xlink_kai_bba_ip_description">IP address or hostname of device running the XLink Kai client</string>
+    <string name="bba_tapserver_destination">Tapserver destination</string>
+    <string name="bba_tapserver_destination_description">Enter the socket path or netloc (address:port) of the tapserver instance</string>
     <string name="bba_builtin_dns">DNS Server</string>
     <string name="bba_builtin_dns_description">Use 8.8.8.8 for normal DNS, else enter your custom one</string>
 

--- a/Source/Core/Common/SocketContext.cpp
+++ b/Source/Core/Common/SocketContext.cpp
@@ -8,12 +8,27 @@ namespace Common
 #ifdef _WIN32
 SocketContext::SocketContext()
 {
-  static_cast<void>(WSAStartup(MAKEWORD(2, 2), &m_data));
+  std::lock_guard<std::mutex> g(s_lock);
+  if (s_num_objects == 0)
+  {
+    static_cast<void>(WSAStartup(MAKEWORD(2, 2), &s_data));
+  }
+  s_num_objects++;
 }
 SocketContext::~SocketContext()
 {
-  WSACleanup();
+  std::lock_guard<std::mutex> g(s_lock);
+  s_num_objects--;
+  if (s_num_objects == 0)
+  {
+    WSACleanup();
+  }
 }
+
+std::mutex SocketContext::s_lock;
+size_t SocketContext::s_num_objects = 0;
+WSADATA SocketContext::s_data;
+
 #else
 SocketContext::SocketContext() = default;
 SocketContext::~SocketContext() = default;

--- a/Source/Core/Common/SocketContext.h
+++ b/Source/Core/Common/SocketContext.h
@@ -5,6 +5,7 @@
 
 #ifdef _WIN32
 #include <WinSock2.h>
+#include <mutex>
 #endif
 
 namespace Common
@@ -23,7 +24,9 @@ public:
 
 private:
 #ifdef _WIN32
-  WSADATA m_data;
+  static std::mutex s_lock;
+  static size_t s_num_objects;
+  static WSADATA s_data;
 #endif
 };
 }  // namespace Common

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -187,6 +187,10 @@ add_library(core
   HW/DVD/DVDThread.h
   HW/DVD/FileMonitor.cpp
   HW/DVD/FileMonitor.h
+  HW/EXI/BBA/TAPServer.cpp
+  HW/EXI/BBA/XLINK_KAI_BBA.cpp
+  HW/EXI/BBA/BuiltIn.cpp
+  HW/EXI/BBA/BuiltIn.h
   HW/EXI/EXI_Channel.cpp
   HW/EXI/EXI_Channel.h
   HW/EXI/EXI_Device.cpp
@@ -692,10 +696,6 @@ if(WIN32)
   target_sources(core PRIVATE
     HW/EXI/BBA/TAP_Win32.cpp
     HW/EXI/BBA/TAP_Win32.h
-    HW/EXI/BBA/TAPServer.cpp
-    HW/EXI/BBA/XLINK_KAI_BBA.cpp
-    HW/EXI/BBA/BuiltIn.cpp
-    HW/EXI/BBA/BuiltIn.h
     HW/WiimoteReal/IOWin.cpp
     HW/WiimoteReal/IOWin.h
   )
@@ -709,19 +709,11 @@ if(WIN32)
 elseif(APPLE)
   target_sources(core PRIVATE
     HW/EXI/BBA/TAP_Apple.cpp
-    HW/EXI/BBA/TAPServer.cpp
-    HW/EXI/BBA/XLINK_KAI_BBA.cpp
-    HW/EXI/BBA/BuiltIn.cpp
-    HW/EXI/BBA/BuiltIn.h
   )
   target_link_libraries(core PUBLIC ${IOB_LIBRARY})
 elseif(UNIX)
   target_sources(core PRIVATE
     HW/EXI/BBA/TAP_Unix.cpp
-    HW/EXI/BBA/TAPServer.cpp
-    HW/EXI/BBA/XLINK_KAI_BBA.cpp
-    HW/EXI/BBA/BuiltIn.cpp
-    HW/EXI/BBA/BuiltIn.h
   )
   if(ANDROID)
     target_sources(core PRIVATE

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -692,6 +692,7 @@ if(WIN32)
   target_sources(core PRIVATE
     HW/EXI/BBA/TAP_Win32.cpp
     HW/EXI/BBA/TAP_Win32.h
+    HW/EXI/BBA/TAPServer.cpp
     HW/EXI/BBA/XLINK_KAI_BBA.cpp
     HW/EXI/BBA/BuiltIn.cpp
     HW/EXI/BBA/BuiltIn.h
@@ -708,7 +709,7 @@ if(WIN32)
 elseif(APPLE)
   target_sources(core PRIVATE
     HW/EXI/BBA/TAP_Apple.cpp
-    HW/EXI/BBA/TAPServer_Apple.cpp
+    HW/EXI/BBA/TAPServer.cpp
     HW/EXI/BBA/XLINK_KAI_BBA.cpp
     HW/EXI/BBA/BuiltIn.cpp
     HW/EXI/BBA/BuiltIn.h
@@ -717,6 +718,7 @@ elseif(APPLE)
 elseif(UNIX)
   target_sources(core PRIVATE
     HW/EXI/BBA/TAP_Unix.cpp
+    HW/EXI/BBA/TAPServer.cpp
     HW/EXI/BBA/XLINK_KAI_BBA.cpp
     HW/EXI/BBA/BuiltIn.cpp
     HW/EXI/BBA/BuiltIn.h

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -135,6 +135,8 @@ const Info<bool> MAIN_BBA_XLINK_CHAT_OSD{{System::Main, "Core", "BBA_XLINK_CHAT_
 // Schthack PSO Server - https://schtserv.com/
 const Info<std::string> MAIN_BBA_BUILTIN_DNS{{System::Main, "Core", "BBA_BUILTIN_DNS"},
                                              "3.18.217.27"};
+const Info<std::string> MAIN_BBA_TAPSERVER_DESTINATION{
+    {System::Main, "Core", "BBA_TAPSERVER_DESTINATION"}, "/tmp/dolphin-tap"};
 const Info<std::string> MAIN_BBA_BUILTIN_IP{{System::Main, "Core", "BBA_BUILTIN_IP"}, ""};
 
 const Info<SerialInterface::SIDevices>& GetInfoForSIDevice(int channel)

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -95,6 +95,7 @@ extern const Info<std::string> MAIN_BBA_XLINK_IP;
 extern const Info<bool> MAIN_BBA_XLINK_CHAT_OSD;
 extern const Info<std::string> MAIN_BBA_BUILTIN_DNS;
 extern const Info<std::string> MAIN_BBA_BUILTIN_IP;
+extern const Info<std::string> MAIN_BBA_TAPSERVER_DESTINATION;
 const Info<SerialInterface::SIDevices>& GetInfoForSIDevice(int channel);
 const Info<bool>& GetInfoForAdapterRumble(int channel);
 const Info<bool>& GetInfoForSimulateKonga(int channel);

--- a/Source/Core/Core/HW/EXI/BBA/TAPServer.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAPServer.cpp
@@ -22,23 +22,38 @@
 namespace ExpansionInterface
 {
 
+#ifdef _WIN32
+static constexpr auto pi_close = &closesocket;
+using ws_ssize_t = int;
+#else
+static constexpr auto pi_close = &close;
+using ws_ssize_t = ssize_t;
+#endif
+
+#ifdef __LINUX__
+#define SEND_FLAGS MSG_NOSIGNAL
+#else
+#define SEND_FLAGS 0
+#endif
+
 static int ConnectToDestination(const std::string& destination)
 {
   if (destination.empty())
   {
-    INFO_LOG_FMT(SP1, "Cannot connect: destination is empty\n");
+    ERROR_LOG_FMT(SP1, "Cannot connect: destination is empty\n");
     return -1;
   }
 
-  size_t ss_size;
+  int ss_size;
   struct sockaddr_storage ss;
   memset(&ss, 0, sizeof(ss));
   if (destination[0] != '/')
-  {  // IP address or hostname
+  {
+    // IP address or hostname
     size_t colon_offset = destination.find(':');
     if (colon_offset == std::string::npos)
     {
-      INFO_LOG_FMT(SP1, "Destination IP address does not include port\n");
+      ERROR_LOG_FMT(SP1, "Destination IP address does not include port\n");
       return -1;
     }
 
@@ -50,11 +65,12 @@ static int ConnectToDestination(const std::string& destination)
 #ifndef _WIN32
   }
   else
-  {  // UNIX socket
+  {
+    // UNIX socket
     struct sockaddr_un* sun = reinterpret_cast<struct sockaddr_un*>(&ss);
     if (destination.size() + 1 > sizeof(sun->sun_path))
     {
-      INFO_LOG_FMT(SP1, "Socket path is too long, unable to init BBA\n");
+      ERROR_LOG_FMT(SP1, "Socket path is too long, unable to init BBA\n");
       return -1;
     }
     sun->sun_family = AF_UNIX;
@@ -64,7 +80,7 @@ static int ConnectToDestination(const std::string& destination)
   }
   else
   {
-    INFO_LOG_FMT(SP1, "UNIX sockets are not supported on Windows\n");
+    ERROR_LOG_FMT(SP1, "UNIX sockets are not supported on Windows\n");
     return -1;
 #endif
   }
@@ -72,7 +88,7 @@ static int ConnectToDestination(const std::string& destination)
   int fd = socket(ss.ss_family, SOCK_STREAM, (ss.ss_family == AF_INET) ? IPPROTO_TCP : 0);
   if (fd == -1)
   {
-    INFO_LOG_FMT(SP1, "Couldn't create socket; unable to init BBA\n");
+    ERROR_LOG_FMT(SP1, "Couldn't create socket; unable to init BBA\n");
     return -1;
   }
 
@@ -86,7 +102,7 @@ static int ConnectToDestination(const std::string& destination)
   {
     std::string s = Common::LastStrerrorString();
     INFO_LOG_FMT(SP1, "Couldn't connect socket ({}), unable to init BBA\n", s.c_str());
-    close(fd);
+    pi_close(fd);
     return -1;
   }
 
@@ -98,10 +114,42 @@ bool CEXIETHERNET::TAPServerNetworkInterface::Activate()
   if (IsActivated())
     return true;
 
-  fd = ConnectToDestination(m_destination);
+  m_fd = ConnectToDestination(m_destination);
 
   INFO_LOG_FMT(SP1, "BBA initialized.");
   return RecvInit();
+}
+
+void CEXIETHERNET::TAPServerNetworkInterface::Deactivate()
+{
+  pi_close(m_fd);
+  m_fd = -1;
+
+  m_read_enabled.Clear();
+  m_read_shutdown.Set();
+  if (m_read_thread.joinable())
+    m_read_thread.join();
+}
+
+bool CEXIETHERNET::TAPServerNetworkInterface::IsActivated()
+{
+  return (m_fd >= 0);
+}
+
+bool CEXIETHERNET::TAPServerNetworkInterface::RecvInit()
+{
+  m_read_thread = std::thread(&CEXIETHERNET::TAPServerNetworkInterface::ReadThreadHandler, this);
+  return true;
+}
+
+void CEXIETHERNET::TAPServerNetworkInterface::RecvStart()
+{
+  m_read_enabled.Set();
+}
+
+void CEXIETHERNET::TAPServerNetworkInterface::RecvStop()
+{
+  m_read_enabled.Clear();
 }
 
 bool CEXIETHERNET::TAPServerNetworkInterface::SendFrame(const u8* frame, u32 size)
@@ -111,13 +159,16 @@ bool CEXIETHERNET::TAPServerNetworkInterface::SendFrame(const u8* frame, u32 siz
     INFO_LOG_FMT(SP1, "SendFrame {}\n{}", size, s);
   }
 
-  auto size16 = u16(size);
-  if (write(fd, &size16, 2) != 2)
+  // On Windows, the data pointer is of type const char*; on other systems it is
+  // of type const void*. This is the reason for the reinterpret_cast here and
+  // in the other send/recv calls in this file.
+  u8 size_bytes[2] = {static_cast<u8>(size), static_cast<u8>(size >> 8)};
+  if (send(m_fd, reinterpret_cast<const char*>(size_bytes), 2, SEND_FLAGS) != 2)
   {
     ERROR_LOG_FMT(SP1, "SendFrame(): could not write size field");
     return false;
   }
-  int written_bytes = write(fd, frame, size);
+  int written_bytes = send(m_fd, reinterpret_cast<const char*>(frame), size, SEND_FLAGS);
   if (u32(written_bytes) != size)
   {
     ERROR_LOG_FMT(SP1, "SendFrame(): expected to write {} bytes, instead wrote {}", size,
@@ -133,45 +184,122 @@ bool CEXIETHERNET::TAPServerNetworkInterface::SendFrame(const u8* frame, u32 siz
 
 void CEXIETHERNET::TAPServerNetworkInterface::ReadThreadHandler()
 {
-  while (!readThreadShutdown.IsSet())
+  while (!m_read_shutdown.IsSet())
   {
     fd_set rfds;
     FD_ZERO(&rfds);
-    FD_SET(fd, &rfds);
+    FD_SET(m_fd, &rfds);
 
     timeval timeout;
     timeout.tv_sec = 0;
     timeout.tv_usec = 50000;
-    if (select(fd + 1, &rfds, nullptr, nullptr, &timeout) <= 0)
+    if (select(m_fd + 1, &rfds, nullptr, nullptr, &timeout) <= 0)
       continue;
 
-    u16 size;
-    if (read(fd, &size, 2) != 2)
+    // The tapserver protocol is very simple: there is a 16-bit little-endian
+    // size field, followed by that many bytes of packet data
+    switch (m_read_state)
     {
-      ERROR_LOG_FMT(SP1, "Failed to read size field from BBA: {}", Common::LastStrerrorString());
+    case ReadState::Size:
+    {
+      u8 size_bytes[2];
+      ws_ssize_t bytes_read = recv(m_fd, reinterpret_cast<char*>(size_bytes), 2, 0);
+      if (bytes_read == 1)
+      {
+        m_read_state = ReadState::SizeHigh;
+        m_read_packet_bytes_remaining = size_bytes[0];
+      }
+      else if (bytes_read == 2)
+      {
+        m_read_packet_bytes_remaining = size_bytes[0] | (size_bytes[1] << 8);
+        if (m_read_packet_bytes_remaining > BBA_RECV_SIZE)
+        {
+          ERROR_LOG_FMT(SP1, "Packet is too large ({} bytes); dropping it",
+                        m_read_packet_bytes_remaining);
+          m_read_state = ReadState::Skip;
+        }
+        else
+        {
+          m_read_state = ReadState::Data;
+        }
+      }
+      else
+      {
+        ERROR_LOG_FMT(SP1, "Failed to read size field from BBA: {}", Common::LastStrerrorString());
+      }
+      break;
     }
-    else
+    case ReadState::SizeHigh:
     {
-      int read_bytes = read(fd, m_eth_ref->mRecvBuffer.get(), size);
-      if (read_bytes < 0)
+      // This handles the annoying case where only one byte of the size field
+      // was available earlier.
+      u8 size_high = 0;
+      ws_ssize_t bytes_read = recv(m_fd, reinterpret_cast<char*>(&size_high), 1, 0);
+      if (bytes_read == 1)
       {
-        ERROR_LOG_FMT(SP1, "Failed to read packet data from BBA: {}", Common::LastStrerrorString());
+        m_read_packet_bytes_remaining |= (size_high << 8);
+        if (m_read_packet_bytes_remaining > BBA_RECV_SIZE)
+        {
+          ERROR_LOG_FMT(SP1, "Packet is too large ({} bytes); dropping it",
+                        m_read_packet_bytes_remaining);
+          m_read_state = ReadState::Skip;
+        }
+        else
+        {
+          m_read_state = ReadState::Data;
+        }
       }
-      else if (readEnabled.IsSet())
+      else
       {
-        std::string data_string = ArrayToString(m_eth_ref->mRecvBuffer.get(), read_bytes, 0x10);
-        INFO_LOG_FMT(SP1, "Read data: {}", data_string);
-        m_eth_ref->mRecvBufferLength = read_bytes;
-        m_eth_ref->RecvHandlePacket();
+        ERROR_LOG_FMT(SP1, "Failed to read split size field from BBA: {}",
+                      Common::LastStrerrorString());
       }
+      break;
+    }
+    case ReadState::Data:
+    {
+      ws_ssize_t bytes_read =
+          recv(m_fd, reinterpret_cast<char*>(m_eth_ref->mRecvBuffer.get() + m_read_packet_offset),
+               m_read_packet_bytes_remaining, 0);
+      if (bytes_read <= 0)
+      {
+        ERROR_LOG_FMT(SP1, "Failed to read data from BBA: {}", Common::LastStrerrorString());
+      }
+      else
+      {
+        m_read_packet_offset += bytes_read;
+        m_read_packet_bytes_remaining -= bytes_read;
+        if (m_read_packet_bytes_remaining == 0)
+        {
+          m_eth_ref->mRecvBufferLength = m_read_packet_offset;
+          m_eth_ref->RecvHandlePacket();
+          m_read_state = ReadState::Size;
+          m_read_packet_offset = 0;
+        }
+      }
+      break;
+    }
+    case ReadState::Skip:
+    {
+      ws_ssize_t bytes_read = recv(m_fd, reinterpret_cast<char*>(m_eth_ref->mRecvBuffer.get()),
+                                   std::min<int>(m_read_packet_bytes_remaining, BBA_RECV_SIZE), 0);
+      if (bytes_read <= 0)
+      {
+        ERROR_LOG_FMT(SP1, "Failed to read data from BBA: {}", Common::LastStrerrorString());
+      }
+      else
+      {
+        m_read_packet_bytes_remaining -= bytes_read;
+        if (m_read_packet_bytes_remaining == 0)
+        {
+          m_read_state = ReadState::Size;
+          m_read_packet_offset = 0;
+        }
+      }
+      break;
+    }
     }
   }
-}
-
-bool CEXIETHERNET::TAPServerNetworkInterface::RecvInit()
-{
-  readThread = std::thread(&CEXIETHERNET::TAPServerNetworkInterface::ReadThreadHandler, this);
-  return true;
 }
 
 }  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Device.cpp
@@ -137,11 +137,9 @@ std::unique_ptr<IEXIDevice> EXIDevice_Create(Core::System& system, const EXIDevi
     result = std::make_unique<CEXIETHERNET>(system, BBADeviceType::TAP);
     break;
 
-#if defined(__APPLE__)
   case EXIDeviceType::EthernetTapServer:
     result = std::make_unique<CEXIETHERNET>(system, BBADeviceType::TAPSERVER);
     break;
-#endif
 
   case EXIDeviceType::EthernetXLink:
     result = std::make_unique<CEXIETHERNET>(system, BBADeviceType::XLINK);

--- a/Source/Core/Core/HW/EXI/EXI_Device.h
+++ b/Source/Core/Core/HW/EXI/EXI_Device.h
@@ -39,7 +39,6 @@ enum class EXIDeviceType : int
   MemoryCardFolder,
   AGP,
   EthernetXLink,
-  // Only used on Apple devices.
   EthernetTapServer,
   EthernetBuiltIn,
   None = 0xFF

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -50,12 +50,11 @@ CEXIETHERNET::CEXIETHERNET(Core::System& system, BBADeviceType type) : IEXIDevic
     m_network_interface = std::make_unique<TAPNetworkInterface>(this);
     INFO_LOG_FMT(SP1, "Created TAP physical network interface.");
     break;
-#if defined(__APPLE__)
   case BBADeviceType::TAPSERVER:
-    m_network_interface = std::make_unique<TAPServerNetworkInterface>(this);
+    m_network_interface = std::make_unique<TAPServerNetworkInterface>(
+        this, Config::Get(Config::MAIN_BBA_TAPSERVER_DESTINATION));
     INFO_LOG_FMT(SP1, "Created tapserver physical network interface.");
     break;
-#endif
   case BBADeviceType::BuiltIn:
     m_network_interface = std::make_unique<BuiltInBBAInterface>(
         this, Config::Get(Config::MAIN_BBA_BUILTIN_DNS), Config::Get(Config::MAIN_BBA_BUILTIN_IP));

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -205,9 +205,7 @@ enum class BBADeviceType
 {
   TAP,
   XLINK,
-#if defined(__APPLE__)
   TAPSERVER,
-#endif
   BuiltIn,
 };
 
@@ -364,11 +362,13 @@ private:
 #endif
   };
 
-#if defined(__APPLE__)
   class TAPServerNetworkInterface : public TAPNetworkInterface
   {
   public:
-    explicit TAPServerNetworkInterface(CEXIETHERNET* eth_ref) : TAPNetworkInterface(eth_ref) {}
+    explicit TAPServerNetworkInterface(CEXIETHERNET* eth_ref, const std::string& destination)
+        : TAPNetworkInterface(eth_ref), m_destination(destination)
+    {
+    }
 
   public:
     bool Activate() override;
@@ -376,9 +376,10 @@ private:
     bool RecvInit() override;
 
   private:
+    std::string m_destination;
+
     void ReadThreadHandler();
   };
-#endif
 
   class XLinkNetworkInterface : public NetworkInterface
   {

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -915,6 +915,7 @@
     <ClCompile Include="Core\HW\DVD\FileMonitor.cpp" />
     <ClCompile Include="Core\HW\EXI\BBA\BuiltIn.cpp" />
     <ClCompile Include="Core\HW\EXI\BBA\TAP_Win32.cpp" />
+    <ClCompile Include="Core\HW\EXI\BBA\TAPServer.cpp" />
     <ClCompile Include="Core\HW\EXI\BBA\XLINK_KAI_BBA.cpp" />
     <ClCompile Include="Core\HW\EXI\EXI_Channel.cpp" />
     <ClCompile Include="Core\HW\EXI\EXI_Device.cpp" />

--- a/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.cpp
@@ -49,13 +49,19 @@ void BroadbandAdapterSettingsDialog::InitControls()
     break;
 
   case Type::TapServer:
-    address_label = new QLabel(tr("UNIX socket path or netloc (address:port):"));
-    address_placeholder = QStringLiteral("/tmp/dolphin-tap");
     current_address = QString::fromStdString(Config::Get(Config::MAIN_BBA_TAPSERVER_DESTINATION));
-    description =
-        new QLabel(tr("On macOS and Linux, the default value \"/tmp/dolphin-tap\" will work with "
-                      "tapserver and newserv. On Windows, you must enter an IP address and port."));
-
+#ifdef _WIN32
+    address_label = new QLabel(tr("Destination (address:port):"));
+    address_placeholder = QStringLiteral("");
+    description = new QLabel(
+        tr("Enter the IP address and port of the tapserver instance you want to connect to."));
+#else
+    address_label = new QLabel(tr("Destination (UNIX socket path or address:port):"));
+    address_placeholder = QStringLiteral("/tmp/dolphin-tap");
+    description = new QLabel(tr(
+        "The default value \"/tmp/dolphin-tap\" will work with a local tapserver and newserv. You "
+        "can also enter a network location (address:port) to connect to a remote tapserver."));
+#endif
     window_title = tr("BBA destination address");
     break;
 

--- a/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.cpp
@@ -48,6 +48,17 @@ void BroadbandAdapterSettingsDialog::InitControls()
     window_title = tr("Broadband Adapter MAC Address");
     break;
 
+  case Type::TapServer:
+    address_label = new QLabel(tr("UNIX socket path or netloc (address:port):"));
+    address_placeholder = QStringLiteral("/tmp/dolphin-tap");
+    current_address = QString::fromStdString(Config::Get(Config::MAIN_BBA_TAPSERVER_DESTINATION));
+    description =
+        new QLabel(tr("On macOS and Linux, the default value \"/tmp/dolphin-tap\" will work with "
+                      "tapserver and newserv. On Windows, you must enter an IP address and port."));
+
+    window_title = tr("BBA destination address");
+    break;
+
   case Type::BuiltIn:
     address_label = new QLabel(tr("Enter the DNS server to use:"));
     address_placeholder = QStringLiteral("8.8.8.8");
@@ -114,6 +125,9 @@ void BroadbandAdapterSettingsDialog::SaveAddress()
     Config::SetBaseOrCurrent(Config::MAIN_BBA_MAC, bba_new_address);
     break;
   }
+  case Type::TapServer:
+    Config::SetBaseOrCurrent(Config::MAIN_BBA_TAPSERVER_DESTINATION, bba_new_address);
+    break;
   case Type::BuiltIn:
     Config::SetBaseOrCurrent(Config::MAIN_BBA_BUILTIN_DNS, bba_new_address);
     break;

--- a/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.h
+++ b/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.h
@@ -15,6 +15,7 @@ public:
   {
     Ethernet,
     XLinkKai,
+    TapServer,
     BuiltIn
   };
 

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -149,9 +149,7 @@ void GameCubePane::CreateWidgets()
            EXIDeviceType::Dummy,
            EXIDeviceType::Ethernet,
            EXIDeviceType::EthernetXLink,
-#ifdef __APPLE__
            EXIDeviceType::EthernetTapServer,
-#endif
            EXIDeviceType::EthernetBuiltIn,
        })
   {
@@ -355,6 +353,7 @@ void GameCubePane::UpdateButton(ExpansionInterface::Slot slot)
   case ExpansionInterface::Slot::SP1:
     has_config = (device == ExpansionInterface::EXIDeviceType::Ethernet ||
                   device == ExpansionInterface::EXIDeviceType::EthernetXLink ||
+                  device == ExpansionInterface::EXIDeviceType::EthernetTapServer ||
                   device == ExpansionInterface::EXIDeviceType::EthernetBuiltIn);
     break;
   }
@@ -396,6 +395,13 @@ void GameCubePane::OnConfigPressed(ExpansionInterface::Slot slot)
   case ExpansionInterface::EXIDeviceType::EthernetXLink:
   {
     BroadbandAdapterSettingsDialog dialog(this, BroadbandAdapterSettingsDialog::Type::XLinkKai);
+    SetQWidgetWindowDecorations(&dialog);
+    dialog.exec();
+    return;
+  }
+  case ExpansionInterface::EXIDeviceType::EthernetTapServer:
+  {
+    BroadbandAdapterSettingsDialog dialog(this, BroadbandAdapterSettingsDialog::Type::TapServer);
     SetQWidgetWindowDecorations(&dialog);
     dialog.exec();
     return;


### PR DESCRIPTION
This expands the tapserver BBA interface to be available on all platforms. tapserver itself is still macOS-only, but newserv (the PSO server) is not, and it can directly accept local and remote tapserver connections as well. This makes the tapserver interface potentially useful on all platforms.

This change also allows the tapserver destination to be configured (so a remote server can be used) and fixes the issue with SIGPIPE killing Dolphin on macOS when the socket is closed by the server.