### PR TITLE
JitCommon: Fix feature_flags truncation in index calculation.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -507,7 +507,7 @@ size_t JitBaseBlockCache::FastLookupIndexForAddress(u32 address, u32 feature_fla
 {
   if (m_entry_points_ptr)
   {
-    return (feature_flags << 30) | (address >> 2);
+    return (static_cast<size_t>(feature_flags) << 30) | (address >> 2);
   }
   else
   {


### PR DESCRIPTION
Regression from 5.0-20555 / #11988.

This should fix the various 'games no longer boot' issues we've had recently such as
https://bugs.dolphin-emu.org/issues/13428
https://bugs.dolphin-emu.org/issues/13425
https://bugs.dolphin-emu.org/issues/13419

I have verified that Resident Evil works again, the others should be confirmed separately.