### PR TITLE
GBAWidget: Use std::span with SetVideoBuffer()

### DIFF
--- a/Source/Core/DolphinQt/GBAWidget.cpp
+++ b/Source/Core/DolphinQt/GBAWidget.cpp
@@ -106,7 +106,7 @@ void GBAWidget::GameChanged(const HW::GBA::CoreInfo& info)
   update();
 }
 
-void GBAWidget::SetVideoBuffer(std::vector<u32> video_buffer)
+void GBAWidget::SetVideoBuffer(std::span<const u32> video_buffer)
 {
   m_previous_frame = std::move(m_last_frame);
   if (video_buffer.size() == static_cast<size_t>(m_core_info.width * m_core_info.height))
@@ -608,7 +608,7 @@ void GBAWidgetController::GameChanged(const HW::GBA::CoreInfo& info)
   m_widget->GameChanged(info);
 }
 
-void GBAWidgetController::FrameEnded(std::vector<u32> video_buffer)
+void GBAWidgetController::FrameEnded(std::span<const u32> video_buffer)
 {
-  m_widget->SetVideoBuffer(std::move(video_buffer));
+  m_widget->SetVideoBuffer(video_buffer);
 }

--- a/Source/Core/DolphinQt/GBAWidget.h
+++ b/Source/Core/DolphinQt/GBAWidget.h
@@ -35,7 +35,7 @@ class GBAWidget : public QWidget
 public:
   explicit GBAWidget(std::weak_ptr<HW::GBA::Core> core, const HW::GBA::CoreInfo& info,
                      const std::optional<NetPlay::PadDetails>& netplay_pad);
-  ~GBAWidget();
+  ~GBAWidget() override;
 
   void GameChanged(const HW::GBA::CoreInfo& info);
   void SetVideoBuffer(std::span<const u32> video_buffer);
@@ -103,7 +103,7 @@ class GBAWidgetController : public QObject
   Q_OBJECT
 public:
   explicit GBAWidgetController() = default;
-  ~GBAWidgetController();
+  ~GBAWidgetController() override;
 
   void Create(std::weak_ptr<HW::GBA::Core> core, const HW::GBA::CoreInfo& info);
   void GameChanged(const HW::GBA::CoreInfo& info);

--- a/Source/Core/DolphinQt/GBAWidget.h
+++ b/Source/Core/DolphinQt/GBAWidget.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -37,7 +38,7 @@ public:
   ~GBAWidget();
 
   void GameChanged(const HW::GBA::CoreInfo& info);
-  void SetVideoBuffer(std::vector<u32> video_buffer);
+  void SetVideoBuffer(std::span<const u32> video_buffer);
 
   void SetVolume(int volume);
   void VolumeDown();
@@ -106,7 +107,7 @@ public:
 
   void Create(std::weak_ptr<HW::GBA::Core> core, const HW::GBA::CoreInfo& info);
   void GameChanged(const HW::GBA::CoreInfo& info);
-  void FrameEnded(std::vector<u32> video_buffer);
+  void FrameEnded(std::span<const u32> video_buffer);
 
 private:
   GBAWidget* m_widget{};


### PR DESCRIPTION
Previously we were always taking the buffer by value, even if it wasn't being stored anywhere and only read from.

We can use a std::span for the same thing.

Gets rid of a redundant copy of the video buffer in `GBAHost::FrameEnded()`