### PR TITLE
Common: update SaturatingCast to support floating point numbers

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -34,7 +34,7 @@ constexpr auto Lerp(const T& x, const T& y, const F& a) -> decltype(x + (y - x) 
 template <typename Dest, typename T>
 constexpr Dest SaturatingCast(T value)
 {
-  static_assert(std::is_integral<Dest>());
+  static_assert(std::is_integral<Dest>() || std::is_floating_point<Dest>());
 
   [[maybe_unused]] constexpr Dest lo = std::numeric_limits<Dest>::lowest();
   constexpr Dest hi = std::numeric_limits<Dest>::max();


### PR DESCRIPTION
This updates the `SaturatingCast` function to be usable for floating point numbers.  `SaturatingCast` is actually being used already for JsonUtil's `ReadNumericOrDefault` in this way but the compilation error was not getting hit in my editor branch until I started using `FromJson` on a `Vec3`.