### PR TITLE
Vulkan DRM/KMS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ option(USE_MGBA "Enables GBA controllers emulation using libmgba" ON)
 option(ENABLE_AUTOUPDATE "Enables support for automatic updates" ON)
 option(USE_RETRO_ACHIEVEMENTS "Enables integration with retroachievements.org" ON)
 option(ENABLE_CCACHE "Enables CCache compiler cache" OFF)
+option(ENABLE_DRM "Enables DRM support" OFF)
 
 # Maintainers: if you consider blanket disabling this for your users, please
 # consider the following points:
@@ -476,6 +477,10 @@ set_property(CACHE OpenGL_GL_PREFERENCE PROPERTY STRINGS GLVND LEGACY)
 find_package(OpenGL)
 if (OPENGL_GL)
   include_directories(${OPENGL_INCLUDE_DIR})
+endif()
+
+if(ENABLE_DRM)
+  add_definitions(-DHAVE_DRM)
 endif()
 
 if(ENABLE_X11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ option(USE_MGBA "Enables GBA controllers emulation using libmgba" ON)
 option(ENABLE_AUTOUPDATE "Enables support for automatic updates" ON)
 option(USE_RETRO_ACHIEVEMENTS "Enables integration with retroachievements.org" ON)
 option(ENABLE_CCACHE "Enables CCache compiler cache" OFF)
+option(ENABLE_DRM "Enables DRM support" OFF)
 
 # Maintainers: if you consider blanket disabling this for your users, please
 # consider the following points:
@@ -489,6 +490,10 @@ set_property(CACHE OpenGL_GL_PREFERENCE PROPERTY STRINGS GLVND LEGACY)
 find_package(OpenGL)
 if (OPENGL_GL)
   include_directories(${OPENGL_INCLUDE_DIR})
+endif()
+
+if(ENABLE_DRM)
+  add_definitions(-DHAVE_DRM)
 endif()
 
 if(ENABLE_X11)

--- a/Source/Core/Common/WindowSystemInfo.h
+++ b/Source/Core/Common/WindowSystemInfo.h
@@ -13,6 +13,7 @@ enum class WindowSystemType
   Wayland,
   FBDev,
   Haiku,
+  DRM,
 };
 
 struct WindowSystemInfo

--- a/Source/Core/DolphinNoGUI/CMakeLists.txt
+++ b/Source/Core/DolphinNoGUI/CMakeLists.txt
@@ -34,6 +34,12 @@ else()
   set_target_properties(dolphin-nogui PROPERTIES OUTPUT_NAME dolphin-emu-nogui)
 endif()
 
+if(ENABLE_DRM)
+  target_sources(dolphin-nogui PRIVATE PlatformDRM.cpp)
+endif()
+
+set_target_properties(dolphin-nogui PROPERTIES OUTPUT_NAME dolphin-emu-nogui)
+
 target_link_libraries(dolphin-nogui
 PRIVATE
   core

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -202,8 +202,8 @@ int main(const int argc, char* argv[])
                 "fbdev"
 #endif
 #if HAVE_DRM
-            ,
-            "drm"
+				        ,
+				        "drm"
 #endif
 #if HAVE_X11
                 ,

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -155,6 +155,11 @@ static std::unique_ptr<Platform> GetPlatform(const optparse::Values& options)
 {
   std::string platform_name = static_cast<const char*>(options.get("platform"));
 
+#if HAVE_DRM
+  if (platform_name == "drm" || platform_name.empty())
+    return Platform::CreateDRMPlatform();
+#endif
+
 #if HAVE_X11
   if (platform_name == "x11" || platform_name.empty())
     return Platform::CreateX11Platform();
@@ -195,6 +200,10 @@ int main(const int argc, char* argv[])
 #ifdef __linux__
                 ,
                 "fbdev"
+#endif
+#if HAVE_DRM
+            ,
+            "drm"
 #endif
 #if HAVE_X11
                 ,

--- a/Source/Core/DolphinNoGUI/Platform.h
+++ b/Source/Core/DolphinNoGUI/Platform.h
@@ -30,6 +30,10 @@ public:
   // Request an immediate shutdown.
   void Stop();
 
+#if HAVE_DRM
+  static std::unique_ptr<Platform> CreateDRMPlatform();
+#endif
+
   static std::unique_ptr<Platform> CreateHeadlessPlatform();
 #ifdef HAVE_X11
   static std::unique_ptr<Platform> CreateX11Platform();

--- a/Source/Core/DolphinNoGUI/PlatformDRM.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformDRM.cpp
@@ -1,0 +1,63 @@
+// Copyright 2024 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <unistd.h>
+
+#include "DolphinNoGUI/Platform.h"
+
+#include "Common/MsgHandler.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "Core/State.h"
+#include "Core/System.h"
+
+#include <climits>
+#include <cstdio>
+#include <thread>
+
+#include <fcntl.h>
+#include <sys/types.h>
+
+namespace
+{
+class PlatformDRM : public Platform
+{
+public:
+  void SetTitle(const std::string& string) override;
+  void MainLoop() override;
+
+  WindowSystemInfo GetWindowSystemInfo() const override;
+};
+
+void PlatformDRM::SetTitle(const std::string& string)
+{
+  std::fprintf(stdout, "%s\n", string.c_str());
+}
+
+void PlatformDRM::MainLoop()
+{
+  while (IsRunning())
+  {
+    UpdateRunningFlag();
+    Core::HostDispatchJobs(Core::System::GetInstance());
+
+    // TODO: Is this sleep appropriate?
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+WindowSystemInfo PlatformDRM::GetWindowSystemInfo() const
+{
+  WindowSystemInfo wsi;
+  wsi.type = WindowSystemType::DRM;
+  wsi.display_connection = nullptr;
+  wsi.render_window = nullptr;
+  wsi.render_surface = nullptr;
+  return wsi;
+}
+}  // namespace
+
+std::unique_ptr<Platform> Platform::CreateDRMPlatform()
+{
+  return std::make_unique<PlatformDRM>();
+}

--- a/Source/Core/VideoBackends/Vulkan/VKMain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKMain.cpp
@@ -142,20 +142,6 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   VulkanContext::PopulateBackendInfo(&g_backend_info);
   VulkanContext::PopulateBackendInfoAdapters(&g_backend_info, gpu_list);
 
-  // We need the surface before we can create a device, as some parameters depend on it.
-  VkSurfaceKHR surface = VK_NULL_HANDLE;
-  if (enable_surface)
-  {
-    surface = SwapChain::CreateVulkanSurface(instance, wsi);
-    if (surface == VK_NULL_HANDLE)
-    {
-      PanicAlertFmt("Failed to create Vulkan surface.");
-      vkDestroyInstance(instance, nullptr);
-      UnloadVulkanLibrary();
-      return false;
-    }
-  }
-
   // Since we haven't called InitializeShared yet, iAdapter may be out of range,
   // so we have to check it ourselves.
   size_t selected_adapter_index = static_cast<size_t>(g_Config.iAdapter);
@@ -163,6 +149,20 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   {
     WARN_LOG_FMT(VIDEO, "Vulkan adapter index out of range, selecting first adapter.");
     selected_adapter_index = 0;
+  }
+
+  // We need the surface before we can create a device, as some parameters depend on it.
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+  if (enable_surface)
+  {
+    surface = SwapChain::CreateVulkanSurface(instance, gpu_list[selected_adapter_index], wsi);
+    if (surface == VK_NULL_HANDLE)
+    {
+      PanicAlertFmt("Failed to create Vulkan surface.");
+      vkDestroyInstance(instance, nullptr);
+      UnloadVulkanLibrary();
+      return false;
+    }
   }
 
   // Now we can create the Vulkan device. VulkanContext takes ownership of the instance and surface.

--- a/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
@@ -36,7 +36,8 @@ SwapChain::~SwapChain()
   DestroySurface();
 }
 
-VkSurfaceKHR SwapChain::CreateVulkanSurface(VkInstance instance, [[maybe_unused]] VkPhysicalDevice physical_device,
+VkSurfaceKHR SwapChain::CreateVulkanSurface(VkInstance instance,
+                                            [[maybe_unused]] VkPhysicalDevice physical_device,
                                             const WindowSystemInfo& wsi)
 {
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)

--- a/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
@@ -36,8 +36,163 @@ SwapChain::~SwapChain()
   DestroySurface();
 }
 
-VkSurfaceKHR SwapChain::CreateVulkanSurface(VkInstance instance, const WindowSystemInfo& wsi)
+VkSurfaceKHR SwapChain::CreateVulkanSurface(VkInstance instance, [[maybe_unused]] VkPhysicalDevice physical_device,
+                                            const WindowSystemInfo& wsi)
 {
+#if defined(VK_USE_PLATFORM_DISPLAY_KHR)
+  if (wsi.type == WindowSystemType::DRM)
+  {
+    // Get the first display
+    uint32_t display_count = 1;
+    VkDisplayPropertiesKHR display_props;
+    if (VkResult err = vkGetPhysicalDeviceDisplayPropertiesKHR(physical_device, &display_count,
+                                                               &display_props);
+        err != VK_SUCCESS && err != VK_INCOMPLETE)
+    {
+      LOG_VULKAN_ERROR(err, "vkGetPhysicalDeviceDisplayPropertiesKHR failed: ");
+      return VK_NULL_HANDLE;
+    }
+
+    // Get the first mode of the display
+    uint32_t mode_count = 0;
+    if (VkResult err = vkGetDisplayModePropertiesKHR(physical_device, display_props.display,
+                                                     &mode_count, nullptr);
+        err != VK_SUCCESS)
+    {
+      LOG_VULKAN_ERROR(err, "vkGetDisplayModePropertiesKHR failed: ");
+      return VK_NULL_HANDLE;
+    }
+
+    if (mode_count == 0)
+    {
+      ERROR_LOG_FMT(VIDEO, "Cannot find any mode for the display!");
+      return VK_NULL_HANDLE;
+    }
+
+    VkDisplayModePropertiesKHR mode_props;
+    mode_count = 1;
+    if (VkResult err = vkGetDisplayModePropertiesKHR(physical_device, display_props.display,
+                                                     &mode_count, &mode_props);
+        err != VK_SUCCESS && err != VK_INCOMPLETE)
+    {
+      LOG_VULKAN_ERROR(err, "vkGetDisplayModePropertiesKHR failed: ");
+      return VK_NULL_HANDLE;
+    }
+
+    // Get the list of planes
+    uint32_t plane_count = 0;
+    if (VkResult err =
+            vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physical_device, &plane_count, nullptr);
+        err != VK_SUCCESS)
+    {
+      LOG_VULKAN_ERROR(err, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR failed: ");
+      return VK_NULL_HANDLE;
+    }
+
+    if (plane_count == 0)
+    {
+      ERROR_LOG_FMT(VIDEO, "No display planes found!");
+      return VK_NULL_HANDLE;
+    }
+
+    // Find a plane compatible with the display
+    uint32_t compatible_plane_index = UINT32_MAX;
+
+    for (uint32_t plane_index = 0; plane_index < plane_count; plane_index++)
+    {
+      // Query the number of displays supported by the plane
+      display_count = 0;
+      VkResult err = vkGetDisplayPlaneSupportedDisplaysKHR(physical_device, plane_index,
+                                                           &display_count, nullptr);
+      if (err != VK_SUCCESS)
+      {
+        LOG_VULKAN_ERROR(err, "vkGetDisplayPlaneSupportedDisplaysKHR (count query) failed: ");
+        return VK_NULL_HANDLE;
+      }
+
+      if (display_count == 0)
+        continue;  // Skip planes that support no displays
+
+      // Allocate memory to hold the supported displays
+      std::vector<VkDisplayKHR> displays(display_count);
+      err = vkGetDisplayPlaneSupportedDisplaysKHR(physical_device, plane_index, &display_count,
+                                                  displays.data());
+      if (err != VK_SUCCESS)
+      {
+        LOG_VULKAN_ERROR(err, "vkGetDisplayPlaneSupportedDisplaysKHR (fetch displays) failed: ");
+        return VK_NULL_HANDLE;
+      }
+
+      // Check if the target display is among the supported displays
+      if (std::ranges::find(displays, display_props.display) != displays.end())
+      {
+        compatible_plane_index = plane_index;
+      }
+
+      if (compatible_plane_index != UINT32_MAX)
+        break;  // Exit early if a compatible plane is found
+    }
+
+    if (compatible_plane_index == UINT32_MAX)
+    {
+      ERROR_LOG_FMT(VIDEO, "No compatible plane found for the display!");
+      return VK_NULL_HANDLE;
+    }
+
+    // Get capabilities of the compatible plane
+    VkDisplayPlaneCapabilitiesKHR plane_capabilities;
+    if (VkResult err = vkGetDisplayPlaneCapabilitiesKHR(
+            physical_device, mode_props.displayMode, compatible_plane_index, &plane_capabilities);
+        err != VK_SUCCESS)
+    {
+      LOG_VULKAN_ERROR(err, "vkGetDisplayPlaneCapabilitiesKHR failed: ");
+      return VK_NULL_HANDLE;
+    }
+
+    // Find a supported alpha mode
+    VkDisplayPlaneAlphaFlagBitsKHR alpha_mode = VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR;
+    VkDisplayPlaneAlphaFlagBitsKHR alpha_modes[] = {
+        VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR,
+        VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR,
+        VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR,
+        VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR,
+    };
+
+    for (auto& curr_alpha_mode : alpha_modes)
+    {
+      if (plane_capabilities.supportedAlpha & curr_alpha_mode)
+      {
+        alpha_mode = curr_alpha_mode;
+        break;
+      }
+    }
+
+    // Create the display surface
+    VkDisplaySurfaceCreateInfoKHR surface_create_info = {};
+    surface_create_info.sType = VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR;
+    surface_create_info.displayMode = mode_props.displayMode;
+    surface_create_info.planeIndex = compatible_plane_index;
+    surface_create_info.planeStackIndex = 0;
+    surface_create_info.transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+    surface_create_info.globalAlpha = 1.0f;
+    surface_create_info.alphaMode = alpha_mode;
+    surface_create_info.imageExtent.width = display_props.physicalResolution.width;
+    surface_create_info.imageExtent.height = display_props.physicalResolution.height;
+
+    VkSurfaceKHR surface;
+    if (VkResult res =
+            vkCreateDisplayPlaneSurfaceKHR(instance, &surface_create_info, nullptr, &surface);
+        res != VK_SUCCESS)
+    {
+      LOG_VULKAN_ERROR(res, "vkCreateDisplayPlaneSurfaceKHR failed: ");
+      return VK_NULL_HANDLE;
+    }
+
+    return surface;
+  }
+
+#endif
+
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
   if (wsi.type == WindowSystemType::Windows)
   {
@@ -577,7 +732,8 @@ bool SwapChain::RecreateSurface(void* native_handle)
 
   // Re-create the surface with the new native handle
   m_wsi.render_surface = native_handle;
-  m_surface = CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(), m_wsi);
+  m_surface = CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(),
+                                  g_vulkan_context->GetPhysicalDevice(), m_wsi);
   if (m_surface == VK_NULL_HANDLE)
     return false;
 

--- a/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
+++ b/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
@@ -25,7 +25,8 @@ public:
   ~SwapChain();
 
   // Creates a vulkan-renderable surface for the specified window handle.
-  static VkSurfaceKHR CreateVulkanSurface(VkInstance instance, const WindowSystemInfo& wsi);
+  static VkSurfaceKHR CreateVulkanSurface(VkInstance instance, VkPhysicalDevice physical_device,
+                                          const WindowSystemInfo& wsi);
 
   // Create a new swap chain from a pre-existing surface.
   static std::unique_ptr<SwapChain> Create(const WindowSystemInfo& wsi, VkSurfaceKHR surface,

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -362,6 +362,20 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
     return false;
   }
 #endif
+
+#if defined(VK_USE_PLATFORM_DISPLAY_KHR)
+  if (wstype == WindowSystemType::DRM)
+  {
+    if (!AddExtension(VK_KHR_DISPLAY_EXTENSION_NAME, true))
+    {
+      return false;
+    }
+    if (!AddExtension(VK_KHR_SURFACE_EXTENSION_NAME, true))
+    {
+      return false;
+    }
+  }
+#endif
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
   if (wstype == WindowSystemType::Android &&
       !AddExtension(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, true))

--- a/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
+++ b/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
@@ -49,6 +49,15 @@ VULKAN_INSTANCE_ENTRY_POINT(vkCreateXlibSurfaceKHR, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceXlibPresentationSupportKHR, false)
 #endif
 
+#if defined(VK_USE_PLATFORM_DISPLAY_KHR)
+VULKAN_INSTANCE_ENTRY_POINT(vkCreateDisplayPlaneSurfaceKHR, false)
+VULKAN_INSTANCE_ENTRY_POINT(vkGetDisplayPlaneCapabilitiesKHR, false)
+VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceDisplayPlanePropertiesKHR, false)
+VULKAN_INSTANCE_ENTRY_POINT(vkGetDisplayPlaneSupportedDisplaysKHR, false)
+VULKAN_INSTANCE_ENTRY_POINT(vkGetDisplayModePropertiesKHR, false)
+VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceDisplayPropertiesKHR, false)
+#endif
+
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 VULKAN_INSTANCE_ENTRY_POINT(vkCreateAndroidSurfaceKHR, false)
 #endif

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -9,6 +9,10 @@
 #define VK_USE_PLATFORM_WIN32_KHR
 #endif
 
+#if defined(HAVE_DRM)
+#define VK_USE_PLATFORM_DISPLAY_KHR
+#endif
+
 #if defined(HAVE_X11)
 #define VK_USE_PLATFORM_XLIB_KHR
 #endif


### PR DESCRIPTION
Utilizes vkCreateDisplayPlaneSurfaceKHR to create a DRM/KMS level surface.

This allows you to avoid dependency on X11, Wayland and other window systems