### PR TITLE
Flatpak: Move wrapper script outside of the manifest

### DIFF
--- a/Flatpak/dolphin-emu-wrapper
+++ b/Flatpak/dolphin-emu-wrapper
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)#flatpak-applications
+for i in {0..9}; do
+  test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+done
+
+dolphin-emu "$@"

--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -62,19 +62,10 @@ modules:
     cleanup:
       - /share/man
     post-install:
-      - install -D -t ${FLATPAK_DEST}/bin/ ../dolphin-emu-wrapper
+      - install -Dm755 -t ${FLATPAK_DEST}/bin/ ../Flatpak/dolphin-emu-wrapper
       - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo/ Flatpak/org.DolphinEmu.dolphin-emu.metainfo.xml
       - desktop-file-edit --set-key=Exec --set-value='/app/bin/dolphin-emu-wrapper'
         /app/share/applications/dolphin-emu.desktop
     sources:
       - type: dir
         path: ..
-      - type: script
-        commands:
-          - |
-            for i in {0..9}; do
-              test -S $XDG_RUNTIME_DIR/discord-ipc-$i ||
-                ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
-            done
-            dolphin-emu "$@"
-        dest-filename: dolphin-emu-wrapper


### PR DESCRIPTION
Writing a script into the repository root causes ScmRevGen to mark the build as `dirty`.