### PR TITLE
Ranges Algorithms Modernization - Contains

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(common
   Config/Enums.h
   Config/Layer.cpp
   Config/Layer.h
+  Contains.h
   CPUDetect.h
   Crypto/AES.cpp
   Crypto/AES.h

--- a/Source/Core/Common/Contains.h
+++ b/Source/Core/Common/Contains.h
@@ -1,0 +1,61 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <iterator>
+
+namespace Common
+{
+struct ContainsFn
+{
+  template <std::input_iterator I, std::sentinel_for<I> S, class T, class Proj = std::identity>
+  requires std::indirect_binary_predicate < std::ranges::equal_to, std::projected<I, Proj>,
+  const T* > constexpr bool operator()(I first, S last, const T& value, Proj proj = {}) const
+  {
+    return std::ranges::find(std::move(first), last, value, std::move(proj)) != last;
+  }
+
+  template <std::ranges::input_range R, class T, class Proj = std::identity>
+  requires std::indirect_binary_predicate < std::ranges::equal_to,
+      std::projected<std::ranges::iterator_t<R>, Proj>,
+  const T* > constexpr bool operator()(R&& r, const T& value, Proj proj = {}) const
+  {
+    return (*this)(std::ranges::begin(r), std::ranges::end(r), value, std::move(proj));
+  }
+};
+
+struct ContainsSubrangeFn
+{
+  template <std::forward_iterator I1, std::sentinel_for<I1> S1, std::forward_iterator I2,
+            std::sentinel_for<I2> S2, class Pred = std::ranges::equal_to,
+            class Proj1 = std::identity, class Proj2 = std::identity>
+  requires std::indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+  constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                            Proj1 proj1 = {}, Proj2 proj2 = {}) const
+  {
+    return !std::ranges::search(std::move(first1), std::move(last1), std::move(first2),
+                                std::move(last2), std::move(pred), std::move(proj1),
+                                std::move(proj2))
+                .empty();
+  }
+
+  template <std::ranges::forward_range R1, std::ranges::forward_range R2,
+            class Pred = std::ranges::equal_to, class Proj1 = std::identity,
+            class Proj2 = std::identity>
+  requires std::indirectly_comparable<std::ranges::iterator_t<R1>, std::ranges::iterator_t<R2>,
+                                      Pred, Proj1, Proj2>
+  constexpr bool operator()(R1&& r1, R2&& r2, Pred pred = {}, Proj1 proj1 = {},
+                            Proj2 proj2 = {}) const
+  {
+    return (*this)(std::ranges::begin(r1), std::ranges::end(r1), std::ranges::begin(r2),
+                   std::ranges::end(r2), std::move(pred), std::move(proj1), std::move(proj2));
+  }
+};
+
+// TODO C++23: Replace with std::ranges::contains.
+inline constexpr ContainsFn Contains{};
+// TODO C++23: Replace with std::ranges::contains_subrange.
+inline constexpr ContainsSubrangeFn ContainsSubrange{};
+}  // namespace Common

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -11,6 +11,7 @@
 #include <fmt/ranges.h>
 
 #include "Common/CommonTypes.h"
+#include "Common/Contains.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
@@ -105,9 +106,8 @@ bool IsTitlePath(const std::string& path, std::optional<FromWhichRoot> from, u64
 
 static bool IsIllegalCharacter(char c)
 {
-  static constexpr auto illegal_chars = {'\"', '*', '/', ':', '<', '>', '?', '\\', '|', '\x7f'};
-  return static_cast<unsigned char>(c) <= 0x1F ||
-         std::find(illegal_chars.begin(), illegal_chars.end(), c) != illegal_chars.end();
+  static constexpr char illegal_chars[] = {'\"', '*', '/', ':', '<', '>', '?', '\\', '|', '\x7f'};
+  return static_cast<unsigned char>(c) <= 0x1F || Common::Contains(illegal_chars, c);
 }
 
 std::string EscapeFileName(const std::string& filename)

--- a/Source/Core/Core/Config/DefaultLocale.cpp
+++ b/Source/Core/Core/Config/DefaultLocale.cpp
@@ -17,6 +17,7 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Contains.h"
 #include "Common/StringUtil.h"
 #include "Core/Host.h"
 #include "DiscIO/Enums.h"
@@ -38,17 +39,13 @@ static std::optional<DiscIO::Language> TryParseLanguage(const std::string& local
   // Special handling of Chinese due to its two writing systems
   if (split_locale[0] == "zh")
   {
-    const auto locale_contains = [&split_locale](std::string_view str) {
-      return std::find(split_locale.cbegin(), split_locale.cend(), str) != split_locale.cend();
-    };
-
-    if (locale_contains("Hans"))
+    if (Common::Contains(split_locale, "Hans"))
       return DiscIO::Language::SimplifiedChinese;
-    if (locale_contains("Hant"))
+    if (Common::Contains(split_locale, "Hant"))
       return DiscIO::Language::TraditionalChinese;
 
     // Mainland China and Singapore use simplified characters
-    if (locale_contains("CN") || locale_contains("SG"))
+    if (Common::Contains(split_locale, "CN") || Common::Contains(split_locale, "SG"))
       return DiscIO::Language::SimplifiedChinese;
     else
       return DiscIO::Language::TraditionalChinese;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 
+#include "Common/Contains.h"
 #include "Core/Config/WiimoteSettings.h"
 
 namespace ConfigLoaders
@@ -15,8 +16,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
   static constexpr std::array systems_not_saveable = {Config::System::GCPad, Config::System::WiiPad,
                                                       Config::System::GCKeyboard};
 
-  if (std::find(begin(systems_not_saveable), end(systems_not_saveable), config_location.system) ==
-      end(systems_not_saveable))
+  if (!Common::Contains(systems_not_saveable, config_location.system))
   {
     return true;
   }

--- a/Source/Core/Core/Debugger/CodeTrace.cpp
+++ b/Source/Core/Core/Debugger/CodeTrace.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <regex>
 
+#include "Common/Contains.h"
 #include "Common/Event.h"
 #include "Core/Core.h"
 #include "Core/Debugger/PPCDebugInterface.h"
@@ -254,12 +255,9 @@ HitType CodeTrace::TraceLogic(const TraceOutput& current_instr, bool first_hit)
   // The reg_itr will be used later for erasing.
   auto reg_itr = std::ranges::find(m_reg_autotrack, instr.reg0);
   const bool match_reg123 =
-      (!instr.reg1.empty() && std::find(m_reg_autotrack.begin(), m_reg_autotrack.end(),
-                                        instr.reg1) != m_reg_autotrack.end()) ||
-      (!instr.reg2.empty() && std::find(m_reg_autotrack.begin(), m_reg_autotrack.end(),
-                                        instr.reg2) != m_reg_autotrack.end()) ||
-      (!instr.reg3.empty() && std::find(m_reg_autotrack.begin(), m_reg_autotrack.end(),
-                                        instr.reg3) != m_reg_autotrack.end());
+      (!instr.reg1.empty() && Common::Contains(m_reg_autotrack, instr.reg1)) ||
+      (!instr.reg2.empty() && Common::Contains(m_reg_autotrack, instr.reg2)) ||
+      (!instr.reg3.empty() && Common::Contains(m_reg_autotrack, instr.reg3));
   const bool match_reg0 = reg_itr != m_reg_autotrack.end();
 
   if (!match_reg0 && !match_reg123 && !mem_hit)

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -13,6 +13,7 @@
 #include <fmt/format.h>
 
 #include "Common/Align.h"
+#include "Common/Contains.h"
 #include "Common/GekkoDisassembler.h"
 #include "Common/StringUtil.h"
 
@@ -253,7 +254,7 @@ Common::Debug::Threads PPCDebugInterface::GetThreads(const Core::CPUThreadGuard&
   const auto insert_threads = [&guard, &threads, &visited_addrs](u32 addr, auto get_next_addr) {
     while (addr != 0 && PowerPC::MMU::HostIsRAMAddress(guard, addr))
     {
-      if (std::find(visited_addrs.begin(), visited_addrs.end(), addr) != visited_addrs.end())
+      if (Common::Contains(visited_addrs, addr))
         break;
       visited_addrs.push_back(addr);
       auto thread = std::make_unique<Core::Debug::OSThreadView>(guard, addr);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -24,6 +24,7 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Contains.h"
 #include "Common/Event.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -261,9 +262,7 @@ static int GetEmptySlot(const std::vector<SlotWithTimestamp>& used_slots)
 {
   for (int i = 1; i <= (int)NUM_STATES; i++)
   {
-    const auto it = std::find_if(used_slots.begin(), used_slots.end(),
-                                 [i](const SlotWithTimestamp& slot) { return slot.slot == i; });
-    if (it == used_slots.end())
+    if (!Common::Contains(used_slots, i, &SlotWithTimestamp::slot))
       return i;
   }
   return -1;

--- a/Source/Core/Core/WC24PatchEngine.cpp
+++ b/Source/Core/Core/WC24PatchEngine.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <fmt/format.h>
 
+#include "Common/Contains.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 
@@ -86,10 +87,7 @@ static void LoadPatchSection(const Common::IniFile& ini)
 static bool IsWC24Channel()
 {
   const auto& sconfig = SConfig::GetInstance();
-  const auto found =
-      std::find(s_wc24_channels.begin(), s_wc24_channels.end(), sconfig.GetTitleID());
-
-  return found != s_wc24_channels.end();
+  return Common::Contains(s_wc24_channels, sconfig.GetTitleID());
 }
 
 static void LoadPatches()

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -21,6 +21,7 @@
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Contains.h"
 #include "Common/EnumUtils.h"
 #include "Common/FileUtil.h"
 #include "Common/HttpRequest.h"
@@ -590,10 +591,8 @@ UpdateResult OnlineSystemUpdater::InstallTitleFromNUS(const std::string& prefix_
   const UpdateResult import_result = [&]() {
     for (const IOS::ES::Content& content : tmd.first.GetContents())
     {
-      const bool is_already_installed = std::find_if(stored_contents.begin(), stored_contents.end(),
-                                                     [&content](const auto& stored_content) {
-                                                       return stored_content.id == content.id;
-                                                     }) != stored_contents.end();
+      const bool is_already_installed =
+          Common::Contains(stored_contents, content.id, &IOS::ES::Content::id);
 
       // Do skip what is already installed on the NAND.
       if (is_already_installed)

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -21,6 +21,7 @@
 #include "Common/CPUDetect.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
+#include "Common/Contains.h"
 #include "Common/Crypto/SHA1.h"
 #include "Common/FileUtil.h"
 #include "Common/Hash.h"
@@ -453,21 +454,18 @@ std::vector<Partition> VolumeVerifier::CheckPartitions()
       types.emplace_back(*type);
   }
 
-  if (std::find(types.cbegin(), types.cend(), PARTITION_UPDATE) == types.cend())
+  if (!Common::Contains(types, PARTITION_UPDATE))
     AddProblem(Severity::Low, Common::GetStringT("The update partition is missing."));
 
-  const bool has_data_partition =
-      std::find(types.cbegin(), types.cend(), PARTITION_DATA) != types.cend();
+  const bool has_data_partition = Common::Contains(types, PARTITION_DATA);
   if (!m_is_datel && !has_data_partition)
     AddProblem(Severity::High, Common::GetStringT("The data partition is missing."));
 
-  const bool has_channel_partition =
-      std::find(types.cbegin(), types.cend(), PARTITION_CHANNEL) != types.cend();
+  const bool has_channel_partition = Common::Contains(types, PARTITION_CHANNEL);
   if (ShouldHaveChannelPartition() && !has_channel_partition)
     AddProblem(Severity::Medium, Common::GetStringT("The channel partition is missing."));
 
-  const bool has_install_partition =
-      std::find(types.cbegin(), types.cend(), PARTITION_INSTALL) != types.cend();
+  const bool has_install_partition = Common::Contains(types, PARTITION_INSTALL);
   if (ShouldHaveInstallPartition() && !has_install_partition)
     AddProblem(Severity::High, Common::GetStringT("The install partition is missing."));
 

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -144,11 +144,8 @@ RedumpVerifier::DownloadStatus RedumpVerifier::DownloadDatfile(const std::string
     if (File::Exists(output_path))
       return DownloadStatus::FailButOldCacheAvailable;
 
-    const std::string system_not_available_message = "System \"" + system + "\" doesn't exist.";
     const bool system_not_available_match =
-        result->end() != std::search(result->begin(), result->end(),
-                                     system_not_available_message.begin(),
-                                     system_not_available_message.end());
+        Common::ContainsSubrange(*result, "System \"" + system + "\" doesn't exist.");
     return system_not_available_match ? DownloadStatus::SystemNotAvailable : DownloadStatus::Fail;
   }
 

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -38,6 +38,7 @@
     <ClInclude Include="Common\Config\ConfigInfo.h" />
     <ClInclude Include="Common\Config\Enums.h" />
     <ClInclude Include="Common\Config\Layer.h" />
+    <ClInclude Include="Common\Contains.h" />
     <ClInclude Include="Common\CPUDetect.h" />
     <ClInclude Include="Common\Crypto\AES.h" />
     <ClInclude Include="Common\Crypto\bn.h" />

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -16,6 +16,7 @@
 #include <QToolBar>
 #include <QVBoxLayout>
 
+#include "Common/Contains.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Core/ConfigManager.h"
@@ -522,10 +523,7 @@ void BreakpointWidget::OnContextMenu(const QPoint& pos)
   if (!is_memory_breakpoint)
   {
     const auto& inst_breakpoints = m_system.GetPowerPC().GetBreakPoints().GetBreakPoints();
-    const auto bp_iter =
-        std::find_if(inst_breakpoints.begin(), inst_breakpoints.end(),
-                     [bp_address](const auto& bp) { return bp.address == bp_address; });
-    if (bp_iter == inst_breakpoints.end())
+    if (!Common::Contains(inst_breakpoints, bp_address, &TBreakPoint::address))
       return;
 
     menu->addAction(tr("Show in Code"), [this, bp_address] { emit ShowCode(bp_address); });
@@ -538,10 +536,7 @@ void BreakpointWidget::OnContextMenu(const QPoint& pos)
   else
   {
     const auto& memory_breakpoints = m_system.GetPowerPC().GetMemChecks().GetMemChecks();
-    const auto mb_iter =
-        std::find_if(memory_breakpoints.begin(), memory_breakpoints.end(),
-                     [bp_address](const auto& bp) { return bp.start_address == bp_address; });
-    if (mb_iter == memory_breakpoints.end())
+    if (!Common::Contains(memory_breakpoints, bp_address, &TMemCheck::start_address))
       return;
 
     menu->addAction(tr("Show in Memory"), [this, bp_address] { emit ShowMemory(bp_address); });

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -43,6 +43,7 @@
 #include <QUrl>
 
 #include "Common/CommonPaths.h"
+#include "Common/Contains.h"
 #include "Common/FileUtil.h"
 
 #include "Core/Config/MainSettings.h"
@@ -805,8 +806,7 @@ bool GameList::AddShortcutToDesktop()
   // Sanitize the string by removing all characters that cannot be used in NTFS file names
   std::erase_if(game_name, [](char ch) {
     static constexpr char illegal_characters[] = {'<', '>', ':', '\"', '/', '\\', '|', '?', '*'};
-    return std::find(std::begin(illegal_characters), std::end(illegal_characters), ch) !=
-           std::end(illegal_characters);
+    return Common::Contains(illegal_characters, ch);
   });
 
   std::wstring desktop_path = std::wstring(desktop.get()) + UTF8ToTStr("\\" + game_name + ".lnk");

--- a/Source/Core/DolphinQt/NetPlay/ChunkedProgressDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/ChunkedProgressDialog.cpp
@@ -16,6 +16,7 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
+#include "Common/Contains.h"
 #include "Core/NetPlayClient.h"
 #include "Core/NetPlayServer.h"
 
@@ -108,7 +109,7 @@ void ChunkedProgressDialog::show(const QString& title, const u64 data_size,
 
   for (const auto* player : client->GetPlayers())
   {
-    if (std::find(players.begin(), players.end(), player->pid) == players.end())
+    if (!Common::Contains(players, player->pid))
       continue;
 
     m_progress_bars[player->pid] = new QProgressBar;

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -22,6 +22,7 @@
 #include "AudioCommon/AudioCommon.h"
 
 #include "Common/Config/Config.h"
+#include "Common/Contains.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
@@ -296,7 +297,7 @@ void Settings::AddPath(const QString& qpath)
   std::string path = qpath.toStdString();
   std::vector<std::string> paths = Config::GetIsoPaths();
 
-  if (std::find(paths.begin(), paths.end(), path) != paths.end())
+  if (Common::Contains(paths, path))
     return;
 
   paths.emplace_back(path);

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -18,6 +18,7 @@
 #include <jni.h>
 
 #include "Common/Assert.h"
+#include "Common/Contains.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 
@@ -1132,8 +1133,7 @@ Java_org_dolphinemu_dolphinemu_features_input_model_ControllerInterface_notifySe
 
   for (ciface::Core::Device::Input* input : device->Inputs())
   {
-    const std::string input_name = input->GetName();
-    if (std::find(axis_names.begin(), axis_names.end(), input_name) != axis_names.end())
+    if (Common::Contains(axis_names, input->GetName()))
     {
       auto casted_input = static_cast<ciface::Android::AndroidSensorAxis*>(input);
       casted_input->NotifyIsSuspended(static_cast<bool>(suspended));

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -10,6 +10,7 @@
 #include <mz_os.h>
 
 #include "Common/CommonPaths.h"
+#include "Common/Contains.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
@@ -181,8 +182,7 @@ bool ResourcePack::Install(const std::string& path)
     bool provided_by_other_pack = false;
     for (const auto& pack : GetHigherPriorityPacks(*this))
     {
-      if (std::find(pack->GetTextures().begin(), pack->GetTextures().end(), texture) !=
-          pack->GetTextures().end())
+      if (Common::Contains(pack->GetTextures(), texture))
       {
         provided_by_other_pack = true;
         break;
@@ -246,9 +246,7 @@ bool ResourcePack::Uninstall(const std::string& path)
     // Check if a higher priority pack already provides a given texture, don't delete it
     for (const auto& pack : GetHigherPriorityPacks(*this))
     {
-      if (::ResourcePack::IsInstalled(*pack) &&
-          std::find(pack->GetTextures().begin(), pack->GetTextures().end(), texture) !=
-              pack->GetTextures().end())
+      if (::ResourcePack::IsInstalled(*pack) && Common::Contains(pack->GetTextures(), texture))
       {
         provided_by_other_pack = true;
         break;
@@ -261,9 +259,7 @@ bool ResourcePack::Uninstall(const std::string& path)
     // Check if a lower priority pack provides a given texture - if so, install it.
     for (auto& pack : lower)
     {
-      if (::ResourcePack::IsInstalled(*pack) &&
-          std::find(pack->GetTextures().rbegin(), pack->GetTextures().rend(), texture) !=
-              pack->GetTextures().rend())
+      if (::ResourcePack::IsInstalled(*pack) && Common::Contains(pack->GetTextures(), texture))
       {
         pack->Install(path);
 

--- a/Source/Core/UICommon/X11Utils.cpp
+++ b/Source/Core/UICommon/X11Utils.cpp
@@ -14,6 +14,7 @@
 
 #include <fmt/format.h>
 
+#include "Common/Contains.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/Config/MainSettings.h"
@@ -244,7 +245,7 @@ void XRRConfiguration::AddResolutions(std::vector<std::string>& resos)
                                        std::string(screenResources->modes[k].name) +
                                        (interlaced ? "i" : "");
             // Only add unique resolutions
-            if (std::find(resos.begin(), resos.end(), strRes) == resos.end())
+            if (!Common::Contains(resos, strRes))
             {
               resos.push_back(strRes);
             }

--- a/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
@@ -8,6 +8,7 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonFuncs.h"
+#include "Common/Contains.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 
@@ -243,31 +244,24 @@ bool SwapChain::SelectPresentMode()
                                                   &mode_count, present_modes.data());
   ASSERT(res == VK_SUCCESS);
 
-  // Checks if a particular mode is supported, if it is, returns that mode.
-  auto CheckForMode = [&present_modes](VkPresentModeKHR check_mode) {
-    auto it = std::find_if(present_modes.begin(), present_modes.end(),
-                           [check_mode](VkPresentModeKHR mode) { return check_mode == mode; });
-    return it != present_modes.end();
-  };
-
   // If vsync is enabled, use VK_PRESENT_MODE_FIFO_KHR.
   // This check should not fail with conforming drivers, as the FIFO present mode is mandated by
   // the specification (VK_KHR_swapchain). In case it isn't though, fall through to any other mode.
-  if (m_vsync_enabled && CheckForMode(VK_PRESENT_MODE_FIFO_KHR))
+  if (m_vsync_enabled && Common::Contains(present_modes, VK_PRESENT_MODE_FIFO_KHR))
   {
     m_present_mode = VK_PRESENT_MODE_FIFO_KHR;
     return true;
   }
 
   // Prefer screen-tearing, if possible, for lowest latency.
-  if (CheckForMode(VK_PRESENT_MODE_IMMEDIATE_KHR))
+  if (Common::Contains(present_modes, VK_PRESENT_MODE_IMMEDIATE_KHR))
   {
     m_present_mode = VK_PRESENT_MODE_IMMEDIATE_KHR;
     return true;
   }
 
   // Use optimized-vsync above vsync.
-  if (CheckForMode(VK_PRESENT_MODE_MAILBOX_KHR))
+  if (Common::Contains(present_modes, VK_PRESENT_MODE_MAILBOX_KHR))
   {
     m_present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
     return true;

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomPipeline.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomPipeline.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <variant>
 
+#include "Common/Contains.h"
 #include "Common/Logging/Log.h"
 #include "Common/VariantUtil.h"
 
@@ -20,7 +21,7 @@ bool IsQualifier(std::string_view value)
   static constexpr std::array<std::string_view, 7> qualifiers = {
       "attribute", "const", "highp", "lowp", "mediump", "uniform", "varying",
   };
-  return std::find(qualifiers.begin(), qualifiers.end(), value) != qualifiers.end();
+  return Common::Contains(qualifiers, value);
 }
 
 bool IsBuiltInMacro(std::string_view value)
@@ -28,7 +29,7 @@ bool IsBuiltInMacro(std::string_view value)
   static constexpr std::array<std::string_view, 5> built_in = {
       "__LINE__", "__FILE__", "__VERSION__", "GL_core_profile", "GL_compatibility_profile",
   };
-  return std::find(built_in.begin(), built_in.end(), value) != built_in.end();
+  return Common::Contains(built_in, value);
 }
 
 std::vector<std::string> GlobalConflicts(std::string_view source)

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Contains.h"
 #include "Common/EnumMap.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
@@ -585,8 +586,7 @@ void VertexManagerBase::Flush()
         const auto cache_entry = g_texture_cache->Load(TextureInfo::FromStage(i));
         if (cache_entry)
         {
-          if (std::find(texture_names.begin(), texture_names.end(),
-                        cache_entry->texture_info_name) == texture_names.end())
+          if (!Common::Contains(texture_names, cache_entry->texture_info_name))
           {
             texture_names.push_back(cache_entry->texture_info_name);
             texture_units.push_back(i);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
+#include "Common/Contains.h"
 #include "Common/StringUtil.h"
 
 #include "Core/CPUThreadConfigCallback.h"
@@ -213,8 +214,7 @@ void VideoConfig::VerifyValidity()
   if (iAdapter < 0 || iAdapter > ((int)backend_info.Adapters.size() - 1))
     iAdapter = 0;
 
-  if (std::find(backend_info.AAModes.begin(), backend_info.AAModes.end(), iMultisamples) ==
-      backend_info.AAModes.end())
+  if (!Common::Contains(backend_info.AAModes, iMultisamples))
     iMultisamples = 1;
 
   if (stereo_mode != StereoMode::Off)


### PR DESCRIPTION
In C++23, two new standard library algorithms were introduced: `std::ranges::contains` and `std::ranges::contains_subrange`. These algorithms are replacements for common idiomatic uses of `std::find`(`_if`) and `std::search`. Unfortunately, we are not yet able to use C++23 features in this codebase. Fortunately, we don't have to wait, as implementing this function [is easy](https://en.cppreference.com/w/cpp/algorithm/ranges/contains#Possible_implementation)! I have isolated these proposed changes so that they may be considered and hopefully accepted.