### PR TITLE
JitArm64: Fix updating MEM_REG with imm MSR without fastmem

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -353,8 +353,8 @@ void JitArm64::EmitStoreMembase(u32 msr)
   auto& memory = m_system.GetMemory();
   MOVP2R(MEM_REG,
          UReg_MSR(msr).DR ?
-             (jo.fastmem_arena ? memory.GetLogicalBase() : memory.GetLogicalPageMappingsBase()) :
-             (jo.fastmem_arena ? memory.GetPhysicalBase() : memory.GetPhysicalPageMappingsBase()));
+             (jo.fastmem ? memory.GetLogicalBase() : memory.GetLogicalPageMappingsBase()) :
+             (jo.fastmem ? memory.GetPhysicalBase() : memory.GetPhysicalPageMappingsBase()));
   STR(IndexType::Unsigned, MEM_REG, PPC_REG, PPCSTATE_OFF(mem_ptr));
 }
 


### PR DESCRIPTION
Dolphin would crash when running with a fastmem arena but without fastmem. This regression was caused by merging 9192128c50 without adapting it after the merge of 0606433404.