### PR TITLE
GameINI: Fix Transformers: Dark of the Moon hang on opening logos

### DIFF
--- a/Data/Sys/GameSettings/S7E.ini
+++ b/Data/Sys/GameSettings/S7E.ini
@@ -1,0 +1,5 @@
+# S7EE52, S7EP52 - Transformers: Ultimate Battle Edition
+
+[Core]
+# Dual core causes hang on opening logos in Transformers: Dark of the Moon
+CPUThread = False

--- a/Data/Sys/GameSettings/STZ.ini
+++ b/Data/Sys/GameSettings/STZ.ini
@@ -1,0 +1,5 @@
+# STZE52, STZP52 - Transformers: Dark of the Moon - Stealth Force Edition
+
+[Core]
+# Dual core causes hang on opening logos
+CPUThread = False


### PR DESCRIPTION
Fixes hang on opening logos by turning off dual core. This game is also included in Transformers: Ultimate Battle Edition, where the same issue occurs, so dual core is disabled there too.