### PR TITLE
GameINI: Shadow the Hedgehog texture cache default

### DIFF
--- a/Data/Sys/GameSettings/GUP.ini
+++ b/Data/Sys/GameSettings/GUP.ini
@@ -13,6 +13,9 @@
 VertexRounding = True
 
 [Video_Settings]
+# Force texture cache to the middle option - fixes the bloom bleed/artifacting and SFD video slowdown issues present on Safe and Fast
+SafeTextureCacheColorSamples = 512
+
 WidescreenHeuristicStandardRatio = 0.91
 WidescreenHeuristicWidescreenRatio = 1.21
 WidescreenHeuristicAspectRatioSlop = 0.15


### PR DESCRIPTION
Adjusts the Texture Cache settings/slider to 512 samples which equates to the 'middle' option in the UI.

If using the 'Safe' Texture Cache Accuracy mode, the left screen will only render bloom in 2P modes.
If using the 'Fast' Texture Cache Accuracy mode, the Intro Movie will drop frames near the end when the "Shadow the Hedgehog" game title letters appear. This mode also can result in artifacts/bleed from bloom effects in some situations.

See https://wiki.dolphin-emu.org/index.php?title=Shadow_the_Hedgehog for screenshot examples.