### PR TITLE
Common: Fix encoding handling in GetWin32ErrorString

### DIFF
--- a/Source/Core/Common/CommonFuncs.cpp
+++ b/Source/Core/Common/CommonFuncs.cpp
@@ -10,7 +10,10 @@
 
 #ifdef _WIN32
 #include <windows.h>
+
 #define strerror_r(err, buf, len) strerror_s(buf, len, err)
+
+#include "Common/StringUtil.h"
 #endif
 
 namespace Common
@@ -59,11 +62,11 @@ std::string GetLastErrorString()
 // Like GetLastErrorString() but if you have already queried the error code.
 std::string GetWin32ErrorString(DWORD error_code)
 {
-  char error_message[BUFFER_SIZE];
+  wchar_t error_message[BUFFER_SIZE];
 
-  FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, error_code,
+  FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, error_code,
                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), error_message, BUFFER_SIZE, nullptr);
-  return std::string(error_message);
+  return WStringToUTF8(error_message);
 }
 
 // Obtains a full path to the specified module.


### PR DESCRIPTION
These messages can be localized, so we can't just assume it's all ASCII.