### PR TITLE
Clear active challenges when game closes

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -908,6 +908,7 @@ void AchievementManager::CloseGame()
     if (m_is_game_loaded)
     {
       m_is_game_loaded = false;
+      m_active_challenges.clear();
       ActivateDeactivateAchievements();
       ActivateDeactivateLeaderboards();
       ActivateDeactivateRichPresence();


### PR DESCRIPTION
Failing to do this was causing challenge icons to carry over into the next game if a game was closed while the icons were active, even if the next game to run was a completely different game entirely with completely different badges.