### PR TITLE
BBA/HLE: Don't assume connect is successful

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
@@ -32,6 +32,8 @@ struct TcpBuffer
   std::vector<u8> data;
 };
 
+struct StackRef;
+
 // Socket helper classes to ensure network interface consistency.
 //
 // If the socket isn't bound, the system will pick the interface to use automatically.
@@ -45,6 +47,19 @@ public:
   sf::Socket::Status Connect(const sf::IpAddress& dest, u16 port, u32 net_ip);
   sf::Socket::Status GetPeerName(sockaddr_in* addr) const;
   sf::Socket::Status GetSockName(sockaddr_in* addr) const;
+
+  bool Connected(StackRef* ref);
+
+private:
+  enum class ConnectingState
+  {
+    None,
+    Connecting,
+    Connected,
+    Error
+  };
+
+  ConnectingState m_connecting_state = ConnectingState::None;
 };
 
 class BbaUdpSocket : public sf::UdpSocket


### PR DESCRIPTION
While writing a hardware test, I found that `connect` was implemented as always being successful. The previous implementation assumed that the connection succeeded (whereas it hasn't yet). Then, a game might call `send`/`recv` which will fail but will be reported as successful as well. So the game will assume the data is properly handled when in reality it wasn't since the socket wasn't properly connected yet. It also means sent data is lost since it was assumed as successful so the game has no way to know it failed.

This PR defers the successful connect packet and depends on https://github.com/dolphin-emu/dolphin/pull/12533 for the time being. Here is a test case (based on the previous hardware test) but with an unreachable IP address hardcoded instead of example's one: [net_connect_failure.zip](https://github.com/dolphin-emu/dolphin/files/14378000/net_connect_failure.zip)

Ready to be reviewed & merged.