### PR TITLE
Core/Common: Fix typos

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -2019,7 +2019,7 @@ void ARM64XEmitter::ABI_PushRegisters(BitSet32 registers)
   if (!num_regs)
     return;
 
-  // 8 byte per register, but 16 byte alignment, so we may have to padd one register.
+  // 8 byte per register, but 16 byte alignment, so we may have to pad one register.
   // Only update the SP on the last write to avoid the dependency between those stores.
 
   // The first push must adjust the SP, else a context switch may invalidate everything below SP.
@@ -2062,7 +2062,7 @@ void ARM64XEmitter::ABI_PopRegisters(BitSet32 registers, BitSet32 ignore_mask)
   else
     second = {};
 
-  // 8 byte per register, but 16 byte alignment, so we may have to padd one register.
+  // 8 byte per register, but 16 byte alignment, so we may have to pad one register.
   // Only update the SP on the last load to avoid the dependency between those loads.
 
   // Fast load for all but the first (two) registers, this is always an even number.
@@ -2904,7 +2904,7 @@ void ARM64FloatEmitter::ST1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM6
 {
   ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "Must have a count of 1 to 4 registers! ({})",
              count);
-  ASSERT_MSG(DYNA_REC, type == IndexType::Post, "Only post indexing is supporte!");
+  ASSERT_MSG(DYNA_REC, type == IndexType::Post, "Only post indexing is supported!");
 
   u32 opcode = 0;
   if (count == 1)

--- a/Source/Core/Common/Assembler/GekkoLexer.cpp
+++ b/Source/Core/Common/Assembler/GekkoLexer.cpp
@@ -616,7 +616,7 @@ const Lexer& Lexer::Step() const
 
 TokenType Lexer::LexStringLit(std::string_view& invalid_reason, Interval& invalid_region) const
 {
-  // The open quote has alread been matched
+  // The open quote has already been matched
   const size_t string_start = m_scan_pos.index - 1;
   TokenType token_type = TokenType::StringLit;
 

--- a/Source/Core/Common/CompatPatches.cpp
+++ b/Source/Core/Common/CompatPatches.cpp
@@ -197,7 +197,7 @@ static bool GetModuleVersion(const wchar_t* name, Version* version)
 void CompatPatchesInstall(LdrWatcher* watcher)
 {
   watcher->Install({{L"EZFRD64.dll", L"811EZFRD64.DLL"}, [](const LdrDllLoadEvent& event) {
-                      // *EZFRD64 is incldued in software packages for cheapo third-party gamepads
+                      // *EZFRD64 is included in software packages for cheapo third-party gamepads
                       // (and gamepad adapters). The module cannot handle its heap being above 4GB,
                       // which tends to happen very often on modern Windows.
                       // NOTE: The patch will always be applied, but it will only actually avoid the
@@ -209,7 +209,7 @@ void CompatPatchesInstall(LdrWatcher* watcher)
   watcher->Install(
       {{L"ucrtbase.dll"}, [](const LdrDllLoadEvent& event) {
          // ucrtbase implements caching between fseek/fread, old versions have a bug
-         // such that some reads return incorrect data. This causes noticable bugs
+         // such that some reads return incorrect data. This causes noticeable bugs
          // in dolphin since we use these APIs for reading game images.
          Version version;
          if (!GetModuleVersion(event.name.c_str(), &version))

--- a/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
@@ -2404,7 +2404,7 @@ static void InitExtensionList(GLContext* context)
     case 100:
       break;
     }
-    // So we can easily determine if we are running dekstop GL
+    // So we can easily determine if we are running desktop GL
     s_extension_list["VERSION_GL"] = true;
   }
 

--- a/Source/Core/Common/Intrinsics.h
+++ b/Source/Core/Common/Intrinsics.h
@@ -22,7 +22,7 @@
  * when not supported.
  *
  * When building with -march=native, or enabling the instruction sets in the compile flags, permit
- * usage of the instrinsics without any function attributes. If the command-line architecture does
+ * usage of the intrinsics without any function attributes. If the command-line architecture does
  * not support this instruction set, enable it via function targeting.
  */
 

--- a/Source/Core/Common/Matrix.h
+++ b/Source/Core/Common/Matrix.h
@@ -348,7 +348,7 @@ public:
   static Quaternion RotateY(float rad);
   static Quaternion RotateZ(float rad);
 
-  // Returns a quaternion with rotations about each axis simulatenously (e.g processing gyroscope
+  // Returns a quaternion with rotations about each axis simultaneously (e.g processing gyroscope
   // input)
   static Quaternion RotateXYZ(const Vec3& rads);
 

--- a/Source/Core/Common/TraversalProto.h
+++ b/Source/Core/Common/TraversalProto.h
@@ -31,7 +31,7 @@ enum class TraversalPacketType : u8
   ConnectReady = 6,
   // [s->c] Alternately, the server might not have heard of this host.
   ConnectFailed = 7,
-  // [c->s] Perform a traveral test. This will send two acks:
+  // [c->s] Perform a traversal test. This will send two acks:
   // one via the server's alt port, and one to the address corresponding to
   // the given host ID.
   TestPlease = 8,

--- a/Source/Core/Common/WindowSystemInfo.h
+++ b/Source/Core/Common/WindowSystemInfo.h
@@ -37,7 +37,7 @@ struct WindowSystemInfo
   void* render_window = nullptr;
 
   // Render surface. Depending on the host platform, this may differ from the window.
-  // This is kept seperate as input may require a different handle to rendering, and
+  // This is kept separate as input may require a different handle to rendering, and
   // during video backend startup the surface pointer may change (MoltenVK).
   void* render_surface = nullptr;
 

--- a/Source/Core/Common/x64ABI.h
+++ b/Source/Core/Common/x64ABI.h
@@ -7,7 +7,7 @@
 #include "Common/x64Reg.h"
 
 // x64 ABI:s, and helpers to help follow them when JIT-ing code.
-// All convensions return values in EAX (+ possibly EDX).
+// All conventions return values in EAX (+ possibly EDX).
 
 // Windows 64-bit
 // * 4-reg "fastcall" variant, very new-skool stack handling


### PR DESCRIPTION
Found via `codespell -q 3 -S "./Externals,./Data/Sys/wiitdb-??.txt,*.po,*.pot" -L andf,asnd,bootup,brocken,bufferin,clen,collet,datas,delt,diety,extint,fpr,inout,inport,interm,nd,nin,ontop,pixelx,re-use,re-used,sav,stateman,strat,transer,wil`