### PR TITLE
Cubeb: check correct log level

### DIFF
--- a/Source/Core/AudioCommon/CubebUtils.cpp
+++ b/Source/Core/AudioCommon/CubebUtils.cpp
@@ -25,7 +25,8 @@ static void LogCallback(const char* format, ...)
     return;
 
   constexpr auto log_type = Common::Log::LogType::AUDIO;
-  if (!instance->IsEnabled(log_type))
+  constexpr auto log_level = Common::Log::LogLevel::LINFO;
+  if (!instance->IsEnabled(log_type, log_level))
     return;
 
   va_list args;
@@ -36,8 +37,7 @@ static void LogCallback(const char* format, ...)
   const std::string message = StringFromFormatV(adapted_format.c_str(), args);
   va_end(args);
 
-  instance->LogWithFullPath(Common::Log::LogLevel::LINFO, log_type, filename, lineno,
-                            message.c_str());
+  instance->LogWithFullPath(log_level, log_type, filename, lineno, message.c_str());
 }
 
 static void DestroyContext(cubeb* ctx)


### PR DESCRIPTION
Follow-up to #12638. I blindly changed the level without checking whether it had any effect. `LogWithFullPath()` doesn't check whether the log level is enabled, it only uses it for printing.