### PR TITLE
Fix graphical corruption bug in Tomb Raider: Legend

### DIFF
--- a/Data/Sys/GameSettings/GL8.ini
+++ b/Data/Sys/GameSettings/GL8.ini
@@ -11,3 +11,4 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
+DeferEFBCopies = False


### PR DESCRIPTION
Tomb Raider: Legend has a graphical bug, as documented in the issue report [here.](https://bugs.dolphin-emu.org/issues/13749?next_issue_id=13748)

This .ini entry fixes the issue.

UNRESOLVED
![Dolphin](https://github.com/user-attachments/assets/12ed49ce-6613-4ca2-9698-987c9e9490f9)

RESOLVED
![GL8E4F_2025-03-01_03-06-36](https://github.com/user-attachments/assets/950b5bec-d449-4908-8c38-a4f5dc4eae6a)
