### PR TITLE
GDBStub: Signal Breakpoint Changes To Host

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -101,6 +101,10 @@ void Host_PPCSymbolsChanged()
 {
 }
 
+void Host_PPCBreakpointsChanged()
+{
+}
+
 void Host_RefreshDSPDebuggerWindow()
 {
 }

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -57,6 +57,7 @@ bool Host_TASInputHasFocus();
 
 void Host_Message(HostMessageID id);
 void Host_PPCSymbolsChanged();
+void Host_PPCBreakpointsChanged();
 void Host_RefreshDSPDebuggerWindow();
 void Host_RequestRenderWindowSize(int width, int height);
 void Host_UpdateDisasmDialog();

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -178,6 +178,7 @@ static void RemoveBreakpoint(BreakpointType type, u32 addr, u32 len)
       INFO_LOG_FMT(GDB_STUB, "gdb: removed a memcheck: {:08x} bytes at {:08x}", len, addr);
     }
   }
+  Host_PPCBreakpointsChanged();
 }
 
 static void Nack()
@@ -896,6 +897,7 @@ static bool AddBreakpoint(BreakpointType type, u32 addr, u32 len)
     INFO_LOG_FMT(GDB_STUB, "gdb: added {} memcheck: {:08x} bytes at {:08x}", static_cast<int>(type),
                  len, addr);
   }
+  Host_PPCBreakpointsChanged();
   return true;
 }
 

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -61,6 +61,10 @@ void Host_PPCSymbolsChanged()
 {
 }
 
+void Host_PPCBreakpointsChanged()
+{
+}
+
 void Host_RefreshDSPDebuggerWindow()
 {
 }

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -271,6 +271,12 @@ void Host_PPCSymbolsChanged()
   QueueOnObject(QApplication::instance(), [] { emit Host::GetInstance()->PPCSymbolsChanged(); });
 }
 
+void Host_PPCBreakpointsChanged()
+{
+  QueueOnObject(QApplication::instance(),
+                [] { emit Host::GetInstance()->PPCBreakpointsChanged(); });
+}
+
 // We ignore these, and their purpose should be questioned individually.
 // In particular, RequestRenderWindowSize, RequestFullscreen, and
 // UpdateMainFrame should almost certainly be removed.

--- a/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
+++ b/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
@@ -25,6 +25,10 @@ void Host_PPCSymbolsChanged()
 {
 }
 
+void Host_PPCBreakpointsChanged()
+{
+}
+
 void Host_RefreshDSPDebuggerWindow()
 {
 }

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -16,6 +16,9 @@ std::vector<std::string> Host_GetPreferredLocales()
 void Host_PPCSymbolsChanged()
 {
 }
+void Host_PPCBreakpointsChanged()
+{
+}
 void Host_RefreshDSPDebuggerWindow()
 {
 }

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -16,6 +16,9 @@ std::vector<std::string> Host_GetPreferredLocales()
 void Host_PPCSymbolsChanged()
 {
 }
+void Host_PPCBreakpointsChanged()
+{
+}
 void Host_RefreshDSPDebuggerWindow()
 {
 }


### PR DESCRIPTION
The GDB stub is capable of adding and removing breakpoints. Failing to signal here:
- Leaves the breakpoint, code, and memory widgets with outdated visual information.
- Potentially leaves the JIT widget with stale references to invalidated JIT blocks. (eek!)

I opted against creating the `Host_PPCBreakpointsChanged` function during https://github.com/dolphin-emu/dolphin/pull/13065 because nothing needed it then, but now something does.