### PR TITLE
JitArm64_Integer: Optimize subfic for zero

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1392,13 +1392,19 @@ void JitArm64::subfic(UGeckoInstruction inst)
   }
   else
   {
-    const bool allocate_reg = d == a;
-    gpr.BindToRegister(d, allocate_reg);
+    const bool will_read = d == a;
+    const bool is_zero = imm == 0;
+    const bool allocate_reg = will_read && !is_zero;
+    gpr.BindToRegister(d, will_read);
 
     // d = imm - a
     ARM64Reg RD = gpr.R(d);
-    ARM64Reg WA = allocate_reg ? gpr.GetReg() : RD;
-    MOVI2R(WA, imm);
+    ARM64Reg WA = ARM64Reg::WZR;
+    if (!is_zero)
+    {
+      WA = will_read ? gpr.GetReg() : RD;
+      MOVI2R(WA, imm);
+    }
     CARRY_IF_NEEDED(SUB, SUBS, RD, WA, gpr.R(a));
 
     if (allocate_reg)


### PR DESCRIPTION
When the immediate value is zero, we can do a negation. On ARM64 the NEG/NEGS instructions are just an alias for SUB/SUBS with a hardcoded WZR.

Before:
```
ldr    w22, [x29, #0x28]
mov    w21, #0x0                 ; =0
subs   w22, w21, w22
```

After:
```
ldr    w22, [x29, #0x28]
negs   w22, w22
```