### PR TITLE
VideoCommon: handle asset memory going over reserved limit correctly

### DIFF
--- a/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
@@ -3,7 +3,6 @@
 
 #include "VideoCommon/Assets/CustomAssetLoader.h"
 
-#include "Common/Logging/Log.h"
 #include "Common/MemoryUtil.h"
 #include "VideoCommon/Assets/CustomAssetLibrary.h"
 
@@ -48,19 +47,22 @@ void CustomAssetLoader::Init()
   m_asset_load_thread.Reset("Custom Asset Loader", [this](std::weak_ptr<CustomAsset> asset) {
     if (auto ptr = asset.lock())
     {
+      if (m_memory_exceeded)
+        return;
+
       if (ptr->Load())
       {
         std::lock_guard lk(m_asset_load_lock);
         const std::size_t asset_memory_size = ptr->GetByteSizeInMemory();
-        if (m_max_memory_available >= m_total_bytes_loaded + asset_memory_size)
+        m_total_bytes_loaded += asset_memory_size;
+        m_assets_to_monitor.try_emplace(ptr->GetAssetId(), ptr);
+        if (m_total_bytes_loaded > m_max_memory_available)
         {
-          m_total_bytes_loaded += asset_memory_size;
-          m_assets_to_monitor.try_emplace(ptr->GetAssetId(), ptr);
-        }
-        else
-        {
-          ERROR_LOG_FMT(VIDEO, "Failed to load asset {} because there was not enough memory.",
+          ERROR_LOG_FMT(VIDEO,
+                        "Asset memory exceeded with asset '{}', future assets won't load until "
+                        "memory is available.",
                         ptr->GetAssetId());
+          m_memory_exceeded = true;
         }
       }
     }


### PR DESCRIPTION
When assets exceeded the reserved memory limit (ex: a large texture pack), we were going over that reserved amount because we were not stopping future loads of assets from occurring (we were only reporting it).  This should hopefully fix the crash that a user was seeing.  Will see if they can test.