### PR TITLE
IP/Top: Fix performance regression in GetInterfaceOpt

### DIFF
--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -1005,7 +1005,6 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
   auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
-  const DefaultInterface interface = GetSystemDefaultInterfaceOrFallback();
   const u32 param = memory.Read_U32(request.in_vectors[0].address);
   const u32 param2 = memory.Read_U32(request.in_vectors[0].address + 4);
   const u32 param3 = memory.Read_U32(request.io_vectors[0].address);
@@ -1159,6 +1158,7 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
     // XXX: this isn't exactly right; the buffer can be larger than 12 bytes,
     // in which case, depending on some interface settings, SO can write 12 more bytes
     memory.Write_U32(0xC, request.io_vectors[1].address);
+    const DefaultInterface interface = GetSystemDefaultInterfaceOrFallback();
     memory.Write_U32(ntohl(interface.inet.s_addr), request.io_vectors[0].address);
     memory.Write_U32(ntohl(interface.netmask.s_addr), request.io_vectors[0].address + 4);
     memory.Write_U32(ntohl(interface.broadcast.s_addr), request.io_vectors[0].address + 8);
@@ -1172,6 +1172,8 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
     break;
 
   case 0x4006:  // get routing table
+  {
+    const DefaultInterface interface = GetSystemDefaultInterfaceOrFallback();
     for (InterfaceRouting route : interface.routing_table)
     {
       memory.Write_U32(ntohl(route.destination.s_addr), request.io_vectors[0].address + param5);
@@ -1191,6 +1193,7 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
 
     memory.Write_U32(param5, request.io_vectors[1].address);
     break;
+  }
 
   case 0x6003:  // hardcoded value
     memory.Write_U32(0x80, request.io_vectors[0].address);


### PR DESCRIPTION
The `GetSystemDefaultInterfaceOrFallback()` function is costly. Let's not pay for something we don't use. This fixes the following performance regression that can occur in some online games _(e.g. Monster Hunter 3)_:
![image](https://github.com/user-attachments/assets/24381819-d41b-4913-bbc5-677afcb0f297)

Ready to be reviewed & merged.