### PR TITLE
DolphinQt: trigger frame advance from hotkeys on the host thread

### DIFF
--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -113,7 +113,7 @@ static void HandleFrameStepHotkeys()
 
     if ((frame_step_count == 0 || frame_step_count == FRAME_STEP_DELAY) && !frame_step_hold)
     {
-      Core::DoFrameStep(Core::System::GetInstance());
+      Core::QueueHostJob([](auto& system) { Core::DoFrameStep(system); });
       frame_step_hold = true;
     }
 


### PR DESCRIPTION
Dolphin manages hot key handling on a separate thread.  One of the features it provides is a way to trigger frame advances.  Advancing a frame uses `SetState` which is only expected to be called from the host thread.  We can resolve this by wrapping the frame step in a `QueueHostJob`