### PR TITLE
GeckoCode: Remove Dead Code

### DIFF
--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -45,14 +45,6 @@ bool operator!=(const GeckoCode::Code& lhs, const GeckoCode::Code& rhs)
   return !operator==(lhs, rhs);
 }
 
-// return true if a code exists
-bool GeckoCode::Exist(u32 address, u32 data) const
-{
-  return std::find_if(codes.begin(), codes.end(), [&](const Code& code) {
-           return code.address == address && code.data == data;
-         }) != codes.end();
-}
-
 enum class Installation
 {
   Uninstalled,

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -36,8 +36,6 @@ public:
   bool enabled = false;
   bool default_enabled = false;
   bool user_defined = false;
-
-  bool Exist(u32 address, u32 data) const;
 };
 
 bool operator==(const GeckoCode& lhs, const GeckoCode& rhs);


### PR DESCRIPTION
This was originally added by https://github.com/dolphin-emu/dolphin/commit/80b09c074e610304d3e34ba05c80c41a6d872507 in service of the now absent `Gecko::GeckoCode::Compare` function. `Gecko::GeckoCode::Compare` was modified to no longer use `Gecko::GeckoCode::Exist` by https://github.com/dolphin-emu/dolphin/commit/e91c0222b4a223a8917c70a444aba0c787efb7f9, and was later removed by https://github.com/dolphin-emu/dolphin/commit/e8cd5a3979d6b475d6f0a5299184a32a43850ee0. Nothing uses `Gecko::GeckoCode::Exist` today.