### PR TITLE
Remove rounded corners on emulation render window

### DIFF
--- a/Source/Core/DolphinNoGUI/PlatformWin32.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformWin32.cpp
@@ -13,6 +13,7 @@
 #include <Windows.h>
 #include <climits>
 #include <cstdio>
+#include <dwmapi.h>
 
 #include "VideoCommon/Present.h"
 #include "resource.h"
@@ -179,6 +180,18 @@ LRESULT PlatformWin32::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
     SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(platform));
     return DefWindowProc(hwnd, msg, wParam, lParam);
   }
+
+  case WM_CREATE:
+  {
+    if (hwnd)
+    {
+      // Remove rounded corners from the render window on Windows 11
+      const DWM_WINDOW_CORNER_PREFERENCE corner_preference = DWMWCP_DONOTROUND;
+      DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &corner_preference,
+                            sizeof(corner_preference));
+    }
+  }
+  break;
 
   case WM_SIZE:
   {

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -34,6 +34,7 @@ signals:
 
 private:
   void HandleCursorTimer();
+  void OnHandleChanged(void* handle);
   void OnHideCursorChanged();
   void OnNeverHideCursorChanged();
   void OnLockCursorChanged();


### PR DESCRIPTION
On Windows 11, when playing windowed in a separate window/widget from the main emulator window, we don't want the window to have rounded corners, as it prevents the corner pixels from being visible

Here's how it would look, there's not much to it:
![image](https://github.com/dolphin-emu/dolphin/assets/7011366/0283ccd7-33e3-4573-8ce0-f1b68d5cdf67)
![image](https://github.com/dolphin-emu/dolphin/assets/7011366/c2bfc090-1641-4f41-a642-7c856267c2b4)
