### PR TITLE
Force NetPlay Clients to Host Hardcore Status

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -16,6 +16,7 @@
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/CommonPaths.h"
+#include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
 #include "Common/Image.h"
@@ -64,6 +65,7 @@ void AchievementManager::Init()
                              [](const char* message, const rc_client_t* client) {
                                INFO_LOG_FMT(ACHIEVEMENTS, "{}", message);
                              });
+    Config::AddConfigChangedCallback([this] { SetHardcoreMode(); });
     SetHardcoreMode();
     m_queue.Reset("AchievementManagerQueue", [](const std::function<void()>& func) { func(); });
     m_image_queue.Reset("AchievementManagerImageQueue",

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -11,6 +11,7 @@
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
 
+#include "Core/Config/AchievementSettings.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
@@ -33,6 +34,9 @@ public:
     layer->Set(Config::MAIN_CPU_THREAD, m_settings.cpu_thread);
     layer->Set(Config::MAIN_CPU_CORE, m_settings.cpu_core);
     layer->Set(Config::MAIN_ENABLE_CHEATS, m_settings.enable_cheats);
+#ifdef USE_RETRO_ACHIEVEMENTS
+    layer->Set(Config::RA_HARDCORE_ENABLED, m_settings.enable_hardcore);
+#endif  // USE_RETRO_ACHIEVEMENTS
     layer->Set(Config::MAIN_GC_LANGUAGE, m_settings.selected_language);
     layer->Set(Config::MAIN_OVERRIDE_REGION_SETTINGS, m_settings.override_region_settings);
     layer->Set(Config::MAIN_DSP_HLE, m_settings.dsp_hle);

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -848,6 +848,7 @@ void NetPlayClient::OnStartGame(sf::Packet& packet)
     packet >> m_net_settings.cpu_thread;
     packet >> m_net_settings.cpu_core;
     packet >> m_net_settings.enable_cheats;
+    packet >> m_net_settings.enable_hardcore;
     packet >> m_net_settings.selected_language;
     packet >> m_net_settings.override_region_settings;
     packet >> m_net_settings.dsp_enable_jit;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -35,6 +35,7 @@ struct NetSettings
   bool cpu_thread = false;
   PowerPC::CPUCore cpu_core{};
   bool enable_cheats = false;
+  bool enable_hardcore = false;
   int selected_language = 0;
   bool override_region_settings = false;
   bool dsp_hle = false;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -31,6 +31,7 @@
 #include "Common/UPnP.h"
 #include "Common/Version.h"
 
+#include "Core/AchievementManager.h"
 #include "Core/ActionReplay.h"
 #include "Core/Boot/Boot.h"
 #include "Core/Config/GraphicsSettings.h"
@@ -1358,6 +1359,7 @@ bool NetPlayServer::SetupNetSettings()
   settings.cpu_thread = Config::Get(Config::MAIN_CPU_THREAD);
   settings.cpu_core = Config::Get(Config::MAIN_CPU_CORE);
   settings.enable_cheats = Config::AreCheatsEnabled();
+  settings.enable_hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
   settings.selected_language = Config::Get(Config::MAIN_GC_LANGUAGE);
   settings.override_region_settings = Config::Get(Config::MAIN_OVERRIDE_REGION_SETTINGS);
   settings.dsp_hle = Config::Get(Config::MAIN_DSP_HLE);
@@ -1586,6 +1588,7 @@ bool NetPlayServer::StartGame()
   spac << m_settings.cpu_thread;
   spac << m_settings.cpu_core;
   spac << m_settings.enable_cheats;
+  spac << m_settings.enable_hardcore;
   spac << m_settings.selected_language;
   spac << m_settings.override_region_settings;
   spac << m_settings.dsp_enable_jit;

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -329,7 +329,6 @@ void AchievementSettingsWidget::ToggleProgress()
 
 void AchievementSettingsWidget::UpdateHardcoreMode()
 {
-  AchievementManager::GetInstance().SetHardcoreMode();
   if (Config::Get(Config::RA_HARDCORE_ENABLED))
   {
     Settings::Instance().SetDebugModeEnabled(false);


### PR DESCRIPTION
If the host is in hardcore mode, all joining players will be set to hardcore mode; if not, all joining players will be set to softcore.