### PR TITLE
PPCAnalyst: Clear crInUse on HLE

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -1011,6 +1011,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
       gprInUse = BitSet32{};
       fprInUse = BitSet32{};
       fprInXmm = BitSet32{};
+      crInUse = BitSet8{};
       gprDiscardable = BitSet32{};
       fprDiscardable = BitSet32{};
       crDiscardable = BitSet8{};


### PR DESCRIPTION
This should have been done when rebasing 6cc4f593e5 after the merge of 3a00ff625e. There are no correctness implications as far as I know, only very minor performance implications.