### PR TITLE
VideoBackends / VideoCommon: update max pixel shader samplers from 8 to 16

### DIFF
--- a/Source/Core/VideoBackends/D3D12/D3D12Gfx.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12Gfx.cpp
@@ -659,7 +659,7 @@ void Gfx::UpdateDescriptorTables()
 bool Gfx::UpdateSRVDescriptorTable()
 {
   static constexpr std::array<UINT, VideoCommon::MAX_PIXEL_SHADER_SAMPLERS> src_sizes = {
-      1, 1, 1, 1, 1, 1, 1, 1};
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
   DescriptorHandle dst_base_handle;
   const UINT dst_handle_sizes = VideoCommon::MAX_PIXEL_SHADER_SAMPLERS;
   if (!g_dx_context->GetDescriptorAllocator()->Allocate(VideoCommon::MAX_PIXEL_SHADER_SAMPLERS,

--- a/Source/Core/VideoBackends/D3D12/DescriptorAllocator.cpp
+++ b/Source/Core/VideoBackends/D3D12/DescriptorAllocator.cpp
@@ -99,7 +99,7 @@ bool SamplerAllocator::GetGroupHandle(const SamplerStateSet& sss,
 
   // Copy samplers from the sampler heap.
   static constexpr std::array<UINT, VideoCommon::MAX_PIXEL_SHADER_SAMPLERS> source_sizes = {
-      {1, 1, 1, 1, 1, 1, 1, 1}};
+      {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}};
   g_dx_context->GetDevice()->CopyDescriptors(
       1, &allocation.cpu_handle, &VideoCommon::MAX_PIXEL_SHADER_SAMPLERS,
       VideoCommon::MAX_PIXEL_SHADER_SAMPLERS, source_handles.data(), source_sizes.data(),

--- a/Source/Core/VideoBackends/Metal/MTLStateTracker.h
+++ b/Source/Core/VideoBackends/Metal/MTLStateTracker.h
@@ -199,7 +199,7 @@ private:
 
   // MARK: State
   u16 m_dirty_textures;
-  u8 m_dirty_samplers;
+  u16 m_dirty_samplers;
   static_assert(sizeof(m_dirty_textures) * 8 >= MAX_TEXTURES, "Make this bigger");
   static_assert(sizeof(m_dirty_samplers) * 8 >= MAX_SAMPLERS, "Make this bigger");
   union Flags

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -121,10 +121,24 @@ bool ObjectCache::CreateDescriptorSetLayouts()
        VK_SHADER_STAGE_GEOMETRY_BIT},
   }};
 
-  static const std::array<VkDescriptorSetLayoutBinding, 1> standard_sampler_bindings{{
-      {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-       static_cast<u32>(VideoCommon::MAX_PIXEL_SHADER_SAMPLERS), VK_SHADER_STAGE_FRAGMENT_BIT},
-  }};
+  constexpr u32 MAX_PIXEL_SAMPLER_ARRAY_SIZE = 8;
+  constexpr u32 TOTAL_PIXEL_SAMPLER_BINDINGS =
+      1 + (VideoCommon::MAX_PIXEL_SHADER_SAMPLERS - MAX_PIXEL_SAMPLER_ARRAY_SIZE);
+  static_assert(VideoCommon::MAX_PIXEL_SHADER_SAMPLERS == 16, "Update descriptor sampler bindings");
+
+  static const std::array<VkDescriptorSetLayoutBinding, TOTAL_PIXEL_SAMPLER_BINDINGS>
+      standard_sampler_bindings{{
+          {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, MAX_PIXEL_SAMPLER_ARRAY_SIZE,
+           VK_SHADER_STAGE_FRAGMENT_BIT},
+          {8, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+          {9, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+          {10, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+          {11, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+          {12, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+          {13, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+          {14, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+          {15, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
+      }};
 
   // The dynamic veretex loader's vertex buffer must be last here, for similar reasons
   static const std::array<VkDescriptorSetLayoutBinding, 2> standard_ssbo_bindings{{

--- a/Source/Core/VideoCommon/Constants.h
+++ b/Source/Core/VideoCommon/Constants.h
@@ -7,6 +7,6 @@
 
 namespace VideoCommon
 {
-constexpr u32 MAX_PIXEL_SHADER_SAMPLERS = 8;
+constexpr u32 MAX_PIXEL_SHADER_SAMPLERS = 16;
 constexpr u32 MAX_COMPUTE_SHADER_SAMPLERS = 8;
 }  // namespace VideoCommon


### PR DESCRIPTION
I'm investigating changing the process of how graphics mod texture samplers are handled, instead of piggybacking off of the 8 pixel shader samplers that can be used on the native GC/Wii, the user can define their own samplers.

The question is how to handle this.  One way is to look at each backend and query what the sampler count is, then request that many resources.  However, this adds complexity to the code base.  Currently we have a hardcoded 8 which is assumed for the GC/Wii.  I'd like to expand this to 12 or 16 but not sure if some devices will see issues.

Opening this PR to do some testing and see what issues might occur on different devices with the hardcoded approach and will evaluate if using a more complex approach is needed.