### PR TITLE
Update our minimum windows 10 version to 1903 and reinstate code that depends on it

### DIFF
--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -137,7 +137,7 @@ Function .onInit
   !insertmacro MULTIUSER_INIT
 
   ; Keep in sync with build_info.txt
-  !define MIN_WIN10_VERSION 1703
+  !define MIN_WIN10_VERSION 1903
   ${IfNot} ${AtLeastwin10}
   ${OrIfNot} ${AtLeastWaaS} ${MIN_WIN10_VERSION}
     MessageBox MB_OK "At least Windows 10 version ${MIN_WIN10_VERSION} is required."

--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 ### Desktop
 
 * OS
-    * Windows (10 1703 or higher).
+    * Windows (10 1903 or higher).
     * Linux.
     * macOS (10.15 Catalina or higher).
     * Unix-like systems other than Linux are not officially supported but might work.

--- a/Source/Core/Common/build_info.txt.in
+++ b/Source/Core/Common/build_info.txt.in
@@ -1,6 +1,6 @@
 // Indicate the minimum OS version required for the binary to run properly.
 // Updater will fail the update if the user does not meet this requirement.
-OSMinimumVersionWin10=10.0.15063.0
+OSMinimumVersionWin10=10.0.18362.0
 OSMinimumVersionWin11=10.0.22000.0
 
 // This is the runtime which was compiled against - providing a way for Updater to detect if update

--- a/Source/Core/Core/Config/DefaultLocale.cpp
+++ b/Source/Core/Core/Config/DefaultLocale.cpp
@@ -90,13 +90,15 @@ static std::string ComputeDefaultCountryCode()
 #ifdef _WIN32
   // Windows codepath: Check the regional information.
   // More likely to match the user's physical location than locales are.
-  // TODO: Can we use GetUserDefaultGeoName? (It was added in a Windows 10 update)
-  GEOID geo = GetUserGeoID(GEOCLASS_NATION);
-  const int buffer_size = GetGeoInfoW(geo, GEO_ISO2, nullptr, 0, 0);
-  std::vector<wchar_t> buffer(buffer_size);
-  const int result = GetGeoInfoW(geo, GEO_ISO2, buffer.data(), buffer_size, 0);
-  if (result != 0)
-    return TStrToUTF8(buffer.data());
+  const int buffer_size = GetUserDefaultGeoName(nullptr, 0);
+  if (buffer_size == 3)
+  {
+    std::wstring buffer(buffer_size, L'\0');
+    const int result = GetUserDefaultGeoName(buffer.data(), buffer_size);
+    buffer.resize(2);
+    if (result > 0)
+      return WStringToUTF8(buffer);
+  }
 #endif
 
   // Generic codepath: Check the locales.


### PR DESCRIPTION
With #13426 possibly needing a newer version of Windows 10 and a long-standing graphics mod crash (see https://bugs.dolphin-emu.org/issues/13352 ... which could easily be addressed to be fair), I wondered if we could try doing this #11452 once more.

This updates our minimum version of Windows 10 to 1903.  With Windows 10 going to end of life toward the end of 2025, this seems like a reasonable step toward supporting a more modern version of Windows.

This reverts #10963 and adds the changes from #11452 .

Discuss!