### PR TITLE
HW/CPU: Remove remaining global system accessors

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -175,11 +175,10 @@ void CPUManager::Run()
 void CPUManager::RunAdjacentSystems(bool running)
 {
   // NOTE: We're assuming these will not try to call Break or EnableStepping.
-  auto& system = Core::System::GetInstance();
-  system.GetFifo().EmulatorState(running);
+  m_system.GetFifo().EmulatorState(running);
   // Core is responsible for shutting down the sound stream.
   if (m_state != State::PowerDown)
-    AudioCommon::SetSoundStreamRunning(Core::System::GetInstance(), running);
+    AudioCommon::SetSoundStreamRunning(m_system, running);
 }
 
 void CPUManager::Stop()


### PR DESCRIPTION
We can just pass in the m_system member instead.