### PR TITLE
Don't unlink shared memory on Unix

### DIFF
--- a/Source/Core/Common/MemArenaUnix.cpp
+++ b/Source/Core/Common/MemArenaUnix.cpp
@@ -37,7 +37,6 @@ void MemArena::GrabSHMSegment(size_t size, std::string_view base_name)
     ERROR_LOG_FMT(MEMMAP, "shm_open failed: {}", strerror(errno));
     return;
   }
-  shm_unlink(file_name.c_str());
   if (ftruncate(m_shm_fd, size) < 0)
     ERROR_LOG_FMT(MEMMAP, "Failed to allocate low memory space");
 }


### PR DESCRIPTION
Essentially adds the functionality from PR #6091 to Unix platforms. This allows third party tools like DME and JuniorsToolbox to access the shared memory region allowing them to manipulate game memory for various functionality. To do this, keep the shared memory object mapped to a name so that the other process can access it, instead of unlinking it from the name right after creation. This might leak files into the filesystem, like mentioned in
https://github.com/dolphin-emu/dolphin/pull/9834#discussion_r803123299, but will only be one virtual file per dolphin so I think it's fine.

If the leaking is a problem or there's another reason why it's important to unlink the file most of the time, I could try to make a larger pull request that makes this a flag instead, but since it makes the behavior more consistent with windows I thought I'd try it this way first.

Happy to discuss/improve!