### PR TITLE
Netplay: Fix building on clang 17.

### DIFF
--- a/Source/Core/Common/ENet.h
+++ b/Source/Core/Common/ENet.h
@@ -3,7 +3,9 @@
 //
 #pragma once
 
+#include <bit>
 #include <memory>
+#include <type_traits>
 
 #include <SFML/Network/Packet.hpp>
 #include <enet/enet.h>
@@ -23,5 +25,6 @@ int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event);
 bool SendPacket(ENetPeer* socket, const sf::Packet& packet, u8 channel_id);
 
 // used for traversal packets and wake-up packets
-constexpr ENetEventType SKIPPABLE_EVENT = ENetEventType(42);
+constexpr ENetEventType SKIPPABLE_EVENT =
+    std::bit_cast<ENetEventType>(std::underlying_type_t<ENetEventType>(42));
 }  // namespace Common::ENet


### PR DESCRIPTION
Casting an enum outside of its defined range is an error there.

Introduced by #12258.
Should fix https://bugs.dolphin-emu.org/issues/13385.