### PR TITLE
Jit64/JitArm64: Check Breakpoints Before FPU Availability

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -16,6 +16,7 @@
 #endif
 
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/GekkoDisassembler.h"
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
@@ -1048,8 +1049,8 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
         ABI_CallFunctionP(PowerPC::CheckBreakPointsFromJIT, &power_pc);
         ABI_PopRegistersAndAdjustStack({}, 0);
         MOV(64, R(RSCRATCH), ImmPtr(cpu.GetStatePtr()));
-        TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
-        FixupBranch noBreakpoint = J_CC(CC_Z);
+        CMP(32, MatR(RSCRATCH), Imm32(Common::ToUnderlying(CPU::State::Running)));
+        FixupBranch noBreakpoint = J_CC(CC_E);
 
         Cleanup();
         MOV(32, PPCSTATE(npc), Imm32(op.address));

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -6,6 +6,7 @@
 #include <climits>
 
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/JitRegister.h"
 #include "Common/x64ABI.h"
 #include "Common/x64Emitter.h"
@@ -105,8 +106,8 @@ void Jit64AsmRoutineManager::Generate()
   if (enable_debugging)
   {
     MOV(64, R(RSCRATCH), ImmPtr(system.GetCPU().GetStatePtr()));
-    TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
-    dbg_exit = J_CC(CC_NZ, Jump::Near);
+    CMP(32, MatR(RSCRATCH), Imm32(Common::ToUnderlying(CPU::State::Running)));
+    dbg_exit = J_CC(CC_NE, Jump::Near);
   }
 
   SetJumpTarget(skipToRealDispatch);
@@ -236,8 +237,8 @@ void Jit64AsmRoutineManager::Generate()
   // Check the state pointer to see if we are exiting
   // Gets checked on at the end of every slice
   MOV(64, R(RSCRATCH), ImmPtr(system.GetCPU().GetStatePtr()));
-  TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
-  J_CC(CC_Z, outerLoop);
+  CMP(32, MatR(RSCRATCH), Imm32(Common::ToUnderlying(CPU::State::Running)));
+  J_CC(CC_E, outerLoop);
 
   // Landing pad for drec space
   dispatcher_exit = GetCodePtr();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/Arm64Emitter.h"
 #include "Common/CommonTypes.h"
+#include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 #include "Common/MsgHandler.h"
@@ -1185,6 +1186,7 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 
         LDR(IndexType::Unsigned, ARM64Reg::W0, ARM64Reg::X0,
             MOVPage2R(ARM64Reg::X0, cpu.GetStatePtr()));
+        static_assert(Common::ToUnderlying(CPU::State::Running) == 0);
         FixupBranch no_breakpoint = CBZ(ARM64Reg::W0);
 
         Cleanup();

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -9,6 +9,7 @@
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
+#include "Common/EnumUtils.h"
 #include "Common/FloatUtils.h"
 #include "Common/JitRegister.h"
 #include "Common/MathUtil.h"
@@ -88,6 +89,7 @@ void JitArm64::GenerateAsm()
   {
     LDR(IndexType::Unsigned, ARM64Reg::W8, ARM64Reg::X8,
         MOVPage2R(ARM64Reg::X8, cpu.GetStatePtr()));
+    static_assert(Common::ToUnderlying(CPU::State::Running) == 0);
     debug_exit = CBNZ(ARM64Reg::W8);
   }
 
@@ -195,6 +197,7 @@ void JitArm64::GenerateAsm()
   // Check the state pointer to see if we are exiting
   // Gets checked on at the end of every slice
   LDR(IndexType::Unsigned, ARM64Reg::W8, ARM64Reg::X8, MOVPage2R(ARM64Reg::X8, cpu.GetStatePtr()));
+  static_assert(Common::ToUnderlying(CPU::State::Running) == 0);
   FixupBranch exit = CBNZ(ARM64Reg::W8);
 
   SetJumpTarget(to_start_of_timing_slice);


### PR DESCRIPTION
Tested using Mario Kart: Double Dash (USA) with the following breakpoints:
```
[BreakPoints]
$00000800 nlbc srr0 == 0x800be4f8
$800be4f4 nlb
$800be4f8 nlb
$80000800 nb
```
At effective address 800be4f8, there is a `stfd` instruction that is frequently executed while the FPU is not unavailable (the exception handler enables it). Note that the fourth breakpoint is a workaround for a Dolphin bug where setting breakpoints at effective addresses in physical memory while address translation is enabled won't invalidate the JitCache correctly to recompile with the new breakpoint. The other three breakpoints are hit in the following unexpected order:
```
Core/PowerPC/PowerPC.cpp:679 N[MI]: BP 800be4f4  --- (000001c0 000001c0 09a7ec80 7082f0c1 00000010 804ebce8 0000000c ffffffff ffffffff 00000000) LR=8007aba4
Core/PowerPC/Expression.cpp:471 N[MI]: Breakpoint condition returned: 1. Vars:  srr0=2148263160
Core/PowerPC/PowerPC.cpp:679 N[MI]: BP 00000800  --- (000001c0 000001c0 09a7ec80 7082f0c1 00000010 804ebce8 0000000c ffffffff ffffffff 00000000) LR=8007aba4
Core/PowerPC/PowerPC.cpp:679 N[MI]: BP 800be4f8  --- (000001c0 000001c0 09a7ec80 7082f0c1 00000010 804ebce8 0000000c ffffffff ffffffff 00000000) LR=8007aba4
```
With the reordering in this PR, they are now hit in the following order (tested on Jit64 and JitArm64):
```
Core/PowerPC/PowerPC.cpp:679 N[MI]: BP 800be4f4  --- (000001c0 000001c0 09a7ec80 76b78e37 00000010 804ebce8 00000013 ffffffff ffffffff 00000000) LR=8007aba4
Core/PowerPC/PowerPC.cpp:679 N[MI]: BP 800be4f8  --- (000001c0 000001c0 09a7ec80 76b78e37 00000010 804ebce8 00000013 ffffffff ffffffff 00000000) LR=8007aba4
Core/PowerPC/Expression.cpp:471 N[MI]: Breakpoint condition returned: 1. Vars:  srr0=2148263160
Core/PowerPC/PowerPC.cpp:679 N[MI]: BP 00000800  --- (000001c0 000001c0 09a7ec80 76b78e37 00000010 804ebce8 00000013 ffffffff ffffffff 00000000) LR=8007aba4
```

The Cached Interpreter already does it in the expected order.