### PR TITLE
Installer: Clean up Windows Start Menu entry

### DIFF
--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -179,17 +179,11 @@ Section "Base"
 
   ; Create start menu and desktop shortcuts
   ; This needs to be done after Dolphin.exe is copied
-  CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"
-  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk" "$INSTDIR\Dolphin.exe"
+  CreateShortCut "$SMPROGRAMS\$DisplayName.lnk" "$INSTDIR\Dolphin.exe"
   CreateShortCut "$DESKTOP\$DisplayName.lnk" "$INSTDIR\Dolphin.exe"
 
   ; ??
   SetOutPath "$TEMP"
-SectionEnd
-
-Section -AdditionalIcons
-  ; Create start menu shortcut for the uninstaller
-  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk" "$INSTDIR\uninst.exe" "/$MultiUser.InstallMode"
 SectionEnd
 
 !include "FileFunc.nsh"
@@ -216,11 +210,8 @@ SectionEnd
 Section Uninstall
   !insertmacro UPDATE_DISPLAYNAME
 
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall $DisplayName.lnk"
-
+  Delete "$SMPROGRAMS\$DisplayName.lnk"
   Delete "$DESKTOP\$DisplayName.lnk"
-  Delete "$SMPROGRAMS\${PRODUCT_NAME}\$DisplayName.lnk"
-  RMDir "$SMPROGRAMS\${PRODUCT_NAME}"
 
   ; Be a bit careful to not delete files a user may have put into the install directory.
   Delete "$INSTDIR\*.dll"


### PR DESCRIPTION
Cleans up the Windows Start Menu entry by removing the creation of the uninstall shortcut (which is ignored and no longer created since at least W10) and by removing the program folder, creating the shortcut directly in the Start Menu. This follows more modern conventions and makes the appearance cleaner (removes the step of needing to expand a folder each time in W10).

Minor change for when/if the installer gets used again.