### PR TITLE
BBA/HLE: Fix random PCAP file corruption

### DIFF
--- a/Source/Core/Common/PcapFile.cpp
+++ b/Source/Core/Common/PcapFile.cpp
@@ -49,6 +49,7 @@ void PCAP::AddHeader(u32 link_type)
   m_fp->WriteBytes(&hdr, sizeof(hdr));
 }
 
+// Not thread-safe, concurrency between multiple calls to IOFile::WriteBytes.
 void PCAP::AddPacket(const u8* bytes, size_t size)
 {
   std::chrono::system_clock::time_point now(std::chrono::system_clock::now());

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -123,6 +123,9 @@ void PCAPSSLCaptureLogger::LogBBA(const void* data, std::size_t length)
 {
   if (!Config::Get(Config::MAIN_NETWORK_DUMP_BBA))
     return;
+
+  // Concurrency between CEXIETHERNET's RecvHandlePacket and SendFromDirectFIFO
+  const std::lock_guard lock(m_io_mutex);
   m_file->AddPacket(static_cast<const u8*>(data), length);
 }
 

--- a/Source/Core/Core/NetworkCaptureLogger.h
+++ b/Source/Core/Core/NetworkCaptureLogger.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <map>
 #include <memory>
+#include <mutex>
 
 #ifdef _WIN32
 #include <WinSock2.h>
@@ -111,6 +112,7 @@ private:
                const sockaddr_in& to);
 
   std::unique_ptr<Common::PCAP> m_file;
+  std::mutex m_io_mutex;
   std::map<s32, u32> m_read_sequence_number;
   std::map<s32, u32> m_write_sequence_number;
 };


### PR DESCRIPTION
This PR addresses a concurrency issue between RecvHandlePacket and SendFromDirectFIFO while logging BBA packets in a PCAP file. I chose not to implement the lock in the PCAP class to avoid performance impacts in cases where there are no concurrency.

Ready to be reviewed & tested.