### PR TITLE
VideoCommon: Only show input count when recording

### DIFF
--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -296,7 +296,8 @@ void OnScreenUI::DrawDebugText()
       else if (Config::Get(Config::MAIN_SHOW_FRAME_COUNT))
       {
         ImGui::Text("Frame: %" PRIu64, movie.GetCurrentFrame());
-        ImGui::Text("Input: %" PRIu64, movie.GetCurrentInputCount());
+        if (movie.IsRecordingInput())
+          ImGui::Text("Input: %" PRIu64, movie.GetCurrentInputCount());
       }
       if (Config::Get(Config::MAIN_SHOW_LAG))
         ImGui::Text("Lag: %" PRIu64 "\n", movie.GetCurrentLagCount());


### PR DESCRIPTION
When a movie is not being recorded, `movie.GetCurrentInputCount()` is always zero. We should hide this if that's the case.