### PR TITLE
Core/GeckoCode: Remove global system accessors

### DIFF
--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -17,6 +17,7 @@
 
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
@@ -206,10 +207,8 @@ static Installation InstallCodeHandlerLocked(const Core::CPUThreadGuard& guard)
   // Turn on codes
   PowerPC::MMU::HostWrite_U8(guard, 1, INSTALLER_BASE_ADDRESS + 7);
 
-  auto& system = Core::System::GetInstance();
-  auto& ppc_state = system.GetPPCState();
-
   // Invalidate the icache and any asm codes
+  auto& ppc_state = guard.GetSystem().GetPPCState();
   for (unsigned int j = 0; j < (INSTALLER_END_ADDRESS - INSTALLER_BASE_ADDRESS); j += 32)
   {
     ppc_state.iCache.Invalidate(INSTALLER_BASE_ADDRESS + j);
@@ -258,8 +257,7 @@ void RunCodeHandler(const Core::CPUThreadGuard& guard)
     }
   }
 
-  auto& system = Core::System::GetInstance();
-  auto& ppc_state = system.GetPPCState();
+  auto& ppc_state = guard.GetSystem().GetPPCState();
 
   // We always do this to avoid problems with the stack since we're branching in random locations.
   // Even with function call return hooks (PC == LR), hand coded assembler won't necessarily

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -146,7 +146,7 @@ static Installation InstallCodeHandlerLocked(const Core::CPUThreadGuard& guard)
     PowerPC::MMU::HostWrite_U8(guard, data[i], INSTALLER_BASE_ADDRESS + i);
 
   // Patch the code handler to the current system type (Gamecube/Wii)
-  for (unsigned int h = 0; h < data.length(); h += 4)
+  for (u32 h = 0; h < data.length(); h += 4)
   {
     // Patch MMIO address
     if (PowerPC::MMU::HostRead_U32(guard, INSTALLER_BASE_ADDRESS + h) ==
@@ -209,7 +209,7 @@ static Installation InstallCodeHandlerLocked(const Core::CPUThreadGuard& guard)
 
   // Invalidate the icache and any asm codes
   auto& ppc_state = guard.GetSystem().GetPPCState();
-  for (unsigned int j = 0; j < (INSTALLER_END_ADDRESS - INSTALLER_BASE_ADDRESS); j += 32)
+  for (u32 j = 0; j < (INSTALLER_END_ADDRESS - INSTALLER_BASE_ADDRESS); j += 32)
   {
     ppc_state.iCache.Invalidate(INSTALLER_BASE_ADDRESS + j);
   }

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -279,7 +279,7 @@ void RunCodeHandler(const Core::CPUThreadGuard& guard)
   PowerPC::MMU::HostWrite_U32(guard, LR(ppc_state), SP + 16);
   PowerPC::MMU::HostWrite_U32(guard, ppc_state.cr.Get(), SP + 20);
   // Registers FPR0->13 are volatile
-  for (int i = 0; i < 14; ++i)
+  for (u32 i = 0; i < 14; ++i)
   {
     PowerPC::MMU::HostWrite_U64(guard, ppc_state.ps[i].PS0AsU64(), SP + 24 + 2 * i * sizeof(u64));
     PowerPC::MMU::HostWrite_U64(guard, ppc_state.ps[i].PS1AsU64(),


### PR DESCRIPTION
We can use the CPUThreadGuard instance to retrieve the system instance instead.

Plus some minor changes noticed while in the area.