### PR TITLE
DiscIO: drop unused Volume::CheckContentIntegrity() overload

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -91,11 +91,6 @@ public:
   {
     return false;
   }
-  virtual bool CheckContentIntegrity(const IOS::ES::Content& content, u64 content_offset,
-                                     const IOS::ES::TicketReader& ticket) const
-  {
-    return false;
-  }
   virtual IOS::ES::TicketReader GetTicketWithFixedCommonKey() const { return {}; }
   // Returns a non-owning pointer. Returns nullptr if the file system couldn't be read.
   virtual const FileSystem* GetFileSystem(const Partition& partition) const = 0;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -170,15 +170,6 @@ bool VolumeWAD::CheckContentIntegrity(const IOS::ES::Content& content,
   return Common::SHA1::CalculateDigest(decrypted_data.data(), content.size) == content.sha1;
 }
 
-bool VolumeWAD::CheckContentIntegrity(const IOS::ES::Content& content, u64 content_offset,
-                                      const IOS::ES::TicketReader& ticket) const
-{
-  std::vector<u8> encrypted_data(Common::AlignUp(content.size, 0x40));
-  if (!m_reader->Read(content_offset, encrypted_data.size(), encrypted_data.data()))
-    return false;
-  return CheckContentIntegrity(content, encrypted_data, ticket);
-}
-
 IOS::ES::TicketReader VolumeWAD::GetTicketWithFixedCommonKey() const
 {
   if (!m_ticket.IsValid() || !m_tmd.IsValid())

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -40,8 +40,6 @@ public:
   std::vector<u64> GetContentOffsets() const override;
   bool CheckContentIntegrity(const IOS::ES::Content& content, const std::vector<u8>& encrypted_data,
                              const IOS::ES::TicketReader& ticket) const override;
-  bool CheckContentIntegrity(const IOS::ES::Content& content, u64 content_offset,
-                             const IOS::ES::TicketReader& ticket) const override;
   IOS::ES::TicketReader GetTicketWithFixedCommonKey() const override;
   std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
   std::string GetGameTDBID(const Partition& partition = PARTITION_NONE) const override;


### PR DESCRIPTION
The offset-based overload hasn't been in use since f754a1a548f2e599e4cc2d1d799f2d21b520076f.