### PR TITLE
Android: Allow Coil image cache to use more memory

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CoilUtils.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CoilUtils.kt
@@ -73,7 +73,7 @@ object CoilUtils {
         }
         .memoryCache {
             MemoryCache.Builder(DolphinApplication.getAppContext())
-                .maxSizePercent(0.25)
+                .maxSizePercent(0.9)
                 .build()
         }
         .build()


### PR DESCRIPTION
Allows the Coil memory cache to use up to 90% of the application's available memory. Previously this could cause problems with reloading images in very large libraries of games.