### PR TITLE
DolphinQt: Don't auto toggle GFX_HACK_SKIP_DUPLICATE_XFBS.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -196,12 +196,16 @@ void HacksWidget::AddDescriptions()
   static const char TR_IMMEDIATE_XFB_DESCRIPTION[] = QT_TR_NOOP(
       "Displays XFB copies as soon as they are created, instead of waiting for "
       "scanout.<br><br>Can cause graphical defects in some games if the game doesn't "
-      "expect all XFB copies to be displayed. However, turning this setting on reduces "
-      "latency.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+      "expect all XFB copies to be displayed. However, turning this setting on reduces latency."
+      "<br><br>Enabling this also force an effect equivalent to the"
+      " Skip Presenting Duplicate Frames setting."
+      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_SKIP_DUPLICATE_XFBS_DESCRIPTION[] = QT_TR_NOOP(
       "Skips presentation of duplicate frames (XFB copies) in 25fps/30fps games. "
       "This may improve performance on low-end devices, while making frame pacing less consistent."
       "<br><br>Disable this option for optimal frame pacing."
+      "<br><br>This setting is unavailable when Immediately Present XFB or VBI Skip is "
+      "enabled. In those cases, duplicate frames are never presented."
       "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
   static const char TR_GPU_DECODING_DESCRIPTION[] = QT_TR_NOOP(
       "Enables texture decoding using the GPU instead of the CPU.<br><br>This may result in "
@@ -230,6 +234,8 @@ void HacksWidget::AddDescriptions()
   static const char TR_VI_SKIP_DESCRIPTION[] =
       QT_TR_NOOP("Skips Vertical Blank Interrupts when lag is detected, allowing for "
                  "smooth audio playback when emulation speed is not 100%. <br><br>"
+                 "Enabling this also forces the effect of the"
+                 " Skip Presenting Duplicate Frames setting.<br><br>"
                  "<dolphin_emphasis>WARNING: Can cause freezes and compatibility "
                  "issues.</dolphin_emphasis> <br><br>"
                  "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -263,12 +263,5 @@ void HacksWidget::UpdateSkipPresentingDuplicateFramesEnabled()
 {
   // If Immediate XFB is on, there's no point to skipping duplicate XFB copies as immediate presents
   // when the XFB is created, therefore all XFB copies will be unique.
-  // This setting is also required for VI skip to work.
-
-  const bool disabled = m_immediate_xfb->isChecked() || m_vi_skip->isChecked();
-
-  if (disabled)
-    m_skip_duplicate_xfbs->setChecked(true);
-
-  m_skip_duplicate_xfbs->setEnabled(!disabled);
+  m_skip_duplicate_xfbs->setDisabled(m_immediate_xfb->isChecked() || m_vi_skip->isChecked());
 }


### PR DESCRIPTION
The "VI Skip" PR #11367 added logic to automatically check the SkipDuplicateFrames box when ImmediateXFB or VBISkip were enabled.

Automatically changing SkipDuplicateFrames when I enable ImmediateXFB is annoying.

The ImmediateXFB code path entirely avoids the duplicate frame check so it's just irrelevant.

VideoConfig forces SkipDuplicateFrames when VBISkip is enabled so it's also not explicitly needed there.
https://github.com/dolphin-emu/dolphin/blob/23ad07b3688a1145c22ac72dfc35b0d2f9f834ff/Source/Core/VideoCommon/VideoConfig.cpp#L144

The mentioned settings now only disable the SkipDuplicateFrames box, which is the behavior prior to #11367.
![image](https://github.com/user-attachments/assets/8c27341d-4165-42ef-b8a9-a377c888dd6a)