### PR TITLE
SI_Device: Remove Dead Config Code

### DIFF
--- a/Source/Core/Core/HW/SI/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI/SI_Device.cpp
@@ -3,11 +3,8 @@
 
 #include "Core/HW/SI/SI_Device.h"
 
-#include <istream>
 #include <memory>
-#include <ostream>
 #include <string>
-#include <type_traits>
 
 #include <fmt/format.h>
 
@@ -33,28 +30,6 @@ constexpr u64 GC_BITS_PER_SECOND = 200000;
 constexpr u64 GBA_BITS_PER_SECOND = 250000;
 constexpr u64 GC_STOP_BIT_NS = 6500;
 constexpr u64 GBA_STOP_BIT_NS = 14000;
-
-std::ostream& operator<<(std::ostream& stream, SIDevices device)
-{
-  stream << static_cast<std::underlying_type_t<SIDevices>>(device);
-  return stream;
-}
-
-std::istream& operator>>(std::istream& stream, SIDevices& device)
-{
-  std::underlying_type_t<SIDevices> value;
-
-  if (stream >> value)
-  {
-    device = static_cast<SIDevices>(value);
-  }
-  else
-  {
-    device = SIDevices::SIDEVICE_NONE;
-  }
-
-  return stream;
-}
 
 ISIDevice::ISIDevice(Core::System& system, SIDevices device_type, int device_number)
     : m_system(system), m_device_number(device_number), m_device_type(device_type)

--- a/Source/Core/Core/HW/SI/SI_Device.h
+++ b/Source/Core/Core/HW/SI/SI_Device.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <iosfwd>
 #include <memory>
 #include "Common/CommonTypes.h"
 
@@ -106,9 +105,6 @@ enum SIDevices : int
   // Not a valid device. Used for checking whether enum values are valid.
   SIDEVICE_COUNT,
 };
-
-std::ostream& operator<<(std::ostream& stream, SIDevices device);
-std::istream& operator>>(std::istream& stream, SIDevices& device);
 
 class ISIDevice
 {


### PR DESCRIPTION
This PR is just like a previous PR of mine: https://github.com/dolphin-emu/dolphin/pull/12762. I found another instance of dead config code by searching for things like `#include <iosfwd>` and stream operator overloads. This now dead code was originally added by https://github.com/dolphin-emu/dolphin/pull/8418/commits/cfbabd4c4116ed042c8e0002ed480e3f4a3dade3.