### PR TITLE
Core/PatchEngine: Get rid of global system accessors

### DIFF
--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -170,7 +170,7 @@ void PatchEngineCallback(Core::System& system, u64 userdata, s64 cycles_late)
   s64 next_schedule = 0;
 
   // Try to patch mem and run the Action Replay
-  if (PatchEngine::ApplyFramePatches())
+  if (PatchEngine::ApplyFramePatches(system))
   {
     next_schedule = vi_interval - cycles_pruned;
     cycles_pruned = 0;

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -13,6 +13,10 @@ namespace Common
 {
 class IniFile;
 }
+namespace Core
+{
+class System;
+}
 
 namespace PatchEngine
 {
@@ -57,7 +61,7 @@ void LoadPatches();
 void AddMemoryPatch(std::size_t index);
 void RemoveMemoryPatch(std::size_t index);
 
-bool ApplyFramePatches();
+bool ApplyFramePatches(Core::System& system);
 void Shutdown();
 void Reload();
 


### PR DESCRIPTION
We can pass the system instance into ApplyFramePatches() instead, especially considering the patch engine callback already has it available.