### PR TITLE
AchievementManager: Make GetInstance() and GetLock() return a reference

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -731,9 +731,9 @@ void AchievementManager::AchievementEventHandler(const rc_runtime_event_t* runti
     m_update_callback();
 }
 
-std::recursive_mutex* AchievementManager::GetLock()
+std::recursive_mutex& AchievementManager::GetLock()
 {
-  return &m_lock;
+  return m_lock;
 }
 
 bool AchievementManager::IsHardcoreModeActive() const
@@ -934,7 +934,7 @@ void* AchievementManager::FilereaderOpenByVolume(const char* path_utf8)
   auto state = std::make_unique<FilereaderState>();
   {
     auto& instance = GetInstance();
-    std::lock_guard lg{*instance.GetLock()};
+    std::lock_guard lg{instance.GetLock()};
     state->volume = std::move(instance.GetLoadingVolume());
   }
   if (!state->volume)

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -28,10 +28,10 @@ static constexpr bool hardcore_mode_enabled = false;
 
 static std::unique_ptr<OSD::Icon> DecodeBadgeToOSDIcon(const AchievementManager::Badge& badge);
 
-AchievementManager* AchievementManager::GetInstance()
+AchievementManager& AchievementManager::GetInstance()
 {
   static AchievementManager s_instance;
-  return &s_instance;
+  return s_instance;
 }
 
 void AchievementManager::Init()
@@ -650,7 +650,7 @@ void AchievementManager::DoFrame()
     rc_runtime_do_frame(
         &m_runtime,
         [](const rc_runtime_event_t* runtime_event) {
-          AchievementManager::GetInstance()->AchievementEventHandler(runtime_event);
+          GetInstance().AchievementEventHandler(runtime_event);
         },
         [](unsigned address, unsigned num_bytes, void* ud) {
           return static_cast<AchievementManager*>(ud)->MemoryPeeker(address, num_bytes, ud);
@@ -933,8 +933,9 @@ void* AchievementManager::FilereaderOpenByVolume(const char* path_utf8)
 {
   auto state = std::make_unique<FilereaderState>();
   {
-    std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
-    state->volume = std::move(AchievementManager::GetInstance()->GetLoadingVolume());
+    auto& instance = GetInstance();
+    std::lock_guard lg{*instance.GetLock()};
+    state->volume = std::move(instance.GetLoadingVolume());
   }
   if (!state->volume)
     return nullptr;

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -109,7 +109,7 @@ public:
     std::unordered_map<u32, LeaderboardEntry> entries;
   };
 
-  static AchievementManager* GetInstance();
+  static AchievementManager& GetInstance();
   void Init();
   void SetUpdateCallback(UpdateCallback callback);
   ResponseType Login(const std::string& password);

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -129,7 +129,7 @@ public:
   u32 MemoryPeeker(u32 address, u32 num_bytes, void* ud);
   void AchievementEventHandler(const rc_runtime_event_t* runtime_event);
 
-  std::recursive_mutex* GetLock();
+  std::recursive_mutex& GetLock();
   bool IsHardcoreModeActive() const;
   std::string GetPlayerDisplayName() const;
   u32 GetPlayerScore() const;

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -580,8 +580,8 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
       }
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-      AchievementManager::GetInstance()->HashGame(executable.path,
-                                                  [](AchievementManager::ResponseType r_type) {});
+      AchievementManager::GetInstance().HashGame(executable.path,
+                                                 [](AchievementManager::ResponseType r_type) {});
 #endif  // USE_RETRO_ACHIEVEMENTS
 
       if (!executable.reader->LoadIntoMemory(system))

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -165,7 +165,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
   }
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  AchievementManager::GetInstance()->SetDisabled(false);
+  AchievementManager::GetInstance().SetDisabled(false);
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   const bool load_ipl = !StartUp.bWii && !Config::Get(Config::MAIN_SKIP_IPL) &&

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -170,7 +170,7 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
     return;
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  AchievementManager::GetInstance()->SetDisabled(true);
+  AchievementManager::GetInstance().SetDisabled(true);
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   if (game_id == "00000000")

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -293,7 +293,7 @@ void Stop()  // - Hammertime!
     return;
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  AchievementManager::GetInstance()->CloseGame();
+  AchievementManager::GetInstance().CloseGame();
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   s_is_stopping = true;
@@ -940,7 +940,7 @@ void Callback_NewField(Core::System& system)
   }
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  AchievementManager::GetInstance()->DoFrame();
+  AchievementManager::GetInstance().DoFrame();
 #endif  // USE_RETRO_ACHIEVEMENTS
 }
 
@@ -1083,7 +1083,7 @@ void HostDispatchJobs()
 void DoFrameStep()
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (AchievementManager::GetInstance()->IsHardcoreModeActive())
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
   {
     OSD::AddMessage("Frame stepping is disabled in RetroAchievements hardcore mode");
     return;

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -139,7 +139,7 @@ void CoreTimingManager::RefreshConfig()
   m_max_variance = std::chrono::duration_cast<DT>(DT_ms(Config::Get(Config::MAIN_TIMING_VARIANCE)));
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (AchievementManager::GetInstance()->IsHardcoreModeActive() &&
+  if (AchievementManager::GetInstance().IsHardcoreModeActive() &&
       Config::Get(Config::MAIN_EMULATION_SPEED) < 1.0f &&
       Config::Get(Config::MAIN_EMULATION_SPEED) > 0.0f)
   {

--- a/Source/Core/Core/FreeLookConfig.cpp
+++ b/Source/Core/Core/FreeLookConfig.cpp
@@ -48,7 +48,7 @@ void Config::Refresh()
   camera_config.control_type = ::Config::Get(::Config::FL1_CONTROL_TYPE);
 #ifdef USE_RETRO_ACHIEVEMENTS
   enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED) &&
-            !AchievementManager::GetInstance()->IsHardcoreModeActive();
+            !AchievementManager::GetInstance().IsHardcoreModeActive();
 #else   // USE_RETRO_ACHIEVEMENTS
   enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED);
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -398,8 +398,8 @@ void DVDInterface::SetDisc(std::unique_ptr<DiscIO::VolumeDisc> disc,
   }
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  AchievementManager::GetInstance()->HashGame(disc.get(),
-                                              [](AchievementManager::ResponseType r_type) {});
+  AchievementManager::GetInstance().HashGame(disc.get(),
+                                             [](AchievementManager::ResponseType r_type) {});
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   // Assume that inserting a disc requires having an empty disc before

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -480,7 +480,7 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
 #ifdef USE_RETRO_ACHIEVEMENTS
   INFO_LOG_FMT(ACHIEVEMENTS,
                "WAD and NAND formats not currently supported by Achievement Manager.");
-  AchievementManager::GetInstance()->SetDisabled(true);
+  AchievementManager::GetInstance().SetDisabled(true);
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   core_timing.RemoveEvent(s_bootstrap_ppc_for_launch_event);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -207,7 +207,7 @@ void LoadFromBuffer(std::vector<u8>& buffer)
   }
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (AchievementManager::GetInstance()->IsHardcoreModeActive())
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
   {
     OSD::AddMessage("Loading savestates is disabled in RetroAchievements hardcore mode");
     return;
@@ -853,7 +853,7 @@ void LoadAs(const std::string& filename)
   }
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (AchievementManager::GetInstance()->IsHardcoreModeActive())
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
   {
     OSD::AddMessage("Loading savestates is disabled in RetroAchievements hardcore mode");
     return;

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -73,33 +73,31 @@ AchievementHeaderWidget::AchievementHeaderWidget(QWidget* parent) : QWidget(pare
   m_total->setAlignment(Qt::AlignTop);
   setLayout(m_total);
 
-  std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
+  std::lock_guard lg{*AchievementManager::GetInstance().GetLock()};
   UpdateData();
 }
 
 void AchievementHeaderWidget::UpdateData()
 {
-  if (!AchievementManager::GetInstance()->IsLoggedIn())
+  auto& instance = AchievementManager::GetInstance();
+  if (!instance.IsLoggedIn())
   {
     m_header_box->setVisible(false);
     return;
   }
 
-  AchievementManager::PointSpread point_spread = AchievementManager::GetInstance()->TallyScore();
-  QString user_name =
-      QString::fromStdString(AchievementManager::GetInstance()->GetPlayerDisplayName());
-  QString game_name =
-      QString::fromStdString(AchievementManager::GetInstance()->GetGameDisplayName());
-  AchievementManager::BadgeStatus player_badge =
-      AchievementManager::GetInstance()->GetPlayerBadge();
-  AchievementManager::BadgeStatus game_badge = AchievementManager::GetInstance()->GetGameBadge();
+  AchievementManager::PointSpread point_spread = instance.TallyScore();
+  QString user_name = QString::fromStdString(instance.GetPlayerDisplayName());
+  QString game_name = QString::fromStdString(instance.GetGameDisplayName());
+  AchievementManager::BadgeStatus player_badge = instance.GetPlayerBadge();
+  AchievementManager::BadgeStatus game_badge = instance.GetGameBadge();
 
   m_user_icon->setVisible(false);
   m_user_icon->clear();
   m_user_icon->setText({});
   if (Config::Get(Config::RA_BADGES_ENABLED))
   {
-    if (player_badge.name != "")
+    if (!player_badge.name.empty())
     {
       QImage i_user_icon{};
       if (i_user_icon.loadFromData(&player_badge.badge.front(), (int)player_badge.badge.size()))
@@ -117,7 +115,7 @@ void AchievementHeaderWidget::UpdateData()
   m_game_icon->setText({});
   if (Config::Get(Config::RA_BADGES_ENABLED))
   {
-    if (game_badge.name != "")
+    if (!game_badge.name.empty())
     {
       QImage i_game_icon{};
       if (i_game_icon.loadFromData(&game_badge.badge.front(), (int)game_badge.badge.size()))
@@ -150,8 +148,7 @@ void AchievementHeaderWidget::UpdateData()
     m_game_progress_soft->setValue(point_spread.hard_unlocks + point_spread.soft_unlocks);
     if (!m_game_progress_soft->isVisible())
       m_game_progress_soft->setVisible(true);
-    m_rich_presence->setText(
-        QString::fromUtf8(AchievementManager::GetInstance()->GetRichPresence().data()));
+    m_rich_presence->setText(QString::fromUtf8(instance.GetRichPresence().data()));
     if (!m_rich_presence->isVisible())
       m_rich_presence->setVisible(Config::Get(Config::RA_RICH_PRESENCE_ENABLED));
     m_locked_warning->setVisible(false);
@@ -159,12 +156,12 @@ void AchievementHeaderWidget::UpdateData()
   else
   {
     m_name->setText(user_name);
-    m_points->setText(tr("%1 points").arg(AchievementManager::GetInstance()->GetPlayerScore()));
+    m_points->setText(tr("%1 points").arg(instance.GetPlayerScore()));
 
     m_game_progress_hard->setVisible(false);
     m_game_progress_soft->setVisible(false);
     m_rich_presence->setVisible(false);
-    if (AchievementManager::GetInstance()->IsDisabled())
+    if (instance.IsDisabled())
     {
       m_locked_warning->setVisible(true);
     }

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -62,7 +62,7 @@ AchievementHeaderWidget::AchievementHeaderWidget(QWidget* parent) : QWidget(pare
   m_total->setAlignment(Qt::AlignTop);
   setLayout(m_total);
 
-  std::lock_guard lg{*AchievementManager::GetInstance().GetLock()};
+  std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
   UpdateData();
 }
 

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -4,28 +4,17 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include "DolphinQt/Achievements/AchievementHeaderWidget.h"
 
-#include <QCheckBox>
 #include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
 #include <QProgressBar>
-#include <QPushButton>
 #include <QString>
 #include <QVBoxLayout>
-
-#include <fmt/format.h>
-
-#include <rcheevos/include/rc_api_runtime.h>
-#include <rcheevos/include/rc_api_user.h>
-#include <rcheevos/include/rc_runtime.h>
 
 #include "Core/AchievementManager.h"
 #include "Core/Config/AchievementSettings.h"
 #include "Core/Core.h"
 
-#include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
 AchievementHeaderWidget::AchievementHeaderWidget(QWidget* parent) : QWidget(parent)

--- a/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
@@ -4,19 +4,11 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include "DolphinQt/Achievements/AchievementLeaderboardWidget.h"
 
-#include <QCheckBox>
 #include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
-#include <QPushButton>
 #include <QString>
 #include <QVBoxLayout>
-
-#include <fmt/format.h>
-
-#include <rcheevos/include/rc_api_runtime.h>
-#include <rcheevos/include/rc_api_user.h>
-#include <rcheevos/include/rc_runtime.h>
 
 #include "Common/CommonTypes.h"
 #include "Core/AchievementManager.h"
@@ -24,11 +16,7 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 
-#include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
 #include "DolphinQt/QtUtils/ClearLayoutRecursively.h"
-#include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
 AchievementLeaderboardWidget::AchievementLeaderboardWidget(QWidget* parent) : QWidget(parent)

--- a/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
@@ -25,7 +25,7 @@ AchievementLeaderboardWidget::AchievementLeaderboardWidget(QWidget* parent) : QW
   m_common_layout = new QGridLayout();
 
   {
-    std::lock_guard lg{*AchievementManager::GetInstance().GetLock()};
+    std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
     UpdateData();
   }
 

--- a/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
@@ -37,7 +37,7 @@ AchievementLeaderboardWidget::AchievementLeaderboardWidget(QWidget* parent) : QW
   m_common_layout = new QGridLayout();
 
   {
-    std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
+    std::lock_guard lg{*AchievementManager::GetInstance().GetLock()};
     UpdateData();
   }
 
@@ -54,9 +54,9 @@ void AchievementLeaderboardWidget::UpdateData()
 {
   ClearLayoutRecursively(m_common_layout);
 
-  if (!AchievementManager::GetInstance()->IsGameLoaded())
+  if (!AchievementManager::GetInstance().IsGameLoaded())
     return;
-  const auto& leaderboards = AchievementManager::GetInstance()->GetLeaderboardsInfo();
+  const auto& leaderboards = AchievementManager::GetInstance().GetLeaderboardsInfo();
   int row = 0;
   for (const auto& board_row : leaderboards)
   {

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
@@ -39,7 +39,7 @@ AchievementProgressWidget::AchievementProgressWidget(QWidget* parent) : QWidget(
   m_common_layout = new QVBoxLayout();
 
   {
-    std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
+    std::lock_guard lg{*AchievementManager::GetInstance().GetLock()};
     UpdateData();
   }
 
@@ -55,10 +55,12 @@ AchievementProgressWidget::AchievementProgressWidget(QWidget* parent) : QWidget(
 QGroupBox*
 AchievementProgressWidget::CreateAchievementBox(const rc_api_achievement_definition_t* achievement)
 {
-  if (!AchievementManager::GetInstance()->IsGameLoaded())
+  const auto& instance = AchievementManager::GetInstance();
+  if (!instance.IsGameLoaded())
     return new QGroupBox();
+
   QLabel* a_badge = new QLabel();
-  const auto unlock_status = AchievementManager::GetInstance()->GetUnlockStatus(achievement->id);
+  const auto unlock_status = instance.GetUnlockStatus(achievement->id);
   const AchievementManager::BadgeStatus* badge = &unlock_status.locked_badge;
   std::string_view color = AchievementManager::GRAY;
   if (unlock_status.remote_unlock_status == AchievementManager::UnlockStatus::UnlockType::HARDCORE)
@@ -106,7 +108,7 @@ AchievementProgressWidget::CreateAchievementBox(const rc_api_achievement_definit
   a_progress_bar->setSizePolicy(sp_retain);
   unsigned int value = 0;
   unsigned int target = 0;
-  if (AchievementManager::GetInstance()->GetAchievementProgress(achievement->id, &value, &target) ==
+  if (AchievementManager::GetInstance().GetAchievementProgress(achievement->id, &value, &target) ==
           AchievementManager::ResponseType::SUCCESS &&
       target > 0)
   {
@@ -136,9 +138,11 @@ void AchievementProgressWidget::UpdateData()
 {
   ClearLayoutRecursively(m_common_layout);
 
-  if (!AchievementManager::GetInstance()->IsGameLoaded())
+  auto& instance = AchievementManager::GetInstance();
+  if (!instance.IsGameLoaded())
     return;
-  const auto* game_data = AchievementManager::GetInstance()->GetGameData();
+
+  const auto* game_data = instance.GetGameData();
   for (u32 ix = 0; ix < game_data->num_achievements; ix++)
   {
     m_common_layout->addWidget(CreateAchievementBox(game_data->achievements + ix));
@@ -147,7 +151,7 @@ void AchievementProgressWidget::UpdateData()
 
 QString AchievementProgressWidget::GetStatusString(u32 achievement_id) const
 {
-  const auto unlock_status = AchievementManager::GetInstance()->GetUnlockStatus(achievement_id);
+  const auto unlock_status = AchievementManager::GetInstance().GetUnlockStatus(achievement_id);
   if (unlock_status.session_unlock_count > 0)
   {
     if (Config::Get(Config::RA_ENCORE_ENABLED))

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
@@ -4,31 +4,21 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include "DolphinQt/Achievements/AchievementProgressWidget.h"
 
-#include <QCheckBox>
 #include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
 #include <QProgressBar>
-#include <QPushButton>
 #include <QString>
 #include <QVBoxLayout>
 
-#include <fmt/format.h>
-
 #include <rcheevos/include/rc_api_runtime.h>
-#include <rcheevos/include/rc_api_user.h>
-#include <rcheevos/include/rc_runtime.h>
 
 #include "Core/AchievementManager.h"
 #include "Core/Config/AchievementSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 
-#include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
 #include "DolphinQt/QtUtils/ClearLayoutRecursively.h"
-#include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
 static constexpr bool hardcore_mode_enabled = false;

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
@@ -29,7 +29,7 @@ AchievementProgressWidget::AchievementProgressWidget(QWidget* parent) : QWidget(
   m_common_layout = new QVBoxLayout();
 
   {
-    std::lock_guard lg{*AchievementManager::GetInstance().GetLock()};
+    std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
     UpdateData();
   }
 

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -4,10 +4,8 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include "DolphinQt/Achievements/AchievementSettingsWidget.h"
 
-#include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
-#include <QPushButton>
 #include <QString>
 #include <QVBoxLayout>
 
@@ -20,7 +18,6 @@
 
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
-#include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -244,16 +244,18 @@ void AchievementSettingsWidget::SaveSettings()
 void AchievementSettingsWidget::ToggleRAIntegration()
 {
   SaveSettings();
+
+  auto& instance = AchievementManager::GetInstance();
   if (Config::Get(Config::RA_ENABLED))
-    AchievementManager::GetInstance()->Init();
+    instance.Init();
   else
-    AchievementManager::GetInstance()->Shutdown();
+    instance.Shutdown();
 }
 
 void AchievementSettingsWidget::Login()
 {
   Config::SetBaseOrCurrent(Config::RA_USERNAME, m_common_username_input->text().toStdString());
-  AchievementManager::GetInstance()->Login(m_common_password_input->text().toStdString());
+  AchievementManager::GetInstance().Login(m_common_password_input->text().toStdString());
   m_common_password_input->setText(QString());
   m_common_login_failed->setVisible(Config::Get(Config::RA_API_TOKEN).empty());
   SaveSettings();
@@ -261,26 +263,26 @@ void AchievementSettingsWidget::Login()
 
 void AchievementSettingsWidget::Logout()
 {
-  AchievementManager::GetInstance()->Logout();
+  AchievementManager::GetInstance().Logout();
   SaveSettings();
 }
 
 void AchievementSettingsWidget::ToggleAchievements()
 {
   SaveSettings();
-  AchievementManager::GetInstance()->ActivateDeactivateAchievements();
+  AchievementManager::GetInstance().ActivateDeactivateAchievements();
 }
 
 void AchievementSettingsWidget::ToggleLeaderboards()
 {
   SaveSettings();
-  AchievementManager::GetInstance()->ActivateDeactivateLeaderboards();
+  AchievementManager::GetInstance().ActivateDeactivateLeaderboards();
 }
 
 void AchievementSettingsWidget::ToggleRichPresence()
 {
   SaveSettings();
-  AchievementManager::GetInstance()->ActivateDeactivateRichPresence();
+  AchievementManager::GetInstance().ActivateDeactivateRichPresence();
 }
 
 void AchievementSettingsWidget::ToggleHardcore()
@@ -305,19 +307,19 @@ void AchievementSettingsWidget::ToggleProgress()
 void AchievementSettingsWidget::ToggleBadges()
 {
   SaveSettings();
-  AchievementManager::GetInstance()->FetchBadges();
+  AchievementManager::GetInstance().FetchBadges();
 }
 
 void AchievementSettingsWidget::ToggleUnofficial()
 {
   SaveSettings();
-  AchievementManager::GetInstance()->ActivateDeactivateAchievements();
+  AchievementManager::GetInstance().ActivateDeactivateAchievements();
 }
 
 void AchievementSettingsWidget::ToggleEncore()
 {
   SaveSettings();
-  AchievementManager::GetInstance()->ActivateDeactivateAchievements();
+  AchievementManager::GetInstance().ActivateDeactivateAchievements();
 }
 
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -75,7 +75,7 @@ void AchievementsWindow::UpdateData()
 {
   {
     auto& instance = AchievementManager::GetInstance();
-    std::lock_guard lg{*instance.GetLock()};
+    std::lock_guard lg{instance.GetLock()};
     const bool is_game_loaded = instance.IsGameLoaded();
 
     m_header_widget->UpdateData();

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -25,7 +25,7 @@ AchievementsWindow::AchievementsWindow(QWidget* parent) : QDialog(parent)
 
   CreateMainLayout();
   ConnectWidgets();
-  AchievementManager::GetInstance()->SetUpdateCallback(
+  AchievementManager::GetInstance().SetUpdateCallback(
       [this] { QueueOnObject(this, &AchievementsWindow::UpdateData); });
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &AchievementsWindow::UpdateData);
@@ -41,7 +41,7 @@ void AchievementsWindow::showEvent(QShowEvent* event)
 
 void AchievementsWindow::CreateMainLayout()
 {
-  auto* layout = new QVBoxLayout();
+  const auto is_game_loaded = AchievementManager::GetInstance().IsGameLoaded();
 
   m_header_widget = new AchievementHeaderWidget(this);
   m_tab_widget = new QTabWidget();
@@ -50,12 +50,13 @@ void AchievementsWindow::CreateMainLayout()
   m_leaderboard_widget = new AchievementLeaderboardWidget(m_tab_widget);
   m_tab_widget->addTab(GetWrappedWidget(m_settings_widget, this, 125, 100), tr("Settings"));
   m_tab_widget->addTab(GetWrappedWidget(m_progress_widget, this, 125, 100), tr("Progress"));
-  m_tab_widget->setTabVisible(1, AchievementManager::GetInstance()->IsGameLoaded());
+  m_tab_widget->setTabVisible(1, is_game_loaded);
   m_tab_widget->addTab(GetWrappedWidget(m_leaderboard_widget, this, 125, 100), tr("Leaderboards"));
-  m_tab_widget->setTabVisible(2, AchievementManager::GetInstance()->IsGameLoaded());
+  m_tab_widget->setTabVisible(2, is_game_loaded);
 
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
+  auto* layout = new QVBoxLayout();
   layout->addWidget(m_header_widget);
   layout->addWidget(m_tab_widget);
   layout->addWidget(m_button_box);
@@ -71,14 +72,17 @@ void AchievementsWindow::ConnectWidgets()
 void AchievementsWindow::UpdateData()
 {
   {
-    std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
+    auto& instance = AchievementManager::GetInstance();
+    std::lock_guard lg{*instance.GetLock()};
+    const bool is_game_loaded = instance.IsGameLoaded();
+
     m_header_widget->UpdateData();
-    m_header_widget->setVisible(AchievementManager::GetInstance()->IsLoggedIn());
+    m_header_widget->setVisible(instance.IsLoggedIn());
     m_settings_widget->UpdateData();
     m_progress_widget->UpdateData();
-    m_tab_widget->setTabVisible(1, AchievementManager::GetInstance()->IsGameLoaded());
+    m_tab_widget->setTabVisible(1, is_game_loaded);
     m_leaderboard_widget->UpdateData();
-    m_tab_widget->setTabVisible(2, AchievementManager::GetInstance()->IsGameLoaded());
+    m_tab_widget->setTabVisible(2, is_game_loaded);
   }
   update();
 }

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -10,6 +10,8 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 
+#include "Core/AchievementManager.h"
+
 #include "DolphinQt/Achievements/AchievementHeaderWidget.h"
 #include "DolphinQt/Achievements/AchievementLeaderboardWidget.h"
 #include "DolphinQt/Achievements/AchievementProgressWidget.h"

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
@@ -6,9 +6,6 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include <QDialog>
 
-#include "Core/AchievementManager.h"
-#include "DolphinQt/QtUtils/QueueOnObject.h"
-
 class AchievementHeaderWidget;
 class AchievementLeaderboardWidget;
 class AchievementSettingsWidget;

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
@@ -24,7 +24,7 @@ public:
 
 private:
   void CreateMainLayout();
-  void showEvent(QShowEvent* event);
+  void showEvent(QShowEvent* event) override;
   void ConnectWidgets();
 
   AchievementHeaderWidget* m_header_widget;

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
@@ -39,7 +39,7 @@ void FreeLookWidget::CreateLayout()
       tr("Allows manipulation of the in-game camera.<br><br><dolphin_emphasis>If unsure, "
          "leave this unchecked.</dolphin_emphasis>"));
 #ifdef USE_RETRO_ACHIEVEMENTS
-  bool hardcore = AchievementManager::GetInstance()->IsHardcoreModeActive();
+  const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_enable_freelook->setEnabled(!hardcore);
 #endif  // USE_RETRO_ACHIEVEMENTS
   m_freelook_controller_configure_button = new NonDefaultQPushButton(tr("Configure Controller"));
@@ -113,7 +113,7 @@ void FreeLookWidget::LoadSettings()
   const bool checked = Config::Get(Config::FREE_LOOK_ENABLED);
   m_enable_freelook->setChecked(checked);
 #ifdef USE_RETRO_ACHIEVEMENTS
-  bool hardcore = AchievementManager::GetInstance()->IsHardcoreModeActive();
+  const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_enable_freelook->setEnabled(!hardcore);
 #endif  // USE_RETRO_ACHIEVEMENTS
   m_freelook_control_type->setEnabled(checked);

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -582,7 +582,7 @@ void HotkeyScheduler::Run()
       const bool new_value = !Config::Get(Config::FREE_LOOK_ENABLED);
       Config::SetCurrent(Config::FREE_LOOK_ENABLED, new_value);
 #ifdef USE_RETRO_ACHIEVEMENTS
-      bool hardcore = AchievementManager::GetInstance()->IsHardcoreModeActive();
+      const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
       if (hardcore)
         OSD::AddMessage("Free Look is Disabled in Hardcore Mode");
       else

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -258,7 +258,7 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
   NetPlayInit();
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  AchievementManager::GetInstance()->Init();
+  AchievementManager::GetInstance().Init();
 #endif  // USE_RETRO_ACHIEVEMENTS
 
 #if defined(__unix__) || defined(__unix) || defined(__APPLE__)
@@ -327,7 +327,7 @@ MainWindow::~MainWindow()
   Settings::Instance().ResetNetPlayServer();
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  AchievementManager::GetInstance()->Shutdown();
+  AchievementManager::GetInstance().Shutdown();
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   delete m_render_widget;

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -125,7 +125,7 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   m_state_save_menu->setEnabled(running);
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  bool hardcore = AchievementManager::GetInstance()->IsHardcoreModeActive();
+  const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_state_load_menu->setEnabled(running && !hardcore);
   m_frame_advance_action->setEnabled(running && !hardcore);
 #else   // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -330,7 +330,7 @@ void OnScreenUI::DrawDebugText()
 #ifdef USE_RETRO_ACHIEVEMENTS
 void OnScreenUI::DrawChallenges()
 {
-  std::lock_guard lg{*AchievementManager::GetInstance().GetLock()};
+  std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
   const auto& challenge_icons = AchievementManager::GetInstance().GetChallengeIcons();
   if (challenge_icons.empty())
     return;

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -330,10 +330,9 @@ void OnScreenUI::DrawDebugText()
 #ifdef USE_RETRO_ACHIEVEMENTS
 void OnScreenUI::DrawChallenges()
 {
-  std::lock_guard lg{*AchievementManager::GetInstance()->GetLock()};
-  const AchievementManager::NamedIconMap& challenge_icons =
-      AchievementManager::GetInstance()->GetChallengeIcons();
-  if (challenge_icons.size() == 0)
+  std::lock_guard lg{*AchievementManager::GetInstance().GetLock()};
+  const auto& challenge_icons = AchievementManager::GetInstance().GetChallengeIcons();
+  if (challenge_icons.empty())
     return;
 
   const std::string window_name = "Challenges";


### PR DESCRIPTION
This is more idiomatic (and consistent with any other singletons we have) for accessing the instance itself. Changing `GetLock()` to return a reference makes using the returned mutex with any kind of scope guard a little more convenient, since there's no need to explicitly dereference the returned pointer.

Also gets rid of a decent chunk of unnecessary includes on the Qt side of things as well.