### PR TITLE
Fix shader compiles on Asahi Linux

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLConfig.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.cpp
@@ -287,10 +287,6 @@ bool PopulateConfig(GLContext* m_main_gl_context)
   g_Config.backend_info.bSupportsPrimitiveRestart =
       !DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVE_RESTART) &&
       ((GLExtensions::Version() >= 310) || GLExtensions::Supports("GL_NV_primitive_restart"));
-  g_Config.backend_info.bSupportsFragmentStoresAndAtomics =
-      GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
-  g_Config.backend_info.bSupportsVSLinePointExpand =
-      GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
   g_Config.backend_info.bSupportsGSInstancing = GLExtensions::Supports("GL_ARB_gpu_shader5");
   g_Config.backend_info.bSupportsSSAA = GLExtensions::Supports("GL_ARB_gpu_shader5") &&
                                         GLExtensions::Supports("GL_ARB_sample_shading");
@@ -350,6 +346,21 @@ bool PopulateConfig(GLContext* m_main_gl_context)
       GLExtensions::Supports("GL_ARB_derivative_control") || GLExtensions::Version() >= 450;
   g_Config.backend_info.bSupportsTextureQueryLevels =
       GLExtensions::Supports("GL_ARB_texture_query_levels") || GLExtensions::Version() >= 430;
+
+  if (GLExtensions::Supports("GL_ARB_shader_storage_buffer_object"))
+  {
+    GLint fs = 0;
+    GLint vs = 0;
+    glGetIntegerv(GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS, &fs);
+    glGetIntegerv(GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS, &vs);
+    g_Config.backend_info.bSupportsFragmentStoresAndAtomics = fs >= 1;
+    g_Config.backend_info.bSupportsVSLinePointExpand = vs >= 1;
+  }
+  else
+  {
+    g_Config.backend_info.bSupportsFragmentStoresAndAtomics = false;
+    g_Config.backend_info.bSupportsVSLinePointExpand = false;
+  }
 
   if (GLExtensions::Supports("GL_EXT_shader_framebuffer_fetch"))
   {

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -101,7 +101,7 @@ SSBO_BINDING(1) readonly restrict buffer Vertices {{
     out.Write(R"(
 uint4 load_input_uint4_ubyte4(uint vtx_offset, uint attr_offset) {{
   uint value = vertex_buffer[vtx_offset + attr_offset];
-  return uint4(value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, value >> 24);
+  return uint4(value & 0xffu, (value >> 8) & 0xffu, (value >> 16) & 0xffu, value >> 24);
 }}
 
 float4 load_input_float4_ubyte4(uint vtx_offset, uint attr_offset) {{

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -149,7 +149,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     // Can't use float3, etc because we want 4-byte alignment
     out.Write(
         "uint4 unpack_ubyte4(uint value) {{\n"
-        "  return uint4(value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, value >> 24);\n"
+        "  return uint4(value & 0xffu, (value >> 8) & 0xffu, (value >> 16) & 0xffu, value >> 24);\n"
         "}}\n\n"
         "struct InputData {{\n");
     if (uid_data->components & VB_HAS_POSMTXIDX)
@@ -271,7 +271,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     if (api_type == APIType::D3D)
       out.Write("uint vertex_id = (gl_VertexID >> 2) + base_vertex;\n");
     else
-      out.Write("uint vertex_id = gl_VertexID >> 2;\n");
+      out.Write("uint vertex_id = uint(gl_VertexID) >> 2u;\n");
     out.Write("InputData i = input_buffer[vertex_id];\n"
               "{}",
               input_extract.GetBuffer());
@@ -524,9 +524,9 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     out.Write("// Line expansion\n"
               "uint other_id = vertex_id;\n"
               "if (is_bottom) {{\n"
-              "  other_id -= 1;\n"
+              "  other_id -= 1u;\n"
               "}} else {{\n"
-              "  other_id += 1;\n"
+              "  other_id += 1u;\n"
               "}}\n"
               "InputData other = input_buffer[other_id];\n");
     if (uid_data->position_has_3_elems)


### PR DESCRIPTION
Fixes some mishandling of drivers with features of an ancient GPU but some much newer extensions like Asahi Linux (e.g. GL 3.2 with SSBOs supported only in fragment shaders)

Note: We still fail to compile fbfetch shaders, I'll handle those later