### PR TITLE
HW/SI: Remove remaining global system accessors

### DIFF
--- a/Source/Core/Core/HW/SI/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI/SI_Device.cpp
@@ -112,7 +112,8 @@ void ISIDevice::OnEvent(u64 userdata, s64 cycles_late)
 {
 }
 
-int SIDevice_GetGBATransferTime(EBufferCommands cmd)
+int SIDevice_GetGBATransferTime(const SystemTimers::SystemTimersManager& timers,
+                                EBufferCommands cmd)
 {
   u64 gc_bytes_transferred = 1;
   u64 gba_bytes_transferred = 1;
@@ -143,7 +144,7 @@ int SIDevice_GetGBATransferTime(EBufferCommands cmd)
   }
   }
 
-  const u32 ticks_per_second = Core::System::GetInstance().GetSystemTimers().GetTicksPerSecond();
+  const u32 ticks_per_second = timers.GetTicksPerSecond();
   const u64 cycles = (gba_bytes_transferred * 8 * ticks_per_second / GBA_BITS_PER_SECOND) +
                      (gc_bytes_transferred * 8 * ticks_per_second / GC_BITS_PER_SECOND) +
                      (stop_bits_ns * ticks_per_second / 1000000000LL);

--- a/Source/Core/Core/HW/SI/SI_Device.h
+++ b/Source/Core/Core/HW/SI/SI_Device.h
@@ -12,6 +12,10 @@ namespace Core
 {
 class System;
 }
+namespace SystemTimers
+{
+class SystemTimersManager;
+}
 
 namespace SerialInterface
 {
@@ -138,7 +142,8 @@ protected:
   SIDevices m_device_type;
 };
 
-int SIDevice_GetGBATransferTime(EBufferCommands cmd);
+int SIDevice_GetGBATransferTime(const SystemTimers::SystemTimersManager& timers,
+                                EBufferCommands cmd);
 bool SIDevice_IsGCController(SIDevices type);
 
 std::unique_ptr<ISIDevice> SIDevice_Create(Core::System& system, SIDevices device, int port_number);

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
@@ -298,7 +298,7 @@ int CSIDevice_GBA::RunBuffer(u8* buffer, int request_length)
   {
     int elapsed_time = static_cast<int>(m_system.GetCoreTiming().GetTicks() - m_timestamp_sent);
     // Tell SI to ask again after TransferInterval() cycles
-    if (SIDevice_GetGBATransferTime(m_last_cmd) > elapsed_time)
+    if (SIDevice_GetGBATransferTime(m_system.GetSystemTimers(), m_last_cmd) > elapsed_time)
       return 0;
     m_next_action = NextAction::ReceiveResponse;
     [[fallthrough]];
@@ -345,7 +345,7 @@ int CSIDevice_GBA::RunBuffer(u8* buffer, int request_length)
 
 int CSIDevice_GBA::TransferInterval()
 {
-  return SIDevice_GetGBATransferTime(m_last_cmd);
+  return SIDevice_GetGBATransferTime(m_system.GetSystemTimers(), m_last_cmd);
 }
 
 bool CSIDevice_GBA::GetData(u32& hi, u32& low)

--- a/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.cpp
@@ -117,7 +117,7 @@ int CSIDevice_GBAEmu::RunBuffer(u8* buffer, int request_length)
 
 int CSIDevice_GBAEmu::TransferInterval()
 {
-  return SIDevice_GetGBATransferTime(m_last_cmd);
+  return SIDevice_GetGBATransferTime(m_system.GetSystemTimers(), m_last_cmd);
 }
 
 bool CSIDevice_GBAEmu::GetData(u32& hi, u32& low)


### PR DESCRIPTION
We can just pass in the system timer instance where needed instead of using the global accessor