### PR TITLE
WiimoteEmu: Make TaTaCon DesiredState use only one byte of space.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
@@ -7,14 +7,12 @@
 #include <cstring>
 
 #include "Common/Assert.h"
-#include "Common/BitUtils.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/HW/WiimoteEmu/Extension/DesiredExtensionState.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
-#include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 
 namespace WiimoteEmu
@@ -54,20 +52,24 @@ TaTaCon::TaTaCon() : Extension3rdParty("TaTaCon", _trans("Taiko Drum"))
 
 void TaTaCon::BuildDesiredExtensionState(DesiredExtensionState* target_state)
 {
-  DataFormat tatacon_data = {};
+  DesiredState tatacon_data = {};
 
   m_center->GetState(&tatacon_data.state, center_bitmasks.data(), m_input_override_function);
   m_rim->GetState(&tatacon_data.state, rim_bitmasks.data(), m_input_override_function);
-
-  // Flip button bits.
-  tatacon_data.state ^= 0xff;
 
   target_state->data = tatacon_data;
 }
 
 void TaTaCon::Update(const DesiredExtensionState& target_state)
 {
-  DefaultExtensionUpdate<DataFormat>(&m_reg, target_state);
+  DesiredState desired_state{};
+  if (std::holds_alternative<DesiredState>(target_state.data))
+    desired_state = std::get<DesiredState>(target_state.data);
+
+  // Flip button bits.
+  desired_state.state ^= 0xff;
+
+  m_reg.controller_data[5] = desired_state.state;
 }
 
 void TaTaCon::Reset()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.h
@@ -29,7 +29,10 @@ public:
   };
   static_assert(sizeof(DataFormat) == 6, "Wrong size");
 
-  using DesiredState = DataFormat;
+  struct DesiredState
+  {
+    u8 state;
+  };
 
   TaTaCon();
 

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -716,7 +716,7 @@ static std::string GenerateWiiInputDisplayString(int index, const DesiredWiimote
   if (state.extension.data.index() != ExtensionNumber::NONE)
   {
     const auto ext_visitor = overloaded{
-        [&](const Nunchuk::DataFormat& nunchuk) {
+        [&](const Nunchuk::DesiredState& nunchuk) {
           const auto bt = nunchuk.GetButtons();
           if (bt & Nunchuk::BUTTON_C)
             display_str += " C";
@@ -726,7 +726,7 @@ static std::string GenerateWiiInputDisplayString(int index, const DesiredWiimote
                                      nunchuk.GetAccelZ());
           display_str += Analog2DToString(nunchuk.jx, nunchuk.jy, " ANA");
         },
-        [&](const Classic::DataFormat& cc) {
+        [&](const Classic::DesiredState& cc) {
           const auto bt = cc.GetButtons();
           constexpr std::pair<u16, const char*> named_buttons[] = {
               {Classic::PAD_LEFT, "LEFT"},    {Classic::PAD_RIGHT, "RIGHT"},
@@ -757,12 +757,12 @@ static std::string GenerateWiiInputDisplayString(int index, const DesiredWiimote
           const auto right_stick = cc.GetRightStick().value;
           display_str += Analog2DToString(right_stick.x, right_stick.y, " R-ANA", rstick_max);
         },
-        [&](const Guitar::DataFormat&) { display_str += " Guitar"; },
+        [&](const Guitar::DesiredState&) { display_str += " Guitar"; },
         [&](const Drums::DesiredState&) { display_str += " Drums"; },
-        [&](const Turntable::DataFormat&) { display_str += " Turntable"; },
-        [&](const UDrawTablet::DataFormat&) { display_str += " UDraw"; },
-        [&](const DrawsomeTablet::DataFormat&) { display_str += " Drawsome"; },
-        [&](const TaTaCon::DataFormat&) { display_str += " TaTaCon"; },
+        [&](const Turntable::DesiredState&) { display_str += " Turntable"; },
+        [&](const UDrawTablet::DesiredState&) { display_str += " UDraw"; },
+        [&](const DrawsomeTablet::DesiredState&) { display_str += " Drawsome"; },
+        [&](const TaTaCon::DesiredState&) { display_str += " TaTaCon"; },
         [&](const Shinkansen::DesiredState&) { display_str += " Shinkansen"; },
         [](const auto& arg) {
           static_assert(std::is_same_v<std::monostate, std::decay_t<decltype(arg)>>,


### PR DESCRIPTION
TaTaCon NetPlay and TAS users rejoice.

The TaTaCon native data format has 5 bytes of padding. Now just the relevant byte is stored.

This change provides a a total savings of of 5 bytes per input frame!
