### PR TITLE
Android: update NDK to 26.1.10909125 in order to pick up new compiler features

### DIFF
--- a/Source/Android/app/build.gradle.kts
+++ b/Source/Android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 @Suppress("UnstableApiUsage")
 android {
     compileSdkVersion = "android-34"
-    ndkVersion = "25.2.9519653"
+    ndkVersion = "26.1.10909125"
 
     buildFeatures {
         viewBinding = true


### PR DESCRIPTION
I needed this in my editor branch for some C++20 features that the current Android SDK was lacking.

@JosJuice / @t895 