### PR TITLE
Core/VideoCommon: Revert change from #12828

### DIFF
--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -66,12 +66,15 @@ void VideoConfig::Refresh()
     CPUThreadConfigCallback::AddConfigChangedCallback([]() {
       auto& system = Core::System::GetInstance();
 
-      system.GetFifo().PauseAndLock(true, false);
+      const bool lock_gpu_thread = Core::IsRunning(system);
+      if (lock_gpu_thread)
+        system.GetFifo().PauseAndLock(true, false);
 
       g_Config.Refresh();
       g_Config.VerifyValidity();
 
-      system.GetFifo().PauseAndLock(false, true);
+      if (lock_gpu_thread)
+        system.GetFifo().PauseAndLock(false, true);
     });
     s_has_registered_callback = true;
   }


### PR DESCRIPTION
This causes Dual Core to lock up during the boot sequence, because it tries to wait for a not-yet-running GPU thread.

Fixes https://bugs.dolphin-emu.org/issues/13559