### PR TITLE
RetroAchievements - Patch Allowlist Unit Test

### DIFF
--- a/Data/Sys/ApprovedInis.json
+++ b/Data/Sys/ApprovedInis.json
@@ -1,0 +1,323 @@
+{
+  "D43J01": {
+    "title": "ZELDA OCARINA MULTI PACK",
+    "CAB9CED2D904F12CCB21F5B1DE9B5433620C3E13": "loophack"
+  },
+  "G2BE5G": {
+    "title": "Black & Bruised",
+    "7FFF6BDD93713BEDFD23739C32B86153FA19AEA0": "Disable interlaced rendering"
+  },
+  "G2BP7D": {
+    "title": "Black & Bruised",
+    "56E85D7285F10348E1E5354E379918D07E79EDA9": "Disable interlaced rendering"
+  },
+  "GC6E01": {
+    "title": "Pokémon Colosseum",
+    "2F64F98686E62B60E466E931A9EBCD19A750FF4E": "Allow Memory Card saving with Savestates"
+  },
+  "GC6J01": {
+    "title": "ポケモンコロシアム",
+    "D8F327304A88FBC717BB1F775494C5F864B9E8D2": "Allow Memory Card saving with Savestates"
+  },
+  "GC6P01": {
+    "title": "Pokémon Colosseum",
+    "EDEE0E28EEA1834868F2865336290FFBDFB9C6DA": "Allow Memory Card saving with Savestates"
+  },
+  "GCCE01": {
+    "title": "FINAL FANTASY Crystal Chronicles",
+    "6C107FEC15C76201233CA2645EB5FAB4FF9751CE": "Fix buffer overrun bug (crash at Goblin Wall)",
+    "483BDB94615C690045C3759795AF13CE76552286": "Fix GBA connections"
+  },
+  "GCCJGC": {
+    "title": "FINAL FANTASY Crystal Chronicles",
+    "4C104D24329172F5D0F8649DE9423B931FE72CA3": "Fix GBA connections"
+  },
+  "GCCP01": {
+    "title": "FINAL FANTASY Crystal Chronicles",
+    "2EAA60A8A115AD68A795109FB59E4A726D29016D": "Fix GBA connections"
+  },
+  "GDREAF": {
+    "title": "Dead to Rights",
+    "F8EAE60FEB0CFB4477FDC4B9E136B63F68DFA63A": "Fix audio issues"
+  },
+  "GDRP69": {
+    "title": "Dead to Rights",
+    "E23D98B2CE185C3993A40F2495D37E41B971BF91": "Fix audio issues"
+  },
+  "GEME7F": {
+    "title": "Egg Mania: Eggstreme Madness",
+    "CB04E00918C9C0F161715D21D046ED6620F7ADEF": "Force Progressive Scan"
+  },
+  "GEMJ28": {
+    "title": "Egg Mania: Eggstreme Madness",
+    "CC2057185BB10DAD4A361412D024DFD586EE0130": "Force Progressive Scan"
+  },
+  "GGVD78": {
+    "title": "The SpongeBob SquarePants Movie",
+    "FE52240DF6D132C15A8324E8A477F2BF2250D208": "EFB Copy Fix"
+  },
+  "GGVE78": {
+    "title": "The SpongeBob SquarePants Movie",
+    "5E38E10829D5F77243C95E9E41518BB3ADE24139": "EFB Copy Fix"
+  },
+  "GGVP78": {
+    "title": "The SpongeBob SquarePants Movie",
+    "5E38E10829D5F77243C95E9E41518BB3ADE24139": "EFB Copy Fix"
+  },
+  "GGVX78": {
+    "title": "The SpongeBob SquarePants Movie",
+    "740F2D1C01DA39D1760D96B03974A48E6F74578D": "EFB Copy Fix"
+  },
+  "GHAE08": {
+    "title": "Resident Evil 2",
+    "9799AFF8463EC86C9230E31E2627E141F0C129D3": "Fix audio issues"
+  },
+  "GHAJ08": {
+    "title": "Biohazard 2",
+    "B45A8FC32D14567B8D6C95F303E00A72C0E1D344": "Fix audio issues"
+  },
+  "GHAP08": {
+    "title": "Resident Evil 2",
+    "BC7F3CFC97593AA2055C370C175950DC478D2709": "Fix audio issues"
+  },
+  "GICD78": {
+    "title": "The Incredibles",
+    "3A94591A149AE88C150AB3320BBC909FE54BAEA5": "EFB Copy Fix"
+  },
+  "GICE78": {
+    "title": "The Incredibles",
+    "5BF55685B8867A85EAA9C86571309B17BF7DED32": "EFB Copy Fix"
+  },
+  "GICF78": {
+    "title": "The Incredibles",
+    "85AABAEB9A59C4F96D9330A3B884F6D757DA1683": "EFB Copy Fix"
+  },
+  "GICH78": {
+    "title": "The Incredibles",
+    "3A94591A149AE88C150AB3320BBC909FE54BAEA5": "EFB Copy Fix"
+  },
+  "GICJG9": {
+    "title": "The Incredibles",
+    "969134EA21A160EBDA91C0870266E7D1707FDC43": "EFB Copy Fix"
+  },
+  "GICP78": {
+    "title": "The Incredibles",
+    "13B158CF41F5412BC637F50644193D43CC3DA49A": "EFB Copy Fix"
+  },
+  "GIQE78": {
+    "title": "The Incredibles: Rise of the Underminer",
+    "E15AA1E30D26E5735D68AAADE436E7B7E4A33A35": "EFB Copy Fix"
+  },
+  "GIQJ8P": {
+    "title": "The Incredibles: Rise of the Underminer",
+    "FFFCB76E98DDB06A7BBBC0AA73C869C87EB787D6": "EFB Copy Fix"
+  },
+  "GIQX78": {
+    "title": "The Incredibles: Rise of the Underminer",
+    "485DA99FAB35646DAA2A138B0315361495ABE778": "EFB Copy Fix"
+  },
+  "GIQY78": {
+    "title": "The Incredibles: Rise of the Underminer",
+    "485DA99FAB35646DAA2A138B0315361495ABE778": "EFB Copy Fix"
+  },
+  "GLEE08": {
+    "title": "Resident Evil 3: Nemesis",
+    "7355F358CAC6F418D37E4C23E64F7867D46E4FC9": "Fix audio issues"
+  },
+  "GLEJ08": {
+    "title": "BioHazard 3: Last Escape",
+    "12B24A6D7389A2AC5AB75FC0BF8493E7661F2A73": "Fix audio issues"
+  },
+  "GLEP08": {
+    "title": "Resident Evil 3: Nemesis",
+    "81BD39F5527552DE89E3B59BA86298900F0A3168": "Fix audio issues"
+  },
+  "GLSD64": {
+    "title": "Gladius",
+    "5E2A73717BD66EF647846DD64C33BC80AD9B5227": "Fix freeze in opening cutscene"
+  },
+  "GLSE64": {
+    "title": "Gladius",
+    "1CE78E7954415A44DF693C0BB879AA5A4FF059A3": "Fix freeze in opening cutscene"
+  },
+  "GLSF64": {
+    "title": "Gladius",
+    "009B0C4AD80A9C28C987934D254C2C4AACC9A07A": "Fix freeze in opening cutscene"
+  },
+  "GLSP64": {
+    "title": "Gladius",
+    "3D0894616C9A7FA5ED91C1D2F461BF14DF47ECEC": "Fix freeze in opening cutscene"
+  },
+  "GNHE5d": {
+    "title": "NHL HITZ 2002",
+    "89393A24E2336841AA4CD0AD3BE1C9A66B89E9EF": "Nop Hack"
+  },
+  "GQPE78": {
+    "title": "SpongeBob SquarePants: Battle for Bikini Bottom",
+    "880B114E9A308084CAB92C004A9EE067B371C310": "EFB Copy Fix"
+  },
+  "GQPP78": {
+    "title": "SpongeBob SquarePants: Battle for Bikini Bottom",
+    "5D9A14954AE8D639C9B254F3BA73A70F284BBC8D": "EFB Copy Fix"
+  },
+  "GRYE41": {
+    "title": "Rayman Arena",
+    "AF0A575EB6071EAC0D2EC3D2EA30A23EB05A4192": "Disable Culling to Fix Rise and Shrine Hang"
+  },
+  "GU2D78": {
+    "title": "2 Games in 1: The Incredibles / Finding Nemo",
+    "CFF4C3F932B08732627572EDA1A0CD2D9C71AE0C": "EFB Copy Fix"
+  },
+  "GU2F78": {
+    "title": "2 Games in 1: The Incredibles / Finding Nemo",
+    "CFF4C3F932B08732627572EDA1A0CD2D9C71AE0C": "EFB Copy Fix"
+  },
+  "GU3D78": {
+    "title": "2 Games in 1: The SpongeBob SquarePants Movie / Tak 2: The Staff of Dreams",
+    "8A0E3114862ADFE421874211BD6F5220AA425BF5": "EFB Copy Fix"
+  },
+  "GU3X78": {
+    "title": "2 Games in 1: The SpongeBob SquarePants Movie / Tak 2: The Staff of Dreams",
+    "E3303FDAE7ECA17A72EDC440C32D94648A6453A0": "EFB Copy Fix"
+  },
+  "GU4Y78": {
+    "title": "2 Games in 1: Nickelodeon SpongeBob Schwammkopf: Der Film + Nickelodeon SpongeBob Schwammkopf: Schlacht um Bikini Bottom",
+    "D54767785E139A8BC8C4B75573FBD5A0B686D8E3": "EFB Copy Fix"
+  },
+  "GV4E69": {
+    "title": "MVP Baseball 2005",
+    "8679891FCAA250FCFF670B26E0CB9875900D17FD": "Fix 2D Rendering"
+  },
+  "GVPE69": {
+    "title": "MVP Baseball 2004",
+    "3159CA79B0A890131763EA6CB163684BEE886E3F": "Fix 2D Rendering"
+  },
+  "GWLE6L": {
+    "title": "Project Zoo",
+    "C9101E4C6800FEEF18136846D771273593C21890": "Bypass FIFO reset"
+  },
+  "GWLX6L": {
+    "title": "Project Zoo",
+    "89C15ADC918F3A4399257534F326EB9F933AF040": "Bypass FIFO reset"
+  },
+  "GXXE01": {
+    "title": "Pokémon XD: Gale of Darkness",
+    "64FAA15062F0D0C319F904BBDE9C4489A25D6369": "Allow Memory Card saving with Savestates"
+  },
+  "GXXJ01": {
+    "title": "ポケモンＸＤ 闇の旋風ダーク・ルギア",
+    "8293802260536FA2EF2EFDAB5266DE36BB88DE1B": "Allow Memory Card saving with Savestates"
+  },
+  "GXXP01": {
+    "title": "Pokémon XD: Gale of Darkness",
+    "3CAFBC4AE6FC5CE9F53377F86AB5BD8F1BC8861A": "Allow Memory Card saving with Savestates"
+  },
+  "GZ2E01": {
+    "title": "The Legend of Zelda: Twilight Princess [GC]",
+    "FCB673D46E716C7F63C618B8D8BF83AEE0B501F0": "Hyrule Field Speed Hack"
+  },
+  "GZ2J01": {
+    "title": "The Legend of Zelda: Twilight Princess [GC]",
+    "FCB673D46E716C7F63C618B8D8BF83AEE0B501F0": "Hyrule Field Speed Hack"
+  },
+  "GZ2P01": {
+    "title": "The Legend of Zelda: Twilight Princess [GC]",
+    "0F63623D4D984B7706F718F57C0ABDB6DBADCF8D": "Hyrule Field Speed Hack"
+  },
+  "HAF": {
+    "title": "Forecast Channel",
+    "181195871F63B89B1CF09AFA4420CF89B9883108": "BufferPatch"
+  },
+  "HAL": {
+    "title": "Region Select",
+    "AD12237401ABE9FE4A545AADB5C5AE10355E2076": "RSAPatch"
+  },
+  "RELJAB": {
+    "title": "SegaBoot",
+    "130F3594CAB57B85616F95C7126F4748AAC5867D": "DI Seed Blanker"
+  },
+  "RGQE70": {
+    "title": "Ghostbusters",
+    "5F4CF8D4DA19A0FF74FF9EB925AC0236069BFD59": "crashfix"
+  },
+  "RLEEFS": {
+    "title": "Ten Pin Alley 2",
+    "793642AC6862C2F3412035A9E3D7172CC4A1D5C7": "Fix crash on main menu"
+  },
+  "RMHP08": {
+    "title": "Monster Hunter Tri",
+    "1720C1173D4698167080DBFC4232F21757C4DA08": "Bloom OFF"
+  },
+  "RO2P7N": {
+    "title": "OFF ROAD",
+    "EEE9C8DE4671C18DD7F81DD08D39B64C57600DEA": "Hangfix"
+  },
+  "RPBE01": {
+    "title": "Pokemon Battle Revolution",
+    "775ABECA6073E02C5C68CF4D644194D966A418F5": "Fix black screen effects"
+  },
+  "RPBJ01r0": {
+    "title": "Pokemon Battle Revolution",
+    "0EAB5D8DE827894AFEF97C10ACB67378E6983323": "Fix black screen effects"
+  },
+  "RPBJ01r1": {
+    "title": "Pokemon Battle Revolution",
+    "4905E08643E9D00136F7EAF51978CF2F54D10D07": "Fix black screen effects"
+  },
+  "RPBJ01r2": {
+    "title": "Pokemon Battle Revolution",
+    "4905E08643E9D00136F7EAF51978CF2F54D10D07": "Fix black screen effects"
+  },
+  "RPBP01": {
+    "title": "Pokemon Battle Revolution",
+    "82AEB60F9A9083F93060531A970FFAABE0833A40": "Fix black screen effects"
+  },
+  "RTH": {
+    "title": "Tony Hawk's Downhill Jam",
+    "812EE46AC967BFCD239335B10A664D71A93E8175": "Disable blur"
+  },
+  "RX4E4Z": {
+    "title": "Casper's Scare School: Spooky Sports Day",
+    "9E4E0F1465A9A1E85349DBA3B1278AC215A97DBB": "Fix file reads (dcache bypass)"
+  },
+  "RX4PMT": {
+    "title": "Casper's Scare School: Spooky Sports Day",
+    "EE85907C03F0295794821383B93F8D5B91D2697A": "Fix file reads (dcache bypass)"
+  },
+  "RZDE01r0": {
+    "title": "The Legend of Zelda: Twilight Princess [Wii]",
+    "15EAD073414C9903D6CAE5229DCE582BD17A9162": "Hyrule Field Speed Hack"
+  },
+  "RZDE01r2": {
+    "title": "The Legend of Zelda: Twilight Princess [Wii]",
+    "27395CC8BC2C51201D566657D31A471A850482FB": "Hyrule Field Speed Hack"
+  },
+  "RZDJ01": {
+    "title": "The Legend of Zelda: Twilight Princess [Wii]",
+    "B3F7473F8C911A32F1D616491C9E78EBBD7A6309": "Hyrule Field Speed Hack"
+  },
+  "RZDK01": {
+    "title": "The Legend of Zelda: Twilight Princess [Wii]",
+    "A280C0114B800D7DC056ECFB5E482229DA0B1550": "Hyrule Field Speed Hack"
+  },
+  "RZDP01": {
+    "title": "The Legend of Zelda: Twilight Princess [Wii]",
+    "2A83ADFB760F9498841ED0ED68B0C0438232472C": "Hyrule Field Speed Hack"
+  },
+  "SAOE78": {
+    "title": "Monster High: Ghoul Spirit",
+    "EA11FA4908FB20B61876ACD360EC7657A6D39FB2": "Fix crash on boot"
+  },
+  "SAOEVZ": {
+    "title": "Monster High: Ghoul Spirit",
+    "AA55C214DE7545DE0E203CC39F06BF3D31451BE9": "Fix crash on boot"
+  },
+  "SGLEA4": {
+    "title": "Gormiti: The Lords of Nature!",
+    "258378187ACF475A55EFEAF8A703681252E014C3": "Fix black screen"
+  },
+  "SGLPA4": {
+    "title": "Gormiti: The Lords of Nature!",
+    "6F8CD59D897338CA90939149E1A62588620C6D88": "Fix black screen"
+  }
+}

--- a/Data/Sys/GameSettings/D43J01.ini
+++ b/Data/Sys/GameSettings/D43J01.ini
@@ -8,5 +8,8 @@
 $loophack
 0x806866E4:word:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$loophack
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/G2BE5G.ini
+++ b/Data/Sys/GameSettings/G2BE5G.ini
@@ -11,6 +11,9 @@
 $Disable interlaced rendering
 0x800D8520:dword:0x38600000
 
+[Patches_RetroAchievements_Verified]
+$Disable interlaced rendering
+
 [ActionReplay]
 # Add action replay cheats here.
 

--- a/Data/Sys/GameSettings/G2BP7D.ini
+++ b/Data/Sys/GameSettings/G2BP7D.ini
@@ -11,6 +11,9 @@
 $Disable interlaced rendering
 0x800D9E68:dword:0x38600000
 
+[Patches_RetroAchievements_Verified]
+$Disable interlaced rendering
+
 [ActionReplay]
 # Add action replay cheats here.
 

--- a/Data/Sys/GameSettings/GC6E01.ini
+++ b/Data/Sys/GameSettings/GC6E01.ini
@@ -25,3 +25,6 @@
 $Allow Memory Card saving with Savestates
 0x801cfc2c:dword:0x9005002c
 0x801cfc7c:dword:0x60000000
+
+[Patches_RetroAchievements_Verified]
+$Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GC6J01.ini
+++ b/Data/Sys/GameSettings/GC6J01.ini
@@ -25,3 +25,6 @@
 $Allow Memory Card saving with Savestates
 0x801cb5b8:dword:0x9005002c
 0x801cb608:dword:0x60000000
+
+[Patches_RetroAchievements_Verified]
+$Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GC6P01.ini
+++ b/Data/Sys/GameSettings/GC6P01.ini
@@ -25,3 +25,6 @@
 $Allow Memory Card saving with Savestates
 0x801d429c:dword:0x9005002c
 0x801d42ec:dword:0x60000000
+
+[Patches_RetroAchievements_Verified]
+$Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GCCE01.ini
+++ b/Data/Sys/GameSettings/GCCE01.ini
@@ -29,6 +29,10 @@ $Fix GBA connections
 [OnFrame_Enabled]
 $Fix GBA connections
 
+[Patches_RetroAchievements_Verified]
+$Fix buffer overrun bug (crash at Goblin Wall)
+$Fix GBA connections
+
 [ActionReplay]
 # Add action replay cheats here.
 $Infinite Health: Single Player

--- a/Data/Sys/GameSettings/GCCJGC.ini
+++ b/Data/Sys/GameSettings/GCCJGC.ini
@@ -23,3 +23,6 @@ $Fix GBA connections
 
 [OnFrame_Enabled]
 $Fix GBA connections
+
+[Patches_RetroAchievements_Verified]
+$Fix GBA connections

--- a/Data/Sys/GameSettings/GCCP01.ini
+++ b/Data/Sys/GameSettings/GCCP01.ini
@@ -23,3 +23,6 @@ $Fix GBA connections
 
 [OnFrame_Enabled]
 $Fix GBA connections
+
+[Patches_RetroAchievements_Verified]
+$Fix GBA connections

--- a/Data/Sys/GameSettings/GDREAF.ini
+++ b/Data/Sys/GameSettings/GDREAF.ini
@@ -9,3 +9,6 @@ $Fix audio issues
 0x8000AF34:dword:0x60000000
 [OnFrame_Enabled]
 $Fix audio issues
+
+[Patches_RetroAchievements_Verified]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GDRP69.ini
+++ b/Data/Sys/GameSettings/GDRP69.ini
@@ -9,3 +9,6 @@ $Fix audio issues
 0x8000B7EC:dword:0x60000000
 [OnFrame_Enabled]
 $Fix audio issues
+
+[Patches_RetroAchievements_Verified]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GEME7F.ini
+++ b/Data/Sys/GameSettings/GEME7F.ini
@@ -10,3 +10,6 @@ $Force Progressive Scan
 0x806D0898:dword:0x801671CC
 [OnFrame_Enabled]
 $Force Progressive Scan
+
+[Patches_RetroAchievements_Verified]
+$Force Progressive Scan

--- a/Data/Sys/GameSettings/GEMJ28.ini
+++ b/Data/Sys/GameSettings/GEMJ28.ini
@@ -10,3 +10,6 @@ $Force Progressive Scan
 0x806D0660:dword:0x801640A4
 [OnFrame_Enabled]
 $Force Progressive Scan
+
+[Patches_RetroAchievements_Verified]
+$Force Progressive Scan

--- a/Data/Sys/GameSettings/GGVD78.ini
+++ b/Data/Sys/GameSettings/GGVD78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GGVE78.ini
+++ b/Data/Sys/GameSettings/GGVE78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GGVP78.ini
+++ b/Data/Sys/GameSettings/GGVP78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GGVX78.ini
+++ b/Data/Sys/GameSettings/GGVX78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GHAE08.ini
+++ b/Data/Sys/GameSettings/GHAE08.ini
@@ -14,3 +14,6 @@ $Fix audio issues
 0x8055AB54:dword:0x60000000:0x4BAA85AD
 [OnFrame_Enabled]
 $Fix audio issues
+
+[Patches_RetroAchievements_Verified]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GHAJ08.ini
+++ b/Data/Sys/GameSettings/GHAJ08.ini
@@ -14,3 +14,6 @@ $Fix audio issues
 0x805C5BFC:dword:0x60000000:0x4BA3D505
 [OnFrame_Enabled]
 $Fix audio issues
+
+[Patches_RetroAchievements_Verified]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GHAP08.ini
+++ b/Data/Sys/GameSettings/GHAP08.ini
@@ -30,3 +30,6 @@ $Fix audio issues
 0x8055CEBC:dword:0x60000000:0x4BAA6245
 [OnFrame_Enabled]
 $Fix audio issues
+
+[Patches_RetroAchievements_Verified]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GICD78.ini
+++ b/Data/Sys/GameSettings/GICD78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GICE78.ini
+++ b/Data/Sys/GameSettings/GICE78.ini
@@ -13,6 +13,9 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
 
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix
+
 [ActionReplay]
 # Add action replay cheats here.
 $Infinite Health

--- a/Data/Sys/GameSettings/GICF78.ini
+++ b/Data/Sys/GameSettings/GICF78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GICH78.ini
+++ b/Data/Sys/GameSettings/GICH78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GICJG9.ini
+++ b/Data/Sys/GameSettings/GICJG9.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GICP78.ini
+++ b/Data/Sys/GameSettings/GICP78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GIQE78.ini
+++ b/Data/Sys/GameSettings/GIQE78.ini
@@ -13,6 +13,9 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
 
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix
+
 [ActionReplay]
 # Add action replay cheats here.
 $Infinite Specials

--- a/Data/Sys/GameSettings/GIQJ8P.ini
+++ b/Data/Sys/GameSettings/GIQJ8P.ini
@@ -13,3 +13,6 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
 
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GIQX78.ini
+++ b/Data/Sys/GameSettings/GIQX78.ini
@@ -13,3 +13,6 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
 
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GIQY78.ini
+++ b/Data/Sys/GameSettings/GIQY78.ini
@@ -13,3 +13,6 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
 
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GLEE08.ini
+++ b/Data/Sys/GameSettings/GLEE08.ini
@@ -10,3 +10,6 @@ $Fix audio issues
 0x80150E94:dword:0x60000000
 [OnFrame_Enabled]
 $Fix audio issues
+
+[Patches_RetroAchievements_Verified]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GLEJ08.ini
+++ b/Data/Sys/GameSettings/GLEJ08.ini
@@ -10,3 +10,6 @@ $Fix audio issues
 0x8015110C:dword:0x60000000
 [OnFrame_Enabled]
 $Fix audio issues
+
+[Patches_RetroAchievements_Verified]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GLEP08.ini
+++ b/Data/Sys/GameSettings/GLEP08.ini
@@ -18,3 +18,6 @@ $Fix audio issues
 0x8058CEA4:dword:0x60000000:0x4BA7625D
 [OnFrame_Enabled]
 $Fix audio issues
+
+[Patches_RetroAchievements_Verified]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GLSD64.ini
+++ b/Data/Sys/GameSettings/GLSD64.ini
@@ -18,3 +18,6 @@ $Fix freeze in opening cutscene
 
 [OnFrame_Enabled]
 $Fix freeze in opening cutscene
+
+[Patches_RetroAchievements_Verified]
+$Fix freeze in opening cutscene

--- a/Data/Sys/GameSettings/GLSE64.ini
+++ b/Data/Sys/GameSettings/GLSE64.ini
@@ -18,3 +18,6 @@ $Fix freeze in opening cutscene
 
 [OnFrame_Enabled]
 $Fix freeze in opening cutscene
+
+[Patches_RetroAchievements_Verified]
+$Fix freeze in opening cutscene

--- a/Data/Sys/GameSettings/GLSF64.ini
+++ b/Data/Sys/GameSettings/GLSF64.ini
@@ -18,3 +18,6 @@ $Fix freeze in opening cutscene
 
 [OnFrame_Enabled]
 $Fix freeze in opening cutscene
+
+[Patches_RetroAchievements_Verified]
+$Fix freeze in opening cutscene

--- a/Data/Sys/GameSettings/GLSP64.ini
+++ b/Data/Sys/GameSettings/GLSP64.ini
@@ -18,3 +18,6 @@ $Fix freeze in opening cutscene
 
 [OnFrame_Enabled]
 $Fix freeze in opening cutscene
+
+[Patches_RetroAchievements_Verified]
+$Fix freeze in opening cutscene

--- a/Data/Sys/GameSettings/GNHE5d.ini
+++ b/Data/Sys/GameSettings/GNHE5d.ini
@@ -8,5 +8,8 @@
 $Nop Hack
 0x80025BA0:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$Nop Hack
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/GQPE78.ini
+++ b/Data/Sys/GameSettings/GQPE78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GQPP78.ini
+++ b/Data/Sys/GameSettings/GQPP78.ini
@@ -12,3 +12,6 @@ $EFB Copy Fix
 # resolutions.  In order for this patch to fully work, the
 # Vertex Rounding Hack must be enabled.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GRYE41.ini
+++ b/Data/Sys/GameSettings/GRYE41.ini
@@ -12,3 +12,6 @@ $Disable Culling to Fix Rise and Shrine Hang
 # causes the "Rise and Shrine" hang in Dolphin.
 # There is no noticeable side-effects unless Dolphin's
 # built-in Widescreen Hack is enabled.
+
+[Patches_RetroAchievements_Verified]
+$Disable Culling to Fix Rise and Shrine Hang

--- a/Data/Sys/GameSettings/GU2D78.ini
+++ b/Data/Sys/GameSettings/GU2D78.ini
@@ -13,3 +13,6 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 # Patch has been made conditional to prevent causing issues on disc 2.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GU2F78.ini
+++ b/Data/Sys/GameSettings/GU2F78.ini
@@ -13,3 +13,6 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 # Patch has been made conditional to prevent causing issues on disc 2.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GU3D78.ini
+++ b/Data/Sys/GameSettings/GU3D78.ini
@@ -13,3 +13,6 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 # The patch has been made conditional as not to crash disc 2's game.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GU3X78.ini
+++ b/Data/Sys/GameSettings/GU3X78.ini
@@ -13,3 +13,6 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 # The patch has been made conditional as not to crash disc 2's game.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GU4Y78.ini
+++ b/Data/Sys/GameSettings/GU4Y78.ini
@@ -20,3 +20,6 @@ $EFB Copy Fix
 # Vertex Rounding Hack must be enabled.
 # These patches have been made conditional.
 $EFB Copy Fix
+
+[Patches_RetroAchievements_Verified]
+$EFB Copy Fix

--- a/Data/Sys/GameSettings/GV4E69.ini
+++ b/Data/Sys/GameSettings/GV4E69.ini
@@ -5,3 +5,6 @@ $Fix 2D Rendering
 0x80319214:dword:0x48113250
 [OnFrame_Enabled]
 $Fix 2D Rendering
+
+[Patches_RetroAchievements_Verified]
+$Fix 2D Rendering

--- a/Data/Sys/GameSettings/GVPE69.ini
+++ b/Data/Sys/GameSettings/GVPE69.ini
@@ -5,3 +5,6 @@ $Fix 2D Rendering
 0x803C92D4:dword:0x480DA8E4
 [OnFrame_Enabled]
 $Fix 2D Rendering
+
+[Patches_RetroAchievements_Verified]
+$Fix 2D Rendering

--- a/Data/Sys/GameSettings/GWLE6L.ini
+++ b/Data/Sys/GameSettings/GWLE6L.ini
@@ -5,3 +5,6 @@ $Bypass FIFO reset
 0x8028EF00:dword:0x48000638
 [OnFrame_Enabled]
 $Bypass FIFO reset
+
+[Patches_RetroAchievements_Verified]
+$Bypass FIFO reset

--- a/Data/Sys/GameSettings/GWLX6L.ini
+++ b/Data/Sys/GameSettings/GWLX6L.ini
@@ -5,3 +5,6 @@ $Bypass FIFO reset
 0x8028EE80:dword:0x48000638
 [OnFrame_Enabled]
 $Bypass FIFO reset
+
+[Patches_RetroAchievements_Verified]
+$Bypass FIFO reset

--- a/Data/Sys/GameSettings/GXXE01.ini
+++ b/Data/Sys/GameSettings/GXXE01.ini
@@ -5,3 +5,6 @@
 $Allow Memory Card saving with Savestates
 0x801cc304:dword:0x90e5002c
 0x801cc4b0:dword:0x60000000
+
+[Patches_RetroAchievements_Verified]
+$Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GXXJ01.ini
+++ b/Data/Sys/GameSettings/GXXJ01.ini
@@ -5,3 +5,6 @@
 $Allow Memory Card saving with Savestates
 0x801c7984:dword:0x90e5002c
 0x801c7b30:dword:0x60000000
+
+[Patches_RetroAchievements_Verified]
+$Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GXXP01.ini
+++ b/Data/Sys/GameSettings/GXXP01.ini
@@ -5,3 +5,6 @@
 $Allow Memory Card saving with Savestates
 0x801cd764:dword:0x90e5002c
 0x801cd910:dword:0x60000000
+
+[Patches_RetroAchievements_Verified]
+$Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GZ2E01.ini
+++ b/Data/Sys/GameSettings/GZ2E01.ini
@@ -39,6 +39,9 @@ $Hyrule Field Speed Hack
 0x8003D5EC:dword:0x60000000
 0x8003D608:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$Hyrule Field Speed Hack
+
 [ActionReplay]
 # Add action replay cheats here.
 $Infinite Health

--- a/Data/Sys/GameSettings/GZ2J01.ini
+++ b/Data/Sys/GameSettings/GZ2J01.ini
@@ -35,3 +35,6 @@ $Hyrule Field Speed Hack
 0x8003D5D4:dword:0x60000000
 0x8003D5EC:dword:0x60000000
 0x8003D608:dword:0x60000000
+
+[Patches_RetroAchievements_Verified]
+$Hyrule Field Speed Hack

--- a/Data/Sys/GameSettings/GZ2P01.ini
+++ b/Data/Sys/GameSettings/GZ2P01.ini
@@ -39,6 +39,9 @@ $Hyrule Field Speed Hack
 0x8003d71c:dword:0x60000000
 0x8003d738:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$Hyrule Field Speed Hack
+
 [ActionReplay]
 # Add action replay cheats here.
 $Infinite Health

--- a/Data/Sys/GameSettings/HAF.ini
+++ b/Data/Sys/GameSettings/HAF.ini
@@ -19,6 +19,9 @@ $BufferPatch
 0x8000B08E:word:0x00000008
 0x8000B09E:word:0x00007000
 
+[Patches_RetroAchievements_Verified]
+$BufferPatch
+
 [WC24Patch]
 $Main
 weather.wapp.wii.com:fore.wiilink24.com:1

--- a/Data/Sys/GameSettings/HAL.ini
+++ b/Data/Sys/GameSettings/HAL.ini
@@ -11,6 +11,9 @@ $RSAPatch
 0x8001AB20:dword:0x38600001
 0x8001AC68:dword:0x38600001
 
+[Patches_RetroAchievements_Verified]
+$RSAPatch
+
 [WC24Patch]
 $Main
 cfh.wapp.wii.com:ch.wiilink24.com:1

--- a/Data/Sys/GameSettings/RELJAB.ini
+++ b/Data/Sys/GameSettings/RELJAB.ini
@@ -13,6 +13,9 @@ $DI Seed Blanker
 0x80000004:dword:0x00000000
 0x80000008:dword:0x00000000
 
+[Patches_RetroAchievements_Verified]
+$DI Seed Blanker
+
 [ActionReplay]
 # Add action replay cheats here.
 

--- a/Data/Sys/GameSettings/RGQE70.ini
+++ b/Data/Sys/GameSettings/RGQE70.ini
@@ -8,5 +8,8 @@
 $crashfix
 0x8006935C:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$crashfix
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/RLEEFS.ini
+++ b/Data/Sys/GameSettings/RLEEFS.ini
@@ -9,3 +9,6 @@ $Fix crash on main menu
 
 [OnFrame_Enabled]
 $Fix crash on main menu
+
+[Patches_RetroAchievements_Verified]
+$Fix crash on main menu

--- a/Data/Sys/GameSettings/RMHP08.ini
+++ b/Data/Sys/GameSettings/RMHP08.ini
@@ -9,5 +9,8 @@ $Bloom OFF
 0x80057058:dword:0xC022FFE4
 0x8079FF44:dword:0x3F800000
 
+[Patches_RetroAchievements_Verified]
+$Bloom OFF
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/RO2P7N.ini
+++ b/Data/Sys/GameSettings/RO2P7N.ini
@@ -10,5 +10,8 @@ $Hangfix
 0x8007D344:byte:0x00000090
 0x8007D348:byte:0x00000090
 
+[Patches_RetroAchievements_Verified]
+$Hangfix
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/RPBE01.ini
+++ b/Data/Sys/GameSettings/RPBE01.ini
@@ -8,3 +8,6 @@
 $Fix black screen effects
 0x80244A94:dword:0x39080000
 0x80244A9C:dword:0x38030000
+
+[Patches_RetroAchievements_Verified]
+$Fix black screen effects

--- a/Data/Sys/GameSettings/RPBJ01r0.ini
+++ b/Data/Sys/GameSettings/RPBJ01r0.ini
@@ -8,3 +8,6 @@
 $Fix black screen effects
 0x802342DC:dword:0x39080000
 0x802342E4:dword:0x38030000
+
+[Patches_RetroAchievements_Verified]
+$Fix black screen effects

--- a/Data/Sys/GameSettings/RPBJ01r1.ini
+++ b/Data/Sys/GameSettings/RPBJ01r1.ini
@@ -8,3 +8,6 @@
 $Fix black screen effects
 0x80234580:dword:0x39080000
 0x80234588:dword:0x38030000
+
+[Patches_RetroAchievements_Verified]
+$Fix black screen effects

--- a/Data/Sys/GameSettings/RPBJ01r2.ini
+++ b/Data/Sys/GameSettings/RPBJ01r2.ini
@@ -8,3 +8,6 @@
 $Fix black screen effects
 0x80234580:dword:0x39080000
 0x80234588:dword:0x38030000
+
+[Patches_RetroAchievements_Verified]
+$Fix black screen effects

--- a/Data/Sys/GameSettings/RPBP01.ini
+++ b/Data/Sys/GameSettings/RPBP01.ini
@@ -8,3 +8,6 @@
 $Fix black screen effects
 0x8023FF50:dword:0x39080000
 0x8023FF58:dword:0x38030000
+
+[Patches_RetroAchievements_Verified]
+$Fix black screen effects

--- a/Data/Sys/GameSettings/RTH.ini
+++ b/Data/Sys/GameSettings/RTH.ini
@@ -11,6 +11,9 @@
 $Disable blur
 0x8015b900:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$Disable blur
+
 [ActionReplay]
 # Add action replay cheats here.
 

--- a/Data/Sys/GameSettings/RX4E4Z.ini
+++ b/Data/Sys/GameSettings/RX4E4Z.ini
@@ -26,3 +26,6 @@ $Fix file reads (dcache bypass)
 0x800d2e68:dword:0x60000000
 [OnFrame_Enabled]
 $Fix file reads (dcache bypass)
+
+[Patches_RetroAchievements_Verified]
+$Fix file reads (dcache bypass)

--- a/Data/Sys/GameSettings/RX4PMT.ini
+++ b/Data/Sys/GameSettings/RX4PMT.ini
@@ -26,3 +26,6 @@ $Fix file reads (dcache bypass)
 0x80164b90:dword:0x60000000
 [OnFrame_Enabled]
 $Fix file reads (dcache bypass)
+
+[Patches_RetroAchievements_Verified]
+$Fix file reads (dcache bypass)

--- a/Data/Sys/GameSettings/RZDE01r0.ini
+++ b/Data/Sys/GameSettings/RZDE01r0.ini
@@ -38,5 +38,8 @@ $Hyrule Field Speed Hack
 0x80040D14:dword:0x60000000
 0x80040D30:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$Hyrule Field Speed Hack
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/RZDE01r2.ini
+++ b/Data/Sys/GameSettings/RZDE01r2.ini
@@ -38,5 +38,8 @@ $Hyrule Field Speed Hack
 0x80040EC4:dword:0x60000000
 0x80040EE0:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$Hyrule Field Speed Hack
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/RZDJ01.ini
+++ b/Data/Sys/GameSettings/RZDJ01.ini
@@ -37,5 +37,8 @@ $Hyrule Field Speed Hack
 0x80040E40:dword:0x60000000
 0x80040E5C:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$Hyrule Field Speed Hack
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/RZDK01.ini
+++ b/Data/Sys/GameSettings/RZDK01.ini
@@ -37,5 +37,8 @@ $Hyrule Field Speed Hack
 0x80047EC8:dword:0x60000000
 0x80047EE4:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$Hyrule Field Speed Hack
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/RZDP01.ini
+++ b/Data/Sys/GameSettings/RZDP01.ini
@@ -38,5 +38,8 @@ $Hyrule Field Speed Hack
 0x80040f90:dword:0x60000000
 0x80040fac:dword:0x60000000
 
+[Patches_RetroAchievements_Verified]
+$Hyrule Field Speed Hack
+
 [ActionReplay]
 # Add action replay cheats here.

--- a/Data/Sys/GameSettings/SAOE78.ini
+++ b/Data/Sys/GameSettings/SAOE78.ini
@@ -7,3 +7,6 @@ $Fix crash on boot
 0x803A5F20:dword:0x60000000
 [OnFrame_Enabled]
 $Fix crash on boot
+
+[Patches_RetroAchievements_Verified]
+$Fix crash on boot

--- a/Data/Sys/GameSettings/SAOEVZ.ini
+++ b/Data/Sys/GameSettings/SAOEVZ.ini
@@ -7,3 +7,6 @@ $Fix crash on boot
 0x803A64D0:dword:0x60000000
 [OnFrame_Enabled]
 $Fix crash on boot
+
+[Patches_RetroAchievements_Verified]
+$Fix crash on boot

--- a/Data/Sys/GameSettings/SGLEA4.ini
+++ b/Data/Sys/GameSettings/SGLEA4.ini
@@ -6,3 +6,6 @@
 # incorrectly, but for now this patch makes the game playable.
 $Fix black screen
 0x801D59AC:dword:0x60000000
+
+[Patches_RetroAchievements_Verified]
+$Fix black screen

--- a/Data/Sys/GameSettings/SGLPA4.ini
+++ b/Data/Sys/GameSettings/SGLPA4.ini
@@ -6,3 +6,6 @@
 # incorrectly, but for now this patch makes the game playable.
 $Fix black screen
 0x801D59C8:dword:0x60000000
+
+[Patches_RetroAchievements_Verified]
+$Fix black screen

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -60,6 +60,10 @@
 #include "jni/AndroidCommon/AndroidCommon.h"
 #endif
 
+#if defined(__FreeBSD__)
+#include <sys/sysctl.h>
+#endif
+
 namespace fs = std::filesystem;
 
 namespace File
@@ -738,6 +742,15 @@ std::string GetExePath()
   return PathToString(exe_path_absolute);
 #elif defined(__APPLE__)
   return GetBundleDirectory();
+#elif defined(__FreeBSD__)
+  int name[4]{CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+  size_t length = 0;
+  if (sysctl(name, 4, nullptr, &length, nullptr, 0) != 0 || length == 0)
+    return {};
+  std::string dolphin_exe_path(length, '\0');
+  if (sysctl(name, 4, dolphin_exe_path.data(), &length, nullptr, 0) != 0)
+    return {};
+  return dolphin_exe_path;
 #else
   char dolphin_exe_path[PATH_MAX];
   ssize_t len = ::readlink("/proc/self/exe", dolphin_exe_path, sizeof(dolphin_exe_path));

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -14,6 +14,7 @@
 #include <rcheevos/include/rc_hash.h>
 
 #include "Common/Assert.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -26,6 +27,7 @@
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/VideoInterface.h"
+#include "Core/PatchEngine.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/System.h"
 #include "DiscIO/Blob.h"
@@ -68,6 +70,34 @@ void AchievementManager::Init()
       Login("");
     INFO_LOG_FMT(ACHIEVEMENTS, "Achievement Manager Initialized");
   }
+}
+
+void AchievementManager::LoadApprovedList()
+{
+  picojson::value temp;
+  std::string error;
+  if (!JsonFromFile(fmt::format("{}{}{}", File::GetSysDirectory(), DIR_SEP, APPROVED_LIST_FILENAME),
+                    &temp, &error))
+  {
+    WARN_LOG_FMT(ACHIEVEMENTS, "Failed to load approved game settings list {}",
+                 APPROVED_LIST_FILENAME);
+    WARN_LOG_FMT(ACHIEVEMENTS, "Error: {}", error);
+    return;
+  }
+  auto context = Common::SHA1::CreateContext();
+  context->Update(temp.serialize());
+  auto digest = context->Finish();
+  if (digest != APPROVED_LIST_HASH)
+  {
+    WARN_LOG_FMT(ACHIEVEMENTS, "Failed to verify approved game settings list {}",
+                 APPROVED_LIST_FILENAME);
+    WARN_LOG_FMT(ACHIEVEMENTS, "Expected hash {}, found hash {}",
+                 Common::SHA1::DigestToString(APPROVED_LIST_HASH),
+                 Common::SHA1::DigestToString(digest));
+    return;
+  }
+  std::lock_guard lg{m_lock};
+  m_ini_root = std::move(temp);
 }
 
 void AchievementManager::SetUpdateCallback(UpdateCallback callback)
@@ -320,6 +350,48 @@ bool AchievementManager::IsHardcoreModeActive() const
   if (!rc_client_get_game_info(m_client))
     return true;
   return rc_client_is_processing_required(m_client);
+}
+
+void AchievementManager::FilterApprovedPatches(std::vector<PatchEngine::Patch>& patches,
+                                               const std::string& game_ini_id) const
+{
+  if (!IsHardcoreModeActive())
+    return;
+
+  if (!m_ini_root.contains(game_ini_id))
+    patches.clear();
+  auto patch_itr = patches.begin();
+  while (patch_itr != patches.end())
+  {
+    INFO_LOG_FMT(ACHIEVEMENTS, "Verifying patch {}", patch_itr->name);
+
+    auto context = Common::SHA1::CreateContext();
+    context->Update(Common::BitCastToArray<u8>(static_cast<u64>(patch_itr->entries.size())));
+    for (const auto& entry : patch_itr->entries)
+    {
+      context->Update(Common::BitCastToArray<u8>(entry.type));
+      context->Update(Common::BitCastToArray<u8>(entry.address));
+      context->Update(Common::BitCastToArray<u8>(entry.value));
+      context->Update(Common::BitCastToArray<u8>(entry.comparand));
+      context->Update(Common::BitCastToArray<u8>(entry.conditional));
+    }
+    auto digest = context->Finish();
+
+    bool verified = m_ini_root.get(game_ini_id).contains(Common::SHA1::DigestToString(digest));
+    if (!verified)
+    {
+      patch_itr = patches.erase(patch_itr);
+      OSD::AddMessage(
+          fmt::format("Failed to verify patch {} from file {}.", patch_itr->name, game_ini_id),
+          OSD::Duration::VERY_LONG, OSD::Color::RED);
+      OSD::AddMessage("Disable hardcore mode to enable this patch.", OSD::Duration::VERY_LONG,
+                      OSD::Color::RED);
+    }
+    else
+    {
+      patch_itr++;
+    }
+  }
 }
 
 void AchievementManager::SetSpectatorMode()

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -27,6 +27,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/HttpRequest.h"
+#include "Common/JsonUtil.h"
 #include "Common/WorkQueueThread.h"
 #include "DiscIO/Volume.h"
 #include "VideoCommon/Assets/CustomTextureData.h"
@@ -36,6 +37,11 @@ namespace Core
 class CPUThreadGuard;
 class System;
 }  // namespace Core
+
+namespace PatchEngine
+{
+struct Patch;
+}  // namespace PatchEngine
 
 class AchievementManager
 {
@@ -60,6 +66,10 @@ public:
   static constexpr std::string_view GRAY = "transparent";
   static constexpr std::string_view GOLD = "#FFD700";
   static constexpr std::string_view BLUE = "#0B71C1";
+  static constexpr std::string_view APPROVED_LIST_FILENAME = "ApprovedInis.json";
+  static const inline Common::SHA1::Digest APPROVED_LIST_HASH = {
+      0x01, 0x1E, 0x2E, 0x74, 0xDD, 0x07, 0x79, 0xDA, 0x0E, 0x5D,
+      0xF8, 0x51, 0x09, 0xC7, 0x9B, 0x46, 0x22, 0x95, 0x50, 0xE9};
 
   struct LeaderboardEntry
   {
@@ -109,6 +119,9 @@ public:
   std::recursive_mutex& GetLock();
   void SetHardcoreMode();
   bool IsHardcoreModeActive() const;
+  void SetGameIniId(const std::string& game_ini_id) { m_game_ini_id = game_ini_id; }
+  void FilterApprovedPatches(std::vector<PatchEngine::Patch>& patches,
+                             const std::string& game_ini_id) const;
   void SetSpectatorMode();
   std::string_view GetPlayerDisplayName() const;
   u32 GetPlayerScore() const;
@@ -132,13 +145,15 @@ public:
   void Shutdown();
 
 private:
-  AchievementManager() = default;
+  AchievementManager() { LoadApprovedList(); };
 
   struct FilereaderState
   {
     int64_t position = 0;
     std::unique_ptr<DiscIO::Volume> volume;
   };
+
+  void LoadApprovedList();
 
   static void* FilereaderOpenByFilepath(const char* path_utf8);
   static void* FilereaderOpenByVolume(const char* path_utf8);
@@ -210,6 +225,9 @@ private:
   RichPresence m_rich_presence;
   std::chrono::steady_clock::time_point m_last_rp_time = std::chrono::steady_clock::now();
   std::chrono::steady_clock::time_point m_last_progress_message = std::chrono::steady_clock::now();
+
+  picojson::value m_ini_root;
+  std::string m_game_ini_id;
 
   std::unordered_map<AchievementId, LeaderboardStatus> m_leaderboard_map;
   bool m_challenges_updated = false;

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -182,6 +182,13 @@ void LoadPatches()
 
   LoadPatchSection("OnFrame", &s_on_frame, globalIni, localIni);
 
+#ifdef USE_RETRO_ACHIEVEMENTS
+  {
+    std::lock_guard lg{AchievementManager::GetInstance().GetLock()};
+    AchievementManager::GetInstance().FilterApprovedPatches(s_on_frame, sconfig.GetGameID());
+  }
+#endif  // USE_RETRO_ACHIEVEMENTS
+
   // Check if I'm syncing Codes
   if (Config::Get(Config::SESSION_CODE_SYNC_OVERRIDE))
   {
@@ -197,9 +204,6 @@ void LoadPatches()
 
 static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Patch>& patches)
 {
-  if (AchievementManager::GetInstance().IsHardcoreModeActive())
-    return;
-
   for (const Patch& patch : patches)
   {
     if (patch.enabled)

--- a/Source/UnitTests/CMakeLists.txt
+++ b/Source/UnitTests/CMakeLists.txt
@@ -8,6 +8,9 @@ add_executable(tests EXCLUDE_FROM_ALL UnitTestsMain.cpp StubHost.cpp)
 set_target_properties(tests PROPERTIES FOLDER Tests)
 target_link_libraries(tests PRIVATE fmt::fmt gtest::gtest core uicommon)
 add_test(NAME tests COMMAND tests)
+add_custom_command(TARGET tests POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/Data/Sys" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sys"
+)
 add_dependencies(unittests tests)
 
 macro(add_dolphin_test target)

--- a/Source/UnitTests/Core/CMakeLists.txt
+++ b/Source/UnitTests/Core/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_dolphin_test(MMIOTest MMIOTest.cpp)
 add_dolphin_test(PageFaultTest PageFaultTest.cpp)
 add_dolphin_test(CoreTimingTest CoreTimingTest.cpp)
+add_dolphin_test(PatchAllowlistTest PatchAllowlistTest.cpp)
 
 add_dolphin_test(DSPAcceleratorTest DSP/DSPAcceleratorTest.cpp)
 add_dolphin_test(DSPAssemblyTest

--- a/Source/UnitTests/Core/PatchAllowlistTest.cpp
+++ b/Source/UnitTests/Core/PatchAllowlistTest.cpp
@@ -1,0 +1,138 @@
+// Copyright 2024 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <array>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <picojson.h>
+
+#include "Common/BitUtils.h"
+#include "Common/CommonPaths.h"
+#include "Common/Crypto/SHA1.h"
+#include "Common/FileUtil.h"
+#include "Common/IOFile.h"
+#include "Common/IniFile.h"
+#include "Common/JsonUtil.h"
+#include "Core/CheatCodes.h"
+#include "Core/PatchEngine.h"
+
+struct GameHashes
+{
+  std::string game_title;
+  std::map<std::string /*hash*/, std::string /*patch name*/> hashes;
+};
+
+TEST(PatchAllowlist, VerifyHashes)
+{
+  // Load allowlist
+  static constexpr std::string_view APPROVED_LIST_FILENAME = "ApprovedInis.json";
+  picojson::value json_tree;
+  std::string error;
+  std::string cur_directory = File::GetExeDirectory()
+#if defined(__APPLE__)
+                              + DIR_SEP "Tests"  // FIXME: Ugly hack.
+#endif
+      ;
+  std::string sys_directory = cur_directory + DIR_SEP "Sys";
+  const auto& list_filepath = fmt::format("{}{}{}", sys_directory, DIR_SEP, APPROVED_LIST_FILENAME);
+  ASSERT_TRUE(JsonFromFile(list_filepath, &json_tree, &error))
+      << "Failed to open file at " << list_filepath;
+  // Parse allowlist - Map<game id, Map<hash, name>
+  ASSERT_TRUE(json_tree.is<picojson::object>());
+  std::map<std::string /*ID*/, GameHashes> allow_list;
+  for (const auto& entry : json_tree.get<picojson::object>())
+  {
+    ASSERT_TRUE(entry.second.is<picojson::object>());
+    GameHashes& game_entry = allow_list[entry.first];
+    for (const auto& line : entry.second.get<picojson::object>())
+    {
+      ASSERT_TRUE(line.second.is<std::string>());
+      if (line.first == "title")
+        game_entry.game_title = line.second.get<std::string>();
+      else
+        game_entry.hashes[line.first] = line.second.get<std::string>();
+    }
+  }
+  // Iterate over GameSettings directory
+  auto directory =
+      File::ScanDirectoryTree(fmt::format("{}{}GameSettings", sys_directory, DIR_SEP), false);
+  for (const auto& file : directory.children)
+  {
+    // Load ini file
+    Common::IniFile ini_file;
+    ini_file.Load(file.physicalName, true);
+    std::string game_id = file.virtualName.substr(0, file.virtualName.find_first_of('.'));
+    std::vector<PatchEngine::Patch> patches;
+    PatchEngine::LoadPatchSection("OnFrame", &patches, ini_file, Common::IniFile());
+    // Filter patches for RetroAchievements approved
+    ReadEnabledOrDisabled<PatchEngine::Patch>(ini_file, "OnFrame", false, &patches);
+    ReadEnabledOrDisabled<PatchEngine::Patch>(ini_file, "Patches_RetroAchievements_Verified", true,
+                                              &patches);
+    // Get game section from allow list
+    auto game_itr = allow_list.find(game_id);
+    // Iterate over approved patches
+    for (const auto& patch : patches)
+    {
+      if (!patch.enabled)
+        continue;
+      // Hash patch
+      auto context = Common::SHA1::CreateContext();
+      context->Update(Common::BitCastToArray<u8>(static_cast<u64>(patch.entries.size())));
+      for (const auto& entry : patch.entries)
+      {
+        context->Update(Common::BitCastToArray<u8>(entry.type));
+        context->Update(Common::BitCastToArray<u8>(entry.address));
+        context->Update(Common::BitCastToArray<u8>(entry.value));
+        context->Update(Common::BitCastToArray<u8>(entry.comparand));
+        context->Update(Common::BitCastToArray<u8>(entry.conditional));
+      }
+      auto digest = context->Finish();
+      std::string hash = Common::SHA1::DigestToString(digest);
+      // Check patch in list
+      if (game_itr == allow_list.end())
+      {
+        // Report: no patches in game found in list
+        ADD_FAILURE() << "Approved hash missing from list." << std::endl
+                      << "Game ID: " << game_id << std::endl
+                      << "Patch: \"" << hash << "\" : \"" << patch.name << "\"";
+        continue;
+      }
+      auto hash_itr = game_itr->second.hashes.find(hash);
+      if (hash_itr == game_itr->second.hashes.end())
+      {
+        // Report: patch not found in list
+        ADD_FAILURE() << "Approved hash missing from list." << std::endl
+                      << "Game ID: " << game_id << ":" << game_itr->second.game_title << std::endl
+                      << "Patch: \"" << hash << "\" : \"" << patch.name << "\"";
+      }
+      else
+      {
+        // Remove patch from map if found
+        game_itr->second.hashes.erase(hash_itr);
+      }
+    }
+    // Report missing patches in map
+    if (game_itr == allow_list.end())
+      continue;
+    for (auto& remaining_hashes : game_itr->second.hashes)
+    {
+      ADD_FAILURE() << "Hash in list not approved in ini." << std::endl
+                    << "Game ID: " << game_id << ":" << game_itr->second.game_title << std::endl
+                    << "Patch: " << remaining_hashes.second << ":" << remaining_hashes.first;
+    }
+    //    Remove section from map
+    allow_list.erase(game_itr);
+  }
+  //  Report remaining sections in map
+  for (auto& remaining_games : allow_list)
+  {
+    ADD_FAILURE() << "Game in list has no ini file." << std::endl
+                  << "Game ID: " << remaining_games.first << ":"
+                  << remaining_games.second.game_title;
+  }
+}

--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -24,6 +24,9 @@
     <Link>
       <SubSystem>Console</SubSystem>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy /i /e /s /y /f "$(ProjectDir)\..\..\Data\Sys\" "$(TargetDir)Sys"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Core\DSP\DSPTestBinary.h" />
@@ -70,6 +73,7 @@
     <ClCompile Include="Core\IOS\USB\SkylandersTest.cpp" />
     <ClCompile Include="Core\MMIOTest.cpp" />
     <ClCompile Include="Core\PageFaultTest.cpp" />
+    <ClCompile Include="Core\PatchAllowlistTest.cpp" />
     <ClCompile Include="Core\PowerPC\DivUtilsTest.cpp" />
     <ClCompile Include="VideoCommon\VertexLoaderTest.cpp" />
     <ClCompile Include="StubHost.cpp" />
@@ -101,6 +105,7 @@
   </ItemGroup>
   <Import Project="$(ExternalsDir)Bochs_disasm\exports.props" />
   <Import Project="$(ExternalsDir)fmt\exports.props" />
+  <Import Project="$(ExternalsDir)picojson\exports.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
This unit test compares ApprovedInis.json with the contents of the GameSettings folder to verify that every patch marked allowed for use with RetroAchievements has a hash in ApprovedInis.json. If not, that hash is reported in the test logs so that the hash may be updated more easily.