### PR TITLE
Memmap: Don't show panic alert for 0 length range

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -409,7 +409,7 @@ u8* MemoryManager::GetPointerForRange(u32 address, size_t size) const
 
   // Check that the beginning and end of the range are valid
   u8* pointer = GetPointer(address);
-  if (!pointer || !GetPointer(address + u32(size) - 1))
+  if (pointer == nullptr || (size != 0 && GetPointer(address + u32(size) - 1) == nullptr))
   {
     // A panic alert has already been raised by GetPointer
     return nullptr;


### PR DESCRIPTION
`IOS::HLE::IOCtlVRequest::Dump` sometimes tries to call `GetPointerForRange` with an address of 0 and a size of 0. Address 0 is valid, but we were mistakenly also trying to check that address 3FFFFFFF is valid, which it isn't.

Fixes https://bugs.dolphin-emu.org/issues/13514.