### PR TITLE
Core/VideoCommon: Fix duplicate OSD Custom Textures messages

### DIFF
--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -77,11 +77,6 @@ std::pair<std::string, bool> GetNameArbPair(const TextureInfo& texture_info)
 }
 }  // namespace
 
-void HiresTexture::Init()
-{
-  Update();
-}
-
 void HiresTexture::Shutdown()
 {
   Clear();

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -22,7 +22,6 @@ std::set<std::string> GetTextureDirectoriesWithGameId(const std::string& root_di
 class HiresTexture
 {
 public:
-  static void Init();
   static void Update();
   static void Clear();
   static void Shutdown();

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -99,8 +99,6 @@ TextureCacheBase::TextureCacheBase()
   TexDecoder_SetTexFmtOverlayOptions(m_backup_config.texfmt_overlay,
                                      m_backup_config.texfmt_overlay_center);
 
-  HiresTexture::Init();
-
   TMEM::InvalidateAll();
 }
 


### PR DESCRIPTION
Resolves duplicate OSD messages for Loading and Found custom textures. 

Upon VideoBackend initialization HiresTexture::Init will be called, which previously called HiresTexture::Update.
This PR removes HiresTexture::Init as it no longer serves a purpose.

**Before:**
![image](https://github.com/user-attachments/assets/634d2960-9d72-4353-9678-cd7e6be237c4)

**After:**
![image](https://github.com/user-attachments/assets/d68262f8-f557-487f-bbbd-c2be166fa333)


**Reproduce Steps:**
1. Enable Graphics -> Advanced -> Load Custom Textures
2. (Optional) Enable Prefetch Custom Textures (this changes the message between Loading and Found)
3. Launch a game
4. Observe the double message

**Suggested Testing:**
1. Test with game window embedded in Main Window, and without
2. Test with DynamicInputTexture scenarios
3. Test with multi-layer texture scenarios (e.g. 'GUP' folder and 'GUPR8P' folder)
4. Launching a game from the Wii menu and make sure the textures load. - iwubcode
