### PR TITLE
GameSettings: Set EFBAccessEnable=True for "I SPY: Spooky Mansion"

### DIFF
--- a/Data/Sys/GameSettings/SPQ.ini
+++ b/Data/Sys/GameSettings/SPQ.ini
@@ -1,0 +1,13 @@
+# SPQE7T - I SPY: Spooky Mansion
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBAccessEnable = True


### PR DESCRIPTION
Seems to resolve an issue with the menu as per the following conversation:

https://discord.com/channels/521709831132807179/521711075721478145/1333569568060342272