### PR TITLE
Make achievement progress text label transparent

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
@@ -40,6 +40,7 @@ AchievementBox::AchievementBox(QWidget* parent, rc_client_achievement_t* achieve
   sp_retain.setRetainSizeWhenHidden(true);
   m_progress_bar->setSizePolicy(sp_retain);
   m_progress_label = new QLabel();
+  m_progress_label->setStyleSheet(QStringLiteral("background-color:transparent;"));
   m_progress_label->setAlignment(Qt::AlignCenter);
 
   QVBoxLayout* a_col_right = new QVBoxLayout();


### PR DESCRIPTION
This field was completely hiding the progress bar in dark mode without this.