### PR TITLE
Fix build with minizip-ng>=4.0.8

### DIFF
--- a/Externals/minizip-ng/CMakeLists.txt
+++ b/Externals/minizip-ng/CMakeLists.txt
@@ -2,8 +2,13 @@ project(minizip C)
 
 add_library(minizip STATIC
   minizip-ng/mz.h
-  minizip-ng/mz_compat.c
-  minizip-ng/mz_compat.h
+  # minizip-ng/compat/crypt.h
+  minizip-ng/compat/ioapi.c
+  minizip-ng/compat/ioapi.h
+  minizip-ng/compat/unzip.c
+  minizip-ng/compat/unzip.h
+  # minizip-ng/compat/zip.c
+  # minizip-ng/compat/zip.h
   minizip-ng/mz_crypt.c
   minizip-ng/mz_crypt.h
   minizip-ng/mz_os.c
@@ -60,7 +65,7 @@ endif()
 #  minizip-ng/mz_crypt_winvista.c
 #  minizip-ng/mz_crypt_winxp.c
 
-target_include_directories(minizip PUBLIC minizip-ng)
+target_include_directories(minizip PUBLIC minizip-ng minizip-ng/compat)
 
 target_compile_definitions(minizip PRIVATE HAVE_ZLIB ZLIB_COMPAT MZ_ZIP_NO_CRYPTO MZ_ZIP_NO_ENCRYPTION)
 if (UNIX)

--- a/Externals/minizip-ng/minizip-ng.vcxproj
+++ b/Externals/minizip-ng/minizip-ng.vcxproj
@@ -17,11 +17,14 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
+      <!-- Ensure minizip-ng sees mz.h -->
+      <AdditionalIncludeDirectories>minizip-ng;minizip-ng\compat;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>HAVE_ZLIB;ZLIB_COMPAT;MZ_ZIP_NO_CRYPTO;MZ_ZIP_NO_ENCRYPTION;HAVE_STDINT_H;HAVE_INTTYPES_H;NO_FSEEKO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="minizip-ng\mz_compat.c" />
+    <ClCompile Include="minizip-ng\compat\ioapi.c" />
+    <ClCompile Include="minizip-ng\compat\unzip.c" />
     <ClCompile Include="minizip-ng\mz_crypt.c" />
     <ClCompile Include="minizip-ng\mz_os.c" />
     <ClCompile Include="minizip-ng\mz_os_win32.c" />
@@ -36,7 +39,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="minizip-ng\mz.h" />
-    <ClInclude Include="minizip-ng\mz_compat.h" />
+    <ClCompile Include="minizip-ng\compat\ioapi.h" />
+    <ClCompile Include="minizip-ng\compat\unzip.h" />
     <ClInclude Include="minizip-ng\mz_crypt.h" />
     <ClInclude Include="minizip-ng\mz_os.h" />
     <ClInclude Include="minizip-ng\mz_strm.h" />

--- a/Source/Core/Common/MinizipUtil.h
+++ b/Source/Core/Common/MinizipUtil.h
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 
-#include <mz_compat.h>
+#include <unzip.h>
 
 #include "Common/CommonTypes.h"
 #include "Common/ScopeGuard.h"

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -13,8 +13,8 @@
 #include <unordered_set>
 
 #include <mbedtls/md5.h>
-#include <mz_compat.h>
 #include <pugixml.hpp>
+#include <unzip.h>
 
 #include "Common/Align.h"
 #include "Common/Assert.h"

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -6,8 +6,9 @@
 #include <algorithm>
 #include <memory>
 
-#include <mz_compat.h>
+#include <mz.h>
 #include <mz_os.h>
+#include <unzip.h>
 
 #include "Common/CommonPaths.h"
 #include "Common/Contains.h"


### PR DESCRIPTION
Minizip-ng 4.0.8 introduced a change where the compatibility layer was split into multiple source files. This caused dolphin to fail to build.  This PR aims to remedy that.

I tested compilation and launching a game that uses a resource pack, which both worked fine for me.