### PR TITLE
Fix performance statistics when Skip Duplicate Frames is turned off.

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -857,10 +857,11 @@ void RunOnCPUThread(Core::System& system, std::function<void()> function, bool w
 // Called from Renderer::Swap (GPU thread) when a frame is presented to the host screen.
 void Callback_FramePresented(const PresentInfo& present_info)
 {
+  g_perf_metrics.CountFrame();
+
   if (present_info.reason == PresentInfo::PresentReason::VideoInterfaceDuplicate)
     return;
 
-  g_perf_metrics.CountFrame();
   s_stop_frame_step.store(true);
 }
 


### PR DESCRIPTION
Prior to this, when `Skip Presenting Duplicate Frames` was turned off, `PerformanceMetrics` would still "skip" duplicate XFBs.

Now, when `Skip Presenting Duplicate Frames` is turned off, performance statistics show the full frame rate.
The default state with `Skip Presenting Duplicate Frames` turned on is unchanged.

In this new state, Luigi's Mansion (a "30fps" game) no longer appears to have terrible frame pacing.
I think it was just a symptom of the duplicate XFB logic not being an absolutely perfect way to detect a duplicate frame.
![image](https://github.com/user-attachments/assets/55d03b3d-c6c7-43f5-b85d-e3ada42b509d)

I'll mention that frame stepping still has the same old logic. "Duplicate" XFBs are skipped even if `Skip Presenting Duplicate Frames` is turned off. Is that really desirable? I would think it should stop on any presented field?