### PR TITLE
InterfacePane: Add BalloonTips

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
@@ -33,10 +33,21 @@ void ConfigChoice::Update(int choice)
 
 ConfigStringChoice::ConfigStringChoice(const std::vector<std::string>& options,
                                        const Config::Info<std::string>& setting)
-    : m_setting(setting)
+    : m_setting(setting), m_text_is_data(true)
 {
   for (const auto& op : options)
     addItem(QString::fromStdString(op));
+
+  Connect();
+  Load();
+}
+
+ConfigStringChoice::ConfigStringChoice(const std::vector<std::pair<QString, QString>>& options,
+                                       const Config::Info<std::string>& setting)
+    : m_setting(setting), m_text_is_data(false)
+{
+  for (const auto& [option_text, option_data] : options)
+    addItem(option_text, option_data);
 
   Connect();
   Load();
@@ -58,11 +69,21 @@ void ConfigStringChoice::Connect()
 
 void ConfigStringChoice::Update(int index)
 {
-  Config::SetBaseOrCurrent(m_setting, itemText(index).toStdString());
+  if (m_text_is_data)
+  {
+    Config::SetBaseOrCurrent(m_setting, itemText(index).toStdString());
+  }
+  else
+  {
+    Config::SetBaseOrCurrent(m_setting, itemData(index).toString().toStdString());
+  }
 }
 
 void ConfigStringChoice::Load()
 {
+  const QString setting_value = QString::fromStdString(Config::Get(m_setting));
+
+  const int index = m_text_is_data ? findText(setting_value) : findData(setting_value);
   const QSignalBlocker blocker(this);
-  setCurrentIndex(findText(QString::fromStdString(Config::Get(m_setting))));
+  setCurrentIndex(index);
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
@@ -30,3 +30,39 @@ void ConfigChoice::Update(int choice)
 {
   Config::SetBaseOrCurrent(m_setting, choice);
 }
+
+ConfigStringChoice::ConfigStringChoice(const std::vector<std::string>& options,
+                                       const Config::Info<std::string>& setting)
+    : m_setting(setting)
+{
+  for (const auto& op : options)
+    addItem(QString::fromStdString(op));
+
+  Connect();
+  Load();
+}
+
+void ConfigStringChoice::Connect()
+{
+  const auto on_config_changed = [this]() {
+    QFont bf = font();
+    bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
+    setFont(bf);
+
+    Load();
+  };
+
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, on_config_changed);
+  connect(this, &QComboBox::currentIndexChanged, this, &ConfigStringChoice::Update);
+}
+
+void ConfigStringChoice::Update(int index)
+{
+  Config::SetBaseOrCurrent(m_setting, itemText(index).toStdString());
+}
+
+void ConfigStringChoice::Load()
+{
+  const QSignalBlocker blocker(this);
+  setCurrentIndex(findText(QString::fromStdString(Config::Get(m_setting))));
+}

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
 
 #include "Common/Config/Config.h"
@@ -17,4 +20,19 @@ private:
   void Update(int choice);
 
   Config::Info<int> m_setting;
+};
+
+class ConfigStringChoice : public ToolTipComboBox
+{
+  Q_OBJECT
+public:
+  ConfigStringChoice(const std::vector<std::string>& options,
+                     const Config::Info<std::string>& setting);
+
+private:
+  void Connect();
+  void Update(int index);
+  void Load();
+
+  Config::Info<std::string> m_setting;
 };

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
@@ -28,6 +29,8 @@ class ConfigStringChoice : public ToolTipComboBox
 public:
   ConfigStringChoice(const std::vector<std::string>& options,
                      const Config::Info<std::string>& setting);
+  ConfigStringChoice(const std::vector<std::pair<QString, QString>>& options,
+                     const Config::Info<std::string>& setting);
 
 private:
   void Connect();
@@ -35,4 +38,5 @@ private:
   void Load();
 
   Config::Info<std::string> m_setting;
+  bool m_text_is_data = false;
 };

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
@@ -27,8 +27,13 @@ ConfigRadioInt::ConfigRadioInt(const QString& label, const Config::Info<int>& se
 
 void ConfigRadioInt::Update()
 {
-  if (!isChecked())
-    return;
-
-  Config::SetBaseOrCurrent(m_setting, m_value);
+  if (isChecked())
+  {
+    Config::SetBaseOrCurrent(m_setting, m_value);
+    emit OnSelected(m_value);
+  }
+  else
+  {
+    emit OnDeselected(m_value);
+  }
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
@@ -13,6 +13,12 @@ class ConfigRadioInt : public ToolTipRadioButton
 public:
   ConfigRadioInt(const QString& label, const Config::Info<int>& setting, int value);
 
+signals:
+  // Since selecting a new radio button deselects the old one, ::toggled will generate two signals.
+  // These are convenience functions so you can receive only one signal if desired.
+  void OnSelected(int new_value);
+  void OnDeselected(int old_value);
+
 private:
   void Update();
 

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -429,12 +429,6 @@ Config::ShowCursor Settings::GetCursorVisibility() const
   return Config::Get(Config::MAIN_SHOW_CURSOR);
 }
 
-void Settings::SetLockCursor(bool lock_cursor)
-{
-  Config::SetBaseOrCurrent(Config::MAIN_LOCK_CURSOR, lock_cursor);
-  emit LockCursorChanged();
-}
-
 bool Settings::GetLockCursor() const
 {
   return Config::Get(Config::MAIN_LOCK_CURSOR);

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -418,12 +418,6 @@ void Settings::SetStateSlot(int slot)
   GetQSettings().setValue(QStringLiteral("Emulation/StateSlot"), slot);
 }
 
-void Settings::SetCursorVisibility(Config::ShowCursor hideCursor)
-{
-  Config::SetBaseOrCurrent(Config::MAIN_SHOW_CURSOR, hideCursor);
-  emit CursorVisibilityChanged();
-}
-
 Config::ShowCursor Settings::GetCursorVisibility() const
 {
   return Config::Get(Config::MAIN_SHOW_CURSOR);

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -445,7 +445,6 @@ void Settings::SetKeepWindowOnTop(bool top)
   if (IsKeepWindowOnTopEnabled() == top)
     return;
 
-  Config::SetBaseOrCurrent(Config::MAIN_KEEP_WINDOW_ON_TOP, top);
   emit KeepWindowOnTopChanged(top);
 }
 

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -118,9 +118,8 @@ QSettings& Settings::GetQSettings()
   return settings;
 }
 
-void Settings::SetThemeName(const QString& theme_name)
+void Settings::TriggerThemeChanged()
 {
-  Config::SetBaseOrCurrent(Config::MAIN_THEME_NAME, theme_name.toStdString());
   emit ThemeChanged();
 }
 

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -51,7 +51,7 @@ public:
   static QSettings& GetQSettings();
 
   // UI
-  void SetThemeName(const QString& theme_name);
+  void TriggerThemeChanged();
   void InitDefaultPalette();
   void UpdateSystemDark();
   void SetSystemDark(bool dark);

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -122,7 +122,6 @@ public:
   void SetUSBKeyboardConnected(bool connected);
 
   // Graphics
-  void SetCursorVisibility(Config::ShowCursor hideCursor);
   Config::ShowCursor GetCursorVisibility() const;
   bool GetLockCursor() const;
   void SetKeepWindowOnTop(bool top);

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -124,7 +124,6 @@ public:
   // Graphics
   void SetCursorVisibility(Config::ShowCursor hideCursor);
   Config::ShowCursor GetCursorVisibility() const;
-  void SetLockCursor(bool lock_cursor);
   bool GetLockCursor() const;
   void SetKeepWindowOnTop(bool top);
   bool IsKeepWindowOnTopEnabled() const;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -185,7 +185,8 @@ void InterfacePane::CreateInGame()
   m_checkbox_confirm_on_stop = new ConfigBool(tr("Confirm on Stop"), Config::MAIN_CONFIRM_ON_STOP);
   m_checkbox_use_panic_handlers =
       new ConfigBool(tr("Use Panic Handlers"), Config::MAIN_USE_PANIC_HANDLERS);
-  m_checkbox_enable_osd = new QCheckBox(tr("Show On-Screen Display Messages"));
+  m_checkbox_enable_osd =
+      new ConfigBool(tr("Show On-Screen Display Messages"), Config::MAIN_OSD_MESSAGES);
   m_checkbox_show_active_title = new QCheckBox(tr("Show Active Title in Window Title"));
   m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Loss"));
 
@@ -243,7 +244,6 @@ void InterfacePane::ConnectLayout()
   connect(m_checkbox_top_window, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::KeepWindowOnTopChanged);
   connect(m_checkbox_show_active_title, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
-  connect(m_checkbox_enable_osd, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_pause_on_focus_lost, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_radio_cursor_visible_movement, &QRadioButton::toggled, this,
           &InterfacePane::OnCursorVisibleMovement);
@@ -299,7 +299,6 @@ void InterfacePane::LoadConfig()
     SignalBlocking(m_combobox_userstyle)->setCurrentIndex(index);
 
   // Render Window Options
-  SignalBlocking(m_checkbox_enable_osd)->setChecked(Config::Get(Config::MAIN_OSD_MESSAGES));
   SignalBlocking(m_checkbox_show_active_title)
       ->setChecked(Config::Get(Config::MAIN_SHOW_ACTIVE_TITLE));
   SignalBlocking(m_checkbox_pause_on_focus_lost)
@@ -327,7 +326,6 @@ void InterfacePane::OnSaveConfig()
   Settings::Instance().ApplyStyle();
 
   // Render Window Options
-  Config::SetBase(Config::MAIN_OSD_MESSAGES, m_checkbox_enable_osd->isChecked());
   Config::SetBase(Config::MAIN_SHOW_ACTIVE_TITLE, m_checkbox_show_active_title->isChecked());
   Config::SetBase(Config::MAIN_PAUSE_ON_FOCUS_LOST, m_checkbox_pause_on_focus_lost->isChecked());
 
@@ -392,6 +390,10 @@ void InterfacePane::AddDescriptions()
                  "present choices on how to proceed. With this option disabled, Dolphin will "
                  "\"ignore\" all errors. Emulation will not be halted and you will not be notified."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static constexpr char TR_ENABLE_OSD_DESCRIPTION[] =
+      QT_TR_NOOP("Shows on-screen display messages over the render window. These messages "
+                 "disappear after several seconds."
+                 "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -412,4 +414,6 @@ void InterfacePane::AddDescriptions()
   m_checkbox_confirm_on_stop->SetDescription(tr(TR_CONFIRM_ON_STOP_DESCRIPTION));
 
   m_checkbox_use_panic_handlers->SetDescription(tr(TR_USE_PANIC_HANDLERS_DESCRIPTION));
+
+  m_checkbox_enable_osd->SetDescription(tr(TR_ENABLE_OSD_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -209,10 +209,9 @@ void InterfacePane::CreateInGame()
   m_vboxlayout_hide_mouse->addWidget(m_radio_cursor_visible_never);
   m_vboxlayout_hide_mouse->addWidget(m_radio_cursor_visible_always);
 
+  m_checkbox_lock_mouse = new ConfigBool(tr("Lock Mouse Cursor"), Config::MAIN_LOCK_CURSOR);
   // this ends up not being managed unless _WIN32, so lets not leak
-  m_checkbox_lock_mouse = new QCheckBox(tr("Lock Mouse Cursor"), this);
-  m_checkbox_lock_mouse->setToolTip(tr("Will lock the Mouse Cursor to the Render Widget as long as "
-                                       "it has focus. You can set a hotkey to unlock it."));
+  m_checkbox_lock_mouse->setParent(this);
 
   mouse_groupbox->setLayout(m_vboxlayout_hide_mouse);
   groupbox_layout->addWidget(m_checkbox_top_window);
@@ -252,7 +251,7 @@ void InterfacePane::ConnectLayout()
   connect(m_radio_cursor_visible_always, &QRadioButton::toggled, this,
           &InterfacePane::OnCursorVisibleAlways);
   connect(m_checkbox_lock_mouse, &QCheckBox::toggled, &Settings::Instance(),
-          &Settings::SetLockCursor);
+          [this]() { Settings::Instance().LockCursorChanged(); });
 }
 
 void InterfacePane::UpdateShowDebuggingCheckbox()
@@ -305,8 +304,6 @@ void InterfacePane::LoadConfig()
       ->setChecked(Settings::Instance().GetCursorVisibility() == Config::ShowCursor::Constantly);
   SignalBlocking(m_radio_cursor_visible_never)
       ->setChecked(Settings::Instance().GetCursorVisibility() == Config::ShowCursor::Never);
-
-  SignalBlocking(m_checkbox_lock_mouse)->setChecked(Settings::Instance().GetLockCursor());
 }
 
 void InterfacePane::OnSaveConfig()
@@ -392,6 +389,10 @@ void InterfacePane::AddDescriptions()
   static constexpr char TR_PAUSE_ON_FOCUS_LOST_DESCRIPTION[] =
       QT_TR_NOOP("Pauses the game whenever the render window isn't focused."
                  "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+  static constexpr char TR_LOCK_MOUSE_DESCRIPTION[] =
+      QT_TR_NOOP("Locks the Mouse Cursor to the Render Widget as long as it has focus. You can "
+                 "set a hotkey to unlock it."
+                 "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -418,4 +419,6 @@ void InterfacePane::AddDescriptions()
   m_checkbox_show_active_title->SetDescription(tr(TR_SHOW_ACTIVE_TITLE_DESCRIPTION));
 
   m_checkbox_pause_on_focus_lost->SetDescription(tr(TR_PAUSE_ON_FOCUS_LOST_DESCRIPTION));
+
+  m_checkbox_lock_mouse->SetDescription(tr(TR_LOCK_MOUSE_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -182,7 +182,7 @@ void InterfacePane::CreateInGame()
   m_main_layout->addWidget(groupbox);
 
   m_checkbox_top_window = new ConfigBool(tr("Keep Window on Top"), Config::MAIN_KEEP_WINDOW_ON_TOP);
-  m_checkbox_confirm_on_stop = new QCheckBox(tr("Confirm on Stop"));
+  m_checkbox_confirm_on_stop = new ConfigBool(tr("Confirm on Stop"), Config::MAIN_CONFIRM_ON_STOP);
   m_checkbox_use_panic_handlers = new QCheckBox(tr("Use Panic Handlers"));
   m_checkbox_enable_osd = new QCheckBox(tr("Show On-Screen Display Messages"));
   m_checkbox_show_active_title = new QCheckBox(tr("Show Active Title in Window Title"));
@@ -241,7 +241,6 @@ void InterfacePane::ConnectLayout()
           [this]() { OnLanguageChanged(); });
   connect(m_checkbox_top_window, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::KeepWindowOnTopChanged);
-  connect(m_checkbox_confirm_on_stop, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_use_panic_handlers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_active_title, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_enable_osd, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
@@ -300,7 +299,6 @@ void InterfacePane::LoadConfig()
     SignalBlocking(m_combobox_userstyle)->setCurrentIndex(index);
 
   // Render Window Options
-  SignalBlocking(m_checkbox_confirm_on_stop)->setChecked(Config::Get(Config::MAIN_CONFIRM_ON_STOP));
   SignalBlocking(m_checkbox_use_panic_handlers)
       ->setChecked(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
   SignalBlocking(m_checkbox_enable_osd)->setChecked(Config::Get(Config::MAIN_OSD_MESSAGES));
@@ -331,7 +329,6 @@ void InterfacePane::OnSaveConfig()
   Settings::Instance().ApplyStyle();
 
   // Render Window Options
-  Config::SetBase(Config::MAIN_CONFIRM_ON_STOP, m_checkbox_confirm_on_stop->isChecked());
   Config::SetBase(Config::MAIN_USE_PANIC_HANDLERS, m_checkbox_use_panic_handlers->isChecked());
   Config::SetBase(Config::MAIN_OSD_MESSAGES, m_checkbox_enable_osd->isChecked());
   Config::SetBase(Config::MAIN_SHOW_ACTIVE_TITLE, m_checkbox_show_active_title->isChecked());
@@ -390,6 +387,9 @@ void InterfacePane::AddDescriptions()
   static constexpr char TR_DISABLE_SCREENSAVER_DESCRIPTION[] =
       QT_TR_NOOP("Disables your screensaver while running a game."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static constexpr char TR_CONFIRM_ON_STOP_DESCRIPTION[] =
+      QT_TR_NOOP("Prompts you to confirm that you want to end emulation when you press Stop."
+                 "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -406,4 +406,6 @@ void InterfacePane::AddDescriptions()
   m_checkbox_use_covers->SetDescription(tr(TR_USE_COVERS_DESCRIPTION));
 
   m_checkbox_disable_screensaver->SetDescription(tr(TR_DISABLE_SCREENSAVER_DESCRIPTION));
+
+  m_checkbox_confirm_on_stop->SetDescription(tr(TR_CONFIRM_ON_STOP_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -187,7 +187,8 @@ void InterfacePane::CreateInGame()
       new ConfigBool(tr("Use Panic Handlers"), Config::MAIN_USE_PANIC_HANDLERS);
   m_checkbox_enable_osd =
       new ConfigBool(tr("Show On-Screen Display Messages"), Config::MAIN_OSD_MESSAGES);
-  m_checkbox_show_active_title = new QCheckBox(tr("Show Active Title in Window Title"));
+  m_checkbox_show_active_title =
+      new ConfigBool(tr("Show Active Title in Window Title"), Config::MAIN_SHOW_ACTIVE_TITLE);
   m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Loss"));
 
   auto* mouse_groupbox = new QGroupBox(tr("Mouse Cursor Visibility"));
@@ -243,7 +244,6 @@ void InterfacePane::ConnectLayout()
           [this]() { OnLanguageChanged(); });
   connect(m_checkbox_top_window, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::KeepWindowOnTopChanged);
-  connect(m_checkbox_show_active_title, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_pause_on_focus_lost, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_radio_cursor_visible_movement, &QRadioButton::toggled, this,
           &InterfacePane::OnCursorVisibleMovement);
@@ -299,8 +299,6 @@ void InterfacePane::LoadConfig()
     SignalBlocking(m_combobox_userstyle)->setCurrentIndex(index);
 
   // Render Window Options
-  SignalBlocking(m_checkbox_show_active_title)
-      ->setChecked(Config::Get(Config::MAIN_SHOW_ACTIVE_TITLE));
   SignalBlocking(m_checkbox_pause_on_focus_lost)
       ->setChecked(Config::Get(Config::MAIN_PAUSE_ON_FOCUS_LOST));
   SignalBlocking(m_radio_cursor_visible_movement)
@@ -326,7 +324,6 @@ void InterfacePane::OnSaveConfig()
   Settings::Instance().ApplyStyle();
 
   // Render Window Options
-  Config::SetBase(Config::MAIN_SHOW_ACTIVE_TITLE, m_checkbox_show_active_title->isChecked());
   Config::SetBase(Config::MAIN_PAUSE_ON_FOCUS_LOST, m_checkbox_pause_on_focus_lost->isChecked());
 
   Config::Save();
@@ -394,6 +391,9 @@ void InterfacePane::AddDescriptions()
       QT_TR_NOOP("Shows on-screen display messages over the render window. These messages "
                  "disappear after several seconds."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static constexpr char TR_SHOW_ACTIVE_TITLE_DESCRIPTION[] =
+      QT_TR_NOOP("Shows the active game title in the render window's title bar."
+                 "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -416,4 +416,6 @@ void InterfacePane::AddDescriptions()
   m_checkbox_use_panic_handlers->SetDescription(tr(TR_USE_PANIC_HANDLERS_DESCRIPTION));
 
   m_checkbox_enable_osd->SetDescription(tr(TR_ENABLE_OSD_DESCRIPTION));
+
+  m_checkbox_show_active_title->SetDescription(tr(TR_SHOW_ACTIVE_TITLE_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -159,7 +159,8 @@ void InterfacePane::CreateUI()
   m_checkbox_use_builtin_title_database = new ConfigBool(tr("Use Built-In Database of Game Names"),
                                                          Config::MAIN_USE_BUILT_IN_TITLE_DATABASE);
   m_checkbox_use_covers =
-      new QCheckBox(tr("Download Game Covers from GameTDB.com for Use in Grid Mode"));
+      new ConfigBool(tr("Download Game Covers from GameTDB.com for Use in Grid Mode"),
+                     Config::MAIN_USE_GAME_COVERS);
   m_checkbox_show_debugging_ui = new ToolTipCheckBox(tr("Enable Debugging UI"));
   m_checkbox_focused_hotkeys =
       new ConfigBool(tr("Hotkeys Require Window Focus"), Config::MAIN_FOCUSED_HOTKEYS);
@@ -227,7 +228,8 @@ void InterfacePane::ConnectLayout()
 {
   connect(m_checkbox_use_builtin_title_database, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::GameListRefreshRequested);
-  connect(m_checkbox_use_covers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_use_covers, &QCheckBox::toggled, &Settings::Instance(),
+          &Settings::RefreshMetadata);
   connect(m_checkbox_disable_screensaver, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::SetDebugModeEnabled);
@@ -306,7 +308,6 @@ void InterfacePane::LoadConfig()
       ->setChecked(Config::Get(Config::MAIN_SHOW_ACTIVE_TITLE));
   SignalBlocking(m_checkbox_pause_on_focus_lost)
       ->setChecked(Config::Get(Config::MAIN_PAUSE_ON_FOCUS_LOST));
-  SignalBlocking(m_checkbox_use_covers)->setChecked(Config::Get(Config::MAIN_USE_GAME_COVERS));
   SignalBlocking(m_radio_cursor_visible_movement)
       ->setChecked(Settings::Instance().GetCursorVisibility() == Config::ShowCursor::OnMovement);
   SignalBlocking(m_radio_cursor_visible_always)
@@ -337,15 +338,6 @@ void InterfacePane::OnSaveConfig()
   Config::SetBase(Config::MAIN_OSD_MESSAGES, m_checkbox_enable_osd->isChecked());
   Config::SetBase(Config::MAIN_SHOW_ACTIVE_TITLE, m_checkbox_show_active_title->isChecked());
   Config::SetBase(Config::MAIN_PAUSE_ON_FOCUS_LOST, m_checkbox_pause_on_focus_lost->isChecked());
-
-  const bool use_covers = m_checkbox_use_covers->isChecked();
-
-  if (use_covers != Config::Get(Config::MAIN_USE_GAME_COVERS))
-  {
-    Config::SetBase(Config::MAIN_USE_GAME_COVERS, use_covers);
-    Settings::Instance().RefreshMetadata();
-  }
-
   Config::SetBase(Config::MAIN_DISABLE_SCREENSAVER, m_checkbox_disable_screensaver->isChecked());
 
   Config::Save();
@@ -391,6 +383,13 @@ void InterfacePane::AddDescriptions()
   static constexpr char TR_FOCUSED_HOTKEYS_DESCRIPTION[] =
       QT_TR_NOOP("Requires the render window to be focused for hotkeys to take effect."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static constexpr char TR_USE_COVERS_DESCRIPTION[] =
+      QT_TR_NOOP("Downloads full game covers from GameTDB.com to display in the Game List's Grid "
+                 "View. If this setting is unchecked the Game List displays a banner generated "
+                 "from the game's save files, and if the game has no save file displays a generic "
+                 "banner instead."
+                 "<br><br>List View will always use the save file banners."
+                 "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -403,4 +402,6 @@ void InterfacePane::AddDescriptions()
   m_combobox_language->SetDescription(tr(TR_LANGUAGE_DESCRIPTION));
 
   m_checkbox_focused_hotkeys->SetDescription(tr(TR_FOCUSED_HOTKEYS_DESCRIPTION));
+
+  m_checkbox_use_covers->SetDescription(tr(TR_USE_COVERS_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -161,7 +161,8 @@ void InterfacePane::CreateUI()
   m_checkbox_use_covers =
       new QCheckBox(tr("Download Game Covers from GameTDB.com for Use in Grid Mode"));
   m_checkbox_show_debugging_ui = new ToolTipCheckBox(tr("Enable Debugging UI"));
-  m_checkbox_focused_hotkeys = new QCheckBox(tr("Hotkeys Require Window Focus"));
+  m_checkbox_focused_hotkeys =
+      new ConfigBool(tr("Hotkeys Require Window Focus"), Config::MAIN_FOCUSED_HOTKEYS);
   m_checkbox_disable_screensaver = new QCheckBox(tr("Inhibit Screensaver During Emulation"));
 
   groupbox_layout->addWidget(m_checkbox_use_builtin_title_database);
@@ -230,7 +231,6 @@ void InterfacePane::ConnectLayout()
   connect(m_checkbox_disable_screensaver, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::SetDebugModeEnabled);
-  connect(m_checkbox_focused_hotkeys, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_combobox_theme, &QComboBox::currentIndexChanged, this,
           [this](int index) { Settings::Instance().TriggerThemeChanged(); });
   connect(m_combobox_userstyle, &QComboBox::currentIndexChanged, this,
@@ -307,7 +307,6 @@ void InterfacePane::LoadConfig()
   SignalBlocking(m_checkbox_pause_on_focus_lost)
       ->setChecked(Config::Get(Config::MAIN_PAUSE_ON_FOCUS_LOST));
   SignalBlocking(m_checkbox_use_covers)->setChecked(Config::Get(Config::MAIN_USE_GAME_COVERS));
-  SignalBlocking(m_checkbox_focused_hotkeys)->setChecked(Config::Get(Config::MAIN_FOCUSED_HOTKEYS));
   SignalBlocking(m_radio_cursor_visible_movement)
       ->setChecked(Settings::Instance().GetCursorVisibility() == Config::ShowCursor::OnMovement);
   SignalBlocking(m_radio_cursor_visible_always)
@@ -347,7 +346,6 @@ void InterfacePane::OnSaveConfig()
     Settings::Instance().RefreshMetadata();
   }
 
-  Config::SetBase(Config::MAIN_FOCUSED_HOTKEYS, m_checkbox_focused_hotkeys->isChecked());
   Config::SetBase(Config::MAIN_DISABLE_SCREENSAVER, m_checkbox_disable_screensaver->isChecked());
 
   Config::Save();
@@ -390,6 +388,9 @@ void InterfacePane::AddDescriptions()
       "Sets the language displayed by Dolphin's User Interface."
       "<br><br>Changes to this setting only take effect once Dolphin is restarted."
       "<br><br><dolphin_emphasis>If unsure, select &lt;System Language&gt;.</dolphin_emphasis>");
+  static constexpr char TR_FOCUSED_HOTKEYS_DESCRIPTION[] =
+      QT_TR_NOOP("Requires the render window to be focused for hotkeys to take effect."
+                 "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -400,4 +401,6 @@ void InterfacePane::AddDescriptions()
 
   m_combobox_language->SetTitle(tr("Language"));
   m_combobox_language->SetDescription(tr(TR_LANGUAGE_DESCRIPTION));
+
+  m_checkbox_focused_hotkeys->SetDescription(tr(TR_FOCUSED_HOTKEYS_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -164,7 +164,8 @@ void InterfacePane::CreateUI()
   m_checkbox_show_debugging_ui = new ToolTipCheckBox(tr("Enable Debugging UI"));
   m_checkbox_focused_hotkeys =
       new ConfigBool(tr("Hotkeys Require Window Focus"), Config::MAIN_FOCUSED_HOTKEYS);
-  m_checkbox_disable_screensaver = new QCheckBox(tr("Inhibit Screensaver During Emulation"));
+  m_checkbox_disable_screensaver =
+      new ConfigBool(tr("Inhibit Screensaver During Emulation"), Config::MAIN_DISABLE_SCREENSAVER);
 
   groupbox_layout->addWidget(m_checkbox_use_builtin_title_database);
   groupbox_layout->addWidget(m_checkbox_use_covers);
@@ -230,7 +231,6 @@ void InterfacePane::ConnectLayout()
           &Settings::GameListRefreshRequested);
   connect(m_checkbox_use_covers, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::RefreshMetadata);
-  connect(m_checkbox_disable_screensaver, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::SetDebugModeEnabled);
   connect(m_combobox_theme, &QComboBox::currentIndexChanged, this,
@@ -316,8 +316,6 @@ void InterfacePane::LoadConfig()
       ->setChecked(Settings::Instance().GetCursorVisibility() == Config::ShowCursor::Never);
 
   SignalBlocking(m_checkbox_lock_mouse)->setChecked(Settings::Instance().GetLockCursor());
-  SignalBlocking(m_checkbox_disable_screensaver)
-      ->setChecked(Config::Get(Config::MAIN_DISABLE_SCREENSAVER));
 }
 
 void InterfacePane::OnSaveConfig()
@@ -338,7 +336,6 @@ void InterfacePane::OnSaveConfig()
   Config::SetBase(Config::MAIN_OSD_MESSAGES, m_checkbox_enable_osd->isChecked());
   Config::SetBase(Config::MAIN_SHOW_ACTIVE_TITLE, m_checkbox_show_active_title->isChecked());
   Config::SetBase(Config::MAIN_PAUSE_ON_FOCUS_LOST, m_checkbox_pause_on_focus_lost->isChecked());
-  Config::SetBase(Config::MAIN_DISABLE_SCREENSAVER, m_checkbox_disable_screensaver->isChecked());
 
   Config::Save();
 }
@@ -390,6 +387,9 @@ void InterfacePane::AddDescriptions()
                  "banner instead."
                  "<br><br>List View will always use the save file banners."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static constexpr char TR_DISABLE_SCREENSAVER_DESCRIPTION[] =
+      QT_TR_NOOP("Disables your screensaver while running a game."
+                 "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -404,4 +404,6 @@ void InterfacePane::AddDescriptions()
   m_checkbox_focused_hotkeys->SetDescription(tr(TR_FOCUSED_HOTKEYS_DESCRIPTION));
 
   m_checkbox_use_covers->SetDescription(tr(TR_USE_COVERS_DESCRIPTION));
+
+  m_checkbox_disable_screensaver->SetDescription(tr(TR_DISABLE_SCREENSAVER_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -23,6 +23,7 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/UISettings.h"
 
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
@@ -97,6 +98,7 @@ void InterfacePane::CreateLayout()
   // Create layout here
   CreateUI();
   CreateInGame();
+  AddDescriptions();
 
   m_main_layout->addStretch(1);
   setLayout(m_main_layout);
@@ -153,7 +155,8 @@ void InterfacePane::CreateUI()
   }
 
   // Checkboxes
-  m_checkbox_use_builtin_title_database = new QCheckBox(tr("Use Built-In Database of Game Names"));
+  m_checkbox_use_builtin_title_database = new ConfigBool(tr("Use Built-In Database of Game Names"),
+                                                         Config::MAIN_USE_BUILT_IN_TITLE_DATABASE);
   m_checkbox_use_covers =
       new QCheckBox(tr("Download Game Covers from GameTDB.com for Use in Grid Mode"));
   m_checkbox_show_debugging_ui = new ToolTipCheckBox(tr("Enable Debugging UI"));
@@ -220,8 +223,8 @@ void InterfacePane::CreateInGame()
 
 void InterfacePane::ConnectLayout()
 {
-  connect(m_checkbox_use_builtin_title_database, &QCheckBox::toggled, this,
-          &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_use_builtin_title_database, &QCheckBox::toggled, &Settings::Instance(),
+          &Settings::GameListRefreshRequested);
   connect(m_checkbox_use_covers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_disable_screensaver, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
@@ -250,8 +253,6 @@ void InterfacePane::ConnectLayout()
 
 void InterfacePane::LoadConfig()
 {
-  SignalBlocking(m_checkbox_use_builtin_title_database)
-      ->setChecked(Config::Get(Config::MAIN_USE_BUILT_IN_TITLE_DATABASE));
   SignalBlocking(m_checkbox_show_debugging_ui)
       ->setChecked(Settings::Instance().IsDebugModeEnabled());
 
@@ -312,8 +313,6 @@ void InterfacePane::LoadConfig()
 
 void InterfacePane::OnSaveConfig()
 {
-  Config::SetBase(Config::MAIN_USE_BUILT_IN_TITLE_DATABASE,
-                  m_checkbox_use_builtin_title_database->isChecked());
   Settings::Instance().SetDebugModeEnabled(m_checkbox_show_debugging_ui->isChecked());
   const auto selected_style = m_combobox_userstyle->currentData();
   bool is_builtin_type = false;
@@ -369,4 +368,13 @@ void InterfacePane::OnCursorVisibleNever()
 void InterfacePane::OnCursorVisibleAlways()
 {
   Settings::Instance().SetCursorVisibility(Config::ShowCursor::Constantly);
+}
+
+void InterfacePane::AddDescriptions()
+{
+  static constexpr char TR_TITLE_DATABASE_DESCRIPTION[] = QT_TR_NOOP(
+      "Uses Dolphin's database of properly formatted names in the Game List Title column."
+      "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+
+  m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -177,7 +177,7 @@ void InterfacePane::CreateInGame()
   groupbox->setLayout(groupbox_layout);
   m_main_layout->addWidget(groupbox);
 
-  m_checkbox_top_window = new QCheckBox(tr("Keep Window on Top"));
+  m_checkbox_top_window = new ConfigBool(tr("Keep Window on Top"), Config::MAIN_KEEP_WINDOW_ON_TOP);
   m_checkbox_confirm_on_stop = new QCheckBox(tr("Confirm on Stop"));
   m_checkbox_use_panic_handlers = new QCheckBox(tr("Use Panic Handlers"));
   m_checkbox_enable_osd = new QCheckBox(tr("Show On-Screen Display Messages"));
@@ -234,7 +234,8 @@ void InterfacePane::ConnectLayout()
   connect(m_combobox_userstyle, &QComboBox::currentIndexChanged, this,
           &InterfacePane::OnSaveConfig);
   connect(m_combobox_language, &QComboBox::currentIndexChanged, this, &InterfacePane::OnSaveConfig);
-  connect(m_checkbox_top_window, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_top_window, &QCheckBox::toggled, &Settings::Instance(),
+          &Settings::KeepWindowOnTopChanged);
   connect(m_checkbox_confirm_on_stop, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_use_panic_handlers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_active_title, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
@@ -283,8 +284,6 @@ void InterfacePane::LoadConfig()
     SignalBlocking(m_combobox_userstyle)->setCurrentIndex(index);
 
   // Render Window Options
-  SignalBlocking(m_checkbox_top_window)
-      ->setChecked(Settings::Instance().IsKeepWindowOnTopEnabled());
   SignalBlocking(m_checkbox_confirm_on_stop)->setChecked(Config::Get(Config::MAIN_CONFIRM_ON_STOP));
   SignalBlocking(m_checkbox_use_panic_handlers)
       ->setChecked(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
@@ -321,7 +320,6 @@ void InterfacePane::OnSaveConfig()
   Settings::Instance().ApplyStyle();
 
   // Render Window Options
-  Settings::Instance().SetKeepWindowOnTop(m_checkbox_top_window->isChecked());
   Config::SetBase(Config::MAIN_CONFIRM_ON_STOP, m_checkbox_confirm_on_stop->isChecked());
   Config::SetBase(Config::MAIN_USE_PANIC_HANDLERS, m_checkbox_use_panic_handlers->isChecked());
   Config::SetBase(Config::MAIN_OSD_MESSAGES, m_checkbox_enable_osd->isChecked());
@@ -374,9 +372,14 @@ void InterfacePane::AddDescriptions()
   static constexpr char TR_THEME_DESCRIPTION[] =
       QT_TR_NOOP("Changes the appearance and color of Dolphin's buttons."
                  "<br><br><dolphin_emphasis>If unsure, select Clean.</dolphin_emphasis>");
+  static constexpr char TR_TOP_WINDOW_DESCRIPTION[] =
+      QT_TR_NOOP("Forces the render window to stay on top of other windows and applications."
+                 "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
   m_combobox_theme->SetTitle(tr("Theme"));
   m_combobox_theme->SetDescription(tr(TR_THEME_DESCRIPTION));
+
+  m_checkbox_top_window->SetDescription(tr(TR_TOP_WINDOW_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -32,48 +32,49 @@
 
 #include "UICommon/GameFile.h"
 
-static QComboBox* MakeLanguageComboBox()
+static ConfigStringChoice* MakeLanguageComboBox()
 {
-  static const struct
-  {
-    const QString name;
-    const char* id;
-  } languages[] = {
-      {QStringLiteral(u"Bahasa Melayu"), "ms"},               // Malay
-      {QStringLiteral(u"Catal\u00E0"), "ca"},                 // Catalan
-      {QStringLiteral(u"\u010Ce\u0161tina"), "cs"},           // Czech
-      {QStringLiteral(u"Dansk"), "da"},                       // Danish
-      {QStringLiteral(u"Deutsch"), "de"},                     // German
-      {QStringLiteral(u"English"), "en"},                     // English
-      {QStringLiteral(u"Espa\u00F1ol"), "es"},                // Spanish
-      {QStringLiteral(u"Fran\u00E7ais"), "fr"},               // French
-      {QStringLiteral(u"Hrvatski"), "hr"},                    // Croatian
-      {QStringLiteral(u"Italiano"), "it"},                    // Italian
-      {QStringLiteral(u"Magyar"), "hu"},                      // Hungarian
-      {QStringLiteral(u"Nederlands"), "nl"},                  // Dutch
-      {QStringLiteral(u"Norsk bokm\u00E5l"), "nb"},           // Norwegian
-      {QStringLiteral(u"Polski"), "pl"},                      // Polish
-      {QStringLiteral(u"Portugu\u00EAs"), "pt"},              // Portuguese
-      {QStringLiteral(u"Portugu\u00EAs (Brasil)"), "pt_BR"},  // Portuguese (Brazil)
-      {QStringLiteral(u"Rom\u00E2n\u0103"), "ro"},            // Romanian
-      {QStringLiteral(u"Srpski"), "sr"},                      // Serbian
-      {QStringLiteral(u"Suomi"), "fi"},                       // Finnish
-      {QStringLiteral(u"Svenska"), "sv"},                     // Swedish
-      {QStringLiteral(u"T\u00FCrk\u00E7e"), "tr"},            // Turkish
-      {QStringLiteral(u"\u0395\u03BB\u03BB\u03B7\u03BD\u03B9\u03BA\u03AC"), "el"},  // Greek
-      {QStringLiteral(u"\u0420\u0443\u0441\u0441\u043A\u0438\u0439"), "ru"},        // Russian
-      {QStringLiteral(u"\u0627\u0644\u0639\u0631\u0628\u064A\u0629"), "ar"},        // Arabic
-      {QStringLiteral(u"\u0641\u0627\u0631\u0633\u06CC"), "fa"},                    // Farsi
-      {QStringLiteral(u"\uD55C\uAD6D\uC5B4"), "ko"},                                // Korean
-      {QStringLiteral(u"\u65E5\u672C\u8A9E"), "ja"},                                // Japanese
-      {QStringLiteral(u"\u7B80\u4F53\u4E2D\u6587"), "zh_CN"},  // Simplified Chinese
-      {QStringLiteral(u"\u7E41\u9AD4\u4E2D\u6587"), "zh_TW"},  // Traditional Chinese
+  using QPair = std::pair<QString, QString>;
+  std::vector<QPair> languages = {
+      QPair{QObject::tr("<System Language>"), QString{}},
+      QPair{QStringLiteral(u"Bahasa Melayu"), QStringLiteral("ms")},      // Malay
+      QPair{QStringLiteral(u"Catal\u00E0"), QStringLiteral("ca")},        // Catalan
+      QPair{QStringLiteral(u"\u010Ce\u0161tina"), QStringLiteral("cs")},  // Czech
+      QPair{QStringLiteral(u"Dansk"), QStringLiteral("da")},              // Danish
+      QPair{QStringLiteral(u"Deutsch"), QStringLiteral("de")},            // German
+      QPair{QStringLiteral(u"English"), QStringLiteral("en")},            // English
+      QPair{QStringLiteral(u"Espa\u00F1ol"), QStringLiteral("es")},       // Spanish
+      QPair{QStringLiteral(u"Fran\u00E7ais"), QStringLiteral("fr")},      // French
+      QPair{QStringLiteral(u"Hrvatski"), QStringLiteral("hr")},           // Croatian
+      QPair{QStringLiteral(u"Italiano"), QStringLiteral("it")},           // Italian
+      QPair{QStringLiteral(u"Magyar"), QStringLiteral("hu")},             // Hungarian
+      QPair{QStringLiteral(u"Nederlands"), QStringLiteral("nl")},         // Dutch
+      QPair{QStringLiteral(u"Norsk bokm\u00E5l"), QStringLiteral("nb")},  // Norwegian
+      QPair{QStringLiteral(u"Polski"), QStringLiteral("pl")},             // Polish
+      QPair{QStringLiteral(u"Portugu\u00EAs"), QStringLiteral("pt")},     // Portuguese
+      QPair{QStringLiteral(u"Portugu\u00EAs (Brasil)"),
+            QStringLiteral("pt_BR")},                                    // Portuguese (Brazil)
+      QPair{QStringLiteral(u"Rom\u00E2n\u0103"), QStringLiteral("ro")},  // Romanian
+      QPair{QStringLiteral(u"Srpski"), QStringLiteral("sr")},            // Serbian
+      QPair{QStringLiteral(u"Suomi"), QStringLiteral("fi")},             // Finnish
+      QPair{QStringLiteral(u"Svenska"), QStringLiteral("sv")},           // Swedish
+      QPair{QStringLiteral(u"T\u00FCrk\u00E7e"), QStringLiteral("tr")},  // Turkish
+      QPair{QStringLiteral(u"\u0395\u03BB\u03BB\u03B7\u03BD\u03B9\u03BA\u03AC"),
+            QStringLiteral("el")},  // Greek
+      QPair{QStringLiteral(u"\u0420\u0443\u0441\u0441\u043A\u0438\u0439"),
+            QStringLiteral("ru")},  // Russian
+      QPair{QStringLiteral(u"\u0627\u0644\u0639\u0631\u0628\u064A\u0629"),
+            QStringLiteral("ar")},                                                     // Arabic
+      QPair{QStringLiteral(u"\u0641\u0627\u0631\u0633\u06CC"), QStringLiteral("fa")},  // Farsi
+      QPair{QStringLiteral(u"\uD55C\uAD6D\uC5B4"), QStringLiteral("ko")},              // Korean
+      QPair{QStringLiteral(u"\u65E5\u672C\u8A9E"), QStringLiteral("ja")},              // Japanese
+      QPair{QStringLiteral(u"\u7B80\u4F53\u4E2D\u6587"),
+            QStringLiteral("zh_CN")},  // Simplified Chinese
+      QPair{QStringLiteral(u"\u7E41\u9AD4\u4E2D\u6587"),
+            QStringLiteral("zh_TW")},  // Traditional Chinese
   };
 
-  auto* combobox = new QComboBox();
-  combobox->addItem(QObject::tr("<System Language>"), QString{});
-  for (const auto& lang : languages)
-    combobox->addItem(lang.name, QString::fromLatin1(lang.id));
+  auto* const combobox = new ConfigStringChoice(languages, Config::MAIN_INTERFACE_LANGUAGE);
 
   // The default, QComboBox::AdjustToContentsOnFirstShow, causes a noticeable pause when opening the
   // SettingWindow for the first time. The culprit seems to be non-Latin graphemes in the above
@@ -233,7 +234,8 @@ void InterfacePane::ConnectLayout()
           [this](int index) { Settings::Instance().TriggerThemeChanged(); });
   connect(m_combobox_userstyle, &QComboBox::currentIndexChanged, this,
           &InterfacePane::OnSaveConfig);
-  connect(m_combobox_language, &QComboBox::currentIndexChanged, this, &InterfacePane::OnSaveConfig);
+  connect(m_combobox_language, &QComboBox::currentIndexChanged, this,
+          [this]() { OnLanguageChanged(); });
   connect(m_checkbox_top_window, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::KeepWindowOnTopChanged);
   connect(m_checkbox_confirm_on_stop, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
@@ -269,10 +271,6 @@ void InterfacePane::LoadConfig()
     m_checkbox_show_debugging_ui->SetDescription({});
   }
 #endif  // USE_RETRO_ACHIEVEMENTS
-
-  SignalBlocking(m_combobox_language)
-      ->setCurrentIndex(m_combobox_language->findData(
-          QString::fromStdString(Config::Get(Config::MAIN_INTERFACE_LANGUAGE))));
 
   const Settings::StyleType style_type = Settings::Instance().GetStyleType();
   const QString userstyle = Settings::Instance().GetUserStyleName();
@@ -326,15 +324,6 @@ void InterfacePane::OnSaveConfig()
   Config::SetBase(Config::MAIN_SHOW_ACTIVE_TITLE, m_checkbox_show_active_title->isChecked());
   Config::SetBase(Config::MAIN_PAUSE_ON_FOCUS_LOST, m_checkbox_pause_on_focus_lost->isChecked());
 
-  auto new_language = m_combobox_language->currentData().toString().toStdString();
-  if (new_language != Config::Get(Config::MAIN_INTERFACE_LANGUAGE))
-  {
-    Config::SetBase(Config::MAIN_INTERFACE_LANGUAGE, new_language);
-    ModalMessageBox::information(
-        this, tr("Restart Required"),
-        tr("You must restart Dolphin in order for the change to take effect."));
-  }
-
   const bool use_covers = m_checkbox_use_covers->isChecked();
 
   if (use_covers != Config::Get(Config::MAIN_USE_GAME_COVERS))
@@ -364,6 +353,13 @@ void InterfacePane::OnCursorVisibleAlways()
   Settings::Instance().SetCursorVisibility(Config::ShowCursor::Constantly);
 }
 
+void InterfacePane::OnLanguageChanged()
+{
+  ModalMessageBox::information(
+      this, tr("Restart Required"),
+      tr("You must restart Dolphin in order for the change to take effect."));
+}
+
 void InterfacePane::AddDescriptions()
 {
   static constexpr char TR_TITLE_DATABASE_DESCRIPTION[] = QT_TR_NOOP(
@@ -375,6 +371,10 @@ void InterfacePane::AddDescriptions()
   static constexpr char TR_TOP_WINDOW_DESCRIPTION[] =
       QT_TR_NOOP("Forces the render window to stay on top of other windows and applications."
                  "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+  static constexpr char TR_LANGUAGE_DESCRIPTION[] = QT_TR_NOOP(
+      "Sets the language displayed by Dolphin's User Interface."
+      "<br><br>Changes to this setting only take effect once Dolphin is restarted."
+      "<br><br><dolphin_emphasis>If unsure, select &lt;System Language&gt;.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -382,4 +382,7 @@ void InterfacePane::AddDescriptions()
   m_combobox_theme->SetDescription(tr(TR_THEME_DESCRIPTION));
 
   m_checkbox_top_window->SetDescription(tr(TR_TOP_WINDOW_DESCRIPTION));
+
+  m_combobox_language->SetTitle(tr("Language"));
+  m_combobox_language->SetDescription(tr(TR_LANGUAGE_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -189,7 +189,8 @@ void InterfacePane::CreateInGame()
       new ConfigBool(tr("Show On-Screen Display Messages"), Config::MAIN_OSD_MESSAGES);
   m_checkbox_show_active_title =
       new ConfigBool(tr("Show Active Title in Window Title"), Config::MAIN_SHOW_ACTIVE_TITLE);
-  m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Loss"));
+  m_checkbox_pause_on_focus_lost =
+      new ConfigBool(tr("Pause on Focus Loss"), Config::MAIN_PAUSE_ON_FOCUS_LOST);
 
   auto* mouse_groupbox = new QGroupBox(tr("Mouse Cursor Visibility"));
   auto* m_vboxlayout_hide_mouse = new QVBoxLayout;
@@ -244,7 +245,6 @@ void InterfacePane::ConnectLayout()
           [this]() { OnLanguageChanged(); });
   connect(m_checkbox_top_window, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::KeepWindowOnTopChanged);
-  connect(m_checkbox_pause_on_focus_lost, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_radio_cursor_visible_movement, &QRadioButton::toggled, this,
           &InterfacePane::OnCursorVisibleMovement);
   connect(m_radio_cursor_visible_never, &QRadioButton::toggled, this,
@@ -299,8 +299,6 @@ void InterfacePane::LoadConfig()
     SignalBlocking(m_combobox_userstyle)->setCurrentIndex(index);
 
   // Render Window Options
-  SignalBlocking(m_checkbox_pause_on_focus_lost)
-      ->setChecked(Config::Get(Config::MAIN_PAUSE_ON_FOCUS_LOST));
   SignalBlocking(m_radio_cursor_visible_movement)
       ->setChecked(Settings::Instance().GetCursorVisibility() == Config::ShowCursor::OnMovement);
   SignalBlocking(m_radio_cursor_visible_always)
@@ -322,9 +320,6 @@ void InterfacePane::OnSaveConfig()
   if (!is_builtin_type)
     Settings::Instance().SetUserStyleName(selected_style.toString());
   Settings::Instance().ApplyStyle();
-
-  // Render Window Options
-  Config::SetBase(Config::MAIN_PAUSE_ON_FOCUS_LOST, m_checkbox_pause_on_focus_lost->isChecked());
 
   Config::Save();
 }
@@ -394,6 +389,9 @@ void InterfacePane::AddDescriptions()
   static constexpr char TR_SHOW_ACTIVE_TITLE_DESCRIPTION[] =
       QT_TR_NOOP("Shows the active game title in the render window's title bar."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static constexpr char TR_PAUSE_ON_FOCUS_LOST_DESCRIPTION[] =
+      QT_TR_NOOP("Pauses the game whenever the render window isn't focused."
+                 "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -418,4 +416,6 @@ void InterfacePane::AddDescriptions()
   m_checkbox_enable_osd->SetDescription(tr(TR_ENABLE_OSD_DESCRIPTION));
 
   m_checkbox_show_active_title->SetDescription(tr(TR_SHOW_ACTIVE_TITLE_DESCRIPTION));
+
+  m_checkbox_pause_on_focus_lost->SetDescription(tr(TR_PAUSE_ON_FOCUS_LOST_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -183,7 +183,8 @@ void InterfacePane::CreateInGame()
 
   m_checkbox_top_window = new ConfigBool(tr("Keep Window on Top"), Config::MAIN_KEEP_WINDOW_ON_TOP);
   m_checkbox_confirm_on_stop = new ConfigBool(tr("Confirm on Stop"), Config::MAIN_CONFIRM_ON_STOP);
-  m_checkbox_use_panic_handlers = new QCheckBox(tr("Use Panic Handlers"));
+  m_checkbox_use_panic_handlers =
+      new ConfigBool(tr("Use Panic Handlers"), Config::MAIN_USE_PANIC_HANDLERS);
   m_checkbox_enable_osd = new QCheckBox(tr("Show On-Screen Display Messages"));
   m_checkbox_show_active_title = new QCheckBox(tr("Show Active Title in Window Title"));
   m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Loss"));
@@ -241,7 +242,6 @@ void InterfacePane::ConnectLayout()
           [this]() { OnLanguageChanged(); });
   connect(m_checkbox_top_window, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::KeepWindowOnTopChanged);
-  connect(m_checkbox_use_panic_handlers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_active_title, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_enable_osd, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_pause_on_focus_lost, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
@@ -299,8 +299,6 @@ void InterfacePane::LoadConfig()
     SignalBlocking(m_combobox_userstyle)->setCurrentIndex(index);
 
   // Render Window Options
-  SignalBlocking(m_checkbox_use_panic_handlers)
-      ->setChecked(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
   SignalBlocking(m_checkbox_enable_osd)->setChecked(Config::Get(Config::MAIN_OSD_MESSAGES));
   SignalBlocking(m_checkbox_show_active_title)
       ->setChecked(Config::Get(Config::MAIN_SHOW_ACTIVE_TITLE));
@@ -329,7 +327,6 @@ void InterfacePane::OnSaveConfig()
   Settings::Instance().ApplyStyle();
 
   // Render Window Options
-  Config::SetBase(Config::MAIN_USE_PANIC_HANDLERS, m_checkbox_use_panic_handlers->isChecked());
   Config::SetBase(Config::MAIN_OSD_MESSAGES, m_checkbox_enable_osd->isChecked());
   Config::SetBase(Config::MAIN_SHOW_ACTIVE_TITLE, m_checkbox_show_active_title->isChecked());
   Config::SetBase(Config::MAIN_PAUSE_ON_FOCUS_LOST, m_checkbox_pause_on_focus_lost->isChecked());
@@ -390,6 +387,11 @@ void InterfacePane::AddDescriptions()
   static constexpr char TR_CONFIRM_ON_STOP_DESCRIPTION[] =
       QT_TR_NOOP("Prompts you to confirm that you want to end emulation when you press Stop."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static constexpr char TR_USE_PANIC_HANDLERS_DESCRIPTION[] =
+      QT_TR_NOOP("In the event of an error, Dolphin will halt to inform you of the error and "
+                 "present choices on how to proceed. With this option disabled, Dolphin will "
+                 "\"ignore\" all errors. Emulation will not be halted and you will not be notified."
+                 "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
 
   m_checkbox_use_builtin_title_database->SetDescription(tr(TR_TITLE_DATABASE_DESCRIPTION));
 
@@ -408,4 +410,6 @@ void InterfacePane::AddDescriptions()
   m_checkbox_disable_screensaver->SetDescription(tr(TR_DISABLE_SCREENSAVER_DESCRIPTION));
 
   m_checkbox_confirm_on_stop->SetDescription(tr(TR_CONFIRM_ON_STOP_DESCRIPTION));
+
+  m_checkbox_use_panic_handlers->SetDescription(tr(TR_USE_PANIC_HANDLERS_DESCRIPTION));
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -48,7 +48,7 @@ private:
   ConfigBool* m_checkbox_disable_screensaver;
 
   ConfigBool* m_checkbox_confirm_on_stop;
-  QCheckBox* m_checkbox_use_panic_handlers;
+  ConfigBool* m_checkbox_use_panic_handlers;
   QCheckBox* m_checkbox_enable_osd;
   QCheckBox* m_checkbox_show_active_title;
   QCheckBox* m_checkbox_pause_on_focus_lost;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -38,7 +38,7 @@ private:
   ConfigStringChoice* m_combobox_theme;
   QComboBox* m_combobox_userstyle;
   QLabel* m_label_userstyle;
-  QCheckBox* m_checkbox_top_window;
+  ConfigBool* m_checkbox_top_window;
   ConfigBool* m_checkbox_use_builtin_title_database;
   ToolTipCheckBox* m_checkbox_show_debugging_ui;
   QCheckBox* m_checkbox_focused_hotkeys;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -44,7 +44,7 @@ private:
   ConfigBool* m_checkbox_use_builtin_title_database;
   ToolTipCheckBox* m_checkbox_show_debugging_ui;
   ConfigBool* m_checkbox_focused_hotkeys;
-  QCheckBox* m_checkbox_use_covers;
+  ConfigBool* m_checkbox_use_covers;
   QCheckBox* m_checkbox_disable_screensaver;
 
   QCheckBox* m_checkbox_confirm_on_stop;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -7,7 +7,6 @@
 
 class ConfigBool;
 class ConfigStringChoice;
-class QCheckBox;
 class QComboBox;
 class QLabel;
 class QRadioButton;
@@ -55,5 +54,5 @@ private:
   QRadioButton* m_radio_cursor_visible_movement;
   QRadioButton* m_radio_cursor_visible_never;
   QRadioButton* m_radio_cursor_visible_always;
-  QCheckBox* m_checkbox_lock_mouse;
+  ConfigBool* m_checkbox_lock_mouse;
 };

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -50,7 +50,7 @@ private:
   ConfigBool* m_checkbox_confirm_on_stop;
   ConfigBool* m_checkbox_use_panic_handlers;
   ConfigBool* m_checkbox_enable_osd;
-  QCheckBox* m_checkbox_show_active_title;
+  ConfigBool* m_checkbox_show_active_title;
   QCheckBox* m_checkbox_pause_on_focus_lost;
   QRadioButton* m_radio_cursor_visible_movement;
   QRadioButton* m_radio_cursor_visible_never;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -45,7 +45,7 @@ private:
   ToolTipCheckBox* m_checkbox_show_debugging_ui;
   ConfigBool* m_checkbox_focused_hotkeys;
   ConfigBool* m_checkbox_use_covers;
-  QCheckBox* m_checkbox_disable_screensaver;
+  ConfigBool* m_checkbox_disable_screensaver;
 
   QCheckBox* m_checkbox_confirm_on_stop;
   QCheckBox* m_checkbox_use_panic_handlers;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -6,10 +6,10 @@
 #include <QWidget>
 
 class ConfigBool;
+class ConfigRadioInt;
 class ConfigStringChoice;
 class QComboBox;
 class QLabel;
-class QRadioButton;
 class QVBoxLayout;
 class ToolTipCheckBox;
 
@@ -28,9 +28,6 @@ private:
   void UpdateShowDebuggingCheckbox();
   void LoadConfig();
   void OnSaveConfig();
-  void OnCursorVisibleMovement();
-  void OnCursorVisibleNever();
-  void OnCursorVisibleAlways();
   void OnLanguageChanged();
 
   QVBoxLayout* m_main_layout;
@@ -51,8 +48,8 @@ private:
   ConfigBool* m_checkbox_enable_osd;
   ConfigBool* m_checkbox_show_active_title;
   ConfigBool* m_checkbox_pause_on_focus_lost;
-  QRadioButton* m_radio_cursor_visible_movement;
-  QRadioButton* m_radio_cursor_visible_never;
-  QRadioButton* m_radio_cursor_visible_always;
+  ConfigRadioInt* m_radio_cursor_visible_movement;
+  ConfigRadioInt* m_radio_cursor_visible_never;
+  ConfigRadioInt* m_radio_cursor_visible_always;
   ConfigBool* m_checkbox_lock_mouse;
 };

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -8,10 +8,10 @@
 class ConfigBool;
 class ConfigRadioInt;
 class ConfigStringChoice;
-class QComboBox;
 class QLabel;
 class QVBoxLayout;
 class ToolTipCheckBox;
+class ToolTipComboBox;
 
 class InterfacePane final : public QWidget
 {
@@ -26,15 +26,15 @@ private:
   void AddDescriptions();
   void ConnectLayout();
   void UpdateShowDebuggingCheckbox();
-  void LoadConfig();
-  void OnSaveConfig();
+  void LoadUserStyle();
+  void OnUserStyleChanged();
   void OnLanguageChanged();
 
   QVBoxLayout* m_main_layout;
   ConfigStringChoice* m_combobox_language;
 
   ConfigStringChoice* m_combobox_theme;
-  QComboBox* m_combobox_userstyle;
+  ToolTipComboBox* m_combobox_userstyle;
   QLabel* m_label_userstyle;
   ConfigBool* m_checkbox_top_window;
   ConfigBool* m_checkbox_use_builtin_title_database;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -47,7 +47,7 @@ private:
   ConfigBool* m_checkbox_use_covers;
   ConfigBool* m_checkbox_disable_screensaver;
 
-  QCheckBox* m_checkbox_confirm_on_stop;
+  ConfigBool* m_checkbox_confirm_on_stop;
   QCheckBox* m_checkbox_use_panic_handlers;
   QCheckBox* m_checkbox_enable_osd;
   QCheckBox* m_checkbox_show_active_title;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -5,6 +5,7 @@
 
 #include <QWidget>
 
+class ConfigBool;
 class QCheckBox;
 class QComboBox;
 class QLabel;
@@ -22,6 +23,7 @@ private:
   void CreateLayout();
   void CreateUI();
   void CreateInGame();
+  void AddDescriptions();
   void ConnectLayout();
   void LoadConfig();
   void OnSaveConfig();
@@ -36,8 +38,7 @@ private:
   QComboBox* m_combobox_userstyle;
   QLabel* m_label_userstyle;
   QCheckBox* m_checkbox_top_window;
-  QCheckBox* m_checkbox_use_builtin_title_database;
-  QCheckBox* m_checkbox_use_userstyle;
+  ConfigBool* m_checkbox_use_builtin_title_database;
   ToolTipCheckBox* m_checkbox_show_debugging_ui;
   QCheckBox* m_checkbox_focused_hotkeys;
   QCheckBox* m_checkbox_use_covers;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -31,9 +31,10 @@ private:
   void OnCursorVisibleMovement();
   void OnCursorVisibleNever();
   void OnCursorVisibleAlways();
+  void OnLanguageChanged();
 
   QVBoxLayout* m_main_layout;
-  QComboBox* m_combobox_language;
+  ConfigStringChoice* m_combobox_language;
 
   ConfigStringChoice* m_combobox_theme;
   QComboBox* m_combobox_userstyle;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -26,6 +26,7 @@ private:
   void CreateInGame();
   void AddDescriptions();
   void ConnectLayout();
+  void UpdateShowDebuggingCheckbox();
   void LoadConfig();
   void OnSaveConfig();
   void OnCursorVisibleMovement();

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -43,7 +43,7 @@ private:
   ConfigBool* m_checkbox_top_window;
   ConfigBool* m_checkbox_use_builtin_title_database;
   ToolTipCheckBox* m_checkbox_show_debugging_ui;
-  QCheckBox* m_checkbox_focused_hotkeys;
+  ConfigBool* m_checkbox_focused_hotkeys;
   QCheckBox* m_checkbox_use_covers;
   QCheckBox* m_checkbox_disable_screensaver;
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -49,7 +49,7 @@ private:
 
   ConfigBool* m_checkbox_confirm_on_stop;
   ConfigBool* m_checkbox_use_panic_handlers;
-  QCheckBox* m_checkbox_enable_osd;
+  ConfigBool* m_checkbox_enable_osd;
   QCheckBox* m_checkbox_show_active_title;
   QCheckBox* m_checkbox_pause_on_focus_lost;
   QRadioButton* m_radio_cursor_visible_movement;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -51,7 +51,7 @@ private:
   ConfigBool* m_checkbox_use_panic_handlers;
   ConfigBool* m_checkbox_enable_osd;
   ConfigBool* m_checkbox_show_active_title;
-  QCheckBox* m_checkbox_pause_on_focus_lost;
+  ConfigBool* m_checkbox_pause_on_focus_lost;
   QRadioButton* m_radio_cursor_visible_movement;
   QRadioButton* m_radio_cursor_visible_never;
   QRadioButton* m_radio_cursor_visible_always;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -6,6 +6,7 @@
 #include <QWidget>
 
 class ConfigBool;
+class ConfigStringChoice;
 class QCheckBox;
 class QComboBox;
 class QLabel;
@@ -34,7 +35,7 @@ private:
   QVBoxLayout* m_main_layout;
   QComboBox* m_combobox_language;
 
-  QComboBox* m_combobox_theme;
+  ConfigStringChoice* m_combobox_theme;
   QComboBox* m_combobox_userstyle;
   QLabel* m_label_userstyle;
   QCheckBox* m_checkbox_top_window;


### PR DESCRIPTION
Add BalloonTips to the Config->Interface pane by replacing the widgets with ConfigControls.

I aimed to make the tooltips reasonable but I'm assuming and open to them being workshopped.

This incidentally fixes the problem where changing any setting in the Interface pane would cause the UI to be unresponsive for a moment. That happened because every change caused the app's stylesheet to be set, which apparently takes several seconds when all the widgets are already created. Now the pause only happens when actually changing the style.