### PR TITLE
CheatsManager: Create Action Replay and Gecko code widgets only once

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -58,7 +58,7 @@ private:
   void OnNewSessionCreated(const Cheats::CheatSearchSessionBase& session);
   void OnTabCloseRequested(int index);
 
-  void RefreshCodeTabs(Core::State state, bool force);
+  void RefreshCodeTabs(Core::State state);
   void UpdateAllCheatSearchWidgetCurrentValues();
 
   std::string m_game_id;

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -238,7 +238,6 @@ void ARCodeWidget::LoadCodes()
   m_code_remove->setEnabled(false);
 
   UpdateList();
-  OnSelectionChanged();
 }
 
 void ARCodeWidget::SaveCodes()

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -35,21 +35,7 @@ ARCodeWidget::ARCodeWidget(std::string game_id, u16 game_revision, bool restart_
   CreateWidgets();
   ConnectWidgets();
 
-  if (!m_game_id.empty())
-  {
-    Common::IniFile game_ini_local;
-
-    // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
-    // will always be stored in GS/${GAMEID}.ini
-    game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
-
-    const Common::IniFile game_ini_default =
-        SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
-    m_ar_codes = ActionReplay::LoadCodes(game_ini_default, game_ini_local);
-  }
-
-  UpdateList();
-  OnSelectionChanged();
+  LoadCodes();
 }
 
 ARCodeWidget::~ARCodeWidget() = default;
@@ -64,11 +50,6 @@ void ARCodeWidget::CreateWidgets()
   m_code_add = new NonDefaultQPushButton(tr("&Add New Code..."));
   m_code_edit = new NonDefaultQPushButton(tr("&Edit Code..."));
   m_code_remove = new NonDefaultQPushButton(tr("&Remove Code"));
-
-  m_code_list->setEnabled(!m_game_id.empty());
-  m_code_add->setEnabled(!m_game_id.empty());
-  m_code_edit->setEnabled(false);
-  m_code_remove->setEnabled(false);
 
   m_code_list->setContextMenuPolicy(Qt::CustomContextMenu);
 
@@ -216,6 +197,30 @@ void ARCodeWidget::UpdateList()
   }
 
   m_code_list->setDragDropMode(QAbstractItemView::InternalMove);
+}
+
+void ARCodeWidget::LoadCodes()
+{
+  if (!m_game_id.empty())
+  {
+    Common::IniFile game_ini_local;
+
+    // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
+    // will always be stored in GS/${GAMEID}.ini
+    game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
+
+    const Common::IniFile game_ini_default =
+        SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
+    m_ar_codes = ActionReplay::LoadCodes(game_ini_default, game_ini_local);
+  }
+
+  m_code_list->setEnabled(!m_game_id.empty());
+  m_code_add->setEnabled(!m_game_id.empty());
+  m_code_edit->setEnabled(false);
+  m_code_remove->setEnabled(false);
+
+  UpdateList();
+  OnSelectionChanged();
 }
 
 void ARCodeWidget::SaveCodes()

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -67,8 +67,8 @@ void ARCodeWidget::CreateWidgets()
 
   m_code_list->setEnabled(!m_game_id.empty());
   m_code_add->setEnabled(!m_game_id.empty());
-  m_code_edit->setEnabled(!m_game_id.empty());
-  m_code_remove->setEnabled(!m_game_id.empty());
+  m_code_edit->setEnabled(false);
+  m_code_remove->setEnabled(false);
 
   m_code_list->setContextMenuPolicy(Qt::CustomContextMenu);
 
@@ -179,14 +179,18 @@ void ARCodeWidget::OnListReordered()
 
 void ARCodeWidget::OnSelectionChanged()
 {
-  auto items = m_code_list->selectedItems();
+  const QList<QListWidgetItem*> items = m_code_list->selectedItems();
+  const bool empty = items.empty();
 
-  if (items.empty())
+  m_code_edit->setDisabled(empty);
+  m_code_remove->setDisabled(empty);
+
+  if (empty)
     return;
 
-  const auto* selected = items[0];
+  const QListWidgetItem* const selected = items[0];
 
-  bool user_defined = m_ar_codes[m_code_list->row(selected)].user_defined;
+  const bool user_defined = m_ar_codes[m_code_list->row(selected)].user_defined;
 
   m_code_remove->setEnabled(user_defined);
   m_code_edit->setText(user_defined ? tr("&Edit Code...") : tr("Clone and &Edit Code..."));

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.h
@@ -15,6 +15,7 @@ namespace ActionReplay
 struct ARCode;
 }
 
+class CheatCodeEditor;
 class CheatWarningWidget;
 #ifdef USE_RETRO_ACHIEVEMENTS
 class HardcoreWarningWidget;
@@ -31,6 +32,7 @@ public:
   explicit ARCodeWidget(std::string game_id, u16 game_revision, bool restart_required = true);
   ~ARCodeWidget() override;
 
+  void ChangeGame(std::string game_id, u16 game_revision);
   void AddCode(ActionReplay::ARCode code);
 
 signals:
@@ -70,6 +72,8 @@ private:
   QPushButton* m_code_add;
   QPushButton* m_code_edit;
   QPushButton* m_code_remove;
+
+  CheatCodeEditor* m_cheat_code_editor;
 
   std::vector<ActionReplay::ARCode> m_ar_codes;
   bool m_restart_required;

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.h
@@ -47,6 +47,7 @@ private:
   void CreateWidgets();
   void ConnectWidgets();
   void UpdateList();
+  void LoadCodes();
   void SaveCodes();
   void SortAlphabetically();
   void SortEnabledCodesFirst();

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -166,17 +166,16 @@ void GeckoCodeWidget::ConnectWidgets()
 
 void GeckoCodeWidget::OnSelectionChanged()
 {
-  auto items = m_code_list->selectedItems();
-
+  const QList<QListWidgetItem*> items = m_code_list->selectedItems();
   const bool empty = items.empty();
 
-  m_edit_code->setEnabled(!empty);
-  m_remove_code->setEnabled(!empty);
+  m_edit_code->setDisabled(empty);
+  m_remove_code->setDisabled(empty);
 
-  if (items.empty())
+  if (empty)
     return;
 
-  auto selected = items[0];
+  const QListWidgetItem* const selected = items[0];
 
   const int index = selected->data(Qt::UserRole).toInt();
 

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -42,20 +42,7 @@ GeckoCodeWidget::GeckoCodeWidget(std::string game_id, std::string gametdb_id, u1
   CreateWidgets();
   ConnectWidgets();
 
-  if (!m_game_id.empty())
-  {
-    Common::IniFile game_ini_local;
-
-    // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
-    // will always be stored in GS/${GAMEID}.ini
-    game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
-
-    const Common::IniFile game_ini_default =
-        SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
-    m_gecko_codes = Gecko::LoadCodes(game_ini_default, game_ini_local);
-  }
-
-  UpdateList();
+  LoadCodes();
 }
 
 GeckoCodeWidget::~GeckoCodeWidget() = default;
@@ -92,17 +79,6 @@ void GeckoCodeWidget::CreateWidgets()
   m_download_codes = new NonDefaultQPushButton(tr("Download Codes"));
 
   m_download_codes->setToolTip(tr("Download Codes from the WiiRD Database"));
-
-  m_code_list->setEnabled(!m_game_id.empty());
-  m_name_label->setEnabled(!m_game_id.empty());
-  m_creator_label->setEnabled(!m_game_id.empty());
-  m_code_description->setEnabled(!m_game_id.empty());
-  m_code_view->setEnabled(!m_game_id.empty());
-
-  m_add_code->setEnabled(!m_game_id.empty());
-  m_edit_code->setEnabled(false);
-  m_remove_code->setEnabled(false);
-  m_download_codes->setEnabled(!m_game_id.empty());
 
   auto* layout = new QVBoxLayout;
 
@@ -251,6 +227,35 @@ void GeckoCodeWidget::RemoveCode()
 
   UpdateList();
   SaveCodes();
+}
+
+void GeckoCodeWidget::LoadCodes()
+{
+  if (!m_game_id.empty())
+  {
+    Common::IniFile game_ini_local;
+
+    // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
+    // will always be stored in GS/${GAMEID}.ini
+    game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
+
+    const Common::IniFile game_ini_default =
+        SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
+    m_gecko_codes = Gecko::LoadCodes(game_ini_default, game_ini_local);
+  }
+
+  m_code_list->setEnabled(!m_game_id.empty());
+  m_name_label->setEnabled(!m_game_id.empty());
+  m_creator_label->setEnabled(!m_game_id.empty());
+  m_code_description->setEnabled(!m_game_id.empty());
+  m_code_view->setEnabled(!m_game_id.empty());
+
+  m_add_code->setEnabled(!m_game_id.empty());
+  m_edit_code->setEnabled(false);
+  m_remove_code->setEnabled(false);
+  m_download_codes->setEnabled(!m_game_id.empty());
+
+  UpdateList();
 }
 
 void GeckoCodeWidget::SaveCodes()

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
@@ -52,6 +52,7 @@ private:
   void EditCode();
   void RemoveCode();
   void DownloadCodes();
+  void LoadCodes();
   void SaveCodes();
   void SortAlphabetically();
   void SortEnabledCodesFirst();

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
@@ -10,6 +10,7 @@
 
 #include "Common/CommonTypes.h"
 
+class CheatCodeEditor;
 class CheatWarningWidget;
 #ifdef USE_RETRO_ACHIEVEMENTS
 class HardcoreWarningWidget;
@@ -32,6 +33,8 @@ public:
   explicit GeckoCodeWidget(std::string game_id, std::string gametdb_id, u16 game_revision,
                            bool restart_required = true);
   ~GeckoCodeWidget() override;
+
+  void ChangeGame(std::string game_id, std::string gametdb_id, u16 game_revision);
 
 signals:
   void OpenGeneralSettings();
@@ -75,6 +78,7 @@ private:
   QPushButton* m_edit_code;
   QPushButton* m_remove_code;
   QPushButton* m_download_codes;
+  CheatCodeEditor* m_cheat_code_editor;
   std::vector<Gecko::GeckoCode> m_gecko_codes;
   bool m_restart_required;
 };


### PR DESCRIPTION
Create CheatsManager's ARCodeWidget and GeckoCodeWidget once on startup (in CheatsManager's constructor), and trigger updates to their contents when the current game changes.

Previously, ARCodeWidget and GeckoCodeWidget would be recreated every time a game was started or shutdown. If either of these widgets was the visible tab this would cause the tab to switch to CheatSearchFactoryWidget (since the other tabs temporarily didn't exist), and also could cause a crash if the user initiated a game shutdown and then opened a code edit window before the shutdown finished.