### PR TITLE
Disable Dual Core in Death Jr.: Root of Evil

### DIFF
--- a/Data/Sys/GameSettings/RDJ.ini
+++ b/Data/Sys/GameSettings/RDJ.ini
@@ -1,0 +1,15 @@
+# RDJE4F, RDJP4F - Death Jr: Root of Evil
+
+[Core]
+# Death Jr.: Root of Evil locks up after minutes of gameplay when Dual Core is enabled.
+# https://bugs.dolphin-emu.org/issues/13544
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.


### PR DESCRIPTION
Workaround for https://bugs.dolphin-emu.org/issues/13544

It's unfortunate as this game is demanding to run full speed, but I've been able to play at full on a Ryzen 5 2600 Six-Core Processor speed using VBI skip with no noticeable issue. I believe this is better than random hangs which locks your entire game.