### PR TITLE
CMakeLists: Add flag to disable Cubeb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ option(ENABLE_GENERIC "Enables generic build that should run on any little-endia
 option(ENABLE_HEADLESS "Enables running Dolphin as a headless variant" OFF)
 option(ENABLE_ALSA "Enables ALSA sound backend" ON)
 option(ENABLE_PULSEAUDIO "Enables PulseAudio sound backend" ON)
+option(ENABLE_CUBEB "Enables Cubeb sound backend" ON)
 option(ENABLE_LLVM "Enables LLVM support, for disassembly" ON)
 option(ENABLE_TESTS "Enables building the unit tests" ON)
 option(ENABLE_VULKAN "Enables vulkan video backend" ON)
@@ -700,7 +701,10 @@ endif()
 add_subdirectory(Externals/soundtouch)
 include_directories(Externals/soundtouch)
 
-dolphin_find_optional_system_library(CUBEB Externals/cubeb)
+if(ENABLE_CUBEB)
+  dolphin_find_optional_system_library(CUBEB Externals/cubeb)
+  add_definitions(-DHAVE_CUBEB)
+endif()
 
 if(NOT ANDROID)
   dolphin_find_optional_system_library_pkgconfig(

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -28,7 +28,7 @@ constexpr int AUDIO_VOLUME_MAX = 100;
 
 static std::unique_ptr<SoundStream> CreateSoundStreamForBackend(std::string_view backend)
 {
-  if (backend == BACKEND_CUBEB)
+  if (backend == BACKEND_CUBEB && CubebStream::IsValid())
     return std::make_unique<CubebStream>();
   else if (backend == BACKEND_OPENAL && OpenALStream::IsValid())
     return std::make_unique<OpenALStream>();
@@ -100,10 +100,11 @@ std::string GetDefaultSoundBackend()
 #elif defined __linux__
   if (AlsaSound::IsValid())
     backend = BACKEND_ALSA;
-  else
+  else if (CubebStream::IsValid())
     backend = BACKEND_CUBEB;
 #elif defined(__APPLE__) || defined(_WIN32) || defined(__OpenBSD__)
-  backend = BACKEND_CUBEB;
+  if (CubebStream::IsValid())
+    backend = BACKEND_CUBEB;
 #endif
   return backend;
 }
@@ -118,7 +119,8 @@ std::vector<std::string> GetSoundBackends()
   std::vector<std::string> backends;
 
   backends.emplace_back(BACKEND_NULLSOUND);
-  backends.emplace_back(BACKEND_CUBEB);
+  if (CubebStream::IsValid())
+    backends.emplace_back(BACKEND_CUBEB);
   if (AlsaSound::IsValid())
     backends.emplace_back(BACKEND_ALSA);
   if (PulseAudio::IsValid())

--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -3,10 +3,7 @@ add_library(audiocommon
   AudioCommon.h
   AudioStretcher.cpp
   AudioStretcher.h
-  CubebStream.cpp
   CubebStream.h
-  CubebUtils.cpp
-  CubebUtils.h
   Enums.h
   Mixer.cpp
   Mixer.h
@@ -17,6 +14,16 @@ add_library(audiocommon
   WaveFile.cpp
   WaveFile.h
 )
+
+if(ENABLE_CUBEB)
+  message(STATUS "Cubeb found, enabling Cubeb sound backend")
+  target_sources(audiocommon PRIVATE
+    CubebStream.cpp
+    CubebUtils.cpp
+    CubebUtils.h
+  )
+  target_link_libraries(audiocommon PRIVATE cubeb)
+endif()
 
 if(ANDROID)
   find_package(OpenSLES)
@@ -83,9 +90,12 @@ PUBLIC
   common
 
 PRIVATE
-  cubeb::cubeb
   SoundTouch
   FreeSurround)
+
+if(ENABLE_CUBEB)
+  target_link_libraries(audiocommon PRIVATE cubeb::cubeb)
+endif()
 
 if(MSVC)
   # Add precompiled header

--- a/Source/Core/AudioCommon/CubebStream.h
+++ b/Source/Core/AudioCommon/CubebStream.h
@@ -11,10 +11,13 @@
 #include "AudioCommon/SoundStream.h"
 #include "Common/WorkQueueThread.h"
 
+#ifdef HAVE_CUBEB
 #include <cubeb/cubeb.h>
+#endif
 
 class CubebStream final : public SoundStream
 {
+#ifdef HAVE_CUBEB
 public:
   CubebStream();
   CubebStream(const CubebStream& other) = delete;
@@ -25,6 +28,7 @@ public:
   bool Init() override;
   bool SetRunning(bool running) override;
   void SetVolume(int) override;
+  static bool IsValid() { return true; }
 
 private:
   bool m_stereo = false;
@@ -43,4 +47,5 @@ private:
   static long DataCallback(cubeb_stream* stream, void* user_data, const void* /*input_buffer*/,
                            void* output_buffer, long num_frames);
   static void StateCallback(cubeb_stream* stream, void* user_data, cubeb_state state);
+#endif
 };

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -213,8 +213,6 @@ add_library(core
   HW/EXI/EXI_DeviceIPL.h
   HW/EXI/EXI_DeviceMemoryCard.cpp
   HW/EXI/EXI_DeviceMemoryCard.h
-  HW/EXI/EXI_DeviceMic.cpp
-  HW/EXI/EXI_DeviceMic.h
   HW/EXI/EXI_DeviceModem.cpp
   HW/EXI/EXI_DeviceModem.h
   HW/EXI/EXI.cpp
@@ -645,7 +643,6 @@ PUBLIC
   videosoftware
 
 PRIVATE
-  cubeb::cubeb
   FatFs
   fmt::fmt
   LZO::LZO
@@ -665,6 +662,14 @@ elseif (ANDROID)
   target_link_libraries(core
   PRIVATE
     androidcommon
+  )
+endif()
+
+if(ENABLE_CUBEB)
+  target_link_libraries(core PUBLIC cubeb)
+  target_sources(core PRIVATE
+    HW/EXI/EXI_DeviceMic.cpp
+    HW/EXI/EXI_DeviceMic.h
   )
 endif()
 

--- a/Source/Core/Core/HW/EXI/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Device.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
 #include "Core/HW/EXI/EXI_DeviceAD16.h"
 #include "Core/HW/EXI/EXI_DeviceAGP.h"
 #include "Core/HW/EXI/EXI_DeviceDummy.h"
@@ -13,10 +14,13 @@
 #include "Core/HW/EXI/EXI_DeviceGecko.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/EXI/EXI_DeviceMemoryCard.h"
-#include "Core/HW/EXI/EXI_DeviceMic.h"
 #include "Core/HW/EXI/EXI_DeviceModem.h"
 #include "Core/HW/Memmap.h"
 #include "Core/System.h"
+
+#ifdef HAVE_CUBEB
+#include "Core/HW/EXI/EXI_DeviceMic.h"
+#endif
 
 namespace ExpansionInterface
 {
@@ -131,7 +135,12 @@ std::unique_ptr<IEXIDevice> EXIDevice_Create(Core::System& system, const EXIDevi
     break;
 
   case EXIDeviceType::Microphone:
+#ifdef HAVE_CUBEB
     result = std::make_unique<CEXIMic>(system, channel_num);
+#else
+    PanicAlertFmtT("Dolphin was built with Cubeb disabled. The Microphone device cannot be used.");
+    result = std::make_unique<IEXIDevice>(system);
+#endif
     break;
 
   case EXIDeviceType::Ethernet:

--- a/Source/VSProps/Base.Dolphin.props
+++ b/Source/VSProps/Base.Dolphin.props
@@ -47,6 +47,7 @@
       <PreprocessorDefinitions Condition="'$(Steam)'=='true'">STEAM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>USE_RETRO_ACHIEVEMENTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>RC_CLIENT_SUPPORTS_HASH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_CUBEB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 
       <!-- Warnings one may want to ignore when using Level4.
       4201  nonstandard extension used : nameless struct/union


### PR DESCRIPTION
Cubeb doesn't support some platforms, so we should have the ability to disable it.

Outside of AudioCommon, `CEXIMic` uses Cubeb to get microphone input, so I added a panic alert when the Microphone device is selected and Cubeb is unavailable.