### PR TITLE
Gameini: Enable PAL60 for Some PAL Games

### DIFF
--- a/Data/Sys/GameSettings/SL2P01.ini
+++ b/Data/Sys/GameSettings/SL2P01.ini
@@ -1,0 +1,5 @@
+# SL2P01 - Project Zero 2
+
+[Core]
+# Supports 60Hz Only
+PAL60 = True

--- a/Data/Sys/GameSettings/SLSP01.ini
+++ b/Data/Sys/GameSettings/SLSP01.ini
@@ -1,0 +1,5 @@
+# SLSP01 - THE LAST STORY
+
+[Core]
+# Supports 60Hz Only
+PAL60 = True

--- a/Data/Sys/GameSettings/ST7P01.ini
+++ b/Data/Sys/GameSettings/ST7P01.ini
@@ -1,0 +1,5 @@
+# ST7P01 - Boom Street
+
+[Core]
+# Supports 60Hz Only
+PAL60 = True


### PR DESCRIPTION
Without PAL60 enabled these PAL games display a message that you are running an incompatible video mode and return to the Wii Menu.