### PR TITLE
GameSettings: Various Nick games fixes

### DIFF
--- a/Data/Sys/GameSettings/GCA.ini
+++ b/Data/Sys/GameSettings/GCA.ini
@@ -1,4 +1,4 @@
-# RSAE78, RSAP78 - SpongeBob's Atlantis SquarePantis
+# GCAE5H - Cubix Robots for Everyone: Showdown
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -9,7 +9,5 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SuggestedAspectRatio = 2
-# Needed for some FMVs.
-SafeTextureCacheColorSamples = 512
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GFO.ini
+++ b/Data/Sys/GameSettings/GFO.ini
@@ -1,4 +1,4 @@
-# RSAE78, RSAP78 - SpongeBob's Atlantis SquarePantis
+# GFOE78, GFOP78 - The Fairly OddParents: Shadow Showdown
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -10,6 +10,8 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SuggestedAspectRatio = 2
 # Needed for some FMVs.
 SafeTextureCacheColorSamples = 512
+
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GFW.ini
+++ b/Data/Sys/GameSettings/GFW.ini
@@ -1,4 +1,4 @@
-# RSAE78, RSAP78 - SpongeBob's Atlantis SquarePantis
+# GFWE78 - The Fairly OddParents: Breakin' Da Rules
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -10,6 +10,8 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SuggestedAspectRatio = 2
 # Needed for some FMVs.
 SafeTextureCacheColorSamples = 512
+
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GJY.ini
+++ b/Data/Sys/GameSettings/GJY.ini
@@ -1,4 +1,4 @@
-# RSAE78, RSAP78 - SpongeBob's Atlantis SquarePantis
+# GJYE78, GJYP78 - The Adventures of Jimmy Neutron Boy Genius: Attack of the Twonkies
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -10,6 +10,5 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SuggestedAspectRatio = 2
 # Needed for some FMVs.
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/GNO.ini
+++ b/Data/Sys/GameSettings/GNO.ini
@@ -1,4 +1,4 @@
-# GNOE78 - Nicktoons Unite!
+# GNOE78, GNOX78 - Nicktoons Unite!
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/GQ4.ini
+++ b/Data/Sys/GameSettings/GQ4.ini
@@ -10,5 +10,6 @@ MemoryCardSize = 2
 [ActionReplay]
 # Add action replay cheats here.
 
-
-
+[Video_Settings]
+# Needed for some FMVs.
+SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/GQQ.ini
+++ b/Data/Sys/GameSettings/GQQ.ini
@@ -1,4 +1,4 @@
-# RSAE78, RSAP78 - SpongeBob's Atlantis SquarePantis
+# GQQD78, GQQE78, GQQF78, GQQH78, GQQP78 - SpongeBob SquarePants: Lights, Camera, Pants!
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -10,6 +10,5 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SuggestedAspectRatio = 2
 # Needed for some FMVs.
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/GU6.ini
+++ b/Data/Sys/GameSettings/GU6.ini
@@ -1,4 +1,4 @@
-# RSAE78, RSAP78 - SpongeBob's Atlantis SquarePantis
+# GU6E78 - Nicktoons: Battle for Volcano Island
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -9,7 +9,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SuggestedAspectRatio = 2
+[Video_Hacks]
 # Needed for some FMVs.
-SafeTextureCacheColorSamples = 512
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GYA.ini
+++ b/Data/Sys/GameSettings/GYA.ini
@@ -9,6 +9,10 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+# Needed for some FMVs.
+SafeTextureCacheColorSamples = 0
+
 [Video_Hacks]
 EFBToTextureEnable = False
 DeferEFBCopies = False

--- a/Data/Sys/GameSettings/R38.ini
+++ b/Data/Sys/GameSettings/R38.ini
@@ -9,8 +9,13 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Enhancements]
+# Fixes FMVs
+ForceTextureFiltering = False
+
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+# Needed for some FMVs.
+SafeTextureCacheColorSamples = 0
 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/R6B.ini
+++ b/Data/Sys/GameSettings/R6B.ini
@@ -10,7 +10,12 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
+# Fixes FMVs
 ForceTextureFiltering = False
+
+[Video_Settings]
+# Needed for some FMVs.
+SafeTextureCacheColorSamples = 0
 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RBY.ini
+++ b/Data/Sys/GameSettings/RBY.ini
@@ -10,5 +10,7 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
+# Needed for some FMVs.
+ImmediateXFBEnable = False
 EFBToTextureEnable = False
 DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RN3.ini
+++ b/Data/Sys/GameSettings/RN3.ini
@@ -1,4 +1,4 @@
-# RSAE78, RSAP78 - SpongeBob's Atlantis SquarePantis
+# RN3J78, RN3E78, RN3P78, RN3X78 - Nicktoons: Attack of the Toybots
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -9,7 +9,10 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Enhancements]
+# Fixes FMVs
+ForceTextureFiltering = False
+
 [Video_Settings]
-SuggestedAspectRatio = 2
 # Needed for some FMVs.
-SafeTextureCacheColorSamples = 512
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RQ4.ini
+++ b/Data/Sys/GameSettings/RQ4.ini
@@ -1,4 +1,16 @@
-# RQ4E78, RQ4J78, RQ4P78 - SpongeBob SquarePants: Creature from the Krusty Krab
+# RQ4E78, RQ4J78, RQ4P78 - SpongeBob SquarePants: Creature from the Krusty Krab [Wii]
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/RUS.ini
+++ b/Data/Sys/GameSettings/RUS.ini
@@ -1,4 +1,4 @@
-# RSAE78, RSAP78 - SpongeBob's Atlantis SquarePantis
+# RUSX78, RUSK78, RUSE78, RUSP78, RUSY78 - SpongeBob SquarePants featuring Nicktoons: Globs of Doom
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -9,7 +9,10 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Enhancements]
+# Fixes FMVs
+ForceTextureFiltering = False
+
 [Video_Settings]
-SuggestedAspectRatio = 2
 # Needed for some FMVs.
-SafeTextureCacheColorSamples = 512
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SDB.ini
+++ b/Data/Sys/GameSettings/SDB.ini
@@ -10,7 +10,12 @@
 # Add action replay cheats here.
 
 [Video_Enhancements]
+# Fixes FMVs
 ForceTextureFiltering = False
+
+[Video_Settings]
+# Needed for some FMVs.
+SafeTextureCacheColorSamples = 0
 
 [Video_Hacks]
 EFBToTextureEnable = False


### PR DESCRIPTION
This PR provides a batch of GameSettings updates:
- Sets SafeTextureCacheColorSamples to proper values to fix choppy/pixelated FMVs.
- Disable texture filtering for several games to prevent broken FMVs.
- Disable ImmediateXFBEnable to prevent some FMV hangs in Nicktoons: Battle for Volcano Island and Barnyard Wii specifically.
