### PR TITLE
AboutDialog: Disable resizing the About window

### DIFF
--- a/Source/Core/DolphinQt/AboutDialog.cpp
+++ b/Source/Core/DolphinQt/AboutDialog.cpp
@@ -100,6 +100,7 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
   QHBoxLayout* h_layout = new QHBoxLayout;
 
   setLayout(main_layout);
+  main_layout->setSizeConstraint(QLayout::SetFixedSize);
   main_layout->addLayout(h_layout);
   main_layout->addWidget(copyright);
   copyright->setAlignment(Qt::AlignCenter);


### PR DESCRIPTION
This prevents the About Dialog window from being resized, which lead to this result:

![image](https://github.com/user-attachments/assets/79ee0d0c-6020-4342-a29e-91b9d30a2500)

It now cannot be maximized or otherwise resized:

![image](https://github.com/user-attachments/assets/fbf5c7a2-04f9-4c73-b6b8-f79c5bd6458f)
