### PR TITLE
JitArm64: Fix creqv/crorc setting eq bit

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -356,7 +356,10 @@ protected:
   void WriteBLRExit(Arm64Gen::ARM64Reg dest);
 
   void GetCRFieldBit(int field, int bit, Arm64Gen::ARM64Reg out);
-  void SetCRFieldBit(int field, int bit, Arm64Gen::ARM64Reg in, bool negate = false);
+  // This assumes that all bits except for bit 0 (LSB) are set to 0. But if bits_1_to_31_are_set
+  // equals true, it instead assumes that all of bits 1 to 31 are set.
+  void SetCRFieldBit(int field, int bit, Arm64Gen::ARM64Reg in, bool negate = false,
+                     bool bits_1_to_31_are_set = false);
   void ClearCRFieldBit(int field, int bit);
   void SetCRFieldBit(int field, int bit);
   void FixGTBeforeSettingCRFieldBit(Arm64Gen::ARM64Reg reg);


### PR DESCRIPTION
When I wrote 71e97665192ef45487262fcdd4df2286208e61cd, there was an interaction I didn't take into account: When setting eq, SetCRFieldBit assumes that all bits in the passed-in host register except the least significant bit are 0. But if we use BIC/EON/ORN, all bits except the least significant bit get set to 1. This can cause eq to end up unset when it should be set.

This pull request fixes the issue.