### PR TITLE
DolphinQt/HacksWidget: Convert accuracy slider to ConfigSlider

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
@@ -1,6 +1,8 @@
 // Copyright 2017 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <cassert>
+
 #include <QFont>
 
 #include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
@@ -24,14 +26,58 @@ ConfigSlider::ConfigSlider(int minimum, int maximum, const Config::Info<int>& se
   connect(this, &ConfigSlider::valueChanged, this, &ConfigSlider::Update);
 }
 
+ConfigSlider::ConfigSlider(std::vector<int> tick_values, const Config::Info<int>& setting,
+                           Config::Layer* layer)
+    : ConfigControl(Qt::Horizontal, setting.GetLocation(), layer), m_setting(setting),
+      m_tick_values(std::move(tick_values))
+{
+  assert(!m_tick_values.empty());
+  setMinimum(0);
+  setMaximum(static_cast<int>(m_tick_values.size() - 1));
+  setPageStep(1);
+  setTickPosition(QSlider::TicksBelow);
+  OnConfigChanged();
+
+  connect(this, &ConfigSlider::valueChanged, this, &ConfigSlider::Update);
+}
+
 void ConfigSlider::Update(int value)
 {
-  SaveValue(m_setting, value);
+  if (!m_tick_values.empty())
+  {
+    if (value >= 0 && static_cast<size_t>(value) < m_tick_values.size())
+      SaveValue(m_setting, m_tick_values[static_cast<size_t>(value)]);
+  }
+  else
+  {
+    SaveValue(m_setting, value);
+  }
 }
 
 void ConfigSlider::OnConfigChanged()
 {
-  setValue(ReadValue(m_setting));
+  if (!m_tick_values.empty())
+  {
+    // re-enable in case it was disabled
+    setEnabled(true);
+
+    const int config_value = ReadValue(m_setting);
+    for (size_t i = 0; i < m_tick_values.size(); ++i)
+    {
+      if (m_tick_values[i] == config_value)
+      {
+        setValue(static_cast<int>(i));
+        return;
+      }
+    }
+
+    // if we reach here than none of the options matched, disable the slider
+    setEnabled(false);
+  }
+  else
+  {
+    setValue(ReadValue(m_setting));
+  }
 }
 
 ConfigSliderLabel::ConfigSliderLabel(const QString& text, ConfigSlider* slider)

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <QLabel>
 #include <QPointer>
 
@@ -19,6 +21,11 @@ public:
   ConfigSlider(int minimum, int maximum, const Config::Info<int>& setting, Config::Layer* layer,
                int tick = 0);
 
+  // Generates a slider with tick_values.size() ticks. Each tick corresponds to the integer at that
+  // index in the vector.
+  ConfigSlider(std::vector<int> tick_values, const Config::Info<int>& setting,
+               Config::Layer* layer);
+
   void Update(int value);
 
 protected:
@@ -26,6 +33,9 @@ protected:
 
 private:
   const Config::Info<int> m_setting;
+
+  // Mappings for slider ticks to config values. Identity mapping is assumed if this is empty.
+  std::vector<int> m_tick_values;
 };
 
 class ConfigSliderLabel final : public QLabel

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -6,6 +6,8 @@
 #include <QWidget>
 
 class ConfigBool;
+class ConfigSlider;
+class ConfigSliderLabel;
 class GameConfigWidget;
 class GraphicsWindow;
 class QLabel;
@@ -24,9 +26,6 @@ public:
   HacksWidget(GameConfigWidget* parent, Config::Layer* layer);
 
 private:
-  void LoadSettings();
-  void SaveSettings();
-
   void OnBackendChanged(const QString& backend_name);
 
   // EFB
@@ -36,8 +35,8 @@ private:
   ConfigBool* m_defer_efb_copies;
 
   // Texture Cache
-  QLabel* m_accuracy_label;
-  ToolTipSlider* m_accuracy;
+  ConfigSliderLabel* m_accuracy_label;
+  ConfigSlider* m_accuracy;
   ConfigBool* m_gpu_texture_decoding;
 
   // External Framebuffer


### PR DESCRIPTION
See https://github.com/dolphin-emu/dolphin/pull/13234#issuecomment-2561573588

We have to extend the ConfigSlider class a little bit for this use case, but it's pretty straightforward.

Less code and makes it work with the per-game config system. Seems like the obvious way to go to me?