### PR TITLE
Android: Fix VSync option not working

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
@@ -124,7 +124,7 @@ class Settings : Closeable {
         const val SECTION_INI_DSP = "DSP"
         const val SECTION_LOGGER_LOGS = "Logs"
         const val SECTION_LOGGER_OPTIONS = "Options"
-        const val SECTION_GFX_HARDWARE = "Settings"
+        const val SECTION_GFX_HARDWARE = "Hardware"
         const val SECTION_GFX_SETTINGS = "Settings"
         const val SECTION_GFX_ENHANCEMENTS = "Enhancements"
         const val SECTION_GFX_COLOR_CORRECTION = "ColorCorrection"


### PR DESCRIPTION
It happened due to a typo from SECTION_GFX_HARDWARE