### PR TITLE
JitArm64: Fix JitAsm without entry points map

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -133,7 +133,7 @@ void JitArm64::GenerateAsm()
       // b.effectiveAddress != addr || b.msrBits != msr
       static_assert(offsetof(JitBlockData, msrBits) + 4 ==
                     offsetof(JitBlockData, effectiveAddress));
-      LDP(IndexType::Signed, msr, pc, block, offsetof(JitBlockData, effectiveAddress));
+      LDP(IndexType::Signed, msr, pc, block, offsetof(JitBlockData, msrBits));
       LDR(IndexType::Unsigned, msr2, PPC_REG, PPCSTATE_OFF(msr));
       CMP(pc, DISPATCHER_PC);
       FixupBranch pc_mismatch = B(CC_NEQ);


### PR DESCRIPTION
This must have broken in a rebase of one of my recently merged PRs.

Dolphin still worked correctly with this bug, for two reasons:

1. Most AArch64 users are not on Windows, and therefore normally do have the entry points map.
2. When the bug was triggered, Dolphin would fall back to the slower path rather than crashing.