### PR TITLE
Arm64Emitter: Don't optimize ADD to MOV for SP

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -4222,9 +4222,15 @@ void ARM64XEmitter::ADDI2R_internal(ARM64Reg Rd, ARM64Reg Rn, u64 imm, bool nega
   // Special path for zeroes
   if (imm == 0 && !flags)
   {
-    if (Rd != Rn)
+    if (Rd == Rn)
+    {
+      return;
+    }
+    else if (DecodeReg(Rd) != DecodeReg(ARM64Reg::SP) && DecodeReg(Rn) != DecodeReg(ARM64Reg::SP))
+    {
       MOV(Rd, Rn);
-    return;
+      return;
+    }
   }
 
   // Regular fast paths, aarch64 immediate instructions


### PR DESCRIPTION
Unlike ADD (immediate), MOV (register) treats SP as ZR. Therefore the ADDI2R optimization that was added in 67791d227c can't optimize ADD to MOV when exactly one of the registers is SP.

There currently isn't any code in Dolphin that calls ADDI2R with parameters that would trigger this case.