### PR TITLE
Externals/expr: Resolve -Wshadow warning

### DIFF
--- a/Externals/expr/include/expr.h
+++ b/Externals/expr/include/expr.h
@@ -826,14 +826,14 @@ static struct expr *expr_create(const char *s, size_t len,
       vec_push(&es, expr_const(num));
       paren_next = EXPR_PAREN_FORBIDDEN;
     } else if (n > 1 && *tok == '"') {
-      char *s = (char *)calloc(1, n - 1);
-      if (s == NULL) {
+      char *str = (char *)calloc(1, n - 1);
+      if (str == NULL) {
         goto cleanup; /* allocation failed */
       }
-      strncpy(s, tok + 1, n - 2);
+      strncpy(str, tok + 1, n - 2);
       struct expr e = expr_init();
       e.type = OP_STRING;
-      e.param.str.s = s;
+      e.param.str.s = str;
       vec_push(&es, e);
       paren_next = EXPR_PAREN_FORBIDDEN;
     } else if (expr_op(tok, n, -1) != OP_UNKNOWN) {


### PR DESCRIPTION
We already made changes to this library, so we can also resolve the lone shadowing warning within it

With this, most warnings for code that we control are all gone.

The main warnings left over are from mgba and cubeb (which both should *really* be checking if they're the top-level project, and disabling warnings for their code respectively if not)