### PR TITLE
Callstack: Bugfix. Fix loop to allow for more lines.

### DIFF
--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -54,7 +54,7 @@ static void WalkTheStack(Core::System& system, const Core::CPUThreadGuard& guard
     u32 addr = PowerPC::MMU::HostRead_U32(guard, ppc_state.gpr[1]);  // SP
 
     // Walk the stack chain
-    for (int count = 0; !IsStackBottom(guard, addr + 4) && (count++ < 20); ++count)
+    for (int count = 0; !IsStackBottom(guard, addr + 4) && (count < 20); ++count)
     {
       u32 func_addr = PowerPC::MMU::HostRead_U32(guard, addr + 4);
       stack_step(func_addr);


### PR DESCRIPTION
There's a double counting typo that limits the callstack to 11 items when it should be 20.