### PR TITLE
Remove option for shared zlib-ng

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,7 +672,7 @@ dolphin_make_imported_target_if_missing(LibLZMA::LibLZMA LIBLZMA)
 
 dolphin_find_optional_system_library_pkgconfig(ZSTD libzstd>=1.4.0 zstd::zstd Externals/zstd)
 
-dolphin_find_optional_system_library_pkgconfig(ZLIB zlib-ng ZLIB::ZLIB Externals/zlib-ng)
+add_subdirectory(Externals/zlib-ng)
 
 dolphin_find_optional_system_library_pkgconfig(MINIZIP
   "minizip>=4.0.4" minizip::minizip Externals/minizip-ng


### PR DESCRIPTION
It never actually worked.  Our bundled zlib-ng uses zlib compat mode, making it override system zlib. The zlib-ng found by pkg-config will not, and all its functions will be prefixed with `zng_`. Therefore the two aren't actually compatible.  Selecting system zlib-ng in reality just causes compile failures as zlib symbols fail to link.

@Mystro256 (or anyone else looking to restore the ability to use system zlib-ng), the proper solution would be to either
 - Make the option one to use system zlib (not ng), and allow people to pick it if they don't mind slower zlib-related tasks (or if their system ships zlib-ng as the system zlib)
 - Edit Dolphin and its dependencies to use `zng_` prefixed functions everywhere, and remove the `set(ZLIB_COMPAT ON)` from `Externals/zlib-ng/CMakeLists.txt` (and make it not alias `ZLIB::ZLIB`, set `ZLIB_INCLUDE_DIR`, etc)
 - Edit Dolphin to use `zng_` prefixed functions in performance-sensitive places, and link to both zlib-ng and (system) zlib

I'll leave arguing over which of those options is best to later, and for now just go back to the bundled zlib-ng.