### PR TITLE
DSPInterpreter: Mark IsProperlySignExtended() as [[maybe_unused]]

### DIFF
--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -589,7 +589,7 @@ void Interpreter::UpdateSR16(s16 value, bool carry, bool overflow, bool over_s32
   }
 }
 
-static constexpr bool IsProperlySignExtended(u64 val)
+[[maybe_unused]] static constexpr bool IsProperlySignExtended(u64 val)
 {
   const u64 topbits = val & 0xffff'ff80'0000'0000ULL;
   return (topbits == 0) || (0xffff'ff80'0000'0000ULL == topbits);


### PR DESCRIPTION
This function is used in debug asserts, so in release builds this will go unused and otherwise generate a warning.