### PR TITLE
Fix segfault when passing invalid arguments

### DIFF
--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -688,7 +688,7 @@ void Shutdown()
   StopScanThread();
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
 #if LIBUSB_API_HAS_HOTPLUG
-  if (s_libusb_context->IsValid() && s_libusb_hotplug_enabled)
+  if (s_libusb_context && s_libusb_context->IsValid() && s_libusb_hotplug_enabled)
     libusb_hotplug_deregister_callback(*s_libusb_context, s_hotplug_handle);
 #endif
 #endif


### PR DESCRIPTION
This is an issue I noticed while working on #13288.

![image](https://github.com/user-attachments/assets/9dce6c66-66ba-4ba5-86de-035a28e17c29)
