### PR TITLE
Fix Leaderboards Tab

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -837,6 +837,22 @@ void AchievementManager::LoadGameCallback(int result, const char* error_message,
   instance.m_update_callback({.all = true});
   // Set this to a value that will immediately trigger RP
   instance.m_last_rp_time = std::chrono::steady_clock::now() - std::chrono::minutes{2};
+
+  std::lock_guard lg{instance.GetLock()};
+  auto* leaderboard_list =
+      rc_client_create_leaderboard_list(client, RC_CLIENT_LEADERBOARD_LIST_GROUPING_NONE);
+  for (u32 bucket = 0; bucket < leaderboard_list->num_buckets; bucket++)
+  {
+    const auto& leaderboard_bucket = leaderboard_list->buckets[bucket];
+    for (u32 board = 0; board < leaderboard_bucket.num_leaderboards; board++)
+    {
+      const auto& leaderboard = leaderboard_bucket.leaderboards[board];
+      instance.m_leaderboard_map.insert(
+          std::pair(leaderboard->id, LeaderboardStatus{.name = leaderboard->title,
+                                                       .description = leaderboard->description}));
+    }
+  }
+  rc_client_destroy_leaderboard_list(leaderboard_list);
 }
 
 void AchievementManager::ChangeMediaCallback(int result, const char* error_message,

--- a/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementLeaderboardWidget.cpp
@@ -87,7 +87,7 @@ void AchievementLeaderboardWidget::UpdateData(bool clean_all)
   }
   for (auto row : m_leaderboard_order)
   {
-    UpdateRow(row.second);
+    UpdateRow(row.first);
   }
 }
 
@@ -98,7 +98,7 @@ void AchievementLeaderboardWidget::UpdateData(
   {
     if (update_ids.contains(row.first))
     {
-      UpdateRow(row.second);
+      UpdateRow(row.first);
     }
   }
 }


### PR DESCRIPTION
Now that we have some test data, it wasn't showing up in the leaderboards tab; this fixes it to ensure (1) that the right ID is being passed to UpdateRow and (2) the map of leaderboard entries is being populated correctly.