### PR TITLE
DolphinQt: Add setting to enable iterative input mappings.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -65,8 +65,9 @@ static QString RefToDisplayString(ControlReference* ref)
   return expression;
 }
 
-MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref)
-    : ElidedButton(RefToDisplayString(ref)), m_mapping_window(parent->GetParent()), m_reference(ref)
+MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref, ControlType control_type)
+    : ElidedButton{RefToDisplayString(ref)}, m_mapping_window{parent->GetParent()},
+      m_reference{ref}, m_control_type{control_type}
 {
   if (m_reference->IsInput())
   {
@@ -140,4 +141,9 @@ void MappingButton::mouseReleaseEvent(QMouseEvent* event)
 ControlReference* MappingButton::GetControlReference()
 {
   return m_reference;
+}
+
+auto MappingButton::GetControlType() const -> ControlType
+{
+  return m_control_type;
 }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -11,8 +11,6 @@
 #include "DolphinQt/Config/Mapping/IOWindow.h"
 #include "DolphinQt/Config/Mapping/MappingWidget.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
-#include "DolphinQt/QtUtils/BlockUserInputFilter.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
@@ -67,15 +65,10 @@ static QString RefToDisplayString(ControlReference* ref)
   return expression;
 }
 
-bool MappingButton::IsInput() const
-{
-  return m_reference->IsInput();
-}
-
 MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref)
     : ElidedButton(RefToDisplayString(ref)), m_mapping_window(parent->GetParent()), m_reference(ref)
 {
-  if (IsInput())
+  if (m_reference->IsInput())
   {
     setToolTip(
         tr("Left-click to detect input.\nMiddle-click to clear.\nRight-click for more options."));
@@ -88,10 +81,8 @@ MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref)
   connect(this, &MappingButton::clicked, this, &MappingButton::Clicked);
 
   connect(parent, &MappingWidget::ConfigChanged, this, &MappingButton::ConfigChanged);
-  connect(this, &MappingButton::ConfigChanged, [this] {
-    setText(RefToDisplayString(m_reference));
-    m_is_mapping = false;
-  });
+  connect(this, &MappingButton::ConfigChanged,
+          [this] { setText(RefToDisplayString(m_reference)); });
 }
 
 void MappingButton::AdvancedPressed()
@@ -114,7 +105,6 @@ void MappingButton::Clicked()
     return;
   }
 
-  m_is_mapping = true;
   m_mapping_window->QueueInputDetection(this);
 }
 
@@ -129,14 +119,6 @@ void MappingButton::Clear()
   m_mapping_window->Save();
 
   m_mapping_window->UnQueueInputDetection(this);
-}
-
-void MappingButton::StartMapping()
-{
-  // Focus just makes it more clear which button is currently being mapped.
-  setFocus();
-  setText(tr("[ Press Now ]"));
-  QtUtils::InstallKeyboardBlocker(this, this, &MappingButton::ConfigChanged);
 }
 
 void MappingButton::mouseReleaseEvent(QMouseEvent* event)

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
@@ -15,9 +15,17 @@ class MappingButton : public ElidedButton
 {
   Q_OBJECT
 public:
-  MappingButton(MappingWidget* widget, ControlReference* ref);
+  enum class ControlType
+  {
+    NormalInput,
+    ModifierInput,
+    Output,
+  };
+
+  MappingButton(MappingWidget* widget, ControlReference* ref, ControlType type);
 
   ControlReference* GetControlReference();
+  ControlType GetControlType() const;
 
 signals:
   void ConfigChanged();
@@ -32,4 +40,5 @@ private:
 
   MappingWindow* const m_mapping_window;
   ControlReference* const m_reference;
+  const ControlType m_control_type;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
@@ -17,12 +17,11 @@ class MappingButton : public ElidedButton
 public:
   MappingButton(MappingWidget* widget, ControlReference* ref);
 
-  bool IsInput() const;
   ControlReference* GetControlReference();
-  void StartMapping();
 
 signals:
   void ConfigChanged();
+  void QueueNextButtonMapping();
 
 private:
   void Clear();
@@ -33,5 +32,4 @@ private:
 
   MappingWindow* const m_mapping_window;
   ControlReference* const m_reference;
-  bool m_is_mapping = false;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -313,7 +313,16 @@ QGroupBox* MappingWidget::CreateControlsBox(const QString& name, ControllerEmu::
 void MappingWidget::CreateControl(const ControllerEmu::Control* control, QFormLayout* layout,
                                   bool indicator)
 {
-  auto* const button = new MappingButton(this, control->control_ref.get());
+  // I know this check is terrible, but it's just UI code.
+  const bool is_modifier = control->name == "Modifier";
+
+  using ControlType = MappingButton::ControlType;
+  const auto control_type =
+      control->control_ref->IsInput() ?
+          (is_modifier ? ControlType::ModifierInput : ControlType::NormalInput) :
+          ControlType::Output;
+
+  auto* const button = new MappingButton(this, control->control_ref.get(), control_type);
 
   if (control->control_ref->IsInput())
   {

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -314,6 +314,17 @@ void MappingWidget::CreateControl(const ControllerEmu::Control* control, QFormLa
                                   bool indicator)
 {
   auto* const button = new MappingButton(this, control->control_ref.get());
+
+  if (control->control_ref->IsInput())
+  {
+    if (m_previous_mapping_button)
+    {
+      connect(m_previous_mapping_button, &MappingButton::QueueNextButtonMapping,
+              [this, button]() { m_parent->QueueInputDetection(button); });
+    }
+    m_previous_mapping_button = button;
+  }
+
   button->setMinimumWidth(100);
   button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -7,6 +7,7 @@
 #include <QWidget>
 
 class InputConfig;
+class MappingButton;
 class MappingNumeric;
 class MappingWindow;
 class QFormLayout;
@@ -55,4 +56,5 @@ protected:
 
 private:
   MappingWindow* m_parent;
+  MappingButton* m_previous_mapping_button = nullptr;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -117,9 +117,13 @@ void MappingWindow::CreateDevicesLayout()
   m_wait_for_alternate_mappings = new QAction(tr("Wait for Alternate Input Mappings"), options);
   m_wait_for_alternate_mappings->setCheckable(true);
 
+  m_iterative_mapping = new QAction(tr("Enable Iterative Input Mapping"), options);
+  m_iterative_mapping->setCheckable(true);
+
   options->addAction(refresh_action);
   options->addAction(m_other_device_mappings);
   options->addAction(m_wait_for_alternate_mappings);
+  options->addAction(m_iterative_mapping);
   options->setDefaultAction(refresh_action);
 
   m_devices_combo->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
@@ -366,6 +370,11 @@ bool MappingWindow::IsCreateOtherDeviceMappingsEnabled() const
 bool MappingWindow::IsWaitForAlternateMappingsEnabled() const
 {
   return m_wait_for_alternate_mappings->isChecked();
+}
+
+bool MappingWindow::IsIterativeMappingEnabled() const
+{
+  return m_iterative_mapping->isChecked();
 }
 
 void MappingWindow::RefreshDevices()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -53,6 +53,7 @@ public:
   ControllerEmu::EmulatedController* GetController() const;
   bool IsCreateOtherDeviceMappingsEnabled() const;
   bool IsWaitForAlternateMappingsEnabled() const;
+  bool IsIterativeMappingEnabled() const;
   void ShowExtensionMotionTabs(bool show);
   void ActivateExtensionTab();
 
@@ -106,6 +107,7 @@ private:
   QComboBox* m_devices_combo;
   QAction* m_other_device_mappings;
   QAction* m_wait_for_alternate_mappings;
+  QAction* m_iterative_mapping;
 
   // Profiles
   QGroupBox* m_profiles_box;


### PR DESCRIPTION
~~This is based-on/depends-on PR #13320. (merge that first and I'll rebase this)~~

![image](https://github.com/user-attachments/assets/82fa3dc9-8131-4cfb-9921-52b5fc22e9d2)

When the setting is enabled, if the current mapping is successful then the next mapping button is activated and waits for mapping.

Now that mapping is non-blocking, this feature is less terrible than it used to be when it was removed in #8031.
Clicking the active mapping button stops the process.
Queuing specific buttons takes precedence over iterative mapping queuing the next button.