### PR TITLE
GameINI: Enable Pokémon Colosseum/XD save patches by default

### DIFF
--- a/Data/Sys/GameSettings/GC6E01.ini
+++ b/Data/Sys/GameSettings/GC6E01.ini
@@ -26,5 +26,8 @@ $Allow Memory Card saving with Savestates
 0x801cfc2c:dword:0x9005002c
 0x801cfc7c:dword:0x60000000
 
+[OnFrame_Enabled]
+$Allow Memory Card saving with Savestates
+
 [Patches_RetroAchievements_Verified]
 $Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GC6J01.ini
+++ b/Data/Sys/GameSettings/GC6J01.ini
@@ -26,5 +26,8 @@ $Allow Memory Card saving with Savestates
 0x801cb5b8:dword:0x9005002c
 0x801cb608:dword:0x60000000
 
+[OnFrame_Enabled]
+$Allow Memory Card saving with Savestates
+
 [Patches_RetroAchievements_Verified]
 $Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GC6P01.ini
+++ b/Data/Sys/GameSettings/GC6P01.ini
@@ -26,5 +26,8 @@ $Allow Memory Card saving with Savestates
 0x801d429c:dword:0x9005002c
 0x801d42ec:dword:0x60000000
 
+[OnFrame_Enabled]
+$Allow Memory Card saving with Savestates
+
 [Patches_RetroAchievements_Verified]
 $Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GXXE01.ini
+++ b/Data/Sys/GameSettings/GXXE01.ini
@@ -6,5 +6,8 @@ $Allow Memory Card saving with Savestates
 0x801cc304:dword:0x90e5002c
 0x801cc4b0:dword:0x60000000
 
+[OnFrame_Enabled]
+$Allow Memory Card saving with Savestates
+
 [Patches_RetroAchievements_Verified]
 $Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GXXJ01.ini
+++ b/Data/Sys/GameSettings/GXXJ01.ini
@@ -6,5 +6,8 @@ $Allow Memory Card saving with Savestates
 0x801c7984:dword:0x90e5002c
 0x801c7b30:dword:0x60000000
 
+[OnFrame_Enabled]
+$Allow Memory Card saving with Savestates
+
 [Patches_RetroAchievements_Verified]
 $Allow Memory Card saving with Savestates

--- a/Data/Sys/GameSettings/GXXP01.ini
+++ b/Data/Sys/GameSettings/GXXP01.ini
@@ -6,5 +6,8 @@ $Allow Memory Card saving with Savestates
 0x801cd764:dword:0x90e5002c
 0x801cd910:dword:0x60000000
 
+[OnFrame_Enabled]
+$Allow Memory Card saving with Savestates
+
 [Patches_RetroAchievements_Verified]
 $Allow Memory Card saving with Savestates


### PR DESCRIPTION
@JMC47 I remember you talking about this, I think?

This comes up surprisingly often in support where people can't save after beating Mt. Battle. I think what's happening is that the save itself is storing the memory card ID and GCI folders are technically a new memory card on each boot, but I never investigated the exact details, I just know that these patches work around the issue.