### PR TITLE
JitArm64: Add additional condition for lmw/stmw a discard

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -549,7 +549,7 @@ void JitArm64::lmw(UGeckoInstruction inst)
     {
       if (a_is_addr_base_reg)
         gprs_to_discard[a] = false;
-      else
+      else if (a < d)
         gpr.DiscardRegisters(BitSet32{int(a)});
     }
   }
@@ -666,7 +666,7 @@ void JitArm64::stmw(UGeckoInstruction inst)
     {
       if (a_is_addr_base_reg)
         gprs_to_discard[a] = false;
-      else
+      else if (a < s)
         gpr.DiscardRegisters(BitSet32{int(a)});
     }
   }


### PR DESCRIPTION
If a is one of the registers that will be loaded/stored, we must not discard it early. Sorry for this fixup of a fixup...