### PR TITLE
Eliminate SettingsHandler's `SetBytes` and `Reset` methods

### DIFF
--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -17,26 +17,19 @@
 
 namespace Common
 {
-SettingsHandler::SettingsHandler()
+SettingsHandler::SettingsHandler() : m_buffer{}, m_position{0}, m_key{INITIAL_SEED}, decoded{""}
 {
-  Reset();
 }
 
-SettingsHandler::SettingsHandler(const Buffer& buffer)
+SettingsHandler::SettingsHandler(const Buffer& buffer) : SettingsHandler()
 {
-  SetBytes(buffer);
+  m_buffer = buffer;
+  Decrypt();
 }
 
 const SettingsHandler::Buffer& SettingsHandler::GetBytes() const
 {
   return m_buffer;
-}
-
-void SettingsHandler::SetBytes(const Buffer& buffer)
-{
-  Reset();
-  m_buffer = buffer;
-  Decrypt();
 }
 
 std::string SettingsHandler::GetValue(std::string_view key) const
@@ -82,14 +75,6 @@ void SettingsHandler::Decrypt()
   // To handle this, we remove every CR and treat LF as the line ending.
   // (We ignore empty lines.)
   std::erase(decoded, '\x0d');
-}
-
-void SettingsHandler::Reset()
-{
-  decoded = "";
-  m_position = 0;
-  m_key = INITIAL_SEED;
-  m_buffer = {};
 }
 
 void SettingsHandler::AddSetting(std::string_view key, std::string_view value)

--- a/Source/Core/Common/SettingsHandler.h
+++ b/Source/Core/Common/SettingsHandler.h
@@ -30,14 +30,12 @@ public:
   void AddSetting(std::string_view key, std::string_view value);
 
   const Buffer& GetBytes() const;
-  void SetBytes(const Buffer& buffer);
   std::string GetValue(std::string_view key) const;
 
-  void Decrypt();
-  void Reset();
   static std::string GenerateSerialNumber();
 
 private:
+  void Decrypt();
   void WriteLine(std::string_view str);
   void WriteByte(u8 b);
 

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -138,8 +138,7 @@ IPCReply GetRealProductCode(Core::System& system, const IOCtlVRequest& request)
   if (!file.ReadBytes(data.data(), data.size()))
     return IPCReply(IPC_ENOENT);
 
-  Common::SettingsHandler gen;
-  gen.SetBytes(data);
+  Common::SettingsHandler gen(data);
   const std::string code = gen.GetValue("CODE");
 
   const size_t length = std::min<size_t>(request.io_vectors[0].size, code.length());

--- a/Source/UnitTests/Common/SettingsHandlerTest.cpp
+++ b/Source/UnitTests/Common/SettingsHandlerTest.cpp
@@ -75,34 +75,10 @@ TEST(SettingsHandlerTest, DecryptMultipleSettings)
   EXPECT_EQ(handler.GetValue("foo"), "bar");
 }
 
-TEST(SettingsHandlerTest, SetBytesOverwritesExistingBuffer)
-{
-  Common::SettingsHandler handler(BUFFER_A);
-  ASSERT_EQ(handler.GetValue("key"), "val");
-  ASSERT_EQ(handler.GetValue("foo"), "");
-
-  handler.SetBytes(BUFFER_B);
-  EXPECT_EQ(handler.GetValue("foo"), "bar");
-  EXPECT_EQ(handler.GetValue("key"), "");
-}
-
 TEST(SettingsHandlerTest, GetValueOnSameInstance)
 {
   Common::SettingsHandler handler;
   handler.AddSetting("key", "val");
-  EXPECT_EQ(handler.GetValue("key"), "");
-
-  Common::SettingsHandler::Buffer buffer = handler.GetBytes();
-  handler.SetBytes(buffer);
-  EXPECT_EQ(handler.GetValue("key"), "val");
-}
-
-TEST(SettingsHandlerTest, GetValueAfterReset)
-{
-  Common::SettingsHandler handler(BUFFER_A);
-  ASSERT_EQ(handler.GetValue("key"), "val");
-
-  handler.Reset();
   EXPECT_EQ(handler.GetValue("key"), "");
 }
 


### PR DESCRIPTION
Also make the `Decrypt` method private.

As far as I can tell, the only motivation for exposing the `SetBytes` and `Reset` methods is to allow `CBoot::SetupWiiMemory` to use the same `SettingsHandler` instance to read settings data and then write it back. It seems cleaner to just use two separate instances, and require a given `SettingsHandler` instance to be used for either writing data to a buffer or reading data from a buffer, but not both.

A natural next step is to split the `SettingsHandler` class into two classes, one for writing data and one for reading data. I've deferred that change for a future PR.