### PR TITLE
Core: Remove RunAsCPUThread

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -515,7 +515,6 @@ Java_org_dolphinemu_dolphinemu_NativeLibrary_UpdateGCAdapterScanThread(JNIEnv*, 
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Initialize(JNIEnv*, jclass)
 {
-  // InitControllers ends up calling config code, and some config callbacks use RunAsCPUThread
   HostThreadLock guard;
 
   UICommon::CreateDirectories();

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -23,8 +23,9 @@
 
 namespace Core
 {
+class CPUThreadGuard;
 class System;
-}
+}  // namespace Core
 
 namespace OSD
 {
@@ -180,7 +181,7 @@ private:
   std::unique_ptr<DiscIO::Volume>& GetLoadingVolume() { return m_loading_volume; };
 
   void ActivateDeactivateAchievement(AchievementId id, bool enabled, bool unofficial, bool encore);
-  void GenerateRichPresence();
+  void GenerateRichPresence(const Core::CPUThreadGuard& guard);
 
   ResponseType AwardAchievement(AchievementId achievement_id);
   ResponseType SubmitLeaderboard(AchievementId leaderboard_id, int value);

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -94,13 +94,10 @@ enum class ConsoleType : u32
   ReservedTDEVSystem = 0x20000007,
 };
 
-// Run a function as the CPU thread. This is an RAII alternative to the RunAsCPUThread function.
-//
-// If constructed from the Host thread, the CPU thread is paused and the current thread temporarily
-// becomes the CPU thread.
-// If constructed from the CPU thread, nothing special happens.
-//
-// This should only be constructed from the CPU thread or the host thread.
+// This is an RAII alternative to using PauseAndLock. If constructed from the host thread, the CPU
+// thread is paused, and the current thread temporarily becomes the CPU thread. If constructed from
+// the CPU thread, nothing special happens. This should only be constructed on the CPU thread or the
+// host thread.
 //
 // Some functions use a parameter of this type to indicate that the function should only be called
 // from the CPU thread. If the parameter is a pointer, the function has a fallback for being called
@@ -157,15 +154,6 @@ void DisplayMessage(std::string message, int time_in_ms);
 
 void FrameUpdateOnCPUThread();
 void OnFrameEnd(Core::System& system);
-
-// Run a function as the CPU thread.
-//
-// If called from the Host thread, the CPU thread is paused and the current thread temporarily
-// becomes the CPU thread while running the function.
-// If called from the CPU thread, the function will be run directly.
-//
-// This should only be called from the CPU thread or the host thread.
-void RunAsCPUThread(std::function<void()> function);
 
 // Run a function on the CPU thread, asynchronously.
 // This is only valid to call from the host thread, since it uses PauseAndLock() internally.

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -50,7 +50,8 @@ void OnSourceChanged(unsigned int index, WiimoteSource source)
 
   WiimoteReal::HandleWiimoteSourceChange(index);
 
-  Core::RunAsCPUThread([index] { WiimoteCommon::UpdateSource(index); });
+  const Core::CPUThreadGuard guard(Core::System::GetInstance());
+  WiimoteCommon::UpdateSource(index);
 }
 
 void RefreshConfig()

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -112,9 +112,9 @@ static void RunWithGPUThreadInactive(std::function<void()> f)
   }
   else
   {
-    // If we reach here, we can call Core::PauseAndLock (which we do using RunAsCPUThread).
-
-    Core::RunAsCPUThread(std::move(f));
+    // If we reach here, we can call Core::PauseAndLock (which we do using a CPUThreadGuard).
+    const Core::CPUThreadGuard guard(Core::System::GetInstance());
+    f();
   }
 }
 

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -52,7 +52,7 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
   std::optional<bool> r = RunOnObject(QApplication::instance(), [&] {
     // If we were called from the CPU/GPU thread, set us as the CPU/GPU thread.
     // This information is used in order to avoid deadlocks when calling e.g.
-    // Host::SetRenderFocus or Core::RunAsCPUThread. (Host::SetRenderFocus
+    // Host::SetRenderFocus or Core::CPUThreadGuard. (Host::SetRenderFocus
     // can get called automatically when a dialog steals the focus.)
 
     Common::ScopeGuard cpu_scope_guard(&Core::UndeclareAsCPUThread);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1932,12 +1932,13 @@ void MainWindow::OnStopRecording()
 
 void MainWindow::OnExportRecording()
 {
-  Core::RunAsCPUThread([this] {
-    QString dtm_file = DolphinFileDialog::getSaveFileName(
-        this, tr("Save Recording File As"), QString(), tr("Dolphin TAS Movies (*.dtm)"));
-    if (!dtm_file.isEmpty())
-      Core::System::GetInstance().GetMovie().SaveRecording(dtm_file.toStdString());
-  });
+  auto& system = Core::System::GetInstance();
+  const Core::CPUThreadGuard guard(system);
+
+  QString dtm_file = DolphinFileDialog::getSaveFileName(
+      this, tr("Save Recording File As"), QString(), tr("Dolphin TAS Movies (*.dtm)"));
+  if (!dtm_file.isEmpty())
+    system.GetMovie().SaveRecording(dtm_file.toStdString());
 }
 
 void MainWindow::OnActivateChat()
@@ -1990,13 +1991,12 @@ void MainWindow::ShowTASInput()
 
 void MainWindow::OnConnectWiiRemote(int id)
 {
-  Core::RunAsCPUThread([&] {
-    if (const auto bt = WiiUtils::GetBluetoothEmuDevice())
-    {
-      const auto wm = bt->AccessWiimoteByIndex(id);
-      wm->Activate(!wm->IsConnected());
-    }
-  });
+  const Core::CPUThreadGuard guard(Core::System::GetInstance());
+  if (const auto bt = WiiUtils::GetBluetoothEmuDevice())
+  {
+    const auto wm = bt->AccessWiimoteByIndex(id);
+    wm->Activate(!wm->IsConnected());
+  }
 }
 
 #ifdef USE_RETRO_ACHIEVEMENTS


### PR DESCRIPTION
Part 2b of an effort to remove global state from one of the biggest offenders.

It's a fine function, but CPUThreadGuard is more vogue. Also, its potential for being confused with RunOnCPUThread will not be missed. If `Core::RunAsCPUThread` should not be removed for some reason, let me know.