### PR TITLE
VideoCommon: add xfbs hashes to present info if available

### DIFF
--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -178,6 +178,25 @@ void Presenter::ViSwap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height,
     present_info.reason = PresentInfo::PresentReason::VideoInterface;
   }
 
+  if (m_xfb_entry)
+  {
+    // With no references, this XFB copy wasn't stitched together
+    // so just use its name directly
+    if (m_xfb_entry->references.empty())
+    {
+      if (!m_xfb_entry->texture_info_name.empty())
+        present_info.xfb_copy_hashes.push_back(m_xfb_entry->texture_info_name);
+    }
+    else
+    {
+      for (const auto& reference : m_xfb_entry->references)
+      {
+        if (!reference->texture_info_name.empty())
+          present_info.xfb_copy_hashes.push_back(reference->texture_info_name);
+      }
+    }
+  }
+
   BeforePresentEvent::Trigger(present_info);
 
   if (!is_duplicate || !g_ActiveConfig.bSkipPresentingDuplicateXFBs)

--- a/Source/Core/VideoCommon/VideoEvents.h
+++ b/Source/Core/VideoCommon/VideoEvents.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <string_view>
+#include <vector>
+
 #include "Common/CommonTypes.h"
 #include "Common/HookableEvent.h"
 
@@ -71,6 +74,8 @@ struct PresentInfo
 
   // Accuracy of actual_present_time
   PresentTimeAccuracy present_time_accuracy = PresentTimeAccuracy::Unimplemented;
+
+  std::vector<std::string_view> xfb_copy_hashes;
 };
 
 // An event called just as a frame is queued for presentation.


### PR DESCRIPTION
Dolphin doesn't have a good idea of when a frame is "finished".  If a game uses a single XFB as its presentation, then we can assume that the XFB creation is a good indication.  However, there are many cases where this is not accurate (see the article about [hybrid xfb](https://dolphin-emu.org/blog/2017/11/19/hybridxfb/)).

@phire [theorized](https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/VideoCommon/BPStructs.cpp#L351) that you could look at the VI settings to determine when a frame would be finished in the future.  Discussing with @booto , I do not see how you could deduce this with any accuracy.

However, my editor PR and graphics mods 2.0 are _highly dependent_ on knowing when the frame ends.  Not only is it used for tracking objects in the scene but also it is used for dumping mesh data for a single frame.

But how can we support this without knowing when the last XFB is created?  We use the frame present event.  Unfortunately, the game is able to present the frame at any time and from my testing, seems to even present frames while in the middle of rendering the scene for a new XFB.  If you're dumping mesh data for instance, this can lead to _duplicate data_ being dumped.

The solution I've come up with is to store data per XFB and then use the present information to fetch the data associated with each XFB.  This leads to a clean way of handling end-of-frame results, while still allowing for separate streams of data to be available at any given time.

This is highly dependent on graphics mods being enabled because the way we track XFB textures is via the texture name (which is guaranteed to be unique).