### PR TITLE
Branch Watch Tool: Fixes

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -207,7 +207,6 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
 {
   setWindowTitle(tr("Branch Watch Tool"));
   setWindowFlags((windowFlags() | Qt::WindowMinMaxButtonsHint) & ~Qt::WindowContextHelpButtonHint);
-  SetQWidgetWindowDecorations(this);
   setLayout([this, &ppc_symbol_db]() {
     auto* main_layout = new QVBoxLayout;
 
@@ -241,6 +240,11 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
       table_view->setEditTriggers(QAbstractItemView::NoEditTriggers);
       table_view->setCornerButtonEnabled(false);
       table_view->verticalHeader()->hide();
+      table_view->setColumnWidth(Column::Instruction, 50);
+      table_view->setColumnWidth(Column::Condition, 50);
+      table_view->setColumnWidth(Column::OriginSymbol, 250);
+      table_view->setColumnWidth(Column::DestinSymbol, 250);
+      // The default column width (100 units) is fine for the rest.
 
       QHeaderView* const horizontal_header = table_view->horizontalHeader();
       horizontal_header->restoreState(  // Restore column visibility state.
@@ -501,16 +505,6 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
 
     return main_layout;
   }());
-
-  // FIXME: On Linux, Qt6 has recently been resetting column widths to their defaults in many
-  // unexpected ways. This affects all kinds of QTables in Dolphin's GUI, so to avoid it in
-  // this QTableView, I have deferred this operation. Any earlier, and this would be undone.
-  // SetQWidgetWindowDecorations was moved to before these operations for the same reason.
-  m_table_view->setColumnWidth(Column::Instruction, 50);
-  m_table_view->setColumnWidth(Column::Condition, 50);
-  m_table_view->setColumnWidth(Column::OriginSymbol, 250);
-  m_table_view->setColumnWidth(Column::DestinSymbol, 250);
-  // The default column width (100 units) is fine for the rest.
 
   const auto& settings = Settings::GetQSettings();
   restoreGeometry(settings.value(QStringLiteral("branchwatchdialog/geometry")).toByteArray());

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -57,6 +57,12 @@ public:
       : QSortFilterProxyModel(parent), m_branch_watch(branch_watch)
   {
   }
+  ~BranchWatchProxyModel() override = default;
+
+  BranchWatchProxyModel(const BranchWatchProxyModel&) = delete;
+  BranchWatchProxyModel(BranchWatchProxyModel&&) = delete;
+  BranchWatchProxyModel& operator=(const BranchWatchProxyModel&) = delete;
+  BranchWatchProxyModel& operator=(BranchWatchProxyModel&&) = delete;
 
   BranchWatchTableModel* sourceModel() const
   {

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -216,6 +216,7 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
       m_table_proxy->setSourceModel(
           m_table_model = new BranchWatchTableModel(m_system, m_branch_watch, ppc_symbol_db));
       m_table_proxy->setSortRole(UserRole::SortRole);
+      m_table_proxy->setSortCaseSensitivity(Qt::CaseInsensitive);
 
       m_table_model->setFont(ui_settings.GetDebugFont());
       connect(&ui_settings, &Settings::DebugFontChanged, m_table_model,

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -9,12 +9,11 @@
 #include <QDialog>
 #include <QModelIndexList>
 
-#include "Core/Core.h"
-
 namespace Core
 {
 class BranchWatch;
 class CPUThreadGuard;
+enum class State;
 class System;
 }  // namespace Core
 class PPCSymbolDB;
@@ -53,6 +52,11 @@ public:
                              PPCSymbolDB& ppc_symbol_db, CodeWidget* code_widget,
                              QWidget* parent = nullptr);
   ~BranchWatchDialog() override;
+
+  BranchWatchDialog(const BranchWatchDialog&) = delete;
+  BranchWatchDialog(BranchWatchDialog&&) = delete;
+  BranchWatchDialog& operator=(const BranchWatchDialog&) = delete;
+  BranchWatchDialog& operator=(BranchWatchDialog&&) = delete;
 
 protected:
   void hideEvent(QHideEvent* event) override;

--- a/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
@@ -75,6 +75,13 @@ public:
         m_ppc_symbol_db(ppc_symbol_db)
   {
   }
+  ~BranchWatchTableModel() override = default;
+
+  BranchWatchTableModel(const BranchWatchTableModel&) = delete;
+  BranchWatchTableModel(BranchWatchTableModel&&) = delete;
+  BranchWatchTableModel& operator=(const BranchWatchTableModel&) = delete;
+  BranchWatchTableModel& operator=(BranchWatchTableModel&&) = delete;
+
   QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role = Qt::DisplayRole) const override;

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -206,6 +206,7 @@ void CodeWidget::OnBranchWatchDialog()
     m_branch_watch_dialog = new BranchWatchDialog(m_system, m_system.GetPowerPC().GetBranchWatch(),
                                                   m_ppc_symbol_db, this, this);
   }
+  SetQWidgetWindowDecorations(m_branch_watch_dialog);
   m_branch_watch_dialog->show();
   m_branch_watch_dialog->raise();
   m_branch_watch_dialog->activateWindow();


### PR DESCRIPTION
Fixing some minor defects of the Branch Watch Tool. Here's the rundown:
- Sorting the table is no longer case-sensitive.
- BranchWatchDialog, BranchWatchProxyModel, and BranchWatchTableModel classes now have the Rule of Five defined.
- Replaced a "Core.h" include with a forward declaration.
- Resolved the Linux Qt6 FIXME because a recent package update seems to have fixed the issue I was previously avoiding.