### PR TITLE
MMU: Implement memory protection support

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -294,11 +294,12 @@ void CachedInterpreter::Jit(u32 address)
 
   const u32 nextPC =
       analyzer.Analyze(m_ppc_state.pc, &code_block, &m_code_buffer, m_code_buffer.size());
-  if (code_block.m_memory_exception)
+  if (code_block.m_memory_exception != 0)
   {
     // Address of instruction could not be translated
     m_ppc_state.npc = nextPC;
     m_ppc_state.Exceptions |= EXCEPTION_ISI;
+    SRR1(m_ppc_state) = code_block.m_memory_exception;
     m_system.GetPowerPC().CheckExceptions();
     WARN_LOG_FMT(POWERPC, "ISI exception at {:#010x}", nextPC);
     return;

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -930,7 +930,8 @@ enum CPUEmuFeatureFlags : u32
 {
   FEATURE_FLAG_MSR_DR = 1 << 0,
   FEATURE_FLAG_MSR_IR = 1 << 1,
-  FEATURE_FLAG_PERFMON = 1 << 2,
+  FEATURE_FLAG_MSR_PR = 1 << 2,
+  FEATURE_FLAG_PERFMON = 1 << 3,
 };
 
 constexpr s32 SignExt16(s16 x)

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -796,11 +796,12 @@ void Jit64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
   // instructions.
   const u32 nextPC = analyzer.Analyze(em_address, &code_block, &m_code_buffer, block_size);
 
-  if (code_block.m_memory_exception)
+  if (code_block.m_memory_exception != 0)
   {
     // Address of instruction could not be translated
     m_ppc_state.npc = nextPC;
     m_ppc_state.Exceptions |= EXCEPTION_ISI;
+    SRR1(m_ppc_state) = code_block.m_memory_exception;
     m_system.GetPowerPC().CheckExceptions();
     m_system.GetJitInterface().UpdateMembase();
     WARN_LOG_FMT(POWERPC, "ISI exception at {:#010x}", nextPC);

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -441,14 +441,14 @@ void EmuCodeBlock::SafeLoadToRegImmediate(X64Reg reg_value, u32 address, int acc
                                           BitSet32 registersInUse, bool signExtend)
 {
   // If the address is known to be RAM, just load it directly.
-  if (m_jit.jo.fastmem_arena && m_jit.m_mmu.IsOptimizableRAMAddress(address))
+  if (m_jit.jo.fastmem_arena && m_jit.m_mmu.IsOptimizableRAMAddress(address, false))
   {
     UnsafeLoadToReg(reg_value, Imm32(address), accessSize, 0, signExtend);
     return;
   }
 
   // If the address maps to an MMIO register, inline MMIO read code.
-  u32 mmioAddress = m_jit.m_mmu.IsOptimizableMMIOAccess(address, accessSize);
+  u32 mmioAddress = m_jit.m_mmu.IsOptimizableMMIOAccess(address, accessSize, false);
   if (accessSize != 64 && mmioAddress)
   {
     auto& memory = m_jit.m_system.GetMemory();
@@ -656,7 +656,7 @@ bool EmuCodeBlock::WriteToConstAddress(int accessSize, OpArg arg, u32 address,
     m_jit.js.fifoBytesSinceCheck += accessSize >> 3;
     return false;
   }
-  else if (m_jit.jo.fastmem_arena && m_jit.m_mmu.IsOptimizableRAMAddress(address))
+  else if (m_jit.jo.fastmem_arena && m_jit.m_mmu.IsOptimizableRAMAddress(address, true))
   {
     WriteToConstRamAddress(accessSize, arg, address);
     return false;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -952,11 +952,12 @@ void JitArm64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
   // instructions.
   const u32 nextPC = analyzer.Analyze(em_address, &code_block, &m_code_buffer, block_size);
 
-  if (code_block.m_memory_exception)
+  if (code_block.m_memory_exception != 0)
   {
     // Address of instruction could not be translated
     m_ppc_state.npc = nextPC;
     m_ppc_state.Exceptions |= EXCEPTION_ISI;
+    SRR1(m_ppc_state) = code_block.m_memory_exception;
     m_system.GetPowerPC().CheckExceptions();
     m_system.GetJitInterface().UpdateMembase();
     WARN_LOG_FMT(POWERPC, "ISI exception at {:#010x}", nextPC);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -134,9 +134,9 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
   u32 access_size = BackPatchInfo::GetFlagSize(flags);
   u32 mmio_address = 0;
   if (is_immediate)
-    mmio_address = m_mmu.IsOptimizableMMIOAccess(imm_addr, access_size);
+    mmio_address = m_mmu.IsOptimizableMMIOAccess(imm_addr, access_size, false);
 
-  if (is_immediate && m_mmu.IsOptimizableRAMAddress(imm_addr))
+  if (is_immediate && m_mmu.IsOptimizableRAMAddress(imm_addr, false))
   {
     set_addr_reg_if_needed();
     EmitBackpatchRoutine(flags, MemAccessMode::AlwaysFastAccess, dest_reg, XA, regs_in_use,
@@ -280,7 +280,7 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
   u32 access_size = BackPatchInfo::GetFlagSize(flags);
   u32 mmio_address = 0;
   if (is_immediate)
-    mmio_address = m_mmu.IsOptimizableMMIOAccess(imm_addr, access_size);
+    mmio_address = m_mmu.IsOptimizableMMIOAccess(imm_addr, access_size, true);
 
   if (is_immediate && jo.optimizeGatherPipe && m_mmu.IsOptimizableGatherPipeWrite(imm_addr))
   {
@@ -308,7 +308,7 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
 
     js.fifoBytesSinceCheck += accessSize >> 3;
   }
-  else if (is_immediate && m_mmu.IsOptimizableRAMAddress(imm_addr))
+  else if (is_immediate && m_mmu.IsOptimizableRAMAddress(imm_addr, true))
   {
     set_addr_reg_if_needed();
     EmitBackpatchRoutine(flags, MemAccessMode::AlwaysFastAccess, RS, XA, regs_in_use, fprs_in_use);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -174,7 +174,7 @@ void JitArm64::lfXX(UGeckoInstruction inst)
   if (!jo.memcheck)
     fprs_in_use[DecodeReg(VD)] = 0;
 
-  if (is_immediate && m_mmu.IsOptimizableRAMAddress(imm_addr))
+  if (is_immediate && m_mmu.IsOptimizableRAMAddress(imm_addr, false))
   {
     EmitBackpatchRoutine(flags, MemAccessMode::AlwaysFastAccess, VD, XA, regs_in_use, fprs_in_use);
   }
@@ -399,7 +399,7 @@ void JitArm64::stfXX(UGeckoInstruction inst)
       STR(IndexType::Unsigned, ARM64Reg::X2, PPC_REG, PPCSTATE_OFF(gather_pipe_ptr));
       js.fifoBytesSinceCheck += accessSize >> 3;
     }
-    else if (m_mmu.IsOptimizableRAMAddress(imm_addr))
+    else if (m_mmu.IsOptimizableRAMAddress(imm_addr, true))
     {
       set_addr_reg_if_needed();
       EmitBackpatchRoutine(flags, MemAccessMode::AlwaysFastAccess, V0, XA, regs_in_use,

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -130,8 +130,8 @@ class JitBaseBlockCache
 {
 public:
   // The size of the fast map is determined like this:
-  // ((4 GiB guest memory space) / (4-byte alignment) * sizeof(JitBlock*)) << (3 feature flag bits)
-  static constexpr u64 FAST_BLOCK_MAP_SIZE = 0x10'0000'0000;
+  // ((4 GiB guest memory space) / (4-byte alignment) * sizeof(JitBlock*)) << (4 feature flag bits)
+  static constexpr u64 FAST_BLOCK_MAP_SIZE = 0x20'0000'0000;
   static constexpr u32 FAST_BLOCK_MAP_FALLBACK_ELEMENTS = 0x10000;
   static constexpr u32 FAST_BLOCK_MAP_FALLBACK_MASK = FAST_BLOCK_MAP_FALLBACK_ELEMENTS - 1;
 

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -809,7 +809,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
 
   // Reset our block state
   block->m_broken = false;
-  block->m_memory_exception = false;
+  block->m_memory_exception = 0;
   block->m_num_instructions = 0;
   block->m_gqr_used = BitSet8(0);
   block->m_physical_addresses.clear();
@@ -831,7 +831,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
     if (!result.valid)
     {
       if (i == 0)
-        block->m_memory_exception = true;
+        block->m_memory_exception = static_cast<u32>(result.error);
       break;
     }
 

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -117,9 +117,6 @@ struct CodeBlock
   // Are we a broken block?
   bool m_broken = false;
 
-  // Did we have a memory_exception?
-  bool m_memory_exception = false;
-
   // Which GQRs this block uses, if any.
   BitSet8 m_gqr_used;
 
@@ -128,6 +125,11 @@ struct CodeBlock
 
   // Which GPRs this block reads from before defining, if any.
   BitSet32 m_gpr_inputs;
+
+  // Memory exception type.
+  // Same possiblities as PowerPC::MemoryExceptionType in MMU.h.
+  // That is, zero means success, non-zero means SRR1 value.
+  u32 m_memory_exception = 0;
 
   // Which memory locations are occupied by this block.
   std::set<u32> m_physical_addresses;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -95,7 +95,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 165;  // Last changed in PR 12328
+constexpr u32 STATE_VERSION = 166;  // Last changed in PR 12426
 
 // Increase this if the StateExtendedHeader definition changes
 constexpr u32 EXTENDED_HEADER_VERSION = 1;  // Last changed in PR 12217


### PR DESCRIPTION
- Added support for using PP bits and user/supervisor mode enable (VsVp) bits in BATs and page tables
- Added support for raising the correct DSI/ISI exception (in JITs/PPCAnalyst/etc too)
- IsOptimizable*Address checks BAT page protection, and falls back to slow code if access would raise exception due to page protection
- Added feature flag for MSR[PR] so JIT cache is separate for user mode and supervisor mode

I'm not sure if this is 100% correct (I implemented based on [PowerPC Microprocessor Family: The Programming Environments](https://www.nxp.com/docs/en/user-guide/MPCFPE_AD_R1.pdf)).
This allows wii-linux-poc 0.1 and 0.2 to boot successfully, and the usb gecko console works fine for both. (wii-linux-poc 0.3 and above still don't work, they deadlock trying to make IOS IPC calls, I haven't really investigated more than that)
I also checked against Wii System Menu and the Homebrew Channel (as examples of official and unofficial code) and both appeared to work fine without anything breaking.
I'm not sure what if anything breaks with this implementation as it is currently.