### PR TITLE
InputCommon/ControllerEmu: Break out functionality of EmulatedController to eliminate redundant members.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/controlleremu/EmulatedController.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/controlleremu/EmulatedController.kt
@@ -5,20 +5,29 @@ package org.dolphinemu.dolphinemu.features.input.model.controlleremu
 import androidx.annotation.Keep
 
 /**
+ * Represents a C++ ControllerEmu::ControlGroupContainer.
+ *
+ * The lifetime of this class is managed by C++ code. Calling methods on it after it's destroyed
+ * in C++ is undefined behavior!
+ */
+@Keep
+open class ControlGroupContainer constructor(private val pointer: Long) {
+  external fun getGroupCount(): Int
+
+  external fun getGroup(index: Int): ControlGroup
+}
+
+/**
  * Represents a C++ ControllerEmu::EmulatedController.
  *
  * The lifetime of this class is managed by C++ code. Calling methods on it after it's destroyed
  * in C++ is undefined behavior!
  */
 @Keep
-class EmulatedController private constructor(private val pointer: Long) {
+class EmulatedController private constructor(private val pointer: Long) : ControlGroupContainer(pointer) {
     external fun getDefaultDevice(): String
 
     external fun setDefaultDevice(device: String)
-
-    external fun getGroupCount(): Int
-
-    external fun getGroup(index: Int): ControlGroup
 
     external fun updateSingleControlReference(controlReference: ControlReference)
 
@@ -50,7 +59,7 @@ class EmulatedController private constructor(private val pointer: Long) {
         external fun getWiimoteAttachment(
             controllerIndex: Int,
             attachmentIndex: Int
-        ): EmulatedController
+        ): ControlGroupContainer
 
         @JvmStatic
         external fun getSelectedWiimoteAttachment(controllerIndex: Int): Int

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -22,6 +22,7 @@ import org.dolphinemu.dolphinemu.features.input.model.InputMappingBooleanSetting
 import org.dolphinemu.dolphinemu.features.input.model.InputMappingDoubleSetting
 import org.dolphinemu.dolphinemu.features.input.model.InputMappingIntSetting
 import org.dolphinemu.dolphinemu.features.input.model.controlleremu.ControlGroup
+import org.dolphinemu.dolphinemu.features.input.model.controlleremu.ControlGroupContainer
 import org.dolphinemu.dolphinemu.features.input.model.controlleremu.EmulatedController
 import org.dolphinemu.dolphinemu.features.input.model.controlleremu.NumericSetting
 import org.dolphinemu.dolphinemu.features.input.model.view.InputDeviceSetting
@@ -2255,8 +2256,9 @@ class SettingsFragmentPresenter(
         wiimoteNumber: Int,
         extensionType: Int
     ) {
-        addControllerMappingSettings(
+        addContainerMappingSettings(
             sl,
+            EmulatedController.getWiimote(wiimoteNumber),
             EmulatedController.getWiimoteAttachment(wiimoteNumber, extensionType),
             null
         )
@@ -2404,15 +2406,32 @@ class SettingsFragmentPresenter(
      * @param groupTypeFilter If this is non-null, only groups whose types match this are considered.
      */
     private fun addControllerMappingSettings(
+      sl: ArrayList<SettingsItem>,
+      controller: EmulatedController,
+      groupTypeFilter: Set<Int>?
+    ) {
+      addContainerMappingSettings(sl, controller, controller, groupTypeFilter)
+    }
+
+    /**
+     * Adds mapping settings and other control-specific settings.
+     *
+     * @param sl              The list to place controller settings into.
+     * @param controller      The encompassing controller.
+     * @param container       The container of control groups to add settings for.
+     * @param groupTypeFilter If this is non-null, only groups whose types match this are considered.
+     */
+    private fun addContainerMappingSettings(
         sl: ArrayList<SettingsItem>,
         controller: EmulatedController,
+        container: ControlGroupContainer,
         groupTypeFilter: Set<Int>?
     ) {
         updateOldControllerSettingsWarningVisibility(controller)
 
-        val groupCount = controller.getGroupCount()
+        val groupCount = container.getGroupCount()
         for (i in 0 until groupCount) {
-            val group = controller.getGroup(i)
+            val group = container.getGroup(i)
             val groupType = group.getGroupType()
             if (groupTypeFilter != null && !groupTypeFilter.contains(groupType)) continue
 

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -97,6 +97,10 @@ static jclass s_control_reference_class;
 static jfieldID s_control_reference_pointer;
 static jmethodID s_control_reference_constructor;
 
+static jclass s_control_group_container_class;
+static jfieldID s_control_group_container_pointer;
+static jmethodID s_control_group_container_constructor;
+
 static jclass s_emulated_controller_class;
 static jfieldID s_emulated_controller_pointer;
 static jmethodID s_emulated_controller_constructor;
@@ -446,6 +450,21 @@ jmethodID GetControlReferenceConstructor()
   return s_control_reference_constructor;
 }
 
+jclass GetControlGroupContainerClass()
+{
+  return s_control_group_container_class;
+}
+
+jfieldID GetControlGroupContainerPointer()
+{
+  return s_control_group_container_pointer;
+}
+
+jmethodID GetControlGroupContainerConstructor()
+{
+  return s_control_group_container_constructor;
+}
+
 jclass GetEmulatedControllerClass()
 {
   return s_emulated_controller_class;
@@ -685,6 +704,16 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
   s_control_reference_constructor = env->GetMethodID(control_reference_class, "<init>", "(J)V");
   env->DeleteLocalRef(control_reference_class);
 
+  const jclass control_group_container_class = env->FindClass(
+      "org/dolphinemu/dolphinemu/features/input/model/controlleremu/ControlGroupContainer");
+  s_control_group_container_class =
+      reinterpret_cast<jclass>(env->NewGlobalRef(control_group_container_class));
+  s_control_group_container_pointer =
+      env->GetFieldID(control_group_container_class, "pointer", "J");
+  s_control_group_container_constructor =
+      env->GetMethodID(control_group_container_class, "<init>", "(J)V");
+  env->DeleteLocalRef(control_group_container_class);
+
   const jclass emulated_controller_class = env->FindClass(
       "org/dolphinemu/dolphinemu/features/input/model/controlleremu/EmulatedController");
   s_emulated_controller_class =
@@ -754,5 +783,6 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved)
   env->DeleteGlobalRef(s_numeric_setting_class);
   env->DeleteGlobalRef(s_core_device_class);
   env->DeleteGlobalRef(s_core_device_control_class);
+  env->DeleteGlobalRef(s_control_group_container_class);
 }
 }

--- a/Source/Android/jni/AndroidCommon/IDCache.h
+++ b/Source/Android/jni/AndroidCommon/IDCache.h
@@ -92,6 +92,10 @@ jclass GetControlReferenceClass();
 jfieldID GetControlReferencePointer();
 jmethodID GetControlReferenceConstructor();
 
+jclass GetControlGroupContainerClass();
+jfieldID GetControlGroupContainerPointer();
+jmethodID GetControlGroupContainerConstructor();
+
 jclass GetEmulatedControllerClass();
 jfieldID GetEmulatedControllerPointer();
 jmethodID GetEmulatedControllerConstructor();

--- a/Source/Android/jni/Input/EmulatedController.cpp
+++ b/Source/Android/jni/Input/EmulatedController.cpp
@@ -20,6 +20,23 @@
 #include "jni/Input/ControlReference.h"
 #include "jni/Input/NumericSetting.h"
 
+ControllerEmu::ControlGroupContainer* ControlGroupContainerFromJava(JNIEnv* env, jobject obj)
+{
+  return reinterpret_cast<ControllerEmu::ControlGroupContainer*>(
+      env->GetLongField(obj, IDCache::GetEmulatedControllerPointer()));
+}
+
+static jobject ControlGroupContainerToJava(JNIEnv* env,
+                                           ControllerEmu::ControlGroupContainer* container)
+{
+  if (!container)
+    return nullptr;
+
+  return env->NewObject(IDCache::GetControlGroupContainerClass(),
+                        IDCache::GetControlGroupContainerConstructor(),
+                        reinterpret_cast<jlong>(container));
+}
+
 ControllerEmu::EmulatedController* EmulatedControllerFromJava(JNIEnv* env, jobject obj)
 {
   return reinterpret_cast<ControllerEmu::EmulatedController*>(
@@ -53,18 +70,18 @@ Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedContro
 }
 
 JNIEXPORT jint JNICALL
-Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedController_getGroupCount(
+Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_ControlGroupContainer_getGroupCount(
     JNIEnv* env, jobject obj)
 {
-  return static_cast<jint>(EmulatedControllerFromJava(env, obj)->groups.size());
+  return static_cast<jint>(ControlGroupContainerFromJava(env, obj)->groups.size());
 }
 
 JNIEXPORT jobject JNICALL
-Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedController_getGroup(
+Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_ControlGroupContainer_getGroup(
     JNIEnv* env, jobject obj, jint controller_index)
 {
-  return ControlGroupToJava(env,
-                            EmulatedControllerFromJava(env, obj)->groups[controller_index].get());
+  return ControlGroupToJava(
+      env, ControlGroupContainerFromJava(env, obj)->groups[controller_index].get());
 }
 
 JNIEXPORT void JNICALL
@@ -175,7 +192,7 @@ Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedContro
 {
   auto* attachments = static_cast<ControllerEmu::Attachments*>(
       Wiimote::GetWiimoteGroup(controller_index, WiimoteEmu::WiimoteGroup::Attachments));
-  return EmulatedControllerToJava(env, attachments->GetAttachmentList()[attachment_index].get());
+  return ControlGroupContainerToJava(env, attachments->GetAttachmentList()[attachment_index].get());
 }
 
 JNIEXPORT jint JNICALL

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -10,8 +10,6 @@
 
 #include "Core/HW/GCPad.h"
 
-#include "InputCommon/ControllerEmu/Control/Input.h"
-#include "InputCommon/ControllerEmu/Control/Output.h"
 #include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
@@ -128,6 +126,8 @@ ControllerEmu::ControlGroup* GCPad::GetGroup(PadGroup group)
 
 GCPadStatus GCPad::GetInput() const
 {
+  using ControllerEmu::MapFloat;
+
   const auto lock = GetStateLock();
   GCPadStatus pad = {};
 
@@ -182,12 +182,12 @@ void GCPad::LoadDefaults(const ControllerInterface& ciface)
   // Rumble
   m_rumble->SetControlExpression(0, "`Android/0/Device Sensors:Motor 0`");
 #else
-  // Buttons
-  m_buttons->SetControlExpression(0, "`X`");       // A
-  m_buttons->SetControlExpression(1, "`Z`");       // B
-  m_buttons->SetControlExpression(2, "`C`");       // X
-  m_buttons->SetControlExpression(3, "`S`");       // Y
-  m_buttons->SetControlExpression(4, "`D`");       // Z
+  // Buttons: A, B, X, Y, Z
+  m_buttons->SetControlExpression(0, "`X`");
+  m_buttons->SetControlExpression(1, "`Z`");
+  m_buttons->SetControlExpression(2, "`C`");
+  m_buttons->SetControlExpression(3, "`S`");
+  m_buttons->SetControlExpression(4, "`D`");
 #ifdef _WIN32
   m_buttons->SetControlExpression(5, "`RETURN`");  // Start
 #else

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -4,17 +4,13 @@
 #include "Core/HW/WiimoteEmu/Extension/Classic.h"
 
 #include <array>
-#include <string_view>
 
-#include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
-#include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
@@ -88,6 +84,8 @@ Classic::Classic() : Extension1stParty("Classic", _trans("Classic Controller"))
 
 void Classic::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
+  using ControllerEmu::MapFloat;
+
   DataFormat classic_data = {};
 
   // left stick

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
@@ -6,14 +6,12 @@
 #include <array>
 
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
-#include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Triggers.h"
 
@@ -37,6 +35,8 @@ DrawsomeTablet::DrawsomeTablet() : Extension3rdParty("Drawsome", _trans("Drawsom
 
 void DrawsomeTablet::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
+  using ControllerEmu::MapFloat;
+
   DataFormat& tablet_data = target_state->data.emplace<DataFormat>();
 
   // Stylus X/Y (calibrated values):

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
@@ -3,8 +3,6 @@
 
 #include "Core/HW/WiimoteEmu/Extension/Drums.h"
 
-#include <type_traits>
-
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
@@ -13,7 +11,6 @@
 #include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
-#include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 
@@ -83,6 +80,8 @@ Drums::Drums() : Extension1stParty("Drums", _trans("Drum Kit"))
 
 void Drums::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
+  using ControllerEmu::MapFloat;
+
   DesiredState& state = target_state->data.emplace<DesiredState>();
 
   {

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
@@ -32,11 +32,6 @@ std::string Extension::GetDisplayName() const
   return m_display_name;
 }
 
-InputConfig* Extension::GetConfig() const
-{
-  return ::Wiimote::GetConfig();
-}
-
 None::None() : Extension("None")
 {
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
@@ -10,13 +10,13 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/Encryption.h"
 #include "Core/HW/WiimoteEmu/I2CBus.h"
-#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 
 namespace WiimoteEmu
 {
 struct DesiredExtensionState;
 
-class Extension : public ControllerEmu::EmulatedController, public I2CSlave
+class Extension : public ControllerEmu::AttachedController, public I2CSlave
 {
 public:
   explicit Extension(const char* name);
@@ -24,8 +24,6 @@ public:
 
   std::string GetName() const override;
   std::string GetDisplayName() const override;
-
-  InputConfig* GetConfig() const override;
 
   // Used by the wiimote to detect extension changes.
   // The normal extensions short this pin so it's always connected,

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
@@ -8,14 +8,12 @@
 #include <map>
 
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
-#include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
@@ -99,6 +97,8 @@ Guitar::Guitar() : Extension1stParty(_trans("Guitar"))
 
 void Guitar::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
+  using ControllerEmu::MapFloat;
+
   DataFormat guitar_data = {};
 
   // stick

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -3,21 +3,17 @@
 
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
 
-#include <algorithm>
 #include <array>
 #include <cstring>
 
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
-#include "Common/MathUtil.h"
 
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
-#include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
@@ -64,6 +60,8 @@ Nunchuk::Nunchuk() : Extension1stParty(_trans("Nunchuk"))
 
 void Nunchuk::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
+  using ControllerEmu::MapFloat;
+
   DataFormat nc_data = {};
 
   // stick
@@ -197,7 +195,7 @@ void Nunchuk::DoState(PointerWrap& p)
   p.Do(m_shake_state);
 }
 
-void Nunchuk::LoadDefaults(const ControllerInterface& ciface)
+void Nunchuk::LoadDefaults()
 {
 #ifndef ANDROID
   // Stick

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
@@ -158,7 +158,7 @@ public:
 
   ControllerEmu::ControlGroup* GetGroup(NunchukGroup group);
 
-  void LoadDefaults(const ControllerInterface& ciface) override;
+  void LoadDefaults() override;
 
   static constexpr u8 BUTTON_C = 0x02;
   static constexpr u8 BUTTON_Z = 0x01;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Shinkansen.cpp
@@ -57,6 +57,8 @@ Shinkansen::Shinkansen() : Extension3rdParty("Shinkansen", _trans("Shinkansen Co
 
 void Shinkansen::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
+  using ControllerEmu::MapFloat;
+
   DesiredState& state = target_state->data.emplace<DesiredState>();
 
   const auto analog = m_levers->GetState().data;
@@ -104,7 +106,7 @@ void Shinkansen::Update(const DesiredExtensionState& target_state)
   ext_data.buttons = desired_state.buttons ^ 0xFFFF;
   Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = ext_data;
 
-  const auto lock = GetStateLock();
+  const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   m_led->controls[0]->control_ref->State(m_reg.identifier[1]);
 }
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -7,19 +7,16 @@
 #include <cstring>
 
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
-#include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Slider.h"
-#include "InputCommon/ControllerEmu/ControlGroup/Triggers.h"
 
 namespace WiimoteEmu
 {
@@ -84,6 +81,8 @@ Turntable::Turntable() : Extension1stParty("Turntable", _trans("DJ Turntable"))
 
 void Turntable::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
+  using ControllerEmu::MapFloat;
+
   DataFormat tt_data = {};
 
   // stick

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -790,7 +790,7 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
   // Enable Nunchuk:
   constexpr ExtensionNumber DEFAULT_EXT = ExtensionNumber::NUNCHUK;
   m_attachments->SetSelectedAttachment(DEFAULT_EXT);
-  m_attachments->GetAttachmentList()[DEFAULT_EXT]->LoadDefaults(ciface);
+  m_attachments->GetAttachmentList()[DEFAULT_EXT]->LoadDefaults();
 }
 
 Extension* Wiimote::GetNoneExtension() const

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -17,11 +17,8 @@
 #include <QSpinBox>
 #include <QVBoxLayout>
 
-#include "Common/CommonTypes.h"
-
 #include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/AspectRatioWidget.h"
-#include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/TAS/StickWidget.h"
 #include "DolphinQt/TAS/TASCheckBox.h"
@@ -250,14 +247,12 @@ std::optional<ControlState> TASInputWindow::GetButton(TASCheckBox* checkbox,
 std::optional<ControlState> TASInputWindow::GetSpinBox(TASSpinBox* spin, int zero, int min, int max,
                                                        ControlState controller_state)
 {
-  const int controller_value =
-      ControllerEmu::EmulatedController::MapFloat<int>(controller_state, zero, 0, max);
+  const int controller_value = ControllerEmu::MapFloat<int>(controller_state, zero, 0, max);
 
   if (m_use_controller->isChecked())
     spin->OnControllerValueChanged(controller_value);
 
-  return ControllerEmu::EmulatedController::MapToFloat<ControlState, int>(spin->GetValue(), zero,
-                                                                          min, max);
+  return ControllerEmu::MapToFloat<ControlState, int>(spin->GetValue(), zero, min, max);
 }
 
 std::optional<ControlState> TASInputWindow::GetSpinBox(TASSpinBox* spin, int zero,

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
@@ -5,11 +5,16 @@
 
 namespace ControllerEmu
 {
+
+void AttachedController::LoadDefaults()
+{
+}
+
 Attachments::Attachments(const std::string& name_) : ControlGroup(name_, GroupType::Attachments)
 {
 }
 
-void Attachments::AddAttachment(std::unique_ptr<EmulatedController> att)
+void Attachments::AddAttachment(std::unique_ptr<AttachedController> att)
 {
   m_attachments.emplace_back(std::move(att));
 }
@@ -40,9 +45,61 @@ SubscribableSettingValue<int>& Attachments::GetAttachmentSetting()
   return m_selection_value;
 }
 
-const std::vector<std::unique_ptr<EmulatedController>>& Attachments::GetAttachmentList() const
+const std::vector<std::unique_ptr<AttachedController>>& Attachments::GetAttachmentList() const
 {
   return m_attachments;
+}
+
+void Attachments::LoadConfig(Common::IniFile::Section* sec, const std::string& base)
+{
+  ControlGroup::LoadConfig(sec, base);
+
+  SetSelectedAttachment(0);
+
+  std::string attachment_text;
+  sec->Get(base + name, &attachment_text, "");
+
+  // First assume attachment string is a valid expression.
+  // If it instead matches one of the names of our attachments it is overridden below.
+  GetSelectionSetting().GetInputReference().SetExpression(attachment_text);
+
+  u32 n = 0;
+  for (auto& ai : GetAttachmentList())
+  {
+    ai->LoadGroupsConfig(sec, base + ai->GetName() + "/");
+
+    if (ai->GetName() == attachment_text)
+      SetSelectedAttachment(n);
+
+    ++n;
+  }
+}
+
+void Attachments::SaveConfig(Common::IniFile::Section* sec, const std::string& base)
+{
+  if (GetSelectionSetting().IsSimpleValue())
+  {
+    sec->Set(base + name, GetAttachmentList()[GetSelectedAttachment()]->GetName(), "None");
+  }
+  else
+  {
+    std::string expression = GetSelectionSetting().GetInputReference().GetExpression();
+    ReplaceBreaksWithSpaces(expression);
+    sec->Set(base + name, expression, "None");
+  }
+
+  for (auto& ai : GetAttachmentList())
+    ai->SaveGroupsConfig(sec, base + ai->GetName() + "/");
+}
+
+void Attachments::UpdateReferences(ciface::ExpressionParser::ControlEnvironment& env)
+{
+  ControlGroup::UpdateReferences(env);
+
+  GetSelectionSetting().GetInputReference().UpdateReference(env);
+
+  for (auto& attachment : GetAttachmentList())
+    attachment->UpdateGroupsReferences(env);
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.h
@@ -3,19 +3,23 @@
 
 #pragma once
 
-#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Core/HW/WiimoteEmu/ExtensionPort.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 namespace ControllerEmu
 {
+class AttachedController : public ControlGroupContainer
+{
+public:
+  virtual void LoadDefaults();
+};
+
 // A container of the selected and available attachments
 // for configuration saving/loading purposes
 class Attachments : public ControlGroup
@@ -23,7 +27,7 @@ class Attachments : public ControlGroup
 public:
   explicit Attachments(const std::string& name);
 
-  void AddAttachment(std::unique_ptr<EmulatedController> att);
+  void AddAttachment(std::unique_ptr<AttachedController> att);
 
   u32 GetSelectedAttachment() const;
   void SetSelectedAttachment(u32 val);
@@ -31,16 +35,20 @@ public:
   NumericSetting<int>& GetSelectionSetting();
   SubscribableSettingValue<int>& GetAttachmentSetting();
 
-  const std::vector<std::unique_ptr<EmulatedController>>& GetAttachmentList() const;
+  const std::vector<std::unique_ptr<AttachedController>>& GetAttachmentList() const;
+
+  void LoadConfig(Common::IniFile::Section* sec, const std::string& base) override;
+  void SaveConfig(Common::IniFile::Section* sec, const std::string& base) override;
+
+  void UpdateReferences(ciface::ExpressionParser::ControlEnvironment& env) override;
 
 private:
   SubscribableSettingValue<int> m_selection_value;
   // This is here and not added to the list of numeric_settings because it's serialized differently,
   // by string (to be independent from the enum), and visualized differently in the UI.
   // For the rest, it's treated similarly to other numeric_settings in the group.
-  NumericSetting<int> m_selection_setting = {
-      &m_selection_value, {""}, 0, 0, WiimoteEmu::ExtensionNumber::MAX - 1};
+  NumericSetting<int> m_selection_setting = {&m_selection_value, {""}, 0, 0, 0};
 
-  std::vector<std::unique_ptr<EmulatedController>> m_attachments;
+  std::vector<std::unique_ptr<AttachedController>> m_attachments;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -13,7 +13,6 @@
 #include <type_traits>
 #include <vector>
 
-#include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
@@ -69,10 +68,10 @@ public:
                DefaultValue default_value = DefaultValue::AlwaysEnabled);
   virtual ~ControlGroup();
 
-  virtual void LoadConfig(Common::IniFile::Section* sec, const std::string& defdev = "",
-                          const std::string& base = "");
-  virtual void SaveConfig(Common::IniFile::Section* sec, const std::string& defdev = "",
-                          const std::string& base = "");
+  virtual void LoadConfig(Common::IniFile::Section* sec, const std::string& base);
+  virtual void SaveConfig(Common::IniFile::Section* sec, const std::string& base);
+
+  virtual void UpdateReferences(ciface::ExpressionParser::ControlEnvironment& env);
 
   void SetControlExpression(int index, const std::string& expression);
 

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -11,10 +11,7 @@
 #include "Common/IniFile.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
-#include "InputCommon/ControllerEmu/Control/Control.h"
-#include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
-#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 namespace ControllerEmu
@@ -23,7 +20,7 @@ namespace ControllerEmu
 // though no EmulatedController usually run in parallel, so it makes little difference
 static std::recursive_mutex s_get_state_mutex;
 
-std::string EmulatedController::GetDisplayName() const
+std::string ControlGroupContainer::GetDisplayName() const
 {
   return GetName();
 }
@@ -47,34 +44,18 @@ void EmulatedController::UpdateReferences(const ControllerInterface& devi)
 
   ciface::ExpressionParser::ControlEnvironment env(devi, GetDefaultDevice(), m_expression_vars);
 
-  UpdateReferences(env);
+  UpdateGroupsReferences(env);
 
   env.CleanUnusedVariables();
 }
 
-void EmulatedController::UpdateReferences(ciface::ExpressionParser::ControlEnvironment& env)
+void ControlGroupContainer::UpdateGroupsReferences(
+    ciface::ExpressionParser::ControlEnvironment& env)
 {
-  const auto lock = GetStateLock();
+  const auto lock = EmulatedController::GetStateLock();
 
-  for (auto& ctrlGroup : groups)
-  {
-    for (auto& control : ctrlGroup->controls)
-      control->control_ref->UpdateReference(env);
-
-    for (auto& setting : ctrlGroup->numeric_settings)
-      setting->GetInputReference().UpdateReference(env);
-
-    // Attachments:
-    if (ctrlGroup->type == GroupType::Attachments)
-    {
-      auto* const attachments = static_cast<Attachments*>(ctrlGroup.get());
-
-      attachments->GetSelectionSetting().GetInputReference().UpdateReference(env);
-
-      for (auto& attachment : attachments->GetAttachmentList())
-        attachment->UpdateReferences(env);
-    }
-  }
+  for (auto& group : groups)
+    group->UpdateReferences(env);
 }
 
 void EmulatedController::UpdateSingleControlReference(const ControllerInterface& devi,
@@ -125,43 +106,40 @@ void EmulatedController::SetDefaultDevice(const std::string& device)
 void EmulatedController::SetDefaultDevice(ciface::Core::DeviceQualifier devq)
 {
   m_default_device = std::move(devq);
-
-  for (auto& ctrlGroup : groups)
-  {
-    // Attachments:
-    if (ctrlGroup->type == GroupType::Attachments)
-    {
-      for (auto& ai : static_cast<Attachments*>(ctrlGroup.get())->GetAttachmentList())
-      {
-        ai->SetDefaultDevice(m_default_device);
-      }
-    }
-  }
 }
 
-void EmulatedController::LoadConfig(Common::IniFile::Section* sec, const std::string& base)
+ControlGroupContainer::~ControlGroupContainer() = default;
+
+void EmulatedController::LoadConfig(Common::IniFile::Section* sec)
 {
-  const auto lock = GetStateLock();
-  std::string defdev = GetDefaultDevice().ToString();
-  if (base.empty())
-  {
-    sec->Get(base + "Device", &defdev, "");
+  const auto lock = EmulatedController::GetStateLock();
+
+  std::string defdev;
+  if (sec->Get("Device", &defdev, ""))
     SetDefaultDevice(defdev);
-  }
 
-  for (auto& cg : groups)
-    cg->LoadConfig(sec, defdev, base);
+  LoadGroupsConfig(sec, "");
 }
 
-void EmulatedController::SaveConfig(Common::IniFile::Section* sec, const std::string& base)
+void ControlGroupContainer::LoadGroupsConfig(Common::IniFile::Section* sec, const std::string& base)
 {
-  const auto lock = GetStateLock();
-  const std::string defdev = GetDefaultDevice().ToString();
-  if (base.empty())
-    sec->Set(/*std::string(" ") +*/ base + "Device", defdev, "");
+  for (auto& cg : groups)
+    cg->LoadConfig(sec, base);
+}
 
-  for (auto& ctrlGroup : groups)
-    ctrlGroup->SaveConfig(sec, defdev, base);
+void EmulatedController::SaveConfig(Common::IniFile::Section* sec)
+{
+  const auto lock = EmulatedController::GetStateLock();
+
+  sec->Set("Device", GetDefaultDevice().ToString(), "");
+
+  SaveGroupsConfig(sec, "");
+}
+
+void ControlGroupContainer::SaveGroupsConfig(Common::IniFile::Section* sec, const std::string& base)
+{
+  for (auto& cg : groups)
+    cg->SaveConfig(sec, base);
 }
 
 void EmulatedController::LoadDefaults(const ControllerInterface& ciface)
@@ -178,12 +156,12 @@ void EmulatedController::LoadDefaults(const ControllerInterface& ciface)
   }
 }
 
-void EmulatedController::SetInputOverrideFunction(InputOverrideFunction override_func)
+void ControlGroupContainer::SetInputOverrideFunction(InputOverrideFunction override_func)
 {
   m_input_override_function = std::move(override_func);
 }
 
-void EmulatedController::ClearInputOverrideFunction()
+void ControlGroupContainer::ClearInputOverrideFunction()
 {
   m_input_override_function = {};
 }

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -10,7 +10,6 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
-#include "Common/Common.h"
 #include "Common/MathUtil.h"
 #include "Common/Matrix.h"
 #include "Common/StringUtil.h"
@@ -228,10 +227,9 @@ void ReshapableInput::SetCenter(ReshapableInput::ReshapeData center)
   m_center = center;
 }
 
-void ReshapableInput::LoadConfig(Common::IniFile::Section* section,
-                                 const std::string& default_device, const std::string& base_name)
+void ReshapableInput::LoadConfig(Common::IniFile::Section* section, const std::string& base_name)
 {
-  ControlGroup::LoadConfig(section, default_device, base_name);
+  ControlGroup::LoadConfig(section, base_name);
 
   const std::string group(base_name + name + '/');
 
@@ -271,10 +269,9 @@ void ReshapableInput::LoadConfig(Common::IniFile::Section* section,
   }
 }
 
-void ReshapableInput::SaveConfig(Common::IniFile::Section* section,
-                                 const std::string& default_device, const std::string& base_name)
+void ReshapableInput::SaveConfig(Common::IniFile::Section* section, const std::string& base_name)
 {
-  ControlGroup::SaveConfig(section, default_device, base_name);
+  ControlGroup::SaveConfig(section, base_name);
 
   const std::string group(base_name + name + '/');
 

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -8,7 +8,6 @@
 
 #include "Common/Matrix.h"
 
-#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
@@ -117,8 +116,8 @@ protected:
   virtual Control* GetModifierInput() const;
 
 private:
-  void LoadConfig(Common::IniFile::Section*, const std::string&, const std::string&) override;
-  void SaveConfig(Common::IniFile::Section*, const std::string&, const std::string&) override;
+  void LoadConfig(Common::IniFile::Section*, const std::string& base_name) override;
+  void SaveConfig(Common::IniFile::Section*, const std::string& base_name) override;
 
   CalibrationData m_calibration;
   SettingValue<double> m_deadzone_setting;


### PR DESCRIPTION
The Wii Remote `Extension` classes previously derived from `ControllerEmu` giving them redundant/unused "default device" and "expression variables" members.

Common functionality has been moved to a `ControlGroupContainer` class.
This eliminated the redundant members and some unnecessary function arguments.

`Attachments` config save/loading is now appropriately handled in an overridden virtual function instead of using ` if (type == GroupType::Attachments)`.

`MapFloat` and `MapToFloat` static member functions changed into more-appropriate free-functions.

I'm mainly just moving code around here. Behaviors should be entirely unchanged.