### PR TITLE
Disable Emulator Pause In Hardcore Mode

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -72,8 +72,9 @@ void AchievementSettingsWidget::CreateLayout()
          "ensure this experience, the following features will be disabled, as they give emulator "
          "players an advantage over console players:<br>- Loading states<br>-- Saving states is "
          "allowed<br>- Emulator speeds below 100%<br>-- Frame advance is disabled<br>-- Turbo is "
-         "allowed<br>- Cheats<br>- Memory patches<br>-- File patches are allowed<br>- Debug "
-         "UI<br>- Freelook<br><br><dolphin_emphasis>This cannot be turned on while a game is "
+         "allowed<br>- Emulator pause<br>-- In-game pause menus are allowed<br>- Cheats<br>- "
+         "Memory patches<br>-- File patches are allowed<br>- Debug UI<br>- "
+         "Freelook<br><br><dolphin_emphasis>This cannot be turned on while a game is "
          "playing.</dolphin_emphasis><br>Close your current game before enabling.<br>Be aware that "
          "turning Hardcore Mode off while a game is running requires the game to be closed before "
          "re-enabling."));

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -854,7 +854,8 @@ void MainWindow::Play(const std::optional<std::string>& savestate_path)
 
 void MainWindow::Pause()
 {
-  Core::SetState(Core::System::GetInstance(), Core::State::Paused);
+  if (!AchievementManager::GetInstance().IsHardcoreModeActive())
+    Core::SetState(Core::System::GetInstance(), Core::State::Paused);
 }
 
 void MainWindow::TogglePause()

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -110,6 +110,7 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
 {
   bool running = state != Core::State::Uninitialized;
   bool playing = running && state != Core::State::Paused;
+  const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
 
   // File
   m_eject_disc->setEnabled(running);
@@ -118,7 +119,7 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   // Emulation
   m_play_action->setEnabled(!playing);
   m_play_action->setVisible(!playing);
-  m_pause_action->setEnabled(playing);
+  m_pause_action->setEnabled(running && !hardcore);
   m_pause_action->setVisible(playing);
   m_stop_action->setEnabled(running);
   m_stop_action->setVisible(running);
@@ -126,8 +127,6 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   m_fullscreen_action->setEnabled(running);
   m_screenshot_action->setEnabled(running);
   m_state_save_menu->setEnabled(running);
-
-  const bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   m_state_load_menu->setEnabled(running && !hardcore);
   m_frame_advance_action->setEnabled(running && !hardcore);
 

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -9,6 +9,7 @@
 #include <QAction>
 #include <QIcon>
 
+#include "Core/AchievementManager.h"
 #include "Core/Core.h"
 #include "Core/NetPlayProto.h"
 #include "Core/System.h"
@@ -158,6 +159,7 @@ void ToolBar::UpdatePausePlayButtonState(const bool playing_state)
     disconnect(m_pause_play_action, nullptr, nullptr, nullptr);
     m_pause_play_action->setText(tr("Pause"));
     m_pause_play_action->setIcon(Resources::GetThemeIcon("pause"));
+    m_pause_play_action->setEnabled(!AchievementManager::GetInstance().IsHardcoreModeActive());
     connect(m_pause_play_action, &QAction::triggered, this, &ToolBar::PausePressed);
   }
   else


### PR DESCRIPTION
Pausing the emulator (as opposed to pausing the game within the emulator) is considered a potential breach of hardcore mode fairness as it can be exploited to artificially improve reaction times and decrease emulation speed.