### PR TITLE
Force Metroid Prime GCN and Metroid Prime 2 GCN to be 4:3

### DIFF
--- a/Data/Sys/GameSettings/G2M.ini
+++ b/Data/Sys/GameSettings/G2M.ini
@@ -12,6 +12,7 @@ CPUThread = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
+SuggestedAspectRatio = 2
 
 # Because the minimap has a lot of unused triangles, 
 # CPU Cull can greatly speed up demanding areas of the game.

--- a/Data/Sys/GameSettings/GM8.ini
+++ b/Data/Sys/GameSettings/GM8.ini
@@ -11,6 +11,7 @@
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
+SuggestedAspectRatio = 2
 
 # Because the minimap has a lot of unused triangles, 
 # CPU Cull can greatly speed up demanding areas of the game.


### PR DESCRIPTION
All of the GameCube versions of *Metroid Prime* and *Metroid Prime 2: [Dark] Echoes* only support 4:3, not 16:9.  
Currently, Dolphin's widescreen heuristic will fail to detect this and will erratically switch between 4:3 and 16:9 when Aspect Ratio is set to Auto.  
These changes prevent the erratic aspect ratio switching by manually declaring that the game is solely 4:3.