### PR TITLE
RiivolutionParser: Make use of std::span where applicable

### DIFF
--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -490,8 +490,8 @@ static void ApplyFolderPatchToFST(const Patch& patch, const Folder& folder,
   ApplyFolderPatchToFST(patch, folder, fst, dol_node, folder.m_disc, folder.m_external);
 }
 
-void ApplyPatchesToFiles(const std::vector<Patch>& patches, PatchIndex index,
-                         std::vector<DiscIO::FSTBuilderNode>* fst, DiscIO::FSTBuilderNode* dol_node)
+void ApplyPatchesToFiles(std::span<const Patch> patches, PatchIndex index,
+                         std::vector<FSTBuilderNode>* fst, FSTBuilderNode* dol_node)
 {
   for (const auto& patch : patches)
   {
@@ -509,7 +509,7 @@ void ApplyPatchesToFiles(const std::vector<Patch>& patches, PatchIndex index,
 }
 
 static bool MemoryMatchesAt(const Core::CPUThreadGuard& guard, u32 offset,
-                            const std::vector<u8>& value)
+                            std::span<const u8> value)
 {
   for (u32 i = 0; i < value.size(); ++i)
   {
@@ -521,7 +521,7 @@ static bool MemoryMatchesAt(const Core::CPUThreadGuard& guard, u32 offset,
 }
 
 static void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, u32 offset,
-                             const std::vector<u8>& value, const std::vector<u8>& original)
+                             std::span<const u8> value, std::span<const u8> original)
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
   if (::Config::Get(::Config::RA_HARDCORE_ENABLED))
@@ -622,10 +622,10 @@ static void ApplyOcarinaMemoryPatch(const Core::CPUThreadGuard& guard, const Pat
   }
 }
 
-void ApplyGeneralMemoryPatches(const Core::CPUThreadGuard& guard, const std::vector<Patch>& patches)
+void ApplyGeneralMemoryPatches(const Core::CPUThreadGuard& guard, std::span<const Patch> patches)
 {
-  auto& system = Core::System::GetInstance();
-  auto& system_memory = system.GetMemory();
+  const auto& system = Core::System::GetInstance();
+  const auto& system_memory = system.GetMemory();
 
   for (const auto& patch : patches)
   {
@@ -642,8 +642,8 @@ void ApplyGeneralMemoryPatches(const Core::CPUThreadGuard& guard, const std::vec
   }
 }
 
-void ApplyApploaderMemoryPatches(const Core::CPUThreadGuard& guard,
-                                 const std::vector<Patch>& patches, u32 ram_address, u32 ram_length)
+void ApplyApploaderMemoryPatches(const Core::CPUThreadGuard& guard, std::span<const Patch> patches,
+                                 u32 ram_address, u32 ram_length)
 {
   for (const auto& patch : patches)
   {
@@ -660,8 +660,7 @@ void ApplyApploaderMemoryPatches(const Core::CPUThreadGuard& guard,
   }
 }
 
-std::optional<SavegameRedirect>
-ExtractSavegameRedirect(const std::vector<Patch>& riivolution_patches)
+std::optional<SavegameRedirect> ExtractSavegameRedirect(std::span<const Patch> riivolution_patches)
 {
   for (const auto& patch : riivolution_patches)
   {

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -15,6 +15,7 @@
 #include "Common/IOFile.h"
 #include "Common/StringUtil.h"
 #include "Core/Config/AchievementSettings.h"
+#include "Core/Core.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/FS/FileSystem.h"
@@ -534,7 +535,7 @@ static void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, u32 offset,
   if (!original.empty() && !MemoryMatchesAt(guard, offset, original))
     return;
 
-  auto& system = Core::System::GetInstance();
+  auto& system = guard.GetSystem();
   const u32 size = static_cast<u32>(value.size());
   for (u32 i = 0; i < size; ++i)
     PowerPC::MMU::HostTryWriteU8(guard, value[i], offset + i);
@@ -590,7 +591,7 @@ static void ApplyOcarinaMemoryPatch(const Core::CPUThreadGuard& guard, const Pat
   if (value.empty())
     return;
 
-  auto& system = Core::System::GetInstance();
+  auto& system = guard.GetSystem();
   for (u32 i = 0; i < length; i += 4)
   {
     // first find the pattern
@@ -624,7 +625,7 @@ static void ApplyOcarinaMemoryPatch(const Core::CPUThreadGuard& guard, const Pat
 
 void ApplyGeneralMemoryPatches(const Core::CPUThreadGuard& guard, std::span<const Patch> patches)
 {
-  const auto& system = Core::System::GetInstance();
+  const auto& system = guard.GetSystem();
   const auto& system_memory = system.GetMemory();
 
   for (const auto& patch : patches)

--- a/Source/Core/DiscIO/RiivolutionPatcher.h
+++ b/Source/Core/DiscIO/RiivolutionPatcher.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -76,14 +77,10 @@ enum class PatchIndex
   DolphinSysFiles,
 };
 
-void ApplyPatchesToFiles(const std::vector<Patch>& patches, PatchIndex index,
-                         std::vector<DiscIO::FSTBuilderNode>* fst,
-                         DiscIO::FSTBuilderNode* dol_node);
-void ApplyGeneralMemoryPatches(const Core::CPUThreadGuard& guard,
-                               const std::vector<Patch>& patches);
-void ApplyApploaderMemoryPatches(const Core::CPUThreadGuard& guard,
-                                 const std::vector<Patch>& patches, u32 ram_address,
-                                 u32 ram_length);
-std::optional<SavegameRedirect>
-ExtractSavegameRedirect(const std::vector<Patch>& riivolution_patches);
+void ApplyPatchesToFiles(std::span<const Patch> patches, PatchIndex index,
+                         std::vector<FSTBuilderNode>* fst, FSTBuilderNode* dol_node);
+void ApplyGeneralMemoryPatches(const Core::CPUThreadGuard& guard, std::span<const Patch> patches);
+void ApplyApploaderMemoryPatches(const Core::CPUThreadGuard& guard, std::span<const Patch> patches,
+                                 u32 ram_address, u32 ram_length);
+std::optional<SavegameRedirect> ExtractSavegameRedirect(std::span<const Patch> riivolution_patches);
 }  // namespace DiscIO::Riivolution


### PR DESCRIPTION
The main interface for these only take in patches and iterate over them in a contiguous sequence, so we can reasonably generify the interface.

Also I noticed that there were a few global system `GetInstance()` calls present that could be removed via the use of CPUThreadGuard's GetSystem() member function instead, so those are included in a separate commit.