### PR TITLE
Properly Toggle Hardcore When Enabling RA

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -247,11 +247,7 @@ void AchievementSettingsWidget::ToggleRAIntegration()
     instance.Init();
   else
     instance.Shutdown();
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
-  {
-    emit Settings::Instance().EmulationStateChanged(Core::GetState(Core::System::GetInstance()));
-    emit Settings::Instance().HardcoreStateChanged();
-  }
+  ToggleHardcore();
 }
 
 void AchievementSettingsWidget::Login()


### PR DESCRIPTION
Fixes a bug where a player could enable hardcore, disable RetroAchievements integration, show the debug menu, and re-enable the integration to get the debug menu in hardcore.