### PR TITLE
VideoBackends:Vulkan: Increase VMA Vulkan Version to 1.2

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -63,7 +63,7 @@
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif  // #ifdef __GNUC__
 
-#define VMA_VULKAN_VERSION 1001000
+#define VMA_VULKAN_VERSION 1002000
 #define VMA_STATIC_VULKAN_FUNCTIONS 1
 #define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
 #undef VK_NO_PROTOTYPES


### PR DESCRIPTION
Fixes assertion failures people were getting in vk_mem_alloc after #13050