### PR TITLE
Add descriptions for more BP registers

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -605,7 +605,7 @@ void FifoPlayer::ClearEfb()
   wh.x = EFB_WIDTH - 1;
   wh.y = EFB_HEIGHT - 1;
   LoadBPReg(BPMEM_EFB_WH, wh.hex);
-  LoadBPReg(BPMEM_MIPMAP_STRIDE, 0x140);
+  LoadBPReg(BPMEM_EFB_STRIDE, 0x140);
   // The clear color and Z value have already been loaded via LoadRegisters()
   LoadBPReg(BPMEM_EFB_ADDR, 0);
   UPE_Copy copy = bpmem.triggerEFBCopy;
@@ -627,7 +627,7 @@ void FifoPlayer::ClearEfb()
   // probably a good idea.
   LoadBPReg(BPMEM_EFB_TL, m_File->GetBPMem()[BPMEM_EFB_TL]);
   LoadBPReg(BPMEM_EFB_WH, m_File->GetBPMem()[BPMEM_EFB_WH]);
-  LoadBPReg(BPMEM_MIPMAP_STRIDE, m_File->GetBPMem()[BPMEM_MIPMAP_STRIDE]);
+  LoadBPReg(BPMEM_EFB_STRIDE, m_File->GetBPMem()[BPMEM_EFB_STRIDE]);
   LoadBPReg(BPMEM_EFB_ADDR, m_File->GetBPMem()[BPMEM_EFB_ADDR]);
   // Wait for the EFB copy to finish.  That way, the EFB copy (which will be performed at a later
   // time) won't clobber any memory updates.

--- a/Source/Core/VideoBackends/Software/TextureEncoder.cpp
+++ b/Source/Core/VideoBackends/Software/TextureEncoder.cpp
@@ -231,7 +231,7 @@ static void SetSpans(int sBlkSize, int tBlkSize, s32* tSpan, s32* sBlkSpan, s32*
   *tBlkSpan = ((640 * tBlkSize) - alignedWidth) *
               readStride;  // bytes to advance src pointer after each row of blocks
 
-  *writeStride = bpmem.copyMipMapStrideChannels * 32;
+  *writeStride = bpmem.copyDestStride << 5;
 }
 
 #define ENCODE_LOOP_BLOCKS                                                                         \

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -2437,7 +2437,7 @@ struct BPMemory
   TEXSCALE texscale[2];            // 0x25,0x26: GXSetIndTexCoordScale
   RAS1_IREF tevindref;             // 0x27: GXSetIndTexOrder
   TwoTevStageOrders tevorders[8];  // 0x28-0x2f
-  TCoordInfo texcoords[8];         // 0x30-0x4f: s,t,s,t,s,t,s,t...
+  TCoordInfo texcoords[8];         // 0x30-0x3f: s,t,s,t,s,t,s,t...
   ZMode zmode;                     // 0x40
   BlendMode blendmode;             // 0x41
   ConstantAlpha dstalpha;          // 0x42

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -1109,6 +1109,16 @@ union ZTex1
   BitField<0, 24, u32> bias;
   u32 hex;
 };
+template <>
+struct fmt::formatter<ZTex1>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const ZTex1& ztex1, FormatContext& ctx) const
+  {
+    return fmt::format_to(ctx.out(), "Bias: 0x{:06x}", ztex1.bias);
+  }
+};
 
 union ZTex2
 {
@@ -2246,6 +2256,17 @@ union BPU_LoadTlutInfo
   BitField<0, 10, u32> tmem_addr;
   BitField<10, 11, u32> tmem_line_count;
   u32 hex;
+};
+template <>
+struct fmt::formatter<BPU_LoadTlutInfo>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const BPU_LoadTlutInfo& info, FormatContext& ctx) const
+  {
+    return fmt::format_to(ctx.out(), "Tmem address: 0x{:05x}\nCount: 0x{:x} lines (0x{:x} bytes)",
+                          info.tmem_addr << 9, info.tmem_line_count, info.tmem_line_count * 32);
+  }
 };
 
 struct BPS_TmemConfig

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -1037,12 +1037,12 @@ struct fmt::formatter<TexImage1>
   auto format(const TexImage1& teximg, FormatContext& ctx) const
   {
     return fmt::format_to(ctx.out(),
-                          "Even TMEM Offset: {:x}\n"
+                          "Even TMEM Line: 0x{:04x} (byte 0x{:05x})\n"
                           "Even TMEM Width: {}\n"
                           "Even TMEM Height: {}\n"
                           "Cache is manually managed: {}",
-                          teximg.tmem_even, teximg.cache_width, teximg.cache_height,
-                          teximg.cache_manually_managed ? "Yes" : "No");
+                          teximg.tmem_even, teximg.tmem_even * 32, teximg.cache_width,
+                          teximg.cache_height, teximg.cache_manually_managed ? "Yes" : "No");
   }
 };
 
@@ -1061,10 +1061,11 @@ struct fmt::formatter<TexImage2>
   auto format(const TexImage2& teximg, FormatContext& ctx) const
   {
     return fmt::format_to(ctx.out(),
-                          "Odd TMEM Offset: {:x}\n"
+                          "Odd TMEM Line: 0x{:04x} (byte 0x{:05x})\n"
                           "Odd TMEM Width: {}\n"
                           "Odd TMEM Height: {}",
-                          teximg.tmem_odd, teximg.cache_width, teximg.cache_height);
+                          teximg.tmem_odd, teximg.tmem_odd * 32, teximg.cache_width,
+                          teximg.cache_height);
   }
 };
 
@@ -1080,7 +1081,7 @@ struct fmt::formatter<TexImage3>
   template <typename FormatContext>
   auto format(const TexImage3& teximg, FormatContext& ctx) const
   {
-    return fmt::format_to(ctx.out(), "Source address (32 byte aligned): 0x{:06X}",
+    return fmt::format_to(ctx.out(), "Source address (32 byte aligned): 0x{:06x}",
                           teximg.image_base << 5);
   }
 };
@@ -1098,7 +1099,7 @@ struct fmt::formatter<TexTLUT>
   template <typename FormatContext>
   auto format(const TexTLUT& tlut, FormatContext& ctx) const
   {
-    return fmt::format_to(ctx.out(), "Address: {:08x}\nFormat: {}", tlut.tmem_offset << 9,
+    return fmt::format_to(ctx.out(), "Tmem address: 0x{:05x}\nFormat: {}", tlut.tmem_offset << 9,
                           tlut.tlut_format);
   }
 };

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -2240,6 +2240,13 @@ struct fmt::formatter<BPU_PreloadTileInfo>
   }
 };
 
+union BPU_LoadTlutInfo
+{
+  BitField<0, 10, u32> tmem_addr;
+  BitField<10, 11, u32> tmem_line_count;
+  u32 hex;
+};
+
 struct BPS_TmemConfig
 {
   u32 preload_addr;
@@ -2247,7 +2254,7 @@ struct BPS_TmemConfig
   u32 preload_tmem_odd;
   BPU_PreloadTileInfo preload_tile_info;
   u32 tlut_src;
-  u32 tlut_dest;
+  BPU_LoadTlutInfo tlut_dest;
   u32 texinvalidate;
 };
 

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -2218,7 +2218,7 @@ union CopyFilterCoefficients
 union BPU_PreloadTileInfo
 {
   BitField<0, 15, u32> count;
-  BitField<15, 2, u32> type;
+  BitField<15, 2, u32> type;  // TODO: enum for this?
   u32 hex;
 };
 template <>
@@ -2228,7 +2228,15 @@ struct fmt::formatter<BPU_PreloadTileInfo>
   template <typename FormatContext>
   auto format(const BPU_PreloadTileInfo& info, FormatContext& ctx) const
   {
-    return fmt::format_to(ctx.out(), "Type: {}\nCount: {}", info.type, info.count);
+    if (info.count == 0 && info.type == 0)
+    {
+      return fmt::format_to(ctx.out(), "GX_TexModeSync (type and count are both 0)");
+    }
+    else
+    {
+      return fmt::format_to(ctx.out(), "Type: {}\nCount: 0x{:x} lines (0x{:x} bytes)", info.type,
+                            info.count, info.count * 32);
+    }
   }
 };
 

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -56,7 +56,7 @@ enum
   BPMEM_EFB_TL = 0x49,
   BPMEM_EFB_WH = 0x4A,
   BPMEM_EFB_ADDR = 0x4B,
-  BPMEM_MIPMAP_STRIDE = 0x4D,
+  BPMEM_EFB_STRIDE = 0x4D,
   BPMEM_COPYYSCALE = 0x4E,
   BPMEM_CLEAR_AR = 0x4F,
   BPMEM_CLEAR_GB = 0x50,
@@ -2426,35 +2426,32 @@ struct BPMemory
   // the 3 offset matrices can either be indirect type, S-type, or T-type
   // 6bit scale factor s is distributed across IND_MTXA/B/C.
   // before using matrices scale by 2^-(s-17)
-  IND_MTX indmtx[3];               // 0x06-0x0e: GXSetIndTexMtx, 2x3 matrices
-  IND_IMASK imask;                 // 0x0f
-  TevStageIndirect tevind[16];     // 0x10-0x1f: GXSetTevIndirect
-  ScissorPos scissorTL;            // 0x20
-  ScissorPos scissorBR;            // 0x21
-  LPSize lineptwidth;              // 0x22
-  u32 sucounter;                   // 0x23
-  u32 rascounter;                  // 0x24
-  TEXSCALE texscale[2];            // 0x25,0x26: GXSetIndTexCoordScale
-  RAS1_IREF tevindref;             // 0x27: GXSetIndTexOrder
-  TwoTevStageOrders tevorders[8];  // 0x28-0x2f
-  TCoordInfo texcoords[8];         // 0x30-0x3f: s,t,s,t,s,t,s,t...
-  ZMode zmode;                     // 0x40
-  BlendMode blendmode;             // 0x41
-  ConstantAlpha dstalpha;          // 0x42
-  PEControl zcontrol;              // 0x43: GXSetZCompLoc, GXPixModeSync
-  FieldMask fieldmask;             // 0x44
-  u32 drawdone;                    // 0x45: bit1=1 if end of list
-  u32 unknown5;                    // 0x46: clock?
-  u32 petoken;                     // 0x47
-  u32 petokenint;                  // 0x48
-  X10Y10 copyTexSrcXY;             // 0x49
-  X10Y10 copyTexSrcWH;             // 0x4a
-  u32 copyTexDest;                 // 0x4b: CopyAddress (GXDispCopy and GXTexCopy use it)
-  u32 unknown6;                    // 0x4c
-  // usually set to 4 when dest is single channel, 8 when dest is 2 channel, 16 when dest is RGBA
-  // also, doubles whenever mipmap box filter option is set (excent on RGBA). Probably to do
-  // with number of bytes to look at when smoothing
-  u32 copyMipMapStrideChannels;       // 0x4d
+  IND_MTX indmtx[3];                  // 0x06-0x0e: GXSetIndTexMtx, 2x3 matrices
+  IND_IMASK imask;                    // 0x0f
+  TevStageIndirect tevind[16];        // 0x10-0x1f: GXSetTevIndirect
+  ScissorPos scissorTL;               // 0x20
+  ScissorPos scissorBR;               // 0x21
+  LPSize lineptwidth;                 // 0x22
+  u32 sucounter;                      // 0x23
+  u32 rascounter;                     // 0x24
+  TEXSCALE texscale[2];               // 0x25,0x26: GXSetIndTexCoordScale
+  RAS1_IREF tevindref;                // 0x27: GXSetIndTexOrder
+  TwoTevStageOrders tevorders[8];     // 0x28-0x2f
+  TCoordInfo texcoords[8];            // 0x30-0x3f: s,t,s,t,s,t,s,t...
+  ZMode zmode;                        // 0x40
+  BlendMode blendmode;                // 0x41
+  ConstantAlpha dstalpha;             // 0x42
+  PEControl zcontrol;                 // 0x43: GXSetZCompLoc, GXPixModeSync
+  FieldMask fieldmask;                // 0x44
+  u32 drawdone;                       // 0x45: bit1=1 if end of list
+  u32 unknown5;                       // 0x46: clock?
+  u32 petoken;                        // 0x47
+  u32 petokenint;                     // 0x48
+  X10Y10 copyTexSrcXY;                // 0x49
+  X10Y10 copyTexSrcWH;                // 0x4a
+  u32 copyTexDest;                    // 0x4b: CopyAddress (GXDispCopy and GXTexCopy use it)
+  u32 unknown6;                       // 0x4c
+  u32 copyDestStride;                 // 0x4d
   u32 dispcopyyscale;                 // 0x4e
   u32 clearcolorAR;                   // 0x4f
   u32 clearcolorGB;                   // 0x50

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -246,7 +246,7 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager,
     // this function
 
     u32 destAddr = bpmem.copyTexDest << 5;
-    u32 destStride = bpmem.copyMipMapStrideChannels << 5;
+    u32 destStride = bpmem.copyDestStride << 5;
 
     MathUtil::Rectangle<s32> srcRect;
     srcRect.left = bpmem.copyTexSrcXY.x;
@@ -515,8 +515,8 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager,
     pixel_shader_manager.SetZModeControl();
     return;
 
-  case BPMEM_MIPMAP_STRIDE:  // MipMap Stride Channel
-  case BPMEM_COPYYSCALE:     // Display Copy Y Scale
+  case BPMEM_EFB_STRIDE:  // Display Copy Stride
+  case BPMEM_COPYYSCALE:  // Display Copy Y Scale
 
   /* 24 RID
    * 21 BC3 - Ind. Tex Stage 3 NTexCoord
@@ -982,8 +982,8 @@ std::pair<std::string, std::string> GetBPRegInfo(u8 cmd, u32 cmddata)
         RegName(BPMEM_EFB_ADDR),
         fmt::format("EFB Target address (32 byte aligned): 0x{:06X}", cmddata << 5));
 
-  case BPMEM_MIPMAP_STRIDE:  // 0x4D
-    return DescriptionlessReg(BPMEM_MIPMAP_STRIDE);
+  case BPMEM_EFB_STRIDE:  // 0x4D
+    return DescriptionlessReg(BPMEM_EFB_STRIDE);
     // TODO: Description
 
   case BPMEM_COPYYSCALE:  // 0x4E

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -991,8 +991,9 @@ std::pair<std::string, std::string> GetBPRegInfo(u8 cmd, u32 cmddata)
         fmt::format("EFB Target address (32 byte aligned): 0x{:06X}", cmddata << 5));
 
   case BPMEM_EFB_STRIDE:  // 0x4D
-    return DescriptionlessReg(BPMEM_EFB_STRIDE);
-    // TODO: Description
+    return std::make_pair(
+        RegName(BPMEM_EFB_STRIDE),
+        fmt::format("EFB destination stride (32 byte aligned): 0x{:06X}", cmddata << 5));
 
   case BPMEM_COPYYSCALE:  // 0x4E
     return std::make_pair(
@@ -1038,12 +1039,14 @@ std::pair<std::string, std::string> GetBPRegInfo(u8 cmd, u32 cmddata)
   }
 
   case BPMEM_CLEARBBOX1:  // 0x55
-    return DescriptionlessReg(BPMEM_CLEARBBOX1);
-    // TODO: Description
+    return std::make_pair(RegName(BPMEM_CLEARBBOX1),
+                          fmt::format("Bounding Box index 0: {}\nBounding Box index 1: {}",
+                                      cmddata & 0x3ff, (cmddata >> 10) & 0x3ff));
 
   case BPMEM_CLEARBBOX2:  // 0x56
-    return DescriptionlessReg(BPMEM_CLEARBBOX2);
-    // TODO: Description
+    return std::make_pair(RegName(BPMEM_CLEARBBOX2),
+                          fmt::format("Bounding Box index 2: {}\nBounding Box index 3: {}",
+                                      cmddata & 0x3ff, (cmddata >> 10) & 0x3ff));
 
   case BPMEM_CLEAR_PIXEL_PERF:  // 0x57
     return DescriptionlessReg(BPMEM_CLEAR_PIXEL_PERF);
@@ -1058,28 +1061,33 @@ std::pair<std::string, std::string> GetBPRegInfo(u8 cmd, u32 cmddata)
                           fmt::to_string(ScissorOffset{.hex = cmddata}));
 
   case BPMEM_PRELOAD_ADDR:  // 0x60
-    return DescriptionlessReg(BPMEM_PRELOAD_ADDR);
-    // TODO: Description
+    return std::make_pair(
+        RegName(BPMEM_PRELOAD_ADDR),
+        fmt::format("Tmem preload address (32 byte aligned, in main memory): 0x{:06x}",
+                    cmddata << 5));
 
   case BPMEM_PRELOAD_TMEMEVEN:  // 0x61
-    return DescriptionlessReg(BPMEM_PRELOAD_TMEMEVEN);
-    // TODO: Description
+    return std::make_pair(RegName(BPMEM_PRELOAD_TMEMEVEN),
+                          fmt::format("Tmem preload even line: 0x{:04x} (byte 0x{:05x})", cmddata,
+                                      cmddata * TMEM_LINE_SIZE));
 
   case BPMEM_PRELOAD_TMEMODD:  // 0x62
-    return DescriptionlessReg(BPMEM_PRELOAD_TMEMODD);
-    // TODO: Description
+    return std::make_pair(RegName(BPMEM_PRELOAD_TMEMODD),
+                          fmt::format("Tmem preload odd line: 0x{:04x} (byte 0x{:05x})", cmddata,
+                                      cmddata * TMEM_LINE_SIZE));
 
   case BPMEM_PRELOAD_MODE:  // 0x63
     return std::make_pair(RegName(BPMEM_PRELOAD_MODE),
                           fmt::to_string(BPU_PreloadTileInfo{.hex = cmddata}));
 
   case BPMEM_LOADTLUT0:  // 0x64
-    return DescriptionlessReg(BPMEM_LOADTLUT0);
-    // TODO: Description
+    return std::make_pair(
+        RegName(BPMEM_LOADTLUT0),
+        fmt::format("TLUT load address (32 byte aligned, in main memory): 0x{:06x}", cmddata << 5));
 
   case BPMEM_LOADTLUT1:  // 0x65
-    return DescriptionlessReg(BPMEM_LOADTLUT1);
-    // TODO: Description
+    return std::make_pair(RegName(BPMEM_LOADTLUT1),
+                          fmt::to_string(BPU_LoadTlutInfo{.hex = cmddata}));
 
   case BPMEM_TEXINVALIDATE:  // 0x66
     return DescriptionlessReg(BPMEM_TEXINVALIDATE);
@@ -1277,12 +1285,11 @@ std::pair<std::string, std::string> GetBPRegInfo(u8 cmd, u32 cmddata)
     return std::make_pair(RegName(BPMEM_FOGPARAM0), fmt::to_string(FogParam0{.hex = cmddata}));
 
   case BPMEM_FOGBMAGNITUDE:  // 0xEF
-    return DescriptionlessReg(BPMEM_FOGBMAGNITUDE);
-    // TODO: Description
+    return std::make_pair(RegName(BPMEM_FOGBMAGNITUDE), fmt::format("B magnitude: {}", cmddata));
 
   case BPMEM_FOGBEXPONENT:  // 0xF0
-    return DescriptionlessReg(BPMEM_FOGBEXPONENT);
-    // TODO: Description
+    return std::make_pair(RegName(BPMEM_FOGBEXPONENT),
+                          fmt::format("B shift: 1>>{} (1/{})", cmddata, 1 << cmddata));
 
   case BPMEM_FOGPARAM3:  // 0xF1
     return std::make_pair(RegName(BPMEM_FOGPARAM3), fmt::to_string(FogParam3{.hex = cmddata}));
@@ -1295,8 +1302,7 @@ std::pair<std::string, std::string> GetBPRegInfo(u8 cmd, u32 cmddata)
     return std::make_pair(RegName(BPMEM_ALPHACOMPARE), fmt::to_string(AlphaTest{.hex = cmddata}));
 
   case BPMEM_BIAS:  // 0xF4
-    return DescriptionlessReg(BPMEM_BIAS);
-    // TODO: Description
+    return std::make_pair(RegName(BPMEM_BIAS), fmt::to_string(ZTex1{.hex = cmddata}));
 
   case BPMEM_ZTEX2:  // 0xF5
     return std::make_pair(RegName(BPMEM_ZTEX2), fmt::to_string(ZTex2{.hex = cmddata}));


### PR DESCRIPTION
I noticed that several registers (mostly those related to tmem) didn't have useful descriptions in the fifo analyzer while looking into https://bugs.dolphin-emu.org/issues/13377. This adds descriptions for those (and makes a few other related cleanup changes). There should be no noticeable changes to emulation behavior.