### PR TITLE
Only Display One Progress At A Time

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -812,11 +812,16 @@ void AchievementManager::HandleAchievementChallengeIndicatorHideEvent(
 void AchievementManager::HandleAchievementProgressIndicatorShowEvent(
     const rc_client_event_t* client_event)
 {
-  const auto& instance = AchievementManager::GetInstance();
+  auto& instance = AchievementManager::GetInstance();
+  auto current_time = std::chrono::steady_clock::now();
+  const auto message_wait_time = std::chrono::milliseconds{OSD::Duration::SHORT};
+  if (current_time - instance.m_last_progress_message < message_wait_time)
+    return;
   OSD::AddMessage(fmt::format("{} {}", client_event->achievement->title,
                               client_event->achievement->measured_progress),
                   OSD::Duration::SHORT, OSD::Color::GREEN,
                   &instance.GetAchievementBadge(client_event->achievement->id, false));
+  instance.m_last_progress_message = current_time;
 }
 
 void AchievementManager::HandleGameCompletedEvent(const rc_client_event_t* client_event,

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -201,6 +201,7 @@ private:
   std::unordered_map<AchievementId, Badge> m_locked_badges;
   RichPresence m_rich_presence;
   std::chrono::steady_clock::time_point m_last_rp_time = std::chrono::steady_clock::now();
+  std::chrono::steady_clock::time_point m_last_progress_message = std::chrono::steady_clock::now();
 
   std::unordered_map<AchievementId, LeaderboardStatus> m_leaderboard_map;
   NamedBadgeMap m_active_challenges;


### PR DESCRIPTION
Add a two second timer to Achievement Progress Indicators to wait until two seconds after the previous message (when it should have decayed out automatically) before posting any new ones.