### PR TITLE
Add host URL setting to achievements config

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -38,6 +38,9 @@ void AchievementManager::Init()
 {
   if (!m_is_runtime_initialized && Config::Get(Config::RA_ENABLED))
   {
+    std::string host_url = Config::Get(Config::RA_HOST_URL);
+    if (!host_url.empty())
+      rc_api_set_host(host_url.c_str());
     rc_runtime_init(&m_runtime);
     m_is_runtime_initialized = true;
     m_queue.Reset("AchievementManagerQueue", [](const std::function<void()>& func) { func(); });

--- a/Source/Core/Core/Config/AchievementSettings.cpp
+++ b/Source/Core/Core/Config/AchievementSettings.cpp
@@ -12,6 +12,7 @@ namespace Config
 {
 // Configuration Information
 const Info<bool> RA_ENABLED{{System::Achievements, "Achievements", "Enabled"}, false};
+const Info<std::string> RA_HOST_URL{{System::Achievements, "Achievements", "HostUrl"}, ""};
 const Info<std::string> RA_USERNAME{{System::Achievements, "Achievements", "Username"}, ""};
 const Info<std::string> RA_API_TOKEN{{System::Achievements, "Achievements", "ApiToken"}, ""};
 const Info<bool> RA_ACHIEVEMENTS_ENABLED{

--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -11,6 +11,7 @@ namespace Config
 // Configuration Information
 extern const Info<bool> RA_ENABLED;
 extern const Info<std::string> RA_USERNAME;
+extern const Info<std::string> RA_HOST_URL;
 extern const Info<std::string> RA_API_TOKEN;
 extern const Info<bool> RA_ACHIEVEMENTS_ENABLED;
 extern const Info<bool> RA_LEADERBOARDS_ENABLED;


### PR DESCRIPTION
The Host URL setting in the RetroAchievements config will, if set, be used as the host URL for all server requests for achievements. This allows for an easy switch to the RetroAchievements staging server for testing.