### PR TITLE
GameFileCache: Pass std::function by reference rather than by value

### DIFF
--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -43,7 +43,7 @@ GameFileCache::GameFileCache() : m_path(File::GetUserPath(D_CACHE_IDX) + "gameli
 {
 }
 
-void GameFileCache::ForEach(std::function<void(const std::shared_ptr<const GameFile>&)> f) const
+void GameFileCache::ForEach(const ForEachFn& f) const
 {
   for (const std::shared_ptr<GameFile>& item : m_cached_files)
     f(item);
@@ -83,11 +83,10 @@ std::shared_ptr<const GameFile> GameFileCache::AddOrGet(const std::string& path,
   return result;
 }
 
-bool GameFileCache::Update(
-    const std::vector<std::string>& all_game_paths,
-    std::function<void(const std::shared_ptr<const GameFile>&)> game_added_to_cache,
-    std::function<void(const std::string&)> game_removed_from_cache,
-    const std::atomic_bool& processing_halted)
+bool GameFileCache::Update(const std::vector<std::string>& all_game_paths,
+                           const GameAddedToCacheFn& game_added_to_cache,
+                           const GameRemovedFromCacheFn& game_removed_from_cache,
+                           const std::atomic_bool& processing_halted)
 {
   // Copy game paths into a set, except ones that match DiscIO::ShouldHideFromGameList.
   // TODO: Prevent DoFileSearch from looking inside /files/ directories of DirectoryBlobs at all?
@@ -151,9 +150,8 @@ bool GameFileCache::Update(
   return cache_changed;
 }
 
-bool GameFileCache::UpdateAdditionalMetadata(
-    std::function<void(const std::shared_ptr<const GameFile>&)> game_updated,
-    const std::atomic_bool& processing_halted)
+bool GameFileCache::UpdateAdditionalMetadata(const GameUpdatedFn& game_updated,
+                                             const std::atomic_bool& processing_halted)
 {
   bool cache_changed = false;
 

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<const GameFile> GameFileCache::AddOrGet(const std::string& path,
   return result;
 }
 
-bool GameFileCache::Update(const std::vector<std::string>& all_game_paths,
+bool GameFileCache::Update(std::span<const std::string> all_game_paths,
                            const GameAddedToCacheFn& game_added_to_cache,
                            const GameRemovedFromCacheFn& game_removed_from_cache,
                            const std::atomic_bool& processing_halted)

--- a/Source/Core/UICommon/GameFileCache.h
+++ b/Source/Core/UICommon/GameFileCache.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -46,7 +47,7 @@ public:
   std::shared_ptr<const GameFile> AddOrGet(const std::string& path, bool* cache_changed);
 
   // These functions return true if the call modified the cache.
-  bool Update(const std::vector<std::string>& all_game_paths,
+  bool Update(std::span<const std::string> all_game_paths,
               const GameAddedToCacheFn& game_added_to_cache = {},
               const GameRemovedFromCacheFn& game_removed_from_cache = {},
               const std::atomic_bool& processing_halted = false);

--- a/Source/Core/UICommon/GameFileCache.h
+++ b/Source/Core/UICommon/GameFileCache.h
@@ -30,9 +30,14 @@ public:
     Yes = 1,
   };
 
+  using ForEachFn = std::function<void(const std::shared_ptr<const GameFile>&)>;
+  using GameAddedToCacheFn = std::function<void(const std::shared_ptr<const GameFile>&)>;
+  using GameRemovedFromCacheFn = std::function<void(const std::string&)>;
+  using GameUpdatedFn = std::function<void(const std::shared_ptr<const GameFile>&)>;
+
   GameFileCache();
 
-  void ForEach(std::function<void(const std::shared_ptr<const GameFile>&)> f) const;
+  void ForEach(const ForEachFn& f) const;
 
   size_t GetSize() const;
   void Clear(DeleteOnDisk delete_on_disk);
@@ -42,12 +47,11 @@ public:
 
   // These functions return true if the call modified the cache.
   bool Update(const std::vector<std::string>& all_game_paths,
-              std::function<void(const std::shared_ptr<const GameFile>&)> game_added_to_cache = {},
-              std::function<void(const std::string&)> game_removed_from_cache = {},
+              const GameAddedToCacheFn& game_added_to_cache = {},
+              const GameRemovedFromCacheFn& game_removed_from_cache = {},
               const std::atomic_bool& processing_halted = false);
-  bool UpdateAdditionalMetadata(
-      std::function<void(const std::shared_ptr<const GameFile>&)> game_updated = {},
-      const std::atomic_bool& processing_halted = false);
+  bool UpdateAdditionalMetadata(const GameUpdatedFn& game_updated = {},
+                                const std::atomic_bool& processing_halted = false);
 
   bool Load();
   bool Save();


### PR DESCRIPTION
std::function is internally allowed to allocate, and these functions aren't being stored anywhere (only called), so we can freely get rid of some minor overhead here by passing by reference. This change also creates aliases for the functions, so that there isn't a lot of visual noise when reading the function signatures.

While we're in the same area, we can make Update() take a span, since all we're doing is iterating over a sequence of strings.