### PR TITLE
GameSettings: add patch to disable blur in Tony Hawk's Downhill Jam

### DIFF
--- a/Data/Sys/GameSettings/RTH.ini
+++ b/Data/Sys/GameSettings/RTH.ini
@@ -8,6 +8,8 @@
 
 [OnFrame]
 # Add memory patches to be applied every frame here.
+$Disable blur
+0x8015b900:dword:0x60000000
 
 [ActionReplay]
 # Add action replay cheats here.


### PR DESCRIPTION
This is a fullscreen blur that looks bad at higher internal resolutions. The offset happens to work out for both the NTSC and the PAL release.

Before:
![blurry](https://github.com/dolphin-emu/dolphin/assets/123798/cd925f1c-6a96-4a2d-98d7-c8d4fa685c90)

After:
![sharp](https://github.com/dolphin-emu/dolphin/assets/123798/059153b9-d48c-4f56-9a7b-9a980ebe0648)