### PR TITLE
Pass `SettingsHandler` buffers by const ref instead of rvalue ref (since the contents are copied either way)

### DIFF
--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -22,9 +22,9 @@ SettingsHandler::SettingsHandler()
   Reset();
 }
 
-SettingsHandler::SettingsHandler(Buffer&& buffer)
+SettingsHandler::SettingsHandler(const Buffer& buffer)
 {
-  SetBytes(std::move(buffer));
+  SetBytes(buffer);
 }
 
 const SettingsHandler::Buffer& SettingsHandler::GetBytes() const
@@ -32,10 +32,10 @@ const SettingsHandler::Buffer& SettingsHandler::GetBytes() const
   return m_buffer;
 }
 
-void SettingsHandler::SetBytes(Buffer&& buffer)
+void SettingsHandler::SetBytes(const Buffer& buffer)
 {
   Reset();
-  m_buffer = std::move(buffer);
+  m_buffer = buffer;
   Decrypt();
 }
 

--- a/Source/Core/Common/SettingsHandler.h
+++ b/Source/Core/Common/SettingsHandler.h
@@ -25,12 +25,12 @@ public:
 
   using Buffer = std::array<u8, SETTINGS_SIZE>;
   SettingsHandler();
-  explicit SettingsHandler(Buffer&& buffer);
+  explicit SettingsHandler(const Buffer& buffer);
 
   void AddSetting(std::string_view key, std::string_view value);
 
   const Buffer& GetBytes() const;
-  void SetBytes(Buffer&& buffer);
+  void SetBytes(const Buffer& buffer);
   std::string GetValue(std::string_view key) const;
 
   void Decrypt();

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -377,7 +377,7 @@ bool CBoot::SetupWiiMemory(Core::System& system, IOS::HLE::IOSC::ConsoleType con
                                    IOS::HLE::FS::Mode::Read);
     if (file && file->Read(data.data(), data.size()))
     {
-      gen.SetBytes(std::move(data));
+      gen.SetBytes(data);
       serno = gen.GetValue("SERNO");
       model = gen.GetValue("MODEL");
 

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -139,7 +139,7 @@ IPCReply GetRealProductCode(Core::System& system, const IOCtlVRequest& request)
     return IPCReply(IPC_ENOENT);
 
   Common::SettingsHandler gen;
-  gen.SetBytes(std::move(data));
+  gen.SetBytes(data);
   const std::string code = gen.GetValue("CODE");
 
   const size_t length = std::min<size_t>(request.io_vectors[0].size, code.length());

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -931,7 +931,7 @@ IPCReply NetKDRequestDevice::HandleRequestRegisterUserId(const IOS::HLE::IOCtlRe
     return IPCReply{IPC_SUCCESS};
   }
 
-  const Common::SettingsHandler gen{std::move(data)};
+  const Common::SettingsHandler gen{data};
   const std::string serno = gen.GetValue("SERNO");
   const std::string form_data =
       fmt::format("mlid=w{}&hdid={}&rgncd={}", m_config.Id(), m_ios.GetIOSC().GetDeviceId(), serno);
@@ -1079,7 +1079,7 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
         Common::SettingsHandler::Buffer data;
         if (file->Read(data.data(), data.size()))
         {
-          const Common::SettingsHandler gen{std::move(data)};
+          const Common::SettingsHandler gen{data};
           area = gen.GetValue("AREA");
           model = gen.GetValue("MODEL");
         }

--- a/Source/UnitTests/Common/SettingsHandlerTest.cpp
+++ b/Source/UnitTests/Common/SettingsHandlerTest.cpp
@@ -52,8 +52,7 @@ TEST(SettingsHandlerTest, EncryptSingleSetting)
 
 TEST(SettingsHandlerTest, DecryptSingleSetting)
 {
-  Common::SettingsHandler::Buffer buffer = BUFFER_A;
-  Common::SettingsHandler handler(std::move(buffer));
+  Common::SettingsHandler handler(BUFFER_A);
   EXPECT_EQ(handler.GetValue("key"), "val");
 }
 
@@ -70,8 +69,7 @@ TEST(SettingsHandlerTest, EncryptMultipleSettings)
 
 TEST(SettingsHandlerTest, DecryptMultipleSettings)
 {
-  Common::SettingsHandler::Buffer buffer = BUFFER_B;
-  Common::SettingsHandler handler(std::move(buffer));
+  Common::SettingsHandler handler(BUFFER_B);
   EXPECT_EQ(handler.GetValue("key1"), "val1");
   EXPECT_EQ(handler.GetValue("key2"), "val2");
   EXPECT_EQ(handler.GetValue("foo"), "bar");
@@ -79,13 +77,11 @@ TEST(SettingsHandlerTest, DecryptMultipleSettings)
 
 TEST(SettingsHandlerTest, SetBytesOverwritesExistingBuffer)
 {
-  Common::SettingsHandler::Buffer buffer = BUFFER_A;
-  Common::SettingsHandler handler(std::move(buffer));
+  Common::SettingsHandler handler(BUFFER_A);
   ASSERT_EQ(handler.GetValue("key"), "val");
   ASSERT_EQ(handler.GetValue("foo"), "");
 
-  Common::SettingsHandler::Buffer buffer2 = BUFFER_B;
-  handler.SetBytes(std::move(buffer2));
+  handler.SetBytes(BUFFER_B);
   EXPECT_EQ(handler.GetValue("foo"), "bar");
   EXPECT_EQ(handler.GetValue("key"), "");
 }
@@ -97,14 +93,13 @@ TEST(SettingsHandlerTest, GetValueOnSameInstance)
   EXPECT_EQ(handler.GetValue("key"), "");
 
   Common::SettingsHandler::Buffer buffer = handler.GetBytes();
-  handler.SetBytes(std::move(buffer));
+  handler.SetBytes(buffer);
   EXPECT_EQ(handler.GetValue("key"), "val");
 }
 
 TEST(SettingsHandlerTest, GetValueAfterReset)
 {
-  Common::SettingsHandler::Buffer buffer = BUFFER_A;
-  Common::SettingsHandler handler(std::move(buffer));
+  Common::SettingsHandler handler(BUFFER_A);
   ASSERT_EQ(handler.GetValue("key"), "val");
 
   handler.Reset();
@@ -131,14 +126,12 @@ TEST(SettingsHandlerTest, EncryptAddsLFOnNullCharTwice)
 
 TEST(SettingsHandlerTest, DecryptSingleAddedLF)
 {
-  Common::SettingsHandler::Buffer buffer = BUFFER_C;
-  Common::SettingsHandler handler(std::move(buffer));
+  Common::SettingsHandler handler(BUFFER_C);
   EXPECT_EQ(handler.GetValue("\xFA"), "a");
 }
 
 TEST(SettingsHandlerTest, DecryptTwoAddedLFs)
 {
-  Common::SettingsHandler::Buffer buffer = BUFFER_D;
-  Common::SettingsHandler handler(std::move(buffer));
+  Common::SettingsHandler handler(BUFFER_D);
   EXPECT_EQ(handler.GetValue("\xFA\xE9"), "a");
 }


### PR DESCRIPTION
`SettingsHandler::Buffer` is a type alias to a `std::array` of `u8`. Moving a `std::array` of primitives doesn't actually avoid any copies, since the elements are stored inline (https://stackoverflow.com/a/28988913). Changing these methods to take a const ref instead of an rvalue ref makes it clear that we are actually copying the arrays.