### PR TITLE
Core: Make use of reentrant time utilities where applicable

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -5,6 +5,8 @@
 
 #include <string>
 
+#include <fmt/chrono.h>
+
 #include "Common/CommonTypes.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/Memmap.h"
@@ -93,10 +95,10 @@ u64 NetKDTimeDevice::GetAdjustedUTC() const
 
   time_t dst_diff{};
   const time_t current_time = CEXIIPL::GetEmulatedTime(GetSystem(), CEXIIPL::UNIX_EPOCH);
-  tm* const gm_time = gmtime(&current_time);
+  tm gm_time = fmt::gmtime(current_time);
 
-  const u32 emulated_time = mktime(gm_time);
-  if (gm_time->tm_isdst == 1)
+  const u32 emulated_time = mktime(&gm_time);
+  if (gm_time.tm_isdst == 1)
     dst_diff = 3600;
 
   return u64(s64(emulated_time) + utcdiff - dst_diff);
@@ -108,10 +110,10 @@ void NetKDTimeDevice::SetAdjustedUTC(u64 wii_utc)
 
   time_t dst_diff{};
   const time_t current_time = CEXIIPL::GetEmulatedTime(GetSystem(), CEXIIPL::UNIX_EPOCH);
-  tm* const gm_time = gmtime(&current_time);
+  tm gm_time = fmt::gmtime(current_time);
 
-  const u32 emulated_time = mktime(gm_time);
-  if (gm_time->tm_isdst == 1)
+  const u32 emulated_time = mktime(&gm_time);
+  if (gm_time.tm_isdst == 1)
     dst_diff = 3600;
 
   utcdiff = s64(emulated_time - wii_utc - dst_diff);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -165,8 +165,7 @@ std::string MovieManager::GetRTCDisplay() const
 {
   using ExpansionInterface::CEXIIPL;
 
-  const time_t current_time =
-      CEXIIPL::GetEmulatedTime(Core::System::GetInstance(), CEXIIPL::UNIX_EPOCH);
+  const time_t current_time = CEXIIPL::GetEmulatedTime(m_system, CEXIIPL::UNIX_EPOCH);
   const tm gm_time = fmt::gmtime(current_time);
 
   // Use current locale for formatting time, as fmt is locale-agnostic by default.

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -7,8 +7,8 @@
 #include <array>
 #include <cctype>
 #include <cstring>
-#include <iomanip>
 #include <iterator>
+#include <locale>
 #include <mbedtls/config.h>
 #include <mbedtls/md.h>
 #include <mutex>
@@ -18,6 +18,7 @@
 #include <variant>
 #include <vector>
 
+#include <fmt/chrono.h>
 #include <fmt/format.h>
 
 #include "Common/Assert.h"
@@ -166,11 +167,10 @@ std::string MovieManager::GetRTCDisplay()
 
   const time_t current_time =
       CEXIIPL::GetEmulatedTime(Core::System::GetInstance(), CEXIIPL::UNIX_EPOCH);
-  const tm* const gm_time = gmtime(&current_time);
+  const tm gm_time = fmt::gmtime(current_time);
 
-  std::ostringstream format_time;
-  format_time << std::put_time(gm_time, "Date/Time: %c\n");
-  return format_time.str();
+  // Use current locale for formatting time, as fmt is locale-agnostic by default.
+  return fmt::format(std::locale{""}, "Date/Time: {:%c}", gm_time);
 }
 
 // NOTE: GPU Thread

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -161,7 +161,7 @@ std::string MovieManager::GetInputDisplay()
 }
 
 // NOTE: GPU Thread
-std::string MovieManager::GetRTCDisplay()
+std::string MovieManager::GetRTCDisplay() const
 {
   using ExpansionInterface::CEXIIPL;
 
@@ -174,7 +174,7 @@ std::string MovieManager::GetRTCDisplay()
 }
 
 // NOTE: GPU Thread
-std::string MovieManager::GetRerecords()
+std::string MovieManager::GetRerecords() const
 {
   if (IsMovieActive())
     return fmt::format("Rerecords: {}", m_rerecords);

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -222,8 +222,8 @@ public:
                           WiimoteEmu::ExtensionNumber ext, const WiimoteEmu::EncryptionKey& key);
 
   std::string GetInputDisplay();
-  std::string GetRTCDisplay();
-  std::string GetRerecords();
+  std::string GetRTCDisplay() const;
+  std::string GetRerecords() const;
 
 private:
   void GetSettings();

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <filesystem>
+#include <locale>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -15,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/chrono.h>
 #include <fmt/format.h>
 
 #include <lz4.h>
@@ -278,21 +280,11 @@ static double GetSystemTimeAsDouble()
 static std::string SystemTimeAsDoubleToString(double time)
 {
   // revert adjustments from GetSystemTimeAsDouble() to get a normal Unix timestamp again
-  time_t seconds = static_cast<time_t>(time) + DOUBLE_TIME_OFFSET;
-  errno = 0;
-  tm* local_time = localtime(&seconds);
-  if (errno != 0 || !local_time)
-    return "";
+  const time_t seconds = static_cast<time_t>(time) + DOUBLE_TIME_OFFSET;
+  const tm local_time = fmt::localtime(seconds);
 
-#ifdef _WIN32
-  wchar_t tmp[32] = {};
-  wcsftime(tmp, std::size(tmp), L"%x %X", local_time);
-  return WStringToUTF8(tmp);
-#else
-  char tmp[32] = {};
-  strftime(tmp, sizeof(tmp), "%x %X", local_time);
-  return tmp;
-#endif
+  // fmt is locale agnostic by default, so explicitly use current locale.
+  return fmt::format(std::locale{""}, "{:%x %X}", local_time);
 }
 
 static std::string MakeStateFilename(int number);


### PR DESCRIPTION
fmt provides general drop-in thread-safe replacements for a few time handling functions, so we can move over to those to make several functions thread-safe, getting rid of the need to be extra careful when using them.