### PR TITLE
Breakpoints: Fix lag when loading multiple memory breakpoints

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -115,19 +115,20 @@ public:
   TMemChecksStr GetStrings() const;
   void AddFromStrings(const TMemChecksStr& mc_strings);
 
-  void Add(TMemCheck memory_check);
+  void Add(TMemCheck memory_check, bool update = true);
 
   bool ToggleEnable(u32 address);
 
   TMemCheck* GetMemCheck(u32 address, size_t size = 1);
   bool OverlapsMemcheck(u32 address, u32 length) const;
-  // Remove Breakpoint. Returns whether it was removed.
-  bool Remove(u32 address);
+  bool Remove(u32 address, bool update = true);
 
+  void Update();
   void Clear();
   bool HasAny() const { return !m_mem_checks.empty(); }
 
 private:
   TMemChecks m_mem_checks;
   Core::System& m_system;
+  bool m_mem_breakpoints_set = false;
 };

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -174,9 +174,10 @@ static void RemoveBreakpoint(BreakpointType type, u32 addr, u32 len)
     auto& memchecks = Core::System::GetInstance().GetPowerPC().GetMemChecks();
     while (memchecks.GetMemCheck(addr, len) != nullptr)
     {
-      memchecks.Remove(addr);
+      memchecks.Remove(addr, false);
       INFO_LOG_FMT(GDB_STUB, "gdb: removed a memcheck: {:08x} bytes at {:08x}", len, addr);
     }
+    memchecks.Update();
   }
   Host_PPCBreakpointsChanged();
 }


### PR DESCRIPTION
Should make loading tons of memory breakpoints instant.

I believe hammering DBATUpdated() is the main source of lag.  I also noticed some instability when a memory breakpoint is triggered while in the middle of loading multiple memory breakpoints, so I thread guarded the entire batch being loaded, which happens near instantly as DBATUpdated is only being hit once.

I assume removing multiple MBPs has the same issue, but can't test GDBStub, which does that. I included it in the fix.