### PR TITLE
Common/MemArenaWin: Don't commit memory pages until they are accessed via segfault handler.

### DIFF
--- a/Source/Core/Common/MemArena.h
+++ b/Source/Core/Common/MemArena.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string_view>
 #include <vector>
 
@@ -155,9 +156,17 @@ public:
   ///
   void Release();
 
+#ifdef _WIN32
+  bool HandleException(uintptr_t address);
+#endif
+
 private:
   void* m_memory = nullptr;
   size_t m_size = 0;
+
+#ifdef _WIN32
+  void* m_exception_handler = nullptr;
+#endif
 };
 
 }  // namespace Common


### PR DESCRIPTION
e: You probably want to merge https://github.com/dolphin-emu/dolphin/pull/12336 instead.

---

This fixes https://bugs.dolphin-emu.org/issues/13387 though not as cleanly as I would like, since as far as I can tell there's no good way to pass userdata to an exception handler on Windows.

Basically, instead of committing the whole 32GB immediately, which causes Windows to assume it needs to reserve space in physical memory and/or the pagefile, we only reserve the memory in the initial VirtualAlloc() call, install an exception handler for accesses into the region, and actually commit the individual pages only once they are accessed.

Suggestions for alternative solutions or improvements welcome. It seems bizarre that there isn't another way to solve this but so far I've come up empty. I've already tried switching back to using CreateFileMapping() instead of VirtualAlloc() ([see here](https://github.com/AdmiralCurtiss/dolphin/commit/318afdc52b2c76ed19bce8a7c00e53dbee63b0f1)) because that was in use before #12150, but the call to that just fails with the 32GB on my system (with 32GB of physical memory, about half of it in use) -- presumably it wants to actually ensure that the 32GB can be used and we just didn't notice it before because a) it was only 8 GB before #12155 and b) it gracefully falls back to the old JIT cache block lookup method if the allocation fails.

(At this point I'm starting to wonder if the huge JIT cache block lookup table is actually worth it. Maybe we should just disable it on Windows...)