### PR TITLE
DolphinQT/Host: Remove unused TLS variable tls_is_host_thread 

### DIFF
--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -41,8 +41,6 @@
 #include "VideoCommon/Present.h"
 #include "VideoCommon/VideoConfig.h"
 
-static thread_local bool tls_is_host_thread = false;
-
 Host::Host()
 {
   State::SetOnAfterLoadCallback([] { Host_UpdateDisasmDialog(); });

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -21,9 +21,6 @@ public:
 
   static Host* GetInstance();
 
-  void DeclareAsHostThread();
-  bool IsHostThread();
-
   bool GetRenderFocus();
   bool GetRenderFullFocus();
   bool GetRenderFullscreen();


### PR DESCRIPTION
Gets rid of an unused static along with dead prototypes