### PR TITLE
VKGfx: Don't panic for VK_SUBOPTIMAL_KHR

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
@@ -283,7 +283,7 @@ void VKGfx::BindBackbuffer(const ClearColor& clear_color)
     }
 
     res = m_swap_chain->AcquireNextImage();
-    if (res != VK_SUCCESS)
+    if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR)
       PanicAlertFmt("Failed to grab image from swap chain: {:#010X} {}", Common::ToUnderlying(res),
                     VkResultToString(res));
   }


### PR DESCRIPTION
When resizing the Dolphin emulation window (when using the Vulkan backend), you get greeted with this:
![image](https://github.com/dolphin-emu/dolphin/assets/40663462/c4f3cc77-8d18-4702-9f4b-cafaaef66309)

Along with (in the logs):
```
VideoBackends/Vulkan/VKGfx.cpp:287 E[MASTER]: Warning: Failed to grab image from swap chain: 0X3B9ACDEB VK_SUBOPTIMAL_KHR
```

Choosing to ignore for this session apparently causes no issues, so maybe it shouldn't pop up in the first place. Which is what this PR does.

I'm absolutely not sure whether this PR does the correct thing.
[Here's how PCSX2 does it.](https://github.com/PCSX2/pcsx2/blob/10389dc3f18a41ba84dd0fea5f95af9419918e59/pcsx2/GS/Renderers/Vulkan/GSDeviceVK.cpp#L2379)