### PR TITLE
VertexManagerBase: Initialize m_ticks_elapsed on construction

### DIFF
--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -247,7 +247,7 @@ private:
   bool m_allow_background_execution = true;
 
   std::unique_ptr<CustomShaderCache> m_custom_shader_cache;
-  u64 m_ticks_elapsed;
+  u64 m_ticks_elapsed = 0;
 
   Common::EventHook m_frame_end_event;
   Common::EventHook m_after_present_event;


### PR DESCRIPTION
Ensures that this always has a deterministic value on construction like everything else in the class.