### PR TITLE
Remove always-true partial condition and simplify condition

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
@@ -210,8 +210,7 @@ bool CEXIETHERNET::TAPNetworkInterface::Activate()
     INFO_LOG_FMT(SP1, "TAP-Win32 Driver Version {}.{} {}", info[0], info[1],
                  info[2] ? "(DEBUG)" : "");
   }
-  if (!(info[0] > TAP_WIN32_MIN_MAJOR ||
-        (info[0] == TAP_WIN32_MIN_MAJOR && info[1] >= TAP_WIN32_MIN_MINOR)))
+  if (info[0] < TAP_WIN32_MIN_MAJOR)
   {
     PanicAlertFmtT("ERROR: This version of Dolphin requires a TAP-Win32 driver"
                    " that is at least version {0}.{1} -- If you recently upgraded your Dolphin"


### PR DESCRIPTION
`TAP_WIN32_MIN_MINOR` equals 0 and `info[1]` is an unsigned integer which means it is always larger than or equal to 0 which means `info[1] >= TAP_WIN32_MIN_MINOR` is always true.