### PR TITLE
WIP: Video: Add 4xRGSS downsampling shader.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -137,6 +137,7 @@ void EnhancementsWidget::CreateWidgets()
                                      static_cast<int>(OutputResamplingMode::SharpBilinear));
   m_output_resampling_combo->addItem(tr("Area Sampling"),
                                      static_cast<int>(OutputResamplingMode::AreaSampling));
+  m_output_resampling_combo->addItem(tr("4xRGSS"), static_cast<int>(OutputResamplingMode::RGSS));
 
   m_configure_color_correction = new ToolTipPushButton(tr("Configure"));
 
@@ -533,6 +534,10 @@ void EnhancementsWidget::AddDescriptions()
                  "<br><br><b>Area Sampling</b> - [up to 324 samples]"
                  "<br>Weights pixels by the percentage of area they occupy. Gamma corrected."
                  "<br>Best for down scaling by more than 2x."
+
+                 "<br><br><b>4xRGSS</b> - [4 samples]"
+                 "<br>Rotated Grid SuperSampling, common antialiasing method with smooth results."
+                 "<br>Best for down scaling by more than 2x, useless for up scaling."
 
                  "<br><br><dolphin_emphasis>If unsure, select 'Default'.</dolphin_emphasis>");
   static const char TR_COLOR_CORRECTION_DESCRIPTION[] =

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -61,6 +61,7 @@ enum class OutputResamplingMode : int
   CatmullRom,
   SharpBilinear,
   AreaSampling,
+  RGSS
 };
 
 enum class ColorCorrectionRegion : int

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -61,7 +61,7 @@ enum class OutputResamplingMode : int
   CatmullRom,
   SharpBilinear,
   AreaSampling,
-  RGSS
+  RGSS,
 };
 
 enum class ColorCorrectionRegion : int


### PR DESCRIPTION
I saw the output resampling in the recent [progress report](https://dolphin-emu.org/blog/2023/11/25/dolphin-progress-report-august-september-and-october-2023/), so I thought this method might be a good addition as it gives quite decent results for the number of samples.

Here's some comparison screenshots using Starfox Adventures (fur, diagonal lines) at 4x internal resolution and native window size. [Album](https://imgur.com/a/u0ZacIP)

EDIT: More screenshots. [LEGO StarWars](https://imgur.com/a/LiJp19H), [Rythm Heaven](https://imgur.com/a/WkPFu8w)

~~Note: Due to resampling_method numbering on the shader, I re-added the hidden methods to the enum. (Nearest, Hermite). Also, no documentation on the shader and no tooltip... therefore, WIP.~~