### PR TITLE
DolphinQt: Fix MappingButton not updating text on middle-click clear.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -149,9 +149,9 @@ public:
 
   bool UnQueueInputDetection(MappingButton* button)
   {
+    button->ConfigChanged();
     if (!std::erase(m_clicked_mapping_buttons, button))
       return false;
-    button->ConfigChanged();
     UpdateInputDetectionStartTimer();
     return true;
   }


### PR DESCRIPTION
Fixes a regression that I introduced in #13323.