### PR TITLE
Add missing cmake includes and remove unused cmake includes

### DIFF
--- a/Externals/bzip2/CMakeLists.txt
+++ b/Externals/bzip2/CMakeLists.txt
@@ -3,7 +3,6 @@ project(bzip2 C)
 include(CheckTypeSize)
 include(CheckFunctionExists)
 include(CheckIncludeFile)
-include(CheckCSourceCompiles)
 
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 check_include_file(stdint.h    HAVE_STDINT_H)

--- a/Externals/liblzma/CMakeLists.txt
+++ b/Externals/liblzma/CMakeLists.txt
@@ -3,7 +3,6 @@ project(lzma C)
 include(CheckTypeSize)
 include(CheckFunctionExists)
 include(CheckIncludeFile)
-include(CheckCSourceCompiles)
 
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 check_include_file(stdint.h    HAVE_STDINT_H)

--- a/Externals/minizip-ng/CMakeLists.txt
+++ b/Externals/minizip-ng/CMakeLists.txt
@@ -1,5 +1,8 @@
 project(minizip C)
 
+include(CheckFunctionExists)
+include(CheckIncludeFile)
+
 add_library(minizip STATIC
   minizip-ng/mz.h
   # minizip-ng/compat/crypt.h

--- a/Externals/zstd/CMakeLists.txt
+++ b/Externals/zstd/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 include(CheckTypeSize)
 include(CheckFunctionExists)
 include(CheckIncludeFile)
-include(CheckCSourceCompiles)
 
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 check_include_file(stdint.h    HAVE_STDINT_H)


### PR DESCRIPTION
The context of noticing the missing includes for minizip-ng was that I was packaging dolphin-2407 for gentoo where using system packages is preferred if viable. This unusual setup meant that includes that were used indirectly were missing.