### PR TITLE
Add missing algorithm header in SettingsHandlerTest.cpp

### DIFF
--- a/Source/UnitTests/Common/SettingsHandlerTest.cpp
+++ b/Source/UnitTests/Common/SettingsHandlerTest.cpp
@@ -1,6 +1,8 @@
 // Copyright 2024 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+
 #include <gtest/gtest.h>
 
 #include "Common/SettingsHandler.h"


### PR DESCRIPTION
This is needed for `std::ranges::equal()`, on Windows with CMake compilation fails otherwise.