### PR TITLE
AchievementManager: Get System By Reference

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -154,7 +154,7 @@ public:
   void Shutdown();
 
 private:
-  AchievementManager() = default;
+  explicit AchievementManager(Core::System& system);
 
   struct FilereaderState
   {
@@ -203,7 +203,7 @@ private:
   ResponseType RequestImage(rc_api_fetch_image_request_t rc_request, Badge* rc_response);
 
   rc_runtime_t m_runtime{};
-  Core::System* m_system{};
+  Core::System& m_system;
   bool m_is_runtime_initialized = false;
   UpdateCallback m_update_callback = [] {};
   std::unique_ptr<DiscIO::Volume> m_loading_volume;


### PR DESCRIPTION
Putting the constructor definition in the header causes issues with the incomplete type, 'OSD::Icon'.

Unless there is a design decision I am missing, this seems like a better alternative to lazy-initializing an `m_system` pointer. If there is a danger of this causing a deadlock in the future (`Core::System` attempting to static initialize `AchievementManager` before it itself is initialized), then this may not be worth pursuing.