### PR TITLE
Properly link against xxhash

### DIFF
--- a/Externals/xxhash/CMakeLists.txt
+++ b/Externals/xxhash/CMakeLists.txt
@@ -6,3 +6,4 @@ target_include_directories(xxhash
 PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/xxHash
 )
+add_library(xxhash::xxhash ALIAS xxhash)

--- a/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
@@ -45,7 +45,7 @@ PUBLIC
 PRIVATE
   # Link against glslang, the other necessary libraries are referenced by the executable.
   glslang
-  xxhash
+  xxhash::xxhash
 )
 
 if (ANDROID AND _M_ARM_64)

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -214,7 +214,7 @@ PUBLIC
 PRIVATE
   fmt::fmt
   spng::spng
-  xxhash
+  xxhash::xxhash
   imgui
   implot
   glslang


### PR DESCRIPTION
(For future reference, every change like 2b9aee5c8fd784d7bfe736074547c114af878326 needs to make sure all our targets link to the name they specify as the third argument to dolphin_find_optional_system_library_pkgconfig rather than some other name, or they won't link against the right thing when using the pkgconfig dependency)