### PR TITLE
IOS/FS: Display the invalid path in the ASSERT in BuildFilename().

### DIFF
--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -46,7 +46,7 @@ HostFileSystem::HostFilename HostFileSystem::BuildFilename(const std::string& wi
   if (wii_path.compare(0, 1, "/") == 0)
     return HostFilename{m_root_path + Common::EscapePath(wii_path), false};
 
-  ASSERT(false);
+  ASSERT_MSG(IOS_FS, false, "Invalid Wii path '{}' given to BuildFilename()", wii_path);
   return HostFilename{m_root_path, false};
 }
 


### PR DESCRIPTION
A user on Discord is running into this assert and I'm not sure how that's possible, so log more info here.