### PR TITLE
Core: Check if msr.DR and msr.IR are valid at ApplyStartupPatches

### DIFF
--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -293,6 +293,17 @@ static void ApplyStartupPatches(Core::System& system)
 {
   ASSERT(Core::IsCPUThread());
   Core::CPUThreadGuard guard(system);
+
+  const auto& ppc_state = system.GetPPCState();
+  if (!ppc_state.msr.DR || !ppc_state.msr.IR)
+  {
+    DEBUG_LOG_FMT(ACTIONREPLAY,
+                  "Need to retry later. CPU configuration is currently incorrect. PC = {:#010x}, "
+                  "MSR = {:#010x}",
+                  ppc_state.pc, ppc_state.msr.Hex);
+    return;
+  }
+
   ApplyPatches(guard, s_on_frame);
 }
 


### PR DESCRIPTION
Checks if msr.DR and msr.IR are valid when patch engine calls ApplyStartupPatches. Solves the issue [here](https://bugs.dolphin-emu.org/issues/13674).

From the conversation with @AdmiralCurtiss at #13312.