### PR TITLE
VideoCommon: Use std::span for BoundingBox::Write()

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBoundingBox.cpp
@@ -88,12 +88,12 @@ std::vector<BBoxType> D3DBoundingBox::Read(u32 index, u32 length)
   return values;
 }
 
-void D3DBoundingBox::Write(u32 index, const std::vector<BBoxType>& values)
+void D3DBoundingBox::Write(u32 index, std::span<const BBoxType> values)
 {
   D3D11_BOX box{index * sizeof(BBoxType),
                 0,
                 0,
-                static_cast<u32>(index + values.size()) * sizeof(BBoxType),
+                static_cast<u32>((index + values.size()) * sizeof(BBoxType)),
                 1,
                 1};
   D3D::context->UpdateSubresource(m_buffer.Get(), 0, &box, values.data(), 0, 0);

--- a/Source/Core/VideoBackends/D3D/D3DBoundingBox.h
+++ b/Source/Core/VideoBackends/D3D/D3DBoundingBox.h
@@ -19,7 +19,7 @@ public:
 
 protected:
   std::vector<BBoxType> Read(u32 index, u32 length) override;
-  void Write(u32 index, const std::vector<BBoxType>& values) override;
+  void Write(u32 index, std::span<const BBoxType> values) override;
 
 private:
   ComPtr<ID3D11Buffer> m_buffer;

--- a/Source/Core/VideoBackends/D3D12/D3D12BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12BoundingBox.cpp
@@ -56,9 +56,9 @@ std::vector<BBoxType> D3D12BoundingBox::Read(u32 index, u32 length)
   return values;
 }
 
-void D3D12BoundingBox::Write(u32 index, const std::vector<BBoxType>& values)
+void D3D12BoundingBox::Write(u32 index, std::span<const BBoxType> values)
 {
-  const u32 copy_size = static_cast<u32>(values.size()) * sizeof(BBoxType);
+  const u32 copy_size = static_cast<u32>(values.size() * sizeof(BBoxType));
   if (!m_upload_buffer.ReserveMemory(copy_size, sizeof(BBoxType)))
   {
     WARN_LOG_FMT(VIDEO, "Executing command list while waiting for space in bbox stream buffer");

--- a/Source/Core/VideoBackends/D3D12/D3D12BoundingBox.h
+++ b/Source/Core/VideoBackends/D3D12/D3D12BoundingBox.h
@@ -21,7 +21,7 @@ public:
 
 protected:
   std::vector<BBoxType> Read(u32 index, u32 length) override;
-  void Write(u32 index, const std::vector<BBoxType>& values) override;
+  void Write(u32 index, std::span<const BBoxType> values) override;
 
 private:
   static constexpr u32 BUFFER_SIZE = sizeof(BBoxType) * NUM_BBOX_VALUES;

--- a/Source/Core/VideoBackends/Metal/MTLBoundingBox.h
+++ b/Source/Core/VideoBackends/Metal/MTLBoundingBox.h
@@ -18,7 +18,7 @@ public:
 
 protected:
   std::vector<BBoxType> Read(u32 index, u32 length) override;
-  void Write(u32 index, const std::vector<BBoxType>& values) override;
+  void Write(u32 index, std::span<const BBoxType> values) override;
 
 private:
   BBoxType* m_cpu_buffer_ptr;

--- a/Source/Core/VideoBackends/Metal/MTLBoundingBox.mm
+++ b/Source/Core/VideoBackends/Metal/MTLBoundingBox.mm
@@ -42,7 +42,7 @@ std::vector<BBoxType> Metal::BoundingBox::Read(u32 index, u32 length)
   }
 }
 
-void Metal::BoundingBox::Write(u32 index, const std::vector<BBoxType>& values)
+void Metal::BoundingBox::Write(u32 index, std::span<const BBoxType> values)
 {
   const u32 size = values.size() * sizeof(BBoxType);
   if (!g_state_tracker->HasUnflushedData() && !g_state_tracker->GPUBusy())

--- a/Source/Core/VideoBackends/Null/NullBoundingBox.h
+++ b/Source/Core/VideoBackends/Null/NullBoundingBox.h
@@ -19,7 +19,7 @@ protected:
   {
     return std::vector<BBoxType>(length);
   }
-  void Write(u32 index, const std::vector<BBoxType>& values) override {}
+  void Write(u32 index, std::span<const BBoxType> values) override {}
 };
 
 }  // namespace Null

--- a/Source/Core/VideoBackends/OGL/OGLBoundingBox.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLBoundingBox.cpp
@@ -66,7 +66,7 @@ std::vector<BBoxType> OGLBoundingBox::Read(u32 index, u32 length)
   return values;
 }
 
-void OGLBoundingBox::Write(u32 index, const std::vector<BBoxType>& values)
+void OGLBoundingBox::Write(u32 index, std::span<const BBoxType> values)
 {
   glBindBuffer(GL_SHADER_STORAGE_BUFFER, m_buffer_id);
   glBufferSubData(GL_SHADER_STORAGE_BUFFER, sizeof(BBoxType) * index,

--- a/Source/Core/VideoBackends/OGL/OGLBoundingBox.h
+++ b/Source/Core/VideoBackends/OGL/OGLBoundingBox.h
@@ -19,7 +19,7 @@ public:
 
 protected:
   std::vector<BBoxType> Read(u32 index, u32 length) override;
-  void Write(u32 index, const std::vector<BBoxType>& values) override;
+  void Write(u32 index, std::span<const BBoxType> values) override;
 
 private:
   GLuint m_buffer_id = 0;

--- a/Source/Core/VideoBackends/Software/SWBoundingBox.cpp
+++ b/Source/Core/VideoBackends/Software/SWBoundingBox.cpp
@@ -55,7 +55,7 @@ std::vector<BBoxType> SWBoundingBox::Read(u32 index, u32 length)
   return values;
 }
 
-void SWBoundingBox::Write(u32 index, const std::vector<BBoxType>& values)
+void SWBoundingBox::Write(u32 index, std::span<const BBoxType> values)
 {
   for (size_t i = 0; i < values.size(); i++)
   {

--- a/Source/Core/VideoBackends/Software/SWBoundingBox.h
+++ b/Source/Core/VideoBackends/Software/SWBoundingBox.h
@@ -37,7 +37,7 @@ public:
 
 protected:
   std::vector<BBoxType> Read(u32 index, u32 length) override;
-  void Write(u32 index, const std::vector<BBoxType>& values) override;
+  void Write(u32 index, std::span<const BBoxType> values) override;
 };
 
 }  // namespace SW

--- a/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKBoundingBox.cpp
@@ -77,7 +77,7 @@ std::vector<BBoxType> VKBoundingBox::Read(u32 index, u32 length)
   return values;
 }
 
-void VKBoundingBox::Write(u32 index, const std::vector<BBoxType>& values)
+void VKBoundingBox::Write(u32 index, std::span<const BBoxType> values)
 {
   // We can't issue vkCmdUpdateBuffer within a render pass.
   // However, the writes must be serialized, so we can't put it in the init buffer.
@@ -91,8 +91,7 @@ void VKBoundingBox::Write(u32 index, const std::vector<BBoxType>& values)
 
   // Write the values to the GPU buffer
   vkCmdUpdateBuffer(g_command_buffer_mgr->GetCurrentCommandBuffer(), m_gpu_buffer,
-                    index * sizeof(BBoxType), values.size() * sizeof(BBoxType),
-                    reinterpret_cast<const BBoxType*>(values.data()));
+                    index * sizeof(BBoxType), values.size() * sizeof(BBoxType), values.data());
 
   // Restore fragment shader access to the buffer.
   StagingBuffer::BufferMemoryBarrier(

--- a/Source/Core/VideoBackends/Vulkan/VKBoundingBox.h
+++ b/Source/Core/VideoBackends/Vulkan/VKBoundingBox.h
@@ -26,7 +26,7 @@ public:
 
 protected:
   std::vector<BBoxType> Read(u32 index, u32 length) override;
-  void Write(u32 index, const std::vector<BBoxType>& values) override;
+  void Write(u32 index, std::span<const BBoxType> values) override;
 
 private:
   bool CreateGPUBuffer();

--- a/Source/Core/VideoCommon/BoundingBox.cpp
+++ b/Source/Core/VideoCommon/BoundingBox.cpp
@@ -51,7 +51,7 @@ void BoundingBox::Flush()
     for (u32 i = start; i < end; ++i)
       m_dirty[i] = false;
 
-    Write(start, std::vector<BBoxType>(m_values.begin() + start, m_values.begin() + end));
+    Write(start, std::span(m_values.begin() + start, m_values.begin() + end));
   }
 }
 

--- a/Source/Core/VideoCommon/BoundingBox.h
+++ b/Source/Core/VideoCommon/BoundingBox.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <memory>
+#include <span>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -38,8 +39,7 @@ public:
 
 protected:
   virtual std::vector<BBoxType> Read(u32 index, u32 length) = 0;
-  // TODO: This can likely use std::span once we're on C++20
-  virtual void Write(u32 index, const std::vector<BBoxType>& values) = 0;
+  virtual void Write(u32 index, std::span<const BBoxType> values) = 0;
 
 private:
   void Readback();


### PR DESCRIPTION
Crosses off a lingering TODO.

Also amends a few nearby cases where a u32 cast was being repromoted to size_t.