### PR TITLE
Assembler: Add aliases for r1 and r2

### DIFF
--- a/Source/Core/Common/Assembler/GekkoLexer.cpp
+++ b/Source/Core/Common/Assembler/GekkoLexer.cpp
@@ -649,7 +649,7 @@ TokenType Lexer::ClassifyAlnum() const
 
       if (rn[0] == '3')
       {
-        return rn[1] <= '2';
+        return rn[1] < '2';
       }
     }
 


### PR DESCRIPTION
All references to r1 and r2 in the disassembler get replaced with sp (stack pointer) and rtoc (register table of contents) respectively. When writing these instructions in the assembler, it fails to resolve:
![image](https://github.com/dolphin-emu/dolphin/assets/68222518/adbb2473-1379-4e55-87c6-7457b5e6b1c8)

This commit allows them to be used interchangeably
I considered adding an extra enum entry `TokenType::Alias` but the current approach seemed straightforward enough as-is