### PR TITLE
GameSettings: fix C4 texture tiling in Crash Nitro Kart

### DIFF
--- a/Data/Sys/GameSettings/GC8JA4.ini
+++ b/Data/Sys/GameSettings/GC8JA4.ini
@@ -1,4 +1,4 @@
-# GCNE7D, GCNP7D - Crash Nitro Kart
+# GC8JA4 - ｸﾗｯｼｭ･ﾊﾞﾝﾃﾞｨｸｰ 爆走！ニトロカート
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -16,10 +16,9 @@ $Fix C4 texture tiling (used for buttons and some character icons)
 04003290 5108452E
 04003294 5508E13E
 04003298 4E800020
-040CC574 4BF36D19
+040CA1B4 4BF390D9
 
 [Video_Settings]
 
 [Video_Hacks]
 ImmediateXFBEnable = False
-


### PR DESCRIPTION
For buttons and some character icons the game loads palleted PNGs and tiles the pallet indices directly into C4 textures but fails to take into account that PNG and C4 use opposite nibble orders. This causes adjacent pixel columns to be swapped, see [issue 13370](https://bugs.dolphin-emu.org/issues/13370).

Also disable Immediate XFB for the Japanese release. It has the same black screen and flickering issues as the other regions.

Before:
![broken](https://github.com/dolphin-emu/dolphin/assets/123798/85923e06-f106-41d7-a83d-018fd861ff53)

After:
![fixed](https://github.com/dolphin-emu/dolphin/assets/123798/09207a55-d03a-4f64-a8a0-a8340161f318)
