### PR TITLE
Fix postprocessing shader not changing when setting stereo mode

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -17,6 +17,7 @@ class QPushButton;
 class QSlider;
 class ToolTipComboBox;
 class ToolTipPushButton;
+enum class StereoMode : int;
 
 class EnhancementsWidget final : public QWidget
 {
@@ -33,7 +34,7 @@ private:
   void AddDescriptions();
   void ConfigureColorCorrection();
   void ConfigurePostProcessingShader();
-  void LoadPPShaders();
+  void LoadPPShaders(StereoMode stereo_mode);
 
   // Enhancements
   ConfigChoice* m_ir_combo;


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/13593. Before, it would attempt to use the old shader, which did not exist for the new stereo mode. Changing the postprocessing shader afterwards would work properly, although passive 3D only has one option, so it was just broken without restarting Dolphin.

This also fixes the UI not updating when using one of the stereo toggle hotkeys.