### PR TITLE
DolphinQt: Move GraphicsModListWidget::ClearLayoutRecursively() to QtUtils.

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -279,6 +279,8 @@ add_executable(dolphin-emu
   QtUtils/AspectRatioWidget.h
   QtUtils/BlockUserInputFilter.cpp
   QtUtils/BlockUserInputFilter.h
+  QtUtils/ClearLayoutRecursively.cpp
+  QtUtils/ClearLayoutRecursively.h
   QtUtils/DolphinFileDialog.cpp
   QtUtils/DolphinFileDialog.h
   QtUtils/DoubleClickEventFilter.cpp

--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
@@ -19,6 +19,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "DolphinQt/Config/GraphicsModWarningWidget.h"
+#include "DolphinQt/QtUtils/ClearLayoutRecursively.h"
 #include "DolphinQt/Settings.h"
 #include "UICommon/GameFile.h"
 #include "VideoCommon/GraphicsModSystem/Config/GraphicsMod.h"
@@ -238,31 +239,6 @@ void GraphicsModListWidget::SaveModList()
     g_Config.graphics_mod_config = m_mod_group;
   }
   m_needs_save = true;
-}
-
-void GraphicsModListWidget::ClearLayoutRecursively(QLayout* layout)
-{
-  while (QLayoutItem* child = layout->takeAt(0))
-  {
-    if (child == nullptr)
-      continue;
-
-    if (child->widget())
-    {
-      layout->removeWidget(child->widget());
-      delete child->widget();
-    }
-    else if (child->layout())
-    {
-      ClearLayoutRecursively(child->layout());
-      layout->removeItem(child);
-    }
-    else
-    {
-      layout->removeItem(child);
-    }
-    delete child;
-  }
 }
 
 void GraphicsModListWidget::SaveToDisk()

--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.h
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.h
@@ -56,8 +56,6 @@ private:
 
   void SaveModList();
 
-  void ClearLayoutRecursively(QLayout* layout);
-
   void OpenGraphicsModDir();
 
   void CalculateGameRunning(Core::State state);

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -181,6 +181,7 @@
     </ClCompile>
     <ClCompile Include="QtUtils\AspectRatioWidget.cpp" />
     <ClCompile Include="QtUtils\BlockUserInputFilter.cpp" />
+    <ClCompile Include="QtUtils\ClearLayoutRecursively.cpp" />
     <ClCompile Include="QtUtils\DolphinFileDialog.cpp" />
     <ClCompile Include="QtUtils\DoubleClickEventFilter.cpp" />
     <ClCompile Include="QtUtils\ElidedButton.cpp" />
@@ -240,6 +241,7 @@
     <ClInclude Include="Debugger\RegisterColumn.h" />
     <ClInclude Include="GBAHost.h" />
     <ClInclude Include="QtUtils\ActionHelper.h" />
+    <ClInclude Include="QtUtils\ClearLayoutRecursively.h" />
     <ClInclude Include="QtUtils\DolphinFileDialog.h" />
     <ClInclude Include="QtUtils\ImageConverter.h" />
     <ClInclude Include="QtUtils\ModalMessageBox.h" />

--- a/Source/Core/DolphinQt/QtUtils/ClearLayoutRecursively.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ClearLayoutRecursively.cpp
@@ -1,0 +1,33 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/QtUtils/ClearLayoutRecursively.h"
+
+#include <QLayout>
+#include <QLayoutItem>
+#include <QWidget>
+
+void ClearLayoutRecursively(QLayout* layout)
+{
+  while (QLayoutItem* child = layout->takeAt(0))
+  {
+    if (child == nullptr)
+      continue;
+
+    if (child->widget())
+    {
+      layout->removeWidget(child->widget());
+      delete child->widget();
+    }
+    else if (child->layout())
+    {
+      ClearLayoutRecursively(child->layout());
+      layout->removeItem(child);
+    }
+    else
+    {
+      layout->removeItem(child);
+    }
+    delete child;
+  }
+}

--- a/Source/Core/DolphinQt/QtUtils/ClearLayoutRecursively.h
+++ b/Source/Core/DolphinQt/QtUtils/ClearLayoutRecursively.h
@@ -1,0 +1,8 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+class QLayout;
+
+void ClearLayoutRecursively(QLayout* layout);


### PR DESCRIPTION
This is needed over in #12027 to avoid memory leaks.