### PR TITLE
VideoBackends:Metal: Fix bbox on newer iOS devices

### DIFF
--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -559,6 +559,9 @@ std::optional<std::string> Metal::Util::TranslateShaderToMSL(ShaderStage stage,
   options.platform = spirv_cross::CompilerMSL::Options::macOS;
 #elif TARGET_OS_IOS
   options.platform = spirv_cross::CompilerMSL::Options::iOS;
+  // Otherwise SPIRV-Cross will try to compile subgroup ops to quad ops instead
+  // (And crash because there's no quad_min or quad_max)
+  options.ios_use_simdgroup_functions = Metal::g_features.subgroup_ops;
 #else
   #error What platform is this?
 #endif

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -309,7 +309,7 @@ void Metal::Util::PopulateBackendInfoFeatures(VideoConfig* config, id<MTLDevice>
   {
     // Requires SIMD-scoped reduction operations
     g_features.subgroup_ops =
-        [device supportsFamily:MTLGPUFamilyMac2] || [device supportsFamily:MTLGPUFamilyApple6];
+        [device supportsFamily:MTLGPUFamilyMac2] || [device supportsFamily:MTLGPUFamilyApple7];
     config->backend_info.bSupportsFramebufferFetch = [device supportsFamily:MTLGPUFamilyApple1];
   }
   if (g_features.subgroup_ops)


### PR DESCRIPTION
Still waiting on confirmation that this is everything from https://github.com/OatmealDome/dolphin-ios/issues/163, but this should fix some issues newer iPhone users were having with bbox