### PR TITLE
Jit64AsmCommon: Remove redundant m_jit member from CommonAsmRoutines

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.h
@@ -26,7 +26,7 @@ private:
 class CommonAsmRoutines : public CommonAsmRoutinesBase, public QuantizedMemoryRoutines
 {
 public:
-  explicit CommonAsmRoutines(Jit64& jit) : QuantizedMemoryRoutines(jit), m_jit(jit) {}
+  explicit CommonAsmRoutines(Jit64& jit) : QuantizedMemoryRoutines(jit) {}
   void GenFrsqrte();
   void GenFres();
   void GenMfcr();
@@ -39,6 +39,4 @@ protected:
   void GenQuantizedSingleLoads();
   void GenQuantizedStores();
   void GenQuantizedSingleStores();
-
-  Jit64& m_jit;
 };


### PR DESCRIPTION
We pass a JIT instance all the way down to EmuCodeBlock, which is accessible under protected as well, so this isn't really necessary.