### PR TITLE
UI, CodeDiffDialog: Fix table widget display issues, including dark style.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
@@ -32,9 +32,9 @@
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Settings.h"
 
-static const QString RECORD_BUTTON_STYLESHEET =
-    QStringLiteral("QPushButton:checked { background-color: rgb(150, 0, 0); border-style: solid; "
-                   "border-width: 3px; border-color: rgb(150,0,0); color: rgb(255, 255, 255);}");
+static const QString RECORD_BUTTON_STYLESHEET = QStringLiteral(
+    "QPushButton:checked { background-color: rgb(150, 0, 0); border-style: solid;"
+    "padding: 0px; border-width: 3px; border-color: rgb(150,0,0); color: rgb(255, 255, 255);}");
 
 CodeDiffDialog::CodeDiffDialog(CodeWidget* parent) : QDialog(parent), m_code_widget(parent)
 {
@@ -61,7 +61,6 @@ void CodeDiffDialog::CreateWidgets()
   m_record_btn = new QPushButton(tr("Start Recording"));
   m_record_btn->setCheckable(true);
   m_record_btn->setStyleSheet(RECORD_BUTTON_STYLESHEET);
-
   m_exclude_btn->setEnabled(false);
   m_include_btn->setEnabled(false);
 
@@ -89,6 +88,7 @@ void CodeDiffDialog::CreateWidgets()
   m_matching_results_table->setColumnWidth(2, 4);
   m_matching_results_table->setColumnWidth(3, 210);
   m_matching_results_table->setColumnWidth(4, 65);
+  m_matching_results_table->setCornerButtonEnabled(false);
   m_reset_btn = new QPushButton(tr("Reset All"));
   m_reset_btn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   m_help_btn = new QPushButton(tr("Help"));

--- a/Source/Core/DolphinQt/Styles/Dark/dark.qss
+++ b/Source/Core/DolphinQt/Styles/Dark/dark.qss
@@ -82,19 +82,20 @@ QColumnView::item:focus, QListView::item:focus, QTableView::item:focus, QTableWi
 	background-color: #606060;
 }
 */
+
+/*
+Qt is extremely convinced that the sort arrow belongs on the right side
+of the header and will reserve space for it there. The padding is to deal with this fact.
+*/
 QHeaderView::section {
 	background-color: #202020;
 	border: 0px;
 	border-right: 1px solid #7e7e7e;
-	padding: 0px;
-	text-align: right;
-
-	/*
-	this is a hack, Qt is extremely convinced that the sort arrow belongs on the right side
-	of the header and will reserve space for it there. so this applies that same space to the left
-	so the text is still centered correctly.
-	*/
+	padding-right: -10px;
+}
+QHeaderView::section::vertical { 
 	padding-left: 10px;
+	padding-right: 0px;
 }
 QHeaderView::section:last {
 	border-right: 0px;
@@ -484,4 +485,11 @@ QTabBar QToolButton::left-arrow {
 }
 QTabBar QToolButton::right-arrow {
 	image: url(:/dolphin_dark_win/right-triangle-tabbar.svg);
+}
+QTableCornerButton::section {
+    background-color: #202020;
+    border: 1px solid #7e7e7e;
+    border-top: 0px;
+    border-left: 0px;
+    border-bottom: 0px;
 }


### PR DESCRIPTION
Before: 
![Dolphin_2RfncvIgR6](https://github.com/dolphin-emu/dolphin/assets/10532806/4ac6f3f8-0e94-453d-beae-8390aabad6c4)
After:
![Dolphin_tl3s9rfejq](https://github.com/dolphin-emu/dolphin/assets/10532806/9a7993fa-02c4-4b87-9f4f-8ea6d8e9ae49)

Note that the top header text is no longer being cutoff.

Would help if people could test this. I don't know what window uses sorting arrows and I was just focused on fixing this one window.

I suggest adding dark.qss to the Styles folder for easy switching.
