### PR TITLE
Remove High Frequency Distortion and Prevent Crackling in Almost All Cases

### DIFF
--- a/Source/Core/AudioCommon/AudioStretcher.h
+++ b/Source/Core/AudioCommon/AudioStretcher.h
@@ -7,19 +7,23 @@
 
 #include <SoundTouch.h>
 
+#include "Common/CommonTypes.h"
+
 namespace AudioCommon
 {
 class AudioStretcher
 {
 public:
-  explicit AudioStretcher(unsigned int sample_rate);
-  void ProcessSamples(const short* in, unsigned int num_in, unsigned int num_out);
-  void GetStretchedSamples(short* out, unsigned int num_out);
+  explicit AudioStretcher(u64 sample_rate);
+  void ProcessSamples(const s16* in, u32 num_in, u32 num_out);
+  void GetStretchedSamples(s16* out, u32 num_out);
   void Clear();
 
+  DT AvailableSamplesTime() const;
+
 private:
-  unsigned int m_sample_rate;
-  std::array<short, 2> m_last_stretched_sample = {};
+  u64 m_sample_rate;
+  std::array<s16, 2> m_last_stretched_sample = {};
   soundtouch::SoundTouch m_sound_touch;
   double m_stretch_ratio = 1.0;
 };

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <atomic>
+#include <optional>
 
 #include "AudioCommon/AudioStretcher.h"
 #include "AudioCommon/SurroundDecoder.h"
@@ -17,32 +18,31 @@ class PointerWrap;
 class Mixer final
 {
 public:
-  explicit Mixer(unsigned int BackendSampleRate);
+  explicit Mixer(u32 BackendSampleRate);
   ~Mixer();
 
   void DoState(PointerWrap& p);
 
   // Called from audio threads
-  unsigned int Mix(short* samples, unsigned int numSamples);
-  unsigned int MixSurround(float* samples, unsigned int num_samples);
+  u32 Mix(s16* samples, u32 num_samples);
+  u32 MixSurround(float* samples, u32 num_samples);
 
   // Called from main thread
-  void PushSamples(const short* samples, unsigned int num_samples);
-  void PushStreamingSamples(const short* samples, unsigned int num_samples);
-  void PushWiimoteSpeakerSamples(const short* samples, unsigned int num_samples,
-                                 unsigned int sample_rate_divisor);
-  void PushSkylanderPortalSamples(const u8* samples, unsigned int num_samples);
-  void PushGBASamples(int device_number, const short* samples, unsigned int num_samples);
+  void PushSamples(const s16* samples, u32 num_samples);
+  void PushStreamingSamples(const s16* samples, u32 num_samples);
+  void PushWiimoteSpeakerSamples(const s16* samples, u32 num_samples, u32 sample_rate_divisor);
+  void PushSkylanderPortalSamples(const u8* samples, u32 num_samples);
+  void PushGBASamples(int device_number, const s16* samples, u32 num_samples);
 
-  unsigned int GetSampleRate() const { return m_sampleRate; }
+  u32 GetSampleRate() const { return m_sampleRate; }
 
-  void SetDMAInputSampleRateDivisor(unsigned int rate_divisor);
-  void SetStreamInputSampleRateDivisor(unsigned int rate_divisor);
-  void SetGBAInputSampleRateDivisors(int device_number, unsigned int rate_divisor);
+  void SetDMAInputSampleRateDivisor(u32 rate_divisor);
+  void SetStreamInputSampleRateDivisor(u32 rate_divisor);
+  void SetGBAInputSampleRateDivisors(int device_number, u32 rate_divisor);
 
-  void SetStreamingVolume(unsigned int lvolume, unsigned int rvolume);
-  void SetWiimoteSpeakerVolume(unsigned int lvolume, unsigned int rvolume);
-  void SetGBAVolume(int device_number, unsigned int lvolume, unsigned int rvolume);
+  void SetStreamingVolume(u32 lvolume, u32 rvolume);
+  void SetWiimoteSpeakerVolume(u32 lvolume, u32 rvolume);
+  void SetGBAVolume(int device_number, u32 lvolume, u32 rvolume);
 
   void StartLogDTKAudio(const std::string& filename);
   void StopLogDTKAudio();
@@ -55,43 +55,48 @@ public:
 
 private:
   static constexpr u32 MAX_SAMPLES = 1024 * 4;  // 128 ms
-  static constexpr u32 INDEX_MASK = MAX_SAMPLES * 2 - 1;
-  static constexpr int MAX_FREQ_SHIFT = 200;  // Per 32000 Hz
-  static constexpr float CONTROL_FACTOR = 0.2f;
-  static constexpr u32 CONTROL_AVG = 32;  // In freq_shift per FIFO size offset
+  static constexpr u32 INDEX_MASK = MAX_SAMPLES - 1;
+  static constexpr double MAX_PITCH_SHIFT = 1.0145453;  // 2 ^ (+1/48) - 1/4th Note Up
+  static constexpr double MIN_PITCH_SHIFT = 0.9856632;  // 2 ^ (-1/48) - 1/4th Note Down
+  static constexpr double SAMPLE_RATE_LPF = 1.0 / 4.0;  // How much to smooth out sample rate
+  static constexpr double CONTROL_EFFORT = 1.0 / 64.0;  // Lowers the strength of pitch shifting
 
-  const unsigned int SURROUND_CHANNELS = 6;
+  const u32 SURROUND_CHANNELS = 6;
 
   class MixerFifo final
   {
   public:
-    MixerFifo(Mixer* mixer, unsigned sample_rate_divisor, bool little_endian)
+    MixerFifo(Mixer* mixer, u32 sample_rate_divisor, bool little_endian)
         : m_mixer(mixer), m_input_sample_rate_divisor(sample_rate_divisor),
           m_little_endian(little_endian)
     {
     }
     void DoState(PointerWrap& p);
-    void PushSamples(const short* samples, unsigned int num_samples);
-    unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit,
-                     float emulationspeed, int timing_variance);
-    void SetInputSampleRateDivisor(unsigned int rate_divisor);
-    unsigned int GetInputSampleRateDivisor() const;
-    void SetVolume(unsigned int lvolume, unsigned int rvolume);
+    void PushSamples(const s16* samples, u32 num_samples);
+    std::pair<float, float> GetSample(u32 index, float frac, float sinc_ratio);
+    void Mix(s16* samples, u32 num_samples, double target_speed);
+    u32 MixRaw(s16* samples, u32 num_samples);
+    void SetInputSampleRateDivisor(u64 rate_divisor);
+    u64 GetInputSampleRateDivisor() const;
+    void SetVolume(s32 lvolume, s32 rvolume);
     std::pair<s32, s32> GetVolume() const;
-    unsigned int AvailableSamples() const;
+    u32 AvailableFIFOSamples() const;
+    u32 AvailableSamples() const;
+    DT AvailableSamplesTime() const;
 
   private:
     Mixer* m_mixer;
-    unsigned m_input_sample_rate_divisor;
+    u64 m_input_sample_rate_divisor;
     bool m_little_endian;
-    std::array<short, MAX_SAMPLES * 2> m_buffer{};
+    std::array<std::pair<float, float>, MAX_SAMPLES> m_buffer{};
     std::atomic<u32> m_indexW{0};
     std::atomic<u32> m_indexR{0};
     // Volume ranges from 0-256
     std::atomic<s32> m_LVolume{256};
     std::atomic<s32> m_RVolume{256};
-    float m_numLeftI = 0.0f;
-    u32 m_frac = 0;
+
+    double m_multiplier = 1.0;
+    double m_frac = 0.0;
   };
 
   void RefreshConfig();
@@ -104,12 +109,12 @@ private:
                                         MixerFifo{this, FIXED_SAMPLE_RATE_DIVIDEND / 48000, true},
                                         MixerFifo{this, FIXED_SAMPLE_RATE_DIVIDEND / 48000, true},
                                         MixerFifo{this, FIXED_SAMPLE_RATE_DIVIDEND / 48000, true}};
-  unsigned int m_sampleRate;
+  u32 m_sampleRate;
 
   bool m_is_stretching = false;
   AudioCommon::AudioStretcher m_stretcher;
   AudioCommon::SurroundDecoder m_surround_decoder;
-  std::array<short, MAX_SAMPLES * 2> m_scratch_buffer{};
+  std::array<s16, MAX_SAMPLES * 2> m_scratch_buffer{};
 
   WaveFileWriter m_wave_writer_dtk;
   WaveFileWriter m_wave_writer_dsp;
@@ -118,8 +123,9 @@ private:
   bool m_log_dsp_audio = false;
 
   float m_config_emulation_speed;
-  int m_config_timing_variance;
   bool m_config_audio_stretch;
+  int m_config_direct_latency;
+  int m_config_sinc_window_width;
 
   Config::ConfigChangedCallbackID m_config_changed_callback_id;
 };

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -44,7 +44,6 @@ const Info<bool> MAIN_LARGE_ENTRY_POINTS_MAP{{System::Main, "Core", "LargeEntryP
 const Info<bool> MAIN_ACCURATE_CPU_CACHE{{System::Main, "Core", "AccurateCPUCache"}, false};
 const Info<bool> MAIN_DSP_HLE{{System::Main, "Core", "DSPHLE"}, true};
 const Info<int> MAIN_MAX_FALLBACK{{System::Main, "Core", "MaxFallback"}, 100};
-const Info<int> MAIN_TIMING_VARIANCE{{System::Main, "Core", "TimingVariance"}, 40};
 const Info<bool> MAIN_CPU_THREAD{{System::Main, "Core", "CPUThread"}, true};
 const Info<bool> MAIN_SYNC_ON_SKIP_IDLE{{System::Main, "Core", "SyncOnSkipIdle"}, true};
 const Info<std::string> MAIN_DEFAULT_ISO{{System::Main, "Core", "DefaultISO"}, ""};
@@ -57,7 +56,9 @@ const Info<AudioCommon::DPL2Quality> MAIN_DPL2_QUALITY{{System::Main, "Core", "D
                                                        AudioCommon::GetDefaultDPL2Quality()};
 const Info<int> MAIN_AUDIO_LATENCY{{System::Main, "Core", "AudioLatency"}, 20};
 const Info<bool> MAIN_AUDIO_STRETCH{{System::Main, "Core", "AudioStretch"}, false};
+const Info<int> MAIN_AUDIO_DIRECT_LATENCY{{System::Main, "Core", "AudioDirectLatency"}, 20};
 const Info<int> MAIN_AUDIO_STRETCH_LATENCY{{System::Main, "Core", "AudioStretchMaxLatency"}, 80};
+const Info<int> MAIN_AUDIO_SINC_WINDOW_WIDTH{{System::Main, "Core", "AudioSincResampleTaps"}, 6};
 const Info<std::string> MAIN_MEMCARD_A_PATH{{System::Main, "Core", "MemcardAPath"}, ""};
 const Info<std::string> MAIN_MEMCARD_B_PATH{{System::Main, "Core", "MemcardBPath"}, ""};
 const Info<std::string>& GetInfoForMemcardPath(ExpansionInterface::Slot slot)

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -62,7 +62,6 @@ extern const Info<bool> MAIN_ACCURATE_CPU_CACHE;
 // Should really be in the DSP section, but we're kind of stuck with bad decisions made in the past.
 extern const Info<bool> MAIN_DSP_HLE;
 extern const Info<int> MAIN_MAX_FALLBACK;
-extern const Info<int> MAIN_TIMING_VARIANCE;
 extern const Info<bool> MAIN_CPU_THREAD;
 extern const Info<bool> MAIN_SYNC_ON_SKIP_IDLE;
 extern const Info<std::string> MAIN_DEFAULT_ISO;
@@ -73,7 +72,9 @@ extern const Info<bool> MAIN_DPL2_DECODER;
 extern const Info<AudioCommon::DPL2Quality> MAIN_DPL2_QUALITY;
 extern const Info<int> MAIN_AUDIO_LATENCY;
 extern const Info<bool> MAIN_AUDIO_STRETCH;
+extern const Info<int> MAIN_AUDIO_DIRECT_LATENCY;
 extern const Info<int> MAIN_AUDIO_STRETCH_LATENCY;
+extern const Info<int> MAIN_AUDIO_SINC_WINDOW_WIDTH;
 extern const Info<std::string> MAIN_MEMCARD_A_PATH;
 extern const Info<std::string> MAIN_MEMCARD_B_PATH;
 const Info<std::string>& GetInfoForMemcardPath(ExpansionInterface::Slot slot);

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -136,8 +136,6 @@ void CoreTimingManager::RefreshConfig()
   // too long or going full speed in an attempt to catch up to timings.
   m_max_fallback = std::chrono::duration_cast<DT>(DT_ms(Config::Get(Config::MAIN_MAX_FALLBACK)));
 
-  m_max_variance = std::chrono::duration_cast<DT>(DT_ms(Config::Get(Config::MAIN_TIMING_VARIANCE)));
-
   if (AchievementManager::GetInstance().IsHardcoreModeActive() &&
       Config::Get(Config::MAIN_EMULATION_SPEED) < 1.0f &&
       Config::Get(Config::MAIN_EMULATION_SPEED) > 0.0f)
@@ -399,7 +397,7 @@ void CoreTimingManager::Throttle(const s64 target_cycle)
     m_throttle_deadline = min_deadline;
   }
 
-  const TimePoint vi_deadline = time - std::min(m_max_fallback, m_max_variance) / 2;
+  const TimePoint vi_deadline = time - m_max_fallback;
 
   // Skip the VI interrupt if the CPU is lagging by a certain amount.
   // It doesn't matter what amount of lag we skip VI at, as long as it's constant.

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -195,7 +195,6 @@ private:
   bool m_throttle_disable_vi_int = false;
 
   DT m_max_fallback = {};
-  DT m_max_variance = {};
   double m_emulation_speed = 1.0;
 
   void ResetThrottle(s64 cycle);

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -15,6 +15,7 @@
 #include <QSlider>
 #include <QSpacerItem>
 #include <QSpinBox>
+#include <QStackedWidget>
 #include <QVBoxLayout>
 
 #include "AudioCommon/AudioCommon.h"
@@ -137,32 +138,81 @@ void AudioPane::CreateWidgets()
   backend_layout->addRow(dolby_quality_layout);
   backend_layout->addRow(m_dolby_quality_latency_label);
 
-  auto* stretching_box = new QGroupBox(tr("Audio Stretching Settings"));
-  auto* stretching_layout = new QGridLayout;
-  m_stretching_enable = new QCheckBox(tr("Enable Audio Stretching"));
+  // Set up for new Audio Options Box with ComboBox and StackedWidget
+  m_audio_group = new QGroupBox(tr("Audio Options"));
+  auto* audio_options_layout = new QGridLayout(m_audio_group);
+
+  // Resampling Options
+  m_audio_resampling_box = new QComboBox;
+  m_audio_resampling_box->addItem(tr("Default (12 Samples)"));
+  m_audio_resampling_box->addItem(tr("High (32 Samples)"));
+  m_audio_resampling_box->addItem(tr("Very High (96 Samples)"));
+  m_audio_resampling_box->addItem(tr("Placebo (256 Samples)"));
+  m_audio_resampling_box->setToolTip(tr(
+      "Dolphin must resample audio from ~32000hz to the modern sample rates like 48000hz.<br><br>"
+      "Higher quality options will only result in lower distortion <i>at high frequencies "
+      "(~16000hz)</i>, at the cost of increased CPU usage. <b>The vast majority of people will be "
+      "unable to notice</b>. <br><br>"
+      "<b>WARNING: If your CPU is not fast enough audio will cutout.</b>"));
+  audio_options_layout->addWidget(new QLabel(tr("Resampling Quality:")), 0, 0);
+  audio_options_layout->addWidget(m_audio_resampling_box, 0, 1);
+
+  // Audio Playback Mode
+  m_audio_playback_mode_box = new QComboBox;
+  m_audio_playback_mode_box->addItem(tr("Direct Playback"));
+  m_audio_playback_mode_box->addItem(tr("Audio Stretching"));
+  m_audio_playback_mode_box->setToolTip(
+      tr("<b>Direct Playback:</b> Audio is played unaltered at a fixed latency.<br><br>"
+         "<b>Audio Stretching:</b> Audio is stretched without changing pitch to match emulation "
+         "speed."));
+  audio_options_layout->addWidget(new QLabel(tr("Playback Mode:")), 1, 0);
+  audio_options_layout->addWidget(m_audio_playback_mode_box, 1, 1);
+
+  // Audio Playback Mode Stack
+  m_audio_playback_mode_stack = new QStackedWidget;
+  audio_options_layout->addWidget(m_audio_playback_mode_stack, 2, 0, 1, 2);
+
+  // Direct Playback Settings
+  m_direct_playback_box = new QGroupBox(tr("Direct Playback Settings"));
+  auto* direct_playback_layout = new QHBoxLayout(m_direct_playback_box);
+  m_direct_playback_latency = new QSlider(Qt::Horizontal);
+  m_direct_playback_indicator = new QLabel();
+  m_direct_playback_latency->setRange(8, 64);
+  m_direct_playback_latency->setSingleStep(4);
+  m_direct_playback_latency->setTickInterval(4);
+  m_direct_playback_latency->setTickPosition(QSlider::TicksBelow);
+  direct_playback_layout->addWidget(new QLabel(tr("Buffer:")));
+  direct_playback_layout->addWidget(m_direct_playback_latency);
+  direct_playback_layout->addWidget(m_direct_playback_indicator);
+  m_audio_playback_mode_stack->addWidget(m_direct_playback_box);
+  m_direct_playback_latency->setToolTip(
+      tr("Sets the buffer size in milliseconds for direct playback.<br><br>"
+         "Higher values may hide small lag spikes at the expense of increased latency."));
+
+  // Audio Stretching Settings
+  m_stretching_box = new QGroupBox(tr("Audio Stretching Settings"));
+  auto* stretching_layout = new QHBoxLayout(m_stretching_box);
   m_stretching_buffer_slider = new QSlider(Qt::Horizontal);
   m_stretching_buffer_indicator = new QLabel();
-  m_stretching_buffer_label = new QLabel(tr("Buffer Size:"));
-  stretching_box->setLayout(stretching_layout);
+  m_stretching_buffer_slider->setRange(48, 256);
+  m_stretching_buffer_slider->setSingleStep(8);
+  m_stretching_buffer_slider->setTickInterval(16);
+  m_stretching_buffer_slider->setTickPosition(QSlider::TicksBelow);
+  stretching_layout->addWidget(new QLabel(tr("Buffer:")));
+  stretching_layout->addWidget(m_stretching_buffer_slider);
+  stretching_layout->addWidget(m_stretching_buffer_indicator);
+  m_audio_playback_mode_stack->addWidget(m_stretching_box);
 
-  m_stretching_buffer_slider->setMinimum(5);
-  m_stretching_buffer_slider->setMaximum(300);
-
-  m_stretching_enable->setToolTip(tr("Enables stretching of the audio to match emulation speed."));
-  m_stretching_buffer_slider->setToolTip(tr("Size of stretch buffer in milliseconds. "
-                                            "Values too low may cause audio crackling."));
-
-  stretching_layout->addWidget(m_stretching_enable, 0, 0, 1, -1);
-  stretching_layout->addWidget(m_stretching_buffer_label, 1, 0);
-  stretching_layout->addWidget(m_stretching_buffer_slider, 1, 1);
-  stretching_layout->addWidget(m_stretching_buffer_indicator, 1, 2);
+  m_stretching_buffer_slider->setToolTip(
+      tr("Sets the buffer size in milliseconds for audio stretching.<br><br>"
+         "Higher values may reduce audio crackling at the expense of increased latency."));
 
   dsp_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
   auto* const main_vbox_layout = new QVBoxLayout;
   main_vbox_layout->addWidget(dsp_box);
   main_vbox_layout->addWidget(backend_box);
-  main_vbox_layout->addWidget(stretching_box);
+  main_vbox_layout->addWidget(m_audio_group);
 
   m_main_layout = new QHBoxLayout;
   m_main_layout->addLayout(main_vbox_layout);
@@ -180,13 +230,18 @@ void AudioPane::ConnectWidgets()
   {
     connect(m_latency_spin, &QSpinBox::valueChanged, this, &AudioPane::SaveSettings);
   }
-  connect(m_stretching_buffer_slider, &QSlider::valueChanged, this, &AudioPane::SaveSettings);
+
   connect(m_dolby_pro_logic, &QCheckBox::toggled, this, &AudioPane::SaveSettings);
   connect(m_dolby_quality_slider, &QSlider::valueChanged, this, &AudioPane::SaveSettings);
-  connect(m_stretching_enable, &QCheckBox::toggled, this, &AudioPane::SaveSettings);
   connect(m_dsp_hle, &QRadioButton::toggled, this, &AudioPane::SaveSettings);
   connect(m_dsp_lle, &QRadioButton::toggled, this, &AudioPane::SaveSettings);
   connect(m_dsp_interpreter, &QRadioButton::toggled, this, &AudioPane::SaveSettings);
+
+  connect(m_audio_resampling_box, &QComboBox::currentIndexChanged, this, &AudioPane::SaveSettings);
+  connect(m_audio_playback_mode_box, &QComboBox::currentIndexChanged, this,
+          &AudioPane::SaveSettings);
+  connect(m_direct_playback_latency, &QSlider::valueChanged, this, &AudioPane::SaveSettings);
+  connect(m_stretching_buffer_slider, &QSlider::valueChanged, this, &AudioPane::SaveSettings);
 
 #ifdef _WIN32
   connect(m_wasapi_device_combo, &QComboBox::currentIndexChanged, this, &AudioPane::SaveSettings);
@@ -242,13 +297,36 @@ void AudioPane::LoadSettings()
   if (m_latency_control_supported)
     m_latency_spin->setValue(Config::Get(Config::MAIN_AUDIO_LATENCY));
 
-  // Stretch
-  m_stretching_enable->setChecked(Config::Get(Config::MAIN_AUDIO_STRETCH));
-  m_stretching_buffer_label->setEnabled(m_stretching_enable->isChecked());
+  // Resampling
+  switch (Config::Get(Config::MAIN_AUDIO_SINC_WINDOW_WIDTH))
+  {
+  default:
+  case 6:
+    m_audio_resampling_box->setCurrentIndex(0);
+    break;
+  case 16:
+    m_audio_resampling_box->setCurrentIndex(1);
+    break;
+  case 48:
+    m_audio_resampling_box->setCurrentIndex(2);
+    break;
+  case 128:
+    m_audio_resampling_box->setCurrentIndex(3);
+    break;
+  }
+
+  // Playback Mode
+  int playback_mode = Config::Get(Config::MAIN_AUDIO_STRETCH) ? 1 : 0;
+  m_audio_playback_mode_box->setCurrentIndex(playback_mode);
+  m_audio_playback_mode_stack->setCurrentIndex(playback_mode);
+
+  m_direct_playback_latency->setValue(Config::Get(Config::MAIN_AUDIO_DIRECT_LATENCY));
+  m_direct_playback_indicator->setText(
+      tr("%1 ms").arg(Config::Get(Config::MAIN_AUDIO_DIRECT_LATENCY)));
+
   m_stretching_buffer_slider->setValue(Config::Get(Config::MAIN_AUDIO_STRETCH_LATENCY));
-  m_stretching_buffer_slider->setEnabled(m_stretching_enable->isChecked());
-  m_stretching_buffer_indicator->setEnabled(m_stretching_enable->isChecked());
-  m_stretching_buffer_indicator->setText(tr("%1 ms").arg(m_stretching_buffer_slider->value()));
+  m_stretching_buffer_indicator->setText(
+      tr("%1 ms").arg(Config::Get(Config::MAIN_AUDIO_STRETCH_LATENCY)));
 
 #ifdef _WIN32
   if (Config::Get(Config::MAIN_WASAPI_DEVICE) == "default")
@@ -310,12 +388,34 @@ void AudioPane::SaveSettings()
   if (m_latency_control_supported)
     Config::SetBaseOrCurrent(Config::MAIN_AUDIO_LATENCY, m_latency_spin->value());
 
+  // Resampling
+  switch (m_audio_resampling_box->currentIndex())
+  {
+  default:
+  case 0:
+    Config::SetBaseOrCurrent(Config::MAIN_AUDIO_SINC_WINDOW_WIDTH, 6);
+    break;
+  case 1:
+    Config::SetBaseOrCurrent(Config::MAIN_AUDIO_SINC_WINDOW_WIDTH, 16);
+    break;
+  case 2:
+    Config::SetBaseOrCurrent(Config::MAIN_AUDIO_SINC_WINDOW_WIDTH, 48);
+    break;
+  case 3:
+    Config::SetBaseOrCurrent(Config::MAIN_AUDIO_SINC_WINDOW_WIDTH, 128);
+    break;
+  }
+
   // Stretch
-  Config::SetBaseOrCurrent(Config::MAIN_AUDIO_STRETCH, m_stretching_enable->isChecked());
+  int playback_mode = m_audio_playback_mode_box->currentIndex();
+  Config::SetBaseOrCurrent(Config::MAIN_AUDIO_STRETCH, playback_mode == 1);
+  m_audio_playback_mode_stack->setCurrentIndex(playback_mode);
+
+  Config::SetBaseOrCurrent(Config::MAIN_AUDIO_DIRECT_LATENCY, m_direct_playback_latency->value());
+  m_direct_playback_indicator->setText(
+      tr("%1 ms").arg(Config::Get(Config::MAIN_AUDIO_DIRECT_LATENCY)));
+
   Config::SetBaseOrCurrent(Config::MAIN_AUDIO_STRETCH_LATENCY, m_stretching_buffer_slider->value());
-  m_stretching_buffer_label->setEnabled(m_stretching_enable->isChecked());
-  m_stretching_buffer_slider->setEnabled(m_stretching_enable->isChecked());
-  m_stretching_buffer_indicator->setEnabled(m_stretching_enable->isChecked());
   m_stretching_buffer_indicator->setText(
       tr("%1 ms").arg(Config::Get(Config::MAIN_AUDIO_STRETCH_LATENCY)));
 

--- a/Source/Core/DolphinQt/Settings/AudioPane.h
+++ b/Source/Core/DolphinQt/Settings/AudioPane.h
@@ -12,11 +12,13 @@ enum class DPL2Quality;
 
 class QCheckBox;
 class QComboBox;
+class QGroupBox;
 class QHBoxLayout;
 class QLabel;
 class QRadioButton;
 class QSlider;
 class QSpinBox;
+class QStackedWidget;
 class SettingsWindow;
 
 class AudioPane final : public QWidget
@@ -71,9 +73,17 @@ private:
   QComboBox* m_wasapi_device_combo;
 #endif
 
-  // Audio Stretching
-  QCheckBox* m_stretching_enable;
-  QLabel* m_stretching_buffer_label;
+  // Audio Options
+  QGroupBox* m_audio_group;
+  QComboBox* m_audio_resampling_box;
+  QComboBox* m_audio_playback_mode_box;
+  QStackedWidget* m_audio_playback_mode_stack;
+
+  QGroupBox* m_direct_playback_box;
+  QSlider* m_direct_playback_latency;
+  QLabel* m_direct_playback_indicator;
+
+  QGroupBox* m_stretching_box;
   QSlider* m_stretching_buffer_slider;
   QLabel* m_stretching_buffer_indicator;
 };

--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -30,6 +30,7 @@ public:
   void CountFrame();
   void CountVBlank();
 
+  void CountAudioLatency(DT latency);
   void CountThrottleSleep(DT sleep);
   void CountPerformanceMarker(Core::System& system, s64 cyclesLate);
 
@@ -37,6 +38,7 @@ public:
   double GetFPS() const;
   double GetVPS() const;
   double GetSpeed() const;
+  double GetAudioSpeed() const;
   double GetMaxSpeed() const;
 
   double GetLastSpeedDenominator() const;
@@ -47,15 +49,17 @@ public:
 private:
   PerformanceTracker m_fps_counter{"render_times.txt"};
   PerformanceTracker m_vps_counter{"vblank_times.txt"};
-  PerformanceTracker m_speed_counter{std::nullopt, 1000000};
+
+  PerformanceTracker m_audio_latency_counter{};
+  PerformanceTracker m_audio_speed_counter{std::nullopt, 128000};
+
+  PerformanceTracker m_speed_counter{std::nullopt, 1280000};
+  PerformanceTracker m_max_speed_counter{std::nullopt, 1280000};
 
   double m_graph_max_time = 0.0;
 
   mutable std::shared_mutex m_time_lock;
-
-  u8 m_time_index = 0;
-  std::array<TimePoint, 256> m_real_times{};
-  std::array<TimePoint, 256> m_cpu_times{};
+  TimePoint m_prev_adjusted_time{};
   DT m_time_sleeping{};
 };
 

--- a/Source/Core/VideoCommon/PerformanceTracker.cpp
+++ b/Source/Core/VideoCommon/PerformanceTracker.cpp
@@ -47,7 +47,7 @@ void PerformanceTracker::Reset()
   m_dt_std = std::nullopt;
 }
 
-void PerformanceTracker::Count()
+void PerformanceTracker::Count(std::optional<DT> custom_value, bool value_is_duration)
 {
   std::unique_lock lock{m_mutex};
 
@@ -57,26 +57,31 @@ void PerformanceTracker::Count()
   const DT window{GetSampleWindow()};
 
   const TimePoint time{Clock::now()};
-  const DT diff{time - m_last_time};
-
+  const DT duration{time - m_last_time};
+  const DT value{custom_value.value_or(duration)};
+  const TimeDataPair data_point{value_is_duration ? value : duration, value};
   m_last_time = time;
 
-  QueuePush(diff);
-  m_dt_total += diff;
+  QueuePush(data_point);
+  m_dt_total += data_point;
 
   if (m_dt_queue_begin == m_dt_queue_end)
     m_dt_total -= QueuePop();
 
-  while (window <= m_dt_total - QueueTop())
+  while (window <= m_dt_total.duration - QueueTop().duration)
     m_dt_total -= QueuePop();
 
   // Simple Moving Average Throughout the Window
-  m_dt_avg = m_dt_total / QueueSize();
-  const double hz = DT_s(1.0) / m_dt_avg;
+  // We want the average value, so we use the value
+  m_dt_avg = m_dt_total.value / QueueSize();
+
+  // Even though the frequency does not make sense if the value
+  // is not the duration, it is still useful to have the value
+  const double hz = DT_s(QueueSize()) / m_dt_total.value;
 
   // Exponential Moving Average
-  const DT_s rc = SAMPLE_RC_RATIO * std::min(window, m_dt_total);
-  const double a = 1.0 - std::exp(-(DT_s(diff) / rc));
+  const DT_s rc = SAMPLE_RC_RATIO * window;
+  const double a = 1.0 - std::exp(-(DT_s(data_point.duration) / rc));
 
   // Sometimes euler averages can break when the average is inf/nan
   if (std::isfinite(m_hz_avg))
@@ -86,7 +91,7 @@ void PerformanceTracker::Count()
 
   m_dt_std = std::nullopt;
 
-  LogRenderTimeToFile(diff);
+  LogRenderTimeToFile(data_point.value);
 }
 
 DT PerformanceTracker::GetSampleWindow() const
@@ -121,7 +126,7 @@ DT PerformanceTracker::GetDtStd() const
   double total = 0.0;
   for (std::size_t i = m_dt_queue_begin; i != m_dt_queue_end; i = IncrementIndex(i))
   {
-    double diff = DT_s(m_dt_queue[i] - m_dt_avg).count();
+    double diff = DT_s(m_dt_queue[i].value - m_dt_avg).count();
     total += diff * diff;
   }
 
@@ -136,7 +141,7 @@ DT PerformanceTracker::GetLastRawDt() const
   if (QueueEmpty())
     return DT::zero();
 
-  return QueueBottom();
+  return QueueBottom().value;
 }
 
 void PerformanceTracker::ImPlotPlotLines(const char* label) const
@@ -152,35 +157,32 @@ void PerformanceTracker::ImPlotPlotLines(const char* label) const
   const bool quality = QueueSize() < MAX_QUALITY_GRAPH_SIZE;
 
   const DT update_time = Clock::now() - m_last_time;
-  const float predicted_frame_time = DT_ms(std::max(update_time, QueueBottom())).count();
 
   std::size_t points = 0;
-  if (quality)
-  {
-    x[points] = 0.f;
-    y[points] = predicted_frame_time;
-    ++points;
-  }
+  x[points] = 0.f;
+  y[points] = DT_ms(QueueBottom().value).count();
+  ++points;
 
   x[points] = DT_ms(update_time).count();
-  y[points] = predicted_frame_time;
+  y[points] = y[points - 1];
   ++points;
 
   const std::size_t begin = DecrementIndex(m_dt_queue_end);
   const std::size_t end = DecrementIndex(m_dt_queue_begin);
   for (std::size_t i = begin; i != end; i = DecrementIndex(i))
   {
-    const float frame_time_ms = DT_ms(m_dt_queue[i]).count();
+    const float frame_duration_ms = DT_ms(m_dt_queue[i].duration).count();
+    const float frame_value_ms = DT_ms(m_dt_queue[i].value).count();
 
     if (quality)
     {
       x[points] = x[points - 1];
-      y[points] = frame_time_ms;
+      y[points] = frame_value_ms;
       ++points;
     }
 
-    x[points] = x[points - 1] + frame_time_ms;
-    y[points] = frame_time_ms;
+    x[points] = x[points - 1] + frame_duration_ms;
+    y[points] = frame_value_ms;
     ++points;
   }
 
@@ -194,25 +196,25 @@ void PerformanceTracker::QueueClear()
   m_dt_queue_end = 0;
 }
 
-void PerformanceTracker::QueuePush(DT dt)
+void PerformanceTracker::QueuePush(TimeDataPair dt)
 {
   m_dt_queue[m_dt_queue_end] = dt;
   m_dt_queue_end = IncrementIndex(m_dt_queue_end);
 }
 
-const DT& PerformanceTracker::QueuePop()
+const PerformanceTracker::TimeDataPair& PerformanceTracker::QueuePop()
 {
   const std::size_t top = m_dt_queue_begin;
   m_dt_queue_begin = IncrementIndex(m_dt_queue_begin);
   return m_dt_queue[top];
 }
 
-const DT& PerformanceTracker::QueueTop() const
+const PerformanceTracker::TimeDataPair& PerformanceTracker::QueueTop() const
 {
   return m_dt_queue[m_dt_queue_begin];
 }
 
-const DT& PerformanceTracker::QueueBottom() const
+const PerformanceTracker::TimeDataPair& PerformanceTracker::QueueBottom() const
 {
   return m_dt_queue[DecrementIndex(m_dt_queue_end)];
 }

--- a/Source/Core/VideoCommon/PerformanceTracker.h
+++ b/Source/Core/VideoCommon/PerformanceTracker.h
@@ -15,7 +15,7 @@ class PerformanceTracker
 {
 private:
   // Must be powers of 2 for masking to work
-  static constexpr u64 MAX_DT_QUEUE_SIZE = 1UL << 12;
+  static constexpr u64 MAX_DT_QUEUE_SIZE = 1UL << 13;
   static constexpr u64 MAX_QUALITY_GRAPH_SIZE = 1UL << 8;
 
   static inline std::size_t IncrementIndex(const std::size_t index)
@@ -33,6 +33,31 @@ private:
     return (end - begin) & (MAX_DT_QUEUE_SIZE - 1);
   }
 
+  struct TimeDataPair
+  {
+  public:
+    TimeDataPair(DT duration_dt, DT value_dt) : duration{duration_dt}, value{value_dt} {}
+    TimeDataPair(DT duration_dt) : TimeDataPair{duration_dt, duration_dt} {}
+    TimeDataPair() : TimeDataPair{DT::zero()} {}
+
+    TimeDataPair& operator+=(const TimeDataPair& other)
+    {
+      duration += other.duration;
+      value += other.value;
+      return *this;
+    }
+
+    TimeDataPair& operator-=(const TimeDataPair& other)
+    {
+      duration -= other.duration;
+      value -= other.value;
+      return *this;
+    }
+
+  public:
+    DT duration, value;
+  };
+
 public:
   PerformanceTracker(const std::optional<std::string> log_name = std::nullopt,
                      const std::optional<s64> sample_window_us = std::nullopt);
@@ -45,7 +70,20 @@ public:
 
   // Functions for recording performance information
   void Reset();
-  void Count();
+
+  /**
+   * custom_value can be used if you are recording something with it's own DT. For example,
+   * if you are recording the fallback of the throttler or the latency of the frame.
+   *
+   * If a custom_value is not supplied, the value will be set to the time between calls aka,
+   * duration. This is the most common use case of this class, as an FPS counter.
+   *
+   * The boolean value_is_duration should be set to true if the custom DTs you are providing
+   * represent a continuous duration. For example, the present times from a render backend
+   * would set value_is_duration to true. Things like throttler fallback or frame latency
+   * are not continuous, so they should not represent duration.
+   */
+  void Count(std::optional<DT> custom_value = std::nullopt, bool value_is_duration = false);
 
   // Functions for reading performance information
   DT GetSampleWindow() const;
@@ -61,13 +99,13 @@ public:
 
 private:  // Functions for managing dt queue
   inline void QueueClear();
-  inline void QueuePush(DT dt);
-  inline const DT& QueuePop();
-  inline const DT& QueueTop() const;
-  inline const DT& QueueBottom() const;
+  inline void QueuePush(TimeDataPair dt);
+  inline const TimeDataPair& QueuePop();
+  inline const TimeDataPair& QueueTop() const;
+  inline const TimeDataPair& QueueBottom() const;
 
-  std::size_t inline QueueSize() const;
-  bool inline QueueEmpty() const;
+  inline std::size_t QueueSize() const;
+  inline bool QueueEmpty() const;
 
   // Handle pausing and logging
   void LogRenderTimeToFile(DT val);
@@ -87,8 +125,8 @@ private:  // Functions for managing dt queue
   const std::optional<s64> m_sample_window_us;
 
   // Queue + Running Total used to calculate average dt
-  DT m_dt_total = DT::zero();
-  std::array<DT, MAX_DT_QUEUE_SIZE> m_dt_queue;
+  TimeDataPair m_dt_total;
+  std::array<TimeDataPair, MAX_DT_QUEUE_SIZE> m_dt_queue;
   std::size_t m_dt_queue_begin = 0;
   std::size_t m_dt_queue_end = 0;
 


### PR DESCRIPTION
### This PR now includes the changes from #12775 for the graphs

### This can help stuff like [this](https://www.instagram.com/reel/C5RSgwXJYNl/?utm_source=ig_web_copy_link) from happening in the future :)

**Changes:**

- [x] Allow Performance Trackers to Custom Time data (time without sleeps + audio latency)
- [x] Improve Max Speed counter (result of previous change
- [x] Add Audio Latency graph to track how many buffers are unplayed by dolphin
- [x] Replace linear interpolation with Sinc filter (removes high frequency distortion)
- [x] Greatly improve algorithm for keeping audio in sync with video (more consistent + less distortion)
- [x] Port previous algorithm to Audio Stretcher so that it is much more consistent
- [x] Play audio backwards when no samples remain in order to prevent crackling
- [x] Audio UI Overhaul allowing users to change resampling quality and buffer length

For some reason, Dolphin was using Linear interpolation for converting audio from 32000hz to 48000hz, this leads to extreme aliasing. The way you can tell there is aliasing is by looking at the high frequencies. In a good resampler, there should be no frequencies above the nyquist frequency (16000hz). Look at the spectrograms provided below, they show a clear improvement with the new resampler. 

<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/f3f4deb9-3c22-4768-b96c-c900ed5f035c">
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/89605e22-e7f2-4c88-a45e-d54908ce2d76">
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/a980ab53-5222-4926-bde3-6831d90d9e46">
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/c90b722d-7140-4036-9a34-fad7a06f8098">
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/55a65061-60fa-4908-8c4c-d37f353414a2">
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/1f626bbb-1fc4-4fc8-8593-b866a13aa56c">

Photo with Direct Playback @ 20ms:
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/46d534fa-1e8d-42a2-8538-9c6166774459">

Photo with Audio Stretching @ 80ms:
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/93607131-cb62-48af-818a-53726233150d">

Photo of Spectrogram @ Default Quality:
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/0106d2c6-a3b9-4e5e-bbd2-3d86f20689d6">

Photo of Spectrogram @ Placebo Quality:
<img width="600" alt="image" src="https://github.com/dolphin-emu/dolphin/assets/28713194/e1027088-8d93-4bd0-81e3-6dc3bf048062">

