### PR TITLE
Dual Core Labeling Update

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
 
     <!-- General Preference Fragment -->
     <string name="general_submenu">General</string>
-    <string name="dual_core">Dual Core</string>
+    <string name="dual_core">Dual Core (speedhack)</string>
     <string name="dual_core_description">Split workload to two CPU cores instead of one. Increases speed.</string>
     <string name="enable_cheats">Enable Cheats</string>
     <string name="speed_limit">Speed Limit (0% = Unlimited)</string>

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -140,7 +140,7 @@ void GeneralPane::CreateBasic()
   basic_group->setLayout(basic_group_layout);
   m_main_layout->addWidget(basic_group);
 
-  m_checkbox_dualcore = new QCheckBox(tr("Enable Dual Core (speedup)"));
+  m_checkbox_dualcore = new QCheckBox(tr("Enable Dual Core (speedhack)"));
   basic_group_layout->addWidget(m_checkbox_dualcore);
 
   m_checkbox_cheats = new QCheckBox(tr("Enable Cheats"));


### PR DESCRIPTION
This PR changes `Dual Core (speedup)` to `Dual Core (speedhack)`. That's all.

If we are ever to remove Dual Core's default enabled status in the distant future, we'll need to start by changing users perception of the option. This extremely tiny change was suggested on discord, and I think it's brilliant. It's a subtle way to help users understand what Dual Core is - a hack - which we can use as a building block for the future.

Before
![dualcorebefore](https://github.com/user-attachments/assets/3da421bb-73f5-4a50-a6fe-9a44e5cb0718)

After
![dualcoreafter](https://github.com/user-attachments/assets/68332c1a-4edb-4475-a8ad-0a4a4e75bd8d)
