### PR TITLE
Config: Don't depend on `is_dirty` to save SYSCONF during restore

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -209,8 +209,7 @@ static void RestoreSYSCONF()
         },
         setting.config_info);
   }
-  // Save the SYSCONF.
-  Config::GetLayer(Config::LayerType::Base)->Save();
+  ConfigLoaders::SaveToSYSCONF(Config::LayerType::Base);
 }
 
 void RestoreConfig()


### PR DESCRIPTION
`Layer::Save` only does its thing if the layer has `is_dirty == true`.
But SYSCONF could have been modified by other layers, so if the base layer wasn't made dirty by anything else, then it wouldn't be restored.
Fixes https://bugs.dolphin-emu.org/issues/13580.