### PR TITLE
WC24Send: Add missing header guard

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/Mail/WC24Send.h
+++ b/Source/Core/Core/IOS/Network/KD/Mail/WC24Send.h
@@ -1,6 +1,8 @@
 // Copyright 2023 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#pragma once
+
 #include <string_view>
 
 #include "Common/CommonPaths.h"


### PR DESCRIPTION
Prevents double inclusions from occurring in the same TU.