### PR TITLE
AchievementSettings: Move pragma once out of ifdef

### DIFF
--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -1,8 +1,9 @@
 // Copyright 2023 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 #pragma once
+
+#ifdef USE_RETRO_ACHIEVEMENTS
 
 #include "Common/Config/Config.h"
 


### PR DESCRIPTION
Makes the header a little more consistent with others (and also we should still have a header guard be present at all times).