### PR TITLE
DolphinQT: Listen For `clicked` Signal Rather Than `pressed`

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -135,8 +135,8 @@ void AchievementSettingsWidget::ConnectWidgets()
 {
   connect(m_common_integration_enabled_input, &QCheckBox::toggled, this,
           &AchievementSettingsWidget::ToggleRAIntegration);
-  connect(m_common_login_button, &QPushButton::pressed, this, &AchievementSettingsWidget::Login);
-  connect(m_common_logout_button, &QPushButton::pressed, this, &AchievementSettingsWidget::Logout);
+  connect(m_common_login_button, &QPushButton::clicked, this, &AchievementSettingsWidget::Login);
+  connect(m_common_logout_button, &QPushButton::clicked, this, &AchievementSettingsWidget::Logout);
   connect(m_common_hardcore_enabled_input, &QCheckBox::toggled, this,
           &AchievementSettingsWidget::ToggleHardcore);
   connect(m_common_unofficial_enabled_input, &QCheckBox::toggled, this,

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -227,7 +227,7 @@ void NetworkWidget::ConnectWidgets()
   connect(m_dump_bba_checkbox, &QCheckBox::stateChanged, [](int state) {
     Config::SetBaseOrCurrent(Config::MAIN_NETWORK_DUMP_BBA, state == Qt::Checked);
   });
-  connect(m_open_dump_folder, &QPushButton::pressed, [] {
+  connect(m_open_dump_folder, &QPushButton::clicked, [] {
     const std::string location = File::GetUserPath(D_DUMPSSL_IDX);
     const QUrl url = QUrl::fromLocalFile(QString::fromStdString(location));
     QDesktopServices::openUrl(url);


### PR DESCRIPTION
The `QPushButton::pressed` signal was likely used by mistake, e.g. https://github.com/dolphin-emu/dolphin/pull/8263. Fixes for the mistaken uses of this signal in the BranchWatchDialog were wrapped into https://github.com/dolphin-emu/dolphin/pull/12977 to avoid merge conflicts down the line.

@LillyJadeKatrin This touches your RetroAchievements work. I assume we agree the intended signal here was `QPushButton::clicked`?