### PR TITLE
Decouple Hardcore from EmulationStateChanged

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -237,7 +237,10 @@ void AchievementSettingsWidget::ToggleRAIntegration()
   else
     instance.Shutdown();
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  {
     emit Settings::Instance().EmulationStateChanged(Core::GetState(Core::System::GetInstance()));
+    emit Settings::Instance().HardcoreStateChanged();
+  }
 }
 
 void AchievementSettingsWidget::Login()
@@ -267,6 +270,7 @@ void AchievementSettingsWidget::ToggleHardcore()
     Settings::Instance().SetDebugModeEnabled(false);
   }
   emit Settings::Instance().EmulationStateChanged(Core::GetState(Core::System::GetInstance()));
+  emit Settings::Instance().HardcoreStateChanged();
 }
 
 void AchievementSettingsWidget::ToggleUnofficial()

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -34,6 +34,8 @@ AchievementsWindow::AchievementsWindow(QWidget* parent) : QDialog(parent)
         });
       });
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
+          [this] { m_settings_widget->UpdateData(); });
+  connect(&Settings::Instance(), &Settings::HardcoreStateChanged, this,
           [this] { AchievementsWindow::UpdateData({.all = true}); });
 }
 

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -224,6 +224,7 @@ signals:
   void SDCardInsertionChanged(bool inserted);
   void USBKeyboardConnectionChanged(bool connected);
   void EnableGfxModsChanged(bool enabled);
+  void HardcoreStateChanged();
 
 private:
   Settings();


### PR DESCRIPTION
Rerendering the entire Achievements dialog every EmulationStateChanged signal is far too often when it turns out that signal fires multiple times to confirm game close, for example. This change results in only the settings changing on EmulationStateChanged, and having the Hardcore mode toggle (which DOES require redrawing the entire dialog) emit its own signal alongside EmulationStateChanged.