### PR TITLE
Android: Fix Gradle deprecation

### DIFF
--- a/Source/Android/app/build.gradle.kts
+++ b/Source/Android/app/build.gradle.kts
@@ -12,6 +12,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 
     compileOptions {
@@ -116,12 +117,11 @@ android {
 }
 
 dependencies {
-    "baselineProfile"(project(":benchmark"))
+    baselineProfile(project(":benchmark"))
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 
     implementation("androidx.core:core-ktx:1.13.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.exifinterface:exifinterface:1.3.7")
     implementation("androidx.cardview:cardview:1.0.0")
     implementation("androidx.recyclerview:recyclerview:1.3.2")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
@@ -135,7 +135,6 @@ dependencies {
     // Kotlin extensions for lifecycle components
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")
 
     // Android TV UI libraries.
     implementation("androidx.leanback:leanback:1.0.0")

--- a/Source/Android/gradle.properties
+++ b/Source/Android/gradle.properties
@@ -14,6 +14,5 @@ android.enableJetifier=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
Fix deprecated `android.defaults.buildfeatures.buildconfig`

Also cleaned up quotation marks around baselineProfile, and removed two unused libraries.