### PR TITLE
Emitters: Define Trivial Getters Inline

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -87,26 +87,6 @@ void ARM64XEmitter::SetCodePtr(u8* ptr, u8* end, bool write_failed)
   m_lastCacheFlushEnd = ptr;
 }
 
-const u8* ARM64XEmitter::GetCodePtr() const
-{
-  return m_code;
-}
-
-u8* ARM64XEmitter::GetWritableCodePtr()
-{
-  return m_code;
-}
-
-const u8* ARM64XEmitter::GetCodeEnd() const
-{
-  return m_code_end;
-}
-
-u8* ARM64XEmitter::GetWritableCodeEnd()
-{
-  return m_code_end;
-}
-
 void ARM64XEmitter::ReserveCodeSpace(u32 bytes)
 {
   for (u32 i = 0; i < bytes / 4; i++)

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -680,10 +680,10 @@ public:
   void SetCodePtr(u8* ptr, u8* end, bool write_failed = false);
 
   void SetCodePtrUnsafe(u8* ptr, u8* end, bool write_failed = false);
-  const u8* GetCodePtr() const;
-  u8* GetWritableCodePtr();
-  const u8* GetCodeEnd() const;
-  u8* GetWritableCodeEnd();
+  const u8* GetCodePtr() const { return m_code; }
+  u8* GetWritableCodePtr() { return m_code; }
+  const u8* GetCodeEnd() const { return m_code_end; }
+  u8* GetWritableCodeEnd() { return m_code_end; }
   void ReserveCodeSpace(u32 bytes);
   u8* AlignCode16();
   u8* AlignCodePage();

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -107,26 +107,6 @@ void XEmitter::SetCodePtr(u8* ptr, u8* end, bool write_failed)
   m_write_failed = write_failed;
 }
 
-const u8* XEmitter::GetCodePtr() const
-{
-  return code;
-}
-
-u8* XEmitter::GetWritableCodePtr()
-{
-  return code;
-}
-
-const u8* XEmitter::GetCodeEnd() const
-{
-  return m_code_end;
-}
-
-u8* XEmitter::GetWritableCodeEnd()
-{
-  return m_code_end;
-}
-
 void XEmitter::Write8(u8 value)
 {
   if (code >= m_code_end)

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -394,10 +394,10 @@ public:
   u8* AlignCode4();
   u8* AlignCode16();
   u8* AlignCodePage();
-  const u8* GetCodePtr() const;
-  u8* GetWritableCodePtr();
-  const u8* GetCodeEnd() const;
-  u8* GetWritableCodeEnd();
+  const u8* GetCodePtr() const { return code; }
+  u8* GetWritableCodePtr() { return code; }
+  const u8* GetCodeEnd() const { return m_code_end; }
+  u8* GetWritableCodeEnd() { return m_code_end; }
 
   void LockFlags() { flags_locked = true; }
   void UnlockFlags() { flags_locked = false; }


### PR DESCRIPTION
As it is, this seems like it would only hinder codegen (assuming no LTO).