### PR TITLE
Fix build failure of gba.cpp on Linux

### DIFF
--- a/Source/Core/Core/HW/GBACore.cpp
+++ b/Source/Core/Core/HW/GBACore.cpp
@@ -306,7 +306,7 @@ CoreInfo Core::GetCoreInfo() const
   info.has_rom = !m_rom_path.empty();
   info.has_ereader =
       info.is_gba && static_cast<::GBA*>(m_core->board)->memory.hw.devices & HW_EREADER;
-  m_core->currentVideoSize(m_core, &info.width, &info.height);
+  m_core->desiredVideoDimensions(m_core, &info.width,  &info.height);
   info.game_title = m_game_title;
   return info;
 }
@@ -393,7 +393,7 @@ void Core::SetSIODriver()
 void Core::SetVideoBuffer()
 {
   u32 width, height;
-  m_core->currentVideoSize(m_core, &width, &height);
+  m_core->desiredVideoDimensions(m_core, &width, &height);
   m_video_buffer.resize(width * height);
   m_core->setVideoBuffer(m_core, m_video_buffer.data(), width);
   if (auto host = m_host.lock())

--- a/Source/Core/Core/HW/GBACore.cpp
+++ b/Source/Core/Core/HW/GBACore.cpp
@@ -306,7 +306,11 @@ CoreInfo Core::GetCoreInfo() const
   info.has_rom = !m_rom_path.empty();
   info.has_ereader =
       info.is_gba && static_cast<::GBA*>(m_core->board)->memory.hw.devices & HW_EREADER;
-  m_core->desiredVideoDimensions(m_core, &info.width,  &info.height);
+  #ifdef NEW_MGBA_VERSION
+      m_core->currentVideoSize(m_core, &info.width,  &info.height);
+  #else
+      m_core->desiredVideoDimensions(m_core, &info.width,  &info.height);
+  #endif
   info.game_title = m_game_title;
   return info;
 }
@@ -390,14 +394,18 @@ void Core::SetSIODriver()
   };
 }
 
-void Core::SetVideoBuffer()
-{
+void Core::SetVideoBuffer() {
   u32 width, height;
-  m_core->desiredVideoDimensions(m_core, &width, &height);
-  m_video_buffer.resize(width * height);
-  m_core->setVideoBuffer(m_core, m_video_buffer.data(), width);
-  if (auto host = m_host.lock())
+  #ifdef NEW_MGBA_VERSION
+    m_core->currentVideoSize(m_core, &width, &height);
+  #else
+    m_core->desiredVideoDimensions(m_core, &width, &height);
+  #endif
+    m_video_buffer.resize(width * height);
+    m_core->setVideoBuffer(m_core, m_video_buffer.data(), width);
+  if (auto host = m_host.lock()) {
     host->GameChanged();
+    }
 }
 
 void Core::SetSampleRates()


### PR DESCRIPTION
The variable currentVideoSize needs to be updated to desiredVideoDimensions to adapt to the new version of mGBA, thereby fixing the build failure of gba.cpp on Linux.
The GBACore.cpp file is located at Source/Core/Core/HW/GBACore.cpp