### PR TITLE
Android: Unset STRIKE_THRU_TEXT_FLAG for editable settings

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SettingViewHolder.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/SettingViewHolder.kt
@@ -28,8 +28,13 @@ abstract class SettingViewHolder(itemView: View, protected val adapter: Settings
         val overridden = settingsItem.isOverridden
         textView.setTypeface(null, if (overridden) Typeface.BOLD else Typeface.NORMAL)
 
-        if (!settingsItem.isEditable) textView.paintFlags =
-            textView.paintFlags or Paint.STRIKE_THRU_TEXT_FLAG
+        if (settingsItem.isEditable) {
+            textView.paintFlags =
+                textView.paintFlags and Paint.STRIKE_THRU_TEXT_FLAG.inv()
+        } else {
+            textView.paintFlags =
+                textView.paintFlags or Paint.STRIKE_THRU_TEXT_FLAG
+        }
     }
 
     /**


### PR DESCRIPTION
Because `SettingViewHolder` is used in `RecyclerView`s, we have to explicitly unset `STRIKE_THRU_TEXT_FLAG` when we don't want it, otherwise it might be left over from when the `SettingViewHolder` was representing a different setting.