### PR TITLE
Refactor `TaskViewModel` to track task-related state in a single `MutableLiveData` instance

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.kt
@@ -102,10 +102,7 @@ class UserDataActivity : AppCompatActivity() {
             dialog.show(supportFragmentManager, UserDataImportWarningDialog.TAG)
         } else if (requestCode == REQUEST_CODE_EXPORT && resultCode == RESULT_OK) {
             taskViewModel.clear()
-            taskViewModel.task = {
-                val resultResource = exportUserData(data!!.data!!)
-                taskViewModel.setResult(resultResource)
-            }
+            taskViewModel.task = { exportUserData(data!!.data!!) }
 
             val arguments = Bundle()
             arguments.putInt(TaskDialog.KEY_TITLE, R.string.export_in_progress)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/TaskDialog.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/TaskDialog.kt
@@ -34,14 +34,11 @@ class TaskDialog : DialogFragment() {
         val progressMessage = requireArguments().getInt(KEY_MESSAGE)
         if (progressMessage != 0) dialog.setMessage(resources.getString(progressMessage))
 
-        viewModel.isComplete.observe(this) { complete: Boolean ->
-            if (complete && viewModel.result.value != null) {
+        viewModel.result.observe(this) { result: Int? ->
+            if (result != null) {
                 dialog.dismiss()
                 val notificationArguments = Bundle()
-                notificationArguments.putInt(
-                    TaskCompleteDialog.KEY_MESSAGE,
-                    viewModel.result.value!!
-                )
+                notificationArguments.putInt(TaskCompleteDialog.KEY_MESSAGE, result)
 
                 val taskCompleteDialog = TaskCompleteDialog()
                 taskCompleteDialog.arguments = notificationArguments

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/UserDataImportWarningDialog.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/UserDataImportWarningDialog.kt
@@ -32,10 +32,8 @@ class UserDataImportWarningDialog : DialogFragment() {
                 taskArguments.putBoolean(TaskDialog.KEY_CANCELLABLE, false)
 
                 taskViewModel.task = {
-                    taskViewModel.setResult(
-                        (requireActivity() as UserDataActivity).importUserData(
-                            requireArguments().getString(KEY_URI_RESULT)!!.toUri()
-                        )
+                    (requireActivity() as UserDataActivity).importUserData(
+                        requireArguments().getString(KEY_URI_RESULT)!!.toUri()
                     )
                 }
 


### PR DESCRIPTION
Also tweak the API so that the caller-specified `task` returns a result directly, instead of requiring it to internally call `setResult`. This refactoring has a few benefits:

1. The compiler now requires the task to complete with a result, preventing mistakes where the caller forgets to call `setResult`.
2. All task-related state is updated atomically, so observers will never transiently observe inconsistent states where the task is completed but no result is available, or the task is "not running" but isn't yet "complete."

This PR also fixes a bug where calling `runTask` on a completed `TaskViewModel` would cause its task to re-run even if `clear` hadn't been called first.

I tested this PR by exporting and importing user data in the app running on an emulator.