### PR TITLE
CustomAssetLibrary: Add virtual destructor

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
@@ -31,6 +31,8 @@ public:
     CustomAssetLibrary::TimeType m_load_time = {};
   };
 
+  virtual ~CustomAssetLibrary() = default;
+
   // Loads a texture, if there are no levels, bytes loaded will be empty
   virtual LoadInfo LoadTexture(const AssetID& asset_id, TextureData* data) = 0;
 

--- a/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLibrary.h
@@ -28,7 +28,7 @@ public:
   struct LoadInfo
   {
     std::size_t m_bytes_loaded = 0;
-    CustomAssetLibrary::TimeType m_load_time = {};
+    TimeType m_load_time = {};
   };
 
   virtual ~CustomAssetLibrary() = default;


### PR DESCRIPTION
This is used as a base pointer inside CustomPipelineAction to handle any derived type, so this should probably really have a virtual destructor to ensure those derived objects are torn down properly.