### PR TITLE
Jit64/JitArm64: Avoid churning range vectors in Jit()

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -759,9 +759,9 @@ void Jit64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
 
   // Check if any code blocks have been freed in the block cache and transfer this information to
   // the local rangesets to allow overwriting them with new code.
-  for (auto range : blocks.GetRangesToFreeNear())
+  for (const auto& range : blocks.GetRangesToFreeNear())
     m_free_ranges_near.insert(range.first, range.second);
-  for (auto range : blocks.GetRangesToFreeFar())
+  for (const auto& range : blocks.GetRangesToFreeFar())
     m_free_ranges_far.insert(range.first, range.second);
   blocks.ClearRangesToFree();
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -904,7 +904,7 @@ void JitArm64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
 
   // Check if any code blocks have been freed in the block cache and transfer this information to
   // the local rangesets to allow overwriting them with new code.
-  for (auto range : blocks.GetRangesToFreeNear())
+  for (const auto& range : blocks.GetRangesToFreeNear())
   {
     auto first_fastmem_area = m_fault_to_handler.upper_bound(range.first);
     auto last_fastmem_area = first_fastmem_area;
@@ -915,7 +915,7 @@ void JitArm64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
 
     m_free_ranges_near.insert(range.first, range.second);
   }
-  for (auto range : blocks.GetRangesToFreeFar())
+  for (const auto& range : blocks.GetRangesToFreeFar())
   {
     m_free_ranges_far.insert(range.first, range.second);
   }


### PR DESCRIPTION
We can just take these via const reference.