### PR TITLE
GameSettings: Set ImmediateXFBEnable = False for Medal of Honor: Frontline

### DIFF
--- a/Data/Sys/GameSettings/GMF.ini
+++ b/Data/Sys/GameSettings/GMF.ini
@@ -1,0 +1,5 @@
+# GMFE69, GMFS69, GMFD69, GMFF69, GMFI69, GMFP69 - Medal of Honor: Frontline
+
+[Video_Hacks]
+# Fixes flashing screen in case it is enabled globally.
+ImmediateXFBEnable = False


### PR DESCRIPTION
Fixes flashing screen in case its enabled globally.