### PR TITLE
GekkoSyntaxHighlight: Fix FPR terminal highlighting being treated as GPRs

### DIFF
--- a/Source/Core/DolphinQt/Debugger/GekkoSyntaxHighlight.cpp
+++ b/Source/Core/DolphinQt/Debugger/GekkoSyntaxHighlight.cpp
@@ -221,17 +221,9 @@ void GekkoSyntaxHighlight::HighlightSubstr(int start, int len, HighlightFormat f
     hl_format.setForeground(IMM_COLOR[m_theme_idx]);
     break;
   case HighlightFormat::GPR:
-    hl_format.setForeground(BUILTIN_COLOR[m_theme_idx]);
-    break;
   case HighlightFormat::FPR:
-    hl_format.setForeground(BUILTIN_COLOR[m_theme_idx]);
-    break;
   case HighlightFormat::SPR:
-    hl_format.setForeground(BUILTIN_COLOR[m_theme_idx]);
-    break;
   case HighlightFormat::CRField:
-    hl_format.setForeground(BUILTIN_COLOR[m_theme_idx]);
-    break;
   case HighlightFormat::CRFlag:
     hl_format.setForeground(BUILTIN_COLOR[m_theme_idx]);
     break;

--- a/Source/Core/DolphinQt/Debugger/GekkoSyntaxHighlight.cpp
+++ b/Source/Core/DolphinQt/Debugger/GekkoSyntaxHighlight.cpp
@@ -52,7 +52,7 @@ public:
       break;
 
     case Terminal::FPR:
-      HighlightCurToken(HighlightFormat::GPR);
+      HighlightCurToken(HighlightFormat::FPR);
       break;
 
     case Terminal::SPR:


### PR DESCRIPTION
Copy-paste error. Ultimately GPR and FPRs use the same highlighting style anyway, so this is mostly just a correctness change.