### PR TITLE
PPCSymbolDB: Eliminate Redundant Member

### DIFF
--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -28,9 +28,7 @@
 
 PPCSymbolDB g_symbolDB;
 
-PPCSymbolDB::PPCSymbolDB() : debugger{&Core::System::GetInstance().GetPowerPC().GetDebugInterface()}
-{
-}
+PPCSymbolDB::PPCSymbolDB() = default;
 
 PPCSymbolDB::~PPCSymbolDB() = default;
 
@@ -510,6 +508,8 @@ bool PPCSymbolDB::SaveCodeMap(const Core::CPUThreadGuard& guard, const std::stri
   // Write ".text" at the top
   f.WriteString(".text\n");
 
+  const auto& ppc_debug_interface = guard.GetSystem().GetPowerPC().GetDebugInterface();
+
   u32 next_address = 0;
   for (const auto& function : m_functions)
   {
@@ -530,7 +530,7 @@ bool PPCSymbolDB::SaveCodeMap(const Core::CPUThreadGuard& guard, const std::stri
     // Write the code
     for (u32 address = symbol.address; address < next_address; address += 4)
     {
-      const std::string disasm = debugger->Disassemble(&guard, address);
+      const std::string disasm = ppc_debug_interface.Disassemble(&guard, address);
       f.WriteString(fmt::format("{0:08x} {1:<{2}.{3}} {4}\n", address, symbol.name,
                                 SYMBOL_NAME_LIMIT, SYMBOL_NAME_LIMIT, disasm));
     }

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -11,7 +11,6 @@
 namespace Core
 {
 class CPUThreadGuard;
-class DebugInterface;
 }  // namespace Core
 
 // This has functionality overlapping Debugger_Symbolmap. Should merge that stuff in here later.
@@ -39,9 +38,6 @@ public:
   void PrintCalls(u32 funcAddr) const;
   void PrintCallers(u32 funcAddr) const;
   void LogFunctionCall(u32 addr);
-
-private:
-  Core::DebugInterface* debugger;
 };
 
 extern PPCSymbolDB g_symbolDB;


### PR DESCRIPTION
This can be accessed through the CPUThreadGuard.