### PR TITLE
BitUtils: Constexpr BitCastToArray, Remove BitCastFromArray

### DIFF
--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <bit>
 #include <climits>
 #include <cstddef>
 #include <cstdint>
@@ -166,50 +167,10 @@ inline auto BitCastPtr(PtrType* ptr) noexcept -> BitCastPtrType<T, PtrType>
 }
 
 // Similar to BitCastPtr, but specifically for aliasing structs to arrays.
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
-inline auto BitCastToArray(const T& obj) noexcept -> Container
+template <typename ValueType, typename From>
+[[nodiscard]] constexpr auto BitCastToArray(const From& obj) noexcept
 {
-  static_assert(sizeof(T) % sizeof(ArrayType) == 0,
-                "Size of array type must be a factor of size of source type.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastToArray source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastToArray array type must be trivially copyable.");
-
-  Container result;
-  std::memcpy(result.data(), &obj, sizeof(T));
-  return result;
-}
-
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
-inline void BitCastFromArray(const Container& array, T& obj) noexcept
-{
-  static_assert(sizeof(T) % sizeof(ArrayType) == 0,
-                "Size of array type must be a factor of size of destination type.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastFromArray array type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastFromArray destination type must be trivially copyable.");
-
-  std::memcpy(&obj, array.data(), sizeof(T));
-}
-
-template <typename ArrayType, typename T,
-          typename Container = std::array<ArrayType, sizeof(T) / sizeof(ArrayType)>>
-inline auto BitCastFromArray(const Container& array) noexcept -> T
-{
-  static_assert(sizeof(T) % sizeof(ArrayType) == 0,
-                "Size of array type must be a factor of size of destination type.");
-  static_assert(std::is_trivially_copyable<Container>(),
-                "BitCastFromArray array type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable<T>(),
-                "BitCastFromArray destination type must be trivially copyable.");
-
-  T obj;
-  std::memcpy(&obj, array.data(), sizeof(T));
-  return obj;
+  return std::bit_cast<std::array<ValueType, sizeof(From) / sizeof(ValueType)>>(obj);
 }
 
 template <typename T>

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -143,7 +143,7 @@ protected:
       pb_mem[update_off] = update_val;
     }
 
-    Common::BitCastFromArray<u16>(pb_mem, pb);
+    pb = std::bit_cast<PBType>(pb_mem);
   }
 
   virtual void HandleCommandList();

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -397,7 +397,7 @@ bool AXWiiUCode::ExtractUpdatesFields(AXPBWii& pb, u16* num_updates, u16* update
   // Remove the updates data from the PB
   memmove(&pb_mem[41], &pb_mem[46], sizeof(pb) - 2 * 46);
 
-  Common::BitCastFromArray<u16>(pb_mem, pb);
+  pb = std::bit_cast<AXPBWii>(pb_mem);
 
   return true;
 }
@@ -416,7 +416,7 @@ void AXWiiUCode::ReinjectUpdatesFields(AXPBWii& pb, u16* num_updates, u32 update
   pb_mem[44] = updates_addr >> 16;
   pb_mem[45] = updates_addr & 0xFFFF;
 
-  Common::BitCastFromArray<u16>(pb_mem, pb);
+  pb = std::bit_cast<AXPBWii>(pb_mem);
 }
 
 void AXWiiUCode::ProcessPBList(u32 pb_addr)


### PR DESCRIPTION
`std::bit_cast` participates in overload resolution only if `sizeof(To) == sizeof(From)` and both `To` and `From` are *TriviallyCopyable* types, so the static assertions here can be removed. `[[nodiscard]]` was added as well.

I tested uses of the now changed `Common::BitCastToArray` in `MemoryViewWidget::ConvertTextToBytes` and `GameFile::GetSyncHash`'s `GetHash` helper, and it worked as expected. I was unable to hit a breakpoint for the remaining uses of either function in Ax/AxWii code, so hopefully it is doing sane things all around. This changes what the compiler must optimize from a `std::memcpy` call to a trivial copy assignment, and I'm assuming the latter is easier for the compiler to work with.

The changes to the template parameter names was a personal choice; I felt it better aligned with what the parameters represent.