### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/Externals/miniupnpc/src/upnpreplyparse.c
+++ b/Externals/miniupnpc/src/upnpreplyparse.c
@@ -104,9 +104,7 @@ ParseNameValue(const char * buffer, int bufsize,
                struct NameValueParserData * data)
 {
 	struct xmlparser parser;
-	data->l_head = NULL;
-	data->portListing = NULL;
-	data->portListingLength = 0;
+	memset(data, 0, sizeof(struct NameValueParserData));
 	/* init xmlparser object */
 	parser.xmlstart = buffer;
 	parser.xmlsize = bufsize;


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in ParseNameValue() that was cloned from miniupnp but did not receive the security patch. The original issue was reported and fixed under https://github.com/miniupnp/miniupnp/commit/7aeb624b44f86d335841242ff427433190e7168a.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2017-1000494
https://github.com/miniupnp/miniupnp/commit/7aeb624b44f86d335841242ff427433190e7168a
