### PR TITLE
QtUtils/ClearLayoutRecursively: Fix potential crash

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/ClearLayoutRecursively.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ClearLayoutRecursively.cpp
@@ -17,7 +17,7 @@ void ClearLayoutRecursively(QLayout* layout)
     if (child->widget())
     {
       layout->removeWidget(child->widget());
-      delete child->widget();
+      child->widget()->deleteLater();
     }
     else if (child->layout())
     {


### PR DESCRIPTION
Use QObject->deleteLater() instead of the delete operator to destroy child widgets of the layout. This prevents crashes caused by pending Qt events trying to access the now-destroyed widget.