### PR TITLE
Externals/mbedtls: Disable -Wdocumentation related warnings

### DIFF
--- a/Externals/mbedtls/library/CMakeLists.txt
+++ b/Externals/mbedtls/library/CMakeLists.txt
@@ -122,7 +122,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif(CMAKE_COMPILER_IS_GNUCC)
 
 if(CMAKE_COMPILER_IS_CLANG)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes -Wunreachable-code")
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(WIN32)


### PR DESCRIPTION
It's actually kind of wild that these flags are enabled by default for Clang. They produce an incredible amount of console output spam.

Let's remove them, especially since we've made other changes to this CMakeLists.txt

Just imagine pages and pages of this:
![image](https://github.com/dolphin-emu/dolphin/assets/712067/9866e46a-8287-4fc4-983f-fd418116e0bd)
