### PR TITLE
Core/DolphinQt: Add "Refresh Rate Rounding" setting.

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -200,6 +200,8 @@ const Info<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES{
     {System::GFX, "Hacks", "EFBEmulateFormatChanges"}, false};
 const Info<bool> GFX_HACK_VERTEX_ROUNDING{{System::GFX, "Hacks", "VertexRounding"}, false};
 const Info<bool> GFX_HACK_VI_SKIP{{System::GFX, "Hacks", "VISkip"}, false};
+const Info<bool> GFX_HACK_REFRESH_RATE_ROUNDING{{System::GFX, "Hacks", "RefreshRateRounding"},
+                                                false};
 const Info<u32> GFX_HACK_MISSING_COLOR_VALUE{{System::GFX, "Hacks", "MissingColorValue"},
                                              0xFFFFFFFF};
 const Info<bool> GFX_HACK_FAST_TEXTURE_SAMPLING{{System::GFX, "Hacks", "FastTextureSampling"},

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -172,6 +172,7 @@ extern const Info<bool> GFX_HACK_COPY_EFB_SCALED;
 extern const Info<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES;
 extern const Info<bool> GFX_HACK_VERTEX_ROUNDING;
 extern const Info<bool> GFX_HACK_VI_SKIP;
+extern const Info<bool> GFX_HACK_REFRESH_RATE_ROUNDING;
 extern const Info<u32> GFX_HACK_MISSING_COLOR_VALUE;
 extern const Info<bool> GFX_HACK_FAST_TEXTURE_SAMPLING;
 #ifdef __APPLE__

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -18,9 +18,10 @@
 
 #include "Core/AchievementManager.h"
 #include "Core/CPUThreadConfigCallback.h"
-#include "Core/Config/AchievementSettings.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
+#include "Core/HW/VideoInterface.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 
@@ -138,6 +139,7 @@ void CoreTimingManager::RefreshConfig()
   }
 
   m_emulation_speed = Config::Get(Config::MAIN_EMULATION_SPEED);
+  m_refresh_rate_rounding = Config::Get(Config::GFX_HACK_REFRESH_RATE_ROUNDING);
 }
 
 void CoreTimingManager::DoState(PointerWrap& p)
@@ -367,7 +369,16 @@ void CoreTimingManager::Throttle(const s64 target_cycle)
 
   m_throttle_last_cycle = target_cycle;
 
-  const double speed = Core::GetIsThrottlerTempDisabled() ? 0.0 : m_emulation_speed;
+  double speed = m_emulation_speed;
+  if (Core::GetIsThrottlerTempDisabled())
+  {
+    speed = 0;
+  }
+  else if (m_refresh_rate_rounding)
+  {
+    const auto refresh_rate = m_system.GetVideoInterface().GetTargetRefreshRate();
+    speed *= std::round(refresh_rate) / refresh_rate;
+  }
 
   if (0.0 < speed)
     m_throttle_deadline +=

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -209,6 +209,7 @@ private:
   DT m_max_fallback = {};
   DT m_max_variance = {};
   double m_emulation_speed = 1.0;
+  bool m_refresh_rate_rounding = false;
 
   void ResetThrottle(s64 cycle);
 

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -114,12 +114,15 @@ void HacksWidget::CreateWidgets()
   m_save_texture_cache_state = new ConfigBool(
       tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE, m_game_layer);
   m_vi_skip = new ConfigBool(tr("VBI Skip"), Config::GFX_HACK_VI_SKIP, m_game_layer);
+  m_refresh_rate_rounding = new ConfigBool(tr("Refresh Rate Rounding"),
+                                           Config::GFX_HACK_REFRESH_RATE_ROUNDING, m_game_layer);
 
   other_layout->addWidget(m_fast_depth_calculation, 0, 0);
   other_layout->addWidget(m_disable_bounding_box, 0, 1);
   other_layout->addWidget(m_vertex_rounding, 1, 0);
   other_layout->addWidget(m_save_texture_cache_state, 1, 1);
   other_layout->addWidget(m_vi_skip, 2, 0);
+  other_layout->addWidget(m_refresh_rate_rounding, 2, 1);
 
   main_layout->addWidget(efb_box);
   main_layout->addWidget(texture_cache_box);
@@ -238,6 +241,10 @@ void HacksWidget::AddDescriptions()
                  "<dolphin_emphasis>WARNING: Can cause freezes and compatibility "
                  "issues.</dolphin_emphasis> <br><br>"
                  "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+  static const char TR_REFRESH_RATE_ROUNDING_DESCRIPTION[] =
+      QT_TR_NOOP("Alters emulation speed for an integer refresh rate. <br><br>"
+                 "e.g. (29.97 -> 30) and (59.94 -> 60) <br><br>"
+                 "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
   m_skip_efb_cpu->SetDescription(tr(TR_SKIP_EFB_CPU_ACCESS_DESCRIPTION));
   m_ignore_format_changes->SetDescription(tr(TR_IGNORE_FORMAT_CHANGE_DESCRIPTION));
@@ -254,6 +261,7 @@ void HacksWidget::AddDescriptions()
   m_save_texture_cache_state->SetDescription(tr(TR_SAVE_TEXTURE_CACHE_TO_STATE_DESCRIPTION));
   m_vertex_rounding->SetDescription(tr(TR_VERTEX_ROUNDING_DESCRIPTION));
   m_vi_skip->SetDescription(tr(TR_VI_SKIP_DESCRIPTION));
+  m_refresh_rate_rounding->SetDescription(tr(TR_REFRESH_RATE_ROUNDING_DESCRIPTION));
 }
 
 void HacksWidget::UpdateDeferEFBCopiesEnabled()

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -50,6 +50,7 @@ private:
   ConfigBool* m_vertex_rounding;
   ConfigBool* m_vi_skip;
   ConfigBool* m_save_texture_cache_state;
+  ConfigBool* m_refresh_rate_rounding;
 
   Config::Layer* m_game_layer = nullptr;
 


### PR DESCRIPTION
This exposes a setting to increase the emulation speed for true 30/60fps.

Maybe this can help users with micro-stutters or tearing when they don't have a variable refresh rate display.

While it's more of an emulation speed setting, I don't know if it belongs in "General" main config with "Speed Limit".
The setting is related to refresh rates and v-sync and I think the "Graphics" "Hacks" tab is appropriate.

![image](https://github.com/user-attachments/assets/3fbfb616-65ef-4cf4-8516-88a450574b33)