### PR TITLE
Jit: Reload RMEM/MEM_REG on ISI exception

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -221,6 +221,9 @@ void Jit64AsmRoutineManager::Generate()
   ABI_CallFunction(JitTrampoline);
   ABI_PopRegistersAndAdjustStack({}, 0);
 
+  // If jitting triggered an ISI exception, MSR.DR may have changed
+  MOV(64, R(RMEM), PPCSTATE(mem_ptr));
+
   JMP(dispatcher_no_check, Jump::Near);
 
   SetJumpTarget(bail);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -177,7 +177,12 @@ void JitArm64::GenerateAsm()
   // Call JIT
   ResetStack();
   ABI_CallFunction(&JitTrampoline, this, DISPATCHER_PC);
+
   LDR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
+
+  // If jitting triggered an ISI exception, MSR.DR may have changed
+  EmitUpdateMembase();
+
   B(dispatcher_no_check);
 
   SetJumpTarget(bail);


### PR DESCRIPTION
Aims to fix https://bugs.dolphin-emu.org/issues/13444.