### PR TITLE
GameINI: Remove OnLoad sections

### DIFF
--- a/Data/Sys/GameSettings/0000000100000002.ini
+++ b/Data/Sys/GameSettings/0000000100000002.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/D43.ini
+++ b/Data/Sys/GameSettings/D43.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/D43E01.ini
+++ b/Data/Sys/GameSettings/D43E01.ini
@@ -1,8 +1,5 @@
 # D43E01 - Legend of Zelda, The - Ocarina of Time - Master Quest
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/D43J01.ini
+++ b/Data/Sys/GameSettings/D43J01.ini
@@ -1,8 +1,5 @@
 # D43J01 - ZELDA OCARINA MULTI PACK
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $loophack

--- a/Data/Sys/GameSettings/D56E01.ini
+++ b/Data/Sys/GameSettings/D56E01.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/D85.ini
+++ b/Data/Sys/GameSettings/D85.ini
@@ -5,9 +5,6 @@
 FPRF = True
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/D86.ini
+++ b/Data/Sys/GameSettings/D86.ini
@@ -5,9 +5,6 @@
 FPRF = True
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/D95.ini
+++ b/Data/Sys/GameSettings/D95.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/DAX.ini
+++ b/Data/Sys/GameSettings/DAX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/DD2.ini
+++ b/Data/Sys/GameSettings/DD2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/DLS.ini
+++ b/Data/Sys/GameSettings/DLS.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/DPOJ8P.ini
+++ b/Data/Sys/GameSettings/DPOJ8P.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/DPSJ8P.ini
+++ b/Data/Sys/GameSettings/DPSJ8P.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/DSR.ini
+++ b/Data/Sys/GameSettings/DSR.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 RealWiiRemoteRepeatReports = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E52.ini
+++ b/Data/Sys/GameSettings/E52.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E53.ini
+++ b/Data/Sys/GameSettings/E53.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E54.ini
+++ b/Data/Sys/GameSettings/E54.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E55.ini
+++ b/Data/Sys/GameSettings/E55.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E56.ini
+++ b/Data/Sys/GameSettings/E56.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E57.ini
+++ b/Data/Sys/GameSettings/E57.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E5Z.ini
+++ b/Data/Sys/GameSettings/E5Z.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E62.ini
+++ b/Data/Sys/GameSettings/E62.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E63.ini
+++ b/Data/Sys/GameSettings/E63.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E6N.ini
+++ b/Data/Sys/GameSettings/E6N.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E6Q.ini
+++ b/Data/Sys/GameSettings/E6Q.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E6V.ini
+++ b/Data/Sys/GameSettings/E6V.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E6W.ini
+++ b/Data/Sys/GameSettings/E6W.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E6X.ini
+++ b/Data/Sys/GameSettings/E6X.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E73.ini
+++ b/Data/Sys/GameSettings/E73.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E78.ini
+++ b/Data/Sys/GameSettings/E78.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E79.ini
+++ b/Data/Sys/GameSettings/E79.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E7V.ini
+++ b/Data/Sys/GameSettings/E7V.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/E7Z.ini
+++ b/Data/Sys/GameSettings/E7Z.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EA2.ini
+++ b/Data/Sys/GameSettings/EA2.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EA3.ini
+++ b/Data/Sys/GameSettings/EA3.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EA4.ini
+++ b/Data/Sys/GameSettings/EA4.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EA5.ini
+++ b/Data/Sys/GameSettings/EA5.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EA6.ini
+++ b/Data/Sys/GameSettings/EA6.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EA7.ini
+++ b/Data/Sys/GameSettings/EA7.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EA8.ini
+++ b/Data/Sys/GameSettings/EA8.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EA9.ini
+++ b/Data/Sys/GameSettings/EA9.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAA.ini
+++ b/Data/Sys/GameSettings/EAA.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAB.ini
+++ b/Data/Sys/GameSettings/EAB.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAC.ini
+++ b/Data/Sys/GameSettings/EAC.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAD.ini
+++ b/Data/Sys/GameSettings/EAD.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAE.ini
+++ b/Data/Sys/GameSettings/EAE.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAF.ini
+++ b/Data/Sys/GameSettings/EAF.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAG.ini
+++ b/Data/Sys/GameSettings/EAG.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAH.ini
+++ b/Data/Sys/GameSettings/EAH.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAI.ini
+++ b/Data/Sys/GameSettings/EAI.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAJ.ini
+++ b/Data/Sys/GameSettings/EAJ.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAK.ini
+++ b/Data/Sys/GameSettings/EAK.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAL.ini
+++ b/Data/Sys/GameSettings/EAL.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAM.ini
+++ b/Data/Sys/GameSettings/EAM.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAN.ini
+++ b/Data/Sys/GameSettings/EAN.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAO.ini
+++ b/Data/Sys/GameSettings/EAO.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAP.ini
+++ b/Data/Sys/GameSettings/EAP.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAQ.ini
+++ b/Data/Sys/GameSettings/EAQ.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAR.ini
+++ b/Data/Sys/GameSettings/EAR.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAS.ini
+++ b/Data/Sys/GameSettings/EAS.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAT.ini
+++ b/Data/Sys/GameSettings/EAT.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAU.ini
+++ b/Data/Sys/GameSettings/EAU.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAV.ini
+++ b/Data/Sys/GameSettings/EAV.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAW.ini
+++ b/Data/Sys/GameSettings/EAW.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAY.ini
+++ b/Data/Sys/GameSettings/EAY.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EAZ.ini
+++ b/Data/Sys/GameSettings/EAZ.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EB2.ini
+++ b/Data/Sys/GameSettings/EB2.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EB3.ini
+++ b/Data/Sys/GameSettings/EB3.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EB4.ini
+++ b/Data/Sys/GameSettings/EB4.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EB5.ini
+++ b/Data/Sys/GameSettings/EB5.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EB6.ini
+++ b/Data/Sys/GameSettings/EB6.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EB7.ini
+++ b/Data/Sys/GameSettings/EB7.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EB8.ini
+++ b/Data/Sys/GameSettings/EB8.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EB9.ini
+++ b/Data/Sys/GameSettings/EB9.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBA.ini
+++ b/Data/Sys/GameSettings/EBA.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBB.ini
+++ b/Data/Sys/GameSettings/EBB.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBC.ini
+++ b/Data/Sys/GameSettings/EBC.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBD.ini
+++ b/Data/Sys/GameSettings/EBD.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBE.ini
+++ b/Data/Sys/GameSettings/EBE.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBF.ini
+++ b/Data/Sys/GameSettings/EBF.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBG.ini
+++ b/Data/Sys/GameSettings/EBG.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBK.ini
+++ b/Data/Sys/GameSettings/EBK.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBL.ini
+++ b/Data/Sys/GameSettings/EBL.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBM.ini
+++ b/Data/Sys/GameSettings/EBM.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBN.ini
+++ b/Data/Sys/GameSettings/EBN.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBO.ini
+++ b/Data/Sys/GameSettings/EBO.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBP.ini
+++ b/Data/Sys/GameSettings/EBP.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBQ.ini
+++ b/Data/Sys/GameSettings/EBQ.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBR.ini
+++ b/Data/Sys/GameSettings/EBR.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBS.ini
+++ b/Data/Sys/GameSettings/EBS.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBT.ini
+++ b/Data/Sys/GameSettings/EBT.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBU.ini
+++ b/Data/Sys/GameSettings/EBU.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBV.ini
+++ b/Data/Sys/GameSettings/EBV.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBW.ini
+++ b/Data/Sys/GameSettings/EBW.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBX.ini
+++ b/Data/Sys/GameSettings/EBX.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/EBZ.ini
+++ b/Data/Sys/GameSettings/EBZ.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECA.ini
+++ b/Data/Sys/GameSettings/ECA.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECC.ini
+++ b/Data/Sys/GameSettings/ECC.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECD.ini
+++ b/Data/Sys/GameSettings/ECD.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECE.ini
+++ b/Data/Sys/GameSettings/ECE.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECF.ini
+++ b/Data/Sys/GameSettings/ECF.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECG.ini
+++ b/Data/Sys/GameSettings/ECG.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECH.ini
+++ b/Data/Sys/GameSettings/ECH.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECI.ini
+++ b/Data/Sys/GameSettings/ECI.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECJ.ini
+++ b/Data/Sys/GameSettings/ECJ.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECK.ini
+++ b/Data/Sys/GameSettings/ECK.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECL.ini
+++ b/Data/Sys/GameSettings/ECL.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECM.ini
+++ b/Data/Sys/GameSettings/ECM.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ECN.ini
+++ b/Data/Sys/GameSettings/ECN.ini
@@ -8,9 +8,6 @@ DSPHLE = False
 # Values set here will override the Dolphin DSP settings.
 EnableJIT = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G2B.ini
+++ b/Data/Sys/GameSettings/G2B.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G2BE5G.ini
+++ b/Data/Sys/GameSettings/G2BE5G.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Disable interlaced rendering

--- a/Data/Sys/GameSettings/G2BP7D.ini
+++ b/Data/Sys/GameSettings/G2BP7D.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Disable interlaced rendering

--- a/Data/Sys/GameSettings/G2FE78.ini
+++ b/Data/Sys/GameSettings/G2FE78.ini
@@ -1,8 +1,5 @@
 # G2FE78 - Tak 2: The Staff of Dreams
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G2M.ini
+++ b/Data/Sys/GameSettings/G2M.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G2ME01.ini
+++ b/Data/Sys/GameSettings/G2ME01.ini
@@ -1,8 +1,5 @@
 # G2ME01 - Metroid Prime 2: Echoes
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G2MP01.ini
+++ b/Data/Sys/GameSettings/G2MP01.ini
@@ -1,8 +1,5 @@
 # G2MP01 - Metroid Prime 2: Echoes
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G2O.ini
+++ b/Data/Sys/GameSettings/G2O.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G2V.ini
+++ b/Data/Sys/GameSettings/G2V.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G2X.ini
+++ b/Data/Sys/GameSettings/G2X.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G3A.ini
+++ b/Data/Sys/GameSettings/G3A.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G3F.ini
+++ b/Data/Sys/GameSettings/G3F.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G3L.ini
+++ b/Data/Sys/GameSettings/G3L.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G3Q.ini
+++ b/Data/Sys/GameSettings/G3Q.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G3R.ini
+++ b/Data/Sys/GameSettings/G3R.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G3X.ini
+++ b/Data/Sys/GameSettings/G3X.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G4C.ini
+++ b/Data/Sys/GameSettings/G4C.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G4GEE9.ini
+++ b/Data/Sys/GameSettings/G4GEE9.ini
@@ -1,8 +1,5 @@
 # G4GEE9 - Harvest Moon: Another Wonderful Life
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G4M.ini
+++ b/Data/Sys/GameSettings/G4M.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G4NJDA.ini
+++ b/Data/Sys/GameSettings/G4NJDA.ini
@@ -1,8 +1,5 @@
 # G4NJDA - NARUTO Gekitou Ninja Taisen! 4
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G4P.ini
+++ b/Data/Sys/GameSettings/G4P.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G4QE01.ini
+++ b/Data/Sys/GameSettings/G4QE01.ini
@@ -1,8 +1,5 @@
 # G4QE01 - Mario Soccer
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G4S.ini
+++ b/Data/Sys/GameSettings/G4S.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G4SP01.ini
+++ b/Data/Sys/GameSettings/G4SP01.ini
@@ -1,8 +1,5 @@
 # G4SP01 - The Legend of Zelda: Four Swords
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G4Z.ini
+++ b/Data/Sys/GameSettings/G4Z.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G5D.ini
+++ b/Data/Sys/GameSettings/G5D.ini
@@ -7,9 +7,6 @@ DisableICache = True
 # Disabling ICache causes issues with the GameCube Main Menu.
 HLE_BS2 = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G5N.ini
+++ b/Data/Sys/GameSettings/G5N.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G5T.ini
+++ b/Data/Sys/GameSettings/G5T.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G6Q.ini
+++ b/Data/Sys/GameSettings/G6Q.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G6S.ini
+++ b/Data/Sys/GameSettings/G6S.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G6T.ini
+++ b/Data/Sys/GameSettings/G6T.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G6W.ini
+++ b/Data/Sys/GameSettings/G6W.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G8M.ini
+++ b/Data/Sys/GameSettings/G8M.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G8ME01.ini
+++ b/Data/Sys/GameSettings/G8ME01.ini
@@ -1,8 +1,5 @@
 # G8ME01 - Paper Mario
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G8W.ini
+++ b/Data/Sys/GameSettings/G8W.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G8WP01.ini
+++ b/Data/Sys/GameSettings/G8WP01.ini
@@ -1,8 +1,5 @@
 # G8WP01 - Battalion Wars
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G95.ini
+++ b/Data/Sys/GameSettings/G95.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G96.ini
+++ b/Data/Sys/GameSettings/G96.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G99.ini
+++ b/Data/Sys/GameSettings/G99.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G9R.ini
+++ b/Data/Sys/GameSettings/G9R.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G9S.ini
+++ b/Data/Sys/GameSettings/G9S.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/G9T.ini
+++ b/Data/Sys/GameSettings/G9T.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAA.ini
+++ b/Data/Sys/GameSettings/GAA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAF.ini
+++ b/Data/Sys/GameSettings/GAF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAFE01.ini
+++ b/Data/Sys/GameSettings/GAFE01.ini
@@ -1,8 +1,5 @@
 # GAFE01 - Animal Crossing
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAK.ini
+++ b/Data/Sys/GameSettings/GAK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAL.ini
+++ b/Data/Sys/GameSettings/GAL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GALP01.ini
+++ b/Data/Sys/GameSettings/GALP01.ini
@@ -1,8 +1,5 @@
 # GALP01 - Super Smash Bros. Melee
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAP.ini
+++ b/Data/Sys/GameSettings/GAP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAS.ini
+++ b/Data/Sys/GameSettings/GAS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAU.ini
+++ b/Data/Sys/GameSettings/GAU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAUE08.ini
+++ b/Data/Sys/GameSettings/GAUE08.ini
@@ -1,8 +1,5 @@
 # GAUE08 - auto modellista
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAV.ini
+++ b/Data/Sys/GameSettings/GAV.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GAY.ini
+++ b/Data/Sys/GameSettings/GAY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GB3.ini
+++ b/Data/Sys/GameSettings/GB3.ini
@@ -5,9 +5,6 @@
 # Progressive Scan is broken by the game by default, disabled feature
 ProgressiveScan = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GB4E51.ini
+++ b/Data/Sys/GameSettings/GB4E51.ini
@@ -1,8 +1,5 @@
 # GB4E51 - Burnout 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GBH.ini
+++ b/Data/Sys/GameSettings/GBH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GBHEC8.ini
+++ b/Data/Sys/GameSettings/GBHEC8.ini
@@ -1,8 +1,5 @@
 # GBHEC8 - Mystic Heroes
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GBL.ini
+++ b/Data/Sys/GameSettings/GBL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GBM.ini
+++ b/Data/Sys/GameSettings/GBM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GBOP51.ini
+++ b/Data/Sys/GameSettings/GBOP51.ini
@@ -1,8 +1,5 @@
 # GBOP51 - Burnout
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GBS.ini
+++ b/Data/Sys/GameSettings/GBS.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GBV.ini
+++ b/Data/Sys/GameSettings/GBV.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GBW.ini
+++ b/Data/Sys/GameSettings/GBW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GBZP08.ini
+++ b/Data/Sys/GameSettings/GBZP08.ini
@@ -1,8 +1,5 @@
 # GBZP08 - Resident Evil 0
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GC2.ini
+++ b/Data/Sys/GameSettings/GC2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GC3.ini
+++ b/Data/Sys/GameSettings/GC3.ini
@@ -7,9 +7,6 @@ DisableICache = True
 # Disabling ICache causes issues with the GameCube Main Menu.
 HLE_BS2 = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GC6.ini
+++ b/Data/Sys/GameSettings/GC6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GC8JA4.ini
+++ b/Data/Sys/GameSettings/GC8JA4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GC9.ini
+++ b/Data/Sys/GameSettings/GC9.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GCC.ini
+++ b/Data/Sys/GameSettings/GCC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GCD.ini
+++ b/Data/Sys/GameSettings/GCD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GCH.ini
+++ b/Data/Sys/GameSettings/GCH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GCI.ini
+++ b/Data/Sys/GameSettings/GCI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GCN.ini
+++ b/Data/Sys/GameSettings/GCN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GCP.ini
+++ b/Data/Sys/GameSettings/GCP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GCVEEB.ini
+++ b/Data/Sys/GameSettings/GCVEEB.ini
@@ -1,8 +1,5 @@
 # GCVEEB - Cubivore
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GCZ.ini
+++ b/Data/Sys/GameSettings/GCZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDD.ini
+++ b/Data/Sys/GameSettings/GDD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDDE41.ini
+++ b/Data/Sys/GameSettings/GDDE41.ini
@@ -1,8 +1,5 @@
 # GDDE41 - Disney's Donald Duck Goin' Quackers
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDE.ini
+++ b/Data/Sys/GameSettings/GDE.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDEE71.ini
+++ b/Data/Sys/GameSettings/GDEE71.ini
@@ -1,8 +1,5 @@
 # GDEE71 - Baldur's Gate: Dark Alliance
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDG.ini
+++ b/Data/Sys/GameSettings/GDG.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDJEB2.ini
+++ b/Data/Sys/GameSettings/GDJEB2.ini
@@ -1,8 +1,5 @@
 # GDJEB2 - Digimon World 4
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDK.ini
+++ b/Data/Sys/GameSettings/GDK.ini
@@ -6,9 +6,6 @@
 # see https://www.nintendo.com/consumer/memorycard1019.jsp
 MemoryCardSize = 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDM.ini
+++ b/Data/Sys/GameSettings/GDM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDQ.ini
+++ b/Data/Sys/GameSettings/GDQ.ini
@@ -6,9 +6,6 @@
 # see https://www.nintendo.com/consumer/memorycard1019.jsp
 MemoryCardSize = 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDS.ini
+++ b/Data/Sys/GameSettings/GDS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDT.ini
+++ b/Data/Sys/GameSettings/GDT.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDTE69.ini
+++ b/Data/Sys/GameSettings/GDTE69.ini
@@ -1,8 +1,5 @@
 # GDTE69 - Def Jam VENDETTA
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GDV.ini
+++ b/Data/Sys/GameSettings/GDV.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GE3.ini
+++ b/Data/Sys/GameSettings/GE3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GE4.ini
+++ b/Data/Sys/GameSettings/GE4.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GE5EA4.ini
+++ b/Data/Sys/GameSettings/GE5EA4.ini
@@ -1,8 +1,5 @@
 # GE5EA4 - TMNT:Mutant Melee
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GE9.ini
+++ b/Data/Sys/GameSettings/GE9.ini
@@ -7,9 +7,6 @@ DisableICache = True
 # Disabling ICache causes issues with the GameCube Main Menu.
 HLE_BS2 = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GEA.ini
+++ b/Data/Sys/GameSettings/GEA.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GED.ini
+++ b/Data/Sys/GameSettings/GED.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GEN.ini
+++ b/Data/Sys/GameSettings/GEN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GEO.ini
+++ b/Data/Sys/GameSettings/GEO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GEZ.ini
+++ b/Data/Sys/GameSettings/GEZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GF4.ini
+++ b/Data/Sys/GameSettings/GF4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GF7.ini
+++ b/Data/Sys/GameSettings/GF7.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GF7E01.ini
+++ b/Data/Sys/GameSettings/GF7E01.ini
@@ -1,8 +1,5 @@
 # GF7E01 - STARFOX ASSAULT
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GF7P01.ini
+++ b/Data/Sys/GameSettings/GF7P01.ini
@@ -1,8 +1,5 @@
 # GF7P01 - STARFOX ASSAULT
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GF8E69.ini
+++ b/Data/Sys/GameSettings/GF8E69.ini
@@ -1,8 +1,5 @@
 # GF8E69 - FIFA Street
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFB.ini
+++ b/Data/Sys/GameSettings/GFB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFD.ini
+++ b/Data/Sys/GameSettings/GFD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFEE01.ini
+++ b/Data/Sys/GameSettings/GFEE01.ini
@@ -1,8 +1,5 @@
 # GFEE01 - Fire Emblem: Path of Radiance GC US
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFEJ01.ini
+++ b/Data/Sys/GameSettings/GFEJ01.ini
@@ -1,8 +1,5 @@
 # GFEJ01 - Fire Emblem: Souen no Kiseki GC JAP
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFF.ini
+++ b/Data/Sys/GameSettings/GFF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFG.ini
+++ b/Data/Sys/GameSettings/GFG.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFH.ini
+++ b/Data/Sys/GameSettings/GFH.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFTE01.ini
+++ b/Data/Sys/GameSettings/GFTE01.ini
@@ -1,8 +1,5 @@
 # GFTE01 - Mario Golf: Toadstool Tour
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFY.ini
+++ b/Data/Sys/GameSettings/GFY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFYE69.ini
+++ b/Data/Sys/GameSettings/GFYE69.ini
@@ -1,8 +1,5 @@
 # GFYE69 - FIFA Street 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFZ.ini
+++ b/Data/Sys/GameSettings/GFZ.ini
@@ -6,9 +6,6 @@
 FPRF = True
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFZE01.ini
+++ b/Data/Sys/GameSettings/GFZE01.ini
@@ -1,8 +1,5 @@
 # GFZE01 - F-Zero GX
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFZJ01.ini
+++ b/Data/Sys/GameSettings/GFZJ01.ini
@@ -1,8 +1,5 @@
 # GFZJ01 - F-Zero GX
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFZJ8P.ini
+++ b/Data/Sys/GameSettings/GFZJ8P.ini
@@ -5,9 +5,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GFZP01.ini
+++ b/Data/Sys/GameSettings/GFZP01.ini
@@ -1,8 +1,5 @@
 # GFZP01 - F-Zero GX
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGC.ini
+++ b/Data/Sys/GameSettings/GGC.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGE.ini
+++ b/Data/Sys/GameSettings/GGE.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGN.ini
+++ b/Data/Sys/GameSettings/GGN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGR.ini
+++ b/Data/Sys/GameSettings/GGR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGS.ini
+++ b/Data/Sys/GameSettings/GGS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGSEA4.ini
+++ b/Data/Sys/GameSettings/GGSEA4.ini
@@ -1,8 +1,5 @@
 # GGSEA4 - Metal Gear Solid The Twin Snakes
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGSPA4.ini
+++ b/Data/Sys/GameSettings/GGSPA4.ini
@@ -1,8 +1,5 @@
 # GGSPA4 - METAL GEAR SOLID THE TWIN SNAKES
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGTE01.ini
+++ b/Data/Sys/GameSettings/GGTE01.ini
@@ -1,8 +1,5 @@
 # GGTE01 - ChibiRobo!
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGV.ini
+++ b/Data/Sys/GameSettings/GGV.ini
@@ -5,9 +5,6 @@
 # Dual Core mode causes FIFO error
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGY.ini
+++ b/Data/Sys/GameSettings/GGY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GGZ.ini
+++ b/Data/Sys/GameSettings/GGZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GH2.ini
+++ b/Data/Sys/GameSettings/GH2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GH7.ini
+++ b/Data/Sys/GameSettings/GH7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GH9.ini
+++ b/Data/Sys/GameSettings/GH9.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 
 [ActionReplay]

--- a/Data/Sys/GameSettings/GHK.ini
+++ b/Data/Sys/GameSettings/GHK.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 
 [ActionReplay]

--- a/Data/Sys/GameSettings/GHME4F.ini
+++ b/Data/Sys/GameSettings/GHME4F.ini
@@ -1,8 +1,5 @@
 # GHME4F - Hitman 2: Silent Assassin
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GHN.ini
+++ b/Data/Sys/GameSettings/GHN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GHQ.ini
+++ b/Data/Sys/GameSettings/GHQ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GHR.ini
+++ b/Data/Sys/GameSettings/GHR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GHRE78.ini
+++ b/Data/Sys/GameSettings/GHRE78.ini
@@ -1,8 +1,5 @@
 # GHRE78 - Hot Wheels World Race
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GHS.ini
+++ b/Data/Sys/GameSettings/GHS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GHV.ini
+++ b/Data/Sys/GameSettings/GHV.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GHY.ini
+++ b/Data/Sys/GameSettings/GHY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GIA.ini
+++ b/Data/Sys/GameSettings/GIA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GIC.ini
+++ b/Data/Sys/GameSettings/GIC.ini
@@ -5,9 +5,6 @@
 # Dual Core mode causes FIFO error
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GIGJ8P.ini
+++ b/Data/Sys/GameSettings/GIGJ8P.ini
@@ -1,8 +1,5 @@
 # GIGJ8P - Bleach: Tasogare Ni Mamieru Shinigami for GC
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GIH.ini
+++ b/Data/Sys/GameSettings/GIH.ini
@@ -5,9 +5,6 @@
 # Dual Core mode causes FIFO error
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GIL.ini
+++ b/Data/Sys/GameSettings/GIL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GINE69.ini
+++ b/Data/Sys/GameSettings/GINE69.ini
@@ -1,8 +1,5 @@
 # GINE69 - Batman Begins
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GIQ.ini
+++ b/Data/Sys/GameSettings/GIQ.ini
@@ -5,9 +5,6 @@
 # Dual Core mode causes FIFO error
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GIS.ini
+++ b/Data/Sys/GameSettings/GIS.ini
@@ -5,9 +5,6 @@
 CPUThread = False
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GIT.ini
+++ b/Data/Sys/GameSettings/GIT.ini
@@ -6,9 +6,6 @@
 # when using Dualcore.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GIZ.ini
+++ b/Data/Sys/GameSettings/GIZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GJB.ini
+++ b/Data/Sys/GameSettings/GJB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GJCE8P.ini
+++ b/Data/Sys/GameSettings/GJCE8P.ini
@@ -1,8 +1,5 @@
 # GJCE8P - jack
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GJF.ini
+++ b/Data/Sys/GameSettings/GJF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GJK.ini
+++ b/Data/Sys/GameSettings/GJK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GJN.ini
+++ b/Data/Sys/GameSettings/GJN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GJUE78.ini
+++ b/Data/Sys/GameSettings/GJUE78.ini
@@ -1,8 +1,5 @@
 # GJUE78 - Tak and the Power of Juju
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GJWE78.ini
+++ b/Data/Sys/GameSettings/GJWE78.ini
@@ -1,8 +1,5 @@
 # GJWE78 - Tak: The Great Juju Challenge
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GK4.ini
+++ b/Data/Sys/GameSettings/GK4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GK4E01.ini
+++ b/Data/Sys/GameSettings/GK4E01.ini
@@ -1,8 +1,5 @@
 # GK4E01 - Baten Kaitos Origins
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GK5.ini
+++ b/Data/Sys/GameSettings/GK5.ini
@@ -7,9 +7,6 @@ DisableICache = True
 # In order to prevent the invalid read messages, we can enable MMU emulation.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GK7.ini
+++ b/Data/Sys/GameSettings/GK7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKB.ini
+++ b/Data/Sys/GameSettings/GKB.ini
@@ -6,9 +6,6 @@
 CPUThread = False
 
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKH.ini
+++ b/Data/Sys/GameSettings/GKH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKL.ini
+++ b/Data/Sys/GameSettings/GKL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKM.ini
+++ b/Data/Sys/GameSettings/GKM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKNEB2.ini
+++ b/Data/Sys/GameSettings/GKNEB2.ini
@@ -1,8 +1,5 @@
 # GKNEB2 - Ultimate Muscle: Legends VS. New Generation
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKO.ini
+++ b/Data/Sys/GameSettings/GKO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKS.ini
+++ b/Data/Sys/GameSettings/GKS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKU.ini
+++ b/Data/Sys/GameSettings/GKU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKY.ini
+++ b/Data/Sys/GameSettings/GKY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GKZ.ini
+++ b/Data/Sys/GameSettings/GKZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GL5.ini
+++ b/Data/Sys/GameSettings/GL5.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GL7.ini
+++ b/Data/Sys/GameSettings/GL7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GL8.ini
+++ b/Data/Sys/GameSettings/GL8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GLC.ini
+++ b/Data/Sys/GameSettings/GLC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GLG.ini
+++ b/Data/Sys/GameSettings/GLG.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GLM.ini
+++ b/Data/Sys/GameSettings/GLM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GLME01.ini
+++ b/Data/Sys/GameSettings/GLME01.ini
@@ -1,8 +1,5 @@
 # GLME01 - Luigi's Mansion
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GLMP01.ini
+++ b/Data/Sys/GameSettings/GLMP01.ini
@@ -1,8 +1,5 @@
 # GLMP01 - LUIGI'S MANSION
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GLNE69.ini
+++ b/Data/Sys/GameSettings/GLNE69.ini
@@ -1,8 +1,5 @@
 # GLNE69 - Looney Tunes Back In Action
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GLR.ini
+++ b/Data/Sys/GameSettings/GLR.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GLS.ini
+++ b/Data/Sys/GameSettings/GLS.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GM2.ini
+++ b/Data/Sys/GameSettings/GM2.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GM3.ini
+++ b/Data/Sys/GameSettings/GM3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GM4.ini
+++ b/Data/Sys/GameSettings/GM4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GM4E01.ini
+++ b/Data/Sys/GameSettings/GM4E01.ini
@@ -1,8 +1,5 @@
 # GM4E01 - Mario Kart: Double Dash!!
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GM4P01.ini
+++ b/Data/Sys/GameSettings/GM4P01.ini
@@ -1,8 +1,5 @@
 # GM4P01 - Mario Kart: Double Dash!!
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GM5.ini
+++ b/Data/Sys/GameSettings/GM5.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GM6.ini
+++ b/Data/Sys/GameSettings/GM6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GM8.ini
+++ b/Data/Sys/GameSettings/GM8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GM8E01.ini
+++ b/Data/Sys/GameSettings/GM8E01.ini
@@ -1,8 +1,5 @@
 # GM8E01 - Metroid Prime
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMB.ini
+++ b/Data/Sys/GameSettings/GMB.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMD.ini
+++ b/Data/Sys/GameSettings/GMD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMH.ini
+++ b/Data/Sys/GameSettings/GMH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMI.ini
+++ b/Data/Sys/GameSettings/GMI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMN.ini
+++ b/Data/Sys/GameSettings/GMN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMPE01.ini
+++ b/Data/Sys/GameSettings/GMPE01.ini
@@ -1,8 +1,5 @@
 # GMPE01 - Mario Party 4
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMS.ini
+++ b/Data/Sys/GameSettings/GMS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMSE01.ini
+++ b/Data/Sys/GameSettings/GMSE01.ini
@@ -1,8 +1,5 @@
 # GMSE01 - Super Mario Sunshine
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMSP01.ini
+++ b/Data/Sys/GameSettings/GMSP01.ini
@@ -1,8 +1,5 @@
 # GMSP01 - Super Mario Sunshine
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMX.ini
+++ b/Data/Sys/GameSettings/GMX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GMXE70.ini
+++ b/Data/Sys/GameSettings/GMXE70.ini
@@ -1,8 +1,5 @@
 # GMXE70 - Enter The Matrix
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GN4.ini
+++ b/Data/Sys/GameSettings/GN4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GN7.ini
+++ b/Data/Sys/GameSettings/GN7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GNC.ini
+++ b/Data/Sys/GameSettings/GNC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GNE.ini
+++ b/Data/Sys/GameSettings/GNE.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GNHE5d.ini
+++ b/Data/Sys/GameSettings/GNHE5d.ini
@@ -1,8 +1,5 @@
 # GNHE5d - NHL HITZ 2002
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Nop Hack

--- a/Data/Sys/GameSettings/GNI.ini
+++ b/Data/Sys/GameSettings/GNI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GNJ.ini
+++ b/Data/Sys/GameSettings/GNJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GNM.ini
+++ b/Data/Sys/GameSettings/GNM.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 JITFollowBranch = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GNN.ini
+++ b/Data/Sys/GameSettings/GNN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GNO.ini
+++ b/Data/Sys/GameSettings/GNO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GNW.ini
+++ b/Data/Sys/GameSettings/GNW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GNWE69.ini
+++ b/Data/Sys/GameSettings/GNWE69.ini
@@ -1,8 +1,5 @@
 # GNWE69 - Def Jam Fight For NY
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GO2.ini
+++ b/Data/Sys/GameSettings/GO2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GO2E4F.ini
+++ b/Data/Sys/GameSettings/GO2E4F.ini
@@ -1,8 +1,5 @@
 # GO2E4F - Legacy Of Kain: Blood Omen 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GO7E69.ini
+++ b/Data/Sys/GameSettings/GO7E69.ini
@@ -1,8 +1,5 @@
 # GO7E69 - James Bond 007(tm): NightFire(tm)
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GO7F69.ini
+++ b/Data/Sys/GameSettings/GO7F69.ini
@@ -1,8 +1,5 @@
 # GO7F69 - James Bond 007(tm): NightFire(tm)
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GO7P69.ini
+++ b/Data/Sys/GameSettings/GO7P69.ini
@@ -1,8 +1,5 @@
 # GO7P69 - James Bond 007(tm): NightFire(tm)
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GOM.ini
+++ b/Data/Sys/GameSettings/GOM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GOME01.ini
+++ b/Data/Sys/GameSettings/GOME01.ini
@@ -1,8 +1,5 @@
 # GOME01 - Mario Power Tennis
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GOQ.ini
+++ b/Data/Sys/GameSettings/GOQ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GOS.ini
+++ b/Data/Sys/GameSettings/GOS.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GOY.ini
+++ b/Data/Sys/GameSettings/GOY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GOYE69.ini
+++ b/Data/Sys/GameSettings/GOYE69.ini
@@ -1,8 +1,5 @@
 # GOYE69 - GoldenEye Rogue Agent
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GP2.ini
+++ b/Data/Sys/GameSettings/GP2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GP5.ini
+++ b/Data/Sys/GameSettings/GP5.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GP5E01.ini
+++ b/Data/Sys/GameSettings/GP5E01.ini
@@ -1,8 +1,5 @@
 # GP5E01 - Mario Party 5
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GP6.ini
+++ b/Data/Sys/GameSettings/GP6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GP6E01.ini
+++ b/Data/Sys/GameSettings/GP6E01.ini
@@ -1,8 +1,5 @@
 # GP6E01 - Mario Party 6
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GP7E01.ini
+++ b/Data/Sys/GameSettings/GP7E01.ini
@@ -1,8 +1,5 @@
 # GP7E01 - Mario Party 7
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 [ActionReplay]

--- a/Data/Sys/GameSettings/GPA.ini
+++ b/Data/Sys/GameSettings/GPA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPE.ini
+++ b/Data/Sys/GameSettings/GPE.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPH.ini
+++ b/Data/Sys/GameSettings/GPH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPIE01.ini
+++ b/Data/Sys/GameSettings/GPIE01.ini
@@ -1,8 +1,5 @@
 # GPIE01 - Pikmin v1.1 NTSC
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPIP01.ini
+++ b/Data/Sys/GameSettings/GPIP01.ini
@@ -1,8 +1,5 @@
 # GPIP01 - Pikmin PAL
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPK.ini
+++ b/Data/Sys/GameSettings/GPK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPNP08.ini
+++ b/Data/Sys/GameSettings/GPNP08.ini
@@ -1,8 +1,5 @@
 # GPNP08 - P.N.03 PAL
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPO.ini
+++ b/Data/Sys/GameSettings/GPO.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPOE8P.ini
+++ b/Data/Sys/GameSettings/GPOE8P.ini
@@ -1,8 +1,5 @@
 # GPOE8P - PHANTASY STAR ONLINE EPISODE I&II
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPOP8P.ini
+++ b/Data/Sys/GameSettings/GPOP8P.ini
@@ -1,8 +1,5 @@
 # GPOP8P - PHANTASY STAR ONLINE EPISODE I&II
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPS.ini
+++ b/Data/Sys/GameSettings/GPS.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPSP8P.ini
+++ b/Data/Sys/GameSettings/GPSP8P.ini
@@ -1,8 +1,5 @@
 # GPSP8P - PHANTASY STAR ONLINE EPISODE III
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPT.ini
+++ b/Data/Sys/GameSettings/GPT.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GPVE01.ini
+++ b/Data/Sys/GameSettings/GPVE01.ini
@@ -1,8 +1,5 @@
 # GPVE01 - PIKMIN 2 NTSC
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GQ4.ini
+++ b/Data/Sys/GameSettings/GQ4.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MemoryCardSize = 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GQC.ini
+++ b/Data/Sys/GameSettings/GQC.ini
@@ -2,7 +2,5 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 MMU = True
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]

--- a/Data/Sys/GameSettings/GQP.ini
+++ b/Data/Sys/GameSettings/GQP.ini
@@ -5,9 +5,6 @@
 # Dual Core mode causes FIFO error
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GQS.ini
+++ b/Data/Sys/GameSettings/GQS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GQSEAF.ini
+++ b/Data/Sys/GameSettings/GQSEAF.ini
@@ -422,9 +422,6 @@
 # use only one of these codes at a time for your
 # favorite character to have max affection.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GQX.ini
+++ b/Data/Sys/GameSettings/GQX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GR6.ini
+++ b/Data/Sys/GameSettings/GR6.ini
@@ -3,9 +3,6 @@
 [Core]
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRB.ini
+++ b/Data/Sys/GameSettings/GRB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GREE08.ini
+++ b/Data/Sys/GameSettings/GREE08.ini
@@ -1,8 +1,5 @@
 # GREE08 - Mega Man Network Transmission
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRH.ini
+++ b/Data/Sys/GameSettings/GRH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRJ.ini
+++ b/Data/Sys/GameSettings/GRJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRK.ini
+++ b/Data/Sys/GameSettings/GRK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRNE52.ini
+++ b/Data/Sys/GameSettings/GRNE52.ini
@@ -1,8 +1,5 @@
 # GRNE52 - LOST KINGDOMS
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRQ.ini
+++ b/Data/Sys/GameSettings/GRQ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRSPAF.ini
+++ b/Data/Sys/GameSettings/GRSPAF.ini
@@ -1,8 +1,5 @@
 # GRSPAF - SOULCALIBUR2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRU.ini
+++ b/Data/Sys/GameSettings/GRU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRUE78.ini
+++ b/Data/Sys/GameSettings/GRUE78.ini
@@ -1,8 +1,5 @@
 # GRUE78 - Power Rangers Dino Thunder
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GRY.ini
+++ b/Data/Sys/GameSettings/GRY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GS2.ini
+++ b/Data/Sys/GameSettings/GS2.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GS2E78.ini
+++ b/Data/Sys/GameSettings/GS2E78.ini
@@ -1,8 +1,5 @@
 # GS2E78 - Summoner 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSAP01.ini
+++ b/Data/Sys/GameSettings/GSAP01.ini
@@ -1,8 +1,5 @@
 # GSAP01 - Star Fox Adventures
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSB.ini
+++ b/Data/Sys/GameSettings/GSB.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSM.ini
+++ b/Data/Sys/GameSettings/GSM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSN.ini
+++ b/Data/Sys/GameSettings/GSN.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSNE8P.ini
+++ b/Data/Sys/GameSettings/GSNE8P.ini
@@ -1,8 +1,5 @@
 # GSNE8P - Sonic Adventure 2 Battle
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSNP8P.ini
+++ b/Data/Sys/GameSettings/GSNP8P.ini
@@ -1,8 +1,5 @@
 # GSNP8P - SONIC ADVENTURE 2 BATTLE
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSO.ini
+++ b/Data/Sys/GameSettings/GSO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSR.ini
+++ b/Data/Sys/GameSettings/GSR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSS.ini
+++ b/Data/Sys/GameSettings/GSS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSSE8P.ini
+++ b/Data/Sys/GameSettings/GSSE8P.ini
@@ -1,8 +1,5 @@
 # GSSE8P - Sega Soccer Slam
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GST.ini
+++ b/Data/Sys/GameSettings/GST.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MemoryCardSize = 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSV.ini
+++ b/Data/Sys/GameSettings/GSV.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSW.ini
+++ b/Data/Sys/GameSettings/GSW.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSX.ini
+++ b/Data/Sys/GameSettings/GSX.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GSZ.ini
+++ b/Data/Sys/GameSettings/GSZ.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GT3.ini
+++ b/Data/Sys/GameSettings/GT3.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GT6.ini
+++ b/Data/Sys/GameSettings/GT6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GT6E70.ini
+++ b/Data/Sys/GameSettings/GT6E70.ini
@@ -1,8 +1,5 @@
 # GT6E70 - Terminator 3: The Redemption
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GT7.ini
+++ b/Data/Sys/GameSettings/GT7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GTEE01.ini
+++ b/Data/Sys/GameSettings/GTEE01.ini
@@ -1,8 +1,5 @@
 # GTEE01 - 1080: Avalanche
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GTEP01.ini
+++ b/Data/Sys/GameSettings/GTEP01.ini
@@ -1,8 +1,5 @@
 # GTEP01 - 1080: Avalanche
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GTK.ini
+++ b/Data/Sys/GameSettings/GTK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GTKE51.ini
+++ b/Data/Sys/GameSettings/GTKE51.ini
@@ -1,8 +1,5 @@
 # GTKE51 - Turok: Evolution
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GTO.ini
+++ b/Data/Sys/GameSettings/GTO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GTSE4F.ini
+++ b/Data/Sys/GameSettings/GTSE4F.ini
@@ -1,8 +1,5 @@
 # GTSE4F - TimeSplitters 2 NTSC
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GTW.ini
+++ b/Data/Sys/GameSettings/GTW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GTY.ini
+++ b/Data/Sys/GameSettings/GTY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GTZ.ini
+++ b/Data/Sys/GameSettings/GTZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GU2.ini
+++ b/Data/Sys/GameSettings/GU2.ini
@@ -5,9 +5,6 @@
 # Dual Core mode causes FIFO error
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GU3.ini
+++ b/Data/Sys/GameSettings/GU3.ini
@@ -5,9 +5,6 @@
 # Dual Core mode causes FIFO error
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GU4.ini
+++ b/Data/Sys/GameSettings/GU4.ini
@@ -5,9 +5,6 @@
 # Dual Core mode causes FIFO error
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GUB.ini
+++ b/Data/Sys/GameSettings/GUB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GUM.ini
+++ b/Data/Sys/GameSettings/GUM.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GUN.ini
+++ b/Data/Sys/GameSettings/GUN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GUNE5D.ini
+++ b/Data/Sys/GameSettings/GUNE5D.ini
@@ -1,8 +1,5 @@
 # GUNE5D - Gauntlet - Dark Legacy
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GUP.ini
+++ b/Data/Sys/GameSettings/GUP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GUT.ini
+++ b/Data/Sys/GameSettings/GUT.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GUZ.ini
+++ b/Data/Sys/GameSettings/GUZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GVC.ini
+++ b/Data/Sys/GameSettings/GVC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GVD.ini
+++ b/Data/Sys/GameSettings/GVD.ini
@@ -3,9 +3,6 @@
 [Core]
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GVJ.ini
+++ b/Data/Sys/GameSettings/GVJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GVL.ini
+++ b/Data/Sys/GameSettings/GVL.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GVO.ini
+++ b/Data/Sys/GameSettings/GVO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GVS.ini
+++ b/Data/Sys/GameSettings/GVS.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GVS46E.ini
+++ b/Data/Sys/GameSettings/GVS46E.ini
@@ -5,9 +5,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GVS46J.ini
+++ b/Data/Sys/GameSettings/GVS46J.ini
@@ -5,9 +5,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GW2.ini
+++ b/Data/Sys/GameSettings/GW2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GW7.ini
+++ b/Data/Sys/GameSettings/GW7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GW9.ini
+++ b/Data/Sys/GameSettings/GW9.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GWJ.ini
+++ b/Data/Sys/GameSettings/GWJ.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 
 [ActionReplay]

--- a/Data/Sys/GameSettings/GWK.ini
+++ b/Data/Sys/GameSettings/GWK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GWL.ini
+++ b/Data/Sys/GameSettings/GWL.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MemoryCardSize = 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GWP.ini
+++ b/Data/Sys/GameSettings/GWP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GWQE52.ini
+++ b/Data/Sys/GameSettings/GWQE52.ini
@@ -1,8 +1,5 @@
 # GWQE52 - WRECKLESS
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GWRE01.ini
+++ b/Data/Sys/GameSettings/GWRE01.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GWRP01.ini
+++ b/Data/Sys/GameSettings/GWRP01.ini
@@ -1,8 +1,5 @@
 # GWRP01 - WAVE RACE / BLUE STORM
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GWT.ini
+++ b/Data/Sys/GameSettings/GWT.ini
@@ -7,9 +7,6 @@
 MemoryCardSize = 2
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GWWP01.ini
+++ b/Data/Sys/GameSettings/GWWP01.ini
@@ -1,8 +1,5 @@
 # GWWP01 - WARIO WORLD
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GWY.ini
+++ b/Data/Sys/GameSettings/GWY.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GX3.ini
+++ b/Data/Sys/GameSettings/GX3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GXB.ini
+++ b/Data/Sys/GameSettings/GXB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GXG.ini
+++ b/Data/Sys/GameSettings/GXG.ini
@@ -1,8 +1,6 @@
 # GXGE08 - MEGAMAN X COLLECTION
 [Core]
 # Values set here will override the main Dolphin settings.
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
 [Video_Settings]

--- a/Data/Sys/GameSettings/GXM.ini
+++ b/Data/Sys/GameSettings/GXM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GXN.ini
+++ b/Data/Sys/GameSettings/GXN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GXS.ini
+++ b/Data/Sys/GameSettings/GXS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GXSP8P.ini
+++ b/Data/Sys/GameSettings/GXSP8P.ini
@@ -1,8 +1,5 @@
 # GXSP8P - Sonic Adventure DX
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GXU.ini
+++ b/Data/Sys/GameSettings/GXU.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GXX.ini
+++ b/Data/Sys/GameSettings/GXX.ini
@@ -7,9 +7,6 @@ CPUThread = False
 # normal (multiplayer) battles when doing multiple battles in a row.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GYA.ini
+++ b/Data/Sys/GameSettings/GYA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GYQ.ini
+++ b/Data/Sys/GameSettings/GYQ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GYT.ini
+++ b/Data/Sys/GameSettings/GYT.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GZ2.ini
+++ b/Data/Sys/GameSettings/GZ2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GZ2E01.ini
+++ b/Data/Sys/GameSettings/GZ2E01.ini
@@ -1,8 +1,5 @@
 # GZ2E01 - The Legend of Zelda: Twilight Princess [GC]
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Hyrule Field Speed Hack

--- a/Data/Sys/GameSettings/GZ2J01.ini
+++ b/Data/Sys/GameSettings/GZ2J01.ini
@@ -1,8 +1,5 @@
 # GZ2J01 - The Legend of Zelda: Twilight Princess [GC]
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 $Hyrule Field Speed Hack
 0x8003D50C:dword:0x60000000

--- a/Data/Sys/GameSettings/GZ2P01.ini
+++ b/Data/Sys/GameSettings/GZ2P01.ini
@@ -1,8 +1,5 @@
 # GZ2P01 - The Legend of Zelda: Twilight Princess [GC]
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Hyrule Field Speed Hack

--- a/Data/Sys/GameSettings/GZ3E70.ini
+++ b/Data/Sys/GameSettings/GZ3E70.ini
@@ -1,8 +1,5 @@
 # GZ3E70 - Dragon Ball Z 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GZE.ini
+++ b/Data/Sys/GameSettings/GZE.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GZL.ini
+++ b/Data/Sys/GameSettings/GZL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GZLE01.ini
+++ b/Data/Sys/GameSettings/GZLE01.ini
@@ -1,8 +1,5 @@
 # GZLE01 - The Legend of Zelda The Wind Waker
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Max health

--- a/Data/Sys/GameSettings/GZLJ01.ini
+++ b/Data/Sys/GameSettings/GZLJ01.ini
@@ -1,8 +1,5 @@
 # GZLJ01 - The Legend of Zelda The Wind Waker
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Max health

--- a/Data/Sys/GameSettings/GZLP01.ini
+++ b/Data/Sys/GameSettings/GZLP01.ini
@@ -1,8 +1,5 @@
 # GZLP01 - The Legend of Zelda The Wind Waker
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Max health

--- a/Data/Sys/GameSettings/GZP.ini
+++ b/Data/Sys/GameSettings/GZP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/GZW.ini
+++ b/Data/Sys/GameSettings/GZW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/HAB.ini
+++ b/Data/Sys/GameSettings/HAB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/HAC.ini
+++ b/Data/Sys/GameSettings/HAC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/HAT.ini
+++ b/Data/Sys/GameSettings/HAT.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/HC4.ini
+++ b/Data/Sys/GameSettings/HC4.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/HCL.ini
+++ b/Data/Sys/GameSettings/HCL.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/HCS.ini
+++ b/Data/Sys/GameSettings/HCS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/NAB.ini
+++ b/Data/Sys/GameSettings/NAB.ini
@@ -2,9 +2,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 
 [ActionReplay]

--- a/Data/Sys/GameSettings/NAC.ini
+++ b/Data/Sys/GameSettings/NAC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/NAD.ini
+++ b/Data/Sys/GameSettings/NAD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/NAE.ini
+++ b/Data/Sys/GameSettings/NAE.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/NAF.ini
+++ b/Data/Sys/GameSettings/NAF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/NAK.ini
+++ b/Data/Sys/GameSettings/NAK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/NAL.ini
+++ b/Data/Sys/GameSettings/NAL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/NAO.ini
+++ b/Data/Sys/GameSettings/NAO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/NAO.ini
+++ b/Data/Sys/GameSettings/NAO.ini
@@ -1,19 +1,19 @@
-# NAOJ01, NAOE01, NAOP01, NAOK01 - 1080° Snowboarding 
+# NAOJ01, NAOE01, NAOP01, NAOK01 - 1080° Snowboarding
 
-[Core] 
-# Values set here will override the main Dolphin settings. 
+[Core]
+# Values set here will override the main Dolphin settings.
 
-[OnLoad] 
-# Add memory patches to be loaded once on boot here. 
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
 
-[OnFrame] 
-# Add memory patches to be applied every frame here. 
+[OnFrame]
+# Add memory patches to be applied every frame here.
 
-[ActionReplay] 
-# Add action replay cheats here. 
+[ActionReplay]
+# Add action replay cheats here.
 
-[Video_Settings] 
+[Video_Settings]
 
-[Video_Hacks] 
-DeferEFBCopies = False 
+[Video_Hacks]
+DeferEFBCopies = False
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/NAR.ini
+++ b/Data/Sys/GameSettings/NAR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/NAT.ini
+++ b/Data/Sys/GameSettings/NAT.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/P2M.ini
+++ b/Data/Sys/GameSettings/P2M.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/P4B.ini
+++ b/Data/Sys/GameSettings/P4B.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/PC6.ini
+++ b/Data/Sys/GameSettings/PC6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/PCK.ini
+++ b/Data/Sys/GameSettings/PCK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/PCS.ini
+++ b/Data/Sys/GameSettings/PCS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/PGS.ini
+++ b/Data/Sys/GameSettings/PGS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/PNR.ini
+++ b/Data/Sys/GameSettings/PNR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/PRJ.ini
+++ b/Data/Sys/GameSettings/PRJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/PZL.ini
+++ b/Data/Sys/GameSettings/PZL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/PZLE01.ini
+++ b/Data/Sys/GameSettings/PZLE01.ini
@@ -1,8 +1,5 @@
 # PZLE01 - The Legend of Zelda: Collector's Edition
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R22.ini
+++ b/Data/Sys/GameSettings/R22.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R25.ini
+++ b/Data/Sys/GameSettings/R25.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R2G.ini
+++ b/Data/Sys/GameSettings/R2G.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R2V.ini
+++ b/Data/Sys/GameSettings/R2V.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R38.ini
+++ b/Data/Sys/GameSettings/R38.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R3A.ini
+++ b/Data/Sys/GameSettings/R3A.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R3B.ini
+++ b/Data/Sys/GameSettings/R3B.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R3D.ini
+++ b/Data/Sys/GameSettings/R3D.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R3M.ini
+++ b/Data/Sys/GameSettings/R3M.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R3N.ini
+++ b/Data/Sys/GameSettings/R3N.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R3O.ini
+++ b/Data/Sys/GameSettings/R3O.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R3R.ini
+++ b/Data/Sys/GameSettings/R3R.ini
@@ -1,8 +1,6 @@
 # R3RE8P, R3RP8P - Sonic & Sega All-Stars Racing
 [Core]
 # Values set here will override the main Dolphin settings.
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
 [Video_Hacks]

--- a/Data/Sys/GameSettings/R44.ini
+++ b/Data/Sys/GameSettings/R44.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R4E.ini
+++ b/Data/Sys/GameSettings/R4E.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R4F.ini
+++ b/Data/Sys/GameSettings/R4F.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R4Z.ini
+++ b/Data/Sys/GameSettings/R4Z.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R55.ini
+++ b/Data/Sys/GameSettings/R55.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R59.ini
+++ b/Data/Sys/GameSettings/R59.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R5D.ini
+++ b/Data/Sys/GameSettings/R5D.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R5I.ini
+++ b/Data/Sys/GameSettings/R5I.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R5P.ini
+++ b/Data/Sys/GameSettings/R5P.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R5T.ini
+++ b/Data/Sys/GameSettings/R5T.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R5W.ini
+++ b/Data/Sys/GameSettings/R5W.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R64.ini
+++ b/Data/Sys/GameSettings/R64.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R6B.ini
+++ b/Data/Sys/GameSettings/R6B.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R6C.INI
+++ b/Data/Sys/GameSettings/R6C.INI
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R6Q.ini
+++ b/Data/Sys/GameSettings/R6Q.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R6T.ini
+++ b/Data/Sys/GameSettings/R6T.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R6Y.ini
+++ b/Data/Sys/GameSettings/R6Y.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R7E.ini
+++ b/Data/Sys/GameSettings/R7E.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R7G.ini
+++ b/Data/Sys/GameSettings/R7G.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 AccurateNaNs = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R7P.ini
+++ b/Data/Sys/GameSettings/R7P.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R7PE01.ini
+++ b/Data/Sys/GameSettings/R7PE01.ini
@@ -1,8 +1,5 @@
 # R7PE01 - Punch Out
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Patch

--- a/Data/Sys/GameSettings/R7PP01.ini
+++ b/Data/Sys/GameSettings/R7PP01.ini
@@ -1,8 +1,5 @@
 # R7PP01 - Punch Out
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Patch

--- a/Data/Sys/GameSettings/R7X.ini
+++ b/Data/Sys/GameSettings/R7X.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R84.ini
+++ b/Data/Sys/GameSettings/R84.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R8A.ini
+++ b/Data/Sys/GameSettings/R8A.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R8I.ini
+++ b/Data/Sys/GameSettings/R8I.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R8J.ini
+++ b/Data/Sys/GameSettings/R8J.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R8L.ini
+++ b/Data/Sys/GameSettings/R8L.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R8P.ini
+++ b/Data/Sys/GameSettings/R8P.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R92.ini
+++ b/Data/Sys/GameSettings/R92.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R9D.ini
+++ b/Data/Sys/GameSettings/R9D.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R9G.ini
+++ b/Data/Sys/GameSettings/R9G.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/R9I.ini
+++ b/Data/Sys/GameSettings/R9I.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RB7.ini
+++ b/Data/Sys/GameSettings/RB7.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FastDiscSpeed = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RB9.ini
+++ b/Data/Sys/GameSettings/RB9.ini
@@ -3,9 +3,6 @@
 [Core]
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBB.ini
+++ b/Data/Sys/GameSettings/RBB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBH.ini
+++ b/Data/Sys/GameSettings/RBH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBI.ini
+++ b/Data/Sys/GameSettings/RBI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBK.ini
+++ b/Data/Sys/GameSettings/RBK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBL.ini
+++ b/Data/Sys/GameSettings/RBL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBO.ini
+++ b/Data/Sys/GameSettings/RBO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBR.ini
+++ b/Data/Sys/GameSettings/RBR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBT.ini
+++ b/Data/Sys/GameSettings/RBT.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBW.ini
+++ b/Data/Sys/GameSettings/RBW.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RBY.ini
+++ b/Data/Sys/GameSettings/RBY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RCC.ini
+++ b/Data/Sys/GameSettings/RCC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RCH.ini
+++ b/Data/Sys/GameSettings/RCH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RCJ.ini
+++ b/Data/Sys/GameSettings/RCJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RCL.ini
+++ b/Data/Sys/GameSettings/RCL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RCP.ini
+++ b/Data/Sys/GameSettings/RCP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RD2.ini
+++ b/Data/Sys/GameSettings/RD2.ini
@@ -3,9 +3,6 @@
 [Core]
 # The game hangs on New Game when using Dual Core
 CPUThread = False
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RDB.ini
+++ b/Data/Sys/GameSettings/RDB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RDF.ini
+++ b/Data/Sys/GameSettings/RDF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RDJ.ini
+++ b/Data/Sys/GameSettings/RDJ.ini
@@ -5,9 +5,6 @@
 # https://bugs.dolphin-emu.org/issues/13544
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RDS.ini
+++ b/Data/Sys/GameSettings/RDS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RDZ.ini
+++ b/Data/Sys/GameSettings/RDZ.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RED.ini
+++ b/Data/Sys/GameSettings/RED.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RELJAB.ini
+++ b/Data/Sys/GameSettings/RELJAB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $DI Seed Blanker

--- a/Data/Sys/GameSettings/REX.ini
+++ b/Data/Sys/GameSettings/REX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RFB.ini
+++ b/Data/Sys/GameSettings/RFB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RFC.ini
+++ b/Data/Sys/GameSettings/RFC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RFF.ini
+++ b/Data/Sys/GameSettings/RFF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RFQ.ini
+++ b/Data/Sys/GameSettings/RFQ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RFS.ini
+++ b/Data/Sys/GameSettings/RFS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RG2.ini
+++ b/Data/Sys/GameSettings/RG2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RG4.ini
+++ b/Data/Sys/GameSettings/RG4.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RG6.ini
+++ b/Data/Sys/GameSettings/RG6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RGB.ini
+++ b/Data/Sys/GameSettings/RGB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RGM.ini
+++ b/Data/Sys/GameSettings/RGM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RGQ.ini
+++ b/Data/Sys/GameSettings/RGQ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RGQE70.ini
+++ b/Data/Sys/GameSettings/RGQE70.ini
@@ -1,8 +1,5 @@
 # RGQE70 - Ghostbusters
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $crashfix

--- a/Data/Sys/GameSettings/RGS.ini
+++ b/Data/Sys/GameSettings/RGS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RGW.ini
+++ b/Data/Sys/GameSettings/RGW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RH6.ini
+++ b/Data/Sys/GameSettings/RH6.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RH8.ini
+++ b/Data/Sys/GameSettings/RH8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RHA.ini
+++ b/Data/Sys/GameSettings/RHA.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RHO.ini
+++ b/Data/Sys/GameSettings/RHO.ini
@@ -3,9 +3,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RHT.ini
+++ b/Data/Sys/GameSettings/RHT.ini
@@ -7,9 +7,6 @@
 OverclockEnable = True
 Overclock = 1.25
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RI3.ini
+++ b/Data/Sys/GameSettings/RI3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RI7.ini
+++ b/Data/Sys/GameSettings/RI7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RIP.ini
+++ b/Data/Sys/GameSettings/RIP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RIU.ini
+++ b/Data/Sys/GameSettings/RIU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RIZ.ini
+++ b/Data/Sys/GameSettings/RIZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RJ2.ini
+++ b/Data/Sys/GameSettings/RJ2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RJ3.ini
+++ b/Data/Sys/GameSettings/RJ3.ini
@@ -5,9 +5,6 @@
 # Fixes the blue screen problem. See issue 13118 for more info.
 AccurateNaNs = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RJ8.ini
+++ b/Data/Sys/GameSettings/RJ8.ini
@@ -5,9 +5,6 @@
 # The JIT cache causes problems with emulated icache invalidation in this game resulting in areas failing to load
 DisableICache = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RJC.ini
+++ b/Data/Sys/GameSettings/RJC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RK2.ini
+++ b/Data/Sys/GameSettings/RK2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RKA.ini
+++ b/Data/Sys/GameSettings/RKA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RKD.ini
+++ b/Data/Sys/GameSettings/RKD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RLJ.ini
+++ b/Data/Sys/GameSettings/RLJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RLS.ini
+++ b/Data/Sys/GameSettings/RLS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RLT.ini
+++ b/Data/Sys/GameSettings/RLT.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RM3.ini
+++ b/Data/Sys/GameSettings/RM3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RM8.ini
+++ b/Data/Sys/GameSettings/RM8.ini
@@ -1,8 +1,6 @@
 # RM8E01, RM8J01, RM8K01, RM8P01 - Mario Party 8
 [Core]
 # Values set here will override the main Dolphin settings.
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
 [Video_Enhancements]

--- a/Data/Sys/GameSettings/RM8E01.ini
+++ b/Data/Sys/GameSettings/RM8E01.ini
@@ -1,8 +1,5 @@
 # RM8E01 - Mario Party 8
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RM9.ini
+++ b/Data/Sys/GameSettings/RM9.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RMC.ini
+++ b/Data/Sys/GameSettings/RMC.ini
@@ -2,9 +2,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RMG.ini
+++ b/Data/Sys/GameSettings/RMG.ini
@@ -2,9 +2,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RMH.ini
+++ b/Data/Sys/GameSettings/RMH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RMHE08.ini
+++ b/Data/Sys/GameSettings/RMHE08.ini
@@ -1,8 +1,5 @@
 # RMHE08 - Monster Hunter Tri
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Bloom OFF

--- a/Data/Sys/GameSettings/RMHJ08.ini
+++ b/Data/Sys/GameSettings/RMHJ08.ini
@@ -1,8 +1,5 @@
 # RMHJ08 - Monster Hunter Tri
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Bloom OFF

--- a/Data/Sys/GameSettings/RMHP08.ini
+++ b/Data/Sys/GameSettings/RMHP08.ini
@@ -1,8 +1,5 @@
 # RMHP08 - Monster Hunter Tri
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Bloom OFF

--- a/Data/Sys/GameSettings/RMK.ini
+++ b/Data/Sys/GameSettings/RMK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RML.ini
+++ b/Data/Sys/GameSettings/RML.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RMO.ini
+++ b/Data/Sys/GameSettings/RMO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RMP.ini
+++ b/Data/Sys/GameSettings/RMP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RNB.ini
+++ b/Data/Sys/GameSettings/RNB.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RNO.ini
+++ b/Data/Sys/GameSettings/RNO.ini
@@ -4,9 +4,6 @@
 # Prevents save game corruption.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RNX.ini
+++ b/Data/Sys/GameSettings/RNX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RO2P7N.ini
+++ b/Data/Sys/GameSettings/RO2P7N.ini
@@ -1,8 +1,5 @@
 # RO2P7N - OFF ROAD
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Hangfix

--- a/Data/Sys/GameSettings/RO3.ini
+++ b/Data/Sys/GameSettings/RO3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RO7.ini
+++ b/Data/Sys/GameSettings/RO7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RO8.ini
+++ b/Data/Sys/GameSettings/RO8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RO9.ini
+++ b/Data/Sys/GameSettings/RO9.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ROA.ini
+++ b/Data/Sys/GameSettings/ROA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ROD.ini
+++ b/Data/Sys/GameSettings/ROD.ini
@@ -2,9 +2,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ROL.ini
+++ b/Data/Sys/GameSettings/ROL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RON.ini
+++ b/Data/Sys/GameSettings/RON.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ROU.ini
+++ b/Data/Sys/GameSettings/ROU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ROW.ini
+++ b/Data/Sys/GameSettings/ROW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/ROX.ini
+++ b/Data/Sys/GameSettings/ROX.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 RealWiiRemoteRepeatReports = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RPB.ini
+++ b/Data/Sys/GameSettings/RPB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RPF.ini
+++ b/Data/Sys/GameSettings/RPF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RPG.ini
+++ b/Data/Sys/GameSettings/RPG.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RPJ.ini
+++ b/Data/Sys/GameSettings/RPJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RPO.ini
+++ b/Data/Sys/GameSettings/RPO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RPY.ini
+++ b/Data/Sys/GameSettings/RPY.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RQ6.ini
+++ b/Data/Sys/GameSettings/RQ6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RQL.ini
+++ b/Data/Sys/GameSettings/RQL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RQR.ini
+++ b/Data/Sys/GameSettings/RQR.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RQW.ini
+++ b/Data/Sys/GameSettings/RQW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RRB.ini
+++ b/Data/Sys/GameSettings/RRB.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RRK.ini
+++ b/Data/Sys/GameSettings/RRK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RRL.ini
+++ b/Data/Sys/GameSettings/RRL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RRP.ini
+++ b/Data/Sys/GameSettings/RRP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RRZ.ini
+++ b/Data/Sys/GameSettings/RRZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RS5.ini
+++ b/Data/Sys/GameSettings/RS5.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSB.ini
+++ b/Data/Sys/GameSettings/RSB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSBP01.ini
+++ b/Data/Sys/GameSettings/RSBP01.ini
@@ -1,8 +1,5 @@
 # RSBP01 - Super Smash Bros. Brawl
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSH.ini
+++ b/Data/Sys/GameSettings/RSH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSI.ini
+++ b/Data/Sys/GameSettings/RSI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSL.ini
+++ b/Data/Sys/GameSettings/RSL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSM.ini
+++ b/Data/Sys/GameSettings/RSM.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSN.ini
+++ b/Data/Sys/GameSettings/RSN.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSO.ini
+++ b/Data/Sys/GameSettings/RSO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSP.ini
+++ b/Data/Sys/GameSettings/RSP.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSR.ini
+++ b/Data/Sys/GameSettings/RSR.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 RealWiiRemoteRepeatReports = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RST.ini
+++ b/Data/Sys/GameSettings/RST.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RSX.ini
+++ b/Data/Sys/GameSettings/RSX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RT4.ini
+++ b/Data/Sys/GameSettings/RT4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RT8.ini
+++ b/Data/Sys/GameSettings/RT8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RTH.ini
+++ b/Data/Sys/GameSettings/RTH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Disable blur

--- a/Data/Sys/GameSettings/RTM.ini
+++ b/Data/Sys/GameSettings/RTM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RTR.ini
+++ b/Data/Sys/GameSettings/RTR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RTU.ini
+++ b/Data/Sys/GameSettings/RTU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RTZ.ini
+++ b/Data/Sys/GameSettings/RTZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RUF.ini
+++ b/Data/Sys/GameSettings/RUF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 
 [ActionReplay]

--- a/Data/Sys/GameSettings/RUU.ini
+++ b/Data/Sys/GameSettings/RUU.ini
@@ -2,9 +2,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 
 [ActionReplay]

--- a/Data/Sys/GameSettings/RW7.ini
+++ b/Data/Sys/GameSettings/RW7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RWO.ini
+++ b/Data/Sys/GameSettings/RWO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RWS.ini
+++ b/Data/Sys/GameSettings/RWS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RX3.ini
+++ b/Data/Sys/GameSettings/RX3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RXI.ini
+++ b/Data/Sys/GameSettings/RXI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RXX.ini
+++ b/Data/Sys/GameSettings/RXX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RY2.ini
+++ b/Data/Sys/GameSettings/RY2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RY3.ini
+++ b/Data/Sys/GameSettings/RY3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RYB.ini
+++ b/Data/Sys/GameSettings/RYB.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RYW.ini
+++ b/Data/Sys/GameSettings/RYW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RZD.ini
+++ b/Data/Sys/GameSettings/RZD.ini
@@ -2,9 +2,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RZDE01r0.ini
+++ b/Data/Sys/GameSettings/RZDE01r0.ini
@@ -1,8 +1,5 @@
 # RZDE01 - The Legend of Zelda: Twilight Princess [Wii]
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Hyrule Field Speed Hack

--- a/Data/Sys/GameSettings/RZDE01r2.ini
+++ b/Data/Sys/GameSettings/RZDE01r2.ini
@@ -1,8 +1,5 @@
 # RZDE01 - The Legend of Zelda: Twilight Princess [Wii]
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Hyrule Field Speed Hack

--- a/Data/Sys/GameSettings/RZDJ01.ini
+++ b/Data/Sys/GameSettings/RZDJ01.ini
@@ -1,8 +1,5 @@
 # RZDJ01 - The Legend of Zelda: Twilight Princess [Wii]
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Hyrule Field Speed Hack

--- a/Data/Sys/GameSettings/RZDK01.ini
+++ b/Data/Sys/GameSettings/RZDK01.ini
@@ -1,8 +1,5 @@
 # RZDK01 - The Legend of Zelda: Twilight Princess [Wii]
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Hyrule Field Speed Hack

--- a/Data/Sys/GameSettings/RZDP01.ini
+++ b/Data/Sys/GameSettings/RZDP01.ini
@@ -1,8 +1,5 @@
 # RZDP01 - The Legend of Zelda: Twilight Princess [Wii]
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Hyrule Field Speed Hack

--- a/Data/Sys/GameSettings/RZF.ini
+++ b/Data/Sys/GameSettings/RZF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RZI.ini
+++ b/Data/Sys/GameSettings/RZI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RZJ.ini
+++ b/Data/Sys/GameSettings/RZJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RZJP69.ini
+++ b/Data/Sys/GameSettings/RZJP69.ini
@@ -1,8 +1,5 @@
 # RZJP69 - DeadSpace
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RZO.ini
+++ b/Data/Sys/GameSettings/RZO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/RZT.ini
+++ b/Data/Sys/GameSettings/RZT.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 
 [ActionReplay]

--- a/Data/Sys/GameSettings/RZY.ini
+++ b/Data/Sys/GameSettings/RZY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S2C.ini
+++ b/Data/Sys/GameSettings/S2C.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S2E.ini
+++ b/Data/Sys/GameSettings/S2E.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S2L.ini
+++ b/Data/Sys/GameSettings/S2L.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S2W.ini
+++ b/Data/Sys/GameSettings/S2W.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S3B.ini
+++ b/Data/Sys/GameSettings/S3B.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S59.ini
+++ b/Data/Sys/GameSettings/S59.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S5D.ini
+++ b/Data/Sys/GameSettings/S5D.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S5S.ini
+++ b/Data/Sys/GameSettings/S5S.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S72.ini
+++ b/Data/Sys/GameSettings/S72.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/S75.ini
+++ b/Data/Sys/GameSettings/S75.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SAK.ini
+++ b/Data/Sys/GameSettings/SAK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SAL.ini
+++ b/Data/Sys/GameSettings/SAL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SB3.ini
+++ b/Data/Sys/GameSettings/SB3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SB4.ini
+++ b/Data/Sys/GameSettings/SB4.ini
@@ -2,9 +2,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SBD.ini
+++ b/Data/Sys/GameSettings/SBD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SBX.ini
+++ b/Data/Sys/GameSettings/SBX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SC2E8P.ini
+++ b/Data/Sys/GameSettings/SC2E8P.ini
@@ -1,8 +1,5 @@
 # SC2E8P - Conduit 2
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SC7.ini
+++ b/Data/Sys/GameSettings/SC7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SCA.ini
+++ b/Data/Sys/GameSettings/SCA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SCI.ini
+++ b/Data/Sys/GameSettings/SCI.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SCY.ini
+++ b/Data/Sys/GameSettings/SCY.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 LowDCBZHack = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SD2.ini
+++ b/Data/Sys/GameSettings/SD2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SD2J01.ini
+++ b/Data/Sys/GameSettings/SD2J01.ini
@@ -6,9 +6,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SDB.ini
+++ b/Data/Sys/GameSettings/SDB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SDL.ini
+++ b/Data/Sys/GameSettings/SDL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SDM.ini
+++ b/Data/Sys/GameSettings/SDM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SDN.ini
+++ b/Data/Sys/GameSettings/SDN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SDW.ini
+++ b/Data/Sys/GameSettings/SDW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SDZ.ini
+++ b/Data/Sys/GameSettings/SDZ.ini
@@ -4,9 +4,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SE2.ini
+++ b/Data/Sys/GameSettings/SE2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SEA.ini
+++ b/Data/Sys/GameSettings/SEA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SEC.ini
+++ b/Data/Sys/GameSettings/SEC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SEM.ini
+++ b/Data/Sys/GameSettings/SEM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SEP.ini
+++ b/Data/Sys/GameSettings/SEP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SER.ini
+++ b/Data/Sys/GameSettings/SER.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SF2.ini
+++ b/Data/Sys/GameSettings/SF2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SFI.ini
+++ b/Data/Sys/GameSettings/SFI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SFP.ini
+++ b/Data/Sys/GameSettings/SFP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SFU.ini
+++ b/Data/Sys/GameSettings/SFU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SG7.ini
+++ b/Data/Sys/GameSettings/SG7.ini
@@ -4,9 +4,6 @@
 # Garfield hangs on level start when Dual Core is enabled.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SG8.ini
+++ b/Data/Sys/GameSettings/SG8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SGV.ini
+++ b/Data/Sys/GameSettings/SGV.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SH6.ini
+++ b/Data/Sys/GameSettings/SH6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SHL.ini
+++ b/Data/Sys/GameSettings/SHL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SHW.ini
+++ b/Data/Sys/GameSettings/SHW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SHX.ini
+++ b/Data/Sys/GameSettings/SHX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SIL.ini
+++ b/Data/Sys/GameSettings/SIL.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJ6.ini
+++ b/Data/Sys/GameSettings/SJ6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJ7.ini
+++ b/Data/Sys/GameSettings/SJ7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJ9.ini
+++ b/Data/Sys/GameSettings/SJ9.ini
@@ -4,9 +4,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJB.ini
+++ b/Data/Sys/GameSettings/SJB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJD.ini
+++ b/Data/Sys/GameSettings/SJD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJDJ01.ini
+++ b/Data/Sys/GameSettings/SJDJ01.ini
@@ -6,9 +6,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJE.ini
+++ b/Data/Sys/GameSettings/SJE.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJHE41.ini
+++ b/Data/Sys/GameSettings/SJHE41.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJTP41.ini
+++ b/Data/Sys/GameSettings/SJTP41.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJX.ini
+++ b/Data/Sys/GameSettings/SJX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SJZ.ini
+++ b/Data/Sys/GameSettings/SJZ.ini
@@ -4,9 +4,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SK3.ini
+++ b/Data/Sys/GameSettings/SK3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SK8.ini
+++ b/Data/Sys/GameSettings/SK8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SKA.ini
+++ b/Data/Sys/GameSettings/SKA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SKC.ini
+++ b/Data/Sys/GameSettings/SKC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SKG.ini
+++ b/Data/Sys/GameSettings/SKG.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SKJ.ini
+++ b/Data/Sys/GameSettings/SKJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SKO.ini
+++ b/Data/Sys/GameSettings/SKO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SKU.ini
+++ b/Data/Sys/GameSettings/SKU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SKV.ini
+++ b/Data/Sys/GameSettings/SKV.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SKY.ini
+++ b/Data/Sys/GameSettings/SKY.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SLE.ini
+++ b/Data/Sys/GameSettings/SLE.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SLS.ini
+++ b/Data/Sys/GameSettings/SLS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SLW.ini
+++ b/Data/Sys/GameSettings/SLW.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SMB.ini
+++ b/Data/Sys/GameSettings/SMB.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 FPRF = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SMF.ini
+++ b/Data/Sys/GameSettings/SMF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SMN.ini
+++ b/Data/Sys/GameSettings/SMN.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SMNE01.ini
+++ b/Data/Sys/GameSettings/SMNE01.ini
@@ -1,8 +1,5 @@
 # SMNE01 - New SUPER MARIO BROS. Wii
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SMNP01.ini
+++ b/Data/Sys/GameSettings/SMNP01.ini
@@ -1,8 +1,5 @@
 # SMNP01 - New SUPER MARIO BROS. Wii
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 $Speed hack

--- a/Data/Sys/GameSettings/SMO.ini
+++ b/Data/Sys/GameSettings/SMO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SMZ.ini
+++ b/Data/Sys/GameSettings/SMZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SNC.ini
+++ b/Data/Sys/GameSettings/SNC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SND.ini
+++ b/Data/Sys/GameSettings/SND.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SNG.ini
+++ b/Data/Sys/GameSettings/SNG.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SNJ.ini
+++ b/Data/Sys/GameSettings/SNJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SNJE69.ini
+++ b/Data/Sys/GameSettings/SNJE69.ini
@@ -1,8 +1,5 @@
 # SNJE69 - NBA JAM
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SNS.ini
+++ b/Data/Sys/GameSettings/SNS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SNT.ini
+++ b/Data/Sys/GameSettings/SNT.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SOJ.ini
+++ b/Data/Sys/GameSettings/SOJ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SOM.ini
+++ b/Data/Sys/GameSettings/SOM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SOS.ini
+++ b/Data/Sys/GameSettings/SOS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SOU.ini
+++ b/Data/Sys/GameSettings/SOU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 
 [ActionReplay]

--- a/Data/Sys/GameSettings/SP8.ini
+++ b/Data/Sys/GameSettings/SP8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SPD.ini
+++ b/Data/Sys/GameSettings/SPD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SPR.ini
+++ b/Data/Sys/GameSettings/SPR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SPT.ini
+++ b/Data/Sys/GameSettings/SPT.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SPV.ini
+++ b/Data/Sys/GameSettings/SPV.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SQD.ini
+++ b/Data/Sys/GameSettings/SQD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SQI.ini
+++ b/Data/Sys/GameSettings/SQI.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 LowDCBZHack = True
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SR4.ini
+++ b/Data/Sys/GameSettings/SR4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SR5.ini
+++ b/Data/Sys/GameSettings/SR5.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SRQ.ini
+++ b/Data/Sys/GameSettings/SRQ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SRX.ini
+++ b/Data/Sys/GameSettings/SRX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SS8.ini
+++ b/Data/Sys/GameSettings/SS8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SSP.ini
+++ b/Data/Sys/GameSettings/SSP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SSQ.ini
+++ b/Data/Sys/GameSettings/SSQ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SSR.ini
+++ b/Data/Sys/GameSettings/SSR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SST.ini
+++ b/Data/Sys/GameSettings/SST.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SSZ.ini
+++ b/Data/Sys/GameSettings/SSZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/STR.ini
+++ b/Data/Sys/GameSettings/STR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/STS.ini
+++ b/Data/Sys/GameSettings/STS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SUK.ini
+++ b/Data/Sys/GameSettings/SUK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SUO.ini
+++ b/Data/Sys/GameSettings/SUO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SVB.ini
+++ b/Data/Sys/GameSettings/SVB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SVM.ini
+++ b/Data/Sys/GameSettings/SVM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SVV.ini
+++ b/Data/Sys/GameSettings/SVV.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SVX.ini
+++ b/Data/Sys/GameSettings/SVX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SVZ.ini
+++ b/Data/Sys/GameSettings/SVZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SX3.ini
+++ b/Data/Sys/GameSettings/SX3.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SX4.ini
+++ b/Data/Sys/GameSettings/SX4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SX7.ini
+++ b/Data/Sys/GameSettings/SX7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SX8.ini
+++ b/Data/Sys/GameSettings/SX8.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 SyncOnSkipIdle = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SXC.ini
+++ b/Data/Sys/GameSettings/SXC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/SZB.ini
+++ b/Data/Sys/GameSettings/SZB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/W3M.ini
+++ b/Data/Sys/GameSettings/W3M.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WA2.ini
+++ b/Data/Sys/GameSettings/WA2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WB7.ini
+++ b/Data/Sys/GameSettings/WB7.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WB8.ini
+++ b/Data/Sys/GameSettings/WB8.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WBK.ini
+++ b/Data/Sys/GameSettings/WBK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WC6.ini
+++ b/Data/Sys/GameSettings/WC6.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 
 [ActionReplay]

--- a/Data/Sys/GameSettings/WD9.ini
+++ b/Data/Sys/GameSettings/WD9.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WDO.ini
+++ b/Data/Sys/GameSettings/WDO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WF4.ini
+++ b/Data/Sys/GameSettings/WF4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WFH.ini
+++ b/Data/Sys/GameSettings/WFH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WGG.ini
+++ b/Data/Sys/GameSettings/WGG.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WGL.ini
+++ b/Data/Sys/GameSettings/WGL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WGS.ini
+++ b/Data/Sys/GameSettings/WGS.ini
@@ -1,8 +1,6 @@
 # WGSE08, WGSP08 - PWAA Ace Attorney
 [Core]
 # Values set here will override the main Dolphin settings.
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
 [Video_Hacks]

--- a/Data/Sys/GameSettings/WHF.ini
+++ b/Data/Sys/GameSettings/WHF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WHP.ini
+++ b/Data/Sys/GameSettings/WHP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WHU.ini
+++ b/Data/Sys/GameSettings/WHU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WIB.ini
+++ b/Data/Sys/GameSettings/WIB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WIC.ini
+++ b/Data/Sys/GameSettings/WIC.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WJA.ini
+++ b/Data/Sys/GameSettings/WJA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WJE.ini
+++ b/Data/Sys/GameSettings/WJE.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 RealWiiRemoteRepeatReports = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WKD.ini
+++ b/Data/Sys/GameSettings/WKD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WKT.ini
+++ b/Data/Sys/GameSettings/WKT.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 CPUThread = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WL9.ini
+++ b/Data/Sys/GameSettings/WL9.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WLO.ini
+++ b/Data/Sys/GameSettings/WLO.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WLZ.ini
+++ b/Data/Sys/GameSettings/WLZ.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WMA.ini
+++ b/Data/Sys/GameSettings/WMA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WMB.ini
+++ b/Data/Sys/GameSettings/WMB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WMG.ini
+++ b/Data/Sys/GameSettings/WMG.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WMS.ini
+++ b/Data/Sys/GameSettings/WMS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WP4.ini
+++ b/Data/Sys/GameSettings/WP4.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WPA.ini
+++ b/Data/Sys/GameSettings/WPA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WPF.ini
+++ b/Data/Sys/GameSettings/WPF.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WPH.ini
+++ b/Data/Sys/GameSettings/WPH.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WPS.ini
+++ b/Data/Sys/GameSettings/WPS.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WR2.ini
+++ b/Data/Sys/GameSettings/WR2.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WR5.ini
+++ b/Data/Sys/GameSettings/WR5.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WR9.ini
+++ b/Data/Sys/GameSettings/WR9.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WRI.ini
+++ b/Data/Sys/GameSettings/WRI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WRX.ini
+++ b/Data/Sys/GameSettings/WRX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WSL.ini
+++ b/Data/Sys/GameSettings/WSL.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WSR.ini
+++ b/Data/Sys/GameSettings/WSR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WTE.ini
+++ b/Data/Sys/GameSettings/WTE.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WTK.ini
+++ b/Data/Sys/GameSettings/WTK.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WTU.ini
+++ b/Data/Sys/GameSettings/WTU.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WTX.ini
+++ b/Data/Sys/GameSettings/WTX.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WWA.ini
+++ b/Data/Sys/GameSettings/WWA.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WXB.ini
+++ b/Data/Sys/GameSettings/WXB.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WXP.ini
+++ b/Data/Sys/GameSettings/WXP.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WXR.ini
+++ b/Data/Sys/GameSettings/WXR.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WYM.ini
+++ b/Data/Sys/GameSettings/WYM.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/WZI.ini
+++ b/Data/Sys/GameSettings/WZI.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/XHD.ini
+++ b/Data/Sys/GameSettings/XHD.ini
@@ -3,9 +3,6 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 

--- a/Data/Sys/GameSettings/XHL.ini
+++ b/Data/Sys/GameSettings/XHL.ini
@@ -4,9 +4,6 @@
 # Values set here will override the main Dolphin settings.
 RealWiiRemoteRepeatReports = False
 
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
 [OnFrame]
 # Add memory patches to be applied every frame here.
 


### PR DESCRIPTION
These haven't worked since 2008 (0b5fed62c1b92017ce43a87ba223763a75e7fbef).

(See also #13136, which makes the OnFrame patches function the same as OnLoad patches would.)