### PR TITLE
Socket: Fix connect issues when using ReShade

### DIFF
--- a/Source/Core/Common/SocketContext.cpp
+++ b/Source/Core/Common/SocketContext.cpp
@@ -3,6 +3,9 @@
 
 #include "Common/SocketContext.h"
 
+#include "Common/Logging/Log.h"
+#include "Common/Network.h"
+
 namespace Common
 {
 #ifdef _WIN32
@@ -11,7 +14,23 @@ SocketContext::SocketContext()
   std::lock_guard<std::mutex> g(s_lock);
   if (s_num_objects == 0)
   {
-    static_cast<void>(WSAStartup(MAKEWORD(2, 2), &s_data));
+    const int ret = WSAStartup(MAKEWORD(2, 2), &s_data);
+    if (ret == 0)
+    {
+      INFO_LOG_FMT(COMMON, "WSAStartup succeeded, wVersion={}.{}, wHighVersion={}.{}",
+                   int(LOBYTE(s_data.wVersion)), int(HIBYTE(s_data.wVersion)),
+                   int(LOBYTE(s_data.wHighVersion)), int(HIBYTE(s_data.wHighVersion)));
+    }
+    else
+    {
+      // The WSAStartup function directly returns the extended error code in the return value.
+      // A call to the WSAGetLastError function is not needed and should not be used.
+      //
+      // Source:
+      // https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsastartup
+      ERROR_LOG_FMT(COMMON, "WSAStartup failed with error {}: {}", ret,
+                    Common::DecodeNetworkError(ret));
+    }
   }
   s_num_objects++;
 }


### PR DESCRIPTION
This PR fixes online connection issues for people using ReShade. This issue happens when using ReShade with and without addons, including while disabling network hooks.

It seems that the way it injects itself changes sockets behaviour. It might have downgraded the socket version somehow but I wasn't able to find how or when. This PR fixes the issue by handling the WS 1.1 edge case as suggested by Microsoft documentation.

Ready to be reviewed & tested.