### PR TITLE
Common/Crypto: Resolve -Wignored-attributes warnings

### DIFF
--- a/Source/Core/Common/Crypto/AES.cpp
+++ b/Source/Core/Common/Crypto/AES.cpp
@@ -250,7 +250,19 @@ public:
   }
 
 private:
-  std::array<__m128i, NUM_ROUND_KEYS> round_keys;
+  // Ensures alignment specifiers are respected.
+  struct XmmReg
+  {
+    __m128i data;
+
+    XmmReg& operator=(const __m128i& m)
+    {
+      data = m;
+      return *this;
+    }
+    operator __m128i() const { return data; }
+  };
+  std::array<XmmReg, NUM_ROUND_KEYS> round_keys;
 };
 
 #endif

--- a/Source/Core/Common/Crypto/SHA1.cpp
+++ b/Source/Core/Common/Crypto/SHA1.cpp
@@ -166,7 +166,20 @@ public:
   }
 
 private:
-  using WorkBlock = CyclicArray<__m128i, 4>;
+  struct XmmReg
+  {
+    // Allows aliasing attributes to be respected in the
+    // face of templates.
+    __m128i data;
+
+    XmmReg& operator=(const __m128i& d)
+    {
+      data = d;
+      return *this;
+    }
+    operator __m128i() const { return data; }
+  };
+  using WorkBlock = CyclicArray<XmmReg, 4>;
 
   ATTRIBUTE_TARGET("ssse3")
   static inline __m128i byterev_16B(__m128i x)
@@ -244,7 +257,7 @@ private:
 
   virtual bool HwAccelerated() const override { return true; }
 
-  std::array<__m128i, 2> state{};
+  std::array<XmmReg, 2> state{};
 };
 
 #endif


### PR DESCRIPTION
The alias for `__m128i` is typically something like:

```cpp
typedef long long __m128i __attribute__((__vector_size__(16), __may_alias__));
```

and the part that ends up not getting preserved is the `__may_alias__` attribute specifier.

So, in order to preserve that, we can just use a wrapper struct, so the data type itself isn't being passed through the template.