### PR TITLE
Common/SettingsHandler: Minor convenience changes

### DIFF
--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -92,12 +92,12 @@ void SettingsHandler::Reset()
   m_buffer = {};
 }
 
-void SettingsHandler::AddSetting(const std::string& key, const std::string& value)
+void SettingsHandler::AddSetting(std::string_view key, std::string_view value)
 {
-  WriteLine(key + '=' + value + "\r\n");
+  WriteLine(fmt::format("{}={}\r\n", key, value));
 }
 
-void SettingsHandler::WriteLine(const std::string& str)
+void SettingsHandler::WriteLine(std::string_view str)
 {
   const u32 old_position = m_position;
   const u32 old_key = m_key;

--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -81,7 +81,7 @@ void SettingsHandler::Decrypt()
   // (see the comment in WriteLine), lines can be separated by CRLFLF.
   // To handle this, we remove every CR and treat LF as the line ending.
   // (We ignore empty lines.)
-  decoded.erase(std::remove(decoded.begin(), decoded.end(), '\x0d'), decoded.end());
+  std::erase(decoded, '\x0d');
 }
 
 void SettingsHandler::Reset()

--- a/Source/Core/Common/SettingsHandler.h
+++ b/Source/Core/Common/SettingsHandler.h
@@ -27,7 +27,7 @@ public:
   SettingsHandler();
   explicit SettingsHandler(Buffer&& buffer);
 
-  void AddSetting(const std::string& key, const std::string& value);
+  void AddSetting(std::string_view key, std::string_view value);
 
   const Buffer& GetBytes() const;
   void SetBytes(Buffer&& buffer);
@@ -38,7 +38,7 @@ public:
   static std::string GenerateSerialNumber();
 
 private:
-  void WriteLine(const std::string& str);
+  void WriteLine(std::string_view str);
   void WriteByte(u8 b);
 
   std::array<u8, SETTINGS_SIZE> m_buffer;


### PR DESCRIPTION
We can make AddSetting make use of std::string_view, and also greatly simplify the code doing the removal of the carriage returns.