### PR TITLE
VertexLoaderBase: Allow the vertex loader type to be set via config

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -126,6 +126,9 @@ const Info<bool> GFX_MODS_ENABLE{{System::GFX, "Settings", "EnableMods"}, false}
 
 const Info<std::string> GFX_DRIVER_LIB_NAME{{System::GFX, "Settings", "DriverLibName"}, ""};
 
+const Info<VertexLoaderType> GFX_VERTEX_LOADER_TYPE{{System::GFX, "Settings", "VertexLoaderType"},
+                                                    VertexLoaderType::Native};
+
 // Graphics.Enhancements
 
 const Info<TextureFilteringMode> GFX_ENHANCE_FORCE_TEXTURE_FILTERING{

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -16,6 +16,7 @@ enum class OutputResamplingMode : int;
 enum class ColorCorrectionRegion : int;
 enum class TriState : int;
 enum class FrameDumpResolutionType : int;
+enum class VertexLoaderType : int;
 
 namespace Config
 {
@@ -183,5 +184,9 @@ extern const Info<bool> GFX_PERF_QUERIES_ENABLE;
 // Android custom GPU drivers
 
 extern const Info<std::string> GFX_DRIVER_LIB_NAME;
+
+// Vertex loader
+
+extern const Info<VertexLoaderType> GFX_VERTEX_LOADER_TYPE;
 
 }  // namespace Config

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -25,6 +25,7 @@
 #include "VideoCommon/VertexLoader_Normal.h"
 #include "VideoCommon/VertexLoader_Position.h"
 #include "VideoCommon/VertexLoader_TextCoord.h"
+#include "VideoCommon/VideoConfig.h"
 
 #ifdef _M_X86_64
 #include "VideoCommon/VertexLoaderX64.h"
@@ -238,29 +239,37 @@ u32 VertexLoaderBase::GetVertexComponents(const TVtxDesc& vtx_desc, const VAT& v
 std::unique_ptr<VertexLoaderBase> VertexLoaderBase::CreateVertexLoader(const TVtxDesc& vtx_desc,
                                                                        const VAT& vtx_attr)
 {
-  std::unique_ptr<VertexLoaderBase> loader = nullptr;
+  const VertexLoaderType loader_type = g_ActiveConfig.vertex_loader_type;
 
-  // #define COMPARE_VERTEXLOADERS
+  if (loader_type == VertexLoaderType::Software)
+  {
+    return std::make_unique<VertexLoader>(vtx_desc, vtx_attr);
+  }
+
+  std::unique_ptr<VertexLoaderBase> native_loader = nullptr;
 
 #if defined(_M_X86_64)
-  loader = std::make_unique<VertexLoaderX64>(vtx_desc, vtx_attr);
+  native_loader = std::make_unique<VertexLoaderX64>(vtx_desc, vtx_attr);
 #elif defined(_M_ARM_64)
-  loader = std::make_unique<VertexLoaderARM64>(vtx_desc, vtx_attr);
+  native_loader = std::make_unique<VertexLoaderARM64>(vtx_desc, vtx_attr);
 #endif
 
   // Use the software loader as a fallback
   // (not currently applicable, as both VertexLoaderX64 and VertexLoaderARM64
   // are always usable, but if a loader that only works on some CPUs is created
   // then this fallback would be used)
-  if (!loader)
-    loader = std::make_unique<VertexLoader>(vtx_desc, vtx_attr);
+  if (!native_loader)
+  {
+    return std::make_unique<VertexLoader>(vtx_desc, vtx_attr);
+  }
 
-#if defined(COMPARE_VERTEXLOADERS)
-  return std::make_unique<VertexLoaderTester>(
-      std::make_unique<VertexLoader>(vtx_desc, vtx_attr),  // the software one
-      std::move(loader),                                   // the new one to compare
-      vtx_desc, vtx_attr);
-#else
-  return loader;
-#endif
+  if (loader_type == VertexLoaderType::Compare)
+  {
+    return std::make_unique<VertexLoaderTester>(
+        std::make_unique<VertexLoader>(vtx_desc, vtx_attr),  // the software one
+        std::move(native_loader),                            // the new one to compare
+        vtx_desc, vtx_attr);
+  }
+
+  return native_loader;
 }

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -206,6 +206,8 @@ void VideoConfig::Refresh()
   bGraphicMods = Config::Get(Config::GFX_MODS_ENABLE);
 
   customDriverLibraryName = Config::Get(Config::GFX_DRIVER_LIB_NAME);
+
+  vertex_loader_type = Config::Get(Config::GFX_VERTEX_LOADER_TYPE);
 }
 
 void VideoConfig::VerifyValidity()

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -90,6 +90,13 @@ enum class FrameDumpResolutionType : int
   XFBRawResolution,
 };
 
+enum class VertexLoaderType : int
+{
+  Native,
+  Software,
+  Compare
+};
+
 // Bitmask containing information about which configuration has changed for the backend.
 enum ConfigChangeBits : u32
 {
@@ -278,6 +285,9 @@ struct VideoConfig final
 
   // Loading custom drivers on Android
   std::string customDriverLibraryName;
+
+  // Vertex loader
+  VertexLoaderType vertex_loader_type;
 
   // Static config per API
   // TODO: Move this out of VideoConfig


### PR DESCRIPTION
Being able to set the vertex loader type without having to recompile Dolphin is useful on some platforms. This also makes it easier to use the native vs. software comparison loader, as Dolphin doesn't need to be rebuilt.

Not sure if this is worth upstreaming, but I figured that I could just PR it and see.