### PR TITLE
Core/PowerPC: Split 'IsRAMAddress' method into 'IsEffectiveRAMAddress' and 'IsPhysicalRAMAddress' methods

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -310,7 +310,8 @@ private:
   template <XCheckTLBFlag flag, bool never_translate = false>
   void WriteToHardware(u32 em_address, const u32 data, const u32 size);
   template <XCheckTLBFlag flag>
-  bool IsRAMAddress(u32 address, bool translate);
+  bool IsEffectiveRAMAddress(u32 address);
+  bool IsPhysicalRAMAddress(u32 address) const;
 
   template <typename T>
   static std::optional<ReadResult<T>> HostTryReadUX(const Core::CPUThreadGuard& guard,


### PR DESCRIPTION
Simple refactor to remove a bool argument. The PR also simplifies the branching returns.