### PR TITLE
VideoCommon: add some helper functions for shader asset

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(common
   IOFile.h
   JitRegister.cpp
   JitRegister.h
+  JsonUtil.h
   Lazy.h
   LinearDiskCache.h
   Logging/ConsoleListener.h

--- a/Source/Core/Common/JsonUtil.h
+++ b/Source/Core/Common/JsonUtil.h
@@ -1,0 +1,26 @@
+// Copyright 2024 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <span>
+
+#include <picojson.h>
+
+// Ideally this would use a concept like, 'template <std::ranges::range Range>' to constrain it,
+// but unfortunately we'd need to require clang 15 for that, since the ranges library isn't
+// fully implemented until then, but this should suffice.
+
+template <typename Range>
+picojson::array ToJsonArray(const Range& data)
+{
+  picojson::array result;
+  result.reserve(std::size(data));
+
+  for (const auto& value : data)
+  {
+    result.emplace_back(static_cast<double>(value));
+  }
+
+  return result;
+}

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -125,6 +125,7 @@
     <ClInclude Include="Common\Intrinsics.h" />
     <ClInclude Include="Common\IOFile.h" />
     <ClInclude Include="Common\JitRegister.h" />
+    <ClInclude Include="Common\JsonUtil.h" />
     <ClInclude Include="Common\Lazy.h" />
     <ClInclude Include="Common\LdrWatcher.h" />
     <ClInclude Include="Common\LinearDiskCache.h" />

--- a/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
@@ -366,6 +366,76 @@ void PixelShaderData::ToJson(picojson::object& obj, const PixelShaderData& data)
   obj["properties"] = picojson::value{json_properties};
 }
 
+std::span<const std::string_view> ShaderProperty::GetValueTypeNames()
+{
+  static constexpr std::array<std::string_view, 14> values = {
+      "sampler2d", "sampler2darray", "samplercube", "int",    "int2", "int3", "int4",
+      "float",     "float2",         "float3",      "float4", "rgb",  "rgba", "bool"};
+  return values;
+}
+
+ShaderProperty::Value ShaderProperty::GetDefaultValueFromTypeName(std::string_view name)
+{
+  if (name == "sampler2d")
+  {
+    return Sampler2D{};
+  }
+  else if (name == "sampler2darray")
+  {
+    return Sampler2DArray{};
+  }
+  else if (name == "samplercube")
+  {
+    return SamplerCube{};
+  }
+  else if (name == "int")
+  {
+    return 0;
+  }
+  else if (name == "int2")
+  {
+    return std::array<s32, 2>{};
+  }
+  else if (name == "int3")
+  {
+    return std::array<s32, 3>{};
+  }
+  else if (name == "int4")
+  {
+    return std::array<s32, 4>{};
+  }
+  else if (name == "float")
+  {
+    return 0.0f;
+  }
+  else if (name == "float2")
+  {
+    return std::array<float, 2>{};
+  }
+  else if (name == "float3")
+  {
+    return std::array<float, 3>{};
+  }
+  else if (name == "float4")
+  {
+    return std::array<float, 4>{};
+  }
+  else if (name == "rgb")
+  {
+    return RGB{};
+  }
+  else if (name == "rgba")
+  {
+    return RGBA{};
+  }
+  else if (name == "bool")
+  {
+    return false;
+  }
+
+  return Value{};
+}
+
 CustomAssetLibrary::LoadInfo PixelShaderAsset::LoadImpl(const CustomAssetLibrary::AssetID& asset_id)
 {
   auto potential_data = std::make_shared<PixelShaderData>();

--- a/Source/Core/VideoCommon/Assets/ShaderAsset.h
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.h
@@ -52,6 +52,7 @@ struct PixelShaderData
 {
   static bool FromJson(const CustomAssetLibrary::AssetID& asset_id, const picojson::object& json,
                        PixelShaderData* data);
+  static void ToJson(picojson::object& obj, const PixelShaderData& data);
 
   // These shader properties describe the input that the
   // shader expects to expose.  The key is text

--- a/Source/Core/VideoCommon/Assets/ShaderAsset.h
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.h
@@ -5,7 +5,9 @@
 
 #include <array>
 #include <map>
+#include <span>
 #include <string>
+#include <string_view>
 #include <variant>
 
 #include <picojson.h>
@@ -44,6 +46,8 @@ struct ShaderProperty
   using Value = std::variant<s32, std::array<s32, 2>, std::array<s32, 3>, std::array<s32, 4>, float,
                              std::array<float, 2>, std::array<float, 3>, std::array<float, 4>, bool,
                              RGB, RGBA, Sampler2D, Sampler2DArray, SamplerCube>;
+  static std::span<const std::string_view> GetValueTypeNames();
+  static Value GetDefaultValueFromTypeName(std::string_view name);
 
   Value m_default;
   std::string m_description;


### PR DESCRIPTION
This adds a way to serialize a shader asset to json.  This will be used in the editor to serialize changes out to disk (see #12280 )  

This also adds a way to calculate the default value of a shader asset property value given a typename (used in the editor when picking a typename from a drop down) and to get a list of typenames available for the shader asset (used to populate a drop down in the editor with available types).