### PR TITLE
MMU: on DSI exception, don't set store bit in DSISR on read

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1283,7 +1283,7 @@ void MMU::GenerateDSIException(u32 effective_address, bool write)
   constexpr u32 dsisr_page = 1U << 30;
   constexpr u32 dsisr_store = 1U << 25;
 
-  if (effective_address != 0)
+  if (write)
     m_ppc_state.spr[SPR_DSISR] = dsisr_page | dsisr_store;
   else
     m_ppc_state.spr[SPR_DSISR] = dsisr_page;


### PR DESCRIPTION
Due to a bug introduced when refactoring in 2015 (commit 821db9798c62d14261116d79e17ec3ba09e64706), the store bit in DSISR is set incorrectly when the faulting address is non-zero, and not on a write.

I assume this wasn't noticed due to the parameter actually being used in the log for when the MMU is disabled.

This is a single-line fix, so again I feel a PR is more appropriate than a bug report.