### PR TITLE
DolphinQt/Settings/GeneralPane: Don't emit a ConfigChanged signal while saving config

### DIFF
--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -351,9 +351,6 @@ void GeneralPane::OnSaveConfig()
 
 #ifdef USE_DISCORD_PRESENCE
   Discord::SetDiscordPresenceEnabled(m_checkbox_discord_presence->isChecked());
-#ifdef USE_RETRO_ACHIEVEMENTS
-  emit Settings::Instance().ConfigChanged();
-#endif  // USE_RETRO_ACHIEVEMENTS
 #endif
 
 #if defined(USE_ANALYTICS) && USE_ANALYTICS


### PR DESCRIPTION
Doing this causes the settings to be reloaded before they're done saving, effectively discarding the user's changes.

Broken by 2328539a76a338d4c3e591e4a96e5ea49a661bb3