### PR TITLE
GameINI: fix `Summoner: Goddess Reborn` sound system crash during transitions

### DIFF
--- a/Data/Sys/GameSettings/GS2E78.ini
+++ b/Data/Sys/GameSettings/GS2E78.ini
@@ -1,7 +1,48 @@
 # GS2E78 - Summoner 2
 
 [OnFrame]
-# Add memory patches to be applied every frame here.
+# This game will reinitialize the sound system buffers during transitions while
+# sounds are still being played. There are still pointers in the sound list to
+# sounds in those buffers when the buffers get cleared, so the game crashes with
+# a null pointer dereference.
+# 
+# This patch will clean up the pending sound list during sound system
+# reinitialization before continuing to the sound system initialization call
+# previously at 0x8017E338.
+$Fix Sound System Crash
+0x8017E338:dword:0x480954C9
+0x80213800:dword:0x9421FFE0
+0x80213804:dword:0x7C0802A6
+0x80213808:dword:0x90010024
+0x8021380C:dword:0x93E1001C
+0x80213810:dword:0x93C10018
+0x80213814:dword:0x93A10014
+0x80213818:dword:0x7C7D1B78
+0x8021381C:dword:0x4BF7A7D1
+0x80213820:dword:0x83CDA0C0
+0x80213824:dword:0x7C7F1B78
+0x80213828:dword:0x48000010
+0x8021382C:dword:0x807E0008
+0x80213830:dword:0x4BF8C721
+0x80213834:dword:0x83DE0000
+0x80213838:dword:0x281E0000
+0x8021383C:dword:0x4082FFF0
+0x80213840:dword:0x38000000
+0x80213844:dword:0x7FE3FB78
+0x80213848:dword:0x900DA0C0
+0x8021384C:dword:0x4BF7A7C9
+0x80213850:dword:0x7FA3EB78
+0x80213854:dword:0x4BF6A49D
+0x80213858:dword:0x80010024
+0x8021385C:dword:0x83E1001C
+0x80213860:dword:0x83C10018
+0x80213864:dword:0x83A10014
+0x80213868:dword:0x7C0803A6
+0x8021386C:dword:0x38210020
+0x80213870:dword:0x4E800020
+
+[OnFrame_Enabled]
+$Fix Sound System Crash
 
 [ActionReplay]
 # Add action replay cheats here.


### PR DESCRIPTION
Summoner: Goddess Reborn will reinitialize the sound system buffers during transitions while sounds are still being played. There are still pointers in the sound list to sounds in those buffers when the buffers get cleared, so the game crashes with a null pointer dereference if an Audio Interface DMA interrupt is triggered while in that state. 

This patch will clean up the pending sound list during sound system reinitialization before continuing to the sound system initialization call previously at 0x8017E338 (On GS2E78).

I would need to work with other people to patch the other regions of the game. If they need patching that is.