### PR TITLE
BreakpointWidget: Add ability to directly edit breakpoints

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -3,9 +3,13 @@
 
 #include "DolphinQt/Debugger/BreakpointWidget.h"
 
+#include <QApplication>
 #include <QHeaderView>
 #include <QMenu>
+#include <QPainter>
 #include <QSignalBlocker>
+#include <QStyleOptionViewItem>
+#include <QStyledItemDelegate>
 #include <QTableWidget>
 #include <QToolBar>
 #include <QVBoxLayout>
@@ -35,6 +39,39 @@ enum CustomRole
   IS_MEMCHECK_ROLE
 };
 }
+
+// Fix icons not centering properly in a QTableWidget.
+class CustomDelegate : public QStyledItemDelegate
+{
+public:
+  CustomDelegate(BreakpointWidget* parent) : QStyledItemDelegate(parent) {}
+
+private:
+  void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+  {
+    Q_ASSERT(index.isValid());
+
+    // Fetch normal drawing logic.
+    QStyleOptionViewItem opt = option;
+    initStyleOption(&opt, index);
+
+    // Disable drawing icon the normal way.
+    opt.icon = QIcon();
+    opt.decorationSize = QSize(0, 0);
+
+    // Default draw command for paint.
+    QApplication::style()->drawControl(QStyle::CE_ItemViewItem, &opt, painter, 0);
+
+    // Draw pixmap at the center of the tablewidget cell
+    QPixmap pix = qvariant_cast<QPixmap>(index.data(Qt::DecorationRole));
+    if (!pix.isNull())
+    {
+      const QRect r = option.rect;
+      const QPoint p = QPoint((r.width() - pix.width()) / 2, (r.height() - pix.height()) / 2);
+      painter->drawPixmap(r.topLeft() + p, pix);
+    }
+  }
+};
 
 BreakpointWidget::BreakpointWidget(QWidget* parent)
     : QDockWidget(parent), m_system(Core::System::GetInstance())
@@ -88,6 +125,7 @@ void BreakpointWidget::CreateWidgets()
   m_toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
   m_table = new QTableWidget;
+  m_table->setItemDelegate(new CustomDelegate(this));
   m_table->setTabKeyNavigation(false);
   m_table->setContentsMargins(0, 0, 0, 0);
   m_table->setColumnCount(6);

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -45,7 +45,6 @@ protected:
 private:
   void CreateWidgets();
 
-  void OnDelete();
   void OnClear();
   void OnNewBreakpoint();
   void OnEditBreakpoint(u32 address, bool is_instruction_bp);
@@ -60,7 +59,6 @@ private:
   QToolBar* m_toolbar;
   QTableWidget* m_table;
   QAction* m_new;
-  QAction* m_delete;
   QAction* m_clear;
   QAction* m_load;
   QAction* m_save;

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -3,15 +3,22 @@
 
 #pragma once
 
+#include <optional>
+
 #include <QDockWidget>
+#include <QString>
 
 #include "Common/CommonTypes.h"
 
 class QAction;
 class QCloseEvent;
+class QPoint;
 class QShowEvent;
 class QTableWidget;
+class QTableWidgetItem;
 class QToolBar;
+class QWidget;
+
 namespace Core
 {
 class System;
@@ -47,12 +54,16 @@ protected:
 private:
   void CreateWidgets();
 
+  void EditBreakpoint(u32 address, int edit, std::optional<QString> = std::nullopt);
+  void EditMBP(u32 address, int edit, std::optional<QString> = std::nullopt);
+
   void OnClear();
+  void OnClicked(QTableWidgetItem* item);
   void OnNewBreakpoint();
   void OnEditBreakpoint(u32 address, bool is_instruction_bp);
   void OnLoad();
   void OnSave();
-  void OnContextMenu();
+  void OnContextMenu(const QPoint& pos);
 
   void UpdateIcons();
 

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -64,7 +64,7 @@ private:
   void OnLoad();
   void OnSave();
   void OnContextMenu(const QPoint& pos);
-
+  void OnItemChanged(QTableWidgetItem* item);
   void UpdateIcons();
 
   Core::System& m_system;

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -17,6 +17,8 @@ namespace Core
 class System;
 }
 
+class CustomDelegate;
+
 class BreakpointWidget : public QDockWidget
 {
   Q_OBJECT


### PR DESCRIPTION
![BP_EDITOR](https://github.com/dolphin-emu/dolphin/assets/10532806/5ec021fa-9590-4c60-af24-b7233326af3a)

Add theme-aware buttons, ability to edit addresses, and a popup for conditional editing.

If a base address is changed, it will delete the breakpoint and then create a new breakpoint at the new address. Useful for moving a conditional to another address.

Removed selecting rows, which breaks the old delete button. Delete moved to context menu.

This new style can result in new odd states for breakpoints. Such as a Memory Breakpoint that is enabled, but has Read + Write disabled, resulting in nothing being done.  Previously Read and/or Write would always be true. Not sure it matters.

If the buttons are no good, they can be replaced with 3-state combo boxes. Break/Log/B+L.