### PR TITLE
DolphinQt/Mapping: Add setting to enable waiting for alternate mappings.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -111,11 +111,15 @@ void MappingWindow::CreateDevicesLayout()
   const auto refresh_action = new QAction(tr("Refresh"), options);
   connect(refresh_action, &QAction::triggered, this, &MappingWindow::RefreshDevices);
 
-  m_all_devices_action = new QAction(tr("Create mappings for other devices"), options);
-  m_all_devices_action->setCheckable(true);
+  m_other_device_mappings = new QAction(tr("Create Mappings for Other Devices"), options);
+  m_other_device_mappings->setCheckable(true);
+
+  m_wait_for_alternate_mappings = new QAction(tr("Wait for Alternate Input Mappings"), options);
+  m_wait_for_alternate_mappings->setCheckable(true);
 
   options->addAction(refresh_action);
-  options->addAction(m_all_devices_action);
+  options->addAction(m_other_device_mappings);
+  options->addAction(m_wait_for_alternate_mappings);
   options->setDefaultAction(refresh_action);
 
   m_devices_combo->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
@@ -354,9 +358,14 @@ void MappingWindow::OnSelectDevice(int)
   m_controller->UpdateReferences(g_controller_interface);
 }
 
-bool MappingWindow::IsMappingAllDevices() const
+bool MappingWindow::IsCreateOtherDeviceMappingsEnabled() const
 {
-  return m_all_devices_action->isChecked();
+  return m_other_device_mappings->isChecked();
+}
+
+bool MappingWindow::IsWaitForAlternateMappingsEnabled() const
+{
+  return m_wait_for_alternate_mappings->isChecked();
 }
 
 void MappingWindow::RefreshDevices()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -51,7 +51,8 @@ public:
 
   int GetPort() const;
   ControllerEmu::EmulatedController* GetController() const;
-  bool IsMappingAllDevices() const;
+  bool IsCreateOtherDeviceMappingsEnabled() const;
+  bool IsWaitForAlternateMappingsEnabled() const;
   void ShowExtensionMotionTabs(bool show);
   void ActivateExtensionTab();
 
@@ -103,7 +104,8 @@ private:
   QGroupBox* m_devices_box;
   QHBoxLayout* m_devices_layout;
   QComboBox* m_devices_combo;
-  QAction* m_all_devices_action;
+  QAction* m_other_device_mappings;
+  QAction* m_wait_for_alternate_mappings;
 
   // Profiles
   QGroupBox* m_profiles_box;

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -491,7 +491,7 @@ void InputDetector::Update(std::chrono::milliseconds initial_wait,
           Detection new_detection;
           new_detection.device = device_state.device;
           new_detection.input = input_state.input;
-          new_detection.press_time = Clock::now();
+          new_detection.press_time = now;
           new_detection.smoothness = smoothness;
 
           // We found an input. Add it to our detections.
@@ -516,12 +516,12 @@ bool InputDetector::IsComplete() const
   return !m_state;
 }
 
-auto InputDetector::GetResults() const -> const std::vector<Detection>&
+auto InputDetector::GetResults() const -> const Results&
 {
   return m_detections;
 }
 
-auto InputDetector::TakeResults() -> std::vector<Detection>
+auto InputDetector::TakeResults() -> Results
 {
   return std::move(m_detections);
 }

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -250,6 +250,7 @@ class InputDetector
 {
 public:
   using Detection = DeviceContainer::InputDetection;
+  using Results = std::vector<Detection>;
 
   InputDetector();
   ~InputDetector();
@@ -259,16 +260,16 @@ public:
               std::chrono::milliseconds maximum_wait);
   bool IsComplete() const;
 
-  const std::vector<Detection>& GetResults() const;
+  const Results& GetResults() const;
 
   // move-return'd to prevent copying.
-  std::vector<Detection> TakeResults();
+  Results TakeResults();
 
 private:
   struct Impl;
 
   Clock::time_point m_start_time;
-  std::vector<Detection> m_detections;
+  Results m_detections;
   std::unique_ptr<Impl> m_state;
 };
 

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.h
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.h
@@ -17,13 +17,16 @@ enum class Quote
 };
 
 std::string GetExpressionForControl(const std::string& control_name,
-                                    const ciface::Core::DeviceQualifier& control_device,
-                                    const ciface::Core::DeviceQualifier& default_device,
+                                    const Core::DeviceQualifier& control_device,
+                                    const Core::DeviceQualifier& default_device,
                                     Quote quote = Quote::On);
 
-std::string BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>&,
-                            const ciface::Core::DeviceQualifier& default_device, Quote quote);
+std::string BuildExpression(const Core::InputDetector::Results&,
+                            const Core::DeviceQualifier& default_device, Quote quote);
 
-void RemoveSpuriousTriggerCombinations(std::vector<ciface::Core::DeviceContainer::InputDetection>*);
+void RemoveSpuriousTriggerCombinations(Core::InputDetector::Results*);
+void RemoveDetectionsAfterTimePoint(Core::InputDetector::Results*,
+                                    Core::DeviceContainer::Clock::time_point after);
+bool ContainsCompleteDetection(const Core::InputDetector::Results&);
 
 }  // namespace ciface::MappingCommon


### PR DESCRIPTION
This feature was removed in #9685 because the delay it introduces during button mappings is annoying.

The default behavior is unchanged.
By enabling this new setting, auto generation of `|` mappings using sequential button presses is again possible.
![image](https://github.com/user-attachments/assets/11aada91-1668-4b99-b099-3d3d6cfa8a96)

Pressing X followed by Z with the setting enabled:

[Screencast_20250201_001656.webm](https://github.com/user-attachments/assets/f335a8d8-a876-404a-aac1-7198a3d41ce8)

Users occasionally ask how to map two buttons without having to press them at the same time.
Telling them to enable this setting is easier than explaining how to use the advanced mapping window.

I also did some other minor code cleanups.