### PR TITLE
Android: Adopt a new versionCode scheme

### DIFF
--- a/Source/Android/app/build.gradle.kts
+++ b/Source/Android/app/build.gradle.kts
@@ -170,7 +170,7 @@ fun getGitVersion(): String {
 
 fun getBuildVersionCode(): Int {
     try {
-        return Integer.valueOf(
+        val commitCount = Integer.valueOf(
             ProcessBuilder("git", "rev-list", "--first-parent", "--count", "HEAD")
                 .directory(project.rootDir)
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
@@ -178,6 +178,15 @@ fun getBuildVersionCode(): Int {
                 .start().inputStream.bufferedReader().use { it.readText() }
                 .trim()
         )
+
+        val isRelease = ProcessBuilder("git", "describe", "--exact-match", "HEAD")
+            .directory(project.rootDir)
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+            .waitFor() == 0
+
+        return commitCount * 2 + (if (isRelease) 0 else 1)
     } catch (e: Exception) {
         logger.error("Cannot find git, defaulting to dummy version code")
     }


### PR DESCRIPTION
Right now, we assign a versionCode to each Android build of Dolphin by counting the total number of git commits made. This has worked fine so far, but it won't work as-is for the new release process.

Let's say we're currently on commit 20000. If we want to create a release under the new release process, we would create a release branch, add a new commit on it that updates the release name in CMake files and so on, and create a tag for that commit. The Android build of this release commit would get the version code 20001. However, the master branch is also going to get a commit with the version code 20001 sooner or later, and this commit would be an entirely different commit than commit 20001 on the release branch. This isn't much of a problem for people downloading Dolphin from dolphin-emu.org, but it's a big problem for Google Play, as Google Play doesn't allow us to upload two builds with the same version code.

This commit makes us calculate the Android version code in a new way: The number of commits times two, and if the current build isn't a release build, plus 1. (We check whether the current build is a release build by checking whether there's a tag for the current commit.)

With this new version code scheme, the release commit described in my example would get the version code 40002, and the master commit would get the version code 40003. This lets us upload both corresponding builds to Google Play, and also lets the user switch from the release build to the development build if they would like to. (Under normal circumstances, Android forbids installing a build with an older version code than the currently installed build. Therefore, whether the 1 is added for release builds or for development builds is a decision with consequences.)