### PR TITLE
Remove min_clock_per_sleep to improve VPS consistency 

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -373,11 +373,6 @@ void CoreTimingManager::Throttle(const s64 target_cycle)
 {
   // Based on number of cycles and emulation speed, increase the target deadline
   const s64 cycles = target_cycle - m_throttle_last_cycle;
-
-  // Prevent any throttling code if the amount of time passed is < ~0.122ms
-  if (cycles < m_throttle_min_clock_per_sleep)
-    return;
-
   m_throttle_last_cycle = target_cycle;
 
   const double speed = Core::GetIsThrottlerTempDisabled() ? 0.0 : m_emulation_speed;
@@ -455,7 +450,6 @@ void CoreTimingManager::LogPendingEvents() const
 void CoreTimingManager::AdjustEventQueueTimes(u32 new_ppc_clock, u32 old_ppc_clock)
 {
   m_throttle_clock_per_sec = new_ppc_clock;
-  m_throttle_min_clock_per_sleep = new_ppc_clock / 1200;
 
   for (Event& ev : m_event_queue)
   {

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -191,7 +191,6 @@ private:
   s64 m_throttle_last_cycle = 0;
   TimePoint m_throttle_deadline = Clock::now();
   s64 m_throttle_clock_per_sec = 0;
-  s64 m_throttle_min_clock_per_sleep = 0;
   bool m_throttle_disable_vi_int = false;
 
   DT m_max_fallback = {};


### PR DESCRIPTION
I think this one needs to be discussed before merging.

Before (std: 0.29ms):

<img width="356" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/07d45f4f-7d26-4472-894b-e5e143934ad1">

After (std: 0.0ms):
<img width="354" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/cd03edf7-d4fb-4df8-a6e9-ce5e4674a40c">

only downside is it makes Max% appear to be too high, but this has more to do with Max% being unable to account for the GPU limitations and only counting the work done by the CPU.

I think we originally decided against this because of the fear that too many sleep calls would hurt performance, but given that this is only called to throttle performance, it shouldn't be able to slow things down unless 