### PR TITLE
GameSettings: safe texture cache for "Winter Sports 3: The Great Tournament"

### DIFF
--- a/Data/Sys/GameSettings/RZI.ini
+++ b/Data/Sys/GameSettings/RZI.ini
@@ -1,0 +1,17 @@
+# RZIE20, RZIPRT - Winter Sports 3: The Great Tournament
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -290,8 +290,7 @@ void WiiIPC::GenerateAck(u32 address)
                 m_ctrl.Y1, m_ctrl.Y2, m_ctrl.X1);
   // Based on a hardware test, the IPC interrupt takes approximately 100 TB ticks to fire
   // after Y2 is seen in the control register.
-  m_system.GetCoreTiming().ScheduleEvent(100 * SystemTimers::TIMER_RATIO,
-                                         m_event_type_update_interrupts);
+  m_system.GetCoreTiming().ScheduleEvent(100_tbticks, m_event_type_update_interrupts);
 }
 
 void WiiIPC::GenerateReply(u32 address)
@@ -302,8 +301,7 @@ void WiiIPC::GenerateReply(u32 address)
                 m_ctrl.Y1, m_ctrl.Y2, m_ctrl.X1);
   // Based on a hardware test, the IPC interrupt takes approximately 100 TB ticks to fire
   // after Y1 is seen in the control register.
-  m_system.GetCoreTiming().ScheduleEvent(100 * SystemTimers::TIMER_RATIO,
-                                         m_event_type_update_interrupts);
+  m_system.GetCoreTiming().ScheduleEvent(100_tbticks, m_event_type_update_interrupts);
 }
 
 bool WiiIPC::IsReady() const


### PR DESCRIPTION
This fixes the texture glitching issue Kolano listed on the wiki: https://wiki.dolphin-emu.org/index.php?title=Winter_Sports_3:_The_Great_Tournament#Downhill_Skiing_Textures.

As a bonus, you also get an unrelated cleanup commit.