### PR TITLE
General: Make use of std::erase_if/std::erase where applicable

### DIFF
--- a/Source/Core/Common/Debug/Watches.cpp
+++ b/Source/Core/Common/Debug/Watches.cpp
@@ -43,9 +43,7 @@ const std::vector<Watch>& Watches::GetWatches() const
 
 void Watches::UnsetWatch(u32 address)
 {
-  m_watches.erase(std::remove_if(m_watches.begin(), m_watches.end(),
-                                 [address](const auto& watch) { return watch.address == address; }),
-                  m_watches.end());
+  std::erase_if(m_watches, [address](const auto& watch) { return watch.address == address; });
 }
 
 void Watches::UpdateWatch(std::size_t index, u32 address, std::string name)

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -997,13 +997,11 @@ void RunAllActive(const Core::CPUThreadGuard& cpu_guard)
   // are only atomic ops unless contested. It should be rare for this to
   // be contested.
   std::lock_guard guard(s_lock);
-  s_active_codes.erase(std::remove_if(s_active_codes.begin(), s_active_codes.end(),
-                                      [&cpu_guard](const ARCode& code) {
-                                        bool success = RunCodeLocked(cpu_guard, code);
-                                        LogInfo("\n");
-                                        return !success;
-                                      }),
-                       s_active_codes.end());
+  std::erase_if(s_active_codes, [&cpu_guard](const ARCode& code) {
+    const bool success = RunCodeLocked(cpu_guard, code);
+    LogInfo("\n");
+    return !success;
+  });
   s_disable_logging = true;
 }
 

--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -138,9 +138,7 @@ std::vector<GeckoCode> LoadCodes(const Common::IniFile& globalIni, const Common:
 
     GeckoCode gcode;
 
-    lines.erase(std::remove_if(lines.begin(), lines.end(),
-                               [](const auto& line) { return line.empty() || line[0] == '#'; }),
-                lines.end());
+    std::erase_if(lines, [](const auto& line) { return line.empty() || line[0] == '#'; });
 
     for (auto& line : lines)
     {

--- a/Source/Core/Core/HW/WiimoteEmu/I2CBus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/I2CBus.cpp
@@ -14,7 +14,7 @@ void I2CBus::AddSlave(I2CSlave* slave)
 
 void I2CBus::RemoveSlave(I2CSlave* slave)
 {
-  m_slaves.erase(std::remove(m_slaves.begin(), m_slaves.end(), slave), m_slaves.end());
+  std::erase(m_slaves, slave);
 }
 
 void I2CBus::Reset()

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -614,9 +614,7 @@ std::string SharedContentMap::AddSharedContent(const std::array<u8, 20>& sha1)
 
 bool SharedContentMap::DeleteSharedContent(const std::array<u8, 20>& sha1)
 {
-  m_entries.erase(std::remove_if(m_entries.begin(), m_entries.end(),
-                                 [&sha1](const auto& entry) { return entry.sha1 == sha1; }),
-                  m_entries.end());
+  std::erase_if(m_entries, [&sha1](const auto& entry) { return entry.sha1 == sha1; });
   return WriteEntries();
 }
 

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -556,7 +556,7 @@ NWC24::ErrorCode NetKDRequestDevice::KDSendMail()
       {
         LogError(ErrorType::SendMail, res);
       }
-      mails.erase(std::remove(mails.begin(), mails.end(), file_index), mails.end());
+      std::erase(mails, file_index);
       continue;
     }
 
@@ -574,7 +574,7 @@ NWC24::ErrorCode NetKDRequestDevice::KDSendMail()
         LogError(ErrorType::SendMail, res);
       }
 
-      mails.erase(std::remove(mails.begin(), mails.end(), file_index), mails.end());
+      std::erase(mails, file_index);
       continue;
     }
 

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -325,8 +325,7 @@ void AddMemoryPatch(std::size_t index)
 void RemoveMemoryPatch(std::size_t index)
 {
   std::lock_guard lock(s_on_frame_memory_mutex);
-  s_on_frame_memory.erase(std::remove(s_on_frame_memory.begin(), s_on_frame_memory.end(), index),
-                          s_on_frame_memory.end());
+  std::erase(s_on_frame_memory, index);
 }
 
 bool ApplyFramePatches()

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -250,9 +250,7 @@ SysConf::Entry* SysConf::GetOrAddEntry(std::string_view key, Entry::Type type)
 
 void SysConf::RemoveEntry(std::string_view key)
 {
-  m_entries.erase(std::remove_if(m_entries.begin(), m_entries.end(),
-                                 [&key](const auto& entry) { return entry.name == key; }),
-                  m_entries.end());
+  std::erase_if(m_entries, [&key](const auto& entry) { return entry.name == key; });
 }
 
 void SysConf::InsertDefaultEntries()

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -963,11 +963,9 @@ static ParseResult ParseComplexExpression(const std::string& str)
 
 void RemoveInertTokens(std::vector<Token>* tokens)
 {
-  tokens->erase(std::remove_if(tokens->begin(), tokens->end(),
-                               [](const Token& tok) {
-                                 return tok.type == TOK_COMMENT || tok.type == TOK_WHITESPACE;
-                               }),
-                tokens->end());
+  std::erase_if(*tokens, [](const Token& tok) {
+    return tok.type == TOK_COMMENT || tok.type == TOK_WHITESPACE;
+  });
 }
 
 static std::unique_ptr<Expression> ParseBarewordExpression(const std::string& str)

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -144,8 +144,7 @@ void RemoveSpuriousTriggerCombinations(
     });
   };
 
-  detections->erase(std::remove_if(detections->begin(), detections->end(), is_spurious),
-                    detections->end());
+  std::erase_if(*detections, is_spurious);
 }
 
 }  // namespace ciface::MappingCommon


### PR DESCRIPTION
In several cases, using std::erase_if or std::erase greatly simplifies a lot of code compared to the remove-erase idiom.

Put into separate commits, but can be squashed if necessary.