### PR TITLE
Add Custom Relative and Raw (Squared Pixels) aspect ratios

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -55,9 +55,9 @@ void GeneralWidget::CreateWidgets()
   m_video_layout = new QGridLayout();
 
   m_backend_combo = new ToolTipComboBox();
-  m_aspect_combo = new ConfigChoice(
-      {tr("Auto"), tr("Force 16:9"), tr("Force 4:3"), tr("Stretch to Window"), tr("Custom")},
-      Config::GFX_ASPECT_RATIO);
+  m_aspect_combo = new ConfigChoice({tr("Auto"), tr("Force 16:9"), tr("Force 4:3"),
+                                     tr("Stretch to Window"), tr("Custom"), tr("Custom (Stretch)")},
+                                    Config::GFX_ASPECT_RATIO);
   m_custom_aspect_label = new QLabel(tr("Custom Aspect Ratio:"));
   m_custom_aspect_label->setHidden(true);
   constexpr int MAX_CUSTOM_ASPECT_RATIO_RESOLUTION = 10000;
@@ -155,7 +155,8 @@ void GeneralWidget::ConnectWidgets()
     emit BackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
   });
   connect(m_aspect_combo, qOverload<int>(&QComboBox::currentIndexChanged), this, [&](int index) {
-    const bool is_custom_aspect_ratio = (index == static_cast<int>(AspectMode::Custom));
+    const bool is_custom_aspect_ratio = (index == static_cast<int>(AspectMode::Custom)) ||
+                                        (index == static_cast<int>(AspectMode::CustomStretch));
     m_custom_aspect_width->setEnabled(is_custom_aspect_ratio);
     m_custom_aspect_height->setEnabled(is_custom_aspect_ratio);
     m_custom_aspect_label->setHidden(!is_custom_aspect_ratio);
@@ -170,7 +171,9 @@ void GeneralWidget::LoadSettings()
   m_backend_combo->setCurrentIndex(m_backend_combo->findData(
       QVariant(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)))));
 
-  const bool is_custom_aspect_ratio = (Config::Get(Config::GFX_ASPECT_RATIO) == AspectMode::Custom);
+  const bool is_custom_aspect_ratio =
+      (Config::Get(Config::GFX_ASPECT_RATIO) == AspectMode::Custom) ||
+      (Config::Get(Config::GFX_ASPECT_RATIO) == AspectMode::CustomStretch);
   m_custom_aspect_width->setEnabled(is_custom_aspect_ratio);
   m_custom_aspect_height->setEnabled(is_custom_aspect_ratio);
   m_custom_aspect_label->setHidden(!is_custom_aspect_ratio);
@@ -247,15 +250,19 @@ void GeneralWidget::AddDescriptions()
       QT_TR_NOOP("Uses the main Dolphin window for rendering rather than "
                  "a separate render window.<br><br><dolphin_emphasis>If unsure, leave "
                  "this unchecked.</dolphin_emphasis>");
-  static const char TR_ASPECT_RATIO_DESCRIPTION[] =
-      QT_TR_NOOP("Selects which aspect ratio to use when rendering.<br>"
-                 "Each game can have a slightly different native aspect ratio."
-                 "<br><br>Auto: Uses the native aspect ratio"
-                 "<br>Force 16:9: Mimics an analog TV with a widescreen aspect ratio."
-                 "<br>Force 4:3: Mimics a standard 4:3 analog TV."
-                 "<br>Stretch to Window: Stretches the picture to the window size."
-                 "<br>Custom: For games running with specific custom aspect ratio cheats.<br><br>"
-                 "<dolphin_emphasis>If unsure, select Auto.</dolphin_emphasis>");
+  static const char TR_ASPECT_RATIO_DESCRIPTION[] = QT_TR_NOOP(
+      "Selects which aspect ratio to use when drawing on the render window.<br>"
+      "Each game can have a slightly different native aspect ratio.<br>They can vary by "
+      "scene and settings and rarely ever exactly match 4:3 or 16:9."
+      "<br><br><b>Auto</b>: Uses the native aspect ratio"
+      "<br><br><b>Force 16:9</b>: Mimics an analog TV with a widescreen aspect ratio."
+      "<br><br><b>Force 4:3</b>: Mimics a standard 4:3 analog TV."
+      "<br><br><b>Stretch to Window</b>: Stretches the picture to the window size."
+      "<br><br><b>Custom</b>: Forces the specified aspect ratio."
+      "<br>This is mostly intended to be used with aspect ratio cheats/mods."
+      "<br><br><b>Custom (Stretch)</b>: Similar to `Custom` but not relative to the "
+      "title's native aspect ratio.<br>This is not meant to be used under normal circumstances."
+      "<br><br><dolphin_emphasis>If unsure, select Auto.</dolphin_emphasis>");
   static const char TR_VSYNC_DESCRIPTION[] = QT_TR_NOOP(
       "Waits for vertical blanks in order to prevent tearing.<br><br>Decreases performance "
       "if emulation speed is below 100%.<br><br><dolphin_emphasis>If unsure, leave "

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -410,6 +410,12 @@ void HotkeyScheduler::Run()
         case AspectMode::Custom:
           OSD::AddMessage("Custom");
           break;
+        case AspectMode::CustomStretch:
+          OSD::AddMessage("Custom (Stretch)");
+          break;
+        case AspectMode::Raw:
+          OSD::AddMessage("Raw (Square Pixels)");
+          break;
         case AspectMode::Auto:
         default:
           OSD::AddMessage("Auto");

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -21,11 +21,13 @@ constexpr int EFB_SCALE_AUTO_INTEGRAL = 0;
 
 enum class AspectMode : int
 {
-  Auto,           // 4:3 or 16:9
-  ForceWide,      // 16:9
-  ForceStandard,  // 4:3
+  Auto,           // ~4:3 or ~16:9 (auto detected)
+  ForceWide,      // ~16:9
+  ForceStandard,  // ~4:3
   Stretch,
-  Custom,
+  Custom,         // Forced relative custom AR
+  CustomStretch,  // Forced absolute custom AR
+  Raw,            // Forced squared pixels
 };
 
 enum class StereoMode : int


### PR DESCRIPTION
Follow up to https://github.com/dolphin-emu/dolphin/pull/12170 as discussed there and on discord.
Specifically, this PR adds a "Custom Relative" aspect ratio, meaning that the user specified aspect ratio will relative to the VI determined aspect ratio. This means that specifying 4:3 and 16:9 as custom relative ARs will act identically as selecting 4:3 and 16:9 as aspect ratio mode.

This also adds a "Raw" aspect ratio mode to see pixels 1:1 with no scaling at all. This has been long asked by users.

Video:
https://github.com/dolphin-emu/dolphin/assets/7011366/bc761acf-6a1a-4387-9787-c7f00af3c251
![Ia9ddW6Q7K](https://github.com/dolphin-emu/dolphin/assets/7011366/fa0cac20-df00-4626-b84f-e2b0b56f6eda)
