### PR TITLE
ScmRevGen: Set commits ahead to zero when on a tag

### DIFF
--- a/CMake/ScmRevGen.cmake
+++ b/CMake/ScmRevGen.cmake
@@ -22,16 +22,17 @@ if(GIT_FOUND)
   execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD ^master
       OUTPUT_VARIABLE DOLPHIN_WC_COMMITS_AHEAD_MASTER
       OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # defines DOLPHIN_WC_TAG
+  execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} describe --exact-match HEAD
+    OUTPUT_VARIABLE DOLPHIN_WC_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
 
 # version number
 set(DOLPHIN_VERSION_MAJOR "5")
 set(DOLPHIN_VERSION_MINOR "0")
-if(DOLPHIN_WC_BRANCH STREQUAL "stable")
-  set(DOLPHIN_VERSION_PATCH "0")
-else()
-  set(DOLPHIN_VERSION_PATCH ${DOLPHIN_WC_REVISION})
-endif()
+set(DOLPHIN_VERSION_PATCH ${DOLPHIN_WC_REVISION})
 
 # If Dolphin is not built from a Git repository, default the version info to
 # reasonable values.
@@ -39,6 +40,13 @@ if(NOT DOLPHIN_WC_REVISION)
   set(DOLPHIN_WC_DESCRIBE "${DOLPHIN_VERSION_MAJOR}.${DOLPHIN_VERSION_MINOR}")
   set(DOLPHIN_WC_REVISION "${DOLPHIN_WC_DESCRIBE} (no further info)")
   set(DOLPHIN_WC_BRANCH "master")
+  set(DOLPHIN_WC_COMMITS_AHEAD_MASTER 0)
+endif()
+
+# If this is a tag (i.e. a release), then set the current patch version and
+# the number of commits ahead to zero.
+if(DOLPHIN_WC_TAG)
+  set(DOLPHIN_VERSION_PATCH "0")
   set(DOLPHIN_WC_COMMITS_AHEAD_MASTER 0)
 endif()
 


### PR DESCRIPTION
Prevents the current ref from being shown in the DolphinQt window title while HEAD is on a tag.