### PR TITLE
Change HDR paper white default to 203 to match the ITU recommendations

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -153,7 +153,7 @@ const Info<bool> GFX_CC_SDR_DISPLAY_GAMMA_SRGB{
 const Info<float> GFX_CC_SDR_DISPLAY_CUSTOM_GAMMA{
     {System::GFX, "ColorCorrection", "SDRDisplayCustomGamma"}, 2.2f};
 const Info<float> GFX_CC_HDR_PAPER_WHITE_NITS{{System::GFX, "ColorCorrection", "HDRPaperWhiteNits"},
-                                              200.f};
+                                              203.f};
 
 // Graphics.Stereoscopy
 

--- a/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.cpp
@@ -51,7 +51,7 @@ void ColorCorrectionConfigWindow::Create()
       "Controls the base luminance of a paper white surface in nits. Useful for adjusting to "
       "different environmental lighting conditions when using a HDR display.<br><br>HDR output is "
       "required for this setting to take effect.<br><br><dolphin_emphasis>If unsure, leave this at "
-      "200.</dolphin_emphasis>");
+      "203.</dolphin_emphasis>");
 
   // Color Space:
 

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -142,8 +142,9 @@ struct VideoConfig final
     float fSDRDisplayCustomGamma = 2.2f;
 
     // HDR:
-    // 200 is a good default value that matches the brightness of many SDR screens
-    float fHDRPaperWhiteNits = 200.f;
+    // 203 is a good default value that matches the brightness of many SDR screens.
+    // It's also the value recommended by the ITU.
+    float fHDRPaperWhiteNits = 203.f;
   } color_correction;
 
   // Information


### PR DESCRIPTION
This is widely used across HDR implementations (and SDR to HDR conversions)

Source:
https://www.google.com/search?q=paper+white+203+itu

The change is tiny anyway, but at least the value now is based on something that isn't "arbitrary".