### PR TITLE
GameINI: drop Single Core override from Eternal Darkness

### DIFF
--- a/Data/Sys/GameSettings/GED.ini
+++ b/Data/Sys/GameSettings/GED.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnFrame]
 # Add memory patches to be applied every frame here.


### PR DESCRIPTION
The patch introduced in PR #13154 also fixed the hang after the Allan Poe quote that occurs when running Eternal Darkness in Dual Core mode. Gave a more throughout test in Dolphin 2412 by playing Chapters 0 and 1 with Dual Core and haven't noticed any other issues, so I think it's safe to drop this override now... 