### PR TITLE
Branch Watch Tool: Refresh Context Menus OnEmulationStateChanged

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.h
@@ -124,11 +124,12 @@ private:
 
   void SetBreakpointMenuActionsIcons() const;
   QMenu* GetTableContextMenu(const QModelIndex& index) const;
-  QMenu* GetTableContextMenu_Instruction(bool core_initialized) const;
-  QMenu* GetTableContextMenu_Condition(bool core_initialized) const;
-  QMenu* GetTableContextMenu_Origin(bool core_initialized) const;
-  QMenu* GetTableContextMenu_Destin(bool core_initialized) const;
-  QMenu* GetTableContextMenu_Symbol(bool core_initialized) const;
+  void RefreshVisibleContextMenuActions(bool core_initialized) const;
+  void RefreshContextMenuActions_Instruction(bool core_initialized) const;
+  void RefreshContextMenuActions_Condition(bool core_initialized) const;
+  void RefreshContextMenuActions_Origin(bool core_initialized) const;
+  void RefreshContextMenuActions_Destin(bool core_initialized) const;
+  void RefreshContextMenuActions_Symbol(bool core_initialized) const;
 
   Core::System& m_system;
   Core::BranchWatch& m_branch_watch;
@@ -148,7 +149,7 @@ private:
   QAction* m_act_log_on_hit;
   QAction* m_act_both_on_hit;
   QMenu *m_mnu_table_context_instruction, *m_mnu_table_context_condition,
-      *m_mnu_table_context_origin, *m_mnu_table_context_destin_or_symbol,
+      *m_mnu_table_context_origin, *m_mnu_table_context_destin, *m_mnu_table_context_symbol,
       *m_mnu_table_context_other;
   QMenu* m_mnu_column_visibility;
 


### PR DESCRIPTION
Before this change, if the core starts up or shuts down while a Branch Watch Tool context menu is open, menu actions would remain enabled or disabled in an outdated way.