### PR TITLE
Trim extra characters from measured progress

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
@@ -4,6 +4,7 @@
 #ifdef USE_RETRO_ACHIEVEMENTS
 #include "DolphinQt/Achievements/AchievementBox.h"
 
+#include <QByteArray>
 #include <QDateTime>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -92,7 +93,9 @@ void AchievementBox::UpdateData()
     m_progress_bar->setRange(0, 100);
     m_progress_bar->setValue(m_achievement->measured_percent);
     m_progress_bar->setTextVisible(false);
-    m_progress_label->setText(QString::fromUtf8(m_achievement->measured_progress, PROGRESS_LENGTH));
+    m_progress_label->setText(
+        QString::fromUtf8(m_achievement->measured_progress,
+                          qstrnlen(m_achievement->measured_progress, PROGRESS_LENGTH)));
     m_progress_bar->setVisible(true);
   }
   else


### PR DESCRIPTION
The measured_progress C string for achievements to display potentially contains junk data after the null terminator, which was rendering in the QString in the dialog. This trims those junk characters.