### PR TITLE
ControllerInterface/SDL: Disable SDL's Windows.Gaming.Input controller handling.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -441,6 +441,8 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
   // We want buttons to come in as positions, not labels
   SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0");
+  // We have our own WGI backend. Enabling SDL's WGI handling creates even more redundant devices.
+  SDL_SetHint(SDL_HINT_JOYSTICK_WGI, "0");
 
   m_hotplug_thread = std::thread([this] {
     Common::ScopeGuard quit_guard([] {


### PR DESCRIPTION
Before:
![Screenshot 2024-10-30 174249](https://github.com/user-attachments/assets/129368b5-9ecd-4b5e-9f90-a2403e4c65b0)

After:
![Screenshot 2024-10-30 174355](https://github.com/user-attachments/assets/a5a6f3b7-5b1e-47e7-967c-ae089b40ac50)

We're still exposing XInput and WGInput *and* SDL (using XInput). But it's an improvement.