### PR TITLE
InputCommon: Disable Player LED for DualSense Controllers by default

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -435,6 +435,9 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
   // We want buttons to come in as positions, not labels
   SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0");
 
+  // Disable DualSense Player LEDs; We already colorize the Primary LED
+  SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED, "0");
+
   m_hotplug_thread = std::thread([this] {
     Common::ScopeGuard quit_guard([] {
       // TODO: there seems to be some sort of memory leak with SDL, quit isn't freeing everything up


### PR DESCRIPTION
Disables the DualSense controller's Player LED.
Does not apply to Android, as Android itself manages the Player LED.

System default before Dolphin runs (windows/linux)
![sysdefault](https://github.com/user-attachments/assets/15f4bdc7-dcf7-4fbf-8e31-f03038b952e6)

When Dolphin runs (before change)
![before](https://github.com/user-attachments/assets/e48a36c1-239c-4bf6-bc35-7b74d038cc0d)

When Dolphin runs (after change)
![after](https://github.com/user-attachments/assets/8bcee738-63d4-4547-84b2-3fd772641439)

----

## Rationale
* There is no option to disable the Player LEDs currently.
* The player LED is exceptional bright (and its a white LED). This is distracting/bright when playing in low lighting conditions.
* You can already tell which player is which due to the customized primary LED colors.
* I've seen people use SteamInput or DS4Windows specifically to turn off the Player LED. This alleviates users having to do that.


In the future I would like to build a UI to allow customization of the Primary LEDs, and at that point I'd add in a Player LED toggle.

In the interim though, I think this is a reasonable and fast change.