### PR TITLE
DolphinQt: Rename "GameCube Adapter for Wii U".

### DIFF
--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -34,7 +34,8 @@ using SIDeviceName = std::pair<SerialInterface::SIDevices, const char*>;
 static constexpr std::array s_gc_types = {
     SIDeviceName{SerialInterface::SIDEVICE_NONE, _trans("None")},
     SIDeviceName{SerialInterface::SIDEVICE_GC_CONTROLLER, _trans("Standard Controller")},
-    SIDeviceName{SerialInterface::SIDEVICE_WIIU_ADAPTER, _trans("GameCube Adapter for Wii U")},
+    SIDeviceName{SerialInterface::SIDEVICE_WIIU_ADAPTER,
+                 _trans("GameCube Controller Adapter (USB)")},
     SIDeviceName{SerialInterface::SIDEVICE_GC_STEERING, _trans("Steering Wheel")},
     SIDeviceName{SerialInterface::SIDEVICE_DANCEMAT, _trans("Dance Mat")},
     SIDeviceName{SerialInterface::SIDEVICE_GC_TARUKONGA, _trans("DK Bongos")},

--- a/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.cpp
@@ -32,7 +32,7 @@ GCPadWiiUConfigDialog::~GCPadWiiUConfigDialog()
 
 void GCPadWiiUConfigDialog::CreateLayout()
 {
-  setWindowTitle(tr("GameCube Adapter for Wii U at Port %1").arg(m_port + 1));
+  setWindowTitle(tr("GameCube Controller Adapter at Port %1").arg(m_port + 1));
 
   m_layout = new QVBoxLayout();
   m_status_label = new QLabel();


### PR DESCRIPTION
"GameCube Adapter for Wii U" is an outdated and confusing name.

Nintendo seems to currently name the device, "GameCube™ Controller Adapter".
![image](https://github.com/user-attachments/assets/38162f05-9d82-4482-a7b9-598e29a51baa)

I added "(USB)" to hopefully prevent confusion with the "Standard Controller".
![image](https://github.com/user-attachments/assets/1c2de0e5-68c5-446d-bd55-9c47d118957e)

Renaming this is somewhat of a blocker for #10489.

I'm open to other suggestions.