### PR TITLE
Add manifest for building as a flatpak

### DIFF
--- a/Flatpak/SDL2/SDL2.json
+++ b/Flatpak/SDL2/SDL2.json
@@ -1,0 +1,22 @@
+{
+  "name": "SDL2",
+  "buildsystem": "autotools",
+  "config-opts": ["--disable-static"],
+  "sources": [
+    {
+      "type": "dir",
+      "path": "../../Externals/SDL/SDL"
+    }
+  ],
+  "cleanup": [ "/bin/sdl2-config",
+               "/include",
+               "/lib/libSDL2.la",
+               "/lib/libSDL2main.a",
+               "/lib/libSDL2main.la",
+               "/lib/libSDL2_test.a",
+               "/lib/libSDL2_test.la",
+               "/lib/cmake",
+               "/share/aclocal",
+               "/lib/pkgconfig"]
+}
+

--- a/Flatpak/fill_release_node.sh
+++ b/Flatpak/fill_release_node.sh
@@ -2,7 +2,7 @@
 
 DATE=$(git log -1 --pretty=%cd --date=iso8601 --date=format:'%Y-%m-%d')
 sed -i -e "s/@DATE_PLACEHOLDER/${DATE}/" org.DolphinEmu.dolphin-emu.metainfo.xml
-VERSION=$(git describe --tags)
+VERSION=$(git describe --tags | sed -E 's/^([0-9]+-[0-9]+).*/\1/')
 sed -i -e "s/@VERSION_PLACEHOLDER/${VERSION}/" org.DolphinEmu.dolphin-emu.metainfo.xml
 
 

--- a/Flatpak/fill_release_node.sh
+++ b/Flatpak/fill_release_node.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+DATE=$(git log -1 --pretty=%cd --date=iso8601 --date=format:'%Y-%m-%d')
+sed -i -e "s/@DATE_PLACEHOLDER/${DATE}/" org.DolphinEmu.dolphin-emu.metainfo.xml
+VERSION=$(git describe --tags)
+sed -i -e "s/@VERSION_PLACEHOLDER/${VERSION}/" org.DolphinEmu.dolphin-emu.metainfo.xml
+
+

--- a/Flatpak/org.DolphinEmu.dolphin-emu.metainfo.xml.in
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.metainfo.xml.in
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2016 Jeremy Newton -->
+<component type="desktop-application">
+  <id>org.DolphinEmu.dolphin-emu</id>
+  <name>Dolphin Emulator</name>
+  <developer id="org.dolphin-emu">
+    <name>Dolphin Emulator Project</name>
+  </developer>
+  <summary>GameCube / Wii</summary>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <content_rating type="oars-1.0"/>
+  <!-- Descriptions taken from Dolphin Homepage -->
+  <description><p>Dolphin is an emulator for two recent Nintendo video game consoles: the GameCube and the Wii. It allows PC gamers to enjoy games for these two consoles in full HD (1080p) with several enhancements: compatibility with all PC controllers, turbo speed, networked multiplayer, and even more!</p></description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Dolphin's main window</caption>
+      <image type="source">http://dolphin-emu.org/m/user/flatpak/screenshot_1.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>In-game</caption>
+      <image type="source">http://dolphin-emu.org/m/user/flatpak/screenshot_2.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Graphics configuration</caption>
+      <image type="source">http://dolphin-emu.org/m/user/flatpak/screenshot_3.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Controller configuration</caption>
+      <image type="source">http://dolphin-emu.org/m/user/flatpak/screenshot_4.png</image>
+    </screenshot>
+  </screenshots>
+  <launchable type="desktop-id">dolphin-emu.desktop</launchable>
+  <provides>
+    <binary>dolphin-emu</binary>
+    <id>dolphin-emu.desktop</id>
+  </provides>
+  <releases>
+    <release version="@VERSION_PLACEHOLDER" date="@DATE_PLACEHOLDER"/>
+  </releases>
+  <url type="homepage">https://dolphin-emu.org</url>
+  <url type="bugtracker">https://bugs.dolphin-emu.org/projects/emulator/issues</url>
+  <url type="faq">https://dolphin-emu.org/docs/faq/</url>
+  <url type="help">https://dolphin-emu.org/docs/guides/</url>
+  <url type="translate">https://www.transifex.com/projects/p/dolphin-emu</url>
+  <url type="contact">https://dolphin-emu.org/docs/faq/#ive-got-idea-make-dolphin-better-how-should-i-tell</url>
+  <url type="vcs-browser">https://github.com/dolphin-emu/dolphin</url>
+  <url type="contribute">https://github.com/dolphin-emu/dolphin/blob/master/Contributing.md</url>
+</component>

--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -1,0 +1,83 @@
+app-id: org.DolphinEmu.dolphin-emu
+runtime: org.kde.Platform
+runtime-version: '6.7'
+sdk: org.kde.Sdk
+command: dolphin-emu-wrapper
+rename-desktop-file: dolphin-emu.desktop
+rename-icon: dolphin-emu
+finish-args:
+  - --device=all
+  - --socket=pulseaudio
+  # dolphin doesn't work on wayland (only the ui does), if a user were to set
+  # this env variable globally to wayland then games wouldn't work. 
+  # we overwrite the setting and force xcb to prevent this from happening.
+  - --env=QT_QPA_PLATFORM=xcb
+  - --socket=x11
+  - --share=network
+  - --share=ipc
+  # required for the emulated bluetooth adapter feature to work.
+  - --allow=bluetooth
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --talk-name=org.freedesktop.ScreenSaver
+  # required for Gamescope on Steam Deck
+  - --filesystem=xdg-run/gamescope-0:ro
+modules:
+  # enables motion controls on non-wii controllers (switch, ps4, etc)
+  # requires a udev rule enabling Motion Sensors access
+  - name: libevdev
+    buildsystem: meson
+    config-opts:
+      - -Dtests=disabled
+      - -Ddocumentation=disabled
+    sources:
+      - type: archive
+        url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.2.tar.xz
+        sha256: 3eca86a6ce55b81d5bce910637fc451c8bbe373b1f9698f375c7f1ad0de3ac48
+        x-checker-data:
+          type: anitya
+          project-id: 20540
+          stable-only: true
+          url-template: https://www.freedesktop.org/software/libevdev/libevdev-$version.tar.xz
+
+  # needed for screensaver inhibition
+  - name: xdg-screensaver-shim
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://github.com/Unrud/xdg-screensaver-shim/archive/0.0.2.tar.gz
+        sha256: 0ed2a69fe6ee6cbffd2fe16f85116db737f17fb1e79bfb812d893cf15c728399
+
+  # build the vendored SDL2 from Externals until the runtime gets 2.30.6
+  - SDL2/SDL2.json
+
+  - name: dolphin-emu
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DENABLE_ALSA=OFF
+      - -DENABLE_SDL=ON
+      - -DENABLE_EVDEV=ON
+      - -DDISTRIBUTOR=dolphin-emu.org
+    cleanup:
+      - /share/man
+    post-install:
+      - install -D -t ${FLATPAK_DEST}/bin/ dolphin-emu-wrapper
+      - "${FLATPAK_BUILDER_BUILDDIR}/Flatpak/fill_release_node.sh"
+      - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo/ org.DolphinEmu.dolphin-emu.metainfo.xml
+      - desktop-file-edit --set-key=Exec --set-value='/app/bin/dolphin-emu-wrapper'
+        /app/share/applications/dolphin-emu.desktop
+    sources:
+      - type: dir
+        path: ..
+      - type: file
+        path: org.DolphinEmu.dolphin-emu.metainfo.xml.in
+        dest-filename: org.DolphinEmu.dolphin-emu.metainfo.xml
+      - type: script
+        commands:
+          - |
+            for i in {0..9}; do
+              test -S $XDG_RUNTIME_DIR/discord-ipc-$i ||
+                ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+            done
+            dolphin-emu "$@"
+        dest-filename: dolphin-emu-wrapper

--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -31,8 +31,8 @@ modules:
       - -Ddocumentation=disabled
     sources:
       - type: archive
-        url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.2.tar.xz
-        sha256: 3eca86a6ce55b81d5bce910637fc451c8bbe373b1f9698f375c7f1ad0de3ac48
+        url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.3.tar.xz
+        sha256: abf1aace86208eebdd5d3550ffded4c8d73bb405b796d51c389c9d0604cbcfbf
         x-checker-data:
           type: anitya
           project-id: 20540


### PR DESCRIPTION
Includes the following:

- `org.DolphinEmu.dolphin-emu.metainfo.xml.in` this file contains general information and metadata that is used by most linux based app stores (kde discover, gnome software, flathub.org, etc) to showcase dolphin.

- `fill_release_node.sh` a script to automatically fill in the release information in the metainfo file when building the flatpak.
- `SDL2.json` manifest to build the vendored version of SDL from the `Exports` directory, it's only temporarily needed until the kde runtime is updated with the current SDL2 version and should be deleted after.
- `org.DolphinEmu.dolphin-emu.yml` the manifest itself.