### PR TITLE
JitArm64_SystemRegisters: Small FixGTBeforeSettingCRFieldBit optimization

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -153,7 +153,7 @@ void JitArm64::FixGTBeforeSettingCRFieldBit(ARM64Reg reg)
   // doesn't accidentally become considered set. Gross but necessary; this can break actual games.
   auto WA = gpr.GetScopedReg();
   ARM64Reg XA = EncodeRegTo64(WA);
-  ORR(XA, reg, LogicalImm(1ULL << 63, GPRSize::B64));
+  MOVI2R(XA, 1ULL << 63);
   CMP(reg, ARM64Reg::ZR);
   CSEL(reg, reg, XA, CC_NEQ);
 }


### PR DESCRIPTION
The computed value is only used when the register is equal to zero, so we can fully precompute it and materialize the constant instead. In other words, we change from

```
return reg == 0 ? (reg | 1ULL << 63) : reg;
```

to

```
return reg == 0 ? 1ULL << 63 : reg;
```

The number of instructions remains the same, but we eliminate an unnecessary dependency on the register value.

Before:
```
0xb241037a   orr    x26, x27, #0x8000000000000000
0xeb1f037f   cmp    x27, xzr
0x9a9a137b   csel   x27, x27, x26, ne
```

After:
```
0xd2f0001a   mov    x26, #-0x8000000000000000 ; =-9223372036854775808
0xeb1f037f   cmp    x27, xzr
0x9a9a137b   csel   x27, x27, x26, ne
```