### PR TITLE
RetroAchievements: Add instructive text to disabled login button

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -178,6 +178,15 @@ void AchievementSettingsWidget::LoadSettings()
   SignalBlocking(m_common_login_button)->setVisible(logged_out);
   SignalBlocking(m_common_login_button)
       ->setEnabled(enabled && !Core::IsRunning(Core::System::GetInstance()));
+  if (enabled && Core::IsRunning(Core::System::GetInstance()))
+  {
+    SignalBlocking(m_common_login_button)->setText(tr("To log in, stop the current emulation."));
+  }
+  else
+  {
+    SignalBlocking(m_common_login_button)->setText(tr("Log In"));
+  }
+
   SignalBlocking(m_common_logout_button)->setVisible(!logged_out);
   SignalBlocking(m_common_logout_button)->setEnabled(enabled);
 


### PR DESCRIPTION
Changes the RetroAchievements "Log In" button's text to "To login, stop the current emulation." when the button is disabled because an emulation session is active. This allows a user to understand why the button is disabled, and how this state can be resolved.

Previously, it could be unclear why this button was disabled without an understanding of the underlying system.