### PR TITLE
Add generation of rcheevos hash as an option in DolphinTool

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -234,7 +234,7 @@ Options:
                         Path to disc image FILE.
   -a ALGORITHM, --algorithm=ALGORITHM
                         Optional. Compute and print the digest using the
-                        selected algorithm, then exit. [crc32|md5|sha1]
+                        selected algorithm, then exit. [crc32|md5|sha1|rchash]
 ```
 
 ```

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -204,6 +204,22 @@ void AchievementManager::SetBackgroundExecutionAllowed(bool allowed)
     DoIdle();
 }
 
+std::string AchievementManager::CalculateHash(const std::string& file_path)
+{
+  char hash_result[33] = "0";
+  rc_hash_filereader volume_reader{
+      .open = &AchievementManager::FilereaderOpenByFilepath,
+      .seek = &AchievementManager::FilereaderSeek,
+      .tell = &AchievementManager::FilereaderTell,
+      .read = &AchievementManager::FilereaderRead,
+      .close = &AchievementManager::FilereaderClose,
+  };
+  rc_hash_init_custom_filereader(&volume_reader);
+  rc_hash_generate_from_file(hash_result, RC_CONSOLE_GAMECUBE, file_path.c_str());
+
+  return std::string(hash_result);
+}
+
 void AchievementManager::FetchPlayerBadge()
 {
   FetchBadge(&m_player_badge, RC_IMAGE_TYPE_USER,

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -110,6 +110,8 @@ public:
   bool IsGameLoaded() const;
   void SetBackgroundExecutionAllowed(bool allowed);
 
+  static std::string CalculateHash(const std::string& file_path);
+
   void FetchPlayerBadge();
   void FetchGameBadges();
 

--- a/Source/Core/DolphinTool/DolphinTool.vcxproj
+++ b/Source/Core/DolphinTool/DolphinTool.vcxproj
@@ -41,6 +41,7 @@
   <Import Project="$(ExternalsDir)liblzma\exports.props" />
   <Import Project="$(ExternalsDir)mbedtls\exports.props" />
   <Import Project="$(ExternalsDir)picojson\exports.props" />
+  <Import Project="$(ExternalsDir)rcheevos\exports.props" />
   <Import Project="$(ExternalsDir)zstd\exports.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Allows the user to generate a [RetroAchievements Game Identification](https://docs.retroachievements.org/developer-docs/game-identification.html#nintendo) hash via the command line for GameCube games in all file formats supported by Dolphin. RA does a quick hash of selected files within a disc image, rather than a very slow full MD5 hash.

```
> .\dolphintool.exe verify -i "game.rvz" -a rchash
9be90fd0a49908be157f8c001794699e
```

This is useful for external game launchers like LaunchBox, who need to identify which files are supported by RA so that information can be queried and displayed on their frontend.

This usually done by RAHasher, an external tool provided by the RA developers with the reference implementation on how to hash game files for each platform they support. However, while it supports reading of common disc formats like ISO and CHD, it doesn't have support for emulator-specific formats such as RVZ and some others used by Dolphin - https://github.com/RetroAchievements/RALibretro/issues/415

Without having to translate over a bunch of Dolphin's DiscIO code into RAHasher so it can understand all of Dolphin's formats, or create an open-source library for handling them, this seems like the easiest way to solve [the problem that RVZ games can't be identified](https://forums.launchbox-app.com/topic/82416-tips-tricks-supercharge-your-nintendo-gamecube-collection-now-with-retroachievements%E2%80%8B-%F0%9F%8F%86-%E2%80%8B/#comment-469314).

Next steps after this would be to embed the hashing properly within `VolumeVerifier` and show this information on the Game Properties page as well, but that's a little more involved as Dolphin's current link with the rcheevos library only seems to support a file path, not working with an existing volume.