### PR TITLE
Add VBI Frequency Override

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -100,6 +100,12 @@ enum class BooleanSetting(
         "OverclockEnable",
         false
     ),
+    MAIN_VI_OVERCLOCK_ENABLE(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_CORE,
+        "VIOverclockEnable",
+        false
+    ),
     MAIN_RAM_OVERRIDE_ENABLE(
         Settings.FILE_DOLPHIN,
         Settings.SECTION_INI_CORE,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.kt
@@ -11,6 +11,7 @@ enum class FloatSetting(
     // These entries have the same names and order as in C++, just for consistency.
     MAIN_EMULATION_SPEED(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "EmulationSpeed", 1.0f),
     MAIN_OVERCLOCK(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "Overclock", 1.0f),
+    MAIN_VI_OVERCLOCK(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "VIOverclock", 1.0f),
     GFX_CC_GAME_GAMMA(Settings.FILE_GFX, Settings.SECTION_GFX_COLOR_CORRECTION, "GameGamma", 2.35f);
 
     override val isOverridden: Boolean

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1027,6 +1027,27 @@ class SettingsFragmentPresenter(
                 false
             )
         )
+        sl.add(
+            SwitchSetting(
+                context,
+                BooleanSetting.MAIN_VI_OVERCLOCK_ENABLE,
+                R.string.vi_overclock_enable,
+                R.string.vi_overclock_enable_description
+            )
+        )
+        sl.add(
+            PercentSliderSetting(
+                context,
+                FloatSetting.MAIN_VI_OVERCLOCK,
+                R.string.vi_overclock_title,
+                R.string.vi_overclock_title_description,
+                0f,
+                500f,
+                "%",
+                1f,
+                false
+            )
+        )
 
         val mem1Size = ScaledIntSetting(1024 * 1024, IntSetting.MAIN_MEM1_SIZE)
         val mem2Size = ScaledIntSetting(1024 * 1024, IntSetting.MAIN_MEM2_SIZE)

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -376,7 +376,7 @@
     <string name="enable_cpu_cache_description">Enables emulation of the CPU write-back cache. Enabling will have a significant impact on performance. This should be left disabled unless absolutely needed.</string>
     <string name="clock_override">Clock Override</string>
     <string name="overclock_enable">Override Emulated CPU Clock Speed</string>
-    <string name="overclock_enable_description">Higher values can make variable-framerate games run at a higher framerate, requiring a powerful device. Lower values make games run at a lower framerate, increasing emulation speed, but reducing the emulated console\'s performance.</string>
+    <string name="overclock_enable_description">On games that have an unstable frame rate despite full emulation speed, higher values can improve their performance, requiring a powerful device. Lower values reduce the emulated console\'s performance, but improve the emulation speed.</string>
     <string name="overclock_title">Emulated CPU Clock Speed</string>
     <string name="overclock_title_description">Adjusts the emulated CPU\'s clock rate if \"Override Emulated CPU Clock Speed\" is enabled.</string>
     <string name="memory_override">Memory Override</string>
@@ -385,6 +385,10 @@
     <string name="main_mem1_size">MEM1 Size</string>
     <string name="main_mem2_size">MEM2 Size</string>
     <string name="gpu_options">GPU Options</string>
+    <string name="vi_overclock_enable">Override VBI Frequency</string>
+    <string name="vi_overclock_enable_description">Makes games run at a different frame rate, making the emulation less demanding when lowered, or improving smoothness when increased. This may affect gameplay speed, as it is often tied to the frame rate.</string>
+    <string name="vi_overclock_title">VBI Frequency</string>
+    <string name="vi_overclock_title_description">Adjusts the VBI frequency rate if \"Override VBI Frequency\" is enabled.\nAlso adjusts the emulated CPU\'s clock speed, to keep it relatively the same.</string>
     <string name="synchronize_gpu_thread">Synchronize GPU Thread</string>
     <string name="synchronize_gpu_thread_description">Synchronizing the GPU thread reduces the risk of games crashing or becoming unstable with dual core enabled, but can also reduce the performance gain of dual core. If unsure, select \"On Idle Skipping\". Selecting \"Never\" is risky and not recommended!</string>
     <string name="custom_rtc_options">Custom RTC Options</string>

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -222,6 +222,8 @@ const Info<bool> MAIN_PRECISION_FRAME_TIMING{{System::Main, "Core", "PrecisionFr
                                              DEFAULT_PRECISION_FRAME_TIMING};
 const Info<float> MAIN_OVERCLOCK{{System::Main, "Core", "Overclock"}, 1.0f};
 const Info<bool> MAIN_OVERCLOCK_ENABLE{{System::Main, "Core", "OverclockEnable"}, false};
+const Info<float> MAIN_VI_OVERCLOCK{{System::Main, "Core", "VIOverclock"}, 1.0f};
+const Info<bool> MAIN_VI_OVERCLOCK_ENABLE{{System::Main, "Core", "VIOverclockEnable"}, false};
 const Info<bool> MAIN_RAM_OVERRIDE_ENABLE{{System::Main, "Core", "RAMOverrideEnable"}, false};
 const Info<u32> MAIN_MEM1_SIZE{{System::Main, "Core", "MEM1Size"}, Memory::MEM1_SIZE_RETAIL};
 const Info<u32> MAIN_MEM2_SIZE{{System::Main, "Core", "MEM2Size"}, Memory::MEM2_SIZE_RETAIL};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -128,6 +128,8 @@ extern const Info<float> MAIN_EMULATION_SPEED;
 extern const Info<bool> MAIN_PRECISION_FRAME_TIMING;
 extern const Info<float> MAIN_OVERCLOCK;
 extern const Info<bool> MAIN_OVERCLOCK_ENABLE;
+extern const Info<float> MAIN_VI_OVERCLOCK;
+extern const Info<bool> MAIN_VI_OVERCLOCK_ENABLE;
 extern const Info<bool> MAIN_RAM_OVERRIDE_ENABLE;
 extern const Info<u32> MAIN_MEM1_SIZE;
 extern const Info<u32> MAIN_MEM2_SIZE;

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -42,6 +42,8 @@ public:
     layer->Set(Config::MAIN_DSP_HLE, m_settings.dsp_hle);
     layer->Set(Config::MAIN_OVERCLOCK_ENABLE, m_settings.oc_enable);
     layer->Set(Config::MAIN_OVERCLOCK, m_settings.oc_factor);
+    layer->Set(Config::MAIN_VI_OVERCLOCK_ENABLE, m_settings.vi_oc_enable);
+    layer->Set(Config::MAIN_VI_OVERCLOCK, m_settings.vi_oc_factor);
     for (ExpansionInterface::Slot slot : ExpansionInterface::SLOTS)
       layer->Set(Config::GetInfoForEXIDevice(slot), m_settings.exi_device[slot]);
     layer->Set(Config::MAIN_MEMORY_CARD_SIZE, m_settings.memcard_size_override);

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -119,7 +119,9 @@ void CoreTimingManager::Shutdown()
 void CoreTimingManager::RefreshConfig()
 {
   m_config_oc_factor =
-      Config::Get(Config::MAIN_OVERCLOCK_ENABLE) ? Config::Get(Config::MAIN_OVERCLOCK) : 1.0f;
+      (Config::Get(Config::MAIN_OVERCLOCK_ENABLE) ? Config::Get(Config::MAIN_OVERCLOCK) : 1.0f) *
+      (Config::Get(Config::MAIN_VI_OVERCLOCK_ENABLE) ? Config::Get(Config::MAIN_VI_OVERCLOCK) :
+                                                       1.0f);
   m_config_oc_inv_factor = 1.0f / m_config_oc_factor;
   m_config_sync_on_skip_idle = Config::Get(Config::MAIN_SYNC_ON_SKIP_IDLE);
 
@@ -480,6 +482,11 @@ void CoreTimingManager::UpdateVISkip(TimePoint current_time, TimePoint target_ti
 bool CoreTimingManager::GetVISkip() const
 {
   return m_throttle_disable_vi_int && g_ActiveConfig.bVISkip && !Core::WantsDeterminism();
+}
+
+float CoreTimingManager::GetOverclock() const
+{
+  return m_config_oc_factor;
 }
 
 bool CoreTimingManager::UseSyncOnSkipIdle() const

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -165,6 +165,8 @@ public:
   // Used by VideoInterface
   bool GetVISkip() const;
 
+  float GetOverclock() const;
+
   bool UseSyncOnSkipIdle() const;
 
 private:

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -365,6 +365,8 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-audio-backend", Config::Get(Config::MAIN_AUDIO_BACKEND));
   builder.AddData("cfg-oc-enable", Config::Get(Config::MAIN_OVERCLOCK_ENABLE));
   builder.AddData("cfg-oc-factor", Config::Get(Config::MAIN_OVERCLOCK));
+  builder.AddData("cfg-vi-oc-enable", Config::Get(Config::MAIN_VI_OVERCLOCK_ENABLE));
+  builder.AddData("cfg-vi-oc-factor", Config::Get(Config::MAIN_VI_OVERCLOCK));
   builder.AddData("cfg-render-to-main", Config::Get(Config::MAIN_RENDER_TO_MAIN));
   if (g_video_backend)
   {

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -13,8 +13,10 @@
 #include "Common/Config/Config.h"
 #include "Common/Logging/Log.h"
 
+#include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PerformanceMetrics.h"
 
+#include "Core/AchievementManager.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
@@ -41,7 +43,10 @@ VideoInterfaceManager::VideoInterfaceManager(Core::System& system) : m_system(sy
 {
 }
 
-VideoInterfaceManager::~VideoInterfaceManager() = default;
+VideoInterfaceManager::~VideoInterfaceManager()
+{
+  Config::RemoveConfigChangedCallback(m_config_changed_callback_id);
+}
 
 static constexpr std::array<u32, 2> CLOCK_FREQUENCIES{{
     27000000,
@@ -173,6 +178,22 @@ void VideoInterfaceManager::Preset(bool _bNTSC)
 void VideoInterfaceManager::Init()
 {
   Preset(true);
+
+  m_config_changed_callback_id = Config::AddConfigChangedCallback([this] { RefreshConfig(); });
+  RefreshConfig();
+}
+
+void VideoInterfaceManager::RefreshConfig()
+{
+  m_config_vi_oc_factor =
+      Config::Get(Config::MAIN_VI_OVERCLOCK_ENABLE) ? Config::Get(Config::MAIN_VI_OVERCLOCK) : 1.0f;
+  if (AchievementManager::GetInstance().IsHardcoreModeActive() && m_config_vi_oc_factor < 1.0f)
+  {
+    Config::SetCurrent(Config::MAIN_VI_OVERCLOCK, 1.0f);
+    m_config_vi_oc_factor = 1.0f;
+    OSD::AddMessage("Minimum VBI frequency is 100% in Hardcore Mode");
+  }
+  UpdateRefreshRate();
 }
 
 void VideoInterfaceManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
@@ -488,7 +509,8 @@ float VideoInterfaceManager::GetAspectRatio() const
   float vertical_period = tick_length * GetTicksPerField();
   float horizontal_period = tick_length * GetTicksPerHalfLine() * 2;
   float vertical_active_area = active_lines * horizontal_period;
-  float horizontal_active_area = tick_length * GetTicksPerSample() * active_width_samples;
+  float horizontal_active_area =
+      tick_length * GetTicksPerSample() * active_width_samples / m_config_vi_oc_factor;
 
   // We are approximating the horizontal/vertical flyback transformers that control the
   // position of the electron beam on the screen. Our flyback transformers create a
@@ -707,7 +729,11 @@ void VideoInterfaceManager::UpdateParameters()
                           m_vblank_timing_even.PRB - odd_even_psb_diff;
   m_even_field_last_hl = m_even_field_first_hl + acv_hl - 1;
 
-  // Refresh rate:
+  UpdateRefreshRate();
+}
+
+void VideoInterfaceManager::UpdateRefreshRate()
+{
   m_target_refresh_rate_numerator = m_system.GetSystemTimers().GetTicksPerSecond() * 2;
   m_target_refresh_rate_denominator = GetTicksPerEvenField() + GetTicksPerOddField();
   m_target_refresh_rate =
@@ -736,7 +762,7 @@ u32 VideoInterfaceManager::GetTicksPerSample() const
 
 u32 VideoInterfaceManager::GetTicksPerHalfLine() const
 {
-  return GetTicksPerSample() * m_h_timing_0.HLW;
+  return GetTicksPerSample() * m_h_timing_0.HLW / m_config_vi_oc_factor;
 }
 
 u32 VideoInterfaceManager::GetTicksPerField() const

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 
 enum class FieldType;
 class PointerWrap;
@@ -407,6 +408,9 @@ private:
   void BeginField(FieldType field, u64 ticks);
   void EndField(FieldType field, u64 ticks);
 
+  void RefreshConfig();
+  void UpdateRefreshRate();
+
   // Registers listed in order:
   UVIVerticalTimingRegister m_vertical_timing_register;
   UVIDisplayControlRegister m_display_control_register;
@@ -447,6 +451,9 @@ private:
   u32 m_even_field_last_hl = 0;   // index last halfline of the even field
   u32 m_odd_field_last_hl = 0;    // index last halfline of the odd field
 
+  float m_config_vi_oc_factor = 0.0f;
+
+  Config::ConfigChangedCallbackID m_config_changed_callback_id;
   Core::System& m_system;
 };
 }  // namespace VideoInterface

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -68,9 +68,7 @@ IPCReply GetCPUSpeed(Core::System& system, const IOCtlVRequest& request)
     return IPCReply(IPC_EINVAL);
   }
 
-  const bool overclock_enabled = Config::Get(Config::MAIN_OVERCLOCK_ENABLE);
-  const float oc = overclock_enabled ? Config::Get(Config::MAIN_OVERCLOCK) : 1.0f;
-
+  const bool oc = system.GetCoreTiming().GetOverclock();
   const u32 core_clock = u32(float(system.GetSystemTimers().GetTicksPerSecond()) * oc);
 
   auto& memory = system.GetMemory();

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -862,6 +862,8 @@ void NetPlayClient::OnStartGame(sf::Packet& packet)
     packet >> m_net_settings.allow_sd_writes;
     packet >> m_net_settings.oc_enable;
     packet >> m_net_settings.oc_factor;
+    packet >> m_net_settings.vi_oc_enable;
+    packet >> m_net_settings.vi_oc_factor;
 
     for (auto slot : ExpansionInterface::SLOTS)
       packet >> m_net_settings.exi_device[slot];

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -47,6 +47,8 @@ struct NetSettings
   bool allow_sd_writes = false;
   bool oc_enable = false;
   float oc_factor = 0;
+  bool vi_oc_enable = false;
+  float vi_oc_factor = 0;
   Common::EnumMap<ExpansionInterface::EXIDeviceType, ExpansionInterface::MAX_SLOT> exi_device{};
   int memcard_size_override = -1;
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1376,6 +1376,8 @@ bool NetPlayServer::SetupNetSettings()
   settings.allow_sd_writes = Config::Get(Config::MAIN_ALLOW_SD_WRITES);
   settings.oc_enable = Config::Get(Config::MAIN_OVERCLOCK_ENABLE);
   settings.oc_factor = Config::Get(Config::MAIN_OVERCLOCK);
+  settings.vi_oc_enable = Config::Get(Config::MAIN_VI_OVERCLOCK_ENABLE);
+  settings.vi_oc_factor = Config::Get(Config::MAIN_VI_OVERCLOCK);
 
   for (ExpansionInterface::Slot slot : ExpansionInterface::SLOTS)
   {
@@ -1603,6 +1605,8 @@ bool NetPlayServer::StartGame()
   spac << m_settings.allow_sd_writes;
   spac << m_settings.oc_enable;
   spac << m_settings.oc_factor;
+  spac << m_settings.vi_oc_enable;
+  spac << m_settings.vi_oc_factor;
 
   for (auto slot : ExpansionInterface::SLOTS)
     spac << static_cast<int>(m_settings.exi_device[slot]);

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -39,6 +39,10 @@ private:
   QSlider* m_cpu_clock_override_slider;
   QLabel* m_cpu_clock_override_slider_label;
 
+  ConfigBool* m_vi_rate_override_checkbox;
+  QSlider* m_vi_rate_override_slider;
+  QLabel* m_vi_rate_override_slider_label;
+
   ConfigBool* m_custom_rtc_checkbox;
   QDateTimeEdit* m_custom_rtc_datetime;
 

--- a/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
+++ b/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
@@ -62,13 +62,13 @@ struct FrameDumpContext
 
 namespace
 {
-AVRational GetTimeBaseForCurrentRefreshRate()
+AVRational GetTimeBaseForCurrentRefreshRate(s64 max_denominator)
 {
   auto& vi = Core::System::GetInstance().GetVideoInterface();
   int num;
   int den;
   av_reduce(&num, &den, int(vi.GetTargetRefreshRateDenominator()),
-            int(vi.GetTargetRefreshRateNumerator()), std::numeric_limits<int>::max());
+            int(vi.GetTargetRefreshRateNumerator()), max_denominator);
   return AVRational{num, den};
 }
 
@@ -248,11 +248,16 @@ bool FFMpegFrameDump::CreateVideoFile()
     return false;
   }
 
+  m_max_denominator = std::numeric_limits<s64>::max();
+
   // Force XVID FourCC for better compatibility when using H.263
   if (codec->id == AV_CODEC_ID_MPEG4)
+  {
     m_context->codec->codec_tag = MKTAG('X', 'V', 'I', 'D');
+    m_max_denominator = std::numeric_limits<unsigned short>::max();
+  }
 
-  const auto time_base = GetTimeBaseForCurrentRefreshRate();
+  const auto time_base = GetTimeBaseForCurrentRefreshRate(m_max_denominator);
 
   INFO_LOG_FMT(FRAMEDUMP, "Creating video file: {} x {} @ {}/{} fps", m_context->width,
                m_context->height, time_base.den, time_base.num);
@@ -535,7 +540,7 @@ FrameState FFMpegFrameDump::FetchState(u64 ticks, int frame_number) const
   state.frame_number = frame_number;
   state.savestate_index = m_savestate_index;
 
-  const auto time_base = GetTimeBaseForCurrentRefreshRate();
+  const auto time_base = GetTimeBaseForCurrentRefreshRate(m_max_denominator);
   state.refresh_rate_num = time_base.den;
   state.refresh_rate_den = time_base.num;
   return state;

--- a/Source/Core/VideoCommon/FrameDumpFFMpeg.h
+++ b/Source/Core/VideoCommon/FrameDumpFFMpeg.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <ctime>
+#include <limits>
 #include <memory>
 
 #include "Common/CommonTypes.h"
@@ -62,6 +63,9 @@ private:
   // Used for filename generation.
   std::time_t m_start_time = {};
   u32 m_file_index = 0;
+
+  // Some codecs (like MPEG4) have a limit to this
+  int64_t m_max_denominator = std::numeric_limits<s64>::max();
 };
 
 #if !defined(HAVE_FFMPEG)


### PR DESCRIPTION
Rebase of #11486, which seems to have been abandoned.

The highlight of this feature is the ability to **play games at higher than 60 FPS**, at normal gameplay speed, and without affecting the audio.

https://github.com/user-attachments/assets/d33119c7-994a-4414-a9f9-0e8ed8f7cb4a

(More videos on #11486)

This feature works, it's simple and non-invasive, and put formally, it is very cool.

However, the current user experience isn't the best.
Here are the current problems, with proposed solutions. I'm asking for feedback on the "IMO"s.

### ~~CPU Overclock~~

A game with more FPS is obviously going to be more demanding for the emulated console, but if the emulated CPU clock doesn't change, then the console is basically going to be underclocked.
At best, this will cause the game to not run at the target frame rate (which defeats the whole point).
At worst, the game will freeze.[^1]

~~IMO, a simple solution would be that changing VBI Frequency will also "secretly" multiply the emulated CPU clock.~~ Done!

### Cheat codes

There are different types of games.
- Some will speed up.[^2]
  -  Worst case, you can do nothing about it.
     - Many Nintendo games like Mario Kart Wii or Super Mario Galaxy have their speed completely tied to the frame rate. They even ignore PAL 50 Hz!
  - Best case, the game doesn't dynamically change the game speed, but it *can* be changed with a cheat code.
    - A good chunk of codes is probably just going to replace a `3C888889` (1/60) with 1/DesiredFPS.
    - If the game speed is adjusted in PAL 50 Hz, then it's a good sign that this is likely possible.
- Others seem to not react at all.
  - Best case, the rendering is capped by a time-based frame rate limiter. It can be theoretically uncapped with a cheat code.
  - Worst case, the game logic is capped by a time-based/MaxFPS frame rate limiter. Forcing the game to render more often simply results in duplicated frames. (e.g. PokéPark Wii, which internally runs at 60 FPS no matter what, even in PAL50.)
- Some are... [a weird mix of these](https://github.com/dolphin-emu/dolphin/pull/11486#issuecomment-2160631877)?
- And some play at normal speed at higher frame rates with no (or minor) issues!

So, the situation here is extremely game-dependent.

The golden standard for this is probably Cemu: its graphics packs, which are automatically downloaded, offer a choice of presets that patch the game *and* set the settings required to play at a specific frame rate.

Dolphin could do something like it with its per-game settings, but... there can only be one per game. You can't "choose" a preset.

The discoverability of cheat codes in general is also bad. Currently, all "enhancement" cheat codes are only located in the Dolphin wiki, and must be manually inserted. This is in contrast to, for instance, PCSX2 and RPCS3, which do have patches included (for the former they are in a separate repo, for the latter they are scraped from the wiki).

This is a complicated issue, and affects more than this PR.[^3] However, because there are games that don't require this, I don't think that it *needs* to be tackled now, IMO.

Plus, giving cheat-makers the ability to cook these codes for the games that need it is valuable, even before the feature has good UX, IMO.

### Where to put the option?

What this says: https://github.com/dolphin-emu/dolphin/pull/11486#issuecomment-1402925859

EDIT: No much of a problem anymore since #13422 has been merged.

Maybe it could be exposed exclusively in the in-game settings (like RPCS3)? That would make the options harder to discover for the users that shouldn't touch it, while allowing the cheat-makers to have fun with it.

### Vsync

Vsync has a side effect of capping the frame rate to the monitor's refresh rate. This would be a problem that slows down the game if it ran at a higher frame rate than the monitor, but it isn't since games could be 60 FPS at most and monitors under 60 Hz basically don't exist.
However, changing VBI Frequency allowing games to go above 60 FPS, this assumption breaks. How should it be handled?
(Technically, it's not a new problem: Immediately Present XFB could also do that.)

One way to fix it would be using a different type of vsync that doesn't cap the frame rate (Mailbox, a.k.a. Fast Sync). However, AFAIK, only Vulkan supports using it without driver overrides. (Maybe there's something for D3D12, but probably not for D3D11, and OpenGL definitely doesn't.)

### Real Wii Remotes

After a certain frame rate, either motion or infrared reporting (or both) from the Wii Remote stops working in Dolphin.
This seems to affect all games.


NOTE: Previous name was VBI Overclock, which is why some comments refer to it as such.

[^1]: For instance, Skylanders: Swap Force is affected by this. Do note that this happens when the emulated CPU is underclocked, even *without* VBI Frequency.
[^2]: Though, I guess being able to play a game in fast-forward without affecting audio is a use case, assuming the game doesn't depend on audio timings.
[^3]: Something I was thinking is, Dolphin currently has a problem in giving a user the choice of performance vs accuracy. The current situation is that performance is favored, and to get accuracy, the user needs to visit the wiki and manually apply the settings listed there. Whatever system is going to solve this could also be applied here.