### PR TITLE
DiscIO/Volume: Fix Partition struct comparison operators

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -32,10 +32,7 @@ struct Partition final
   constexpr Partition() = default;
   constexpr explicit Partition(u64 offset_) : offset(offset_) {}
   constexpr bool operator==(const Partition& other) const { return offset == other.offset; }
-  constexpr bool operator<(const Partition& other) const { return offset < other.offset; }
-  constexpr bool operator>(const Partition& other) const { return other < *this; }
-  constexpr bool operator<=(const Partition& other) const { return !(*this < other); }
-  constexpr bool operator>=(const Partition& other) const { return !(*this > other); }
+  constexpr auto operator<=>(const Partition other) const { return offset <=> other.offset; }
   u64 offset{std::numeric_limits<u64>::max()};
 };
 


### PR DESCRIPTION
Replaces #13517 due to branch rename