### PR TITLE
DolphinQt/MenuBar: Hide assembler option if debug UI is disabled

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -185,6 +185,7 @@ void MenuBar::OnDebugModeToggled(bool enabled)
   m_show_memory->setVisible(enabled);
   m_show_network->setVisible(enabled);
   m_show_jit->setVisible(enabled);
+  m_show_assembler->setVisible(enabled);
 
   if (enabled)
   {


### PR DESCRIPTION
Fixes a little visual inconsistency in the UI, where the assembler would always be shown, but all other debug-related utilities would be hidden.