### PR TITLE
[Debugger] CTRL+G support in code and memory view

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -1085,6 +1085,11 @@ void CodeViewWidget::keyPressEvent(QKeyEvent* event)
     m_address += rowCount() * sizeof(u32);
     Update();
     return;
+  case Qt::Key_G:
+    if (event->modifiers() == Qt::ControlModifier)
+    {
+      emit ActivateSearch();
+    }
   default:
     QWidget::keyPressEvent(event);
     break;

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -58,6 +58,7 @@ signals:
   void RequestPPCComparison(u32 address, bool translate_address);
   void ShowMemory(u32 address);
   void UpdateCodeWidget();
+  void ActivateSearch();
 
 private:
   enum class ReplaceWith

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -212,6 +212,7 @@ void CodeWidget::ConnectWidgets()
   connect(m_code_view, &CodeViewWidget::RequestPPCComparison, this,
           &CodeWidget::RequestPPCComparison);
   connect(m_code_view, &CodeViewWidget::ShowMemory, this, &CodeWidget::ShowMemory);
+  connect(m_code_view, &CodeViewWidget::ActivateSearch, this, &CodeWidget::ActivateSearchAddress);
 }
 
 void CodeWidget::OnBranchWatchDialog()
@@ -241,6 +242,12 @@ void CodeWidget::OnPPCSymbolsChanged()
     UpdateFunctionCalls(symbol);
     UpdateFunctionCallers(symbol);
   }
+}
+
+void CodeWidget::ActivateSearchAddress()
+{
+  m_search_address->setFocus();
+  m_search_address->selectAll();
 }
 
 void CodeWidget::OnSearchAddress()

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -50,6 +50,7 @@ public:
 
   void Update();
   void UpdateSymbols();
+  void ActivateSearchAddress();
 signals:
   void RequestPPCComparison(u32 address, bool translate_address);
   void ShowMemory(u32 address);

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -123,6 +123,11 @@ public:
     case Qt::Key_PageDown:
       m_view->m_address += this->rowCount() * m_view->m_bytes_per_row;
       break;
+    case Qt::Key_G:
+      if (event->modifiers() == Qt::ControlModifier)
+      {
+        m_view->TriggerActivateSearch();
+      }
     default:
       QWidget::keyPressEvent(event);
       return;
@@ -250,6 +255,11 @@ void MemoryViewWidget::UpdateFont(const QFont& font)
   m_table->setFont(font);
 
   UpdateDispatcher(UpdateType::Full);
+}
+
+void MemoryViewWidget::TriggerActivateSearch()
+{
+  emit ActivateSearch();
 }
 
 constexpr int GetTypeSize(MemoryViewWidget::Type type)

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -105,12 +105,14 @@ signals:
   void AutoUpdate();
   void ShowCode(u32 address);
   void RequestWatch(QString name, u32 address);
+  void ActivateSearch();
 
 private:
   void OnContextMenu(const QPoint& pos);
   void OnCopyAddress(u32 addr);
   void OnCopyHex(u32 addr);
   void UpdateBreakpointTags();
+  void TriggerActivateSearch();
   void UpdateColumns();
   void ScrollbarActionTriggered(int action);
   void ScrollbarSliderReleased();

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -361,6 +361,8 @@ void MemoryWidget::ConnectWidgets()
   connect(m_bp_log_check, &QCheckBox::toggled, this, &MemoryWidget::OnBPLogChanged);
   connect(m_memory_view, &MemoryViewWidget::ShowCode, this, &MemoryWidget::ShowCode);
   connect(m_memory_view, &MemoryViewWidget::RequestWatch, this, &MemoryWidget::RequestWatch);
+  connect(m_memory_view, &MemoryViewWidget::ActivateSearch, this,
+          &MemoryWidget::ActivateSearchAddress);
 }
 
 void MemoryWidget::closeEvent(QCloseEvent*)
@@ -563,6 +565,12 @@ void MemoryWidget::SetAddress(u32 address)
   raise();
 
   m_memory_view->setFocus();
+}
+
+void MemoryWidget::ActivateSearchAddress()
+{
+  m_search_address->setFocus();
+  m_search_address->lineEdit()->selectAll();
 }
 
 void MemoryWidget::OnSearchAddress()

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -82,6 +82,7 @@ private:
   void RegisterAfterFrameEventCallback();
   void RemoveAfterFrameEventCallback();
   void AutoUpdateTable();
+  void ActivateSearchAddress();
 
   Core::System& m_system;
 


### PR DESCRIPTION
Makes it possible to jump directly to address search box for code view and memory view by pressing CTRL+G. Similar to many debuggers/disassemblers/IDEs.