### PR TITLE
Core::GetState: Avoid Global System Accessor

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -283,7 +283,7 @@ JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunnin
 JNIEXPORT jboolean JNICALL
 Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunningAndUnpaused(JNIEnv*, jclass)
 {
-  return static_cast<jboolean>(Core::GetState() == Core::State::Running);
+  return static_cast<jboolean>(Core::GetState(Core::System::GetInstance()) == Core::State::Running);
 }
 
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetVersionString(JNIEnv* env,
@@ -458,7 +458,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SurfaceDestr
       host_identity_guard.Lock();
     }
 
-    if (Core::GetState() == Core::State::Running)
+    if (Core::GetState(Core::System::GetInstance()) == Core::State::Running)
       Core::SetState(Core::State::Paused);
   }
 
@@ -572,7 +572,7 @@ static void Run(JNIEnv* env, std::unique_ptr<BootParameters>&& boot, bool riivol
   if (BootManager::BootCore(Core::System::GetInstance(), std::move(boot), wsi))
   {
     static constexpr int WAIT_STEP = 25;
-    while (Core::GetState() == Core::State::Starting)
+    while (Core::GetState(Core::System::GetInstance()) == Core::State::Starting)
       std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_STEP));
   }
 

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -211,12 +211,13 @@ Cheats::NewSearch(const Core::CPUThreadGuard& guard,
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
 #endif  // USE_RETRO_ACHIEVEMENTS
+  auto& system = guard.GetSystem();
   std::vector<Cheats::SearchResult<T>> results;
-  const Core::State core_state = Core::GetState();
+  const Core::State core_state = Core::GetState(system);
   if (core_state != Core::State::Running && core_state != Core::State::Paused)
     return Cheats::SearchErrorCode::NoEmulationActive;
 
-  const auto& ppc_state = guard.GetSystem().GetPPCState();
+  const auto& ppc_state = system.GetPPCState();
   if (address_space == PowerPC::RequestedAddressSpace::Virtual && !ppc_state.msr.DR)
     return Cheats::SearchErrorCode::VirtualAddressesCurrentlyNotAccessible;
 
@@ -265,12 +266,13 @@ Cheats::NextSearch(const Core::CPUThreadGuard& guard,
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
 #endif  // USE_RETRO_ACHIEVEMENTS
+  auto& system = guard.GetSystem();
   std::vector<Cheats::SearchResult<T>> results;
-  const Core::State core_state = Core::GetState();
+  const Core::State core_state = Core::GetState(system);
   if (core_state != Core::State::Running && core_state != Core::State::Paused)
     return Cheats::SearchErrorCode::NoEmulationActive;
 
-  const auto& ppc_state = guard.GetSystem().GetPPCState();
+  const auto& ppc_state = system.GetPPCState();
   if (address_space == PowerPC::RequestedAddressSpace::Virtual && !ppc_state.msr.DR)
     return Cheats::SearchErrorCode::VirtualAddressesCurrentlyNotAccessible;
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -144,7 +144,7 @@ bool WantsDeterminism();
 
 // [NOT THREADSAFE] For use by Host only
 void SetState(State state, bool report_state_change = true);
-State GetState();
+State GetState(Core::System& system);
 
 void SaveScreenShot();
 void SaveScreenShot(std::string_view name);
@@ -185,7 +185,7 @@ void QueueHostJob(std::function<void(Core::System&)> job, bool run_during_stop =
 // WMUserJobDispatch will be sent when something is added to the queue.
 void HostDispatchJobs(Core::System& system);
 
-void DoFrameStep();
+void DoFrameStep(Core::System& system);
 
 void UpdateInputGate(bool require_focus, bool require_full_focus = false);
 

--- a/Source/Core/Core/Debugger/BranchWatch.cpp
+++ b/Source/Core/Core/Debugger/BranchWatch.cpp
@@ -198,7 +198,7 @@ void BranchWatch::IsolateNotExecuted(const CPUThreadGuard&)
 
 void BranchWatch::IsolateWasOverwritten(const CPUThreadGuard& guard)
 {
-  if (Core::GetState() == Core::State::Uninitialized)
+  if (Core::GetState(guard.GetSystem()) == Core::State::Uninitialized)
   {
     ASSERT_MSG(CORE, false, "Core is uninitialized.");
     return;
@@ -246,7 +246,7 @@ void BranchWatch::IsolateWasOverwritten(const CPUThreadGuard& guard)
 
 void BranchWatch::IsolateNotOverwritten(const CPUThreadGuard& guard)
 {
-  if (Core::GetState() == Core::State::Uninitialized)
+  if (Core::GetState(guard.GetSystem()) == Core::State::Uninitialized)
   {
     ASSERT_MSG(CORE, false, "Core is uninitialized.");
     return;

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -720,11 +720,14 @@ void WiimoteScanner::ThreadFunc()
     // If we don't want Wiimotes in ControllerInterface, we may not need them at all.
     if (!Config::Get(Config::MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE))
     {
+      auto& system = Core::System::GetInstance();
       // We don't want any remotes in passthrough mode or running in GC mode.
-      const bool core_running = Core::GetState() != Core::State::Uninitialized;
+      const bool core_running = Core::GetState(system) != Core::State::Uninitialized;
       if (Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_ENABLED) ||
-          (core_running && !Core::System::GetInstance().IsWii()))
+          (core_running && !system.IsWii()))
+      {
         continue;
+      }
 
       // We don't want any remotes if we already connected everything we need.
       if (0 == CalculateWantedWiimotes() && 0 == CalculateWantedBB())

--- a/Source/Core/DolphinNoGUI/PlatformMacos.mm
+++ b/Source/Core/DolphinNoGUI/PlatformMacos.mm
@@ -42,7 +42,8 @@
 
 - (void)togglePause
 {
-  if (Core::GetState() == Core::State::Running)
+  auto& system = Core::System::GetInstance();
+  if (Core::GetState(system) == Core::State::Running)
     Core::SetState(Core::State::Paused);
   else
     Core::SetState(Core::State::Running);
@@ -263,8 +264,10 @@ void PlatformMacOS::ProcessEvents()
     {
       m_window_focus = true;
       if (Config::Get(Config::MAIN_SHOW_CURSOR) == Config::ShowCursor::Never &&
-          Core::GetState() != Core::State::Paused)
+          Core::GetState(Core::System::GetInstance()) != Core::State::Paused)
+      {
         [NSCursor unhide];
+      }
     }
     else
     {

--- a/Source/Core/DolphinNoGUI/PlatformX11.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformX11.cpp
@@ -199,7 +199,7 @@ void PlatformX11::ProcessEvents()
       }
       else if (key == XK_F10)
       {
-        if (Core::GetState() == Core::State::Running)
+        if (Core::GetState(Core::System::GetInstance()) == Core::State::Running)
         {
           if (Config::Get(Config::MAIN_SHOW_CURSOR) == Config::ShowCursor::Never)
             XUndefineCursor(m_display, m_window);
@@ -245,8 +245,10 @@ void PlatformX11::ProcessEvents()
     {
       m_window_focus = true;
       if (Config::Get(Config::MAIN_SHOW_CURSOR) == Config::ShowCursor::Never &&
-          Core::GetState() != Core::State::Paused)
+          Core::GetState(Core::System::GetInstance()) != Core::State::Paused)
+      {
         XDefineCursor(m_display, m_window, m_blank_cursor);
+      }
     }
     break;
     case FocusOut:

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -197,10 +197,11 @@ void AchievementSettingsWidget::LoadSettings()
 
   SignalBlocking(m_common_hardcore_enabled_input)
       ->setChecked(Config::Get(Config::RA_HARDCORE_ENABLED));
+  auto& system = Core::System::GetInstance();
   SignalBlocking(m_common_hardcore_enabled_input)
-      ->setEnabled(enabled && (hardcore_enabled ||
-                               (Core::GetState() == Core::State::Uninitialized &&
-                                !Core::System::GetInstance().GetMovie().IsPlayingInput())));
+      ->setEnabled(enabled &&
+                   (hardcore_enabled || (Core::GetState(system) == Core::State::Uninitialized &&
+                                         !system.GetMovie().IsPlayingInput())));
 
   SignalBlocking(m_common_progress_enabled_input)
       ->setChecked(Config::Get(Config::RA_PROGRESS_ENABLED));
@@ -294,7 +295,7 @@ void AchievementSettingsWidget::ToggleHardcore()
     Settings::Instance().SetCheatsEnabled(false);
     Settings::Instance().SetDebugModeEnabled(false);
   }
-  emit Settings::Instance().EmulationStateChanged(Core::GetState());
+  emit Settings::Instance().EmulationStateChanged(Core::GetState(Core::System::GetInstance()));
 }
 
 void AchievementSettingsWidget::ToggleProgress()

--- a/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
@@ -158,7 +158,8 @@ void CheatSearchFactoryWidget::OnNewSearchClicked()
   PowerPC::RequestedAddressSpace address_space;
   if (m_standard_address_space->isChecked())
   {
-    const Core::State core_state = Core::GetState();
+    auto& system = Core::System::GetInstance();
+    const Core::State core_state = Core::GetState(system);
     if (core_state != Core::State::Running && core_state != Core::State::Paused)
     {
       ModalMessageBox::warning(
@@ -167,7 +168,6 @@ void CheatSearchFactoryWidget::OnNewSearchClicked()
       return;
     }
 
-    auto& system = Core::System::GetInstance();
     auto& memory = system.GetMemory();
     memory_ranges.emplace_back(0x80000000, memory.GetRamSizeReal());
     if (system.IsWii())

--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -520,7 +520,7 @@ void CheatSearchWidget::OnDisplayHexCheckboxStateChanged()
     return;
 
   // If the game is running CheatsManager::OnFrameEnd will update values automatically.
-  if (Core::GetState() != Core::State::Running)
+  if (Core::GetState(m_system) != Core::State::Running)
     UpdateTableAllCurrentValues(UpdateSource::User);
 }
 

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -36,7 +36,7 @@ CheatsManager::CheatsManager(Core::System& system, QWidget* parent)
   CreateWidgets();
   ConnectWidgets();
 
-  RefreshCodeTabs(Core::GetState(), true);
+  RefreshCodeTabs(Core::GetState(m_system), true);
 
   auto& settings = Settings::GetQSettings();
   restoreGeometry(settings.value(QStringLiteral("cheatsmanager/geometry")).toByteArray());

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -66,10 +66,10 @@ GamecubeControllersWidget::GamecubeControllersWidget(QWidget* parent) : QWidget(
   ConnectWidgets();
 
   connect(&Settings::Instance(), &Settings::ConfigChanged, this,
-          [this] { LoadSettings(Core::GetState()); });
+          [this] { LoadSettings(Core::GetState(Core::System::GetInstance())); });
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           [this](Core::State state) { LoadSettings(state); });
-  LoadSettings(Core::GetState());
+  LoadSettings(Core::GetState(Core::System::GetInstance()));
 }
 
 void GamecubeControllersWidget::CreateLayout()

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -14,6 +14,7 @@
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/System.h"
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
@@ -42,7 +43,8 @@ AdvancedWidget::AdvancedWidget(GraphicsWindow* parent)
   });
 
   OnBackendChanged();
-  OnEmulationStateChanged(Core::GetState() != Core::State::Uninitialized);
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()) !=
+                          Core::State::Uninitialized);
 }
 
 void AdvancedWidget::CreateWidgets()

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -17,6 +17,7 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/System.h"
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
@@ -43,7 +44,8 @@ GeneralWidget::GeneralWidget(GraphicsWindow* parent)
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     OnEmulationStateChanged(state != Core::State::Uninitialized);
   });
-  OnEmulationStateChanged(Core::GetState() != Core::State::Uninitialized);
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()) !=
+                          Core::State::Uninitialized);
 }
 
 void GeneralWidget::CreateWidgets()

--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
@@ -18,6 +18,7 @@
 #include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/System.h"
 #include "DolphinQt/Config/GraphicsModWarningWidget.h"
 #include "DolphinQt/QtUtils/ClearLayoutRecursively.h"
 #include "DolphinQt/Settings.h"
@@ -28,7 +29,7 @@
 GraphicsModListWidget::GraphicsModListWidget(const UICommon::GameFile& game)
     : m_game_id(game.GetGameID()), m_mod_group(m_game_id)
 {
-  CalculateGameRunning(Core::GetState());
+  CalculateGameRunning(Core::GetState(Core::System::GetInstance()));
   if (m_loaded_game_is_running && g_Config.graphics_mod_config)
   {
     m_mod_group.SetChangeCount(g_Config.graphics_mod_config->GetChangeCount());

--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -17,6 +17,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Core/Core.h"
+#include "Core/System.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeVerifier.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
@@ -49,7 +50,7 @@ VerifyWidget::VerifyWidget(std::shared_ptr<DiscIO::Volume> volume) : m_volume(st
 
 void VerifyWidget::OnEmulationStateChanged()
 {
-  const bool running = Core::GetState() != Core::State::Uninitialized;
+  const bool running = Core::GetState(Core::System::GetInstance()) != Core::State::Uninitialized;
 
   // Verifying a Wii game while emulation is running doesn't work correctly
   // due to verification of a Wii game creating an instance of IOS

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -46,10 +46,10 @@ WiimoteControllersWidget::WiimoteControllersWidget(QWidget* parent) : QWidget(pa
   ConnectWidgets();
 
   connect(&Settings::Instance(), &Settings::ConfigChanged, this,
-          [this] { LoadSettings(Core::GetState()); });
+          [this] { LoadSettings(Core::GetState(Core::System::GetInstance())); });
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           [this](Core::State state) { LoadSettings(state); });
-  LoadSettings(Core::GetState());
+  LoadSettings(Core::GetState(Core::System::GetInstance()));
 }
 
 void WiimoteControllersWidget::UpdateBluetoothAvailableStatus()
@@ -173,16 +173,16 @@ void WiimoteControllersWidget::ConnectWidgets()
 {
   connect(m_wiimote_passthrough, &QRadioButton::toggled, this, [this] {
     SaveSettings();
-    LoadSettings(Core::GetState());
+    LoadSettings(Core::GetState(Core::System::GetInstance()));
   });
   connect(m_wiimote_ciface, &QCheckBox::toggled, this, [this] {
     SaveSettings();
-    LoadSettings(Core::GetState());
+    LoadSettings(Core::GetState(Core::System::GetInstance()));
     WiimoteReal::HandleWiimotesInControllerInterfaceSettingChange();
   });
   connect(m_wiimote_continuous_scanning, &QCheckBox::toggled, this, [this] {
     SaveSettings();
-    LoadSettings(Core::GetState());
+    LoadSettings(Core::GetState(Core::System::GetInstance()));
   });
 
   connect(m_wiimote_real_balance_board, &QCheckBox::toggled, this,
@@ -200,7 +200,7 @@ void WiimoteControllersWidget::ConnectWidgets()
   {
     connect(m_wiimote_boxes[i], &QComboBox::currentIndexChanged, this, [this] {
       SaveSettings();
-      LoadSettings(Core::GetState());
+      LoadSettings(Core::GetState(Core::System::GetInstance()));
     });
     connect(m_wiimote_buttons[i], &QPushButton::clicked, this,
             [this, i] { OnWiimoteConfigure(i); });

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -531,7 +531,7 @@ void BranchWatchDialog::hideEvent(QHideEvent* event)
 
 void BranchWatchDialog::showEvent(QShowEvent* event)
 {
-  if (TimerCondition(m_branch_watch, Core::GetState()))
+  if (TimerCondition(m_branch_watch, Core::GetState(m_system)))
     m_timer->start(BRANCH_WATCH_TOOL_TIMER_DELAY_MS);
   QDialog::showEvent(event);
 }
@@ -544,7 +544,7 @@ void BranchWatchDialog::OnStartPause(bool checked)
     m_btn_start_pause->setText(tr("Pause Branch Watch"));
     // Restart the timer if the situation calls for it, but always turn off single-shot.
     m_timer->setSingleShot(false);
-    if (Core::GetState() > Core::State::Paused)
+    if (Core::GetState(m_system) > Core::State::Paused)
       m_timer->start(BRANCH_WATCH_TOOL_TIMER_DELAY_MS);
   }
   else
@@ -552,7 +552,7 @@ void BranchWatchDialog::OnStartPause(bool checked)
     m_branch_watch.Pause();
     m_btn_start_pause->setText(tr("Start Branch Watch"));
     // Schedule one last update in the future in case Branch Watch is in the middle of a hit.
-    if (Core::GetState() > Core::State::Paused)
+    if (Core::GetState(m_system) > Core::State::Paused)
       m_timer->setInterval(BRANCH_WATCH_TOOL_TIMER_PAUSE_ONESHOT_MS);
     m_timer->setSingleShot(true);
   }
@@ -645,7 +645,7 @@ void BranchWatchDialog::OnCodePathNotTaken()
 
 void BranchWatchDialog::OnBranchWasOverwritten()
 {
-  if (Core::GetState() == Core::State::Uninitialized)
+  if (Core::GetState(m_system) == Core::State::Uninitialized)
   {
     ModalMessageBox::warning(this, tr("Error"), tr("Core is uninitialized."));
     return;
@@ -660,7 +660,7 @@ void BranchWatchDialog::OnBranchWasOverwritten()
 
 void BranchWatchDialog::OnBranchNotOverwritten()
 {
-  if (Core::GetState() == Core::State::Uninitialized)
+  if (Core::GetState(m_system) == Core::State::Uninitialized)
   {
     ModalMessageBox::warning(this, tr("Error"), tr("Core is uninitialized."));
     return;
@@ -810,7 +810,7 @@ void BranchWatchDialog::OnTableContextMenu(const QPoint& pos)
   case Column::Origin:
   {
     QAction* const action = menu->addAction(tr("Insert &NOP"));
-    if (Core::GetState() != Core::State::Uninitialized)
+    if (Core::GetState(m_system) != Core::State::Uninitialized)
       connect(action, &QAction::triggered,
               [this, index_list]() { OnTableSetNOP(std::move(index_list)); });
     else
@@ -824,7 +824,7 @@ void BranchWatchDialog::OnTableContextMenu(const QPoint& pos)
   {
     QAction* const action = menu->addAction(tr("Insert &BLR"));
     const bool enable_action =
-        Core::GetState() != Core::State::Uninitialized &&
+        Core::GetState(m_system) != Core::State::Uninitialized &&
         std::all_of(index_list.begin(), index_list.end(), [this](const QModelIndex& idx) {
           const QModelIndex sibling = idx.siblingAtColumn(Column::Instruction);
           return BranchSavesLR(m_table_proxy->data(sibling, UserRole::ClickRole).value<u32>());
@@ -844,7 +844,7 @@ void BranchWatchDialog::OnTableContextMenu(const QPoint& pos)
   {
     QAction* const action = menu->addAction(tr("Insert &BLR at start"));
     const bool enable_action =
-        Core::GetState() != Core::State::Uninitialized &&
+        Core::GetState(m_system) != Core::State::Uninitialized &&
         std::all_of(index_list.begin(), index_list.end(), [this](const QModelIndex& idx) {
           return m_table_proxy->data(idx, UserRole::ClickRole).isValid();
         });

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -150,7 +150,7 @@ void BreakpointWidget::UpdateButtonsEnabled()
   if (!isVisible())
     return;
 
-  const bool is_initialised = Core::GetState() != Core::State::Uninitialized;
+  const bool is_initialised = Core::GetState(m_system) != Core::State::Uninitialized;
   m_new->setEnabled(is_initialised);
   m_load->setEnabled(is_initialised);
   m_save->setEnabled(is_initialised);

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -267,7 +267,7 @@ void CodeViewWidget::Update()
   if (m_updating)
     return;
 
-  if (Core::GetState() == Core::State::Paused)
+  if (Core::GetState(m_system) == Core::State::Paused)
   {
     Core::CPUThreadGuard guard(m_system);
     Update(&guard);
@@ -558,8 +558,8 @@ void CodeViewWidget::OnContextMenu()
 {
   QMenu* menu = new QMenu(this);
 
-  const bool running = Core::GetState() != Core::State::Uninitialized;
-  const bool paused = Core::GetState() == Core::State::Paused;
+  const bool running = Core::GetState(m_system) != Core::State::Uninitialized;
+  const bool paused = Core::GetState(m_system) == Core::State::Paused;
 
   const u32 addr = GetContextAddress();
 
@@ -761,7 +761,7 @@ void CodeViewWidget::OnCopyAddress()
 
 void CodeViewWidget::OnCopyTargetAddress()
 {
-  if (Core::GetState() != Core::State::Paused)
+  if (Core::GetState(m_system) != Core::State::Paused)
     return;
 
   const u32 addr = GetContextAddress();
@@ -791,7 +791,7 @@ void CodeViewWidget::OnShowInMemory()
 
 void CodeViewWidget::OnShowTargetInMemory()
 {
-  if (Core::GetState() != Core::State::Paused)
+  if (Core::GetState(m_system) != Core::State::Paused)
     return;
 
   const u32 addr = GetContextAddress();

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -60,7 +60,7 @@ CodeWidget::CodeWidget(QWidget* parent)
           [this](bool visible) { setHidden(!visible); });
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, [this] {
-    if (Core::GetState() == Core::State::Paused)
+    if (Core::GetState(m_system) == Core::State::Paused)
       SetAddress(m_system.GetPPCState().pc, CodeViewWidget::SetAddressUpdate::WithoutUpdate);
     Update();
   });
@@ -339,7 +339,7 @@ void CodeWidget::UpdateCallstack()
 {
   m_callstack_list->clear();
 
-  if (Core::GetState() != Core::State::Paused)
+  if (Core::GetState(m_system) != Core::State::Paused)
     return;
 
   std::vector<Dolphin_Debugger::CallstackEntry> stack;

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -14,6 +14,7 @@
 #include "Common/GekkoDisassembler.h"
 #include "Core/Core.h"
 #include "Core/PowerPC/PPCAnalyst.h"
+#include "Core/System.h"
 #include "UICommon/Disassembler.h"
 
 #include "DolphinQt/Host.h"
@@ -136,7 +137,7 @@ void JITWidget::Update()
   if (!isVisible())
     return;
 
-  if (!m_address || (Core::GetState() != Core::State::Paused))
+  if (!m_address || (Core::GetState(Core::System::GetInstance()) != Core::State::Paused))
   {
     m_ppc_asm_widget->setHtml(QStringLiteral("<i>%1</i>").arg(tr("(ppc)")));
     m_host_asm_widget->setHtml(QStringLiteral("<i>%1</i>").arg(tr("(host)")));

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -441,7 +441,7 @@ void MemoryViewWidget::UpdateColumns()
   if (m_table->item(1, 1) == nullptr)
     return;
 
-  if (Core::GetState() == Core::State::Paused)
+  if (Core::GetState(m_system) == Core::State::Paused)
   {
     const Core::CPUThreadGuard guard(m_system);
     UpdateColumns(&guard);

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -239,7 +239,8 @@ void NetworkWidget::Update()
   if (!isVisible())
     return;
 
-  if (Core::GetState() != Core::State::Paused)
+  auto& system = Core::System::GetInstance();
+  if (Core::GetState(system) != Core::State::Paused)
   {
     m_socket_table->setDisabled(true);
     m_ssl_table->setDisabled(true);
@@ -250,9 +251,9 @@ void NetworkWidget::Update()
   m_ssl_table->setDisabled(false);
 
   // needed because there's a race condition on the IOS instance otherwise
-  Core::CPUThreadGuard guard(Core::System::GetInstance());
+  const Core::CPUThreadGuard guard(system);
 
-  auto* ios = guard.GetSystem().GetIOS();
+  auto* ios = system.GetIOS();
   if (!ios)
     return;
 

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -533,7 +533,7 @@ void RegisterWidget::AddRegister(int row, int column, RegisterType type, std::st
 
 void RegisterWidget::Update()
 {
-  if (isVisible() && Core::GetState() == Core::State::Paused)
+  if (isVisible() && Core::GetState(m_system) == Core::State::Paused)
   {
     m_updating = true;
     emit UpdateTable();

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -252,13 +252,14 @@ void ThreadWidget::Update()
   if (!isVisible())
     return;
 
-  const auto emu_state = Core::GetState();
+  auto& system = Core::System::GetInstance();
+  const auto emu_state = Core::GetState(system);
   if (emu_state == Core::State::Stopping)
   {
     m_thread_table->setRowCount(0);
     UpdateThreadContext({});
 
-    Core::CPUThreadGuard guard(Core::System::GetInstance());
+    const Core::CPUThreadGuard guard(system);
     UpdateThreadCallstack(guard, {});
   }
   if (emu_state != Core::State::Paused)
@@ -303,7 +304,7 @@ void ThreadWidget::Update()
   };
 
   {
-    Core::CPUThreadGuard guard(Core::System::GetInstance());
+    const Core::CPUThreadGuard guard(system);
 
     // YAGCD - Section 4.2.1.4 Dolphin OS Globals
     m_current_context->setText(format_hex_from(guard, 0x800000D4));

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -158,7 +158,7 @@ void WatchWidget::Update()
 
   m_updating = true;
 
-  if (Core::GetState() != Core::State::Paused)
+  if (Core::GetState(m_system) != Core::State::Paused)
   {
     m_table->setDisabled(true);
     m_updating = false;

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -103,8 +103,8 @@ static void RunWithGPUThreadInactive(std::function<void()> f)
     // (Note that this case cannot be reached in single core mode, because in single core mode,
     // the CPU and GPU threads are the same thread, and we already checked for the GPU thread.)
 
-    const bool was_running = Core::GetState() == Core::State::Running;
     auto& system = Core::System::GetInstance();
+    const bool was_running = Core::GetState(system) == Core::State::Running;
     auto& fifo = system.GetFifo();
     fifo.PauseAndLock(true, was_running);
     f();

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -113,7 +113,7 @@ static void HandleFrameStepHotkeys()
 
     if ((frame_step_count == 0 || frame_step_count == FRAME_STEP_DELAY) && !frame_step_hold)
     {
-      Core::DoFrameStep();
+      Core::DoFrameStep(Core::System::GetInstance());
       frame_step_hold = true;
     }
 
@@ -159,7 +159,7 @@ void HotkeyScheduler::Run()
     if (!HotkeyManagerEmu::IsEnabled())
       continue;
 
-    if (Core::GetState() != Core::State::Stopping)
+    if (Core::GetState(Core::System::GetInstance()) != Core::State::Stopping)
     {
       // Obey window focus (config permitting) before checking hotkeys.
       Core::UpdateInputGate(Config::Get(Config::MAIN_FOCUSED_HOTKEYS));

--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
@@ -46,7 +46,7 @@ InfinityBaseWindow::InfinityBaseWindow(QWidget* parent) : QWidget(parent)
 
   installEventFilter(this);
 
-  OnEmulationStateChanged(Core::GetState());
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()));
 };
 
 InfinityBaseWindow::~InfinityBaseWindow() = default;

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -499,7 +499,7 @@ void MainWindow::CreateComponents()
   connect(m_breakpoint_widget, &BreakpointWidget::BreakpointsChanged, m_memory_widget,
           &MemoryWidget::Update);
   connect(m_breakpoint_widget, &BreakpointWidget::ShowCode, [this](u32 address) {
-    if (Core::GetState() == Core::State::Paused)
+    if (Core::GetState(Core::System::GetInstance()) == Core::State::Paused)
       m_code_widget->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithDetailedUpdate);
   });
   connect(m_breakpoint_widget, &BreakpointWidget::ShowMemory, m_memory_widget,
@@ -823,7 +823,7 @@ void MainWindow::Play(const std::optional<std::string>& savestate_path)
   // Otherwise, play the default game.
   // Otherwise, play the last played game, if there is one.
   // Otherwise, prompt for a new game.
-  if (Core::GetState() == Core::State::Paused)
+  if (Core::GetState(Core::System::GetInstance()) == Core::State::Paused)
   {
     Core::SetState(Core::State::Running);
   }
@@ -858,7 +858,7 @@ void MainWindow::Pause()
 
 void MainWindow::TogglePause()
 {
-  if (Core::GetState() == Core::State::Paused)
+  if (Core::GetState(Core::System::GetInstance()) == Core::State::Paused)
   {
     Play();
   }
@@ -926,7 +926,7 @@ bool MainWindow::RequestStop()
 
     Common::ScopeGuard confirm_lock([this] { m_stop_confirm_showing = false; });
 
-    const Core::State state = Core::GetState();
+    const Core::State state = Core::GetState(Core::System::GetInstance());
 
     // Only pause the game, if NetPlay is not running
     bool pause = !Settings::Instance().GetNetPlayClient();
@@ -983,7 +983,7 @@ bool MainWindow::RequestStop()
 
     // Unpause because gracefully shutting down needs the game to actually request a shutdown.
     // TODO: Do not unpause in debug mode to allow debugging until the complete shutdown.
-    if (Core::GetState() == Core::State::Paused)
+    if (Core::GetState(Core::System::GetInstance()) == Core::State::Paused)
       Core::SetState(Core::State::Running);
 
     // Tell NetPlay about the power event
@@ -1017,7 +1017,7 @@ void MainWindow::Reset()
 
 void MainWindow::FrameAdvance()
 {
-  Core::DoFrameStep();
+  Core::DoFrameStep(Core::System::GetInstance());
 }
 
 void MainWindow::FullScreen()
@@ -1108,7 +1108,7 @@ void MainWindow::StartGame(std::unique_ptr<BootParameters>&& parameters)
   }
 
   // If we're running, only start a new game once we've stopped the last.
-  if (Core::GetState() != Core::State::Uninitialized)
+  if (Core::GetState(Core::System::GetInstance()) != Core::State::Uninitialized)
   {
     if (!RequestStop())
       return;
@@ -1660,8 +1660,8 @@ void MainWindow::NetPlayQuit()
 
 void MainWindow::UpdateScreenSaverInhibition()
 {
-  const bool inhibit =
-      Config::Get(Config::MAIN_DISABLE_SCREENSAVER) && (Core::GetState() == Core::State::Running);
+  const bool inhibit = Config::Get(Config::MAIN_DISABLE_SCREENSAVER) &&
+                       (Core::GetState(Core::System::GetInstance()) == Core::State::Running);
 
   if (inhibit == m_is_screensaver_inhibited)
     return;

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -93,9 +93,9 @@ MenuBar::MenuBar(QWidget* parent) : QMenuBar(parent)
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           [=, this](Core::State state) { OnEmulationStateChanged(state); });
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this,
-          [this] { OnEmulationStateChanged(Core::GetState()); });
+          [this] { OnEmulationStateChanged(Core::GetState(Core::System::GetInstance())); });
 
-  OnEmulationStateChanged(Core::GetState());
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()));
   connect(&Settings::Instance(), &Settings::DebugModeToggled, this, &MenuBar::OnDebugModeToggled);
 
   connect(this, &MenuBar::SelectionChanged, this, &MenuBar::OnSelectionChanged);

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -406,8 +406,11 @@ bool RenderWidget::event(QEvent* event)
   // Note that this event in Windows is not always aligned to the window that is highlighted,
   // it's the window that has keyboard and mouse focus
   case QEvent::WindowActivate:
-    if (m_should_unpause_on_focus && Core::GetState() == Core::State::Paused)
+    if (m_should_unpause_on_focus &&
+        Core::GetState(Core::System::GetInstance()) == Core::State::Paused)
+    {
       Core::SetState(Core::State::Running);
+    }
 
     m_should_unpause_on_focus = false;
 
@@ -430,7 +433,8 @@ bool RenderWidget::event(QEvent* event)
 
     UpdateCursor();
 
-    if (Config::Get(Config::MAIN_PAUSE_ON_FOCUS_LOST) && Core::GetState() == Core::State::Running)
+    if (Config::Get(Config::MAIN_PAUSE_ON_FOCUS_LOST) &&
+        Core::GetState(Core::System::GetInstance()) == Core::State::Running)
     {
       // If we are declared as the CPU or GPU thread, it means that the real CPU or GPU thread
       // is waiting for us to finish showing a panic alert (with that panic alert likely being

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -240,7 +240,7 @@ void AdvancedPane::ConnectLayout()
 
 void AdvancedPane::Update()
 {
-  const bool running = Core::GetState() != Core::State::Uninitialized;
+  const bool running = Core::GetState(Core::System::GetInstance()) != Core::State::Uninitialized;
   const bool enable_cpu_clock_override_widgets = Config::Get(Config::MAIN_OVERCLOCK_ENABLE);
   const bool enable_ram_override_widgets = Config::Get(Config::MAIN_RAM_OVERRIDE_ENABLE);
   const bool enable_custom_rtc_widgets = Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE) && !running;

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -40,7 +40,8 @@ AudioPane::AudioPane()
     OnEmulationStateChanged(state != Core::State::Uninitialized);
   });
 
-  OnEmulationStateChanged(Core::GetState() != Core::State::Uninitialized);
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()) !=
+                          Core::State::Uninitialized);
 }
 
 void AudioPane::CreateWidgets()

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -22,6 +22,7 @@
 #include "Core/Core.h"
 #include "Core/DolphinAnalytics.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
@@ -58,7 +59,7 @@ GeneralPane::GeneralPane(QWidget* parent) : QWidget(parent)
           &GeneralPane::OnEmulationStateChanged);
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, &GeneralPane::LoadConfig);
 
-  OnEmulationStateChanged(Core::GetState());
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()));
 }
 
 void GeneralPane::CreateLayout()

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -30,6 +30,7 @@
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/System.h"
 
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
@@ -92,7 +93,8 @@ WiiPane::WiiPane(QWidget* parent) : QWidget(parent)
   LoadConfig();
   ConnectLayout();
   ValidateSelectionState();
-  OnEmulationStateChanged(Core::GetState() != Core::State::Uninitialized);
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()) !=
+                          Core::State::Uninitialized);
 }
 
 void WiiPane::CreateLayout()

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
@@ -56,7 +56,7 @@ SkylanderPortalWindow::SkylanderPortalWindow(QWidget* parent) : QWidget(parent)
 
   installEventFilter(this);
 
-  OnEmulationStateChanged(Core::GetState());
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()));
 
   connect(m_skylander_list, &QListWidget::itemSelectionChanged, this,
           &SkylanderPortalWindow::UpdateCurrentIDs);

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -11,6 +11,7 @@
 
 #include "Core/Core.h"
 #include "Core/NetPlayProto.h"
+#include "Core/System.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
@@ -36,7 +37,7 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
           [this](Core::State state) { OnEmulationStateChanged(state); });
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this,
-          [this] { OnEmulationStateChanged(Core::GetState()); });
+          [this] { OnEmulationStateChanged(Core::GetState(Core::System::GetInstance())); });
 
   connect(&Settings::Instance(), &Settings::DebugModeToggled, this, &ToolBar::OnDebugModeToggled);
 
@@ -51,7 +52,7 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   connect(&Settings::Instance(), &Settings::GameListRefreshStarted, this,
           [this] { m_refresh_action->setEnabled(true); });
 
-  OnEmulationStateChanged(Core::GetState());
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()));
   OnDebugModeToggled(Settings::Instance().IsDebugModeEnabled());
 }
 
@@ -65,7 +66,7 @@ void ToolBar::OnEmulationStateChanged(Core::State state)
   bool playing = running && state != Core::State::Paused;
   UpdatePausePlayButtonState(playing);
 
-  bool paused = Core::GetState() == Core::State::Paused;
+  const bool paused = Core::GetState(Core::System::GetInstance()) == Core::State::Paused;
   m_step_action->setEnabled(paused);
   m_step_over_action->setEnabled(paused);
   m_step_out_action->setEnabled(paused);
@@ -87,7 +88,7 @@ void ToolBar::OnDebugModeToggled(bool enabled)
   m_show_pc_action->setVisible(enabled);
   m_set_pc_action->setVisible(enabled);
 
-  bool paused = Core::GetState() == Core::State::Paused;
+  const bool paused = Core::GetState(Core::System::GetInstance()) == Core::State::Paused;
   m_step_action->setEnabled(paused);
   m_step_over_action->setEnabled(paused);
   m_step_out_action->setEnabled(paused);
@@ -180,7 +181,7 @@ void ToolBar::UpdateIcons()
   m_open_action->setIcon(Resources::GetThemeIcon("open"));
   m_refresh_action->setIcon(Resources::GetThemeIcon("refresh"));
 
-  const Core::State state = Core::GetState();
+  const Core::State state = Core::GetState(Core::System::GetInstance());
   const bool playing = state != Core::State::Uninitialized && state != Core::State::Paused;
   if (!playing)
     m_pause_play_action->setIcon(Resources::GetThemeIcon("play"));

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -432,9 +432,10 @@ void Init()
     return;
 #endif
 
-  if (Core::GetState() != Core::State::Uninitialized && Core::GetState() != Core::State::Starting)
+  auto& system = Core::System::GetInstance();
+  if (const Core::State state = Core::GetState(system);
+      state != Core::State::Uninitialized && state != Core::State::Starting)
   {
-    auto& system = Core::System::GetInstance();
     auto& core_timing = system.GetCoreTiming();
     if ((core_timing.GetTicks() - s_last_init) < system.GetSystemTimers().GetTicksPerSecond())
       return;

--- a/Source/Core/VideoCommon/AsyncShaderCompiler.cpp
+++ b/Source/Core/VideoCommon/AsyncShaderCompiler.cpp
@@ -10,6 +10,7 @@
 #include "Common/Thread.h"
 
 #include "Core/Core.h"
+#include "Core/System.h"
 
 namespace VideoCommon
 {
@@ -96,7 +97,7 @@ bool AsyncShaderCompiler::WaitUntilCompletion(
   // Update progress while the compiles complete.
   for (;;)
   {
-    if (Core::GetState() == Core::State::Stopping)
+    if (Core::GetState(Core::System::GetInstance()) == Core::State::Stopping)
       return false;
 
     size_t remaining_items;


### PR DESCRIPTION
Part 3 of an effort to remove global state from one of the biggest offenders.

And boy, is this a big one. Lots of code assumes this function is free to call, including several DolphinQt widgets. This PR does not focus on hooking up non-global `System` access to the new locations that need it (though it is something I may pursue in the near future).