### PR TITLE
JIT64 (Jit_Integer): for twx instructions, raise exception with correct SRR0

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -2752,6 +2752,7 @@ void Jit64::twX(UGeckoInstruction inst)
     gpr.Flush();
     fpr.Flush();
 
+    MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
     WriteExceptionExit();
 
     SwitchToNearCode();


### PR DESCRIPTION
In the AMD64 JIT, the `tw*` instructions did fail to update `PPCSTATE(pc)` before raising the exception, so the program exception was taken with incorrect SRR0.

This is a one-line change so I figured it would be best to open a PR rather than open a bug report.

The ARM64 JIT does things properly as far as I can tell.