### PR TITLE
Data: update Rune Factory Frontier with community gecko codes

### DIFF
--- a/Data/Sys/GameSettings/RUFEMV.ini
+++ b/Data/Sys/GameSettings/RUFEMV.ini
@@ -1,0 +1,73 @@
+# RUFEMV - Rune Factory: Frontier
+[Gecko]
+$All areas max runeys (60-60-60-60) [DendeX3]
+04492B9C 3C3C3C3C
+04492BA0 3C3C3C3C
+04492BA4 3C3C3C3C
+04492BA8 3C3C3C3C
+04492BAC 3C3C3C3C
+04492BB0 3C3C3C3C
+04492BB4 3C3C3C3C
+04492BB8 3C3C3C3C
+04492BBC 3C3C3C3C
+* https://forums.dolphin-emu.org/Thread-rune-factory-frontier-pal-ntsc-runeys-ar-codes
+*
+* The 1st digits sequence points areas :
+* 04492B9C - Homestead
+* 04492BA0 - Beach Road
+* 04492BA4 - Business District
+* 04492BA8 - South District
+* 04492BAC - Public Square
+* 04492BB0 - Church
+* 04492BB4 - Mountain Road
+* 04492BB8 - Lake Poli
+* 04492BBC - Beach
+* The second sequence points the number of runey of each type in the area (2 digits per runey type, in this order : water, rock, tree, grass. In hexa decimal : 3C = 60).
+* When an area is modified, its runey amount will be locked as long as the code remains activated  (e.g. you can infinitely harvest/release runeys in a modified area, runey amount in this area won't change).
+$Balanced Runeys [DendeX3]
+04492BA0 00000001
+04492BA4 00010000
+04492BA8 00000001
+04492BAC 00010000
+04492BB0 00000100
+04492BB4 00000100
+04492BB8 01000000
+04492BBC 01000000
+* https://forums.dolphin-emu.org/Thread-rune-factory-frontier-pal-ntsc-runeys-ar-codes
+*
+* Homestead area is not modified, it will work like vanilla : no food chain, homestead runeys will be produced by your crops. Homestead's runeys will decrease if you collect them. If homestead is in prosperity (35-35-35-35), you will gain a 1 day bonus of growth speed (fodder will regrow in 1 day instead of 2).
+* Other areas will only have 1 runey at all times (even if you catch or release some in these areas).
+* The purpose is to ignore the runey system as possible, but not to get penalties/bonus of other areas in return. Runeys are hardly collectible infinitely either in other aeras (locked to 1 runey).
+$Half Runeys Management [DendeX3]
+04492BA8 00000001
+04492BAC 00010000
+04492BB4 00000100
+04492BB8 01000000
+* https://forums.dolphin-emu.org/Thread-rune-factory-frontier-pal-ntsc-runeys-ar-codes
+*
+* South district, Public Square, Mountain Road and Lake Poli are locked to 1 runey.
+* Homestead, Beach Road (grass bonus), Business District (rock bonus), Church (tree bonus) and Beach (water bonus) are untouched/working vanilla.
+* Half management, half growth speed bonus/penalties. 
+$Japanese exclusive items [Woenix]
+04499240 028D0101
+04499244 02910101
+04499248 02930101
+0449924C 029D0101
+04499250 02A20101
+04499254 02A30101
+04499258 02AA0101
+0449925C 02B60101
+04499260 02B70101
+04499264 02BE0101
+04499268 02D20101
+0449926C 02D30101
+04499270 02D40101
+04499274 02D50101
+04499278 02D60101
+0449927C 02D70101
+04499284 00360101
+* https://www.reddit.com/r/runefactory/comments/14rpd5l/til_there_were_a_handful_of_items_in_frontier/
+*
+* Items normally exclusive to the Japanese version of the game!
+* 
+* Just make sure the first 17 slots in your inventory are empty beforehand. Some items are glitchy so use at your own risk!

--- a/Data/Sys/GameSettings/RUFP99.ini
+++ b/Data/Sys/GameSettings/RUFP99.ini
@@ -1,0 +1,45 @@
+# RUFP99 - Rune Factory: Frontier
+[Gecko]
+$All areas max runeys (60-60-60-60) [DendeX3]
+04452D9C 3C3C3C3C
+04452DA0 3C3C3C3C
+04452DA4 3C3C3C3C
+04452DA8 3C3C3C3C
+04452DAC 3C3C3C3C
+04452DB0 3C3C3C3C
+04452DB4 3C3C3C3C
+04452DB8 3C3C3C3C
+04452DBC 3C3C3C3C 
+* https://forums.dolphin-emu.org/Thread-rune-factory-frontier-pal-ntsc-runeys-ar-codes
+*
+* The 1st digits sequence points areas :
+* 04452D9C - Homestead
+* 04452DA0 - Beach Road
+* 04452DA4 - Business District
+* 04452DA8 - South District
+* 04452DAC - Public Square
+* 04452DB0 - Church
+* 04452DB4 - Mountain Road
+* 04452DB8 - Lake Poli
+* 04452DBC - Beach
+* The second sequence points the number of runey of each type in the area (2 digits per runey type, in this order : water, rock, tree, grass. In hexa decimal : 3C = 60).
+* When an area is modified, its runey amount will be locked as long as the code remains activated  (e.g. you can infinitely harvest/release runeys in a modified area, runey amount in this area won't change).
+$Balanced Runeys [DendeX3]
+04452DA0 00000001
+04452DA4 00010000
+04452DA8 00000001
+04452DAC 00010000
+04452DB0 00000100
+04452DB4 00000100
+04452DB8 01000000
+04452DBC 01000000
+* https://forums.dolphin-emu.org/Thread-rune-factory-frontier-pal-ntsc-runeys-ar-codes
+*
+* Homestead area is not modified, it will work like vanilla : no food chain, homestead runeys will be produced by your crops. Homestead's runeys will decrease if you collect them. If homestead is in prosperity (35-35-35-35), you will gain a 1 day bonus of growth speed (fodder will regrow in 1 day instead of 2).
+* Other areas will only have 1 runey at all times (even if you catch or release some in these areas).
+* The purpose is to ignore the runey system as possible, but not to get penalties/bonus of other areas in return. Runeys are hardly collectible infinitely either in other aeras (locked to 1 runey).
+$Half Runeys Management [DendeX3]
+04452DA8 00000001
+04452DAC 00010000
+04452DB4 00000100
+04452DB8 01000000


### PR DESCRIPTION
Game communities have attempted to add gecko codes to the wiki for their specific game. These codes don't necessarily fall into the agreed 16:9 or FPS enhancement codes and are removed if noticed. The game communities still want these codes to be accessible to new players and some codes are hidden away on the internet (or worse, locked away in a discord).

The runey codes are regularly suggested as the only way to play the game.  I also added a code [from the community](https://www.reddit.com/r/runefactory/comments/14rpd5l/til_there_were_a_handful_of_items_in_frontier/) that was for some Japanese only items.

I have verified all the ntsc runey codes personally.