### PR TITLE
Core: Convert some preprocessor checking to use #ifdef/#if defined() over #if

### DIFF
--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -293,7 +293,7 @@ void DolphinAnalytics::MakeBaseBuilder()
     };
     // Under arm64, we need to call objc_msgSend to recieve a struct.
     // On x86_64, we need to explicitly call objc_msgSend_stret for a struct.
-#if _M_ARM_64
+#ifdef _M_ARM_64
 #define msgSend objc_msgSend
 #else
 #define msgSend objc_msgSend_stret

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -160,7 +160,7 @@ void FreeLookController::LoadDefaults(const ControllerInterface& ciface)
                                         "if(`Click 3`,`RelativeMouse Y-` * 0.10, 0)");
   m_rotation_gyro->SetControlExpression(GyroButtons::PitchDown,
                                         "if(`Click 3`,`RelativeMouse Y+` * 0.10, 0)");
-#elif __APPLE__
+#elif defined(__APPLE__)
   m_rotation_gyro->SetControlExpression(GyroButtons::PitchUp,
                                         "if(`Left Click`,`RelativeMouse Y-` * 0.10, 0)");
   m_rotation_gyro->SetControlExpression(GyroButtons::PitchDown,
@@ -191,7 +191,7 @@ void FreeLookController::LoadDefaults(const ControllerInterface& ciface)
                                         "if(`Click 3`,`RelativeMouse X-` * 0.10, 0)");
   m_rotation_gyro->SetControlExpression(GyroButtons::YawRight,
                                         "if(`Click 3`,`RelativeMouse X+` * 0.10, 0)");
-#elif __APPLE__
+#elif defined(__APPLE__)
   m_rotation_gyro->SetControlExpression(GyroButtons::YawLeft,
                                         "if(`Right Click`,`RelativeMouse X-` * 0.10, 0)");
   m_rotation_gyro->SetControlExpression(GyroButtons::YawRight,

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -694,7 +694,7 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
   m_buttons->SetControlExpression(0, "`Click 1`");
   // B
   m_buttons->SetControlExpression(1, "`Click 3`");
-#elif __APPLE__
+#elif defined(__APPLE__)
   // A
   m_buttons->SetControlExpression(0, "`Left Click`");
   // B

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -32,11 +32,11 @@
 #include "Core/PowerPC/Profiler.h"
 #include "Core/System.h"
 
-#if _M_X86_64
+#ifdef _M_X86_64
 #include "Core/PowerPC/Jit64/Jit.h"
 #endif
 
-#if _M_ARM_64
+#ifdef _M_ARM_64
 #include "Core/PowerPC/JitArm64/Jit.h"
 #endif
 
@@ -61,12 +61,12 @@ CPUCoreBase* JitInterface::InitJitCore(PowerPC::CPUCore core)
 {
   switch (core)
   {
-#if _M_X86_64
+#ifdef _M_X86_64
   case PowerPC::CPUCore::JIT64:
     m_jit = std::make_unique<Jit64>(m_system);
     break;
 #endif
-#if _M_ARM_64
+#ifdef _M_ARM_64
   case PowerPC::CPUCore::JITARM64:
     m_jit = std::make_unique<JitArm64>(m_system);
     break;

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -160,7 +160,7 @@ struct PowerPCState
   // lscbx
   u16 xer_stringctrl = 0;
 
-#if _M_X86_64
+#ifdef _M_X86_64
   // This member exists only for the purpose of an assertion that its offset <= 0x100.
   std::tuple<> above_fits_in_first_0x100;
 
@@ -234,7 +234,7 @@ struct PowerPCState
   void UpdateFPRFSingle(float fvalue);
 };
 
-#if _M_X86_64
+#ifdef _M_X86_64
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"


### PR DESCRIPTION
In a few cases, we were assuming certain definitions would exist, but e.g. __APPLE__ wouldn't be defined by default on Windows.

This isn't a huge deal (the most that would happen is some warning/output spam), but we can just convert them over to make it nicer.