### PR TITLE
Simplify Calls To CheckBreakPoints With A Return Value

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -249,8 +249,7 @@ bool CachedInterpreter::CheckProgramException(CachedInterpreter& cached_interpre
 
 bool CachedInterpreter::CheckBreakpoint(CachedInterpreter& cached_interpreter, u32 data)
 {
-  cached_interpreter.m_system.GetPowerPC().CheckBreakPoints();
-  if (cached_interpreter.m_system.GetCPU().GetState() != CPU::State::Running)
+  if (cached_interpreter.m_system.GetPowerPC().CheckBreakPoints())
   {
     cached_interpreter.m_ppc_state.downcount -= data;
     return true;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -1075,8 +1075,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
         ABI_PushRegistersAndAdjustStack({}, 0);
         ABI_CallFunctionP(PowerPC::CheckBreakPointsFromJIT, &power_pc);
         ABI_PopRegistersAndAdjustStack({}, 0);
-        MOV(64, R(RSCRATCH), ImmPtr(cpu.GetStatePtr()));
-        TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
+        TEST(8, R(ABI_RETURN), R(ABI_RETURN));
         FixupBranch noBreakpoint = J_CC(CC_Z);
 
         Cleanup();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -1214,8 +1214,6 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
         STP(IndexType::Signed, DISPATCHER_PC, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
         ABI_CallFunction(&PowerPC::CheckBreakPointsFromJIT, &m_system.GetPowerPC());
 
-        LDR(IndexType::Unsigned, ARM64Reg::W0, ARM64Reg::X0,
-            MOVPage2R(ARM64Reg::X0, cpu.GetStatePtr()));
         FixupBranch no_breakpoint = CBZ(ARM64Reg::W0);
 
         Cleanup();

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -655,12 +655,12 @@ void PowerPCManager::CheckExternalExceptions()
   m_system.GetJitInterface().UpdateMembase();
 }
 
-void PowerPCManager::CheckBreakPoints()
+bool PowerPCManager::CheckBreakPoints()
 {
   const TBreakPoint* bp = m_breakpoints.GetBreakpoint(m_ppc_state.pc);
 
   if (!bp || !bp->is_enabled || !EvaluateCondition(m_system, bp->condition))
-    return;
+    return false;
 
   if (bp->break_on_hit)
   {
@@ -680,6 +680,7 @@ void PowerPCManager::CheckBreakPoints()
   }
   if (m_breakpoints.IsTempBreakPoint(m_ppc_state.pc))
     m_breakpoints.Remove(m_ppc_state.pc);
+  return true;
 }
 
 void PowerPCState::SetSR(u32 index, u32 value)
@@ -748,8 +749,8 @@ void CheckExternalExceptionsFromJIT(PowerPCManager& power_pc)
   power_pc.CheckExternalExceptions();
 }
 
-void CheckBreakPointsFromJIT(PowerPCManager& power_pc)
+bool CheckBreakPointsFromJIT(PowerPCManager& power_pc)
 {
-  power_pc.CheckBreakPoints();
+  return power_pc.CheckBreakPoints();
 }
 }  // namespace PowerPC

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -286,7 +286,7 @@ public:
   void SingleStep();
   void CheckExceptions();
   void CheckExternalExceptions();
-  void CheckBreakPoints();
+  bool CheckBreakPoints();
   void RunLoop();
 
   u64 ReadFullTimeBaseValue() const;
@@ -335,7 +335,7 @@ void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst,
 
 void CheckExceptionsFromJIT(PowerPCManager& power_pc);
 void CheckExternalExceptionsFromJIT(PowerPCManager& power_pc);
-void CheckBreakPointsFromJIT(PowerPCManager& power_pc);
+bool CheckBreakPointsFromJIT(PowerPCManager& power_pc);
 
 // Easy register access macros.
 #define HID0(ppc_state) ((UReg_HID0&)(ppc_state).spr[SPR_HID0])


### PR DESCRIPTION
This is something I needed to do for my CachedInterpreter rework, so why not make all three JITs a little better?

Marking this as a draft until I can ask someone to make sure JitArm64 still works fine, as I can't test this change using Android.