### PR TITLE
Graphics: Clarify relationship between incompatible settings

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -415,9 +415,9 @@ void AdvancedWidget::AddDescriptions()
       "emulation of texture wrapping special cases (at 1x IR or when scaled EFB is disabled, and "
       "with custom textures disabled) and better emulates Level of Detail calculation.<br><br>"
       "This comes at the cost of potentially worse performance, especially at higher internal "
-      "resolutions; additionally, Anisotropic Filtering is currently incompatible with Manual "
-      "Texture Sampling.<br><br>"
-      "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+      "resolutions.<br><br>If this setting is enabled, the Texture Filtering setting will be "
+      "disabled."
+      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
 #ifdef _WIN32
   static const char TR_BORDERLESS_FULLSCREEN_DESCRIPTION[] = QT_TR_NOOP(

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -546,8 +546,8 @@ void EnhancementsWidget::AddDescriptions()
       "Adjust the texture filtering. Anisotropic filtering enhances the visual quality of textures "
       "that are at oblique viewing angles. Force Nearest and Force Linear override the texture "
       "scaling filter selected by the game.<br><br>Any option except 'Default' will alter the look "
-      "of the game's textures and might cause issues in a small number of "
-      "games.<br><br>This option is incompatible with Manual Texture Sampling.<br><br>"
+      "of the game's textures and might cause issues in a small number of games.<br><br>This "
+      "setting is disabled when Manual Texture Sampling is enabled.<br><br>"
       "<dolphin_emphasis>If unsure, select 'Default'.</dolphin_emphasis>");
   static const char TR_OUTPUT_RESAMPLING_DESCRIPTION[] =
       QT_TR_NOOP("Affects how the game output is scaled to the window resolution."
@@ -645,8 +645,8 @@ void EnhancementsWidget::AddDescriptions()
       "effects.<br><br>May have false positives that result in blurry textures at increased "
       "internal "
       "resolution, such as in games that use very low resolution mipmaps. Disabling this can also "
-      "reduce stutter in games that frequently load new textures. This feature is not compatible "
-      "with GPU Texture Decoding.<br><br><dolphin_emphasis>If unsure, leave this "
+      "reduce stutter in games that frequently load new textures.<br><br>This setting is disabled "
+      "when GPU Texture Decoding is enabled.<br><br><dolphin_emphasis>If unsure, leave this "
       "unchecked.</dolphin_emphasis>");
   static const char TR_HDR_DESCRIPTION[] = QT_TR_NOOP(
       "Enables scRGB HDR output (if supported by your graphics backend and monitor)."

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -268,7 +268,8 @@ void HacksWidget::AddDescriptions()
   static const char TR_GPU_DECODING_DESCRIPTION[] = QT_TR_NOOP(
       "Enables texture decoding using the GPU instead of the CPU.<br><br>This may result in "
       "performance gains in some scenarios, or on systems where the CPU is the "
-      "bottleneck.<br><br>This option is incompatible with Arbitrary Mipmap Detection.<br><br>"
+      "bottleneck.<br><br>If this setting is enabled, Arbitrary Mipmap Detection will be "
+      "disabled.<br><br>"
       "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_FAST_DEPTH_CALC_DESCRIPTION[] = QT_TR_NOOP(
       "Uses a less accurate algorithm to calculate depth values.<br><br>Causes issues in a few "


### PR DESCRIPTION
Explicitly state that Manual Texture Sampling disables the Texture Filtering setting and that GPU Texture Decoding disables Arbitrary Mipmap Detection, rather than just saying they're incompatible.