### PR TITLE
Use Hybrid Log Gamma in PerceptualHDR

### DIFF
--- a/Data/Sys/Shaders/PerceptualHDR.glsl
+++ b/Data/Sys/Shaders/PerceptualHDR.glsl
@@ -120,7 +120,7 @@ void main()
     // For more information, see this desmos demonstrating this scaling process:
     // https://www.desmos.com/calculator/syjyrjsj5c
     const float luminance = ictcp_color.x;
-    ictcp_color *= HLG_f(pow(AMPLIFICATION, luminance));
+    ictcp_color *= pow(HLG_f(AMPLIFICATION), luminance);
 
     // Convert back to Linear RGB and output the color to the display.
     // We use hdr_paper_white to renormalize the color to the comfortable

--- a/Data/Sys/Shaders/PerceptualHDR.glsl
+++ b/Data/Sys/Shaders/PerceptualHDR.glsl
@@ -5,7 +5,7 @@
 GUIName = Amplificiation
 OptionName = AMPLIFICATION
 MinValue = 1.0
-MaxValue = 10.0
+MaxValue = 6.0
 StepAmount = 0.25
 DefaultValue = 2.5
 
@@ -119,8 +119,8 @@ void main()
     //
     // For more information, see this desmos demonstrating this scaling process:
     // https://www.desmos.com/calculator/syjyrjsj5c
-    const float luminance = ictcp_color.x;
-    ictcp_color *= pow(HLG_f(AMPLIFICATION), luminance);
+    float exposure = length(ictcp_color.xyz);
+    ictcp_color *= pow(HLG_f(AMPLIFICATION), exposure);
 
     // Convert back to Linear RGB and output the color to the display.
     // We use hdr_paper_white to renormalize the color to the comfortable

--- a/Data/Sys/Shaders/PerceptualHDR.glsl
+++ b/Data/Sys/Shaders/PerceptualHDR.glsl
@@ -5,7 +5,7 @@
 GUIName = Amplificiation
 OptionName = AMPLIFICATION
 MinValue = 1.0
-MaxValue = 6.0
+MaxValue = 10.0
 StepAmount = 0.25
 DefaultValue = 2.5
 


### PR DESCRIPTION
This is a rather Niche, but fairly large improvement to the PerceptualHDR Shader.

Turns out that the HLG (Hybrid Log Gamma) response function is becoming more popular, and people are phasing out the PQ EOTF function. I decided to try using the HLG function in the perceptual shader, and it tracks a lot better with what the shader is supposed too look like. 

Before Graph:
<img width="100" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/718cc661-4e4e-46f5-8905-646877f6a165">

After Graph:
<img width="100" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/d6f9a4d9-b201-4692-bc4d-2047a3387818">

Apparently when using PQ's EOTF, the derivative near zero isn't even 1. I did not really account for this. But when using HLG, it tracks a lot better:

Try to look at the dark areas, it will show you why this HLG is superior:

**SDR:**
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/5d479efb-2a5d-4666-b92a-546c1e05f67e">

**HLG:**
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/0af298c2-d4f7-42b4-b5aa-d57909664138">

**EOTF:**
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/7f03cfe7-218b-4f53-8cae-43296b9c2f73">

It's hard to tell because these are not HDR screenshots, however it is apparent when viewing that when using the HLG transfer function, the amount of alteration to dark colors is reduced, increasing the perceived dynamic range. This is quite a large improvement, so hopefully this can get merged.