### PR TITLE
JitCache: Disable the 32GB JitBlock lookup table on Windows.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -42,7 +42,7 @@ void JitBaseBlockCache::Init()
 {
   Common::JitRegister::Init(Config::Get(Config::MAIN_PERF_MAP_DIR));
 
-#ifdef _ARCH_64
+#if defined(_ARCH_64) && !defined(_WIN32)
   m_entry_points_ptr = reinterpret_cast<u8**>(m_entry_points_arena.Create(FAST_BLOCK_MAP_SIZE));
 #else
   m_entry_points_ptr = nullptr;


### PR DESCRIPTION
e: You probably want to merge https://github.com/dolphin-emu/dolphin/pull/12336 instead.

---

Alternate approach to #12293. Fixes https://bugs.dolphin-emu.org/issues/13387.

Not sure how much performance difference this causes in practice. It doesn't seem to be noticeable on my system, though I haven't tested it all that much.