### PR TITLE
PPCSymbolDB: Fix loading maps with CRLF endings

### DIFF
--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -251,7 +251,7 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, const std::string& 
       continue;
 
     // Support CodeWarrior and Dolphin map
-    if (std::string_view{line}.ends_with(" section layout\n") || strcmp(temp, ".text") == 0 ||
+    if (StripWhitespace(line).ends_with(" section layout") || strcmp(temp, ".text") == 0 ||
         strcmp(temp, ".init") == 0)
     {
       section_name = temp;


### PR DESCRIPTION
Symbol maps ending in CRLF were not properly loading on non-windows systems.

Test map used:
https://github.com/ShadowTheHedgehogHacking/shadow-symbols-and-dmw/blob/main/GUPE8P.map

### Expected output
```
48261 symbols loaded, 0 symbols ignored.
```
### Actual output (Before this PR)
```
windows:  48261 symbols loaded, 0 symbols ignored.
mac:  37436 symbols loaded, 10825 symbols ignored.
linux:  37436 symbols loaded, 10825 symbols ignored.
```
### Actual output (After this PR)
`all platforms: 48261 symbols loaded, 0 symbols ignored.`

