### PR TITLE
AchievementManager: Make SetHardcoreMode private

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -132,7 +132,6 @@ public:
   void DoIdle();
 
   std::recursive_mutex& GetLock();
-  void SetHardcoreMode();
   bool IsHardcoreModeActive() const;
   void SetGameIniId(const std::string& game_ini_id) { m_game_ini_id = game_ini_id; }
 
@@ -198,6 +197,8 @@ private:
   static void ChangeMediaCallback(int result, const char* error_message, rc_client_t* client,
                                   void* userdata);
   void DisplayWelcomeMessage();
+
+  void SetHardcoreMode();
 
   template <typename T>
   void FilterApprovedIni(std::vector<T>& codes, const std::string& game_ini_id) const;


### PR DESCRIPTION
This is an implementation detail that doesn't need to be exposed.