### PR TITLE
Add ability to edit game-specific GFX settings from game properties tab.

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(dolphin-emu
   Config/ConfigControls/ConfigBool.h
   Config/ConfigControls/ConfigChoice.cpp
   Config/ConfigControls/ConfigChoice.h
+  Config/ConfigControls/ConfigControl.h
   Config/ConfigControls/ConfigInteger.cpp
   Config/ConfigControls/ConfigInteger.h
   Config/ConfigControls/ConfigRadio.cpp

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.cpp
@@ -4,7 +4,13 @@
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 
 ConfigBool::ConfigBool(const QString& label, const Config::Info<bool>& setting, bool reverse)
-    : ConfigControl(label, setting.GetLocation()), m_setting(setting), m_reverse(reverse)
+    : ConfigBool(label, setting, nullptr, reverse)
+{
+}
+
+ConfigBool::ConfigBool(const QString& label, const Config::Info<bool>& setting,
+                       Config::Layer* layer, bool reverse)
+    : ConfigControl(label, setting.GetLocation(), layer), m_setting(setting), m_reverse(reverse)
 {
   setChecked(ReadValue(setting) ^ reverse);
 

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.cpp
@@ -3,31 +3,22 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 
-#include <QEvent>
-#include <QFont>
-#include <QSignalBlocker>
-
-#include "Common/Config/Config.h"
-
-#include "DolphinQt/Settings.h"
-
 ConfigBool::ConfigBool(const QString& label, const Config::Info<bool>& setting, bool reverse)
-    : ToolTipCheckBox(label), m_setting(setting), m_reverse(reverse)
+    : ConfigControl(label, setting.GetLocation()), m_setting(setting), m_reverse(reverse)
 {
+  setChecked(ReadValue(setting) ^ reverse);
+
   connect(this, &QCheckBox::toggled, this, &ConfigBool::Update);
-  setChecked(Config::Get(m_setting) ^ reverse);
-
-  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
-    QFont bf = font();
-    bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
-    setFont(bf);
-
-    const QSignalBlocker blocker(this);
-    setChecked(Config::Get(m_setting) ^ m_reverse);
-  });
 }
 
 void ConfigBool::Update()
 {
-  Config::SetBaseOrCurrent(m_setting, static_cast<bool>(isChecked() ^ m_reverse));
+  const bool value = static_cast<bool>(isChecked() ^ m_reverse);
+
+  SaveValue(m_setting, value);
+}
+
+void ConfigBool::OnConfigChanged()
+{
+  setChecked(ReadValue(m_setting) ^ m_reverse);
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.h
@@ -17,6 +17,8 @@ class ConfigBool final : public ConfigControl<ToolTipCheckBox>
   Q_OBJECT
 public:
   ConfigBool(const QString& label, const Config::Info<bool>& setting, bool reverse = false);
+  ConfigBool(const QString& label, const Config::Info<bool>& setting, Config::Layer* layer,
+             bool reverse = false);
 
 protected:
   void OnConfigChanged() override;

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 
 namespace Config
@@ -11,11 +12,14 @@ template <typename T>
 class Info;
 }
 
-class ConfigBool : public ToolTipCheckBox
+class ConfigBool final : public ConfigControl<ToolTipCheckBox>
 {
   Q_OBJECT
 public:
   ConfigBool(const QString& label, const Config::Info<bool>& setting, bool reverse = false);
+
+protected:
+  void OnConfigChanged() override;
 
 private:
   void Update();

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
@@ -5,85 +5,65 @@
 
 #include <QSignalBlocker>
 
-#include "Common/Config/Config.h"
-
-#include "DolphinQt/Settings.h"
-
 ConfigChoice::ConfigChoice(const QStringList& options, const Config::Info<int>& setting)
-    : m_setting(setting)
+    : ConfigControl(setting.GetLocation()), m_setting(setting)
 {
   addItems(options);
+  setCurrentIndex(ReadValue(setting));
+
   connect(this, &QComboBox::currentIndexChanged, this, &ConfigChoice::Update);
-  setCurrentIndex(Config::Get(m_setting));
-
-  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
-    QFont bf = font();
-    bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
-    setFont(bf);
-
-    const QSignalBlocker blocker(this);
-    setCurrentIndex(Config::Get(m_setting));
-  });
 }
 
 void ConfigChoice::Update(int choice)
 {
-  Config::SetBaseOrCurrent(m_setting, choice);
+  SaveValue(m_setting, choice);
+}
+
+void ConfigChoice::OnConfigChanged()
+{
+  setCurrentIndex(ReadValue(m_setting));
 }
 
 ConfigStringChoice::ConfigStringChoice(const std::vector<std::string>& options,
                                        const Config::Info<std::string>& setting)
-    : m_setting(setting), m_text_is_data(true)
+    : ConfigControl(setting.GetLocation()), m_setting(setting), m_text_is_data(true)
 {
   for (const auto& op : options)
     addItem(QString::fromStdString(op));
 
-  Connect();
   Load();
+  connect(this, &QComboBox::currentIndexChanged, this, &ConfigStringChoice::Update);
 }
 
 ConfigStringChoice::ConfigStringChoice(const std::vector<std::pair<QString, QString>>& options,
                                        const Config::Info<std::string>& setting)
-    : m_setting(setting), m_text_is_data(false)
+    : ConfigControl(setting.GetLocation()), m_setting(setting), m_text_is_data(false)
 {
   for (const auto& [option_text, option_data] : options)
     addItem(option_text, option_data);
 
-  Connect();
-  Load();
-}
-
-void ConfigStringChoice::Connect()
-{
-  const auto on_config_changed = [this]() {
-    QFont bf = font();
-    bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
-    setFont(bf);
-
-    Load();
-  };
-
-  connect(&Settings::Instance(), &Settings::ConfigChanged, this, on_config_changed);
   connect(this, &QComboBox::currentIndexChanged, this, &ConfigStringChoice::Update);
+  Load();
 }
 
 void ConfigStringChoice::Update(int index)
 {
   if (m_text_is_data)
-  {
-    Config::SetBaseOrCurrent(m_setting, itemText(index).toStdString());
-  }
+    SaveValue(m_setting, itemText(index).toStdString());
   else
-  {
-    Config::SetBaseOrCurrent(m_setting, itemData(index).toString().toStdString());
-  }
+    SaveValue(m_setting, itemData(index).toString().toStdString());
 }
 
 void ConfigStringChoice::Load()
 {
-  const QString setting_value = QString::fromStdString(Config::Get(m_setting));
+  const QString setting_value = QString::fromStdString(ReadValue(m_setting));
 
   const int index = m_text_is_data ? findText(setting_value) : findData(setting_value);
   const QSignalBlocker blocker(this);
   setCurrentIndex(index);
+}
+
+void ConfigStringChoice::OnConfigChanged()
+{
+  Load();
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
@@ -5,8 +5,9 @@
 
 #include <QSignalBlocker>
 
-ConfigChoice::ConfigChoice(const QStringList& options, const Config::Info<int>& setting)
-    : ConfigControl(setting.GetLocation()), m_setting(setting)
+ConfigChoice::ConfigChoice(const QStringList& options, const Config::Info<int>& setting,
+                           Config::Layer* layer)
+    : ConfigControl(setting.GetLocation(), layer), m_setting(setting)
 {
   addItems(options);
   setCurrentIndex(ReadValue(setting));
@@ -25,8 +26,9 @@ void ConfigChoice::OnConfigChanged()
 }
 
 ConfigStringChoice::ConfigStringChoice(const std::vector<std::string>& options,
-                                       const Config::Info<std::string>& setting)
-    : ConfigControl(setting.GetLocation()), m_setting(setting), m_text_is_data(true)
+                                       const Config::Info<std::string>& setting,
+                                       Config::Layer* layer)
+    : ConfigControl(setting.GetLocation(), layer), m_setting(setting), m_text_is_data(true)
 {
   for (const auto& op : options)
     addItem(QString::fromStdString(op));
@@ -36,8 +38,9 @@ ConfigStringChoice::ConfigStringChoice(const std::vector<std::string>& options,
 }
 
 ConfigStringChoice::ConfigStringChoice(const std::vector<std::pair<QString, QString>>& options,
-                                       const Config::Info<std::string>& setting)
-    : ConfigControl(setting.GetLocation()), m_setting(setting), m_text_is_data(false)
+                                       const Config::Info<std::string>& setting,
+                                       Config::Layer* layer)
+    : ConfigControl(setting.GetLocation(), layer), m_setting(setting), m_text_is_data(false)
 {
   for (const auto& [option_text, option_data] : options)
     addItem(option_text, option_data);
@@ -57,9 +60,10 @@ void ConfigStringChoice::Update(int index)
 void ConfigStringChoice::Load()
 {
   const QString setting_value = QString::fromStdString(ReadValue(m_setting));
-
   const int index = m_text_is_data ? findText(setting_value) : findData(setting_value);
-  const QSignalBlocker blocker(this);
+
+  // This can be called publicly.
+  const QSignalBlocker block(this);
   setCurrentIndex(index);
 }
 

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
@@ -71,3 +71,102 @@ void ConfigStringChoice::OnConfigChanged()
 {
   Load();
 }
+
+ConfigComplexChoice::ConfigComplexChoice(const InfoVariant setting1, const InfoVariant setting2,
+                                         Config::Layer* layer)
+    : m_setting1(setting1), m_setting2(setting2), m_layer(layer)
+{
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, &ConfigComplexChoice::Refresh);
+  connect(this, &QComboBox::currentIndexChanged, this, &ConfigComplexChoice::SaveValue);
+}
+
+void ConfigComplexChoice::Refresh()
+{
+  auto& location = GetLocation();
+
+  QFont bf = font();
+  if (m_layer != nullptr)
+  {
+    bf.setBold(m_layer->Exists(location.first) || m_layer->Exists(location.second));
+  }
+  else
+  {
+    bf.setBold(Config::GetActiveLayerForConfig(location.first) != Config::LayerType::Base ||
+               Config::GetActiveLayerForConfig(location.second) != Config::LayerType::Base);
+  }
+
+  setFont(bf);
+  UpdateComboIndex();
+}
+
+void ConfigComplexChoice::Add(const QString& name, const OptionVariant option1,
+                              const OptionVariant option2)
+{
+  const QSignalBlocker blocker(this);
+  addItem(name);
+  m_options.push_back(std::make_pair(option1, option2));
+}
+
+void ConfigComplexChoice::Reset()
+{
+  clear();
+  m_options.clear();
+}
+
+void ConfigComplexChoice::SaveValue(int choice)
+{
+  auto Set = [this, choice](auto& setting, auto& value) {
+    if (m_layer != nullptr)
+    {
+      m_layer->Set(setting.GetLocation(), value);
+      Config::OnConfigChanged();
+      return;
+    }
+
+    Config::SetBaseOrCurrent(setting, value);
+  };
+
+  std::visit(Set, m_setting1, m_options[choice].first);
+  std::visit(Set, m_setting2, m_options[choice].second);
+}
+
+void ConfigComplexChoice::UpdateComboIndex()
+{
+  auto Get = [this](auto& setting) {
+    if (m_layer != nullptr)
+      return static_cast<OptionVariant>(m_layer->Get(setting));
+
+    return static_cast<OptionVariant>(Config::Get(setting));
+  };
+
+  std::pair<OptionVariant, OptionVariant> values =
+      std::make_pair(std::visit(Get, m_setting1), std::visit(Get, m_setting2));
+
+  auto it = std::find(m_options.begin(), m_options.end(), values);
+  int index = static_cast<int>(std::distance(m_options.begin(), it));
+
+  const QSignalBlocker blocker(this);
+  setCurrentIndex(index);
+}
+
+const std::pair<Config::Location, Config::Location> ConfigComplexChoice::GetLocation() const
+{
+  auto visit = [](auto& v) { return v.GetLocation(); };
+
+  return {std::visit(visit, m_setting1), std::visit(visit, m_setting2)};
+}
+
+void ConfigComplexChoice::mousePressEvent(QMouseEvent* event)
+{
+  if (event->button() == Qt::RightButton && m_layer != nullptr)
+  {
+    auto& location = GetLocation();
+    m_layer->DeleteKey(location.first);
+    m_layer->DeleteKey(location.second);
+    Config::OnConfigChanged();
+  }
+  else
+  {
+    QComboBox::mousePressEvent(event);
+  }
+};

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
@@ -7,15 +7,23 @@
 #include <utility>
 #include <vector>
 
+#include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
 
-#include "Common/Config/Config.h"
+namespace Config
+{
+template <typename T>
+class Info;
+}
 
-class ConfigChoice : public ToolTipComboBox
+class ConfigChoice final : public ConfigControl<ToolTipComboBox>
 {
   Q_OBJECT
 public:
   ConfigChoice(const QStringList& options, const Config::Info<int>& setting);
+
+protected:
+  void OnConfigChanged() override;
 
 private:
   void Update(int choice);
@@ -23,7 +31,7 @@ private:
   Config::Info<int> m_setting;
 };
 
-class ConfigStringChoice : public ToolTipComboBox
+class ConfigStringChoice final : public ConfigControl<ToolTipComboBox>
 {
   Q_OBJECT
 public:
@@ -32,11 +40,13 @@ public:
   ConfigStringChoice(const std::vector<std::pair<QString, QString>>& options,
                      const Config::Info<std::string>& setting);
 
+protected:
+  void OnConfigChanged() override;
+
 private:
-  void Connect();
   void Update(int index);
   void Load();
 
-  Config::Info<std::string> m_setting;
+  const Config::Info<std::string>& m_setting;
   bool m_text_is_data = false;
 };

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
@@ -51,3 +51,30 @@ private:
   const Config::Info<std::string>& m_setting;
   bool m_text_is_data = false;
 };
+
+class ConfigComplexChoice final : public ToolTipComboBox
+{
+  Q_OBJECT
+
+  using InfoVariant = std::variant<Config::Info<u32>, Config::Info<int>, Config::Info<bool>>;
+  using OptionVariant = std::variant<u32, int, bool>;
+
+public:
+  ConfigComplexChoice(const InfoVariant setting1, const InfoVariant setting2,
+                      Config::Layer* layer = nullptr);
+
+  void Add(const QString& name, const OptionVariant option1, const OptionVariant option2);
+  void Refresh();
+  void Reset();
+  const std::pair<Config::Location, Config::Location> GetLocation() const;
+
+private:
+  void SaveValue(int choice);
+  void UpdateComboIndex();
+  void mousePressEvent(QMouseEvent* event) override;
+
+  Config::Layer* m_layer;
+  const InfoVariant m_setting1;
+  const InfoVariant m_setting2;
+  std::vector<std::pair<OptionVariant, OptionVariant>> m_options;
+};

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
@@ -20,7 +20,8 @@ class ConfigChoice final : public ConfigControl<ToolTipComboBox>
 {
   Q_OBJECT
 public:
-  ConfigChoice(const QStringList& options, const Config::Info<int>& setting);
+  ConfigChoice(const QStringList& options, const Config::Info<int>& setting,
+               Config::Layer* layer = nullptr);
 
 protected:
   void OnConfigChanged() override;
@@ -36,16 +37,16 @@ class ConfigStringChoice final : public ConfigControl<ToolTipComboBox>
   Q_OBJECT
 public:
   ConfigStringChoice(const std::vector<std::string>& options,
-                     const Config::Info<std::string>& setting);
+                     const Config::Info<std::string>& setting, Config::Layer* layer = nullptr);
   ConfigStringChoice(const std::vector<std::pair<QString, QString>>& options,
-                     const Config::Info<std::string>& setting);
+                     const Config::Info<std::string>& setting, Config::Layer* layer = nullptr);
+  void Load();
 
 protected:
   void OnConfigChanged() override;
 
 private:
   void Update(int index);
-  void Load();
 
   const Config::Info<std::string>& m_setting;
   bool m_text_is_data = false;

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigControl.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigControl.h
@@ -1,0 +1,72 @@
+// Copyright 2024 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QFont>
+#include <QMouseEvent>
+#include <QSignalBlocker>
+
+#include "Common/Config/Enums.h"
+#include "DolphinQt/Settings.h"
+
+namespace Config
+{
+template <typename T>
+class Info;
+struct Location;
+}  // namespace Config
+
+template <class Derived>
+class ConfigControl : public Derived
+{
+public:
+  ConfigControl(const Config::Location& location) : m_location(location) { ConnectConfig(); }
+  ConfigControl(const QString& label, const Config::Location& location)
+      : Derived(label), m_location(location)
+  {
+    ConnectConfig();
+  }
+  ConfigControl(const Qt::Orientation& orient, const Config::Location& location)
+      : Derived(orient), m_location(location)
+  {
+    ConnectConfig();
+  }
+
+  const Config::Location GetLocation() const { return m_location; }
+
+protected:
+  void ConnectConfig()
+  {
+    Derived::connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
+      QFont bf = Derived::font();
+      bf.setBold(IsConfigLocal());
+      Derived::setFont(bf);
+
+      const QSignalBlocker blocker(this);
+      OnConfigChanged();
+    });
+  }
+
+  template <typename T>
+  void SaveValue(const Config::Info<T>& setting, const T& value)
+  {
+    Config::SetBaseOrCurrent(setting, value);
+  }
+
+  template <typename T>
+  const T ReadValue(const Config::Info<T>& setting) const
+  {
+    return Config::Get(setting);
+  }
+
+  virtual void OnConfigChanged() {};
+
+private:
+  bool IsConfigLocal() const
+  {
+    return Config::GetActiveLayerForConfig(m_location) != Config::LayerType::Base;
+  }
+
+  const Config::Location m_location;
+};

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.cpp
@@ -3,20 +3,15 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigFloatSlider.h"
 
-#include <QSignalBlocker>
-
-#include "Common/Config/Config.h"
-
-#include "DolphinQt/Settings.h"
-
 ConfigFloatSlider::ConfigFloatSlider(float minimum, float maximum,
                                      const Config::Info<float>& setting, float step)
-    : ToolTipSlider(Qt::Horizontal), m_minimum(minimum), m_step(step), m_setting(setting)
+    : ConfigControl(Qt::Horizontal, setting.GetLocation()), m_minimum(minimum), m_step(step),
+      m_setting(setting)
 {
   const float range = maximum - minimum;
   const int steps = std::round(range / step);
   const int interval = std::round(range / steps);
-  const int current_value = std::round((Config::Get(m_setting) - minimum) / step);
+  const int current_value = std::round((ReadValue(setting) - minimum) / step);
 
   setMinimum(0);
   setMaximum(steps);
@@ -24,25 +19,21 @@ ConfigFloatSlider::ConfigFloatSlider(float minimum, float maximum,
   setValue(current_value);
 
   connect(this, &ConfigFloatSlider::valueChanged, this, &ConfigFloatSlider::Update);
-
-  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
-    QFont bf = font();
-    bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
-    setFont(bf);
-
-    const QSignalBlocker blocker(this);
-    const int value = std::round((Config::Get(m_setting) - m_minimum) / m_step);
-    setValue(value);
-  });
 }
 
 void ConfigFloatSlider::Update(int value)
 {
   const float current_value = (m_step * value) + m_minimum;
-  Config::SetBaseOrCurrent(m_setting, current_value);
+
+  SaveValue(m_setting, current_value);
 }
 
 float ConfigFloatSlider::GetValue() const
 {
   return (m_step * value()) + m_minimum;
+}
+
+void ConfigFloatSlider::OnConfigChanged()
+{
+  setValue(std::round((ReadValue(m_setting) - m_minimum) / m_step));
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.cpp
@@ -4,8 +4,9 @@
 #include "DolphinQt/Config/ConfigControls/ConfigFloatSlider.h"
 
 ConfigFloatSlider::ConfigFloatSlider(float minimum, float maximum,
-                                     const Config::Info<float>& setting, float step)
-    : ConfigControl(Qt::Horizontal, setting.GetLocation()), m_minimum(minimum), m_step(step),
+                                     const Config::Info<float>& setting, float step,
+                                     Config::Layer* layer)
+    : ConfigControl(Qt::Horizontal, setting.GetLocation(), layer), m_minimum(minimum), m_step(step),
       m_setting(setting)
 {
   const float range = maximum - minimum;

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
@@ -18,7 +18,8 @@ class ConfigFloatSlider final : public ConfigControl<ToolTipSlider>
 {
   Q_OBJECT
 public:
-  ConfigFloatSlider(float minimum, float maximum, const Config::Info<float>& setting, float step);
+  ConfigFloatSlider(float minimum, float maximum, const Config::Info<float>& setting, float step,
+                    Config::Layer* layer = nullptr);
   void Update(int value);
 
   // Returns the adjusted float value

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
 
 namespace Config
@@ -13,7 +14,7 @@ class Info;
 
 // Automatically converts an int slider into a float one.
 // Do not read the int values or ranges directly from it.
-class ConfigFloatSlider : public ToolTipSlider
+class ConfigFloatSlider final : public ConfigControl<ToolTipSlider>
 {
   Q_OBJECT
 public:
@@ -22,6 +23,9 @@ public:
 
   // Returns the adjusted float value
   float GetValue() const;
+
+protected:
+  void OnConfigChanged() override;
 
 private:
   float m_minimum;

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
@@ -29,3 +29,13 @@ void ConfigInteger::OnConfigChanged()
 {
   setValue(ReadValue(m_setting));
 }
+
+ConfigIntegerLabel::ConfigIntegerLabel(const QString& text, ConfigInteger* widget)
+    : QLabel(text), m_widget(QPointer<ConfigInteger>(widget))
+{
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this]() {
+    // Label shares font changes with ConfigInteger to mark game ini settings.
+    if (m_widget)
+      setFont(m_widget->font());
+  });
+}

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
@@ -3,33 +3,23 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigInteger.h"
 
-#include <QSignalBlocker>
-
-#include "Common/Config/Config.h"
-
-#include "DolphinQt/Settings.h"
-
 ConfigInteger::ConfigInteger(int minimum, int maximum, const Config::Info<int>& setting, int step)
-    : ToolTipSpinBox(), m_setting(setting)
+    : ConfigControl(setting.GetLocation()), m_setting(setting)
 {
   setMinimum(minimum);
   setMaximum(maximum);
   setSingleStep(step);
-
-  setValue(Config::Get(setting));
+  setValue(ReadValue(setting));
 
   connect(this, &ConfigInteger::valueChanged, this, &ConfigInteger::Update);
-  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
-    QFont bf = font();
-    bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
-    setFont(bf);
-
-    const QSignalBlocker blocker(this);
-    setValue(Config::Get(m_setting));
-  });
 }
 
 void ConfigInteger::Update(int value)
 {
-  Config::SetBaseOrCurrent(m_setting, value);
+  SaveValue(m_setting, value);
+}
+
+void ConfigInteger::OnConfigChanged()
+{
+  setValue(ReadValue(m_setting));
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.cpp
@@ -4,7 +4,13 @@
 #include "DolphinQt/Config/ConfigControls/ConfigInteger.h"
 
 ConfigInteger::ConfigInteger(int minimum, int maximum, const Config::Info<int>& setting, int step)
-    : ConfigControl(setting.GetLocation()), m_setting(setting)
+    : ConfigInteger(minimum, maximum, setting, nullptr, step)
+{
+}
+
+ConfigInteger::ConfigInteger(int minimum, int maximum, const Config::Info<int>& setting,
+                             Config::Layer* layer, int step)
+    : ConfigControl(setting.GetLocation(), layer), m_setting(setting)
 {
   setMinimum(minimum);
   setMaximum(maximum);

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSpinBox.h"
 
 namespace Config
@@ -11,12 +12,15 @@ template <typename T>
 class Info;
 }
 
-class ConfigInteger : public ToolTipSpinBox
+class ConfigInteger final : public ConfigControl<ToolTipSpinBox>
 {
   Q_OBJECT
 public:
   ConfigInteger(int minimum, int maximum, const Config::Info<int>& setting, int step = 1);
   void Update(int value);
+
+protected:
+  void OnConfigChanged() override;
 
 private:
   const Config::Info<int>& m_setting;

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <QLabel>
+#include <QPointer>
+
 #include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSpinBox.h"
 
@@ -27,4 +30,15 @@ protected:
 
 private:
   const Config::Info<int>& m_setting;
+};
+
+class ConfigIntegerLabel final : public QLabel
+{
+  Q_OBJECT
+
+public:
+  ConfigIntegerLabel(const QString& text, ConfigInteger* widget);
+
+private:
+  QPointer<ConfigInteger> m_widget;
 };

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
@@ -17,6 +17,9 @@ class ConfigInteger final : public ConfigControl<ToolTipSpinBox>
   Q_OBJECT
 public:
   ConfigInteger(int minimum, int maximum, const Config::Info<int>& setting, int step = 1);
+  ConfigInteger(int minimum, int maximum, const Config::Info<int>& setting, Config::Layer* layer,
+                int step = 1);
+
   void Update(int value);
 
 protected:

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
@@ -3,37 +3,29 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
 
-#include <QSignalBlocker>
-
-#include "Common/Config/Config.h"
-
-#include "DolphinQt/Settings.h"
-
 ConfigRadioInt::ConfigRadioInt(const QString& label, const Config::Info<int>& setting, int value)
-    : ToolTipRadioButton(label), m_setting(setting), m_value(value)
+    : ConfigControl(label, setting.GetLocation()), m_setting(setting), m_value(value)
 {
-  setChecked(Config::Get(m_setting) == m_value);
+  setChecked(ReadValue(setting) == value);
+
   connect(this, &QRadioButton::toggled, this, &ConfigRadioInt::Update);
-
-  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
-    QFont bf = font();
-    bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
-    setFont(bf);
-
-    const QSignalBlocker blocker(this);
-    setChecked(Config::Get(m_setting) == m_value);
-  });
 }
 
 void ConfigRadioInt::Update()
 {
   if (isChecked())
   {
-    Config::SetBaseOrCurrent(m_setting, m_value);
+    SaveValue(m_setting, m_value);
+
     emit OnSelected(m_value);
   }
   else
   {
     emit OnDeselected(m_value);
   }
+}
+
+void ConfigRadioInt::OnConfigChanged()
+{
+  setChecked(ReadValue(m_setting) == m_value);
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
@@ -3,8 +3,9 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
 
-ConfigRadioInt::ConfigRadioInt(const QString& label, const Config::Info<int>& setting, int value)
-    : ConfigControl(label, setting.GetLocation()), m_setting(setting), m_value(value)
+ConfigRadioInt::ConfigRadioInt(const QString& label, const Config::Info<int>& setting, int value,
+                               Config::Layer* layer)
+    : ConfigControl(label, setting.GetLocation(), layer), m_setting(setting), m_value(value)
 {
   setChecked(ReadValue(setting) == value);
 

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
@@ -3,11 +3,16 @@
 
 #pragma once
 
+#include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipRadioButton.h"
 
-#include "Common/Config/Config.h"
+namespace Config
+{
+template <typename T>
+class Info;
+}
 
-class ConfigRadioInt : public ToolTipRadioButton
+class ConfigRadioInt final : public ConfigControl<ToolTipRadioButton>
 {
   Q_OBJECT
 public:
@@ -19,9 +24,12 @@ signals:
   void OnSelected(int new_value);
   void OnDeselected(int old_value);
 
+protected:
+  void OnConfigChanged() override;
+
 private:
   void Update();
 
-  Config::Info<int> m_setting;
+  const Config::Info<int>& m_setting;
   int m_value;
 };

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
@@ -16,7 +16,8 @@ class ConfigRadioInt final : public ConfigControl<ToolTipRadioButton>
 {
   Q_OBJECT
 public:
-  ConfigRadioInt(const QString& label, const Config::Info<int>& setting, int value);
+  ConfigRadioInt(const QString& label, const Config::Info<int>& setting, int value,
+                 Config::Layer* layer = nullptr);
 
 signals:
   // Since selecting a new radio button deselects the old one, ::toggled will generate two signals.

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
@@ -3,34 +3,24 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
 
-#include <QSignalBlocker>
-
-#include "Common/Config/Config.h"
-
-#include "DolphinQt/Settings.h"
-
 ConfigSlider::ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting, int tick)
-    : ToolTipSlider(Qt::Horizontal), m_setting(setting)
+    : ConfigControl(Qt::Horizontal, setting.GetLocation()), m_setting(setting)
+
 {
   setMinimum(minimum);
   setMaximum(maximum);
   setTickInterval(tick);
-
-  setValue(Config::Get(setting));
+  setValue(ReadValue(setting));
 
   connect(this, &ConfigSlider::valueChanged, this, &ConfigSlider::Update);
-
-  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
-    QFont bf = font();
-    bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
-    setFont(bf);
-
-    const QSignalBlocker blocker(this);
-    setValue(Config::Get(m_setting));
-  });
 }
 
 void ConfigSlider::Update(int value)
 {
-  Config::SetBaseOrCurrent(m_setting, value);
+  SaveValue(m_setting, value);
+}
+
+void ConfigSlider::OnConfigChanged()
+{
+  setValue(ReadValue(m_setting));
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
@@ -1,7 +1,10 @@
 // Copyright 2017 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <QFont>
+
 #include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
+#include "DolphinQt/Settings.h"
 
 ConfigSlider::ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting, int tick)
     : ConfigSlider(minimum, maximum, setting, nullptr, tick)
@@ -29,4 +32,14 @@ void ConfigSlider::Update(int value)
 void ConfigSlider::OnConfigChanged()
 {
   setValue(ReadValue(m_setting));
+}
+
+ConfigSliderLabel::ConfigSliderLabel(const QString& text, ConfigSlider* slider)
+    : QLabel(text), m_slider(QPointer<ConfigSlider>(slider))
+{
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this]() {
+    // Label shares font changes with slider to mark game ini settings.
+    if (m_slider)
+      setFont(m_slider->font());
+  });
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
@@ -4,7 +4,13 @@
 #include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
 
 ConfigSlider::ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting, int tick)
-    : ConfigControl(Qt::Horizontal, setting.GetLocation()), m_setting(setting)
+    : ConfigSlider(minimum, maximum, setting, nullptr, tick)
+{
+}
+
+ConfigSlider::ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting,
+                           Config::Layer* layer, int tick)
+    : ConfigControl(Qt::Horizontal, setting.GetLocation(), layer), m_setting(setting)
 
 {
   setMinimum(minimum);

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
 
 namespace Config
@@ -11,12 +12,15 @@ template <typename T>
 class Info;
 }
 
-class ConfigSlider : public ToolTipSlider
+class ConfigSlider final : public ConfigControl<ToolTipSlider>
 {
   Q_OBJECT
 public:
   ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting, int tick = 0);
   void Update(int value);
+
+protected:
+  void OnConfigChanged() override;
 
 private:
   const Config::Info<int>& m_setting;

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
@@ -17,6 +17,9 @@ class ConfigSlider final : public ConfigControl<ToolTipSlider>
   Q_OBJECT
 public:
   ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting, int tick = 0);
+  ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting, Config::Layer* layer,
+               int tick = 0);
+
   void Update(int value);
 
 protected:

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <QLabel>
+#include <QPointer>
+
 #include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
 
@@ -27,4 +30,15 @@ protected:
 
 private:
   const Config::Info<int>& m_setting;
+};
+
+class ConfigSliderLabel final : public QLabel
+{
+  Q_OBJECT
+
+public:
+  ConfigSliderLabel(const QString& text, ConfigSlider* slider);
+
+private:
+  QPointer<ConfigSlider> m_slider;
 };

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -363,4 +363,15 @@ void GameConfigWidget::SetItalics()
     italics(config);
   for (auto* config : findChildren<ConfigStringChoice*>())
     italics(config);
+
+  for (auto* config : findChildren<ConfigComplexChoice*>())
+  {
+    std::pair<Config::Location, Config::Location> location = config->GetLocation();
+    if (m_global_layer->Exists(location.first) || m_global_layer->Exists(location.second))
+    {
+      QFont ifont = config->font();
+      ifont.setItalic(true);
+      config->setFont(ifont);
+    }
+  }
 }

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -152,9 +152,11 @@ void GameConfigWidget::CreateWidgets()
   m_use_monoscopic_shadows->setToolTip(
       tr("Use a single depth buffer for both eyes. Needed for a few games."));
 
-  stereoscopy_layout->addWidget(new QLabel(tr("Depth Percentage:")), 0, 0);
+  stereoscopy_layout->addWidget(new ConfigSliderLabel(tr("Depth Percentage:"), m_depth_slider), 0,
+                                0);
   stereoscopy_layout->addWidget(m_depth_slider, 0, 1);
-  stereoscopy_layout->addWidget(new QLabel(tr("Convergence:")), 1, 0);
+  stereoscopy_layout->addWidget(new ConfigIntegerLabel(tr("Convergence:"), m_convergence_spin), 1,
+                                0);
   stereoscopy_layout->addWidget(m_convergence_spin, 1, 1);
   stereoscopy_layout->addWidget(m_use_monoscopic_shadows, 2, 0);
 

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.h
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.h
@@ -7,19 +7,21 @@
 
 #include <QString>
 #include <QWidget>
-
-#include "Common/IniFile.h"
-
 namespace UICommon
 {
 class GameFile;
 }
 
-class QCheckBox;
-class QComboBox;
+namespace Config
+{
+class Layer;
+}  // namespace Config
+
+class ConfigBool;
+class ConfigInteger;
+class ConfigSlider;
+class ConfigStringChoice;
 class QPushButton;
-class QSlider;
-class QSpinBox;
 class QTabWidget;
 
 class GameConfigWidget : public QWidget
@@ -27,45 +29,33 @@ class GameConfigWidget : public QWidget
   Q_OBJECT
 public:
   explicit GameConfigWidget(const UICommon::GameFile& game);
+  ~GameConfigWidget();
 
 private:
   void CreateWidgets();
-  void ConnectWidgets();
-
   void LoadSettings();
-  void SaveSettings();
+  void SetItalics();
 
-  void SaveCheckBox(QCheckBox* checkbox, const std::string& section, const std::string& key,
-                    bool reverse = false);
-  void LoadCheckBox(QCheckBox* checkbox, const std::string& section, const std::string& key,
-                    bool reverse = false);
-
-  QString m_gameini_sys_path;
   QString m_gameini_local_path;
 
   QTabWidget* m_default_tab;
   QTabWidget* m_local_tab;
 
-  QCheckBox* m_enable_dual_core;
-  QCheckBox* m_enable_mmu;
-  QCheckBox* m_enable_fprf;
-  QCheckBox* m_sync_gpu;
-  QCheckBox* m_emulate_disc_speed;
-  QCheckBox* m_use_dsp_hle;
-  QCheckBox* m_use_monoscopic_shadows;
-  QCheckBox* m_manual_texture_sampling;
+  ConfigBool* m_enable_dual_core;
+  ConfigBool* m_enable_mmu;
+  ConfigBool* m_enable_fprf;
+  ConfigBool* m_sync_gpu;
+  ConfigBool* m_emulate_disc_speed;
+  ConfigBool* m_use_dsp_hle;
+  ConfigBool* m_use_monoscopic_shadows;
 
-  QPushButton* m_refresh_config;
-
-  QComboBox* m_deterministic_dual_core;
-
-  QSlider* m_depth_slider;
-
-  QSpinBox* m_convergence_spin;
+  ConfigStringChoice* m_deterministic_dual_core;
+  ConfigSlider* m_depth_slider;
+  ConfigInteger* m_convergence_spin;
 
   const UICommon::GameFile& m_game;
   std::string m_game_id;
-
-  Common::IniFile m_gameini_local;
-  Common::IniFile m_gameini_default;
+  std::unique_ptr<Config::Layer> m_layer;
+  std::unique_ptr<Config::Layer> m_global_layer;
+  int m_prev_tab_index = 0;
 };

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -8,22 +8,22 @@
 class ConfigBool;
 class ConfigChoice;
 class ConfigInteger;
+class GameConfigWidget;
 class GraphicsWindow;
-class QCheckBox;
-class QComboBox;
-class QSpinBox;
-class ToolTipCheckBox;
+
+namespace Config
+{
+class Layer;
+}  // namespace Config
 
 class AdvancedWidget final : public QWidget
 {
   Q_OBJECT
 public:
   explicit AdvancedWidget(GraphicsWindow* parent);
+  AdvancedWidget(GameConfigWidget* parent, Config::Layer* layer);
 
 private:
-  void LoadSettings();
-  void SaveSettings();
-
   void CreateWidgets();
   void ConnectWidgets();
   void AddDescriptions();
@@ -52,7 +52,7 @@ private:
   ConfigBool* m_dump_xfb_target;
   ConfigBool* m_disable_vram_copies;
   ConfigBool* m_load_custom_textures;
-  ToolTipCheckBox* m_enable_graphics_mods;
+  ConfigBool* m_enable_graphics_mods;
 
   // Texture dumping
   ConfigBool* m_dump_textures;
@@ -67,7 +67,7 @@ private:
 
   // Misc
   ConfigBool* m_enable_cropping;
-  ToolTipCheckBox* m_enable_prog_scan;
+  ConfigBool* m_enable_prog_scan;
   ConfigBool* m_backend_multithreading;
   ConfigBool* m_prefer_vs_for_point_line_expansion;
   ConfigBool* m_cpu_cull;
@@ -76,4 +76,6 @@ private:
   // Experimental
   ConfigBool* m_defer_efb_access_invalidation;
   ConfigBool* m_manual_texture_sampling;
+
+  Config::Layer* m_game_layer = nullptr;
 };

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -236,9 +236,9 @@ void EnhancementsWidget::CreateWidgets()
 
   stereoscopy_layout->addWidget(new QLabel(tr("Stereoscopic 3D Mode:")), 0, 0);
   stereoscopy_layout->addWidget(m_3d_mode, 0, 1);
-  stereoscopy_layout->addWidget(new QLabel(tr("Depth:")), 1, 0);
+  stereoscopy_layout->addWidget(new ConfigSliderLabel(tr("Depth:"), m_3d_depth), 1, 0);
   stereoscopy_layout->addWidget(m_3d_depth, 1, 1);
-  stereoscopy_layout->addWidget(new QLabel(tr("Convergence:")), 2, 0);
+  stereoscopy_layout->addWidget(new ConfigSliderLabel(tr("Convergence:"), m_3d_convergence), 2, 0);
   stereoscopy_layout->addWidget(m_3d_convergence, 2, 1);
   stereoscopy_layout->addWidget(m_3d_swap_eyes, 3, 0);
   stereoscopy_layout->addWidget(m_3d_per_eye_resolution, 4, 0);

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -11,6 +11,8 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
+#include "Common/CommonTypes.h"
+
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
 
@@ -32,40 +34,43 @@
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
-EnhancementsWidget::EnhancementsWidget(GraphicsWindow* parent) : m_block_save(false)
+EnhancementsWidget::EnhancementsWidget(GraphicsWindow* parent)
 {
   CreateWidgets();
-  LoadSettings();
+  LoadPPShaders();
   ConnectWidgets();
   AddDescriptions();
-  connect(parent, &GraphicsWindow::BackendChanged,
-          [this](const QString& backend) { LoadSettings(); });
-  connect(parent, &GraphicsWindow::UseFastTextureSamplingChanged, this,
-          &EnhancementsWidget::LoadSettings);
-  connect(parent, &GraphicsWindow::UseGPUTextureDecodingChanged, this,
-          &EnhancementsWidget::LoadSettings);
+
+  // BackendChanged is called by parent on window creation.
+  connect(parent, &GraphicsWindow::BackendChanged, this, &EnhancementsWidget::OnBackendChanged);
+  connect(parent, &GraphicsWindow::UseFastTextureSamplingChanged, this, [this]() {
+    m_texture_filtering_combo->setEnabled(ReadSetting(Config::GFX_HACK_FAST_TEXTURE_SAMPLING));
+  });
+  connect(parent, &GraphicsWindow::UseGPUTextureDecodingChanged, this, [this]() {
+    m_arbitrary_mipmap_detection->setEnabled(!ReadSetting(Config::GFX_ENABLE_GPU_TEXTURE_DECODING));
+  });
 }
 
 EnhancementsWidget::EnhancementsWidget(GameConfigWidget* parent, Config::Layer* layer)
     : m_game_layer(layer)
 {
   CreateWidgets();
-  LoadSettings();
+  LoadPPShaders();
   ConnectWidgets();
   AddDescriptions();
+
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this,
+          &EnhancementsWidget::OnConfigChanged);
 }
 
-constexpr int TEXTURE_FILTERING_DEFAULT = 0;
-constexpr int TEXTURE_FILTERING_ANISO_2X = 1;
-constexpr int TEXTURE_FILTERING_ANISO_4X = 2;
-constexpr int TEXTURE_FILTERING_ANISO_8X = 3;
-constexpr int TEXTURE_FILTERING_ANISO_16X = 4;
-constexpr int TEXTURE_FILTERING_FORCE_NEAREST = 5;
-constexpr int TEXTURE_FILTERING_FORCE_LINEAR = 6;
-constexpr int TEXTURE_FILTERING_FORCE_LINEAR_ANISO_2X = 7;
-constexpr int TEXTURE_FILTERING_FORCE_LINEAR_ANISO_4X = 8;
-constexpr int TEXTURE_FILTERING_FORCE_LINEAR_ANISO_8X = 9;
-constexpr int TEXTURE_FILTERING_FORCE_LINEAR_ANISO_16X = 10;
+constexpr int ANISO_DEFAULT = 0;
+constexpr int ANISO_2X = 1;
+constexpr int ANISO_4X = 2;
+constexpr int ANISO_8X = 3;
+constexpr int ANISO_16X = 4;
+constexpr int FILTERING_DEFAULT = 0;
+constexpr int FILTERING_NEAREST = 1;
+constexpr int FILTERING_LINEAR = 2;
 
 void EnhancementsWidget::CreateWidgets()
 {
@@ -93,7 +98,7 @@ void EnhancementsWidget::CreateWidgets()
   // If the current scale is greater than the max scale in the ini, add sufficient options so that
   // when the settings are saved we don't lose the user-modified value from the ini.
   const int max_efb_scale =
-      std::max(Config::Get(Config::GFX_EFB_SCALE), Config::Get(Config::GFX_MAX_EFB_SCALE));
+      std::max(ReadSetting(Config::GFX_EFB_SCALE), ReadSetting(Config::GFX_MAX_EFB_SCALE));
   for (int scale = static_cast<int>(resolution_options.size()); scale <= max_efb_scale; scale++)
   {
     const QString scale_text = QString::number(scale);
@@ -117,45 +122,40 @@ void EnhancementsWidget::CreateWidgets()
   m_ir_combo = new ConfigChoice(resolution_options, Config::GFX_EFB_SCALE, m_game_layer);
   m_ir_combo->setMaxVisibleItems(visible_resolution_option_count);
 
-  m_aa_combo = new ToolTipComboBox();
+  m_aa_combo = new ConfigComplexChoice(Config::GFX_MSAA, Config::GFX_SSAA, m_game_layer);
+  m_aa_combo->Add(tr("None"), (u32)1, false);
 
-  m_texture_filtering_combo = new ToolTipComboBox();
-  m_texture_filtering_combo->addItem(tr("Default"), TEXTURE_FILTERING_DEFAULT);
-  m_texture_filtering_combo->addItem(tr("2x Anisotropic"), TEXTURE_FILTERING_ANISO_2X);
-  m_texture_filtering_combo->addItem(tr("4x Anisotropic"), TEXTURE_FILTERING_ANISO_4X);
-  m_texture_filtering_combo->addItem(tr("8x Anisotropic"), TEXTURE_FILTERING_ANISO_8X);
-  m_texture_filtering_combo->addItem(tr("16x Anisotropic"), TEXTURE_FILTERING_ANISO_16X);
-  m_texture_filtering_combo->addItem(tr("Force Nearest"), TEXTURE_FILTERING_FORCE_NEAREST);
-  m_texture_filtering_combo->addItem(tr("Force Linear"), TEXTURE_FILTERING_FORCE_LINEAR);
-  m_texture_filtering_combo->addItem(tr("Force Linear and 2x Anisotropic"),
-                                     TEXTURE_FILTERING_FORCE_LINEAR_ANISO_2X);
-  m_texture_filtering_combo->addItem(tr("Force Linear and 4x Anisotropic"),
-                                     TEXTURE_FILTERING_FORCE_LINEAR_ANISO_4X);
-  m_texture_filtering_combo->addItem(tr("Force Linear and 8x Anisotropic"),
-                                     TEXTURE_FILTERING_FORCE_LINEAR_ANISO_8X);
-  m_texture_filtering_combo->addItem(tr("Force Linear and 16x Anisotropic"),
-                                     TEXTURE_FILTERING_FORCE_LINEAR_ANISO_16X);
+  m_texture_filtering_combo =
+      new ConfigComplexChoice(Config::GFX_ENHANCE_MAX_ANISOTROPY,
+                              Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING, m_game_layer);
 
-  m_output_resampling_combo = new ToolTipComboBox();
-  m_output_resampling_combo->addItem(tr("Default"),
-                                     static_cast<int>(OutputResamplingMode::Default));
-  m_output_resampling_combo->addItem(tr("Bilinear"),
-                                     static_cast<int>(OutputResamplingMode::Bilinear));
-  m_output_resampling_combo->addItem(tr("Bicubic: B-Spline"),
-                                     static_cast<int>(OutputResamplingMode::BSpline));
-  m_output_resampling_combo->addItem(tr("Bicubic: Mitchell-Netravali"),
-                                     static_cast<int>(OutputResamplingMode::MitchellNetravali));
-  m_output_resampling_combo->addItem(tr("Bicubic: Catmull-Rom"),
-                                     static_cast<int>(OutputResamplingMode::CatmullRom));
-  m_output_resampling_combo->addItem(tr("Sharp Bilinear"),
-                                     static_cast<int>(OutputResamplingMode::SharpBilinear));
-  m_output_resampling_combo->addItem(tr("Area Sampling"),
-                                     static_cast<int>(OutputResamplingMode::AreaSampling));
+  m_texture_filtering_combo->Add(tr("Default"), ANISO_DEFAULT, FILTERING_DEFAULT);
+  m_texture_filtering_combo->Add(tr("2x Anisotropic"), ANISO_2X, FILTERING_DEFAULT);
+  m_texture_filtering_combo->Add(tr("4x Anisotropic"), ANISO_4X, FILTERING_DEFAULT);
+  m_texture_filtering_combo->Add(tr("8x Anisotropic"), ANISO_8X, FILTERING_DEFAULT);
+  m_texture_filtering_combo->Add(tr("16x Anisotropic"), ANISO_16X, FILTERING_DEFAULT);
+  m_texture_filtering_combo->Add(tr("Force Nearest"), ANISO_DEFAULT, FILTERING_NEAREST);
+  m_texture_filtering_combo->Add(tr("Force Linear"), ANISO_DEFAULT, FILTERING_LINEAR);
+  m_texture_filtering_combo->Add(tr("Force Linear and 2x Anisotropic"), ANISO_2X, FILTERING_LINEAR);
+  m_texture_filtering_combo->Add(tr("Force Linear and 4x Anisotropic"), ANISO_4X, FILTERING_LINEAR);
+  m_texture_filtering_combo->Add(tr("Force Linear and 8x Anisotropic"), ANISO_8X, FILTERING_LINEAR);
+  m_texture_filtering_combo->Add(tr("Force Linear and 16x Anisotropic"), ANISO_16X,
+                                 FILTERING_LINEAR);
+  m_texture_filtering_combo->Refresh();
+  m_texture_filtering_combo->setEnabled(ReadSetting(Config::GFX_HACK_FAST_TEXTURE_SAMPLING));
+
+  m_output_resampling_combo = new ConfigChoice(
+      {tr("Default"), tr("Bilinear"), tr("Bicubic: B-Spline"), tr("Bicubic: Mitchell-Netravali"),
+       tr("Bicubic: Catmull-Rom"), tr("Sharp Bilinear"), tr("Area Sampling")},
+      Config::GFX_ENHANCE_OUTPUT_RESAMPLING, m_game_layer);
 
   m_configure_color_correction = new ToolTipPushButton(tr("Configure"));
 
-  m_pp_effect = new ToolTipComboBox();
+  m_pp_effect = new ConfigStringChoice(VideoCommon::PostProcessing::GetShaderList(),
+                                       Config::GFX_ENHANCE_POST_SHADER, m_game_layer);
   m_configure_pp_effect = new NonDefaultQPushButton(tr("Configure"));
+  m_configure_pp_effect->setDisabled(true);
+
   m_scaled_efb_copy =
       new ConfigBool(tr("Scaled EFB Copy"), Config::GFX_HACK_COPY_EFB_SCALED, m_game_layer);
   m_per_pixel_lighting =
@@ -171,6 +171,7 @@ void EnhancementsWidget::CreateWidgets()
   m_arbitrary_mipmap_detection =
       new ConfigBool(tr("Arbitrary Mipmap Detection"),
                      Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION, m_game_layer);
+  m_arbitrary_mipmap_detection->setEnabled(!ReadSetting(Config::GFX_ENABLE_GPU_TEXTURE_DECODING));
   m_hdr = new ConfigBool(tr("HDR Post-Processing"), Config::GFX_ENHANCE_HDR_OUTPUT, m_game_layer);
 
   int row = 0;
@@ -242,7 +243,7 @@ void EnhancementsWidget::CreateWidgets()
   stereoscopy_layout->addWidget(m_3d_swap_eyes, 3, 0);
   stereoscopy_layout->addWidget(m_3d_per_eye_resolution, 4, 0);
 
-  auto current_stereo_mode = Config::Get(Config::GFX_STEREO_MODE);
+  auto current_stereo_mode = ReadSetting(Config::GFX_STEREO_MODE);
   if (current_stereo_mode != StereoMode::SBS && current_stereo_mode != StereoMode::TAB)
     m_3d_per_eye_resolution->hide();
 
@@ -255,58 +256,53 @@ void EnhancementsWidget::CreateWidgets()
 
 void EnhancementsWidget::ConnectWidgets()
 {
-  connect(m_aa_combo, &QComboBox::currentIndexChanged, [this](int) { SaveSettings(); });
-  connect(m_texture_filtering_combo, &QComboBox::currentIndexChanged,
-          [this](int) { SaveSettings(); });
-  connect(m_output_resampling_combo, &QComboBox::currentIndexChanged,
-          [this](int) { SaveSettings(); });
-  connect(m_pp_effect, &QComboBox::currentIndexChanged, [this](int) { SaveSettings(); });
   connect(m_3d_mode, &QComboBox::currentIndexChanged, [this] {
-    m_block_save = true;
-    m_configure_color_correction->setEnabled(g_Config.backend_info.bSupportsPostProcessing);
-
-    auto current_stereo_mode = Config::Get(Config::GFX_STEREO_MODE);
-    LoadPPShaders(current_stereo_mode);
+    auto current_stereo_mode = ReadSetting(Config::GFX_STEREO_MODE);
+    LoadPPShaders();
 
     if (current_stereo_mode == StereoMode::SBS || current_stereo_mode == StereoMode::TAB)
       m_3d_per_eye_resolution->show();
     else
       m_3d_per_eye_resolution->hide();
-
-    m_block_save = false;
-    SaveSettings();
   });
+
+  connect(m_pp_effect, &QComboBox::currentIndexChanged, this, &EnhancementsWidget::ShaderChanged);
+
   connect(m_configure_color_correction, &QPushButton::clicked, this,
           &EnhancementsWidget::ConfigureColorCorrection);
   connect(m_configure_pp_effect, &QPushButton::clicked, this,
           &EnhancementsWidget::ConfigurePostProcessingShader);
-
-  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
-    const QSignalBlocker blocker(this);
-    m_block_save = true;
-    LoadPPShaders(Config::Get(Config::GFX_STEREO_MODE));
-    m_block_save = false;
-  });
 }
 
-void EnhancementsWidget::LoadPPShaders(StereoMode stereo_mode)
+template <typename T>
+T EnhancementsWidget::ReadSetting(const Config::Info<T>& setting) const
 {
-  std::vector<std::string> shaders = VideoCommon::PostProcessing::GetShaderList();
-  if (stereo_mode == StereoMode::Anaglyph)
-  {
-    shaders = VideoCommon::PostProcessing::GetAnaglyphShaderList();
-  }
-  else if (stereo_mode == StereoMode::Passive)
-  {
-    shaders = VideoCommon::PostProcessing::GetPassiveShaderList();
-  }
+  if (m_game_layer != nullptr)
+    return m_game_layer->Get(setting);
+  else
+    return Config::Get(setting);
+}
 
+void EnhancementsWidget::LoadPPShaders()
+{
+  auto stereo_mode = ReadSetting(Config::GFX_STEREO_MODE);
+
+  const QSignalBlocker blocker(m_pp_effect);
   m_pp_effect->clear();
 
+  // Get shader list
+  std::vector<std::string> shaders = VideoCommon::PostProcessing::GetShaderList();
+
+  if (stereo_mode == StereoMode::Anaglyph)
+    shaders = VideoCommon::PostProcessing::GetAnaglyphShaderList();
+  else if (stereo_mode == StereoMode::Passive)
+    shaders = VideoCommon::PostProcessing::GetPassiveShaderList();
+
+  // Populate widget
   if (stereo_mode != StereoMode::Anaglyph && stereo_mode != StereoMode::Passive)
     m_pp_effect->addItem(tr("(off)"));
 
-  auto selected_shader = Config::Get(Config::GFX_ENHANCE_POST_SHADER);
+  auto selected_shader = ReadSetting(Config::GFX_ENHANCE_POST_SHADER);
 
   bool found = false;
 
@@ -320,6 +316,7 @@ void EnhancementsWidget::LoadPPShaders(StereoMode stereo_mode)
     }
   }
 
+  // Force a shader for StereoModes that require it.
   if (!found)
   {
     if (stereo_mode == StereoMode::Anaglyph)
@@ -335,103 +332,20 @@ void EnhancementsWidget::LoadPPShaders(StereoMode stereo_mode)
     else
       m_pp_effect->setCurrentIndex(0);
 
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER, selected_shader);
+    // Save forced shader, but avoid forcing an option into a game ini layer.
+    if (m_game_layer == nullptr && ReadSetting(Config::GFX_ENHANCE_POST_SHADER) != selected_shader)
+      Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER, selected_shader);
   }
 
-  const bool supports_postprocessing = g_Config.backend_info.bSupportsPostProcessing;
-  m_pp_effect->setEnabled(supports_postprocessing);
-
-  m_pp_effect->setToolTip(supports_postprocessing ?
-                              QString{} :
-                              tr("%1 doesn't support this feature.")
-                                  .arg(tr(g_video_backend->GetDisplayName().c_str())));
-
-  VideoCommon::PostProcessingConfiguration pp_shader;
-  if (selected_shader != "" && supports_postprocessing)
-  {
-    pp_shader.LoadShader(selected_shader);
-    m_configure_pp_effect->setEnabled(pp_shader.HasOptions());
-  }
-  else
-  {
-    m_configure_pp_effect->setEnabled(false);
-  }
+  m_pp_effect->Load();
+  ShaderChanged();
 }
 
-void EnhancementsWidget::LoadSettings()
+void EnhancementsWidget::OnBackendChanged()
 {
-  m_block_save = true;
-  m_texture_filtering_combo->setEnabled(Config::Get(Config::GFX_HACK_FAST_TEXTURE_SAMPLING));
-  m_arbitrary_mipmap_detection->setEnabled(!Config::Get(Config::GFX_ENABLE_GPU_TEXTURE_DECODING));
-
-  // Anti-Aliasing
-
-  const u32 aa_selection = Config::Get(Config::GFX_MSAA);
-  const bool ssaa = Config::Get(Config::GFX_SSAA);
-  const int aniso = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);
-  const TextureFilteringMode tex_filter_mode =
-      Config::Get(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING);
-
-  m_aa_combo->clear();
-
-  for (const u32 aa_mode : g_Config.backend_info.AAModes)
-  {
-    if (aa_mode == 1)
-      m_aa_combo->addItem(tr("None"), 1);
-    else
-      m_aa_combo->addItem(tr("%1x MSAA").arg(aa_mode), static_cast<int>(aa_mode));
-
-    if (aa_mode == aa_selection && !ssaa)
-      m_aa_combo->setCurrentIndex(m_aa_combo->count() - 1);
-  }
-  if (g_Config.backend_info.bSupportsSSAA)
-  {
-    for (const u32 aa_mode : g_Config.backend_info.AAModes)
-    {
-      if (aa_mode != 1)  // don't show "None" twice
-      {
-        // Mark SSAA using negative values in the variant
-        m_aa_combo->addItem(tr("%1x SSAA").arg(aa_mode), -static_cast<int>(aa_mode));
-        if (aa_mode == aa_selection && ssaa)
-          m_aa_combo->setCurrentIndex(m_aa_combo->count() - 1);
-      }
-    }
-  }
-
-  m_aa_combo->setEnabled(m_aa_combo->count() > 1);
-
-  switch (tex_filter_mode)
-  {
-  case TextureFilteringMode::Default:
-    if (aniso >= 0 && aniso <= 4)
-      m_texture_filtering_combo->setCurrentIndex(aniso);
-    else
-      m_texture_filtering_combo->setCurrentIndex(TEXTURE_FILTERING_DEFAULT);
-    break;
-  case TextureFilteringMode::Nearest:
-    m_texture_filtering_combo->setCurrentIndex(TEXTURE_FILTERING_FORCE_NEAREST);
-    break;
-  case TextureFilteringMode::Linear:
-    if (aniso >= 0 && aniso <= 4)
-      m_texture_filtering_combo->setCurrentIndex(TEXTURE_FILTERING_FORCE_LINEAR + aniso);
-    else
-      m_texture_filtering_combo->setCurrentIndex(TEXTURE_FILTERING_FORCE_LINEAR);
-    break;
-  }
-
-  // Resampling
-  const OutputResamplingMode output_resampling_mode =
-      Config::Get(Config::GFX_ENHANCE_OUTPUT_RESAMPLING);
-  m_output_resampling_combo->setCurrentIndex(
-      m_output_resampling_combo->findData(static_cast<int>(output_resampling_mode)));
-
   m_output_resampling_combo->setEnabled(g_Config.backend_info.bSupportsPostProcessing);
-
-  // Color Correction
   m_configure_color_correction->setEnabled(g_Config.backend_info.bSupportsPostProcessing);
-
-  // Post Processing Shader
-  LoadPPShaders(Config::Get(Config::GFX_STEREO_MODE));
+  m_hdr->setEnabled(g_Config.backend_info.bSupportsHDROutput);
 
   // Stereoscopy
   const bool supports_stereoscopy = g_Config.backend_info.bSupportsGeometryShaders;
@@ -440,105 +354,98 @@ void EnhancementsWidget::LoadSettings()
   m_3d_depth->setEnabled(supports_stereoscopy);
   m_3d_swap_eyes->setEnabled(supports_stereoscopy);
 
-  m_hdr->setEnabled(g_Config.backend_info.bSupportsHDROutput);
-
-  m_block_save = false;
-}
-
-void EnhancementsWidget::SaveSettings()
-{
-  if (m_block_save)
-    return;
-
-  const u32 aa_value = static_cast<u32>(std::abs(m_aa_combo->currentData().toInt()));
-  const bool is_ssaa = m_aa_combo->currentData().toInt() < 0;
-
-  Config::SetBaseOrCurrent(Config::GFX_MSAA, aa_value);
-  Config::SetBaseOrCurrent(Config::GFX_SSAA, is_ssaa);
-
-  const int texture_filtering_selection = m_texture_filtering_combo->currentData().toInt();
-  switch (texture_filtering_selection)
+  // PostProcessing
+  const bool supports_postprocessing = g_Config.backend_info.bSupportsPostProcessing;
+  if (!supports_postprocessing)
   {
-  case TEXTURE_FILTERING_DEFAULT:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 0);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Default);
-    break;
-  case TEXTURE_FILTERING_ANISO_2X:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 1);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Default);
-    break;
-  case TEXTURE_FILTERING_ANISO_4X:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 2);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Default);
-    break;
-  case TEXTURE_FILTERING_ANISO_8X:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 3);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Default);
-    break;
-  case TEXTURE_FILTERING_ANISO_16X:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 4);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Default);
-    break;
-  case TEXTURE_FILTERING_FORCE_NEAREST:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 0);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Nearest);
-    break;
-  case TEXTURE_FILTERING_FORCE_LINEAR:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 0);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Linear);
-    break;
-  case TEXTURE_FILTERING_FORCE_LINEAR_ANISO_2X:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 1);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Linear);
-    break;
-  case TEXTURE_FILTERING_FORCE_LINEAR_ANISO_4X:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 2);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Linear);
-    break;
-  case TEXTURE_FILTERING_FORCE_LINEAR_ANISO_8X:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 3);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Linear);
-    break;
-  case TEXTURE_FILTERING_FORCE_LINEAR_ANISO_16X:
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, 4);
-    Config::SetBaseOrCurrent(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING,
-                             TextureFilteringMode::Linear);
-    break;
+    m_configure_pp_effect->setEnabled(false);
+    m_pp_effect->setEnabled(false);
+    m_pp_effect->setToolTip(
+        tr("%1 doesn't support this feature.").arg(tr(g_video_backend->GetDisplayName().c_str())));
+  }
+  else if (!m_pp_effect->isEnabled() && supports_postprocessing)
+  {
+    m_configure_pp_effect->setEnabled(true);
+    m_pp_effect->setEnabled(true);
+    m_pp_effect->setToolTip(QString{});
+    LoadPPShaders();
   }
 
-  const int output_resampling_selection = m_output_resampling_combo->currentData().toInt();
-  Config::SetBaseOrCurrent(Config::GFX_ENHANCE_OUTPUT_RESAMPLING,
-                           static_cast<OutputResamplingMode>(output_resampling_selection));
+  UpdateAAOptions();
+}
 
-  const bool anaglyph = g_Config.stereo_mode == StereoMode::Anaglyph;
-  const bool passive = g_Config.stereo_mode == StereoMode::Passive;
-  Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER,
-                           (!anaglyph && !passive && m_pp_effect->currentIndex() == 0) ?
-                               "" :
-                               m_pp_effect->currentText().toStdString());
+void EnhancementsWidget::ShaderChanged()
+{
+  auto shader = ReadSetting(Config::GFX_ENHANCE_POST_SHADER);
 
-  VideoCommon::PostProcessingConfiguration pp_shader;
-  if (Config::Get(Config::GFX_ENHANCE_POST_SHADER) != "")
+  if (shader == "(off)" || shader == "")
   {
-    pp_shader.LoadShader(Config::Get(Config::GFX_ENHANCE_POST_SHADER));
+    shader = "";
+
+    // Setting a shader to null in a game ini could be confusing, as it won't be bolded. Remove it
+    // instead.
+    if (m_game_layer != nullptr)
+      m_game_layer->DeleteKey(Config::GFX_ENHANCE_POST_SHADER.GetLocation());
+    else
+      Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER, shader);
+  }
+
+  if (shader != "" && m_pp_effect->isEnabled())
+  {
+    VideoCommon::PostProcessingConfiguration pp_shader;
+    pp_shader.LoadShader(shader);
     m_configure_pp_effect->setEnabled(pp_shader.HasOptions());
   }
   else
   {
     m_configure_pp_effect->setEnabled(false);
   }
+}
 
-  LoadSettings();
+void EnhancementsWidget::OnConfigChanged()
+{
+  // Only used for the GameConfigWidget. Bypasses graphics window signals and backend info due to it
+  // being global.
+  m_texture_filtering_combo->setEnabled(ReadSetting(Config::GFX_HACK_FAST_TEXTURE_SAMPLING));
+  m_arbitrary_mipmap_detection->setEnabled(!ReadSetting(Config::GFX_ENABLE_GPU_TEXTURE_DECODING));
+  UpdateAAOptions();
+
+  // Needs to update after deleting a key for 3d settings.
+  LoadPPShaders();
+}
+
+void EnhancementsWidget::UpdateAAOptions()
+{
+  const QSignalBlocker blocker_aa(m_aa_combo);
+
+  m_aa_combo->Reset();
+  m_aa_combo->Add(tr("None"), (u32)1, false);
+
+  std::vector<u32> aa_modes = g_Config.backend_info.AAModes;
+  for (const u32 aa_mode : aa_modes)
+  {
+    if (aa_mode > 1)
+      m_aa_combo->Add(tr("%1x MSAA").arg(aa_mode), aa_mode, false);
+  }
+
+  if (g_Config.backend_info.bSupportsSSAA)
+  {
+    for (const u32 aa_mode : aa_modes)
+    {
+      if (aa_mode > 1)
+        m_aa_combo->Add(tr("%1x SSAA").arg(aa_mode), aa_mode, true);
+    }
+  }
+
+  m_aa_combo->Refresh();
+
+  // Backend info can't be populated in the local game settings window. Only enable local game AA
+  // edits when the backend info is correct - global and local have the same backend.
+  const bool good_info =
+      m_game_layer == nullptr || !m_game_layer->Exists(Config::MAIN_GFX_BACKEND.GetLocation()) ||
+      Config::Get(Config::MAIN_GFX_BACKEND) == m_game_layer->Get(Config::MAIN_GFX_BACKEND);
+
+  m_aa_combo->setEnabled(m_aa_combo->count() > 1 && good_info);
 }
 
 void EnhancementsWidget::AddDescriptions()
@@ -727,7 +634,7 @@ void EnhancementsWidget::ConfigureColorCorrection()
 
 void EnhancementsWidget::ConfigurePostProcessingShader()
 {
-  const std::string shader = Config::Get(Config::GFX_ENHANCE_POST_SHADER);
+  const std::string shader = ReadSetting(Config::GFX_ENHANCE_POST_SHADER);
   PostProcessingConfigWindow dialog(this, shader);
   SetQWidgetWindowDecorations(&dialog);
   dialog.exec();

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -9,19 +9,19 @@
 
 class ConfigBool;
 class ConfigChoice;
+class ConfigComplexChoice;
+class ConfigStringChoice;
 class ConfigSlider;
 class GameConfigWidget;
 class GraphicsWindow;
-class QCheckBox;
-class QComboBox;
 class QPushButton;
-class QSlider;
-class ToolTipComboBox;
 class ToolTipPushButton;
 enum class StereoMode : int;
 
 namespace Config
 {
+template <typename T>
+class Info;
 class Layer;
 }  // namespace Config
 
@@ -33,22 +33,28 @@ public:
   EnhancementsWidget(GameConfigWidget* parent, Config::Layer* layer);
 
 private:
-  void LoadSettings();
-  void SaveSettings();
+  template <typename T>
+  T ReadSetting(const Config::Info<T>& setting) const;
 
   void CreateWidgets();
   void ConnectWidgets();
   void AddDescriptions();
+
+  void OnBackendChanged();
+  void UpdateAAOptions();
+  void LoadPPShaders();
+  void ShaderChanged();
+  void OnConfigChanged();
+
   void ConfigureColorCorrection();
   void ConfigurePostProcessingShader();
-  void LoadPPShaders(StereoMode stereo_mode);
 
   // Enhancements
   ConfigChoice* m_ir_combo;
-  ToolTipComboBox* m_aa_combo;
-  ToolTipComboBox* m_texture_filtering_combo;
-  ToolTipComboBox* m_output_resampling_combo;
-  ToolTipComboBox* m_pp_effect;
+  ConfigComplexChoice* m_aa_combo;
+  ConfigComplexChoice* m_texture_filtering_combo;
+  ConfigChoice* m_output_resampling_combo;
+  ConfigStringChoice* m_pp_effect;
   ToolTipPushButton* m_configure_color_correction;
   QPushButton* m_configure_pp_effect;
   ConfigBool* m_scaled_efb_copy;
@@ -68,6 +74,4 @@ private:
   ConfigBool* m_3d_per_eye_resolution;
 
   Config::Layer* m_game_layer = nullptr;
-  int m_msaa_modes;
-  bool m_block_save;
 };

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -10,6 +10,7 @@
 class ConfigBool;
 class ConfigChoice;
 class ConfigSlider;
+class GameConfigWidget;
 class GraphicsWindow;
 class QCheckBox;
 class QComboBox;
@@ -19,11 +20,17 @@ class ToolTipComboBox;
 class ToolTipPushButton;
 enum class StereoMode : int;
 
+namespace Config
+{
+class Layer;
+}  // namespace Config
+
 class EnhancementsWidget final : public QWidget
 {
   Q_OBJECT
 public:
   explicit EnhancementsWidget(GraphicsWindow* parent);
+  EnhancementsWidget(GameConfigWidget* parent, Config::Layer* layer);
 
 private:
   void LoadSettings();
@@ -60,6 +67,7 @@ private:
   ConfigBool* m_3d_swap_eyes;
   ConfigBool* m_3d_per_eye_resolution;
 
+  Config::Layer* m_game_layer = nullptr;
   int m_msaa_modes;
   bool m_block_save;
 };

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -23,6 +23,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
 #include "DolphinQt/Config/ConfigControls/ConfigInteger.h"
 #include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
+#include "DolphinQt/Config/GameConfigWidget.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
@@ -38,13 +39,20 @@ GeneralWidget::GeneralWidget(GraphicsWindow* parent)
   LoadSettings();
   ConnectWidgets();
   AddDescriptions();
-  emit BackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
 
   connect(parent, &GraphicsWindow::BackendChanged, this, &GeneralWidget::OnBackendChanged);
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     OnEmulationStateChanged(state != Core::State::Uninitialized);
   });
   OnEmulationStateChanged(!Core::IsUninitialized(Core::System::GetInstance()));
+}
+
+GeneralWidget::GeneralWidget(GameConfigWidget* parent, Config::Layer* layer) : m_game_layer(layer)
+{
+  CreateWidgets();
+  LoadSettings();
+  ConnectWidgets();
+  AddDescriptions();
 }
 
 void GeneralWidget::CreateWidgets()
@@ -55,32 +63,35 @@ void GeneralWidget::CreateWidgets()
   auto* m_video_box = new QGroupBox(tr("Basic"));
   m_video_layout = new QGridLayout();
 
-  m_backend_combo = new ToolTipComboBox();
+  std::vector<std::pair<QString, QString>> options;
+  for (auto& backend : VideoBackendBase::GetAvailableBackends())
+  {
+    options.push_back(std::make_pair(tr(backend->GetDisplayName().c_str()),
+                                     QString::fromStdString(backend->GetName())));
+  }
+  m_backend_combo = new ConfigStringChoice(options, Config::MAIN_GFX_BACKEND, m_game_layer);
+  m_previous_backend = m_backend_combo->currentIndex();
+
   m_aspect_combo = new ConfigChoice({tr("Auto"), tr("Force 16:9"), tr("Force 4:3"),
                                      tr("Stretch to Window"), tr("Custom"), tr("Custom (Stretch)")},
-                                    Config::GFX_ASPECT_RATIO);
+                                    Config::GFX_ASPECT_RATIO, m_game_layer);
   m_custom_aspect_label = new QLabel(tr("Custom Aspect Ratio:"));
   m_custom_aspect_label->setHidden(true);
   constexpr int MAX_CUSTOM_ASPECT_RATIO_RESOLUTION = 10000;
   m_custom_aspect_width = new ConfigInteger(1, MAX_CUSTOM_ASPECT_RATIO_RESOLUTION,
-                                            Config::GFX_CUSTOM_ASPECT_RATIO_WIDTH);
+                                            Config::GFX_CUSTOM_ASPECT_RATIO_WIDTH, m_game_layer);
   m_custom_aspect_width->setEnabled(false);
   m_custom_aspect_width->setHidden(true);
   m_custom_aspect_height = new ConfigInteger(1, MAX_CUSTOM_ASPECT_RATIO_RESOLUTION,
-                                             Config::GFX_CUSTOM_ASPECT_RATIO_HEIGHT);
+                                             Config::GFX_CUSTOM_ASPECT_RATIO_HEIGHT, m_game_layer);
   m_custom_aspect_height->setEnabled(false);
   m_custom_aspect_height->setHidden(true);
   m_adapter_combo = new ToolTipComboBox;
-  m_enable_vsync = new ConfigBool(tr("V-Sync"), Config::GFX_VSYNC);
-  m_enable_fullscreen = new ConfigBool(tr("Start in Fullscreen"), Config::MAIN_FULLSCREEN);
+  m_enable_vsync = new ConfigBool(tr("V-Sync"), Config::GFX_VSYNC, m_game_layer);
+  m_enable_fullscreen =
+      new ConfigBool(tr("Start in Fullscreen"), Config::MAIN_FULLSCREEN, m_game_layer);
 
   m_video_box->setLayout(m_video_layout);
-
-  for (auto& backend : VideoBackendBase::GetAvailableBackends())
-  {
-    m_backend_combo->addItem(tr(backend->GetDisplayName().c_str()),
-                             QVariant(QString::fromStdString(backend->GetName())));
-  }
 
   m_video_layout->addWidget(new QLabel(tr("Backend:")), 0, 0);
   m_video_layout->addWidget(m_backend_combo, 0, 1, 1, -1);
@@ -102,11 +113,14 @@ void GeneralWidget::CreateWidgets()
   auto* m_options_box = new QGroupBox(tr("Other"));
   auto* m_options_layout = new QGridLayout();
 
-  m_show_ping = new ConfigBool(tr("Show NetPlay Ping"), Config::GFX_SHOW_NETPLAY_PING);
-  m_autoadjust_window_size =
-      new ConfigBool(tr("Auto-Adjust Window Size"), Config::MAIN_RENDER_WINDOW_AUTOSIZE);
-  m_show_messages = new ConfigBool(tr("Show NetPlay Messages"), Config::GFX_SHOW_NETPLAY_MESSAGES);
-  m_render_main_window = new ConfigBool(tr("Render to Main Window"), Config::MAIN_RENDER_TO_MAIN);
+  m_show_ping =
+      new ConfigBool(tr("Show NetPlay Ping"), Config::GFX_SHOW_NETPLAY_PING, m_game_layer);
+  m_autoadjust_window_size = new ConfigBool(tr("Auto-Adjust Window Size"),
+                                            Config::MAIN_RENDER_WINDOW_AUTOSIZE, m_game_layer);
+  m_show_messages =
+      new ConfigBool(tr("Show NetPlay Messages"), Config::GFX_SHOW_NETPLAY_MESSAGES, m_game_layer);
+  m_render_main_window =
+      new ConfigBool(tr("Render to Main Window"), Config::MAIN_RENDER_TO_MAIN, m_game_layer);
 
   m_options_box->setLayout(m_options_layout);
 
@@ -128,13 +142,13 @@ void GeneralWidget::CreateWidgets()
   }};
   for (size_t i = 0; i < modes.size(); i++)
   {
-    m_shader_compilation_mode[i] =
-        new ConfigRadioInt(tr(modes[i]), Config::GFX_SHADER_COMPILATION_MODE, static_cast<int>(i));
+    m_shader_compilation_mode[i] = new ConfigRadioInt(
+        tr(modes[i]), Config::GFX_SHADER_COMPILATION_MODE, static_cast<int>(i), m_game_layer);
     shader_compilation_layout->addWidget(m_shader_compilation_mode[i], static_cast<int>(i / 2),
                                          static_cast<int>(i % 2));
   }
   m_wait_for_shaders = new ConfigBool(tr("Compile Shaders Before Starting"),
-                                      Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING);
+                                      Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING, m_game_layer);
   shader_compilation_layout->addWidget(m_wait_for_shaders);
   shader_compilation_box->setLayout(shader_compilation_layout);
 
@@ -149,7 +163,7 @@ void GeneralWidget::CreateWidgets()
 void GeneralWidget::ConnectWidgets()
 {
   // Video Backend
-  connect(m_backend_combo, &QComboBox::currentIndexChanged, this, &GeneralWidget::SaveSettings);
+  connect(m_backend_combo, &QComboBox::currentIndexChanged, this, &GeneralWidget::BackendWarning);
   connect(m_adapter_combo, &QComboBox::currentIndexChanged, this, [&](int index) {
     g_Config.iAdapter = index;
     Config::SetBaseOrCurrent(Config::GFX_ADAPTER, index);
@@ -168,10 +182,6 @@ void GeneralWidget::ConnectWidgets()
 
 void GeneralWidget::LoadSettings()
 {
-  // Video Backend
-  m_backend_combo->setCurrentIndex(m_backend_combo->findData(
-      QVariant(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)))));
-
   const bool is_custom_aspect_ratio =
       (Config::Get(Config::GFX_ASPECT_RATIO) == AspectMode::Custom) ||
       (Config::Get(Config::GFX_ASPECT_RATIO) == AspectMode::CustomStretch);
@@ -182,13 +192,8 @@ void GeneralWidget::LoadSettings()
   m_custom_aspect_height->setHidden(!is_custom_aspect_ratio);
 }
 
-void GeneralWidget::SaveSettings()
+void GeneralWidget::BackendWarning()
 {
-  // Video Backend
-  const auto current_backend = m_backend_combo->currentData().toString().toStdString();
-  if (Config::Get(Config::MAIN_GFX_BACKEND) == current_backend)
-    return;
-
   if (Config::GetActiveLayerForConfig(Config::MAIN_GFX_BACKEND) == Config::LayerType::Base)
   {
     auto warningMessage = VideoBackendBase::GetAvailableBackends()[m_backend_combo->currentIndex()]
@@ -205,15 +210,14 @@ void GeneralWidget::SaveSettings()
       SetQWidgetWindowDecorations(&confirm_sw);
       if (confirm_sw.exec() != QMessageBox::Yes)
       {
-        m_backend_combo->setCurrentIndex(m_backend_combo->findData(
-            QVariant(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)))));
+        m_backend_combo->setCurrentIndex(m_previous_backend);
         return;
       }
     }
   }
 
-  Config::SetBaseOrCurrent(Config::MAIN_GFX_BACKEND, current_backend);
-  emit BackendChanged(QString::fromStdString(current_backend));
+  m_previous_backend = m_backend_combo->currentIndex();
+  emit BackendChanged(m_backend_combo->currentData().toString());
 }
 
 void GeneralWidget::OnEmulationStateChanged(bool running)
@@ -227,7 +231,10 @@ void GeneralWidget::OnEmulationStateChanged(bool running)
 
   std::string current_backend = m_backend_combo->currentData().toString().toStdString();
   if (Config::Get(Config::MAIN_GFX_BACKEND) != current_backend)
+  {
+    m_backend_combo->Load();
     emit BackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
+  }
 }
 
 void GeneralWidget::AddDescriptions()
@@ -348,8 +355,6 @@ void GeneralWidget::AddDescriptions()
 
 void GeneralWidget::OnBackendChanged(const QString& backend_name)
 {
-  m_backend_combo->setCurrentIndex(m_backend_combo->findData(QVariant(backend_name)));
-
   const QSignalBlocker blocker(m_adapter_combo);
 
   m_adapter_combo->clear();

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -11,6 +11,8 @@ class ConfigBool;
 class ConfigChoice;
 class ConfigInteger;
 class ConfigRadioInt;
+class ConfigStringChoice;
+class GameConfigWidget;
 class GraphicsWindow;
 class QCheckBox;
 class QComboBox;
@@ -19,17 +21,24 @@ class QRadioButton;
 class QGridLayout;
 class ToolTipComboBox;
 
+namespace Config
+{
+class Layer;
+}  // namespace Config
+
 class GeneralWidget final : public QWidget
 {
   Q_OBJECT
 public:
   explicit GeneralWidget(GraphicsWindow* parent);
+  GeneralWidget(GameConfigWidget* parent, Config::Layer* layer);
+
 signals:
   void BackendChanged(const QString& backend);
 
 private:
   void LoadSettings();
-  void SaveSettings();
+  void BackendWarning();
 
   void CreateWidgets();
   void ConnectWidgets();
@@ -40,7 +49,7 @@ private:
 
   // Video
   QGridLayout* m_video_layout;
-  ToolTipComboBox* m_backend_combo;
+  ConfigStringChoice* m_backend_combo;
   ToolTipComboBox* m_adapter_combo;
   ConfigChoice* m_aspect_combo;
   QLabel* m_custom_aspect_label;
@@ -56,4 +65,6 @@ private:
   ConfigBool* m_render_main_window;
   std::array<ConfigRadioInt*, 4> m_shader_compilation_mode{};
   ConfigBool* m_wait_for_shaders;
+  int m_previous_backend = 0;
+  Config::Layer* m_game_layer = nullptr;
 };

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -15,6 +15,7 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
+#include "DolphinQt/Config/GameConfigWidget.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
 #include "DolphinQt/Settings.h"
@@ -37,6 +38,14 @@ HacksWidget::HacksWidget(GraphicsWindow* parent)
   });
 }
 
+HacksWidget::HacksWidget(GameConfigWidget* parent, Config::Layer* layer) : m_game_layer(layer)
+{
+  CreateWidgets();
+  LoadSettings();
+  ConnectWidgets();
+  AddDescriptions();
+}
+
 void HacksWidget::CreateWidgets()
 {
   auto* main_layout = new QVBoxLayout;
@@ -45,14 +54,14 @@ void HacksWidget::CreateWidgets()
   auto* efb_box = new QGroupBox(tr("Embedded Frame Buffer (EFB)"));
   auto* efb_layout = new QGridLayout();
   efb_box->setLayout(efb_layout);
-  m_skip_efb_cpu =
-      new ConfigBool(tr("Skip EFB Access from CPU"), Config::GFX_HACK_EFB_ACCESS_ENABLE, true);
-  m_ignore_format_changes = new ConfigBool(tr("Ignore Format Changes"),
-                                           Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES, true);
-  m_store_efb_copies =
-      new ConfigBool(tr("Store EFB Copies to Texture Only"), Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);
-  m_defer_efb_copies =
-      new ConfigBool(tr("Defer EFB Copies to RAM"), Config::GFX_HACK_DEFER_EFB_COPIES);
+  m_skip_efb_cpu = new ConfigBool(tr("Skip EFB Access from CPU"),
+                                  Config::GFX_HACK_EFB_ACCESS_ENABLE, m_game_layer, true);
+  m_ignore_format_changes = new ConfigBool(
+      tr("Ignore Format Changes"), Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES, m_game_layer, true);
+  m_store_efb_copies = new ConfigBool(tr("Store EFB Copies to Texture Only"),
+                                      Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, m_game_layer);
+  m_defer_efb_copies = new ConfigBool(tr("Defer EFB Copies to RAM"),
+                                      Config::GFX_HACK_DEFER_EFB_COPIES, m_game_layer);
 
   efb_layout->addWidget(m_skip_efb_cpu, 0, 0);
   efb_layout->addWidget(m_ignore_format_changes, 0, 1);
@@ -69,8 +78,8 @@ void HacksWidget::CreateWidgets()
   m_accuracy->setMaximum(2);
   m_accuracy->setPageStep(1);
   m_accuracy->setTickPosition(QSlider::TicksBelow);
-  m_gpu_texture_decoding =
-      new ConfigBool(tr("GPU Texture Decoding"), Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
+  m_gpu_texture_decoding = new ConfigBool(tr("GPU Texture Decoding"),
+                                          Config::GFX_ENABLE_GPU_TEXTURE_DECODING, m_game_layer);
 
   auto* safe_label = new QLabel(tr("Safe"));
   safe_label->setAlignment(Qt::AlignRight);
@@ -88,11 +97,12 @@ void HacksWidget::CreateWidgets()
   auto* xfb_layout = new QVBoxLayout();
   xfb_box->setLayout(xfb_layout);
 
-  m_store_xfb_copies =
-      new ConfigBool(tr("Store XFB Copies to Texture Only"), Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM);
-  m_immediate_xfb = new ConfigBool(tr("Immediately Present XFB"), Config::GFX_HACK_IMMEDIATE_XFB);
-  m_skip_duplicate_xfbs =
-      new ConfigBool(tr("Skip Presenting Duplicate Frames"), Config::GFX_HACK_SKIP_DUPLICATE_XFBS);
+  m_store_xfb_copies = new ConfigBool(tr("Store XFB Copies to Texture Only"),
+                                      Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM, m_game_layer);
+  m_immediate_xfb =
+      new ConfigBool(tr("Immediately Present XFB"), Config::GFX_HACK_IMMEDIATE_XFB, m_game_layer);
+  m_skip_duplicate_xfbs = new ConfigBool(tr("Skip Presenting Duplicate Frames"),
+                                         Config::GFX_HACK_SKIP_DUPLICATE_XFBS, m_game_layer);
 
   xfb_layout->addWidget(m_store_xfb_copies);
   xfb_layout->addWidget(m_immediate_xfb);
@@ -104,13 +114,14 @@ void HacksWidget::CreateWidgets()
   other_box->setLayout(other_layout);
 
   m_fast_depth_calculation =
-      new ConfigBool(tr("Fast Depth Calculation"), Config::GFX_FAST_DEPTH_CALC);
+      new ConfigBool(tr("Fast Depth Calculation"), Config::GFX_FAST_DEPTH_CALC, m_game_layer);
   m_disable_bounding_box =
-      new ConfigBool(tr("Disable Bounding Box"), Config::GFX_HACK_BBOX_ENABLE, true);
-  m_vertex_rounding = new ConfigBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUNDING);
-  m_save_texture_cache_state =
-      new ConfigBool(tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE);
-  m_vi_skip = new ConfigBool(tr("VBI Skip"), Config::GFX_HACK_VI_SKIP);
+      new ConfigBool(tr("Disable Bounding Box"), Config::GFX_HACK_BBOX_ENABLE, m_game_layer, true);
+  m_vertex_rounding =
+      new ConfigBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUNDING, m_game_layer);
+  m_save_texture_cache_state = new ConfigBool(
+      tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE, m_game_layer);
+  m_vi_skip = new ConfigBool(tr("VBI Skip"), Config::GFX_HACK_VI_SKIP, m_game_layer);
 
   other_layout->addWidget(m_fast_depth_calculation, 0, 0);
   other_layout->addWidget(m_disable_bounding_box, 0, 1);

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -6,15 +6,22 @@
 #include <QWidget>
 
 class ConfigBool;
+class GameConfigWidget;
 class GraphicsWindow;
 class QLabel;
 class ToolTipSlider;
+
+namespace Config
+{
+class Layer;
+}  // namespace Config
 
 class HacksWidget final : public QWidget
 {
   Q_OBJECT
 public:
   explicit HacksWidget(GraphicsWindow* parent);
+  HacksWidget(GameConfigWidget* parent, Config::Layer* layer);
 
 private:
   void LoadSettings();
@@ -44,6 +51,8 @@ private:
   ConfigBool* m_vertex_rounding;
   ConfigBool* m_vi_skip;
   ConfigBool* m_save_texture_cache_state;
+
+  Config::Layer* m_game_layer = nullptr;
 
   void CreateWidgets();
   void ConnectWidgets();

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -241,6 +241,7 @@
     -->
   <ItemGroup>
     <ClInclude Include="Config\CheatCodeEditor.h" />
+    <ClInclude Include="Config\ConfigControls\ConfigControl.h" />
     <ClInclude Include="Config\GameConfigEdit.h" />
     <ClInclude Include="Config\Mapping\MappingCommon.h" />
     <ClInclude Include="Config\Mapping\MappingIndicator.h" />

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -546,13 +546,13 @@ void GameList::OpenProperties()
     return;
 
   PropertiesDialog* properties = new PropertiesDialog(this, *game);
-  // Since the properties dialog locks the game file, it's important to free it as soon as it's
-  // closed so that the file can be moved or deleted.
-  properties->setAttribute(Qt::WA_DeleteOnClose, true);
 
   connect(properties, &PropertiesDialog::OpenGeneralSettings, this, &GameList::OpenGeneralSettings);
   connect(properties, &PropertiesDialog::OpenGraphicsSettings, this,
           &GameList::OpenGraphicsSettings);
+  connect(properties, &PropertiesDialog::finished, this,
+          [properties]() { properties->deleteLater(); });
+
 #ifdef USE_RETRO_ACHIEVEMENTS
   connect(properties, &PropertiesDialog::OpenAchievementSettings, this,
           &GameList::OpenAchievementSettings);


### PR DESCRIPTION
*edit* Reworked and ready to be reviewed.
Follows iwubcode's suggestion below.  Adds tabs to game properties window that allows editing game-specific GFX settings.  Uses the existing GFX widgets as new tabs, but passes a game layer to them that's outside the global game layer system.  This is the solution I came to after trying multiple things.

Features:
- Right click gfx option to remove it from the ini
- Edit multiple games at once
- Edit while a game is running, but only activates settings when window is closed (not sure how safe it is to do it more often).

Notes:
This PR integrates with the ConfigBool, etc widgets that set most GFX settings.  The GFX settings outside of this system require too much editing for this PR. They would need to be conditionally redirected to the custom layer, be bold-able if in the game ini, right clickable to remove them from the game ini, and save only when interacted with (they usually batch save).  All of those are hard to do for the few options that require it. 

Possible issue:
If multiple game ini's are somehow loaded into the editor widget as tabs (maybe from game modding?) it won't refresh the game ini tab correctly.