### PR TITLE
ExpressionParser: Get rid of some redundant copies

### DIFF
--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -438,7 +438,7 @@ protected:
 class LiteralReal : public LiteralExpression
 {
 public:
-  LiteralReal(ControlState value) : m_value(value) {}
+  explicit LiteralReal(ControlState value) : m_value(value) {}
 
   ControlState GetValue() const override { return m_value; }
 
@@ -460,7 +460,7 @@ static ParseResult MakeLiteralExpression(Token token)
 class VariableExpression : public Expression
 {
 public:
-  VariableExpression(std::string name) : m_name(name) {}
+  explicit VariableExpression(std::string name) : m_name(name) {}
 
   ControlState GetValue() const override { return m_variable_ptr ? *m_variable_ptr : 0; }
 
@@ -485,7 +485,7 @@ protected:
 class HotkeyExpression : public Expression
 {
 public:
-  HotkeyExpression(std::vector<std::unique_ptr<ControlExpression>> inputs)
+  explicit HotkeyExpression(std::vector<std::unique_ptr<ControlExpression>> inputs)
       : m_modifiers(std::move(inputs))
   {
     m_final_input = std::move(m_modifiers.back());

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -600,7 +600,7 @@ private:
   std::unique_ptr<Expression> m_rhs;
 };
 
-std::shared_ptr<Device> ControlEnvironment::FindDevice(ControlQualifier qualifier) const
+std::shared_ptr<Device> ControlEnvironment::FindDevice(const ControlQualifier& qualifier) const
 {
   if (qualifier.has_device)
     return container.FindDevice(qualifier.device_qualifier);
@@ -608,7 +608,7 @@ std::shared_ptr<Device> ControlEnvironment::FindDevice(ControlQualifier qualifie
     return container.FindDevice(default_device);
 }
 
-Device::Input* ControlEnvironment::FindInput(ControlQualifier qualifier) const
+Device::Input* ControlEnvironment::FindInput(const ControlQualifier& qualifier) const
 {
   const std::shared_ptr<Device> device = FindDevice(qualifier);
   if (!device)
@@ -617,7 +617,7 @@ Device::Input* ControlEnvironment::FindInput(ControlQualifier qualifier) const
   return device->FindInput(qualifier.control_name);
 }
 
-Device::Output* ControlEnvironment::FindOutput(ControlQualifier qualifier) const
+Device::Output* ControlEnvironment::FindOutput(const ControlQualifier& qualifier) const
 {
   const std::shared_ptr<Device> device = FindDevice(qualifier);
   if (!device)

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -248,7 +248,7 @@ ParseStatus Lexer::Tokenize(std::vector<Token>& tokens)
 class ControlExpression : public Expression
 {
 public:
-  explicit ControlExpression(ControlQualifier qualifier) : m_qualifier(qualifier) {}
+  explicit ControlExpression(ControlQualifier qualifier) : m_qualifier(std::move(qualifier)) {}
 
   ControlState GetValue() const override
   {
@@ -448,7 +448,7 @@ private:
   const ControlState m_value{};
 };
 
-static ParseResult MakeLiteralExpression(Token token)
+static ParseResult MakeLiteralExpression(const Token& token)
 {
   ControlState val{};
   if (TryParse(token.data, &val))
@@ -460,7 +460,7 @@ static ParseResult MakeLiteralExpression(Token token)
 class VariableExpression : public Expression
 {
 public:
-  explicit VariableExpression(std::string name) : m_name(name) {}
+  explicit VariableExpression(std::string name) : m_name(std::move(name)) {}
 
   ControlState GetValue() const override { return m_variable_ptr ? *m_variable_ptr : 0; }
 

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -150,9 +150,9 @@ public:
   {
   }
 
-  std::shared_ptr<Core::Device> FindDevice(ControlQualifier qualifier) const;
-  Core::Device::Input* FindInput(ControlQualifier qualifier) const;
-  Core::Device::Output* FindOutput(ControlQualifier qualifier) const;
+  std::shared_ptr<Core::Device> FindDevice(const ControlQualifier& qualifier) const;
+  Core::Device::Input* FindInput(const ControlQualifier& qualifier) const;
+  Core::Device::Output* FindOutput(const ControlQualifier& qualifier) const;
   // Returns an existing variable by the specified name if already existing. Creates it otherwise.
   std::shared_ptr<ControlState> GetVariablePtr(const std::string& name);
 


### PR DESCRIPTION
A few cases were making copies of ControlQualifier instances, which hold 3 strings, so we can be churning memory a little. We can instead pass those by reference or move them instead.