### PR TITLE
Fix sharp bilinear using ceil instead of floor

### DIFF
--- a/Data/Sys/Shaders/default_pre_post_process.glsl
+++ b/Data/Sys/Shaders/default_pre_post_process.glsl
@@ -173,7 +173,7 @@ float4 SharpBilinearSample(float3 uvw, float gamma)
 	float2 texel = uvw.xy * source_size;
 	float2 texel_floored = floor(texel);
 	float2 s = fract(texel);
-	float scale = ceil(max(target_size.x * inverted_source_size.x, target_size.y * inverted_source_size.y));
+	float scale = max(floor(max(target_size.x * inverted_source_size.x, target_size.y * inverted_source_size.y)), 1.f);
 	float region_range = 0.5 - (0.5 / scale);
 
 	// Figure out where in the texel to sample to get correct pre-scaled bilinear.


### PR DESCRIPTION
I noticed sharp bilinear was shifting pixels around when the dolphin emulation output image resolution exactly matched the window size (like, no rescaling at all, at native game resolution).
The top part of the image would shift up and the bottom one would shift down. Any other resampling method wasn't affected by this. I checked the reference code that inspired the feature, and noticed we used ceil instead of floor.
https://github.com/libretro/slang-shaders/blob/0830c831ce18cdd144d8447dc2bec8de498bd237/interpolation/shaders/sharp-bilinear-simple.slang
Flooring seems to make it look better in all cases from what I could see, and it's now even more similar to area resampling.

Video showcasing the problem (and how the fix behaves):
https://github.com/dolphin-emu/dolphin/assets/7011366/f4c8f111-8609-439c-8ebf-776e6cc0cb58

