### PR TITLE
MainWindow: Fix batch mode

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -239,7 +239,8 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
   QSettings& settings = Settings::GetQSettings();
   restoreState(settings.value(QStringLiteral("mainwindow/state")).toByteArray());
   restoreGeometry(settings.value(QStringLiteral("mainwindow/geometry")).toByteArray());
-  show();
+  if (!Settings::Instance().IsBatchModeEnabled())
+    show();
 
   InitControllers();
   ConnectHotkeys();


### PR DESCRIPTION
I accidentally broke batch mode (for keeping the main window hidden) in #12794.  Hopefully that's the only thing I missed, as I don't know another way to initialize the Window before it is initialized somewhat randomly with bugs on Windows platforms.