### PR TITLE
Ranges Algorithms Modernization - Return

### DIFF
--- a/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
@@ -62,7 +62,7 @@ bool IsPathAndroidContent(std::string_view uri)
 std::string OpenModeToAndroid(std::string mode)
 {
   // The 'b' specifier is not supported by Android. Since we're on POSIX, it's fine to just skip it.
-  mode.erase(std::remove(mode.begin(), mode.end(), 'b'));
+  std::erase(mode, 'b');
 
   if (mode == "r")
     return "r";

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -98,7 +98,8 @@ std::vector<std::string> DoFileSearch(const std::vector<std::string>& directorie
   // not because std::filesystem returns duplicates). Also note that this pathname-based uniqueness
   // isn't as thorough as std::filesystem::equivalent.
   std::ranges::sort(result);
-  result.erase(std::unique(result.begin(), result.end()), result.end());
+  const auto unique_result = std::ranges::unique(result);
+  result.erase(unique_result.begin(), unique_result.end());
 
   // Dolphin expects to be able to use "/" (DIR_SEP) everywhere.
   // std::filesystem uses the OS separator.

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -1085,10 +1085,10 @@ void WiiSockMan::UpdatePollCommands()
       std::vector<int> original_order(pfds.size());
       std::iota(original_order.begin(), original_order.end(), 0);
       // Select indices with valid fds
-      auto mid = std::partition(original_order.begin(), original_order.end(), [&](auto i) {
+      const auto partition_result = std::ranges::partition(original_order, [&](auto i) {
         return GetHostSocket(memory.Read_U32(pcmd.buffer_out + 0xc * i)) >= 0;
       });
-      const auto n_valid = std::distance(original_order.begin(), mid);
+      const auto n_valid = std::distance(original_order.begin(), partition_result.begin());
 
       // Move all the valid pollfds to the front of the vector
       for (auto i = 0; i < n_valid; ++i)

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1081,11 +1081,11 @@ void MovieManager::LoadInput(const std::string& movie_path)
       std::vector<u8> movInput(m_current_byte);
       t_record.ReadArray(movInput.data(), movInput.size());
 
-      const auto result = std::mismatch(movInput.begin(), movInput.end(), m_temp_input.begin());
+      const auto mismatch_result = std::ranges::mismatch(movInput, m_temp_input);
 
-      if (result.first != movInput.end())
+      if (mismatch_result.in1 != movInput.end())
       {
-        const ptrdiff_t mismatch_index = std::distance(movInput.begin(), result.first);
+        const ptrdiff_t mismatch_index = std::distance(movInput.begin(), mismatch_result.in1);
 
         // this is a "you did something wrong" alert for the user's benefit.
         // we'll try to say what's going on in excruciating detail, otherwise the user might not

--- a/Source/Core/DiscIO/NANDImporter.cpp
+++ b/Source/Core/DiscIO/NANDImporter.cpp
@@ -240,11 +240,9 @@ bool NANDImporter::ExtractCertificates()
 
   for (const PEMCertificate& certificate : certificates)
   {
-    const auto search_result =
-        std::search(content_bytes.begin(), content_bytes.end(), certificate.search_bytes.begin(),
-                    certificate.search_bytes.end());
+    const auto search_result = std::ranges::search(content_bytes, certificate.search_bytes);
 
-    if (search_result == content_bytes.end())
+    if (search_result.empty())
     {
       ERROR_LOG_FMT(DISCIO, "ExtractCertificates: Could not find offset for certficate '{}'",
                     certificate.filename);
@@ -252,7 +250,8 @@ bool NANDImporter::ExtractCertificates()
     }
 
     const std::string pem_file_path = m_nand_root + std::string(certificate.filename);
-    const ptrdiff_t certificate_offset = std::distance(content_bytes.begin(), search_result);
+    const ptrdiff_t certificate_offset =
+        std::distance(content_bytes.begin(), search_result.begin());
     constexpr int min_offset = 2;
     if (certificate_offset < min_offset)
     {

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -309,11 +309,9 @@ void Settings::RemovePath(const QString& qpath)
   std::string path = qpath.toStdString();
   std::vector<std::string> paths = Config::GetIsoPaths();
 
-  auto new_end = std::remove(paths.begin(), paths.end(), path);
-  if (new_end == paths.end())
+  if (std::erase(paths, path) == 0)
     return;
 
-  paths.erase(new_end, paths.end());
   Config::SetIsoPaths(paths);
   emit PathRemoved(qpath);
 }

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -129,7 +129,8 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
 
   // Remove duplicates
   std::ranges::sort(alternations);
-  alternations.erase(std::unique(alternations.begin(), alternations.end()), alternations.end());
+  const auto unique_result = std::ranges::unique(alternations);
+  alternations.erase(unique_result.begin(), unique_result.end());
 
   return fmt::to_string(fmt::join(alternations, "|"));
 }


### PR DESCRIPTION
In C++20, algorithms from the standard library evolved to feature new niceties and additional compile-time checks. A few of these updated algorithm functions (found in the `std::ranges` namespace) have new return values, and thus code beyond the expression being modernized must also be updated. I have isolated these changes so that they may be recognized and more easily understood.