### PR TITLE
Fix LULZ (Homebrew Channel) being forced to 4:3

### DIFF
--- a/Data/Sys/GameSettings/LULZHB.ini
+++ b/Data/Sys/GameSettings/LULZHB.ini
@@ -1,0 +1,4 @@
+# LULZHB - Homebrew Channel
+
+[Video_Settings]
+SuggestedAspectRatio =


### PR DESCRIPTION
LULZ is forced to 4:3 because of the default for L being Sega Master System Virtual Console games. This commit fixes that.