### PR TITLE
Core: Use fmt over sprintf in trivial cases

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -329,7 +329,7 @@ endif()
 if(UNIX)
   # Posix networking code needs to be fixed for Windows
   add_executable(traversal_server TraversalServer.cpp)
-  target_link_libraries(traversal_server PRIVATE common)
+  target_link_libraries(traversal_server PRIVATE common fmt::fmt)
   if(SYSTEMD_FOUND)
     target_link_libraries(traversal_server PRIVATE ${SYSTEMD_LIBRARIES})
   endif()

--- a/Source/Core/Common/TraversalServer.cpp
+++ b/Source/Core/Common/TraversalServer.cpp
@@ -18,6 +18,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
 #endif
@@ -177,17 +179,17 @@ static sockaddr_in6 MakeSinAddr(const Common::TraversalInetAddress& addr)
 
 static void GetRandomHostId(Common::TraversalHostId* hostId)
 {
-  char buf[9];
+  char buf[9]{};
   const u32 num = Common::Random::GenerateValue<u32>();
-  sprintf(buf, "%08x", num);
+  fmt::format_to_n(buf, sizeof(buf) - 1, "{:08x}", num);
   memcpy(hostId->data(), buf, 8);
 }
 
 static const char* SenderName(sockaddr_in6* addr)
 {
-  static char buf[INET6_ADDRSTRLEN + 10];
+  static char buf[INET6_ADDRSTRLEN + 10]{};
   inet_ntop(PF_INET6, &addr->sin6_addr, buf, sizeof(buf));
-  sprintf(buf + strlen(buf), ":%d", ntohs(addr->sin6_port));
+  fmt::format_to(buf + strlen(buf), ":{}", ntohs(addr->sin6_port));
   return buf;
 }
 

--- a/Source/Core/Common/TraversalServer.cpp
+++ b/Source/Core/Common/TraversalServer.cpp
@@ -87,12 +87,12 @@ retry:
     }
   }
 #if DEBUG
-  printf("failed to find key '");
+  fmt::print("failed to find key '");
   for (size_t i = 0; i < sizeof(key); i++)
   {
-    printf("%02x", ((u8*)&key)[i]);
+    fmt::print("{:02x}", ((u8*)&key)[i]);
   }
-  printf("'\n");
+  fmt::print("'\n");
 #endif
   result.found = false;
   return result;
@@ -133,7 +133,7 @@ static Common::TraversalInetAddress MakeInetAddress(const sockaddr_in6& addr)
 {
   if (addr.sin6_family != AF_INET6)
   {
-    fprintf(stderr, "bad sockaddr_in6\n");
+    fmt::print(stderr, "bad sockaddr_in6\n");
     exit(1);
   }
   u32* words = (u32*)addr.sin6_addr.s6_addr;
@@ -197,8 +197,8 @@ static void TrySend(const void* buffer, size_t size, sockaddr_in6* addr, bool fr
 {
 #if DEBUG
   const auto* packet = static_cast<const Common::TraversalPacket*>(buffer);
-  printf("%s-> %d %llu %s\n", fromAlt ? "alt " : "", static_cast<int>(packet->type),
-         static_cast<long long>(packet->requestId), SenderName(addr));
+  fmt::print("{}-> {} {} {}\n", fromAlt ? "alt " : "", static_cast<int>(packet->type),
+             static_cast<long long>(packet->requestId), SenderName(addr));
 #endif
   if ((size_t)sendto(fromAlt ? sockAlt : sock, buffer, size, 0, (sockaddr*)addr, sizeof(*addr)) !=
       size)
@@ -271,8 +271,8 @@ static void ResendPackets()
 static void HandlePacket(Common::TraversalPacket* packet, sockaddr_in6* addr, bool toAlt)
 {
 #if DEBUG
-  printf("<- %d %llu %s\n", static_cast<int>(packet->type),
-         static_cast<long long>(packet->requestId), SenderName(addr));
+  fmt::print("<- {} {} {}\n", static_cast<int>(packet->type),
+             static_cast<long long>(packet->requestId), SenderName(addr));
 #endif
   bool packetOk = true;
   switch (packet->type)
@@ -377,8 +377,8 @@ static void HandlePacket(Common::TraversalPacket* packet, sockaddr_in6* addr, bo
     break;
   }
   default:
-    fprintf(stderr, "received unknown packet type %d from %s\n", static_cast<int>(packet->type),
-            SenderName(addr));
+    fmt::print(stderr, "received unknown packet type {} from {}\n", static_cast<int>(packet->type),
+               SenderName(addr));
     break;
   }
   if (packet->type != Common::TraversalPacketType::Ack)
@@ -516,7 +516,7 @@ int main()
     }
     else if ((size_t)rv < sizeof(packet))
     {
-      fprintf(stderr, "received short packet from %s\n", SenderName(&raddr));
+      fmt::print(stderr, "received short packet from {}\n", SenderName(&raddr));
     }
     else
     {

--- a/Source/Core/Core/DSP/DSPTables.cpp
+++ b/Source/Core/Core/DSP/DSPTables.cpp
@@ -10,6 +10,8 @@
 #include <cstddef>
 #include <cstdio>
 
+#include <fmt/format.h>
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
@@ -492,18 +494,15 @@ const std::array<pdlabel_t, 36> regnames =
 }};
 // clang-format on
 
-const char* pdname(u16 val)
+std::string pdname(u16 val)
 {
-  static char tmpstr[12];  // nasty
-
   for (const pdlabel_t& pdlabel : pdlabels)
   {
     if (pdlabel.addr == val)
       return pdlabel.name;
   }
 
-  sprintf(tmpstr, "0x%04x", val);
-  return tmpstr;
+  return fmt::format("0x{:04x}", val);
 }
 
 const char* pdregname(int val)

--- a/Source/Core/Core/DSP/DSPTables.cpp
+++ b/Source/Core/Core/DSP/DSPTables.cpp
@@ -505,12 +505,12 @@ std::string pdname(u16 val)
   return fmt::format("0x{:04x}", val);
 }
 
-const char* pdregname(int val)
+std::string pdregname(int val)
 {
   return regnames[val].name;
 }
 
-const char* pdregnamelong(int val)
+std::string pdregnamelong(int val)
 {
   return regnames[val].description;
 }

--- a/Source/Core/Core/DSP/DSPTables.h
+++ b/Source/Core/Core/DSP/DSPTables.h
@@ -94,8 +94,8 @@ extern const std::array<pdlabel_t, 36> regnames;
 extern const std::array<pdlabel_t, 96> pdlabels;
 
 std::string pdname(u16 val);
-const char* pdregname(int val);
-const char* pdregnamelong(int val);
+std::string pdregname(int val);
+std::string pdregnamelong(int val);
 
 void InitInstructionTable();
 

--- a/Source/Core/Core/DSP/DSPTables.h
+++ b/Source/Core/Core/DSP/DSPTables.h
@@ -93,7 +93,7 @@ struct pdlabel_t
 extern const std::array<pdlabel_t, 36> regnames;
 extern const std::array<pdlabel_t, 96> pdlabels;
 
-const char* pdname(u16 val);
+std::string pdname(u16 val);
 const char* pdregname(int val);
 const char* pdregnamelong(int val);
 

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "Common/ChunkFile.h"
 #include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
@@ -218,10 +220,11 @@ IPCReply ESDevice::GetTitleDirectory(const IOCtlVRequest& request)
   auto& memory = system.GetMemory();
 
   const u64 title_id = memory.Read_U64(request.in_vectors[0].address);
+  const auto path = fmt::format("/title/{:08x}/{:08x}/data", static_cast<u32>(title_id >> 32),
+                                static_cast<u32>(title_id));
 
-  char* path = reinterpret_cast<char*>(memory.GetPointer(request.io_vectors[0].address));
-  sprintf(path, "/title/%08x/%08x/data", static_cast<u32>(title_id >> 32),
-          static_cast<u32>(title_id));
+  const auto path_dst = request.io_vectors[0].address;
+  memory.CopyToEmu(path_dst, path.data(), path.size());
 
   INFO_LOG_FMT(IOS_ES, "IOCTL_ES_GETTITLEDIR: {}", path);
   return IPCReply(IPC_SUCCESS);

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -667,10 +667,11 @@ IPCReply NetIPTopDevice::HandleInetNToPRequest(const IOCtlRequest& request)
   // u32 validAddress = memory.Read_U32(request.buffer_in + 4);
   // u32 src = memory.Read_U32(request.buffer_in + 8);
 
-  char ip_s[16];
-  sprintf(ip_s, "%i.%i.%i.%i", memory.Read_U8(request.buffer_in + 8),
-          memory.Read_U8(request.buffer_in + 8 + 1), memory.Read_U8(request.buffer_in + 8 + 2),
-          memory.Read_U8(request.buffer_in + 8 + 3));
+  char ip_s[16]{};
+  fmt::format_to_n(ip_s, sizeof(ip_s) - 1, "{}.{}.{}.{}", memory.Read_U8(request.buffer_in + 8),
+                   memory.Read_U8(request.buffer_in + 8 + 1),
+                   memory.Read_U8(request.buffer_in + 8 + 2),
+                   memory.Read_U8(request.buffer_in + 8 + 3));
 
   INFO_LOG_FMT(IOS_NET, "IOCTL_SO_INETNTOP {}", ip_s);
   memory.CopyToEmu(request.buffer_out, reinterpret_cast<u8*>(ip_s), std::strlen(ip_s));

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -2294,8 +2294,9 @@ std::unordered_set<std::string> NetPlayServer::GetInterfaceSet() const
 // called from ---GUI--- thread
 std::string NetPlayServer::GetInterfaceHost(const std::string& inter) const
 {
-  char buf[16];
-  sprintf(buf, ":%d", GetPort());
+  char buf[16]{};
+  fmt::format_to_n(buf, sizeof(buf) - 1, ":{}", GetPort());
+
   auto lst = GetInterfaceListInternal();
   for (const auto& list_entry : lst)
   {


### PR DESCRIPTION
On macOS, we get some noisy warnings about sprintf

e.g.
<img width="1436" alt="Screenshot 2023-12-18 at 10 41 57 AM" src="https://github.com/dolphin-emu/dolphin/assets/712067/48e939c2-80ea-4cf1-a46c-8f6ff1c233dc">


Rather than disable the warning, it's trivial enough to just resolve them by converting over to fmt (which is better anyway, given the formatting is type generic).

The only remaining in-source usages now are confined to DSPAssembler (which isn't trivial to flip over).