### PR TITLE
DolphinQt: Extract creator name from code name in Gecko codes.

### DIFF
--- a/Source/Core/DolphinQt/Config/CheatCodeEditor.cpp
+++ b/Source/Core/DolphinQt/Config/CheatCodeEditor.cpp
@@ -3,6 +3,8 @@
 
 #include "DolphinQt/Config/CheatCodeEditor.h"
 
+#include <regex>
+
 #include <QDialogButtonBox>
 #include <QFontDatabase>
 #include <QGridLayout>
@@ -251,11 +253,25 @@ bool CheatCodeEditor::AcceptGecko()
     return false;
   }
 
-  m_gecko_code->name = name.toStdString();
-  m_gecko_code->creator = m_creator_edit->text().toStdString();
+  m_gecko_code->name = name.trimmed().toStdString();
+  m_gecko_code->creator = m_creator_edit->text().trimmed().toStdString();
   m_gecko_code->codes = std::move(entries);
   m_gecko_code->notes = SplitString(m_notes_edit->toPlainText().toStdString(), '\n');
   m_gecko_code->user_defined = true;
+
+  {
+    // The creator name is not expected to be present in the cheat code name. It will be extracted
+    // and moved into its dedicated "creator" field.
+    std::smatch matches;
+    if (std::regex_match(m_gecko_code->name, matches, std::regex{R"(^(.*)\[(.*)\]$)"}))
+    {
+      m_gecko_code->name = StripWhitespace(matches[1].str());
+      if (m_gecko_code->creator.empty())
+      {
+        m_gecko_code->creator = StripWhitespace(matches[2].str());
+      }
+    }
+  }
 
   return true;
 }


### PR DESCRIPTION
Gecko codes in Dolphin feature a dedicated field for the creator of the cheat code. When saved into the INI file, the code name and the creator name are concatenated, and then inserted in the `[Gecko]` section:

```ini
[Gecko]
$<cheat code name> [<creator>]
<code line 1>
<code line 2>
<code line 3>
<...>
$<other cheat code name> [<creator>]
<code line 1>
<code line 2>
<code line 3>
<...>
```

On the other hand, enabled codes are listed under the `[Gecko_Enabled]` section, but in this case the creator name is omitted from the line:

```ini
[Gecko_Enabled]
$<cheat code name>
$<other cheat code name>
```

Having the creator name in the `[Gecko]` section but not in the `[Gecko_Enabled]` section is arguably not ideal, but this is legacy behavior in Dolphin.

The **Cheat Code Editor** dialog is not acknowledging this subtle behavior in Dolphin: the cheat code name and the creator name *can* be both inserted in the name field. This issue manifests as an inconsistent state where a Gecko code that *appears* to be enabled has no effect when the game is launched.

As part of this fix, the creator name (if present) is now moved into the dedicated creator field before the code is stored internally.

Test plan:

- Right-click on any game and open the **Properties** dialog.
- Switch to the **Gecko Codes** tab.
- Press the **Add New Code...** button.
- In the **Cheat Code Editor** dialog:
  - Enter `This is a test [Jane Doe]` in the **Name:** field.
  - Enter `01234567 00000000` in the **Code:** field.
  - Press **Save**.
- Observe that the newly added code is now in the list, and *appears* to be enabled.
- Close the **Properties** dialog.
- Right-click on the same game and open the **Properties** dialog again.

**Without** the fix, the newly added code, while still on the list, has been inadvertently disabled (it was never really enabled!).

**With** the fix, the newly added code is the list and remains enabled.

This fixes https://bugs.dolphin-emu.org/issues/13695.