### PR TITLE
Add SYSCONF widescreen setting to dtm header

### DIFF
--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -40,6 +40,7 @@ static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
     config_layer->Set(Config::SYSCONF_LANGUAGE, static_cast<u32>(dtm->language));
   else
     config_layer->Set(Config::MAIN_GC_LANGUAGE, static_cast<int>(dtm->language));
+  config_layer->Set(Config::SYSCONF_WIDESCREEN, dtm->bWidescreen);
 
   config_layer->Set(Config::GFX_HACK_EFB_ACCESS_ENABLE, dtm->bEFBAccessEnable);
   config_layer->Set(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, dtm->bSkipEFBCopyToRam);
@@ -67,6 +68,7 @@ void SaveToDTM(Movie::DTMHeader* dtm)
     dtm->language = Config::Get(Config::SYSCONF_LANGUAGE);
   else
     dtm->language = Config::Get(Config::MAIN_GC_LANGUAGE);
+  dtm->bWidescreen = Config::Get(Config::SYSCONF_WIDESCREEN);
 
   dtm->bEFBAccessEnable = Config::Get(Config::GFX_HACK_EFB_ACCESS_ENABLE);
   dtm->bSkipEFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -124,7 +124,8 @@ struct DTMHeader
   bool bFollowBranch;
   bool bUseFMA;
   u8 GBAControllers;                // GBA Controllers plugged in (the bits are ports 1-4)
-  std::array<u8, 7> reserved;       // Padding for any new config options
+  bool bWidescreen;                 // true indicates SYSCONF aspect ratio is 16:9, false for 4:3
+  std::array<u8, 6> reserved;       // Padding for any new config options
   std::array<char, 40> discChange;  // Name of iso file to switch to, for two disc games.
   std::array<u8, 20> revision;      // Git hash
   u32 DSPiromHash;


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10357 / https://bugs.dolphin-emu.org/issues/11827