### PR TITLE
CMake: update required enet version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,7 +659,7 @@ endif()
 
 dolphin_find_optional_system_library(pugixml Externals/pugixml)
 
-dolphin_find_optional_system_library_pkgconfig(ENET libenet>=1.3.8 enet::enet Externals/enet)
+dolphin_find_optional_system_library_pkgconfig(ENET libenet>=1.3.18 enet::enet Externals/enet)
 
 dolphin_find_optional_system_library_pkgconfig(xxhash libxxhash>=0.8.2 xxhash::xxhash Externals/xxhash)
 


### PR DESCRIPTION
Dolphin now relies on ENET_SOCKOPT_TTL which was [merged upstream](https://github.com/lsalzman/enet/pull/217) but not released yet. This fix assumes that enet continues its current versioning scheme.