### PR TITLE
Bugfix - small square in bottom right corner

### DIFF
--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -333,6 +333,8 @@ void OnScreenUI::DrawChallenges()
   std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
   const AchievementManager::NamedIconMap& challenge_icons =
       AchievementManager::GetInstance()->GetChallengeIcons();
+  if (challenge_icons.size() == 0)
+    return;
 
   const std::string window_name = "Challenges";
 


### PR DESCRIPTION
Fixed a bug in OSUI created by the challenge icons that caused a small rectangle to appear in the bottom right corner of the screen.