### PR TITLE
LibusbDevice: Don't detach kernel drivers on macOS

### DIFF
--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -439,6 +439,9 @@ static int DoForEachInterface(const Configs& configs, u8 config_num, Function ac
 int LibusbDevice::ClaimAllInterfaces(u8 config_num) const
 {
   const int ret = DoForEachInterface(m_config_descriptors, config_num, [this](u8 i) {
+  // On macos detaching would fail without root or entitlement.
+  // We assume user is using GCAdapterDriver and therefore don't want to detach anything
+#if !defined(__APPLE__)
     const int ret2 = libusb_detach_kernel_driver(m_handle, i);
     if (ret2 < LIBUSB_SUCCESS && ret2 != LIBUSB_ERROR_NOT_FOUND &&
         ret2 != LIBUSB_ERROR_NOT_SUPPORTED)
@@ -447,6 +450,7 @@ int LibusbDevice::ClaimAllInterfaces(u8 config_num) const
                     LibusbUtils::ErrorWrap(ret2));
       return ret2;
     }
+#endif
     return libusb_claim_interface(m_handle, i);
   });
   if (ret < LIBUSB_SUCCESS)

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -584,7 +584,7 @@ static bool CheckDeviceAccess(libusb_device* device)
   if (ret == 1)  // 1: kernel driver is active
   {
     // On macos detaching would fail without root or entitlement.
-    // We assume user is using GCAdapterDriver and therefor don't want to detach anything
+    // We assume user is using GCAdapterDriver and therefore don't want to detach anything
 #if !defined(__APPLE__)
     ret = libusb_detach_kernel_driver(s_handle, 0);
     detach_failed =


### PR DESCRIPTION
I was working on updating GCAdapterDriver so it works for more devices, and noted that we would need to skip detaching the kernel driver in LibusbDevice too, much like we already do for GCAdapter.

https://github.com/secretkeysio/GCAdapterDriver/pull/27
I have already added all the PS3 and Wii controllers i can think of, and there is a test build of GCAdapterDriver on that pull request that has these devices included.