### PR TITLE
Improve Accuracy of Max% by using same counter as Speed%

### DIFF
--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -47,15 +47,13 @@ public:
 private:
   PerformanceTracker m_fps_counter{"render_times.txt"};
   PerformanceTracker m_vps_counter{"vblank_times.txt"};
-  PerformanceTracker m_speed_counter{std::nullopt, 1000000};
+  PerformanceTracker m_speed_counter{std::nullopt, 1280000};
+  PerformanceTracker m_max_speed_counter{std::nullopt, 1280000};
 
   double m_graph_max_time = 0.0;
 
   mutable std::shared_mutex m_time_lock;
-
-  u8 m_time_index = 0;
-  std::array<TimePoint, 256> m_real_times{};
-  std::array<TimePoint, 256> m_cpu_times{};
+  TimePoint m_prev_adjusted_time{};
   DT m_time_sleeping{};
 };
 

--- a/Source/Core/VideoCommon/PerformanceTracker.cpp
+++ b/Source/Core/VideoCommon/PerformanceTracker.cpp
@@ -16,7 +16,7 @@
 #include "Core/Core.h"
 #include "VideoCommon/VideoConfig.h"
 
-static constexpr double SAMPLE_RC_RATIO = 0.25;
+static constexpr double SAMPLE_RC_RATIO = 0.33;
 
 PerformanceTracker::PerformanceTracker(const std::optional<std::string> log_name,
                                        const std::optional<s64> sample_window_us)
@@ -47,7 +47,7 @@ void PerformanceTracker::Reset()
   m_dt_std = std::nullopt;
 }
 
-void PerformanceTracker::Count()
+void PerformanceTracker::Count(std::optional<DT> custom_measurement, bool is_continuous_duration)
 {
   std::unique_lock lock{m_mutex};
 
@@ -57,26 +57,31 @@ void PerformanceTracker::Count()
   const DT window{GetSampleWindow()};
 
   const TimePoint time{Clock::now()};
-  const DT diff{time - m_last_time};
-
+  const DT duration{time - m_last_time};
+  const DT value{custom_measurement.value_or(duration)};
+  const TimeDataPair data_point{is_continuous_duration ? value : duration, value};
   m_last_time = time;
 
-  QueuePush(diff);
-  m_dt_total += diff;
+  QueuePush(data_point);
+  m_dt_total += data_point;
 
   if (m_dt_queue_begin == m_dt_queue_end)
     m_dt_total -= QueuePop();
 
-  while (window <= m_dt_total - QueueTop())
+  while (window <= m_dt_total.duration - QueueTop().duration)
     m_dt_total -= QueuePop();
 
   // Simple Moving Average Throughout the Window
-  m_dt_avg = m_dt_total / QueueSize();
-  const double hz = DT_s(1.0) / m_dt_avg;
+  // We want the average value, so we use the value
+  m_dt_avg = m_dt_total.measurement / QueueSize();
+
+  // Even though the frequency does not make sense if the value
+  // is not the duration, it is still useful to have the value
+  const double hz = DT_s(QueueSize()) / m_dt_total.measurement;
 
   // Exponential Moving Average
-  const DT_s rc = SAMPLE_RC_RATIO * std::min(window, m_dt_total);
-  const double a = 1.0 - std::exp(-(DT_s(diff) / rc));
+  const DT_s rc = SAMPLE_RC_RATIO * window;
+  const double a = 1.0 - std::exp(-(DT_s(data_point.duration) / rc));
 
   // Sometimes euler averages can break when the average is inf/nan
   if (std::isfinite(m_hz_avg))
@@ -86,7 +91,7 @@ void PerformanceTracker::Count()
 
   m_dt_std = std::nullopt;
 
-  LogRenderTimeToFile(diff);
+  LogRenderTimeToFile(data_point.measurement);
 }
 
 DT PerformanceTracker::GetSampleWindow() const
@@ -121,7 +126,7 @@ DT PerformanceTracker::GetDtStd() const
   double total = 0.0;
   for (std::size_t i = m_dt_queue_begin; i != m_dt_queue_end; i = IncrementIndex(i))
   {
-    double diff = DT_s(m_dt_queue[i] - m_dt_avg).count();
+    double diff = DT_s(m_dt_queue[i].measurement - m_dt_avg).count();
     total += diff * diff;
   }
 
@@ -136,51 +141,42 @@ DT PerformanceTracker::GetLastRawDt() const
   if (QueueEmpty())
     return DT::zero();
 
-  return QueueBottom();
+  return QueueBottom().measurement;
 }
 
 void PerformanceTracker::ImPlotPlotLines(const char* label) const
 {
-  static std::array<float, MAX_DT_QUEUE_SIZE + 2> x, y;
+  static std::array<float, 2 * MAX_DT_QUEUE_SIZE + 2> x, y;
 
   std::shared_lock lock{m_mutex};
 
   if (QueueEmpty())
     return;
 
-  // Decides if there are too many points to plot using rectangles
-  const bool quality = QueueSize() < MAX_QUALITY_GRAPH_SIZE;
-
   const DT update_time = Clock::now() - m_last_time;
-  const float predicted_frame_time = DT_ms(std::max(update_time, QueueBottom())).count();
 
   std::size_t points = 0;
-  if (quality)
-  {
-    x[points] = 0.f;
-    y[points] = predicted_frame_time;
-    ++points;
-  }
+  x[points] = 0.f;
+  y[points] = DT_ms(QueueBottom().measurement).count();
+  ++points;
 
   x[points] = DT_ms(update_time).count();
-  y[points] = predicted_frame_time;
+  y[points] = y[points - 1];
   ++points;
 
   const std::size_t begin = DecrementIndex(m_dt_queue_end);
   const std::size_t end = DecrementIndex(m_dt_queue_begin);
   for (std::size_t i = begin; i != end; i = DecrementIndex(i))
   {
-    const float frame_time_ms = DT_ms(m_dt_queue[i]).count();
+    const float frame_duration_ms = DT_ms(m_dt_queue[i].duration).count();
+    const float frame_value_ms = DT_ms(m_dt_queue[i].measurement).count();
 
-    if (quality)
-    {
-      x[points] = x[points - 1];
-      y[points] = frame_time_ms;
-      ++points;
-    }
+    x[points] = x[points - 1];
+    y[points] = frame_value_ms;
+    ++points;
 
-    x[points] = x[points - 1] + frame_time_ms;
-    y[points] = frame_time_ms;
+    x[points] = x[points - 1] + frame_duration_ms;
+    y[points] = frame_value_ms;
     ++points;
   }
 
@@ -194,25 +190,25 @@ void PerformanceTracker::QueueClear()
   m_dt_queue_end = 0;
 }
 
-void PerformanceTracker::QueuePush(DT dt)
+void PerformanceTracker::QueuePush(TimeDataPair dt)
 {
   m_dt_queue[m_dt_queue_end] = dt;
   m_dt_queue_end = IncrementIndex(m_dt_queue_end);
 }
 
-const DT& PerformanceTracker::QueuePop()
+const PerformanceTracker::TimeDataPair& PerformanceTracker::QueuePop()
 {
   const std::size_t top = m_dt_queue_begin;
   m_dt_queue_begin = IncrementIndex(m_dt_queue_begin);
   return m_dt_queue[top];
 }
 
-const DT& PerformanceTracker::QueueTop() const
+const PerformanceTracker::TimeDataPair& PerformanceTracker::QueueTop() const
 {
   return m_dt_queue[m_dt_queue_begin];
 }
 
-const DT& PerformanceTracker::QueueBottom() const
+const PerformanceTracker::TimeDataPair& PerformanceTracker::QueueBottom() const
 {
   return m_dt_queue[DecrementIndex(m_dt_queue_end)];
 }

--- a/Source/Core/VideoCommon/PerformanceTracker.h
+++ b/Source/Core/VideoCommon/PerformanceTracker.h
@@ -15,7 +15,7 @@ class PerformanceTracker
 {
 private:
   // Must be powers of 2 for masking to work
-  static constexpr u64 MAX_DT_QUEUE_SIZE = 1UL << 12;
+  static constexpr u64 MAX_DT_QUEUE_SIZE = 1UL << 13;
   static constexpr u64 MAX_QUALITY_GRAPH_SIZE = 1UL << 8;
 
   static inline std::size_t IncrementIndex(const std::size_t index)
@@ -33,6 +33,31 @@ private:
     return (end - begin) & (MAX_DT_QUEUE_SIZE - 1);
   }
 
+  struct TimeDataPair
+  {
+  public:
+    TimeDataPair(DT duration, DT measurement) : duration{duration}, measurement{measurement} {}
+    TimeDataPair(DT duration) : TimeDataPair{duration, duration} {}
+    TimeDataPair() : TimeDataPair{DT::zero()} {}
+
+    TimeDataPair& operator+=(const TimeDataPair& other)
+    {
+      duration += other.duration;
+      measurement += other.measurement;
+      return *this;
+    }
+
+    TimeDataPair& operator-=(const TimeDataPair& other)
+    {
+      duration -= other.duration;
+      measurement -= other.measurement;
+      return *this;
+    }
+
+  public:
+    DT duration, measurement;
+  };
+
 public:
   PerformanceTracker(const std::optional<std::string> log_name = std::nullopt,
                      const std::optional<s64> sample_window_us = std::nullopt);
@@ -45,7 +70,21 @@ public:
 
   // Functions for recording performance information
   void Reset();
-  void Count();
+
+  /**
+   * custom_measurement can be used if you are recording something with it's own DT. For example,
+   * if you are recording the fallback of the throttler or the latency of the frame.
+   *
+   * If a custom_measurement is not supplied, the value will be set to the time between calls aka,
+   * duration. This is the most common use case of this class, as an FPS counter.
+   *
+   * The boolean is_continuous_duration should be set to true if the custom DTs you are providing
+   * represent a continuous duration. For example, the present times from a render backend
+   * would set is_continuous_duration to true. Things like throttler fallback or frame latency
+   * are not continuous, so they should not represent duration.
+   */
+  void Count(std::optional<DT> custom_measurement = std::nullopt,
+             bool is_continuous_duration = false);
 
   // Functions for reading performance information
   DT GetSampleWindow() const;
@@ -61,13 +100,13 @@ public:
 
 private:  // Functions for managing dt queue
   inline void QueueClear();
-  inline void QueuePush(DT dt);
-  inline const DT& QueuePop();
-  inline const DT& QueueTop() const;
-  inline const DT& QueueBottom() const;
+  inline void QueuePush(TimeDataPair dt);
+  inline const TimeDataPair& QueuePop();
+  inline const TimeDataPair& QueueTop() const;
+  inline const TimeDataPair& QueueBottom() const;
 
-  std::size_t inline QueueSize() const;
-  bool inline QueueEmpty() const;
+  inline std::size_t QueueSize() const;
+  inline bool QueueEmpty() const;
 
   // Handle pausing and logging
   void LogRenderTimeToFile(DT val);
@@ -87,8 +126,8 @@ private:  // Functions for managing dt queue
   const std::optional<s64> m_sample_window_us;
 
   // Queue + Running Total used to calculate average dt
-  DT m_dt_total = DT::zero();
-  std::array<DT, MAX_DT_QUEUE_SIZE> m_dt_queue;
+  TimeDataPair m_dt_total;
+  std::array<TimeDataPair, MAX_DT_QUEUE_SIZE> m_dt_queue;
   std::size_t m_dt_queue_begin = 0;
   std::size_t m_dt_queue_end = 0;
 


### PR DESCRIPTION
I have noticed that people have been referring to `max%` in order to determine performance. However the old way of counting it made it difficult to compare to the normal speed. This PR is a rehash of #11532 with the a merge with master + the requests from @iwubcode. Hopefully you guys find this useful when testing the performance of something.