### PR TITLE
Android: Add vsync setting

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -651,6 +651,7 @@ enum class BooleanSetting(
     SYSCONF_PROGRESSIVE_SCAN(Settings.FILE_SYSCONF, "IPL", "PGS", true),
     SYSCONF_PAL60(Settings.FILE_SYSCONF, "IPL", "E60", true),
     SYSCONF_WIIMOTE_MOTOR(Settings.FILE_SYSCONF, "BT", "MOT", true),
+    GFX_VSYNC(Settings.FILE_GFX, Settings.SECTION_GFX_HARDWARE, "VSync", false),
     GFX_WIDESCREEN_HACK(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "wideScreenHack", false),
     GFX_CROP(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "Crop", false),
     GFX_SHOW_FPS(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS, "ShowFPS", false),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
@@ -124,6 +124,7 @@ class Settings : Closeable {
         const val SECTION_INI_DSP = "DSP"
         const val SECTION_LOGGER_LOGS = "Logs"
         const val SECTION_LOGGER_OPTIONS = "Options"
+        const val SECTION_GFX_HARDWARE = "Settings"
         const val SECTION_GFX_SETTINGS = "Settings"
         const val SECTION_GFX_ENHANCEMENTS = "Enhancements"
         const val SECTION_GFX_COLOR_CORRECTION = "ColorCorrection"

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1798,6 +1798,14 @@ class SettingsFragmentPresenter(
         sl.add(
             SwitchSetting(
                 context,
+                BooleanSetting.GFX_VSYNC,
+                R.string.vsync,
+                R.string.vsync_description
+            )
+        )
+        sl.add(
+            SwitchSetting(
+                context,
                 BooleanSetting.GFX_BACKEND_MULTITHREADING,
                 R.string.backend_multithreading,
                 R.string.backend_multithreading_description

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -332,6 +332,8 @@
     <string name="crop">Crop</string>
     <string name="crop_description">Crops the picture from its native aspect ratio to 4:3 or 16:9. If unsure, leave this unchecked.</string>
     <string name="progressive_scan">Enable Progressive Scan</string>
+    <string name="vsync">V-Sync</string>
+    <string name="vsync_description">This setting is unnecessary on most Android devices, because Android always enables V-Sync. If unsure, leave this unchecked.</string>
     <string name="backend_multithreading">Backend Multithreading</string>
     <string name="backend_multithreading_description">Enables graphics backend multithreading (Vulkan only). May affect performance. If unsure, leave this checked.</string>
     <string name="prefer_vs_for_point_line_expansion">Prefer VS for Point/Line Expansion</string>


### PR DESCRIPTION
Recently we have been getting some requests to make the existing vsync setting available in the Android GUI:

https://bugs.dolphin-emu.org/issues/13650
https://forums.dolphin-emu.org/Thread-vsync-toggle-for-android

I don't quite understand why enabling the vsync setting is helpful when Android already enforces vsync, but I guess having the option available doesn't hurt. I'm putting the setting under Advanced, unlike in DolphinQt, since there's no clear reason why the typical user would want to use this setting.