### PR TITLE
(old) PPCSymbolDB: Refactor SymbolMap Save/Load

### DIFF
--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -18,6 +18,7 @@
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
+#include "Common/Unreachable.h"
 #include "Core/Core.h"
 #include "Core/Debugger/DebugInterface.h"
 #include "Core/PowerPC/MMU.h"
@@ -310,7 +311,7 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& 
         continue;
       column_count = 2;
 
-      // Three columns format:
+      // Three columns format (with optional alignment):
       //  Starting        Virtual
       //  address  Size   address
       //  -----------------------
@@ -319,7 +320,7 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& 
       else
         iss.str("");
 
-      // Four columns format:
+      // Four columns format (with optional alignment):
       //  Starting        Virtual  File
       //  address  Size   address  offset
       //  ---------------------------------
@@ -327,75 +328,72 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& 
         column_count = 4;
     }
 
-    u32 address, vaddress, size, offset, alignment;
-    char name[512];
-    static constexpr char ENTRY_OF_STRING[] = "(entry of ";
+    u32 address;
+    u32 vaddress;
+    u32 size = 0;
+    u32 offset = 0;
+    u32 alignment = 0;
+    char name[512]{};
+    static constexpr char ENTRY_OF_STRING[] = " (entry of ";
     static constexpr std::string_view ENTRY_OF_VIEW(ENTRY_OF_STRING);
-    auto parse_entry_of = [](const char* line, char* name) {
-      const char* s = strstr(line, ENTRY_OF_STRING);
-      if (s)
+    auto parse_entry_of = [](char* name) {
+      if (char* s1 = strstr(name, ENTRY_OF_STRING); s1 != nullptr)
       {
         char container[512];
-        sscanf(s + ENTRY_OF_VIEW.size(), "%511s", container);
-        char* s2 = strchr(container, ')');
+        char* ptr = s1 + ENTRY_OF_VIEW.size();
+        sscanf(ptr, "%511s", container);
         // Skip sections, those start with a dot, e.g. (entry of .text)
-        if (s2 && container[0] != '.')
+        if (char* s2 = strchr(container, ')'); s2 != nullptr && *container != '.')
         {
-          s2[0] = '\0';
+          ptr += strlen(container);
+          // Preserve data after the entry part, usually it contains object names
+          strcpy(s1, ptr);
+          *s2 = '\0';
           strcat(container, "::");
           strcat(container, name);
           strcpy(name, container);
         }
       }
     };
-    if (column_count == 4)
+    auto was_alignment = [](const char* name) {
+      return *name == ' ' || (*name >= '0' && *name <= '9');
+    };
+    auto parse_alignment = [](char* name, u32* alignment) {
+      const std::string buffer(StripWhitespace(name));
+      return sscanf(buffer.c_str(), "%i %511[^\r\n]", alignment, name);
+    };
+    switch (column_count)
     {
+    case 4:
       // sometimes there is no alignment value, and sometimes it is because it is an entry of
       // something else
-      if (length > 37 && line[37] == ' ')
-      {
-        alignment = 0;
-        sscanf(line, "%08x %08x %08x %08x %511s", &address, &size, &vaddress, &offset, name);
-        parse_entry_of(line, name);
-      }
-      else
-      {
-        sscanf(line, "%08x %08x %08x %08x %i %511s", &address, &size, &vaddress, &offset,
-               &alignment, name);
-      }
-    }
-    else if (column_count == 3)
-    {
+      sscanf(line, "%08x %08x %08x %08x %511[^\r\n]", &address, &size, &vaddress, &offset, name);
+      if (was_alignment(name))
+        parse_alignment(name, &alignment);
+      // The `else` statement was omitted to handle symbol already saved in Dolphin symbol map
+      // since it doesn't omit the alignment on save for such case.
+      parse_entry_of(name);
+      break;
+    case 3:
       // some entries in the table have a function name followed by " (entry of " followed by a
       // container name, followed by ")"
       // instead of a space followed by a number followed by a space followed by a name
-      if (length > 27 && line[27] != ' ' && strstr(line, ENTRY_OF_STRING))
-      {
-        alignment = 0;
-        sscanf(line, "%08x %08x %08x %511s", &address, &size, &vaddress, name);
-        parse_entry_of(line, name);
-      }
-      else
-      {
-        sscanf(line, "%08x %08x %08x %i %511s", &address, &size, &vaddress, &alignment, name);
-      }
-    }
-    else if (column_count == 2)
-    {
-      sscanf(line, "%08x %511s", &address, name);
+      sscanf(line, "%08x %08x %08x %511[^\r\n]", &address, &size, &vaddress, name);
+      if (was_alignment(name))
+        parse_alignment(name, &alignment);
+      // The `else` statement was omitted to handle symbol already saved in Dolphin symbol map
+      // since it doesn't omit the alignment on save for such case.
+      parse_entry_of(name);
+      break;
+    case 2:
+      sscanf(line, "%08x %511[^\r\n]", &address, name);
       vaddress = address;
-      size = 0;
-    }
-    else
-    {
+      break;
+    default:
+      // Should never happen
+      Common::Unreachable();
       break;
     }
-    const char* namepos = strstr(line, name);
-    if (namepos != nullptr)  // would be odd if not :P
-      strcpy(name, namepos);
-    name[strlen(name) - 1] = 0;
-    if (name[strlen(name) - 1] == '\r')
-      name[strlen(name) - 1] = 0;
 
     // Split the current name string into separate parts, and get the object name
     // if it exists.

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -226,10 +226,12 @@ void PPCSymbolDB::LogFunctionCall(u32 addr)
 // bad=true means carefully load map files that might not be from exactly the right version
 bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& filename, bool bad)
 {
+  INFO_LOG_FMT(SYMBOLS, "Loading symbol map: {}", filename);
   File::IOFile f(filename, "r");
   if (!f)
     return false;
 
+  INFO_LOG_FMT(SYMBOLS, "Symbol map file loaded");
   // Two columns are used by Super Smash Bros. Brawl Korean map file
   // Three columns are commonly used
   // Four columns are used in American Mensa Academy map files and perhaps other games
@@ -337,6 +339,8 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& 
     static constexpr char ENTRY_OF_STRING[] = " (entry of ";
     static constexpr std::string_view ENTRY_OF_VIEW(ENTRY_OF_STRING);
     auto parse_entry_of = [](char* name) {
+      INFO_LOG_FMT(SYMBOLS, "Entering parse_entry_of({})", name);
+
       if (char* s1 = strstr(name, ENTRY_OF_STRING); s1 != nullptr)
       {
         char container[512];
@@ -354,13 +358,18 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& 
           strcpy(name, container);
         }
       }
+
+      INFO_LOG_FMT(SYMBOLS, "Leaving parse_entry_of({})", name);
     };
     auto was_alignment = [](const char* name) {
       return *name == ' ' || (*name >= '0' && *name <= '9');
     };
     auto parse_alignment = [](char* name, u32* alignment) {
+      INFO_LOG_FMT(SYMBOLS, "Entering parse_alignment({})", name);
       const std::string buffer(StripWhitespace(name));
-      return sscanf(buffer.c_str(), "%i %511[^\r\n]", alignment, name);
+      auto ret = sscanf(buffer.c_str(), "%i %511[^\r\n]", alignment, name);
+      INFO_LOG_FMT(SYMBOLS, "Leaving parse_alignment({})", name);
+      return ret;
     };
     switch (column_count)
     {
@@ -391,6 +400,8 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& 
       break;
     default:
       // Should never happen
+      INFO_LOG_FMT(SYMBOLS, "Bad column count: {}, line={}, temp={}, good={}, bad={}", column_count,
+                   std::string_view{line}, temp, good_count, bad_count);
       Common::Unreachable();
       break;
     }


### PR DESCRIPTION
This PR refactors parts of the loading/saving process of symbol map. ~I'm putting it as a draft for now as I'd like to wait for https://dolp.in/pr13113 to be merged first.~

This PR fixes issues I had where some symbols weren't loaded properly (which might get saved later). Here are some examples on how they can alter existing symbol maps.

## The alignment wasn't properly detected and `0` was detected as `name` by `sscanf`.
This issue was also caused by the `namepos`/`strstr` logic which is flawed when the name is small and equals to part of the symbol address, size or vaddress. Moreover, checking for a space doesn't work when alignment is 16. I've seen this alignment value on some `*fill*` symbols.
```diff
-80468370 00000008 80468370 0 TRKPositionFile (entry of .text)  TRK_Hollywood_Revolution.a C:\products\RVL\runtime_libs\debugger\embedded\MetroTRK\Processor\
+80468360 00000008 80468360 0 0468360 00000008 80468360 0 TRKPositionFile (entry of .text)      TRK_Hollywood_Revolution.a C:\products\RVL\runtime_libs\debugger\embedded\MetroTRK\Processor\
```

## savegpr / loadgpr entry wasn't properly detected
This issue also trimmed the object names after the "entry of" part.
```diff
-80456e54 000018 80456e54 0 _restgpr_27 (entry of __restore_gpr)        Runtime.PPCEABI.H.a runtime.o
+80456e54 000018 80456e54 0 __restore_gpr::
```

This PR is ready to be reviewed and tested. I also advise people testing this PR to backup their symbol maps just in case or test this PR in a dedicated portable build.