### PR TITLE
Jit: Get rid of short-lived std::vectors

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -7,12 +7,12 @@
 #include <cmath>
 #include <limits>
 #include <optional>
-#include <vector>
 
 #include "Common/Assert.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
+#include "Common/SmallVector.h"
 #include "Common/x64Emitter.h"
 #include "Core/Config/SessionSettings.h"
 #include "Core/ConfigManager.h"
@@ -119,7 +119,7 @@ void Jit64::HandleNaNs(UGeckoInstruction inst, X64Reg xmm, X64Reg clobber, std::
     SetJumpTarget(handle_nan);
 
     // If any inputs are NaNs, pick the first NaN of them
-    std::vector<FixupBranch> fixups;
+    Common::SmallVector<FixupBranch, 3> fixups;
     const auto check_input = [&](const OpArg& Rx) {
       MOVDDUP(xmm, Rx);
       UCOMISD(xmm, R(xmm));

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -6,13 +6,13 @@
 #include <array>
 #include <bit>
 #include <limits>
-#include <vector>
 
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
+#include "Common/SmallVector.h"
 #include "Common/x64Emitter.h"
 
 #include "Core/CoreTiming.h"
@@ -2723,7 +2723,7 @@ void Jit64::twX(UGeckoInstruction inst)
   }
 
   constexpr std::array<CCFlags, 5> conditions{{CC_A, CC_B, CC_E, CC_G, CC_L}};
-  std::vector<FixupBranch> fixups;
+  Common::SmallVector<FixupBranch, conditions.size()> fixups;
 
   for (size_t i = 0; i < conditions.size(); i++)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -9,6 +9,7 @@
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
+#include "Common/SmallVector.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Config/SessionSettings.h"
@@ -189,7 +190,7 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
     break;
   }
 
-  std::vector<FixupBranch> nan_fixups;
+  Common::SmallVector<FixupBranch, 4> nan_fixups;
   if (m_accurate_nans)
   {
     // Check if we need to handle NaNs
@@ -205,7 +206,7 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
 
     EmitQuietNaNBitConstant(quiet_bit_reg, inputs_are_singles && output_is_single, temp_gpr);
 
-    std::vector<ARM64Reg> inputs;
+    Common::SmallVector<ARM64Reg, 3> inputs;
     inputs.push_back(VA);
     if (use_b && VA != VB)
       inputs.push_back(VB);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -3,10 +3,13 @@
 
 #include "Core/PowerPC/JitArm64/Jit.h"
 
+#include <array>
+
 #include "Common/Arm64Emitter.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
+#include "Common/SmallVector.h"
 
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -231,10 +234,10 @@ void JitArm64::twx(UGeckoInstruction inst)
     CMP(gpr.R(a), gpr.R(inst.RB));
   }
 
-  std::vector<FixupBranch> fixups;
-  CCFlags conditions[] = {CC_LT, CC_GT, CC_EQ, CC_VC, CC_VS};
+  constexpr std::array<CCFlags, 5> conditions{{CC_LT, CC_GT, CC_EQ, CC_VC, CC_VS}};
+  Common::SmallVector<FixupBranch, conditions.size()> fixups;
 
-  for (int i = 0; i < 5; i++)
+  for (int i = 0; i < conditions.size(); i++)
   {
     if (inst.TO & (1 << i))
     {


### PR DESCRIPTION
Let's aim for making as few heap allocations as possible while jitting.