### PR TITLE
[ GMS.ini ] Missing Override

### DIFF
--- a/Data/Sys/GameSettings/GMS.ini
+++ b/Data/Sys/GameSettings/GMS.ini
@@ -17,6 +17,7 @@ PerfQueriesEnable = True
 
 [Video_Settings]
 EnableGPUTextureDecoding = False
+# Required for arbitrary mipmap detection to work.
 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GMS.ini
+++ b/Data/Sys/GameSettings/GMS.ini
@@ -15,6 +15,9 @@
 [Video]
 PerfQueriesEnable = True
 
+[Video_Settings]
+EnableGPUTextureDecoding = False
+
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBAccessEnable = True


### PR DESCRIPTION
_[Video_Settings]_
_EnableGPUTextureDecoding = False_

**Missing override that prevents the already present Arbitrary Mipmap Detection override from taking effect if the user's settings enables GPU Texture Decoding.**
~Rebuilding Dolphin to keep it up to date keeps overwriting my personal changes to the .ini file, therefore I propose fixing the issue from the source.~

~(While I'm at it, - _this is only a suggestion/idea_ - but an override override could be useful to keep the base overrides up to date without compromising personal overrides. No obligation to implement that, of course.)~

Thank you.