### PR TITLE
Test: invalidate TMEM on GXTexModeSync

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -625,9 +625,8 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager,
 
       if (OpcodeDecoder::g_record_fifo_data)
         FifoRecorder::GetInstance().UseMemory(src_addr, bytes_read, MemoryUpdate::Type::TMEM);
-
-      TMEM::InvalidateAll();
     }
+    TMEM::InvalidateAll();
     return;
 
   // ---------------------------------------------------


### PR DESCRIPTION
This may or may not fix Defender (see https://bugs.dolphin-emu.org/issues/13403).