### PR TITLE
HW/SI: Don't require waiting a second before disconnecting an SIDevice.

### DIFF
--- a/Source/Core/Core/HW/SI/SI.h
+++ b/Source/Core/Core/HW/SI/SI.h
@@ -131,7 +131,7 @@ private:
     USIChannelIn_Lo in_lo{};
     std::unique_ptr<ISIDevice> device;
 
-    bool has_recent_device_change = false;
+    bool has_recent_device_unplug = false;
   };
 
   // SI Poll: Controls how often a device is polled


### PR DESCRIPTION
When an `SIDevice` was plugged/unplugged a flag was set to prevent additional changes for one second so the system has time to acknowledge the change or whatever. One second seems excessive, but anyways, that's the existing behavior.

Now that only happens when a device is specifically *unplugged*.

This allows an `SIDevice` to always be disconnected as soon as requested.
I don't think it makes sense to leave a device connection lingering, even if it was recently attached.
We don't want some potentially stale/stuck data getting read for the remaining timeout.
If we desire a device to be disconnected then it should *now* be disconnected.

After unplugging a device, plugging in a new one is still prevented for 1 second, which again, seems excessive.

The state version doesn't need a bump. The `bool` still does the same thing. It's just not set on plug anymore.

I've also removed the `SetNoResponse` stuff in `ChangeDeviceCallback`. That's already appropriately handled in `UpdateDevices`.

I tested some problematic games, Eternal Darkness, Mortal Kombat, Mario Kart Wii, Sonic Heroes, and they still behave fine.

This is partially in preparation for a `DesiredWiimoteState`-like system for GameCube ports, so NetPlay and TAS can handle device changes.