### PR TITLE
DolphinQt: Fix post processing shader selector when language is not English.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -378,7 +378,7 @@ void EnhancementsWidget::ShaderChanged()
 {
   auto shader = ReadSetting(Config::GFX_ENHANCE_POST_SHADER);
 
-  if (shader == "(off)" || shader == "")
+  if (shader == tr("(off)") || shader == "")
   {
     shader = "";
 


### PR DESCRIPTION
This fixes the check and prevents translations of the string "(off)" from being saved in GFX.ini