### PR TITLE
JitArm64: Optimize mtspr

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -649,7 +649,7 @@ void JitArm64::cmp(UGeckoInstruction inst)
     SXTW(CR, gpr.R(b));
     NEG(CR, CR);
   }
-  else if (gpr.IsImm(a) && gpr.GetImm(a) == 0xFFFFFFFF)
+  else if (gpr.IsImm(a, 0xFFFFFFFF))
   {
     SXTW(CR, gpr.R(b));
     MVN(CR, CR);
@@ -1640,7 +1640,7 @@ void JitArm64::divwx(UGeckoInstruction inst)
     if (inst.Rc)
       ComputeRC0(imm_d);
   }
-  else if (gpr.IsImm(a) && gpr.GetImm(a) == 0)
+  else if (gpr.IsImm(a, 0))
   {
     // Zero divided by anything is always zero
     gpr.SetImmediate(d, 0);
@@ -1829,7 +1829,7 @@ void JitArm64::slwx(UGeckoInstruction inst)
     if (inst.Rc)
       ComputeRC0(gpr.GetImm(a));
   }
-  else if (gpr.IsImm(s) && gpr.GetImm(s) == 0)
+  else if (gpr.IsImm(s, 0))
   {
     gpr.SetImmediate(a, 0);
     if (inst.Rc)
@@ -1934,7 +1934,7 @@ void JitArm64::srawx(UGeckoInstruction inst)
       ComputeRC0(gpr.GetImm(a));
     return;
   }
-  else if (gpr.IsImm(s) && gpr.GetImm(s) == 0)
+  else if (gpr.IsImm(s, 0))
   {
     gpr.SetImmediate(a, 0);
     ComputeCarry(false);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -286,6 +286,8 @@ public:
   // Gets the immediate that a register is set to. Only valid for guest GPRs.
   u32 GetImm(size_t preg) const { return GetGuestGPROpArg(preg).GetImm(); }
 
+  bool IsImm(size_t preg, u32 imm) { return IsImm(preg) && GetImm(preg) == imm; }
+
   // Binds a guest GPR to a host register, optionally loading its value.
   //
   // preg: The guest register index.

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -477,7 +477,7 @@ void JitArm64::mtspr(UGeckoInstruction inst)
   }
 
   // OK, this is easy.
-  ARM64Reg RD = gpr.R(inst.RD);
+  ARM64Reg RD = gpr.IsImm(inst.RD, 0) ? ARM64Reg::WZR : gpr.R(inst.RD);
   STR(IndexType::Unsigned, RD, PPC_REG, PPCSTATE_OFF_SPR(iIndex));
 }
 


### PR DESCRIPTION
No need to materialize the constant in a register if it's zero, we can just use `WZR`.

Before:
```
mov w27, #0x0 ; =0
str w27, [x29, #0x1178]
```
After:
```
str wzr, [x29, #0x1178]
```