### PR TITLE
AudioCommon: Increased Granule Synthesis Performance

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.kt
@@ -32,6 +32,7 @@ enum class IntSetting(
     MAIN_SI_DEVICE_2(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SIDevice2", 0),
     MAIN_SI_DEVICE_3(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SIDevice3", 0),
     MAIN_AUDIO_VOLUME(Settings.FILE_DOLPHIN, Settings.SECTION_INI_DSP, "Volume", 100),
+    MAIN_AUDIO_BUFFER_SIZE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_DSP, "AudioBufferSize", 80),
     MAIN_OVERLAY_GC_CONTROLLER(
         Settings.FILE_DOLPHIN,
         Settings.SECTION_INI_ANDROID,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -532,6 +532,18 @@ class SettingsFragmentPresenter(
             )
         )
         sl.add(
+            IntSliderSetting(
+                context,
+                IntSetting.MAIN_AUDIO_BUFFER_SIZE,
+                R.string.audio_buffer_size,
+                R.string.audio_buffer_size_description,
+                16,
+                512,
+                "ms",
+                8
+            )
+        )
+        sl.add(
             SwitchSetting(
                 context,
                 BooleanSetting.MAIN_AUDIO_FILL_GAPS,

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -183,6 +183,8 @@
     <!-- Audio Settings -->
     <string name="audio_submenu">Audio</string>
     <string name="dsp_emulation_engine">DSP Emulation Engine</string>
+    <string name="audio_buffer_size">Audio Buffer Size</string>
+    <string name="audio_buffer_size_description">Controls the number of audio samples buffered. Lower values reduce latency but may cause more crackling or stuttering. If unsure, set this to 80 ms.</string>
     <string name="audio_fill_gaps">Fill Audio Gaps</string>
     <string name="audio_fill_gaps_description">Repeat existing audio during lag spikes to prevent stuttering. If unsure, leave this checked.</string>
     <string name="audio_volume">Audio Volume</string>

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -56,6 +56,7 @@ const Info<bool> MAIN_DPL2_DECODER{{System::Main, "Core", "DPL2Decoder"}, false}
 const Info<AudioCommon::DPL2Quality> MAIN_DPL2_QUALITY{{System::Main, "Core", "DPL2Quality"},
                                                        AudioCommon::GetDefaultDPL2Quality()};
 const Info<int> MAIN_AUDIO_LATENCY{{System::Main, "Core", "AudioLatency"}, 20};
+const Info<int> MAIN_AUDIO_BUFFER_SIZE{{System::Main, "Core", "AudioBufferSize"}, 80};
 const Info<bool> MAIN_AUDIO_FILL_GAPS{{System::Main, "Core", "AudioFillGaps"}, true};
 const Info<std::string> MAIN_MEMCARD_A_PATH{{System::Main, "Core", "MemcardAPath"}, ""};
 const Info<std::string> MAIN_MEMCARD_B_PATH{{System::Main, "Core", "MemcardBPath"}, ""};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -72,6 +72,7 @@ extern const Info<bool> MAIN_OVERRIDE_REGION_SETTINGS;
 extern const Info<bool> MAIN_DPL2_DECODER;
 extern const Info<AudioCommon::DPL2Quality> MAIN_DPL2_QUALITY;
 extern const Info<int> MAIN_AUDIO_LATENCY;
+extern const Info<int> MAIN_AUDIO_BUFFER_SIZE;
 extern const Info<bool> MAIN_AUDIO_FILL_GAPS;
 extern const Info<std::string> MAIN_MEMCARD_A_PATH;
 extern const Info<std::string> MAIN_MEMCARD_B_PATH;

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -126,23 +126,53 @@ void AudioPane::CreateWidgets()
 
   dsp_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
-  auto* misc_box = new QGroupBox(tr("Miscellaneous Settings"));
-  auto* misc_layout = new QGridLayout;
-  misc_box->setLayout(misc_layout);
+  auto* playback_box = new QGroupBox(tr("Audio Playback Settings"));
+  auto* playback_layout = new QGridLayout;
+  playback_box->setLayout(playback_layout);
+
+  ConfigSlider* audio_buffer_size = new ConfigSlider(16, 512, Config::MAIN_AUDIO_BUFFER_SIZE, 8);
+  QLabel* audio_buffer_size_label = new QLabel;
+
+  audio_buffer_size->setSingleStep(8);
+  audio_buffer_size->setPageStep(8);
+
+  audio_buffer_size->SetDescription(
+      tr("Controls the number of audio samples buffered."
+         " Lower values reduce latency but may cause more crackling or stuttering."
+         "<br><br><dolphin_emphasis>If unsure, set this to 80 ms.</dolphin_emphasis>"));
+
+  // Connect the slider to update the value label live
+  connect(audio_buffer_size, &QSlider::valueChanged, this, [=](int value) {
+    int stepped_value = (value / 8) * 8;
+    audio_buffer_size->setValue(stepped_value);
+    audio_buffer_size_label->setText(tr("%1 ms").arg(stepped_value));
+  });
+
+  // Set initial value display
+  audio_buffer_size_label->setText(tr("%1 ms").arg(audio_buffer_size->value()));
 
   m_audio_fill_gaps = new ConfigBool(tr("Fill Audio Gaps"), Config::MAIN_AUDIO_FILL_GAPS);
 
   m_speed_up_mute_enable = new ConfigBool(tr("Mute When Disabling Speed Limit"),
                                           Config::MAIN_AUDIO_MUTE_ON_DISABLED_SPEED_LIMIT);
 
-  misc_layout->addWidget(m_audio_fill_gaps, 0, 0, 1, 1);
-  misc_layout->addWidget(m_speed_up_mute_enable, 1, 0, 1, 1);
+  // Create a horizontal layout for the slider + value label
+  auto* buffer_layout = new QHBoxLayout;
+  buffer_layout->addWidget(new ConfigSliderLabel(tr("Audio Buffer Size:"), audio_buffer_size));
+  buffer_layout->addWidget(audio_buffer_size);
+  buffer_layout->addWidget(audio_buffer_size_label);
+
+  playback_layout->addLayout(buffer_layout, 0, 0);
+  playback_layout->addWidget(m_audio_fill_gaps, 1, 0);
+  playback_layout->addWidget(m_speed_up_mute_enable, 2, 0);
+  playback_layout->setRowStretch(3, 1);
+  playback_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
   auto* const main_vbox_layout = new QVBoxLayout;
 
   main_vbox_layout->addWidget(dsp_box);
   main_vbox_layout->addWidget(backend_box);
-  main_vbox_layout->addWidget(misc_box);
+  main_vbox_layout->addWidget(playback_box);
 
   m_main_layout = new QHBoxLayout;
   m_main_layout->addLayout(main_vbox_layout);


### PR DESCRIPTION
- Replace a lot of the granule copying either reusing buffers or writing directly into granules when updating.
- All Jumping and Looping is handled on one thread, allowing the other thread to handle just pushing audio. This removes a possibility of an extremely rare race condition, and allows extremely small buffer sizes to play back more smoothly. 
- Previous change makes it significantly more likely to play nicely with VBI Skip.
- Adds Audio Buffer Size option to allow users to choose between latency and smoothness

<img width="628" alt="image" src="https://github.com/user-attachments/assets/ffa58eec-8310-497b-b6dd-4028e54f8904" />


This also potentially helps very low end android devices.