### PR TITLE
IOS/USB: Change Skylander File Type Filter

### DIFF
--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
@@ -554,7 +554,7 @@ void SkylanderPortalWindow::LoadFromFile()
   const u8 slot = GetCurrentSlot();
   const QString file_path =
       DolphinFileDialog::getOpenFileName(this, tr("Select Skylander File"), m_last_skylander_path,
-                                         tr("Skylander (*.sky);;All Files (*)"));
+                                         tr("Skylander (*.sky *.bin *.dmp *.dump);;All Files (*)"));
   ;
   if (file_path.isEmpty())
   {
@@ -708,7 +708,9 @@ void SkylanderPortalWindow::RefreshList()
   {
     const QDir collection = QDir(m_collection_path);
     auto& system = Core::System::GetInstance();
-    for (const auto& file : collection.entryInfoList(QStringList(QStringLiteral("*.sky"))))
+    for (const auto& file : collection.entryInfoList(
+             QStringList() << QStringLiteral("*.sky") << QStringLiteral("*.bin")
+                           << QStringLiteral("*.dmp") << QStringLiteral("*.dump")))
     {
       File::IOFile sky_file(file.filePath().toStdString(), "r+b");
       if (!sky_file)
@@ -910,7 +912,9 @@ QString SkylanderPortalWindow::GetFilePath(u16 id, u16 var) const
 {
   const QDir collection = QDir(m_collection_path);
   auto& system = Core::System::GetInstance();
-  for (const auto& file : collection.entryInfoList(QStringList(QStringLiteral("*.sky"))))
+  for (const auto& file : collection.entryInfoList(
+           QStringList() << QStringLiteral("*.sky") << QStringLiteral("*.bin")
+                         << QStringLiteral("*.dmp") << QStringLiteral("*.dump")))
   {
     File::IOFile sky_file(file.filePath().toStdString(), "r+b");
     if (!sky_file)


### PR DESCRIPTION
Skylanders created via the Dolphin UI are created with the .sky extension by default, but Skylanders are often backed up with a different file extension depending on the method used, so I have added these types to the QT File filters so that they can be selected by default.