### PR TITLE
[DEBUGGER] Assemble dialog box instruction proper disassembly and absolute addresses support

### DIFF
--- a/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.cpp
@@ -38,8 +38,9 @@ QString HtmlFormatErrorLine(const Common::GekkoAssembler::AssemblerError& err)
 }
 }  // namespace
 
-AssembleInstructionDialog::AssembleInstructionDialog(QWidget* parent, u32 address, u32 value)
-    : QDialog(parent), m_code(value), m_address(address)
+AssembleInstructionDialog::AssembleInstructionDialog(QWidget* parent, u32 address, u32 value,
+                                                     QString disasm)
+    : QDialog(parent), m_code(value), m_address(address), m_disassembly(disasm)
 {
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowModality(Qt::WindowModal);
@@ -66,7 +67,7 @@ void AssembleInstructionDialog::CreateWidgets()
   layout->addWidget(m_error_line_label);
   layout->addWidget(m_msg_label);
   layout->addWidget(m_button_box);
-  m_input_edit->setText(QStringLiteral(".4byte 0x%1").arg(m_code, 8, 16, QLatin1Char('0')));
+  m_input_edit->setText(m_disassembly);
 
   setLayout(layout);
   OnEditChanged();
@@ -85,6 +86,37 @@ void AssembleInstructionDialog::OnEditChanged()
   using namespace Common::GekkoAssembler;
   std::string line = m_input_edit->text().toStdString();
   Common::ToLower(&line);
+
+  size_t posArrow = line.find("->");
+  if (posArrow != std::string::npos)
+  {
+    std::string start = line.substr(0, posArrow);
+    std::string dest = line.substr(posArrow + 2);
+    u32 destAddress = 0;
+    size_t posHex = dest.find("0x");
+    try
+    {
+      if (posHex == std::string::npos)
+      {
+        destAddress = (u32)std::stoi(dest);
+      }
+      else
+      {
+        destAddress = (u32)std::stoul(dest.substr(posHex + 2), NULL, 16);
+      }
+    }
+    catch (...)
+    {
+    }
+    if (destAddress < m_address)
+    {
+      line = start + " -" + std::to_string(m_address - destAddress);
+    }
+    else
+    {
+      line = start + " " + std::to_string(destAddress - m_address);
+    }
+  }
 
   FailureOr<std::vector<CodeBlock>> asm_result = Assemble(line, m_address);
 

--- a/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.h
+++ b/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.h
@@ -15,7 +15,7 @@ class AssembleInstructionDialog : public QDialog
 {
   Q_OBJECT
 public:
-  explicit AssembleInstructionDialog(QWidget* parent, u32 address, u32 value);
+  explicit AssembleInstructionDialog(QWidget* parent, u32 address, u32 value, QString disasm);
 
   u32 GetCode() const;
 
@@ -28,6 +28,7 @@ private:
   u32 m_code;
   u32 m_address;
 
+  QString m_disassembly;
   QLineEdit* m_input_edit;
   QLabel* m_error_loc_label;
   QLabel* m_error_line_label;

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -1030,7 +1030,11 @@ void CodeViewWidget::DoPatchInstruction(bool assemble)
 
   if (assemble)
   {
-    AssembleInstructionDialog dialog(this, addr, debug_interface.ReadInstruction(guard, addr));
+    std::string code_line = m_system.GetPowerPC().GetDebugInterface().Disassemble(&guard, addr);
+    std::ranges::replace(code_line, '\t', ' ');
+
+    AssembleInstructionDialog dialog(this, addr, debug_interface.ReadInstruction(guard, addr),
+                                     QString::fromStdString(code_line));
     SetQWidgetWindowDecorations(&dialog);
     if (dialog.exec() == QDialog::Accepted)
     {


### PR DESCRIPTION
[DEBUGGER] Assemble dialog box instruction automatically filed with the right disassembly instead of .li and the hex since the hex edition is available in "replace instruction"
[DEBUGGER] Assemble dialog can now deal with absolute addresses computing automatically the offset. For example assembling b ->0x80359370 at the address 0x8035936c will result in the right relative jump. Add -> before any address you want to use as absolute to respect the disassembly syntax