### PR TITLE
Cache achievement measurements in Unlock Map

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -90,6 +90,8 @@ public:
     BadgeStatus locked_badge;
     BadgeStatus unlocked_badge;
     u32 category = RC_ACHIEVEMENT_CATEGORY_CORE;
+    u32 measured_value = 0;
+    u32 measured_target = 0;
   };
 
   static constexpr std::string_view GRAY = "transparent";


### PR DESCRIPTION
Adds measured_value and measured_target to the UnlockStatus object so that the information is already updated and calculated every time the UI needs it, as opposed to recalculating every measurement whenever the dialog updates.