### PR TITLE
VideoCommon: revert max pixel samplers back to 8 for Android

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -121,6 +121,12 @@ bool ObjectCache::CreateDescriptorSetLayouts()
        VK_SHADER_STAGE_GEOMETRY_BIT},
   }};
 
+#ifdef ANDROID
+  static const std::array<VkDescriptorSetLayoutBinding, 1> standard_sampler_bindings{{
+      {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+       static_cast<u32>(VideoCommon::MAX_PIXEL_SHADER_SAMPLERS), VK_SHADER_STAGE_FRAGMENT_BIT},
+  }};
+#else
   constexpr u32 MAX_PIXEL_SAMPLER_ARRAY_SIZE = 8;
   constexpr u32 TOTAL_PIXEL_SAMPLER_BINDINGS =
       1 + (VideoCommon::MAX_PIXEL_SHADER_SAMPLERS - MAX_PIXEL_SAMPLER_ARRAY_SIZE);
@@ -139,6 +145,7 @@ bool ObjectCache::CreateDescriptorSetLayouts()
           {14, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
           {15, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT},
       }};
+#endif
 
   // The dynamic veretex loader's vertex buffer must be last here, for similar reasons
   static const std::array<VkDescriptorSetLayoutBinding, 2> standard_ssbo_bindings{{

--- a/Source/Core/VideoCommon/Constants.h
+++ b/Source/Core/VideoCommon/Constants.h
@@ -7,6 +7,13 @@
 
 namespace VideoCommon
 {
+#ifdef ANDROID
+// Some devices seem to have graphical errors when providing 16 pixel samplers
+// given the logic is for a performance heavy feature (custom shaders), will just disable for now
+// TODO: handle this more elegantly
+constexpr u32 MAX_PIXEL_SHADER_SAMPLERS = 8;
+#else
 constexpr u32 MAX_PIXEL_SHADER_SAMPLERS = 16;
+#endif
 constexpr u32 MAX_COMPUTE_SHADER_SAMPLERS = 8;
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.cpp
@@ -3,6 +3,9 @@
 
 #include "VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.h"
 
+#include "Common/Logging/Log.h"
+
+#include "VideoCommon/Constants.h"
 #include "VideoCommon/GraphicsModSystem/Runtime/Actions/CustomPipelineAction.h"
 #include "VideoCommon/GraphicsModSystem/Runtime/Actions/MoveAction.h"
 #include "VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.h"
@@ -32,7 +35,16 @@ std::unique_ptr<GraphicsModAction> Create(std::string_view name, const picojson:
   }
   else if (name == "custom_pipeline")
   {
+#ifdef ANDROID
+    // Custom shaders currently need more than 8 pixel samplers
+    // to be used with textures, rather than make things complicated
+    // just disable the feature for Android which has issues
+    ERROR_LOG_FMT(VIDEO, "Android needs more than 8 pixel samplers to function, {} provided",
+                  VideoCommon::MAX_PIXEL_SHADER_SAMPLERS);
+    return nullptr;
+#else
     return CustomPipelineAction::Create(json_data, std::move(library));
+#endif
   }
 
   return nullptr;


### PR DESCRIPTION
In #12370 I increased the max pixel samplers to 16, after having a handful of users test various backends and devices.  Unfortunately, my biggest fear came true, some Android devices seem to have issues with this change.  For reasons I can't explain, there are graphical issues that occur on some games (Zelda:WW and Zelda:TP were reported) on at least some devices (Pixel6).

The feature 12370 was implemented for was a new approach to how custom shaders are handled.  Given that custom shaders are an enhancement and could potentially be a heavy performance operation on weaker Android devices anyway, I've reverted the pixel shader count there and log an error saying custom shaders are unsupported on Android.

In the future, a more flexible approach could be looked at (for instance, changing the static value to something dynamic) that might allow us to support certain Android devices.