### PR TITLE
CheatSearch: Use two's complement for negative hex values

### DIFF
--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -572,11 +572,19 @@ std::string Cheats::CheatSearchSession<T>::GetResultValueAsString(size_t index, 
   if (hex)
   {
     if constexpr (std::is_same_v<T, float>)
-      return fmt::format("0x{0:08x}", Common::BitCast<u32>(m_search_results[index].m_value));
+    {
+      return fmt::format("0x{0:08x}", Common::BitCast<s32>(m_search_results[index].m_value));
+    }
     else if constexpr (std::is_same_v<T, double>)
-      return fmt::format("0x{0:016x}", Common::BitCast<u64>(m_search_results[index].m_value));
+    {
+      return fmt::format("0x{0:016x}", Common::BitCast<s64>(m_search_results[index].m_value));
+    }
     else
-      return fmt::format("0x{0:0{1}x}", m_search_results[index].m_value, sizeof(T) * 2);
+    {
+      return fmt::format("0x{0:0{1}x}",
+                         Common::BitCast<std::make_unsigned_t<T>>(m_search_results[index].m_value),
+                         sizeof(T) * 2);
+    }
   }
 
   return fmt::format("{}", m_search_results[index].m_value);


### PR DESCRIPTION
When a Cheat Search is using a signed integer data type and "Display values in Hex" is checked, show the bytes of Last Value and Current Value in two's complement rather than with signed magnitude as was previously happening.

Before:
![negative_ten_before](https://github.com/dolphin-emu/dolphin/assets/73494713/cc49c787-a1b7-401d-ab5d-fb9b265e5e26)
After:
![negative_ten_after](https://github.com/dolphin-emu/dolphin/assets/73494713/2dc05117-668a-4362-81e7-9aeafaa8f471)
