### PR TITLE
Change Sensor Bar Position Default to Bottom

### DIFF
--- a/Source/Core/Core/Config/SYSCONFSettings.cpp
+++ b/Source/Core/Core/Config/SYSCONFSettings.cpp
@@ -20,7 +20,7 @@ const Info<u32> SYSCONF_SOUND_MODE{{System::SYSCONF, "IPL", "SND"}, 0x01};
 
 // SYSCONF.BT
 
-const Info<u32> SYSCONF_SENSOR_BAR_POSITION{{System::SYSCONF, "BT", "BAR"}, 0x01};
+const Info<u32> SYSCONF_SENSOR_BAR_POSITION{{System::SYSCONF, "BT", "BAR"}, 0x00};
 const Info<u32> SYSCONF_SENSOR_BAR_SENSITIVITY{{System::SYSCONF, "BT", "SENS"}, 0x03};
 const Info<u32> SYSCONF_SPEAKER_VOLUME{{System::SYSCONF, "BT", "SPKV"}, 0x58};
 const Info<bool> SYSCONF_WIIMOTE_MOTOR{{System::SYSCONF, "BT", "MOT"}, true};

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -260,7 +260,7 @@ void SysConf::InsertDefaultEntries()
   AddEntry({Entry::Type::BigArray, "BT.DINF", std::vector<u8>(0x460 + 1)});
   AddEntry({Entry::Type::BigArray, "BT.CDIF", std::vector<u8>(0x204 + 1)});
   AddEntry({Entry::Type::Long, "BT.SENS", {0, 0, 0, 3}});
-  AddEntry({Entry::Type::Byte, "BT.BAR", {1}});
+  AddEntry({Entry::Type::Byte, "BT.BAR", {0}});
   AddEntry({Entry::Type::Byte, "BT.SPKV", {0x58}});
   AddEntry({Entry::Type::Byte, "BT.MOT", {1}});
 


### PR DESCRIPTION
The default from running the Wii system menu is bottom so change Dolphin's default sensor position too.

To see the issue, start Dolphin from scratch like from a portable build from master and do the same from a portable build based on this PR. Then perform an online system update and load the Wii system menu.

You will observe the sensor bar position defaults to "Bottom", so I made the change to match this observation.