### PR TITLE
Bluetooth: show vid:pid in error message

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -103,7 +103,8 @@ std::optional<IPCReply> BluetoothRealDevice::Open(const OpenRequest& request)
 
     const libusb_interface& interface = config_descriptor->interface[INTERFACE];
     const libusb_interface_descriptor& descriptor = interface.altsetting[0];
-    if (IsBluetoothDevice(descriptor) && IsWantedDevice(device_descriptor) && OpenDevice(device))
+    if (IsBluetoothDevice(descriptor) && IsWantedDevice(device_descriptor) &&
+        OpenDevice(device_descriptor, device))
     {
       unsigned char manufacturer[50] = {}, product[50] = {}, serial_number[50] = {};
       const int manufacturer_ret = libusb_get_string_descriptor_ascii(
@@ -637,14 +638,16 @@ void BluetoothRealDevice::SaveLinkKeys()
   Config::SetBase(Config::MAIN_BLUETOOTH_PASSTHROUGH_LINK_KEYS, config_string);
 }
 
-bool BluetoothRealDevice::OpenDevice(libusb_device* device)
+bool BluetoothRealDevice::OpenDevice(const libusb_device_descriptor& device_descriptor,
+                                     libusb_device* device)
 {
   m_device = libusb_ref_device(device);
   const int ret = libusb_open(m_device, &m_handle);
   if (ret != LIBUSB_SUCCESS)
   {
-    m_last_open_error =
-        Common::FmtFormatT("Failed to open Bluetooth device: {0}", LibusbUtils::ErrorWrap(ret));
+    m_last_open_error = Common::FmtFormatT("Failed to open Bluetooth device {:04x}:{:04x}: {}",
+                                           device_descriptor.idVendor, device_descriptor.idProduct,
+                                           LibusbUtils::ErrorWrap(ret));
     return false;
   }
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -23,6 +23,7 @@
 class PointerWrap;
 struct libusb_device;
 struct libusb_device_handle;
+struct libusb_device_descriptor;
 struct libusb_transfer;
 
 namespace IOS::HLE
@@ -116,7 +117,7 @@ private:
   void LoadLinkKeys();
   void SaveLinkKeys();
 
-  bool OpenDevice(libusb_device* device);
+  bool OpenDevice(const libusb_device_descriptor& device_descriptor, libusb_device* device);
 };
 }  // namespace IOS::HLE
 


### PR DESCRIPTION
When trying to get Bluetooth passthrough to work, it helps to know whether Dolphin is trying to connect to the right USB device.