### PR TITLE
use pkg-config to find libfmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -628,7 +628,9 @@ if (_M_X86_64)
 endif()
 add_subdirectory(Externals/cpp-optparse)
 
-dolphin_find_optional_system_library(fmt Externals/fmt 10.1)
+dolphin_find_optional_system_library_pkgconfig(FMT
+  fmt>=10.1 fmt::fmt Externals/fmt
+)
 
 add_subdirectory(Externals/imgui)
 add_subdirectory(Externals/implot)


### PR DESCRIPTION
I've tested this on OpenBSD 7.5 and NetBSD 10.0.
On OpenBSD, it detects the system libfmt is too old and uses the Externals/ one. On NetBSD, generating the build system succeeds, but compilation fails for unrelated reasons (Dolphin doesn't run on NetBSD).