### PR TITLE
Ranges Algorithms Modernization - Of

### DIFF
--- a/Source/Android/jni/Cheats/GraphicsModGroup.cpp
+++ b/Source/Android/jni/Cheats/GraphicsModGroup.cpp
@@ -51,10 +51,9 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_GraphicsModGroup_getMods(JN
   for (GraphicsModConfig& mod : mod_group->GetMods())
   {
     // If no group matches the mod's features, or if the mod has no features, skip it
-    if (std::none_of(mod.m_features.begin(), mod.m_features.end(),
-                     [&groups](const GraphicsModFeatureConfig& feature) {
-                       return groups.contains(feature.m_group);
-                     }))
+    if (std::ranges::none_of(mod.m_features, [&groups](const GraphicsModFeatureConfig& feature) {
+          return groups.contains(feature.m_group);
+        }))
     {
       continue;
     }

--- a/Source/Core/Common/Crypto/ec.cpp
+++ b/Source/Core/Common/Crypto/ec.cpp
@@ -24,7 +24,7 @@ struct Elt
 {
   bool IsZero() const
   {
-    return std::all_of(data.begin(), data.end(), [](u8 b) { return b == 0; });
+    return std::ranges::all_of(data, [](u8 b) { return b == 0; });
   }
 
   void MulX()

--- a/Source/Core/Common/Debug/MemoryPatches.cpp
+++ b/Source/Core/Common/Debug/MemoryPatches.cpp
@@ -91,7 +91,7 @@ void MemoryPatches::DisablePatch(const Core::CPUThreadGuard& guard, std::size_t 
 
 bool MemoryPatches::HasEnabledPatch(u32 address) const
 {
-  return std::any_of(m_patches.begin(), m_patches.end(), [address](const MemoryPatch& patch) {
+  return std::ranges::any_of(m_patches, [address](const MemoryPatch& patch) {
     return patch.address == address && patch.is_enabled == MemoryPatch::State::Enabled;
   });
 }

--- a/Source/Core/Common/Debug/Watches.cpp
+++ b/Source/Core/Common/Debug/Watches.cpp
@@ -79,7 +79,7 @@ void Watches::DisableWatch(std::size_t index)
 
 bool Watches::HasEnabledWatch(u32 address) const
 {
-  return std::any_of(m_watches.begin(), m_watches.end(), [address](const auto& watch) {
+  return std::ranges::any_of(m_watches, [address](const auto& watch) {
     return watch.address == address && watch.is_enabled == Watch::State::Enabled;
   });
 }

--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -729,7 +729,7 @@ static bool Unpack(const std::function<bool()>& cancelled, const std::string pat
     const bool is_path_traversal_attack =
         (childname.find("\\") != std::string_view::npos) ||
         (childname.find('/') != std::string_view::npos) ||
-        std::all_of(childname.begin(), childname.end(), [](char c) { return c == '.'; });
+        std::ranges::all_of(childname, [](char c) { return c == '.'; });
     if (is_path_traversal_attack)
     {
       ERROR_LOG_FMT(

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -41,7 +41,7 @@ std::vector<std::string> DoFileSearch(const std::vector<std::string>& directorie
   // N.B. This avoids doing any copies
   auto ext_matches = [&native_exts](const fs::path& path) {
     const std::basic_string_view<fs::path::value_type> native_path = path.native();
-    return std::any_of(native_exts.cbegin(), native_exts.cend(), [&native_path](const auto& ext) {
+    return std::ranges::any_of(native_exts, [&native_path](const auto& ext) {
       const auto compare_len = ext.native().length();
       if (native_path.length() < compare_len)
         return false;

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -171,6 +171,6 @@ std::string UnescapeFileName(const std::string& filename)
 bool IsFileNameSafe(const std::string_view filename)
 {
   return !filename.empty() && !std::ranges::all_of(filename, [](char c) { return c == '.'; }) &&
-         std::none_of(filename.begin(), filename.end(), IsIllegalCharacter);
+         std::ranges::none_of(filename, IsIllegalCharacter);
 }
 }  // namespace Common

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -113,7 +113,7 @@ static bool IsIllegalCharacter(char c)
 std::string EscapeFileName(const std::string& filename)
 {
   // Prevent paths from containing special names like ., .., ..., ...., and so on
-  if (std::all_of(filename.begin(), filename.end(), [](char c) { return c == '.'; }))
+  if (std::ranges::all_of(filename, [](char c) { return c == '.'; }))
     return ReplaceAll(filename, ".", "__2e__");
 
   // Escape all double underscores since we will use double underscores for our escape sequences
@@ -170,8 +170,7 @@ std::string UnescapeFileName(const std::string& filename)
 
 bool IsFileNameSafe(const std::string_view filename)
 {
-  return !filename.empty() &&
-         !std::all_of(filename.begin(), filename.end(), [](char c) { return c == '.'; }) &&
+  return !filename.empty() && !std::ranges::all_of(filename, [](char c) { return c == '.'; }) &&
          std::none_of(filename.begin(), filename.end(), IsIllegalCharacter);
 }
 }  // namespace Common

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -275,6 +275,21 @@ inline bool IsAlpha(char c)
   return std::isalpha(c, std::locale::classic());
 }
 
+inline bool IsAlnum(char c)
+{
+  return std::isalnum(c, std::locale::classic());
+}
+
+inline bool IsUpper(char c)
+{
+  return std::isupper(c, std::locale::classic());
+}
+
+inline bool IsXDigit(char c)
+{
+  return std::isxdigit(c /* no locale needed */) != 0;
+}
+
 inline char ToLower(char ch)
 {
   return std::tolower(ch, std::locale::classic());

--- a/Source/Core/Core/Config/DefaultLocale.cpp
+++ b/Source/Core/Core/Config/DefaultLocale.cpp
@@ -79,11 +79,9 @@ static DiscIO::Language ComputeDefaultLanguage()
 
 static std::optional<std::string> TryParseCountryCode(const std::string& locale)
 {
-  const auto is_upper = [](char c) { return std::isupper(c, std::locale::classic()); };
-
   for (const std::string& part : SplitString(locale, '-'))
   {
-    if (part.size() == 2 && is_upper(part[0]) && is_upper(part[1]))
+    if (part.size() == 2 && Common::IsUpper(part[0]) && Common::IsUpper(part[1]))
       return part;
   }
 

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -114,9 +114,8 @@ public:
         for (const auto& value : section_map)
         {
           const Config::Location location{system.first, section_name, value.first};
-          const bool load_disallowed =
-              std::any_of(begin(s_setting_disallowed), end(s_setting_disallowed),
-                          [&location](const Config::Location* l) { return *l == location; });
+          const bool load_disallowed = std::ranges::any_of(
+              s_setting_disallowed, [&location](const auto* l) { return *l == location; });
           if (load_disallowed)
             continue;
 

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -27,9 +27,8 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::WIIMOTE_BB_SOURCE.GetLocation(),
   };
 
-  return std::any_of(begin(s_setting_saveable), end(s_setting_saveable),
-                     [&config_location](const Config::Location* location) {
-                       return *location == config_location;
-                     });
+  return std::ranges::any_of(s_setting_saveable, [&config_location](const auto* location) {
+    return *location == config_location;
+  });
 }
 }  // namespace ConfigLoaders

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -194,7 +194,7 @@ void DisplayMessage(std::string message, int time_in_ms)
     return;
 
   // Actually displaying non-ASCII could cause things to go pear-shaped
-  if (!std::all_of(message.begin(), message.end(), Common::IsPrintableCharacter))
+  if (!std::ranges::all_of(message, Common::IsPrintableCharacter))
     return;
 
   OSD::AddMessage(std::move(message), time_in_ms);

--- a/Source/Core/Core/Debugger/CodeTrace.cpp
+++ b/Source/Core/Core/Debugger/CodeTrace.cpp
@@ -267,8 +267,8 @@ HitType CodeTrace::TraceLogic(const TraceOutput& current_instr, bool first_hit)
 
   // Checks if the intstruction is a type that needs special handling.
   const auto CompareInstruction = [](std::string_view instruction, const auto& type_compare) {
-    return std::any_of(type_compare.begin(), type_compare.end(),
-                       [&instruction](std::string_view s) { return instruction.starts_with(s); });
+    return std::ranges::any_of(
+        type_compare, [&instruction](std::string_view s) { return instruction.starts_with(s); });
   };
 
   // Exclusions from updating tracking logic. mt operations are too complex and specialized.

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -101,8 +101,8 @@ std::pair<GCMemcardErrorCode, std::optional<GCMemcard>> GCMemcard::Open(std::str
       MBIT_SIZE_MEMORY_CARD_2043,
   }};
 
-  if (!std::any_of(valid_megabits.begin(), valid_megabits.end(),
-                   [filesize_megabits](u64 mbits) { return mbits == filesize_megabits; }))
+  if (!std::ranges::any_of(valid_megabits,
+                           [filesize_megabits](u64 mbits) { return mbits == filesize_megabits; }))
   {
     error_code.Set(GCMemcardValidityIssues::INVALID_CARD_SIZE);
     return std::make_pair(error_code, std::nullopt);
@@ -1296,8 +1296,8 @@ GCMemcardErrorCode Header::CheckForErrors(u16 card_size_mbits) const
     error_code.Set(GCMemcardValidityIssues::MISMATCHED_CARD_SIZE);
 
   // unused areas, should always be filled with 0xFF
-  if (std::any_of(m_unused_1.begin(), m_unused_1.end(), [](u8 val) { return val != 0xFF; }) ||
-      std::any_of(m_unused_2.begin(), m_unused_2.end(), [](u8 val) { return val != 0xFF; }))
+  if (std::ranges::any_of(m_unused_1, [](u8 val) { return val != 0xFF; }) ||
+      std::ranges::any_of(m_unused_2, [](u8 val) { return val != 0xFF; }))
   {
     error_code.Set(GCMemcardValidityIssues::DATA_IN_UNUSED_AREA);
   }
@@ -1361,7 +1361,7 @@ GCMemcardErrorCode Directory::CheckForErrors() const
     error_code.Set(GCMemcardValidityIssues::INVALID_CHECKSUM);
 
   // unused area, should always be filled with 0xFF
-  if (std::any_of(m_padding.begin(), m_padding.end(), [](u8 val) { return val != 0xFF; }))
+  if (std::ranges::any_of(m_padding, [](u8 val) { return val != 0xFF; }))
     error_code.Set(GCMemcardValidityIssues::DATA_IN_UNUSED_AREA);
 
   return error_code;

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -613,8 +613,7 @@ void WiimoteScanner::SetScanMode(WiimoteScanMode scan_mode)
 bool WiimoteScanner::IsReady() const
 {
   std::lock_guard lg(m_backends_mutex);
-  return std::any_of(m_backends.begin(), m_backends.end(),
-                     [](const auto& backend) { return backend->IsReady(); });
+  return std::ranges::any_of(m_backends, &WiimoteScannerBackend::IsReady);
 }
 
 static void CheckForDisconnectedWiimotes()

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -98,8 +98,8 @@ bool IOCtlVRequest::HasNumberOfValidVectors(const size_t in_count, const size_t 
     return false;
 
   auto IsValidVector = [](const auto& vector) { return vector.size == 0 || vector.address != 0; };
-  return std::all_of(in_vectors.begin(), in_vectors.end(), IsValidVector) &&
-         std::all_of(io_vectors.begin(), io_vectors.end(), IsValidVector);
+  return std::ranges::all_of(in_vectors, IsValidVector) &&
+         std::ranges::all_of(io_vectors, IsValidVector);
 }
 
 void IOCtlRequest::Log(std::string_view device_name, Common::Log::LogType type,

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -298,7 +298,7 @@ std::string TMDReader::GetGameID() const
   std::memcpy(game_id, m_bytes.data() + offsetof(TMDHeader, title_id) + 4, 4);
   std::memcpy(game_id + 4, m_bytes.data() + offsetof(TMDHeader, group_id), 2);
 
-  if (std::all_of(std::begin(game_id), std::end(game_id), Common::IsPrintableCharacter))
+  if (std::ranges::all_of(game_id, Common::IsPrintableCharacter))
     return std::string(game_id, sizeof(game_id));
 
   return fmt::format("{:016x}", GetTitleId());

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -79,7 +79,7 @@ static bool IsValidPartOfTitleID(const std::string& string)
 {
   if (string.length() != 8)
     return false;
-  return std::all_of(string.begin(), string.end(), Common::IsXDigit);
+  return std::ranges::all_of(string, Common::IsXDigit);
 }
 
 static std::vector<u64> GetTitlesInTitleOrImport(FS::FileSystem* fs, const std::string& titles_dir)

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -79,8 +79,7 @@ static bool IsValidPartOfTitleID(const std::string& string)
 {
   if (string.length() != 8)
     return false;
-  return std::all_of(string.begin(), string.end(),
-                     [](const auto character) { return std::isxdigit(character) != 0; });
+  return std::all_of(string.begin(), string.end(), Common::IsXDigit);
 }
 
 static std::vector<u64> GetTitlesInTitleOrImport(FS::FileSystem* fs, const std::string& titles_dir)

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -464,7 +464,7 @@ static bool HasAllRequiredContents(Kernel& ios, const ES::TMDReader& tmd)
   const u64 title_id = tmd.GetTitleId();
   const std::vector<ES::Content> contents = tmd.GetContents();
   const ES::SharedContentMap shared_content_map{ios.GetFSCore()};
-  return std::all_of(contents.cbegin(), contents.cend(), [&](const ES::Content& content) {
+  return std::ranges::all_of(contents, [&](const ES::Content& content) {
     if (content.IsOptional())
       return true;
 

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -878,7 +878,7 @@ ReturnCode ESCore::DeleteSharedContent(const std::array<u8, 20>& sha1) const
 
   // Check whether the shared content is used by a system title.
   const std::vector<u64> titles = GetInstalledTitles();
-  const bool is_used_by_system_title = std::any_of(titles.begin(), titles.end(), [&](u64 id) {
+  const bool is_used_by_system_title = std::ranges::any_of(titles, [&](u64 id) {
     if (!ES::IsTitleType(id, ES::TitleType::System))
       return false;
 
@@ -887,8 +887,8 @@ ReturnCode ESCore::DeleteSharedContent(const std::array<u8, 20>& sha1) const
       return true;
 
     const auto contents = tmd.GetContents();
-    return std::any_of(contents.begin(), contents.end(),
-                       [&sha1](const auto& content) { return content.sha1 == sha1; });
+    return std::ranges::any_of(contents,
+                               [&sha1](const auto& content) { return content.sha1 == sha1; });
   });
 
   // Any shared content used by a system title cannot be deleted.

--- a/Source/Core/Core/IOS/FS/FileSystemCommon.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemCommon.cpp
@@ -26,7 +26,7 @@ bool IsValidNonRootPath(std::string_view path)
 bool IsValidFilename(std::string_view filename)
 {
   return filename.length() <= MaxFilenameLength &&
-         !std::any_of(filename.begin(), filename.end(), [](char c) { return c == '/'; });
+         !std::ranges::any_of(filename, [](char c) { return c == '/'; });
 }
 
 SplitPathResult SplitPathAndBasename(std::string_view path)

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -461,8 +461,7 @@ ResultCode HostFileSystem::Format(Uid uid)
 ResultCode HostFileSystem::CreateFileOrDirectory(Uid uid, Gid gid, const std::string& path,
                                                  FileAttribute attr, Modes modes, bool is_file)
 {
-  if (!IsValidNonRootPath(path) ||
-      !std::all_of(path.begin(), path.end(), Common::IsPrintableCharacter))
+  if (!IsValidNonRootPath(path) || !std::ranges::all_of(path, Common::IsPrintableCharacter))
   {
     return ResultCode::Invalid;
   }

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -515,14 +515,14 @@ ResultCode HostFileSystem::CreateDirectory(Uid uid, Gid gid, const std::string& 
 
 bool HostFileSystem::IsFileOpened(const std::string& path) const
 {
-  return std::any_of(m_handles.begin(), m_handles.end(), [&path](const Handle& handle) {
+  return std::ranges::any_of(m_handles, [&path](const Handle& handle) {
     return handle.opened && handle.wii_path == path;
   });
 }
 
 bool HostFileSystem::IsDirectoryInUse(const std::string& path) const
 {
-  return std::any_of(m_handles.begin(), m_handles.end(), [&path](const Handle& handle) {
+  return std::ranges::any_of(m_handles, [&path](const Handle& handle) {
     return handle.opened && handle.wii_path.starts_with(path);
   });
 }

--- a/Source/Core/Core/IOS/Network/KD/Mail/WC24FriendList.cpp
+++ b/Source/Core/Core/IOS/Network/KD/Mail/WC24FriendList.cpp
@@ -58,8 +58,8 @@ bool WC24FriendList::CheckFriendList() const
 
 bool WC24FriendList::DoesFriendExist(u64 friend_id) const
 {
-  return std::any_of(m_data.friend_codes.cbegin(), m_data.friend_codes.cend(),
-                     [&friend_id](const u64 v) { return v == friend_id; });
+  return std::ranges::any_of(m_data.friend_codes,
+                             [&friend_id](const u64 v) { return v == friend_id; });
 }
 
 std::vector<u64> WC24FriendList::GetUnconfirmedFriends() const

--- a/Source/Core/Core/IOS/USB/Common.cpp
+++ b/Source/Core/Core/IOS/USB/Common.cpp
@@ -74,7 +74,7 @@ bool Device::HasClass(const u8 device_class) const
   if (GetDeviceDescriptor().bDeviceClass == device_class)
     return true;
   const auto interfaces = GetInterfaces(0);
-  return std::any_of(interfaces.begin(), interfaces.end(), [device_class](const auto& interface) {
+  return std::ranges::any_of(interfaces, [device_class](const auto& interface) {
     return interface.bInterfaceClass == device_class;
   });
 }

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -234,7 +234,7 @@ std::optional<IPCReply> OH0::RegisterClassChangeHook(const IOCtlVRequest& reques
 
 bool OH0::HasDeviceWithVidPid(const u16 vid, const u16 pid) const
 {
-  return std::any_of(m_devices.begin(), m_devices.end(), [=](const auto& device) {
+  return std::ranges::any_of(m_devices, [=](const auto& device) {
     return device.second->GetVid() == vid && device.second->GetPid() == pid;
   });
 }

--- a/Source/Core/Core/IOS/VersionInfo.cpp
+++ b/Source/Core/Core/IOS/VersionInfo.cpp
@@ -380,9 +380,9 @@ bool IsEmulated(u32 major_version)
   if (major_version == static_cast<u32>(Titles::BC & 0xffffffff))
     return true;
 
-  return std::any_of(
-      ios_memory_values.begin(), ios_memory_values.end(),
-      [major_version](const MemoryValues& values) { return values.ios_number == major_version; });
+  return std::ranges::any_of(ios_memory_values, [major_version](const MemoryValues& values) {
+    return values.ios_number == major_version;
+  });
 }
 
 bool IsEmulated(u64 title_id)

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -375,8 +375,8 @@ s32 WFSSRVDevice::Rename(std::string source, std::string dest) const
 
   INFO_LOG_FMT(IOS_WFS, "IOCTL_WFS_RENAME: {} to {}", source, dest);
 
-  const bool opened = std::any_of(m_fds.begin(), m_fds.end(),
-                                  [&](const auto& fd) { return fd.in_use && fd.path == source; });
+  const bool opened =
+      std::ranges::any_of(m_fds, [&](const auto& fd) { return fd.in_use && fd.path == source; });
 
   if (opened)
     return WFS_FILE_IS_OPENED;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -93,7 +93,7 @@ static std::array<u8, 20> ConvertGitRevisionToBytes(const std::string& revision)
 {
   std::array<u8, 20> revision_bytes{};
 
-  if (revision.size() % 2 == 0 && std::all_of(revision.begin(), revision.end(), Common::IsXDigit))
+  if (revision.size() % 2 == 0 && std::ranges::all_of(revision, Common::IsXDigit))
   {
     // The revision string normally contains a git commit hash,
     // which is 40 hexadecimal digits long. In DTM files, each pair of

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -93,7 +93,7 @@ static std::array<u8, 20> ConvertGitRevisionToBytes(const std::string& revision)
 {
   std::array<u8, 20> revision_bytes{};
 
-  if (revision.size() % 2 == 0 && std::all_of(revision.begin(), revision.end(), ::isxdigit))
+  if (revision.size() % 2 == 0 && std::all_of(revision.begin(), revision.end(), Common::IsXDigit))
   {
     // The revision string normally contains a git commit hash,
     // which is 40 hexadecimal digits long. In DTM files, each pair of

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2486,8 +2486,8 @@ bool NetPlayClient::PlayerHasControllerMapped(const PlayerId pid) const
 {
   const auto mapping_matches_player_id = [pid](const PlayerId& mapping) { return mapping == pid; };
 
-  return std::any_of(m_pad_map.begin(), m_pad_map.end(), mapping_matches_player_id) ||
-         std::any_of(m_wiimote_map.begin(), m_wiimote_map.end(), mapping_matches_player_id);
+  return std::ranges::any_of(m_pad_map, mapping_matches_player_id) ||
+         std::ranges::any_of(m_wiimote_map, mapping_matches_player_id);
 }
 
 bool NetPlayClient::IsLocalPlayer(const PlayerId pid) const

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2543,7 +2543,7 @@ bool NetPlayClient::DoAllPlayersHaveGame()
 {
   std::lock_guard lkp(m_crit.players);
 
-  return std::all_of(std::begin(m_players), std::end(m_players), [](auto entry) {
+  return std::ranges::all_of(m_players, [](const auto& entry) {
     return entry.second.game_status == SyncIdentifierComparison::SameGame;
   });
 }

--- a/Source/Core/Core/NetPlayCommon.cpp
+++ b/Source/Core/Core/NetPlayCommon.cpp
@@ -237,7 +237,7 @@ static bool DecompressPacketIntoFolderInternal(sf::Packet& packet, const std::st
     if (name.find('\\') != std::string::npos)
       return false;
 #endif
-    if (std::all_of(name.begin(), name.end(), [](char c) { return c == '.'; }))
+    if (std::ranges::all_of(name, [](char c) { return c == '.'; }))
       return false;
 
     bool is_folder;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -2232,8 +2232,8 @@ bool NetPlayServer::PlayerHasControllerMapped(const PlayerId pid) const
 {
   const auto mapping_matches_player_id = [pid](const PlayerId& mapping) { return mapping == pid; };
 
-  return std::any_of(m_pad_map.begin(), m_pad_map.end(), mapping_matches_player_id) ||
-         std::any_of(m_wiimote_map.begin(), m_wiimote_map.end(), mapping_matches_player_id);
+  return std::ranges::any_of(m_pad_map, mapping_matches_player_id) ||
+         std::ranges::any_of(m_wiimote_map, mapping_matches_player_id);
 }
 
 void NetPlayServer::AssignNewUserAPad(const Client& player)

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1060,14 +1060,14 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
     {
       // we have all records for this frame
 
-      if (!std::all_of(timebases.begin(), timebases.end(), [&](std::pair<PlayerId, u64> pair) {
+      if (!std::ranges::all_of(timebases, [&](std::pair<PlayerId, u64> pair) {
             return pair.second == timebases[0].second;
           }))
       {
         int pid_to_blame = 0;
         for (auto pair : timebases)
         {
-          if (std::all_of(timebases.begin(), timebases.end(), [&](std::pair<PlayerId, u64> other) {
+          if (std::ranges::all_of(timebases, [&](std::pair<PlayerId, u64> other) {
                 return other.first == pair.first || other.second != pair.second;
               }))
           {
@@ -1467,14 +1467,12 @@ bool NetPlayServer::SetupNetSettings()
 
 bool NetPlayServer::DoAllPlayersHaveIPLDump() const
 {
-  return std::all_of(m_players.begin(), m_players.end(),
-                     [](const auto& p) { return p.second.has_ipl_dump; });
+  return std::ranges::all_of(m_players, [](const auto& p) { return p.second.has_ipl_dump; });
 }
 
 bool NetPlayServer::DoAllPlayersHaveHardwareFMA() const
 {
-  return std::all_of(m_players.begin(), m_players.end(),
-                     [](const auto& p) { return p.second.has_hardware_fma; });
+  return std::ranges::all_of(m_players, [](const auto& p) { return p.second.has_hardware_fma; });
 }
 
 struct SaveSyncInfo

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -371,7 +371,7 @@ bool MemChecks::OverlapsMemcheck(u32 address, u32 length) const
   const u32 page_end_suffix = length - 1;
   const u32 page_end_address = address | page_end_suffix;
 
-  return std::any_of(m_mem_checks.cbegin(), m_mem_checks.cend(), [&](const auto& mc) {
+  return std::ranges::any_of(m_mem_checks, [&](const auto& mc) {
     return ((mc.start_address | page_end_suffix) == page_end_address ||
             (mc.end_address | page_end_suffix) == page_end_address) ||
            ((mc.start_address | page_end_suffix) < page_end_address &&

--- a/Source/Core/Core/PowerPC/Expression.cpp
+++ b/Source/Core/Core/PowerPC/Expression.cpp
@@ -136,15 +136,14 @@ static double CallstackFunc(expr_func* f, vec_expr_t* args, void* c)
   if (!std::isnan(num))
   {
     u32 address = static_cast<u32>(num);
-    return std::any_of(stack.begin(), stack.end(),
-                       [address](const auto& s) { return s.vAddress == address; });
+    return std::ranges::any_of(stack, [address](const auto& s) { return s.vAddress == address; });
   }
 
   const char* cstr = expr_get_str(&vec_nth(args, 0));
   if (cstr != nullptr)
   {
-    return std::any_of(stack.begin(), stack.end(),
-                       [cstr](const auto& s) { return s.Name.find(cstr) != std::string::npos; });
+    return std::ranges::any_of(
+        stack, [cstr](const auto& s) { return s.Name.find(cstr) != std::string::npos; });
   }
 
   return 0;

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -754,6 +754,5 @@ void RegCache::Realize(preg_t preg)
 
 bool RegCache::IsAnyConstraintActive() const
 {
-  return std::any_of(m_constraints.begin(), m_constraints.end(),
-                     [](const auto& c) { return c.IsActive(); });
+  return std::ranges::any_of(m_constraints, &RCConstraint::IsActive);
 }

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -369,10 +369,8 @@ RCForkGuard RegCache::Fork()
 
 void RegCache::Discard(BitSet32 pregs)
 {
-  ASSERT_MSG(
-      DYNA_REC,
-      std::none_of(m_xregs.begin(), m_xregs.end(), [](const auto& x) { return x.IsLocked(); }),
-      "Someone forgot to unlock a X64 reg");
+  ASSERT_MSG(DYNA_REC, std::ranges::none_of(m_xregs, &X64CachedReg::IsLocked),
+             "Someone forgot to unlock a X64 reg");
 
   for (preg_t i : pregs)
   {
@@ -393,10 +391,8 @@ void RegCache::Discard(BitSet32 pregs)
 
 void RegCache::Flush(BitSet32 pregs, IgnoreDiscardedRegisters ignore_discarded_registers)
 {
-  ASSERT_MSG(
-      DYNA_REC,
-      std::none_of(m_xregs.begin(), m_xregs.end(), [](const auto& x) { return x.IsLocked(); }),
-      "Someone forgot to unlock a X64 reg");
+  ASSERT_MSG(DYNA_REC, std::ranges::none_of(m_xregs, &X64CachedReg::IsLocked),
+             "Someone forgot to unlock a X64 reg");
 
   for (preg_t i : pregs)
   {
@@ -459,9 +455,8 @@ void RegCache::Commit()
 
 bool RegCache::IsAllUnlocked() const
 {
-  return std::none_of(m_regs.begin(), m_regs.end(), [](const auto& r) { return r.IsLocked(); }) &&
-         std::none_of(m_xregs.begin(), m_xregs.end(), [](const auto& x) { return x.IsLocked(); }) &&
-         !IsAnyConstraintActive();
+  return std::ranges::none_of(m_regs, &PPCCachedReg::IsLocked) &&
+         std::ranges::none_of(m_xregs, &X64CachedReg::IsLocked) && !IsAnyConstraintActive();
 }
 
 void RegCache::PreloadRegisters(BitSet32 to_preload)

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -112,7 +112,7 @@ JitBase::~JitBase()
 
 bool JitBase::DoesConfigNeedRefresh()
 {
-  return std::any_of(JIT_SETTINGS.begin(), JIT_SETTINGS.end(), [this](const auto& pair) {
+  return std::ranges::any_of(JIT_SETTINGS, [this](const auto& pair) {
     return this->*pair.first != Config::Get(*pair.second);
   });
 }

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -191,7 +191,7 @@ static void AnalyzeFunction2(PPCSymbolDB* func_db, Common::Symbol* func)
 {
   u32 flags = func->flags;
 
-  bool nonleafcall = std::any_of(func->calls.begin(), func->calls.end(), [&](const auto& call) {
+  bool nonleafcall = std::ranges::any_of(func->calls, [&](const auto& call) {
     const Common::Symbol* const called_func = func_db->GetSymbolFromAddr(call.function);
     return called_func && (called_func->flags & Common::FFLAG_LEAF) == 0;
   });

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -223,15 +223,14 @@ bool IsTitleInstalled(u64 title_id)
   // Since this isn't IOS and we only need a simple way to figure out if a title is installed,
   // we make the (reasonable) assumption that having more than just the TMD in the content
   // directory means that the title is installed.
-  return std::any_of(entries->begin(), entries->end(),
-                     [](const std::string& file) { return file != "title.tmd"; });
+  return std::ranges::any_of(*entries, [](const std::string& file) { return file != "title.tmd"; });
 }
 
 bool IsTMDImported(IOS::HLE::FS::FileSystem& fs, u64 title_id)
 {
   const auto entries = fs.ReadDirectory(0, 0, Common::GetTitleContentPath(title_id));
-  return entries && std::any_of(entries->begin(), entries->end(),
-                                [](const std::string& file) { return file == "title.tmd"; });
+  return entries &&
+         std::ranges::any_of(*entries, [](const std::string& file) { return file == "title.tmd"; });
 }
 
 IOS::ES::TMDReader FindBackupTMD(IOS::HLE::FS::FileSystem& fs, u64 title_id)
@@ -947,8 +946,8 @@ static NANDCheckResult CheckNAND(IOS::HLE::Kernel& ios, bool repair)
     }
 
     const auto installed_contents = es.GetStoredContentsFromTMD(tmd);
-    const bool is_installed = std::any_of(installed_contents.begin(), installed_contents.end(),
-                                          [](const auto& content) { return !content.IsShared(); });
+    const bool is_installed = std::ranges::any_of(
+        installed_contents, [](const auto& content) { return !content.IsShared(); });
 
     if (is_installed && installed_contents != tmd.GetContents() &&
         (tmd.GetTitleFlags() & IOS::ES::TitleFlags::TITLE_TYPE_DATA) == 0)

--- a/Source/Core/DiscIO/DiscUtils.cpp
+++ b/Source/Core/DiscIO/DiscUtils.cpp
@@ -40,7 +40,7 @@ std::string NameForPartitionType(u32 partition_type, bool include_prefix)
                                       static_cast<char>((partition_type >> 16) & 0xFF),
                                       static_cast<char>((partition_type >> 8) & 0xFF),
                                       static_cast<char>(partition_type & 0xFF)};
-    if (std::all_of(type_as_game_id.cbegin(), type_as_game_id.cend(), Common::IsAlnum))
+    if (std::ranges::all_of(type_as_game_id, Common::IsAlnum))
     {
       return include_prefix ? "P-" + type_as_game_id : type_as_game_id;
     }

--- a/Source/Core/DiscIO/DiscUtils.cpp
+++ b/Source/Core/DiscIO/DiscUtils.cpp
@@ -13,6 +13,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
+#include "Common/StringUtil.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
@@ -39,8 +40,7 @@ std::string NameForPartitionType(u32 partition_type, bool include_prefix)
                                       static_cast<char>((partition_type >> 16) & 0xFF),
                                       static_cast<char>((partition_type >> 8) & 0xFF),
                                       static_cast<char>(partition_type & 0xFF)};
-    if (std::all_of(type_as_game_id.cbegin(), type_as_game_id.cend(),
-                    [](char c) { return std::isalnum(c, std::locale::classic()); }))
+    if (std::all_of(type_as_game_id.cbegin(), type_as_game_id.cend(), Common::IsAlnum))
     {
       return include_prefix ? "P-" + type_as_game_id : type_as_game_id;
     }

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -104,7 +104,7 @@ FileDataLoaderHostFS::MakeAbsoluteFromRelative(std::string_view external_relativ
         result.pop_back();
       result.pop_back();
     }
-    else if (std::all_of(element.begin(), element.end(), [](char c) { return c == '.'; }))
+    else if (std::ranges::all_of(element, [](char c) { return c == '.'; }))
     {
       // This is a triple, quadruple, etc. dot.
       // Some file systems treat this as several 'up' path traversals, but Riivolution does not.

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -729,16 +729,15 @@ bool VolumeVerifier::ShouldHaveInstallPartition() const
   static constexpr std::array<std::string_view, 4> dragon_quest_x = {"S4MJGD", "S4SJGD", "S6TJGD",
                                                                      "SDQJGD"};
   const std::string& game_id = m_volume.GetGameID();
-  return std::any_of(dragon_quest_x.cbegin(), dragon_quest_x.cend(),
-                     [&game_id](std::string_view x) { return x == game_id; });
+  return std::ranges::any_of(dragon_quest_x,
+                             [&game_id](std::string_view x) { return x == game_id; });
 }
 
 bool VolumeVerifier::ShouldHaveMasterpiecePartitions() const
 {
   static constexpr std::array<std::string_view, 4> ssbb = {"RSBE01", "RSBJ01", "RSBK01", "RSBP01"};
   const std::string& game_id = m_volume.GetGameID();
-  return std::any_of(ssbb.cbegin(), ssbb.cend(),
-                     [&game_id](std::string_view x) { return x == game_id; });
+  return std::ranges::any_of(ssbb, [&game_id](std::string_view x) { return x == game_id; });
 }
 
 bool VolumeVerifier::ShouldBeDualLayer() const
@@ -1039,7 +1038,7 @@ void VolumeVerifier::CheckSuperPaperMario()
   if (!m_volume.Read(offset, length, data.data(), partition))
     return;
 
-  if (std::any_of(data.cbegin(), data.cend(), [](u8 x) { return x != 0; }))
+  if (std::ranges::any_of(data, [](u8 x) { return x != 0; }))
   {
     AddProblem(Severity::High,
                Common::GetStringT("Some padding data that should be zero is not zero. "

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -176,7 +176,7 @@ IOS::ES::TicketReader VolumeWAD::GetTicketWithFixedCommonKey() const
     return m_ticket;
 
   const std::vector<u8> sig = m_ticket.GetSignatureData();
-  if (!std::all_of(sig.cbegin(), sig.cend(), [](u8 a) { return a == 0; }))
+  if (!std::ranges::all_of(sig, [](u8 a) { return a == 0; }))
   {
     // This does not look like a typical "invalid common key index" ticket, so let's assume
     // the index is correct. This saves some time when reading properly signed titles.

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -1126,7 +1126,7 @@ bool WIARVZFileReader<RVZ>::TryReuse(std::map<ReuseID, GroupEntry>* reusable_gro
 
 static bool AllAre(const std::vector<u8>& data, u8 x)
 {
-  return std::all_of(data.begin(), data.end(), [x](u8 y) { return x == y; });
+  return std::ranges::all_of(data, [x](u8 y) { return x == y; });
 }
 
 static bool AllAre(const u8* begin, const u8* end, u8 x)
@@ -1379,8 +1379,8 @@ WIARVZFileReader<RVZ>::ProcessAndCompress(CompressThreadState* state, CompressPa
       }
     }
 
-    if (!std::all_of(output_entries.begin(), output_entries.end(),
-                     [](const OutputParametersEntry& entry) { return entry.reused_group; }))
+    if (!std::ranges::all_of(output_entries,
+                             [](const auto& entry) { return entry.reused_group.has_value(); }))
     {
       const u64 number_of_exception_lists =
           chunks_per_wii_group == 1 ? exception_lists_per_chunk : chunks;

--- a/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GraphicsModListWidget.cpp
@@ -138,10 +138,9 @@ void GraphicsModListWidget::RefreshModList()
   for (const GraphicsModConfig& mod : m_mod_group.GetMods())
   {
     // If no group matches the mod's features, or if the mod has no features, skip it
-    if (std::none_of(mod.m_features.begin(), mod.m_features.end(),
-                     [&groups](const GraphicsModFeatureConfig& feature) {
-                       return groups.contains(feature.m_group);
-                     }))
+    if (std::ranges::none_of(mod.m_features, [&groups](const GraphicsModFeatureConfig& feature) {
+          return groups.contains(feature.m_group);
+        }))
     {
       continue;
     }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -598,9 +598,8 @@ void ShakeMappingIndicator::Update(float elapsed_seconds)
 
   m_position_samples.push_front(ShakeSample{m_motion_state.position / MAX_DISTANCE});
 
-  const bool any_non_zero_samples =
-      std::any_of(m_position_samples.begin(), m_position_samples.end(),
-                  [](const ShakeSample& s) { return s.state.LengthSquared() != 0.0; });
+  const bool any_non_zero_samples = std::ranges::any_of(
+      m_position_samples, [](const ShakeSample& s) { return s.state.LengthSquared() != 0.0; });
 
   // Only start moving the line if there's non-zero data.
   if (m_grid_line_position || any_non_zero_samples)

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -248,9 +248,8 @@ void ConvertDialog::OnFormatChanged()
   m_compression->setEnabled(m_compression->count() > 1);
 
   // Block scrubbing of RVZ containers and Datel discs
-  const bool scrubbing_allowed =
-      format != DiscIO::BlobType::RVZ &&
-      std::none_of(m_files.begin(), m_files.end(), std::mem_fn(&UICommon::GameFile::IsDatelDisc));
+  const bool scrubbing_allowed = format != DiscIO::BlobType::RVZ &&
+                                 std::ranges::none_of(m_files, &UICommon::GameFile::IsDatelDisc);
 
   m_scrub->setEnabled(scrubbing_allowed);
   if (!scrubbing_allowed)

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -52,8 +52,8 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
   m_format->addItem(QStringLiteral("GCZ"), static_cast<int>(DiscIO::BlobType::GCZ));
   m_format->addItem(QStringLiteral("WIA"), static_cast<int>(DiscIO::BlobType::WIA));
   m_format->addItem(QStringLiteral("RVZ"), static_cast<int>(DiscIO::BlobType::RVZ));
-  if (std::all_of(m_files.begin(), m_files.end(),
-                  [](const auto& file) { return file->GetBlobType() == DiscIO::BlobType::PLAIN; }))
+  if (std::ranges::all_of(
+          m_files, [](const auto& file) { return file->GetBlobType() == DiscIO::BlobType::PLAIN; }))
   {
     m_format->setCurrentIndex(m_format->count() - 1);
   }
@@ -153,7 +153,7 @@ void ConvertDialog::OnFormatChanged()
     // To support legacy versions of dolphin, we have to check the GCZ block size
     // See DiscIO::IsGCZBlockSizeLegacyCompatible() for details
     const auto block_size_ok = [this](int block_size) {
-      return std::all_of(m_files.begin(), m_files.end(), [block_size](const auto& file) {
+      return std::ranges::all_of(m_files, [block_size](const auto& file) {
         return DiscIO::IsGCZBlockSizeLegacyCompatible(block_size, file->GetVolumeSize());
       });
     };

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -309,7 +309,7 @@ void ConvertDialog::Convert()
   }
 
   if (!scrub && format == DiscIO::BlobType::GCZ &&
-      std::any_of(m_files.begin(), m_files.end(), [](const auto& file) {
+      std::ranges::any_of(m_files, [](const auto& file) {
         return file->GetPlatform() == DiscIO::Platform::WiiDisc && !file->IsDatelDisc();
       }))
   {
@@ -321,7 +321,7 @@ void ConvertDialog::Convert()
     }
   }
 
-  if (std::any_of(m_files.begin(), m_files.end(), std::mem_fn(&UICommon::GameFile::IsNKit)))
+  if (std::ranges::any_of(m_files, &UICommon::GameFile::IsNKit))
   {
     if (!ShowAreYouSureDialog(
             tr("Dolphin can't convert NKit files to non-NKit files. Converting an NKit file in "

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -377,15 +377,15 @@ void GameList::ShowContextMenu(const QPoint&)
   {
     const auto selected_games = GetSelectedGames();
 
-    if (std::all_of(selected_games.begin(), selected_games.end(),
-                    [](const auto& game) { return game->ShouldAllowConversion(); }))
+    if (std::ranges::all_of(selected_games,
+                            [](const auto& game) { return game->ShouldAllowConversion(); }))
     {
       menu->addAction(tr("Convert Selected Files..."), this, &GameList::ConvertFile);
       menu->addSeparator();
     }
 
-    if (std::all_of(selected_games.begin(), selected_games.end(),
-                    [](const auto& game) { return DiscIO::IsWii(game->GetPlatform()); }))
+    if (std::ranges::all_of(selected_games,
+                            [](const auto& game) { return DiscIO::IsWii(game->GetPlatform()); }))
     {
       menu->addAction(tr("Export Wii Saves"), this, &GameList::ExportWiiSave);
       menu->addSeparator();

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -428,8 +428,7 @@ void AudioPane::OnVolumeChanged(int volume)
 void AudioPane::CheckNeedForLatencyControl()
 {
   std::vector<std::string> backends = AudioCommon::GetSoundBackends();
-  m_latency_control_supported =
-      std::any_of(backends.cbegin(), backends.cend(), AudioCommon::SupportsLatencyControl);
+  m_latency_control_supported = std::ranges::any_of(backends, AudioCommon::SupportsLatencyControl);
 }
 
 QString AudioPane::GetDPL2QualityLabel(AudioCommon::DPL2Quality value) const

--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -30,8 +30,7 @@ static bool IsValidUSBIDString(const std::string& string)
 {
   if (string.empty() || string.length() > 4)
     return false;
-  return std::all_of(string.begin(), string.end(),
-                     [](const auto character) { return std::isxdigit(character) != 0; });
+  return std::all_of(string.begin(), string.end(), Common::IsXDigit);
 }
 
 USBDeviceAddToWhitelistDialog::USBDeviceAddToWhitelistDialog(QWidget* parent) : QDialog(parent)

--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -30,7 +30,7 @@ static bool IsValidUSBIDString(const std::string& string)
 {
   if (string.empty() || string.length() > 4)
     return false;
-  return std::all_of(string.begin(), string.end(), Common::IsXDigit);
+  return std::ranges::all_of(string, Common::IsXDigit);
 }
 
 USBDeviceAddToWhitelistDialog::USBDeviceAddToWhitelistDialog(QWidget* parent) : QDialog(parent)

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -305,9 +305,10 @@ bool HotkeySuppressions::IsSuppressedIgnoringModifiers(Device::Input* input,
     return i1 && i2 && (i1 == i2 || i1->IsChild(i2) || i2->IsChild(i1));
   };
 
-  return std::any_of(it, it_end, [&](auto& s) {
-    return std::none_of(begin(ignore_modifiers), end(ignore_modifiers),
-                        [&](auto& m) { return is_same_modifier(m->GetInput(), s.first.second); });
+  return std::any_of(it, it_end, [&](const auto& s) {
+    return std::ranges::none_of(ignore_modifiers, [&](const auto& m) {
+      return is_same_modifier(m->GetInput(), s.first.second);
+    });
   });
 }
 

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -495,10 +495,8 @@ public:
   ControlState GetValue() const override
   {
     // True if we have no modifiers
-    const bool modifiers_pressed = std::all_of(m_modifiers.begin(), m_modifiers.end(),
-                                               [](const std::unique_ptr<ControlExpression>& input) {
-                                                 return input->GetValue() > CONDITION_THRESHOLD;
-                                               });
+    const bool modifiers_pressed = std::ranges::all_of(
+        m_modifiers, [](const auto& input) { return input->GetValue() > CONDITION_THRESHOLD; });
 
     const auto final_input_state = m_final_input->GetValueIgnoringSuppression();
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
@@ -25,8 +25,8 @@ IMUAccelerometer::IMUAccelerometer(std::string name_, std::string ui_name_)
 
 bool IMUAccelerometer::AreInputsBound() const
 {
-  return std::all_of(controls.begin(), controls.end(),
-                     [](const auto& control) { return control->control_ref->BoundCount() > 0; });
+  return std::ranges::all_of(
+      controls, [](const auto& control) { return control->control_ref->BoundCount() > 0; });
 }
 
 std::optional<IMUAccelerometer::StateData> IMUAccelerometer::GetState() const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -90,8 +90,8 @@ void IMUGyroscope::UpdateCalibration(const StateData& state)
     // Check for required calibration update frequency
     // and if current data is within deadzone distance of mean stable value.
     if (calibration_freq < WORST_ACCEPTABLE_CALIBRATION_UPDATE_FREQUENCY ||
-        std::any_of(current_difference.data.begin(), current_difference.data.end(),
-                    [&](auto c) { return std::abs(c) > deadzone; }))
+        std::ranges::any_of(current_difference.data,
+                            [&](auto c) { return std::abs(c) > deadzone; }))
     {
       RestartCalibration();
     }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -123,8 +123,8 @@ auto IMUGyroscope::GetRawState() const -> StateData
 
 bool IMUGyroscope::AreInputsBound() const
 {
-  return std::all_of(controls.begin(), controls.end(),
-                     [](const auto& control) { return control->control_ref->BoundCount() > 0; });
+  return std::ranges::all_of(
+      controls, [](const auto& control) { return control->control_ref->BoundCount() > 0; });
 }
 
 bool IMUGyroscope::CanCalibrate() const

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -248,7 +248,7 @@ bool ControllerInterface::AddDevice(std::shared_ptr<ciface::Core::Device> device
     std::lock_guard lk(m_devices_mutex);
 
     const auto is_id_in_use = [&device, this](int id) {
-      return std::any_of(m_devices.begin(), m_devices.end(), [&device, &id](const auto& d) {
+      return std::ranges::any_of(m_devices, [&device, &id](const auto& d) {
         return d->GetSource() == device->GetSource() && d->GetName() == device->GetName() &&
                d->GetId() == id;
       });
@@ -368,10 +368,8 @@ void ControllerInterface::UpdateInput()
   if (devices_to_remove.size() > 0)
   {
     RemoveDevice([&](const ciface::Core::Device* device) {
-      return std::any_of(devices_to_remove.begin(), devices_to_remove.end(),
-                         [device](const std::weak_ptr<ciface::Core::Device>& d) {
-                           return d.lock().get() == device;
-                         });
+      return std::ranges::any_of(devices_to_remove,
+                                 [device](const auto& d) { return d.lock().get() == device; });
     });
   }
 }

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -44,7 +44,7 @@ std::string GetExpressionForControl(const std::string& control_name,
   {
     // If our expression contains any non-alpha characters
     // we should quote it
-    if (!std::all_of(expr.begin(), expr.end(), Common::IsAlpha))
+    if (!std::ranges::all_of(expr, Common::IsAlpha))
       expr = fmt::format("`{}`", expr);
   }
 

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -137,8 +137,8 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
 void RemoveSpuriousTriggerCombinations(
     std::vector<ciface::Core::DeviceContainer::InputDetection>* detections)
 {
-  const auto is_spurious = [&](auto& detection) {
-    return std::any_of(detections->begin(), detections->end(), [&](auto& d) {
+  const auto is_spurious = [&](const auto& detection) {
+    return std::ranges::any_of(*detections, [&](const auto& d) {
       // This is a spurious digital detection if a "smooth" (analog) detection is temporally near.
       return &d != &detection && d.smoothness > 1 && d.smoothness > detection.smoothness &&
              abs(d.press_time - detection.press_time) < SPURIOUS_TRIGGER_COMBO_THRESHOLD;

--- a/Source/Core/InputCommon/DynamicInputTextures/DITSpecification.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextures/DITSpecification.cpp
@@ -136,8 +136,7 @@ bool ProcessSpecificationV1(picojson::value& root, std::vector<Data>& input_text
             return false;
           }
 
-          if (!std::all_of(region_offsets.begin(), region_offsets.end(),
-                           [](picojson::value val) { return val.is<double>(); }))
+          if (!std::ranges::all_of(region_offsets, &picojson::value::is<double>))
           {
             ERROR_LOG_FMT(
                 VIDEO,

--- a/Source/Core/VideoBackends/OGL/OGLGfx.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLGfx.cpp
@@ -304,8 +304,8 @@ void OGLGfx::DispatchComputeShader(const AbstractShader* shader, u32 groupsize_x
     static_cast<const OGLPipeline*>(m_current_pipeline)->GetProgram()->shader.Bind();
 
   // Barrier to texture can be used for reads.
-  if (std::any_of(m_bound_image_textures.begin(), m_bound_image_textures.end(),
-                  [](auto image) { return image != nullptr; }))
+  if (std::ranges::any_of(m_bound_image_textures,
+                          [](const auto* image) { return image != nullptr; }))
   {
     glMemoryBarrier(GL_TEXTURE_UPDATE_BARRIER_BIT);
   }

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -929,8 +929,8 @@ void VulkanContext::DisableDebugUtils()
 
 bool VulkanContext::SupportsDeviceExtension(const char* name) const
 {
-  return std::any_of(m_device_extensions.begin(), m_device_extensions.end(),
-                     [name](const std::string& extension) { return extension == name; });
+  return std::ranges::any_of(m_device_extensions,
+                             [name](const std::string& extension) { return extension == name; });
 }
 
 static bool DriverIsMesa(VkDriverId driver_id)

--- a/Source/Core/VideoCommon/Assets/CustomAssetLibrary.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLibrary.cpp
@@ -69,10 +69,8 @@ CustomAssetLibrary::LoadInfo CustomAssetLibrary::LoadGameTexture(const AssetID& 
     }
 
     // All levels have to have the same format.
-    if (std::any_of(slice.m_levels.begin(), slice.m_levels.end(),
-                    [&first_mip](const VideoCommon::CustomTextureData::ArraySlice::Level& l) {
-                      return l.format != first_mip.format;
-                    }))
+    if (std::ranges::any_of(slice.m_levels,
+                            [&first_mip](const auto& l) { return l.format != first_mip.format; }))
     {
       ERROR_LOG_FMT(
           VIDEO, "Custom game texture {} has inconsistent formats across mip levels for slice {}.",

--- a/Source/Core/VideoCommon/Assets/MaterialAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/MaterialAsset.cpp
@@ -63,8 +63,7 @@ bool ParseNumeric(const CustomAssetLibrary::AssetID& asset_id, const picojson::v
       return false;
     }
 
-    if (!std::all_of(json_data.begin(), json_data.end(),
-                     [](const picojson::value& v) { return v.is<double>(); }))
+    if (!std::ranges::all_of(json_data, &picojson::value::is<double>))
     {
       ERROR_LOG_FMT(VIDEO,
                     "Asset id '{}' material has attribute '{}' where "

--- a/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
@@ -54,8 +54,7 @@ bool ParseNumeric(const CustomAssetLibrary::AssetID& asset_id, const picojson::v
       return false;
     }
 
-    if (!std::all_of(json_data.begin(), json_data.end(),
-                     [](const picojson::value& v) { return v.is<double>(); }))
+    if (!std::ranges::all_of(json_data, &picojson::value::is<double>))
     {
       ERROR_LOG_FMT(VIDEO,
                     "Asset id '{}' shader has attribute '{}' where "

--- a/Source/Core/VideoCommon/BoundingBox.cpp
+++ b/Source/Core/VideoCommon/BoundingBox.cpp
@@ -34,7 +34,7 @@ void BoundingBox::Flush()
 
   m_is_valid = false;
 
-  if (std::none_of(m_dirty.begin(), m_dirty.end(), [](bool dirty) { return dirty; }))
+  if (std::ranges::none_of(m_dirty, std::identity{}))
     return;
 
   // TODO: Does this make any difference over just writing all the values?


### PR DESCRIPTION
The modernization of trivial examples of the `all_of`/`any_of`/`none_of` family of algorithms was originally a part of https://github.com/dolphin-emu/dolphin/pull/13090, but I determined that the large number of places they are used was detrimental to the overall review process.  For that reason, I have split them off into their own PR.

This PR has a small prerequisite in the form of its first commit. I noticed across the codebase that wrappers for \<cctype\> functions could be found in random places. Some of these wrappers were relevant to algorithms I planned on updating, and I was aware that wrapper functions like these also exist in the StringUtil header. For these reasons, I migrated them all to "Common/StringUtil.h".

This PR will remain a draft until I am confident there are no mistakes in my changes.