### PR TITLE
CheatsManager/CheatSearchWidget: Avoid Global System Accessor

### DIFF
--- a/Source/Core/DolphinQt/CheatSearchWidget.h
+++ b/Source/Core/DolphinQt/CheatSearchWidget.h
@@ -18,6 +18,10 @@ namespace ActionReplay
 {
 struct ARCode;
 }
+namespace Core
+{
+class System;
+}
 
 class QCheckBox;
 class QComboBox;
@@ -36,7 +40,9 @@ class CheatSearchWidget : public QWidget
 {
   Q_OBJECT
 public:
-  explicit CheatSearchWidget(std::unique_ptr<Cheats::CheatSearchSessionBase> session);
+  explicit CheatSearchWidget(Core::System& system,
+                             std::unique_ptr<Cheats::CheatSearchSessionBase> session,
+                             QWidget* parent = nullptr);
   ~CheatSearchWidget() override;
 
   enum class UpdateSource
@@ -73,6 +79,8 @@ private:
   void GenerateARCode();
   int GetVisibleRowsBeginIndex() const;
   int GetVisibleRowsEndIndex() const;
+
+  Core::System& m_system;
 
   std::unique_ptr<Cheats::CheatSearchSessionBase> m_session;
 

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -24,7 +24,8 @@
 
 #include "VideoCommon/VideoEvents.h"
 
-CheatsManager::CheatsManager(QWidget* parent) : QDialog(parent)
+CheatsManager::CheatsManager(Core::System& system, QWidget* parent)
+    : QDialog(parent), m_system(system)
 {
   setWindowTitle(tr("Cheats Manager"));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -169,7 +170,7 @@ void CheatsManager::CreateWidgets()
 
 void CheatsManager::OnNewSessionCreated(const Cheats::CheatSearchSessionBase& session)
 {
-  auto* w = new CheatSearchWidget(session.Clone());
+  auto* w = new CheatSearchWidget(m_system, session.Clone());
   const int tab_index = m_tab_widget->addTab(w, tr("Cheat Search"));
   w->connect(w, &CheatSearchWidget::ActionReplayCodeGenerated, this,
              [this](const ActionReplay::ARCode& ar_code) {

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -26,13 +26,14 @@ class PartiallyClosableTabWidget;
 namespace Core
 {
 enum class State;
-}
+class System;
+}  // namespace Core
 
 class CheatsManager : public QDialog
 {
   Q_OBJECT
 public:
-  explicit CheatsManager(QWidget* parent = nullptr);
+  explicit CheatsManager(Core::System& system, QWidget* parent = nullptr);
   ~CheatsManager();
 
 signals:
@@ -63,6 +64,8 @@ private:
   std::string m_game_id;
   std::string m_game_tdb_id;
   u16 m_revision = 0;
+
+  Core::System& m_system;
 
   QDialogButtonBox* m_button_box;
   PartiallyClosableTabWidget* m_tab_widget = nullptr;

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -456,7 +456,7 @@ void MainWindow::CreateComponents()
   m_watch_widget = new WatchWidget(this);
   m_breakpoint_widget = new BreakpointWidget(this);
   m_code_widget = new CodeWidget(this);
-  m_cheats_manager = new CheatsManager(this);
+  m_cheats_manager = new CheatsManager(Core::System::GetInstance(), this);
   m_assembler_widget = new AssemblerWidget(this);
 
   const auto request_watch = [this](QString name, u32 addr) {


### PR DESCRIPTION
OnResetClicked and GenerateARCode appear to have been using the CPUThreadGuard in error.