### PR TITLE
MMU: Remove erroneous continue statement

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1546,7 +1546,6 @@ void MMU::UpdateBATs(BatTable& bat_table, u32 base_spr)
       // (input & ~BL_mask) == BEPI. For now, assume it's
       // implemented this way for invalid BATs as well.
       WARN_LOG_FMT(POWERPC, "Bad BAT setup: BEPI overlaps BL");
-      continue;
     }
     if ((batl.BRPN & batu.BL) != 0)
     {


### PR DESCRIPTION
The updated behavior more closely emulates the functionality of physical hardware.