### PR TITLE
Update default IP for HLE BBA

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
@@ -21,7 +21,7 @@ enum class StringSetting(
         Settings.FILE_DOLPHIN,
         Settings.SECTION_INI_CORE,
         "BBA_BUILTIN_DNS",
-        "149.56.167.128"
+        "3.18.217.27"
     ),
     MAIN_CUSTOM_RTC_VALUE(
         Settings.FILE_DOLPHIN,

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -134,7 +134,7 @@ const Info<bool> MAIN_BBA_XLINK_CHAT_OSD{{System::Main, "Core", "BBA_XLINK_CHAT_
 
 // Schthack PSO Server - https://schtserv.com/
 const Info<std::string> MAIN_BBA_BUILTIN_DNS{{System::Main, "Core", "BBA_BUILTIN_DNS"},
-                                             "149.56.167.128"};
+                                             "3.18.217.27"};
 const Info<std::string> MAIN_BBA_BUILTIN_IP{{System::Main, "Core", "BBA_BUILTIN_IP"}, ""};
 
 const Info<SerialInterface::SIDevices>& GetInfoForSIDevice(int channel)


### PR DESCRIPTION
This updates the default IP for the HLE BBA, as the existing IP is apparently no longer in use by schtserv (@schthack please feel free to comment here).  The new IP was found [here](https://schtserv.com/).

For the sake of discussion, alternatively consider populating the default IP with 8.8.8.8, and providing a link to a Wiki from the tooltips or inline descriptions, which would then reference other IPs such as schtserv and sylverant (currently 138.197.20.130 as found [here](https://sylverant.net/connecting-to-sylverant/)).  Maintainers of these servers could then more easily update the Wiki with network etc. changes than having to create a PR to do so in the codebase.

On one hand this approach would be more standardized and balanced, however the current method may be better overall since promoting the most popular server fosters a less fragmented and therefore larger online community as it was with the original server.