### PR TITLE
Breakpoints: Fix lag when adding/removing multiple breakpoints.

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -114,19 +114,21 @@ public:
   TMemChecksStr GetStrings() const;
   void AddFromStrings(const TMemChecksStr& mc_strings);
 
-  void Add(TMemCheck memory_check);
+  void Add(TMemCheck memory_check, bool update = true);
 
   bool ToggleBreakPoint(u32 address);
 
   // memory breakpoint
   TMemCheck* GetMemCheck(u32 address, size_t size = 1);
   bool OverlapsMemcheck(u32 address, u32 length) const;
-  void Remove(u32 address);
+  void Remove(u32 address, bool update = true);
 
+  void Update();
   void Clear();
   bool HasAny() const { return !m_mem_checks.empty(); }
 
 private:
   TMemChecks m_mem_checks;
   Core::System& m_system;
+  bool m_breakpoints_set = false;
 };

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -175,9 +175,10 @@ static void RemoveBreakpoint(BreakpointType type, u32 addr, u32 len)
     auto& memchecks = Core::System::GetInstance().GetPowerPC().GetMemChecks();
     while (memchecks.GetMemCheck(addr, len) != nullptr)
     {
-      memchecks.Remove(addr);
+      memchecks.Remove(addr, false);
       INFO_LOG_FMT(GDB_STUB, "gdb: removed a memcheck: {:08x} bytes at {:08x}", len, addr);
     }
+    memchecks.Update();
   }
 }
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -828,14 +828,16 @@ void MemoryViewWidget::ToggleBreakpoint(u32 addr, bool row)
       check.log_on_hit = m_do_log;
       check.break_on_hit = true;
 
-      memchecks.Add(std::move(check));
+      memchecks.Add(std::move(check), false);
     }
     else if (check_ptr != nullptr)
     {
       // Using the pointer fixes misaligned breakpoints (0x11 breakpoint in 0x10 aligned view).
-      memchecks.Remove(check_ptr->start_address);
+      memchecks.Remove(check_ptr->start_address, false);
     }
   }
+
+  memchecks.Update();
 
   emit BreakpointsChanged();
   Update();


### PR DESCRIPTION
Updates the mmu once after doing a set of breakpoint changes, rather than for each change.

I assumed we didn't really need to update m_mem_checks in a Core::RunAsCPUThread.  I can re-add that if I'm wrong.;  