### PR TITLE
TAS Input: Enable emulator hotkeys and controller input when TAS Input window has focus

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -173,6 +173,11 @@ bool Host_RendererIsFullscreen()
   return false;
 }
 
+bool Host_TASInputHasFocus()
+{
+  return false;
+}
+
 void Host_YieldToUI()
 {
 }

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -1073,7 +1073,8 @@ void UpdateInputGate(bool require_focus, bool require_full_focus)
 {
   // If the user accepts background input, controls should pass even if an on screen interface is on
   const bool focus_passes =
-      !require_focus || (Host_RendererHasFocus() && !Host_UIBlocksControllerState());
+      !require_focus ||
+      ((Host_RendererHasFocus() || Host_TASInputHasFocus()) && !Host_UIBlocksControllerState());
   // Ignore full focus if we don't require basic focus
   const bool full_focus_passes =
       !require_focus || !require_full_focus || (focus_passes && Host_RendererHasFullFocus());

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -53,6 +53,7 @@ bool Host_UIBlocksControllerState();
 bool Host_RendererHasFocus();
 bool Host_RendererHasFullFocus();
 bool Host_RendererIsFullscreen();
+bool Host_TASInputHasFocus();
 
 void Host_Message(HostMessageID id);
 void Host_PPCSymbolsChanged();

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -111,6 +111,11 @@ bool Host_RendererIsFullscreen()
   return s_platform->IsWindowFullscreen();
 }
 
+bool Host_TASInputHasFocus()
+{
+  return false;
+}
+
 void Host_YieldToUI()
 {
 }

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -162,6 +162,11 @@ bool Host::GetGBAFocus()
 #endif
 }
 
+bool Host::GetTASInputFocus() const
+{
+  return m_tas_input_focus;
+}
+
 bool Host::GetRenderFullscreen()
 {
   return m_render_fullscreen;
@@ -175,6 +180,11 @@ void Host::SetRenderFullscreen(bool fullscreen)
   {
     RunWithGPUThreadInactive([fullscreen] { g_gfx->SetFullscreen(fullscreen); });
   }
+}
+
+void Host::SetTASInputFocus(const bool focus)
+{
+  m_tas_input_focus = focus;
 }
 
 void Host::ResizeSurface(int new_width, int new_height)
@@ -226,6 +236,11 @@ bool Host_RendererHasFullFocus()
 bool Host_RendererIsFullscreen()
 {
   return Host::GetInstance()->GetRenderFullscreen();
+}
+
+bool Host_TASInputHasFocus()
+{
+  return Host::GetInstance()->GetTASInputFocus();
 }
 
 void Host_YieldToUI()

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -25,12 +25,14 @@ public:
   bool GetRenderFullFocus();
   bool GetRenderFullscreen();
   bool GetGBAFocus();
+  bool GetTASInputFocus() const;
 
   void SetMainWindowHandle(void* handle);
   void SetRenderHandle(void* handle);
   void SetRenderFocus(bool focus);
   void SetRenderFullFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
+  void SetTASInputFocus(bool focus);
   void ResizeSurface(int new_width, int new_height);
 
 signals:
@@ -49,4 +51,5 @@ private:
   std::atomic<bool> m_render_focus{false};
   std::atomic<bool> m_render_full_focus{false};
   std::atomic<bool> m_render_fullscreen{false};
+  std::atomic<bool> m_tas_input_focus{false};
 };

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -6,7 +6,9 @@
 #include <cmath>
 #include <utility>
 
+#include <QApplication>
 #include <QCheckBox>
+#include <QEvent>
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -17,6 +19,7 @@
 
 #include "Common/CommonTypes.h"
 
+#include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/AspectRatioWidget.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/Resources.h"
@@ -267,4 +270,17 @@ std::optional<ControlState> TASInputWindow::GetSpinBox(TASSpinBox* spin, int zer
     spin->OnControllerValueChanged(controller_value);
 
   return (spin->GetValue() - zero) / scale;
+}
+
+void TASInputWindow::changeEvent(QEvent* const event)
+{
+  if (event->type() == QEvent::ActivationChange)
+  {
+    const bool active_window_is_tas_input =
+        qobject_cast<TASInputWindow*>(QApplication::activeWindow()) != nullptr;
+
+    // Switching between TAS Input windows will call SetTASInputFocus(true) twice, but that's fine.
+    Host::GetInstance()->SetTASInputFocus(active_window_is_tas_input);
+  }
+  QDialog::changeEvent(event);
 }

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.h
@@ -18,6 +18,7 @@
 class QBoxLayout;
 class QCheckBox;
 class QDialog;
+class QEvent;
 class QGroupBox;
 class QSpinBox;
 class QString;
@@ -67,6 +68,8 @@ protected:
   TASSpinBox* CreateSliderValuePair(QBoxLayout* layout, int default_, int max,
                                     QKeySequence shortcut_key_sequence, Qt::Orientation orientation,
                                     QWidget* shortcut_widget);
+
+  void changeEvent(QEvent* event) override;
 
   QGroupBox* m_settings_box;
   QCheckBox* m_use_controller;

--- a/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
+++ b/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
@@ -84,6 +84,11 @@ bool Host_RendererIsFullscreen()
   return false;
 }
 
+bool Host_TASInputHasFocus()
+{
+  return false;
+}
+
 void Host_YieldToUI()
 {
 }

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -179,7 +179,8 @@ void KeyboardMouse::UpdateCursorInput()
   const auto win_height = std::max(rect.bottom - rect.top, 1l);
 
   POINT point = {};
-  if (g_controller_interface.IsMouseCenteringRequested() && Host_RendererHasFocus())
+  if (g_controller_interface.IsMouseCenteringRequested() &&
+      (Host_RendererHasFocus() || Host_TASInputHasFocus()))
   {
     point.x = win_width / 2;
     point.y = win_height / 2;
@@ -188,6 +189,15 @@ void KeyboardMouse::UpdateCursorInput()
     ClientToScreen(s_hwnd, &screen_point);
     SetCursorPos(screen_point.x, screen_point.y);
     g_controller_interface.SetMouseCenteringRequested(false);
+  }
+  else if (Host_TASInputHasFocus())
+  {
+    // When a TAS Input window has focus and "Enable Controller Input" is checked most types of
+    // input should be read normally as if the render window had focus instead. The cursor is an
+    // exception, as otherwise using the mouse to set any control in the TAS Input window will also
+    // update the Wii IR value (or any other input controlled by the cursor).
+
+    return;
   }
   else
   {

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -244,7 +244,8 @@ Core::DeviceRemoval KeyboardAndMouse::UpdateInput()
   const double window_width = std::max(bounds.size.width, 1.0);
   const double window_height = std::max(bounds.size.height, 1.0);
 
-  if (g_controller_interface.IsMouseCenteringRequested() && Host_RendererHasFocus())
+  if (g_controller_interface.IsMouseCenteringRequested() &&
+      (Host_RendererHasFocus() || Host_TASInputHasFocus()))
   {
     m_cursor.x = 0;
     m_cursor.y = 0;
@@ -258,8 +259,13 @@ Core::DeviceRemoval KeyboardAndMouse::UpdateInput()
 
     g_controller_interface.SetMouseCenteringRequested(false);
   }
-  else
+  else if (!Host_TASInputHasFocus())
   {
+    // When a TAS Input window has focus and "Enable Controller Input" is checked most types of
+    // input should be read normally as if the render window had focus instead. The cursor is an
+    // exception, as otherwise using the mouse to set any control in the TAS Input window will also
+    // update the Wii IR value (or any other input controlled by the cursor).
+
     NSPoint loc = [NSEvent mouseLocation];
 
     const auto window_scale = g_controller_interface.GetWindowInputScale();

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -391,9 +391,16 @@ Core::DeviceRemoval KeyboardMouse::UpdateInput()
   m_state.axis.z += delta_z;
   m_state.axis.z /= SCROLL_AXIS_DECAY;
 
-  const bool should_center_mouse =
-      g_controller_interface.IsMouseCenteringRequested() && Host_RendererHasFocus();
-  if (update_mouse || should_center_mouse)
+  const bool should_center_mouse = g_controller_interface.IsMouseCenteringRequested() &&
+                                   (Host_RendererHasFocus() || Host_TASInputHasFocus());
+
+  // When a TAS Input window has focus and "Enable Controller Input" is checked most types of
+  // input should be read normally as if the render window had focus instead. The cursor is an
+  // exception, as otherwise using the mouse to set any control in the TAS Input window will also
+  // update the Wii IR value (or any other input controlled by the cursor).
+  const bool should_update_mouse = update_mouse && !Host_TASInputHasFocus();
+
+  if (should_update_mouse || should_center_mouse)
     UpdateCursor(should_center_mouse);
 
   if (update_keyboard)

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -59,6 +59,10 @@ bool Host_RendererIsFullscreen()
 {
   return false;
 }
+bool Host_TASInputHasFocus()
+{
+  return false;
+}
 void Host_YieldToUI()
 {
 }

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -63,6 +63,10 @@ bool Host_RendererIsFullscreen()
 {
   return false;
 }
+bool Host_TASInputHasFocus()
+{
+  return false;
+}
 void Host_YieldToUI()
 {
 }


### PR DESCRIPTION
Enable emulator hotkeys and controller input (when that option is enabled) when a TAS Input window has focus, as if it was the render window instead.  This allows TASers to use frame advance and the like without having to either switch the focused window or disabling Hotkeys Require Window Focus (which also causes keypresses to be picked up while other apps are focused).

Cursor updates are disabled when the TAS Input window has focus, as otherwise the Wii IR widget (and anything else controlled by the mouse) becomes unusable. The cursor continues to work normally when the render window has focus.