### PR TITLE
Interface: Static Game Window Title option

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -398,6 +398,7 @@ const Info<ShowCursor> MAIN_SHOW_CURSOR{{System::Main, "Interface", "CursorVisib
                                         ShowCursor::OnMovement};
 const Info<bool> MAIN_LOCK_CURSOR{{System::Main, "Interface", "LockCursor"}, false};
 const Info<std::string> MAIN_INTERFACE_LANGUAGE{{System::Main, "Interface", "LanguageCode"}, ""};
+const Info<bool> MAIN_STATIC_TITLE{{System::Main, "Interface", "StaticTitle"}, false};
 const Info<bool> MAIN_SHOW_ACTIVE_TITLE{{System::Main, "Interface", "ShowActiveTitle"}, true};
 const Info<bool> MAIN_USE_BUILT_IN_TITLE_DATABASE{
     {System::Main, "Interface", "UseBuiltinTitleDatabase"}, true};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -245,6 +245,7 @@ extern const Info<ShowCursor> MAIN_SHOW_CURSOR;
 
 extern const Info<bool> MAIN_LOCK_CURSOR;
 extern const Info<std::string> MAIN_INTERFACE_LANGUAGE;
+extern const Info<bool> MAIN_STATIC_TITLE;
 extern const Info<bool> MAIN_SHOW_ACTIVE_TITLE;
 extern const Info<bool> MAIN_USE_BUILT_IN_TITLE_DATABASE;
 extern const Info<std::string> MAIN_THEME_NAME;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -915,9 +915,10 @@ void UpdateTitle(Core::System& system)
   std::string message = fmt::format("{} | {}", Common::GetScmRevStr(), SSettings);
 
   if (Config::Get(Config::MAIN_STATIC_TITLE))
-    message = "Render";
-
-  if (Config::Get(Config::MAIN_SHOW_ACTIVE_TITLE))
+  {
+    message = "Dolphin Render Window";
+  }
+  else if (Config::Get(Config::MAIN_SHOW_ACTIVE_TITLE))
   {
     const std::string& title = SConfig::GetInstance().GetTitleDescription();
     if (!title.empty())

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -14,6 +14,7 @@
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
+#include "Common/Config/Config.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -913,6 +914,10 @@ void UpdateTitle(Core::System& system)
       g_video_backend->GetDisplayName(), Config::Get(Config::MAIN_DSP_HLE) ? "HLE" : "LLE");
 
   std::string message = fmt::format("{} | {}", Common::GetScmRevStr(), SSettings);
+
+  if (Config::Get(Config::MAIN_STATIC_TITLE))
+    message = "Render";
+
   if (Config::Get(Config::MAIN_SHOW_ACTIVE_TITLE))
   {
     const std::string& title = SConfig::GetInstance().GetTitleDescription();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -14,7 +14,6 @@
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
-#include "Common/Config/Config.h"
 
 #ifdef _WIN32
 #include <windows.h>

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -12,7 +12,6 @@
 #include <QRadioButton>
 #include <QVBoxLayout>
 #include <QWidget>
-#include <qcheckbox.h>
 
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -14,6 +14,7 @@
 #include <QWidget>
 
 #include "Common/CommonPaths.h"
+#include "Common/Config/Config.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"
@@ -190,6 +191,7 @@ void InterfacePane::CreateInGame()
       new ConfigBool(tr("Use Panic Handlers"), Config::MAIN_USE_PANIC_HANDLERS);
   m_checkbox_enable_osd =
       new ConfigBool(tr("Show On-Screen Display Messages"), Config::MAIN_OSD_MESSAGES);
+  m_checkbox_static_title = new ConfigBool(tr("Static Window Title"), Config::MAIN_STATIC_TITLE);
   m_checkbox_show_active_title =
       new ConfigBool(tr("Show Active Title in Window Title"), Config::MAIN_SHOW_ACTIVE_TITLE);
   m_checkbox_pause_on_focus_lost =
@@ -220,6 +222,7 @@ void InterfacePane::CreateInGame()
   groupbox_layout->addWidget(m_checkbox_confirm_on_stop);
   groupbox_layout->addWidget(m_checkbox_use_panic_handlers);
   groupbox_layout->addWidget(m_checkbox_enable_osd);
+  groupbox_layout->addWidget(m_checkbox_static_title);
   groupbox_layout->addWidget(m_checkbox_show_active_title);
   groupbox_layout->addWidget(m_checkbox_pause_on_focus_lost);
   groupbox_layout->addWidget(mouse_groupbox);
@@ -354,6 +357,11 @@ void InterfacePane::AddDescriptions()
       QT_TR_NOOP("Shows on-screen display messages over the render window. These messages "
                  "disappear after several seconds."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static constexpr char TR_STATIC_WINDOW_TITLE[] =
+      QT_TR_NOOP("The render window's title will always be \"Render\"."
+                 " If \"Show Active Title in Window Title\" is enabled "
+                 "then it will also display the game name."
+                  "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static constexpr char TR_SHOW_ACTIVE_TITLE_DESCRIPTION[] =
       QT_TR_NOOP("Shows the active game title in the render window's title bar."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
@@ -400,6 +408,8 @@ void InterfacePane::AddDescriptions()
   m_checkbox_use_panic_handlers->SetDescription(tr(TR_USE_PANIC_HANDLERS_DESCRIPTION));
 
   m_checkbox_enable_osd->SetDescription(tr(TR_ENABLE_OSD_DESCRIPTION));
+
+  m_checkbox_static_title->SetDescription(tr(TR_STATIC_WINDOW_TITLE));
 
   m_checkbox_show_active_title->SetDescription(tr(TR_SHOW_ACTIVE_TITLE_DESCRIPTION));
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -12,6 +12,7 @@
 #include <QRadioButton>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <qcheckbox.h>
 
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
@@ -256,6 +257,8 @@ void InterfacePane::ConnectLayout()
           &Settings::CursorVisibilityChanged);
   connect(m_checkbox_lock_mouse, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::LockCursorChanged);
+  connect(m_checkbox_static_title, &QCheckBox::stateChanged,
+          [this](int) { UpdateShowActiveTitleEnabled(); });
 }
 
 void InterfacePane::UpdateShowDebuggingCheckbox()
@@ -357,9 +360,7 @@ void InterfacePane::AddDescriptions()
                  "disappear after several seconds."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
   static constexpr char TR_STATIC_WINDOW_TITLE[] =
-      QT_TR_NOOP("The render window's title will always be \"Render\"."
-                 " If \"Show Active Title in Window Title\" is enabled "
-                 "then it will also display the game name."
+      QT_TR_NOOP("The render window's title will always be \"Dolphin Render Window\"."
                   "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static constexpr char TR_SHOW_ACTIVE_TITLE_DESCRIPTION[] =
       QT_TR_NOOP("Shows the active game title in the render window's title bar."
@@ -424,4 +425,14 @@ void InterfacePane::AddDescriptions()
 
   m_combobox_userstyle->SetTitle(tr("Style"));
   m_combobox_userstyle->SetDescription(tr(TR_USER_STYLE_DESCRIPTION));
+}
+
+void InterfacePane::UpdateShowActiveTitleEnabled()
+{
+
+  const bool enabled = m_checkbox_static_title->isChecked();
+
+  m_checkbox_show_active_title->setChecked(false);
+
+  m_checkbox_show_active_title->setEnabled(!enabled);
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -14,7 +14,6 @@
 #include <QWidget>
 
 #include "Common/CommonPaths.h"
-#include "Common/Config/Config.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -46,6 +46,7 @@ private:
   ConfigBool* m_checkbox_confirm_on_stop;
   ConfigBool* m_checkbox_use_panic_handlers;
   ConfigBool* m_checkbox_enable_osd;
+  ConfigBool* m_checkbox_static_title;
   ConfigBool* m_checkbox_show_active_title;
   ConfigBool* m_checkbox_pause_on_focus_lost;
   ConfigRadioInt* m_radio_cursor_visible_movement;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -29,6 +29,7 @@ private:
   void LoadUserStyle();
   void OnUserStyleChanged();
   void OnLanguageChanged();
+  void UpdateShowActiveTitleEnabled();
 
   QVBoxLayout* m_main_layout;
   ConfigStringChoice* m_combobox_language;


### PR DESCRIPTION
Implementing Feature Request from https://bugs.dolphin-emu.org/issues/11982
![Screenshot_20241013_131257](https://github.com/user-attachments/assets/46c4d566-bf72-44af-b303-6dba4f12823d)

Adds a "Static Window Title" checkbox in ( Options->Configuration->Interface ).
This makes the render window title always be "Render".

My only problem is that I made it so if "Show Active Title in Window Title" is enabled, the render window title will be "Render" + [game name], I don't know if this is the right thing to do but i don't know how else I would implement it.

A solution would be to name the option differently, but I don't know which name and description to use, Help would be appreciated, thanks.