### PR TITLE
RetroAchievements - Leaderboard Indicators

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -69,6 +69,7 @@ public:
   using RichPresence = std::array<char, RP_SIZE>;
   using Badge = std::vector<u8>;
   using NamedIconMap = std::map<std::string, std::unique_ptr<OSD::Icon>, std::less<>>;
+  static constexpr size_t MAX_DISPLAYED_LBOARDS = 4;
 
   struct BadgeStatus
   {
@@ -111,6 +112,13 @@ public:
     std::unordered_map<u32, LeaderboardEntry> entries;
   };
 
+  struct LeaderboardDisplay
+  {
+    AchievementId id;
+    FormattedValue value;
+    int format;
+  };
+
   static AchievementManager& GetInstance();
   void Init();
   void SetUpdateCallback(UpdateCallback callback);
@@ -148,6 +156,7 @@ public:
   bool IsDisabled() const { return m_disabled; };
   void SetDisabled(bool disabled);
   const NamedIconMap& GetChallengeIcons() const;
+  std::vector<FormattedValue> GetActiveLeaderboards() const;
 
   void CloseGame();
   void Logout();
@@ -193,6 +202,7 @@ private:
   void HandleAchievementPrimedEvent(const rc_runtime_event_t* runtime_event);
   void HandleAchievementUnprimedEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardStartedEvent(const rc_runtime_event_t* runtime_event);
+  void HandleLeaderboardUpdatedEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardCanceledEvent(const rc_runtime_event_t* runtime_event);
   void HandleLeaderboardTriggeredEvent(const rc_runtime_event_t* runtime_event);
 
@@ -223,6 +233,7 @@ private:
   std::unordered_map<AchievementId, UnlockStatus> m_unlock_map;
   std::unordered_map<AchievementId, LeaderboardStatus> m_leaderboard_map;
   NamedIconMap m_active_challenges;
+  std::vector<LeaderboardDisplay> m_active_leaderboards;
 
   Common::WorkQueueThread<std::function<void()>> m_queue;
   Common::WorkQueueThread<std::function<void()>> m_image_queue;

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -331,63 +331,70 @@ void OnScreenUI::DrawDebugText()
 }
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-void OnScreenUI::DrawChallenges()
+void OnScreenUI::DrawChallengesAndLeaderboards()
 {
   std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
   const auto& challenge_icons = AchievementManager::GetInstance().GetChallengeIcons();
-  if (challenge_icons.empty())
-    return;
-
-  const std::string window_name = "Challenges";
-
-  u32 sum_of_icon_heights = 0;
-  u32 max_icon_width = 0;
-  for (const auto& [name, icon] : challenge_icons)
+  const auto& leaderboard_progress = AchievementManager::GetInstance().GetActiveLeaderboards();
+  float leaderboard_y = ImGui::GetIO().DisplaySize.y;
+  if (!challenge_icons.empty())
   {
-    // These *should* all be the same square size but you never know.
-    if (icon->width > max_icon_width)
-      max_icon_width = icon->width;
-    sum_of_icon_heights += icon->height;
-  }
-  ImGui::SetNextWindowPos(
-      ImVec2(ImGui::GetIO().DisplaySize.x - 20.f * m_backbuffer_scale - max_icon_width,
-             ImGui::GetIO().DisplaySize.y - 20.f * m_backbuffer_scale - sum_of_icon_heights));
-  ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f));
-  if (ImGui::Begin(window_name.c_str(), nullptr,
-                   ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
-                       ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings |
-                       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |
-                       ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing))
-  {
-    for (const auto& [name, icon] : challenge_icons)
+    ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x, ImGui::GetIO().DisplaySize.y), 0,
+                            ImVec2(1.0, 1.0));
+    ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f));
+    if (ImGui::Begin("Challenges", nullptr,
+                     ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
+                         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings |
+                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |
+                         ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing))
     {
-      if (m_challenge_texture_map.find(name) != m_challenge_texture_map.end())
-        continue;
-      const u32 width = icon->width;
-      const u32 height = icon->height;
-      TextureConfig tex_config(width, height, 1, 1, 1, AbstractTextureFormat::RGBA8, 0,
-                               AbstractTextureType::Texture_2DArray);
-      auto res = m_challenge_texture_map.insert_or_assign(name, g_gfx->CreateTexture(tex_config));
-      res.first->second->Load(0, width, height, width, icon->rgba_data.data(),
-                              sizeof(u32) * width * height);
-    }
-    for (auto& [name, texture] : m_challenge_texture_map)
-    {
-      auto icon_itr = challenge_icons.find(name);
-      if (icon_itr == challenge_icons.end())
+      for (const auto& [name, icon] : challenge_icons)
       {
-        m_challenge_texture_map.erase(name);
-        continue;
+        if (m_challenge_texture_map.find(name) != m_challenge_texture_map.end())
+          continue;
+        const u32 width = icon->width;
+        const u32 height = icon->height;
+        TextureConfig tex_config(width, height, 1, 1, 1, AbstractTextureFormat::RGBA8, 0,
+                                 AbstractTextureType::Texture_2DArray);
+        auto res = m_challenge_texture_map.insert_or_assign(name, g_gfx->CreateTexture(tex_config));
+        res.first->second->Load(0, width, height, width, icon->rgba_data.data(),
+                                sizeof(u32) * width * height);
       }
-      if (texture)
+      for (auto& [name, texture] : m_challenge_texture_map)
       {
-        ImGui::Image(texture.get(), ImVec2(static_cast<float>(icon_itr->second->width),
-                                           static_cast<float>(icon_itr->second->height)));
+        auto icon_itr = challenge_icons.find(name);
+        if (icon_itr == challenge_icons.end())
+        {
+          m_challenge_texture_map.erase(name);
+          continue;
+        }
+        if (texture)
+        {
+          ImGui::Image(texture.get(), ImVec2(static_cast<float>(icon_itr->second->width),
+                                             static_cast<float>(icon_itr->second->height)));
+        }
       }
+      leaderboard_y -= ImGui::GetWindowHeight();
     }
+    ImGui::End();
   }
 
-  ImGui::End();
+  if (!leaderboard_progress.empty())
+  {
+    ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x, leaderboard_y), 0,
+                            ImVec2(1.0, 1.0));
+    ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f));
+    if (ImGui::Begin("Leaderboards", nullptr,
+                     ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
+                         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings |
+                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |
+                         ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing))
+    {
+      for (const auto& value : leaderboard_progress)
+        ImGui::Text(value.data());
+    }
+    ImGui::End();
+  }
 }
 #endif  // USE_RETRO_ACHIEVEMENTS
 
@@ -399,7 +406,7 @@ void OnScreenUI::Finalize()
   DrawDebugText();
   OSD::DrawMessages();
 #ifdef USE_RETRO_ACHIEVEMENTS
-  DrawChallenges();
+  DrawChallengesAndLeaderboards();
 #endif  // USE_RETRO_ACHIEVEMENTS
   ImGui::Render();
 }

--- a/Source/Core/VideoCommon/OnScreenUI.h
+++ b/Source/Core/VideoCommon/OnScreenUI.h
@@ -62,7 +62,7 @@ public:
 private:
   void DrawDebugText();
 #ifdef USE_RETRO_ACHIEVEMENTS
-  void DrawChallenges();
+  void DrawChallengesAndLeaderboards();
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   // ImGui resources.


### PR DESCRIPTION
RetroAchievements provides Leaderboards for competitive statistics, such as best times and top scores. When a player is actively playing towards a leaderboard (the leaderboard is "active"), we display an indicator on screen to notify the player that they are competing and what their current submitted value is. Up to four of these values can be on screen at a time (if there are five or more leaderboards active, the ones displayed are the first ones started) and they are displayed on the bottom right of the screen, just above any challenge icons.