### PR TITLE
DolphinQt: Make mapping window spinboxes horizontally expanding.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -228,6 +228,8 @@ void MappingWidget::AddSettingWidgets(QFormLayout* layout, ControllerEmu::Contro
       const auto hbox = new QHBoxLayout;
 
       hbox->addWidget(setting_widget);
+      setting_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
       hbox->addWidget(CreateSettingAdvancedMappingButton(*setting));
 
       layout->addRow(tr(setting->GetUIName()), hbox);


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/12253180-a27a-491c-976f-2b34770530d8)

After:
![image](https://github.com/user-attachments/assets/2331a34b-e427-4609-86a8-9c482def5447)
