### PR TITLE
Achievements Fail Messaging

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -733,6 +733,7 @@ void AchievementManager::LoginCallback(int result, const char* error_message, rc
   {
     WARN_LOG_FMT(ACHIEVEMENTS, "Failed to login {} to RetroAchievements server.",
                  Config::Get(Config::RA_USERNAME));
+    AchievementManager::GetInstance().m_update_callback({.failed_login_code = result});
     return;
   }
 
@@ -744,6 +745,7 @@ void AchievementManager::LoginCallback(int result, const char* error_message, rc
   if (!user)
   {
     WARN_LOG_FMT(ACHIEVEMENTS, "Failed to retrieve user information from client.");
+    AchievementManager::GetInstance().m_update_callback({.failed_login_code = RC_INVALID_STATE});
     return;
   }
 
@@ -762,6 +764,7 @@ void AchievementManager::LoginCallback(int result, const char* error_message, rc
       INFO_LOG_FMT(ACHIEVEMENTS, "Attempted to login prior user {}; current user is {}.",
                    user->username, Config::Get(Config::RA_USERNAME));
       rc_client_logout(client);
+      AchievementManager::GetInstance().m_update_callback({.failed_login_code = RC_INVALID_STATE});
       return;
     }
   }

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -814,6 +814,15 @@ void AchievementManager::LoadGameCallback(int result, const char* error_message,
                                           rc_client_t* client, void* userdata)
 {
   AchievementManager::GetInstance().m_loading_volume.reset(nullptr);
+  if (result == RC_API_FAILURE)
+  {
+    WARN_LOG_FMT(ACHIEVEMENTS, "Load data request rejected for old Dolphin version.");
+    OSD::AddMessage("RetroAchievements no longer supports this version of Dolphin.",
+                    OSD::Duration::VERY_LONG, OSD::Color::RED);
+    OSD::AddMessage("Please update Dolphin to a newer version.", OSD::Duration::VERY_LONG,
+                    OSD::Color::RED);
+    return;
+  }
   if (result != RC_OK)
   {
     WARN_LOG_FMT(ACHIEVEMENTS, "Failed to load data for current game.");

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -98,6 +98,7 @@ public:
     bool all_leaderboards = false;
     std::set<AchievementId> leaderboards{};
     bool rich_presence = false;
+    int failed_login_code = 0;
   };
   using UpdateCallback = std::function<void(const UpdatedItems&)>;
 

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -39,8 +39,24 @@ AchievementSettingsWidget::AchievementSettingsWidget(QWidget* parent) : QWidget(
     ToggleHardcore();
 }
 
-void AchievementSettingsWidget::UpdateData()
+void AchievementSettingsWidget::UpdateData(int login_failed_code)
 {
+  if (login_failed_code != RC_OK)
+  {
+    switch (login_failed_code)
+    {
+    case RC_INVALID_CREDENTIALS:
+      m_common_login_failed->setText(tr("Login Failed - Invalid Username/Password"));
+      break;
+    case RC_NO_RESPONSE:
+      m_common_login_failed->setText(tr("Login Failed - No Internet Connection"));
+      break;
+    default:
+      m_common_login_failed->setText(tr("Login Failed - Server Error"));
+      break;
+    }
+    m_common_login_failed->setVisible(true);
+  }
   LoadSettings();
 }
 
@@ -245,6 +261,7 @@ void AchievementSettingsWidget::ToggleRAIntegration()
 
 void AchievementSettingsWidget::Login()
 {
+  m_common_login_failed->setVisible(false);
   Config::SetBaseOrCurrent(Config::RA_USERNAME, m_common_username_input->text().toStdString());
   AchievementManager::GetInstance().Login(m_common_password_input->text().toStdString());
   m_common_password_input->setText(QString());

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.h
@@ -18,7 +18,7 @@ class AchievementSettingsWidget final : public QWidget
   Q_OBJECT
 public:
   explicit AchievementSettingsWidget(QWidget* parent);
-  void UpdateData();
+  void UpdateData(int login_failed_code);
 
 private:
   void OnControllerInterfaceConfigure();

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -6,6 +6,8 @@
 
 #include <mutex>
 
+#include <rcheevos/include/rc_error.h>
+
 #include <QDialogButtonBox>
 #include <QScrollArea>
 #include <QScrollBar>
@@ -36,7 +38,7 @@ AchievementsWindow::AchievementsWindow(QWidget* parent) : QDialog(parent)
         });
       });
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
-          [this] { m_settings_widget->UpdateData(); });
+          [this] { m_settings_widget->UpdateData(RC_OK); });
   connect(&Settings::Instance(), &Settings::HardcoreStateChanged, this,
           [this] { AchievementsWindow::UpdateData({.all = true}); });
 }
@@ -79,7 +81,7 @@ void AchievementsWindow::ConnectWidgets()
 
 void AchievementsWindow::UpdateData(AchievementManager::UpdatedItems updated_items)
 {
-  m_settings_widget->UpdateData();
+  m_settings_widget->UpdateData(updated_items.failed_login_code);
   if (updated_items.all)
   {
     m_header_widget->UpdateData();


### PR DESCRIPTION
A couple improvements to what messages are given to the user upon failures: failing to log in, and failing to load data because the emulator version (user agent) is blocked.