### PR TITLE
Jit64: Remove outdated comment about R12

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/RegCache/GPRRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/GPRRegCache.cpp
@@ -33,8 +33,6 @@ OpArg GPRRegCache::GetDefaultLocation(preg_t preg) const
 std::span<const X64Reg> GPRRegCache::GetAllocationOrder() const
 {
   static constexpr X64Reg allocation_order[] = {
-// R12, when used as base register, for example in a LEA, can generate bad code! Need to look into
-// this.
 #ifdef _WIN32
       RSI, RDI, R13, R14, R15, R8,
       R9,  R10, R11, R12, RCX


### PR DESCRIPTION
This comment was added 15 years ago in 1c1425a406. The bug the comment refers to was fixed one day later in 41ce35deb3.