### PR TITLE
Android: Add 16 KiB page size support

### DIFF
--- a/Source/Android/app/build.gradle.kts
+++ b/Source/Android/app/build.gradle.kts
@@ -101,8 +101,12 @@ android {
     defaultConfig {
         externalNativeBuild {
             cmake {
-                arguments("-DANDROID_STL=c++_static", "-DCMAKE_BUILD_TYPE=RelWithDebInfo")
-                // , "-DENABLE_GENERIC=ON"
+                arguments(
+                    "-DANDROID_STL=c++_static",
+                    "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON",
+                    "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+                    // , "-DENABLE_GENERIC=ON"
+                )
                 abiFilters("arm64-v8a", "x86_64") //, "armeabi-v7a", "x86"
 
                 // Uncomment the line below if you don't want to build the C++ unit tests


### PR DESCRIPTION
So far, Dolphin hasn't been able to run on Android devices that use a 16 KiB page size. 16 KiB page sizes are a very new Android feature that no phones have shipped with so far, so we're still compatible with the phones that exist out there, but let's get this fixed before phones start shipping with 16 KiB page sizes.

Because I couldn't get Android Studio's emulator to work, I haven't been able to confirm that this change actually makes Dolphin fully compatible with devices that use a 16 KiB page size. But I have confirmed that this doesn't break anything on a regular 4 KiB page size device.