### PR TITLE
GraphicsWindow: Fix crash when opening for the first time during emulation startup

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -573,8 +573,6 @@ static void EmuThread(Core::System& system, std::unique_ptr<BootParameters> boot
     system.GetPowerPC().GetDebugInterface().Clear(guard);
   }};
 
-  VideoBackendBase::PopulateBackendInfo(wsi);
-
   if (!g_video_backend->Initialize(wsi))
   {
     PanicAlertFmt("Failed to initialize video backend!");

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
@@ -67,7 +67,7 @@ void GraphicsWindow::CreateMainLayout()
 
 void GraphicsWindow::OnBackendChanged(const QString& backend_name)
 {
-  VideoBackendBase::PopulateBackendInfoFromUI(m_main_window->GetWindowSystemInfo());
+  VideoBackendBase::PopulateBackendInfo(m_main_window->GetWindowSystemInfo());
 
   setWindowTitle(
       tr("%1 Graphics Configuration").arg(tr(g_video_backend->GetDisplayName().c_str())));

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -284,6 +284,11 @@ void VideoBackendBase::ActivateBackend(const std::string& name)
 
 void VideoBackendBase::PopulateBackendInfo(const WindowSystemInfo& wsi)
 {
+  // If the core is running, the backend info will have been populated already. If we did it here,
+  // the UI thread could race with the GPU thread.
+  if (Core::IsRunningOrStarting(Core::System::GetInstance()))
+    return;
+
   g_Config.Refresh();
   // Reset backend_info so if the backend forgets to initialize something it doesn't end up using
   // a value from the previously used renderer
@@ -294,14 +299,6 @@ void VideoBackendBase::PopulateBackendInfo(const WindowSystemInfo& wsi)
   // We validate the config after initializing the backend info, as system-specific settings
   // such as anti-aliasing, or the selected adapter may be invalid, and should be checked.
   g_Config.VerifyValidity();
-}
-
-void VideoBackendBase::PopulateBackendInfoFromUI(const WindowSystemInfo& wsi)
-{
-  // If the core is running, the backend info will have been populated already.
-  // If we did it here, the UI thread can race with the with the GPU thread.
-  if (!Core::IsRunningOrStarting(Core::System::GetInstance()))
-    PopulateBackendInfo(wsi);
 }
 
 void VideoBackendBase::DoState(PointerWrap& p)

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -300,7 +300,7 @@ void VideoBackendBase::PopulateBackendInfoFromUI(const WindowSystemInfo& wsi)
 {
   // If the core is running, the backend info will have been populated already.
   // If we did it here, the UI thread can race with the with the GPU thread.
-  if (!Core::IsRunning(Core::System::GetInstance()))
+  if (!Core::IsRunningOrStarting(Core::System::GetInstance()))
     PopulateBackendInfo(wsi);
 }
 

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -70,8 +70,6 @@ public:
 
   // Fills the backend_info fields with the capabilities of the selected backend/device.
   static void PopulateBackendInfo(const WindowSystemInfo& wsi);
-  // Called by the UI thread when the graphics config is opened.
-  static void PopulateBackendInfoFromUI(const WindowSystemInfo& wsi);
 
   // Wrapper function which pushes the event to the GPU thread.
   void DoState(PointerWrap& p);


### PR DESCRIPTION
Fix a crash when starting emulation, then opening the Graphics window for the first time with the Vulkan, Direct3D 11, or Direct3D 12 backends.

Creating the Graphics window results in PopulateBackendInfo() being called, which in turn calls g_video_backend->InitBackendInfo() being called by the Host thread. For Vulkan and D3D11/12 this ends up loading and unloading various backend libraries which are being used by other threads, which in turn causes various pointers to be set to null that had previously been assigned by other threads.

This also does some minor cleanup to PopulateBackendInfo() and removes a redundant call of it, incidentally getting rid of one of the duplicate OpenGL "Video Info:" OSD messages that appear at startup.

Fixes https://bugs.dolphin-emu.org/issues/13634.