### PR TITLE
Fix accidental fallthrough in BPStructs

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -525,6 +525,7 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager,
 
   case BPMEM_EFB_STRIDE:  // Display Copy Stride
   case BPMEM_COPYYSCALE:  // Display Copy Y Scale
+    return;
 
   /* 24 RID
    * 21 BC3 - Ind. Tex Stage 3 NTexCoord


### PR DESCRIPTION
This caused us to update the indirect texture information in shaders more often than we needed to, which probably doesn't matter in practice since it's only used in ubershaders and copyyscale and stride are generally only updated before EFB/XFB copies, which generally will have other changes afterwards.