### PR TITLE
Display Taiwanese covers for Taiwanese games

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -451,7 +451,14 @@ std::string SConfig::GetGameTDBImageRegionCode(bool wii, DiscIO::Region region) 
   switch (region)
   {
   case DiscIO::Region::NTSC_J:
+  {
+    // Taiwanese games share the Japanese region code however their title ID ends with 'W'.
+    // GameTDB differentiates the covers using the code "ZH".
+    if (m_game_id.size() >= 4 && m_game_id.at(3) == 'W')
+      return "ZH";
+
     return "JA";
+  }
   case DiscIO::Region::NTSC_U:
     return "US";
   case DiscIO::Region::NTSC_K:


### PR DESCRIPTION
Taiwanese games share the same region code as Japan, however they have a different character at the 3rd index which differentiates them. 

i.e: RHAW01 for Taiwanese Wii Play as opposed to RHAJ01 for Japanese Wii Play.