### PR TITLE
PPCSymbolDB: Move instance to PowerPCManager

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -376,11 +376,11 @@ bool CBoot::FindMapFile(std::string* existing_map_file, std::string* writable_ma
   return false;
 }
 
-bool CBoot::LoadMapFromFilename(const Core::CPUThreadGuard& guard)
+bool CBoot::LoadMapFromFilename(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db)
 {
   std::string strMapFilename;
   bool found = FindMapFile(&strMapFilename, nullptr);
-  if (found && g_symbolDB.LoadMap(guard, strMapFilename))
+  if (found && ppc_symbol_db.LoadMap(guard, strMapFilename))
   {
     UpdateDebugger_MapLoaded();
     return true;
@@ -514,9 +514,9 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
 {
   SConfig& config = SConfig::GetInstance();
 
-  if (!g_symbolDB.IsEmpty())
+  if (auto& ppc_symbol_db = system.GetPPCSymbolDB(); !ppc_symbol_db.IsEmpty())
   {
-    g_symbolDB.Clear();
+    ppc_symbol_db.Clear();
     UpdateDebugger_MapLoaded();
   }
 
@@ -595,7 +595,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
 
       ppc_state.pc = executable.reader->GetEntryPoint();
 
-      if (executable.reader->LoadSymbols(guard))
+      if (executable.reader->LoadSymbols(guard, system.GetPPCSymbolDB()))
       {
         UpdateDebugger_MapLoaded();
         HLE::PatchFunctions(system);

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -19,6 +19,8 @@
 #include "DiscIO/VolumeDisc.h"
 #include "DiscIO/VolumeWad.h"
 
+class PPCSymbolDB;
+
 namespace Core
 {
 class CPUThreadGuard;
@@ -168,7 +170,7 @@ public:
   //
   // Returns true if a map file exists, false if none could be found.
   static bool FindMapFile(std::string* existing_map_file, std::string* writable_map_file);
-  static bool LoadMapFromFilename(const Core::CPUThreadGuard& guard);
+  static bool LoadMapFromFilename(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db);
 
 private:
   static bool DVDRead(Core::System& system, const DiscIO::VolumeDisc& disc, u64 dvd_offset,
@@ -215,7 +217,7 @@ public:
   virtual bool IsValid() const = 0;
   virtual bool IsWii() const = 0;
   virtual bool LoadIntoMemory(Core::System& system, bool only_in_mem1 = false) const = 0;
-  virtual bool LoadSymbols(const Core::CPUThreadGuard& guard) const = 0;
+  virtual bool LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db) const = 0;
 
 protected:
   std::vector<u8> m_bytes;

--- a/Source/Core/Core/Boot/DolReader.h
+++ b/Source/Core/Core/Boot/DolReader.h
@@ -27,7 +27,10 @@ public:
   bool IsAncast() const { return m_is_ancast; };
   u32 GetEntryPoint() const override { return m_dolheader.entryPoint; }
   bool LoadIntoMemory(Core::System& system, bool only_in_mem1 = false) const override;
-  bool LoadSymbols(const Core::CPUThreadGuard& guard) const override { return false; }
+  bool LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db) const override
+  {
+    return false;
+  }
 
 private:
   enum

--- a/Source/Core/Core/Boot/ElfReader.cpp
+++ b/Source/Core/Core/Boot/ElfReader.cpp
@@ -180,7 +180,7 @@ SectionID ElfReader::GetSectionByName(const char* name, int firstSection) const
   return -1;
 }
 
-bool ElfReader::LoadSymbols(const Core::CPUThreadGuard& guard) const
+bool ElfReader::LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db) const
 {
   bool hasSymbols = false;
   SectionID sec = GetSectionByName(".symtab");
@@ -218,11 +218,11 @@ bool ElfReader::LoadSymbols(const Core::CPUThreadGuard& guard) const
       default:
         continue;
       }
-      g_symbolDB.AddKnownSymbol(guard, value, size, name, symtype);
+      ppc_symbol_db.AddKnownSymbol(guard, value, size, name, symtype);
       hasSymbols = true;
     }
   }
-  g_symbolDB.Index();
+  ppc_symbol_db.Index();
   return hasSymbols;
 }
 

--- a/Source/Core/Core/Boot/ElfReader.h
+++ b/Source/Core/Core/Boot/ElfReader.h
@@ -36,7 +36,7 @@ public:
   u32 GetEntryPoint() const override { return entryPoint; }
   u32 GetFlags() const { return (u32)(header->e_flags); }
   bool LoadIntoMemory(Core::System& system, bool only_in_mem1 = false) const override;
-  bool LoadSymbols(const Core::CPUThreadGuard& guard) const override;
+  bool LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db) const override;
   // TODO: actually check for validity.
   bool IsValid() const override { return true; }
   bool IsWii() const override;

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -205,13 +205,14 @@ void SConfig::OnNewTitleLoad(const Core::CPUThreadGuard& guard)
   if (!Core::IsRunning())
     return;
 
-  if (!g_symbolDB.IsEmpty())
+  auto& system = guard.GetSystem();
+  auto& ppc_symbol_db = system.GetPPCSymbolDB();
+  if (!ppc_symbol_db.IsEmpty())
   {
-    g_symbolDB.Clear();
+    ppc_symbol_db.Clear();
     Host_NotifyMapLoaded();
   }
-  CBoot::LoadMapFromFilename(guard);
-  auto& system = Core::System::GetInstance();
+  CBoot::LoadMapFromFilename(guard, ppc_symbol_db);
   HLE::Reload(system);
   PatchEngine::Reload();
   HiresTexture::Update();

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -90,7 +90,8 @@ void PPCPatches::UnPatch(std::size_t index)
   PatchEngine::RemoveMemoryPatch(index);
 }
 
-PPCDebugInterface::PPCDebugInterface(Core::System& system) : m_system(system)
+PPCDebugInterface::PPCDebugInterface(Core::System& system, PPCSymbolDB& ppc_symbol_db)
+    : m_system(system), m_ppc_symbol_db(ppc_symbol_db)
 {
 }
 
@@ -423,7 +424,7 @@ u32 PPCDebugInterface::GetColor(const Core::CPUThreadGuard* guard, u32 address) 
   if (!PowerPC::MMU::HostIsRAMAddress(*guard, address))
     return 0xeeeeee;
 
-  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
+  const Common::Symbol* const symbol = m_ppc_symbol_db.GetSymbolFromAddr(address);
   if (!symbol)
     return 0xFFFFFF;
   if (symbol->type != Common::Symbol::Type::Function)
@@ -443,7 +444,7 @@ u32 PPCDebugInterface::GetColor(const Core::CPUThreadGuard* guard, u32 address) 
 
 std::string PPCDebugInterface::GetDescription(u32 address) const
 {
-  return g_symbolDB.GetDescription(address);
+  return m_ppc_symbol_db.GetDescription(address);
 }
 
 std::optional<u32>

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -17,6 +17,7 @@ namespace Core
 class CPUThreadGuard;
 class System;
 }  // namespace Core
+class PPCSymbolDB;
 
 void ApplyMemoryPatch(const Core::CPUThreadGuard&, Common::Debug::MemoryPatch& patch,
                       bool store_existing_value = true);
@@ -36,7 +37,7 @@ private:
 class PPCDebugInterface final : public Core::DebugInterface
 {
 public:
-  explicit PPCDebugInterface(Core::System& system);
+  explicit PPCDebugInterface(Core::System& system, PPCSymbolDB& ppc_symbol_db);
   ~PPCDebugInterface() override;
 
   // Watches
@@ -112,4 +113,5 @@ private:
   PPCPatches m_patches;
   std::shared_ptr<Core::NetworkCaptureLogger> m_network_logger;
   Core::System& m_system;
+  PPCSymbolDB& m_ppc_symbol_db;
 };

--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -18,6 +18,8 @@ namespace PowerPC
 enum class CoreMode;
 }
 
+class PPCSymbolDB;
+
 namespace HLE
 {
 using HookFunction = void (*)(const Core::CPUThreadGuard&);
@@ -66,7 +68,7 @@ void ExecuteFromJIT(u32 current_pc, u32 hook_index, Core::System& system);
 // Returns the HLE hook index of the address
 u32 GetHookByAddress(u32 address);
 // Returns the HLE hook index if the address matches the function start
-u32 GetHookByFunctionAddress(u32 address);
+u32 GetHookByFunctionAddress(PPCSymbolDB& ppc_symbol_db, u32 address);
 HookType GetHookTypeByIndex(u32 index);
 HookFlag GetHookFlagsByIndex(u32 index);
 
@@ -74,6 +76,7 @@ bool IsEnabled(HookFlag flag, PowerPC::CoreMode mode);
 
 // Performs the backend-independent preliminary checking for whether a function
 // can be HLEd. If it can be, the information needed for HLEing it is returned.
-TryReplaceFunctionResult TryReplaceFunction(u32 address, PowerPC::CoreMode mode);
+TryReplaceFunctionResult TryReplaceFunction(PPCSymbolDB& ppc_symbol_db, u32 address,
+                                            PowerPC::CoreMode mode);
 
 }  // namespace HLE

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -67,20 +67,21 @@ bool Load(Core::System& system)
   ReinitHardware(system);
   NOTICE_LOG_FMT(IOS, "Reinitialised hardware.");
 
+  auto& power_pc = system.GetPowerPC();
+  auto& ppc_symbol_db = power_pc.GetSymbolDB();
+
   // Load symbols for the IPL if they exist.
-  if (!g_symbolDB.IsEmpty())
+  if (!ppc_symbol_db.IsEmpty())
   {
-    g_symbolDB.Clear();
+    ppc_symbol_db.Clear();
     Host_NotifyMapLoaded();
   }
-  if (g_symbolDB.LoadMap(guard, File::GetUserPath(D_MAPS_IDX) + "mios-ipl.map"))
+  if (ppc_symbol_db.LoadMap(guard, File::GetUserPath(D_MAPS_IDX) + "mios-ipl.map"))
   {
     ::HLE::Clear();
     ::HLE::PatchFunctions(system);
     Host_NotifyMapLoaded();
   }
-
-  auto& power_pc = system.GetPowerPC();
 
   const PowerPC::CoreMode core_mode = power_pc.GetMode();
   power_pc.SetMode(PowerPC::CoreMode::Interpreter);

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -365,8 +365,7 @@ bool MemChecks::OverlapsMemcheck(u32 address, u32 length) const
   });
 }
 
-bool TMemCheck::Action(Core::System& system, Core::DebugInterface* debug_interface, u64 value,
-                       u32 addr, bool write, size_t size, u32 pc)
+bool TMemCheck::Action(Core::System& system, u64 value, u32 addr, bool write, size_t size, u32 pc)
 {
   if (!is_enabled)
     return false;
@@ -376,9 +375,10 @@ bool TMemCheck::Action(Core::System& system, Core::DebugInterface* debug_interfa
   {
     if (log_on_hit)
     {
+      auto& ppc_symbol_db = system.GetPPCSymbolDB();
       NOTICE_LOG_FMT(MEMMAP, "MBP {:08x} ({}) {}{} {:x} at {:08x} ({})", pc,
-                     debug_interface->GetDescription(pc), write ? "Write" : "Read", size * 8, value,
-                     addr, debug_interface->GetDescription(addr));
+                     ppc_symbol_db.GetDescription(pc), write ? "Write" : "Read", size * 8, value,
+                     addr, ppc_symbol_db.GetDescription(addr));
     }
     if (break_on_hit)
       return true;

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -13,10 +13,6 @@
 
 namespace Core
 {
-class DebugInterface;
-}
-namespace Core
-{
 class System;
 }
 
@@ -49,8 +45,7 @@ struct TMemCheck
   std::optional<Expression> condition;
 
   // returns whether to break
-  bool Action(Core::System& system, Core::DebugInterface* debug_interface, u64 value, u32 addr,
-              bool write, size_t size, u32 pc);
+  bool Action(Core::System& system, u64 value, u32 addr, bool write, size_t size, u32 pc);
 };
 
 // Code breakpoints.

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -271,7 +271,7 @@ bool CachedInterpreter::HandleFunctionHooking(u32 address)
 {
   // CachedInterpreter inherits from JitBase and is considered a JIT by relevant code.
   // (see JitInterface and how m_mode is set within PowerPC.cpp)
-  const auto result = HLE::TryReplaceFunction(address, PowerPC::CoreMode::JIT);
+  const auto result = HLE::TryReplaceFunction(m_ppc_symbol_db, address, PowerPC::CoreMode::JIT);
   if (!result)
     return false;
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -65,8 +65,9 @@ void Interpreter::UpdatePC()
 }
 
 Interpreter::Interpreter(Core::System& system, PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu,
-                         Core::BranchWatch& branch_watch)
-    : m_system(system), m_ppc_state(ppc_state), m_mmu(mmu), m_branch_watch(branch_watch)
+                         Core::BranchWatch& branch_watch, PPCSymbolDB& ppc_symbol_db)
+    : m_system(system), m_ppc_state(ppc_state), m_mmu(mmu), m_branch_watch(branch_watch),
+      m_ppc_symbol_db(ppc_symbol_db)
 {
 }
 
@@ -107,7 +108,8 @@ void Interpreter::Trace(const UGeckoInstruction& inst)
 
 bool Interpreter::HandleFunctionHooking(u32 address)
 {
-  const auto result = HLE::TryReplaceFunction(address, PowerPC::CoreMode::Interpreter);
+  const auto result =
+      HLE::TryReplaceFunction(m_ppc_symbol_db, address, PowerPC::CoreMode::Interpreter);
   if (!result)
     return false;
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -19,12 +19,13 @@ namespace PowerPC
 class MMU;
 struct PowerPCState;
 }  // namespace PowerPC
+class PPCSymbolDB;
 
 class Interpreter : public CPUCoreBase
 {
 public:
   Interpreter(Core::System& system, PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu,
-              Core::BranchWatch& branch_watch);
+              Core::BranchWatch& branch_watch, PPCSymbolDB& ppc_symbol_db);
   Interpreter(const Interpreter&) = delete;
   Interpreter(Interpreter&&) = delete;
   Interpreter& operator=(const Interpreter&) = delete;
@@ -317,6 +318,7 @@ private:
   PowerPC::PowerPCState& m_ppc_state;
   PowerPC::MMU& m_mmu;
   Core::BranchWatch& m_branch_watch;
+  PPCSymbolDB& m_ppc_symbol_db;
 
   UGeckoInstruction m_prev_inst{};
   u32 m_last_pc = 0;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -1285,7 +1285,7 @@ void Jit64::IntializeSpeculativeConstants()
 
 bool Jit64::HandleFunctionHooking(u32 address)
 {
-  const auto result = HLE::TryReplaceFunction(address, PowerPC::CoreMode::JIT);
+  const auto result = HLE::TryReplaceFunction(m_ppc_symbol_db, address, PowerPC::CoreMode::JIT);
   if (!result)
     return false;
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -781,7 +781,7 @@ void JitArm64::WriteConditionalExceptionExit(int exception, ARM64Reg temp_gpr, A
 
 bool JitArm64::HandleFunctionHooking(u32 address)
 {
-  const auto result = HLE::TryReplaceFunction(address, PowerPC::CoreMode::JIT);
+  const auto result = HLE::TryReplaceFunction(m_ppc_symbol_db, address, PowerPC::CoreMode::JIT);
   if (!result)
     return false;
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -94,7 +94,8 @@ void JitTrampoline(JitBase& jit, u32 em_address)
 
 JitBase::JitBase(Core::System& system)
     : m_code_buffer(code_buffer_size), m_system(system), m_ppc_state(system.GetPPCState()),
-      m_mmu(system.GetMMU()), m_branch_watch(system.GetPowerPC().GetBranchWatch())
+      m_mmu(system.GetMMU()), m_branch_watch(system.GetPowerPC().GetBranchWatch()),
+      m_ppc_symbol_db(system.GetPPCSymbolDB())
 {
   m_registered_config_callback_id = CPUThreadConfigCallback::AddConfigChangedCallback([this] {
     if (DoesConfigNeedRefresh())

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -31,6 +31,7 @@ namespace PowerPC
 class MMU;
 struct PowerPCState;
 }  // namespace PowerPC
+class PPCSymbolDB;
 
 //#define JIT_LOG_GENERATED_CODE  // Enables logging of generated code
 //#define JIT_LOG_GPR             // Enables logging of the PPC general purpose regs
@@ -208,6 +209,7 @@ public:
   PowerPC::PowerPCState& m_ppc_state;
   PowerPC::MMU& m_mmu;
   Core::BranchWatch& m_branch_watch;
+  PPCSymbolDB& m_ppc_symbol_db;
 };
 
 void JitTrampoline(JitBase& jit, u32 em_address);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -152,7 +152,7 @@ void JitBaseBlockCache::FinalizeBlock(JitBlock& block, bool block_link,
 
   Common::Symbol* symbol = nullptr;
   if (Common::JitRegister::IsEnabled() &&
-      (symbol = g_symbolDB.GetSymbolFromAddr(block.effectiveAddress)) != nullptr)
+      (symbol = m_jit.m_ppc_symbol_db.GetSymbolFromAddr(block.effectiveAddress)) != nullptr)
   {
     Common::JitRegister::Register(block.normalEntry, block.codeSize, "JIT_PPC_{}_{:08x}",
                                   symbol->function_name.c_str(), block.physicalAddress);

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -138,7 +138,7 @@ void JitInterface::WriteProfileResults(const std::string& filename) const
                 "ms)\tblkCodeSize\n");
   for (auto& stat : prof_stats.block_stats)
   {
-    std::string name = g_symbolDB.GetDescription(stat.addr);
+    std::string name = m_system.GetPPCSymbolDB().GetDescription(stat.addr);
     double percent = 100.0 * (double)stat.cost / (double)prof_stats.cost_sum;
     double timePercent = 100.0 * (double)stat.tick_counter / (double)prof_stats.timecost_sum;
     f.WriteString(fmt::format("{0:08x}\t{1}\t{2}\t{3}\t{4}\t{5:.2f}\t{6:.2f}\t{7:.2f}\t{8}\n",

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -558,8 +558,7 @@ void MMU::Memcheck(u32 address, u64 var, bool write, size_t size)
 
   mc->num_hits++;
 
-  const bool pause = mc->Action(m_system, &m_power_pc.GetDebugInterface(), var, address, write,
-                                size, m_ppc_state.pc);
+  const bool pause = mc->Action(m_system, var, address, write, size, m_ppc_state.pc);
   if (!pause)
     return;
 

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -187,12 +187,12 @@ bool ReanalyzeFunction(const Core::CPUThreadGuard& guard, u32 start_addr, Common
 
 // Second pass analysis, done after the first pass is done for all functions
 // so we have more information to work with
-static void AnalyzeFunction2(Common::Symbol* func)
+static void AnalyzeFunction2(PPCSymbolDB* func_db, Common::Symbol* func)
 {
   u32 flags = func->flags;
 
-  bool nonleafcall = std::any_of(func->calls.begin(), func->calls.end(), [](const auto& call) {
-    const Common::Symbol* called_func = g_symbolDB.GetSymbolFromAddr(call.function);
+  bool nonleafcall = std::any_of(func->calls.begin(), func->calls.end(), [&](const auto& call) {
+    const Common::Symbol* const called_func = func_db->GetSymbolFromAddr(call.function);
     return called_func && (called_func->flags & Common::FFLAG_LEAF) == 0;
   });
 
@@ -408,7 +408,7 @@ void FindFunctions(const Core::CPUThreadGuard& guard, u32 startAddr, u32 endAddr
       WARN_LOG_FMT(SYMBOLS, "Weird function");
       continue;
     }
-    AnalyzeFunction2(&(func.second));
+    AnalyzeFunction2(func_db, &(func.second));
     Common::Symbol& f = func.second;
     if (f.name.substr(0, 3) == "zzz")
     {
@@ -824,7 +824,8 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
 
   const bool enable_follow = m_enable_branch_following;
 
-  auto& mmu = Core::System::GetInstance().GetMMU();
+  auto& system = Core::System::GetInstance();
+  auto& mmu = system.GetMMU();
   for (std::size_t i = 0; i < block_size; ++i)
   {
     auto result = mmu.TryReadInstruction(address);
@@ -979,6 +980,8 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
     block->m_broken = true;
   }
 
+  auto& power_pc = system.GetPowerPC();
+  auto& ppc_symbol_db = power_pc.GetSymbolDB();
   // Scan for flag dependencies; assume the next block (or any branch that can leave the block)
   // wants flags, to be safe.
   bool wantsFPRF = true;
@@ -998,8 +1001,8 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
       crDiscardable = BitSet8{};
     }
 
-    const auto ppc_mode = Core::System::GetInstance().GetPowerPC().GetMode();
-    const bool hle = !!HLE::TryReplaceFunction(op.address, ppc_mode);
+    const auto ppc_mode = power_pc.GetMode();
+    const bool hle = !!HLE::TryReplaceFunction(ppc_symbol_db, op.address, ppc_mode);
     const bool may_exit_block = hle || op.canEndBlock || op.canCauseException;
 
     const bool opWantsFPRF = op.wantsFPRF;

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -26,8 +26,6 @@
 #include "Core/PowerPC/SignatureDB/SignatureDB.h"
 #include "Core/System.h"
 
-PPCSymbolDB g_symbolDB;
-
 PPCSymbolDB::PPCSymbolDB() = default;
 
 PPCSymbolDB::~PPCSymbolDB() = default;

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -39,5 +39,3 @@ public:
   void PrintCallers(u32 funcAddr) const;
   void LogFunctionCall(u32 addr);
 };
-
-extern PPCSymbolDB g_symbolDB;

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -85,7 +85,8 @@ std::ostream& operator<<(std::ostream& os, CPUCore core)
 }
 
 PowerPCManager::PowerPCManager(Core::System& system)
-    : m_breakpoints(system), m_memchecks(system), m_debug_interface(system), m_system(system)
+    : m_breakpoints(system), m_memchecks(system), m_debug_interface(system, m_symbol_db),
+      m_system(system)
 {
 }
 
@@ -668,7 +669,7 @@ void PowerPCManager::CheckBreakPoints()
     NOTICE_LOG_FMT(MEMMAP,
                    "BP {:08x} {}({:08x} {:08x} {:08x} {:08x} {:08x} {:08x} {:08x} {:08x} {:08x} "
                    "{:08x}) LR={:08x}",
-                   m_ppc_state.pc, g_symbolDB.GetDescription(m_ppc_state.pc), m_ppc_state.gpr[3],
+                   m_ppc_state.pc, m_symbol_db.GetDescription(m_ppc_state.pc), m_ppc_state.gpr[3],
                    m_ppc_state.gpr[4], m_ppc_state.gpr[5], m_ppc_state.gpr[6], m_ppc_state.gpr[7],
                    m_ppc_state.gpr[8], m_ppc_state.gpr[9], m_ppc_state.gpr[10], m_ppc_state.gpr[11],
                    m_ppc_state.gpr[12], LR(m_ppc_state));

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -20,6 +20,7 @@
 #include "Core/PowerPC/ConditionRegister.h"
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/PPCCache.h"
+#include "Core/PowerPC/PPCSymbolDB.h"
 
 class CPUCoreBase;
 class PointerWrap;
@@ -299,6 +300,8 @@ public:
   const MemChecks& GetMemChecks() const { return m_memchecks; }
   PPCDebugInterface& GetDebugInterface() { return m_debug_interface; }
   const PPCDebugInterface& GetDebugInterface() const { return m_debug_interface; }
+  PPCSymbolDB& GetSymbolDB() { return m_symbol_db; }
+  const PPCSymbolDB& GetSymbolDB() const { return m_symbol_db; }
   Core::BranchWatch& GetBranchWatch() { return m_branch_watch; }
   const Core::BranchWatch& GetBranchWatch() const { return m_branch_watch; }
 
@@ -316,6 +319,7 @@ private:
 
   BreakPoints m_breakpoints;
   MemChecks m_memchecks;
+  PPCSymbolDB m_symbol_db;
   PPCDebugInterface m_debug_interface;
   Core::BranchWatch m_branch_watch;
 

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -52,7 +52,8 @@ struct System::Impl
         m_memory(system), m_pixel_engine{system}, m_power_pc(system),
         m_mmu(system, m_memory, m_power_pc), m_processor_interface(system),
         m_serial_interface(system), m_system_timers(system), m_video_interface(system),
-        m_interpreter(system, m_power_pc.GetPPCState(), m_mmu, m_power_pc.GetBranchWatch()),
+        m_interpreter(system, m_power_pc.GetPPCState(), m_mmu, m_power_pc.GetBranchWatch(),
+                      m_power_pc.GetSymbolDB()),
         m_jit_interface(system), m_fifo_player(system), m_fifo_recorder(system), m_movie(system)
   {
   }
@@ -285,6 +286,11 @@ PowerPC::PowerPCManager& System::GetPowerPC() const
 PowerPC::PowerPCState& System::GetPPCState() const
 {
   return m_impl->m_power_pc.GetPPCState();
+}
+
+PPCSymbolDB& System::GetPPCSymbolDB() const
+{
+  return m_impl->m_power_pc.GetSymbolDB();
 }
 
 ProcessorInterface::ProcessorInterfaceManager& System::GetProcessorInterface() const

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -92,6 +92,7 @@ class MMU;
 class PowerPCManager;
 struct PowerPCState;
 }  // namespace PowerPC
+class PPCSymbolDB;
 namespace ProcessorInterface
 {
 class ProcessorInterfaceManager;
@@ -184,6 +185,7 @@ public:
   PixelShaderManager& GetPixelShaderManager() const;
   PowerPC::PowerPCManager& GetPowerPC() const;
   PowerPC::PowerPCState& GetPPCState() const;
+  PPCSymbolDB& GetPPCSymbolDB() const;
   ProcessorInterface::ProcessorInterfaceManager& GetProcessorInterface() const;
   SerialInterface::SerialInterfaceManager& GetSerialInterface() const;
   Sram& GetSRAM() const;

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -194,25 +194,26 @@ void BranchWatchProxyModel::SetInspected(const QModelIndex& index)
 }
 
 BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& branch_watch,
-                                     CodeWidget* code_widget, QWidget* parent)
+                                     PPCSymbolDB& ppc_symbol_db, CodeWidget* code_widget,
+                                     QWidget* parent)
     : QDialog(parent), m_system(system), m_branch_watch(branch_watch), m_code_widget(code_widget)
 {
   setWindowTitle(tr("Branch Watch Tool"));
   setWindowFlags((windowFlags() | Qt::WindowMinMaxButtonsHint) & ~Qt::WindowContextHelpButtonHint);
   SetQWidgetWindowDecorations(this);
-  setLayout([this]() {
+  setLayout([this, &ppc_symbol_db]() {
     auto* main_layout = new QVBoxLayout;
 
     // Controls Toolbar (widgets are added later)
     main_layout->addWidget(m_control_toolbar = new QToolBar);
 
     // Branch Watch Table
-    main_layout->addWidget(m_table_view = [this]() {
+    main_layout->addWidget(m_table_view = [this, &ppc_symbol_db]() {
       const auto& ui_settings = Settings::Instance();
 
       m_table_proxy = new BranchWatchProxyModel(m_branch_watch);
-      m_table_proxy->setSourceModel(m_table_model =
-                                        new BranchWatchTableModel(m_system, m_branch_watch));
+      m_table_proxy->setSourceModel(
+          m_table_model = new BranchWatchTableModel(m_system, m_branch_watch, ppc_symbol_db));
       m_table_proxy->setSortRole(UserRole::SortRole);
 
       m_table_model->setFont(ui_settings.GetDebugFont());

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -17,6 +17,8 @@ class BranchWatch;
 class CPUThreadGuard;
 class System;
 }  // namespace Core
+class PPCSymbolDB;
+
 class BranchWatchProxyModel;
 class BranchWatchTableModel;
 class CodeWidget;
@@ -48,7 +50,8 @@ class BranchWatchDialog : public QDialog
 
 public:
   explicit BranchWatchDialog(Core::System& system, Core::BranchWatch& branch_watch,
-                             CodeWidget* code_widget, QWidget* parent = nullptr);
+                             PPCSymbolDB& ppc_symbol_db, CodeWidget* code_widget,
+                             QWidget* parent = nullptr);
   ~BranchWatchDialog() override;
 
 protected:

--- a/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.cpp
@@ -285,8 +285,8 @@ void BranchWatchTableModel::PrefetchSymbols()
   for (const Core::BranchWatch::Selection::value_type& value : selection)
   {
     const Core::BranchWatch::Collection::value_type* const kv = value.collection_ptr;
-    m_symbol_list.emplace_back(g_symbolDB.GetSymbolFromAddr(kv->first.origin_addr),
-                               g_symbolDB.GetSymbolFromAddr(kv->first.destin_addr));
+    m_symbol_list.emplace_back(m_ppc_symbol_db.GetSymbolFromAddr(kv->first.origin_addr),
+                               m_ppc_symbol_db.GetSymbolFromAddr(kv->first.destin_addr));
   }
 }
 

--- a/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
@@ -18,6 +18,7 @@ class BranchWatch;
 class CPUThreadGuard;
 class System;
 }  // namespace Core
+class PPCSymbolDB;
 
 namespace BranchWatchTableModelColumn
 {
@@ -69,8 +70,9 @@ public:
   using SymbolList = QList<SymbolListValueType>;
 
   explicit BranchWatchTableModel(Core::System& system, Core::BranchWatch& branch_watch,
-                                 QObject* parent = nullptr)
-      : QAbstractTableModel(parent), m_system(system), m_branch_watch(branch_watch)
+                                 PPCSymbolDB& ppc_symbol_db, QObject* parent = nullptr)
+      : QAbstractTableModel(parent), m_system(system), m_branch_watch(branch_watch),
+        m_ppc_symbol_db(ppc_symbol_db)
   {
   }
   QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
@@ -113,6 +115,7 @@ private:
 
   Core::System& m_system;
   Core::BranchWatch& m_branch_watch;
+  PPCSymbolDB& m_ppc_symbol_db;
 
   SymbolList m_symbol_list;
   mutable QFont m_font;

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -178,6 +178,7 @@ void BreakpointWidget::Update()
   auto& power_pc = m_system.GetPowerPC();
   auto& breakpoints = power_pc.GetBreakPoints();
   auto& memchecks = power_pc.GetMemChecks();
+  auto& ppc_symbol_db = power_pc.GetSymbolDB();
 
   // Breakpoints
   for (const auto& bp : breakpoints.GetBreakPoints())
@@ -192,10 +193,10 @@ void BreakpointWidget::Update()
     m_table->setItem(i, 0, active);
     m_table->setItem(i, 1, create_item(QStringLiteral("BP")));
 
-    if (g_symbolDB.GetSymbolFromAddr(bp.address))
+    if (ppc_symbol_db.GetSymbolFromAddr(bp.address))
     {
-      m_table->setItem(i, 2,
-                       create_item(QString::fromStdString(g_symbolDB.GetDescription(bp.address))));
+      m_table->setItem(
+          i, 2, create_item(QString::fromStdString(ppc_symbol_db.GetDescription(bp.address))));
     }
 
     m_table->setItem(i, 3,
@@ -233,10 +234,11 @@ void BreakpointWidget::Update()
     m_table->setItem(i, 0, active);
     m_table->setItem(i, 1, create_item(QStringLiteral("MBP")));
 
-    if (g_symbolDB.GetSymbolFromAddr(mbp.start_address))
+    if (ppc_symbol_db.GetSymbolFromAddr(mbp.start_address))
     {
       m_table->setItem(
-          i, 2, create_item(QString::fromStdString(g_symbolDB.GetDescription(mbp.start_address))));
+          i, 2,
+          create_item(QString::fromStdString(ppc_symbol_db.GetDescription(mbp.start_address))));
     }
 
     if (mbp.is_ranged)

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -23,6 +23,7 @@ class System;
 
 struct CodeViewBranch;
 class BranchDisplayDelegate;
+class PPCSymbolDB;
 
 class CodeViewWidget : public QTableWidget
 {
@@ -102,6 +103,7 @@ private:
   void CalculateBranchIndentation();
 
   Core::System& m_system;
+  PPCSymbolDB& m_ppc_symbol_db;
 
   bool m_updating = false;
 

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -26,6 +26,7 @@ namespace Core
 {
 class System;
 }
+class PPCSymbolDB;
 
 class CodeWidget : public QDockWidget
 {
@@ -71,6 +72,7 @@ private:
   void showEvent(QShowEvent* event) override;
 
   Core::System& m_system;
+  PPCSymbolDB& m_ppc_symbol_db;
 
   BranchWatchDialog* m_branch_watch_dialog = nullptr;
   QLineEdit* m_search_address;


### PR DESCRIPTION
`PPCSymbolDB` is now owned by `PowerPC::PowerPCManager`, accessible via the `GetSymbolDB()` getter. `Core::System` also has a new getter, `GetPPCSymbolDB()`, which is shorthand for `GetPowerPC().GetSymbolDB()`. In this PR, care has been taken to access `PPCSymbolDB` through a `PowerPC::PowerPCManager` reference whenever possible for efficiency.

In HLE.cpp, the result of `SymbolDB::GetSymbolsFromName` is returned by value but was being bound to an auto reference, which I felt was misleading even though the lifetime (I think) is extended in this case, so I changed it.