### PR TITLE
Memmap: Replace GetPointer with GetSpanForAddress

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -126,6 +126,7 @@ add_library(common
   SmallVector.h
   SocketContext.cpp
   SocketContext.h
+  SpanUtils.h
   SPSCQueue.h
   StringLiteral.h
   StringUtil.cpp

--- a/Source/Core/Common/SpanUtils.h
+++ b/Source/Core/Common/SpanUtils.h
@@ -1,0 +1,41 @@
+// Copyright 2024 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <span>
+#include <utility>
+
+#include "Common/CommonTypes.h"
+
+namespace Common
+{
+
+// Like std::span::subspan, except undefined behavior is replaced with returning a 0-length span.
+template <class T>
+[[nodiscard]] constexpr std::span<T> SafeSubspan(std::span<T> span, size_t offset,
+                                                 size_t count = std::dynamic_extent)
+{
+  if (count == std::dynamic_extent || offset > span.size())
+    return span.subspan(std::min(offset, span.size()));
+  else
+    return span.subspan(offset, std::min(count, span.size() - offset));
+}
+
+// Default-constructs an object of type T, then copies data into it from the specified offset in
+// the specified span. Out-of-bounds reads will be skipped, meaning that specifying a too large
+// offset results in the object partially or entirely remaining default constructed.
+template <class T>
+[[nodiscard]] T SafeSpanRead(std::span<const u8> span, size_t offset)
+{
+  static_assert(std::is_trivially_copyable<T>());
+
+  const std::span<const u8> subspan = SafeSubspan(span, offset);
+  T result{};
+  std::memcpy(&result, subspan.data(), std::min(subspan.size(), sizeof(result)));
+  return result;
+}
+
+}  // namespace Common

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -697,7 +697,7 @@ void FifoPlayer::LoadTextureMemory()
 {
   static_assert(static_cast<size_t>(TMEM_SIZE) == static_cast<size_t>(FifoDataFile::TEX_MEM_SIZE),
                 "TMEM_SIZE matches the size of texture memory in FifoDataFile");
-  std::memcpy(texMem, m_File->GetTexMem(), FifoDataFile::TEX_MEM_SIZE);
+  std::memcpy(s_tex_mem.data(), m_File->GetTexMem(), FifoDataFile::TEX_MEM_SIZE);
 }
 
 void FifoPlayer::WriteCP(u32 address, u16 value)

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -291,7 +291,7 @@ void FifoRecorder::RecordInitialVideoMemory()
 
   g_main_cp_state.FillCPMemoryArray(cpmem);
 
-  SetVideoMemory(bpmem_ptr, cpmem, xfmem_ptr, xfregs_ptr, xfregs_size, texMem);
+  SetVideoMemory(bpmem_ptr, cpmem, xfmem_ptr, xfregs_ptr, xfregs_size, s_tex_mem.data());
 }
 
 void FifoRecorder::StopRecording()

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -105,10 +106,16 @@ public:
   // Routines to access physically addressed memory, designed for use by
   // emulated hardware outside the CPU. Use "Device_" prefix.
   std::string GetString(u32 em_address, size_t size = 0);
-  // WARNING: Incrementing the pointer returned by GetPointer is unsafe without additional bounds
-  // checks. New code should use other functions instead, like GetPointerForRange or CopyFromEmu.
-  u8* GetPointer(u32 address) const;
+
+  // If the specified guest address is within a valid memory region, returns a span starting at the
+  // host address corresponding to the specified address and ending where the memory region ends.
+  // Otherwise, returns a 0-length span starting at nullptr.
+  std::span<u8> GetSpanForAddress(u32 address) const;
+
+  // If the specified range is within a single valid memory region, returns a pointer to the start
+  // of the corresponding range in host memory. Otherwise, returns nullptr.
   u8* GetPointerForRange(u32 address, size_t size) const;
+
   void CopyFromEmu(void* data, u32 address, size_t size) const;
   void CopyToEmu(u32 address, const void* data, size_t size);
   void Memset(u32 address, u8 value, size_t size);

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -153,6 +153,7 @@
     <ClInclude Include="Common\SFMLHelper.h" />
     <ClInclude Include="Common\SmallVector.h" />
     <ClInclude Include="Common\SocketContext.h" />
+    <ClInclude Include="Common\SpanUtils.h" />
     <ClInclude Include="Common\SPSCQueue.h" />
     <ClInclude Include="Common\StringLiteral.h" />
     <ClInclude Include="Common\StringUtil.h" />

--- a/Source/Core/VideoBackends/Software/TextureSampler.cpp
+++ b/Source/Core/VideoBackends/Software/TextureSampler.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <span>
 
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
@@ -137,7 +138,9 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
     auto& memory = system.GetMemory();
 
     const u32 imageBase = texUnit.texImage3.image_base << 5;
-    imageSrc = memory.GetPointer(imageBase);
+    // TODO: For memory safety, we need to check the size of this span
+    std::span<const u8> span = memory.GetSpanForAddress(imageBase);
+    imageSrc = span.data();
   }
 
   int image_width_minus_1 = ti0.width;

--- a/Source/Core/VideoBackends/Software/TextureSampler.cpp
+++ b/Source/Core/VideoBackends/Software/TextureSampler.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
+#include "Common/SpanUtils.h"
 #include "Core/HW/Memmap.h"
 #include "Core/System.h"
 
@@ -124,13 +125,13 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
   const TextureFormat texfmt = ti0.format;
   const TLUTFormat tlutfmt = texTlut.tlut_format;
 
-  const u8* imageSrc;
-  const u8* imageSrcOdd = nullptr;
+  std::span<const u8> image_src;
+  std::span<const u8> image_src_odd;
   if (texUnit.texImage1.cache_manually_managed)
   {
-    imageSrc = &texMem[texUnit.texImage1.tmem_even * TMEM_LINE_SIZE];
+    image_src = TexDecoder_GetTmemSpan(texUnit.texImage1.tmem_even * TMEM_LINE_SIZE);
     if (texfmt == TextureFormat::RGBA8)
-      imageSrcOdd = &texMem[texUnit.texImage2.tmem_odd * TMEM_LINE_SIZE];
+      image_src_odd = TexDecoder_GetTmemSpan(texUnit.texImage2.tmem_odd * TMEM_LINE_SIZE);
   }
   else
   {
@@ -138,16 +139,14 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
     auto& memory = system.GetMemory();
 
     const u32 imageBase = texUnit.texImage3.image_base << 5;
-    // TODO: For memory safety, we need to check the size of this span
-    std::span<const u8> span = memory.GetSpanForAddress(imageBase);
-    imageSrc = span.data();
+    image_src = memory.GetSpanForAddress(imageBase);
   }
 
   int image_width_minus_1 = ti0.width;
   int image_height_minus_1 = ti0.height;
 
   const int tlutAddress = texTlut.tmem_offset << 9;
-  const u8* tlut = &texMem[tlutAddress];
+  const std::span<const u8> tlut = TexDecoder_GetTmemSpan(tlutAddress);
 
   // reduce sample location and texture size to mip level
   // move texture pointer to mip location
@@ -171,7 +170,7 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
       mipHeight = std::max(mipHeight, fmtHeight);
       const u32 size = (mipWidth * mipHeight * fmtDepth) >> 1;
 
-      imageSrc += size;
+      image_src = Common::SafeSubspan(image_src, size);
       mipWidth >>= 1;
       mipHeight >>= 1;
       mip--;
@@ -205,37 +204,37 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
 
     if (!(texfmt == TextureFormat::RGBA8 && texUnit.texImage1.cache_manually_managed))
     {
-      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageS, imageT, image_width_minus_1, texfmt,
+      TexDecoder_DecodeTexel(sampledTex, image_src, imageS, imageT, image_width_minus_1, texfmt,
                              tlut, tlutfmt);
       SetTexel(sampledTex, texel, (128 - fractS) * (128 - fractT));
 
-      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageSPlus1, imageT, image_width_minus_1, texfmt,
-                             tlut, tlutfmt);
+      TexDecoder_DecodeTexel(sampledTex, image_src, imageSPlus1, imageT, image_width_minus_1,
+                             texfmt, tlut, tlutfmt);
       AddTexel(sampledTex, texel, (fractS) * (128 - fractT));
 
-      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageS, imageTPlus1, image_width_minus_1, texfmt,
-                             tlut, tlutfmt);
+      TexDecoder_DecodeTexel(sampledTex, image_src, imageS, imageTPlus1, image_width_minus_1,
+                             texfmt, tlut, tlutfmt);
       AddTexel(sampledTex, texel, (128 - fractS) * (fractT));
 
-      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageSPlus1, imageTPlus1, image_width_minus_1,
+      TexDecoder_DecodeTexel(sampledTex, image_src, imageSPlus1, imageTPlus1, image_width_minus_1,
                              texfmt, tlut, tlutfmt);
       AddTexel(sampledTex, texel, (fractS) * (fractT));
     }
     else
     {
-      TexDecoder_DecodeTexelRGBA8FromTmem(sampledTex, imageSrc, imageSrcOdd, imageS, imageT,
+      TexDecoder_DecodeTexelRGBA8FromTmem(sampledTex, image_src, image_src_odd, imageS, imageT,
                                           image_width_minus_1);
       SetTexel(sampledTex, texel, (128 - fractS) * (128 - fractT));
 
-      TexDecoder_DecodeTexelRGBA8FromTmem(sampledTex, imageSrc, imageSrcOdd, imageSPlus1, imageT,
+      TexDecoder_DecodeTexelRGBA8FromTmem(sampledTex, image_src, image_src_odd, imageSPlus1, imageT,
                                           image_width_minus_1);
       AddTexel(sampledTex, texel, (fractS) * (128 - fractT));
 
-      TexDecoder_DecodeTexelRGBA8FromTmem(sampledTex, imageSrc, imageSrcOdd, imageS, imageTPlus1,
+      TexDecoder_DecodeTexelRGBA8FromTmem(sampledTex, image_src, image_src_odd, imageS, imageTPlus1,
                                           image_width_minus_1);
       AddTexel(sampledTex, texel, (128 - fractS) * (fractT));
 
-      TexDecoder_DecodeTexelRGBA8FromTmem(sampledTex, imageSrc, imageSrcOdd, imageSPlus1,
+      TexDecoder_DecodeTexelRGBA8FromTmem(sampledTex, image_src, image_src_odd, imageSPlus1,
                                           imageTPlus1, image_width_minus_1);
       AddTexel(sampledTex, texel, (fractS) * (fractT));
     }
@@ -256,11 +255,15 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
     WrapCoord(&imageT, tm0.wrap_t, image_height_minus_1 + 1);
 
     if (!(texfmt == TextureFormat::RGBA8 && texUnit.texImage1.cache_manually_managed))
-      TexDecoder_DecodeTexel(sample, imageSrc, imageS, imageT, image_width_minus_1, texfmt, tlut,
+    {
+      TexDecoder_DecodeTexel(sample, image_src, imageS, imageT, image_width_minus_1, texfmt, tlut,
                              tlutfmt);
+    }
     else
-      TexDecoder_DecodeTexelRGBA8FromTmem(sample, imageSrc, imageSrcOdd, imageS, imageT,
+    {
+      TexDecoder_DecodeTexelRGBA8FromTmem(sample, image_src, image_src_odd, imageS, imageT,
                                           image_width_minus_1);
+    }
   }
 }
 }  // namespace TextureSampler

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -401,7 +401,7 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
     static_assert(MAX_LOADABLE_TMEM_ADDR + MAX_TMEM_LINE_COUNT < TMEM_SIZE);
 
     auto& memory = system.GetMemory();
-    memory.CopyFromEmu(texMem + tmem_addr, addr, tmem_transfer_count);
+    memory.CopyFromEmu(s_tex_mem.data() + tmem_addr, addr, tmem_transfer_count);
 
     if (OpcodeDecoder::g_record_fifo_data)
       system.GetFifoRecorder().UseMemory(addr, tmem_transfer_count, MemoryUpdate::Type::TMEM);
@@ -596,7 +596,7 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
 
         auto& system = Core::System::GetInstance();
         auto& memory = system.GetMemory();
-        memory.CopyFromEmu(texMem + tmem_addr_even, src_addr, bytes_read);
+        memory.CopyFromEmu(s_tex_mem.data() + tmem_addr_even, src_addr, bytes_read);
       }
       else  // RGBA8 tiles (and CI14, but that might just be stupid libogc!)
       {
@@ -615,9 +615,10 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
             break;
           }
 
-          memory.CopyFromEmu(texMem + tmem_addr_even, src_addr + bytes_read, TMEM_LINE_SIZE);
-          memory.CopyFromEmu(texMem + tmem_addr_odd, src_addr + bytes_read + TMEM_LINE_SIZE,
+          memory.CopyFromEmu(s_tex_mem.data() + tmem_addr_even, src_addr + bytes_read,
                              TMEM_LINE_SIZE);
+          memory.CopyFromEmu(s_tex_mem.data() + tmem_addr_odd,
+                             src_addr + bytes_read + TMEM_LINE_SIZE, TMEM_LINE_SIZE);
           tmem_addr_even += TMEM_LINE_SIZE;
           tmem_addr_odd += TMEM_LINE_SIZE;
           bytes_read += TMEM_LINE_SIZE * 2;

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -590,13 +590,16 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
 
       if (tmem_cfg.preload_tile_info.type != 3)
       {
-        bytes_read = tmem_cfg.preload_tile_info.count * TMEM_LINE_SIZE;
-        if (tmem_addr_even + bytes_read > TMEM_SIZE)
-          bytes_read = TMEM_SIZE - tmem_addr_even;
+        if (tmem_addr_even < TMEM_SIZE)
+        {
+          bytes_read = tmem_cfg.preload_tile_info.count * TMEM_LINE_SIZE;
+          if (tmem_addr_even + bytes_read > TMEM_SIZE)
+            bytes_read = TMEM_SIZE - tmem_addr_even;
 
-        auto& system = Core::System::GetInstance();
-        auto& memory = system.GetMemory();
-        memory.CopyFromEmu(s_tex_mem.data() + tmem_addr_even, src_addr, bytes_read);
+          auto& system = Core::System::GetInstance();
+          auto& memory = system.GetMemory();
+          memory.CopyFromEmu(s_tex_mem.data() + tmem_addr_even, src_addr, bytes_read);
+        }
       }
       else  // RGBA8 tiles (and CI14, but that might just be stupid libogc!)
       {

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1319,6 +1319,9 @@ TCacheEntry* TextureCacheBase::LoadImpl(const TextureInfo& texture_info, bool fo
 RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSampleSize,
                                            const TextureInfo& texture_info)
 {
+  if (!texture_info.IsDataValid())
+    return {};
+
   // Hash assigned to texcache entry (also used to generate filenames used for texture dumping and
   // custom texture lookup)
   u64 base_hash = TEXHASH_INVALID;
@@ -1337,12 +1340,6 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
   // TODO: the texture cache lookup is based on address, but a texture from tmem has no reason
   //       to have a unique and valid address. This could result in a regular texture and a tmem
   //       texture aliasing onto the same texture cache entry.
-  if (!texture_info.GetData())
-  {
-    ERROR_LOG_FMT(VIDEO, "Trying to use an invalid texture address {:#010x}",
-                  texture_info.GetRawAddress());
-    return {};
-  }
 
   // If we are recording a FifoLog, keep track of what memory we read. FifoRecorder does
   // its own memory modification tracking independent of the texture hashing below.
@@ -1916,7 +1913,7 @@ RcTcacheEntry TextureCacheBase::GetXFBTexture(u32 address, u32 width, u32 height
   entry->frameCount = FRAMECOUNT_INVALID;
   if (!g_ActiveConfig.UseGPUTextureDecoding() ||
       !DecodeTextureOnGPU(entry, 0, src_data, total_size, entry->format.texfmt, width, height,
-                          width, height, stride, texMem, entry->format.tlutfmt))
+                          width, height, stride, s_tex_mem.data(), entry->format.tlutfmt))
   {
     const u32 decoded_size = width * height * sizeof(u32);
     CheckTempSize(decoded_size);

--- a/Source/Core/VideoCommon/TextureDecoder.h
+++ b/Source/Core/VideoCommon/TextureDecoder.h
@@ -3,16 +3,20 @@
 
 #pragma once
 
+#include <array>
+#include <span>
 #include <tuple>
+
 #include "Common/CommonTypes.h"
 #include "Common/EnumFormatter.h"
+#include "Common/SpanUtils.h"
 
 enum
 {
   TMEM_SIZE = 1024 * 1024,
   TMEM_LINE_SIZE = 32,
 };
-alignas(16) extern u8 texMem[TMEM_SIZE];
+alignas(16) extern std::array<u8, TMEM_SIZE> s_tex_mem;
 
 enum class TextureFormat
 {
@@ -171,6 +175,11 @@ static inline bool CanReinterpretTextureOnGPU(TextureFormat from_format, Texture
   }
 }
 
+inline std::span<u8> TexDecoder_GetTmemSpan(size_t offset = 0)
+{
+  return Common::SafeSubspan(std::span<u8>(s_tex_mem), offset);
+}
+
 int TexDecoder_GetTexelSizeInNibbles(TextureFormat format);
 int TexDecoder_GetTextureSizeInBytes(int width, int height, TextureFormat format);
 int TexDecoder_GetBlockWidthInTexels(TextureFormat format);
@@ -184,8 +193,10 @@ void TexDecoder_Decode(u8* dst, const u8* src, int width, int height, TextureFor
                        const u8* tlut, TLUTFormat tlutfmt);
 void TexDecoder_DecodeRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb, int width,
                                     int height);
-void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth,
-                            TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt);
+void TexDecoder_DecodeTexel(u8* dst, std::span<const u8> src, int s, int t, int imageWidth,
+                            TextureFormat texformat, std::span<const u8> tlut, TLUTFormat tlutfmt);
+void TexDecoder_DecodeTexelRGBA8FromTmem(u8* dst, std::span<const u8> src_ar,
+                                         std::span<const u8> src_gb, int s, int t, int imageWidth);
 void TexDecoder_DecodeTexelRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb, int s, int t,
                                          int imageWidth);
 void TexDecoder_DecodeXFB(u8* dst, const u8* src, u32 width, u32 height, u32 stride);

--- a/Source/Core/VideoCommon/TextureInfo.cpp
+++ b/Source/Core/VideoCommon/TextureInfo.cpp
@@ -9,6 +9,9 @@
 #include <xxhash.h>
 
 #include "Common/Align.h"
+#include "Common/Assert.h"
+#include "Common/Logging/Log.h"
+#include "Common/SpanUtils.h"
 #include "Core/HW/Memmap.h"
 #include "Core/System.h"
 #include "VideoCommon/BPMemory.h"
@@ -27,7 +30,7 @@ TextureInfo TextureInfo::FromStage(u32 stage)
   const u32 address = (tex.texImage3.image_base /* & 0x1FFFFF*/) << 5;
 
   const u32 tlutaddr = tex.texTlut.tmem_offset << 9;
-  const u8* tlut_ptr = &texMem[tlutaddr];
+  std::span<const u8> tlut_data = TexDecoder_GetTmemSpan(tlutaddr);
 
   std::optional<u32> mip_count;
   const bool has_mipmaps = tex.texMode0.mipmap_filter != MipMode::None;
@@ -42,25 +45,24 @@ TextureInfo TextureInfo::FromStage(u32 stage)
 
   if (from_tmem)
   {
-    return TextureInfo(stage, &texMem[tmem_address_even], tlut_ptr, address, texture_format,
-                       tlut_format, width, height, true, &texMem[tmem_address_odd],
-                       &texMem[tmem_address_even], mip_count);
+    return TextureInfo(stage, TexDecoder_GetTmemSpan(tmem_address_even), tlut_data, address,
+                       texture_format, tlut_format, width, height, true,
+                       TexDecoder_GetTmemSpan(tmem_address_odd),
+                       TexDecoder_GetTmemSpan(tmem_address_even), mip_count);
   }
 
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
-  // TODO: For memory safety, we need to check the size of this span
-  std::span<const u8> span = memory.GetSpanForAddress(address);
-  return TextureInfo(stage, span.data(), tlut_ptr, address, texture_format, tlut_format, width,
-                     height, false, nullptr, nullptr, mip_count);
+  return TextureInfo(stage, memory.GetSpanForAddress(address), tlut_data, address, texture_format,
+                     tlut_format, width, height, false, {}, {}, mip_count);
 }
 
-TextureInfo::TextureInfo(u32 stage, const u8* ptr, const u8* tlut_ptr, u32 address,
-                         TextureFormat texture_format, TLUTFormat tlut_format, u32 width,
-                         u32 height, bool from_tmem, const u8* tmem_odd, const u8* tmem_even,
-                         std::optional<u32> mip_count)
-    : m_ptr(ptr), m_tlut_ptr(tlut_ptr), m_address(address), m_from_tmem(from_tmem),
-      m_tmem_odd(tmem_odd), m_texture_format(texture_format), m_tlut_format(tlut_format),
+TextureInfo::TextureInfo(u32 stage, std::span<const u8> data, std::span<const u8> tlut_data,
+                         u32 address, TextureFormat texture_format, TLUTFormat tlut_format,
+                         u32 width, u32 height, bool from_tmem, std::span<const u8> tmem_odd,
+                         std::span<const u8> tmem_even, std::optional<u32> mip_count)
+    : m_ptr(data.data()), m_tlut_ptr(tlut_data.data()), m_address(address), m_from_tmem(from_tmem),
+      m_tmem_odd(tmem_odd.data()), m_texture_format(texture_format), m_tlut_format(tlut_format),
       m_raw_width(width), m_raw_height(height), m_stage(stage)
 {
   const bool is_palette_texture = IsColorIndexed(m_texture_format);
@@ -77,6 +79,21 @@ TextureInfo::TextureInfo(u32 stage, const u8* ptr, const u8* tlut_ptr, u32 addre
   m_texture_size =
       TexDecoder_GetTextureSizeInBytes(m_expanded_width, m_expanded_height, m_texture_format);
 
+  if (data.size() < m_texture_size)
+  {
+    ERROR_LOG_FMT(VIDEO, "Trying to use an invalid texture address {:#010x}", GetRawAddress());
+    m_data_valid = false;
+  }
+  else if (m_palette_size && tlut_data.size() < *m_palette_size)
+  {
+    ERROR_LOG_FMT(VIDEO, "Trying to use an invalid TLUT address {:#010x}", GetRawAddress());
+    m_data_valid = false;
+  }
+  else
+  {
+    m_data_valid = true;
+  }
+
   if (mip_count)
   {
     m_mipmaps_enabled = true;
@@ -90,13 +107,17 @@ TextureInfo::TextureInfo(u32 stage, const u8* ptr, const u8* tlut_ptr, u32 addre
         std::min<u32>(MathUtil::IntLog2(std::max(width, height)) + 1, raw_mip_count + 1) - 1;
 
     // load mips
-    const u8* src_data = m_ptr + GetTextureSize();
-    if (tmem_even)
-      tmem_even += GetTextureSize();
+    std::span<const u8> src_data = Common::SafeSubspan(data, GetTextureSize());
+    tmem_even = Common::SafeSubspan(tmem_even, GetTextureSize());
 
     for (u32 i = 0; i < limited_mip_count; i++)
     {
-      MipLevel mip_level(i + 1, *this, m_from_tmem, src_data, tmem_even, tmem_odd);
+      MipLevel mip_level(i + 1, *this, m_from_tmem, &src_data, &tmem_even, &tmem_odd);
+      if (!mip_level.IsDataValid())
+      {
+        ERROR_LOG_FMT(VIDEO, "Trying to use an invalid mipmap address {:#010x}", GetRawAddress());
+        break;
+      }
       m_mip_levels.push_back(std::move(mip_level));
     }
   }
@@ -109,7 +130,7 @@ std::string TextureInfo::NameDetails::GetFullName() const
 
 TextureInfo::NameDetails TextureInfo::CalculateTextureName() const
 {
-  if (!m_ptr)
+  if (!IsDataValid())
     return NameDetails{};
 
   const u8* tlut = m_tlut_ptr;
@@ -133,7 +154,6 @@ TextureInfo::NameDetails TextureInfo::CalculateTextureName() const
     }
     break;
   case 256 * 2:
-  {
     for (size_t i = 0; i < m_texture_size; i++)
     {
       const u32 texture_byte = m_ptr[i];
@@ -142,7 +162,6 @@ TextureInfo::NameDetails TextureInfo::CalculateTextureName() const
       max = std::max(max, texture_byte);
     }
     break;
-  }
   case 16384 * 2:
     for (size_t i = 0; i < m_texture_size; i += sizeof(u16))
     {
@@ -159,6 +178,8 @@ TextureInfo::NameDetails TextureInfo::CalculateTextureName() const
     tlut += 2 * min;
   }
 
+  DEBUG_ASSERT(tlut_size <= m_palette_size.value_or(0));
+
   const u64 tex_hash = XXH64(m_ptr, m_texture_size, 0);
   const u64 tlut_hash = tlut_size ? XXH64(tlut, tlut_size, 0) : 0;
 
@@ -170,6 +191,11 @@ TextureInfo::NameDetails TextureInfo::CalculateTextureName() const
   result.format_name = fmt::to_string(static_cast<int>(m_texture_format));
 
   return result;
+}
+
+bool TextureInfo::IsDataValid() const
+{
+  return m_data_valid;
 }
 
 const u8* TextureInfo::GetData() const
@@ -271,7 +297,8 @@ const TextureInfo::MipLevel* TextureInfo::GetMipMapLevel(u32 level) const
 }
 
 TextureInfo::MipLevel::MipLevel(u32 level, const TextureInfo& parent, bool from_tmem,
-                                const u8*& src_data, const u8*& ptr_even, const u8*& ptr_odd)
+                                std::span<const u8>* src_data, std::span<const u8>* tmem_even,
+                                std::span<const u8>* tmem_odd)
 {
   m_raw_width = std::max(parent.GetRawWidth() >> level, 1u);
   m_raw_height = std::max(parent.GetRawHeight() >> level, 1u);
@@ -281,9 +308,11 @@ TextureInfo::MipLevel::MipLevel(u32 level, const TextureInfo& parent, bool from_
   m_texture_size = TexDecoder_GetTextureSizeInBytes(m_expanded_width, m_expanded_height,
                                                     parent.GetTextureFormat());
 
-  const u8*& ptr = from_tmem ? ((level % 2) ? ptr_odd : ptr_even) : src_data;
-  m_ptr = ptr;
-  ptr += m_texture_size;
+  std::span<const u8>* data = from_tmem ? ((level % 2) ? tmem_odd : tmem_even) : src_data;
+  m_ptr = data->data();
+  m_data_valid = data->size() >= m_texture_size;
+
+  *data = Common::SafeSubspan(*data, m_texture_size);
 }
 
 u32 TextureInfo::GetFullLevelSize() const
@@ -294,6 +323,11 @@ u32 TextureInfo::GetFullLevelSize() const
     all_mips_size += mip_map.GetTextureSize();
   }
   return m_texture_size + all_mips_size;
+}
+
+bool TextureInfo::MipLevel::IsDataValid() const
+{
+  return m_data_valid;
 }
 
 const u8* TextureInfo::MipLevel::GetData() const

--- a/Source/Core/VideoCommon/TextureInfo.cpp
+++ b/Source/Core/VideoCommon/TextureInfo.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoCommon/TextureInfo.h"
 
+#include <span>
+
 #include <fmt/format.h>
 #include <xxhash.h>
 
@@ -47,8 +49,10 @@ TextureInfo TextureInfo::FromStage(u32 stage)
 
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
-  return TextureInfo(stage, memory.GetPointer(address), tlut_ptr, address, texture_format,
-                     tlut_format, width, height, false, nullptr, nullptr, mip_count);
+  // TODO: For memory safety, we need to check the size of this span
+  std::span<const u8> span = memory.GetSpanForAddress(address);
+  return TextureInfo(stage, span.data(), tlut_ptr, address, texture_format, tlut_format, width,
+                     height, false, nullptr, nullptr, mip_count);
 }
 
 TextureInfo::TextureInfo(u32 stage, const u8* ptr, const u8* tlut_ptr, u32 address,

--- a/Source/Core/VideoCommon/TextureInfo.h
+++ b/Source/Core/VideoCommon/TextureInfo.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -17,9 +18,9 @@ class TextureInfo
 {
 public:
   static TextureInfo FromStage(u32 stage);
-  TextureInfo(u32 stage, const u8* ptr, const u8* tlut_ptr, u32 address,
+  TextureInfo(u32 stage, std::span<const u8> data, std::span<const u8> tlut_data, u32 address,
               TextureFormat texture_format, TLUTFormat tlut_format, u32 width, u32 height,
-              bool from_tmem, const u8* tmem_odd, const u8* tmem_even,
+              bool from_tmem, std::span<const u8> tmem_odd, std::span<const u8> tmem_even,
               std::optional<u32> mip_count);
 
   struct NameDetails
@@ -32,6 +33,8 @@ public:
     std::string GetFullName() const;
   };
   NameDetails CalculateTextureName() const;
+
+  bool IsDataValid() const;
 
   const u8* GetData() const;
   const u8* GetTlutAddress() const;
@@ -61,11 +64,12 @@ public:
   class MipLevel
   {
   public:
-    MipLevel(u32 level, const TextureInfo& parent, bool from_tmem, const u8*& src_data,
-             const u8*& ptr_even, const u8*& ptr_odd);
+    MipLevel(u32 level, const TextureInfo& parent, bool from_tmem, std::span<const u8>* src_data,
+             std::span<const u8>* tmem_even, std::span<const u8>* tmem_odd);
+
+    bool IsDataValid() const;
 
     const u8* GetData() const;
-
     u32 GetTextureSize() const;
 
     u32 GetExpandedWidth() const;
@@ -75,6 +79,8 @@ public:
     u32 GetRawHeight() const;
 
   private:
+    bool m_data_valid;
+
     const u8* m_ptr;
 
     u32 m_texture_size = 0;
@@ -98,6 +104,8 @@ private:
   const u8* m_tlut_ptr;
 
   u32 m_address;
+
+  bool m_data_valid;
 
   bool m_from_tmem;
   const u8* m_tmem_odd;

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -91,26 +91,35 @@ void UpdateVertexArrayPointers()
   // Note: Only array bases 0 through 11 are used by the Vertex loaders.
   //       12 through 15 are used for loading data into xfmem.
   // We also only update the array base if the vertex description states we are going to use it.
+  // TODO: For memory safety, we need to check the sizes returned by GetSpanForAddress
   if (IsIndexed(g_main_cp_state.vtx_desc.low.Position))
+  {
     cached_arraybases[CPArray::Position] =
-        memory.GetPointer(g_main_cp_state.array_bases[CPArray::Position]);
+        memory.GetSpanForAddress(g_main_cp_state.array_bases[CPArray::Position]).data();
+  }
 
   if (IsIndexed(g_main_cp_state.vtx_desc.low.Normal))
+  {
     cached_arraybases[CPArray::Normal] =
-        memory.GetPointer(g_main_cp_state.array_bases[CPArray::Normal]);
+        memory.GetSpanForAddress(g_main_cp_state.array_bases[CPArray::Normal]).data();
+  }
 
   for (u8 i = 0; i < g_main_cp_state.vtx_desc.low.Color.Size(); i++)
   {
     if (IsIndexed(g_main_cp_state.vtx_desc.low.Color[i]))
+    {
       cached_arraybases[CPArray::Color0 + i] =
-          memory.GetPointer(g_main_cp_state.array_bases[CPArray::Color0 + i]);
+          memory.GetSpanForAddress(g_main_cp_state.array_bases[CPArray::Color0 + i]).data();
+    }
   }
 
   for (u8 i = 0; i < g_main_cp_state.vtx_desc.high.TexCoord.Size(); i++)
   {
     if (IsIndexed(g_main_cp_state.vtx_desc.high.TexCoord[i]))
+    {
       cached_arraybases[CPArray::TexCoord0 + i] =
-          memory.GetPointer(g_main_cp_state.array_bases[CPArray::TexCoord0 + i]);
+          memory.GetSpanForAddress(g_main_cp_state.array_bases[CPArray::TexCoord0 + i]).data();
+    }
   }
 
   g_bases_dirty = false;

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -344,7 +344,7 @@ bool VideoBackendBase::InitializeShared(std::unique_ptr<AbstractGfx> gfx,
 {
   memset(reinterpret_cast<u8*>(&g_main_cp_state), 0, sizeof(g_main_cp_state));
   memset(reinterpret_cast<u8*>(&g_preprocess_cp_state), 0, sizeof(g_preprocess_cp_state));
-  memset(texMem, 0, TMEM_SIZE);
+  s_tex_mem.fill(0);
 
   // do not initialize again for the config window
   m_initialized = true;

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -57,7 +57,7 @@ void VideoCommon_DoState(PointerWrap& p)
   p.DoMarker("XF Memory");
 
   // Texture decoder
-  p.DoArray(texMem);
+  p.DoArray(s_tex_mem);
   p.DoMarker("texMem");
 
   // TMEM


### PR DESCRIPTION
To ensure memory safety, callers of GetPointer have to perform a bounds check. But how is this bounds check supposed to be performed? GetPointerForRange contained one implementation of a bounds check, but it was cumbersome, and it also isn't obvious why it's correct.

To make doing the right thing easier, the first commit of this PR changes GetPointer to return a span that tells the caller how many bytes it's allowed to access. Then, the second commit adds bounds checks to two of the three callers of GetPointer. The third caller, VertexLoader, will have to wait due to its tight optimization.