### PR TITLE
VideoCommon: ensure cached textures are recorded into FIFO logs

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1243,7 +1243,7 @@ private:
 
 TCacheEntry* TextureCacheBase::Load(const TextureInfo& texture_info)
 {
-  if (auto entry = LoadImpl(texture_info, false))
+  if (auto entry = LoadImpl(texture_info, OpcodeDecoder::g_record_fifo_data))
   {
     if (!DidLinkedAssetsChange(*entry))
     {


### PR DESCRIPTION
Not sure this is a good fix. According to the big comment in LoadImpl(), this could break FIFO logs of Spyro: A Hero's Tail.