### PR TITLE
Core: Make AchievementManager act as a dummy when USE_RETRO_ACHIEVEMENTS is disabled.

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -580,10 +580,8 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
         SetupGCMemory(system, guard);
       }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
       AchievementManager::GetInstance().HashGame(executable.path,
                                                  [](AchievementManager::ResponseType r_type) {});
-#endif  // USE_RETRO_ACHIEVEMENTS
 
       if (!executable.reader->LoadIntoMemory(system))
       {

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -166,9 +166,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     }
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().SetDisabled(false);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   const bool load_ipl = !system.IsWii() && !Config::Get(Config::MAIN_SKIP_IPL) &&
                         std::holds_alternative<BootParameters::Disc>(boot->parameters);

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -207,10 +207,9 @@ Cheats::NewSearch(const Core::CPUThreadGuard& guard,
                   PowerPC::RequestedAddressSpace address_space, bool aligned,
                   const std::function<bool(const T& value)>& validator)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   std::vector<Cheats::SearchResult<T>> results;
   const Core::State core_state = Core::GetState();
   if (core_state != Core::State::Running && core_state != Core::State::Paused)
@@ -261,10 +260,9 @@ Cheats::NextSearch(const Core::CPUThreadGuard& guard,
                    PowerPC::RequestedAddressSpace address_space,
                    const std::function<bool(const T& new_value, const T& old_value)>& validator)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   std::vector<Cheats::SearchResult<T>> results;
   const Core::State core_state = Core::GetState();
   if (core_state != Core::State::Running && core_state != Core::State::Paused)
@@ -427,10 +425,9 @@ MakeCompareFunctionForLastValue(Cheats::CompareType op)
 template <typename T>
 Cheats::SearchErrorCode Cheats::CheatSearchSession<T>::RunSearch(const Core::CPUThreadGuard& guard)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   Common::Result<SearchErrorCode, std::vector<SearchResult<T>>> result =
       Cheats::SearchErrorCode::InvalidParameters;
   if (m_filter_type == FilterType::CompareAgainstSpecificValue)

--- a/Source/Core/Core/CheatSearch.h
+++ b/Source/Core/Core/CheatSearch.h
@@ -100,10 +100,8 @@ enum class SearchErrorCode
   // currently off in the emulated game.
   VirtualAddressesCurrentlyNotAccessible,
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   // Cheats and memory reading are disabled in RetroAchievements hardcore mode.
   DisabledInHardcoreMode,
-#endif  // USE_RETRO_ACHIEVEMENTS
 };
 
 // Returns the corresponding DataType enum for the value currently held by the given SearchValue.

--- a/Source/Core/Core/Config/AchievementSettings.cpp
+++ b/Source/Core/Core/Config/AchievementSettings.cpp
@@ -1,7 +1,6 @@
 // Copyright 2023 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 #include "Core/Config/AchievementSettings.h"
 
 #include <string>
@@ -30,5 +29,3 @@ const Info<bool> RA_UNOFFICIAL_ENABLED{{System::Achievements, "Achievements", "U
                                        false};
 const Info<bool> RA_ENCORE_ENABLED{{System::Achievements, "Achievements", "EncoreEnabled"}, false};
 }  // namespace Config
-
-#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#ifdef USE_RETRO_ACHIEVEMENTS
-
 #include "Common/Config/Config.h"
 
 namespace Config
@@ -23,5 +21,3 @@ extern const Info<bool> RA_BADGES_ENABLED;
 extern const Info<bool> RA_UNOFFICIAL_ENABLED;
 extern const Info<bool> RA_ENCORE_ENABLED;
 }  // namespace Config
-
-#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -743,21 +743,13 @@ bool IsDefaultGCIFolderPathConfigured(ExpansionInterface::Slot slot)
 
 bool AreCheatsEnabled()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   return Config::Get(::Config::MAIN_ENABLE_CHEATS) && !::Config::Get(::Config::RA_HARDCORE_ENABLED);
-#else   // USE_RETRO_ACHIEVEMENTS
-  return Config::Get(::Config::MAIN_ENABLE_CHEATS);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 bool IsDebuggingEnabled()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   return Config::Get(::Config::MAIN_ENABLE_DEBUGGING) &&
          !::Config::Get(::Config::RA_HARDCORE_ENABLED);
-#else   // USE_RETRO_ACHIEVEMENTS
-  return Config::Get(::Config::MAIN_ENABLE_DEBUGGING);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 }  // namespace Config

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -169,17 +169,14 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   if (!was_changed)
     return;
 
-#ifdef USE_RETRO_ACHIEVEMENTS
-  if (game_id != "00000000")
-    AchievementManager::GetInstance().SetDisabled(true);
-#endif  // USE_RETRO_ACHIEVEMENTS
-
   if (game_id == "00000000")
   {
     m_title_name.clear();
     m_title_description.clear();
     return;
   }
+
+  AchievementManager::GetInstance().SetDisabled(true);
 
   const Core::TitleDatabase title_database;
   auto& system = Core::System::GetInstance();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -289,10 +289,8 @@ void Stop()  // - Hammertime!
   if (GetState() == State::Stopping || GetState() == State::Uninitialized)
     return;
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().CloseGame();
   AchievementManager::GetInstance().SetDisabled(false);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   s_is_stopping = true;
 
@@ -931,9 +929,7 @@ void Callback_NewField(Core::System& system)
     }
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().DoFrame();
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 void UpdateTitle()
@@ -1074,13 +1070,12 @@ void HostDispatchJobs()
 // NOTE: Host Thread
 void DoFrameStep()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
   {
     OSD::AddMessage("Frame stepping is disabled in RetroAchievements hardcore mode");
     return;
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   if (GetState() == State::Paused)
   {
     // if already paused, frame advance for 1 frame

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -138,7 +138,6 @@ void CoreTimingManager::RefreshConfig()
 
   m_max_variance = std::chrono::duration_cast<DT>(DT_ms(Config::Get(Config::MAIN_TIMING_VARIANCE)));
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive() &&
       Config::Get(Config::MAIN_EMULATION_SPEED) < 1.0f &&
       Config::Get(Config::MAIN_EMULATION_SPEED) > 0.0f)
@@ -147,7 +146,6 @@ void CoreTimingManager::RefreshConfig()
     m_emulation_speed = 1.0f;
     OSD::AddMessage("Minimum speed is 100% in Hardcore Mode");
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   m_emulation_speed = Config::Get(Config::MAIN_EMULATION_SPEED);
 }

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -30,10 +30,8 @@
 void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, Common::Debug::MemoryPatch& patch,
                       bool store_existing_value)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     return;
-#endif  // USE_RETRO_ACHIEVEMENTS
   if (patch.value.empty())
     return;
 

--- a/Source/Core/Core/FreeLookConfig.cpp
+++ b/Source/Core/Core/FreeLookConfig.cpp
@@ -46,11 +46,7 @@ void Config::Refresh()
   }
 
   camera_config.control_type = ::Config::Get(::Config::FL1_CONTROL_TYPE);
-#ifdef USE_RETRO_ACHIEVEMENTS
   enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED) &&
             !AchievementManager::GetInstance().IsHardcoreModeActive();
-#else   // USE_RETRO_ACHIEVEMENTS
-  enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 }  // namespace FreeLook

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -397,10 +397,8 @@ void DVDInterface::SetDisc(std::unique_ptr<DiscIO::VolumeDisc> disc,
     m_auto_disc_change_index = 0;
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().HashGame(disc.get(),
                                              [](AchievementManager::ResponseType r_type) {});
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   // Assume that inserting a disc requires having an empty disc before
   if (had_disc != has_disc)

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -478,11 +478,9 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
   if (!Core::IsRunningAndStarted())
     return BootstrapPPC();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   INFO_LOG_FMT(ACHIEVEMENTS,
                "WAD and NAND formats not currently supported by Achievement Manager.");
   AchievementManager::GetInstance().SetDisabled(true);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   core_timing.RemoveEvent(s_bootstrap_ppc_for_launch_event);
   core_timing.ScheduleEvent(ticks, s_bootstrap_ppc_for_launch_event);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -940,10 +940,8 @@ bool MovieManager::PlayInput(const std::string& movie_path,
 
   ReadHeader();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     return false;
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   m_total_frames = m_temp_header.frameCount;
   m_total_lag_count = m_temp_header.lagCount;
@@ -982,10 +980,8 @@ bool MovieManager::PlayInput(const std::string& movie_path,
 
     m_recording_from_save_state = true;
 
-#ifdef USE_RETRO_ACHIEVEMENTS
     // On the chance someone tries to re-enable before the TAS can start
     Config::SetBase(Config::RA_HARDCORE_ENABLED, false);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
     LoadInput(movie_path);
   }

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -233,10 +233,9 @@ void LoadPatches()
 
 static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Patch>& patches)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     return;
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   for (const Patch& patch : patches)
   {
     if (patch.enabled)
@@ -278,10 +277,9 @@ static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Pa
 static void ApplyMemoryPatches(const Core::CPUThreadGuard& guard,
                                std::span<const std::size_t> memory_patch_indices)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     return;
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   std::lock_guard lock(s_on_frame_memory_mutex);
   for (std::size_t index : memory_patch_indices)
   {

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -210,13 +210,11 @@ void LoadFromBuffer(std::vector<u8>& buffer)
     return;
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
   {
     OSD::AddMessage("Loading savestates is disabled in RetroAchievements hardcore mode");
     return;
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   Core::RunOnCPUThread(
       [&] {
@@ -849,13 +847,11 @@ void LoadAs(const std::string& filename)
     return;
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
   {
     OSD::AddMessage("Loading savestates is disabled in RetroAchievements hardcore mode");
     return;
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   std::unique_lock lk(s_load_or_save_in_progress_mutex, std::try_to_lock);
   if (!lk)

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -524,10 +524,8 @@ static bool MemoryMatchesAt(const Core::CPUThreadGuard& guard, u32 offset,
 static void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, u32 offset,
                              std::span<const u8> value, std::span<const u8> original)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (::Config::Get(::Config::RA_HARDCORE_ENABLED))
     return;
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   if (value.empty())
     return;

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -1,12 +1,13 @@
 // Copyright 2023 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 #include "DolphinQt/Achievements/AchievementsWindow.h"
 
 #include <mutex>
 
 #include <QDialogButtonBox>
+#include <QGroupBox>
+#include <QLabel>
 #include <QTabWidget>
 #include <QVBoxLayout>
 
@@ -43,6 +44,7 @@ void AchievementsWindow::showEvent(QShowEvent* event)
 
 void AchievementsWindow::CreateMainLayout()
 {
+#ifdef USE_RETRO_ACHIEVEMENTS
   const auto is_game_loaded = AchievementManager::GetInstance().IsGameLoaded();
 
   m_header_widget = new AchievementHeaderWidget(this);
@@ -55,12 +57,23 @@ void AchievementsWindow::CreateMainLayout()
   m_tab_widget->setTabVisible(1, is_game_loaded);
   m_tab_widget->addTab(GetWrappedWidget(m_leaderboard_widget, this, 125, 100), tr("Leaderboards"));
   m_tab_widget->setTabVisible(2, is_game_loaded);
+#else   // USE_RETRO_ACHIEVEMENTS
+  auto* achievements_disabled_layout = new QVBoxLayout();
+  achievements_disabled_layout->addWidget(
+      new QLabel(tr("This build of Dolphin was compiled without Achievement support.")));
+  auto* achievements_disabled_box = new QGroupBox(tr("Achievements not supported"));
+  achievements_disabled_box->setLayout(achievements_disabled_layout);
+#endif  // USE_RETRO_ACHIEVEMENTS
 
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
   auto* layout = new QVBoxLayout();
+#ifdef USE_RETRO_ACHIEVEMENTS
   layout->addWidget(m_header_widget);
   layout->addWidget(m_tab_widget);
+#else   // USE_RETRO_ACHIEVEMENTS
+  layout->addWidget(achievements_disabled_box);
+#endif  // USE_RETRO_ACHIEVEMENTS
   layout->addWidget(m_button_box);
 
   WrapInScrollArea(this, layout);
@@ -73,6 +86,7 @@ void AchievementsWindow::ConnectWidgets()
 
 void AchievementsWindow::UpdateData()
 {
+#ifdef USE_RETRO_ACHIEVEMENTS
   {
     auto& instance = AchievementManager::GetInstance();
     std::lock_guard lg{instance.GetLock()};
@@ -86,12 +100,13 @@ void AchievementsWindow::UpdateData()
     m_leaderboard_widget->UpdateData();
     m_tab_widget->setTabVisible(2, is_game_loaded);
   }
+#endif  // USE_RETRO_ACHIEVEMENTS
   update();
 }
 
 void AchievementsWindow::ForceSettingsTab()
 {
+#ifdef USE_RETRO_ACHIEVEMENTS
   m_tab_widget->setCurrentIndex(0);
-}
-
 #endif  // USE_RETRO_ACHIEVEMENTS
+}

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
@@ -3,16 +3,17 @@
 
 #pragma once
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 #include <QDialog>
 
+class QDialogButtonBox;
+
+#ifdef USE_RETRO_ACHIEVEMENTS
 class AchievementHeaderWidget;
 class AchievementLeaderboardWidget;
 class AchievementSettingsWidget;
 class AchievementProgressWidget;
-class QDialogButtonBox;
 class QTabWidget;
-class UpdateCallback;
+#endif  // USE_RETRO_ACHIEVEMENTS
 
 class AchievementsWindow : public QDialog
 {
@@ -27,12 +28,13 @@ private:
   void showEvent(QShowEvent* event) override;
   void ConnectWidgets();
 
+#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementHeaderWidget* m_header_widget;
   QTabWidget* m_tab_widget;
   AchievementSettingsWidget* m_settings_widget;
   AchievementProgressWidget* m_progress_widget;
   AchievementLeaderboardWidget* m_leaderboard_widget;
+#endif  // USE_RETRO_ACHIEVEMENTS
+
   QDialogButtonBox* m_button_box;
 };
-
-#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -143,12 +143,10 @@ void CheatsManager::RefreshCodeTabs(Core::State state, bool force)
   connect(m_ar_code, &ARCodeWidget::OpenGeneralSettings, this, &CheatsManager::OpenGeneralSettings);
   connect(m_gecko_code, &GeckoCodeWidget::OpenGeneralSettings, this,
           &CheatsManager::OpenGeneralSettings);
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(m_ar_code, &ARCodeWidget::OpenAchievementSettings, this,
           &CheatsManager::OpenAchievementSettings);
   connect(m_gecko_code, &GeckoCodeWidget::OpenAchievementSettings, this,
           &CheatsManager::OpenAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 void CheatsManager::CreateWidgets()

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -37,9 +37,7 @@ public:
 
 signals:
   void OpenGeneralSettings();
-#ifdef USE_RETRO_ACHIEVEMENTS
   void OpenAchievementSettings();
-#endif  // USE_RETRO_ACHIEVEMENTS
   void ShowMemory(u32 address);
   void RequestWatch(QString name, u32 address);
 

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -56,9 +56,7 @@ ARCodeWidget::~ARCodeWidget() = default;
 void ARCodeWidget::CreateWidgets()
 {
   m_warning = new CheatWarningWidget(m_game_id, m_restart_required, this);
-#ifdef USE_RETRO_ACHIEVEMENTS
   m_hc_warning = new HardcoreWarningWidget(this);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_code_list = new QListWidget;
   m_code_add = new NonDefaultQPushButton(tr("&Add New Code..."));
   m_code_edit = new NonDefaultQPushButton(tr("&Edit Code..."));
@@ -80,9 +78,7 @@ void ARCodeWidget::CreateWidgets()
   QVBoxLayout* layout = new QVBoxLayout;
 
   layout->addWidget(m_warning);
-#ifdef USE_RETRO_ACHIEVEMENTS
   layout->addWidget(m_hc_warning);
-#endif  // USE_RETRO_ACHIEVEMENTS
   layout->addWidget(m_code_list);
   layout->addLayout(button_layout);
 
@@ -93,10 +89,8 @@ void ARCodeWidget::ConnectWidgets()
 {
   connect(m_warning, &CheatWarningWidget::OpenCheatEnableSettings, this,
           &ARCodeWidget::OpenGeneralSettings);
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(m_hc_warning, &HardcoreWarningWidget::OpenAchievementSettings, this,
           &ARCodeWidget::OpenAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   connect(m_code_list, &QListWidget::itemChanged, this, &ARCodeWidget::OnItemChanged);
   connect(m_code_list, &QListWidget::itemSelectionChanged, this, &ARCodeWidget::OnSelectionChanged);

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.h
@@ -16,9 +16,7 @@ struct ARCode;
 }
 
 class CheatWarningWidget;
-#ifdef USE_RETRO_ACHIEVEMENTS
 class HardcoreWarningWidget;
-#endif  // USE_RETRO_ACHIEVEMENTS
 class QLabel;
 class QListWidget;
 class QListWidgetItem;
@@ -35,9 +33,7 @@ public:
 
 signals:
   void OpenGeneralSettings();
-#ifdef USE_RETRO_ACHIEVEMENTS
   void OpenAchievementSettings();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
 private:
   void OnSelectionChanged();
@@ -62,9 +58,7 @@ private:
   u16 m_game_revision;
 
   CheatWarningWidget* m_warning;
-#ifdef USE_RETRO_ACHIEVEMENTS
   HardcoreWarningWidget* m_hc_warning;
-#endif  // USE_RETRO_ACHIEVEMENTS
   QListWidget* m_code_list;
   QPushButton* m_code_add;
   QPushButton* m_code_edit;

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
@@ -38,10 +38,8 @@ void FreeLookWidget::CreateLayout()
   m_enable_freelook->SetDescription(
       tr("Allows manipulation of the in-game camera.<br><br><dolphin_emphasis>If unsure, "
          "leave this unchecked.</dolphin_emphasis>"));
-#ifdef USE_RETRO_ACHIEVEMENTS
   const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_enable_freelook->setEnabled(!hardcore);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_freelook_controller_configure_button = new NonDefaultQPushButton(tr("Configure Controller"));
 
   m_freelook_control_type = new ConfigChoice({tr("Six Axis"), tr("First Person"), tr("Orbital")},
@@ -112,10 +110,8 @@ void FreeLookWidget::LoadSettings()
 {
   const bool checked = Config::Get(Config::FREE_LOOK_ENABLED);
   m_enable_freelook->setChecked(checked);
-#ifdef USE_RETRO_ACHIEVEMENTS
   const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_enable_freelook->setEnabled(!hardcore);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_freelook_control_type->setEnabled(checked);
   m_freelook_controller_configure_button->setEnabled(checked);
   m_freelook_background_input->setEnabled(checked);

--- a/Source/Core/DolphinQt/Config/FreeLookWindow.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWindow.cpp
@@ -22,17 +22,13 @@ FreeLookWindow::FreeLookWindow(QWidget* parent) : QDialog(parent)
 
 void FreeLookWindow::CreateMainLayout()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   m_hc_warning = new HardcoreWarningWidget(this);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
   auto* main_layout = new QVBoxLayout();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   main_layout->addWidget(m_hc_warning);
-#endif  // USE_RETRO_ACHIEVEMENTS
   main_layout->addWidget(new FreeLookWidget(this));
   main_layout->addWidget(m_button_box);
   setLayout(main_layout);
@@ -40,8 +36,6 @@ void FreeLookWindow::CreateMainLayout()
 
 void FreeLookWindow::ConnectWidgets()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(m_hc_warning, &HardcoreWarningWidget::OpenAchievementSettings, this,
           &FreeLookWindow::OpenAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }

--- a/Source/Core/DolphinQt/Config/FreeLookWindow.h
+++ b/Source/Core/DolphinQt/Config/FreeLookWindow.h
@@ -5,9 +5,7 @@
 
 #include <QDialog>
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 class HardcoreWarningWidget;
-#endif  // USE_RETRO_ACHIEVEMENTS
 class QDialogButtonBox;
 
 class FreeLookWindow final : public QDialog
@@ -16,17 +14,13 @@ class FreeLookWindow final : public QDialog
 public:
   explicit FreeLookWindow(QWidget* parent);
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 signals:
   void OpenAchievementSettings();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
 private:
   void CreateMainLayout();
   void ConnectWidgets();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   HardcoreWarningWidget* m_hc_warning;
-#endif  // USE_RETRO_ACHIEVEMENTS
   QDialogButtonBox* m_button_box;
 };

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -62,9 +62,7 @@ GeckoCodeWidget::~GeckoCodeWidget() = default;
 void GeckoCodeWidget::CreateWidgets()
 {
   m_warning = new CheatWarningWidget(m_game_id, m_restart_required, this);
-#ifdef USE_RETRO_ACHIEVEMENTS
   m_hc_warning = new HardcoreWarningWidget(this);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_code_list = new QListWidget;
   m_name_label = new QLabel;
   m_creator_label = new QLabel;
@@ -106,9 +104,7 @@ void GeckoCodeWidget::CreateWidgets()
   auto* layout = new QVBoxLayout;
 
   layout->addWidget(m_warning);
-#ifdef USE_RETRO_ACHIEVEMENTS
   layout->addWidget(m_hc_warning);
-#endif  // USE_RETRO_ACHIEVEMENTS
   layout->addWidget(m_code_list);
 
   auto* info_layout = new QFormLayout;
@@ -157,10 +153,8 @@ void GeckoCodeWidget::ConnectWidgets()
   connect(m_download_codes, &QPushButton::clicked, this, &GeckoCodeWidget::DownloadCodes);
   connect(m_warning, &CheatWarningWidget::OpenCheatEnableSettings, this,
           &GeckoCodeWidget::OpenGeneralSettings);
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(m_hc_warning, &HardcoreWarningWidget::OpenAchievementSettings, this,
           &GeckoCodeWidget::OpenAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 void GeckoCodeWidget::OnSelectionChanged()

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
@@ -11,9 +11,7 @@
 #include "Common/CommonTypes.h"
 
 class CheatWarningWidget;
-#ifdef USE_RETRO_ACHIEVEMENTS
 class HardcoreWarningWidget;
-#endif  // USE_RETRO_ACHIEVEMENTS
 class QLabel;
 class QListWidget;
 class QListWidgetItem;
@@ -35,9 +33,7 @@ public:
 
 signals:
   void OpenGeneralSettings();
-#ifdef USE_RETRO_ACHIEVEMENTS
   void OpenAchievementSettings();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
 private:
   void OnSelectionChanged();
@@ -62,9 +58,7 @@ private:
   u16 m_game_revision;
 
   CheatWarningWidget* m_warning;
-#ifdef USE_RETRO_ACHIEVEMENTS
   HardcoreWarningWidget* m_hc_warning;
-#endif  // USE_RETRO_ACHIEVEMENTS
   QListWidget* m_code_list;
   QLabel* m_name_label;
   QLabel* m_creator_label;

--- a/Source/Core/DolphinQt/Config/HardcoreWarningWidget.cpp
+++ b/Source/Core/DolphinQt/Config/HardcoreWarningWidget.cpp
@@ -1,7 +1,6 @@
 // Copyright 2023 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 #include "DolphinQt/Config/HardcoreWarningWidget.h"
 
 #include <QHBoxLayout>
@@ -59,4 +58,3 @@ void HardcoreWarningWidget::Update()
 {
   setHidden(!Config::Get(Config::RA_HARDCORE_ENABLED));
 }
-#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Config/HardcoreWarningWidget.h
+++ b/Source/Core/DolphinQt/Config/HardcoreWarningWidget.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 #include <QWidget>
 
 class QLabel;
@@ -27,4 +26,3 @@ private:
   QLabel* m_text;
   QPushButton* m_settings_button;
 };
-#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Config/PatchesWidget.cpp
+++ b/Source/Core/DolphinQt/Config/PatchesWidget.cpp
@@ -41,9 +41,7 @@ PatchesWidget::PatchesWidget(const UICommon::GameFile& game)
 
 void PatchesWidget::CreateWidgets()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   m_hc_warning = new HardcoreWarningWidget(this);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_list = new QListWidget;
   m_add_button = new QPushButton(tr("&Add..."));
   m_edit_button = new QPushButton();
@@ -58,9 +56,7 @@ void PatchesWidget::CreateWidgets()
 
   auto* layout = new QVBoxLayout;
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   layout->addWidget(m_hc_warning);
-#endif  // USE_RETRO_ACHIEVEMENTS
   layout->addLayout(grid_layout);
 
   setLayout(layout);
@@ -68,11 +64,8 @@ void PatchesWidget::CreateWidgets()
 
 void PatchesWidget::ConnectWidgets()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(m_hc_warning, &HardcoreWarningWidget::OpenAchievementSettings, this,
           &PatchesWidget::OpenAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
-
   connect(m_list, &QListWidget::itemSelectionChanged, this, &PatchesWidget::UpdateActions);
   connect(m_list, &QListWidget::itemChanged, this, &PatchesWidget::OnItemChanged);
   connect(m_remove_button, &QPushButton::clicked, this, &PatchesWidget::OnRemove);

--- a/Source/Core/DolphinQt/Config/PatchesWidget.h
+++ b/Source/Core/DolphinQt/Config/PatchesWidget.h
@@ -11,9 +11,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/PatchEngine.h"
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 class HardcoreWarningWidget;
-#endif  // USE_RETRO_ACHIEVEMENTS
 class QListWidget;
 class QListWidgetItem;
 class QPushButton;
@@ -29,10 +27,8 @@ class PatchesWidget : public QWidget
 public:
   explicit PatchesWidget(const UICommon::GameFile& game);
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 signals:
   void OpenAchievementSettings();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
 private:
   void CreateWidgets();
@@ -46,9 +42,7 @@ private:
   void OnRemove();
   void OnEdit();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   HardcoreWarningWidget* m_hc_warning;
-#endif  // USE_RETRO_ACHIEVEMENTS
   QListWidget* m_list;
   QPushButton* m_add_button;
   QPushButton* m_edit_button;

--- a/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
@@ -51,15 +51,12 @@ PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& ga
           &PropertiesDialog::OpenGeneralSettings);
 
   connect(ar, &ARCodeWidget::OpenGeneralSettings, this, &PropertiesDialog::OpenGeneralSettings);
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(ar, &ARCodeWidget::OpenAchievementSettings, this,
           &PropertiesDialog::OpenAchievementSettings);
   connect(gecko, &GeckoCodeWidget::OpenAchievementSettings, this,
           &PropertiesDialog::OpenAchievementSettings);
   connect(patches, &PatchesWidget::OpenAchievementSettings, this,
           &PropertiesDialog::OpenAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
-
   connect(graphics_mod_list, &GraphicsModListWidget::OpenGraphicsSettings, this,
           &PropertiesDialog::OpenGraphicsSettings);
 

--- a/Source/Core/DolphinQt/Config/PropertiesDialog.h
+++ b/Source/Core/DolphinQt/Config/PropertiesDialog.h
@@ -19,7 +19,5 @@ public:
 signals:
   void OpenGeneralSettings();
   void OpenGraphicsSettings();
-#ifdef USE_RETRO_ACHIEVEMENTS
   void OpenAchievementSettings();
-#endif  // USE_RETRO_ACHIEVEMENTS
 };

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -553,10 +553,8 @@ void GameList::OpenProperties()
   connect(properties, &PropertiesDialog::OpenGeneralSettings, this, &GameList::OpenGeneralSettings);
   connect(properties, &PropertiesDialog::OpenGraphicsSettings, this,
           &GameList::OpenGraphicsSettings);
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(properties, &PropertiesDialog::OpenAchievementSettings, this,
           &GameList::OpenAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   SetQWidgetWindowDecorations(properties);
   properties->show();

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -56,9 +56,7 @@ signals:
   void SelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
   void OpenGeneralSettings();
   void OpenGraphicsSettings();
-#ifdef USE_RETRO_ACHIEVEMENTS
   void OpenAchievementSettings();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
 private:
   void ShowHeaderContextMenu(const QPoint& pos);

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -583,15 +583,11 @@ void HotkeyScheduler::Run()
     {
       const bool new_value = !Config::Get(Config::FREE_LOOK_ENABLED);
       Config::SetCurrent(Config::FREE_LOOK_ENABLED, new_value);
-#ifdef USE_RETRO_ACHIEVEMENTS
       const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
       if (hardcore)
         OSD::AddMessage("Free Look is Disabled in Hardcore Mode");
       else
         OSD::AddMessage(fmt::format("Free Look: {}", new_value ? "Enabled" : "Disabled"));
-#else   // USE_RETRO_ACHIEVEMENTS
-      OSD::AddMessage(fmt::format("Free Look: {}", new_value ? "Enabled" : "Disabled"));
-#endif  // USE_RETRO_ACHIEVEMENTS
     }
 
     // Savestates

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -246,21 +246,16 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 
   connect(m_cheats_manager, &CheatsManager::OpenGeneralSettings, this,
           &MainWindow::ShowGeneralWindow);
-
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(m_cheats_manager, &CheatsManager::OpenAchievementSettings, this,
           &MainWindow::ShowAchievementSettings);
   connect(m_game_list, &GameList::OpenAchievementSettings, this,
           &MainWindow::ShowAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   InitCoreCallbacks();
 
   NetPlayInit();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().Init();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
 #if defined(__unix__) || defined(__unix) || defined(__APPLE__)
   auto* daemon = new SignalDaemon(this);
@@ -327,9 +322,7 @@ MainWindow::~MainWindow()
   Settings::Instance().ResetNetPlayClient();
   Settings::Instance().ResetNetPlayServer();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().Shutdown();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   delete m_render_widget;
   delete m_netplay_dialog;
@@ -560,10 +553,7 @@ void MainWindow::ConnectMenuBar()
   connect(m_menu_bar, &MenuBar::ShowSkylanderPortal, this, &MainWindow::ShowSkylanderPortal);
   connect(m_menu_bar, &MenuBar::ShowInfinityBase, this, &MainWindow::ShowInfinityBase);
   connect(m_menu_bar, &MenuBar::ConnectWiiRemote, this, &MainWindow::OnConnectWiiRemote);
-
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(m_menu_bar, &MenuBar::ShowAchievementsWindow, this, &MainWindow::ShowAchievementsWindow);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   // Movie
   connect(m_menu_bar, &MenuBar::PlayRecording, this, &MainWindow::OnPlayRecording);
@@ -1262,10 +1252,8 @@ void MainWindow::ShowFreeLookWindow()
     m_freelook_window = new FreeLookWindow(this);
     InstallHotkeyFilter(m_freelook_window);
 
-#ifdef USE_RETRO_ACHIEVEMENTS
     connect(m_freelook_window, &FreeLookWindow::OpenAchievementSettings, this,
             &MainWindow::ShowAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
   }
 
   SetQWidgetWindowDecorations(m_freelook_window);
@@ -1997,7 +1985,6 @@ void MainWindow::OnConnectWiiRemote(int id)
   });
 }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 void MainWindow::ShowAchievementsWindow()
 {
   if (!m_achievements_window)
@@ -2016,7 +2003,6 @@ void MainWindow::ShowAchievementSettings()
   ShowAchievementsWindow();
   m_achievements_window->ForceSettingsTab();
 }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
 void MainWindow::ShowMemcardManager()
 {
@@ -2057,10 +2043,8 @@ void MainWindow::ShowRiivolutionBootWidget(const UICommon::GameFile& game)
                           disc.volume->GetDiscNumber(), game.GetFilePath(), this);
   SetQWidgetWindowDecorations(&w);
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(&w, &RiivolutionBootWidget::OpenAchievementSettings, this,
           &MainWindow::ShowAchievementSettings);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   w.exec();
   if (!w.ShouldBoot())

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -174,10 +174,8 @@ private:
   void ShowCheatsManager();
   void ShowRiivolutionBootWidget(const UICommon::GameFile& game);
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   void ShowAchievementsWindow();
   void ShowAchievementSettings();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   void NetPlayInit();
   bool NetPlayJoin();
@@ -257,9 +255,7 @@ private:
   static constexpr int num_wii_controllers = 4;
   std::array<WiiTASInputWindow*, num_wii_controllers> m_wii_tas_input_windows{};
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementsWindow* m_achievements_window = nullptr;
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   AssemblerWidget* m_assembler_widget;
   BreakpointWidget* m_breakpoint_widget;

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -124,14 +124,9 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   m_screenshot_action->setEnabled(running);
   m_state_save_menu->setEnabled(running);
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_state_load_menu->setEnabled(running && !hardcore);
   m_frame_advance_action->setEnabled(running && !hardcore);
-#else   // USE_RETRO_ACHIEVEMENTS
-  m_state_load_menu->setEnabled(running);
-  m_frame_advance_action->setEnabled(running);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   // Movie
   m_recording_read_only->setEnabled(running);
@@ -141,11 +136,7 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
     m_recording_export->setEnabled(false);
   }
   m_recording_play->setEnabled(m_game_selected && !running);
-#ifdef USE_RETRO_ACHIEVEMENTS
   m_recording_play->setEnabled(m_game_selected && !running && !hardcore);
-#else   // USE_RETRO_ACHIEVEMENTS
-  m_recording_play->setEnabled(m_game_selected && !running);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_recording_start->setEnabled((m_game_selected || running) &&
                                 !Core::System::GetInstance().GetMovie().IsPlayingInput());
 
@@ -246,14 +237,12 @@ void MenuBar::AddToolsMenu()
 
   tools_menu->addSeparator();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (Config::Get(Config::RA_ENABLED))
   {
     tools_menu->addAction(tr("Achievements"), this, [this] { emit ShowAchievementsWindow(); });
 
     tools_menu->addSeparator();
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   QMenu* gc_ipl = tools_menu->addMenu(tr("Load GameCube Main Menu"));
 

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -93,9 +93,7 @@ signals:
   void ShowInfinityBase();
   void ConnectWiiRemote(int id);
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   void ShowAchievementsWindow();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   // Options
   void Configure();

--- a/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
+++ b/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
@@ -59,9 +59,7 @@ RiivolutionBootWidget::~RiivolutionBootWidget() = default;
 
 void RiivolutionBootWidget::CreateWidgets()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   m_hc_warning = new HardcoreWarningWidget(this);
-#endif  // USE_RETRO_ACHIEVEMENTS
   auto* open_xml_button = new QPushButton(tr("Open Riivolution XML..."));
   auto* boot_game_button = new QPushButton(tr("Start"));
   boot_game_button->setDefault(true);
@@ -84,9 +82,7 @@ void RiivolutionBootWidget::CreateWidgets()
   button_layout->addWidget(boot_game_button, 0, Qt::AlignRight);
 
   auto* layout = new QVBoxLayout();
-#ifdef USE_RETRO_ACHIEVEMENTS
   layout->addWidget(m_hc_warning);
-#endif  // USE_RETRO_ACHIEVEMENTS
   layout->addWidget(scroll_area);
   layout->addLayout(button_layout);
   setLayout(layout);
@@ -98,12 +94,10 @@ void RiivolutionBootWidget::CreateWidgets()
 
 void RiivolutionBootWidget::ConnectWidgets()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   connect(m_hc_warning, &HardcoreWarningWidget::OpenAchievementSettings, this,
           &RiivolutionBootWidget::OpenAchievementSettings);
   connect(m_hc_warning, &HardcoreWarningWidget::OpenAchievementSettings, this,
           &RiivolutionBootWidget::reject);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 void RiivolutionBootWidget::LoadMatchingXMLs()

--- a/Source/Core/DolphinQt/RiivolutionBootWidget.h
+++ b/Source/Core/DolphinQt/RiivolutionBootWidget.h
@@ -11,9 +11,7 @@
 #include "Common/CommonTypes.h"
 #include "DiscIO/RiivolutionParser.h"
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 class HardcoreWarningWidget;
-#endif  // USE_RETRO_ACHIEVEMENTS
 class QPushButton;
 class QVBoxLayout;
 
@@ -29,10 +27,8 @@ public:
   bool ShouldBoot() const { return m_should_boot; }
   std::vector<DiscIO::Riivolution::Patch>& GetPatches() { return m_patches; }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 signals:
   void OpenAchievementSettings();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
 private:
   void CreateWidgets();
@@ -47,9 +43,7 @@ private:
   void BootGame();
   void SaveAsPreset();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   HardcoreWarningWidget* m_hc_warning;
-#endif  // USE_RETRO_ACHIEVEMENTS
   std::string m_game_id;
   std::optional<u16> m_revision;
   std::optional<u8> m_disc_number;

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -564,10 +564,9 @@ void Settings::SetCheatsEnabled(bool enabled)
 
 void Settings::SetDebugModeEnabled(bool enabled)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     enabled = false;
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   if (IsDebugModeEnabled() != enabled)
   {
     Config::SetBaseOrCurrent(Config::MAIN_ENABLE_DEBUGGING, enabled);

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -85,12 +85,8 @@ void GeneralPane::OnEmulationStateChanged(Core::State state)
   const bool running = state != Core::State::Uninitialized;
 
   m_checkbox_dualcore->setEnabled(!running);
-#ifdef USE_RETRO_ACHIEVEMENTS
   bool hardcore = Config::Get(Config::RA_HARDCORE_ENABLED);
   m_checkbox_cheats->setEnabled(!running && !hardcore);
-#else   // USE_RETRO_ACHIEVEMENTS
-  m_checkbox_cheats->setEnabled(!running);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_checkbox_override_region_settings->setEnabled(!running);
 #ifdef USE_DISCORD_PRESENCE
   m_checkbox_discord_presence->setEnabled(!running);

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -255,7 +255,6 @@ void InterfacePane::LoadConfig()
   SignalBlocking(m_checkbox_show_debugging_ui)
       ->setChecked(Settings::Instance().IsDebugModeEnabled());
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   bool hardcore = Config::Get(Config::RA_HARDCORE_ENABLED);
   SignalBlocking(m_checkbox_show_debugging_ui)->setEnabled(!hardcore);
   if (hardcore)
@@ -267,7 +266,6 @@ void InterfacePane::LoadConfig()
   {
     m_checkbox_show_debugging_ui->SetDescription({});
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   SignalBlocking(m_combobox_language)
       ->setCurrentIndex(m_combobox_language->findData(

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -330,7 +330,6 @@ void OnScreenUI::DrawDebugText()
     ImGui::TextUnformatted(profile_output.c_str());
 }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 void OnScreenUI::DrawChallenges()
 {
   std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
@@ -389,7 +388,6 @@ void OnScreenUI::DrawChallenges()
 
   ImGui::End();
 }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
 void OnScreenUI::Finalize()
 {
@@ -398,9 +396,7 @@ void OnScreenUI::Finalize()
   g_perf_metrics.DrawImGuiStats(m_backbuffer_scale);
   DrawDebugText();
   OSD::DrawMessages();
-#ifdef USE_RETRO_ACHIEVEMENTS
   DrawChallenges();
-#endif  // USE_RETRO_ACHIEVEMENTS
   ImGui::Render();
 }
 

--- a/Source/Core/VideoCommon/OnScreenUI.h
+++ b/Source/Core/VideoCommon/OnScreenUI.h
@@ -61,9 +61,7 @@ public:
 
 private:
   void DrawDebugText();
-#ifdef USE_RETRO_ACHIEVEMENTS
   void DrawChallenges();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   // ImGui resources.
   std::unique_ptr<NativeVertexFormat> m_imgui_vertex_format;
@@ -77,9 +75,7 @@ private:
   u32 m_backbuffer_height = 1;
   float m_backbuffer_scale = 1.0;
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   std::map<std::string, std::unique_ptr<AbstractTexture>, std::less<>> m_challenge_texture_map;
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   bool m_ready = false;
 };


### PR DESCRIPTION
This way call sites don't have to check for the define every time they want to do anything achievement-related.