### PR TITLE
PPCAnalyst: Don't discard CR before gather pipe interrupt check

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -976,6 +976,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
       // be able to flush all registers, so we can't have any discarded registers.
       gprDiscardable = BitSet32{};
       fprDiscardable = BitSet32{};
+      crDiscardable = BitSet8{};
     }
 
     const bool hle = !!HLE::TryReplaceFunction(op.address);


### PR DESCRIPTION
This fixes a frequently occurring JitArm64 assert which was caused by merging PR #9857 without adapting it to the changes made in PR #12138.