### PR TITLE
Common: add determinant functions to Matrix33 and Matrix44

### DIFF
--- a/Source/Core/Common/Matrix.cpp
+++ b/Source/Core/Common/Matrix.cpp
@@ -250,11 +250,7 @@ Matrix33 Matrix33::Inverted() const
 {
   const auto m = [this](int x, int y) { return data[y + x * 3]; };
 
-  const auto det = m(0, 0) * (m(1, 1) * m(2, 2) - m(2, 1) * m(1, 2)) -
-                   m(0, 1) * (m(1, 0) * m(2, 2) - m(1, 2) * m(2, 0)) +
-                   m(0, 2) * (m(1, 0) * m(2, 1) - m(1, 1) * m(2, 0));
-
-  const auto invdet = 1 / det;
+  const auto invdet = 1 / Determinant();
 
   Matrix33 result;
 
@@ -271,6 +267,15 @@ Matrix33 Matrix33::Inverted() const
   minv(2, 2) = (m(0, 0) * m(1, 1) - m(1, 0) * m(0, 1)) * invdet;
 
   return result;
+}
+
+float Matrix33::Determinant() const
+{
+  const auto m = [this](int x, int y) { return data[y + x * 3]; };
+
+  return m(0, 0) * (m(1, 1) * m(2, 2) - m(2, 1) * m(1, 2)) -
+         m(0, 1) * (m(1, 0) * m(2, 2) - m(1, 2) * m(2, 0)) +
+         m(0, 2) * (m(1, 0) * m(2, 1) - m(1, 1) * m(2, 0));
 }
 
 Matrix44 Matrix44::Identity()
@@ -358,6 +363,19 @@ Vec3 Matrix44::Transform(const Vec3& v, float w) const
 void Matrix44::Multiply(const Matrix44& a, const Vec4& vec, Vec4* result)
 {
   result->data = MatrixMultiply<4, 4, 1>(a.data, vec.data);
+}
+
+float Matrix44::Determinant() const
+{
+  const auto& m = data;
+  return m[12] * m[9] * m[6] * m[3] - m[8] * m[13] * m[6] * m[3] - m[12] * m[5] * m[10] * m[3] +
+         m[4] * m[13] * m[10] * m[3] + m[8] * m[5] * m[14] * m[3] - m[4] * m[9] * m[14] * m[3] -
+         m[12] * m[9] * m[2] * m[7] + m[8] * m[13] * m[2] * m[7] + m[12] * m[1] * m[10] * m[7] -
+         m[0] * m[13] * m[10] * m[7] - m[8] * m[1] * m[14] * m[7] + m[0] * m[9] * m[14] * m[7] +
+         m[12] * m[5] * m[2] * m[11] - m[4] * m[13] * m[2] * m[11] - m[12] * m[1] * m[6] * m[11] +
+         m[0] * m[13] * m[6] * m[11] + m[4] * m[1] * m[14] * m[11] - m[0] * m[5] * m[14] * m[11] -
+         m[8] * m[5] * m[2] * m[15] + m[4] * m[9] * m[2] * m[15] + m[8] * m[1] * m[6] * m[15] -
+         m[0] * m[9] * m[6] * m[15] - m[4] * m[1] * m[10] * m[15] + m[0] * m[5] * m[10] * m[15];
 }
 
 }  // namespace Common

--- a/Source/Core/Common/Matrix.h
+++ b/Source/Core/Common/Matrix.h
@@ -392,6 +392,7 @@ public:
   static void Multiply(const Matrix33& a, const Vec3& vec, Vec3* result);
 
   Matrix33 Inverted() const;
+  float Determinant() const;
 
   Matrix33& operator*=(const Matrix33& rhs)
   {
@@ -431,6 +432,8 @@ public:
 
   // For when a vec4 isn't needed a multiplication function that takes a Vec3 and w:
   Vec3 Transform(const Vec3& point, float w) const;
+
+  float Determinant() const;
 
   Matrix44& operator*=(const Matrix44& rhs)
   {


### PR DESCRIPTION
Just trying to make our matrix class a little more general purpose.

I was looking at some functionality for determining the winding order of a (GLTF) mesh and found out you can calculate this by determining if the global transform's determinant is negative.  Not sure if this will be something I use or not but wanted to make these changes in case I decide to do that.