### PR TITLE
Add SettingsHandler unit tests exercising the edge case fixed in PR #8704

### DIFF
--- a/Source/UnitTests/Common/SettingsHandlerTest.cpp
+++ b/Source/UnitTests/Common/SettingsHandlerTest.cpp
@@ -18,6 +18,27 @@ Common::SettingsHandler::Buffer BUFFER_A{0x91, 0x91, 0x90, 0xEE, 0xD1, 0x2F, 0xF
 Common::SettingsHandler::Buffer BUFFER_B{
     0x91, 0x91, 0x90, 0xE2, 0x9A, 0x38, 0xFD, 0x55, 0x42, 0xEA, 0xC4, 0xF6, 0x5E, 0xF,  0xDF, 0xE7,
     0xC3, 0x0A, 0xBB, 0x9C, 0x50, 0xB1, 0x10, 0x82, 0xB4, 0x8A, 0x0D, 0xBE, 0xCD, 0x72, 0xF4};
+
+// The encrypted bytes corresponding to the following setting:
+//   "\xFA" = "a"
+//
+// This setting triggers the edge case fixed in PR #8704: the key's first and only byte matches the
+// first byte of the initial encryption key, resulting in a null encoded byte on the first attempt
+// to encode the line.
+Common::SettingsHandler::Buffer BUFFER_C{0xF0, 0x0E, 0xD4, 0xB2, 0xAA, 0x44};
+
+// The encrypted bytes corresponding to the following setting:
+//   "\xFA\xE9" = "a"
+//
+// This setting triggers the edge case fixed in PR #8704 twice:
+//
+// 1. The key's first byte matches the first byte of the initial encryption key, resulting in a null
+// encoded byte on the first attempt to encode the line.
+//
+// 2. The key's second byte matches the first byte of the encryption key after two
+// rotations, resulting in a null encoded byte on the second attempt to encode the line (with a
+// single LF inserted before the line).
+Common::SettingsHandler::Buffer BUFFER_D{0xF0, 0xFE, 0x13, 0x3A, 0x9A, 0x2F, 0x91, 0x33};
 }  // namespace
 
 TEST(SettingsHandlerTest, EncryptSingleSetting)
@@ -90,5 +111,34 @@ TEST(SettingsHandlerTest, GetValueAfterReset)
   EXPECT_EQ(handler.GetValue("key"), "");
 }
 
-// TODO: Add test coverage of the edge case fixed in
-// https://github.com/dolphin-emu/dolphin/pull/8704.
+TEST(SettingsHandlerTest, EncryptAddsLFOnNullChar)
+{
+  Common::SettingsHandler handler;
+  handler.AddSetting("\xFA", "a");
+  Common::SettingsHandler::Buffer buffer = handler.GetBytes();
+
+  EXPECT_TRUE(std::equal(buffer.begin(), buffer.end(), BUFFER_C.begin(), BUFFER_C.end()));
+}
+
+TEST(SettingsHandlerTest, EncryptAddsLFOnNullCharTwice)
+{
+  Common::SettingsHandler handler;
+  handler.AddSetting("\xFA\xE9", "a");
+  Common::SettingsHandler::Buffer buffer = handler.GetBytes();
+
+  EXPECT_TRUE(std::equal(buffer.begin(), buffer.end(), BUFFER_D.begin(), BUFFER_D.end()));
+}
+
+TEST(SettingsHandlerTest, DecryptSingleAddedLF)
+{
+  Common::SettingsHandler::Buffer buffer = BUFFER_C;
+  Common::SettingsHandler handler(std::move(buffer));
+  EXPECT_EQ(handler.GetValue("\xFA"), "a");
+}
+
+TEST(SettingsHandlerTest, DecryptTwoAddedLFs)
+{
+  Common::SettingsHandler::Buffer buffer = BUFFER_D;
+  Common::SettingsHandler handler(std::move(buffer));
+  EXPECT_EQ(handler.GetValue("\xFA\xE9"), "a");
+}


### PR DESCRIPTION
This PR adds tests verifying that an LF is added if the first attempt to encode a line results in a null byte, and that another LF is added if the second encoding attempt again results in a null byte. It also adds corresponding tests of decrypting the resulting buffers.