### PR TITLE
DolphinQt: Fix unresponsive hotkeys when clicking overlay during a framestep

### DIFF
--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -291,7 +291,9 @@ void Host_RequestRenderWindowSize(int w, int h)
 
 bool Host_UIBlocksControllerState()
 {
-  return ImGui::GetCurrentContext() && ImGui::GetIO().WantCaptureKeyboard;
+  // TODO: Remove the Paused check once async presentation is implemented.
+  return ImGui::GetCurrentContext() && ImGui::GetIO().WantCaptureKeyboard &&
+         Core::GetState(Core::System::GetInstance()) != Core::State::Paused;
 }
 
 void Host_RefreshDSPDebuggerWindow()


### PR DESCRIPTION
Fix the following bug:

* Have a moveable ImGui overlay enabled, such as the Statistics window.
* Pause the game.
* Click and hold on the overlay's title bar as if you were going to move it. Because the screen isn't updating while the game is paused, you won't be able to actually move the overlay.
* Press the Frame Advance hotkey several times until it stops responding.

At this point emulation hotkeys are no longer responsive. This can be resolved by selecting Play from the toolbar or menu, or selecting Frame Advance from the menu a couple times, but it's annoying and not obvious what's gone wrong or how to fix it.

Why the bug is happening:

* Doing a framestep while clicking on the overlay title bar causes ImGui to set IO.WantCaptureKeyboard to true, indicating that ImGui is requesting Dolphin ignore any keyboard events while the overlay is being interacted with.
* Dolphin complies with this request, causing Host_UIBlocksControllerState to return true and thus setting the input gate to ignore input.
* IO.WantCaptureKeyboard is only updated when ImGui::NewFrame() is called, which only happens at the end of each present. It thus remains true indefinitely since the game paused after the last framestep, and so Dolphin ignores any hotkeys such as the framestep or play keys.

The fix:

Ignore IO.WantCaptureKeyboard when the game is paused. ImGui can't meaningfully capture input anyway when the game is paused, so this shouldn't cause any problems elsewhere.

Once async presentation is implemented we'll want to revert this change, both because it'll become unnecessary and because ImGui will be able to do stuff while paused and so suppressing emulation hotkeys will actually be useful.