### PR TITLE
DolphinQt: Fix blank square in MappingWindow's top-left corner.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -31,10 +31,10 @@ bool ContainsAnalogInput(const ciface::Core::InputDetector::Results& results)
   return std::ranges::any_of(results, [](auto& detection) { return detection.smoothness > 1; });
 }
 
-class MappingProcessor : public QWidget
+class MappingProcessor : public QObject
 {
 public:
-  MappingProcessor(MappingWindow* parent) : QWidget{parent}, m_parent{parent}
+  MappingProcessor(MappingWindow* parent) : QObject{parent}, m_parent{parent}
   {
     using MW = MappingWindow;
     using MP = MappingProcessor;


### PR DESCRIPTION
I caused this in #13162 
@Dentomologist brought this to my attention.

It was maybe only a problem on Windows? I don't see it in Linux.

Broken:
![image](https://github.com/user-attachments/assets/93915351-e1ef-4a9e-bdc9-ddf3f66dc85a)

Fixed:
![image](https://github.com/user-attachments/assets/bb37abb3-c365-4d9a-83d4-9d5b5e5e8111)
