### PR TITLE
JitArm64_LoadStore: Small dcbx optimization

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -816,9 +816,8 @@ void JitArm64::dcbx(UGeckoInstruction inst)
     STR(IndexType::Unsigned, loop_counter, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
 
     // downcount -= (WA * reg_cycle_count)
-    MUL(WB, WA, reg_cycle_count);
+    MSUB(reg_downcount, WA, reg_cycle_count, reg_downcount);
     // ^ Note that this cannot overflow because it's limited by (downcount/cycle_count).
-    SUB(reg_downcount, reg_downcount, WB);
     STR(IndexType::Unsigned, reg_downcount, PPC_REG, PPCSTATE_OFF(downcount));
 
     SetJumpTarget(downcount_is_zero_or_negative);


### PR DESCRIPTION
MUL and SUB can be combined in one instruction.

Before:
```
0x1b1a7c01   mul    w1, w0, w26
0x4b010318   sub    w24, w24, w1
```

After:
```
0x1b1ae018   msub   w24, w0, w26, w24
```