### PR TITLE
PerformanceMetrics: Allow users to move overlays

### DIFF
--- a/Source/Core/VideoCommon/PerformanceMetrics.cpp
+++ b/Source/Core/VideoCommon/PerformanceMetrics.cpp
@@ -83,8 +83,7 @@ double PerformanceMetrics::GetLastSpeedDenominator() const
 void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
 {
   const float bg_alpha = 0.7f;
-  const auto imgui_flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
-                           ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings |
+  const auto imgui_flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings |
                            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |
                            ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing;
 
@@ -119,7 +118,7 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 4.f * backbuffer_scale));
 
     // Position in the top-right corner of the screen.
-    ImGui::SetNextWindowPos(ImVec2(window_x, window_y), ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+    ImGui::SetNextWindowPos(ImVec2(window_x, window_y), ImGuiCond_FirstUseEver, ImVec2(1.0f, 0.0f));
     ImGui::SetNextWindowSize(ImVec2(graph_width, graph_height));
     ImGui::SetNextWindowBgAlpha(bg_alpha);
     window_y += graph_height + window_padding;
@@ -161,7 +160,8 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
           DT_ms(std::max(m_fps_counter.GetSampleWindow(), m_vps_counter.GetSampleWindow())).count();
 
       if (ImPlot::BeginPlot("PerformanceGraphs", ImVec2(-1.0, -1.0),
-                            ImPlotFlags_NoFrame | ImPlotFlags_NoTitle | ImPlotFlags_NoMenus))
+                            ImPlotFlags_NoFrame | ImPlotFlags_NoTitle | ImPlotFlags_NoMenus |
+                                ImPlotFlags_NoInputs))
       {
         ImPlot::PushStyleColor(ImPlotCol_PlotBg, {0, 0, 0, 0});
         ImPlot::PushStyleColor(ImPlotCol_LegendBg, {0, 0, 0, 0.2f});
@@ -192,7 +192,7 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
     // Position in the top-right corner of the screen.
     float window_height = 47.f * backbuffer_scale;
 
-    ImGui::SetNextWindowPos(ImVec2(window_x, window_y), ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+    ImGui::SetNextWindowPos(ImVec2(window_x, window_y), ImGuiCond_FirstUseEver, ImVec2(1.0f, 0.0f));
     ImGui::SetNextWindowSize(ImVec2(window_width, window_height));
     ImGui::SetNextWindowBgAlpha(bg_alpha);
 
@@ -215,7 +215,7 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
     float window_height = (12.f + 17.f * count) * backbuffer_scale;
 
     // Position in the top-right corner of the screen.
-    ImGui::SetNextWindowPos(ImVec2(window_x, window_y), ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+    ImGui::SetNextWindowPos(ImVec2(window_x, window_y), ImGuiCond_FirstUseEver, ImVec2(1.0f, 0.0f));
     ImGui::SetNextWindowSize(ImVec2(window_width, window_height));
     ImGui::SetNextWindowBgAlpha(bg_alpha);
 
@@ -245,7 +245,7 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
     float window_height = (12.f + 17.f * count) * backbuffer_scale;
 
     // Position in the top-right corner of the screen.
-    ImGui::SetNextWindowPos(ImVec2(window_x, window_y), ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+    ImGui::SetNextWindowPos(ImVec2(window_x, window_y), ImGuiCond_FirstUseEver, ImVec2(1.0f, 0.0f));
     ImGui::SetNextWindowSize(ImVec2(window_width, (12.f + 17.f * count) * backbuffer_scale));
     ImGui::SetNextWindowBgAlpha(bg_alpha);
 


### PR DESCRIPTION
Allow users to move the FPS, VPS, Speed, and Performance Graph overlays.

![moved_overlays](https://github.com/user-attachments/assets/b2834429-ea12-4051-931e-975839d602d4)
