### PR TITLE
SkylandersPortalWindow: Remove unnecessary string conversions

### DIFF
--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderModifyDialog.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderModifyDialog.cpp
@@ -160,11 +160,11 @@ void SkylanderModifyDialog::PopulateSkylanderOptions(QVBoxLayout* layout)
 
   edit_money->setValidator(new QIntValidator(0, 65000, this));
   edit_hero->setValidator(new QIntValidator(0, 100, this));
-  edit_nick->setValidator(new QRegularExpressionValidator(
-      QRegularExpression(QString::fromStdString("^\\p{L}{0,15}$")), this));
+  edit_nick->setValidator(
+      new QRegularExpressionValidator(QRegularExpression(QStringLiteral("^\\p{L}{0,15}$")), this));
   edit_playtime->setValidator(new QIntValidator(0, INT_MAX, this));
-  edit_last_reset->setDisplayFormat(QString::fromStdString("dd/MM/yyyy hh:mm"));
-  edit_last_placed->setDisplayFormat(QString::fromStdString("dd/MM/yyyy hh:mm"));
+  edit_last_reset->setDisplayFormat(QStringLiteral("dd/MM/yyyy hh:mm"));
+  edit_last_placed->setDisplayFormat(QStringLiteral("dd/MM/yyyy hh:mm"));
 
   edit_toy_code->setToolTip(tr("The toy code for this figure. Only available for real figures."));
   edit_money->setToolTip(tr("The amount of money this skylander should have. Between 0 and 65000"));

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderModifyDialog.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderModifyDialog.cpp
@@ -57,7 +57,7 @@ SkylanderModifyDialog::SkylanderModifyDialog(QWidget* parent, u8 slot)
     }
   }
 
-  auto* label_name = new QLabel(QString::fromStdString("Modifying Skylander %1").arg(name));
+  auto* label_name = new QLabel(tr("Modifying Skylander: %1").arg(name));
 
   hbox_name->addWidget(label_name);
 
@@ -86,7 +86,7 @@ SkylanderModifyDialog::SkylanderModifyDialog(QWidget* parent, u8 slot)
   else if (m_figure_data.normalized_type == IOS::HLE::USB::Type::Unknown)
   {
     should_show = false;
-    QMessageBox::warning(this, tr("Unknow Skylander type!"),
+    QMessageBox::warning(this, tr("Unknown Skylander type!"),
                          tr("The type of this Skylander is unknown!"), QMessageBox::Ok);
   }
   else

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
@@ -44,7 +44,7 @@ SkylanderPortalWindow::SkylanderPortalWindow(QWidget* parent) : QWidget(parent)
 {
   setWindowTitle(tr("Skylanders Manager"));
   setWindowIcon(Resources::GetAppIcon());
-  setObjectName(QString::fromStdString("skylanders_manager"));
+  setObjectName(QStringLiteral("skylanders_manager"));
   setMinimumSize(QSize(650, 500));
 
   m_only_show_collection = new QCheckBox(tr("Only Show Collection"));
@@ -64,9 +64,9 @@ SkylanderPortalWindow::SkylanderPortalWindow(QWidget* parent) : QWidget(parent)
   QDir skylanders_folder;
   // skylanders folder in user directory
   QString user_path =
-      QString::fromStdString(File::GetUserPath(D_USER_IDX)) + QString::fromStdString("Skylanders");
+      QString::fromStdString(File::GetUserPath(D_USER_IDX)) + QStringLiteral("Skylanders");
   // first time initialize path in config
-  if (Config::Get(Config::MAIN_SKYLANDERS_PATH) == "")
+  if (Config::Get(Config::MAIN_SKYLANDERS_PATH).empty())
   {
     Config::SetBase(Config::MAIN_SKYLANDERS_PATH, user_path.toStdString());
     skylanders_folder = QDir(user_path);
@@ -185,7 +185,7 @@ QVBoxLayout* SkylanderPortalWindow::CreateSlotLayout()
     }
 
     auto* hbox_skylander = new QHBoxLayout();
-    auto* label_skyname = new QLabel(QString(tr("Skylander %1")).arg(i + 1));
+    auto* label_skyname = new QLabel(tr("Skylander %1").arg(i + 1));
     m_edit_skylanders[i] = new QLineEdit();
     m_edit_skylanders[i]->setEnabled(false);
 
@@ -589,8 +589,7 @@ void SkylanderPortalWindow::CreateSkylanderAdvanced()
   auto* label_var = new QLabel(tr("Variant:"));
   auto* edit_id = new QLineEdit(tr("0"));
   auto* edit_var = new QLineEdit(tr("0"));
-  auto* rxv =
-      new QRegularExpressionValidator(QRegularExpression(QString::fromStdString("\\d*")), this);
+  auto* rxv = new QRegularExpressionValidator(QRegularExpression(QStringLiteral("\\d*")), this);
   edit_id->setValidator(rxv);
   edit_var->setValidator(rxv);
   hbox_idvar->addWidget(label_id);
@@ -803,7 +802,7 @@ void SkylanderPortalWindow::CreateSkyfile(const QString& path, bool load_after)
     }
     figure.Close();
   }
-  m_last_skylander_path = QFileInfo(path).absolutePath() + QString::fromStdString("/");
+  m_last_skylander_path = QFileInfo(path).absolutePath() + QLatin1Char{'/'};
 
   if (load_after)
     LoadSkyfilePath(GetCurrentSlot(), path);

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
@@ -875,7 +875,7 @@ void SkylanderPortalWindow::UpdateSlotNames()
 }
 
 // Helpers
-bool SkylanderPortalWindow::PassesFilter(QString name, u16 id, u16 var)
+bool SkylanderPortalWindow::PassesFilter(const QString& name, u16 id, u16 var) const
 {
   const auto skypair = IOS::HLE::USB::list_skylanders.find(std::make_pair(id, var));
   IOS::HLE::USB::SkyData character;
@@ -916,7 +916,7 @@ bool SkylanderPortalWindow::PassesFilter(QString name, u16 id, u16 var)
   return true;
 }
 
-QString SkylanderPortalWindow::GetFilePath(u16 id, u16 var)
+QString SkylanderPortalWindow::GetFilePath(u16 id, u16 var) const
 {
   const QDir collection = QDir(m_collection_path);
   auto& system = Core::System::GetInstance();
@@ -938,12 +938,12 @@ QString SkylanderPortalWindow::GetFilePath(u16 id, u16 var)
       return file.filePath();
     }
   }
-  return QString();
+  return {};
 }
 
-u8 SkylanderPortalWindow::GetCurrentSlot()
+u8 SkylanderPortalWindow::GetCurrentSlot() const
 {
-  for (auto radio : m_slot_radios)
+  for (const auto* radio : m_slot_radios)
   {
     if (radio->isChecked())
     {
@@ -953,9 +953,9 @@ u8 SkylanderPortalWindow::GetCurrentSlot()
   return 0;
 }
 
-int SkylanderPortalWindow::GetElementRadio()
+int SkylanderPortalWindow::GetElementRadio() const
 {
-  for (auto radio : m_element_filter)
+  for (const auto* radio : m_element_filter)
   {
     if (radio->isChecked())
     {
@@ -965,9 +965,9 @@ int SkylanderPortalWindow::GetElementRadio()
   return -1;
 }
 
-int SkylanderPortalWindow::GetTypeRadio()
+int SkylanderPortalWindow::GetTypeRadio() const
 {
-  for (auto radio : m_type_filter)
+  for (const auto* radio : m_type_filter)
   {
     if (radio->isChecked())
     {
@@ -984,7 +984,7 @@ QBrush SkylanderPortalWindow::GetBaseColor(std::pair<const u16, const u16> ids, 
   if (skylander == IOS::HLE::USB::list_skylanders.end())
     return QBrush(dark_theme ? QColor(32, 32, 32) : QColor(255, 255, 255));
 
-  switch ((*skylander).second.game)
+  switch (skylander->second.game)
   {
   case Game::SpyrosAdv:
     return QBrush(dark_theme ? QColor(10, 42, 90) : QColor(240, 255, 240));

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
@@ -157,7 +157,7 @@ QVBoxLayout* SkylanderPortalWindow::CreateSlotLayout()
   m_enabled_checkbox = new QCheckBox(tr("Emulate Skylander Portal"), this);
   m_enabled_checkbox->setChecked(Config::Get(Config::MAIN_EMULATE_SKYLANDER_PORTAL));
   m_emulating = Config::Get(Config::MAIN_EMULATE_SKYLANDER_PORTAL);
-  connect(m_enabled_checkbox, &QCheckBox::toggled, [&](bool checked) { EmulatePortal(checked); });
+  connect(m_enabled_checkbox, &QCheckBox::toggled, this, &SkylanderPortalWindow::EmulatePortal);
   checkbox_layout->addWidget(m_enabled_checkbox);
   slot_layout->addLayout(checkbox_layout);
 

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.h
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.h
@@ -76,15 +76,15 @@ private:
   void UpdateSlotNames();
 
   // Helpers
-  bool PassesFilter(QString name, u16 id, u16 var);
-  QString GetFilePath(u16 id, u16 var);
-  u8 GetCurrentSlot();
-  int GetElementRadio();
-  int GetTypeRadio();
-  QBrush GetBaseColor(std::pair<const u16, const u16> ids, bool dark_theme);
-  int GetGameID(Game game);
-  int GetElementID(Element elem);
-  int GetTypeID(Type type);
+  bool PassesFilter(const QString& name, u16 id, u16 var) const;
+  QString GetFilePath(u16 id, u16 var) const;
+  u8 GetCurrentSlot() const;
+  int GetElementRadio() const;
+  int GetTypeRadio() const;
+  static QBrush GetBaseColor(std::pair<const u16, const u16> ids, bool dark_theme);
+  static int GetGameID(Game game);
+  static int GetElementID(Element elem);
+  static int GetTypeID(Type type);
 
   bool m_emulating;
   QCheckBox* m_enabled_checkbox;


### PR DESCRIPTION
Just some churn I noticed that could be eliminated fairly easy. Also has some other minor changes that were noticed along the way that are fairly minor