### PR TITLE
Core: Include partition when calling GetGameTDBID for non-game partition

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -114,7 +114,7 @@ void SConfig::SetRunningGameMetadata(const DiscIO::Volume& volume,
   }
   else
   {
-    SetRunningGameMetadata(volume.GetGameID(partition), volume.GetGameTDBID(),
+    SetRunningGameMetadata(volume.GetGameID(partition), volume.GetGameTDBID(partition),
                            volume.GetTitleID(partition).value_or(0),
                            volume.GetRevision(partition).value_or(0), volume.GetRegion());
   }


### PR DESCRIPTION
This problem was introduced in 8842a0f402ffe60a80ce7894bfd36afd039009fc and is likely a copy-paste error.

Fixes the problem mentioned in the issue comment
https://bugs.dolphin-emu.org/issues/13640#note-2.