### PR TITLE
Android/ControllerInterface: Run the init code

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -448,7 +448,7 @@ namespace ciface::Android
 class InputBackend final : public ciface::InputBackend
 {
 public:
-  using ciface::InputBackend::InputBackend;
+  InputBackend(ControllerInterface* controller_interface);
   ~InputBackend();
   void PopulateDevices() override;
 
@@ -797,7 +797,8 @@ static jintArray CreateKeyCodesArray(JNIEnv* env)
   return keycodes_array;
 }
 
-void Init()
+InputBackend::InputBackend(ControllerInterface* controller_interface)
+    : ciface::InputBackend(controller_interface)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 


### PR DESCRIPTION
This was broken by a9a9fdd9e9. Because Init didn't run, the Android input backend would crash whenever it tried to call into JVM code.