### PR TITLE
RFC - Half Pixel Offset for Linear Filter

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2925,8 +2925,10 @@ void TextureCacheBase::CopyEFBToCacheEntry(RcTcacheEntry& entry, bool is_depth_c
   //         Statistically, that could happen.
   const u32 top_coord = clamp_top ? framebuffer_rect.top : 0;
   uniforms.clamp_top = (static_cast<float>(top_coord) + .5f) * rcp_efb_height;
+  uniforms.clamp_top -= uniforms.src_top;
   const u32 bottom_coord = (clamp_bottom ? framebuffer_rect.bottom : efb_height) - 1;
-  uniforms.clamp_bottom = (static_cast<float>(bottom_coord) + .5f) * rcp_efb_height;
+  uniforms.clamp_bottom = (uniforms.src_top + uniforms.src_height);
+  uniforms.clamp_bottom -= (static_cast<float>(bottom_coord) + .5f) * rcp_efb_height;
   uniforms.pixel_height = g_ActiveConfig.bCopyEFBScaled ? rcp_efb_height : 1.0f / EFB_HEIGHT;
   uniforms.padding = 0;
   g_vertex_manager->UploadUtilityUniforms(&uniforms, sizeof(uniforms));
@@ -2974,6 +2976,7 @@ void TextureCacheBase::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams&
   // Fill uniform buffer.
   struct Uniforms
   {
+    float src_left, src_top, src_width, src_height;
     std::array<s32, 4> position_uniform;
     float y_scale;
     float gamma_rcp;
@@ -2983,8 +2986,13 @@ void TextureCacheBase::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams&
     u32 padding;
   };
   Uniforms encoder_params;
+  const float rcp_efb_width = 1.0f / static_cast<float>(g_framebuffer_manager->GetEFBWidth());
   const u32 efb_height = g_framebuffer_manager->GetEFBHeight();
   const float rcp_efb_height = 1.0f / static_cast<float>(efb_height);
+  encoder_params.src_left = framebuffer_rect.left * rcp_efb_width;
+  encoder_params.src_top = framebuffer_rect.top * rcp_efb_height;
+  encoder_params.src_width = framebuffer_rect.GetWidth() * rcp_efb_width;
+  encoder_params.src_height = framebuffer_rect.GetHeight() * rcp_efb_height;
   encoder_params.position_uniform[0] = src_rect.left;
   encoder_params.position_uniform[1] = src_rect.top;
   encoder_params.position_uniform[2] = static_cast<s32>(native_width);
@@ -2998,8 +3006,10 @@ void TextureCacheBase::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams&
   //         Statistically, that could happen.
   const u32 top_coord = clamp_top ? framebuffer_rect.top : 0;
   encoder_params.clamp_top = (static_cast<float>(top_coord) + .5f) * rcp_efb_height;
+  encoder_params.clamp_top -= encoder_params.src_top;
   const u32 bottom_coord = (clamp_bottom ? framebuffer_rect.bottom : efb_height) - 1;
-  encoder_params.clamp_bottom = (static_cast<float>(bottom_coord) + .5f) * rcp_efb_height;
+  encoder_params.clamp_bottom = (encoder_params.src_top + encoder_params.src_height);
+  encoder_params.clamp_bottom -= (static_cast<float>(bottom_coord) + .5f) * rcp_efb_height;
   encoder_params.filter_coefficients = filter_coefficients;
   g_vertex_manager->UploadUtilityUniforms(&encoder_params, sizeof(encoder_params));
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2906,6 +2906,11 @@ void TextureCacheBase::CopyEFBToCacheEntry(RcTcacheEntry& entry, bool is_depth_c
     float clamp_top;
     float clamp_bottom;
     float pixel_height;
+    float rcp_pixel_width;
+    float rcp_pixel_height;
+    float efb_scale;
+    u32 efb_copy_scaled;
+    u32 linear_filter;
     u32 padding;
   };
   Uniforms uniforms;
@@ -2930,6 +2935,11 @@ void TextureCacheBase::CopyEFBToCacheEntry(RcTcacheEntry& entry, bool is_depth_c
   uniforms.clamp_bottom = (uniforms.src_top + uniforms.src_height);
   uniforms.clamp_bottom -= (static_cast<float>(bottom_coord) + .5f) * rcp_efb_height;
   uniforms.pixel_height = g_ActiveConfig.bCopyEFBScaled ? rcp_efb_height : 1.0f / EFB_HEIGHT;
+  uniforms.rcp_pixel_width = rcp_efb_width;
+  uniforms.rcp_pixel_height = rcp_efb_height;
+  uniforms.efb_scale = static_cast<float>(g_framebuffer_manager->GetEFBScale());
+  uniforms.efb_copy_scaled = g_ActiveConfig.bCopyEFBScaled ? 1u : 0u;
+  uniforms.linear_filter = linear_filter ? 1u : 0u;
   uniforms.padding = 0;
   g_vertex_manager->UploadUtilityUniforms(&uniforms, sizeof(uniforms));
 

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -61,6 +61,11 @@ static void WriteHeader(APIType api_type, ShaderCode& out)
             "  float gamma_rcp;\n"
             "  float2 clamp_tb;\n"
             "  float pixel_height;\n"
+            "  float rcp_pixel_width;\n"
+            "  float rcp_pixel_height;\n"
+            "  float efb_scale;\n"
+            "  uint efb_copy_scaled;\n"
+            "  uint linear_filter;\n"
             "}};\n");
 }
 
@@ -106,18 +111,27 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
   out.Write("SAMPLER_BINDING(0) uniform sampler2DArray samp0;\n");
   out.Write("uint4 SampleEFB(float3 uv, float y_offset) {{\n"
             "  float clamp_top = src_offset.y + clamp_tb.x;\n"
-            "  float clamp_bottom = (src_offset.y + src_size.y) - clamp_tb.y;\n");
+            "  float clamp_bottom = (src_offset.y + src_size.y) - clamp_tb.y;\n"
+            "  float shift_x = 0.0f;\n"
+            "  float shift_y = 0.0f;\n");
+
+  // Linear filtering half pixel offset for even IRs
+  out.Write("  if(linear_filter == 1 && efb_copy_scaled == 0 && mod(efb_scale, 2.0f) == 0){{\n"
+            "    shift_x = rcp_pixel_width / 2.f;\n"
+            "    shift_y = rcp_pixel_height / 2.f;\n"
+            "  }}\n");
 
   // Reverse the direction for OpenGL
   if (api_type == APIType::OpenGL)
   {
     out.Write("  clamp_top = src_offset.y + clamp_tb.y;\n"
               "  clamp_bottom = (src_offset.y + src_size.y) - clamp_tb.x;\n"
-              "  y_offset = -y_offset;\n");
+              "  y_offset = -y_offset;\n"
+              "  shift_y = -shift_y;\n");
   }
 
-  out.Write("  float clamp_y = clamp(uv.y + (y_offset * pixel_height), clamp_top, clamp_bottom);\n"
-            "  float4 tex_sample = texture(samp0, float3(uv.x, clamp_y, {}));\n",
+  out.Write("  float clamp_y = clamp(uv.y + shift_y + (y_offset * pixel_height), clamp_top, clamp_bottom);\n"
+            "  float4 tex_sample = texture(samp0, float3(uv.x + shift_x, clamp_y, {}));\n",
             mono_depth ? "0.0" : "uv.z");
 
   if (uid_data->is_depth_copy)


### PR DESCRIPTION
This is just for feedback on approach to tackling the issue with using even IRs with "Scaled EFB Copies" disabled.

It's currently got https://github.com/dolphin-emu/dolphin/pull/12982 included but that commit will be removed when that PR is merged and this will then be rebased on master again.

This fixes the corrupted minimap for Twilight Princess for GC, which is this [issue](https://bugs.dolphin-emu.org/issues/13345), when using odd IRs with "Scaled EFB Copies" disabled.

This also fixes the graphical issues in Sonic Heroes, which is this old [issue](https://bugs.dolphin-emu.org/issues/267), which again occurs with using odd IRs with "Scaled EFB Copies" disabled.