### PR TITLE
GameSettings: fix startup hang in Moki Moki

### DIFF
--- a/Data/Sys/GameSettings/WMOEE9.ini
+++ b/Data/Sys/GameSettings/WMOEE9.ini
@@ -1,0 +1,7 @@
+# WMOEE9 - Moki Moki
+
+[OnFrame_Enabled]
+$Fix startup hang
+[OnFrame]
+$Fix startup hang
+0x8001729C:dword:0x4182FFF8

--- a/Data/Sys/GameSettings/WMOJE9.ini
+++ b/Data/Sys/GameSettings/WMOJE9.ini
@@ -1,0 +1,7 @@
+# WMOJE9 - Anata ga Mawashite Sukuu Puzzle - Mochi Mochi Q
+
+[OnFrame_Enabled]
+$Fix startup hang
+[OnFrame]
+$Fix startup hang
+0x80018894:dword:0x4182FFF8

--- a/Data/Sys/GameSettings/WMOPE9.ini
+++ b/Data/Sys/GameSettings/WMOPE9.ini
@@ -1,0 +1,7 @@
+# WMOPE9 - Moki Moki
+
+[OnFrame_Enabled]
+$Fix startup hang
+[OnFrame]
+$Fix startup hang
+0x8001729C:dword:0x4182FFF8


### PR DESCRIPTION
The game sets up a fifo breakpoint callback that just writes a flag to memory. The hang occurs right after calling GXEnableBreakPt(). It is a busy loop that repeatedly compares the same register without reloading it from memory. I guess the developers forgot to make the variable atomic and never noticed because on hardware the breakpoint is hit immediately so the flag is already set when it is loaded for the first (and only) time. This patch grows the loop by one instruction to include the flag load in the loop.

This fixes [issue 13730](https://bugs.dolphin-emu.org/issues/13730).