### PR TITLE
Cheats Manager: Fix factory widget spacing

### DIFF
--- a/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
@@ -123,6 +123,8 @@ void CheatSearchFactoryWidget::CreateWidgets()
   m_new_search = new NonDefaultQPushButton(tr("New Search"));
   layout->addWidget(m_new_search);
 
+  layout->addStretch();
+
   setLayout(layout);
 }
 


### PR DESCRIPTION
Add stretch to bottom of factory widget to prevent the Data Type QGroupBox from getting stretched out awkwardly.

Before/After:
![before](https://github.com/dolphin-emu/dolphin/assets/73494713/a982318c-86fc-46da-a4c6-2e96a5981277)![after](https://github.com/dolphin-emu/dolphin/assets/73494713/7cfe2cc1-32d3-4068-9fac-d953fbae590a)
