### PR TITLE
GameSettings: add patch to fix Eternal Darkness startup hang

### DIFF
--- a/Data/Sys/GameSettings/GED.ini
+++ b/Data/Sys/GameSettings/GED.ini
@@ -1,4 +1,4 @@
-# GEDE01, GEDP01 - Eternal Darkness
+# GEDE01, GEDP01, GEDJ01, GEDW01 - Eternal Darkness
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/GEDE01.ini
+++ b/Data/Sys/GameSettings/GEDE01.ini
@@ -1,0 +1,8 @@
+# GEDE01 - Eternal Darkness
+
+[OnFrame]
+$Fix startup hang
+0x801EF444:dword:0x480371ED
+
+[OnFrame_Enabled]
+$Fix startup hang

--- a/Data/Sys/GameSettings/GEDJ01.ini
+++ b/Data/Sys/GameSettings/GEDJ01.ini
@@ -1,0 +1,8 @@
+# GEDJ01 - Eternal Darkness
+
+[OnFrame]
+$Fix startup hang
+0x801E4588:dword:0x48036E71
+
+[OnFrame_Enabled]
+$Fix startup hang

--- a/Data/Sys/GameSettings/GEDP01.ini
+++ b/Data/Sys/GameSettings/GEDP01.ini
@@ -1,0 +1,8 @@
+# GEDP01 - Eternal Darkness
+
+[OnFrame]
+$Fix startup hang
+0x801E3BC4:dword:0x48036F15
+
+[OnFrame_Enabled]
+$Fix startup hang

--- a/Data/Sys/GameSettings/GEDW01.ini
+++ b/Data/Sys/GameSettings/GEDW01.ini
@@ -1,0 +1,8 @@
+# GEDW01 - Eternal Darkness
+
+[OnFrame]
+$Fix startup hang
+0x801BE42C:dword:0x48036E65
+
+[OnFrame_Enabled]
+$Fix startup hang


### PR DESCRIPTION
The game calls GXSetDrawDone and then switches the GP fifo without first waiting for the draw done interrupt to arrive. Before e96960e2a678f072f316173c80650897013fb99c, Dolphin would not execute the draw done command and potentially also skip other commands in the old GP fifo. Since that commit, Dolphin executes the remaining commands on the old GP fifo just before disabling reads for switching, but because PixelEngineManager::RaiseEvent() enforces a minimum delay of 500 cycles for the draw done interrupt, it arrives after the game has switched to the new GP fifo which seems to trigger the deadlock.

This patch replaces the call to GXSetDrawDone by a call to GXDrawDone which does the same but also waits for the interrupt.