### PR TITLE
IOS/USB: Reconnect HIDv4 Devices after shutdown

### DIFF
--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -96,10 +96,11 @@ std::optional<IPCReply> USB_HIDv4::GetDeviceChange(const IOCtlRequest& request)
   m_devicechange_hook_request = std::make_unique<IOCtlRequest>(GetSystem(), request.address);
   // If there are pending changes, the reply is sent immediately (instead of on device
   // insertion/removal).
-  if (m_has_pending_changes)
+  if (m_has_pending_changes || m_is_shut_down)
   {
     TriggerDeviceChangeReply();
     m_has_pending_changes = false;
+    m_is_shut_down = false;
   }
   return std::nullopt;
 }
@@ -114,6 +115,7 @@ IPCReply USB_HIDv4::Shutdown(const IOCtlRequest& request)
     memory.Write_U32(0xffffffff, m_devicechange_hook_request->buffer_out);
     GetEmulationKernel().EnqueueIPCReply(*m_devicechange_hook_request, -1);
     m_devicechange_hook_request.reset();
+    m_is_shut_down = true;
   }
   return IPCReply(IPC_SUCCESS);
 }

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
@@ -45,6 +45,7 @@ private:
   static constexpr u8 HID_CLASS = 0x03;
 
   bool m_has_pending_changes = true;
+  bool m_is_shut_down = false;
   std::mutex m_devicechange_hook_address_mutex;
   std::unique_ptr<IOCtlRequest> m_devicechange_hook_request;
 


### PR DESCRIPTION
Between races during Skylanders Superchargers Racing (with both a real and the emulated portal), the game calls IOCTL_USBV4_SHUTDOWN, which then removes from memory references to connected devices. When the next race begins, the game calls IOCTL_USBV4_GETVERSION, then IOCTL_USBV4_GETDEVICECHANGE, however because we haven't added or removed a device manually, TriggerDeviceChangeReply is not called to populate the references in memory to the already attached devices. I have added a new flag that is set to true when Shutdown is called, so that we call  TriggerDeviceChangeReply after shutdown during gameplay.

Fixes https://bugs.dolphin-emu.org/issues/13282