### PR TITLE
NetKDRequestDevice: Fix sporadic crashes during emulation shutdown

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -577,8 +577,11 @@ void EmulationKernel::AddStaticDevices()
   }
   if (HasFeature(features, Feature::KD))
   {
-    AddDevice(std::make_unique<NetKDRequestDevice>(*this, "/dev/net/kd/request"));
-    AddDevice(std::make_unique<NetKDTimeDevice>(*this, "/dev/net/kd/time"));
+    constexpr auto time_device_name = "/dev/net/kd/time";
+    AddDevice(std::make_unique<NetKDTimeDevice>(*this, time_device_name));
+    const auto time_device =
+        std::static_pointer_cast<NetKDTimeDevice>(GetDeviceByName(time_device_name));
+    AddDevice(std::make_unique<NetKDRequestDevice>(*this, "/dev/net/kd/request", time_device));
   }
   if (HasFeature(features, Feature::NCD))
   {

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -190,6 +190,8 @@ NetKDRequestDevice::~NetKDRequestDevice()
   }
 
   m_scheduler_timer_thread.join();
+  m_scheduler_work_queue.Shutdown();
+  m_work_queue.Shutdown();
 }
 
 void NetKDRequestDevice::Update()

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -153,9 +153,10 @@ s32 NWC24MakeUserID(u64* nwc24_id, u32 hollywood_id, u16 id_ctr, HardwareModel h
 }
 }  // Anonymous namespace
 
-NetKDRequestDevice::NetKDRequestDevice(EmulationKernel& ios, const std::string& device_name)
+NetKDRequestDevice::NetKDRequestDevice(EmulationKernel& ios, const std::string& device_name,
+                                       const std::shared_ptr<NetKDTimeDevice>& time_device)
     : EmulationDevice(ios, device_name), m_config{ios.GetFS()}, m_dl_list{ios.GetFS()},
-      m_send_list{ios.GetFS()}, m_friend_list{ios.GetFS()}
+      m_send_list{ios.GetFS()}, m_friend_list{ios.GetFS()}, m_time_device{time_device}
 {
   // Enable all NWC24 permissions
   m_scheduler_buffer[1] = Common::swap32(-1);
@@ -443,9 +444,7 @@ NWC24::ErrorCode NetKDRequestDevice::DetermineDownloadTask(u16* entry_index,
   // As the scheduler does not tell us which entry to download, we must determine that.
   // A correct entry is one that hasn't been downloaded the longest compared to other entries.
   // We first need current UTC.
-  const auto time_device =
-      std::static_pointer_cast<NetKDTimeDevice>(GetIOS()->GetDeviceByName("/dev/net/kd/time"));
-  const u64 current_utc = time_device->GetAdjustedUTC();
+  const u64 current_utc = m_time_device->GetAdjustedUTC();
   u64 lowest_timestamp = std::numeric_limits<u64>::max();
 
   for (u16 i = 0; i < static_cast<u16>(NWC24::NWC24Dl::MAX_ENTRIES); i++)
@@ -495,9 +494,7 @@ NWC24::ErrorCode NetKDRequestDevice::DetermineSubtask(u16 entry_index,
   if (m_dl_list.IsSubtaskDownloadDisabled(entry_index))
     return NWC24::WC24_ERR_DISABLED;
 
-  const auto time_device =
-      std::static_pointer_cast<NetKDTimeDevice>(GetIOS()->GetDeviceByName("/dev/net/kd/time"));
-  const u64 current_utc = time_device->GetAdjustedUTC();
+  const u64 current_utc = m_time_device->GetAdjustedUTC();
   for (u8 i = 0; i < 32; i++)
   {
     if (!m_dl_list.IsValidSubtask(entry_index, i))
@@ -647,9 +644,7 @@ NWC24::ErrorCode NetKDRequestDevice::KDDownload(const u16 entry_index,
 {
   bool success = false;
   Common::ScopeGuard state_guard([&] {
-    const auto time_device =
-        std::static_pointer_cast<NetKDTimeDevice>(GetIOS()->GetDeviceByName("/dev/net/kd/time"));
-    const u64 current_utc = time_device->GetAdjustedUTC();
+    const u64 current_utc = m_time_device->GetAdjustedUTC();
     if (success)
     {
       // Set the next download time to the dl_margin

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <queue>
 #include <string>
 
@@ -17,6 +18,7 @@
 #include "Core/IOS/Network/KD/Mail/WC24Send.h"
 #include "Core/IOS/Network/KD/NWC24Config.h"
 #include "Core/IOS/Network/KD/NWC24DL.h"
+#include "Core/IOS/Network/KD/NetKDTime.h"
 
 namespace IOS::HLE
 {
@@ -26,7 +28,8 @@ namespace IOS::HLE
 class NetKDRequestDevice : public EmulationDevice
 {
 public:
-  NetKDRequestDevice(EmulationKernel& ios, const std::string& device_name);
+  NetKDRequestDevice(EmulationKernel& ios, const std::string& device_name,
+                     const std::shared_ptr<NetKDTimeDevice>& time_device);
   IPCReply HandleNWC24DownloadNowEx(const IOCtlRequest& request);
   NWC24::ErrorCode KDDownload(const u16 entry_index, const std::optional<u8> subtask_id);
   IPCReply HandleNWC24CheckMailNow(const IOCtlRequest& request);
@@ -114,6 +117,7 @@ private:
   std::queue<AsyncReply> m_async_replies;
   u32 m_error_count = 0;
   std::array<u32, 256> m_scheduler_buffer{};
+  std::shared_ptr<NetKDTimeDevice> m_time_device;
   // TODO: Maybe move away from Common::HttpRequest?
   Common::HttpRequest m_http{std::chrono::minutes{1}};
   u32 m_download_span = 2;


### PR DESCRIPTION
In the last few months I've had a handful of random crashes when shutting down emulation which happened in NetKDRequestDevice::KDDownload().

The first was the result of using-after-freeing of some of NetKDRequestDevices's members by its WorkQueueThreads, which this PR resolves by calling the latter's Shutdown function in NetKDRequestDevice's destructor so the threads are finished before destroying any members.

The other crash was caused by one of two possible nullptr dereferences. The first is when calling GetIOS() in KDDownload(), which could return nullptr if called after IOS::HLE::Shutdown had reset s_ios. The other happened with the following sequence: 
* The work thread called GetIOS and got the non-null s_ios ptr.
* The CPU thread called s_ios.reset(), which runs EmulationKernel's destructor and clears m_device_map.
* The work thread called GetDeviceByName(), which failed to find NetKDTimeDevice in the now-empty map

This crash is resolved by storing a shared_ptr to NetKDTimeDevice inside NetKDRequestDevice, which skips the lookup via GetIOS and ensures the NetKDTimeDevice will exist through NetKDRequestDevice's lifespan.

