### PR TITLE
Core/WiimoteReal: Make Wii Remote scan logging less spammy on Linux.

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
@@ -3,6 +3,8 @@
 
 #include "Core/HW/WiimoteReal/IOLinux.h"
 
+#include <ranges>
+
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
@@ -73,30 +75,29 @@ void WiimoteScannerLinux::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wi
   DEBUG_LOG_FMT(WIIMOTE, "Found {} Bluetooth device(s).", found_devices);
 
   // Display discovered devices
-  for (int i = 0; i < found_devices; ++i)
+  for (auto& scan_info : scan_infos | std::ranges::views::take(found_devices))
   {
-    NOTICE_LOG_FMT(WIIMOTE, "found a device...");
-
     // BT names are a maximum of 248 bytes apparently
     char name[255] = {};
-    if (hci_read_remote_name(m_device_sock, &scan_infos[i].bdaddr, sizeof(name), name, 1000) < 0)
+    if (hci_read_remote_name(m_device_sock, &scan_info.bdaddr, sizeof(name), name, 1000) < 0)
     {
-      ERROR_LOG_FMT(WIIMOTE, "name request failed");
+      ERROR_LOG_FMT(WIIMOTE, "Bluetooth read remote name failed.");
       continue;
     }
 
-    NOTICE_LOG_FMT(WIIMOTE, "device name {}", name);
+    INFO_LOG_FMT(WIIMOTE, "Found bluetooth device with name: {}", name);
+
     if (!IsValidDeviceName(name))
       continue;
 
     char bdaddr_str[18] = {};
-    ba2str(&scan_infos[i].bdaddr, bdaddr_str);
+    ba2str(&scan_info.bdaddr, bdaddr_str);
 
     if (!IsNewWiimote(bdaddr_str))
       continue;
 
     // Found a new device
-    Wiimote* wm = new WiimoteLinux(scan_infos[i].bdaddr);
+    Wiimote* wm = new WiimoteLinux(scan_info.bdaddr);
     if (IsBalanceBoardName(name))
     {
       found_board = wm;


### PR DESCRIPTION
The "found a device..." NOTICE-level log was very spammy with "Continuous Scanning" enabled.

Also cleaned up some of the other related log messages.