### PR TITLE
[DO NOT MERGE] Mixer: Assume emulation speed is 100% for easier poor performance audio testing.

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -70,7 +70,7 @@ void Mixer::MixerFifo::Mix(s16* samples, std::size_t num_samples)
   double in_sample_rate =
       static_cast<double>(FIXED_SAMPLE_RATE_DIVIDEND) / m_input_sample_rate_divisor;
 
-  const double emulation_speed = m_mixer->m_config_emulation_speed;
+  const double emulation_speed = 1.0;  // m_mixer->m_config_emulation_speed;
   if (0 < emulation_speed && emulation_speed != 1.0)
     in_sample_rate *= emulation_speed;
 


### PR DESCRIPTION
Users are complaining of poor "Fill Audio Gaps" performance when games aren't running at full speed.

The poor audio can now be observed by setting the speed limit in settings.
Mixer is no longer informed of the change and the audio will play as if the game was struggling at 80%.
![image](https://github.com/user-attachments/assets/b85647a7-7fbb-49d6-bfa4-681faedf6aa2)

I'm making this PR for @dreamsyntax so his users have a build for testing.