### PR TITLE
Software/SWGfx: Default destructor in cpp file

### DIFF
--- a/Source/Core/VideoBackends/Software/SWGfx.cpp
+++ b/Source/Core/VideoBackends/Software/SWGfx.cpp
@@ -22,6 +22,8 @@ SWGfx::SWGfx(std::unique_ptr<SWOGLWindow> window) : m_window(std::move(window))
 {
 }
 
+SWGfx::~SWGfx() = default;
+
 bool SWGfx::IsHeadless() const
 {
   return m_window->IsHeadless();

--- a/Source/Core/VideoBackends/Software/SWGfx.h
+++ b/Source/Core/VideoBackends/Software/SWGfx.h
@@ -12,7 +12,8 @@ namespace SW
 class SWGfx final : public AbstractGfx
 {
 public:
-  SWGfx(std::unique_ptr<SWOGLWindow> window);
+  explicit SWGfx(std::unique_ptr<SWOGLWindow> window);
+  ~SWGfx() override;
 
   bool IsHeadless() const override;
   virtual bool SupportsUtilityDrawing() const override;


### PR DESCRIPTION
Fixes a build failure with clang 17.

The destructor needs to be in the cpp file, since we have a forward declared std::unique_ptr type as part of the class. So technically the default inline destructor could invoke without seeing the full data type definition.