### PR TITLE
Core/VideoCommon: Fix some weird (!eof) logic.

### DIFF
--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -776,14 +776,11 @@ bool DSPAssembler::AssemblePass(const std::string& text, int pass)
   m_location.line_num = 0;
   m_cur_pass = pass;
 
-#define LINEBUF_SIZE 1024
-  char line[LINEBUF_SIZE] = {0};
-  while (!m_failed && !fsrc.fail() && !fsrc.eof())
+  constexpr int LINEBUF_SIZE = 1024;
+  char line[LINEBUF_SIZE] = {};
+  while (!m_failed && fsrc.getline(line, LINEBUF_SIZE))
   {
     int opcode_size = 0;
-    fsrc.getline(line, LINEBUF_SIZE);
-    if (fsrc.fail())
-      break;
 
     m_location.line_text = line;
     m_location.line_num++;

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -137,43 +137,40 @@ void PostProcessingConfiguration::LoadOptions(const std::string& code)
 
   std::vector<GLSLStringOption> option_strings;
   GLSLStringOption* current_strings = nullptr;
-  while (!in.eof())
+  std::string line_str;
+  while (std::getline(in, line_str))
   {
-    std::string line_str;
-    if (std::getline(in, line_str))
-    {
-      std::string_view line = line_str;
+    std::string_view line = line_str;
 
 #ifndef _WIN32
-      // Check for CRLF eol and convert it to LF
-      if (!line.empty() && line.at(line.size() - 1) == '\r')
-        line.remove_suffix(1);
+    // Check for CRLF eol and convert it to LF
+    if (!line.empty() && line.at(line.size() - 1) == '\r')
+      line.remove_suffix(1);
 #endif
 
-      if (!line.empty())
+    if (!line.empty())
+    {
+      if (line[0] == '[')
       {
-        if (line[0] == '[')
-        {
-          size_t endpos = line.find("]");
+        size_t endpos = line.find("]");
 
-          if (endpos != std::string::npos)
-          {
-            // New section!
-            std::string_view sub = line.substr(1, endpos - 1);
-            option_strings.push_back({std::string(sub)});
-            current_strings = &option_strings.back();
-          }
+        if (endpos != std::string::npos)
+        {
+          // New section!
+          std::string_view sub = line.substr(1, endpos - 1);
+          option_strings.push_back({std::string(sub)});
+          current_strings = &option_strings.back();
         }
-        else
+      }
+      else
+      {
+        if (current_strings)
         {
-          if (current_strings)
-          {
-            std::string key, value;
-            Common::IniFile::ParseLine(line, &key, &value);
+          std::string key, value;
+          Common::IniFile::ParseLine(line, &key, &value);
 
-            if (!(key.empty() && value.empty()))
-              current_strings->m_options.emplace_back(key, value);
-          }
+          if (!(key.empty() && value.empty()))
+            current_strings->m_options.emplace_back(key, value);
         }
       }
     }


### PR DESCRIPTION
Logic of the form, `while (!eof)`, is almost always "wrong".

The success of the actual read needs to be tested, which may or may not trigger eof.

The three pieces of code I found with `while (!eof)` did *also* test that the read was successful, so the behavior was correct, but the `eof` checks were still unnecessary and made the loops awkward.