### PR TITLE
TypeUtils: Remove Common::Fill

### DIFF
--- a/Source/Core/Common/TypeUtils.h
+++ b/Source/Core/Common/TypeUtils.h
@@ -82,17 +82,4 @@ static_assert(!IsNOf<int, 1, int, int>::value);
 static_assert(IsNOf<int, 2, int, int>::value);
 static_assert(IsNOf<int, 2, int, short>::value);  // Type conversions ARE allowed
 static_assert(!IsNOf<int, 2, int, char*>::value);
-
-// TODO: This can be replaced with std::array's fill() once C++20 is fully supported.
-// Prior to C++20, std::array's fill() function is, unfortunately, not constexpr.
-// Ditto for <algorithm>'s std::fill. Although Dolphin targets C++20, Android doesn't
-// seem to properly support constexpr fill(), so we need this for now.
-template <typename T1, size_t N, typename T2>
-constexpr void Fill(std::array<T1, N>& array, const T2& value)
-{
-  for (auto& entry : array)
-  {
-    entry = value;
-  }
-}
 }  // namespace Common

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
@@ -6,7 +6,6 @@
 #include <array>
 
 #include "Common/Assert.h"
-#include "Common/TypeUtils.h"
 #include "Core/PowerPC/Gekko.h"
 
 namespace
@@ -341,7 +340,7 @@ constexpr std::array<InterpreterOpTemplate, 10> s_table63_2{{
 constexpr std::array<Interpreter::Instruction, 64> s_interpreter_op_table = []() consteval
 {
   std::array<Interpreter::Instruction, 64> table{};
-  Common::Fill(table, Interpreter::unknown_instruction);
+  table.fill(Interpreter::unknown_instruction);
   for (auto& tpl : s_primary_table)
   {
     ASSERT(table[tpl.opcode] == Interpreter::unknown_instruction);
@@ -353,7 +352,7 @@ constexpr std::array<Interpreter::Instruction, 64> s_interpreter_op_table = []()
 constexpr std::array<Interpreter::Instruction, 1024> s_interpreter_op_table4 = []() consteval
 {
   std::array<Interpreter::Instruction, 1024> table{};
-  Common::Fill(table, Interpreter::unknown_instruction);
+  table.fill(Interpreter::unknown_instruction);
 
   for (u32 i = 0; i < 32; i++)
   {
@@ -390,7 +389,7 @@ constexpr std::array<Interpreter::Instruction, 1024> s_interpreter_op_table4 = [
 constexpr std::array<Interpreter::Instruction, 1024> s_interpreter_op_table19 = []() consteval
 {
   std::array<Interpreter::Instruction, 1024> table{};
-  Common::Fill(table, Interpreter::unknown_instruction);
+  table.fill(Interpreter::unknown_instruction);
   for (auto& tpl : s_table19)
   {
     ASSERT(table[tpl.opcode] == Interpreter::unknown_instruction);
@@ -402,7 +401,7 @@ constexpr std::array<Interpreter::Instruction, 1024> s_interpreter_op_table19 = 
 constexpr std::array<Interpreter::Instruction, 1024> s_interpreter_op_table31 = []() consteval
 {
   std::array<Interpreter::Instruction, 1024> table{};
-  Common::Fill(table, Interpreter::unknown_instruction);
+  table.fill(Interpreter::unknown_instruction);
   for (auto& tpl : s_table31)
   {
     ASSERT(table[tpl.opcode] == Interpreter::unknown_instruction);
@@ -414,7 +413,7 @@ constexpr std::array<Interpreter::Instruction, 1024> s_interpreter_op_table31 = 
 constexpr std::array<Interpreter::Instruction, 32> s_interpreter_op_table59 = []() consteval
 {
   std::array<Interpreter::Instruction, 32> table{};
-  Common::Fill(table, Interpreter::unknown_instruction);
+  table.fill(Interpreter::unknown_instruction);
   for (auto& tpl : s_table59)
   {
     ASSERT(table[tpl.opcode] == Interpreter::unknown_instruction);
@@ -426,7 +425,7 @@ constexpr std::array<Interpreter::Instruction, 32> s_interpreter_op_table59 = []
 constexpr std::array<Interpreter::Instruction, 1024> s_interpreter_op_table63 = []() consteval
 {
   std::array<Interpreter::Instruction, 1024> table{};
-  Common::Fill(table, Interpreter::unknown_instruction);
+  table.fill(Interpreter::unknown_instruction);
   for (auto& tpl : s_table63)
   {
     ASSERT(table[tpl.opcode] == Interpreter::unknown_instruction);

--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -6,7 +6,6 @@
 #include <array>
 
 #include "Common/Assert.h"
-#include "Common/TypeUtils.h"
 #include "Core/PowerPC/Gekko.h"
 
 namespace
@@ -339,7 +338,7 @@ constexpr std::array<Jit64OpTemplate, 10> s_table63_2{{
 constexpr std::array<Jit64::Instruction, 64> s_dyna_op_table = []() consteval
 {
   std::array<Jit64::Instruction, 64> table{};
-  Common::Fill(table, &Jit64::FallBackToInterpreter);
+  table.fill(&Jit64::FallBackToInterpreter);
 
   for (auto& tpl : s_primary_table)
   {
@@ -354,7 +353,7 @@ constexpr std::array<Jit64::Instruction, 64> s_dyna_op_table = []() consteval
 constexpr std::array<Jit64::Instruction, 1024> s_dyna_op_table4 = []() consteval
 {
   std::array<Jit64::Instruction, 1024> table{};
-  Common::Fill(table, &Jit64::FallBackToInterpreter);
+  table.fill(&Jit64::FallBackToInterpreter);
 
   for (u32 i = 0; i < 32; i++)
   {
@@ -392,7 +391,7 @@ constexpr std::array<Jit64::Instruction, 1024> s_dyna_op_table4 = []() consteval
 constexpr std::array<Jit64::Instruction, 1024> s_dyna_op_table19 = []() consteval
 {
   std::array<Jit64::Instruction, 1024> table{};
-  Common::Fill(table, &Jit64::FallBackToInterpreter);
+  table.fill(&Jit64::FallBackToInterpreter);
 
   for (const auto& tpl : s_table19)
   {
@@ -407,7 +406,7 @@ constexpr std::array<Jit64::Instruction, 1024> s_dyna_op_table19 = []() consteva
 constexpr std::array<Jit64::Instruction, 1024> s_dyna_op_table31 = []() consteval
 {
   std::array<Jit64::Instruction, 1024> table{};
-  Common::Fill(table, &Jit64::FallBackToInterpreter);
+  table.fill(&Jit64::FallBackToInterpreter);
 
   for (const auto& tpl : s_table31)
   {
@@ -422,7 +421,7 @@ constexpr std::array<Jit64::Instruction, 1024> s_dyna_op_table31 = []() consteva
 constexpr std::array<Jit64::Instruction, 32> s_dyna_op_table59 = []() consteval
 {
   std::array<Jit64::Instruction, 32> table{};
-  Common::Fill(table, &Jit64::FallBackToInterpreter);
+  table.fill(&Jit64::FallBackToInterpreter);
 
   for (const auto& tpl : s_table59)
   {
@@ -437,7 +436,7 @@ constexpr std::array<Jit64::Instruction, 32> s_dyna_op_table59 = []() consteval
 constexpr std::array<Jit64::Instruction, 1024> s_dyna_op_table63 = []() consteval
 {
   std::array<Jit64::Instruction, 1024> table{};
-  Common::Fill(table, &Jit64::FallBackToInterpreter);
+  table.fill(&Jit64::FallBackToInterpreter);
 
   for (const auto& tpl : s_table63)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -6,7 +6,6 @@
 #include <array>
 
 #include "Common/Assert.h"
-#include "Common/TypeUtils.h"
 #include "Core/PowerPC/Gekko.h"
 
 namespace
@@ -339,7 +338,7 @@ constexpr std::array<JitArm64OpTemplate, 10> s_table63_2{{
 constexpr std::array<JitArm64::Instruction, 64> s_dyna_op_table = []() consteval
 {
   std::array<JitArm64::Instruction, 64> table{};
-  Common::Fill(table, &JitArm64::FallBackToInterpreter);
+  table.fill(&JitArm64::FallBackToInterpreter);
 
   for (auto& tpl : s_primary_table)
   {
@@ -354,7 +353,7 @@ constexpr std::array<JitArm64::Instruction, 64> s_dyna_op_table = []() consteval
 constexpr std::array<JitArm64::Instruction, 1024> s_dyna_op_table4 = []() consteval
 {
   std::array<JitArm64::Instruction, 1024> table{};
-  Common::Fill(table, &JitArm64::FallBackToInterpreter);
+  table.fill(&JitArm64::FallBackToInterpreter);
 
   for (u32 i = 0; i < 32; i++)
   {
@@ -392,7 +391,7 @@ constexpr std::array<JitArm64::Instruction, 1024> s_dyna_op_table4 = []() conste
 constexpr std::array<JitArm64::Instruction, 1024> s_dyna_op_table19 = []() consteval
 {
   std::array<JitArm64::Instruction, 1024> table{};
-  Common::Fill(table, &JitArm64::FallBackToInterpreter);
+  table.fill(&JitArm64::FallBackToInterpreter);
 
   for (const auto& tpl : s_table19)
   {
@@ -407,7 +406,7 @@ constexpr std::array<JitArm64::Instruction, 1024> s_dyna_op_table19 = []() const
 constexpr std::array<JitArm64::Instruction, 1024> s_dyna_op_table31 = []() consteval
 {
   std::array<JitArm64::Instruction, 1024> table{};
-  Common::Fill(table, &JitArm64::FallBackToInterpreter);
+  table.fill(&JitArm64::FallBackToInterpreter);
 
   for (const auto& tpl : s_table31)
   {
@@ -422,7 +421,7 @@ constexpr std::array<JitArm64::Instruction, 1024> s_dyna_op_table31 = []() const
 constexpr std::array<JitArm64::Instruction, 32> s_dyna_op_table59 = []() consteval
 {
   std::array<JitArm64::Instruction, 32> table{};
-  Common::Fill(table, &JitArm64::FallBackToInterpreter);
+  table.fill(&JitArm64::FallBackToInterpreter);
 
   for (const auto& tpl : s_table59)
   {
@@ -437,7 +436,7 @@ constexpr std::array<JitArm64::Instruction, 32> s_dyna_op_table59 = []() constev
 constexpr std::array<JitArm64::Instruction, 1024> s_dyna_op_table63 = []() consteval
 {
   std::array<JitArm64::Instruction, 1024> table{};
-  Common::Fill(table, &JitArm64::FallBackToInterpreter);
+  table.fill(&JitArm64::FallBackToInterpreter);
 
   for (const auto& tpl : s_table63)
   {

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -17,7 +17,6 @@
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
-#include "Common/TypeUtils.h"
 
 #include "Core/PowerPC/PowerPC.h"
 
@@ -527,14 +526,14 @@ constexpr Tables s_tables = []() consteval
   u32 unknown_op_info = make_info(s_unknown_op_info);
   tables.unknown_op_info = unknown_op_info;
 
-  Common::Fill(tables.primary_table, unknown_op_info);
+  tables.primary_table.fill(unknown_op_info);
   for (auto& tpl : s_primary_table)
   {
     ASSERT(tables.primary_table[tpl.opcode] == unknown_op_info);
     tables.primary_table[tpl.opcode] = make_info(tpl);
   };
 
-  Common::Fill(tables.table4, unknown_op_info);
+  tables.table4.fill(unknown_op_info);
 
   for (const auto& tpl : s_table4_2)
   {
@@ -567,28 +566,28 @@ constexpr Tables s_tables = []() consteval
     tables.table4[op] = make_info(tpl);
   }
 
-  Common::Fill(tables.table19, unknown_op_info);
+  tables.table19.fill(unknown_op_info);
   for (auto& tpl : s_table19)
   {
     ASSERT(tables.table19[tpl.opcode] == unknown_op_info);
     tables.table19[tpl.opcode] = make_info(tpl);
   };
 
-  Common::Fill(tables.table31, unknown_op_info);
+  tables.table31.fill(unknown_op_info);
   for (auto& tpl : s_table31)
   {
     ASSERT(tables.table31[tpl.opcode] == unknown_op_info);
     tables.table31[tpl.opcode] = make_info(tpl);
   };
 
-  Common::Fill(tables.table59, unknown_op_info);
+  tables.table59.fill(unknown_op_info);
   for (auto& tpl : s_table59)
   {
     ASSERT(tables.table59[tpl.opcode] == unknown_op_info);
     tables.table59[tpl.opcode] = make_info(tpl);
   };
 
-  Common::Fill(tables.table63, unknown_op_info);
+  tables.table63.fill(unknown_op_info);
   for (auto& tpl : s_table63)
   {
     ASSERT(tables.table63[tpl.opcode] == unknown_op_info);


### PR DESCRIPTION
This temporary solution was put in place by https://github.com/dolphin-emu/dolphin/pull/11400 due to the Android NDK being deficient. The NDK has updated since then, so this is no longer necessary.