### PR TITLE
Android: Fix issue when launching a game when Dolphin is not open

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
@@ -1066,16 +1066,16 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
         }
 
         @JvmStatic
-        fun launch(activity: FragmentActivity, filePaths: Array<String>, riivolution: Boolean) {
+        fun launch(activity: FragmentActivity, filePaths: Array<String>, riivolution: Boolean, fromIntent: Boolean = false) {
             if (ignoreLaunchRequests)
                 return
 
-            performLaunchChecks(activity) { launchWithoutChecks(activity, filePaths, riivolution) }
+            performLaunchChecks(activity, fromIntent) { launchWithoutChecks(activity, filePaths, riivolution) }
         }
 
         @JvmStatic
-        fun launch(activity: FragmentActivity, filePath: String, riivolution: Boolean) =
-            launch(activity, arrayOf(filePath), riivolution)
+        fun launch(activity: FragmentActivity, filePath: String, riivolution: Boolean, fromIntent: Boolean = false) =
+            launch(activity, arrayOf(filePath), riivolution, fromIntent)
 
         private fun launchWithoutChecks(
             activity: FragmentActivity,
@@ -1089,8 +1089,11 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             activity.startActivity(launcher)
         }
 
-        private fun performLaunchChecks(activity: FragmentActivity, continueCallback: Runnable) {
+        private fun performLaunchChecks(activity: FragmentActivity, fromIntent: Boolean, continueCallback: Runnable) {
             AfterDirectoryInitializationRunner().runWithLifecycle(activity) {
+                if (fromIntent) {
+                    activity.finish()
+                }
                 if (!FileBrowserHelper.isPathEmptyOrValid(StringSetting.MAIN_DEFAULT_ISO) ||
                     !FileBrowserHelper.isPathEmptyOrValid(StringSetting.MAIN_FS_PATH) ||
                     !FileBrowserHelper.isPathEmptyOrValid(StringSetting.MAIN_DUMP_PATH) ||
@@ -1129,7 +1132,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             if (ignoreLaunchRequests)
                 return
 
-            performLaunchChecks(activity) { launchSystemMenuWithoutChecks(activity) }
+            performLaunchChecks(activity, false) { launchSystemMenuWithoutChecks(activity) }
         }
 
         private fun launchSystemMenuWithoutChecks(activity: FragmentActivity) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -37,8 +37,7 @@ public final class StartupHandler
     if (gamesToLaunch != null && gamesToLaunch.length > 0)
     {
       // Start the emulation activity, send the ISO passed in and finish the main activity
-      EmulationActivity.launch(parent, gamesToLaunch, false);
-      parent.finish();
+      EmulationActivity.launch(parent, gamesToLaunch, false, true);
     }
   }
 


### PR DESCRIPTION
### What
When Dolphin is not open, attempting to launch a game from a frontend launcher will result in the user opening Dolphin and being taken back to the frontend launcher. 

### Why
This is caused by calling `parent.finish()` before `AfterDirectoryInitializationRunner` is complete, thus canceling the launch of the game.

### How
Fixed by calling `activity.finish()` after `AfterDirectoryInitializationRunner` is initialized and complete.



