### PR TITLE
GameINI: Remove Broken Cheat from "Paper Mario: The Thousand Year Door"

### DIFF
--- a/Data/Sys/GameSettings/G8ME01.ini
+++ b/Data/Sys/GameSettings/G8ME01.ini
@@ -33,7 +33,5 @@ $Non-Mario Party Members Max/Full Health
 02B07BC4 000203E7
 $Max/Infinite Badge Points
 026EE2D2 00010063
-$Max Gold
-026EE2B8 000003E7
 $Max Shop Points
 026EE7F0 000003E7


### PR DESCRIPTION
This is causing graphical glitches on some sprites, specifically the partner character after loading a game.

![G8ME01_2024-09-03_23-31-50](https://github.com/user-attachments/assets/9904eeed-e839-4491-ac09-ba36c755d355)
