### PR TITLE
BranchWatchDialog: Fix Misc. Errata

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -49,9 +49,11 @@ class BranchWatchDialog : public QDialog
 public:
   explicit BranchWatchDialog(Core::System& system, Core::BranchWatch& branch_watch,
                              CodeWidget* code_widget, QWidget* parent = nullptr);
-  void done(int r) override;
-  int exec() override;
-  void open() override;
+  ~BranchWatchDialog() override;
+
+protected:
+  void hideEvent(QHideEvent* event) override;
+  void showEvent(QShowEvent* event) override;
 
 private:
   void OnStartPause(bool checked);
@@ -81,6 +83,8 @@ private:
   void OnTableSetBLR(QModelIndexList index_list);
   void OnTableSetNOP(QModelIndexList index_list);
   void OnTableCopyAddress(QModelIndexList index_list);
+
+  void SaveSettings();
 
 public:
   // TODO: Step doesn't cause EmulationStateChanged to be emitted, so it has to call this manually.

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -36,10 +36,7 @@ static const QString BOX_SPLITTER_STYLESHEET = QStringLiteral(
     "QSplitter::handle { border-top: 1px dashed black; width: 1px; margin-left: 10px; "
     "margin-right: 10px; }");
 
-CodeWidget::CodeWidget(QWidget* parent)
-    : QDockWidget(parent), m_system(Core::System::GetInstance()),
-      m_branch_watch_dialog(
-          new BranchWatchDialog(m_system, m_system.GetPowerPC().GetBranchWatch(), this))
+CodeWidget::CodeWidget(QWidget* parent) : QDockWidget(parent), m_system(Core::System::GetInstance())
 {
   setWindowTitle(tr("Code"));
   setObjectName(QStringLiteral("code"));
@@ -215,7 +212,12 @@ void CodeWidget::ConnectWidgets()
 
 void CodeWidget::OnBranchWatchDialog()
 {
-  m_branch_watch_dialog->open();
+  if (m_branch_watch_dialog == nullptr)
+  {
+    m_branch_watch_dialog =
+        new BranchWatchDialog(m_system, m_system.GetPowerPC().GetBranchWatch(), this, this);
+  }
+  m_branch_watch_dialog->show();
   m_branch_watch_dialog->raise();
   m_branch_watch_dialog->activateWindow();
 }
@@ -397,7 +399,8 @@ void CodeWidget::UpdateSymbols()
 
   // TODO: There seems to be a lack of a ubiquitous signal for when symbols change.
   // This is the best location to catch the signals from MenuBar and CodeViewWidget.
-  m_branch_watch_dialog->UpdateSymbols();
+  if (m_branch_watch_dialog != nullptr)
+    m_branch_watch_dialog->UpdateSymbols();
 }
 
 void CodeWidget::UpdateFunctionCalls(const Common::Symbol* symbol)
@@ -470,7 +473,8 @@ void CodeWidget::Step()
   // Will get a UpdateDisasmDialog(), don't update the GUI here.
 
   // TODO: Step doesn't cause EmulationStateChanged to be emitted, so it has to call this manually.
-  m_branch_watch_dialog->Update();
+  if (m_branch_watch_dialog != nullptr)
+    m_branch_watch_dialog->Update();
 }
 
 void CodeWidget::StepOver()

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -72,7 +72,7 @@ private:
 
   Core::System& m_system;
 
-  BranchWatchDialog* m_branch_watch_dialog;
+  BranchWatchDialog* m_branch_watch_dialog = nullptr;
   QLineEdit* m_search_address;
   QPushButton* m_branch_watch;
 


### PR DESCRIPTION
Window icon was missing from QDialog lacking a parent.
Giving the QDialog a parent revealed I had failed to make it properly non-modal, necessitating further changes.
Settings save less often, now only upon destruction.
Construction of BranchWatchDialog is now deferred.