### PR TITLE
RetroAchievements - Leaderboard Spam Fix

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -479,8 +479,6 @@ AchievementManager::GetLeaderboardInfo(AchievementManager::AchievementId leaderb
   if (const auto leaderboard_iter = m_leaderboard_map.find(leaderboard_id);
       leaderboard_iter != m_leaderboard_map.end())
   {
-    if (leaderboard_iter->second.entries.size() == 0)
-      FetchBoardInfo(leaderboard_id);
     return &leaderboard_iter->second;
   }
 

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -804,6 +804,8 @@ void AchievementManager::LeaderboardEntriesCallback(int result, const char* erro
     map_entry.username.assign(response_entry.user);
     memcpy(map_entry.score.data(), response_entry.display, FORMAT_SIZE);
     map_entry.rank = response_entry.rank;
+    if (ix == list->user_index)
+      leaderboard.player_index = response_entry.rank;
   }
   AchievementManager::GetInstance().m_update_callback({.leaderboards = {*leaderboard_id}});
 }

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -55,12 +55,12 @@ void AchievementsWindow::CreateMainLayout()
   m_tab_widget = new QTabWidget();
   m_settings_widget = new AchievementSettingsWidget(m_tab_widget);
   m_progress_widget = new AchievementProgressWidget(m_tab_widget);
-  //  m_leaderboard_widget = new AchievementLeaderboardWidget(m_tab_widget);
+  m_leaderboard_widget = new AchievementLeaderboardWidget(m_tab_widget);
   m_tab_widget->addTab(GetWrappedWidget(m_settings_widget, this, 125, 100), tr("Settings"));
   m_tab_widget->addTab(GetWrappedWidget(m_progress_widget, this, 125, 100), tr("Progress"));
   m_tab_widget->setTabVisible(1, is_game_loaded);
-  //  m_tab_widget->addTab(GetWrappedWidget(m_leaderboard_widget, this, 125, 100),
-  //  tr("Leaderboards")); m_tab_widget->setTabVisible(2, is_game_loaded);
+  m_tab_widget->addTab(GetWrappedWidget(m_leaderboard_widget, this, 125, 100), tr("Leaderboards"));
+  m_tab_widget->setTabVisible(2, is_game_loaded);
 
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
@@ -84,9 +84,9 @@ void AchievementsWindow::UpdateData(AchievementManager::UpdatedItems updated_ite
   {
     m_header_widget->UpdateData();
     m_progress_widget->UpdateData(true);
-    //    m_leaderboard_widget->UpdateData(true);
+    m_leaderboard_widget->UpdateData(true);
     static_cast<QScrollArea*>(m_tab_widget->widget(1))->verticalScrollBar()->setValue(0);
-    //    static_cast<QScrollArea*>(m_tab_widget->widget(2))->verticalScrollBar()->setValue(0);
+    static_cast<QScrollArea*>(m_tab_widget->widget(2))->verticalScrollBar()->setValue(0);
   }
   else
   {
@@ -99,10 +99,10 @@ void AchievementsWindow::UpdateData(AchievementManager::UpdatedItems updated_ite
       m_progress_widget->UpdateData(false);
     else if (updated_items.achievements.size() > 0)
       m_progress_widget->UpdateData(updated_items.achievements);
-    //    if (updated_items.all_leaderboards)
-    //      m_leaderboard_widget->UpdateData(false);
-    //    else if (updated_items.leaderboards.size() > 0)
-    //      m_leaderboard_widget->UpdateData(updated_items.leaderboards);
+    if (updated_items.all_leaderboards)
+      m_leaderboard_widget->UpdateData(false);
+    else if (updated_items.leaderboards.size() > 0)
+      m_leaderboard_widget->UpdateData(updated_items.leaderboards);
   }
 
   {
@@ -111,7 +111,7 @@ void AchievementsWindow::UpdateData(AchievementManager::UpdatedItems updated_ite
     const bool is_game_loaded = instance.IsGameLoaded();
     m_header_widget->setVisible(instance.HasAPIToken());
     m_tab_widget->setTabVisible(1, is_game_loaded);
-    //    m_tab_widget->setTabVisible(2, is_game_loaded);
+    m_tab_widget->setTabVisible(2, is_game_loaded);
   }
   update();
 }


### PR DESCRIPTION
Resolves the leaderboard request spam that DDoS'd the server upon the Gamecube launch, by removing the request being spammed. Also fixes a minor logic issue with the leaderboard display that wasn't obvious until there was data to display.