### PR TITLE
DolphinQt: Auto hide the mapping window tab bar.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -167,6 +167,8 @@ void MappingWindow::CreateMainLayout()
   m_tab_widget = new QTabWidget();
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
+  m_tab_widget->setTabBarAutoHide(true);
+
   m_config_layout->addWidget(m_devices_box);
   m_config_layout->addWidget(m_reset_box);
   m_config_layout->addWidget(m_profiles_box);


### PR DESCRIPTION
This hides the tab bar on the mapping windows if there are fewer than 2 tabs (GameCube Controller, GBA, Microphone, Keyboard).

Before:
![image](https://github.com/user-attachments/assets/9cd2d54e-7480-4e65-98d2-decadd2869f4)

After:
![image](https://github.com/user-attachments/assets/c1f0f793-d044-4422-bbaf-2b50e1412fc6)

I think this resolves this issue: https://bugs.dolphin-emu.org/issues/11019