### PR TITLE
Core / DolphinQt / InputCommon: reduce the number disk writes when using DynamicInputTextures

### DIFF
--- a/Source/Android/jni/Input/EmulatedController.cpp
+++ b/Source/Android/jni/Input/EmulatedController.cpp
@@ -71,8 +71,10 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedController_updateSingleControlReference(
     JNIEnv* env, jobject obj, jobject control_reference)
 {
-  return EmulatedControllerFromJava(env, obj)->UpdateSingleControlReference(
-      g_controller_interface, ControlReferenceFromJava(env, control_reference));
+  ControllerEmu::EmulatedController* controller = EmulatedControllerFromJava(env, obj);
+  controller->GetConfig()->GenerateControllerTextures();
+  return controller->UpdateSingleControlReference(g_controller_interface,
+                                                  ControlReferenceFromJava(env, control_reference));
 }
 
 JNIEXPORT void JNICALL
@@ -83,6 +85,7 @@ Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedContro
 
   controller->LoadDefaults(g_controller_interface);
   controller->UpdateReferences(g_controller_interface);
+  controller->GetConfig()->GenerateControllerTextures();
 }
 
 JNIEXPORT void JNICALL
@@ -96,6 +99,7 @@ Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedContro
 
   controller->LoadConfig(&section);
   controller->UpdateReferences(g_controller_interface);
+  controller->GetConfig()->GenerateControllerTextures();
 }
 
 JNIEXPORT void JNICALL
@@ -109,6 +113,7 @@ Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedContro
 
   controller->LoadConfig(ini.GetOrCreateSection("Profile"));
   controller->UpdateReferences(g_controller_interface);
+  controller->GetConfig()->GenerateControllerTextures();
 }
 
 JNIEXPORT void JNICALL

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -550,7 +550,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
       if (!EmulatedBS2(system, guard, system.IsWii(), *volume, riivolution_patches))
         return false;
 
-      SConfig::OnNewTitleLoad(guard);
+      SConfig::OnTitleDirectlyBooted(guard);
       return true;
     }
 
@@ -601,7 +601,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
         return false;
       }
 
-      SConfig::OnNewTitleLoad(guard);
+      SConfig::OnTitleDirectlyBooted(guard);
 
       ppc_state.pc = executable.reader->GetEntryPoint();
 
@@ -621,7 +621,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
       if (!Boot_WiiWAD(system, wad))
         return false;
 
-      SConfig::OnNewTitleLoad(guard);
+      SConfig::OnTitleDirectlyBooted(guard);
       return true;
     }
 
@@ -631,7 +631,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
       if (!BootNANDTitle(system, nand_title.id))
         return false;
 
-      SConfig::OnNewTitleLoad(guard);
+      SConfig::OnTitleDirectlyBooted(guard);
       return true;
     }
 
@@ -657,7 +657,7 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
                 ipl.disc->auto_disc_change_paths);
       }
 
-      SConfig::OnNewTitleLoad(guard);
+      SConfig::OnTitleDirectlyBooted(guard);
       return true;
     }
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -73,9 +73,15 @@ struct SConfig
   void SetRunningGameMetadata(const DiscIO::Volume& volume, const DiscIO::Partition& partition);
   void SetRunningGameMetadata(const IOS::ES::TMDReader& tmd, DiscIO::Platform platform);
   void SetRunningGameMetadata(const std::string& game_id);
-  // Reloads title-specific map files, patches, custom textures, etc.
-  // This should only be called after the new title has been loaded into memory.
-  static void OnNewTitleLoad(const Core::CPUThreadGuard& guard);
+
+  // Triggered when Dolphin loads a title directly
+  // Reloads title-specific map files, patches, etc.
+  static void OnTitleDirectlyBooted(const Core::CPUThreadGuard& guard);
+
+  // Direct title change from ES (Wii system)
+  // Wii titles will still hit OnTitleDirectlyBooted
+  // but GC titles will never see this call
+  static void OnESTitleChanged();
 
   void LoadDefaults();
   static std::string MakeGameID(std::string_view file_name);
@@ -111,6 +117,8 @@ struct SConfig
 private:
   SConfig();
   ~SConfig();
+
+  static void ReloadTextures(Core::System& system);
 
   void SetRunningGameMetadata(const std::string& game_id, const std::string& gametdb_id,
                               u64 title_id, u16 revision, DiscIO::Region region);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -493,8 +493,10 @@ static void EmuThread(Core::System& system, std::unique_ptr<BootParameters> boot
   g_controller_interface.ChangeWindow(wsi.render_window);
 
   Pad::LoadConfig();
+  Pad::GenerateDynamicInputTextures();
   Pad::LoadGBAConfig();
   Keyboard::LoadConfig();
+  Keyboard::GenerateDynamicInputTextures();
 
   BootSessionData boot_session_data = std::move(boot->boot_session_data);
   const std::optional<std::string>& savestate_path = boot_session_data.GetSavestatePath();
@@ -528,6 +530,7 @@ static void EmuThread(Core::System& system, std::unique_ptr<BootParameters> boot
   if (system.IsWii() && !Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_ENABLED))
   {
     Wiimote::LoadConfig();
+    Wiimote::GenerateDynamicInputTextures();
   }
 
   FreeLook::LoadInputConfig();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -493,10 +493,8 @@ static void EmuThread(Core::System& system, std::unique_ptr<BootParameters> boot
   g_controller_interface.ChangeWindow(wsi.render_window);
 
   Pad::LoadConfig();
-  Pad::GenerateDynamicInputTextures();
   Pad::LoadGBAConfig();
   Keyboard::LoadConfig();
-  Keyboard::GenerateDynamicInputTextures();
 
   BootSessionData boot_session_data = std::move(boot->boot_session_data);
   const std::optional<std::string>& savestate_path = boot_session_data.GetSavestatePath();
@@ -526,12 +524,7 @@ static void EmuThread(Core::System& system, std::unique_ptr<BootParameters> boot
     }
   }};
 
-  // Load Wiimotes - only if we are booting in Wii mode
-  if (system.IsWii() && !Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_ENABLED))
-  {
-    Wiimote::LoadConfig();
-    Wiimote::GenerateDynamicInputTextures();
-  }
+  // Wiimote input config is loaded in OnESTitleChanged
 
   FreeLook::LoadInputConfig();
 

--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -49,6 +49,11 @@ void LoadConfig()
   s_config.LoadConfig();
 }
 
+void GenerateDynamicInputTextures()
+{
+  s_config.GenerateControllerTextures();
+}
+
 ControllerEmu::ControlGroup* GetGroup(int port, KeyboardGroup group)
 {
   return static_cast<GCKeyboard*>(s_config.GetController(port))->GetGroup(group);

--- a/Source/Core/Core/HW/GCKeyboard.h
+++ b/Source/Core/Core/HW/GCKeyboard.h
@@ -19,6 +19,7 @@ namespace Keyboard
 void Shutdown();
 void Initialize();
 void LoadConfig();
+void GenerateDynamicInputTextures();
 
 InputConfig* GetConfig();
 ControllerEmu::ControlGroup* GetGroup(int port, KeyboardGroup group);

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -46,6 +46,11 @@ void LoadConfig()
   s_config.LoadConfig();
 }
 
+void GenerateDynamicInputTextures()
+{
+  s_config.GenerateControllerTextures();
+}
+
 bool IsInitialized()
 {
   return !s_config.ControllersNeedToBeCreated();

--- a/Source/Core/Core/HW/GCPad.h
+++ b/Source/Core/Core/HW/GCPad.h
@@ -20,6 +20,7 @@ namespace Pad
 void Shutdown();
 void Initialize();
 void LoadConfig();
+void GenerateDynamicInputTextures();
 bool IsInitialized();
 
 InputConfig* GetConfig();

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -211,6 +211,11 @@ void LoadConfig()
   s_last_connect_request_counter.fill(0);
 }
 
+void GenerateDynamicInputTextures()
+{
+  s_config.GenerateControllerTextures();
+}
+
 void Resume()
 {
   WiimoteReal::Resume();

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -78,6 +78,7 @@ void Shutdown();
 void Initialize(InitializeMode init_mode);
 void ResetAllWiimotes();
 void LoadConfig();
+void GenerateDynamicInputTextures();
 void Resume();
 void Pause();
 

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -205,6 +205,7 @@ void TitleContext::Update(const ES::TMDReader& tmd_, const ES::TicketReader& tic
   if (first_change)
   {
     SConfig::GetInstance().SetRunningGameMetadata(tmd, platform);
+    SConfig::GetInstance().OnESTitleChanged();
     first_change = false;
   }
 }

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -952,7 +952,7 @@ static void FinishPPCBootstrap(Core::System& system, u64 userdata, s64 cycles_la
 
   ASSERT(Core::IsCPUThread());
   Core::CPUThreadGuard guard(system);
-  SConfig::OnNewTitleLoad(guard);
+  SConfig::OnTitleDirectlyBooted(guard);
 
   INFO_LOG_FMT(IOS, "Bootstrapping done.");
 }

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -103,7 +103,7 @@ bool Load(Core::System& system)
   NOTICE_LOG_FMT(IOS, "IPL ready.");
   system.SetIsMIOS(true);
   system.GetDVDInterface().UpdateRunningGameMetadata();
-  SConfig::OnNewTitleLoad(guard);
+  SConfig::OnTitleDirectlyBooted(guard);
   return true;
 }
 }  // namespace IOS::HLE::MIOS

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -16,6 +16,7 @@
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/MappingCommon.h"
+#include "InputCommon/InputConfig.h"
 
 namespace MappingCommon
 {
@@ -135,6 +136,7 @@ public:
     m_parent->Save();
     m_parent->GetController()->UpdateSingleControlReference(g_controller_interface,
                                                             control_reference);
+    m_parent->GetController()->GetConfig()->GenerateControllerTextures();
   }
 
   void UpdateInputDetectionStartTimer()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -322,6 +322,7 @@ void MappingWindow::OnLoadProfilePressed()
 
   m_controller->LoadConfig(ini.GetOrCreateSection("Profile"));
   m_controller->UpdateReferences(g_controller_interface);
+  m_controller->GetConfig()->GenerateControllerTextures();
 
   const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
@@ -561,6 +562,7 @@ void MappingWindow::OnDefaultFieldsPressed()
 {
   m_controller->LoadDefaults(g_controller_interface);
   m_controller->UpdateReferences(g_controller_interface);
+  m_controller->GetConfig()->GenerateControllerTextures();
 
   const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
@@ -578,6 +580,7 @@ void MappingWindow::OnClearFieldsPressed()
   m_controller->SetDefaultDevice(default_device);
 
   m_controller->UpdateReferences(g_controller_interface);
+  m_controller->GetConfig()->GenerateControllerTextures();
 
   const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();

--- a/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.h
+++ b/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.h
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <map>
 #include <string>
 #include <vector>
 
 #include "Common/CommonTypes.h"
 #include "InputCommon/DynamicInputTextures/DITData.h"
+#include "InputCommon/ImageOperations.h"
 
 namespace Common
 {
@@ -16,18 +18,21 @@ class IniFile;
 
 namespace InputCommon::DynamicInputTextures
 {
+// Output folder name to image name to image data
+using OutputDetails = std::map<std::string, std::map<std::string, ImagePixelData>>;
 class Configuration
 {
 public:
   explicit Configuration(const std::string& json_path);
   ~Configuration();
-  bool GenerateTextures(const Common::IniFile& file,
-                        const std::vector<std::string>& controller_names) const;
+  void GenerateTextures(const Common::IniFile& file,
+                        const std::vector<std::string>& controller_names,
+                        OutputDetails* output) const;
 
 private:
-  bool GenerateTexture(const Common::IniFile& file,
-                       const std::vector<std::string>& controller_names,
-                       const Data& texture_data) const;
+  void GenerateTexture(const Common::IniFile& file,
+                       const std::vector<std::string>& controller_names, const Data& texture_data,
+                       OutputDetails* output) const;
 
   std::vector<Data> m_dynamic_input_textures;
   std::string m_base_path;

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -35,8 +35,6 @@ bool InputConfig::LoadConfig()
   static constexpr std::array<std::string_view, MAX_BBMOTES> num = {"1", "2", "3", "4", "BB"};
   std::string profile[MAX_BBMOTES];
 
-  m_dynamic_input_tex_config_manager.Load();
-
   if (SConfig::GetInstance().GetGameID() != "00000000")
   {
     const std::string profile_directory = GetUserProfileDirectoryPath();
@@ -102,8 +100,6 @@ bool InputConfig::LoadConfig()
       // Next profile
       n++;
     }
-
-    m_dynamic_input_tex_config_manager.GenerateTextures(inifile, controller_names);
     return true;
   }
   else
@@ -138,8 +134,6 @@ void InputConfig::SaveConfig()
     controller->SaveConfig(inifile.GetOrCreateSection(controller->GetName()));
     controller_names.push_back(controller->GetName());
   }
-
-  m_dynamic_input_tex_config_manager.GenerateTextures(inifile, controller_names);
 
   inifile.Save(ini_filename);
 }
@@ -210,6 +204,8 @@ bool InputConfig::IsControllerControlledByGamepadDevice(int index) const
 
 void InputConfig::GenerateControllerTextures(const Common::IniFile& file)
 {
+  m_dynamic_input_tex_config_manager.Load();
+
   std::vector<std::string> controller_names;
   for (auto& controller : m_controllers)
   {
@@ -217,4 +213,19 @@ void InputConfig::GenerateControllerTextures(const Common::IniFile& file)
   }
 
   m_dynamic_input_tex_config_manager.GenerateTextures(file, controller_names);
+}
+
+void InputConfig::GenerateControllerTextures()
+{
+  const std::string ini_filename = File::GetUserPath(D_CONFIG_IDX) + m_ini_name + ".ini";
+
+  Common::IniFile inifile;
+  inifile.Load(ini_filename);
+
+  for (auto& controller : m_controllers)
+  {
+    controller->SaveConfig(inifile.GetOrCreateSection(controller->GetName()));
+  }
+
+  GenerateControllerTextures(inifile);
 }

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -55,6 +55,7 @@ public:
   void UnregisterHotplugCallback();
 
   void GenerateControllerTextures(const Common::IniFile& file);
+  void GenerateControllerTextures();
 
 private:
   ControllerInterface::HotplugCallbackHandle m_hotplug_callback_handle;


### PR DESCRIPTION
While working on an optimized system for asset loading, I wanted to make sure Dynamic Input Textures (DIT) still worked.  While doing so, I found that images were being written to disk six times for one actual change.  This PR reduces the image write down to the expected one time.

The reason for the six times was that the generate texture logic was being called on `LoadConfig()` and `SaveConfig()`.  I recall struggling on where to put the generation code previously that would hit every scenario (profile loading, game loading, and the various options in the input mapping window).  When the input mapping is ran, multiple loads/configs are called, which causes excessive generation.  I've removed the logic from those two functions and instead called them in each location.