### PR TITLE
vulkan: Add line number to vulkan error logger

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
@@ -241,10 +241,10 @@ const char* VkResultToString(VkResult res)
   }
 }
 
-void LogVulkanResult(Common::Log::LogLevel level, const char* func_name, VkResult res,
-                     const char* msg)
+void LogVulkanResult(Common::Log::LogLevel level, const char* func_name, const int line,
+                     VkResult res, const char* msg)
 {
-  GENERIC_LOG_FMT(Common::Log::LogType::VIDEO, level, "({}) {} ({}: {})", func_name, msg,
+  GENERIC_LOG_FMT(Common::Log::LogType::VIDEO, level, "({}:{}) {} ({}: {})", func_name, line, msg,
                   static_cast<int>(res), VkResultToString(res));
 }
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -95,10 +95,10 @@ bool SupportsCustomDriver();
 #endif
 
 const char* VkResultToString(VkResult res);
-void LogVulkanResult(Common::Log::LogLevel level, const char* func_name, VkResult res,
-                     const char* msg);
+void LogVulkanResult(Common::Log::LogLevel level, const char* func_name, const int line,
+                     VkResult res, const char* msg);
 
 #define LOG_VULKAN_ERROR(res, msg)                                                                 \
-  LogVulkanResult(Common::Log::LogLevel::LERROR, __func__, res, msg)
+  LogVulkanResult(Common::Log::LogLevel::LERROR, __func__, __LINE__, res, msg)
 
 }  // namespace Vulkan


### PR DESCRIPTION
This is a minor improvement to add line numbers to the LOG_VULKAN_ERROR define. Basically error logs for Vulkan will now look like:

```
// This
25:03:347 VideoBackends/Vulkan/VulkanLoader.cpp:247 E[Video]: (WaitForCommandBufferCompletion:278) vkWaitForFences failed:  (2: VK_TIMEOUT)

// Instead of
15:45:154 VideoBackends/Vulkan/VulkanLoader.cpp:247 E[Video]: (WaitForCommandBufferCompletion) vkWaitForFences failed:  (2: VK_TIMEOUT)
```