### PR TITLE
Remove Bounding Box from GSZ.ini

### DIFF
--- a/Data/Sys/GameSettings/GSZ.ini
+++ b/Data/Sys/GameSettings/GSZ.ini
@@ -12,6 +12,3 @@ CPUThread = False
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-BBoxEnable = True


### PR DESCRIPTION
This game [does not use Bounding Box](https://dolphin-emu.org/blog/2021/08/01/dolphin-progress-report-june-and-july-2021/#50-14392-50-14394-and-50-14404-bounding-box-the-saga-continues-by-techjar), so this PR removes the BoundingBox line from the GameINI.