### PR TITLE
CheatSearch: Remove redundant lambdas

### DIFF
--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -301,9 +301,7 @@ void CheatSearchWidget::OnNextScanClicked()
     }
   }
 
-  const Cheats::SearchErrorCode error_code = [this, &guard] {
-    return m_session->RunSearch(guard);
-  }();
+  const Cheats::SearchErrorCode error_code = m_session->RunSearch(guard);
 
   if (error_code == Cheats::SearchErrorCode::Success)
   {


### PR DESCRIPTION
Core::RunAsCPUThread is obsoleted by CPUThreadGuard reference already passed into the function. The nonsense lambda in CheatSearchWidget is from changes in fdb7328c737f2bba148b903491b66fa62cc03703.