### PR TITLE
C++20: Synthesize `operator!=` From `operator==`

### DIFF
--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -20,7 +20,6 @@ struct ConfigChangedCallbackID
   size_t id = -1;
 
   bool operator==(const ConfigChangedCallbackID&) const = default;
-  bool operator!=(const ConfigChangedCallbackID&) const = default;
 };
 
 using ConfigChangedCallback = std::function<void()>;

--- a/Source/Core/Common/Config/ConfigInfo.cpp
+++ b/Source/Core/Common/Config/ConfigInfo.cpp
@@ -15,11 +15,6 @@ bool Location::operator==(const Location& other) const
          strcasecmp(key.c_str(), other.key.c_str()) == 0;
 }
 
-bool Location::operator!=(const Location& other) const
-{
-  return !(*this == other);
-}
-
 bool Location::operator<(const Location& other) const
 {
   if (system != other.system)

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -28,7 +28,6 @@ struct Location
   std::string key;
 
   bool operator==(const Location& other) const;
-  bool operator!=(const Location& other) const;
   bool operator<(const Location& other) const;
 };
 

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -122,7 +122,6 @@ struct OpArg
     return std::tie(scale, offsetOrBaseReg, indexReg, offset, operandReg) ==
            std::tie(b.scale, b.offsetOrBaseReg, b.indexReg, b.offset, b.operandReg);
   }
-  constexpr bool operator!=(const OpArg& b) const { return !operator==(b); }
   u64 Imm64() const
   {
     DEBUG_ASSERT(scale == SCALE_IMM64);

--- a/Source/Core/Core/CPUThreadConfigCallback.h
+++ b/Source/Core/Core/CPUThreadConfigCallback.h
@@ -16,7 +16,6 @@ struct ConfigChangedCallbackID
   size_t id = -1;
 
   bool operator==(const ConfigChangedCallbackID&) const = default;
-  bool operator!=(const ConfigChangedCallbackID&) const = default;
 };
 
 // returns an ID that can be passed to RemoveConfigChangedCallback()

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -30,19 +30,9 @@ bool operator==(const GeckoCode& lhs, const GeckoCode& rhs)
   return lhs.codes == rhs.codes;
 }
 
-bool operator!=(const GeckoCode& lhs, const GeckoCode& rhs)
-{
-  return !operator==(lhs, rhs);
-}
-
 bool operator==(const GeckoCode::Code& lhs, const GeckoCode::Code& rhs)
 {
   return std::tie(lhs.address, lhs.data) == std::tie(rhs.address, rhs.data);
-}
-
-bool operator!=(const GeckoCode::Code& lhs, const GeckoCode::Code& rhs)
-{
-  return !operator==(lhs, rhs);
 }
 
 enum class Installation

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -39,10 +39,8 @@ public:
 };
 
 bool operator==(const GeckoCode& lhs, const GeckoCode& rhs);
-bool operator!=(const GeckoCode& lhs, const GeckoCode& rhs);
 
 bool operator==(const GeckoCode::Code& lhs, const GeckoCode::Code& rhs);
-bool operator!=(const GeckoCode::Code& lhs, const GeckoCode::Code& rhs);
 
 // Installation address for codehandler.bin in the Game's RAM
 constexpr u32 INSTALLER_BASE_ADDRESS = 0x80001800;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1228,11 +1228,6 @@ bool operator==(const HeaderData& lhs, const HeaderData& rhs)
   return std::memcmp(&lhs, &rhs, sizeof(HeaderData)) == 0;
 }
 
-bool operator!=(const HeaderData& lhs, const HeaderData& rhs)
-{
-  return !(lhs == rhs);
-}
-
 Header::Header(const CardFlashId& flash_id, u16 size_mbits, bool shift_jis, u32 rtc_bias,
                u32 sram_language, u64 format_time)
 {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -192,7 +192,6 @@ void InitializeHeaderData(HeaderData* data, const CardFlashId& flash_id, u16 siz
                           bool shift_jis, u32 rtc_bias, u32 sram_language, u64 format_time);
 
 bool operator==(const HeaderData& lhs, const HeaderData& rhs);
-bool operator!=(const HeaderData& lhs, const HeaderData& rhs);
 
 struct Header
 {

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.h
@@ -30,7 +30,6 @@ struct CameraPoint
   {
     return this->position == other.position && this->size == other.size;
   }
-  constexpr bool operator!=(const CameraPoint& other) const { return !(*this == other); }
 };
 
 // Four bytes for two objects. Filled with 0xFF if empty

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -73,11 +73,6 @@ bool operator==(const Content& lhs, const Content& rhs)
   return fields(lhs) == fields(rhs);
 }
 
-bool operator!=(const Content& lhs, const Content& rhs)
-{
-  return !operator==(lhs, rhs);
-}
-
 SignedBlobReader::SignedBlobReader(std::vector<u8> bytes) : m_bytes(std::move(bytes))
 {
 }

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -101,7 +101,6 @@ struct Content
 };
 static_assert(sizeof(Content) == 36, "Content has the wrong size");
 bool operator==(const Content&, const Content&);
-bool operator!=(const Content&, const Content&);
 
 struct TimeLimit
 {

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -91,11 +91,6 @@ inline bool operator==(const Modes& lhs, const Modes& rhs)
   return fields(lhs) == fields(rhs);
 }
 
-inline bool operator!=(const Modes& lhs, const Modes& rhs)
-{
-  return !(lhs == rhs);
-}
-
 struct Metadata
 {
   Uid uid;
@@ -188,11 +183,6 @@ inline bool operator==(const SplitPathResult& lhs, const SplitPathResult& rhs)
     return std::tie(obj.parent, obj.file_name);
   };
   return fields(lhs) == fields(rhs);
-}
-
-inline bool operator!=(const SplitPathResult& lhs, const SplitPathResult& rhs)
-{
-  return !(lhs == rhs);
 }
 
 /// Split a path into a parent path and the file name. Takes a *valid non-root* path.

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -151,7 +151,6 @@ public:
   Arm64Gen::ARM64Reg GetReg() const { return m_reg; }
 
   bool operator==(Arm64Gen::ARM64Reg reg) const { return reg == m_reg; }
-  bool operator!=(Arm64Gen::ARM64Reg reg) const { return !operator==(reg); }
 
 private:
   Arm64Gen::ARM64Reg m_reg = Arm64Gen::ARM64Reg::INVALID_REG;

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -140,7 +140,6 @@ public:
   bool Read(u64* offset, u64* length, u8** buffer, DirectoryBlobReader* blob) const;
 
   bool operator==(const DiscContent& other) const { return GetEndOffset() == other.GetEndOffset(); }
-  bool operator!=(const DiscContent& other) const { return !(*this == other); }
   bool operator<(const DiscContent& other) const { return GetEndOffset() < other.GetEndOffset(); }
   bool operator>(const DiscContent& other) const { return other < *this; }
   bool operator<=(const DiscContent& other) const { return !(*this > other); }

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -60,7 +60,6 @@ public:
     {
       return m_file_info ? (it.m_file_info && *m_file_info == *it.m_file_info) : (!it.m_file_info);
     }
-    bool operator!=(const const_iterator& it) const { return !operator==(it); }
     // Incrementing or destroying an iterator will invalidate its returned references and
     // pointers, but will not invalidate copies of the iterator or file info object.
     const FileInfo& operator*() const { return *m_file_info.get(); }
@@ -73,7 +72,6 @@ public:
   virtual ~FileInfo();
 
   bool operator==(const FileInfo& other) const { return GetAddress() == other.GetAddress(); }
-  bool operator!=(const FileInfo& other) const { return !operator==(other); }
   virtual std::unique_ptr<FileInfo> clone() const = 0;
   virtual const_iterator cbegin() const { return begin(); }
   virtual const_iterator cend() const { return end(); }

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -32,7 +32,6 @@ struct Partition final
   constexpr Partition() = default;
   constexpr explicit Partition(u64 offset_) : offset(offset_) {}
   constexpr bool operator==(const Partition& other) const { return offset == other.offset; }
-  constexpr bool operator!=(const Partition& other) const { return !(*this == other); }
   constexpr bool operator<(const Partition& other) const { return offset < other.offset; }
   constexpr bool operator>(const Partition& other) const { return other < *this; }
   constexpr bool operator<=(const Partition& other) const { return !(*this < other); }

--- a/Source/Core/DiscIO/WIABlob.h
+++ b/Source/Core/DiscIO/WIABlob.h
@@ -264,7 +264,6 @@ private:
              std::tie(other.partition_key, other.data_size, other.encrypted, other.value);
     }
 
-    bool operator!=(const ReuseID& other) const { return !operator==(other); }
     bool operator>=(const ReuseID& other) const { return !operator<(other); }
     bool operator<=(const ReuseID& other) const { return !operator>(other); }
 

--- a/Source/Core/DolphinQt/Translation.cpp
+++ b/Source/Core/DolphinQt/Translation.cpp
@@ -80,7 +80,6 @@ public:
 
   // Needed for InputIterator concept
   bool operator==(const MoIterator& other) const { return distance_to(other) == 0; }
-  bool operator!=(const MoIterator& other) const { return !(*this == other); }
   pointer operator->() const { return dereference(); }
   MoIterator operator++(int)
   {

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -227,19 +227,9 @@ bool DeviceQualifier::operator==(const Device* const dev) const
   return false;
 }
 
-bool DeviceQualifier::operator!=(const Device* const dev) const
-{
-  return !operator==(dev);
-}
-
 bool DeviceQualifier::operator==(const DeviceQualifier& devq) const
 {
   return std::tie(cid, name, source) == std::tie(devq.cid, devq.name, devq.source);
-}
-
-bool DeviceQualifier::operator!=(const DeviceQualifier& devq) const
-{
-  return !operator==(devq);
 }
 
 std::shared_ptr<Device> DeviceContainer::FindDevice(const DeviceQualifier& devq) const

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -213,10 +213,8 @@ public:
   std::string ToString() const;
 
   bool operator==(const DeviceQualifier& devq) const;
-  bool operator!=(const DeviceQualifier& devq) const;
 
   bool operator==(const Device* dev) const;
-  bool operator!=(const Device* dev) const;
 
   std::string source;
   int cid;

--- a/Source/Core/InputCommon/ImageOperations.h
+++ b/Source/Core/InputCommon/ImageOperations.h
@@ -21,7 +21,6 @@ struct Pixel
   u8 a = 0;
 
   bool operator==(const Pixel& o) const { return r == o.r && g == o.g && b == o.b && a == o.a; }
-  bool operator!=(const Pixel& o) const { return !(o == *this); }
 };
 
 using Point = Common::TVec2<u32>;

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -307,9 +307,4 @@ bool ResourcePack::operator==(const ResourcePack& pack) const
   return pack.GetPath() == m_path;
 }
 
-bool ResourcePack::operator!=(const ResourcePack& pack) const
-{
-  return !operator==(pack);
-}
-
 }  // namespace ResourcePack

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.h
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.h
@@ -30,7 +30,6 @@ public:
   bool Uninstall(const std::string& path);
 
   bool operator==(const ResourcePack& pack) const;
-  bool operator!=(const ResourcePack& pack) const;
 
 private:
   bool m_valid = true;

--- a/Source/Core/VideoBackends/Metal/MTLObjectCache.h
+++ b/Source/Core/VideoBackends/Metal/MTLObjectCache.h
@@ -39,7 +39,6 @@ struct DepthStencilSelector
   enum CompareMode CompareMode() const { return static_cast<enum CompareMode>(value >> 1); }
 
   bool operator==(const DepthStencilSelector& other) const { return value == other.value; }
-  bool operator!=(const DepthStencilSelector& other) const { return !(*this == other); }
   static constexpr size_t N_VALUES = 1 << 4;
 };
 
@@ -65,7 +64,6 @@ struct SamplerSelector
   bool AnisotropicFiltering() const { return ((value >> 3) & 1); }
 
   bool operator==(const SamplerSelector& other) const { return value == other.value; }
-  bool operator!=(const SamplerSelector& other) const { return !(*this == other); }
   static constexpr size_t N_VALUES = (1 << 4) * 9;
 };
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -191,11 +191,6 @@ void SHADER::DestroyShaders()
   }
 }
 
-bool PipelineProgramKey::operator!=(const PipelineProgramKey& rhs) const
-{
-  return !operator==(rhs);
-}
-
 bool PipelineProgramKey::operator==(const PipelineProgramKey& rhs) const
 {
   return std::tie(vertex_shader_id, geometry_shader_id, pixel_shader_id) ==

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -48,7 +48,6 @@ struct PipelineProgramKey
   u64 pixel_shader_id;
 
   bool operator==(const PipelineProgramKey& rhs) const;
-  bool operator!=(const PipelineProgramKey& rhs) const;
   bool operator<(const PipelineProgramKey& rhs) const;
 };
 

--- a/Source/Core/VideoCommon/AbstractPipeline.h
+++ b/Source/Core/VideoCommon/AbstractPipeline.h
@@ -60,7 +60,6 @@ struct AbstractPipelineConfig
                     rhs.rasterization_state.hex, rhs.depth_state.hex, rhs.blending_state.hex,
                     rhs.framebuffer_state.hex, rhs.usage);
   }
-  bool operator!=(const AbstractPipelineConfig& rhs) const { return !operator==(rhs); }
   bool operator<(const AbstractPipelineConfig& rhs) const
   {
     return std::tie(vertex_format, vertex_shader, geometry_shader, pixel_shader,

--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -43,7 +43,6 @@ struct GXPipelineUid
   {
     return std::memcmp(this, &rhs, sizeof(*this)) == 0;
   }
-  bool operator!=(const GXPipelineUid& rhs) const { return !operator==(rhs); }
 };
 struct GXUberPipelineUid
 {
@@ -64,7 +63,6 @@ struct GXUberPipelineUid
   {
     return std::memcmp(this, &rhs, sizeof(*this)) == 0;
   }
-  bool operator!=(const GXUberPipelineUid& rhs) const { return !operator==(rhs); }
 };
 
 // Disk cache of pipeline UIDs. We can't use the whole UID as a type as it contains pointers.

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/FBInfo.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/FBInfo.cpp
@@ -15,8 +15,3 @@ bool FBInfo::operator==(const FBInfo& other) const
   return m_height == other.m_height && m_width == other.m_width &&
          m_texture_format == other.m_texture_format;
 }
-
-bool FBInfo::operator!=(const FBInfo& other) const
-{
-  return !(*this == other);
-}

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/FBInfo.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/FBInfo.h
@@ -13,7 +13,6 @@ struct FBInfo
   TextureFormat m_texture_format = TextureFormat::I4;
   u32 CalculateHash() const;
   bool operator==(const FBInfo& other) const;
-  bool operator!=(const FBInfo& other) const;
 };
 
 struct FBInfoHasher

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -47,7 +47,6 @@ union RasterizationState
   }
 
   bool operator==(const RasterizationState& rhs) const { return hex == rhs.hex; }
-  bool operator!=(const RasterizationState& rhs) const { return !operator==(rhs); }
   bool operator<(const RasterizationState& rhs) const { return hex < rhs.hex; }
 
   BitField<0, 2, CullMode> cullmode;
@@ -73,7 +72,6 @@ union FramebufferState
   }
 
   bool operator==(const FramebufferState& rhs) const { return hex == rhs.hex; }
-  bool operator!=(const FramebufferState& rhs) const { return !operator==(rhs); }
 
   BitField<0, 8, AbstractTextureFormat> color_texture_format;
   BitField<8, 8, AbstractTextureFormat> depth_texture_format;
@@ -108,7 +106,6 @@ union DepthState
   }
 
   bool operator==(const DepthState& rhs) const { return hex == rhs.hex; }
-  bool operator!=(const DepthState& rhs) const { return !operator==(rhs); }
   bool operator<(const DepthState& rhs) const { return hex < rhs.hex; }
 
   BitField<0, 1, u32> testenable;
@@ -143,7 +140,6 @@ union BlendingState
   }
 
   bool operator==(const BlendingState& rhs) const { return hex == rhs.hex; }
-  bool operator!=(const BlendingState& rhs) const { return !operator==(rhs); }
   bool operator<(const BlendingState& rhs) const { return hex < rhs.hex; }
 
   BitField<0, 1, u32> blendenable;
@@ -185,7 +181,6 @@ struct SamplerState
   }
 
   bool operator==(const SamplerState& rhs) const { return Hex() == rhs.Hex(); }
-  bool operator!=(const SamplerState& rhs) const { return !operator==(rhs); }
   bool operator<(const SamplerState& rhs) const { return Hex() < rhs.Hex(); }
 
   constexpr u64 Hex() const { return tm0.hex | (static_cast<u64>(tm1.hex) << 32); }

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -80,8 +80,6 @@ public:
     return memcmp(GetUidData(), obj.GetUidData(), GetUidDataSize()) == 0;
   }
 
-  bool operator!=(const ShaderUid& obj) const { return !operator==(obj); }
-
   // determines the storage order inside STL containers
   bool operator<(const ShaderUid& obj) const
   {

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -63,7 +63,6 @@ struct TextureAndTLUTFormat
     return texfmt == other.texfmt;
   }
 
-  bool operator!=(const TextureAndTLUTFormat& other) const { return !operator==(other); }
   TextureFormat texfmt;
   TLUTFormat tlutfmt;
 };

--- a/Source/Core/VideoCommon/TextureConfig.cpp
+++ b/Source/Core/VideoCommon/TextureConfig.cpp
@@ -13,11 +13,6 @@ bool TextureConfig::operator==(const TextureConfig& o) const
          std::tie(o.width, o.height, o.levels, o.layers, o.samples, o.format, o.flags, o.type);
 }
 
-bool TextureConfig::operator!=(const TextureConfig& o) const
-{
-  return !operator==(o);
-}
-
 MathUtil::Rectangle<int> TextureConfig::GetRect() const
 {
   return {0, 0, static_cast<int>(width), static_cast<int>(height)};

--- a/Source/Core/VideoCommon/TextureConfig.h
+++ b/Source/Core/VideoCommon/TextureConfig.h
@@ -59,7 +59,6 @@ struct TextureConfig
   }
 
   bool operator==(const TextureConfig& o) const;
-  bool operator!=(const TextureConfig& o) const;
   MathUtil::Rectangle<int> GetRect() const;
   MathUtil::Rectangle<int> GetMipRect(u32 level) const;
   size_t GetStride() const;


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/language/operators#Comparison_operators As of C++20, the inequality operator is automatically generated by the compiler if `operator==` is defined. Thus, I have removed all `operator!=` overloads which are doing nothing more than manually invoking the equality operator and calculating its logical not.