### PR TITLE
VideoCommon: Dirty pixel shader manager on efb scale changes

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -293,6 +293,10 @@ bool FramebufferManager::CreateEFBFramebuffer()
   g_gfx->SetAndClearFramebuffer(m_efb_framebuffer.get(), {{0.0f, 0.0f, 0.0f, 0.0f}},
                                 g_ActiveConfig.backend_info.bSupportsReversedDepthRange ? 1.0f :
                                                                                           0.0f);
+
+  // Pixel Shader uses EFB scale as a constant, dirty that in case it changed
+  Core::System::GetInstance().GetPixelShaderManager().Dirty();
+
   return true;
 }
 


### PR DESCRIPTION
I've been told bounding box is broken on Auto-IR

Pixel shaders not getting up-to-date efb scale seems like a possible cause

This is completely untested, and I have no clue what to test here, but @JMC47 might