### PR TITLE
GameINI: Fix tattoo texture saving in Rabbids Go Home

### DIFF
--- a/Data/Sys/GameSettings/RGW.ini
+++ b/Data/Sys/GameSettings/RGW.ini
@@ -22,3 +22,5 @@ SafeTextureCacheColorSamples = 0
 # Fixes visible lines in air vents/fans.
 VertexRounding = True
 ImmediateXFBEnable = False
+# Fixes rabbid tattoo textures saving as black.
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/WR2.ini
+++ b/Data/Sys/GameSettings/WR2.ini
@@ -22,3 +22,5 @@ SafeTextureCacheColorSamples = 0
 # Fixes visible lines in air vents/fans.
 VertexRounding = True
 ImmediateXFBEnable = False
+# Fixes rabbid tattoo textures saving as black.
+EFBToTextureEnable = False


### PR DESCRIPTION
Saving rabbid with EFB Copies to Texture Only:
Rabbid's texture is saved as fully black.
![image](https://github.com/user-attachments/assets/1ed7477d-59ef-4776-a3fc-67a1e328299b)

Saving rabbid without EFB Copies to Texture Only:
Intended behavior.
![image](https://github.com/user-attachments/assets/e29d44d4-0650-4d22-9598-eca0d0f38015)
