### PR TITLE
DolphinQt: DualSense Player LED Toggle

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -487,6 +487,7 @@ const Info<bool> MAIN_MOVIE_SHOW_RERECORD{{System::Main, "Movie", "ShowRerecord"
 // Main.Input
 
 const Info<bool> MAIN_INPUT_BACKGROUND_INPUT{{System::Main, "Input", "BackgroundInput"}, false};
+const Info<bool> MAIN_INPUT_SDL_PS5_PLAYER_LED{{System::Main, "Input", "SDLPS5PlayerLED"}, false};
 
 // Main.Debug
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -320,6 +320,7 @@ extern const Info<bool> MAIN_MOVIE_SHOW_RERECORD;
 // Main.Input
 
 extern const Info<bool> MAIN_INPUT_BACKGROUND_INPUT;
+extern const Info<bool> MAIN_INPUT_SDL_PS5_PLAYER_LED;
 
 // Main.Debug
 

--- a/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
@@ -33,10 +33,12 @@ void CommonControllersWidget::CreateLayout()
   m_common_box = new QGroupBox(tr("Common"));
   m_common_layout = new QVBoxLayout();
   m_common_bg_input = new QCheckBox(tr("Background Input"));
+  m_common_sdl_ps5_player_led = new QCheckBox(tr("Enable DualSense Player LED"));
   m_common_configure_controller_interface =
       new NonDefaultQPushButton(tr("Alternate Input Sources"));
 
   m_common_layout->addWidget(m_common_bg_input);
+  m_common_layout->addWidget(m_common_sdl_ps5_player_led);
   m_common_layout->addWidget(m_common_configure_controller_interface);
 
   m_common_box->setLayout(m_common_layout);
@@ -51,6 +53,8 @@ void CommonControllersWidget::CreateLayout()
 void CommonControllersWidget::ConnectWidgets()
 {
   connect(m_common_bg_input, &QCheckBox::toggled, this, &CommonControllersWidget::SaveSettings);
+  connect(m_common_sdl_ps5_player_led, &QCheckBox::toggled, this,
+          &CommonControllersWidget::SaveSettings);
   connect(m_common_configure_controller_interface, &QPushButton::clicked, this,
           &CommonControllersWidget::OnControllerInterfaceConfigure);
 }
@@ -67,10 +71,14 @@ void CommonControllersWidget::OnControllerInterfaceConfigure()
 void CommonControllersWidget::LoadSettings()
 {
   SignalBlocking(m_common_bg_input)->setChecked(Config::Get(Config::MAIN_INPUT_BACKGROUND_INPUT));
+  SignalBlocking(m_common_sdl_ps5_player_led)
+      ->setChecked(Config::Get(Config::MAIN_INPUT_SDL_PS5_PLAYER_LED));
 }
 
 void CommonControllersWidget::SaveSettings()
 {
   Config::SetBaseOrCurrent(Config::MAIN_INPUT_BACKGROUND_INPUT, m_common_bg_input->isChecked());
+  Config::SetBaseOrCurrent(Config::MAIN_INPUT_SDL_PS5_PLAYER_LED,
+                           m_common_sdl_ps5_player_led->isChecked());
   Config::Save();
 }

--- a/Source/Core/DolphinQt/Config/CommonControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/CommonControllersWidget.h
@@ -30,5 +30,6 @@ private:
   QGroupBox* m_common_box;
   QVBoxLayout* m_common_layout;
   QCheckBox* m_common_bg_input;
+  QCheckBox* m_common_sdl_ps5_player_led;
   QPushButton* m_common_configure_controller_interface;
 };

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -14,6 +14,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 #include "Common/ScopeGuard.h"
+#include "Core/Config/MainSettings.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 #ifdef _WIN32
@@ -287,6 +288,7 @@ public:
 
 private:
   void OpenAndAddDevice(int index);
+  void SetPS5PlayerLED();
 
   bool HandleEventAndContinue(const SDL_Event& e);
 
@@ -437,11 +439,13 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
   // We have our own WGI backend. Enabling SDL's WGI handling creates even more redundant devices.
   SDL_SetHint(SDL_HINT_JOYSTICK_WGI, "0");
 
-  // Disable DualSense Player LEDs; We already colorize the Primary LED
-  SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED, "0");
+  const Config::ConfigChangedCallbackID config_changed_callback_id =
+      Config::AddConfigChangedCallback([this] { SetPS5PlayerLED(); });
+  SetPS5PlayerLED();
 
-  m_hotplug_thread = std::thread([this] {
-    Common::ScopeGuard quit_guard([] {
+  m_hotplug_thread = std::thread([this, config_changed_callback_id] {
+    Common::ScopeGuard quit_guard([config_changed_callback_id] {
+      Config::RemoveConfigChangedCallback(config_changed_callback_id);
       // TODO: there seems to be some sort of memory leak with SDL, quit isn't freeing everything up
       SDL_Quit();
     });
@@ -528,6 +532,12 @@ void InputBackend::PopulateDevices()
 
   SDL_Event populate_event{m_populate_event_type};
   SDL_PushEvent(&populate_event);
+}
+
+void InputBackend::SetPS5PlayerLED()
+{
+  SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED,
+              Config::Get(Config::MAIN_INPUT_SDL_PS5_PLAYER_LED) ? "1" : "0");
 }
 
 struct SDLMotionAxis


### PR DESCRIPTION
Add DualSense Player LED toggle to Controller Settings

![image](https://github.com/user-attachments/assets/d809c42d-84e9-4396-879b-34da87dba862)


Remaining issues:
[x] Pulls in SDL header (with a weird include path) ✅  RESOLVED
[x] Pulls in Config header to SDL.cpp (for init setting; rather than waiting until the Controller Settinsg Window opens)  ✅  RESOLVED
[x] Does it make sense for the toggle to be in Common? In the future a Primary LED customization window/widget will be added; but until then this toggle must live somewhere. || Decided to open new PR https://github.com/dolphin-emu/dolphin/pull/13198 to resolve this. We can merge as is if we want to expose the setting early before the design change.