### PR TITLE
VideoCommon: Scan texture dumping directory + subdirectories to not re-dump existing files.

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -52,7 +52,6 @@
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/TextureConverterShaderGen.h"
 #include "VideoCommon/TextureDecoder.h"
-#include "VideoCommon/TextureUtils.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
@@ -1818,15 +1817,13 @@ RcTcacheEntry TextureCacheBase::CreateTextureEntry(
       const std::string basename = texture_info.CalculateTextureName().GetFullName();
       if (g_ActiveConfig.bDumpBaseTextures)
       {
-        VideoCommon::TextureUtils::DumpTexture(*entry->texture, basename, 0,
-                                               entry->has_arbitrary_mips);
+        m_texture_dumper.DumpTexture(*entry->texture, basename, 0, entry->has_arbitrary_mips);
       }
       if (g_ActiveConfig.bDumpMipmapTextures)
       {
         for (u32 level = 1; level < texLevels; ++level)
         {
-          VideoCommon::TextureUtils::DumpTexture(*entry->texture, basename, level,
-                                                 entry->has_arbitrary_mips);
+          m_texture_dumper.DumpTexture(*entry->texture, basename, level, entry->has_arbitrary_mips);
         }
       }
     }

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -27,6 +27,7 @@
 #include "VideoCommon/TextureConfig.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/TextureInfo.h"
+#include "VideoCommon/TextureUtils.h"
 #include "VideoCommon/VideoEvents.h"
 
 class AbstractFramebuffer;
@@ -460,6 +461,8 @@ private:
 
   Common::EventHook m_frame_event =
       AfterFrameEvent::Register([this](Core::System&) { OnFrameEnd(); }, "TextureCache");
+
+  VideoCommon::TextureUtils::TextureDumper m_texture_dumper;
 };
 
 extern std::unique_ptr<TextureCacheBase> g_texture_cache;

--- a/Source/Core/VideoCommon/TextureUtils.cpp
+++ b/Source/Core/VideoCommon/TextureUtils.cpp
@@ -5,37 +5,76 @@
 
 #include <fmt/format.h>
 
+#include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
+#include "Common/Logging/Log.h"
+
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
 
 #include "VideoCommon/AbstractTexture.h"
 
+namespace
+{
+std::string BuildDumpTextureFilename(std::string basename, u32 level, bool is_arbitrary)
+{
+  if (is_arbitrary)
+    basename += "_arb";
+
+  if (level > 0)
+    basename += fmt::format("_mip{}", level);
+
+  return basename;
+}
+}  // namespace
 namespace VideoCommon::TextureUtils
 {
 void DumpTexture(const ::AbstractTexture& texture, std::string basename, u32 level,
                  bool is_arbitrary)
 {
-  std::string szDir = File::GetUserPath(D_DUMPTEXTURES_IDX) + SConfig::GetInstance().GetGameID();
+  const std::string dump_dir =
+      File::GetUserPath(D_DUMPTEXTURES_IDX) + SConfig::GetInstance().GetGameID();
 
-  // make sure that the directory exists
-  if (!File::IsDirectory(szDir))
-    File::CreateDir(szDir);
+  if (!File::IsDirectory(dump_dir))
+    File::CreateDir(dump_dir);
 
-  if (is_arbitrary)
-  {
-    basename += "_arb";
-  }
+  const std::string name = BuildDumpTextureFilename(std::move(basename), level, is_arbitrary);
+  const std::string filename = fmt::format("{}/{}.png", dump_dir, name);
 
-  if (level > 0)
-  {
-    basename += fmt::format("_mip{}", level);
-  }
-
-  const std::string filename = fmt::format("{}/{}.png", szDir, basename);
   if (File::Exists(filename))
     return;
 
   texture.Save(filename, level, Config::Get(Config::GFX_TEXTURE_PNG_COMPRESSION_LEVEL));
+}
+
+void TextureDumper::DumpTexture(const ::AbstractTexture& texture, std::string basename, u32 level,
+                                bool is_arbitrary)
+{
+  const std::string dump_dir =
+      File::GetUserPath(D_DUMPTEXTURES_IDX) + SConfig::GetInstance().GetGameID();
+
+  if (m_dumped_textures.empty())
+  {
+    if (!File::IsDirectory(dump_dir))
+      File::CreateDir(dump_dir);
+
+    for (auto& filename : Common::DoFileSearch({dump_dir}, {".png"}, true))
+    {
+      std::string name;
+      SplitPath(filename, nullptr, &name, nullptr);
+      m_dumped_textures.insert(name);
+    }
+
+    NOTICE_LOG_FMT(VIDEO, "Found {} dumped textures that will not be re-dumped.",
+                   m_dumped_textures.size());
+  }
+
+  const std::string name = BuildDumpTextureFilename(std::move(basename), level, is_arbitrary);
+  const bool file_existed = !m_dumped_textures.insert(name).second;
+  if (file_existed)
+    return;
+
+  texture.Save(fmt::format("{}/{}.png", dump_dir, name), level,
+               Config::Get(Config::GFX_TEXTURE_PNG_COMPRESSION_LEVEL));
 }
 }  // namespace VideoCommon::TextureUtils

--- a/Source/Core/VideoCommon/TextureUtils.h
+++ b/Source/Core/VideoCommon/TextureUtils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_set>
 
 #include "Common/CommonTypes.h"
 
@@ -11,6 +12,18 @@ class AbstractTexture;
 
 namespace VideoCommon::TextureUtils
 {
+class TextureDumper
+{
+public:
+  // Only dumps if texture did not already exist anywhere within the dump-textures path.
+  void DumpTexture(const ::AbstractTexture& texture, std::string basename, u32 level,
+                   bool is_arbitrary);
+
+private:
+  std::unordered_set<std::string> m_dumped_textures;
+};
+
 void DumpTexture(const ::AbstractTexture& texture, std::string basename, u32 level,
                  bool is_arbitrary);
-}
+
+}  // namespace VideoCommon::TextureUtils


### PR DESCRIPTION
This allows users to place already handled textures in subdirectories and easily spot newly dumped textures for purposes of texture pack creation. They can relocate the files into subdirectories either during or outside of emulation.

Note that the directory is scanned upon first dump. Files moved completely outside of the texture dumping directory during emulation will not enable them to be re-dumped until the next emulation session as the scan is only done once.
This is a behavior change. Previously, `File::Exists` was used on every dump attempt.

Fixes: https://bugs.dolphin-emu.org/issues/4411

The feature is always enabled (as long as texture dumping is on).

I don't think this needs a setting to turn it on/off. It's minimally resource intensive compared to the actual texture dumping itself and I don't think anyone would ever specifically not desire this behavior.