### PR TITLE
Frame dump at raw internal resolution

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -72,7 +72,7 @@ const Info<std::string> GFX_DUMP_PATH{{System::GFX, "Settings", "DumpPath"}, ""}
 const Info<int> GFX_BITRATE_KBPS{{System::GFX, "Settings", "BitrateKbps"}, 25000};
 const Info<FrameDumpResolutionType> GFX_FRAME_DUMPS_RESOLUTION_TYPE{
     {System::GFX, "Settings", "FrameDumpsResolutionType"},
-    FrameDumpResolutionType::XFB_ASPECT_RATIO_CORRECTED_RESOLUTION};
+    FrameDumpResolutionType::XFBAspectRatioCorrectedResolution};
 const Info<int> GFX_PNG_COMPRESSION_LEVEL{{System::GFX, "Settings", "PNGCompressionLevel"}, 6};
 const Info<bool> GFX_ENABLE_GPU_TEXTURE_DECODING{
     {System::GFX, "Settings", "EnableGPUTextureDecoding"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -70,8 +70,9 @@ const Info<std::string> GFX_DUMP_PIXEL_FORMAT{{System::GFX, "Settings", "DumpPix
 const Info<std::string> GFX_DUMP_ENCODER{{System::GFX, "Settings", "DumpEncoder"}, ""};
 const Info<std::string> GFX_DUMP_PATH{{System::GFX, "Settings", "DumpPath"}, ""};
 const Info<int> GFX_BITRATE_KBPS{{System::GFX, "Settings", "BitrateKbps"}, 25000};
-const Info<bool> GFX_INTERNAL_RESOLUTION_FRAME_DUMPS{
-    {System::GFX, "Settings", "InternalResolutionFrameDumps"}, false};
+const Info<FrameDumpResolutionType> GFX_FRAME_DUMPS_RESOLUTION_TYPE{
+    {System::GFX, "Settings", "FrameDumpsResolutionType"},
+    FrameDumpResolutionType::XFB_ASPECT_RATIO_CORRECTED_RESOLUTION};
 const Info<int> GFX_PNG_COMPRESSION_LEVEL{{System::GFX, "Settings", "PNGCompressionLevel"}, 6};
 const Info<bool> GFX_ENABLE_GPU_TEXTURE_DECODING{
     {System::GFX, "Settings", "EnableGPUTextureDecoding"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -14,6 +14,7 @@ enum class TextureFilteringMode : int;
 enum class OutputResamplingMode : int;
 enum class ColorCorrectionRegion : int;
 enum class TriState : int;
+enum class FrameDumpResolutionType : int;
 
 namespace Config
 {
@@ -67,7 +68,7 @@ extern const Info<std::string> GFX_DUMP_PIXEL_FORMAT;
 extern const Info<std::string> GFX_DUMP_ENCODER;
 extern const Info<std::string> GFX_DUMP_PATH;
 extern const Info<int> GFX_BITRATE_KBPS;
-extern const Info<bool> GFX_INTERNAL_RESOLUTION_FRAME_DUMPS;
+extern const Info<FrameDumpResolutionType> GFX_FRAME_DUMPS_RESOLUTION_TYPE;
 extern const Info<int> GFX_PNG_COMPRESSION_LEVEL;
 extern const Info<bool> GFX_ENABLE_GPU_TEXTURE_DECODING;
 extern const Info<bool> GFX_ENABLE_PIXEL_LIGHTING;

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -135,21 +135,24 @@ void AdvancedWidget::CreateWidgets()
   auto* dump_layout = new QGridLayout();
   dump_box->setLayout(dump_layout);
 
-  m_use_fullres_framedumps = new ConfigBool(tr("Dump at Internal Resolution"),
-                                            Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS);
+  m_frame_dumps_resolution_type =
+      new ConfigChoice({tr("Window Resolution"), tr("Aspect Ratio Corrected Internal Resolution"),
+                        tr("Raw Internal Resolution")},
+                       Config::GFX_FRAME_DUMPS_RESOLUTION_TYPE);
   m_dump_use_ffv1 = new ConfigBool(tr("Use Lossless Codec (FFV1)"), Config::GFX_USE_FFV1);
   m_dump_bitrate = new ConfigInteger(0, 1000000, Config::GFX_BITRATE_KBPS, 1000);
   m_png_compression_level = new ConfigInteger(0, 9, Config::GFX_PNG_COMPRESSION_LEVEL);
 
-  dump_layout->addWidget(m_use_fullres_framedumps, 0, 0);
+  dump_layout->addWidget(new QLabel(tr("Resolution Type:")), 0, 0);
+  dump_layout->addWidget(m_frame_dumps_resolution_type, 0, 1);
 #if defined(HAVE_FFMPEG)
-  dump_layout->addWidget(m_dump_use_ffv1, 0, 1);
-  dump_layout->addWidget(new QLabel(tr("Bitrate (kbps):")), 1, 0);
-  dump_layout->addWidget(m_dump_bitrate, 1, 1);
+  dump_layout->addWidget(m_dump_use_ffv1, 1, 0);
+  dump_layout->addWidget(new QLabel(tr("Bitrate (kbps):")), 2, 0);
+  dump_layout->addWidget(m_dump_bitrate, 2, 1);
 #endif
-  dump_layout->addWidget(new QLabel(tr("PNG Compression Level:")), 2, 0);
+  dump_layout->addWidget(new QLabel(tr("PNG Compression Level:")), 3, 0);
   m_png_compression_level->SetTitle(tr("PNG Compression Level"));
-  dump_layout->addWidget(m_png_compression_level, 2, 1);
+  dump_layout->addWidget(m_png_compression_level, 3, 1);
 
   // Misc.
   auto* misc_box = new QGroupBox(tr("Misc"));
@@ -338,10 +341,21 @@ void AdvancedWidget::AddDescriptions()
   static const char TR_LOAD_GRAPHICS_MODS_DESCRIPTION[] =
       QT_TR_NOOP("Loads graphics mods from User/Load/GraphicsMods/.<br><br><dolphin_emphasis>If "
                  "unsure, leave this unchecked.</dolphin_emphasis>");
-  static const char TR_INTERNAL_RESOLUTION_FRAME_DUMPING_DESCRIPTION[] = QT_TR_NOOP(
-      "Creates frame dumps and screenshots at the raw internal resolution of the renderer,"
-      "rather than using the size it is displayed within the window.<br><br>"
-      "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+  static const char TR_FRAME_DUMPS_RESOLUTION_TYPE_DESCRIPTION[] = QT_TR_NOOP(
+      "Selects how frame dumps (videos) and screenshots are going to be captured.<br>If the game "
+      "or window resolution change during a recording, multiple video files might be created.<br>"
+      "Note that color correction and cropping are always ignored by the captures."
+      "<br><br><b>Window Resolution</b>: Uses the output window resolution (without black bars)."
+      "<br>This is a simple dumping option that will capture the image more or less as you see it."
+      "<br><b>Aspect Ratio Corrected Internal Resolution</b>: "
+      "Uses the Internal Resolution (XFB size), and corrects it by the target aspect ratio.<br>"
+      "This option will consistently dump at the specified Internal Resolution "
+      "regardless of how the image is displayed during recording."
+      "<br><b>Raw Internal Resolution</b>: Uses the Internal Resolution (XFB size) "
+      "without correcting it with the target aspect ratio.<br>"
+      "This will provide a clean dump without any aspect ratio correction so users have as raw as "
+      "possible input for external editing software.<br><br><dolphin_emphasis>If unsure, leave "
+      "this at \"Aspect Ratio Corrected Internal Resolution\".</dolphin_emphasis>");
 #if defined(HAVE_FFMPEG)
   static const char TR_USE_FFV1_DESCRIPTION[] =
       QT_TR_NOOP("Encodes frame dumps using the FFV1 codec.<br><br><dolphin_emphasis>If "
@@ -432,7 +446,7 @@ void AdvancedWidget::AddDescriptions()
   m_dump_xfb_target->SetDescription(tr(TR_DUMP_XFB_DESCRIPTION));
   m_disable_vram_copies->SetDescription(tr(TR_DISABLE_VRAM_COPIES_DESCRIPTION));
   m_enable_graphics_mods->SetDescription(tr(TR_LOAD_GRAPHICS_MODS_DESCRIPTION));
-  m_use_fullres_framedumps->SetDescription(tr(TR_INTERNAL_RESOLUTION_FRAME_DUMPING_DESCRIPTION));
+  m_frame_dumps_resolution_type->SetDescription(tr(TR_FRAME_DUMPS_RESOLUTION_TYPE_DESCRIPTION));
 #ifdef HAVE_FFMPEG
   m_dump_use_ffv1->SetDescription(tr(TR_USE_FFV1_DESCRIPTION));
 #endif

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -339,9 +339,8 @@ void AdvancedWidget::AddDescriptions()
       QT_TR_NOOP("Loads graphics mods from User/Load/GraphicsMods/.<br><br><dolphin_emphasis>If "
                  "unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_INTERNAL_RESOLUTION_FRAME_DUMPING_DESCRIPTION[] = QT_TR_NOOP(
-      "Creates frame dumps and screenshots at the internal resolution of the renderer, rather than "
-      "the size of the window it is displayed within.<br><br>If the aspect ratio is widescreen, "
-      "the output image will be scaled horizontally to preserve the vertical resolution.<br><br>"
+      "Creates frame dumps and screenshots at the raw internal resolution of the renderer,"
+      "rather than using the size it is displayed within the window.<br><br>"
       "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 #if defined(HAVE_FFMPEG)
   static const char TR_USE_FFV1_DESCRIPTION[] =

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -60,7 +60,7 @@ private:
 
   // Frame dumping
   ConfigBool* m_dump_use_ffv1;
-  ConfigBool* m_use_fullres_framedumps;
+  ConfigChoice* m_frame_dumps_resolution_type;
   ConfigInteger* m_dump_bitrate;
   ConfigInteger* m_png_compression_level;
 

--- a/Source/Core/VideoCommon/FrameDumper.cpp
+++ b/Source/Core/VideoCommon/FrameDumper.cpp
@@ -18,6 +18,9 @@
 #include "VideoCommon/Present.h"
 #include "VideoCommon/VideoConfig.h"
 
+// The video encoder needs the image to be a multiple of x samples.
+static constexpr int VIDEO_ENCODER_LCM = 4;
+
 static bool DumpFrameToPNG(const FrameData& frame, const std::string& file_name)
 {
   return Common::ConvertRGBAToRGBAndSavePNG(file_name, frame.data, frame.width, frame.height,
@@ -352,6 +355,13 @@ bool FrameDumper::IsFrameDumping() const
     return true;
 
   return false;
+}
+
+int FrameDumper::GetRequiredResolutionLeastCommonMultiple() const
+{
+  if (Config::Get(Config::MAIN_MOVIE_DUMP_FRAMES))
+    return VIDEO_ENCODER_LCM;
+  return 1;
 }
 
 void FrameDumper::DoState(PointerWrap& p)

--- a/Source/Core/VideoCommon/FrameDumper.h
+++ b/Source/Core/VideoCommon/FrameDumper.h
@@ -33,6 +33,7 @@ public:
   void SaveScreenshot(std::string filename);
 
   bool IsFrameDumping() const;
+  int GetRequiredResolutionLeastCommonMultiple() const;
 
   void DoState(PointerWrap& p);
 

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -214,14 +214,17 @@ void Presenter::ProcessFrameDumping(u64 ticks) const
     MathUtil::Rectangle<int> target_rect;
     if (!g_ActiveConfig.bInternalResolutionFrameDumps && !g_gfx->IsHeadless())
     {
+      // This is already scaled by "VIDEO_ENCODER_LCM"
       target_rect = GetTargetRectangle();
     }
     else
     {
-      int width, height;
-      std::tie(width, height) =
-          CalculateOutputDimensions(m_xfb_rect.GetWidth(), m_xfb_rect.GetHeight());
-      target_rect = MathUtil::Rectangle<int>(0, 0, width, height);
+      target_rect = m_xfb_rect;
+      ASSERT(target_rect.top == 0 && target_rect.left == 0);
+      // Scale positively to make sure the least amount of information is lost.
+      // TODO: this should be added as black padding on the edges by the frame dumper
+      target_rect.right += VIDEO_ENCODER_LCM - (target_rect.GetWidth() % VIDEO_ENCODER_LCM);
+      target_rect.bottom += VIDEO_ENCODER_LCM - (target_rect.GetHeight() % VIDEO_ENCODER_LCM);
     }
 
     g_frame_dumper->DumpCurrentFrame(m_xfb_entry->texture.get(), m_xfb_rect, target_rect, ticks,

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -25,9 +25,6 @@
 
 std::unique_ptr<VideoCommon::Presenter> g_presenter;
 
-// The video encoder needs the image to be a multiple of x samples.
-static constexpr int VIDEO_ENCODER_LCM = 4;
-
 namespace VideoCommon
 {
 // Stretches the native/internal analog resolution aspect ratio from ~4:3 to ~16:9
@@ -246,16 +243,18 @@ void Presenter::ProcessFrameDumping(u64 ticks) const
     int width = target_rect.GetWidth();
     int height = target_rect.GetHeight();
 
-    // Ensure divisibility by "VIDEO_ENCODER_LCM" and a min of 1 to make it compatible with all the
+    const int resolution_lcm = g_frame_dumper->GetRequiredResolutionLeastCommonMultiple();
+
+    // Ensure divisibility by the dumper LCM and a min of 1 to make it compatible with all the
     // video encoders. Note that this is theoretically only necessary when recording videos and not
     // screenshots.
     // We always scale positively to make sure the least amount of information is lost.
     //
     // TODO: this should be added as black padding on the edges by the frame dumper.
-    if ((width % VIDEO_ENCODER_LCM) != 0 || width == 0)
-      width += VIDEO_ENCODER_LCM - (width % VIDEO_ENCODER_LCM);
-    if ((height % VIDEO_ENCODER_LCM) != 0 || height == 0)
-      height += VIDEO_ENCODER_LCM - (height % VIDEO_ENCODER_LCM);
+    if ((width % resolution_lcm) != 0 || width == 0)
+      width += resolution_lcm - (width % resolution_lcm);
+    if ((height % resolution_lcm) != 0 || height == 0)
+      height += resolution_lcm - (height % resolution_lcm);
 
     // Remove any black borders, there would be no point in including them in the recording
     target_rect.left = 0;

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -212,7 +212,7 @@ void Presenter::ProcessFrameDumping(u64 ticks) const
     switch (g_ActiveConfig.frame_dumps_resolution_type)
     {
     default:
-    case FrameDumpResolutionType::WINDOW_RESOLUTION:
+    case FrameDumpResolutionType::WindowResolution:
     {
       if (!g_gfx->IsHeadless())
       {
@@ -221,7 +221,7 @@ void Presenter::ProcessFrameDumping(u64 ticks) const
       }
       [[fallthrough]];
     }
-    case FrameDumpResolutionType::XFB_ASPECT_RATIO_CORRECTED_RESOLUTION:
+    case FrameDumpResolutionType::XFBAspectRatioCorrectedResolution:
     {
       target_rect = m_xfb_rect;
       const bool allow_stretch = false;
@@ -233,7 +233,7 @@ void Presenter::ProcessFrameDumping(u64 ticks) const
       target_rect = MathUtil::Rectangle<int>(0, 0, int_width, int_height);
       break;
     }
-    case FrameDumpResolutionType::XFB_RAW_RESOLUTION:
+    case FrameDumpResolutionType::XFBRawResolution:
     {
       target_rect = m_xfb_rect;
       break;

--- a/Source/Core/VideoCommon/Present.h
+++ b/Source/Core/VideoCommon/Present.h
@@ -107,10 +107,13 @@ private:
 
   void OnBackBufferSizeChanged();
 
+  // Scales a raw XFB resolution to the target (display) aspect ratio,
+  // also accounting for crop and other minor adjustments
   std::tuple<int, int> CalculateOutputDimensions(int width, int height,
                                                  bool allow_stretch = true) const;
   std::tuple<float, float> ApplyStandardAspectCrop(float width, float height,
                                                    bool allow_stretch = true) const;
+  // Scales a raw XFB resolution to the target (display) aspect ratio
   std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height,
                                                      bool allow_stretch = true) const;
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -128,7 +128,7 @@ void VideoConfig::Refresh()
   sDumpEncoder = Config::Get(Config::GFX_DUMP_ENCODER);
   sDumpPath = Config::Get(Config::GFX_DUMP_PATH);
   iBitrateKbps = Config::Get(Config::GFX_BITRATE_KBPS);
-  bInternalResolutionFrameDumps = Config::Get(Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS);
+  frame_dumps_resolution_type = Config::Get(Config::GFX_FRAME_DUMPS_RESOLUTION_TYPE);
   bEnableGPUTextureDecoding = Config::Get(Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
   bPreferVSForLinePointExpansion = Config::Get(Config::GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION);
   bEnablePixelLighting = Config::Get(Config::GFX_ENABLE_PIXEL_LIGHTING);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -80,6 +80,16 @@ enum class TriState : int
   Auto
 };
 
+enum class FrameDumpResolutionType : int
+{
+  // Window resolution (not including potential back buffer black borders)
+  WINDOW_RESOLUTION,
+  // The aspect ratio corrected XFB resolution (XFB pixels might not have been square)
+  XFB_ASPECT_RATIO_CORRECTED_RESOLUTION,
+  // The raw unscaled XFB resolution (based on "internal resolution" scale)
+  XFB_RAW_RESOLUTION,
+};
+
 // Bitmask containing information about which configuration has changed for the backend.
 enum ConfigChangeBits : u32
 {
@@ -189,7 +199,8 @@ struct VideoConfig final
   std::string sDumpEncoder;
   std::string sDumpFormat;
   std::string sDumpPath;
-  bool bInternalResolutionFrameDumps = false;
+  FrameDumpResolutionType frame_dumps_resolution_type =
+      FrameDumpResolutionType::XFB_ASPECT_RATIO_CORRECTED_RESOLUTION;
   bool bBorderlessFullscreen = false;
   bool bEnableGPUTextureDecoding = false;
   bool bPreferVSForLinePointExpansion = false;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -83,11 +83,11 @@ enum class TriState : int
 enum class FrameDumpResolutionType : int
 {
   // Window resolution (not including potential back buffer black borders)
-  WINDOW_RESOLUTION,
+  WindowResolution,
   // The aspect ratio corrected XFB resolution (XFB pixels might not have been square)
-  XFB_ASPECT_RATIO_CORRECTED_RESOLUTION,
+  XFBAspectRatioCorrectedResolution,
   // The raw unscaled XFB resolution (based on "internal resolution" scale)
-  XFB_RAW_RESOLUTION,
+  XFBRawResolution,
 };
 
 // Bitmask containing information about which configuration has changed for the backend.
@@ -200,7 +200,7 @@ struct VideoConfig final
   std::string sDumpFormat;
   std::string sDumpPath;
   FrameDumpResolutionType frame_dumps_resolution_type =
-      FrameDumpResolutionType::XFB_ASPECT_RATIO_CORRECTED_RESOLUTION;
+      FrameDumpResolutionType::XFBAspectRatioCorrectedResolution;
   bool bBorderlessFullscreen = false;
   bool bEnableGPUTextureDecoding = false;
   bool bPreferVSForLinePointExpansion = false;


### PR DESCRIPTION
Allows the frame dumper to use the raw emulation output (XFB) resolution, avoiding any scaling if possible.
This should make comparisons much more reliable as pixels wouldn't be smushed together or stretched.

Currently even if `bInternalResolutionFrameDumps` is enabled, dumps are done after scaling to the target aspect ratio (which is almost always different from the raw emulation render), so they aren't really raw, they are scaled, but they scaling isn't done with gamma correction as the post process effects pipeline doesn't run on them.

This PR adds an enum with 3 dumping resolution choices:
![image](https://github.com/dolphin-emu/dolphin/assets/7011366/3f510065-a9fe-4c92-9620-7dafa5e3790d)

Some possible future improvements related to this:
- Save the target aspect ratio number in the output file name, so it could be stretched in post.
- Remove the `VIDEO_ENCODER_LCM` (4) limit, or move it to the frame dumper and just make it add black pixel lines of padding on the edges instead of forcing images to stretch.

The FifoCI differences are expected.

The 2nd commit moves the adjustments to the dumping resolution into the actual dumping function, so the window output resolution isn't affected by recording anymore (previously it would snap to the closest multiple of 4 when recording, which was unnecessary).
The 4th commit allows screenshots to be taken at any resolution, without the unnecessary `VIDEO_ENCODER_LCM` (4) limit.