### PR TITLE
DolphinQt: Lay out the Controllers window horizontally and dynamically hide widgets.

### DIFF
--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -31,16 +31,19 @@ void ControllersWindow::showEvent(QShowEvent* event)
 
 void ControllersWindow::CreateMainLayout()
 {
-  auto* layout = new QVBoxLayout();
-  m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
+  auto* const grid = new QGridLayout;
+  grid->addWidget(m_gamecube_controllers, 0, 0);
+  grid->addWidget(m_wiimote_controllers, 0, 1, 2, 1);
+  grid->addWidget(m_common, 1, 0);
 
-  layout->addWidget(m_gamecube_controllers);
-  layout->addWidget(m_wiimote_controllers);
-  layout->addWidget(m_common);
+  auto* const layout = new QVBoxLayout;
+  layout->addLayout(grid);
+
   layout->addStretch();
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Close);
   layout->addWidget(m_button_box);
 
-  WrapInScrollArea(this, layout);
+  setLayout(layout);
 }
 
 void ControllersWindow::ConnectWidgets()

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
@@ -42,11 +42,12 @@ private:
 
   QGroupBox* m_wiimote_box;
   QGridLayout* m_wiimote_layout;
-  std::array<QLabel*, 4> m_wiimote_labels;
+
+  QWidget* m_emulated_bt_contents;
+  QWidget* m_passthru_bt_contents;
+
   std::array<QComboBox*, 4> m_wiimote_boxes;
   std::array<QPushButton*, 4> m_wiimote_buttons;
-  std::array<QHBoxLayout*, 4> m_wiimote_groups;
-  std::array<QLabel*, 2> m_wiimote_pt_labels;
 
   QRadioButton* m_wiimote_emu;
   QRadioButton* m_wiimote_passthrough;


### PR DESCRIPTION
Emu/Passthrough widgets are now dynamically hidden.

The "Refresh" button is now only enabled when appropriate.
- When "Continuous Scanning" is turned off
- When at least 1 "Real" Remote/BalanceBoard is requested or when "Connect Wii Remotes for Emulated Controllers" is enabled

![image](https://github.com/user-attachments/assets/37a758d8-0cad-41bb-9442-2357879ca51f)
![image](https://github.com/user-attachments/assets/df8017dd-a52b-44f2-aab4-a6ce2ceda516)