### PR TITLE
InputCommon: Fix unnecessary "Modifier/Range" ini file entries.

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -275,6 +275,14 @@ void ReshapableInput::SaveConfig(Common::IniFile::Section* section,
   ControlGroup::SaveConfig(section, default_device, base_name);
 
   const std::string group(base_name + name + '/');
+
+  // Special handling for "Modifier" button "Range" settings which default to 50% instead of 100%.
+  if (const auto* modifier_input = GetModifierInput())
+  {
+    section->Set(group + modifier_input->name + "/Range", modifier_input->control_ref->range * 100,
+                 50.0);
+  }
+
   std::vector<std::string> save_data(m_calibration.size());
   std::transform(
       m_calibration.begin(), m_calibration.end(), save_data.begin(),


### PR DESCRIPTION
This prevents "Modifier/Range" values from saving if they are the default of 50%.
It was annoying that even non-configured Wii Remotes produced many of these ini file lines.

It changes this:
```ini
[Wiimote3]
Device = XInput2/0/Virtual core pointer
Source = 0
Tilt/Modifier/Range = 50.
Nunchuk/Stick/Modifier/Range = 50.
Nunchuk/Tilt/Modifier/Range = 50.
Classic/Left Stick/Modifier/Range = 50.
Classic/Right Stick/Modifier/Range = 50.
Guitar/Stick/Modifier/Range = 50.
Drums/Stick/Modifier/Range = 50.
Turntable/Stick/Modifier/Range = 50.
uDraw/Stylus/Modifier/Range = 50.
Drawsome/Stylus/Modifier/Range = 50.
[Wiimote4]
Device = XInput2/0/Virtual core pointer
Source = 0
Tilt/Modifier/Range = 50.
Nunchuk/Stick/Modifier/Range = 50.
Nunchuk/Tilt/Modifier/Range = 50.
Classic/Left Stick/Modifier/Range = 50.
Classic/Right Stick/Modifier/Range = 50.
Guitar/Stick/Modifier/Range = 50.
Drums/Stick/Modifier/Range = 50.
Turntable/Stick/Modifier/Range = 50.
uDraw/Stylus/Modifier/Range = 50.
Drawsome/Stylus/Modifier/Range = 50.
[BalanceBoard]
Device = XInput2/0/Virtual core pointer
Source = 0
Tilt/Modifier/Range = 50.
Nunchuk/Stick/Modifier/Range = 50.
Nunchuk/Tilt/Modifier/Range = 50.
Classic/Left Stick/Modifier/Range = 50.
Classic/Right Stick/Modifier/Range = 50.
Guitar/Stick/Modifier/Range = 50.
Drums/Stick/Modifier/Range = 50.
Turntable/Stick/Modifier/Range = 50.
uDraw/Stylus/Modifier/Range = 50.
Drawsome/Stylus/Modifier/Range = 50.
```

To this:
```ini
[Wiimote3]
Device = XInput2/0/Virtual core pointer
Source = 0
[Wiimote4]
Device = XInput2/0/Virtual core pointer
Source = 0
[BalanceBoard]
Device = XInput2/0/Virtual core pointer
Source = 0
```