### PR TITLE
Updater: Bundle macOS updater inside main app.

### DIFF
--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -7,6 +7,14 @@ add_subdirectory(UICommon)
 add_subdirectory(VideoCommon)
 add_subdirectory(VideoBackends)
 
+if (APPLE AND ENABLE_AUTOUPDATE)
+  add_subdirectory(MacUpdater)
+endif()
+
+if (WIN32 AND ENABLE_AUTOUPDATE)
+  add_subdirectory(WinUpdater)
+endif()
+
 if(ENABLE_NOGUI)
   add_subdirectory(DolphinNoGUI)
 endif()
@@ -21,12 +29,4 @@ endif()
 
 if (APPLE OR WIN32)
   add_subdirectory(UpdaterCommon)
-endif()
-
-if (APPLE AND ENABLE_AUTOUPDATE)
-  add_subdirectory(MacUpdater)
-endif()
-
-if (WIN32 AND ENABLE_AUTOUPDATE)
-  add_subdirectory(WinUpdater)
 endif()

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -638,13 +638,21 @@ bool SetCurrentDir(const std::string& directory)
   return true;
 }
 
-std::string CreateTempDir()
-{
+std::string GetTempDir() {
 #ifdef _WIN32
   TCHAR temp[MAX_PATH];
   if (!GetTempPath(MAX_PATH, temp))
     return "";
+  return TStrToUTF8(temp);
+#else
+  return getenv("TMPDIR") ?: "/tmp";
+#endif
+}
 
+std::string CreateTempDir()
+{
+  std::string temp = GetTempDir();
+#ifdef _WIN32
   GUID guid;
   if (FAILED(CoCreateGuid(&guid)))
   {
@@ -655,14 +663,13 @@ std::string CreateTempDir()
   {
     return "";
   }
-  std::string dir = TStrToUTF8(temp) + "/" + TStrToUTF8(tguid);
+  std::string dir = temp + "/" + TStrToUTF8(tguid);
   if (!CreateDir(dir))
     return "";
   dir = ReplaceAll(dir, "\\", DIR_SEP);
   return dir;
 #else
-  const char* base = getenv("TMPDIR") ?: "/tmp";
-  std::string path = std::string(base) + "/DolphinWii.XXXXXX";
+  std::string path = temp + "/DolphinWii.XXXXXX";
   if (!mkdtemp(&path[0]))
     return "";
   return path;

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -210,6 +210,9 @@ bool MoveWithOverwrite(std::string_view source_path, std::string_view dest_path)
 // Set the current directory to given directory
 bool SetCurrentDir(const std::string& directory);
 
+// Returns the path to the system temporary directory.
+std::string GetTempDir();
+
 // Creates and returns the path to a new temporary directory.
 std::string CreateTempDir();
 

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -632,6 +632,18 @@ if(APPLE)
       $<TARGET_FILE:dolphin-emu>)
   endif()
 
+  if(ENABLE_AUTOUPDATE)
+    # Copy updater into the app bundle as a helper.
+    add_custom_command(TARGET dolphin-emu
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+      "$<TARGET_BUNDLE_DIR:dolphin-emu>/Contents/Helpers"
+      COMMAND ${CMAKE_COMMAND} -E copy_directory
+      "$<TARGET_BUNDLE_DIR:MacUpdater>"
+      "$<TARGET_BUNDLE_DIR:dolphin-emu>/Contents/Helpers/Dolphin Updater.app"
+      DEPENDS MacUpdater)
+  endif()
+
   if(MACOS_CODE_SIGNING)
     # Code sign make file builds
     add_custom_command(TARGET dolphin-emu POST_BUILD

--- a/Source/Core/MacUpdater/CMakeLists.txt
+++ b/Source/Core/MacUpdater/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(MacUpdater PRIVATE
     "-framework AppKit"
     "-framework CoreData"
     "-framework Foundation"
-    uicommon
+    common
     updatercommon
 )
 

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -49,14 +49,13 @@ const char UPDATER_LOG_FILE[] = "Updater.log";
 
 std::string UpdaterPath(bool relocated = false)
 {
-  std::string path(File::GetExeDirectory() + DIR_SEP);
 #ifdef __APPLE__
   if (relocated)
-    path += ".Dolphin Updater.2.app";
+    return fmt::format("{}/Dolphin Updater.app", File::GetTempDir());
   else
-    path += "Dolphin Updater.app";
-  return path;
+    return fmt::format("{}/Contents/Helpers/Dolphin Updater.app", File::GetBundleDirectory());
 #else
+  std::string path(File::GetExeDirectory() + DIR_SEP);
   return path + "Updater.exe";
 #endif
 }
@@ -271,7 +270,7 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
 #ifdef __APPLE__
   // Copy the updater so it can update itself if needed.
   const std::string reloc_updater_path = UpdaterPath(true);
-  if (!File::Copy(UpdaterPath(), reloc_updater_path))
+  if (!File::Copy(UpdaterPath(), reloc_updater_path, true))
   {
     CriticalAlertFmtT("Unable to create updater copy.");
     return;

--- a/Source/Core/UpdaterCommon/CMakeLists.txt
+++ b/Source/Core/UpdaterCommon/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(updatercommon
 )
 
 target_link_libraries(updatercommon PRIVATE
-  uicommon
+  common
   MbedTLS::mbedtls
   ZLIB::ZLIB
   ed25519

--- a/Source/Core/WinUpdater/CMakeLists.txt
+++ b/Source/Core/WinUpdater/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(winupdater WIN32
   ${MANIFEST_FILE})
 
 target_link_libraries(winupdater PRIVATE
-  uicommon
+  common
   updatercommon
   Comctl32
 )


### PR DESCRIPTION
### Description

This is an attempt to revive the concept from https://github.com/dolphin-emu/dolphin/pull/10428 by including the macOS updater app inside the main app bundle.

At runtime, the updater is copied from inside the bundle to the user's temporary directory, so that it does not run into issues related to apps modifying themselves on macOS.

Bundling the updater inside the main app simplifies the install process with a single app bundle, allows the updater to always be available without an external dependency, and eliminates an extra app in the user's app menu.

_Misc_: I've also replaced the updater dependency on `UICommon` with `Common` since `UICommon` code is not used. This should help reduce the updater binary size and dependency list a bit.

### Testing

I've tested this with a local development build and it seems to work if I manually point it at the hash for an older development build. I'm unable to do a full end-to-end test of this with codesigned builds though, so if someone could help validate this approach it would be appreciated.