### PR TITLE
Mixer: Keep actual sample rates rather than divisors.

### DIFF
--- a/Source/Core/AudioCommon/WaveFile.h
+++ b/Source/Core/AudioCommon/WaveFile.h
@@ -30,13 +30,13 @@ public:
   WaveFileWriter(WaveFileWriter&&) = delete;
   WaveFileWriter& operator=(WaveFileWriter&&) = delete;
 
-  bool Start(const std::string& filename, u32 sample_rate_divisor);
+  bool Start(const std::string& filename, u32 sample_rate);
   void Stop();
 
   void SetSkipSilence(bool skip) { skip_silence = skip; }
   // big endian
-  void AddStereoSamplesBE(const short* sample_data, u32 count, u32 sample_rate_divisor,
-                          int l_volume, int r_volume);
+  void AddStereoSamplesBE(const short* sample_data, u32 count, u32 sample_rate, int l_volume,
+                          int r_volume);
   u32 GetAudioSize() const { return audio_size; }
 
 private:
@@ -50,7 +50,7 @@ private:
   u32 file_index = 0;
   u32 audio_size = 0;
 
-  u32 current_sample_rate_divisor;
+  u32 current_sample_rate;
   std::array<short, BUFFER_SIZE> conv_buffer{};
 
   bool skip_silence = false;

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -71,8 +71,8 @@ enum
 };
 
 AudioInterfaceManager::AudioInterfaceManager(Core::System& system)
-    : m_ais_sample_rate_divisor(Mixer::FIXED_SAMPLE_RATE_DIVIDEND / 48000),
-      m_aid_sample_rate_divisor(Mixer::FIXED_SAMPLE_RATE_DIVIDEND / 32000), m_system(system)
+    : m_ais_sample_rate_divisor(FIXED_SAMPLE_RATE_DIVIDEND / 48000),
+      m_aid_sample_rate_divisor(FIXED_SAMPLE_RATE_DIVIDEND / 32000), m_system(system)
 {
 }
 
@@ -125,8 +125,7 @@ void AudioInterfaceManager::IncreaseSampleCount(const u32 amount)
 int AudioInterfaceManager::GetAIPeriod() const
 {
   u64 period = m_cpu_cycles_per_sample * (m_interrupt_timing - m_sample_counter);
-  u64 s_period =
-      m_cpu_cycles_per_sample * Mixer::FIXED_SAMPLE_RATE_DIVIDEND / m_ais_sample_rate_divisor;
+  u64 s_period = m_cpu_cycles_per_sample * FIXED_SAMPLE_RATE_DIVIDEND / m_ais_sample_rate_divisor;
   if (period == 0)
     return static_cast<int>(s_period);
   return static_cast<int>(std::min(period, s_period));
@@ -168,7 +167,8 @@ void AudioInterfaceManager::SetAIDSampleRate(SampleRate sample_rate)
   }
 
   SoundStream* sound_stream = m_system.GetSoundStream();
-  sound_stream->GetMixer()->SetDMAInputSampleRateDivisor(m_aid_sample_rate_divisor);
+  sound_stream->GetMixer()->SetDMAInputSampleRate(FIXED_SAMPLE_RATE_DIVIDEND /
+                                                  m_aid_sample_rate_divisor);
 }
 
 void AudioInterfaceManager::SetAISSampleRate(SampleRate sample_rate)
@@ -185,9 +185,10 @@ void AudioInterfaceManager::SetAISSampleRate(SampleRate sample_rate)
   }
 
   m_cpu_cycles_per_sample = static_cast<u64>(m_system.GetSystemTimers().GetTicksPerSecond()) *
-                            m_ais_sample_rate_divisor / Mixer::FIXED_SAMPLE_RATE_DIVIDEND;
+                            m_ais_sample_rate_divisor / FIXED_SAMPLE_RATE_DIVIDEND;
   SoundStream* sound_stream = m_system.GetSoundStream();
-  sound_stream->GetMixer()->SetStreamInputSampleRateDivisor(m_ais_sample_rate_divisor);
+  sound_stream->GetMixer()->SetStreamInputSampleRate(FIXED_SAMPLE_RATE_DIVIDEND /
+                                                     m_ais_sample_rate_divisor);
 }
 
 void AudioInterfaceManager::Init()

--- a/Source/Core/Core/HW/AudioInterface.h
+++ b/Source/Core/Core/HW/AudioInterface.h
@@ -23,6 +23,9 @@ class Mapping;
 
 namespace AudioInterface
 {
+// 54000000 doesn't work here as it doesn't evenly divide with 32000, but 108000000 does
+static constexpr u64 FIXED_SAMPLE_RATE_DIVIDEND = 54000000 * 2;
+
 enum class SampleRate
 {
   AI32KHz,

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -237,7 +237,7 @@ void DVDInterface::DTKStreamingCallback(DIInterruptType interrupt_type,
   // Read the next chunk of audio data asynchronously.
   s64 ticks_to_dtk = m_system.GetSystemTimers().GetTicksPerSecond() * s64(m_pending_blocks) *
                      StreamADPCM::SAMPLES_PER_BLOCK * sample_rate_divisor /
-                     Mixer::FIXED_SAMPLE_RATE_DIVIDEND;
+                     AudioInterface::FIXED_SAMPLE_RATE_DIVIDEND;
   ticks_to_dtk -= cycles_late;
   if (read_length > 0)
   {

--- a/Source/Core/Core/HW/GBACore.cpp
+++ b/Source/Core/Core/HW/GBACore.cpp
@@ -407,8 +407,7 @@ void Core::SetSampleRates()
   blip_set_rates(m_core->getAudioChannel(m_core, 1), m_core->frequency(m_core), SAMPLE_RATE);
 
   SoundStream* sound_stream = m_system.GetSoundStream();
-  sound_stream->GetMixer()->SetGBAInputSampleRateDivisors(
-      m_device_number, Mixer::FIXED_SAMPLE_RATE_DIVIDEND / SAMPLE_RATE);
+  sound_stream->GetMixer()->SetGBAInputSampleRate(m_device_number, SAMPLE_RATE);
 }
 
 void Core::AddCallbacks()

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -85,7 +85,7 @@ static int GetAudioDMACallbackPeriod(u32 cpu_core_clock, u32 aid_sample_rate_div
 {
   // System internal sample rate is fixed at 32KHz * 4 (16bit Stereo) / 32 bytes DMA
   return static_cast<u64>(cpu_core_clock) * aid_sample_rate_divisor /
-         (Mixer::FIXED_SAMPLE_RATE_DIVIDEND * 4 / 32);
+         (AudioInterface::FIXED_SAMPLE_RATE_DIVIDEND * 4 / 32);
 }
 
 void SystemTimersManager::AudioDMACallback(Core::System& system, u64 userdata, s64 cycles_late)

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -133,8 +133,8 @@ void SpeakerLogic::SpeakerData(const u8* data, int length, float speaker_pan)
 
   // ADPCM sample rate is thought to be x2.(3000 x2 = 6000).
   const unsigned int sample_rate = sample_rate_dividend / reg_data.sample_rate;
-  sound_stream->GetMixer()->PushWiimoteSpeakerSamples(
-      samples.data(), sample_length, Mixer::FIXED_SAMPLE_RATE_DIVIDEND / (sample_rate * 2));
+  sound_stream->GetMixer()->PushWiimoteSpeakerSamples(samples.data(), sample_length,
+                                                      sample_rate * 2);
 }
 
 void SpeakerLogic::Reset()

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -99,7 +99,7 @@ static size_t s_state_writes_in_queue;
 static std::condition_variable s_state_write_queue_is_empty;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 172;  // Last changed in PR 13385
+constexpr u32 STATE_VERSION = 173;  // Last changed in PR 13480
 
 // Increase this if the StateExtendedHeader definition changes
 constexpr u32 EXTENDED_HEADER_VERSION = 1;  // Last changed in PR 12217


### PR DESCRIPTION
PR #10762 introduced a `FIXED_SAMPLE_RATE_DIVIDEND` constant to keep sample rates as divisors rather than actual sample rates.

The divisors were just converted to normal sample rates upon use.
It unnecessarily made the interface of Mixer and WaveFile weird for no benefit.

I've moved the `FIXED_SAMPLE_RATE_DIVIDEND` constant from Mixer to AudioInterface and made Mixer/WaveFile take normal sample rate values like before.