### PR TITLE
JitArm64_Integer: cmp/cmpl optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -728,9 +728,13 @@ void JitArm64::cmpl(UGeckoInstruction inst)
   {
     NEG(CR, EncodeRegTo64(gpr.R(b)));
   }
-  else if (gpr.IsImm(b) && !gpr.GetImm(b))
+  else if (gpr.IsImm(b) && (gpr.GetImm(b) & 0xFFF) == gpr.GetImm(b))
   {
-    MOV(EncodeRegTo32(CR), gpr.R(a));
+    const u32 imm = gpr.GetImm(b);
+    if (imm == 0)
+      MOV(EncodeRegTo32(CR), gpr.R(a));
+    else
+      SUB(CR, EncodeRegTo64(gpr.R(a)), imm);
   }
   else
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -658,6 +658,11 @@ void JitArm64::cmp(UGeckoInstruction inst)
     if (const u32 imm = gpr.GetImm(b); imm != 0)
       SUB(CR, CR, imm);
   }
+  else if (gpr.IsImm(b) && (gpr.GetImm(b) & 0xFFF000) == gpr.GetImm(b))
+  {
+    SXTW(CR, gpr.R(a));
+    SUB(CR, CR, gpr.GetImm(b) >> 12, true);
+  }
   else
   {
     ARM64Reg RA = gpr.R(a);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -736,6 +736,10 @@ void JitArm64::cmpl(UGeckoInstruction inst)
     else
       SUB(CR, EncodeRegTo64(gpr.R(a)), imm);
   }
+  else if (gpr.IsImm(b) && (gpr.GetImm(b) & 0xFFF000) == gpr.GetImm(b))
+  {
+    SUB(CR, EncodeRegTo64(gpr.R(a)), gpr.GetImm(b) >> 12, true);
+  }
   else
   {
     SUB(CR, EncodeRegTo64(gpr.R(a)), EncodeRegTo64(gpr.R(b)));

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -668,6 +668,11 @@ void JitArm64::cmp(UGeckoInstruction inst)
     SXTW(CR, gpr.R(a));
     ADD(CR, CR, ~gpr.GetImm(b) + 1);
   }
+  else if (gpr.IsImm(b) && (((~gpr.GetImm(b) + 1) & 0xFFF000) == (~gpr.GetImm(b) + 1)))
+  {
+    SXTW(CR, gpr.R(a));
+    ADD(CR, CR, (~gpr.GetImm(b) + 1) >> 12, true);
+  }
   else
   {
     ARM64Reg RA = gpr.R(a);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -652,9 +652,11 @@ void JitArm64::cmp(UGeckoInstruction inst)
     SXTW(CR, gpr.R(b));
     MVN(CR, CR);
   }
-  else if (gpr.IsImm(b) && !gpr.GetImm(b))
+  else if (gpr.IsImm(b) && (gpr.GetImm(b) & 0xFFF) == gpr.GetImm(b))
   {
     SXTW(CR, gpr.R(a));
+    if (const u32 imm = gpr.GetImm(b); imm != 0)
+      SUB(CR, CR, imm);
   }
   else
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -663,6 +663,11 @@ void JitArm64::cmp(UGeckoInstruction inst)
     SXTW(CR, gpr.R(a));
     SUB(CR, CR, gpr.GetImm(b) >> 12, true);
   }
+  else if (gpr.IsImm(b) && (((~gpr.GetImm(b) + 1) & 0xFFF) == (~gpr.GetImm(b) + 1)))
+  {
+    SXTW(CR, gpr.R(a));
+    ADD(CR, CR, ~gpr.GetImm(b) + 1);
+  }
   else
   {
     ARM64Reg RA = gpr.R(a);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -345,7 +345,7 @@ public:
   // Gets the immediate that a register is set to. Only valid for guest GPRs.
   u32 GetImm(size_t preg) const { return GetGuestGPROpArg(preg).GetImm(); }
 
-  bool IsImm(size_t preg, u32 imm) { return IsImm(preg) && GetImm(preg) == imm; }
+  bool IsImm(size_t preg, u32 imm) const { return IsImm(preg) && GetImm(preg) == imm; }
 
   // Binds a guest GPR to a host register, optionally loading its value.
   //


### PR DESCRIPTION
The main optimizations here take advantage of ARM64's `ADD`/`SUB` instructions which can encode a (shifted) 12-bit immediate value, allowing us to skip materializing the immediate in a register. This either means we save an instruction, we end up with an equal amount of instructions if it needs to be materialized for a subsequence use. I didn't implement the (shifted) 12-bit additions for `cmpl`, as I was unable to find games where this occurred.

The second optimization consists of skipping the sign extension step in `cmp` if possible.

Finally, I fixed a const correctness issue I accidentally introduced in #13120.

---
<details><summary>cmp - Subtract 12-bit constant</summary>

Before:
```
0x52800416   mov    w22, #0x20                ; =32
0x93407f78   sxtw   x24, w27
0xcb36c318   sub    x24, x24, w22, sxtw
```
After:
```
0x93407f78   sxtw   x24, w27
0xd1008318   sub    x24, x24, #0x20
```
</details>
<details><summary>cmp - Subtract shifted 12-bit constant</summary>

Before:
```
0x52a00099   mov    w25, #0x40000             ; =262144
0x93407f7a   sxtw   x26, w27
0xcb39c35a   sub    x26, x26, w25, sxtw
```
After:
```
0x93407f7a   sxtw   x26, w27
0xd141035a   sub    x26, x26, #0x40, lsl #12  ; =0x40000
```
</details>
<details><summary>cmp - Add 12-bit constant</summary>

Before:
```
0x12800019   mov    w25, #-0x1                ; =-1
0x93407f5b   sxtw   x27, w26
0xcb39c37b   sub    x27, x27, w25, sxtw
```
After:
```
0x93407f5b   sxtw   x27, w26
0x9100077b   add    x27, x27, #0x1
```
</details>
<details><summary>cmp - Add shifted 12-bit constant</summary>

Before:
```
0x52bff01a   mov    w26, #-0x800000           ; =-8388608
0x93407f1b   sxtw   x27, w24
0xcb3ac37b   sub    x27, x27, w26, sxtw
```
After:
```
0x93407f1b   sxtw   x27, w24
0x9160037b   add    x27, x27, #0x800, lsl #12 ; =0x800000
```
</details>
<details><summary>cmp - Skip sign extension for a</summary>

Before:
```
0x5280003a   mov    w26, #0x1                 ; =1
0x93407f5b   sxtw   x27, w26
0xcb38c37b   sub    x27, x27, w24, sxtw
```
After:
```
0x5280003a   mov    w26, #0x1                 ; =1
0xcb38c35b   sub    x27, x26, w24, sxtw
```
</details>
<details><summary>cmp - Skip sign extension for b</summary>

Before:
```
0x52a20018   mov    w24, #0x10000000          ; =268435456
0x93407f79   sxtw   x25, w27
0xcb38c339   sub    x25, x25, w24, sxtw
```
After:
```
0x52a20018   mov    w24, #0x10000000          ; =268435456
0x93407f79   sxtw   x25, w27
0xcb180339   sub    x25, x25, x24
```
</details>
<details><summary>cmpl - Subtract 12-bit constant</summary>

Before:
```
0x5280003a   mov    w26, #0x1                 ; =1
0xcb1a033b   sub    x27, x25, x26
```
After:
```
0xd100073b   sub    x27, x25, #0x1
```
</details>
<details><summary>cmpl - Subtract shifted 12-bit constant</summary>

Before:
```
0x52a00218   mov    w24, #0x100000            ; =1048576
0xcb180379   sub    x25, x27, x24
```
After:
```
0xd1440379   sub    x25, x27, #0x100, lsl #12 ; =0x100000
```
</details>