### PR TITLE
Externals: Update SDL to 2.30.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,7 +585,7 @@ if(UNIX)
 endif()
 
 if(ENABLE_SDL)
-  dolphin_find_optional_system_library(SDL2 Externals/SDL 2.30.6)
+  dolphin_find_optional_system_library(SDL2 Externals/SDL 2.30.9)
 endif()
 
 if(ENABLE_ANALYTICS)

--- a/Externals/SDL/CMakeLists.txt
+++ b/Externals/SDL/CMakeLists.txt
@@ -9,7 +9,7 @@ option(SDL_TEST "Build the SDL2_test library" OFF)
 option(SDL_TEST_ENABLED_BY_DEFAULT "" OFF)
 
 # SDL fails to clean up old headers after version upgrades, so do that manually
-set(EXPECTED_SDL_REVISION "SDL-release-2.30.6-0")
+set(EXPECTED_SDL_REVISION "SDL-release-2.30.9-0")
 if (EXISTS "${CMAKE_CURRENT_BINARY_DIR}/SDL/include/SDL2/SDL_revision.h")
   file(READ "${CMAKE_CURRENT_BINARY_DIR}/SDL/include/SDL2/SDL_revision.h" ACTUAL_SDL_REVISION)
   if (NOT "${ACTUAL_SDL_REVISION}" MATCHES "${EXPECTED_SDL_REVISION}")

--- a/Flatpak/SDL2/SDL2.json
+++ b/Flatpak/SDL2/SDL2.json
@@ -1,0 +1,21 @@
+{
+  "name": "SDL2",
+  "buildsystem": "autotools",
+  "config-opts": ["--disable-static"],
+  "sources": [
+    {
+      "type": "dir",
+      "path": "../../Externals/SDL/SDL"
+    }
+  ],
+  "cleanup": [ "/bin/sdl2-config",
+               "/include",
+               "/lib/libSDL2.la",
+               "/lib/libSDL2main.a",
+               "/lib/libSDL2main.la",
+               "/lib/libSDL2_test.a",
+               "/lib/libSDL2_test.la",
+               "/lib/cmake",
+               "/share/aclocal",
+               "/lib/pkgconfig"]
+}

--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -47,6 +47,9 @@ modules:
         url: https://github.com/Unrud/xdg-screensaver-shim/archive/0.0.2.tar.gz
         sha256: 0ed2a69fe6ee6cbffd2fe16f85116db737f17fb1e79bfb812d893cf15c728399
 
+  # build the vendored SDL2 from Externals until the runtime gets 2.30.9
+  - SDL2/SDL2.json
+
   - name: dolphin-emu
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
Changes since 2.30.6 per https://github.com/libsdl-org/SDL/releases/tag/release-2.30.9
```
2.30.9
    Fixed audio issues on Android 15
    Fixed rare audio distortion and crash when audio devices are changed on Windows
    Fixed the PS5 controller face buttons on Amazon Fire TV
    Fixed detecting the Steam Virtual Gamepad on macOS
    Added support for wired XBox controllers on macOS 15.0 Sequoia
    Added support for the Steam Virtual Gamepad on macOS Sequoia
    Fixed the Steam Virtual Gamepad from showing up when games aren't running under Steam
    Fixed flicker when entering/exiting fullscreen or moving the window between scaled and non-scaled displays under Wayland.
    Fixes for data addresses above 2gb on Emscripten
    Fixed horizontal mousewheel scale on Emscripten
2.30.8
    Fixed a crash in XInput code at startup
    Fixed flooding the OS with I/O when a PS4/PS5 controller is disconnected
    Added SDL_VIDEO_DOUBLE_BUFFER support to the Wayland backend
    SDL_WINDOWEVENT_EXPOSED is sent appropriately when using Wayland
    Fixed hang at startup in audio code when the application has large stack usage on Linux
    Fixed initializing KMSDRM on older Linux systems
    The pre-built SDL2.dll no longer depends on ucrtbase.dll
2.30.7
    Added support for the Retro-bit Controller in PS3 mode
    Fixed the cursor becoming visible when using relative mode under XWayland
    Fixed DRM initialization failure on some Linux systems
    Fixed a crash when the current mouse capture window is destroyed
```

Note:
[SDL Override](https://github.com/dolphin-emu/dolphin/pull/13160/files) re-added as a temporary workaround for the Flatpak until the runtime has SDL 2.30.9.
https://github.com/dolphin-emu/dolphin/pull/13160/files