### PR TITLE
BPStructs: Add TODO for unsafe usage of GetTicks.

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -357,8 +357,13 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
       auto& system = Core::System::GetInstance();
       if (g_ActiveConfig.bImmediateXFB)
       {
+        // TODO: GetTicks is not sane from the GPU thread.
+        // This value is currently used for frame dumping and the custom shader "time_ms" value.
+        // Frame dumping has more calls that aren't sane from the GPU thread.
+        // i.e. Frame dumping is not sane in "Dual Core" mode in general.
+        const u64 ticks = system.GetCoreTiming().GetTicks();
+
         // below div two to convert from bytes to pixels - it expects width, not stride
-        u64 ticks = system.GetCoreTiming().GetTicks();
         g_presenter->ImmediateSwap(destAddr, destStride / 2, destStride, height, ticks);
       }
       else


### PR DESCRIPTION
I noticed this problem when I started working on frame pacing improvements.

"Immediate XFB" unsafely uses `CoreTiming::GetTicks` in "Dual Core" mode.

The result is currently just used for frame dumping and custom shaders, so it's not a major problem yet, but the value existing at all is encouraging more important things to use it in the future and be a bigger problem.

I don't see an easy fix other than completely eliminating the value and making frame-dumping/custom-shaders get timing by other means.

I don't know if there is a sensible way for the current ticks to even be gotten here.
I guess if we could get the time that this command was written from the CPU it could be done?
I haven't wrapped my head around all that yet so I've added a TODO for now.

Maybe someone more knowledgeable will come out of hiding and be able to fix this properly or give insight.

This is related to the TODO here from @phire.
https://github.com/dolphin-emu/dolphin/blob/01363572cbd6905e0427116fdf75fad66d99d81d/Source/Core/VideoCommon/Present.cpp#L214

I guess using the next calculated VI field time could solve some of the problems, but I was under the impression that there isn't necessarily a 1:1 relationship for XFB copies and VI fields. Some games can provide a higher refresh rate with "Immediate XFB"?