### PR TITLE
CoreTiming: Cleanups to avoid drift from cumulative rounding errors.

### DIFF
--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -202,16 +202,19 @@ private:
   float m_config_oc_inv_factor = 0.0f;
   bool m_config_sync_on_skip_idle = false;
 
-  s64 m_throttle_last_cycle = 0;
-  TimePoint m_throttle_deadline = Clock::now();
-  s64 m_throttle_clock_per_sec = 0;
+  s64 m_throttle_reference_cycle = 0;
+  TimePoint m_throttle_reference_time = Clock::now();
+  u32 m_throttle_adj_clock_per_sec = 0;
   bool m_throttle_disable_vi_int = false;
 
   DT m_max_fallback = {};
   DT m_max_variance = {};
   double m_emulation_speed = 1.0;
 
+  bool IsSpeedUnlimited() const;
+  void UpdateSpeedLimit(s64 cycle, double new_speed);
   void ResetThrottle(s64 cycle);
+  TimePoint CalculateTargetHostTimeInternal(s64 target_cycle);
 
   int DowncountToCycles(int downcount) const;
   int CyclesToDowncount(int cycles) const;

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -215,6 +215,7 @@ private:
   void UpdateSpeedLimit(s64 cycle, double new_speed);
   void ResetThrottle(s64 cycle);
   TimePoint CalculateTargetHostTimeInternal(s64 target_cycle);
+  void UpdateVISkip(TimePoint current_time, TimePoint target_time);
 
   int DowncountToCycles(int downcount) const;
   int CyclesToDowncount(int cycles) const;


### PR DESCRIPTION
This is just the cleanups of #13392 
I decided to make this a separate PR so discussion/reviews in that PR can be about just the setting itself.

Previous Throttle code adjusted time points every call leading to potential rounding errors and accumulated drift over time.
Time points are now adjusted by exact seconds to avoid this.