### PR TITLE
DolphinQt: Use global settings object also for debugger settings.

### DIFF
--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -608,14 +608,14 @@ void Settings::SetMemoryVisible(bool enabled)
 {
   if (IsMemoryVisible() == enabled)
     return;
-  QSettings().setValue(QStringLiteral("debugger/showmemory"), enabled);
+  GetQSettings().setValue(QStringLiteral("debugger/showmemory"), enabled);
 
   emit MemoryVisibilityChanged(enabled);
 }
 
 bool Settings::IsMemoryVisible() const
 {
-  return QSettings().value(QStringLiteral("debugger/showmemory")).toBool();
+  return GetQSettings().value(QStringLiteral("debugger/showmemory")).toBool();
 }
 
 void Settings::SetNetworkVisible(bool enabled)
@@ -636,28 +636,28 @@ void Settings::SetJITVisible(bool enabled)
 {
   if (IsJITVisible() == enabled)
     return;
-  QSettings().setValue(QStringLiteral("debugger/showjit"), enabled);
+  GetQSettings().setValue(QStringLiteral("debugger/showjit"), enabled);
 
   emit JITVisibilityChanged(enabled);
 }
 
 bool Settings::IsJITVisible() const
 {
-  return QSettings().value(QStringLiteral("debugger/showjit")).toBool();
+  return GetQSettings().value(QStringLiteral("debugger/showjit")).toBool();
 }
 
 void Settings::SetAssemblerVisible(bool enabled)
 {
   if (IsAssemblerVisible() == enabled)
     return;
-  QSettings().setValue(QStringLiteral("debugger/showassembler"), enabled);
+  GetQSettings().setValue(QStringLiteral("debugger/showassembler"), enabled);
 
   emit AssemblerVisibilityChanged(enabled);
 }
 
 bool Settings::IsAssemblerVisible() const
 {
-  return QSettings().value(QStringLiteral("debugger/showassembler")).toBool();
+  return GetQSettings().value(QStringLiteral("debugger/showassembler")).toBool();
 }
 
 void Settings::RefreshWidgetVisibility()


### PR DESCRIPTION
A number of settings in the `debugger` group were wrongly using a newly constructed `QSettings` object instead of the singleton object that `GetQSettings()` provides.

This made the application create a spurious, extra configuration file in the user directory:

```
~/.config/Dolphin Emulator/dolphin-emu.conf
```

Notice that,  by default, the application configuration files are stored in `~/.config/dolphin-emu`; not in `~/.config/Dolphin Emulator`.