### PR TITLE
DolphinQt/InputCommon: Make input mapping and output testing non-blocking.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
@@ -12,11 +12,10 @@
 #include <QString>
 #include <QSyntaxHighlighter>
 
-#include "Common/Flag.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
 class ControlReference;
-class MappingWidget;
+class MappingWindow;
 class QAbstractButton;
 class QDialogButtonBox;
 class QLineEdit;
@@ -66,8 +65,12 @@ public:
     Output
   };
 
-  explicit IOWindow(MappingWidget* parent, ControllerEmu::EmulatedController* m_controller,
+  explicit IOWindow(MappingWindow* window, ControllerEmu::EmulatedController* m_controller,
                     ControlReference* ref, Type type);
+
+signals:
+  void DetectInputComplete();
+  void TestOutputComplete();
 
 private:
   std::shared_ptr<ciface::Core::Device> GetSelectedDevice() const;
@@ -79,8 +82,6 @@ private:
 
   void OnDialogButtonPressed(QAbstractButton* button);
   void OnDeviceChanged();
-  void OnDetectButtonPressed();
-  void OnTestButtonPressed();
   void OnRangeChanged(int range);
 
   void AppendSelectedOption();
@@ -115,10 +116,12 @@ private:
 
   // Input actions
   QPushButton* m_detect_button;
+  std::unique_ptr<ciface::Core::InputDetector> m_input_detector;
   QComboBox* m_functions_combo;
 
   // Output actions
   QPushButton* m_test_button;
+  QTimer* m_output_test_timer;
 
   // Textarea
   QPlainTextEdit* m_expression_text;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include "Common/Flag.h"
 #include "DolphinQt/QtUtils/ElidedButton.h"
 
 class ControlReference;
 class MappingWidget;
+class MappingWindow;
 class QEvent;
 class QMouseEvent;
 
@@ -18,16 +18,21 @@ public:
   MappingButton(MappingWidget* widget, ControlReference* ref, bool indicator);
 
   bool IsInput() const;
+  ControlReference* GetControlReference();
+  void StartMapping();
+
+signals:
+  void ConfigChanged();
 
 private:
   void Clear();
   void UpdateIndicator();
-  void ConfigChanged();
   void AdvancedPressed();
 
   void Clicked();
   void mouseReleaseEvent(QMouseEvent* event) override;
 
-  MappingWidget* m_parent;
-  ControlReference* m_reference;
+  MappingWindow* const m_mapping_window;
+  ControlReference* const m_reference;
+  bool m_is_mapping = false;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
@@ -3,23 +3,14 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
+#include <chrono>
 
-#include "InputCommon/ControllerInterface/CoreDevice.h"
-#include "InputCommon/ControllerInterface/MappingCommon.h"
-
-class QString;
-class OutputReference;
-class QPushButton;
+class MappingWindow;
 
 namespace MappingCommon
 {
-QString DetectExpression(QPushButton* button, ciface::Core::DeviceContainer& device_container,
-                         const std::vector<std::string>& device_strings,
-                         const ciface::Core::DeviceQualifier& default_device,
-                         ciface::MappingCommon::Quote quote = ciface::MappingCommon::Quote::On);
+// A slight delay improves behavior when "clicking" the detect button via key-press.
+static constexpr auto INPUT_DETECT_INITIAL_DELAY = std::chrono::milliseconds{100};
 
-void TestOutput(QPushButton* button, OutputReference* reference);
-
+void CreateMappingProcessor(MappingWindow*);
 }  // namespace MappingCommon

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -20,7 +20,6 @@
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
-#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h"
@@ -340,10 +339,10 @@ MappingWidget::CreateSettingAdvancedMappingButton(ControllerEmu::NumericSettingB
       setting.SetExpressionFromValue();
 
     // Ensure the UI has the game-controller indicator while editing the expression.
+    // And cancel in-progress mappings.
     ConfigChanged();
 
-    IOWindow io(this, GetController(), &setting.GetInputReference(), IOWindow::Type::Input);
-    SetQWidgetWindowDecorations(&io);
+    IOWindow io(GetParent(), GetController(), &setting.GetInputReference(), IOWindow::Type::Input);
     io.exec();
 
     setting.SimplifyIfPossible();

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -3,15 +3,10 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
-
 #include <QString>
 #include <QWidget>
 
-class ControlGroupBox;
 class InputConfig;
-class MappingButton;
 class MappingNumeric;
 class MappingWindow;
 class QFormLayout;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -41,6 +41,7 @@
 #include "DolphinQt/Config/Mapping/HotkeyTAS.h"
 #include "DolphinQt/Config/Mapping/HotkeyUSBEmu.h"
 #include "DolphinQt/Config/Mapping/HotkeyWii.h"
+#include "DolphinQt/Config/Mapping/MappingCommon.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtension.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionSimulation.h"
@@ -93,6 +94,8 @@ MappingWindow::MappingWindow(QWidget* parent, Type type, int port_num)
                   [] { HotkeyManagerEmu::Enable(true); });
   filter->connect(filter, &WindowActivationEventFilter::windowActivated,
                   [] { HotkeyManagerEmu::Enable(false); });
+
+  MappingCommon::CreateMappingProcessor(this);
 }
 
 void MappingWindow::CreateDevicesLayout()
@@ -185,9 +188,8 @@ void MappingWindow::CreateMainLayout()
 
 void MappingWindow::ConnectWidgets()
 {
-  connect(&Settings::Instance(), &Settings::DevicesChanged, this,
-          &MappingWindow::OnGlobalDevicesChanged);
-  connect(this, &MappingWindow::ConfigChanged, this, &MappingWindow::OnGlobalDevicesChanged);
+  connect(&Settings::Instance(), &Settings::DevicesChanged, this, &MappingWindow::ConfigChanged);
+  connect(this, &MappingWindow::ConfigChanged, this, &MappingWindow::UpdateDeviceList);
   connect(m_devices_combo, &QComboBox::currentIndexChanged, this, &MappingWindow::OnSelectDevice);
 
   connect(m_reset_clear, &QPushButton::clicked, this, &MappingWindow::OnClearFieldsPressed);
@@ -203,6 +205,8 @@ void MappingWindow::ConnectWidgets()
   // We currently use the "Close" button as an "Accept" button so we must save on reject.
   connect(this, &QDialog::rejected, [this] { emit Save(); });
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  connect(m_tab_widget, &QTabWidget::currentChanged, this, &MappingWindow::CancelMapping);
 }
 
 void MappingWindow::UpdateProfileIndex()
@@ -345,6 +349,8 @@ void MappingWindow::OnSelectDevice(int)
   const auto device = m_devices_combo->currentData().toString().toStdString();
 
   m_controller->SetDefaultDevice(device);
+
+  emit ConfigChanged();
   m_controller->UpdateReferences(g_controller_interface);
 }
 
@@ -358,7 +364,7 @@ void MappingWindow::RefreshDevices()
   g_controller_interface.RefreshDevices();
 }
 
-void MappingWindow::OnGlobalDevicesChanged()
+void MappingWindow::UpdateDeviceList()
 {
   const QSignalBlocker blocker(m_devices_combo);
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -5,9 +5,6 @@
 
 #include <QDialog>
 #include <QString>
-#include <memory>
-
-#include "InputCommon/ControllerInterface/CoreDevice.h"
 
 namespace ControllerEmu
 {
@@ -15,6 +12,8 @@ class EmulatedController;
 }
 
 class InputConfig;
+class MappingButton;
+
 class QComboBox;
 class QDialogButtonBox;
 class QEvent;
@@ -58,9 +57,13 @@ public:
 signals:
   // Emitted when config has changed so widgets can update to reflect the change.
   void ConfigChanged();
-  // Emitted at 30hz for real-time indicators to be updated.
+  // Emitted at INDICATOR_UPDATE_FREQ Hz for real-time indicators to be updated.
   void Update();
   void Save();
+
+  void UnQueueInputDetection(MappingButton*);
+  void QueueInputDetection(MappingButton*);
+  void CancelMapping();
 
 private:
   void SetMappingType(Type type);
@@ -82,11 +85,11 @@ private:
   void UpdateProfileIndex();
   void UpdateProfileButtonState();
   void PopulateProfileSelection();
+  void UpdateDeviceList();
 
   void OnDefaultFieldsPressed();
   void OnClearFieldsPressed();
   void OnSelectDevice(int index);
-  void OnGlobalDevicesChanged();
 
   ControllerEmu::EmulatedController* m_controller = nullptr;
 

--- a/Source/Core/DolphinQt/QtUtils/BlockUserInputFilter.cpp
+++ b/Source/Core/DolphinQt/QtUtils/BlockUserInputFilter.cpp
@@ -3,12 +3,34 @@
 
 #include "DolphinQt/QtUtils/BlockUserInputFilter.h"
 
-#include <QEvent>
+#include <chrono>
 
-bool BlockUserInputFilter::eventFilter(QObject* object, QEvent* event)
+#include <QEvent>
+#include <QTimer>
+
+namespace QtUtils
 {
-  const QEvent::Type event_type = event->type();
-  return event_type == QEvent::KeyPress || event_type == QEvent::KeyRelease ||
-         event_type == QEvent::MouseButtonPress || event_type == QEvent::MouseButtonRelease ||
-         event_type == QEvent::MouseButtonDblClick;
+
+// Leave filter active for a bit to prevent Return/Space detection from reactivating the button.
+constexpr auto REMOVAL_DELAY = std::chrono::milliseconds{100};
+
+BlockKeyboardInputFilter::BlockKeyboardInputFilter(QObject* parent) : QObject{parent}
+{
+  parent->installEventFilter(this);
 }
+
+void BlockKeyboardInputFilter::ScheduleRemoval()
+{
+  auto* const timer = new QTimer(this);
+  timer->setSingleShot(true);
+  connect(timer, &QTimer::timeout, [this] { delete this; });
+  timer->start(REMOVAL_DELAY);
+}
+
+bool BlockKeyboardInputFilter::eventFilter(QObject* object, QEvent* event)
+{
+  const auto event_type = event->type();
+  return event_type == QEvent::KeyPress || event_type == QEvent::KeyRelease;
+}
+
+}  // namespace QtUtils

--- a/Source/Core/DolphinQt/QtUtils/BlockUserInputFilter.h
+++ b/Source/Core/DolphinQt/QtUtils/BlockUserInputFilter.h
@@ -5,14 +5,26 @@
 
 #include <QObject>
 
-class QEvent;
+namespace QtUtils
+{
 
-class BlockUserInputFilter : public QObject
+class BlockKeyboardInputFilter : public QObject
 {
   Q_OBJECT
 public:
-  using QObject::QObject;
+  BlockKeyboardInputFilter(QObject* parent);
+  void ScheduleRemoval();
 
 private:
   bool eventFilter(QObject* object, QEvent* event) override;
 };
+
+template <typename T>
+void InstallKeyboardBlocker(QObject* obj, T* removal_signal_object, void (T::*removal_signal)())
+{
+  removal_signal_object->connect(removal_signal_object, removal_signal,
+                                 new QtUtils::BlockKeyboardInputFilter{obj},
+                                 &QtUtils::BlockKeyboardInputFilter::ScheduleRemoval);
+}
+
+}  // namespace QtUtils

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -346,6 +346,20 @@ auto DeviceContainer::DetectInput(const std::vector<std::string>& device_strings
                                   std::chrono::milliseconds maximum_wait) const
     -> std::vector<InputDetection>
 {
+  InputDetector input_detector;
+  input_detector.Start(*this, device_strings);
+
+  while (!input_detector.IsComplete())
+  {
+    Common::SleepCurrentThread(10);
+    input_detector.Update(initial_wait, confirmation_wait, maximum_wait);
+  }
+
+  return input_detector.TakeResults();
+}
+
+struct InputDetector::Impl
+{
   struct InputState
   {
     InputState(ciface::Core::Device::Input* input_) : input{input_} { stats.Push(0.0); }
@@ -355,7 +369,7 @@ auto DeviceContainer::DetectInput(const std::vector<std::string>& device_strings
     ControlState last_state = initial_state;
     MathUtil::RunningVariance<ControlState> stats;
 
-    // Prevent multiiple detections until after release.
+    // Prevent multiple detections until after release.
     bool is_ready = true;
 
     void Update()
@@ -392,18 +406,32 @@ auto DeviceContainer::DetectInput(const std::vector<std::string>& device_strings
     std::vector<InputState> input_states;
   };
 
-  // Acquire devices and initial input states.
   std::vector<DeviceState> device_states;
+};
+
+InputDetector::InputDetector() : m_start_time{}, m_state{}
+{
+}
+
+void InputDetector::Start(const DeviceContainer& container,
+                          const std::vector<std::string>& device_strings)
+
+{
+  m_start_time = Clock::now();
+  m_detections = {};
+  m_state = std::make_unique<Impl>();
+
+  // Acquire devices and initial input states.
   for (const auto& device_string : device_strings)
   {
     DeviceQualifier dq;
     dq.FromString(device_string);
-    auto device = FindDevice(dq);
+    auto device = container.FindDevice(dq);
 
     if (!device)
       continue;
 
-    std::vector<InputState> input_states;
+    std::vector<Impl::InputState> input_states;
 
     for (auto* input : device->Inputs())
     {
@@ -413,38 +441,42 @@ auto DeviceContainer::DetectInput(const std::vector<std::string>& device_strings
 
       // Undesirable axes will have negative values here when trying to map a
       // "FullAnalogSurface".
-      input_states.push_back(InputState{input});
+      input_states.push_back(Impl::InputState{input});
     }
 
     if (!input_states.empty())
-      device_states.emplace_back(DeviceState{std::move(device), std::move(input_states)});
+    {
+      m_state->device_states.emplace_back(
+          Impl::DeviceState{std::move(device), std::move(input_states)});
+    }
   }
 
-  if (device_states.empty())
-    return {};
+  // If no inputs were found via the supplied device strings, immediately complete.
+  if (m_state->device_states.empty())
+    m_state.reset();
+}
 
-  std::vector<InputDetection> detections;
-
-  const auto start_time = Clock::now();
-  while (true)
+void InputDetector::Update(std::chrono::milliseconds initial_wait,
+                           std::chrono::milliseconds confirmation_wait,
+                           std::chrono::milliseconds maximum_wait)
+{
+  if (m_state)
   {
     const auto now = Clock::now();
-    const auto elapsed_time = now - start_time;
+    const auto elapsed_time = now - m_start_time;
 
-    if (elapsed_time >= maximum_wait || (detections.empty() && elapsed_time >= initial_wait) ||
-        (!detections.empty() && detections.back().release_time.has_value() &&
-         now >= *detections.back().release_time + confirmation_wait))
+    if (elapsed_time >= maximum_wait || (m_detections.empty() && elapsed_time >= initial_wait) ||
+        (!m_detections.empty() && m_detections.back().release_time.has_value() &&
+         now >= *m_detections.back().release_time + confirmation_wait))
     {
-      break;
+      m_state.reset();
+      return;
     }
 
-    Common::SleepCurrentThread(10);
-
-    for (auto& device_state : device_states)
+    for (auto& device_state : m_state->device_states)
     {
-      for (std::size_t i = 0; i != device_state.input_states.size(); ++i)
+      for (auto& input_state : device_state.input_states)
       {
-        auto& input_state = device_state.input_states[i];
         input_state.Update();
 
         if (input_state.IsPressed())
@@ -456,26 +488,42 @@ auto DeviceContainer::DetectInput(const std::vector<std::string>& device_strings
           const auto smoothness =
               1 / std::sqrt(input_state.stats.Variance() / input_state.stats.Mean());
 
-          InputDetection new_detection;
+          Detection new_detection;
           new_detection.device = device_state.device;
           new_detection.input = input_state.input;
           new_detection.press_time = Clock::now();
           new_detection.smoothness = smoothness;
 
           // We found an input. Add it to our detections.
-          detections.emplace_back(std::move(new_detection));
+          m_detections.emplace_back(std::move(new_detection));
         }
       }
     }
 
     // Check for any releases of our detected inputs.
-    for (auto& d : detections)
+    for (auto& d : m_detections)
     {
       if (!d.release_time.has_value() && d.input->GetState() < (1 - INPUT_DETECT_THRESHOLD))
         d.release_time = Clock::now();
     }
   }
-
-  return detections;
 }
+
+InputDetector::~InputDetector() = default;
+
+bool InputDetector::IsComplete() const
+{
+  return !m_state;
+}
+
+auto InputDetector::GetResults() const -> const std::vector<Detection>&
+{
+  return m_detections;
+}
+
+auto InputDetector::TakeResults() -> std::vector<Detection>
+{
+  return std::move(m_detections);
+}
+
 }  // namespace ciface::Core

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -245,5 +245,32 @@ protected:
   mutable std::recursive_mutex m_devices_mutex;
   std::vector<std::shared_ptr<Device>> m_devices;
 };
+
+class InputDetector
+{
+public:
+  using Detection = DeviceContainer::InputDetection;
+
+  InputDetector();
+  ~InputDetector();
+
+  void Start(const DeviceContainer& container, const std::vector<std::string>& device_strings);
+  void Update(std::chrono::milliseconds initial_wait, std::chrono::milliseconds confirmation_wait,
+              std::chrono::milliseconds maximum_wait);
+  bool IsComplete() const;
+
+  const std::vector<Detection>& GetResults() const;
+
+  // move-return'd to prevent copying.
+  std::vector<Detection> TakeResults();
+
+private:
+  struct Impl;
+
+  Clock::time_point m_start_time;
+  std::vector<Detection> m_detections;
+  std::unique_ptr<Impl> m_state;
+};
+
 }  // namespace Core
 }  // namespace ciface


### PR DESCRIPTION
Normal Mapping Window:
Multiple input mappings can be queued/un-queued/cleared without the UI blocking.
This allows for quicker batch input mapping for power users.
Mapping a mouse-click itself requires clicking *not* on a mapping button.
Each mapping button interaction resets the timeout.
Waiting for the timeout cancels all queued input mappings.
Interacting with the window in other ways cancels in-progress mappings appropriately.

https://github.com/user-attachments/assets/86bd87a9-4740-4068-8f5d-b3bf52bd991f

"Advanced" Window:
The live previews now update while detecting inputs.
Button labels are renamed to be more clear.

https://github.com/user-attachments/assets/97cbf69d-4d38-452c-9725-09f5668a8efb

Output/Rumble test in the "Advanced" window is also now non-blocking.
Clicking it while active will stop the rumble test.

Overall, mapping window interaction is less terrible when input detection is non-blocking.
