### PR TITLE
MTLStateTracker: Increase fragment buffer array size to 3

### DIFF
--- a/Source/Core/VideoBackends/Metal/MTLStateTracker.h
+++ b/Source/Core/VideoBackends/Metal/MTLStateTracker.h
@@ -237,7 +237,7 @@ private:
     NSString* label;
     id<MTLRenderPipelineState> pipeline;
     std::array<id<MTLBuffer>, 2> vertex_buffers;
-    std::array<id<MTLBuffer>, 2> fragment_buffers;
+    std::array<id<MTLBuffer>, 3> fragment_buffers;
     u32 width;
     u32 height;
     MathUtil::Rectangle<int> scissor_rect;


### PR DESCRIPTION
We're now hitting an out-of-bounds write assert in `RelWithDebInfo` builds after upgrading macOS to 14.2 and Xcode to 15.1. (found by @TellowKrinkle)