### PR TITLE
Qt crash hotfix

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigBool.h
@@ -6,11 +6,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 
-namespace Config
-{
-template <typename T>
-class Info;
-}
+#include "Common/Config/ConfigInfo.h"
 
 class ConfigBool final : public ConfigControl<ToolTipCheckBox>
 {
@@ -26,6 +22,6 @@ protected:
 private:
   void Update();
 
-  const Config::Info<bool>& m_setting;
+  const Config::Info<bool> m_setting;
   bool m_reverse;
 };

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
@@ -10,11 +10,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
 
-namespace Config
-{
-template <typename T>
-class Info;
-}
+#include "Common/Config/ConfigInfo.h"
 
 class ConfigChoice final : public ConfigControl<ToolTipComboBox>
 {
@@ -48,7 +44,7 @@ protected:
 private:
   void Update(int index);
 
-  const Config::Info<std::string>& m_setting;
+  const Config::Info<std::string> m_setting;
   bool m_text_is_data = false;
 };
 

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
@@ -6,11 +6,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
 
-namespace Config
-{
-template <typename T>
-class Info;
-}
+#include "Common/Config/ConfigInfo.h"
 
 // Automatically converts an int slider into a float one.
 // Do not read the int values or ranges directly from it.
@@ -31,5 +27,5 @@ protected:
 private:
   float m_minimum;
   float m_step;
-  const Config::Info<float>& m_setting;
+  const Config::Info<float> m_setting;
 };

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigInteger.h
@@ -9,11 +9,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSpinBox.h"
 
-namespace Config
-{
-template <typename T>
-class Info;
-}
+#include "Common/Config/ConfigInfo.h"
 
 class ConfigInteger final : public ConfigControl<ToolTipSpinBox>
 {
@@ -29,7 +25,7 @@ protected:
   void OnConfigChanged() override;
 
 private:
-  const Config::Info<int>& m_setting;
+  const Config::Info<int> m_setting;
 };
 
 class ConfigIntegerLabel final : public QLabel

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
@@ -6,11 +6,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipRadioButton.h"
 
-namespace Config
-{
-template <typename T>
-class Info;
-}
+#include "Common/Config/ConfigInfo.h"
 
 class ConfigRadioInt final : public ConfigControl<ToolTipRadioButton>
 {
@@ -31,6 +27,6 @@ protected:
 private:
   void Update();
 
-  const Config::Info<int>& m_setting;
+  const Config::Info<int> m_setting;
   int m_value;
 };

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
@@ -9,11 +9,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
 
-namespace Config
-{
-template <typename T>
-class Info;
-}
+#include "Common/Config/ConfigInfo.h"
 
 class ConfigSlider final : public ConfigControl<ToolTipSlider>
 {
@@ -29,7 +25,7 @@ protected:
   void OnConfigChanged() override;
 
 private:
-  const Config::Info<int>& m_setting;
+  const Config::Info<int> m_setting;
 };
 
 class ConfigSliderLabel final : public QLabel


### PR DESCRIPTION
During a final refactor and fixup, some member variables accidentally got changed to references.