### PR TITLE
PPCAnalyst: Remove unused member isBranchTarget

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -272,8 +272,6 @@ bool JitBase::CanMergeNextInstructions(int count) const
     {
       return false;
     }
-    if (js.op[i].isBranchTarget)
-      return false;
   }
   return true;
 }

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -38,7 +38,6 @@ struct CodeOp  // 16B
   s8 fregOut = 0;
   BitSet8 crIn;
   BitSet8 crOut;
-  bool isBranchTarget = false;
   bool branchUsesCtr = false;
   bool branchIsIdleLoop = false;
   BitSet8 wantsCR;


### PR DESCRIPTION
Branch targets always start a new block, so this variable isn't useful.