### PR TITLE
Release Achievement Manager Loaded Volume

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -642,6 +642,7 @@ void AchievementManager::LeaderboardEntriesCallback(int result, const char* erro
 void AchievementManager::LoadGameCallback(int result, const char* error_message,
                                           rc_client_t* client, void* userdata)
 {
+  AchievementManager::GetInstance().m_loading_volume.reset(nullptr);
   if (result != RC_OK)
   {
     WARN_LOG_FMT(ACHIEVEMENTS, "Failed to load data for current game.");
@@ -672,6 +673,7 @@ void AchievementManager::LoadGameCallback(int result, const char* error_message,
 void AchievementManager::ChangeMediaCallback(int result, const char* error_message,
                                              rc_client_t* client, void* userdata)
 {
+  AchievementManager::GetInstance().m_loading_volume.reset(nullptr);
   if (result == RC_OK)
     return;
 


### PR DESCRIPTION
AchievementManager maintains a unique pointer to a copy of the current volume so it can asynchronously hash that volume. It is not needed otherwise, so I can release that pointer when hashing is complete. This change fixes a bug whereby changing discs in a game and then changing to a different game would result in the loaded volume pointer still being loaded with and hashing to the previous game.