### PR TITLE
VideoCommon: move xf state management to its own class

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -39,8 +39,8 @@
 #include "DiscIO/VolumeDisc.h"
 
 #include "VideoCommon/VertexManagerBase.h"
-#include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/XFMemory.h"
+#include "VideoCommon/XFStateManager.h"
 
 namespace
 {
@@ -285,8 +285,8 @@ bool CBoot::EmulatedBS2_GC(Core::System& system, const Core::CPUThreadGuard& gua
   xfmem.postMatrices[0x3e * 4 + 1] = 1.0f;
   xfmem.postMatrices[0x3f * 4 + 2] = 1.0f;
   g_vertex_manager->Flush();
-  auto& vertex_shader_manager = system.GetVertexShaderManager();
-  vertex_shader_manager.InvalidateXFRange(XFMEM_POSTMATRICES + 0x3d * 4, XFMEM_POSTMATRICES_END);
+  auto& xf_state_manager = system.GetXFStateManager();
+  xf_state_manager.InvalidateXFRange(XFMEM_POSTMATRICES + 0x3d * 4, XFMEM_POSTMATRICES_END);
 
   DVDReadDiscID(system, volume, 0x00000000);
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -93,7 +93,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 164;  // Last changed in PR 12282
+constexpr u32 STATE_VERSION = 165;  // Last changed in PR 12328
 
 // Increase this if the StateExtendedHeader definition changes
 constexpr u32 EXTENDED_HEADER_VERSION = 1;  // Last changed in PR 12217

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -34,6 +34,7 @@
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/VertexShaderManager.h"
+#include "VideoCommon/XFStateManager.h"
 
 namespace Core
 {
@@ -77,6 +78,7 @@ struct System::Impl
   SerialInterface::SerialInterfaceManager m_serial_interface;
   Sram m_sram;
   VertexShaderManager m_vertex_shader_manager;
+  XFStateManager m_xf_state_manager;
   VideoInterface::VideoInterfaceManager m_video_interface;
   Interpreter m_interpreter;
   JitInterface m_jit_interface;
@@ -259,6 +261,11 @@ Sram& System::GetSRAM() const
 VertexShaderManager& System::GetVertexShaderManager() const
 {
   return m_impl->m_vertex_shader_manager;
+}
+
+XFStateManager& System::GetXFStateManager() const
+{
+  return m_impl->m_xf_state_manager;
 }
 
 VideoInterface::VideoInterfaceManager& System::GetVideoInterface() const

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -12,6 +12,7 @@ class PixelShaderManager;
 class SoundStream;
 struct Sram;
 class VertexShaderManager;
+class XFStateManager;
 
 namespace AudioInterface
 {
@@ -155,6 +156,7 @@ public:
   SerialInterface::SerialInterfaceManager& GetSerialInterface() const;
   Sram& GetSRAM() const;
   VertexShaderManager& GetVertexShaderManager() const;
+  XFStateManager& GetXFStateManager() const;
   VideoInterface::VideoInterfaceManager& GetVideoInterface() const;
   VideoCommon::CustomAssetLoader& GetCustomAssetLoader() const;
 

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -746,6 +746,7 @@
     <ClInclude Include="VideoCommon\VideoState.h" />
     <ClInclude Include="VideoCommon\Widescreen.h" />
     <ClInclude Include="VideoCommon\XFMemory.h" />
+    <ClInclude Include="VideoCommon\XFStateManager.h" />
     <ClInclude Include="VideoCommon\XFStructs.h" />
   </ItemGroup>
   <ItemGroup>
@@ -1356,6 +1357,7 @@
     <ClCompile Include="VideoCommon\VideoState.cpp" />
     <ClCompile Include="VideoCommon\Widescreen.cpp" />
     <ClCompile Include="VideoCommon\XFMemory.cpp" />
+    <ClCompile Include="VideoCommon\XFStateManager.cpp" />
     <ClCompile Include="VideoCommon\XFStructs.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -38,11 +38,11 @@
 #include "VideoCommon/TMEM.h"
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/TextureDecoder.h"
-#include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/VideoEvents.h"
+#include "VideoCommon/XFStateManager.h"
 
 using namespace BPFunctions;
 
@@ -55,8 +55,7 @@ void BPInit()
   bpmem.bpMask = 0xFFFFFF;
 }
 
-static void BPWritten(PixelShaderManager& pixel_shader_manager,
-                      VertexShaderManager& vertex_shader_manager,
+static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& xf_state_manager,
                       GeometryShaderManager& geometry_shader_manager, const BPCmd& bp,
                       int cycles_into_future)
 {
@@ -139,7 +138,7 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager,
   case BPMEM_SCISSORTL:      // Scissor Rectable Top, Left
   case BPMEM_SCISSORBR:      // Scissor Rectable Bottom, Right
   case BPMEM_SCISSOROFFSET:  // Scissor Offset
-    vertex_shader_manager.SetViewportChanged();
+    xf_state_manager.SetViewportChanged();
     geometry_shader_manager.SetViewportChanged();
     return;
   case BPMEM_LINEPTWIDTH:  // Line Width
@@ -790,7 +789,7 @@ void LoadBPReg(u8 reg, u32 value, int cycles_into_future)
   if (reg != BPMEM_BP_MASK)
     bpmem.bpMask = 0xFFFFFF;
 
-  BPWritten(system.GetPixelShaderManager(), system.GetVertexShaderManager(),
+  BPWritten(system.GetPixelShaderManager(), system.GetXFStateManager(),
             system.GetGeometryShaderManager(), bp, cycles_into_future);
 }
 

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -196,6 +196,8 @@ add_library(videocommon
   Widescreen.h
   XFMemory.cpp
   XFMemory.h
+  XFStateManager.cpp
+  XFStateManager.h
   XFStructs.cpp
   XFStructs.h
 )

--- a/Source/Core/VideoCommon/CPUCull.cpp
+++ b/Source/Core/VideoCommon/CPUCull.cpp
@@ -14,6 +14,7 @@
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
+#include "VideoCommon/XFStateManager.h"
 
 // We really want things like c.w * a.x - a.w * c.x to stay symmetric, so they cancel to zero on
 // degenerate triangles.  Make sure the compiler doesn't optimize in fmas where not requested.
@@ -153,7 +154,8 @@ bool CPUCull::AreAllVerticesCulled(VertexLoaderBase* loader, OpcodeDecoder::Prim
   }
 
   // transform functions need the projection matrix to tranform to clip space
-  Core::System::GetInstance().GetVertexShaderManager().SetProjectionMatrix();
+  auto& system = Core::System::GetInstance();
+  system.GetVertexShaderManager().SetProjectionMatrix(system.GetXFStateManager());
 
   static constexpr Common::EnumMap<CullMode, CullMode::All> cullmode_invert = {
       CullMode::None, CullMode::Front, CullMode::Back, CullMode::All};

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -27,8 +27,8 @@
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderBase.h"
 #include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/XFMemory.h"
+#include "VideoCommon/XFStateManager.h"
 #include "VideoCommon/XFStructs.h"
 
 namespace OpcodeDecoder
@@ -60,13 +60,13 @@ public:
       {
         VertexLoaderManager::g_needs_cp_xf_consistency_check = true;
         auto& system = Core::System::GetInstance();
-        system.GetVertexShaderManager().SetTexMatrixChangedA(value);
+        system.GetXFStateManager().SetTexMatrixChangedA(value);
       }
       else if (sub_command == MATINDEX_B)
       {
         VertexLoaderManager::g_needs_cp_xf_consistency_check = true;
         auto& system = Core::System::GetInstance();
-        system.GetVertexShaderManager().SetTexMatrixChangedB(value);
+        system.GetXFStateManager().SetTexMatrixChangedB(value);
       }
       else if (sub_command == VCD_LO || sub_command == VCD_HI)
       {

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -42,6 +42,7 @@
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
+#include "VideoCommon/XFStateManager.h"
 
 std::unique_ptr<VertexManagerBase> g_vertex_manager;
 
@@ -539,6 +540,7 @@ void VertexManagerBase::Flush()
   auto& pixel_shader_manager = system.GetPixelShaderManager();
   auto& geometry_shader_manager = system.GetGeometryShaderManager();
   auto& vertex_shader_manager = system.GetVertexShaderManager();
+  auto& xf_state_manager = system.GetXFStateManager();
 
   if (g_ActiveConfig.bGraphicMods)
   {
@@ -578,7 +580,7 @@ void VertexManagerBase::Flush()
       }
     }
   }
-  vertex_shader_manager.SetConstants(texture_names);
+  vertex_shader_manager.SetConstants(texture_names, xf_state_manager);
   if (!bpmem.genMode.zfreeze)
   {
     // Must be done after VertexShaderManager::SetConstants()

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -15,28 +15,18 @@
 
 class PointerWrap;
 struct PortableVertexDeclaration;
+class XFStateManager;
 
 // The non-API dependent parts.
 class alignas(16) VertexShaderManager
 {
 public:
   void Init();
-  void Dirty();
   void DoState(PointerWrap& p);
 
   // constant management
-  void SetProjectionMatrix();
-  void SetConstants(const std::vector<std::string>& textures);
-
-  void InvalidateXFRange(int start, int end);
-  void SetTexMatrixChangedA(u32 value);
-  void SetTexMatrixChangedB(u32 value);
-  void SetViewportChanged();
-  void SetProjectionChanged();
-  void SetMaterialColorChanged(int index);
-
-  void SetTexMatrixInfoChanged(int index);
-  void SetLightingConfigChanged();
+  void SetProjectionMatrix(XFStateManager& xf_state_manager);
+  void SetConstants(const std::vector<std::string>& textures, XFStateManager& xf_state_manager);
 
   // data: 3 floats representing the X, Y and Z vertex model coordinates and the posmatrix index.
   // out:  4 floats which will be initialized with the corresponding clip space coordinates
@@ -92,18 +82,7 @@ private:
   alignas(16) std::array<float, 16> m_projection_matrix;
 
   // track changes
-  std::array<bool, 2> m_tex_matrices_changed{};
-  bool m_pos_normal_matrix_changed = false;
-  bool m_projection_changed = false;
-  bool m_viewport_changed = false;
-  bool m_tex_mtx_info_changed = false;
-  bool m_lighting_config_changed = false;
   bool m_projection_graphics_mod_change = false;
-  BitSet32 m_materials_changed;
-  std::array<int, 2> m_minmax_transform_matrices_changed{};
-  std::array<int, 2> m_minmax_normal_matrices_changed{};
-  std::array<int, 2> m_minmax_post_transform_matrices_changed{};
-  std::array<int, 2> m_minmax_lights_changed{};
 
   Common::Matrix44 m_viewport_correction{};
 

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -66,6 +66,7 @@
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/VideoState.h"
 #include "VideoCommon/Widescreen.h"
+#include "VideoCommon/XFStateManager.h"
 
 VideoBackendBase* g_video_backend = nullptr;
 
@@ -385,6 +386,7 @@ bool VideoBackendBase::InitializeShared(std::unique_ptr<AbstractGfx> gfx,
   system.GetVertexShaderManager().Init();
   system.GetGeometryShaderManager().Init();
   system.GetPixelShaderManager().Init();
+  system.GetXFStateManager().Init();
   TMEM::Init();
 
   g_Config.VerifyValidity();

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -27,6 +27,7 @@
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/Widescreen.h"
 #include "VideoCommon/XFMemory.h"
+#include "VideoCommon/XFStateManager.h"
 
 void VideoCommon_DoState(PointerWrap& p)
 {
@@ -104,6 +105,9 @@ void VideoCommon_DoState(PointerWrap& p)
 
   g_widescreen->DoState(p);
   p.DoMarker("Widescreen");
+
+  system.GetXFStateManager().DoState(p);
+  p.DoMarker("XFStateManager");
 
   // Refresh state.
   if (p.IsReadMode())

--- a/Source/Core/VideoCommon/XFStateManager.cpp
+++ b/Source/Core/VideoCommon/XFStateManager.cpp
@@ -1,0 +1,279 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "VideoCommon/XFStateManager.h"
+
+#include "Common/ChunkFile.h"
+
+#include "VideoCommon/FramebufferManager.h"
+#include "VideoCommon/VertexManagerBase.h"
+#include "VideoCommon/XFMemory.h"
+
+void XFStateManager::Init()
+{
+  // Initialize state tracking variables
+  ResetTexMatrixAChange();
+  ResetTexMatrixBChange();
+  ResetPosNormalChange();
+  ResetProjection();
+  ResetViewportChange();
+  ResetTexMatrixInfoChange();
+  ResetLightingConfigChange();
+  ResetLightsChanged();
+  ResetMaterialChanges();
+  ResetPerVertexTransformMatrixChanges();
+  ResetPerVertexNormalMatrixChanges();
+  ResetPostTransformMatrixChanges();
+
+  std::memset(static_cast<void*>(&xfmem), 0, sizeof(xfmem));
+}
+
+void XFStateManager::DoState(PointerWrap& p)
+{
+  p.DoArray(m_minmax_transform_matrices_changed);
+  p.DoArray(m_minmax_normal_matrices_changed);
+  p.DoArray(m_minmax_post_transform_matrices_changed);
+  p.DoArray(m_minmax_lights_changed);
+
+  p.Do(m_materials_changed);
+  p.DoArray(m_tex_matrices_changed);
+  p.Do(m_pos_normal_matrix_changed);
+  p.Do(m_projection_changed);
+  p.Do(m_viewport_changed);
+  p.Do(m_tex_mtx_info_changed);
+  p.Do(m_lighting_config_changed);
+
+  if (p.IsReadMode())
+  {
+    // This is called after a savestate is loaded.
+    // Any constants that can changed based on settings should be re-calculated
+    m_projection_changed = true;
+  }
+}
+
+void XFStateManager::InvalidateXFRange(int start, int end)
+{
+  if (((u32)start >= (u32)g_main_cp_state.matrix_index_a.PosNormalMtxIdx * 4 &&
+       (u32)start < (u32)g_main_cp_state.matrix_index_a.PosNormalMtxIdx * 4 + 12) ||
+      ((u32)start >=
+           XFMEM_NORMALMATRICES + ((u32)g_main_cp_state.matrix_index_a.PosNormalMtxIdx & 31) * 3 &&
+       (u32)start < XFMEM_NORMALMATRICES +
+                        ((u32)g_main_cp_state.matrix_index_a.PosNormalMtxIdx & 31) * 3 + 9))
+  {
+    m_pos_normal_matrix_changed = true;
+  }
+
+  if (((u32)start >= (u32)g_main_cp_state.matrix_index_a.Tex0MtxIdx * 4 &&
+       (u32)start < (u32)g_main_cp_state.matrix_index_a.Tex0MtxIdx * 4 + 12) ||
+      ((u32)start >= (u32)g_main_cp_state.matrix_index_a.Tex1MtxIdx * 4 &&
+       (u32)start < (u32)g_main_cp_state.matrix_index_a.Tex1MtxIdx * 4 + 12) ||
+      ((u32)start >= (u32)g_main_cp_state.matrix_index_a.Tex2MtxIdx * 4 &&
+       (u32)start < (u32)g_main_cp_state.matrix_index_a.Tex2MtxIdx * 4 + 12) ||
+      ((u32)start >= (u32)g_main_cp_state.matrix_index_a.Tex3MtxIdx * 4 &&
+       (u32)start < (u32)g_main_cp_state.matrix_index_a.Tex3MtxIdx * 4 + 12))
+  {
+    m_tex_matrices_changed[0] = true;
+  }
+
+  if (((u32)start >= (u32)g_main_cp_state.matrix_index_b.Tex4MtxIdx * 4 &&
+       (u32)start < (u32)g_main_cp_state.matrix_index_b.Tex4MtxIdx * 4 + 12) ||
+      ((u32)start >= (u32)g_main_cp_state.matrix_index_b.Tex5MtxIdx * 4 &&
+       (u32)start < (u32)g_main_cp_state.matrix_index_b.Tex5MtxIdx * 4 + 12) ||
+      ((u32)start >= (u32)g_main_cp_state.matrix_index_b.Tex6MtxIdx * 4 &&
+       (u32)start < (u32)g_main_cp_state.matrix_index_b.Tex6MtxIdx * 4 + 12) ||
+      ((u32)start >= (u32)g_main_cp_state.matrix_index_b.Tex7MtxIdx * 4 &&
+       (u32)start < (u32)g_main_cp_state.matrix_index_b.Tex7MtxIdx * 4 + 12))
+  {
+    m_tex_matrices_changed[1] = true;
+  }
+
+  if (start < XFMEM_POSMATRICES_END)
+  {
+    if (m_minmax_transform_matrices_changed[0] == -1)
+    {
+      m_minmax_transform_matrices_changed[0] = start;
+      m_minmax_transform_matrices_changed[1] =
+          end > XFMEM_POSMATRICES_END ? XFMEM_POSMATRICES_END : end;
+    }
+    else
+    {
+      if (m_minmax_transform_matrices_changed[0] > start)
+        m_minmax_transform_matrices_changed[0] = start;
+
+      if (m_minmax_transform_matrices_changed[1] < end)
+        m_minmax_transform_matrices_changed[1] =
+            end > XFMEM_POSMATRICES_END ? XFMEM_POSMATRICES_END : end;
+    }
+  }
+
+  if (start < XFMEM_NORMALMATRICES_END && end > XFMEM_NORMALMATRICES)
+  {
+    int _start = start < XFMEM_NORMALMATRICES ? 0 : start - XFMEM_NORMALMATRICES;
+    int _end = end < XFMEM_NORMALMATRICES_END ? end - XFMEM_NORMALMATRICES :
+                                                XFMEM_NORMALMATRICES_END - XFMEM_NORMALMATRICES;
+
+    if (m_minmax_normal_matrices_changed[0] == -1)
+    {
+      m_minmax_normal_matrices_changed[0] = _start;
+      m_minmax_normal_matrices_changed[1] = _end;
+    }
+    else
+    {
+      if (m_minmax_normal_matrices_changed[0] > _start)
+        m_minmax_normal_matrices_changed[0] = _start;
+
+      if (m_minmax_normal_matrices_changed[1] < _end)
+        m_minmax_normal_matrices_changed[1] = _end;
+    }
+  }
+
+  if (start < XFMEM_POSTMATRICES_END && end > XFMEM_POSTMATRICES)
+  {
+    int _start = start < XFMEM_POSTMATRICES ? XFMEM_POSTMATRICES : start - XFMEM_POSTMATRICES;
+    int _end = end < XFMEM_POSTMATRICES_END ? end - XFMEM_POSTMATRICES :
+                                              XFMEM_POSTMATRICES_END - XFMEM_POSTMATRICES;
+
+    if (m_minmax_post_transform_matrices_changed[0] == -1)
+    {
+      m_minmax_post_transform_matrices_changed[0] = _start;
+      m_minmax_post_transform_matrices_changed[1] = _end;
+    }
+    else
+    {
+      if (m_minmax_post_transform_matrices_changed[0] > _start)
+        m_minmax_post_transform_matrices_changed[0] = _start;
+
+      if (m_minmax_post_transform_matrices_changed[1] < _end)
+        m_minmax_post_transform_matrices_changed[1] = _end;
+    }
+  }
+
+  if (start < XFMEM_LIGHTS_END && end > XFMEM_LIGHTS)
+  {
+    int _start = start < XFMEM_LIGHTS ? XFMEM_LIGHTS : start - XFMEM_LIGHTS;
+    int _end = end < XFMEM_LIGHTS_END ? end - XFMEM_LIGHTS : XFMEM_LIGHTS_END - XFMEM_LIGHTS;
+
+    if (m_minmax_lights_changed[0] == -1)
+    {
+      m_minmax_lights_changed[0] = _start;
+      m_minmax_lights_changed[1] = _end;
+    }
+    else
+    {
+      if (m_minmax_lights_changed[0] > _start)
+        m_minmax_lights_changed[0] = _start;
+
+      if (m_minmax_lights_changed[1] < _end)
+        m_minmax_lights_changed[1] = _end;
+    }
+  }
+}
+
+void XFStateManager::SetTexMatrixChangedA(u32 Value)
+{
+  if (g_main_cp_state.matrix_index_a.Hex != Value)
+  {
+    g_vertex_manager->Flush();
+    if (g_main_cp_state.matrix_index_a.PosNormalMtxIdx != (Value & 0x3f))
+      m_pos_normal_matrix_changed = true;
+    m_tex_matrices_changed[0] = true;
+    g_main_cp_state.matrix_index_a.Hex = Value;
+  }
+}
+
+void XFStateManager::ResetTexMatrixAChange()
+{
+  m_tex_matrices_changed[0] = false;
+}
+
+void XFStateManager::SetTexMatrixChangedB(u32 Value)
+{
+  if (g_main_cp_state.matrix_index_b.Hex != Value)
+  {
+    g_vertex_manager->Flush();
+    m_tex_matrices_changed[1] = true;
+    g_main_cp_state.matrix_index_b.Hex = Value;
+  }
+}
+
+void XFStateManager::ResetTexMatrixBChange()
+{
+  m_tex_matrices_changed[1] = false;
+}
+
+void XFStateManager::ResetPosNormalChange()
+{
+  m_pos_normal_matrix_changed = false;
+}
+
+void XFStateManager::SetProjectionChanged()
+{
+  m_projection_changed = true;
+}
+
+void XFStateManager::ResetProjection()
+{
+  m_projection_changed = false;
+}
+
+void XFStateManager::SetViewportChanged()
+{
+  m_viewport_changed = true;
+}
+
+void XFStateManager::ResetViewportChange()
+{
+  m_viewport_changed = false;
+}
+
+void XFStateManager::SetTexMatrixInfoChanged(int index)
+{
+  // TODO: Should we track this with more precision, like which indices changed?
+  // The whole vertex constants are probably going to be uploaded regardless.
+  m_tex_mtx_info_changed = true;
+}
+
+void XFStateManager::ResetTexMatrixInfoChange()
+{
+  m_tex_mtx_info_changed = false;
+}
+
+void XFStateManager::SetLightingConfigChanged()
+{
+  m_lighting_config_changed = true;
+}
+
+void XFStateManager::ResetLightingConfigChange()
+{
+  m_lighting_config_changed = false;
+}
+
+void XFStateManager::ResetLightsChanged()
+{
+  m_minmax_lights_changed.fill(-1);
+}
+
+void XFStateManager::SetMaterialColorChanged(int index)
+{
+  m_materials_changed[index] = true;
+}
+
+void XFStateManager::ResetMaterialChanges()
+{
+  m_materials_changed = BitSet32(0);
+}
+
+void XFStateManager::ResetPerVertexTransformMatrixChanges()
+{
+  m_minmax_transform_matrices_changed.fill(-1);
+}
+
+void XFStateManager::ResetPerVertexNormalMatrixChanges()
+{
+  m_minmax_normal_matrices_changed.fill(-1);
+}
+
+void XFStateManager::ResetPostTransformMatrixChanges()
+{
+  m_minmax_post_transform_matrices_changed.fill(-1);
+}

--- a/Source/Core/VideoCommon/XFStateManager.h
+++ b/Source/Core/VideoCommon/XFStateManager.h
@@ -1,0 +1,87 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+
+#include "Common/BitSet.h"
+
+class PointerWrap;
+
+// This class manages how XF state changes over
+// a period of time (typically a single draw call)
+class XFStateManager
+{
+public:
+  void Init();
+  void DoState(PointerWrap& p);
+
+  void InvalidateXFRange(int start, int end);
+
+  void SetTexMatrixChangedA(u32 value);
+  bool DidTexMatrixAChange() const { return m_tex_matrices_changed[0]; }
+  void ResetTexMatrixAChange();
+
+  void SetTexMatrixChangedB(u32 value);
+  bool DidTexMatrixBChange() const { return m_tex_matrices_changed[1]; }
+  void ResetTexMatrixBChange();
+
+  bool DidPosNormalChange() const { return m_pos_normal_matrix_changed; }
+  void ResetPosNormalChange();
+
+  void SetProjectionChanged();
+  bool DidProjectionChange() const { return m_projection_changed; }
+  void ResetProjection();
+
+  void SetViewportChanged();
+  bool DidViewportChange() const { return m_viewport_changed; }
+  void ResetViewportChange();
+
+  void SetTexMatrixInfoChanged(int index);
+  bool DidTexMatrixInfoChange() const { return m_tex_mtx_info_changed; }
+  void ResetTexMatrixInfoChange();
+
+  void SetLightingConfigChanged();
+  bool DidLightingConfigChange() const { return m_lighting_config_changed; }
+  void ResetLightingConfigChange();
+
+  const std::array<int, 2>& GetLightsChanged() const { return m_minmax_lights_changed; }
+  void ResetLightsChanged();
+
+  void SetMaterialColorChanged(int index);
+  const BitSet32& GetMaterialChanges() const { return m_materials_changed; }
+  void ResetMaterialChanges();
+
+  const std::array<int, 2>& GetPerVertexTransformMatrixChanges() const
+  {
+    return m_minmax_transform_matrices_changed;
+  }
+  void ResetPerVertexTransformMatrixChanges();
+
+  const std::array<int, 2>& GetPerVertexNormalMatrixChanges() const
+  {
+    return m_minmax_normal_matrices_changed;
+  }
+  void ResetPerVertexNormalMatrixChanges();
+
+  const std::array<int, 2>& GetPostTransformMatrixChanges() const
+  {
+    return m_minmax_post_transform_matrices_changed;
+  }
+  void ResetPostTransformMatrixChanges();
+
+private:
+  // track changes
+  std::array<bool, 2> m_tex_matrices_changed{};
+  bool m_pos_normal_matrix_changed = false;
+  bool m_projection_changed = false;
+  bool m_viewport_changed = false;
+  bool m_tex_mtx_info_changed = false;
+  bool m_lighting_config_changed = false;
+  BitSet32 m_materials_changed;
+  std::array<int, 2> m_minmax_transform_matrices_changed{};
+  std::array<int, 2> m_minmax_normal_matrices_changed{};
+  std::array<int, 2> m_minmax_post_transform_matrices_changed{};
+  std::array<int, 2> m_minmax_lights_changed{};
+};


### PR DESCRIPTION
At the moment, changes to xf state are tracked in `VertexShaderManager`.  This makes it impossible to know what state changed outside of that class.  For new graphics mod features, it is useful to know what state changed and then do something with that information and having a separate class gives that capability.

Once the graphics mod changes are pushed up, I'll link this PR to that to show how it is being used.