### PR TITLE
CMake: Allow shared zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,7 +689,7 @@ dolphin_make_imported_target_if_missing(LibLZMA::LibLZMA LIBLZMA)
 
 dolphin_find_optional_system_library_pkgconfig(ZSTD libzstd>=1.4.0 zstd::zstd Externals/zstd)
 
-add_subdirectory(Externals/zlib-ng)
+dolphin_find_optional_system_library_pkgconfig(ZLIB zlib>=1.3.1 ZLIB::ZLIB Externals/zlib-ng)
 
 dolphin_find_optional_system_library_pkgconfig(MINIZIP
   "minizip>=4.0.4" minizip::minizip Externals/minizip-ng


### PR DESCRIPTION
This allows for `zlib` to be provided by the system. This includes the case where the distro builds and ships `zlib-ng` in `zlib` compat mode.

For some reason, `minizip-ng` from Externals cannot find `check_function_exists` if `zlib` is provided by the system while  `minizip` is not, which is why the CMakeLists was modified.

This is a followup to #13089.