### PR TITLE
Core: Make EmuThread spawn a GPU thread and become the CPU thread in dual-core mode.

### DIFF
--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -61,9 +61,6 @@ void AsyncRequests::PushEvent(const AsyncRequests::Event& event, bool blocking)
   m_empty.Clear();
   m_wake_me_up_again |= blocking;
 
-  if (!m_enable)
-    return;
-
   m_queue.push(event);
 
   auto& system = Core::System::GetInstance();
@@ -78,21 +75,6 @@ void AsyncRequests::WaitForEmptyQueue()
 {
   std::unique_lock<std::mutex> lock(m_mutex);
   m_cond.wait(lock, [this] { return m_queue.empty(); });
-}
-
-void AsyncRequests::SetEnable(bool enable)
-{
-  std::unique_lock<std::mutex> lock(m_mutex);
-  m_enable = enable;
-
-  if (!enable)
-  {
-    // flush the queue on disabling
-    while (!m_queue.empty())
-      m_queue.pop();
-    if (m_wake_me_up_again)
-      m_cond.notify_all();
-  }
 }
 
 void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -86,7 +86,6 @@ public:
   }
   void PushEvent(const Event& event, bool blocking = false);
   void WaitForEmptyQueue();
-  void SetEnable(bool enable);
   void SetPassthrough(bool enable);
 
   static AsyncRequests* GetInstance() { return &s_singleton; }
@@ -103,6 +102,5 @@ private:
   std::condition_variable m_cond;
 
   bool m_wake_me_up_again = false;
-  bool m_enable = false;
   bool m_passthrough = true;
 };

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -287,9 +287,6 @@ void FifoManager::ResetVideoBuffer()
 // Purpose: Keep the Core HW updated about the CPU-GPU distance
 void FifoManager::RunGpuLoop()
 {
-  AsyncRequests::GetInstance()->SetEnable(true);
-  AsyncRequests::GetInstance()->SetPassthrough(false);
-
   m_gpu_mainloop.Run(
       [this] {
         // Run events from the CPU thread.
@@ -391,9 +388,6 @@ void FifoManager::RunGpuLoop()
         }
       },
       100);
-
-  AsyncRequests::GetInstance()->SetEnable(false);
-  AsyncRequests::GetInstance()->SetPassthrough(true);
 }
 
 void FifoManager::FlushGpu()


### PR DESCRIPTION
This makes EmuThread spawn a GPU-thread and become the CPU-thread in dual-core mode, which is the opposite of before.

Maybe there's something I'm missing, but it seems way less hacky for CPU-thread to complete first and then wait for the GPU-thread to finish.

And the code is just less weird in general when EmuThread is the CPU-thread in both single and dual-core mode.