### PR TITLE
VideoCommon: Don't merge EFBPoke AsyncRequests.

### DIFF
--- a/Source/Core/VideoBackends/Null/NullGfx.h
+++ b/Source/Core/VideoBackends/Null/NullGfx.h
@@ -45,7 +45,7 @@ public:
   ~NullRenderer() override;
 
   u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override { return 0; }
-  void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override {}
+  void PokeEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override {}
 
   void ReinterpretPixelData(EFBReinterpretType convtype) override {}
 };

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -3,9 +3,6 @@
 
 #pragma once
 
-#include <memory>
-#include <string_view>
-
 #include "Common/CommonTypes.h"
 
 #include "VideoCommon/RenderBase.h"
@@ -16,7 +13,7 @@ class SWRenderer final : public Renderer
 {
 public:
   u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
-  void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override {}
+  void PokeEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override {}
 
   void ReinterpretPixelData(EFBReinterpretType convtype) override {}
 };

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -14,7 +14,6 @@
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoBackendBase.h"
-#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoEvents.h"
 #include "VideoCommon/VideoState.h"
 
@@ -34,34 +33,6 @@ void AsyncRequests::PullEventsInternal()
   while (!m_queue.empty())
   {
     Event e = m_queue.front();
-
-    // try to merge as many efb pokes as possible
-    // it's a bit hacky, but some games render a complete frame in this way
-    if ((e.type == Event::EFB_POKE_COLOR || e.type == Event::EFB_POKE_Z))
-    {
-      m_merged_efb_pokes.clear();
-      Event first_event = m_queue.front();
-      const auto t = first_event.type == Event::EFB_POKE_COLOR ? EFBAccessType::PokeColor :
-                                                                 EFBAccessType::PokeZ;
-
-      do
-      {
-        e = m_queue.front();
-
-        EfbPokeData d;
-        d.data = e.efb_poke.data;
-        d.x = e.efb_poke.x;
-        d.y = e.efb_poke.y;
-        m_merged_efb_pokes.push_back(d);
-
-        m_queue.pop();
-      } while (!m_queue.empty() && m_queue.front().type == first_event.type);
-
-      lock.unlock();
-      g_renderer->PokeEFB(t, m_merged_efb_pokes.data(), m_merged_efb_pokes.size());
-      lock.lock();
-      continue;
-    }
 
     lock.unlock();
     HandleEvent(e);
@@ -131,16 +102,14 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
   case Event::EFB_POKE_COLOR:
   {
     INCSTAT(g_stats.this_frame.num_efb_pokes);
-    EfbPokeData poke = {e.efb_poke.x, e.efb_poke.y, e.efb_poke.data};
-    g_renderer->PokeEFB(EFBAccessType::PokeColor, &poke, 1);
+    g_renderer->PokeEFB(EFBAccessType::PokeColor, e.efb_poke.x, e.efb_poke.y, e.efb_poke.data);
   }
   break;
 
   case Event::EFB_POKE_Z:
   {
     INCSTAT(g_stats.this_frame.num_efb_pokes);
-    EfbPokeData poke = {e.efb_poke.x, e.efb_poke.y, e.efb_poke.data};
-    g_renderer->PokeEFB(EFBAccessType::PokeZ, &poke, 1);
+    g_renderer->PokeEFB(EFBAccessType::PokeZ, e.efb_poke.x, e.efb_poke.y, e.efb_poke.data);
   }
   break;
 

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -6,7 +6,6 @@
 #include <condition_variable>
 #include <mutex>
 #include <queue>
-#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/Flag.h"
@@ -106,6 +105,4 @@ private:
   bool m_wake_me_up_again = false;
   bool m_enable = false;
   bool m_passthrough = true;
-
-  std::vector<EfbPokeData> m_merged_efb_pokes;
 };

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -112,31 +112,23 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
   }
 }
 
-void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points)
+void Renderer::PokeEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 {
   if (type == EFBAccessType::PokeColor)
   {
-    for (size_t i = 0; i < num_points; i++)
-    {
-      // Convert to expected format (BGRA->RGBA)
-      // TODO: Check alpha, depending on mode?
-      const EfbPokeData& point = points[i];
-      u32 color = ((point.data & 0xFF00FF00) | ((point.data >> 16) & 0xFF) |
-                   ((point.data << 16) & 0xFF0000));
-      g_framebuffer_manager->PokeEFBColor(point.x, point.y, color);
-    }
+    // Convert to expected format (BGRA->RGBA)
+    // TODO: Check alpha, depending on mode?
+    const u32 color =
+        ((poke_data & 0xFF00FF00) | ((poke_data >> 16) & 0xFF) | ((poke_data << 16) & 0xFF0000));
+    g_framebuffer_manager->PokeEFBColor(x, y, color);
   }
   else  // if (type == EFBAccessType::PokeZ)
   {
-    for (size_t i = 0; i < num_points; i++)
-    {
-      // Convert to floating-point depth.
-      const EfbPokeData& point = points[i];
-      float depth = float(point.data & 0xFFFFFF) / 16777216.0f;
-      if (!g_backend_info.bSupportsReversedDepthRange)
-        depth = 1.0f - depth;
+    // Convert to floating-point depth.
+    float depth = float(poke_data & 0xFFFFFF) / 16777216.0f;
+    if (!g_backend_info.bSupportsReversedDepthRange)
+      depth = 1.0f - depth;
 
-      g_framebuffer_manager->PokeEFBDepth(point.x, point.y, depth);
-    }
+    g_framebuffer_manager->PokeEFBDepth(x, y, depth);
   }
 }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -10,12 +10,6 @@
 enum class EFBAccessType;
 enum class EFBReinterpretType;
 
-struct EfbPokeData
-{
-  u16 x, y;
-  u32 data;
-};
-
 // Renderer really isn't a very good name for this class - it's more like "Misc".
 // It used to be a massive mess, but almost everything has been refactored out.
 //
@@ -28,7 +22,7 @@ public:
   virtual void ReinterpretPixelData(EFBReinterpretType convtype);
 
   virtual u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data);
-  virtual void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points);
+  virtual void PokeEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data);
 };
 
 extern std::unique_ptr<Renderer> g_renderer;


### PR DESCRIPTION
This was unnecessary since #7753.

`Renderer::PokeEFB` was just iterating `AsyncRequests`'s merged pokes and individually sending them to `FramebufferManager` which then handled the batching all over again.

Also `PullEventsInternal` isn't used in "single core" mode so the unnecessary merging didn't even happen there.