### PR TITLE
Ranges Algorithms Modernization - Trivial

### DIFF
--- a/Source/Core/Common/Crypto/ec.cpp
+++ b/Source/Core/Common/Crypto/ec.cpp
@@ -252,8 +252,8 @@ Signature Sign(const u8* key, const u8* hash)
   bn_mul(s.data.data(), minv, kk, ec_N, 30);
 
   Signature signature;
-  std::copy(r.data.cbegin(), r.data.cend(), signature.begin());
-  std::copy(s.data.cbegin(), s.data.cend(), signature.begin() + 30);
+  std::ranges::copy(r.data, signature.begin());
+  std::ranges::copy(s.data, signature.begin() + 30);
   return signature;
 }
 

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -97,7 +97,7 @@ std::vector<std::string> DoFileSearch(const std::vector<std::string>& directorie
   // Remove duplicates (occurring because caller gave e.g. duplicate or overlapping directories -
   // not because std::filesystem returns duplicates). Also note that this pathname-based uniqueness
   // isn't as thorough as std::filesystem::equivalent.
-  std::sort(result.begin(), result.end());
+  std::ranges::sort(result);
   result.erase(std::unique(result.begin(), result.end()), result.end());
 
   // Dolphin expects to be able to use "/" (DIR_SEP) everywhere.

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -107,7 +107,7 @@ std::vector<std::string> DoFileSearch(const std::vector<std::string>& directorie
   if constexpr (os_separator != DIR_SEP_CHR)
   {
     for (auto& path : result)
-      std::replace(path.begin(), path.end(), '\\', DIR_SEP_CHR);
+      std::ranges::replace(path, '\\', DIR_SEP_CHR);
   }
 
   return result;

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -446,7 +446,7 @@ FSTEntry ScanDirectoryTree(std::string directory, bool recursive)
     // about with directory separators (for host paths - emulated paths may require it) and instead
     // use fs::path to interact with them.
     auto wpath = path.wstring();
-    std::replace(wpath.begin(), wpath.end(), L'\\', L'/');
+    std::ranges::replace(wpath, L'\\', L'/');
     return WStringToUTF8(wpath);
 #else
     return PathToString(path);

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -36,10 +36,10 @@ MACAddress GenerateMacAddress(const MACConsumer type)
   switch (type)
   {
   case MACConsumer::BBA:
-    std::copy(oui_bba.begin(), oui_bba.end(), mac.begin());
+    std::ranges::copy(oui_bba, mac.begin());
     break;
   case MACConsumer::IOS:
-    std::copy(oui_ios.begin(), oui_ios.end(), mac.begin());
+    std::ranges::copy(oui_ios, mac.begin());
     break;
   }
 

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -234,8 +234,8 @@ std::string_view StripQuotes(std::string_view s)
 // Turns "\n\rhello" into "  hello".
 void ReplaceBreaksWithSpaces(std::string& str)
 {
-  std::replace(str.begin(), str.end(), '\r', ' ');
-  std::replace(str.begin(), str.end(), '\n', ' ');
+  std::ranges::replace(str, '\r', ' ');
+  std::ranges::replace(str, '\n', ' ');
 }
 
 void TruncateToCString(std::string* s)

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -655,12 +655,12 @@ std::string GetEscapedHtml(std::string html)
 
 void ToLower(std::string* str)
 {
-  std::transform(str->begin(), str->end(), str->begin(), [](char c) { return Common::ToLower(c); });
+  std::ranges::transform(*str, str->begin(), static_cast<char (&)(char)>(Common::ToLower));
 }
 
 void ToUpper(std::string* str)
 {
-  std::transform(str->begin(), str->end(), str->begin(), [](char c) { return Common::ToUpper(c); });
+  std::ranges::transform(*str, str->begin(), static_cast<char (&)(char)>(Common::ToUpper));
 }
 
 bool CaseInsensitiveEquals(std::string_view a, std::string_view b)

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -403,8 +403,7 @@ void StringPopBackIf(std::string* s, char c)
 
 size_t StringUTF8CodePointCount(std::string_view str)
 {
-  return str.size() -
-         std::count_if(str.begin(), str.end(), [](char c) -> bool { return (c & 0xC0) == 0x80; });
+  return str.size() - std::ranges::count_if(str, [](char c) -> bool { return (c & 0xC0) == 0x80; });
 }
 
 #ifdef _WIN32

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -265,7 +265,7 @@ struct SetGameMetadata
     std::string executable_path = executable.path;
     constexpr char BACKSLASH = '\\';
     constexpr char FORWARDSLASH = '/';
-    std::replace(executable_path.begin(), executable_path.end(), BACKSLASH, FORWARDSLASH);
+    std::ranges::replace(executable_path, BACKSLASH, FORWARDSLASH);
     config->SetRunningGameMetadata(SConfig::MakeGameID(PathToFileName(executable_path)));
 
     Host_TitleChanged();

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -143,20 +143,20 @@ bool SDSP::Initialize(const DSPInitOptions& opts)
 
   std::memset(&r, 0, sizeof(r));
 
-  std::fill(std::begin(reg_stack_ptrs), std::end(reg_stack_ptrs), 0);
+  std::ranges::fill(reg_stack_ptrs, 0);
 
   for (auto& stack : reg_stacks)
-    std::fill(std::begin(stack), std::end(stack), 0);
+    std::ranges::fill(stack, 0);
 
   // Fill IRAM with HALT opcodes.
-  std::fill(iram, iram + DSP_IRAM_SIZE, 0x0021);
+  std::ranges::fill_n(iram, DSP_IRAM_SIZE, 0x0021);
 
   // Just zero out DRAM.
-  std::fill(dram, dram + DSP_DRAM_SIZE, 0);
+  std::ranges::fill_n(dram, DSP_DRAM_SIZE, 0);
 
   // Copied from a real console after the custom UCode has been loaded.
   // These are the indexing wrapping registers.
-  std::fill(std::begin(r.wr), std::end(r.wr), 0xffff);
+  std::ranges::fill(r.wr, 0xffff);
 
   r.sr |= SR_INT_ENABLE;
   r.sr |= SR_EXT_INT_ENABLE;
@@ -172,7 +172,7 @@ bool SDSP::Initialize(const DSPInitOptions& opts)
 void SDSP::Reset()
 {
   pc = DSP_RESET_VECTOR;
-  std::fill(std::begin(r.wr), std::end(r.wr), 0xffff);
+  std::ranges::fill(r.wr, 0xffff);
 }
 
 void SDSP::Shutdown()

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -40,7 +40,7 @@ DSPEmitter::DSPEmitter(DSPCore& dsp)
   m_stub_entry_point = CompileStub();
 
   // Clear all of the block references
-  std::fill(m_blocks.begin(), m_blocks.end(), (DSPCompiledCode)m_stub_entry_point);
+  std::ranges::fill(m_blocks, (DSPCompiledCode)m_stub_entry_point);
 }
 
 DSPEmitter::~DSPEmitter()

--- a/Source/Core/Core/Debugger/BranchWatch.cpp
+++ b/Source/Core/Core/Debugger/BranchWatch.cpp
@@ -307,8 +307,7 @@ void BranchWatch::UpdateHitsSnapshot()
 
 void BranchWatch::ClearSelectionInspection()
 {
-  std::for_each(m_selection.begin(), m_selection.end(),
-                [](Selection::value_type& value) { value.inspection = {}; });
+  std::ranges::for_each(m_selection, [](Selection::value_type& value) { value.inspection = {}; });
 }
 
 void BranchWatch::SetSelectedInspected(std::size_t idx, SelectionInspection inspection)

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -266,7 +266,7 @@ Common::Debug::Threads PPCDebugInterface::GetThreads(const Core::CPUThreadGuard&
 
   const u32 prev_addr = active_thread->Data().thread_link.prev;
   insert_threads(prev_addr, [](const auto& thread) { return thread.Data().thread_link.prev; });
-  std::reverse(threads.begin(), threads.end());
+  std::ranges::reverse(threads);
 
   const u32 next_addr = active_thread->Data().thread_link.next;
   threads.emplace_back(std::move(active_thread));

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -500,7 +500,7 @@ void FifoPlayer::WriteMemory(const MemoryUpdate& memUpdate)
   else
     mem = &memory.GetRAM()[memUpdate.address & memory.GetRamMask()];
 
-  std::copy(memUpdate.data.begin(), memUpdate.data.end(), mem);
+  std::ranges::copy(memUpdate.data, mem);
 }
 
 void FifoPlayer::WriteFifo(const u8* data, u32 start, u32 end)

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -240,8 +240,8 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
   m_Ram.resize(memory.GetRamSize());
   m_ExRam.resize(memory.GetExRamSize());
 
-  std::fill(m_Ram.begin(), m_Ram.end(), 0);
-  std::fill(m_ExRam.begin(), m_ExRam.end(), 0);
+  std::ranges::fill(m_Ram, 0);
+  std::ranges::fill(m_ExRam, 0);
 
   m_File->SetIsWii(m_system.IsWii());
 

--- a/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.cpp
@@ -93,7 +93,7 @@ int CSIDevice_GBAEmu::RunBuffer(u8* buffer, int request_length)
     std::vector<u8> response = m_core->GetJoybusResponse();
     if (response.empty())
       return -1;
-    std::copy(response.begin(), response.end(), buffer);
+    std::ranges::copy(response, buffer);
 
 #ifdef _DEBUG
     const Common::Log::LogLevel log_level =

--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -422,7 +422,7 @@ public:
       if (data)
       {
         std::vector<u8> file_data_enc(Common::AlignUp(data->size(), BLOCK_SZ));
-        std::copy(data->cbegin(), data->cend(), file_data_enc.begin());
+        std::ranges::copy(*data, file_data_enc.begin());
         m_iosc.Encrypt(IOS::HLE::IOSC::HANDLE_SD_KEY, file_hdr.iv.data(), file_data_enc.data(),
                        file_data_enc.size(), file_data_enc.data(), IOS::PID_ES);
         if (!m_file.WriteBytes(file_data_enc.data(), file_data_enc.size()))

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
@@ -70,7 +70,7 @@ CameraLogic::GetCameraPoints(const Common::Matrix44& transform, Common::Vec2 fie
 
   std::array<CameraPoint, CameraLogic::NUM_POINTS> camera_points;
 
-  std::transform(leds.begin(), leds.end(), camera_points.begin(), [&](const Vec3& v) {
+  std::ranges::transform(leds, camera_points.begin(), [&](const Vec3& v) {
     const auto point = camera_view * Vec4(v, 1.0);
 
     // Check if LED is behind camera.

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -452,7 +452,7 @@ bool Wiimote::ProcessReadDataRequest()
   reply.address = Common::swap16(m_read_request.address);
 
   // Pre-fill with zeros in case of read-error or read < 16-bytes:
-  std::fill(std::begin(reply.data), std::end(reply.data), 0x00);
+  std::ranges::fill(reply.data, 0x00);
 
   ErrorCode error_code = ErrorCode::Success;
 

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
@@ -44,7 +44,7 @@ struct MPI : mbedtls_mpi
     if (mbedtls_mpi_write_binary(this, out_data->data(), out_data->size()))
       return false;
 
-    std::reverse(out_data->begin(), out_data->end());
+    std::ranges::reverse(*out_data);
     return true;
   }
 

--- a/Source/Core/Core/IOS/Crypto/Sha.cpp
+++ b/Source/Core/Core/IOS/Crypto/Sha.cpp
@@ -33,14 +33,14 @@ std::optional<IPCReply> ShaDevice::Open(const OpenRequest& request)
 
 static void ConvertContext(const ShaDevice::ShaContext& src, mbedtls_sha1_context* dest)
 {
-  std::copy(std::begin(src.length), std::end(src.length), std::begin(dest->total));
-  std::copy(std::begin(src.states), std::end(src.states), std::begin(dest->state));
+  std::ranges::copy(src.length, std::begin(dest->total));
+  std::ranges::copy(src.states, std::begin(dest->state));
 }
 
 static void ConvertContext(const mbedtls_sha1_context& src, ShaDevice::ShaContext* dest)
 {
-  std::copy(std::begin(src.total), std::end(src.total), std::begin(dest->length));
-  std::copy(std::begin(src.state), std::end(src.state), std::begin(dest->states));
+  std::ranges::copy(src.total, std::begin(dest->length));
+  std::ranges::copy(src.state, std::begin(dest->states));
 }
 
 HLE::ReturnCode ShaDevice::ProcessShaCommand(ShaIoctlv command, const IOCtlVRequest& request)

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -535,7 +535,7 @@ HLE::ReturnCode TicketReader::Unpersonalise(HLE::IOSC& iosc)
                      sizeof(Ticket::title_key), key.data(), PID_ES);
   // Finally, IOS copies the decrypted title key back to the ticket buffer.
   if (ret == IPC_SUCCESS)
-    std::copy(key.cbegin(), key.cend(), ticket_begin + offsetof(Ticket, title_key));
+    std::ranges::copy(key, ticket_begin + offsetof(Ticket, title_key));
 
   return ret;
 }

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -219,11 +219,10 @@ ESCore::GetStoredContentsFromTMD(const ES::TMDReader& tmd,
 u32 ESCore::GetSharedContentsCount() const
 {
   const auto entries = m_ios.GetFS()->ReadDirectory(PID_KERNEL, PID_KERNEL, "/shared1");
-  return static_cast<u32>(
-      std::count_if(entries->begin(), entries->end(), [this](const std::string& entry) {
-        return !m_ios.GetFS()->ReadDirectory(PID_KERNEL, PID_KERNEL, "/shared1/" + entry) &&
-               entry.size() == 12 && entry.compare(8, 4, ".app") == 0;
-      }));
+  return static_cast<u32>(std::ranges::count_if(*entries, [this](const std::string& entry) {
+    return !m_ios.GetFS()->ReadDirectory(PID_KERNEL, PID_KERNEL, "/shared1/" + entry) &&
+           entry.size() == 12 && entry.compare(8, 4, ".app") == 0;
+  }));
 }
 
 std::vector<std::array<u8, 20>> ESCore::GetSharedContents() const

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -817,7 +817,7 @@ ReturnCode ESCore::ExportContentData(Context& context, u32 content_fd, u8* data,
   if (encrypt_ret != IPC_SUCCESS)
     return encrypt_ret;
 
-  std::copy(output.cbegin(), output.cend(), data);
+  std::ranges::copy(output, data);
   return IPC_SUCCESS;
 }
 

--- a/Source/Core/Core/IOS/ES/Views.cpp
+++ b/Source/Core/Core/IOS/ES/Views.cpp
@@ -147,7 +147,7 @@ ReturnCode ESCore::GetTicketFromView(const u8* ticket_view, u8* ticket, u32* tic
     return ES_EACCES;
   }
 
-  std::copy(ticket_bytes.begin(), ticket_bytes.end(), ticket);
+  std::ranges::copy(ticket_bytes, ticket);
   return IPC_SUCCESS;
 }
 

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -143,7 +143,7 @@ enum class FileLookupMode
 static SystemTimers::TimeBaseTick EstimateFileLookupTicks(const std::string& path,
                                                           FileLookupMode mode)
 {
-  const size_t number_of_path_components = std::count(path.cbegin(), path.cend(), '/');
+  const size_t number_of_path_components = std::ranges::count(path, '/');
   if (number_of_path_components == 0)
     return 0_tbticks;
 

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -467,7 +467,7 @@ ResultCode HostFileSystem::CreateFileOrDirectory(Uid uid, Gid gid, const std::st
     return ResultCode::Invalid;
   }
 
-  if (!is_file && std::count(path.begin(), path.end(), '/') > int(MaxPathDepth))
+  if (!is_file && std::ranges::count(path, '/') > int(MaxPathDepth))
     return ResultCode::TooManyPathComponents;
 
   const auto split_path = SplitPathAndBasename(path);

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -551,7 +551,7 @@ void IOSC::Sign(u8* sig_out, u8* ap_cert_out, u64 title_id, const u8* data, u32 
   // Sign the data.
   const auto data_digest = Common::SHA1::CalculateDigest(data, data_size);
   const auto signature = Common::ec::Sign(ap_priv.data(), data_digest.data());
-  std::copy(signature.cbegin(), signature.cend(), sig_out);
+  std::ranges::copy(signature, sig_out);
 }
 
 void IOSC::LoadDefaultEntries()

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -51,8 +51,8 @@ BluetoothEmuDevice::BluetoothEmuDevice(EmulationKernel& ios, const std::string& 
     const bdaddr_t tmp_bd = {0x11, 0x02, 0x19, 0x79, 0, i};
 
     // Previous records can be safely overwritten, since they are backed up
-    std::copy(tmp_bd.begin(), tmp_bd.end(), std::rbegin(bt_dinf.active[i].bdaddr));
-    std::copy(tmp_bd.begin(), tmp_bd.end(), std::rbegin(bt_dinf.registered[i].bdaddr));
+    std::ranges::copy(tmp_bd, std::rbegin(bt_dinf.active[i].bdaddr));
+    std::ranges::copy(tmp_bd, std::rbegin(bt_dinf.registered[i].bdaddr));
 
     const auto& wm_name =
         (i == WIIMOTE_BALANCE_BOARD) ? "Nintendo RVL-WBC-01" : "Nintendo RVL-CNT-01";

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -621,7 +621,7 @@ void BluetoothRealDevice::SaveLinkKeys()
   {
     bdaddr_t address;
     // Reverse the address so that it is stored in the correct order in the config file
-    std::reverse_copy(entry.first.begin(), entry.first.end(), address.begin());
+    std::ranges::reverse_copy(entry.first, address.begin());
     oss << Common::MacAddressToString(address);
     oss << '=';
     oss << std::hex;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -482,9 +482,9 @@ bool BluetoothRealDevice::SendHCIStoreLinkKeyCommand()
   auto iterator = packet.begin() + sizeof(hci_cmd_hdr_t) + sizeof(hci_write_stored_link_key_cp);
   for (const auto& entry : m_link_keys)
   {
-    std::copy(entry.first.begin(), entry.first.end(), iterator);
+    std::ranges::copy(entry.first, iterator);
     iterator += entry.first.size();
-    std::copy(entry.second.begin(), entry.second.end(), iterator);
+    std::ranges::copy(entry.second, iterator);
     iterator += entry.second.size();
   }
 
@@ -737,7 +737,7 @@ void BluetoothRealDevice::HandleBulkOrIntrTransfer(libusb_transfer* tr)
       hci_link_key_notification_ep notification;
       std::memcpy(&notification, tr->buffer + sizeof(hci_event_hdr_t), sizeof(notification));
       linkkey_t key;
-      std::copy(std::begin(notification.key), std::end(notification.key), std::begin(key));
+      std::ranges::copy(notification.key, std::begin(key));
       m_link_keys[notification.bdaddr] = key;
     }
     else if (event == HCI_EVENT_COMMAND_COMPL)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -598,7 +598,7 @@ void BluetoothRealDevice::LoadLinkKeys()
     }
 
     auto& mac = address.value();
-    std::reverse(mac.begin(), mac.end());
+    std::ranges::reverse(mac);
 
     const std::string& key_string = pair.substr(index + 1);
     linkkey_t key{};

--- a/Source/Core/Core/IOS/USB/USBV4.cpp
+++ b/Source/Core/Core/IOS/USB/USBV4.cpp
@@ -87,7 +87,7 @@ void V4GetUSStringMessage::OnTransferComplete(s32 return_value) const
   auto& memory = system.GetMemory();
 
   std::string message = memory.GetString(data_address);
-  std::replace_if(message.begin(), message.end(), std::not_fn(Common::IsPrintableCharacter), '?');
+  std::ranges::replace_if(message, std::not_fn(Common::IsPrintableCharacter), '?');
   memory.CopyToEmu(data_address, message.c_str(), message.size());
   TransferCommand::OnTransferComplete(return_value);
 }

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1100,7 +1100,7 @@ void MovieManager::LoadInput(const std::string& movie_path)
                          "read-only mode off. Otherwise you'll probably get a desync.",
                          byte_offset, byte_offset);
 
-          std::copy(movInput.begin(), movInput.end(), m_temp_input.begin());
+          std::ranges::copy(movInput, m_temp_input.begin());
         }
         else
         {

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -100,9 +100,9 @@ void Cache::Reset()
   valid.fill(0);
   plru.fill(0);
   modified.fill(0);
-  std::fill(lookup_table.begin(), lookup_table.end(), 0xFF);
-  std::fill(lookup_table_ex.begin(), lookup_table_ex.end(), 0xFF);
-  std::fill(lookup_table_vmem.begin(), lookup_table_vmem.end(), 0xFF);
+  std::ranges::fill(lookup_table, 0xFF);
+  std::ranges::fill(lookup_table_ex, 0xFF);
+  std::ranges::fill(lookup_table_vmem, 0xFF);
 }
 
 void InstructionCache::Reset(JitInterface& jit_interface)

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -128,10 +128,10 @@ void PowerPCManager::DoState(PointerWrap& p)
 
 void PowerPCManager::ResetRegisters()
 {
-  std::fill(std::begin(m_ppc_state.ps), std::end(m_ppc_state.ps), PairedSingle{});
-  std::fill(std::begin(m_ppc_state.sr), std::end(m_ppc_state.sr), 0U);
-  std::fill(std::begin(m_ppc_state.gpr), std::end(m_ppc_state.gpr), 0U);
-  std::fill(std::begin(m_ppc_state.spr), std::end(m_ppc_state.spr), 0U);
+  std::ranges::fill(m_ppc_state.ps, PairedSingle{});
+  std::ranges::fill(m_ppc_state.sr, 0U);
+  std::ranges::fill(m_ppc_state.gpr, 0U);
+  std::ranges::fill(m_ppc_state.spr, 0U);
 
   // Gamecube:
   // 0x00080200 = lonestar 2.0

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -192,7 +192,7 @@ bool SysConf::Save() const
   // Make sure the buffer size is 0x4000 bytes now and write the footer.
   buffer.resize(SYSCONF_SIZE);
   constexpr std::array<u8, 4> footer = {{'S', 'C', 'e', 'd'}};
-  std::copy(footer.cbegin(), footer.cend(), buffer.end() - footer.size());
+  std::ranges::copy(footer, buffer.end() - footer.size());
 
   // Write the new data.
   const std::string temp_file = "/tmp/SYSCONF";

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -624,16 +624,15 @@ void DirectoryBlobReader::SetWiiRegionData(const std::vector<u8>& wii_region_dat
 
 void DirectoryBlobReader::SetPartitions(std::vector<PartitionWithType>&& partitions)
 {
-  std::sort(partitions.begin(), partitions.end(),
-            [](const PartitionWithType& lhs, const PartitionWithType& rhs) {
-              if (lhs.type == rhs.type)
-                return lhs.partition.GetRootDirectory() < rhs.partition.GetRootDirectory();
+  std::ranges::sort(partitions, [](const PartitionWithType& lhs, const PartitionWithType& rhs) {
+    if (lhs.type == rhs.type)
+      return lhs.partition.GetRootDirectory() < rhs.partition.GetRootDirectory();
 
-              // Ascending sort by partition type, except Update (1) comes before before Game (0)
-              return (lhs.type > PartitionType::Update || rhs.type > PartitionType::Update) ?
-                         lhs.type < rhs.type :
-                         lhs.type > rhs.type;
-            });
+    // Ascending sort by partition type, except Update (1) comes before before Game (0)
+    return (lhs.type > PartitionType::Update || rhs.type > PartitionType::Update) ?
+               lhs.type < rhs.type :
+               lhs.type > rhs.type;
+  });
 
   u32 subtable_1_size = 0;
   while (subtable_1_size < partitions.size() && subtable_1_size < 3 &&

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -722,8 +722,7 @@ bool VolumeVerifier::ShouldHaveChannelPartition() const
   };
   static_assert(std::ranges::is_sorted(channel_discs));
 
-  return std::binary_search(channel_discs.cbegin(), channel_discs.cend(),
-                            std::string_view(m_volume.GetGameID()));
+  return std::ranges::binary_search(channel_discs, m_volume.GetGameID());
 }
 
 bool VolumeVerifier::ShouldHaveInstallPartition() const
@@ -755,8 +754,7 @@ bool VolumeVerifier::ShouldBeDualLayer() const
   };
   static_assert(std::ranges::is_sorted(dual_layer_discs));
 
-  return std::binary_search(dual_layer_discs.cbegin(), dual_layer_discs.cend(),
-                            std::string_view(m_volume.GetGameID()));
+  return std::ranges::binary_search(dual_layer_discs, m_volume.GetGameID());
 }
 
 void VolumeVerifier::CheckVolumeSize()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -913,7 +913,7 @@ CalibrationWidget::CalibrationWidget(ControllerEmu::ReshapableInput& input,
   m_informative_timer = new QTimer(this);
   connect(m_informative_timer, &QTimer::timeout, this, [this] {
     // If the user has started moving we'll assume they know what they are doing.
-    if (*std::max_element(m_calibration_data.begin(), m_calibration_data.end()) > 0.5)
+    if (*std::ranges::max_element(m_calibration_data) > 0.5)
       return;
 
     ModalMessageBox::information(

--- a/Source/Core/DolphinQt/Debugger/AssemblerWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/AssemblerWidget.cpp
@@ -846,7 +846,7 @@ void AssemblerWidget::CloseTab(int index, AsmEditor* editor)
 
 int AssemblerWidget::AllocateTabNum()
 {
-  auto min_it = std::min_element(m_free_editor_nums.begin(), m_free_editor_nums.end());
+  auto min_it = std::ranges::min_element(m_free_editor_nums);
   if (min_it == m_free_editor_nums.end())
   {
     return m_unnamed_editor_count++;

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -481,7 +481,7 @@ void WatchWidget::DeleteSelectedWatches()
     }
 
     // Sort greatest to smallest, so we don't stomp on existing indices
-    std::sort(row_indices.begin(), row_indices.end(), std::greater{});
+    std::ranges::sort(row_indices, std::ranges::greater{});
     for (const int row : row_indices)
     {
       DeleteWatch(guard, row);

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -191,8 +191,7 @@ void FIFOAnalyzer::UpdateTree()
     // We shouldn't end on a Command (it should end with an EFB copy)
     ASSERT(part_start == frame_info.parts.size());
     // The counts we computed should match the frame's counts
-    ASSERT(std::equal(frame_info.part_type_counts.begin(), frame_info.part_type_counts.end(),
-                      part_counts.begin()));
+    ASSERT(std::ranges::equal(frame_info.part_type_counts, part_counts));
   }
 }
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -130,8 +130,7 @@ void InterfacePane::CreateUI()
       Common::DoFileSearch({File::GetUserPath(D_THEMES_IDX), File::GetSysDirectory() + THEMES_DIR});
   std::vector<std::string> theme_names;
   theme_names.reserve(theme_paths.size());
-  std::transform(theme_paths.cbegin(), theme_paths.cend(), std::back_inserter(theme_names),
-                 PathToFileName);
+  std::ranges::transform(theme_paths, std::back_inserter(theme_names), PathToFileName);
 
   // Theme Combobox
   m_combobox_theme = new ConfigStringChoice(theme_names, Config::MAIN_THEME_NAME);

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -146,7 +146,7 @@ void ToolBar::MakeActions()
   std::ranges::transform(items, std::back_inserter(widths),
                          [](QWidget* item) { return item->sizeHint().width(); });
 
-  const int min_width = *std::max_element(widths.begin(), widths.end()) * 0.85;
+  const int min_width = *std::ranges::max_element(widths) * 0.85;
   for (QWidget* widget : items)
     widget->setMinimumWidth(min_width);
 }

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -143,8 +143,8 @@ void ToolBar::MakeActions()
   }
 
   std::vector<int> widths;
-  std::transform(items.begin(), items.end(), std::back_inserter(widths),
-                 [](QWidget* item) { return item->sizeHint().width(); });
+  std::ranges::transform(items, std::back_inserter(widths),
+                         [](QWidget* item) { return item->sizeHint().width(); });
 
   const int min_width = *std::max_element(widths.begin(), widths.end()) * 0.85;
   for (QWidget* widget : items)

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -53,8 +53,7 @@ struct TwoPointCalibration
     }
     else
     {
-      return std::equal(std::begin(max.data), std::end(max.data), std::begin(zero.data),
-                        std::not_equal_to<>());
+      return std::ranges::equal(max.data, zero.data, std::ranges::not_equal_to{});
     }
   }
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -183,7 +183,7 @@ Joystick::Joystick(const LPDIRECTINPUTDEVICE8 device) : m_device(device)
 
   // Set hats to center:
   // "The center position is normally reported as -1" -MSDN
-  std::fill(std::begin(m_state_in.rgdwPOV), std::end(m_state_in.rgdwPOV), -1);
+  std::ranges::fill(m_state_in.rgdwPOV, -1);
 }
 
 Joystick::~Joystick()

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -176,9 +176,8 @@ Joystick::Joystick(const LPDIRECTINPUTDEVICE8 device) : m_device(device)
   std::list<DIDEVICEOBJECTINSTANCE> objects;
   if (SUCCEEDED(m_device->EnumObjects(DIEnumDeviceObjectsCallback, (LPVOID)&objects, DIDFT_AXIS)))
   {
-    const int num_ff_axes =
-        std::count_if(std::begin(objects), std::end(objects),
-                      [](const auto& pdidoi) { return (pdidoi.dwFlags & DIDOI_FFACTUATOR) != 0; });
+    const int num_ff_axes = std::ranges::count_if(
+        objects, [](const auto& pdidoi) { return (pdidoi.dwFlags & DIDOI_FFACTUATOR) != 0; });
     InitForceFeedback(m_device, num_ff_axes);
   }
 

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -101,7 +101,7 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
     }
     else
     {
-      std::sort(alternation.begin(), alternation.end());
+      std::ranges::sort(alternation);
       alternations.push_back(fmt::to_string(fmt::join(alternation, "&")));
     }
   };
@@ -128,7 +128,7 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
   handle_release();
 
   // Remove duplicates
-  std::sort(alternations.begin(), alternations.end());
+  std::ranges::sort(alternations);
   alternations.erase(std::unique(alternations.begin(), alternations.end()), alternations.end());
 
   return fmt::to_string(fmt::join(alternations, "|"));

--- a/Source/Core/InputCommon/InputProfile.cpp
+++ b/Source/Core/InputCommon/InputProfile.cpp
@@ -111,8 +111,7 @@ ProfileCycler::GetMatchingProfilesFromSetting(const std::string& setting,
   }
 
   std::vector<std::string> result;
-  std::set_intersection(profiles.begin(), profiles.end(), profiles_from_setting.begin(),
-                        profiles_from_setting.end(), std::back_inserter(result));
+  std::ranges::set_intersection(profiles, profiles_from_setting, std::back_inserter(result));
   return result;
 }
 

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -616,8 +616,7 @@ bool GameFile::CheckIfTwoDiscGame(const std::string& game_id) const
   static_assert(std::ranges::is_sorted(two_disc_game_id_prefixes));
 
   std::string_view game_id_prefix(game_id.data(), GAME_ID_PREFIX_SIZE);
-  return std::binary_search(two_disc_game_id_prefixes.begin(), two_disc_game_id_prefixes.end(),
-                            game_id_prefix);
+  return std::ranges::binary_search(two_disc_game_id_prefixes, game_id_prefix);
 }
 
 std::string GameFile::GetNetPlayName(const Core::TitleDatabase& title_database) const

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -613,7 +613,7 @@ bool GameFile::CheckIfTwoDiscGame(const std::string& game_id) const
       "S6T",
       "SDQ",
   };
-  static_assert(std::is_sorted(two_disc_game_id_prefixes.begin(), two_disc_game_id_prefixes.end()));
+  static_assert(std::ranges::is_sorted(two_disc_game_id_prefixes));
 
   std::string_view game_id_prefix(game_id.data(), GAME_ID_PREFIX_SIZE);
   return std::binary_search(two_disc_game_id_prefixes.begin(), two_disc_game_id_prefixes.end(),

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -225,7 +225,7 @@ void SetLocale(std::string locale_name)
   if (locale_name == "en")
     locale_name = "en_GB";
 
-  std::replace(locale_name.begin(), locale_name.end(), OTHER_SEPARATOR, PREFERRED_SEPARATOR);
+  std::ranges::replace(locale_name, OTHER_SEPARATOR, PREFERRED_SEPARATOR);
 
   // Use the specified locale if supported.
   if (set_locale(locale_name))

--- a/Source/Core/VideoBackends/OGL/OGLConfig.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.cpp
@@ -660,7 +660,7 @@ bool PopulateConfig(GLContext* m_main_gl_context)
       }
       g_Config.backend_info.AAModes.push_back(1);
       // The UI wants ascending order
-      std::reverse(g_Config.backend_info.AAModes.begin(), g_Config.backend_info.AAModes.end());
+      std::ranges::reverse(g_Config.backend_info.AAModes);
     }
   }
   else

--- a/Source/Core/VideoBackends/OGL/OGLConfig.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.cpp
@@ -631,10 +631,10 @@ bool PopulateConfig(GLContext* m_main_gl_context)
       g_Config.backend_info.AAModes.clear();
       g_Config.backend_info.AAModes.reserve(std::min(color_aa_modes.size(), depth_aa_modes.size()));
       // We only want AA modes that are supported for both the color and depth textures. Probably
-      // the support is the same, though. rbegin/rend are used to swap the order ahead of time.
-      std::set_intersection(color_aa_modes.rbegin(), color_aa_modes.rend(), depth_aa_modes.rbegin(),
-                            depth_aa_modes.rend(),
-                            std::back_inserter(g_Config.backend_info.AAModes));
+      // the support is the same, though. views::reverse is used to swap the order ahead of time.
+      std::ranges::set_intersection(color_aa_modes | std::views::reverse,
+                                    depth_aa_modes | std::views::reverse,
+                                    std::back_inserter(g_Config.backend_info.AAModes));
     }
     else
     {

--- a/Source/Core/VideoBackends/OGL/OGLConfig.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.cpp
@@ -4,6 +4,7 @@
 #include "VideoBackends/OGL/OGLConfig.h"
 
 #include <cstdio>
+#include <ranges>
 #include <string>
 #include <string_view>
 
@@ -585,7 +586,7 @@ bool PopulateConfig(GLContext* m_main_gl_context)
           glGetInternalformativ(GL_TEXTURE_2D_MULTISAMPLE_ARRAY, colorInternalFormat, GL_SAMPLES,
                                 num_color_sample_counts,
                                 reinterpret_cast<GLint*>(color_aa_modes.data()));
-          ASSERT_MSG(VIDEO, std::is_sorted(color_aa_modes.rbegin(), color_aa_modes.rend()),
+          ASSERT_MSG(VIDEO, std::ranges::is_sorted(color_aa_modes | std::views::reverse),
                      "GPU driver didn't return sorted color AA modes: [{}]",
                      fmt::join(color_aa_modes, ", "));
         }
@@ -614,7 +615,7 @@ bool PopulateConfig(GLContext* m_main_gl_context)
           glGetInternalformativ(GL_TEXTURE_2D_MULTISAMPLE_ARRAY, depthInternalFormat, GL_SAMPLES,
                                 num_depth_sample_counts,
                                 reinterpret_cast<GLint*>(depth_aa_modes.data()));
-          ASSERT_MSG(VIDEO, std::is_sorted(depth_aa_modes.rbegin(), depth_aa_modes.rend()),
+          ASSERT_MSG(VIDEO, std::ranges::is_sorted(depth_aa_modes | std::views::reverse),
                      "GPU driver didn't return sorted depth AA modes: [{}]",
                      fmt::join(depth_aa_modes, ", "));
         }

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -151,7 +151,7 @@ ScissorResult::ScissorResult(const BPMemory& bpmemory, std::pair<float, float> v
   }
 
   auto cmp = [&](const ScissorRect& lhs, const ScissorRect& rhs) { return IsWorse(lhs, rhs); };
-  std::sort(m_result.begin(), m_result.end(), cmp);
+  std::ranges::sort(m_result, cmp);
 }
 
 ScissorRect ScissorResult::Best() const

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -764,9 +764,9 @@ bool FramebufferManager::CreateReadbackFramebuffer()
   }
 
   m_efb_color_cache.tiles.resize(total_tiles);
-  std::fill(m_efb_color_cache.tiles.begin(), m_efb_color_cache.tiles.end(), EFBCacheTile{false, 0});
+  std::ranges::fill(m_efb_color_cache.tiles, EFBCacheTile{false, 0});
   m_efb_depth_cache.tiles.resize(total_tiles);
-  std::fill(m_efb_depth_cache.tiles.begin(), m_efb_depth_cache.tiles.end(), EFBCacheTile{false, 0});
+  std::ranges::fill(m_efb_depth_cache.tiles, EFBCacheTile{false, 0});
 
   return true;
 }

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -954,8 +954,7 @@ void VertexManagerBase::OnDraw()
 
   // Check if this draw is scheduled to kick a command buffer.
   // The draw counters will always be sorted so a binary search is possible here.
-  if (std::binary_search(m_scheduled_command_buffer_kicks.begin(),
-                         m_scheduled_command_buffer_kicks.end(), m_draw_counter))
+  if (std::ranges::binary_search(m_scheduled_command_buffer_kicks, m_draw_counter))
   {
     // Kick a command buffer on the background thread.
     g_gfx->Flush();

--- a/Source/UnitTests/Common/SettingsHandlerTest.cpp
+++ b/Source/UnitTests/Common/SettingsHandlerTest.cpp
@@ -47,7 +47,7 @@ TEST(SettingsHandlerTest, EncryptSingleSetting)
   handler.AddSetting("key", "val");
   Common::SettingsHandler::Buffer buffer = handler.GetBytes();
 
-  EXPECT_TRUE(std::equal(buffer.begin(), buffer.end(), BUFFER_A.begin(), BUFFER_A.end()));
+  EXPECT_TRUE(std::ranges::equal(buffer, BUFFER_A));
 }
 
 TEST(SettingsHandlerTest, DecryptSingleSetting)
@@ -64,7 +64,7 @@ TEST(SettingsHandlerTest, EncryptMultipleSettings)
   handler.AddSetting("foo", "bar");
   Common::SettingsHandler::Buffer buffer = handler.GetBytes();
 
-  EXPECT_TRUE(std::equal(buffer.begin(), buffer.end(), BUFFER_B.begin(), BUFFER_B.end()));
+  EXPECT_TRUE(std::ranges::equal(buffer, BUFFER_B));
 }
 
 TEST(SettingsHandlerTest, DecryptMultipleSettings)
@@ -88,7 +88,7 @@ TEST(SettingsHandlerTest, EncryptAddsLFOnNullChar)
   handler.AddSetting("\xFA", "a");
   Common::SettingsHandler::Buffer buffer = handler.GetBytes();
 
-  EXPECT_TRUE(std::equal(buffer.begin(), buffer.end(), BUFFER_C.begin(), BUFFER_C.end()));
+  EXPECT_TRUE(std::ranges::equal(buffer, BUFFER_C));
 }
 
 TEST(SettingsHandlerTest, EncryptAddsLFOnNullCharTwice)
@@ -97,7 +97,7 @@ TEST(SettingsHandlerTest, EncryptAddsLFOnNullCharTwice)
   handler.AddSetting("\xFA\xE9", "a");
   Common::SettingsHandler::Buffer buffer = handler.GetBytes();
 
-  EXPECT_TRUE(std::equal(buffer.begin(), buffer.end(), BUFFER_D.begin(), BUFFER_D.end()));
+  EXPECT_TRUE(std::ranges::equal(buffer, BUFFER_D));
 }
 
 TEST(SettingsHandlerTest, DecryptSingleAddedLF)

--- a/Source/UnitTests/Core/IOS/FS/FileSystemTest.cpp
+++ b/Source/UnitTests/Core/IOS/FS/FileSystemTest.cpp
@@ -121,7 +121,7 @@ TEST_F(FileSystemTest, CreateFile)
 
   const Result<std::vector<std::string>> tmp_files = m_fs->ReadDirectory(Uid{0}, Gid{0}, "/tmp");
   ASSERT_TRUE(tmp_files.Succeeded());
-  EXPECT_EQ(std::count(tmp_files->begin(), tmp_files->end(), "f"), 1u);
+  EXPECT_EQ(std::ranges::count(*tmp_files, "f"), 1u);
 
   // Test invalid paths
   // Unprintable characters


### PR DESCRIPTION
In C++20, algorithms from the standard library evolved to feature new niceties and additional compile-time checks. The first and most obvious improvement offered by these updated algorithm functions (found in the `std::ranges` namespace) is that they allow you to pass an entire container as a range rather than a first and last iterator representing a range. In this PR, I have focused (almost) solely on modernizing algorithm usage in the codebase using this improvement. My goal in isolating these changes is it should be obvious just from looking at the diff that the behavior is unchanged.