### PR TITLE
Game setting fix: Monster Hunter Tri bloom

### DIFF
--- a/Data/Sys/GameSettings/RMH.ini
+++ b/Data/Sys/GameSettings/RMH.ini
@@ -11,3 +11,4 @@
 
 [Video_Hacks]
 ImmediateXFBEnable = False
+EFBAccessEnable = True


### PR DESCRIPTION
Bug: MH Tri has super bloom issues.
https://bugs.dolphin-emu.org/issues/13689

Relevant PR: Changes global default for EFBAccessEnable
https://github.com/dolphin-emu/dolphin/pull/13140

Set EFBAccessEnable = True to return it to normal behavior.