### PR TITLE
VideoCommon: move texture dump to a free function

### DIFF
--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -724,6 +724,7 @@
     <ClInclude Include="VideoCommon\TextureDecoder_Util.h" />
     <ClInclude Include="VideoCommon\TextureDecoder.h" />
     <ClInclude Include="VideoCommon\TextureInfo.h" />
+    <ClInclude Include="VideoCommon\TextureUtils.h" />
     <ClInclude Include="VideoCommon\TMEM.h" />
     <ClInclude Include="VideoCommon\UberShaderCommon.h" />
     <ClInclude Include="VideoCommon\UberShaderPixel.h" />
@@ -1337,6 +1338,7 @@
     <ClCompile Include="VideoCommon\TextureConverterShaderGen.cpp" />
     <ClCompile Include="VideoCommon\TextureDecoder_Common.cpp" />
     <ClCompile Include="VideoCommon\TextureInfo.cpp" />
+    <ClCompile Include="VideoCommon\TextureUtils.cpp" />
     <ClCompile Include="VideoCommon\TMEM.cpp" />
     <ClCompile Include="VideoCommon\UberShaderCommon.cpp" />
     <ClCompile Include="VideoCommon\UberShaderPixel.cpp" />

--- a/Source/Core/VideoCommon/AbstractTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractTexture.cpp
@@ -19,7 +19,7 @@ void AbstractTexture::FinishedRendering()
 {
 }
 
-bool AbstractTexture::Save(const std::string& filename, unsigned int level, int compression)
+bool AbstractTexture::Save(const std::string& filename, unsigned int level, int compression) const
 {
   // We can't dump compressed textures currently (it would mean drawing them to a RGBA8
   // framebuffer, and saving that). TextureCache does not call Save for custom textures

--- a/Source/Core/VideoCommon/AbstractTexture.h
+++ b/Source/Core/VideoCommon/AbstractTexture.h
@@ -38,7 +38,7 @@ public:
   MathUtil::Rectangle<int> GetRect() const { return m_config.GetRect(); }
   MathUtil::Rectangle<int> GetMipRect(u32 level) const { return m_config.GetMipRect(level); }
   bool IsMultisampled() const { return m_config.IsMultisampled(); }
-  bool Save(const std::string& filename, unsigned int level, int compression = 6);
+  bool Save(const std::string& filename, unsigned int level, int compression = 6) const;
 
   static bool IsCompressedFormat(AbstractTextureFormat format);
   static bool IsDepthFormat(AbstractTextureFormat format);

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -155,6 +155,8 @@ add_library(videocommon
   TextureDecoder_Util.h
   TextureInfo.cpp
   TextureInfo.h
+  TextureUtils.cpp
+  TextureUtils.h
   TMEM.cpp
   TMEM.h
   UberShaderCommon.cpp

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -52,6 +52,7 @@
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/TextureConverterShaderGen.h"
 #include "VideoCommon/TextureDecoder.h"
+#include "VideoCommon/TextureUtils.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
@@ -998,39 +999,6 @@ RcTcacheEntry TextureCacheBase::DoPartialTextureUpdates(RcTcacheEntry& entry_to_
   return entry_to_update;
 }
 
-void TextureCacheBase::DumpTexture(RcTcacheEntry& entry, std::string basename, unsigned int level,
-                                   bool is_arbitrary)
-{
-  std::string szDir = File::GetUserPath(D_DUMPTEXTURES_IDX) + SConfig::GetInstance().GetGameID();
-
-  // make sure that the directory exists
-  if (!File::IsDirectory(szDir))
-    File::CreateDir(szDir);
-
-  if (is_arbitrary)
-  {
-    basename += "_arb";
-  }
-
-  if (level > 0)
-  {
-    if (!g_ActiveConfig.bDumpMipmapTextures)
-      return;
-    basename += fmt::format("_mip{}", level);
-  }
-  else
-  {
-    if (!g_ActiveConfig.bDumpBaseTextures)
-      return;
-  }
-
-  const std::string filename = fmt::format("{}/{}.png", szDir, basename);
-  if (File::Exists(filename))
-    return;
-
-  entry->texture->Save(filename, level, Config::Get(Config::GFX_TEXTURE_PNG_COMPRESSION_LEVEL));
-}
-
 // Helper for checking if a BPMemory TexMode0 register is set to Point
 // Filtering modes. This is used to decide whether Anisotropic enhancements
 // are (mostly) safe in the VideoBackends.
@@ -1838,12 +1806,21 @@ RcTcacheEntry TextureCacheBase::CreateTextureEntry(
 
     entry->has_arbitrary_mips = arbitrary_mip_detector.HasArbitraryMipmaps(dst_buffer);
 
-    if (g_ActiveConfig.bDumpTextures && !skip_texture_dump)
+    if (g_ActiveConfig.bDumpTextures && !skip_texture_dump && texLevels > 0)
     {
       const std::string basename = texture_info.CalculateTextureName().GetFullName();
-      for (u32 level = 0; level < texLevels; ++level)
+      if (g_ActiveConfig.bDumpBaseTextures)
       {
-        DumpTexture(entry, basename, level, entry->has_arbitrary_mips);
+        VideoCommon::TextureUtils::DumpTexture(*entry->texture, basename, 0,
+                                               entry->has_arbitrary_mips);
+      }
+      if (g_ActiveConfig.bDumpMipmapTextures)
+      {
+        for (u32 level = 1; level < texLevels; ++level)
+        {
+          VideoCommon::TextureUtils::DumpTexture(*entry->texture, basename, level,
+                                                 entry->has_arbitrary_mips);
+        }
       }
     }
   }

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -361,8 +361,6 @@ private:
                                         TLUTFormat tlutfmt);
   void StitchXFBCopy(RcTcacheEntry& entry_to_update);
 
-  void DumpTexture(RcTcacheEntry& entry, std::string basename, unsigned int level,
-                   bool is_arbitrary);
   void CheckTempSize(size_t required_size);
 
   RcTcacheEntry AllocateCacheEntry(const TextureConfig& config);

--- a/Source/Core/VideoCommon/TextureUtils.cpp
+++ b/Source/Core/VideoCommon/TextureUtils.cpp
@@ -1,0 +1,41 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "VideoCommon/TextureUtils.h"
+
+#include <fmt/format.h>
+
+#include "Common/FileUtil.h"
+#include "Core/Config/GraphicsSettings.h"
+#include "Core/ConfigManager.h"
+
+#include "VideoCommon/AbstractTexture.h"
+
+namespace VideoCommon::TextureUtils
+{
+void DumpTexture(const ::AbstractTexture& texture, std::string basename, u32 level,
+                 bool is_arbitrary)
+{
+  std::string szDir = File::GetUserPath(D_DUMPTEXTURES_IDX) + SConfig::GetInstance().GetGameID();
+
+  // make sure that the directory exists
+  if (!File::IsDirectory(szDir))
+    File::CreateDir(szDir);
+
+  if (is_arbitrary)
+  {
+    basename += "_arb";
+  }
+
+  if (level > 0)
+  {
+    basename += fmt::format("_mip{}", level);
+  }
+
+  const std::string filename = fmt::format("{}/{}.png", szDir, basename);
+  if (File::Exists(filename))
+    return;
+
+  texture.Save(filename, level, Config::Get(Config::GFX_TEXTURE_PNG_COMPRESSION_LEVEL));
+}
+}  // namespace VideoCommon::TextureUtils

--- a/Source/Core/VideoCommon/TextureUtils.h
+++ b/Source/Core/VideoCommon/TextureUtils.h
@@ -1,0 +1,16 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+#include "Common/CommonTypes.h"
+
+class AbstractTexture;
+
+namespace VideoCommon::TextureUtils
+{
+void DumpTexture(const ::AbstractTexture& texture, std::string basename, u32 level,
+                 bool is_arbitrary);
+}


### PR DESCRIPTION
This PR moves the texture dump logic out of the texture cache to a free function so that it can be used elsewhere if desired.  Some slight changes were made that could be considered a slight performance boost when using this capability (depending on configuration).