### PR TITLE
DSPHLE: Support 2023 libaesnd uCode

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.cpp
@@ -72,13 +72,13 @@ constexpr u32 ACCELERATOR_GAIN_16_BIT = 0x0800;
 bool AESndUCode::SwapLeftRight() const
 {
   return m_crc == HASH_2012 || m_crc == HASH_EDUKE32 || m_crc == HASH_2020 ||
-         m_crc == HASH_2020_PAD || m_crc == HASH_2022_PAD;
+         m_crc == HASH_2020_PAD || m_crc == HASH_2022_PAD || m_crc == HASH_2023;
 }
 
 bool AESndUCode::UseNewFlagMasks() const
 {
   return m_crc == HASH_EDUKE32 || m_crc == HASH_2020 || m_crc == HASH_2020_PAD ||
-         m_crc == HASH_2022_PAD;
+         m_crc == HASH_2022_PAD || m_crc == HASH_2023;
 }
 
 AESndUCode::AESndUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
@@ -164,7 +164,7 @@ void AESndUCode::HandleMail(u32 mail)
       break;
     case MAIL_TERMINATE:
       INFO_LOG_FMT(DSPHLE, "AESndUCode - MAIL_TERMINATE: {:08x}", mail);
-      if (m_crc != HASH_2022_PAD)
+      if (m_crc != HASH_2022_PAD && m_crc != HASH_2023)
       {
         // The relevant code looks like this:
         //
@@ -181,9 +181,6 @@ void AESndUCode::HandleMail(u32 mail)
         // AESND_Reset never returns, resulting in a hang. We always send the mail to avoid this
         // hang. (It's possible to exit without calling AESND_Reset, so most homebrew probably
         // isn't affected by this bug in the first place.)
-        //
-        // A fix exists, but has not yet been added to mainline libogc:
-        // https://github.com/extremscorner/libogc2/commit/38edc9db93232faa612f680c91be1eb4d95dd1c6
         WARN_LOG_FMT(DSPHLE, "AESndUCode - MAIL_TERMINATE is broken in this version of the "
                              "uCode; this will hang on real hardware or with DSP LLE");
       }

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
@@ -45,10 +45,14 @@ public:
   // https://github.com/extremscorner/libogc-rice/commit/cfddd4f3bec77812d6d333954e39d401d2276cd8
   // https://github.com/extremscorner/libogc2/commit/89ae39544e22f720a9c986af3524f7e6f20e7293
   static constexpr u32 HASH_2020_PAD = 0xa02a6131;
-  // July 19, 2022 version (padded to 0x0400 bytes) - fixed MAIL_TERMINATE. This is not currently
-  // included in libogc, only in libogc2 and libogc-rice (which generate a padded header file).
+  // July 19, 2022 version (padded to 0x0400 bytes) - fixed MAIL_TERMINATE. This padded version
+  // is only in libogc2 and libogc-rice (which generate a padded header file).
   // https://github.com/extremscorner/libogc2/commit/38edc9db93232faa612f680c91be1eb4d95dd1c6
   static constexpr u32 HASH_2022_PAD = 0x2e5e4100;
+  // March 13, 2023 version (0x03e8 bytes) - fixed MAIL_TERMINATE. This is the same fix as the
+  // above version, and was released in regular libogc 2.4.0 on April 17, 2023.
+  // https://github.com/devkitPro/libogc/commit/a7e4bcd3ad4477d8dfc3aa196cfeb10cf195cd6a
+  static constexpr u32 HASH_2023 = 0x002e5e41;
 
 private:
   void DMAInParameterBlock();

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -324,6 +324,7 @@ std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
   case AESndUCode::HASH_2020:
   case AESndUCode::HASH_2020_PAD:
   case AESndUCode::HASH_2022_PAD:
+  case AESndUCode::HASH_2023:
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: AESnd chosen (Homebrew)", crc);
     return std::make_unique<AESndUCode>(dsphle, crc);
 


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/13401. This was added in libogc 2.4.0, PR devkitPro/libogc#143. We already implemented the padded version in libogc2/libogc-rice in #10892.

<details><summary>Hashes of relevant versions</summary>

[aesnd_ucode_versions_2023.zip](https://github.com/dolphin-emu/dolphin/files/13401501/aesnd_ucode_versions_2023.zip) contains 3 ucodes relevant to this change:

```
Hashes of DSP_UC_2e5e4100.bin: ector 2e5e4100 crc 8e2da39f adler 6ed62d5e fletcher 664dee8d; 0400 bytes (0200 words)
Hashes of DSP_UC_002e5e41.bin: ector 002e5e41 crc 5ba4fb19 adler 2dca2d5e 03e8 bytes (01f4 words)
Hashes of DSP_UC_802e5e41.bin: ector 802e5e41 crc 7380067f adler 311f2d5f 03e8 bytes (01f4 words)
```

`DSP_UC_2e5e4100.bin` is the padded version from libogc2, which is the same as `Extrems/compiled_pad.bin` from #10892.

`DSP_UC_802e5e41.bin` is a broken version of this uCode that was in the libogc PR. I didn't implement it since it shouldn't ever appear in the wild, but I included it here for search purposes. And, it's a 1-bit difference in the input file which has a 1-bit difference in the hash, which shows how terrible the ector hash we're using is (also note how the padded version is the exact same hash, just rotated...)

I generated the hashes with `hash3.patch` in the zip file; the fletcher hash was moved elsewhere in #10903 so I just skipped it.
</details>