### PR TITLE
use pkg-config to find libusb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,7 +703,9 @@ include_directories(Externals/soundtouch)
 dolphin_find_optional_system_library(CUBEB Externals/cubeb)
 
 if(NOT ANDROID)
-  dolphin_find_optional_system_library(LibUSB Externals/libusb)
+  dolphin_find_optional_system_library_pkgconfig(
+    LibUSB libusb-1.0 LibUSB::LibUSB Externals/libusb
+  )
   add_definitions(-D__LIBUSB__)
 endif()
 

--- a/Externals/hidapi/CMakeLists.txt
+++ b/Externals/hidapi/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
     target_link_libraries(hidapi PRIVATE udev)
   else()
     target_sources(hidapi PRIVATE hidapi-src/libusb/hid.c)
-    target_link_libraries(hidapi PRIVATE ${LIBUSB_LIBRARIES})
+    target_link_libraries(hidapi PRIVATE LibUSB::LibUSB)
   endif()
 endif()
 


### PR DESCRIPTION
I've tested this on OpenBSD 7.5 and NetBSD 10.0 only. 
OpenBSD works, and compilation goes further than it used to before failing on NetBSD.
