### PR TITLE
Core/EXI/EXI_DeviceMemoryCard: Remove global system accessor

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -110,7 +110,8 @@ void ExpansionInterfaceManager::Init(const Sram* override_sram)
     m_using_overridden_sram = false;
   }
 
-  CEXIMemoryCard::Init();
+  auto& core_timing = m_system.GetCoreTiming();
+  CEXIMemoryCard::Init(core_timing);
 
   {
     u16 size_mbits = Memcard::MBIT_SIZE_MEMORY_CARD_2043;
@@ -142,7 +143,6 @@ void ExpansionInterfaceManager::Init(const Sram* override_sram)
                                                      SlotToEXIDevice(Slot::SP1));
   m_channels[2]->AddDevice(EXIDeviceType::AD16, 0);
 
-  auto& core_timing = m_system.GetCoreTiming();
   m_event_type_change_device = core_timing.RegisterEvent("ChangeEXIDevice", ChangeDeviceCallback);
   m_event_type_update_interrupts =
       core_timing.RegisterEvent("EXIUpdateInterrupts", UpdateInterruptsCallback);

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -83,12 +83,11 @@ void CEXIMemoryCard::TransferCompleteCallback(Core::System& system, u64 userdata
                             [](CEXIMemoryCard* instance) { instance->TransferComplete(); });
 }
 
-void CEXIMemoryCard::Init()
+void CEXIMemoryCard::Init(CoreTiming::CoreTimingManager& core_timing)
 {
   static_assert(s_et_cmd_done.size() == s_et_transfer_complete.size(), "Event array size differs");
   static_assert(s_et_cmd_done.size() == MEMCARD_SLOTS.size(), "Event array size differs");
-  auto& system = Core::System::GetInstance();
-  auto& core_timing = system.GetCoreTiming();
+
   for (Slot slot : MEMCARD_SLOTS)
   {
     s_et_cmd_done[slot] = core_timing.RegisterEvent(

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.h
@@ -18,6 +18,10 @@ namespace Core
 {
 class System;
 }
+namespace CoreTiming
+{
+class CoreTimingManager;
+}
 namespace Memcard
 {
 struct HeaderData;
@@ -50,7 +54,7 @@ public:
   // CoreTiming events need to be registered during boot since CoreTiming is DoState()-ed
   // before ExpansionInterface so we'll lose the save stated events if the callbacks are
   // not already registered first.
-  static void Init();
+  static void Init(CoreTiming::CoreTimingManager& core_timing);
   static void Shutdown();
 
   static std::pair<std::string /* path */, bool /* migrate */>


### PR DESCRIPTION
We can pass the core timing instance into the Init() call.