### PR TITLE
Retooled Achievements Welcome Message

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -192,8 +192,8 @@ private:
   u32 m_game_id = 0;
   rc_api_fetch_game_data_response_t m_game_data{};
   bool m_is_game_loaded = false;
-  u32 m_framecount = 0;
   BadgeStatus m_game_badge;
+  bool m_display_welcome_message = false;
   std::unordered_map<AchievementId, BadgeStatus> m_unlocked_badges;
   std::unordered_map<AchievementId, BadgeStatus> m_locked_badges;
   RichPresence m_rich_presence;


### PR DESCRIPTION
The "welcome message" that shows up to players when a game starts up and Achievements are active will now either tell the player upon load that there's no support for achievements, or will wait until the first attempt to load the game's badge either succeeds or fails and then display a full message with title and progress and status. This is in part facilitated by a boolean field for when to display a welcome message, set to true upon loading and to false upon a message being displayed.