### PR TITLE
Adjust order and spacing of various #includes

### DIFF
--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "AudioCommon/WaveFile.h"
-#include "AudioCommon/Mixer.h"
 
 #include <string>
 
 #include <fmt/format.h>
 
+#include "AudioCommon/Mixer.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"

--- a/Source/Core/Common/ColorUtil.cpp
+++ b/Source/Core/Common/ColorUtil.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Common/ColorUtil.h"
+
 #include "Common/Swap.h"
 
 namespace Common

--- a/Source/Core/Common/Crypto/AES.cpp
+++ b/Source/Core/Common/Crypto/AES.cpp
@@ -1,6 +1,8 @@
 // Copyright 2017 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "Common/Crypto/AES.h"
+
 #include <array>
 #include <bit>
 #include <memory>
@@ -9,7 +11,6 @@
 
 #include "Common/Assert.h"
 #include "Common/CPUDetect.h"
-#include "Common/Crypto/AES.h"
 
 #ifdef _MSC_VER
 #include <intrin.h>

--- a/Source/Core/Common/GL/GLInterface/AGL.mm
+++ b/Source/Core/Common/GL/GLInterface/AGL.mm
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Common/GL/GLInterface/AGL.h"
+
 #include "Common/Logging/Log.h"
 
 // UpdateCachedDimensions and AttachContextToView contain calls to UI APIs, so they must only be

--- a/Source/Core/Common/GL/GLX11Window.cpp
+++ b/Source/Core/Common/GL/GLX11Window.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Common/GL/GLX11Window.h"
+
 #include "Common/GL/GLContext.h"
 
 GLX11Window::GLX11Window(Display* display, Window parent_window, Colormap color_map, Window window,

--- a/Source/Core/Core/HLE/HLE_VarArgs.cpp
+++ b/Source/Core/Core/HLE/HLE_VarArgs.cpp
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Core/HLE/HLE_VarArgs.h"
-#include "Core/Core.h"
-#include "Core/System.h"
 
 #include "Common/Logging/Log.h"
+
+#include "Core/Core.h"
+#include "Core/System.h"
 
 HLE::SystemVABI::VAList::~VAList() = default;
 

--- a/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Core/HW/EXI/BBA/TAP_Win32.h"
-#include "Core/HW/EXI/EXI_DeviceEthernet.h"
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Core/HW/EXI/EXI_Device.h"
+#include "Core/HW/EXI/EXI_DeviceEthernet.h"
 
 namespace Win32TAPHelper
 {

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
@@ -1,6 +1,8 @@
 // Copyright 2022 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "Core/HW/WiimoteEmu/DesiredWiimoteState.h"
+
 #include <cstring>
 #include <optional>
 #include <type_traits>
@@ -9,7 +11,6 @@
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 
-#include "Core/HW/WiimoteEmu/DesiredWiimoteState.h"
 #include "Core/HW/WiimoteEmu/Extension/Classic.h"
 #include "Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h"
 #include "Core/HW/WiimoteEmu/Extension/Drums.h"

--- a/Source/Core/DolphinNoGUI/Platform.cpp
+++ b/Source/Core/DolphinNoGUI/Platform.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinNoGUI/Platform.h"
+
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/STM/STM.h"

--- a/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/CheatSearchFactoryWidget.h"
-#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include <string>
 #include <vector>
@@ -26,6 +25,7 @@
 #include "Core/System.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
+#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 CheatSearchFactoryWidget::CheatSearchFactoryWidget()
 {

--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/CheatSearchWidget.h"
-#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include <functional>
 #include <optional>
@@ -42,6 +41,7 @@
 
 #include "DolphinQt/Config/CheatCodeEditor.h"
 #include "DolphinQt/Config/CheatWarningWidget.h"
+#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 #include "DolphinQt/Settings.h"
 
 #include "UICommon/GameFile.h"

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/Config/ARCodeWidget.h"
-#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include <algorithm>
 #include <utility>
@@ -25,6 +24,7 @@
 #include "DolphinQt/Config/HardcoreWarningWidget.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/SetWindowDecorations.h"
+#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include "UICommon/GameFile.h"
 

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/Config/GeckoCodeWidget.h"
-#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include <algorithm>
 #include <utility>
@@ -31,6 +30,7 @@
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/SetWindowDecorations.h"
+#include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include "UICommon/GameFile.h"
 

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/Quartz.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/Quartz.mm
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "InputCommon/ControllerInterface/Quartz/Quartz.h"
+
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h"
 

--- a/Source/Core/VideoCommon/AbstractFramebuffer.cpp
+++ b/Source/Core/VideoCommon/AbstractFramebuffer.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "VideoCommon/AbstractFramebuffer.h"
+
 #include "VideoCommon/AbstractTexture.h"
 
 AbstractFramebuffer::AbstractFramebuffer(AbstractTexture* color_attachment,

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomShaderCache.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomShaderCache.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "VideoCommon/GraphicsModSystem/Runtime/CustomShaderCache.h"
+
 #include "VideoCommon/AbstractGfx.h"
 #include "VideoCommon/VideoConfig.h"
 

--- a/Source/Core/VideoCommon/PerfQueryBase.cpp
+++ b/Source/Core/VideoCommon/PerfQueryBase.cpp
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "VideoCommon/PerfQueryBase.h"
+
 #include <memory>
+
 #include "VideoCommon/VideoConfig.h"
 
 std::unique_ptr<PerfQueryBase> g_perf_query;


### PR DESCRIPTION
Move some #includes around to match the [Contributing guidelines](https://github.com/dolphin-emu/dolphin/blob/master/Contributing.md#cpp-code-headers).

The codebase is inconsistent about whether Dolphin sections (Common/DolphinQt/Core/etc.) have a space between their include blocks, so I matched the file's style where there was one and otherwise added a space.