### PR TITLE
PowerPC: Remove Dead Config Code

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -5,8 +5,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <istream>
-#include <ostream>
 #include <type_traits>
 #include <vector>
 
@@ -59,30 +57,6 @@ static void InvalidateCacheThreadSafe(Core::System& system, u64 userdata, s64 cy
 {
   system.GetPPCState().iCache.Invalidate(system.GetMemory(), system.GetJitInterface(),
                                          static_cast<u32>(userdata));
-}
-
-std::istream& operator>>(std::istream& is, CPUCore& core)
-{
-  std::underlying_type_t<CPUCore> val{};
-
-  if (is >> val)
-  {
-    core = static_cast<CPUCore>(val);
-  }
-  else
-  {
-    // Upon failure, fall back to the cached interpreter
-    // to ensure we always initialize our core reference.
-    core = CPUCore::CachedInterpreter;
-  }
-
-  return is;
-}
-
-std::ostream& operator<<(std::ostream& os, CPUCore core)
-{
-  os << static_cast<std::underlying_type_t<CPUCore>>(core);
-  return os;
 }
 
 PowerPCManager::PowerPCManager(Core::System& system)

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -5,7 +5,6 @@
 
 #include <array>
 #include <cstddef>
-#include <iosfwd>
 #include <span>
 #include <tuple>
 #include <type_traits>
@@ -40,10 +39,6 @@ enum class CPUCore
   JITARM64 = 4,
   CachedInterpreter = 5,
 };
-
-// For reading from and writing to our config.
-std::istream& operator>>(std::istream& is, CPUCore& core);
-std::ostream& operator<<(std::ostream& os, CPUCore core);
 
 enum class CoreMode
 {


### PR DESCRIPTION
This was something I noticed back when I was considering adding a virtual function to CPUCoreBase to return an identifying enum. Nothing seems to be using this code anymore.