### PR TITLE
cmake: Fix building with system minizip-ng

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,7 +677,7 @@ dolphin_find_optional_system_library_pkgconfig(ZSTD libzstd>=1.4.0 zstd::zstd Ex
 dolphin_find_optional_system_library_pkgconfig(ZLIB zlib-ng ZLIB::ZLIB Externals/zlib-ng)
 
 dolphin_find_optional_system_library_pkgconfig(MINIZIP
-  "minizip-ng>=4.0.4;minizip>=4.0.4" minizip::minizip Externals/minizip-ng
+  "minizip>=4.0.4" minizip::minizip Externals/minizip-ng
 )
 
 dolphin_find_optional_system_library(LZO Externals/LZO)


### PR DESCRIPTION
Dolphin currently fails to build when the Linux system building it includes headers/pkgconfigs for minizip-ng built in both minizip-ng mode and legacy compat mode (the minizip API).

This is because minizip-ng is checked for in cmake however the code is not actually compatible against minizip-ng built in non-legacy mode. Until that is rectified Dolphin should just check for a pkgconfig for minizip. If the system has a pkgconfig for minizip with a version >= 4 then the system package is minizip-ng built in compat mode which is exactly what we want.