### PR TITLE
Fix balloon tip position on secondary monitors

### DIFF
--- a/Source/Core/DolphinQt/Config/ToolTipControls/BalloonTip.cpp
+++ b/Source/Core/DolphinQt/Config/ToolTipControls/BalloonTip.cpp
@@ -228,7 +228,7 @@ void BalloonTip::UpdateBoundsAndRedraw(const QPoint& target_arrow_tip_position,
   const bool arrow_at_bottom =
       target_arrow_tip_position.y() - size_hint.height() + arrow_height >= 0;
   const bool arrow_at_left =
-      target_arrow_tip_position.x() + size_hint.width() - arrow_tip_x_offset < screen_rect.width();
+      target_arrow_tip_position.x() + size_hint.width() - arrow_tip_x_offset < screen_rect.left() + screen_rect.width();
 
   const float arrow_base_y =
       arrow_at_bottom ? rect_bottom - border_half_width : rect_top + border_half_width;


### PR DESCRIPTION
Balloon tip was always position on the right on my second monitor, which messed up the tip position if my window was too much to the left.