### PR TITLE
Fix random crash when using the cheat search

### DIFF
--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -280,6 +280,8 @@ void CheatSearchWidget::ConnectWidgets()
 
 void CheatSearchWidget::OnNextScanClicked()
 {
+  Core::CPUThreadGuard guard{m_system};
+
   const bool had_old_results = m_session->WasFirstSearchDone();
 
   const auto filter_type = m_value_source_dropdown->currentData().value<Cheats::FilterType>();
@@ -304,7 +306,7 @@ void CheatSearchWidget::OnNextScanClicked()
   }
 
   const size_t old_count = m_session->GetResultCount();
-  const Cheats::SearchErrorCode error_code = m_session->RunSearch(Core::CPUThreadGuard{m_system});
+  const Cheats::SearchErrorCode error_code = m_session->RunSearch(guard);
 
   if (error_code == Cheats::SearchErrorCode::Success)
   {


### PR DESCRIPTION
Before, Dolphin would randomly crash when updating the cheat search when automatic refresh was enabled. (Having a large number of addresses listed, e.g. by starting with an "any value" search, may contribute). The crash was due to QTableWidget::item returning nullptr in RefreshGUICurrentValues, presumably due to the table being resized on the UI thread while the emulated CPU thread was updating the values. I've fixed this by pausing the CPU thread for the entirety of OnNextScanClicked; this eliminated crashes in my testing.

```
>	Dolphin.exe!CheatSearchWidget::RefreshGUICurrentValues(unsigned __int64 begin_index, unsigned __int64 end_index) Line 608	C++
 	Dolphin.exe!CheatSearchWidget::UpdateTableRows(const Core::CPUThreadGuard & guard, unsigned __int64 begin_index, unsigned __int64 end_index, CheatSearchWidget::UpdateSource source) Line 412	C++
 	Dolphin.exe!CheatSearchWidget::UpdateTableVisibleCurrentValues(CheatSearchWidget::UpdateSource source) Line 425	C++
 	[Inline Frame] Dolphin.exe!std::_Func_class<void>::operator()() Line 951	C++
 	[Inline Frame] Dolphin.exe!Common::HookableEvent<Common::StringLiteral<11>{char{86,73,69,110,100,70,105,101,108,100,0}}>::Trigger() Line 111	C++
 	Dolphin.exe!VideoInterface::VideoInterfaceManager::EndField(FieldType field, unsigned __int64 ticks) Line 843	C++
 	Dolphin.exe!VideoInterface::VideoInterfaceManager::Update(unsigned __int64 ticks) Line 881	C++
 	Dolphin.exe!SystemTimers::SystemTimersManager::VICallback(Core::System & system, unsigned __int64 userdata, __int64 cycles_late) Line 143	C++
 	[Inline Frame] Dolphin.exe!CoreTiming::CoreTimingManager::Advance() Line 348	C++
 	Dolphin.exe!CoreTiming::GlobalAdvance() Line 536	C++
 	0000025c260c8089()	Unknown
 	0000000000009032()	Unknown
 	0000025a940c0000()	Unknown
 	0000000000009032()	Unknown
 	0000000000000040()	Unknown
 	0000000000000001()	Unknown
 	ffffffffffffffff()	Unknown
 	0000026c3b6141d0()	Unknown

Unhandled exception thrown: read access violation.
__imp_QTableWidget::item(...) returned nullptr.
```