### PR TITLE
Constness of 'result' prevents automatic move [performance-no-automatic-move]

### DIFF
--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -177,10 +177,8 @@ void VerifyWidget::Verify()
                    }
                    verifier.Finish();
 
-                   const DiscIO::VolumeVerifier::Result result = verifier.GetResult();
                    progress.Reset();
-
-                   return result;
+                   return verifier.GetResult();
                  });
   SetQWidgetWindowDecorations(progress.GetRaw());
   progress.GetRaw()->exec();


### PR DESCRIPTION
https://releases.llvm.org/10.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-no-automatic-move.html