### PR TITLE
WiiSocket: Explicitly delete move assignment operator

### DIFF
--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -182,10 +182,10 @@ class WiiSocket
 public:
   explicit WiiSocket(WiiSockMan& socket_manager) : m_socket_manager(socket_manager) {}
   WiiSocket(const WiiSocket&) = delete;
-  WiiSocket(WiiSocket&&) = default;
+  WiiSocket(WiiSocket&&) = delete;
   ~WiiSocket();
   WiiSocket& operator=(const WiiSocket&) = delete;
-  WiiSocket& operator=(WiiSocket&&) = default;
+  WiiSocket& operator=(WiiSocket&&) = delete;
 
 private:
   using Timeout = std::chrono::time_point<std::chrono::steady_clock>;


### PR DESCRIPTION
The move assignment operator for a class is implicitly deleted when the class has a non-static reference data member, which is true of WiiSocket's m_socket_manager member.

Explicitly declaring the operator as default generated a -Wdefaulted-function-deleted warning on Clang.