### PR TITLE
Show Achievements in Menu Bar always

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -276,12 +276,9 @@ void MenuBar::AddToolsMenu()
   tools_menu->addSeparator();
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  if (Config::Get(Config::RA_ENABLED))
-  {
-    tools_menu->addAction(tr("Achievements"), this, [this] { emit ShowAchievementsWindow(); });
+  tools_menu->addAction(tr("Achievements"), this, [this] { emit ShowAchievementsWindow(); });
 
-    tools_menu->addSeparator();
-  }
+  tools_menu->addSeparator();
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   QMenu* gc_ipl = tools_menu->addMenu(tr("Load GameCube Main Menu"));


### PR DESCRIPTION
Makes the Achievements menu visible to all users. Achievements can be tested unofficially, and will become official at 5PM EST July 15, 2024.