### PR TITLE
Jit64: Clean up ExtractWithByteOffset

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -109,19 +109,6 @@ OpArg RCOpArg::Location() const
   return {};
 }
 
-OpArg RCOpArg::ExtractWithByteOffset(int offset)
-{
-  if (offset == 0)
-    return Location();
-
-  ASSERT(rc);
-  const preg_t preg = std::get<preg_t>(contents);
-  rc->StoreFromRegister(preg, RegCache::FlushMode::MaintainState);
-  OpArg result = rc->GetDefaultLocation(preg);
-  result.AddMemOffset(offset);
-  return result;
-}
-
 void RCOpArg::Unlock()
 {
   if (const preg_t* preg = std::get_if<preg_t>(&contents))

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -47,9 +47,6 @@ public:
   bool IsSimpleReg(Gen::X64Reg reg) const { return Location().IsSimpleReg(reg); }
   Gen::X64Reg GetSimpleReg() const { return Location().GetSimpleReg(); }
 
-  // Use to extract bytes from a register using the regcache. offset is in bytes.
-  Gen::OpArg ExtractWithByteOffset(int offset);
-
   void Unlock();
 
   bool IsImm() const;
@@ -158,6 +155,8 @@ public:
   }
   u32 Imm32(preg_t preg) const { return R(preg).Imm32(); }
   s32 SImm32(preg_t preg) const { return R(preg).SImm32(); }
+
+  bool IsBound(preg_t preg) const { return m_regs[preg].IsBound(); }
 
   RCOpArg Use(preg_t preg, RCMode mode);
   RCOpArg UseNoImm(preg_t preg, RCMode mode);


### PR DESCRIPTION
`RCOpArg::ExtractWithByteOffset` is only used in one place: a special case of `rlwinmx`. `ExtractWithByteOffset` first stores the value of the specified register into `m_ppc_state` (unless it's already there), and then returns an offset into `m_ppc_state`. Our use of this function has two undesirable properties (except in the trivial case `offset == 0`):

1. `ExtractWithByteOffset` calls `StoreFromRegister` without going through any of the usual functions. This violated an assumption I made when working on my constant propagation PR and led to a hard-to-find bug.
2. If the specified register is in a host register and is dirty, `ExtractWithByteOffset` will store its value to `m_ppc_state` even when it's unnecessary. In particular, this always happens when `rlwinmx` uses the same register as input and output, since `rlwinmx` always allocates a host register for the output and marks it as dirty.

Since `ExtractWithByteOffset` is only used in one place, I figure we might as well inline it there. This commit does that, and also alters `rlwinmx`'s logic so the special case code is only triggered when the input is already in `m_ppc_state`.

Input in `m_ppc_state`, before (11 bytes):

```
mov         esi, dword ptr [rbp-104]
mov         dword ptr [rbp-104], esi
movzx       esi, byte ptr [rbp-101]
```

Input in `m_ppc_state`, after (5 bytes):

```
movzx       esi, byte ptr [rbp-101]
```

Input in host register, before (8 bytes):

```
mov         dword ptr [rbp-104], esi
movzx       esi, byte ptr [rbp-101]
```

Input in host register, after (3 bytes):

```
shr         edi, 0x18
```