### PR TITLE
VideoCommon: Use XXH3 Instead of XXH64

### DIFF
--- a/Source/Core/VideoCommon/TextureInfo.cpp
+++ b/Source/Core/VideoCommon/TextureInfo.cpp
@@ -180,8 +180,8 @@ TextureInfo::NameDetails TextureInfo::CalculateTextureName() const
 
   DEBUG_ASSERT(tlut_size <= m_palette_size.value_or(0));
 
-  const u64 tex_hash = XXH64(m_ptr, m_texture_size, 0);
-  const u64 tlut_hash = tlut_size ? XXH64(tlut, tlut_size, 0) : 0;
+  const u64 tex_hash = XXH3_64bits(m_ptr, m_texture_size);
+  const u64 tlut_hash = tlut_size ? XXH3_64bits(tlut, tlut_size) : 0;
 
   NameDetails result;
   result.base_name = fmt::format("{}{}x{}{}", format_prefix, m_raw_width, m_raw_height,


### PR DESCRIPTION
As we can see in the xxHash benchmark, **XXH3** is definitely faster than **XXH64**.
The performance gain will probably be more visible on less powerful machines.

See the [**xxHash Benchmark**](https://github.com/Cyan4973/xxHash?tab=readme-ov-file#benchmarks).