### PR TITLE
GameList: Ignore non-left double-clicks

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -93,6 +93,25 @@ protected:
     else
       return QTableView::moveCursor(cursorAction, modifiers);
   }
+
+  virtual void mouseDoubleClickEvent(QMouseEvent* const event) override
+  {
+    if (event->button() == Qt::LeftButton)
+      QTableView::mouseDoubleClickEvent(event);
+  }
+};
+
+class GameListListView : public QListView
+{
+public:
+  explicit GameListListView(QWidget* parent = nullptr) : QListView(parent) {}
+
+protected:
+  virtual void mouseDoubleClickEvent(QMouseEvent* const event) override
+  {
+    if (event->button() == Qt::LeftButton)
+      QListView::mouseDoubleClickEvent(event);
+  }
 };
 }  // namespace
 
@@ -319,7 +338,7 @@ void GameList::resizeEvent(QResizeEvent* event)
 
 void GameList::MakeGridView()
 {
-  m_grid = new QListView(this);
+  m_grid = new GameListListView(this);
   m_grid->setModel(m_grid_proxy);
   m_grid->setSelectionMode(QAbstractItemView::ExtendedSelection);
 


### PR DESCRIPTION
When a game in the Game List is double-clicked by a mouse button other than the left button, don't start the game. This prevents things like accidentally starting a game when trying to close a context menu.

Fixes https://bugs.dolphin-emu.org/issues/12272.

The Game List's empty widget (shown when you don't have any paths set up, or games in those paths) continues to respond to right/other clicks since there's no other action to confuse that with.