### PR TITLE
DolphinTool: Fix parsing of command line bzip2 flag

### DIFF
--- a/Source/Core/DolphinTool/ConvertCommand.cpp
+++ b/Source/Core/DolphinTool/ConvertCommand.cpp
@@ -102,7 +102,7 @@ int ConvertCommand(const std::vector<std::string>& args)
       .action("store")
       .help("Compression method to use when converting to WIA/RVZ. Suggested value for RVZ: zstd "
             "[%choices]")
-      .choices({"none", "zstd", "bzip", "lzma", "lzma2"});
+      .choices({"none", "zstd", "bzip2", "lzma", "lzma2"});
 
   parser.add_option("-l", "--compression_level")
       .type("int")


### PR DESCRIPTION
Use "bzip2" instead of "bzip" in optparse's compression choices for the convert command. This is both more accurate and matches what the ParseCompressionTypeString function expects.

The mismatch between the two parsing functions prevented compression using bzip2 because either ParseCompressionTypeString or optparse would generate an error when using "bzip" or "bzip2" respectively.

Fixes https://bugs.dolphin-emu.org/issues/13427

This appears to have been broken since DolphinTool was created so there shouldn't be any backward compatibility issues.