### PR TITLE
VideoCommon: mark 'WriteTexCoordTransforms' as 'static'

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -74,8 +74,8 @@ VertexShaderUid GetVertexShaderUid()
   return out;
 }
 
-void WriteTexCoordTransforms(APIType api_type, const ShaderHostConfig& host_config,
-                             const vertex_shader_uid_data* uid_data, ShaderCode& out)
+static void WriteTexCoordTransforms(APIType api_type, const ShaderHostConfig& host_config,
+                                    const vertex_shader_uid_data* uid_data, ShaderCode& out)
 {
   for (u32 i = 0; i < uid_data->numTexGens; ++i)
   {


### PR DESCRIPTION
This was requested by @Tilka .

I normally prefer anonymous namespaces but given I still have a lot of changes to make to these files, I figured taking a lighter approach would be less disruptive to my other PRs.