### PR TITLE
IOS::HLE::EmulationKernel::InitIPC: Fix WiiIPC ack generation

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -533,7 +533,7 @@ bool EmulationKernel::BootIOS(const u64 ios_title_id, HangPPC hang_ppc,
 
 void EmulationKernel::InitIPC()
 {
-  if (!Core::IsRunning(m_system))
+  if (Core::GetState(m_system) == Core::State::Uninitialized)
     return;
 
   INFO_LOG_FMT(IOS, "IPC initialised.");


### PR DESCRIPTION
This fixes a regression from https://github.com/dolphin-emu/dolphin/commit/962230f91e06a60b2395de6f0974fdd213854d4c onwards, where the state in `InitIPC` was still `State::Starting`, causing the WiiIPC ack to never be generated.
This causes the vWii System Menu to be stuck waiting on the IPC to be initialized, as described in https://github.com/dolphin-emu/dolphin/pull/11186 where the `IsRunning` check was added.