### PR TITLE
MenuBar: Update checkmarked Select State Slot when hotkeys are pressed

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -408,6 +408,10 @@ void MenuBar::AddStateSlotMenu(QMenu* emu_menu)
       action->setChecked(true);
 
     connect(action, &QAction::triggered, this, [=, this]() { emit SetStateSlot(i); });
+    connect(this, &MenuBar::SetStateSlot, [action, i](const int slot) {
+      if (slot == i)
+        action->setChecked(true);
+    });
   }
 }
 


### PR DESCRIPTION
Update the checkmarked slot in the Select State Slot menu when the `Increase Selected State Slot` or `Decrease Selected State Slot` hotkeys are pressed.

The actual selected save slot was being changed correctly before this commit; this just fixes the menu checkmark.