### PR TITLE
UnitTests: Test frsqrte against known values

### DIFF
--- a/Source/UnitTests/Common/FloatUtilsTest.cpp
+++ b/Source/UnitTests/Common/FloatUtilsTest.cpp
@@ -1,6 +1,7 @@
 // Copyright 2018 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <array>
 #include <limits>
 #include <random>
 
@@ -8,6 +9,8 @@
 
 #include "Common/BitUtils.h"
 #include "Common/FloatUtils.h"
+
+#include "../Core/PowerPC/TestValues.h"
 
 TEST(FloatUtils, IsQNAN)
 {
@@ -60,5 +63,37 @@ TEST(FloatUtils, FlushToZero)
 
     i_tmp |= 0x80000000u;
     EXPECT_EQ(i_tmp, Common::BitCast<u32>(Common::FlushToZero(Common::BitCast<float>(i_tmp))));
+  }
+}
+
+TEST(FloatUtils, ApproximateReciprocalSquareRoot)
+{
+  constexpr std::array<u64, 57> expected_values{
+      0x7FF0'0000'0000'0000, 0x617F'FE80'0000'0000, 0x60BF'FE80'0000'0000, 0x5FE0'0008'2C00'0000,
+      0x5FDF'FE80'0000'0000, 0x5FDF'FE80'0000'0000, 0x3FEF'FE80'0000'0000, 0x1FF0'0008'2C00'0000,
+      0x0000'0000'0000'0000, 0x7FF8'0000'0000'0001, 0x7FFF'FFFF'FFFF'FFFF, 0x7FF8'0000'0000'0000,
+      0x7FFF'FFFF'FFFF'FFFF, 0xFFF0'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000,
+      0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000,
+      0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0xFFF8'0000'0000'0001, 0xFFFF'FFFF'FFFF'FFFF,
+      0xFFF8'0000'0000'0000, 0xFFFF'FFFF'FFFF'FFFF, 0x43E6'9FA0'0000'0000, 0x43DF'FE80'0000'0000,
+      0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x43E6'9360'6000'0000, 0x43DF'ED30'7000'0000,
+      0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x44A6'9FA0'0000'0000, 0x4496'9FA0'0000'0000,
+      0x448F'FE80'0000'0000, 0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000,
+      0x44A6'9360'6000'0000, 0x4496'9360'6000'0000, 0x448F'ED30'7000'0000, 0x7FF8'0000'0000'0000,
+      0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x3C06'9FA0'0000'0000, 0x3BFF'FE80'0000'0000,
+      0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x43EF'FE80'0000'0000, 0x43F6'9FA0'0000'0000,
+      0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x3FEA'2040'0000'0000, 0x3FA0'3108'0000'0000,
+      0x7FF8'0000'0000'0000};
+
+  for (int i = 0; i < double_test_values.size(); ++i)
+  {
+    u64 ivalue = double_test_values[i];
+    double dvalue = Common::BitCast<double>(ivalue);
+
+    u64 expected = expected_values[i];
+
+    u64 actual = Common::BitCast<u64>(Common::ApproximateReciprocalSquareRoot(dvalue));
+
+    EXPECT_EQ(expected, actual);
   }
 }


### PR DESCRIPTION
This was discussed in #12249. We have a unit test that validates that the Jit64 result matches the interpreter, but the interpreter results itself are not being tested. This diff adds a new test case validating the interpreter results against a hard-coded list.