### PR TITLE
DolphinQt: Don't recommend v-sync for optimal frame pacing in tool-tip.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -202,12 +202,10 @@ void HacksWidget::AddDescriptions()
       "expect all XFB copies to be displayed. However, turning this setting on reduces "
       "latency.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_SKIP_DUPLICATE_XFBS_DESCRIPTION[] = QT_TR_NOOP(
-      "Skips presentation of duplicate frames (XFB copies) in 25fps/30fps games. This may improve "
-      "performance on low-end devices, while making frame pacing less consistent.<br><br "
-      "/>Disable this "
-      "option as well as enabling V-Sync for optimal frame pacing.<br><br><dolphin_emphasis>If "
-      "unsure, leave this "
-      "checked.</dolphin_emphasis>");
+      "Skips presentation of duplicate frames (XFB copies) in 25fps/30fps games. "
+      "This may improve performance on low-end devices, while making frame pacing less consistent."
+      "<br><br>Disable this option for optimal frame pacing."
+      "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
   static const char TR_GPU_DECODING_DESCRIPTION[] = QT_TR_NOOP(
       "Enables texture decoding using the GPU instead of the CPU.<br><br>This may result in "
       "performance gains in some scenarios, or on systems where the CPU is the "


### PR DESCRIPTION
I think this was an unusual recommendation. V-Sync will probably hurt frame-pacing.