### PR TITLE
VideoCommon: prevent a potential custom texture crash

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -346,10 +346,11 @@ private:
 
   void SetBackupConfig(const VideoConfig& config);
 
-  RcTcacheEntry CreateTextureEntry(const TextureCreationInfo& creation_info,
-                                   const TextureInfo& texture_info, int safety_color_sample_size,
-                                   std::vector<VideoCommon::CustomTextureData*> assets_data,
-                                   bool custom_arbitrary_mipmaps, bool skip_texture_dump);
+  RcTcacheEntry
+  CreateTextureEntry(const TextureCreationInfo& creation_info, const TextureInfo& texture_info,
+                     int safety_color_sample_size,
+                     std::vector<std::shared_ptr<VideoCommon::TextureData>> assets_data,
+                     bool custom_arbitrary_mipmaps, bool skip_texture_dump);
 
   RcTcacheEntry GetXFBFromCache(u32 address, u32 width, u32 height, u32 stride);
 


### PR DESCRIPTION
Custom asset data is loaded on a separate thread and stored in a `shared_ptr`.  When something wants some of that asset data, a copy of the `shared_ptr` will be provided.  At any time the separate thread can destroy the original `shared_ptr` copy, meaning something that wants to use that data must keep that `shared_ptr` around as long as it wants that copy of the data.

In `TextureCache`, I was loading a `shared_ptr`, getting a pointer to one of its member variables, then letting that `shared_ptr` copy die.  So it was undefined how long that member pointer would be valid.

A user on discord had a crash that looked eerily like it could be caused by this.  This PR fixes that issue by holding onto the `shared_ptr` instead of the member pointer.