### PR TITLE
Jit64: Disable branch merging for SO bit

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -381,7 +381,7 @@ bool Jit64::CheckMergedBranch(u32 crf) const
            ((next.OPCD == 19) && (next.SUBOP10 == 528) /* bcctrx */) ||
            ((next.OPCD == 19) && (next.SUBOP10 == 16) /* bclrx */)) &&
           (next.BO & BO_DONT_DECREMENT_FLAG) && !(next.BO & BO_DONT_CHECK_CONDITION) &&
-          static_cast<u32>(next.BI >> 2) == crf);
+          static_cast<u32>(next.BI >> 2) == crf && (next.BI & 3) != 3 - PowerPC::CR_SO_BIT);
 }
 
 void Jit64::DoMergedBranch()
@@ -476,7 +476,7 @@ void Jit64::DoMergedBranchCondition()
     pDontBranch = J_CC(condition ? CC_NE : CC_E, Jump::Near);
     break;
   case PowerPC::CR_SO_BIT:
-    // SO bit, do not branch (we don't emulate SO for cmp).
+    ASSERT_MSG(DYNA_REC, false, "SO isn't supported for branch merging");
     pDontBranch = J(Jump::Near);
     break;
   }


### PR DESCRIPTION
Dolphin's JITs don't accurately emulate the SO bit of condition registers. However, exactly which inaccurate behavior they end up using depends on whether branch merging is applied. This is in theory a problem for cross-determinism between Jit64 and JitArm64, because JitArm64 doesn't support branch merging. But since games generally don't branch based on the SO bit, I'm not sure if it's a problem in practice.

This commit disables branch merging for the SO bit so that we get the same behavior in Jit64 as in JitArm64.