### PR TITLE
Core: Don't store game ID inside TimePlayed

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -78,17 +78,17 @@ void CPUManager::StartTimePlayedTimer()
 
   while (true)
   {
-    const std::string game_id = SConfig::GetInstance().GetGameID();
-    TimePlayed time_played(game_id);
+    TimePlayed time_played;
     auto curr_time = timer.now();
 
     // Check that emulation is not paused
     // If the emulation is paused, wait for SetStepping() to reactivate
     if (m_state == State::Running)
     {
+      const std::string game_id = SConfig::GetInstance().GetGameID();
       const auto diff_time =
           std::chrono::duration_cast<std::chrono::milliseconds>(curr_time - prev_time);
-      time_played.AddTime(diff_time);
+      time_played.AddTime(game_id, diff_time);
     }
     else if (m_state == State::Stepping)
     {

--- a/Source/Core/Core/TimePlayed.cpp
+++ b/Source/Core/Core/TimePlayed.cpp
@@ -11,47 +11,23 @@
 #include "Common/IniFile.h"
 #include "Common/NandPaths.h"
 
-TimePlayed::TimePlayed()
-    : m_game_id(""), m_ini_path(File::GetUserPath(D_CONFIG_IDX) + "TimePlayed.ini")
-{
-  Reload();
-}
-
-TimePlayed::TimePlayed(std::string game_id)
-    : m_game_id(Common::EscapeFileName(game_id)),  // filter for unsafe characters
-      m_ini_path(File::GetUserPath(D_CONFIG_IDX) + "TimePlayed.ini")
+TimePlayed::TimePlayed() : m_ini_path(File::GetUserPath(D_CONFIG_IDX) + "TimePlayed.ini")
 {
   Reload();
 }
 
 TimePlayed::~TimePlayed() = default;
 
-void TimePlayed::AddTime(std::chrono::milliseconds time_emulated)
+void TimePlayed::AddTime(const std::string& game_id, std::chrono::milliseconds time_emulated)
 {
-  if (m_game_id == "")
-  {
-    return;
-  }
-
+  std::string filtered_game_id = Common::EscapeFileName(game_id);
   u64 previous_time;
-  m_time_list->Get(m_game_id, &previous_time);
-  m_time_list->Set(m_game_id, previous_time + static_cast<u64>(time_emulated.count()));
+  m_time_list->Get(filtered_game_id, &previous_time);
+  m_time_list->Set(filtered_game_id, previous_time + static_cast<u64>(time_emulated.count()));
   m_ini.Save(m_ini_path);
 }
 
-std::chrono::milliseconds TimePlayed::GetTimePlayed() const
-{
-  if (m_game_id == "")
-  {
-    return std::chrono::milliseconds(0);
-  }
-
-  u64 previous_time;
-  m_time_list->Get(m_game_id, &previous_time);
-  return std::chrono::milliseconds(previous_time);
-}
-
-std::chrono::milliseconds TimePlayed::GetTimePlayed(std::string game_id) const
+std::chrono::milliseconds TimePlayed::GetTimePlayed(const std::string& game_id) const
 {
   std::string filtered_game_id = Common::EscapeFileName(game_id);
   u64 previous_time;

--- a/Source/Core/Core/TimePlayed.h
+++ b/Source/Core/Core/TimePlayed.h
@@ -12,10 +12,7 @@
 class TimePlayed
 {
 public:
-  // used for QT interface - general access to time played for games
   TimePlayed();
-
-  TimePlayed(std::string game_id);
 
   // not copyable due to the stored section pointer
   TimePlayed(const TimePlayed& other) = delete;
@@ -25,15 +22,13 @@ public:
 
   ~TimePlayed();
 
-  void AddTime(std::chrono::milliseconds time_emulated);
+  void AddTime(const std::string& game_id, std::chrono::milliseconds time_emulated);
 
-  std::chrono::milliseconds GetTimePlayed() const;
-  std::chrono::milliseconds GetTimePlayed(std::string game_id) const;
+  std::chrono::milliseconds GetTimePlayed(const std::string& game_id) const;
 
   void Reload();
 
 private:
-  std::string m_game_id;
   std::string m_ini_path;
   Common::IniFile m_ini;
   Common::IniFile::Section* m_time_list;


### PR DESCRIPTION
When you use TimePlayed, you have to provide a game ID either when creating the object or when calling GetTimePlayed on it. If you don't provide a game ID when creating the object, function calls that don't take a game ID will silently fail, except for Reload. This isn't very obvious, and there's no strong benefit to storing the game ID inside TimePlayed anyway (it just lets TimePlayed skip calling EscapeFileName), so this commit removes the TimePlayed constructor that takes a game ID and instead makes the functions that need game IDs always take a game ID argument.