### PR TITLE
ControllerEmu: Remove nunchuk stick data hax.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -67,30 +67,10 @@ void Nunchuk::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   DataFormat nc_data = {};
 
   // stick
-  bool override_occurred = false;
   const ControllerEmu::AnalogStick::StateData stick_state =
-      m_stick->GetState(m_input_override_function, &override_occurred);
+      m_stick->GetState(m_input_override_function);
   nc_data.jx = MapFloat<u8>(stick_state.x, STICK_CENTER, 0, STICK_RANGE);
   nc_data.jy = MapFloat<u8>(stick_state.y, STICK_CENTER, 0, STICK_RANGE);
-
-  if (!override_occurred)
-  {
-    // Some terribly coded games check whether to move with a check like
-    //
-    //     if (x != 0 && y != 0)
-    //         do_movement(x, y);
-    //
-    // With keyboard controls, these games break if you simply hit one
-    // of the axes. Adjust this if you're hitting one of the axes so that
-    // we slightly tweak the other axis.
-    if (nc_data.jx != STICK_CENTER || nc_data.jy != STICK_CENTER)
-    {
-      if (nc_data.jx == STICK_CENTER)
-        ++nc_data.jx;
-      if (nc_data.jy == STICK_CENTER)
-        ++nc_data.jy;
-    }
-  }
 
   // buttons
   u8 buttons = 0;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -51,13 +51,6 @@ AnalogStick::StateData AnalogStick::GetState() const
 
 AnalogStick::StateData AnalogStick::GetState(const InputOverrideFunction& override_func) const
 {
-  bool override_occurred = false;
-  return GetState(override_func, &override_occurred);
-}
-
-AnalogStick::StateData AnalogStick::GetState(const InputOverrideFunction& override_func,
-                                             bool* override_occurred) const
-{
   StateData state = GetState();
   if (!override_func)
     return state;
@@ -65,13 +58,11 @@ AnalogStick::StateData AnalogStick::GetState(const InputOverrideFunction& overri
   if (const std::optional<ControlState> x_override = override_func(name, X_INPUT_OVERRIDE, state.x))
   {
     state.x = *x_override;
-    *override_occurred = true;
   }
 
   if (const std::optional<ControlState> y_override = override_func(name, Y_INPUT_OVERRIDE, state.y))
   {
     state.y = *y_override;
-    *override_occurred = true;
   }
 
   return state;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -22,7 +22,6 @@ public:
 
   StateData GetState() const;
   StateData GetState(const InputOverrideFunction& override_func) const;
-  StateData GetState(const InputOverrideFunction& override_func, bool* override_occurred) const;
 
 private:
   Control* GetModifierInput() const override;


### PR DESCRIPTION
This hack was introduced 11 years ago in https://github.com/dolphin-emu/dolphin/commit/9b20280bcff0b31b1deb4a5b3e6560ac853b40e7

They claimed some "programs" don't properly detect movement if the Nunchuk stick is pushed perfectly vertically or horizontally.
The old commit message said "it's expected by some emulated programs".
Which "programs"?

I find it somewhat hard to believe any legitimate game behaves in this manner.
It would be apparent on real hardware.

If it turns out these games actually exist, we can add the hack back with a proper comment mentioning the actual problem-game.