### PR TITLE
IOS: Fix return code inaccuracy

### DIFF
--- a/Source/Core/Core/IOS/FS/HostBackend/File.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/File.cpp
@@ -81,6 +81,12 @@ Result<FileHandle> HostFileSystem::OpenFile(Uid, Gid, const std::string& path, M
     return ResultCode::NoFreeHandle;
 
   const std::string host_path = BuildFilename(path).host_path;
+  if (File::IsDirectory(host_path))
+  {
+    *handle = Handle{};
+    return ResultCode::Invalid;
+  }
+
   if (!File::IsFile(host_path))
   {
     *handle = Handle{};


### PR DESCRIPTION
When attempting to open a directory via `IOS_Open` on console, it returns error code -101, and in the latest version of Dolphin, it currently returns -106.