### PR TITLE
DolphinQt/Mapping: Adjust dark theme indicator gate color calculation.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -125,7 +125,7 @@ QColor MappingIndicator::GetAltTextColor() const
 void MappingIndicator::AdjustGateColor(QColor* color)
 {
   if (Settings::Instance().IsThemeDark())
-    color->setHsvF(color->hueF(), color->saturationF(), 1 - color->valueF());
+    color->setHsvF(color->hueF(), std::min(color->saturationF(), 0.5f), color->valueF() * 0.35f);
 }
 
 ButtonIndicator::ButtonIndicator(ControlReference* control_ref) : m_control_ref{control_ref}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/33bc0dfa-a463-45ef-8521-07ad5215eae5)
![image](https://github.com/user-attachments/assets/dfa15011-d19b-4880-9b0a-565c31ee5c5b)

After:
![image](https://github.com/user-attachments/assets/ecef8ead-b669-49dc-b839-f30764b8ad9a)
![image](https://github.com/user-attachments/assets/062957ec-51d7-410a-8cd3-b00ea8670890)

Light themes are unaffected.