### PR TITLE
Cubeb: change log level from NOTICE to INFO

### DIFF
--- a/Source/Core/AudioCommon/CubebUtils.cpp
+++ b/Source/Core/AudioCommon/CubebUtils.cpp
@@ -36,7 +36,7 @@ static void LogCallback(const char* format, ...)
   const std::string message = StringFromFormatV(adapted_format.c_str(), args);
   va_end(args);
 
-  instance->LogWithFullPath(Common::Log::LogLevel::LNOTICE, log_type, filename, lineno,
+  instance->LogWithFullPath(Common::Log::LogLevel::LINFO, log_type, filename, lineno,
                             message.c_str());
 }
 


### PR DESCRIPTION
Cubeb logs a message at CUBEB_LOG_NORMAL verbosity every time you start or stop a stream which can get a bit annoying when using frame advance at Dolphin's default verbosity.