### PR TITLE
JitArm64: Skip UBFX in mfcr

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -672,6 +672,7 @@ void JitArm64::mfcr(UGeckoInstruction inst)
   ARM64Reg WB = gpr.GetReg();
   ARM64Reg WC = gpr.GetReg();
   ARM64Reg XA = EncodeRegTo64(WA);
+  ARM64Reg XB = EncodeRegTo64(WB);
   ARM64Reg XC = EncodeRegTo64(WC);
 
   for (int i = 0; i < 8; i++)
@@ -683,15 +684,14 @@ void JitArm64::mfcr(UGeckoInstruction inst)
     static_assert(PowerPC::CR_SO_BIT == 0);
     static_assert(PowerPC::CR_LT_BIT == 3);
     static_assert(PowerPC::CR_EMU_LT_BIT - PowerPC::CR_EMU_SO_BIT == 3);
-    UBFX(XC, CR, PowerPC::CR_EMU_SO_BIT, 4);
     if (i == 0)
     {
-      MOVI2R(WB, PowerPC::CR_SO | PowerPC::CR_LT);
-      AND(WA, WC, WB);
+      MOVI2R(XB, PowerPC::CR_SO | PowerPC::CR_LT);
+      AND(XA, XB, CR, ArithOption(CR, ShiftType::LSR, PowerPC::CR_EMU_SO_BIT));
     }
     else
     {
-      AND(WC, WC, WB);
+      AND(XC, XB, CR, ArithOption(CR, ShiftType::LSR, PowerPC::CR_EMU_SO_BIT));
       ORR(XA, XC, XA, ArithOption(XA, ShiftType::LSL, 4));
     }
 


### PR DESCRIPTION
We can implement the same behavior in one instruction less.