### PR TITLE
Android: Detect GCAdapter hotplug using BroadcastReceiver

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
@@ -9,8 +9,8 @@ import android.hardware.usb.UsbManager;
 
 import org.dolphinemu.dolphinemu.utils.ActivityTracker;
 import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
-import org.dolphinemu.dolphinemu.utils.Java_GCAdapter;
-import org.dolphinemu.dolphinemu.utils.Java_WiimoteAdapter;
+import org.dolphinemu.dolphinemu.utils.GCAdapter;
+import org.dolphinemu.dolphinemu.utils.WiimoteAdapter;
 import org.dolphinemu.dolphinemu.utils.VolleyUtil;
 
 public class DolphinApplication extends Application
@@ -28,8 +28,8 @@ public class DolphinApplication extends Application
     VolleyUtil.init(getApplicationContext());
     System.loadLibrary("main");
 
-    Java_GCAdapter.manager = (UsbManager) getSystemService(Context.USB_SERVICE);
-    Java_WiimoteAdapter.manager = (UsbManager) getSystemService(Context.USB_SERVICE);
+    GCAdapter.manager = (UsbManager) getSystemService(Context.USB_SERVICE);
+    WiimoteAdapter.manager = (UsbManager) getSystemService(Context.USB_SERVICE);
 
     if (DirectoryInitialization.shouldStart(getApplicationContext()))
       DirectoryInitialization.start(getApplicationContext());

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/GCAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/GCAdapter.java
@@ -142,43 +142,48 @@ public class GCAdapter
     {
       dev = adapterDevice;
     }
-
-    if (dev != null)
+    if (dev == null)
     {
-      usbConnection = manager.openDevice(dev);
-
-      Log.info("GCAdapter: Number of configurations: " + dev.getConfigurationCount());
-      Log.info("GCAdapter: Number of interfaces: " + dev.getInterfaceCount());
-
-      if (dev.getConfigurationCount() > 0 && dev.getInterfaceCount() > 0)
-      {
-        UsbConfiguration conf = dev.getConfiguration(0);
-        usbInterface = conf.getInterface(0);
-        usbConnection.claimInterface(usbInterface, true);
-
-        Log.info("GCAdapter: Number of endpoints: " + usbInterface.getEndpointCount());
-
-        if (usbInterface.getEndpointCount() == 2)
-        {
-          for (int i = 0; i < usbInterface.getEndpointCount(); ++i)
-            if (usbInterface.getEndpoint(i).getDirection() == UsbConstants.USB_DIR_IN)
-              usbIn = usbInterface.getEndpoint(i);
-            else
-              usbOut = usbInterface.getEndpoint(i);
-
-          initAdapter();
-          return true;
-        }
-        else
-        {
-          usbConnection.releaseInterface(usbInterface);
-        }
-      }
-
-      Toast.makeText(DolphinApplication.getAppContext(), R.string.replug_gc_adapter,
-              Toast.LENGTH_LONG).show();
-      usbConnection.close();
+      return false;
     }
+
+    usbConnection = manager.openDevice(dev);
+    if (usbConnection == null)
+    {
+      return false;
+    }
+
+    Log.info("GCAdapter: Number of configurations: " + dev.getConfigurationCount());
+    Log.info("GCAdapter: Number of interfaces: " + dev.getInterfaceCount());
+
+    if (dev.getConfigurationCount() > 0 && dev.getInterfaceCount() > 0)
+    {
+      UsbConfiguration conf = dev.getConfiguration(0);
+      usbInterface = conf.getInterface(0);
+      usbConnection.claimInterface(usbInterface, true);
+
+      Log.info("GCAdapter: Number of endpoints: " + usbInterface.getEndpointCount());
+
+      if (usbInterface.getEndpointCount() == 2)
+      {
+        for (int i = 0; i < usbInterface.getEndpointCount(); ++i)
+          if (usbInterface.getEndpoint(i).getDirection() == UsbConstants.USB_DIR_IN)
+            usbIn = usbInterface.getEndpoint(i);
+          else
+            usbOut = usbInterface.getEndpoint(i);
+
+        initAdapter();
+        return true;
+      }
+      else
+      {
+        usbConnection.releaseInterface(usbInterface);
+      }
+    }
+
+    Toast.makeText(DolphinApplication.getAppContext(), R.string.replug_gc_adapter,
+            Toast.LENGTH_LONG).show();
+    usbConnection.close();
     return false;
   }
 

--- a/Source/Core/Core/HW/WiimoteReal/IOAndroid.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOAndroid.cpp
@@ -30,8 +30,8 @@ void WiimoteScannerAndroid::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
 
   JNIEnv* env = IDCache::GetEnvForThread();
 
-  jmethodID openadapter_func = env->GetStaticMethodID(s_adapter_class, "OpenAdapter", "()Z");
-  jmethodID queryadapter_func = env->GetStaticMethodID(s_adapter_class, "QueryAdapter", "()Z");
+  jmethodID openadapter_func = env->GetStaticMethodID(s_adapter_class, "openAdapter", "()Z");
+  jmethodID queryadapter_func = env->GetStaticMethodID(s_adapter_class, "queryAdapter", "()Z");
 
   if (env->CallStaticBooleanMethod(s_adapter_class, queryadapter_func) &&
       env->CallStaticBooleanMethod(s_adapter_class, openadapter_func))
@@ -55,15 +55,15 @@ bool WiimoteAndroid::ConnectInternal()
 {
   m_env = IDCache::GetEnvForThread();
 
-  jfieldID payload_field = m_env->GetStaticFieldID(s_adapter_class, "wiimote_payload", "[[B");
+  jfieldID payload_field = m_env->GetStaticFieldID(s_adapter_class, "wiimotePayload", "[[B");
   jobjectArray payload_object =
       reinterpret_cast<jobjectArray>(m_env->GetStaticObjectField(s_adapter_class, payload_field));
   m_java_wiimote_payload =
       (jbyteArray)m_env->GetObjectArrayElement(payload_object, m_mayflash_index);
 
   // Get function pointers
-  m_input_func = m_env->GetStaticMethodID(s_adapter_class, "Input", "(I)I");
-  m_output_func = m_env->GetStaticMethodID(s_adapter_class, "Output", "(I[BI)I");
+  m_input_func = m_env->GetStaticMethodID(s_adapter_class, "input", "(I)I");
+  m_output_func = m_env->GetStaticMethodID(s_adapter_class, "output", "(I[BI)I");
 
   is_connected = true;
 
@@ -110,7 +110,7 @@ int WiimoteAndroid::IOWrite(u8 const* buf, size_t len)
 void InitAdapterClass()
 {
   JNIEnv* env = IDCache::GetEnvForThread();
-  jclass adapter_class = env->FindClass("org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter");
+  jclass adapter_class = env->FindClass("org/dolphinemu/dolphinemu/utils/WiimoteAdapter");
   s_adapter_class = reinterpret_cast<jclass>(env->NewGlobalRef(adapter_class));
 }
 }  // namespace WiimoteReal

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -180,14 +180,14 @@ static void ReadThreadFunc()
   bool first_read = true;
   JNIEnv* const env = IDCache::GetEnvForThread();
 
-  const jfieldID payload_field = env->GetStaticFieldID(s_adapter_class, "controller_payload", "[B");
+  const jfieldID payload_field = env->GetStaticFieldID(s_adapter_class, "controllerPayload", "[B");
   jobject payload_object = env->GetStaticObjectField(s_adapter_class, payload_field);
   auto* const java_controller_payload = reinterpret_cast<jbyteArray*>(&payload_object);
 
   // Get function pointers
-  const jmethodID getfd_func = env->GetStaticMethodID(s_adapter_class, "GetFD", "()I");
-  const jmethodID input_func = env->GetStaticMethodID(s_adapter_class, "Input", "()I");
-  const jmethodID openadapter_func = env->GetStaticMethodID(s_adapter_class, "OpenAdapter", "()Z");
+  const jmethodID getfd_func = env->GetStaticMethodID(s_adapter_class, "getFd", "()I");
+  const jmethodID input_func = env->GetStaticMethodID(s_adapter_class, "input", "()I");
+  const jmethodID openadapter_func = env->GetStaticMethodID(s_adapter_class, "openAdapter", "()Z");
 
   const bool connected = env->CallStaticBooleanMethod(s_adapter_class, openadapter_func);
 
@@ -279,7 +279,7 @@ static void WriteThreadFunc()
   int size = 0;
 #elif GCADAPTER_USE_ANDROID_IMPLEMENTATION
   JNIEnv* const env = IDCache::GetEnvForThread();
-  const jmethodID output_func = env->GetStaticMethodID(s_adapter_class, "Output", "([B)I");
+  const jmethodID output_func = env->GetStaticMethodID(s_adapter_class, "output", "([B)I");
 #endif
 
   while (s_write_adapter_thread_running.IsSet())
@@ -394,7 +394,7 @@ static void ScanThreadFunc()
   JNIEnv* const env = IDCache::GetEnvForThread();
 
   const jmethodID queryadapter_func =
-      env->GetStaticMethodID(s_adapter_class, "QueryAdapter", "()Z");
+      env->GetStaticMethodID(s_adapter_class, "queryAdapter", "()Z");
 
   while (s_adapter_detect_thread_running.IsSet())
   {
@@ -456,7 +456,7 @@ void Init()
 #elif GCADAPTER_USE_ANDROID_IMPLEMENTATION
   JNIEnv* const env = IDCache::GetEnvForThread();
 
-  const jclass adapter_class = env->FindClass("org/dolphinemu/dolphinemu/utils/Java_GCAdapter");
+  const jclass adapter_class = env->FindClass("org/dolphinemu/dolphinemu/utils/GCAdapter");
   s_adapter_class = reinterpret_cast<jclass>(env->NewGlobalRef(adapter_class));
 #endif
 


### PR DESCRIPTION
We can register a BroadcastReceiver to have Android tell us when a GC adapter gets connected or disconnected instead of having a loop where we continuously call `SleepCurrentThread(1000)` and poll the current status. When waiting for a GC adapter to connect, this both reduces power usage and improves responsiveness. Additionally, we can get rid of the `Reset` call from the read thread, making PR #13203 unnecessary.