### PR TITLE
JitArm64: Handle rlwinmx with zero mask

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -765,6 +765,14 @@ void JitArm64::rlwinmx_internal(UGeckoInstruction inst, u32 sh)
     return;
   }
 
+  if (mask == 0)
+  {
+    gpr.SetImmediate(a, 0);
+    if (inst.Rc)
+      ComputeRC0(0);
+    return;
+  }
+
   gpr.BindToRegister(a, a == s);
 
   if (sh == 0 && mask == 0xFFFFFFFF)


### PR DESCRIPTION
No games seem to use this, so this isn't useful as a performance optimization, but it's required for correctness because the (sh == 0) case of our implementation doesn't handle zero masks.