### PR TITLE
DolphinQt: Remove unnecessary qOverloads

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
@@ -13,7 +13,7 @@ ConfigChoice::ConfigChoice(const QStringList& options, const Config::Info<int>& 
     : m_setting(setting)
 {
   addItems(options);
-  connect(this, qOverload<int>(&QComboBox::currentIndexChanged), this, &ConfigChoice::Update);
+  connect(this, &QComboBox::currentIndexChanged, this, &ConfigChoice::Update);
   setCurrentIndex(Config::Get(m_setting));
 
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
@@ -18,7 +18,7 @@ ConfigInteger::ConfigInteger(int minimum, int maximum, const Config::Info<int>& 
 
   setValue(Config::Get(setting));
 
-  connect(this, qOverload<int>(&ConfigInteger::valueChanged), this, &ConfigInteger::Update);
+  connect(this, &ConfigInteger::valueChanged, this, &ConfigInteger::Update);
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -215,12 +215,10 @@ void GameConfigWidget::ConnectWidgets()
         m_use_dsp_hle, m_manual_texture_sampling, m_use_monoscopic_shadows})
     connect(box, &QCheckBox::stateChanged, this, &GameConfigWidget::SaveSettings);
 
-  connect(m_deterministic_dual_core, qOverload<int>(&QComboBox::currentIndexChanged), this,
+  connect(m_deterministic_dual_core, &QComboBox::currentIndexChanged, this,
           &GameConfigWidget::SaveSettings);
-  connect(m_depth_slider, qOverload<int>(&QSlider::valueChanged), this,
-          &GameConfigWidget::SaveSettings);
-  connect(m_convergence_spin, qOverload<int>(&QSpinBox::valueChanged), this,
-          &GameConfigWidget::SaveSettings);
+  connect(m_depth_slider, &QSlider::valueChanged, this, &GameConfigWidget::SaveSettings);
+  connect(m_convergence_spin, &QSpinBox::valueChanged, this, &GameConfigWidget::SaveSettings);
 }
 
 void GameConfigWidget::LoadCheckBox(QCheckBox* checkbox, const std::string& section,

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -108,11 +108,10 @@ void GamecubeControllersWidget::ConnectWidgets()
 {
   for (size_t i = 0; i < m_gc_controller_boxes.size(); ++i)
   {
-    connect(m_gc_controller_boxes[i], qOverload<int>(&QComboBox::currentIndexChanged), this,
-            [this, i] {
-              OnGCTypeChanged(i);
-              SaveSettings();
-            });
+    connect(m_gc_controller_boxes[i], &QComboBox::currentIndexChanged, this, [this, i] {
+      OnGCTypeChanged(i);
+      SaveSettings();
+    });
     connect(m_gc_buttons[i], &QPushButton::clicked, this, [this, i] { OnGCPadConfigure(i); });
   }
 }

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -228,15 +228,13 @@ void EnhancementsWidget::CreateWidgets()
 
 void EnhancementsWidget::ConnectWidgets()
 {
-  connect(m_aa_combo, qOverload<int>(&QComboBox::currentIndexChanged),
+  connect(m_aa_combo, &QComboBox::currentIndexChanged, [this](int) { SaveSettings(); });
+  connect(m_texture_filtering_combo, &QComboBox::currentIndexChanged,
           [this](int) { SaveSettings(); });
-  connect(m_texture_filtering_combo, qOverload<int>(&QComboBox::currentIndexChanged),
+  connect(m_output_resampling_combo, &QComboBox::currentIndexChanged,
           [this](int) { SaveSettings(); });
-  connect(m_output_resampling_combo, qOverload<int>(&QComboBox::currentIndexChanged),
-          [this](int) { SaveSettings(); });
-  connect(m_pp_effect, qOverload<int>(&QComboBox::currentIndexChanged),
-          [this](int) { SaveSettings(); });
-  connect(m_3d_mode, qOverload<int>(&QComboBox::currentIndexChanged), [this] {
+  connect(m_pp_effect, &QComboBox::currentIndexChanged, [this](int) { SaveSettings(); });
+  connect(m_3d_mode, &QComboBox::currentIndexChanged, [this] {
     m_block_save = true;
     m_configure_color_correction->setEnabled(g_Config.backend_info.bSupportsPostProcessing);
     LoadPPShaders();

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -132,9 +132,8 @@ void GeneralWidget::CreateWidgets()
 void GeneralWidget::ConnectWidgets()
 {
   // Video Backend
-  connect(m_backend_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &GeneralWidget::SaveSettings);
-  connect(m_adapter_combo, qOverload<int>(&QComboBox::currentIndexChanged), this, [&](int index) {
+  connect(m_backend_combo, &QComboBox::currentIndexChanged, this, &GeneralWidget::SaveSettings);
+  connect(m_adapter_combo, &QComboBox::currentIndexChanged, this, [&](int index) {
     g_Config.iAdapter = index;
     Config::SetBaseOrCurrent(Config::GFX_ADAPTER, index);
     emit BackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));

--- a/Source/Core/DolphinQt/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt/Config/InfoWidget.cpp
@@ -225,8 +225,7 @@ void InfoWidget::CreateLanguageSelector()
   if (m_language_selector->count() == 1)
     m_language_selector->setDisabled(true);
 
-  connect(m_language_selector, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &InfoWidget::ChangeLanguage);
+  connect(m_language_selector, &QComboBox::currentIndexChanged, this, &InfoWidget::ChangeLanguage);
 }
 
 void InfoWidget::ChangeLanguage()

--- a/Source/Core/DolphinQt/Config/LogWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogWidget.cpp
@@ -163,8 +163,7 @@ void LogWidget::ConnectWidgets()
     m_log_ring_buffer.clear();
   });
   connect(m_log_wrap, &QCheckBox::toggled, this, &LogWidget::SaveSettings);
-  connect(m_log_font, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &LogWidget::SaveSettings);
+  connect(m_log_font, &QComboBox::currentIndexChanged, this, &LogWidget::SaveSettings);
   connect(this, &QDockWidget::topLevelChanged, this, &LogWidget::SaveSettings);
   connect(&Settings::Instance(), &Settings::LogVisibilityChanged, this, &LogWidget::setVisible);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -458,13 +458,12 @@ void IOWindow::ConnectWidgets()
 
   connect(m_button_box, &QDialogButtonBox::clicked, this, &IOWindow::OnDialogButtonPressed);
   connect(m_devices_combo, &QComboBox::currentTextChanged, this, &IOWindow::OnDeviceChanged);
-  connect(m_scalar_spinbox, qOverload<int>(&QSpinBox::valueChanged), this,
-          &IOWindow::OnRangeChanged);
+  connect(m_scalar_spinbox, &QSpinBox::valueChanged, this, &IOWindow::OnRangeChanged);
 
   connect(m_expression_text, &QPlainTextEdit::textChanged,
           [this] { UpdateExpression(m_expression_text->toPlainText().toStdString()); });
 
-  connect(m_variables_combo, qOverload<int>(&QComboBox::activated), [this](int index) {
+  connect(m_variables_combo, &QComboBox::activated, [this](int index) {
     if (index == 0)
       return;
 
@@ -482,7 +481,7 @@ void IOWindow::ConnectWidgets()
     m_variables_combo->setCurrentIndex(0);
   });
 
-  connect(m_operators_combo, qOverload<int>(&QComboBox::activated), [this](int index) {
+  connect(m_operators_combo, &QComboBox::activated, [this](int index) {
     if (index == 0)
       return;
 
@@ -491,7 +490,7 @@ void IOWindow::ConnectWidgets()
     m_operators_combo->setCurrentIndex(0);
   });
 
-  connect(m_functions_combo, qOverload<int>(&QComboBox::activated), [this](int index) {
+  connect(m_functions_combo, &QComboBox::activated, [this](int index) {
     if (index == 0)
       return;
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -18,12 +18,11 @@ MappingDouble::MappingDouble(MappingWidget* parent, ControllerEmu::NumericSettin
   if (const auto ui_description = m_setting.GetUIDescription())
     setToolTip(tr(ui_description));
 
-  connect(this, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
-          [this, parent](double value) {
-            m_setting.SetValue(value);
-            ConfigChanged();
-            parent->SaveSettings();
-          });
+  connect(this, &QDoubleSpinBox::valueChanged, this, [this, parent](double value) {
+    m_setting.SetValue(value);
+    ConfigChanged();
+    parent->SaveSettings();
+  });
 
   connect(parent, &MappingWidget::ConfigChanged, this, &MappingDouble::ConfigChanged);
   connect(parent, &MappingWidget::Update, this, &MappingDouble::Update);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -185,8 +185,7 @@ void MappingWindow::ConnectWidgets()
   connect(&Settings::Instance(), &Settings::DevicesChanged, this,
           &MappingWindow::OnGlobalDevicesChanged);
   connect(this, &MappingWindow::ConfigChanged, this, &MappingWindow::OnGlobalDevicesChanged);
-  connect(m_devices_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &MappingWindow::OnSelectDevice);
+  connect(m_devices_combo, &QComboBox::currentIndexChanged, this, &MappingWindow::OnSelectDevice);
 
   connect(m_reset_clear, &QPushButton::clicked, this, &MappingWindow::OnClearFieldsPressed);
   connect(m_reset_default, &QPushButton::clicked, this, &MappingWindow::OnDefaultFieldsPressed);
@@ -194,8 +193,7 @@ void MappingWindow::ConnectWidgets()
   connect(m_profiles_load, &QPushButton::clicked, this, &MappingWindow::OnLoadProfilePressed);
   connect(m_profiles_delete, &QPushButton::clicked, this, &MappingWindow::OnDeleteProfilePressed);
 
-  connect(m_profiles_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &MappingWindow::OnSelectProfile);
+  connect(m_profiles_combo, &QComboBox::currentIndexChanged, this, &MappingWindow::OnSelectProfile);
   connect(m_profiles_combo, &QComboBox::editTextChanged, this,
           &MappingWindow::OnProfileTextChanged);
 

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
@@ -76,10 +76,9 @@ void WiimoteEmuGeneral::CreateMainLayout()
 
 void WiimoteEmuGeneral::Connect()
 {
-  connect(m_extension_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
+  connect(m_extension_combo, &QComboBox::currentIndexChanged, this,
           &WiimoteEmuGeneral::OnAttachmentChanged);
-  connect(m_extension_combo, qOverload<int>(&QComboBox::activated), this,
-          &WiimoteEmuGeneral::OnAttachmentSelected);
+  connect(m_extension_combo, &QComboBox::activated, this, &WiimoteEmuGeneral::OnAttachmentSelected);
   connect(this, &MappingWidget::ConfigChanged, this, &WiimoteEmuGeneral::ConfigChanged);
   connect(this, &MappingWidget::Update, this, &WiimoteEmuGeneral::Update);
 }

--- a/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
+++ b/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
@@ -87,7 +87,7 @@ void NewPatchDialog::CreateWidgets()
 
 void NewPatchDialog::ConnectWidgets()
 {
-  connect(m_name_edit, qOverload<const QString&>(&QLineEdit::textEdited),
+  connect(m_name_edit, &QLineEdit::textEdited,
           [this](const QString& name) { m_patch.name = name.toStdString(); });
 
   connect(m_add_button, &QPushButton::clicked, this, &NewPatchDialog::AddEntry);
@@ -162,20 +162,17 @@ QGroupBox* NewPatchDialog::CreateEntry(const PatchEngine::PatchEntry& entry)
   layout->addWidget(remove, 5, 0, 1, -1);
   box->setLayout(layout);
 
-  connect(address, qOverload<const QString&>(&QLineEdit::textEdited),
-          [new_entry](const QString& text) {
-            new_entry->entry.address = OnTextEdited(new_entry->address, text);
-          });
+  connect(address, &QLineEdit::textEdited, [new_entry](const QString& text) {
+    new_entry->entry.address = OnTextEdited(new_entry->address, text);
+  });
 
-  connect(value, qOverload<const QString&>(&QLineEdit::textEdited),
-          [new_entry](const QString& text) {
-            new_entry->entry.value = OnTextEdited(new_entry->value, text);
-          });
+  connect(value, &QLineEdit::textEdited, [new_entry](const QString& text) {
+    new_entry->entry.value = OnTextEdited(new_entry->value, text);
+  });
 
-  connect(comparand, qOverload<const QString&>(&QLineEdit::textEdited),
-          [new_entry](const QString& text) {
-            new_entry->entry.comparand = OnTextEdited(new_entry->comparand, text);
-          });
+  connect(comparand, &QLineEdit::textEdited, [new_entry](const QString& text) {
+    new_entry->entry.comparand = OnTextEdited(new_entry->comparand, text);
+  });
 
   connect(remove, &QPushButton::clicked, [this, box, new_entry] {
     if (m_entries.size() > 1)

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -197,7 +197,7 @@ void WiimoteControllersWidget::ConnectWidgets()
 
   for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
-    connect(m_wiimote_boxes[i], qOverload<int>(&QComboBox::currentIndexChanged), this, [this] {
+    connect(m_wiimote_boxes[i], &QComboBox::currentIndexChanged, this, [this] {
       SaveSettings();
       LoadSettings(Core::GetState());
     });

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -108,9 +108,8 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
 
   setLayout(main_layout);
 
-  connect(m_format, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-          &ConvertDialog::OnFormatChanged);
-  connect(m_compression, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+  connect(m_format, &QComboBox::currentIndexChanged, this, &ConvertDialog::OnFormatChanged);
+  connect(m_compression, &QComboBox::currentIndexChanged, this,
           &ConvertDialog::OnCompressionChanged);
   connect(convert_button, &QPushButton::clicked, this, &ConvertDialog::Convert);
 

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -307,7 +307,7 @@ void MemoryWidget::ConnectWidgets()
   connect(m_search_offset, &QLineEdit::textChanged, this, &MemoryWidget::OnSearchAddress);
   connect(m_data_edit, &QLineEdit::textChanged, this, &MemoryWidget::ValidateAndPreviewInputValue);
 
-  connect(m_input_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
+  connect(m_input_combo, &QComboBox::currentIndexChanged, this,
           &MemoryWidget::ValidateAndPreviewInputValue);
   connect(m_set_value, &QPushButton::clicked, this, &MemoryWidget::OnSetValue);
 
@@ -321,8 +321,7 @@ void MemoryWidget::ConnectWidgets()
   }
   for (auto* combo : {m_display_combo, m_align_combo, m_row_length_combo})
   {
-    connect(combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-            &MemoryWidget::OnDisplayChanged);
+    connect(combo, &QComboBox::currentIndexChanged, this, &MemoryWidget::OnDisplayChanged);
   }
 
   connect(m_dual_check, &QCheckBox::toggled, this, &MemoryWidget::OnDisplayChanged);

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -207,7 +207,7 @@ void NetworkWidget::CreateWidgets()
 
 void NetworkWidget::ConnectWidgets()
 {
-  connect(m_dump_format_combo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+  connect(m_dump_format_combo, &QComboBox::currentIndexChanged, this,
           &NetworkWidget::OnDumpFormatComboChanged);
   connect(m_dump_ssl_read_checkbox, &QCheckBox::stateChanged, [](int state) {
     Config::SetBaseOrCurrent(Config::MAIN_NETWORK_SSL_DUMP_READ, state == Qt::Checked);

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -187,15 +187,11 @@ void FIFOPlayerWindow::ConnectWidgets()
   connect(m_early_memory_updates, &QCheckBox::toggled, this, &FIFOPlayerWindow::OnConfigChanged);
   connect(m_loop, &QCheckBox::toggled, this, &FIFOPlayerWindow::OnConfigChanged);
 
-  connect(m_frame_range_from, qOverload<int>(&QSpinBox::valueChanged), this,
-          &FIFOPlayerWindow::OnLimitsChanged);
-  connect(m_frame_range_to, qOverload<int>(&QSpinBox::valueChanged), this,
-          &FIFOPlayerWindow::OnLimitsChanged);
+  connect(m_frame_range_from, &QSpinBox::valueChanged, this, &FIFOPlayerWindow::OnLimitsChanged);
+  connect(m_frame_range_to, &QSpinBox::valueChanged, this, &FIFOPlayerWindow::OnLimitsChanged);
 
-  connect(m_object_range_from, qOverload<int>(&QSpinBox::valueChanged), this,
-          &FIFOPlayerWindow::OnLimitsChanged);
-  connect(m_object_range_to, qOverload<int>(&QSpinBox::valueChanged), this,
-          &FIFOPlayerWindow::OnLimitsChanged);
+  connect(m_object_range_from, &QSpinBox::valueChanged, this, &FIFOPlayerWindow::OnLimitsChanged);
+  connect(m_object_range_to, &QSpinBox::valueChanged, this, &FIFOPlayerWindow::OnLimitsChanged);
 }
 
 void FIFOPlayerWindow::AddDescriptions()

--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
@@ -246,7 +246,7 @@ CreateFigureDialog::CreateFigureDialog(QWidget* parent, u8 slot) : QDialog(paren
 
   setLayout(layout);
 
-  connect(combo_figlist, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) {
+  connect(combo_figlist, &QComboBox::currentIndexChanged, [=](int index) {
     const u32 char_info = combo_figlist->itemData(index).toUInt();
     if (char_info != 0xFFFFFFFF)
     {

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -130,8 +130,7 @@ void NetPlayBrowser::CreateWidgets()
 
 void NetPlayBrowser::ConnectWidgets()
 {
-  connect(m_region_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &NetPlayBrowser::Refresh);
+  connect(m_region_combo, &QComboBox::currentIndexChanged, this, &NetPlayBrowser::Refresh);
 
   connect(m_button_box, &QDialogButtonBox::accepted, this, &NetPlayBrowser::accept);
   connect(m_button_box, &QDialogButtonBox::rejected, this, &NetPlayBrowser::reject);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -319,8 +319,7 @@ void NetPlayDialog::CreatePlayersLayout()
 void NetPlayDialog::ConnectWidgets()
 {
   // Players
-  connect(m_room_box, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &NetPlayDialog::UpdateGUI);
+  connect(m_room_box, &QComboBox::currentIndexChanged, this, &NetPlayDialog::UpdateGUI);
   connect(m_hostcode_action_button, &QPushButton::clicked, [this] {
     if (m_is_copy_button_retry)
       Common::g_TraversalClient->ReconnectToServer();
@@ -352,7 +351,7 @@ void NetPlayDialog::ConnectWidgets()
           [this] { m_chat_send_button->setEnabled(!m_chat_type_edit->text().isEmpty()); });
 
   // Other
-  connect(m_buffer_size_box, qOverload<int>(&QSpinBox::valueChanged), [this](int value) {
+  connect(m_buffer_size_box, &QSpinBox::valueChanged, [this](int value) {
     if (value == m_buffer_size)
       return;
 
@@ -413,8 +412,7 @@ void NetPlayDialog::ConnectWidgets()
 
   // SaveSettings() - Save Hosting-Dialog Settings
 
-  connect(m_buffer_size_box, qOverload<int>(&QSpinBox::valueChanged), this,
-          &NetPlayDialog::SaveSettings);
+  connect(m_buffer_size_box, &QSpinBox::valueChanged, this, &NetPlayDialog::SaveSettings);
   connect(m_savedata_none_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_savedata_load_only_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_savedata_load_and_write_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -206,18 +206,16 @@ void NetPlaySetupDialog::CreateMainLayout()
 
 void NetPlaySetupDialog::ConnectWidgets()
 {
-  connect(m_connection_type, qOverload<int>(&QComboBox::currentIndexChanged), this,
+  connect(m_connection_type, &QComboBox::currentIndexChanged, this,
           &NetPlaySetupDialog::OnConnectionTypeChanged);
   connect(m_nickname_edit, &QLineEdit::textChanged, this, &NetPlaySetupDialog::SaveSettings);
 
   // Connect widget
   connect(m_ip_edit, &QLineEdit::textChanged, this, &NetPlaySetupDialog::SaveSettings);
-  connect(m_connect_port_box, qOverload<int>(&QSpinBox::valueChanged), this,
-          &NetPlaySetupDialog::SaveSettings);
+  connect(m_connect_port_box, &QSpinBox::valueChanged, this, &NetPlaySetupDialog::SaveSettings);
   // Host widget
-  connect(m_host_port_box, qOverload<int>(&QSpinBox::valueChanged), this,
-          &NetPlaySetupDialog::SaveSettings);
-  connect(m_host_games, qOverload<int>(&QListWidget::currentRowChanged), [this](int index) {
+  connect(m_host_port_box, &QSpinBox::valueChanged, this, &NetPlaySetupDialog::SaveSettings);
+  connect(m_host_games, &QListWidget::currentRowChanged, [this](int index) {
     Settings::GetQSettings().setValue(QStringLiteral("netplay/hostgame"),
                                       m_host_games->item(index)->text());
   });
@@ -230,7 +228,7 @@ void NetPlaySetupDialog::ConnectWidgets()
     m_host_chunked_upload_limit_box->setEnabled(value);
     SaveSettings();
   });
-  connect(m_host_chunked_upload_limit_box, qOverload<int>(&QSpinBox::valueChanged), this,
+  connect(m_host_chunked_upload_limit_box, &QSpinBox::valueChanged, this,
           &NetPlaySetupDialog::SaveSettings);
 
   connect(m_host_server_browser, &QCheckBox::toggled, this, &NetPlaySetupDialog::SaveSettings);

--- a/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
@@ -56,14 +56,12 @@ void PadMappingDialog::ConnectWidgets()
   {
     for (const auto& combo : combo_group)
     {
-      connect(combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-              &PadMappingDialog::OnMappingChanged);
+      connect(combo, &QComboBox::currentIndexChanged, this, &PadMappingDialog::OnMappingChanged);
     }
   }
   for (const auto& checkbox : m_gba_boxes)
   {
-    connect(checkbox, qOverload<int>(&QCheckBox::stateChanged), this,
-            &PadMappingDialog::OnMappingChanged);
+    connect(checkbox, &QCheckBox::stateChanged, this, &PadMappingDialog::OnMappingChanged);
   }
 }
 

--- a/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
+++ b/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
@@ -204,14 +204,13 @@ void RiivolutionBootWidget::MakeGUIForParsedFile(std::string path, std::string r
       if (option.m_selected_choice <= option.m_choices.size())
         selection->setCurrentIndex(static_cast<int>(option.m_selected_choice));
 
-      connect(selection, qOverload<int>(&QComboBox::currentIndexChanged), this,
-              [this, selection](int idx) {
-                const auto gui_index = selection->currentData().value<GuiRiivolutionPatchIndex>();
-                auto& selected_disc = m_discs[gui_index.m_disc_index].disc;
-                auto& selected_section = selected_disc.m_sections[gui_index.m_section_index];
-                auto& selected_option = selected_section.m_options[gui_index.m_option_index];
-                selected_option.m_selected_choice = static_cast<u32>(gui_index.m_choice_index);
-              });
+      connect(selection, &QComboBox::currentIndexChanged, this, [this, selection](int idx) {
+        const auto gui_index = selection->currentData().value<GuiRiivolutionPatchIndex>();
+        auto& selected_disc = m_discs[gui_index.m_disc_index].disc;
+        auto& selected_section = selected_disc.m_sections[gui_index.m_section_index];
+        auto& selected_option = selected_section.m_options[gui_index.m_option_index];
+        selected_option.m_selected_choice = static_cast<u32>(gui_index.m_choice_index);
+      });
 
       grid_layout->addWidget(label, row, 0, 1, 1);
       grid_layout->addWidget(selection, row, 1, 1, 1);

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -190,12 +190,11 @@ void AdvancedPane::CreateLayout()
 
 void AdvancedPane::ConnectLayout()
 {
-  connect(m_cpu_emulation_engine_combobox, qOverload<int>(&QComboBox::currentIndexChanged),
-          [](int index) {
-            const auto cpu_cores = PowerPC::AvailableCPUCores();
-            if (index >= 0 && static_cast<size_t>(index) < cpu_cores.size())
-              Config::SetBaseOrCurrent(Config::MAIN_CPU_CORE, cpu_cores[index]);
-          });
+  connect(m_cpu_emulation_engine_combobox, &QComboBox::currentIndexChanged, [](int index) {
+    const auto cpu_cores = PowerPC::AvailableCPUCores();
+    if (index >= 0 && static_cast<size_t>(index) < cpu_cores.size())
+      Config::SetBaseOrCurrent(Config::MAIN_CPU_CORE, cpu_cores[index]);
+  });
 
   connect(m_cpu_clock_override_checkbox, &QCheckBox::toggled, [this](bool enable_clock_override) {
     Config::SetBaseOrCurrent(Config::MAIN_OVERCLOCK_ENABLE, enable_clock_override);

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -174,13 +174,11 @@ void AudioPane::CreateWidgets()
 
 void AudioPane::ConnectWidgets()
 {
-  connect(m_backend_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &AudioPane::SaveSettings);
+  connect(m_backend_combo, &QComboBox::currentIndexChanged, this, &AudioPane::SaveSettings);
   connect(m_volume_slider, &QSlider::valueChanged, this, &AudioPane::SaveSettings);
   if (m_latency_control_supported)
   {
-    connect(m_latency_spin, qOverload<int>(&QSpinBox::valueChanged), this,
-            &AudioPane::SaveSettings);
+    connect(m_latency_spin, &QSpinBox::valueChanged, this, &AudioPane::SaveSettings);
   }
   connect(m_stretching_buffer_slider, &QSlider::valueChanged, this, &AudioPane::SaveSettings);
   connect(m_dolby_pro_logic, &QCheckBox::toggled, this, &AudioPane::SaveSettings);
@@ -191,8 +189,7 @@ void AudioPane::ConnectWidgets()
   connect(m_dsp_interpreter, &QRadioButton::toggled, this, &AudioPane::SaveSettings);
 
 #ifdef _WIN32
-  connect(m_wasapi_device_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &AudioPane::SaveSettings);
+  connect(m_wasapi_device_combo, &QComboBox::currentIndexChanged, this, &AudioPane::SaveSettings);
 #endif
 }
 

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -249,15 +249,14 @@ void GameCubePane::ConnectWidgets()
 {
   // IPL Settings
   connect(m_skip_main_menu, &QCheckBox::stateChanged, this, &GameCubePane::SaveSettings);
-  connect(m_language_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &GameCubePane::SaveSettings);
+  connect(m_language_combo, &QComboBox::currentIndexChanged, this, &GameCubePane::SaveSettings);
 
   // Device Settings
   for (ExpansionInterface::Slot slot : ExpansionInterface::SLOTS)
   {
-    connect(m_slot_combos[slot], qOverload<int>(&QComboBox::currentIndexChanged), this,
+    connect(m_slot_combos[slot], &QComboBox::currentIndexChanged, this,
             [this, slot] { UpdateButton(slot); });
-    connect(m_slot_combos[slot], qOverload<int>(&QComboBox::currentIndexChanged), this,
+    connect(m_slot_combos[slot], &QComboBox::currentIndexChanged, this,
             &GameCubePane::SaveSettings);
     connect(m_slot_buttons[slot], &QPushButton::clicked, [this, slot] { OnConfigPressed(slot); });
   }

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -105,20 +105,20 @@ void GeneralPane::ConnectLayout()
 
   if (AutoUpdateChecker::SystemSupportsAutoUpdates())
   {
-    connect(m_combobox_update_track, qOverload<int>(&QComboBox::currentIndexChanged), this,
+    connect(m_combobox_update_track, &QComboBox::currentIndexChanged, this,
             &GeneralPane::OnSaveConfig);
     connect(&Settings::Instance(), &Settings::AutoUpdateTrackChanged, this,
             &GeneralPane::LoadConfig);
   }
 
   // Advanced
-  connect(m_combobox_speedlimit, qOverload<int>(&QComboBox::currentIndexChanged), [this]() {
+  connect(m_combobox_speedlimit, &QComboBox::currentIndexChanged, [this]() {
     Config::SetBaseOrCurrent(Config::MAIN_EMULATION_SPEED,
                              m_combobox_speedlimit->currentIndex() * 0.1f);
     Config::Save();
   });
 
-  connect(m_combobox_fallback_region, qOverload<int>(&QComboBox::currentIndexChanged), this,
+  connect(m_combobox_fallback_region, &QComboBox::currentIndexChanged, this,
           &GeneralPane::OnSaveConfig);
   connect(&Settings::Instance(), &Settings::FallbackRegionChanged, this, &GeneralPane::LoadConfig);
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -217,13 +217,12 @@ void InterfacePane::ConnectLayout()
   connect(m_checkbox_disable_screensaver, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_focused_hotkeys, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
-  connect(
-      m_combobox_theme, qOverload<int>(&QComboBox::currentIndexChanged), this,
-      [this](int index) { Settings::Instance().SetThemeName(m_combobox_theme->itemText(index)); });
-  connect(m_combobox_userstyle, qOverload<int>(&QComboBox::currentIndexChanged), this,
+  connect(m_combobox_theme, &QComboBox::currentIndexChanged, this, [this](int index) {
+    Settings::Instance().SetThemeName(m_combobox_theme->itemText(index));
+  });
+  connect(m_combobox_userstyle, &QComboBox::currentIndexChanged, this,
           &InterfacePane::OnSaveConfig);
-  connect(m_combobox_language, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &InterfacePane::OnSaveConfig);
+  connect(m_combobox_language, &QComboBox::currentIndexChanged, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_top_window, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_confirm_on_stop, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_use_panic_handlers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -109,12 +109,9 @@ void WiiPane::CreateLayout()
 void WiiPane::ConnectLayout()
 {
   // Misc Settings
-  connect(m_aspect_ratio_choice, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &WiiPane::OnSaveConfig);
-  connect(m_system_language_choice, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &WiiPane::OnSaveConfig);
-  connect(m_sound_mode_choice, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &WiiPane::OnSaveConfig);
+  connect(m_aspect_ratio_choice, &QComboBox::currentIndexChanged, this, &WiiPane::OnSaveConfig);
+  connect(m_system_language_choice, &QComboBox::currentIndexChanged, this, &WiiPane::OnSaveConfig);
+  connect(m_sound_mode_choice, &QComboBox::currentIndexChanged, this, &WiiPane::OnSaveConfig);
   connect(m_screensaver_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
   connect(m_pal60_mode_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
   connect(m_connect_keyboard_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
@@ -128,8 +125,7 @@ void WiiPane::ConnectLayout()
   connect(m_sd_card_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
   connect(m_allow_sd_writes_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
   connect(m_sync_sd_folder_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
-  connect(m_sd_card_size_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
-          &WiiPane::OnSaveConfig);
+  connect(m_sd_card_size_combo, &QComboBox::currentIndexChanged, this, &WiiPane::OnSaveConfig);
 
   // Whitelisted USB Passthrough Devices
   connect(m_whitelist_usb_list, &QListWidget::itemClicked, this, &WiiPane::ValidateSelectionState);
@@ -139,7 +135,7 @@ void WiiPane::ConnectLayout()
           &WiiPane::OnUSBWhitelistRemoveButton);
 
   // Wii Remote Settings
-  connect(m_wiimote_ir_sensor_position, qOverload<int>(&QComboBox::currentIndexChanged), this,
+  connect(m_wiimote_ir_sensor_position, &QComboBox::currentIndexChanged, this,
           &WiiPane::OnSaveConfig);
   connect(m_wiimote_ir_sensitivity, &QSlider::valueChanged, this, &WiiPane::OnSaveConfig);
   connect(m_wiimote_speaker_volume, &QSlider::valueChanged, this, &WiiPane::OnSaveConfig);

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -122,8 +122,8 @@ QGroupBox* TASInputWindow::CreateStickInputs(const QString& text, std::string_vi
   visual->SetX(x_default);
   visual->SetY(y_default);
 
-  connect(x_value, qOverload<int>(&QSpinBox::valueChanged), visual, &StickWidget::SetX);
-  connect(y_value, qOverload<int>(&QSpinBox::valueChanged), visual, &StickWidget::SetY);
+  connect(x_value, &QSpinBox::valueChanged, visual, &StickWidget::SetX);
+  connect(y_value, &QSpinBox::valueChanged, visual, &StickWidget::SetY);
   connect(visual, &StickWidget::ChangedX, x_value, &QSpinBox::setValue);
   connect(visual, &StickWidget::ChangedY, y_value, &QSpinBox::setValue);
 
@@ -208,7 +208,7 @@ TASSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int defaul
   auto* value = new TASSpinBox();
   value->setRange(0, 99999);
   value->setValue(default_);
-  connect(value, qOverload<int>(&QSpinBox::valueChanged), [value, max](int i) {
+  connect(value, &QSpinBox::valueChanged, [value, max](int i) {
     if (i > max)
       value->setValue(max);
   });
@@ -218,7 +218,7 @@ TASSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, int defaul
   slider->setFocusPolicy(Qt::ClickFocus);
 
   connect(slider, &QSlider::valueChanged, value, &QSpinBox::setValue);
-  connect(value, qOverload<int>(&QSpinBox::valueChanged), slider, &QSlider::setValue);
+  connect(value, &QSpinBox::valueChanged, slider, &QSlider::setValue);
 
   auto* shortcut = new QShortcut(shortcut_key_sequence, shortcut_widget);
   connect(shortcut, &QShortcut::activated, [value] {

--- a/Source/Core/DolphinQt/TAS/TASSpinBox.cpp
+++ b/Source/Core/DolphinQt/TAS/TASSpinBox.cpp
@@ -7,7 +7,7 @@
 
 TASSpinBox::TASSpinBox(QWidget* parent) : QSpinBox(parent)
 {
-  connect(this, QOverload<int>::of(&TASSpinBox::valueChanged), this, &TASSpinBox::OnUIValueChanged);
+  connect(this, &TASSpinBox::valueChanged, this, &TASSpinBox::OnUIValueChanged);
 }
 
 int TASSpinBox::GetValue() const

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
@@ -70,8 +70,8 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
   visual->SetX(ir_x_center);
   visual->SetY(ir_y_center);
 
-  connect(m_ir_x_value, qOverload<int>(&QSpinBox::valueChanged), visual, &IRWidget::SetX);
-  connect(m_ir_y_value, qOverload<int>(&QSpinBox::valueChanged), visual, &IRWidget::SetY);
+  connect(m_ir_x_value, &QSpinBox::valueChanged, visual, &IRWidget::SetX);
+  connect(m_ir_y_value, &QSpinBox::valueChanged, visual, &IRWidget::SetY);
   connect(visual, &IRWidget::ChangedX, m_ir_x_value, &QSpinBox::setValue);
   connect(visual, &IRWidget::ChangedY, m_ir_y_value, &QSpinBox::setValue);
 


### PR DESCRIPTION
qOverload is used to disambiguate pointers to overloaded functions, but most of the usages in the code base were with non-overloaded functions.