### PR TITLE
VideoBackends/Metal: Fix anisotropic filtering handling.

### DIFF
--- a/Source/Core/VideoBackends/Metal/MTLObjectCache.h
+++ b/Source/Core/VideoBackends/Metal/MTLObjectCache.h
@@ -44,7 +44,7 @@ struct DepthStencilSelector
 
 struct SamplerSelector
 {
-  u8 value;
+  u16 value;
   SamplerSelector() : value(0) {}
   SamplerSelector(SamplerState state)
   {
@@ -54,17 +54,17 @@ struct SamplerSelector
             (static_cast<u32>(state.tm0.anisotropic_filtering) << 3);
     value |= (static_cast<u32>(state.tm0.wrap_u.Value()) +
               3 * static_cast<u32>(state.tm0.wrap_v.Value()))
-             << 4;
+             << 7;
   }
   FilterMode MinFilter() const { return static_cast<FilterMode>(value & 1); }
   FilterMode MagFilter() const { return static_cast<FilterMode>((value >> 1) & 1); }
   FilterMode MipFilter() const { return static_cast<FilterMode>((value >> 2) & 1); }
-  WrapMode WrapU() const { return static_cast<WrapMode>((value >> 4) % 3); }
-  WrapMode WrapV() const { return static_cast<WrapMode>((value >> 4) / 3); }
-  bool AnisotropicFiltering() const { return ((value >> 3) & 1); }
+  WrapMode WrapU() const { return static_cast<WrapMode>((value >> 7) % 3); }
+  WrapMode WrapV() const { return static_cast<WrapMode>((value >> 7) / 3); }
+  u32 AnisotropicFiltering() const { return ((value >> 3) & 0xf); }
 
   bool operator==(const SamplerSelector& other) const { return value == other.value; }
-  static constexpr size_t N_VALUES = (1 << 4) * 9;
+  static constexpr size_t N_VALUES = (1 << 7) * 9;
 };
 
 class ObjectCache

--- a/Source/Core/VideoBackends/Metal/MTLObjectCache.mm
+++ b/Source/Core/VideoBackends/Metal/MTLObjectCache.mm
@@ -173,10 +173,10 @@ MRCOwned<id<MTLSamplerState>> Metal::ObjectCache::CreateSampler(SamplerSelector 
     [desc setTAddressMode:Convert(sel.WrapV())];
     [desc setMaxAnisotropy:1 << sel.AnisotropicFiltering()];
     [desc setLabel:MRCTransfer([[NSString alloc]
-                       initWithFormat:@"%s%s%s %s%s%s", to_string(sel.MinFilter()),
+                       initWithFormat:@"%s%s%s %s%s%d", to_string(sel.MinFilter()),
                                       to_string(sel.MagFilter()), to_string(sel.MipFilter()),
                                       to_string(sel.WrapU()), to_string(sel.WrapV()),
-                                      sel.AnisotropicFiltering() ? "(AF)" : ""])];
+                                      1 << sel.AnisotropicFiltering()])];
     return MRCTransfer([Metal::g_device newSamplerStateWithDescriptor:desc]);
   }
 }


### PR DESCRIPTION
This is an attempt to fix my regression of #13368 

Ideally `SamplerSelector` wouldn't be so fragile with all those magic numbers, but it is what it is.