### PR TITLE
Eliminate TaskViewModel's `mustRestartApp` field

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/UserDataActivity.kt
@@ -31,6 +31,7 @@ import java.io.IOException
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
+import kotlin.system.exitProcess
 
 class UserDataActivity : AppCompatActivity() {
     private lateinit var taskViewModel: TaskViewModel
@@ -180,7 +181,10 @@ class UserDataActivity : AppCompatActivity() {
             if (!isDolphinUserDataBackup(source))
                 return R.string.user_data_import_invalid_file
 
-            taskViewModel.mustRestartApp = true
+            taskViewModel.onResultDismiss = {
+                // Restart the app to apply the imported user data.
+                exitProcess(0)
+            }
 
             contentResolver.openInputStream(source).use { `is` ->
                 ZipInputStream(`is`).use { zis ->

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/UserDataImportWarningDialog.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/UserDataImportWarningDialog.kt
@@ -12,7 +12,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.dolphinemu.dolphinemu.R
 import org.dolphinemu.dolphinemu.activities.UserDataActivity
 import org.dolphinemu.dolphinemu.model.TaskViewModel
-import kotlin.system.exitProcess
 
 class UserDataImportWarningDialog : DialogFragment() {
     private lateinit var taskViewModel: TaskViewModel
@@ -35,12 +34,6 @@ class UserDataImportWarningDialog : DialogFragment() {
                     (requireActivity() as UserDataActivity).importUserData(
                         requireArguments().getString(KEY_URI_RESULT)!!.toUri()
                     )
-                }
-
-                taskViewModel.onResultDismiss = {
-                    if (taskViewModel.mustRestartApp) {
-                        exitProcess(0)
-                    }
                 }
 
                 val taskDialog = TaskDialog()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/TaskViewModel.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/TaskViewModel.kt
@@ -38,7 +38,6 @@ class TaskViewModel : ViewModel() {
     }
 
     var cancelled = false
-    var mustRestartApp = false
 
     private val state = MutableLiveData<State>(NotStartedState())
 
@@ -57,7 +56,6 @@ class TaskViewModel : ViewModel() {
     fun clear() {
         state.value = NotStartedState()
         cancelled = false
-        mustRestartApp = false
         onResultDismiss = null
     }
 


### PR DESCRIPTION
Instead of having UserDataImportWarningDialog set an `onResultDismiss` callback that examines `mustRestartApp`, and having UserDataActivity set `mustRestartApp`, just have UserDataActivity set the callback directly.

This approach is no more data-race-y than the previous approach, and it simplifies the code. (The behavior of restarting the app when the task finishes is specific to the user data import flow, and there is no reason for TaskViewModel to be directly aware of it.)

I tested this PR by running the app in an Android emulator and importing user data, and verifying that the app restarts the same way it did before.