### PR TITLE
FileUtil: Fix BranchWatch User Path

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -937,7 +937,7 @@ static void RebuildUserDirectories(unsigned int dir_index)
     s_user_paths[D_DUMPSSL_IDX] = s_user_paths[D_DUMP_IDX] + DUMP_SSL_DIR DIR_SEP;
     s_user_paths[D_DUMPDEBUG_IDX] = s_user_paths[D_DUMP_IDX] + DUMP_DEBUG_DIR DIR_SEP;
     s_user_paths[D_DUMPDEBUG_BRANCHWATCH_IDX] =
-        s_user_paths[D_DUMP_IDX] + DUMP_DEBUG_BRANCHWATCH_DIR DIR_SEP;
+        s_user_paths[D_DUMPDEBUG_IDX] + DUMP_DEBUG_BRANCHWATCH_DIR DIR_SEP;
     s_user_paths[F_MEM1DUMP_IDX] = s_user_paths[D_DUMP_IDX] + MEM1_DUMP;
     s_user_paths[F_MEM2DUMP_IDX] = s_user_paths[D_DUMP_IDX] + MEM2_DUMP;
     s_user_paths[F_ARAMDUMP_IDX] = s_user_paths[D_DUMP_IDX] + ARAM_DUMP;


### PR DESCRIPTION
I mistakenly put `D_DUMP_IDX` here instead of `D_DUMPDEBUG_IDX`. Note that, in practice, the BranchWatch user folder appears where I intended, so I don't know what would cause this erroneous statement to overwrite the correct location set on line 861.