### PR TITLE
ProcessorInterface: sync GPU just before PI_FIFO_RESET

### DIFF
--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -98,6 +98,10 @@ void ProcessorInterfaceManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                    {
                      system.GetGPFifo().ResetGatherPipe();
 
+                     // Assume that all bytes that made it into the GPU fifo did in fact execute
+                     // before this MMIO write takes effect.
+                     system.GetFifo().SyncGPUForRegisterAccess();
+
                      // Call Fifo::ResetVideoBuffer() from the video thread. Since that function
                      // resets various pointers used by the video thread, we can't call it directly
                      // from the CPU thread, so queue a task to do it instead. In single-core mode,


### PR DESCRIPTION
GXAbortFrame() is problematic for Dolphin because it first writes PI_FIFO_RESET (for which we discard our internal fifo), then disables CP reads (for which we execute pending commands in the GP fifo in emulated memory). I don't know whether there is a race condition on hardware, but there is one for us. Avoid this by also doing a GPU sync here.

Fixes regression from #13115:
- New Super Mario Bros Wii (shutdown)

Fixes errors that existed even before #13115:
- Deadliest Catch - Sea of Chaos (startup)
- The Oregon Trail (startup)
- Monster 4x4 - World Circuit (startup)
- G.I. Joe - The Rise of Cobra (shutdown)

Does not fix existing errors in:
- NCIS - The Game (vertex size mismatch when triggering shutdown during strap reminder, presumably a game bug)
- SpongeBob SquarePants featuring Nicktoons - Globs of Doom (shutdown)
- Resident Evil (startup, PAL only, XFB/fifo overlap)
- SSX Tricky (startup, PAL only, XFB/fifo overlap)
- MaxPlay Classic Games (startup)