### PR TITLE
VideoCommon: Remove calls to GetPointer

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -602,7 +602,6 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
       {
         auto& system = Core::System::GetInstance();
         auto& memory = system.GetMemory();
-        u8* src_ptr = memory.GetPointer(src_addr);
 
         // AR and GB tiles are stored in separate TMEM banks => can't use a single memcpy for
         // everything
@@ -612,10 +611,13 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
         {
           if (tmem_addr_even + TMEM_LINE_SIZE > TMEM_SIZE ||
               tmem_addr_odd + TMEM_LINE_SIZE > TMEM_SIZE)
+          {
             break;
+          }
 
-          memcpy(texMem + tmem_addr_even, src_ptr + bytes_read, TMEM_LINE_SIZE);
-          memcpy(texMem + tmem_addr_odd, src_ptr + bytes_read + TMEM_LINE_SIZE, TMEM_LINE_SIZE);
+          memory.CopyFromEmu(texMem + tmem_addr_even, src_addr + bytes_read, TMEM_LINE_SIZE);
+          memory.CopyFromEmu(texMem + tmem_addr_odd, src_addr + bytes_read + TMEM_LINE_SIZE,
+                             TMEM_LINE_SIZE);
           tmem_addr_even += TMEM_LINE_SIZE;
           tmem_addr_odd += TMEM_LINE_SIZE;
           bytes_read += TMEM_LINE_SIZE * 2;

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -158,7 +158,7 @@ public:
       if constexpr (is_preprocess)
       {
         auto& memory = system.GetMemory();
-        const u8* const start_address = memory.GetPointer(address);
+        const u8* const start_address = memory.GetPointerForRange(address, size);
 
         system.GetFifo().PushFifoAuxBuffer(start_address, size);
 
@@ -179,10 +179,10 @@ public:
         else
         {
           auto& memory = system.GetMemory();
-          start_address = memory.GetPointer(address);
+          start_address = memory.GetPointerForRange(address, size);
         }
 
-        // Avoid the crash if memory.GetPointer failed ..
+        // Avoid the crash if memory.GetPointerForRange failed ..
         if (start_address != nullptr)
         {
           // temporarily swap dl and non-dl (small "hack" for the stats)


### PR DESCRIPTION
This fourth part of my series of patches to get rid of unsafe uses of GetPointer takes care of the "easy" cases in VideoCommon. Three uses of GetPointer now remain in Dolphin: VertexLoaderManager, TextureInfo, and the software renderer's TextureSampler.