### PR TITLE
CMake: fix various typos

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -57,7 +57,7 @@ DEFAULT_CONFIG = {
     # SHA checksum to verify the integrity of the app. This doesn't
     # protect against malicious actors, but it does protect against
     # running corrupted binaries and allows for access to the extended
-    # permisions needed for ARM builds
+    # permissions needed for ARM builds
     "codesign_identity":  "-",
 
     # Minimum macOS version for each architecture slice
@@ -77,7 +77,7 @@ DEFAULT_CONFIG = {
     "distributor": "None"
 }
 
-# Architectures to build for. This is explicity left out of the command line
+# Architectures to build for. This is explicitly left out of the command line
 # config options for several reasons:
 # 1) Adding new architectures will generally require more code changes
 # 2) Single architecture builds should utilize the normal generated cmake

--- a/CMake/FindFFmpeg.cmake
+++ b/CMake/FindFFmpeg.cmake
@@ -11,7 +11,7 @@
 #  FFmpeg_LIBRARIES: aggregate all the paths to the libraries
 #  FFmpeg_FOUND: True if all components have been found
 #
-# This module defines the following targets, which are prefered over variables:
+# This module defines the following targets, which are preferred over variables:
 #
 #  FFmpeg::<component>: Target to use <component> directly, with include path,
 #    library and dependencies set up. If you are using a static build, you are

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 set(COMPILER ${CMAKE_CXX_COMPILER_ID})
 if (COMPILER STREQUAL "GNU")
-  set(COMPILER "GCC") # perfer printing GCC instead of GNU
+  set(COMPILER "GCC") # prefer printing GCC instead of GNU
 endif()
 
 # Enforce minimum compiler versions that support the c++20 features we use
@@ -407,7 +407,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/local/lib")
 
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0)
-    # Workaround: the llvm libc++ and versions of clang eariler than 14 have a bug with consteval
+    # Workaround: the llvm libc++ and versions of clang earlier than 14 have a bug with consteval
     # so we define FMT_CONSTEVAL to blank to just disable consteval in fmt
     add_definitions(-DFMT_CONSTEVAL=)
   endif()


### PR DESCRIPTION
Also includes a fix for BuildMacOSUniversalBinary.py