### PR TITLE
Qt: Fix some options not changing enabled status on game start.

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
@@ -63,7 +63,6 @@ void ConfigStringChoice::Load()
   const int index = m_text_is_data ? findText(setting_value) : findData(setting_value);
 
   // This can be called publicly.
-  const QSignalBlocker block(this);
   setCurrentIndex(index);
 }
 
@@ -145,6 +144,7 @@ void ConfigComplexChoice::UpdateComboIndex()
   auto it = std::find(m_options.begin(), m_options.end(), values);
   int index = static_cast<int>(std::distance(m_options.begin(), it));
 
+  // Will crash if not blocked
   const QSignalBlocker blocker(this);
   setCurrentIndex(index);
 }

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -232,7 +232,10 @@ void GeneralWidget::OnEmulationStateChanged(bool running)
   std::string current_backend = m_backend_combo->currentData().toString().toStdString();
   if (Config::Get(Config::MAIN_GFX_BACKEND) != current_backend)
   {
-    m_backend_combo->Load();
+    {
+      const QSignalBlocker blocker(m_backend_combo);
+      m_backend_combo->Load();
+    }
     emit BackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
   }
 }


### PR DESCRIPTION
When a game starts and the game config is loaded, the signal block on ConfigChanged will prevent options from updating properly, such as triggering an enable/disable for some options that are linked.  The signal block was used to prevent triggering a Save.

Programmatic updates that change the value to something different from the config need to be saved. "VBI skip" triggering "skip duplicate XFBs" is one example. 
ConfigChanged updates change the value of an option to be consistent with the new config, and should not trigger a Save, because that triggers another ConfigChanged.

I dropped the SignalBlocker in favor of an m_updating bool, to only block the re-saving.

A different solution would be to just shove every enable/disable/etc check under the ConfigChanged signal. I don't really like how bloated it's getting though.