### PR TITLE
MainWindow: Bugfix. Windows Dark mode titlebar not being set.

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -251,7 +251,6 @@ int main(int argc, char* argv[])
     Settings::Instance().ApplyStyle();
 
     MainWindow win{std::move(boot), static_cast<const char*>(options.get("movie"))};
-    win.Show();
 
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
     if (!Config::Get(Config::MAIN_ANALYTICS_PERMISSION_ASKED))

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -240,7 +240,10 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
   restoreState(settings.value(QStringLiteral("mainwindow/state")).toByteArray());
   restoreGeometry(settings.value(QStringLiteral("mainwindow/geometry")).toByteArray());
   if (!Settings::Instance().IsBatchModeEnabled())
+  {
+    SetQWidgetWindowDecorations(this);
     show();
+  }
 
   InitControllers();
   ConnectHotkeys();
@@ -320,6 +323,12 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
   }
 
   Host::GetInstance()->SetMainWindowHandle(reinterpret_cast<void*>(winId()));
+
+  if (m_pending_boot != nullptr)
+  {
+    StartGame(std::move(m_pending_boot));
+    m_pending_boot.reset();
+  }
 }
 
 MainWindow::~MainWindow()
@@ -2072,20 +2081,4 @@ void MainWindow::ShowRiivolutionBootWidget(const UICommon::GameFile& game)
 
   AddRiivolutionPatches(boot_params.get(), std::move(w.GetPatches()));
   StartGame(std::move(boot_params));
-}
-
-void MainWindow::Show()
-{
-  if (!Settings::Instance().IsBatchModeEnabled())
-  {
-    SetQWidgetWindowDecorations(this);
-    QWidget::show();
-  }
-
-  // If the booting of a game was requested on start up, do that now
-  if (m_pending_boot != nullptr)
-  {
-    StartGame(std::move(m_pending_boot));
-    m_pending_boot.reset();
-  }
 }

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -78,7 +78,6 @@ public:
                       const std::string& movie_path);
   ~MainWindow();
 
-  void Show();
   WindowSystemInfo GetWindowSystemInfo() const;
 
   bool eventFilter(QObject* object, QEvent* event) override;


### PR DESCRIPTION
Related #12794

Remove Show() and redistribute its logic to other places.

bugfix:  SetQWidgetWindowDecorations(this); not called before show() for Windows darkmode titlebar.

The actual call to (QWidget) show() needed to come sooner. Show() was originally left alone, but with other checks needing to move with (QWidget) show(), this function became less useful.  Show() was originally created to fix the render widget appearing behind the main window when a game is auto-launched on boot, but that appears to work fine in this iteration.

@CasualPokePlayer  I can't actually test this myself. I tried dark mode in two different Windows versions and neither set a different title bar color while in dark mode (outside dolphin). 