### PR TITLE
Fix out of bound write in EfbCopy::ClearEfb

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbCopy.cpp
+++ b/Source/Core/VideoBackends/Software/EfbCopy.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoBackends/Software/EfbCopy.h"
 
+#include <algorithm>
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
@@ -11,6 +13,7 @@
 
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/Fifo.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace EfbCopy
 {
@@ -21,8 +24,8 @@ void ClearEfb()
 
   int left = bpmem.copyTexSrcXY.x;
   int top = bpmem.copyTexSrcXY.y;
-  int right = left + bpmem.copyTexSrcWH.x;
-  int bottom = top + bpmem.copyTexSrcWH.y;
+  int right = std::min(left + bpmem.copyTexSrcWH.x, EFB_WIDTH - 1);
+  int bottom = std::min(top + bpmem.copyTexSrcWH.y, EFB_HEIGHT - 1);
 
   for (u16 y = top; y <= bottom; y++)
   {


### PR DESCRIPTION
The current implementation of [EfbCopy::ClearEfb](https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/VideoBackends/Software/EfbCopy.cpp) doesn't check whether `left + bpmem.copyTexSrcWH.x` and `top + bpmem.copyTexSrcWH.y` are in-bound. This omission leads to an out-of-bounds write access with an arbitrary value. 

This issue can cause crashes and, in the worst-case scenario can lead to RCE on the host machine.

Here is a POC that triggers the bug:

```c++
  // Setting corrupted width & height (max values are 2**10)
  GX_SetDispCopySrc(640 - 1, 528 - 1, pow(2, 10), 1);
  
  GX_SetDispCopyDst(rmode->fbWidth, xfbHeight);
  
  // Trigger the vulnerability
  GX_CopyDisp(xfb[curr_fb], GX_TRUE);
  GX_SetCopyClear(background, GX_MAX_Z24);
``` 

> [!NOTE]
> This vulnerability can only be exploited with Dolphin's `VideoBackend`, therefore a specific option has to be selected in the emulator for this to work.