### PR TITLE
Jit: Flush registers used in memory breakpoint conditions

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "Common/BitSet.h"
 #include "Common/CommonTypes.h"
 #include "Core/PowerPC/Expression.h"
 
@@ -127,7 +128,15 @@ public:
   void Clear();
   bool HasAny() const { return !m_mem_checks.empty(); }
 
+  BitSet32 GetGPRsUsedInConditions() { return m_gprs_used_in_conditions; }
+  BitSet32 GetFPRsUsedInConditions() { return m_fprs_used_in_conditions; }
+
 private:
+  // Returns whether any change was made
+  bool UpdateRegistersUsedInConditions();
+
   TMemChecks m_mem_checks;
   Core::System& m_system;
+  BitSet32 m_gprs_used_in_conditions;
+  BitSet32 m_fprs_used_in_conditions;
 };

--- a/Source/Core/Core/PowerPC/Expression.cpp
+++ b/Source/Core/Core/PowerPC/Expression.cpp
@@ -495,3 +495,22 @@ std::string Expression::GetText() const
 {
   return m_text;
 }
+
+void Expression::ComputeRegistersUsed()
+{
+  if (m_has_computed_registers_used)
+    return;
+
+  for (const VarBinding& bind : m_binds)
+  {
+    switch (bind.type)
+    {
+    case VarBindingType::GPR:
+      m_gprs_used[bind.index] = true;
+      break;
+    case VarBindingType::FPR:
+      m_fprs_used[bind.index] = true;
+      break;
+    }
+  }
+}

--- a/Source/Core/Core/PowerPC/Expression.h
+++ b/Source/Core/Core/PowerPC/Expression.h
@@ -9,6 +9,8 @@
 #include <string_view>
 #include <vector>
 
+#include "Common/BitSet.h"
+
 struct expr;
 struct expr_var_list;
 
@@ -41,6 +43,18 @@ public:
 
   std::string GetText() const;
 
+  BitSet32 GetGPRsUsed()
+  {
+    ComputeRegistersUsed();
+    return m_gprs_used;
+  }
+
+  BitSet32 GetFPRsUsed()
+  {
+    ComputeRegistersUsed();
+    return m_fprs_used;
+  }
+
 private:
   enum class SynchronizeDirection
   {
@@ -69,10 +83,16 @@ private:
   void SynchronizeBindings(Core::System& system, SynchronizeDirection dir) const;
   void Reporting(const double result) const;
 
+  void ComputeRegistersUsed();
+
   std::string m_text;
   ExprPointer m_expr;
   ExprVarListPointer m_vars;
   std::vector<VarBinding> m_binds;
+
+  BitSet32 m_gprs_used;
+  BitSet32 m_fprs_used;
+  bool m_has_computed_registers_used = false;
 };
 
 inline bool EvaluateCondition(Core::System& system, const std::optional<Expression>& condition)

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -81,6 +81,9 @@ public:
 
   void IntializeSpeculativeConstants();
 
+  void FlushPCBeforeSlowAccess();
+  void FlushRegistersBeforeSlowAccess();
+
   JitBlockCache* GetBlockCache() override { return &blocks; }
   void Trace();
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -30,6 +30,8 @@ void Jit64::lfXXX(UGeckoInstruction inst)
 
   FALLBACK_IF(!indexed && !a);
 
+  FlushRegistersBeforeSlowAccess();
+
   s32 offset = 0;
   RCOpArg addr = gpr.Bind(a, update ? RCMode::ReadWrite : RCMode::Read);
   RegCache::Realize(addr);
@@ -102,6 +104,8 @@ void Jit64::stfXXX(UGeckoInstruction inst)
   int accessSize = single ? 32 : 64;
 
   FALLBACK_IF(update && jo.memcheck && indexed && a == b);
+
+  FlushRegistersBeforeSlowAccess();
 
   if (single)
   {
@@ -195,6 +199,8 @@ void Jit64::stfiwx(UGeckoInstruction inst)
   int s = inst.RS;
   int a = inst.RA;
   int b = inst.RB;
+
+  FlushRegistersBeforeSlowAccess();
 
   RCOpArg Ra = a ? gpr.Use(a, RCMode::Read) : RCOpArg::Imm32(0);
   RCOpArg Rb = gpr.Use(b, RCMode::Read);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -35,6 +35,8 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
   int w = indexed ? inst.Wx : inst.W;
   FALLBACK_IF(!a);
 
+  FlushRegistersBeforeSlowAccess();
+
   RCX64Reg scratch_guard = gpr.Scratch(RSCRATCH_EXTRA);
   RCOpArg Ra = update ? gpr.Bind(a, RCMode::ReadWrite) : gpr.Use(a, RCMode::Read);
   RCOpArg Rb = indexed ? gpr.Use(b, RCMode::Read) : RCOpArg::Imm32((u32)offset);
@@ -69,8 +71,8 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
     }
     else
     {
-      // Stash PC in case asm routine needs to call into C++
-      MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
+      FlushPCBeforeSlowAccess();
+
       // We know what GQR is here, so we can load RSCRATCH2 and call into the store method directly
       // with just the scale bits.
       MOV(32, R(RSCRATCH2), Imm32(gqrValue & 0x3F00));
@@ -83,8 +85,8 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
   }
   else
   {
-    // Stash PC in case asm routine needs to call into C++
-    MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
+    FlushPCBeforeSlowAccess();
+
     // Some games (e.g. Dirt 2) incorrectly set the unused bits which breaks the lookup table code.
     // Hence, we need to mask out the unused bits. The layout of the GQR register is
     // UU[SCALE]UUUUU[TYPE] where SCALE is 6 bits and TYPE is 3 bits, so we have to AND with
@@ -124,6 +126,8 @@ void Jit64::psq_lXX(UGeckoInstruction inst)
   int w = indexed ? inst.Wx : inst.W;
   FALLBACK_IF(!a);
 
+  FlushRegistersBeforeSlowAccess();
+
   RCX64Reg scratch_guard = gpr.Scratch(RSCRATCH_EXTRA);
   RCX64Reg Ra = gpr.Bind(a, update ? RCMode::ReadWrite : RCMode::Read);
   RCOpArg Rb = indexed ? gpr.Use(b, RCMode::Read) : RCOpArg::Imm32((u32)offset);
@@ -144,8 +148,8 @@ void Jit64::psq_lXX(UGeckoInstruction inst)
   }
   else
   {
-    // Stash PC in case asm routine needs to call into C++
-    MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
+    FlushPCBeforeSlowAccess();
+
     // Get the high part of the GQR register
     OpArg gqr = PPCSTATE_SPR(SPR_GQR0 + i);
     gqr.AddMemOffset(2);

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -386,15 +386,10 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, 
     SetJumpTarget(slow);
   }
 
-  // PC is used by memory watchpoints (if enabled), profiling where to insert gather pipe
-  // interrupt checks, and printing accurate PC locations in debug logs.
-  //
-  // In the case of Jit64AsmCommon routines, we don't know the PC here,
-  // so the caller has to store the PC themselves.
+  // In the case of Jit64AsmCommon routines, the state we want to store here
+  // isn't known at JIT time, so the caller has to store it themselves.
   if (!(flags & SAFE_LOADSTORE_NO_UPDATE_PC))
-  {
-    MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
-  }
+    m_jit.FlushPCBeforeSlowAccess();
 
   size_t rsp_alignment = (flags & SAFE_LOADSTORE_NO_PROLOG) ? 8 : 0;
   ABI_PushRegistersAndAdjustStack(registersInUse, rsp_alignment);
@@ -457,8 +452,7 @@ void EmuCodeBlock::SafeLoadToRegImmediate(X64Reg reg_value, u32 address, int acc
     return;
   }
 
-  // Helps external systems know which instruction triggered the read.
-  MOV(32, PPCSTATE(pc), Imm32(m_jit.js.compilerPC));
+  m_jit.FlushPCBeforeSlowAccess();
 
   // Fall back to general-case code.
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
@@ -560,15 +554,10 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
     SetJumpTarget(slow);
   }
 
-  // PC is used by memory watchpoints (if enabled), profiling where to insert gather pipe
-  // interrupt checks, and printing accurate PC locations in debug logs.
-  //
-  // In the case of Jit64AsmCommon routines, we don't know the PC here,
-  // so the caller has to store the PC themselves.
+  // In the case of Jit64AsmCommon routines, the state we want to store here
+  // isn't known at JIT time, so the caller has to store it themselves.
   if (!(flags & SAFE_LOADSTORE_NO_UPDATE_PC))
-  {
-    MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
-  }
+    m_jit.FlushPCBeforeSlowAccess();
 
   size_t rsp_alignment = (flags & SAFE_LOADSTORE_NO_PROLOG) ? 8 : 0;
   ABI_PushRegistersAndAdjustStack(registersInUse, rsp_alignment);
@@ -663,8 +652,7 @@ bool EmuCodeBlock::WriteToConstAddress(int accessSize, OpArg arg, u32 address,
   }
   else
   {
-    // Helps external systems know which instruction triggered the write
-    MOV(32, PPCSTATE(pc), Imm32(m_jit.js.compilerPC));
+    m_jit.FlushPCBeforeSlowAccess();
 
     ABI_PushRegistersAndAdjustStack(registersInUse, 0);
     switch (accessSize)

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -273,8 +273,11 @@ protected:
   // !emitting_routine && mode != AlwaysSlowAccess && !jo.fastmem:                X30
   // !emitting_routine && mode == Auto && jo.fastmem:                             X30
   //
-  // Furthermore, any callee-saved register which isn't marked in gprs_to_push/fprs_to_push
-  // may be clobbered if mode != AlwaysFastAccess.
+  // Furthermore:
+  // - Any callee-saved register which isn't marked in gprs_to_push/fprs_to_push may be
+  //   clobbered if mode != AlwaysFastAccess.
+  // - If !emitting_routine && mode != AlwaysFastAccess && jo.memcheck, X30 must not
+  //   contain a guest register.
   void EmitBackpatchRoutine(u32 flags, MemAccessMode mode, Arm64Gen::ARM64Reg RS,
                             Arm64Gen::ARM64Reg addr, BitSet32 gprs_to_push = BitSet32(0),
                             BitSet32 fprs_to_push = BitSet32(0), bool emitting_routine = false);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -282,6 +282,9 @@ protected:
                             Arm64Gen::ARM64Reg addr, BitSet32 gprs_to_push = BitSet32(0),
                             BitSet32 fprs_to_push = BitSet32(0), bool emitting_routine = false);
 
+  // temp_gpr must be a valid register, but temp_fpr can be INVALID_REG.
+  void FlushPPCStateBeforeSlowAccess(Arm64Gen::ARM64Reg temp_gpr, Arm64Gen::ARM64Reg temp_fpr);
+
   // Loadstore routines
   void SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 offset, bool update);
   void SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s32 offset, bool update);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -102,9 +102,7 @@ void JitArm64::psq_lXX(UGeckoInstruction inst)
   {
     LDR(IndexType::Unsigned, scale_reg, PPC_REG, PPCSTATE_OFF_SPR(SPR_GQR0 + i));
 
-    // Stash PC in case asm routine needs to call into C++
-    MOVI2R(ARM64Reg::W30, js.compilerPC);
-    STR(IndexType::Unsigned, ARM64Reg::W30, PPC_REG, PPCSTATE_OFF(pc));
+    FlushPPCStateBeforeSlowAccess(ARM64Reg::W30, ARM64Reg::Q1);
 
     UBFM(type_reg, scale_reg, 16, 18);   // Type
     UBFM(scale_reg, scale_reg, 24, 29);  // Scale
@@ -260,9 +258,7 @@ void JitArm64::psq_stXX(UGeckoInstruction inst)
   {
     LDR(IndexType::Unsigned, scale_reg, PPC_REG, PPCSTATE_OFF_SPR(SPR_GQR0 + i));
 
-    // Stash PC in case asm routine needs to call into C++
-    MOVI2R(ARM64Reg::W30, js.compilerPC);
-    STR(IndexType::Unsigned, ARM64Reg::W30, PPC_REG, PPCSTATE_OFF(pc));
+    FlushPPCStateBeforeSlowAccess(ARM64Reg::W30, ARM64Reg::Q1);
 
     UBFM(type_reg, scale_reg, 0, 2);    // Type
     UBFM(scale_reg, scale_reg, 8, 13);  // Scale

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -388,14 +388,16 @@ public:
 
   BitSet32 GetDirtyGPRs() const;
 
-  void StoreRegisters(BitSet32 regs, Arm64Gen::ARM64Reg tmp_reg = Arm64Gen::ARM64Reg::INVALID_REG)
+  void StoreRegisters(BitSet32 regs, Arm64Gen::ARM64Reg tmp_reg = Arm64Gen::ARM64Reg::INVALID_REG,
+                      FlushMode flush_mode = FlushMode::All)
   {
-    FlushRegisters(regs, FlushMode::All, tmp_reg, IgnoreDiscardedRegisters::No);
+    FlushRegisters(regs, flush_mode, tmp_reg, IgnoreDiscardedRegisters::No);
   }
 
-  void StoreCRRegisters(BitSet8 regs, Arm64Gen::ARM64Reg tmp_reg = Arm64Gen::ARM64Reg::INVALID_REG)
+  void StoreCRRegisters(BitSet8 regs, Arm64Gen::ARM64Reg tmp_reg = Arm64Gen::ARM64Reg::INVALID_REG,
+                        FlushMode flush_mode = FlushMode::All)
   {
-    FlushCRRegisters(regs, FlushMode::All, tmp_reg, IgnoreDiscardedRegisters::No);
+    FlushCRRegisters(regs, flush_mode, tmp_reg, IgnoreDiscardedRegisters::No);
   }
 
   void DiscardCRRegisters(BitSet8 regs);
@@ -459,9 +461,10 @@ public:
 
   void FixSinglePrecision(size_t preg);
 
-  void StoreRegisters(BitSet32 regs, Arm64Gen::ARM64Reg tmp_reg = Arm64Gen::ARM64Reg::INVALID_REG)
+  void StoreRegisters(BitSet32 regs, Arm64Gen::ARM64Reg tmp_reg = Arm64Gen::ARM64Reg::INVALID_REG,
+                      FlushMode flush_mode = FlushMode::All)
   {
-    FlushRegisters(regs, FlushMode::All, tmp_reg);
+    FlushRegisters(regs, flush_mode, tmp_reg);
   }
 
 protected:


### PR DESCRIPTION
Aims to fix https://bugs.dolphin-emu.org/issues/13686.

I'm using a less efficient approach for Jit64 than for JitArm64. In JitArm64, I'm flushing in the slow access code, but in Jit64, I'm flushing before the split between the slow access code and the fast access code, because Jit64 doesn't keep register mappings around for when it's time to emit the slow access code. But the flushing code is only emitted when there are memory breakpoints with conditions, so I'd say that this is a performance loss we can live with.