### PR TITLE
 DolphinQt/FIFO/FIFOAnalyzer: Use Common::ToUnderlying

### DIFF
--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -20,6 +20,7 @@
 #include <QTreeWidgetItem>
 
 #include "Common/Assert.h"
+#include "Common/EnumUtils.h"
 #include "Common/Swap.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
 
@@ -262,7 +263,7 @@ public:
     const u32 object_prim_size = num_vertices * vertex_size;
 
     const u8 opcode =
-        0x80 | (static_cast<u8>(primitive) << OpcodeDecoder::GX_PRIMITIVE_SHIFT) | vat;
+        0x80 | Common::ToUnderlying(primitive) << OpcodeDecoder::GX_PRIMITIVE_SHIFT | vat;
     text = QStringLiteral("PRIMITIVE %1 (%2)  %3 vertices %4 bytes/vertex %5 total bytes")
                .arg(QString::fromStdString(name))
                .arg(opcode, 2, 16, QLatin1Char('0'))


### PR DESCRIPTION
This is the first step towards using the C++23 standard library method for [converting an enum to its underlying type](https://en.cppreference.com/w/cpp/utility/to_underlying).