### PR TITLE
MMU: Use VSID in segment register as additional TLB lookup key

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -62,6 +62,7 @@ struct TLBEntry
 
   WayArray tag{INVALID_TAG, INVALID_TAG};
   WayArray paddr{};
+  WayArray vsid{};
   WayArray pte{};
   u32 recent = 0;
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -93,7 +93,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 163;  // Last changed in PR 12217
+constexpr u32 STATE_VERSION = 164;  // Last changed in PR 12282
 
 // Increase this if the StateExtendedHeader definition changes
 constexpr u32 EXTENDED_HEADER_VERSION = 1;  // Last changed in PR 12217


### PR DESCRIPTION
The current TLB implementation does not use the VSID at all.

This is incorrect behaviour (I think the diagram on [A Quick Introduction to the PPC Memory Management System](https://www.usenix.org/legacy/publications/library/proceedings/osdi99/full_papers/dougan/dougan_html/node3.html) explained the correct behaviour easily for me).

The incorrect behaviour leads to previously cached pages still being used until they are flushed out of the TLB, which could lead to an application or game reading or writing to the "wrong" pages.