### PR TITLE
Gecko: Shadow the Hedgehog: Reloaded RA Approved Codes

### DIFF
--- a/Data/Sys/GameSettings/GUPR8P.ini
+++ b/Data/Sys/GameSettings/GUPR8P.ini
@@ -1,0 +1,35 @@
+# GUPR8P - Shadow the Hedgehog: Reloaded
+
+[Gecko]
+$No Idle ChaosPowers Music v2 [dreamsyntax]
+040A4FF0 60000000
+040A4D84 60000000
+*Disables the jingle when Shadow is in HeroShadow or DarkShadow state. Chaos Powers (Blast/Control) will still play their special music/sounds. After the Chaos Power completes, the original stage music will resume instead of restarting from the beginning.
+
+$Mute music and cutscenes
+0458F99C 00000000
+0458FA90 00000000
+*Mutes all adx tracks (including cutscenes).
+
+$Skip Loading Any Events In Story Mode / Last Story [dreamsyntax]
+0425D460 60000000
+*Makes StageSequenceManager skip all events/sfd. For example pressing Last Story will immediately start The Last Way instead of playing the multiple events.
+
+$No Subtitles [LimblessVector]
+045E1B9C 00000000
+*Voice lines will play, but no subtitles will render to the screen.
+*This includes pause text and rank info on select mode.
+
+$Restore Partner Intro Cutscene Behavior [dreamsyntax]
+04073E10 4082004C
+*Restore the camera event on first partner meet.
+
+$Force Restart on Death (Hold L) [dreamsyntax]
+C2204854 00000005
+3C808057 60845D5E
+88840000 2C040010
+38800008 41820008
+40820008 38800007
+60000000 00000000
+*QoL code for speedruns.
+*Hold L to force a restart on death.


### PR DESCRIPTION
Predecessor PR to https://github.com/dolphin-emu/dolphin/pull/13204
Adds GUPR8P's required RA codes (from the community list) to Sys, in preparation for being added to the allowlist.