### PR TITLE
DolphinQt: Replace stateChanged with checkStateChanged and fix shadowed variable warnings.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -31,7 +31,7 @@ HacksWidget::HacksWidget(GraphicsWindow* parent)
   connect(parent, &GraphicsWindow::BackendChanged, this, &HacksWidget::OnBackendChanged);
   OnBackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
   connect(m_gpu_texture_decoding, &QCheckBox::toggled,
-          [this, parent] { emit parent->UseGPUTextureDecodingChanged(); });
+          [parent] { emit parent->UseGPUTextureDecodingChanged(); });
 }
 
 HacksWidget::HacksWidget(GameConfigWidget* parent, Config::Layer* layer) : m_game_layer(layer)
@@ -150,13 +150,13 @@ void HacksWidget::OnBackendChanged(const QString& backend_name)
 
 void HacksWidget::ConnectWidgets()
 {
-  connect(m_store_efb_copies, &QCheckBox::stateChanged,
+  connect(m_store_efb_copies, &QCheckBox::checkStateChanged,
           [this](int) { UpdateDeferEFBCopiesEnabled(); });
-  connect(m_store_xfb_copies, &QCheckBox::stateChanged,
+  connect(m_store_xfb_copies, &QCheckBox::checkStateChanged,
           [this](int) { UpdateDeferEFBCopiesEnabled(); });
-  connect(m_immediate_xfb, &QCheckBox::stateChanged,
+  connect(m_immediate_xfb, &QCheckBox::checkStateChanged,
           [this](int) { UpdateSkipPresentingDuplicateFramesEnabled(); });
-  connect(m_vi_skip, &QCheckBox::stateChanged,
+  connect(m_vi_skip, &QCheckBox::checkStateChanged,
           [this](int) { UpdateSkipPresentingDuplicateFramesEnabled(); });
 }
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -76,7 +76,7 @@ MappingBool::MappingBool(MappingWidget* parent, ControllerEmu::NumericSetting<bo
   if (const auto ui_description = m_setting.GetUIDescription())
     setToolTip(tr(ui_description));
 
-  connect(this, &QCheckBox::stateChanged, this, [this, parent](int value) {
+  connect(this, &QCheckBox::checkStateChanged, this, [this, parent](int value) {
     m_setting.SetValue(value != 0);
     ConfigChanged();
     parent->SaveSettings();

--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -121,8 +121,8 @@ void VerifyWidget::ConnectWidgets()
 {
   connect(m_verify_button, &QPushButton::clicked, this, &VerifyWidget::Verify);
 
-  connect(m_md5_checkbox, &QCheckBox::stateChanged, this, &VerifyWidget::UpdateRedumpEnabled);
-  connect(m_sha1_checkbox, &QCheckBox::stateChanged, this, &VerifyWidget::UpdateRedumpEnabled);
+  connect(m_md5_checkbox, &QCheckBox::checkStateChanged, this, &VerifyWidget::UpdateRedumpEnabled);
+  connect(m_sha1_checkbox, &QCheckBox::checkStateChanged, this, &VerifyWidget::UpdateRedumpEnabled);
 }
 
 static void SetHash(QLineEdit* line_edit, const std::vector<u8>& hash)

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -209,22 +209,22 @@ void NetworkWidget::ConnectWidgets()
 {
   connect(m_dump_format_combo, &QComboBox::currentIndexChanged, this,
           &NetworkWidget::OnDumpFormatComboChanged);
-  connect(m_dump_ssl_read_checkbox, &QCheckBox::stateChanged, [](int state) {
+  connect(m_dump_ssl_read_checkbox, &QCheckBox::checkStateChanged, [](int state) {
     Config::SetBaseOrCurrent(Config::MAIN_NETWORK_SSL_DUMP_READ, state == Qt::Checked);
   });
-  connect(m_dump_ssl_write_checkbox, &QCheckBox::stateChanged, [](int state) {
+  connect(m_dump_ssl_write_checkbox, &QCheckBox::checkStateChanged, [](int state) {
     Config::SetBaseOrCurrent(Config::MAIN_NETWORK_SSL_DUMP_WRITE, state == Qt::Checked);
   });
-  connect(m_dump_root_ca_checkbox, &QCheckBox::stateChanged, [](int state) {
+  connect(m_dump_root_ca_checkbox, &QCheckBox::checkStateChanged, [](int state) {
     Config::SetBaseOrCurrent(Config::MAIN_NETWORK_SSL_DUMP_ROOT_CA, state == Qt::Checked);
   });
-  connect(m_dump_peer_cert_checkbox, &QCheckBox::stateChanged, [](int state) {
+  connect(m_dump_peer_cert_checkbox, &QCheckBox::checkStateChanged, [](int state) {
     Config::SetBaseOrCurrent(Config::MAIN_NETWORK_SSL_DUMP_PEER_CERT, state == Qt::Checked);
   });
-  connect(m_verify_certificates_checkbox, &QCheckBox::stateChanged, [](int state) {
+  connect(m_verify_certificates_checkbox, &QCheckBox::checkStateChanged, [](int state) {
     Config::SetBaseOrCurrent(Config::MAIN_NETWORK_SSL_VERIFY_CERTIFICATES, state == Qt::Checked);
   });
-  connect(m_dump_bba_checkbox, &QCheckBox::stateChanged, [](int state) {
+  connect(m_dump_bba_checkbox, &QCheckBox::checkStateChanged, [](int state) {
     Config::SetBaseOrCurrent(Config::MAIN_NETWORK_DUMP_BBA, state == Qt::Checked);
   });
   connect(m_open_dump_folder, &QPushButton::clicked, [] {

--- a/Source/Core/DolphinQt/GBAWidget.cpp
+++ b/Source/Core/DolphinQt/GBAWidget.cpp
@@ -38,12 +38,12 @@ static void RestartCore(const std::weak_ptr<HW::GBA::Core>& core, std::string_vi
 {
   Core::RunOnCPUThread(
       Core::System::GetInstance(),
-      [core, rom_path = std::string(rom_path)]() {
+      [core, rom_path_str = std::string(rom_path)]() {
         if (auto core_ptr = core.lock())
         {
           auto& info = Config::MAIN_GBA_ROM_PATHS[core_ptr->GetCoreInfo().device_number];
           core_ptr->Stop();
-          Config::SetCurrent(info, rom_path);
+          Config::SetCurrent(info, rom_path_str);
           auto& system = Core::System::GetInstance();
           auto& core_timing = system.GetCoreTiming();
           if (core_ptr->Start(core_timing.GetTicks()))
@@ -59,9 +59,9 @@ static void QueueEReaderCard(const std::weak_ptr<HW::GBA::Core>& core, std::stri
 {
   Core::RunOnCPUThread(
       Core::System::GetInstance(),
-      [core, card_path = std::string(card_path)]() {
+      [core, card_path_str = std::string(card_path)]() {
         if (auto core_ptr = core.lock())
-          core_ptr->EReaderQueueCard(card_path);
+          core_ptr->EReaderQueueCard(card_path_str);
       },
       false);
 }
@@ -225,13 +225,13 @@ void GBAWidget::DoState(bool export_state)
 
   Core::RunOnCPUThread(
       Core::System::GetInstance(),
-      [export_state, core = m_core, state_path = state_path.toStdString()]() {
+      [export_state, core = m_core, state_path_str = state_path.toStdString()]() {
         if (auto core_ptr = core.lock())
         {
           if (export_state)
-            core_ptr->ExportState(state_path);
+            core_ptr->ExportState(state_path_str);
           else
-            core_ptr->ImportState(state_path);
+            core_ptr->ImportState(state_path_str);
         }
       },
       false);
@@ -256,13 +256,13 @@ void GBAWidget::ImportExportSave(bool export_save)
 
   Core::RunOnCPUThread(
       Core::System::GetInstance(),
-      [export_save, core = m_core, save_path = save_path.toStdString()]() {
+      [export_save, core = m_core, state_path_str = save_path.toStdString()]() {
         if (auto core_ptr = core.lock())
         {
           if (export_save)
-            core_ptr->ExportSave(save_path);
+            core_ptr->ExportSave(state_path_str);
           else
-            core_ptr->ImportSave(save_path);
+            core_ptr->ImportSave(state_path_str);
         }
       },
       false);

--- a/Source/Core/DolphinQt/NKitWarningDialog.cpp
+++ b/Source/Core/DolphinQt/NKitWarningDialog.cpp
@@ -80,7 +80,7 @@ NKitWarningDialog::NKitWarningDialog(QWidget* parent) : QDialog(parent)
   connect(cancel, &QPushButton::clicked, this, &QDialog::reject);
 
   ok->setEnabled(false);
-  connect(checkbox_accept, &QCheckBox::stateChanged,
+  connect(checkbox_accept, &QCheckBox::checkStateChanged,
           [ok](int state) { ok->setEnabled(state == Qt::Checked); });
 
   connect(this, &QDialog::accepted, [checkbox_skip] {

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -243,7 +243,7 @@ void NetPlaySetupDialog::ConnectWidgets()
           &NetPlaySetupDialog::SaveSettings);
 
 #ifdef USE_UPNP
-  connect(m_host_upnp, &QCheckBox::stateChanged, this, &NetPlaySetupDialog::SaveSettings);
+  connect(m_host_upnp, &QCheckBox::checkStateChanged, this, &NetPlaySetupDialog::SaveSettings);
 #endif
 
   connect(m_connect_button, &QPushButton::clicked, this, &QDialog::accept);

--- a/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
@@ -61,7 +61,7 @@ void PadMappingDialog::ConnectWidgets()
   }
   for (const auto& checkbox : m_gba_boxes)
   {
-    connect(checkbox, &QCheckBox::stateChanged, this, &PadMappingDialog::OnMappingChanged);
+    connect(checkbox, &QCheckBox::checkStateChanged, this, &PadMappingDialog::OnMappingChanged);
   }
 }
 

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -247,7 +247,7 @@ void GameCubePane::CreateWidgets()
 void GameCubePane::ConnectWidgets()
 {
   // IPL Settings
-  connect(m_skip_main_menu, &QCheckBox::stateChanged, this, &GameCubePane::SaveSettings);
+  connect(m_skip_main_menu, &QCheckBox::checkStateChanged, this, &GameCubePane::SaveSettings);
   connect(m_language_combo, &QComboBox::currentIndexChanged, this, &GameCubePane::SaveSettings);
 
   // Device Settings
@@ -278,10 +278,11 @@ void GameCubePane::ConnectWidgets()
 
 #ifdef HAS_LIBMGBA
   // GBA Settings
-  connect(m_gba_threads, &QCheckBox::stateChanged, this, &GameCubePane::SaveSettings);
+  connect(m_gba_threads, &QCheckBox::checkStateChanged, this, &GameCubePane::SaveSettings);
   connect(m_gba_bios_edit, &QLineEdit::editingFinished, this, &GameCubePane::SaveSettings);
   connect(m_gba_browse_bios, &QPushButton::clicked, this, &GameCubePane::BrowseGBABios);
-  connect(m_gba_save_rom_path, &QCheckBox::stateChanged, this, &GameCubePane::SaveRomPathChanged);
+  connect(m_gba_save_rom_path, &QCheckBox::checkStateChanged, this,
+          &GameCubePane::SaveRomPathChanged);
   connect(m_gba_saves_edit, &QLineEdit::editingFinished, this, &GameCubePane::SaveSettings);
   connect(m_gba_browse_saves, &QPushButton::clicked, this, &GameCubePane::BrowseGBASaves);
   for (size_t i = 0; i < m_gba_browse_roms.size(); ++i)

--- a/Source/Core/DolphinQt/TAS/TASCheckBox.cpp
+++ b/Source/Core/DolphinQt/TAS/TASCheckBox.cpp
@@ -15,7 +15,7 @@ TASCheckBox::TASCheckBox(const QString& text, TASInputWindow* parent)
 {
   setTristate(true);
 
-  connect(this, &TASCheckBox::stateChanged, this, &TASCheckBox::OnUIValueChanged);
+  connect(this, &TASCheckBox::checkStateChanged, this, &TASCheckBox::OnUIValueChanged);
 }
 
 bool TASCheckBox::GetValue() const


### PR DESCRIPTION
`stateChanged` was throwing warnings for being deprecated.

The non-deprecated `checkStateChanged` replacement has been available since Qt 6.7 (April of 2024).