### PR TITLE
GCAdapter: Adjust libusb transfer timeout to 100ms.

### DIFF
--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -59,7 +59,7 @@ namespace GCAdapter
 {
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
 
-constexpr unsigned int USB_TIMEOUT_MS = 16;
+constexpr unsigned int USB_TIMEOUT_MS = 100;
 
 static bool CheckDeviceAccess(libusb_device* device);
 static void AddGCAdapter(libusb_device* device);


### PR DESCRIPTION
This is a replacement for PR #5799.

Apparently the 16ms timeout can be a little too tight for usbip.

Fixes: https://bugs.dolphin-emu.org/issues/10408
100ms is mentioned to be satisfactory.

Note that transfers are done in threads. Increasing this timeout will not slow down emulation. It will reduce the responsiveness of controllers when the higher timeouts were necessary, as opposed to entirely not working.