### PR TITLE
GameSettings: force EFB-to-RAM for My First Songs

### DIFF
--- a/Data/Sys/GameSettings/SON.ini
+++ b/Data/Sys/GameSettings/SON.ini
@@ -1,0 +1,6 @@
+# SONDMR, SONFMR, SONPMR - My First Songs
+
+[Video_Hacks]
+# EFB-to-RAM is required for the game to proceed past the song loading screen
+# and for lyrics to show up.
+EFBToTextureEnable = False


### PR DESCRIPTION
I don't fully understand how the game renders the lyrics but it involves EFB copies and the game notices if they don't work: `N[OSREPORT]: Capturing failed: at TEXELDAT_NORMALTEXT of Old` ("Old" being the first syllable of "Old MacDonald".)

During the song the game renders each syllable first fully in white and then in blue with a growing quad for the currently sung syllable. Also note how the red background of the syllable texture bleeds through some not fully opaque texels.
![image](https://github.com/user-attachments/assets/149726ab-29fb-4890-a1c8-53ba440e4c9e)