### PR TITLE
BreakpointWidget: Correct icon position

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -83,7 +83,8 @@ private:
     if (!pix.isNull())
     {
       const QRect r = option.rect;
-      const QPoint p = QPoint((r.width() - pix.width()) / 2, (r.height() - pix.height()) / 2);
+      const QSize size = pix.deviceIndependentSize().toSize();
+      const QPoint p = QPoint((r.width() - size.width()) / 2, (r.height() - size.height()) / 2);
       painter->drawPixmap(r.topLeft() + p, pix);
     }
   }


### PR DESCRIPTION
On Windows, when the current display scale is set to over 150%, the breakpoint icons are in the wrong location. For example, at 200%:
![image](https://github.com/dolphin-emu/dolphin/assets/68222518/8441de0b-cce9-451f-bf96-51be6d732142)

This is because the size of the QPixmap is consistent until devicePixelRatioF > 1.5

- 100% - pix.size: QSize(24, 24)

- 125% - pix.size: QSize(24, 24)

- 150% - pix.size: QSize(24, 24)

- 165% - pix.size: QSize(40, 40)

- 175% - pix.size: QSize(42, 42)

- 200% - pix.size: QSize(48, 48)

- 225% - pix.size: QSize(48, 48)

The simple fix is to use an immediate value of 24 and ignore the size 