### PR TITLE
VideoConfig: Eliminate the widescreen hack adjustment values.

### DIFF
--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -19,6 +19,7 @@
 #include "VideoCommon/PostProcessing.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexManagerBase.h"
+#include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/VideoEvents.h"
 #include "VideoCommon/Widescreen.h"
@@ -622,8 +623,7 @@ void Presenter::UpdateDrawRectangle()
   const float draw_aspect_ratio = CalculateDrawAspectRatio();
 
   // Update aspect ratio hack values
-  // Won't take effect until next frame
-  // Don't know if there is a better place for this code so there isn't a 1 frame delay
+  auto& system = Core::System::GetInstance();
   if (g_ActiveConfig.bWidescreenHack)
   {
     const auto& vi = Core::System::GetInstance().GetVideoInterface();
@@ -634,24 +634,12 @@ void Presenter::UpdateDrawRectangle()
       source_aspect_ratio = SourceAspectRatioToWidescreen(source_aspect_ratio);
 
     const float adjust = source_aspect_ratio / draw_aspect_ratio;
-    if (adjust > 1)
-    {
-      // Vert+
-      g_Config.fAspectRatioHackW = 1;
-      g_Config.fAspectRatioHackH = 1 / adjust;
-    }
-    else
-    {
-      // Hor+
-      g_Config.fAspectRatioHackW = adjust;
-      g_Config.fAspectRatioHackH = 1;
-    }
+    system.GetVertexShaderManager().SetAspectRatioHack(adjust);
   }
   else
   {
     // Hack is disabled.
-    g_Config.fAspectRatioHackW = 1;
-    g_Config.fAspectRatioHackH = 1;
+    system.GetVertexShaderManager().SetAspectRatioHack(1.f);
   }
 
   // The rendering window size

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -4,10 +4,10 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <string>
 #include <vector>
 
-#include "Common/BitSet.h"
 #include "Common/CommonTypes.h"
 #include "Common/Matrix.h"
 #include "VideoCommon/ConstantManager.h"
@@ -78,6 +78,8 @@ public:
     UpdateOffsets(&dirty, false, &constants.vertex_offset_normals, format.normals);
   }
 
+  void SetAspectRatioHack(float adjustment);
+
 private:
   alignas(16) std::array<float, 16> m_projection_matrix;
 
@@ -87,4 +89,6 @@ private:
   Common::Matrix44 m_viewport_correction{};
 
   Common::Matrix44 LoadProjectionMatrix();
+
+  std::atomic<float> m_aspect_ratio_hack = 1.f;
 };

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -293,8 +293,6 @@ struct VideoConfig final
   bool bSkipPresentingDuplicateXFBs = false;
   bool bCopyEFBScaled = false;
   int iSafeTextureCache_ColorSamples = 0;
-  float fAspectRatioHackW = 1;  // Initial value needed for the first frame
-  float fAspectRatioHackH = 1;
   bool bEnablePixelLighting = false;
   bool bFastDepthCalc = false;
   bool bVertexRounding = false;


### PR DESCRIPTION
These don't need to be in `VideoConfig`.