### PR TITLE
Fix path-loading of GBA map configurations

### DIFF
--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -208,8 +208,9 @@ private:
     if (m_id == "00000000")
       return;
 
-    const std::array<std::tuple<std::string, std::string, Config::System>, 2> profile_info = {{
+    const std::array<std::tuple<std::string, std::string, Config::System>, 3> profile_info = {{
         std::make_tuple("Pad", "GCPad", Config::System::GCPad),
+        std::make_tuple("GBA", "GBA", Config::System::GCPad),
         std::make_tuple("Wiimote", "Wiimote", Config::System::WiiPad),
     }};
 


### PR DESCRIPTION
After digging into configuration loading, I wanted to give a try at tackling a bug I discovered a while ago
( https://bugs.dolphin-emu.org/issues/13096 )

Currently, Dolphin only recognize PadProfileX (pointing to the "GCPad" folder) and WiimoteProfileX (pointing to the "Wiimote" folder) for loading controller mapping parameters.

As such, it's not currently possible to specify a GBA control map in a game-specific INI (unless you step in relative paths territory).

Since GBA profiles are stored in their own third folder, I propose to add a third parameter "GBAProfileX", using the very same loading process and naming convention as the other two.

Since this wasn't supported before, this shouldn't have adverse effect (even for people like me using relative paths, the relative path would still work) but as I'm still pretty new here, I'll welcome any remarks and even if I haven't noticed any issue, some more testing might be in order.
