### PR TITLE
DolphinTool: print title IDs in hex

### DIFF
--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -367,7 +367,7 @@ void ConvertDialog::Convert()
   if (m_files.size() > 1)
   {
     dst_dir = DolphinFileDialog::getExistingDirectory(
-        this, tr("Save Converted Image"),
+        this, tr("Save Converted Images"),
         QFileInfo(QString::fromStdString(m_files[0]->GetFilePath())).dir().absolutePath());
 
     if (dst_dir.isEmpty())

--- a/Source/Core/DolphinTool/ConvertCommand.cpp
+++ b/Source/Core/DolphinTool/ConvertCommand.cpp
@@ -260,7 +260,7 @@ int ConvertCommand(const std::vector<std::string>& args)
   {
     if (!compression_o.has_value())
     {
-      fmt::print(std::cerr, "Error: Compression format must be set for WIA or RVZ\n");
+      fmt::print(std::cerr, "Error: Compression method must be set for WIA or RVZ\n");
       return EXIT_FAILURE;
     }
 

--- a/Source/Core/DolphinTool/HeaderCommand.cpp
+++ b/Source/Core/DolphinTool/HeaderCommand.cpp
@@ -92,7 +92,7 @@ int HeaderCommand(const std::vector<std::string>& args)
     {
       json["internal_name"] = picojson::value(volume->GetInternalName());
 
-      if (const std::optional<u64> revision = volume->GetRevision())
+      if (const std::optional<u16> revision = volume->GetRevision())
         json["revision"] = picojson::value((double)revision.value());
 
       json["game_id"] = picojson::value(volume->GetGameID());
@@ -153,13 +153,13 @@ int HeaderCommand(const std::vector<std::string>& args)
     {
       fmt::print(std::cout, "Internal Name: {}\n", volume->GetInternalName());
 
-      if (const std::optional<u64> revision = volume->GetRevision())
+      if (const std::optional<u16> revision = volume->GetRevision())
         fmt::print(std::cout, "Revision: {}\n", revision.value());
 
       fmt::print(std::cout, "Game ID: {}\n", volume->GetGameID());
 
       if (const std::optional<u64> title_id = volume->GetTitleID())
-        fmt::print(std::cout, "Title ID: {}\n", title_id.value());
+        fmt::print(std::cout, "Title ID: {:016x}\n", title_id.value());
 
       fmt::print(std::cout, "Region: {}\n", DiscIO::GetName(volume->GetRegion(), false));
 


### PR DESCRIPTION
Never seen title IDs in decimal.

Also some small wording changes for dump conversions.