### PR TITLE
IOS: fix crash when closing invalid file descriptor

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -654,7 +654,7 @@ std::shared_ptr<Device> EmulationKernel::GetDeviceByName(std::string_view device
   return iterator != m_device_map.end() ? iterator->second : nullptr;
 }
 
-std::shared_ptr<Device> EmulationKernel::GetDeviceByFileDescriptor(const int fd)
+std::shared_ptr<Device> EmulationKernel::GetDeviceByFileDescriptor(const u32 fd)
 {
   if (fd < IPC_MAX_FDS)
     return m_fdmap[fd];

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -154,7 +154,7 @@ public:
   // Get a resource manager by name.
   // This only works for devices which are part of the device map.
   std::shared_ptr<Device> GetDeviceByName(std::string_view device_name);
-  std::shared_ptr<Device> GetDeviceByFileDescriptor(const int fd);
+  std::shared_ptr<Device> GetDeviceByFileDescriptor(const u32 fd);
 
   std::shared_ptr<FSDevice> GetFSDevice();
   std::shared_ptr<ESDevice> GetESDevice();


### PR DESCRIPTION
The game [Truth or Lies](https://wiki.dolphin-emu.org/index.php?title=Truth_or_Lies) does this for some reason.

This regression was introduced in #12244 (5.0-20284).