### PR TITLE
PPCAnalyst: Don't discard registers across HLE'd functions

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -200,6 +200,23 @@ HookFlag GetHookFlagsByIndex(u32 index)
   return os_patches[index].flags;
 }
 
+TryReplaceFunctionResult TryReplaceFunction(u32 address)
+{
+  const u32 hook_index = GetHookByFunctionAddress(address);
+  if (hook_index == 0)
+    return {};
+
+  const HookType type = GetHookTypeByIndex(hook_index);
+  if (type != HookType::Start && type != HookType::Replace)
+    return {};
+
+  const HookFlag flags = GetHookFlagsByIndex(hook_index);
+  if (!IsEnabled(flags))
+    return {};
+
+  return {type, hook_index};
+}
+
 bool IsEnabled(HookFlag flag)
 {
   return flag != HLE::HookFlag::Debug || Config::Get(Config::MAIN_ENABLE_DEBUGGING) ||

--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -19,9 +19,9 @@ using HookFunction = void (*)(const Core::CPUThreadGuard&);
 
 enum class HookType
 {
+  None,     // Do not hook the function
   Start,    // Hook the beginning of the function and execute the function afterwards
   Replace,  // Replace the function with the HLE version
-  None,     // Do not hook the function
 };
 
 enum class HookFlag
@@ -37,6 +37,14 @@ struct Hook
   HookFunction function;
   HookType type;
   HookFlag flags;
+};
+
+struct TryReplaceFunctionResult
+{
+  HookType type = HookType::None;
+  u32 hook_index = 0;
+
+  explicit operator bool() const { return type != HookType::None; }
 };
 
 void PatchFixedFunctions(Core::System& system);
@@ -59,32 +67,8 @@ HookFlag GetHookFlagsByIndex(u32 index);
 
 bool IsEnabled(HookFlag flag);
 
-// Performs the backend-independent preliminary checking before calling a
-// FunctionObject to do the actual replacing. Typically, this callback will
-// be in the backend itself, containing the backend-specific portions
-// required in replacing a function.
-//
-// fn may be any object that satisfies the FunctionObject concept in the C++
-// standard library. That is, any lambda, object with an overloaded function
-// call operator, or regular function pointer.
-//
-// fn must return a bool indicating whether or not function replacing occurred.
-// fn must also accept a parameter list of the form: fn(u32 function, HLE::HookType type).
-template <typename FunctionObject>
-bool ReplaceFunctionIfPossible(u32 address, FunctionObject fn)
-{
-  const u32 hook_index = GetHookByFunctionAddress(address);
-  if (hook_index == 0)
-    return false;
+// Performs the backend-independent preliminary checking for whether a function
+// can be HLEd. If it can be, the information needed for HLEing it is returned.
+TryReplaceFunctionResult TryReplaceFunction(u32 address);
 
-  const HookType type = GetHookTypeByIndex(hook_index);
-  if (type != HookType::Start && type != HookType::Replace)
-    return false;
-
-  const HookFlag flags = GetHookFlagsByIndex(hook_index);
-  if (!IsEnabled(flags))
-    return false;
-
-  return fn(hook_index, type);
-}
 }  // namespace HLE

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -106,10 +106,13 @@ void Interpreter::Trace(const UGeckoInstruction& inst)
 
 bool Interpreter::HandleFunctionHooking(u32 address)
 {
-  return HLE::ReplaceFunctionIfPossible(address, [this](u32 hook_index, HLE::HookType type) {
-    HLEFunction(*this, hook_index);
-    return type != HLE::HookType::Start;
-  });
+  const auto result = HLE::TryReplaceFunction(address);
+  if (!result)
+    return false;
+
+  HLEFunction(*this, result.hook_index);
+
+  return result.type != HLE::HookType::Start;
 }
 
 int Interpreter::SingleStepInner()


### PR DESCRIPTION
Not sure if this was causing correctness issues – it depends on whether the HLE code was actually reading the discarded registers – but it was at least causing annoying assert messages in one piece of homebrew.