### PR TITLE
Steam Deck: Pad out feature report to 64 bytes

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp
@@ -288,14 +288,13 @@ Core::DeviceRemoval Device::UpdateInput()
   if (++m_gyro_reenable == 250)
   {
     m_gyro_reenable = 0;
-    // Using names from Valve's contribution to SDL for the Steam Controller
-    // (and assuming this has not changed for the Deck), this packet decodes as:
+    // Using names from Valve's contribution to SDL this packet decodes as:
     // 0x00 = report ID
     // 0x87 = ID_SET_SETTINGS_VALUES
     // 0x03 = payload length
-    // 0x30 = SETTING_GYRO_MODE
+    // 0x30 = SETTING_IMU_MODE
     // 0x18 0x00 = SETTING_GYRO_MODE_SEND_RAW_ACCEL | SETTING_GYRO_MODE_SEND_RAW_GYRO
-    const unsigned char pkt[] = {0x00, 0x87, 0x03, 0x30, 0x18, 0x00};
+    const unsigned char pkt[65] = {0x00, 0x87, 0x03, 0x30, 0x18, 0x00};
     hid_send_feature_report(m_device, pkt, sizeof(pkt));
   }
 


### PR DESCRIPTION
Also update the names of the setting post-Steam Deck commits to SDL

I believe this fixes https://bugs.dolphin-emu.org/issues/13412, but it needs more testing from people that aren't me.