### PR TITLE
General: Resolve -Wsign-compare warnings

### DIFF
--- a/Source/Android/jni/AndroidCommon/AndroidCommon.h
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.h
@@ -19,8 +19,9 @@ jobjectArray VectorToJStringArray(JNIEnv* env, const std::vector<std::string>& v
 template <typename T, typename F>
 jobjectArray VectorToJObjectArray(JNIEnv* env, const std::vector<T>& vector, jclass clazz, F f)
 {
-  jobjectArray result = env->NewObjectArray(vector.size(), clazz, nullptr);
-  for (jsize i = 0; i < vector.size(); ++i)
+  const auto vector_size = static_cast<jsize>(vector.size());
+  jobjectArray result = env->NewObjectArray(vector_size, clazz, nullptr);
+  for (jsize i = 0; i < vector_size; ++i)
   {
     jobject obj = f(env, vector[i]);
     env->SetObjectArrayElement(result, i, obj);

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -373,7 +373,7 @@ void TraversalClient::HandleTraversalTest()
           waitCondition = 0;
           break;
         }
-        else if (rv < sizeof(packet) || raddr.host != m_ServerAddress.host ||
+        else if (rv < int(sizeof(packet)) || raddr.host != m_ServerAddress.host ||
                  raddr.host != m_portAlt || packet.requestId != m_TestRequestId)
         {
           // irrelevant packet, ignore

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -248,7 +248,7 @@ void Arm64GPRCache::FlushRegisters(BitSet32 regs, bool maintain_state, ARM64Reg 
     ASSERT_MSG(DYNA_REC, m_guest_registers[GUEST_GPR_OFFSET + i].GetType() != RegType::Discarded,
                "Attempted to flush discarded register");
 
-    if (i + 1 < GUEST_GPR_COUNT && regs[i + 1])
+    if (i + 1 < int(GUEST_GPR_COUNT) && regs[i + 1])
     {
       // We've got two guest registers in a row to store
       OpArg& reg1 = m_guest_registers[GUEST_GPR_OFFSET + i];

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -236,9 +236,9 @@ void JitArm64::twx(UGeckoInstruction inst)
   constexpr std::array<CCFlags, 5> conditions{{CC_LT, CC_GT, CC_EQ, CC_VC, CC_VS}};
   Common::SmallVector<FixupBranch, conditions.size()> fixups;
 
-  for (int i = 0; i < conditions.size(); i++)
+  for (size_t i = 0; i < conditions.size(); i++)
   {
-    if (inst.TO & (1 << i))
+    if (inst.TO & (1U << i))
     {
       FixupBranch f = B(conditions[i]);
       fixups.push_back(f);

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -598,7 +598,7 @@ void VertexManagerBase::Flush()
     std::optional<CustomPixelShader> custom_pixel_shader;
     std::vector<std::string> custom_pixel_texture_names;
     std::span<u8> custom_pixel_shader_uniforms;
-    for (int i = 0; i < texture_names.size(); i++)
+    for (size_t i = 0; i < texture_names.size(); i++)
     {
       const std::string& texture_name = texture_names[i];
       const u32 texture_unit = texture_units[i];

--- a/Source/UnitTests/Common/FloatUtilsTest.cpp
+++ b/Source/UnitTests/Common/FloatUtilsTest.cpp
@@ -85,7 +85,7 @@ TEST(FloatUtils, ApproximateReciprocalSquareRoot)
       0x7FF8'0000'0000'0000, 0x7FF8'0000'0000'0000, 0x3FEA'2040'0000'0000, 0x3FA0'3108'0000'0000,
       0x7FF8'0000'0000'0000};
 
-  for (int i = 0; i < double_test_values.size(); ++i)
+  for (size_t i = 0; i < double_test_values.size(); ++i)
   {
     u64 ivalue = double_test_values[i];
     double dvalue = Common::BitCast<double>(ivalue);


### PR DESCRIPTION
These spam the output log quite a bit (particularly the AndroidCommon one). These are easy enough to fix.