### PR TITLE
RetroAchievements - Challenge Icons

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <ctime>
 #include <functional>
+#include <map>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -23,6 +24,11 @@
 namespace Core
 {
 class System;
+}
+
+namespace OSD
+{
+struct Icon;
 }
 
 class AchievementManager
@@ -61,6 +67,7 @@ public:
   static constexpr size_t RP_SIZE = 256;
   using RichPresence = std::array<char, RP_SIZE>;
   using Badge = std::vector<u8>;
+  using NamedIconMap = std::map<std::string, std::unique_ptr<OSD::Icon>, std::less<>>;
 
   struct BadgeStatus
   {
@@ -138,6 +145,7 @@ public:
   RichPresence GetRichPresence();
   bool IsDisabled() const { return m_disabled; };
   void SetDisabled(bool disabled);
+  const NamedIconMap& GetChallengeIcons() const;
 
   void CloseGame();
   void Logout();
@@ -180,6 +188,8 @@ private:
 
   void HandleAchievementTriggeredEvent(const rc_runtime_event_t* runtime_event);
   void HandleAchievementProgressUpdatedEvent(const rc_runtime_event_t* runtime_event);
+  void HandleAchievementPrimedEvent(const rc_runtime_event_t* runtime_event);
+  void HandleAchievementUnprimedEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardStartedEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardCanceledEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardTriggeredEvent(const rc_runtime_event_t* runtime_event);
@@ -210,6 +220,7 @@ private:
 
   std::unordered_map<AchievementId, UnlockStatus> m_unlock_map;
   std::unordered_map<AchievementId, LeaderboardStatus> m_leaderboard_map;
+  NamedIconMap m_active_challenges;
 
   Common::WorkQueueThread<std::function<void()>> m_queue;
   Common::WorkQueueThread<std::function<void()>> m_image_queue;

--- a/Source/Core/VideoCommon/OnScreenUI.h
+++ b/Source/Core/VideoCommon/OnScreenUI.h
@@ -61,6 +61,9 @@ public:
 
 private:
   void DrawDebugText();
+#ifdef USE_RETRO_ACHIEVEMENTS
+  void DrawChallenges();
+#endif  // USE_RETRO_ACHIEVEMENTS
 
   // ImGui resources.
   std::unique_ptr<NativeVertexFormat> m_imgui_vertex_format;
@@ -73,6 +76,10 @@ private:
   u32 m_backbuffer_width = 1;
   u32 m_backbuffer_height = 1;
   float m_backbuffer_scale = 1.0;
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+  std::map<std::string, std::unique_ptr<AbstractTexture>, std::less<>> m_challenge_texture_map;
+#endif  // USE_RETRO_ACHIEVEMENTS
 
   bool m_ready = false;
 };


### PR DESCRIPTION
This is a portion of an integration with the RetroAchievements tools and libraries for connecting to the website, downloading data, unlocking achievements and submitting to leaderboards for games running in Dolphin. In this PR, I handle achievement events for when a "challenge" is "primed" or unprimed, and display the results on screen.
A "challenge" (not an official term) in this context is the completion of a portion of a game while meeting certain optional conditions. Examples would be completing a level in under a certain amount of time or a boss fight without taking damage. While a challenge is currently active, emulators that support RetroAchievements will display the achievement's badge in the corner of the screen to denote that the challenge is still active and valid. If the player completes the achievement's requirements while the badge is on screen, it will be rewarded; if the player fails the challenge (eg from above, once too much time elapses or once the player takes damage) the icon will be removed, denoting that the challenge is no longer active.
In the official RetroAchievements terminology, the runtime will emit an AchievementPrimedEvent when a challenge becomes active and an AchievementUnprimedEvent when it deactivates, whether the challenge was failed or completed. The achievement logic uses the denotation "Trigger" on the portion of the achievement logic that is _not_ the challenge; when every portion of the logic is true _except_ the trigger the achievement is primed, and then when the trigger is also true the achievement is rewarded. This terminology is a bit unwieldy so I use the term "challenge" to denote when the achievement is primed.