### PR TITLE
GameINI: Ubisoft updates

### DIFF
--- a/Data/Sys/GameSettings/RRB.ini
+++ b/Data/Sys/GameSettings/RRB.ini
@@ -13,5 +13,9 @@ CPUThread = False
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Enhancements]
+ForceTextureFiltering = False
+
 [Video_Settings]
 SuggestedAspectRatio = 2
+SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/RY2.ini
+++ b/Data/Sys/GameSettings/RY2.ini
@@ -1,4 +1,20 @@
 # RY2E41, RY2J41, RY2K41, RY2P41, RY2R41 - Rayman Raving Rabbids 2
 
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Enhancements]
+ForceTextureFiltering = False
+
 [Video_Settings]
 SuggestedAspectRatio = 2
+SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/RY3.ini
+++ b/Data/Sys/GameSettings/RY3.ini
@@ -1,4 +1,17 @@
-# RY3E41, RY3J41, RY3K41, RY3P41 - Rayman Raving Rabbids TV Party
+# RY3E41, RY3J41, RY3K41, RY3P41 - Rayman Raving Rabbids: TV Party
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/SOJ.ini
+++ b/Data/Sys/GameSettings/SOJ.ini
@@ -1,4 +1,4 @@
-# RGWE41, RGWJ41, RGWP41, RGWX41 - Rabbids Go Home
+# SOJE41, SOJP41 - Rayman Origins
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -15,10 +15,5 @@
 [Video_Enhancements]
 ForceTextureFiltering = False
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 0
-
 [Video_Hacks]
-# Fixes visible lines in air vents/fans.
-VertexRounding = True
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/SR4.ini
+++ b/Data/Sys/GameSettings/SR4.ini
@@ -1,4 +1,4 @@
-# RGWE41, RGWJ41, RGWP41, RGWX41 - Rabbids Go Home
+# SR4E41, SR4J41, SR4P41 - Raving Rabbids: Travel in Time
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -14,11 +14,3 @@
 
 [Video_Enhancements]
 ForceTextureFiltering = False
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 0
-
-[Video_Hacks]
-# Fixes visible lines in air vents/fans.
-VertexRounding = True
-ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/SR5.ini
+++ b/Data/Sys/GameSettings/SR5.ini
@@ -1,4 +1,23 @@
 # SR5E41, SR5P41 - Raving Rabbids Party Collection
 
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Enhancements]
+ForceTextureFiltering = False
+
 [Video_Settings]
 SuggestedAspectRatio = 2
+SafeTextureCacheColorSamples = 512
+
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/WR2.ini
+++ b/Data/Sys/GameSettings/WR2.ini
@@ -1,4 +1,4 @@
-# RGWE41, RGWJ41, RGWP41, RGWX41 - Rabbids Go Home
+# WR2E41, WR2P41 - Rabbids Lab
 
 [Core]
 # Values set here will override the main Dolphin settings.


### PR DESCRIPTION
This PR provides a batch of GameINI updates:
- Sets SafeTextureCacheColorSamples to proper values for a few games to fix choppy/pixelated FMVs.
- Disable texture filtering for several games to prevent broken FMVs.
- Disable ImmediateXFBEnable to prevent some potential crashes.
- Add Vertex Rounding to Rabbids Go Home to fix visible lines in fans/air vents (which are common).

I've also added Rabbids Lab since it's currently broken and uses the same codebase as Rabbids Go Home. Also, this game is an unoptimized mess and I would've added more fixes if it weren't for the severely degraded performance.