### PR TITLE
Allow optional conversion & eol for OSREPORT

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -306,9 +306,9 @@ void CEXIIPL::TransferByte(u8& data)
         if (data != '\0')
           m_buffer += data;
 
-        if (data == '\r')
+        if (data == m_osreport_eol)
         {
-          NOTICE_LOG_FMT(OSREPORT, "{}", SHIFTJISToUTF8(m_buffer));
+          NOTICE_LOG_FMT(OSREPORT, "{}", m_osreport_sjis ? SHIFTJISToUTF8(m_buffer) : m_buffer);
           m_buffer.clear();
         }
       }

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.h
@@ -36,6 +36,9 @@ public:
 private:
   std::unique_ptr<u8[]> m_rom;
 
+  char m_osreport_eol = '\n';
+  bool m_osreport_sjis = false;
+
   // TODO these ranges are highly suspect
   enum
   {


### PR DESCRIPTION
Recently I added code in libogc to allow homebrew to send OSREPORT messages to Dolphin but it seems more sensible to use \n to end the message and stick with UTF8 encoding on the application side. I presume that commercial games have left debug messages which follow this format? I've used variables here to default to \n and no conversion from Shift JIS but my intention is to add checkboxes in the UI to set this as appropriate & store it as a setting.

I was thinking about adding either checkboxes or dropdowns to the the log window here https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/DolphinQt/Config/LogWidget.cpp#L140 but I'm not entirely sure of the best way to get settings configured there back to the code in EXI_DeviceIPL. Could someone point me in the right direction.

