### PR TITLE
Update Achievement List when Rich Presence Updates

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
@@ -61,33 +61,36 @@ AchievementBox::AchievementBox(QWidget* parent, rc_client_achievement_t* achieve
 
 void AchievementBox::UpdateData()
 {
-  std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
-  // rc_client guarantees m_achievement will be valid as long as the game is loaded
-  if (!AchievementManager::GetInstance().IsGameLoaded())
-    return;
-
-  const auto& badge = AchievementManager::GetInstance().GetAchievementBadge(
-      m_achievement->id, m_achievement->state != RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED);
-  std::string_view color = AchievementManager::GRAY;
-  if (m_achievement->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE)
-    color = AchievementManager::GOLD;
-  else if (m_achievement->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE)
-    color = AchievementManager::BLUE;
-  QImage i_badge(&badge.data.front(), badge.width, badge.height, QImage::Format_RGBA8888);
-  m_badge->setPixmap(
-      QPixmap::fromImage(i_badge).scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
-  m_badge->adjustSize();
-  m_badge->setStyleSheet(QStringLiteral("border: 4px solid %1").arg(QtUtils::FromStdString(color)));
-
-  if (m_achievement->state == RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED)
   {
-    m_status->setText(
-        tr("Unlocked at %1")
-            .arg(QDateTime::fromSecsSinceEpoch(m_achievement->unlock_time).toString()));
-  }
-  else
-  {
-    m_status->setText(tr("Locked"));
+    std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
+    // rc_client guarantees m_achievement will be valid as long as the game is loaded
+    if (!AchievementManager::GetInstance().IsGameLoaded())
+      return;
+
+    const auto& badge = AchievementManager::GetInstance().GetAchievementBadge(
+        m_achievement->id, m_achievement->state != RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED);
+    std::string_view color = AchievementManager::GRAY;
+    if (m_achievement->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE)
+      color = AchievementManager::GOLD;
+    else if (m_achievement->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE)
+      color = AchievementManager::BLUE;
+    QImage i_badge(&badge.data.front(), badge.width, badge.height, QImage::Format_RGBA8888);
+    m_badge->setPixmap(
+        QPixmap::fromImage(i_badge).scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+    m_badge->adjustSize();
+    m_badge->setStyleSheet(
+        QStringLiteral("border: 4px solid %1").arg(QtUtils::FromStdString(color)));
+
+    if (m_achievement->state == RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED)
+    {
+      m_status->setText(
+          tr("Unlocked at %1")
+              .arg(QDateTime::fromSecsSinceEpoch(m_achievement->unlock_time).toString()));
+    }
+    else
+    {
+      m_status->setText(tr("Locked"));
+    }
   }
 
   UpdateProgress();

--- a/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
@@ -62,6 +62,9 @@ AchievementBox::AchievementBox(QWidget* parent, rc_client_achievement_t* achieve
 void AchievementBox::UpdateData()
 {
   std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
+  // rc_client guarantees m_achievement will be valid as long as the game is loaded
+  if (!AchievementManager::GetInstance().IsGameLoaded())
+    return;
 
   const auto& badge = AchievementManager::GetInstance().GetAchievementBadge(
       m_achievement->id, m_achievement->state != RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED);
@@ -92,6 +95,11 @@ void AchievementBox::UpdateData()
 
 void AchievementBox::UpdateProgress()
 {
+  std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
+  // rc_client guarantees m_achievement will be valid as long as the game is loaded
+  if (!AchievementManager::GetInstance().IsGameLoaded())
+    return;
+
   if (m_achievement->measured_percent > 0.000)
   {
     m_progress_bar->setRange(0, 100);

--- a/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
@@ -87,6 +87,11 @@ void AchievementBox::UpdateData()
     m_status->setText(tr("Locked"));
   }
 
+  UpdateProgress();
+}
+
+void AchievementBox::UpdateProgress()
+{
   if (m_achievement->measured_percent > 0.000)
   {
     m_progress_bar->setRange(0, 100);

--- a/Source/Core/DolphinQt/Achievements/AchievementBox.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementBox.h
@@ -20,6 +20,7 @@ class AchievementBox final : public QGroupBox
 public:
   explicit AchievementBox(QWidget* parent, rc_client_achievement_t* achievement);
   void UpdateData();
+  void UpdateProgress();
 
 private:
   QLabel* m_badge;

--- a/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementProgressWidget.cpp
@@ -42,33 +42,47 @@ void AchievementProgressWidget::UpdateData(bool clean_all)
   {
     m_achievement_boxes.clear();
     ClearLayoutRecursively(m_common_layout);
-
-    auto& instance = AchievementManager::GetInstance();
-    if (!instance.IsGameLoaded())
-      return;
-    auto* client = instance.GetClient();
-    auto* achievement_list = rc_client_create_achievement_list(
-        client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE_AND_UNOFFICIAL,
-        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS);
-    for (u32 ix = 0; ix < achievement_list->num_buckets; ix++)
-    {
-      m_common_layout->addWidget(new QLabel(tr(achievement_list->buckets[ix].label)));
-      for (u32 jx = 0; jx < achievement_list->buckets[ix].num_achievements; jx++)
-      {
-        auto* achievement = achievement_list->buckets[ix].achievements[jx];
-        m_achievement_boxes[achievement->id] = std::make_shared<AchievementBox>(this, achievement);
-        m_common_layout->addWidget(m_achievement_boxes[achievement->id].get());
-      }
-    }
-    rc_client_destroy_achievement_list(achievement_list);
   }
   else
   {
-    for (auto box : m_achievement_boxes)
+    while (auto* item = m_common_layout->takeAt(0))
     {
-      box.second->UpdateData();
+      auto* widget = item->widget();
+      m_common_layout->removeWidget(widget);
+      if (std::strcmp(widget->metaObject()->className(), "QLabel") == 0)
+      {
+        delete widget;
+        delete item;
+      }
     }
   }
+
+  auto& instance = AchievementManager::GetInstance();
+  if (!instance.IsGameLoaded())
+    return;
+  auto* client = instance.GetClient();
+  auto* achievement_list =
+      rc_client_create_achievement_list(client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE_AND_UNOFFICIAL,
+                                        RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS);
+  for (u32 ix = 0; ix < achievement_list->num_buckets; ix++)
+  {
+    m_common_layout->addWidget(new QLabel(tr(achievement_list->buckets[ix].label)));
+    for (u32 jx = 0; jx < achievement_list->buckets[ix].num_achievements; jx++)
+    {
+      auto* achievement = achievement_list->buckets[ix].achievements[jx];
+      auto box_itr = m_achievement_boxes.find(achievement->id);
+      if (box_itr == m_achievement_boxes.end())
+      {
+        m_achievement_boxes[achievement->id] = std::make_shared<AchievementBox>(this, achievement);
+      }
+      else
+      {
+        box_itr->second->UpdateProgress();
+      }
+      m_common_layout->addWidget(m_achievement_boxes[achievement->id].get());
+    }
+  }
+  rc_client_destroy_achievement_list(achievement_list);
 }
 
 void AchievementProgressWidget::UpdateData(

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -89,7 +89,7 @@ void AchievementsWindow::UpdateData(AchievementManager::UpdatedItems updated_ite
     {
       m_header_widget->UpdateData();
     }
-    if (updated_items.all_achievements)
+    if (updated_items.all_achievements || updated_items.rich_presence)
       m_progress_widget->UpdateData(false);
     else if (updated_items.achievements.size() > 0)
       m_progress_widget->UpdateData(updated_items.achievements);


### PR DESCRIPTION
Due to the new events provided by the rc_client refactor, there is no way to easily identify if an achievement has moved to a different sort bucket or if its measured value has changed - the events concern popup messages specifically, because every other supported emulator at this time can only bring up the list of achievements while the game is paused and therefore redraw this list from scratch every time it is accessed. This is not the case with Dolphin, so if this list will be kept reasonably up to date with the current game state, it needs to be refreshed manually. Here I set this up to do so whenever the Rich Presence updates, which internally happens every ten seconds.