### PR TITLE
Core: apply Dolphin OnFrame patches right after boot

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -211,7 +211,7 @@ void SConfig::OnNewTitleLoad(const Core::CPUThreadGuard& guard)
   }
   CBoot::LoadMapFromFilename(guard, ppc_symbol_db);
   HLE::Reload(system);
-  PatchEngine::Reload();
+  PatchEngine::Reload(system);
   HiresTexture::Update();
   WC24PatchEngine::Reload();
 }

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -295,6 +295,13 @@ void RemoveMemoryPatch(std::size_t index)
   std::erase(s_on_frame_memory, index);
 }
 
+static void ApplyStartupPatches(Core::System& system)
+{
+  ASSERT(Core::IsCPUThread());
+  Core::CPUThreadGuard guard(system);
+  ApplyPatches(guard, s_on_frame);
+}
+
 bool ApplyFramePatches(Core::System& system)
 {
   const auto& ppc_state = system.GetPPCState();
@@ -332,10 +339,11 @@ void Shutdown()
   Gecko::Shutdown();
 }
 
-void Reload()
+void Reload(Core::System& system)
 {
   Shutdown();
   LoadPatches();
+  ApplyStartupPatches(system);
 }
 
 }  // namespace PatchEngine

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -61,7 +61,7 @@ void RemoveMemoryPatch(std::size_t index);
 
 bool ApplyFramePatches(Core::System& system);
 void Shutdown();
-void Reload();
+void Reload(Core::System& system);
 
 inline int GetPatchTypeCharLength(PatchType type)
 {


### PR DESCRIPTION
We currently don't have a way to apply game patches before the first frame has rendered. Riivolution has this feature but I'm not sure there is a good way to use it for patches we want to ship enabled by default. Instead, apply Dolphin OnFrame patches (and only those) right after boot. The apploader, if any, is still not patchable.

You can test this with the following SSX Tricky (GSTE69) patch that limits the initial EFB clear height to the XFB height in order to avoid a [buffer overflow into the start of the GP fifo](https://bugs.dolphin-emu.org/issues/12818):
```
[OnFrame]
$Fix startup error
0x8012707C:dword:0xA0DF0006
```