### PR TITLE
DSPHLE/Zelda: use precise 32-step volume ramping

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -1234,24 +1234,24 @@ void ZeldaAudioRenderer::AddVoice(u16 voice_id)
 
     struct
     {
-      MixingBuffer* buffer;
+      MixingBuffer& buffer;
       s16 volume;
       s16 volume_delta;
     } buffers[8] = {
-        {&m_buf_front_left, quadrant_volumes[0], volume_deltas[0]},
-        {&m_buf_back_left, quadrant_volumes[1], volume_deltas[1]},
-        {&m_buf_front_right, quadrant_volumes[2], volume_deltas[2]},
-        {&m_buf_back_right, quadrant_volumes[3], volume_deltas[3]},
+        {m_buf_front_left, quadrant_volumes[0], volume_deltas[0]},
+        {m_buf_back_left, quadrant_volumes[1], volume_deltas[1]},
+        {m_buf_front_right, quadrant_volumes[2], volume_deltas[2]},
+        {m_buf_back_right, quadrant_volumes[3], volume_deltas[3]},
 
-        {&m_buf_front_left_reverb, reverb_volumes[0], reverb_volume_deltas[0]},
-        {&m_buf_back_left_reverb, reverb_volumes[1], reverb_volume_deltas[1]},
-        {&m_buf_front_right_reverb, reverb_volumes[2], reverb_volume_deltas[2]},
-        {&m_buf_back_right_reverb, reverb_volumes[3], reverb_volume_deltas[3]},
+        {m_buf_front_left_reverb, reverb_volumes[0], reverb_volume_deltas[0]},
+        {m_buf_back_left_reverb, reverb_volumes[1], reverb_volume_deltas[1]},
+        {m_buf_front_right_reverb, reverb_volumes[2], reverb_volume_deltas[2]},
+        {m_buf_back_right_reverb, reverb_volumes[3], reverb_volume_deltas[3]},
     };
     for (const auto& buffer : buffers)
     {
       AddBuffersWithVolumeRamp(buffer.buffer, input_samples, buffer.volume << 16,
-                               (buffer.volume_delta << 16) / (s32)buffer.buffer->size());
+                               (buffer.volume_delta << 16) / (s32)buffer.buffer.size());
     }
 
     vpb.dolby_volume_current = vpb.dolby_volume_target;
@@ -1304,7 +1304,7 @@ void ZeldaAudioRenderer::AddVoice(u16 voice_id)
         continue;
       }
 
-      s32 new_volume = AddBuffersWithVolumeRamp(dst_buffer, input_samples,
+      s32 new_volume = AddBuffersWithVolumeRamp(*dst_buffer, input_samples,
                                                 vpb.channels[i].current_volume << 16, volume_step);
       vpb.channels[i].current_volume = new_volume >> 16;
     }

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -1251,7 +1251,7 @@ void ZeldaAudioRenderer::AddVoice(u16 voice_id)
     for (const auto& buffer : buffers)
     {
       AddBuffersWithVolumeRamp(buffer.buffer, input_samples, buffer.volume << 16,
-                               (buffer.volume_delta << 16) / (s32)buffer.buffer.size());
+                               buffer.volume_delta << 16);
     }
 
     vpb.dolby_volume_current = vpb.dolby_volume_target;
@@ -1286,13 +1286,11 @@ void ZeldaAudioRenderer::AddVoice(u16 voice_id)
       else
         volume_delta = vpb.channels[i].target_volume - vpb.channels[i].current_volume;
 
-      s32 volume_step = (volume_delta << 16) / (s32)input_samples.size();  // In 1.31 format.
-
       // TODO: The last value of each channel structure is used to
       // determine whether a channel should be skipped or not. Not
       // implemented yet.
 
-      if (!vpb.channels[i].current_volume && !volume_step)
+      if (!vpb.channels[i].current_volume && !volume_delta)
         continue;
 
       MixingBuffer* dst_buffer = BufferForID(vpb.channels[i].id);
@@ -1304,8 +1302,8 @@ void ZeldaAudioRenderer::AddVoice(u16 voice_id)
         continue;
       }
 
-      s32 new_volume = AddBuffersWithVolumeRamp(*dst_buffer, input_samples,
-                                                vpb.channels[i].current_volume << 16, volume_step);
+      s32 new_volume = AddBuffersWithVolumeRamp(
+          *dst_buffer, input_samples, vpb.channels[i].current_volume << 16, volume_delta << 16);
       vpb.channels[i].current_volume = new_volume >> 16;
     }
   }

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -51,6 +51,8 @@ private:
   // See Zelda.cpp for the list of possible flags.
   u32 m_flags;
 
+  typedef std::array<s16, 0x50> MixingBuffer;
+
   // Utility functions for audio operations.
 
   // Apply volume to a buffer. The volume is a fixed point integer, usually
@@ -82,16 +84,15 @@ private:
   //
   // Note: On a real GC, the stepping happens in 32 steps instead. But hey,
   // we can do better here with very low risk. Why not? :)
-  template <size_t N>
-  s32 AddBuffersWithVolumeRamp(std::array<s16, N>* dst, const std::array<s16, N>& src, s32 vol,
+  s32 AddBuffersWithVolumeRamp(MixingBuffer& dst, const MixingBuffer& src, s32 vol,
                                s32 step)
   {
     if (!vol && !step)
       return vol;
 
-    for (size_t i = 0; i < N; ++i)
+    for (size_t i = 0; i < 0x50; ++i)
     {
-      (*dst)[i] += ((vol >> 16) * src[i]) >> 16;
+      dst[i] += ((vol >> 16) * src[i]) >> 16;
       vol += step;
     }
 
@@ -120,7 +121,6 @@ private:
   u16 m_output_volume = 0;
 
   // Mixing buffers.
-  typedef std::array<s16, 0x50> MixingBuffer;
   MixingBuffer m_buf_front_left{};
   MixingBuffer m_buf_front_right{};
   MixingBuffer m_buf_back_left{};

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -80,20 +80,25 @@ private:
   }
 
   // Mixes two buffers together while applying a volume to one of them. The
-  // volume ramps up/down in N steps using the provided step delta value.
-  //
-  // Note: On a real GC, the stepping happens in 32 steps instead. But hey,
-  // we can do better here with very low risk. Why not? :)
-  s32 AddBuffersWithVolumeRamp(MixingBuffer& dst, const MixingBuffer& src, s32 vol,
-                               s32 step)
+  // volume ramps up/down in 32 steps using the provided delta value.
+  s32 AddBuffersWithVolumeRamp(MixingBuffer& dst, const MixingBuffer& src, s32 vol, s32 delta)
   {
-    if (!vol && !step)
+    if (!vol && !delta)
       return vol;
 
-    for (size_t i = 0; i < 0x50; ++i)
+    s32 step = delta >> 5;
+    for (size_t i = 0; i < 0x40;)
     {
       dst[i] += ((vol >> 16) * src[i]) >> 16;
+      ++i;
+      dst[i] += ((vol >> 16) * src[i]) >> 16;
+      ++i;
       vol += step;
+    }
+
+    for (size_t i = 0x40; i < 0x50; ++i)
+    {
+      dst[i] += ((vol >> 16) * src[i]) >> 16;
     }
 
     return vol;


### PR DESCRIPTION
Whilst the 80-step approach theoretically improves ramping smoothness, in practice it causes accumulating rounding errors because the delta value is not always a multiple of the buffer size.

Also pull the step computation into AddBuffersWithVolumeRamp() so that all ramping related math is in the same place.

This could fix some volume issues but so far I've not noticed anything definitive.