### PR TITLE
AX: fix envelope volume for Wii ucodes

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -424,7 +424,14 @@ void ProcessVoice(PB_TYPE& pb, const AXBuffers& buffers, u16 count, AXMixControl
   // Apply a global volume ramp using the volume envelope parameters.
   for (u32 i = 0; i < count; ++i)
   {
-    const s32 sample = ((s32)samples[i] * pb.vol_env.cur_volume) >> 15;
+#ifdef AX_GC
+    // signed on GameCube
+    const s32 volume = (s16)pb.vol_env.cur_volume;
+#else
+    // unsigned on Wii
+    const s32 volume = (u16)pb.vol_env.cur_volume;
+#endif
+    const s32 sample = ((s32)samples[i] * volume) >> 15;
     samples[i] = std::clamp(sample, -32767, 32767);  // -32768 ?
     pb.vol_env.cur_volume += pb.vol_env.cur_volume_delta;
   }


### PR DESCRIPTION
Technically it is signed in the 0x7699af32 ucode but that's only used by the Wii Startup Disc which never uses negative values.

This fixes [issue 13396](https://bugs.dolphin-emu.org/issues/13396).