### PR TITLE
InputCommon/ExpressionParser: Function argument parsing minor cleanup.

### DIFF
--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -769,7 +769,8 @@ private:
       }
     }
 
-    const auto argument_validation = func->SetArguments(std::move(args));
+    func->SetArguments(std::move(args));
+    const auto argument_validation = func->ValidateArguments();
 
     if (std::holds_alternative<FunctionExpression::ExpectedArguments>(argument_validation))
     {

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -764,7 +764,7 @@ private:
 
           // Comma before the next argument.
           if (TOK_COMMA != tok.type)
-            return ParseResult::MakeErrorResult(tok, Common::GetStringT("Expected comma."));
+            return ParseResult::MakeErrorResult(tok, Common::GetStringT("Expected closing paren."));
         };
       }
     }

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
@@ -16,11 +16,10 @@ using FSec = std::chrono::duration<ControlState>;
 class ToggleExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
     // Optional 2nd argument for clearing state:
-    if (args.size() == 1 || args.size() == 2)
+    if (GetArgCount() == 1 || GetArgCount() == 2)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"toggle_state_input, [clear_state_input]"};
@@ -56,10 +55,9 @@ private:
 class NotExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -73,10 +71,9 @@ private:
 class AbsExpression final : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -89,10 +86,9 @@ private:
 class SinExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -105,10 +101,9 @@ private:
 class CosExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -121,10 +116,9 @@ private:
 class TanExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -137,10 +131,9 @@ private:
 class ASinExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -153,10 +146,9 @@ private:
 class ACosExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -169,10 +161,9 @@ private:
 class ATanExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -185,10 +176,9 @@ private:
 class ATan2Expression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 2)
+    if (GetArgCount() == 2)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"y, x"};
@@ -204,10 +194,9 @@ private:
 class SqrtExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -220,10 +209,9 @@ private:
 class PowExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 2)
+    if (GetArgCount() == 2)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"base, exponent"};
@@ -239,10 +227,9 @@ private:
 class MinExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 2)
+    if (GetArgCount() == 2)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"a, b"};
@@ -258,10 +245,9 @@ private:
 class MaxExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 2)
+    if (GetArgCount() == 2)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"a, b"};
@@ -277,10 +263,9 @@ private:
 class ClampExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 3)
+    if (GetArgCount() == 3)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"value, min, max"};
@@ -296,10 +281,9 @@ private:
 class TimerExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"seconds"};
@@ -339,10 +323,9 @@ private:
 class IfExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 3)
+    if (GetArgCount() == 3)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"condition, true_expression, false_expression"};
@@ -359,10 +342,9 @@ private:
 class UnaryMinusExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -379,10 +361,9 @@ private:
 class UnaryPlusExpression : public FunctionExpression
 {
 private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 1)
+    if (GetArgCount() == 1)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"expression"};
@@ -394,10 +375,9 @@ private:
 // usage: deadzone(input, amount)
 class DeadzoneExpression : public FunctionExpression
 {
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 2)
+    if (GetArgCount() == 2)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"input, amount"};
@@ -415,10 +395,9 @@ class DeadzoneExpression : public FunctionExpression
 // seconds is seconds to change from 0.0 to 1.0
 class SmoothExpression : public FunctionExpression
 {
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 2 || args.size() == 3)
+    if (GetArgCount() == 2 || GetArgCount() == 3)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"input, seconds_up, seconds_down = seconds_up"};
@@ -459,10 +438,9 @@ private:
 // usage: hold(input, seconds)
 class HoldExpression : public FunctionExpression
 {
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 2)
+    if (GetArgCount() == 2)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"input, seconds"};
@@ -498,10 +476,9 @@ private:
 // usage: tap(input, seconds, taps=2)
 class TapExpression : public FunctionExpression
 {
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 2 || args.size() == 3)
+    if (GetArgCount() == 2 || GetArgCount() == 3)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"input, seconds, taps = 2"};
@@ -558,10 +535,9 @@ private:
 // speed is max movement per second
 class RelativeExpression : public FunctionExpression
 {
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() >= 2 && args.size() <= 4)
+    if (GetArgCount() >= 2 && GetArgCount() <= 4)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"input, speed, [max_abs_value, [shared_state]]"};
@@ -617,10 +593,9 @@ private:
 // usage: pulse(input, seconds)
 class PulseExpression : public FunctionExpression
 {
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  ArgumentValidation ValidateArguments() override
   {
-    if (args.size() == 2)
+    if (GetArgCount() == 2)
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"input, seconds"};
@@ -739,12 +714,9 @@ void FunctionExpression::UpdateReferences(ControlEnvironment& env)
     arg->UpdateReferences(env);
 }
 
-FunctionExpression::ArgumentValidation
-FunctionExpression::SetArguments(std::vector<std::unique_ptr<Expression>>&& args)
+void FunctionExpression::SetArguments(std::vector<std::unique_ptr<Expression>>&& args)
 {
   m_args = std::move(args);
-
-  return ValidateArguments(m_args);
 }
 
 Expression& FunctionExpression::GetArg(u32 number)

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.h
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.h
@@ -33,14 +33,12 @@ public:
   int CountNumControls() const override;
   void UpdateReferences(ControlEnvironment& env) override;
 
-  ArgumentValidation SetArguments(std::vector<std::unique_ptr<Expression>>&& args);
+  void SetArguments(std::vector<std::unique_ptr<Expression>>&& args);
+  virtual ArgumentValidation ValidateArguments() = 0;
 
   void SetValue(ControlState value) override;
 
 protected:
-  virtual ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) = 0;
-
   Expression& GetArg(u32 number);
   const Expression& GetArg(u32 number) const;
   u32 GetArgCount() const;


### PR DESCRIPTION
Made function argument parsing error mention parenthesis instead of comma.
![image](https://github.com/user-attachments/assets/dffd8fc0-f528-4625-a622-41b925f6d042)

Made `FunctionExpression::ValidateArguments` look at previously set arguments instead of having to provide them.
Made `FunctionExpression::SetArguments` no longer call/return `ValidateArguments()` since it's not obvious that would happen from the name.