### PR TITLE
JitArm64: Add rlwinmx case for only shifting

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -784,6 +784,10 @@ void JitArm64::rlwinmx(UGeckoInstruction inst)
     // Immediate mask
     AND(gpr.R(a), gpr.R(s), LogicalImm(mask, 32));
   }
+  else if (mask == 0xFFFFFFFF)
+  {
+    ROR(gpr.R(a), gpr.R(s), 32 - inst.SH);
+  }
   else if (inst.ME == 31 && 31 < inst.SH + inst.MB)
   {
     // Bit select of the upper part


### PR DESCRIPTION
Small optimization.