### PR TITLE
VideoCommon: initialize uninitialized state value in pixel ubershader

### DIFF
--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -921,6 +921,7 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
   out.Write("  int3 tevcoord = int3(0, 0, 0);\n"
             "  State s;\n"
             "  s.TexColor = int4(0, 0, 0, 0);\n"
+            "  s.RawTexColor = int4(0, 0, 0, 0);\n"
             "  s.AlphaBump = 0;\n"
             "\n");
   for (int i = 0; i < 4; i++)


### PR DESCRIPTION
Users were reporting a shader value may not be fully initialized.  This was a missing change from https://github.com/dolphin-emu/dolphin/pull/13345.  I really hate that requirement.

Anyway, this fixes that error by initializing `RawTexColor`