### PR TITLE
GameINI: Use Safe Texture Cache for Cabela's Dangerous Hunts 2011

### DIFF
--- a/Data/Sys/GameSettings/SCD.ini
+++ b/Data/Sys/GameSettings/SCD.ini
@@ -1,0 +1,5 @@
+# SCDE52, SCDP52 - Cabela's Dangerous Hunts 2011
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+

--- a/Data/Sys/GameSettings/SHU.ini
+++ b/Data/Sys/GameSettings/SHU.ini
@@ -1,0 +1,5 @@
+# SHUE52 - Cabela's Dangerous Hunts 2011: Special Edition
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+


### PR DESCRIPTION
This fixes text on the menu and in-game.

Previously tested by @JMC47 (though I'm not sure if it was the regular version or the special edition that was tested; the main difference is that the special edition has an option for a questionable cel-shading effect).

There's still a possibility of some audio issues in this game, but I don't own it (so I couldn't confirm if it was an HLE vs LLE difference) and couldn't find any videos of it on real hardware that had stereo audio.