### PR TITLE
Jit64: fix invalid instruction encoding

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -585,7 +585,7 @@ void Jit64::mcrxr(UGeckoInstruction inst)
 
   // Clear XER[0-3]
   static_assert(PPCSTATE_OFF(xer_ca) + 1 == PPCSTATE_OFF(xer_so_ov));
-  MOV(16, PPCSTATE(xer_ca), Imm8(0));
+  MOV(16, PPCSTATE(xer_ca), Imm16(0));
 }
 
 void Jit64::crXXX(UGeckoInstruction inst)


### PR DESCRIPTION
This is a recent regression introduced in c70dcf99dd7b434d5196feb47f2a6e87bb34234b.