### PR TITLE
Core: Remove Unused IsRunningInCurrentThread Function

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -210,11 +210,6 @@ bool IsRunningAndStarted()
   return s_is_started && !s_is_stopping;
 }
 
-bool IsRunningInCurrentThread()
-{
-  return IsRunning() && IsCPUThread();
-}
-
 bool IsCPUThread()
 {
   return tls_is_cpu_thread;

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -138,9 +138,8 @@ void UndeclareAsHostThread();
 std::string StopMessage(bool main_thread, std::string_view message);
 
 bool IsRunning();
-bool IsRunningAndStarted();       // is running and the CPU loop has been entered
-bool IsRunningInCurrentThread();  // this tells us whether we are running in the CPU thread.
-bool IsCPUThread();               // this tells us whether we are the CPU thread.
+bool IsRunningAndStarted();  // is running and the CPU loop has been entered
+bool IsCPUThread();          // this tells us whether we are the CPU thread.
 bool IsGPUThread();
 bool IsHostThread();
 


### PR DESCRIPTION
This small function has been unused for a very long time. I believe the last uses for it were removed in  dfe84ce0acf288157a867f0df1678930b281fd40 (Feb 3, 2011) and fb4c82fb48b756b348140993c36d3177a869aa52 (Feb 15, 2011). Despite being unused, it was greatly simplified by a81631b58e3a77f8d088c574fc048f3fb37a7c51 (May 25, 2012) to simply return the result of `IsRunning() && IsCPUThread()`. I say it's time to let this function retire.