### PR TITLE
DolphinQt: Display more user-friendly names in the mapping window device list.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -59,6 +59,22 @@
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 #include "InputCommon/InputConfig.h"
 
+namespace
+{
+
+QString GetUserFriendlyDeviceName(const std::string& str)
+{
+  ciface::Core::DeviceQualifier qualifier;
+  qualifier.FromString(str);
+
+  return QStringLiteral("%1 (%2) %3")
+      .arg(QString::fromStdString(qualifier.name))
+      .arg(qualifier.cid + 1)
+      .arg(QString::fromStdString(qualifier.source));
+}
+
+}  // namespace
+
 MappingWindow::MappingWindow(QWidget* parent, Type type, int port_num)
     : QDialog(parent), m_port(port_num)
 {
@@ -363,8 +379,9 @@ void MappingWindow::OnGlobalDevicesChanged()
 
   for (const auto& name : g_controller_interface.GetAllDeviceStrings())
   {
+    const auto display_name = GetUserFriendlyDeviceName(name);
     const auto qname = QString::fromStdString(name);
-    m_devices_combo->addItem(qname, qname);
+    m_devices_combo->addItem(display_name, qname);
   }
 
   const auto default_device = m_controller->GetDefaultDevice().ToString();
@@ -372,7 +389,7 @@ void MappingWindow::OnGlobalDevicesChanged()
   if (!default_device.empty())
   {
     const auto default_device_index =
-        m_devices_combo->findText(QString::fromStdString(default_device));
+        m_devices_combo->findData(QString::fromStdString(default_device));
 
     if (default_device_index != -1)
     {
@@ -382,9 +399,10 @@ void MappingWindow::OnGlobalDevicesChanged()
     {
       // Selected device is not currently attached.
       m_devices_combo->insertSeparator(m_devices_combo->count());
+      const auto display_name = GetUserFriendlyDeviceName(default_device);
       const auto qname = QString::fromStdString(default_device);
-      m_devices_combo->addItem(QLatin1Char{'['} + tr("disconnected") + QStringLiteral("] ") + qname,
-                               qname);
+      m_devices_combo->addItem(
+          QLatin1Char{'['} + tr("disconnected") + QStringLiteral("] ") + display_name, qname);
       m_devices_combo->setCurrentIndex(m_devices_combo->count() - 1);
     }
   }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/cce4b5f5-cff6-4bb4-ba11-54115bef6e4b)

After:
![image](https://github.com/user-attachments/assets/db5e18f9-6b6d-4d78-8fd5-ee543f797b13)

I think the `SDL/0/DualSense` text is too weird and technical looking for a typical user.

The information is now reversed with device name first and backend name last.
Device index has one added for 1-based numbering.

This is only a UI change, config names remain unchanged.

The advanced window also remains unchanged.
This creates a 0-based/1-based numbering discrepancy, but since the config names can end up in the input expression I think it's appropriate to have that match the device list shown here for "advanced" users.

Open to opinions on the situation.