### PR TITLE
CMake: update required compiler versions for std::bitcast support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,13 @@ if (COMPILER STREQUAL "GNU")
   set(COMPILER "GCC") # perfer printing GCC instead of GNU
 endif()
 
-# Enforce minimium compiler versions that support the c++20 features we use
-set (GCC_min_version 10)
-set (Clang_min_version 12)
-set (AppleClang_min_version 13.0.0)
-set (min_xcode_version "13.0") # corrosponding xcode version for AppleClang_min_version
+# Enforce minimum compiler versions that support the c++20 features we use
+set (GCC_min_version 11)
+set (Clang_min_version 14)
+set (AppleClang_min_version 14.0.3)
+set (min_xcode_version "14.0") # corresponding xcode version for AppleClang_min_version
 set (MSVC_min_version 14.32)
-set (min_vs_version "2022 17.2.3") # corrosponding Visual Studio version for MSVC_min_version
+set (min_vs_version "2022 17.2.3") # corresponding Visual Studio version for MSVC_min_version
 
 message(STATUS "Using ${COMPILER} ${CMAKE_CXX_COMPILER_VERSION}")
 


### PR DESCRIPTION
This is based on https://en.cppreference.com/w/cpp/compiler_support. I'm not actually entirely sure what the needed Xcode version is.