### PR TITLE
PPCAnalyst: Fix handling of FL_READ_CR_BI

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -590,7 +590,7 @@ void PPCAnalyzer::SetInstructionStats(CodeBlock* block, CodeOp* code,
   }
   else if (opinfo->flags & FL_READ_CR_BI)
   {
-    code->crIn[code->inst.BI] = true;
+    code->crIn[code->inst.BI >> 2] = true;
   }
   else if (opinfo->type == OpType::CR)
   {


### PR DESCRIPTION
BI contains both the field and the flag (5 bits total), so we need to shift away the 2 flag bits to get the 3 field bits. (Same as the CRBA/CRBB handling in the code just below the BI code.)