### PR TITLE
VFFUtil: Use std::span with WriteToVFF

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/Mail/WC24Send.cpp
+++ b/Source/Core/Core/IOS/Network/KD/Mail/WC24Send.cpp
@@ -219,13 +219,13 @@ ErrorCode WC24SendList::AddRegistrationMessages(const WC24FriendList& friend_lis
     const u32 msg_id = GetNextEntryId();
     m_data.entries[entry_index].id = Common::swap32(msg_id);
 
-    std::time_t t = std::time(nullptr);
+    const std::time_t t = std::time(nullptr);
 
     const std::string formatted_message =
         fmt::format(MAIL_REGISTRATION_STRING, sender, code, fmt::gmtime(t));
-    std::vector<u8> message{formatted_message.begin(), formatted_message.end()};
-    NWC24::ErrorCode reply =
-        NWC24::WriteToVFF(NWC24::Mail::SEND_BOX_PATH, GetMailPath(entry_index), m_fs, message);
+    const std::span message{reinterpret_cast<const u8*>(formatted_message.data()),
+                            formatted_message.size()};
+    const ErrorCode reply = WriteToVFF(SEND_BOX_PATH, GetMailPath(entry_index), m_fs, message);
 
     if (reply != WC24_OK)
     {

--- a/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
+++ b/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.cpp
@@ -189,7 +189,7 @@ static DRESULT vff_ioctl(IOS::HLE::FS::FileHandle* vff, BYTE pdrv, BYTE cmd, voi
 
 namespace IOS::HLE::NWC24
 {
-static ErrorCode WriteFile(const std::string& filename, const std::vector<u8>& tmp_buffer)
+static ErrorCode WriteFile(const std::string& filename, std::span<const u8> tmp_buffer)
 {
   FIL dst{};
   const auto open_error_code = f_open(&dst, filename.c_str(), FA_CREATE_ALWAYS | FA_WRITE);
@@ -301,7 +301,7 @@ public:
 }  // namespace
 
 ErrorCode WriteToVFF(const std::string& path, const std::string& filename,
-                     const std::shared_ptr<FS::FileSystem>& fs, const std::vector<u8>& data)
+                     const std::shared_ptr<FS::FileSystem>& fs, std::span<const u8> data)
 {
   VffFatFsCallbacks callbacks;
   ErrorCode return_value;

--- a/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.h
+++ b/Source/Core/Core/IOS/Network/KD/VFF/VFFUtil.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -23,7 +24,7 @@ constexpr u16 SECTOR_SIZE = 512;
 constexpr u16 VF_LITTLE_ENDIAN = 0xFFFE;
 constexpr u16 VF_BIG_ENDIAN = 0xFEFF;
 ErrorCode WriteToVFF(const std::string& path, const std::string& filename,
-                     const std::shared_ptr<FS::FileSystem>& fs, const std::vector<u8>& data);
+                     const std::shared_ptr<FS::FileSystem>& fs, std::span<const u8> data);
 ErrorCode ReadFromVFF(const std::string& path, const std::string& filename,
                       const std::shared_ptr<FS::FileSystem>& fs, std::vector<u8>& out);
 ErrorCode DeleteFileFromVFF(const std::string& path, const std::string& filename,


### PR DESCRIPTION
Same behavior, but allows different containers to be used.

In one case it also gets rid of needing to construct a std::vector.