### PR TITLE
CheatSearchWidget: Make use of CPUThreadGuard parameter in UpdateTableRows()

### DIFF
--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -388,15 +388,10 @@ bool CheatSearchWidget::UpdateTableRows(const Core::CPUThreadGuard& guard, const
 {
   const bool update_status_text = source == UpdateSource::User;
 
-  std::unique_ptr<Cheats::CheatSearchSessionBase> tmp =
-      m_session->ClonePartial(begin_index, end_index);
+  auto tmp = m_session->ClonePartial(begin_index, end_index);
   tmp->SetFilterType(Cheats::FilterType::DoNotFilter);
 
-  const Cheats::SearchErrorCode error_code = [&tmp] {
-    Core::CPUThreadGuard guard(Core::System::GetInstance());
-    return tmp->RunSearch(guard);
-  }();
-
+  const Cheats::SearchErrorCode error_code = tmp->RunSearch(guard);
   if (error_code != Cheats::SearchErrorCode::Success)
   {
     if (update_status_text)


### PR DESCRIPTION
Previously, the parameter wasn't being used, because it was being shadowed by another CPUThreadGuard at its only would-be usage point.