### PR TITLE
GameINI: Shadow The Hedgehog widescreen heuristic

### DIFF
--- a/Data/Sys/GameSettings/GUP.ini
+++ b/Data/Sys/GameSettings/GUP.ini
@@ -15,5 +15,10 @@
 [Video_Hacks]
 VertexRounding = True
 
+[Video_Settings]
+WidescreenHeuristicStandardRatio = 0.91
+WidescreenHeuristicWidescreenRatio = 1.21
+WidescreenHeuristicAspectRatioSlop = 0.15
+
 [Video_Stereoscopy]
 StereoConvergence = 1


### PR DESCRIPTION
Adjusts widescreen heuristic values to work properly for both the original game and the widescreen hack versions.

---

Prior behavior: While using a widescreen hack (not dolphin's built in one), when the camera skews the aspect would incorrectly change to 4:3. Only restoring to 16:9 when a subtitle renders.

https://github.com/dolphin-emu/dolphin/assets/14857235/574971f1-270b-4c51-8461-460bb3c34d07

After behavior:
* Original game continues to stay in 4:3, including alternate viewport modes such as 2P split screen.
* Widescreen hack applied variants properly stay in 16:9 in all cases.

* Tested against widescreen hack variants of the game, works as expected.
* Tested original game

Credit to Billiard for determining values.