### PR TITLE
InputCommon: Rename AddAnalogInputs to AddFullAnalogSurfaceInputs.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -693,7 +693,7 @@ private:
         negative = new AndroidAxis(source, axis, true);
 
       if (positive && negative)
-        AddAnalogInputs(positive, negative);
+        AddFullAnalogSurfaceInputs(positive, negative);
       else if (positive || negative)
         AddInput(positive ? positive : negative);
     }

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -164,6 +164,14 @@ bool Device::FullAnalogSurface::IsMatchingName(std::string_view name) const
   return old_name == name;
 }
 
+void Device::AddFullAnalogSurfaceInputs(Input* low, Input* high)
+{
+  AddInput(low);
+  AddInput(high);
+  AddInput(new FullAnalogSurface(low, high));
+  AddInput(new FullAnalogSurface(high, low));
+}
+
 void Device::AddCombinedInput(std::string name, const std::pair<std::string, std::string>& inputs)
 {
   AddInput(new CombinedInput(std::move(name), {FindInput(inputs.first), FindInput(inputs.second)}));

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -130,39 +130,43 @@ bool Device::Control::IsHidden() const
   return false;
 }
 
-ControlState Device::FullAnalogSurface::GetState() const
+class FullAnalogSurface final : public Device::Input
 {
-  return (1 + std::max(0.0, m_high.GetState()) - std::max(0.0, m_low.GetState())) / 2;
-}
+public:
+  FullAnalogSurface(Input* low, Input* high) : m_low(*low), m_high(*high) {}
 
-std::string Device::FullAnalogSurface::GetName() const
-{
-  // E.g. "Full Axis X+"
-  return "Full " + m_high.GetName();
-}
+  ControlState GetState() const override
+  {
+    return (1 + std::max(0.0, m_high.GetState()) - std::max(0.0, m_low.GetState())) / 2;
+  }
 
-bool Device::FullAnalogSurface::IsDetectable() const
-{
-  return m_low.IsDetectable() && m_high.IsDetectable();
-}
+  std::string GetName() const override
+  {
+    // E.g. "Full Axis X+"
+    return "Full " + m_high.GetName();
+  }
 
-bool Device::FullAnalogSurface::IsHidden() const
-{
-  return m_low.IsHidden() && m_high.IsHidden();
-}
+  bool IsDetectable() const override { return m_low.IsDetectable() && m_high.IsDetectable(); }
 
-bool Device::FullAnalogSurface::IsMatchingName(std::string_view name) const
-{
-  if (Control::IsMatchingName(name))
-    return true;
+  bool IsHidden() const override { return m_low.IsHidden() && m_high.IsHidden(); }
 
-  // Old naming scheme was "Axis X-+" which is too visually similar to "Axis X+".
-  // This has caused countless problems for users with mysterious misconfigurations.
-  // We match this old name to support old configurations.
-  const auto old_name = m_low.GetName() + *m_high.GetName().rbegin();
+  bool IsMatchingName(std::string_view name) const override
+  {
+    if (Control::IsMatchingName(name))
+      return true;
 
-  return old_name == name;
-}
+    // Old naming scheme was "Axis X-+" which is too visually similar to "Axis X+".
+    // This has caused countless problems for users with mysterious misconfigurations.
+    // We match this old name to support old configurations.
+    const auto old_name = m_low.GetName() + *m_high.GetName().rbegin();
+
+    return old_name == name;
+  }
+
+private:
+  Input& m_low;
+  Input& m_high;
+};
 
 void Device::AddFullAnalogSurfaceInputs(Input* low, Input* high)
 {

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -178,13 +178,14 @@ protected:
     Input& m_high;
   };
 
-  void AddAnalogInputs(Input* low, Input* high)
-  {
-    AddInput(low);
-    AddInput(high);
-    AddInput(new FullAnalogSurface(low, high));
-    AddInput(new FullAnalogSurface(high, low));
-  }
+  // Pass Inputs for center-neutral (- and +) directions of some axis.
+  // This function adds those Inputs and also a FullAnalogSurface Input for each direction.
+  // This is only needed when it's not known if the particular axis is neutral in the center
+  //  or neutral on one of the extremes.
+  // Some e.g. DInput devices expose a trigger across the full analog surface
+  //  but we have no way of knowing this until the user actually maps the Input,
+  //  so both center-neutral and full-surface Inputs need to be created in that case.
+  void AddFullAnalogSurfaceInputs(Input* low, Input* high);
 
   void AddCombinedInput(std::string name, const std::pair<std::string, std::string>& inputs);
 

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -163,21 +163,6 @@ protected:
   void AddInput(Input* const i);
   void AddOutput(Output* const o);
 
-  class FullAnalogSurface final : public Input
-  {
-  public:
-    FullAnalogSurface(Input* low, Input* high) : m_low(*low), m_high(*high) {}
-    ControlState GetState() const override;
-    std::string GetName() const override;
-    bool IsDetectable() const override;
-    bool IsHidden() const override;
-    bool IsMatchingName(std::string_view name) const override;
-
-  private:
-    Input& m_low;
-    Input& m_high;
-  };
-
   // Pass Inputs for center-neutral (- and +) directions of some axis.
   // This function adds those Inputs and also a FullAnalogSurface Input for each direction.
   // This is only needed when it's not known if the particular axis is neutral in the center

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -167,8 +167,8 @@ Joystick::Joystick(const LPDIRECTINPUTDEVICE8 device) : m_device(device)
       const LONG& ax = (&m_state_in.lX)[offset];
 
       // each axis gets a negative and a positive input instance associated with it
-      AddAnalogInputs(new Axis(offset, ax, base, range.lMin - base),
-                      new Axis(offset, ax, base, range.lMax - base));
+      AddFullAnalogSurfaceInputs(new Axis(offset, ax, base, range.lMin - base),
+                                 new Axis(offset, ax, base, range.lMax - base));
     }
   }
 

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -129,7 +129,7 @@ void PipeDevice::AddAxis(const std::string& name, double value)
   ax_lo->SetState(value);
   m_axes[name + " +"] = ax_hi;
   m_axes[name + " -"] = ax_lo;
-  AddAnalogInputs(ax_lo, ax_hi);
+  AddFullAnalogSurfaceInputs(ax_lo, ax_hi);
 }
 
 void PipeDevice::SetAxis(const std::string& entry, double value)

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -710,8 +710,8 @@ GameController::GameController(SDL_GameController* const gamecontroller,
     const bool is_registered = registered_axes.contains(i);
 
     // each axis gets a negative and a positive input instance associated with it
-    AddAnalogInputs(new LegacyAxis(m_joystick, i, -32768, is_registered),
-                    new LegacyAxis(m_joystick, i, 32767, is_registered));
+    AddFullAnalogSurfaceInputs(new LegacyAxis(m_joystick, i, -32768, is_registered),
+                               new LegacyAxis(m_joystick, i, 32767, is_registered));
   }
 
   // Hats

--- a/Source/Core/InputCommon/ControllerInterface/WGInput/WGInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/WGInput/WGInput.cpp
@@ -125,9 +125,8 @@ public:
         u32 i = 0;
         for (auto& axis : m_axes)
         {
-          // AddAnalogInputs adds additional "FullAnalogSurface" Inputs.
-          AddAnalogInputs(new IndexedAxis(&axis, 0.5, +0.5, i),
-                          new IndexedAxis(&axis, 0.5, -0.5, i));
+          AddFullAnalogSurfaceInputs(new IndexedAxis(&axis, 0.5, +0.5, i),
+                                     new IndexedAxis(&axis, 0.5, -0.5, i));
           ++i;
         }
       }

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -572,7 +572,8 @@ bool evdevDevice::AddNode(std::string devnode, int fd, libevdev* dev)
   {
     if (libevdev_has_event_code(dev, EV_ABS, axis))
     {
-      AddAnalogInputs(new Axis(num_axis, axis, false, dev), new Axis(num_axis, axis, true, dev));
+      AddFullAnalogSurfaceInputs(new Axis(num_axis, axis, false, dev),
+                                 new Axis(num_axis, axis, true, dev));
       ++num_axis;
     }
   }


### PR DESCRIPTION
The old `AddAnalogInputs` name unsurprisingly confused people in the past.
I renamed the function and explained its use in a comment.