### PR TITLE
Refactored Challenge Icons to handle icon updates

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -16,6 +16,7 @@
 #include <string_view>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <rcheevos/include/rc_api_runtime.h>
@@ -50,7 +51,6 @@ public:
   static constexpr size_t RP_SIZE = 256;
   using RichPresence = std::array<char, RP_SIZE>;
   using Badge = VideoCommon::CustomTextureData::ArraySlice::Level;
-  using NamedBadgeMap = std::unordered_map<std::string, const Badge*>;
   static constexpr size_t MAX_DISPLAYED_LBOARDS = 4;
 
   static constexpr std::string_view DEFAULT_PLAYER_BADGE_FILENAME = "achievements_player.png";
@@ -116,7 +116,9 @@ public:
   const Badge& GetAchievementBadge(AchievementId id, bool locked) const;
   const LeaderboardStatus* GetLeaderboardInfo(AchievementId leaderboard_id);
   RichPresence GetRichPresence() const;
-  const NamedBadgeMap& GetChallengeIcons() const;
+  const bool AreChallengesUpdated() const;
+  void ResetChallengesUpdated();
+  const std::unordered_set<AchievementId>& GetActiveChallenges() const;
   std::vector<std::string> GetActiveLeaderboards() const;
 
   void DoState(PointerWrap& p);
@@ -203,7 +205,8 @@ private:
   std::chrono::steady_clock::time_point m_last_rp_time = std::chrono::steady_clock::now();
 
   std::unordered_map<AchievementId, LeaderboardStatus> m_leaderboard_map;
-  NamedBadgeMap m_active_challenges;
+  bool m_challenges_updated = false;
+  std::unordered_set<AchievementId> m_active_challenges;
   std::vector<rc_client_leaderboard_tracker_t> m_active_leaderboards;
 
   Common::WorkQueueThread<std::function<void()>> m_queue;

--- a/Source/Core/VideoCommon/OnScreenUI.h
+++ b/Source/Core/VideoCommon/OnScreenUI.h
@@ -76,7 +76,7 @@ private:
   float m_backbuffer_scale = 1.0;
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  std::map<std::string, std::unique_ptr<AbstractTexture>, std::less<>> m_challenge_texture_map;
+  std::map<int, std::unique_ptr<AbstractTexture>, std::less<>> m_challenge_texture_map;
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   bool m_ready = false;


### PR DESCRIPTION
If an icon is displayed on screen before it downloads, it was displaying a default icon but it would fail to load the actual icon even after it was downloaded. This fixes that.