### PR TITLE
Fix regression when recording multiple fifologs

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -261,7 +261,11 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
         OpcodeDecoder::g_record_fifo_data = IsRecording();
 
         if (!OpcodeDecoder::g_record_fifo_data)
+        {
+          // Remove this frame end callback when recording finishes
+          m_end_of_frame_event.reset();
           return;
+        }
 
         if (!was_recording)
         {
@@ -430,9 +434,6 @@ void FifoRecorder::EndFrame(u32 fifoStart, u32 fifoEnd)
     m_SkipFutureData = true;
     // Signal video backend that it should not call this function when the next frame ends
     m_IsRecording = false;
-
-    // Remove our frame end callback
-    m_end_of_frame_event.reset();
   }
 }
 


### PR DESCRIPTION
Since ccf92a3e56764d6378c436a8040519a5bffc3372, recording fifologs multiple times after launching dolphin caused all initial state to not be saved (the initial contents of bpmem, cpmem, etc were all zeroed out). For some games, this was not noticeable, as most registers were set each frame, but for others, this resulted in completely broken fifologs. (Note that recording fifologs also required 05181f6b88fd8ee671113bcafb81c65027f911a4 and 9e0755a5983d8d9a277cea284534fb32a545f270 to be cherry-picked due to other, since fixed, regressions.)

This was because previously, `Renderer::CheckFifoRecording` was called every frame, but ccf92a3e56764d6378c436a8040519a5bffc3372 changed it into a callback (`m_end_of_frame_event`) that was removed when recording ended. Thus, before, `OpcodeDecoder::g_record_fifo_data = IsRecording()` was called when `IsRecording()` returned false, but after that commit `g_record_fifo_data` never got changed back to false, so the check for `was_recording` only ever passed on the first fifolog recorded (even after stopping and starting a game).

There may still be another issue lurking, as I'm not sure if all broken fifologs were caused by recording multiple fifologs (for instance, on https://bugs.dolphin-emu.org/issues/13377, only one fifolog was initially uploaded, but it was affected by an issue with the same symptoms as this).