### PR TITLE
DolphinAnalytics: Use Config::Get instead of accessing g_Config.

### DIFF
--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include "Core/Config/GraphicsSettings.h"
 
 #if defined(_WIN32)
 #include <Windows.h>
@@ -26,6 +27,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
 #include "Common/Crypto/SHA1.h"
+#include "Common/EnumUtils.h"
 #include "Common/Random.h"
 #include "Common/Timer.h"
 #include "Common/Version.h"
@@ -328,9 +330,9 @@ void DolphinAnalytics::MakeBaseBuilder()
   m_base_builder = builder;
 }
 
-static const char* GetShaderCompilationMode(const VideoConfig& video_config)
+static const char* GetShaderCompilationMode()
 {
-  switch (video_config.iShaderCompilationMode)
+  switch (Config::Get(Config::GFX_SHADER_COMPILATION_MODE))
   {
   case ShaderCompilationMode::AsynchronousUberShaders:
     return "async-ubershaders";
@@ -342,6 +344,11 @@ static const char* GetShaderCompilationMode(const VideoConfig& video_config)
   default:
     return "sync";
   }
+}
+
+static bool UseVertexRounding()
+{
+  return Config::Get(Config::GFX_HACK_VERTEX_ROUNDING) && Config::Get(Config::GFX_EFB_SCALE) != 1;
 }
 
 void DolphinAnalytics::MakePerGameBuilder()
@@ -371,34 +378,39 @@ void DolphinAnalytics::MakePerGameBuilder()
   }
 
   // Video configuration.
-  builder.AddData("cfg-gfx-multisamples", g_Config.iMultisamples);
-  builder.AddData("cfg-gfx-ssaa", g_Config.bSSAA);
-  builder.AddData("cfg-gfx-anisotropy", g_Config.iMaxAnisotropy);
-  builder.AddData("cfg-gfx-vsync", g_Config.bVSync);
-  builder.AddData("cfg-gfx-aspect-ratio", static_cast<int>(g_Config.aspect_mode));
-  builder.AddData("cfg-gfx-efb-access", g_Config.bEFBAccessEnable);
-  builder.AddData("cfg-gfx-efb-copy-format-changes", g_Config.bEFBEmulateFormatChanges);
-  builder.AddData("cfg-gfx-efb-copy-ram", !g_Config.bSkipEFBCopyToRam);
-  builder.AddData("cfg-gfx-xfb-copy-ram", !g_Config.bSkipXFBCopyToRam);
-  builder.AddData("cfg-gfx-defer-efb-copies", g_Config.bDeferEFBCopies);
-  builder.AddData("cfg-gfx-immediate-xfb", !g_Config.bImmediateXFB);
-  builder.AddData("cfg-gfx-efb-copy-scaled", g_Config.bCopyEFBScaled);
-  builder.AddData("cfg-gfx-internal-resolution", g_Config.iEFBScale);
-  builder.AddData("cfg-gfx-tc-samples", g_Config.iSafeTextureCache_ColorSamples);
-  builder.AddData("cfg-gfx-stereo-mode", static_cast<int>(g_Config.stereo_mode));
+  builder.AddData("cfg-gfx-multisamples", Config::Get(Config::GFX_MSAA));
+  builder.AddData("cfg-gfx-ssaa", Config::Get(Config::GFX_SSAA));
+  builder.AddData("cfg-gfx-anisotropy", Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY));
+  builder.AddData("cfg-gfx-vsync", Config::Get(Config::GFX_VSYNC));
+  builder.AddData("cfg-gfx-aspect-ratio",
+                  Common::ToUnderlying(Config::Get(Config::GFX_ASPECT_RATIO)));
+  builder.AddData("cfg-gfx-efb-access", Config::Get(Config::GFX_HACK_EFB_ACCESS_ENABLE));
+  builder.AddData("cfg-gfx-efb-copy-format-changes",
+                  Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES));
+  builder.AddData("cfg-gfx-efb-copy-ram", !Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM));
+  builder.AddData("cfg-gfx-xfb-copy-ram", !Config::Get(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM));
+  builder.AddData("cfg-gfx-defer-efb-copies", Config::Get(Config::GFX_HACK_DEFER_EFB_COPIES));
+  builder.AddData("cfg-gfx-immediate-xfb", !Config::Get(Config::GFX_HACK_IMMEDIATE_XFB));
+  builder.AddData("cfg-gfx-efb-copy-scaled", Config::Get(Config::GFX_HACK_COPY_EFB_SCALED));
+  builder.AddData("cfg-gfx-internal-resolution", Config::Get(Config::GFX_EFB_SCALE));
+  builder.AddData("cfg-gfx-tc-samples", Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES));
+  builder.AddData("cfg-gfx-stereo-mode",
+                  Common::ToUnderlying(Config::Get(Config::GFX_STEREO_MODE)));
   builder.AddData("cfg-gfx-stereo-per-eye-resolution-full",
-                  g_Config.stereo_per_eye_resolution_full);
-  builder.AddData("cfg-gfx-hdr", static_cast<int>(g_Config.bHDR));
-  builder.AddData("cfg-gfx-per-pixel-lighting", g_Config.bEnablePixelLighting);
-  builder.AddData("cfg-gfx-shader-compilation-mode", GetShaderCompilationMode(g_Config));
-  builder.AddData("cfg-gfx-wait-for-shaders", g_Config.bWaitForShadersBeforeStarting);
-  builder.AddData("cfg-gfx-fast-depth", g_Config.bFastDepthCalc);
-  builder.AddData("cfg-gfx-vertex-rounding", g_Config.UseVertexRounding());
+                  Config::Get(Config::GFX_STEREO_PER_EYE_RESOLUTION_FULL));
+  builder.AddData("cfg-gfx-hdr", Config::Get(Config::GFX_ENHANCE_HDR_OUTPUT));
+  builder.AddData("cfg-gfx-per-pixel-lighting", Config::Get(Config::GFX_ENABLE_PIXEL_LIGHTING));
+  builder.AddData("cfg-gfx-shader-compilation-mode", GetShaderCompilationMode());
+  builder.AddData("cfg-gfx-wait-for-shaders",
+                  Config::Get(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING));
+  builder.AddData("cfg-gfx-fast-depth", Config::Get(Config::GFX_FAST_DEPTH_CALC));
+  builder.AddData("cfg-gfx-vertex-rounding", UseVertexRounding());
 
   // GPU features.
-  if (g_Config.iAdapter < static_cast<int>(g_backend_info.Adapters.size()))
+  const int adapter_index = Config::Get(Config::GFX_ADAPTER);
+  if (adapter_index < static_cast<int>(g_backend_info.Adapters.size()))
   {
-    builder.AddData("gpu-adapter", g_backend_info.Adapters[g_Config.iAdapter]);
+    builder.AddData("gpu-adapter", g_backend_info.Adapters[adapter_index]);
   }
   else if (!g_backend_info.AdapterName.empty())
   {


### PR DESCRIPTION
Some progress at eliminating usage of `g_Config`.

Questions:
I've changed "cfg-gfx-hdr" from an `int` to a `bool`. Will that break analytics? Should I change it back to `int`?
Why is the value of "cfg-gfx-immediate-xfb" inverted with `!` ?