### PR TITLE
HW/CEXIIPL: Fix loading files at nonzero offset in LoadFileToIPL().

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -168,10 +168,7 @@ bool CEXIIPL::LoadFileToIPL(const std::string& filename, u32 offset)
     return false;
 
   const u64 filesize = stream.GetSize();
-  if (offset >= filesize)
-    return false;
-
-  if (!stream.ReadBytes(&m_rom[offset], std::min<u64>(filesize, ROM_SIZE) - offset))
+  if (!stream.ReadBytes(&m_rom[offset], std::min<u64>(filesize, ROM_SIZE - offset)))
     return false;
 
   m_fonts_loaded = true;


### PR DESCRIPTION
Fixes the IPL fonts when you don't have a dump in your user directory. My bad.