### PR TITLE
Core/CodeTrace: Take address from given instruction in GetInstructionAttributes().

### DIFF
--- a/Source/Core/Core/Debugger/CodeTrace.cpp
+++ b/Source/Core/Core/Debugger/CodeTrace.cpp
@@ -73,13 +73,11 @@ void CodeTrace::SetRegTracked(const std::string& reg)
 
 InstructionAttributes CodeTrace::GetInstructionAttributes(const TraceOutput& instruction) const
 {
-  auto& system = Core::System::GetInstance();
-
   // Slower process of breaking down saved instruction. Only used when stepping through code if a
   // decision has to be made, otherwise used afterwards on a log file.
   InstructionAttributes tmp_attributes;
   tmp_attributes.instruction = instruction.instruction;
-  tmp_attributes.address = system.GetPPCState().pc;
+  tmp_attributes.address = instruction.address;
   std::string instr = instruction.instruction;
   std::smatch match;
 


### PR DESCRIPTION
In all instance this method is called, the instruction comes from SaveCurrentInstruction(), which already sets the address to the PC.

Avoids the use of the global system.