### PR TITLE
DolphinQt: Rename the pack/unpack SD Card buttons.

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -105,10 +105,10 @@
     <string name="wii_sd_card_sync_description">Synchronizes the SD Card with the SD Sync Folder when starting and ending emulation.</string>
     <string name="wii_sd_card_path">SD Card Path</string>
     <string name="wii_sd_sync_folder">SD Sync Folder</string>
-    <string name="wii_sd_card_folder_to_file">Convert Folder to File Now</string>
-    <string name="wii_sd_card_folder_to_file_confirmation">You are about to convert the content of the SD sync folder into the SD card file. All current content of the file will be deleted. Are you sure you want to continue?</string>
-    <string name="wii_sd_card_file_to_folder">Convert File to Folder Now</string>
-    <string name="wii_sd_card_file_to_folder_confirmation">You are about to convert the content of the SD card file into the SD sync folder. All current content of the folder will be deleted. Are you sure you want to continue?</string>
+    <string name="wii_sd_card_folder_to_file">Pack SD Card Now</string>
+    <string name="wii_sd_card_folder_to_file_confirmation">You are about to pack the content of the SD sync folder into the SD card file. All current content of the file will be deleted. Are you sure you want to continue?</string>
+    <string name="wii_sd_card_file_to_folder">Unpack SD Card Now</string>
+    <string name="wii_sd_card_file_to_folder_confirmation">You are about to unpack the content of the SD card file into the SD sync folder. All current content of the folder will be deleted. Are you sure you want to continue?</string>
     <string name="wii_converting">Converting…</string>
     <string name="wii_convert_success">Conversion done.</string>
     <string name="wii_convert_failure">Conversion failed.</string>

--- a/Source/Core/Common/FatFsUtil.h
+++ b/Source/Core/Common/FatFsUtil.h
@@ -9,6 +9,9 @@
 
 namespace Common
 {
+static constexpr auto SD_PACK_TEXT = "Pack SD Card Now";
+static constexpr auto SD_UNPACK_TEXT = "Unpack SD Card Now";
+
 bool SyncSDFolderToSDImage(const std::function<bool()>& cancelled, bool deterministic);
 bool SyncSDImageToSDFolder(const std::function<bool()>& cancelled);
 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -537,7 +537,8 @@ static void EmuThread(Core::System& system, std::unique_ptr<BootParameters> boot
         PanicAlertFmtT(
             "Failed to sync SD card with folder. All changes made this session will be "
             "discarded on next boot if you do not manually re-issue a resync in Config > "
-            "Wii > SD Card Settings > Convert File to Folder Now!");
+            "Wii > SD Card Settings > {0}!",
+            Common::GetStringT(Common::SD_UNPACK_TEXT));
       }
     }
   }};

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -265,12 +265,12 @@ void WiiPane::CreateSDCard()
   sd_settings_group_layout->addWidget(m_sd_card_size_combo, row, 1);
   ++row;
 
-  m_sd_pack_button = new NonDefaultQPushButton(tr("Convert Folder to File Now"));
-  m_sd_unpack_button = new NonDefaultQPushButton(tr("Convert File to Folder Now"));
+  m_sd_pack_button = new NonDefaultQPushButton(tr(Common::SD_PACK_TEXT));
+  m_sd_unpack_button = new NonDefaultQPushButton(tr(Common::SD_UNPACK_TEXT));
   connect(m_sd_pack_button, &QPushButton::clicked, [this] {
     auto result = ModalMessageBox::warning(
-        this, tr("Convert Folder to File Now"),
-        tr("You are about to convert the content of the folder at %1 into the file at %2. All "
+        this, tr(Common::SD_PACK_TEXT),
+        tr("You are about to pack the content of the folder at %1 into the file at %2. All "
            "current content of the file will be deleted. Are you sure you want to continue?")
             .arg(QString::fromStdString(File::GetUserPath(D_WIISDCARDSYNCFOLDER_IDX)))
             .arg(QString::fromStdString(File::GetUserPath(F_WIISDCARDIMAGE_IDX))),
@@ -289,13 +289,13 @@ void WiiPane::CreateSDCard()
       SetQWidgetWindowDecorations(progress_dialog.GetRaw());
       progress_dialog.GetRaw()->exec();
       if (!success.get())
-        ModalMessageBox::warning(this, tr("Convert Folder to File Now"), tr("Conversion failed."));
+        ModalMessageBox::warning(this, tr(Common::SD_PACK_TEXT), tr("Conversion failed."));
     }
   });
   connect(m_sd_unpack_button, &QPushButton::clicked, [this] {
     auto result = ModalMessageBox::warning(
-        this, tr("Convert File to Folder Now"),
-        tr("You are about to convert the content of the file at %2 into the folder at %1. All "
+        this, tr(Common::SD_UNPACK_TEXT),
+        tr("You are about to unpack the content of the file at %2 into the folder at %1. All "
            "current content of the folder will be deleted. Are you sure you want to continue?")
             .arg(QString::fromStdString(File::GetUserPath(D_WIISDCARDSYNCFOLDER_IDX)))
             .arg(QString::fromStdString(File::GetUserPath(F_WIISDCARDIMAGE_IDX))),
@@ -314,7 +314,7 @@ void WiiPane::CreateSDCard()
       SetQWidgetWindowDecorations(progress_dialog.GetRaw());
       progress_dialog.GetRaw()->exec();
       if (!success.get())
-        ModalMessageBox::warning(this, tr("Convert File to Folder Now"), tr("Conversion failed."));
+        ModalMessageBox::warning(this, tr(Common::SD_UNPACK_TEXT), tr("Conversion failed."));
     }
   });
   sd_settings_group_layout->addWidget(m_sd_pack_button, row, 0, 1, 1);


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/0ff40be5-59bb-4fc7-8fe3-2d5dc42c1f66)

After:
![image](https://github.com/user-attachments/assets/847ed463-ade1-4a04-a827-4ec97bd3deaf)

I think the old names were too similar and clicking the wrong one could be unfortunate.
A user on discord just clicked the wrong one.

Files are on both ends of the conversion so it might not be immediately obvious that "File" is the raw SD Card file.
"Pack" and "Unpack" make it more clear what is going on.