### PR TITLE
Suppress extract success message when quiet flag is set

### DIFF
--- a/Source/Core/DolphinTool/ExtractCommand.cpp
+++ b/Source/Core/DolphinTool/ExtractCommand.cpp
@@ -355,7 +355,8 @@ int Extract(const std::vector<std::string>& args)
     return EXIT_FAILURE;
   }
 
-  fmt::println(std::cerr, "Finished Successfully!");
+  if (!quiet)
+    fmt::println(std::cerr, "Finished Successfully!");
   return EXIT_SUCCESS;
 }
 }  // namespace DolphinTool


### PR DESCRIPTION
The `--quiet` flag should suppress all non-error messages. 

---

This change is useful in a personal wrapper I have around `dolphin-tool` (and other extract tools). My wrapper outputs it's own extraction success messages, but allows any warnings/errors to be displayed. Since `dolphin-tool extract` outputs everything to stderr, this PR would negate me having to capture and filter stderr to suppress the success message. displayed immediately. https://github.com/nvllsvm/dotfiles/blob/7456f47280aa7f5e1f7385225c41a5335cba7148/scripts/terminal/archive#L802-L813