### PR TITLE
Added widescreen code for Tomb Raider: Legend GL8.ini

### DIFF
--- a/Data/Sys/GameSettings/GL8.ini
+++ b/Data/Sys/GameSettings/GL8.ini
@@ -12,3 +12,8 @@
 [Video_Hacks]
 EFBToTextureEnable = False
 DeferEFBCopies = False
+
+[Gecko]
+$Widescreen 16:9 (Region Free)
+04007B7C 38600001
+*Renders the game in Widescreen 16:9


### PR DESCRIPTION
… Legend

As the PS2 version is the only one with proper 16:9 widescreen, this cheat has been tested on the NTSC version, but is labeled as region free, to bring 16:9 widescreen.

BEFORE
![GL8E4F_2025-02-20_11-47-35](https://github.com/user-attachments/assets/c5c2c68f-da31-4a8b-aff4-8602b0447d9d)
![GL8E4F_2025-02-20_11-47-59](https://github.com/user-attachments/assets/2116fc65-3fd9-44cd-a5c3-1762df98c83f)

AFTER
![GL8E4F_2025-02-20_11-34-16](https://github.com/user-attachments/assets/4d7162c6-3708-47a1-b382-36c5d12447ed)
![GL8E4F_2025-02-20_11-34-44](https://github.com/user-attachments/assets/05a153ca-a3c1-40d7-81e3-f96e092af693)
