### PR TITLE
VideoCommon: move factory names to be a static inside each action class

### DIFF
--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/CustomPipelineAction.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/CustomPipelineAction.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <picojson.h>
@@ -21,6 +22,7 @@ public:
     std::string m_pixel_material_asset;
   };
 
+  static constexpr std::string_view factory_name = "custom_pipeline";
   static std::unique_ptr<CustomPipelineAction>
   Create(const picojson::value& json_data,
          std::shared_ptr<VideoCommon::CustomAssetLibrary> library);

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/MoveAction.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/MoveAction.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 
 #include <picojson.h>
 
@@ -12,6 +13,7 @@
 class MoveAction final : public GraphicsModAction
 {
 public:
+  static constexpr std::string_view factory_name = "move";
   static std::unique_ptr<MoveAction> Create(const picojson::value& json_data);
   explicit MoveAction(Common::Vec3 position_offset);
   void OnProjection(GraphicsModActionData::Projection* projection) override;

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/PrintAction.h
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "VideoCommon/GraphicsModSystem/Runtime/GraphicsModAction.h"
 
 class PrintAction final : public GraphicsModAction
 {
 public:
+  static constexpr std::string_view factory_name = "print";
   void OnDrawStarted(GraphicsModActionData::DrawStarted*) override;
   void OnEFB(GraphicsModActionData::EFB*) override;
   void OnProjection(GraphicsModActionData::Projection*) override;

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/ScaleAction.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/ScaleAction.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 
 #include <picojson.h>
 
@@ -12,6 +13,7 @@
 class ScaleAction final : public GraphicsModAction
 {
 public:
+  static constexpr std::string_view factory_name = "scale";
   static std::unique_ptr<ScaleAction> Create(const picojson::value& json_data);
   explicit ScaleAction(Common::Vec3 scale);
   void OnEFB(GraphicsModActionData::EFB*) override;

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/SkipAction.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/Actions/SkipAction.h
@@ -8,6 +8,7 @@
 class SkipAction final : public GraphicsModAction
 {
 public:
+  static constexpr std::string_view factory_name = "skip";
   void OnDrawStarted(GraphicsModActionData::DrawStarted*) override;
   void OnEFB(GraphicsModActionData::EFB*) override;
 };

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionFactory.cpp
@@ -14,23 +14,23 @@ namespace GraphicsModActionFactory
 std::unique_ptr<GraphicsModAction> Create(std::string_view name, const picojson::value& json_data,
                                           std::shared_ptr<VideoCommon::CustomAssetLibrary> library)
 {
-  if (name == "print")
+  if (name == PrintAction::factory_name)
   {
     return std::make_unique<PrintAction>();
   }
-  else if (name == "skip")
+  else if (name == SkipAction::factory_name)
   {
     return std::make_unique<SkipAction>();
   }
-  else if (name == "move")
+  else if (name == MoveAction::factory_name)
   {
     return MoveAction::Create(json_data);
   }
-  else if (name == "scale")
+  else if (name == ScaleAction::factory_name)
   {
     return ScaleAction::Create(json_data);
   }
-  else if (name == "custom_pipeline")
+  else if (name == CustomPipelineAction::factory_name)
   {
     return CustomPipelineAction::Create(json_data, std::move(library));
   }


### PR DESCRIPTION
This just moves the factory names to be a static inside each class so that they can be reused in the future when serializing any action data.