### PR TITLE
VideoConfig: Eliminate bForceProgressive.

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -783,7 +783,8 @@ void VideoInterfaceManager::OutputField(FieldType field, u64 ticks)
   // Multiply the stride by 2 to get the byte offset for each subsequent line.
   fbStride *= 2;
 
-  if (potentially_interlaced_xfb && interlaced_video_mode && g_ActiveConfig.bForceProgressive)
+  if (potentially_interlaced_xfb && interlaced_video_mode &&
+      Config::Get(Config::GFX_HACK_FORCE_PROGRESSIVE))
   {
     // Strictly speaking, in interlaced mode, we're only supposed to read
     // half of the lines of the XFB, and use that to display a field; the

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -179,7 +179,6 @@ void VideoConfig::Refresh()
   bEFBAccessEnable = Config::Get(Config::GFX_HACK_EFB_ACCESS_ENABLE);
   bEFBAccessDeferInvalidation = Config::Get(Config::GFX_HACK_EFB_DEFER_INVALIDATION);
   bBBoxEnable = Config::Get(Config::GFX_HACK_BBOX_ENABLE);
-  bForceProgressive = Config::Get(Config::GFX_HACK_FORCE_PROGRESSIVE);
   bSkipEFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);
   bSkipXFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM);
   bDisableCopyToVRAM = Config::Get(Config::GFX_HACK_DISABLE_COPY_TO_VRAM);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -281,7 +281,6 @@ struct VideoConfig final
   bool bEFBAccessDeferInvalidation = false;
   bool bPerfQueriesEnable = false;
   bool bBBoxEnable = false;
-  bool bForceProgressive = false;
   bool bCPUCull = false;
 
   bool bEFBEmulateFormatChanges = false;


### PR DESCRIPTION
This value was only used by `VideoInterfaceManager::OutputField` (CPU Thread). It doesn't need to exist in `VideoConfig`.