### PR TITLE
InputCommon/ExpressionParser: Require delimited tokens actually have their terminating delimiter.

### DIFF
--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -92,12 +92,15 @@ Lexer::Lexer(std::string expr_) : expr(std::move(expr_))
   it = expr.begin();
 }
 
-std::string Lexer::FetchDelimString(char delim)
+Token Lexer::GetDelimitedToken(TokenType type, char delimeter)
 {
-  const std::string result = FetchCharsWhile([delim](char c) { return c != delim; });
-  if (it != expr.end())
-    ++it;
-  return result;
+  const std::string value = FetchCharsWhile([&](char c) { return c != delimeter && c != '\n'; });
+
+  if (it == expr.end() || *it != delimeter)
+    return Token(TOK_INVALID);
+
+  ++it;
+  return Token(type, value);
 }
 
 std::string Lexer::FetchWordChars()
@@ -110,7 +113,7 @@ std::string Lexer::FetchWordChars()
 
 Token Lexer::GetDelimitedLiteral()
 {
-  return Token(TOK_LITERAL, FetchDelimString('\''));
+  return GetDelimitedToken(TOK_LITERAL, '\'');
 }
 
 Token Lexer::GetVariable()
@@ -120,7 +123,7 @@ Token Lexer::GetVariable()
 
 Token Lexer::GetFullyQualifiedControl()
 {
-  return Token(TOK_CONTROL, FetchDelimString('`'));
+  return GetDelimitedToken(TOK_CONTROL, '`');
 }
 
 Token Lexer::GetBareword(char first_char)

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -91,8 +91,8 @@ private:
     return value;
   }
 
-  std::string FetchDelimString(char delim);
   std::string FetchWordChars();
+  Token GetDelimitedToken(TokenType type, char delimeter);
   Token GetDelimitedLiteral();
   Token GetVariable();
   Token GetFullyQualifiedControl();


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/6034dca9-ea59-42d6-93df-7ea7eb7c4300)

After:
![image](https://github.com/user-attachments/assets/70f66ff4-810b-41d1-b166-dc520319b437) ![image](https://github.com/user-attachments/assets/d9d4136b-f718-48a7-854c-b13ef363dc90)

