### PR TITLE
Core/PatchEngine: Remove remnants of Speedhack system

### DIFF
--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <array>
 #include <iterator>
-#include <map>
 #include <mutex>
 #include <optional>
 #include <span>
@@ -48,7 +47,6 @@ constexpr std::array<const char*, 3> s_patch_type_strings{{
 static std::vector<Patch> s_on_frame;
 static std::vector<std::size_t> s_on_frame_memory;
 static std::mutex s_on_frame_memory_mutex;
-static std::map<u32, u32> s_speed_hacks;
 
 const char* PatchTypeAsString(PatchType type)
 {
@@ -175,38 +173,6 @@ void SavePatchSection(Common::IniFile* local_ini, const std::vector<Patch>& patc
   local_ini->SetLines("OnFrame", lines);
 }
 
-static void LoadSpeedhacks(const std::string& section, Common::IniFile& ini)
-{
-  std::vector<std::string> keys;
-  ini.GetKeys(section, &keys);
-  for (const std::string& key : keys)
-  {
-    std::string value;
-    ini.GetOrCreateSection(section)->Get(key, &value, "BOGUS");
-    if (value != "BOGUS")
-    {
-      u32 address;
-      u32 cycles;
-      bool success = true;
-      success &= TryParse(key, &address);
-      success &= TryParse(value, &cycles);
-      if (success)
-      {
-        s_speed_hacks[address] = cycles;
-      }
-    }
-  }
-}
-
-u32 GetSpeedhackCycles(const u32 addr)
-{
-  const auto iter = s_speed_hacks.find(addr);
-  if (iter == s_speed_hacks.end())
-    return 0;
-
-  return iter->second;
-}
-
 void LoadPatches()
 {
   const auto& sconfig = SConfig::GetInstance();
@@ -227,8 +193,6 @@ void LoadPatches()
     Gecko::SetActiveCodes(Gecko::LoadCodes(globalIni, localIni));
     ActionReplay::LoadAndApplyCodes(globalIni, localIni);
   }
-
-  LoadSpeedhacks("Speedhacks", merged);
 }
 
 static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Patch>& patches)
@@ -360,7 +324,6 @@ bool ApplyFramePatches(Core::System& system)
 void Shutdown()
 {
   s_on_frame.clear();
-  s_speed_hacks.clear();
   ActionReplay::ApplyCodes({});
   Gecko::Shutdown();
 }

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -49,8 +49,6 @@ struct Patch
 
 const char* PatchTypeAsString(PatchType type);
 
-u32 GetSpeedhackCycles(const u32 addr);
-
 std::optional<PatchEntry> DeserializeLine(std::string line);
 std::string SerializeLine(const PatchEntry& entry);
 void LoadPatchSection(const std::string& section, std::vector<Patch>* patches,

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -958,9 +958,6 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
     js.fastmemLoadStore = nullptr;
     js.fixupExceptionHandler = false;
 
-    if (!m_enable_debugging)
-      js.downcountAmount += PatchEngine::GetSpeedhackCycles(js.compilerPC);
-
     if (i == (code_block.m_num_instructions - 1))
     {
       js.isLastInstruction = true;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -1145,9 +1145,6 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
     js.downcountAmount += opinfo->num_cycles;
     js.isLastInstruction = i == (code_block.m_num_instructions - 1);
 
-    if (!m_enable_debugging)
-      js.downcountAmount += PatchEngine::GetSpeedhackCycles(js.compilerPC);
-
     // Skip calling UpdateLastUsed for lmw/stmw - it usually hurts more than it helps
     if (op.inst.OPCD != 46 && op.inst.OPCD != 47)
       gpr.UpdateLastUsed(op.regsIn | op.regsOut);


### PR DESCRIPTION
All usages of this have been removed many years ago in cbe9c3e040a466bba410f025e026ed84f3f8b1c0