### PR TITLE
MainWindow: Fix batch mode (again).

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -346,8 +346,11 @@ MainWindow::~MainWindow()
 
   QSettings& settings = Settings::GetQSettings();
 
-  settings.setValue(QStringLiteral("mainwindow/state"), saveState());
-  settings.setValue(QStringLiteral("mainwindow/geometry"), saveGeometry());
+  if (!Settings::Instance().IsBatchModeEnabled())
+  {
+    settings.setValue(QStringLiteral("mainwindow/state"), saveState());
+    settings.setValue(QStringLiteral("mainwindow/geometry"), saveGeometry());
+  }
 
   settings.setValue(QStringLiteral("renderwidget/geometry"), m_render_widget_geometry);
 


### PR DESCRIPTION
It was erasing the saved UI geometry for when batch mode is off.  Initializing then hiding the window will make sure it re-saves the UI geometry.  If this has an issue, possibly not saving the UI geometry while in batch mode would work.
 
 @Owlet7  can you download this and check for any issues?