### PR TITLE
CMakeLists: Bump minimum macOS to 11.0

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -60,10 +60,6 @@ DEFAULT_CONFIG = {
     # permissions needed for ARM builds
     "codesign_identity":  "-",
 
-    # Minimum macOS version for each architecture slice
-    "arm64_mac_os_deployment_target":  "11.0.0",
-    "x86_64_mac_os_deployment_target": "10.15.0",
-
     # CMake Generator to use for building
     "generator": "Unix Makefiles",
     "build_type": "Release",
@@ -145,11 +141,6 @@ def parse_args(conf=DEFAULT_CONFIG):
              f"--{arch}_qt5_path",
              help=f"Install path for {arch} qt5 libraries",
              default=conf[arch+"_qt5_path"])
-
-        parser.add_argument(
-             f"--{arch}_mac_os_deployment_target",
-             help=f"Deployment architecture for {arch} slice",
-             default=conf[arch+"_mac_os_deployment_target"])
 
     return vars(parser.parse_args())
 
@@ -297,8 +288,6 @@ def build(config):
                 "-DCMAKE_PREFIX_PATH="+prefix_path,
                 "-DCMAKE_SYSTEM_PROCESSOR="+arch,
                 "-DCMAKE_IGNORE_PATH="+ignore_path,
-                "-DCMAKE_OSX_DEPLOYMENT_TARGET="
-                + config[arch+"_mac_os_deployment_target"],
                 "-DMACOS_CODE_SIGNING_IDENTITY="
                 + config["codesign_identity"],
                 '-DMACOS_CODE_SIGNING="ON"',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 # Minimum OS X version.
 # This is inserted into the Info.plist as well.
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15.0" CACHE STRING "")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0.0" CACHE STRING "")
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_CURRENT_SOURCE_DIR}/CMake/FlagsOverride.cmake")
 

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 * OS
     * Windows (10 1903 or higher).
     * Linux.
-    * macOS (10.15 Catalina or higher).
+    * macOS (11.0 Big Sur or higher).
     * Unix-like systems other than Linux are not officially supported but might work.
 * Processor
     * A CPU with SSE2 support.

--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -97,10 +97,7 @@ void JITPageWriteEnableExecuteDisable()
 #if defined(_M_ARM_64) && defined(__APPLE__)
   if (JITPageWriteNestCounter() == 0)
   {
-    if (__builtin_available(macOS 11.0, *))
-    {
-      pthread_jit_write_protect_np(0);
-    }
+    pthread_jit_write_protect_np(0);
   }
 #endif
   JITPageWriteNestCounter()++;
@@ -119,10 +116,7 @@ void JITPageWriteDisableExecuteEnable()
 #if defined(_M_ARM_64) && defined(__APPLE__)
   if (JITPageWriteNestCounter() == 0)
   {
-    if (__builtin_available(macOS 11.0, *))
-    {
-      pthread_jit_write_protect_np(1);
-    }
+    pthread_jit_write_protect_np(1);
   }
 #endif
 }

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -565,14 +565,7 @@ std::optional<std::string> Metal::Util::TranslateShaderToMSL(ShaderStage stage,
 
   spirv_cross::CompilerMSL compiler(std::move(*code));
 
-  if (@available(macOS 11, iOS 14, *))
-    options.set_msl_version(2, 3);
-  else if (@available(macOS 10.15, iOS 13, *))
-    options.set_msl_version(2, 2);
-  else if (@available(macOS 10.14, iOS 12, *))
-    options.set_msl_version(2, 1);
-  else
-    options.set_msl_version(2, 0);
+  options.set_msl_version(2, 3);
   options.use_framebuffer_fetch_subpasses = true;
   compiler.set_msl_options(options);
 

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -262,15 +262,11 @@ void Metal::Util::PopulateBackendInfoFeatures(const VideoConfig& config, Backend
   backend_info->bSupportsST3CTextures = true;
   backend_info->bSupportsBPTCTextures = true;
 #else
-  bool supports_apple4 = false;
+  backend_info->bSupportsDepthClamp = [device supportsFamily:MTLGPUFamilyApple4];
+
   bool supports_bcn = false;
-  if (@available(iOS 13, *))
-    supports_apple4 = [device supportsFamily:MTLGPUFamilyApple4];
-  else
-    supports_apple4 = [device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily4_v1];
   if (@available(iOS 16.4, *))
     supports_bcn = [device supportsBCTextureCompression];
-  backend_info->bSupportsDepthClamp = supports_apple4;
   backend_info->bSupportsST3CTextures = supports_bcn;
   backend_info->bSupportsBPTCTextures = supports_bcn;
 

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -324,9 +324,8 @@ void Metal::Util::PopulateBackendInfoFeatures(const VideoConfig& config, Backend
     }
   }
 #if TARGET_OS_OSX
-  if (@available(macOS 11, *))
-    if (vendor == DriverDetails::VENDOR_INTEL)
-      backend_info->bSupportsFramebufferFetch |= DetectIntelGPUFBFetch(device);
+  if (vendor == DriverDetails::VENDOR_INTEL)
+    backend_info->bSupportsFramebufferFetch |= DetectIntelGPUFBFetch(device);
 #endif
   if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING))
     backend_info->bSupportsDynamicSamplerIndexing = false;

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -304,14 +304,8 @@ void Metal::Util::PopulateBackendInfoFeatures(const VideoConfig& config, Backend
     break;
   }
 
-  g_features.subgroup_ops = false;
-  if (@available(macOS 10.15, iOS 13, *))
-  {
-    // Requires SIMD-scoped reduction operations
-    g_features.subgroup_ops =
-        [device supportsFamily:MTLGPUFamilyMac2] || [device supportsFamily:MTLGPUFamilyApple7];
-    backend_info->bSupportsFramebufferFetch = [device supportsFamily:MTLGPUFamilyApple1];
-  }
+  g_features.subgroup_ops =
+      [device supportsFamily:MTLGPUFamilyMac2] || [device supportsFamily:MTLGPUFamilyApple7];
   if (g_features.subgroup_ops)
   {
     DetectionResult result = DetectInvertedIsHelper(device);
@@ -322,10 +316,13 @@ void Metal::Util::PopulateBackendInfoFeatures(const VideoConfig& config, Backend
         DriverDetails::OverrideBug(DriverDetails::BUG_INVERTED_IS_HELPER, is_helper_inverted);
     }
   }
+
+  backend_info->bSupportsFramebufferFetch = [device supportsFamily:MTLGPUFamilyApple1];
 #if TARGET_OS_OSX
   if (vendor == DriverDetails::VENDOR_INTEL)
     backend_info->bSupportsFramebufferFetch |= DetectIntelGPUFBFetch(device);
 #endif
+
   if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DYNAMIC_SAMPLER_INDEXING))
     backend_info->bSupportsDynamicSamplerIndexing = false;
 }

--- a/Source/Core/VideoBackends/Metal/MTLUtil.mm
+++ b/Source/Core/VideoBackends/Metal/MTLUtil.mm
@@ -295,9 +295,8 @@ void Metal::Util::PopulateBackendInfoFeatures(const VideoConfig& config, Backend
   case TriState::Auto:
 #if TARGET_OS_OSX
     g_features.manual_buffer_upload = false;
-    if (@available(macOS 10.15, *))
-      if (![device hasUnifiedMemory])
-        g_features.manual_buffer_upload = true;
+    if (![device hasUnifiedMemory])
+      g_features.manual_buffer_upload = true;
 #else
     // All iOS devices have unified memory
     g_features.manual_buffer_upload = false;


### PR DESCRIPTION
Bumps the minimum macOS version to 11.0 Big Sur. I've also gone ahead and removed some checks for macOS 10.15 which were missed when the last version bump happened.

Approximately ~2.6% of our macOS users within the past 30 days (and have analytics enabled) are running a version of macOS 10.15 Catalina.

<details>
<summary>Analytics data</summary>

macOS Version | Unique Users
| -- | -- |
15.5.0 | 1
15.4.0 | 571
15.3.2 | 4484
15.3.1 | 4869
15.3.0 | 626
15.2.0 | 802
15.1.1 | 560
15.1.0 | 411
15.0.1 | 304
15.0.0 | 265
14.7.5 | 4
14.7.4 | 247
14.7.3 | 67
14.7.2 | 67
14.7.1 | 74
14.7.0 | 70
14.6.1 | 917
14.6.0 | 195
14.5.0 | 905
14.4.1 | 323
14.4.0 | 169
14.3.1 | 113
14.3.0 | 155
14.2.1 | 163
14.2.0 | 37
14.1.2 | 43
14.1.1 | 66
14.1.0 | 58
14.0.0 | 102
13.7.5 | 12
13.7.4 | 420
13.7.3 | 55
13.7.2 | 61
13.7.1 | 72
13.7.0 | 29
13.6.9 | 37
13.6.8 | 2
13.6.7 | 60
13.6.6 | 43
13.6.5 | 4
13.6.4 | 17
13.6.3 | 22
13.6.2 | 2
13.6.1 | 24
13.6.0 | 15
13.5.2 | 27
13.5.1 | 51
13.5.0 | 102
13.4.1 | 58
13.4.0 | 111
13.3.1 | 59
13.3.0 | 37
13.2.1 | 110
13.2.0 | 20
13.1.0 | 49
13.0.1 | 40
13.0.0 | 121
12.7.6 | 949
12.7.5 | 117
12.7.4 | 146
12.7.3 | 30
12.7.2 | 19
12.7.1 | 21
12.7.0 | 10
12.6.9 | 4
12.6.8 | 10
12.6.7 | 23
12.6.6 | 14
12.6.5 | 22
12.6.4 | 5
12.6.3 | 23
12.6.2 | 7
12.6.1 | 15
12.6.0 | 37
12.5.1 | 43
12.5.0 | 65
12.4.0 | 46
12.3.1 | 27
12.3.0 | 24
12.2.1 | 43
12.2.0 | 8
12.1.0 | 34
12.0.1 | 47
12.0.0 | 2
11.7.10 | 412
11.7.9 | 12
11.7.8 | 9
11.7.7 | 7
11.7.6 | 3
11.7.5 | 2
11.7.4 | 10
11.7.3 | 1
11.7.2 | 3
11.7.1 | 3
11.7.0 | 6
11.6.8 | 1
11.6.7 | 3
11.6.6 | 1
11.6.5 | 2
11.6.4 | 4
11.6.3 | 1
11.6.2 | 5
11.6.0 | 23
11.5.2 | 14
11.5.1 | 8
11.5.0 | 2
11.4.0 | 16
11.3.1 | 9
11.3.0 | 5
11.2.3 | 18
11.2.2 | 4
11.2.1 | 7
11.2.0 | 6
11.1.0 | 10
11.0.1 | 7
11.0.0 | 1
10.16.0 | 483
10.15.7 | 530
10.15.6 | 9
10.15.5 | 7
10.15.4 | 4
10.15.3 | 7
10.15.2 | 2
10.15.1 | 2
10.15.0 | 5
10.14.6 | 67
10.14.5 | 2
10.14.2 | 1
10.13.6 | 153
10.13.3 | 2
10.13.1 | 5
10.13.0 | 4
10.12.6 | 22
10.12.5 | 1
10.12.3 | 1
10.11.6 | 3
10.9.5 | 2
</details>
