### PR TITLE
DSPJitRegCache: Take DynamicReg instances by reference in FlushRegs()

### DIFF
--- a/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
@@ -258,8 +258,8 @@ void DSPJitRegCache::FlushRegs(DSPJitRegCache& cache, bool emit)
   // free all host regs that are not used for the same guest reg
   for (size_t i = 0; i < m_regs.size(); i++)
   {
-    const auto reg = m_regs[i];
-    const auto cached_reg = cache.m_regs[i];
+    const auto& reg = m_regs[i];
+    const auto& cached_reg = cache.m_regs[i];
 
     if (cached_reg.loc.GetSimpleReg() != reg.loc.GetSimpleReg() && reg.loc.IsSimpleReg())
     {


### PR DESCRIPTION
A `DynamicReg` instance is 80 bytes in size, and we iterate over an array of 37 of them, so this just gets rid of some unnecessary copy churn.