### PR TITLE
BBA/HLE: Fix GC homebrew if_config not working

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -143,6 +143,12 @@ void CEXIETHERNET::BuiltInBBAInterface::WriteToQueue(const std::vector<u8>& data
 void CEXIETHERNET::BuiltInBBAInterface::HandleARP(const Common::ARPPacket& packet)
 {
   const auto& [hwdata, arpdata] = packet;
+  if (arpdata.sender_address == m_current_mac && arpdata.sender_ip == 0 &&
+      arpdata.target_ip == m_current_ip)
+  {
+    // Ignore ARP probe to itself (RFC 5227) sometimes used to prevent IP collision
+    return;
+  }
   Common::ARPPacket response(m_current_mac, m_router_mac);
   response.arp_header = Common::ARPHeader(arpdata.target_ip, ResolveAddress(arpdata.target_ip),
                                           m_current_ip, m_current_mac);


### PR DESCRIPTION
This PR fixes libogc `if_config` which fails to initialise because it uses ARP to check if the IP address offered by the DHCP is available. If it receives an ARP response, it declines the DHCP offer and return an error.

I haven't tested this PR on my BBA games yet but only tested it on some devkitPPC socket examples for GC homebrews.

Ready to be reviewed & tested.