### PR TITLE
StringUtil: Remove `JoinStrings`

### DIFF
--- a/Source/Android/jni/Cheats/GeckoCheat.cpp
+++ b/Source/Android/jni/Cheats/GeckoCheat.cpp
@@ -6,6 +6,9 @@
 
 #include <jni.h>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Core/ConfigManager.h"
@@ -58,7 +61,7 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_GeckoCheat_getCreator(JNIEn
 JNIEXPORT jstring JNICALL
 Java_org_dolphinemu_dolphinemu_features_cheats_model_GeckoCheat_getNotes(JNIEnv* env, jobject obj)
 {
-  return ToJString(env, JoinStrings(GetPointer(env, obj)->notes, "\n"));
+  return ToJString(env, fmt::to_string(fmt::join(GetPointer(env, obj)->notes, "\n")));
 }
 
 JNIEXPORT jstring JNICALL

--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
@@ -332,5 +333,5 @@ std::string CPUInfo::Summarize()
   if (bSHA2)
     sum.push_back("SHA2");
 
-  return JoinStrings(sum, ",");
+  return fmt::to_string(fmt::join(sum, ","));
 }

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
@@ -141,7 +142,7 @@ std::string EscapePath(const std::string& path)
   for (const std::string& split_string : split_strings)
     escaped_split_strings.push_back(EscapeFileName(split_string));
 
-  return JoinStrings(escaped_split_strings, "/");
+  return fmt::to_string(fmt::join(escaped_split_strings, "/"));
 }
 
 std::string UnescapeFileName(const std::string& filename)

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -368,21 +368,6 @@ std::vector<std::string> SplitString(const std::string& str, const char delim)
   return output;
 }
 
-std::string JoinStrings(const std::vector<std::string>& strings, const std::string& delimiter)
-{
-  // Check if we can return early, just for speed
-  if (strings.empty())
-    return "";
-
-  std::ostringstream res;
-  std::copy(strings.begin(), strings.end(),
-            std::ostream_iterator<std::string>(res, delimiter.c_str()));
-
-  // Drop the trailing delimiter.
-  std::string joined = res.str();
-  return joined.substr(0, joined.length() - delimiter.length());
-}
-
 std::string TabsToSpaces(int tab_size, std::string str)
 {
   const std::string spaces(tab_size, ' ');

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -200,7 +200,6 @@ std::from_chars_result FromChars(std::string_view sv, T& value,
 std::string TabsToSpaces(int tab_size, std::string str);
 
 std::vector<std::string> SplitString(const std::string& str, char delim);
-std::string JoinStrings(const std::vector<std::string>& strings, const std::string& delimiter);
 
 // "C:/Windows/winhelp.exe" to "C:/Windows/", "winhelp", ".exe"
 // This requires forward slashes to be used for the path separators, even on Windows.

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -14,6 +14,7 @@
 #include <thread>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "Common/CommonTypes.h"
 #include "Common/Intrinsics.h"
@@ -275,5 +276,5 @@ std::string CPUInfo::Summarize()
   if (bSHA2)
     sum.push_back("SHA2");
 
-  return JoinStrings(sum, ",");
+  return fmt::to_string(fmt::join(sum, ","));
 }

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -15,6 +15,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/ranges.h>
+
 #include "Common/Align.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
@@ -90,7 +92,7 @@ static std::vector<std::string> ReadM3UFile(const std::string& m3u_path,
   if (!nonexistent.empty())
   {
     PanicAlertFmtT("Files specified in the M3U file \"{0}\" were not found:\n{1}", m3u_path,
-                   JoinStrings(nonexistent, "\n"));
+                   fmt::join(nonexistent, "\n"));
     return {};
   }
 

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -3,6 +3,9 @@
 
 #include "Core/FreeLookManager.h"
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
@@ -129,7 +132,7 @@ void FreeLookController::LoadDefaults(const ControllerInterface& ciface)
 
 #ifndef ANDROID
   auto hotkey_string = [](std::vector<std::string> inputs) {
-    return "@(" + JoinStrings(inputs, "+") + ')';
+    return fmt::format("@({})", fmt::join(inputs, "+"));
   };
 
   m_move_buttons->SetControlExpression(MoveButtons::Up, hotkey_string({"Shift", "E"}));

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -9,12 +9,12 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
-#include "Common/StringUtil.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
@@ -442,7 +442,7 @@ void HotkeyManager::LoadDefaults(const ControllerInterface& ciface)
   };
 
   auto hotkey_string = [](std::vector<std::string> inputs) {
-    return "@(" + JoinStrings(inputs, "+") + ')';
+    return fmt::format("@({})", fmt::join(inputs, "+"));
   };
 
   // General hotkeys

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -7,6 +7,9 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -423,7 +426,7 @@ std::string WFSSRVDevice::NormalizePath(const std::string& path) const
       normalized_components.push_back(component);
     }
   }
-  return "/" + JoinStrings(normalized_components, "/");
+  return fmt::format("/{}", fmt::join(normalized_components, "/"));
 }
 
 WFSSRVDevice::FileDescriptor* WFSSRVDevice::FindFileDescriptor(u16 fd)

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "Common/Common.h"
 #include "Common/MathUtil.h"
@@ -287,7 +288,7 @@ void ReshapableInput::SaveConfig(Common::IniFile::Section* section,
   std::transform(
       m_calibration.begin(), m_calibration.end(), save_data.begin(),
       [](ControlState val) { return fmt::format("{:.2f}", val * CALIBRATION_CONFIG_SCALE); });
-  section->Set(group + CALIBRATION_CONFIG_NAME, JoinStrings(save_data, " "), "");
+  section->Set(group + CALIBRATION_CONFIG_NAME, fmt::to_string(fmt::join(save_data, " ")), "");
 
   // Save center value.
   static constexpr char center_format[] = "{:.2f} {:.2f}";

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "Common/StringUtil.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
@@ -96,12 +97,12 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
 
     if (is_hotkey)
     {
-      alternations.push_back(fmt::format("@({})", JoinStrings(alternation, "+")));
+      alternations.push_back(fmt::format("@({})", fmt::join(alternation, "+")));
     }
     else
     {
       std::sort(alternation.begin(), alternation.end());
-      alternations.push_back(JoinStrings(alternation, "&"));
+      alternations.push_back(fmt::to_string(fmt::join(alternation, "&")));
     }
   };
 
@@ -130,7 +131,7 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
   std::sort(alternations.begin(), alternations.end());
   alternations.erase(std::unique(alternations.begin(), alternations.end()), alternations.end());
 
-  return JoinStrings(alternations, "|");
+  return fmt::to_string(fmt::join(alternations, "|"));
 }
 
 void RemoveSpuriousTriggerCombinations(

--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -7,15 +7,6 @@
 
 #include "Common/StringUtil.h"
 
-TEST(StringUtil, JoinStrings)
-{
-  EXPECT_EQ("", JoinStrings({}, ", "));
-  EXPECT_EQ("a", JoinStrings({"a"}, ","));
-  EXPECT_EQ("ab", JoinStrings({"a", "b"}, ""));
-  EXPECT_EQ("a, bb, c", JoinStrings({"a", "bb", "c"}, ", "));
-  EXPECT_EQ("???", JoinStrings({"?", "?"}, "?"));
-}
-
 TEST(StringUtil, StringPopBackIf)
 {
   std::string abc = "abc";


### PR DESCRIPTION
With 12 uses of `JoinStrings` in the codebase vs 36 uses of `fmt::join`, fmtlib's range adapter for string concatenation with delimiters is clearly the preferred option.