### PR TITLE
GeneralPane: Add Hardcore Mode tooltip clarifications

### DIFF
--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -96,6 +96,8 @@ void GeneralPane::OnEmulationStateChanged(Core::State state)
   m_checkbox_discord_presence->setEnabled(!running);
 #endif
   m_combobox_fallback_region->setEnabled(!running);
+
+  UpdateDescriptionsUsingHardcoreStatus();
 }
 
 void GeneralPane::ConnectLayout()
@@ -399,12 +401,6 @@ void GeneralPane::AddDescriptions()
                  "<br><br>This setting cannot be changed while emulation is active."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
 #endif
-  static constexpr char TR_SPEEDLIMIT_DESCRIPTION[] =
-      QT_TR_NOOP("Controls how fast emulation runs relative to the original hardware."
-                 "<br><br>Values higher than 100% will emulate faster than the original hardware "
-                 "can run, if your hardware is able to keep up. Values lower than 100% will slow "
-                 "emulation instead. Unlimited will emulate as fast as your hardware is able to."
-                 "<br><br><dolphin_emphasis>If unsure, select 100%.</dolphin_emphasis>");
   static constexpr char TR_UPDATE_TRACK_DESCRIPTION[] = QT_TR_NOOP(
       "Selects which update track Dolphin uses when checking for updates at startup. If a new "
       "update is available, Dolphin will show a list of changes made since your current version "
@@ -452,7 +448,6 @@ void GeneralPane::AddDescriptions()
 #endif
 
   m_combobox_speedlimit->SetTitle(tr("Speed Limit"));
-  m_combobox_speedlimit->SetDescription(tr(TR_SPEEDLIMIT_DESCRIPTION));
 
   if (AutoUpdateChecker::SystemSupportsAutoUpdates())
   {
@@ -469,4 +464,31 @@ void GeneralPane::AddDescriptions()
   m_button_generate_new_identity->SetTitle(tr("Generate a New Statistics Identity"));
   m_button_generate_new_identity->SetDescription(tr(TR_GENERATE_NEW_IDENTITY_DESCRIPTION));
 #endif
+}
+
+void GeneralPane::UpdateDescriptionsUsingHardcoreStatus()
+{
+  const bool hardcore_enabled = AchievementManager::GetInstance().IsHardcoreModeActive();
+
+  static constexpr char TR_SPEEDLIMIT_DESCRIPTION[] =
+      QT_TR_NOOP("Controls how fast emulation runs relative to the original hardware."
+                 "<br><br>Values higher than 100% will emulate faster than the original hardware "
+                 "can run, if your hardware is able to keep up. Values lower than 100% will slow "
+                 "emulation instead. Unlimited will emulate as fast as your hardware is able to."
+                 "<br><br><dolphin_emphasis>If unsure, select 100%.</dolphin_emphasis>");
+  static constexpr char TR_SPEEDLIMIT_RESTRICTION_IN_HARDCORE_DESCRIPTION[] =
+      QT_TR_NOOP("<dolphin_emphasis>When Hardcore Mode is enabled, Speed Limit values less than "
+                 "100% will be treated as 100%.</dolphin_emphasis>");
+
+  if (hardcore_enabled)
+  {
+    m_combobox_speedlimit->SetDescription(
+        tr("%1<br><br>%2")
+            .arg(tr(TR_SPEEDLIMIT_DESCRIPTION))
+            .arg(tr(TR_SPEEDLIMIT_RESTRICTION_IN_HARDCORE_DESCRIPTION)));
+  }
+  else
+  {
+    m_combobox_speedlimit->SetDescription(tr(TR_SPEEDLIMIT_DESCRIPTION));
+  }
 }

--- a/Source/Core/DolphinQt/Settings/GeneralPane.h
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.h
@@ -39,6 +39,7 @@ private:
   void LoadConfig();
   void OnSaveConfig();
   void OnEmulationStateChanged(Core::State state);
+  void UpdateDescriptionsUsingHardcoreStatus();
 
   // Widgets
   QVBoxLayout* m_main_layout;


### PR DESCRIPTION
When Hardcore Mode is active, clarify in the Speed Limit tooltip that values less than 100% won't slow emulation.