### PR TITLE
ControllerEmu: Change trigger threshold check to prevent user error.

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
@@ -28,7 +28,7 @@ MixedTriggers::MixedTriggers(const std::string& name_)
               _trans("%"),
               // i18n: Refers to the "threshold" setting for pressure sensitive gamepad inputs.
               _trans("Input strength required for activation.")},
-             90, 0, 100);
+             90, 1, 100);
 }
 
 void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlState* analog,
@@ -51,7 +51,7 @@ void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlSta
         std::min(ApplyDeadzone(controls[trigger_count + i]->GetState(), deadzone), 1.0);
 
     // Apply threshold:
-    if (button_value > threshold)
+    if (button_value >= threshold)
     {
       // Fully activate analog:
       analog_value = 1.0;
@@ -87,7 +87,7 @@ void MixedTriggers::GetState(u16* digital, const u16* bitmasks, ControlState* an
     ControlState analog_value = ApplyDeadzone(controls[trigger_count + i]->GetState(), deadzone);
 
     // Apply threshold:
-    if (button_value > threshold)
+    if (button_value >= threshold)
     {
       analog_value = 1.0;
       button_bool = true;


### PR DESCRIPTION
I've observed at least two users with non-working trigger inputs because they carelessly set the `Threshold` setting to 100%, effectively making them impossible to activate (because the test was `button_value > threshold`).

This changes the test to `button_value >= threshold` and prevents a threshold value below 1% in the UI.

Maybe this will prevent someone frustration in the future.