### PR TITLE
HacksWidget: Convert texture cache accuracy option to radio buttons.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -6,6 +6,8 @@
 #include <QWidget>
 
 class ConfigBool;
+class ConfigRadioInt;
+class QRadioButton;
 class GameConfigWidget;
 class GraphicsWindow;
 class QLabel;
@@ -24,10 +26,8 @@ public:
   HacksWidget(GameConfigWidget* parent, Config::Layer* layer);
 
 private:
-  void LoadSettings();
-  void SaveSettings();
-
   void OnBackendChanged(const QString& backend_name);
+  void UpdateCacheAccuracy();
 
   // EFB
   ConfigBool* m_skip_efb_cpu;
@@ -37,7 +37,10 @@ private:
 
   // Texture Cache
   QLabel* m_accuracy_label;
-  ToolTipSlider* m_accuracy;
+  ConfigRadioInt* m_accuracy_safe;
+  ConfigRadioInt* m_accuracy_mid;
+  ConfigRadioInt* m_accuracy_fast;
+  QRadioButton* m_accuracy_custom;
   ConfigBool* m_gpu_texture_decoding;
 
   // External Framebuffer


### PR DESCRIPTION
![cache](https://github.com/user-attachments/assets/7c0d15e4-4ee1-403b-b7d4-13b5f9eecbca)

The only option I didn't fold into the game properties widgets PR.  It required UI changes, which I didn't want to make in that PR.
Works better with the config system, and allows user to toggle off/on a preset custom value during play.

There is the small issue with the game properties widgets not having global/system game ini data to set/show the options with.  When accessed within game properties, I coded it for users changing between the preset options and left custom values out of it, as that's usually done in a system and not user ini afaik.