### PR TITLE
Add some unit test coverage of the `SplitPath` function

### DIFF
--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -81,3 +81,114 @@ TEST(StringUtil, GetEscapedHtml)
   EXPECT_EQ(Common::GetEscapedHtml("&<>'\""), "&amp;&lt;&gt;&apos;&quot;");
   EXPECT_EQ(Common::GetEscapedHtml("&&&"), "&amp;&amp;&amp;");
 }
+
+TEST(StringUtil, SplitPath)
+{
+  std::string path;
+  std::string filename;
+  std::string extension;
+  EXPECT_TRUE(SplitPath("/usr/lib/some_file.txt", &path, &filename, &extension));
+  EXPECT_EQ(path, "/usr/lib/");
+  EXPECT_EQ(filename, "some_file");
+  EXPECT_EQ(extension, ".txt");
+}
+
+TEST(StringUtil, SplitPathNullOutputPathAllowed)
+{
+  std::string filename;
+  std::string extension;
+  EXPECT_TRUE(SplitPath("/usr/lib/some_file.txt", /*path=*/nullptr, &filename, &extension));
+  EXPECT_EQ(filename, "some_file");
+  EXPECT_EQ(extension, ".txt");
+}
+
+TEST(StringUtil, SplitPathNullOutputFilenameAllowed)
+{
+  std::string path;
+  std::string extension;
+  EXPECT_TRUE(SplitPath("/usr/lib/some_file.txt", &path, /*filename=*/nullptr, &extension));
+  EXPECT_EQ(path, "/usr/lib/");
+  EXPECT_EQ(extension, ".txt");
+}
+
+TEST(StringUtil, SplitPathNullOutputExtensionAllowed)
+{
+  std::string path;
+  std::string filename;
+  EXPECT_TRUE(SplitPath("/usr/lib/some_file.txt", &path, &filename, /*extension=*/nullptr));
+  EXPECT_EQ(path, "/usr/lib/");
+  EXPECT_EQ(filename, "some_file");
+}
+
+TEST(StringUtil, SplitPathReturnsFalseIfFullPathIsEmpty)
+{
+  std::string path;
+  std::string filename;
+  std::string extension;
+  EXPECT_FALSE(SplitPath(/*full_path=*/"", &path, &filename, &extension));
+  EXPECT_EQ(path, "");
+  EXPECT_EQ(filename, "");
+  EXPECT_EQ(extension, "");
+}
+
+TEST(StringUtil, SplitPathNoPath)
+{
+  std::string path;
+  std::string filename;
+  std::string extension;
+  EXPECT_TRUE(SplitPath("some_file.txt", &path, &filename, &extension));
+  EXPECT_EQ(path, "");
+  EXPECT_EQ(filename, "some_file");
+  EXPECT_EQ(extension, ".txt");
+}
+
+TEST(StringUtil, SplitPathNoFileName)
+{
+  std::string path;
+  std::string filename;
+  std::string extension;
+  EXPECT_TRUE(SplitPath("/usr/lib/.txt", &path, &filename, &extension));
+  EXPECT_EQ(path, "/usr/lib/");
+  EXPECT_EQ(filename, "");
+  EXPECT_EQ(extension, ".txt");
+}
+
+TEST(StringUtil, SplitPathNoExtension)
+{
+  std::string path;
+  std::string filename;
+  std::string extension;
+  EXPECT_TRUE(SplitPath("/usr/lib/some_file", &path, &filename, &extension));
+  EXPECT_EQ(path, "/usr/lib/");
+  EXPECT_EQ(filename, "some_file");
+  EXPECT_EQ(extension, "");
+}
+
+TEST(StringUtil, SplitPathDifferentPathLengths)
+{
+  std::string path;
+  std::string filename;
+  std::string extension;
+  EXPECT_TRUE(SplitPath("/usr/some_file.txt", &path, &filename, &extension));
+  EXPECT_EQ(path, "/usr/");
+  EXPECT_EQ(filename, "some_file");
+  EXPECT_EQ(extension, ".txt");
+
+  EXPECT_TRUE(SplitPath("/usr/lib/foo/some_file.txt", &path, &filename, &extension));
+  EXPECT_EQ(path, "/usr/lib/foo/");
+  EXPECT_EQ(filename, "some_file");
+  EXPECT_EQ(extension, ".txt");
+}
+
+TEST(StringUtil, SplitPathBackslashesNotRecognizedAsSeparators)
+{
+  std::string path;
+  std::string filename;
+  std::string extension;
+  EXPECT_TRUE(SplitPath("\\usr\\some_file.txt", &path, &filename, &extension));
+  EXPECT_EQ(path, "");
+  EXPECT_EQ(filename, "\\usr\\some_file");
+  EXPECT_EQ(extension, ".txt");
+}
+
+// TODO: add `SplitPath` test coverage for paths containing Windows drives, e.g., "C:".


### PR DESCRIPTION
This PR leaves coverage of paths containing Windows drives to a follow-up PR, since some of the edge case handling there is platform-specific.