### PR TITLE
Add tapserver BBA and Modem Adapter UI options to Android

### DIFF
--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -103,12 +103,16 @@
         <item>@string/device_dummy</item>
         <item>@string/broadband_adapter_xlink</item>
         <item>@string/broadband_adapter_hle</item>
+        <item>@string/broadband_adapter_tapserver</item>
+        <item>@string/modem_adapter_tapserver</item>
     </string-array>
     <integer-array name="serialPort1DeviceValues">
         <item>255</item>
         <item>0</item>
         <item>10</item>
         <item>12</item>
+        <item>11</item>
+        <item>13</item>
     </integer-array>
 
     <!-- Wii System Languages -->

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -681,6 +681,8 @@ It can efficiently compress both junk data and encrypted Wii data.
     <!-- Slot SP1 Device selection -->
     <string name="broadband_adapter_xlink">Broadband Adapter (XLink Kai)</string>
     <string name="broadband_adapter_hle">Broadband Adapter (HLE)</string>
+    <string name="broadband_adapter_tapserver">Broadband Adapter (tapserver)</string>
+    <string name="modem_adapter_tapserver">Modem Adapter (tapserver)</string>
 
     <!-- Sound Mode -->
     <string name="sound_mode_mono">Mono</string>


### PR DESCRIPTION
This PR simply exposes the tapserver options in Serial Port 1 on Android. They already exist and work, but are not selectable.

I've tested the tapserver options myself with Phantasy Star Online Episode I & II and they work fine.