### PR TITLE
Add support to overwrite existing title version when installing a WAD

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/WADInstallOverwriteVersion.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/sysupdate/ui/WADInstallOverwriteVersion.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.sysupdate.ui
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.dolphinemu.dolphinemu.R
+import org.dolphinemu.dolphinemu.utils.WiiUtils
+
+class WADInstallOverwriteVersionFragment : DialogFragment() {
+  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+    return MaterialAlertDialogBuilder(requireContext())
+      .setTitle(getString(R.string.title_already_installed))
+      .setMessage(getString(R.string.overwrite_installed_version))
+      .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
+        val path = arguments?.getString("path")
+        val success = WiiUtils.installWAD(path!!, true);
+        dismiss()
+      }
+      .setNegativeButton(R.string.no) { _: DialogInterface?, _: Int -> dismiss() }
+      .create()
+  }
+
+  companion object {
+    const val TAG = "WADInstallOverwriteVersionFragment"
+
+    fun newInstance(path: String): WADInstallOverwriteVersionFragment {
+      val fragment = WADInstallOverwriteVersionFragment()
+      val bundle = Bundle()
+      bundle.putString("path", path)
+      fragment.arguments = bundle
+      return fragment
+    }
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.kt
@@ -17,6 +17,7 @@ import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag
 import org.dolphinemu.dolphinemu.features.sysupdate.ui.SystemMenuNotInstalledDialogFragment
 import org.dolphinemu.dolphinemu.features.sysupdate.ui.SystemUpdateProgressBarDialogFragment
 import org.dolphinemu.dolphinemu.features.sysupdate.ui.SystemUpdateViewModel
+import org.dolphinemu.dolphinemu.features.sysupdate.ui.WADInstallOverwriteVersionFragment
 import org.dolphinemu.dolphinemu.fragments.AboutDialogFragment
 import org.dolphinemu.dolphinemu.model.GameFileCache
 import org.dolphinemu.dolphinemu.services.GameFileCacheManager
@@ -181,8 +182,17 @@ class MainPresenter(private val mainView: MainView, private val activity: Fragme
             R.string.import_in_progress,
             0,
             {
-                val success = WiiUtils.installWAD(path!!)
-                val message =
+              val message: Int;
+              val isTitleVersionMismatch = WiiUtils.isTitleVersionMismatch(path!!);
+              if (isTitleVersionMismatch) {
+                    val fragment = WADInstallOverwriteVersionFragment.newInstance(path)
+                    fragment.show(
+                    activity.supportFragmentManager,
+                    WADInstallOverwriteVersionFragment.TAG
+                  )
+                }
+                val success = WiiUtils.installWAD(path, false)
+                message =
                     if (success) R.string.wad_install_success else R.string.wad_install_failure
                 activity.getString(message)
             })

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/WiiUtils.kt
@@ -19,7 +19,10 @@ object WiiUtils {
     const val UPDATE_RESULT_CANCELLED = 8
 
     @JvmStatic
-    external fun installWAD(file: String): Boolean
+    external fun installWAD(file: String, overwriteInstalled: Boolean): Boolean
+    @JvmStatic
+    external fun isTitleVersionMismatch(file: String): Boolean
+
 
     @JvmStatic
     external fun importWiiSave(file: String, canOverwrite: BooleanSupplier): Int

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -492,6 +492,8 @@
     <string name="nand_import_warning">Merging a new NAND over your currently selected NAND will overwrite any channels and savegames that already exist. This process is not reversible, so it is recommended that you keep backups of both NANDs. Are you sure you want to continue?</string>
     <string name="system_menu_not_installed_title">Not installed</string>
     <string name="system_menu_not_installed_message">The Wii Menu isn\'t installed. Would you like to install it now?\n\nRoughly 110 MiB of data will be downloaded from the internet. A Wi-Fi connection is recommended.</string>
+    <string name="overwrite_installed_version">A different version of this title is already installed on the NAND. Installing this WAD will replace it irreversibly. Continue?</string>
+    <string name="title_already_installed">Already installed</string>
 
     <!-- Game Properties Screen -->
     <string name="properties_details">Details</string>

--- a/Source/Android/jni/WiiUtils.cpp
+++ b/Source/Android/jni/WiiUtils.cpp
@@ -74,12 +74,18 @@ static jint ConvertUpdateResult(WiiUtils::UpdateResult result)
 
 extern "C" {
 
-JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_WiiUtils_installWAD(JNIEnv* env,
-                                                                                    jclass,
-                                                                                    jstring jFile)
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_WiiUtils_installWAD(
+    JNIEnv* env, jclass, jstring jFile, jboolean jOverwrite)
 {
   const std::string path = GetJString(env, jFile);
-  return static_cast<jboolean>(WiiUtils::InstallWAD(path));
+  return static_cast<jboolean>(WiiUtils::InstallWAD(path, jOverwrite));
+}
+
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_WiiUtils_isTitleVersionMismatch(
+    JNIEnv* env, jclass, jstring jFile)
+{
+  const std::string path = GetJString(env, jFile);
+  return static_cast<jboolean>(WiiUtils::IsTitleVersionMismatch(path));
 }
 
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_utils_WiiUtils_importWiiSave(

--- a/Source/Core/Core/WiiUtils.h
+++ b/Source/Core/Core/WiiUtils.h
@@ -40,10 +40,13 @@ enum class InstallType
   Temporary,
 };
 
-bool InstallWAD(IOS::HLE::Kernel& ios, const DiscIO::VolumeWAD& wad, InstallType type);
+bool IsTitleVersionMismatch(const std::string& wad_path);
+
+bool InstallWAD(IOS::HLE::Kernel& ios, const DiscIO::VolumeWAD& wad, InstallType type,
+                bool overwrite_installed = false);
 // Same as the above, but constructs a temporary IOS and VolumeWAD instance for importing
 // and does a permanent install.
-bool InstallWAD(const std::string& wad_path);
+bool InstallWAD(const std::string& wad_path, bool overwrite_installed = false);
 
 bool UninstallTitle(u64 title_id);
 


### PR DESCRIPTION
Currently on Android, you just get an error message saying there is already a title installed of a different version and it does not let you overwrite it, unlike any other platform. This commit aims to fix that issue.