### PR TITLE
Change JitState::downcountAmount to a u32

### DIFF
--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -48,7 +48,7 @@ constexpr std::array<const char*, 3> s_patch_type_strings{{
 static std::vector<Patch> s_on_frame;
 static std::vector<std::size_t> s_on_frame_memory;
 static std::mutex s_on_frame_memory_mutex;
-static std::map<u32, int> s_speed_hacks;
+static std::map<u32, u32> s_speed_hacks;
 
 const char* PatchTypeAsString(PatchType type)
 {
@@ -192,13 +192,13 @@ static void LoadSpeedhacks(const std::string& section, Common::IniFile& ini)
       success &= TryParse(value, &cycles);
       if (success)
       {
-        s_speed_hacks[address] = static_cast<int>(cycles);
+        s_speed_hacks[address] = cycles;
       }
     }
   }
 }
 
-int GetSpeedhackCycles(const u32 addr)
+u32 GetSpeedhackCycles(const u32 addr)
 {
   const auto iter = s_speed_hacks.find(addr);
   if (iter == s_speed_hacks.end())

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -49,7 +49,7 @@ struct Patch
 
 const char* PatchTypeAsString(PatchType type);
 
-int GetSpeedhackCycles(const u32 addr);
+u32 GetSpeedhackCycles(const u32 addr);
 
 std::optional<PatchEntry> DeserializeLine(std::string line);
 std::string SerializeLine(const PatchEntry& entry);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -93,7 +93,7 @@ protected:
     u32 blockStart;
     int instructionNumber;
     int instructionsLeft;
-    int downcountAmount;
+    u32 downcountAmount;
     u32 numLoadStoreInst;
     u32 numFloatingPointInst;
     // If this is set, we need to generate an exception handler for the fastmem load.

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -38,7 +38,7 @@ void JitBlock::ProfileData::BeginProfiling(ProfileData* data)
   data->time_start = Clock::now();
 }
 
-void JitBlock::ProfileData::EndProfiling(ProfileData* data, int downcount_amount)
+void JitBlock::ProfileData::EndProfiling(ProfileData* data, u32 downcount_amount)
 {
   data->cycles_spent += downcount_amount;
   data->time_spent += Clock::now() - data->time_start;

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -71,7 +71,7 @@ struct JitBlock : public JitBlockData
     using Clock = std::chrono::steady_clock;
 
     static void BeginProfiling(ProfileData* data);
-    static void EndProfiling(ProfileData* data, int downcount_amount);
+    static void EndProfiling(ProfileData* data, u32 downcount_amount);
 
     std::size_t run_count = 0;
     u64 cycles_spent = 0;

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -88,7 +88,7 @@ struct CodeOp  // 16B
 
 struct BlockStats
 {
-  int numCycles;
+  u32 numCycles;
 };
 
 struct BlockRegStats


### PR DESCRIPTION
Almost every place I found pretends this is unsigned anyway. PatchEngine acknowledges `downcountAmount` is an int... and casts a `u32` into an `int` in doing so. `BeginProfiling` and `EndProfiling` I wrote, so I know that's fine to change too. `BlockStats::numCycles` only ever has unsigned values added to it, and only ever adds to `downcountAmount`.