### PR TITLE
DSPHLE/Zelda: fix Pikmin 2 save sound (issue 8855)

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -1407,12 +1407,13 @@ void ZeldaAudioRenderer::LoadInputSamples(MixingBuffer* buffer, VPB* vpb)
     else
       shift = 2;
     u32 mask = (1 << shift) - 1;
+    u32 ratio = vpb->resampling_ratio << (shift - 1);
 
     u32 pos = vpb->current_pos_frac << shift;
     for (s16& sample : *buffer)
     {
       sample = ((pos >> 16) & mask) ? 0xC000 : 0x4000;
-      pos += vpb->resampling_ratio;
+      pos += ratio;
     }
     vpb->current_pos_frac = (pos >> shift) & 0xFFFF;
     break;


### PR DESCRIPTION
This fixes the sound effect in Pikmin 2 that plays when saving has completed.

Tracked as [issue 8855](https://bugs.dolphin-emu.org/issues/8855), originally reported over 9 years ago in [issue 8051](https://bugs.dolphin-emu.org/issues/8051) by @pauldacheez.

Before:
https://github.com/dolphin-emu/dolphin/assets/123798/6ab638b3-fb40-4e01-ab37-6e934964e36f

After:
https://github.com/dolphin-emu/dolphin/assets/123798/5cabe58f-1923-4322-89d8-675a4658a575