### PR TITLE
VerifyWidget: Listen for Core::State OnEmulationStateChanged

### DIFF
--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -45,12 +45,12 @@ VerifyWidget::VerifyWidget(std::shared_ptr<DiscIO::Volume> volume) : m_volume(st
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &VerifyWidget::OnEmulationStateChanged);
 
-  OnEmulationStateChanged();
+  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()));
 }
 
-void VerifyWidget::OnEmulationStateChanged()
+void VerifyWidget::OnEmulationStateChanged(Core::State state)
 {
-  const bool running = Core::GetState(Core::System::GetInstance()) != Core::State::Uninitialized;
+  const bool running = state != Core::State::Uninitialized;
 
   // Verifying a Wii game while emulation is running doesn't work correctly
   // due to verification of a Wii game creating an instance of IOS

--- a/Source/Core/DolphinQt/Config/VerifyWidget.h
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.h
@@ -15,6 +15,10 @@
 #include <QTextEdit>
 #include <QWidget>
 
+namespace Core
+{
+enum class State;
+}
 namespace DiscIO
 {
 class Volume;
@@ -26,10 +30,8 @@ class VerifyWidget final : public QWidget
 public:
   explicit VerifyWidget(std::shared_ptr<DiscIO::Volume> volume);
 
-private slots:
-  void OnEmulationStateChanged();
-
 private:
+  void OnEmulationStateChanged(Core::State state);
   void CreateWidgets();
   std::pair<QCheckBox*, QLineEdit*> AddHashLine(QFormLayout* layout, QString text);
   void ConnectWidgets();


### PR DESCRIPTION
Removing the private `slots` macro is necessary to avoid the MOC requiring `Core::State` to be a Qt meta type on Linux (would require including Settings.h). The `slots` macro is not required in Qt5+ regardless.