### PR TITLE
Android: Mention download size in the Wii Menu not installed message

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -478,7 +478,7 @@
     <string name="wii_save_import_title_missing">Failed to import save file. Please launch the game once, then try again.</string>
     <string name="nand_import_warning">Merging a new NAND over your currently selected NAND will overwrite any channels and savegames that already exist. This process is not reversible, so it is recommended that you keep backups of both NANDs. Are you sure you want to continue?</string>
     <string name="system_menu_not_installed_title">Not installed</string>
-    <string name="system_menu_not_installed_message">The Wii Menu is currently not installed. Would you like to install it now?\nAn internet connection is required to download the update. It is recommended to download the update on Wi-Fi, as the amount of data downloaded may be large.</string>
+    <string name="system_menu_not_installed_message">The Wii Menu isn\'t installed. Would you like to install it now?\n\nRoughly 110 MiB of data will be downloaded from the internet. A Wi-Fi connection is recommended.</string>
 
     <!-- Game Properties Screen -->
     <string name="properties_details">Details</string>


### PR DESCRIPTION
Google Play's policies require us to tell the user the size of any large download.

The size seems to vary by just a megabyte or two across regions in my testing, so I'm listing a rough size for all the regions.

I'm also taking the opportunity to shorten the message to make it easier to read.