### PR TITLE
DolphinQt: Restrict size of banner image in game properties info tab.

### DIFF
--- a/Source/Core/DiscIO/WiiSaveBanner.cpp
+++ b/Source/Core/DiscIO/WiiSaveBanner.cpp
@@ -15,10 +15,6 @@
 
 namespace DiscIO
 {
-constexpr u32 BANNER_WIDTH = 192;
-constexpr u32 BANNER_HEIGHT = 64;
-constexpr u32 BANNER_SIZE = BANNER_WIDTH * BANNER_HEIGHT * 2;
-
 constexpr u32 ICON_WIDTH = 48;
 constexpr u32 ICON_HEIGHT = 48;
 constexpr u32 ICON_SIZE = ICON_WIDTH * ICON_HEIGHT * 2;
@@ -31,6 +27,8 @@ WiiSaveBanner::WiiSaveBanner(u64 title_id)
 
 WiiSaveBanner::WiiSaveBanner(const std::string& path) : m_path(path)
 {
+  constexpr u32 BANNER_SIZE = BANNER_WIDTH * BANNER_HEIGHT * 2;
+
   constexpr size_t MINIMUM_SIZE = sizeof(Header) + BANNER_SIZE + ICON_SIZE;
   File::IOFile file(path, "rb");
   if (!file.ReadArray(&m_header, 1))

--- a/Source/Core/DiscIO/WiiSaveBanner.h
+++ b/Source/Core/DiscIO/WiiSaveBanner.h
@@ -13,6 +13,9 @@ namespace DiscIO
 class WiiSaveBanner
 {
 public:
+  static constexpr u32 BANNER_WIDTH = 192;
+  static constexpr u32 BANNER_HEIGHT = 64;
+
   explicit WiiSaveBanner(u64 title_id);
   explicit WiiSaveBanner(const std::string& path);
 

--- a/Source/Core/DolphinQt/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt/Config/InfoWidget.cpp
@@ -18,6 +18,7 @@
 #include "DiscIO/Blob.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
+#include "DiscIO/WiiSaveBanner.h"
 
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ImageConverter.h"
@@ -179,7 +180,9 @@ QWidget* InfoWidget::CreateBannerGraphic(const QPixmap& image)
   QHBoxLayout* layout = new QHBoxLayout();
 
   QLabel* banner = new QLabel();
-  banner->setPixmap(image);
+  banner->setPixmap(image.scaled(image.size().boundedTo(
+      QSize{DiscIO::WiiSaveBanner::BANNER_WIDTH, DiscIO::WiiSaveBanner::BANNER_HEIGHT})));
+
   QPushButton* save = new QPushButton(tr("Save as..."));
   connect(save, &QPushButton::clicked, this, &InfoWidget::SaveBanner);
 


### PR DESCRIPTION
Fixes: https://bugs.dolphin-emu.org/issues/13062