### PR TITLE
IRWidget: Move header constants into class

### DIFF
--- a/Source/Core/DolphinQt/TAS/IRWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/IRWidget.cpp
@@ -25,14 +25,14 @@ IRWidget::IRWidget(QWidget* parent) : QWidget(parent)
 
 void IRWidget::SetX(u16 x)
 {
-  m_x = std::min(ir_max_x, x);
+  m_x = std::min(IR_MAX_X, x);
 
   update();
 }
 
 void IRWidget::SetY(u16 y)
 {
-  m_y = std::min(ir_max_y, y);
+  m_y = std::min(IR_MAX_Y, y);
 
   update();
 }
@@ -54,8 +54,8 @@ void IRWidget::paintEvent(QPaintEvent* event)
   painter.drawLine(PADDING + w / 2, PADDING, PADDING + w / 2, PADDING + h);
 
   // convert from value space to widget space
-  u16 x = PADDING + ((m_x * w) / ir_max_x);
-  u16 y = PADDING + (h - (m_y * h) / ir_max_y);
+  u16 x = PADDING + ((m_x * w) / IR_MAX_X);
+  u16 y = PADDING + (h - (m_y * h) / IR_MAX_Y);
 
   painter.drawLine(PADDING + w / 2, PADDING + h / 2, x, y);
 
@@ -84,17 +84,17 @@ void IRWidget::handleMouseEvent(QMouseEvent* event)
 
   if (event->button() == Qt::RightButton)
   {
-    m_x = std::round(ir_max_x / 2.);
-    m_y = std::round(ir_max_y / 2.);
+    m_x = std::round(IR_MAX_X / 2.);
+    m_y = std::round(IR_MAX_Y / 2.);
   }
   else
   {
     // convert from widget space to value space
-    int new_x = (event->pos().x() * ir_max_x) / width();
-    int new_y = ir_max_y - (event->pos().y() * ir_max_y) / height();
+    int new_x = (event->pos().x() * IR_MAX_X) / width();
+    int new_y = IR_MAX_Y - (event->pos().y() * IR_MAX_Y) / height();
 
-    m_x = std::max(0, std::min(static_cast<int>(ir_max_x), new_x));
-    m_y = std::max(0, std::min(static_cast<int>(ir_max_y), new_y));
+    m_x = std::max(0, std::min(static_cast<int>(IR_MAX_X), new_x));
+    m_y = std::max(0, std::min(static_cast<int>(IR_MAX_Y), new_y));
   }
 
   bool changed = false;

--- a/Source/Core/DolphinQt/TAS/IRWidget.h
+++ b/Source/Core/DolphinQt/TAS/IRWidget.h
@@ -13,6 +13,11 @@ class IRWidget : public QWidget
 public:
   explicit IRWidget(QWidget* parent);
 
+  static constexpr u16 IR_MIN_X = 0;
+  static constexpr u16 IR_MIN_Y = 0;
+  static constexpr u16 IR_MAX_X = 1023;
+  static constexpr u16 IR_MAX_Y = 767;
+
 signals:
   void ChangedX(u16 x);
   void ChangedY(u16 y);
@@ -32,9 +37,3 @@ private:
   u16 m_y = 0;
   bool m_ignore_movement = false;
 };
-
-// Should be part of class but fails to compile on mac os
-static const u16 ir_min_x = 0;
-static const u16 ir_min_y = 0;
-static const u16 ir_max_x = 1023;
-static const u16 ir_max_y = 767;

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
@@ -51,20 +51,20 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
                                     ir_x_shortcut_key_sequence.toString(QKeySequence::NativeText),
                                     ir_y_shortcut_key_sequence.toString(QKeySequence::NativeText)));
 
-  const int ir_x_center = static_cast<int>(std::round(ir_max_x / 2.));
-  const int ir_y_center = static_cast<int>(std::round(ir_max_y / 2.));
+  const int ir_x_center = static_cast<int>(std::round(IRWidget::IR_MAX_X / 2.));
+  const int ir_y_center = static_cast<int>(std::round(IRWidget::IR_MAX_Y / 2.));
 
   auto* x_layout = new QHBoxLayout;
   m_ir_x_value = CreateSliderValuePair(
       WiimoteEmu::Wiimote::IR_GROUP, ControllerEmu::ReshapableInput::X_INPUT_OVERRIDE,
-      &m_wiimote_overrider, x_layout, ir_x_center, ir_x_center, ir_min_x, ir_max_x,
-      ir_x_shortcut_key_sequence, Qt::Horizontal, m_ir_box);
+      &m_wiimote_overrider, x_layout, ir_x_center, ir_x_center, IRWidget::IR_MIN_X,
+      IRWidget::IR_MAX_X, ir_x_shortcut_key_sequence, Qt::Horizontal, m_ir_box);
 
   auto* y_layout = new QVBoxLayout;
   m_ir_y_value = CreateSliderValuePair(
       WiimoteEmu::Wiimote::IR_GROUP, ControllerEmu::ReshapableInput::Y_INPUT_OVERRIDE,
-      &m_wiimote_overrider, y_layout, ir_y_center, ir_y_center, ir_min_y, ir_max_y,
-      ir_y_shortcut_key_sequence, Qt::Vertical, m_ir_box);
+      &m_wiimote_overrider, y_layout, ir_y_center, ir_y_center, IRWidget::IR_MIN_Y,
+      IRWidget::IR_MAX_Y, ir_y_shortcut_key_sequence, Qt::Vertical, m_ir_box);
   m_ir_y_value->setMaximumWidth(60);
 
   auto* visual = new IRWidget(this);
@@ -76,7 +76,7 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
   connect(visual, &IRWidget::ChangedX, m_ir_x_value, &QSpinBox::setValue);
   connect(visual, &IRWidget::ChangedY, m_ir_y_value, &QSpinBox::setValue);
 
-  auto* visual_ar = new AspectRatioWidget(visual, ir_max_x, ir_max_y);
+  auto* visual_ar = new AspectRatioWidget(visual, IRWidget::IR_MAX_X, IRWidget::IR_MAX_Y);
 
   auto* visual_layout = new QHBoxLayout;
   visual_layout->addWidget(visual_ar);


### PR DESCRIPTION
This apparently didn't compile on macOS six years ago before c++20, but it should be fine by now.

While I'm at it, make the constants upper case per convention.