### PR TITLE
RetroAchievements - Dialog Performance Improvement

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -830,10 +830,12 @@ const AchievementManager::BadgeStatus& AchievementManager::GetGameBadge() const
   return m_game_badge;
 }
 
-const AchievementManager::UnlockStatus&
+const AchievementManager::UnlockStatus*
 AchievementManager::GetUnlockStatus(AchievementId achievement_id) const
 {
-  return m_unlock_map.at(achievement_id);
+  if (m_unlock_map.count(achievement_id) < 1)
+    return nullptr;
+  return &m_unlock_map.at(achievement_id);
 }
 
 AchievementManager::ResponseType

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -859,10 +859,12 @@ AchievementManager::GetAchievementProgress(AchievementId achievement_id, u32* va
   return ResponseType::SUCCESS;
 }
 
-const std::unordered_map<AchievementManager::AchievementId, AchievementManager::LeaderboardStatus>&
-AchievementManager::GetLeaderboardsInfo() const
+const AchievementManager::LeaderboardStatus*
+AchievementManager::GetLeaderboardInfo(AchievementManager::AchievementId leaderboard_id) const
 {
-  return m_leaderboard_map;
+  if (m_leaderboard_map.count(leaderboard_id) < 1)
+    return nullptr;
+  return &m_leaderboard_map.at(leaderboard_id);
 }
 
 AchievementManager::RichPresence AchievementManager::GetRichPresence() const

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -47,7 +47,6 @@ public:
     UNKNOWN_FAILURE
   };
   using ResponseCallback = std::function<void(ResponseType)>;
-  using UpdateCallback = std::function<void()>;
 
   struct PointSpread
   {
@@ -110,6 +109,19 @@ public:
     u32 player_index = 0;
     std::unordered_map<u32, LeaderboardEntry> entries;
   };
+
+  struct UpdatedItems
+  {
+    bool all = false;
+    bool player_icon = false;
+    bool game_icon = false;
+    bool all_achievements = false;
+    std::set<AchievementId> achievements{};
+    bool all_leaderboards = false;
+    std::set<AchievementId> leaderboards{};
+    bool rich_presence = false;
+  };
+  using UpdateCallback = std::function<void(const UpdatedItems&)>;
 
   static AchievementManager& GetInstance();
   void Init();
@@ -205,7 +217,7 @@ private:
   rc_runtime_t m_runtime{};
   Core::System* m_system{};
   bool m_is_runtime_initialized = false;
-  UpdateCallback m_update_callback = [] {};
+  UpdateCallback m_update_callback = [](const UpdatedItems&) {};
   std::unique_ptr<DiscIO::Volume> m_loading_volume;
   bool m_disabled = false;
   std::string m_display_name;

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -140,7 +140,7 @@ public:
   PointSpread TallyScore() const;
   rc_api_fetch_game_data_response_t* GetGameData();
   const BadgeStatus& GetGameBadge() const;
-  const UnlockStatus& GetUnlockStatus(AchievementId achievement_id) const;
+  const UnlockStatus* GetUnlockStatus(AchievementId achievement_id) const;
   AchievementManager::ResponseType GetAchievementProgress(AchievementId achievement_id, u32* value,
                                                           u32* target);
   const std::unordered_map<AchievementId, LeaderboardStatus>& GetLeaderboardsInfo() const;

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -143,7 +143,7 @@ public:
   const UnlockStatus* GetUnlockStatus(AchievementId achievement_id) const;
   AchievementManager::ResponseType GetAchievementProgress(AchievementId achievement_id, u32* value,
                                                           u32* target);
-  const std::unordered_map<AchievementId, LeaderboardStatus>& GetLeaderboardsInfo() const;
+  const LeaderboardStatus* GetLeaderboardInfo(AchievementId leaderboard_id) const;
   RichPresence GetRichPresence() const;
   bool IsDisabled() const { return m_disabled; };
   void SetDisabled(bool disabled);

--- a/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
@@ -1,0 +1,140 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+#include "DolphinQt/Achievements/AchievementBox.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QProgressBar>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <rcheevos/include/rc_api_runtime.h>
+
+#include "Core/AchievementManager.h"
+#include "Core/Config/AchievementSettings.h"
+
+AchievementBox::AchievementBox(QWidget* parent, const rc_api_achievement_definition_t* achievement)
+    : QGroupBox(parent)
+{
+  const auto& instance = AchievementManager::GetInstance();
+  if (!instance.IsGameLoaded())
+    return;
+
+  m_achievement_id = achievement->id;
+
+  m_badge = new QLabel();
+  m_title = new QLabel(QString::fromUtf8(achievement->title, strlen(achievement->title)));
+  m_description =
+      new QLabel(QString::fromUtf8(achievement->description, strlen(achievement->description)));
+  m_points = new QLabel(tr("%1 points").arg(achievement->points));
+  m_status = new QLabel();
+  m_progress_bar = new QProgressBar();
+  QSizePolicy sp_retain = m_progress_bar->sizePolicy();
+  sp_retain.setRetainSizeWhenHidden(true);
+  m_progress_bar->setSizePolicy(sp_retain);
+
+  QVBoxLayout* a_col_right = new QVBoxLayout();
+  a_col_right->addWidget(m_title);
+  a_col_right->addWidget(m_description);
+  a_col_right->addWidget(m_points);
+  a_col_right->addWidget(m_status);
+  a_col_right->addWidget(m_progress_bar);
+  QHBoxLayout* a_total = new QHBoxLayout();
+  a_total->addWidget(m_badge);
+  a_total->addLayout(a_col_right);
+  setLayout(a_total);
+
+  UpdateData();
+}
+
+void AchievementBox::UpdateData()
+{
+  std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
+
+  const auto* unlock_status = AchievementManager::GetInstance().GetUnlockStatus(m_achievement_id);
+  if (!unlock_status)
+    return;
+  const AchievementManager::BadgeStatus* badge = &unlock_status->locked_badge;
+  std::string_view color = AchievementManager::GRAY;
+  if (unlock_status->remote_unlock_status == AchievementManager::UnlockStatus::UnlockType::HARDCORE)
+  {
+    badge = &unlock_status->unlocked_badge;
+    color = AchievementManager::GOLD;
+  }
+  else if (Config::Get(Config::RA_HARDCORE_ENABLED) && unlock_status->session_unlock_count > 1)
+  {
+    badge = &unlock_status->unlocked_badge;
+    color = AchievementManager::GOLD;
+  }
+  else if (unlock_status->remote_unlock_status ==
+           AchievementManager::UnlockStatus::UnlockType::SOFTCORE)
+  {
+    badge = &unlock_status->unlocked_badge;
+    color = AchievementManager::BLUE;
+  }
+  else if (unlock_status->session_unlock_count > 1)
+  {
+    badge = &unlock_status->unlocked_badge;
+    color = AchievementManager::BLUE;
+  }
+  if (Config::Get(Config::RA_BADGES_ENABLED) && badge->name != "")
+  {
+    QImage i_badge{};
+    if (i_badge.loadFromData(&badge->badge.front(), (int)badge->badge.size()))
+    {
+      m_badge->setPixmap(QPixmap::fromImage(i_badge).scaled(64, 64, Qt::KeepAspectRatio,
+                                                            Qt::SmoothTransformation));
+      m_badge->adjustSize();
+      m_badge->setStyleSheet(
+          QStringLiteral("border: 4px solid %1").arg(QString::fromStdString(std::string(color))));
+    }
+  }
+  else
+  {
+    m_badge->setText({});
+  }
+
+  m_status->setText(GetStatusString());
+
+  unsigned int value = 0;
+  unsigned int target = 0;
+  if (AchievementManager::GetInstance().GetAchievementProgress(m_achievement_id, &value, &target) ==
+          AchievementManager::ResponseType::SUCCESS &&
+      target > 0)
+  {
+    m_progress_bar->setRange(0, target);
+    m_progress_bar->setValue(value);
+    m_progress_bar->setVisible(true);
+  }
+  else
+  {
+    m_progress_bar->setVisible(false);
+  }
+}
+
+QString AchievementBox::GetStatusString() const
+{
+  const auto* unlock_status = AchievementManager::GetInstance().GetUnlockStatus(m_achievement_id);
+  if (unlock_status->session_unlock_count > 0)
+  {
+    if (Config::Get(Config::RA_ENCORE_ENABLED))
+    {
+      return tr("Unlocked %1 times this session").arg(unlock_status->session_unlock_count);
+    }
+    return tr("Unlocked this session");
+  }
+  switch (unlock_status->remote_unlock_status)
+  {
+  case AchievementManager::UnlockStatus::UnlockType::LOCKED:
+    return tr("Locked");
+  case AchievementManager::UnlockStatus::UnlockType::SOFTCORE:
+    return tr("Unlocked (Casual)");
+  case AchievementManager::UnlockStatus::UnlockType::HARDCORE:
+    return tr("Unlocked");
+  }
+  return {};
+}
+
+#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementBox.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementBox.h
@@ -1,0 +1,37 @@
+// Copyright 2023 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+#include <QGroupBox>
+
+#include "Core/AchievementManager.h"
+
+class QLabel;
+class QProgressBar;
+class QWidget;
+
+struct rc_api_achievement_definition_t;
+
+class AchievementBox final : public QGroupBox
+{
+  Q_OBJECT
+public:
+  explicit AchievementBox(QWidget* parent, const rc_api_achievement_definition_t* achievement);
+  void UpdateData();
+
+private:
+  QString GetStatusString() const;
+
+  QLabel* m_badge;
+  QLabel* m_title;
+  QLabel* m_description;
+  QLabel* m_points;
+  QLabel* m_status;
+  QProgressBar* m_progress_bar;
+
+  AchievementManager::AchievementId m_achievement_id;
+};
+
+#endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -61,13 +61,11 @@ AchievementHeaderWidget::AchievementHeaderWidget(QWidget* parent) : QWidget(pare
   m_total->setContentsMargins(0, 0, 0, 0);
   m_total->setAlignment(Qt::AlignTop);
   setLayout(m_total);
-
-  std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
-  UpdateData();
 }
 
 void AchievementHeaderWidget::UpdateData()
 {
+  std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
   auto& instance = AchievementManager::GetInstance();
   if (!instance.IsLoggedIn())
   {

--- a/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
@@ -24,10 +24,7 @@ AchievementLeaderboardWidget::AchievementLeaderboardWidget(QWidget* parent) : QW
   m_common_box = new QGroupBox();
   m_common_layout = new QGridLayout();
 
-  {
-    std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
-    UpdateData();
-  }
+  UpdateData(true);
 
   m_common_box->setLayout(m_common_layout);
 
@@ -38,77 +35,120 @@ AchievementLeaderboardWidget::AchievementLeaderboardWidget(QWidget* parent) : QW
   setLayout(layout);
 }
 
-void AchievementLeaderboardWidget::UpdateData()
+void AchievementLeaderboardWidget::UpdateData(bool clean_all)
 {
-  ClearLayoutRecursively(m_common_layout);
-
-  if (!AchievementManager::GetInstance().IsGameLoaded())
-    return;
-  const auto& leaderboards = AchievementManager::GetInstance().GetLeaderboardsInfo();
-  int row = 0;
-  for (const auto& board_row : leaderboards)
+  if (clean_all)
   {
-    const AchievementManager::LeaderboardStatus& board = board_row.second;
-    QLabel* a_title = new QLabel(QString::fromStdString(board.name));
-    QLabel* a_description = new QLabel(QString::fromStdString(board.description));
-    QVBoxLayout* a_col_left = new QVBoxLayout();
-    a_col_left->addWidget(a_title);
-    a_col_left->addWidget(a_description);
-    if (row > 0)
+    ClearLayoutRecursively(m_common_layout);
+
+    auto& instance = AchievementManager::GetInstance();
+    if (!instance.IsGameLoaded())
+      return;
+
+    rc_api_fetch_game_data_response_t* game_data;
     {
-      QFrame* a_divider = new QFrame();
-      a_divider->setFrameShape(QFrame::HLine);
-      m_common_layout->addWidget(a_divider, row - 1, 0);
+      std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
+      game_data = instance.GetGameData();
     }
-    m_common_layout->addLayout(a_col_left, row, 0);
-    // Each leaderboard entry is displayed with four values. These are *generally* intended to be,
-    // in order, the first place entry, the entry one above the player, the player's entry, and
-    // the entry one below the player.
-    // Edge cases:
-    // * If there are fewer than four entries in the leaderboard, all entries will be shown in
-    //   order and the remainder of the list will be padded with empty values.
-    // * If the player does not currently have a score in the leaderboard, or is in the top 3,
-    //   the four slots will be the top four players in order.
-    // * If the player is last place, the player will be in the fourth slot, and the second and
-    //   third slots will be the two players above them. The first slot will always be first place.
-    std::array<u32, 4> to_display{1, 2, 3, 4};
-    if (board.player_index > to_display.size() - 1)
+    for (u32 row = 0; row < game_data->num_leaderboards; row += 2)
     {
-      // If the rank one below than the player is found, offset = 1.
-      u32 offset = static_cast<u32>(board.entries.count(board.player_index + 1));
-      // Example: player is 10th place but not last
-      // to_display = {1, 10-3+1+1, 10-3+1+2, 10-3+1+3} = {1, 9, 10, 11}
-      // Example: player is 15th place and is last
-      // to_display = {1, 15-3+0+1, 15-3+0+2, 15-3+0+3} = {1, 13, 14, 15}
-      for (size_t i = 1; i < to_display.size(); ++i)
-        to_display[i] = board.player_index - 3 + offset + static_cast<u32>(i);
-    }
-    for (size_t i = 0; i < to_display.size(); ++i)
-    {
-      u32 index = to_display[i];
-      QLabel* a_rank = new QLabel(QStringLiteral("---"));
-      QLabel* a_username = new QLabel(QStringLiteral("---"));
-      QLabel* a_score = new QLabel(QStringLiteral("---"));
-      const auto it = board.entries.find(index);
-      if (it != board.entries.end())
-      {
-        a_rank->setText(tr("Rank %1").arg(it->second.rank));
-        a_username->setText(QString::fromStdString(it->second.username));
-        a_score->setText(QString::fromUtf8(it->second.score.data()));
-      }
-      QVBoxLayout* a_col = new QVBoxLayout();
-      a_col->addWidget(a_rank);
-      a_col->addWidget(a_username);
-      a_col->addWidget(a_score);
+      const auto* leaderboard = game_data->leaderboards + (row / 2);
+      m_leaderboard_order[leaderboard->id] = row;
+      QLabel* a_title = new QLabel(QString::fromUtf8(leaderboard->title));
+      QLabel* a_description = new QLabel(QString::fromUtf8(leaderboard->description));
+      QVBoxLayout* a_col_left = new QVBoxLayout();
+      a_col_left->addWidget(a_title);
+      a_col_left->addWidget(a_description);
       if (row > 0)
       {
         QFrame* a_divider = new QFrame();
         a_divider->setFrameShape(QFrame::HLine);
-        m_common_layout->addWidget(a_divider, row - 1, static_cast<int>(i) + 1);
+        m_common_layout->addWidget(a_divider, row - 1, 0);
       }
-      m_common_layout->addLayout(a_col, row, static_cast<int>(i) + 1);
+      m_common_layout->addLayout(a_col_left, row, 0);
+      for (size_t ix = 0; ix < 4; ix++)
+      {
+        QVBoxLayout* a_col = new QVBoxLayout();
+        for (size_t jx = 0; jx < 3; jx++)
+          a_col->addWidget(new QLabel(QStringLiteral("---")));
+        if (row > 0)
+        {
+          QFrame* a_divider = new QFrame();
+          a_divider->setFrameShape(QFrame::HLine);
+          m_common_layout->addWidget(a_divider, row - 1, static_cast<int>(ix) + 1);
+        }
+        m_common_layout->addLayout(a_col, row, static_cast<int>(ix) + 1);
+      }
     }
-    row += 2;
+  }
+  for (auto row : m_leaderboard_order)
+  {
+    UpdateRow(row.second);
+  }
+}
+
+void AchievementLeaderboardWidget::UpdateData(
+    const std::set<AchievementManager::AchievementId>& update_ids)
+{
+  for (auto row : m_leaderboard_order)
+  {
+    if (update_ids.count(row.first) > 0)
+    {
+      UpdateRow(row.second);
+    }
+  }
+}
+
+void AchievementLeaderboardWidget::UpdateRow(AchievementManager::AchievementId leaderboard_id)
+{
+  if (m_leaderboard_order.count(leaderboard_id) < 1)
+    return;
+  int row = m_leaderboard_order[leaderboard_id];
+
+  const AchievementManager::LeaderboardStatus* board;
+  {
+    std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
+    board = AchievementManager::GetInstance().GetLeaderboardInfo(leaderboard_id);
+  }
+  if (!board)
+    return;
+
+  // Each leaderboard entry is displayed with four values. These are *generally* intended to be,
+  // in order, the first place entry, the entry one above the player, the player's entry, and
+  // the entry one below the player.
+  // Edge cases:
+  // * If there are fewer than four entries in the leaderboard, all entries will be shown in
+  //   order and the remainder of the list will be padded with empty values.
+  // * If the player does not currently have a score in the leaderboard, or is in the top 3,
+  //   the four slots will be the top four players in order.
+  // * If the player is last place, the player will be in the fourth slot, and the second and
+  //   third slots will be the two players above them. The first slot will always be first place.
+  std::array<u32, 4> to_display{1, 2, 3, 4};
+  if (board->player_index > to_display.size() - 1)
+  {
+    // If the rank one below than the player is found, offset = 1.
+    u32 offset = static_cast<u32>(board->entries.count(board->player_index + 1));
+    // Example: player is 10th place but not last
+    // to_display = {1, 10-3+1+1, 10-3+1+2, 10-3+1+3} = {1, 9, 10, 11}
+    // Example: player is 15th place and is last
+    // to_display = {1, 15-3+0+1, 15-3+0+2, 15-3+0+3} = {1, 13, 14, 15}
+    for (size_t ix = 1; ix < to_display.size(); ++ix)
+      to_display[ix] = board->player_index - 3 + offset + static_cast<u32>(ix);
+  }
+  for (size_t ix = 0; ix < to_display.size(); ++ix)
+  {
+    const auto it = board->entries.find(to_display[ix]);
+    if (it != board->entries.end())
+    {
+      QVBoxLayout* a_col = new QVBoxLayout();
+      a_col->addWidget(new QLabel(tr("Rank %1").arg(it->second.rank)));
+      a_col->addWidget(new QLabel(QString::fromStdString(it->second.username)));
+      a_col->addWidget(new QLabel(QString::fromUtf8(it->second.score.data())));
+      auto old_item = m_common_layout->itemAtPosition(row, static_cast<int>(ix) + 1);
+      m_common_layout->removeItem(old_item);
+      ClearLayoutRecursively(static_cast<QLayout*>(old_item));
+      m_common_layout->addLayout(a_col, row, static_cast<int>(ix) + 1);
+    }
   }
 }
 

--- a/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
@@ -24,8 +24,6 @@ AchievementLeaderboardWidget::AchievementLeaderboardWidget(QWidget* parent) : QW
   m_common_box = new QGroupBox();
   m_common_layout = new QGridLayout();
 
-  UpdateData(true);
-
   m_common_box->setLayout(m_common_layout);
 
   auto* layout = new QVBoxLayout;

--- a/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.h
@@ -6,6 +6,8 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include <QWidget>
 
+#include "Core/AchievementManager.h"
+
 class QGroupBox;
 class QGridLayout;
 
@@ -14,11 +16,14 @@ class AchievementLeaderboardWidget final : public QWidget
   Q_OBJECT
 public:
   explicit AchievementLeaderboardWidget(QWidget* parent);
-  void UpdateData();
+  void UpdateData(bool clean_all);
+  void UpdateData(const std::set<AchievementManager::AchievementId>& update_ids);
+  void UpdateRow(AchievementManager::AchievementId leaderboard_id);
 
 private:
   QGroupBox* m_common_box;
   QGridLayout* m_common_layout;
+  std::map<AchievementManager::AchievementId, int> m_leaderboard_order;
 };
 
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
@@ -18,6 +18,7 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 
+#include "DolphinQt/Achievements/AchievementBox.h"
 #include "DolphinQt/QtUtils/ClearLayoutRecursively.h"
 #include "DolphinQt/Settings.h"
 
@@ -42,88 +43,6 @@ AchievementProgressWidget::AchievementProgressWidget(QWidget* parent) : QWidget(
   setLayout(layout);
 }
 
-QGroupBox*
-AchievementProgressWidget::CreateAchievementBox(const rc_api_achievement_definition_t* achievement)
-{
-  const auto& instance = AchievementManager::GetInstance();
-  if (!instance.IsGameLoaded())
-    return new QGroupBox();
-
-  QLabel* a_badge = new QLabel();
-  const auto unlock_status = instance.GetUnlockStatus(achievement->id);
-  const AchievementManager::BadgeStatus* badge = &unlock_status.locked_badge;
-  std::string_view color = AchievementManager::GRAY;
-  if (unlock_status.remote_unlock_status == AchievementManager::UnlockStatus::UnlockType::HARDCORE)
-  {
-    badge = &unlock_status.unlocked_badge;
-    color = AchievementManager::GOLD;
-  }
-  else if (hardcore_mode_enabled && unlock_status.session_unlock_count > 1)
-  {
-    badge = &unlock_status.unlocked_badge;
-    color = AchievementManager::GOLD;
-  }
-  else if (unlock_status.remote_unlock_status ==
-           AchievementManager::UnlockStatus::UnlockType::SOFTCORE)
-  {
-    badge = &unlock_status.unlocked_badge;
-    color = AchievementManager::BLUE;
-  }
-  else if (unlock_status.session_unlock_count > 1)
-  {
-    badge = &unlock_status.unlocked_badge;
-    color = AchievementManager::BLUE;
-  }
-  if (Config::Get(Config::RA_BADGES_ENABLED) && badge->name != "")
-  {
-    QImage i_badge{};
-    if (i_badge.loadFromData(&badge->badge.front(), (int)badge->badge.size()))
-    {
-      a_badge->setPixmap(QPixmap::fromImage(i_badge).scaled(64, 64, Qt::KeepAspectRatio,
-                                                            Qt::SmoothTransformation));
-      a_badge->adjustSize();
-      a_badge->setStyleSheet(
-          QStringLiteral("border: 4px solid %1").arg(QString::fromStdString(std::string(color))));
-    }
-  }
-
-  QLabel* a_title = new QLabel(QString::fromUtf8(achievement->title, strlen(achievement->title)));
-  QLabel* a_description =
-      new QLabel(QString::fromUtf8(achievement->description, strlen(achievement->description)));
-  QLabel* a_points = new QLabel(tr("%1 points").arg(achievement->points));
-  QLabel* a_status = new QLabel(GetStatusString(achievement->id));
-  QProgressBar* a_progress_bar = new QProgressBar();
-  QSizePolicy sp_retain = a_progress_bar->sizePolicy();
-  sp_retain.setRetainSizeWhenHidden(true);
-  a_progress_bar->setSizePolicy(sp_retain);
-  unsigned int value = 0;
-  unsigned int target = 0;
-  if (AchievementManager::GetInstance().GetAchievementProgress(achievement->id, &value, &target) ==
-          AchievementManager::ResponseType::SUCCESS &&
-      target > 0)
-  {
-    a_progress_bar->setRange(0, target);
-    a_progress_bar->setValue(value);
-  }
-  else
-  {
-    a_progress_bar->setVisible(false);
-  }
-
-  QVBoxLayout* a_col_right = new QVBoxLayout();
-  a_col_right->addWidget(a_title);
-  a_col_right->addWidget(a_description);
-  a_col_right->addWidget(a_points);
-  a_col_right->addWidget(a_status);
-  a_col_right->addWidget(a_progress_bar);
-  QHBoxLayout* a_total = new QHBoxLayout();
-  a_total->addWidget(a_badge);
-  a_total->addLayout(a_col_right);
-  QGroupBox* a_group_box = new QGroupBox();
-  a_group_box->setLayout(a_total);
-  return a_group_box;
-}
-
 void AchievementProgressWidget::UpdateData()
 {
   ClearLayoutRecursively(m_common_layout);
@@ -135,31 +54,8 @@ void AchievementProgressWidget::UpdateData()
   const auto* game_data = instance.GetGameData();
   for (u32 ix = 0; ix < game_data->num_achievements; ix++)
   {
-    m_common_layout->addWidget(CreateAchievementBox(game_data->achievements + ix));
+    m_common_layout->addWidget(new AchievementBox(this, game_data->achievements + ix));
   }
-}
-
-QString AchievementProgressWidget::GetStatusString(u32 achievement_id) const
-{
-  const auto unlock_status = AchievementManager::GetInstance().GetUnlockStatus(achievement_id);
-  if (unlock_status.session_unlock_count > 0)
-  {
-    if (Config::Get(Config::RA_ENCORE_ENABLED))
-    {
-      return tr("Unlocked %1 times this session").arg(unlock_status.session_unlock_count);
-    }
-    return tr("Unlocked this session");
-  }
-  switch (unlock_status.remote_unlock_status)
-  {
-  case AchievementManager::UnlockStatus::UnlockType::LOCKED:
-    return tr("Locked");
-  case AchievementManager::UnlockStatus::UnlockType::SOFTCORE:
-    return tr("Unlocked (Casual)");
-  case AchievementManager::UnlockStatus::UnlockType::HARDCORE:
-    return tr("Unlocked");
-  }
-  return {};
 }
 
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
@@ -29,8 +29,6 @@ AchievementProgressWidget::AchievementProgressWidget(QWidget* parent) : QWidget(
   m_common_box = new QGroupBox();
   m_common_layout = new QVBoxLayout();
 
-  UpdateData(true);
-
   m_common_box->setLayout(m_common_layout);
 
   auto* layout = new QVBoxLayout;

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.h
@@ -7,7 +7,9 @@
 #include <QWidget>
 
 #include "Common/CommonTypes.h"
+#include "Core/AchievementManager.h"
 
+class AchievementBox;
 class QCheckBox;
 class QGroupBox;
 class QLineEdit;
@@ -21,11 +23,13 @@ class AchievementProgressWidget final : public QWidget
   Q_OBJECT
 public:
   explicit AchievementProgressWidget(QWidget* parent);
-  void UpdateData();
+  void UpdateData(bool clean_all);
+  void UpdateData(std::set<AchievementManager::AchievementId> update_ids);
 
 private:
   QGroupBox* m_common_box;
   QVBoxLayout* m_common_layout;
+  std::map<AchievementManager::AchievementId, AchievementBox*> m_achievement_boxes;
 };
 
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.h
@@ -24,9 +24,6 @@ public:
   void UpdateData();
 
 private:
-  QGroupBox* CreateAchievementBox(const rc_api_achievement_definition_t* achievement);
-  QString GetStatusString(u32 achievement_id) const;
-
   QGroupBox* m_common_box;
   QVBoxLayout* m_common_layout;
 };

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -81,7 +81,7 @@ void AchievementsWindow::UpdateData()
     m_header_widget->UpdateData();
     m_header_widget->setVisible(instance.IsLoggedIn());
     m_settings_widget->UpdateData();
-    m_progress_widget->UpdateData();
+    m_progress_widget->UpdateData(true);
     m_tab_widget->setTabVisible(1, is_game_loaded);
     m_leaderboard_widget->UpdateData();
     m_tab_widget->setTabVisible(2, is_game_loaded);

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -83,7 +83,7 @@ void AchievementsWindow::UpdateData()
     m_settings_widget->UpdateData();
     m_progress_widget->UpdateData(true);
     m_tab_widget->setTabVisible(1, is_game_loaded);
-    m_leaderboard_widget->UpdateData();
+    m_leaderboard_widget->UpdateData(true);
     m_tab_widget->setTabVisible(2, is_game_loaded);
   }
   update();

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -28,11 +28,12 @@ AchievementsWindow::AchievementsWindow(QWidget* parent) : QDialog(parent)
   CreateMainLayout();
   ConnectWidgets();
   AchievementManager::GetInstance().SetUpdateCallback(
-      [this] { QueueOnObject(this, &AchievementsWindow::UpdateData); });
+      [this](AchievementManager::UpdatedItems updated_items) {
+        QueueOnObject(this,
+                      [this, updated_items] { AchievementsWindow::UpdateData(updated_items); });
+      });
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
-          &AchievementsWindow::UpdateData);
-
-  UpdateData();
+          [this] { AchievementsWindow::UpdateData({.all = true}); });
 }
 
 void AchievementsWindow::showEvent(QShowEvent* event)
@@ -71,19 +72,38 @@ void AchievementsWindow::ConnectWidgets()
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 }
 
-void AchievementsWindow::UpdateData()
+void AchievementsWindow::UpdateData(AchievementManager::UpdatedItems updated_items)
 {
+  m_settings_widget->UpdateData();
+  if (updated_items.all)
+  {
+    m_header_widget->UpdateData();
+    m_progress_widget->UpdateData(true);
+    m_leaderboard_widget->UpdateData(true);
+  }
+  else
+  {
+    if (updated_items.player_icon || updated_items.game_icon || updated_items.rich_presence ||
+        updated_items.all_achievements || updated_items.achievements.size() > 0)
+    {
+      m_header_widget->UpdateData();
+    }
+    if (updated_items.all_achievements)
+      m_progress_widget->UpdateData(false);
+    else if (updated_items.achievements.size() > 0)
+      m_progress_widget->UpdateData(updated_items.achievements);
+    if (updated_items.all_leaderboards)
+      m_leaderboard_widget->UpdateData(false);
+    else if (updated_items.leaderboards.size() > 0)
+      m_leaderboard_widget->UpdateData(updated_items.leaderboards);
+  }
+
   {
     auto& instance = AchievementManager::GetInstance();
     std::lock_guard lg{instance.GetLock()};
     const bool is_game_loaded = instance.IsGameLoaded();
-
-    m_header_widget->UpdateData();
     m_header_widget->setVisible(instance.IsLoggedIn());
-    m_settings_widget->UpdateData();
-    m_progress_widget->UpdateData(true);
     m_tab_widget->setTabVisible(1, is_game_loaded);
-    m_leaderboard_widget->UpdateData(true);
     m_tab_widget->setTabVisible(2, is_game_loaded);
   }
   update();

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
@@ -6,6 +6,8 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include <QDialog>
 
+#include "Core/AchievementManager.h"
+
 class AchievementHeaderWidget;
 class AchievementLeaderboardWidget;
 class AchievementSettingsWidget;
@@ -19,7 +21,7 @@ class AchievementsWindow : public QDialog
   Q_OBJECT
 public:
   explicit AchievementsWindow(QWidget* parent);
-  void UpdateData();
+  void UpdateData(AchievementManager::UpdatedItems updated_items);
   void ForceSettingsTab();
 
 private:

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -28,6 +28,8 @@ add_executable(dolphin-emu
   CheatSearchWidget.h
   CheatsManager.cpp
   CheatsManager.h
+  Achievements/AchievementBox.cpp
+  Achievements/AchievementBox.h
   Achievements/AchievementHeaderWidget.cpp
   Achievements/AchievementHeaderWidget.h
   Achievements/AchievementLeaderboardWidget.cpp

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -48,6 +48,7 @@
     <ClCompile Include="CheatSearchFactoryWidget.cpp" />
     <ClCompile Include="CheatSearchWidget.cpp" />
     <ClCompile Include="CheatsManager.cpp" />
+    <ClCompile Include="Achievements\AchievementBox.cpp" />
     <ClCompile Include="Achievements\AchievementHeaderWidget.cpp" />
     <ClCompile Include="Achievements\AchievementLeaderboardWidget.cpp" />
     <ClCompile Include="Achievements\AchievementProgressWidget.cpp" />
@@ -267,6 +268,7 @@
     <QtMoc Include="CheatSearchFactoryWidget.h" />
     <QtMoc Include="CheatSearchWidget.h" />
     <QtMoc Include="CheatsManager.h" />
+    <QtMoc Include="Achievements\AchievementBox.h" />
     <QtMoc Include="Achievements\AchievementHeaderWidget.h" />
     <QtMoc Include="Achievements\AchievementLeaderboardWidget.h" />
     <QtMoc Include="Achievements\AchievementProgressWidget.h" />

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -2011,6 +2011,7 @@ void MainWindow::ShowAchievementsWindow()
   m_achievements_window->show();
   m_achievements_window->raise();
   m_achievements_window->activateWindow();
+  m_achievements_window->UpdateData(AchievementManager::UpdatedItems{.all = true});
 }
 
 void MainWindow::ShowAchievementSettings()


### PR DESCRIPTION
The AchievementsWindow was formerly rebuilding itself almost completely from scratch every time an update was called on it, which could be quite often in the first few minutes of a game running on account of the number of calls made to update data. This change refactors the window to maintain as much data as possible when small things need to change, and fixes its UpdateData method to only update the portions that need to be updated. The result is that games like Kirby's Air Ride that previously were dipping below 1fps while RetroAchievements was downloading are now reaching a smooth 60fps during this period.