### PR TITLE
AutoUpdate: Remove the old updater app on macOS if it exists

### DIFF
--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -84,6 +84,12 @@ void CleanupFromPreviousUpdate()
 {
   // Remove the relocated updater file.
   File::DeleteDirRecursively(UpdaterPath(true));
+
+  // Remove the old (non-embedded) updater app bundle.
+  // While the update process will delete the files within the old bundle after updating to a
+  // version with an embedded updater, it won't delete the folder structure of the bundle, so
+  // we should clean those leftovers up.
+  File::DeleteDirRecursively(File::GetExeDirectory() + DIR_SEP + "Dolphin Updater.app");
 }
 #endif
 


### PR DESCRIPTION
While the update process will delete the files within the old bundle after updating to a version with an embedded updater, it won't delete the folder structure of the bundle, so we should clean those leftovers up.

Example of a Dolphin installation after updating from 2407-150 to 2407-165 (#12968):

![image](https://github.com/user-attachments/assets/8ae54351-f835-444f-a281-74760e43214a)
