### PR TITLE
IOS: Only have one USB scanning thread

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -154,6 +154,7 @@ add_library(common
   VariantUtil.h
   Version.cpp
   Version.h
+  WaitableFlag.h
   WindowSystemInfo.h
   WorkQueueThread.h
 )

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -449,6 +449,8 @@ add_library(core
   IOS/USB/USB_KBD.h
   IOS/USB/USB_VEN/VEN.cpp
   IOS/USB/USB_VEN/VEN.h
+  IOS/USB/USBScanner.cpp
+  IOS/USB/USBScanner.h
   IOS/USB/USBV0.cpp
   IOS/USB/USBV0.h
   IOS/USB/USBV4.cpp

--- a/Source/Core/Core/IOS/USB/Common.cpp
+++ b/Source/Core/Core/IOS/USB/Common.cpp
@@ -15,6 +15,11 @@
 
 namespace IOS::HLE::USB
 {
+EmulationKernel& TransferCommand::GetEmulationKernel() const
+{
+  return m_ios;
+}
+
 std::unique_ptr<u8[]> TransferCommand::MakeBuffer(const size_t size) const
 {
   ASSERT_MSG(IOS_USB, data_address != 0, "Invalid data_address");

--- a/Source/Core/Core/IOS/USB/Common.h
+++ b/Source/Core/Core/IOS/USB/Common.h
@@ -106,6 +106,8 @@ struct TransferCommand
   {
   }
   virtual ~TransferCommand() = default;
+
+  EmulationKernel& GetEmulationKernel() const;
   // Called after a transfer has completed to reply to the IPC request.
   // This can be overridden for additional processing before replying.
   virtual void OnTransferComplete(s32 return_value) const;

--- a/Source/Core/Core/IOS/USB/Emulated/Infinity.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Infinity.cpp
@@ -137,7 +137,7 @@ static constexpr std::array<u8, 32> SHA1_CONSTANT = {
 static constexpr std::array<u8, 16> BLANK_BLOCK = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-InfinityUSB::InfinityUSB(EmulationKernel& ios) : m_ios(ios)
+InfinityUSB::InfinityUSB()
 {
   m_vid = 0x0E6F;
   m_pid = 0x0129;
@@ -241,7 +241,7 @@ int InfinityUSB::SubmitTransfer(std::unique_ptr<IntrMessage> cmd)
   DEBUG_LOG_FMT(IOS_USB, "[{:04x}:{:04x} {}] Interrupt: length={:04x} endpoint={:02x}", m_vid,
                 m_pid, m_active_interface, cmd->length, cmd->endpoint);
 
-  auto& system = m_ios.GetSystem();
+  auto& system = cmd->GetEmulationKernel().GetSystem();
   auto& memory = system.GetMemory();
   auto& infinity_base = system.GetInfinityBase();
   u8* buf = memory.GetPointerForRange(cmd->data_address, cmd->length);

--- a/Source/Core/Core/IOS/USB/Emulated/Infinity.h
+++ b/Source/Core/Core/IOS/USB/Emulated/Infinity.h
@@ -32,7 +32,7 @@ struct InfinityFigure final
 class InfinityUSB final : public Device
 {
 public:
-  InfinityUSB(EmulationKernel& ios);
+  InfinityUSB();
   ~InfinityUSB() override;
   DeviceDescriptor GetDeviceDescriptor() const override;
   std::vector<ConfigDescriptor> GetConfigurations() const override;
@@ -53,7 +53,6 @@ private:
   void ScheduleTransfer(std::unique_ptr<TransferCommand> command, const std::array<u8, 32>& data,
                         u64 expected_time_us);
 
-  EmulationKernel& m_ios;
   u16 m_vid = 0;
   u16 m_pid = 0;
   u8 m_active_interface = 0;

--- a/Source/Core/Core/IOS/USB/Emulated/Skylanders/Skylander.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Skylanders/Skylander.cpp
@@ -612,7 +612,7 @@ const std::map<const std::pair<const u16, const u16>, SkyData> list_skylanders =
     {{3503, 0x4000}, {"Kaos Trophy", Game::Superchargers, Element::Other, Type::Trophy}},
 };
 
-SkylanderUSB::SkylanderUSB(EmulationKernel& ios) : m_ios(ios)
+SkylanderUSB::SkylanderUSB()
 {
   m_vid = 0x1430;
   m_pid = 0x0150;
@@ -741,7 +741,7 @@ int SkylanderUSB::SubmitTransfer(std::unique_ptr<CtrlMessage> cmd)
   else
   {
     // Skylander Portal Requests
-    auto& system = m_ios.GetSystem();
+    auto& system = cmd->GetEmulationKernel().GetSystem();
     auto& memory = system.GetMemory();
     u8* buf = memory.GetPointerForRange(cmd->data_address, cmd->length);
     if (cmd->length == 0 || buf == nullptr)
@@ -1028,7 +1028,7 @@ int SkylanderUSB::SubmitTransfer(std::unique_ptr<IntrMessage> cmd)
   DEBUG_LOG_FMT(IOS_USB, "[{:04x}:{:04x} {}] Interrupt: length={} endpoint={}", m_vid, m_pid,
                 m_active_interface, cmd->length, cmd->endpoint);
 
-  auto& system = m_ios.GetSystem();
+  auto& system = cmd->GetEmulationKernel().GetSystem();
   auto& memory = system.GetMemory();
   u8* buf = memory.GetPointerForRange(cmd->data_address, cmd->length);
   if (cmd->length == 0 || buf == nullptr)

--- a/Source/Core/Core/IOS/USB/Emulated/Skylanders/Skylander.h
+++ b/Source/Core/Core/IOS/USB/Emulated/Skylanders/Skylander.h
@@ -72,7 +72,7 @@ extern const std::map<const std::pair<const u16, const u16>, SkyData> list_skyla
 class SkylanderUSB final : public Device
 {
 public:
-  SkylanderUSB(EmulationKernel& ios);
+  SkylanderUSB();
   ~SkylanderUSB();
   DeviceDescriptor GetDeviceDescriptor() const override;
   std::vector<ConfigDescriptor> GetConfigurations() const override;
@@ -92,7 +92,6 @@ public:
                         s32 expected_count, u64 expected_time_us);
 
 private:
-  EmulationKernel& m_ios;
   u16 m_vid = 0;
   u16 m_pid = 0;
   u8 m_active_interface = 0;

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -3,30 +3,17 @@
 
 #include "Core/IOS/USB/Host.h"
 
-#include <algorithm>
+#include <functional>
 #include <memory>
-#include <mutex>
-#include <set>
+#include <optional>
 #include <string>
-#include <utility>
 
-#ifdef __LIBUSB__
-#include <libusb.h>
-#endif
-
-#include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-#include "Common/Thread.h"
-#include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 #include "Core/IOS/USB/Common.h"
-#include "Core/IOS/USB/Emulated/Infinity.h"
-#include "Core/IOS/USB/Emulated/Skylanders/Skylander.h"
-#include "Core/IOS/USB/LibusbDevice.h"
-#include "Core/NetPlayProto.h"
-#include "Core/System.h"
+#include "Core/IOS/USB/USBScanner.h"
 
 namespace IOS::HLE
 {
@@ -35,16 +22,19 @@ USBHost::USBHost(EmulationKernel& ios, const std::string& device_name)
 {
 }
 
-USBHost::~USBHost() = default;
+USBHost::~USBHost()
+{
+  m_usb_scanner.Stop();
+}
 
 std::optional<IPCReply> USBHost::Open(const OpenRequest& request)
 {
   if (!m_has_initialised)
   {
-    GetScanThread().Start();
+    m_usb_scanner.Start();
     // Force a device scan to complete, because some games (including Your Shape) only care
     // about the initial device list (in the first GETDEVICECHANGE reply).
-    GetScanThread().WaitForFirstScan();
+    m_usb_scanner.WaitForFirstScan();
     m_has_initialised = true;
   }
   return IPCReply(IPC_SUCCESS);
@@ -53,9 +43,9 @@ std::optional<IPCReply> USBHost::Open(const OpenRequest& request)
 void USBHost::UpdateWantDeterminism(const bool new_want_determinism)
 {
   if (new_want_determinism)
-    GetScanThread().Stop();
+    m_usb_scanner.Stop();
   else if (IsOpened())
-    GetScanThread().Start();
+    m_usb_scanner.Start();
 }
 
 void USBHost::DoState(PointerWrap& p)
@@ -65,27 +55,13 @@ void USBHost::DoState(PointerWrap& p)
   {
     // After a state has loaded, there may be insertion hooks for devices that were
     // already plugged in, and which need to be triggered.
-    UpdateDevices(true);
+    m_usb_scanner.UpdateDevices(true);
   }
-}
-
-bool USBHost::AddDevice(std::unique_ptr<USB::Device> device)
-{
-  std::lock_guard lk(m_devices_mutex);
-  if (m_devices.contains(device->GetId()))
-    return false;
-
-  m_devices[device->GetId()] = std::move(device);
-  return true;
 }
 
 std::shared_ptr<USB::Device> USBHost::GetDeviceById(const u64 device_id) const
 {
-  std::lock_guard lk(m_devices_mutex);
-  const auto it = m_devices.find(device_id);
-  if (it == m_devices.end())
-    return nullptr;
-  return it->second;
+  return m_usb_scanner.GetDeviceById(device_id);
 }
 
 void USBHost::OnDeviceChange(ChangeEvent event, std::shared_ptr<USB::Device> changed_device)
@@ -104,69 +80,7 @@ bool USBHost::ShouldAddDevice(const USB::Device& device) const
 void USBHost::Update()
 {
   if (Core::WantsDeterminism())
-    UpdateDevices();
-}
-
-// This is called from the scan thread. Returns false if we failed to update the device list.
-bool USBHost::UpdateDevices(const bool always_add_hooks)
-{
-  DeviceChangeHooks hooks;
-  std::set<u64> plugged_devices;
-  // If we failed to get a new, up-to-date list of devices, we cannot detect device removals.
-  if (!AddNewDevices(plugged_devices, hooks, always_add_hooks))
-    return false;
-  DetectRemovedDevices(plugged_devices, hooks);
-  DispatchHooks(hooks);
-  return true;
-}
-
-bool USBHost::AddNewDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks,
-                            const bool always_add_hooks)
-{
-  AddEmulatedDevices(new_devices, hooks, always_add_hooks);
-#ifdef __LIBUSB__
-  if (!Core::WantsDeterminism())
-  {
-    auto whitelist = Config::GetUSBDeviceWhitelist();
-    if (whitelist.empty())
-      return true;
-
-    if (m_context.IsValid())
-    {
-      const int ret = m_context.GetDeviceList([&](libusb_device* device) {
-        libusb_device_descriptor descriptor;
-        libusb_get_device_descriptor(device, &descriptor);
-        if (!whitelist.contains({descriptor.idVendor, descriptor.idProduct}))
-          return true;
-
-        auto usb_device =
-            std::make_unique<USB::LibusbDevice>(GetEmulationKernel(), device, descriptor);
-        CheckAndAddDevice(std::move(usb_device), new_devices, hooks, always_add_hooks);
-        return true;
-      });
-      if (ret != LIBUSB_SUCCESS)
-        WARN_LOG_FMT(IOS_USB, "GetDeviceList failed: {}", LibusbUtils::ErrorWrap(ret));
-    }
-  }
-#endif
-  return true;
-}
-
-void USBHost::DetectRemovedDevices(const std::set<u64>& plugged_devices, DeviceChangeHooks& hooks)
-{
-  std::lock_guard lk(m_devices_mutex);
-  for (auto it = m_devices.begin(); it != m_devices.end();)
-  {
-    if (!plugged_devices.contains(it->second->GetId()))
-    {
-      hooks.emplace(it->second, ChangeEvent::Removed);
-      it = m_devices.erase(it);
-    }
-    else
-    {
-      ++it;
-    }
-  }
+    m_usb_scanner.UpdateDevices();
 }
 
 void USBHost::DispatchHooks(const DeviceChangeHooks& hooks)
@@ -180,80 +94,6 @@ void USBHost::DispatchHooks(const DeviceChangeHooks& hooks)
   }
   if (!hooks.empty())
     OnDeviceChangeEnd();
-}
-
-void USBHost::AddEmulatedDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks,
-                                 bool always_add_hooks)
-{
-  if (Config::Get(Config::MAIN_EMULATE_SKYLANDER_PORTAL) && !NetPlay::IsNetPlayRunning())
-  {
-    auto skylanderportal = std::make_unique<USB::SkylanderUSB>(GetEmulationKernel());
-    CheckAndAddDevice(std::move(skylanderportal), new_devices, hooks, always_add_hooks);
-  }
-  if (Config::Get(Config::MAIN_EMULATE_INFINITY_BASE) && !NetPlay::IsNetPlayRunning())
-  {
-    auto infinity_base = std::make_unique<USB::InfinityUSB>(GetEmulationKernel());
-    CheckAndAddDevice(std::move(infinity_base), new_devices, hooks, always_add_hooks);
-  }
-}
-
-void USBHost::CheckAndAddDevice(std::unique_ptr<USB::Device> device, std::set<u64>& new_devices,
-                                DeviceChangeHooks& hooks, bool always_add_hooks)
-{
-  if (ShouldAddDevice(*device))
-  {
-    const u64 deviceid = device->GetId();
-    new_devices.insert(deviceid);
-    if (AddDevice(std::move(device)) || always_add_hooks)
-    {
-      hooks.emplace(GetDeviceById(deviceid), ChangeEvent::Inserted);
-    }
-  }
-}
-
-USBHost::ScanThread::~ScanThread()
-{
-  Stop();
-}
-
-void USBHost::ScanThread::WaitForFirstScan()
-{
-  if (m_thread_running.IsSet())
-  {
-    m_first_scan_complete_event.Wait();
-  }
-}
-
-void USBHost::ScanThread::Start()
-{
-  if (Core::WantsDeterminism())
-  {
-    m_host->UpdateDevices();
-    return;
-  }
-  if (m_thread_running.TestAndSet())
-  {
-    m_thread = std::thread([this] {
-      Common::SetCurrentThreadName("USB Scan Thread");
-      while (m_thread_running.IsSet())
-      {
-        if (m_host->UpdateDevices())
-          m_first_scan_complete_event.Set();
-        Common::SleepCurrentThread(50);
-      }
-    });
-  }
-}
-
-void USBHost::ScanThread::Stop()
-{
-  if (m_thread_running.TestAndClear())
-    m_thread.join();
-
-  // Clear all devices and dispatch removal hooks.
-  DeviceChangeHooks hooks;
-  m_host->DetectRemovedDevices(std::set<u64>(), hooks);
-  m_host->DispatchHooks(hooks);
 }
 
 std::optional<IPCReply> USBHost::HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
@@ -270,4 +110,5 @@ std::optional<IPCReply> USBHost::HandleTransfer(std::shared_ptr<USB::Device> dev
                 device->GetVid(), device->GetPid(), request, device->GetErrorName(ret));
   return IPCReply(ret <= 0 ? ret : IPC_EINVAL);
 }
+
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -31,8 +31,6 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  virtual bool ShouldAddDevice(const USB::Device& device) const;
-
   void OnDevicesChanged(const USBScanner::DeviceMap& new_devices);
 
 protected:
@@ -46,14 +44,13 @@ protected:
   std::shared_ptr<USB::Device> GetDeviceById(u64 device_id) const;
   virtual void OnDeviceChange(ChangeEvent event, std::shared_ptr<USB::Device> changed_device);
   virtual void OnDeviceChangeEnd();
+  virtual bool ShouldAddDevice(const USB::Device& device) const;
 
   std::optional<IPCReply> HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
                                          std::function<s32()> submit) const;
 
   std::map<u64, std::shared_ptr<USB::Device>> m_devices;
   mutable std::recursive_mutex m_devices_mutex;
-
-  USBScanner m_usb_scanner{this};
 
 private:
   void Update() override;

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -3,23 +3,16 @@
 
 #pragma once
 
-#include <cstddef>
 #include <functional>
-#include <map>
 #include <memory>
-#include <mutex>
-#include <set>
+#include <optional>
 #include <string>
-#include <thread>
-#include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Common/Event.h"
-#include "Common/Flag.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Common.h"
-#include "Core/LibusbUtils.h"
+#include "Core/IOS/USB/USBScanner.h"
 
 class PointerWrap;
 
@@ -37,56 +30,26 @@ public:
   void UpdateWantDeterminism(bool new_want_determinism) override;
   void DoState(PointerWrap& p) override;
 
+  virtual bool ShouldAddDevice(const USB::Device& device) const;
+
+  void DispatchHooks(const USBScanner::DeviceChangeHooks& hooks);
+
 protected:
-  enum class ChangeEvent
-  {
-    Inserted,
-    Removed,
-  };
-  using DeviceChangeHooks = std::map<std::shared_ptr<USB::Device>, ChangeEvent>;
-
-  class ScanThread final
-  {
-  public:
-    explicit ScanThread(USBHost* host) : m_host(host) {}
-    ~ScanThread();
-    void Start();
-    void Stop();
-    void WaitForFirstScan();
-
-  private:
-    USBHost* m_host = nullptr;
-    Common::Flag m_thread_running;
-    std::thread m_thread;
-    Common::Event m_first_scan_complete_event;
-    Common::Flag m_is_initialized;
-  };
-
-  std::map<u64, std::shared_ptr<USB::Device>> m_devices;
-  mutable std::mutex m_devices_mutex;
+  using ChangeEvent = USBScanner::ChangeEvent;
+  using DeviceChangeHooks = USBScanner::DeviceChangeHooks;
 
   std::shared_ptr<USB::Device> GetDeviceById(u64 device_id) const;
   virtual void OnDeviceChange(ChangeEvent event, std::shared_ptr<USB::Device> changed_device);
   virtual void OnDeviceChangeEnd();
-  virtual bool ShouldAddDevice(const USB::Device& device) const;
-  virtual ScanThread& GetScanThread() = 0;
 
   std::optional<IPCReply> HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
                                          std::function<s32()> submit) const;
 
+  USBScanner m_usb_scanner{this};
+
 private:
-  bool AddDevice(std::unique_ptr<USB::Device> device);
   void Update() override;
-  bool UpdateDevices(bool always_add_hooks = false);
-  bool AddNewDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks, bool always_add_hooks);
-  void DetectRemovedDevices(const std::set<u64>& plugged_devices, DeviceChangeHooks& hooks);
-  void DispatchHooks(const DeviceChangeHooks& hooks);
-  void AddEmulatedDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks,
-                          bool always_add_hooks);
-  void CheckAndAddDevice(std::unique_ptr<USB::Device> device, std::set<u64>& new_devices,
-                         DeviceChangeHooks& hooks, bool always_add_hooks);
 
   bool m_has_initialised = false;
-  LibusbUtils::Context m_context;
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 
@@ -44,6 +46,9 @@ protected:
 
   std::optional<IPCReply> HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
                                          std::function<s32()> submit) const;
+
+  std::map<u64, std::shared_ptr<USB::Device>> m_devices;
+  mutable std::recursive_mutex m_devices_mutex;
 
   USBScanner m_usb_scanner{this};
 

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -29,16 +29,19 @@ public:
 
   std::optional<IPCReply> Open(const OpenRequest& request) override;
 
-  void UpdateWantDeterminism(bool new_want_determinism) override;
   void DoState(PointerWrap& p) override;
 
   virtual bool ShouldAddDevice(const USB::Device& device) const;
 
-  void DispatchHooks(const USBScanner::DeviceChangeHooks& hooks);
+  void OnDevicesChanged(const USBScanner::DeviceMap& new_devices);
 
 protected:
-  using ChangeEvent = USBScanner::ChangeEvent;
-  using DeviceChangeHooks = USBScanner::DeviceChangeHooks;
+  enum class ChangeEvent
+  {
+    Inserted,
+    Removed,
+  };
+  using DeviceChangeHooks = std::map<std::shared_ptr<USB::Device>, ChangeEvent>;
 
   std::shared_ptr<USB::Device> GetDeviceById(u64 device_id) const;
   virtual void OnDeviceChange(ChangeEvent event, std::shared_ptr<USB::Device> changed_device);
@@ -54,6 +57,7 @@ protected:
 
 private:
   void Update() override;
+  void OnDevicesChangedInternal(const USBScanner::DeviceMap& new_devices);
 
   bool m_has_initialised = false;
 };

--- a/Source/Core/Core/IOS/USB/LibusbDevice.h
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.h
@@ -26,8 +26,7 @@ namespace IOS::HLE::USB
 class LibusbDevice final : public Device
 {
 public:
-  LibusbDevice(EmulationKernel& ios, libusb_device* device,
-               const libusb_device_descriptor& device_descriptor);
+  LibusbDevice(libusb_device* device, const libusb_device_descriptor& device_descriptor);
   ~LibusbDevice();
   DeviceDescriptor GetDeviceDescriptor() const override;
   std::vector<ConfigDescriptor> GetConfigurations() const override;
@@ -46,8 +45,6 @@ public:
   int SubmitTransfer(std::unique_ptr<IsoMessage> message) override;
 
 private:
-  EmulationKernel& m_ios;
-
   std::vector<LibusbUtils::ConfigDescriptor> m_config_descriptors;
   u16 m_vid = 0;
   u16 m_pid = 0;

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -73,7 +73,7 @@ std::optional<IPCReply> OH0::IOCtlV(const IOCtlVRequest& request)
 
 void OH0::DoState(PointerWrap& p)
 {
-  if (p.IsReadMode() && !m_usb_scanner.m_devices.empty())
+  if (p.IsReadMode() && !m_devices.empty())
   {
     Core::DisplayMessage("It is suggested that you unplug and replug all connected USB devices.",
                          5000);
@@ -114,8 +114,8 @@ IPCReply OH0::GetDeviceList(const IOCtlVRequest& request) const
 
   const u8 interface_class = memory.Read_U8(request.in_vectors[1].address);
   u8 entries_count = 0;
-  std::lock_guard lk(m_usb_scanner.m_devices_mutex);
-  for (const auto& device : m_usb_scanner.m_devices)
+  std::lock_guard lk(m_devices_mutex);
+  for (const auto& device : m_devices)
   {
     if (entries_count >= max_entries_count)
       break;
@@ -231,14 +231,13 @@ std::optional<IPCReply> OH0::RegisterClassChangeHook(const IOCtlVRequest& reques
 
 bool OH0::HasDeviceWithVidPid(const u16 vid, const u16 pid) const
 {
-  return std::ranges::any_of(m_usb_scanner.m_devices, [=](const auto& device) {
+  return std::ranges::any_of(m_devices, [=](const auto& device) {
     return device.second->GetVid() == vid && device.second->GetPid() == pid;
   });
 }
 
 void OH0::OnDeviceChange(const ChangeEvent event, std::shared_ptr<USB::Device> device)
 {
-  std::lock_guard lk(m_usb_scanner.m_devices_mutex);
   if (event == ChangeEvent::Inserted)
     TriggerHook(m_insertion_hooks, {device->GetVid(), device->GetPid()}, IPC_SUCCESS);
   else if (event == ChangeEvent::Removed)
@@ -259,10 +258,10 @@ void OH0::TriggerHook(std::map<T, u32>& hooks, T value, const ReturnCode return_
 
 std::pair<ReturnCode, u64> OH0::DeviceOpen(const u16 vid, const u16 pid)
 {
-  std::lock_guard lk(m_usb_scanner.m_devices_mutex);
+  std::lock_guard lk(m_devices_mutex);
 
   bool has_device_with_vid_pid = false;
-  for (const auto& device : m_usb_scanner.m_devices)
+  for (const auto& device : m_devices)
   {
     if (device.second->GetVid() != vid || device.second->GetPid() != pid)
       continue;

--- a/Source/Core/Core/IOS/USB/OH0/OH0.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.h
@@ -64,8 +64,6 @@ private:
   template <typename T>
   void TriggerHook(std::map<T, u32>& hooks, T value, ReturnCode return_value);
 
-  ScanThread& GetScanThread() override { return m_scan_thread; }
-
   struct DeviceEntry
   {
     u32 unknown;
@@ -79,7 +77,5 @@ private:
   std::map<u64, u32> m_removal_hooks;
   std::set<u64> m_opened_devices;
   std::mutex m_hooks_mutex;
-
-  ScanThread m_scan_thread{this};
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBScanner.cpp
+++ b/Source/Core/Core/IOS/USB/USBScanner.cpp
@@ -1,0 +1,191 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Core/IOS/USB/USBScanner.h"
+
+#include <memory>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <utility>
+
+#ifdef __LIBUSB__
+#include <libusb.h>
+#endif
+
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
+#include "Common/Thread.h"
+#include "Core/Config/MainSettings.h"
+#include "Core/Core.h"
+#include "Core/IOS/USB/Common.h"
+#include "Core/IOS/USB/Emulated/Infinity.h"
+#include "Core/IOS/USB/Emulated/Skylanders/Skylander.h"
+#include "Core/IOS/USB/Host.h"
+#include "Core/IOS/USB/LibusbDevice.h"
+#include "Core/NetPlayProto.h"
+#include "Core/System.h"
+
+namespace IOS::HLE
+{
+USBScanner::USBScanner(USBHost* host) : m_host(host)
+{
+}
+
+USBScanner::~USBScanner()
+{
+  Stop();
+}
+
+void USBScanner::WaitForFirstScan()
+{
+  if (m_thread_running.IsSet())
+  {
+    m_first_scan_complete_event.Wait();
+  }
+}
+
+void USBScanner::Start()
+{
+  if (Core::WantsDeterminism())
+  {
+    UpdateDevices();
+    return;
+  }
+  if (m_thread_running.TestAndSet())
+  {
+    m_thread = std::thread([this] {
+      Common::SetCurrentThreadName("USB Scan Thread");
+      while (m_thread_running.IsSet())
+      {
+        if (UpdateDevices())
+          m_first_scan_complete_event.Set();
+        Common::SleepCurrentThread(50);
+      }
+    });
+  }
+}
+
+void USBScanner::Stop()
+{
+  if (m_thread_running.TestAndClear())
+    m_thread.join();
+
+  // Clear all devices and dispatch removal hooks.
+  DeviceChangeHooks hooks;
+  DetectRemovedDevices(std::set<u64>(), hooks);
+  m_host->DispatchHooks(hooks);
+}
+
+// This is called from the scan thread. Returns false if we failed to update the device list.
+bool USBScanner::UpdateDevices(const bool always_add_hooks)
+{
+  DeviceChangeHooks hooks;
+  std::set<u64> plugged_devices;
+  // If we failed to get a new, up-to-date list of devices, we cannot detect device removals.
+  if (!AddNewDevices(plugged_devices, hooks, always_add_hooks))
+    return false;
+  DetectRemovedDevices(plugged_devices, hooks);
+  m_host->DispatchHooks(hooks);
+  return true;
+}
+
+bool USBScanner::AddDevice(std::unique_ptr<USB::Device> device)
+{
+  std::lock_guard lk(m_devices_mutex);
+  if (m_devices.contains(device->GetId()))
+    return false;
+
+  m_devices[device->GetId()] = std::move(device);
+  return true;
+}
+
+bool USBScanner::AddNewDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks,
+                               const bool always_add_hooks)
+{
+  AddEmulatedDevices(new_devices, hooks, always_add_hooks);
+#ifdef __LIBUSB__
+  if (!Core::WantsDeterminism())
+  {
+    auto whitelist = Config::GetUSBDeviceWhitelist();
+    if (whitelist.empty())
+      return true;
+
+    if (m_context.IsValid())
+    {
+      const int ret = m_context.GetDeviceList([&](libusb_device* device) {
+        libusb_device_descriptor descriptor;
+        libusb_get_device_descriptor(device, &descriptor);
+        if (!whitelist.contains({descriptor.idVendor, descriptor.idProduct}))
+          return true;
+
+        auto usb_device =
+            std::make_unique<USB::LibusbDevice>(m_host->GetEmulationKernel(), device, descriptor);
+        CheckAndAddDevice(std::move(usb_device), new_devices, hooks, always_add_hooks);
+        return true;
+      });
+      if (ret != LIBUSB_SUCCESS)
+        WARN_LOG_FMT(IOS_USB, "GetDeviceList failed: {}", LibusbUtils::ErrorWrap(ret));
+    }
+  }
+#endif
+  return true;
+}
+
+void USBScanner::DetectRemovedDevices(const std::set<u64>& plugged_devices,
+                                      DeviceChangeHooks& hooks)
+{
+  std::lock_guard lk(m_devices_mutex);
+  for (auto it = m_devices.begin(); it != m_devices.end();)
+  {
+    if (!plugged_devices.contains(it->second->GetId()))
+    {
+      hooks.emplace(it->second, ChangeEvent::Removed);
+      it = m_devices.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+}
+
+void USBScanner::AddEmulatedDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks,
+                                    bool always_add_hooks)
+{
+  if (Config::Get(Config::MAIN_EMULATE_SKYLANDER_PORTAL) && !NetPlay::IsNetPlayRunning())
+  {
+    auto skylanderportal = std::make_unique<USB::SkylanderUSB>(m_host->GetEmulationKernel());
+    CheckAndAddDevice(std::move(skylanderportal), new_devices, hooks, always_add_hooks);
+  }
+  if (Config::Get(Config::MAIN_EMULATE_INFINITY_BASE) && !NetPlay::IsNetPlayRunning())
+  {
+    auto infinity_base = std::make_unique<USB::InfinityUSB>(m_host->GetEmulationKernel());
+    CheckAndAddDevice(std::move(infinity_base), new_devices, hooks, always_add_hooks);
+  }
+}
+
+void USBScanner::CheckAndAddDevice(std::unique_ptr<USB::Device> device, std::set<u64>& new_devices,
+                                   DeviceChangeHooks& hooks, bool always_add_hooks)
+{
+  if (m_host->ShouldAddDevice(*device))
+  {
+    const u64 deviceid = device->GetId();
+    new_devices.insert(deviceid);
+    if (AddDevice(std::move(device)) || always_add_hooks)
+    {
+      hooks.emplace(GetDeviceById(deviceid), ChangeEvent::Inserted);
+    }
+  }
+}
+
+std::shared_ptr<USB::Device> USBScanner::GetDeviceById(const u64 device_id) const
+{
+  std::lock_guard lk(m_devices_mutex);
+  const auto it = m_devices.find(device_id);
+  if (it == m_devices.end())
+    return nullptr;
+  return it->second;
+}
+
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBScanner.h
+++ b/Source/Core/Core/IOS/USB/USBScanner.h
@@ -24,33 +24,24 @@ class USBHost;
 class USBScanner final
 {
 public:
+  using DeviceMap = std::map<u64, std::shared_ptr<USB::Device>>;
+
   explicit USBScanner(USBHost* host);
   ~USBScanner();
 
   void Start();
   void Stop();
   void WaitForFirstScan();
-  bool UpdateDevices(bool always_add_hooks = false);
 
-  enum class ChangeEvent
-  {
-    Inserted,
-    Removed,
-  };
-  using DeviceChangeHooks = std::map<std::shared_ptr<USB::Device>, ChangeEvent>;
+  DeviceMap GetDevices() const;
 
 private:
-  bool AddDevice(std::unique_ptr<USB::Device> device);
-  bool AddNewDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks, bool always_add_hooks);
-  void DetectRemovedDevices(const std::set<u64>& plugged_devices, DeviceChangeHooks& hooks);
-  void AddEmulatedDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks,
-                          bool always_add_hooks);
-  void CheckAndAddDevice(std::unique_ptr<USB::Device> device, std::set<u64>& new_devices,
-                         DeviceChangeHooks& hooks, bool always_add_hooks);
+  bool UpdateDevices();
+  bool AddNewDevices(DeviceMap* new_devices) const;
+  void AddEmulatedDevices(DeviceMap* new_devices) const;
+  void AddDevice(std::unique_ptr<USB::Device> device, DeviceMap* new_devices) const;
 
-  std::shared_ptr<USB::Device> GetDeviceById(u64 device_id) const;
-
-  std::map<u64, std::shared_ptr<USB::Device>> m_devices;
+  DeviceMap m_devices;
   mutable std::mutex m_devices_mutex;
 
   USBHost* m_host = nullptr;

--- a/Source/Core/Core/IOS/USB/USBScanner.h
+++ b/Source/Core/Core/IOS/USB/USBScanner.h
@@ -1,0 +1,64 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <thread>
+
+#include "Common/CommonTypes.h"
+#include "Common/Event.h"
+#include "Common/Flag.h"
+#include "Core/IOS/USB/Common.h"
+#include "Core/LibusbUtils.h"
+
+class PointerWrap;
+
+namespace IOS::HLE
+{
+class USBHost;
+
+class USBScanner final
+{
+public:
+  explicit USBScanner(USBHost* host);
+  ~USBScanner();
+
+  void Start();
+  void Stop();
+  void WaitForFirstScan();
+  bool UpdateDevices(bool always_add_hooks = false);
+
+  std::shared_ptr<USB::Device> GetDeviceById(u64 device_id) const;
+
+  enum class ChangeEvent
+  {
+    Inserted,
+    Removed,
+  };
+  using DeviceChangeHooks = std::map<std::shared_ptr<USB::Device>, ChangeEvent>;
+
+  std::map<u64, std::shared_ptr<USB::Device>> m_devices;
+  mutable std::mutex m_devices_mutex;
+
+private:
+  bool AddDevice(std::unique_ptr<USB::Device> device);
+  bool AddNewDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks, bool always_add_hooks);
+  void DetectRemovedDevices(const std::set<u64>& plugged_devices, DeviceChangeHooks& hooks);
+  void AddEmulatedDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks,
+                          bool always_add_hooks);
+  void CheckAndAddDevice(std::unique_ptr<USB::Device> device, std::set<u64>& new_devices,
+                         DeviceChangeHooks& hooks, bool always_add_hooks);
+
+  USBHost* m_host = nullptr;
+  Common::Flag m_thread_running;
+  std::thread m_thread;
+  Common::Event m_first_scan_complete_event;
+
+  LibusbUtils::Context m_context;
+};
+
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBScanner.h
+++ b/Source/Core/Core/IOS/USB/USBScanner.h
@@ -32,17 +32,12 @@ public:
   void WaitForFirstScan();
   bool UpdateDevices(bool always_add_hooks = false);
 
-  std::shared_ptr<USB::Device> GetDeviceById(u64 device_id) const;
-
   enum class ChangeEvent
   {
     Inserted,
     Removed,
   };
   using DeviceChangeHooks = std::map<std::shared_ptr<USB::Device>, ChangeEvent>;
-
-  std::map<u64, std::shared_ptr<USB::Device>> m_devices;
-  mutable std::mutex m_devices_mutex;
 
 private:
   bool AddDevice(std::unique_ptr<USB::Device> device);
@@ -52,6 +47,11 @@ private:
                           bool always_add_hooks);
   void CheckAndAddDevice(std::unique_ptr<USB::Device> device, std::set<u64>& new_devices,
                          DeviceChangeHooks& hooks, bool always_add_hooks);
+
+  std::shared_ptr<USB::Device> GetDeviceById(u64 device_id) const;
+
+  std::map<u64, std::shared_ptr<USB::Device>> m_devices;
+  mutable std::mutex m_devices_mutex;
 
   USBHost* m_host = nullptr;
   Common::Flag m_thread_running;

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -207,10 +207,10 @@ void USB_HIDv4::TriggerDeviceChangeReply()
   auto& memory = system.GetMemory();
 
   {
-    std::lock_guard lk(m_usb_scanner.m_devices_mutex);
+    std::lock_guard lk(m_devices_mutex);
     const u32 dest = m_devicechange_hook_request->buffer_out;
     u32 offset = 0;
-    for (const auto& device : m_usb_scanner.m_devices)
+    for (const auto& device : m_devices)
     {
       const std::vector<u8> device_section = GetDeviceEntry(*device.second.get());
       if (offset + device_section.size() > m_devicechange_hook_request->buffer_out_size - 1)

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -27,10 +27,7 @@ USB_HIDv4::USB_HIDv4(EmulationKernel& ios, const std::string& device_name)
 {
 }
 
-USB_HIDv4::~USB_HIDv4()
-{
-  m_scan_thread.Stop();
-}
+USB_HIDv4::~USB_HIDv4() = default;
 
 std::optional<IPCReply> USB_HIDv4::IOCtl(const IOCtlRequest& request)
 {
@@ -210,10 +207,10 @@ void USB_HIDv4::TriggerDeviceChangeReply()
   auto& memory = system.GetMemory();
 
   {
-    std::lock_guard lk(m_devices_mutex);
+    std::lock_guard lk(m_usb_scanner.m_devices_mutex);
     const u32 dest = m_devicechange_hook_request->buffer_out;
     u32 offset = 0;
-    for (const auto& device : m_devices)
+    for (const auto& device : m_usb_scanner.m_devices)
     {
       const std::vector<u8> device_section = GetDeviceEntry(*device.second.get());
       if (offset + device_section.size() > m_devicechange_hook_request->buffer_out_size - 1)

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
@@ -39,7 +39,6 @@ private:
   std::vector<u8> GetDeviceEntry(const USB::Device& device) const;
   void OnDeviceChange(ChangeEvent, std::shared_ptr<USB::Device>) override;
   bool ShouldAddDevice(const USB::Device& device) const override;
-  ScanThread& GetScanThread() override { return m_scan_thread; }
 
   static constexpr u32 VERSION = 0x40001;
   static constexpr u8 HID_CLASS = 0x03;
@@ -53,7 +52,5 @@ private:
   // IOS device IDs <=> USB device IDs
   std::map<s32, u64> m_ios_ids;
   std::map<u64, s32> m_device_ids;
-
-  ScanThread m_scan_thread{this};
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -18,10 +18,7 @@ namespace IOS::HLE
 {
 constexpr u32 USBV5_VERSION = 0x50001;
 
-USB_HIDv5::~USB_HIDv5()
-{
-  m_scan_thread.Stop();
-}
+USB_HIDv5::~USB_HIDv5() = default;
 
 std::optional<IPCReply> USB_HIDv5::IOCtl(const IOCtlRequest& request)
 {

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.h
@@ -27,15 +27,11 @@ private:
   bool ShouldAddDevice(const USB::Device& device) const override;
   bool HasInterfaceNumberInIDs() const override { return true; }
 
-  ScanThread& GetScanThread() override { return m_scan_thread; }
-
   struct AdditionalDeviceData
   {
     u8 interrupt_in_endpoint = 0;
     u8 interrupt_out_endpoint = 0;
   };
   std::array<AdditionalDeviceData, 32> m_additional_device_data{};
-
-  ScanThread m_scan_thread{this};
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -18,10 +18,7 @@ namespace IOS::HLE
 {
 constexpr u32 USBV5_VERSION = 0x50001;
 
-USB_VEN::~USB_VEN()
-{
-  m_scan_thread.Stop();
-}
+USB_VEN::~USB_VEN() = default;
 
 std::optional<IPCReply> USB_VEN::IOCtl(const IOCtlRequest& request)
 {

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
@@ -25,9 +25,5 @@ private:
 
   s32 SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv);
   bool HasInterfaceNumberInIDs() const override { return false; }
-
-  ScanThread& GetScanThread() override { return m_scan_thread; }
-
-  ScanThread m_scan_thread{this};
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -32,6 +32,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "IOS/USB/Emulated/Infinity.h"
 #include "IOS/USB/Emulated/Skylanders/Skylander.h"
+#include "IOS/USB/USBScanner.h"
 #include "VideoCommon/Assets/CustomAssetLoader.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Fifo.h"
@@ -89,6 +90,7 @@ struct System::Impl
   SerialInterface::SerialInterfaceManager m_serial_interface;
   Sram m_sram;
   SystemTimers::SystemTimersManager m_system_timers;
+  IOS::HLE::USBScanner m_usb_scanner;
   VertexShaderManager m_vertex_shader_manager;
   XFStateManager m_xf_state_manager;
   VideoInterface::VideoInterfaceManager m_video_interface;
@@ -311,6 +313,11 @@ Sram& System::GetSRAM() const
 SystemTimers::SystemTimersManager& System::GetSystemTimers() const
 {
   return m_impl->m_system_timers;
+}
+
+IOS::HLE::USBScanner& System::GetUSBScanner() const
+{
+  return m_impl->m_usb_scanner;
 }
 
 VertexShaderManager& System::GetVertexShaderManager() const

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -56,7 +56,8 @@ class GPFifoManager;
 namespace IOS::HLE
 {
 class EmulationKernel;
-}
+class USBScanner;
+}  // namespace IOS::HLE
 namespace HSP
 {
 class HSPManager;
@@ -192,6 +193,7 @@ public:
   SerialInterface::SerialInterfaceManager& GetSerialInterface() const;
   Sram& GetSRAM() const;
   SystemTimers::SystemTimersManager& GetSystemTimers() const;
+  IOS::HLE::USBScanner& GetUSBScanner() const;
   VertexShaderManager& GetVertexShaderManager() const;
   XFStateManager& GetXFStateManager() const;
   VideoInterface::VideoInterfaceManager& GetVideoInterface() const;

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -171,6 +171,7 @@
     <ClInclude Include="Common\UPnP.h" />
     <ClInclude Include="Common\VariantUtil.h" />
     <ClInclude Include="Common\Version.h" />
+    <ClInclude Include="Common\WaitableFlag.h" />
     <ClInclude Include="Common\WindowsRegistry.h" />
     <ClInclude Include="Common\WindowSystemInfo.h" />
     <ClInclude Include="Common\WorkQueueThread.h" />

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -413,6 +413,7 @@
     <ClInclude Include="Core\IOS\USB\USB_HID\HIDv5.h" />
     <ClInclude Include="Core\IOS\USB\USB_KBD.h" />
     <ClInclude Include="Core\IOS\USB\USB_VEN\VEN.h" />
+    <ClInclude Include="Core\IOS\USB\USBScanner.h" />
     <ClInclude Include="Core\IOS\USB\USBV0.h" />
     <ClInclude Include="Core\IOS\USB\USBV4.h" />
     <ClInclude Include="Core\IOS\USB\USBV5.h" />
@@ -1077,6 +1078,7 @@
     <ClCompile Include="Core\IOS\USB\USB_HID\HIDv5.cpp" />
     <ClCompile Include="Core\IOS\USB\USB_KBD.cpp" />
     <ClCompile Include="Core\IOS\USB\USB_VEN\VEN.cpp" />
+    <ClCompile Include="Core\IOS\USB\USBScanner.cpp" />
     <ClCompile Include="Core\IOS\USB\USBV0.cpp" />
     <ClCompile Include="Core\IOS\USB\USBV4.cpp" />
     <ClCompile Include="Core\IOS\USB\USBV5.cpp" />


### PR DESCRIPTION
Some games open two USB interfaces, e.g. `/dev/usb/oh0` and `/dev/usb/hid`. This was causing us to run two scanning threads at once, using up more CPU time for scanning than we need to.