### PR TITLE
Save folder memory card header to disk

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -14,8 +14,6 @@
 #include "Core/HW/GCMemcard/GCMemcardBase.h"
 #include "DiscIO/Enums.h"
 
-// Uncomment this to write the system data of the memorycard from directory to disc
-//#define _WRITE_MC_HEADER 1
 void MigrateFromMemcardFile(const std::string& directory_name, ExpansionInterface::Slot card_slot,
                             DiscIO::Region region);
 


### PR DESCRIPTION
This way the memory card won't be recognized as a completely different memory card every game session, which can matter for some save files that use this information as copy protection.

This likely works around https://bugs.dolphin-emu.org/issues/12781 for saves created after this change only, though I have not verified this.

This also likely works around that issue where the PSO license file doesn't work on folder memory cards because we don't implement the encryption/checksum for it. I only vaguely remember the details about this and wasn't able to find an issue on our bug tracker, maybe someone knows what I'm talking about so we can verify this...