### PR TITLE
Add Bloom definitions for Need for Speed: Nitro

### DIFF
--- a/Data/Sys/Load/GraphicMods/Need for Speed Nitro/metadata.json
+++ b/Data/Sys/Load/GraphicMods/Need for Speed Nitro/metadata.json
@@ -1,0 +1,19 @@
+{
+	"meta":
+	{
+		"title": "Bloom Texture Definitions",
+		"author": "SuperSamus"
+	},
+	"groups":
+	[
+		{
+			"name": "Bloom",
+			"targets": [
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000008_160x120_4"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Screenshots at 4x resolution
The DOF isn't *exactly* DOF, tell me if you want the name changed.

Before
![R7XP69_2024-07-25_14-31-32](https://github.com/user-attachments/assets/72b73238-ac6b-425b-b670-3f1cd6023af6)

Native bloom
![R7XP69_2024-07-25_14-31-09](https://github.com/user-attachments/assets/28e6430e-ca91-4781-927b-510c3ccba705)

No bloom
![R7XP69_2024-07-25_14-31-43](https://github.com/user-attachments/assets/b2c3c232-05fe-4bfd-aa26-1728d1aa58d1)

No DOF
![R7XP69_2024-07-25_14-31-53](https://github.com/user-attachments/assets/55a937f2-a212-4f86-b11c-37864cda00bb)

Native bloom + No DOF
![R7XP69_2024-07-25_14-31-59](https://github.com/user-attachments/assets/4ae30b23-7fd5-41fe-9a07-e19085b9af61)
