### PR TITLE
Add Missing EncodeRegTo64 in JitArm64::dcbx

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -890,7 +890,7 @@ void JitArm64::dcbx(UGeckoInstruction inst)
     gprs_to_push[DecodeReg(loop_counter)] = false;
 
   ABI_PushRegisters(gprs_to_push);
-  m_float_emit.ABI_PushRegisters(fprs_to_push, WA);
+  m_float_emit.ABI_PushRegisters(fprs_to_push, EncodeRegTo64(WA));
 
   // For efficiency, effective_addr and loop_counter are already in W1 and W2 respectively
   if (make_loop)
@@ -904,7 +904,7 @@ void JitArm64::dcbx(UGeckoInstruction inst)
                      effective_addr);
   }
 
-  m_float_emit.ABI_PopRegisters(fprs_to_push, WA);
+  m_float_emit.ABI_PopRegisters(fprs_to_push, EncodeRegTo64(WA));
   ABI_PopRegisters(gprs_to_push);
 
   FixupBranch near_addr = B();


### PR DESCRIPTION
I from what I can tell, `ARM64FloatEmitter::ABI_PushRegisters` expects an XReg temporary, not a WReg. Otherwise, it may emit code with incongruent usage of WRegs then XRegs:
![WReg](https://github.com/dolphin-emu/dolphin/assets/140017135/ae8fadc1-0c8d-4cd6-a098-50d3dc669c11)
This causes a segmentation fault. While I have never witnessed this happening from the usage in `JitArm64::dcbx`, it's better in principle to fix it. This error mislead me in my own usage of `ARM64FloatEmitter::ABI_PushRegisters`. It may be worth adding a runtime assertion in `ARM64FloatEmitter::ABI_PushRegisters` to enforce this.