### PR TITLE
Add a `SplitPath` unit test exercising Windows paths with drive letters

### DIFF
--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -191,4 +191,37 @@ TEST(StringUtil, SplitPathBackslashesNotRecognizedAsSeparators)
   EXPECT_EQ(extension, ".txt");
 }
 
-// TODO: add `SplitPath` test coverage for paths containing Windows drives, e.g., "C:".
+#ifdef _WIN32
+TEST(StringUtil, SplitPathWindowsPathWithDriveLetter)
+{
+  // Verify that on Windows, valid paths that include a drive letter and volume separator (e.g.,
+  // "C:") parse correctly.
+  std::string path;
+  std::string filename;
+  std::string extension;
+
+  // Absolute path with drive letter
+  EXPECT_TRUE(SplitPath("C:/dir/some_file.txt", &path, &filename, &extension));
+  EXPECT_EQ(path, "C:/dir/");
+  EXPECT_EQ(filename, "some_file");
+  EXPECT_EQ(extension, ".txt");
+
+  // Relative path with drive letter
+  EXPECT_TRUE(SplitPath("C:dir/some_file.txt", &path, &filename, &extension));
+  EXPECT_EQ(path, "C:dir/");
+  EXPECT_EQ(filename, "some_file");
+  EXPECT_EQ(extension, ".txt");
+
+  // Relative path with drive letter and no directory
+  EXPECT_TRUE(SplitPath("C:some_file.txt", &path, &filename, &extension));
+  EXPECT_EQ(path, "C:");
+  EXPECT_EQ(filename, "some_file");
+  EXPECT_EQ(extension, ".txt");
+
+  // Path that is just the drive letter
+  EXPECT_TRUE(SplitPath("C:", &path, &filename, &extension));
+  EXPECT_EQ(path, "C:");
+  EXPECT_EQ(filename, "");
+  EXPECT_EQ(extension, "");
+}
+#endif


### PR DESCRIPTION
The goal of this PR is to test Windows-specific behavior that is working as intended for `SplitPath`.

There are some behaviors of the current implementation that this PR does not test. For example:

* A Windows path like `"C:/dir/some_file.txt"` parses fine on non-Windows platforms, with the same output.
* An invalid path like `"C:/malformed_dir/:some_file.txt"` parses fine on Windows, with the output path being `"C:/malformed_dir/:"`.

I referenced this page to figure out what exactly qualifies as a valid Windows path: https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats.