### PR TITLE
JitArm64: Fix frsqrte misclassifying large negative inputs as NaN

### DIFF
--- a/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/Frsqrte.cpp
@@ -57,18 +57,49 @@ TEST(JitArm64, Frsqrte)
   Core::DeclareAsCPUThread();
   Common::ScopeGuard cpu_thread_guard([] { Core::UndeclareAsCPUThread(); });
 
-  TestFrsqrte test(Core::System::GetInstance());
+  Core::System& system = Core::System::GetInstance();
+  TestFrsqrte test(system);
 
   for (const u64 ivalue : double_test_values)
   {
+    SCOPED_TRACE(fmt::format("frsqrte input: {:016x}\n", ivalue));
+
     const double dvalue = std::bit_cast<double>(ivalue);
 
     const u64 expected = std::bit_cast<u64>(Common::ApproximateReciprocalSquareRoot(dvalue));
     const u64 actual = test.frsqrte(ivalue);
 
-    if (expected != actual)
-      fmt::print("{:016x} -> {:016x} == {:016x}\n", ivalue, actual, expected);
-
     EXPECT_EQ(expected, actual);
+
+    for (u32 zx = 0; zx < 2; ++zx)
+    {
+      for (u32 vxsqrt = 0; vxsqrt < 2; ++vxsqrt)
+      {
+        UReg_FPSCR& fpscr = system.GetPPCState().fpscr;
+        fpscr = {};
+        fpscr.ZX = zx;
+        fpscr.VXSQRT = vxsqrt;
+
+        test.frsqrte(ivalue);
+
+        const u32 value_class = Common::ClassifyDouble(dvalue);
+
+        const bool input_is_zero =
+            value_class == Common::PPC_FPCLASS_NZ || value_class == Common::PPC_FPCLASS_PZ;
+        const bool input_is_negative = value_class == Common::PPC_FPCLASS_NN ||
+                                       value_class == Common::PPC_FPCLASS_ND ||
+                                       value_class == Common::PPC_FPCLASS_NINF;
+
+        const bool zx_expected = input_is_zero || zx;
+        const bool vxsqrt_expected = input_is_negative || vxsqrt;
+        const bool fx_expected = (input_is_zero && !zx) || (input_is_negative && !vxsqrt);
+
+        const u32 fpscr_expected = (zx_expected ? FPSCR_ZX : 0) |
+                                   (vxsqrt_expected ? FPSCR_VXSQRT : 0) |
+                                   (fx_expected ? FPSCR_FX : 0);
+
+        EXPECT_EQ(fpscr_expected, fpscr.Hex);
+      }
+    }
   }
 }


### PR DESCRIPTION
The frsqrte routine has a little trick where it uses `TBNZ(ARM64Reg::X1, 62)` to check if the input is NaN/Inf. This only works if we've checked that the input isn't normal. While we have checked that the input isn't a positive normal at this point, it could still be a negative normal. Because of this, the frsqrte routine would incorrectly treat certain negative normal inputs as NaNs, causing it to output the wrong exception in FPSCR (while still producing the correct numerical value).

To fix the problem, I'm swapping the order of the lines `FixupBranch nan_or_inf = TBNZ(ARM64Reg::X1, 62);` and `FixupBranch negative = TBNZ(ARM64Reg::X1, 63);`, and then instead of having the `nan_or_inf` case do a special check for negative infinity, I'm making the `negative` case do a special check for NaN. The total instruction count is the same.