### PR TITLE
GameSettings: set EFBAccessEnable=True for Neighbours from Hell

### DIFF
--- a/Data/Sys/GameSettings/GFH.ini
+++ b/Data/Sys/GameSettings/GFH.ini
@@ -10,3 +10,6 @@ MMU = True
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+# Needed for loading screens to show up.
+EFBAccessEnable = True


### PR DESCRIPTION
This fixes the loading screens that show a walking animation.