### PR TITLE
Core/VideoBackendBase: Call ExitGpuLoop from Core to eliminate Video_ExitLoop.

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -310,12 +310,12 @@ void Stop(Core::System& system)  // - Hammertime!
 
   if (system.IsDualCoreMode())
   {
-    // Video_EnterLoop() should now exit so that EmuThread()
+    // FIFO processing should now exit so that EmuThread()
     // will continue concurrently with the rest of the commands
     // in this function. We no longer rely on Postmessage.
     INFO_LOG_FMT(CONSOLE, "{}", StopMessage(true, "Wait for Video Loop to exit ..."));
 
-    g_video_backend->Video_ExitLoop();
+    system.GetFifo().ExitGpuLoop();
   }
 
   s_last_actual_emulation_speed = 1.0;

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -91,12 +91,6 @@ std::string VideoBackendBase::BadShaderFilename(const char* shader_stage, int co
                      g_video_backend->GetName(), counter);
 }
 
-void VideoBackendBase::Video_ExitLoop()
-{
-  auto& system = Core::System::GetInstance();
-  system.GetFifo().ExitGpuLoop();
-}
-
 // Run from the CPU thread (from VideoInterface.cpp)
 void VideoBackendBase::Video_OutputXFB(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height,
                                        u64 ticks)

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -56,8 +56,6 @@ public:
 
   static std::string BadShaderFilename(const char* shader_stage, int counter);
 
-  void Video_ExitLoop();
-
   void Video_OutputXFB(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u64 ticks);
 
   u32 Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 data);


### PR DESCRIPTION
This eliminates an unnecessary function. Emu start/stop is hard enough to follow as it is.