### PR TITLE
VideoCommon: Fix out-of-bounds and disabled EFB access.

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -47,9 +47,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 
-#include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/EFBInterface.h"
-#include "VideoCommon/Statistics.h"
 
 namespace PowerPC
 {
@@ -111,18 +109,12 @@ static u32 EFB_Read(const u32 addr)
   }
   else if (addr & 0x00400000)
   {
-    var = AsyncRequests::GetInstance()->PushBlockingEvent([&] {
-      INCSTAT(g_stats.this_frame.num_efb_peeks);
-      return g_efb_interface->PeekDepth(x, y);
-    });
+    var = g_efb_interface->PeekDepth(x, y);
     DEBUG_LOG_FMT(MEMMAP, "EFB Z Read @ {}, {}\t= {:#010x}", x, y, var);
   }
   else
   {
-    var = AsyncRequests::GetInstance()->PushBlockingEvent([&] {
-      INCSTAT(g_stats.this_frame.num_efb_peeks);
-      return g_efb_interface->PeekColor(x, y);
-    });
+    var = g_efb_interface->PeekColor(x, y);
     DEBUG_LOG_FMT(MEMMAP, "EFB Color Read @ {}, {}\t= {:#010x}", x, y, var);
   }
 
@@ -142,18 +134,12 @@ static void EFB_Write(u32 data, u32 addr)
   }
   else if (addr & 0x00400000)
   {
-    AsyncRequests::GetInstance()->PushEvent([x, y, data] {
-      INCSTAT(g_stats.this_frame.num_efb_pokes);
-      g_efb_interface->PokeDepth(x, y, data);
-    });
+    g_efb_interface->PokeDepth(x, y, data);
     DEBUG_LOG_FMT(MEMMAP, "EFB Z Write {:08x} @ {}, {}", data, x, y);
   }
   else
   {
-    AsyncRequests::GetInstance()->PushEvent([x, y, data] {
-      INCSTAT(g_stats.this_frame.num_efb_pokes);
-      g_efb_interface->PokeColor(x, y, data);
-    });
+    g_efb_interface->PokeColor(x, y, data);
     DEBUG_LOG_FMT(MEMMAP, "EFB Color Write {:08x} @ {}, {}", data, x, y);
   }
 }

--- a/Source/Core/VideoBackends/Null/NullGfx.cpp
+++ b/Source/Core/VideoBackends/Null/NullGfx.cpp
@@ -108,7 +108,7 @@ u32 NullEFBInterface::PeekColorInternal(u16 x, u16 y)
   return 0;
 }
 
-u32 NullEFBInterface::PeekDepth(u16 x, u16 y)
+u32 NullEFBInterface::PeekDepthInternal(u16 x, u16 y)
 {
   return 0;
 }

--- a/Source/Core/VideoBackends/Null/NullGfx.h
+++ b/Source/Core/VideoBackends/Null/NullGfx.h
@@ -46,7 +46,7 @@ class NullEFBInterface final : public EFBInterfaceBase
   void PokeDepth(u16 x, u16 y, u32 depth) override;
 
   u32 PeekColorInternal(u16 x, u16 y) override;
-  u32 PeekDepth(u16 x, u16 y) override;
+  u32 PeekDepthInternal(u16 x, u16 y) override;
 };
 
 }  // namespace Null

--- a/Source/Core/VideoBackends/Software/SWEfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/SWEfbInterface.cpp
@@ -742,7 +742,7 @@ u32 SWEFBInterface::PeekColorInternal(u16 x, u16 y)
   return value;
 }
 
-u32 SWEFBInterface::PeekDepth(u16 x, u16 y)
+u32 SWEFBInterface::PeekDepthInternal(u16 x, u16 y)
 {
   return EfbInterface::GetDepth(x, y);
 }

--- a/Source/Core/VideoBackends/Software/SWEfbInterface.h
+++ b/Source/Core/VideoBackends/Software/SWEfbInterface.h
@@ -69,6 +69,6 @@ class SWEFBInterface final : public EFBInterfaceBase
   void PokeDepth(u16 x, u16 y, u32 depth) override;
 
   u32 PeekColorInternal(u16 x, u16 y) override;
-  u32 PeekDepth(u16 x, u16 y) override;
+  u32 PeekDepthInternal(u16 x, u16 y) override;
 };
 }  // namespace SW

--- a/Source/Core/VideoCommon/EFBInterface.h
+++ b/Source/Core/VideoCommon/EFBInterface.h
@@ -20,10 +20,13 @@ public:
   virtual void PokeDepth(u16 x, u16 y, u32 depth) = 0;
 
   u32 PeekColor(u16 x, u16 y);
-  virtual u32 PeekDepth(u16 x, u16 y) = 0;
+  u32 PeekDepth(u16 x, u16 y);
 
 protected:
+  bool ShouldSkipAccess(u16 x, u16 y) const;
+
   virtual u32 PeekColorInternal(u16 x, u16 y) = 0;
+  virtual u32 PeekDepthInternal(u16 x, u16 y) = 0;
 };
 
 class HardwareEFBInterface final : public EFBInterfaceBase
@@ -34,7 +37,7 @@ class HardwareEFBInterface final : public EFBInterfaceBase
   void PokeDepth(u16 x, u16 y, u32 depth) override;
 
   u32 PeekColorInternal(u16 x, u16 y) override;
-  u32 PeekDepth(u16 x, u16 y) override;
+  u32 PeekDepthInternal(u16 x, u16 y) override;
 };
 
 extern std::unique_ptr<EFBInterfaceBase> g_efb_interface;


### PR DESCRIPTION
This fixes my regression from #13423 
Thanks to @iwubcode for discovering it

I accidentally removed this check, making EFB Access always enabled and out-of-bounds access trigger an assert, breaking DQX and maybe more.
https://github.com/dolphin-emu/dolphin/blob/ca9b34a6d1e7ad03c4879239e9c5b79a6c47522e/Source/Core/VideoCommon/VideoBackendBase.cpp#L116

I've re-added this check and moved the AsyncRequest usage from MMU into EFBInterface which is closer to how things were organized before.