### PR TITLE
RetroAchievements: Fix crash on repeated launch of game

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementHeaderWidget.cpp
@@ -84,7 +84,7 @@ void AchievementHeaderWidget::UpdateData()
   m_user_icon->setVisible(false);
   m_user_icon->clear();
   m_user_icon->setText({});
-  QImage i_user_icon(&player_badge.data.front(), player_badge.width, player_badge.height,
+  QImage i_user_icon(player_badge.data.data(), player_badge.width, player_badge.height,
                      QImage::Format_RGBA8888);
   m_user_icon->setPixmap(QPixmap::fromImage(i_user_icon)
                              .scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
@@ -100,7 +100,7 @@ void AchievementHeaderWidget::UpdateData()
   {
     rc_client_user_game_summary_t game_summary;
     rc_client_get_user_game_summary(instance.GetClient(), &game_summary);
-    QImage i_game_icon(&game_badge.data.front(), game_badge.width, game_badge.height,
+    QImage i_game_icon(game_badge.data.data(), game_badge.width, game_badge.height,
                        QImage::Format_RGBA8888);
     m_game_icon->setPixmap(QPixmap::fromImage(i_game_icon)
                                .scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));


### PR DESCRIPTION
When repeatedly launching a game with the Achievements Tab open, sometimes Dolphin would CTD.
![image](https://github.com/user-attachments/assets/d5f464ef-be9a-45fa-bd40-5440d14542cc)
