### PR TITLE
gitignore: Ignore flatpak-builder's cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ CMakeLists.txt.user
 .idea/
 # Ignore Visual Studio Code's working dir
 /.vscode/
+# Ignore flatpak-builder's cache dir
+.flatpak-builder


### PR DESCRIPTION
[See the command reference for more information.](https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html#idm384)