### PR TITLE
Fifo analyzer: Fix indexed XF loads showing "bytes" instead of "words"

### DIFF
--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -646,7 +646,7 @@ std::pair<std::string, std::string> GetXFTransferInfo(u16 base_address, u8 trans
 std::pair<std::string, std::string> GetXFIndexedLoadInfo(CPArray array, u32 index, u16 address,
                                                          u8 size)
 {
-  const auto desc = fmt::format("Load {} bytes to XF address {:03x} from CP array {} row {}", size,
+  const auto desc = fmt::format("Load {} words to XF address {:03x} from CP array {} row {}", size,
                                 address, array, index);
   fmt::memory_buffer written;
   for (u32 i = 0; i < size; i++)


### PR DESCRIPTION
Indexed XF loads specify the number of 32-bit words (generally floats, but light data has some integers) to load, not the number of bytes. This was only a mistake in the fifo analyzer text; the actual implementation already loaded words.