### PR TITLE
Ranges Algorithms Modernization - Projection

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(common
   PcapFile.h
   Profiler.cpp
   Profiler.h
+  Projection.h
   QoSSession.cpp
   QoSSession.h
   Random.cpp

--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "Common/Projection.h"
+
 namespace Config
 {
 using Layers = std::map<LayerType, std::shared_ptr<Layer>>;
@@ -168,8 +170,7 @@ const std::string& GetSystemName(System system)
 
 std::optional<System> GetSystemFromName(const std::string& name)
 {
-  const auto system = std::find_if(system_to_name.begin(), system_to_name.end(),
-                                   [&name](const auto& entry) { return entry.second == name; });
+  const auto system = std::ranges::find(system_to_name, name, Common::Projection::Value{});
   if (system != system_to_name.end())
     return system->first;
 

--- a/Source/Core/Common/Debug/MemoryPatches.cpp
+++ b/Source/Core/Common/Debug/MemoryPatches.cpp
@@ -63,8 +63,7 @@ const std::vector<MemoryPatch>& MemoryPatches::GetPatches() const
 
 void MemoryPatches::UnsetPatch(const Core::CPUThreadGuard& guard, u32 address)
 {
-  const auto it = std::find_if(m_patches.begin(), m_patches.end(),
-                               [address](const auto& patch) { return patch.address == address; });
+  const auto it = std::ranges::find(m_patches, address, &MemoryPatch::address);
 
   if (it == m_patches.end())
     return;

--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -485,10 +485,7 @@ static bool Pack(const std::function<bool()>& cancelled, const File::FSTEntry& e
 
 static void SortFST(File::FSTEntry* root)
 {
-  std::sort(root->children.begin(), root->children.end(),
-            [](const File::FSTEntry& lhs, const File::FSTEntry& rhs) {
-              return lhs.virtualName < rhs.virtualName;
-            });
+  std::ranges::sort(root->children, {}, &File::FSTEntry::virtualName);
   for (auto& child : root->children)
     SortFST(&child);
 }

--- a/Source/Core/Common/MemArenaWin.cpp
+++ b/Source/Core/Common/MemArenaWin.cpp
@@ -220,9 +220,7 @@ WindowsMemoryRegion* MemArena::EnsureSplitRegionForMapping(void* start_address, 
   }
 
   // find closest region that is <= the given address by using upper bound and decrementing
-  auto it = std::upper_bound(
-      regions.begin(), regions.end(), address,
-      [](u8* addr, const WindowsMemoryRegion& region) { return addr < region.m_start; });
+  auto it = std::ranges::upper_bound(regions, address, {}, &WindowsMemoryRegion::m_start);
   if (it == regions.begin())
   {
     // this should never happen, implies that the given address is before the start of the
@@ -363,9 +361,7 @@ bool MemArena::JoinRegionsAfterUnmap(void* start_address, size_t size)
   }
 
   // there should be a mapping that matches the request exactly, find it
-  auto it = std::lower_bound(
-      regions.begin(), regions.end(), address,
-      [](const WindowsMemoryRegion& region, u8* addr) { return region.m_start < addr; });
+  auto it = std::ranges::lower_bound(regions, address, {}, &WindowsMemoryRegion::m_start);
   if (it == regions.end() || it->m_start != address || it->m_size != size)
   {
     // didn't find it, we were given bogus input

--- a/Source/Core/Common/Projection.h
+++ b/Source/Core/Common/Projection.h
@@ -1,0 +1,30 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <utility>
+
+namespace Common::Projection
+{
+struct First
+{
+  // TODO C++23: static operator()
+  template <class T>
+  [[nodiscard]] constexpr auto&& operator()(T&& t) const noexcept
+  {
+    return std::forward<T>(t).first;
+  }
+};
+
+struct Second
+{
+  // TODO C++23: static operator()
+  template <class T>
+  [[nodiscard]] constexpr auto&& operator()(T&& t) const noexcept
+  {
+    return std::forward<T>(t).second;
+  }
+};
+
+using Key = First;
+using Value = Second;
+}  // namespace Common::Projection

--- a/Source/Core/Core/DSP/DSPTables.cpp
+++ b/Source/Core/Core/DSP/DSPTables.cpp
@@ -525,8 +525,7 @@ std::array<const DSPOPCTemplate*, EXT_OPTABLE_SIZE> s_ext_op_table;
 template <size_t N>
 auto FindByName(std::string_view name, const std::array<DSPOPCTemplate, N>& data)
 {
-  return std::find_if(data.cbegin(), data.cend(),
-                      [&name](const auto& info) { return name == info.name; });
+  return std::ranges::find(data, name, &DSPOPCTemplate::name);
 }
 }  // Anonymous namespace
 

--- a/Source/Core/Core/DSP/LabelMap.cpp
+++ b/Source/Core/Core/DSP/LabelMap.cpp
@@ -63,8 +63,7 @@ bool LabelMap::RegisterLabel(std::string label, u16 lval, LabelType type)
 
 void LabelMap::DeleteLabel(std::string_view label)
 {
-  const auto iter = std::find_if(labels.cbegin(), labels.cend(),
-                                 [&label](const auto& entry) { return entry.name == label; });
+  const auto iter = std::ranges::find(labels, label, &Label::name);
 
   if (iter == labels.cend())
     return;

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -240,8 +240,7 @@ bool IsEnabled(HookFlag flag, PowerPC::CoreMode mode)
 
 u32 UnPatch(Core::System& system, std::string_view patch_name)
 {
-  const auto patch = std::find_if(std::begin(os_patches), std::end(os_patches),
-                                  [&](const Hook& p) { return patch_name == p.name; });
+  const auto patch = std::ranges::find(os_patches, patch_name, &Hook::name);
   if (patch == std::end(os_patches))
     return 0;
 

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -22,6 +22,7 @@
 #include "Common/Crypto/SHA1.h"
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
+#include "Common/Projection.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
 #include "Core/CommonTitles.h"
@@ -571,8 +572,7 @@ SharedContentMap::~SharedContentMap() = default;
 std::optional<std::string>
 SharedContentMap::GetFilenameFromSHA1(const std::array<u8, 20>& sha1) const
 {
-  const auto it = std::find_if(m_entries.begin(), m_entries.end(),
-                               [&sha1](const auto& entry) { return entry.sha1 == sha1; });
+  const auto it = std::ranges::find(m_entries, sha1, &Entry::sha1);
   if (it == m_entries.end())
     return {};
 
@@ -670,8 +670,7 @@ UIDSys::UIDSys(HLE::FSCore& fs_core) : m_fs{fs_core.GetFS()}
 
 u32 UIDSys::GetUIDFromTitle(u64 title_id) const
 {
-  const auto it = std::find_if(m_entries.begin(), m_entries.end(),
-                               [title_id](const auto& entry) { return entry.second == title_id; });
+  const auto it = std::ranges::find(m_entries, title_id, Common::Projection::Value{});
   return (it == m_entries.end()) ? 0 : it->first;
 }
 

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -686,17 +686,17 @@ Result<std::vector<std::string>> HostFileSystem::ReadDirectory(Uid uid, Gid gid,
 
   // Now sort in reverse order because Nintendo traverses a linked list
   // in which new elements are inserted at the front.
-  std::sort(host_entry.children.begin(), host_entry.children.end(),
-            [&get_key](const File::FSTEntry& one, const File::FSTEntry& two) {
-              const int key1 = get_key(one.virtualName);
-              const int key2 = get_key(two.virtualName);
-              if (key1 != key2)
-                return key1 > key2;
+  std::ranges::sort(host_entry.children,
+                    [&get_key](const File::FSTEntry& one, const File::FSTEntry& two) {
+                      const int key1 = get_key(one.virtualName);
+                      const int key2 = get_key(two.virtualName);
+                      if (key1 != key2)
+                        return key1 > key2;
 
-              // For files that are not in the FST, sort lexicographically to ensure that
-              // results are consistent no matter what the underlying filesystem is.
-              return one.virtualName > two.virtualName;
-            });
+                      // For files that are not in the FST, sort lexicographically to ensure that
+                      // results are consistent no matter what the underlying filesystem is.
+                      return one.virtualName > two.virtualName;
+                    });
 
   std::vector<std::string> output;
   for (const File::FSTEntry& child : host_entry.children)

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -105,9 +105,8 @@ constexpr u32 PLACEHOLDER = 0xDEADBEEF;
 
 static bool SetupMemory(Memory::MemoryManager& memory, u64 ios_title_id, MemorySetupType setup_type)
 {
-  auto target_imv = std::find_if(
-      GetMemoryValues().begin(), GetMemoryValues().end(),
-      [&](const MemoryValues& imv) { return imv.ios_number == (ios_title_id & 0xffff); });
+  auto target_imv = std::ranges::find(GetMemoryValues(), static_cast<u16>(ios_title_id & 0xffff),
+                                      &MemoryValues::ios_number);
 
   if (target_imv == GetMemoryValues().end())
   {

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -16,6 +16,7 @@
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
+#include "Common/Projection.h"
 #include "Common/SettingsHandler.h"
 #include "Common/StringUtil.h"
 
@@ -62,8 +63,7 @@ u8 GetAreaCode(std::string_view area)
       {"CHN", 6},
   }};
 
-  const auto entry_pos = std::find_if(regions.cbegin(), regions.cend(),
-                                      [&area](const auto& entry) { return entry.first == area; });
+  const auto entry_pos = std::ranges::find(regions, area, Common::Projection::Key{});
   if (entry_pos != regions.end())
     return entry_pos->second;
 
@@ -79,8 +79,7 @@ HardwareModel GetHardwareModel(std::string_view model)
       {"RVD", HardwareModel::RVD},
   }};
 
-  const auto entry_pos = std::find_if(models.cbegin(), models.cend(),
-                                      [&model](const auto& entry) { return entry.first == model; });
+  const auto entry_pos = std::ranges::find(models, model, Common::Projection::Key{});
   if (entry_pos != models.cend())
     return entry_pos->second;
 

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1538,9 +1538,7 @@ void NetPlayClient::DisplayPlayersPing()
 
 u32 NetPlayClient::GetPlayersMaxPing() const
 {
-  return std::max_element(
-             m_players.begin(), m_players.end(),
-             [](const auto& a, const auto& b) { return a.second.ping < b.second.ping; })
+  return std::ranges::max_element(m_players, {}, [](const auto& kv) { return kv.second.ping; })
       ->second.ping;
 }
 

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2407,22 +2407,14 @@ bool NetPlayClient::IsFirstInGamePad(int ingame_pad) const
                       [](auto mapping) { return mapping > 0; });
 }
 
-static int CountLocalPads(const PadMappingArray& pad_map, const PlayerId& local_player_pid)
-{
-  return static_cast<int>(
-      std::count_if(pad_map.begin(), pad_map.end(), [&local_player_pid](const auto& mapping) {
-        return mapping == local_player_pid;
-      }));
-}
-
 int NetPlayClient::NumLocalPads() const
 {
-  return CountLocalPads(m_pad_map, m_local_player->pid);
+  return std::ranges::count(m_pad_map, m_local_player->pid);
 }
 
 int NetPlayClient::NumLocalWiimotes() const
 {
-  return CountLocalPads(m_wiimote_map, m_local_player->pid);
+  return std::ranges::count(m_wiimote_map, m_local_player->pid);
 }
 
 static int InGameToLocal(int ingame_pad, const PadMappingArray& pad_map, PlayerId local_player_pid)

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -49,8 +49,7 @@ const TBreakPoint* BreakPoints::GetBreakpoint(u32 address) const
 
 const TBreakPoint* BreakPoints::GetRegularBreakpoint(u32 address) const
 {
-  auto bp = std::find_if(m_breakpoints.begin(), m_breakpoints.end(),
-                         [address](const auto& bp_) { return bp_.address == address; });
+  auto bp = std::ranges::find(m_breakpoints, address, &TBreakPoint::address);
 
   if (bp == m_breakpoints.end())
     return nullptr;
@@ -127,8 +126,7 @@ void BreakPoints::Add(u32 address, bool break_on_hit, bool log_on_hit,
 {
   // Check for existing breakpoint, and overwrite with new info.
   // This is assuming we usually want the new breakpoint over an old one.
-  auto iter = std::find_if(m_breakpoints.begin(), m_breakpoints.end(),
-                           [address](const auto& bp) { return bp.address == address; });
+  auto iter = std::ranges::find(m_breakpoints, address, &TBreakPoint::address);
 
   TBreakPoint bp;  // breakpoint settings
   bp.is_enabled = true;
@@ -176,8 +174,7 @@ bool BreakPoints::ToggleBreakPoint(u32 address)
 
 bool BreakPoints::ToggleEnable(u32 address)
 {
-  auto iter = std::find_if(m_breakpoints.begin(), m_breakpoints.end(),
-                           [address](const auto& bp) { return bp.address == address; });
+  auto iter = std::ranges::find(m_breakpoints, address, &TBreakPoint::address);
 
   if (iter == m_breakpoints.end())
     return false;
@@ -188,8 +185,7 @@ bool BreakPoints::ToggleEnable(u32 address)
 
 bool BreakPoints::Remove(u32 address)
 {
-  const auto iter = std::find_if(m_breakpoints.begin(), m_breakpoints.end(),
-                                 [address](const auto& bp) { return bp.address == address; });
+  const auto iter = std::ranges::find(m_breakpoints, address, &TBreakPoint::address);
 
   if (iter == m_breakpoints.cend())
     return false;
@@ -296,9 +292,7 @@ void MemChecks::Add(TMemCheck memory_check, bool update)
   // Check for existing breakpoint, and overwrite with new info.
   // This is assuming we usually want the new breakpoint over an old one.
   const u32 address = memory_check.start_address;
-  auto old_mem_check =
-      std::find_if(m_mem_checks.begin(), m_mem_checks.end(),
-                   [address](const auto& check) { return check.start_address == address; });
+  auto old_mem_check = std::ranges::find(m_mem_checks, address, &TMemCheck::start_address);
   if (old_mem_check != m_mem_checks.end())
   {
     memory_check.is_enabled = old_mem_check->is_enabled;  // Preserve enabled status
@@ -316,8 +310,7 @@ void MemChecks::Add(TMemCheck memory_check, bool update)
 
 bool MemChecks::ToggleEnable(u32 address)
 {
-  auto iter = std::find_if(m_mem_checks.begin(), m_mem_checks.end(),
-                           [address](const auto& bp) { return bp.start_address == address; });
+  auto iter = std::ranges::find(m_mem_checks, address, &TMemCheck::start_address);
 
   if (iter == m_mem_checks.end())
     return false;
@@ -328,9 +321,7 @@ bool MemChecks::ToggleEnable(u32 address)
 
 bool MemChecks::Remove(u32 address, bool update)
 {
-  const auto iter =
-      std::find_if(m_mem_checks.cbegin(), m_mem_checks.cend(),
-                   [address](const auto& check) { return check.start_address == address; });
+  const auto iter = std::ranges::find(m_mem_checks, address, &TMemCheck::start_address);
 
   if (iter == m_mem_checks.cend())
     return false;

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -521,10 +521,9 @@ void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
     }
 
     ASSERT_MSG(DYNA_REC,
-               std::none_of(m_regs.begin(), m_regs.end(),
-                            [xr](const auto& r) {
-                              return r.Location().has_value() && r.Location()->IsSimpleReg(xr);
-                            }),
+               std::ranges::none_of(
+                   m_regs, [xr](const auto& l) { return l.has_value() && l->IsSimpleReg(xr); },
+                   &PPCCachedReg::Location),
                "Xreg {} already bound", Common::ToUnderlying(xr));
 
     m_regs[i].SetBoundTo(xr);

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -16,6 +16,7 @@
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
+#include "Common/Projection.h"
 #include "Common/StringUtil.h"
 
 #include "Core/PowerPC/PowerPC.h"
@@ -694,8 +695,7 @@ void PrintInstructionRunCounts()
     const GekkoOPInfo& info = s_tables.all_instructions[i];
     temp[i] = std::make_pair(info.opname, info.stats->run_count);
   }
-  std::sort(temp.begin(), temp.end(),
-            [](const OpInfo& a, const OpInfo& b) { return a.second > b.second; });
+  std::ranges::sort(temp, std::ranges::greater{}, Common::Projection::Second{});
 
   for (auto& inst : temp)
   {

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -312,11 +312,6 @@ static std::vector<SlotWithTimestamp> GetUsedSlotsWithTimestamp()
   return result;
 }
 
-static bool CompareTimestamp(const SlotWithTimestamp& lhs, const SlotWithTimestamp& rhs)
-{
-  return lhs.timestamp < rhs.timestamp;
-}
-
 static void CompressBufferToFile(const u8* raw_buffer, u64 size, File::IOFile& f)
 {
   u64 total_bytes_compressed = 0;
@@ -999,7 +994,7 @@ void LoadLastSaved(Core::System& system, int i)
     return;
   }
 
-  std::stable_sort(used_slots.begin(), used_slots.end(), CompareTimestamp);
+  std::ranges::stable_sort(used_slots, {}, &SlotWithTimestamp::timestamp);
   Load(system, (used_slots.end() - i)->slot);
 }
 
@@ -1015,7 +1010,7 @@ void SaveFirstSaved(Core::System& system)
   }
 
   // overwrite the oldest state
-  std::stable_sort(used_slots.begin(), used_slots.end(), CompareTimestamp);
+  std::ranges::stable_sort(used_slots, {}, &SlotWithTimestamp::timestamp);
   Save(system, used_slots.front().slot, true);
 }
 

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -228,15 +228,13 @@ SysConf::Entry& SysConf::AddEntry(Entry&& entry)
 
 SysConf::Entry* SysConf::GetEntry(std::string_view key)
 {
-  const auto iterator = std::find_if(m_entries.begin(), m_entries.end(),
-                                     [&key](const auto& entry) { return entry.name == key; });
+  const auto iterator = std::ranges::find(m_entries, key, &Entry::name);
   return iterator != m_entries.end() ? &*iterator : nullptr;
 }
 
 const SysConf::Entry* SysConf::GetEntry(std::string_view key) const
 {
-  const auto iterator = std::find_if(m_entries.begin(), m_entries.end(),
-                                     [&key](const auto& entry) { return entry.name == key; });
+  const auto iterator = std::ranges::find(m_entries, key, &Entry::name);
   return iterator != m_entries.end() ? &*iterator : nullptr;
 }
 

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -43,6 +43,7 @@
 #include "Core/SysConf.h"
 #include "Core/System.h"
 #include "DiscIO/DiscExtractor.h"
+#include "DiscIO/DiscUtils.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/VolumeDisc.h"
@@ -743,10 +744,9 @@ UpdateResult DiscSystemUpdater::DoDiscUpdate()
     return UpdateResult::RegionMismatch;
 
   const auto partitions = m_volume->GetPartitions();
-  const auto update_partition =
-      std::find_if(partitions.cbegin(), partitions.cend(), [&](const DiscIO::Partition& partition) {
-        return m_volume->GetPartitionType(partition) == 1u;
-      });
+  const auto update_partition = std::ranges::find(
+      partitions, DiscIO::PARTITION_UPDATE,
+      [&](const DiscIO::Partition& partition) { return m_volume->GetPartitionType(partition); });
 
   if (update_partition == partitions.cend())
   {

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -862,10 +862,7 @@ static std::vector<u8> ExtractNodeToVector(std::vector<FSTBuilderNode>* nodes, v
                                            DirectoryBlobReader* blob)
 {
   std::vector<u8> data;
-  const auto it =
-      std::find_if(nodes->begin(), nodes->end(), [&userdata](const FSTBuilderNode& node) {
-        return node.m_user_data == userdata;
-      });
+  const auto it = std::ranges::find(*nodes, userdata, &FSTBuilderNode::m_user_data);
   if (it == nodes->end() || !it->IsFile())
     return data;
 

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -1192,15 +1192,13 @@ void DirectoryBlobPartition::WriteDirectory(std::vector<u8>* fst_data,
   std::vector<FSTBuilderNode>& sorted_entries = *parent_entries;
 
   // Sort for determinism
-  std::sort(sorted_entries.begin(), sorted_entries.end(),
-            [](const FSTBuilderNode& one, const FSTBuilderNode& two) {
-              std::string one_upper = one.m_filename;
-              std::string two_upper = two.m_filename;
-              Common::ToUpper(&one_upper);
-              Common::ToUpper(&two_upper);
-              return one_upper == two_upper ? one.m_filename < two.m_filename :
-                                              one_upper < two_upper;
-            });
+  std::ranges::sort(sorted_entries, [](const FSTBuilderNode& one, const FSTBuilderNode& two) {
+    std::string one_upper = one.m_filename;
+    std::string two_upper = two.m_filename;
+    Common::ToUpper(&one_upper);
+    Common::ToUpper(&two_upper);
+    return one_upper == two_upper ? one.m_filename < two.m_filename : one_upper < two_upper;
+  });
 
   for (FSTBuilderNode& entry : sorted_entries)
   {

--- a/Source/Core/DiscIO/RiivolutionParser.cpp
+++ b/Source/Core/DiscIO/RiivolutionParser.cpp
@@ -146,8 +146,7 @@ std::optional<Disc> ParseString(std::string_view xml, std::string xml_path)
       const std::string macro_id = macro_node.attribute("id").as_string();
       for (auto& section : disc.m_sections)
       {
-        auto option_to_clone = std::find_if(section.m_options.begin(), section.m_options.end(),
-                                            [&](const Option& o) { return o.m_id == macro_id; });
+        auto option_to_clone = std::ranges::find(section.m_options, macro_id, &Option::m_id);
         if (option_to_clone == section.m_options.end())
           continue;
 
@@ -305,8 +304,7 @@ std::vector<Patch> Disc::GeneratePatches(const std::string& game_id) const
       const Choice& choice = option.m_choices[selected - 1];
       for (const auto& patch_ref : choice.m_patch_references)
       {
-        const auto patch = std::find_if(m_patches.begin(), m_patches.end(),
-                                        [&](const Patch& p) { return patch_ref.m_id == p.m_id; });
+        const auto patch = std::ranges::find(m_patches, patch_ref.m_id, &Patch::m_id);
         if (patch == m_patches.end())
           continue;
 

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -1053,8 +1053,7 @@ void VolumeVerifier::SetUpHashing()
     m_scrubber.SetupScrub(m_volume);
   }
 
-  std::sort(m_groups.begin(), m_groups.end(),
-            [](const GroupToVerify& a, const GroupToVerify& b) { return a.offset < b.offset; });
+  std::ranges::sort(m_groups, {}, &GroupToVerify::offset);
 
   if (m_hashes_to_calculate.crc32)
     m_crc32_context = Common::StartCRC32();

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -1335,8 +1335,7 @@ void VolumeVerifier::Finish()
   }
 
   // Show the most serious problems at the top
-  std::stable_sort(m_result.problems.begin(), m_result.problems.end(),
-                   [](const Problem& p1, const Problem& p2) { return p1.severity > p2.severity; });
+  std::ranges::stable_sort(m_result.problems, std::ranges::greater{}, &Problem::severity);
   const Severity highest_severity =
       m_result.problems.empty() ? Severity::None : m_result.problems[0].severity;
 

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -941,8 +941,7 @@ ConversionResultCode WIARVZFileReader<RVZ>::SetUpDataEntriesForWriting(
   if (volume && volume->HasWiiHashes() && volume->HasWiiEncryption())
     partitions = volume->GetPartitions();
 
-  std::sort(partitions.begin(), partitions.end(),
-            [](const Partition& a, const Partition& b) { return a.offset < b.offset; });
+  std::ranges::sort(partitions, {}, &Partition::offset);
 
   *total_groups = 0;
 

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -1372,8 +1372,8 @@ WIARVZFileReader<RVZ>::ProcessAndCompress(CompressThreadState* state, CompressPa
       TryReuse(reusable_groups, reusable_groups_mutex, &entry);
       if (!entry.reused_group && reuse_id)
       {
-        const auto it = std::find_if(output_entries.begin(), output_entries.begin() + i,
-                                     [reuse_id](const auto& e) { return e.reuse_id == reuse_id; });
+        const auto it = std::ranges::find(output_entries.begin(), output_entries.begin() + i,
+                                          reuse_id, &OutputParametersEntry::reuse_id);
         if (it != output_entries.begin() + i)
           entry.reused_group = it->reused_group;
       }

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -144,6 +144,7 @@
     <ClInclude Include="Common\Network.h" />
     <ClInclude Include="Common\PcapFile.h" />
     <ClInclude Include="Common\Profiler.h" />
+    <ClInclude Include="Common\Projection.h" />
     <ClInclude Include="Common\QoSSession.h" />
     <ClInclude Include="Common\Random.h" />
     <ClInclude Include="Common\Result.h" />

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -154,10 +154,9 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
             [group_enable_checkbox, group] { group_enable_checkbox->setChecked(group->enabled); });
   }
 
-  const auto advanced_setting_count = std::count_if(
-      group->numeric_settings.begin(), group->numeric_settings.end(), [](auto& setting) {
-        return setting->GetVisibility() == ControllerEmu::SettingVisibility::Advanced;
-      });
+  const auto advanced_setting_count =
+      std::ranges::count(group->numeric_settings, ControllerEmu::SettingVisibility::Advanced,
+                         &ControllerEmu::NumericSettingBase::GetVisibility);
 
   if (advanced_setting_count != 0)
   {

--- a/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
+++ b/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
@@ -181,8 +181,8 @@ QGroupBox* NewPatchDialog::CreateEntry(const PatchEngine::PatchEntry& entry)
       m_entry_layout->removeWidget(box);
       box->deleteLater();
 
-      m_entries.erase(std::find_if(m_entries.begin(), m_entries.end(),
-                                   [new_entry](const auto& e) { return e.get() == new_entry; }));
+      m_entries.erase(
+          std::ranges::find(m_entries, new_entry, [](const auto& e) { return e.get(); }));
     }
   });
 

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -433,13 +433,9 @@ void CodeViewWidget::CalculateBranchIndentation()
 
   // process in order of how much vertical space the drawn arrow would take up
   // so shorter arrows go further to the left
-  const auto priority = [](const CodeViewBranch& b) {
+  std::ranges::stable_sort(m_branches, {}, [](const CodeViewBranch& b) {
     return b.is_link ? 0 : (std::max(b.src_addr, b.dst_addr) - std::min(b.src_addr, b.dst_addr));
-  };
-  std::stable_sort(m_branches.begin(), m_branches.end(),
-                   [&priority](const CodeViewBranch& lhs, const CodeViewBranch& rhs) {
-                     return priority(lhs) < priority(rhs);
-                   });
+  });
 
   // build a 2D lookup table representing the columns and rows the arrow could be drawn in
   // and try to place all branch arrows in it as far left as possible

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -273,18 +273,14 @@ bool ControllerInterface::AddDevice(std::shared_ptr<ciface::Core::Device> device
     NOTICE_LOG_FMT(CONTROLLERINTERFACE, "Added device: {}", device->GetQualifiedName());
     m_devices.emplace_back(std::move(device));
 
-    // We can't (and don't want) to control the order in which devices are added, but we
-    // need their order to be consistent, and we need the same one to always be the first, where
-    // present (the keyboard and mouse device usually). This is because when defaulting a
-    // controller profile, it will automatically select the first device in the list as its default.
-    std::stable_sort(m_devices.begin(), m_devices.end(),
-                     [](const std::shared_ptr<ciface::Core::Device>& a,
-                        const std::shared_ptr<ciface::Core::Device>& b) {
-                       // It would be nice to sort devices by Source then Name then ID but it's
-                       // better to leave them sorted by the add order, which also avoids breaking
-                       // the order on other platforms that are less tested.
-                       return a->GetSortPriority() > b->GetSortPriority();
-                     });
+    // We can't (and don't want) to control the order in which devices are added, but we need
+    // their order to be consistent, and we need the same one to always be the first, where present
+    // (the keyboard and mouse device usually). This is because when defaulting a controller
+    // profile, it will automatically select the first device in the list as its default. It would
+    // be nice to sort devices by Source then Name then ID, but it's better to leave them sorted by
+    // the add order. This also avoids breaking the order on other platforms that are less tested.
+    std::ranges::stable_sort(m_devices, std::ranges::greater{},
+                             &ciface::Core::Device::GetSortPriority);
   }
 
   if (!m_populating_devices_counter)

--- a/Source/Core/MacUpdater/MacUI.mm
+++ b/Source/Core/MacUpdater/MacUI.mm
@@ -148,9 +148,8 @@ bool UI::IsTestMode()
 bool Platform::VersionCheck(const std::vector<TodoList::UpdateOp>& to_update,
                             const std::string& install_base_path, const std::string& temp_dir)
 {
-  const auto op_it = std::find_if(to_update.cbegin(), to_update.cend(), [&](const auto& op) {
-    return op.filename == "Dolphin.app/Contents/Info.plist";
-  });
+  const auto op_it = std::ranges::find(to_update, "Dolphin.app/Contents/Info.plist",
+                                       &TodoList::UpdateOp::filename);
   if (op_it == to_update.cend())
     return true;
 

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -65,9 +65,7 @@ void GameFileCache::Clear(DeleteOnDisk delete_on_disk)
 std::shared_ptr<const GameFile> GameFileCache::AddOrGet(const std::string& path,
                                                         bool* cache_changed)
 {
-  auto it = std::find_if(
-      m_cached_files.begin(), m_cached_files.end(),
-      [&path](const std::shared_ptr<GameFile>& file) { return file->GetFilePath() == path; });
+  auto it = std::ranges::find(m_cached_files, path, &GameFile::GetFilePath);
   const bool found = it != m_cached_files.cend();
   if (!found)
   {

--- a/Source/Core/UICommon/ResourcePack/Manager.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manager.cpp
@@ -53,9 +53,7 @@ bool Init()
     pack_list_order.emplace_back(OrderHelper{i, std::move(manifest_id)});
   }
 
-  std::sort(
-      pack_list_order.begin(), pack_list_order.end(),
-      [](const OrderHelper& a, const OrderHelper& b) { return a.manifest_id < b.manifest_id; });
+  std::ranges::sort(pack_list_order, {}, &OrderHelper::manifest_id);
 
   bool error = false;
   for (size_t i = 0; i < pack_list_order.size(); ++i)

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomPipeline.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomPipeline.cpp
@@ -165,10 +165,8 @@ std::vector<std::string> GlobalConflicts(std::string_view source)
   // Sort the conflicts from largest to smallest string
   // this way we can ensure smaller strings that are a substring
   // of the larger string are able to be replaced appropriately
-  std::sort(global_result.begin(), global_result.end(),
-            [](const std::string& first, const std::string& second) {
-              return first.size() > second.size();
-            });
+  std::ranges::sort(global_result, std::ranges::greater{},
+                    [](const std::string& s) { return s.size(); });
   return global_result;
 }
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2026,8 +2026,7 @@ void TextureCacheBase::StitchXFBCopy(RcTcacheEntry& stitched_entry)
   if (candidates.empty())
     return;
 
-  std::sort(candidates.begin(), candidates.end(),
-            [](const TCacheEntry* a, const TCacheEntry* b) { return a->id < b->id; });
+  std::ranges::sort(candidates, {}, &TCacheEntry::id);
 
   // We only upscale when necessary to preserve resolution. i.e. when there are upscaled partial
   // copies to be stitched together.

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1665,11 +1665,8 @@ RcTcacheEntry TextureCacheBase::CreateTextureEntry(
   if (!assets_data.empty())
   {
     const auto calculate_max_levels = [&]() {
-      const auto max_element = std::max_element(
-          assets_data.begin(), assets_data.end(), [](const auto& lhs, const auto& rhs) {
-            return lhs->m_texture.m_slices[0].m_levels.size() <
-                   rhs->m_texture.m_slices[0].m_levels.size();
-          });
+      const auto max_element = std::ranges::max_element(
+          assets_data, {}, [](const auto& v) { return v->m_texture.m_slices[0].m_levels.size(); });
       return (*max_element)->m_texture.m_slices[0].m_levels.size();
     };
     const u32 texLevels = no_mips ? 1 : (u32)calculate_max_levels();

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -278,9 +278,7 @@ void VideoBackendBase::ActivateBackend(const std::string& name)
     g_video_backend = GetDefaultVideoBackend();
 
   const auto& backends = GetAvailableBackends();
-  const auto iter = std::find_if(backends.begin(), backends.end(), [&name](const auto& backend) {
-    return name == backend->GetName();
-  });
+  const auto iter = std::ranges::find(backends, name, &VideoBackendBase::GetName);
 
   if (iter == backends.end())
     return;

--- a/Source/Core/WinUpdater/Platform.cpp
+++ b/Source/Core/WinUpdater/Platform.cpp
@@ -250,8 +250,7 @@ std::optional<BuildInfos> InitBuildInfos(const std::vector<TodoList::UpdateOp>& 
                                          const std::string& install_base_path,
                                          const std::string& temp_dir)
 {
-  const auto op_it = std::find_if(to_update.cbegin(), to_update.cend(),
-                                  [&](const auto& op) { return op.filename == "build_info.txt"; });
+  const auto op_it = std::ranges::find(to_update, "build_info.txt", &TodoList::UpdateOp::filename);
   if (op_it == to_update.cend())
     return {};
 


### PR DESCRIPTION
In C++20, algorithms from the standard library evolved to feature new niceties and additional compile-time checks. A lesser-known feature of these updated algorithm functions (found in the `std::ranges` namespace) is [range projections](https://ezoeryou.github.io/blog/article/2019-01-22-ranges-projection.html). Range projections are a fantastic feature for expressing what you really mean instead of opening yet another lambda to write a boilerplate predicate or comparison function. Projections also allow some algorithms, namely `std::find_if` and `std::count_if` to be simplified into their non-`if` form, greatly improving readability. Comprehending this new approach to using standard algorithms in so many places across the codebase is a bit taxing on the mind, so for that reason I have isolated these changes.

The standard library offers very few built-in range projections, so for this reason I opted to invent two new ones in the new "Common/Projections.h" header. `Common::Projections::First` and `Common::Projections::Second` (and their aliases, `Common::Projections::Key` and `Common::Projections::Value` respectively) exist for the common scenario in which only the first or second member from a `std::pair` needs to be considered in an algorithm. I found enough use-cases for these projections that I thought it was worthwhile to codify this operation into something reusable.