### PR TITLE
feat(linux): allow configuring real wiimotes with known bluetooth addresses

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -187,6 +187,8 @@ const Info<u64> MAIN_WII_SD_CARD_FILESIZE{{System::Main, "Core", "WiiSDCardFiles
 const Info<bool> MAIN_WII_KEYBOARD{{System::Main, "Core", "WiiKeyboard"}, false};
 const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING{
     {System::Main, "Core", "WiimoteContinuousScanning"}, false};
+const Info<std::string> MAIN_WIIMOTE_AUTO_CONNECT_ADDRESSES{
+    {System::Main, "Core", "WiimoteAutoConnectAddresses"}, ""};
 const Info<bool> MAIN_WIIMOTE_ENABLE_SPEAKER{{System::Main, "Core", "WiimoteEnableSpeaker"}, false};
 const Info<bool> MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE{
     {System::Main, "Core", "WiimoteControllerInterface"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -106,6 +106,7 @@ extern const Info<bool> MAIN_WII_SD_CARD_ENABLE_FOLDER_SYNC;
 extern const Info<u64> MAIN_WII_SD_CARD_FILESIZE;
 extern const Info<bool> MAIN_WII_KEYBOARD;
 extern const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING;
+extern const Info<std::string> MAIN_WIIMOTE_AUTO_CONNECT_ADDRESSES;
 extern const Info<bool> MAIN_WIIMOTE_ENABLE_SPEAKER;
 extern const Info<bool> MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE;
 extern const Info<bool> MAIN_MMU;

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
@@ -14,6 +14,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Core/Config/MainSettings.h"
 
 namespace WiimoteReal
 {
@@ -52,6 +53,8 @@ bool WiimoteScannerLinux::IsReady() const
 
 void WiimoteScannerLinux::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wiimote*& found_board)
 {
+  WiimoteScannerLinux::AddAutoConnectAddresses(found_wiimotes);
+
   // supposedly 1.28 seconds
   int const wait_len = 1;
 
@@ -108,6 +111,27 @@ void WiimoteScannerLinux::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wi
       found_wiimotes.push_back(wm);
       NOTICE_LOG_FMT(WIIMOTE, "Found Wiimote ({}).", bdaddr_str);
     }
+  }
+}
+
+void WiimoteScannerLinux::AddAutoConnectAddresses(std::vector<Wiimote*>& found_wiimotes)
+{
+  std::string entries = Config::Get(Config::MAIN_WIIMOTE_AUTO_CONNECT_ADDRESSES);
+  if (entries.empty())
+    return;
+  for (const auto& bt_address_str : SplitString(entries, ','))
+  {
+    bdaddr_t bt_addr;
+    if (str2ba(bt_address_str.c_str(), &bt_addr) < 0)
+    {
+      WARN_LOG_FMT(WIIMOTE, "Bad Known Bluetooth Address: {}", bt_address_str);
+      continue;
+    }
+    if (!IsNewWiimote(bt_address_str))
+      continue;
+    Wiimote* wm = new WiimoteLinux(bt_addr);
+    found_wiimotes.push_back(wm);
+    NOTICE_LOG_FMT(WIIMOTE, "Added Wiimote with fixed address ({}).", bt_address_str);
   }
 }
 

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.h
@@ -50,6 +50,8 @@ public:
 private:
   int m_device_id;
   int m_device_sock;
+
+  void AddAutoConnectAddresses(std::vector<Wiimote*>&);
 };
 }  // namespace WiimoteReal
 


### PR DESCRIPTION
This adds the option to configure real Wiimotes by specifying their Bluetooth addresses in the configuration file.  This allows off-brand Wiimotes to work without using the Bluetooth Passthrough option, if you know their Bluetooth addresses beforehand.

Despite correctly setting the LAP to `0x9e8b00` _(Limited Inquiry Access Code (LIAC))_ in `WiimoteScannerLinux::FindWiimotes` while scanning, which is indeed enough to make off-brand / knock-off Wiimotes respond to a Bluetooth Inquiry, some (several? all?) bluetooth adapters seem to override and ignore this given LAP value when performing the Inquiry, and actually use the `0x9e8b33` value _(General Inquiry Access Code (GIAC))_ as if a null pointer have been given to `hci_inquiry`, as inspection of USB/Bluetooth packets by Wireshark indicate.  Off-brand Wiimotes don't respond to inquiries with this LAP.

![Wireshark capture of an Inquiry that attempts to use LAP = `0x9e8b00`](https://github.com/user-attachments/assets/5044f6d2-6d1f-4265-b2a1-bfbd1b590855)

If one happens to know the Bluetooth address of their Wiimote (for example, by checking `BluetoothPassthrough.LinkKeys` after using Bluetooth Passthrough, or other means such as directly using `libusb` to force the adapter to use the correct LAP in the Inquiry), then it's enough to add those addresses to the vector of found Wiimotes.

![Example logs of using this patch to connect to a knock-off Wiimote with a known address](https://github.com/user-attachments/assets/d2ed4b64-22cf-4e3e-b96f-00aa2c5d3726)

Since this a niche use case and I only happen to know and have tested in Linux, this change only affects the `WiimoteScannerLinux` backend.  It's likely that it could be added to other backends, but I'm unfamiliar with these.

If no addresses are given or this config section does not exist, behavior is completely unchanged.