### PR TITLE
Common/Crypto/SHA1: Use span and string_view for Context::Update()

### DIFF
--- a/Source/Core/Common/Crypto/SHA1.h
+++ b/Source/Core/Common/Crypto/SHA1.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <limits>
 #include <memory>
+#include <span>
 #include <string_view>
 #include <type_traits>
 #include <vector>
@@ -23,7 +24,11 @@ class Context
 public:
   virtual ~Context() = default;
   virtual void Update(const u8* msg, size_t len) = 0;
-  void Update(const std::vector<u8>& msg) { return Update(msg.data(), msg.size()); }
+  void Update(std::span<const u8> msg) { return Update(msg.data(), msg.size()); }
+  void Update(std::string_view msg)
+  {
+    return Update(reinterpret_cast<const u8*>(msg.data()), msg.size());
+  }
   virtual Digest Finish() = 0;
   virtual bool HwAccelerated() const = 0;
 };


### PR DESCRIPTION
I also tried updating the `CalculateDigest()` below to use spans but for some reason the compiler is bad at automatically deducing the template type if you do that. Oh well, this is still worthwhile on its own IMO.

```
template <typename T>
inline Digest CalculateDigest(std::span<const T> msg)
{
  static_assert(std::is_trivially_copyable_v<T>);
  ASSERT(std::numeric_limits<size_t>::max() / sizeof(T) >= msg.size());
  return CalculateDigest(reinterpret_cast<const u8*>(msg.data()), sizeof(T) * msg.size());
}
```

```
C:\dolphin\Source\Core\Core\IOS\ES\Identity.cpp(194): error C2665: 'Common::SHA1::CalculateDigest': no overloaded function could convert all the argument types
  C:\dolphin\Source\Core\Common/Crypto/SHA1.h(48): note: could be 'Common::SHA1::Digest Common::SHA1::CalculateDigest(const std::string_view &)'
  C:\dolphin\Source\Core\Core\IOS\ES\Identity.cpp(194): note: 'Common::SHA1::Digest Common::SHA1::CalculateDigest(const std::string_view &)': cannot convert argument 1 from 'const std::vector<u8,std::allocator<u8>>' to 'const std::string_view &'
  C:\dolphin\Source\Core\Core\IOS\ES\Identity.cpp(194): note: Reason: cannot convert from 'const std::vector<u8,std::allocator<u8>>' to 'const std::string_view'
  C:\dolphin\Source\Core\Core\IOS\ES\Identity.cpp(194): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
  C:\dolphin\Source\Core\Common/Crypto/SHA1.h(41): note: or       'Common::SHA1::Digest Common::SHA1::CalculateDigest(std::span<const T,18446744073709551615>)'
  C:\dolphin\Source\Core\Core\IOS\ES\Identity.cpp(194): note: 'Common::SHA1::Digest Common::SHA1::CalculateDigest(std::span<const T,18446744073709551615>)': could not deduce template argument for 'std::span<const T,18446744073709551615>' from 'const std::vector<u8,std::allocator<u8>>'
  C:\dolphin\Source\Core\Core\IOS\ES\Identity.cpp(194): note: while trying to match the argument list '(const std::vector<u8,std::allocator<u8>>)'
```