### PR TITLE
CMakeLists: Fix LLVM Usage In UICommon

### DIFF
--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -56,6 +56,7 @@ if(ENABLE_LLVM)
   find_package(LLVM CONFIG)
   if(LLVM_FOUND)
     message(STATUS "LLVM found, enabling LLVM support in disassembler")
+    target_compile_definitions(uicommon PRIVATE HAVE_LLVM)
     # Minimal documentation about LLVM's CMake functions is available here:
     # https://releases.llvm.org/16.0.0/docs/CMake.html#embedding-llvm-in-your-project
     # https://groups.google.com/g/llvm-dev/c/YeEVe7HTasQ?pli=1
@@ -69,6 +70,7 @@ if(ENABLE_LLVM)
     llvm_config(uicommon USE_SHARED
       mcdisassembler target ${LLVM_EXPAND_COMPONENTS}
     )
+    target_include_directories(uicommon PRIVATE ${LLVM_INCLUDE_DIRS})
   endif()
 endif()
 


### PR DESCRIPTION
This compile definition was removed in https://github.com/dolphin-emu/dolphin/pull/12756 because it was complicated by changes in https://github.com/dolphin-emu/dolphin/pull/12716. Thus, the LLVM disassembler would never actually be used in UICommon's Disassembler class.