### PR TITLE
FifoPlayer: Set up additional BATs in Wii mode

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -639,6 +639,16 @@ void FifoPlayer::LoadMemory()
   ppc_state.spr[SPR_DBAT0L] = 0x00000002;
   ppc_state.spr[SPR_DBAT1U] = 0xc0001fff;
   ppc_state.spr[SPR_DBAT1L] = 0x0000002a;
+  if (m_File->GetIsWii())
+  {
+    ppc_state.spr[SPR_IBAT4U] = 0x90001fff;
+    ppc_state.spr[SPR_IBAT4L] = 0x10000002;
+    ppc_state.spr[SPR_DBAT4U] = 0x90001fff;
+    ppc_state.spr[SPR_DBAT4L] = 0x10000002;
+    ppc_state.spr[SPR_DBAT5U] = 0xd0001fff;
+    ppc_state.spr[SPR_DBAT5L] = 0x1000002a;
+    HID4(ppc_state).SBE = 1;
+  }
 
   PowerPC::MSRUpdated(ppc_state);
 


### PR DESCRIPTION
The light LIT fifolog from https://bugs.dolphin-emu.org/issues/13635 has position data at physical address 11ae3180. This works fine when using the memory viewer in physical mode, but the corresponding virtual address (91ae3180) previously didn't show anything in effective mode. It works fine now though.

This shouldn't affect playback of fifologs as everything in there uses physical addresses; this only impacts the memory viewer.

This logic was copied from CBoot::SetupBAT:

https://github.com/dolphin-emu/dolphin/blob/339f9311fb86aaf081f2e9ea2ca2c1a1071b35d6/Source/Core/Core/Boot/Boot_BS2Emu.cpp#L114-L137