### PR TITLE
IOS/USB: Use Enum for Infinity Base Positions

### DIFF
--- a/Source/Android/jni/InfinityConfig.cpp
+++ b/Source/Android/jni/InfinityConfig.cpp
@@ -10,6 +10,8 @@
 #include "Core/IOS/USB/Emulated/Infinity.h"
 #include "Core/System.h"
 
+using FigureUIPosition = IOS::HLE::USB::FigureUIPosition;
+
 extern "C" {
 
 JNIEXPORT jobject JNICALL
@@ -66,7 +68,7 @@ Java_org_dolphinemu_dolphinemu_features_infinitybase_InfinityConfig_removeFigure
                                                                                  jint position)
 {
   auto& system = Core::System::GetInstance();
-  system.GetInfinityBase().RemoveFigure(position);
+  system.GetInfinityBase().RemoveFigure(static_cast<FigureUIPosition>(position));
 }
 
 JNIEXPORT jstring JNICALL
@@ -87,9 +89,10 @@ Java_org_dolphinemu_dolphinemu_features_infinitybase_InfinityConfig_loadFigure(J
   }
 
   auto& system = Core::System::GetInstance();
-  system.GetInfinityBase().RemoveFigure(position);
+  system.GetInfinityBase().RemoveFigure(static_cast<FigureUIPosition>(position));
   return ToJString(env,
-                   system.GetInfinityBase().LoadFigure(file_data, std::move(inf_file), position));
+                   system.GetInfinityBase().LoadFigure(file_data, std::move(inf_file),
+                                                       static_cast<FigureUIPosition>(position)));
 }
 
 JNIEXPORT jstring JNICALL
@@ -102,7 +105,7 @@ Java_org_dolphinemu_dolphinemu_features_infinitybase_InfinityConfig_createFigure
 
   auto& system = Core::System::GetInstance();
   system.GetInfinityBase().CreateFigure(file_name, fig_num);
-  system.GetInfinityBase().RemoveFigure(position);
+  system.GetInfinityBase().RemoveFigure(static_cast<FigureUIPosition>(position));
 
   File::IOFile inf_file(file_name, "r+b");
   if (!inf_file)
@@ -116,6 +119,7 @@ Java_org_dolphinemu_dolphinemu_features_infinitybase_InfinityConfig_createFigure
   }
 
   return ToJString(env,
-                   system.GetInfinityBase().LoadFigure(file_data, std::move(inf_file), position));
+                   system.GetInfinityBase().LoadFigure(file_data, std::move(inf_file),
+                                                       static_cast<FigureUIPosition>(position)));
 }
 }

--- a/Source/Core/Core/IOS/USB/Emulated/Infinity.h
+++ b/Source/Core/Core/IOS/USB/Emulated/Infinity.h
@@ -66,6 +66,27 @@ private:
   std::queue<std::unique_ptr<IntrMessage>> m_response_list;
 };
 
+enum class FigureUIPosition : u8
+{
+  HexagonDiscOne = 0,
+  HexagonDiscTwo = 1,
+  HexagonDiscThree = 2,
+  PlayerOne = 3,
+  P1AbilityOne = 4,
+  P1AbilityTwo = 5,
+  PlayerTwo = 6,
+  P2AbilityOne = 7,
+  P2AbilityTwo = 8
+};
+
+enum class FigureBasePosition : u8
+{
+  Unknown = 0,
+  HexagonSlot = 1,
+  PlayerOneSlot = 2,
+  PlayerTwoSlot = 3
+};
+
 class InfinityBase final
 {
 public:
@@ -79,10 +100,10 @@ public:
                   u8 sequence);
   void DescrambleAndSeed(u8* buf, u8 sequence, std::array<u8, 32>& reply_buf);
   void GetNextAndScramble(u8 sequence, std::array<u8, 32>& reply_buf);
-  void RemoveFigure(u8 position);
+  void RemoveFigure(FigureUIPosition position);
   // Returns Infinity Figure name based on data from in_file param
   std::string LoadFigure(const std::array<u8, INFINITY_NUM_BLOCKS * INFINITY_BLOCK_SIZE>& buf,
-                         File::IOFile in_file, u8 position);
+                         File::IOFile in_file, FigureUIPosition position);
   bool CreateFigure(const std::string& file_path, u32 character);
   static std::span<const std::pair<const char*, const u32>> GetFigureList();
   std::string FindFigure(u32 character) const;
@@ -95,7 +116,7 @@ private:
   InfinityFigure& GetFigureByOrder(u8 order_added);
   std::array<u8, 16> GenerateInfinityFigureKey(const std::vector<u8>& sha1_data);
   std::array<u8, 16> GenerateBlankFigureData(u32 figure_num);
-  u8 DeriveFigurePosition(u8 position);
+  FigureBasePosition DeriveFigurePosition(FigureUIPosition position);
   void GenerateSeed(u32 seed);
   u32 GetNext();
   u64 Scramble(u32 num_to_scramble, u32 garbage);

--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
@@ -33,6 +33,8 @@
 // static variable to ensure we open at the most recent figure file location
 static QString s_last_figure_path;
 
+using FigureUIPosition = IOS::HLE::USB::FigureUIPosition;
+
 InfinityBaseWindow::InfinityBaseWindow(QWidget* parent) : QWidget(parent)
 {
   // i18n: Window for managing Disney Infinity figures
@@ -77,23 +79,23 @@ void InfinityBaseWindow::CreateMainWindow()
   auto* vbox_group = new QVBoxLayout();
   auto* scroll_area = new QScrollArea();
 
-  AddFigureSlot(vbox_group, tr("Play Set/Power Disc"), 0);
+  AddFigureSlot(vbox_group, tr("Play Set/Power Disc"), FigureUIPosition::HexagonDiscOne);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Power Disc Two"), 1);
+  AddFigureSlot(vbox_group, tr("Power Disc Two"), FigureUIPosition::HexagonDiscTwo);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Power Disc Three"), 2);
+  AddFigureSlot(vbox_group, tr("Power Disc Three"), FigureUIPosition::HexagonDiscThree);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player One"), 3);
+  AddFigureSlot(vbox_group, tr("Player One"), FigureUIPosition::PlayerOne);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player One Ability One"), 4);
+  AddFigureSlot(vbox_group, tr("Player One Ability One"), FigureUIPosition::P1AbilityOne);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player One Ability Two"), 5);
+  AddFigureSlot(vbox_group, tr("Player One Ability Two"), FigureUIPosition::P1AbilityTwo);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player Two"), 6);
+  AddFigureSlot(vbox_group, tr("Player Two"), FigureUIPosition::PlayerTwo);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player Two Ability One"), 7);
+  AddFigureSlot(vbox_group, tr("Player Two Ability One"), FigureUIPosition::P2AbilityOne);
   add_line(vbox_group);
-  AddFigureSlot(vbox_group, tr("Player Two Ability Two"), 8);
+  AddFigureSlot(vbox_group, tr("Player Two Ability Two"), FigureUIPosition::P2AbilityTwo);
 
   m_group_figures->setLayout(vbox_group);
   scroll_area->setWidget(m_group_figures);
@@ -103,7 +105,7 @@ void InfinityBaseWindow::CreateMainWindow()
   setLayout(main_layout);
 }
 
-void InfinityBaseWindow::AddFigureSlot(QVBoxLayout* vbox_group, QString name, u8 slot)
+void InfinityBaseWindow::AddFigureSlot(QVBoxLayout* vbox_group, QString name, FigureUIPosition slot)
 {
   auto* hbox_infinity = new QHBoxLayout();
 
@@ -112,16 +114,16 @@ void InfinityBaseWindow::AddFigureSlot(QVBoxLayout* vbox_group, QString name, u8
   auto* clear_btn = new QPushButton(tr("Clear"));
   auto* create_btn = new QPushButton(tr("Create"));
   auto* load_btn = new QPushButton(tr("Load"));
-  m_edit_figures[slot] = new QLineEdit();
-  m_edit_figures[slot]->setEnabled(false);
-  m_edit_figures[slot]->setText(tr("None"));
+  m_edit_figures[static_cast<u8>(slot)] = new QLineEdit();
+  m_edit_figures[static_cast<u8>(slot)]->setEnabled(false);
+  m_edit_figures[static_cast<u8>(slot)]->setText(tr("None"));
 
   connect(clear_btn, &QAbstractButton::clicked, this, [this, slot] { ClearFigure(slot); });
   connect(create_btn, &QAbstractButton::clicked, this, [this, slot] { CreateFigure(slot); });
   connect(load_btn, &QAbstractButton::clicked, this, [this, slot] { LoadFigure(slot); });
 
   hbox_infinity->addWidget(label_skyname);
-  hbox_infinity->addWidget(m_edit_figures[slot]);
+  hbox_infinity->addWidget(m_edit_figures[static_cast<u8>(slot)]);
   hbox_infinity->addWidget(clear_btn);
   hbox_infinity->addWidget(create_btn);
   hbox_infinity->addWidget(load_btn);
@@ -129,15 +131,15 @@ void InfinityBaseWindow::AddFigureSlot(QVBoxLayout* vbox_group, QString name, u8
   vbox_group->addLayout(hbox_infinity);
 }
 
-void InfinityBaseWindow::ClearFigure(u8 slot)
+void InfinityBaseWindow::ClearFigure(FigureUIPosition slot)
 {
   auto& system = Core::System::GetInstance();
-  m_edit_figures[slot]->setText(tr("None"));
+  m_edit_figures[static_cast<u8>(slot)]->setText(tr("None"));
 
   system.GetInfinityBase().RemoveFigure(slot);
 }
 
-void InfinityBaseWindow::LoadFigure(u8 slot)
+void InfinityBaseWindow::LoadFigure(FigureUIPosition slot)
 {
   const QString file_path =
       DolphinFileDialog::getOpenFileName(this, tr("Select Figure File"), s_last_figure_path,
@@ -152,7 +154,7 @@ void InfinityBaseWindow::LoadFigure(u8 slot)
   LoadFigurePath(slot, file_path);
 }
 
-void InfinityBaseWindow::CreateFigure(u8 slot)
+void InfinityBaseWindow::CreateFigure(FigureUIPosition slot)
 {
   CreateFigureDialog create_dlg(this, slot);
   SetQWidgetWindowDecorations(&create_dlg);
@@ -162,7 +164,7 @@ void InfinityBaseWindow::CreateFigure(u8 slot)
   }
 }
 
-void InfinityBaseWindow::LoadFigurePath(u8 slot, const QString& path)
+void InfinityBaseWindow::LoadFigurePath(FigureUIPosition slot, const QString& path)
 {
   File::IOFile inf_file(path.toStdString(), "r+b");
   if (!inf_file)
@@ -187,11 +189,11 @@ void InfinityBaseWindow::LoadFigurePath(u8 slot, const QString& path)
   auto& system = Core::System::GetInstance();
 
   system.GetInfinityBase().RemoveFigure(slot);
-  m_edit_figures[slot]->setText(QString::fromStdString(
+  m_edit_figures[static_cast<u8>(slot)]->setText(QString::fromStdString(
       system.GetInfinityBase().LoadFigure(file_data, std::move(inf_file), slot)));
 }
 
-CreateFigureDialog::CreateFigureDialog(QWidget* parent, u8 slot) : QDialog(parent)
+CreateFigureDialog::CreateFigureDialog(QWidget* parent, FigureUIPosition slot) : QDialog(parent)
 {
   setWindowTitle(tr("Infinity Figure Creator"));
   setObjectName(QStringLiteral("infinity_creator"));
@@ -205,11 +207,14 @@ CreateFigureDialog::CreateFigureDialog(QWidget* parent, u8 slot) : QDialog(paren
   {
     const auto figure = entry.second;
     // Only display entry if it is a piece appropriate for the slot
-    if ((slot == 0 &&
+    if ((slot == FigureUIPosition::HexagonDiscOne &&
          ((figure > 0x1E8480 && figure < 0x2DC6BF) || (figure > 0x3D0900 && figure < 0x4C4B3F))) ||
-        ((slot == 1 || slot == 2) && (figure > 0x3D0900 && figure < 0x4C4B3F)) ||
-        ((slot == 3 || slot == 6) && figure < 0x1E847F) ||
-        ((slot == 4 || slot == 5 || slot == 7 || slot == 8) &&
+        ((slot == FigureUIPosition::HexagonDiscTwo || slot == FigureUIPosition::HexagonDiscThree) &&
+         (figure > 0x3D0900 && figure < 0x4C4B3F)) ||
+        ((slot == FigureUIPosition::PlayerOne || slot == FigureUIPosition::PlayerTwo) &&
+         figure < 0x1E847F) ||
+        ((slot == FigureUIPosition::P1AbilityOne || slot == FigureUIPosition::P1AbilityTwo ||
+          slot == FigureUIPosition::P2AbilityOne || slot == FigureUIPosition::P2AbilityTwo) &&
          (figure > 0x2DC6C0 && figure < 0x3D08FF)))
     {
       const auto figure_name = QString::fromStdString(entry.first);

--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.h
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.h
@@ -20,6 +20,11 @@ namespace Core
 enum class State;
 }
 
+namespace IOS::HLE::USB
+{
+enum class FigureUIPosition : u8;
+}
+
 class InfinityBaseWindow : public QWidget
 {
   Q_OBJECT
@@ -32,13 +37,13 @@ protected:
 
 private:
   void CreateMainWindow();
-  void AddFigureSlot(QVBoxLayout* vbox_group, QString name, u8 slot);
+  void AddFigureSlot(QVBoxLayout* vbox_group, QString name, IOS::HLE::USB::FigureUIPosition slot);
   void OnEmulationStateChanged(Core::State state);
   void EmulateBase(bool emulate);
-  void ClearFigure(u8 slot);
-  void LoadFigure(u8 slot);
-  void CreateFigure(u8 slot);
-  void LoadFigurePath(u8 slot, const QString& path);
+  void ClearFigure(IOS::HLE::USB::FigureUIPosition slot);
+  void LoadFigure(IOS::HLE::USB::FigureUIPosition slot);
+  void CreateFigure(IOS::HLE::USB::FigureUIPosition slot);
+  void LoadFigurePath(IOS::HLE::USB::FigureUIPosition slot, const QString& path);
 
   QCheckBox* m_checkbox;
   QGroupBox* m_group_figures;
@@ -49,7 +54,7 @@ class CreateFigureDialog : public QDialog
   Q_OBJECT
 
 public:
-  explicit CreateFigureDialog(QWidget* parent, u8 slot);
+  explicit CreateFigureDialog(QWidget* parent, IOS::HLE::USB::FigureUIPosition slot);
   QString GetFilePath() const;
 
 protected:


### PR DESCRIPTION
Convert Infinity Base Position values to an enum to make it easier to understand the values being passed