### PR TITLE
Improved achievements disabled messaging

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -884,10 +884,14 @@ void AchievementManager::SetDisabled(bool disable)
     INFO_LOG_FMT(ACHIEVEMENTS, "Achievement Manager has been disabled.");
     OSD::AddMessage("Please close all games to re-enable achievements.", OSD::Duration::VERY_LONG,
                     OSD::Color::RED);
+    m_update_callback();
   }
 
   if (previously_disabled && !disable)
+  {
     INFO_LOG_FMT(ACHIEVEMENTS, "Achievement Manager has been re-enabled.");
+    m_update_callback();
+  }
 };
 
 const AchievementManager::NamedIconMap& AchievementManager::GetChallengeIcons() const
@@ -926,6 +930,7 @@ void AchievementManager::Logout()
   {
     std::lock_guard lg{m_lock};
     CloseGame();
+    SetDisabled(false);
     m_player_badge.name.clear();
     Config::SetBaseOrCurrent(Config::RA_API_TOKEN, "");
   }
@@ -937,6 +942,7 @@ void AchievementManager::Logout()
 void AchievementManager::Shutdown()
 {
   CloseGame();
+  SetDisabled(false);
   m_is_runtime_initialized = false;
   m_queue.Shutdown();
   // DON'T log out - keep those credentials for next run.

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -170,7 +170,8 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
     return;
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  AchievementManager::GetInstance().SetDisabled(true);
+  if (game_id != "00000000")
+    AchievementManager::GetInstance().SetDisabled(true);
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   if (game_id == "00000000")

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -291,6 +291,7 @@ void Stop()  // - Hammertime!
 
 #ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().CloseGame();
+  AchievementManager::GetInstance().SetDisabled(false);
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   s_is_stopping = true;

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -150,10 +150,7 @@ void AchievementHeaderWidget::UpdateData()
     m_game_progress_hard->setVisible(false);
     m_game_progress_soft->setVisible(false);
     m_rich_presence->setVisible(false);
-    if (instance.IsDisabled())
-    {
-      m_locked_warning->setVisible(true);
-    }
+    m_locked_warning->setVisible(instance.IsDisabled());
   }
 }
 


### PR DESCRIPTION
Most obviously, there is no longer a warning message to the player in the achievement window that achievements are disabled if a game is not currently running.