### PR TITLE
Android: Replace SwitchMaterial with MaterialSwitch

### DIFF
--- a/Source/Android/app/src/main/res/layout/fragment_grid_options_tv.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_grid_options_tv.xml
@@ -36,7 +36,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/switch_download_covers" />
 
-            <com.google.android.material.switchmaterial.SwitchMaterial
+            <com.google.android.material.materialswitch.MaterialSwitch
                 android:id="@+id/switch_download_covers"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
See [here](https://developer.android.com/reference/com/google/android/material/materialswitch/MaterialSwitch#:~:text=A%20class%20that%20creates%20a%20Material%20Themed%20Switch.%20This%20class%20is%20intended%20to%20provide%20a%20brand%20new%20Switch%20design%20and%20replace%20the%20obsolete%20SwitchMaterial%20class.) for context. Regular `fragment_grid_options` already used MaterialSwitch, so this was missed somehow.