### PR TITLE
VolumeVerifier: Promote `DEBUG_ASSERT` to `static_assert`

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -720,7 +720,7 @@ bool VolumeVerifier::ShouldHaveChannelPartition() const
       "RFNE01", "RFNJ01", "RFNK01", "RFNP01", "RFNW01", "RFPE01", "RFPJ01", "RFPK01", "RFPP01",
       "RFPW01", "RGWE41", "RGWJ41", "RGWP41", "RGWX41", "RMCE01", "RMCJ01", "RMCK01", "RMCP01",
   };
-  DEBUG_ASSERT(std::is_sorted(channel_discs.cbegin(), channel_discs.cend()));
+  static_assert(std::ranges::is_sorted(channel_discs));
 
   return std::binary_search(channel_discs.cbegin(), channel_discs.cend(),
                             std::string_view(m_volume.GetGameID()));
@@ -753,7 +753,7 @@ bool VolumeVerifier::ShouldBeDualLayer() const
       "SLSEXJ", "SLSP01", "SQIE4Q", "SQIP4Q", "SQIY4Q", "SR5E41", "SR5P41", "SUOE41", "SUOP41",
       "SVXX52", "SVXY52", "SX4E01", "SX4P01", "SZ3EGT", "SZ3PGT",
   };
-  DEBUG_ASSERT(std::is_sorted(dual_layer_discs.cbegin(), dual_layer_discs.cend()));
+  static_assert(std::ranges::is_sorted(dual_layer_discs));
 
   return std::binary_search(dual_layer_discs.cbegin(), dual_layer_discs.cend(),
                             std::string_view(m_volume.GetGameID()));


### PR DESCRIPTION
This runtime assertion was added before `std::is_sorted` became constexpr in the codebase.