### PR TITLE
SVX.ini: Replace `EFBToTextureEnable=False` with `ImmediateXFBEnable=False`

### DIFF
--- a/Data/Sys/GameSettings/SVX.ini
+++ b/Data/Sys/GameSettings/SVX.ini
@@ -13,4 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
-EFBToTextureEnable = False
+ImmediateXFBEnable = False


### PR DESCRIPTION
According to this very old report https://bugs.dolphin-emu.org/issues/6972, this was needed to prevent flickering pre-rendered cutscenes.
Now, after (I imagine) the Hybrid XFB era, the cutscenes work perfectly fine regardless of `EFBToTextureEnable`. So let's boost the performance!

(Though, pre-rendered cutscenes *do* flicker with "Immediately Present XFB" (again, regardless of `EFBToTextureEnable`). Should I force disable that, instead of deleting `SVX.ini` completely?)