### PR TITLE
GraphicsMod/ShaderAsset: Lessen object churn a little bit

### DIFF
--- a/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
@@ -299,71 +299,71 @@ void PixelShaderData::ToJson(picojson::object& obj, const PixelShaderData& data)
   for (const auto& [name, property] : data.m_properties)
   {
     picojson::object json_property;
-    json_property["code_name"] = picojson::value{name};
-    json_property["description"] = picojson::value{property.m_description};
+    json_property.emplace("code_name", name);
+    json_property.emplace("description", property.m_description);
 
-    std::visit(
-        overloaded{[&](const ShaderProperty::Sampler2D& default_value) {
-                     json_property["type"] = picojson::value{"sampler2d"};
-                     json_property["default"] = picojson::value{default_value.value};
-                   },
-                   [&](const ShaderProperty::Sampler2DArray& default_value) {
-                     json_property["type"] = picojson::value{"sampler2darray"};
-                     json_property["default"] = picojson::value{default_value.value};
-                   },
-                   [&](const ShaderProperty::SamplerCube& default_value) {
-                     json_property["type"] = picojson::value{"samplercube"};
-                     json_property["default"] = picojson::value{default_value.value};
-                   },
-                   [&](s32 default_value) {
-                     json_property["type"] = picojson::value{"int"};
-                     json_property["default"] = picojson::value{static_cast<double>(default_value)};
-                   },
-                   [&](const std::array<s32, 2>& default_value) {
-                     json_property["type"] = picojson::value{"int2"};
-                     json_property["default"] = picojson::value{ToJsonArray(default_value)};
-                   },
-                   [&](const std::array<s32, 3>& default_value) {
-                     json_property["type"] = picojson::value{"int3"};
-                     json_property["default"] = picojson::value{ToJsonArray(default_value)};
-                   },
-                   [&](const std::array<s32, 4>& default_value) {
-                     json_property["type"] = picojson::value{"int4"};
-                     json_property["default"] = picojson::value{ToJsonArray(default_value)};
-                   },
-                   [&](float default_value) {
-                     json_property["type"] = picojson::value{"float"};
-                     json_property["default"] = picojson::value{static_cast<double>(default_value)};
-                   },
-                   [&](const std::array<float, 2>& default_value) {
-                     json_property["type"] = picojson::value{"float2"};
-                     json_property["default"] = picojson::value{ToJsonArray(default_value)};
-                   },
-                   [&](const std::array<float, 3>& default_value) {
-                     json_property["type"] = picojson::value{"float3"};
-                     json_property["default"] = picojson::value{ToJsonArray(default_value)};
-                   },
-                   [&](const std::array<float, 4>& default_value) {
-                     json_property["type"] = picojson::value{"float4"};
-                     json_property["default"] = picojson::value{ToJsonArray(default_value)};
-                   },
-                   [&](const ShaderProperty::RGB& default_value) {
-                     json_property["type"] = picojson::value{"rgb"};
-                     json_property["default"] = picojson::value{ToJsonArray(default_value.value)};
-                   },
-                   [&](const ShaderProperty::RGBA& default_value) {
-                     json_property["type"] = picojson::value{"rgba"};
-                     json_property["default"] = picojson::value{ToJsonArray(default_value.value)};
-                   },
-                   [&](bool default_value) {
-                     json_property["type"] = picojson::value{"bool"};
-                     json_property["default"] = picojson::value{default_value};
-                   }},
-        property.m_default);
+    std::visit(overloaded{[&](const ShaderProperty::Sampler2D& default_value) {
+                            json_property.emplace("type", "sampler2d");
+                            json_property.emplace("default", default_value.value);
+                          },
+                          [&](const ShaderProperty::Sampler2DArray& default_value) {
+                            json_property.emplace("type", "sampler2darray");
+                            json_property.emplace("default", default_value.value);
+                          },
+                          [&](const ShaderProperty::SamplerCube& default_value) {
+                            json_property.emplace("type", "samplercube");
+                            json_property.emplace("default", default_value.value);
+                          },
+                          [&](s32 default_value) {
+                            json_property.emplace("type", "int");
+                            json_property.emplace("default", static_cast<double>(default_value));
+                          },
+                          [&](const std::array<s32, 2>& default_value) {
+                            json_property.emplace("type", "int2");
+                            json_property.emplace("default", ToJsonArray(default_value));
+                          },
+                          [&](const std::array<s32, 3>& default_value) {
+                            json_property.emplace("type", "int3");
+                            json_property.emplace("default", ToJsonArray(default_value));
+                          },
+                          [&](const std::array<s32, 4>& default_value) {
+                            json_property.emplace("type", "int4");
+                            json_property.emplace("default", ToJsonArray(default_value));
+                          },
+                          [&](float default_value) {
+                            json_property.emplace("type", "float");
+                            json_property.emplace("default", static_cast<double>(default_value));
+                          },
+                          [&](const std::array<float, 2>& default_value) {
+                            json_property.emplace("type", "float2");
+                            json_property.emplace("default", ToJsonArray(default_value));
+                          },
+                          [&](const std::array<float, 3>& default_value) {
+                            json_property.emplace("type", "float3");
+                            json_property.emplace("default", ToJsonArray(default_value));
+                          },
+                          [&](const std::array<float, 4>& default_value) {
+                            json_property.emplace("type", "float4");
+                            json_property.emplace("default", ToJsonArray(default_value));
+                          },
+                          [&](const ShaderProperty::RGB& default_value) {
+                            json_property.emplace("type", "rgb");
+                            json_property.emplace("default", ToJsonArray(default_value.value));
+                          },
+                          [&](const ShaderProperty::RGBA& default_value) {
+                            json_property.emplace("type", "rgba");
+                            json_property.emplace("default", ToJsonArray(default_value.value));
+                          },
+                          [&](bool default_value) {
+                            json_property.emplace("type", "bool");
+                            json_property.emplace("default", default_value);
+                          }},
+               property.m_default);
 
-    json_properties.push_back(picojson::value{json_property});
+    json_properties.emplace_back(std::move(json_property));
   }
-  obj["properties"] = picojson::value{json_properties};
+
+  obj.emplace("properties", std::move(json_properties));
 }
 
 std::span<const std::string_view> ShaderProperty::GetValueTypeNames()

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsMod.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsMod.cpp
@@ -115,37 +115,37 @@ std::string GraphicsModConfig::GetAbsolutePath() const
 void GraphicsModConfig::SerializeToConfig(picojson::object& json_obj) const
 {
   picojson::object serialized_metadata;
-  serialized_metadata["title"] = picojson::value{m_title};
-  serialized_metadata["author"] = picojson::value{m_author};
-  serialized_metadata["description"] = picojson::value{m_description};
-  json_obj["meta"] = picojson::value{serialized_metadata};
+  serialized_metadata.emplace("title", m_title);
+  serialized_metadata.emplace("author", m_author);
+  serialized_metadata.emplace("description", m_description);
+  json_obj.emplace("meta", std::move(serialized_metadata));
 
   picojson::array serialized_groups;
   for (const auto& group : m_groups)
   {
     picojson::object serialized_group;
     group.SerializeToConfig(serialized_group);
-    serialized_groups.push_back(picojson::value{serialized_group});
+    serialized_groups.emplace_back(std::move(serialized_group));
   }
-  json_obj["groups"] = picojson::value{serialized_groups};
+  json_obj.emplace("groups", std::move(serialized_groups));
 
   picojson::array serialized_features;
   for (const auto& feature : m_features)
   {
     picojson::object serialized_feature;
     feature.SerializeToConfig(serialized_feature);
-    serialized_features.push_back(picojson::value{serialized_feature});
+    serialized_features.emplace_back(std::move(serialized_feature));
   }
-  json_obj["features"] = picojson::value{serialized_features};
+  json_obj.emplace("features", std::move(serialized_features));
 
   picojson::array serialized_assets;
   for (const auto& asset : m_assets)
   {
     picojson::object serialized_asset;
     asset.SerializeToConfig(serialized_asset);
-    serialized_assets.push_back(picojson::value{serialized_asset});
+    serialized_assets.emplace_back(std::move(serialized_asset));
   }
-  json_obj["assets"] = picojson::value{serialized_assets};
+  json_obj.emplace("assets", std::move(serialized_assets));
 }
 
 bool GraphicsModConfig::DeserializeFromConfig(const picojson::value& value)
@@ -189,7 +189,7 @@ bool GraphicsModConfig::DeserializeFromConfig(const picojson::value& value)
         return false;
       }
 
-      m_groups.push_back(group);
+      m_groups.push_back(std::move(group));
     }
   }
 
@@ -210,7 +210,7 @@ bool GraphicsModConfig::DeserializeFromConfig(const picojson::value& value)
         return false;
       }
 
-      m_features.push_back(feature);
+      m_features.push_back(std::move(feature));
     }
   }
 
@@ -247,40 +247,36 @@ void GraphicsModConfig::SerializeToProfile(picojson::object* obj) const
   switch (m_source)
   {
   case Source::User:
-  {
-    json_obj["source"] = picojson::value{"user"};
-  }
-  break;
+    json_obj.emplace("source", "user");
+    break;
   case Source::System:
-  {
-    json_obj["source"] = picojson::value{"system"};
+    json_obj.emplace("source", "system");
+    break;
   }
-  break;
-  };
 
-  json_obj["path"] = picojson::value{m_relative_path};
+  json_obj.emplace("path", m_relative_path);
 
   picojson::array serialized_groups;
   for (const auto& group : m_groups)
   {
     picojson::object serialized_group;
     group.SerializeToProfile(&serialized_group);
-    serialized_groups.push_back(picojson::value{serialized_group});
+    serialized_groups.emplace_back(std::move(serialized_group));
   }
-  json_obj["groups"] = picojson::value{serialized_groups};
+  json_obj.emplace("groups", std::move(serialized_groups));
 
   picojson::array serialized_features;
   for (const auto& feature : m_features)
   {
     picojson::object serialized_feature;
     feature.SerializeToProfile(&serialized_feature);
-    serialized_features.push_back(picojson::value{serialized_feature});
+    serialized_features.emplace_back(std::move(serialized_feature));
   }
-  json_obj["features"] = picojson::value{serialized_features};
+  json_obj.emplace("features", std::move(serialized_features));
 
-  json_obj["enabled"] = picojson::value{m_enabled};
+  json_obj.emplace("enabled", m_enabled);
 
-  json_obj["weight"] = picojson::value{static_cast<double>(m_weight)};
+  json_obj.emplace("weight", static_cast<double>(m_weight));
 }
 
 void GraphicsModConfig::DeserializeFromProfile(const picojson::object& obj)
@@ -289,7 +285,7 @@ void GraphicsModConfig::DeserializeFromProfile(const picojson::object& obj)
   {
     if (it->second.is<picojson::array>())
     {
-      auto serialized_groups = it->second.get<picojson::array>();
+      const auto& serialized_groups = it->second.get<picojson::array>();
       if (serialized_groups.size() != m_groups.size())
         return;
 
@@ -309,7 +305,7 @@ void GraphicsModConfig::DeserializeFromProfile(const picojson::object& obj)
   {
     if (it->second.is<picojson::array>())
     {
-      auto serialized_features = it->second.get<picojson::array>();
+      const auto& serialized_features = it->second.get<picojson::array>();
       if (serialized_features.size() != m_features.size())
         return;
 

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModAsset.cpp
@@ -8,14 +8,14 @@
 
 void GraphicsModAssetConfig::SerializeToConfig(picojson::object& json_obj) const
 {
-  json_obj["name"] = picojson::value{m_asset_id};
+  json_obj.emplace("name", m_asset_id);
 
   picojson::object serialized_data;
   for (const auto& [name, path] : m_map)
   {
-    serialized_data[name] = picojson::value{PathToString(path)};
+    serialized_data.emplace(name, PathToString(path));
   }
-  json_obj["data"] = picojson::value{serialized_data};
+  json_obj.emplace("data", std::move(serialized_data));
 }
 
 bool GraphicsModAssetConfig::DeserializeFromConfig(const picojson::object& obj)

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModFeature.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModFeature.cpp
@@ -7,9 +7,9 @@
 
 void GraphicsModFeatureConfig::SerializeToConfig(picojson::object& json_obj) const
 {
-  json_obj["group"] = picojson::value{m_group};
-  json_obj["action"] = picojson::value{m_action};
-  json_obj["action_data"] = m_action_data;
+  json_obj.emplace("group", m_group);
+  json_obj.emplace("action", m_action);
+  json_obj.emplace("action_data", m_action_data);
 }
 
 bool GraphicsModFeatureConfig::DeserializeFromConfig(const picojson::object& obj)

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
@@ -26,11 +26,12 @@ GraphicsModGroupConfig::~GraphicsModGroupConfig() = default;
 
 GraphicsModGroupConfig::GraphicsModGroupConfig(const GraphicsModGroupConfig&) = default;
 
-GraphicsModGroupConfig::GraphicsModGroupConfig(GraphicsModGroupConfig&&) = default;
+GraphicsModGroupConfig::GraphicsModGroupConfig(GraphicsModGroupConfig&&) noexcept = default;
 
 GraphicsModGroupConfig& GraphicsModGroupConfig::operator=(const GraphicsModGroupConfig&) = default;
 
-GraphicsModGroupConfig& GraphicsModGroupConfig::operator=(GraphicsModGroupConfig&&) = default;
+GraphicsModGroupConfig&
+GraphicsModGroupConfig::operator=(GraphicsModGroupConfig&&) noexcept = default;
 
 void GraphicsModGroupConfig::Load()
 {

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
@@ -18,7 +18,7 @@
 #include "VideoCommon/GraphicsModSystem/Constants.h"
 #include "VideoCommon/HiresTextures.h"
 
-GraphicsModGroupConfig::GraphicsModGroupConfig(const std::string& game_id) : m_game_id(game_id)
+GraphicsModGroupConfig::GraphicsModGroupConfig(std::string game_id) : m_game_id(std::move(game_id))
 {
 }
 
@@ -145,9 +145,9 @@ void GraphicsModGroupConfig::Save() const
   {
     picojson::object serialized_mod;
     mod.SerializeToProfile(&serialized_mod);
-    serialized_mods.push_back(picojson::value{serialized_mod});
+    serialized_mods.emplace_back(std::move(serialized_mod));
   }
-  serialized_root["mods"] = picojson::value{serialized_mods};
+  serialized_root.emplace("mods", std::move(serialized_mods));
 
   const auto output = picojson::value{serialized_root}.serialize(true);
   json_stream << output;

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.h
@@ -20,10 +20,10 @@ public:
   ~GraphicsModGroupConfig();
 
   GraphicsModGroupConfig(const GraphicsModGroupConfig&);
-  GraphicsModGroupConfig(GraphicsModGroupConfig&&);
+  GraphicsModGroupConfig(GraphicsModGroupConfig&&) noexcept;
 
   GraphicsModGroupConfig& operator=(const GraphicsModGroupConfig&);
-  GraphicsModGroupConfig& operator=(GraphicsModGroupConfig&&);
+  GraphicsModGroupConfig& operator=(GraphicsModGroupConfig&&) noexcept;
 
   void Load();
   void Save() const;

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.h
@@ -16,7 +16,7 @@ struct GraphicsModConfig;
 class GraphicsModGroupConfig
 {
 public:
-  explicit GraphicsModGroupConfig(const std::string& game_id);
+  explicit GraphicsModGroupConfig(std::string game_id);
   ~GraphicsModGroupConfig();
 
   GraphicsModGroupConfig(const GraphicsModGroupConfig&);

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTarget.cpp
@@ -155,49 +155,47 @@ std::optional<std::string> ExtractTextureFilenameForConfig(const picojson::objec
 
 void SerializeTargetToConfig(picojson::object& json_obj, const GraphicsTargetConfig& target)
 {
-  std::visit(
-      overloaded{
-          [&](const DrawStartedTextureTarget& the_target) {
-            json_obj["type"] = picojson::value{"draw_started"};
-            json_obj["texture_filename"] = picojson::value{the_target.m_texture_info_string};
-          },
-          [&](const LoadTextureTarget& the_target) {
-            json_obj["type"] = picojson::value{"load_texture"};
-            json_obj["texture_filename"] = picojson::value{the_target.m_texture_info_string};
-          },
-          [&](const CreateTextureTarget& the_target) {
-            json_obj["type"] = picojson::value{"create_texture"};
-            json_obj["texture_filename"] = picojson::value{the_target.m_texture_info_string};
-          },
-          [&](const EFBTarget& the_target) {
-            json_obj["type"] = picojson::value{"efb"};
-            json_obj["texture_filename"] = picojson::value{
-                fmt::format("{}_{}x{}_{}", EFB_DUMP_PREFIX, the_target.m_width, the_target.m_height,
-                            static_cast<int>(the_target.m_texture_format))};
-          },
-          [&](const XFBTarget& the_target) {
-            json_obj["type"] = picojson::value{"xfb"};
-            json_obj["texture_filename"] = picojson::value{
-                fmt::format("{}_{}x{}_{}", XFB_DUMP_PREFIX, the_target.m_width, the_target.m_height,
-                            static_cast<int>(the_target.m_texture_format))};
-          },
-          [&](const ProjectionTarget& the_target) {
-            json_obj["type"] = picojson::value{"projection"};
-            if (the_target.m_projection_type == ProjectionType::Orthographic)
-            {
-              json_obj["type"] = picojson::value{"2d"};
-            }
-            else
-            {
-              json_obj["type"] = picojson::value{"3d"};
-            }
-            if (the_target.m_texture_info_string)
-            {
-              json_obj["texture_filename"] = picojson::value{*the_target.m_texture_info_string};
-            }
-          },
-      },
-      target);
+  std::visit(overloaded{
+                 [&](const DrawStartedTextureTarget& the_target) {
+                   json_obj.emplace("type", "draw_started");
+                   json_obj.emplace("texture_filename", the_target.m_texture_info_string);
+                 },
+                 [&](const LoadTextureTarget& the_target) {
+                   json_obj.emplace("type", "load_texture");
+                   json_obj.emplace("texture_filename", the_target.m_texture_info_string);
+                 },
+                 [&](const CreateTextureTarget& the_target) {
+                   json_obj.emplace("type", "create_texture");
+                   json_obj.emplace("texture_filename", the_target.m_texture_info_string);
+                 },
+                 [&](const EFBTarget& the_target) {
+                   json_obj.emplace("type", "efb");
+                   json_obj.emplace("texture_filename",
+                                    fmt::format("{}_{}x{}_{}", EFB_DUMP_PREFIX, the_target.m_width,
+                                                the_target.m_height,
+                                                static_cast<int>(the_target.m_texture_format)));
+                 },
+                 [&](const XFBTarget& the_target) {
+                   json_obj.emplace("type", "xfb");
+                   json_obj.emplace("texture_filename",
+                                    fmt::format("{}_{}x{}_{}", XFB_DUMP_PREFIX, the_target.m_width,
+                                                the_target.m_height,
+                                                static_cast<int>(the_target.m_texture_format)));
+                 },
+                 [&](const ProjectionTarget& the_target) {
+                   const char* type_name = "3d";
+                   if (the_target.m_projection_type == ProjectionType::Orthographic)
+                     type_name = "2d";
+
+                   json_obj.emplace("type", type_name);
+
+                   if (the_target.m_texture_info_string)
+                   {
+                     json_obj.emplace("texture_filename", *the_target.m_texture_info_string);
+                   }
+                 },
+             },
+             target);
 }
 
 std::optional<GraphicsTargetConfig> DeserializeTargetFromConfig(const picojson::object& obj)

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTargetGroup.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsTargetGroup.cpp
@@ -12,10 +12,10 @@ void GraphicsTargetGroupConfig::SerializeToConfig(picojson::object& json_obj) co
   {
     picojson::object serialized_target;
     SerializeTargetToConfig(serialized_target, target);
-    serialized_targets.push_back(picojson::value{serialized_target});
+    serialized_targets.emplace_back(std::move(serialized_target));
   }
-  json_obj["targets"] = picojson::value{serialized_targets};
-  json_obj["name"] = picojson::value{m_name};
+  json_obj.emplace("targets", std::move(serialized_targets));
+  json_obj.emplace("name", m_name);
 }
 
 bool GraphicsTargetGroupConfig::DeserializeFromConfig(const picojson::object& obj)
@@ -72,9 +72,9 @@ void GraphicsTargetGroupConfig::SerializeToProfile(picojson::object* obj) const
   {
     picojson::object serialized_target;
     SerializeTargetToProfile(&serialized_target, target);
-    serialized_targets.push_back(picojson::value{serialized_target});
+    serialized_targets.emplace_back(std::move(serialized_target));
   }
-  json_obj["targets"] = picojson::value{serialized_targets};
+  json_obj.emplace("targets", std::move(serialized_targets));
 }
 
 void GraphicsTargetGroupConfig::DeserializeFromProfile(const picojson::object& obj)
@@ -83,7 +83,7 @@ void GraphicsTargetGroupConfig::DeserializeFromProfile(const picojson::object& o
   {
     if (it->second.is<picojson::array>())
     {
-      auto serialized_targets = it->second.get<picojson::array>();
+      const auto& serialized_targets = it->second.get<picojson::array>();
       if (serialized_targets.size() != m_targets.size())
         return;
 


### PR DESCRIPTION
Lets us construct some elements directly inside the container as opposed to moving into them and also makes it shorter to read in certain instances.

(note: in GraphicsTarget, the "projection" string for the ProjectionTarget visitor would always get overwritten, so I removed it. If that was intended to actually be a meaningful string, let me know)