### PR TITLE
Apply Clang-Tidy's modernize-use-starts-ends-with

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -1017,11 +1017,11 @@ bool ESCore::IsIssuerCorrect(VerifyContainerType type, const ES::CertReader& iss
   switch (type)
   {
   case VerifyContainerType::TMD:
-    return issuer_cert.GetName().compare(0, 2, "CP") == 0;
+    return issuer_cert.GetName().starts_with("CP");
   case VerifyContainerType::Ticket:
-    return issuer_cert.GetName().compare(0, 2, "XS") == 0;
+    return issuer_cert.GetName().starts_with("XS");
   case VerifyContainerType::Device:
-    return issuer_cert.GetName().compare(0, 2, "MS") == 0;
+    return issuer_cert.GetName().starts_with("MS");
   default:
     return false;
   }

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -43,7 +43,7 @@ HostFileSystem::HostFilename HostFileSystem::BuildFilename(const std::string& wi
     }
   }
 
-  if (wii_path.compare(0, 1, "/") == 0)
+  if (wii_path.starts_with("/"))
     return HostFilename{m_root_path + Common::EscapePath(wii_path), false};
 
   ASSERT_MSG(IOS_FS, false, "Invalid Wii path '{}' given to BuildFilename()", wii_path);

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -673,16 +673,16 @@ std::optional<IPCReply> EmulationKernel::OpenDevice(OpenRequest& request)
   request.fd = new_fd;
 
   std::shared_ptr<Device> device;
-  if (request.path.find("/dev/usb/oh0/") == 0 && !GetDeviceByName(request.path) &&
+  if (request.path.starts_with("/dev/usb/oh0/") && !GetDeviceByName(request.path) &&
       !HasFeature(GetVersion(), Feature::NewUSB))
   {
     device = std::make_shared<OH0Device>(*this, request.path);
   }
-  else if (request.path.find("/dev/") == 0)
+  else if (request.path.starts_with("/dev/"))
   {
     device = GetDeviceByName(request.path);
   }
-  else if (request.path.find('/') == 0)
+  else if (request.path.starts_with('/'))
   {
     device = GetDeviceByName("/dev/fs");
   }

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -88,7 +88,7 @@ ResourcePack::ResourcePack(const std::string& path) : m_path(path)
     unzGetCurrentFileInfo64(file, &texture_info, filename.data(), static_cast<u16>(filename.size()),
                             nullptr, 0, nullptr, 0);
 
-    if (filename.compare(0, 9, "textures/") != 0 || texture_info.uncompressed_size == 0)
+    if (!filename.starts_with("textures/") || texture_info.uncompressed_size == 0)
       continue;
 
     // If a texture is compressed and the manifest doesn't state that, abort.


### PR DESCRIPTION
I am currently working on some additions to this Clang-Tidy check, and running it on some C++ codebases to test my changes.

This should be safe as it seems Dolphin requires a C++ standard and/or a compiler version that will always have `starts_with` included. (In CMakeLists: C++23 for MSVC, GCC 10, Clang 12). Dolphin builds on my setup following changes.

```
python3 ~/llvm-project/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py \
    -clang-tidy-binary="~/llvm-project/build/bin/clang-tidy" \
    -clang-apply-replacements-binary="~/llvm-project/build/bin/clang-apply-replacements" \
    -checks="-*,modernize-use-starts-ends-with" \
    -header-filter=".*" \
    -fix -format
```

This improves readability. There's also a theoretical performance improvement replacing `find(...) == 0` by `compare(...) == 0` or `starts_with(...)`, it's probably negligible.