### PR TITLE
CMake: Fix CCache support when already using _LAUNCHER

### DIFF
--- a/CMake/CCache.cmake
+++ b/CMake/CCache.cmake
@@ -3,17 +3,15 @@ if(CCACHE_BIN)
     # Official ccache recommendation is to set CMAKE_C(XX)_COMPILER_LAUNCHER
     if (NOT CMAKE_C_COMPILER_LAUNCHER MATCHES "ccache")
         list(INSERT CMAKE_C_COMPILER_LAUNCHER 0 "${CCACHE_BIN}")
-        # ccache uses -I when compiling without preprocessor, which makes clang complain.
-        if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-            set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments -fcolor-diagnostics")
-        endif()
     endif()
 
     if (NOT CMAKE_CXX_COMPILER_LAUNCHER MATCHES "ccache")
         list(INSERT CMAKE_CXX_COMPILER_LAUNCHER 0 "${CCACHE_BIN}")
-        # ccache uses -I when compiling without preprocessor, which makes clang complain.
-        if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-            set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments -fcolor-diagnostics")
-        endif()
+    endif()
+
+    # ccache uses -I when compiling without preprocessor, which makes clang complain.
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -fcolor-diagnostics")
     endif()
 endif()

--- a/CMake/CCache.cmake
+++ b/CMake/CCache.cmake
@@ -1,10 +1,19 @@
 find_program(CCACHE_BIN NAMES ccache sccache)
 if(CCACHE_BIN)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_BIN})
+    # Official ccache recommendation is to set CMAKE_C(XX)_COMPILER_LAUNCHER
+    if (NOT CMAKE_C_COMPILER_LAUNCHER MATCHES "ccache")
+        list(INSERT CMAKE_C_COMPILER_LAUNCHER 0 "${CCACHE_BIN}")
+        # ccache uses -I when compiling without preprocessor, which makes clang complain.
+        if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+            set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+        endif()
+    endif()
 
-    # ccache uses -I when compiling without preprocessor, which makes clang complain.
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -fcolor-diagnostics")
-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+    if (NOT CMAKE_CXX_COMPILER_LAUNCHER MATCHES "ccache")
+        list(INSERT CMAKE_CXX_COMPILER_LAUNCHER 0 "${CCACHE_BIN}")
+        # ccache uses -I when compiling without preprocessor, which makes clang complain.
+        if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+            set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+        endif()
     endif()
 endif()


### PR DESCRIPTION
The [official ccache documentation](https://github.com/ccache/ccache/wiki/CMake) recommends to set `CMAKE_C(XX)_COMPILER_LAUNCHER` to ccache to enable ccache. These also work as envionment variables (supported by CMake itself) so one can get use of ccache with every CMake project. However, using these instructions generates the following error during building with dolphin:

    ccache: error: Recursive invocation (the name of the ccache binary must be "ccache")

This is because Dolphin adds an additional command ccache layer (ccache ccache compiler ...).

This fixes that issue by checking for `CMAKE_C(XX)_COMPILER_LAUNCHER` before inserting our own. Also, use `CMAKE_C(XX)_COMPILER_LAUNCHER` to add ccache because the CMake docs discourages the use of `RULE_LAUNCH_COMPILE` in favour of `CMAKE_C(XX)_COMPILER_LAUNCHER`.

Inspired by #11027 (which ended up as basically the same).