### PR TITLE
VideoCommon: use imgui input queue for mouse clicks

### DIFF
--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -481,7 +481,9 @@ void OnScreenUI::SetMousePress(u32 button_mask)
   auto lock = GetImGuiLock();
 
   for (size_t i = 0; i < std::size(ImGui::GetIO().MouseDown); i++)
-    ImGui::GetIO().MouseDown[i] = (button_mask & (1u << i)) != 0;
+  {
+    ImGui::GetIO().AddMouseButtonEvent(static_cast<int>(i), (button_mask & (1u << i)) != 0);
+  }
 }
 
 }  // namespace VideoCommon


### PR DESCRIPTION
In imgui 1.87 they introduced a new input system.  One of the advantages of this input system was an input queuing system to keep input smooth when frame times were inconsistent.  We switched over to this system for keyboard events when updating imgui as part of an interface breakage but we didn't update our mouse clicks to use this system.

This code updates our mouse handling to use the input event system.