### PR TITLE
Movie: Eliminate MovieManager::SetGraphicsConfig.

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -67,7 +67,6 @@
 #include "InputCommon/GCPadStatus.h"
 
 #include "VideoCommon/VideoBackendBase.h"
-#include "VideoCommon/VideoConfig.h"
 
 namespace Movie
 {
@@ -1406,16 +1405,6 @@ void MovieManager::SaveRecording(const std::string& filename)
     Core::DisplayMessage(fmt::format("DTM {} saved", filename), 2000);
   else
     Core::DisplayMessage(fmt::format("Failed to save {}", filename), 2000);
-}
-
-// NOTE: GPU Thread
-void MovieManager::SetGraphicsConfig()
-{
-  g_Config.bEFBAccessEnable = m_temp_header.bEFBAccessEnable;
-  g_Config.bSkipEFBCopyToRam = m_temp_header.bSkipEFBCopyToRam;
-  g_Config.bEFBEmulateFormatChanges = m_temp_header.bEFBEmulateFormatChanges;
-  g_Config.bImmediateXFB = m_temp_header.bImmediateXFB;
-  g_Config.bSkipXFBCopyToRam = m_temp_header.bSkipXFBCopyToRam;
 }
 
 // NOTE: EmuThread / Host Thread

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -192,7 +192,6 @@ public:
   bool IsConfigSaved() const;
   bool IsStartingFromClearSave() const;
   bool IsUsingMemcard(ExpansionInterface::Slot slot) const;
-  void SetGraphicsConfig();
   bool IsNetPlayRecording() const;
 
   bool IsUsingPad(int controller) const;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -44,9 +44,6 @@ static bool IsVSyncActive(bool enabled)
 
 void UpdateActiveConfig()
 {
-  auto& movie = Core::System::GetInstance().GetMovie();
-  if (movie.IsPlayingInput() && movie.IsConfigSaved())
-    movie.SetGraphicsConfig();
   g_ActiveConfig = g_Config;
   g_ActiveConfig.bVSyncActive = IsVSyncActive(g_ActiveConfig.bVSync);
 }


### PR DESCRIPTION
More VideoConfig cleanups.

`MovieManager::SetGraphicsConfig` isn't needed. This stuff is already handled by `MovieConfigLayerLoader`:
https://github.com/dolphin-emu/dolphin/blob/5ed8b7bc9d8f70d5dae4f009939ac9715adf83b4/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp#L46