### PR TITLE
VideoCommon: Collapse hash specialization namespaces

### DIFF
--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -79,14 +79,12 @@ struct PortableVertexDeclaration
 static_assert(std::is_trivially_copyable_v<PortableVertexDeclaration>,
               "Make sure we can memset-initialize");
 
-namespace std
-{
 template <>
-struct hash<PortableVertexDeclaration>
+struct std::hash<PortableVertexDeclaration>
 {
   // Implementation from Wikipedia.
   template <typename T>
-  u32 Fletcher32(const T& data) const
+  static u32 Fletcher32(const T& data)
   {
     static_assert(sizeof(T) % sizeof(u16) == 0);
 
@@ -114,9 +112,11 @@ struct hash<PortableVertexDeclaration>
     sum2 = (sum2 & 0xffff) + (sum2 >> 16);
     return (sum2 << 16 | sum1);
   }
-  size_t operator()(const PortableVertexDeclaration& decl) const { return Fletcher32(decl); }
+  size_t operator()(const PortableVertexDeclaration& decl) const noexcept
+  {
+    return Fletcher32(decl);
+  }
 };
-}  // namespace std
 
 // The implementation of this class is specific for GL/DX, so NativeVertexFormat.cpp
 // is in the respective backend, not here in VideoCommon.

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -220,17 +220,14 @@ struct SamplerState
   TM1 tm1;
 };
 
-namespace std
-{
 template <>
-struct hash<SamplerState>
+struct std::hash<SamplerState>
 {
-  std::size_t operator()(SamplerState const& state) const noexcept
+  std::size_t operator()(const SamplerState& state) const noexcept
   {
     return std::hash<u64>{}(state.Hex());
   }
 };
-}  // namespace std
 
 namespace RenderState
 {

--- a/Source/Core/VideoCommon/TextureConfig.h
+++ b/Source/Core/VideoCommon/TextureConfig.h
@@ -79,10 +79,8 @@ struct TextureConfig
   AbstractTextureType type = AbstractTextureType::Texture_2DArray;
 };
 
-namespace std
-{
 template <>
-struct hash<TextureConfig>
+struct std::hash<TextureConfig>
 {
   using argument_type = TextureConfig;
   using result_type = size_t;
@@ -95,4 +93,3 @@ struct hash<TextureConfig>
     return std::hash<u64>{}(id);
   }
 };
-}  // namespace std

--- a/Source/Core/VideoCommon/VertexLoaderBase.h
+++ b/Source/Core/VideoCommon/VertexLoaderBase.h
@@ -46,14 +46,11 @@ private:
   }
 };
 
-namespace std
-{
 template <>
-struct hash<VertexLoaderUID>
+struct std::hash<VertexLoaderUID>
 {
-  size_t operator()(const VertexLoaderUID& uid) const { return uid.GetHash(); }
+  size_t operator()(const VertexLoaderUID& uid) const noexcept { return uid.GetHash(); }
 };
-}  // namespace std
 
 class VertexLoaderBase
 {


### PR DESCRIPTION
We can specify the `std::` portion on the struct to perform the specialization instead of creating a namespace, which makes things a little less noisy.