### PR TITLE
IOS/USB Add 2 more Spaces for Disney Infinity figures

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
@@ -80,7 +80,6 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
     private var infinityFigureData = Figure(-1, "Position")
     private var skylanderSlot = -1
     private var infinityPosition = -1
-    private var infinityListPosition = -1
     private lateinit var skylandersBinding: DialogNfcFiguresManagerBinding
     private lateinit var infinityBinding: DialogNfcFiguresManagerBinding
 
@@ -140,12 +139,14 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
         if (infinityFigures.isEmpty()) {
             infinityFigures.apply {
                 add(FigureSlot(getString(R.string.infinity_hexagon_label), 0))
-                add(FigureSlot(getString(R.string.infinity_p1_label), 1))
-                add(FigureSlot(getString(R.string.infinity_p1a1_label), 3))
+                add(FigureSlot(getString(R.string.infinity_power_hex_two_label), 1))
+                add(FigureSlot(getString(R.string.infinity_power_hex_three_label), 2))
+                add(FigureSlot(getString(R.string.infinity_p1_label), 3))
+                add(FigureSlot(getString(R.string.infinity_p1a1_label), 4))
                 add(FigureSlot(getString(R.string.infinity_p1a2_label), 5))
-                add(FigureSlot(getString(R.string.infinity_p2_label), 2))
-                add(FigureSlot(getString(R.string.infinity_p2a1_label), 4))
-                add(FigureSlot(getString(R.string.infinity_p2a2_label), 6))
+                add(FigureSlot(getString(R.string.infinity_p2_label), 6))
+                add(FigureSlot(getString(R.string.infinity_p2a1_label), 7))
+                add(FigureSlot(getString(R.string.infinity_p2a2_label), 8))
             }
         }
     }
@@ -164,7 +165,6 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             putInt(EXTRA_SKYLANDER_VAR, skylanderData.variant)
             putString(EXTRA_SKYLANDER_NAME, skylanderData.name)
             putInt(EXTRA_INFINITY_POSITION, infinityPosition)
-            putInt(EXTRA_INFINITY_LIST_POSITION, infinityListPosition)
             putLong(EXTRA_INFINITY_NUM, infinityFigureData.number)
             putString(EXTRA_INFINITY_NAME, infinityFigureData.name)
         }
@@ -183,7 +183,6 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
                 savedInstanceState.getString(EXTRA_SKYLANDER_NAME)!!
             )
             infinityPosition = savedInstanceState.getInt(EXTRA_INFINITY_POSITION)
-            infinityListPosition = savedInstanceState.getInt(EXTRA_INFINITY_LIST_POSITION)
             infinityFigureData = Figure(
                 savedInstanceState.getLong(EXTRA_INFINITY_NUM),
                 savedInstanceState.getString(EXTRA_INFINITY_NAME)!!
@@ -297,11 +296,10 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             } else if (requestCode == REQUEST_INFINITY_FIGURE_FILE) {
                 val label = InfinityConfig.loadFigure(infinityPosition, result!!.data.toString())
                 if (label != null && label != "Unknown Figure") {
-                    clearInfinityFigure(infinityListPosition)
-                    infinityFigures[infinityListPosition].label = label
-                    infinityBinding.figureManager.adapter?.notifyItemChanged(infinityListPosition)
+                    clearInfinityFigure(infinityPosition)
+                    infinityFigures[infinityPosition].label = label
+                    infinityBinding.figureManager.adapter?.notifyItemChanged(infinityPosition)
                     infinityPosition = -1
-                    infinityListPosition = -1
                     infinityFigureData = Figure.BLANK_FIGURE
                 } else {
                     MaterialAlertDialogBuilder(this)
@@ -317,11 +315,10 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
                         result!!.data.toString(),
                         infinityPosition
                     )
-                    clearInfinityFigure(infinityListPosition)
-                    infinityFigures[infinityListPosition].label = label!!
-                    infinityBinding.figureManager.adapter?.notifyItemChanged(infinityListPosition)
+                    clearInfinityFigure(infinityPosition)
+                    infinityFigures[infinityPosition].label = label!!
+                    infinityBinding.figureManager.adapter?.notifyItemChanged(infinityPosition)
                     infinityPosition = -1
-                    infinityListPosition = -1
                     infinityFigureData = Figure.BLANK_FIGURE
                 }
             }
@@ -906,18 +903,19 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
     fun setInfinityFigureData(num: Long, name: String, position: Int, listPosition: Int) {
         infinityFigureData = Figure(num, name)
         infinityPosition = position
-        infinityListPosition = listPosition
     }
 
     fun clearInfinityFigure(position: Int) {
         when (position) {
             0 -> infinityFigures[position].label = getString(R.string.infinity_hexagon_label)
-            1 -> infinityFigures[position].label = getString(R.string.infinity_p1_label)
-            2 -> infinityFigures[position].label = getString(R.string.infinity_p1a1_label)
-            3 -> infinityFigures[position].label = getString(R.string.infinity_p1a2_label)
-            4 -> infinityFigures[position].label = getString(R.string.infinity_p2_label)
-            5 -> infinityFigures[position].label = getString(R.string.infinity_p2a1_label)
-            6 -> infinityFigures[position].label = getString(R.string.infinity_p2a2_label)
+            1 -> infinityFigures[position].label = getString(R.string.infinity_power_hex_two_label)
+            2 -> infinityFigures[position].label = getString(R.string.infinity_power_hex_three_label)
+            3 -> infinityFigures[position].label = getString(R.string.infinity_p1_label)
+            4 -> infinityFigures[position].label = getString(R.string.infinity_p1a1_label)
+            5 -> infinityFigures[position].label = getString(R.string.infinity_p1a2_label)
+            6 -> infinityFigures[position].label = getString(R.string.infinity_p2_label)
+            7 -> infinityFigures[position].label = getString(R.string.infinity_p2a1_label)
+            8 -> infinityFigures[position].label = getString(R.string.infinity_p2a2_label)
         }
         infinityBinding.figureManager.adapter?.notifyItemChanged(position)
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/infinitybase/ui/FigureSlotAdapter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/infinitybase/ui/FigureSlotAdapter.kt
@@ -75,6 +75,11 @@ class FigureSlotAdapter(
                 }
 
                 1, 2 -> {
+                    // Hexagon Power Discs
+                    validFigures.filter { (_, value) -> value in 4000000..4999999 }
+                }
+
+                3, 6  -> {
                     // Characters
                     validFigures.filter { (_, value) -> value in 1000000..1999999 }
                 }

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -914,6 +914,8 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="infinity_number">Figure Number</string>
     <string name="invalid_infinity_figure">Invalid Figure Selection</string>
     <string name="infinity_hexagon_label">Power Disc/Play Set</string>
+    <string name="infinity_power_hex_two_label">Power Disc Two</string>
+    <string name="infinity_power_hex_three_label">Power Disc Three</string>
     <string name="infinity_p1_label">Player One</string>
     <string name="infinity_p2_label">Player Two</string>
     <string name="infinity_p1a1_label">P1 Ability One</string>

--- a/Source/Core/Core/IOS/USB/Emulated/Infinity.h
+++ b/Source/Core/Core/IOS/USB/Emulated/Infinity.h
@@ -89,7 +89,7 @@ public:
 
 protected:
   std::mutex m_infinity_mutex;
-  std::array<InfinityFigure, 7> m_figures;
+  std::array<InfinityFigure, 9> m_figures;
 
 private:
   InfinityFigure& GetFigureByOrder(u8 order_added);

--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
@@ -79,17 +79,21 @@ void InfinityBaseWindow::CreateMainWindow()
 
   AddFigureSlot(vbox_group, tr("Play Set/Power Disc"), 0);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player One"), 1);
+  AddFigureSlot(vbox_group, tr("Power Disc Two"), 1);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player One Ability One"), 3);
+  AddFigureSlot(vbox_group, tr("Power Disc Three"), 2);
+  add_line(vbox_group);
+  AddFigureSlot(vbox_group, tr("Player One"), 3);
+  add_line(vbox_group);
+  AddFigureSlot(vbox_group, tr("Player One Ability One"), 4);
   add_line(vbox_group);
   AddFigureSlot(vbox_group, tr("Player One Ability Two"), 5);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player Two"), 2);
+  AddFigureSlot(vbox_group, tr("Player Two"), 6);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player Two Ability One"), 4);
+  AddFigureSlot(vbox_group, tr("Player Two Ability One"), 7);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player Two Ability Two"), 6);
+  AddFigureSlot(vbox_group, tr("Player Two Ability Two"), 8);
 
   m_group_figures->setLayout(vbox_group);
   scroll_area->setWidget(m_group_figures);
@@ -203,8 +207,9 @@ CreateFigureDialog::CreateFigureDialog(QWidget* parent, u8 slot) : QDialog(paren
     // Only display entry if it is a piece appropriate for the slot
     if ((slot == 0 &&
          ((figure > 0x1E8480 && figure < 0x2DC6BF) || (figure > 0x3D0900 && figure < 0x4C4B3F))) ||
-        ((slot == 1 || slot == 2) && figure < 0x1E847F) ||
-        ((slot == 3 || slot == 4 || slot == 5 || slot == 6) &&
+        ((slot == 1 || slot == 2) && (figure > 0x3D0900 && figure < 0x4C4B3F)) ||
+        ((slot == 3 || slot == 6) && figure < 0x1E847F) ||
+        ((slot == 4 || slot == 5 || slot == 7 || slot == 8) &&
          (figure > 0x2DC6C0 && figure < 0x3D08FF)))
     {
       const auto figure_name = QString::fromStdString(entry.first);

--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.h
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.h
@@ -28,7 +28,7 @@ public:
   ~InfinityBaseWindow() override;
 
 protected:
-  std::array<QLineEdit*, 7> m_edit_figures;
+  std::array<QLineEdit*, 9> m_edit_figures;
 
 private:
   void CreateMainWindow();


### PR DESCRIPTION
This was raised to me by a user that pointed out that you can have 2 "Power Discs" underneath the playset/power disc in the Hexagon space on the infinity base, so I have added 2 more slots to the qt and android UIs, as well as changing the behaviour of one of the C++ methods to allow for this. Removed the infinityListPosition from the Android version, as now the position in the UI list is ordered and doesn't need to have a separate UI list position and backend base position.