### PR TITLE
GameSettings: port Gormiti black screen fix to PAL version

### DIFF
--- a/Data/Sys/GameSettings/SGLPA4.ini
+++ b/Data/Sys/GameSettings/SGLPA4.ini
@@ -1,0 +1,8 @@
+# SGLPA4 - Gormiti: The Lords of Nature!
+
+[OnFrame]
+# Fixes black screen ingame, see https://bugs.dolphin-emu.org/issues/12436
+# This NOPs out UpdateFade's call to RenderFade. We are probably emulating the way the fade works
+# incorrectly, but for now this patch makes the game playable.
+$Fix black screen
+0x801D59C8:dword:0x60000000


### PR DESCRIPTION
Same workaround as @Pokechu22's NTSC version (8316c7af9964f19cc54c3533e017252f922ceee9).