### PR TITLE
AdvancedWidget: Replace FFV1 codec with Ut Video

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -63,7 +63,7 @@ const Info<bool> GFX_CACHE_HIRES_TEXTURES{{System::GFX, "Settings", "CacheHiresT
 const Info<bool> GFX_DUMP_EFB_TARGET{{System::GFX, "Settings", "DumpEFBTarget"}, false};
 const Info<bool> GFX_DUMP_XFB_TARGET{{System::GFX, "Settings", "DumpXFBTarget"}, false};
 const Info<bool> GFX_DUMP_FRAMES_AS_IMAGES{{System::GFX, "Settings", "DumpFramesAsImages"}, false};
-const Info<bool> GFX_USE_FFV1{{System::GFX, "Settings", "UseFFV1"}, false};
+const Info<bool> GFX_USE_LOSSLESS{{System::GFX, "Settings", "UseLossless"}, false};
 const Info<std::string> GFX_DUMP_FORMAT{{System::GFX, "Settings", "DumpFormat"}, "avi"};
 const Info<std::string> GFX_DUMP_CODEC{{System::GFX, "Settings", "DumpCodec"}, ""};
 const Info<std::string> GFX_DUMP_PIXEL_FORMAT{{System::GFX, "Settings", "DumpPixelFormat"}, ""};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -62,7 +62,7 @@ extern const Info<bool> GFX_CACHE_HIRES_TEXTURES;
 extern const Info<bool> GFX_DUMP_EFB_TARGET;
 extern const Info<bool> GFX_DUMP_XFB_TARGET;
 extern const Info<bool> GFX_DUMP_FRAMES_AS_IMAGES;
-extern const Info<bool> GFX_USE_FFV1;
+extern const Info<bool> GFX_USE_LOSSLESS;
 extern const Info<std::string> GFX_DUMP_FORMAT;
 extern const Info<std::string> GFX_DUMP_CODEC;
 extern const Info<std::string> GFX_DUMP_PIXEL_FORMAT;

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -185,11 +185,13 @@ void AdvancedWidget::CreateWidgets()
   dump_layout->addWidget(m_frame_dumps_resolution_type, 0, 1);
 
 #if defined(HAVE_FFMPEG)
-  m_dump_use_ffv1 =
-      new ConfigBool(tr("Use Lossless Codec (FFV1)"), Config::GFX_USE_FFV1, m_game_layer);
+  m_dump_use_lossless =
+      new ConfigBool(tr("Use Lossless Codec (Ut Video)"), Config::GFX_USE_LOSSLESS, m_game_layer);
+
   m_dump_bitrate = new ConfigInteger(0, 1000000, Config::GFX_BITRATE_KBPS, m_game_layer, 1000);
-  m_dump_bitrate->setEnabled(!m_dump_use_ffv1->isChecked());
-  dump_layout->addWidget(m_dump_use_ffv1, 1, 0);
+  m_dump_bitrate->setEnabled(!m_dump_use_lossless->isChecked());
+
+  dump_layout->addWidget(m_dump_use_lossless, 1, 0);
   dump_layout->addWidget(new QLabel(tr("Bitrate (kbps):")), 2, 0);
   dump_layout->addWidget(m_dump_bitrate, 2, 1);
 #endif
@@ -261,9 +263,8 @@ void AdvancedWidget::ConnectWidgets()
   });
   connect(m_enable_graphics_mods, &QCheckBox::toggled, this,
           [this](bool checked) { emit Settings::Instance().EnableGfxModsChanged(checked); });
-
 #if defined(HAVE_FFMPEG)
-  connect(m_dump_use_ffv1, &QCheckBox::toggled, this,
+  connect(m_dump_use_lossless, &QCheckBox::toggled, this,
           [this](bool checked) { m_dump_bitrate->setEnabled(!checked); });
 #endif
 }
@@ -391,8 +392,9 @@ void AdvancedWidget::AddDescriptions()
       "possible input for external editing software.<br><br><dolphin_emphasis>If unsure, leave "
       "this at \"Aspect Ratio Corrected Internal Resolution\".</dolphin_emphasis>");
 #if defined(HAVE_FFMPEG)
-  static const char TR_USE_FFV1_DESCRIPTION[] =
-      QT_TR_NOOP("Encodes frame dumps using the FFV1 codec.<br><br><dolphin_emphasis>If "
+  static const char TR_USE_LOSSLESS_DESCRIPTION[] =
+      QT_TR_NOOP("Encodes frame dumps using the Ut Video codec. If this option is unchecked, a "
+                 "lossy Xvid codec will be used.<br><br><dolphin_emphasis>If "
                  "unsure, leave this unchecked.</dolphin_emphasis>");
 #endif
   static const char TR_PNG_COMPRESSION_LEVEL_DESCRIPTION[] =
@@ -483,7 +485,7 @@ void AdvancedWidget::AddDescriptions()
   m_enable_graphics_mods->SetDescription(tr(TR_LOAD_GRAPHICS_MODS_DESCRIPTION));
   m_frame_dumps_resolution_type->SetDescription(tr(TR_FRAME_DUMPS_RESOLUTION_TYPE_DESCRIPTION));
 #ifdef HAVE_FFMPEG
-  m_dump_use_ffv1->SetDescription(tr(TR_USE_FFV1_DESCRIPTION));
+  m_dump_use_lossless->SetDescription(tr(TR_USE_LOSSLESS_DESCRIPTION));
 #endif
   m_png_compression_level->SetDescription(tr(TR_PNG_COMPRESSION_LEVEL_DESCRIPTION));
   m_enable_cropping->SetDescription(tr(TR_CROPPING_DESCRIPTION));

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -60,7 +60,7 @@ private:
   ConfigBool* m_dump_base_textures;
 
   // Frame dumping
-  ConfigBool* m_dump_use_ffv1;
+  ConfigBool* m_dump_use_lossless;
   ConfigChoice* m_frame_dumps_resolution_type;
   ConfigInteger* m_dump_bitrate;
   ConfigInteger* m_png_compression_level;

--- a/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
+++ b/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
@@ -217,7 +217,7 @@ bool FFMpegFrameDump::CreateVideoFile()
     return false;
   }
 
-  const std::string& codec_name = g_Config.bUseFFV1 ? "ffv1" : g_Config.sDumpCodec;
+  const std::string& codec_name = g_Config.bUseLossless ? "utvideo" : g_Config.sDumpCodec;
 
   AVCodecID codec_id = output_format->video_codec;
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -121,7 +121,7 @@ void VideoConfig::Refresh()
   bDumpEFBTarget = Config::Get(Config::GFX_DUMP_EFB_TARGET);
   bDumpXFBTarget = Config::Get(Config::GFX_DUMP_XFB_TARGET);
   bDumpFramesAsImages = Config::Get(Config::GFX_DUMP_FRAMES_AS_IMAGES);
-  bUseFFV1 = Config::Get(Config::GFX_USE_FFV1);
+  bUseLossless = Config::Get(Config::GFX_USE_LOSSLESS);
   sDumpFormat = Config::Get(Config::GFX_DUMP_FORMAT);
   sDumpCodec = Config::Get(Config::GFX_DUMP_CODEC);
   sDumpPixelFormat = Config::Get(Config::GFX_DUMP_PIXEL_FORMAT);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -193,7 +193,7 @@ struct VideoConfig final
   bool bDumpEFBTarget = false;
   bool bDumpXFBTarget = false;
   bool bDumpFramesAsImages = false;
-  bool bUseFFV1 = false;
+  bool bUseLossless = false;
   std::string sDumpCodec;
   std::string sDumpPixelFormat;
   std::string sDumpEncoder;


### PR DESCRIPTION
Replaces FFV1 codec checkbox with Ut Video.  To still use FFV1, one would have to uncheck "Use lossless" and set DumpCodec =  ffv1, which is currently what it takes to use Ut Video.

Users who previously had FFV1 checked will need to re-enable the Use Lossless replacement.

Requested here:
https://bugs.dolphin-emu.org/issues/13657

<details>
  <summary>Abandoned Plan</summary>

![codec](https://github.com/user-attachments/assets/8675724d-11c4-49c9-b6d4-7b53c6085cd6)

Requested here:
https://bugs.dolphin-emu.org/issues/13657

Problem: "UseFFV1" should no longer be needed, but I'm not sure how/where to convert that over so it doesn't collide.

</details>