### PR TITLE
Core: Pass System through more of the emulation thread init process.

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -142,7 +142,8 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
   if (!boot->riivolution_patches.empty())
     Config::SetCurrent(Config::MAIN_FAST_DISC_SPEED, true);
 
-  Core::System::GetInstance().Initialize();
+  auto& system = Core::System::GetInstance();
+  system.Initialize();
 
   Core::UpdateWantDeterminism(/*initial*/ true);
 
@@ -173,13 +174,14 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
   if (load_ipl)
   {
     return Core::Init(
+        system,
         std::make_unique<BootParameters>(
             BootParameters::IPL{StartUp.m_region,
                                 std::move(std::get<BootParameters::Disc>(boot->parameters))},
             std::move(boot->boot_session_data)),
         wsi);
   }
-  return Core::Init(std::move(boot), wsi);
+  return Core::Init(system, std::move(boot), wsi);
 }
 
 // SYSCONF can be modified during emulation by the user and internally, which makes it

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -124,7 +124,7 @@ private:
   bool m_was_unpaused = false;
 };
 
-bool Init(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi);
+bool Init(Core::System& system, std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi);
 void Stop();
 void Shutdown();
 


### PR DESCRIPTION
Gets rid of a few calls to `Core::System::GetInstance()`.