### PR TITLE
EXI: Don't kill Dolphin when receiving BBA_IOB

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -143,9 +143,7 @@ void CEXIETHERNET::ImmWrite(u32 data, u32 size)
     if (transfer.address == BBA_IOB && transfer.region == transfer.MX)
     {
       ERROR_LOG_FMT(SP1,
-                    "Usage of BBA_IOB indicates that the rx packet descriptor has been corrupted. "
-                    "Killing Dolphin...");
-      std::exit(0);
+                    "Usage of BBA_IOB indicates that the rx packet descriptor has been corrupted.");
     }
 
     // transfer has been setup


### PR DESCRIPTION
This PR prevents Dolphin from being killed when receiving `BBA_IOB`. Apparently, in some circumstances, the game might be in such situation and it might be non-fatal. For instance, when sending tons of UDP packet to an unbound port this situation can happen. This seems to only affect BBA TAP adapter.

I was able to replicate the issue on Windows 10 _(OpenVPN 2.4.11's TAP Adapter V9)_ with Mario Kart: Double Dash and Kirby Air Ride. It happens during the matchmaking sequence, right after Dolphin's BBA acquired an IP address and announced it via ARP.

The following python script can be used to spam UDP packets to an unbound port _(Wireshark can be used to find Dolphin's BBA IP using arp filter)_:
```python
#! /usr/bin/env python
from random import randint
from socket import *


def send_loop(ip, port=26510, size=1024):
    print("Keep sending {}-bytes data to {}:{}".format(size, ip, port))
    data = bytearray((randint(0, 255) for _ in range(size)))
    try:
        s = socket(AF_INET, SOCK_DGRAM)
        while True:
            s.sendto(data, (ip, port))
    finally:
        s.close()


if __name__ == "__main__":
    # Example:
    # python send_udp.py 169.254.220.117
    from sys import argv
    send_loop(*argv[1:])
```

Games don't appear to crash when the error is occurring and I'd rather have these games crash than the emulator exiting silently without a panic alert.

Ready to be reviewed & merged.