### PR TITLE
EnhancementsWidget: Refactor to using ConfigControls and add new control

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
@@ -40,3 +40,27 @@ private:
   Config::Info<std::string> m_setting;
   bool m_text_is_data = false;
 };
+
+class ConfigComplexChoice final : public ToolTipComboBox
+{
+  Q_OBJECT
+
+  using InfoVariant = std::variant<Config::Info<u32>, Config::Info<int>, Config::Info<bool>>;
+  using OptionVariant = std::variant<u32, int, bool>;
+
+public:
+  ConfigComplexChoice(const InfoVariant setting1, const InfoVariant setting2);
+
+  void Add(const QString& name, const OptionVariant option1, const OptionVariant option2);
+  void Refresh();
+  void Reset();
+
+private:
+  void SaveValue(int choice);
+  void UpdateComboIndex();
+  const std::pair<Config::Location, Config::Location> GetLocation() const;
+
+  InfoVariant m_setting1;
+  InfoVariant m_setting2;
+  std::vector<std::pair<OptionVariant, OptionVariant>> m_options;
+};

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -9,13 +9,11 @@
 
 class ConfigBool;
 class ConfigChoice;
+class ConfigComplexChoice;
+class ConfigStringChoice;
 class ConfigSlider;
 class GraphicsWindow;
-class QCheckBox;
-class QComboBox;
 class QPushButton;
-class QSlider;
-class ToolTipComboBox;
 class ToolTipPushButton;
 enum class StereoMode : int;
 
@@ -26,22 +24,22 @@ public:
   explicit EnhancementsWidget(GraphicsWindow* parent);
 
 private:
-  void LoadSettings();
-  void SaveSettings();
-
   void CreateWidgets();
   void ConnectWidgets();
   void AddDescriptions();
+
+  void OnBackendChanged();
+  void LoadPPShaders();
+
   void ConfigureColorCorrection();
   void ConfigurePostProcessingShader();
-  void LoadPPShaders(StereoMode stereo_mode);
 
   // Enhancements
   ConfigChoice* m_ir_combo;
-  ToolTipComboBox* m_aa_combo;
-  ToolTipComboBox* m_texture_filtering_combo;
-  ToolTipComboBox* m_output_resampling_combo;
-  ToolTipComboBox* m_pp_effect;
+  ConfigComplexChoice* m_aa_combo;
+  ConfigComplexChoice* m_texture_filtering_combo;
+  ConfigChoice* m_output_resampling_combo;
+  ConfigStringChoice* m_pp_effect;
   ToolTipPushButton* m_configure_color_correction;
   QPushButton* m_configure_pp_effect;
   ConfigBool* m_scaled_efb_copy;
@@ -59,7 +57,4 @@ private:
   ConfigSlider* m_3d_convergence;
   ConfigBool* m_3d_swap_eyes;
   ConfigBool* m_3d_per_eye_resolution;
-
-  int m_msaa_modes;
-  bool m_block_save;
 };


### PR DESCRIPTION
Split from https://github.com/dolphin-emu/dolphin/pull/13063 and improved.  My other PR was crashing on Mac and I couldn't find the issue, so thought splitting it up would help. I don't expect this to show any crashes, because the crash in the other PR was after destroying a new graphics option window.  This is just for the normal GraphicsSettings window that never gets destroyed after being created.

Switching to ConfigControls cleans up the loading/saving and connections. I moved every enabled state that relies on checking for backend support to OnBackendChanged.

Made a new ConfigComplexChoice for ComboBoxes that use two settings at once, like anti-aliasing.

Should not alter the behavior of the UI.