### PR TITLE
DolphinQt: Simplify the Speed Limit description

### DIFF
--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -400,13 +400,12 @@ void GeneralPane::AddDescriptions()
                  "<br><br>This setting cannot be changed while emulation is active."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
 #endif
-  static constexpr char TR_SPEEDLIMIT_DESCRIPTION[] = QT_TR_NOOP(
-      "Sets the maximum time scale of emulation. Values higher than 100% will accelerate emulated "
-      "time by processing faster than the original hardware, while values lower than 100% will "
-      "slow emulated time. Unlimited will emulate as fast as your host hardware can run."
-      "<br><br>Higher speeds are proportionally more costly to emulate. Depending on the title, "
-      "your settings, and your host hardware, some of these values may not be sustainable."
-      "<br><br><dolphin_emphasis>If unsure, select 100%.</dolphin_emphasis>");
+  static constexpr char TR_SPEEDLIMIT_DESCRIPTION[] =
+      QT_TR_NOOP("Controls how fast emulation runs relative to the original hardware."
+                 "<br><br>Values higher than 100% will emulate faster than the original hardware "
+                 "can run, if your hardware is able to keep up. Values lower than 100% will slow "
+                 "emulation instead. Unlimited will emulate as fast as your hardware is able to."
+                 "<br><br><dolphin_emphasis>If unsure, select 100%.</dolphin_emphasis>");
   static constexpr char TR_UPDATE_TRACK_DESCRIPTION[] = QT_TR_NOOP(
       "Selects which update track Dolphin uses when checking for updates at startup. If a new "
       "update is available, Dolphin will show a list of changes made since your current version "


### PR DESCRIPTION
The description of the Speed Limit setting currently uses a lot of complicated terms, like "emulated time" (known to many Dolphin developers, but in my experience not known by even advanced emulator users) and "maximum time scale" (I have never heard it before). The meaning of "sustainable" is also unclear in context.

This commit rewords the description to be easier to understand.