### PR TITLE
Remove Extra Speed Limit Message

### DIFF
--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -472,9 +472,14 @@ void HotkeyScheduler::Run()
 
       auto ShowEmulationSpeed = []() {
         const float emulation_speed = Config::Get(Config::MAIN_EMULATION_SPEED);
-        OSD::AddMessage(emulation_speed <= 0 ?
-                            "Speed Limit: Unlimited" :
-                            fmt::format("Speed Limit: {}%", std::lround(emulation_speed * 100.f)));
+        if (!AchievementManager::GetInstance().IsHardcoreModeActive() ||
+            Config::Get(Config::MAIN_EMULATION_SPEED) >= 1.0f ||
+            Config::Get(Config::MAIN_EMULATION_SPEED) <= 0.0f)
+        {
+          OSD::AddMessage(emulation_speed <= 0 ? "Speed Limit: Unlimited" :
+                                                 fmt::format("Speed Limit: {}%",
+                                                             std::lround(emulation_speed * 100.f)));
+        }
       };
 
       if (IsHotkey(HK_DECREASE_EMULATION_SPEED))


### PR DESCRIPTION
Prior to this change, attempting to decrease the speed limit below 100% in hardmode would display the new attempted speed and then warn that the speed can not be decreased below 100%; this disables that first message under those conditions.