### PR TITLE
Data: fix various typos

### DIFF
--- a/Data/Sys/GameSettings/F.ini
+++ b/Data/Sys/GameSettings/F.ini
@@ -9,9 +9,9 @@ SafeTextureCacheColorSamples = 0
 
 [Video_Hacks]
 # Some very early NES releases use a version of the NES emulator that doesn't require EFB2Ram.
-# All US releases before Feburary 2007 use this version (with all remaining US releases requiring EFB2Ram).
+# All US releases before February 2007 use this version (with all remaining US releases requiring EFB2Ram).
 # But in the PAL region the same games don't necessarily have the same emulator version and
-# only a few of the pre-Feburary 2007 releases don't require EFB2Ram.
+# only a few of the pre-February 2007 releases don't require EFB2Ram.
 #
 # Because of this, Inifiles that override this setting should only be created for the explicit region
 # that was tested and they should not be merged.

--- a/Data/Sys/GameSettings/FAAE01.ini
+++ b/Data/Sys/GameSettings/FAAE01.ini
@@ -1,5 +1,5 @@
 # FAAE01 - Donkey Kong
 
 [Video_Hacks]
-# All US NES VC titles released before Feburary 2007 don't need EFB2ram
+# All US NES VC titles released before February 2007 don't need EFB2ram
 EFBToTextureEnable = 

--- a/Data/Sys/GameSettings/FAGE01.ini
+++ b/Data/Sys/GameSettings/FAGE01.ini
@@ -1,5 +1,5 @@
 # FAGE01 - Super Mario Bros.
 
 [Video_Hacks]
-# All US NES VC titles released before Feburary 2007 don't need EFB2ram
+# All US NES VC titles released before February 2007 don't need EFB2ram
 EFBToTextureEnable = 

--- a/Data/Sys/GameSettings/GP6E01.ini
+++ b/Data/Sys/GameSettings/GP6E01.ini
@@ -968,7 +968,7 @@ $Minigame: Memory Lane - No Trail [Airsola]
 204d6a0f 00000000
 044d699f 0000003f
 e2000002 80008000
-*Shy Guy will no longer leave a trail durning the demo in the minigame Memory Lane.
+*Shy Guy will no longer leave a trail during the demo in the minigame Memory Lane.
 
 $Minigame: Mole It – All Moles are Worth 3 Points [gamemasterplc]
 204D57F0 A8A10008

--- a/Data/Sys/GameSettings/GP7E01.ini
+++ b/Data/Sys/GameSettings/GP7E01.ini
@@ -1164,7 +1164,7 @@ $Mechanics - Use Multiple Orbs in the Same Turn [Ralf]
 041E3764 3860FFFF
 *Does not work with CPUs
 
-$Mechanics - Vaccum Orb Always Steals 5 Coins
+$Mechanics - Vacuum Orb Always Steals 5 Coins
 041c8a34 38600005
 
 $Minigame: Balloonatic - 25 Second Timer [Airsola]

--- a/Data/Sys/GameSettings/GZ2E01.ini
+++ b/Data/Sys/GameSettings/GZ2E01.ini
@@ -362,7 +362,7 @@ $Can Walk Ontop of Deep Snow (Twilight Spectre)
 $Run Normal Speed With Iron Boots On (brkirch)
 040BB53C 38600000
 040B2D18 4800004C
-$Alywas Preform Dive When Jumping (brkirch)
+$Always Perform Dive When Jumping (brkirch)
 040B6618 60000000
 $Can Always Flourish Sword (brkirch)
 040B9B68 60000000
@@ -514,7 +514,7 @@ $Mute BG Music (Twilight Spectre)
 043DC3D0 00000000
 $BG music muted v2 (Twilight Spectre)
 044507F4 00000000
-$Enviornment muted (Twilight Spectre)
+$Environment muted (Twilight Spectre)
 04450814 00000000
 $Link makes no noise (Twilight Spectre)
 044507FC 00000000

--- a/Data/Sys/GameSettings/PZLE01.ini
+++ b/Data/Sys/GameSettings/PZLE01.ini
@@ -7,7 +7,7 @@
 # Add action replay cheats here.
 $==========The Legend of Zelda==========
 001D73B0 000000FB
-$Max/Infinte Health
+$Max/Infinite Health
 001D73AF 000000FF
 001D73B0 000000FB
 $Max/Infinite Rupees

--- a/Data/Sys/GameSettings/RLI.ini
+++ b/Data/Sys/GameSettings/RLI.ini
@@ -1,5 +1,5 @@
 # RLIE64, RLIP64 - Lego Indiana Jones: The Original Adventures
 
 [Video_Hacks]
-# Fixes the alpha value of glpyh puzzles; see https://bugs.dolphin-emu.org/issues/12987
+# Fixes the alpha value of glyph puzzles; see https://bugs.dolphin-emu.org/issues/12987
 MissingColorValue = 0xFFFFFF82

--- a/Data/Sys/GameSettings/RM8E01.ini
+++ b/Data/Sys/GameSettings/RM8E01.ini
@@ -542,7 +542,7 @@ de000000 80008180
 30012d2c 2c000000
 14012d54 38030000
 e0000000 80008000
-*Carry Infinite Boosts instad of 3 in the minigame Cosmic Slalom
+*Carry Infinite Boosts instead of 3 in the minigame Cosmic Slalom
 
 $Minigame - Lob to Rob: All Targets Worth 30 Points [gamemasterplc]
 48000000 800030c8

--- a/Data/Sys/Shaders/PerceptualHDR.glsl
+++ b/Data/Sys/Shaders/PerceptualHDR.glsl
@@ -106,14 +106,14 @@ void main()
     // scaling while also being able to use the luminance channel.
     float4 ictcp_color = LinearRGBToICtCP(color);
 
-    // Scale the color in perceptual space depending on the percieved luminance.
+    // Scale the color in perceptual space depending on the perceived luminance.
     //
     // At low luminances, ~0.0, pow(AMPLIFICATION, ~0.0) ~= 1.0, so the
     // color will appear to be unchanged. This is important as we don't want to
     // over expose dark colors which would not have otherwise been seen.
     //
     // At high luminances, ~1.0, pow(AMPLIFICATION, ~1.0) ~= AMPLIFICATION,
-    // which is equivilant to scaling the color by AMPLIFICATION. This is
+    // which is equivalent to scaling the color by AMPLIFICATION. This is
     // important as we want to get the most out of the display, and we want to
     // get bright colors to hit their target brightness.
     //

--- a/Data/Sys/Shaders/asciiart.glsl
+++ b/Data/Sys/Shaders/asciiart.glsl
@@ -391,7 +391,7 @@ bool supportsSIMD(uint simd_width)
 #endif
 }
 
-// "Error: The AsciiArt shader requires the missing GPU extention KHR_shader_subgroup."
+// "Error: The AsciiArt shader requires the missing GPU extension KHR_shader_subgroup."
 const uint missing_subgroup_warning_len = 82;
 const uint missing_subgroup_warning[missing_subgroup_warning_len] = {
     37, 82, 82, 79, 82, 26, 95, 52, 72, 69, 95, 33, 83, 67, 73, 73, 33, 82, 84, 95, 83,

--- a/Data/Sys/Shaders/default_pre_post_process.glsl
+++ b/Data/Sys/Shaders/default_pre_post_process.glsl
@@ -353,7 +353,7 @@ void main()
 		// Doing linear sampling in "gamma space" on linear texture formats isn't correct.
 		// If the source and target resolutions don't match, the GPU will return a color
 		// that is the average of 4 gamma space colors, but gamma space colors can't be blended together,
-		// gamma neeeds to be de-applied first. This makes a big difference if colors change
+		// gamma needs to be de-applied first. This makes a big difference if colors change
 		// drastically between two pixels.
 
 		color = LinearGammaCorrectedSample(game_gamma);

--- a/Data/Sys/Shaders/nightvision2.glsl
+++ b/Data/Sys/Shaders/nightvision2.glsl
@@ -40,7 +40,7 @@ void main()
 
 	/*****inline square root routines*****/
 	// bit of a performance bottleneck.
-	// neccessary to make the darkened area rounded
+	// necessary to make the darkened area rounded
 	// instead of rhombus-shaped.
 	float sqrt = x / 10.0;
 

--- a/Data/Sys/Shaders/nightvision2scanlines.glsl
+++ b/Data/Sys/Shaders/nightvision2scanlines.glsl
@@ -50,7 +50,7 @@ void main()
 
 	//****inline square root routines*****/
 	// bit of a performance bottleneck.
-	// neccessary to make the darkened area rounded
+	// necessary to make the darkened area rounded
 	// instead of rhombus-shaped.
 	float sqrt = x / 10.0;
 	while ((sqrt*sqrt) < x)


### PR DESCRIPTION
Found via `codespell -q 3 -S "./Externals,./Data/Sys/wiitdb-??.txt,*.po,*.pot" -L andf,asnd,bootup,brocken,bufferin,clen,collet,datas,delt,diety,extint,fpr,inout,inport,interm,nd,nin,ontop,pixelx,re-use,re-used,sav,stateman,strat,transer,wil`