### PR TITLE
Fix aspect ratio heuristics getting stuck to a state

### DIFF
--- a/Source/Core/VideoCommon/Widescreen.h
+++ b/Source/Core/VideoCommon/Widescreen.h
@@ -24,12 +24,21 @@ public:
   void DoState(PointerWrap& p);
 
 private:
-  void Update();
+  enum class HeuristicState
+  {
+    Inactive,
+    Active_NotFound,
+    Active_Found_Normal,
+    Active_Found_Anamorphic,
+  };
+
+  // Returns whether the widescreen state wants to change, and its target value
+  std::optional<bool> GetWidescreenOverride() const;
   void UpdateWidescreenHeuristic();
 
   bool m_is_game_widescreen = false;
   bool m_was_orthographically_anamorphic = false;
-  bool m_widescreen_heuristics_active_and_successful = false;
+  HeuristicState m_heuristic_state = HeuristicState::Inactive;
 
   Common::EventHook m_update_widescreen;
   Common::EventHook m_config_changed;

--- a/Source/Core/VideoCommon/Widescreen.h
+++ b/Source/Core/VideoCommon/Widescreen.h
@@ -29,6 +29,7 @@ private:
 
   bool m_is_game_widescreen = false;
   bool m_was_orthographically_anamorphic = false;
+  bool m_widescreen_heuristics_active_and_successful = false;
 
   Common::EventHook m_update_widescreen;
   Common::EventHook m_config_changed;


### PR DESCRIPTION
Fix aspect ratio heuristics getting stuck to widescreen (or to non widescreen) (`m_is_game_widescreen` variable) if the user first forced the aspect ratio to 16:9/4:3 and then set it back to Auto.

This specifically happens in games 2D main menus, which have no 3D graphics so the aspect ratio heuristics fail to determine whether the game was widescreen or not. The behaviour can be replicated in _The Legend of Zelda: Four Swords Adventures_ 60Hz mode.

Video showcasing the problem:
https://github.com/dolphin-emu/dolphin/assets/7011366/fad3c4e3-ba1b-4c09-89f4-976ec3fac3d1
