### PR TITLE
SDL: Add default case to switch statement

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -156,6 +156,7 @@ static void EnableSDLLogging()
           log_level = Common::Log::LogLevel::LERROR;
           break;
         case SDL_LOG_PRIORITY_CRITICAL:
+        default:
           log_level = Common::Log::LogLevel::LNOTICE;
           break;
         }


### PR DESCRIPTION
Fix -WSwitch warning about unhandled enum value SDL_NUM_LOG_PRIORITIES.

log_level is initialized to LNOTICE right before the switch statement so this doesn't cause any behavior changes.