### PR TITLE
IOS/KD: Set download span if download task not found

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -246,6 +246,12 @@ void NetKDRequestDevice::SchedulerWorker(const SchedulerEvent event)
     NWC24::ErrorCode code = DetermineDownloadTask(&entry_index, &subtask_id);
     if (code != NWC24::WC24_OK)
     {
+      if (code == NWC24::WC24_ERR_NOT_FOUND)
+      {
+        std::lock_guard lg(m_scheduler_lock);
+        m_download_span = DEFAULT_SCHEDULER_SPAN_MINUTES;
+      }
+
       LogError(ErrorType::KD_Download, code);
       return;
     }

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
@@ -93,6 +93,8 @@ private:
                                                         0xc2, 0x61, 0x91, 0x72, 0xb5, 0xcb, 0x29,
                                                         0x8c, 0x89, 0x72, 0xd4, 0x50, 0xad};
 
+  static constexpr u32 DEFAULT_SCHEDULER_SPAN_MINUTES = 11;
+
   NWC24::NWC24Config m_config;
   NWC24::NWC24Dl m_dl_list;
   NWC24::Mail::WC24SendList m_send_list;


### PR DESCRIPTION
If a download task was not found by the scheduler, it will set the time before next download to 11 minutes.