### PR TITLE
InputCommon: Activate IMU Accelerometer and Gyroscope mappings when any direction has a bound input.

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
@@ -4,7 +4,6 @@
 #include "InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.h"
 
 #include <algorithm>
-#include <memory>
 
 #include "Common/Common.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
@@ -25,7 +24,7 @@ IMUAccelerometer::IMUAccelerometer(std::string name_, std::string ui_name_)
 
 bool IMUAccelerometer::AreInputsBound() const
 {
-  return std::ranges::all_of(
+  return std::ranges::any_of(
       controls, [](const auto& control) { return control->control_ref->BoundCount() > 0; });
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -4,7 +4,6 @@
 #include "InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h"
 
 #include <algorithm>
-#include <memory>
 
 #include "Common/Common.h"
 #include "Common/MathUtil.h"
@@ -123,7 +122,7 @@ auto IMUGyroscope::GetRawState() const -> StateData
 
 bool IMUGyroscope::AreInputsBound() const
 {
-  return std::ranges::all_of(
+  return std::ranges::any_of(
       controls, [](const auto& control) { return control->control_ref->BoundCount() > 0; });
 }
 


### PR DESCRIPTION
This allows IMU accelerometer and gyroscope to function when only some of the directions are mapped.

Especially for "Free Look", users may not want to map every gyroscope direction.

A user just ran into this on discord. Free Look rotation wasn't working at all because they only had "Yaw" mappings.

