### PR TITLE
Fix build error on newer GCC

### DIFF
--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -36,7 +36,7 @@ ResourcePack::ResourcePack(const std::string& path) : m_path(path)
     return;
   }
 
-  if (unzLocateFile(file, "manifest.json", nullptr) == UNZ_END_OF_LIST_OF_FILE)
+  if (unzLocateFile(file, "manifest.json", 0) == UNZ_END_OF_LIST_OF_FILE)
   {
     m_valid = false;
     m_error = "Resource pack is missing a manifest.";
@@ -63,7 +63,7 @@ ResourcePack::ResourcePack(const std::string& path) : m_path(path)
     return;
   }
 
-  if (unzLocateFile(file, "logo.png", nullptr) != UNZ_END_OF_LIST_OF_FILE)
+  if (unzLocateFile(file, "logo.png", 0) != UNZ_END_OF_LIST_OF_FILE)
   {
     unz_file_info64 logo_info{};
     unzGetCurrentFileInfo64(file, &logo_info, nullptr, 0, nullptr, 0, nullptr, 0);


### PR DESCRIPTION
In commit a5d06fde4b597d93750ba29bc2db83401fe431f7, a few instances of unzLocateFile changed to using nullptr. This argument is actually an int not a pointer (int iCaseSensitivity), so the compiler complains.

I believe older GCC considered this a warning, but it seems like newer GCC returns an error.