### PR TITLE
Externals: minizip-ng Forward Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -674,6 +674,8 @@ dolphin_find_optional_system_library_pkgconfig(ZSTD libzstd>=1.4.0 zstd::zstd Ex
 
 dolphin_find_optional_system_library_pkgconfig(ZLIB zlib-ng ZLIB::ZLIB Externals/zlib-ng)
 
+# https://github.com/zlib-ng/minizip-ng/commit/6c5f265a55f1a12a7a016cd2962feff91cff5d2e
+add_definitions(-DMZ_COMPAT_VERSION=110)  # This macro is for forwards compatibility with 4.0.4+
 dolphin_find_optional_system_library_pkgconfig(MINIZIP minizip>=3.0.0 minizip::minizip Externals/minizip)
 
 dolphin_find_optional_system_library(LZO Externals/LZO)


### PR DESCRIPTION
This resolves https://bugs.dolphin-emu.org/issues/13515 and supersedes https://github.com/dolphin-emu/dolphin/pull/12611. I was able to confirm this change fixes the build errors with the latest version of minizip-ng.