### PR TITLE
GraphicsModListWidget: Add string specifier to By and Description fields

### DIFF
--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
@@ -210,14 +210,14 @@ void GraphicsModListWidget::OnModChanged(std::optional<std::string> absolute_pat
 
   if (!mod->m_author.empty())
   {
-    auto* author_label = new QLabel(tr("By:  ") + QString::fromStdString(mod->m_author));
+    auto* author_label = new QLabel(tr("By: %1").arg(QString::fromStdString(mod->m_author)));
     m_mod_meta_layout->addWidget(author_label);
   }
 
   if (!mod->m_description.empty())
   {
     auto* description_label =
-        new QLabel(tr("Description:  ") + QString::fromStdString(mod->m_description));
+        new QLabel(tr("Description: %1").arg(QString::fromStdString(mod->m_description)));
     description_label->setWordWrap(true);
     m_mod_meta_layout->addWidget(description_label);
   }


### PR DESCRIPTION
Translators should always know where text is going to be appended and have the ability to move things around to fit the language better.