### PR TITLE
Android: Controls Haptic Feedback

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
@@ -4,16 +4,15 @@ package org.dolphinemu.dolphinemu.features.input.model
 
 import android.content.Context
 import android.hardware.input.InputManager
-import android.os.Build
 import android.os.Handler
-import android.os.VibrationEffect
 import android.os.Vibrator
-import android.os.VibratorManager
 import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.MotionEvent
 import androidx.annotation.Keep
 import org.dolphinemu.dolphinemu.DolphinApplication
+import org.dolphinemu.dolphinemu.utils.HapticEffect
+import org.dolphinemu.dolphinemu.utils.HapticsProvider
 import org.dolphinemu.dolphinemu.utils.LooperThread
 
 /**
@@ -105,36 +104,19 @@ object ControllerInterface {
 
     @Keep
     @JvmStatic
-    private fun getVibratorManager(device: InputDevice): DolphinVibratorManager {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            DolphinVibratorManagerPassthrough(device.vibratorManager)
-        } else {
-            DolphinVibratorManagerCompat(device.vibrator)
-        }
-    }
+    private fun getDeviceVibratorManager(device: InputDevice): DolphinVibratorManager =
+        DolphinVibratorManagerFactory.getDeviceVibratorManager(device)
 
     @Keep
     @JvmStatic
-    private fun getSystemVibratorManager(): DolphinVibratorManager {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val vibratorManager = DolphinApplication.getAppContext()
-                .getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager?
-            if (vibratorManager != null)
-                return DolphinVibratorManagerPassthrough(vibratorManager)
-        }
-        val vibrator = DolphinApplication.getAppContext()
-            .getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-        return DolphinVibratorManagerCompat(vibrator)
-    }
+    private fun getSystemVibratorManager(): DolphinVibratorManager =
+        DolphinVibratorManagerFactory.getSystemVibratorManager()
 
     @Keep
     @JvmStatic
     private fun vibrate(vibrator: Vibrator) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            vibrator.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE))
-        } else {
-            vibrator.vibrate(100)
-        }
+        // TODO: Add a slider to the Rumble options that allows adjusting the vibration intensity.
+        HapticsProvider(vibrator).provideFeedback(HapticEffect.SPIN, 0.5f)
     }
 
     private class InputDeviceListener : InputManager.InputDeviceListener {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManager.kt
@@ -13,4 +13,6 @@ interface DolphinVibratorManager {
     fun getVibrator(vibratorId: Int): Vibrator
 
     fun getVibratorIds(): IntArray
+
+    fun getDefaultVibrator(): Vibrator
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerCompat.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerCompat.kt
@@ -21,4 +21,6 @@ class DolphinVibratorManagerCompat(vibrator: Vibrator) : DolphinVibratorManager 
     }
 
     override fun getVibratorIds(): IntArray = vibratorIds
+
+    override fun getDefaultVibrator(): Vibrator = vibrator
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerFactory.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerFactory.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.input.model
+
+import android.content.Context
+import android.os.Build
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.view.InputDevice
+import org.dolphinemu.dolphinemu.DolphinApplication
+
+object DolphinVibratorManagerFactory {
+    fun getDeviceVibratorManager(device: InputDevice): DolphinVibratorManager {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            DolphinVibratorManagerPassthrough(device.vibratorManager)
+        } else {
+            DolphinVibratorManagerCompat(device.vibrator)
+        }
+    }
+
+    fun getSystemVibratorManager(): DolphinVibratorManager {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val vibratorManager = DolphinApplication.getAppContext()
+                .getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager?
+            if (vibratorManager != null) {
+                return DolphinVibratorManagerPassthrough(vibratorManager)
+            }
+        }
+        val vibrator = DolphinApplication.getAppContext()
+            .getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        return DolphinVibratorManagerCompat(vibrator)
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerPassthrough.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerPassthrough.kt
@@ -13,4 +13,6 @@ class DolphinVibratorManagerPassthrough(private val vibratorManager: VibratorMan
     override fun getVibrator(vibratorId: Int): Vibrator = vibratorManager.getVibrator(vibratorId)
 
     override fun getVibratorIds(): IntArray = vibratorManager.vibratorIds
+
+    override fun getDefaultVibrator(): Vibrator = vibratorManager.defaultVibrator
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -646,6 +646,24 @@ enum class BooleanSetting(
         "ButtonLatchingNunchukZ",
         false
     ),
+    MAIN_OVERLAY_HAPTICS_PRESS(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "OverlayHapticsPress",
+        false
+    ),
+    MAIN_OVERLAY_HAPTICS_RELEASE(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "OverlayHapticsRelease",
+        false
+    ),
+    MAIN_OVERLAY_HAPTICS_JOYSTICK(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "OverlayHapticsJoystick",
+        false
+    ),
     SYSCONF_SCREENSAVER(Settings.FILE_SYSCONF, "IPL", "SSV", false),
     SYSCONF_WIDESCREEN(Settings.FILE_SYSCONF, "IPL", "AR", true),
     SYSCONF_PROGRESSIVE_SCAN(Settings.FILE_SYSCONF, "IPL", "PGS", true),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.kt
@@ -8,6 +8,12 @@ enum class FloatSetting(
     private val key: String,
     private val defaultValue: Float
 ) : AbstractFloatSetting {
+    MAIN_OVERLAY_HAPTICS_SCALE(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "OverlayHapticsScale",
+        0.5f
+    ),
     // These entries have the same names and order as in C++, just for consistency.
     MAIN_EMULATION_SPEED(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "EmulationSpeed", 1.0f),
     MAIN_OVERCLOCK(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "Overclock", 1.0f),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/HapticsProvider.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/HapticsProvider.kt
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.utils
+
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import androidx.annotation.FloatRange
+import androidx.annotation.RequiresApi
+import org.dolphinemu.dolphinemu.features.input.model.DolphinVibratorManagerFactory
+
+/**
+ * This class provides methods that facilitate performing haptic feedback.
+ *
+ * @property vibrator The [Vibrator] instance to be used for vibration.
+ * Defaults to the system default vibrator.
+ */
+class HapticsProvider(
+    private val vibrator: Vibrator =
+        DolphinVibratorManagerFactory.getSystemVibratorManager().getDefaultVibrator()
+) {
+    private val primitiveSupport: Boolean = areAllPrimitivesSupported()
+
+    /**
+     * Perform haptic feedback by composing primitives (if supported),
+     * with a fallback to a waveform or a legacy vibration.
+     *
+     * @param effect The [HapticEffect] of the feedback.
+     * @param scale The intensity scale of the feedback.
+     */
+    fun provideFeedback(effect: HapticEffect, @FloatRange(from = 0.0, to = 1.0) scale: Float) {
+        if (primitiveSupport) {
+            vibrator.vibrate(
+                VibrationEffect
+                    .startComposition()
+                    .addPrimitive(getPrimitive(effect), scale)
+                    .compose()
+            )
+        } else {
+            val timings = getTimings(effect, scale)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                if (vibrator.hasAmplitudeControl()) {
+                    vibrator.vibrate(
+                        VibrationEffect.createWaveform(
+                            timings, getAmplitudes(effect, scale), -1
+                        )
+                    )
+                } else {
+                    vibrator.vibrate(VibrationEffect.createWaveform(timings, -1))
+                }
+            } else {
+                vibrator.vibrate(timings.sum())
+            }
+        }
+    }
+
+    /**
+     * Get the timings for a waveform vibration based on the [effect], scaled by [scale].
+     *
+     * @param effect The [HapticEffect] of the vibration.
+     * @param scale The intensity scale of the vibration.
+     * @return The LongArray of scaled timings for the specified [effect].
+     */
+    private fun getTimings(
+        effect: HapticEffect, @FloatRange(from = 0.0, to = 1.0) scale: Float
+    ): LongArray {
+        // Note: It is recommended that these values differ by a ratio of 1.4 or more,
+        // so the difference in the duration of the vibration can be easily perceived.
+        // Lower-end vibrators can't vibrate at all if the duration is too short.
+        return when (effect) {
+            HapticEffect.QUICK_FALL -> longArrayOf(0L, (100f * scale).toLong())
+            HapticEffect.QUICK_RISE -> longArrayOf(0L, (70f * scale).toLong())
+            HapticEffect.LOW_TICK -> longArrayOf(0L, (50f * scale).toLong())
+            HapticEffect.SPIN -> LongArray(SPIN_TIMINGS.size) { (SPIN_TIMINGS[it] * scale).toLong() }
+        }
+    }
+
+    /**
+     * Get the amplitudes for a waveform vibration based on the [effect], scaled by [scale].
+     *
+     * @param effect The [HapticEffect] of the vibration.
+     * @param scale The intensity scale of the vibration.
+     * @return The IntArray of scaled amplitudes for the specified [effect].
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun getAmplitudes(
+        effect: HapticEffect, @FloatRange(from = 0.0, to = 1.0) scale: Float
+    ): IntArray {
+        // Note: It is recommended that these values differ by a ratio of 1.4 or more,
+        // so the difference in the amplitude of the vibration can be easily perceived.
+        return when (effect) {
+            HapticEffect.QUICK_FALL -> intArrayOf(0, (180 * scale).toInt())
+            HapticEffect.QUICK_RISE -> intArrayOf(0, (128 * scale).toInt())
+            HapticEffect.LOW_TICK -> intArrayOf(0, (90 * scale).toInt())
+            HapticEffect.SPIN -> IntArray(SPIN_AMPLITUDES.size) { (SPIN_AMPLITUDES[it] * scale).toInt() }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun getPrimitive(effect: HapticEffect): Int {
+        return when (effect) {
+            HapticEffect.QUICK_FALL -> VibrationEffect.Composition.PRIMITIVE_QUICK_FALL
+            HapticEffect.QUICK_RISE -> VibrationEffect.Composition.PRIMITIVE_QUICK_RISE
+            HapticEffect.LOW_TICK -> VibrationEffect.Composition.PRIMITIVE_LOW_TICK
+            HapticEffect.SPIN -> VibrationEffect.Composition.PRIMITIVE_SPIN
+        }
+    }
+
+    private fun areAllPrimitivesSupported(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && vibrator.areAllPrimitivesSupported(
+            *HapticEffect.values().map { getPrimitive(it) }.toIntArray()
+        )
+    }
+
+    companion object {
+        private val SPIN_TIMINGS = longArrayOf(15L, 30L, 20L, 30L, 20L, 30L, 20L, 10L)
+        private val SPIN_AMPLITUDES = intArrayOf(0, 128, 255, 100, 200, 32, 64, 0)
+    }
+}
+
+enum class HapticEffect {
+    QUICK_FALL,
+    QUICK_RISE,
+    LOW_TICK,
+    SPIN
+}

--- a/Source/Android/app/src/main/res/layout/dialog_haptics_adjust.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_haptics_adjust.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/haptics_triggers"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/spacing_large">
+
+        <TextView
+            android:id="@+id/haptics_triggers_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacing_medlarge"
+            android:text="@string/haptics_triggers"
+            android:textAlignment="viewStart"
+            android:textAppearance="@style/TextAppearance.AppCompat.Title"
+            app:layout_constraintBottom_toTopOf="@id/haptics_release_checkbox"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/haptics_press_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:text="@string/haptics_press"
+            android:textAppearance="?android:textAppearanceListItem"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/haptics_release_checkbox"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/haptics_release_checkbox" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/haptics_release_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:text="@string/haptics_release"
+            android:textAppearance="?android:textAppearanceListItem"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/haptics_joystick_checkbox"
+            app:layout_constraintStart_toEndOf="@+id/haptics_press_checkbox"
+            app:layout_constraintTop_toBottomOf="@+id/haptics_triggers_text" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/haptics_joystick_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:text="@string/haptics_joystick"
+            android:textAppearance="?android:textAppearanceListItem"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/haptics_release_checkbox"
+            app:layout_constraintTop_toTopOf="@id/haptics_release_checkbox" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/haptics_intensity"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:paddingHorizontal="24dp">
+
+        <TextView
+            android:id="@+id/haptics_intensity_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/haptics_intensity"
+            android:textAlignment="viewStart"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/haptics_intensity_slider"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/haptics_intensity_slider"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/spacing_medlarge"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/haptics_intensity_value"
+            app:layout_constraintStart_toEndOf="@id/haptics_intensity_name"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/haptics_intensity_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/haptics_intensity_slider"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="50%" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/Source/Android/app/src/main/res/menu/menu_overlay_controls_gc.xml
+++ b/Source/Android/app/src/main/res/menu/menu_overlay_controls_gc.xml
@@ -28,6 +28,10 @@
         android:title="@string/emulation_choose_controller"/>
 
     <item
+        android:id="@+id/menu_emulation_haptics"
+        android:title="@string/emulation_haptics"/>
+
+    <item
         android:id="@+id/menu_emulation_reset_overlay"
         android:title="@string/emulation_touch_overlay_reset"/>
 </menu>

--- a/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
@@ -30,6 +30,10 @@
         android:title="@string/emulation_choose_controller"/>
 
     <item
+        android:id="@+id/menu_emulation_haptics"
+        android:title="@string/emulation_haptics"/>
+
+    <item
         android:id="@+id/menu_emulation_ir_group"
         android:title="@string/emulation_ir_group">
         <menu>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -610,6 +610,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="emulation_ir_mode">IR Mode</string>
     <string name="emulation_ir_sensitivity">IR Sensitivity</string>
     <string name="emulation_choose_doubletap">Double tap button</string>
+    <string name="emulation_haptics">Touch Haptics</string>
 
     <!-- GC Adapter Menu-->
     <string name="gc_adapter_rumble">Enable Vibration</string>
@@ -811,6 +812,13 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="ir_disabled">Disabled</string>
     <string name="ir_follow">Follow</string>
     <string name="ir_drag">Drag</string>
+
+    <!-- Haptics -->
+    <string name="haptics_triggers">Feedback Triggers</string>
+    <string name="haptics_press">Press</string>
+    <string name="haptics_release">Release</string>
+    <string name="haptics_joystick">Joystick</string>
+    <string name="haptics_intensity">Intensity</string>
 
     <!-- Double Tap Buttons -->
     <string name="double_tap_a">Button A</string>

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -63,7 +63,7 @@ jmethodID s_motion_event_get_source;
 jclass s_controller_interface_class;
 jmethodID s_controller_interface_register_input_device_listener;
 jmethodID s_controller_interface_unregister_input_device_listener;
-jmethodID s_controller_interface_get_vibrator_manager;
+jmethodID s_controller_interface_get_device_vibrator_manager;
 jmethodID s_controller_interface_get_system_vibrator_manager;
 jmethodID s_controller_interface_vibrate;
 
@@ -78,6 +78,7 @@ jmethodID s_sensor_event_listener_get_negative_axes;
 jclass s_dolphin_vibrator_manager_class;
 jmethodID s_dolphin_vibrator_manager_get_vibrator;
 jmethodID s_dolphin_vibrator_manager_get_vibrator_ids;
+jmethodID s_dolphin_vibrator_manager_get_default_vibrator;
 
 jintArray s_keycodes_array;
 
@@ -746,7 +747,8 @@ private:
   void AddMotors(JNIEnv* env, jobject input_device)
   {
     jobject vibrator_manager = env->CallStaticObjectMethod(
-        s_controller_interface_class, s_controller_interface_get_vibrator_manager, input_device);
+        s_controller_interface_class, s_controller_interface_get_device_vibrator_manager,
+        input_device);
     AddMotorsFromManager(env, vibrator_manager);
     env->DeleteLocalRef(vibrator_manager);
   }
@@ -857,8 +859,8 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
       env->GetStaticMethodID(s_controller_interface_class, "registerInputDeviceListener", "()V");
   s_controller_interface_unregister_input_device_listener =
       env->GetStaticMethodID(s_controller_interface_class, "unregisterInputDeviceListener", "()V");
-  s_controller_interface_get_vibrator_manager =
-      env->GetStaticMethodID(s_controller_interface_class, "getVibratorManager",
+  s_controller_interface_get_device_vibrator_manager =
+      env->GetStaticMethodID(s_controller_interface_class, "getDeviceVibratorManager",
                              "(Landroid/view/InputDevice;)Lorg/dolphinemu/dolphinemu/features/"
                              "input/model/DolphinVibratorManager;");
   s_controller_interface_get_system_vibrator_manager = env->GetStaticMethodID(
@@ -894,6 +896,8 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
       env->GetMethodID(s_dolphin_vibrator_manager_class, "getVibrator", "(I)Landroid/os/Vibrator;");
   s_dolphin_vibrator_manager_get_vibrator_ids =
       env->GetMethodID(s_dolphin_vibrator_manager_class, "getVibratorIds", "()[I");
+  s_dolphin_vibrator_manager_get_default_vibrator = env->GetMethodID(
+      s_dolphin_vibrator_manager_class, "getDefaultVibrator", "()Landroid/os/Vibrator;");
   env->DeleteLocalRef(dolphin_vibrator_manager_class);
 
   jintArray keycodes_array = CreateKeyCodesArray(env);


### PR DESCRIPTION
This PR adds haptic feedback support for input overlay touch controls and alters the controller vibration effect.

There is a new dialog in "Overlay Controls" -> "Touch Haptics" for enabling any of the following haptic feedback triggers (all are disabled by default):
1) Overlay button press -> [Quick fall](https://developer.android.com/reference/android/os/VibrationEffect.Composition#PRIMITIVE_QUICK_FALL) effect with a fallback to a vibration of up to 100ms duration and ~70% amplitude
2) Overlay button release -> [Quick rise](https://developer.android.com/reference/android/os/VibrationEffect.Composition#PRIMITIVE_QUICK_RISE) effect with a fallback to a vibration of up to 70ms duration and ~50% amplitude
3) Overlay joystick movement -> [Low tick](https://developer.android.com/reference/android/os/VibrationEffect.Composition#PRIMITIVE_LOW_TICK) effect with a fallback to a vibration of up to 50ms duration and ~35% amplitude

_Note that rich haptics are available only in devices of API 31+ with a decent vibration motor which supports the effects above._

_The maximum recommended duration is 20 ms for a short vibration effect according to the Android [docs](https://source.android.com/docs/core/interaction/haptics/haptics-implement#short-effect), but some low-end or unoptimized vibrators may not vibrate at all if the duration is that low. Therefore the maximum duration is higher to workaround this limitation._

You may also notice that the controller vibration has been replaced with a (rich haptics) [spin](https://developer.android.com/reference/android/os/VibrationEffect.Composition#PRIMITIVE_SPIN) effect.
Also, I've moved the content of vibration related functions from ControllerInterface.kt to a new object so I could use them in the new HapticsProvider class without duplicating code.

In the dialog mentioned before there is a slider for adjusting the intensity (duration and amplitude) of the vibration. It applies only to the input overlay haptics and does not affect the intensity of the controller vibration which is issued to the vibration motor selected in the Rumble options. 
It would have been ideal if there was an additional intensity slider under the Rumble options, but it seems that the controller settings are retrieved from the C++ core and I am not sure how a new Android-specific setting should be added there.

Please let me know what you think or if you have found an issue. Thanks!