### PR TITLE
BBA/HLE: Increase polling efficiency

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -678,14 +678,17 @@ bool CEXIETHERNET::BuiltInBBAInterface::SendFrame(const u8* frame, u32 size)
 
 void CEXIETHERNET::BuiltInBBAInterface::ReadThreadHandler(CEXIETHERNET::BuiltInBBAInterface* self)
 {
+  std::size_t datasize = 0;
   while (!self->m_read_thread_shutdown.IsSet())
   {
-    // make thread less cpu hungry
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    if (datasize == 0)
+    {
+      // Make thread less CPU hungry
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
 
     if (!self->m_read_enabled.IsSet())
       continue;
-    std::size_t datasize = 0;
 
     u8 wp = self->m_eth_ref->page_ptr(BBA_RWP);
     const u8 rp = self->m_eth_ref->page_ptr(BBA_RRP);
@@ -710,6 +713,10 @@ void CEXIETHERNET::BuiltInBBAInterface::ReadThreadHandler(CEXIETHERNET::BuiltInB
                   datasize);
       self->m_queue_read++;
       self->m_queue_read &= 15;
+    }
+    else
+    {
+      datasize = 0;
     }
 
     // Check network stack references

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
@@ -48,9 +48,6 @@ public:
   sf::Socket::Status GetPeerName(sockaddr_in* addr) const;
   sf::Socket::Status GetSockName(sockaddr_in* addr) const;
 
-  bool Connected(StackRef* ref);
-
-private:
   enum class ConnectingState
   {
     None,
@@ -59,6 +56,9 @@ private:
     Error
   };
 
+  ConnectingState Connected(StackRef* ref);
+
+private:
   ConnectingState m_connecting_state = ConnectingState::None;
 };
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -463,6 +463,7 @@ private:
     static void ReadThreadHandler(BuiltInBBAInterface* self);
 #endif
     void WriteToQueue(const std::vector<u8>& data);
+    bool WillQueueOverrun() const;
     void PollData(std::size_t* datasize);
     std::optional<std::vector<u8>> TryGetDataFromSocket(StackRef* ref);
 


### PR DESCRIPTION
This PR is based on https://github.com/dolphin-emu/dolphin/pull/12559 and updates the way BBA/HLE polls data. It does so by sleeping less often and pulling data as soon as possible and as much as possible.

I suspect this PR has improved the matchmaking stability. My Windows build seems to match consistently my Android phone and the other way around. It might be a coincidence since I don't have a lot of device to test it.

This PR is ready to be tested.