### PR TITLE
Audio: Add option to temporarily mute audio when using turbo

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -280,6 +280,8 @@ const Info<std::string> MAIN_AUDIO_BACKEND{{System::Main, "DSP", "Backend"},
                                            AudioCommon::GetDefaultSoundBackend()};
 const Info<int> MAIN_AUDIO_VOLUME{{System::Main, "DSP", "Volume"}, 100};
 const Info<bool> MAIN_AUDIO_MUTED{{System::Main, "DSP", "Muted"}, false};
+const Info<bool> MAIN_AUDIO_MUTE_ON_DISABLED_SPEED_LIMIT{
+    {System::Main, "DSP", "MuteOnDisabledSpeedLimit"}, false};
 #ifdef _WIN32
 const Info<std::string> MAIN_WASAPI_DEVICE{{System::Main, "DSP", "WASAPIDevice"}, "Default"};
 #endif

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -167,6 +167,7 @@ extern const Info<bool> MAIN_DUMP_UCODE;
 extern const Info<std::string> MAIN_AUDIO_BACKEND;
 extern const Info<int> MAIN_AUDIO_VOLUME;
 extern const Info<bool> MAIN_AUDIO_MUTED;
+extern const Info<bool> MAIN_AUDIO_MUTE_ON_DISABLED_SPEED_LIMIT;
 #ifdef _WIN32
 extern const Info<std::string> MAIN_WASAPI_DEVICE;
 #endif

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -360,7 +360,7 @@ void HotkeyScheduler::Run()
 
       if (IsHotkey(HK_VOLUME_TOGGLE_MUTE))
       {
-        AudioCommon::ToggleMuteVolume(Core::System::GetInstance());
+        AudioCommon::ToggleMuteVolume(system);
         ShowVolume();
       }
 
@@ -482,6 +482,20 @@ void HotkeyScheduler::Run()
         Config::SetCurrent(Config::GFX_HIRES_TEXTURES, !Config::Get(Config::GFX_HIRES_TEXTURES));
 
       Core::SetIsThrottlerTempDisabled(IsHotkey(HK_TOGGLE_THROTTLE, true));
+
+      if (IsHotkey(HK_TOGGLE_THROTTLE, true) && !Config::Get(Config::MAIN_AUDIO_MUTED) &&
+          Config::Get(Config::MAIN_AUDIO_MUTE_ON_DISABLED_SPEED_LIMIT))
+      {
+        Config::SetCurrent(Config::MAIN_AUDIO_MUTED, true);
+        AudioCommon::UpdateSoundStream(system);
+      }
+      else if (!IsHotkey(HK_TOGGLE_THROTTLE, true) && Config::Get(Config::MAIN_AUDIO_MUTED) &&
+               Config::GetActiveLayerForConfig(Config::MAIN_AUDIO_MUTED) ==
+                   Config::LayerType::CurrentRun)
+      {
+        Config::DeleteKey(Config::LayerType::CurrentRun, Config::MAIN_AUDIO_MUTED);
+        AudioCommon::UpdateSoundStream(system);
+      }
 
       auto ShowEmulationSpeed = []() {
         const float emulation_speed = Config::Get(Config::MAIN_EMULATION_SPEED);

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -160,10 +160,22 @@ void AudioPane::CreateWidgets()
 
   dsp_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
+  auto* misc_box = new QGroupBox(tr("Miscellaneous Settings"));
+  auto* misc_layout = new QGridLayout;
+  misc_box->setLayout(misc_layout);
+
+  m_speed_up_mute_enable = new QCheckBox(tr("Mute When Disabling Speed Limit."));
+  m_speed_up_mute_enable->setToolTip(
+      tr("Mutes the audio when overriding the emulation speed limit (default hotkey: Tab)."));
+
+  misc_layout->addWidget(m_speed_up_mute_enable, 0, 0, 1, 1);
+
   auto* const main_vbox_layout = new QVBoxLayout;
+
   main_vbox_layout->addWidget(dsp_box);
   main_vbox_layout->addWidget(backend_box);
   main_vbox_layout->addWidget(stretching_box);
+  main_vbox_layout->addWidget(misc_box);
 
   m_main_layout = new QHBoxLayout;
   m_main_layout->addLayout(main_vbox_layout);
@@ -188,6 +200,7 @@ void AudioPane::ConnectWidgets()
   connect(m_dsp_hle, &QRadioButton::toggled, this, &AudioPane::SaveSettings);
   connect(m_dsp_lle, &QRadioButton::toggled, this, &AudioPane::SaveSettings);
   connect(m_dsp_interpreter, &QRadioButton::toggled, this, &AudioPane::SaveSettings);
+  connect(m_speed_up_mute_enable, &QCheckBox::toggled, this, &AudioPane::SaveSettings);
 
 #ifdef _WIN32
   connect(m_wasapi_device_combo, &QComboBox::currentIndexChanged, this, &AudioPane::SaveSettings);
@@ -250,6 +263,9 @@ void AudioPane::LoadSettings()
   m_stretching_buffer_slider->setEnabled(m_stretching_enable->isChecked());
   m_stretching_buffer_indicator->setEnabled(m_stretching_enable->isChecked());
   m_stretching_buffer_indicator->setText(tr("%1 ms").arg(m_stretching_buffer_slider->value()));
+
+  // Misc
+  m_speed_up_mute_enable->setChecked(Config::Get(Config::MAIN_AUDIO_MUTE_ON_DISABLED_SPEED_LIMIT));
 
 #ifdef _WIN32
   if (Config::Get(Config::MAIN_WASAPI_DEVICE) == "default")
@@ -319,6 +335,10 @@ void AudioPane::SaveSettings()
   m_stretching_buffer_indicator->setEnabled(m_stretching_enable->isChecked());
   m_stretching_buffer_indicator->setText(
       tr("%1 ms").arg(Config::Get(Config::MAIN_AUDIO_STRETCH_LATENCY)));
+
+  // Misc
+  Config::SetBaseOrCurrent(Config::MAIN_AUDIO_MUTE_ON_DISABLED_SPEED_LIMIT,
+                           m_speed_up_mute_enable->isChecked());
 
 #ifdef _WIN32
   std::string device = "default";

--- a/Source/Core/DolphinQt/Settings/AudioPane.h
+++ b/Source/Core/DolphinQt/Settings/AudioPane.h
@@ -76,4 +76,7 @@ private:
   QLabel* m_stretching_buffer_label;
   QSlider* m_stretching_buffer_slider;
   QLabel* m_stretching_buffer_indicator;
+
+  // Misc Settings
+  QCheckBox* m_speed_up_mute_enable;
 };


### PR DESCRIPTION
Turbo meaning overriding the emulation speed limit (tab).

Adds new Miscellaneous Settings groupbox to bottom of audio panel.
Uses Config::SetCurrent to temporarily mute audio and DeleteKey to undo it.

Small issue is that the audio still crackles a little when coming out of turbo muted.