### PR TITLE
PowerPC: Unify "FromJit" MMU functions

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -445,7 +445,7 @@ void Jit64::dcbz(UGeckoInstruction inst)
   MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
   BitSet32 registersInUse = CallerSavedRegistersInUse();
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
-  ABI_CallFunctionPR(PowerPC::ClearDCacheLineFromJit64, &m_mmu, RSCRATCH);
+  ABI_CallFunctionPR(PowerPC::ClearDCacheLineFromJit, &m_mmu, RSCRATCH);
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);
 
   if (emit_fast_path)

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -397,16 +397,16 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, 
   switch (accessSize)
   {
   case 64:
-    ABI_CallFunctionPR(PowerPC::ReadU64FromJit64, &m_jit.m_mmu, reg_addr);
+    ABI_CallFunctionPR(PowerPC::ReadU64FromJit, &m_jit.m_mmu, reg_addr);
     break;
   case 32:
-    ABI_CallFunctionPR(PowerPC::ReadU32FromJit64, &m_jit.m_mmu, reg_addr);
+    ABI_CallFunctionPR(PowerPC::ReadU32FromJit, &m_jit.m_mmu, reg_addr);
     break;
   case 16:
-    ABI_CallFunctionPR(PowerPC::ReadU16ZXFromJit64, &m_jit.m_mmu, reg_addr);
+    ABI_CallFunctionPR(PowerPC::ReadU16FromJit, &m_jit.m_mmu, reg_addr);
     break;
   case 8:
-    ABI_CallFunctionPR(PowerPC::ReadU8ZXFromJit64, &m_jit.m_mmu, reg_addr);
+    ABI_CallFunctionPR(PowerPC::ReadU8FromJit, &m_jit.m_mmu, reg_addr);
     break;
   }
   ABI_PopRegistersAndAdjustStack(registersInUse, rsp_alignment);
@@ -461,16 +461,16 @@ void EmuCodeBlock::SafeLoadToRegImmediate(X64Reg reg_value, u32 address, int acc
   switch (accessSize)
   {
   case 64:
-    ABI_CallFunctionPC(PowerPC::ReadU64FromJit64, &m_jit.m_mmu, address);
+    ABI_CallFunctionPC(PowerPC::ReadU64FromJit, &m_jit.m_mmu, address);
     break;
   case 32:
-    ABI_CallFunctionPC(PowerPC::ReadU32FromJit64, &m_jit.m_mmu, address);
+    ABI_CallFunctionPC(PowerPC::ReadU32FromJit, &m_jit.m_mmu, address);
     break;
   case 16:
-    ABI_CallFunctionPC(PowerPC::ReadU16ZXFromJit64, &m_jit.m_mmu, address);
+    ABI_CallFunctionPC(PowerPC::ReadU16FromJit, &m_jit.m_mmu, address);
     break;
   case 8:
-    ABI_CallFunctionPC(PowerPC::ReadU8ZXFromJit64, &m_jit.m_mmu, address);
+    ABI_CallFunctionPC(PowerPC::ReadU8FromJit, &m_jit.m_mmu, address);
     break;
   }
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);
@@ -580,19 +580,19 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
   switch (accessSize)
   {
   case 64:
-    ABI_CallFunctionPRR(swap ? PowerPC::WriteU64FromJit64 : PowerPC::WriteU64SwapFromJit64,
+    ABI_CallFunctionPRR(swap ? PowerPC::WriteU64FromJit : PowerPC::WriteU64SwapFromJit,
                         &m_jit.m_mmu, reg, reg_addr);
     break;
   case 32:
-    ABI_CallFunctionPRR(swap ? PowerPC::WriteU32FromJit64 : PowerPC::WriteU32SwapFromJit64,
+    ABI_CallFunctionPRR(swap ? PowerPC::WriteU32FromJit : PowerPC::WriteU32SwapFromJit,
                         &m_jit.m_mmu, reg, reg_addr);
     break;
   case 16:
-    ABI_CallFunctionPRR(swap ? PowerPC::WriteU16FromJit64 : PowerPC::WriteU16SwapFromJit64,
+    ABI_CallFunctionPRR(swap ? PowerPC::WriteU16FromJit : PowerPC::WriteU16SwapFromJit,
                         &m_jit.m_mmu, reg, reg_addr);
     break;
   case 8:
-    ABI_CallFunctionPRR(PowerPC::WriteU8FromJit64, &m_jit.m_mmu, reg, reg_addr);
+    ABI_CallFunctionPRR(PowerPC::WriteU8FromJit, &m_jit.m_mmu, reg, reg_addr);
     break;
   }
   ABI_PopRegistersAndAdjustStack(registersInUse, rsp_alignment);
@@ -662,16 +662,16 @@ bool EmuCodeBlock::WriteToConstAddress(int accessSize, OpArg arg, u32 address,
     switch (accessSize)
     {
     case 64:
-      ABI_CallFunctionPAC(64, PowerPC::WriteU64FromJit64, &m_jit.m_mmu, arg, address);
+      ABI_CallFunctionPAC(64, PowerPC::WriteU64FromJit, &m_jit.m_mmu, arg, address);
       break;
     case 32:
-      ABI_CallFunctionPAC(32, PowerPC::WriteU32FromJit64, &m_jit.m_mmu, arg, address);
+      ABI_CallFunctionPAC(32, PowerPC::WriteU32FromJit, &m_jit.m_mmu, arg, address);
       break;
     case 16:
-      ABI_CallFunctionPAC(16, PowerPC::WriteU16FromJit64, &m_jit.m_mmu, arg, address);
+      ABI_CallFunctionPAC(16, PowerPC::WriteU16FromJit, &m_jit.m_mmu, arg, address);
       break;
     case 8:
-      ABI_CallFunctionPAC(8, PowerPC::WriteU8FromJit64, &m_jit.m_mmu, arg, address);
+      ABI_CallFunctionPAC(8, PowerPC::WriteU8FromJit, &m_jit.m_mmu, arg, address);
       break;
     }
     ABI_PopRegistersAndAdjustStack(registersInUse, 0);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -246,21 +246,23 @@ protected:
   // Registers used:
   //
   //                 addr     scratch
-  // Store:          X1       X0
-  // Load:           X0
-  // Zero 256:       X0       X30
-  // Store float:    X1       Q0
-  // Load float:     X0
+  // Store:          X2       X1
+  // Load:           X1
+  // Zero 256:       X1       X30
+  // Store float:    X2       Q0
+  // Load float:     X1
   //
   // If mode == AlwaysFastAccess, the addr argument can be any register.
   // Otherwise it must be the register listed in the table above.
   //
   // Additional scratch registers are used in the following situations:
   //
-  // emitting_routine && mode == Auto:                                            X2
+  // emitting_routine && mode == Auto:                                            X0
   // emitting_routine && mode == Auto && !(flags & BackPatchInfo::FLAG_STORE):    X3
   // emitting_routine && mode != AlwaysSlowAccess && !jo.fastmem:                 X3
-  // mode != AlwaysSlowAccess && !jo.fastmem:                                     X2
+  // mode != AlwaysSlowAccess && !jo.fastmem:                                     X0
+  // !emitting_routine && mode != AlwaysFastAccess && jo.memcheck &&
+  //         (flags & BackPatchInfo::FLAG_LOAD):                                  X0
   // !emitting_routine && mode != AlwaysSlowAccess && !jo.fastmem:                X30
   // !emitting_routine && mode == Auto && jo.fastmem:                             X30
   //

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1681,100 +1681,51 @@ std::optional<u32> MMU::GetTranslatedAddress(u32 address)
   return std::optional<u32>(result.address);
 }
 
-void ClearDCacheLineFromJit64(MMU& mmu, u32 address)
+void ClearDCacheLineFromJit(MMU& mmu, u32 address)
 {
   mmu.ClearDCacheLine(address);
 }
-u32 ReadU8ZXFromJit64(MMU& mmu, u32 address)
+u32 ReadU8FromJit(MMU& mmu, u32 address)
 {
   return mmu.Read_U8(address);
 }
-u32 ReadU16ZXFromJit64(MMU& mmu, u32 address)
+u32 ReadU16FromJit(MMU& mmu, u32 address)
 {
   return mmu.Read_U16(address);
 }
-u32 ReadU32FromJit64(MMU& mmu, u32 address)
+u32 ReadU32FromJit(MMU& mmu, u32 address)
 {
   return mmu.Read_U32(address);
 }
-u64 ReadU64FromJit64(MMU& mmu, u32 address)
+u64 ReadU64FromJit(MMU& mmu, u32 address)
 {
   return mmu.Read_U64(address);
 }
-void WriteU8FromJit64(MMU& mmu, u32 var, u32 address)
+void WriteU8FromJit(MMU& mmu, u32 var, u32 address)
 {
   mmu.Write_U8(var, address);
 }
-void WriteU16FromJit64(MMU& mmu, u32 var, u32 address)
+void WriteU16FromJit(MMU& mmu, u32 var, u32 address)
 {
   mmu.Write_U16(var, address);
 }
-void WriteU32FromJit64(MMU& mmu, u32 var, u32 address)
+void WriteU32FromJit(MMU& mmu, u32 var, u32 address)
 {
   mmu.Write_U32(var, address);
 }
-void WriteU64FromJit64(MMU& mmu, u64 var, u32 address)
+void WriteU64FromJit(MMU& mmu, u64 var, u32 address)
 {
   mmu.Write_U64(var, address);
 }
-void WriteU16SwapFromJit64(MMU& mmu, u32 var, u32 address)
+void WriteU16SwapFromJit(MMU& mmu, u32 var, u32 address)
 {
   mmu.Write_U16_Swap(var, address);
 }
-void WriteU32SwapFromJit64(MMU& mmu, u32 var, u32 address)
+void WriteU32SwapFromJit(MMU& mmu, u32 var, u32 address)
 {
   mmu.Write_U32_Swap(var, address);
 }
-void WriteU64SwapFromJit64(MMU& mmu, u64 var, u32 address)
-{
-  mmu.Write_U64_Swap(var, address);
-}
-
-void ClearDCacheLineFromJitArm64(u32 address, MMU& mmu)
-{
-  mmu.ClearDCacheLine(address);
-}
-u8 ReadU8FromJitArm64(u32 address, MMU& mmu)
-{
-  return mmu.Read_U8(address);
-}
-u16 ReadU16FromJitArm64(u32 address, MMU& mmu)
-{
-  return mmu.Read_U16(address);
-}
-u32 ReadU32FromJitArm64(u32 address, MMU& mmu)
-{
-  return mmu.Read_U32(address);
-}
-u64 ReadU64FromJitArm64(u32 address, MMU& mmu)
-{
-  return mmu.Read_U64(address);
-}
-void WriteU8FromJitArm64(u32 var, u32 address, MMU& mmu)
-{
-  mmu.Write_U8(var, address);
-}
-void WriteU16FromJitArm64(u32 var, u32 address, MMU& mmu)
-{
-  mmu.Write_U16(var, address);
-}
-void WriteU32FromJitArm64(u32 var, u32 address, MMU& mmu)
-{
-  mmu.Write_U32(var, address);
-}
-void WriteU64FromJitArm64(u64 var, u32 address, MMU& mmu)
-{
-  mmu.Write_U64(var, address);
-}
-void WriteU16SwapFromJitArm64(u32 var, u32 address, MMU& mmu)
-{
-  mmu.Write_U16_Swap(var, address);
-}
-void WriteU32SwapFromJitArm64(u32 var, u32 address, MMU& mmu)
-{
-  mmu.Write_U32_Swap(var, address);
-}
-void WriteU64SwapFromJitArm64(u64 var, u32 address, MMU& mmu)
+void WriteU64SwapFromJit(MMU& mmu, u64 var, u32 address)
 {
   mmu.Write_U64_Swap(var, address);
 }

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -328,32 +328,16 @@ private:
   BatTable m_dbat_table;
 };
 
-void ClearDCacheLineFromJit64(MMU& mmu, u32 address);
-u32 ReadU8ZXFromJit64(MMU& mmu, u32 address);   // Returns zero-extended 32bit value
-u32 ReadU16ZXFromJit64(MMU& mmu, u32 address);  // Returns zero-extended 32bit value
-u32 ReadU32FromJit64(MMU& mmu, u32 address);
-u64 ReadU64FromJit64(MMU& mmu, u32 address);
-void WriteU8FromJit64(MMU& mmu, u32 var, u32 address);
-void WriteU16FromJit64(MMU& mmu, u32 var, u32 address);
-void WriteU32FromJit64(MMU& mmu, u32 var, u32 address);
-void WriteU64FromJit64(MMU& mmu, u64 var, u32 address);
-void WriteU16SwapFromJit64(MMU& mmu, u32 var, u32 address);
-void WriteU32SwapFromJit64(MMU& mmu, u32 var, u32 address);
-void WriteU64SwapFromJit64(MMU& mmu, u64 var, u32 address);
-
-// The JitArm64 function that calls these has very specific register allocation that's difficult to
-// change, so we have a separate set of functions here for it. This can probably be refactored in
-// the future.
-void ClearDCacheLineFromJitArm64(u32 address, MMU& mmu);
-u8 ReadU8FromJitArm64(u32 address, MMU& mmu);
-u16 ReadU16FromJitArm64(u32 address, MMU& mmu);
-u32 ReadU32FromJitArm64(u32 address, MMU& mmu);
-u64 ReadU64FromJitArm64(u32 address, MMU& mmu);
-void WriteU8FromJitArm64(u32 var, u32 address, MMU& mmu);
-void WriteU16FromJitArm64(u32 var, u32 address, MMU& mmu);
-void WriteU32FromJitArm64(u32 var, u32 address, MMU& mmu);
-void WriteU64FromJitArm64(u64 var, u32 address, MMU& mmu);
-void WriteU16SwapFromJitArm64(u32 var, u32 address, MMU& mmu);
-void WriteU32SwapFromJitArm64(u32 var, u32 address, MMU& mmu);
-void WriteU64SwapFromJitArm64(u64 var, u32 address, MMU& mmu);
+void ClearDCacheLineFromJit(MMU& mmu, u32 address);
+u32 ReadU8FromJit(MMU& mmu, u32 address);   // Returns zero-extended 32bit value
+u32 ReadU16FromJit(MMU& mmu, u32 address);  // Returns zero-extended 32bit value
+u32 ReadU32FromJit(MMU& mmu, u32 address);
+u64 ReadU64FromJit(MMU& mmu, u32 address);
+void WriteU8FromJit(MMU& mmu, u32 var, u32 address);
+void WriteU16FromJit(MMU& mmu, u32 var, u32 address);
+void WriteU32FromJit(MMU& mmu, u32 var, u32 address);
+void WriteU64FromJit(MMU& mmu, u64 var, u32 address);
+void WriteU16SwapFromJit(MMU& mmu, u32 var, u32 address);
+void WriteU32SwapFromJit(MMU& mmu, u32 var, u32 address);
+void WriteU64SwapFromJit(MMU& mmu, u64 var, u32 address);
 }  // namespace PowerPC


### PR DESCRIPTION
This gets rid of the odd argument order we were using for JitArm64.