### PR TITLE
DolphinQt Settings: Signal Debug Font By Const Reference

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -172,9 +172,8 @@ CodeViewWidget::CodeViewWidget()
 
   connect(this, &CodeViewWidget::customContextMenuRequested, this, &CodeViewWidget::OnContextMenu);
   connect(this, &CodeViewWidget::itemSelectionChanged, this, &CodeViewWidget::OnSelectionChanged);
-  connect(&Settings::Instance(), &Settings::DebugFontChanged, this, &QWidget::setFont);
   connect(&Settings::Instance(), &Settings::DebugFontChanged, this,
-          &CodeViewWidget::FontBasedSizing);
+          &CodeViewWidget::OnDebugFontChanged);
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this] {
     m_address = m_system.GetPPCState().pc;
@@ -208,7 +207,7 @@ void CodeViewWidget::FontBasedSizing()
   // just text width is too small with some fonts, so increase by a bit
   constexpr int extra_text_width = 8;
 
-  const QFontMetrics fm(Settings::Instance().GetDebugFont());
+  const QFontMetrics fm(font());
 
   const int rowh = fm.height() + 1;
   verticalHeader()->setMaximumSectionSize(rowh);
@@ -743,6 +742,12 @@ void CodeViewWidget::AutoStep(CodeTrace::AutoStop option)
     msgbox.exec();
 
   } while (msgbox.clickedButton() == (QAbstractButton*)run_button);
+}
+
+void CodeViewWidget::OnDebugFontChanged(const QFont& font)
+{
+  setFont(font);
+  FontBasedSizing();
 }
 
 void CodeViewWidget::OnCopyAddress()

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/Debugger/CodeTrace.h"
 
+class QFont;
 class QKeyEvent;
 class QMouseEvent;
 class QResizeEvent;
@@ -78,6 +79,7 @@ private:
   void OnContextMenu();
 
   void AutoStep(CodeTrace::AutoStop option = CodeTrace::AutoStop::Always);
+  void OnDebugFontChanged(const QFont& font);
   void OnFollowBranch();
   void OnCopyAddress();
   void OnCopyTargetAddress();

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -202,18 +202,18 @@ MemoryViewWidget::MemoryViewWidget(Core::System& system, QWidget* parent)
   connect(&Settings::Instance(), &Settings::ThemeChanged, this, &MemoryViewWidget::Update);
 
   // Also calls create table.
-  UpdateFont();
+  UpdateFont(Settings::Instance().GetDebugFont());
 }
 
-void MemoryViewWidget::UpdateFont()
+void MemoryViewWidget::UpdateFont(const QFont& font)
 {
-  const QFontMetrics fm(Settings::Instance().GetDebugFont());
+  const QFontMetrics fm(font);
   m_font_vspace = fm.lineSpacing() + 4;
   // BoundingRect is too unpredictable, a custom one would be needed for each view type. Different
   // fonts have wildly different spacing between two characters and horizontalAdvance includes
   // spacing.
   m_font_width = fm.horizontalAdvance(QLatin1Char('0'));
-  m_table->setFont(Settings::Instance().GetDebugFont());
+  m_table->setFont(font);
 
   CreateTable();
 }

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -7,6 +7,7 @@
 
 #include "Common/CommonTypes.h"
 
+class QFont;
 class QPoint;
 class QScrollBar;
 
@@ -57,7 +58,7 @@ public:
 
   void CreateTable();
   void Update();
-  void UpdateFont();
+  void UpdateFont(const QFont& font);
   void ToggleBreakpoint(u32 addr, bool row);
 
   std::vector<u8> ConvertTextToBytes(Type type, QStringView input_text) const;

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -106,7 +106,7 @@ void RegisterWidget::ConnectWidgets()
   connect(m_table, &QTableWidget::customContextMenuRequested, this,
           &RegisterWidget::ShowContextMenu);
   connect(m_table, &QTableWidget::itemChanged, this, &RegisterWidget::OnItemChanged);
-  connect(&Settings::Instance(), &Settings::DebugFontChanged, m_table, &QWidget::setFont);
+  connect(&Settings::Instance(), &Settings::DebugFontChanged, m_table, &RegisterWidget::setFont);
 }
 
 void RegisterWidget::OnItemChanged(QTableWidgetItem* item)

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -51,13 +51,9 @@ FIFOAnalyzer::FIFOAnalyzer(FifoPlayer& fifo_player) : m_fifo_player(fifo_player)
   m_search_splitter->restoreState(
       settings.value(QStringLiteral("fifoanalyzer/searchsplitter")).toByteArray());
 
-  m_detail_list->setFont(Settings::Instance().GetDebugFont());
-  m_entry_detail_browser->setFont(Settings::Instance().GetDebugFont());
-
-  connect(&Settings::Instance(), &Settings::DebugFontChanged, this, [this] {
-    m_detail_list->setFont(Settings::Instance().GetDebugFont());
-    m_entry_detail_browser->setFont(Settings::Instance().GetDebugFont());
-  });
+  OnDebugFontChanged(Settings::Instance().GetDebugFont());
+  connect(&Settings::Instance(), &Settings::DebugFontChanged, this,
+          &FIFOAnalyzer::OnDebugFontChanged);
 }
 
 FIFOAnalyzer::~FIFOAnalyzer()
@@ -778,4 +774,10 @@ void FIFOAnalyzer::UpdateDescription()
   OpcodeDecoder::RunCommand(&fifo_frame.fifoData[object_start + entry_start],
                             object_size - entry_start, callback);
   m_entry_detail_browser->setText(callback.text);
+}
+
+void FIFOAnalyzer::OnDebugFontChanged(const QFont& font)
+{
+  m_detail_list->setFont(font);
+  m_entry_detail_browser->setFont(font);
 }

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.h
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.h
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 
 class FifoPlayer;
+class QFont;
 class QGroupBox;
 class QLabel;
 class QLineEdit;
@@ -42,6 +43,8 @@ private:
   void UpdateTree();
   void UpdateDetails();
   void UpdateDescription();
+
+  void OnDebugFontChanged(const QFont& font);
 
   FifoPlayer& m_fifo_player;
 

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -217,7 +217,7 @@ signals:
   void JITVisibilityChanged(bool visible);
   void AssemblerVisibilityChanged(bool visible);
   void DebugModeToggled(bool enabled);
-  void DebugFontChanged(QFont font);
+  void DebugFontChanged(const QFont& font);
   void AutoUpdateTrackChanged(const QString& mode);
   void FallbackRegionChanged(const DiscIO::Region& region);
   void AnalyticsToggled(bool enabled);


### PR DESCRIPTION
As small as it may be, this is an unnecessary copy.