### PR TITLE
Boot: write Apploader version into memory

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -571,6 +571,13 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
         // we default to IOS58, which is the version used by the Homebrew Channel.
         SetupWiiMemory(system, IOS::HLE::IOSC::ConsoleType::Retail);
         system.GetIOS()->BootIOS(Titles::IOS(58));
+
+        // The Apploader writes an IOS-like version number into memory.
+        // Older versions of OSInit read it to check IOS compatibility.
+        constexpr u32 ADDR_IOS_VERSION = 0x3140;
+        constexpr u32 ADDR_APPLOADER_VERSION = 0x3188;
+        const u32 ios_version = system.GetMemory().Read_U32(ADDR_IOS_VERSION);
+        system.GetMemory().Write_U32(ios_version, ADDR_APPLOADER_VERSION);
       }
       else
       {


### PR DESCRIPTION
When HLE-ing the apploader, this is necessary to avoid `Error #002` errors. Homebrew doesn't care.
![xfb1_n000000_640x480](https://github.com/user-attachments/assets/c8ee7560-06e1-4033-9fbb-a9442d3f9c07)
