### PR TITLE
GameSettings: Disable GPU Texture Decoding when needed

### DIFF
--- a/Data/Sys/GameSettings/DAX.ini
+++ b/Data/Sys/GameSettings/DAX.ini
@@ -18,3 +18,8 @@ EFBEmulateFormatChanges = True
 
 [Video_Enhancements]
 ArbitraryMipmapDetection = True
+
+[Video_Settings]
+# Allow the ArbitraryMipmapDetection setting to take effect.
+
+EnableGPUTextureDecoding = False

--- a/Data/Sys/GameSettings/GMS.ini
+++ b/Data/Sys/GameSettings/GMS.ini
@@ -24,5 +24,10 @@ MissingColorValue = 0x00000000
 ForceTextureFiltering = False
 ArbitraryMipmapDetection = True
 
+[Video_Settings]
+# Allow the ArbitraryMipmapDetection setting to take effect.
+
+EnableGPUTextureDecoding = False
+
 [Video_Stereoscopy]
 StereoConvergence = 732

--- a/Data/Sys/GameSettings/GZ2.ini
+++ b/Data/Sys/GameSettings/GZ2.ini
@@ -28,5 +28,9 @@ VISkip = False
 
 CPUCull = True
 
+# Allow the ArbitraryMipmapDetection setting to take effect.
+
+EnableGPUTextureDecoding = False
+
 [Video_Enhancements]
 ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/GZL.ini
+++ b/Data/Sys/GameSettings/GZL.ini
@@ -27,3 +27,8 @@ ArbitraryMipmapDetection = True
 
 [Video_Stereoscopy]
 StereoConvergence = 115
+
+[Video_Settings]
+# Allow the ArbitraryMipmapDetection setting to take effect.
+
+EnableGPUTextureDecoding = False

--- a/Data/Sys/GameSettings/RMG.ini
+++ b/Data/Sys/GameSettings/RMG.ini
@@ -17,3 +17,8 @@ EFBAccessDeferInvalidation = True
 
 [Video_Enhancements]
 ArbitraryMipmapDetection = True
+
+[Video_Settings]
+# Allow the ArbitraryMipmapDetection setting to take effect.
+
+EnableGPUTextureDecoding = False

--- a/Data/Sys/GameSettings/RZD.ini
+++ b/Data/Sys/GameSettings/RZD.ini
@@ -28,5 +28,9 @@ VISkip = False
 
 CPUCull = True
 
+# Allow the ArbitraryMipmapDetection setting to take effect.
+
+EnableGPUTextureDecoding = False
+
 [Video_Enhancements]
 ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/SB4.ini
+++ b/Data/Sys/GameSettings/SB4.ini
@@ -20,3 +20,8 @@ ArbitraryMipmapDetection = True
 
 [Video_Stereoscopy]
 StereoConvergence = 929
+
+[Video_Settings]
+# Allow the ArbitraryMipmapDetection setting to take effect.
+
+EnableGPUTextureDecoding = False

--- a/Data/Sys/GameSettings/SOU.ini
+++ b/Data/Sys/GameSettings/SOU.ini
@@ -16,3 +16,8 @@ EFBEmulateFormatChanges = True
 
 [Video_Enhancements]
 ArbitraryMipmapDetection = True
+
+[Video_Settings]
+# Allow the ArbitraryMipmapDetection setting to take effect.
+
+EnableGPUTextureDecoding = False


### PR DESCRIPTION
Arbitrary Mipmap Detection doesn't work when GPU Texture Decoding is enabled, so disable GPU Texture Decoding for games where the .ini enables Arbitrary Mipmap Detection.

This skips GMS.ini because that's handled in https://github.com/dolphin-emu/dolphin/pull/13056.