### PR TITLE
Metal: fix crash by enabling concurrent compilation only if available

### DIFF
--- a/Source/Core/VideoBackends/Metal/MTLMain.mm
+++ b/Source/Core/VideoBackends/Metal/MTLMain.mm
@@ -96,8 +96,23 @@ bool Metal::VideoBackend::Initialize(const WindowSystemInfo& wsi)
     Util::PopulateBackendInfoFeatures(&g_Config, adapter);
 
 #if TARGET_OS_OSX
-    if (@available(macOS 13.3, *))
+// This should be available on all macOS 13.3+ systems – but when using OCLP drivers, some devices
+// fail with "Unrecognized selector -[MTLIGAccelDevice setShouldMaximizeConcurrentCompilation:]"
+//
+// This concerns Intel Ivy Bridge, Haswell and Nvidia Kepler on macOS 13.3 or newer.
+// (See
+// https://github.com/dortania/OpenCore-Legacy-Patcher/blob/34676702f494a2a789c514cc76dba19b8b7206b1/docs/PATCHEXPLAIN.md?plain=1#L354C1-L354C83)
+//
+// Perform the feature detection dynamically instead.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+
+    if ([adapter respondsToSelector:@selector(setShouldMaximizeConcurrentCompilation:)])
+    {
       [adapter setShouldMaximizeConcurrentCompilation:YES];
+    }
+
+#pragma clang diagnostic pop
 #endif
 
     UpdateActiveConfig();


### PR DESCRIPTION
Bug: https://bugs.dolphin-emu.org/issues/13404

On macOS 13.6 / Intel Iris with Metal 2, when starting any game, Dolphin crashes immediately with this message:

> -[MTLIGAccelDevice setShouldMaximizeConcurrentCompilation:]: unrecognized selector

It seems that even on macOS 13.3+, not all devices implement this selector (first implemented in #11911).

As the behavior is an optional optimization anyway, we now perform a dynamic detection to avoid crashing if the feature is not available.