### PR TITLE
IOFile: avoid clearing errors on null file struct

### DIFF
--- a/Source/Core/Common/IOFile.h
+++ b/Source/Core/Common/IOFile.h
@@ -116,7 +116,8 @@ public:
   void ClearError()
   {
     m_good = true;
-    std::clearerr(m_file);
+    if (IsOpen())
+      std::clearerr(m_file);
   }
 
 private:


### PR DESCRIPTION
When performing a default compilation with recent GCC & glibc, the use of -Werror=nonnull causes a build error.

The error is given as IOFile::ClearError() can call std::clearerr() with a null file, which can trigger a null-pointer dereference in libc.

Change the std::clearerr() call to be conditional on a file being open.