### PR TITLE
PerformanceMetrics: Eliminated a mutex. Code cleanups.

### DIFF
--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -26,10 +26,6 @@ class System;
 bool GetIsThrottlerTempDisabled();
 void SetIsThrottlerTempDisabled(bool disable);
 
-// Returns the latest emulation speed (1 is full speed) (swings a lot)
-double GetActualEmulationSpeed();
-
-void Callback_FramePresented(double actual_emulation_speed = 1.0);
 void Callback_NewField(Core::System& system);
 
 enum class State

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -433,12 +433,6 @@ void CoreTimingManager::ResetThrottle(s64 cycle)
   m_throttle_deadline = Clock::now();
 }
 
-TimePoint CoreTimingManager::GetCPUTimePoint(s64 cyclesLate) const
-{
-  return TimePoint(std::chrono::duration_cast<DT>(DT_s(m_globals.global_timer - cyclesLate) /
-                                                  m_throttle_clock_per_sec));
-}
-
 bool CoreTimingManager::GetVISkip() const
 {
   return m_throttle_disable_vi_int && g_ActiveConfig.bVISkip && !Core::WantsDeterminism();

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -161,8 +161,8 @@ public:
   // May be used from any thread.
   void SleepUntil(TimePoint time_point);
 
-  TimePoint GetCPUTimePoint(s64 cyclesLate) const;  // Used by Dolphin Analytics
-  bool GetVISkip() const;                           // Used By VideoInterface
+  // Used by VideoInterface
+  bool GetVISkip() const;
 
   bool UseSyncOnSkipIdle() const;
 

--- a/Source/Core/VideoCommon/PerformanceMetrics.cpp
+++ b/Source/Core/VideoCommon/PerformanceMetrics.cpp
@@ -82,12 +82,6 @@ double PerformanceMetrics::GetMaxSpeed() const
   return m_max_speed;
 }
 
-double PerformanceMetrics::GetLastSpeedDenominator() const
-{
-  return DT_s(m_speed_counter.GetLastRawDt()).count() *
-         Core::System::GetInstance().GetVideoInterface().GetTargetRefreshRate();
-}
-
 void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
 {
   const int movable_flag = Config::Get(Config::GFX_MOVABLE_PERFORMANCE_METRICS) ?

--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -39,8 +39,6 @@ public:
   double GetSpeed() const;
   double GetMaxSpeed() const;
 
-  double GetLastSpeedDenominator() const;
-
   // ImGui Functions
   void DrawImGuiStats(const float backbuffer_scale);
 

--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <array>
-#include <shared_mutex>
+#include <atomic>
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/PerformanceTracker.h"
@@ -51,11 +51,10 @@ private:
 
   double m_graph_max_time = 0.0;
 
-  mutable std::shared_mutex m_time_lock;
-
+  std::atomic<double> m_max_speed{};
   u8 m_time_index = 0;
   std::array<TimePoint, 256> m_real_times{};
-  std::array<TimePoint, 256> m_cpu_times{};
+  std::array<u64, 256> m_core_ticks{};
   DT m_time_sleeping{};
 };
 


### PR DESCRIPTION
`GetCPUTimePoint` was implemented assuming a constant `GetTicksPerSecond` but this isn't always the case.

The returned nanoseconds would jump in time when ticks-per-second changed, such as when booting a GC game from the Wii menu.
![image](https://github.com/user-attachments/assets/daa77665-a71b-4c0c-945d-ada9f7437218)
"Max Speed" values would be wildly wrong until the sample window left this transition period.

While this is a weird edge-case, I think calculating time from cycles-delta rather than cycles-since-boot is less problematic and not any more complicated.

I've also eliminated a mutex in `PerformanceMetrics` by writing an `atomic<double> m_max_speed` in the Core thread rather than relying on locking around the sample data.