### PR TITLE
RetroAchievements - Discord Presence

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -21,6 +21,7 @@
 #include "Core/PowerPC/MMU.h"
 #include "Core/System.h"
 #include "DiscIO/Blob.h"
+#include "UICommon/DiscordPresence.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoEvents.h"
 
@@ -687,6 +688,8 @@ void AchievementManager::DoFrame()
   if (difftime(current_time, m_last_ping_time) > 120)
   {
     GenerateRichPresence();
+    if (Config::Get(Config::RA_DISCORD_PRESENCE_ENABLED))
+      Discord::UpdateDiscordPresence();
     m_queue.EmplaceItem([this] { PingRichPresence(m_rich_presence); });
     m_last_ping_time = current_time;
     m_update_callback();

--- a/Source/Core/Core/Config/AchievementSettings.cpp
+++ b/Source/Core/Core/Config/AchievementSettings.cpp
@@ -21,6 +21,8 @@ const Info<bool> RA_LEADERBOARDS_ENABLED{
     {System::Achievements, "Achievements", "LeaderboardsEnabled"}, false};
 const Info<bool> RA_RICH_PRESENCE_ENABLED{
     {System::Achievements, "Achievements", "RichPresenceEnabled"}, false};
+const Info<bool> RA_DISCORD_PRESENCE_ENABLED{
+    {System::Achievements, "Achievements", "DiscordPresenceEnabled"}, false};
 const Info<bool> RA_HARDCORE_ENABLED{{System::Achievements, "Achievements", "HardcoreEnabled"},
                                      false};
 const Info<bool> RA_PROGRESS_ENABLED{{System::Achievements, "Achievements", "ProgressEnabled"},

--- a/Source/Core/Core/Config/AchievementSettings.h
+++ b/Source/Core/Core/Config/AchievementSettings.h
@@ -17,6 +17,7 @@ extern const Info<std::string> RA_API_TOKEN;
 extern const Info<bool> RA_ACHIEVEMENTS_ENABLED;
 extern const Info<bool> RA_LEADERBOARDS_ENABLED;
 extern const Info<bool> RA_RICH_PRESENCE_ENABLED;
+extern const Info<bool> RA_DISCORD_PRESENCE_ENABLED;
 extern const Info<bool> RA_HARDCORE_ENABLED;
 extern const Info<bool> RA_PROGRESS_ENABLED;
 extern const Info<bool> RA_BADGES_ENABLED;

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
@@ -35,6 +35,7 @@ private:
   void ToggleAchievements();
   void ToggleLeaderboards();
   void ToggleRichPresence();
+  void ToggleDiscordPresence();
   void ToggleHardcore();
   void ToggleProgress();
   void ToggleBadges();
@@ -54,6 +55,7 @@ private:
   ToolTipCheckBox* m_common_achievements_enabled_input;
   ToolTipCheckBox* m_common_leaderboards_enabled_input;
   ToolTipCheckBox* m_common_rich_presence_enabled_input;
+  ToolTipCheckBox* m_common_discord_presence_enabled_input;
   ToolTipCheckBox* m_common_hardcore_enabled_input;
   ToolTipCheckBox* m_common_progress_enabled_input;
   ToolTipCheckBox* m_common_badges_enabled_input;

--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -21,6 +21,8 @@
 #include "Common/HttpRequest.h"
 #include "Common/StringUtil.h"
 
+#include "Core/AchievementManager.h"
+#include "Core/Config/AchievementSettings.h"
 #include "Core/System.h"
 
 #endif
@@ -228,6 +230,9 @@ void UpdateDiscordPresence(int party_size, SecretType type, const std::string& s
                                         std::chrono::system_clock::now().time_since_epoch())
                                         .count();
 
+#ifdef USE_RETRO_ACHIEVEMENTS
+  std::string state_string;
+#endif  // USE_RETRO_ACHIEVEMENTS
   if (party_size > 0)
   {
     if (party_size < 4)
@@ -244,6 +249,19 @@ void UpdateDiscordPresence(int party_size, SecretType type, const std::string& s
       // Note: joining still works without partyMax
     }
   }
+#ifdef USE_RETRO_ACHIEVEMENTS
+  else if (Config::Get(Config::RA_ENABLED) && Config::Get(Config::RA_RICH_PRESENCE_ENABLED) &&
+           Config::Get(Config::RA_DISCORD_PRESENCE_ENABLED))
+  {
+    state_string = AchievementManager::GetInstance().GetRichPresence().data();
+    if (state_string.length() >= 128)
+    {
+      // 124 characters + 3 dots + null terminator - thanks to Stenzek for format
+      state_string.replace(124, 4, "...");
+    }
+    discord_presence.state = state_string.c_str();
+  }
+#endif  // USE_RETRO_ACHIEVEMENTS
 
   std::string party_id;
   std::string secret_final;


### PR DESCRIPTION
Provided the player has decided to turn Rich Presence on via RetroAchievements, we can transmit this information to Discord to appear as part of the player's Discord status. This PR adds the configuration change, both backend and frontend, to enable this.