### PR TITLE
Jit: Skip discarded registers when flushing for interpreter fallback

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -334,8 +334,8 @@ void Jit64::Shutdown()
 
 void Jit64::FallBackToInterpreter(UGeckoInstruction inst)
 {
-  gpr.Flush();
-  fpr.Flush();
+  gpr.Flush(BitSet32(0xFFFFFFFF), RegCache::IgnoreDiscardedRegisters::Yes);
+  fpr.Flush(BitSet32(0xFFFFFFFF), RegCache::IgnoreDiscardedRegisters::Yes);
 
   if (js.op->canEndBlock)
   {

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -404,7 +404,7 @@ void RegCache::Discard(BitSet32 pregs)
   }
 }
 
-void RegCache::Flush(BitSet32 pregs)
+void RegCache::Flush(BitSet32 pregs, IgnoreDiscardedRegisters ignore_discarded_registers)
 {
   ASSERT_MSG(
       DYNA_REC,
@@ -423,7 +423,8 @@ void RegCache::Flush(BitSet32 pregs)
     case PPCCachedReg::LocationType::Default:
       break;
     case PPCCachedReg::LocationType::Discarded:
-      ASSERT_MSG(DYNA_REC, false, "Attempted to flush discarded PPC reg {}", i);
+      ASSERT_MSG(DYNA_REC, ignore_discarded_registers != IgnoreDiscardedRegisters::No,
+                 "Attempted to flush discarded PPC reg {}", i);
       break;
     case PPCCachedReg::LocationType::SpeculativeImmediate:
       // We can have a cached value without a host register through speculative constants.

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -129,6 +129,12 @@ public:
     MaintainState,
   };
 
+  enum class IgnoreDiscardedRegisters
+  {
+    No,
+    Yes,
+  };
+
   explicit RegCache(Jit64& jit);
   virtual ~RegCache() = default;
 
@@ -169,7 +175,8 @@ public:
 
   RCForkGuard Fork();
   void Discard(BitSet32 pregs);
-  void Flush(BitSet32 pregs = BitSet32::AllTrue(32));
+  void Flush(BitSet32 pregs = BitSet32::AllTrue(32),
+             IgnoreDiscardedRegisters ignore_discarded_registers = IgnoreDiscardedRegisters::No);
   void Reset(BitSet32 pregs);
   void Revert();
   void Commit();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -184,8 +184,8 @@ void JitArm64::Shutdown()
 void JitArm64::FallBackToInterpreter(UGeckoInstruction inst)
 {
   FlushCarry();
-  gpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
-  fpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
+  gpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG, IgnoreDiscardedRegisters::Yes);
+  fpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG, IgnoreDiscardedRegisters::Yes);
 
   if (js.op->canEndBlock)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -81,6 +81,12 @@ enum class FlushMode : bool
   MaintainState,
 };
 
+enum class IgnoreDiscardedRegisters
+{
+  No,
+  Yes,
+};
+
 class OpArg
 {
 public:
@@ -172,7 +178,8 @@ public:
   // Flushes the register cache in different ways depending on the mode.
   // A temporary register must be supplied when flushing GPRs with FlushMode::MaintainState,
   // but in other cases it can be set to ARM64Reg::INVALID_REG when convenient for the caller.
-  virtual void Flush(FlushMode mode, Arm64Gen::ARM64Reg tmp_reg) = 0;
+  virtual void Flush(FlushMode mode, Arm64Gen::ARM64Reg tmp_reg,
+                     IgnoreDiscardedRegisters ignore_discarded_registers) = 0;
 
   virtual BitSet32 GetCallerSavedUsed() const = 0;
 
@@ -265,7 +272,9 @@ public:
   // Flushes the register cache in different ways depending on the mode.
   // A temporary register must be supplied when flushing GPRs with FlushMode::MaintainState,
   // but in other cases it can be set to ARM64Reg::INVALID_REG when convenient for the caller.
-  void Flush(FlushMode mode, Arm64Gen::ARM64Reg tmp_reg) override;
+  void Flush(
+      FlushMode mode, Arm64Gen::ARM64Reg tmp_reg,
+      IgnoreDiscardedRegisters ignore_discarded_registers = IgnoreDiscardedRegisters::No) override;
 
   // Returns a guest GPR inside of a host register.
   // Will dump an immediate to the host register as well.
@@ -329,12 +338,12 @@ public:
 
   void StoreRegisters(BitSet32 regs, Arm64Gen::ARM64Reg tmp_reg = Arm64Gen::ARM64Reg::INVALID_REG)
   {
-    FlushRegisters(regs, FlushMode::All, tmp_reg);
+    FlushRegisters(regs, FlushMode::All, tmp_reg, IgnoreDiscardedRegisters::No);
   }
 
   void StoreCRRegisters(BitSet8 regs, Arm64Gen::ARM64Reg tmp_reg = Arm64Gen::ARM64Reg::INVALID_REG)
   {
-    FlushCRRegisters(regs, FlushMode::All, tmp_reg);
+    FlushCRRegisters(regs, FlushMode::All, tmp_reg, IgnoreDiscardedRegisters::No);
   }
 
   void DiscardCRRegisters(BitSet8 regs);
@@ -369,8 +378,10 @@ private:
   void SetImmediate(const GuestRegInfo& guest_reg, u32 imm, bool dirty);
   void BindToRegister(const GuestRegInfo& guest_reg, bool will_read, bool will_write = true);
 
-  void FlushRegisters(BitSet32 regs, FlushMode mode, Arm64Gen::ARM64Reg tmp_reg);
-  void FlushCRRegisters(BitSet8 regs, FlushMode mode, Arm64Gen::ARM64Reg tmp_reg);
+  void FlushRegisters(BitSet32 regs, FlushMode mode, Arm64Gen::ARM64Reg tmp_reg,
+                      IgnoreDiscardedRegisters ignore_discarded_registers);
+  void FlushCRRegisters(BitSet8 regs, FlushMode mode, Arm64Gen::ARM64Reg tmp_reg,
+                        IgnoreDiscardedRegisters ignore_discarded_registers);
 };
 
 class Arm64FPRCache : public Arm64RegCache
@@ -380,7 +391,9 @@ public:
 
   // Flushes the register cache in different ways depending on the mode.
   // The temporary register can be set to ARM64Reg::INVALID_REG when convenient for the caller.
-  void Flush(FlushMode mode, Arm64Gen::ARM64Reg tmp_reg) override;
+  void Flush(
+      FlushMode mode, Arm64Gen::ARM64Reg tmp_reg,
+      IgnoreDiscardedRegisters ignore_discarded_registers = IgnoreDiscardedRegisters::No) override;
 
   // Returns a guest register inside of a host register
   // Will dump an immediate to the host register as well


### PR DESCRIPTION
Normally, the asserts added in 34b0a6ea90 are only triggered when something actually went wrong in Dolphin. But there is one exception: In FallBackToInterpreter, we flush all registers regardless of whether they're discarded. This is fine as long as none of the discarded registers are inputs to the instruction that the interpreter will run.

To avoid false positive asserts, this change adds a parameter to Flush that controls whether to skip the asserts for discarded registers.

Additionally, an assert for discarded registers is added to Arm64FPRCache::Flush. (Previously JitArm64 asserted for GPRs (and CRs) only, whereas Jit64 asserted both for GPRs and FPRs. I most likely didn't think of FPRs when writing 34b0a6ea90.)