### PR TITLE
WiiNetConfig: Eliminate usages of the global system accessor

### DIFF
--- a/Source/Core/Core/IOS/Network/NCD/Manage.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.cpp
@@ -87,24 +87,24 @@ std::optional<IPCReply> NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
 
   case IOCTLV_NCD_GETCONFIG:
     INFO_LOG_FMT(IOS_NET, "NET_NCD_MANAGE: IOCTLV_NCD_GETCONFIG");
-    config.WriteToMem(request.io_vectors.at(0).address);
+    config.WriteToMem(memory, request.io_vectors.at(0).address);
     common_vector = 1;
     break;
 
   case IOCTLV_NCD_SETCONFIG:
     INFO_LOG_FMT(IOS_NET, "NET_NCD_MANAGE: IOCTLV_NCD_SETCONFIG");
-    config.ReadFromMem(request.in_vectors.at(0).address);
+    config.ReadFromMem(memory, request.in_vectors.at(0).address);
     break;
 
   case IOCTLV_NCD_READCONFIG:
     INFO_LOG_FMT(IOS_NET, "NET_NCD_MANAGE: IOCTLV_NCD_READCONFIG");
     config.ReadConfig(m_ios.GetFS().get());
-    config.WriteToMem(request.io_vectors.at(0).address);
+    config.WriteToMem(memory, request.io_vectors.at(0).address);
     break;
 
   case IOCTLV_NCD_WRITECONFIG:
     INFO_LOG_FMT(IOS_NET, "NET_NCD_MANAGE: IOCTLV_NCD_WRITECONFIG");
-    config.ReadFromMem(request.in_vectors.at(0).address);
+    config.ReadFromMem(memory, request.in_vectors.at(0).address);
     config.WriteConfig(m_ios.GetFS().get());
     break;
 

--- a/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
@@ -12,7 +12,6 @@
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/Uids.h"
-#include "Core/System.h"
 
 namespace IOS::HLE::Net
 {
@@ -52,17 +51,13 @@ void WiiNetConfig::ResetConfig(FS::FileSystem* fs)
   WriteConfig(fs);
 }
 
-void WiiNetConfig::WriteToMem(const u32 address) const
+void WiiNetConfig::WriteToMem(Memory::MemoryManager& memory, const u32 address) const
 {
-  auto& system = Core::System::GetInstance();
-  auto& memory = system.GetMemory();
   memory.CopyToEmu(address, &m_data, sizeof(m_data));
 }
 
-void WiiNetConfig::ReadFromMem(const u32 address)
+void WiiNetConfig::ReadFromMem(const Memory::MemoryManager& memory, const u32 address)
 {
-  auto& system = Core::System::GetInstance();
-  auto& memory = system.GetMemory();
   memory.CopyFromEmu(&m_data, address, sizeof(m_data));
 }
 }  // namespace IOS::HLE::Net

--- a/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.h
+++ b/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.h
@@ -6,6 +6,11 @@
 #include <string>
 #include "Common/CommonTypes.h"
 
+namespace Memory
+{
+class MemoryManager;
+}
+
 namespace IOS::HLE
 {
 namespace FS
@@ -111,8 +116,8 @@ public:
   void WriteConfig(FS::FileSystem* fs) const;
   void ResetConfig(FS::FileSystem* fs);
 
-  void WriteToMem(u32 address) const;
-  void ReadFromMem(u32 address);
+  void WriteToMem(Memory::MemoryManager& memory, u32 address) const;
+  void ReadFromMem(const Memory::MemoryManager& memory, u32 address);
 
 private:
 // Data layout of the network configuration file (/shared2/sys/net/02/config.dat)


### PR DESCRIPTION
We can pass in the existing system instance from the ncd/manage instance.