### PR TITLE
Core/ConfigManager: Remove dead bAutomaticStart flag.

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -219,7 +219,6 @@ void SConfig::OnNewTitleLoad(const Core::CPUThreadGuard& guard)
 
 void SConfig::LoadDefaults()
 {
-  bAutomaticStart = false;
   bBootToPause = false;
 
   auto& system = Core::System::GetInstance();

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -44,7 +44,6 @@ struct BootParameters;
 struct SConfig
 {
   // Settings
-  bool bAutomaticStart = false;
   bool bBootToPause = false;
 
   bool bJITNoBlockCache = false;

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -172,7 +172,6 @@ void MenuBar::OnDebugModeToggled(bool enabled)
 {
   // Options
   m_boot_to_pause->setVisible(enabled);
-  m_automatic_start->setVisible(enabled);
   m_reset_ignore_panic_handler->setVisible(enabled);
   m_change_font->setVisible(enabled);
 
@@ -572,13 +571,6 @@ void MenuBar::AddOptionsMenu()
 
   connect(m_boot_to_pause, &QAction::toggled, this,
           [](bool enable) { SConfig::GetInstance().bBootToPause = enable; });
-
-  m_automatic_start = options_menu->addAction(tr("&Automatic Start"));
-  m_automatic_start->setCheckable(true);
-  m_automatic_start->setChecked(SConfig::GetInstance().bAutomaticStart);
-
-  connect(m_automatic_start, &QAction::toggled, this,
-          [](bool enable) { SConfig::GetInstance().bAutomaticStart = enable; });
 
   m_reset_ignore_panic_handler = options_menu->addAction(tr("Reset Ignore Panic Handler"));
 

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -241,7 +241,6 @@ private:
 
   // Options
   QAction* m_boot_to_pause;
-  QAction* m_automatic_start;
   QAction* m_reset_ignore_panic_handler;
   QAction* m_change_font;
   QAction* m_controllers_action;


### PR DESCRIPTION
This has been dead since at the very least the move to Qt, possibly longer.

This was apparently used at one point to automatically start a game when Dolphin was opened, a feature which can easily be replicated with a batch file.
https://github.com/dolphin-emu/dolphin/blob/3570c7f03a2aa90aa634f96c0af1969af610f14d/Source/Core/DolphinWX/Main.cpp#L285