### PR TITLE
DolphinQt: Split Controller Settings in Tabs

### DIFF
--- a/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
@@ -30,7 +30,7 @@ CommonControllersWidget::CommonControllersWidget(QWidget* parent) : QWidget(pare
 void CommonControllersWidget::CreateLayout()
 {
   // i18n: This is "common" as in "shared", not the opposite of "uncommon"
-  m_common_box = new QGroupBox(tr("Common"));
+  m_common_widget = new QWidget();
   m_common_layout = new QVBoxLayout();
   m_common_bg_input = new QCheckBox(tr("Background Input"));
   m_common_configure_controller_interface =
@@ -39,12 +39,12 @@ void CommonControllersWidget::CreateLayout()
   m_common_layout->addWidget(m_common_bg_input);
   m_common_layout->addWidget(m_common_configure_controller_interface);
 
-  m_common_box->setLayout(m_common_layout);
+  m_common_widget->setLayout(m_common_layout);
 
   auto* layout = new QVBoxLayout;
   layout->setContentsMargins(0, 0, 0, 0);
   layout->setAlignment(Qt::AlignTop);
-  layout->addWidget(m_common_box);
+  layout->addWidget(m_common_widget);
   setLayout(layout);
 }
 

--- a/Source/Core/DolphinQt/Config/CommonControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/CommonControllersWidget.h
@@ -27,7 +27,7 @@ private:
   void LoadSettings();
   void SaveSettings();
 
-  QGroupBox* m_common_box;
+  QWidget* m_common_widget;
   QVBoxLayout* m_common_layout;
   QCheckBox* m_common_bg_input;
   QPushButton* m_common_configure_controller_interface;

--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -11,6 +11,10 @@
 #include "DolphinQt/Config/WiimoteControllersWidget.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
+#if defined(CIFACE_USE_DUALSHOCKUDPCLIENT)
+#include "DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.h"
+#endif
+
 ControllersWindow::ControllersWindow(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("Controller Settings"));
@@ -31,12 +35,18 @@ void ControllersWindow::showEvent(QShowEvent* event)
 
 void ControllersWindow::CreateMainLayout()
 {
+  m_tab_widget = new QTabWidget();
   auto* layout = new QVBoxLayout();
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
 
-  layout->addWidget(m_gamecube_controllers);
-  layout->addWidget(m_wiimote_controllers);
-  layout->addWidget(m_common);
+  m_tab_widget->addTab(m_gamecube_controllers, tr("GameCube"));
+  m_tab_widget->addTab(m_wiimote_controllers, tr("Wii"));
+  m_tab_widget->addTab(m_common, tr("Common"));
+#if defined(CIFACE_USE_DUALSHOCKUDPCLIENT)
+  m_dsuclient_widget = new DualShockUDPClientWidget();
+  m_tab_widget->addTab(m_dsuclient_widget, tr("DSU Client"));  // TODO: use GetWrappedWidget()?
+#endif
+  layout->addWidget(m_tab_widget);
   layout->addStretch();
   layout->addWidget(m_button_box);
 

--- a/Source/Core/DolphinQt/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QTabWidget>
 
 #if defined(CIFACE_USE_DUALSHOCKUDPCLIENT)
 class DualShockUDPClientWidget;

--- a/Source/Core/DolphinQt/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.h
@@ -5,6 +5,9 @@
 
 #include <QDialog>
 
+#if defined(CIFACE_USE_DUALSHOCKUDPCLIENT)
+class DualShockUDPClientWidget;
+#endif
 class CommonControllersWidget;
 class GamecubeControllersWidget;
 class QDialogButtonBox;
@@ -25,7 +28,12 @@ private:
   void ConnectWidgets();
 
   QDialogButtonBox* m_button_box;
+  QTabWidget* m_tab_widget;
   GamecubeControllersWidget* m_gamecube_controllers;
   WiimoteControllersWidget* m_wiimote_controllers;
   CommonControllersWidget* m_common;
+
+#if defined(CIFACE_USE_DUALSHOCKUDPCLIENT)
+  DualShockUDPClientWidget* m_dsuclient_widget;
+#endif
 };

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -74,7 +74,7 @@ GamecubeControllersWidget::GamecubeControllersWidget(QWidget* parent) : QWidget(
 
 void GamecubeControllersWidget::CreateLayout()
 {
-  m_gc_box = new QGroupBox(tr("GameCube Controllers"));
+  m_gc_widget = new QWidget();
   m_gc_layout = new QGridLayout();
   m_gc_layout->setVerticalSpacing(7);
   m_gc_layout->setColumnStretch(1, 1);
@@ -95,12 +95,12 @@ void GamecubeControllersWidget::CreateLayout()
     m_gc_layout->addWidget(gc_box, controller_row, 1);
     m_gc_layout->addWidget(gc_button, controller_row, 2);
   }
-  m_gc_box->setLayout(m_gc_layout);
+  m_gc_widget->setLayout(m_gc_layout);
 
   auto* layout = new QVBoxLayout;
   layout->setContentsMargins(0, 0, 0, 0);
   layout->setAlignment(Qt::AlignTop);
-  layout->addWidget(m_gc_box);
+  layout->addWidget(m_gc_widget);
   setLayout(layout);
 }
 

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.h
@@ -35,7 +35,7 @@ private:
   void ConnectWidgets();
 
   // Gamecube
-  QGroupBox* m_gc_box;
+  QWidget* m_gc_widget;
   QGridLayout* m_gc_layout;
   std::array<QComboBox*, 4> m_gc_controller_boxes;
   std::array<QPushButton*, 4> m_gc_buttons;

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -100,8 +100,8 @@ static int GetLayoutHorizontalSpacing(const QGridLayout* layout)
 void WiimoteControllersWidget::CreateLayout()
 {
   m_wiimote_layout = new QGridLayout();
-  m_wiimote_box = new QGroupBox(tr("Wii Remotes"));
-  m_wiimote_box->setLayout(m_wiimote_layout);
+  m_wiimote_widget = new QWidget();
+  m_wiimote_widget->setLayout(m_wiimote_layout);
 
   m_wiimote_passthrough = new QRadioButton(tr("Passthrough a Bluetooth adapter"));
   m_wiimote_sync = new NonDefaultQPushButton(tr("Sync"));
@@ -165,7 +165,7 @@ void WiimoteControllersWidget::CreateLayout()
   auto* layout = new QVBoxLayout;
   layout->setContentsMargins(0, 0, 0, 0);
   layout->setAlignment(Qt::AlignTop);
-  layout->addWidget(m_wiimote_box);
+  layout->addWidget(m_wiimote_widget);
   setLayout(layout);
 }
 

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
@@ -40,7 +40,7 @@ private:
   void ConnectWidgets();
   void LoadSettings(Core::State state);
 
-  QGroupBox* m_wiimote_box;
+  QWidget* m_wiimote_widget;
   QGridLayout* m_wiimote_layout;
   std::array<QLabel*, 4> m_wiimote_labels;
   std::array<QComboBox*, 4> m_wiimote_boxes;


### PR DESCRIPTION
Existing:
<img width="268" alt="image" src="https://github.com/user-attachments/assets/6391e4b0-1741-4535-8233-f80b3807ecca">


Proposed:
<img width="268" alt="image" src="https://github.com/user-attachments/assets/f3188b7e-cb51-4122-ab74-cc203c635a6b">
<img width="268" alt="image" src="https://github.com/user-attachments/assets/4e4ff541-0c03-4217-9bbe-08fd21bd0c70">
<img width="268" alt="image" src="https://github.com/user-attachments/assets/195a10dc-2923-4f56-9d06-dd4d230a9805">

--
Draft PR to discuss approaches to this change.
I think I would prefer if the Widget auto resized when clicking a tab if we go for this approach.
Example, when clicking GameCube it would shrink like this:
<img width="262" alt="image" src="https://github.com/user-attachments/assets/038fcc74-61ba-446e-a667-1569ffd8b398">

It seems kind of wasteful considering the Wii section is so much bigger.
I'm not opposed to other options, just not sure what it *should* look like.