### PR TITLE
JitArm64: Fix some oddities with non-dirty immediates

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -317,7 +317,6 @@ ARM64Reg Arm64GPRCache::R(const GuestRegInfo& guest_reg)
     ARM64Reg host_reg = bitsize != 64 ? GetReg() : EncodeRegTo64(GetReg());
     m_emit->MOVI2R(host_reg, reg.GetImm());
     reg.Load(host_reg);
-    reg.SetDirty(true);
     return host_reg;
   }
   break;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -232,10 +232,10 @@ void Arm64GPRCache::FlushRegister(size_t index, bool maintain_state, ARM64Reg tm
         if (allocated_tmp_reg)
           UnlockRegister(tmp_reg);
       }
-
-      if (!maintain_state)
-        reg.Flush();
     }
+
+    if (!maintain_state)
+      reg.Flush();
   }
 }
 


### PR DESCRIPTION
This fixes some oversights I made when creating PR #10046. One is a bug fix and one is a slight performance improvement.