### PR TITLE
Hide Achievement Dialog Header When Disabled

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -59,11 +59,12 @@ void AchievementHeaderWidget::UpdateData()
 {
   std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
   auto& instance = AchievementManager::GetInstance();
-  if (!instance.HasAPIToken())
+  if (!Config::Get(Config::RA_ENABLED) || !instance.HasAPIToken())
   {
     m_header_box->setVisible(false);
     return;
   }
+  m_header_box->setVisible(true);
 
   QString user_name = QtUtils::FromStdString(instance.GetPlayerDisplayName());
   QString game_name = QtUtils::FromStdString(instance.GetGameDisplayName());


### PR DESCRIPTION
If achievements were disabled but a player token is in settings, prior to this change the Achievement Manager dialog would show a box with no player name and score zero, which is unnecessary.