### PR TITLE
Core/Core: fix typos

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -1152,7 +1152,7 @@ void AchievementManager::HandleGameCompletedEvent(const rc_client_event_t* clien
 
 void AchievementManager::HandleResetEvent(const rc_client_event_t* client_event)
 {
-  INFO_LOG_FMT(ACHIEVEMENTS, "Reset requested by Achievement Mananger");
+  INFO_LOG_FMT(ACHIEVEMENTS, "Reset requested by Achievement Manager");
   Core::Stop(Core::System::GetInstance());
 }
 

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -189,8 +189,8 @@ bool BootCore(Core::System& system, std::unique_ptr<BootParameters> boot,
 // Conversely, we also shouldn't just accept any changes to SYSCONF, as it may cause
 // temporary settings (from Movie, Netplay, game INIs, etc.) to stick around.
 //
-// To avoid inconveniences in most cases, we accept changes that aren't being overriden by a
-// non-base layer, and restore only the overriden settings.
+// To avoid inconveniences in most cases, we accept changes that aren't being overridden by a
+// non-base layer, and restore only the overridden settings.
 static void RestoreSYSCONF()
 {
   // This layer contains the new SYSCONF settings (including any temporary settings).

--- a/Source/Core/Core/BootManager.h
+++ b/Source/Core/Core/BootManager.h
@@ -18,6 +18,6 @@ bool BootCore(Core::System& system, std::unique_ptr<BootParameters> parameters,
               const WindowSystemInfo& wsi);
 
 // Synchronise Dolphin's configuration with the SYSCONF (which may have changed during emulation),
-// and restore settings that were overriden by per-game INIs or for some other reason.
+// and restore settings that were overridden by per-game INIs or for some other reason.
 void RestoreConfig();
 }  // namespace BootManager

--- a/Source/Core/Core/Config/UISettings.h
+++ b/Source/Core/Core/Config/UISettings.h
@@ -5,7 +5,7 @@
 
 #include "Common/Config/Config.h"
 
-// This is a temporary soluation, although they should be in their repected cpp file in UICommon.
+// This is a temporary solution, although they should be in their respective cpp file in UICommon.
 // However, in order for IsSettingSaveable to compile without some issues, this needs to be here.
 // Once IsSettingSaveable is removed, then you should able to move these back to UICommon.
 

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -93,7 +93,7 @@ void CoreTimingManager::Init()
   m_globals.global_timer = 0;
   m_idled_cycles = 0;
 
-  // The time between CoreTiming being intialized and the first call to Advance() is considered
+  // The time between CoreTiming being initialized and the first call to Advance() is considered
   // the slice boundary between slice -1 and slice 0. Dispatcher loops must call Advance() before
   // executing the first PPC cycle of each slice to prepare the slice length and downcount for
   // that slice.

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -177,7 +177,7 @@ private:
   // STATE_TO_SAVE
   // The queue is a min-heap using std::ranges::make_heap/push_heap/pop_heap.
   // We don't use std::priority_queue because we need to be able to serialize, unserialize and
-  // erase arbitrary events (RemoveEvent()) regardless of the queue order. These aren't accomodated
+  // erase arbitrary events (RemoveEvent()) regardless of the queue order. These aren't accommodated
   // by the standard adaptor class.
   std::vector<Event> m_event_queue;
   u64 m_event_fifo_id = 0;

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -296,7 +296,7 @@ void DolphinAnalytics::MakeBaseBuilder()
       s64 minor_version;  // NSInteger minorVersion
       s64 patch_version;  // NSInteger patchVersion
     };
-    // Under arm64, we need to call objc_msgSend to recieve a struct.
+    // Under arm64, we need to call objc_msgSend to receive a struct.
     // On x86_64, we need to explicitly call objc_msgSend_stret for a struct.
 #ifdef _M_ARM_64
 #define msgSend objc_msgSend

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -158,7 +158,7 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
       return;
     }
 
-    // Update time in milliseconds of no acknoledgment of
+    // Update time in milliseconds of no acknowledgment of
     // sent packets before a connection is deemed disconnected
     enet_peer_timeout(m_server, 0, PEER_TIMEOUT.count(), PEER_TIMEOUT.count());
 
@@ -221,7 +221,7 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
         case ENET_EVENT_TYPE_CONNECT:
           m_server = netEvent.peer;
 
-          // Update time in milliseconds of no acknoledgment of
+          // Update time in milliseconds of no acknowledgment of
           // sent packets before a connection is deemed disconnected
           enet_peer_timeout(m_server, 0, PEER_TIMEOUT.count(), PEER_TIMEOUT.count());
 
@@ -1303,7 +1303,7 @@ void NetPlayClient::OnSyncSaveDataGBA(sf::Packet& packet)
 
 void NetPlayClient::OnSyncCodes(sf::Packet& packet)
 {
-  // Recieve Data Packet
+  // Receive Data Packet
   SyncCodeID sub_id;
   packet >> sub_id;
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -460,7 +460,7 @@ ConnectionError NetPlayServer::OnConnect(ENetPeer* incoming_connection, sf::Pack
   if (StringUTF8CodePointCount(new_player.name) > MAX_NAME_LENGTH)
     return ConnectionError::NameTooLong;
 
-  // Update time in milliseconds of no acknoledgment of
+  // Update time in milliseconds of no acknowledgment of
   // sent packets before a connection is deemed disconnected
   enet_peer_timeout(incoming_connection, 0, PEER_TIMEOUT.count(), PEER_TIMEOUT.count());
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "./Externals,./Data/Sys/wiitdb-??.txt,*.po,*.pot" -L andf,asnd,bootup,bufferin,clen,collet,datas,delt,fpr,inout,inport,interm,pixelx,re-use,re-used,sav,stateman,strat,wil`