### PR TITLE
VideoCommon: add additional data types to material asset

### DIFF
--- a/Source/Core/VideoCommon/Assets/MaterialAsset.h
+++ b/Source/Core/VideoCommon/Assets/MaterialAsset.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <optional>
+#include <array>
 #include <string>
 #include <variant>
 #include <vector>
@@ -14,20 +14,20 @@
 #include "Common/EnumFormatter.h"
 #include "VideoCommon/Assets/CustomAsset.h"
 
+class ShaderCode;
+
 namespace VideoCommon
 {
 struct MaterialProperty
 {
-  using Value = std::variant<std::string>;
-  enum class Type
-  {
-    Type_Undefined,
-    Type_TextureAsset,
-    Type_Max = Type_TextureAsset
-  };
+  static void WriteToMemory(u8*& buffer, const MaterialProperty& property);
+  static std::size_t GetMemorySize(const MaterialProperty& property);
+  static void WriteAsShaderCode(ShaderCode& shader_source, const MaterialProperty& property);
+  using Value = std::variant<CustomAssetLibrary::AssetID, s32, std::array<s32, 2>,
+                             std::array<s32, 3>, std::array<s32, 4>, float, std::array<float, 2>,
+                             std::array<float, 3>, std::array<float, 4>, bool>;
   std::string m_code_name;
-  Type m_type = Type::Type_Undefined;
-  std::optional<Value> m_value;
+  Value m_value;
 };
 
 struct MaterialData
@@ -52,10 +52,3 @@ private:
 };
 
 }  // namespace VideoCommon
-
-template <>
-struct fmt::formatter<VideoCommon::MaterialProperty::Type>
-    : EnumFormatter<VideoCommon::MaterialProperty::Type::Type_Max>
-{
-  constexpr formatter() : EnumFormatter({"Undefined", "Texture"}) {}
-};

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/CustomPipelineAction.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/CustomPipelineAction.cpp
@@ -393,21 +393,15 @@ void CustomPipelineAction::OnTextureCreate(GraphicsModActionData::TextureCreate*
       return;
     }
 
-    if (property.m_type == VideoCommon::MaterialProperty::Type::Type_TextureAsset)
+    if (auto* value = std::get_if<std::string>(&property.m_value))
     {
-      if (property.m_value)
+      auto asset = loader.LoadGameTexture(*value, m_library);
+      if (asset)
       {
-        if (auto* value = std::get_if<std::string>(&*property.m_value))
-        {
-          auto asset = loader.LoadGameTexture(*value, m_library);
-          if (asset)
-          {
-            const auto loaded_time = asset->GetLastLoadedTime();
-            game_assets.push_back(VideoCommon::CachedAsset<VideoCommon::GameTextureAsset>{
-                std::move(asset), loaded_time});
-            m_texture_code_names.push_back(property.m_code_name);
-          }
-        }
+        const auto loaded_time = asset->GetLastLoadedTime();
+        game_assets.push_back(
+            VideoCommon::CachedAsset<VideoCommon::GameTextureAsset>{std::move(asset), loaded_time});
+        m_texture_code_names.push_back(property.m_code_name);
       }
     }
   }


### PR DESCRIPTION
This is another PR for adding support for custom shader uniforms to Dolphin.  This time, we extend the Material asset to include additional properties (int, int2, ... float, float2,...bool) and add some helper functions to get the material data to the GPU (not used yet, will be used in a future PR).