### PR TITLE
Jit: Define new terms related to fastmem

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -888,9 +888,8 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   js.constantGqrValid = BitSet8();
 
   // Assume that GQR values don't change often at runtime. Many paired-heavy games use largely float
-  // loads and stores,
-  // which are significantly faster when inlined (especially in MMU mode, where this lets them use
-  // fastmem).
+  // loads and stores, which are significantly faster when inlined (especially in MMU mode, where
+  // this lets them use fastmem).
   if (js.pairedQuantizeAddresses.find(js.blockStart) == js.pairedQuantizeAddresses.end())
   {
     // If there are GQRs used but not set, we'll treat those as constant and optimize them

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -76,8 +76,8 @@ public:
     // This indicates that the write being generated cannot be patched (and thus can't use fastmem)
     SAFE_LOADSTORE_NO_FASTMEM = 4,
     SAFE_LOADSTORE_CLOBBER_RSCRATCH_INSTEAD_OF_ADDR = 8,
-    // Force slowmem (used when generating fallbacks in trampolines)
-    SAFE_LOADSTORE_FORCE_SLOWMEM = 16,
+    // Always call into C++ (used when generating fallbacks in trampolines)
+    SAFE_LOADSTORE_FORCE_SLOW_ACCESS = 16,
     SAFE_LOADSTORE_DR_ON = 32,
     // Generated from a context that doesn't have the PC of the instruction that caused it
     SAFE_LOADSTORE_NO_UPDATE_PC = 64,

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -44,7 +44,7 @@ const u8* TrampolineCache::GenerateReadTrampoline(const TrampolineInfo& info)
   const u8* trampoline = GetCodePtr();
 
   SafeLoadToReg(info.op_reg, info.op_arg, info.accessSize << 3, info.offset, info.registersInUse,
-                info.signExtend, info.flags | SAFE_LOADSTORE_FORCE_SLOWMEM);
+                info.signExtend, info.flags | SAFE_LOADSTORE_FORCE_SLOW_ACCESS);
 
   JMP(info.start + info.len, Jump::Near);
 
@@ -63,7 +63,7 @@ const u8* TrampolineCache::GenerateWriteTrampoline(const TrampolineInfo& info)
   // check anyway.
 
   SafeWriteRegToReg(info.op_arg, info.op_reg, info.accessSize << 3, info.offset,
-                    info.registersInUse, info.flags | SAFE_LOADSTORE_FORCE_SLOWMEM);
+                    info.registersInUse, info.flags | SAFE_LOADSTORE_FORCE_SLOW_ACCESS);
 
   JMP(info.start + info.len, Jump::Near);
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -189,8 +189,8 @@ public:
 protected:
   struct FastmemArea
   {
-    const u8* fastmem_code;
-    const u8* slowmem_code;
+    const u8* fast_access_code;
+    const u8* slow_access_code;
   };
 
   void SetBlockLinkingEnabled(bool enabled);
@@ -229,10 +229,10 @@ protected:
   {
     // Always calls the slow C++ code. For performance reasons, should generally only be used if
     // the guest address is known in advance and IsOptimizableRAMAddress returns false for it.
-    AlwaysSafe,
+    AlwaysSlowAccess,
     // Only emits fast access code. Must only be used if the guest address is known in advance
     // and IsOptimizableRAMAddress returns true for it, otherwise Dolphin will likely crash!
-    AlwaysUnsafe,
+    AlwaysFastAccess,
     // Best in most cases. If backpatching is possible (!emitting_routine && jo.fastmem):
     // Tries to run fast access code, and if that fails, uses backpatching to replace the code
     // with a call to the slow C++ code. Otherwise: Checks whether the fast access code will work,
@@ -252,20 +252,20 @@ protected:
   // Store float:    X1       Q0
   // Load float:     X0
   //
-  // If mode == AlwaysUnsafe, the addr argument can be any register.
+  // If mode == AlwaysFastAccess, the addr argument can be any register.
   // Otherwise it must be the register listed in the table above.
   //
   // Additional scratch registers are used in the following situations:
   //
   // emitting_routine && mode == Auto:                                            X2
   // emitting_routine && mode == Auto && !(flags & BackPatchInfo::FLAG_STORE):    X3
-  // emitting_routine && mode != AlwaysSafe && !jo.fastmem:                       X3
-  // mode != AlwaysSafe && !jo.fastmem:                                           X2
-  // !emitting_routine && mode != AlwaysSafe && !jo.fastmem:                      X30
+  // emitting_routine && mode != AlwaysSlowAccess && !jo.fastmem:                 X3
+  // mode != AlwaysSlowAccess && !jo.fastmem:                                     X2
+  // !emitting_routine && mode != AlwaysSlowAccess && !jo.fastmem:                X30
   // !emitting_routine && mode == Auto && jo.fastmem:                             X30
   //
   // Furthermore, any callee-saved register which isn't marked in gprs_to_push/fprs_to_push
-  // may be clobbered if mode != AlwaysUnsafe.
+  // may be clobbered if mode != AlwaysFastAccess.
   void EmitBackpatchRoutine(u32 flags, MemAccessMode mode, Arm64Gen::ARM64Reg RS,
                             Arm64Gen::ARM64Reg addr, BitSet32 gprs_to_push = BitSet32(0),
                             BitSet32 fprs_to_push = BitSet32(0), bool emitting_routine = false);
@@ -356,7 +356,7 @@ protected:
   void SetFPRFIfNeeded(bool single, Arm64Gen::ARM64Reg reg);
   void Force25BitPrecision(Arm64Gen::ARM64Reg output, Arm64Gen::ARM64Reg input);
 
-  // <Fastmem fault location, slowmem handler location>
+  // <Fast path fault location, slow path handler location>
   std::map<const u8*, FastmemArea> m_fault_to_handler{};
   Arm64GPRCache gpr;
   Arm64FPRCache fpr;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -137,7 +137,7 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
   if (is_immediate && m_mmu.IsOptimizableRAMAddress(imm_addr))
   {
     set_addr_reg_if_needed();
-    EmitBackpatchRoutine(flags, MemAccessMode::AlwaysUnsafe, dest_reg, XA, regs_in_use,
+    EmitBackpatchRoutine(flags, MemAccessMode::AlwaysFastAccess, dest_reg, XA, regs_in_use,
                          fprs_in_use);
   }
   else if (mmio_address)
@@ -309,7 +309,7 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
   else if (is_immediate && m_mmu.IsOptimizableRAMAddress(imm_addr))
   {
     set_addr_reg_if_needed();
-    EmitBackpatchRoutine(flags, MemAccessMode::AlwaysUnsafe, RS, XA, regs_in_use, fprs_in_use);
+    EmitBackpatchRoutine(flags, MemAccessMode::AlwaysFastAccess, RS, XA, regs_in_use, fprs_in_use);
   }
   else if (mmio_address)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -176,7 +176,7 @@ void JitArm64::lfXX(UGeckoInstruction inst)
 
   if (is_immediate && m_mmu.IsOptimizableRAMAddress(imm_addr))
   {
-    EmitBackpatchRoutine(flags, MemAccessMode::AlwaysUnsafe, VD, XA, regs_in_use, fprs_in_use);
+    EmitBackpatchRoutine(flags, MemAccessMode::AlwaysFastAccess, VD, XA, regs_in_use, fprs_in_use);
   }
   else
   {
@@ -402,12 +402,14 @@ void JitArm64::stfXX(UGeckoInstruction inst)
     else if (m_mmu.IsOptimizableRAMAddress(imm_addr))
     {
       set_addr_reg_if_needed();
-      EmitBackpatchRoutine(flags, MemAccessMode::AlwaysUnsafe, V0, XA, regs_in_use, fprs_in_use);
+      EmitBackpatchRoutine(flags, MemAccessMode::AlwaysFastAccess, V0, XA, regs_in_use,
+                           fprs_in_use);
     }
     else
     {
       set_addr_reg_if_needed();
-      EmitBackpatchRoutine(flags, MemAccessMode::AlwaysSafe, V0, XA, regs_in_use, fprs_in_use);
+      EmitBackpatchRoutine(flags, MemAccessMode::AlwaysSlowAccess, V0, XA, regs_in_use,
+                           fprs_in_use);
     }
   }
   else

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1564,7 +1564,8 @@ void MMU::UpdateBATs(BatTable& bat_table, u32 base_spr)
           valid_bit |= BAT_WI_BIT;
 
         // Enable fastmem mappings for cached memory. There are quirks related to uncached memory
-        // that fastmem doesn't emulate properly (though no normal games are known to rely on them).
+        // that can't be correctly emulated by fast accesses, so we don't map uncached memory.
+        // (No normal games are known to rely on the quirks, though.)
         if (!wi)
         {
           if (m_memory.GetFakeVMEM() && (physical_address & 0xFE000000) == 0x7E000000)
@@ -1587,7 +1588,8 @@ void MMU::UpdateBATs(BatTable& bat_table, u32 base_spr)
           }
         }
 
-        // Fastmem doesn't support memchecks, so disable it for all overlapping virtual pages.
+        // Fast accesses don't support memchecks, so force slow accesses by removing fastmem
+        // mappings for all overlapping virtual pages.
         if (m_power_pc.GetMemChecks().OverlapsMemcheck(virtual_address, BAT_PAGE_SIZE))
           valid_bit &= ~BAT_PHYSICAL_BIT;
 


### PR DESCRIPTION
Dolphin's JITs have a minor terminology problem: The term "fastmem" can refer to either the system of switching between a fast path and a slow path using backpatching, or to the fast path itself. To hopefully make things clearer, I'm adding some new terms, defining the old and new terms as follows:

Fastmem: The system of switching from a fast path to a slow path by backpatching when an invalid memory access occurs.

Fast access: A code path that accesses guest memory without calling C++ code.

Slow access: A code path that accesses guest memory by calling C++ code.