### PR TITLE
JitArm64: Remove unused temp_gprs

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -132,8 +132,6 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
     result_reg = reg_encoder(V1Q);
   }
 
-  const ARM64Reg temp_gpr = m_accurate_nans && !single ? gpr.GetReg() : ARM64Reg::INVALID_REG;
-
   switch (op5)
   {
   case 18:
@@ -251,8 +249,6 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
     fpr.Unlock(V0Q);
   if (V1Q != ARM64Reg::INVALID_REG)
     fpr.Unlock(V1Q);
-  if (temp_gpr != ARM64Reg::INVALID_REG)
-    gpr.Unlock(temp_gpr);
 
   if (output_is_single)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -141,8 +141,6 @@ void JitArm64::ps_arith(UGeckoInstruction inst)
     result_reg = reg_encoder(V1Q);
   }
 
-  const ARM64Reg temp_gpr = m_accurate_nans && !singles ? gpr.GetReg() : ARM64Reg::INVALID_REG;
-
   if (m_accurate_nans)
   {
     if (V0Q == ARM64Reg::INVALID_REG)
@@ -304,8 +302,6 @@ void JitArm64::ps_arith(UGeckoInstruction inst)
     fpr.Unlock(V1Q);
   if (V2Q != ARM64Reg::INVALID_REG)
     fpr.Unlock(V2Q);
-  if (temp_gpr != ARM64Reg::INVALID_REG)
-    gpr.Unlock(temp_gpr);
 
   ASSERT_MSG(DYNA_REC, singles == singles_func(),
              "Register allocation turned singles into doubles in the middle of ps_arith");


### PR DESCRIPTION
Spotted and removed these in #12868 as well, but that might take a bit longer to land.