### PR TITLE
Use a stub AchivementManager when USE_RETRO_ACHIEVEMENTS isn't defined

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -5,19 +5,25 @@
 
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include <array>
+#include <chrono>
 #include <ctime>
 #include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
+#include <set>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 #include <rcheevos/include/rc_api_runtime.h>
 #include <rcheevos/include/rc_api_user.h>
 #include <rcheevos/include/rc_client.h>
 #include <rcheevos/include/rc_runtime.h>
 
+#include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/HttpRequest.h"
 #include "Common/WorkQueueThread.h"
@@ -205,5 +211,32 @@ private:
   mutable std::recursive_mutex m_lock;
   std::recursive_mutex m_filereader_lock;
 };  // class AchievementManager
+
+#else  // USE_RETRO_ACHIEVEMENTS
+
+#include <string>
+
+namespace DiscIO
+{
+class Volume;
+}
+
+class AchievementManager
+{
+public:
+  static AchievementManager& GetInstance()
+  {
+    static AchievementManager s_instance;
+    return s_instance;
+  }
+
+  constexpr bool IsHardcoreModeActive() { return false; }
+
+  constexpr void LoadGame(const std::string&, const DiscIO::Volume*) {}
+
+  constexpr void DoFrame() {}
+
+  constexpr void CloseGame() {}
+};
 
 #endif  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -575,9 +575,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
         SetupGCMemory(system, guard);
       }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
       AchievementManager::GetInstance().LoadGame(executable.path, nullptr);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
       if (!executable.reader->LoadIntoMemory(system))
       {

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -166,9 +166,7 @@ bool BootCore(Core::System& system, std::unique_ptr<BootParameters> boot,
     }
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().CloseGame();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   const bool load_ipl = !system.IsWii() && !Config::Get(Config::MAIN_SKIP_IPL) &&
                         std::holds_alternative<BootParameters::Disc>(boot->parameters);

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -207,10 +207,8 @@ Cheats::NewSearch(const Core::CPUThreadGuard& guard,
                   PowerPC::RequestedAddressSpace address_space, bool aligned,
                   const std::function<bool(const T& value)>& validator)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
-#endif  // USE_RETRO_ACHIEVEMENTS
   auto& system = guard.GetSystem();
   std::vector<Cheats::SearchResult<T>> results;
   const Core::State core_state = Core::GetState(system);
@@ -262,10 +260,8 @@ Cheats::NextSearch(const Core::CPUThreadGuard& guard,
                    PowerPC::RequestedAddressSpace address_space,
                    const std::function<bool(const T& new_value, const T& old_value)>& validator)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
-#endif  // USE_RETRO_ACHIEVEMENTS
   auto& system = guard.GetSystem();
   std::vector<Cheats::SearchResult<T>> results;
   const Core::State core_state = Core::GetState(system);
@@ -429,10 +425,8 @@ MakeCompareFunctionForLastValue(Cheats::CompareType op)
 template <typename T>
 Cheats::SearchErrorCode Cheats::CheatSearchSession<T>::RunSearch(const Core::CPUThreadGuard& guard)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return Cheats::SearchErrorCode::DisabledInHardcoreMode;
-#endif  // USE_RETRO_ACHIEVEMENTS
   Common::Result<SearchErrorCode, std::vector<SearchResult<T>>> result =
       Cheats::SearchErrorCode::InvalidParameters;
   if (m_filter_type == FilterType::CompareAgainstSpecificValue)

--- a/Source/Core/Core/CheatSearch.h
+++ b/Source/Core/Core/CheatSearch.h
@@ -100,10 +100,8 @@ enum class SearchErrorCode
   // currently off in the emulated game.
   VirtualAddressesCurrentlyNotAccessible,
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   // Cheats and memory reading are disabled in RetroAchievements hardcore mode.
   DisabledInHardcoreMode,
-#endif  // USE_RETRO_ACHIEVEMENTS
 };
 
 // Returns the corresponding DataType enum for the value currently held by the given SearchValue.

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -749,22 +749,14 @@ bool IsDefaultGCIFolderPathConfigured(ExpansionInterface::Slot slot)
 
 bool AreCheatsEnabled()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   return Config::Get(::Config::MAIN_ENABLE_CHEATS) &&
          !AchievementManager::GetInstance().IsHardcoreModeActive();
-#else   // USE_RETRO_ACHIEVEMENTS
-  return Config::Get(::Config::MAIN_ENABLE_CHEATS);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 bool IsDebuggingEnabled()
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   return Config::Get(::Config::MAIN_ENABLE_DEBUGGING) &&
          !AchievementManager::GetInstance().IsHardcoreModeActive();
-#else   // USE_RETRO_ACHIEVEMENTS
-  return Config::Get(::Config::MAIN_ENABLE_DEBUGGING);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 }  // namespace Config

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -169,17 +169,14 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   if (!was_changed)
     return;
 
-#ifdef USE_RETRO_ACHIEVEMENTS
-  if (game_id != "00000000")
-    AchievementManager::GetInstance().CloseGame();
-#endif  // USE_RETRO_ACHIEVEMENTS
-
   if (game_id == "00000000")
   {
     m_title_name.clear();
     m_title_description.clear();
     return;
   }
+
+  AchievementManager::GetInstance().CloseGame();
 
   const Core::TitleDatabase title_database;
   auto& system = Core::System::GetInstance();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -287,9 +287,7 @@ void Stop(Core::System& system)  // - Hammertime!
     return;
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().CloseGame();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   s_is_stopping = true;
 
@@ -908,9 +906,7 @@ void Callback_NewField(Core::System& system)
     }
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().DoFrame();
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 void UpdateTitle(Core::System& system)
@@ -1048,13 +1044,11 @@ void HostDispatchJobs(Core::System& system)
 // NOTE: Host Thread
 void DoFrameStep(Core::System& system)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
   {
     OSD::AddMessage("Frame stepping is disabled in RetroAchievements hardcore mode");
     return;
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
   if (GetState(system) == State::Paused)
   {
     // if already paused, frame advance for 1 frame

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -138,7 +138,6 @@ void CoreTimingManager::RefreshConfig()
 
   m_max_variance = std::chrono::duration_cast<DT>(DT_ms(Config::Get(Config::MAIN_TIMING_VARIANCE)));
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive() &&
       Config::Get(Config::MAIN_EMULATION_SPEED) < 1.0f &&
       Config::Get(Config::MAIN_EMULATION_SPEED) > 0.0f)
@@ -147,7 +146,6 @@ void CoreTimingManager::RefreshConfig()
     m_emulation_speed = 1.0f;
     OSD::AddMessage("Minimum speed is 100% in Hardcore Mode");
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   m_emulation_speed = Config::Get(Config::MAIN_EMULATION_SPEED);
 }

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -30,10 +30,9 @@
 void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, Common::Debug::MemoryPatch& patch,
                       bool store_existing_value)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return;
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   if (patch.value.empty())
     return;
 

--- a/Source/Core/Core/FreeLookConfig.cpp
+++ b/Source/Core/Core/FreeLookConfig.cpp
@@ -46,11 +46,7 @@ void Config::Refresh()
   }
 
   camera_config.control_type = ::Config::Get(::Config::FL1_CONTROL_TYPE);
-#ifdef USE_RETRO_ACHIEVEMENTS
   enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED) &&
             !AchievementManager::GetInstance().IsHardcoreModeActive();
-#else   // USE_RETRO_ACHIEVEMENTS
-  enabled = ::Config::Get(::Config::FREE_LOOK_ENABLED);
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 }  // namespace FreeLook

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -398,9 +398,7 @@ void DVDInterface::SetDisc(std::unique_ptr<DiscIO::VolumeDisc> disc,
     m_auto_disc_change_index = 0;
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().LoadGame("", disc.get());
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   // Assume that inserting a disc requires having an empty disc before
   if (had_disc != has_disc)

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -478,11 +478,9 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
   if (!Core::IsRunningAndStarted())
     return BootstrapPPC();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   INFO_LOG_FMT(ACHIEVEMENTS,
                "WAD and NAND formats not currently supported by Achievement Manager.");
   AchievementManager::GetInstance().CloseGame();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   core_timing.RemoveEvent(s_bootstrap_ppc_for_launch_event);
   core_timing.ScheduleEvent(ticks, s_bootstrap_ppc_for_launch_event);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -941,10 +941,8 @@ bool MovieManager::PlayInput(const std::string& movie_path,
 
   ReadHeader();
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return false;
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   m_total_frames = m_temp_header.frameCount;
   m_total_lag_count = m_temp_header.lagCount;

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -233,10 +233,9 @@ void LoadPatches()
 
 static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Patch>& patches)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return;
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   for (const Patch& patch : patches)
   {
     if (patch.enabled)
@@ -278,10 +277,9 @@ static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Pa
 static void ApplyMemoryPatches(const Core::CPUThreadGuard& guard,
                                std::span<const std::size_t> memory_patch_indices)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return;
-#endif  // USE_RETRO_ACHIEVEMENTS
+
   std::lock_guard lock(s_on_frame_memory_mutex);
   for (std::size_t index : memory_patch_indices)
   {

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -212,13 +212,11 @@ void LoadFromBuffer(Core::System& system, std::vector<u8>& buffer)
     return;
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
   {
     OSD::AddMessage("Loading savestates is disabled in RetroAchievements hardcore mode");
     return;
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   Core::RunOnCPUThread(
       system,
@@ -865,13 +863,11 @@ void LoadAs(Core::System& system, const std::string& filename)
     return;
   }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
   {
     OSD::AddMessage("Loading savestates is disabled in RetroAchievements hardcore mode");
     return;
   }
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   std::unique_lock lk(s_load_or_save_in_progress_mutex, std::try_to_lock);
   if (!lk)

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -524,10 +524,8 @@ static bool MemoryMatchesAt(const Core::CPUThreadGuard& guard, u32 offset,
 static void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, u32 offset,
                              std::span<const u8> value, std::span<const u8> original)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     return;
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   if (value.empty())
     return;

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -589,15 +589,12 @@ void HotkeyScheduler::Run()
     {
       const bool new_value = !Config::Get(Config::FREE_LOOK_ENABLED);
       Config::SetCurrent(Config::FREE_LOOK_ENABLED, new_value);
-#ifdef USE_RETRO_ACHIEVEMENTS
+
       const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
       if (hardcore)
         OSD::AddMessage("Free Look is Disabled in Hardcore Mode");
       else
         OSD::AddMessage(fmt::format("Free Look: {}", new_value ? "Enabled" : "Disabled"));
-#else   // USE_RETRO_ACHIEVEMENTS
-      OSD::AddMessage(fmt::format("Free Look: {}", new_value ? "Enabled" : "Disabled"));
-#endif  // USE_RETRO_ACHIEVEMENTS
     }
 
     // Savestates

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -127,14 +127,9 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   m_screenshot_action->setEnabled(running);
   m_state_save_menu->setEnabled(running);
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_state_load_menu->setEnabled(running && !hardcore);
   m_frame_advance_action->setEnabled(running && !hardcore);
-#else   // USE_RETRO_ACHIEVEMENTS
-  m_state_load_menu->setEnabled(running);
-  m_frame_advance_action->setEnabled(running);
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   // Movie
   m_recording_read_only->setEnabled(running);
@@ -144,11 +139,7 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
     m_recording_export->setEnabled(false);
   }
   m_recording_play->setEnabled(m_game_selected && !running);
-#ifdef USE_RETRO_ACHIEVEMENTS
   m_recording_play->setEnabled(m_game_selected && !running && !hardcore);
-#else   // USE_RETRO_ACHIEVEMENTS
-  m_recording_play->setEnabled(m_game_selected && !running);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_recording_start->setEnabled((m_game_selected || running) &&
                                 !Core::System::GetInstance().GetMovie().IsPlayingInput());
 

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -550,10 +550,8 @@ void Settings::SetCheatsEnabled(bool enabled)
 
 void Settings::SetDebugModeEnabled(bool enabled)
 {
-#ifdef USE_RETRO_ACHIEVEMENTS
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     enabled = false;
-#endif  // USE_RETRO_ACHIEVEMENTS
   if (IsDebugModeEnabled() != enabled)
   {
     Config::SetBaseOrCurrent(Config::MAIN_ENABLE_DEBUGGING, enabled);

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -84,14 +84,10 @@ void GeneralPane::CreateLayout()
 void GeneralPane::OnEmulationStateChanged(Core::State state)
 {
   const bool running = state != Core::State::Uninitialized;
+  const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
 
   m_checkbox_dualcore->setEnabled(!running);
-#ifdef USE_RETRO_ACHIEVEMENTS
-  bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_checkbox_cheats->setEnabled(!running && !hardcore);
-#else   // USE_RETRO_ACHIEVEMENTS
-  m_checkbox_cheats->setEnabled(!running);
-#endif  // USE_RETRO_ACHIEVEMENTS
   m_checkbox_override_region_settings->setEnabled(!running);
 #ifdef USE_DISCORD_PRESENCE
   m_checkbox_discord_presence->setEnabled(!running);

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -268,7 +268,6 @@ void InterfacePane::UpdateShowDebuggingCheckbox()
   static constexpr char TR_DISABLED_IN_HARDCORE_DESCRIPTION[] =
       QT_TR_NOOP("<dolphin_emphasis>Disabled in Hardcore Mode.</dolphin_emphasis>");
 
-#ifdef USE_RETRO_ACHIEVEMENTS
   bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   SignalBlocking(m_checkbox_show_debugging_ui)->setEnabled(!hardcore);
   if (hardcore)
@@ -281,9 +280,6 @@ void InterfacePane::UpdateShowDebuggingCheckbox()
   {
     m_checkbox_show_debugging_ui->SetDescription(tr(TR_SHOW_DEBUGGING_UI_DESCRIPTION));
   }
-#else
-  m_checkbox_show_debugging_ui->SetDescription(tr(TR_SHOW_DEBUGGING_UI_DESCRIPTION));
-#endif  // USE_RETRO_ACHIEVEMENTS
 }
 
 void InterfacePane::LoadUserStyle()

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -331,9 +331,9 @@ void OnScreenUI::DrawDebugText()
     ImGui::TextUnformatted(profile_output.c_str());
 }
 
-#ifdef USE_RETRO_ACHIEVEMENTS
 void OnScreenUI::DrawChallengesAndLeaderboards()
 {
+#ifdef USE_RETRO_ACHIEVEMENTS
   std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
   const auto& challenge_icons = AchievementManager::GetInstance().GetChallengeIcons();
   const auto& leaderboard_progress = AchievementManager::GetInstance().GetActiveLeaderboards();
@@ -396,8 +396,8 @@ void OnScreenUI::DrawChallengesAndLeaderboards()
     }
     ImGui::End();
   }
-}
 #endif  // USE_RETRO_ACHIEVEMENTS
+}
 
 void OnScreenUI::Finalize()
 {
@@ -406,9 +406,7 @@ void OnScreenUI::Finalize()
   g_perf_metrics.DrawImGuiStats(m_backbuffer_scale);
   DrawDebugText();
   OSD::DrawMessages();
-#ifdef USE_RETRO_ACHIEVEMENTS
   DrawChallengesAndLeaderboards();
-#endif  // USE_RETRO_ACHIEVEMENTS
   ImGui::Render();
 }
 

--- a/Source/Core/VideoCommon/OnScreenUI.h
+++ b/Source/Core/VideoCommon/OnScreenUI.h
@@ -61,9 +61,7 @@ public:
 
 private:
   void DrawDebugText();
-#ifdef USE_RETRO_ACHIEVEMENTS
   void DrawChallengesAndLeaderboards();
-#endif  // USE_RETRO_ACHIEVEMENTS
 
   // ImGui resources.
   std::unique_ptr<NativeVertexFormat> m_imgui_vertex_format;


### PR DESCRIPTION
This lets us reduce the number of USE_RETRO_ACHIEVEMENTS ifdefs in the code base, reducing visual clutter. In particular, needing an ifdef for each call to IsHardcodeModeActive was annoying to me. This also reduces the risk that someone writes code that accidentally fails to compile with USE_RETRO_ACHIEVEMENTS disabled.

We could cut down on ifdefs even further by making HardcodeWarningWidget always exist, but that would result in non-trivial code ending up in the binary even with USE_RETRO_ACHIEVEMENTS disabled, so I'm leaving it out of this PR. It's not a lot of code though, so I might end up revisiting it at some point.