### PR TITLE
Core/IOS/ES: Remove global system accessor in InitializeEmulationState()

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -125,10 +125,8 @@ ESDevice::ESDevice(EmulationKernel& ios, ESCore& core, const std::string& device
 
 ESDevice::~ESDevice() = default;
 
-void ESDevice::InitializeEmulationState()
+void ESDevice::InitializeEmulationState(CoreTiming::CoreTimingManager& core_timing)
 {
-  auto& system = Core::System::GetInstance();
-  auto& core_timing = system.GetCoreTiming();
   s_finish_init_event =
       core_timing.RegisterEvent("IOS-ESFinishInit", [](Core::System& system_, u64, s64) {
         GetIOS()->GetESDevice()->FinishInit();

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -17,6 +17,10 @@
 
 class PointerWrap;
 
+namespace CoreTiming
+{
+class CoreTimingManager;
+}
 namespace DiscIO
 {
 enum class Platform;
@@ -232,7 +236,7 @@ public:
   ESDevice& operator=(ESDevice&& other) = delete;
   ~ESDevice();
 
-  static void InitializeEmulationState();
+  static void InitializeEmulationState(CoreTiming::CoreTimingManager& core_timing);
   static void FinalizeEmulationState();
 
   ReturnCode DIVerify(const ES::TMDReader& tmd, const ES::TicketReader& ticket);

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -959,7 +959,7 @@ void Init(Core::System& system)
           s_ios->HandleIPCEvent(userdata);
       });
 
-  ESDevice::InitializeEmulationState();
+  ESDevice::InitializeEmulationState(core_timing);
 
   s_event_finish_ppc_bootstrap =
       core_timing.RegisterEvent("IOSFinishPPCBootstrap", FinishPPCBootstrap);


### PR DESCRIPTION
We can pass the core timing instance into the function.