### PR TITLE
Fix RPI 4/5 Vulkan Hardware support

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
@@ -156,6 +156,10 @@ bool StagingBuffer::AllocateBuffer(STAGING_BUFFER_TYPE type, VkDeviceSize size,
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     alloc_create_info.preferredFlags = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
   }
+  else if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_CREATE_HOST_ACCESS_RANDOM_BIT))
+  {
+    alloc_create_info.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+  }
   else
   {
     if (type == STAGING_BUFFER_TYPE_UPLOAD)

--- a/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
@@ -156,16 +156,21 @@ bool StagingBuffer::AllocateBuffer(STAGING_BUFFER_TYPE type, VkDeviceSize size,
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     alloc_create_info.preferredFlags = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
   }
-  else if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_CREATE_HOST_ACCESS_RANDOM_BIT))
-  {
-    alloc_create_info.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
-  }
   else
   {
     if (type == STAGING_BUFFER_TYPE_UPLOAD)
       alloc_create_info.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
     else
-      alloc_create_info.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
+    {
+      if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_CREATE_HOST_ACCESS_RANDOM_BIT))
+      {
+	    alloc_create_info.requiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+        alloc_create_info.requiredFlags |= VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        alloc_create_info.preferredFlags = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+      }
+      else
+        alloc_create_info.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
+    }
   }
 
   VmaAllocationInfo alloc_info;

--- a/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
@@ -164,7 +164,7 @@ bool StagingBuffer::AllocateBuffer(STAGING_BUFFER_TYPE type, VkDeviceSize size,
     {
       if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_CREATE_HOST_ACCESS_RANDOM_BIT))
       {
-	    alloc_create_info.requiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+        alloc_create_info.requiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
         alloc_create_info.requiredFlags |= VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
         alloc_create_info.preferredFlags = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
       }

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -950,6 +950,20 @@ void VulkanContext::InitDriverDetails()
     vendor = DriverDetails::VENDOR_APPLE;
     driver = DriverDetails::DRIVER_PORTABILITY;
   }
+  else if (vendor_id == 0x14E4)
+  {
+    // Official Broadcom binary driver
+    vendor = DriverDetails::VENDOR_BROADCOM;
+    driver = DriverDetails::DRIVER_BROADCOM;
+
+    if (device_name.find("V3D") != std::string::npos)
+    {
+      // Raspberry Pi use Broadcom VideoCore GPU drivers:
+      //  - RPI 4: DeviceName "V3D 4.2"
+      //  - RPI 5: DeviceName "V3D 7.1"
+      driver = DriverDetails::DRIVER_RPI;
+    }
+  }
   else
   {
     WARN_LOG_FMT(VIDEO, "Unknown Vulkan driver vendor, please report it to us.");

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -158,6 +158,8 @@ constexpr BugInfo m_known_bugs[] = {
      BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING, -1.0, -1.0, true},
     {API_VULKAN, OS_ANDROID, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN,
      BUG_SLOW_OPTIMAL_IMAGE_TO_BUFFER_COPY, -1.0, -1.0, true},
+    {API_VULKAN, OS_ALL, VENDOR_BROADCOM, DRIVER_RPI, Family::UNKNOWN,
+     BUG_SLOW_CACHED_READBACK_MEMORY, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;
@@ -260,6 +262,8 @@ static const char* to_string(Driver driver)
     case DRIVER_VIVANTE:     return "Vivante";
     case DRIVER_PORTABILITY: return "Portability";
     case DRIVER_APPLE:       return "Apple";
+    case DRIVER_BROADCOM:    return "Broadcom";
+    case DRIVER_RPI:         return "Broadcom Videocore";
     case DRIVER_UNKNOWN:     return "Unknown";
   }
   return "Unknown";

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -159,7 +159,7 @@ constexpr BugInfo m_known_bugs[] = {
     {API_VULKAN, OS_ANDROID, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN,
      BUG_SLOW_OPTIMAL_IMAGE_TO_BUFFER_COPY, -1.0, -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_BROADCOM, DRIVER_RPI, Family::UNKNOWN,
-     BUG_SLOW_CACHED_READBACK_MEMORY, -1.0, -1.0, true},
+     BUG_BROKEN_CREATE_HOST_ACCESS_RANDOM_BIT, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;
@@ -301,6 +301,7 @@ static const char* to_string(Bug bug)
     case BUG_BROKEN_DISCARD_WITH_EARLY_Z:                return "broken-discard-with-early-z";
     case BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING:            return "broken-dynamic-sampler-indexing";
     case BUG_SLOW_OPTIMAL_IMAGE_TO_BUFFER_COPY:          return "slow-optimal-image-to-buffer-copy";
+    case BUG_BROKEN_CREATE_HOST_ACCESS_RANDOM_BIT:       return "broken-create-host-access-random-bit";
   }
   return "Unknown";
 }

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -46,6 +46,7 @@ enum Vendor
   VENDOR_VIVANTE,
   VENDOR_MESA,
   VENDOR_APPLE,
+  VENDOR_BROADCOM,
   VENDOR_UNKNOWN
 };
 
@@ -67,6 +68,8 @@ enum Driver
   DRIVER_VIVANTE,      // Official Vivante driver
   DRIVER_PORTABILITY,  // Vulkan via Metal on macOS
   DRIVER_APPLE,        // Metal on macOS
+  DRIVER_BROADCOM,     // Official Broadcom driver
+  DRIVER_RPI,          // Raspberry Pi Broadcom Videocore drivers
   DRIVER_UNKNOWN       // Unknown driver, default to official hardware driver
 };
 

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -349,7 +349,8 @@ enum Bug
 
   // BUG: Vulkan vmaCreateBuffer fails to allocate a memory buffer with error
   // VK_FEATURE_NOT_PRESENT when requesting memory with flag
-  // VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT
+  // VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT because it has no available
+  // video memory satisfying all HOST_VISIBLE, HOST_COHERENT, HOST_CACHED bits
   // Affected devices: Broadcom Videocore 6/7
   // Started Version: -1
   // Ended Version: -1

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -345,7 +345,15 @@ enum Bug
   // Affected devices: Adreno
   // Started Version: -1
   // Ended Version: -1
-  BUG_SLOW_OPTIMAL_IMAGE_TO_BUFFER_COPY
+  BUG_SLOW_OPTIMAL_IMAGE_TO_BUFFER_COPY,
+
+  // BUG: Vulkan vmaCreateBuffer fails to allocate a memory buffer with error
+  // VK_FEATURE_NOT_PRESENT when requesting memory with flag
+  // VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT
+  // Affected devices: Broadcom Videocore 6/7
+  // Started Version: -1
+  // Ended Version: -1
+  BUG_BROKEN_CREATE_HOST_ACCESS_RANDOM_BIT
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
**What happened:** 
Vulkan backend through hardware support in Raspberry Pi 4 and Raspberry Pi 5 was failing in master latest because the `vmaCreateBuffer` call in `Core/VideoBackends/Vulkan/StagingBuffer.cpp`:168 was returning `VK_ERROR_FEATURE_NOT_PRESENT` when a buffer was requested with flag `VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT` because there is no memory available for vulkan lib with `HOST_CACHED` bit set. This might be a limitation of the hardware itself.

**What was done:** 
Broadcom vendor and driver was added to `Core/VideoCommon/DriverDetails.h` and appropriate vendor/driver detection code was added to `Core/VideoBackends/Vulkan/VulkanContext.cpp`. A new bug was also declared into `Core/VideoCommon/DriverDetails.cpp` so RPI4 Broadcom Videocore 6 and RPI5 Broadcom Videocore 7 drivers are assigned `BUG_BROKEN_CREATE_HOST_ACCESS_RANDOM_BIT`. Afterwards, in `Core/VideoBackends/Vulkan/StagingBuffer.cpp`:165 this bug is tested to set the `HOST_CACHED` bit as preferred rather than required.

**What it does:** 
This allows vulkan library to find compatible memory to allocate the buffer and thus return `VK_SUCCESS`. If in the future, Broadcom, the RPI dev team or anyone else make `HOST_CACHED` memory available to vulkan lib, the preferred setting should make `vmaCreateBuffer` allocate it as such, improving performance.

**Tested with:** 
My own RPI5 using `Vulkan 1.3.211` and `mesa-vulkan-drivers` package version `23.2.1-1~bpo12+rpt3` in official RPI OS (Debian Bookworm). RPI4 testers needed. Dolphin logs still warn dolphin is using Vulkan 1.1 while card supports Vulkan 1.3 but that should be OK for now.