### PR TITLE
Core::SetState: Avoid Global System Accessor

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -247,13 +247,13 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_UnPauseEmula
                                                                                      jclass)
 {
   HostThreadLock guard;
-  Core::SetState(Core::State::Running);
+  Core::SetState(Core::System::GetInstance(), Core::State::Running);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_PauseEmulation(JNIEnv*, jclass)
 {
   HostThreadLock guard;
-  Core::SetState(Core::State::Paused);
+  Core::SetState(Core::System::GetInstance(), Core::State::Paused);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulation(JNIEnv*, jclass)
@@ -469,7 +469,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SurfaceDestr
     }
 
     if (Core::GetState(Core::System::GetInstance()) == Core::State::Running)
-      Core::SetState(Core::State::Paused);
+      Core::SetState(Core::System::GetInstance(), Core::State::Paused);
   }
 
   std::lock_guard surface_guard(s_surface_lock);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -354,9 +354,9 @@ static void CPUSetInitialExecutionState(bool force_paused = false)
 {
   // The CPU starts in stepping state, and will wait until a new state is set before executing.
   // SetState must be called on the host thread, so we defer it for later.
-  QueueHostJob([force_paused](Core::System&) {
+  QueueHostJob([force_paused](Core::System& system) {
     bool paused = SConfig::GetInstance().bBootToPause || force_paused;
-    SetState(paused ? State::Paused : State::Running);
+    SetState(system, paused ? State::Paused : State::Running);
     Host_UpdateDisasmDialog();
     Host_UpdateMainFrame();
     Host_Message(HostMessageID::WMUserCreate);
@@ -700,13 +700,12 @@ static void EmuThread(Core::System& system, std::unique_ptr<BootParameters> boot
 
 // Set or get the running state
 
-void SetState(State state, bool report_state_change)
+void SetState(Core::System& system, State state, bool report_state_change)
 {
   // State cannot be controlled until the CPU Thread is operational
   if (!IsRunningAndStarted())
     return;
 
-  auto& system = Core::System::GetInstance();
   switch (state)
   {
   case State::Paused:
@@ -1061,12 +1060,12 @@ void DoFrameStep(Core::System& system)
     // if already paused, frame advance for 1 frame
     s_stop_frame_step = false;
     s_frame_step = true;
-    SetState(State::Running, false);
+    SetState(system, State::Running, false);
   }
   else if (!s_frame_step)
   {
     // if not paused yet, pause immediately instead
-    SetState(State::Paused);
+    SetState(system, State::Paused);
   }
 }
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -143,7 +143,7 @@ bool IsHostThread();
 bool WantsDeterminism();
 
 // [NOT THREADSAFE] For use by Host only
-void SetState(State state, bool report_state_change = true);
+void SetState(Core::System& system, State state, bool report_state_change = true);
 State GetState(Core::System& system);
 
 void SaveScreenShot();

--- a/Source/Core/DolphinNoGUI/PlatformMacos.mm
+++ b/Source/Core/DolphinNoGUI/PlatformMacos.mm
@@ -44,9 +44,9 @@
 {
   auto& system = Core::System::GetInstance();
   if (Core::GetState(system) == Core::State::Running)
-    Core::SetState(Core::State::Paused);
+    Core::SetState(system, Core::State::Paused);
   else
-    Core::SetState(Core::State::Running);
+    Core::SetState(system, Core::State::Running);
 }
 
 - (void)saveScreenShot

--- a/Source/Core/DolphinNoGUI/PlatformX11.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformX11.cpp
@@ -203,13 +203,13 @@ void PlatformX11::ProcessEvents()
         {
           if (Config::Get(Config::MAIN_SHOW_CURSOR) == Config::ShowCursor::Never)
             XUndefineCursor(m_display, m_window);
-          Core::SetState(Core::State::Paused);
+          Core::SetState(Core::System::GetInstance(), Core::State::Paused);
         }
         else
         {
           if (Config::Get(Config::MAIN_SHOW_CURSOR) == Config::ShowCursor::Never)
             XDefineCursor(m_display, m_window, m_blank_cursor);
-          Core::SetState(Core::State::Running);
+          Core::SetState(Core::System::GetInstance(), Core::State::Running);
         }
       }
       else if ((key == XK_Return) && (event.xkey.state & Mod1Mask))

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -825,7 +825,7 @@ void MainWindow::Play(const std::optional<std::string>& savestate_path)
   // Otherwise, prompt for a new game.
   if (Core::GetState(Core::System::GetInstance()) == Core::State::Paused)
   {
-    Core::SetState(Core::State::Running);
+    Core::SetState(Core::System::GetInstance(), Core::State::Running);
   }
   else
   {
@@ -853,7 +853,7 @@ void MainWindow::Play(const std::optional<std::string>& savestate_path)
 
 void MainWindow::Pause()
 {
-  Core::SetState(Core::State::Paused);
+  Core::SetState(Core::System::GetInstance(), Core::State::Paused);
 }
 
 void MainWindow::TogglePause()
@@ -932,7 +932,7 @@ bool MainWindow::RequestStop()
     bool pause = !Settings::Instance().GetNetPlayClient();
 
     if (pause)
-      Core::SetState(Core::State::Paused);
+      Core::SetState(Core::System::GetInstance(), Core::State::Paused);
 
     if (rendered_widget_was_active)
     {
@@ -962,7 +962,7 @@ bool MainWindow::RequestStop()
       m_render_widget->SetWaitingForMessageBox(false);
 
       if (pause)
-        Core::SetState(state);
+        Core::SetState(Core::System::GetInstance(), state);
 
       return false;
     }
@@ -984,7 +984,7 @@ bool MainWindow::RequestStop()
     // Unpause because gracefully shutting down needs the game to actually request a shutdown.
     // TODO: Do not unpause in debug mode to allow debugging until the complete shutdown.
     if (Core::GetState(Core::System::GetInstance()) == Core::State::Paused)
-      Core::SetState(Core::State::Running);
+      Core::SetState(Core::System::GetInstance(), Core::State::Running);
 
     // Tell NetPlay about the power event
     if (NetPlay::IsNetPlayRunning())

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -424,7 +424,7 @@ bool RenderWidget::event(QEvent* event)
     if (m_should_unpause_on_focus &&
         Core::GetState(Core::System::GetInstance()) == Core::State::Paused)
     {
-      Core::SetState(Core::State::Running);
+      Core::SetState(Core::System::GetInstance(), Core::State::Running);
     }
 
     m_should_unpause_on_focus = false;
@@ -457,7 +457,7 @@ bool RenderWidget::event(QEvent* event)
       if (!Core::IsCPUThread() && !Core::IsGPUThread())
       {
         m_should_unpause_on_focus = true;
-        Core::SetState(Core::State::Paused);
+        Core::SetState(Core::System::GetInstance(), Core::State::Paused);
       }
     }
 


### PR DESCRIPTION
Part 5 of an effort to remove global state from one of the biggest offenders. This is my last planned change to Core.cpp, leaving `Core::DisplayMessage` and `Core::SaveScreenshot` unchanged. I believe these remaining uses of `Core::System::GetInstance` are open design questions that shouldn't be tackled in the same way I have for the other functions.