### PR TITLE
WiimoteDevice. Bugfix. Remove signal spam while starting a game.

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -145,7 +145,8 @@ void WiimoteDevice::SetBasebandState(BasebandState new_state)
   m_baseband_state = new_state;
 
   // Update wiimote connection checkboxes in UI.
-  Host_UpdateDisasmDialog();
+  if (IsConnected() != was_connected)
+    Host_UpdateDisasmDialog();
 
   if (!IsSourceValid())
     return;


### PR DESCRIPTION
WiimoteDevice spams DisasmDialog signals while a game is starting.  While booting, dolphin will incorrectly report as being paused, so a DisasmDialog update at that time will cause errors.  The pause/play button will update to the wrong state for a few moments. Debugger widgets will get triggered and the incorrectly reported pause state causes them to read instructions/memory when they shouldn't as well.

Even if the incorrect state reporting is fixed, this still doesn't need to spam signals while booting.

According to the comment in WiimoteDevice, DisasmDialog is used to update the Wiimote state in the menubar.  This has a few states:
1. Game is running. Will only be active while playing a game, otherwise disabled.
2.  BT passthrough. This can only be set when a game is not loaded/playing.  Will disable the menu items if active.
3. Checked On/Off depending on if a connection was made.

1 & 2 are handled with EmulationStateChanged signals and don't need the DisasmDialog.
3. Needs a DisasmDialog whenever the connection changes to make sure it's correctly represented.  My PR forces it to only send the signal for this case.

See https://github.com/dolphin-emu/dolphin/pull/11593 for more information.