### PR TITLE
Gameini: Enable AccurateNaNs for "Jeep Thrills"

### DIFF
--- a/Data/Sys/GameSettings/RJ3.ini
+++ b/Data/Sys/GameSettings/RJ3.ini
@@ -1,0 +1,17 @@
+# RJ3E20, RJ3P7J - Jeep Thrills
+
+[Core]
+# Values set here will override the main Dolphin settings.
+# Fixes the blue screen problem. See issue 13118 for more info.
+AccurateNaNs = True
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]


### PR DESCRIPTION
This enables AccurateNaNs for "Jeep Thrills".

Solves the blue screen issue [Bug 13118](https://bugs.dolphin-emu.org/issues/13118)

Alternatively the issue is not present if bJITPairedOff = true in Jit64::ps_muls ie. Interpreter::ps_muls0/Interpreter::ps_muls1