### PR TITLE
JitArm64_Integer: Carry flag optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1495,8 +1495,16 @@ void JitArm64::addex(UGeckoInstruction inst)
     {
       gpr.BindToRegister(d, false);
       ARM64Reg RD = gpr.R(d);
-      MOVI2R(RD, imm);
-      ADC(RD, RD, ARM64Reg::WZR);
+      if (is_zero)
+      {
+        // RD = 0 + carry = carry ? 1 : 0
+        CSET(RD, CC_CS);
+      }
+      else
+      {
+        MOVI2R(RD, imm);
+        ADC(RD, RD, ARM64Reg::WZR);
+      }
       break;
     }
     case CarryFlag::ConstantTrue:

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1244,8 +1244,18 @@ void JitArm64::subfex(UGeckoInstruction inst)
     {
       gpr.BindToRegister(d, false);
       ARM64Reg RD = gpr.R(d);
-      MOVI2R(RD, imm);
-      ADC(RD, RD, ARM64Reg::WZR);
+      if (is_all_ones)
+      {
+        // RD = -1 + carry = carry ? 0 : -1
+        // CSETM sets the destination to -1 if the condition is true, 0
+        // otherwise. Hence, the condition must be carry clear.
+        CSETM(RD, CC_CC);
+      }
+      else
+      {
+        MOVI2R(RD, imm);
+        ADC(RD, RD, ARM64Reg::WZR);
+      }
       break;
     }
     case CarryFlag::ConstantTrue:

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1500,6 +1500,13 @@ void JitArm64::addex(UGeckoInstruction inst)
         // RD = 0 + carry = carry ? 1 : 0
         CSET(RD, CC_CS);
       }
+      else if (is_all_ones)
+      {
+        // RD = -1 + carry = carry ? 0 : -1
+        // Note that CSETM sets the destination to -1 if the condition is true,
+        // and 0 otherwise. Hence, the condition must be carry clear.
+        CSETM(RD, CC_CC);
+      }
       else
       {
         MOVI2R(RD, imm);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1219,6 +1219,7 @@ void JitArm64::subfex(UGeckoInstruction inst)
     const u32 i = gpr.GetImm(a);
     const u32 j = mex ? -1 : gpr.GetImm(b);
     const u32 imm = ~i + j;
+    const bool is_zero = imm == 0;
     const bool is_all_ones = imm == 0xFFFFFFFF;
 
     switch (js.carryFlag)
@@ -1227,9 +1228,16 @@ void JitArm64::subfex(UGeckoInstruction inst)
     {
       gpr.BindToRegister(d, false);
       ARM64Reg RD = gpr.R(d);
-      auto WA = gpr.GetScopedReg();
-      LDRB(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
-      ADDI2R(RD, WA, imm, RD);
+      if (is_zero)
+      {
+        LDRB(IndexType::Unsigned, RD, PPC_REG, PPCSTATE_OFF(xer_ca));
+      }
+      else
+      {
+        auto WA = gpr.GetScopedReg();
+        LDRB(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
+        ADDI2R(RD, WA, imm, RD);
+      }
       break;
     }
     case CarryFlag::InHostCarry:

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -110,7 +110,7 @@ JitBase::~JitBase()
   CPUThreadConfigCallback::RemoveConfigChangedCallback(m_registered_config_callback_id);
 }
 
-bool JitBase::DoesConfigNeedRefresh()
+bool JitBase::DoesConfigNeedRefresh() const
 {
   return std::ranges::any_of(JIT_SETTINGS, [this](const auto& pair) {
     return this->*pair.first != Config::Get(*pair.second);
@@ -276,7 +276,7 @@ bool JitBase::CanMergeNextInstructions(int count) const
   return true;
 }
 
-bool JitBase::ShouldHandleFPExceptionForInstruction(const PPCAnalyst::CodeOp* op)
+bool JitBase::ShouldHandleFPExceptionForInstruction(const PPCAnalyst::CodeOp* op) const
 {
   if (jo.fp_exceptions)
     return (op->opinfo->flags & FL_FLOAT_EXCEPTION) != 0;

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -167,7 +167,7 @@ protected:
 
   static const std::array<std::pair<bool JitBase::*, const Config::Info<bool>*>, 23> JIT_SETTINGS;
 
-  bool DoesConfigNeedRefresh();
+  bool DoesConfigNeedRefresh() const;
   void RefreshConfig();
 
   void InitFastmemArena();
@@ -187,7 +187,7 @@ protected:
 #endif
   }
 
-  bool ShouldHandleFPExceptionForInstruction(const PPCAnalyst::CodeOp* op);
+  bool ShouldHandleFPExceptionForInstruction(const PPCAnalyst::CodeOp* op) const;
 
 public:
   explicit JitBase(Core::System& system);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -178,6 +178,14 @@ protected:
   void CleanUpAfterStackFault();
 
   bool CanMergeNextInstructions(int count) const;
+  bool HasConstantCarry() const
+  {
+#ifdef _M_ARM_64
+    return js.carryFlag == CarryFlag::ConstantTrue || js.carryFlag == CarryFlag::ConstantFalse;
+#else
+    return false;
+#endif
+  }
 
   bool ShouldHandleFPExceptionForInstruction(const PPCAnalyst::CodeOp* op);
 


### PR DESCRIPTION
This PR implements a bunch of missing optimization opportunities regarding the carry flag.

- addex

<details><summary>Optimize InPPCState for 0</summary>
Before:

```
0x394bd3b8 ldrb w24, [x29, #0x2f4]
0x2a1803f9 mov w25, w24
```

After:
```
0x394bd3b9 ldrb w25, [x29, #0x2f4]
```

</details>

<details><summary>Optimize InHostCarry for 0</summary>
Before:

```
0x5280001b   mov    w27, #0x0                 ; =0
0x1a1f037b   adc    w27, w27, wzr
```

After:
```
0x1a9f37fb   cset   w27, hs
```
</details>

<details><summary>Optimize InHostCarry for -1</summary>
Before:

```
0x1280001a   mov    w26, #-0x1                ; =-1
0x1a1f035a   adc    w26, w26, wzr
```

After:
```
0x5a9f23fa   csetm  w26, lo
```
</details>

- addzex

<details><summary>Optimize ConstantFalse for 0</summary>
Before:

```
0x52800119   mov    w25, #0x8                 ; =8
0x2a1903fa   mov    w26, w25
```

After:
```
```

</details>

<details><summary>Optimize ConstantTrue for 0</summary>
Before:

```
0x52800119   mov    w25, #0x8                 ; =8
0x1100073a   add    w26, w25, #0x1
```

After:
```
```

</details>

<details><summary>Optimize InPPCState for 0</summary>
Before:

```
0x52800019   mov    w25, #0x0                 ; =0
0x394bd3b8   ldrb   w24, [x29, #0x2f4]
0x2b180339   adds   w25, w25, w24
```

After:
```
0x394bd3b9   ldrb   w25, [x29, #0x2f4]
```

</details>

<details><summary>Optimize InHostCarry for 0</summary>
Before:

```
0x5280000d   mov    w13, #0x0                 ; =0
0x1a1f01ae   adc    w14, w13, wzr
```

After:
```
0x1a9f37ee   cset   w14, hs
```
</details>

- subfex

<details><summary>Optimize InPPCState for 0</summary>
Before:

```
0x394bd3b8   ldrb   w24, [x29, #0x2f4]
0x2a1803f9   mov    w25, w24
```

After:
```
0x394bd3b9   ldrb   w25, [x29, #0x2f4]
```
</details>

<details><summary>Optimize InHostCarry for -1</summary>
Before:

```
0x1280001a   mov    w26, #-0x1                ; =-1
0x1a1f035a   adc    w26, w26, wzr
```

After:
```
0x5a9f23fa   csetm  w26, lo
```
</details>

- subfzex

<details><summary>Constant folding</summary>
Before:

```
0x52800016   mov    w22, #0x0                 ; =0
0x2a3603f6   mvn    w22, w22
```

After:
```
```
</details>