### PR TITLE
VideoBackendBase: Only populate backend info when uninitialized

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -284,9 +284,9 @@ void VideoBackendBase::ActivateBackend(const std::string& name)
 
 void VideoBackendBase::PopulateBackendInfo(const WindowSystemInfo& wsi)
 {
-  // If the core is running, the backend info will have been populated already. If we did it here,
-  // the UI thread could race with the GPU thread.
-  if (Core::IsRunningOrStarting(Core::System::GetInstance()))
+  // If the core has been initialized, the backend info will have been populated already. Doing it
+  // again would be unnecessary and could cause the UI thread to race with the GPU thread.
+  if (Core::GetState(Core::System::GetInstance()) != Core::State::Uninitialized)
     return;
 
   g_Config.Refresh();


### PR DESCRIPTION
Prevent potential issues when creating the Graphics window (and thus calling PopulateBackendInfo) while the core state is Stopping, like we already do while it's Starting or Running.