### PR TITLE
Core/Debugger_SymbolMap: Minor interface cleanup

### DIFF
--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -61,26 +61,28 @@ bool GetCallstack(const Core::CPUThreadGuard& guard, std::vector<CallstackEntry>
 
   if (LR(ppc_state) == 0)
   {
-    CallstackEntry entry;
-    entry.Name = "(error: LR=0)";
-    entry.vAddress = 0x0;
-    output.push_back(entry);
+    output.push_back({
+        .Name = "(error: LR=0)",
+        .vAddress = 0,
+    });
     return false;
   }
 
-  CallstackEntry entry;
-  entry.Name = fmt::format(" * {} [ LR = {:08x} ]\n", g_symbolDB.GetDescription(LR(ppc_state)),
-                           LR(ppc_state) - 4);
-  entry.vAddress = LR(ppc_state) - 4;
-  output.push_back(entry);
+  output.push_back({
+      .Name = fmt::format(" * {} [ LR = {:08x} ]\n", g_symbolDB.GetDescription(LR(ppc_state)),
+                          LR(ppc_state) - 4),
+      .vAddress = LR(ppc_state) - 4,
+  });
 
-  WalkTheStack(guard, [&entry, &output](u32 func_addr) {
+  WalkTheStack(guard, [&output](u32 func_addr) {
     std::string func_desc = g_symbolDB.GetDescription(func_addr);
     if (func_desc.empty() || func_desc == "Invalid")
       func_desc = "(unknown)";
-    entry.Name = fmt::format(" * {} [ addr = {:08x} ]\n", func_desc, func_addr - 4);
-    entry.vAddress = func_addr - 4;
-    output.push_back(entry);
+
+    output.push_back({
+        .Name = fmt::format(" * {} [ addr = {:08x} ]\n", func_desc, func_addr - 4),
+        .vAddress = func_addr - 4,
+    });
   });
 
   return true;

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -20,24 +20,6 @@
 
 namespace Dolphin_Debugger
 {
-void AddAutoBreakpoints()
-{
-#if defined(_DEBUG) || defined(DEBUGFAST)
-#if 1
-  const char* bps[] = {
-      "PPCHalt",
-  };
-
-  for (const char* bp : bps)
-  {
-    Common::Symbol* symbol = g_symbolDB.GetSymbolFromName(bp);
-    if (symbol)
-      Core::System::GetInstance().GetPowerPC().GetBreakPoints().Add(symbol->address, false);
-  }
-#endif
-#endif
-}
-
 // Returns true if the address is not a valid RAM address or NULL.
 static bool IsStackBottom(const Core::CPUThreadGuard& guard, u32 addr)
 {

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.h
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.h
@@ -30,6 +30,4 @@ void PrintCallstack(Core::System& system, const Core::CPUThreadGuard& guard,
                     Common::Log::LogType type, Common::Log::LogLevel level);
 void PrintDataBuffer(Common::Log::LogType type, const u8* data, size_t size,
                      std::string_view title);
-void AddAutoBreakpoints();
-
 }  // namespace Dolphin_Debugger

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.h
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.h
@@ -13,8 +13,7 @@
 namespace Core
 {
 class CPUThreadGuard;
-class System;
-}  // namespace Core
+}
 
 namespace Dolphin_Debugger
 {
@@ -24,10 +23,9 @@ struct CallstackEntry
   u32 vAddress = 0;
 };
 
-bool GetCallstack(Core::System& system, const Core::CPUThreadGuard& guard,
-                  std::vector<CallstackEntry>& output);
-void PrintCallstack(Core::System& system, const Core::CPUThreadGuard& guard,
-                    Common::Log::LogType type, Common::Log::LogLevel level);
+bool GetCallstack(const Core::CPUThreadGuard& guard, std::vector<CallstackEntry>& output);
+void PrintCallstack(const Core::CPUThreadGuard& guard, Common::Log::LogType type,
+                    Common::Log::LogLevel level);
 void PrintDataBuffer(Common::Log::LogType type, const u8* data, size_t size,
                      std::string_view title);
 }  // namespace Dolphin_Debugger

--- a/Source/Core/Core/PowerPC/Expression.cpp
+++ b/Source/Core/Core/PowerPC/Expression.cpp
@@ -115,9 +115,8 @@ static double CallstackFunc(expr_func* f, vec_expr_t* args, void* c)
 
   std::vector<Dolphin_Debugger::CallstackEntry> stack;
   {
-    auto& system = Core::System::GetInstance();
-    Core::CPUThreadGuard guard(system);
-    bool success = Dolphin_Debugger::GetCallstack(system, guard, stack);
+    Core::CPUThreadGuard guard(Core::System::GetInstance());
+    const bool success = Dolphin_Debugger::GetCallstack(guard, stack);
     if (!success)
       return 0;
   }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -323,7 +323,7 @@ void Interpreter::unknown_instruction(Interpreter& interpreter, UGeckoInstructio
   const u32 opcode = PowerPC::MMU::HostRead_U32(guard, last_pc);
   const std::string disasm = Common::GekkoDisassembler::Disassemble(opcode, last_pc);
   NOTICE_LOG_FMT(POWERPC, "Last PC = {:08x} : {}", last_pc, disasm);
-  Dolphin_Debugger::PrintCallstack(system, guard, Common::Log::LogType::POWERPC,
+  Dolphin_Debugger::PrintCallstack(guard, Common::Log::LogType::POWERPC,
                                    Common::Log::LogLevel::LNOTICE);
 
   const auto& ppc_state = interpreter.m_ppc_state;

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -344,7 +344,7 @@ void CodeWidget::UpdateCallstack()
 
   const bool success = [this, &stack] {
     Core::CPUThreadGuard guard(m_system);
-    return Dolphin_Debugger::GetCallstack(m_system, guard, stack);
+    return Dolphin_Debugger::GetCallstack(guard, stack);
   }();
 
   if (!success)


### PR DESCRIPTION
We don't need to pass in both a reference to a System instance and a CPUThreadGuard instance at the same time. We can just pass in the the cpu thread guard and retrieve the system instance from it.

Also removes an unused function and makes GetCallstack() a little nicer by moving callstack entries into the output vector instead of churning copies.