### PR TITLE
Core/DSPHLE: Deglobalize HLEAccelerator state in AX and AXWii UCodes.

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <optional>
 
 #include "Common/BitUtils.h"
@@ -20,6 +21,11 @@
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/Memmap.h"
 #include "Core/System.h"
+
+namespace DSP
+{
+class Accelerator;
+}
 
 namespace DSP::HLE
 {
@@ -67,6 +73,7 @@ class AXUCode /* not final: subclassed by AXWiiUCode */ : public UCodeInterface
 {
 public:
   AXUCode(DSPHLE* dsphle, u32 crc);
+  ~AXUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;
@@ -99,6 +106,10 @@ protected:
   std::array<s16, 0x800> m_coeffs{};
 
   u16 m_compressor_pos = 0;
+
+  std::unique_ptr<Accelerator> m_accelerator;
+
+  void InitializeShared();
 
   bool LoadResamplingCoefficients(bool require_same_checksum, u32 desired_checksum);
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -30,6 +30,13 @@ AXWiiUCode::AXWiiUCode(DSPHLE* dsphle, u32 crc) : AXUCode(dsphle, crc), m_last_m
   m_old_axwii = (crc == 0xfa450138) || (crc == 0x7699af32);
 }
 
+void AXWiiUCode::Initialize()
+{
+  InitializeShared();
+
+  m_accelerator = std::make_unique<HLEAccelerator>();
+}
+
 void AXWiiUCode::HandleCommandList()
 {
   // Temp variables for addresses computation
@@ -436,7 +443,8 @@ void AXWiiUCode::ProcessPBList(u32 pb_addr)
       for (int curr_ms = 0; curr_ms < 3; ++curr_ms)
       {
         ApplyUpdatesForMs(curr_ms, pb, num_updates, updates);
-        ProcessVoice(pb, buffers, spms, ConvertMixerControl(HILO_TO_32(pb.mixer_control)),
+        ProcessVoice(static_cast<HLEAccelerator*>(m_accelerator.get()), pb, buffers, spms,
+                     ConvertMixerControl(HILO_TO_32(pb.mixer_control)),
                      m_coeffs_checksum ? m_coeffs.data() : nullptr);
 
         // Forward the buffers
@@ -447,7 +455,8 @@ void AXWiiUCode::ProcessPBList(u32 pb_addr)
     }
     else
     {
-      ProcessVoice(pb, buffers, 96, ConvertMixerControl(HILO_TO_32(pb.mixer_control)),
+      ProcessVoice(static_cast<HLEAccelerator*>(m_accelerator.get()), pb, buffers, 96,
+                   ConvertMixerControl(HILO_TO_32(pb.mixer_control)),
                    m_coeffs_checksum ? m_coeffs.data() : nullptr);
     }
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
@@ -16,6 +16,7 @@ class AXWiiUCode final : public AXUCode
 public:
   AXWiiUCode(DSPHLE* dsphle, u32 crc);
 
+  void Initialize() override;
   void DoState(PointerWrap& p) override;
 
 protected:

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -95,7 +95,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 165;  // Last changed in PR 12328
+constexpr u32 STATE_VERSION = 166;  // Last changed in PR 12487
 
 // Increase this if the StateExtendedHeader definition changes
 constexpr u32 EXTENDED_HEADER_VERSION = 1;  // Last changed in PR 12217


### PR DESCRIPTION
Genuinely don't understand why this was global state before. The entire state of the accelerator is reset on every call to GetInputSamples(), and that's the only function that uses it.