### PR TITLE
MenuBar: F1 Help Shortcut

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -294,6 +294,8 @@ add_executable(dolphin-emu
   NANDRepairDialog.h
   NKitWarningDialog.cpp
   NKitWarningDialog.h
+  QtUtils/ApplicationShortcutControl.cpp
+  QtUtils/ApplicationShortcutControl.h
   QtUtils/AspectRatioWidget.cpp
   QtUtils/AspectRatioWidget.h
   QtUtils/BlockUserInputFilter.cpp

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="pch_qt.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="QtUtils\ApplicationShortcutControl.cpp" />
     <ClCompile Include="QtUtils\AspectRatioWidget.cpp" />
     <ClCompile Include="QtUtils\BlockUserInputFilter.cpp" />
     <ClCompile Include="QtUtils\ClearLayoutRecursively.cpp" />
@@ -398,6 +399,7 @@
     <QtMoc Include="NetPlay\PadMappingDialog.h" />
     <QtMoc Include="NANDRepairDialog.h" />
     <QtMoc Include="NKitWarningDialog.h" />
+    <QtMoc Include="QtUtils\ApplicationShortcutControl.h" />
     <QtMoc Include="QtUtils\AspectRatioWidget.h" />
     <QtMoc Include="QtUtils\BlockUserInputFilter.h" />
     <QtMoc Include="QtUtils\DoubleClickEventFilter.h" />

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -104,6 +104,7 @@
 #include "DolphinQt/NetPlay/NetPlayBrowser.h"
 #include "DolphinQt/NetPlay/NetPlayDialog.h"
 #include "DolphinQt/NetPlay/NetPlaySetupDialog.h"
+#include "DolphinQt/QtUtils/ApplicationShortcutControl.h"
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/FileOpenEventFilter.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
@@ -1192,6 +1193,8 @@ void MainWindow::ShowRenderWidget()
     // If we're rendering to main, add it to the stack and update our title when necessary.
     m_rendering_to_main = true;
 
+    ApplicationShortcutControl::Instance()->EnableShortcuts(false);
+
     m_stack->setCurrentIndex(m_stack->addWidget(m_render_widget));
     connect(Host::GetInstance(), &Host::RequestTitle, this, &MainWindow::setWindowTitle);
     m_stack->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
@@ -1221,6 +1224,7 @@ void MainWindow::HideRenderWidget(bool reinit, bool is_exit)
     m_stack->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     disconnect(Host::GetInstance(), &Host::RequestTitle, this, &MainWindow::setWindowTitle);
     setWindowTitle(QString::fromStdString(Common::GetScmRevStr()));
+    ApplicationShortcutControl::Instance()->EnableShortcuts(true);
   }
 
   // The following code works around a driver bug that would lead to Dolphin crashing when changing

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -61,6 +61,7 @@
 #include "DolphinQt/AboutDialog.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/NANDRepairDialog.h"
+#include "DolphinQt/QtUtils/ApplicationShortcutControl.h"
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
@@ -577,10 +578,13 @@ void MenuBar::AddViewMenu()
           [purge_action] { purge_action->setEnabled(true); });
   view_menu->addSeparator();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
-  view_menu->addAction(tr("Search"), QKeySequence::Find, this, &MenuBar::ShowSearch);
+  QAction* search =
+      view_menu->addAction(tr("Search"), QKeySequence::Find, this, &MenuBar::ShowSearch);
 #else
-  view_menu->addAction(tr("Search"), this, &MenuBar::ShowSearch, QKeySequence::Find);
+  QAction* search =
+      view_menu->addAction(tr("Search"), this, &MenuBar::ShowSearch, QKeySequence::Find);
 #endif
+  ApplicationShortcutControl::Instance()->AddAction(search);
 }
 
 void MenuBar::AddOptionsMenu()
@@ -665,6 +669,7 @@ void MenuBar::AddHelpMenu()
   help_menu->addAction(tr("&About"), this, &MenuBar::ShowAboutDialog);
 
   documentation->setShortcut(Qt::Key_F1);
+  ApplicationShortcutControl::Instance()->AddAction(documentation);
 }
 
 void MenuBar::AddGameListTypeSection(QMenu* view_menu)

--- a/Source/Core/DolphinQt/QtUtils/ApplicationShortcutControl.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ApplicationShortcutControl.cpp
@@ -1,0 +1,35 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/QtUtils/ApplicationShortcutControl.h"
+
+#include <QEvent>
+#include <QKeySequence>
+#include <QObject>
+#include <QVariant>
+
+ApplicationShortcutControl* ApplicationShortcutControl::Instance()
+{
+  static ApplicationShortcutControl* s_instance = new ApplicationShortcutControl();
+  return s_instance;
+}
+
+void ApplicationShortcutControl::AddAction(QAction* action)
+{
+  action->setData(action->shortcut());
+  m_actions.append(action);
+}
+
+void ApplicationShortcutControl::EnableShortcuts(bool enable_toggle)
+{
+  if (enable_toggle)
+  {
+    for (QAction* action : m_actions)
+      action->setShortcut(action->data().value<QKeySequence>());
+  }
+  else
+  {
+    for (QAction* action : m_actions)
+      action->setShortcut(QKeySequence());
+  }
+}

--- a/Source/Core/DolphinQt/QtUtils/ApplicationShortcutControl.h
+++ b/Source/Core/DolphinQt/QtUtils/ApplicationShortcutControl.h
@@ -1,0 +1,21 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QAction>
+#include <QList>
+#include <QObject>
+
+class ApplicationShortcutControl : public QObject
+{
+  Q_OBJECT
+public:
+  static ApplicationShortcutControl* Instance();
+
+  void AddAction(QAction* action);
+  void EnableShortcuts(bool enable_toggle);
+
+private:
+  QList<QAction*> m_actions;
+};


### PR DESCRIPTION
I recently tried and failed to press F1 to open the help/documentation

Here is a PR to rectify that

I also moved the entry bound to F1 at the top of the Help menu to be consistent with other applications—which all seem to do that 