### PR TITLE
UnitTests: Remove MSBuild input/output tracking

### DIFF
--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -109,7 +109,7 @@
   <ItemGroup>
     <DataSysFiles Include="$(DolphinRootDir)Data\**\Sys\**\*.*" />
   </ItemGroup>
-  <Target Name="AfterBuild" Inputs="@(DataSysFiles)" Outputs="@(DataSysFiles -> '$(TargetDir)%(RecursiveDir)%(Filename)%(Extension)')">
+  <Target Name="AfterBuild">
     <Message Text="Copying Data directory..." Importance="High" />
     <RemoveDir Directories="$(TargetDir)Sys" />
     <Copy SourceFiles="@(DataSysFiles)" DestinationFolder="$(TargetDir)%(RecursiveDir)" SkipUnchangedFiles="True" />


### PR DESCRIPTION
Input/output tracking is intended to speed up incremental builds by skipping a target when it doesn't need to be built. However, this seems to be unreliable for UnitTests' AfterBuild target. Let's remove it.

It's still the case that UnitTests' AfterBuild target will be skipped if UnitTests doesn't need to be rebuilt. (Note that UnitTests always needs to be rebuilt if MakeScmRev changed.)

I haven't seen these problems with DolphinQt's rather similar input/output tracking. This may be because DolphinQt's one also has the exe file as an input/output.