### PR TITLE
Gameini: Disable "Immediately Present XFB" for Racquet Sports

### DIFF
--- a/Data/Sys/GameSettings/SRQ.ini
+++ b/Data/Sys/GameSettings/SRQ.ini
@@ -1,0 +1,17 @@
+# SRQE41, SRQP41 - Racquet Sports
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+#This prevents the loading screen from running uncapped
+ImmediateXFBEnable = False


### PR DESCRIPTION
This was causing the game to output thousands of FPS during the loading screen when it would run uncapped if Immediately Present XFB was enabled.

Please see [redmine 13447](https://bugs.dolphin-emu.org/issues/13447) for reference