### PR TITLE
CachedInterpreterEmitter: Fix `std::memcpy` UB

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreterEmitter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreterEmitter.cpp
@@ -19,6 +19,8 @@ void CachedInterpreterEmitter::Write(AnyCallback callback, const void* operands,
   }
   std::memcpy(m_code, &callback, sizeof(callback));
   m_code += sizeof(callback);
+  if (size == 0)
+    return;
   std::memcpy(m_code, operands, size);
   m_code += size;
 }


### PR DESCRIPTION
I wasn't aware that even with a size of zero, it's still [not safe](https://en.cppreference.com/w/cpp/string/byte/memcpy) to pass a nullptr to `std::memcpy`. When `CachedInterpreterEmitter::PoisonCallback` is written, UB is happening.