### PR TITLE
CheatsManager: Allow making the window smaller

### DIFF
--- a/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/CheatSearchFactoryWidget.h"
+#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include <string>
 #include <vector>
@@ -124,7 +125,7 @@ void CheatSearchFactoryWidget::CreateWidgets()
 
   layout->addStretch();
 
-  setLayout(layout);
+  WrapInScrollArea(this, layout);
 }
 
 void CheatSearchFactoryWidget::ConnectWidgets()

--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/CheatSearchWidget.h"
+#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include <functional>
 #include <optional>
@@ -174,6 +175,7 @@ void CheatSearchWidget::CreateWidgets()
     }
     QString aligned = m_session->GetAligned() ? tr("aligned") : tr("unaligned");
     session_info_label->setText(tr("%1, %2, %3, %4").arg(ranges).arg(space).arg(type).arg(aligned));
+    session_info_label->setWordWrap(true);
   }
 
   // i18n: This label is followed by a dropdown where the user can select things like "is equal to"
@@ -256,7 +258,8 @@ void CheatSearchWidget::CreateWidgets()
   layout->addWidget(m_info_label_1);
   layout->addWidget(m_info_label_2);
   layout->addWidget(m_address_table);
-  setLayout(layout);
+
+  WrapInScrollArea(this, layout);
 }
 
 void CheatSearchWidget::ConnectWidgets()

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/Config/ARCodeWidget.h"
+#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include <algorithm>
 #include <utility>
@@ -86,7 +87,7 @@ void ARCodeWidget::CreateWidgets()
   layout->addWidget(m_code_list);
   layout->addLayout(button_layout);
 
-  setLayout(layout);
+  WrapInScrollArea(this, layout);
 }
 
 void ARCodeWidget::ConnectWidgets()

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/Config/GeckoCodeWidget.h"
+#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include <algorithm>
 #include <utility>
@@ -138,7 +139,7 @@ void GeckoCodeWidget::CreateWidgets()
 
   layout->addLayout(btn_layout);
 
-  setLayout(layout);
+  WrapInScrollArea(this, layout);
 }
 
 void GeckoCodeWidget::ConnectWidgets()


### PR DESCRIPTION
Move CheatManager's child widgets into scroll areas to allow making the window smaller than the default, as one can already do with many of Dolphin's other windows.

In CheatSearchWidget, enable word wrapping for the label describing the address space and search type to help it fit better inside a narrower window.