### PR TITLE
Core: Add option to not report state change to SetState (bugfix)

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -712,7 +712,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
 
 // Set or get the running state
 
-void SetState(State state)
+void SetState(State state, bool report_state_change)
 {
   // State cannot be controlled until the CPU Thread is operational
   if (!IsRunningAndStarted())
@@ -739,7 +739,10 @@ void SetState(State state)
     break;
   }
 
-  CallOnStateChangedCallbacks(GetState());
+  // Certain callers only change the state momentarily. Sending a callback for them causes
+  // unwanted updates, such as the Pause/Play button flickering between states on frame advance.
+  if (report_state_change)
+    CallOnStateChangedCallbacks(GetState());
 }
 
 State GetState()
@@ -1083,7 +1086,7 @@ void DoFrameStep()
     // if already paused, frame advance for 1 frame
     s_stop_frame_step = false;
     s_frame_step = true;
-    SetState(State::Running);
+    SetState(State::Running, false);
   }
   else if (!s_frame_step)
   {

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -750,7 +750,7 @@ State GetState()
   if (s_hardware_initialized)
   {
     auto& system = Core::System::GetInstance();
-    if (system.GetCPU().IsStepping() || s_frame_step)
+    if (system.GetCPU().IsStepping())
       return State::Paused;
 
     return State::Running;

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -147,7 +147,7 @@ bool IsHostThread();
 bool WantsDeterminism();
 
 // [NOT THREADSAFE] For use by Host only
-void SetState(State state);
+void SetState(State state, bool report_state_change = true);
 State GetState();
 
 void SaveScreenShot();

--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
@@ -160,7 +160,7 @@ void CodeDiffDialog::ClearBlockCache()
   Core::State old_state = Core::GetState();
 
   if (old_state == Core::State::Running)
-    Core::SetState(Core::State::Paused);
+    Core::SetState(Core::State::Paused, false);
 
   Core::System::GetInstance().GetJitInterface().ClearCache();
 
@@ -349,7 +349,7 @@ void CodeDiffDialog::Update(bool include)
   // Wrap everything in a pause
   Core::State old_state = Core::GetState();
   if (old_state == Core::State::Running)
-    Core::SetState(Core::State::Paused);
+    Core::SetState(Core::State::Paused, false);
 
   // Main process
   if (include)


### PR DESCRIPTION
bug: https://bugs.dolphin-emu.org/issues/13277

Frame advance was reporting the incorrect emulation state to prevent flickering UI updates, which was breaking debugger widgets and crashing dolphin. Replaced with the option to not report a state change on SetState().

Applied the new option in CodeDiff, because it's a similar quick, temporary state switch.

Breakpoints now work correctly, and playing from a breakpoint will finish the frame advance and then pause.