### PR TITLE
Fix Logic Inefficiency in Arm64GPRCache::FlushRegisters

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -243,8 +243,9 @@ void Arm64GPRCache::FlushRegister(size_t index, bool maintain_state, ARM64Reg tm
 
 void Arm64GPRCache::FlushRegisters(BitSet32 regs, bool maintain_state, ARM64Reg tmp_reg)
 {
-  for (int i : regs)
+  for (auto iter = regs.begin(); iter != regs.end(); ++iter)
   {
+    const int i = *iter;
     ASSERT_MSG(DYNA_REC, m_guest_registers[GUEST_GPR_OFFSET + i].GetType() != RegType::Discarded,
                "Attempted to flush discarded register");
 
@@ -269,7 +270,7 @@ void Arm64GPRCache::FlushRegisters(BitSet32 regs, bool maintain_state, ARM64Reg 
             reg1.Flush();
             reg2.Flush();
           }
-          ++i;
+          ++iter;
           continue;
         }
       }


### PR DESCRIPTION
This was introduced in 6a9f565ac4ddc65b2fdbf2293282ddd432ba89ae.