### PR TITLE
VKSwapChain: Always use surface formats with a normal sRGB color space if not RGBA16F

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
@@ -176,18 +176,20 @@ bool SwapChain::SelectSurfaceFormat()
     // because we already apply gamma ourselves, and we might not use sRGB gamma.
     // Force using a linear format instead, if this is the case.
     VkFormat format = VKTexture::GetLinearFormat(surface_format.format);
-    if (format == VK_FORMAT_R8G8B8A8_UNORM)
-      surface_format_RGBA8 = &surface_format;
-    else if (format == VK_FORMAT_B8G8R8A8_UNORM)
-      surface_format_BGRA8 = &surface_format;
-    else if (format == VK_FORMAT_A2B10G10R10_UNORM_PACK32 &&
-             surface_format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
-      surface_format_RGB10_A2 = &surface_format;
+    if (surface_format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+    {
+      if (format == VK_FORMAT_R8G8B8A8_UNORM)
+        surface_format_RGBA8 = &surface_format;
+      else if (format == VK_FORMAT_B8G8R8A8_UNORM)
+        surface_format_BGRA8 = &surface_format;
+      else if (format == VK_FORMAT_A2B10G10R10_UNORM_PACK32)
+        surface_format_RGB10_A2 = &surface_format;
+    }
     else if (format == VK_FORMAT_R16G16B16A16_SFLOAT &&
              surface_format.colorSpace == VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT)
+    {
       surface_format_RGBA16F_scRGB = &surface_format;
-    else
-      continue;
+    }
   }
 
   const VkSurfaceFormatKHR* surface_format = nullptr;


### PR DESCRIPTION
`VKSwapChain` will use whatever `VK_FORMAT_R8G8B8A8_UNORM` or `VK_FORMAT_B8G8R8A8_UNORM` surface format comes last in the array returned by `vkGetPhysicalDeviceSurfaceFormatsKHR`, but the ordering of items within the array is seemingly arbitrary.

On some devices running MoltenVK, the last `VK_FORMAT_B8G8R8A8_UNORM` format happens to be one with the `VK_COLOR_SPACE_HDR10_ST2084_EXT` color space. Using this will cause non-HDR content to be rendered in an HDR-enabled `CAMetalLayer`.

This bug might affect other drivers as well?

Thanks to @TellowKrinkle for the help.