### PR TITLE
WiimoteEmu: Clean up variant handling in DesiredExtensionState.

### DIFF
--- a/Source/Core/Common/VariantUtil.h
+++ b/Source/Core/Common/VariantUtil.h
@@ -34,3 +34,18 @@ struct overloaded : Ts...
 
 template <class... Ts>
 overloaded(Ts...) -> overloaded<Ts...>;
+
+// Visits a functor with a variant_alternative of the given index.
+// e.g. WithVariantAlternative<variant<int, float>>(1, func) calls func<float>()
+// An out-of-bounds index causes no visitation.
+template <typename Variant, std::size_t I = 0, typename Func>
+void WithVariantAlternative(std::size_t index, Func&& func)
+{
+  if constexpr (I < std::variant_size_v<Variant>)
+  {
+    if (index == 0)
+      func.template operator()<std::variant_alternative_t<I, Variant>>();
+    else
+      WithVariantAlternative<Variant, I + 1>(index - 1, std::forward<Func>(func));
+  }
+}

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
@@ -10,16 +10,8 @@
 
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+#include "Common/VariantUtil.h"
 
-#include "Core/HW/WiimoteEmu/Extension/Classic.h"
-#include "Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h"
-#include "Core/HW/WiimoteEmu/Extension/Drums.h"
-#include "Core/HW/WiimoteEmu/Extension/Guitar.h"
-#include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
-#include "Core/HW/WiimoteEmu/Extension/Shinkansen.h"
-#include "Core/HW/WiimoteEmu/Extension/TaTaCon.h"
-#include "Core/HW/WiimoteEmu/Extension/Turntable.h"
-#include "Core/HW/WiimoteEmu/Extension/UDrawTablet.h"
 #include "Core/HW/WiimoteEmu/MotionPlus.h"
 
 namespace WiimoteEmu
@@ -114,31 +106,14 @@ SerializedWiimoteState SerializeDesiredState(const DesiredWiimoteState& state)
     std::visit(
         [&s](const auto& arg) {
           using T = std::decay_t<decltype(arg)>;
-          if constexpr (!std::is_same_v<std::monostate, T>)
-          {
-            static_assert(sizeof(arg) <= 6);
-            static_assert(std::is_trivially_copyable_v<T>);
-            std::memcpy(&s.data[s.length], &arg, sizeof(arg));
-            s.length += sizeof(arg);
-          }
+          static_assert(sizeof(arg) <= 6);
+          Common::BitCastPtr<T>(&s.data[s.length]) = arg;
+          s.length += sizeof(arg);
         },
         state.extension.data);
   }
 
   return s;
-}
-
-template <typename T>
-static bool DeserializeExtensionState(DesiredWiimoteState* state,
-                                      const SerializedWiimoteState& serialized, size_t offset)
-{
-  if (serialized.length < offset + sizeof(T))
-    return false;
-  auto& e = state->extension.data.emplace<T>();
-  static_assert(std::is_trivially_copyable_v<T>);
-  std::memcpy(static_cast<void*>(&e), static_cast<const void*>(&serialized.data[offset]),
-              sizeof(T));
-  return true;
 }
 
 bool DeserializeDesiredState(DesiredWiimoteState* state, const SerializedWiimoteState& serialized)
@@ -181,39 +156,10 @@ bool DeserializeDesiredState(DesiredWiimoteState* state, const SerializedWiimote
       s += 12;
     if (has_motion_plus)
       s += 6;
-    switch (extension)
+    if (extension)
     {
-    case ExtensionNumber::NONE:
-      break;
-    case ExtensionNumber::NUNCHUK:
-      s += sizeof(Nunchuk::DataFormat);
-      break;
-    case ExtensionNumber::CLASSIC:
-      s += sizeof(Classic::DataFormat);
-      break;
-    case ExtensionNumber::GUITAR:
-      s += sizeof(Guitar::DataFormat);
-      break;
-    case ExtensionNumber::DRUMS:
-      s += sizeof(Drums::DesiredState);
-      break;
-    case ExtensionNumber::TURNTABLE:
-      s += sizeof(Turntable::DataFormat);
-      break;
-    case ExtensionNumber::UDRAW_TABLET:
-      s += sizeof(UDrawTablet::DataFormat);
-      break;
-    case ExtensionNumber::DRAWSOME_TABLET:
-      s += sizeof(DrawsomeTablet::DataFormat);
-      break;
-    case ExtensionNumber::TATACON:
-      s += sizeof(TaTaCon::DataFormat);
-      break;
-    case ExtensionNumber::SHINKANSEN:
-      s += sizeof(Shinkansen::DesiredState);
-      break;
-    default:
-      break;
+      WithVariantAlternative<DesiredExtensionState::ExtensionData>(
+          extension, [&]<typename T>() { s += sizeof(T); });
     }
     return s;
   }();
@@ -283,32 +229,13 @@ bool DeserializeDesiredState(DesiredWiimoteState* state, const SerializedWiimote
     pos += 6;
   }
 
-  switch (extension)
+  if (extension)
   {
-  case ExtensionNumber::NONE:
-    return true;
-  case ExtensionNumber::NUNCHUK:
-    return DeserializeExtensionState<Nunchuk::DataFormat>(state, serialized, pos);
-  case ExtensionNumber::CLASSIC:
-    return DeserializeExtensionState<Classic::DataFormat>(state, serialized, pos);
-  case ExtensionNumber::GUITAR:
-    return DeserializeExtensionState<Guitar::DataFormat>(state, serialized, pos);
-  case ExtensionNumber::DRUMS:
-    return DeserializeExtensionState<Drums::DesiredState>(state, serialized, pos);
-  case ExtensionNumber::TURNTABLE:
-    return DeserializeExtensionState<Turntable::DataFormat>(state, serialized, pos);
-  case ExtensionNumber::UDRAW_TABLET:
-    return DeserializeExtensionState<UDrawTablet::DataFormat>(state, serialized, pos);
-  case ExtensionNumber::DRAWSOME_TABLET:
-    return DeserializeExtensionState<DrawsomeTablet::DataFormat>(state, serialized, pos);
-  case ExtensionNumber::TATACON:
-    return DeserializeExtensionState<TaTaCon::DataFormat>(state, serialized, pos);
-  case ExtensionNumber::SHINKANSEN:
-    return DeserializeExtensionState<Shinkansen::DesiredState>(state, serialized, pos);
-  default:
-    break;
+    WithVariantAlternative<DesiredExtensionState::ExtensionData>(extension, [&]<typename T>() {
+      state->extension.data.emplace<T>(Common::BitCastPtr<T>(&d[pos]));
+    });
   }
 
-  return false;
+  return true;
 }
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
@@ -129,6 +129,8 @@ public:
   };
   static_assert(sizeof(DataFormat) == 6, "Wrong size");
 
+  using DesiredState = DataFormat;
+
   static constexpr int CAL_STICK_BITS = 8;
   static constexpr int CAL_TRIGGER_BITS = 8;
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h
@@ -17,21 +17,42 @@
 #include "Core/HW/WiimoteEmu/Extension/TaTaCon.h"
 #include "Core/HW/WiimoteEmu/Extension/Turntable.h"
 #include "Core/HW/WiimoteEmu/Extension/UDrawTablet.h"
+#include "Core/HW/WiimoteEmu/ExtensionPort.h"
 
 namespace WiimoteEmu
 {
 struct DesiredExtensionState
 {
 private:
+  template <ExtensionNumber N, typename T>
+  struct ExtNumTypePair
+  {
+    static constexpr ExtensionNumber ext_num = N;
+    using ext_type = T;
+  };
+
   template <typename... Ts>
   struct ExtDataImpl
   {
-    using type = std::variant<std::monostate, typename Ts::DesiredState...>;
+    using type = std::variant<std::monostate, typename Ts::ext_type::DesiredState...>;
+
+    static_assert((std::is_same_v<std::variant_alternative_t<Ts::ext_num, type>,
+                                  typename Ts::ext_type::DesiredState> &&
+                   ...),
+                  "Please use ExtensionNumber enum order for DTM file index consistency.");
   };
 
 public:
-  using ExtensionData = ExtDataImpl<Nunchuk, Classic, Guitar, Drums, Turntable, UDrawTablet,
-                                    DrawsomeTablet, TaTaCon, Shinkansen>::type;
+  using ExtensionData =
+      ExtDataImpl<ExtNumTypePair<ExtensionNumber::NUNCHUK, Nunchuk>,
+                  ExtNumTypePair<ExtensionNumber::CLASSIC, Classic>,
+                  ExtNumTypePair<ExtensionNumber::GUITAR, Guitar>,
+                  ExtNumTypePair<ExtensionNumber::DRUMS, Drums>,
+                  ExtNumTypePair<ExtensionNumber::TURNTABLE, Turntable>,
+                  ExtNumTypePair<ExtensionNumber::UDRAW_TABLET, UDrawTablet>,
+                  ExtNumTypePair<ExtensionNumber::DRAWSOME_TABLET, DrawsomeTablet>,
+                  ExtNumTypePair<ExtensionNumber::TATACON, TaTaCon>,
+                  ExtNumTypePair<ExtensionNumber::SHINKANSEN, Shinkansen>>::type;
 
   ExtensionData data = std::monostate{};
 };

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <type_traits>
 #include <variant>
 
 #include "Common/BitUtils.h"
@@ -18,46 +17,23 @@
 #include "Core/HW/WiimoteEmu/Extension/TaTaCon.h"
 #include "Core/HW/WiimoteEmu/Extension/Turntable.h"
 #include "Core/HW/WiimoteEmu/Extension/UDrawTablet.h"
-#include "Core/HW/WiimoteEmu/ExtensionPort.h"
 
 namespace WiimoteEmu
 {
 struct DesiredExtensionState
 {
-  using ExtensionData =
-      std::variant<std::monostate, Nunchuk::DataFormat, Classic::DataFormat, Guitar::DataFormat,
-                   Drums::DesiredState, Turntable::DataFormat, UDrawTablet::DataFormat,
-                   DrawsomeTablet::DataFormat, TaTaCon::DataFormat, Shinkansen::DesiredState>;
-  ExtensionData data = std::monostate();
+private:
+  template <typename... Ts>
+  struct ExtDataImpl
+  {
+    using type = std::variant<std::monostate, typename Ts::DesiredState...>;
+  };
 
-  static_assert(std::is_same_v<std::monostate,
-                               std::variant_alternative_t<ExtensionNumber::NONE, ExtensionData>>);
-  static_assert(
-      std::is_same_v<Nunchuk::DataFormat,
-                     std::variant_alternative_t<ExtensionNumber::NUNCHUK, ExtensionData>>);
-  static_assert(
-      std::is_same_v<Classic::DataFormat,
-                     std::variant_alternative_t<ExtensionNumber::CLASSIC, ExtensionData>>);
-  static_assert(std::is_same_v<Guitar::DataFormat,
-                               std::variant_alternative_t<ExtensionNumber::GUITAR, ExtensionData>>);
-  static_assert(std::is_same_v<Drums::DesiredState,
-                               std::variant_alternative_t<ExtensionNumber::DRUMS, ExtensionData>>);
-  static_assert(
-      std::is_same_v<Turntable::DataFormat,
-                     std::variant_alternative_t<ExtensionNumber::TURNTABLE, ExtensionData>>);
-  static_assert(
-      std::is_same_v<UDrawTablet::DataFormat,
-                     std::variant_alternative_t<ExtensionNumber::UDRAW_TABLET, ExtensionData>>);
-  static_assert(
-      std::is_same_v<DrawsomeTablet::DataFormat,
-                     std::variant_alternative_t<ExtensionNumber::DRAWSOME_TABLET, ExtensionData>>);
-  static_assert(
-      std::is_same_v<TaTaCon::DataFormat,
-                     std::variant_alternative_t<ExtensionNumber::TATACON, ExtensionData>>);
-  static_assert(
-      std::is_same_v<Shinkansen::DesiredState,
-                     std::variant_alternative_t<ExtensionNumber::SHINKANSEN, ExtensionData>>);
-  static_assert(std::variant_size_v<DesiredExtensionState::ExtensionData> == ExtensionNumber::MAX);
+public:
+  using ExtensionData = ExtDataImpl<Nunchuk, Classic, Guitar, Drums, Turntable, UDrawTablet,
+                                    DrawsomeTablet, TaTaCon, Shinkansen>::type;
+
+  ExtensionData data = std::monostate{};
 };
 
 template <typename T>

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h
@@ -50,8 +50,9 @@ public:
       BitField<3, 5, u8> status;
     };
   };
-
   static_assert(6 == sizeof(DataFormat), "Wrong size.");
+
+  using DesiredState = DataFormat;
 
 private:
   ControllerEmu::AnalogStick* m_stylus;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.h
@@ -48,6 +48,8 @@ public:
   };
   static_assert(sizeof(DataFormat) == 6, "Wrong size");
 
+  using DesiredState = DataFormat;
+
   Guitar();
 
   void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
@@ -116,6 +116,8 @@ public:
   };
   static_assert(sizeof(DataFormat) == 6, "Wrong size");
 
+  using DesiredState = DataFormat;
+
   struct CalibrationData
   {
     using StickType = DataFormat::StickType;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.h
@@ -29,6 +29,8 @@ public:
   };
   static_assert(sizeof(DataFormat) == 6, "Wrong size");
 
+  using DesiredState = DataFormat;
+
   TaTaCon();
 
   void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
@@ -54,6 +54,8 @@ public:
   };
   static_assert(sizeof(DataFormat) == 6, "Wrong size");
 
+  using DesiredState = DataFormat;
+
   Turntable();
 
   void BuildDesiredExtensionState(DesiredExtensionState* target_state) override;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.h
@@ -56,8 +56,9 @@ public:
     // 0x04 is always unset (neutral state is 0xfb)
     u8 buttons;
   };
-
   static_assert(6 == sizeof(DataFormat), "Wrong size.");
+
+  using DesiredState = DataFormat;
 
 private:
   ControllerEmu::Buttons* m_buttons;


### PR DESCRIPTION
The old code relied on variant alternative indices matching ExtensionNumber values.
That wasn't inherently an issue, but there was a lot of boilerplate to handle that and ensure that it was maintained.

High-level behavior remains unchanged.
DTM format is unchanged.