### PR TITLE
General: Resolve -Wmissing-declaration warnings

### DIFF
--- a/Source/Core/Core/WC24PatchEngine.cpp
+++ b/Source/Core/Core/WC24PatchEngine.cpp
@@ -81,7 +81,7 @@ void LoadPatchSection(const Common::IniFile& ini)
   ReadEnabledAndDisabled(ini, "WC24Patch", &s_patches);
 }
 
-void LoadPatches()
+static void LoadPatches()
 {
   const auto& sconfig = SConfig::GetInstance();
   // We can only load WC24 Channels.

--- a/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
@@ -14,9 +14,9 @@
 
 namespace VideoCommon
 {
-bool ParseShaderProperties(const VideoCommon::CustomAssetLibrary::AssetID& asset_id,
-                           const picojson::array& properties_data,
-                           std::map<std::string, VideoCommon::ShaderProperty>* shader_properties)
+static bool ParseShaderProperties(const CustomAssetLibrary::AssetID& asset_id,
+                                  const picojson::array& properties_data,
+                                  std::map<std::string, ShaderProperty>* shader_properties)
 {
   if (!shader_properties) [[unlikely]]
     return false;

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -39,8 +39,8 @@ static const char s_default_pixel_shader_name[] = "default_pre_post_process";
 // RGBA16F should have enough quality even if we store colors in gamma space on it.
 static const AbstractTextureFormat s_intermediary_buffer_format = AbstractTextureFormat::RGBA16F;
 
-bool LoadShaderFromFile(const std::string& shader, const std::string& sub_dir,
-                        std::string& out_code)
+static bool LoadShaderFromFile(const std::string& shader, const std::string& sub_dir,
+                               std::string& out_code)
 {
   std::string path = File::GetUserPath(D_SHADERS_IDX) + sub_dir + shader + ".glsl";
 
@@ -769,7 +769,7 @@ std::string PostProcessing::GetFooter() const
   return {};
 }
 
-std::string GetVertexShaderBody()
+static std::string GetVertexShaderBody()
 {
   std::ostringstream ss;
   if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
@@ -1002,7 +1002,7 @@ bool PostProcessing::CompilePixelShader()
   return true;
 }
 
-bool UseGeometryShaderForPostProcess(bool is_intermediary_buffer)
+static bool UseGeometryShaderForPostProcess(bool is_intermediary_buffer)
 {
   // We only return true on stereo modes that need to copy
   // both source texture layers into the target texture layers.


### PR DESCRIPTION
Resolves warnings related to functions with external linkage not having any prototype declarations. In these cases, it's sufficient to make them internally linked with static.