### PR TITLE
DolphinQt: Properly Delete (Some) Widgets

### DIFF
--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -495,6 +495,7 @@ void CheatSearchWidget::OnAddressTableContextMenu()
   const u32 address = item->data(ADDRESS_TABLE_ADDRESS_ROLE).toUInt();
 
   QMenu* menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
 
   menu->addAction(tr("Show in memory"), [this, address] { emit ShowMemory(address); });
   menu->addAction(tr("Add to watch"), this, [this, address] {

--- a/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
@@ -226,6 +226,7 @@ void FilesystemWidget::ShowContextMenu(const QPoint&)
   auto* item = m_tree_model->itemFromIndex(selection->selectedIndexes()[0]);
 
   QMenu* menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
 
   EntryType type = item->data(ENTRY_TYPE).value<EntryType>();
 

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -806,6 +806,8 @@ void BranchWatchDialog::OnTableContextMenu(const QPoint& pos)
   QModelIndexList index_list = m_table_view->selectionModel()->selectedRows(index.column());
 
   QMenu* const menu = new QMenu;
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
+
   menu->addAction(tr("&Delete"), [this, index_list]() { OnTableDelete(std::move(index_list)); });
   switch (index.column())
   {

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -309,6 +309,7 @@ void BreakpointWidget::OnClear()
 void BreakpointWidget::OnNewBreakpoint()
 {
   BreakpointDialog* dialog = new BreakpointDialog(this);
+  dialog->setAttribute(Qt::WA_DeleteOnClose, true);
   SetQWidgetWindowDecorations(dialog);
   dialog->exec();
 }
@@ -319,6 +320,7 @@ void BreakpointWidget::OnEditBreakpoint(u32 address, bool is_instruction_bp)
   {
     auto* dialog =
         new BreakpointDialog(this, m_system.GetPowerPC().GetBreakPoints().GetBreakpoint(address));
+    dialog->setAttribute(Qt::WA_DeleteOnClose, true);
     SetQWidgetWindowDecorations(dialog);
     dialog->exec();
   }
@@ -326,6 +328,7 @@ void BreakpointWidget::OnEditBreakpoint(u32 address, bool is_instruction_bp)
   {
     auto* dialog =
         new BreakpointDialog(this, m_system.GetPowerPC().GetMemChecks().GetMemCheck(address));
+    dialog->setAttribute(Qt::WA_DeleteOnClose, true);
     SetQWidgetWindowDecorations(dialog);
     dialog->exec();
   }
@@ -387,6 +390,7 @@ void BreakpointWidget::OnContextMenu()
   const auto is_memory_breakpoint = selected_item->data(IS_MEMCHECK_ROLE).toBool();
 
   auto* menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
 
   if (!is_memory_breakpoint)
   {

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -558,6 +558,7 @@ void CodeViewWidget::ReplaceAddress(u32 address, ReplaceWith replace)
 void CodeViewWidget::OnContextMenu()
 {
   QMenu* menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
 
   const bool running = Core::GetState(m_system) != Core::State::Uninitialized;
   const bool paused = Core::GetState(m_system) == Core::State::Paused;

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -873,6 +873,7 @@ void MemoryViewWidget::OnContextMenu(const QPoint& pos)
           ->IsValidAddress(Core::CPUThreadGuard{m_system}, addr);
 
   auto* menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
 
   menu->addAction(tr("Copy Address"), this, [this, addr] { OnCopyAddress(addr); });
 

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -118,6 +118,7 @@ void RegisterWidget::OnItemChanged(QTableWidgetItem* item)
 void RegisterWidget::ShowContextMenu()
 {
   QMenu* menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
 
   auto* raw_item = m_table->currentItem();
 

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -119,6 +119,8 @@ void ThreadWidget::ShowContextMenu(QTableWidget* table)
     return;
 
   QMenu* menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
+
   const QString watch_name = QStringLiteral("thread_context_%1").arg(addr, 8, 16, QLatin1Char('0'));
   menu->addAction(tr("Add &breakpoint"), this, [this, addr] { emit RequestBreakpoint(addr); });
   menu->addAction(tr("Add memory breakpoint"), this,

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -327,6 +327,7 @@ void WatchWidget::OnSave()
 void WatchWidget::ShowContextMenu()
 {
   QMenu* menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
 
   if (!m_table->selectedItems().empty())
   {

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -372,6 +372,7 @@ void GameList::ShowContextMenu(const QPoint&)
     return;
 
   QMenu* menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
 
   if (HasMultipleSelected())
   {

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -295,19 +295,19 @@ void NetPlayBrowser::accept()
 
   if (m_sessions[index].has_password)
   {
-    auto* dialog = new QInputDialog(this);
+    QInputDialog dialog(this);
 
-    dialog->setWindowFlags(dialog->windowFlags() & ~Qt::WindowContextHelpButtonHint);
-    dialog->setWindowTitle(tr("Enter password"));
-    dialog->setLabelText(tr("This session requires a password:"));
-    dialog->setWindowModality(Qt::WindowModal);
-    dialog->setTextEchoMode(QLineEdit::Password);
+    dialog.setWindowFlags(dialog.windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    dialog.setWindowTitle(tr("Enter password"));
+    dialog.setLabelText(tr("This session requires a password:"));
+    dialog.setWindowModality(Qt::WindowModal);
+    dialog.setTextEchoMode(QLineEdit::Password);
 
-    SetQWidgetWindowDecorations(dialog);
-    if (dialog->exec() != QDialog::Accepted)
+    SetQWidgetWindowDecorations(&dialog);
+    if (dialog.exec() != QDialog::Accepted)
       return;
 
-    const std::string password = dialog->textValue().toStdString();
+    const std::string password = dialog.textValue().toStdString();
 
     auto decrypted_id = session.DecryptID(password);
 

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -57,6 +57,7 @@ void Updater::OnUpdateAvailable(const NewVersionInformation& info)
 
   std::optional<int> choice = RunOnObject(m_parent, [&] {
     QDialog* dialog = new QDialog(m_parent);
+    dialog->setAttribute(Qt::WA_DeleteOnClose, true);
     dialog->setWindowTitle(tr("Update available"));
     dialog->setWindowFlags(dialog->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 


### PR DESCRIPTION
I have personally gone around and verified every widget still executes. This is not every memory leak, just the ones that were obvious. A notable change: The GameList context menu has a slot for `Host::EmulationStateChanged`, and every un-deleted context menu was cluttering this signal's responsibilities.