### PR TITLE
Contributing.md: Replace egrep with grep -E in clang-format command.

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -49,7 +49,7 @@ In most cases, clang-format can and **should** be used to automatically reformat
 
 - To run clang-format on all staged files:
   ```
-  git diff --cached --name-only | egrep '[.](cpp|h|mm)$' | xargs clang-format -i
+  git diff --cached --name-only | grep -E '[.](cpp|h|mm)$' | xargs -I {} clang-format -i {}
   ```
 
 - Formatting issues can be checked for before committing with a lint script that is included with the codebase. To enable it as a pre-commit hook (assuming you are in the repository root):


### PR DESCRIPTION
Fixes the following error in the clang-format command for all staged files:

```
git diff --cached --name-only | egrep '[.](cpp|h|mm)$' | xargs clang-format -i
egrep: warning: egrep is obsolescent; using grep -E
error: cannot use -i when reading from stdin.
```