### PR TITLE
SysConf: std::move fs pointer in constructor

### DIFF
--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -36,7 +36,7 @@ static size_t GetNonArrayEntrySize(SysConf::Entry::Type type)
     return 0;
   }
 }
-SysConf::SysConf(std::shared_ptr<IOS::HLE::FS::FileSystem> fs) : m_fs{fs}
+SysConf::SysConf(std::shared_ptr<IOS::HLE::FS::FileSystem> fs) : m_fs{std::move(fs)}
 {
   Load();
 }


### PR DESCRIPTION
Just gets rid of a trivial atomic reference count increment and decrement. Not a super heavyweight thing, but it is essentially "free" to get rid of.