### PR TITLE
WiimoteEmu: Fix Drum Extension Velocity

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.h
@@ -5,6 +5,7 @@
 
 #include <array>
 
+#include "Common/BitField.h"
 #include "Core/HW/WiimoteEmu/Extension/Extension.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
@@ -34,7 +35,7 @@ public:
     u8 stick_y;    // 6 bits
     u8 buttons;    // 2 bits
     u8 drum_pads;  // 6 bits
-    u8 softness;   // 3 bits
+    u8 softness;   // 7 bits
   };
 
   struct DataFormat
@@ -47,24 +48,28 @@ public:
     // Seemingly random.
     u8 unk2 : 2;
 
-    // Always 1 with no velocity data and seemingly random otherwise.
-    u8 unk3 : 1;
+    u8 velocity3 : 1;
+
     // For which "pad" the velocity data is for.
     u8 velocity_id : 7;
 
-    // Always 1 with no velocity data and seemingly random otherwise.
-    u8 unk4 : 1;
+    u8 velocity2 : 1;
     // 1 with no velocity data and 0 when velocity data is present.
     u8 no_velocity_data_1 : 1;
     // These two bits seem to always be set. (0b11)
     u8 unk5 : 2;
     // 1 with no velocity data and 0 when velocity data is present.
     u8 no_velocity_data_2 : 1;
-    // How "soft" a drum pad has been hit as a range from 0:very-hard to 7:very-soft.
-    u8 softness : 3;
+
+    u8 velocity4 : 3;
 
     // Button bits.
-    u8 buttons;
+    union
+    {
+      u8 buttons;  // buttons
+      BitField<0, 1, u8> velocity0;
+      BitField<7, 1, u8> velocity1;
+    };
 
     // Drum-pad bits.
     u8 drum_pads;
@@ -94,8 +99,6 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  // FYI: The low/high bits of the button byte are "random" when velocity data is present.
-  // static constexpr u8 HAVE_VELOCITY_DATA = 0b10000001;
   static constexpr u8 BUTTON_PLUS = 0x04;
   static constexpr u8 BUTTON_MINUS = 0x10;
 


### PR DESCRIPTION
I did some tests by sending MIDI commands directly to a GHWT kit, and figured out that a lot of the "random" bits were actually just part of the velocity, and that there is actually a full 7 bits of velocity here, not just 3.

It turns out these kits actually just outright send MIDI data raw over the extension port, the MIDI velocity is just `0x7f - midi_velocity` and the MIDI note is just `0x7f - velocity_id`. The drums will even happily forward any MIDI note and velocity, not just the ones the pads are hardcoded with.