### PR TITLE
CheatSearch: Get rid of global system accessors

### DIFF
--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -222,8 +222,7 @@ Cheats::NewSearch(const Core::CPUThreadGuard& guard,
       return;
     }
 
-    auto& system = Core::System::GetInstance();
-    auto& ppc_state = system.GetPPCState();
+    const auto& ppc_state = guard.GetSystem().GetPPCState();
     if (address_space == PowerPC::RequestedAddressSpace::Virtual && !ppc_state.msr.DR)
     {
       error_code = Cheats::SearchErrorCode::VirtualAddressesCurrentlyNotAccessible;
@@ -288,8 +287,7 @@ Cheats::NextSearch(const Core::CPUThreadGuard& guard,
       return;
     }
 
-    auto& system = Core::System::GetInstance();
-    auto& ppc_state = system.GetPPCState();
+    const auto& ppc_state = guard.GetSystem().GetPPCState();
     if (address_space == PowerPC::RequestedAddressSpace::Virtual && !ppc_state.msr.DR)
     {
       error_code = Cheats::SearchErrorCode::VirtualAddressesCurrentlyNotAccessible;


### PR DESCRIPTION
We can retrieve the system via the CPUThreadGuard instances.