### PR TITLE
DolphinQt: A Ubiquitous Signal For When Symbols Change

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -96,7 +96,7 @@ std::vector<std::string> Host_GetPreferredLocales()
   return {};
 }
 
-void Host_NotifyMapLoaded()
+void Host_PPCSymbolsChanged()
 {
 }
 

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -351,11 +351,6 @@ bool CBoot::DVDReadDiscID(Core::System& system, const DiscIO::VolumeDisc& disc, 
   return true;
 }
 
-void CBoot::UpdateDebugger_MapLoaded()
-{
-  Host_NotifyMapLoaded();
-}
-
 // Get map file paths for the active title.
 bool CBoot::FindMapFile(std::string* existing_map_file, std::string* writable_map_file)
 {
@@ -382,7 +377,7 @@ bool CBoot::LoadMapFromFilename(const Core::CPUThreadGuard& guard, PPCSymbolDB& 
   bool found = FindMapFile(&strMapFilename, nullptr);
   if (found && ppc_symbol_db.LoadMap(guard, strMapFilename))
   {
-    UpdateDebugger_MapLoaded();
+    Host_PPCSymbolsChanged();
     return true;
   }
 
@@ -517,7 +512,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
   if (auto& ppc_symbol_db = system.GetPPCSymbolDB(); !ppc_symbol_db.IsEmpty())
   {
     ppc_symbol_db.Clear();
-    UpdateDebugger_MapLoaded();
+    Host_PPCSymbolsChanged();
   }
 
   // PAL Wii uses NTSC framerate and linecount in 60Hz modes
@@ -597,7 +592,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
 
       if (executable.reader->LoadSymbols(guard, system.GetPPCSymbolDB()))
       {
-        UpdateDebugger_MapLoaded();
+        Host_PPCSymbolsChanged();
         HLE::PatchFunctions(system);
       }
       return true;

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -179,8 +179,6 @@ private:
                             u32 output_address);
   static void RunFunction(Core::System& system, u32 address);
 
-  static void UpdateDebugger_MapLoaded();
-
   static bool Boot_WiiWAD(Core::System& system, const DiscIO::VolumeWAD& wad);
   static bool BootNANDTitle(Core::System& system, u64 title_id);
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -210,7 +210,7 @@ void SConfig::OnNewTitleLoad(const Core::CPUThreadGuard& guard)
   if (!ppc_symbol_db.IsEmpty())
   {
     ppc_symbol_db.Clear();
-    Host_NotifyMapLoaded();
+    Host_PPCSymbolsChanged();
   }
   CBoot::LoadMapFromFilename(guard, ppc_symbol_db);
   HLE::Reload(system);

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -55,7 +55,7 @@ bool Host_RendererHasFullFocus();
 bool Host_RendererIsFullscreen();
 
 void Host_Message(HostMessageID id);
-void Host_NotifyMapLoaded();
+void Host_PPCSymbolsChanged();
 void Host_RefreshDSPDebuggerWindow();
 void Host_RequestRenderWindowSize(int width, int height);
 void Host_UpdateDisasmDialog();

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -74,13 +74,13 @@ bool Load(Core::System& system)
   if (!ppc_symbol_db.IsEmpty())
   {
     ppc_symbol_db.Clear();
-    Host_NotifyMapLoaded();
+    Host_PPCSymbolsChanged();
   }
   if (ppc_symbol_db.LoadMap(guard, File::GetUserPath(D_MAPS_IDX) + "mios-ipl.map"))
   {
     ::HLE::Clear();
     ::HLE::PatchFunctions(system);
-    Host_NotifyMapLoaded();
+    Host_PPCSymbolsChanged();
   }
 
   const PowerPC::CoreMode core_mode = power_pc.GetMode();

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -57,7 +57,7 @@ std::vector<std::string> Host_GetPreferredLocales()
   return {};
 }
 
-void Host_NotifyMapLoaded()
+void Host_PPCSymbolsChanged()
 {
 }
 

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -42,6 +42,7 @@
 #include "Core/System.h"
 #include "DolphinQt/Debugger/BranchWatchTableModel.h"
 #include "DolphinQt/Debugger/CodeWidget.h"
+#include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/SetWindowDecorations.h"
@@ -219,6 +220,8 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
       m_table_model->setFont(ui_settings.GetDebugFont());
       connect(&ui_settings, &Settings::DebugFontChanged, m_table_model,
               &BranchWatchTableModel::setFont);
+      connect(Host::GetInstance(), &Host::PPCSymbolsChanged, m_table_model,
+              &BranchWatchTableModel::UpdateSymbols);
 
       auto* const table_view = new QTableView;
       table_view->setModel(m_table_proxy);
@@ -936,11 +939,6 @@ void BranchWatchDialog::Update()
   if (m_branch_watch.GetRecordingPhase() == Core::BranchWatch::Phase::Blacklist)
     UpdateStatus();
   m_table_model->UpdateHits();
-}
-
-void BranchWatchDialog::UpdateSymbols()
-{
-  m_table_model->UpdateSymbols();
 }
 
 void BranchWatchDialog::UpdateStatus()

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -92,8 +92,6 @@ private:
 public:
   // TODO: Step doesn't cause EmulationStateChanged to be emitted, so it has to call this manually.
   void Update();
-  // TODO: There seems to be a lack of a ubiquitous signal for when symbols change.
-  void UpdateSymbols();
 
 private:
   void UpdateStatus();

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -184,6 +184,8 @@ CodeViewWidget::CodeViewWidget()
     m_address = m_system.GetPPCState().pc;
     Update();
   });
+  connect(Host::GetInstance(), &Host::PPCSymbolsChanged, this,
+          qOverload<>(&CodeViewWidget::Update));
 
   connect(&Settings::Instance(), &Settings::ThemeChanged, this,
           qOverload<>(&CodeViewWidget::Update));
@@ -879,8 +881,7 @@ void CodeViewWidget::OnAddFunction()
   Core::CPUThreadGuard guard(m_system);
 
   m_ppc_symbol_db.AddFunction(guard, addr);
-  emit SymbolsChanged();
-  Update(&guard);
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void CodeViewWidget::OnInsertBLR()
@@ -929,8 +930,7 @@ void CodeViewWidget::OnRenameSymbol()
   if (good && !name.isEmpty())
   {
     symbol->Rename(name.toStdString());
-    emit SymbolsChanged();
-    Update();
+    emit Host::GetInstance()->PPCSymbolsChanged();
   }
 }
 
@@ -968,8 +968,7 @@ void CodeViewWidget::OnSetSymbolSize()
   Core::CPUThreadGuard guard(m_system);
 
   PPCAnalyst::ReanalyzeFunction(guard, symbol->address, *symbol, size);
-  emit SymbolsChanged();
-  Update(&guard);
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void CodeViewWidget::OnSetSymbolEndAddress()
@@ -996,8 +995,7 @@ void CodeViewWidget::OnSetSymbolEndAddress()
   Core::CPUThreadGuard guard(m_system);
 
   PPCAnalyst::ReanalyzeFunction(guard, symbol->address, *symbol, address - symbol->address);
-  emit SymbolsChanged();
-  Update(&guard);
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void CodeViewWidget::OnReplaceInstruction()

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -56,7 +56,6 @@ public:
 signals:
   void RequestPPCComparison(u32 addr);
   void ShowMemory(u32 address);
-  void SymbolsChanged();
   void BreakpointsChanged();
   void UpdateCodeWidget();
 

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -61,6 +61,7 @@ private:
   void UpdateFunctionCalls(const Common::Symbol* symbol);
   void UpdateFunctionCallers(const Common::Symbol* symbol);
 
+  void OnPPCSymbolsChanged();
   void OnSearchAddress();
   void OnSearchSymbols();
   void OnSelectSymbol();

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -238,14 +238,9 @@ void Host_UpdateDisasmDialog()
   QueueOnObject(QApplication::instance(), [] { emit Host::GetInstance()->UpdateDisasmDialog(); });
 }
 
-void Host::RequestNotifyMapLoaded()
+void Host_PPCSymbolsChanged()
 {
-  QueueOnObject(QApplication::instance(), [this] { emit NotifyMapLoaded(); });
-}
-
-void Host_NotifyMapLoaded()
-{
-  Host::GetInstance()->RequestNotifyMapLoaded();
+  QueueOnObject(QApplication::instance(), [] { emit Host::GetInstance()->PPCSymbolsChanged(); });
 }
 
 // We ignore these, and their purpose should be questioned individually.

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -32,14 +32,13 @@ public:
   void SetRenderFullFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
   void ResizeSurface(int new_width, int new_height);
-  void RequestNotifyMapLoaded();
 
 signals:
   void RequestTitle(const QString& title);
   void RequestStop();
   void RequestRenderSize(int w, int h);
   void UpdateDisasmDialog();
-  void NotifyMapLoaded();
+  void PPCSymbolsChanged();
 
 private:
   Host();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -591,12 +591,6 @@ void MainWindow::ConnectMenuBar()
   connect(m_game_list, &GameList::SelectionChanged, m_menu_bar, &MenuBar::SelectionChanged);
   connect(this, &MainWindow::ReadOnlyModeChanged, m_menu_bar, &MenuBar::ReadOnlyModeChanged);
   connect(this, &MainWindow::RecordingStatusChanged, m_menu_bar, &MenuBar::RecordingStatusChanged);
-
-  // Symbols
-  connect(m_menu_bar, &MenuBar::NotifySymbolsUpdated, [this] {
-    m_code_widget->UpdateSymbols();
-    m_code_widget->Update();
-  });
 }
 
 void MainWindow::ConnectHotkeys()

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1262,7 +1262,7 @@ void MenuBar::ClearSymbols()
     return;
 
   Core::System::GetInstance().GetPPCSymbolDB().Clear();
-  emit NotifySymbolsUpdated();
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void MenuBar::GenerateSymbolsFromAddress()
@@ -1275,7 +1275,7 @@ void MenuBar::GenerateSymbolsFromAddress()
 
   PPCAnalyst::FindFunctions(guard, Memory::MEM1_BASE_ADDR,
                             Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal(), &ppc_symbol_db);
-  emit NotifySymbolsUpdated();
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void MenuBar::GenerateSymbolsFromSignatureDB()
@@ -1304,7 +1304,7 @@ void MenuBar::GenerateSymbolsFromSignatureDB()
         tr("'%1' not found, no symbol names generated").arg(QString::fromStdString(TOTALDB)));
   }
 
-  emit NotifySymbolsUpdated();
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void MenuBar::GenerateSymbolsFromRSO()
@@ -1334,7 +1334,7 @@ void MenuBar::GenerateSymbolsFromRSO()
   if (rso_chain.Load(guard, static_cast<u32>(address)))
   {
     rso_chain.Apply(guard, &system.GetPPCSymbolDB());
-    emit NotifySymbolsUpdated();
+    emit Host::GetInstance()->PPCSymbolsChanged();
   }
   else
   {
@@ -1391,7 +1391,7 @@ void MenuBar::GenerateSymbolsFromRSOAuto()
   if (rso_chain.Load(guard, address))
   {
     rso_chain.Apply(guard, &system.GetPPCSymbolDB());
-    emit NotifySymbolsUpdated();
+    emit Host::GetInstance()->PPCSymbolsChanged();
   }
   else
   {
@@ -1541,7 +1541,7 @@ void MenuBar::LoadSymbolMap()
   }
 
   HLE::PatchFunctions(system);
-  emit NotifySymbolsUpdated();
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void MenuBar::SaveSymbolMap()
@@ -1566,7 +1566,7 @@ void MenuBar::LoadOtherSymbolMap()
 
   auto& system = Core::System::GetInstance();
   HLE::PatchFunctions(system);
-  emit NotifySymbolsUpdated();
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void MenuBar::LoadBadSymbolMap()
@@ -1583,7 +1583,7 @@ void MenuBar::LoadBadSymbolMap()
 
   auto& system = Core::System::GetInstance();
   HLE::PatchFunctions(system);
-  emit NotifySymbolsUpdated();
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void MenuBar::SaveSymbolMapAs()
@@ -1708,7 +1708,7 @@ void MenuBar::ApplySignatureFile()
   db.Apply(Core::CPUThreadGuard{system}, &system.GetPPCSymbolDB());
   db.List();
   HLE::PatchFunctions(system);
-  emit NotifySymbolsUpdated();
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void MenuBar::CombineSignatureFiles()

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -125,9 +125,6 @@ signals:
   void RecordingStatusChanged(bool recording);
   void ReadOnlyModeChanged(bool read_only);
 
-  // Synbols
-  void NotifySymbolsUpdated();
-
 private:
   void OnEmulationStateChanged(Core::State state);
 

--- a/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
+++ b/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
@@ -21,7 +21,7 @@ std::vector<std::string> Host_GetPreferredLocales()
   return {};
 }
 
-void Host_NotifyMapLoaded()
+void Host_PPCSymbolsChanged()
 {
 }
 

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -13,7 +13,7 @@ std::vector<std::string> Host_GetPreferredLocales()
 {
   return {};
 }
-void Host_NotifyMapLoaded()
+void Host_PPCSymbolsChanged()
 {
 }
 void Host_RefreshDSPDebuggerWindow()

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -13,7 +13,7 @@ std::vector<std::string> Host_GetPreferredLocales()
 {
   return {};
 }
-void Host_NotifyMapLoaded()
+void Host_PPCSymbolsChanged()
 {
 }
 void Host_RefreshDSPDebuggerWindow()


### PR DESCRIPTION
There were three distinct mechanisms for signaling symbol changes in DolphinQt: `Host::NotifyMapLoaded`, `MenuBar::NotifySymbolsUpdated`, and `CodeViewWidget::SymbolsChanged`. The behavior of these signals has been consolidated into the new `Host::PPCSymbolsUpdated` signal, which can be emitted from anywhere in DolphinQt to properly update symbols everywhere in DolphinQt.

This PR:
- Addresses a DolphinQt shortcoming I found while creating Branch Watch Tool, and resolves a TODO left in its design.
- Does not fix widgets that currently do nothing to update symbols properly, such as BreakpointWidget.
- Does not communicate to Core when symbols are changed, which is relevant to obscure mechanisms such as JitRegister.

I am open to critique on the design and location of the new signal.