### PR TITLE
Partially revert "Revert "Audit uses of IsRunning and GetState""

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -381,9 +381,15 @@ public final class NativeLibrary
    */
   public static native boolean IsRunning();
 
-  public static native boolean IsRunningAndStarted();
-
+  /**
+   * Returns true if emulation is running and not paused.
+   */
   public static native boolean IsRunningAndUnpaused();
+
+  /**
+   * Returns true if emulation is fully shut down.
+   */
+  public static native boolean IsUninitialized();
 
   /**
    * Writes out the JitBlock Cache log dump

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
@@ -36,7 +36,7 @@ class Settings : Closeable {
 
         if (isGameSpecific) {
             // Loading game INIs while the core is running will mess with the game INIs loaded by the core
-            check(!NativeLibrary.IsRunning()) { "Attempted to load game INI while emulating" }
+            check(NativeLibrary.IsUninitialized()) { "Attempted to load game INI while emulating" }
             NativeConfig.loadGameInis(gameId, revision)
         }
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/RunRunnable.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/RunRunnable.kt
@@ -20,5 +20,5 @@ class RunRunnable(
     override val setting: AbstractSetting? = null
 
     override val isEditable: Boolean
-        get() = worksDuringEmulation || !NativeLibrary.IsRunning()
+        get() = worksDuringEmulation || NativeLibrary.IsUninitialized()
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.kt
@@ -54,7 +54,7 @@ abstract class SettingsItem {
 
     open val isEditable: Boolean
         get() {
-            if (!NativeLibrary.IsRunning()) return true
+            if (NativeLibrary.IsUninitialized()) return true
             val setting = setting
             return setting != null && setting.isRuntimeEditable
         }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -69,7 +69,7 @@ class SettingsFragmentPresenter(
         } else if (
             menuTag == MenuTag.GRAPHICS
             && this.gameId.isNullOrEmpty()
-            && !NativeLibrary.IsRunning()
+            && NativeLibrary.IsUninitialized()
             && GpuDriverHelper.supportsCustomDriverLoading()
         ) {
             this.gpuDriver =
@@ -1303,7 +1303,7 @@ class SettingsFragmentPresenter(
 
         if (
             this.gpuDriver != null && this.gameId.isNullOrEmpty()
-            && !NativeLibrary.IsRunning()
+            && NativeLibrary.IsUninitialized()
             && GpuDriverHelper.supportsCustomDriverLoading()
         ) {
             sl.add(

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
@@ -180,11 +180,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
 
     private fun run(isActivityRecreated: Boolean) {
         if (isActivityRecreated) {
-            if (NativeLibrary.IsRunning()) {
+            if (NativeLibrary.IsUninitialized()) {
+                loadPreviousTemporaryState = true
+            } else {
                 loadPreviousTemporaryState = false
                 deleteFile(temporaryStateFilePath)
-            } else {
-                loadPreviousTemporaryState = true
             }
         } else {
             Log.debug("[EmulationFragment] activity resumed or fresh start")
@@ -203,7 +203,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
 
     private fun runWithValidSurface() {
         runWhenSurfaceIsValid = false
-        if (!NativeLibrary.IsRunning()) {
+        if (NativeLibrary.IsUninitialized()) {
             NativeLibrary.SetIsBooting()
             val emulationThread = Thread({
                 if (loadPreviousTemporaryState) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.kt
@@ -83,7 +83,7 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
 
     fun initTouchPointer() {
         // Check if we have all the data we need yet
-        val aspectRatioAvailable = NativeLibrary.IsRunningAndStarted()
+        val aspectRatioAvailable = NativeLibrary.IsRunning()
         if (!aspectRatioAvailable || surfacePosition == null)
             return
 

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -118,8 +118,7 @@ void Host_Message(HostMessageID id)
   }
   else if (id == HostMessageID::WMUserStop)
   {
-    if (Core::IsRunning(Core::System::GetInstance()))
-      Core::QueueHostJob(&Core::Stop);
+    Core::QueueHostJob(&Core::Stop);
   }
 }
 
@@ -277,13 +276,6 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetIsBooting
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunning(JNIEnv*, jclass)
 {
-  return s_is_booting.IsSet() ||
-         static_cast<jboolean>(Core::IsRunning(Core::System::GetInstance()));
-}
-
-JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunningAndStarted(JNIEnv*,
-                                                                                            jclass)
-{
   return static_cast<jboolean>(Core::IsRunning(Core::System::GetInstance()));
 }
 
@@ -291,6 +283,13 @@ JNIEXPORT jboolean JNICALL
 Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunningAndUnpaused(JNIEnv*, jclass)
 {
   return static_cast<jboolean>(Core::GetState(Core::System::GetInstance()) == Core::State::Running);
+}
+
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsUninitialized(JNIEnv*,
+                                                                                        jclass)
+{
+  return static_cast<jboolean>(Core::IsUninitialized(Core::System::GetInstance()) &&
+                               !s_is_booting.IsSet());
 }
 
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetVersionString(JNIEnv* env,

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -211,6 +211,11 @@ bool IsRunningOrStarting(Core::System& system)
   return state == State::Running || state == State::Starting;
 }
 
+bool IsUninitialized(Core::System& system)
+{
+  return s_state.load() == State::Uninitialized;
+}
+
 bool IsCPUThread()
 {
   return tls_is_cpu_thread;
@@ -237,7 +242,7 @@ bool Init(Core::System& system, std::unique_ptr<BootParameters> boot, const Wind
 {
   if (s_emu_thread.joinable())
   {
-    if (IsRunning(system))
+    if (!IsUninitialized(system))
     {
       PanicAlertFmtT("Emu Thread already running");
       return false;

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -134,8 +134,13 @@ void UndeclareAsHostThread();
 
 std::string StopMessage(bool main_thread, std::string_view message);
 
+// Returns true when GetState returns Running or Paused.
 bool IsRunning(Core::System& system);
+// Returns true when GetState returns Starting, Running or Paused.
 bool IsRunningOrStarting(Core::System& system);
+// Returns true when GetState returns Uninitialized.
+bool IsUninitialized(Core::System& system);
+
 bool IsCPUThread();  // this tells us whether we are the CPU thread.
 bool IsGPUThread();
 bool IsHostThread();

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -533,7 +533,7 @@ bool EmulationKernel::BootIOS(const u64 ios_title_id, HangPPC hang_ppc,
 
 void EmulationKernel::InitIPC()
 {
-  if (Core::GetState(m_system) == Core::State::Uninitialized)
+  if (Core::IsUninitialized(m_system))
     return;
 
   INFO_LOG_FMT(IOS, "IPC initialised.");

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -177,6 +177,8 @@ void AchievementSettingsWidget::OnControllerInterfaceConfigure()
 
 void AchievementSettingsWidget::LoadSettings()
 {
+  Core::System& system = Core::System::GetInstance();
+
   bool enabled = Config::Get(Config::RA_ENABLED);
   bool hardcore_enabled = Config::Get(Config::RA_HARDCORE_ENABLED);
   bool logged_out = Config::Get(Config::RA_API_TOKEN).empty();
@@ -192,27 +194,20 @@ void AchievementSettingsWidget::LoadSettings()
   SignalBlocking(m_common_password_input)->setVisible(logged_out);
   SignalBlocking(m_common_password_input)->setEnabled(enabled);
   SignalBlocking(m_common_login_button)->setVisible(logged_out);
-  SignalBlocking(m_common_login_button)
-      ->setEnabled(enabled && !Core::IsRunning(Core::System::GetInstance()));
-  if (enabled && Core::IsRunning(Core::System::GetInstance()))
-  {
-    SignalBlocking(m_common_login_button)->setText(tr("To log in, stop the current emulation."));
-  }
-  else
-  {
+  SignalBlocking(m_common_login_button)->setEnabled(enabled && Core::IsUninitialized(system));
+  if (!enabled || Core::IsUninitialized(system))
     SignalBlocking(m_common_login_button)->setText(tr("Log In"));
-  }
+  else
+    SignalBlocking(m_common_login_button)->setText(tr("To log in, stop the current emulation."));
 
   SignalBlocking(m_common_logout_button)->setVisible(!logged_out);
   SignalBlocking(m_common_logout_button)->setEnabled(enabled);
 
   SignalBlocking(m_common_hardcore_enabled_input)
       ->setChecked(Config::Get(Config::RA_HARDCORE_ENABLED));
-  auto& system = Core::System::GetInstance();
   SignalBlocking(m_common_hardcore_enabled_input)
-      ->setEnabled(enabled &&
-                   (hardcore_enabled || (Core::GetState(system) == Core::State::Uninitialized &&
-                                         !system.GetMovie().IsPlayingInput())));
+      ->setEnabled(enabled && (hardcore_enabled || (Core::IsUninitialized(system) &&
+                                                    !system.GetMovie().IsPlayingInput())));
 
   SignalBlocking(m_common_unofficial_enabled_input)
       ->setChecked(Config::Get(Config::RA_UNOFFICIAL_ENABLED));

--- a/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
@@ -159,8 +159,7 @@ void CheatSearchFactoryWidget::OnNewSearchClicked()
   if (m_standard_address_space->isChecked())
   {
     auto& system = Core::System::GetInstance();
-    const Core::State core_state = Core::GetState(system);
-    if (core_state != Core::State::Running && core_state != Core::State::Paused)
+    if (!Core::IsRunning(system))
     {
       ModalMessageBox::warning(
           this, tr("No game running."),

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -102,8 +102,9 @@ void CheatsManager::RefreshCodeTabs(Core::State state)
   if (state == Core::State::Starting || state == Core::State::Stopping)
     return;
 
-  const auto& game_id =
-      state != Core::State::Uninitialized ? SConfig::GetInstance().GetGameID() : std::string();
+  const auto& game_id = state == Core::State::Running || state == Core::State::Paused ?
+                            SConfig::GetInstance().GetGameID() :
+                            std::string();
   const auto& game_tdb_id = SConfig::GetInstance().GetGameTDBID();
   const u16 revision = SConfig::GetInstance().GetRevision();
 

--- a/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
@@ -24,8 +24,9 @@ CheatWarningWidget::CheatWarningWidget(const std::string& game_id, bool restart_
 
   connect(&Settings::Instance(), &Settings::EnableCheatsChanged, this,
           [this] { Update(Core::IsRunning(Core::System::GetInstance())); });
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
-          [this](Core::State state) { Update(state == Core::State::Running); });
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
+    Update(state == Core::State::Running || state == Core::State::Paused);
+  });
 
   Update(Core::IsRunning(Core::System::GetInstance()));
 }

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -43,8 +43,7 @@ AdvancedWidget::AdvancedWidget(GraphicsWindow* parent)
   });
 
   OnBackendChanged();
-  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()) !=
-                          Core::State::Uninitialized);
+  OnEmulationStateChanged(!Core::IsUninitialized(Core::System::GetInstance()));
 }
 
 void AdvancedWidget::CreateWidgets()

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -44,8 +44,7 @@ GeneralWidget::GeneralWidget(GraphicsWindow* parent)
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     OnEmulationStateChanged(state != Core::State::Uninitialized);
   });
-  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()) !=
-                          Core::State::Uninitialized);
+  OnEmulationStateChanged(!Core::IsUninitialized(Core::System::GetInstance()));
 }
 
 void GeneralWidget::CreateWidgets()
@@ -361,7 +360,8 @@ void GeneralWidget::OnBackendChanged(const QString& backend_name)
   const bool supports_adapters = !adapters.empty();
 
   m_adapter_combo->setCurrentIndex(g_Config.iAdapter);
-  m_adapter_combo->setEnabled(supports_adapters && !Core::IsRunning(Core::System::GetInstance()));
+  m_adapter_combo->setEnabled(supports_adapters &&
+                              Core::IsUninitialized(Core::System::GetInstance()));
 
   static constexpr char TR_ADAPTER_AVAILABLE_DESCRIPTION[] =
       QT_TR_NOOP("Selects a hardware adapter to use.<br><br>"

--- a/Source/Core/DolphinQt/Debugger/AssemblerWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/AssemblerWidget.cpp
@@ -791,7 +791,7 @@ bool AssemblerWidget::SaveEditor(AsmEditor* editor)
 
 void AssemblerWidget::OnEmulationStateChanged(Core::State state)
 {
-  m_inject->setEnabled(state != Core::State::Uninitialized);
+  m_inject->setEnabled(state == Core::State::Running || state == Core::State::Paused);
 }
 
 void AssemblerWidget::OnTabClose(int index)

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -257,9 +257,9 @@ void BreakpointWidget::UpdateButtonsEnabled()
   if (!isVisible())
     return;
 
-  const bool is_initialised = Core::GetState(m_system) != Core::State::Uninitialized;
-  m_load->setEnabled(is_initialised);
-  m_save->setEnabled(is_initialised);
+  const bool is_running = Core::IsRunning(m_system);
+  m_load->setEnabled(is_running);
+  m_save->setEnabled(is_running);
 }
 
 void BreakpointWidget::Update()

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -565,7 +565,7 @@ void CodeViewWidget::OnContextMenu()
   QMenu* menu = new QMenu(this);
   menu->setAttribute(Qt::WA_DeleteOnClose, true);
 
-  const bool running = Core::GetState(m_system) != Core::State::Uninitialized;
+  const bool running = Core::IsRunning(m_system);
   const bool paused = Core::GetState(m_system) == Core::State::Paused;
 
   const u32 addr = GetContextAddress();

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -258,7 +258,7 @@ void ThreadWidget::Update()
 
   auto& system = Core::System::GetInstance();
   const auto emu_state = Core::GetState(system);
-  if (emu_state == Core::State::Stopping)
+  if (emu_state == Core::State::Stopping || emu_state == Core::State::Uninitialized)
   {
     m_thread_table->setRowCount(0);
     UpdateThreadContext({});

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -195,10 +195,11 @@ void WatchWidget::Update()
 
     QBrush brush = QPalette().brush(QPalette::Text);
 
-    if (!Core::IsRunning(m_system) || !PowerPC::MMU::HostIsRAMAddress(guard, entry.address))
+    const bool core_is_running = Core::IsRunning(m_system);
+    if (!core_is_running || !PowerPC::MMU::HostIsRAMAddress(guard, entry.address))
       brush.setColor(Qt::red);
 
-    if (Core::IsRunning(m_system))
+    if (core_is_running)
     {
       if (PowerPC::MMU::HostIsRAMAddress(guard, entry.address))
       {

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -59,10 +59,14 @@ FIFOPlayerWindow::FIFOPlayerWindow(FifoPlayer& fifo_player, FifoRecorder& fifo_r
   });
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
+    if (state == m_emu_state)
+      return;
+
     if (state == Core::State::Running && m_emu_state != Core::State::Paused)
       OnEmulationStarted();
     else if (state == Core::State::Uninitialized)
       OnEmulationStopped();
+
     m_emu_state = state;
   });
 
@@ -376,9 +380,11 @@ void FIFOPlayerWindow::UpdateLimits()
 
 void FIFOPlayerWindow::UpdateControls()
 {
-  bool running = Core::IsRunning(Core::System::GetInstance());
-  bool is_recording = m_fifo_recorder.IsRecording();
-  bool is_playing = m_fifo_player.IsPlaying();
+  Core::System& system = Core::System::GetInstance();
+  const bool core_is_uninitialized = Core::IsUninitialized(system);
+  const bool core_is_running = Core::IsRunning(system);
+  const bool is_recording = m_fifo_recorder.IsRecording();
+  const bool is_playing = m_fifo_player.IsPlaying();
 
   m_frame_range_from->setEnabled(is_playing);
   m_frame_range_from_label->setEnabled(is_playing);
@@ -394,10 +400,10 @@ void FIFOPlayerWindow::UpdateControls()
   m_frame_record_count_label->setEnabled(enable_frame_record_count);
   m_frame_record_count->setEnabled(enable_frame_record_count);
 
-  m_load->setEnabled(!running);
-  m_record->setEnabled(running && !is_playing);
+  m_load->setEnabled(core_is_uninitialized);
+  m_record->setEnabled(core_is_running && !is_playing);
 
-  m_stop->setVisible(running && is_recording);
+  m_stop->setVisible(core_is_running && is_recording);
   m_record->setVisible(!m_stop->isVisible());
 
   m_save->setEnabled(m_fifo_recorder.IsRecordingDone());

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -436,7 +436,7 @@ void GameList::ShowContextMenu(const QPoint&)
                                                     // system menu, trigger a refresh.
                                                     Settings::Instance().NANDRefresh();
                                                   });
-      perform_disc_update->setEnabled(!Core::IsRunning(system) || !system.IsWii());
+      perform_disc_update->setEnabled(Core::IsUninitialized(system) || !system.IsWii());
     }
 
     if (!is_mod_descriptor && platform == DiscIO::Platform::WiiWAD)
@@ -449,10 +449,10 @@ void GameList::ShowContextMenu(const QPoint&)
 
       for (QAction* a : {wad_install_action, wad_uninstall_action})
       {
-        a->setEnabled(!Core::IsRunning(system));
+        a->setEnabled(Core::IsUninitialized(system));
         menu->addAction(a);
       }
-      if (!Core::IsRunning(system))
+      if (Core::IsUninitialized(system))
         wad_uninstall_action->setEnabled(WiiUtils::IsTitleInstalled(game->GetTitleID()));
 
       connect(&Settings::Instance(), &Settings::EmulationStateChanged, menu,
@@ -473,8 +473,8 @@ void GameList::ShowContextMenu(const QPoint&)
       QAction* export_wii_save =
           menu->addAction(tr("Export Wii Save"), this, &GameList::ExportWiiSave);
 
-      open_wii_save_folder->setEnabled(!Core::IsRunning(system));
-      export_wii_save->setEnabled(!Core::IsRunning(system));
+      open_wii_save_folder->setEnabled(Core::IsUninitialized(system));
+      export_wii_save->setEnabled(Core::IsUninitialized(system));
 
       menu->addSeparator();
     }
@@ -531,7 +531,7 @@ void GameList::ShowContextMenu(const QPoint&)
     connect(&Settings::Instance(), &Settings::EmulationStateChanged, menu, [=](Core::State state) {
       netplay_host->setEnabled(state == Core::State::Uninitialized);
     });
-    netplay_host->setEnabled(!Core::IsRunning(system));
+    netplay_host->setEnabled(Core::IsUninitialized(system));
 
     menu->addAction(netplay_host);
   }

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -197,7 +197,7 @@ void HotkeyScheduler::Run()
         emit OpenAchievements();
 #endif  // USE_RETRO_ACHIEVEMENTS
 
-      if (!Core::IsRunning(system))
+      if (Core::IsUninitialized(system))
       {
         // Only check for Play Recording hotkey when no game is running
         if (IsHotkey(HK_PLAY_RECORDING))

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -910,7 +910,7 @@ void MainWindow::OnStopComplete()
 
 bool MainWindow::RequestStop()
 {
-  if (!Core::IsRunning(Core::System::GetInstance()))
+  if (Core::IsUninitialized(Core::System::GetInstance()))
   {
     Core::QueueHostJob([this](Core::System&) { OnStopComplete(); }, true);
     return true;
@@ -1118,7 +1118,7 @@ void MainWindow::StartGame(std::unique_ptr<BootParameters>&& parameters)
   }
 
   // If we're running, only start a new game once we've stopped the last.
-  if (Core::GetState(Core::System::GetInstance()) != Core::State::Uninitialized)
+  if (!Core::IsUninitialized(Core::System::GetInstance()))
   {
     if (!RequestStop())
       return;
@@ -1542,7 +1542,7 @@ void MainWindow::NetPlayInit()
 
 bool MainWindow::NetPlayJoin()
 {
-  if (Core::IsRunning(Core::System::GetInstance()))
+  if (!Core::IsUninitialized(Core::System::GetInstance()))
   {
     ModalMessageBox::critical(nullptr, tr("Error"),
                               tr("Can't start a NetPlay Session while a game is still running!"));
@@ -1609,7 +1609,7 @@ bool MainWindow::NetPlayJoin()
 
 bool MainWindow::NetPlayHost(const UICommon::GameFile& game)
 {
-  if (Core::IsRunning(Core::System::GetInstance()))
+  if (!Core::IsUninitialized(Core::System::GetInstance()))
   {
     ModalMessageBox::critical(nullptr, tr("Error"),
                               tr("Can't start a NetPlay Session while a game is still running!"));
@@ -1856,7 +1856,7 @@ void MainWindow::OnImportNANDBackup()
 
   result.wait();
 
-  m_menu_bar->UpdateToolsMenu(Core::IsRunning(Core::System::GetInstance()));
+  m_menu_bar->UpdateToolsMenu(Core::State::Uninitialized);
 }
 
 void MainWindow::OnPlayRecording()
@@ -1888,7 +1888,8 @@ void MainWindow::OnStartRecording()
 {
   auto& system = Core::System::GetInstance();
   auto& movie = system.GetMovie();
-  if (Core::GetState(system) == Core::State::Starting || movie.IsRecordingInput() ||
+  if (Core::GetState(system) == Core::State::Starting ||
+      Core::GetState(system) == Core::State::Stopping || movie.IsRecordingInput() ||
       movie.IsPlayingInput())
   {
     return;
@@ -1920,7 +1921,7 @@ void MainWindow::OnStartRecording()
   {
     emit RecordingStatusChanged(true);
 
-    if (!Core::IsRunning(system))
+    if (Core::IsUninitialized(system))
       Play();
   }
 }

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -138,9 +138,11 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
     m_recording_stop->setEnabled(false);
     m_recording_export->setEnabled(false);
   }
-  m_recording_play->setEnabled(m_game_selected && !running);
-  m_recording_play->setEnabled(m_game_selected && !running && !hardcore);
-  m_recording_start->setEnabled((m_game_selected || running) &&
+  const bool can_start_from_boot = m_game_selected && state == Core::State::Uninitialized;
+  const bool can_start_from_savestate =
+      state == Core::State::Running || state == Core::State::Paused;
+  m_recording_play->setEnabled(can_start_from_boot && !hardcore);
+  m_recording_start->setEnabled((can_start_from_boot || can_start_from_savestate) &&
                                 !Core::System::GetInstance().GetMovie().IsPlayingInput());
 
   // JIT
@@ -159,7 +161,7 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   m_symbols->setEnabled(running);
 
   UpdateStateSlotMenu();
-  UpdateToolsMenu(running);
+  UpdateToolsMenu(state);
 
   OnDebugModeToggled(Settings::Instance().IsDebugModeEnabled());
 }
@@ -297,7 +299,8 @@ void MenuBar::AddToolsMenu()
 
   m_boot_sysmenu->setEnabled(false);
 
-  connect(&Settings::Instance(), &Settings::NANDRefresh, this, [this] { UpdateToolsMenu(false); });
+  connect(&Settings::Instance(), &Settings::NANDRefresh, this,
+          [this] { UpdateToolsMenu(Core::State::Uninitialized); });
 
   m_perform_online_update_menu = tools_menu->addMenu(tr("Perform Online System Update"));
   m_perform_online_update_for_current_region = m_perform_online_update_menu->addAction(
@@ -1051,20 +1054,23 @@ void MenuBar::AddSymbolsMenu()
   m_symbols->addAction(tr("&Patch HLE Functions"), this, &MenuBar::PatchHLEFunctions);
 }
 
-void MenuBar::UpdateToolsMenu(bool emulation_started)
+void MenuBar::UpdateToolsMenu(const Core::State state)
 {
-  m_boot_sysmenu->setEnabled(!emulation_started);
-  m_perform_online_update_menu->setEnabled(!emulation_started);
-  m_ntscj_ipl->setEnabled(!emulation_started && File::Exists(Config::GetBootROMPath(JAP_DIR)));
-  m_ntscu_ipl->setEnabled(!emulation_started && File::Exists(Config::GetBootROMPath(USA_DIR)));
-  m_pal_ipl->setEnabled(!emulation_started && File::Exists(Config::GetBootROMPath(EUR_DIR)));
-  m_wad_install_action->setEnabled(!emulation_started);
-  m_import_backup->setEnabled(!emulation_started);
-  m_check_nand->setEnabled(!emulation_started);
-  m_import_wii_save->setEnabled(!emulation_started);
-  m_export_wii_saves->setEnabled(!emulation_started);
+  const bool is_uninitialized = state == Core::State::Uninitialized;
+  const bool is_running = state == Core::State::Running || state == Core::State::Paused;
 
-  if (!emulation_started)
+  m_boot_sysmenu->setEnabled(is_uninitialized);
+  m_perform_online_update_menu->setEnabled(is_uninitialized);
+  m_ntscj_ipl->setEnabled(is_uninitialized && File::Exists(Config::GetBootROMPath(JAP_DIR)));
+  m_ntscu_ipl->setEnabled(is_uninitialized && File::Exists(Config::GetBootROMPath(USA_DIR)));
+  m_pal_ipl->setEnabled(is_uninitialized && File::Exists(Config::GetBootROMPath(EUR_DIR)));
+  m_wad_install_action->setEnabled(is_uninitialized);
+  m_import_backup->setEnabled(is_uninitialized);
+  m_check_nand->setEnabled(is_uninitialized);
+  m_import_wii_save->setEnabled(is_uninitialized);
+  m_export_wii_saves->setEnabled(is_uninitialized);
+
+  if (is_uninitialized)
   {
     IOS::HLE::Kernel ios;
     const auto tmd = ios.GetESCore().FindInstalledTMD(Titles::SYSTEM_MENU);
@@ -1087,7 +1093,7 @@ void MenuBar::UpdateToolsMenu(bool emulation_started)
   }
 
   const auto bt = WiiUtils::GetBluetoothEmuDevice();
-  const bool enable_wiimotes = emulation_started && bt != nullptr;
+  const bool enable_wiimotes = is_running && bt != nullptr;
 
   for (std::size_t i = 0; i < m_wii_remotes.size(); i++)
   {
@@ -1258,16 +1264,20 @@ void MenuBar::OnSelectionChanged(std::shared_ptr<const UICommon::GameFile> game_
   m_game_selected = !!game_file;
 
   auto& system = Core::System::GetInstance();
-  const bool core_is_running = Core::IsRunning(system);
-  m_recording_play->setEnabled(m_game_selected && !core_is_running);
-  m_recording_start->setEnabled((m_game_selected || core_is_running) &&
+  const bool can_start_from_boot = m_game_selected && Core::IsUninitialized(system);
+  const bool can_start_from_savestate = Core::IsRunning(system);
+  m_recording_play->setEnabled(can_start_from_boot);
+  m_recording_start->setEnabled((can_start_from_boot || can_start_from_savestate) &&
                                 !system.GetMovie().IsPlayingInput());
 }
 
 void MenuBar::OnRecordingStatusChanged(bool recording)
 {
   auto& system = Core::System::GetInstance();
-  m_recording_start->setEnabled(!recording && (m_game_selected || Core::IsRunning(system)));
+  const bool can_start_from_boot = m_game_selected && Core::IsUninitialized(system);
+  const bool can_start_from_savestate = Core::IsRunning(system);
+
+  m_recording_start->setEnabled(!recording && (can_start_from_boot || can_start_from_savestate));
   m_recording_stop->setEnabled(recording);
   m_recording_export->setEnabled(recording);
 }

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -43,7 +43,7 @@ public:
 
   explicit MenuBar(QWidget* parent = nullptr);
 
-  void UpdateToolsMenu(bool emulation_started);
+  void UpdateToolsMenu(Core::State state);
 
   QMenu* GetListColumnsMenu() const { return m_cols_menu; }
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -806,9 +806,11 @@ void NetPlayDialog::DisplayMessage(const QString& msg, const std::string& color,
   QColor c(color.empty() ? QStringLiteral("white") : QString::fromStdString(color));
 
   if (g_ActiveConfig.bShowNetPlayMessages && Core::IsRunning(Core::System::GetInstance()))
+  {
     g_netplay_chat_ui->AppendChat(msg.toStdString(),
                                   {static_cast<float>(c.redF()), static_cast<float>(c.greenF()),
                                    static_cast<float>(c.blueF())});
+  }
 }
 
 void NetPlayDialog::AppendChat(const std::string& msg)

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -239,10 +239,11 @@ void AdvancedPane::ConnectLayout()
 
 void AdvancedPane::Update()
 {
-  const bool running = Core::GetState(Core::System::GetInstance()) != Core::State::Uninitialized;
+  const bool is_uninitialized = Core::IsUninitialized(Core::System::GetInstance());
   const bool enable_cpu_clock_override_widgets = Config::Get(Config::MAIN_OVERCLOCK_ENABLE);
   const bool enable_ram_override_widgets = Config::Get(Config::MAIN_RAM_OVERRIDE_ENABLE);
-  const bool enable_custom_rtc_widgets = Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE) && !running;
+  const bool enable_custom_rtc_widgets =
+      Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE) && is_uninitialized;
 
   const auto available_cpu_cores = PowerPC::AvailableCPUCores();
   const auto cpu_core = Config::Get(Config::MAIN_CPU_CORE);
@@ -251,9 +252,9 @@ void AdvancedPane::Update()
     if (available_cpu_cores[i] == cpu_core)
       m_cpu_emulation_engine_combobox->setCurrentIndex(int(i));
   }
-  m_cpu_emulation_engine_combobox->setEnabled(!running);
-  m_enable_mmu_checkbox->setEnabled(!running);
-  m_pause_on_panic_checkbox->setEnabled(!running);
+  m_cpu_emulation_engine_combobox->setEnabled(is_uninitialized);
+  m_enable_mmu_checkbox->setEnabled(is_uninitialized);
+  m_pause_on_panic_checkbox->setEnabled(is_uninitialized);
 
   {
     QFont bf = font();
@@ -282,11 +283,11 @@ void AdvancedPane::Update()
     return tr("%1% (%2 MHz)").arg(QString::number(percent), QString::number(clock));
   }());
 
-  m_ram_override_checkbox->setEnabled(!running);
+  m_ram_override_checkbox->setEnabled(is_uninitialized);
   SignalBlocking(m_ram_override_checkbox)->setChecked(enable_ram_override_widgets);
 
-  m_mem1_override_slider->setEnabled(enable_ram_override_widgets && !running);
-  m_mem1_override_slider_label->setEnabled(enable_ram_override_widgets && !running);
+  m_mem1_override_slider->setEnabled(enable_ram_override_widgets && is_uninitialized);
+  m_mem1_override_slider_label->setEnabled(enable_ram_override_widgets && is_uninitialized);
 
   {
     const QSignalBlocker blocker(m_mem1_override_slider);
@@ -299,8 +300,8 @@ void AdvancedPane::Update()
     return tr("%1 MB (MEM1)").arg(QString::number(mem1_size));
   }());
 
-  m_mem2_override_slider->setEnabled(enable_ram_override_widgets && !running);
-  m_mem2_override_slider_label->setEnabled(enable_ram_override_widgets && !running);
+  m_mem2_override_slider->setEnabled(enable_ram_override_widgets && is_uninitialized);
+  m_mem2_override_slider_label->setEnabled(enable_ram_override_widgets && is_uninitialized);
 
   {
     const QSignalBlocker blocker(m_mem2_override_slider);
@@ -313,7 +314,7 @@ void AdvancedPane::Update()
     return tr("%1 MB (MEM2)").arg(QString::number(mem2_size));
   }());
 
-  m_custom_rtc_checkbox->setEnabled(!running);
+  m_custom_rtc_checkbox->setEnabled(is_uninitialized);
   SignalBlocking(m_custom_rtc_checkbox)->setChecked(Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE));
 
   QDateTime initial_date_time;

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -40,8 +40,7 @@ AudioPane::AudioPane()
     OnEmulationStateChanged(state != Core::State::Uninitialized);
   });
 
-  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()) !=
-                          Core::State::Uninitialized);
+  OnEmulationStateChanged(!Core::IsUninitialized(Core::System::GetInstance()));
 }
 
 void AudioPane::CreateWidgets()

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -93,8 +93,7 @@ WiiPane::WiiPane(QWidget* parent) : QWidget(parent)
   LoadConfig();
   ConnectLayout();
   ValidateSelectionState();
-  OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()) !=
-                          Core::State::Uninitialized);
+  OnEmulationStateChanged(!Core::IsUninitialized(Core::System::GetInstance()));
 }
 
 void WiiPane::CreateLayout()

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -286,7 +286,7 @@ void VideoBackendBase::PopulateBackendInfo(const WindowSystemInfo& wsi)
 {
   // If the core has been initialized, the backend info will have been populated already. Doing it
   // again would be unnecessary and could cause the UI thread to race with the GPU thread.
-  if (Core::GetState(Core::System::GetInstance()) != Core::State::Uninitialized)
+  if (!Core::IsUninitialized(Core::System::GetInstance()))
     return;
 
   g_Config.Refresh();


### PR DESCRIPTION
This reverts the revert commit bc67fc97c39628c76a4dbca411b0e8a9bfaf726a, except for the changes in BaseConfigLoader.cpp, which caused the bug that made us revert 72cf2bdb87f09deff22e1085de3290126aa4ad05. PR #12917 contains an improved change to BaseConfigLoader.cpp, which can be merged (or rejected) independently.