### PR TITLE
WC24PatchEngine: Move IniFile header dependency into the cpp file

### DIFF
--- a/Source/Core/Core/WC24PatchEngine.cpp
+++ b/Source/Core/Core/WC24PatchEngine.cpp
@@ -4,17 +4,19 @@
 // WC24PatchEngine
 // Allows for replacing URLs used in WC24 requests
 
+#include "Core/WC24PatchEngine.h"
+
 #include <algorithm>
 #include <array>
 #include <fmt/format.h>
 
+#include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 
 #include "Core/CheatCodes.h"
 #include "Core/CommonTitles.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
-#include "Core/WC24PatchEngine.h"
 
 namespace WC24PatchEngine
 {
@@ -38,7 +40,7 @@ static constexpr std::array<u64, 15> s_wc24_channels{
 
 static std::vector<NetworkPatch> s_patches;
 
-bool DeserializeLine(const std::string& line, NetworkPatch* patch)
+static bool DeserializeLine(const std::string& line, NetworkPatch* patch)
 {
   const std::vector<std::string> items = SplitString(line, ':');
 
@@ -54,13 +56,13 @@ bool DeserializeLine(const std::string& line, NetworkPatch* patch)
   return patch;
 }
 
-void LoadPatchSection(const Common::IniFile& ini)
+static void LoadPatchSection(const Common::IniFile& ini)
 {
   std::vector<std::string> lines;
   NetworkPatch patch;
   ini.GetLines("WC24Patch", &lines);
 
-  for (std::string& line : lines)
+  for (const std::string& line : lines)
   {
     if (line.empty())
       continue;
@@ -81,6 +83,15 @@ void LoadPatchSection(const Common::IniFile& ini)
   ReadEnabledAndDisabled(ini, "WC24Patch", &s_patches);
 }
 
+static bool IsWC24Channel()
+{
+  const auto& sconfig = SConfig::GetInstance();
+  const auto found =
+      std::find(s_wc24_channels.begin(), s_wc24_channels.end(), sconfig.GetTitleID());
+
+  return found != s_wc24_channels.end();
+}
+
 static void LoadPatches()
 {
   const auto& sconfig = SConfig::GetInstance();
@@ -96,15 +107,6 @@ static void LoadPatches()
     ini = sconfig.LoadLocalGameIni();
 
   LoadPatchSection(ini);
-}
-
-bool IsWC24Channel()
-{
-  const auto& sconfig = SConfig::GetInstance();
-  const auto found =
-      std::find(s_wc24_channels.begin(), s_wc24_channels.end(), sconfig.GetTitleID());
-
-  return found != s_wc24_channels.end();
 }
 
 void Reload()

--- a/Source/Core/Core/WC24PatchEngine.cpp
+++ b/Source/Core/Core/WC24PatchEngine.cpp
@@ -115,7 +115,7 @@ void Reload()
   LoadPatches();
 }
 
-std::optional<std::string> GetNetworkPatch(const std::string& source, IsKD is_kd)
+std::optional<std::string> GetNetworkPatch(std::string_view source, IsKD is_kd)
 {
   const auto patch =
       std::find_if(s_patches.begin(), s_patches.end(), [&source, &is_kd](const NetworkPatch& p) {

--- a/Source/Core/Core/WC24PatchEngine.h
+++ b/Source/Core/Core/WC24PatchEngine.h
@@ -6,8 +6,6 @@
 #include <optional>
 #include <string>
 
-#include "Common/IniFile.h"
-
 namespace WC24PatchEngine
 {
 enum class IsKD : bool;
@@ -22,9 +20,7 @@ struct NetworkPatch final
 };
 
 void Reload();
-bool DeserializeLine(const std::string& line, NetworkPatch* patch);
-bool IsWC24Channel();
-void LoadPatchSection(const Common::IniFile& ini);
+
 std::optional<std::string> GetNetworkPatch(const std::string& source, IsKD is_kd);
 std::optional<std::string> GetNetworkPatchByPayload(std::string_view source);
 }  // namespace WC24PatchEngine

--- a/Source/Core/Core/WC24PatchEngine.h
+++ b/Source/Core/Core/WC24PatchEngine.h
@@ -21,6 +21,6 @@ struct NetworkPatch final
 
 void Reload();
 
-std::optional<std::string> GetNetworkPatch(const std::string& source, IsKD is_kd);
+std::optional<std::string> GetNetworkPatch(std::string_view source, IsKD is_kd);
 std::optional<std::string> GetNetworkPatchByPayload(std::string_view source);
 }  // namespace WC24PatchEngine


### PR DESCRIPTION
Also makes a few functions internally linked, considering they're only used within the implementation.

