### PR TITLE
GameINI: Fix Emergency Mayhem hang on loading

### DIFF
--- a/Data/Sys/GameSettings/REG.ini
+++ b/Data/Sys/GameSettings/REG.ini
@@ -1,0 +1,4 @@
+# REGE36, REGP36 - Emergency Mayhem
+[Core]
+# Dual core causes hang on loading
+CPUThread = False


### PR DESCRIPTION
Fixes hang on game loading by turning off dual core. Sorry for submitting the same pull request twice, I had to close the old one because I accidentally added a second commit and Github wouldn't let me get rid of it