### PR TITLE
JitBlockTableModel: Catch All Block Invalidating Events (I Hope)

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -146,7 +146,7 @@ void Host_UpdateDisasmDialog()
 {
 }
 
-void Host_JitCacheCleared()
+void Host_JitCacheInvalidation()
 {
 }
 

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -17,6 +17,7 @@
 
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
+#include "Core/Host.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
@@ -196,6 +197,7 @@ static Installation InstallCodeHandlerLocked(const Core::CPUThreadGuard& guard)
   {
     ppc_state.iCache.Invalidate(memory, jit_interface, INSTALLER_BASE_ADDRESS + j);
   }
+  Host_JitCacheInvalidation();
   return Installation::Installed;
 }
 

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -16,6 +16,7 @@
 #include "Core/HLE/HLE_Misc.h"
 #include "Core/HLE/HLE_OS.h"
 #include "Core/HW/Memmap.h"
+#include "Core/Host.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -74,6 +75,7 @@ void Patch(Core::System& system, u32 addr, std::string_view func_name)
     {
       s_hooked_addresses[addr] = i;
       ppc_state.iCache.Invalidate(memory, jit_interface, addr);
+      Host_JitCacheInvalidation();
       return;
     }
   }
@@ -144,6 +146,8 @@ void PatchFunctions(Core::System& system)
       INFO_LOG_FMT(OSHLE, "Patching {} {:08x}", os_patches[i].name, symbol->address);
     }
   }
+
+  Host_JitCacheInvalidation();
 }
 
 void Clear()
@@ -264,6 +268,7 @@ u32 UnPatch(Core::System& system, std::string_view patch_name)
         ++i;
       }
     }
+    Host_JitCacheInvalidation();
     return addr;
   }
 
@@ -276,6 +281,7 @@ u32 UnPatch(Core::System& system, std::string_view patch_name)
       s_hooked_addresses.erase(addr);
       ppc_state.iCache.Invalidate(memory, jit_interface, addr);
     }
+    Host_JitCacheInvalidation();
     return symbol->address;
   }
 
@@ -299,6 +305,7 @@ u32 UnpatchRange(Core::System& system, u32 start_addr, u32 end_addr)
     i = s_hooked_addresses.erase(i);
     count += 1;
   }
+  Host_JitCacheInvalidation();
 
   return count;
 }

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -60,7 +60,7 @@ void Host_PPCSymbolsChanged();
 void Host_RefreshDSPDebuggerWindow();
 void Host_RequestRenderWindowSize(int width, int height);
 void Host_UpdateDisasmDialog();
-void Host_JitCacheCleared();
+void Host_JitCacheInvalidation();
 void Host_JitProfileDataWiped();
 void Host_UpdateMainFrame();
 void Host_UpdateTitle(const std::string& title);

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -442,7 +442,7 @@ void CachedInterpreter::ClearCache()
   ClearCodeSpace();
   ResetFreeMemoryRanges();
   RefreshConfig();
-  Host_JitCacheCleared();
+  Host_JitCacheInvalidation();
 }
 
 void CachedInterpreter::LogGeneratedCode() const

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -313,7 +313,7 @@ void Jit64::ClearCache()
   RefreshConfig();
   asm_routines.Regenerate();
   ResetFreeMemoryRanges();
-  Host_JitCacheCleared();
+  Host_JitCacheInvalidation();
 }
 
 void Jit64::FreeRanges()

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -197,7 +197,7 @@ void JitArm64::GenerateAsmAndResetFreeMemoryRanges()
   ResetFreeMemoryRanges(routines_near_end - routines_near_start,
                         routines_far_end - routines_far_start);
 
-  Host_JitCacheCleared();
+  Host_JitCacheInvalidation();
 }
 
 void JitArm64::FreeRanges()

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -57,6 +57,7 @@ static void InvalidateCacheThreadSafe(Core::System& system, u64 userdata, s64 cy
 {
   system.GetPPCState().iCache.Invalidate(system.GetMemory(), system.GetJitInterface(),
                                          static_cast<u32>(userdata));
+  Host_JitCacheInvalidation();
 }
 
 PowerPCManager::PowerPCManager(Core::System& system)
@@ -296,6 +297,7 @@ void PowerPCManager::ScheduleInvalidateCacheThreadSafe(u32 address)
   {
     m_ppc_state.iCache.Invalidate(m_system.GetMemory(), m_system.GetJitInterface(),
                                   static_cast<u32>(address));
+    Host_JitCacheInvalidation();
   }
 }
 

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -86,7 +86,7 @@ void Host_UpdateDisasmDialog()
 {
 }
 
-void Host_JitCacheCleared()
+void Host_JitCacheInvalidation()
 {
 }
 

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -313,7 +313,7 @@ void JITWidget::SaveQSettings() const
 void JITWidget::ConnectSlots()
 {
   auto* const host = Host::GetInstance();
-  connect(host, &Host::JitCacheCleared, this, &JITWidget::OnJitCacheCleared);
+  connect(host, &Host::JitCacheInvalidation, this, &JITWidget::OnJitCacheInvalidation);
   connect(host, &Host::UpdateDisasmDialog, this, &JITWidget::OnUpdateDisasmDialog);
   connect(host, &Host::PPCSymbolsChanged, this, &JITWidget::OnPPCSymbolsUpdated);
   connect(host, &Host::PPCBreakpointsChanged, this, &JITWidget::OnPPCBreakpointsChanged);
@@ -326,7 +326,7 @@ void JITWidget::ConnectSlots()
 void JITWidget::DisconnectSlots()
 {
   auto* const host = Host::GetInstance();
-  disconnect(host, &Host::JitCacheCleared, this, &JITWidget::OnJitCacheCleared);
+  disconnect(host, &Host::JitCacheInvalidation, this, &JITWidget::OnJitCacheInvalidation);
   disconnect(host, &Host::UpdateDisasmDialog, this, &JITWidget::OnUpdateDisasmDialog);
   disconnect(host, &Host::PPCSymbolsChanged, this, &JITWidget::OnPPCSymbolsUpdated);
   disconnect(host, &Host::PPCBreakpointsChanged, this, &JITWidget::OnPPCBreakpointsChanged);
@@ -340,7 +340,7 @@ void JITWidget::Show()
 {
   ConnectSlots();
   // Handle every slot that may have missed a signal while this widget was hidden.
-  // OnJitCacheCleared() can be skipped.
+  // OnJitCacheInvalidation() can be skipped.
   // OnUpdateDisasmDialog() can be skipped.
   // OnPPCSymbolsUpdated() can be skipped.
   // OnPPCBreakpointsChanged() can be skipped.
@@ -446,7 +446,7 @@ void JITWidget::OnStatusBarPressed()
     ShowFreeMemoryStatus();
 }
 
-void JITWidget::OnJitCacheCleared()
+void JITWidget::OnJitCacheInvalidation()
 {
   if (Core::GetState(m_system) != Core::State::Paused)
     return;

--- a/Source/Core/DolphinQt/Debugger/JITWidget.h
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.h
@@ -102,7 +102,7 @@ private:
   void OnStatusBarPressed();
 
   // Conditionally connected slots (external signals)
-  void OnJitCacheCleared();
+  void OnJitCacheInvalidation();
   void OnUpdateDisasmDialog();
   void OnPPCSymbolsUpdated();
   void OnPPCBreakpointsChanged();

--- a/Source/Core/DolphinQt/Debugger/JitBlockTableModel.cpp
+++ b/Source/Core/DolphinQt/Debugger/JitBlockTableModel.cpp
@@ -187,7 +187,9 @@ void JitBlockTableModel::OnUpdateDisasmDialog()
 
 void JitBlockTableModel::OnPPCSymbolsUpdated()
 {
-  UpdateSymbols();
+  // Previously, this was only a call to `UpdateSymbols`, but HLE patch engine code can
+  // invalidate JIT blocks when specific symbols are loaded. What can be done about it?
+  Update(Core::GetState(m_system));
 }
 
 void JitBlockTableModel::OnPPCBreakpointsChanged()

--- a/Source/Core/DolphinQt/Debugger/JitBlockTableModel.cpp
+++ b/Source/Core/DolphinQt/Debugger/JitBlockTableModel.cpp
@@ -112,7 +112,7 @@ void JitBlockTableModel::UpdateSymbols()
 void JitBlockTableModel::ConnectSlots()
 {
   auto* const host = Host::GetInstance();
-  connect(host, &Host::JitCacheCleared, this, &JitBlockTableModel::OnJitCacheCleared);
+  connect(host, &Host::JitCacheInvalidation, this, &JitBlockTableModel::OnJitCacheInvalidation);
   connect(host, &Host::JitProfileDataWiped, this, &JitBlockTableModel::OnJitProfileDataWiped);
   connect(host, &Host::UpdateDisasmDialog, this, &JitBlockTableModel::OnUpdateDisasmDialog);
   connect(host, &Host::PPCSymbolsChanged, this, &JitBlockTableModel::OnPPCSymbolsUpdated);
@@ -125,7 +125,7 @@ void JitBlockTableModel::ConnectSlots()
 void JitBlockTableModel::DisconnectSlots()
 {
   auto* const host = Host::GetInstance();
-  disconnect(host, &Host::JitCacheCleared, this, &JitBlockTableModel::OnJitCacheCleared);
+  disconnect(host, &Host::JitCacheInvalidation, this, &JitBlockTableModel::OnJitCacheInvalidation);
   disconnect(host, &Host::JitProfileDataWiped, this, &JitBlockTableModel::OnJitProfileDataWiped);
   disconnect(host, &Host::UpdateDisasmDialog, this, &JitBlockTableModel::OnUpdateDisasmDialog);
   disconnect(host, &Host::PPCSymbolsChanged, this, &JitBlockTableModel::OnPPCSymbolsUpdated);
@@ -169,7 +169,7 @@ void JitBlockTableModel::OnFilterSymbolTextChanged(const QString& string)
   m_filtering_by_symbols = !string.isEmpty();
 }
 
-void JitBlockTableModel::OnJitCacheCleared()
+void JitBlockTableModel::OnJitCacheInvalidation()
 {
   Update(Core::GetState(m_system));
 }

--- a/Source/Core/DolphinQt/Debugger/JitBlockTableModel.h
+++ b/Source/Core/DolphinQt/Debugger/JitBlockTableModel.h
@@ -106,7 +106,7 @@ private:
   void Hide();
 
   // Conditionally connected slots (external signals)
-  void OnJitCacheCleared();
+  void OnJitCacheInvalidation();
   void OnJitProfileDataWiped();
   void OnUpdateDisasmDialog();
   void OnPPCSymbolsUpdated();

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -256,9 +256,9 @@ void Host_UpdateDisasmDialog()
   QueueOnObject(QApplication::instance(), [] { emit Host::GetInstance()->UpdateDisasmDialog(); });
 }
 
-void Host_JitCacheCleared()
+void Host_JitCacheInvalidation()
 {
-  QueueOnObject(QApplication::instance(), [] { emit Host::GetInstance()->JitCacheCleared(); });
+  QueueOnObject(QApplication::instance(), [] { emit Host::GetInstance()->JitCacheInvalidation(); });
 }
 
 void Host_JitProfileDataWiped()

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -40,7 +40,7 @@ signals:
   void RequestStop();
   void RequestRenderSize(int w, int h);
   void UpdateDisasmDialog();
-  void JitCacheCleared();
+  void JitCacheInvalidation();
   void JitProfileDataWiped();
   void PPCSymbolsChanged();
   void PPCBreakpointsChanged();

--- a/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
+++ b/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
@@ -61,7 +61,7 @@ void Host_UpdateDisasmDialog()
 {
 }
 
-void Host_JitCacheCleared()
+void Host_JitCacheInvalidation()
 {
 }
 

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -41,7 +41,7 @@ bool Host_UpdateDiscordPresenceRaw(const std::string& details, const std::string
 void Host_UpdateDisasmDialog()
 {
 }
-void Host_JitCacheCleared()
+void Host_JitCacheInvalidation()
 {
 }
 void Host_JitProfileDataWiped()

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -41,7 +41,7 @@ bool Host_UpdateDiscordPresenceRaw(const std::string& details, const std::string
 void Host_UpdateDisasmDialog()
 {
 }
-void Host_JitCacheCleared()
+void Host_JitCacheInvalidation()
 {
 }
 void Host_JitProfileDataWiped()


### PR DESCRIPTION
It was brought to my attention that loading symbols causes the HLE patch engine to invalidate JIT blocks, potentially leading to stale references in `JitBlockTableModel`. Upon further examination, I noticed a few other places I failed to consider could cause stale references, so I addressed those as well. The "solution" of simply putting `Host_JitCacheInvalidation` in many disparate places across the codebase is not ideal, but I unfortunately cannot emit this signal from the JitCache's `InvalidateICache`(`Line`) functions because those functions gets called by `icbi`/`dcbi`/etc. tens of thousands of times whenever booting most software. I am actively pursuing a better solution, but I'd rather not leave my latest merged project with such a glaring flaw for too long, especially when considering the November release coming up.