### PR TITLE
Android: Remove HostThreadLocks that are no longer needed

### DIFF
--- a/Source/Android/jni/Config/NativeConfig.cpp
+++ b/Source/Android/jni/Config/NativeConfig.cpp
@@ -123,7 +123,6 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_loadGameInis
                                                                                  jstring jGameId,
                                                                                  jint jRevision)
 {
-  HostThreadLock guard;
   const std::string game_id = GetJString(env, jGameId);
   const u16 revision = static_cast<u16>(jRevision);
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
@@ -133,7 +132,6 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_loadGameInis
 JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_unloadGameInis(JNIEnv*, jclass)
 {
-  HostThreadLock guard;
   Config::RemoveLayer(Config::LayerType::GlobalGame);
   Config::RemoveLayer(Config::LayerType::LocalGame);
 }
@@ -141,7 +139,10 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_unloadGameIn
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_save(
     JNIEnv*, jclass, jint layer)
 {
+  // HostThreadLock is used to ensure we don't try to save to SYSCONF at the same time as
+  // emulation shutdown does
   HostThreadLock guard;
+
   return GetLayer(layer, {})->Save();
 }
 
@@ -149,7 +150,6 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_deleteAllKeys(JNIEnv*, jclass,
                                                                                   jint layer)
 {
-  HostThreadLock guard;
   return GetLayer(layer, {})->DeleteAllKeys();
 }
 
@@ -166,7 +166,6 @@ JNIEXPORT jboolean JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_deleteKey(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key)
 {
-  HostThreadLock guard;
   const Config::Location location = GetLocation(env, file, section, key);
   const bool had_value = GetLayer(layer, location)->DeleteKey(location);
   if (had_value)
@@ -220,7 +219,6 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setString(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jstring value)
 {
-  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), GetJString(env, value));
 }
 
@@ -228,21 +226,18 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setBoolean(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jboolean value)
 {
-  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), static_cast<bool>(value));
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setInt(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jint value)
 {
-  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), value);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setFloat(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jfloat value)
 {
-  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), value);
 }
 }

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -531,18 +531,12 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Initialize(J
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ReportStartToAnalytics(JNIEnv*,
                                                                                            jclass)
 {
-  // Identity generation ends up calling config code, and some config callbacks use RunAsCPUThread
-  HostThreadLock guard;
-
   DolphinAnalytics::Instance().ReportDolphinStart(GetAnalyticValue("DEVICE_TYPE"));
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GenerateNewStatisticsId(JNIEnv*,
                                                                                             jclass)
 {
-  // Identity generation ends up calling config code, and some config callbacks use RunAsCPUThread
-  HostThreadLock guard;
-
   DolphinAnalytics::Instance().GenerateNewIdentity();
 }
 


### PR DESCRIPTION
PR #12117 got rid of the need to be the host or CPU thread when writing to the config.