### PR TITLE
CheatSearch: Use std comparison function objects

### DIFF
--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -424,17 +424,17 @@ MakeCompareFunctionForLastValue(Cheats::CompareType op)
   switch (op)
   {
   case Cheats::CompareType::Equal:
-    return [](const T& new_value, const T& old_value) { return new_value == old_value; };
+    return std::equal_to<T>();
   case Cheats::CompareType::NotEqual:
-    return [](const T& new_value, const T& old_value) { return new_value != old_value; };
+    return std::not_equal_to<T>();
   case Cheats::CompareType::Less:
-    return [](const T& new_value, const T& old_value) { return new_value < old_value; };
+    return std::less<T>();
   case Cheats::CompareType::LessOrEqual:
-    return [](const T& new_value, const T& old_value) { return new_value <= old_value; };
+    return std::less_equal<T>();
   case Cheats::CompareType::Greater:
-    return [](const T& new_value, const T& old_value) { return new_value > old_value; };
+    return std::greater<T>();
   case Cheats::CompareType::GreaterOrEqual:
-    return [](const T& new_value, const T& old_value) { return new_value >= old_value; };
+    return std::greater_equal<T>();
   default:
     DEBUG_ASSERT(false);
     return nullptr;


### PR DESCRIPTION
Use std::equal_to<T>() and so on for the last value comparison functions since they exist and we already include the functional header.

I didn't replace the functions used for comparing against a specific value because I'd need to use bind and it's not really any clearer or less verbose than the lambda.