### PR TITLE
Branch Watch Tool: Refactors, Fixes, and Features

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -163,7 +163,7 @@ bool CBoot::RunApploader(Core::System& system, const Core::CPUThreadGuard& guard
 
   const bool resume_branch_watch = branch_watch.GetRecordingActive();
   if (system.IsBranchWatchIgnoreApploader())
-    branch_watch.Pause();
+    branch_watch.SetRecordingActive(guard, false);
 
   // Call iAppLoaderEntry.
   DEBUG_LOG_FMT(BOOT, "Call iAppLoaderEntry");
@@ -226,7 +226,7 @@ bool CBoot::RunApploader(Core::System& system, const Core::CPUThreadGuard& guard
   // return
   ppc_state.pc = ppc_state.gpr[3];
 
-  branch_watch.SetRecordingActive(resume_branch_watch);
+  branch_watch.SetRecordingActive(guard, resume_branch_watch);
 
   return true;
 }

--- a/Source/Core/Core/Debugger/BranchWatch.cpp
+++ b/Source/Core/Core/Debugger/BranchWatch.cpp
@@ -38,14 +38,14 @@ union USnapshotMetadata
   using Inspection = BranchWatch::SelectionInspection;
   using StorageType = unsigned long long;
 
-  static_assert(Inspection::EndOfEnumeration == Inspection{(1u << 3) + 1});
+  static_assert(Inspection::EndOfEnumeration == Inspection{(1u << 5) + 1});
 
   StorageType hex;
 
   BitField<0, 1, bool, StorageType> is_virtual;
   BitField<1, 1, bool, StorageType> condition;
   BitField<2, 1, bool, StorageType> is_selected;
-  BitField<3, 4, Inspection, StorageType> inspection;
+  BitField<3, 6, Inspection, StorageType> inspection;
 
   USnapshotMetadata() : hex(0) {}
   explicit USnapshotMetadata(bool is_virtual_, bool condition_, bool is_selected_,

--- a/Source/Core/Core/Debugger/BranchWatch.cpp
+++ b/Source/Core/Core/Debugger/BranchWatch.cpp
@@ -69,18 +69,22 @@ void BranchWatch::Save(const CPUThreadGuard& guard, std::FILE* file) const
   if (file == nullptr)
     return;
 
+  const bool is_reduction_phase = GetRecordingPhase() == Phase::Reduction;
+
   const auto routine = [&](const Collection& collection, bool is_virtual, bool condition) {
     for (const Collection::value_type& kv : collection)
     {
-      const auto iter = std::find_if(
-          m_selection.begin(), m_selection.end(),
-          [&](const Selection::value_type& value) { return value.collection_ptr == &kv; });
+      const auto iter = std::ranges::find_if(m_selection, [&](const Selection::value_type& value) {
+        return value.collection_ptr == &kv;
+      });
+      const bool selected = iter != m_selection.end();
+      if (is_reduction_phase && !selected)
+        continue;  // Unselected hits are irrelevant to the reduction phase.
+      const auto inspection = selected ? iter->inspection : SelectionInspection{};
       fmt::println(file, "{:08x} {:08x} {:08x} {} {} {:x}", kv.first.origin_addr,
                    kv.first.destin_addr, kv.first.original_inst.hex, kv.second.total_hits,
                    kv.second.hits_snapshot,
-                   iter == m_selection.end() ?
-                       USnapshotMetadata(is_virtual, condition, false, {}).hex :
-                       USnapshotMetadata(is_virtual, condition, true, iter->inspection).hex);
+                   USnapshotMetadata(is_virtual, condition, selected, inspection).hex);
     }
   };
   routine(m_collection_vt, true, true);

--- a/Source/Core/Core/Debugger/BranchWatch.h
+++ b/Source/Core/Core/Debugger/BranchWatch.h
@@ -63,6 +63,8 @@ enum class BranchWatchSelectionInspection : u8
   SetDestinBLR = 1u << 1,
   SetOriginSymbolBLR = 1u << 2,
   SetDestinSymbolBLR = 1u << 3,
+  InvertBranchOption = 1u << 4,  // Used for both conditions and decrement checks.
+  MakeUnconditional = 1u << 5,
   EndOfEnumeration,
 };
 

--- a/Source/Core/Core/Debugger/BranchWatch.h
+++ b/Source/Core/Core/Debugger/BranchWatch.h
@@ -117,9 +117,7 @@ public:
   using SelectionInspection = BranchWatchSelectionInspection;
 
   bool GetRecordingActive() const { return m_recording_active; }
-  void SetRecordingActive(bool active) { m_recording_active = active; }
-  void Start() { SetRecordingActive(true); }
-  void Pause() { SetRecordingActive(false); }
+  void SetRecordingActive(const CPUThreadGuard& guard, bool active) { m_recording_active = active; }
   void Clear(const CPUThreadGuard& guard);
 
   void Save(const CPUThreadGuard& guard, std::FILE* file) const;

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -294,6 +294,14 @@ union UGeckoInstruction
   };
 };
 
+// Precondition: inst is a bx, bcx, bclrx, or bcctrx instruction.
+constexpr bool BranchIsConditional(UGeckoInstruction inst)
+{
+  if (inst.OPCD == 18)  // bx
+    return false;
+  return (inst.BO & 0b10100) != 0b10100;  // 1z1zz - Branch always
+}
+
 // Used in implementations of rlwimi, rlwinm, and rlwnm
 inline u32 MakeRotationMask(u32 mb, u32 me)
 {

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -202,10 +202,8 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
   setWindowTitle(tr("Branch Watch Tool"));
   setWindowFlags((windowFlags() | Qt::WindowMinMaxButtonsHint) & ~Qt::WindowContextHelpButtonHint);
 
-  auto* main_layout = new QVBoxLayout;
-
   // Controls Toolbar (widgets are added later)
-  main_layout->addWidget(m_control_toolbar = new QToolBar);
+  m_control_toolbar = new QToolBar;
 
   // Branch Watch Table
   const auto& ui_settings = Settings::Instance();
@@ -257,8 +255,6 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
   connect(new QShortcut(QKeySequence(Qt::Key_Delete), this), &QShortcut::activated, this,
           &BranchWatchDialog::OnTableDeleteKeypress);
 
-  main_layout->addWidget(m_table_view);
-
   {
     // Column Visibility Menu
     static constexpr std::array<const char*, Column::NumberOfColumns> headers = {
@@ -277,11 +273,11 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
       action->setCheckable(true);
     }
   }
-  {
-    // Menu Bar
-    QMenuBar* const menu_bar = new QMenuBar;
-    menu_bar->setNativeMenuBar(false);
 
+  // Menu Bar
+  QMenuBar* const menu_bar = new QMenuBar;
+  menu_bar->setNativeMenuBar(false);
+  {
     QMenu* const menu_file = new QMenu(tr("&File"), menu_bar);
     menu_file->addAction(tr("&Save Branch Watch"), this, &BranchWatchDialog::OnSave);
     menu_file->addAction(tr("Save Branch Watch &As..."), this, &BranchWatchDialog::OnSaveAs);
@@ -309,37 +305,38 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
     menu_tool->addAction(tr("&Help"), this, &BranchWatchDialog::OnHelp);
 
     menu_bar->addMenu(menu_tool);
+  }
 
-    main_layout->setMenuBar(menu_bar);
-  }
-  {
-    // Status Bar
-    m_status_bar = new QStatusBar;
-    m_status_bar->setSizeGripEnabled(false);
-    main_layout->addWidget(m_status_bar);
-  }
+  // Status Bar
+  m_status_bar = new QStatusBar;
+  m_status_bar->setSizeGripEnabled(false);
+
   {
     // Tool Controls
-    auto* const layout = new QGridLayout;
-
-    layout->addWidget(m_btn_start_pause = new QPushButton(tr("Start Branch Watch")), 0, 0);
+    m_btn_start_pause = new QPushButton(tr("Start Branch Watch"));
     connect(m_btn_start_pause, &QPushButton::toggled, this, &BranchWatchDialog::OnStartPause);
     m_btn_start_pause->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     m_btn_start_pause->setCheckable(true);
 
-    layout->addWidget(m_btn_clear_watch = new QPushButton(tr("Clear Branch Watch")), 1, 0);
+    m_btn_clear_watch = new QPushButton(tr("Clear Branch Watch"));
     connect(m_btn_clear_watch, &QPushButton::pressed, this, &BranchWatchDialog::OnClearBranchWatch);
     m_btn_clear_watch->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
-    layout->addWidget(m_btn_path_was_taken = new QPushButton(tr("Code Path Was Taken")), 0, 1);
+    m_btn_path_was_taken = new QPushButton(tr("Code Path Was Taken"));
     connect(m_btn_path_was_taken, &QPushButton::pressed, this,
             &BranchWatchDialog::OnCodePathWasTaken);
     m_btn_path_was_taken->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
-    layout->addWidget(m_btn_path_not_taken = new QPushButton(tr("Code Path Not Taken")), 1, 1);
+    m_btn_path_not_taken = new QPushButton(tr("Code Path Not Taken"));
     connect(m_btn_path_not_taken, &QPushButton::pressed, this,
             &BranchWatchDialog::OnCodePathNotTaken);
     m_btn_path_not_taken->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+
+    auto* const layout = new QGridLayout;
+    layout->addWidget(m_btn_start_pause, 0, 0);
+    layout->addWidget(m_btn_clear_watch, 1, 0);
+    layout->addWidget(m_btn_path_was_taken, 0, 1);
+    layout->addWidget(m_btn_path_not_taken, 1, 1);
 
     auto* const group_box = new QGroupBox(tr("Tool Controls"));
     group_box->setLayout(layout);
@@ -455,23 +452,26 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
   }
   {
     // Misc. Controls
-    auto* const layout = new QVBoxLayout;
-
-    layout->addWidget(m_btn_was_overwritten = new QPushButton(tr("Branch Was Overwritten")));
+    m_btn_was_overwritten = new QPushButton(tr("Branch Was Overwritten"));
     connect(m_btn_was_overwritten, &QPushButton::pressed, this,
             &BranchWatchDialog::OnBranchWasOverwritten);
     m_btn_was_overwritten->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
-    layout->addWidget(m_btn_not_overwritten = new QPushButton(tr("Branch Not Overwritten")));
+    m_btn_not_overwritten = new QPushButton(tr("Branch Not Overwritten"));
     connect(m_btn_not_overwritten, &QPushButton::pressed, this,
             &BranchWatchDialog::OnBranchNotOverwritten);
     m_btn_not_overwritten->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
-    layout->addWidget(m_btn_wipe_recent_hits = new QPushButton(tr("Wipe Recent Hits")));
+    m_btn_wipe_recent_hits = new QPushButton(tr("Wipe Recent Hits"));
     connect(m_btn_wipe_recent_hits, &QPushButton::pressed, this,
             &BranchWatchDialog::OnWipeRecentHits);
     m_btn_wipe_recent_hits->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     m_btn_wipe_recent_hits->setEnabled(false);
+
+    auto* const layout = new QVBoxLayout;
+    layout->addWidget(m_btn_was_overwritten);
+    layout->addWidget(m_btn_not_overwritten);
+    layout->addWidget(m_btn_wipe_recent_hits);
 
     auto* const group_box = new QGroupBox(tr("Misc. Controls"));
     group_box->setLayout(layout);
@@ -489,6 +489,11 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
   connect(m_table_proxy, &BranchWatchProxyModel::layoutChanged, this,
           &BranchWatchDialog::UpdateStatus);
 
+  auto* const main_layout = new QVBoxLayout;
+  main_layout->setMenuBar(menu_bar);
+  main_layout->addWidget(m_control_toolbar);
+  main_layout->addWidget(m_table_view);
+  main_layout->addWidget(m_status_bar);
   setLayout(main_layout);
 
   const auto& settings = Settings::GetQSettings();

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -256,16 +256,16 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
     m_btn_start_pause->setCheckable(true);
 
     m_btn_clear_watch = new QPushButton(tr("Clear Branch Watch"), nullptr);
-    connect(m_btn_clear_watch, &QPushButton::pressed, this, &BranchWatchDialog::OnClearBranchWatch);
+    connect(m_btn_clear_watch, &QPushButton::clicked, this, &BranchWatchDialog::OnClearBranchWatch);
     m_btn_clear_watch->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
     m_btn_path_was_taken = new QPushButton(tr("Code Path Was Taken"), nullptr);
-    connect(m_btn_path_was_taken, &QPushButton::pressed, this,
+    connect(m_btn_path_was_taken, &QPushButton::clicked, this,
             &BranchWatchDialog::OnCodePathWasTaken);
     m_btn_path_was_taken->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
     m_btn_path_not_taken = new QPushButton(tr("Code Path Not Taken"), nullptr);
-    connect(m_btn_path_not_taken, &QPushButton::pressed, this,
+    connect(m_btn_path_not_taken, &QPushButton::clicked, this,
             &BranchWatchDialog::OnCodePathNotTaken);
     m_btn_path_not_taken->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
@@ -388,17 +388,17 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
   {
     // Misc. Controls
     m_btn_was_overwritten = new QPushButton(tr("Branch Was Overwritten"), nullptr);
-    connect(m_btn_was_overwritten, &QPushButton::pressed, this,
+    connect(m_btn_was_overwritten, &QPushButton::clicked, this,
             &BranchWatchDialog::OnBranchWasOverwritten);
     m_btn_was_overwritten->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
     m_btn_not_overwritten = new QPushButton(tr("Branch Not Overwritten"), nullptr);
-    connect(m_btn_not_overwritten, &QPushButton::pressed, this,
+    connect(m_btn_not_overwritten, &QPushButton::clicked, this,
             &BranchWatchDialog::OnBranchNotOverwritten);
     m_btn_not_overwritten->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
     m_btn_wipe_recent_hits = new QPushButton(tr("Wipe Recent Hits"), nullptr);
-    connect(m_btn_wipe_recent_hits, &QPushButton::pressed, this,
+    connect(m_btn_wipe_recent_hits, &QPushButton::clicked, this,
             &BranchWatchDialog::OnWipeRecentHits);
     m_btn_wipe_recent_hits->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     m_btn_wipe_recent_hits->setEnabled(false);

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -104,7 +104,7 @@ public:
   }
 
   bool IsBranchTypeAllowed(UGeckoInstruction inst) const;
-  void SetInspected(const QModelIndex& index);
+  void SetInspected(const QModelIndex& index) const;
 
 private:
   const Core::BranchWatch& m_branch_watch;
@@ -190,7 +190,7 @@ bool BranchWatchProxyModel::IsBranchTypeAllowed(UGeckoInstruction inst) const
   return false;
 }
 
-void BranchWatchProxyModel::SetInspected(const QModelIndex& index)
+void BranchWatchProxyModel::SetInspected(const QModelIndex& index) const
 {
   sourceModel()->SetInspected(mapToSource(index));
 }
@@ -535,7 +535,7 @@ void BranchWatchDialog::showEvent(QShowEvent* event)
   QDialog::showEvent(event);
 }
 
-void BranchWatchDialog::OnStartPause(bool checked)
+void BranchWatchDialog::OnStartPause(bool checked) const
 {
   if (checked)
   {
@@ -672,22 +672,22 @@ void BranchWatchDialog::OnBranchNotOverwritten()
   UpdateStatus();
 }
 
-void BranchWatchDialog::OnWipeRecentHits()
+void BranchWatchDialog::OnWipeRecentHits() const
 {
   m_table_model->OnWipeRecentHits();
 }
 
-void BranchWatchDialog::OnWipeInspection()
+void BranchWatchDialog::OnWipeInspection() const
 {
   m_table_model->OnWipeInspection();
 }
 
-void BranchWatchDialog::OnTimeout()
+void BranchWatchDialog::OnTimeout() const
 {
   Update();
 }
 
-void BranchWatchDialog::OnEmulationStateChanged(Core::State new_state)
+void BranchWatchDialog::OnEmulationStateChanged(Core::State new_state) const
 {
   if (TimerCondition(m_branch_watch, new_state))
     m_timer->start(BRANCH_WATCH_TOOL_TIMER_DELAY_MS);
@@ -781,7 +781,7 @@ void BranchWatchDialog::OnToggleAutoSave(bool checked)
     m_autosave_filepath = filepath.toStdString();
 }
 
-void BranchWatchDialog::OnHideShowControls(bool checked)
+void BranchWatchDialog::OnHideShowControls(bool checked) const
 {
   if (checked)
     m_control_toolbar->hide();
@@ -789,12 +789,12 @@ void BranchWatchDialog::OnHideShowControls(bool checked)
     m_control_toolbar->show();
 }
 
-void BranchWatchDialog::OnToggleIgnoreApploader(bool checked)
+void BranchWatchDialog::OnToggleIgnoreApploader(bool checked) const
 {
   m_system.SetIsBranchWatchIgnoreApploader(checked);
 }
 
-void BranchWatchDialog::OnTableClicked(const QModelIndex& index)
+void BranchWatchDialog::OnTableClicked(const QModelIndex& index) const
 {
   const QVariant v = m_table_proxy->data(index, UserRole::ClickRole);
   switch (index.column())
@@ -811,7 +811,7 @@ void BranchWatchDialog::OnTableClicked(const QModelIndex& index)
   }
 }
 
-void BranchWatchDialog::OnTableContextMenu(const QPoint& pos)
+void BranchWatchDialog::OnTableContextMenu(const QPoint& pos) const
 {
   if (m_table_view->horizontalHeader()->hiddenSectionCount() == Column::NumberOfColumns)
   {
@@ -827,12 +827,12 @@ void BranchWatchDialog::OnTableContextMenu(const QPoint& pos)
   m_index_list_temp.shrink_to_fit();
 }
 
-void BranchWatchDialog::OnTableHeaderContextMenu(const QPoint& pos)
+void BranchWatchDialog::OnTableHeaderContextMenu(const QPoint& pos) const
 {
   m_mnu_column_visibility->exec(m_table_view->horizontalHeader()->mapToGlobal(pos));
 }
 
-void BranchWatchDialog::OnTableDelete()
+void BranchWatchDialog::OnTableDelete() const
 {
   std::ranges::transform(
       m_index_list_temp, m_index_list_temp.begin(),
@@ -847,7 +847,7 @@ void BranchWatchDialog::OnTableDelete()
   UpdateStatus();
 }
 
-void BranchWatchDialog::OnTableDeleteKeypress()
+void BranchWatchDialog::OnTableDeleteKeypress() const
 {
   m_index_list_temp = m_table_view->selectionModel()->selectedRows();
   OnTableDelete();
@@ -855,17 +855,17 @@ void BranchWatchDialog::OnTableDeleteKeypress()
   m_index_list_temp.shrink_to_fit();
 }
 
-void BranchWatchDialog::OnTableSetBLR()
+void BranchWatchDialog::OnTableSetBLR() const
 {
   SetStubPatches(0x4e800020);
 }
 
-void BranchWatchDialog::OnTableSetNOP()
+void BranchWatchDialog::OnTableSetNOP() const
 {
   SetStubPatches(0x60000000);
 }
 
-void BranchWatchDialog::OnTableCopyAddress()
+void BranchWatchDialog::OnTableCopyAddress() const
 {
   auto iter = m_index_list_temp.begin();
   if (iter == m_index_list_temp.end())
@@ -883,17 +883,17 @@ void BranchWatchDialog::OnTableCopyAddress()
   QApplication::clipboard()->setText(text);
 }
 
-void BranchWatchDialog::OnTableSetBreakpointBreak()
+void BranchWatchDialog::OnTableSetBreakpointBreak() const
 {
   SetBreakpoints(true, false);
 }
 
-void BranchWatchDialog::OnTableSetBreakpointLog()
+void BranchWatchDialog::OnTableSetBreakpointLog() const
 {
   SetBreakpoints(false, true);
 }
 
-void BranchWatchDialog::OnTableSetBreakpointBoth()
+void BranchWatchDialog::OnTableSetBreakpointBoth() const
 {
   SetBreakpoints(true, true);
 }
@@ -955,14 +955,14 @@ void BranchWatchDialog::SaveQSettings() const
                     m_table_view->horizontalHeader()->saveState());
 }
 
-void BranchWatchDialog::Update()
+void BranchWatchDialog::Update() const
 {
   if (m_branch_watch.GetRecordingPhase() == Core::BranchWatch::Phase::Blacklist)
     UpdateStatus();
   m_table_model->UpdateHits();
 }
 
-void BranchWatchDialog::UpdateStatus()
+void BranchWatchDialog::UpdateStatus() const
 {
   switch (m_branch_watch.GetRecordingPhase())
   {

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -644,11 +644,6 @@ void BranchWatchDialog::OnCodePathNotTaken()
 
 void BranchWatchDialog::OnBranchWasOverwritten()
 {
-  if (Core::GetState(m_system) == Core::State::Uninitialized)
-  {
-    ModalMessageBox::warning(this, tr("Error"), tr("Core is uninitialized."));
-    return;
-  }
   {
     const Core::CPUThreadGuard guard{m_system};
     m_table_model->OnBranchWasOverwritten(guard);
@@ -659,11 +654,6 @@ void BranchWatchDialog::OnBranchWasOverwritten()
 
 void BranchWatchDialog::OnBranchNotOverwritten()
 {
-  if (Core::GetState(m_system) == Core::State::Uninitialized)
-  {
-    ModalMessageBox::warning(this, tr("Error"), tr("Core is uninitialized."));
-    return;
-  }
   {
     const Core::CPUThreadGuard guard{m_system};
     m_table_model->OnBranchNotOverwritten(guard);
@@ -689,6 +679,8 @@ void BranchWatchDialog::OnTimeout() const
 
 void BranchWatchDialog::OnEmulationStateChanged(Core::State new_state) const
 {
+  m_btn_was_overwritten->setEnabled(new_state != Core::State::Uninitialized);
+  m_btn_not_overwritten->setEnabled(new_state != Core::State::Uninitialized);
   if (TimerCondition(m_branch_watch, new_state))
     m_timer->start(BRANCH_WATCH_TOOL_TIMER_DELAY_MS);
   else if (m_timer->isActive())

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -321,7 +321,7 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
     group_box->setLayout(layout);
     group_box->setAlignment(Qt::AlignHCenter);
 
-    m_control_toolbar->addWidget(group_box);
+    m_act_branch_type_filters = m_control_toolbar->addWidget(group_box);
   }
   {
     // Origin and Destination Filter Options
@@ -353,7 +353,7 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
     group_box->setLayout(layout);
     group_box->setAlignment(Qt::AlignHCenter);
 
-    m_control_toolbar->addWidget(group_box);
+    m_act_origin_destin_filters = m_control_toolbar->addWidget(group_box);
   }
   {
     // Condition Filter Options
@@ -382,7 +382,7 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
     group_box->setLayout(layout);
     group_box->setAlignment(Qt::AlignHCenter);
 
-    m_control_toolbar->addWidget(group_box);
+    m_act_condition_filters = m_control_toolbar->addWidget(group_box);
   }
   {
     // Misc. Controls
@@ -411,7 +411,7 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
     group_box->setLayout(layout);
     group_box->setAlignment(Qt::AlignHCenter);
 
-    m_control_toolbar->addWidget(group_box);
+    m_act_misc_controls = m_control_toolbar->addWidget(group_box);
   }
 
   // Table Context Menus
@@ -486,6 +486,21 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
     }
   }
 
+  // Toolbar Visibility Menu
+  auto* const toolbar_visibility_menu = new QMenu(this);
+  {
+    const auto routine = [toolbar_visibility_menu](const QString& text, QAction* toolbar_action) {
+      auto* const menu_action =
+          toolbar_visibility_menu->addAction(text, toolbar_action, &QAction::setVisible);
+      menu_action->setChecked(toolbar_action->isVisible());
+      menu_action->setCheckable(true);
+    };
+    routine(tr("&Branch Type"), m_act_branch_type_filters);
+    routine(tr("&Origin and Destination"), m_act_origin_destin_filters);
+    routine(tr("&Condition"), m_act_condition_filters);
+    routine(tr("&Misc. Controls"), m_act_misc_controls);
+  }
+
   // Menu Bar
   auto* const menu_bar = new QMenuBar(nullptr);
   menu_bar->setNativeMenuBar(false);
@@ -512,6 +527,7 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
     connect(act_ignore_apploader, &QAction::toggled, this,
             &BranchWatchDialog::OnToggleIgnoreApploader);
     menu->addMenu(m_mnu_column_visibility)->setText(tr("Column &Visibility"));
+    menu->addMenu(toolbar_visibility_menu)->setText(tr("&Toolbar Visibility"));
     menu->addAction(tr("Wipe &Inspection Data"), this, &BranchWatchDialog::OnWipeInspection);
     menu->addAction(tr("&Help"), this, &BranchWatchDialog::OnHelp);
   }
@@ -985,6 +1001,14 @@ void BranchWatchDialog::LoadQSettings()
   restoreGeometry(settings.value(QStringLiteral("branchwatchdialog/geometry")).toByteArray());
   m_table_view->horizontalHeader()->restoreState(  // Restore column visibility state.
       settings.value(QStringLiteral("branchwatchdialog/tableheader/state")).toByteArray());
+  m_act_branch_type_filters->setVisible(
+      !settings.value(QStringLiteral("branchwatchdialog/toolbar/branch_type_hidden")).toBool());
+  m_act_origin_destin_filters->setVisible(
+      !settings.value(QStringLiteral("branchwatchdialog/toolbar/origin_destin_hidden")).toBool());
+  m_act_condition_filters->setVisible(
+      !settings.value(QStringLiteral("branchwatchdialog/toolbar/condition_hidden")).toBool());
+  m_act_misc_controls->setVisible(
+      !settings.value(QStringLiteral("branchwatchdialog/toolbar/misc_controls_hidden")).toBool());
 }
 
 void BranchWatchDialog::SaveQSettings() const
@@ -993,6 +1017,14 @@ void BranchWatchDialog::SaveQSettings() const
   settings.setValue(QStringLiteral("branchwatchdialog/geometry"), saveGeometry());
   settings.setValue(QStringLiteral("branchwatchdialog/tableheader/state"),
                     m_table_view->horizontalHeader()->saveState());
+  settings.setValue(QStringLiteral("branchwatchdialog/toolbar/branch_type_hidden"),
+                    !m_act_branch_type_filters->isVisible());
+  settings.setValue(QStringLiteral("branchwatchdialog/toolbar/origin_destin_hidden"),
+                    !m_act_origin_destin_filters->isVisible());
+  settings.setValue(QStringLiteral("branchwatchdialog/toolbar/condition_hidden"),
+                    !m_act_condition_filters->isVisible());
+  settings.setValue(QStringLiteral("branchwatchdialog/toolbar/misc_controls_hidden"),
+                    !m_act_misc_controls->isVisible());
 }
 
 void BranchWatchDialog::Update() const

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -153,6 +153,8 @@ private:
   QMenu* m_mnu_column_visibility;
 
   QToolBar* m_control_toolbar;
+  QAction *m_act_branch_type_filters, *m_act_origin_destin_filters, *m_act_condition_filters,
+      *m_act_misc_controls;
   QTableView* m_table_view;
   BranchWatchProxyModel* m_table_proxy;
   BranchWatchTableModel* m_table_model;

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -98,7 +98,8 @@ private:
   void OnTableSetBreakpointLog();
   void OnTableSetBreakpointBoth();
 
-  void SaveSettings();
+  void LoadQSettings();
+  void SaveQSettings() const;
 
 public:
   // TODO: Step doesn't cause EmulationStateChanged to be emitted, so it has to call this manually.

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -98,6 +98,10 @@ private:
   void OnTableSetBreakpointLog();
   void OnTableSetBreakpointBoth();
 
+  void ConnectSlots();
+  void DisconnectSlots();
+  void Show();
+  void Hide();
   void LoadQSettings();
   void SaveQSettings() const;
 

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -66,7 +66,7 @@ protected:
   void showEvent(QShowEvent* event) override;
 
 private:
-  void OnStartPause(bool checked);
+  void OnStartPause(bool checked) const;
   void OnClearBranchWatch();
   void OnSave();
   void OnSaveAs();
@@ -76,27 +76,27 @@ private:
   void OnCodePathNotTaken();
   void OnBranchWasOverwritten();
   void OnBranchNotOverwritten();
-  void OnWipeRecentHits();
-  void OnWipeInspection();
-  void OnTimeout();
-  void OnEmulationStateChanged(Core::State new_state);
+  void OnWipeRecentHits() const;
+  void OnWipeInspection() const;
+  void OnTimeout() const;
+  void OnEmulationStateChanged(Core::State new_state) const;
   void OnThemeChanged();
   void OnHelp();
   void OnToggleAutoSave(bool checked);
-  void OnHideShowControls(bool checked);
-  void OnToggleIgnoreApploader(bool checked);
+  void OnHideShowControls(bool checked) const;
+  void OnToggleIgnoreApploader(bool checked) const;
 
-  void OnTableClicked(const QModelIndex& index);
-  void OnTableContextMenu(const QPoint& pos);
-  void OnTableHeaderContextMenu(const QPoint& pos);
-  void OnTableDelete();
-  void OnTableDeleteKeypress();
-  void OnTableSetBLR();
-  void OnTableSetNOP();
-  void OnTableCopyAddress();
-  void OnTableSetBreakpointBreak();
-  void OnTableSetBreakpointLog();
-  void OnTableSetBreakpointBoth();
+  void OnTableClicked(const QModelIndex& index) const;
+  void OnTableContextMenu(const QPoint& pos) const;
+  void OnTableHeaderContextMenu(const QPoint& pos) const;
+  void OnTableDelete() const;
+  void OnTableDeleteKeypress() const;
+  void OnTableSetBLR() const;
+  void OnTableSetNOP() const;
+  void OnTableCopyAddress() const;
+  void OnTableSetBreakpointBreak() const;
+  void OnTableSetBreakpointLog() const;
+  void OnTableSetBreakpointBoth() const;
 
   void ConnectSlots();
   void DisconnectSlots();
@@ -107,10 +107,10 @@ private:
 
 public:
   // TODO: Step doesn't cause EmulationStateChanged to be emitted, so it has to call this manually.
-  void Update();
+  void Update() const;
 
 private:
-  void UpdateStatus();
+  void UpdateStatus() const;
   void UpdateIcons();
   void Save(const Core::CPUThreadGuard& guard, const std::string& filepath);
   void Load(const Core::CPUThreadGuard& guard, const std::string& filepath);
@@ -151,6 +151,6 @@ private:
 
   QIcon m_icn_full, m_icn_partial;
 
-  QModelIndexList m_index_list_temp;
+  mutable QModelIndexList m_index_list_temp;
   std::optional<std::string> m_autosave_filepath;
 };

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -93,6 +93,9 @@ private:
   void OnTableDeleteKeypress() const;
   void OnTableSetBLR() const;
   void OnTableSetNOP() const;
+  void OnTableInvertCondition() const;
+  void OnTableInvertDecrementCheck() const;
+  void OnTableMakeUnconditional() const;
   void OnTableCopyAddress() const;
   void OnTableSetBreakpointBreak() const;
   void OnTableSetBreakpointLog() const;
@@ -116,10 +119,13 @@ private:
   void Load(const Core::CPUThreadGuard& guard, const std::string& filepath);
   void AutoSave(const Core::CPUThreadGuard& guard);
   void SetStubPatches(u32 value) const;
+  void SetEditPatches(u32 (*transform)(u32)) const;
   void SetBreakpoints(bool break_on_hit, bool log_on_hit) const;
 
   void SetBreakpointMenuActionsIcons() const;
   QMenu* GetTableContextMenu(const QModelIndex& index) const;
+  QMenu* GetTableContextMenu_Instruction(bool core_initialized) const;
+  QMenu* GetTableContextMenu_Condition(bool core_initialized) const;
   QMenu* GetTableContextMenu_Origin(bool core_initialized) const;
   QMenu* GetTableContextMenu_Destin(bool core_initialized) const;
   QMenu* GetTableContextMenu_Symbol(bool core_initialized) const;
@@ -131,6 +137,9 @@ private:
   QPushButton *m_btn_start_pause, *m_btn_clear_watch, *m_btn_path_was_taken, *m_btn_path_not_taken,
       *m_btn_was_overwritten, *m_btn_not_overwritten, *m_btn_wipe_recent_hits;
   QAction* m_act_autosave;
+  QAction* m_act_invert_condition;
+  QAction* m_act_invert_decrement_check;
+  QAction* m_act_make_unconditional;
   QAction* m_act_insert_nop;
   QAction* m_act_insert_blr;
   QAction* m_act_copy_address;
@@ -138,7 +147,8 @@ private:
   QAction* m_act_break_on_hit;
   QAction* m_act_log_on_hit;
   QAction* m_act_both_on_hit;
-  QMenu *m_mnu_table_context_origin, *m_mnu_table_context_destin_or_symbol,
+  QMenu *m_mnu_table_context_instruction, *m_mnu_table_context_condition,
+      *m_mnu_table_context_origin, *m_mnu_table_context_destin_or_symbol,
       *m_mnu_table_context_other;
   QMenu* m_mnu_column_visibility;
 

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -118,7 +118,11 @@ private:
   void SetStubPatches(u32 value) const;
   void SetBreakpoints(bool break_on_hit, bool log_on_hit) const;
 
-  [[nodiscard]] QMenu* GetTableContextMenu(const QModelIndex& index);
+  void SetBreakpointMenuActionsIcons() const;
+  QMenu* GetTableContextMenu(const QModelIndex& index) const;
+  QMenu* GetTableContextMenu_Origin(bool core_initialized) const;
+  QMenu* GetTableContextMenu_Destin(bool core_initialized) const;
+  QMenu* GetTableContextMenu_Symbol(bool core_initialized) const;
 
   Core::System& m_system;
   Core::BranchWatch& m_branch_watch;
@@ -134,7 +138,8 @@ private:
   QAction* m_act_break_on_hit;
   QAction* m_act_log_on_hit;
   QAction* m_act_both_on_hit;
-  QMenu* m_mnu_table_context = nullptr;
+  QMenu *m_mnu_table_context_origin, *m_mnu_table_context_destin_or_symbol,
+      *m_mnu_table_context_other;
   QMenu* m_mnu_column_visibility;
 
   QToolBar* m_control_toolbar;

--- a/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.cpp
@@ -195,6 +195,12 @@ void BranchWatchTableModel::SetInspected(const QModelIndex& index)
   const int row = index.row();
   switch (index.column())
   {
+  case Column::Instruction:
+    SetInspected(index, Core::BranchWatchSelectionInspection::InvertBranchOption);
+    return;
+  case Column::Condition:
+    SetInspected(index, Core::BranchWatchSelectionInspection::MakeUnconditional);
+    return;
   case Column::Origin:
     SetOriginInspected(m_branch_watch.GetSelection()[row].collection_ptr->first.origin_addr);
     return;
@@ -210,35 +216,35 @@ void BranchWatchTableModel::SetInspected(const QModelIndex& index)
   }
 }
 
+void BranchWatchTableModel::SetInspected(const QModelIndex& index,
+                                         Core::BranchWatchSelectionInspection inspection)
+{
+  static const QList<int> roles = {Qt::FontRole, Qt::ForegroundRole};
+  m_branch_watch.SetSelectedInspected(index.row(), inspection);
+  emit dataChanged(index, index, roles);
+}
+
 void BranchWatchTableModel::SetOriginInspected(u32 origin_addr)
 {
-  using Inspection = Core::BranchWatchSelectionInspection;
-  static const QList<int> roles = {Qt::FontRole, Qt::ForegroundRole};
-
   const Core::BranchWatch::Selection& selection = m_branch_watch.GetSelection();
   for (std::size_t i = 0; i < selection.size(); ++i)
   {
     if (selection[i].collection_ptr->first.origin_addr != origin_addr)
       continue;
-    m_branch_watch.SetSelectedInspected(i, Inspection::SetOriginNOP);
-    const QModelIndex index = createIndex(static_cast<int>(i), Column::Origin);
-    emit dataChanged(index, index, roles);
+    SetInspected(createIndex(static_cast<int>(i), Column::Origin),
+                 Core::BranchWatchSelectionInspection::SetOriginNOP);
   }
 }
 
 void BranchWatchTableModel::SetDestinInspected(u32 destin_addr, bool nested)
 {
-  using Inspection = Core::BranchWatchSelectionInspection;
-  static const QList<int> roles = {Qt::FontRole, Qt::ForegroundRole};
-
   const Core::BranchWatch::Selection& selection = m_branch_watch.GetSelection();
   for (std::size_t i = 0; i < selection.size(); ++i)
   {
     if (selection[i].collection_ptr->first.destin_addr != destin_addr)
       continue;
-    m_branch_watch.SetSelectedInspected(i, Inspection::SetDestinBLR);
-    const QModelIndex index = createIndex(static_cast<int>(i), Column::Destination);
-    emit dataChanged(index, index, roles);
+    SetInspected(createIndex(static_cast<int>(i), Column::Destination),
+                 Core::BranchWatchSelectionInspection::SetDestinBLR);
   }
 
   if (nested)
@@ -248,29 +254,31 @@ void BranchWatchTableModel::SetDestinInspected(u32 destin_addr, bool nested)
 
 void BranchWatchTableModel::SetSymbolInspected(u32 symbol_addr, bool nested)
 {
-  using Inspection = Core::BranchWatchSelectionInspection;
-  static const QList<int> roles = {Qt::FontRole, Qt::ForegroundRole};
-
   for (qsizetype i = 0; i < m_symbol_list.size(); ++i)
   {
     const SymbolListValueType& value = m_symbol_list[i];
     if (value.origin_addr.isValid() && value.origin_addr.value<u32>() == symbol_addr)
     {
-      m_branch_watch.SetSelectedInspected(i, Inspection::SetOriginSymbolBLR);
-      const QModelIndex index = createIndex(i, Column::OriginSymbol);
-      emit dataChanged(index, index, roles);
+      SetInspected(createIndex(static_cast<int>(i), Column::OriginSymbol),
+                   Core::BranchWatchSelectionInspection::SetOriginSymbolBLR);
     }
     if (value.destin_addr.isValid() && value.destin_addr.value<u32>() == symbol_addr)
     {
-      m_branch_watch.SetSelectedInspected(i, Inspection::SetDestinSymbolBLR);
-      const QModelIndex index = createIndex(i, Column::DestinSymbol);
-      emit dataChanged(index, index, roles);
+      SetInspected(createIndex(static_cast<int>(i), Column::DestinSymbol),
+                   Core::BranchWatchSelectionInspection::SetDestinSymbolBLR);
     }
   }
 
   if (nested)
     return;
   SetDestinInspected(symbol_addr, true);
+}
+
+const Core::BranchWatchSelectionValueType&
+BranchWatchTableModel::GetBranchWatchSelection(const QModelIndex& index) const
+{
+  ASSERT(index.isValid());
+  return m_branch_watch.GetSelection()[index.row()];
 }
 
 void BranchWatchTableModel::PrefetchSymbols()
@@ -306,25 +314,14 @@ static QString GetInstructionMnemonic(u32 hex)
   return QString::fromLatin1(disas.data(), split);
 }
 
-static bool BranchIsUnconditional(UGeckoInstruction inst)
-{
-  if (inst.OPCD == 18)  // bx
-    return true;
-  // If BranchWatch is doing its job, the input will be only bcx, bclrx, and bcctrx instructions.
-  DEBUG_ASSERT(inst.OPCD == 16 || (inst.OPCD == 19 && (inst.SUBOP10 == 16 || inst.SUBOP10 == 528)));
-  if ((inst.BO & 0b10100) == 0b10100)  // 1z1zz - Branch always
-    return true;
-  return false;
-}
-
 static QString GetConditionString(const Core::BranchWatch::Selection::value_type& value,
                                   const Core::BranchWatch::Collection::value_type* kv)
 {
   if (value.condition == false)
     return BranchWatchTableModel::tr("false");
-  if (BranchIsUnconditional(kv->first.original_inst))
-    return QStringLiteral("");
-  return BranchWatchTableModel::tr("true");
+  if (BranchIsConditional(kv->first.original_inst))
+    return BranchWatchTableModel::tr("true");
+  return QStringLiteral("");
 }
 
 QVariant BranchWatchTableModel::DisplayRoleData(const QModelIndex& index) const
@@ -361,21 +358,25 @@ QVariant BranchWatchTableModel::DisplayRoleData(const QModelIndex& index) const
 QVariant BranchWatchTableModel::FontRoleData(const QModelIndex& index) const
 {
   m_font.setBold([&]() -> bool {
+    using Inspection = Core::BranchWatchSelectionInspection;
+    const auto get_bit_test = [this, &index](Inspection inspection_mask) -> bool {
+      const Inspection inspection = m_branch_watch.GetSelection()[index.row()].inspection;
+      return (inspection & inspection_mask) != Inspection{};
+    };
     switch (index.column())
     {
-      using Inspection = Core::BranchWatchSelectionInspection;
+    case Column::Instruction:
+      return get_bit_test(Inspection::InvertBranchOption);
+    case Column::Condition:
+      return get_bit_test(Inspection::MakeUnconditional);
     case Column::Origin:
-      return (m_branch_watch.GetSelection()[index.row()].inspection & Inspection::SetOriginNOP) !=
-             Inspection{};
+      return get_bit_test(Inspection::SetOriginNOP);
     case Column::Destination:
-      return (m_branch_watch.GetSelection()[index.row()].inspection & Inspection::SetDestinBLR) !=
-             Inspection{};
+      return get_bit_test(Inspection::SetDestinBLR);
     case Column::OriginSymbol:
-      return (m_branch_watch.GetSelection()[index.row()].inspection &
-              Inspection::SetOriginSymbolBLR) != Inspection{};
+      return get_bit_test(Inspection::SetOriginSymbolBLR);
     case Column::DestinSymbol:
-      return (m_branch_watch.GetSelection()[index.row()].inspection &
-              Inspection::SetDestinSymbolBLR) != Inspection{};
+      return get_bit_test(Inspection::SetDestinSymbolBLR);
     }
     // Importantly, this code path avoids subscripting the selection to get an inspection value.
     return false;
@@ -406,31 +407,25 @@ QVariant BranchWatchTableModel::TextAlignmentRoleData(const QModelIndex& index) 
 
 QVariant BranchWatchTableModel::ForegroundRoleData(const QModelIndex& index) const
 {
+  using Inspection = Core::BranchWatchSelectionInspection;
+  const auto get_brush_v = [this, &index](Inspection inspection_mask) -> QVariant {
+    const Inspection inspection = m_branch_watch.GetSelection()[index.row()].inspection;
+    return (inspection & inspection_mask) != Inspection{} ? QBrush(Qt::red) : QVariant();
+  };
   switch (index.column())
   {
-    using Inspection = Core::BranchWatchSelectionInspection;
+  case Column::Instruction:
+    return get_brush_v(Inspection::InvertBranchOption);
+  case Column::Condition:
+    return get_brush_v(Inspection::MakeUnconditional);
   case Column::Origin:
-  {
-    const Inspection inspection = m_branch_watch.GetSelection()[index.row()].inspection;
-    return (inspection & Inspection::SetOriginNOP) != Inspection{} ? QBrush(Qt::red) : QVariant();
-  }
+    return get_brush_v(Inspection::SetOriginNOP);
   case Column::Destination:
-  {
-    const Inspection inspection = m_branch_watch.GetSelection()[index.row()].inspection;
-    return (inspection & Inspection::SetDestinBLR) != Inspection{} ? QBrush(Qt::red) : QVariant();
-  }
+    return get_brush_v(Inspection::SetDestinBLR);
   case Column::OriginSymbol:
-  {
-    const Inspection inspection = m_branch_watch.GetSelection()[index.row()].inspection;
-    return (inspection & Inspection::SetOriginSymbolBLR) != Inspection{} ? QBrush(Qt::red) :
-                                                                           QVariant();
-  }
+    return get_brush_v(Inspection::SetOriginSymbolBLR);
   case Column::DestinSymbol:
-  {
-    const Inspection inspection = m_branch_watch.GetSelection()[index.row()].inspection;
-    return (inspection & Inspection::SetDestinSymbolBLR) != Inspection{} ? QBrush(Qt::red) :
-                                                                           QVariant();
-  }
+    return get_brush_v(Inspection::SetDestinSymbolBLR);
   }
   // Importantly, this code path avoids subscripting the selection to get an inspection value.
   return QVariant();
@@ -465,9 +460,9 @@ static int GetConditionInteger(const Core::BranchWatch::Selection::value_type& v
 {
   if (value.condition == false)
     return 0;
-  if (BranchIsUnconditional(kv->first.original_inst))
-    return 2;
-  return 1;
+  if (BranchIsConditional(kv->first.original_inst))
+    return 1;
+  return 2;
 }
 
 QVariant BranchWatchTableModel::SortRoleData(const QModelIndex& index) const

--- a/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.cpp
@@ -145,6 +145,16 @@ void BranchWatchTableModel::OnWipeInspection()
                    roles);
 }
 
+void BranchWatchTableModel::OnDebugFontChanged(const QFont& font)
+{
+  setFont(font);
+}
+
+void BranchWatchTableModel::OnPPCSymbolsChanged()
+{
+  UpdateSymbols();
+}
+
 void BranchWatchTableModel::Save(const Core::CPUThreadGuard& guard, std::FILE* file) const
 {
   m_branch_watch.Save(guard, file);

--- a/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
@@ -15,6 +15,8 @@
 namespace Core
 {
 class BranchWatch;
+enum class BranchWatchSelectionInspection : u8;
+struct BranchWatchSelectionValueType;
 class CPUThreadGuard;
 class System;
 }  // namespace Core
@@ -106,9 +108,12 @@ public:
   void UpdateHits();
   void SetInspected(const QModelIndex& index);
 
+  const Core::BranchWatchSelectionValueType&
+  GetBranchWatchSelection(const QModelIndex& index) const;
   const SymbolList& GetSymbolList() const { return m_symbol_list; }
 
 private:
+  void SetInspected(const QModelIndex& index, Core::BranchWatchSelectionInspection inspection);
   void SetOriginInspected(u32 origin_addr);
   void SetDestinInspected(u32 destin_addr, bool nested);
   void SetSymbolInspected(u32 symbol_addr, bool nested);

--- a/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchTableModel.h
@@ -97,6 +97,8 @@ public:
   void OnBranchNotOverwritten(const Core::CPUThreadGuard& guard);
   void OnWipeRecentHits();
   void OnWipeInspection();
+  void OnDebugFontChanged(const QFont& font);
+  void OnPPCSymbolsChanged();
 
   void Save(const Core::CPUThreadGuard& guard, std::FILE* file) const;
   void Load(const Core::CPUThreadGuard& guard, std::FILE* file);

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -180,7 +180,7 @@ void CodeWidget::ConnectWidgets()
   });
   connect(m_search_callstack, &QLineEdit::textChanged, this, &CodeWidget::UpdateCallstack);
 
-  connect(m_branch_watch, &QPushButton::pressed, this, &CodeWidget::OnBranchWatchDialog);
+  connect(m_branch_watch, &QPushButton::clicked, this, &CodeWidget::OnBranchWatchDialog);
 
   connect(m_symbols_list, &QListWidget::itemPressed, this, &CodeWidget::OnSelectSymbol);
   connect(m_callstack_list, &QListWidget::itemPressed, this, &CodeWidget::OnSelectCallstack);


### PR DESCRIPTION
![fixes-4](https://github.com/user-attachments/assets/84c5e73e-908f-458a-b6dc-49b1c83e2c9a)
- While in the reduction phase, Branch Watch snapshot files will now only contain hits found in the selection. Previously, all hits from the collection were being written despite some no longer being relevant.
- When I created the Branch Watch Dialog, I employed a novel coding style that abused lambdas and the values of assignment statements. I have come to realize this design choice was sub-optimal, plus I have found new design patterns while working on my JIT Widget Refresh project. Across six commits, I have refactored the Branch Watch Dialog to meet the quality I am currently capable of. The sixth refactoring commit contains some notable changes to the construction of context menus in the Branch Watch Tool. Creating breakpoints while the core is not initialized is no longer forbidden as other parts of DolphinQt no longer discourage it (see: https://github.com/dolphin-emu/dolphin/pull/12862).
- A last-minute addition in the original Branch Watch Tool PR, the "Ignore Apploader Branch Hits" feature causes concurrency issues with the recording state if the Branch Watch Dialog attempts to start or pause the Branch Watch while the apploader is being run. This has been addressed by requiring a CPUThreadGuard to change the Branch Watch's recording state. Disappointingly, not requiring this before was an explicit design choice that had some clever code on the Qt side to make things behave nicely, but oh well.
- I mistakenly have been using `QPushButton::pressed` in my Qt code when I really intended for the behavior of `QPushButton::clicked`. This has been addressed.
- The "Branch Was Overwritten" and "Branch Not Overwritten" buttons are now disabled when emulation is uninitialized rather than presenting a pop-up dialog implying they are unusable.
- New inspection tools have been added to the Branch Watch Tool. It is now possible to inspect conditional branches by inverting the condition (gt, lt, eq, ne, etc.), by inverting the decrement check (zero, not zero), and by turning them unconditional. Previous versions of the Branch Watch Tool are forward-compatible with a Branch Watch snapshot file containing this new inspection metadata (tested on x86_64).
- I added a new feature to hide unneeded features of the controls toolbar, found under Tool > Toolbar Visibility.
