### PR TITLE
DolphinQt: Add a "Configure Extension" button under the extension selection combo box.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -579,3 +579,8 @@ void MappingWindow::ShowExtensionMotionTabs(bool show)
     m_tab_widget->removeTab(4);
   }
 }
+
+void MappingWindow::ActivateExtensionTab()
+{
+  m_tab_widget->setCurrentIndex(3);
+}

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -53,6 +53,7 @@ public:
   ControllerEmu::EmulatedController* GetController() const;
   bool IsMappingAllDevices() const;
   void ShowExtensionMotionTabs(bool show);
+  void ActivateExtensionTab();
 
 signals:
   // Emitted when config has changed so widgets can update to reflect the change.

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
@@ -59,7 +59,13 @@ void WiimoteEmuGeneral::CreateMainLayout()
 
   extension->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
-  static_cast<QFormLayout*>(extension->layout())->insertRow(0, combo_hbox);
+  auto* const ext_layout = static_cast<QFormLayout*>(extension->layout());
+  ext_layout->insertRow(0, combo_hbox);
+
+  m_configure_ext_button = new QPushButton(tr("Configure Extension"));
+  m_configure_ext_button->setDisabled(true);
+  m_configure_ext_button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  ext_layout->insertRow(1, m_configure_ext_button);
 
   layout->addWidget(extension, 0, 3);
   layout->addWidget(CreateGroupBox(tr("Rumble"), Wiimote::GetWiimoteGroup(
@@ -81,6 +87,8 @@ void WiimoteEmuGeneral::Connect()
   connect(m_extension_combo, &QComboBox::activated, this, &WiimoteEmuGeneral::OnAttachmentSelected);
   connect(this, &MappingWidget::ConfigChanged, this, &WiimoteEmuGeneral::ConfigChanged);
   connect(this, &MappingWidget::Update, this, &WiimoteEmuGeneral::Update);
+  connect(m_configure_ext_button, &QPushButton::clicked, GetParent(),
+          &MappingWindow::ActivateExtensionTab);
 }
 
 void WiimoteEmuGeneral::OnAttachmentChanged(int extension)
@@ -88,6 +96,8 @@ void WiimoteEmuGeneral::OnAttachmentChanged(int extension)
   GetParent()->ShowExtensionMotionTabs(extension == WiimoteEmu::ExtensionNumber::NUNCHUK);
 
   m_extension_widget->ChangeExtensionType(extension);
+
+  m_configure_ext_button->setEnabled(extension != WiimoteEmu::ExtensionNumber::NONE);
 }
 
 void WiimoteEmuGeneral::OnAttachmentSelected(int extension)

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.h
@@ -34,6 +34,7 @@ private:
   // Extensions
   QComboBox* m_extension_combo;
   QLabel* m_extension_combo_dynamic_indicator;
+  QPushButton* m_configure_ext_button;
 
   WiimoteEmuExtension* m_extension_widget;
 };


### PR DESCRIPTION
I've seen at least one user rightfully confused about where to go when the "..." button didn't do what they expected.

Clicking the "Configure Extension" button switches to the `Extension` tab.
![image](https://github.com/user-attachments/assets/eea6d930-82a2-4a9a-abab-880acfa6a260)

The button is disabled when extension "None" is selected.