### PR TITLE
Partially revert "DolphinQt/Assembler: improve translatability"

### DIFF
--- a/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.cpp
@@ -17,10 +17,9 @@ namespace
 {
 QString HtmlFormatErrorLoc(const Common::GekkoAssembler::AssemblerError& err)
 {
-  const QString error = QStringLiteral("<span style=\"color: red; font-weight: bold\">%1</span>")
-                            .arg(QObject::tr("Error"));
-  // i18n: '%1' is the translation of 'Error'
-  return QObject::tr("%1 in column %2").arg(error).arg(err.col + 1);
+  return QObject::tr("<span style=\"color: red; font-weight: bold\">Error</span> on line %1 col %2")
+      .arg(err.line + 1)
+      .arg(err.col + 1);
 }
 
 QString HtmlFormatErrorLine(const Common::GekkoAssembler::AssemblerError& err)

--- a/Source/Core/DolphinQt/Debugger/AssemblerWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/AssemblerWidget.cpp
@@ -48,10 +48,9 @@ using namespace Common::GekkoAssembler;
 
 QString HtmlFormatErrorLoc(const AssemblerError& err)
 {
-  const QString error = QStringLiteral("<span style=\"color: red; font-weight: bold\">%1</span>")
-                            .arg(QObject::tr("Error"));
-  // i18n: '%1' is the translation of 'Error'
-  return QObject::tr("%1 on line %1 column %2").arg(error).arg(err.line + 1).arg(err.col + 1);
+  return QObject::tr("<span style=\"color: red; font-weight: bold\">Error</span> on line %1 col %2")
+      .arg(err.line + 1)
+      .arg(err.col + 1);
 }
 
 QString HtmlFormatErrorLine(const AssemblerError& err)
@@ -525,10 +524,8 @@ void AssemblerWidget::OnAssemble(std::vector<CodeBlock>* asm_out)
   if (!good)
   {
     base_address = 0;
-    const QString warning =
-        QStringLiteral("<span style=\"color:#ffcc00\">%1</span>").arg(tr("Warning"));
-    // i18n: '%1' is the translation of 'Warning'
-    m_error_box->append(tr("%1 invalid base address, defaulting to 0").arg(warning));
+    m_error_box->append(
+        tr("<span style=\"color:#ffcc00\">Warning</span> invalid base address, defaulting to 0"));
   }
 
   const std::string contents = active_editor->toPlainText().toStdString();


### PR DESCRIPTION
This reverts the parts of commit c8c9928eb1 that made translatability worse rather than better. Changing "Error in column %2" to "%1 in column %2" not only means that the translators have to check the i18n comments to know what word hides behind %1, but there's also the problem that the translator might need to translate "Error" in this context differently from the standalone string "Error". Having to copy-paste some HTML tags may be annoying for translators, but it's a far less serious problem.