### PR TITLE
Disable Dualcore in Geist

### DIFF
--- a/Data/Sys/GameSettings/GIT.ini
+++ b/Data/Sys/GameSettings/GIT.ini
@@ -1,0 +1,16 @@
+# GITP01, GITE01 - Geist
+
+[Core]
+# Values set here will override the main Dolphin settings.
+# The game has random crashes and tons of unknown opcodes
+# when using Dualcore.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.


### PR DESCRIPTION
Fixes random crashes and unknown opcode errors.  Tested past the first boss.  There were no visual issues, unknown opcode popups, or any other kind of visual anomalies.  The only downside is that the framerate is fairly inconsistent, but that is normal for this game even on console.  The game ran full speed.

Credit to snow from RetroAchievements for helping me realize how easy of a fix this was.