### PR TITLE
VideoConfig: Eliminate frame dumping members.

### DIFF
--- a/Source/Core/VideoCommon/FrameDumper.cpp
+++ b/Source/Core/VideoCommon/FrameDumper.cpp
@@ -16,7 +16,6 @@
 #include "VideoCommon/AbstractTexture.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/Present.h"
-#include "VideoCommon/VideoConfig.h"
 
 // The video encoder needs the image to be a multiple of x samples.
 static constexpr int VIDEO_ENCODER_LCM = 4;
@@ -201,7 +200,7 @@ void FrameDumper::FrameDumpThreadFunc()
 {
   Common::SetCurrentThreadName("FrameDumping");
 
-  bool dump_to_ffmpeg = !g_ActiveConfig.bDumpFramesAsImages;
+  bool dump_to_ffmpeg = !Config::Get(Config::GFX_DUMP_FRAMES_AS_IMAGES);
   bool frame_dump_started = false;
 
 // If Dolphin was compiled without ffmpeg, we only support dumping to images.

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -229,7 +229,7 @@ void Presenter::ProcessFrameDumping(u64 ticks) const
   if (g_frame_dumper->IsFrameDumping() && m_xfb_entry)
   {
     MathUtil::Rectangle<int> target_rect;
-    switch (g_ActiveConfig.frame_dumps_resolution_type)
+    switch (Config::Get(Config::GFX_FRAME_DUMPS_RESOLUTION_TYPE))
     {
     default:
     case FrameDumpResolutionType::WindowResolution:

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -112,15 +112,6 @@ void VideoConfig::Refresh()
   bCacheHiresTextures = Config::Get(Config::GFX_CACHE_HIRES_TEXTURES);
   bDumpEFBTarget = Config::Get(Config::GFX_DUMP_EFB_TARGET);
   bDumpXFBTarget = Config::Get(Config::GFX_DUMP_XFB_TARGET);
-  bDumpFramesAsImages = Config::Get(Config::GFX_DUMP_FRAMES_AS_IMAGES);
-  bUseLossless = Config::Get(Config::GFX_USE_LOSSLESS);
-  sDumpFormat = Config::Get(Config::GFX_DUMP_FORMAT);
-  sDumpCodec = Config::Get(Config::GFX_DUMP_CODEC);
-  sDumpPixelFormat = Config::Get(Config::GFX_DUMP_PIXEL_FORMAT);
-  sDumpEncoder = Config::Get(Config::GFX_DUMP_ENCODER);
-  sDumpPath = Config::Get(Config::GFX_DUMP_PATH);
-  iBitrateKbps = Config::Get(Config::GFX_BITRATE_KBPS);
-  frame_dumps_resolution_type = Config::Get(Config::GFX_FRAME_DUMPS_RESOLUTION_TYPE);
   bEnableGPUTextureDecoding = Config::Get(Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
   bPreferVSForLinePointExpansion = Config::Get(Config::GFX_PREFER_VS_FOR_LINE_POINT_EXPANSION);
   bEnablePixelLighting = Config::Get(Config::GFX_ENABLE_PIXEL_LIGHTING);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -258,19 +258,9 @@ struct VideoConfig final
   bool bCacheHiresTextures = false;
   bool bDumpEFBTarget = false;
   bool bDumpXFBTarget = false;
-  bool bDumpFramesAsImages = false;
-  bool bUseLossless = false;
-  std::string sDumpCodec;
-  std::string sDumpPixelFormat;
-  std::string sDumpEncoder;
-  std::string sDumpFormat;
-  std::string sDumpPath;
-  FrameDumpResolutionType frame_dumps_resolution_type =
-      FrameDumpResolutionType::XFBAspectRatioCorrectedResolution;
   bool bBorderlessFullscreen = false;
   bool bEnableGPUTextureDecoding = false;
   bool bPreferVSForLinePointExpansion = false;
-  int iBitrateKbps = 0;
   bool bGraphicMods = false;
   std::optional<GraphicsModGroupConfig> graphics_mod_config;
 


### PR DESCRIPTION
These don't need to be in `VideoConfig`.