### PR TITLE
VideoBackends: Use DXGI 1.6 and D3D11_4

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -3,10 +3,9 @@
 
 #pragma once
 
-#include <d3d11.h>
-#include <d3d11_1.h>
+#include <d3d11_4.h>
 #include <d3dcompiler.h>
-#include <dxgi1_5.h>
+#include <dxgi1_6.h>
 #include <fmt/format.h>
 #include <vector>
 #include <wrl/client.h>

--- a/Source/Core/VideoBackends/D3D/D3DGfx.h
+++ b/Source/Core/VideoBackends/D3D/D3DGfx.h
@@ -3,8 +3,9 @@
 
 #pragma once
 
-#include <d3d11.h>
+#include <d3d11_4.h>
 #include <string_view>
+
 #include "VideoBackends/D3D/D3DState.h"
 #include "VideoCommon/AbstractGfx.h"
 

--- a/Source/Core/VideoBackends/D3D/D3DSwapChain.h
+++ b/Source/Core/VideoBackends/D3D/D3DSwapChain.h
@@ -3,8 +3,7 @@
 
 #pragma once
 
-#include <d3d11.h>
-#include <dxgi.h>
+#include <d3d11_4.h>
 #include <memory>
 #include <vector>
 

--- a/Source/Core/VideoBackends/D3D/D3DVertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DVertexManager.cpp
@@ -3,7 +3,7 @@
 
 #include "VideoBackends/D3D/D3DVertexManager.h"
 
-#include <d3d11.h>
+#include <d3d11_4.h>
 
 #include "Common/Align.h"
 #include "Common/Assert.h"

--- a/Source/Core/VideoBackends/D3D/DXPipeline.h
+++ b/Source/Core/VideoBackends/D3D/DXPipeline.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <d3d11.h>
+#include <d3d11_4.h>
 #include <memory>
 
 #include "VideoBackends/D3D/D3DBase.h"

--- a/Source/Core/VideoBackends/D3D/DXTexture.h
+++ b/Source/Core/VideoBackends/D3D/DXTexture.h
@@ -3,11 +3,12 @@
 
 #pragma once
 
-#include <d3d11.h>
+#include <d3d11_4.h>
 #include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
+
 #include "Common/CommonTypes.h"
 
 #include "VideoBackends/D3D/D3DBase.h"

--- a/Source/Core/VideoBackends/D3D12/D3D12Gfx.h
+++ b/Source/Core/VideoBackends/D3D12/D3D12Gfx.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <d3d12.h>
+
 #include "VideoBackends/D3D12/DescriptorAllocator.h"
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"
 #include "VideoCommon/AbstractGfx.h"

--- a/Source/Core/VideoBackends/D3D12/D3D12SwapChain.h
+++ b/Source/Core/VideoBackends/D3D12/D3D12SwapChain.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <d3d12.h>
-#include <dxgi.h>
 #include <memory>
 #include <vector>
 

--- a/Source/Core/VideoBackends/D3D12/D3D12VertexManager.h
+++ b/Source/Core/VideoBackends/D3D12/D3D12VertexManager.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+
 #include "VideoBackends/D3D12/D3D12StreamBuffer.h"
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"
 #include "VideoCommon/VertexManagerBase.h"

--- a/Source/Core/VideoBackends/D3D12/DX12Context.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Context.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 #include <array>
-#include <dxgi1_2.h>
+#include <dxgi1_6.h>
 #include <queue>
 #include <vector>
 

--- a/Source/Core/VideoBackends/D3D12/DX12Shader.h
+++ b/Source/Core/VideoBackends/D3D12/DX12Shader.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3DCommon/Shader.h"
 

--- a/Source/Core/VideoBackends/D3D12/DX12Texture.h
+++ b/Source/Core/VideoBackends/D3D12/DX12Texture.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+
 #include "Common/CommonTypes.h"
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"

--- a/Source/Core/VideoBackends/D3D12/DescriptorAllocator.h
+++ b/Source/Core/VideoBackends/D3D12/DescriptorAllocator.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <map>
+
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"
 #include "VideoCommon/Constants.h"
 

--- a/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.h
+++ b/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.h
@@ -5,6 +5,7 @@
 
 #include <bitset>
 #include <unordered_map>
+
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoCommon/RenderState.h"
 

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.h
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+
 #include "VideoCommon/VideoBackendBase.h"
 
 namespace DX12

--- a/Source/Core/VideoBackends/D3DCommon/D3DCommon.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/D3DCommon.cpp
@@ -3,9 +3,9 @@
 
 #include "VideoBackends/D3DCommon/D3DCommon.h"
 
-#include <d3d11.h>
+#include <d3d11_4.h>
 #include <d3d12.h>
-#include <dxgi1_3.h>
+#include <dxgi1_6.h>
 #include <wrl/client.h>
 
 #include "Common/Assert.h"


### PR DESCRIPTION
This allows D3D11 and D3D12 to use DXGI 1.6 and D3D11 to use its latest version (11.4)