### PR TITLE
Netplay: Don't log skippable events as errors

### DIFF
--- a/Source/Core/Common/ENet.cpp
+++ b/Source/Core/Common/ENet.cpp
@@ -31,7 +31,7 @@ int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event)
   // wakeup packet received
   if (host->receivedDataLength == 1 && host->receivedData[0] == 0)
   {
-    event->type = (ENetEventType)42;
+    event->type = SKIPPABLE_EVENT;
     return 1;
   }
   return 0;

--- a/Source/Core/Common/ENet.h
+++ b/Source/Core/Common/ENet.h
@@ -21,4 +21,7 @@ using ENetHostPtr = std::unique_ptr<ENetHost, ENetHostDeleter>;
 void WakeupThread(ENetHost* host);
 int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event);
 bool SendPacket(ENetPeer* socket, const sf::Packet& packet, u8 channel_id);
+
+// used for traversal packets and wake-up packets
+constexpr ENetEventType SKIPPABLE_EVENT = ENetEventType(42);
 }  // namespace Common::ENet

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -299,7 +299,7 @@ int ENET_CALLBACK TraversalClient::InterceptCallback(ENetHost* host, ENetEvent* 
                                   &host->receivedAddress) ||
       (host->receivedDataLength == 1 && host->receivedData[0] == 0))
   {
-    event->type = (ENetEventType)42;
+    event->type = Common::ENet::SKIPPABLE_EVENT;
     return 1;
   }
   return 0;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -257,7 +257,7 @@ bool NetPlayClient::Connect()
   ENetEvent netEvent;
   int net;
   while ((net = enet_host_service(m_client, &netEvent, 5000)) > 0 &&
-         netEvent.type == ENetEventType(42))  // See PR #11381 and ENetUtil::InterceptCallback
+         netEvent.type == Common::ENet::SKIPPABLE_EVENT)
   {
     // ignore packets from traversal server
   }
@@ -1644,7 +1644,11 @@ void NetPlayClient::ThreadFunc()
 
         break;
       default:
-        ERROR_LOG_FMT(NETPLAY, "enet_host_service: unknown event type: {}", int(netEvent.type));
+        // not a valid switch case due to not technically being part of the enum
+        if (netEvent.type == Common::ENet::SKIPPABLE_EVENT)
+          INFO_LOG_FMT(NETPLAY, "enet_host_service: skippable packet event");
+        else
+          ERROR_LOG_FMT(NETPLAY, "enet_host_service: unknown event type: {}", int(netEvent.type));
         break;
       }
     }

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -386,7 +386,11 @@ void NetPlayServer::ThreadFunc()
       }
       break;
       default:
-        ERROR_LOG_FMT(NETPLAY, "enet_host_service: unknown event type: {}", int(netEvent.type));
+        // not a valid switch case due to not technically being part of the enum
+        if (netEvent.type == Common::ENet::SKIPPABLE_EVENT)
+          INFO_LOG_FMT(NETPLAY, "enet_host_service: skippable packet event");
+        else
+          ERROR_LOG_FMT(NETPLAY, "enet_host_service: unknown event type: {}", int(netEvent.type));
         break;
       }
     }


### PR DESCRIPTION
A few days ago, I was asked about "unknown event type: 42" errors appearing in the Dolphin log. After investigating, it turned out that these logging calls were added in #11704, without taking into account the Dolphin-specific hack for skipping events relating to traversal and wake-up packets in the main ENet code.
This PR adjusts the logging so that these skipped events are not logged as errors, in case someone asks about this in future. It also gives the 42 constant a name. I put it in ENet.h since that was the lowest common denominator of all the places where it was used.