### PR TITLE
CodeViewWidget bugfix: Fix invalid symbol updates

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -268,7 +268,7 @@ void CodeViewWidget::Update()
   if (m_updating)
     return;
 
-  if (Core::GetState(m_system) == Core::State::Paused)
+  if (Core::GetState(m_system) == Core::State::Paused && Core::IsRunningAndStarted())
   {
     Core::CPUThreadGuard guard(m_system);
     Update(&guard);

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -339,7 +339,7 @@ void CodeWidget::UpdateCallstack()
 {
   m_callstack_list->clear();
 
-  if (Core::GetState(m_system) != Core::State::Paused)
+  if (Core::GetState(m_system) != Core::State::Paused || !Core::IsRunningAndStarted())
     return;
 
   std::vector<Dolphin_Debugger::CallstackEntry> stack;


### PR DESCRIPTION
Fixes this issue being hit again: https://github.com/dolphin-emu/dolphin/pull/11593

### Bug
The behavior described in that Pull was resulting in HotkeyScheduler infinitely hanging on:
```
void CPUManager::EnableStepping(bool stepping)
{
  std::lock_guard stepping_lock(m_stepping_lock);
```
while trying to do a FrameAdvance (hotkey) after the invalid thread guard was attempted. Only happens if loading a game while codewidget is active and possibly only if symbols are involved.

#12788 also bypasses the hotkey bug in that particular case.

### Fix
Prevent PPCSymbol signals from triggering Updates during boot. These signals are unnecessary at that time. Thread guard breaks when Core::IsRunningAndStarted == false, so the check just makes sure that is true.

This could be avoided if Core::GetState() returned Core::State::Starting when `s_hardware_initialized && !s_is_started`, but I don't know if that'd break anything, so I didn't attempt it.

/edit I reduced the size and scope of this PR.  Talking to mitaclaw, just focusing on handling the signal in CodeViewWidget would be better.