### PR TITLE
Core: Store object name separately for symbols

### DIFF
--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -44,6 +44,7 @@ struct Symbol
 
   std::string name;
   std::string function_name;   // stripped function name
+  std::string object_name;     // name of object/source file symbol belongs to
   std::vector<SCall> callers;  // addresses of functions that call this function
   std::vector<SCall> calls;    // addresses of functions that are called by this function
   u32 hash = 0;                // use for HLE function finding

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -605,7 +605,9 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
 
       ppc_state.pc = executable.reader->GetEntryPoint();
 
-      if (executable.reader->LoadSymbols(guard, system.GetPPCSymbolDB()))
+      const std::string filename = PathToFileName(executable.path);
+
+      if (executable.reader->LoadSymbols(guard, system.GetPPCSymbolDB(), filename))
       {
         Host_PPCSymbolsChanged();
         HLE::PatchFunctions(system);

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -215,7 +215,8 @@ public:
   virtual bool IsValid() const = 0;
   virtual bool IsWii() const = 0;
   virtual bool LoadIntoMemory(Core::System& system, bool only_in_mem1 = false) const = 0;
-  virtual bool LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db) const = 0;
+  virtual bool LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db,
+                           const std::string& filename) const = 0;
 
 protected:
   std::vector<u8> m_bytes;

--- a/Source/Core/Core/Boot/DolReader.h
+++ b/Source/Core/Core/Boot/DolReader.h
@@ -27,7 +27,8 @@ public:
   bool IsAncast() const { return m_is_ancast; }
   u32 GetEntryPoint() const override { return m_dolheader.entryPoint; }
   bool LoadIntoMemory(Core::System& system, bool only_in_mem1 = false) const override;
-  bool LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db) const override
+  bool LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db,
+                   const std::string& filename) const override
   {
     return false;
   }

--- a/Source/Core/Core/Boot/ElfReader.cpp
+++ b/Source/Core/Core/Boot/ElfReader.cpp
@@ -180,7 +180,8 @@ SectionID ElfReader::GetSectionByName(const char* name, int firstSection) const
   return -1;
 }
 
-bool ElfReader::LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db) const
+bool ElfReader::LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db,
+                            const std::string& filename) const
 {
   bool hasSymbols = false;
   SectionID sec = GetSectionByName(".symtab");
@@ -218,7 +219,7 @@ bool ElfReader::LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_
       default:
         continue;
       }
-      ppc_symbol_db.AddKnownSymbol(guard, value, size, name, symtype);
+      ppc_symbol_db.AddKnownSymbol(guard, value, size, name, filename, symtype);
       hasSymbols = true;
     }
   }

--- a/Source/Core/Core/Boot/ElfReader.h
+++ b/Source/Core/Core/Boot/ElfReader.h
@@ -36,7 +36,8 @@ public:
   u32 GetEntryPoint() const override { return entryPoint; }
   u32 GetFlags() const { return (u32)(header->e_flags); }
   bool LoadIntoMemory(Core::System& system, bool only_in_mem1 = false) const override;
-  bool LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db) const override;
+  bool LoadSymbols(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db,
+                   const std::string& filename) const override;
   // TODO: actually check for validity.
   bool IsValid() const override { return true; }
   bool IsWii() const override;

--- a/Source/Core/Core/Debugger/RSO.cpp
+++ b/Source/Core/Core/Debugger/RSO.cpp
@@ -375,6 +375,7 @@ void RSOView::LoadAll(const Core::CPUThreadGuard& guard, u32 address)
 
 void RSOView::Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) const
 {
+  const std::string rso_name = GetName();
   for (const RSOExport& rso_export : GetExports())
   {
     u32 address = GetExportAddress(rso_export);
@@ -389,15 +390,17 @@ void RSOView::Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) c
       {
         // Function symbol
         symbol->Rename(export_name);
+        symbol->object_name = rso_name;
       }
       else
       {
         // Data symbol
-        symbol_db->AddKnownSymbol(guard, address, 0, export_name, Common::Symbol::Type::Data);
+        symbol_db->AddKnownSymbol(guard, address, 0, export_name, rso_name,
+                                  Common::Symbol::Type::Data);
       }
     }
   }
-  DEBUG_LOG_FMT(SYMBOLS, "RSO({}): {} symbols applied", GetName(), GetExportsCount());
+  DEBUG_LOG_FMT(SYMBOLS, "RSO({}): {} symbols applied", rso_name, GetExportsCount());
 }
 
 u32 RSOView::GetNextEntry() const

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -23,7 +23,7 @@ public:
 
   Common::Symbol* AddFunction(const Core::CPUThreadGuard& guard, u32 start_addr) override;
   void AddKnownSymbol(const Core::CPUThreadGuard& guard, u32 startAddr, u32 size,
-                      const std::string& name,
+                      const std::string& name, const std::string& object_name,
                       Common::Symbol::Type type = Common::Symbol::Type::Function);
 
   Common::Symbol* GetSymbolFromAddr(u32 addr) override;

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -379,6 +379,12 @@ void CodeWidget::UpdateSymbols()
   {
     QString name = QString::fromStdString(symbol.second.name);
 
+    // If the symbol has an object name, add it to the entry name.
+    if (!symbol.second.object_name.empty())
+    {
+      name += QString::fromStdString(fmt::format(" ({})", symbol.second.object_name));
+    }
+
     auto* item = new QListWidgetItem(name);
     if (name == selection)
       item->setSelected(true);
@@ -408,8 +414,17 @@ void CodeWidget::UpdateFunctionCalls(const Common::Symbol* symbol)
 
     if (call_symbol)
     {
-      const QString name =
-          QString::fromStdString(fmt::format("> {} ({:08x})", call_symbol->name, addr));
+      QString name;
+
+      if (!call_symbol->object_name.empty())
+      {
+        name = QString::fromStdString(
+            fmt::format("< {} ({}, {:08x})", call_symbol->name, call_symbol->object_name, addr));
+      }
+      else
+      {
+        name = QString::fromStdString(fmt::format("< {} ({:08x})", call_symbol->name, addr));
+      }
 
       if (!name.contains(filter, Qt::CaseInsensitive))
         continue;
@@ -433,8 +448,17 @@ void CodeWidget::UpdateFunctionCallers(const Common::Symbol* symbol)
 
     if (caller_symbol)
     {
-      const QString name =
-          QString::fromStdString(fmt::format("< {} ({:08x})", caller_symbol->name, addr));
+      QString name;
+
+      if (!caller_symbol->object_name.empty())
+      {
+        name = QString::fromStdString(fmt::format("< {} ({}, {:08x})", caller_symbol->name,
+                                                  caller_symbol->object_name, addr));
+      }
+      else
+      {
+        name = QString::fromStdString(fmt::format("< {} ({:08x})", caller_symbol->name, addr));
+      }
 
       if (!name.contains(filter, Qt::CaseInsensitive))
         continue;


### PR DESCRIPTION
This PR adds code that checks for extra information following symbol names that is often present in CodeWarrior symbol maps, namely the names of the .a/.o files that symbol belongs to. If present, the symbol name string is truncated to remove the extra text from the symbol name.