### PR TITLE
VideoCommon/PixelEngine: Passthrough system instance in constructor

### DIFF
--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -43,8 +43,9 @@ struct System::Impl
   explicit Impl(System& system)
       : m_audio_interface(system), m_core_timing(system), m_command_processor{system},
         m_cpu(system), m_dsp(system), m_dvd_interface(system), m_dvd_thread(system),
-        m_expansion_interface(system), m_fifo{system}, m_gp_fifo(system), m_memory(system),
-        m_power_pc(system), m_mmu(system, m_memory, m_power_pc), m_processor_interface(system),
+        m_expansion_interface(system), m_fifo{system}, m_gp_fifo(system),
+        m_memory(system), m_pixel_engine{system}, m_power_pc(system),
+        m_mmu(system, m_memory, m_power_pc), m_processor_interface(system),
         m_serial_interface(system), m_video_interface(system),
         m_interpreter(system, m_power_pc.GetPPCState(), m_mmu), m_jit_interface(system)
   {

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -190,7 +190,7 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
       g_framebuffer_manager->RefreshPeekCache();
       auto& system = Core::System::GetInstance();
       if (!system.GetFifo().UseDeterministicGPUThread())
-        system.GetPixelEngine().SetFinish(system, cycles_into_future);  // may generate interrupt
+        system.GetPixelEngine().SetFinish(cycles_into_future);  // may generate interrupt
       DEBUG_LOG_FMT(VIDEO, "GXSetDrawDone SetPEFinish (value: {:#04X})", bp.newvalue & 0xFFFF);
       return;
     }
@@ -210,7 +210,7 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
     auto& system = Core::System::GetInstance();
     if (!system.GetFifo().UseDeterministicGPUThread())
     {
-      system.GetPixelEngine().SetToken(system, static_cast<u16>(bp.newvalue & 0xFFFF), false,
+      system.GetPixelEngine().SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), false,
                                        cycles_into_future);
     }
     DEBUG_LOG_FMT(VIDEO, "SetPEToken {:#06X}", bp.newvalue & 0xFFFF);
@@ -226,7 +226,7 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
     auto& system = Core::System::GetInstance();
     if (!system.GetFifo().UseDeterministicGPUThread())
     {
-      system.GetPixelEngine().SetToken(system, static_cast<u16>(bp.newvalue & 0xFFFF), true,
+      system.GetPixelEngine().SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), true,
                                        cycles_into_future);
     }
     DEBUG_LOG_FMT(VIDEO, "SetPEToken + INT {:#06X}", bp.newvalue & 0xFFFF);
@@ -803,13 +803,13 @@ void LoadBPRegPreprocess(u8 reg, u32 value, int cycles_into_future)
   {
   case BPMEM_SETDRAWDONE:
     if ((newval & 0xff) == 0x02)
-      system.GetPixelEngine().SetFinish(system, cycles_into_future);
+      system.GetPixelEngine().SetFinish(cycles_into_future);
     break;
   case BPMEM_PE_TOKEN_ID:
-    system.GetPixelEngine().SetToken(system, newval & 0xffff, false, cycles_into_future);
+    system.GetPixelEngine().SetToken(newval & 0xffff, false, cycles_into_future);
     break;
   case BPMEM_PE_TOKEN_INT_ID:  // Pixel Engine Interrupt Token ID
-    system.GetPixelEngine().SetToken(system, newval & 0xffff, true, cycles_into_future);
+    system.GetPixelEngine().SetToken(newval & 0xffff, true, cycles_into_future);
     break;
   }
 }

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -160,8 +160,7 @@ void PixelEngineManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 
 void PixelEngineManager::UpdateInterrupts()
 {
-  auto& system = Core::System::GetInstance();
-  auto& processor_interface = system.GetProcessorInterface();
+  auto& processor_interface = m_system.GetProcessorInterface();
 
   // check if there is a token-interrupt
   processor_interface.SetInterrupt(INT_CAUSE_PE_TOKEN,

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -179,7 +179,7 @@ void PixelEngineManager::SetTokenFinish_OnMainThread_Static(Core::System& system
 
 void PixelEngineManager::SetTokenFinish_OnMainThread(u64 userdata, s64 cycles_late)
 {
-  std::unique_lock<std::mutex> lk(m_token_finish_mutex);
+  std::unique_lock lk(m_token_finish_mutex);
   m_event_raised = false;
 
   m_token = m_token_pending;
@@ -230,7 +230,7 @@ void PixelEngineManager::SetToken(const u16 token, const bool interrupt, int cyc
 {
   DEBUG_LOG_FMT(PIXELENGINE, "VIDEO Backend raises INT_CAUSE_PE_TOKEN (btw, token: {:04x})", token);
 
-  std::lock_guard<std::mutex> lk(m_token_finish_mutex);
+  std::lock_guard lk(m_token_finish_mutex);
 
   m_token_pending = token;
   m_token_interrupt_pending |= interrupt;
@@ -244,7 +244,7 @@ void PixelEngineManager::SetFinish(int cycles_into_future)
 {
   DEBUG_LOG_FMT(PIXELENGINE, "VIDEO Set Finish");
 
-  std::lock_guard<std::mutex> lk(m_token_finish_mutex);
+  std::lock_guard lk(m_token_finish_mutex);
 
   m_finish_interrupt_pending |= true;
 

--- a/Source/Core/VideoCommon/PixelEngine.h
+++ b/Source/Core/VideoCommon/PixelEngine.h
@@ -179,20 +179,22 @@ union UPECtrlReg
 class PixelEngineManager
 {
 public:
-  void Init(Core::System& system);
+  explicit PixelEngineManager(Core::System& system);
+
+  void Init();
   void DoState(PointerWrap& p);
 
   void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
   // gfx backend support
-  void SetToken(Core::System& system, const u16 token, const bool interrupt, int cycle_delay);
-  void SetFinish(Core::System& system, int cycle_delay);
+  void SetToken(const u16 token, const bool interrupt, int cycle_delay);
+  void SetFinish(int cycle_delay);
   AlphaReadMode GetAlphaReadMode() const { return m_alpha_read.read_mode; }
 
 private:
-  void RaiseEvent(Core::System& system, int cycles_into_future);
+  void RaiseEvent(int cycles_into_future);
   void UpdateInterrupts();
-  void SetTokenFinish_OnMainThread(Core::System& system, u64 userdata, s64 cycles_late);
+  void SetTokenFinish_OnMainThread(u64 userdata, s64 cycles_late);
 
   static void SetTokenFinish_OnMainThread_Static(Core::System& system, u64 userdata,
                                                  s64 cycles_late);
@@ -216,6 +218,8 @@ private:
   bool m_signal_finish_interrupt = false;
 
   CoreTiming::EventType* m_event_type_set_token_finish = nullptr;
+
+  Core::System& m_system;
 };
 
 }  // namespace PixelEngine

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -380,7 +380,7 @@ bool VideoBackendBase::InitializeShared(std::unique_ptr<AbstractGfx> gfx,
   auto& command_processor = system.GetCommandProcessor();
   command_processor.Init();
   system.GetFifo().Init();
-  system.GetPixelEngine().Init(system);
+  system.GetPixelEngine().Init();
   BPInit();
   VertexLoaderManager::Init();
   system.GetVertexShaderManager().Init();


### PR DESCRIPTION
Simplifies the interface in terms of usage. Also lets us get rid of a global system accessor and be consistent with most other manager types.