### PR TITLE
Core: Fix UI slowdown for savestate timestamp reads

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -560,7 +560,8 @@ static bool GetVersionFromLZO(StateHeader& header, File::IOFile& f)
   return true;
 }
 
-static bool ReadStateHeaderFromFile(StateHeader& header, File::IOFile& f)
+static bool ReadStateHeaderFromFile(StateHeader& header, File::IOFile& f,
+                                    bool get_version_header = true)
 {
   if (!f.IsOpen())
   {
@@ -573,6 +574,11 @@ static bool ReadStateHeaderFromFile(StateHeader& header, File::IOFile& f)
     Core::DisplayMessage("Failed to read state legacy header", 2000);
     return false;
   }
+
+  // Bail out if we only care for retrieving the legacy header.
+  // This is the case with ReadHeader() calls.
+  if (!get_version_header)
+    return true;
 
   if (header.legacy_header.lzo_size != 0)
   {
@@ -608,7 +614,8 @@ bool ReadHeader(const std::string& filename, StateHeader& header)
   std::lock_guard lk(s_save_thread_mutex);
 
   File::IOFile f(filename, "rb");
-  return ReadStateHeaderFromFile(header, f);
+  bool get_version_header = false;
+  return ReadStateHeaderFromFile(header, f, get_version_header);
 }
 
 std::string GetInfoStringOfSlot(int slot, bool translate)


### PR DESCRIPTION
Special thanks to @TryTwo for identifying this regression.

On core state changes (Play/Pause for example), Dolphin reads the headers of all savestates associated with the currently running game. Normally this just involves reading the state header, which is uncompressed, thus reads are quick and simple. Changes introduced in #12217 change the behavior when calling `ReadHeader()` in `State.cpp`, whose aim is to just get each state's timestamp. Instead of reading just the legacy header, `ReadStateHeaderFromFile()` reads what we consider to be the NEW header, which includes version information. To support legacy savestate version checks, we decompress the state using LZ4 to retrieve the version info to copy over to our new header. However, this decompression does not need to occur if we simply wish to read timestamps. If you have several legacy LZ4 states in your Savestate folder, this would cause several decompressions to happen. Toggling play/pause several times in quick succession will lead to the UI hanging.

To fix this I can just introduce a boolean for `ReadStateHeaderFromFile()` to exit out if we only need the legacy portion of the header to be read. This fixes the issue for me and seems safe as the callers to `ReadHeader()` solely reference the timestamp field.