### PR TITLE
Core/DSPHLE: Move AESndAccelerator instance into AESndUCode.

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AESnd.h
@@ -7,11 +7,20 @@
 #include <utility>
 
 #include "Common/CommonTypes.h"
+#include "Core/DSP/DSPAccelerator.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 namespace DSP::HLE
 {
 class DSPHLE;
+
+class AESndAccelerator final : public Accelerator
+{
+protected:
+  void OnEndException() override;
+  u8 ReadMemory(u32 address) override;
+  void WriteMemory(u32 address, u8 value) override;
+};
 
 class AESndUCode final : public UCodeInterface
 {
@@ -104,6 +113,8 @@ private:
   static constexpr u32 NUM_OUTPUT_SAMPLES = 96;
 
   std::array<s16, NUM_OUTPUT_SAMPLES * 2> m_output_buffer{};
+
+  AESndAccelerator m_accelerator;
 
   bool m_has_shown_unsupported_sample_format_warning = false;
 };


### PR DESCRIPTION
This changes the `AESndAccelerator` instance from global state to state local to each `AESndUCode` instance. I'm not sure whether this has side-effects (is this state intendend to persist across unload and reload of an UCode?), so this may need a different approach if it does.

Untested.