### PR TITLE
GameSettings: fix startup crash in "The Daring Game for Girls"

### DIFF
--- a/Data/Sys/GameSettings/SDAE5G.ini
+++ b/Data/Sys/GameSettings/SDAE5G.ini
@@ -1,0 +1,35 @@
+# SDAE5G - The Daring Game for Girls
+
+[OnFrame]
+# The game registers an AX callback function that uses a pointer which is only
+# initialized afterwards. The race condition depends on AID interrupt timing.
+# This patch moves the pointer initialization from 0x801C9E5C to 0x801C9DFC,
+# shifting the instructions in-between down.
+$Fix startup crash
+0x801C9DFC:dword:0x93EDBAB0
+0x801C9E00:dword:0x48030721
+0x801C9E04:dword:0x48032B8D
+0x801C9E08:dword:0x48063A89
+0x801C9E0C:dword:0x5460063F
+0x801C9E10:dword:0x41820018
+0x801C9E14:dword:0x2C000001
+0x801C9E18:dword:0x41820024
+0x801C9E1C:dword:0x2C000002
+0x801C9E20:dword:0x41820030
+0x801C9E24:dword:0x4800003C
+0x801C9E28:dword:0x38600000
+0x801C9E2C:dword:0x4802FF85
+0x801C9E30:dword:0x38600000
+0x801C9E34:dword:0x48032C9D
+0x801C9E38:dword:0x48000028
+0x801C9E3C:dword:0x38600000
+0x801C9E40:dword:0x4802FF71
+0x801C9E44:dword:0x38600001
+0x801C9E48:dword:0x48032C89
+0x801C9E4C:dword:0x48000014
+0x801C9E50:dword:0x38600001
+0x801C9E54:dword:0x4802FF5D
+0x801C9E58:dword:0x38600002
+0x801C9E5C:dword:0x48032C75
+[OnFrame_Enabled]
+$Fix startup crash


### PR DESCRIPTION
This fixes [issue 10821](https://bugs.dolphin-emu.org/issues/10821) by patching the race condition in the game. An alternative fix would be to delay the AID interrupt a little longer, but that would slow down emulation of well-behaved games.

Thanks to @hthh for debugging this!