### PR TITLE
Core: Move CountPerformanceMarker to VideoInterface to eliminate a Throttle call. PerformanceMetrics: Fixes/Cleanups.

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -457,6 +457,8 @@ void CoreTimingManager::LogPendingEvents() const
 // Should only be called from the CPU thread after the PPC clock has changed
 void CoreTimingManager::AdjustEventQueueTimes(u32 new_ppc_clock, u32 old_ppc_clock)
 {
+  g_perf_metrics.AdjustClockSpeed(m_globals.global_timer, new_ppc_clock, old_ppc_clock);
+
   m_throttle_clock_per_sec = new_ppc_clock;
 
   for (Event& ev : m_event_queue)

--- a/Source/Core/Core/HW/SystemTimers.h
+++ b/Source/Core/Core/HW/SystemTimers.h
@@ -94,7 +94,6 @@ private:
   static void AudioDMACallback(Core::System& system, u64 userdata, s64 cycles_late);
   static void IPC_HLE_UpdateCallback(Core::System& system, u64 userdata, s64 cycles_late);
   static void GPUSleepCallback(Core::System& system, u64 userdata, s64 cycles_late);
-  static void PerfTrackerCallback(Core::System& system, u64 userdata, s64 cycles_late);
   static void VICallback(Core::System& system, u64 userdata, s64 cycles_late);
   static void DecrementerCallback(Core::System& system, u64 userdata, s64 cycles_late);
   static void PatchEngineCallback(Core::System& system, u64 userdata, s64 cycles_late);
@@ -116,7 +115,6 @@ private:
   CoreTiming::EventType* m_event_type_dsp = nullptr;
   CoreTiming::EventType* m_event_type_ipc_hle = nullptr;
   CoreTiming::EventType* m_event_type_gpu_sleeper = nullptr;
-  CoreTiming::EventType* m_event_type_perf_tracker = nullptr;
   // PatchEngine updates every 1/60th of a second by default
   CoreTiming::EventType* m_event_type_patch_engine = nullptr;
 };

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -853,10 +853,14 @@ void VideoInterfaceManager::EndField(FieldType field, u64 ticks)
   if (!Config::Get(Config::GFX_HACK_EARLY_XFB_OUTPUT))
     OutputField(field, ticks);
 
-  // Note: We really only need to Throttle prior to to presentation,
-  //  but it is needed here if we want accurate "VBlank" statistics,
-  //  when using GPU-on-Thread or Early/Immediate XFB.
-  m_system.GetCoreTiming().Throttle(ticks);
+  // Note: OutputField above doesn't present when using GPU-on-Thread or Early/Immediate XFB,
+  //  giving "VBlank" measurements here poor pacing without a Throttle call.
+  // If the user actually wants the data, we'll Throttle to make the numbers nice.
+  const bool is_vblank_data_wanted = g_ActiveConfig.bShowVPS || g_ActiveConfig.bShowVTimes ||
+                                     g_ActiveConfig.bLogRenderTimeToFile ||
+                                     g_ActiveConfig.bShowGraphs;
+  if (is_vblank_data_wanted)
+    m_system.GetCoreTiming().Throttle(ticks);
 
   g_perf_metrics.CountVBlank();
   VIEndFieldEvent::Trigger();

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -914,6 +914,10 @@ void VideoInterfaceManager::Update(u64 ticks)
   {
     // Throttle before SI poll so user input is taken just before needed. (lower input latency)
     core_timing.Throttle(ticks);
+
+    // This is a nice place to measure performance so we don't have to Throttle elsewhere.
+    g_perf_metrics.CountPerformanceMarker(ticks, m_system.GetSystemTimers().GetTicksPerSecond());
+
     Core::UpdateInputGate(!Config::Get(Config::MAIN_INPUT_BACKGROUND_INPUT),
                           Config::Get(Config::MAIN_LOCK_CURSOR));
     auto& si = m_system.GetSerialInterface();

--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <array>
 #include <atomic>
+#include <deque>
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/PerformanceTracker.h"
@@ -25,15 +25,17 @@ public:
   PerformanceMetrics(PerformanceMetrics&&) = delete;
   PerformanceMetrics& operator=(PerformanceMetrics&&) = delete;
 
-  // Count Functions
   void Reset();
+
   void CountFrame();
   void CountVBlank();
 
+  // Call from CPU thread.
   void CountThrottleSleep(DT sleep);
-  void CountPerformanceMarker(Core::System& system, s64 cyclesLate);
+  void AdjustClockSpeed(s64 ticks, u32 new_ppc_clock, u32 old_ppc_clock);
+  void CountPerformanceMarker(s64 ticks, u32 ticks_per_second);
 
-  // Getter Functions
+  // Getter Functions. May be called from any thread.
   double GetFPS() const;
   double GetVPS() const;
   double GetSpeed() const;
@@ -45,14 +47,20 @@ public:
 private:
   PerformanceTracker m_fps_counter{"render_times.txt"};
   PerformanceTracker m_vps_counter{"vblank_times.txt"};
-  PerformanceTracker m_speed_counter{std::nullopt, std::chrono::seconds{1}};
 
   double m_graph_max_time = 0.0;
 
+  std::atomic<double> m_speed{};
   std::atomic<double> m_max_speed{};
-  u8 m_time_index = 0;
-  std::array<TimePoint, 256> m_real_times{};
-  std::array<u64, 256> m_core_ticks{};
+
+  struct PerfSample
+  {
+    TimePoint clock_time;
+    TimePoint work_time;
+    s64 core_ticks;
+  };
+
+  std::deque<PerfSample> m_samples;
   DT m_time_sleeping{};
 };
 


### PR DESCRIPTION
This is a followup to #13387 and #13397.

I've eliminated the 100hz `PerfTrackerCallback` in `SystemTimers`.
It was only needed for `CountPerformanceMarker` which is now called from `VideoInterface`.

The ~60hz `Throttle` call in `VideoInterfaceManager::EndField` is now also skipped if "VBlank" data isn't asked for.

This might marginally reduce stuttering and improve pacing.
This should reduce the CPU-spinning of `PrecisionTimer` in #13426 from around 28% to maybe more like 12%.

`PerformanceMetrics` is now informed of clock speed changes to adjust previous samples to keep speed/max_speed values accurate during the transition period.
This is the same logic that's applied to the `Event::time` values in `CoreTiming::AdjustEventQueueTimes`.

`PerformanceMetrics` now uses the configured `Performance Sample Window` for the speed/max_speed calculation instead of always using 2.56 seconds.