### PR TITLE
Reverse endianness of achievement memory peeks

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -711,15 +711,17 @@ u32 AchievementManager::MemoryPeeker(u32 address, u32 num_bytes, void* ud)
         .value_or(PowerPC::ReadResult<u8>(false, 0u))
         .value;
   case 2:
-    return m_system->GetMMU()
-        .HostTryReadU16(threadguard, address, PowerPC::RequestedAddressSpace::Physical)
-        .value_or(PowerPC::ReadResult<u16>(false, 0u))
-        .value;
+    return Common::swap16(
+        m_system->GetMMU()
+            .HostTryReadU16(threadguard, address, PowerPC::RequestedAddressSpace::Physical)
+            .value_or(PowerPC::ReadResult<u16>(false, 0u))
+            .value);
   case 4:
-    return m_system->GetMMU()
-        .HostTryReadU32(threadguard, address, PowerPC::RequestedAddressSpace::Physical)
-        .value_or(PowerPC::ReadResult<u32>(false, 0u))
-        .value;
+    return Common::swap32(
+        m_system->GetMMU()
+            .HostTryReadU32(threadguard, address, PowerPC::RequestedAddressSpace::Physical)
+            .value_or(PowerPC::ReadResult<u32>(false, 0u))
+            .value);
   default:
     ASSERT(false);
     return 0u;


### PR DESCRIPTION
rcheevos expects these multi-byte peeks to have the opposite endianness so they need to be swapped before rcheevos gets them.