### PR TITLE
GameINI: fix missing Miis in Data East Arcade Classics

### DIFF
--- a/Data/Sys/GameSettings/R26.ini
+++ b/Data/Sys/GameSettings/R26.ini
@@ -2,3 +2,7 @@
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+
+[Video_Hacks]
+# Required for Mii portraits to show up
+EFBToTextureEnable = False


### PR DESCRIPTION
This game requires "Store EFB Copies to Texture Only" set to false for Mii portraits to appear properly in the save data menu.