### PR TITLE
Ranges Algorithms Modernization - N

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -382,7 +382,7 @@ void FifoRecorder::UseMemory(u32 address, u32 size, MemoryUpdate::Type type, boo
     memUpdate.fifoPosition = (u32)(m_FifoData.size());
     memUpdate.type = type;
     memUpdate.data.resize(size);
-    std::copy(newData, newData + size, memUpdate.data.begin());
+    std::copy_n(newData, size, memUpdate.data.begin());
 
     m_CurrentFrame.memoryUpdates.push_back(std::move(memUpdate));
   }

--- a/Source/Core/Core/HW/GBACore.cpp
+++ b/Source/Core/Core/HW/GBACore.cpp
@@ -543,8 +543,7 @@ void Core::RunCommand(Command& command)
     {
       int recvd = GBASIOJOYSendCommand(
           &m_sio_driver, static_cast<GBASIOJOYCommand>(command.buffer[0]), &command.buffer[1]);
-      std::copy(command.buffer.begin() + 1, command.buffer.begin() + 1 + recvd,
-                std::back_inserter(m_response));
+      std::copy_n(command.buffer.begin() + 1, recvd, std::back_inserter(m_response));
     }
 
     if (m_thread && !m_response_ready)

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -275,7 +275,7 @@ int IOWritePerWriteFile(HANDLE& dev_handle, OVERLAPPED& hid_overlap_write,
   // This is currently needed by the Toshiba Bluetooth Stack.
   if ((write_method == WWM_WRITE_FILE_LARGEST_REPORT_SIZE) && (MAX_PAYLOAD > len))
   {
-    std::copy(buf, buf + len, resized_buffer);
+    std::copy_n(buf, len, resized_buffer);
     std::fill(resized_buffer + len, resized_buffer + MAX_PAYLOAD, 0);
     write_buffer = resized_buffer + 1;
     bytes_to_write = MAX_PAYLOAD - 1;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -413,7 +413,7 @@ void BluetoothEmuDevice::ACLPool::Store(const u8* data, const u16 size, const u1
   m_queue.push_back(Packet());
   auto& packet = m_queue.back();
 
-  std::copy(data, data + size, packet.data);
+  std::copy_n(data, size, packet.data);
   packet.size = size;
   packet.conn_handle = conn_handle;
 }
@@ -438,7 +438,7 @@ void BluetoothEmuDevice::ACLPool::WriteToEndpoint(const USB::V0BulkMessage& endp
   header->length = size;
 
   // Write the packet to the buffer
-  std::copy(data, data + size, (u8*)header + sizeof(hci_acldata_hdr_t));
+  std::copy_n(data, size, (u8*)header + sizeof(hci_acldata_hdr_t));
 
   m_queue.pop_front();
 

--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -153,8 +153,7 @@ bool SectorReader::Read(u64 offset, u64 size, u8* out_ptr)
     u32 can_read = m_block_size * cache->num_blocks - read_offset;
     u32 was_read = static_cast<u32>(std::min<u64>(can_read, remain));
 
-    std::copy(cache->data.begin() + read_offset, cache->data.begin() + read_offset + was_read,
-              out_ptr);
+    std::copy_n(cache->data.begin() + read_offset, was_read, out_ptr);
 
     offset += was_read;
     out_ptr += was_read;

--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -203,7 +203,7 @@ u32 SectorReader::ReadChunk(u8* buffer, u64 chunk_num)
     {
       if (!GetBlock(block_num + i, buffer))
       {
-        std::fill(buffer, buffer + (cnt_blocks - i) * m_block_size, 0u);
+        std::fill_n(buffer, (cnt_blocks - i) * m_block_size, 0u);
         return i;
       }
       buffer += m_block_size;

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -130,7 +130,7 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
 
   if (uncompressed)
   {
-    std::copy(m_zlib_buffer.begin(), m_zlib_buffer.begin() + comp_block_size, out_ptr);
+    std::copy_n(m_zlib_buffer.begin(), comp_block_size, out_ptr);
   }
   else
   {

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -107,8 +107,7 @@ bool DiscContent::Read(u64* offset, u64* length, u8** buffer, DirectoryBlobReade
     else if (std::holds_alternative<ContentMemory>(m_content_source))
     {
       const auto& content = std::get<ContentMemory>(m_content_source);
-      std::copy(content->begin() + offset_in_content,
-                content->begin() + offset_in_content + bytes_to_read, *buffer);
+      std::copy_n(content->begin() + offset_in_content, bytes_to_read, *buffer);
     }
     else if (std::holds_alternative<ContentPartition>(m_content_source))
     {

--- a/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp
+++ b/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp
@@ -78,8 +78,8 @@ bool LaggedFibonacciGenerator::GetSeed(const u32* data, size_t size, size_t data
   const size_t data_offset_mod_k = data_offset % LFG_K;
   const size_t data_offset_div_k = data_offset / LFG_K;
 
-  std::copy(data, data + LFG_K - data_offset_mod_k, lfg->m_buffer.data() + data_offset_mod_k);
-  std::copy(data + LFG_K - data_offset_mod_k, data + LFG_K, lfg->m_buffer.data());
+  std::copy_n(data, LFG_K - data_offset_mod_k, lfg->m_buffer.data() + data_offset_mod_k);
+  std::copy_n(data + LFG_K - data_offset_mod_k, data_offset_mod_k, lfg->m_buffer.data());
 
   lfg->Backward(0, data_offset_mod_k);
 

--- a/Source/Core/DiscIO/TGCBlob.cpp
+++ b/Source/Core/DiscIO/TGCBlob.cpp
@@ -28,8 +28,8 @@ void Replace(u64 offset, u64 size, u8* out_ptr, u64 replace_offset, u64 replace_
 
   if (replace_end > replace_start)
   {
-    std::copy(replace_ptr + (replace_start - replace_offset),
-              replace_ptr + (replace_end - replace_offset), out_ptr + (replace_start - offset));
+    std::copy_n(replace_ptr + (replace_start - replace_offset), replace_end - replace_start,
+                out_ptr + (replace_start - offset));
   }
 }
 

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -1301,8 +1301,7 @@ void VolumeVerifier::Finish()
     {
       m_result.hashes.crc32 = std::vector<u8>(4);
       const u32 crc32_be = Common::swap32(m_crc32_context);
-      const u8* crc32_be_ptr = reinterpret_cast<const u8*>(&crc32_be);
-      std::copy(crc32_be_ptr, crc32_be_ptr + 4, m_result.hashes.crc32.begin());
+      std::memcpy(m_result.hashes.crc32.data(), &crc32_be, 4);
     }
 
     if (m_hashes_to_calculate.md5)

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -1635,7 +1635,7 @@ WIARVZFileReader<RVZ>::ProcessAndCompress(CompressThreadState* state, CompressPa
       const size_t size = state->compressor->GetSize();
 
       entry.main_data.resize(size);
-      std::copy(data, data + size, entry.main_data.data());
+      std::copy_n(data, size, entry.main_data.data());
 
       if (compressed_exception_lists)
         entry.exception_lists.clear();

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -3,6 +3,7 @@
 
 #include "UpdaterCommon/UpdaterCommon.h"
 
+#include <algorithm>
 #include <array>
 #include <memory>
 #include <optional>
@@ -150,7 +151,7 @@ Manifest::Hash ComputeHash(const std::string& contents)
                      false);
 
   Manifest::Hash out;
-  std::copy(full.begin(), full.begin() + 16, out.begin());
+  std::copy_n(full.begin(), 16, out.begin());
   return out;
 }
 

--- a/Source/DSPSpy/ConsoleHelper.h
+++ b/Source/DSPSpy/ConsoleHelper.h
@@ -60,7 +60,7 @@ inline void CON_BlankRow(const int y)
   int columns = 0, rows = 0;
   CON_GetMetrics(&columns, &rows);
   char blank[columns];
-  std::fill(blank, blank + columns, ' ');
+  std::fill_n(blank, columns, ' ');
   blank[columns - 1] = '\0';
   CON_Printf(0, y, "%s", blank);
 }


### PR DESCRIPTION
The algorithms `std::copy` and `std::fill` have alternate forms called `std::copy_n` and `std::fill_n`. These algorithms replace a common idiomatic way of using the copy and fill algorithms, yet they have not been used in several places where they could have been. These changes have very little to do with modernizing algorithms using C++20 ranges, but these are potential changes I noticed while evaluating the entire codebase, thus I am proposing them in case they are deemed valuable.