### PR TITLE
Core/IOS/IOS: Remove global system accessors

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -572,7 +572,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
         // Because there is no TMD to get the requested system (IOS) version from,
         // we default to IOS58, which is the version used by the Homebrew Channel.
         SetupWiiMemory(system, IOS::HLE::IOSC::ConsoleType::Retail);
-        IOS::HLE::GetIOS()->BootIOS(system, Titles::IOS(58));
+        IOS::HLE::GetIOS()->BootIOS(Titles::IOS(58));
       }
       else
       {

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -592,7 +592,7 @@ bool CBoot::EmulatedBS2_Wii(Core::System& system, const Core::CPUThreadGuard& gu
     return false;
 
   // The Apploader probably just overwrote values needed for RAM Override.  Run this again!
-  IOS::HLE::RAMOverrideForIOSMemoryValues(IOS::HLE::MemorySetupType::IOSReload);
+  IOS::HLE::RAMOverrideForIOSMemoryValues(memory, IOS::HLE::MemorySetupType::IOSReload);
 
   // Warning: This call will set incorrect running game metadata if our volume parameter
   // doesn't point to the same disc as the one that's inserted in the emulated disc drive!

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -559,7 +559,7 @@ bool CBoot::EmulatedBS2_Wii(Core::System& system, const Core::CPUThreadGuard& gu
   const u64 ios = ios_override >= 0 ? Titles::IOS(static_cast<u32>(ios_override)) : tmd.GetIOSId();
 
   const auto console_type = volume.GetTicket(data_partition).GetConsoleType();
-  if (!SetupWiiMemory(system, console_type) || !IOS::HLE::GetIOS()->BootIOS(system, ios))
+  if (!SetupWiiMemory(system, console_type) || !IOS::HLE::GetIOS()->BootIOS(ios))
     return false;
 
   auto di =

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -57,7 +57,7 @@ void Init(Core::System& system, const Sram* override_sram)
   if (SConfig::GetInstance().bWii)
   {
     IOS::Init();
-    IOS::HLE::Init();  // Depends on Memory
+    IOS::HLE::Init(system);  // Depends on Memory
   }
 }
 

--- a/Source/Core/Core/IOS/DI/DI.h
+++ b/Source/Core/Core/IOS/DI/DI.h
@@ -120,7 +120,7 @@ private:
   };
 
   friend class ::CBoot;
-  friend void ::IOS::HLE::Init();
+  friend void ::IOS::HLE::Init(Core::System&);
 
   void ProcessQueuedIOCtl();
   std::optional<DIResult> StartIOCtl(const IOCtlRequest& request);

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -374,7 +374,7 @@ bool ESDevice::LaunchIOS(u64 ios_title_id, HangPPC hang_ppc)
     const ES::TicketReader ticket = m_core.FindSignedTicket(ios_title_id);
     ES::Content content;
     if (!tmd.IsValid() || !ticket.IsValid() || !tmd.GetContent(tmd.GetBootIndex(), &content) ||
-        !GetEmulationKernel().BootIOS(GetSystem(), ios_title_id, hang_ppc,
+        !GetEmulationKernel().BootIOS(ios_title_id, hang_ppc,
                                       m_core.GetContentPath(ios_title_id, content)))
     {
       PanicAlertFmtT("Could not launch IOS {0:016x} because it is missing from the NAND.\n"
@@ -385,7 +385,7 @@ bool ESDevice::LaunchIOS(u64 ios_title_id, HangPPC hang_ppc)
     return true;
   }
 
-  return GetEmulationKernel().BootIOS(GetSystem(), ios_title_id, hang_ppc);
+  return GetEmulationKernel().BootIOS(ios_title_id, hang_ppc);
 }
 
 s32 ESDevice::WriteLaunchFile(const ES::TMDReader& tmd, Ticks ticks)
@@ -490,8 +490,7 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
 
 bool ESDevice::BootstrapPPC()
 {
-  const bool result =
-      GetEmulationKernel().BootstrapPPC(GetSystem(), m_pending_ppc_boot_content_path);
+  const bool result = GetEmulationKernel().BootstrapPPC(m_pending_ppc_boot_content_path);
   m_pending_ppc_boot_content_path = {};
   return result;
 }

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -349,7 +349,7 @@ EmulationKernel::EmulationKernel(Core::System& system, u64 title_id)
 
 EmulationKernel::~EmulationKernel()
 {
-  Core::System::GetInstance().GetCoreTiming().RemoveAllEvents(s_event_enqueue);
+  m_system.GetCoreTiming().RemoveAllEvents(s_event_enqueue);
 
   m_device_map.clear();
   m_socket_manager.reset();

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -949,9 +949,8 @@ static void FinishPPCBootstrap(Core::System& system, u64 userdata, s64 cycles_la
   INFO_LOG_FMT(IOS, "Bootstrapping done.");
 }
 
-void Init()
+void Init(Core::System& system)
 {
-  auto& system = Core::System::GetInstance();
   auto& core_timing = system.GetCoreTiming();
 
   s_event_enqueue =

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -140,8 +140,7 @@ static bool SetupMemory(Memory::MemoryManager& memory, u64 ios_title_id, MemoryS
     memory.Write_U32(target_imv->ios_reserved_begin, ADDR_IOS_RESERVED_BEGIN);
     memory.Write_U32(target_imv->ios_reserved_end, ADDR_IOS_RESERVED_END);
 
-    RAMOverrideForIOSMemoryValues(setup_type);
-
+    RAMOverrideForIOSMemoryValues(memory, setup_type);
     return true;
   }
 
@@ -184,8 +183,7 @@ static bool SetupMemory(Memory::MemoryManager& memory, u64 ios_title_id, MemoryS
   memory.Write_U32(target_imv->mem1_arena_end, ADDR_LEGACY_ARENA_HIGH);
   memory.Write_U32(target_imv->mem1_simulated_size, ADDR_LEGACY_MEM_SIM_SIZE);
 
-  RAMOverrideForIOSMemoryValues(setup_type);
-
+  RAMOverrideForIOSMemoryValues(memory, setup_type);
   return true;
 }
 
@@ -225,14 +223,11 @@ static void ReleasePPCAncast(Core::System& system)
   system.GetPPCState().pc = ESPRESSO_ANCAST_LOCATION_VIRT + sizeof(EspressoAncastHeader);
 }
 
-void RAMOverrideForIOSMemoryValues(MemorySetupType setup_type)
+void RAMOverrideForIOSMemoryValues(Memory::MemoryManager& memory, MemorySetupType setup_type)
 {
   // Don't touch anything if the feature isn't enabled.
   if (!Config::Get(Config::MAIN_RAM_OVERRIDE_ENABLE))
     return;
-
-  auto& system = Core::System::GetInstance();
-  auto& memory = system.GetMemory();
 
   // Some unstated constants that can be inferred.
   const u32 ipc_buffer_size =

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -275,10 +275,8 @@ void RAMOverrideForIOSMemoryValues(Memory::MemoryManager& memory, MemorySetupTyp
   memory.Write_U32(ios_reserved_end, ADDR_IOS_RESERVED_END);
 }
 
-void WriteReturnValue(s32 value, u32 address)
+void WriteReturnValue(Memory::MemoryManager& memory, s32 value, u32 address)
 {
-  auto& system = Core::System::GetInstance();
-  auto& memory = system.GetMemory();
   memory.Write_U32(static_cast<u32>(value), address);
 }
 

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -216,7 +216,7 @@ private:
 };
 
 // Used for controlling and accessing an IOS instance that is tied to emulation.
-void Init();
+void Init(Core::System& system);
 void Shutdown();
 EmulationKernel* GetIOS();
 

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -177,8 +177,8 @@ public:
   void SetGidForPPC(u16 gid);
   u16 GetGidForPPC() const;
 
-  bool BootstrapPPC(Core::System& system, const std::string& boot_content_path);
-  bool BootIOS(Core::System& system, u64 ios_title_id, HangPPC hang_ppc = HangPPC::No,
+  bool BootstrapPPC(const std::string& boot_content_path);
+  bool BootIOS(u64 ios_title_id, HangPPC hang_ppc = HangPPC::No,
                const std::string& boot_content_path = {});
   void InitIPC();
 

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -23,6 +23,10 @@ namespace Core
 {
 class System;
 }
+namespace Memory
+{
+class MemoryManager;
+}
 
 namespace IOS::HLE
 {
@@ -109,7 +113,7 @@ enum class HangPPC : bool
   Yes = true,
 };
 
-void RAMOverrideForIOSMemoryValues(MemorySetupType setup_type);
+void RAMOverrideForIOSMemoryValues(Memory::MemoryManager& memory, MemorySetupType setup_type);
 
 void WriteReturnValue(s32 value, u32 address);
 

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -115,7 +115,7 @@ enum class HangPPC : bool
 
 void RAMOverrideForIOSMemoryValues(Memory::MemoryManager& memory, MemorySetupType setup_type);
 
-void WriteReturnValue(s32 value, u32 address);
+void WriteReturnValue(Memory::MemoryManager& memory, s32 value, u32 address);
 
 // HLE for the IOS kernel: IPC, device management, syscalls, and Dolphin-specific, IOS-wide calls.
 class Kernel

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -281,12 +281,12 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
 
       ssl->hostname = hostname;
       ssl->active = true;
-      WriteReturnValue(freeSSL, BufferIn);
+      WriteReturnValue(memory, freeSSL, BufferIn);
     }
     else
     {
     _SSL_NEW_ERROR:
-      WriteReturnValue(SSL_ERR_FAILED, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_FAILED, BufferIn);
     }
 
     INFO_LOG_FMT(IOS_SSL,
@@ -321,11 +321,11 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
 
       ssl->active = false;
 
-      WriteReturnValue(SSL_OK, BufferIn);
+      WriteReturnValue(memory, SSL_OK, BufferIn);
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
     }
     INFO_LOG_FMT(IOS_SSL,
                  "IOCTLV_NET_SSL_SHUTDOWN "
@@ -361,19 +361,19 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
 
       if (ret)
       {
-        WriteReturnValue(SSL_ERR_FAILED, BufferIn);
+        WriteReturnValue(memory, SSL_ERR_FAILED, BufferIn);
       }
       else
       {
         mbedtls_ssl_conf_ca_chain(&ssl->config, &ssl->cacert, nullptr);
-        WriteReturnValue(SSL_OK, BufferIn);
+        WriteReturnValue(memory, SSL_OK, BufferIn);
       }
 
       INFO_LOG_FMT(IOS_SSL, "IOCTLV_NET_SSL_SETROOTCA = {}", ret);
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
     }
     break;
   }
@@ -407,19 +407,19 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
       {
         mbedtls_x509_crt_free(&ssl->clicert);
         mbedtls_pk_free(&ssl->pk);
-        WriteReturnValue(SSL_ERR_FAILED, BufferIn);
+        WriteReturnValue(memory, SSL_ERR_FAILED, BufferIn);
       }
       else
       {
         mbedtls_ssl_conf_own_cert(&ssl->config, &ssl->clicert, &ssl->pk);
-        WriteReturnValue(SSL_OK, BufferIn);
+        WriteReturnValue(memory, SSL_OK, BufferIn);
       }
 
       INFO_LOG_FMT(IOS_SSL, "IOCTLV_NET_SSL_SETBUILTINCLIENTCERT = ({}, {})", ret, pk_ret);
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
       INFO_LOG_FMT(IOS_SSL, "IOCTLV_NET_SSL_SETBUILTINCLIENTCERT invalid sslID = {}", sslID);
     }
     break;
@@ -442,11 +442,11 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
       mbedtls_pk_free(&ssl->pk);
 
       mbedtls_ssl_conf_own_cert(&ssl->config, nullptr, nullptr);
-      WriteReturnValue(SSL_OK, BufferIn);
+      WriteReturnValue(memory, SSL_OK, BufferIn);
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
       INFO_LOG_FMT(IOS_SSL, "IOCTLV_NET_SSL_SETBUILTINCLIENTCERT invalid sslID = {}", sslID);
     }
     break;
@@ -467,18 +467,18 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
       if (ret)
       {
         mbedtls_x509_crt_free(&ssl->clicert);
-        WriteReturnValue(SSL_ERR_FAILED, BufferIn);
+        WriteReturnValue(memory, SSL_ERR_FAILED, BufferIn);
       }
       else
       {
         mbedtls_ssl_conf_ca_chain(&ssl->config, &ssl->cacert, nullptr);
-        WriteReturnValue(SSL_OK, BufferIn);
+        WriteReturnValue(memory, SSL_OK, BufferIn);
       }
       INFO_LOG_FMT(IOS_SSL, "IOCTLV_NET_SSL_SETBUILTINROOTCA = {}", ret);
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
     }
     INFO_LOG_FMT(IOS_SSL,
                  "IOCTLV_NET_SSL_SETBUILTINROOTCA "
@@ -500,11 +500,11 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
       ssl->hostfd = GetEmulationKernel().GetSocketManager()->GetHostSocket(ssl->sockfd);
       INFO_LOG_FMT(IOS_SSL, "IOCTLV_NET_SSL_CONNECT socket = {}", ssl->sockfd);
       mbedtls_ssl_set_bio(&ssl->ctx, ssl, SSLSendWithoutSNI, SSLRecv, nullptr);
-      WriteReturnValue(SSL_OK, BufferIn);
+      WriteReturnValue(memory, SSL_OK, BufferIn);
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
     }
     INFO_LOG_FMT(IOS_SSL,
                  "IOCTLV_NET_SSL_CONNECT "
@@ -526,7 +526,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
     }
     break;
   }
@@ -541,7 +541,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
     }
     INFO_LOG_FMT(IOS_SSL,
                  "IOCTLV_NET_SSL_WRITE "
@@ -565,7 +565,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
     }
 
     INFO_LOG_FMT(IOS_SSL,
@@ -582,11 +582,11 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
-      WriteReturnValue(SSL_OK, BufferIn);
+      WriteReturnValue(memory, SSL_OK, BufferIn);
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
     }
     INFO_LOG_FMT(IOS_SSL,
                  "IOCTLV_NET_SSL_SETROOTCADEFAULT "
@@ -610,11 +610,11 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
     int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
-      WriteReturnValue(SSL_OK, BufferIn);
+      WriteReturnValue(memory, SSL_OK, BufferIn);
     }
     else
     {
-      WriteReturnValue(SSL_ERR_ID, BufferIn);
+      WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
     }
     break;
   }

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -397,14 +397,14 @@ void WiiSocket::Update(bool read, bool write, bool except)
             connecting_state = GetConnectingState();
             if (connecting_state == ConnectingState::Connecting)
             {
-              WriteReturnValue(SSL_ERR_RAGAIN, BufferIn);
+              WriteReturnValue(memory, SSL_ERR_RAGAIN, BufferIn);
               ReturnValue = SSL_ERR_RAGAIN;
               break;
             }
             else if (connecting_state == ConnectingState::None ||
                      connecting_state == ConnectingState::Error)
             {
-              WriteReturnValue(SSL_ERR_SYSCALL, BufferIn);
+              WriteReturnValue(memory, SSL_ERR_SYSCALL, BufferIn);
               ReturnValue = SSL_ERR_SYSCALL;
               break;
             }
@@ -420,15 +420,15 @@ void WiiSocket::Update(bool read, bool write, bool except)
             switch (ret)
             {
             case 0:
-              WriteReturnValue(SSL_OK, BufferIn);
+              WriteReturnValue(memory, SSL_OK, BufferIn);
               break;
             case MBEDTLS_ERR_SSL_WANT_READ:
-              WriteReturnValue(SSL_ERR_RAGAIN, BufferIn);
+              WriteReturnValue(memory, SSL_ERR_RAGAIN, BufferIn);
               if (!nonBlock)
                 ReturnValue = SSL_ERR_RAGAIN;
               break;
             case MBEDTLS_ERR_SSL_WANT_WRITE:
-              WriteReturnValue(SSL_ERR_WAGAIN, BufferIn);
+              WriteReturnValue(memory, SSL_ERR_WAGAIN, BufferIn);
               if (!nonBlock)
                 ReturnValue = SSL_ERR_WAGAIN;
               break;
@@ -451,13 +451,13 @@ void WiiSocket::Update(bool read, bool write, bool except)
               else
                 res = SSL_ERR_FAILED;
 
-              WriteReturnValue(res, BufferIn);
+              WriteReturnValue(memory, res, BufferIn);
               if (!nonBlock)
                 ReturnValue = res;
               break;
             }
             default:
-              WriteReturnValue(SSL_ERR_FAILED, BufferIn);
+              WriteReturnValue(memory, SSL_ERR_FAILED, BufferIn);
               break;
             }
 
@@ -495,24 +495,24 @@ void WiiSocket::Update(bool read, bool write, bool except)
               system.GetPowerPC().GetDebugInterface().NetworkLogger()->LogSSLWrite(
                   memory.GetPointer(BufferOut2), ret, ssl->hostfd);
               // Return bytes written or SSL_ERR_ZERO if none
-              WriteReturnValue((ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
+              WriteReturnValue(memory, (ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
             }
             else
             {
               switch (ret)
               {
               case MBEDTLS_ERR_SSL_WANT_READ:
-                WriteReturnValue(SSL_ERR_RAGAIN, BufferIn);
+                WriteReturnValue(memory, SSL_ERR_RAGAIN, BufferIn);
                 if (!nonBlock)
                   ReturnValue = SSL_ERR_RAGAIN;
                 break;
               case MBEDTLS_ERR_SSL_WANT_WRITE:
-                WriteReturnValue(SSL_ERR_WAGAIN, BufferIn);
+                WriteReturnValue(memory, SSL_ERR_WAGAIN, BufferIn);
                 if (!nonBlock)
                   ReturnValue = SSL_ERR_WAGAIN;
                 break;
               default:
-                WriteReturnValue(SSL_ERR_FAILED, BufferIn);
+                WriteReturnValue(memory, SSL_ERR_FAILED, BufferIn);
                 break;
               }
             }
@@ -529,24 +529,24 @@ void WiiSocket::Update(bool read, bool write, bool except)
               system.GetPowerPC().GetDebugInterface().NetworkLogger()->LogSSLRead(
                   memory.GetPointer(BufferIn2), ret, ssl->hostfd);
               // Return bytes read or SSL_ERR_ZERO if none
-              WriteReturnValue((ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
+              WriteReturnValue(memory, (ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
             }
             else
             {
               switch (ret)
               {
               case MBEDTLS_ERR_SSL_WANT_READ:
-                WriteReturnValue(SSL_ERR_RAGAIN, BufferIn);
+                WriteReturnValue(memory, SSL_ERR_RAGAIN, BufferIn);
                 if (!nonBlock)
                   ReturnValue = SSL_ERR_RAGAIN;
                 break;
               case MBEDTLS_ERR_SSL_WANT_WRITE:
-                WriteReturnValue(SSL_ERR_WAGAIN, BufferIn);
+                WriteReturnValue(memory, SSL_ERR_WAGAIN, BufferIn);
                 if (!nonBlock)
                   ReturnValue = SSL_ERR_WAGAIN;
                 break;
               default:
-                WriteReturnValue(SSL_ERR_FAILED, BufferIn);
+                WriteReturnValue(memory, SSL_ERR_FAILED, BufferIn);
                 break;
               }
             }
@@ -558,7 +558,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
         }
         else
         {
-          WriteReturnValue(SSL_ERR_ID, BufferIn);
+          WriteReturnValue(memory, SSL_ERR_ID, BufferIn);
         }
       }
       else


### PR DESCRIPTION
Removes all global system accessors in IOS.cpp. Most are resolved by just passing via parameters.

Given this moves quite a bit around, I've separated the changes into a few commits to make it easier to review.