### PR TITLE
GameSettings: Don't force EFB to RAM for PokéPark Wii

### DIFF
--- a/Data/Sys/GameSettings/R8A.ini
+++ b/Data/Sys/GameSettings/R8A.ini
@@ -14,7 +14,3 @@
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-EFBToTextureEnable = False
-


### PR DESCRIPTION
This is another one of those games that has an optional screenshot feature where the images end up all black if you have Store EFB Copies to Texture Only turned on. Like for other such games, let's not force Store EFB Copies to Texture Only off, since it's a large performance impact for a feature most players won't use.

There's one wrinkle here. As part of teaching the player how to take screenshots, the game forces the player to take a screenshot before it lets them progress in the story. However, the game doesn't care what's in the screenshot, so you can progress just fine even if Store EFB Copies to Texture Only is turned on. I personally tested it.