### PR TITLE
Add SYSCONF country code to DTM

### DIFF
--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -41,6 +41,7 @@ static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
   else
     config_layer->Set(Config::MAIN_GC_LANGUAGE, static_cast<int>(dtm->language));
   config_layer->Set(Config::SYSCONF_WIDESCREEN, dtm->bWidescreen);
+  config_layer->Set(Config::SYSCONF_COUNTRY, dtm->countryCode);
 
   config_layer->Set(Config::GFX_HACK_EFB_ACCESS_ENABLE, dtm->bEFBAccessEnable);
   config_layer->Set(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, dtm->bSkipEFBCopyToRam);
@@ -69,6 +70,7 @@ void SaveToDTM(Movie::DTMHeader* dtm)
   else
     dtm->language = Config::Get(Config::MAIN_GC_LANGUAGE);
   dtm->bWidescreen = Config::Get(Config::SYSCONF_WIDESCREEN);
+  dtm->countryCode = Config::Get(Config::SYSCONF_COUNTRY);
 
   dtm->bEFBAccessEnable = Config::Get(Config::GFX_HACK_EFB_ACCESS_ENABLE);
   dtm->bSkipEFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -132,7 +132,8 @@ struct DTMHeader
   bool bUseFMA;
   u8 GBAControllers;                // GBA Controllers plugged in (the bits are ports 1-4)
   bool bWidescreen;                 // true indicates SYSCONF aspect ratio is 16:9, false for 4:3
-  std::array<u8, 6> reserved;       // Padding for any new config options
+  u8 countryCode;                   // SYSCONF country code
+  std::array<u8, 5> reserved;       // Padding for any new config options
   std::array<char, 40> discChange;  // Name of iso file to switch to, for two disc games.
   std::array<u8, 20> revision;      // Git hash
   u32 DSPiromHash;


### PR DESCRIPTION
Recently there was some issues in TASVideos trying to sync a Donkey Kong Country Returns TAS. It eventually was synced by directly using the config from the TAS author. The exact setting which caused the desync was narrowed down to being in SYSCONF, with the country code. The TAS author lives in the US, so the country code matched the US country code, while the person attempting to sync the TAS did not live in the US.

Adding SYSCONF country code to the DTM should avoid this being an issue for future Dolphin versions.