### PR TITLE
Common: add even more json utility functions

### DIFF
--- a/Source/Core/Common/JsonUtil.cpp
+++ b/Source/Core/Common/JsonUtil.cpp
@@ -18,3 +18,23 @@ void FromJson(const picojson::object& obj, Common::Vec3& vec)
   vec.y = ReadNumericFromJson<float>(obj, "y").value_or(0.0f);
   vec.z = ReadNumericFromJson<float>(obj, "z").value_or(0.0f);
 }
+
+std::optional<std::string> ReadStringFromJson(const picojson::object& obj, const std::string& key)
+{
+  const auto it = obj.find(key);
+  if (it == obj.end())
+    return std::nullopt;
+  if (!it->second.is<std::string>())
+    return std::nullopt;
+  return it->second.to_str();
+}
+
+std::optional<bool> ReadBoolFromJson(const picojson::object& obj, const std::string& key)
+{
+  const auto it = obj.find(key);
+  if (it == obj.end())
+    return std::nullopt;
+  if (!it->second.is<bool>())
+    return std::nullopt;
+  return it->second.get<bool>();
+}

--- a/Source/Core/Common/JsonUtil.cpp
+++ b/Source/Core/Common/JsonUtil.cpp
@@ -14,7 +14,7 @@ picojson::object ToJsonObject(const Common::Vec3& vec)
 
 void FromJson(const picojson::object& obj, Common::Vec3& vec)
 {
-  vec.x = ReadNumericOrDefault<float>(obj, "x");
-  vec.y = ReadNumericOrDefault<float>(obj, "y");
-  vec.z = ReadNumericOrDefault<float>(obj, "z");
+  vec.x = ReadNumericFromJson<float>(obj, "x").value_or(0.0f);
+  vec.y = ReadNumericFromJson<float>(obj, "y").value_or(0.0f);
+  vec.z = ReadNumericFromJson<float>(obj, "z").value_or(0.0f);
 }

--- a/Source/Core/Common/JsonUtil.h
+++ b/Source/Core/Common/JsonUtil.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include <picojson.h>
@@ -29,14 +30,13 @@ picojson::array ToJsonArray(const Range& data)
 }
 
 template <typename Type>
-Type ReadNumericOrDefault(const picojson::object& obj, const std::string& key,
-                          Type default_value = Type{})
+std::optional<Type> ReadNumericFromJson(const picojson::object& obj, const std::string& key)
 {
   const auto it = obj.find(key);
   if (it == obj.end())
-    return default_value;
+    return std::nullopt;
   if (!it->second.is<double>())
-    return default_value;
+    return std::nullopt;
   return MathUtil::SaturatingCast<Type>(it->second.get<double>());
 }
 


### PR DESCRIPTION
This adds some more utility functions to help with writing `picojson` logic.  `ReadStringFromJson` and `ReadBoolFromJson` were added to match the existing numeric capability.  They all now return a `optional` as that was more flexible than passing in the default.

Similarly, I updated `ToJsonArray` to support any array type that the json library natively supports (strings or bools).