### PR TITLE
GameListModel: Remove fallthrough in data()

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -195,6 +195,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
 
       return tags.join(QStringLiteral(", "));
     }
+    break;
   default:
     break;
   }


### PR DESCRIPTION
A harmless case of it, but this can still cause warnings.