### PR TITLE
VideoCommon: add way to serialize Texture Asset to json, update to deserialize values independently

### DIFF
--- a/Source/Core/VideoCommon/Assets/TextureAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/TextureAsset.cpp
@@ -199,6 +199,61 @@ bool TextureData::FromJson(const CustomAssetLibrary::AssetID& asset_id,
   return true;
 }
 
+void TextureData::ToJson(picojson::object* obj, const TextureData& data)
+{
+  if (!obj) [[unlikely]]
+    return;
+
+  auto& json_obj = *obj;
+  switch (data.m_type)
+  {
+  case TextureData::Type::Type_Texture2D:
+    json_obj.emplace("type", "texture2d");
+    break;
+  case TextureData::Type::Type_TextureCube:
+    json_obj.emplace("type", "texturecube");
+    break;
+  case TextureData::Type::Type_Undefined:
+    break;
+  };
+
+  auto wrap_mode_to_string = [](WrapMode mode) {
+    switch (mode)
+    {
+    case WrapMode::Clamp:
+      return "clamp";
+    case WrapMode::Mirror:
+      return "mirror";
+    case WrapMode::Repeat:
+      return "repeat";
+    };
+
+    return "";
+  };
+  auto filter_mode_to_string = [](FilterMode mode) {
+    switch (mode)
+    {
+    case FilterMode::Linear:
+      return "linear";
+    case FilterMode::Near:
+      return "near";
+    };
+
+    return "";
+  };
+
+  picojson::object wrap_mode;
+  wrap_mode.emplace("u", wrap_mode_to_string(data.m_sampler.tm0.wrap_u));
+  wrap_mode.emplace("v", wrap_mode_to_string(data.m_sampler.tm0.wrap_v));
+  json_obj.emplace("wrap_mode", wrap_mode);
+
+  picojson::object filter_mode;
+  filter_mode.emplace("min", filter_mode_to_string(data.m_sampler.tm0.min_filter));
+  filter_mode.emplace("mag", filter_mode_to_string(data.m_sampler.tm0.mag_filter));
+  filter_mode.emplace("mipmap", filter_mode_to_string(data.m_sampler.tm0.mipmap_filter));
+  json_obj.emplace("filter_mode", filter_mode);
+}
+
 CustomAssetLibrary::LoadInfo GameTextureAsset::LoadImpl(const CustomAssetLibrary::AssetID& asset_id)
 {
   auto potential_data = std::make_shared<TextureData>();

--- a/Source/Core/VideoCommon/Assets/TextureAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/TextureAsset.cpp
@@ -78,11 +78,11 @@ bool ParseSampler(const VideoCommon::CustomAssetLibrary::AssetID& asset_id,
     sampler->tm0.mag_filter = FilterMode::Linear;
     sampler->tm0.mipmap_filter = FilterMode::Linear;
   }
-  else if (sampler_state_filter == "point")
+  else if (sampler_state_filter == "near")
   {
-    sampler->tm0.min_filter = FilterMode::Linear;
-    sampler->tm0.mag_filter = FilterMode::Linear;
-    sampler->tm0.mipmap_filter = FilterMode::Linear;
+    sampler->tm0.min_filter = FilterMode::Near;
+    sampler->tm0.mag_filter = FilterMode::Near;
+    sampler->tm0.mipmap_filter = FilterMode::Near;
   }
   else
   {

--- a/Source/Core/VideoCommon/Assets/TextureAsset.h
+++ b/Source/Core/VideoCommon/Assets/TextureAsset.h
@@ -17,6 +17,7 @@ struct TextureData
 {
   static bool FromJson(const CustomAssetLibrary::AssetID& asset_id, const picojson::object& json,
                        TextureData* data);
+  static void ToJson(picojson::object* obj, const TextureData& data);
   enum class Type
   {
     Type_Undefined,


### PR DESCRIPTION
Finally getting into texture asset sampling tests in my editor branch.  This allows serializing a texture asset to json and also modifies reading from json so that the values (filter mode / wrap mode) are able to be independent.