### PR TITLE
Game config settings: Show global value when no game setting exists.

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigControl.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigControl.h
@@ -76,8 +76,16 @@ protected:
   template <typename T>
   const T ReadValue(const Config::Info<T>& setting) const
   {
+    // For loading game specific settings.  If the game setting doesn't exist, load the current
+    // global setting. There's no way to know what game is being edited, so GlobalGame settings
+    // can't be shown, but otherwise would be good to include.
     if (m_layer != nullptr)
-      return m_layer->Get(setting);
+    {
+      if (m_layer->Exists(m_location))
+        return m_layer->Get(setting);
+      else
+        return Config::GetBase(setting);
+    }
 
     return Config::Get(setting);
   }


### PR DESCRIPTION
 Previously showed the default value if the game setting didn't exist, which meant it could be confusing as to what the actual option would end up being.

Also, for the note in the commit. Global Game settings are loaded through a workaround in GameConfigWidget that is a little complicated.