### PR TITLE
Fix depth texture being incorrectly affected by swap table

### DIFF
--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -467,6 +467,11 @@ void Tev::Draw()
         std::memset(texel, 0, 4);
       }
 
+      RawTexColor.r = texel[u32(ColorChannel::Red)];
+      RawTexColor.g = texel[u32(ColorChannel::Green)];
+      RawTexColor.b = texel[u32(ColorChannel::Blue)];
+      RawTexColor.a = texel[u32(ColorChannel::Alpha)];
+
       const auto& swap = bpmem.tevksel.GetSwapTable(ac.tswap);
       TexColor.r = texel[u32(swap[ColorChannel::Red])];
       TexColor.g = texel[u32(swap[ColorChannel::Green])];
@@ -551,13 +556,13 @@ void Tev::Draw()
     switch (bpmem.ztex2.type)
     {
     case ZTexFormat::U8:
-      ztex += TexColor[ALP_C];
+      ztex += RawTexColor[ALP_C];
       break;
     case ZTexFormat::U16:
-      ztex += TexColor[ALP_C] << 8 | TexColor[RED_C];
+      ztex += RawTexColor[ALP_C] << 8 | RawTexColor[RED_C];
       break;
     case ZTexFormat::U24:
-      ztex += TexColor[RED_C] << 16 | TexColor[GRN_C] << 8 | TexColor[BLU_C];
+      ztex += RawTexColor[RED_C] << 16 | RawTexColor[GRN_C] << 8 | RawTexColor[BLU_C];
       break;
     default:
       PanicAlertFmt("Invalid ztex format {}", bpmem.ztex2.type);

--- a/Source/Core/VideoBackends/Software/Tev.h
+++ b/Source/Core/VideoBackends/Software/Tev.h
@@ -107,6 +107,7 @@ class Tev
   // color order: ABGR
   Common::EnumMap<TevColor, TevOutput::Color2> Reg;
   std::array<TevColor, 4> KonstantColors;
+  TevColor RawTexColor;
   TevColor TexColor;
   TevColor RasColor;
   TevColor StageKonst;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1104,8 +1104,8 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
   out.Write("\tint4 c0 = " I_COLORS "[1], c1 = " I_COLORS "[2], c2 = " I_COLORS
             "[3], prev = " I_COLORS "[0];\n"
-            "\tint4 rastemp = int4(0, 0, 0, 0), textemp = int4(0, 0, 0, 0), konsttemp = int4(0, 0, "
-            "0, 0);\n"
+            "\tint4 rastemp = int4(0, 0, 0, 0), rawtextemp = int4(0, 0, 0, 0), "
+            "textemp = int4(0, 0, 0, 0), konsttemp = int4(0, 0, 0, 0);\n"
             "\tint3 comp16 = int3(1, 256, 0), comp24 = int3(1, 256, 256*256);\n"
             "\tint alphabump=0;\n"
             "\tint3 tevcoord=int3(0, 0, 0);\n"
@@ -1291,7 +1291,7 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
     // use the texture input of the last texture stage (textemp), hopefully this has been read and
     // is in correct format...
     out.SetConstantsUsed(C_ZBIAS, C_ZBIAS + 1);
-    out.Write("\tzCoord = idot(" I_ZBIAS "[0].xyzw, textemp.xyzw) + " I_ZBIAS "[1].w {};\n",
+    out.Write("\tzCoord = idot(" I_ZBIAS "[0].xyzw, rawtextemp.xyzw) + " I_ZBIAS "[1].w {};\n",
               (uid_data->ztex_op == ZTexOp::Add) ? "+ zCoord" : "");
     out.Write("\tzCoord = zCoord & 0xFFFFFF;\n");
   }
@@ -1614,8 +1614,9 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   if (stage.tevorders_enable && uid_data->genMode_numtexgens > 0)
   {
     // Generate swizzle string to represent the texture color channel swapping
-    out.Write("\ttextemp = sampleTextureWrapper({}u, tevcoord.xy, layer).{}{}{}{};\n",
-              stage.tevorders_texmap, rgba_swizzle[stage.tex_swap_r],
+    out.Write("\trawtextemp = sampleTextureWrapper({}u, tevcoord.xy, layer);\n",
+              stage.tevorders_texmap);
+    out.Write("\ttextemp = rawtextemp.{}{}{}{};\n", rgba_swizzle[stage.tex_swap_r],
               rgba_swizzle[stage.tex_swap_g], rgba_swizzle[stage.tex_swap_b],
               rgba_swizzle[stage.tex_swap_a]);
   }

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -724,6 +724,7 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
 
   out.Write("struct State {{\n"
             "  int4 Reg[4];\n"
+            "  int4 RawTexColor;\n"
             "  int4 TexColor;\n"
             "  int AlphaBump;\n"
             "}};\n"
@@ -1090,10 +1091,10 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
               "      uint sampler_num = {};\n",
               BitfieldExtract<&TwoTevStageOrders::texmap_even>("ss.order"));
     out.Write("\n"
-              "      int4 color = sampleTextureWrapper(sampler_num, tevcoord.xy, layer);\n"
+              "      s.RawTexColor = sampleTextureWrapper(sampler_num, tevcoord.xy, layer);\n"
               "      uint swap = {};\n",
               BitfieldExtract<&TevStageCombiner::AlphaCombiner::tswap>("ss.ac"));
-    out.Write("      s.TexColor = Swizzle(swap, color);\n");
+    out.Write("      s.TexColor = Swizzle(swap, s.RawTexColor);\n");
     out.Write("    }} else {{\n"
               "      // Texture is disabled\n"
               "      s.TexColor = int4(255, 255, 255, 255);\n"
@@ -1371,7 +1372,7 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
             "    int ztex = int(" I_ZBIAS "[1].w); // fixed bias\n"
             "\n"
             "    // Whatever texture was in our last stage, it's now our depth texture\n"
-            "    ztex += idot(s.TexColor.xyzw, " I_ZBIAS "[0].xyzw);\n"
+            "    ztex += idot(s.RawTexColor.xyzw, " I_ZBIAS "[0].xyzw);\n"
             "    ztex += (bpmem_ztex_op == 1u) ? zCoord : 0;\n"
             "    zCoord = ztex & 0xFFFFFF;\n"
             "  }}\n"


### PR DESCRIPTION
This fixes [issue 13734](https://bugs.dolphin-emu.org/issues/13734): "Z-textures are incorrectly affected by swaptable". This was reported by @fadedled, who presumably noticed this while working on [Seta GX](https://github.com/fadedled/seta-gx).

I've not hardware-tested this myself beyond running the repro case using the [hardware fifoplayer](https://github.com/dolphin-emu/fifoplayer).