### PR TITLE
JitArm64: Remove unnecessary locking of W0 in psq_stXX

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -27,9 +27,9 @@ void JitArm64::psq_lXX(UGeckoInstruction inst)
               !(m_ppc_state.feature_flags & FEATURE_FLAG_MSR_DR));
 
   // X30 is LR
-  // X0 is the address
-  // X1 contains the scale
-  // X2 is a temporary
+  // X0 is a temporary
+  // X1 is the address
+  // X2 is the scale
   // Q0 is the return register
   // Q1 is a temporary
   const s32 offset = inst.SIMM_12;
@@ -156,8 +156,9 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
               !(m_ppc_state.feature_flags & FEATURE_FLAG_MSR_DR));
 
   // X30 is LR
-  // X0 contains the scale
-  // X1 is the address
+  // X0 is a temporary
+  // X1 is the scale
+  // X2 is the address
   // Q0 is the store register
 
   const s32 offset = inst.SIMM_12;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -204,7 +204,7 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
   }
 
   gpr.Lock(ARM64Reg::W1, ARM64Reg::W2, ARM64Reg::W30);
-  if (!js.assumeNoPairedQuantize || jo.memcheck || !jo.fastmem)
+  if (!js.assumeNoPairedQuantize || !jo.fastmem)
     gpr.Lock(ARM64Reg::W0);
   if (!js.assumeNoPairedQuantize && !jo.fastmem)
     gpr.Lock(ARM64Reg::W3);
@@ -283,7 +283,7 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
 
   gpr.Unlock(ARM64Reg::W1, ARM64Reg::W2, ARM64Reg::W30);
   fpr.Unlock(ARM64Reg::Q0);
-  if (!js.assumeNoPairedQuantize || jo.memcheck || !jo.fastmem)
+  if (!js.assumeNoPairedQuantize || !jo.fastmem)
     gpr.Unlock(ARM64Reg::W0);
   if (!js.assumeNoPairedQuantize && !jo.fastmem)
     gpr.Unlock(ARM64Reg::W3);


### PR DESCRIPTION
It seems like I made a small mistake in PR #12320. Locking W0 when `jo.memcheck` is true is only necessary for load instructions, not store instructions.