### PR TITLE
CustomAssetLibrary: Remove unused GetAssetSize() function

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomAssetLibrary.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLibrary.cpp
@@ -10,21 +10,6 @@
 
 namespace VideoCommon
 {
-namespace
-{
-std::size_t GetAssetSize(const CustomTextureData& data)
-{
-  std::size_t total = 0;
-  for (const auto& slice : data.m_slices)
-  {
-    for (const auto& level : slice.m_levels)
-    {
-      total += level.data.size();
-    }
-  }
-  return total;
-}
-}  // namespace
 CustomAssetLibrary::LoadInfo CustomAssetLibrary::LoadGameTexture(const AssetID& asset_id,
                                                                  TextureData* data)
 {


### PR DESCRIPTION
There's a direct analogue of this function within DirectFilesystemAssetLibrary that *is* used, however, so we can get rid of this one.