### PR TITLE
[Android] Input overlay haptic feedback

### DIFF
--- a/Data/Sys/GameSettings/GFH.ini
+++ b/Data/Sys/GameSettings/GFH.ini
@@ -10,3 +10,6 @@ MMU = True
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+# Needed for loading screens to show up.
+EFBAccessEnable = True

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
@@ -8,7 +8,6 @@ import android.os.Build
 import android.os.Handler
 import android.os.VibrationEffect
 import android.os.Vibrator
-import android.os.VibratorManager
 import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -105,27 +104,13 @@ object ControllerInterface {
 
     @Keep
     @JvmStatic
-    private fun getVibratorManager(device: InputDevice): DolphinVibratorManager {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            DolphinVibratorManagerPassthrough(device.vibratorManager)
-        } else {
-            DolphinVibratorManagerCompat(device.vibrator)
-        }
-    }
+    private fun getDeviceVibratorManager(device: InputDevice): DolphinVibratorManager =
+        DolphinVibratorManagerFactory.getDeviceVibratorManager(device)
 
     @Keep
     @JvmStatic
-    private fun getSystemVibratorManager(): DolphinVibratorManager {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val vibratorManager = DolphinApplication.getAppContext()
-                .getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager?
-            if (vibratorManager != null)
-                return DolphinVibratorManagerPassthrough(vibratorManager)
-        }
-        val vibrator = DolphinApplication.getAppContext()
-            .getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-        return DolphinVibratorManagerCompat(vibrator)
-    }
+    private fun getSystemVibratorManager(): DolphinVibratorManager =
+        DolphinVibratorManagerFactory.getSystemVibratorManager()
 
     @Keep
     @JvmStatic

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManager.kt
@@ -13,4 +13,6 @@ interface DolphinVibratorManager {
     fun getVibrator(vibratorId: Int): Vibrator
 
     fun getVibratorIds(): IntArray
+
+    fun getDefaultVibrator(): Vibrator
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerCompat.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerCompat.kt
@@ -21,4 +21,6 @@ class DolphinVibratorManagerCompat(vibrator: Vibrator) : DolphinVibratorManager 
     }
 
     override fun getVibratorIds(): IntArray = vibratorIds
+
+    override fun getDefaultVibrator(): Vibrator = vibrator
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerFactory.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerFactory.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.input.model
+
+import android.content.Context
+import android.os.Build
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.view.InputDevice
+import org.dolphinemu.dolphinemu.DolphinApplication
+
+object DolphinVibratorManagerFactory {
+    fun getDeviceVibratorManager(device: InputDevice): DolphinVibratorManager {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            DolphinVibratorManagerPassthrough(device.vibratorManager)
+        } else {
+            DolphinVibratorManagerCompat(device.vibrator)
+        }
+    }
+
+    fun getSystemVibratorManager(): DolphinVibratorManager {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val vibratorManager = DolphinApplication.getAppContext()
+                .getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager?
+            if (vibratorManager != null) {
+                return DolphinVibratorManagerPassthrough(vibratorManager)
+            }
+        }
+        val vibrator = DolphinApplication.getAppContext()
+            .getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        return DolphinVibratorManagerCompat(vibrator)
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerPassthrough.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManagerPassthrough.kt
@@ -13,4 +13,6 @@ class DolphinVibratorManagerPassthrough(private val vibratorManager: VibratorMan
     override fun getVibrator(vibratorId: Int): Vibrator = vibratorManager.getVibrator(vibratorId)
 
     override fun getVibratorIds(): IntArray = vibratorManager.vibratorIds
+
+    override fun getDefaultVibrator(): Vibrator = vibratorManager.defaultVibrator
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -646,6 +646,24 @@ enum class BooleanSetting(
         "ButtonLatchingNunchukZ",
         false
     ),
+    MAIN_OVERLAY_HAPTICS_PRESS(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "OverlayHapticsPress",
+        false
+    ),
+    MAIN_OVERLAY_HAPTICS_RELEASE(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "OverlayHapticsRelease",
+        false
+    ),
+    MAIN_OVERLAY_HAPTICS_JOYSTICK(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "OverlayHapticsJoystick",
+        false
+    ),
     SYSCONF_SCREENSAVER(Settings.FILE_SYSCONF, "IPL", "SSV", false),
     SYSCONF_WIDESCREEN(Settings.FILE_SYSCONF, "IPL", "AR", true),
     SYSCONF_PROGRESSIVE_SCAN(Settings.FILE_SYSCONF, "IPL", "PGS", true),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.kt
@@ -8,6 +8,12 @@ enum class FloatSetting(
     private val key: String,
     private val defaultValue: Float
 ) : AbstractFloatSetting {
+    MAIN_OVERLAY_HAPTICS_SCALE(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "OverlayHapticsScale",
+        0.5f
+    ),
     // These entries have the same names and order as in C++, just for consistency.
     MAIN_EMULATION_SPEED(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "EmulationSpeed", 1.0f),
     MAIN_OVERCLOCK(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "Overclock", 1.0f),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/HapticsProvider.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/HapticsProvider.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.utils
+
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import androidx.annotation.FloatRange
+import androidx.annotation.RequiresApi
+import org.dolphinemu.dolphinemu.features.input.model.DolphinVibratorManagerFactory
+
+/**
+ * This class provides methods that facilitate performing haptic feedback.
+ *
+ * @property vibrator The [Vibrator] instance to be used for vibration.
+ * Defaults to the system default vibrator.
+ */
+class HapticsProvider(
+    private val vibrator: Vibrator =
+        DolphinVibratorManagerFactory.getSystemVibratorManager().getDefaultVibrator()
+) {
+    private val primitiveSupport: Boolean = areAllPrimitivesSupported()
+
+    /**
+     * Perform haptic feedback by composing primitives (if supported),
+     * with a fallback to a waveform or a legacy vibration.
+     *
+     * @param effect The [HapticEffect] of the feedback.
+     * @param scale The intensity scale of the feedback.
+     */
+    fun provideFeedback(effect: HapticEffect, @FloatRange(from = 0.0, to = 1.0) scale: Float) {
+        if (primitiveSupport) {
+            vibrator.vibrate(
+                VibrationEffect
+                    .startComposition()
+                    .addPrimitive(getPrimitive(effect), scale)
+                    .compose()
+            )
+        } else {
+            val timings = getTimings(effect, scale)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                if (vibrator.hasAmplitudeControl()) {
+                    vibrator.vibrate(
+                        VibrationEffect.createWaveform(
+                            timings, getAmplitudes(effect, scale), -1
+                        )
+                    )
+                } else {
+                    vibrator.vibrate(VibrationEffect.createWaveform(timings, -1))
+                }
+            } else {
+                vibrator.vibrate(timings.sum())
+            }
+        }
+    }
+
+    /**
+     * Get the timings for a waveform vibration based on the [effect], scaled by [scale].
+     *
+     * @param effect The [HapticEffect] of the vibration.
+     * @param scale The intensity scale of the vibration.
+     * @return The LongArray of scaled timings for the specified [effect].
+     */
+    private fun getTimings(
+        effect: HapticEffect, @FloatRange(from = 0.0, to = 1.0) scale: Float
+    ): LongArray {
+        // Note: It is recommended that these values differ by a ratio of 1.4 or more,
+        // so the difference in the duration of the vibration can be easily perceived.
+        // Lower-end vibrators can't vibrate at all if the duration is too short.
+        return when (effect) {
+            HapticEffect.QUICK_FALL -> longArrayOf(0L, (100f * scale).toLong())
+            HapticEffect.QUICK_RISE -> longArrayOf(0L, (70f * scale).toLong())
+            HapticEffect.LOW_TICK -> longArrayOf(0L, (50f * scale).toLong())
+        }
+    }
+
+    /**
+     * Get the amplitudes for a waveform vibration based on the [effect], scaled by [scale].
+     *
+     * @param effect The [HapticEffect] of the vibration.
+     * @param scale The intensity scale of the vibration.
+     * @return The IntArray of scaled amplitudes for the specified [effect].
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun getAmplitudes(
+        effect: HapticEffect, @FloatRange(from = 0.0, to = 1.0) scale: Float
+    ): IntArray {
+        // Note: It is recommended that these values differ by a ratio of 1.4 or more,
+        // so the difference in the amplitude of the vibration can be easily perceived.
+        return when (effect) {
+            HapticEffect.QUICK_FALL -> intArrayOf(0, (180 * scale).toInt())
+            HapticEffect.QUICK_RISE -> intArrayOf(0, (128 * scale).toInt())
+            HapticEffect.LOW_TICK -> intArrayOf(0, (90 * scale).toInt())
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun getPrimitive(effect: HapticEffect): Int {
+        return when (effect) {
+            HapticEffect.QUICK_FALL -> VibrationEffect.Composition.PRIMITIVE_QUICK_FALL
+            HapticEffect.QUICK_RISE -> VibrationEffect.Composition.PRIMITIVE_QUICK_RISE
+            HapticEffect.LOW_TICK -> VibrationEffect.Composition.PRIMITIVE_LOW_TICK
+        }
+    }
+
+    private fun areAllPrimitivesSupported(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && vibrator.areAllPrimitivesSupported(
+            *HapticEffect.values().map { getPrimitive(it) }.toIntArray()
+        )
+    }
+
+}
+
+enum class HapticEffect {
+    QUICK_FALL,
+    QUICK_RISE,
+    LOW_TICK
+}

--- a/Source/Android/app/src/main/res/layout/dialog_haptics_adjust.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_haptics_adjust.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/haptics_triggers"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/spacing_large">
+
+        <TextView
+            android:id="@+id/haptics_triggers_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacing_medlarge"
+            android:text="@string/haptics_triggers"
+            android:textAlignment="viewStart"
+            android:textAppearance="@style/TextAppearance.AppCompat.Title"
+            app:layout_constraintBottom_toTopOf="@id/haptics_release_checkbox"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/haptics_press_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:text="@string/haptics_press"
+            android:textAppearance="?android:textAppearanceListItem"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/haptics_release_checkbox"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/haptics_release_checkbox" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/haptics_release_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:text="@string/haptics_release"
+            android:textAppearance="?android:textAppearanceListItem"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/haptics_joystick_checkbox"
+            app:layout_constraintStart_toEndOf="@+id/haptics_press_checkbox"
+            app:layout_constraintTop_toBottomOf="@+id/haptics_triggers_text" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/haptics_joystick_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:text="@string/haptics_joystick"
+            android:textAppearance="?android:textAppearanceListItem"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/haptics_release_checkbox"
+            app:layout_constraintTop_toTopOf="@id/haptics_release_checkbox" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/haptics_intensity"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:paddingHorizontal="24dp">
+
+        <TextView
+            android:id="@+id/haptics_intensity_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/haptics_intensity"
+            android:textAlignment="viewStart"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/haptics_intensity_slider"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/haptics_intensity_slider"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/spacing_medlarge"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/haptics_intensity_value"
+            app:layout_constraintStart_toEndOf="@id/haptics_intensity_name"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/haptics_intensity_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/haptics_intensity_slider"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="50%" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/Source/Android/app/src/main/res/menu/menu_overlay_controls_gc.xml
+++ b/Source/Android/app/src/main/res/menu/menu_overlay_controls_gc.xml
@@ -28,6 +28,10 @@
         android:title="@string/emulation_choose_controller"/>
 
     <item
+        android:id="@+id/menu_emulation_haptics"
+        android:title="@string/emulation_haptics"/>
+
+    <item
         android:id="@+id/menu_emulation_reset_overlay"
         android:title="@string/emulation_touch_overlay_reset"/>
 </menu>

--- a/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
@@ -30,6 +30,10 @@
         android:title="@string/emulation_choose_controller"/>
 
     <item
+        android:id="@+id/menu_emulation_haptics"
+        android:title="@string/emulation_haptics"/>
+
+    <item
         android:id="@+id/menu_emulation_ir_group"
         android:title="@string/emulation_ir_group">
         <menu>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -616,6 +616,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="emulation_ir_mode">IR Mode</string>
     <string name="emulation_ir_sensitivity">IR Sensitivity</string>
     <string name="emulation_choose_doubletap">Double tap button</string>
+    <string name="emulation_haptics">Touch Haptics</string>
 
     <!-- GC Adapter Menu-->
     <string name="gc_adapter_rumble">Enable Vibration</string>
@@ -817,6 +818,13 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="ir_disabled">Disabled</string>
     <string name="ir_follow">Follow</string>
     <string name="ir_drag">Drag</string>
+
+    <!-- Haptics -->
+    <string name="haptics_triggers">Feedback Triggers</string>
+    <string name="haptics_press">Press</string>
+    <string name="haptics_release">Release</string>
+    <string name="haptics_joystick">Joystick</string>
+    <string name="haptics_intensity">Intensity</string>
 
     <!-- Double Tap Buttons -->
     <string name="double_tap_a">Button A</string>

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -63,7 +63,7 @@ jmethodID s_motion_event_get_source;
 jclass s_controller_interface_class;
 jmethodID s_controller_interface_register_input_device_listener;
 jmethodID s_controller_interface_unregister_input_device_listener;
-jmethodID s_controller_interface_get_vibrator_manager;
+jmethodID s_controller_interface_get_device_vibrator_manager;
 jmethodID s_controller_interface_get_system_vibrator_manager;
 jmethodID s_controller_interface_vibrate;
 
@@ -78,6 +78,7 @@ jmethodID s_sensor_event_listener_get_negative_axes;
 jclass s_dolphin_vibrator_manager_class;
 jmethodID s_dolphin_vibrator_manager_get_vibrator;
 jmethodID s_dolphin_vibrator_manager_get_vibrator_ids;
+jmethodID s_dolphin_vibrator_manager_get_default_vibrator;
 
 jintArray s_keycodes_array;
 
@@ -746,7 +747,8 @@ private:
   void AddMotors(JNIEnv* env, jobject input_device)
   {
     jobject vibrator_manager = env->CallStaticObjectMethod(
-        s_controller_interface_class, s_controller_interface_get_vibrator_manager, input_device);
+        s_controller_interface_class, s_controller_interface_get_device_vibrator_manager,
+        input_device);
     AddMotorsFromManager(env, vibrator_manager);
     env->DeleteLocalRef(vibrator_manager);
   }
@@ -857,8 +859,8 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
       env->GetStaticMethodID(s_controller_interface_class, "registerInputDeviceListener", "()V");
   s_controller_interface_unregister_input_device_listener =
       env->GetStaticMethodID(s_controller_interface_class, "unregisterInputDeviceListener", "()V");
-  s_controller_interface_get_vibrator_manager =
-      env->GetStaticMethodID(s_controller_interface_class, "getVibratorManager",
+  s_controller_interface_get_device_vibrator_manager =
+      env->GetStaticMethodID(s_controller_interface_class, "getDeviceVibratorManager",
                              "(Landroid/view/InputDevice;)Lorg/dolphinemu/dolphinemu/features/"
                              "input/model/DolphinVibratorManager;");
   s_controller_interface_get_system_vibrator_manager = env->GetStaticMethodID(
@@ -894,6 +896,8 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
       env->GetMethodID(s_dolphin_vibrator_manager_class, "getVibrator", "(I)Landroid/os/Vibrator;");
   s_dolphin_vibrator_manager_get_vibrator_ids =
       env->GetMethodID(s_dolphin_vibrator_manager_class, "getVibratorIds", "()[I");
+  s_dolphin_vibrator_manager_get_default_vibrator = env->GetMethodID(
+      s_dolphin_vibrator_manager_class, "getDefaultVibrator", "()Landroid/os/Vibrator;");
   env->DeleteLocalRef(dolphin_vibrator_manager_class);
 
   jintArray keycodes_array = CreateKeyCodesArray(env);


### PR DESCRIPTION
_(I had previously opened #12970 but decided to revert the controller rumble changes as they weren't ready for merge)_

Basically I added vibration when pressing the input overlay controls. This feature is disabled by default and can be enabled only if the device has a vibrator. 

The vibration's intensity (duration/amplitude) and triggers (button press/release & overlay joystick) can be adjusted using the new dialog accessible via "Overlay Controls" -> "Touch Haptics".

To ensure all devices including those on Android 13+ can perceive a vibration even when haptic feedback is disabled in Android settings, I've decided to use the [VibrationEffect.Composition](https://developer.android.com/reference/android/os/VibrationEffect.Composition) library with automatic fallback to non-rich haptics on older devices that do not support primitive composition.

Any feedback would be appreciated, thank you for reading