### PR TITLE
DolphinQt: Fix BalloonTip positioning on secondary monitors.

### DIFF
--- a/Source/Core/DolphinQt/Config/ToolTipControls/BalloonTip.cpp
+++ b/Source/Core/DolphinQt/Config/ToolTipControls/BalloonTip.cpp
@@ -315,10 +315,12 @@ void BalloonTip::UpdateBoundsAndRedraw(const QPoint& target_arrow_tip_position,
   // Place the arrow tip at the target position whether the arrow tip is drawn or not
   const int target_balloontip_global_x =
       target_arrow_tip_position.x() - static_cast<int>(arrow_tip_x);
-  const int rightmost_valid_balloontip_global_x = screen_rect.width() - size_hint.width();
+  const int rightmost_valid_balloontip_global_x =
+      screen_rect.left() + screen_rect.width() - size_hint.width();
   // If the balloon would extend off the screen, push it left or right until it's not
   const int actual_balloontip_global_x =
-      std::max(0, std::min(rightmost_valid_balloontip_global_x, target_balloontip_global_x));
+      std::max(screen_rect.left(),
+               std::min(rightmost_valid_balloontip_global_x, target_balloontip_global_x));
   // The tip pixel should be in the middle of the control, and arrow_tip_exterior_y is at the bottom
   // of that pixel. When arrow_at_bottom is true the arrow is above arrow_tip_exterior_y and so the
   // tip pixel is in the right place, but when it's false the arrow is below arrow_tip_exterior_y


### PR DESCRIPTION
This fixes `BalloonTip` showing up at totally wrong x positions or on completely wrong monitors.

Things still get funky at screen edges, but that hasn't changed.