### PR TITLE
DolphinQt: Adjust CPU Clock Override slider

### DIFF
--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -100,7 +100,7 @@ void AdvancedPane::CreateLayout()
   clock_override_layout->addLayout(cpu_clock_override_slider_layout);
 
   m_cpu_clock_override_slider = new QSlider(Qt::Horizontal);
-  m_cpu_clock_override_slider->setRange(0, 150);
+  m_cpu_clock_override_slider->setRange(1, 400);
   cpu_clock_override_slider_layout->addWidget(m_cpu_clock_override_slider);
 
   m_cpu_clock_override_slider_label = new QLabel();
@@ -203,8 +203,7 @@ void AdvancedPane::ConnectLayout()
   });
 
   connect(m_cpu_clock_override_slider, &QSlider::valueChanged, [this](int oc_factor) {
-    // Vaguely exponential scaling?
-    const float factor = std::exp2f((m_cpu_clock_override_slider->value() - 100.f) / 25.f);
+    const float factor = m_cpu_clock_override_slider->value() / 100.f;
     Config::SetBaseOrCurrent(Config::MAIN_OVERCLOCK, factor);
     Update();
   });
@@ -271,8 +270,8 @@ void AdvancedPane::Update()
 
   {
     const QSignalBlocker blocker(m_cpu_clock_override_slider);
-    m_cpu_clock_override_slider->setValue(static_cast<int>(
-        std::round(std::log2f(Config::Get(Config::MAIN_OVERCLOCK)) * 25.f + 100.f)));
+    m_cpu_clock_override_slider->setValue(
+        static_cast<int>(std::round(Config::Get(Config::MAIN_OVERCLOCK) * 100.f)));
   }
 
   m_cpu_clock_override_slider_label->setText([] {


### PR DESCRIPTION
CPU Clock Override slider now increments 1% in the UI, with the new lower limit being 1% instead of 6%.
Prior implementation made it impossible to set exactly 150% in the GUI. 147% -> 152%.
Now users can set exact clock % without needing to edit INIs.

The upper limit of 400% is unchanged.
The lower limit of 6% is now 1%.
The INI value behavior is unchanged.

For testing, navigate to:
Config -> Advanced -> Clock Override

This is a DolphinQt change only so Android is unchanged. Android can already slide from 0% to 400% at 1% increments.