### PR TITLE
Vulkan: Remove unnecessary command buffer execution

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
@@ -260,9 +260,6 @@ bool VKGfx::BindBackbuffer(const ClearColor& clear_color)
 
   if (res != VK_SUCCESS)
   {
-    // Execute cmdbuffer before resizing, as the last frame could still be presenting.
-    ExecuteCommandBuffer(false, true);
-
     // Was this a lost exclusive fullscreen?
     if (res == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
     {


### PR DESCRIPTION
When resizing the game window there is a chance that the swapchain state is bad. This will result in a deadlock on Linux + Nvidia's proprietary driver. This code can be removed and the next command buffer execution will simply occur when the swapchain has been recreated.

The root issue may be a Linux Nvidia driver implementation problem. I wasn't able to reproduce the original problem on Windows, nor on my Steam Deck. I tested this change on Fedora 40+Nvidia & SteamOS+AMD.

Fixes https://bugs.dolphin-emu.org/issues/13523