### PR TITLE
Frame Advance:  Fix UI update spam when continuously advancing.

### DIFF
--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -250,6 +250,9 @@ void Host_YieldToUI()
 
 void Host_UpdateDisasmDialog()
 {
+  if (Settings::Instance().GetIsContinuouslyFrameStepping())
+    return;
+
   QueueOnObject(QApplication::instance(), [] { emit Host::GetInstance()->UpdateDisasmDialog(); });
 }
 

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -113,6 +113,8 @@ static void HandleFrameStepHotkeys()
 
     if ((frame_step_count == 0 || frame_step_count == FRAME_STEP_DELAY) && !frame_step_hold)
     {
+      if (frame_step_count > 0)
+        Settings::Instance().SetIsContinuouslyFrameStepping(true);
       Core::QueueHostJob([](auto& system) { Core::DoFrameStep(system); });
       frame_step_hold = true;
     }
@@ -138,6 +140,8 @@ static void HandleFrameStepHotkeys()
     frame_step_count = 0;
     frame_step_hold = false;
     frame_step_delay_count = 0;
+    Settings::Instance().SetIsContinuouslyFrameStepping(false);
+    emit Settings::Instance().EmulationStateChanged(Core::GetState(Core::System::GetInstance()));
   }
 }
 

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -59,7 +59,12 @@ Settings::Settings()
 {
   qRegisterMetaType<Core::State>();
   Core::AddOnStateChangedCallback([this](Core::State new_state) {
-    QueueOnObject(this, [this, new_state] { emit EmulationStateChanged(new_state); });
+    QueueOnObject(this, [this, new_state] {
+      // Avoid signal spam while continuously frame stepping. Will still send a signal for the first
+      // and last framestep.
+      if (!m_continuously_frame_stepping)
+        emit EmulationStateChanged(new_state);
+    });
   });
 
   Config::AddConfigChangedCallback([this] {
@@ -826,4 +831,14 @@ void Settings::SetUSBKeyboardConnected(bool connected)
     Config::SetBaseOrCurrent(Config::MAIN_WII_KEYBOARD, connected);
     emit USBKeyboardConnectionChanged(connected);
   }
+}
+
+void Settings::SetIsContinuouslyFrameStepping(bool is_stepping)
+{
+  m_continuously_frame_stepping = is_stepping;
+}
+
+bool Settings::GetIsContinuouslyFrameStepping() const
+{
+  return m_continuously_frame_stepping;
 }

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -120,6 +120,9 @@ public:
   bool IsUSBKeyboardConnected() const;
   void SetUSBKeyboardConnected(bool connected);
 
+  void SetIsContinuouslyFrameStepping(bool is_stepping);
+  bool GetIsContinuouslyFrameStepping() const;
+
   // Graphics
   Config::ShowCursor GetCursorVisibility() const;
   bool GetLockCursor() const;
@@ -228,6 +231,8 @@ private:
   Settings();
 
   bool m_batch = false;
+  std::atomic<bool> m_continuously_frame_stepping = false;
+
   std::shared_ptr<NetPlay::NetPlayClient> m_client;
   std::shared_ptr<NetPlay::NetPlayServer> m_server;
   ControllerInterface::HotplugCallbackHandle m_hotplug_callback_handle;


### PR DESCRIPTION
Holding down frame advance was overloading Qt with update calls, causing issues 

Not sure if this is the best method.   If there are other times blocking updates would be useful, the names could be made to be more general.

New behavior:  Updates calls on first frame advance (for quick 1-frame advances). Blocks all other calls until finished, then reports a new OnStateChanged  (paused usually) call. 

It could also just do an UpdateDisasmDialog, but things are getting messy with that signal and widgets are more reliable with using OnStateChanged. 