### PR TITLE
RetroAchievements: Put "RetroAchievements.ini" in the correct config location for POSIX

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -918,6 +918,8 @@ static void RebuildUserDirectories(unsigned int dir_index)
     s_user_paths[F_DUALSHOCKUDPCLIENTCONFIG_IDX] =
         s_user_paths[D_CONFIG_IDX] + DUALSHOCKUDPCLIENT_CONFIG;
     s_user_paths[F_FREELOOKCONFIG_IDX] = s_user_paths[D_CONFIG_IDX] + FREELOOK_CONFIG;
+    s_user_paths[F_RETROACHIEVEMENTSCONFIG_IDX] =
+        s_user_paths[D_CONFIG_IDX] + RETROACHIEVEMENTS_CONFIG;
     break;
 
   case D_CACHE_IDX:


### PR DESCRIPTION
Neglecting this case in `File::RebuildUserDirectories` leaves `RetroAchievements.ini` in `/home/<username>/.local/share/dolphin-emu/Config/` rather than `/home/<username>/.config/` as expected.