### PR TITLE
Common: add Json helper utilities for loading or saving to a file

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(common
   JitRegister.cpp
   JitRegister.h
   JsonUtil.h
+  JsonUtil.cpp
   Lazy.h
   LinearDiskCache.h
   Logging/ConsoleListener.h

--- a/Source/Core/Common/JsonUtil.cpp
+++ b/Source/Core/Common/JsonUtil.cpp
@@ -3,6 +3,10 @@
 
 #include "Common/JsonUtil.h"
 
+#include <fstream>
+
+#include "Common/FileUtil.h"
+
 picojson::object ToJsonObject(const Common::Vec3& vec)
 {
   picojson::object obj;
@@ -37,4 +41,28 @@ std::optional<bool> ReadBoolFromJson(const picojson::object& obj, const std::str
   if (!it->second.is<bool>())
     return std::nullopt;
   return it->second.get<bool>();
+}
+
+bool JsonToFile(const std::string& filename, const picojson::value& root, bool prettify)
+{
+  std::ofstream json_stream;
+  File::OpenFStream(json_stream, filename, std::ios_base::out);
+  if (!json_stream.is_open())
+  {
+    return false;
+  }
+  json_stream << root.serialize(prettify);
+  return true;
+}
+
+bool JsonFromFile(const std::string& filename, picojson::value* root, std::string* error)
+{
+  std::string json_data;
+  if (!File::ReadFileToString(filename, json_data))
+  {
+    return false;
+  }
+
+  *error = picojson::parse(*root, json_data);
+  return error->empty();
 }

--- a/Source/Core/Common/JsonUtil.h
+++ b/Source/Core/Common/JsonUtil.h
@@ -56,3 +56,6 @@ std::optional<bool> ReadBoolFromJson(const picojson::object& obj, const std::str
 
 picojson::object ToJsonObject(const Common::Vec3& vec);
 void FromJson(const picojson::object& obj, Common::Vec3& vec);
+
+bool JsonToFile(const std::string& filename, const picojson::value& root, bool prettify = false);
+bool JsonFromFile(const std::string& filename, picojson::value* root, std::string* error);

--- a/Source/Core/Common/JsonUtil.h
+++ b/Source/Core/Common/JsonUtil.h
@@ -9,7 +9,6 @@
 
 #include <picojson.h>
 
-#include "Common/MathUtil.h"
 #include "Common/Matrix.h"
 
 // Ideally this would use a concept like, 'template <std::ranges::range Range>' to constrain it,
@@ -47,7 +46,7 @@ std::optional<Type> ReadNumericFromJson(const picojson::object& obj, const std::
     return std::nullopt;
   if (!it->second.is<double>())
     return std::nullopt;
-  return MathUtil::SaturatingCast<Type>(it->second.get<double>());
+  return static_cast<Type>(it->second.get<double>());
 }
 
 std::optional<std::string> ReadStringFromJson(const picojson::object& obj, const std::string& key);

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -813,6 +813,7 @@
     <ClCompile Include="Common\IniFile.cpp" />
     <ClCompile Include="Common\IOFile.cpp" />
     <ClCompile Include="Common\JitRegister.cpp" />
+    <ClCompile Include="Common\JsonUtil.cpp" />
     <ClCompile Include="Common\LdrWatcher.cpp" />
     <ClCompile Include="Common\Logging\ConsoleListenerWin.cpp" />
     <ClCompile Include="Common\Logging\LogManager.cpp" />

--- a/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.cpp
@@ -12,6 +12,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
+#include "Common/JsonUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
@@ -23,18 +24,9 @@ namespace InputCommon::DynamicInputTextures
 {
 Configuration::Configuration(const std::string& json_path)
 {
-  std::string json_data;
-  if (!File::ReadFileToString(json_path, json_data))
-  {
-    ERROR_LOG_FMT(VIDEO, "Failed to load dynamic input json file '{}'", json_path);
-    m_valid = false;
-    return;
-  }
-
   picojson::value root;
-  const auto error = picojson::parse(root, json_data);
-
-  if (!error.empty())
+  std::string error;
+  if (!JsonFromFile(json_path, &root, &error))
   {
     ERROR_LOG_FMT(VIDEO, "Failed to load dynamic input json file '{}' due to parse error: {}",
                   json_path, error);

--- a/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.cpp
+++ b/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.cpp
@@ -10,6 +10,7 @@
 
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
+#include "Common/JsonUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "VideoCommon/Assets/MaterialAsset.h"
@@ -133,24 +134,16 @@ CustomAssetLibrary::LoadInfo DirectFilesystemAssetLibrary::LoadPixelShader(const
     return {};
   }
 
-  std::string json_data;
-  if (!File::ReadFileToString(PathToString(metadata->second), json_data))
-  {
-    ERROR_LOG_FMT(VIDEO, "Asset '{}' error -  failed to load the json file '{}',", asset_id,
-                  PathToString(metadata->second));
-    return {};
-  }
-
   picojson::value root;
-  const auto error = picojson::parse(root, json_data);
-
-  if (!error.empty())
+  std::string error;
+  if (!JsonFromFile(PathToString(metadata->second), &root, &error))
   {
     ERROR_LOG_FMT(VIDEO,
                   "Asset '{}' error -  failed to load the json file '{}', due to parse error: {}",
                   asset_id, PathToString(metadata->second), error);
     return {};
   }
+
   if (!root.is<picojson::object>())
   {
     ERROR_LOG_FMT(
@@ -181,18 +174,21 @@ CustomAssetLibrary::LoadInfo DirectFilesystemAssetLibrary::LoadMaterial(const As
   }
   const auto& asset_path = asset_map.begin()->second;
 
-  std::string json_data;
-  if (!File::ReadFileToString(PathToString(asset_path), json_data))
+  std::size_t metadata_size;
   {
-    ERROR_LOG_FMT(VIDEO, "Asset '{}' error -  material failed to load the json file '{}',",
-                  asset_id, PathToString(asset_path));
-    return {};
+    std::error_code ec;
+    metadata_size = std::filesystem::file_size(asset_path, ec);
+    if (ec)
+    {
+      ERROR_LOG_FMT(VIDEO, "Asset '{}' error - failed to get material file size with error '{}'!",
+                    asset_id, ec);
+      return {};
+    }
   }
 
   picojson::value root;
-  const auto error = picojson::parse(root, json_data);
-
-  if (!error.empty())
+  std::string error;
+  if (!JsonFromFile(PathToString(asset_path), &root, &error))
   {
     ERROR_LOG_FMT(
         VIDEO,
@@ -220,7 +216,7 @@ CustomAssetLibrary::LoadInfo DirectFilesystemAssetLibrary::LoadMaterial(const As
     return {};
   }
 
-  return LoadInfo{json_data.size(), GetLastAssetWriteTime(asset_id)};
+  return LoadInfo{metadata_size, GetLastAssetWriteTime(asset_id)};
 }
 
 CustomAssetLibrary::LoadInfo DirectFilesystemAssetLibrary::LoadMesh(const AssetID& asset_id,
@@ -292,18 +288,9 @@ CustomAssetLibrary::LoadInfo DirectFilesystemAssetLibrary::LoadMesh(const AssetI
     return {};
   }
 
-  std::string json_data;
-  if (!File::ReadFileToString(PathToString(metadata->second), json_data))
-  {
-    ERROR_LOG_FMT(VIDEO, "Asset '{}' error -  failed to load the json file '{}'!", asset_id,
-                  PathToString(metadata->second));
-    return {};
-  }
-
   picojson::value root;
-  const auto error = picojson::parse(root, json_data);
-
-  if (!error.empty())
+  std::string error;
+  if (!JsonFromFile(PathToString(metadata->second), &root, &error))
   {
     ERROR_LOG_FMT(VIDEO,
                   "Asset '{}' error -  failed to load the json file '{}', due to parse error: {}",
@@ -362,18 +349,9 @@ CustomAssetLibrary::LoadInfo DirectFilesystemAssetLibrary::LoadTexture(const Ass
       return {};
     }
 
-    std::string json_data;
-    if (!File::ReadFileToString(PathToString(metadata->second), json_data))
-    {
-      ERROR_LOG_FMT(VIDEO, "Asset '{}' error -  failed to load the json file '{}',", asset_id,
-                    PathToString(metadata->second));
-      return {};
-    }
-
     picojson::value root;
-    const auto error = picojson::parse(root, json_data);
-
-    if (!error.empty())
+    std::string error;
+    if (!JsonFromFile(PathToString(metadata->second), &root, &error))
     {
       ERROR_LOG_FMT(VIDEO,
                     "Asset '{}' error -  failed to load the json file '{}', due to parse error: {}",

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsMod.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsMod.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
+#include "Common/JsonUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 
@@ -15,17 +16,9 @@
 std::optional<GraphicsModConfig> GraphicsModConfig::Create(const std::string& file_path,
                                                            Source source)
 {
-  std::string json_data;
-  if (!File::ReadFileToString(file_path, json_data))
-  {
-    ERROR_LOG_FMT(VIDEO, "Failed to load graphics mod json file '{}'", file_path);
-    return std::nullopt;
-  }
-
   picojson::value root;
-  const auto error = picojson::parse(root, json_data);
-
-  if (!error.empty())
+  std::string error;
+  if (!JsonFromFile(file_path, &root, &error))
   {
     ERROR_LOG_FMT(VIDEO, "Failed to load graphics mod json file '{}' due to parse error: {}",
                   file_path, error);

--- a/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Config/GraphicsModGroup.cpp
@@ -12,6 +12,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
+#include "Common/JsonUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
@@ -42,17 +43,9 @@ void GraphicsModGroupConfig::Load()
   std::set<std::string> known_paths;
   if (File::Exists(file_path))
   {
-    std::string json_data;
-    if (!File::ReadFileToString(file_path, json_data))
-    {
-      ERROR_LOG_FMT(VIDEO, "Failed to load graphics mod group json file '{}'", file_path);
-      return;
-    }
-
     picojson::value root;
-    const auto error = picojson::parse(root, json_data);
-
-    if (!error.empty())
+    std::string error;
+    if (!JsonFromFile(file_path, &root, &error))
     {
       ERROR_LOG_FMT(VIDEO,
                     "Failed to load graphics mod group json file '{}' due to parse error: {}",


### PR DESCRIPTION
I was doing this enough in a branch that I figured I should probably make some functions out of it.  And hey, it turns out it can clean up a bit of our code in master too!

I tested all areas impacted:  DiT, texture loading, and graphics mods.

(also JsonUtil.cpp wasn't added to the source file, which triggered the `SaturatingCast` error, so that was fixed based on our [previous discussion](https://github.com/dolphin-emu/dolphin/pull/12653))