### PR TITLE
DolphinQt: A Ubiquitous Signal For When Breakpoints Change

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -1156,8 +1156,7 @@ void BranchWatchDialog::SetBreakpoints(bool break_on_hit, bool log_on_hit) const
     const u32 address = m_table_proxy->data(index, UserRole::ClickRole).value<u32>();
     breakpoints.Add(address, break_on_hit, log_on_hit, {});
   }
-  emit m_code_widget->BreakpointsChanged();
-  m_code_widget->Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void BranchWatchDialog::SetBreakpointMenuActionsIcons() const

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -28,6 +28,7 @@
 
 #include "DolphinQt/Debugger/BreakpointDialog.h"
 #include "DolphinQt/Debugger/MemoryWidget.h"
+#include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
@@ -130,6 +131,8 @@ BreakpointWidget::BreakpointWidget(QWidget* parent)
     Update();
   });
 
+  connect(Host::GetInstance(), &Host::PPCBreakpointsChanged, this, &BreakpointWidget::Update);
+
   UpdateIcons();
 }
 
@@ -222,8 +225,7 @@ void BreakpointWidget::OnClicked(QTableWidgetItem* item)
     else
       m_system.GetPowerPC().GetBreakPoints().ToggleEnable(address);
 
-    emit BreakpointsChanged();
-    Update();
+    emit Host::GetInstance()->PPCBreakpointsChanged();
     return;
   }
 
@@ -431,8 +433,7 @@ void BreakpointWidget::OnClear()
 
   m_table->setRowCount(0);
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void BreakpointWidget::OnNewBreakpoint()
@@ -462,8 +463,7 @@ void BreakpointWidget::OnEditBreakpoint(u32 address, bool is_instruction_bp)
     dialog->exec();
   }
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void BreakpointWidget::OnLoad()
@@ -492,8 +492,7 @@ void BreakpointWidget::OnLoad()
     memchecks.AddFromStrings(new_mcs);
   }
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void BreakpointWidget::OnSave()
@@ -532,8 +531,7 @@ void BreakpointWidget::OnContextMenu(const QPoint& pos)
     menu->addAction(tr("Edit..."), [this, bp_address] { OnEditBreakpoint(bp_address, true); });
     menu->addAction(tr("Delete"), [this, &bp_address]() {
       m_system.GetPowerPC().GetBreakPoints().Remove(bp_address);
-      emit BreakpointsChanged();
-      Update();
+      emit Host::GetInstance()->PPCBreakpointsChanged();
     });
   }
   else
@@ -550,8 +548,7 @@ void BreakpointWidget::OnContextMenu(const QPoint& pos)
     menu->addAction(tr("Delete"), [this, &bp_address]() {
       const QSignalBlocker blocker(Settings::Instance());
       m_system.GetPowerPC().GetMemChecks().Remove(bp_address);
-      emit BreakpointsChanged();
-      Update();
+      emit Host::GetInstance()->PPCBreakpointsChanged();
     });
   }
 
@@ -615,8 +612,7 @@ void BreakpointWidget::AddBP(u32 addr, bool break_on_hit, bool log_on_hit, const
       addr, break_on_hit, log_on_hit,
       !condition.isEmpty() ? Expression::TryParse(condition.toUtf8().constData()) : std::nullopt);
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void BreakpointWidget::EditBreakpoint(u32 address, int edit, std::optional<QString> string)
@@ -650,8 +646,7 @@ void BreakpointWidget::EditBreakpoint(u32 address, int edit, std::optional<QStri
   m_system.GetPowerPC().GetBreakPoints().Remove(address);
   m_system.GetPowerPC().GetBreakPoints().Add(std::move(bp));
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool do_log,
@@ -673,8 +668,7 @@ void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool
     m_system.GetPowerPC().GetMemChecks().Add(std::move(check));
   }
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void BreakpointWidget::AddRangedMBP(u32 from, u32 to, bool on_read, bool on_write, bool do_log,
@@ -696,8 +690,7 @@ void BreakpointWidget::AddRangedMBP(u32 from, u32 to, bool on_read, bool on_writ
     m_system.GetPowerPC().GetMemChecks().Add(std::move(check));
   }
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void BreakpointWidget::EditMBP(u32 address, int edit, std::optional<QString> string)
@@ -754,6 +747,5 @@ void BreakpointWidget::EditMBP(u32 address, int edit, std::optional<QString> str
       m_system.GetPowerPC().GetMemChecks().Remove(address);
   }
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -131,6 +131,7 @@ BreakpointWidget::BreakpointWidget(QWidget* parent)
     Update();
   });
 
+  connect(Host::GetInstance(), &Host::PPCSymbolsChanged, this, &BreakpointWidget::Update);
   connect(Host::GetInstance(), &Host::PPCBreakpointsChanged, this, &BreakpointWidget::Update);
 
   UpdateIcons();

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -43,7 +43,6 @@ public:
   void Update();
 
 signals:
-  void BreakpointsChanged();
   void ShowCode(u32 address);
   void ShowMemory(u32 address);
 

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -188,6 +188,8 @@ CodeViewWidget::CodeViewWidget()
   });
   connect(Host::GetInstance(), &Host::PPCSymbolsChanged, this,
           qOverload<>(&CodeViewWidget::Update));
+  connect(Host::GetInstance(), &Host::PPCBreakpointsChanged, this,
+          qOverload<>(&CodeViewWidget::Update));
 
   connect(&Settings::Instance(), &Settings::ThemeChanged, this,
           qOverload<>(&CodeViewWidget::Update));
@@ -1139,16 +1141,14 @@ void CodeViewWidget::ToggleBreakpoint()
 {
   m_system.GetPowerPC().GetBreakPoints().ToggleBreakPoint(GetContextAddress());
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void CodeViewWidget::AddBreakpoint()
 {
   m_system.GetPowerPC().GetBreakPoints().Add(GetContextAddress());
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 u32 CodeViewWidget::GetContextAddress() const

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -57,7 +57,6 @@ public:
 signals:
   void RequestPPCComparison(u32 addr);
   void ShowMemory(u32 address);
-  void BreakpointsChanged();
   void UpdateCodeWidget();
 
 private:

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -190,8 +190,6 @@ void CodeWidget::ConnectWidgets()
           &CodeWidget::OnSelectFunctionCallers);
 
   connect(Host::GetInstance(), &Host::PPCSymbolsChanged, this, &CodeWidget::OnPPCSymbolsChanged);
-  connect(m_code_view, &CodeViewWidget::BreakpointsChanged, this,
-          [this] { emit BreakpointsChanged(); });
   connect(m_code_view, &CodeViewWidget::UpdateCodeWidget, this, &CodeWidget::Update);
 
   connect(m_code_view, &CodeViewWidget::RequestPPCComparison, this,

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -50,7 +50,6 @@ public:
   void Update();
   void UpdateSymbols();
 signals:
-  void BreakpointsChanged();
   void RequestPPCComparison(u32 addr);
   void ShowMemory(u32 address);
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -200,6 +200,8 @@ MemoryViewWidget::MemoryViewWidget(Core::System& system, QWidget* parent)
   connect(&Settings::Instance(), &Settings::DebugFontChanged, this, &MemoryViewWidget::UpdateFont);
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           qOverload<>(&MemoryViewWidget::UpdateColumns));
+  connect(Host::GetInstance(), &Host::PPCBreakpointsChanged, this,
+          qOverload<>(&MemoryViewWidget::Update));
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this,
           qOverload<>(&MemoryViewWidget::UpdateColumns));
   connect(&Settings::Instance(), &Settings::ThemeChanged, this, &MemoryViewWidget::Update);
@@ -840,8 +842,7 @@ void MemoryViewWidget::ToggleBreakpoint(u32 addr, bool row)
     }
   }
 
-  emit BreakpointsChanged();
-  Update();
+  emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
 void MemoryViewWidget::OnCopyAddress(u32 addr)

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -72,7 +72,6 @@ public:
   void SetBPLoggingEnabled(bool enabled);
 
 signals:
-  void BreakpointsChanged();
   void ShowCode(u32 address);
   void RequestWatch(QString name, u32 address);
 

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -333,8 +333,6 @@ void MemoryWidget::ConnectWidgets()
 
   connect(m_base_check, &QCheckBox::toggled, this, &MemoryWidget::ValidateAndPreviewInputValue);
   connect(m_bp_log_check, &QCheckBox::toggled, this, &MemoryWidget::OnBPLogChanged);
-  connect(m_memory_view, &MemoryViewWidget::BreakpointsChanged, this,
-          &MemoryWidget::BreakpointsChanged);
   connect(m_memory_view, &MemoryViewWidget::ShowCode, this, &MemoryWidget::ShowCode);
   connect(m_memory_view, &MemoryViewWidget::RequestWatch, this, &MemoryWidget::RequestWatch);
 }

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -36,7 +36,6 @@ public:
   void SetAddress(u32 address);
   void Update();
 signals:
-  void BreakpointsChanged();
   void ShowCode(u32 address);
   void RequestWatch(QString name, u32 address);
 

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -41,6 +41,7 @@ signals:
   void RequestRenderSize(int w, int h);
   void UpdateDisasmDialog();
   void PPCSymbolsChanged();
+  void PPCBreakpointsChanged();
 
 private:
   Host();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -496,21 +496,13 @@ void MainWindow::CreateComponents()
   connect(m_thread_widget, &ThreadWidget::RequestViewInMemory, request_view_in_memory);
   connect(m_thread_widget, &ThreadWidget::RequestViewInCode, request_view_in_code);
 
-  connect(m_code_widget, &CodeWidget::BreakpointsChanged, m_breakpoint_widget,
-          &BreakpointWidget::Update);
   connect(m_code_widget, &CodeWidget::RequestPPCComparison, m_jit_widget, &JITWidget::Compare);
   connect(m_code_widget, &CodeWidget::ShowMemory, m_memory_widget, &MemoryWidget::SetAddress);
-  connect(m_memory_widget, &MemoryWidget::BreakpointsChanged, m_breakpoint_widget,
-          &BreakpointWidget::Update);
   connect(m_memory_widget, &MemoryWidget::ShowCode, m_code_widget, [this](u32 address) {
     m_code_widget->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithDetailedUpdate);
   });
   connect(m_memory_widget, &MemoryWidget::RequestWatch, request_watch);
 
-  connect(m_breakpoint_widget, &BreakpointWidget::BreakpointsChanged, m_code_widget,
-          &CodeWidget::Update);
-  connect(m_breakpoint_widget, &BreakpointWidget::BreakpointsChanged, m_memory_widget,
-          &MemoryWidget::Update);
   connect(m_breakpoint_widget, &BreakpointWidget::ShowCode, [this](u32 address) {
     if (Core::GetState(Core::System::GetInstance()) == Core::State::Paused)
       m_code_widget->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithDetailedUpdate);


### PR DESCRIPTION
There were three distinct mechanisms for signaling breakpoint changes in DolphinQt, and the wiring had room for improvement. The behavior of these signals has been consolidated into the new `Host::PPCBreakpointsChanged` signal, which can be emitted from anywhere in DolphinQt to properly update breakpoints everywhere in DolphinQt.

This improves a few things:
- For the `CodeViewWidget` and `MemoryViewWidget`, signals no longer need to propagate through the `CodeWidget` and `MemoryWidget` (respectively) to reach their destination (incoming or outgoing).
- For the `BreakpointWidget`, by self-triggering from its own signal, it no longer must manually call `Update()` after all of the emission sites.
- For the `BranchWatchDialog`, it now has one less thing it must go through the `CodeWidget` for, which is a plus.

There is also a bonus commit: I fixed the `BreakpointWidget` not updating when symbols it references change.