### PR TITLE
NumericSetting: Stop values from binding to numbered input names.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -332,6 +332,9 @@ MappingWidget::CreateSettingAdvancedMappingButton(ControllerEmu::NumericSettingB
     if (setting.IsSimpleValue())
       setting.SetExpressionFromValue();
 
+    // Ensure the UI has the game-controller indicator while editing the expression.
+    ConfigChanged();
+
     IOWindow io(this, GetController(), &setting.GetInputReference(), IOWindow::Type::Input);
     SetQWidgetWindowDecorations(&io);
     io.exec();

--- a/Source/Core/InputCommon/ControlReference/ControlReference.h
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.h
@@ -9,6 +9,12 @@
 #include "InputCommon/ControlReference/ExpressionParser.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
+namespace ControllerEmu
+{
+template <typename T>
+T ControlStateCast(ControlState value);
+}
+
 // ControlReference
 //
 // These are what you create to actually use the inputs, InputReference or OutputReference.
@@ -31,7 +37,10 @@ public:
   virtual bool IsInput() const = 0;
 
   template <typename T>
-  T GetState();
+  T GetState()
+  {
+    return ControllerEmu::ControlStateCast<T>(State());
+  }
 
   int BoundCount() const;
   ciface::ExpressionParser::ParseStatus GetParseStatus() const;
@@ -51,24 +60,27 @@ protected:
       ciface::ExpressionParser::ParseStatus::EmptyExpression;
 };
 
+namespace ControllerEmu
+{
 template <>
-inline bool ControlReference::GetState<bool>()
+inline bool ControlStateCast<bool>(ControlState value)
 {
   // Round to nearest of 0 or 1.
-  return std::lround(State()) > 0;
+  return std::lround(value) > 0;
 }
 
 template <>
-inline int ControlReference::GetState<int>()
+inline int ControlStateCast<int>(ControlState value)
 {
-  return std::lround(State());
+  return std::lround(value);
 }
 
 template <>
-inline ControlState ControlReference::GetState<ControlState>()
+inline ControlState ControlStateCast<ControlState>(ControlState value)
 {
-  return State();
+  return value;
 }
+}  // namespace ControllerEmu
 
 //
 // InputReference

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -830,6 +830,12 @@ private:
       // Interpret it as a unary minus function.
       return ParseFunctionArguments("minus", MakeFunctionExpression("minus"), tok);
     }
+    case TOK_ADD:
+    {
+      // An atom was expected but we got an addition symbol.
+      // Interpret it as a unary plus.
+      return ParseFunctionArguments("plus", MakeFunctionExpression("plus"), tok);
+    }
     default:
     {
       return ParseResult::MakeErrorResult(tok, _trans("Expected start of expression."));

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
@@ -375,6 +375,22 @@ private:
   }
 };
 
+// usage: plus(expression)
+class UnaryPlusExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"expression"};
+  }
+
+  ControlState GetValue() const override { return GetArg(0).GetValue(); }
+};
+
 // usage: deadzone(input, amount)
 class DeadzoneExpression : public FunctionExpression
 {
@@ -689,6 +705,8 @@ std::unique_ptr<FunctionExpression> MakeFunctionExpression(std::string_view name
     return std::make_unique<ToggleExpression>();
   if (name == "minus")
     return std::make_unique<UnaryMinusExpression>();
+  if (name == "plus")
+    return std::make_unique<UnaryPlusExpression>();
   if (name == "deadzone")
     return std::make_unique<DeadzoneExpression>();
   if (name == "smooth")

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
@@ -3,13 +3,18 @@
 
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
-#include <sstream>
+#include <fmt/format.h>
 
 namespace ControllerEmu
 {
 NumericSettingBase::NumericSettingBase(const NumericSettingDetails& details) : m_details(details)
 {
 }
+
+// Explicit instantiations so generic definitions can exist outside of the header.
+template class NumericSetting<int>;
+template class NumericSetting<double>;
+template class NumericSetting<bool>;
 
 const char* NumericSettingBase::GetININame() const
 {
@@ -36,28 +41,20 @@ SettingVisibility NumericSettingBase::GetVisibility() const
   return m_details.visibility;
 }
 
-template <>
-void NumericSetting<int>::SetExpressionFromValue()
+template <typename T>
+void NumericSetting<T>::SetExpressionFromValue()
 {
-  m_value.m_input.SetExpression(ValueToString(GetValue()));
+  // Always include -/+ sign to prevent CoalesceExpression binding.
+  // e.g. 1 is a valid input name for keyboard devices, +1 is not.
+  m_value.m_input.SetExpression(fmt::format("{:+g}", ControlState(GetValue())));
 }
 
-template <>
-void NumericSetting<double>::SetExpressionFromValue()
+template <typename T>
+void NumericSetting<T>::SimplifyIfPossible()
 {
-  // We must use a dot decimal separator for expression parser.
-  std::ostringstream ss;
-  ss.imbue(std::locale::classic());
-  ss << GetValue();
-
-  m_value.m_input.SetExpression(ss.str());
-}
-
-template <>
-void NumericSetting<bool>::SetExpressionFromValue()
-{
-  // Cast bool to prevent "true"/"false" strings.
-  m_value.m_input.SetExpression(ValueToString(int(GetValue())));
+  ValueType value;
+  if (TryParse(std::string(StripWhitespace(m_value.m_input.GetExpression())), &value))
+    m_value.SetValue(value);
 }
 
 template <>

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -143,14 +143,7 @@ public:
   }
 
   bool IsSimpleValue() const override { return m_value.IsSimpleValue(); }
-
-  void SimplifyIfPossible() override
-  {
-    ValueType value;
-    if (TryParse(m_value.m_input.GetExpression(), &value))
-      m_value.SetValue(value);
-  }
-
+  void SimplifyIfPossible() override;
   void SetExpressionFromValue() override;
   InputReference& GetInputReference() override { return m_value.m_input; }
   const InputReference& GetInputReference() const override { return m_value.m_input; }


### PR DESCRIPTION
The problem:
When the "..." button is clicked, the numeric setting is converted to an input expression. Unfortunately integers are also valid keyboard `Input` names and get handled by `CoalesceExpression`.
Despite the expression being 1, the "Sideways Wii Remote" setting turns off, because the keyboard's 1 key is not being pressed..
When the dialog is closed, the expression is correctly converted to a simple `true` value, but in the meanwhile, it's `false`, which is especially strange when quickly opening and closing the advanced window.
The Wii Remote Extension setting has the same issue.
![image](https://github.com/dolphin-emu/dolphin/assets/1768214/d80fdcf2-9b98-4295-8758-11453b532298)

The solution:
The sign of the value is always included to not match any `Input` names.
![image](https://github.com/dolphin-emu/dolphin/assets/1768214/56002eb4-17be-45a3-9d11-cc5971ac8472)

Alternatively, instead of always including the `+` sign, decimal places could be always included, but this is maybe equally weird for integer or boolean settings to appear as `1.0`. Opinions?
