### PR TITLE
Android: Fix crash when trying to edit gate size setting

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.kt
@@ -56,9 +56,6 @@ open class FloatSliderSetting : SliderSetting {
         get() = floatSetting.float
 
     open fun setSelectedValue(settings: Settings, selection: Float) {
-        floatSetting.setFloat(
-            settings,
-            BigDecimal((selection).toDouble()).round(MathContext(3)).toFloat()
-        )
+        floatSetting.setFloat(settings, selection)
     }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.kt
@@ -41,6 +41,7 @@ import java.io.File
 import java.io.IOException
 import java.io.RandomAccessFile
 import java.util.*
+import kotlin.math.roundToInt
 
 class SettingsAdapter(
     private val fragmentView: SettingsFragmentView,
@@ -259,7 +260,7 @@ class SettingsAdapter(
                 slider.stepSize = item.stepSize.toFloat()
             }
         }
-        slider.value = seekbarProgress
+        slider.value = (seekbarProgress / slider.stepSize).roundToInt() * slider.stepSize
         slider.addOnChangeListener(this)
 
         dialog = MaterialAlertDialogBuilder(fragmentView.fragmentActivity)


### PR DESCRIPTION
The gate size is 79.37125 by default, and the step size is 0.5. Android throws an exception if we try to show the slider with the value set to something that isn't divisible by the step size. To avoid this problem, round the value.