### PR TITLE
VideoCommon: refactor drawing into its own function

### DIFF
--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -15,9 +15,12 @@
 #include "VideoCommon/ShaderCache.h"
 #include "VideoCommon/VideoEvents.h"
 
+struct CustomPixelShaderContents;
 class CustomShaderCache;
 class DataReader;
+class GeometryShaderManager;
 class NativeVertexFormat;
+class PixelShaderManager;
 class PointerWrap;
 struct PortableVertexDeclaration;
 
@@ -218,8 +221,19 @@ private:
   // Minimum number of draws per command buffer when attempting to preempt a readback operation.
   static constexpr u32 MINIMUM_DRAW_CALLS_PER_COMMAND_BUFFER_FOR_READBACK = 10;
 
+  void RenderDrawCall(PixelShaderManager& pixel_shader_manager,
+                      GeometryShaderManager& geometry_shader_manager,
+                      const CustomPixelShaderContents& custom_pixel_shader_contents,
+                      std::span<u8> custom_pixel_shader_uniforms, PrimitiveType primitive_type,
+                      const AbstractPipeline* current_pipeline);
   void UpdatePipelineConfig();
   void UpdatePipelineObject();
+
+  const AbstractPipeline*
+  GetCustomPipeline(const CustomPixelShaderContents& custom_pixel_shader_contents,
+                    const VideoCommon::GXPipelineUid& current_pipeline_config,
+                    const VideoCommon::GXUberPipelineUid& current_uber_pipeline_confi,
+                    const AbstractPipeline* current_pipeline) const;
 
   bool m_is_flushed = true;
   FlushStatistics m_flush_statistics = {};


### PR DESCRIPTION
This PR refactors drawing into its own function during a flush so that it can be reused in the future (multi-pass drawing for custom shaders and/or custom meshes).

Pulled out of #12280 