### PR TITLE
Fix aspect ratio swapping in Pitfall: The Lost Expedition

### DIFF
--- a/Data/Sys/GameSettings/GPH.ini
+++ b/Data/Sys/GameSettings/GPH.ini
@@ -17,3 +17,7 @@
 # for the "Pitfall!" and "Lost Cavern" Atari 2600 games to render correctly.
 # Otherwise the retro games appear to be stuttering.
 SafeTextureCacheColorSamples = 2048
+
+# Fixes cutscenes playing in a different aspect ratio and gameplay flipping back and forth between 4:3 and 16:9.
+WidescreenHeuristicStandardRatio = 1.17
+WidescreenHeuristicWidescreenRatio = 1.56


### PR DESCRIPTION
Based on Billiard's recommendations in this discussion: https://discord.com/channels/521709831132807179/521711075721478145/1216164450936160417

I've tested a handful of menus, cutscenes, FMVs, ~~and the first 10 minutes of gameplay. I still want to play past the final boss with this before publishing the PR because I know the post-credit loads have weird aspect ratio even on console.~~
Myself and another community member have played through the entire game, including minigames, w/o issue.