### PR TITLE
Socket: Fix a nullptr dereference when operations are pending

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -573,7 +573,7 @@ void EmulationKernel::AddStaticDevices()
   if (HasFeature(features, Feature::KD) || HasFeature(features, Feature::SO) ||
       HasFeature(features, Feature::SSL))
   {
-    m_socket_manager = std::make_shared<IOS::HLE::WiiSockMan>();
+    m_socket_manager = std::make_shared<IOS::HLE::WiiSockMan>(*this);
   }
   if (HasFeature(features, Feature::KD))
   {

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -199,7 +199,6 @@ private:
       NET_IOCTL net_type;
       SSL_IOCTL ssl_type;
     };
-    void Abort(s32 value);
   };
 
   enum class ConnectingState
@@ -216,6 +215,7 @@ private:
   s32 Shutdown(u32 how);
   s32 CloseFd();
   s32 FCntl(u32 cmd, u32 arg);
+  void Abort(sockop* op, s32 value) const;
 
   const Timeout& GetTimeout();
   void ResetTimeout();
@@ -256,7 +256,7 @@ public:
     s64 timeout = 0;
   };
 
-  WiiSockMan();
+  explicit WiiSockMan(EmulationKernel& ios);
   WiiSockMan(const WiiSockMan&) = delete;
   WiiSockMan& operator=(const WiiSockMan&) = delete;
   WiiSockMan(WiiSockMan&&) = delete;
@@ -283,6 +283,7 @@ public:
   s32 GetLastNetError() const { return errno_last; }
   void SetLastNetError(s32 error) { errno_last = error; }
   void Clean() { WiiSockets.clear(); }
+  void EnqueueIPCReply(const Request& request, s32 return_value) const;
   template <typename T>
   void DoSock(s32 sock, const Request& request, T type)
   {
@@ -291,7 +292,7 @@ public:
     {
       ERROR_LOG_FMT(IOS_NET, "DoSock: Error, fd not found ({:08x}, {:08X}, {:08X})", sock,
                     request.address, Common::ToUnderlying(type));
-      GetIOS()->EnqueueIPCReply(request, -SO_EBADF);
+      EnqueueIPCReply(request, -SO_EBADF);
     }
     else
     {
@@ -304,6 +305,7 @@ public:
 private:
   void UpdatePollCommands();
 
+  EmulationKernel& m_ios;
   std::unordered_map<s32, WiiSocket> WiiSockets;
   s32 errno_last = 0;
   std::vector<PollCommand> pending_polls;


### PR DESCRIPTION
This PR fixes the crash mentioned in https://dolp.in/i13442.

I suppose it's introduced in https://github.com/dolphin-emu/dolphin/pull/11767. Since the instance was moved to the kernel, it's destroyed when the kernel is. When the socket manager is destroyed so are its sockets which will abort pending operations. Pending operations relied on `GetIOS()` to abort them. However, this function will return `nullptr` on force shutdown because `s_ios.reset()` is called. So it wasn't able to call member functions of the IOS instance being destructed and was dereferencing `nullptr` instead.

I created a simple test case to reproduce the issue which is accepting a socket connection. You just need to run it _(and not connect to it)_, then force shutdown the homebrew by pressing the stop button twice on the GUI which will crash Dolphin.
[net_accept.zip](https://github.com/dolphin-emu/dolphin/files/13760203/net_accept.zip)

Ready to be reviewed & merged.