### PR TITLE
AchievementManager: Improve error message for repeated pausing

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -295,10 +295,9 @@ bool AchievementManager::CanPause()
   bool can_pause = rc_client_can_pause(m_client, &frames_to_next_pause);
   if (!can_pause)
   {
-    OSD::AddMessage("Cannot spam pausing in hardcore mode.", OSD::Duration::VERY_LONG,
-                    OSD::Color::RED);
     OSD::AddMessage(
-        fmt::format("Can pause in {} seconds.",
+        fmt::format("RetroAchievements Hardcore Mode:\n"
+                    "Cannot pause until another {:.2f} seconds have passed.",
                     static_cast<float>(frames_to_next_pause) /
                         Core::System::GetInstance().GetVideoInterface().GetTargetRefreshRate()),
         OSD::Duration::VERY_LONG, OSD::Color::RED);


### PR DESCRIPTION
'spam' in an OSD message just sounds wrong to me. I've taken the new phrasing mostly from pcsx2:

https://github.com/PCSX2/pcsx2/blob/cd3e11bff77bb5a7f44c5a39cb534b670c09abd7/pcsx2/Hotkeys.cpp#L97

This also rounds the seconds to two digits after the comma, because it would print things like `0.06673333333333334` before which is not very helpful.