### PR TITLE
InputCommon: Fix profile path inconsistencies

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/controlleremu/EmulatedController.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/controlleremu/EmulatedController.kt
@@ -30,7 +30,11 @@ class EmulatedController private constructor(private val pointer: Long) {
 
     external fun saveProfile(path: String)
 
-    external fun getProfileName(): String
+    external fun getProfileKey(): String
+
+    external fun getUserProfileDirectoryPath(): String
+
+    external fun getSysProfileDirectoryPath(): String
 
     companion object {
         @JvmStatic

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/ui/ProfileDialogPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/ui/ProfileDialogPresenter.kt
@@ -101,11 +101,11 @@ class ProfileDialogPresenter {
     }
 
     private fun getProfileDirectoryPath(stock: Boolean): String {
-        val profileDirectoryName = menuTag.correspondingEmulatedController.getProfileName()
+        val controller = menuTag.correspondingEmulatedController
         return if (stock) {
-            "${DirectoryInitialization.getSysDirectory()}/Profiles/$profileDirectoryName/"
+            controller.getSysProfileDirectoryPath()
         } else {
-            "${DirectoryInitialization.getUserDirectory()}/Config/Profiles/$profileDirectoryName/"
+            controller.getUserProfileDirectoryPath()
         }
     }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -2237,7 +2237,7 @@ class SettingsFragmentPresenter(
         controllerNumber: Int
     ) {
         val profiles = ProfileDialogPresenter(menuTag).getProfileNames(false)
-        val profileKey = controller.getProfileName() + "Profile" + (controllerNumber + 1)
+        val profileKey = controller.getProfileKey() + "Profile" + (controllerNumber + 1)
         sl.add(
             StringSingleChoiceSetting(
                 context,

--- a/Source/Android/jni/Input/EmulatedController.cpp
+++ b/Source/Android/jni/Input/EmulatedController.cpp
@@ -126,10 +126,26 @@ Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedContro
 }
 
 JNIEXPORT jstring JNICALL
-Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedController_getProfileName(
+Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedController_getProfileKey(
     JNIEnv* env, jobject obj)
 {
-  return ToJString(env, EmulatedControllerFromJava(env, obj)->GetConfig()->GetProfileName());
+  return ToJString(env, EmulatedControllerFromJava(env, obj)->GetConfig()->GetProfileKey());
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedController_getUserProfileDirectoryPath(
+    JNIEnv* env, jobject obj)
+{
+  return ToJString(
+      env, EmulatedControllerFromJava(env, obj)->GetConfig()->GetUserProfileDirectoryPath());
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedController_getSysProfileDirectoryPath(
+    JNIEnv* env, jobject obj)
+{
+  return ToJString(env,
+                   EmulatedControllerFromJava(env, obj)->GetConfig()->GetSysProfileDirectoryPath());
 }
 
 JNIEXPORT jobject JNICALL

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -313,7 +313,7 @@ void FreeLookController::UpdateInput(CameraControllerInput* camera_controller)
 namespace FreeLook
 {
 static InputConfig s_config("FreeLookController", _trans("FreeLook"), "FreeLookController",
-                            InputConfig::InputClass::GC);
+                            "FreeLookController");
 InputConfig* GetInputConfig()
 {
   return &s_config;

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -312,7 +312,8 @@ void FreeLookController::UpdateInput(CameraControllerInput* camera_controller)
 
 namespace FreeLook
 {
-static InputConfig s_config("FreeLookController", _trans("FreeLook"), "FreeLookController");
+static InputConfig s_config("FreeLookController", _trans("FreeLook"), "FreeLookController",
+                            InputConfig::InputClass::GC);
 InputConfig* GetInputConfig()
 {
   return &s_config;
@@ -336,12 +337,12 @@ void Initialize()
 
   FreeLook::GetConfig().Refresh();
 
-  s_config.LoadConfig(InputConfig::InputClass::GC);
+  s_config.LoadConfig();
 }
 
 void LoadInputConfig()
 {
-  s_config.LoadConfig(InputConfig::InputClass::GC);
+  s_config.LoadConfig();
 }
 
 bool IsInitialized()

--- a/Source/Core/Core/HW/GBAPad.cpp
+++ b/Source/Core/Core/HW/GBAPad.cpp
@@ -10,7 +10,7 @@
 
 namespace Pad
 {
-static InputConfig s_config("GBA", _trans("Pad"), "GBA", InputConfig::InputClass::GBA);
+static InputConfig s_config("GBA", _trans("Pad"), "GBA", "GBA");
 InputConfig* GetGBAConfig()
 {
   return &s_config;

--- a/Source/Core/Core/HW/GBAPad.cpp
+++ b/Source/Core/Core/HW/GBAPad.cpp
@@ -10,7 +10,7 @@
 
 namespace Pad
 {
-static InputConfig s_config("GBA", _trans("Pad"), "GBA");
+static InputConfig s_config("GBA", _trans("Pad"), "GBA", InputConfig::InputClass::GBA);
 InputConfig* GetGBAConfig()
 {
   return &s_config;
@@ -34,12 +34,12 @@ void InitializeGBA()
   s_config.RegisterHotplugCallback();
 
   // Load the saved controller config
-  s_config.LoadConfig(InputConfig::InputClass::GBA);
+  s_config.LoadConfig();
 }
 
 void LoadGBAConfig()
 {
-  s_config.LoadConfig(InputConfig::InputClass::GBA);
+  s_config.LoadConfig();
 }
 
 bool IsGBAInitialized()

--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -17,7 +17,7 @@
 
 namespace Keyboard
 {
-static InputConfig s_config("GCKeyNew", _trans("Keyboard"), "GCKey", InputConfig::InputClass::GC);
+static InputConfig s_config("GCKeyNew", _trans("Keyboard"), "GCKey", "GCKey");
 InputConfig* GetConfig()
 {
   return &s_config;

--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -17,7 +17,7 @@
 
 namespace Keyboard
 {
-static InputConfig s_config("GCKeyNew", _trans("Keyboard"), "GCKey");
+static InputConfig s_config("GCKeyNew", _trans("Keyboard"), "GCKey", InputConfig::InputClass::GC);
 InputConfig* GetConfig()
 {
   return &s_config;
@@ -41,12 +41,12 @@ void Initialize()
   s_config.RegisterHotplugCallback();
 
   // Load the saved controller config
-  s_config.LoadConfig(InputConfig::InputClass::GC);
+  s_config.LoadConfig();
 }
 
 void LoadConfig()
 {
-  s_config.LoadConfig(InputConfig::InputClass::GC);
+  s_config.LoadConfig();
 }
 
 ControllerEmu::ControlGroup* GetGroup(int port, KeyboardGroup group)

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -14,7 +14,7 @@
 
 namespace Pad
 {
-static InputConfig s_config("GCPadNew", _trans("Pad"), "GCPad");
+static InputConfig s_config("GCPadNew", _trans("Pad"), "GCPad", InputConfig::InputClass::GC);
 InputConfig* GetConfig()
 {
   return &s_config;
@@ -38,12 +38,12 @@ void Initialize()
   s_config.RegisterHotplugCallback();
 
   // Load the saved controller config
-  s_config.LoadConfig(InputConfig::InputClass::GC);
+  s_config.LoadConfig();
 }
 
 void LoadConfig()
 {
-  s_config.LoadConfig(InputConfig::InputClass::GC);
+  s_config.LoadConfig();
 }
 
 bool IsInitialized()

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -14,7 +14,7 @@
 
 namespace Pad
 {
-static InputConfig s_config("GCPadNew", _trans("Pad"), "GCPad", InputConfig::InputClass::GC);
+static InputConfig s_config("GCPadNew", _trans("Pad"), "GCPad", "Pad");
 InputConfig* GetConfig()
 {
   return &s_config;

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -97,8 +97,7 @@ HIDWiimote* GetHIDWiimoteSource(unsigned int index)
 
 namespace Wiimote
 {
-static InputConfig s_config(WIIMOTE_INI_NAME, _trans("Wii Remote"), "Wiimote",
-                            InputConfig::InputClass::Wii);
+static InputConfig s_config(WIIMOTE_INI_NAME, _trans("Wii Remote"), "Wiimote", "Wiimote");
 
 InputConfig* GetConfig()
 {

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -97,7 +97,8 @@ HIDWiimote* GetHIDWiimoteSource(unsigned int index)
 
 namespace Wiimote
 {
-static InputConfig s_config(WIIMOTE_INI_NAME, _trans("Wii Remote"), "Wiimote");
+static InputConfig s_config(WIIMOTE_INI_NAME, _trans("Wii Remote"), "Wiimote",
+                            InputConfig::InputClass::Wii);
 
 InputConfig* GetConfig()
 {
@@ -206,7 +207,7 @@ void ResetAllWiimotes()
 
 void LoadConfig()
 {
-  s_config.LoadConfig(InputConfig::InputClass::Wii);
+  s_config.LoadConfig();
   s_last_connect_request_counter.fill(0);
 }
 

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -207,7 +207,7 @@ static std::array<u32, NUM_HOTKEY_GROUPS> s_hotkey_down;
 static HotkeyStatus s_hotkey;
 static bool s_enabled;
 
-static InputConfig s_config("Hotkeys", _trans("Hotkeys"), "Hotkeys", InputConfig::InputClass::GC);
+static InputConfig s_config("Hotkeys", _trans("Hotkeys"), "Hotkeys", "Hotkeys");
 
 InputConfig* GetConfig()
 {

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -207,7 +207,7 @@ static std::array<u32, NUM_HOTKEY_GROUPS> s_hotkey_down;
 static HotkeyStatus s_hotkey;
 static bool s_enabled;
 
-static InputConfig s_config("Hotkeys", _trans("Hotkeys"), "Hotkeys");
+static InputConfig s_config("Hotkeys", _trans("Hotkeys"), "Hotkeys", InputConfig::InputClass::GC);
 
 InputConfig* GetConfig()
 {
@@ -304,7 +304,7 @@ void Initialize()
 
 void LoadConfig()
 {
-  s_config.LoadConfig(InputConfig::InputClass::GC);
+  s_config.LoadConfig();
   LoadLegacyConfig(s_config.GetController(0));
 }
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -319,9 +319,8 @@ void MappingWindow::OnSaveProfilePressed()
   if (profile_name.isEmpty())
     return;
 
-  const std::string profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
-                                   m_config->GetProfileName() + "/" + profile_name.toStdString() +
-                                   ".ini";
+  const std::string profile_path =
+      m_config->GetUserProfileDirectoryPath() + profile_name.toStdString() + ".ini";
 
   File::CreateFullPath(profile_path);
 
@@ -487,8 +486,7 @@ void MappingWindow::PopulateProfileSelection()
 {
   m_profiles_combo->clear();
 
-  const std::string profiles_path =
-      File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR + m_config->GetProfileName();
+  const std::string profiles_path = m_config->GetUserProfileDirectoryPath();
   for (const auto& filename : Common::DoFileSearch({profiles_path}, {".ini"}))
   {
     std::string basename;
@@ -499,9 +497,8 @@ void MappingWindow::PopulateProfileSelection()
 
   m_profiles_combo->insertSeparator(m_profiles_combo->count());
 
-  const std::string builtin_profiles_path =
-      File::GetSysDirectory() + PROFILES_DIR + m_config->GetProfileName();
-  for (const auto& filename : Common::DoFileSearch({builtin_profiles_path}, {".ini"}))
+  for (const auto& filename :
+       Common::DoFileSearch({m_config->GetSysProfileDirectoryPath()}, {".ini"}))
   {
     std::string basename;
     SplitPath(filename, nullptr, &basename, nullptr);

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -20,9 +20,9 @@
 #include "InputCommon/InputProfile.h"
 
 InputConfig::InputConfig(const std::string& ini_name, const std::string& gui_name,
-                         const std::string& profile_directory_name, InputClass input_class)
+                         const std::string& profile_directory_name, const std::string& profile_key)
     : m_ini_name(ini_name), m_gui_name(gui_name), m_profile_directory_name(profile_directory_name),
-      m_input_class(input_class)
+      m_profile_key(profile_key)
 {
 }
 
@@ -157,20 +157,6 @@ void InputConfig::ClearControllers()
 bool InputConfig::ControllersNeedToBeCreated() const
 {
   return m_controllers.empty();
-}
-
-std::string InputConfig::GetProfileKey() const
-{
-  switch (m_input_class)
-  {
-  case InputClass::GBA:
-    return "GBA";
-  case InputClass::Wii:
-    return "Wiimote";
-  case InputClass::GC:
-  default:
-    return "Pad";
-  }
 }
 
 std::string InputConfig::GetUserProfileDirectoryPath() const

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -20,8 +20,8 @@
 #include "InputCommon/InputProfile.h"
 
 InputConfig::InputConfig(const std::string& ini_name, const std::string& gui_name,
-                         const std::string& profile_name, InputClass input_class)
-    : m_ini_name(ini_name), m_gui_name(gui_name), m_profile_name(profile_name),
+                         const std::string& profile_directory_name, InputClass input_class)
+    : m_ini_name(ini_name), m_gui_name(gui_name), m_profile_directory_name(profile_directory_name),
       m_input_class(input_class)
 {
 }
@@ -39,7 +39,7 @@ bool InputConfig::LoadConfig()
 
   if (SConfig::GetInstance().GetGameID() != "00000000")
   {
-    const std::string profile_directory = GetProfileDirectoryPath();
+    const std::string profile_directory = GetUserProfileDirectoryPath();
 
     Common::IniFile game_ini = SConfig::GetInstance().LoadGameIni();
     auto* control_section = game_ini.GetOrCreateSection("Controls");
@@ -173,23 +173,14 @@ std::string InputConfig::GetProfileKey() const
   }
 }
 
-std::string InputConfig::GetProfileDirectoryName() const
-{
-  switch (m_input_class)
-  {
-  case InputClass::GBA:
-    return "GBA";
-  case InputClass::Wii:
-    return "Wiimote";
-  case InputClass::GC:
-  default:
-    return "GCPad";
-  }
-}
-
-std::string InputConfig::GetProfileDirectoryPath() const
+std::string InputConfig::GetUserProfileDirectoryPath() const
 {
   return fmt::format("{}Profiles/{}/", File::GetUserPath(D_CONFIG_IDX), GetProfileDirectoryName());
+}
+
+std::string InputConfig::GetSysProfileDirectoryPath() const
+{
+  return fmt::format("{}Profiles/{}/", File::GetSysDirectory(), GetProfileDirectoryName());
 }
 
 int InputConfig::GetControllerCount() const

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -32,7 +32,7 @@ public:
   };
 
   InputConfig(const std::string& ini_name, const std::string& gui_name,
-              const std::string& profile_name, InputClass input_class);
+              const std::string& profile_directory_name, InputClass input_class);
 
   ~InputConfig();
 
@@ -51,10 +51,10 @@ public:
   bool IsControllerControlledByGamepadDevice(int index) const;
 
   std::string GetGUIName() const { return m_gui_name; }
-  std::string GetProfileName() const { return m_profile_name; }
   std::string GetProfileKey() const;
-  std::string GetProfileDirectoryName() const;
-  std::string GetProfileDirectoryPath() const;
+  std::string GetProfileDirectoryName() const { return m_profile_directory_name; }
+  std::string GetUserProfileDirectoryPath() const;
+  std::string GetSysProfileDirectoryPath() const;
   int GetControllerCount() const;
 
   // These should be used after creating all controllers and before clearing them, respectively.
@@ -68,7 +68,7 @@ private:
   std::vector<std::unique_ptr<ControllerEmu::EmulatedController>> m_controllers;
   const std::string m_ini_name;
   const std::string m_gui_name;
-  const std::string m_profile_name;
+  const std::string m_profile_directory_name;
   const InputClass m_input_class;
   InputCommon::DynamicInputTextureManager m_dynamic_input_tex_config_manager;
 };

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -24,15 +24,8 @@ class EmulatedController;
 class InputConfig
 {
 public:
-  enum class InputClass
-  {
-    GC,
-    Wii,
-    GBA,
-  };
-
   InputConfig(const std::string& ini_name, const std::string& gui_name,
-              const std::string& profile_directory_name, InputClass input_class);
+              const std::string& profile_directory_name, const std::string& profile_key);
 
   ~InputConfig();
 
@@ -51,7 +44,7 @@ public:
   bool IsControllerControlledByGamepadDevice(int index) const;
 
   std::string GetGUIName() const { return m_gui_name; }
-  std::string GetProfileKey() const;
+  std::string GetProfileKey() const { return m_profile_key; }
   std::string GetProfileDirectoryName() const { return m_profile_directory_name; }
   std::string GetUserProfileDirectoryPath() const;
   std::string GetSysProfileDirectoryPath() const;
@@ -69,6 +62,6 @@ private:
   const std::string m_ini_name;
   const std::string m_gui_name;
   const std::string m_profile_directory_name;
-  const InputClass m_input_class;
+  const std::string m_profile_key;
   InputCommon::DynamicInputTextureManager m_dynamic_input_tex_config_manager;
 };

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -24,11 +24,6 @@ class EmulatedController;
 class InputConfig
 {
 public:
-  InputConfig(const std::string& ini_name, const std::string& gui_name,
-              const std::string& profile_name);
-
-  ~InputConfig();
-
   enum class InputClass
   {
     GC,
@@ -36,7 +31,12 @@ public:
     GBA,
   };
 
-  bool LoadConfig(InputClass type);
+  InputConfig(const std::string& ini_name, const std::string& gui_name,
+              const std::string& profile_name, InputClass input_class);
+
+  ~InputConfig();
+
+  bool LoadConfig();
   void SaveConfig();
 
   template <typename T, typename... Args>
@@ -52,6 +52,9 @@ public:
 
   std::string GetGUIName() const { return m_gui_name; }
   std::string GetProfileName() const { return m_profile_name; }
+  std::string GetProfileKey() const;
+  std::string GetProfileDirectoryName() const;
+  std::string GetProfileDirectoryPath() const;
   int GetControllerCount() const;
 
   // These should be used after creating all controllers and before clearing them, respectively.
@@ -66,5 +69,6 @@ private:
   const std::string m_ini_name;
   const std::string m_gui_name;
   const std::string m_profile_name;
+  const InputClass m_input_class;
   InputCommon::DynamicInputTextureManager m_dynamic_input_tex_config_manager;
 };

--- a/Source/Core/InputCommon/InputProfile.cpp
+++ b/Source/Core/InputCommon/InputProfile.cpp
@@ -55,8 +55,8 @@ std::vector<std::string> GetProfilesFromSetting(const std::string& setting, cons
 
 std::vector<std::string> ProfileCycler::GetProfilesForDevice(InputConfig* device_configuration)
 {
-  const std::string device_profile_root_location(File::GetUserPath(D_CONFIG_IDX) + "Profiles/" +
-                                                 device_configuration->GetProfileName());
+  const std::string device_profile_root_location(
+      device_configuration->GetUserProfileDirectoryPath());
   return Common::DoFileSearch({device_profile_root_location}, {".ini"}, true);
 }
 
@@ -101,8 +101,8 @@ ProfileCycler::GetMatchingProfilesFromSetting(const std::string& setting,
                                               const std::vector<std::string>& profiles,
                                               InputConfig* device_configuration)
 {
-  const std::string device_profile_root_location(File::GetUserPath(D_CONFIG_IDX) + "Profiles/" +
-                                                 device_configuration->GetProfileName() + "/");
+  const std::string device_profile_root_location(
+      device_configuration->GetUserProfileDirectoryPath());
 
   const auto& profiles_from_setting = GetProfilesFromSetting(setting, device_profile_root_location);
   if (profiles_from_setting.empty())


### PR DESCRIPTION
Fixes an regression from PR #12215 where the Android GUI would write an incorrect game INI key when setting a per-game profile for a GameCube controller, as well as a much older bug that affects loading GameCube keyboard controller profiles from a game INI on all platforms. Read the commit descriptions for details.