### PR TITLE
GraphicsModGroup: Allow heterogenous lookup for GetMod()

### DIFF
--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
@@ -185,7 +185,7 @@ void GraphicsModListWidget::ModItemChanged(QListWidgetItem* item)
   m_needs_save = true;
 }
 
-void GraphicsModListWidget::OnModChanged(std::optional<std::string> absolute_path)
+void GraphicsModListWidget::OnModChanged(const std::optional<std::string>& absolute_path)
 {
   ClearLayoutRecursively(m_mod_meta_layout);
 
@@ -198,7 +198,7 @@ void GraphicsModListWidget::OnModChanged(std::optional<std::string> absolute_pat
     return;
   }
 
-  GraphicsModConfig* mod = m_mod_group.GetMod(*absolute_path);
+  const GraphicsModConfig* mod = m_mod_group.GetMod(*absolute_path);
   if (!mod)
     return;
 

--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.h
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.h
@@ -52,7 +52,7 @@ private:
   void ModSelectionChanged();
   void ModItemChanged(QListWidgetItem* item);
 
-  void OnModChanged(std::optional<std::string> absolute_path);
+  void OnModChanged(const std::optional<std::string>& absolute_path);
 
   void SaveModList();
 

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
@@ -85,7 +85,7 @@ void GraphicsModGroupConfig::Load()
 
           auto mod_full_path = graphics_mod->GetAbsolutePath();
           known_paths.insert(std::move(mod_full_path));
-          m_graphics_mods.push_back(*graphics_mod);
+          m_graphics_mods.push_back(std::move(*graphics_mod));
         }
       }
     }

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
@@ -7,6 +7,8 @@
 #include <sstream>
 #include <string>
 
+#include <picojson.h>
+
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
@@ -174,7 +176,7 @@ std::vector<GraphicsModConfig>& GraphicsModGroupConfig::GetMods()
   return m_graphics_mods;
 }
 
-GraphicsModConfig* GraphicsModGroupConfig::GetMod(const std::string& absolute_path) const
+GraphicsModConfig* GraphicsModGroupConfig::GetMod(std::string_view absolute_path) const
 {
   if (const auto iter = m_path_to_graphics_mod.find(absolute_path);
       iter != m_path_to_graphics_mod.end())

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
@@ -95,15 +95,11 @@ void GraphicsModGroupConfig::Load()
                                                 GraphicsModConfig::Source source) {
     auto file = dir + DIR_SEP + "metadata.json";
     UnifyPathSeparators(file);
-    if (known_paths.find(file) != known_paths.end())
-    {
+    if (known_paths.contains(file))
       return;
-    }
-    const auto mod = GraphicsModConfig::Create(file, source);
-    if (mod)
-    {
-      m_graphics_mods.push_back(*mod);
-    }
+
+    if (auto mod = GraphicsModConfig::Create(file, source))
+      m_graphics_mods.push_back(std::move(*mod));
   };
 
   const std::set<std::string> graphics_mod_user_directories =

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.h
@@ -5,9 +5,8 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <picojson.h>
 
 #include "Common/CommonTypes.h"
 
@@ -34,7 +33,7 @@ public:
   const std::vector<GraphicsModConfig>& GetMods() const;
   std::vector<GraphicsModConfig>& GetMods();
 
-  GraphicsModConfig* GetMod(const std::string& absolute_path) const;
+  GraphicsModConfig* GetMod(std::string_view absolute_path) const;
 
   const std::string& GetGameID() const;
 
@@ -42,6 +41,6 @@ private:
   std::string GetPath() const;
   std::string m_game_id;
   std::vector<GraphicsModConfig> m_graphics_mods;
-  std::map<std::string, GraphicsModConfig*> m_path_to_graphics_mod;
+  std::map<std::string, GraphicsModConfig*, std::less<>> m_path_to_graphics_mod;
   u32 m_change_count = 0;
 };


### PR DESCRIPTION
Allows using keys that aren't directly std::string as the key. This lets us use std::string_view for the incoming path name, making it more flexible with other string types.

Forgot that I noticed this when doing the picojson changes until now.