### PR TITLE
RVZ: Fix undefined behaviour when copying 0 bytes to a null pointer

### DIFF
--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -765,7 +765,14 @@ bool WIARVZFileReader<RVZ>::Chunk::Decompress()
     const size_t bytes_to_move = m_out.bytes_written - m_out_bytes_used_for_exceptions;
 
     DecompressionBuffer in{std::vector<u8>(bytes_to_move), bytes_to_move};
-    std::memcpy(in.data.data(), m_out.data.data() + m_out_bytes_used_for_exceptions, bytes_to_move);
+
+    // Copying to a null pointer is undefined behaviour, so only copy when we
+    // actually have data to copy.
+    if (bytes_to_move > 0)
+    {
+      std::memcpy(in.data.data(), m_out.data.data() + m_out_bytes_used_for_exceptions,
+                  bytes_to_move);
+    }
 
     m_out.bytes_written = m_out_bytes_used_for_exceptions;
 


### PR DESCRIPTION
This PR fixes a case of undefined behaviour that caused crashes when compiling Dolphin with Clang and LTO enabled and loading a Metroid Prime 3 RVZ.

A vector of length 0 can have a null data pointer, which causes UB when passed to memcpy, so this PR changes the code to only copy when we actually have data to copy.

This issue was initially encountered in [dolphin-primehack](https://github.com/xiota/dolphin-primehack/issues/1), but also occurs with upstream dolphin.