### PR TITLE
CPUThreadConfigCallback: Mark static ID as [[maybe_unused]]

### DIFF
--- a/Source/Core/Core/CPUThreadConfigCallback.cpp
+++ b/Source/Core/Core/CPUThreadConfigCallback.cpp
@@ -44,7 +44,8 @@ namespace CPUThreadConfigCallback
 {
 ConfigChangedCallbackID AddConfigChangedCallback(Config::ConfigChangedCallback func)
 {
-  static auto s_config_changed_callback_id = Config::AddConfigChangedCallback(&OnConfigChanged);
+  [[maybe_unused]] static auto s_config_changed_callback_id =
+      Config::AddConfigChangedCallback(&OnConfigChanged);
 
   const ConfigChangedCallbackID callback_id{s_next_callback_id};
   ++s_next_callback_id;


### PR DESCRIPTION
This isn't used, but is likely kept around so the one-timed execution of a magic static is taken advantage of.

Technically this could also use `std::call_once` instead if that's a more preferable approach.

Resolves a -Wunused-but-set-variable warning.