### PR TITLE
ScmRevGen: Don't generate Info.plist files directly

### DIFF
--- a/CMake/DolphinInjectVersionInfo.cmake
+++ b/CMake/DolphinInjectVersionInfo.cmake
@@ -1,0 +1,24 @@
+function(dolphin_inject_version_info target)
+  set(INFO_PLIST_PATH "$<TARGET_BUNDLE_DIR:${target}>/Contents/Info.plist")
+  add_custom_command(TARGET ${target}
+    POST_BUILD
+
+    COMMAND /usr/libexec/PlistBuddy -c
+    "Delete :CFBundleShortVersionString"
+    "${INFO_PLIST_PATH}"
+    || true
+
+    COMMAND /usr/libexec/PlistBuddy -c
+    "Delete :CFBundleLongVersionString"
+    "${INFO_PLIST_PATH}"
+    || true
+
+    COMMAND /usr/libexec/PlistBuddy -c
+    "Delete :CFBundleVersion"
+    "${INFO_PLIST_PATH}"
+    || true
+
+    COMMAND /usr/libexec/PlistBuddy -c
+    "Merge '${CMAKE_BINARY_DIR}/Source/Core/VersionInfo.plist'"
+    "${INFO_PLIST_PATH}")
+endfunction()

--- a/CMake/ScmRevGen.cmake
+++ b/CMake/ScmRevGen.cmake
@@ -65,6 +65,5 @@ endfunction()
 configure_source_file("Source/Core/Common/scmrev.h")
 
 if(APPLE)
-  configure_source_file("Source/Core/DolphinQt/Info.plist")
-  configure_source_file("Source/Core/MacUpdater/Info.plist")
+  configure_source_file("Source/Core/VersionInfo.plist")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,14 +783,9 @@ if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/Source/Core/Common/scmrev.h)
 endif()
 
 if(APPLE)
-  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Source/Core/DolphinQt)
-  if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/Source/Core/DolphinQt/Info.plist)
-    file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/Source/Core/DolphinQt/Info.plist)
-  endif()
-
-  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Source/Core/MacUpdater)
-  if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/Source/Core/MacUpdater/Info.plist)
-    file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/Source/Core/MacUpdater/Info.plist)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Source/Core)
+  if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/Source/Core/VersionInfo.plist)
+    file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/Source/Core/VersionInfo.plist)
   endif()
 endif()
 

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -572,7 +572,6 @@ endif()
 
 if(APPLE)
   include(BundleUtilities)
-  set(BUNDLE_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DolphinQt.app)
 
   # Ask for an application bundle.
   set_target_properties(dolphin-emu PROPERTIES
@@ -648,7 +647,7 @@ if(APPLE)
       COMMAND "${CMAKE_SOURCE_DIR}/Tools/mac-codesign.sh"
       "-e" "${CMAKE_CURRENT_SOURCE_DIR}/DolphinEmu$<$<CONFIG:Debug>:Debug>.entitlements"
       "${MACOS_CODE_SIGNING_IDENTITY}"
-      "${BUNDLE_PATH}"
+      "$<TARGET_BUNDLE_DIR:dolphin-emu>"
     )
   endif()
 else()

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -576,7 +576,7 @@ if(APPLE)
   # Ask for an application bundle.
   set_target_properties(dolphin-emu PROPERTIES
     MACOSX_BUNDLE true
-    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist"
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
     XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
     OUTPUT_NAME DolphinQt
     )
@@ -612,6 +612,9 @@ if(APPLE)
       MACOSX_PACKAGE_LOCATION "Resources/${resdir}")
     source_group("Resources" FILES "${CMAKE_SOURCE_DIR}/Data/${res}")
   endforeach()
+
+  include(DolphinInjectVersionInfo)
+  dolphin_inject_version_info(dolphin-emu)
 
   # Copy MoltenVK into the bundle
   if(ENABLE_VULKAN)

--- a/Source/Core/DolphinQt/Info.plist.in
+++ b/Source/Core/DolphinQt/Info.plist.in
@@ -39,12 +39,6 @@
     <string>English</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
-    <key>CFBundleShortVersionString</key>
-    <string>${DOLPHIN_WC_DESCRIBE}</string>
-    <key>CFBundleLongVersionString</key>
-    <string>${DOLPHIN_WC_REVISION}</string>
-    <key>CFBundleVersion</key>
-    <string>${DOLPHIN_VERSION_MAJOR}.${DOLPHIN_VERSION_MINOR}</string>
     <key>NSHumanReadableCopyright</key>
     <string>Licensed under GPL version 2 or later (GPLv2+)</string>
     <key>LSApplicationCategoryType</key>

--- a/Source/Core/MacUpdater/CMakeLists.txt
+++ b/Source/Core/MacUpdater/CMakeLists.txt
@@ -16,7 +16,7 @@ add_dependencies(MacUpdater dolphin_scmrev)
 
 set_target_properties(MacUpdater PROPERTIES
   MACOSX_BUNDLE true
-  MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist"
+  MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
   OUTPUT_NAME "Dolphin Updater")
 
 target_compile_options(MacUpdater PRIVATE -x objective-c++)
@@ -52,6 +52,9 @@ foreach(sb ${STORYBOARDS})
     DEPENDS ${input}
     COMMENT "Compiling Storyboard ${sb}...")
 endforeach()
+
+include(DolphinInjectVersionInfo)
+dolphin_inject_version_info(MacUpdater)
 
 if(NOT SKIP_POSTPROCESS_BUNDLE)
   # Update library references to make the bundle portable

--- a/Source/Core/MacUpdater/Info.plist.in
+++ b/Source/Core/MacUpdater/Info.plist.in
@@ -16,10 +16,6 @@
 	<string>Dolphin Updater</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>${DOLPHIN_WC_DESCRIBE}</string>
-	<key>CFBundleVersion</key>
-	<string>${DOLPHIN_VERSION_MAJOR}.${DOLPHIN_VERSION_MINOR}</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Source/Core/VersionInfo.plist.in
+++ b/Source/Core/VersionInfo.plist.in
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- This plist file is merged with the application's Info.plist to set its version info. -->
+    <key>CFBundleShortVersionString</key>
+    <string>${DOLPHIN_WC_DESCRIBE}</string>
+    <key>CFBundleLongVersionString</key>
+    <string>${DOLPHIN_WC_REVISION}</string>
+    <key>CFBundleVersion</key>
+    <string>${DOLPHIN_VERSION_MAJOR}.${DOLPHIN_VERSION_MINOR}</string>
+</dict>
+</plist>


### PR DESCRIPTION
Some generators (like `Unix Makefiles` and `Xcode`) copy an app's `Info.plist` at configure time. This causes a problem when we need to generate the `Info.plist` at build time, like how we currently do it with ScmRevGen.

Instead of generating the `Info.plist` directly in ScmRevGen, provide an `Info.plist` without any version information to CMake at configure time, have ScmRevGen generate a separate plist file with the version information at build time, and then merge the two together to create the final `Info.plist`.

Fixes https://bugs.dolphin-emu.org/issues/13669.

(This PR also includes a bonus fix for codesigning in Xcode.)