### PR TITLE
DolphinQt: avoid scrolling while game list is being modified

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -320,6 +320,8 @@ add_executable(dolphin-emu
   QtUtils/SignalBlocking.h
   QtUtils/UTF8CodePointCountValidator.cpp
   QtUtils/UTF8CodePointCountValidator.h
+  QtUtils/ViewportLock.cpp
+  QtUtils/ViewportLock.h
   QtUtils/WindowActivationEventFilter.cpp
   QtUtils/WindowActivationEventFilter.h
   QtUtils/WrapInScrollArea.cpp

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -59,8 +59,6 @@
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 #include "InputCommon/InputConfig.h"
 
-constexpr const char* PROFILES_DIR = "Profiles/";
-
 MappingWindow::MappingWindow(QWidget* parent, Type type, int port_num)
     : QDialog(parent), m_port(port_num)
 {

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -67,6 +67,7 @@
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
 #include "DolphinQt/QtUtils/SetWindowDecorations.h"
+#include "DolphinQt/QtUtils/ViewportLock.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/WiiUpdate.h"
@@ -115,6 +116,8 @@ GameList::GameList(QWidget* parent) : QStackedWidget(parent), m_model(this)
   connect(m_grid, &QListView::doubleClicked, this, &GameList::GameSelected);
   connect(&m_model, &QAbstractItemModel::rowsInserted, this, &GameList::ConsiderViewChange);
   connect(&m_model, &QAbstractItemModel::rowsRemoved, this, &GameList::ConsiderViewChange);
+
+  m_viewportLock = new ViewportLock(this, m_list_proxy, m_list);
 
   addWidget(m_list);
   addWidget(m_grid);

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -299,16 +299,14 @@ void GameList::MakeEmptyView()
   size_policy.setRetainSizeWhenHidden(true);
   m_empty->setSizePolicy(size_policy);
 
-  connect(&Settings::Instance(), &Settings::GameListRefreshRequested, this,
-          [this, refreshing_msg = refreshing_msg] {
-            m_empty->setText(refreshing_msg);
-            m_empty->setEnabled(false);
-          });
-  connect(&Settings::Instance(), &Settings::GameListRefreshCompleted, this,
-          [this, empty_msg = empty_msg] {
-            m_empty->setText(empty_msg);
-            m_empty->setEnabled(true);
-          });
+  connect(&Settings::Instance(), &Settings::GameListRefreshRequested, this, [this, refreshing_msg] {
+    m_empty->setText(refreshing_msg);
+    m_empty->setEnabled(false);
+  });
+  connect(&Settings::Instance(), &Settings::GameListRefreshCompleted, this, [this, empty_msg] {
+    m_empty->setText(empty_msg);
+    m_empty->setEnabled(true);
+  });
 }
 
 void GameList::resizeEvent(QResizeEvent* event)

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -20,6 +20,8 @@ namespace UICommon
 class GameFile;
 }
 
+class ViewportLock;
+
 class GameList final : public QStackedWidget
 {
   Q_OBJECT
@@ -100,6 +102,7 @@ private:
   void UpdateFont();
 
   GameListModel m_model;
+  ViewportLock* m_viewportLock;
   QSortFilterProxyModel* m_list_proxy;
   QSortFilterProxyModel* m_grid_proxy;
 

--- a/Source/Core/DolphinQt/QtUtils/ViewportLock.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ViewportLock.cpp
@@ -1,0 +1,34 @@
+// Copyright 2024 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <QAbstractItemModel>
+#include <QAbstractItemView>
+
+#include "DolphinQt/QtUtils/ViewportLock.h"
+
+ViewportLock::ViewportLock(QObject* parent, QAbstractItemModel* model, QAbstractItemView* view)
+    : QObject(parent), m_view(view)
+{
+  connect(model, &QAbstractItemModel::rowsAboutToBeInserted, this,
+          &ViewportLock::AboutToBeModified);
+  connect(model, &QAbstractItemModel::rowsAboutToBeRemoved, this, &ViewportLock::AboutToBeModified);
+  connect(model, &QAbstractItemModel::rowsInserted, this, &ViewportLock::Modified);
+  connect(model, &QAbstractItemModel::rowsRemoved, this, &ViewportLock::Modified);
+}
+
+void ViewportLock::AboutToBeModified()
+{
+  QSize size = m_view->size();
+  m_first = m_view->indexAt(QPoint(0, 0));
+  m_last = m_view->indexAt(QPoint(size.height(), size.width()));
+}
+
+void ViewportLock::Modified()
+{
+  // Try to keep the first row at the top.
+  // If that fails, try to keep the last row at the bottom.
+  if (m_first.isValid())
+    m_view->scrollTo(m_first, QAbstractItemView::PositionAtTop);
+  else if (m_last.isValid())
+    m_view->scrollTo(m_last, QAbstractItemView::PositionAtBottom);
+}

--- a/Source/Core/DolphinQt/QtUtils/ViewportLock.h
+++ b/Source/Core/DolphinQt/QtUtils/ViewportLock.h
@@ -1,0 +1,25 @@
+// Copyright 2024 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QPersistentModelIndex>
+
+class QAbstractItemModel;
+class QAbstractItemView;
+
+// Try to keep visible items in view while items are added/removed.
+class ViewportLock : public QObject
+{
+  Q_OBJECT
+
+public:
+  ViewportLock(QObject* parent, QAbstractItemModel* model, QAbstractItemView* view);
+  void AboutToBeModified();
+  void Modified();
+
+private:
+  QAbstractItemView* m_view;
+  QPersistentModelIndex m_first, m_last;
+};

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -354,11 +354,6 @@ void Settings::NotifyRefreshGameListComplete()
   emit GameListRefreshCompleted();
 }
 
-void Settings::RefreshMetadata()
-{
-  emit MetadataRefreshRequested();
-}
-
 void Settings::NotifyMetadataRefreshComplete()
 {
   emit MetadataRefreshCompleted();

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -104,7 +104,6 @@ public:
   void RefreshGameList();
   void NotifyRefreshGameListStarted();
   void NotifyRefreshGameListComplete();
-  void RefreshMetadata();
   void NotifyMetadataRefreshComplete();
   void ReloadTitleDB();
   bool IsAutoRefreshEnabled() const;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -235,15 +235,15 @@ void InterfacePane::ConnectLayout()
   connect(m_checkbox_use_builtin_title_database, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::GameListRefreshRequested);
   connect(m_checkbox_use_covers, &QCheckBox::toggled, &Settings::Instance(),
-          &Settings::RefreshMetadata);
+          &Settings::MetadataRefreshRequested);
   connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::SetDebugModeEnabled);
-  connect(m_combobox_theme, &QComboBox::currentIndexChanged, this,
-          [this](int index) { Settings::Instance().TriggerThemeChanged(); });
+  connect(m_combobox_theme, &QComboBox::currentIndexChanged, &Settings::Instance(),
+          &Settings::ThemeChanged);
   connect(m_combobox_userstyle, &QComboBox::currentIndexChanged, this,
           &InterfacePane::OnUserStyleChanged);
   connect(m_combobox_language, &QComboBox::currentIndexChanged, this,
-          [this]() { OnLanguageChanged(); });
+          &InterfacePane::OnLanguageChanged);
   connect(m_checkbox_top_window, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::KeepWindowOnTopChanged);
   connect(m_radio_cursor_visible_movement, &ConfigRadioInt::OnSelected, &Settings::Instance(),
@@ -253,7 +253,7 @@ void InterfacePane::ConnectLayout()
   connect(m_radio_cursor_visible_always, &ConfigRadioInt::OnSelected, &Settings::Instance(),
           &Settings::CursorVisibilityChanged);
   connect(m_checkbox_lock_mouse, &QCheckBox::toggled, &Settings::Instance(),
-          [this]() { Settings::Instance().LockCursorChanged(); });
+          &Settings::LockCursorChanged);
 }
 
 void InterfacePane::UpdateShowDebuggingCheckbox()


### PR DESCRIPTION
Based on top of #12884.

I keep most of my games on a storage server, so whenever I refresh the game list, it takes a while to load everything. During the update I can't really use the game list because it keeps scrolling whenever something gets added or removed above the current viewport. With this PR, it tries to keep currently visible rows in view.

Doesn't seem to work reliably yet, not sure why. Still an improvement over the status quo I think.