### PR TITLE
Qt: trigger first USB device scan without a timer

### DIFF
--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -91,6 +91,7 @@ void USBDeviceAddToWhitelistDialog::InitControls()
           &QPushButton::clicked);
   connect(m_refresh_devices_timer, &QTimer::timeout, this,
           &USBDeviceAddToWhitelistDialog::RefreshDeviceList);
+  RefreshDeviceList();
   m_refresh_devices_timer->start(1000);
 
   main_layout->addWidget(usb_inserted_devices_list);


### PR DESCRIPTION
Currently the dialog makes you wait one second before it shows anything. Instead, trigger the first scan manually.