### PR TITLE
MainWindow, Bugfix: Initialize geometries before calling GetWindowSystemInfo

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -227,8 +227,6 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
   setAcceptDrops(true);
   setAttribute(Qt::WA_NativeWindow);
 
-  InitControllers();
-
   CreateComponents();
 
   ConnectGameList();
@@ -237,6 +235,13 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
   ConnectRenderWidget();
   ConnectStack();
   ConnectMenuBar();
+
+  QSettings& settings = Settings::GetQSettings();
+  restoreState(settings.value(QStringLiteral("mainwindow/state")).toByteArray());
+  restoreGeometry(settings.value(QStringLiteral("mainwindow/geometry")).toByteArray());
+  show();
+
+  InitControllers();
   ConnectHotkeys();
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
@@ -288,11 +293,6 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 
   m_state_slot =
       std::clamp(Settings::Instance().GetStateSlot(), 1, static_cast<int>(State::NUM_STATES));
-
-  QSettings& settings = Settings::GetQSettings();
-
-  restoreState(settings.value(QStringLiteral("mainwindow/state")).toByteArray());
-  restoreGeometry(settings.value(QStringLiteral("mainwindow/geometry")).toByteArray());
 
   m_render_widget_geometry = settings.value(QStringLiteral("renderwidget/geometry")).toByteArray();
 


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/11191
https://bugs.dolphin-emu.org/issues/13355

On Windows:
 InitControllers()  -> GetWindowSystemInfo -> wsi.render_window being set will set/save the initial geometry, which will cause sizing bugs until it's set again by the user resizing/repositioning.

Not tested on other platforms.  I don't see any problem with moving InitControllers() down, but someone should double check.

If the normal sized window is very small there will still be some issues with maximized windows restoring geometry, but that's more of a Qt bug. 