### PR TITLE
FatFsUtil: Generate a non-partitioned image in our folder-to-sdcard conversion.

### DIFF
--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -553,7 +553,7 @@ bool SyncSDFolderToSDImage(const std::function<bool()>& cancelled, bool determin
   }
 
   MKFS_PARM options = {};
-  options.fmt = FM_FAT32;
+  options.fmt = FM_FAT32 | FM_SFD;
   options.n_fat = 0;    // Number of FATs: automatic
   options.align = 1;    // Alignment of the data region (in sectors)
   options.n_root = 0;   // Number of root directory entries: automatic (and unused for FAT32)


### PR DESCRIPTION
We currently have two code paths to create sdcard images.
`SDCardUtil.cpp` for empty fat32 image creation and `FatFsUtil.cpp` for folder-image syncing.

SDCardUtil manually creates an empty fat32 filesystem *without* a partition table.
FatFsUtil uses an external library which *was* creating a partition table.

"Photo Channel" does not like FatFsUtil's image.
![HAAA01_2024-06-04_15-28-52](https://github.com/dolphin-emu/dolphin/assets/1768214/68159072-0b71-4283-8909-db0ec6a3149b)

This is potentially caused by the partition size being larger than the filesystem size. Or maybe some other sector alignment issue. I stopped investigating.

Anyways, I've added the `FM_SFD` flag (aka Super-Floppy Disk) to stop generation of the partition table.
This makes the behavior between of our two fat32 image generation code paths more similar.

I have plans to eliminate all this redundant fat32 logic. But that is for another PR.