### PR TITLE
Correct AppStream metainfo XML fixing validations errors.

### DIFF
--- a/CMake/ScmRevGen.cmake
+++ b/CMake/ScmRevGen.cmake
@@ -71,5 +71,5 @@ if(APPLE)
 endif()
 
 if(LINUX)
-  configure_source_file("Flatpak/org.DolphinEmu.dolphin-emu.metainfo.xml")
+  configure_source_file("Flatpak/org.dolphin_emu.dolphin_emu.metainfo.xml")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,8 +791,8 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Flatpak)
-  if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/Flatpak/org.DolphinEmu.dolphin-emu.metainfo.xml)
-    file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/Flatpak/org.DolphinEmu.dolphin-emu.metainfo.xml)
+  if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/Flatpak/org.dolphin_emu.dolphin_emu.metainfo.xml)
+    file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/Flatpak/org.dolphin_emu.dolphin_emu.metainfo.xml)
   endif()
 endif()
 
@@ -803,7 +803,7 @@ endif()
 add_custom_target(
 	dolphin_scmrev
 	${CMAKE_COMMAND} -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR} -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR} -DDISTRIBUTOR=${DISTRIBUTOR} -DDOLPHIN_DEFAULT_UPDATE_TRACK=${DOLPHIN_DEFAULT_UPDATE_TRACK} -DGIT_FOUND=${GIT_FOUND} -DGIT_EXECUTABLE=${GIT_EXECUTABLE} -DDOLPHIN_WC_REVISION=${DOLPHIN_WC_REVISION} -DDOLPHIN_WC_DESCRIBE=${DOLPHIN_WC_DESCRIBE} -DDOLPHIN_WC_BRANCH=${DOLPHIN_WC_BRANCH} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET} -P ${CMAKE_CURRENT_SOURCE_DIR}/CMake/ScmRevGen.cmake
-	BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/Source/Core/Common/scmrev.h" "${CMAKE_CURRENT_BINARY_DIR}/Source/Core/DolphinQt/Info.plist" "${CMAKE_CURRENT_BINARY_DIR}/Source/Core/MacUpdater/Info.plist" "${CMAKE_CURRENT_BINARY_DIR}/Flatpak/org.DolphinEmu.dolphin-emu.metainfo.xml"
+	BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/Source/Core/Common/scmrev.h" "${CMAKE_CURRENT_BINARY_DIR}/Source/Core/DolphinQt/Info.plist" "${CMAKE_CURRENT_BINARY_DIR}/Source/Core/MacUpdater/Info.plist" "${CMAKE_CURRENT_BINARY_DIR}/Flatpak/org.dolphin_emu.dolphin_emu.metainfo.xml"
 	VERBATIM
 )
 

--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -63,7 +63,7 @@ modules:
       - /share/man
     post-install:
       - install -D -t ${FLATPAK_DEST}/bin/ ../dolphin-emu-wrapper
-      - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo/ Flatpak/org.DolphinEmu.dolphin-emu.metainfo.xml
+      - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo/ Flatpak/org.dolphin_emu.dolphin_emu.metainfo.xml
       - desktop-file-edit --set-key=Exec --set-value='/app/bin/dolphin-emu-wrapper'
         /app/share/applications/dolphin-emu.desktop
     sources:

--- a/Flatpak/org.dolphin_emu.dolphin_emu.metainfo.xml.in
+++ b/Flatpak/org.dolphin_emu.dolphin_emu.metainfo.xml.in
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2016 Jeremy Newton -->
 <component type="desktop-application">
-  <id>org.DolphinEmu.dolphin-emu</id>
+  <id>org.dolphin_emu.dolphin_emu</id>
   <name>Dolphin Emulator</name>
-  <developer id="org.dolphin-emu">
-    <name>Dolphin Emulator Project</name>
-  </developer>
   <summary>GameCube / Wii</summary>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
@@ -15,19 +12,19 @@
   <screenshots>
     <screenshot type="default">
       <caption>Dolphin's main window</caption>
-      <image type="source">http://dolphin-emu.org/m/user/flatpak/screenshot_1.png</image>
+      <image type="source">https://dolphin-emu.org/m/user/flatpak/screenshot_1.png</image>
     </screenshot>
     <screenshot>
       <caption>In-game</caption>
-      <image type="source">http://dolphin-emu.org/m/user/flatpak/screenshot_2.png</image>
+      <image type="source">https://dolphin-emu.org/m/user/flatpak/screenshot_2.png</image>
     </screenshot>
     <screenshot>
       <caption>Graphics configuration</caption>
-      <image type="source">http://dolphin-emu.org/m/user/flatpak/screenshot_3.png</image>
+      <image type="source">https://dolphin-emu.org/m/user/flatpak/screenshot_3.png</image>
     </screenshot>
     <screenshot>
       <caption>Controller configuration</caption>
-      <image type="source">http://dolphin-emu.org/m/user/flatpak/screenshot_4.png</image>
+      <image type="source">https://dolphin-emu.org/m/user/flatpak/screenshot_4.png</image>
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">dolphin-emu.desktop</launchable>


### PR DESCRIPTION
The specification state that the ID and file name should be in reverse DNS form, and that '-' is an invalid character, so the customary way to handle it is replace '-' with '_'.

Also, replaced http with https links for screen shots and drop the now obsolete <developer> tag.

Adjusted build system to use the new file name.