### PR TITLE
Qt: fix 13524 - output resampling mode not loading correctly from ini

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -372,7 +372,8 @@ void EnhancementsWidget::LoadSettings()
   // Resampling
   const OutputResamplingMode output_resampling_mode =
       Config::Get(Config::GFX_ENHANCE_OUTPUT_RESAMPLING);
-  m_output_resampling_combo->setCurrentIndex(static_cast<int>(output_resampling_mode));
+  m_output_resampling_combo->setCurrentIndex(
+      m_output_resampling_combo->findData(static_cast<int>(output_resampling_mode)));
 
   m_output_resampling_combo->setEnabled(g_Config.backend_info.bSupportsPostProcessing);
 


### PR DESCRIPTION
I couldn't reproduce the issue (https://bugs.dolphin-emu.org/issues/13524), but the code was slightly wrong anyway, as the enum indexes weren't guaranteed to match the Qt drop down list indexes (they currently did match, but possibly not in the future).
The user mentioned that the issue only appears when using game specific inis. I haven't tried with these as I've never manually used that system. There's nothing special about the output resampling settings serialization, it looks like any other video enhancement setting to me. If anybody else has any idea what could be the reason of the issue, let me know.