### PR TITLE
NetPlaySetupDialog: Fix spacing in Connect tab

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -110,19 +110,23 @@ void NetPlaySetupDialog::CreateMainLayout()
   connection_layout->addWidget(m_ip_edit, 0, 1);
   connection_layout->addWidget(m_connect_port_label, 0, 2);
   connection_layout->addWidget(m_connect_port_box, 0, 3);
-  connection_layout->addWidget(
-      new QLabel(
-          tr("ALERT:\n\n"
-             "All players must use the same Dolphin version.\n"
-             "If enabled, SD cards must be identical between players.\n"
-             "If DSP LLE is used, DSP ROMs must be identical between players.\n"
-             "If a game is hanging on boot, it may not support Dual Core Netplay."
-             " Disable Dual Core.\n"
-             "If connecting directly, the host must have the chosen UDP port open/forwarded!\n"
-             "\n"
-             "Wii Remote support in netplay is experimental and may not work correctly.\n"
-             "Use at your own risk.\n")),
-      1, 0, -1, -1);
+  auto* const alert_label = new QLabel(
+      tr("ALERT:\n\n"
+         "All players must use the same Dolphin version.\n"
+         "If enabled, SD cards must be identical between players.\n"
+         "If DSP LLE is used, DSP ROMs must be identical between players.\n"
+         "If a game is hanging on boot, it may not support Dual Core Netplay."
+         " Disable Dual Core.\n"
+         "If connecting directly, the host must have the chosen UDP port open/forwarded!\n"
+         "\n"
+         "Wii Remote support in netplay is experimental and may not work correctly.\n"
+         "Use at your own risk.\n"));
+
+  // Prevent the label from stretching vertically so the spacer gets all the extra space
+  alert_label->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+
+  connection_layout->addWidget(alert_label, 1, 0, 1, -1);
+  connection_layout->addItem(new QSpacerItem(1, 1), 2, 0, -1, -1);
   connection_layout->addWidget(m_connect_button, 3, 3, Qt::AlignRight);
 
   connection_widget->setLayout(connection_layout);


### PR DESCRIPTION
Add a spacer between the alert text and Connect button to prevent the alert text from migrating down with larger window heights.

Before:
![before](https://github.com/dolphin-emu/dolphin/assets/73494713/9b72f02c-7030-4f04-a016-521878b9d3f4)
After:
![after](https://github.com/dolphin-emu/dolphin/assets/73494713/6564f997-04fe-4892-a73a-847a9ef59d28)
