### PR TITLE
fix linking against LLVM shared library

### DIFF
--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -52,28 +52,22 @@ if(TARGET LibUSB::LibUSB)
 endif()
 
 if(ENABLE_LLVM)
-  find_package(LLVM CONFIG QUIET)
-  if(LLVM_FOUND AND TARGET LLVM)
+  find_package(LLVM CONFIG)
+  if(LLVM_FOUND)
     message(STATUS "LLVM found, enabling LLVM support in disassembler")
     # Minimal documentation about LLVM's CMake functions is available here:
     # https://releases.llvm.org/16.0.0/docs/CMake.html#embedding-llvm-in-your-project
+    # https://groups.google.com/g/llvm-dev/c/YeEVe7HTasQ?pli=1
     #
     # However, you have to read the source code in any case.
     # Look for LLVM-Config.cmake in your (Unix) system:
     # $ find /usr -name LLVM-Config\\.cmake 2>/dev/null
-    separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
-    target_compile_definitions(uicommon
-      PRIVATE HAVE_LLVM ${LLVM_DEFINITIONS_LIST}
-    )
-    target_link_directories(uicommon PRIVATE ${LLVM_LIBRARY_DIRS})
     llvm_expand_pseudo_components(LLVM_EXPAND_COMPONENTS
       AllTargetsInfos AllTargetsDisassemblers AllTargetsCodeGens
     )
-    llvm_map_components_to_libnames(LLVM_LIBRARIES
+    llvm_config(uicommon USE_SHARED
       mcdisassembler target ${LLVM_EXPAND_COMPONENTS}
     )
-    target_link_libraries(uicommon PRIVATE ${LLVM_LIBRARIES})
-    target_include_directories(uicommon PRIVATE ${LLVM_INCLUDE_DIRS})
   endif()
 endif()
 


### PR DESCRIPTION
Tested on OpenBSD 7.5 amd64 and FreeBSD 13.2 amd64 by me. I needed to disable achievements on FreeBSD, doesn't seem to be this PR's fault.

@mitaclaw also tested it on Manjaro Linux.