### PR TITLE
Simplify including Dolphin via `FetchContent`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 # This is inserted into the Info.plist as well.
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15.0" CACHE STRING "")
 
-set(CMAKE_USER_MAKE_RULES_OVERRIDE "CMake/FlagsOverride.cmake")
+set(CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_CURRENT_SOURCE_DIR}/CMake/FlagsOverride.cmake")
 
 project(dolphin-emu)
 


### PR DESCRIPTION
I've been experimenting with embedding Dolphin as a dependency with CMake's `FetchContent`, but the use of `CMAKE_USER_MAKE_RULES_OVERRIDE` complicates this; the various compiler flag checks use this option, but they all fail with errors similar to the following:

```
-- Performing Test FLAG_C_HAVE_SSE2
CMake Error at C:/Users/Jesse/AppData/Local/Programs/CLion Nova/bin/cmake/win/x64/share/cmake-3.28/Modules/CMakeRCInformation.cmake:27 (include):
  include could not find requested file:

    CMake/FlagsOverride.cmake
Call Stack (most recent call first):
  C:/Users/Jesse/AppData/Local/Programs/CLion Nova/bin/cmake/win/x64/share/cmake-3.28/Modules/Platform/Windows-MSVC.cmake:530 (enable_language)
  C:/Users/Jesse/AppData/Local/Programs/CLion Nova/bin/cmake/win/x64/share/cmake-3.28/Modules/Platform/Windows-MSVC.cmake:508 (__windows_compiler_msvc_enable_rc)
  C:/Users/Jesse/AppData/Local/Programs/CLion Nova/bin/cmake/win/x64/share/cmake-3.28/Modules/Platform/Windows-MSVC-C.cmake:5 (__windows_compiler_msvc)
  C:/Users/Jesse/AppData/Local/Programs/CLion Nova/bin/cmake/win/x64/share/cmake-3.28/Modules/CMakeCInformation.cmake:48 (include)
  C:/Users/Jesse/Projects/dolphin-master-quest/cmake-build-debug-windows/CMakeFiles/CMakeScratch/TryCompile-6fffhw/CMakeLists.txt:8 (project)


CMake Error at C:/Users/Jesse/AppData/Local/Programs/CLion Nova/bin/cmake/win/x64/share/cmake-3.28/Modules/Internal/CheckSourceCompiles.cmake:101 (try_compile):
  Failed to configure test project build system.
Call Stack (most recent call first):
  C:/Users/Jesse/AppData/Local/Programs/CLion Nova/bin/cmake/win/x64/share/cmake-3.28/Modules/Internal/CheckCompilerFlag.cmake:18 (cmake_check_source_compiles)
  C:/Users/Jesse/AppData/Local/Programs/CLion Nova/bin/cmake/win/x64/share/cmake-3.28/Modules/CheckCCompilerFlag.cmake:51 (cmake_check_compiler_flag)
  cmake-build-debug-windows/_deps/dolphin-src/CMake/CheckAndAddFlag.cmake:49 (check_c_compiler_flag)
  cmake-build-debug-windows/_deps/dolphin-src/CMakeLists.txt:224 (check_and_add_flag)


-- Configuring incomplete, errors occurred!
```

This PR resolves the issue by ~~making the use of `CMAKE_USER_MAKE_RULES_OVERRIDE` optional. The default behavior is unchanged; to disable it, define `-DDOLPHIN_NO_USER_MAKE_RULES_OVERRIDE=ON` on the initial `cmake` call.~~ fixing the use of `CMAKE_USER_MAKE_RULES_OVERRIDE` to be an absolute path instead.