### PR TITLE
General: Resolve -Wswitch warnings

### DIFF
--- a/Source/Core/Core/IOS/Crypto/Sha.cpp
+++ b/Source/Core/Core/IOS/Crypto/Sha.cpp
@@ -93,6 +93,10 @@ std::optional<IPCReply> ShaDevice::IOCtlV(const IOCtlVRequest& request)
       break;
 
     return_code = ProcessShaCommand(command, request);
+    break;
+
+  case ShaIoctlv::ShaCommandUnknown:
+    break;
   }
 
   return IPCReply(return_code);


### PR DESCRIPTION
Gets rid of a trivial warning with GCC by adding default handling for a missing enum value.