### PR TITLE
CoreTiming: Add setting to pursue accurate overall emulation runtime

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -45,6 +45,7 @@ const Info<bool> MAIN_ACCURATE_CPU_CACHE{{System::Main, "Core", "AccurateCPUCach
 const Info<bool> MAIN_DSP_HLE{{System::Main, "Core", "DSPHLE"}, true};
 const Info<int> MAIN_MAX_FALLBACK{{System::Main, "Core", "MaxFallback"}, 100};
 const Info<int> MAIN_TIMING_VARIANCE{{System::Main, "Core", "TimingVariance"}, 40};
+const Info<bool> MAIN_CORRECT_TIME_DRIFT{{System::Main, "Core", "CorrectTimeDrift"}, false};
 const Info<bool> MAIN_CPU_THREAD{{System::Main, "Core", "CPUThread"}, true};
 const Info<bool> MAIN_SYNC_ON_SKIP_IDLE{{System::Main, "Core", "SyncOnSkipIdle"}, true};
 const Info<std::string> MAIN_DEFAULT_ISO{{System::Main, "Core", "DefaultISO"}, ""};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -63,6 +63,7 @@ extern const Info<bool> MAIN_ACCURATE_CPU_CACHE;
 extern const Info<bool> MAIN_DSP_HLE;
 extern const Info<int> MAIN_MAX_FALLBACK;
 extern const Info<int> MAIN_TIMING_VARIANCE;
+extern const Info<bool> MAIN_CORRECT_TIME_DRIFT;
 extern const Info<bool> MAIN_CPU_THREAD;
 extern const Info<bool> MAIN_SYNC_ON_SKIP_IDLE;
 extern const Info<std::string> MAIN_DEFAULT_ISO;

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -105,10 +105,20 @@ void CoreTimingManager::Init()
 
   m_last_oc_factor = m_config_oc_factor;
   m_globals.last_OC_factor_inverted = m_config_oc_inv_factor;
+
+  m_on_state_changed_handle = Core::AddOnStateChangedCallback([this](Core::State state) {
+    if (state == Core::State::Running)
+    {
+      // We don't want Throttle to attempt catch-up for all the time lost while paused.
+      ResetThrottle(GetTicks());
+    }
+  });
 }
 
 void CoreTimingManager::Shutdown()
 {
+  Core::RemoveOnStateChangedCallback(&m_on_state_changed_handle);
+
   std::lock_guard lk(m_ts_write_lock);
   MoveEvents();
   ClearPendingEvents();
@@ -128,6 +138,8 @@ void CoreTimingManager::RefreshConfig()
   m_max_fallback = std::chrono::duration_cast<DT>(DT_ms(Config::Get(Config::MAIN_MAX_FALLBACK)));
 
   m_max_variance = std::chrono::duration_cast<DT>(DT_ms(Config::Get(Config::MAIN_TIMING_VARIANCE)));
+
+  m_correct_time_drift = Config::Get(Config::MAIN_CORRECT_TIME_DRIFT);
 
   if (AchievementManager::GetInstance().IsHardcoreModeActive() &&
       Config::Get(Config::MAIN_EMULATION_SPEED) < 1.0f &&
@@ -426,7 +438,9 @@ void CoreTimingManager::Throttle(const s64 target_cycle)
   const TimePoint time = Clock::now();
 
   const TimePoint min_target = time - m_max_fallback;
-  if (target_time < min_target)
+
+  // "Correct Time Drift" setting prevents timing relaxing.
+  if (!m_correct_time_drift && target_time < min_target)
   {
     // Core is running too slow.. i.e. CPU bottleneck.
     const DT adjustment = min_target - target_time;

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -209,6 +209,7 @@ private:
 
   DT m_max_fallback = {};
   DT m_max_variance = {};
+  bool m_correct_time_drift = false;
   double m_emulation_speed = 1.0;
 
   bool IsSpeedUnlimited() const;
@@ -223,6 +224,8 @@ private:
   std::atomic_bool m_use_precision_timer = false;
   Common::PrecisionTimer m_precision_cpu_timer;
   Common::PrecisionTimer m_precision_gpu_timer;
+
+  int m_on_state_changed_handle;
 };
 
 }  // namespace CoreTiming

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -88,6 +88,18 @@ void AdvancedPane::CreateLayout()
          "needed.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
   cpu_options_group_layout->addWidget(m_accurate_cpu_cache_checkbox);
 
+  auto* const timing_group = new QGroupBox(tr("Timing"));
+  main_layout->addWidget(timing_group);
+  auto* timing_group_layout = new QVBoxLayout{timing_group};
+  auto* const correct_time_drift =
+      new ConfigBool{tr("Correct Time Drift"), Config::MAIN_CORRECT_TIME_DRIFT};
+  correct_time_drift->SetDescription(
+      tr("Allow the emulated console to run fast after stutters,"
+         "<br>pursuing accurate overall elapsed time unless paused or speed-adjusted."
+         "<br><br>This may be useful for internet play."
+         "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
+  timing_group_layout->addWidget(correct_time_drift);
+
   auto* clock_override = new QGroupBox(tr("Clock Override"));
   auto* clock_override_layout = new QVBoxLayout();
   clock_override->setLayout(clock_override_layout);


### PR DESCRIPTION
Followup of #13499 which eliminated the time drift from cumulative rounding errors.

`MaxFallback` (default: 100ms) has already existed to reset the throttle if emulation strays too far from the target time, such as from a CPU bottleneck.
If stutters exceeds 100ms before Dolphin can catch up, it will adjust the reference time and effectively commit to running >100ms in the past.

That is not ideal for internet play and a user has reported it as a cause of issue with Wiimmfi.
https://bugs.dolphin-emu.org/issues/13609 (fixed)

I've added a new setting, `CorrectTimeDrift`. When enabled, `MaxFallback` is ignored to instead pursue accurate elapsed time.

I've added a "Timing" section on the "Advanced" tab for now.
"Sync with Host Refresh Rate" and "Reduce Input Latency" settings might also go there in future PRs.

![image](https://github.com/user-attachments/assets/19b1980a-6f6e-4c16-9c21-51829b3bd0a3)
![image](https://github.com/user-attachments/assets/0fb36c38-0720-4864-8eff-1a7fe1cafe66)

I'm not 100% set on the setting name, but it's the best I could come up with that is accurate and not overly technical.
Suggestions?
 