### PR TITLE
DSPHLE: Implement 2024 libasnd uCodes

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
@@ -64,7 +64,8 @@ bool ASndUCode::SwapLeftRight() const
 bool ASndUCode::UseNewFlagMasks() const
 {
   return m_crc == HASH_2011 || m_crc == HASH_2020 || m_crc == HASH_2020_PAD ||
-         m_crc == HASH_DESERT_BUS_2011 || m_crc == HASH_DESERT_BUS_2012;
+         m_crc == HASH_DESERT_BUS_2011 || m_crc == HASH_DESERT_BUS_2012 || m_crc == HASH_2024 ||
+         m_crc == HASH_2024_PAD;
 }
 
 ASndUCode::ASndUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
@@ -403,7 +404,7 @@ void ASndUCode::DoMixing(u32 return_mail)
         if (SwapLeftRight())
         {
           // Most versions of the ASnd ucode have the right channel come before the left channel.
-          // The Desert Bus versions swapped the left and right input channels so that left
+          // The Desert Bus and 2024 versions swapped the left and right input channels so that left
           // comes first, and then right, matching mp3/ogg files.
           std::swap(new_r, new_l);
         }

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.cpp
@@ -57,7 +57,8 @@ constexpr u32 SAMPLE_RATE = 48000;
 
 bool ASndUCode::SwapLeftRight() const
 {
-  return m_crc == HASH_DESERT_BUS_2011 || m_crc == HASH_DESERT_BUS_2012;
+  return m_crc == HASH_2008 || m_crc == HASH_2009 || m_crc == HASH_2011 || m_crc == HASH_2020 ||
+         m_crc == HASH_2020_PAD;
 }
 
 bool ASndUCode::UseNewFlagMasks() const
@@ -398,11 +399,12 @@ void ASndUCode::DoMixing(u32 return_mail)
         }
         // Both paths jmpr $AR3, which is an index into sample_selector
 
-        auto [new_r, new_l] = (this->*sample_function)();
+        auto [new_l, new_r] = (this->*sample_function)();
         if (SwapLeftRight())
         {
+          // Most versions of the ASnd ucode have the right channel come before the left channel.
           // The Desert Bus versions swapped the left and right input channels so that left
-          // comes first, and then right. Before, right came before left.
+          // comes first, and then right, matching mp3/ogg files.
           std::swap(new_r, new_l);
         }
         // out_samp: "multiply sample x volume" - left is put in $ax0.h, right is put in $ax1.h

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
@@ -53,7 +53,8 @@ public:
   static constexpr u32 HASH_2020_PAD = 0xbad876ef;
   // Variant used in Desert Bus v1.04 - this is based off of the code in libogc (as it existed in
   // 2011, even though that code only became used in 2020), but the left and right channels are
-  // swapped. Padded to 0x0620 bytes.
+  // swapped (with the left channel coming before the right channel, which is the the conventional
+  // behavior). Padded to 0x0620 bytes.
   static constexpr u32 HASH_DESERT_BUS_2011 = 0xfa9c576f;
   // Variant used in Desert Bus v1.05 - this is the same as the previous version, except 4 junk
   // instructions were added to the start, which do not change behavior in any way. Padded to 0x0620

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ASnd.h
@@ -60,6 +60,16 @@ public:
   // instructions were added to the start, which do not change behavior in any way. Padded to 0x0620
   // bytes.
   static constexpr u32 HASH_DESERT_BUS_2012 = 0x614dd145;
+  // March 22, 2024 version (0x0606 bytes) - libogc fixed left and right channels being reversed,
+  // which apparently has been the case from the start but was not obvious in earlier testing
+  // because of the oggplayer sample using a mono sound file.
+  // https://github.com/devkitPro/libogc/commit/a0b4b5680944ee7c2ae1b7af63a721623c1a6b69
+  static constexpr u32 HASH_2024 = 0x5dbf8bf1;
+  // March 22, 2024 version (padded to 0x0620 bytes) - same as above, but padded as it's used by
+  // libogc2 and libogc-rice.
+  // https://github.com/extremscorner/libogc2/commit/f3fd10635d4b3fbc6ee03cec335eeb2a2237fd56
+  // https://github.com/extremscorner/libogc-rice/commit/5ebbf8b96d7433bc2af9e882f730e67a5eb20f00
+  static constexpr u32 HASH_2024_PAD = 0x373a950e;
 
 private:
   void DMAInVoiceData();

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -293,6 +293,8 @@ std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
   case ASndUCode::HASH_2020_PAD:
   case ASndUCode::HASH_DESERT_BUS_2011:
   case ASndUCode::HASH_DESERT_BUS_2012:
+  case ASndUCode::HASH_2024:
+  case ASndUCode::HASH_2024_PAD:
     INFO_LOG_FMT(DSPHLE, "CRC {:08x}: ASnd chosen (Homebrew)", crc);
     return std::make_unique<ASndUCode>(dsphle, crc);
 


### PR DESCRIPTION
@Wohlstand realized that the left and right channels are reversed by the asnd uCode, observable with e.g. a stereo file played with the oggplayer example. (But the oggplayer uses a mono file by default, where this is not observable). See devkitPro/libogc#169. This was fixed in devkitPro/libogc#170.

Dolphin already had those channels swapped (matching the behavior of the previous uCodes), and also already had a variant that swapped the channels back (#11354, from the desert bus homebrew, which has other weird quirks).

[asnd_2024_versions.zip](https://github.com/dolphin-emu/dolphin/files/14736472/asnd_2024_versions.zip)

```
Hashes of 2024/DSP_UC_5DBF8BF1.bin: ector 5dbf8bf1 crc ce5e93e7 adler 490ec76d 0606 bytes (0303 words)
Hashes of 2024/DSP_UC_373A950E.bin: ector 373a950e crc 4548a0e4 adler c87ac78b 0620 bytes (0310 words)
```