### PR TITLE
IniFile: Migrate `Common::CaseInsensitiveLess` to StringUtil

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -130,7 +130,7 @@ const IniFile::Section* IniFile::GetSection(std::string_view section_name) const
 {
   for (const Section& sect : sections)
   {
-    if (CaseInsensitiveStringCompare::IsEqual(sect.name, section_name))
+    if (CaseInsensitiveEquals(sect.name, section_name))
       return &sect;
   }
 
@@ -141,7 +141,7 @@ IniFile::Section* IniFile::GetSection(std::string_view section_name)
 {
   for (Section& sect : sections)
   {
-    if (CaseInsensitiveStringCompare::IsEqual(sect.name, section_name))
+    if (CaseInsensitiveEquals(sect.name, section_name))
       return &sect;
   }
 

--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -15,29 +15,6 @@
 
 namespace Common
 {
-struct CaseInsensitiveStringCompare
-{
-  // Allow heterogenous lookup.
-  using is_transparent = void;
-
-  bool operator()(std::string_view a, std::string_view b) const
-  {
-    return std::lexicographical_compare(
-        a.begin(), a.end(), b.begin(), b.end(),
-        [](char lhs, char rhs) { return Common::ToLower(lhs) < Common::ToLower(rhs); });
-  }
-
-  static bool IsEqual(std::string_view a, std::string_view b)
-  {
-    if (a.size() != b.size())
-      return false;
-
-    return std::equal(a.begin(), a.end(), b.begin(), b.end(), [](char lhs, char rhs) {
-      return Common::ToLower(lhs) == Common::ToLower(rhs);
-    });
-  }
-};
-
 class IniFile
 {
 public:
@@ -86,7 +63,7 @@ public:
     bool GetLines(std::vector<std::string>* lines, const bool remove_comments = true) const;
 
     bool operator<(const Section& other) const { return name < other.name; }
-    using SectionMap = std::map<std::string, std::string, CaseInsensitiveStringCompare>;
+    using SectionMap = std::map<std::string, std::string, CaseInsensitiveLess>;
 
     const std::string& GetName() const { return name; }
     const SectionMap& GetValues() const { return values; }

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -681,10 +681,14 @@ void ToUpper(std::string* str)
 
 bool CaseInsensitiveEquals(std::string_view a, std::string_view b)
 {
-  if (a.size() != b.size())
-    return false;
-  return std::equal(a.begin(), a.end(), b.begin(),
-                    [](char ca, char cb) { return Common::ToLower(ca) == Common::ToLower(cb); });
+  return std::ranges::equal(
+      a, b, [](char ca, char cb) { return Common::ToLower(ca) == Common::ToLower(cb); });
+}
+
+bool CaseInsensitiveLess::operator()(std::string_view a, std::string_view b) const
+{
+  return std::ranges::lexicographical_compare(
+      a, b, [](char ca, char cb) { return Common::ToLower(ca) < Common::ToLower(cb); });
 }
 
 std::string BytesToHexString(std::span<const u8> bytes)

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -314,5 +314,13 @@ std::string GetEscapedHtml(std::string html);
 void ToLower(std::string* str);
 void ToUpper(std::string* str);
 bool CaseInsensitiveEquals(std::string_view a, std::string_view b);
+
+// 'std::less'-like comparison function object type for case-insensitive strings.
+struct CaseInsensitiveLess
+{
+  using is_transparent = void;  // Allow heterogenous lookup.
+  bool operator()(std::string_view a, std::string_view b) const;
+};
+
 std::string BytesToHexString(std::span<const u8> bytes);
 }  // namespace Common


### PR DESCRIPTION
Migrating `Common::CaseInsensitiveLess` to StringUtil.h will hopefully discourage rolling one's own solution in the future for case-insensitive associative containers when this (quite robust!) solution already exists.

`Common::CaseInsensitiveStringCompare::IsEqual` was removed in favor of using the `Common::CaseInsensitiveEquals` function.

The `a.size() != b.size()` condition in `Common::CaseInsensitiveEquals` can be removed, since `std::ranges::equal` already checks this condition (confirmed in libc++).

And of course, I confirmed config files with weirdly capitalized keys are still loaded and saved as they were before.