### PR TITLE
Fix compiling with libfmt>=11.0

### DIFF
--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -99,7 +99,13 @@ void GenericLogFmt(LogLevel level, LogType type, const char* file, int line, con
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-  GenericLogFmtImpl(level, type, file, line, format, fmt::make_format_args(args...));
+
+#if FMT_VERSION >= 110000
+  auto&& format_str = fmt::format_string<Args...>(format);
+#else
+  auto&& format_str = format;
+#endif
+  GenericLogFmtImpl(level, type, file, line, format_str, fmt::make_format_args(args...));
 }
 }  // namespace Common::Log
 

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -41,12 +41,17 @@ bool MsgAlertFmt(bool yes_no, MsgType style, Common::Log::LogType log_type, cons
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
+#if FMT_VERSION >= 110000
+  static_assert(std::is_base_of_v<fmt::detail::compile_string, S>);
+  auto&& format_str = fmt::format_string<Args...>(format);
+#elif FMT_VERSION >= 90000
   static_assert(fmt::detail::is_compile_string<S>::value);
+  auto&& format_str = format;
 #else
   static_assert(fmt::is_compile_string<S>::value);
+  auto&& format_str = format;
 #endif
-  return MsgAlertFmtImpl(yes_no, style, log_type, file, line, format,
+  return MsgAlertFmtImpl(yes_no, style, log_type, file, line, format_str,
                          fmt::make_format_args(args...));
 }
 
@@ -60,7 +65,9 @@ bool MsgAlertFmtT(bool yes_no, MsgType style, Common::Log::LogType log_type, con
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
+#if FMT_VERSION >= 110000
+  static_assert(std::is_base_of_v<fmt::detail::compile_string, S>);
+#elif FMT_VERSION >= 90000
   static_assert(fmt::detail::is_compile_string<S>::value);
 #else
   static_assert(fmt::is_compile_string<S>::value);

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -686,7 +686,7 @@ bool CEXIETHERNET::BuiltInBBAInterface::SendFrame(const u8* frame, u32 size)
   }
 
   default:
-    ERROR_LOG_FMT(SP1, "Unsupported EtherType {#06x}", *ethertype);
+    ERROR_LOG_FMT(SP1, "Unsupported EtherType {:#06x}", *ethertype);
     return false;
   }
 


### PR DESCRIPTION
This PR fixes compilation with libfmt 11.0 and later. Without this fix, the build fails on Arch Linux with fmt 11.1.1.

The main changes are that `fmt::detail::is_compile_string` no longer exists and that `fmt::string_view` is no longer directly constructible from compile time format strings (not sure exactly why), but manually constructing a `fmt::format_string` before converting to `fmt::string_view` works.

The change to fmt v11 also brought up that BBA/HLE `BuiltIn.cpp` seems to contain an invalid format string that hasn't been caught previously, fixed that as well.

Tested compilation and basic functionality with the bundled fmt 10.2.1 and with fmt 11.1.1.

I'm not sure if the implementation is perfect, I'll try to find a cleaner way to do this that requires fewer `#ifdef`s and I'm also open to suggestions.