### PR TITLE
MainWindow: Prevent Confirm On Stop dialog from being hidden by the Render window

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -925,7 +925,8 @@ bool MainWindow::RequestStop()
   }
 
   const bool rendered_widget_was_active =
-      m_render_widget->isActiveWindow() && !m_render_widget->isFullScreen();
+      Settings::Instance().IsKeepWindowOnTopEnabled() ||
+      (m_render_widget->isActiveWindow() && !m_render_widget->isFullScreen());
   QWidget* confirm_parent = (!m_rendering_to_main && rendered_widget_was_active) ?
                                 m_render_widget :
                                 static_cast<QWidget*>(this);


### PR DESCRIPTION
Set the Render window as the parent of the Confirm On Stop confirmation dialog when Keep Window On Top is enabled, ensuring it will always be visible.

Previously, when Keep Window On Top was enabled the Confirm On Stop dialog could be hidden by the Render window in the following situations:
* Clicking Stop in the Main Window
* Clicking the Main Window's close button
* Pressing the Stop hotkey while in FullScreen mode

This was particularly troublesome because the Confirm On Stop dialog is modal, preventing the user from moving the Render window out of the way if it was obscuring the dialog.

Fixes [#13247](https://bugs.dolphin-emu.org/issues/13247).