### PR TITLE
VideoCommon: use imgui mouse position event when the mouse position changes

### DIFF
--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -472,8 +472,7 @@ void OnScreenUI::SetMousePos(float x, float y)
 {
   auto lock = GetImGuiLock();
 
-  ImGui::GetIO().MousePos.x = x;
-  ImGui::GetIO().MousePos.y = y;
+  ImGui::GetIO().AddMousePosEvent(x, y);
 }
 
 void OnScreenUI::SetMousePress(u32 button_mask)


### PR DESCRIPTION
Similar to #12787 , this event was overlooked earlier.  I believe this is the last one that needs to be updated.