### PR TITLE
Add Approved Patch Allowlist for Achievements

### DIFF
--- a/Data/Sys/ApprovedInis.json
+++ b/Data/Sys/ApprovedInis.json
@@ -1,0 +1,31 @@
+{
+  "GCCE01" : {
+    "title" : "FINAL FANTASY Crystal Chronicles",
+    "6C107FEC15C76201233CA2645EB5FAB4FF9751CE" : "Fix buffer overrun bug (crash at Goblin Wall)",
+    "483BDB94615C690045C3759795AF13CE76552286" : "Fix GBA connections"
+  },
+  "GHAE08" : {
+    "title" : "Resident Evil 2",
+    "9799AFF8463EC86C9230E31E2627E141F0C129D3" : "Fix audio issues"
+  },
+  "GHAJ08" : {
+    "title" : "Biohazard 2",
+    "B45A8FC32D14567B8D6C95F303E00A72C0E1D344" : "Fix audio issues"
+  },
+  "GHAP08" : {
+    "title" : "Resident Evil 2",
+    "BC7F3CFC97593AA2055C370C175950DC478D2709" : "Fix audio issues"
+  },
+  "GLEE08" : {
+    "title" : "Resident Evil 3: Nemesis",
+    "7355F358CAC6F418D37E4C23E64F7867D46E4FC9" : "Fix audio issues"
+  },
+  "GLEJ08" : {
+    "title" : "BioHazard 3: Last Escape",
+    "12B24A6D7389A2AC5AB75FC0BF8493E7661F2A73" : "Fix audio issues"
+  },
+  "GLEP08" : {
+    "title" : "Resident Evil 3: Nemesis",
+    "81BD39F5527552DE89E3B59BA86298900F0A3168" : "Fix audio issues"
+  }
+}

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -14,6 +14,7 @@
 #include <rcheevos/include/rc_hash.h>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -26,6 +27,7 @@
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/VideoInterface.h"
+#include "Core/PatchEngine.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/System.h"
 #include "DiscIO/Blob.h"
@@ -68,6 +70,34 @@ void AchievementManager::Init()
       Login("");
     INFO_LOG_FMT(ACHIEVEMENTS, "Achievement Manager Initialized");
   }
+}
+
+void AchievementManager::LoadApprovedList()
+{
+  picojson::value temp;
+  std::string error;
+  if (!JsonFromFile(fmt::format("{}{}{}", File::GetSysDirectory(), DIR_SEP, APPROVED_LIST_FILENAME),
+                    &temp, &error))
+  {
+    WARN_LOG_FMT(ACHIEVEMENTS, "Failed to load approved game settings list {}",
+                 APPROVED_LIST_FILENAME);
+    WARN_LOG_FMT(ACHIEVEMENTS, "Error: {}", error);
+    return;
+  }
+  auto context = Common::SHA1::CreateContext();
+  context->Update(temp.serialize());
+  auto digest = context->Finish();
+  if (digest != APPROVED_LIST_HASH)
+  {
+    WARN_LOG_FMT(ACHIEVEMENTS, "Failed to verify approved game settings list {}",
+                 APPROVED_LIST_FILENAME);
+    WARN_LOG_FMT(ACHIEVEMENTS, "Expected hash {}, found hash {}",
+                 Common::SHA1::DigestToString(APPROVED_LIST_HASH),
+                 Common::SHA1::DigestToString(digest));
+    return;
+  }
+  std::lock_guard lg{m_lock};
+  m_ini_root = temp;
 }
 
 void AchievementManager::SetUpdateCallback(UpdateCallback callback)
@@ -320,6 +350,48 @@ bool AchievementManager::IsHardcoreModeActive() const
   if (!rc_client_get_game_info(m_client))
     return true;
   return rc_client_is_processing_required(m_client);
+}
+
+void AchievementManager::FilterApprovedPatches(std::vector<PatchEngine::Patch>& patches,
+                                               const std::string& game_ini_id) const
+{
+  if (!IsHardcoreModeActive())
+    return;
+
+  if (!m_ini_root.contains(game_ini_id))
+    patches.clear();
+  auto patch_itr = patches.begin();
+  while (patch_itr < patches.end())
+  {
+    INFO_LOG_FMT(ACHIEVEMENTS, "Verifying patch {}", patch_itr->name);
+
+    auto context = Common::SHA1::CreateContext();
+    context->Update(Common::BitCastToArray<u8>(static_cast<u64>(patch_itr->entries.size())));
+    for (const auto& entry : patch_itr->entries)
+    {
+      context->Update(Common::BitCastToArray<u8>(entry.type));
+      context->Update(Common::BitCastToArray<u8>(entry.address));
+      context->Update(Common::BitCastToArray<u8>(entry.value));
+      context->Update(Common::BitCastToArray<u8>(entry.comparand));
+      context->Update(Common::BitCastToArray<u8>(entry.conditional));
+    }
+    auto digest = context->Finish();
+
+    bool verified = m_ini_root.get(game_ini_id).contains(Common::SHA1::DigestToString(digest));
+    if (!verified)
+    {
+      patches.erase(patch_itr);
+      OSD::AddMessage(
+          fmt::format("Failed to verify patch {} from file {}.", patch_itr->name, game_ini_id),
+          OSD::Duration::VERY_LONG, OSD::Color::RED);
+      OSD::AddMessage("Disable hardcore mode to enable this patch.", OSD::Duration::VERY_LONG,
+                      OSD::Color::RED);
+    }
+    else
+    {
+      patch_itr++;
+    }
+  }
 }
 
 void AchievementManager::SetSpectatorMode()

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -182,6 +182,13 @@ void LoadPatches()
 
   LoadPatchSection("OnFrame", &s_on_frame, globalIni, localIni);
 
+#ifdef USE_RETRO_ACHIEVEMENTS
+  {
+    std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
+    AchievementManager::GetInstance().FilterApprovedPatches(s_on_frame, sconfig.GetGameID());
+  }
+#endif  // USE_RETRO_ACHIEVEMENTS
+
   // Check if I'm syncing Codes
   if (Config::Get(Config::SESSION_CODE_SYNC_OVERRIDE))
   {
@@ -197,9 +204,6 @@ void LoadPatches()
 
 static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Patch>& patches)
 {
-  if (AchievementManager::GetInstance().IsHardcoreModeActive())
-    return;
-
   for (const Patch& patch : patches)
   {
     if (patch.enabled)


### PR DESCRIPTION
Prototype of a system to whitelist known game patches that are allowed to be used while RetroAchievements Hardcore mode is active. ApprovedInis.txt contains known hashes for the ini files as they appear in the repo, and can be compared to the local versions of these files to ensure they have not been edited locally by the player. ApprovedInis.txt is hashed and verified similarly first, with its hash residing as a const string within AchievementManager.h, ensuring ApprovedInis and the hashes within cannot be modified without editing Dolphin's source code and recompiling completely.