### PR TITLE
AchievementManager: Fix -Wignored-qualifiers warning

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -341,7 +341,7 @@ AchievementManager::RichPresence AchievementManager::GetRichPresence() const
   return m_rich_presence;
 }
 
-const bool AchievementManager::AreChallengesUpdated() const
+bool AchievementManager::AreChallengesUpdated() const
 {
   return m_challenges_updated;
 }

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -116,7 +116,7 @@ public:
   const Badge& GetAchievementBadge(AchievementId id, bool locked) const;
   const LeaderboardStatus* GetLeaderboardInfo(AchievementId leaderboard_id);
   RichPresence GetRichPresence() const;
-  const bool AreChallengesUpdated() const;
+  bool AreChallengesUpdated() const;
   void ResetChallengesUpdated();
   const std::unordered_set<AchievementId>& GetActiveChallenges() const;
   std::vector<std::string> GetActiveLeaderboards() const;


### PR DESCRIPTION
Fix a warning on the Android builder by returning `bool` instead of `const bool` from AreChallengesUpdated().