### PR TITLE
VideoInterface: Update m_ticks_last_line_start from the event's ticks value.

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -916,7 +916,7 @@ void VideoInterfaceManager::Update(u64 ticks)
   auto& core_timing = m_system.GetCoreTiming();
   if (!(m_half_line_count & 1))
   {
-    m_ticks_last_line_start = core_timing.GetTicks();
+    m_ticks_last_line_start = ticks;
   }
 
   // TODO: Findout why skipping interrupts acts as a frameskip


### PR DESCRIPTION
`GetTicks()` is often a few cycles further than the `ticks` argument which already has `cycles_late` applied to give us the event's original `ticks`.

It looks like this value is only used for reading `VI_HORIZONTAL_BEAM_POSITION`.

I don't expect this to really affect much but maybe someone else can confirm if this is a sensible change.