### PR TITLE
DolphinQt: Use tooltips on Advanced tab.

### DIFF
--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -35,15 +35,15 @@ private:
   ConfigBool* m_enable_mmu_checkbox;
   ConfigBool* m_pause_on_panic_checkbox;
   ConfigBool* m_accurate_cpu_cache_checkbox;
-  QCheckBox* m_cpu_clock_override_checkbox;
+  ConfigBool* m_cpu_clock_override_checkbox;
   QSlider* m_cpu_clock_override_slider;
   QLabel* m_cpu_clock_override_slider_label;
   QLabel* m_cpu_clock_override_description;
 
-  QCheckBox* m_custom_rtc_checkbox;
+  ConfigBool* m_custom_rtc_checkbox;
   QDateTimeEdit* m_custom_rtc_datetime;
 
-  QCheckBox* m_ram_override_checkbox;
+  ConfigBool* m_ram_override_checkbox;
   QSlider* m_mem1_override_slider;
   QLabel* m_mem1_override_slider_label;
   QSlider* m_mem2_override_slider;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ac9c31cc-778c-4b01-9f42-e07abcb6f74f)
![image](https://github.com/user-attachments/assets/d9b0a055-c743-4688-bde0-d4b09c86ffe0)

That tab was getting too tall.

The warnings are less visible, but I'm not so sure they worked anyways?