### PR TITLE
[Debugger] Memory View search box improvements

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -973,6 +973,11 @@ void MemoryViewWidget::SetAddress(u32 address)
   UpdateDispatcher(UpdateType::Addresses);
 }
 
+u32 MemoryViewWidget::GetAddress()
+{
+  return m_address;
+}
+
 void MemoryViewWidget::SetBPLoggingEnabled(bool enabled)
 {
   m_do_log = enabled;

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -97,6 +97,7 @@ public:
   void SetHighlightColor();
   void SetBPType(BPType type);
   void SetAddress(u32 address);
+  u32 GetAddress();
   void SetFocus() const;
 
   void SetBPLoggingEnabled(bool enabled);

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -32,6 +32,8 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/AddressSpace.h"
+#include "Core/PowerPC/BreakPoints.h"
+#include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 #include "DolphinQt/Debugger/MemoryViewWidget.h"
 #include "DolphinQt/Host.h"
@@ -73,6 +75,7 @@ MemoryWidget::MemoryWidget(Core::System& system, QWidget* parent)
     else
       RemoveAfterFrameEventCallback();
   });
+
   LoadSettings();
 
   ConnectWidgets();
@@ -156,10 +159,26 @@ void MemoryWidget::CreateWidgets()
 
   m_find_next = new QPushButton(tr("Find &Next"));
   m_find_previous = new QPushButton(tr("Find &Previous"));
+  m_find_align = new QComboBox;
+  m_find_align->addItem(tr("No alignment"), 0);
+  m_find_align->addItem(tr("2 Bytes"), 2);
+  m_find_align->addItem(tr("4 Bytes"), 4);
+  m_find_align->addItem(tr("8 Bytes"), 8);
+  m_find_align->addItem(tr("16 Bytes"), 16);
   m_result_label = new QLabel;
+
+  auto* search_bp_group = new QHBoxLayout;
+  auto* auto_bp_label = new QLabel(tr("Auto BP"));
+  m_find_auto_mem_bp = new QCheckBox(tr("Mem"));
+  m_find_auto_code_bp = new QCheckBox(tr("Code"));
+  search_bp_group->addWidget(auto_bp_label);
+  search_bp_group->addWidget(m_find_auto_mem_bp);
+  search_bp_group->addWidget(m_find_auto_code_bp);
 
   search_layout->addWidget(m_find_next);
   search_layout->addWidget(m_find_previous);
+  search_layout->addWidget(m_find_align);
+  search_layout->addLayout(search_bp_group);
   search_layout->addWidget(m_result_label);
   search_layout->setSpacing(1);
 
@@ -347,11 +366,13 @@ void MemoryWidget::ConnectWidgets()
   {
     connect(radio, &QRadioButton::toggled, this, &MemoryWidget::OnAddressSpaceChanged);
   }
-  for (auto* combo : {m_display_combo, m_align_combo, m_row_length_combo})
+  for (auto* combo : {m_display_combo, m_align_combo, m_row_length_combo, m_find_align})
   {
     connect(combo, &QComboBox::currentIndexChanged, this, &MemoryWidget::OnDisplayChanged);
   }
 
+  connect(m_find_auto_mem_bp, &QCheckBox::toggled, this, &MemoryWidget::OnDisplayChanged);
+  connect(m_find_auto_code_bp, &QCheckBox::toggled, this, &MemoryWidget::OnDisplayChanged);
   connect(m_dual_check, &QCheckBox::toggled, this, &MemoryWidget::OnDisplayChanged);
 
   for (auto* radio : {m_bp_read_write, m_bp_read_only, m_bp_write_only})
@@ -849,20 +870,20 @@ MemoryWidget::TargetAddress MemoryWidget::GetTargetAddress() const
   return target;
 }
 
-void MemoryWidget::FindValue(bool next)
+bool MemoryWidget::FindValue(bool next)
 {
   auto target_addr = GetTargetAddress();
 
   if (!target_addr.is_good_address)
   {
     m_result_label->setText(tr("Bad address provided."));
-    return;
+    return false;
   }
 
   if (!target_addr.is_good_offset)
   {
     m_result_label->setText(tr("Bad offset provided."));
-    return;
+    return false;
   }
 
   const QByteArray search_for = GetInputData();
@@ -870,7 +891,7 @@ void MemoryWidget::FindValue(bool next)
   if (search_for.isEmpty())
   {
     m_result_label->setText(tr("Bad Value Given"));
-    return;
+    return false;
   }
 
   if (!m_search_address->currentText().isEmpty())
@@ -900,15 +921,35 @@ void MemoryWidget::FindValue(bool next)
 
     m_memory_view->SetAddress(offset);
 
-    return;
+    return true;
   }
 
   m_result_label->setText(tr("No Match"));
+  return false;
 }
 
 void MemoryWidget::OnFindNextValue()
 {
-  FindValue(true);
+  int alignment = m_find_align->currentData().toInt();
+  bool set_mem_bp = m_find_auto_mem_bp->isChecked();
+  bool set_code_bp = m_find_auto_code_bp->isChecked();
+
+  while (FindValue(true))
+  {
+    if ((alignment == 0) || ((m_memory_view->GetAddress() & (alignment - 1)) == 0))
+    {
+      if (set_mem_bp)
+      {
+        m_memory_view->ToggleBreakpoint(m_memory_view->GetAddress(), false);
+      }
+      if (set_code_bp && (4 <= alignment))
+      {
+        m_system.GetPowerPC().GetBreakPoints().ToggleBreakPoint(m_memory_view->GetAddress());
+        emit Host::GetInstance() -> PPCBreakpointsChanged();
+      }
+      break;
+    }
+  }
 }
 
 void MemoryWidget::OnFindPreviousValue()

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -60,6 +60,7 @@ private:
   void OnBPTypeChanged();
 
   void OnSearchAddress();
+  void OnBreakOnAll();
   void OnFindNextValue();
   void OnFindPreviousValue();
 
@@ -74,7 +75,7 @@ private:
   void ValidateAndPreviewInputValue();
   QByteArray GetInputData() const;
   TargetAddress GetTargetAddress() const;
-  void FindValue(bool next);
+  bool FindValue(bool next);
 
   void closeEvent(QCloseEvent*) override;
   void hideEvent(QHideEvent* event) override;
@@ -101,6 +102,9 @@ private:
   // Search
   QPushButton* m_find_next;
   QPushButton* m_find_previous;
+  QComboBox* m_find_align;
+  QCheckBox* m_find_auto_mem_bp;
+  QCheckBox* m_find_auto_code_bp;
   QComboBox* m_input_combo;
   QLabel* m_result_label;
 


### PR DESCRIPTION
- Added alignment option for memory search. Useful to find only valid code patterns or valid float values for example
- Added auto breakpoint setting when value found

Helpful when looking for trying to find all accessed instances of a value for example 0x41f00000 (30.0) in a game. Put 0x41f0000 in the search box, set alignment to 4, set auto bp memory and spam the search button. Then run the game and examine the code using those values to see if any is relevant. Similar use case for code with lis r0, 0x41f0 for example.