### PR TITLE
VSProps: Set VcpkgEnabled to false

### DIFF
--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -10,6 +10,8 @@
     <OutDir>$(IntDir)bin\</OutDir>
     <!--Set link /INCREMENTAL:NO to remove some entropy from builds (assists with deterministic build)-->
     <LinkIncremental>false</LinkIncremental>
+    <!--Disable vcpkg to avoid accidentally linking to its packages-->
+    <VcpkgEnabled>false</VcpkgEnabled>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <!--ClCompile Base-->


### PR DESCRIPTION
I'm using vcpkg on my machine and this resulted in multiple defined symbols because vcpkg dependencies were being pulled in.