### PR TITLE
Add Sorting to Achievements Dialog

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
@@ -44,12 +44,13 @@ void AchievementLeaderboardWidget::UpdateData(bool clean_all)
       return;
     auto* client = instance.GetClient();
     auto* leaderboard_list =
-        rc_client_create_leaderboard_list(client, RC_CLIENT_LEADERBOARD_LIST_GROUPING_NONE);
+        rc_client_create_leaderboard_list(client, RC_CLIENT_LEADERBOARD_LIST_GROUPING_TRACKING);
 
     u32 row = 0;
     for (u32 bucket = 0; bucket < leaderboard_list->num_buckets; bucket++)
     {
       const auto& leaderboard_bucket = leaderboard_list->buckets[bucket];
+      m_common_layout->addWidget(new QLabel(tr(leaderboard_bucket.label)));
       for (u32 board = 0; board < leaderboard_bucket.num_leaderboards; board++)
       {
         const auto* leaderboard = leaderboard_bucket.leaderboards[board];

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
@@ -49,9 +49,10 @@ void AchievementProgressWidget::UpdateData(bool clean_all)
     auto* client = instance.GetClient();
     auto* achievement_list = rc_client_create_achievement_list(
         client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE_AND_UNOFFICIAL,
-        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS);
     for (u32 ix = 0; ix < achievement_list->num_buckets; ix++)
     {
+      m_common_layout->addWidget(new QLabel(tr(achievement_list->buckets[ix].label)));
       for (u32 jx = 0; jx < achievement_list->buckets[ix].num_achievements; jx++)
       {
         auto* achievement = achievement_list->buckets[ix].achievements[jx];


### PR DESCRIPTION
rc_client provides basic sorting buckets as a possible option when retrieving the list of achievements or leaderboards; this enables them and labels them in the dialog.