### PR TITLE
Debugger quality of life improvements

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreterEmitter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreterEmitter.h
@@ -26,7 +26,7 @@ protected:
   using AnyCallback = s32 (*)(PowerPC::PowerPCState& ppc_state, const void* operands);
 
   template <class Operands>
-  static Callback<Operands> CallbackCast(Callback<Operands> callback)
+  static consteval Callback<Operands> CallbackCast(Callback<Operands> callback)
   {
     return callback;
   }

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreterEmitter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreterEmitter.h
@@ -26,7 +26,7 @@ protected:
   using AnyCallback = s32 (*)(PowerPC::PowerPCState& ppc_state, const void* operands);
 
   template <class Operands>
-  static consteval Callback<Operands> CallbackCast(Callback<Operands> callback)
+  static Callback<Operands> CallbackCast(Callback<Operands> callback)
   {
     return callback;
   }

--- a/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.h
+++ b/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.h
@@ -15,7 +15,7 @@ class AssembleInstructionDialog : public QDialog
 {
   Q_OBJECT
 public:
-  explicit AssembleInstructionDialog(QWidget* parent, u32 address, u32 value);
+  explicit AssembleInstructionDialog(QWidget* parent, u32 address, u32 value, QString disasm );
 
   u32 GetCode() const;
 
@@ -27,7 +27,7 @@ private:
 
   u32 m_code;
   u32 m_address;
-
+  QString m_disassembly;
   QLineEdit* m_input_edit;
   QLabel* m_error_loc_label;
   QLabel* m_error_line_label;

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -1060,7 +1060,15 @@ void CodeViewWidget::DoPatchInstruction(bool assemble)
 
   if (assemble)
   {
-    AssembleInstructionDialog dialog(this, addr, debug_interface.ReadInstruction(guard, addr));
+    std::string code_line = [this, addr] {
+      Core::CPUThreadGuard guard(m_system);
+      return m_system.GetPowerPC().GetDebugInterface().Disassemble(&guard, addr);
+    }();
+
+    std::ranges::replace(code_line, '\t', ' ' );
+
+    AssembleInstructionDialog dialog(this, addr, debug_interface.ReadInstruction(guard, addr),
+                                     QString::fromStdString(code_line));
     SetQWidgetWindowDecorations(&dialog);
     if (dialog.exec() == QDialog::Accepted)
     {

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -58,6 +58,7 @@ signals:
   void RequestPPCComparison(u32 address, bool translate_address);
   void ShowMemory(u32 address);
   void UpdateCodeWidget();
+  void ActivateSearch();
 
 private:
   enum class ReplaceWith
@@ -85,6 +86,7 @@ private:
   void OnShowTargetInMemory();
   void OnCopyFunction();
   void OnCopyCode();
+  void OnCopyWholeLine();
   void OnCopyHex();
   void OnRenameSymbol();
   void OnSelectionChanged();

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -247,6 +247,7 @@ void CodeWidget::OnPPCSymbolsChanged()
 void CodeWidget::ActivateSearchAddress()
 {
   m_search_address->setFocus();
+  m_search_address->selectAll();
 }
 
 void CodeWidget::OnSearchAddress()

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -208,6 +208,7 @@ void CodeWidget::ConnectWidgets()
 
   connect(Host::GetInstance(), &Host::PPCSymbolsChanged, this, &CodeWidget::OnPPCSymbolsChanged);
   connect(m_code_view, &CodeViewWidget::UpdateCodeWidget, this, &CodeWidget::Update);
+  connect(m_code_view, &CodeViewWidget::ActivateSearch, this, &CodeWidget::ActivateSearchAddress);
 
   connect(m_code_view, &CodeViewWidget::RequestPPCComparison, this,
           &CodeWidget::RequestPPCComparison);
@@ -241,6 +242,11 @@ void CodeWidget::OnPPCSymbolsChanged()
     UpdateFunctionCalls(symbol);
     UpdateFunctionCallers(symbol);
   }
+}
+
+void CodeWidget::ActivateSearchAddress()
+{
+  m_search_address->setFocus();
 }
 
 void CodeWidget::OnSearchAddress()

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -50,6 +50,7 @@ public:
 
   void Update();
   void UpdateSymbols();
+  void ActivateSearchAddress();
 signals:
   void RequestPPCComparison(u32 address, bool translate_address);
   void ShowMemory(u32 address);

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -123,6 +123,11 @@ public:
     case Qt::Key_PageDown:
       m_view->m_address += this->rowCount() * m_view->m_bytes_per_row;
       break;
+    case Qt::Key_G:
+      if (event->modifiers() == Qt::ControlModifier)
+      {
+        m_view->TriggerActivateSearch();
+      }
     default:
       QWidget::keyPressEvent(event);
       return;
@@ -250,6 +255,11 @@ void MemoryViewWidget::UpdateFont(const QFont& font)
   m_table->setFont(font);
 
   UpdateDispatcher(UpdateType::Full);
+}
+
+void MemoryViewWidget::TriggerActivateSearch()
+{
+  emit ActivateSearch();
 }
 
 constexpr int GetTypeSize(MemoryViewWidget::Type type)
@@ -971,6 +981,11 @@ void MemoryViewWidget::SetAddress(u32 address)
   m_address = address;
 
   UpdateDispatcher(UpdateType::Addresses);
+}
+
+u32 MemoryViewWidget::GetAddress()
+{
+  return m_address;
 }
 
 void MemoryViewWidget::SetBPLoggingEnabled(bool enabled)

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -97,6 +97,7 @@ public:
   void SetHighlightColor();
   void SetBPType(BPType type);
   void SetAddress(u32 address);
+  u32 GetAddress();
   void SetFocus() const;
 
   void SetBPLoggingEnabled(bool enabled);
@@ -105,12 +106,14 @@ signals:
   void AutoUpdate();
   void ShowCode(u32 address);
   void RequestWatch(QString name, u32 address);
+  void ActivateSearch();
 
 private:
   void OnContextMenu(const QPoint& pos);
   void OnCopyAddress(u32 addr);
   void OnCopyHex(u32 addr);
   void UpdateBreakpointTags();
+  void TriggerActivateSearch();
   void UpdateColumns();
   void ScrollbarActionTriggered(int action);
   void ScrollbarSliderReleased();

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -592,6 +592,7 @@ void MemoryWidget::SetAddress(u32 address)
 void MemoryWidget::ActivateSearchAddress()
 {
   m_search_address->setFocus();
+  m_search_address->lineEdit()->selectAll();
 }
 
 void MemoryWidget::OnSearchAddress()

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -60,6 +60,7 @@ private:
   void OnBPTypeChanged();
 
   void OnSearchAddress();
+  void OnBreakOnAll();
   void OnFindNextValue();
   void OnFindPreviousValue();
 
@@ -74,7 +75,7 @@ private:
   void ValidateAndPreviewInputValue();
   QByteArray GetInputData() const;
   TargetAddress GetTargetAddress() const;
-  void FindValue(bool next);
+  bool FindValue(bool next);
 
   void closeEvent(QCloseEvent*) override;
   void hideEvent(QHideEvent* event) override;
@@ -82,6 +83,7 @@ private:
   void RegisterAfterFrameEventCallback();
   void RemoveAfterFrameEventCallback();
   void AutoUpdateTable();
+  void ActivateSearchAddress();
 
   Core::System& m_system;
 
@@ -101,6 +103,9 @@ private:
   // Search
   QPushButton* m_find_next;
   QPushButton* m_find_previous;
+  QComboBox* m_find_align;
+  QCheckBox* m_find_auto_mem_bp;
+  QCheckBox* m_find_auto_code_bp;
   QComboBox* m_input_combo;
   QLabel* m_result_label;
 


### PR DESCRIPTION
- [BUILD] Removing consteval in CallbackCast to fix Windows VS build. Might be optional but was unable to build on Windows with it
- [DEBUGGER] CTRL+G in code view or memory view toggles address box, comparable with other debuggers
- [DEBUGGER] Memory search box alignment option
- [DEBUGGER] Memory search auto breakpoint setting helping search for large number of constants in memory and associated code: 0x41f00000 for example
- [DEBUGGER] Disassembler copy whole line option in the right click menu copying address, code and memory pointed to in clipboard all in one go making it easier to research and document
- [DEBUGGER] Assemble dialog box instruction automatically filed with the right disassembly instead of .li and the hex since the hex edition is available in "replace instruction"
- [DEBUGGER] Assemble dialog can now deal with absolute addresses computing automatically the offset. For example assembling b ->0x80359370 at the address 0x8035936c will result in the right relative jump. Add -> before any address you want to use as absolute to respect the disassembly syntax