### PR TITLE
Branch Watch Tool: Add Set Breakpoints Submenu

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -9,6 +9,8 @@
 #include <QDialog>
 #include <QModelIndexList>
 
+#include "Common/CommonTypes.h"
+
 namespace Core
 {
 class BranchWatch;
@@ -85,11 +87,11 @@ private:
   void OnTableClicked(const QModelIndex& index);
   void OnTableContextMenu(const QPoint& pos);
   void OnTableHeaderContextMenu(const QPoint& pos);
-  void OnTableDelete(QModelIndexList index_list);
+  void OnTableDelete();
   void OnTableDeleteKeypress();
-  void OnTableSetBLR(QModelIndexList index_list);
-  void OnTableSetNOP(QModelIndexList index_list);
-  void OnTableCopyAddress(QModelIndexList index_list);
+  void OnTableSetBLR();
+  void OnTableSetNOP();
+  void OnTableCopyAddress();
 
   void SaveSettings();
 
@@ -102,6 +104,9 @@ private:
   void Save(const Core::CPUThreadGuard& guard, const std::string& filepath);
   void Load(const Core::CPUThreadGuard& guard, const std::string& filepath);
   void AutoSave(const Core::CPUThreadGuard& guard);
+  void SetStubPatches(u32 value) const;
+
+  [[nodiscard]] QMenu* GetTableContextMenu(const QModelIndex& index);
 
   Core::System& m_system;
   Core::BranchWatch& m_branch_watch;
@@ -110,6 +115,10 @@ private:
   QPushButton *m_btn_start_pause, *m_btn_clear_watch, *m_btn_path_was_taken, *m_btn_path_not_taken,
       *m_btn_was_overwritten, *m_btn_not_overwritten, *m_btn_wipe_recent_hits;
   QAction* m_act_autosave;
+  QAction* m_act_insert_nop;
+  QAction* m_act_insert_blr;
+  QAction* m_act_copy_address;
+  QMenu* m_mnu_table_context = nullptr;
   QMenu* m_mnu_column_visibility;
 
   QToolBar* m_control_toolbar;
@@ -119,5 +128,6 @@ private:
   QStatusBar* m_status_bar;
   QTimer* m_timer;
 
+  QModelIndexList m_index_list_temp;
   std::optional<std::string> m_autosave_filepath;
 };

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include <QDialog>
+#include <QIcon>
 #include <QModelIndexList>
 
 #include "Common/CommonTypes.h"
@@ -79,6 +80,7 @@ private:
   void OnWipeInspection();
   void OnTimeout();
   void OnEmulationStateChanged(Core::State new_state);
+  void OnThemeChanged();
   void OnHelp();
   void OnToggleAutoSave(bool checked);
   void OnHideShowControls(bool checked);
@@ -92,6 +94,9 @@ private:
   void OnTableSetBLR();
   void OnTableSetNOP();
   void OnTableCopyAddress();
+  void OnTableSetBreakpointBreak();
+  void OnTableSetBreakpointLog();
+  void OnTableSetBreakpointBoth();
 
   void SaveSettings();
 
@@ -101,10 +106,12 @@ public:
 
 private:
   void UpdateStatus();
+  void UpdateIcons();
   void Save(const Core::CPUThreadGuard& guard, const std::string& filepath);
   void Load(const Core::CPUThreadGuard& guard, const std::string& filepath);
   void AutoSave(const Core::CPUThreadGuard& guard);
   void SetStubPatches(u32 value) const;
+  void SetBreakpoints(bool break_on_hit, bool log_on_hit) const;
 
   [[nodiscard]] QMenu* GetTableContextMenu(const QModelIndex& index);
 
@@ -118,6 +125,10 @@ private:
   QAction* m_act_insert_nop;
   QAction* m_act_insert_blr;
   QAction* m_act_copy_address;
+  QMenu* m_mnu_set_breakpoint;
+  QAction* m_act_break_on_hit;
+  QAction* m_act_log_on_hit;
+  QAction* m_act_both_on_hit;
   QMenu* m_mnu_table_context = nullptr;
   QMenu* m_mnu_column_visibility;
 
@@ -127,6 +138,8 @@ private:
   BranchWatchTableModel* m_table_model;
   QStatusBar* m_status_bar;
   QTimer* m_timer;
+
+  QIcon m_icn_full, m_icn_partial;
 
   QModelIndexList m_index_list_temp;
   std::optional<std::string> m_autosave_filepath;

--- a/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.cpp
@@ -144,18 +144,6 @@ void BranchWatchTableModel::OnWipeInspection()
                    roles);
 }
 
-void BranchWatchTableModel::OnDelete(QModelIndexList index_list)
-{
-  std::sort(index_list.begin(), index_list.end());
-  // TODO C++20: std::ranges::reverse_view
-  for (auto iter = index_list.rbegin(); iter != index_list.rend(); ++iter)
-  {
-    if (!iter->isValid())
-      continue;
-    removeRow(iter->row());
-  }
-}
-
 void BranchWatchTableModel::Save(const Core::CPUThreadGuard& guard, std::FILE* file) const
 {
   m_branch_watch.Save(guard, file);

--- a/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
@@ -97,7 +97,6 @@ public:
   void OnBranchNotOverwritten(const Core::CPUThreadGuard& guard);
   void OnWipeRecentHits();
   void OnWipeInspection();
-  void OnDelete(QModelIndexList index_list);
 
   void Save(const Core::CPUThreadGuard& guard, std::FILE* file) const;
   void Load(const Core::CPUThreadGuard& guard, std::FILE* file);


### PR DESCRIPTION
First I rewrote the Table Context Menu code to only construct it once (lazily) and hide/show/activate/deactivate actions based on what column was right clicked to bring it up. Right clicking the table's scroll area when all columns are hidden will now bring up the Column Visibility Menu. I also made the `OnTableSetNOP` and `OnTableSetBLR` functions follow DRY.

Next, I made it possible to set breakpoints en-mass from a selection in the Branch Watch Tool. This works for the origin, destination, and symbol columns.

![Branch Watch Tool Set Breakpoint](https://github.com/dolphin-emu/dolphin/assets/140017135/f1ca7c98-c0b7-4d85-83bb-6ee2e677bc50)
