### PR TITLE
Disabled Hardcore Mode when Achievements disabled

### DIFF
--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -16,7 +16,7 @@
 #include "Common/BitUtils.h"
 #include "Common/StringUtil.h"
 
-#include "Core/Config/AchievementSettings.h"
+#include "Core/AchievementManager.h"
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/MMU.h"
@@ -208,7 +208,7 @@ Cheats::NewSearch(const Core::CPUThreadGuard& guard,
                   const std::function<bool(const T& value)>& validator)
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
 #endif  // USE_RETRO_ACHIEVEMENTS
   auto& system = guard.GetSystem();
@@ -263,7 +263,7 @@ Cheats::NextSearch(const Core::CPUThreadGuard& guard,
                    const std::function<bool(const T& new_value, const T& old_value)>& validator)
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
 #endif  // USE_RETRO_ACHIEVEMENTS
   auto& system = guard.GetSystem();
@@ -430,7 +430,7 @@ template <typename T>
 Cheats::SearchErrorCode Cheats::CheatSearchSession<T>::RunSearch(const Core::CPUThreadGuard& guard)
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
 #endif  // USE_RETRO_ACHIEVEMENTS
   Common::Result<SearchErrorCode, std::vector<SearchResult<T>>> result =

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -18,7 +18,7 @@
 #include "Common/MathUtil.h"
 #include "Common/StringUtil.h"
 #include "Common/Version.h"
-#include "Core/Config/AchievementSettings.h"
+#include "Core/AchievementManager.h"
 #include "Core/Config/DefaultLocale.h"
 #include "Core/HW/EXI/EXI.h"
 #include "Core/HW/EXI/EXI_Device.h"
@@ -750,7 +750,8 @@ bool IsDefaultGCIFolderPathConfigured(ExpansionInterface::Slot slot)
 bool AreCheatsEnabled()
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  return Config::Get(::Config::MAIN_ENABLE_CHEATS) && !::Config::Get(::Config::RA_HARDCORE_ENABLED);
+  return Config::Get(::Config::MAIN_ENABLE_CHEATS) &&
+         !AchievementManager::GetInstance().IsHardcoreModeActive();
 #else   // USE_RETRO_ACHIEVEMENTS
   return Config::Get(::Config::MAIN_ENABLE_CHEATS);
 #endif  // USE_RETRO_ACHIEVEMENTS
@@ -760,7 +761,7 @@ bool IsDebuggingEnabled()
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
   return Config::Get(::Config::MAIN_ENABLE_DEBUGGING) &&
-         !::Config::Get(::Config::RA_HARDCORE_ENABLED);
+         !AchievementManager::GetInstance().IsHardcoreModeActive();
 #else   // USE_RETRO_ACHIEVEMENTS
   return Config::Get(::Config::MAIN_ENABLE_DEBUGGING);
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -16,7 +16,7 @@
 #include "Common/GekkoDisassembler.h"
 #include "Common/StringUtil.h"
 
-#include "Core/Config/AchievementSettings.h"
+#include "Core/AchievementManager.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 #include "Core/Debugger/OSThread.h"
@@ -31,7 +31,7 @@ void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, Common::Debug::MemoryPa
                       bool store_existing_value)
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return;
 #endif  // USE_RETRO_ACHIEVEMENTS
   if (patch.value.empty())

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -34,6 +34,7 @@
 #include "Common/Timer.h"
 #include "Common/Version.h"
 
+#include "Core/AchievementManager.h"
 #include "Core/Boot/Boot.h"
 #include "Core/Config/AchievementSettings.h"
 #include "Core/Config/MainSettings.h"
@@ -941,7 +942,7 @@ bool MovieManager::PlayInput(const std::string& movie_path,
   ReadHeader();
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return false;
 #endif  // USE_RETRO_ACHIEVEMENTS
 

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -24,9 +24,9 @@
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 
+#include "Core/AchievementManager.h"
 #include "Core/ActionReplay.h"
 #include "Core/CheatCodes.h"
-#include "Core/Config/AchievementSettings.h"
 #include "Core/Config/SessionSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -234,7 +234,7 @@ void LoadPatches()
 static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Patch>& patches)
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return;
 #endif  // USE_RETRO_ACHIEVEMENTS
   for (const Patch& patch : patches)
@@ -279,7 +279,7 @@ static void ApplyMemoryPatches(const Core::CPUThreadGuard& guard,
                                std::span<const std::size_t> memory_patch_indices)
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return;
 #endif  // USE_RETRO_ACHIEVEMENTS
   std::lock_guard lock(s_on_frame_memory_mutex);

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -14,7 +14,7 @@
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
 #include "Common/StringUtil.h"
-#include "Core/Config/AchievementSettings.h"
+#include "Core/AchievementManager.h"
 #include "Core/Core.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HW/Memmap.h"
@@ -525,7 +525,7 @@ static void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, u32 offset,
                              std::span<const u8> value, std::span<const u8> original)
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (::Config::Get(::Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return;
 #endif  // USE_RETRO_ACHIEVEMENTS
 

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -229,6 +229,8 @@ void AchievementSettingsWidget::ToggleRAIntegration()
     instance.Init();
   else
     instance.Shutdown();
+  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+    emit Settings::Instance().EmulationStateChanged(Core::GetState(Core::System::GetInstance()));
 }
 
 void AchievementSettingsWidget::Login()

--- a/Source/Core/DolphinQt/Config/HardcoreWarningWidget.cpp
+++ b/Source/Core/DolphinQt/Config/HardcoreWarningWidget.cpp
@@ -10,7 +10,7 @@
 #include <QPushButton>
 #include <QStyle>
 
-#include "Core/Config/AchievementSettings.h"
+#include "Core/AchievementManager.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
@@ -57,6 +57,6 @@ void HardcoreWarningWidget::ConnectWidgets()
 
 void HardcoreWarningWidget::Update()
 {
-  setHidden(!Config::Get(Config::RA_HARDCORE_ENABLED));
+  setHidden(!AchievementManager::GetInstance().IsHardcoreModeActive());
 }
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -33,7 +33,7 @@
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
-#include "Core/Config/AchievementSettings.h"
+#include "Core/AchievementManager.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
@@ -565,7 +565,7 @@ void Settings::SetCheatsEnabled(bool enabled)
 void Settings::SetDebugModeEnabled(bool enabled)
 {
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     enabled = false;
 #endif  // USE_RETRO_ACHIEVEMENTS
   if (IsDebugModeEnabled() != enabled)

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -15,7 +15,7 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-#include "Core/Config/AchievementSettings.h"
+#include "Core/AchievementManager.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/UISettings.h"
 #include "Core/ConfigManager.h"
@@ -87,7 +87,7 @@ void GeneralPane::OnEmulationStateChanged(Core::State state)
 
   m_checkbox_dualcore->setEnabled(!running);
 #ifdef USE_RETRO_ACHIEVEMENTS
-  bool hardcore = Config::Get(Config::RA_HARDCORE_ENABLED);
+  bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_checkbox_cheats->setEnabled(!running && !hardcore);
 #else   // USE_RETRO_ACHIEVEMENTS
   m_checkbox_cheats->setEnabled(!running);

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -19,7 +19,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
-#include "Core/Config/AchievementSettings.h"
+#include "Core/AchievementManager.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/UISettings.h"
 
@@ -256,7 +256,7 @@ void InterfacePane::LoadConfig()
       ->setChecked(Settings::Instance().IsDebugModeEnabled());
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  bool hardcore = Config::Get(Config::RA_HARDCORE_ENABLED);
+  bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   SignalBlocking(m_checkbox_show_debugging_ui)->setEnabled(!hardcore);
   if (hardcore)
   {


### PR DESCRIPTION
Bugfix for hardcore-disabled items being disabled when hardcore was true but achievement integration was false, which should mean hardcore is effectively disabled. Now everything checks the IsHardcoreModeActive method in AchievementManager which processes the setting AND the game state to determine if hardcore mode is actually active.