### PR TITLE
Core/DSPHLE: Construct accelerator in AX and AXWii constructors.

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -27,9 +27,15 @@
 
 namespace DSP::HLE
 {
-AXUCode::AXUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
+AXUCode::AXUCode(DSPHLE* dsphle, u32 crc, bool dummy) : UCodeInterface(dsphle, crc)
+{
+}
+
+AXUCode::AXUCode(DSPHLE* dsphle, u32 crc) : AXUCode(dsphle, crc, false)
 {
   INFO_LOG_FMT(DSPHLE, "Instantiating AXUCode: crc={:08x}", crc);
+
+  m_accelerator = std::make_unique<HLEAccelerator>(dsphle->GetSystem().GetDSP());
 }
 
 AXUCode::~AXUCode() = default;
@@ -37,8 +43,6 @@ AXUCode::~AXUCode() = default;
 void AXUCode::Initialize()
 {
   InitializeShared();
-
-  m_accelerator = std::make_unique<HLEAccelerator>(m_dsphle->GetSystem().GetDSP());
 }
 
 void AXUCode::InitializeShared()

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -110,6 +110,9 @@ protected:
 
   std::unique_ptr<Accelerator> m_accelerator;
 
+  // Constructs without any GC-specific state, so it can be used by the deriving AXWii.
+  AXUCode(DSPHLE* dsphle, u32 crc, bool dummy);
+
   void InitializeShared();
 
   bool LoadResamplingCoefficients(bool require_same_checksum, u32 desired_checksum);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -20,21 +20,22 @@
 
 namespace DSP::HLE
 {
-AXWiiUCode::AXWiiUCode(DSPHLE* dsphle, u32 crc) : AXUCode(dsphle, crc), m_last_main_volume(0x8000)
+AXWiiUCode::AXWiiUCode(DSPHLE* dsphle, u32 crc)
+    : AXUCode(dsphle, crc, false), m_last_main_volume(0x8000)
 {
+  INFO_LOG_FMT(DSPHLE, "Instantiating AXWiiUCode: crc={:08x}", crc);
+
   for (u16& volume : m_last_aux_volumes)
     volume = 0x8000;
 
-  INFO_LOG_FMT(DSPHLE, "Instantiating AXWiiUCode");
-
   m_old_axwii = (crc == 0xfa450138) || (crc == 0x7699af32);
+
+  m_accelerator = std::make_unique<HLEAccelerator>(dsphle->GetSystem().GetDSP());
 }
 
 void AXWiiUCode::Initialize()
 {
   InitializeShared();
-
-  m_accelerator = std::make_unique<HLEAccelerator>(m_dsphle->GetSystem().GetDSP());
 }
 
 void AXWiiUCode::HandleCommandList()


### PR DESCRIPTION
This fixes an issue introduced by 3b0444be6bf38ca5c20f5b9b8916c54fd8f6fa36 where the m_accelerator would not be initialized when loading a savestate if the current UCode mismatched the UCode in the savestate, leading to a crash.

