### PR TITLE
GCC: Remedy NRVO Fails

### DIFF
--- a/Source/Core/Core/IOS/FS/FileSystemCommon.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemCommon.cpp
@@ -95,8 +95,7 @@ Result<FileStatus> FileHandle::GetStatus() const
 Result<FileHandle> FileSystem::CreateAndOpenFile(Uid uid, Gid gid, const std::string& path,
                                                  Modes modes)
 {
-  Result<FileHandle> file = OpenFile(uid, gid, path, Mode::ReadWrite);
-  if (file.Succeeded())
+  if (Result<FileHandle> file = OpenFile(uid, gid, path, Mode::ReadWrite))
     return file;
 
   const ResultCode result = CreateFile(uid, gid, path, 0, modes);

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -697,7 +697,7 @@ std::string VolumeVerifier::GetPartitionName(std::optional<u32> type) const
     // (French), Clásicos (Spanish), Capolavori (Italian), 클래식 게임 체험판 (Korean).
     // If your language is not one of the languages above, consider leaving the string untranslated
     // so that people will recognize it as the name of the game mode.
-    name = Common::FmtFormatT("{0} (Masterpiece)", name);
+    return Common::FmtFormatT("{0} (Masterpiece)", name);
   }
   return name;
 }

--- a/Source/Core/DolphinTool/ExtractCommand.cpp
+++ b/Source/Core/DolphinTool/ExtractCommand.cpp
@@ -39,8 +39,7 @@ static std::unique_ptr<DiscIO::FileInfo> GetFileInfo(const DiscIO::Volume& disc_
   if (!filesystem)
     return nullptr;
 
-  std::unique_ptr<DiscIO::FileInfo> info = filesystem->FindFileInfo(path);
-  return info;
+  return filesystem->FindFileInfo(path);
 }
 
 static bool VolumeSupported(const DiscIO::Volume& disc_volume)

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -837,7 +837,7 @@ std::string GameFile::GetFileFormatName() const
   {
     std::string name = DiscIO::GetName(m_blob_type, true);
     if (m_is_nkit)
-      name = Common::FmtFormatT("{0} (NKit)", name);
+      return Common::FmtFormatT("{0} (NKit)", name);
     return name;
   }
   }

--- a/Source/Core/VideoCommon/TextureInfo.cpp
+++ b/Source/Core/VideoCommon/TextureInfo.cpp
@@ -183,14 +183,11 @@ TextureInfo::NameDetails TextureInfo::CalculateTextureName() const
   const u64 tex_hash = XXH64(m_ptr, m_texture_size, 0);
   const u64 tlut_hash = tlut_size ? XXH64(tlut, tlut_size, 0) : 0;
 
-  NameDetails result;
-  result.base_name = fmt::format("{}{}x{}{}", format_prefix, m_raw_width, m_raw_height,
-                                 m_mipmaps_enabled ? "_m" : "");
-  result.texture_name = fmt::format("{:016x}", tex_hash);
-  result.tlut_name = tlut_size ? fmt::format("_{:016x}", tlut_hash) : "";
-  result.format_name = fmt::to_string(static_cast<int>(m_texture_format));
-
-  return result;
+  return {.base_name = fmt::format("{}{}x{}{}", format_prefix, m_raw_width, m_raw_height,
+                                   m_mipmaps_enabled ? "_m" : ""),
+          .texture_name = fmt::format("{:016x}", tex_hash),
+          .tlut_name = tlut_size ? fmt::format("_{:016x}", tlut_hash) : "",
+          .format_name = fmt::to_string(static_cast<int>(m_texture_format))};
 }
 
 bool TextureInfo::IsDataValid() const

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -57,11 +57,10 @@ VertexLoaderX64::VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att)
 
 OpArg VertexLoaderX64::GetVertexAddr(CPArray array, VertexComponentFormat attribute)
 {
-  OpArg data = MDisp(src_reg, m_src_ofs);
   if (IsIndexed(attribute))
   {
     int bits = attribute == VertexComponentFormat::Index8 ? 8 : 16;
-    LoadAndSwap(bits, scratch1, data);
+    LoadAndSwap(bits, scratch1, MDisp(src_reg, m_src_ofs));
     m_src_ofs += bits / 8;
     if (array == CPArray::Position)
     {
@@ -74,7 +73,7 @@ OpArg VertexLoaderX64::GetVertexAddr(CPArray array, VertexComponentFormat attrib
   }
   else
   {
-    return data;
+    return MDisp(src_reg, m_src_ofs);
   }
 }
 


### PR DESCRIPTION
Using the [`-Wnrvo`](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wnrvo) flag introduced by GCC 14, I identified a few places where NRVO was clearly intended, but is fumbled.