### PR TITLE
Remove unneeded Win32 code for color scheme

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -247,7 +247,6 @@ int main(int argc, char* argv[])
     DolphinAnalytics::Instance().ReportDolphinStart("qt");
 
     Settings::Instance().InitDefaultPalette();
-    Settings::Instance().UpdateSystemDark();
     Settings::Instance().ApplyStyle();
 
     MainWindow win{std::move(boot), static_cast<const char*>(options.get("movie"))};

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -250,7 +250,11 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
-          [](Qt::ColorScheme colorScheme) { Settings::Instance().ApplyStyle(); });
+          [this](Qt::ColorScheme colorScheme) {
+            Settings::Instance().ApplyStyle();
+            if (m_skylander_window)
+              m_skylander_window->RefreshList();
+          });
 #endif
 
   connect(m_cheats_manager, &CheatsManager::OpenGeneralSettings, this,
@@ -1772,36 +1776,6 @@ QSize MainWindow::sizeHint() const
 {
   return QSize(800, 600);
 }
-
-#ifdef _WIN32
-bool MainWindow::nativeEvent(const QByteArray& eventType, void* message, qintptr* result)
-{
-  auto* msg = reinterpret_cast<MSG*>(message);
-  if (msg && msg->message == WM_SETTINGCHANGE && msg->lParam != NULL &&
-      std::wstring_view(L"ImmersiveColorSet")
-              .compare(reinterpret_cast<const wchar_t*>(msg->lParam)) == 0)
-  {
-    // Windows light/dark theme has changed. Update our flag and refresh the theme.
-    auto& settings = Settings::Instance();
-    const bool was_dark_before = settings.IsSystemDark();
-    settings.UpdateSystemDark();
-    if (settings.IsSystemDark() != was_dark_before)
-    {
-      settings.ApplyStyle();
-
-      // force the colors in the Skylander window to update
-      if (m_skylander_window)
-        m_skylander_window->RefreshList();
-    }
-
-    // TODO: When switching from light to dark, the window decorations remain light. Qt seems very
-    // convinced that it needs to change these in response to this message, so even if we set them
-    // to dark here, Qt sets them back to light afterwards.
-  }
-
-  return false;
-}
-#endif
 
 void MainWindow::OnBootGameCubeIPL(DiscIO::Region region)
 {

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -213,11 +213,6 @@ private:
   void dropEvent(QDropEvent* event) override;
   QSize sizeHint() const override;
 
-#ifdef _WIN32
-  // This gets called for each event from the Windows message queue.
-  bool nativeEvent(const QByteArray& eventType, void* message, qintptr* result) override;
-#endif
-
 #ifdef HAVE_XRANDR
   std::unique_ptr<X11Utils::XRRConfiguration> m_xrr_config;
 #endif

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -16,16 +16,8 @@
 #include <QRadioButton>
 #include <QSize>
 #include <QStyle>
+#include <QStyleHints>
 #include <QWidget>
-
-#ifdef _WIN32
-#include <fmt/format.h>
-
-#include <winrt/Windows.UI.ViewManagement.h>
-
-#include <QTabBar>
-#include <QToolButton>
-#endif
 
 #include "AudioCommon/AudioCommon.h"
 
@@ -52,7 +44,6 @@
 #include "VideoCommon/NetPlayChatUI.h"
 #include "VideoCommon/NetPlayGolfUI.h"
 
-static bool s_system_dark = false;
 static std::unique_ptr<QPalette> s_default_palette;
 
 Settings::Settings()
@@ -147,30 +138,13 @@ void Settings::InitDefaultPalette()
   s_default_palette = std::make_unique<QPalette>(qApp->palette());
 }
 
-void Settings::UpdateSystemDark()
-{
-#ifdef _WIN32
-  // Check if the system is set to dark mode so we can set the default theme and window
-  // decorations accordingly.
-  {
-    using namespace winrt::Windows::UI::ViewManagement;
-    const UISettings settings;
-    const auto& color = settings.GetColorValue(UIColorType::Foreground);
-
-    const bool is_system_dark = 5 * color.G + 2 * color.R + color.B > 8 * 128;
-    Settings::Instance().SetSystemDark(is_system_dark);
-  }
-#endif
-}
-
-void Settings::SetSystemDark(bool dark)
-{
-  s_system_dark = dark;
-}
-
 bool Settings::IsSystemDark()
 {
-  return s_system_dark;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+  return (qApp->styleHints()->colorScheme() == Qt::ColorScheme::Dark);
+#else
+  return false;
+#endif
 }
 
 bool Settings::IsThemeDark()

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -53,8 +53,6 @@ public:
   // UI
   void TriggerThemeChanged();
   void InitDefaultPalette();
-  void UpdateSystemDark();
-  void SetSystemDark(bool dark);
   bool IsSystemDark();
   bool IsThemeDark();
 


### PR DESCRIPTION
This Windows-specific method of obtaining the current color scheme is now redundant. Since the colorSchemeChanged signal is already being used, it's simpler to just read the mode from QStyleHints as well.