### PR TITLE
InputCommon: Use Clock from CommonTypes.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -170,7 +170,7 @@ public:
       // Ignore the mouse-click that queued this new detection and finalize the current mapping.
       auto results = m_input_detector->TakeResults();
       ciface::MappingCommon::RemoveDetectionsAfterTimePoint(
-          &results, ciface::Core::DeviceContainer::Clock::now() - INPUT_DETECT_ENDING_IGNORE_TIME);
+          &results, Clock::now() - INPUT_DETECT_ENDING_IGNORE_TIME);
       FinalizeMapping(&results);
     }
     UpdateInputDetectionStartTimer();

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -210,8 +210,6 @@ public:
 class DeviceContainer
 {
 public:
-  using Clock = std::chrono::steady_clock;
-
   struct InputDetection
   {
     std::shared_ptr<Device> device;

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -147,8 +147,7 @@ void RemoveSpuriousTriggerCombinations(Core::InputDetector::Results* detections)
   std::erase_if(*detections, is_spurious);
 }
 
-void RemoveDetectionsAfterTimePoint(Core::InputDetector::Results* results,
-                                    Core::DeviceContainer::Clock::time_point after)
+void RemoveDetectionsAfterTimePoint(Core::InputDetector::Results* results, Clock::time_point after)
 {
   const auto is_after_time = [&](const Core::InputDetector::Detection& detection) {
     return detection.release_time.value_or(after) >= after;

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.h
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
@@ -25,8 +24,7 @@ std::string BuildExpression(const Core::InputDetector::Results&,
                             const Core::DeviceQualifier& default_device, Quote quote);
 
 void RemoveSpuriousTriggerCombinations(Core::InputDetector::Results*);
-void RemoveDetectionsAfterTimePoint(Core::InputDetector::Results*,
-                                    Core::DeviceContainer::Clock::time_point after);
+void RemoveDetectionsAfterTimePoint(Core::InputDetector::Results*, Clock::time_point after);
 bool ContainsCompleteDetection(const Core::InputDetector::Results&);
 
 }  // namespace ciface::MappingCommon


### PR DESCRIPTION
`DeviceContainer::Clock` was typedef'd to the same thing as CommonType's `Clock` but a mix of the two were used throughout so changing one without the other would just break compilation.

Now only the one `Clock` exists. There is no behavioral change, just a code cleanup.