### PR TITLE
JitArm64: Use 64-bit register for address in mtsrin

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -209,8 +209,8 @@ void JitArm64::mtsrin(UGeckoInstruction inst)
   ARM64Reg addr = gpr.GetReg();
 
   UBFM(index, RB, 28, 31);
-  ADDI2R(addr, PPC_REG, PPCSTATE_OFF_SR(0), addr);
-  STR(RD, addr, ArithOption(EncodeRegTo64(index), true));
+  ADDI2R(EncodeRegTo64(addr), PPC_REG, PPCSTATE_OFF_SR(0), EncodeRegTo64(addr));
+  STR(RD, EncodeRegTo64(addr), ArithOption(EncodeRegTo64(index), true));
 
   gpr.Unlock(index, addr);
 }


### PR DESCRIPTION
Fixes a regression from PR #12124 that, depending on the host memory layout, could cause either a host crash or a guest crash when running F-Zero GX.