### PR TITLE
Qt: Handle Overridden Graphics Backend

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -182,7 +182,10 @@ void GeneralWidget::SaveSettings()
 {
   // Video Backend
   const auto current_backend = m_backend_combo->currentData().toString().toStdString();
-  if (Config::Get(Config::MAIN_GFX_BACKEND) != current_backend)
+  if (Config::Get(Config::MAIN_GFX_BACKEND) == current_backend)
+    return;
+
+  if (Config::GetActiveLayerForConfig(Config::MAIN_GFX_BACKEND) == Config::LayerType::Base)
   {
     auto warningMessage = VideoBackendBase::GetAvailableBackends()[m_backend_combo->currentIndex()]
                               ->GetWarningMessage();
@@ -203,8 +206,10 @@ void GeneralWidget::SaveSettings()
         return;
       }
     }
-    emit BackendChanged(QString::fromStdString(current_backend));
   }
+
+  Config::SetBaseOrCurrent(Config::MAIN_GFX_BACKEND, current_backend);
+  emit BackendChanged(QString::fromStdString(current_backend));
 }
 
 void GeneralWidget::OnEmulationStateChanged(bool running)
@@ -215,6 +220,10 @@ void GeneralWidget::OnEmulationStateChanged(bool running)
 
   const bool supports_adapters = !g_Config.backend_info.Adapters.empty();
   m_adapter_combo->setEnabled(!running && supports_adapters);
+
+  std::string current_backend = m_backend_combo->currentData().toString().toStdString();
+  if (Config::Get(Config::MAIN_GFX_BACKEND) != current_backend)
+    emit BackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
 }
 
 void GeneralWidget::AddDescriptions()

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
@@ -67,7 +67,6 @@ void GraphicsWindow::CreateMainLayout()
 
 void GraphicsWindow::OnBackendChanged(const QString& backend_name)
 {
-  Config::SetBase(Config::MAIN_GFX_BACKEND, backend_name.toStdString());
   VideoBackendBase::PopulateBackendInfoFromUI(m_main_window->GetWindowSystemInfo());
 
   setWindowTitle(


### PR DESCRIPTION
This fixes an issue where the game specific graphics backend would be saved as the global setting after playing a game.

This also now displays the currently running graphics backend when looking in the graphics configuration window.