### PR TITLE
DolphinQt/Mapping: Disable relative input when "Mouse Controlled Pointing" button is pressed.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -172,7 +172,9 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
   {
     QPushButton* mouse_button = new QPushButton(tr("Use Mouse Controlled Pointing"));
     form_layout->insertRow(2, mouse_button);
-    connect(mouse_button, &QCheckBox::clicked, [this, group] {
+
+    using ControllerEmu::Cursor;
+    connect(mouse_button, &QCheckBox::clicked, [this, group = static_cast<Cursor*>(group)] {
       std::string default_device = g_controller_interface.GetDefaultDeviceString() + ":";
       const std::string controller_device = GetController()->GetDefaultDevice().ToString() + ":";
       if (default_device == controller_device)
@@ -183,6 +185,9 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
       group->SetControlExpression(1, fmt::format("`{}Cursor Y+`", default_device));
       group->SetControlExpression(2, fmt::format("`{}Cursor X-`", default_device));
       group->SetControlExpression(3, fmt::format("`{}Cursor X+`", default_device));
+
+      group->SetRelativeInput(false);
+
       emit ConfigChanged();
       GetController()->UpdateReferences(g_controller_interface);
     });

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -181,6 +181,11 @@ ControlState Cursor::GetVerticalOffset() const
   return m_vertical_offset_setting.GetValue() / 100;
 }
 
+void Cursor::SetRelativeInput(bool value)
+{
+  m_relative_setting.SetValue(value);
+}
+
 bool Cursor::StateData::IsVisible() const
 {
   return !std::isnan(x);

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -40,6 +40,8 @@ public:
   // Vertical offset in meters.
   ControlState GetVerticalOffset() const;
 
+  void SetRelativeInput(bool enabled);
+
 private:
   Cursor::StateData UpdateState(Cursor::ReshapeData input);
 

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -186,7 +186,6 @@ public:
 
   bool IsSimpleValue() const { return m_input.GetExpression().empty(); }
 
-private:
   void SetValue(ValueType value)
   {
     m_value = value;
@@ -195,6 +194,7 @@ private:
     m_input.SetExpression("");
   }
 
+private:
   // Values are R/W by both UI and CPU threads.
   mutable std::atomic<ValueType> m_value = {};
 


### PR DESCRIPTION
If "Relative Input" is enabled then "Mouse Controlled Pointing" will not work properly.
Some users don't understand the "Relative Input" setting so it's probably a good idea to set it for them.