### PR TITLE
Core & UnitTests: Replace C-style casts with `static_cast`

### DIFF
--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -147,7 +147,7 @@ OpenALStream::~OpenALStream()
 
 void OpenALStream::SetVolume(int volume)
 {
-  m_volume = (float)volume / 100.0f;
+  m_volume = static_cast<float>(volume) / 100.0f;
 
   if (m_source)
     palSourcef(m_source, AL_GAIN, m_volume);

--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -149,8 +149,8 @@ void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count,
   for (u32 i = 0; i < count; i++)
   {
     // Flip the audio channels from RL to LR
-    conv_buffer[2 * i] = Common::swap16((u16)sample_data[2 * i + 1]);
-    conv_buffer[2 * i + 1] = Common::swap16((u16)sample_data[2 * i]);
+    conv_buffer[2 * i] = Common::swap16(static_cast<u16>(sample_data[2 * i + 1]));
+    conv_buffer[2 * i + 1] = Common::swap16(static_cast<u16>(sample_data[2 * i]));
 
     // Apply volume (volume ranges from 0 to 256)
     conv_buffer[2 * i] = conv_buffer[2 * i] * l_volume / 256;

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -67,7 +67,7 @@ public:
   template <typename K, class V>
   void Do(std::map<K, V>& x)
   {
-    u32 count = (u32)x.size();
+    u32 count = static_cast<u32>(x.size());
     Do(count);
 
     switch (m_mode)
@@ -97,7 +97,7 @@ public:
   template <typename V>
   void Do(std::set<V>& x)
   {
-    u32 count = (u32)x.size();
+    u32 count = static_cast<u32>(x.size());
     Do(count);
 
     switch (m_mode)

--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -377,7 +377,7 @@ void GekkoDisassembler::ill(u32 in)
 // Type 3: A register is ignored (li)
 std::string GekkoDisassembler::imm(u32 in, int uimm, int type, bool hex)
 {
-  int i = (int)(in & 0xffff);
+  int i = static_cast<int>(in & 0xffff);
 
   if (uimm == 0)
   {
@@ -461,13 +461,13 @@ void GekkoDisassembler::trapi(u32 in, unsigned char dmode)
 
 void GekkoDisassembler::cmpi(u32 in, int uimm)
 {
-  int i = (int)PPCGETL(in);
+  int i = static_cast<int>(PPCGETL(in));
 
   if (i < 2)
   {
     m_opcode = fmt::format("{}i", cmpname[uimm * 2 + i]);
 
-    i = (int)PPCGETCRD(in);
+    i = static_cast<int>(PPCGETCRD(in));
     if (i != 0)
     {
       m_operands += fmt::format("cr{}, ", i);
@@ -507,10 +507,10 @@ void GekkoDisassembler::addi(u32 in, std::string_view ext)
 // Build a branch instr. and return number of chars written to operand.
 size_t GekkoDisassembler::branch(u32 in, std::string_view bname, int aform, int bdisp)
 {
-  int bo = (int)PPCGETD(in);
-  int bi = (int)PPCGETA(in);
-  char y = (char)(bo & 1);
-  const char* ext = b_ext[aform * 2 + (int)(in & 1)];
+  int bo = static_cast<int>(PPCGETD(in));
+  int bi = static_cast<int>(PPCGETA(in));
+  char y = static_cast<char>(bo & 1);
+  const char* ext = b_ext[aform * 2 + static_cast<int>(in & 1)];
 
   if (bdisp < 0)
     y ^= 1;
@@ -558,7 +558,7 @@ size_t GekkoDisassembler::branch(u32 in, std::string_view bname, int aform, int 
 
 void GekkoDisassembler::bc(u32 in)
 {
-  unsigned int d = (int)(in & 0xfffc);
+  unsigned int d = static_cast<int>(in & 0xfffc);
 
   if (d & 0x8000)
     d |= 0xffff0000;
@@ -601,9 +601,9 @@ void GekkoDisassembler::mcrf(u32 in, std::string_view suffix)
 
 void GekkoDisassembler::crop(u32 in, std::string_view n1, std::string_view n2)
 {
-  int crd = (int)PPCGETD(in);
-  int cra = (int)PPCGETA(in);
-  int crb = (int)PPCGETB(in);
+  int crd = static_cast<int>(PPCGETD(in));
+  int cra = static_cast<int>(PPCGETA(in));
+  int crb = static_cast<int>(PPCGETB(in));
 
   if ((in & 1) == 0)
   {
@@ -633,11 +633,11 @@ void GekkoDisassembler::nooper(u32 in, std::string_view name)
 
 void GekkoDisassembler::rlw(u32 in, std::string_view name, int i)
 {
-  int s = (int)PPCGETD(in);
-  int a = (int)PPCGETA(in);
-  int bsh = (int)PPCGETB(in);
-  int mb = (int)PPCGETC(in);
-  int me = (int)PPCGETM(in);
+  int s = static_cast<int>(PPCGETD(in));
+  int a = static_cast<int>(PPCGETA(in));
+  int bsh = static_cast<int>(PPCGETB(in));
+  int mb = static_cast<int>(PPCGETC(in));
+  int me = static_cast<int>(PPCGETM(in));
 
   m_opcode = fmt::format("rlw{}{}", name, (in & 1) ? "." : "");
   m_operands = fmt::format("{}, {}, {}{}, {}, {} ({:08x})", regnames[a], regnames[s], regsel[i],
@@ -652,10 +652,10 @@ void GekkoDisassembler::ori(u32 in, std::string_view name)
 
 void GekkoDisassembler::rld(u32 in, std::string_view name, int i)
 {
-  int s = (int)PPCGETD(in);
-  int a = (int)PPCGETA(in);
-  int bsh = i ? (int)PPCGETB(in) : (int)(((in & 2) << 4) + PPCGETB(in));
-  int m = (int)(in & 0x7e0) >> 5;
+  int s = static_cast<int>(PPCGETD(in));
+  int a = static_cast<int>(PPCGETA(in));
+  int bsh = i ? static_cast<int>(PPCGETB(in)) : static_cast<int>(((in & 2) << 4) + PPCGETB(in));
+  int m = static_cast<int>(in & 0x7e0) >> 5;
 
   m_opcode = fmt::format("rld{}{}", name, (in & 1) ? "." : "");
   m_operands = fmt::format("{}, {}, {}{}, {}", regnames[a], regnames[s], regsel[i], bsh, m);
@@ -663,13 +663,13 @@ void GekkoDisassembler::rld(u32 in, std::string_view name, int i)
 
 void GekkoDisassembler::cmp(u32 in)
 {
-  int i = (int)PPCGETL(in);
+  int i = static_cast<int>(PPCGETL(in));
 
   if (i < 2)
   {
     m_opcode = cmpname[((in & PPCIDX2MASK) ? 2 : 0) + i];
 
-    i = (int)PPCGETCRD(in);
+    i = static_cast<int>(PPCGETCRD(in));
     if (i != 0)
       m_operands += fmt::format("cr{},", i);
 
@@ -683,7 +683,7 @@ void GekkoDisassembler::cmp(u32 in)
 
 void GekkoDisassembler::trap(u32 in, unsigned char dmode)
 {
-  int to = (int)PPCGETD(in);
+  int to = static_cast<int>(PPCGETD(in));
   const char* cnd = trap_condition[to];
 
   if (cnd != nullptr)
@@ -716,7 +716,7 @@ void GekkoDisassembler::trap(u32 in, unsigned char dmode)
 void GekkoDisassembler::dab(u32 in, std::string_view name, int mask, int smode, int chkoe,
                             int chkrc)
 {
-  if (chkrc >= 0 && ((in & 1) != (unsigned int)chkrc))
+  if (chkrc >= 0 && ((in & 1) != static_cast<unsigned int>(chkrc)))
   {
     ill(in);
   }
@@ -735,7 +735,7 @@ void GekkoDisassembler::dab(u32 in, std::string_view name, int mask, int smode, 
 // Last operand is no register: xxxx rD,rA,NB
 void GekkoDisassembler::rrn(u32 in, std::string_view name, int smode, int chkoe, int chkrc)
 {
-  if (chkrc >= 0 && ((in & 1) != (unsigned int)chkrc))
+  if (chkrc >= 0 && ((in & 1) != static_cast<unsigned int>(chkrc)))
   {
     ill(in);
   }
@@ -754,8 +754,8 @@ void GekkoDisassembler::rrn(u32 in, std::string_view name, int smode, int chkoe,
 
 void GekkoDisassembler::mtcr(u32 in)
 {
-  int s = (int)PPCGETD(in);
-  int crm = (int)(in & 0x000ff000) >> 12;
+  int s = static_cast<int>(PPCGETD(in));
+  int crm = static_cast<int>(in & 0x000ff000) >> 12;
 
   if (in & 0x00100801)
   {
@@ -774,8 +774,8 @@ void GekkoDisassembler::mtcr(u32 in)
 
 void GekkoDisassembler::msr(u32 in, int smode)
 {
-  int s = (int)PPCGETD(in);
-  int sr = (int)(in & 0x000f0000) >> 16;
+  int s = static_cast<int>(PPCGETD(in));
+  int sr = static_cast<int>(in & 0x000f0000) >> 16;
 
   if (in & 0x0010f801)
   {
@@ -794,8 +794,8 @@ void GekkoDisassembler::msr(u32 in, int smode)
 
 void GekkoDisassembler::mspr(u32 in, int smode)
 {
-  int d = (int)PPCGETD(in);
-  int spr = (int)((PPCGETB(in) << 5) + PPCGETA(in));
+  int d = static_cast<int>(PPCGETD(in));
+  int spr = static_cast<int>((PPCGETB(in) << 5) + PPCGETA(in));
   int fmt = 0;
 
   if (in & 1)
@@ -843,8 +843,8 @@ void GekkoDisassembler::mspr(u32 in, int smode)
 
 void GekkoDisassembler::mtb(u32 in)
 {
-  int d = (int)PPCGETD(in);
-  int tbr = (int)((PPCGETB(in) << 5) + PPCGETA(in));
+  int d = static_cast<int>(PPCGETD(in));
+  int tbr = static_cast<int>((PPCGETB(in) << 5) + PPCGETA(in));
 
   if (in & 1)
   {
@@ -876,9 +876,9 @@ void GekkoDisassembler::mtb(u32 in)
 
 void GekkoDisassembler::sradi(u32 in)
 {
-  int s = (int)PPCGETD(in);
-  int a = (int)PPCGETA(in);
-  int bsh = (int)(((in & 2) << 4) + PPCGETB(in));
+  int s = static_cast<int>(PPCGETD(in));
+  int a = static_cast<int>(PPCGETA(in));
+  int bsh = static_cast<int>(((in & 2) << 4) + PPCGETB(in));
 
   m_opcode = fmt::format("sradi{}", (in & 1) ? "." : "");
   m_operands = fmt::format("{}, {}, {}", regnames[a], regnames[s], bsh);
@@ -886,8 +886,8 @@ void GekkoDisassembler::sradi(u32 in)
 
 void GekkoDisassembler::ldst(u32 in, std::string_view name, char reg)
 {
-  int s = (int)PPCGETD(in);
-  int a = (int)PPCGETA(in);
+  int s = static_cast<int>(PPCGETD(in));
+  int a = static_cast<int>(PPCGETA(in));
   int d = (u32)(in & 0xffff);
 
   m_opcode = name;
@@ -913,17 +913,17 @@ void GekkoDisassembler::fdabc(u32 in, std::string_view name, int mask)
   if (mask & 4)
     m_operands += fmt::format(", f{}", PPCGETA(in));
   else if ((mask & 8) == 0)
-    err |= (int)PPCGETA(in);
+    err |= static_cast<int>(PPCGETA(in));
 
   if (mask & 2)
     m_operands += fmt::format(", f{}", PPCGETC(in));
   else if (PPCGETC(in) && (mask & 8) == 0)
-    err |= (int)PPCGETC(in);
+    err |= static_cast<int>(PPCGETC(in));
 
   if (mask & 1)
     m_operands += fmt::format(", f{}", PPCGETB(in));
   else if (!(mask & 8))
-    err |= (int)PPCGETB(in);
+    err |= static_cast<int>(PPCGETB(in));
 
   if (err)
     ill(in);
@@ -1149,7 +1149,7 @@ void GekkoDisassembler::ps(u32 inst)
   {
     m_opcode = ps_cmpname[(inst >> 6) & 0x3];
 
-    int i = (int)PPCGETCRD(inst);
+    int i = static_cast<int>(PPCGETCRD(inst));
     if (i != 0)
       m_operands += fmt::format("cr{}, ", i);
     m_operands += fmt::format("p{}, p{}", FA, FB);

--- a/Source/Core/Common/Hash.cpp
+++ b/Source/Core/Common/Hash.cpp
@@ -137,36 +137,36 @@ static u64 GetMurmurHash3(const u8* src, u32 len, u32 samples)
   switch (len & 15)
   {
   case 15:
-    k2 ^= u64(tail[14]) << 48;
+    k2 ^= static_cast<u64>(tail[14]) << 48;
   case 14:
-    k2 ^= u64(tail[13]) << 40;
+    k2 ^= static_cast<u64>(tail[13]) << 40;
   case 13:
-    k2 ^= u64(tail[12]) << 32;
+    k2 ^= static_cast<u64>(tail[12]) << 32;
   case 12:
-    k2 ^= u64(tail[11]) << 24;
+    k2 ^= static_cast<u64>(tail[11]) << 24;
   case 11:
-    k2 ^= u64(tail[10]) << 16;
+    k2 ^= static_cast<u64>(tail[10]) << 16;
   case 10:
-    k2 ^= u64(tail[9]) << 8;
+    k2 ^= static_cast<u64>(tail[9]) << 8;
   case 9:
-    k2 ^= u64(tail[8]) << 0;
+    k2 ^= static_cast<u64>(tail[8]) << 0;
 
   case 8:
-    k1 ^= u64(tail[7]) << 56;
+    k1 ^= static_cast<u64>(tail[7]) << 56;
   case 7:
-    k1 ^= u64(tail[6]) << 48;
+    k1 ^= static_cast<u64>(tail[6]) << 48;
   case 6:
-    k1 ^= u64(tail[5]) << 40;
+    k1 ^= static_cast<u64>(tail[5]) << 40;
   case 5:
-    k1 ^= u64(tail[4]) << 32;
+    k1 ^= static_cast<u64>(tail[4]) << 32;
   case 4:
-    k1 ^= u64(tail[3]) << 24;
+    k1 ^= static_cast<u64>(tail[3]) << 24;
   case 3:
-    k1 ^= u64(tail[2]) << 16;
+    k1 ^= static_cast<u64>(tail[2]) << 16;
   case 2:
-    k1 ^= u64(tail[1]) << 8;
+    k1 ^= static_cast<u64>(tail[1]) << 8;
   case 1:
-    k1 ^= u64(tail[0]) << 0;
+    k1 ^= static_cast<u64>(tail[0]) << 0;
     bmix64(h1, h2, k1, k2, c1, c2);
   };
 

--- a/Source/Core/Common/JitRegister.h
+++ b/Source/Core/Common/JitRegister.h
@@ -27,7 +27,7 @@ template <typename... Args>
 inline void Register(const void* start, const void* end, fmt::format_string<Args...> format,
                      Args&&... args)
 {
-  u32 code_size = (u32)((const char*)end - (const char*)start);
+  u32 code_size = static_cast<u32>(static_cast<const char*>(end) - static_cast<const char*>(start));
   Register(start, code_size, fmt::format(format, std::forward<Args>(args)...));
 }
 }  // namespace Common::JitRegister

--- a/Source/Core/Common/MemArenaWin.cpp
+++ b/Source/Core/Common/MemArenaWin.cpp
@@ -346,7 +346,8 @@ void* MemArena::MapInMemoryRegion(s64 offset, size_t size, void* base)
     return rv;
   }
 
-  return MapViewOfFileEx(m_memory_handle, FILE_MAP_ALL_ACCESS, 0, (DWORD)((u64)offset), size, base);
+  return MapViewOfFileEx(m_memory_handle, FILE_MAP_ALL_ACCESS, 0,
+                         static_cast<DWORD>(static_cast<u64>(offset)), size, base);
 }
 
 bool MemArena::JoinRegionsAfterUnmap(void* start_address, size_t size)

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -267,7 +267,7 @@ void DHCPPacket::AddOption(u8 fnc, const std::vector<u8>& params)
 {
   if (params.size() > 255)
     return;
-  std::vector<u8> opt = {fnc, u8(params.size())};
+  std::vector<u8> opt = {fnc, static_cast<u8>(params.size())};
   opt.insert(opt.end(), params.begin(), params.end());
   options.emplace_back(std::move(opt));
 }
@@ -386,11 +386,11 @@ std::vector<u8> TCPPacket::Build() const
 
   auto ip_checksum_bitcast_ptr =
       Common::BitCastPtr<u16>(ip_ptr + offsetof(IPv4Header, header_checksum));
-  ip_checksum_bitcast_ptr = u16(0);
+  ip_checksum_bitcast_ptr = static_cast<u16>(0);
   ip_checksum_bitcast_ptr = htons(Common::ComputeNetworkChecksum(ip_ptr, ip_header_size));
 
   auto checksum_bitcast_ptr = Common::BitCastPtr<u16>(tcp_ptr + offsetof(TCPHeader, checksum));
-  checksum_bitcast_ptr = u16(0);
+  checksum_bitcast_ptr = static_cast<u16>(0);
   checksum_bitcast_ptr = ComputeTCPNetworkChecksum(
       ip_header.source_addr, ip_header.destination_addr, tcp_ptr, tcp_length, IPPROTO_TCP);
 
@@ -436,11 +436,11 @@ std::vector<u8> UDPPacket::Build() const
 
   auto ip_checksum_bitcast_ptr =
       Common::BitCastPtr<u16>(ip_ptr + offsetof(IPv4Header, header_checksum));
-  ip_checksum_bitcast_ptr = u16(0);
+  ip_checksum_bitcast_ptr = static_cast<u16>(0);
   ip_checksum_bitcast_ptr = htons(Common::ComputeNetworkChecksum(ip_ptr, ip_header_size));
 
   auto checksum_bitcast_ptr = Common::BitCastPtr<u16>(udp_ptr + offsetof(UDPHeader, checksum));
-  checksum_bitcast_ptr = u16(0);
+  checksum_bitcast_ptr = static_cast<u16>(0);
   checksum_bitcast_ptr = ComputeTCPNetworkChecksum(
       ip_header.source_addr, ip_header.destination_addr, udp_ptr, udp_length, IPPROTO_UDP);
 

--- a/Source/Core/Common/PcapFile.cpp
+++ b/Source/Core/Common/PcapFile.cpp
@@ -55,9 +55,10 @@ void PCAP::AddPacket(const u8* bytes, size_t size)
   std::chrono::system_clock::time_point now(std::chrono::system_clock::now());
   auto ts = now.time_since_epoch();
   PCAPRecordHeader rec_hdr = {
-      (u32)std::chrono::duration_cast<std::chrono::seconds>(ts).count(),
-      (u32)(std::chrono::duration_cast<std::chrono::microseconds>(ts).count() % 1000000), (u32)size,
-      (u32)size};
+      static_cast<u32>(std::chrono::duration_cast<std::chrono::seconds>(ts).count()),
+      static_cast<u32>(std::chrono::duration_cast<std::chrono::microseconds>(ts).count() % 1000000),
+      static_cast<u32>(size),
+      static_cast<u32>(size)};
   m_fp->WriteBytes(&rec_hdr, sizeof(rec_hdr));
   m_fp->WriteBytes(bytes, size);
 }

--- a/Source/Core/Common/Profiler.cpp
+++ b/Source/Core/Common/Profiler.cpp
@@ -33,7 +33,7 @@ Profiler::Profiler(const std::string& name)
       m_calls(0), m_depth(0)
 {
   m_time = Common::Timer::NowUs();
-  s_max_length = std::max<u32>(s_max_length, u32(m_name.length()));
+  s_max_length = std::max<u32>(s_max_length, static_cast<u32>(m_name.length()));
 
   std::lock_guard<std::mutex> lk(s_mutex);
   s_all_profilers.push_back(this);
@@ -128,8 +128,8 @@ std::string Profiler::Read()
   double time_rel = 0;
   if (m_calls)
   {
-    avg = double(m_usecs) / m_calls;
-    stdev = std::sqrt(double(m_usecs_quad) / m_calls - avg * avg);
+    avg = static_cast<double>(m_usecs) / m_calls;
+    stdev = std::sqrt(static_cast<double>(m_usecs_quad) / m_calls - avg * avg);
   }
   else
   {
@@ -137,7 +137,7 @@ std::string Profiler::Read()
   }
   if (s_usecs_frame)
   {
-    time_rel = double(m_usecs) * 100 / s_usecs_frame;
+    time_rel = static_cast<double>(m_usecs) * 100 / s_usecs_frame;
   }
 
   std::ostringstream buffer;

--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -66,7 +66,7 @@ SettingsReader::SettingsReader(const SettingsBuffer& buffer) : m_decoded{""}
   u32 key = INITIAL_SEED;
   for (u32 position = 0; position < buffer.size(); ++position)
   {
-    m_decoded.push_back((u8)(buffer[position] ^ key));
+    m_decoded.push_back(static_cast<u8>(buffer[position] ^ key));
     key = (key >> 31) | (key << 1);
   }
 

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -263,7 +263,7 @@ void TraversalClient::HandleResends()
   const u32 now = enet_time_get();
   for (auto& tpi : m_OutgoingTraversalPackets)
   {
-    if (now - tpi.sendTime >= (u32)(300 * tpi.tries))
+    if (now - tpi.sendTime >= static_cast<u32>(300 * tpi.tries))
     {
       if (tpi.tries >= 5)
       {
@@ -373,7 +373,7 @@ void TraversalClient::HandleTraversalTest()
           waitCondition = 0;
           break;
         }
-        else if (rv < int(sizeof(packet)) || raddr.host != m_ServerAddress.host ||
+        else if (rv < static_cast<int>(sizeof(packet)) || raddr.host != m_ServerAddress.host ||
                  raddr.host != m_portAlt || packet.requestId != m_TestRequestId)
         {
           // irrelevant packet, ignore

--- a/Source/Core/Common/x64ABI.cpp
+++ b/Source/Core/Common/x64ABI.cpp
@@ -55,14 +55,17 @@ size_t XEmitter::ABI_PushRegistersAndAdjustStack(BitSet32 mask, size_t rsp_align
     MOV(64, R(RBP), R(RSP));
   }
   for (int r : (mask & ABI_ALL_GPRS & ~BitSet32{RBP}))
-    PUSH((X64Reg)r);
+    PUSH(static_cast<X64Reg>(r));
 
   if (subtraction)
-    SUB(64, R(RSP), subtraction >= 0x80 ? Imm32((u32)subtraction) : Imm8((u8)subtraction));
+    SUB(64, R(RSP),
+        subtraction >= 0x80 ?
+          Imm32(static_cast<u32>(subtraction)) :
+          Imm8(static_cast<u8>(subtraction)));
 
   for (int x : (mask & ABI_ALL_FPRS))
   {
-    MOVAPD(MDisp(RSP, (int)xmm_offset), (X64Reg)(x - 16));
+    MOVAPD(MDisp(RSP, static_cast<int>(xmm_offset)), static_cast<X64Reg>(x - 16));
     xmm_offset += 16;
   }
 
@@ -79,17 +82,19 @@ void XEmitter::ABI_PopRegistersAndAdjustStack(BitSet32 mask, size_t rsp_alignmen
 
   for (int x : (mask & ABI_ALL_FPRS))
   {
-    MOVAPD((X64Reg)(x - 16), MDisp(RSP, (int)xmm_offset));
+    MOVAPD(static_cast<X64Reg>(x - 16), MDisp(RSP, static_cast<int>(xmm_offset)));
     xmm_offset += 16;
   }
 
   if (subtraction)
-    ADD(64, R(RSP), subtraction >= 0x80 ? Imm32((u32)subtraction) : Imm8((u8)subtraction));
+    ADD(64, R(RSP),
+        subtraction >= 0x80 ? Imm32(static_cast<u32>(subtraction)) :
+                              Imm8(static_cast<u8>(subtraction)));
 
   for (int r = 15; r >= 0; r--)
   {
     if (r != RBP && mask[r])
-      POP((X64Reg)r);
+      POP(static_cast<X64Reg>(r));
   }
   // RSP is pushed first and popped last to make debuggers/profilers happy
   if (mask[RBP])

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -130,38 +130,38 @@ struct OpArg
   u32 Imm32() const
   {
     DEBUG_ASSERT(scale == SCALE_IMM32);
-    return (u32)offset;
+    return static_cast<u32>(offset);
   }
   u16 Imm16() const
   {
     DEBUG_ASSERT(scale == SCALE_IMM16);
-    return (u16)offset;
+    return static_cast<u16>(offset);
   }
   u8 Imm8() const
   {
     DEBUG_ASSERT(scale == SCALE_IMM8);
-    return (u8)offset;
+    return static_cast<u8>(offset);
   }
 
   s64 SImm64() const
   {
     DEBUG_ASSERT(scale == SCALE_IMM64);
-    return (s64)offset;
+    return static_cast<s64>(offset);
   }
   s32 SImm32() const
   {
     DEBUG_ASSERT(scale == SCALE_IMM32);
-    return (s32)offset;
+    return static_cast<s32>(offset);
   }
   s16 SImm16() const
   {
     DEBUG_ASSERT(scale == SCALE_IMM16);
-    return (s16)offset;
+    return static_cast<s16>(offset);
   }
   s8 SImm8() const
   {
     DEBUG_ASSERT(scale == SCALE_IMM8);
-    return (s8)offset;
+    return static_cast<s8>(offset);
   }
 
   OpArg AsImm64() const
@@ -172,17 +172,17 @@ struct OpArg
   OpArg AsImm32() const
   {
     DEBUG_ASSERT(IsImm());
-    return OpArg((u32)offset, SCALE_IMM32);
+    return OpArg(static_cast<u32>(offset), SCALE_IMM32);
   }
   OpArg AsImm16() const
   {
     DEBUG_ASSERT(IsImm());
-    return OpArg((u16)offset, SCALE_IMM16);
+    return OpArg(static_cast<u16>(offset), SCALE_IMM16);
   }
   OpArg AsImm8() const
   {
     DEBUG_ASSERT(IsImm());
-    return OpArg((u8)offset, SCALE_IMM8);
+    return OpArg(static_cast<u8>(offset), SCALE_IMM8);
   }
 
   constexpr bool IsImm() const
@@ -244,7 +244,7 @@ private:
 template <typename T>
 inline OpArg M(const T* ptr)
 {
-  return OpArg((u64)(const void*)ptr, (int)SCALE_RIP);
+  return OpArg((u64) static_cast<const void*>(ptr), (int)SCALE_RIP);
 }
 constexpr OpArg R(X64Reg value)
 {
@@ -308,7 +308,7 @@ inline u32 PtrOffset(const void* ptr, const void* base = nullptr)
     return 0;
   }
 
-  return (u32)distance;
+  return static_cast<u32>(distance);
 }
 
 struct FixupBranch

--- a/Source/Core/Core/ARDecrypt.cpp
+++ b/Source/Core/Core/ARDecrypt.cpp
@@ -150,8 +150,8 @@ constexpr Seeds genseeds = [] {
 
   for (size_t i = 0; i < array0.size(); ++i)
   {
-    const auto tmp = u8(gentable0[i] - 1);
-    array0[i] = (u32(0 - (gensubtable[tmp >> 3] & gentable1[tmp & 7])) >> 31);
+    const auto tmp = static_cast<u8>(gentable0[i] - 1);
+    array0[i] = (static_cast<u32>(0 - (gensubtable[tmp >> 3] & gentable1[tmp & 7])) >> 31);
   }
 
   for (int i = 0; i < 0x10; ++i)
@@ -163,7 +163,7 @@ constexpr Seeds genseeds = [] {
 
     for (u32 j = 0; j < 0x38; j++)
     {
-      auto tmp = u8(tmp2 + j);
+      auto tmp = static_cast<u8>(tmp2 + j);
 
       if (j > 0x1B)
       {
@@ -394,7 +394,7 @@ static bool batchdecrypt(u32* codes, u16 size)
 
 static int GetVal(const char* flt, char chr)
 {
-  int ret = (int)(strchr(flt, chr) - flt);
+  int ret = static_cast<int>(strchr(flt, chr) - flt);
   switch (ret)
   {
   case 32:  // 'I'
@@ -466,7 +466,7 @@ void DecryptARCode(std::vector<std::string> vCodes, std::vector<AREntry>* ops)
     Common::ToUpper(&s);
   }
 
-  const u32 ret = alphatobin(uCodes.data(), vCodes, (int)vCodes.size());
+  const u32 ret = alphatobin(uCodes.data(), vCodes, static_cast<int>(vCodes.size()));
   if (ret)
   {
     // Return value is index + 1, 0 being the success flag value.
@@ -474,7 +474,7 @@ void DecryptARCode(std::vector<std::string> vCodes, std::vector<AREntry>* ops)
         "Action Replay Code Decryption Error:\nParity Check Failed\n\nCulprit Code:\n{0}",
         vCodes[ret - 1]);
   }
-  else if (!batchdecrypt(uCodes.data(), (u16)vCodes.size() << 1))
+  else if (!batchdecrypt(uCodes.data(), static_cast<u16>(vCodes.size()) << 1))
   {
     // Commented out since we just send the code anyways and hope for the best XD
     // PanicAlertFmt("Action Replay Code Decryption Error:\nCRC Check Failed\n\n"

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -640,7 +640,7 @@ void AchievementManager::DoState(PointerWrap& p)
       return;
     }
   }
-  p.DoArray(buffer.get(), (u32)size);
+  p.DoArray(buffer.get(), static_cast<u32>(size));
   if (p.IsReadMode())
   {
     int result = rc_client_deserialize_progress_sized(m_client, buffer.get(), size);

--- a/Source/Core/Core/Boot/DolReader.cpp
+++ b/Source/Core/Core/Boot/DolReader.cpp
@@ -86,7 +86,7 @@ bool DolReader::Initialize(const std::vector<u8>& buffer)
       std::vector<u8> data(section_size);
       const u8* data_start = &buffer[section_offset];
       std::memcpy(&data[0], data_start,
-                  std::min((size_t)section_size, buffer.size() - section_offset));
+                  std::min(static_cast<size_t>(section_size), buffer.size() - section_offset));
       m_data_sections.emplace_back(data);
     }
     else

--- a/Source/Core/Core/Boot/ElfReader.h
+++ b/Source/Core/Core/Boot/ElfReader.h
@@ -31,8 +31,8 @@ public:
   ~ElfReader();
   u32 Read32(int off) const { return base32[off >> 2]; }
   // Quick accessors
-  ElfType GetType() const { return (ElfType)(header->e_type); }
-  ElfMachine GetMachine() const { return (ElfMachine)(header->e_machine); }
+  ElfType GetType() const { return static_cast<ElfType>(header->e_type); }
+  ElfMachine GetMachine() const { return static_cast<ElfMachine>(header->e_machine); }
   u32 GetEntryPoint() const override { return entryPoint; }
   u32 GetFlags() const { return (u32)(header->e_flags); }
   bool LoadIntoMemory(Core::System& system, bool only_in_mem1 = false) const override;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -924,11 +924,11 @@ int AddOnStateChangedCallback(StateChangedCallbackFunc callback)
     if (!s_on_state_changed_callbacks[i])
     {
       s_on_state_changed_callbacks[i] = std::move(callback);
-      return int(i);
+      return static_cast<int>(i);
     }
   }
   s_on_state_changed_callbacks.emplace_back(std::move(callback));
-  return int(s_on_state_changed_callbacks.size()) - 1;
+  return static_cast<int>(s_on_state_changed_callbacks.size()) - 1;
 }
 
 bool RemoveOnStateChangedCallback(int* handle)

--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -273,7 +273,7 @@ s32 DSPAssembler::ParseValue(const char* str)
 //
 char* DSPAssembler::FindBrackets(char* src, char* dst)
 {
-  s32 len = (s32)strlen(src);
+  s32 len = static_cast<s32>(strlen(src));
   s32 first = -1;
   s32 count = 0;
   s32 i, j;
@@ -323,8 +323,8 @@ u32 DSPAssembler::ParseExpression(const char* ptr)
   char* pbuf;
   s32 val = 0;
 
-  char* d_buffer = (char*)malloc(1024);
-  char* s_buffer = (char*)malloc(1024);
+  char* d_buffer = static_cast<char*>(malloc(1024));
+  char* s_buffer = static_cast<char*>(malloc(1024));
   strcpy(s_buffer, ptr);
 
   while ((pbuf = FindBrackets(s_buffer, d_buffer)) != nullptr)
@@ -335,14 +335,14 @@ u32 DSPAssembler::ParseExpression(const char* ptr)
   }
 
   int j = 0;
-  for (int i = 0; i < ((s32)strlen(s_buffer) + 1); i++)
+  for (int i = 0; i < (static_cast<s32>(strlen(s_buffer)) + 1); i++)
   {
     char c = s_buffer[i];
     if (c != ' ')
       d_buffer[j++] = c;
   }
 
-  for (int i = 0; i < ((s32)strlen(d_buffer) + 1); i++)
+  for (int i = 0; i < (static_cast<s32>(strlen(d_buffer)) + 1); i++)
   {
     char c = d_buffer[i];
     if (c == '-')
@@ -537,21 +537,23 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
         case P_REG1C:
         {
           int value = (opc->params[i].type >> 8) & 0x1f;
-          if ((int)par[i].val < value ||
-              (int)par[i].val > value + get_mask_shifted_down(opc->params[i].mask))
+          if (static_cast<int>(par[i].val) < value ||
+              static_cast<int>(par[i].val) > value + get_mask_shifted_down(opc->params[i].mask))
           {
             ShowError(AssemblerError::InvalidRegister);
           }
           break;
         }
         case P_PRG:
-          if ((int)par[i].val < DSP_REG_AR0 || (int)par[i].val > DSP_REG_AR3)
+          if (static_cast<int>(par[i].val) < DSP_REG_AR0 ||
+              static_cast<int>(par[i].val) > DSP_REG_AR3)
           {
             ShowError(AssemblerError::InvalidRegister);
           }
           break;
         case P_ACC:
-          if ((int)par[i].val < DSP_REG_ACC0_FULL || (int)par[i].val > DSP_REG_ACC1_FULL)
+          if (static_cast<int>(par[i].val) < DSP_REG_ACC0_FULL ||
+              static_cast<int>(par[i].val) > DSP_REG_ACC1_FULL)
           {
             if (par[i].val >= DSP_REG_ACM0 && par[i].val <= DSP_REG_ACM1)
             {
@@ -568,7 +570,8 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
           }
           break;
         case P_ACCM:
-          if ((int)par[i].val < DSP_REG_ACM0 || (int)par[i].val > DSP_REG_ACM1)
+          if (static_cast<int>(par[i].val) < DSP_REG_ACM0 ||
+              static_cast<int>(par[i].val) > DSP_REG_ACM1)
           {
             if (par[i].val >= DSP_REG_ACL0 && par[i].val <= DSP_REG_ACL1)
             {
@@ -585,7 +588,8 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
           }
           break;
         case P_ACCL:
-          if ((int)par[i].val < DSP_REG_ACL0 || (int)par[i].val > DSP_REG_ACL1)
+          if (static_cast<int>(par[i].val) < DSP_REG_ACL0 ||
+              static_cast<int>(par[i].val) > DSP_REG_ACL1)
           {
             if (par[i].val >= DSP_REG_ACM0 && par[i].val <= DSP_REG_ACM1)
             {
@@ -630,12 +634,12 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
       // modified by Hermes: test NUMBER range
       int value = get_mask_shifted_down(opc->params[i].mask);
       unsigned int valueu = 0xffff & ~(value >> 1);
-      if ((int)par[i].val < 0)
+      if (static_cast<int>(par[i].val) < 0)
       {
         if (value == 7)  // value 7 for sbclr/sbset
         {
           ShowError(AssemblerError::NumberOutOfRange, "Value must be from 0x0 to {:#x}, was {:#x}",
-                    value, (int)par[i].val);
+                    value, static_cast<int>(par[i].val));
         }
         else if (opc->params[i].type == P_MEM)
         {
@@ -643,27 +647,28 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
           {
             ShowError(AssemblerError::NumberOutOfRange,
                       "Address value must be from {:#x} to {:#x}, was {:#x}", valueu, (value >> 1),
-                      (int)par[i].val);
+                      static_cast<int>(par[i].val));
           }
           else
           {
             ShowError(AssemblerError::NumberOutOfRange,
-                      "Address value must be from 0x0 to {:#x}, was {:#x}", value, (int)par[i].val);
+                      "Address value must be from 0x0 to {:#x}, was {:#x}", value,
+                      static_cast<int>(par[i].val));
           }
         }
-        else if ((int)par[i].val < -((value >> 1) + 1))
+        else if (static_cast<int>(par[i].val) < -((value >> 1) + 1))
         {
           if (value < 128)
           {
             ShowError(AssemblerError::NumberOutOfRange,
                       "Value must be from {:#x} to {:#x}, was {:#x}", -((value >> 1) + 1),
-                      value >> 1, (int)par[i].val);
+                      value >> 1, static_cast<int>(par[i].val));
           }
           else
           {
             ShowError(AssemblerError::NumberOutOfRange,
                       "Value must be from {:#x} to {:#x} or 0x0 to {:#x}, was {:#x}",
-                      -((value >> 1) + 1), value >> 1, value, (int)par[i].val);
+                      -((value >> 1) + 1), value >> 1, value, static_cast<int>(par[i].val));
           }
         }
       }
@@ -671,7 +676,7 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
       {
         if (value == 7)  // value 7 for sbclr/sbset
         {
-          if (par[i].val > (unsigned)value)
+          if (par[i].val > static_cast<unsigned>(value))
           {
             ShowError(AssemblerError::NumberOutOfRange,
                       "Value must be from {:#x} to {:#x}, was {:#x}\n", valueu, value, par[i].val);
@@ -681,8 +686,8 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
         {
           if (value < 256)
             value >>= 1;  // addressing 8 bit with sign
-          if (par[i].val > (unsigned)value &&
-              (par[i].val < valueu || par[i].val > (unsigned)0xffff))
+          if (par[i].val > static_cast<unsigned>(value) &&
+              (par[i].val < valueu || par[i].val > static_cast<unsigned>(0xffff)))
           {
             if (value < 256)
             {
@@ -702,7 +707,7 @@ bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t 
         {
           if (value < 128)
             value >>= 1;  // special case ASL/ASR/LSL/LSR
-          if (par[i].val > (unsigned)value)
+          if (par[i].val > static_cast<unsigned>(value))
           {
             if (value < 64)
             {
@@ -818,7 +823,7 @@ bool DSPAssembler::AssemblePass(const std::string& text, int pass)
       }
 
       // turn text into spaces if disable_text is on (in a comment).
-      if (disable_text && ((unsigned char)c) > ' ')
+      if (disable_text && static_cast<unsigned char>(c) > ' ')
         c = ' ';
 
       if (c == '\r' || c == '\n' || c == ';')
@@ -842,7 +847,7 @@ bool DSPAssembler::AssemblePass(const std::string& text, int pass)
     {
       bool valid = true;
 
-      for (int j = 0; j < (int)col_pos; j++)
+      for (int j = 0; j < static_cast<int>(col_pos); j++)
       {
         if (j == 0)
           if (!((ptr[j] >= 'A' && ptr[j] <= 'Z') || (ptr[j] == '_')))

--- a/Source/Core/Core/DSP/DSPCodeUtil.cpp
+++ b/Source/Core/Core/DSP/DSPCodeUtil.cpp
@@ -141,7 +141,8 @@ std::vector<u16> BinaryStringBEToCode(const std::string& str)
 
   for (size_t i = 0; i < code.size(); i++)
   {
-    code[i] = ((u16)(u8)str[i * 2 + 0] << 8) | ((u16)(u8)str[i * 2 + 1]);
+    code[i] = (static_cast<u16>(static_cast<u8>(str[i * 2 + 0])) << 8) |
+              static_cast<u16>(static_cast<u8>(str[i * 2 + 1]));
   }
 
   return code;

--- a/Source/Core/Core/DSP/DSPDisassembler.cpp
+++ b/Source/Core/Core/DSP/DSPDisassembler.cpp
@@ -109,7 +109,8 @@ std::string DSPDisassembler::DisassembleParameters(const DSPOPCTemplate& opc, u1
         {
           // Left and right shifts function essentially as a single shift by a 7-bit signed value,
           // but are split into two intructions for clarity.
-          buf += fmt::format("#{}", (val & 0x20) != 0 ? (int(val) - 64) : int(val));
+          buf += fmt::format("#{}", (val & 0x20) != 0 ? (static_cast<int>(val) - 64) :
+            static_cast<int>(val));
         }
         else
         {
@@ -124,7 +125,7 @@ std::string DSPDisassembler::DisassembleParameters(const DSPOPCTemplate& opc, u1
 
     case P_MEM:
       if (opc.params[j].size != 2)
-        val = (u16)(s16)(s8)val;
+        val = static_cast<u16>(static_cast<s16>((s8)val));
 
       if (settings_.decode_names)
         buf += fmt::format("@{}", pdname(val));

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitArithmetic.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitArithmetic.cpp
@@ -1226,7 +1226,7 @@ void DSPEmitter::lsl(const UDSPInstruction opc)
   get_long_acc(rreg);
 
   //	acc <<= shift;
-  SHL(64, R(RAX), Imm8((u8)shift));
+  SHL(64, R(RAX), Imm8(static_cast<u8>(shift)));
 
   //	dsp_set_long_acc(rreg, acc);
   set_long_acc(rreg);
@@ -1285,7 +1285,7 @@ void DSPEmitter::asl(const UDSPInstruction opc)
   //	u64 acc = dsp_get_long_acc(rreg);
   get_long_acc(rreg);
   //	acc <<= shift;
-  SHL(64, R(RAX), Imm8((u8)shift));
+  SHL(64, R(RAX), Imm8(static_cast<u8>(shift)));
   //	dsp_set_long_acc(rreg, acc);
   set_long_acc(rreg);
   //	Update_SR_Register64(dsp_get_long_acc(rreg));
@@ -1315,7 +1315,7 @@ void DSPEmitter::asr(const UDSPInstruction opc)
   //	s64 acc = dsp_get_long_acc(dreg);
   get_long_acc(dreg);
   //	acc >>= shift;
-  SAR(64, R(RAX), Imm8((u8)shift));
+  SAR(64, R(RAX), Imm8(static_cast<u8>(shift)));
 
   //	dsp_set_long_acc(dreg, acc);
   set_long_acc(dreg);

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitMisc.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitMisc.cpp
@@ -47,7 +47,7 @@ void DSPEmitter::lri(const UDSPInstruction opc)
 void DSPEmitter::lris(const UDSPInstruction opc)
 {
   u8 reg = ((opc >> 8) & 0x7) + DSP_REG_AXL0;
-  u16 imm = (s8)opc;
+  u16 imm = static_cast<s8>(opc);
   dsp_op_write_reg_imm(reg, imm);
   dsp_conditional_extend_accum_imm(reg, imm);
 }

--- a/Source/Core/Core/Debugger/Dump.cpp
+++ b/Source/Core/Core/Debugger/Dump.cpp
@@ -33,7 +33,7 @@ CDump::~CDump()
 
 int CDump::GetNumberOfSteps()
 {
-  return (int)(m_size / STRUCTUR_SIZE);
+  return static_cast<int>(m_size / STRUCTUR_SIZE);
 }
 
 u32 CDump::GetGPR(int _step, int _gpr)

--- a/Source/Core/Core/Debugger/OSThread.cpp
+++ b/Source/Core/Core/Debugger/OSThread.cpp
@@ -19,23 +19,23 @@ namespace Core::Debug
 void OSContext::Read(const Core::CPUThreadGuard& guard, u32 addr)
 {
   for (std::size_t i = 0; i < gpr.size(); i++)
-    gpr[i] = PowerPC::MMU::HostRead_U32(guard, addr + u32(i * sizeof(int)));
+    gpr[i] = PowerPC::MMU::HostRead_U32(guard, addr + static_cast<u32>(i * sizeof(int)));
   cr = PowerPC::MMU::HostRead_U32(guard, addr + 0x80);
   lr = PowerPC::MMU::HostRead_U32(guard, addr + 0x84);
   ctr = PowerPC::MMU::HostRead_U32(guard, addr + 0x88);
   xer = PowerPC::MMU::HostRead_U32(guard, addr + 0x8C);
   for (std::size_t i = 0; i < fpr.size(); i++)
-    fpr[i] = PowerPC::MMU::HostRead_F64(guard, addr + 0x90 + u32(i * sizeof(double)));
+    fpr[i] = PowerPC::MMU::HostRead_F64(guard, addr + 0x90 + static_cast<u32>(i * sizeof(double)));
   fpscr = PowerPC::MMU::HostRead_U64(guard, addr + 0x190);
   srr0 = PowerPC::MMU::HostRead_U32(guard, addr + 0x198);
   srr1 = PowerPC::MMU::HostRead_U32(guard, addr + 0x19c);
   dummy = PowerPC::MMU::HostRead_U16(guard, addr + 0x1a0);
   state = static_cast<OSContext::State>(PowerPC::MMU::HostRead_U16(guard, addr + 0x1a2));
   for (std::size_t i = 0; i < gqr.size(); i++)
-    gqr[i] = PowerPC::MMU::HostRead_U32(guard, addr + 0x1a4 + u32(i * sizeof(int)));
+    gqr[i] = PowerPC::MMU::HostRead_U32(guard, addr + 0x1a4 + static_cast<u32>(i * sizeof(int)));
   psf_padding = 0;
   for (std::size_t i = 0; i < psf.size(); i++)
-    psf[i] = PowerPC::MMU::HostRead_F64(guard, addr + 0x1c8 + u32(i * sizeof(double)));
+    psf[i] = PowerPC::MMU::HostRead_F64(guard, addr + 0x1c8 + static_cast<u32>(i * sizeof(double)));
 }
 
 // Mutex offsets based on the following functions:

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -458,8 +458,8 @@ PPCDebugInterface::GetMemoryAddressFromInstruction(const std::string& instructio
   // match[1]: negative sign for offset or no match.
   // match[2]: 0xNNNN, 0, or rNN. Check next for 'r' to see if a gpr needs to be loaded.
   // match[3]: will either be p, toc, or NN. Always a gpr.
-  const std::string_view offset_match{&*match[2].first, size_t(match[2].length())};
-  const std::string_view register_match{&*match[3].first, size_t(match[3].length())};
+  const std::string_view offset_match{&*match[2].first, static_cast<size_t>(match[2].length())};
+  const std::string_view register_match{&*match[3].first, static_cast<size_t>(match[3].length())};
   constexpr char is_reg = 'r';
   u32 offset = 0;
 
@@ -488,7 +488,8 @@ PPCDebugInterface::GetMemoryAddressFromInstruction(const std::string& instructio
 
   const u32 base_address = m_system.GetPPCState().gpr[i];
 
-  if (std::string_view sign{&*match[1].first, size_t(match[1].length())}; !sign.empty())
+  if (std::string_view sign{&*match[1].first, static_cast<size_t>(match[1].length())};
+      !sign.empty())
     return base_address - offset;
 
   return base_address + offset;

--- a/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
@@ -158,7 +158,7 @@ bool FifoDataFile::Save(const std::string& filename)
   header.texMemSize = TEX_MEM_SIZE;
 
   header.frameListOffset = frameListOffset;
-  header.frameCount = (u32)m_Frames.size();
+  header.frameCount = static_cast<u32>(m_Frames.size());
 
   header.flags = m_Flags;
 

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -92,8 +92,8 @@ void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file,
 
     while (offset < frame.fifoData.size())
     {
-      const u32 cmd_size = OpcodeDecoder::RunCommand(&frame.fifoData[offset],
-                                                     u32(frame.fifoData.size()) - offset, analyzer);
+      const u32 cmd_size = OpcodeDecoder::RunCommand(
+          &frame.fifoData[offset], static_cast<u32>(frame.fifoData.size()) - offset, analyzer);
 
       if (analyzer.m_start_of_primitives)
       {
@@ -414,7 +414,7 @@ void FifoPlayer::WriteFrame(const FifoFrameInfo& frame, const AnalyzedFrameInfo&
   // Skip all memory updates if early memory updates are enabled, as we already wrote them
   if (m_EarlyMemoryUpdates)
   {
-    memory_update = (u32)(frame.memoryUpdates.size());
+    memory_update = static_cast<u32>(frame.memoryUpdates.size());
   }
 
   for (const FramePart& part : info.parts)
@@ -533,7 +533,7 @@ void FifoPlayer::WriteFifo(const u8* data, u32 start, u32 end)
     gpfifo.Write8(data[written++]);
 
     // Advance core timing
-    u32 elapsedCycles = u32(((u64)written * m_CyclesPerFrame) / m_FrameFifoSize);
+    u32 elapsedCycles = static_cast<u32>((static_cast<u64>(written) * m_CyclesPerFrame) / m_FrameFifoSize);
     u32 cyclesUsed = elapsedCycles - m_ElapsedCycles;
     m_ElapsedCycles = elapsedCycles;
 

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -379,7 +379,7 @@ void FifoRecorder::UseMemory(u32 address, u32 size, MemoryUpdate::Type type, boo
     // Record memory update
     MemoryUpdate memUpdate;
     memUpdate.address = address;
-    memUpdate.fifoPosition = (u32)(m_FifoData.size());
+    memUpdate.fifoPosition = static_cast<u32>(m_FifoData.size());
     memUpdate.type = type;
     memUpdate.data.resize(size);
     std::copy_n(newData, size, memUpdate.data.begin());
@@ -447,7 +447,7 @@ void FifoRecorder::SetVideoMemory(const u32* bpMem, const u32* cpMem, const u32*
     memcpy(m_File->GetCPMem(), cpMem, FifoDataFile::CP_MEM_SIZE * 4);
     memcpy(m_File->GetXFMem(), xfMem, FifoDataFile::XF_MEM_SIZE * 4);
 
-    u32 xfRegsCopySize = std::min((u32)FifoDataFile::XF_REGS_SIZE, xfRegsSize);
+    u32 xfRegsCopySize = std::min(static_cast<u32>(FifoDataFile::XF_REGS_SIZE), xfRegsSize);
     memcpy(m_File->GetXFRegs(), xfRegs, xfRegsCopySize * 4);
 
     memcpy(m_File->GetTexMem(), texMem_ptr, FifoDataFile::TEX_MEM_SIZE);

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -118,7 +118,7 @@ FreeLookController::FreeLookController(const unsigned int index) : m_index(index
 
 std::string FreeLookController::GetName() const
 {
-  return std::string("FreeLook") + char('1' + m_index);
+  return std::string("FreeLook") + static_cast<char>('1' + m_index);
 }
 
 InputConfig* FreeLookController::GetConfig() const

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -43,7 +43,7 @@ u16 CMailHandler::ReadDSPMailboxHigh()
   {
     m_last_mail = m_pending_mails.front().first;
   }
-  return u16(m_last_mail >> 0x10);
+  return static_cast<u16>(m_last_mail >> 0x10);
 }
 
 u16 CMailHandler::ReadDSPMailboxLow()
@@ -66,7 +66,7 @@ u16 CMailHandler::ReadDSPMailboxLow()
   // (The CPU reads the high word first, and then the low word; since this function returns the low
   // word, this means that the next read of the high word will have the top bit cleared.)
   m_last_mail &= ~0x8000'0000;
-  return u16(m_last_mail & 0xffff);
+  return static_cast<u16>(m_last_mail & 0xffff);
 }
 
 void CMailHandler::ClearPending()

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -145,7 +145,8 @@ protected:
     for (size_t i = 0; i < BufCount; ++i)
     {
       const BufferDesc& buf = buffers[i];
-      s32 value = s32((u32(init_array[3 * i]) << 16) | init_array[3 * i + 1]);
+      s32 value =
+          static_cast<s32>((static_cast<u32>(init_array[3 * i]) << 16) | init_array[3 * i + 1]);
       s16 delta = init_array[3 * i + 2];
       if (value == 0)
       {

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -368,7 +368,7 @@ void MixAdd(int* out, const s16* input, u32 count, VolumeData* vd, s16* dpop, bo
     s64 sample = input[i];
     sample *= volume;
     sample >>= 15;
-    s16 sample16 = ClampS16((s32)sample);
+    s16 sample16 = ClampS16(static_cast<s32>(sample));
 
     out[i] += sample16;
     volume += volume_delta;
@@ -381,7 +381,8 @@ void MixAdd(int* out, const s16* input, u32 count, VolumeData* vd, s16* dpop, bo
 static void LowPassFilter(s16* samples, u32 count, PBLowPassFilter& f)
 {
   for (u32 i = 0; i < count; ++i)
-    f.yn1 = samples[i] = ClampS16((f.a0 * (s32)samples[i] + f.b0 * (s32)f.yn1) >> 15);
+    f.yn1 = samples[i] =
+      ClampS16((f.a0 * static_cast<s32>(samples[i]) + f.b0 * static_cast<s32>(f.yn1)) >> 15);
 }
 
 #ifdef AX_WII
@@ -436,7 +437,7 @@ void ProcessVoice(HLEAccelerator* accelerator, PB_TYPE& pb, const AXBuffers& buf
     // unsigned on Wii
     const s32 volume = (u16)pb.vol_env.cur_volume;
 #endif
-    const s32 sample = ((s32)samples[i] * volume) >> 15;
+    const s32 sample = (static_cast<s32>(samples[i]) * volume) >> 15;
     samples[i] = ClampS16(sample);
     pb.vol_env.cur_volume += pb.vol_env.cur_volume_delta;
   }

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -106,12 +106,12 @@ void AXWiiUCode::HandleCommandList()
       {
         volume = m_cmdlist[curr_idx++];
         u32 addresses[6] = {
-            (u32)(m_cmdlist[curr_idx + 0] << 16) | m_cmdlist[curr_idx + 1],
-            (u32)(m_cmdlist[curr_idx + 2] << 16) | m_cmdlist[curr_idx + 3],
-            (u32)(m_cmdlist[curr_idx + 4] << 16) | m_cmdlist[curr_idx + 5],
-            (u32)(m_cmdlist[curr_idx + 6] << 16) | m_cmdlist[curr_idx + 7],
-            (u32)(m_cmdlist[curr_idx + 8] << 16) | m_cmdlist[curr_idx + 9],
-            (u32)(m_cmdlist[curr_idx + 10] << 16) | m_cmdlist[curr_idx + 11],
+            static_cast<u32>(m_cmdlist[curr_idx + 0] << 16) | m_cmdlist[curr_idx + 1],
+            static_cast<u32>(m_cmdlist[curr_idx + 2] << 16) | m_cmdlist[curr_idx + 3],
+            static_cast<u32>(m_cmdlist[curr_idx + 4] << 16) | m_cmdlist[curr_idx + 5],
+            static_cast<u32>(m_cmdlist[curr_idx + 6] << 16) | m_cmdlist[curr_idx + 7],
+            static_cast<u32>(m_cmdlist[curr_idx + 8] << 16) | m_cmdlist[curr_idx + 9],
+            static_cast<u32>(m_cmdlist[curr_idx + 10] << 16) | m_cmdlist[curr_idx + 11],
         };
         curr_idx += 12;
         UploadAUXMixLRSC(cmd == CMD_UPL_AUXB_MIX_LRSC_OLD, addresses, volume);
@@ -140,10 +140,10 @@ void AXWiiUCode::HandleCommandList()
       case CMD_WM_OUTPUT_OLD:
       {
         u32 addresses[4] = {
-            (u32)(m_cmdlist[curr_idx + 0] << 16) | m_cmdlist[curr_idx + 1],
-            (u32)(m_cmdlist[curr_idx + 2] << 16) | m_cmdlist[curr_idx + 3],
-            (u32)(m_cmdlist[curr_idx + 4] << 16) | m_cmdlist[curr_idx + 5],
-            (u32)(m_cmdlist[curr_idx + 6] << 16) | m_cmdlist[curr_idx + 7],
+            static_cast<u32>(m_cmdlist[curr_idx + 0] << 16) | m_cmdlist[curr_idx + 1],
+            static_cast<u32>(m_cmdlist[curr_idx + 2] << 16) | m_cmdlist[curr_idx + 3],
+            static_cast<u32>(m_cmdlist[curr_idx + 4] << 16) | m_cmdlist[curr_idx + 5],
+            static_cast<u32>(m_cmdlist[curr_idx + 6] << 16) | m_cmdlist[curr_idx + 7],
         };
         curr_idx += 8;
         OutputWMSamples(addresses);
@@ -203,12 +203,12 @@ void AXWiiUCode::HandleCommandList()
       {
         volume = m_cmdlist[curr_idx++];
         u32 addresses[6] = {
-            (u32)(m_cmdlist[curr_idx + 0] << 16) | m_cmdlist[curr_idx + 1],
-            (u32)(m_cmdlist[curr_idx + 2] << 16) | m_cmdlist[curr_idx + 3],
-            (u32)(m_cmdlist[curr_idx + 4] << 16) | m_cmdlist[curr_idx + 5],
-            (u32)(m_cmdlist[curr_idx + 6] << 16) | m_cmdlist[curr_idx + 7],
-            (u32)(m_cmdlist[curr_idx + 8] << 16) | m_cmdlist[curr_idx + 9],
-            (u32)(m_cmdlist[curr_idx + 10] << 16) | m_cmdlist[curr_idx + 11],
+            static_cast<u32>(m_cmdlist[curr_idx + 0] << 16) | m_cmdlist[curr_idx + 1],
+            static_cast<u32>(m_cmdlist[curr_idx + 2] << 16) | m_cmdlist[curr_idx + 3],
+            static_cast<u32>(m_cmdlist[curr_idx + 4] << 16) | m_cmdlist[curr_idx + 5],
+            static_cast<u32>(m_cmdlist[curr_idx + 6] << 16) | m_cmdlist[curr_idx + 7],
+            static_cast<u32>(m_cmdlist[curr_idx + 8] << 16) | m_cmdlist[curr_idx + 9],
+            static_cast<u32>(m_cmdlist[curr_idx + 10] << 16) | m_cmdlist[curr_idx + 11],
         };
         curr_idx += 12;
         UploadAUXMixLRSC(cmd == CMD_UPL_AUXB_MIX_LRSC, addresses, volume);
@@ -238,10 +238,10 @@ void AXWiiUCode::HandleCommandList()
       case CMD_WM_OUTPUT:
       {
         u32 addresses[4] = {
-            (u32)(m_cmdlist[curr_idx + 0] << 16) | m_cmdlist[curr_idx + 1],
-            (u32)(m_cmdlist[curr_idx + 2] << 16) | m_cmdlist[curr_idx + 3],
-            (u32)(m_cmdlist[curr_idx + 4] << 16) | m_cmdlist[curr_idx + 5],
-            (u32)(m_cmdlist[curr_idx + 6] << 16) | m_cmdlist[curr_idx + 7],
+            static_cast<u32>(m_cmdlist[curr_idx + 0] << 16) | m_cmdlist[curr_idx + 1],
+            static_cast<u32>(m_cmdlist[curr_idx + 2] << 16) | m_cmdlist[curr_idx + 3],
+            static_cast<u32>(m_cmdlist[curr_idx + 4] << 16) | m_cmdlist[curr_idx + 5],
+            static_cast<u32>(m_cmdlist[curr_idx + 6] << 16) | m_cmdlist[curr_idx + 7],
         };
         curr_idx += 8;
         OutputWMSamples(addresses);
@@ -274,10 +274,10 @@ void AXWiiUCode::SetupProcessing(u32 init_addr)
 void AXWiiUCode::AddToLR(u32 val_addr, bool neg)
 {
   auto& memory = m_dsphle->GetSystem().GetMemory();
-  int* ptr = (int*)HLEMemory_Get_Pointer(memory, val_addr);
+  int* ptr = static_cast<int*>(HLEMemory_Get_Pointer(memory, val_addr));
   for (int i = 0; i < 32 * 3; ++i)
   {
-    int val = (int)Common::swap32(*ptr++);
+    int val = static_cast<int>(Common::swap32(*ptr++));
     if (neg)
       val = -val;
 
@@ -289,15 +289,15 @@ void AXWiiUCode::AddToLR(u32 val_addr, bool neg)
 void AXWiiUCode::AddSubToLR(u32 val_addr)
 {
   auto& memory = m_dsphle->GetSystem().GetMemory();
-  int* ptr = (int*)HLEMemory_Get_Pointer(memory, val_addr);
+  int* ptr = static_cast<int*>(HLEMemory_Get_Pointer(memory, val_addr));
   for (int i = 0; i < 32 * 3; ++i)
   {
-    int val = (int)Common::swap32(*ptr++);
+    int val = static_cast<int>(Common::swap32(*ptr++));
     m_samples_main_left[i] += val;
   }
   for (int i = 0; i < 32 * 3; ++i)
   {
-    int val = (int)Common::swap32(*ptr++);
+    int val = static_cast<int>(Common::swap32(*ptr++));
     m_samples_main_right[i] -= val;
   }
 }
@@ -347,7 +347,7 @@ AXMixControl AXWiiUCode::ConvertMixerControl(u32 mixer_control)
   if (mixer_control & 0x40000000)
     ret |= MIX_AUXC_S | MIX_AUXC_S_RAMP;
 
-  return (AXMixControl)ret;
+  return static_cast<AXMixControl>(ret);
 }
 
 void AXWiiUCode::GenerateVolumeRamp(u16* output, u16 vol1, u16 vol2, size_t nvals)
@@ -355,8 +355,8 @@ void AXWiiUCode::GenerateVolumeRamp(u16* output, u16 vol1, u16 vol2, size_t nval
   float curr = vol1;
   for (size_t i = 0; i < nvals; ++i)
   {
-    curr += (vol2 - vol1) / (float)nvals;
-    output[i] = (u16)curr;
+    curr += (vol2 - vol1) / static_cast<float>(nvals);
+    output[i] = static_cast<u16>(curr);
   }
 }
 
@@ -526,7 +526,7 @@ void AXWiiUCode::MixAUXSamples(int aux_id, u32 write_addr, u32 read_addr, u16 vo
   auto& memory = m_dsphle->GetSystem().GetMemory();
   if (write_addr)
   {
-    int* ptr = (int*)HLEMemory_Get_Pointer(memory, write_addr);
+    int* ptr = static_cast<int*>(HLEMemory_Get_Pointer(memory, write_addr));
     for (const auto& buffer : buffers)
     {
       for (u32 j = 0; j < 3 * 32; ++j)
@@ -535,14 +535,14 @@ void AXWiiUCode::MixAUXSamples(int aux_id, u32 write_addr, u32 read_addr, u16 vo
   }
 
   // Then read the buffers from the CPU and add to our main buffers.
-  const int* ptr = (int*)HLEMemory_Get_Pointer(memory, read_addr);
+  const int* ptr = static_cast<int*>(HLEMemory_Get_Pointer(memory, read_addr));
   for (auto& main_buffer : main_buffers)
   {
     for (u32 j = 0; j < 3 * 32; ++j)
     {
-      s64 sample = (s64)(s32)Common::swap32(*ptr++);
+      s64 sample = (s64) static_cast<s32>(Common::swap32(*ptr++));
       sample *= volume_ramp[j];
-      main_buffer[j] += (s32)(sample >> 15);
+      main_buffer[j] += static_cast<s32>(sample >> 15);
     }
   }
 }
@@ -555,7 +555,7 @@ void AXWiiUCode::UploadAUXMixLRSC(int aux_id, u32* addresses, u16 volume)
   int* auxc_buffer = aux_id ? m_samples_auxC_surround : m_samples_auxC_right;
 
   auto& memory = m_dsphle->GetSystem().GetMemory();
-  int* upload_ptr = (int*)HLEMemory_Get_Pointer(memory, addresses[0]);
+  int* upload_ptr = static_cast<int*>(HLEMemory_Get_Pointer(memory, addresses[0]));
   for (u32 i = 0; i < 96; ++i)
     *upload_ptr++ = Common::swap32(aux_left[i]);
   for (u32 i = 0; i < 96; ++i)
@@ -563,7 +563,7 @@ void AXWiiUCode::UploadAUXMixLRSC(int aux_id, u32* addresses, u16 volume)
   for (u32 i = 0; i < 96; ++i)
     *upload_ptr++ = Common::swap32(aux_surround[i]);
 
-  upload_ptr = (int*)HLEMemory_Get_Pointer(memory, addresses[1]);
+  upload_ptr = static_cast<int*>(HLEMemory_Get_Pointer(memory, addresses[1]));
   for (u32 i = 0; i < 96; ++i)
     *upload_ptr++ = Common::swap32(auxc_buffer[i]);
 
@@ -575,7 +575,7 @@ void AXWiiUCode::UploadAUXMixLRSC(int aux_id, u32* addresses, u16 volume)
                       m_samples_auxC_left};
   for (u32 mix_i = 0; mix_i < 4; ++mix_i)
   {
-    int* dl_ptr = (int*)HLEMemory_Get_Pointer(memory, addresses[2 + mix_i]);
+    int* dl_ptr = static_cast<int*>(HLEMemory_Get_Pointer(memory, addresses[2 + mix_i]));
     for (u32 i = 0; i < 96; ++i)
       aux_left[i] = Common::swap32(dl_ptr[i]);
 
@@ -583,7 +583,7 @@ void AXWiiUCode::UploadAUXMixLRSC(int aux_id, u32* addresses, u16 volume)
     {
       s64 sample = (s64)(s32)aux_left[i];
       sample *= volume_ramp[i];
-      mix_dest[mix_i][i] += (s32)(sample >> 15);
+      mix_dest[mix_i][i] += static_cast<s32>(sample >> 15);
     }
   }
 }
@@ -644,11 +644,11 @@ void AXWiiUCode::OutputWMSamples(u32* addresses)
   for (u32 i = 0; i < 4; ++i)
   {
     int* in = buffers[i];
-    u16* out = (u16*)HLEMemory_Get_Pointer(memory, addresses[i]);
+    u16* out = static_cast<u16*>(HLEMemory_Get_Pointer(memory, addresses[i]));
     for (u32 j = 0; j < 3 * 6; ++j)
     {
       s16 sample = ClampS16(in[j]);
-      out[j] = Common::swap16((u16)sample);
+      out[j] = Common::swap16(static_cast<u16>(sample));
     }
   }
 }

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -470,7 +470,7 @@ void ZeldaUCode::RunPendingCommands()
       m_renderer.SetVPBBaseAddress(Read32());
 
       auto& memory = m_dsphle->GetSystem().GetMemory();
-      u16* data_ptr = (u16*)HLEMemory_Get_Pointer(memory, Read32());
+      u16* data_ptr = static_cast<u16*>(HLEMemory_Get_Pointer(memory, Read32()));
 
       std::array<s16, 0x100> resampling_coeffs;
       for (size_t i = 0; i < 0x100; ++i)
@@ -492,7 +492,7 @@ void ZeldaUCode::RunPendingCommands()
         m_renderer.SetSineTable(std::move(sine_table));
       }
 
-      u16* afc_coeffs_ptr = (u16*)HLEMemory_Get_Pointer(memory, Read32());
+      u16* afc_coeffs_ptr = static_cast<u16*>(HLEMemory_Get_Pointer(memory, Read32()));
       std::array<s16, 0x20> afc_coeffs;
       for (size_t i = 0; i < 0x20; ++i)
         afc_coeffs[i] = Common::swap16(afc_coeffs_ptr[i]);
@@ -1084,7 +1084,7 @@ void ZeldaAudioRenderer::ApplyReverb(bool post_rendering)
   };
 
   auto& memory = m_system.GetMemory();
-  u16* rpb_base_ptr = (u16*)HLEMemory_Get_Pointer(memory, m_reverb_pb_base_addr);
+  u16* rpb_base_ptr = static_cast<u16*>(HLEMemory_Get_Pointer(memory, m_reverb_pb_base_addr));
   for (u16 rpb_idx = 0; rpb_idx < 4; ++rpb_idx)
   {
     ReverbPB rpb;
@@ -1098,7 +1098,7 @@ void ZeldaAudioRenderer::ApplyReverb(bool post_rendering)
     u16 mram_buffer_idx = m_reverb_pb_frames_count[rpb_idx];
 
     u32 mram_addr = rpb.GetCircularBufferBase() + mram_buffer_idx * 0x50 * sizeof(s16);
-    s16* mram_ptr = (s16*)HLEMemory_Get_Pointer(memory, mram_addr);
+    s16* mram_ptr = static_cast<s16*>(HLEMemory_Get_Pointer(memory, mram_addr));
 
     if (!post_rendering)
     {
@@ -1120,7 +1120,7 @@ void ZeldaAudioRenderer::ApplyReverb(bool post_rendering)
         {
           s32 sample = 0;
           for (u16 j = 0; j < 8; ++j)
-            sample += (s32)buffer[i + j] * rpb.filter_coeffs[j];
+            sample += static_cast<s32>(buffer[i + j]) * rpb.filter_coeffs[j];
           sample >>= 15;
           buffer[i] = std::clamp(sample, -0x8000, 0x7FFF);
         }
@@ -1305,10 +1305,10 @@ void ZeldaAudioRenderer::AddVoice(u16 voice_id)
     // Compute volume for each quadrant.
     u16 shift_factor = (m_flags & MAKE_DOLBY_LOUDER) ? 15 : 16;
     s16 quadrant_volumes[4] = {
-        (s16)((left_volume * front_volume) >> shift_factor),
-        (s16)((left_volume * back_volume) >> shift_factor),
-        (s16)((right_volume * front_volume) >> shift_factor),
-        (s16)((right_volume * back_volume) >> shift_factor),
+        static_cast<s16>((left_volume * front_volume) >> shift_factor),
+        static_cast<s16>((left_volume * back_volume) >> shift_factor),
+        static_cast<s16>((right_volume * front_volume) >> shift_factor),
+        static_cast<s16>((right_volume * back_volume) >> shift_factor),
     };
 
     // Compute the volume delta for each sample to match the difference
@@ -1316,7 +1316,7 @@ void ZeldaAudioRenderer::AddVoice(u16 voice_id)
     s16 delta = vpb.dolby_volume_target - vpb.dolby_volume_current;
     s16 volume_deltas[4];
     for (size_t i = 0; i < 4; ++i)
-      volume_deltas[i] = ((u16)quadrant_volumes[i] * delta) >> shift_factor;
+      volume_deltas[i] = (static_cast<u16>(quadrant_volumes[i]) * delta) >> shift_factor;
 
     // Apply master volume to each quadrant.
     for (s16& quadrant_volume : quadrant_volumes)
@@ -1349,7 +1349,8 @@ void ZeldaAudioRenderer::AddVoice(u16 voice_id)
     for (const auto& buffer : buffers)
     {
       AddBuffersWithVolumeRamp(buffer.buffer, input_samples, buffer.volume << 16,
-                               (buffer.volume_delta << 16) / (s32)buffer.buffer->size());
+                               (buffer.volume_delta << 16) /
+                                    static_cast<s32>(buffer.buffer->size()));
     }
 
     vpb.dolby_volume_current = vpb.dolby_volume_target;
@@ -1384,7 +1385,8 @@ void ZeldaAudioRenderer::AddVoice(u16 voice_id)
       else
         volume_delta = vpb.channels[i].target_volume - vpb.channels[i].current_volume;
 
-      s32 volume_step = (volume_delta << 16) / (s32)input_samples.size();  // In 1.31 format.
+      s32 volume_step =
+          (volume_delta << 16) / static_cast<s32>(input_samples.size());  // In 1.31 format.
 
       // TODO: The last value of each channel structure is used to
       // determine whether a channel should be skipped or not. Not
@@ -1424,15 +1426,15 @@ void ZeldaAudioRenderer::FinalizeFrame()
   ApplyVolumeInPlace_4_12(&m_buf_front_right, m_output_volume);
 
   auto& memory = m_system.GetMemory();
-  u16* ram_left_buffer = (u16*)HLEMemory_Get_Pointer(memory, m_output_lbuf_addr);
-  u16* ram_right_buffer = (u16*)HLEMemory_Get_Pointer(memory, m_output_rbuf_addr);
+  u16* ram_left_buffer = static_cast<u16*>(HLEMemory_Get_Pointer(memory, m_output_lbuf_addr));
+  u16* ram_right_buffer = static_cast<u16*>(HLEMemory_Get_Pointer(memory, m_output_rbuf_addr));
   for (size_t i = 0; i < m_buf_front_left.size(); ++i)
   {
     ram_left_buffer[i] = Common::swap16(m_buf_front_left[i]);
     ram_right_buffer[i] = Common::swap16(m_buf_front_right[i]);
   }
-  m_output_lbuf_addr += sizeof(u16) * (u32)m_buf_front_left.size();
-  m_output_rbuf_addr += sizeof(u16) * (u32)m_buf_front_right.size();
+  m_output_lbuf_addr += sizeof(u16) * static_cast<u32>(m_buf_front_left.size());
+  m_output_rbuf_addr += sizeof(u16) * static_cast<u32>(m_buf_front_right.size());
 
   // TODO: Some more Dolby mixing.
 
@@ -1445,7 +1447,7 @@ void ZeldaAudioRenderer::FetchVPB(u16 voice_id, VPB* vpb)
 {
   auto& memory = m_system.GetMemory();
   u16* vpb_words = (u16*)vpb;
-  u16* ram_vpbs = (u16*)HLEMemory_Get_Pointer(memory, m_vpb_base_addr);
+  u16* ram_vpbs = static_cast<u16*>(HLEMemory_Get_Pointer(memory, m_vpb_base_addr));
 
   // A few versions of the UCode have VPB of size 0x80 (vs. the standard
   // 0xC0). The whole 0x40-0x80 part is gone. Handle that by moving things
@@ -1464,7 +1466,7 @@ void ZeldaAudioRenderer::StoreVPB(u16 voice_id, VPB* vpb)
 {
   auto& memory = m_system.GetMemory();
   u16* vpb_words = (u16*)vpb;
-  u16* ram_vpbs = (u16*)HLEMemory_Get_Pointer(memory, m_vpb_base_addr);
+  u16* ram_vpbs = static_cast<u16*>(HLEMemory_Get_Pointer(memory, m_vpb_base_addr));
 
   size_t vpb_size = (m_flags & TINY_VPB) ? 0x80 : 0xC0;
   size_t base_idx = voice_id * vpb_size;
@@ -1631,10 +1633,10 @@ void ZeldaAudioRenderer::Resample(VPB* vpb, const s16* src, MixingBuffer* dst)
 
       s64 dst_sample_unclamped = 0;
       for (size_t i = 0; i < 4; ++i)
-        dst_sample_unclamped += (s64)2 * coeffs[i] * input[i];
+        dst_sample_unclamped += static_cast<s64>(2) * coeffs[i] * input[i];
       dst_sample_unclamped >>= 16;
 
-      dst_sample = (s16)std::clamp<s64>(dst_sample_unclamped, -0x8000, 0x7FFF);
+      dst_sample = static_cast<s16>(std::clamp<s64>(dst_sample_unclamped, -0x8000, 0x7FFF));
 
       pos += ratio;
     }
@@ -1688,8 +1690,9 @@ void ZeldaAudioRenderer::DownloadPCMSamplesFromARAM(s16* dst, VPB* vpb, u16 requ
       vpb->SetCurrentARAMAddr(vpb->GetBaseAddress() + vpb->GetCurrentPosition() * sizeof(T));
     }
 
-    T* src_ptr = (T*)GetARAMPtr(vpb->GetCurrentARAMAddr());
-    u16 samples_to_download = std::min(vpb->GetRemainingLength(), (u32)requested_samples_count);
+    T* src_ptr = static_cast<T*>(GetARAMPtr(vpb->GetCurrentARAMAddr()));
+    u16 samples_to_download =
+        std::min(vpb->GetRemainingLength(), static_cast<u32>(requested_samples_count));
 
     for (u16 i = 0; i < samples_to_download; ++i)
       *dst++ = Common::FromBigEndian<T>(*src_ptr++) << (16 - 8 * sizeof(T));
@@ -1823,8 +1826,8 @@ void ZeldaAudioRenderer::DownloadAFCSamplesFromARAM(s16* dst, VPB* vpb, u16 requ
 void ZeldaAudioRenderer::DecodeAFC(VPB* vpb, s16* dst, size_t block_count)
 {
   u32 addr = vpb->GetCurrentARAMAddr();
-  u8* src = (u8*)GetARAMPtr(addr);
-  vpb->SetCurrentARAMAddr(addr + (u32)block_count * vpb->samples_source_type);
+  u8* src = static_cast<u8*>(GetARAMPtr(addr));
+  vpb->SetCurrentARAMAddr(addr + static_cast<u32>(block_count) * vpb->samples_source_type);
 
   for (size_t b = 0; b < block_count; ++b)
   {
@@ -1843,7 +1846,7 @@ void ZeldaAudioRenderer::DecodeAFC(VPB* vpb, s16* dst, size_t block_count)
         src++;
       }
       for (auto& nibble : nibbles)
-        nibble = s16(nibble << 12) >> 1;
+        nibble = static_cast<s16>(nibble << 12) >> 1;
     }
     else
     {
@@ -1857,7 +1860,7 @@ void ZeldaAudioRenderer::DecodeAFC(VPB* vpb, s16* dst, size_t block_count)
         src++;
       }
       for (auto& nibble : nibbles)
-        nibble = s16(nibble << 14) >> 1;
+        nibble = static_cast<s16>(nibble << 14) >> 1;
     }
 
     s32 yn1 = *vpb->AFCYN1(), yn2 = *vpb->AFCYN2();
@@ -1866,7 +1869,7 @@ void ZeldaAudioRenderer::DecodeAFC(VPB* vpb, s16* dst, size_t block_count)
       s32 sample = delta * nibble + yn1 * m_afc_coeffs[idx * 2] + yn2 * m_afc_coeffs[idx * 2 + 1];
       sample >>= 11;
       sample = std::clamp(sample, -0x8000, 0x7fff);
-      *dst++ = (s16)sample;
+      *dst++ = static_cast<s16>(sample);
       yn2 = yn1;
       yn1 = sample;
     }
@@ -1880,7 +1883,7 @@ void ZeldaAudioRenderer::DownloadRawSamplesFromMRAM(s16* dst, VPB* vpb, u16 requ
 {
   auto& memory = m_system.GetMemory();
   u32 addr = vpb->GetBaseAddress() + vpb->current_position_h * sizeof(u16);
-  s16* src_ptr = (s16*)HLEMemory_Get_Pointer(memory, addr);
+  s16* src_ptr = static_cast<s16*>(HLEMemory_Get_Pointer(memory, addr));
 
   if (requested_samples_count > vpb->GetRemainingLength())
   {
@@ -1909,7 +1912,7 @@ void ZeldaAudioRenderer::DownloadRawSamplesFromMRAM(s16* dst, VPB* vpb, u16 requ
       for (u16 i = 0; i < vpb->samples_before_loop; ++i)
         *dst++ = Common::swap16(*src_ptr++);
       vpb->SetBaseAddress(vpb->GetLoopAddress());
-      src_ptr = (s16*)HLEMemory_Get_Pointer(memory, vpb->GetLoopAddress());
+      src_ptr = static_cast<s16*>(HLEMemory_Get_Pointer(memory, vpb->GetLoopAddress()));
       for (u16 i = vpb->samples_before_loop; i < requested_samples_count; ++i)
         *dst++ = Common::swap16(*src_ptr++);
       vpb->current_position_h = requested_samples_count - vpb->samples_before_loop;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -60,10 +60,10 @@ private:
   {
     for (size_t i = 0; i < N; ++i)
     {
-      s32 tmp = (u32)(*buf)[i] * (u32)vol;
+      s32 tmp = static_cast<u32>((*buf)[i]) * static_cast<u32>(vol);
       tmp >>= 16 - B;
 
-      (*buf)[i] = (s16)std::clamp(tmp, -0x8000, 0x7FFF);
+      (*buf)[i] = static_cast<s16>(std::clamp(tmp, -0x8000, 0x7FFF));
     }
   }
   template <size_t N>
@@ -104,7 +104,7 @@ private:
   {
     while (count--)
     {
-      s32 vol_src = ((s32)*src++ * (s32)vol) >> 15;
+      s32 vol_src = (static_cast<s32>(*src++) * static_cast<s32>(vol)) >> 15;
       *dst++ += std::clamp(vol_src, -0x8000, 0x7FFF);
     }
   }

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -40,7 +40,7 @@ int Line2Addr(int line)  // -1 for not found
 
 const char* GetLineText(int line)
 {
-  if (line >= 0 && line < (int)lines.size())
+  if (line >= 0 && line < static_cast<int>(lines.size()))
   {
     return lines[line].c_str();
   }

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -235,9 +235,10 @@ void DVDInterface::DTKStreamingCallback(DIInterruptType interrupt_type,
   }
 
   // Read the next chunk of audio data asynchronously.
-  s64 ticks_to_dtk = m_system.GetSystemTimers().GetTicksPerSecond() * s64(m_pending_blocks) *
-                     StreamADPCM::SAMPLES_PER_BLOCK * sample_rate_divisor /
-                     Mixer::FIXED_SAMPLE_RATE_DIVIDEND;
+  s64 ticks_to_dtk = m_system.GetSystemTimers().GetTicksPerSecond() *
+                     static_cast<s64>(m_pending_blocks) *
+                     StreamADPCM::SAMPLES_PER_BLOCK *
+                     sample_rate_divisor / Mixer::FIXED_SAMPLE_RATE_DIVIDEND;
   ticks_to_dtk -= cycles_late;
   if (read_length > 0)
   {

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -65,7 +65,7 @@ void SetIPIdentification(u8* ptr, std::size_t size, u16 value)
 
   u8* const ip_checksum_ptr = ip_ptr + offsetof(Common::IPv4Header, header_checksum);
   auto checksum_bitcast_ptr = Common::BitCastPtr<u16>(ip_checksum_ptr);
-  checksum_bitcast_ptr = u16(0);
+  checksum_bitcast_ptr = static_cast<u16>(0);
   checksum_bitcast_ptr = htons(Common::ComputeNetworkChecksum(ip_ptr, ip_header_size));
 }
 }  // namespace

--- a/Source/Core/Core/HW/EXI/BBA/TAPServerConnection.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAPServerConnection.cpp
@@ -205,7 +205,7 @@ bool TAPServerConnection::SendAndRemoveAllHDLCFrames(std::string* send_buf)
     }
     const int written_bytes =
         send(m_fd, send_buf->data() + start_offset, static_cast<int>(size), SEND_FLAGS);
-    if (u32(written_bytes) != size)
+    if (static_cast<u32>(written_bytes) != size)
     {
       ERROR_LOG_FMT(SP1,
                     "SendAndRemoveAllHDLCFrames(): expected to write {} bytes, instead wrote {}",
@@ -232,7 +232,7 @@ bool TAPServerConnection::SendFrame(const u8* frame, u32 size)
   }
   const int written_bytes =
       send(m_fd, reinterpret_cast<const char*>(frame), static_cast<ws_ssize_t>(size), SEND_FLAGS);
-  if (u32(written_bytes) != size)
+  if (static_cast<u32>(written_bytes) != size)
   {
     ERROR_LOG_FMT(SP1, "SendFrame(): expected to write {} bytes, instead wrote {}", size,
                   written_bytes);

--- a/Source/Core/Core/HW/EXI/BBA/XLINK_KAI_BBA.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/XLINK_KAI_BBA.cpp
@@ -42,7 +42,7 @@ bool CEXIETHERNET::XLinkNetworkInterface::Activate()
   std::string cmd =
       "connect;" + m_client_identifier + ";dolphin;000000000000000000000000000000000000000000";
 
-  const auto size = u32(cmd.length());
+  const auto size = static_cast<u32>(cmd.length());
   memmove(buffer, cmd.c_str(), size);
 
   DEBUG_LOG_FMT(SP1, "SendCommandPayload {:x}\n{}", size, ArrayToString(buffer, size, 0x10));
@@ -67,7 +67,7 @@ void CEXIETHERNET::XLinkNetworkInterface::Deactivate()
   // disconnect;optional_locally_unique_name;optional_padding
   std::string cmd =
       "disconnect;" + m_client_identifier + ";0000000000000000000000000000000000000000000";
-  const auto size = u32(cmd.length());
+  const auto size = static_cast<u32>(cmd.length());
   u8 buffer[255] = {};
   memmove(buffer, cmd.c_str(), size);
 
@@ -188,7 +188,7 @@ void CEXIETHERNET::XLinkNetworkInterface::ReadThreadHandler(
           // Only uncomment for debugging, the performance hit is too big otherwise
           // DEBUG_LOG_FMT(SP1, "Read data: {}", ArrayToString(self->m_eth_ref->mRecvBuffer.get(),
           // u32(bytes_read - 4), 0x10));
-          self->m_eth_ref->mRecvBufferLength = u32(bytes_read - 4);
+          self->m_eth_ref->mRecvBufferLength = static_cast<u32>(bytes_read - 4);
           self->m_eth_ref->RecvHandlePacket();
         }
       }
@@ -213,7 +213,7 @@ void CEXIETHERNET::XLinkNetworkInterface::ReadThreadHandler(
         if (self->m_chat_osd_enabled)
         {
           constexpr std::string_view cmd = "setting;chat;true;";
-          const auto size = u32(cmd.length());
+          const auto size = static_cast<u32>(cmd.length());
           u8 buffer[255] = {};
           memmove(buffer, cmd.data(), size);
 

--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -193,9 +193,9 @@ void ExpansionInterfaceManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 void ExpansionInterfaceManager::ChangeDeviceCallback(Core::System& system, u64 userdata,
                                                      s64 cycles_late)
 {
-  u8 channel = (u8)(userdata >> 32);
-  u8 type = (u8)(userdata >> 16);
-  u8 num = (u8)userdata;
+  u8 channel = static_cast<u8>(userdata >> 32);
+  u8 type = static_cast<u8>(userdata >> 16);
+  u8 num = static_cast<u8>(userdata);
 
   system.GetExpansionInterface().m_channels.at(channel)->AddDevice(static_cast<EXIDeviceType>(type),
                                                                    num);
@@ -213,11 +213,13 @@ void ExpansionInterfaceManager::ChangeDevice(u8 channel, u8 device_num, EXIDevic
   // Let the hardware see no device for 1 second
   auto& core_timing = m_system.GetCoreTiming();
   core_timing.ScheduleEvent(0, m_event_type_change_device,
-                            ((u64)channel << 32) | ((u64)EXIDeviceType::None << 16) | device_num,
+                            (static_cast<u64>(channel) << 32) |
+                                (static_cast<u64>(EXIDeviceType::None) << 16) | device_num,
                             from_thread);
   core_timing.ScheduleEvent(
       m_system.GetSystemTimers().GetTicksPerSecond(), m_event_type_change_device,
-      ((u64)channel << 32) | ((u64)device_type << 16) | device_num, from_thread);
+      (static_cast<u64>(channel) << 32) | (static_cast<u64>(device_type) << 16) | device_num,
+      from_thread);
 }
 
 CEXIChannel* ExpansionInterfaceManager::GetChannel(u32 index)

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -292,7 +292,7 @@ private:
 
   inline u16 page_ptr(int const index) const
   {
-    return ((u16)mBbaMem[index + 1] << 8) | mBbaMem[index];
+    return (static_cast<u16>(mBbaMem[index + 1]) << 8) | mBbaMem[index];
   }
 
   bool IsMXCommand(u32 const data);

--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -84,7 +84,7 @@ GCKeyboard::GCKeyboard(const unsigned int index) : m_index(index)
 
 std::string GCKeyboard::GetName() const
 {
-  return std::string("GCKeyboard") + char('1' + m_index);
+  return std::string("GCKeyboard") + static_cast<char>('1' + m_index);
 }
 
 InputConfig* GCKeyboard::GetConfig() const

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -435,7 +435,7 @@ u16 GCMemcard::DEntry_FirstBlock(u8 index) const
     return 0xFFFF;
 
   u16 block = GetActiveDirectory().m_dir_entries[index].m_first_block;
-  if (block > (u16)m_size_blocks)
+  if (block > static_cast<u16>(m_size_blocks))
     return 0xFFFF;
   return block;
 }
@@ -446,7 +446,7 @@ u16 GCMemcard::DEntry_BlockCount(u8 index) const
     return 0xFFFF;
 
   u16 blocks = GetActiveDirectory().m_dir_entries[index].m_block_count;
-  if (blocks > (u16)m_size_blocks)
+  if (blocks > static_cast<u16>(m_size_blocks))
     return 0xFFFF;
   return blocks;
 }
@@ -1043,7 +1043,7 @@ bool GCMemcard::Format(const CardFlashId& flash_id, u16 size_mbits, bool shift_j
   m_bat_blocks[0] = m_bat_blocks[1] = BlockAlloc(size_mbits);
 
   m_size_mb = size_mbits;
-  m_size_blocks = (u32)m_size_mb * MBIT_TO_BLOCKS;
+  m_size_blocks = static_cast<u32>(m_size_mb) * MBIT_TO_BLOCKS;
   m_data_blocks.clear();
   m_data_blocks.resize(m_size_blocks - MC_FST_BLOCKS);
 
@@ -1083,10 +1083,14 @@ s32 GCMemcard::FZEROGX_MakeSaveGameValid(const Header& cardheader, const DEntry&
   const auto [serial1, serial2] = cardheader.CalculateSerial();
 
   // set new serial numbers
-  *(u16*)&FileBuffer[1].m_block[0x0066] = Common::swap16(u16(Common::swap32(serial1) >> 16));
-  *(u16*)&FileBuffer[3].m_block[0x1580] = Common::swap16(u16(Common::swap32(serial2) >> 16));
-  *(u16*)&FileBuffer[1].m_block[0x0060] = Common::swap16(u16(Common::swap32(serial1) & 0xFFFF));
-  *(u16*)&FileBuffer[1].m_block[0x0200] = Common::swap16(u16(Common::swap32(serial2) & 0xFFFF));
+  *(u16*)&FileBuffer[1].m_block[0x0066] =
+      Common::swap16(static_cast<u16>(Common::swap32(serial1) >> 16));
+  *(u16*)&FileBuffer[3].m_block[0x1580] =
+      Common::swap16(static_cast<u16>(Common::swap32(serial2) >> 16));
+  *(u16*)&FileBuffer[1].m_block[0x0060] =
+      Common::swap16(static_cast<u16>(Common::swap32(serial1) & 0xFFFF));
+  *(u16*)&FileBuffer[1].m_block[0x0200] =
+      Common::swap16(static_cast<u16>(Common::swap32(serial2) & 0xFFFF));
 
   // calc 16-bit checksum
   for (i = 0x02; i < 0x8000; i++)
@@ -1104,7 +1108,7 @@ s32 GCMemcard::FZEROGX_MakeSaveGameValid(const Header& cardheader, const DEntry&
   }
 
   // set new checksum
-  *(u16*)&FileBuffer[0].m_block[0x00] = Common::swap16(u16(~chksum));
+  *(u16*)&FileBuffer[0].m_block[0x00] = Common::swap16(static_cast<u16>(~chksum));
 
   return 1;
 }
@@ -1210,7 +1214,7 @@ void InitializeHeaderData(HeaderData* data, const CardFlashId& flash_id, u16 siz
   for (int i = 0; i < 12; i++)
   {
     rand = (((rand * (u64)0x0000000041c64e6dULL) + (u64)0x0000000000003039ULL) >> 16);
-    data->m_serial[i] = (u8)(flash_id[i] + (u32)rand);
+    data->m_serial[i] = static_cast<u8>(flash_id[i] + static_cast<u32>(rand));
     rand = (((rand * (u64)0x0000000041c64e6dULL) + (u64)0x0000000000003039ULL) >> 16);
     rand &= (u64)0x0000000000007fffULL;
   }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -115,7 +115,7 @@ bool GCMemcardDirectory::LoadGCI(Memcard::GCIFile gci)
   }
 
   // actually load save file into memory card
-  int idx = (int)m_saves.size();
+  int idx = static_cast<int>(m_saves.size());
   m_dir1.Replace(gci.m_gci_header, idx);
   m_saves.push_back(std::move(gci));
   SetUsedBlocks(idx);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
@@ -43,7 +43,7 @@ MemoryCard::MemoryCard(const std::string& filename, ExpansionInterface::Slot car
   if (file)
   {
     // Measure size of the existing memcard file.
-    m_memory_card_size = (u32)file.GetSize();
+    m_memory_card_size = static_cast<u32>(file.GetSize());
     m_nintendo_card_id = m_memory_card_size / SIZE_TO_Mb;
     m_memcard_data = std::make_unique<u8[]>(m_memory_card_size);
     memset(&m_memcard_data[0], 0xFF, m_memory_card_size);

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -91,7 +91,7 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
 
 std::string GCPad::GetName() const
 {
-  return std::string("GCPad") + char('1' + m_index);
+  return std::string("GCPad") + static_cast<char>('1' + m_index);
 }
 
 InputConfig* GCPad::GetConfig() const

--- a/Source/Core/Core/HW/MMIO.cpp
+++ b/Source/Core/Core/HW/MMIO.cpp
@@ -230,7 +230,7 @@ ReadHandlingMethod<T>* ReadToSmaller(Mapping* mmio, u32 high_part_addr, u32 low_
 
   // TODO(delroth): optimize
   return ComplexRead<T>([=](Core::System& system, u32 addr) {
-    return ((T)high_part->Read(system, high_part_addr) << (8 * sizeof(ST))) |
+    return (static_cast<T>(high_part->Read(system, high_part_addr)) << (8 * sizeof(ST))) |
            low_part->Read(system, low_part_addr);
   });
 }
@@ -246,7 +246,7 @@ WriteHandlingMethod<T>* WriteToSmaller(Mapping* mmio, u32 high_part_addr, u32 lo
   // TODO(delroth): optimize
   return ComplexWrite<T>([=](Core::System& system, u32 addr, T val) {
     high_part->Write(system, high_part_addr, val >> (8 * sizeof(ST)));
-    low_part->Write(system, low_part_addr, (ST)val);
+    low_part->Write(system, low_part_addr, static_cast<ST>(val));
   });
 }
 

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -131,7 +131,7 @@ void MemoryManager::Init()
     if (!region.active)
       continue;
 
-    *region.out_pointer = (u8*)m_arena.CreateView(region.shm_position, region.size);
+    *region.out_pointer = static_cast<u8*>(m_arena.CreateView(region.shm_position, region.size));
 
     if (!*region.out_pointer)
     {
@@ -217,7 +217,7 @@ bool MemoryManager::InitFastmemArena()
       continue;
 
     u8* base = m_physical_base + region.physical_address;
-    u8* view = (u8*)m_arena.MapInMemoryRegion(region.shm_position, region.size, base);
+    u8* view = static_cast<u8*>(m_arena.MapInMemoryRegion(region.shm_position, region.size, base));
 
     if (base != view)
     {

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -162,7 +162,7 @@ void SerialInterfaceManager::RunSIBuffer(u64 user_data, s64 cycles_late)
       std::ostringstream ss;
       for (u8 b : request_copy)
       {
-        ss << std::hex << std::setw(2) << std::setfill('0') << (int)b << ' ';
+        ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(b) << ' ';
       }
       DEBUG_LOG_FMT(
           SERIALINTERFACE,
@@ -360,7 +360,7 @@ void SerialInterfaceManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   }
 
   // In and out for the 4 SI channels.
-  for (u32 i = 0; i < u32(MAX_SI_CHANNELS); ++i)
+  for (u32 i = 0; i < static_cast<u32>(MAX_SI_CHANNELS); ++i)
   {
     // We need to clear the RDST bit for the SI channel when reading.
     const u32 clear_rdst = ~GetRDSTBit(i);

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
@@ -57,7 +57,7 @@ u32 CSIDevice_DanceMat::MapPadStatus(const GCPadStatus& pad_status)
   if (pad_status.button & PAD_BUTTON_START)
     map |= 0x1000;
 
-  return (u32)(map << 16) | 0x8080;
+  return static_cast<u32>(map << 16) | 0x8080;
 }
 
 bool CSIDevice_DanceMat::GetData(u32& hi, u32& low)

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
@@ -158,10 +158,11 @@ void GBASockServer::ClockSync(Core::System& system)
   }
   else
   {
-    time_slice = (u32)(core_timing.GetTicks() - m_last_time_slice);
+    time_slice = static_cast<u32>(core_timing.GetTicks() - m_last_time_slice);
   }
 
-  time_slice = (u32)((u64)time_slice * 16777216 / system.GetSystemTimers().GetTicksPerSecond());
+  time_slice = static_cast<u32>(static_cast<u64>(time_slice) * 16777216 /
+                                system.GetSystemTimers().GetTicksPerSecond());
   m_last_time_slice = core_timing.GetTicks();
   char bytes[4] = {0, 0, 0, 0};
   bytes[0] = (time_slice >> 24) & 0xff;

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -80,7 +80,7 @@ int CSIDevice_GCController::RunBuffer(u8* buffer, int request_length)
     INFO_LOG_FMT(SERIALINTERFACE, "PAD - Get Origin");
 
     u8* calibration = reinterpret_cast<u8*>(&m_origin);
-    for (int i = 0; i < (int)sizeof(SOrigin); i++)
+    for (int i = 0; i < static_cast<int>(sizeof(SOrigin)); i++)
     {
       buffer[i] = *calibration++;
     }
@@ -93,7 +93,7 @@ int CSIDevice_GCController::RunBuffer(u8* buffer, int request_length)
     INFO_LOG_FMT(SERIALINTERFACE, "PAD - Recalibrate");
 
     u8* calibration = reinterpret_cast<u8*>(&m_origin);
-    for (int i = 0; i < (int)sizeof(SOrigin); i++)
+    for (int i = 0; i < static_cast<int>(sizeof(SOrigin)); i++)
     {
       buffer[i] = *calibration++;
     }
@@ -263,7 +263,7 @@ CSIDevice_GCController::HandleButtonCombos(const GCPadStatus& pad_status)
   {
     const u64 current_time = m_system.GetCoreTiming().GetTicks();
     const u32 ticks_per_second = m_system.GetSystemTimers().GetTicksPerSecond();
-    if (u32(current_time - m_timer_button_combo_start) > ticks_per_second * 3)
+    if (static_cast<u32>(current_time - m_timer_button_combo_start) > ticks_per_second * 3)
     {
       if (m_last_button_combo == COMBO_RESET)
       {

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
@@ -49,12 +49,12 @@ bool CSIDevice_GCSteeringWheel::GetData(u32& hi, u32& low)
   {
     GCPadStatus pad_status = GetPadStatus();
 
-    hi = (u32)((u8)pad_status.stickX);  // Steering
-    hi |= 0x800;                        // Pedal connected flag
-    hi |= (u32)((u16)(pad_status.button | PAD_USE_ORIGIN) << 16);
+    hi = static_cast<u32>((u8)pad_status.stickX);  // Steering
+    hi |= 0x800;                                   // Pedal connected flag
+    hi |= static_cast<u32>(static_cast<u16>(pad_status.button | PAD_USE_ORIGIN) << 16);
 
-    low = (u8)pad_status.triggerRight;              // All 8 bits
-    low |= (u32)((u8)pad_status.triggerLeft << 8);  // All 8 bits
+    low = (u8)pad_status.triggerRight;                         // All 8 bits
+    low |= static_cast<u32>((u8)pad_status.triggerLeft << 8);  // All 8 bits
 
     // The GC Steering Wheel has 8 bit values for both the accelerator/brake.
     // Our mapping UI and GCPadEmu class weren't really designed to provide
@@ -83,10 +83,10 @@ bool CSIDevice_GCSteeringWheel::GetData(u32& hi, u32& low)
     // but we'll have to redesign our GameCube controller input to fix that.
 
     // All 8 bits (Accelerate)
-    low |= u32(std::clamp(accel_value * 2, 0, 0xff)) << 24;
+    low |= static_cast<u32>(std::clamp(accel_value * 2, 0, 0xff)) << 24;
 
     // All 8 bits (Brake)
-    low |= u32(std::clamp(brake_value * 2, 0, 0xff)) << 16;
+    low |= static_cast<u32>(std::clamp(brake_value * 2, 0, 0xff)) << 16;
 
     HandleButtonCombos(pad_status);
   }
@@ -110,7 +110,7 @@ void CSIDevice_GCSteeringWheel::SendCommand(u32 command, u8 poll)
     if (pad_num < 4)
     {
       // Lowest bit is the high bit of the strength field.
-      const auto type = ForceCommandType(wheel_command.parameter2 >> 1);
+      const auto type = static_cast<ForceCommandType>(wheel_command.parameter2 >> 1);
 
       // Strength is a 9 bit value from 0 to 256.
       // 0 = left strong, 256 = right strong
@@ -129,7 +129,7 @@ void CSIDevice_GCSteeringWheel::SendCommand(u32 command, u8 poll)
         Pad::Rumble(pad_num, 0);
         break;
       default:
-        WARN_LOG_FMT(SERIALINTERFACE, "Unknown CMD_FORCE type {}", int(type));
+        WARN_LOG_FMT(SERIALINTERFACE, "Unknown CMD_FORCE type {}", static_cast<int>(type));
         break;
       }
     }

--- a/Source/Core/Core/HW/Sram.cpp
+++ b/Source/Core/Core/HW/Sram.cpp
@@ -68,7 +68,7 @@ void SetCardFlashID(Sram* sram, const u8* buffer, ExpansionInterface::Slot card_
   for (int i = 0; i < 12; i++)
   {
     rand = (((rand * (u64)0x0000000041c64e6dULL) + (u64)0x0000000000003039ULL) >> 16);
-    csum += sram->settings_ex.flash_id[card_index][i] = buffer[i] - ((u8)rand & 0xff);
+    csum += sram->settings_ex.flash_id[card_index][i] = buffer[i] - (static_cast<u8>(rand) & 0xff);
     rand = (((rand * (u64)0x0000000041c64e6dULL) + (u64)0x0000000000003039ULL) >> 16);
     rand &= (u64)0x0000000000007fffULL;
   }

--- a/Source/Core/Core/HW/StreamADPCM.cpp
+++ b/Source/Core/Core/HW/StreamADPCM.cpp
@@ -32,7 +32,7 @@ static s16 ADPDecodeSample(s32 bits, s32 q, s32& hist1, s32& hist2)
   }
   hist = std::clamp((hist + 0x20) >> 6, -0x200000, 0x1fffff);
 
-  s32 cur = (((s16)(bits << 12) >> (q & 0xf)) << 6) + hist;
+  s32 cur = ((static_cast<s16>(bits << 12) >> (q & 0xf)) << 6) + hist;
 
   hist2 = hist1;
   hist1 = cur;
@@ -40,7 +40,7 @@ static s16 ADPDecodeSample(s32 bits, s32 q, s32& hist1, s32& hist2)
   cur >>= 6;
   cur = std::clamp(cur, -0x8000, 0x7fff);
 
-  return (s16)cur;
+  return static_cast<s16>(cur);
 }
 
 void ADPCMDecoder::ResetFilter()

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -194,7 +194,8 @@ u32 SystemTimersManager::GetFakeDecrementer() const
 {
   const auto& core_timing = m_system.GetCoreTiming();
   return (core_timing.GetFakeDecStartValue() -
-          (u32)((core_timing.GetTicks() - core_timing.GetFakeDecStartTicks()) / TIMER_RATIO));
+          static_cast<u32>((core_timing.GetTicks() - core_timing.GetFakeDecStartTicks()) /
+                            TIMER_RATIO));
 }
 
 void SystemTimersManager::TimeBaseSet()

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -355,7 +355,7 @@ void VideoInterfaceManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::ComplexWrite<u16>([](Core::System& system, u32, u16 val) {
                    auto& vi = system.GetVideoInterface();
                    vi.m_unknown_aa_register =
-                       (vi.m_unknown_aa_register & 0x0000FFFF) | ((u32)val << 16);
+                       (vi.m_unknown_aa_register & 0x0000FFFF) | (static_cast<u32>(val) << 16);
                    WARN_LOG_FMT(VIDEOINTERFACE, "Writing to the unknown AA register (hi)");
                  }));
   mmio->Register(base | VI_UNK_AA_REG_LO, MMIO::ComplexRead<u16>([](Core::System& system, u32) {

--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -244,12 +244,14 @@ private:
 
   static constexpr FS::Modes GetFsMode(u8 bin_mode)
   {
-    return {FS::Mode(bin_mode >> 4 & 3), FS::Mode(bin_mode >> 2 & 3), FS::Mode(bin_mode >> 0 & 3)};
+    return {static_cast<FS::Mode>(bin_mode >> 4 & 3), static_cast<FS::Mode>(bin_mode >> 2 & 3),
+            static_cast<FS::Mode>(bin_mode >> 0 & 3)};
   }
 
   static constexpr u8 GetBinMode(const FS::Modes& modes)
   {
-    return u8(modes.owner) << 4 | u8(modes.group) << 2 | u8(modes.other) << 0;
+    return static_cast<u8>(modes.owner) << 4 | static_cast<u8>(modes.group) << 2 |
+           static_cast<u8>(modes.other) << 0;
   }
 
   u8 GetBinMode(const std::string& path) const

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -231,10 +231,10 @@ void DoState(PointerWrap& p)
   for (int i = 0; i < MAX_BBMOTES; ++i)
   {
     const WiimoteSource source = GetSource(i);
-    auto state_wiimote_source = u8(source);
+    auto state_wiimote_source = static_cast<u8>(source);
     p.Do(state_wiimote_source);
 
-    if (WiimoteSource(state_wiimote_source) == WiimoteSource::Emulated)
+    if (static_cast<WiimoteSource>(state_wiimote_source) == WiimoteSource::Emulated)
     {
       // Sync complete state of emulated wiimotes.
       static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->DoState(p);
@@ -244,7 +244,8 @@ void DoState(PointerWrap& p)
     {
       // If using a real wiimote or the save-state source does not match the current source,
       // then force a reconnection on load.
-      if (source == WiimoteSource::Real || source != WiimoteSource(state_wiimote_source))
+      if (source == WiimoteSource::Real ||
+          source != static_cast<WiimoteSource>(state_wiimote_source))
         WiimoteCommon::UpdateSource(i);
     }
   }

--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteReport.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteReport.h
@@ -209,7 +209,8 @@ struct InputReportStatus
   }
   void SetEstimatedCharge(float charge)
   {
-    battery = u8(std::lround((charge - BATTERY_LEVEL_B) / BATTERY_LEVEL_M * BATTERY_MAX));
+    battery =
+        static_cast<u8>(std::lround((charge - BATTERY_LEVEL_B) / BATTERY_LEVEL_M * BATTERY_MAX));
   }
 
 private:

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
@@ -66,7 +66,7 @@ CameraLogic::GetCameraPoints(const Common::Matrix44& transform, Common::Vec2 fie
 
   const auto camera_view =
       Matrix44::Perspective(field_of_view.y, field_of_view.x / field_of_view.y, 0.001f, 1000) *
-      Matrix44::FromMatrix33(Matrix33::RotateX(float(MathUtil::TAU / 4))) * transform;
+      Matrix44::FromMatrix33(Matrix33::RotateX(static_cast<float>(MathUtil::TAU / 4))) * transform;
 
   std::array<CameraPoint, CameraLogic::NUM_POINTS> camera_points;
 
@@ -78,8 +78,8 @@ CameraLogic::GetCameraPoints(const Common::Matrix44& transform, Common::Vec2 fie
       return CameraPoint();
 
     // FYI: truncating vs. rounding seems to produce more symmetrical cursor positioning.
-    const auto x = s32((1 - point.x / point.w) * CAMERA_RES_X / 2);
-    const auto y = s32((1 - point.y / point.w) * CAMERA_RES_Y / 2);
+    const auto x = static_cast<s32>((1 - point.x / point.w) * CAMERA_RES_X / 2);
+    const auto y = static_cast<s32>((1 - point.y / point.w) * CAMERA_RES_Y / 2);
 
     // Check if LED is outside of view.
     if (x < 0 || y < 0 || x >= CAMERA_RES_X || y >= CAMERA_RES_Y)
@@ -91,7 +91,8 @@ CameraLogic::GetCameraPoints(const Common::Matrix44& transform, Common::Vec2 fie
 
     const auto clamped_point_size = std::clamp<s32>(std::lround(point_size), 1, MAX_POINT_SIZE);
 
-    return CameraPoint({u16(x), u16(y)}, u8(clamped_point_size));
+    return CameraPoint({static_cast<u16>(x), static_cast<u16>(y)},
+                       static_cast<u8>(clamped_point_size));
   });
 
   return camera_points;
@@ -166,7 +167,7 @@ void CameraLogic::Update(const std::array<CameraPoint, NUM_POINTS>& camera_point
             std::lround((irdata.xmax - irdata.xmin) * (irdata.ymax - irdata.ymin) /
                         SUBPIXEL_RESOLUTION / SUBPIXEL_RESOLUTION * MathUtil::TAU / 8);
 
-        irdata.intensity = u8(std::min(MAX_INTENSITY, intensity));
+        irdata.intensity = static_cast<u8>(std::min(MAX_INTENSITY, intensity));
 
         Common::BitCastPtr<IRFull>(&data[i * sizeof(IRFull)]) = irdata;
       }

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.h
@@ -113,7 +113,7 @@ public:
   // Jordan: I calculate the FOV at 42 degrees horizontally and having a 4:3 aspect ratio.
   // This is 31.5 degrees vertically.
   static constexpr float CAMERA_AR = 4.f / 3;
-  static constexpr float CAMERA_FOV_X = 42 * float(MathUtil::TAU) / 360;
+  static constexpr float CAMERA_FOV_X = 42 * static_cast<float>(MathUtil::TAU) / 360;
   static constexpr float CAMERA_FOV_Y = CAMERA_FOV_X / CAMERA_AR;
 
   enum : u8

--- a/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/DesiredWiimoteState.cpp
@@ -29,20 +29,21 @@ SerializedWiimoteState SerializeDesiredState(const DesiredWiimoteState& state)
   // encoding so that typical extensions (None, Nunchuk, Classic Controller) still fit into the
   // initial 4 bits.
   static_assert(std::variant_size_v<DesiredExtensionState::ExtensionData> <= (1 << 4));
-  const u8 extension = u8(state.extension.data.index());
+  const u8 extension = static_cast<u8>(state.extension.data.index());
 
   SerializedWiimoteState s;
   s.length = 0;
-  s.data[s.length++] = u8(has_buttons | (has_accel << 1) | (has_camera << 2) |
-                          (has_motion_plus << 3) | (extension << 4));
+  s.data[s.length++] = static_cast<u8>(has_buttons | (has_accel << 1) | (has_camera << 2) |
+                                       (has_motion_plus << 3) | (extension << 4));
 
   if (has_buttons)
   {
-    const u8 buttons = u8((state.buttons.a) | (state.buttons.b << 1) | (state.buttons.plus << 2) |
-                          (state.buttons.minus << 3) | (state.buttons.one << 4) |
-                          (state.buttons.two << 5) | (state.buttons.home << 6));
-    const u8 dpad = u8((state.buttons.up) | (state.buttons.down << 1) | (state.buttons.left << 2) |
-                       (state.buttons.right << 3));
+    const u8 buttons =
+        static_cast<u8>((state.buttons.a) | (state.buttons.b << 1) | (state.buttons.plus << 2)
+                        (state.buttons.minus << 3) | (state.buttons.one << 4)
+                        (state.buttons.two << 5) | (state.buttons.home << 6));
+    const u8 dpad = static_cast<u8>((state.buttons.up) | (state.buttons.down << 1)
+                                    (state.buttons.left << 2) | (state.buttons.right << 3));
     s.data[s.length++] = buttons;
     s.data[s.length++] = dpad;
   }
@@ -52,20 +53,20 @@ SerializedWiimoteState SerializeDesiredState(const DesiredWiimoteState& state)
     const u16 accel_x = state.acceleration.value.x;  // 10 bits
     const u16 accel_y = state.acceleration.value.y;  // 9 bits (ignore lowest bit)
     const u16 accel_z = state.acceleration.value.z;  // 9 bits (ignore lowest bit)
-    const u8 accel_x_high = u8(accel_x >> 2);
-    const u8 accel_y_high = u8(accel_y >> 2);
-    const u8 accel_z_high = u8(accel_z >> 2);
-    const u8 accel_low = u8((accel_x & 0b11) | (Common::ExtractBit<1>(accel_y) << 2) |
-                            (Common::ExtractBit<1>(accel_z) << 3));
+    const u8 accel_x_high = static_cast<u8>(accel_x >> 2);
+    const u8 accel_y_high = static_cast<u8>(accel_y >> 2);
+    const u8 accel_z_high = static_cast<u8>(accel_z >> 2);
+    const u8 accel_low = static_cast<u8>((accel_x & 0b11) | (Common::ExtractBit<1>(accel_y) << 2) |
+                                         (Common::ExtractBit<1>(accel_z) << 3));
 
     if (has_buttons)
     {
       // can use the high bits of the dpad field from buttons
-      s.data[s.length - 1] |= u8(accel_low << 4);
+      s.data[s.length - 1] |= static_cast<u8>(accel_low << 4);
     }
     else
     {
-      s.data[s.length++] = u8(accel_low << 4);
+      s.data[s.length++] = static_cast<u8>(accel_low << 4);
     }
 
     s.data[s.length++] = accel_x_high;
@@ -93,12 +94,12 @@ SerializedWiimoteState SerializeDesiredState(const DesiredWiimoteState& state)
     const u16 pitch_value = state.motion_plus->gyro.value.x;  // 14 bits
     const u16 roll_value = state.motion_plus->gyro.value.y;   // 14 bits
     const u16 yaw_value = state.motion_plus->gyro.value.z;    // 14 bits
-    s.data[s.length++] = u8(pitch_value);
-    s.data[s.length++] = u8(((pitch_value >> 8) & 0x3f) | (pitch_slow << 7));
-    s.data[s.length++] = u8(roll_value);
-    s.data[s.length++] = u8(((roll_value >> 8) & 0x3f) | (roll_slow << 7));
-    s.data[s.length++] = u8(yaw_value);
-    s.data[s.length++] = u8(((yaw_value >> 8) & 0x3f) | (yaw_slow << 7));
+    s.data[s.length++] = static_cast<u8>(pitch_value);
+    s.data[s.length++] = static_cast<u8>(((pitch_value >> 8) & 0x3f) | (pitch_slow << 7));
+    s.data[s.length++] = static_cast<u8>(roll_value);
+    s.data[s.length++] = static_cast<u8>(((roll_value >> 8) & 0x3f) | (roll_slow << 7));
+    s.data[s.length++] = static_cast<u8>(yaw_value);
+    s.data[s.length++] = static_cast<u8>(((yaw_value >> 8) & 0x3f) | (yaw_slow << 7));
   }
 
   if (extension)

--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -83,7 +83,8 @@ Common::Quaternion ComplementaryFilter(const Common::Quaternion& gyroscope,
 void EmulateShake(PositionalState* state, ControllerEmu::Shake* const shake_group,
                   float time_elapsed)
 {
-  auto target_position = shake_group->GetState() * float(shake_group->GetIntensity() / 2);
+  auto target_position =
+      shake_group->GetState() * static_cast<float>(shake_group->GetIntensity() / 2);
   for (std::size_t i = 0; i != target_position.data.size(); ++i)
   {
     if (state->velocity.data[i] * std::copysign(1.f, target_position.data[i]) < 0 ||
@@ -122,7 +123,7 @@ void EmulateTilt(RotationalState* state, ControllerEmu::Tilt* const tilt_group, 
   for (std::size_t i = 0; i != target_angle.data.size(); ++i)
   {
     auto& angle = state->angle.data[i];
-    if (std::abs(angle - target_angle.data[i]) > float(MathUtil::PI))
+    if (std::abs(angle - target_angle.data[i]) > static_cast<float>(MathUtil::PI))
       angle -= std::copysign(MathUtil::TAU, angle);
   }
 
@@ -146,9 +147,10 @@ void EmulateSwing(MotionState* state, ControllerEmu::Force* swing_group, float t
   const auto xz_target_dist = Common::Vec2{target_position.x, target_position.z}.Length();
   const auto y_target_dist = std::abs(target_position.y);
   const auto target_dist = Common::Vec3{xz_target_dist, y_target_dist, xz_target_dist};
-  const auto speed = MathUtil::Lerp(Common::Vec3{1, 1, 1} * float(swing_group->GetReturnSpeed()),
-                                    Common::Vec3{1, 1, 1} * float(swing_group->GetSpeed()),
-                                    target_dist / max_distance);
+  const auto speed =
+      MathUtil::Lerp(Common::Vec3{1, 1, 1} * static_cast<float>(swing_group->GetReturnSpeed()),
+                     Common::Vec3{1, 1, 1} * static_cast<float>(swing_group->GetSpeed()),
+                     target_dist / max_distance);
 
   // Convert our m/s "speed" to the jerk required to reach this speed when traveling 1 meter.
   const auto max_jerk = speed * speed * speed * 4;
@@ -211,15 +213,15 @@ void EmulateSwing(MotionState* state, ControllerEmu::Force* swing_group, float t
 
 WiimoteCommon::AccelData ConvertAccelData(const Common::Vec3& accel, u16 zero_g, u16 one_g)
 {
-  const auto scaled_accel = accel * (one_g - zero_g) / float(GRAVITY_ACCELERATION);
+  const auto scaled_accel = accel * (one_g - zero_g) / static_cast<float>(GRAVITY_ACCELERATION);
 
   // 10-bit integers.
   constexpr long MAX_VALUE = (1 << 10) - 1;
 
   return WiimoteCommon::AccelData(
-      {u16(std::clamp(std::lround(scaled_accel.x + zero_g), 0l, MAX_VALUE)),
-       u16(std::clamp(std::lround(scaled_accel.y + zero_g), 0l, MAX_VALUE)),
-       u16(std::clamp(std::lround(scaled_accel.z + zero_g), 0l, MAX_VALUE))});
+      {static_cast<u16>(std::clamp(std::lround(scaled_accel.x + zero_g), 0l, MAX_VALUE)),
+       static_cast<u16>(std::clamp(std::lround(scaled_accel.y + zero_g), 0l, MAX_VALUE)),
+       static_cast<u16>(std::clamp(std::lround(scaled_accel.z + zero_g), 0l, MAX_VALUE))});
 }
 
 void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group,
@@ -266,7 +268,7 @@ void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group,
   // Higher values will be more responsive but increase rate of M+ "desync".
   // I'd rather not expose this value in the UI if not needed.
   // At this value, sync is very good and responsiveness still appears instant.
-  constexpr auto MAX_ACCEL = float(MathUtil::TAU * 8);
+  constexpr auto MAX_ACCEL = static_cast<float>(MathUtil::TAU * 8);
 
   ApproachAngleWithAccel(state, target_angle, MAX_ACCEL, time_elapsed);
 }
@@ -329,7 +331,7 @@ void EmulateIMUCursor(IMUCursorState* state, ControllerEmu::IMUCursor* imu_ir_gr
 
   // Clamp yaw within configured bounds.
   const auto yaw = GetYaw(state->rotation);
-  const auto max_yaw = float(imu_ir_group->GetTotalYaw() / 2);
+  const auto max_yaw = static_cast<float>(imu_ir_group->GetTotalYaw() / 2);
   auto target_yaw = std::clamp(yaw, -max_yaw, max_yaw);
 
   // Handle the "Recenter" button being pressed.

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -302,7 +302,8 @@ void Wiimote::HandleWriteData(const OutputReportWriteData& wd)
     }
 
     // Top byte of address is ignored on the bus.
-    auto const bytes_written = m_i2c_bus.BusWrite(wd.slave_address, (u8)address, wd.size, wd.data);
+    auto const bytes_written =
+        m_i2c_bus.BusWrite(wd.slave_address, static_cast<u8>(address), wd.size, wd.data);
     if (bytes_written != wd.size)
     {
       // A real wiimote gives error 7 for failed write to i2c bus (mainly a non-existant slave)
@@ -488,8 +489,9 @@ bool Wiimote::ProcessReadDataRequest()
     }
 
     // Top byte of address is ignored on the bus, but it IS maintained in the read-reply.
-    auto const bytes_read = m_i2c_bus.BusRead(
-        m_read_request.slave_address, (u8)m_read_request.address, bytes_to_read, reply.data);
+    auto const bytes_read =
+      m_i2c_bus.BusRead(m_read_request.slave_address, static_cast<u8>(m_read_request.address),
+                        bytes_to_read, reply.data);
 
     if (bytes_read != bytes_to_read)
     {
@@ -504,7 +506,8 @@ bool Wiimote::ProcessReadDataRequest()
   break;
 
   default:
-    WARN_LOG_FMT(WIIMOTE, "ReadData: invalid address space: {:#x}", int(m_read_request.space));
+    WARN_LOG_FMT(WIIMOTE, "ReadData: invalid address space: {:#x}",
+                 static_cast<int>(m_read_request.space));
     // A real wiimote gives error 6:
     error_code = ErrorCode::InvalidSpace;
     break;

--- a/Source/Core/Core/HW/WiimoteEmu/Encryption.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Encryption.cpp
@@ -521,12 +521,12 @@ EncryptionKey::KeyData KeyGen1stParty::GenerateKeyData(const EncryptionKey::Rand
     t0[i] = keygen_sbox_1st_party[rand[i]];
 
   return {
-      u8((std::rotr<u8>(ans[0] ^ t0[5], t0[2]) - t0[9]) ^ t0[4]),
-      u8((std::rotr<u8>(ans[1] ^ t0[1], t0[0]) - t0[5]) ^ t0[7]),
-      u8((std::rotr<u8>(ans[2] ^ t0[6], t0[8]) - t0[2]) ^ t0[0]),
-      u8((std::rotr<u8>(ans[3] ^ t0[4], t0[7]) - t0[3]) ^ t0[2]),
-      u8((std::rotr<u8>(ans[4] ^ t0[1], t0[6]) - t0[3]) ^ t0[4]),
-      u8((std::rotr<u8>(ans[5] ^ t0[7], t0[8]) - t0[5]) ^ t0[9]),
+      static_cast<u8>((std::rotr<u8>(ans[0] ^ t0[5], t0[2]) - t0[9]) ^ t0[4]),
+      static_cast<u8>((std::rotr<u8>(ans[1] ^ t0[1], t0[0]) - t0[5]) ^ t0[7]),
+      static_cast<u8>((std::rotr<u8>(ans[2] ^ t0[6], t0[8]) - t0[2]) ^ t0[0]),
+      static_cast<u8>((std::rotr<u8>(ans[3] ^ t0[4], t0[7]) - t0[3]) ^ t0[2]),
+      static_cast<u8>((std::rotr<u8>(ans[4] ^ t0[1], t0[6]) - t0[3]) ^ t0[4]),
+      static_cast<u8>((std::rotr<u8>(ans[5] ^ t0[7], t0[8]) - t0[5]) ^ t0[9]),
   };
 }
 
@@ -547,12 +547,12 @@ EncryptionKey::KeyData KeyGen3rdParty::GenerateKeyData(const EncryptionKey::Rand
     t0[i] = keygen_sbox_3rd_party[rand[i]];
 
   return {
-      u8(t0[7] ^ (t0[6] + std::rotl<u8>(ans[0] ^ t0[0], t0[1]))),
-      u8(t0[1] ^ (t0[3] + std::rotl<u8>(ans[1] ^ t0[4], t0[2]))),
-      u8(t0[5] ^ (t0[4] + std::rotl<u8>(ans[2] ^ t0[2], t0[8]))),
-      u8(t0[0] ^ (t0[7] + std::rotl<u8>(ans[3] ^ t0[6], t0[9]))),
-      u8(t0[1] ^ (t0[8] + std::rotl<u8>(ans[4] ^ t0[5], t0[4]))),
-      u8(t0[5] ^ (t0[8] + std::rotl<u8>(ans[5] ^ t0[9], t0[3]))),
+      static_cast<u8>(t0[7] ^ (t0[6] + std::rotl<u8>(ans[0] ^ t0[0], t0[1]))),
+      static_cast<u8>(t0[1] ^ (t0[3] + std::rotl<u8>(ans[1] ^ t0[4], t0[2]))),
+      static_cast<u8>(t0[5] ^ (t0[4] + std::rotl<u8>(ans[2] ^ t0[2], t0[8]))),
+      static_cast<u8>(t0[0] ^ (t0[7] + std::rotl<u8>(ans[3] ^ t0[6], t0[9]))),
+      static_cast<u8>(t0[1] ^ (t0[8] + std::rotl<u8>(ans[4] ^ t0[5], t0[4]))),
+      static_cast<u8>(t0[5] ^ (t0[8] + std::rotl<u8>(ans[5] ^ t0[9], t0[3]))),
   };
 }
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -61,7 +61,7 @@ Classic::Classic() : Extension1stParty("Classic", _trans("Classic Controller"))
   m_buttons->AddInput(Translatability::DoNotTranslate, HOME_BUTTON, "HOME");
 
   // sticks
-  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / CAL_STICK_RADIUS;
+  constexpr auto gate_radius = static_cast<ControlState>(STICK_GATE_RADIUS) / CAL_STICK_RADIUS;
   groups.emplace_back(m_left_stick =
                           new ControllerEmu::OctagonAnalogStick(LEFT_STICK_GROUP, gate_radius));
   groups.emplace_back(m_right_stick =

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
@@ -53,11 +53,11 @@ void DrawsomeTablet::BuildDesiredExtensionState(DesiredExtensionState* target_st
   const u16 stylus_x = MapFloat<u16>(stylus_state.x, CENTER_X, MIN_X, MAX_X);
   const u16 stylus_y = MapFloat<u16>(-stylus_state.y, CENTER_Y, MAX_Y, MIN_Y);
 
-  tablet_data.stylus_x1 = u8(stylus_x);
-  tablet_data.stylus_x2 = u8(stylus_x >> 8);
+  tablet_data.stylus_x1 = static_cast<u8>(stylus_x);
+  tablet_data.stylus_x2 = static_cast<u8>(stylus_x >> 8);
 
-  tablet_data.stylus_y1 = u8(stylus_y);
-  tablet_data.stylus_y2 = u8(stylus_y >> 8);
+  tablet_data.stylus_y1 = static_cast<u8>(stylus_y);
+  tablet_data.stylus_y2 = static_cast<u8>(stylus_y >> 8);
 
   const auto touch_state = m_touch->GetState(m_input_override_function);
 
@@ -79,8 +79,8 @@ void DrawsomeTablet::BuildDesiredExtensionState(DesiredExtensionState* target_st
 
   const u16 pressure = MapFloat<u16>(touch_state.data[0], 0, 0, MAX_PRESSURE);
 
-  tablet_data.pressure1 = u8(pressure);
-  tablet_data.pressure2 = u8(pressure >> 8);
+  tablet_data.pressure1 = static_cast<u8>(pressure);
+  tablet_data.pressure2 = static_cast<u8>(pressure >> 8);
 }
 
 void DrawsomeTablet::Update(const DesiredExtensionState& target_state)

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
@@ -100,7 +100,8 @@ void Drums::BuildDesiredExtensionState(DesiredExtensionState* target_state)
   state.drum_pads = 0;
   m_pads->GetState(&state.drum_pads, drum_pad_bitmasks.data(), m_input_override_function);
 
-  state.softness = u8(0x7F - std::lround(m_hit_strength_setting.GetValue() * 0x7F / 100));
+  state.softness =
+      static_cast<u8>(0x7F - std::lround(m_hit_strength_setting.GetValue() * 0x7F / 100));
 }
 
 void Drums::Update(const DesiredExtensionState& target_state)
@@ -129,7 +130,7 @@ void Drums::Update(const DesiredExtensionState& target_state)
   drum_data.unk5 = 0b11;
 
   // Send no velocity data by default.
-  drum_data.velocity_id = u8(VelocityID::None);
+  drum_data.velocity_id = static_cast<u8>(VelocityID::None);
   drum_data.no_velocity_data_1 = 1;
   drum_data.no_velocity_data_2 = 1;
 
@@ -156,7 +157,7 @@ void Drums::Update(const DesiredExtensionState& target_state)
       // Clear the bit so velocity data is not sent again until the next hit.
       m_new_pad_hits &= ~drum_pad;
 
-      drum_data.velocity_id = u8(drum_pad_velocity_ids[i]);
+      drum_data.velocity_id = static_cast<u8>(drum_pad_velocity_ids[i]);
 
       drum_data.no_velocity_data_1 = 0;
       drum_data.no_velocity_data_2 = 0;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
@@ -83,7 +83,7 @@ Guitar::Guitar() : Extension1stParty(_trans("Guitar"))
   m_buttons->AddInput(Translatability::DoNotTranslate, "+");
 
   // stick
-  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
+  constexpr auto gate_radius = static_cast<ControlState>(STICK_GATE_RADIUS) / STICK_RADIUS;
   groups.emplace_back(m_stick =
                           new ControllerEmu::OctagonAnalogStick(_trans("Stick"), gate_radius));
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -39,7 +39,7 @@ Nunchuk::Nunchuk() : Extension1stParty(_trans("Nunchuk"))
   m_buttons->AddInput(Translatability::DoNotTranslate, Z_BUTTON);
 
   // stick
-  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
+  constexpr auto gate_radius = static_cast<ControlState>(STICK_GATE_RADIUS) / STICK_RADIUS;
   groups.emplace_back(m_stick = new ControllerEmu::OctagonAnalogStick(STICK_GROUP, gate_radius));
 
   // Shake
@@ -104,9 +104,9 @@ void Nunchuk::BuildDesiredExtensionState(DesiredExtensionState* target_state)
       GetRotationalMatrix(-m_tilt_state.angle) * GetRotationalMatrix(-m_swing_state.angle);
 
   Common::Vec3 accel =
-      transformation *
-      (m_swing_state.acceleration +
-       m_imu_accelerometer->GetState().value_or(Common::Vec3(0, 0, float(GRAVITY_ACCELERATION))));
+      transformation * (m_swing_state.acceleration +
+                        m_imu_accelerometer->GetState().value_or(Common::Vec3(
+                        0, 0, static_cast<float>(GRAVITY_ACCELERATION))));
 
   // shake
   accel += m_shake_state.acceleration;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -68,7 +68,7 @@ Turntable::Turntable() : Extension1stParty("Turntable", _trans("DJ Turntable"))
                       new ControllerEmu::Slider("Table Right", _trans("Right Table")));
 
   // stick
-  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
+  constexpr auto gate_radius = static_cast<ControlState>(STICK_GATE_RADIUS) / STICK_RADIUS;
   groups.emplace_back(m_stick =
                           new ControllerEmu::OctagonAnalogStick(_trans("Stick"), gate_radius));
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
@@ -90,8 +90,8 @@ void UDrawTablet::BuildDesiredExtensionState(DesiredExtensionState* target_state
 
   if (!is_stylus_lifted)
   {
-    stylus_x = u16(center_x + stylus_state.x * (max_x - center_x));
-    stylus_y = u16(center_y + stylus_state.y * (max_y - center_y));
+    stylus_x = static_cast<u16>(center_x + stylus_state.x * (max_x - center_x));
+    stylus_y = static_cast<u16>(center_y + stylus_state.y * (max_y - center_y));
   }
 
   tablet_data.stylus_x1 = stylus_x & 0xff;

--- a/Source/Core/Core/HW/WiimoteEmu/I2CBus.h
+++ b/Source/Core/Core/HW/WiimoteEmu/I2CBus.h
@@ -31,7 +31,7 @@ protected:
     // TODO: addr wraps around after 0xff
 
     u8* src = reinterpret_cast<u8*>(reg_data) + addr;
-    count = std::min(count, int(reinterpret_cast<u8*>(reg_data + 1) - src));
+    count = std::min(count, static_cast<int>(reinterpret_cast<u8*>(reg_data + 1) - src));
 
     std::copy_n(src, count, data_out);
 
@@ -47,7 +47,7 @@ protected:
     // TODO: addr wraps around after 0xff
 
     u8* dst = reinterpret_cast<u8*>(reg_data) + addr;
-    count = std::min(count, int(reinterpret_cast<u8*>(reg_data + 1) - dst));
+    count = std::min(count, static_cast<int>(reinterpret_cast<u8*>(reg_data + 1) - dst));
 
     std::copy_n(data_in, count, dst);
 

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
@@ -62,7 +62,7 @@ Common::Vec3 MotionPlus::DataFormat::Data::GetAngularVelocity(const CalibrationB
   const auto sign_fix = Common::Vec3(-1, +1, -1);
 
   // Adjust deg/s to rad/s.
-  constexpr auto scalar = float(MathUtil::TAU / 360);
+  constexpr auto scalar = static_cast<float>(MathUtil::TAU / 360);
 
   return gyro.GetNormalizedValue(calibration.value) * sign_fix * Common::Vec3(calibration.degrees) *
          scalar;
@@ -149,8 +149,8 @@ void MotionPlus::CalibrationData::UpdateChecksum()
   crc_result = Common::UpdateCRC32(crc_result, reinterpret_cast<const u8*>(this), 0xe);
   crc_result = Common::UpdateCRC32(crc_result, reinterpret_cast<const u8*>(this) + 0x10, 0xe);
 
-  crc32_lsb = u16(crc_result);
-  crc32_msb = u16(crc_result >> 16);
+  crc32_lsb = static_cast<u16>(crc_result);
+  crc32_msb = static_cast<u16>(crc_result >> 16);
 }
 
 void MotionPlus::DoState(PointerWrap& p)
@@ -435,14 +435,16 @@ void MotionPlus::Update(const DesiredExtensionState& target_state)
       {
         constexpr u8 INIT_OFFSET = offsetof(Register, init_trigger);
         std::array<u8, 1> enc_data = {0x55};
-        m_i2c_bus.BusWrite(ACTIVE_DEVICE_ADDR, INIT_OFFSET, int(enc_data.size()), enc_data.data());
+        m_i2c_bus.BusWrite(ACTIVE_DEVICE_ADDR, INIT_OFFSET, static_cast<int>(enc_data.size()),
+                           enc_data.data());
       }
 
       // Read identifier
       {
         constexpr u8 ID_OFFSET = offsetof(Register, ext_identifier);
         std::array<u8, 6> id_data = {};
-        m_i2c_bus.BusRead(ACTIVE_DEVICE_ADDR, ID_OFFSET, int(id_data.size()), id_data.data());
+        m_i2c_bus.BusRead(ACTIVE_DEVICE_ADDR, ID_OFFSET, static_cast<int>(id_data.size()),
+                          id_data.data());
         m_reg_data.passthrough_ext_id_0 = id_data[0];
         m_reg_data.passthrough_ext_id_4 = id_data[4];
         m_reg_data.passthrough_ext_id_5 = id_data[5];
@@ -452,7 +454,7 @@ void MotionPlus::Update(const DesiredExtensionState& target_state)
       {
         constexpr u8 CAL_OFFSET = offsetof(Register, calibration_data);
         m_i2c_bus.BusRead(ACTIVE_DEVICE_ADDR, CAL_OFFSET,
-                          int(m_reg_data.passthrough_ext_calib.size()),
+                          static_cast<int>(m_reg_data.passthrough_ext_calib.size()),
                           m_reg_data.passthrough_ext_calib.data());
       }
     }
@@ -538,7 +540,7 @@ MotionPlus::DataFormat::Data MotionPlus::GetGyroscopeData(const Common::Vec3& an
     result.is_slow.data[i] = is_slow;
 
     const s32 value = std::lround(rad_per_sec * (is_slow ? SLOW_SCALE : FAST_SCALE));
-    result.gyro.value.data[i] = u16(std::clamp(value + ZERO_VALUE, 0, MAX_VALUE));
+    result.gyro.value.data[i] = static_cast<u16>(std::clamp(value + ZERO_VALUE, 0, MAX_VALUE));
   }
   return result;
 }
@@ -546,7 +548,8 @@ MotionPlus::DataFormat::Data MotionPlus::GetGyroscopeData(const Common::Vec3& an
 MotionPlus::DataFormat::Data MotionPlus::GetDefaultGyroscopeData()
 {
   return DataFormat::Data{DataFormat::GyroRawValue{DataFormat::GyroType{
-                              u16(ZERO_VALUE), u16(ZERO_VALUE), u16(ZERO_VALUE)}},
+                              static_cast<u16>(ZERO_VALUE), static_cast<u16>(ZERO_VALUE),
+                              static_cast<u16>(ZERO_VALUE)}},
                           DataFormat::SlowType{true, true, true}};
 }
 
@@ -627,19 +630,19 @@ void MotionPlus::PrepareInput(const MotionPlus::DataFormat::Data& gyroscope_data
     const u16 roll_value = gyroscope_data.gyro.value.y;
     const u16 yaw_value = gyroscope_data.gyro.value.z;
 
-    mplus_data.yaw_slow = u8(yaw_slow);
-    mplus_data.roll_slow = u8(roll_slow);
-    mplus_data.pitch_slow = u8(pitch_slow);
+    mplus_data.yaw_slow = static_cast<u8>(yaw_slow);
+    mplus_data.roll_slow = static_cast<u8>(roll_slow);
+    mplus_data.pitch_slow = static_cast<u8>(pitch_slow);
 
     // Bits 0-7
-    mplus_data.yaw1 = u8(yaw_value);
-    mplus_data.roll1 = u8(roll_value);
-    mplus_data.pitch1 = u8(pitch_value);
+    mplus_data.yaw1 = static_cast<u8>(yaw_value);
+    mplus_data.roll1 = static_cast<u8>(roll_value);
+    mplus_data.pitch1 = static_cast<u8>(pitch_value);
 
     // Bits 8-13
-    mplus_data.yaw2 = u8(yaw_value >> 8);
-    mplus_data.roll2 = u8(roll_value >> 8);
-    mplus_data.pitch2 = u8(pitch_value >> 8);
+    mplus_data.yaw2 = static_cast<u8>(yaw_value >> 8);
+    mplus_data.roll2 = static_cast<u8>(roll_value >> 8);
+    mplus_data.pitch2 = static_cast<u8>(pitch_value >> 8);
   }
 
   mplus_data.extension_connected = is_ext_connected;

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.h
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.h
@@ -131,7 +131,8 @@ public:
 
   static constexpr u16 VALUE_SCALE =
       (CALIBRATION_SCALE_OFFSET >> (CALIBRATION_BITS - BITS_OF_PRECISION));
-  static constexpr float VALUE_SCALE_DEGREES = VALUE_SCALE / float(MathUtil::TAU) * 360;
+  static constexpr float VALUE_SCALE_DEGREES =
+      VALUE_SCALE / static_cast<float>(MathUtil::TAU) * 360;
 
   static constexpr float SLOW_SCALE = VALUE_SCALE_DEGREES / CALIBRATION_SLOW_SCALE_DEGREES;
   static constexpr float FAST_SCALE = VALUE_SCALE_DEGREES / CALIBRATION_FAST_SCALE_DEGREES;

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -77,13 +77,13 @@ void SpeakerLogic::SpeakerData(const u8* data, int length, float speaker_pan)
     // 8 bit PCM
     for (int i = 0; i < length; ++i)
     {
-      samples[i] = ((s16)(s8)data[i]) * 0x100;
+      samples[i] = static_cast<s16>(static_cast<s8>(data[i])) * 0x100;
     }
 
     // Following details from http://wiibrew.org/wiki/Wiimote#Speaker
     sample_rate_dividend = 12000000;
     volume_divisor = 0xff;
-    sample_length = (unsigned int)length;
+    sample_length = static_cast<unsigned int>(length);
   }
   else if (reg_data.format == SpeakerLogic::DATA_FORMAT_ADPCM)
   {
@@ -97,7 +97,7 @@ void SpeakerLogic::SpeakerData(const u8* data, int length, float speaker_pan)
     // Following details from http://wiibrew.org/wiki/Wiimote#Speaker
     sample_rate_dividend = 6000000;
     volume_divisor = 0x7F;
-    sample_length = (unsigned int)length * 2;
+    sample_length = static_cast<unsigned int>(length) * 2;
   }
   else
   {
@@ -113,7 +113,7 @@ void SpeakerLogic::SpeakerData(const u8* data, int length, float speaker_pan)
 
   // SetWiimoteSpeakerVolume expects values from 0 to 255.
   // Multiply by 256, floor to int, and clamp to 255 for a uniformly mapped conversion.
-  const double volume = float(reg_data.volume) * 256.f / volume_divisor;
+  const double volume = static_cast<float>(reg_data.volume) * 256.f / volume_divisor;
 
   // This used the "Constant Power Pan Law", but it is undesirable
   // if the pan is 0, and it implied that the loudness of a wiimote speaker
@@ -123,8 +123,8 @@ void SpeakerLogic::SpeakerData(const u8* data, int length, float speaker_pan)
   // because you can lower their volume from the Wii settings and because they are
   // already extremely low quality, so any additional quality loss isn't welcome.
   speaker_pan = std::clamp(speaker_pan, -1.f, 1.f);
-  const u32 l_volume = std::min(u32(std::min(1.f - speaker_pan, 1.f) * volume), 255u);
-  const u32 r_volume = std::min(u32(std::min(1.f + speaker_pan, 1.f) * volume), 255u);
+  const u32 l_volume = std::min(static_cast<u32>(std::min(1.f - speaker_pan, 1.f) * volume), 255u);
+  const u32 r_volume = std::min(static_cast<u32>(std::min(1.f + speaker_pan, 1.f) * volume), 255u);
 
   auto& system = Core::System::GetInstance();
   SoundStream* sound_stream = system.GetSoundStream();

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -461,14 +461,14 @@ GetPassthroughCameraPoints(ControllerEmu::IRPassthrough* ir_passthrough)
     const ControlState y = ir_passthrough->GetObjectPositionY(i);
 
     camera_points[i].position.x =
-        std::clamp(std::lround(x * ControlState(CameraLogic::CAMERA_RES_X - 1)), long(0),
-                   long(CameraLogic::CAMERA_RES_X - 1));
+        std::clamp(std::lround(x * static_cast<ControlState>(CameraLogic::CAMERA_RES_X - 1)),
+                   static_cast<long>(0), static_cast<long>(CameraLogic::CAMERA_RES_X - 1));
     camera_points[i].position.y =
-        std::clamp(std::lround(y * ControlState(CameraLogic::CAMERA_RES_Y - 1)), long(0),
-                   long(CameraLogic::CAMERA_RES_Y - 1));
+        std::clamp(std::lround(y * static_cast<ControlState>(CameraLogic::CAMERA_RES_Y - 1)),
+                   static_cast<long>(0), static_cast<long>(CameraLogic::CAMERA_RES_Y - 1));
     camera_points[i].size =
-        std::clamp(std::lround(size * ControlState(CameraLogic::MAX_POINT_SIZE)), long(0),
-                   long(CameraLogic::MAX_POINT_SIZE));
+        std::clamp(std::lround(size * static_cast<ControlState>(CameraLogic::MAX_POINT_SIZE)),
+                   static_cast<long>(0), static_cast<long>(CameraLogic::MAX_POINT_SIZE));
   }
 
   return camera_points;
@@ -506,7 +506,7 @@ void Wiimote::BuildDesiredWiimoteState(DesiredWiimoteState* target_state,
     target_state->camera_points = CameraLogic::GetCameraPoints(
         GetTotalTransformation(),
         Common::Vec2(m_fov_x_setting.GetValue(), m_fov_y_setting.GetValue()) / 360 *
-            float(MathUtil::TAU));
+            static_cast<float>(MathUtil::TAU));
   }
   else
   {
@@ -629,7 +629,7 @@ void Wiimote::SendDataReport(const DesiredWiimoteState& target_state)
     {
       // This happens when IR reporting is enabled but the camera hardware is disabled.
       // It commonly occurs when changing IR sensitivity.
-      std::fill_n(ir_data, ir_size, u8(0xff));
+      std::fill_n(ir_data, ir_size, static_cast<u8>(0xff));
     }
   }
 
@@ -656,7 +656,7 @@ void Wiimote::SendDataReport(const DesiredWiimoteState& target_state)
                                       ExtensionPort::REPORT_I2C_ADDR, ext_size, ext_data))
     {
       // Real wiimote seems to fill with 0xff on failed bus read
-      std::fill_n(ext_data, ext_size, u8(0xff));
+      std::fill_n(ext_data, ext_size, static_cast<u8>(0xff));
     }
   }
 
@@ -870,8 +870,8 @@ Common::Matrix44 Wiimote::GetTransformation(const Common::Matrix33& extra_rotati
 
 Common::Quaternion Wiimote::GetOrientation() const
 {
-  return Common::Quaternion::RotateZ(float(MathUtil::TAU / -4 * IsSideways())) *
-         Common::Quaternion::RotateX(float(MathUtil::TAU / 4 * IsUpright()));
+  return Common::Quaternion::RotateZ(static_cast<float>(MathUtil::TAU / -4 * IsSideways())) *
+         Common::Quaternion::RotateX(static_cast<float>(MathUtil::TAU / 4 * IsUpright()));
 }
 
 std::optional<Common::Vec3> Wiimote::OverrideVec3(const ControllerEmu::ControlGroup* control_group,
@@ -943,7 +943,7 @@ Wiimote::OverrideVec3(const ControllerEmu::ControlGroup* control_group, Common::
 
 Common::Vec3 Wiimote::GetTotalAcceleration() const
 {
-  const Common::Vec3 default_accel = Common::Vec3(0, 0, float(GRAVITY_ACCELERATION));
+  const Common::Vec3 default_accel = Common::Vec3(0, 0, static_cast<float>(GRAVITY_ACCELERATION));
   const Common::Vec3 accel = m_imu_accelerometer->GetState().value_or(default_accel);
 
   return OverrideVec3(m_imu_accelerometer, GetAcceleration(accel));

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -235,7 +235,7 @@ std::wstring GetDeviceProperty(const HDEVINFO& device_info, const PSP_DEVINFO_DA
 int IOWritePerSetOutputReport(HANDLE& dev_handle, const u8* buf, size_t len, DWORD* written)
 {
   const BOOLEAN result =
-      pHidD_SetOutputReport(dev_handle, const_cast<u8*>(buf) + 1, (ULONG)(len - 1));
+      pHidD_SetOutputReport(dev_handle, const_cast<u8*>(buf) + 1, static_cast<ULONG>(len - 1));
   if (!result)
   {
     const DWORD err = GetLastError();
@@ -254,7 +254,7 @@ int IOWritePerSetOutputReport(HANDLE& dev_handle, const u8* buf, size_t len, DWO
 
   if (written)
   {
-    *written = (result ? (DWORD)len : 0);
+    *written = (result ? static_cast<DWORD>(len) : 0);
   }
 
   return result;
@@ -265,7 +265,7 @@ int IOWritePerWriteFile(HANDLE& dev_handle, OVERLAPPED& hid_overlap_write,
 {
   DWORD bytes_written;
   LPCVOID write_buffer = buf + 1;
-  DWORD bytes_to_write = (DWORD)(len - 1);
+  DWORD bytes_to_write = static_cast<DWORD>(len - 1);
 
   u8 resized_buffer[MAX_PAYLOAD];
 
@@ -368,7 +368,7 @@ bool GetParentDevice(const DEVINST& child_device_instance, HDEVINFO* parent_devi
 
   // Get the device id of the parent, required to open the device info
   result =
-      CM_Get_Device_ID(parent_device, parent_device_id.data(), (ULONG)parent_device_id.size(), 0);
+      CM_Get_Device_ID(parent_device, parent_device_id.data(), static_cast<ULONG>(parent_device_id.size()), 0);
   if (result != CR_SUCCESS)
   {
     return false;
@@ -467,7 +467,7 @@ bool IsWiimote(const std::basic_string<TCHAR>& device_path, WinWriteMethod& meth
   Common::ScopeGuard handle_guard{[&dev_handle] { CloseHandle(dev_handle); }};
 
   u8 buf[MAX_PAYLOAD];
-  u8 const req_status_report[] = {WR_SET_REPORT | BT_OUTPUT, u8(OutputReportID::RequestStatus), 0};
+  u8 const req_status_report[] = {WR_SET_REPORT | BT_OUTPUT, static_cast<u8>(OutputReportID::RequestStatus), 0};
   int invalid_report_count = 0;
   int rc = WriteToHandle(dev_handle, method, req_status_report, sizeof(req_status_report));
   while (rc > 0)
@@ -476,7 +476,7 @@ bool IsWiimote(const std::basic_string<TCHAR>& device_path, WinWriteMethod& meth
     if (rc <= 0)
       break;
 
-    switch (InputReportID(buf[1]))
+    switch (static_cast<InputReportID>(buf[1]))
     {
     case InputReportID::Status:
       return true;

--- a/Source/Core/Core/HW/WiimoteReal/IOhidapi.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOhidapi.cpp
@@ -27,7 +27,7 @@ static bool IsDeviceUsable(const std::string& device_path)
   // Some third-party adapters (DolphinBar) always expose all four Wii Remotes as HIDs
   // even when they are not connected, which causes an endless error loop when we try to use them.
   // Try to write a report to the device to see if this Wii Remote is really usable.
-  static const u8 report[] = {WR_SET_REPORT | BT_OUTPUT, u8(OutputReportID::RequestStatus), 0};
+  static const u8 report[] = {WR_SET_REPORT | BT_OUTPUT, static_cast<u8>(OutputReportID::RequestStatus), 0};
   const int result = hid_write(handle, report, sizeof(report));
   // The DolphinBar uses EPIPE to signal the absence of a Wii Remote connected to this HID.
   if (result == -1 && errno != EPIPE)

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -47,7 +47,7 @@ IPCReply GetVersion(Core::System& system, const IOCtlVRequest& request)
     return IPCReply(IPC_EINVAL);
   }
 
-  const auto length = std::min(size_t(request.io_vectors[0].size), Common::GetScmDescStr().size());
+  const auto length = std::min(static_cast<size_t>(request.io_vectors[0].size), Common::GetScmDescStr().size());
 
   auto& memory = system.GetMemory();
   memory.Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
@@ -71,7 +71,7 @@ IPCReply GetCPUSpeed(Core::System& system, const IOCtlVRequest& request)
   const bool overclock_enabled = Config::Get(Config::MAIN_OVERCLOCK_ENABLE);
   const float oc = overclock_enabled ? Config::Get(Config::MAIN_OVERCLOCK) : 1.0f;
 
-  const u32 core_clock = u32(float(system.GetSystemTimers().GetTicksPerSecond()) * oc);
+  const u32 core_clock = static_cast<u32>(static_cast<float>(system.GetSystemTimers().GetTicksPerSecond()) * oc);
 
   auto& memory = system.GetMemory();
   memory.Write_U32(core_clock, request.io_vectors[0].address);
@@ -114,7 +114,7 @@ IPCReply SetSpeedLimit(Core::System& system, const IOCtlVRequest& request)
   }
 
   auto& memory = system.GetMemory();
-  const float speed = float(memory.Read_U32(request.in_vectors[0].address)) / 100.0f;
+  const float speed = static_cast<float>(memory.Read_U32(request.in_vectors[0].address)) / 100.0f;
   Config::SetCurrent(Config::MAIN_EMULATION_SPEED, speed);
 
   return IPCReply(IPC_SUCCESS);

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -423,7 +423,7 @@ s32 ESDevice::WriteSystemFile(const std::string& path, const std::vector<u8>& da
     return fd.Get();
   }
 
-  if (fs.Write(fd.Get(), data.data(), u32(data.size()), {}, ticks) != s32(data.size()))
+  if (fs.Write(fd.Get(), data.data(), static_cast<u32>(data.size()), {}, ticks) != static_cast<s32>(data.size()))
   {
     ERROR_LOG_FMT(IOS_ES, "Failed to write to temporary file {}", tmp_path);
     return ES_EIO;

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -189,7 +189,7 @@ FSCore::ScopedFd FSCore::Open(FS::Uid uid, FS::Gid gid, const std::string& path,
   if (path.size() >= 64)
     return {this, ConvertResult(ResultCode::Invalid), ticks};
 
-  const u64 fd = ipc_fd.has_value() ? u64(*ipc_fd) : m_next_fd++;
+  const u64 fd = ipc_fd.has_value() ? static_cast<u64>(*ipc_fd) : m_next_fd++;
 
   if (path == "/dev/fs")
   {
@@ -386,7 +386,7 @@ s32 FSCore::Write(u64 fd, const u8* data, u32 size, std::optional<u32> ipc_buffe
 std::optional<IPCReply> FSDevice::Seek(const SeekRequest& request)
 {
   return MakeIPCReply([&](Ticks t) {
-    return m_core.Seek(request.fd, request.offset, HLE::FS::SeekMode(request.mode), t);
+    return m_core.Seek(request.fd, request.offset, static_cast<HLE::FS::SeekMode>(request.mode), t);
   });
 }
 

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -136,7 +136,7 @@ bool HostFileSystem::FstEntry::CheckPermission(Uid caller_uid, Gid caller_gid,
     file_mode = data.modes.owner;
   else if (data.gid == caller_gid)
     file_mode = data.modes.group;
-  return (u8(requested_mode) & u8(file_mode)) == u8(requested_mode);
+  return (static_cast<u8>(requested_mode) & static_cast<u8>(file_mode)) == static_cast<u8>(requested_mode);
 }
 
 HostFileSystem::HostFileSystem(const std::string& root_path,
@@ -210,7 +210,7 @@ void HostFileSystem::SaveFst()
     SerializedFstEntry& serialized = to_write.emplace_back();
     serialized.SetName(entry.name);
     GetMetadataFields(serialized) = GetMetadataFields(entry.data);
-    serialized.num_children = u32(entry.children.size());
+    serialized.num_children = static_cast<u32>(entry.children.size());
     for (const FstEntry& child : entry.children)
       collect(collect, child);
   };
@@ -343,7 +343,7 @@ void HostFileSystem::DoStateWriteOrMeasure(PointerWrap& p, std::string start_dir
     }
     else
     {
-      u32 size = (u32)entry.size;
+      u32 size = static_cast<u32>(entry.size);
       p.Do(size);
 
       File::IOFile handle(entry.physicalName, "rb");
@@ -460,7 +460,7 @@ ResultCode HostFileSystem::CreateFileOrDirectory(Uid uid, Gid gid, const std::st
     return ResultCode::Invalid;
   }
 
-  if (!is_file && std::ranges::count(path, '/') > int(MaxPathDepth))
+  if (!is_file && std::ranges::count(path, '/') > static_cast<int>(MaxPathDepth))
     return ResultCode::TooManyPathComponents;
 
   const auto split_path = SplitPathAndBasename(path);
@@ -676,7 +676,7 @@ Result<std::vector<std::string>> HostFileSystem::ReadDirectory(Uid uid, Gid gid,
   std::unordered_map<std::string_view, int> sort_keys;
   sort_keys.reserve(entry->children.size());
   for (size_t i = 0; i < entry->children.size(); ++i)
-    sort_keys.emplace(entry->children[i].name, int(i));
+    sort_keys.emplace(entry->children[i].name, static_cast<int>(i));
 
   const auto get_key = [&sort_keys](std::string_view key) {
     const auto it = sort_keys.find(key);

--- a/Source/Core/Core/IOS/FS/HostBackend/File.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/File.cpp
@@ -124,7 +124,7 @@ Result<u32> HostFileSystem::ReadBytesFromFile(Fd fd, u8* ptr, u32 count)
   if (!handle || !handle->host_file->IsOpen())
     return ResultCode::Invalid;
 
-  if ((u8(handle->mode) & u8(Mode::Read)) == 0)
+  if ((static_cast<u8>(handle->mode) & static_cast<u8>(Mode::Read)) == 0)
     return ResultCode::AccessDenied;
 
   const u32 file_size = static_cast<u32>(handle->host_file->GetSize());
@@ -151,7 +151,7 @@ Result<u32> HostFileSystem::WriteBytesToFile(Fd fd, const u8* ptr, u32 count)
   if (!handle || !handle->host_file->IsOpen())
     return ResultCode::Invalid;
 
-  if ((u8(handle->mode) & u8(Mode::Write)) == 0)
+  if ((static_cast<u8>(handle->mode) & static_cast<u8>(Mode::Write)) == 0)
     return ResultCode::AccessDenied;
 
   // File might be opened twice, need to seek before we read

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -509,9 +509,9 @@ static CertECC MakeBlankEccCert(const std::string& issuer, const std::string& na
                                 const u8* private_key, u32 key_id)
 {
   CertECC cert{};
-  cert.signature.type = SignatureType(Common::swap32(u32(SignatureType::ECC)));
+  cert.signature.type = static_cast<SignatureType>(Common::swap32(static_cast<u32>(SignatureType::ECC)));
   issuer.copy(cert.signature.issuer, sizeof(cert.signature.issuer) - 1);
-  cert.header.public_key_type = PublicKeyType(Common::swap32(u32(PublicKeyType::ECC)));
+  cert.header.public_key_type = static_cast<PublicKeyType>(Common::swap32(static_cast<u32>(PublicKeyType::ECC)));
   name.copy(cert.header.name, sizeof(cert.header.name) - 1);
   cert.header.id = Common::swap32(key_id);
   cert.public_key = Common::ec::PrivToPub(private_key);

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -193,7 +193,7 @@ static std::vector<InterfaceRouting> GetSystemInterfaceRouting()
   if (GetIpForwardTable(nullptr, &forward_table_size, FALSE) == ERROR_INSUFFICIENT_BUFFER)
   {
     forward_table =
-        std::unique_ptr<MIB_IPFORWARDTABLE>((PMIB_IPFORWARDTABLE) operator new(forward_table_size));
+        std::unique_ptr<MIB_IPFORWARDTABLE>(static_cast<PMIB_IPFORWARDTABLE>(operator new(forward_table_size)));
   }
 
   DWORD result = GetIpForwardTable(forward_table.get(), &forward_table_size, FALSE);
@@ -354,7 +354,7 @@ static std::optional<DefaultInterface> GetSystemDefaultInterface()
   DWORD ip_table_size = 0;
   if (GetIpAddrTable(nullptr, &ip_table_size, FALSE) == ERROR_INSUFFICIENT_BUFFER)
   {
-    ip_table = std::unique_ptr<MIB_IPADDRTABLE>((PMIB_IPADDRTABLE) operator new(ip_table_size));
+    ip_table = std::unique_ptr<MIB_IPADDRTABLE>(static_cast<PMIB_IPADDRTABLE>(operator new(ip_table_size)));
   }
 
   // find the interface IP used for the default route and use that
@@ -695,7 +695,7 @@ IPCReply NetIPTopDevice::HandleSetSockOptRequest(const IOCtlRequest& request)
   const u32 optname = memory.Read_U32(request.buffer_in + 8);
   u32 optlen = memory.Read_U32(request.buffer_in + 0xc);
   u8 optval[20];
-  optlen = std::min(optlen, (u32)sizeof(optval));
+  optlen = std::min(optlen, static_cast<u32>(sizeof(optval)));
   memory.CopyFromEmu(optval, request.buffer_in + 0x10, optlen);
 
   INFO_LOG_FMT(IOS_NET,
@@ -1057,7 +1057,7 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
           FREE(AdapterAddresses);
         }
 
-        AdapterAddresses = (PIP_ADAPTER_ADDRESSES)MALLOC(OutBufferLength);
+        AdapterAddresses = static_cast<PIP_ADAPTER_ADDRESSES>(MALLOC(OutBufferLength));
         if (AdapterAddresses == nullptr)
         {
           RetVal = GetLastError();
@@ -1080,10 +1080,10 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
               INFO_LOG_FMT(IOS_NET, "Name of valid interface: {}",
                            WStringToUTF8(AdapterList->FriendlyName));
               INFO_LOG_FMT(IOS_NET, "DNS: {}.{}.{}.{}",
-                           u8(AdapterList->FirstDnsServerAddress->Address.lpSockaddr->sa_data[2]),
-                           u8(AdapterList->FirstDnsServerAddress->Address.lpSockaddr->sa_data[3]),
-                           u8(AdapterList->FirstDnsServerAddress->Address.lpSockaddr->sa_data[4]),
-                           u8(AdapterList->FirstDnsServerAddress->Address.lpSockaddr->sa_data[5]));
+                           static_cast<u8>(AdapterList->FirstDnsServerAddress->Address.lpSockaddr->sa_data[2]),
+                           static_cast<u8>(AdapterList->FirstDnsServerAddress->Address.lpSockaddr->sa_data[3]),
+                           static_cast<u8>(AdapterList->FirstDnsServerAddress->Address.lpSockaddr->sa_data[4]),
+                           static_cast<u8>(AdapterList->FirstDnsServerAddress->Address.lpSockaddr->sa_data[5]));
               address = Common::swap32(
                   *(u32*)(&AdapterList->FirstDnsServerAddress->Address.lpSockaddr->sa_data[2]));
               break;
@@ -1295,7 +1295,7 @@ IPCReply NetIPTopDevice::HandleGetAddressInfoRequest(const IOCtlVRequest& reques
       memory.Write_U32(result_iter->ai_family, addr + 0x04);
       memory.Write_U32(result_iter->ai_socktype, addr + 0x08);
       memory.Write_U32(result_iter->ai_protocol, addr + 0x0C);
-      memory.Write_U32((u32)result_iter->ai_addrlen, addr + 0x10);
+      memory.Write_U32(static_cast<u32>(result_iter->ai_addrlen), addr + 0x10);
       // what to do? where to put? the buffer of 0x834 doesn't allow space for this
       memory.Write_U32(/*result->ai_cannonname*/ 0, addr + 0x14);
 

--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
@@ -178,12 +178,12 @@ void NWC24Config::SetChecksum(u32 checksum)
 
 NWC24CreationStage NWC24Config::CreationStage() const
 {
-  return NWC24CreationStage(Common::swap32(u32(m_data.creation_stage)));
+  return static_cast<NWC24CreationStage>(Common::swap32(static_cast<u32>(m_data.creation_stage)));
 }
 
 void NWC24Config::SetCreationStage(NWC24CreationStage creation_stage)
 {
-  m_data.creation_stage = NWC24CreationStage(Common::swap32(u32(creation_stage)));
+  m_data.creation_stage = static_cast<NWC24CreationStage>(Common::swap32(static_cast<u32>(creation_stage)));
 }
 
 u32 NWC24Config::EnableBooting() const

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -96,7 +96,7 @@ s32 NWC24MakeUserID(u64* nwc24_id, u32 hollywood_id, u16 id_ctr, HardwareModel h
       0x4, 0xB, 0x7, 0x9, 0xF, 0x1, 0xD, 0x3, 0xC, 0x2, 0x6, 0xE, 0x8, 0x0, 0xA, 0x5,
   };
 
-  constexpr auto u64_get_byte = [](u64 value, u32 shift) -> u8 { return u8(value >> (shift * 8)); };
+  constexpr auto u64_get_byte = [](u64 value, u32 shift) -> u8 { return static_cast<u8>(value >> (shift * 8)); };
 
   constexpr auto u64_insert_byte = [](u64 value, u32 shift, u8 byte) -> u64 {
     const u64 mask = 0x00000000000000FFULL << (shift * 8);
@@ -104,7 +104,7 @@ s32 NWC24MakeUserID(u64* nwc24_id, u32 hollywood_id, u16 id_ctr, HardwareModel h
     return (value & ~mask) | inst;
   };
 
-  u64 mix_id = (u64{area_code} << 50) | (u64(hardware_model) << 47) | (u64{hollywood_id} << 15) |
+  u64 mix_id = (u64{area_code} << 50) | (static_cast<u64>(hardware_model) << 47) | (u64{hollywood_id} << 15) |
                (u64{id_ctr} << 10);
   const u64 mix_id_copy1 = mix_id;
 
@@ -125,7 +125,7 @@ s32 NWC24MakeUserID(u64* nwc24_id, u32 hollywood_id, u16 id_ctr, HardwareModel h
   for (ctr = 0; ctr <= 5; ctr++)
   {
     const u8 ret = u64_get_byte(mix_id, ctr);
-    const u8 foobar = u8((u32{table1[(ret >> 4) & 0xF]} << 4) | table1[ret & 0xF]);
+    const u8 foobar = static_cast<u8>((u32{table1[(ret >> 4) & 0xF]} << 4) | table1[ret & 0xF]);
     mix_id = u64_insert_byte(mix_id, ctr, foobar & 0xff);
   }
 
@@ -1087,7 +1087,7 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
       if (!area.empty() && !model.empty())
       {
         const u8 area_code = GetAreaCode(area);
-        const u8 id_ctr = u8(m_config.IdGen());
+        const u8 id_ctr = static_cast<u8>(m_config.IdGen());
         const HardwareModel hardware_model = GetHardwareModel(model);
 
         const u32 hollywood_id = m_ios.GetIOSC().GetDeviceId();
@@ -1118,7 +1118,7 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
       WriteReturnValue(memory, NWC24::WC24_ERR_ID_REGISTERED, request.buffer_out);
     }
     memory.Write_U64(m_config.Id(), request.buffer_out + 4);
-    memory.Write_U32(u32(m_config.CreationStage()), request.buffer_out + 0xC);
+    memory.Write_U32(static_cast<u32>(m_config.CreationStage()), request.buffer_out + 0xC);
     break;
 
   case IOCTL_NWC24_GET_SCHEDULER_STAT:

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -101,7 +101,7 @@ u64 NetKDTimeDevice::GetAdjustedUTC() const
   if (gm_time.tm_isdst == 1)
     dst_diff = 3600;
 
-  return u64(s64(emulated_time) + utcdiff - dst_diff);
+  return static_cast<u64>(static_cast<s64>(emulated_time) + utcdiff - dst_diff);
 }
 
 void NetKDTimeDevice::SetAdjustedUTC(u64 wii_utc)
@@ -116,6 +116,6 @@ void NetKDTimeDevice::SetAdjustedUTC(u64 wii_utc)
   if (gm_time.tm_isdst == 1)
     dst_diff = 3600;
 
-  utcdiff = s64(emulated_time - wii_utc - dst_diff);
+  utcdiff = static_cast<s64>(emulated_time - wii_utc - dst_diff);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -1176,8 +1176,8 @@ WiiSockAddrIn WiiSockMan::ToWiiAddrIn(const sockaddr_in& from, socklen_t addrlen
 {
   WiiSockAddrIn result;
 
-  result.len = u8(addrlen > sizeof(WiiSockAddrIn) ? sizeof(WiiSockAddrIn) : addrlen);
-  result.family = u8(from.sin_family & 0xFF);
+  result.len = static_cast<u8>(addrlen > sizeof(WiiSockAddrIn) ? sizeof(WiiSockAddrIn) : addrlen);
+  result.family = static_cast<u8>(from.sin_family & 0xFF);
   result.port = from.sin_port;
   result.addr.addr = from.sin_addr.s_addr;
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -496,7 +496,7 @@ bool BluetoothEmuDevice::SendEventInquiryResponse()
   const auto& wiimote = *iter;
 
   SQueuedEvent event(
-      u32(sizeof(SHCIEventInquiryResult) + num_responses * sizeof(hci_inquiry_response)), 0);
+      static_cast<u32>(sizeof(SHCIEventInquiryResult) + num_responses * sizeof(hci_inquiry_response)), 0);
 
   const auto inquiry_result = reinterpret_cast<SHCIEventInquiryResult*>(event.buffer);
   inquiry_result->EventType = HCI_EVENT_INQUIRY_RESULT;
@@ -518,8 +518,8 @@ bool BluetoothEmuDevice::SendEventInquiryResponse()
                 response->bdaddr[5]);
 
   inquiry_result->PayloadLength =
-      u8(sizeof(SHCIEventInquiryResult) - 2 +
-         (inquiry_result->num_responses * sizeof(hci_inquiry_response)));
+      static_cast<u8>(sizeof(SHCIEventInquiryResult) - 2 +
+                      (inquiry_result->num_responses * sizeof(hci_inquiry_response)));
 
   AddEventToQueue(event);
   SendEventInquiryComplete(num_responses);
@@ -739,7 +739,7 @@ void BluetoothEmuDevice::SendEventCommandComplete(u16 opcode, const void* data, 
 
   SHCIEventCommand* hci_event = reinterpret_cast<SHCIEventCommand*>(event.buffer);
   hci_event->EventType = HCI_EVENT_COMMAND_COMPL;
-  hci_event->PayloadLength = (u8)(sizeof(SHCIEventCommand) - 2 + data_size);
+  hci_event->PayloadLength = static_cast<u8>(sizeof(SHCIEventCommand) - 2 + data_size);
   hci_event->PacketIndicator = 0x01;
   hci_event->Opcode = opcode;
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -802,7 +802,7 @@ void WiimoteDevice::SDPSendServiceSearchResponse(u16 cid, u16 transaction_id,
   buffer.Write8(offset, 0x00);
   offset++;  // No continuation state;
 
-  header->length = (u16)(offset - sizeof(l2cap_hdr_t));
+  header->length = static_cast<u16>(offset - sizeof(l2cap_hdr_t));
   m_host->SendACLPacket(GetBD(), data_frame, header->length + sizeof(l2cap_hdr_t));
 }
 
@@ -892,7 +892,7 @@ void WiimoteDevice::SDPSendServiceAttributeResponse(u16 cid, u16 transaction_id,
   memcpy(buffer.GetPointer(offset), packet, packet_size);
   offset += packet_size;
 
-  header->length = (u16)(offset - sizeof(l2cap_hdr_t));
+  header->length = static_cast<u16>(offset - sizeof(l2cap_hdr_t));
   m_host->SendACLPacket(GetBD(), data_frame, header->length + sizeof(l2cap_hdr_t));
 }
 
@@ -994,7 +994,7 @@ void WiimoteDevice::InterruptDataInputCallback(u8 hid_type, const u8* data, u32 
   static_assert(sizeof(data_frame) == sizeof(data_frame.data) + sizeof(u8) + sizeof(l2cap_hdr_t));
 
   data_frame.header.dcid = channel->remote_cid;
-  data_frame.header.length = u16(sizeof(hid_type) + size);
+  data_frame.header.length = static_cast<u16>(sizeof(hid_type) + size);
   data_frame.hid_type = hid_type;
   std::copy_n(data, size, data_frame.data.data());
 

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1271,7 +1271,7 @@ bool MovieManager::PlayWiimote(int wiimote, DesiredWiimoteState* desired_state)
 
   if (serialized.length > serialized.data.size())
   {
-    PanicAlertFmtT("Invalid serialized length:{0} in PlayWiimote. byte:{1}", int(serialized.length),
+    PanicAlertFmtT("Invalid serialized length:{0} in PlayWiimote. byte:{1}", static_cast<int>(serialized.length),
                    m_current_byte);
     EndPlayInput(!m_read_only);
     return false;
@@ -1281,7 +1281,7 @@ bool MovieManager::PlayWiimote(int wiimote, DesiredWiimoteState* desired_state)
   if (m_current_byte + serialized.length > m_temp_input.size())
   {
     PanicAlertFmtT("Premature movie end in PlayWiimote. {0} + {1} > {2}", m_current_byte,
-                   int(serialized.length), m_temp_input.size());
+                   static_cast<int>(serialized.length), m_temp_input.size());
     EndPlayInput(!m_read_only);
     return false;
   }

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1650,7 +1650,7 @@ void NetPlayClient::ThreadFunc()
         if (static_cast<int>(netEvent.type) == Common::ENet::SKIPPABLE_EVENT)
           INFO_LOG_FMT(NETPLAY, "enet_host_service: skippable packet event");
         else
-          ERROR_LOG_FMT(NETPLAY, "enet_host_service: unknown event type: {}", int(netEvent.type));
+          ERROR_LOG_FMT(NETPLAY, "enet_host_service: unknown event type: {}", static_cast<int>(netEvent.type));
         break;
       }
     }

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -332,7 +332,7 @@ void NetPlayServer::ThreadFunc()
 
           if (error != ConnectionError::NoError)
           {
-            INFO_LOG_FMT(NETPLAY, "Error {} initializing peer {:x}:{}", u8(error),
+            INFO_LOG_FMT(NETPLAY, "Error {} initializing peer {:x}:{}", static_cast<u8>(error),
                          netEvent.peer->address.host, netEvent.peer->address.port);
 
             sf::Packet spac;
@@ -397,7 +397,7 @@ void NetPlayServer::ThreadFunc()
         if (static_cast<int>(netEvent.type) == Common::ENet::SKIPPABLE_EVENT)
           INFO_LOG_FMT(NETPLAY, "enet_host_service: skippable packet event");
         else
-          ERROR_LOG_FMT(NETPLAY, "enet_host_service: unknown event type: {}", int(netEvent.type));
+          ERROR_LOG_FMT(NETPLAY, "enet_host_service: unknown event type: {}", static_cast<int>(netEvent.type));
         break;
       }
     }
@@ -1141,7 +1141,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
     SyncSaveDataID sub_id;
     packet >> sub_id;
 
-    INFO_LOG_FMT(NETPLAY, "Got client SyncSaveData message: {:x} from client {}", u8(sub_id),
+    INFO_LOG_FMT(NETPLAY, "Got client SyncSaveData message: {:x} from client {}", static_cast<u8>(sub_id),
                  player.pid);
 
     switch (sub_id)
@@ -1198,7 +1198,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
     SyncCodeID sub_id;
     packet >> sub_id;
 
-    INFO_LOG_FMT(NETPLAY, "Got client SyncCodes message: {:x} from client {}", u8(sub_id),
+    INFO_LOG_FMT(NETPLAY, "Got client SyncCodes message: {:x} from client {}", static_cast<u8>(sub_id),
                  player.pid);
 
     // Check If Code Sync was successful or not

--- a/Source/Core/Core/PowerPC/ConditionRegister.h
+++ b/Source/Core/Core/PowerPC/ConditionRegister.h
@@ -48,10 +48,10 @@ struct ConditionRegister
   static constexpr u64 PPCToInternal(u8 value)
   {
     u64 cr_val = 0x100000000;
-    cr_val |= (u64) !!(value & CR_SO) << CR_EMU_SO_BIT;
-    cr_val |= (u64) !(value & CR_EQ);
-    cr_val |= (u64) !(value & CR_GT) << 63;
-    cr_val |= (u64) !!(value & CR_LT) << CR_EMU_LT_BIT;
+    cr_val |= static_cast<u64>(!!(value & CR_SO)) << CR_EMU_SO_BIT;
+    cr_val |= static_cast<u64>(!(value & CR_EQ));
+    cr_val |= static_cast<u64>(!(value & CR_GT)) << 63;
+    cr_val |= static_cast<u64>(!!(value & CR_LT)) << CR_EMU_LT_BIT;
 
     return cr_val;
   }

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -287,7 +287,7 @@ static void SendReply(const char* reply)
 
   memset(s_cmd_bfr, 0, sizeof s_cmd_bfr);
 
-  s_cmd_len = (u32)strlen(reply);
+  s_cmd_len = static_cast<u32>(strlen(reply));
   if (s_cmd_len + 4 > sizeof s_cmd_bfr)
     ERROR_LOG_FMT(GDB_STUB, "cmd_bfr overflow in gdb_reply");
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
@@ -20,7 +20,7 @@ void Interpreter::bx(Interpreter& interpreter, UGeckoInstruction inst)
   if (inst.LK)
     LR(ppc_state) = ppc_state.pc + 4;
 
-  u32 destination_addr = u32(SignExt26(inst.LI << 2));
+  u32 destination_addr = static_cast<u32>(SignExt26(inst.LI << 2));
   if (!inst.AA)
     destination_addr += ppc_state.pc;
   ppc_state.npc = destination_addr;
@@ -45,14 +45,14 @@ void Interpreter::bcx(Interpreter& interpreter, UGeckoInstruction inst)
   const bool only_condition_check = ((inst.BO >> 2) & 1) != 0;
   const u32 ctr_check = ((CTR(ppc_state) != 0) ^ (inst.BO >> 1)) & 1;
   const bool counter = only_condition_check || ctr_check != 0;
-  const bool condition = only_counter_check || (ppc_state.cr.GetBit(inst.BI) == u32(true_false));
+  const bool condition = only_counter_check || (ppc_state.cr.GetBit(inst.BI) == static_cast<u32>(true_false));
 
   if (counter && condition)
   {
     if (inst.LK)
       LR(ppc_state) = ppc_state.pc + 4;
 
-    u32 destination_addr = u32(SignExt16(s16(inst.BD << 2)));
+    u32 destination_addr = static_cast<u32>(SignExt16(static_cast<s16>(inst.BD << 2)));
     if (!inst.AA)
       destination_addr += ppc_state.pc;
     ppc_state.npc = destination_addr;

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -369,39 +369,39 @@ inline FPResult NI_msub(PowerPC::PowerPCState& ppc_state, double a, double c, do
 // used by stfsXX instructions and ps_rsqrte
 inline u32 ConvertToSingle(u64 x)
 {
-  const u32 exp = u32((x >> 52) & 0x7ff);
+  const u32 exp = static_cast<u32>((x >> 52) & 0x7ff);
 
   if (exp > 896 || (x & ~Common::DOUBLE_SIGN) == 0)
   {
-    return u32(((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff));
+    return static_cast<u32>(((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff));
   }
   else if (exp >= 874)
   {
-    u32 t = u32(0x80000000 | ((x & Common::DOUBLE_FRAC) >> 21));
+    u32 t = static_cast<u32>(0x80000000 | ((x & Common::DOUBLE_FRAC) >> 21));
     t = t >> (905 - exp);
-    t |= u32((x >> 32) & 0x80000000);
+    t |= static_cast<u32>((x >> 32) & 0x80000000);
     return t;
   }
   else
   {
     // This is said to be undefined.
     // The code is based on hardware tests.
-    return u32(((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff));
+    return static_cast<u32>(((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff));
   }
 }
 
 // used by psq_stXX operations.
 inline u32 ConvertToSingleFTZ(u64 x)
 {
-  const u32 exp = u32((x >> 52) & 0x7ff);
+  const u32 exp = static_cast<u32>((x >> 52) & 0x7ff);
 
   if (exp > 896 || (x & ~Common::DOUBLE_SIGN) == 0)
   {
-    return u32(((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff));
+    return static_cast<u32>(((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff));
   }
   else
   {
-    return u32((x >> 32) & 0x80000000);
+    return static_cast<u32>((x >> 32) & 0x80000000);
   }
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -517,7 +517,7 @@ void Interpreter::fresx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto compute_result = [&ppc_state, inst](double value) {
     const double result = Common::ApproximateReciprocal(value);
     ppc_state.ps[inst.FD].Fill(result);
-    ppc_state.UpdateFPRFSingle(float(result));
+    ppc_state.UpdateFPRFSingle(static_cast<float>(result));
   };
 
   if (b == 0.0)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -14,8 +14,8 @@
 
 void Interpreter::Helper_UpdateCR0(PowerPC::PowerPCState& ppc_state, u32 value)
 {
-  const s64 sign_extended = s64{s32(value)};
-  u64 cr_val = u64(sign_extended);
+  const s64 sign_extended = s64{static_cast<s32>(value)};
+  u64 cr_val = static_cast<u64>(sign_extended);
 
   if (value == 0)
   {
@@ -40,16 +40,16 @@ void Interpreter::addi(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
   if (inst.RA)
-    ppc_state.gpr[inst.RD] = ppc_state.gpr[inst.RA] + u32(inst.SIMM_16);
+    ppc_state.gpr[inst.RD] = ppc_state.gpr[inst.RA] + static_cast<u32>(inst.SIMM_16);
   else
-    ppc_state.gpr[inst.RD] = u32(inst.SIMM_16);
+    ppc_state.gpr[inst.RD] = static_cast<u32>(inst.SIMM_16);
 }
 
 void Interpreter::addic(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
   const u32 a = ppc_state.gpr[inst.RA];
-  const u32 imm = u32(s32{inst.SIMM_16});
+  const u32 imm = static_cast<u32>(s32{inst.SIMM_16});
 
   ppc_state.gpr[inst.RD] = a + imm;
   ppc_state.SetCarry(Helper_Carry(a, imm));
@@ -66,9 +66,9 @@ void Interpreter::addis(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
   if (inst.RA)
-    ppc_state.gpr[inst.RD] = ppc_state.gpr[inst.RA] + u32(inst.SIMM_16 << 16);
+    ppc_state.gpr[inst.RD] = ppc_state.gpr[inst.RA] + static_cast<u32>(inst.SIMM_16 << 16);
   else
-    ppc_state.gpr[inst.RD] = u32(inst.SIMM_16 << 16);
+    ppc_state.gpr[inst.RD] = static_cast<u32>(inst.SIMM_16 << 16);
 }
 
 void Interpreter::andi_rc(Interpreter& interpreter, UGeckoInstruction inst)
@@ -123,7 +123,7 @@ void Interpreter::cmpli(Interpreter& interpreter, UGeckoInstruction inst)
 void Interpreter::mulli(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  ppc_state.gpr[inst.RD] = u32(s32(ppc_state.gpr[inst.RA]) * inst.SIMM_16);
+  ppc_state.gpr[inst.RD] = static_cast<u32>(static_cast<s32>(ppc_state.gpr[inst.RA]) * inst.SIMM_16);
 }
 
 void Interpreter::ori(Interpreter& interpreter, UGeckoInstruction inst)
@@ -141,23 +141,23 @@ void Interpreter::oris(Interpreter& interpreter, UGeckoInstruction inst)
 void Interpreter::subfic(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  const s32 a = s32(ppc_state.gpr[inst.RA]);
+  const s32 a = static_cast<s32>(ppc_state.gpr[inst.RA]);
   const s32 immediate = inst.SIMM_16;
-  ppc_state.gpr[inst.RD] = u32(immediate - a);
-  ppc_state.SetCarry((a == 0) || (Helper_Carry(0 - u32(a), u32(immediate))));
+  ppc_state.gpr[inst.RD] = static_cast<u32>(immediate - a);
+  ppc_state.SetCarry((a == 0) || (Helper_Carry(0 - static_cast<u32>(a), static_cast<u32>(immediate))));
 }
 
 void Interpreter::twi(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  const s32 a = s32(ppc_state.gpr[inst.RA]);
+  const s32 a = static_cast<s32>(ppc_state.gpr[inst.RA]);
   const s32 b = inst.SIMM_16;
   const u32 TO = inst.TO;
 
   DEBUG_LOG_FMT(POWERPC, "twi rA {:x} SIMM {:x} TO {:x}", a, b, TO);
 
   if ((a < b && (TO & 0x10) != 0) || (a > b && (TO & 0x08) != 0) || (a == b && (TO & 0x04) != 0) ||
-      (u32(a) < u32(b) && (TO & 0x02) != 0) || (u32(a) > u32(b) && (TO & 0x01) != 0))
+      (static_cast<u32>(a) < static_cast<u32>(b) && (TO & 0x02) != 0) || (static_cast<u32>(a) > static_cast<u32>(b) && (TO & 0x01) != 0))
   {
     GenerateProgramException(ppc_state, ProgramExceptionCause::Trap);
     interpreter.m_system.GetPowerPC().CheckExceptions();
@@ -245,7 +245,7 @@ void Interpreter::cmpl(Interpreter& interpreter, UGeckoInstruction inst)
 void Interpreter::cntlzwx(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  ppc_state.gpr[inst.RA] = u32(std::countl_zero(ppc_state.gpr[inst.RS]));
+  ppc_state.gpr[inst.RA] = static_cast<u32>(std::countl_zero(ppc_state.gpr[inst.RS]));
 
   if (inst.Rc)
     Helper_UpdateCR0(ppc_state, ppc_state.gpr[inst.RA]);
@@ -263,7 +263,7 @@ void Interpreter::eqvx(Interpreter& interpreter, UGeckoInstruction inst)
 void Interpreter::extsbx(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  ppc_state.gpr[inst.RA] = u32(s32(s8(ppc_state.gpr[inst.RS])));
+  ppc_state.gpr[inst.RA] = static_cast<u32>(static_cast<s32>(s8(ppc_state.gpr[inst.RS])));
 
   if (inst.Rc)
     Helper_UpdateCR0(ppc_state, ppc_state.gpr[inst.RA]);
@@ -272,7 +272,7 @@ void Interpreter::extsbx(Interpreter& interpreter, UGeckoInstruction inst)
 void Interpreter::extshx(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  ppc_state.gpr[inst.RA] = u32(s32(s16(ppc_state.gpr[inst.RS])));
+  ppc_state.gpr[inst.RA] = static_cast<u32>(static_cast<s32>(s16(ppc_state.gpr[inst.RS])));
 
   if (inst.Rc)
     Helper_UpdateCR0(ppc_state, ppc_state.gpr[inst.RA]);
@@ -345,10 +345,10 @@ void Interpreter::srawx(Interpreter& interpreter, UGeckoInstruction inst)
   else
   {
     const u32 amount = rb & 0x1f;
-    const s32 rrs = s32(ppc_state.gpr[inst.RS]);
-    ppc_state.gpr[inst.RA] = u32(rrs >> amount);
+    const s32 rrs = static_cast<s32>(ppc_state.gpr[inst.RS]);
+    ppc_state.gpr[inst.RA] = static_cast<u32>(rrs >> amount);
 
-    ppc_state.SetCarry(rrs < 0 && amount > 0 && (u32(rrs) << (32 - amount)) != 0);
+    ppc_state.SetCarry(rrs < 0 && amount > 0 && (static_cast<u32>(rrs) << (32 - amount)) != 0);
   }
 
   if (inst.Rc)
@@ -359,10 +359,10 @@ void Interpreter::srawix(Interpreter& interpreter, UGeckoInstruction inst)
 {
   const u32 amount = inst.SH;
   auto& ppc_state = interpreter.m_ppc_state;
-  const s32 rrs = s32(ppc_state.gpr[inst.RS]);
+  const s32 rrs = static_cast<s32>(ppc_state.gpr[inst.RS]);
 
-  ppc_state.gpr[inst.RA] = u32(rrs >> amount);
-  ppc_state.SetCarry(rrs < 0 && amount > 0 && (u32(rrs) << (32 - amount)) != 0);
+  ppc_state.gpr[inst.RA] = static_cast<u32>(rrs >> amount);
+  ppc_state.SetCarry(rrs < 0 && amount > 0 && (static_cast<u32>(rrs) << (32 - amount)) != 0);
 
   if (inst.Rc)
     Helper_UpdateCR0(ppc_state, ppc_state.gpr[inst.RA]);
@@ -381,14 +381,14 @@ void Interpreter::srwx(Interpreter& interpreter, UGeckoInstruction inst)
 void Interpreter::tw(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  const s32 a = s32(ppc_state.gpr[inst.RA]);
-  const s32 b = s32(ppc_state.gpr[inst.RB]);
+  const s32 a = static_cast<s32>(ppc_state.gpr[inst.RA]);
+  const s32 b = static_cast<s32>(ppc_state.gpr[inst.RB]);
   const u32 TO = inst.TO;
 
   DEBUG_LOG_FMT(POWERPC, "tw rA {:x} rB {:x} TO {:x}", a, b, TO);
 
   if ((a < b && (TO & 0x10) != 0) || (a > b && (TO & 0x08) != 0) || (a == b && (TO & 0x04) != 0) ||
-      ((u32(a) < u32(b)) && (TO & 0x02) != 0) || ((u32(a) > u32(b)) && (TO & 0x01) != 0))
+      ((static_cast<u32>(a) < static_cast<u32>(b)) && (TO & 0x02) != 0) || ((static_cast<u32>(a) > static_cast<u32>(b)) && (TO & 0x01) != 0))
   {
     GenerateProgramException(ppc_state, ProgramExceptionCause::Trap);
     interpreter.m_system.GetPowerPC().CheckExceptions();
@@ -501,8 +501,8 @@ void Interpreter::addzex(Interpreter& interpreter, UGeckoInstruction inst)
 void Interpreter::divwx(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  const auto a = s32(ppc_state.gpr[inst.RA]);
-  const auto b = s32(ppc_state.gpr[inst.RB]);
+  const auto a = static_cast<s32>(ppc_state.gpr[inst.RA]);
+  const auto b = static_cast<s32>(ppc_state.gpr[inst.RB]);
   const bool overflow = b == 0 || (static_cast<u32>(a) == 0x80000000 && b == -1);
 
   if (overflow)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -20,12 +20,12 @@
 
 static u32 Helper_Get_EA(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
 {
-  return inst.RA ? (ppcs.gpr[inst.RA] + u32(inst.SIMM_16)) : u32(inst.SIMM_16);
+  return inst.RA ? (ppcs.gpr[inst.RA] + static_cast<u32>(inst.SIMM_16)) : static_cast<u32>(inst.SIMM_16);
 }
 
 static u32 Helper_Get_EA_U(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
 {
-  return (ppcs.gpr[inst.RA] + u32(inst.SIMM_16));
+  return (ppcs.gpr[inst.RA] + static_cast<u32>(inst.SIMM_16));
 }
 
 static u32 Helper_Get_EA_X(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
@@ -219,7 +219,7 @@ void Interpreter::lfsx(Interpreter& interpreter, UGeckoInstruction inst)
 void Interpreter::lha(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  const u32 temp = u32(s32(s16(interpreter.m_mmu.Read_U16(Helper_Get_EA(ppc_state, inst)))));
+  const u32 temp = static_cast<u32>(static_cast<s32>(s16(interpreter.m_mmu.Read_U16(Helper_Get_EA(ppc_state, inst)))));
 
   if (!(ppc_state.Exceptions & EXCEPTION_DSI))
   {
@@ -231,7 +231,7 @@ void Interpreter::lhau(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
   const u32 address = Helper_Get_EA_U(ppc_state, inst);
-  const u32 temp = u32(s32(s16(interpreter.m_mmu.Read_U16(address))));
+  const u32 temp = static_cast<u32>(static_cast<s32>(s16(interpreter.m_mmu.Read_U16(address))));
 
   if (!(ppc_state.Exceptions & EXCEPTION_DSI))
   {
@@ -664,11 +664,11 @@ void Interpreter::lhaux(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
   const u32 address = Helper_Get_EA_UX(ppc_state, inst);
-  const s32 temp = s32{s16(interpreter.m_mmu.Read_U16(address))};
+  const s32 temp = s32{static_cast<s16>(interpreter.m_mmu.Read_U16(address))};
 
   if (!(ppc_state.Exceptions & EXCEPTION_DSI))
   {
-    ppc_state.gpr[inst.RD] = u32(temp);
+    ppc_state.gpr[inst.RD] = static_cast<u32>(temp);
     ppc_state.gpr[inst.RA] = address;
   }
 }
@@ -676,11 +676,11 @@ void Interpreter::lhaux(Interpreter& interpreter, UGeckoInstruction inst)
 void Interpreter::lhax(Interpreter& interpreter, UGeckoInstruction inst)
 {
   auto& ppc_state = interpreter.m_ppc_state;
-  const s32 temp = s32{s16(interpreter.m_mmu.Read_U16(Helper_Get_EA_X(ppc_state, inst)))};
+  const s32 temp = s32{static_cast<s16>(interpreter.m_mmu.Read_U16(Helper_Get_EA_X(ppc_state, inst)))};
 
   if (!(ppc_state.Exceptions & EXCEPTION_DSI))
   {
-    ppc_state.gpr[inst.RD] = u32(temp);
+    ppc_state.gpr[inst.RD] = static_cast<u32>(temp);
   }
 }
 
@@ -1012,7 +1012,7 @@ void Interpreter::stswx(Interpreter& interpreter, UGeckoInstruction inst)
     return;
   }
 
-  u32 n = u8(ppc_state.xer_stringctrl);
+  u32 n = static_cast<u8>(ppc_state.xer_stringctrl);
   u32 r = inst.RS;
   u32 i = 0;
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
@@ -61,9 +61,9 @@ const float m_quantizeTable[] = {
 template <typename SType>
 SType ScaleAndClamp(double ps, u32 st_scale)
 {
-  const float conv_ps = float(ps) * m_quantizeTable[st_scale];
-  constexpr float min = float(std::numeric_limits<SType>::min());
-  constexpr float max = float(std::numeric_limits<SType>::max());
+  const float conv_ps = static_cast<float>(ps) * m_quantizeTable[st_scale];
+  constexpr float min = static_cast<float>(std::numeric_limits<SType>::min());
+  constexpr float max = static_cast<float>(std::numeric_limits<SType>::max());
 
   return SType(std::clamp(conv_ps, min, max));
 }
@@ -96,21 +96,21 @@ template <>
 std::pair<u8, u8> ReadPair<u8>(PowerPC::MMU& mmu, u32 addr)
 {
   const u16 val = mmu.Read_U16(addr);
-  return {u8(val >> 8), u8(val)};
+  return {static_cast<u8>(val >> 8), static_cast<u8>(val)};
 }
 
 template <>
 std::pair<u16, u16> ReadPair<u16>(PowerPC::MMU& mmu, u32 addr)
 {
   const u32 val = mmu.Read_U32(addr);
-  return {u16(val >> 16), u16(val)};
+  return {static_cast<u16>(val >> 16), static_cast<u16>(val)};
 }
 
 template <>
 std::pair<u32, u32> ReadPair<u32>(PowerPC::MMU& mmu, u32 addr)
 {
   const u64 val = mmu.Read_U64(addr);
-  return {u32(val >> 32), u32(val)};
+  return {static_cast<u32>(val >> 32), static_cast<u32>(val)};
 }
 
 template <typename T>
@@ -236,14 +236,14 @@ std::pair<double, double> LoadAndDequantize(PowerPC::MMU& mmu, u32 addr, u32 ins
   if (instW != 0)
   {
     const U value = ReadUnpaired<U>(mmu, addr);
-    ps0 = float(T(value)) * m_dequantizeTable[ld_scale];
+    ps0 = static_cast<float>(T(value)) * m_dequantizeTable[ld_scale];
     ps1 = 1.0f;
   }
   else
   {
     const auto [first, second] = ReadPair<U>(mmu, addr);
-    ps0 = float(T(first)) * m_dequantizeTable[ld_scale];
-    ps1 = float(T(second)) * m_dequantizeTable[ld_scale];
+    ps0 = static_cast<float>(T(first)) * m_dequantizeTable[ld_scale];
+    ps1 = static_cast<float>(T(second)) * m_dequantizeTable[ld_scale];
   }
   // ps0 and ps1 always contain finite and normal numbers. So we can just cast them to double
   return {static_cast<double>(ps0), static_cast<double>(ps1)};
@@ -318,7 +318,7 @@ void Interpreter::psq_l(Interpreter& interpreter, UGeckoInstruction inst)
     return;
   }
 
-  const u32 EA = inst.RA ? (ppc_state.gpr[inst.RA] + u32(inst.SIMM_12)) : u32(inst.SIMM_12);
+  const u32 EA = inst.RA ? (ppc_state.gpr[inst.RA] + static_cast<u32>(inst.SIMM_12)) : static_cast<u32>(inst.SIMM_12);
   Helper_Dequantize(interpreter.m_mmu, &ppc_state, EA, inst.I, inst.RD, inst.W);
 }
 
@@ -331,7 +331,7 @@ void Interpreter::psq_lu(Interpreter& interpreter, UGeckoInstruction inst)
     return;
   }
 
-  const u32 EA = ppc_state.gpr[inst.RA] + u32(inst.SIMM_12);
+  const u32 EA = ppc_state.gpr[inst.RA] + static_cast<u32>(inst.SIMM_12);
   Helper_Dequantize(interpreter.m_mmu, &ppc_state, EA, inst.I, inst.RD, inst.W);
 
   if ((ppc_state.Exceptions & EXCEPTION_DSI) != 0)
@@ -351,7 +351,7 @@ void Interpreter::psq_st(Interpreter& interpreter, UGeckoInstruction inst)
     return;
   }
 
-  const u32 EA = inst.RA ? (ppc_state.gpr[inst.RA] + u32(inst.SIMM_12)) : u32(inst.SIMM_12);
+  const u32 EA = inst.RA ? (ppc_state.gpr[inst.RA] + static_cast<u32>(inst.SIMM_12)) : static_cast<u32>(inst.SIMM_12);
   Helper_Quantize(interpreter.m_mmu, &ppc_state, EA, inst.I, inst.RS, inst.W);
 }
 
@@ -364,7 +364,7 @@ void Interpreter::psq_stu(Interpreter& interpreter, UGeckoInstruction inst)
     return;
   }
 
-  const u32 EA = ppc_state.gpr[inst.RA] + u32(inst.SIMM_12);
+  const u32 EA = ppc_state.gpr[inst.RA] + static_cast<u32>(inst.SIMM_12);
   Helper_Quantize(interpreter.m_mmu, &ppc_state, EA, inst.I, inst.RS, inst.W);
 
   if ((ppc_state.Exceptions & EXCEPTION_DSI) != 0)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -161,7 +161,7 @@ void Interpreter::ps_res(Interpreter& interpreter, UGeckoInstruction inst)
   const double ps1 = Common::ApproximateReciprocal(b);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
-  ppc_state.UpdateFPRFSingle(float(ps0));
+  ppc_state.UpdateFPRFSingle(static_cast<float>(ps0));
 
   if (inst.Rc)
     ppc_state.UpdateCR1();

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -489,7 +489,7 @@ void Jit64::FakeBLCall(u32 after)
 
   // We may need to fake the BLR stack on inlined CALL instructions.
   // Else we can't return to this location any more.
-  MOV(64, R(RSCRATCH2), Imm64(u64(m_ppc_state.feature_flags) << 32 | after));
+  MOV(64, R(RSCRATCH2), Imm64(static_cast<u64>(m_ppc_state.feature_flags) << 32 | after));
   PUSH(RSCRATCH2);
   FixupBranch skip_exit = CALL();
   POP(RSCRATCH2);
@@ -552,7 +552,7 @@ void Jit64::WriteExit(u32 destination, bool bl, u32 after)
 
   if (bl)
   {
-    MOV(64, R(RSCRATCH2), Imm64(u64(m_ppc_state.feature_flags) << 32 | after));
+    MOV(64, R(RSCRATCH2), Imm64(static_cast<u64>(m_ppc_state.feature_flags) << 32 | after));
     PUSH(RSCRATCH2);
   }
 
@@ -609,7 +609,7 @@ void Jit64::WriteExitDestInRSCRATCH(bool bl, u32 after)
 
   if (bl)
   {
-    MOV(64, R(RSCRATCH2), Imm64(u64(m_ppc_state.feature_flags) << 32 | after));
+    MOV(64, R(RSCRATCH2), Imm64(static_cast<u64>(m_ppc_state.feature_flags) << 32 | after));
     PUSH(RSCRATCH2);
   }
 

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -63,7 +63,7 @@ void Jit64AsmRoutineManager::Generate()
   MOV(64, PPCSTATE(stored_stack_pointer), R(RSP));
 
   // something that can't pass the BLR test
-  MOV(64, MDisp(RSP, 8), Imm32((u32)-1));
+  MOV(64, MDisp(RSP, 8), Imm32(static_cast<u32>(-1)));
 
   const u8* outerLoop = GetCodePtr();
   ABI_PushRegistersAndAdjustStack({}, 0);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -282,7 +282,7 @@ void Jit64::fp_arith(UGeckoInstruction inst)
   RCOpArg Rarg2 = fpr.Use(arg2, RCMode::Read);
   RegCache::Realize(Rd, Ra, Rarg2);
 
-  X64Reg dest = X64Reg(Rd);
+  X64Reg dest = static_cast<X64Reg>(Rd);
   if (preserve_inputs && (a == d || arg2 == d))
     dest = XMM1;
   if (round_rhs)
@@ -408,12 +408,12 @@ void Jit64::fmaddXX(UGeckoInstruction inst)
     {
       result_xmm_guard = fpr.Scratch();
       RegCache::Realize(Ra, Rb, Rc, Rd, xmm2_guard, result_xmm_guard);
-      result_xmm = Gen::X64Reg(result_xmm_guard);
+      result_xmm = static_cast<Gen::X64Reg>(result_xmm_guard);
     }
     else
     {
       RegCache::Realize(Ra, Rb, Rc, Rd, xmm2_guard);
-      result_xmm = packed ? Gen::X64Reg(Rd) : XMM0;
+      result_xmm = packed ? static_cast<Gen::X64Reg>(Rd) : XMM0;
     }
   }
   else

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -305,7 +305,7 @@ void Jit64::reg_imm(UGeckoInstruction inst)
     // occasionally used as MOV - emulate, with immediate propagation
     if (a != 0 && d != a && gpr.IsImm(a))
     {
-      gpr.SetImmediate32(d, gpr.Imm32(a) + (u32)(s32)inst.SIMM_16);
+      gpr.SetImmediate32(d, gpr.Imm32(a) + static_cast<u32>((s32)inst.SIMM_16));
     }
     else if (a != 0 && d != a && inst.SIMM_16 == 0)
     {
@@ -316,11 +316,11 @@ void Jit64::reg_imm(UGeckoInstruction inst)
     }
     else
     {
-      regimmop(d, a, false, (u32)(s32)inst.SIMM_16, Add, &XEmitter::ADD);  // addi
+      regimmop(d, a, false, static_cast<u32>((s32)inst.SIMM_16), Add, &XEmitter::ADD);  // addi
     }
     break;
   case 15:  // addis
-    regimmop(d, a, false, (u32)inst.SIMM_16 << 16, Add, &XEmitter::ADD);
+    regimmop(d, a, false, static_cast<u32>(inst.SIMM_16) << 16, Add, &XEmitter::ADD);
     break;
   case 24:  // ori
   case 25:  // oris
@@ -358,10 +358,10 @@ void Jit64::reg_imm(UGeckoInstruction inst)
     break;
   }
   case 12:  // addic
-    regimmop(d, a, false, (u32)(s32)inst.SIMM_16, Add, &XEmitter::ADD, false, true);
+    regimmop(d, a, false, static_cast<u32>((s32)inst.SIMM_16), Add, &XEmitter::ADD, false, true);
     break;
   case 13:  // addic_rc
-    regimmop(d, a, true, (u32)(s32)inst.SIMM_16, Add, &XEmitter::ADD, true, true);
+    regimmop(d, a, true, static_cast<u32>((s32)inst.SIMM_16), Add, &XEmitter::ADD, true, true);
     break;
   default:
     FALLBACK_IF(true);
@@ -593,7 +593,7 @@ void Jit64::cmpXX(UGeckoInstruction inst)
   // cmpi
   case 11:
     signedCompare = true;
-    comparand = RCOpArg::Imm32((u32)(s32)(s16)inst.UIMM);
+    comparand = RCOpArg::Imm32(static_cast<u32>(static_cast<s32>((s16)inst.UIMM)));
     break;
 
   default:
@@ -604,11 +604,11 @@ void Jit64::cmpXX(UGeckoInstruction inst)
   if (gpr.IsImm(a) && comparand.IsImm())
   {
     // Both registers contain immediate values, so we can pre-compile the compare result
-    s64 compareResult = signedCompare ? (s64)gpr.SImm32(a) - (s64)comparand.SImm32() :
-                                        (u64)gpr.Imm32(a) - (u64)comparand.Imm32();
-    if (compareResult == (s32)compareResult)
+    s64 compareResult = signedCompare ? static_cast<s64>(gpr.SImm32(a)) - static_cast<s64>(comparand.SImm32()) :
+                                        static_cast<u64>(gpr.Imm32(a)) - static_cast<u64>(comparand.Imm32());
+    if (compareResult == static_cast<s32>(compareResult))
     {
-      MOV(64, PPCSTATE_CR(crf), Imm32((u32)compareResult));
+      MOV(64, PPCSTATE_CR(crf), Imm32(static_cast<u32>(compareResult)));
     }
     else
     {
@@ -767,7 +767,7 @@ void Jit64::boolX(UGeckoInstruction inst)
       {
         XOR(32, Ra, Imm32(imm));
       }
-      else if (s32(imm) >= -128 && s32(imm) <= 127)
+      else if (static_cast<s32>(imm) >= -128 && static_cast<s32>(imm) <= 127)
       {
         MOV(32, Ra, Rj);
         XOR(32, Ra, Imm32(imm));
@@ -811,7 +811,7 @@ void Jit64::boolX(UGeckoInstruction inst)
           {
             AND(32, Ra, Imm32(imm));
           }
-          else if (s32(imm) >= -128 && s32(imm) <= 127)
+          else if (static_cast<s32>(imm) >= -128 && static_cast<s32>(imm) <= 127)
           {
             MOV(32, Ra, Rj);
             AND(32, Ra, Imm32(imm));
@@ -857,7 +857,7 @@ void Jit64::boolX(UGeckoInstruction inst)
         {
           OR(32, Ra, Imm32(imm));
         }
-        else if (s32(imm) >= -128 && s32(imm) <= 127)
+        else if (static_cast<s32>(imm) >= -128 && static_cast<s32>(imm) <= 127)
         {
           MOV(32, Ra, Rj);
           OR(32, Ra, Imm32(imm));
@@ -1081,7 +1081,7 @@ void Jit64::extsXx(UGeckoInstruction inst)
 
   if (gpr.IsImm(s))
   {
-    gpr.SetImmediate32(a, (u32)(s32)(size == 16 ? (s16)gpr.Imm32(s) : (s8)gpr.Imm32(s)));
+    gpr.SetImmediate32(a, static_cast<u32>((s32)(size == 16 ? static_cast<s16>(gpr.Imm32(s)) : static_cast<s8>(gpr.Imm32(s)))));
   }
   else
   {
@@ -1168,9 +1168,9 @@ void Jit64::subfx(UGeckoInstruction inst)
     s32 i = gpr.SImm32(b), j = gpr.SImm32(a);
     gpr.SetImmediate32(d, i - j);
     if (carry)
-      FinalizeCarry(j == 0 || Interpreter::Helper_Carry((u32)i, 0u - (u32)j));
+      FinalizeCarry(j == 0 || Interpreter::Helper_Carry(static_cast<u32>(i), 0u - static_cast<u32>(j)));
     if (inst.OE)
-      GenerateConstantOverflow((s64)i - (s64)j);
+      GenerateConstantOverflow(static_cast<s64>(i) - static_cast<s64>(j));
   }
   else if (gpr.IsImm(a))
   {
@@ -1266,7 +1266,7 @@ void Jit64::MultiplyImmediate(u32 imm, int a, int d, bool overflow)
     return;
   }
 
-  if (imm == (u32)-1)
+  if (imm == static_cast<u32>(-1))
   {
     if (d != a)
       MOV(32, Rd, Ra);
@@ -1341,7 +1341,7 @@ void Jit64::mullwx(UGeckoInstruction inst)
     s32 i = gpr.SImm32(a), j = gpr.SImm32(b);
     gpr.SetImmediate32(d, i * j);
     if (inst.OE)
-      GenerateConstantOverflow((s64)i * (s64)j);
+      GenerateConstantOverflow(static_cast<s64>(i) * static_cast<s64>(j));
   }
   else if (gpr.IsImm(a) || gpr.IsImm(b))
   {
@@ -1388,9 +1388,9 @@ void Jit64::mulhwXx(UGeckoInstruction inst)
   if (gpr.IsImm(a, b))
   {
     if (sign)
-      gpr.SetImmediate32(d, (u32)((u64)(((s64)gpr.SImm32(a) * (s64)gpr.SImm32(b))) >> 32));
+      gpr.SetImmediate32(d, static_cast<u32>(static_cast<u64>(((s64)gpr.SImm32(a) * (s64)gpr.SImm32(b))) >> 32));
     else
-      gpr.SetImmediate32(d, (u32)(((u64)gpr.Imm32(a) * (u64)gpr.Imm32(b)) >> 32));
+      gpr.SetImmediate32(d, static_cast<u32>((static_cast<u64>(gpr.Imm32(a)) * static_cast<u64>(gpr.Imm32(b))) >> 32));
   }
   else if (sign)
   {
@@ -1562,7 +1562,7 @@ void Jit64::divwx(UGeckoInstruction inst)
   if (gpr.IsImm(a, b))
   {
     s32 i = gpr.SImm32(a), j = gpr.SImm32(b);
-    if (j == 0 || (i == (s32)0x80000000 && j == -1))
+    if (j == 0 || (i == static_cast<s32>(0x80000000) && j == -1))
     {
       const u32 result = i < 0 ? 0xFFFFFFFF : 0x00000000;
       gpr.SetImmediate32(d, result);
@@ -1886,7 +1886,7 @@ void Jit64::addx(UGeckoInstruction inst)
     if (carry)
       FinalizeCarry(Interpreter::Helper_Carry(i, j));
     if (inst.OE)
-      GenerateConstantOverflow((s64)i + (s64)j);
+      GenerateConstantOverflow(static_cast<s64>(i) + static_cast<s64>(j));
   }
   else if (gpr.IsImm(a) || gpr.IsImm(b))
   {
@@ -2544,7 +2544,7 @@ void Jit64::srawx(UGeckoInstruction inst)
     {
       amount &= 0x1F;
       gpr.SetImmediate32(a, i >> amount);
-      FinalizeCarry(amount != 0 && i < 0 && (u32(i) << (32 - amount)));
+      FinalizeCarry(amount != 0 && i < 0 && (static_cast<u32>(i) << (32 - amount)));
     }
   }
   else if (gpr.IsImm(b))
@@ -2656,7 +2656,7 @@ void Jit64::srawix(UGeckoInstruction inst)
   {
     s32 imm = gpr.SImm32(s);
     gpr.SetImmediate32(a, imm >> amount);
-    FinalizeCarry(amount != 0 && imm < 0 && (u32(imm) << (32 - amount)));
+    FinalizeCarry(amount != 0 && imm < 0 && (static_cast<u32>(imm) << (32 - amount)));
   }
   else if (amount != 0)
   {
@@ -2756,7 +2756,7 @@ void Jit64::twX(UGeckoInstruction inst)
   {
     RCOpArg Ra = gpr.UseNoImm(a, RCMode::Read);
     RegCache::Realize(Ra);
-    CMP(32, Ra, Imm32((s32)(s16)inst.SIMM_16));
+    CMP(32, Ra, Imm32((s32)static_cast<s16>(inst.SIMM_16)));
   }
   else  // tw
   {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -147,7 +147,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
     }
     else
     {
-      opAddress = RCOpArg::Imm32((u32)(s32)inst.SIMM_16);
+      opAddress = RCOpArg::Imm32(static_cast<u32>((s32)inst.SIMM_16));
     }
   }
   else if (update && ((a == 0) || (d == a)))
@@ -191,7 +191,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
         if (!use_constant_offset)
           ADD(32, opAddress, Rb);
         else if (update)
-          ADD(32, opAddress, Imm32((u32)offset));
+          ADD(32, opAddress, Imm32(static_cast<u32>(offset)));
         else
           loadOffset = offset;
       }
@@ -204,7 +204,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
         RegCache::Realize(opAddress, Ra, Rb);
 
         if (use_constant_offset)
-          MOV_sum(32, RSCRATCH2, Ra, Imm32((u32)offset));
+          MOV_sum(32, RSCRATCH2, Ra, Imm32(static_cast<u32>(offset)));
         else
           MOV_sum(32, RSCRATCH2, Ra, Rb);
       }
@@ -306,7 +306,7 @@ void Jit64::dcbx(UGeckoInstruction inst)
     {
       const X64Reg bw_reg_a = reg_cycle_count, bw_reg_b = reg_downcount;
       const BitSet32 bw_caller_save = (CallerSavedRegistersInUse() | BitSet32{RSCRATCH2}) &
-                                      ~BitSet32{int(bw_reg_a), int(bw_reg_b)};
+                                      ~BitSet32{static_cast<int>(bw_reg_a), static_cast<int>(bw_reg_b)};
 
       MOV(64, R(bw_reg_a), ImmPtr(&m_branch_watch));
       MOVZX(32, 8, bw_reg_b, MDisp(bw_reg_a, Core::BranchWatch::GetOffsetOfRecordingActive()));
@@ -388,10 +388,10 @@ void Jit64::dcbx(UGeckoInstruction inst)
     SetJumpTarget(bat_lookup_failed);
 
   BitSet32 registersInUse = CallerSavedRegistersInUse();
-  registersInUse[X64Reg(tmp)] = false;
-  registersInUse[X64Reg(effective_address)] = false;
+  registersInUse[static_cast<X64Reg>(tmp)] = false;
+  registersInUse[static_cast<X64Reg>(effective_address)] = false;
   if (make_loop)
-    registersInUse[X64Reg(loop_counter)] = false;
+    registersInUse[static_cast<X64Reg>(loop_counter)] = false;
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
   if (make_loop)
   {
@@ -501,7 +501,7 @@ void Jit64::stX(UGeckoInstruction inst)
 
   int s = inst.RS;
   int a = inst.RA;
-  s32 offset = (s32)(s16)inst.SIMM_16;
+  s32 offset = (s32)static_cast<s16>(inst.SIMM_16);
   bool update = (inst.OPCD & 1) && offset;
 
   if (!a && update)
@@ -568,7 +568,7 @@ void Jit64::stX(UGeckoInstruction inst)
                       SAFE_LOADSTORE_CLOBBER_RSCRATCH_INSTEAD_OF_ADDR);
 
     if (update)
-      ADD(32, Ra, Imm32((u32)offset));
+      ADD(32, Ra, Imm32(static_cast<u32>(offset)));
   }
 }
 
@@ -638,7 +638,7 @@ void Jit64::lmw(UGeckoInstruction inst)
   {
     RCOpArg Ra = a ? gpr.Use(a, RCMode::Read) : RCOpArg::Imm32(0);
     RegCache::Realize(Ra);
-    MOV_sum(32, RSCRATCH2, Ra, Imm32((u32)(s32)inst.SIMM_16));
+    MOV_sum(32, RSCRATCH2, Ra, Imm32(static_cast<u32>((s32)inst.SIMM_16)));
   }
   for (int i = d; i < 32; i++)
   {
@@ -673,7 +673,7 @@ void Jit64::stmw(UGeckoInstruction inst)
       MOV(32, R(RSCRATCH2), Ri);
       Ri = RCOpArg::R(RSCRATCH2);
     }
-    SafeWriteRegToReg(Ri, RSCRATCH, 32, (i - d) * 4 + (u32)(s32)inst.SIMM_16,
+    SafeWriteRegToReg(Ri, RSCRATCH, 32, (i - d) * 4 + static_cast<u32>((s32)inst.SIMM_16),
                       CallerSavedRegistersInUse());
   }
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -56,9 +56,9 @@ void Jit64::lfXXX(UGeckoInstruction inst)
   else
   {
     if (update)
-      ADD(32, addr, Imm32((s32)(s16)inst.SIMM_16));
+      ADD(32, addr, Imm32((s32)static_cast<s16>(inst.SIMM_16)));
     else
-      offset = (s16)inst.SIMM_16;
+      offset = static_cast<s16>(inst.SIMM_16);
   }
 
   RCMode Rd_mode = !single ? RCMode::ReadWrite : RCMode::Write;
@@ -98,7 +98,7 @@ void Jit64::stfXXX(UGeckoInstruction inst)
   int s = inst.RS;
   int a = inst.RA;
   int b = inst.RB;
-  s32 imm = (s16)inst.SIMM_16;
+  s32 imm = static_cast<s16>(inst.SIMM_16);
   int accessSize = single ? 32 : 64;
 
   FALLBACK_IF(update && jo.memcheck && indexed && a == b);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -37,7 +37,7 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
 
   RCX64Reg scratch_guard = gpr.Scratch(RSCRATCH_EXTRA);
   RCOpArg Ra = update ? gpr.Bind(a, RCMode::ReadWrite) : gpr.Use(a, RCMode::Read);
-  RCOpArg Rb = indexed ? gpr.Use(b, RCMode::Read) : RCOpArg::Imm32((u32)offset);
+  RCOpArg Rb = indexed ? gpr.Use(b, RCMode::Read) : RCOpArg::Imm32(static_cast<u32>(offset));
   RCOpArg Rs = fpr.Use(s, RCMode::Read);
   RegCache::Realize(scratch_guard, Ra, Rb, Rs);
 
@@ -126,7 +126,7 @@ void Jit64::psq_lXX(UGeckoInstruction inst)
 
   RCX64Reg scratch_guard = gpr.Scratch(RSCRATCH_EXTRA);
   RCX64Reg Ra = gpr.Bind(a, update ? RCMode::ReadWrite : RCMode::Read);
-  RCOpArg Rb = indexed ? gpr.Use(b, RCMode::Read) : RCOpArg::Imm32((u32)offset);
+  RCOpArg Rb = indexed ? gpr.Use(b, RCMode::Read) : RCOpArg::Imm32(static_cast<u32>(offset));
   RCX64Reg Rs = fpr.Bind(s, RCMode::Write);
   RegCache::Realize(scratch_guard, Ra, Rb, Rs);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -520,9 +520,9 @@ void Jit64::mtcrf(UGeckoInstruction inst)
         {
           u8 newcr = (gpr.Imm32(inst.RS) >> (28 - (i * 4))) & 0xF;
           u64 newcrval = PowerPC::ConditionRegister::PPCToInternal(newcr);
-          if ((s64)newcrval == (s32)newcrval)
+          if (static_cast<s64>(newcrval) == static_cast<s32>(newcrval))
           {
-            MOV(64, CROffset(i), Imm32((s32)newcrval));
+            MOV(64, CROffset(i), Imm32(static_cast<s32>(newcrval)));
           }
           else
           {

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -649,7 +649,7 @@ float RegCache::ScoreRegister(X64Reg xreg) const
     u32 regs_in_count = CountRegsIn(preg, lookahead).Count();
     // Totally ad-hoc heuristic to bias based on how many other registers we'll need
     // before this one gets used again.
-    score += 1 + 2 * (5 - log2f(1 + (float)regs_in_count));
+    score += 1 + 2 * (5 - log2f(1 + static_cast<float>(regs_in_count)));
   }
 
   return score;

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -176,7 +176,7 @@ bool EmuCodeBlock::UnsafeLoadToReg(X64Reg reg_value, OpArg opAddress, int access
     // offsets with the wrong sign, so whatever.  Since the original code
     // *could* try to wrap an address around, however, this is the correct
     // place to address the issue.)
-    if ((u32)offset >= 0x1000)
+    if (static_cast<u32>(offset) >= 0x1000)
     {
       // This method can potentially clobber the address if it shares a register
       // with the load target. In this case we can just subtract offset from the
@@ -535,12 +535,12 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
   {
     if (flags & SAFE_LOADSTORE_CLOBBER_RSCRATCH_INSTEAD_OF_ADDR)
     {
-      LEA(32, RSCRATCH, MDisp(reg_addr, (u32)offset));
+      LEA(32, RSCRATCH, MDisp(reg_addr, static_cast<u32>(offset)));
       reg_addr = RSCRATCH;
     }
     else
     {
-      ADD(32, R(reg_addr), Imm32((u32)offset));
+      ADD(32, R(reg_addr), Imm32(static_cast<u32>(offset)));
     }
   }
 

--- a/Source/Core/Core/PowerPC/JitCommon/DivUtils.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/DivUtils.cpp
@@ -64,7 +64,7 @@ UnsignedMagic UnsignedDivisionConstants(u32 divisor)
   u32 max_quotient = multiplier >> shift;
 
   // Test for failure in round-up method
-  u32 round_up = (u64(multiplier + 1) * (max_quotient * divisor - 1)) >> (shift + 32);
+  u32 round_up = (static_cast<u64>(multiplier + 1) * (max_quotient * divisor - 1)) >> (shift + 32);
   bool fast = round_up == max_quotient - 1;
 
   if (fast)
@@ -72,7 +72,7 @@ UnsignedMagic UnsignedDivisionConstants(u32 divisor)
     multiplier++;
 
     // Use smallest magic number and shift amount possible
-    u32 trailing_zeroes = std::min(shift, u32(std::countr_zero(multiplier)));
+    u32 trailing_zeroes = std::min(shift, static_cast<u32>(std::countr_zero(multiplier)));
     multiplier >>= trailing_zeroes;
     shift -= trailing_zeroes;
   }

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1544,7 +1544,7 @@ void MMU::UpdateBATs(BatTable& bat_table, u32 base_spr)
       // implemented this way for invalid BATs as well.
       WARN_LOG_FMT(POWERPC, "Bad BAT setup: BPRN overlaps BL");
     }
-    if (!Common::IsValidLowMask((u32)batu.BL))
+    if (!Common::IsValidLowMask(static_cast<u32>(batu.BL)))
     {
       // With a valid BAT, the simplest way of masking is
       // (input & ~BL_mask) for matching and (input & BL_mask) for

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -45,7 +45,7 @@ constexpr std::array<u32, 128> s_way_from_plru = [] {
   {
     std::array<u32, 7> b{};
     for (size_t i = 0; i < b.size(); i++)
-      b[i] = u32(m & (size_t{1} << i));
+      b[i] = static_cast<u32>(m & (size_t{1} << i));
 
     u32 w = 0;
     if (b[0] != 0)

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -260,7 +260,7 @@ struct SlotWithTimestamp
 // returns first slot number not in the vector, or -1 if all are in the vector
 static int GetEmptySlot(const std::vector<SlotWithTimestamp>& used_slots)
 {
-  for (int i = 1; i <= (int)NUM_STATES; i++)
+  for (int i = 1; i <= static_cast<int>(NUM_STATES); i++)
   {
     if (!Common::Contains(used_slots, i, &SlotWithTimestamp::slot))
       return i;
@@ -298,7 +298,7 @@ static std::vector<SlotWithTimestamp> GetUsedSlotsWithTimestamp()
 {
   std::vector<SlotWithTimestamp> result;
   StateHeader header;
-  for (int i = 1; i <= (int)NUM_STATES; i++)
+  for (int i = 1; i <= static_cast<int>(NUM_STATES); i++)
   {
     std::string filename = MakeStateFilename(i);
     if (File::Exists(filename))
@@ -689,7 +689,7 @@ static bool DecompressLZ4(std::vector<u8>& raw_buffer, u64 size, File::IOFile& f
     }
 
     u32 max_decompress_size =
-        static_cast<u32>(std::min((u64)LZ4_MAX_INPUT_SIZE, size - total_bytes_read));
+        static_cast<u32>(std::min(static_cast<u64>(LZ4_MAX_INPUT_SIZE), size - total_bytes_read));
 
     int bytes_read = LZ4_decompress_safe(
         compressed_data.get(), reinterpret_cast<char*>(raw_buffer.data()) + total_bytes_read,

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -330,7 +330,7 @@ std::string SystemUpdater::GetDeviceId()
   u32 ios_device_id;
   if (m_ios.GetESCore().GetDeviceId(&ios_device_id) < 0)
     return "";
-  return std::to_string((u64(1) << 32) | ios_device_id);
+  return std::to_string((static_cast<u64>(1) << 32) | ios_device_id);
 }
 
 class OnlineSystemUpdater final : public SystemUpdater

--- a/Source/Core/DiscIO/CISOBlob.cpp
+++ b/Source/Core/DiscIO/CISOBlob.cpp
@@ -69,7 +69,7 @@ bool CISOFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
     if (block < CISO_MAP_SIZE && UNUSED_BLOCK_ID != m_ciso_map[block])
     {
       // calculate the base address
-      u64 const file_off = CISO_HEADER_SIZE + m_ciso_map[block] * (u64)m_block_size + data_offset;
+      u64 const file_off = CISO_HEADER_SIZE + m_ciso_map[block] * static_cast<u64>(m_block_size) + data_offset;
 
       if (!(m_file.Seek(file_off, File::SeekOrigin::Begin) &&
             m_file.ReadArray(out_ptr, bytes_to_read)))

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -95,7 +95,7 @@ u64 CompressedBlobReader::GetBlockCompressedSize(u64 block_num) const
 bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
 {
   bool uncompressed = false;
-  u32 comp_block_size = (u32)GetBlockCompressedSize(block_num);
+  u32 comp_block_size = static_cast<u32>(GetBlockCompressedSize(block_num));
   u64 offset = m_block_pointers[block_num] + m_data_offset;
 
   if (offset & (1ULL << 63))
@@ -300,7 +300,7 @@ bool ConvertToGCZ(BlobReader* infile, const std::string& infile_path,
   header.data_size = infile->GetDataSize();
 
   // round upwards!
-  header.num_blocks = (u32)((header.data_size + (block_size - 1)) / block_size);
+  header.num_blocks = static_cast<u32>((header.data_size + (block_size - 1)) / block_size);
 
   std::vector<u64> offsets(header.num_blocks);
   std::vector<u32> hashes(header.num_blocks);

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -1150,9 +1150,9 @@ void DirectoryBlobPartition::BuildFST(std::vector<FSTBuilderNode> root_nodes, u6
   ASSERT(Common::AlignUp(name_offset, 1ull << m_address_shift) == name_table_size);
 
   // write FST size and location
-  Write32((u32)(fst_address >> m_address_shift), 0x0424, disc_header);
-  Write32((u32)(fst_data.size() >> m_address_shift), 0x0428, disc_header);
-  Write32((u32)(fst_data.size() >> m_address_shift), 0x042c, disc_header);
+  Write32(static_cast<u32>(fst_address >> m_address_shift), 0x0424, disc_header);
+  Write32(static_cast<u32>(fst_data.size() >> m_address_shift), 0x0428, disc_header);
+  Write32(static_cast<u32>(fst_data.size() >> m_address_shift), 0x042c, disc_header);
 
   m_contents.Add(fst_address, std::move(fst_data));
 
@@ -1169,10 +1169,10 @@ void DirectoryBlobPartition::WriteEntryData(std::vector<u8>* fst_data, u32* entr
   (*fst_data)[(*entry_offset)++] = (name_offset >> 8) & 0xff;
   (*fst_data)[(*entry_offset)++] = (name_offset)&0xff;
 
-  Write32((u32)(data_offset >> address_shift), *entry_offset, fst_data);
+  Write32(static_cast<u32>(data_offset >> address_shift), *entry_offset, fst_data);
   *entry_offset += 4;
 
-  Write32((u32)length, *entry_offset, fst_data);
+  Write32(static_cast<u32>(length), *entry_offset, fst_data);
   *entry_offset += 4;
 }
 
@@ -1181,7 +1181,7 @@ void DirectoryBlobPartition::WriteEntryName(std::vector<u8>* fst_data, u32* name
 {
   strncpy((char*)&(*fst_data)[*name_offset + name_table_offset], name.c_str(), name.length() + 1);
 
-  *name_offset += (u32)(name.length() + 1);
+  *name_offset += static_cast<u32>(name.length() + 1);
 }
 
 void DirectoryBlobPartition::WriteDirectory(std::vector<u8>* fst_data,

--- a/Source/Core/DiscIO/FileBlob.cpp
+++ b/Source/Core/DiscIO/FileBlob.cpp
@@ -84,7 +84,7 @@ bool ConvertToPlain(BlobReader* infile, const std::string& infile_path,
     if (i % progress_monitor == 0)
     {
       const bool was_cancelled =
-          !callback(Common::GetStringT("Unpacking"), (float)i / (float)num_buffers);
+          !callback(Common::GetStringT("Unpacking"), static_cast<float>(i) / static_cast<float>(num_buffers));
       if (was_cancelled)
       {
         success = false;

--- a/Source/Core/DiscIO/NFSBlob.cpp
+++ b/Source/Core/DiscIO/NFSBlob.cpp
@@ -120,7 +120,7 @@ u64 NFSFileReader::CalculateExpectedDataSize(const std::vector<NFSLBARange>& lba
   for (const NFSLBARange& range : lba_ranges)
     greatest_block_index = std::max(greatest_block_index, range.start_block + range.num_blocks);
 
-  return u64(greatest_block_index) * BLOCK_SIZE;
+  return static_cast<u64>(greatest_block_index) * BLOCK_SIZE;
 }
 
 std::unique_ptr<NFSFileReader> NFSFileReader::Create(File::IOFile first_file,

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -356,7 +356,7 @@ static void ApplyPatchToFile(const Patch& patch, const File& file_patch,
                              DiscIO::FSTBuilderNode* file_node)
 {
   // The last two bits of the offset seem to be ignored by actual Riivolution.
-  ApplyPatchToFile(patch, file_node, file_patch.m_external, file_patch.m_offset & ~u64(3),
+  ApplyPatchToFile(patch, file_node, file_patch.m_external, file_patch.m_offset & ~static_cast<u64>(3),
                    file_patch.m_fileoffset, file_patch.m_length, file_patch.m_resize);
 }
 

--- a/Source/Core/DiscIO/Volume.cpp
+++ b/Source/Core/DiscIO/Volume.cpp
@@ -117,7 +117,7 @@ static std::unique_ptr<VolumeWAD> TryCreateWAD(std::unique_ptr<BlobReader>& read
   // Check for WAD
   // 0x206962 for boot2 wads
   const std::optional<u32> wad_magic = reader->ReadSwapped<u32>(0x02);
-  if (wad_magic == u32(0x00204973) || wad_magic == u32(0x00206962))
+  if (wad_magic == static_cast<u32>(0x00204973) || wad_magic == static_cast<u32>(0x00206962))
     return std::make_unique<VolumeWAD>(std::move(reader));
 
   // No known magic words found

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -41,8 +41,8 @@ VolumeWii::VolumeWii(std::unique_ptr<BlobReader> reader)
 {
   ASSERT(m_reader);
 
-  m_has_hashes = m_reader->ReadSwapped<u8>(0x60) == u8(0);
-  m_has_encryption = m_reader->ReadSwapped<u8>(0x61) == u8(0);
+  m_has_hashes = m_reader->ReadSwapped<u8>(0x60) == static_cast<u8>(0);
+  m_has_encryption = m_reader->ReadSwapped<u8>(0x61) == static_cast<u8>(0);
 
   if (m_has_encryption && !m_has_hashes)
     ERROR_LOG_FMT(DISCIO, "Wii disc has encryption but no hashes! This probably won't work well");

--- a/Source/Core/DolphinQt/CheatSearchWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchWidget.cpp
@@ -622,7 +622,7 @@ void CheatSearchWidget::RecreateGUITable()
 
   const size_t result_count = m_session->GetResultCount();
   const bool too_many_results = result_count > TABLE_MAX_ROWS;
-  const int result_count_to_display = int(too_many_results ? TABLE_MAX_ROWS : result_count);
+  const int result_count_to_display = static_cast<int>(too_many_results ? TABLE_MAX_ROWS : result_count);
   m_address_table->setRowCount(result_count_to_display);
 
   for (int i = 0; i < result_count_to_display; ++i)

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -196,8 +196,8 @@ void ControlExpressionSyntaxHighlighter::Highlight(QTextDocument* document)
 
     for (auto& token : tokens)
     {
-      int token_length = int(token.string_length);
-      int token_start = int(token.string_position) - block_position;
+      int token_length = static_cast<int>(token.string_length);
+      int token_start = static_cast<int>(token.string_position) - block_position;
       if (token_start < 0)
       {
         token_length += token_start;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -169,7 +169,7 @@ SquareIndicator::SquareIndicator()
 MixedTriggersIndicator::MixedTriggersIndicator(ControllerEmu::MixedTriggers& group) : m_group(group)
 {
   setSizePolicy(QSizePolicy::Policy::Expanding, QSizePolicy::Policy::Ignored);
-  setFixedHeight(TRIGGER_INDICATOR_HEIGHT * int(group.GetTriggerCount()) + 1);
+  setFixedHeight(TRIGGER_INDICATOR_HEIGHT * static_cast<int>(group.GetTriggerCount()) + 1);
 }
 
 namespace

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -272,7 +272,7 @@ void WiimoteControllersWidget::LoadSettings(Core::State state)
   for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
     SignalBlocking(m_wiimote_boxes[i])
-        ->setCurrentIndex(int(Config::Get(Config::GetInfoForWiimoteSource(int(i)))));
+        ->setCurrentIndex(static_cast<int>(Config::Get(Config::GetInfoForWiimoteSource(static_cast<int>(i)))));
   }
   SignalBlocking(m_wiimote_real_balance_board)
       ->setChecked(Config::Get(Config::WIIMOTE_BB_SOURCE) == WiimoteSource::Real);
@@ -349,7 +349,7 @@ void WiimoteControllersWidget::SaveSettings()
     for (size_t i = 0; i < m_wiimote_groups.size(); i++)
     {
       const int index = m_wiimote_boxes[i]->currentIndex();
-      Config::SetBaseOrCurrent(Config::GetInfoForWiimoteSource(int(i)), WiimoteSource(index));
+      Config::SetBaseOrCurrent(Config::GetInfoForWiimoteSource(static_cast<int>(i)), static_cast<WiimoteSource>(index));
     }
   }
 

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -138,16 +138,16 @@ void MemoryWidget::CreateWidgets()
   m_input_combo = new QComboBox;
   m_input_combo->setMaxVisibleItems(20);
   // Order here determines combo list order.
-  m_input_combo->addItem(tr("Hex Byte String"), int(Type::HexString));
-  m_input_combo->addItem(tr("ASCII"), int(Type::ASCII));
-  m_input_combo->addItem(tr("Float"), int(Type::Float32));
-  m_input_combo->addItem(tr("Double"), int(Type::Double));
-  m_input_combo->addItem(tr("Unsigned 8"), int(Type::Unsigned8));
-  m_input_combo->addItem(tr("Unsigned 16"), int(Type::Unsigned16));
-  m_input_combo->addItem(tr("Unsigned 32"), int(Type::Unsigned32));
-  m_input_combo->addItem(tr("Signed 8"), int(Type::Signed8));
-  m_input_combo->addItem(tr("Signed 16"), int(Type::Signed16));
-  m_input_combo->addItem(tr("Signed 32"), int(Type::Signed32));
+  m_input_combo->addItem(tr("Hex Byte String"), static_cast<int>(Type::HexString));
+  m_input_combo->addItem(tr("ASCII"), static_cast<int>(Type::ASCII));
+  m_input_combo->addItem(tr("Float"), static_cast<int>(Type::Float32));
+  m_input_combo->addItem(tr("Double"), static_cast<int>(Type::Double));
+  m_input_combo->addItem(tr("Unsigned 8"), static_cast<int>(Type::Unsigned8));
+  m_input_combo->addItem(tr("Unsigned 16"), static_cast<int>(Type::Unsigned16));
+  m_input_combo->addItem(tr("Unsigned 32"), static_cast<int>(Type::Unsigned32));
+  m_input_combo->addItem(tr("Signed 8"), static_cast<int>(Type::Signed8));
+  m_input_combo->addItem(tr("Signed 16"), static_cast<int>(Type::Signed16));
+  m_input_combo->addItem(tr("Signed 32"), static_cast<int>(Type::Signed32));
 
   // Search Options
   auto* search_group = new QGroupBox(tr("Search"));
@@ -190,18 +190,18 @@ void MemoryWidget::CreateWidgets()
 
   m_display_combo = new QComboBox;
   m_display_combo->setMaxVisibleItems(20);
-  m_display_combo->addItem(tr("Hex 8"), int(Type::Hex8));
-  m_display_combo->addItem(tr("Hex 16"), int(Type::Hex16));
-  m_display_combo->addItem(tr("Hex 32"), int(Type::Hex32));
-  m_display_combo->addItem(tr("Unsigned 8"), int(Type::Unsigned8));
-  m_display_combo->addItem(tr("Unsigned 16"), int(Type::Unsigned16));
-  m_display_combo->addItem(tr("Unsigned 32"), int(Type::Unsigned32));
-  m_display_combo->addItem(tr("Signed 8"), int(Type::Signed8));
-  m_display_combo->addItem(tr("Signed 16"), int(Type::Signed16));
-  m_display_combo->addItem(tr("Signed 32"), int(Type::Signed32));
-  m_display_combo->addItem(tr("ASCII"), int(Type::ASCII));
-  m_display_combo->addItem(tr("Float"), int(Type::Float32));
-  m_display_combo->addItem(tr("Double"), int(Type::Double));
+  m_display_combo->addItem(tr("Hex 8"), static_cast<int>(Type::Hex8));
+  m_display_combo->addItem(tr("Hex 16"), static_cast<int>(Type::Hex16));
+  m_display_combo->addItem(tr("Hex 32"), static_cast<int>(Type::Hex32));
+  m_display_combo->addItem(tr("Unsigned 8"), static_cast<int>(Type::Unsigned8));
+  m_display_combo->addItem(tr("Unsigned 16"), static_cast<int>(Type::Unsigned16));
+  m_display_combo->addItem(tr("Unsigned 32"), static_cast<int>(Type::Unsigned32));
+  m_display_combo->addItem(tr("Signed 8"), static_cast<int>(Type::Signed8));
+  m_display_combo->addItem(tr("Signed 16"), static_cast<int>(Type::Signed16));
+  m_display_combo->addItem(tr("Signed 32"), static_cast<int>(Type::Signed32));
+  m_display_combo->addItem(tr("ASCII"), static_cast<int>(Type::ASCII));
+  m_display_combo->addItem(tr("Float"), static_cast<int>(Type::Float32));
+  m_display_combo->addItem(tr("Double"), static_cast<int>(Type::Double));
 
   m_align_combo = new QComboBox;
   // i18n: "Fixed" here means that the alignment is always the same
@@ -842,10 +842,10 @@ MemoryWidget::TargetAddress MemoryWidget::GetTargetAddress() const
   const s32 offset = m_search_offset->text().toInt(&target.is_good_offset, 16);
   const u32 neg_offset = offset != std::numeric_limits<s32>::min() ?
                              -offset :
-                             u32(std::numeric_limits<s32>::max()) + 1;
+                             static_cast<u32>(std::numeric_limits<s32>::max()) + 1;
   target.is_good_offset |= m_search_offset->text().isEmpty();
   target.is_good_offset &= offset >= 0 || neg_offset <= addr;
-  target.is_good_offset &= offset <= 0 || (std::numeric_limits<u32>::max() - u32(offset)) >= addr;
+  target.is_good_offset &= offset <= 0 || (std::numeric_limits<u32>::max() - static_cast<u32>(offset)) >= addr;
 
   if (!target.is_good_address || !target.is_good_offset)
     return target;
@@ -853,7 +853,7 @@ MemoryWidget::TargetAddress MemoryWidget::GetTargetAddress() const
   if (offset < 0)
     target.address = addr - neg_offset;
   else
-    target.address = addr + u32(offset);
+    target.address = addr + static_cast<u32>(offset);
   return target;
 }
 

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -305,7 +305,7 @@ void NetworkWidget::Update()
   m_verify_certificates_checkbox->setChecked(
       Config::Get(Config::MAIN_NETWORK_SSL_VERIFY_CERTIFICATES));
 
-  const int combo_index = int([is_pcap, is_ssl_read, is_ssl_write]() -> FormatComboId {
+  const int combo_index = static_cast<int>([is_pcap, is_ssl_read, is_ssl_write]() -> FormatComboId {
     if (is_pcap)
       return FormatComboId::PCAP;
     else if (is_ssl_read && is_ssl_write)
@@ -421,12 +421,12 @@ QComboBox* NetworkWidget::CreateDumpFormatCombo()
 {
   auto* combo = new QComboBox();
 
-  combo->insertItem(int(FormatComboId::None), tr("None"));
+  combo->insertItem(static_cast<int>(FormatComboId::None), tr("None"));
   // i18n: PCAP is a file format
-  combo->insertItem(int(FormatComboId::PCAP), tr("PCAP"));
-  combo->insertItem(int(FormatComboId::BinarySSL), tr("Binary SSL"));
-  combo->insertItem(int(FormatComboId::BinarySSLRead), tr("Binary SSL (read)"));
-  combo->insertItem(int(FormatComboId::BinarySSLWrite), tr("Binary SSL (write)"));
+  combo->insertItem(static_cast<int>(FormatComboId::PCAP), tr("PCAP"));
+  combo->insertItem(static_cast<int>(FormatComboId::BinarySSL), tr("Binary SSL"));
+  combo->insertItem(static_cast<int>(FormatComboId::BinarySSLRead), tr("Binary SSL (read)"));
+  combo->insertItem(static_cast<int>(FormatComboId::BinarySSLWrite), tr("Binary SSL (write)"));
 
   return combo;
 }

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -481,7 +481,7 @@ void ThreadWidget::OnSelectionChanged(int row)
   Core::CPUThreadGuard guard(Core::System::GetInstance());
   Common::Debug::PartialContext context;
 
-  if (row >= 0 && size_t(row) < m_threads.size())
+  if (row >= 0 && static_cast<size_t>(row) < m_threads.size())
     context = m_threads[row]->GetContext(guard);
 
   UpdateThreadContext(context);

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -124,8 +124,8 @@ bool Host::GetRenderFocus()
   // Unfortunately Qt calls SetRenderFocus() with a slight delay compared to what we actually need
   // to avoid inputs that cause a focus loss to be processed by the emulation
   if (m_render_to_main && !m_render_fullscreen)
-    return GetForegroundWindow() == (HWND)m_main_window_handle.load();
-  return GetForegroundWindow() == (HWND)m_render_handle.load();
+    return GetForegroundWindow() == static_cast<HWND>(m_main_window_handle.load());
+  return GetForegroundWindow() == static_cast<HWND>(m_render_handle.load());
 #else
   return m_render_focus;
 #endif

--- a/Source/Core/DolphinQt/QtUtils/PartiallyClosableTabWidget.cpp
+++ b/Source/Core/DolphinQt/QtUtils/PartiallyClosableTabWidget.cpp
@@ -13,7 +13,7 @@ PartiallyClosableTabWidget::PartiallyClosableTabWidget(QWidget* parent) : QTabWi
 
 void PartiallyClosableTabWidget::setTabUnclosable(int index)
 {
-  QTabBar::ButtonPosition closeSide = (QTabBar::ButtonPosition)style()->styleHint(
-      QStyle::SH_TabBar_CloseButtonPosition, nullptr, this);
+  QTabBar::ButtonPosition closeSide = static_cast<QTabBar::ButtonPosition>(style()->styleHint(
+      QStyle::SH_TabBar_CloseButtonPosition, nullptr, this));
   tabBar()->setTabButton(index, closeSide, nullptr);
 }

--- a/Source/Core/DolphinQt/QtUtils/SetWindowDecorations.cpp
+++ b/Source/Core/DolphinQt/QtUtils/SetWindowDecorations.cpp
@@ -20,6 +20,6 @@ void SetQWidgetWindowDecorations(QWidget* widget)
   BOOL use_dark_title_bar = TRUE;
   DwmSetWindowAttribute(HWND(widget->winId()),
                         20 /* DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE */,
-                        &use_dark_title_bar, DWORD(sizeof(use_dark_title_bar)));
+                        &use_dark_title_bar, static_cast<DWORD>(sizeof(use_dark_title_bar)));
 #endif
 }

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -248,7 +248,7 @@ void RenderWidget::SetCursorLocked(bool locked, bool follow_aspect_ratio)
     Common::Vec2 aspect_ratio = g_controller_interface.GetWindowInputScale();
     if (aspect_ratio.x > 1.f)
     {
-      const float new_half_width = float(render_rect.width()) / (aspect_ratio.x * 2.f);
+      const float new_half_width = static_cast<float>(render_rect.width()) / (aspect_ratio.x * 2.f);
       // Only ceil if it was >= 0.25
       const float ceiled_new_half_width = std::ceil(std::round(new_half_width * 2.f) / 2.f);
       const int x_center = render_rect.center().x();

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -126,7 +126,7 @@ void ResourcePackManager::RepopulateTable()
     QPixmap logo;
 
     logo.loadFromData(reinterpret_cast<const uchar*>(pack.GetLogo().data()),
-                      (int)pack.GetLogo().size());
+                      static_cast<int>(pack.GetLogo().size()));
 
     logo_item->setIcon(QIcon(logo));
 

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -245,7 +245,7 @@ void AdvancedPane::Update()
   for (size_t i = 0; i < available_cpu_cores.size(); ++i)
   {
     if (available_cpu_cores[i] == cpu_core)
-      m_cpu_emulation_engine_combobox->setCurrentIndex(int(i));
+      m_cpu_emulation_engine_combobox->setCurrentIndex(static_cast<int>(i));
   }
   m_cpu_emulation_engine_combobox->setEnabled(is_uninitialized);
   m_enable_mmu_checkbox->setEnabled(is_uninitialized);

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
@@ -885,7 +885,7 @@ bool SkylanderPortalWindow::PassesFilter(const QString& name, u16 id, u16 var) c
   // Check against active game filters
   for (size_t i = 0; i < NUM_SKYLANDER_GAMES; i++)
   {
-    if (m_game_filters[i]->isChecked() && character.game == (Game)i)
+    if (m_game_filters[i]->isChecked() && character.game == static_cast<Game>(i))
     {
       pass = true;
     }
@@ -898,11 +898,11 @@ bool SkylanderPortalWindow::PassesFilter(const QString& name, u16 id, u16 var) c
     return false;
 
   // Check against active element filter
-  if ((Element)GetElementRadio() != character.element && GetElementRadio() != 0)
+  if (static_cast<Element>(GetElementRadio()) != character.element && GetElementRadio() != 0)
     return false;
 
   // Check against active type filter
-  if ((Type)GetTypeRadio() != character.type && GetTypeRadio() != 0)
+  if (static_cast<Type>(GetTypeRadio()) != character.type && GetTypeRadio() != 0)
     return false;
 
   return true;
@@ -997,15 +997,15 @@ QBrush SkylanderPortalWindow::GetBaseColor(std::pair<const u16, const u16> ids, 
 
 int SkylanderPortalWindow::GetGameID(Game game)
 {
-  return (int)game;
+  return static_cast<int>(game);
 }
 
 int SkylanderPortalWindow::GetElementID(Element elem)
 {
-  return (int)elem;
+  return static_cast<int>(elem);
 }
 
 int SkylanderPortalWindow::GetTypeID(Type type)
 {
-  return (int)type;
+  return static_cast<int>(type);
 }

--- a/Source/Core/DolphinTool/HeaderCommand.cpp
+++ b/Source/Core/DolphinTool/HeaderCommand.cpp
@@ -78,14 +78,14 @@ int HeaderCommand(const std::vector<std::string>& args)
 
     // File data
     if (const u64 block_size = blob_reader->GetBlockSize())
-      json["block_size"] = picojson::value((double)block_size);
+      json["block_size"] = picojson::value(static_cast<double>(block_size));
 
     const std::string compression_method = blob_reader->GetCompressionMethod();
     if (compression_method != "")
       json["compression_method"] = picojson::value(compression_method);
 
     if (const std::optional<int> compression_level = blob_reader->GetCompressionLevel())
-      json["compression_level"] = picojson::value((double)compression_level.value());
+      json["compression_level"] = picojson::value(static_cast<double>(compression_level.value()));
 
     // Game data
     if (volume)
@@ -93,12 +93,12 @@ int HeaderCommand(const std::vector<std::string>& args)
       json["internal_name"] = picojson::value(volume->GetInternalName());
 
       if (const std::optional<u16> revision = volume->GetRevision())
-        json["revision"] = picojson::value((double)revision.value());
+        json["revision"] = picojson::value(static_cast<double>(revision.value()));
 
       json["game_id"] = picojson::value(volume->GetGameID());
 
       if (const std::optional<u64> title_id = volume->GetTitleID())
-        json["title_id"] = picojson::value((double)title_id.value());
+        json["title_id"] = picojson::value(static_cast<double>(title_id.value()));
 
       json["region"] = picojson::value(DiscIO::GetName(volume->GetRegion(), false));
 

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
@@ -487,7 +487,7 @@ class TapExpression : public FunctionExpression
 
     const bool is_time_up = elapsed > seconds;
 
-    const u32 desired_taps = GetArgCount() == 3 ? u32(GetArg(2).GetValue() + 0.5) : 2;
+    const u32 desired_taps = GetArgCount() == 3 ? static_cast<u32>(GetArg(2).GetValue() + 0.5) : 2;
 
     if (input < CONDITION_THRESHOLD)
     {
@@ -718,7 +718,7 @@ Expression& FunctionExpression::GetArg(u32 number)
 
 u32 FunctionExpression::GetArgCount() const
 {
-  return u32(m_args.size());
+  return static_cast<u32>(m_args.size());
 }
 
 void FunctionExpression::SetValue(ControlState)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
@@ -25,7 +25,7 @@ u32 Attachments::GetSelectedAttachment() const
   const int value = m_selection_value.GetValue();
 
   if (value > 0 && static_cast<size_t>(value) < m_attachments.size())
-    return u32(value);
+    return static_cast<u32>(value);
 
   return 0;
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
@@ -87,7 +87,7 @@ Force::StateData Force::GetState(bool adjusted) const
     z = ApplyDeadzone(z, GetDeadzonePercentage()) * GetMaxDistance();
   }
 
-  return {float(state.x), float(state.y), float(z)};
+  return {static_cast<float>(state.x), static_cast<float>(state.y), static_cast<float>(z)};
 }
 
 ControlState Force::GetGateRadiusAtAngle(double) const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
@@ -43,7 +43,7 @@ void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlSta
     deadzone = 0.0;
   }
 
-  const int trigger_count = int(controls.size() / 2);
+  const int trigger_count = static_cast<int>(controls.size() / 2);
   for (int i = 0; i != trigger_count; ++i)
   {
     const ControlState button_value = ApplyDeadzone(controls[i]->GetState(), deadzone);
@@ -79,7 +79,7 @@ void MixedTriggers::GetState(u16* digital, const u16* bitmasks, ControlState* an
     deadzone = 0.0;
   }
 
-  const int trigger_count = int(controls.size() / 2);
+  const int trigger_count = static_cast<int>(controls.size() / 2);
   for (int i = 0; i != trigger_count; ++i)
   {
     bool button_bool = false;

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -122,10 +122,10 @@ struct RawValue
   auto GetNormalizedValue(const TwoPointCalibration<OtherT, OtherBits>& calibration) const
   {
     const auto value_expansion =
-        std::max(0, int(calibration.BITS_OF_PRECISION) - int(BITS_OF_PRECISION));
+        std::max(0, static_cast<int>(calibration.BITS_OF_PRECISION) - static_cast<int>(BITS_OF_PRECISION));
 
     const auto calibration_expansion =
-        std::max(0, int(BITS_OF_PRECISION) - int(calibration.BITS_OF_PRECISION));
+        std::max(0, static_cast<int>(BITS_OF_PRECISION) - static_cast<int>(calibration.BITS_OF_PRECISION));
 
     const auto calibration_zero = ExpandValue(calibration.zero, calibration_expansion) * 1.f;
     const auto calibration_max = ExpandValue(calibration.max, calibration_expansion) * 1.f;
@@ -139,10 +139,10 @@ struct RawValue
   auto GetNormalizedValue(const ThreePointCalibration<OtherT, OtherBits>& calibration) const
   {
     const auto value_expansion =
-        std::max(0, int(calibration.BITS_OF_PRECISION) - int(BITS_OF_PRECISION));
+        std::max(0, static_cast<int>(calibration.BITS_OF_PRECISION) - static_cast<int>(BITS_OF_PRECISION));
 
     const auto calibration_expansion =
-        std::max(0, int(BITS_OF_PRECISION) - int(calibration.BITS_OF_PRECISION));
+        std::max(0, static_cast<int>(BITS_OF_PRECISION) - static_cast<int>(calibration.BITS_OF_PRECISION));
 
     const auto calibration_min = ExpandValue(calibration.min, calibration_expansion) * 1.f;
     const auto calibration_zero = ExpandValue(calibration.zero, calibration_expansion) * 1.f;

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
@@ -46,7 +46,7 @@ void NumericSetting<T>::SetExpressionFromValue()
 {
   // Always include -/+ sign to prevent CoalesceExpression binding.
   // e.g. 1 is a valid input name for keyboard devices, +1 is not.
-  m_value.m_input.SetExpression(fmt::format("{:+g}", ControlState(GetValue())));
+  m_value.m_input.SetExpression(fmt::format("{:+g}", static_cast<ControlState>(GetValue())));
 }
 
 template <typename T>

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -159,7 +159,7 @@ ControlState ReshapableInput::GetCalibrationDataRadiusAtAngle(const CalibrationD
 {
   const auto sample_pos = angle / MathUtil::TAU * data.size();
   // Interpolate the radius between 2 calibration samples.
-  const u32 sample1_index = u32(sample_pos) % data.size();
+  const u32 sample1_index = static_cast<u32>(sample_pos) % data.size();
   const u32 sample2_index = (sample1_index + 1) % data.size();
   const double sample1_angle = sample1_index * MathUtil::TAU / data.size();
   const double sample2_angle = sample2_index * MathUtil::TAU / data.size();

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -150,7 +150,7 @@ class RelativeInputState
 public:
   void Update()
   {
-    const auto channel = int(ControllerInterface::GetCurrentInputChannel());
+    const auto channel = static_cast<int>(ControllerInterface::GetCurrentInputChannel());
 
     m_value[channel] = m_delta[channel];
     m_delta[channel] = {};
@@ -158,7 +158,7 @@ public:
 
   T GetValue() const
   {
-    const auto channel = int(ControllerInterface::GetCurrentInputChannel());
+    const auto channel = static_cast<int>(ControllerInterface::GetCurrentInputChannel());
 
     return m_value[channel];
   }
@@ -170,8 +170,8 @@ public:
   }
 
 private:
-  std::array<T, int(InputChannel::Count)> m_value;
-  std::array<T, int(InputChannel::Count)> m_delta;
+  std::array<T, static_cast<int>(InputChannel::Count)> m_value;
+  std::array<T, static_cast<int>(InputChannel::Count)> m_delta;
 };
 }  // namespace ciface
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
@@ -20,13 +20,13 @@ static IDirectInput8* s_idi8 = nullptr;
 
 BOOL CALLBACK DIEnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef)
 {
-  ((std::list<DIDEVICEOBJECTINSTANCE>*)pvRef)->push_back(*lpddoi);
+  static_cast<std::list<DIDEVICEOBJECTINSTANCE>*>(pvRef)->push_back(*lpddoi);
   return DIENUM_CONTINUE;
 }
 
 BOOL CALLBACK DIEnumDevicesCallback(LPCDIDEVICEINSTANCE lpddi, LPVOID pvRef)
 {
-  ((std::list<DIDEVICEINSTANCE>*)pvRef)->push_back(*lpddi);
+  static_cast<std::list<DIDEVICEINSTANCE>*>(pvRef)->push_back(*lpddi);
   return DIENUM_CONTINUE;
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -127,8 +127,8 @@ Joystick::Joystick(const LPDIRECTINPUTDEVICE8 device) : m_device(device)
     return;
 
   // max of 32 buttons and 4 hats / the limit of the data format I am using
-  js_caps.dwButtons = std::min((DWORD)32, js_caps.dwButtons);
-  js_caps.dwPOVs = std::min((DWORD)4, js_caps.dwPOVs);
+  js_caps.dwButtons = std::min(static_cast<DWORD>(32), js_caps.dwButtons);
+  js_caps.dwPOVs = std::min(static_cast<DWORD>(4), js_caps.dwPOVs);
 
   // m_must_poll = (js_caps.dwFlags & DIDC_POLLEDDATAFORMAT) != 0;
 
@@ -244,7 +244,7 @@ Core::DeviceRemoval Joystick::UpdateInput()
         if (evt->dwOfs < DIJOFS_BUTTON(0))
           *(DWORD*)(((BYTE*)&m_state_in) + evt->dwOfs) = evt->dwData;
         else
-          ((BYTE*)&m_state_in)[evt->dwOfs] = (BYTE)evt->dwData;
+          ((BYTE*)&m_state_in)[evt->dwOfs] = static_cast<BYTE>(evt->dwData);
       }
 
       // seems like this needs to be done maybe...
@@ -289,12 +289,12 @@ std::string Joystick::Hat::GetName() const
 
 ControlState Joystick::Axis::GetState() const
 {
-  return ControlState(m_axis - m_base) / m_range;
+  return static_cast<ControlState>(m_axis - m_base) / m_range;
 }
 
 ControlState Joystick::Button::GetState() const
 {
-  return ControlState(m_button > 0);
+  return static_cast<ControlState>(m_button > 0);
 }
 
 ControlState Joystick::Hat::GetState() const
@@ -306,6 +306,6 @@ ControlState Joystick::Hat::GetState() const
   if (is_centered)
     return 0;
 
-  return (std::abs(int(m_hat / 4500 - m_direction * 2 + 8) % 8 - 4) > 2);
+  return (std::abs(static_cast<int>(m_hat / 4500 - m_direction * 2 + 8) % 8 - 4) > 2);
 }
 }  // namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -29,7 +29,7 @@ class RelativeMouseAxis final : public Core::Device::RelativeInput
 public:
   std::string GetName() const override
   {
-    return fmt::format("RelativeMouse {}{}", char('X' + m_index), (m_scale > 0) ? '+' : '-');
+    return fmt::format("RelativeMouse {}{}", static_cast<char>('X' + m_index), (m_scale > 0) ? '+' : '-');
   }
 
   RelativeMouseAxis(u8 index, bool positive, const RelativeMouseState* state)
@@ -39,7 +39,7 @@ public:
 
   ControlState GetState() const override
   {
-    return ControlState(m_state.GetValue().data[m_index] * m_scale);
+    return static_cast<ControlState>(m_state.GetValue().data[m_index] * m_scale);
   }
 
 private:
@@ -211,8 +211,8 @@ void KeyboardMouse::UpdateCursorInput()
   const auto window_scale = g_controller_interface.GetWindowInputScale();
 
   // Convert the cursor position to a range from -1 to 1.
-  m_state_in.cursor.x = (ControlState(point.x) / win_width * 2 - 1) * window_scale.x;
-  m_state_in.cursor.y = (ControlState(point.y) / win_height * 2 - 1) * window_scale.y;
+  m_state_in.cursor.x = (static_cast<ControlState>(point.x) / win_width * 2 - 1) * window_scale.x;
+  m_state_in.cursor.y = (static_cast<ControlState>(point.y) / win_height * 2 - 1) * window_scale.y;
 }
 
 Core::DeviceRemoval KeyboardMouse::UpdateInput()
@@ -297,13 +297,13 @@ std::string KeyboardMouse::Key::GetName() const
 
 std::string KeyboardMouse::Button::GetName() const
 {
-  return std::string("Click ") + char('0' + m_index);
+  return std::string("Click ") + static_cast<char>('0' + m_index);
 }
 
 std::string KeyboardMouse::Axis::GetName() const
 {
   char tmpstr[] = "Axis ..";
-  tmpstr[5] = (char)('X' + m_index);
+  tmpstr[5] = static_cast<char>('X' + m_index);
   tmpstr[6] = (m_range < 0 ? '-' : '+');
   return tmpstr;
 }
@@ -311,7 +311,7 @@ std::string KeyboardMouse::Axis::GetName() const
 std::string KeyboardMouse::Cursor::GetName() const
 {
   char tmpstr[] = "Cursor ..";
-  tmpstr[7] = (char)('X' + m_index);
+  tmpstr[7] = static_cast<char>('X' + m_index);
   tmpstr[8] = (m_positive ? '+' : '-');
   return tmpstr;
 }
@@ -329,7 +329,7 @@ ControlState KeyboardMouse::Button::GetState() const
 
 ControlState KeyboardMouse::Axis::GetState() const
 {
-  return ControlState(m_axis) / m_range;
+  return static_cast<ControlState>(m_axis) / m_range;
 }
 
 ControlState KeyboardMouse::Cursor::GetState() const

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -74,7 +74,7 @@ private:
     std::string GetName() const final override { return m_name; }
     ControlState GetState() const final override
     {
-      return (ControlState(m_input) + m_offset) / m_range;
+      return (static_cast<ControlState>(m_input) + m_offset) / m_range;
     }
 
   private:
@@ -118,7 +118,7 @@ private:
       case BatteryState::Charged:
         return BATTERY_INPUT_MAX_VALUE;
       default:
-        return ControlState(m_battery) / ControlState(BatteryState::Full) * BATTERY_INPUT_MAX_VALUE;
+        return static_cast<ControlState>(m_battery) / static_cast<ControlState>(BatteryState::Full) * BATTERY_INPUT_MAX_VALUE;
       }
     }
 

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
@@ -90,7 +90,7 @@ bool ForceFeedbackDevice::InitForceFeedback(const LPDIRECTINPUTDEVICE8 device, i
   eff.dwGain = DI_FFNOMINALMAX;
   eff.dwTriggerButton = DIEB_NOTRIGGER;
   eff.dwTriggerRepeatInterval = 0;
-  eff.cAxes = DWORD(rgdwAxes.size());
+  eff.cAxes = static_cast<DWORD>(rgdwAxes.size());
   eff.rgdwAxes = rgdwAxes.data();
   eff.rglDirection = rglDirection.data();
   eff.dwStartDelay = 0;
@@ -236,7 +236,7 @@ ForceFeedbackDevice::Force::Force(ForceFeedbackDevice* parent, const char* name,
 
 void ForceFeedbackDevice::Force::SetState(ControlState state)
 {
-  const auto new_val = int(DI_FFNOMINALMAX * state);
+  const auto new_val = static_cast<int>(DI_FFNOMINALMAX * state);
 
   if (m_desired_magnitude.exchange(new_val) != new_val)
     m_parent.SignalUpdateThread();

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -1010,7 +1010,7 @@ ControlState GameController::Button::GetState() const
 
 ControlState GameController::Axis::GetState() const
 {
-  return ControlState(SDL_GameControllerGetAxis(m_gc, m_axis)) / m_range;
+  return static_cast<ControlState>(SDL_GameControllerGetAxis(m_gc, m_axis)) / m_range;
 }
 
 bool GameController::Button::IsMatchingName(std::string_view name) const
@@ -1036,7 +1036,7 @@ bool GameController::Button::IsMatchingName(std::string_view name) const
     return name == GetLegacyButtonName(bind.value.button);
   case SDL_CONTROLLER_BINDTYPE_HAT:
     return name == GetLegacyHatName(bind.value.hat.hat,
-                                    GetDirectionFromHatMask(u8(bind.value.hat.hat_mask)));
+                                    GetDirectionFromHatMask(static_cast<u8>(bind.value.hat.hat_mask)));
   default:
     return false;
   }
@@ -1057,7 +1057,7 @@ ControlState GameController::LegacyButton::GetState() const
 
 ControlState GameController::LegacyAxis::GetState() const
 {
-  return ControlState(SDL_JoystickGetAxis(m_js, m_index)) / m_range;
+  return static_cast<ControlState>(SDL_JoystickGetAxis(m_js, m_index)) / m_range;
 }
 
 ControlState GameController::LegacyHat::GetState() const
@@ -1180,7 +1180,7 @@ void GameController::HapticEffect::SetState(ControlState state)
   // Maximum force value for all SDL effects:
   constexpr s16 MAX_FORCE_VALUE = 0x7fff;
 
-  if (UpdateParameters(s16(state * MAX_FORCE_VALUE)))
+  if (UpdateParameters(static_cast<s16>(state * MAX_FORCE_VALUE)))
   {
     UpdateEffect();
   }

--- a/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp
@@ -94,7 +94,7 @@ private:
     {
     }
     std::string GetName() const final override { return m_name; }
-    ControlState GetState() const final override { return ControlState(m_input) / m_range; }
+    ControlState GetState() const final override { return static_cast<ControlState>(m_input) / m_range; }
 
   private:
     const char* m_name;

--- a/Source/Core/InputCommon/ControllerInterface/WGInput/WGInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/WGInput/WGInput.cpp
@@ -198,7 +198,7 @@ private:
   {
   public:
     explicit Button(const ButtonValueType* button) : m_button(*button) {}
-    ControlState GetState() const override { return ControlState(m_button != 0); }
+    ControlState GetState() const override { return static_cast<ControlState>(m_button != 0); }
 
   private:
     const ButtonValueType& m_button;
@@ -236,7 +236,7 @@ private:
     {
     }
 
-    ControlState GetState() const override { return ControlState(m_axis - m_base) / m_range; }
+    ControlState GetState() const override { return static_cast<ControlState>(m_axis - m_base) / m_range; }
 
   protected:
     const double m_base;
@@ -332,7 +332,7 @@ private:
       // directions. This tests that the current switch state value is within 1 of the desired
       // state.
       const auto direction_diff = std::abs(static_cast<int32_t>(m_switch) - m_direction);
-      return ControlState(direction_diff <= 1 || direction_diff == 7);
+      return static_cast<ControlState>(direction_diff <= 1 || direction_diff == 7);
     }
 
   private:

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
@@ -51,7 +51,7 @@ public:
 
   std::string GetName() const override { return m_name; }
 
-  ControlState GetState() const final override { return ControlState(m_value) / m_extent; }
+  ControlState GetState() const final override { return static_cast<ControlState>(m_value) / m_extent; }
 
 protected:
   const T& m_value;
@@ -304,7 +304,7 @@ Device::Device(std::unique_ptr<WiimoteReal::Wiimote> wiimote) : m_wiimote(std::m
   // Specialty inputs:
   AddInput(new UndetectableAnalogInput<float>(&m_battery, "Battery", 1.f));
   AddInput(new UndetectableAnalogInput<WiimoteEmu::ExtensionNumber>(
-      &m_extension_number_input, "Attached Extension", WiimoteEmu::ExtensionNumber(1)));
+      &m_extension_number_input, "Attached Extension", static_cast<WiimoteEmu::ExtensionNumber>(1)));
   AddInput(new UndetectableAnalogInput<bool>(&m_mplus_attached_input, "Attached MotionPlus", 1));
 
   AddOutput(new Motor(&m_rumble_level));
@@ -480,7 +480,7 @@ void Device::RunTasks()
     // Note that this signal also DE-activates a M+.
     WriteData(AddressSpace::I2CBus, WiimoteEmu::ExtensionPort::REPORT_I2C_SLAVE, INIT_ADDR,
               {INIT_VALUE}, [this](ErrorCode result) {
-                DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: Initialized extension: {}.", int(result));
+                DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: Initialized extension: {}.", static_cast<int>(result));
                 m_extension_id = std::nullopt;
               });
 
@@ -515,7 +515,7 @@ void Device::RunTasks()
 
                WriteData(AddressSpace::I2CBus, WiimoteEmu::MotionPlus::INACTIVE_DEVICE_ADDR,
                          INIT_ADDR, {INIT_VALUE}, [this](ErrorCode result) {
-                           DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: M+ initialization: {}.", int(result));
+                           DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: M+ initialization: {}.", static_cast<int>(result));
                            if (result != ErrorCode::Success)
                            {
                              HandleMotionPlusNonResponse();
@@ -863,11 +863,11 @@ void Device::ReadActiveExtensionID()
              // Check for M+ ID.
              if (identifier[5] == 0x05)
              {
-               const auto passthrough_mode = MotionPlusState::PassthroughMode(identifier[4]);
+               const auto passthrough_mode = static_cast<MotionPlusState::PassthroughMode>(identifier[4]);
 
                m_mplus_state.current_mode = passthrough_mode;
 
-               INFO_LOG_FMT(WIIMOTE, "WiiRemote: M+ is active in mode: {}.", int(passthrough_mode));
+               INFO_LOG_FMT(WIIMOTE, "WiiRemote: M+ is active in mode: {}.", static_cast<int>(passthrough_mode));
              }
              else
              {
@@ -1051,14 +1051,14 @@ void Device::TriggerMotionPlusModeChange()
   if (!m_mplus_desired_mode.has_value())
     return;
 
-  const u8 passthrough_mode = u8(*m_mplus_desired_mode);
+  const u8 passthrough_mode = static_cast<u8>(*m_mplus_desired_mode);
 
   const u8 device_addr = IsMotionPlusActive() ? WiimoteEmu::MotionPlus::ACTIVE_DEVICE_ADDR :
                                                 WiimoteEmu::MotionPlus::INACTIVE_DEVICE_ADDR;
 
   WriteData(AddressSpace::I2CBus, device_addr, WiimoteEmu::MotionPlus::PASSTHROUGH_MODE_OFFSET,
             {passthrough_mode}, [this](ErrorCode activation_result) {
-              DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: M+ activation: {}.", int(activation_result));
+              DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: M+ activation: {}.", static_cast<int>(activation_result));
 
               WaitForMotionPlus();
 
@@ -1079,7 +1079,7 @@ void Device::TriggerMotionPlusCalibration()
   // It seems we're better off just manually determining "zero".
   WriteData(AddressSpace::I2CBus, WiimoteEmu::MotionPlus::ACTIVE_DEVICE_ADDR,
             CALIBRATION_TRIGGER_ADDR, {CALIBRATION_TRIGGER_VALUE}, [](ErrorCode result) {
-              DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: M+ calibration trigger done: {}.", int(result));
+              DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: M+ calibration trigger done: {}.", static_cast<int>(result));
             });
 }
 
@@ -1107,7 +1107,7 @@ void Device::ProcessInputReport(WiimoteReal::Report& report)
     return;
   }
 
-  auto report_id = InputReportID(report[WiimoteReal::REPORT_HID_HEADER_SIZE]);
+  auto report_id = static_cast<InputReportID>(report[WiimoteReal::REPORT_HID_HEADER_SIZE]);
 
   for (auto it = m_report_handlers.begin(); true;)
   {
@@ -1128,7 +1128,7 @@ void Device::ProcessInputReport(WiimoteReal::Report& report)
       else if (report_id < InputReportID::ReportCore)
       {
         WARN_LOG_FMT(WIIMOTE, "WiiRemote: Unhandled input report: {}.",
-                     ArrayToString(report.data(), u32(report.size())));
+                     ArrayToString(report.data(), static_cast<u32>(report.size())));
       }
 
       break;
@@ -1160,7 +1160,7 @@ void Device::ProcessInputReport(WiimoteReal::Report& report)
   {
     // We can assume the last received input report is the current reporting mode.
     // FYI: This logic fails to properly handle the (never used) "interleaved" reports.
-    m_reporting_mode = InputReportID(report_id);
+    m_reporting_mode = static_cast<InputReportID>(report_id);
   }
 
   auto manipulator = MakeDataReportManipulator(
@@ -1183,7 +1183,7 @@ void Device::ProcessInputReport(WiimoteReal::Report& report)
     manipulator->GetAccelData(&accel_data);
 
     m_accel_data =
-        accel_data.GetNormalizedValue(*m_accel_calibration) * float(MathUtil::GRAVITY_ACCELERATION);
+        accel_data.GetNormalizedValue(*m_accel_calibration) * static_cast<float>(MathUtil::GRAVITY_ACCELERATION);
   }
 
   // Process IR data.
@@ -1258,7 +1258,7 @@ void Device::UpdateOrientation()
   m_rotation_inputs =
       Common::Vec3{WiimoteEmu::GetPitch(m_orientation), WiimoteEmu::GetRoll(m_orientation),
                    WiimoteEmu::GetYaw(m_orientation)} /
-      float(MathUtil::PI);
+      static_cast<float>(MathUtil::PI);
 }
 
 void Device::IRState::ProcessData(const DataReportManipulator& manipulator)
@@ -1391,7 +1391,7 @@ void Device::ProcessMotionPlusExtensionData(const u8* ext_data, u32 ext_size)
   // Undo bit-hacks of M+ passthrough.
   WiimoteEmu::MotionPlus::ReversePassthroughModifications(*m_mplus_state.current_mode, data.data());
 
-  ProcessNormalExtensionData(data.data(), u32(data.size()));
+  ProcessNormalExtensionData(data.data(), static_cast<u32>(data.size()));
 }
 
 void Device::ProcessNormalExtensionData(const u8* ext_data, u32 ext_size)
@@ -1489,7 +1489,7 @@ void Device::NunchukState::ProcessData(const WiimoteEmu::Nunchuk::DataFormat& da
 
   stick = data.GetStick().GetNormalizedValue(calibration->stick);
   accel = data.GetAccel().GetNormalizedValue(calibration->accel) *
-          float(MathUtil::GRAVITY_ACCELERATION);
+          static_cast<float>(MathUtil::GRAVITY_ACCELERATION);
 }
 
 void Device::ClassicState::ProcessData(const WiimoteEmu::Classic::DataFormat& data)
@@ -1510,12 +1510,12 @@ void Device::ReadData(AddressSpace space, u8 slave, u16 address, u16 size,
                       std::function<void(ReadResponse)> callback)
 {
   OutputReportReadData read_data{};
-  read_data.space = u8(space);
+  read_data.space = static_cast<u8>(space);
   read_data.slave_address = slave;
-  read_data.address[0] = u8(address >> 8);
-  read_data.address[1] = u8(address);
-  read_data.size[0] = u8(size >> 8);
-  read_data.size[1] = u8(size);
+  read_data.address[0] = static_cast<u8>(address >> 8);
+  read_data.address[1] = static_cast<u8>(address);
+  read_data.size[0] = static_cast<u8>(size >> 8);
+  read_data.size[1] = static_cast<u8>(size);
   QueueReport(read_data);
 
   AddReadDataReplyHandler(space, slave, address, size, {}, std::move(callback));
@@ -1527,7 +1527,7 @@ void Device::AddReadDataReplyHandler(AddressSpace space, u8 slave, u16 address, 
 {
   // Data read may return a busy ack.
   auto ack_handler = MakeAckHandler(OutputReportID::ReadData, [callback](ErrorCode result) {
-    DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: Read ack error: {}.", int(result));
+    DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: Read ack error: {}.", static_cast<int>(result));
     callback(ReadResponse{});
   });
 
@@ -1538,9 +1538,9 @@ void Device::AddReadDataReplyHandler(AddressSpace space, u8 slave, u16 address, 
     if (Common::swap16(reply.address) != address)
       return ReportHandler::HandlerResult::NotHandled;
 
-    if (reply.error != u8(ErrorCode::Success))
+    if (reply.error != static_cast<u8>(ErrorCode::Success))
     {
-      DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: Read reply error: {}.", int(reply.error));
+      DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: Read reply error: {}.", static_cast<int>(reply.error));
       callback(ReadResponse{});
 
       return ReportHandler::HandlerResult::Handled;
@@ -1575,13 +1575,13 @@ template <typename T, typename C>
 void Device::WriteData(AddressSpace space, u8 slave, u16 address, T&& data, C&& callback)
 {
   OutputReportWriteData write_data = {};
-  write_data.space = u8(space);
+  write_data.space = static_cast<u8>(space);
   write_data.slave_address = slave;
-  write_data.address[0] = u8(address >> 8);
-  write_data.address[1] = u8(address);
+  write_data.address[0] = static_cast<u8>(address >> 8);
+  write_data.address[1] = static_cast<u8>(address);
 
   static constexpr auto MAX_DATA_SIZE = std::size(write_data.data);
-  write_data.size = u8(std::min(std::size(data), MAX_DATA_SIZE));
+  write_data.size = static_cast<u8>(std::min(std::size(data), MAX_DATA_SIZE));
 
   std::copy_n(std::begin(data), write_data.size, write_data.data);
 
@@ -1621,7 +1621,7 @@ template <typename R, typename T>
 void Device::ReportHandler::AddHandler(std::function<R(const T&)> handler)
 {
   m_callbacks.emplace_back([handler = std::move(handler)](const WiimoteReal::Report& report) {
-    if (report[WiimoteReal::REPORT_HID_HEADER_SIZE] != u8(T::REPORT_ID))
+    if (report[WiimoteReal::REPORT_HID_HEADER_SIZE] != static_cast<u8>(T::REPORT_ID))
       return ReportHandler::HandlerResult::NotHandled;
 
     T data;
@@ -1630,7 +1630,7 @@ void Device::ReportHandler::AddHandler(std::function<R(const T&)> handler)
     {
       // Off-brand "NEW 2in1" Wii Remote likes to shorten read data replies.
       WARN_LOG_FMT(WIIMOTE, "WiiRemote: Bad report size ({}) for report {:#x}. Zero-filling.",
-                   report.size(), int(T::REPORT_ID));
+                   report.size(), static_cast<int>(T::REPORT_ID));
 
       data = {};
       std::memcpy(&data, report.data() + WiimoteReal::REPORT_HID_HEADER_SIZE + 1,

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.h
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.h
@@ -129,7 +129,7 @@ private:
     void ProcessData(const DataReportManipulator& manipulator);
     bool IsFullyConfigured() const;
 
-    u32 current_sensitivity = u32(-1);
+    u32 current_sensitivity = static_cast<u32>(-1);
     bool enabled = false;
     bool mode_set = false;
 

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
@@ -61,7 +61,7 @@ public:
   {
     return std::string(named_axes[m_index]) + (m_range < 0 ? '-' : '+');
   }
-  ControlState GetState() const override { return ControlState(m_axis) / m_range; }
+  ControlState GetState() const override { return static_cast<ControlState>(m_axis) / m_range; }
 
 private:
   const SHORT& m_axis;
@@ -77,7 +77,7 @@ public:
   {
   }
   std::string GetName() const override { return named_triggers[m_index]; }
-  ControlState GetState() const override { return ControlState(m_trigger) / m_range; }
+  ControlState GetState() const override { return static_cast<ControlState>(m_trigger) / m_range; }
 
 private:
   const BYTE& m_trigger;
@@ -97,7 +97,7 @@ public:
   void SetState(ControlState state) override
   {
     const auto old_value = m_motor;
-    m_motor = (WORD)(state * m_range);
+    m_motor = static_cast<WORD>(state * m_range);
 
     // Only update if the state changed.
     if (m_motor != old_value)
@@ -212,12 +212,12 @@ Device::Device(const XINPUT_CAPABILITIES& caps, u8 index) : m_subtype(caps.SubTy
     if (named_buttons[i].bitmask == XINPUT_GAMEPAD_GUIDE && !s_have_guide_button)
       continue;
 
-    AddInput(new Button(u8(i), m_state_in.Gamepad.wButtons));
+    AddInput(new Button(static_cast<u8>(i), m_state_in.Gamepad.wButtons));
   }
 
   // Triggers.
   for (size_t i = 0; i != size(named_triggers); ++i)
-    AddInput(new Trigger(u8(i), (&m_state_in.Gamepad.bLeftTrigger)[i], 255));
+    AddInput(new Trigger(static_cast<u8>(i), (&m_state_in.Gamepad.bLeftTrigger)[i], 255));
 
   // Axes.
   for (size_t i = 0; i != size(named_axes); ++i)
@@ -225,13 +225,13 @@ Device::Device(const XINPUT_CAPABILITIES& caps, u8 index) : m_subtype(caps.SubTy
     const SHORT& ax = (&m_state_in.Gamepad.sThumbLX)[i];
 
     // Each axis gets a negative and a positive input instance associated with it.
-    AddInput(new Axis(u8(i), ax, -32768));
-    AddInput(new Axis(u8(i), ax, 32767));
+    AddInput(new Axis(static_cast<u8>(i), ax, -32768));
+    AddInput(new Axis(static_cast<u8>(i), ax, 32767));
   }
 
   // Rumble motors.
   for (size_t i = 0; i != size(named_motors); ++i)
-    AddOutput(new Motor(u8(i), this, (&m_state_out.wLeftMotorSpeed)[i], 65535));
+    AddOutput(new Motor(static_cast<u8>(i), this, (&m_state_out.wLeftMotorSpeed)[i], 65535));
 
   AddInput(new Battery(&m_battery_level));
 }
@@ -282,7 +282,7 @@ Core::DeviceRemoval Device::UpdateInput()
       break;
     default:
       m_battery_level =
-          battery_info.BatteryLevel / ControlState(BATTERY_LEVEL_FULL) * BATTERY_INPUT_MAX_VALUE;
+          battery_info.BatteryLevel / static_cast<ControlState>(BATTERY_LEVEL_FULL) * BATTERY_INPUT_MAX_VALUE;
       break;
     }
   }

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -214,7 +214,7 @@ static void ReadThreadFunc()
 
     int payload_size = 0;
     int error = libusb_interrupt_transfer(s_handle, s_endpoint_in, input_buffer.data(),
-                                          int(input_buffer.size()), &payload_size, USB_TIMEOUT_MS);
+                                          static_cast<int>(input_buffer.size()), &payload_size, USB_TIMEOUT_MS);
     if (error != LIBUSB_SUCCESS)
     {
       ERROR_LOG_FMT(CONTROLLERINTERFACE, "Read: libusb_interrupt_transfer failed: {}",

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -382,7 +382,7 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
          D3D11_LOGIC_OP_COPY_INVERTED, D3D11_LOGIC_OP_OR_INVERTED, D3D11_LOGIC_OP_NAND,
          D3D11_LOGIC_OP_SET}};
     tdesc.LogicOpEnable = TRUE;
-    tdesc.LogicOp = logic_ops[u32(state.logicmode.Value())];
+    tdesc.LogicOp = logic_ops[static_cast<u32>(state.logicmode.Value())];
 
     ComPtr<ID3D11BlendState1> res;
     HRESULT hr = D3D::device1->CreateBlendState1(&desc, res.GetAddressOf());
@@ -420,10 +420,10 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
        use_dual_source ? D3D11_BLEND_INV_SRC1_ALPHA : D3D11_BLEND_INV_SRC_ALPHA,
        D3D11_BLEND_DEST_ALPHA, D3D11_BLEND_INV_DEST_ALPHA}};
 
-  tdesc.SrcBlend = src_factors[u32(state.srcfactor.Value())];
-  tdesc.SrcBlendAlpha = src_factors[u32(state.srcfactoralpha.Value())];
-  tdesc.DestBlend = dst_factors[u32(state.dstfactor.Value())];
-  tdesc.DestBlendAlpha = dst_factors[u32(state.dstfactoralpha.Value())];
+  tdesc.SrcBlend = src_factors[static_cast<u32>(state.srcfactor.Value())];
+  tdesc.SrcBlendAlpha = src_factors[static_cast<u32>(state.srcfactoralpha.Value())];
+  tdesc.DestBlend = dst_factors[static_cast<u32>(state.dstfactor.Value())];
+  tdesc.DestBlendAlpha = dst_factors[static_cast<u32>(state.dstfactoralpha.Value())];
   tdesc.BlendOp = state.subtract ? D3D11_BLEND_OP_REV_SUBTRACT : D3D11_BLEND_OP_ADD;
   tdesc.BlendOpAlpha = state.subtractAlpha ? D3D11_BLEND_OP_REV_SUBTRACT : D3D11_BLEND_OP_ADD;
 
@@ -445,7 +445,7 @@ ID3D11RasterizerState* StateCache::Get(RasterizationState state)
 
   D3D11_RASTERIZER_DESC desc = {};
   desc.FillMode = D3D11_FILL_SOLID;
-  desc.CullMode = cull_modes[u32(state.cullmode.Value())];
+  desc.CullMode = cull_modes[static_cast<u32>(state.cullmode.Value())];
   desc.ScissorEnable = TRUE;
 
   ComPtr<ID3D11RasterizerState> res;
@@ -481,7 +481,7 @@ ID3D11DepthStencilState* StateCache::Get(DepthState state)
     depthdc.DepthEnable = TRUE;
     depthdc.DepthWriteMask =
         state.updateenable ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
-    depthdc.DepthFunc = d3dCmpFuncs[u32(state.func.Value())];
+    depthdc.DepthFunc = d3dCmpFuncs[static_cast<u32>(state.func.Value())];
   }
   else
   {

--- a/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
@@ -66,7 +66,7 @@ static void GetD3DRasterizerDesc(D3D12_RASTERIZER_DESC* desc, const Rasterizatio
       {D3D12_CULL_MODE_NONE, D3D12_CULL_MODE_BACK, D3D12_CULL_MODE_FRONT, D3D12_CULL_MODE_FRONT}};
 
   desc->FillMode = D3D12_FILL_MODE_SOLID;
-  desc->CullMode = cull_modes[u32(rs_state.cullmode.Value())];
+  desc->CullMode = cull_modes[static_cast<u32>(rs_state.cullmode.Value())];
   desc->MultisampleEnable = fb_state.samples > 1;
 }
 
@@ -80,7 +80,7 @@ static void GetD3DDepthDesc(D3D12_DEPTH_STENCIL_DESC* desc, const DepthState& st
        D3D12_COMPARISON_FUNC_ALWAYS}};
 
   desc->DepthEnable = state.testenable;
-  desc->DepthFunc = compare_funcs[u32(state.func.Value())];
+  desc->DepthFunc = compare_funcs[static_cast<u32>(state.func.Value())];
   desc->DepthWriteMask =
       state.updateenable ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
 }
@@ -139,24 +139,24 @@ static void GetD3DBlendDesc(D3D12_BLEND_DESC* desc, const BlendingState& state,
           state.subtractAlpha ? D3D12_BLEND_OP_REV_SUBTRACT : D3D12_BLEND_OP_ADD;
       if (state.usedualsrc)
       {
-        rtblend->SrcBlend = src_dual_src_factors[u32(state.srcfactor.Value())];
-        rtblend->SrcBlendAlpha = src_dual_src_factors[u32(state.srcfactoralpha.Value())];
-        rtblend->DestBlend = dst_dual_src_factors[u32(state.dstfactor.Value())];
-        rtblend->DestBlendAlpha = dst_dual_src_factors[u32(state.dstfactoralpha.Value())];
+        rtblend->SrcBlend = src_dual_src_factors[static_cast<u32>(state.srcfactor.Value())];
+        rtblend->SrcBlendAlpha = src_dual_src_factors[static_cast<u32>(state.srcfactoralpha.Value())];
+        rtblend->DestBlend = dst_dual_src_factors[static_cast<u32>(state.dstfactor.Value())];
+        rtblend->DestBlendAlpha = dst_dual_src_factors[static_cast<u32>(state.dstfactoralpha.Value())];
       }
       else
       {
-        rtblend->SrcBlend = src_factors[u32(state.srcfactor.Value())];
-        rtblend->SrcBlendAlpha = src_factors[u32(state.srcfactoralpha.Value())];
-        rtblend->DestBlend = dst_factors[u32(state.dstfactor.Value())];
-        rtblend->DestBlendAlpha = dst_factors[u32(state.dstfactoralpha.Value())];
+        rtblend->SrcBlend = src_factors[static_cast<u32>(state.srcfactor.Value())];
+        rtblend->SrcBlendAlpha = src_factors[static_cast<u32>(state.srcfactoralpha.Value())];
+        rtblend->DestBlend = dst_factors[static_cast<u32>(state.dstfactor.Value())];
+        rtblend->DestBlendAlpha = dst_factors[static_cast<u32>(state.dstfactoralpha.Value())];
       }
     }
     else
     {
       rtblend->LogicOpEnable = state.logicopenable;
       if (state.logicopenable)
-        rtblend->LogicOp = logic_ops[u32(state.logicmode.Value())];
+        rtblend->LogicOp = logic_ops[static_cast<u32>(state.logicmode.Value())];
     }
   }
 }

--- a/Source/Core/VideoBackends/OGL/OGLGfx.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLGfx.cpp
@@ -380,14 +380,14 @@ void OGLGfx::ClearRegion(const MathUtil::Rectangle<int>& target_rc, bool colorEn
   if (colorEnable || alphaEnable)
   {
     glColorMask(colorEnable, colorEnable, colorEnable, alphaEnable);
-    glClearColor(float((color >> 16) & 0xFF) / 255.0f, float((color >> 8) & 0xFF) / 255.0f,
-                 float((color >> 0) & 0xFF) / 255.0f, float((color >> 24) & 0xFF) / 255.0f);
+    glClearColor(static_cast<float>((color >> 16) & 0xFF) / 255.0f, static_cast<float>((color >> 8) & 0xFF) / 255.0f,
+                 static_cast<float>((color >> 0) & 0xFF) / 255.0f, static_cast<float>((color >> 24) & 0xFF) / 255.0f);
     clear_mask = GL_COLOR_BUFFER_BIT;
   }
   if (zEnable)
   {
     glDepthMask(zEnable ? GL_TRUE : GL_FALSE);
-    glClearDepthf(float(z & 0xFFFFFF) / 16777216.0f);
+    glClearDepthf(static_cast<float>(z & 0xFFFFFF) / 16777216.0f);
     clear_mask |= GL_DEPTH_BUFFER_BIT;
   }
 
@@ -536,7 +536,7 @@ void OGLGfx::ApplyDepthState(const DepthState state)
   {
     glEnable(GL_DEPTH_TEST);
     glDepthMask(state.updateenable ? GL_TRUE : GL_FALSE);
-    glDepthFunc(glCmpFuncs[u32(state.func.Value())]);
+    glDepthFunc(glCmpFuncs[static_cast<u32>(state.func.Value())]);
   }
   else
   {
@@ -561,18 +561,18 @@ void OGLGfx::ApplyBlendingState(const BlendingState state)
                                  GL_ONE,
                                  GL_DST_COLOR,
                                  GL_ONE_MINUS_DST_COLOR,
-                                 useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
+                                 useDualSource ? GL_SRC1_ALPHA : static_cast<GLenum>(GL_SRC_ALPHA),
                                  useDualSource ? GL_ONE_MINUS_SRC1_ALPHA :
-                                                 (GLenum)GL_ONE_MINUS_SRC_ALPHA,
+                                                 static_cast<GLenum>(GL_ONE_MINUS_SRC_ALPHA),
                                  GL_DST_ALPHA,
                                  GL_ONE_MINUS_DST_ALPHA};
   const GLenum dst_factors[8] = {GL_ZERO,
                                  GL_ONE,
                                  GL_SRC_COLOR,
                                  GL_ONE_MINUS_SRC_COLOR,
-                                 useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
+                                 useDualSource ? GL_SRC1_ALPHA : static_cast<GLenum>(GL_SRC_ALPHA),
                                  useDualSource ? GL_ONE_MINUS_SRC1_ALPHA :
-                                                 (GLenum)GL_ONE_MINUS_SRC_ALPHA,
+                                                 static_cast<GLenum>(GL_ONE_MINUS_SRC_ALPHA),
                                  GL_DST_ALPHA,
                                  GL_ONE_MINUS_DST_ALPHA};
 
@@ -588,10 +588,10 @@ void OGLGfx::ApplyBlendingState(const BlendingState state)
   GLenum equation = state.subtract ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
   GLenum equationAlpha = state.subtractAlpha ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
   glBlendEquationSeparate(equation, equationAlpha);
-  glBlendFuncSeparate(src_factors[u32(state.srcfactor.Value())],
-                      dst_factors[u32(state.dstfactor.Value())],
-                      src_factors[u32(state.srcfactoralpha.Value())],
-                      dst_factors[u32(state.dstfactoralpha.Value())]);
+  glBlendFuncSeparate(src_factors[static_cast<u32>(state.srcfactor.Value())],
+                      dst_factors[static_cast<u32>(state.dstfactor.Value())],
+                      src_factors[static_cast<u32>(state.srcfactoralpha.Value())],
+                      dst_factors[static_cast<u32>(state.dstfactoralpha.Value())]);
 
   const GLenum logic_op_codes[16] = {
       GL_CLEAR,         GL_AND,         GL_AND_REVERSE, GL_COPY,  GL_AND_INVERTED, GL_NOOP,
@@ -604,7 +604,7 @@ void OGLGfx::ApplyBlendingState(const BlendingState state)
     if (state.logicopenable)
     {
       glEnable(GL_COLOR_LOGIC_OP);
-      glLogicOp(logic_op_codes[u32(state.logicmode.Value())]);
+      glLogicOp(logic_op_codes[static_cast<u32>(state.logicmode.Value())]);
     }
     else
     {

--- a/Source/Core/VideoBackends/OGL/OGLNativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLNativeVertexFormat.cpp
@@ -41,10 +41,10 @@ static void SetPointer(ShaderAttrib attrib, u32 stride, const AttributeFormat& f
   glEnableVertexAttribArray(static_cast<GLuint>(attrib));
   if (format.integer)
     glVertexAttribIPointer(static_cast<GLuint>(attrib), format.components, VarToGL(format.type),
-                           stride, (u8*)nullptr + format.offset);
+                           stride, static_cast<u8*>(nullptr) + format.offset);
   else
     glVertexAttribPointer(static_cast<GLuint>(attrib), format.components, VarToGL(format.type),
-                          true, stride, (u8*)nullptr + format.offset);
+                          true, stride, static_cast<u8*>(nullptr) + format.offset);
 }
 
 GLVertexFormat::GLVertexFormat(const PortableVertexDeclaration& vtx_decl)

--- a/Source/Core/VideoBackends/OGL/OGLShader.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLShader.cpp
@@ -33,7 +33,7 @@ OGLShader::OGLShader(ShaderStage stage, GLenum gl_type, GLuint gl_id, std::strin
 {
   if (!m_name.empty() && g_backend_info.bSupportsSettingObjectNames)
   {
-    glObjectLabel(GL_SHADER, m_gl_id, (GLsizei)m_name.size(), m_name.c_str());
+    glObjectLabel(GL_SHADER, m_gl_id, static_cast<GLsizei>(m_name.size()), m_name.c_str());
   }
 }
 
@@ -44,7 +44,7 @@ OGLShader::OGLShader(GLuint gl_compute_program_id, std::string source, std::stri
 {
   if (!m_name.empty() && g_backend_info.bSupportsSettingObjectNames)
   {
-    glObjectLabel(GL_PROGRAM, m_gl_compute_program_id, (GLsizei)m_name.size(), m_name.c_str());
+    glObjectLabel(GL_PROGRAM, m_gl_compute_program_id, static_cast<GLsizei>(m_name.size()), m_name.c_str());
   }
 }
 

--- a/Source/Core/VideoBackends/OGL/OGLStreamBuffer.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLStreamBuffer.cpp
@@ -150,9 +150,9 @@ public:
       glBufferData(m_buffertype, m_size, nullptr, GL_STREAM_DRAW);
       m_iterator = 0;
     }
-    u8* pointer = (u8*)glMapBufferRange(m_buffertype, m_iterator, size,
-                                        GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT |
-                                            GL_MAP_UNSYNCHRONIZED_BIT);
+    u8* pointer = static_cast<u8*>(glMapBufferRange(m_buffertype, m_iterator, size,
+                                                    GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT |
+                                                    GL_MAP_UNSYNCHRONIZED_BIT));
     return std::make_pair(pointer, m_iterator);
   }
 
@@ -185,9 +185,9 @@ public:
   std::pair<u8*, u32> Map(u32 size) override
   {
     AllocMemory(size);
-    u8* pointer = (u8*)glMapBufferRange(m_buffertype, m_iterator, size,
-                                        GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT |
-                                            GL_MAP_UNSYNCHRONIZED_BIT);
+    u8* pointer = static_cast<u8*>(glMapBufferRange(m_buffertype, m_iterator, size,
+                                                    GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT |
+                                                    GL_MAP_UNSYNCHRONIZED_BIT));
     return std::make_pair(pointer, m_iterator);
   }
 
@@ -229,9 +229,9 @@ public:
                     GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT |
                         (coherent ? GL_MAP_COHERENT_BIT : 0));
     m_pointer =
-        (u8*)glMapBufferRange(m_buffertype, 0, m_size,
-                              GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT |
-                                  (coherent ? GL_MAP_COHERENT_BIT : GL_MAP_FLUSH_EXPLICIT_BIT));
+        static_cast<u8*>(glMapBufferRange(m_buffertype, 0, m_size,
+                                          GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT |
+                                          (coherent ? GL_MAP_COHERENT_BIT : GL_MAP_FLUSH_EXPLICIT_BIT)));
   }
 
   ~BufferStorage()

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -134,7 +134,7 @@ OGLTexture::OGLTexture(const TextureConfig& tex_config, std::string_view name)
 
   if (!m_name.empty() && g_backend_info.bSupportsSettingObjectNames)
   {
-    glObjectLabel(GL_TEXTURE, m_texId, (GLsizei)m_name.size(), m_name.c_str());
+    glObjectLabel(GL_TEXTURE, m_texId, static_cast<GLsizei>(m_name.size()), m_name.c_str());
   }
 
   glTexParameteri(target, GL_TEXTURE_MAX_LEVEL, m_config.levels - 1);

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -32,8 +32,8 @@ struct SlopeContext
     // adjust a little less than 0.5
     const float adjust = 0.495f;
 
-    xOff = ((float)x0_ - (v0->screenPosition.x - x_off)) + adjust;
-    yOff = ((float)y0_ - (v0->screenPosition.y - y_off)) + adjust;
+    xOff = (static_cast<float>(x0_) - (v0->screenPosition.x - x_off)) + adjust;
+    yOff = (static_cast<float>(y0_) - (v0->screenPosition.y - y_off)) + adjust;
 
     dx10 = v1->screenPosition.x - v0->screenPosition.x;
     dx20 = v2->screenPosition.x - v0->screenPosition.x;
@@ -88,8 +88,8 @@ struct Slope
 
   float GetValue(s32 x, s32 y) const
   {
-    float dx = xOff + (float)(x - x0);
-    float dy = yOff + (float)(y - y0);
+    float dx = xOff + static_cast<float>(x - x0);
+    float dy = yOff + static_cast<float>(y - y0);
     return f0 + (dfdx * dx) + (dfdy * dy);
   }
 };
@@ -131,7 +131,7 @@ static s32 FixedLog2(float f)
 
 static inline int iround(float x)
 {
-  int t = (int)x;
+  int t = static_cast<int>(x);
   if ((x - t) >= 0.5)
     return t + 1;
 
@@ -147,7 +147,7 @@ static void Draw(s32 x, s32 y, s32 xi, s32 yi)
 {
   INCSTAT(g_stats.this_frame.rasterized_pixels);
 
-  s32 z = (s32)std::clamp<float>(ZSlope.GetValue(x, y), 0.0f, 16777215.0f);
+  s32 z = static_cast<s32>(std::clamp<float>(ZSlope.GetValue(x, y), 0.0f, 16777215.0f));
 
   if (bpmem.GetEmulatedZ() == EmulatedZ::Early)
   {
@@ -173,7 +173,7 @@ static void Draw(s32 x, s32 y, s32 xi, s32 yi)
   {
     for (int comp = 0; comp < 4; comp++)
     {
-      u16 color = (u16)ColorSlopes[i][comp].GetValue(x, y);
+      u16 color = static_cast<u16>(ColorSlopes[i][comp].GetValue(x, y));
 
       // clamp color value to 0
       u16 mask = ~(color >> 8);
@@ -186,8 +186,8 @@ static void Draw(s32 x, s32 y, s32 xi, s32 yi)
   for (unsigned int i = 0; i < bpmem.genMode.numtexgens; i++)
   {
     // multiply by 128 because TEV stores UVs as s17.7
-    tev.Uv[i].s = (s32)(pixel.Uv[i][0] * 128);
-    tev.Uv[i].t = (s32)(pixel.Uv[i][1] * 128);
+    tev.Uv[i].s = static_cast<s32>(pixel.Uv[i][0] * 128);
+    tev.Uv[i].t = static_cast<s32>(pixel.Uv[i][1] * 128);
   }
 
   for (unsigned int i = 0; i < bpmem.genMode.numindstages; i++)

--- a/Source/Core/VideoBackends/Software/SWEfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/SWEfbInterface.cpp
@@ -388,7 +388,7 @@ static void SubtractBlend(u8* srcClr, u8* dstClr)
 {
   for (int i = 0; i < 4; i++)
   {
-    int c = (int)dstClr[i] - (int)srcClr[i];
+    int c = static_cast<int>(dstClr[i]) - static_cast<int>(srcClr[i]);
     dstClr[i] = (c < 0) ? 0 : c;
   }
 }

--- a/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
+++ b/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
@@ -90,8 +90,8 @@ void SWOGLWindow::ShowImage(const AbstractTexture* image,
   const SW::SWTexture* sw_image = static_cast<const SW::SWTexture*>(image);
   m_gl_context->Update();  // just updates the render window position and the backbuffer size
 
-  GLsizei glWidth = (GLsizei)m_gl_context->GetBackBufferWidth();
-  GLsizei glHeight = (GLsizei)m_gl_context->GetBackBufferHeight();
+  GLsizei glWidth = static_cast<GLsizei>(m_gl_context->GetBackBufferWidth());
+  GLsizei glHeight = static_cast<GLsizei>(m_gl_context->GetBackBufferHeight());
 
   glViewport(0, 0, glWidth, glHeight);
 

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -109,11 +109,11 @@ void SWVertexLoader::SetFormat()
 template <typename T, typename I>
 static T ReadNormalized(I value)
 {
-  T casted = (T)value;
+  T casted = static_cast<T>(value);
   if (!std::numeric_limits<T>::is_integer && std::numeric_limits<I>::is_integer)
   {
     // normalize if non-float is converted to a float
-    casted *= (T)(1.0 / std::numeric_limits<I>::max());
+    casted *= static_cast<T>(1.0 / std::numeric_limits<I>::max());
   }
   return casted;
 }

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -39,20 +39,20 @@ void Tev::SetRasColor(RasColorChan colorChan, u32 swaptable)
   {
     const u8* color = Color[0];
     const auto& swap = bpmem.tevksel.GetSwapTable(swaptable);
-    RasColor.r = color[u32(swap[ColorChannel::Red])];
-    RasColor.g = color[u32(swap[ColorChannel::Green])];
-    RasColor.b = color[u32(swap[ColorChannel::Blue])];
-    RasColor.a = color[u32(swap[ColorChannel::Alpha])];
+    RasColor.r = color[static_cast<u32>(swap[ColorChannel::Red])];
+    RasColor.g = color[static_cast<u32>(swap[ColorChannel::Green])];
+    RasColor.b = color[static_cast<u32>(swap[ColorChannel::Blue])];
+    RasColor.a = color[static_cast<u32>(swap[ColorChannel::Alpha])];
   }
   break;
   case RasColorChan::Color1:
   {
     const u8* color = Color[1];
     const auto& swap = bpmem.tevksel.GetSwapTable(swaptable);
-    RasColor.r = color[u32(swap[ColorChannel::Red])];
-    RasColor.g = color[u32(swap[ColorChannel::Green])];
-    RasColor.b = color[u32(swap[ColorChannel::Blue])];
-    RasColor.a = color[u32(swap[ColorChannel::Alpha])];
+    RasColor.r = color[static_cast<u32>(swap[ColorChannel::Red])];
+    RasColor.g = color[static_cast<u32>(swap[ColorChannel::Green])];
+    RasColor.b = color[static_cast<u32>(swap[ColorChannel::Blue])];
+    RasColor.a = color[static_cast<u32>(swap[ColorChannel::Alpha])];
   }
   break;
   case RasColorChan::AlphaBump:
@@ -386,8 +386,8 @@ void Tev::Indirect(unsigned int stageNum, s32 s, s32 t)
 
 void Tev::Draw()
 {
-  ASSERT(Position[0] >= 0 && Position[0] < s32(EFB_WIDTH));
-  ASSERT(Position[1] >= 0 && Position[1] < s32(EFB_HEIGHT));
+  ASSERT(Position[0] >= 0 && Position[0] < static_cast<s32>(EFB_WIDTH));
+  ASSERT(Position[1] >= 0 && Position[1] < static_cast<s32>(EFB_HEIGHT));
 
   INCSTAT(g_stats.this_frame.tev_pixels_in);
 
@@ -465,16 +465,16 @@ void Tev::Draw()
         std::memset(texel, 0, 4);
       }
 
-      RawTexColor.r = texel[u32(ColorChannel::Red)];
-      RawTexColor.g = texel[u32(ColorChannel::Green)];
-      RawTexColor.b = texel[u32(ColorChannel::Blue)];
-      RawTexColor.a = texel[u32(ColorChannel::Alpha)];
+      RawTexColor.r = texel[static_cast<u32>(ColorChannel::Red)];
+      RawTexColor.g = texel[static_cast<u32>(ColorChannel::Green)];
+      RawTexColor.b = texel[static_cast<u32>(ColorChannel::Blue)];
+      RawTexColor.a = texel[static_cast<u32>(ColorChannel::Alpha)];
 
       const auto& swap = bpmem.tevksel.GetSwapTable(ac.tswap);
-      TexColor.r = texel[u32(swap[ColorChannel::Red])];
-      TexColor.g = texel[u32(swap[ColorChannel::Green])];
-      TexColor.b = texel[u32(swap[ColorChannel::Blue])];
-      TexColor.a = texel[u32(swap[ColorChannel::Alpha])];
+      TexColor.r = texel[static_cast<u32>(swap[ColorChannel::Red])];
+      TexColor.g = texel[static_cast<u32>(swap[ColorChannel::Green])];
+      TexColor.b = texel[static_cast<u32>(swap[ColorChannel::Blue])];
+      TexColor.a = texel[static_cast<u32>(swap[ColorChannel::Alpha])];
     }
 
     // set konst for this stage
@@ -541,8 +541,8 @@ void Tev::Draw()
   // regardless of the used destination register - TODO: Verify!
   const auto& color_index = bpmem.combiners[bpmem.genMode.numtevstages].colorC.dest;
   const auto& alpha_index = bpmem.combiners[bpmem.genMode.numtevstages].alphaC.dest;
-  u8 output[4] = {(u8)Reg[alpha_index].a, (u8)Reg[color_index].b, (u8)Reg[color_index].g,
-                  (u8)Reg[color_index].r};
+  u8 output[4] = {static_cast<u8>(Reg[alpha_index].a), static_cast<u8>(Reg[color_index].b), static_cast<u8>(Reg[color_index].g),
+                  static_cast<u8>(Reg[color_index].r)};
 
   if (!TevAlphaTest(output[ALP_C]))
     return;
@@ -611,7 +611,7 @@ void Tev::Draw()
       floatindex = std::clamp(floatindex, 0.f, 9.f);  // TODO: This shouldn't be necessary!
 
       // Get the two closest integer indices, look up the corresponding samples
-      const int indexlower = (int)floatindex;
+      const int indexlower = static_cast<int>(floatindex);
       const int indexupper = indexlower + 1;
       // Look up coefficient... Seems like multiplying by 4 makes Fortune Street work properly (fog
       // is too strong without the factor)
@@ -652,7 +652,7 @@ void Tev::Draw()
     }
 
     // lerp from output to fog color
-    const u32 fogInt = (u32)(fog * 256);
+    const u32 fogInt = static_cast<u32>(fog * 256);
     const u32 invFog = 256 - fogInt;
 
     output[RED_C] = (output[RED_C] * invFog + fogInt * bpmem.fog.color.r) >> 8;

--- a/Source/Core/VideoBackends/Software/TextureSampler.cpp
+++ b/Source/Core/VideoBackends/Software/TextureSampler.cpp
@@ -103,10 +103,10 @@ void Sample(s32 s, s32 t, s32 lod, bool linear, u8 texmap, u8* sample)
     SampleMip(s, t, baseMip + 1, linear, texmap, sampledTex);
     AddTexel(sampledTex, texel, lodFract);
 
-    sample[0] = (u8)(texel[0] >> 4);
-    sample[1] = (u8)(texel[1] >> 4);
-    sample[2] = (u8)(texel[2] >> 4);
-    sample[3] = (u8)(texel[3] >> 4);
+    sample[0] = static_cast<u8>(texel[0] >> 4);
+    sample[1] = static_cast<u8>(texel[1] >> 4);
+    sample[2] = static_cast<u8>(texel[2] >> 4);
+    sample[3] = static_cast<u8>(texel[3] >> 4);
   }
   else
 #endif
@@ -239,10 +239,10 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
       AddTexel(sampledTex, texel, (fractS) * (fractT));
     }
 
-    sample[0] = (u8)(texel[0] >> 14);
-    sample[1] = (u8)(texel[1] >> 14);
-    sample[2] = (u8)(texel[2] >> 14);
-    sample[3] = (u8)(texel[3] >> 14);
+    sample[0] = static_cast<u8>(texel[0] >> 14);
+    sample[1] = static_cast<u8>(texel[1] >> 14);
+    sample[2] = static_cast<u8>(texel[2] >> 14);
+    sample[3] = static_cast<u8>(texel[3] >> 14);
   }
   else
   {

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -62,7 +62,7 @@ static void MultipleVec3Perspective(const Vec3& vec, const Projection::Raw& proj
   result.x = proj[0] * vec.x + proj[1] * vec.z;
   result.y = proj[2] * vec.y + proj[3] * vec.z;
   // result.z = (proj[4] * vec.z + proj[5]);
-  result.z = (proj[4] * vec.z + proj[5]) * (1.0f - (float)1e-7);
+  result.z = (proj[4] * vec.z + proj[5]) * (1.0f - static_cast<float>(1e-7));
   result.w = -vec.z;
 }
 
@@ -422,14 +422,14 @@ void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst)
     break;
     case TexGenType::Color0:
       ASSERT(texinfo.inputform == TexInputForm::AB11);
-      dst->texCoords[coordNum].x = (float)dst->color[0][0] / 255.0f;
-      dst->texCoords[coordNum].y = (float)dst->color[0][1] / 255.0f;
+      dst->texCoords[coordNum].x = static_cast<float>(dst->color[0][0]) / 255.0f;
+      dst->texCoords[coordNum].y = static_cast<float>(dst->color[0][1]) / 255.0f;
       dst->texCoords[coordNum].z = 1.0f;
       break;
     case TexGenType::Color1:
       ASSERT(texinfo.inputform == TexInputForm::AB11);
-      dst->texCoords[coordNum].x = (float)dst->color[1][0] / 255.0f;
-      dst->texCoords[coordNum].y = (float)dst->color[1][1] / 255.0f;
+      dst->texCoords[coordNum].x = static_cast<float>(dst->color[1][0]) / 255.0f;
+      dst->texCoords[coordNum].y = static_cast<float>(dst->color[1][1]) / 255.0f;
       dst->texCoords[coordNum].z = 1.0f;
       break;
     default:

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -380,11 +380,11 @@ VkSampler ObjectCache::GetSampler(const SamplerState& info)
       VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,              // VkStructureType         sType
       nullptr,                                            // const void*             pNext
       0,                                                  // VkSamplerCreateFlags    flags
-      filters[u32(info.tm0.mag_filter.Value())],          // VkFilter                magFilter
-      filters[u32(info.tm0.min_filter.Value())],          // VkFilter                minFilter
-      mipmap_modes[u32(info.tm0.mipmap_filter.Value())],  // VkSamplerMipmapMode mipmapMode
-      address_modes[u32(info.tm0.wrap_u.Value())],        // VkSamplerAddressMode    addressModeU
-      address_modes[u32(info.tm0.wrap_v.Value())],        // VkSamplerAddressMode    addressModeV
+      filters[static_cast<u32>(info.tm0.mag_filter.Value())],          // VkFilter                magFilter
+      filters[static_cast<u32>(info.tm0.min_filter.Value())],          // VkFilter                minFilter
+      mipmap_modes[static_cast<u32>(info.tm0.mipmap_filter.Value())],  // VkSamplerMipmapMode mipmapMode
+      address_modes[static_cast<u32>(info.tm0.wrap_u.Value())],        // VkSamplerAddressMode    addressModeU
+      address_modes[static_cast<u32>(info.tm0.wrap_v.Value())],        // VkSamplerAddressMode    addressModeV
       VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,              // VkSamplerAddressMode    addressModeW
       info.tm0.lod_bias / 256.0f,                         // float                   mipLodBias
       VK_FALSE,                                 // VkBool32                anisotropyEnable

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -55,7 +55,7 @@ GetVulkanRasterizationState(const RasterizationState& state)
       depth_clamp,           // VkBool32                                  depthClampEnable
       VK_FALSE,              // VkBool32                                  rasterizerDiscardEnable
       VK_POLYGON_MODE_FILL,  // VkPolygonMode                             polygonMode
-      cull_modes[u32(state.cullmode.Value())],  // VkCullModeFlags        cullMode
+      cull_modes[static_cast<u32>(state.cullmode.Value())],  // VkCullModeFlags        cullMode
       VK_FRONT_FACE_CLOCKWISE,                  // VkFrontFace            frontFace
       VK_FALSE,  // VkBool32                                              depthBiasEnable
       0.0f,      // float                                                 depthBiasConstantFactor
@@ -224,7 +224,7 @@ GetVulkanColorBlendState(const BlendingState& state,
   }
 
   VkLogicOp vk_logic_op =
-      vk_logic_op_enable ? vk_logic_ops[u32(state.logicmode.Value())] : VK_LOGIC_OP_CLEAR;
+      vk_logic_op_enable ? vk_logic_ops[static_cast<u32>(state.logicmode.Value())] : VK_LOGIC_OP_CLEAR;
 
   VkPipelineColorBlendStateCreateInfo vk_state = {
       VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,  // VkStructureType sType

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -137,7 +137,7 @@ std::unique_ptr<VKTexture> VKTexture::CreateAdopted(const TextureConfig& tex_con
                                                     VkImageViewType view_type, VkImageLayout layout)
 {
   std::unique_ptr<VKTexture> texture = std::make_unique<VKTexture>(
-      tex_config, VmaAllocation(VK_NULL_HANDLE), image, "", layout, ComputeImageLayout::Undefined);
+      tex_config, static_cast<VmaAllocation>(VK_NULL_HANDLE), image, "", layout, ComputeImageLayout::Undefined);
   if (!texture->CreateView(view_type))
     return nullptr;
 

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -54,7 +54,7 @@ public:
   VkImageView GetView() const { return m_view; }
   VkImageLayout GetLayout() const { return m_layout; }
   VkFormat GetVkFormat() const { return GetVkFormatForHostTextureFormat(m_config.format); }
-  bool IsAdopted() const { return m_alloc != VmaAllocation(VK_NULL_HANDLE); }
+  bool IsAdopted() const { return m_alloc != static_cast<VmaAllocation>(VK_NULL_HANDLE); }
 
   static std::unique_ptr<VKTexture> Create(const TextureConfig& tex_config, std::string_view name);
   static std::unique_ptr<VKTexture>

--- a/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
@@ -13,7 +13,7 @@ void CustomAssetLoader::Init()
   m_asset_monitor_thread_shutdown.Clear();
 
   const size_t sys_mem = Common::MemPhysical();
-  const size_t recommended_min_mem = 2 * size_t(1024 * 1024 * 1024);
+  const size_t recommended_min_mem = 2 * static_cast<size_t>(1024 * 1024 * 1024);
   // keep 2GB memory for system stability if system RAM is 4GB+ - use half of memory in other cases
   m_max_memory_available =
       (sys_mem / 2 < recommended_min_mem) ? (sys_mem / 2) : (sys_mem - recommended_min_mem);

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -270,12 +270,12 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
     // to the EFB borders for over-offset copies. The arcade virtual console games (e.g. 1942) are
     // known for configuring these out-of-range copies.
 
-    if (u32(srcRect.right) > EFB_WIDTH || u32(srcRect.bottom) > EFB_HEIGHT)
+    if (static_cast<u32>(srcRect.right) > EFB_WIDTH || static_cast<u32>(srcRect.bottom) > EFB_HEIGHT)
     {
       WARN_LOG_FMT(VIDEO, "Oversized EFB copy: {}x{} (offset {},{} stride {})", srcRect.GetWidth(),
                    srcRect.GetHeight(), srcRect.left, srcRect.top, destStride);
 
-      if (u32(srcRect.left) >= EFB_WIDTH || u32(srcRect.top) >= EFB_HEIGHT)
+      if (static_cast<u32>(srcRect.left) >= EFB_WIDTH || static_cast<u32>(srcRect.top) >= EFB_HEIGHT)
       {
         // This is not a sane src rectangle, it doesn't touch any valid image data at all
         // Just ignore it

--- a/Source/Core/VideoCommon/EFBInterface.cpp
+++ b/Source/Core/VideoCommon/EFBInterface.cpp
@@ -152,7 +152,7 @@ void HardwareEFBInterface::PokeDepth(u16 x, u16 y, u32 poke_data)
     return;
 
   // Convert to floating-point depth.
-  float depth = float(poke_data & 0xFFFFFF) / 16777216.0f;
+  float depth = static_cast<float>(poke_data & 0xFFFFFF) / 16777216.0f;
   if (!g_backend_info.bSupportsReversedDepthRange)
     depth = 1.0f - depth;
 

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -186,7 +186,7 @@ void FifoManager::SyncGPU(SyncGPUReason reason, bool may_move_read_ptr)
 
 void FifoManager::PushFifoAuxBuffer(const void* ptr, size_t size)
 {
-  if (size > (size_t)(m_fifo_aux_data + FIFO_SIZE - m_fifo_aux_write_ptr))
+  if (size > static_cast<size_t>(m_fifo_aux_data + FIFO_SIZE - m_fifo_aux_write_ptr))
   {
     SyncGPU(SyncGPUReason::AuxSpace, /* may_move_read_ptr */ false);
     if (!m_gpu_mainloop.IsRunning())
@@ -194,7 +194,7 @@ void FifoManager::PushFifoAuxBuffer(const void* ptr, size_t size)
       // GPU is shutting down
       return;
     }
-    if (size > (size_t)(m_fifo_aux_data + FIFO_SIZE - m_fifo_aux_write_ptr))
+    if (size > static_cast<size_t>(m_fifo_aux_data + FIFO_SIZE - m_fifo_aux_write_ptr))
     {
       // That will sync us up to the last 32 bytes, so this short region
       // of FIFO would have to point to a 2MB display list or something.
@@ -360,10 +360,10 @@ void FifoManager::RunGpuLoop()
 
             if (m_config_sync_gpu)
             {
-              cyclesExecuted = (int)(cyclesExecuted / m_config_sync_gpu_overclock);
+              cyclesExecuted = static_cast<int>(cyclesExecuted / m_config_sync_gpu_overclock);
               int old = m_sync_ticks.fetch_sub(cyclesExecuted);
               if (old >= m_config_sync_gpu_max_distance &&
-                  old - (int)cyclesExecuted < m_config_sync_gpu_max_distance)
+                  old - static_cast<int>(cyclesExecuted) < m_config_sync_gpu_max_distance)
               {
                 m_sync_wakeup_event.Set();
               }
@@ -445,7 +445,7 @@ int FifoManager::RunGpuOnCpu(int ticks)
   auto& command_processor = m_system.GetCommandProcessor();
   auto& fifo = command_processor.GetFifo();
   bool reset_simd_state = false;
-  int available_ticks = int(ticks * m_config_sync_gpu_overclock) + m_sync_ticks.load();
+  int available_ticks = static_cast<int>(ticks * m_config_sync_gpu_overclock) + m_sync_ticks.load();
   while (fifo.bFF_GPReadEnable.load(std::memory_order_relaxed) &&
          fifo.CPReadWriteDistance.load(std::memory_order_relaxed) && !AtBreakpoint(m_system) &&
          available_ticks >= 0)
@@ -572,11 +572,11 @@ void FifoManager::SyncGPUCallback(Core::System& system, u64 ticks, s64 cyclesLat
   auto& fifo = system.GetFifo();
   if (!system.IsDualCoreMode() || fifo.m_use_deterministic_gpu_thread)
   {
-    next = fifo.RunGpuOnCpu(int(ticks));
+    next = fifo.RunGpuOnCpu(static_cast<int>(ticks));
   }
   else if (fifo.m_config_sync_gpu)
   {
-    next = fifo.WaitForGpuThread(int(ticks));
+    next = fifo.WaitForGpuThread(static_cast<int>(ticks));
   }
 
   fifo.m_syncing_suspended = next < 0;

--- a/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
+++ b/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
@@ -67,8 +67,8 @@ AVRational GetTimeBaseForCurrentRefreshRate()
   auto& vi = Core::System::GetInstance().GetVideoInterface();
   int num;
   int den;
-  av_reduce(&num, &den, int(vi.GetTargetRefreshRateDenominator()),
-            int(vi.GetTargetRefreshRateNumerator()), std::numeric_limits<int>::max());
+  av_reduce(&num, &den, static_cast<int>(vi.GetTargetRefreshRateDenominator()),
+            static_cast<int>(vi.GetTargetRefreshRateNumerator()), std::numeric_limits<int>::max());
   return AVRational{num, den};
 }
 
@@ -154,7 +154,7 @@ std::string AVErrorString(int error)
 {
   std::array<char, AV_ERROR_MAX_STRING_SIZE> msg;
   av_make_error_string(&msg[0], msg.size(), error);
-  return fmt::format("{:8x} {}", (u32)error, &msg[0]);
+  return fmt::format("{:8x} {}", static_cast<u32>(error), &msg[0]);
 }
 
 }  // namespace
@@ -358,7 +358,7 @@ void FFMpegFrameDump::AddFrame(const FrameData& frame)
   // Calculate presentation timestamp from ticks since start.
   const s64 pts = av_rescale_q(
       frame.state.ticks - m_context->start_ticks,
-      AVRational{1, int(Core::System::GetInstance().GetSystemTimers().GetTicksPerSecond())},
+      AVRational{1, static_cast<int>(Core::System::GetInstance().GetSystemTimers().GetTicksPerSecond())},
       m_context->codec->time_base);
 
   if (!IsFirstFrameInCurrentFile())

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -202,12 +202,12 @@ int FramebufferManager::EFBToScaledY(int y) const
 
 float FramebufferManager::EFBToScaledXf(float x) const
 {
-  return x * ((float)GetEFBWidth() / (float)EFB_WIDTH);
+  return x * (static_cast<float>(GetEFBWidth()) / static_cast<float>(EFB_WIDTH));
 }
 
 float FramebufferManager::EFBToScaledYf(float y) const
 {
-  return y * ((float)GetEFBHeight() / (float)EFB_HEIGHT);
+  return y * (static_cast<float>(GetEFBHeight()) / static_cast<float>(EFB_HEIGHT));
 }
 
 std::tuple<u32, u32> FramebufferManager::CalculateTargetSize()

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -75,7 +75,7 @@ static float DrawMessage(int index, Message& msg, const ImVec2& position, int ti
   ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f));
 
   // Gradually fade old messages away (except in their first frame)
-  const float fade_time = std::max(std::min(MESSAGE_FADE_TIME, (float)msg.duration), 1.f);
+  const float fade_time = std::max(std::min(MESSAGE_FADE_TIME, static_cast<float>(msg.duration)), 1.f);
   const float alpha = std::clamp(time_left / fade_time, 0.f, 1.f);
   ImGui::PushStyleVar(ImGuiStyleVar_Alpha, msg.ever_drawn ? alpha : 1.0);
 

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -449,10 +449,10 @@ void OnScreenUI::SetKeyMap(const DolphinKeyMap& key_map)
   m_dolphin_to_imgui_map.clear();
   for (int dolphin_key = 0; dolphin_key <= static_cast<int>(DolphinKey::Z); dolphin_key++)
   {
-    const int imgui_key = dolphin_to_imgui_map[DolphinKey(dolphin_key)];
+    const int imgui_key = dolphin_to_imgui_map[static_cast<DolphinKey>(dolphin_key)];
     if (imgui_key >= 0)
     {
-      const int mapped_key = key_map[DolphinKey(dolphin_key)];
+      const int mapped_key = key_map[static_cast<DolphinKey>(dolphin_key)];
       m_dolphin_to_imgui_map[mapped_key & 0x1FF] = imgui_key;
     }
   }
@@ -462,7 +462,7 @@ void OnScreenUI::SetKey(u32 key, bool is_down, const char* chars)
 {
   auto lock = GetImGuiLock();
   if (auto iter = m_dolphin_to_imgui_map.find(key); iter != m_dolphin_to_imgui_map.end())
-    ImGui::GetIO().AddKeyEvent((ImGuiKey)iter->second, is_down);
+    ImGui::GetIO().AddKeyEvent(static_cast<ImGuiKey>(iter->second), is_down);
 
   if (chars)
     ImGui::GetIO().AddInputCharactersUTF8(chars);

--- a/Source/Core/VideoCommon/OpcodeDecoding.h
+++ b/Source/Core/VideoCommon/OpcodeDecoding.h
@@ -162,7 +162,7 @@ static DOLPHIN_FORCE_INLINE u32 RunCommand(const u8* data, u32 available, T& cal
     ASSERT_MSG(VIDEO, stream_size_temp < 16, "cmd2 = 0x{:08X}", cmd2);
     const u8 stream_size = (stream_size_temp & 0xf) + 1;
 
-    if (available < u32(5 + stream_size * 4))
+    if (available < static_cast<u32>(5 + stream_size * 4))
       return 0;
 
     callback.OnXF(base_address, stream_size, &data[5]);

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1354,7 +1354,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     else
     {
       out.Write("\twrappedcoord.x = fixpoint_uv{}.x & ({} - 1);\n", texcoord,
-                tev_ind_wrap_start[u32(tevind.sw.Value()) - u32(IndTexWrap::ITW_256)]);
+                tev_ind_wrap_start[static_cast<u32>(tevind.sw.Value()) - static_cast<u32>(IndTexWrap::ITW_256)]);
     }
 
     // wrap T
@@ -1369,7 +1369,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     else
     {
       out.Write("\twrappedcoord.y = fixpoint_uv{}.y & ({} - 1);\n", texcoord,
-                tev_ind_wrap_start[u32(tevind.tw.Value()) - u32(IndTexWrap::ITW_256)]);
+                tev_ind_wrap_start[static_cast<u32>(tevind.tw.Value()) - static_cast<u32>(IndTexWrap::ITW_256)]);
     }
 
     if (tevind.fb_addprev)  // add previous tevcoord
@@ -1426,15 +1426,15 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     out.Write("\tkonsttemp = int4({}, {});\n", tev_ksel_table_c[stage.tevksel_kc],
               tev_ksel_table_a[stage.tevksel_ka]);
 
-    if (u32(stage.tevksel_kc) > 7)
+    if (static_cast<u32>(stage.tevksel_kc) > 7)
     {
-      out.SetConstantsUsed(C_KCOLORS + ((u32(stage.tevksel_kc) - 0xc) % 4),
-                           C_KCOLORS + ((u32(stage.tevksel_kc) - 0xc) % 4));
+      out.SetConstantsUsed(C_KCOLORS + ((static_cast<u32>(stage.tevksel_kc) - 0xc) % 4),
+                           C_KCOLORS + ((static_cast<u32>(stage.tevksel_kc) - 0xc) % 4));
     }
-    if (u32(stage.tevksel_ka) > 7)
+    if (static_cast<u32>(stage.tevksel_ka) > 7)
     {
-      out.SetConstantsUsed(C_KCOLORS + ((u32(stage.tevksel_ka) - 0xc) % 4),
-                           C_KCOLORS + ((u32(stage.tevksel_ka) - 0xc) % 4));
+      out.SetConstantsUsed(C_KCOLORS + ((static_cast<u32>(stage.tevksel_ka) - 0xc) % 4),
+                           C_KCOLORS + ((static_cast<u32>(stage.tevksel_ka) - 0xc) % 4));
     }
   }
 
@@ -1448,10 +1448,10 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     out.SetConstantsUsed(C_COLORS + 3, C_COLORS + 3);
 
   if (cc.dest >= TevOutput::Color0)
-    out.SetConstantsUsed(C_COLORS + u32(cc.dest.Value()), C_COLORS + u32(cc.dest.Value()));
+    out.SetConstantsUsed(C_COLORS + static_cast<u32>(cc.dest.Value()), C_COLORS + static_cast<u32>(cc.dest.Value()));
 
   if (ac.dest >= TevOutput::Color0)
-    out.SetConstantsUsed(C_COLORS + u32(ac.dest.Value()), C_COLORS + u32(ac.dest.Value()));
+    out.SetConstantsUsed(C_COLORS + static_cast<u32>(ac.dest.Value()), C_COLORS + static_cast<u32>(ac.dest.Value()));
 
   if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_VECTOR_BITWISE_AND))
   {

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -91,7 +91,7 @@ void PixelShaderManager::SetConstants()
     {
       // bpmem.fogRange.Base.Center : center of the viewport in x axis. observation:
       // bpmem.fogRange.Base.Center = realcenter + 342;
-      int center = ((u32)bpmem.fogRange.Base.Center) - 342;
+      int center = static_cast<u32>(bpmem.fogRange.Base.Center) - 342;
       // normalize center to make calculations easy
       float ScreenSpaceCenter = center / (2.0f * xfmem.viewport.wd);
       ScreenSpaceCenter = (ScreenSpaceCenter * 2.0f) - 1.0f;
@@ -127,8 +127,8 @@ void PixelShaderManager::SetConstants()
 
   if (m_viewport_changed)
   {
-    constants.zbias[1][0] = (s32)xfmem.viewport.farZ;
-    constants.zbias[1][1] = (s32)xfmem.viewport.zRange;
+    constants.zbias[1][0] = static_cast<s32>(xfmem.viewport.farZ);
+    constants.zbias[1][1] = static_cast<s32>(xfmem.viewport.zRange);
     dirty = true;
     m_viewport_changed = false;
   }

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -305,7 +305,7 @@ void Presenter::SetBackbuffer(SurfaceInfo info)
 {
   const bool is_first = m_backbuffer_width == 0 && m_backbuffer_height == 0;
   const bool size_changed =
-      (m_backbuffer_width != (int)info.width || m_backbuffer_height != (int)info.height);
+      (m_backbuffer_width != static_cast<int>(info.width) || m_backbuffer_height != static_cast<int>(info.height));
   m_backbuffer_width = info.width;
   m_backbuffer_height = info.height;
   m_backbuffer_scale = info.scale;
@@ -534,8 +534,8 @@ u32 Presenter::AutoIntegralScale() const
   u32 source_height = m_last_xfb_height;
   const u32 target_width = m_target_rectangle.GetWidth();
   const u32 target_height = m_target_rectangle.GetHeight();
-  const float source_aspect_ratio = (float)source_width / source_height;
-  const float target_aspect_ratio = (float)target_width / target_height;
+  const float source_aspect_ratio = static_cast<float>(source_width) / source_height;
+  const float target_aspect_ratio = static_cast<float>(target_width) / target_height;
   if (source_aspect_ratio >= target_aspect_ratio)
     source_width = std::round(source_height * target_aspect_ratio);
   else

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -244,8 +244,8 @@ void Statistics::DisplayScissor()
   constexpr int DRAW_END = DRAW_START + 3 * 1024;
 
   const auto vec = [&](int x, int y, int xoff = 0, int yoff = 0) {
-    return ImVec2(p.x + int(float(x - DRAW_START) / scissor_scale) + xoff,
-                  p.y + int(float(y - DRAW_START) / scissor_scale) + yoff);
+    return ImVec2(p.x + static_cast<int>(static_cast<float>(x - DRAW_START) / scissor_scale) + xoff,
+                  p.y + static_cast<int>(static_cast<float>(y - DRAW_START) / scissor_scale) + yoff);
   };
 
   const auto light_grey = ImGui::GetColorU32(ImVec4(.5f, .5f, .5f, 1.f));
@@ -380,7 +380,7 @@ void Statistics::DisplayScissor()
     draw_list->AddRect(
         p2, ImVec2(p2.x + EFB_WIDTH * scale_height, p2.y + EFB_HEIGHT * scale_height), light_grey);
     ImGui::SameLine();
-    ImGui::Text("%d", int(info.m_result.size()));
+    ImGui::Text("%d", static_cast<int>(info.m_result.size()));
 
     if (show_raw_scissors)
     {

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1535,7 +1535,7 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
   // different ones
   if (textureCacheSafetyColorSampleSize == 0 ||
       std::max(texture_info.GetTextureSize(), palette_size) <=
-          (u32)textureCacheSafetyColorSampleSize * 8)
+          static_cast<u32>(textureCacheSafetyColorSampleSize) * 8)
   {
     auto hash_range = m_textures_by_hash.equal_range(full_hash);
     TexHashCache::iterator hash_iter = hash_range.first;
@@ -1667,7 +1667,7 @@ RcTcacheEntry TextureCacheBase::CreateTextureEntry(
           assets_data, {}, [](const auto& v) { return v->m_texture.m_slices[0].m_levels.size(); });
       return (*max_element)->m_texture.m_slices[0].m_levels.size();
     };
-    const u32 texLevels = no_mips ? 1 : (u32)calculate_max_levels();
+    const u32 texLevels = no_mips ? 1 : static_cast<u32>(calculate_max_levels());
     const auto& first_level = assets_data[0]->m_texture.m_slices[0].m_levels[0];
     const TextureConfig config(first_level.width, first_level.height, texLevels,
                                static_cast<u32>(assets_data.size()), 1, first_level.format, 0,
@@ -1821,7 +1821,7 @@ RcTcacheEntry TextureCacheBase::CreateTextureEntry(
   const auto iter = m_textures_by_address.emplace(texture_info.GetRawAddress(), entry);
   if (safety_color_sample_size == 0 ||
       std::max(texture_info.GetTextureSize(), creation_info.palette_size) <=
-          (u32)safety_color_sample_size * 8)
+          static_cast<u32>(safety_color_sample_size) * 8)
   {
     entry->textures_by_hash_iter = m_textures_by_hash.emplace(creation_info.full_hash, entry);
   }
@@ -2650,7 +2650,7 @@ void TextureCacheBase::UninitializeXFBMemory(u8* dst, u32 stride, u32 bytes_per_
   // like is done in the EFB path.
 
 #if defined(_M_X86_64)
-  __m128i sixteenBytes = _mm_set1_epi16((s16)(u16)0xFE01);
+  __m128i sixteenBytes = _mm_set1_epi16(static_cast<s16>(static_cast<u16>(0xFE01)));
 #endif
 
   for (u32 i = 0; i < num_blocks_y; i++)

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -623,17 +623,17 @@ void TexDecoder_DecodeTexel(u8* dst, std::span<const u8> src, int s, int t, int 
     size_t offset = (t * imageWidth + (s & (~1))) * 2;
 
     // We do this one color sample (aka 2 RGB pixles) at a time
-    int Y = int((s & 1) == 0 ? src[offset] : src[offset + 2]) - 16;
-    int U = int(src[offset + 1]) - 128;
-    int V = int(src[offset + 3]) - 128;
+    int Y = static_cast<int>((s & 1) == 0 ? src[offset] : src[offset + 2]) - 16;
+    int U = static_cast<int>(src[offset + 1]) - 128;
+    int V = static_cast<int>(src[offset + 3]) - 128;
 
     // We do the inverse BT.601 conversion for YCbCr to RGB
     // http://www.equasys.de/colorconversion.html#YCbCr-RGBColorFormatConversion
     // TODO: Use more precise numbers for this conversion (although on real hardware, the XFB isn't
     // in a real texture format, so does this conversion actually ever happen?)
-    u8 R = std::clamp(int(1.164f * Y + 1.596f * V), 0, 255);
-    u8 G = std::clamp(int(1.164f * Y - 0.392f * U - 0.813f * V), 0, 255);
-    u8 B = std::clamp(int(1.164f * Y + 2.017f * U), 0, 255);
+    u8 R = std::clamp(static_cast<int>(1.164f * Y + 1.596f * V), 0, 255);
+    u8 G = std::clamp(static_cast<int>(1.164f * Y - 0.392f * U - 0.813f * V), 0, 255);
+    u8 B = std::clamp(static_cast<int>(1.164f * Y + 2.017f * U), 0, 255);
     dst[t * imageWidth + s] = 0xff000000 | B << 16 | G << 8 | R;
   }
   break;
@@ -711,22 +711,22 @@ void TexDecoder_DecodeXFB(u8* dst, const u8* src, u32 width, u32 height, u32 str
     for (u32 x = 0; x < width; x += 2)
     {
       // We do this one color sample (aka 2 RGB pixels) at a time
-      int Y1 = int(*(row_ptr++)) - 16;
-      int U = int(*(row_ptr++)) - 128;
-      int Y2 = int(*(row_ptr++)) - 16;
-      int V = int(*(row_ptr++)) - 128;
+      int Y1 = static_cast<int>(*(row_ptr++)) - 16;
+      int U = static_cast<int>(*(row_ptr++)) - 128;
+      int Y2 = static_cast<int>(*(row_ptr++)) - 16;
+      int V = static_cast<int>(*(row_ptr++)) - 128;
 
       // We do the inverse BT.601 conversion for YCbCr to RGB
       // http://www.equasys.de/colorconversion.html#YCbCr-RGBColorFormatConversion
       // TODO: Use more precise numbers for this conversion (although on real hardware, the XFB
       // isn't in a real texture format, so does this conversion actually ever happen?)
-      u8 R1 = static_cast<u8>(std::clamp(int(1.164f * Y1 + 1.596f * V), 0, 255));
-      u8 G1 = static_cast<u8>(std::clamp(int(1.164f * Y1 - 0.392f * U - 0.813f * V), 0, 255));
-      u8 B1 = static_cast<u8>(std::clamp(int(1.164f * Y1 + 2.017f * U), 0, 255));
+      u8 R1 = static_cast<u8>(std::clamp(static_cast<int>(1.164f * Y1 + 1.596f * V), 0, 255));
+      u8 G1 = static_cast<u8>(std::clamp(static_cast<int>(1.164f * Y1 - 0.392f * U - 0.813f * V), 0, 255));
+      u8 B1 = static_cast<u8>(std::clamp(static_cast<int>(1.164f * Y1 + 2.017f * U), 0, 255));
 
-      u8 R2 = static_cast<u8>(std::clamp(int(1.164f * Y2 + 1.596f * V), 0, 255));
-      u8 G2 = static_cast<u8>(std::clamp(int(1.164f * Y2 - 0.392f * U - 0.813f * V), 0, 255));
-      u8 B2 = static_cast<u8>(std::clamp(int(1.164f * Y2 + 2.017f * U), 0, 255));
+      u8 R2 = static_cast<u8>(std::clamp(static_cast<int>(1.164f * Y2 + 1.596f * V), 0, 255));
+      u8 G2 = static_cast<u8>(std::clamp(static_cast<int>(1.164f * Y2 - 0.392f * U - 0.813f * V), 0, 255));
+      u8 B2 = static_cast<u8>(std::clamp(static_cast<int>(1.164f * Y2 + 2.017f * U), 0, 255));
 
       u32 rgba = 0xff000000 | B1 << 16 | G1 << 8 | R1;
       std::memcpy(dst_ptr, &rgba, sizeof(rgba));

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -646,8 +646,8 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
             "    ss.order = bpmem_tevorder(stage>>1);\n"
             "    if ((stage & 1u) == 1u)\n"
             "      ss.order = ss.order >> {};\n\n",
-            int(TwoTevStageOrders().enable_tex_odd.StartBit() -
-                TwoTevStageOrders().enable_tex_even.StartBit()));
+            static_cast<int>(TwoTevStageOrders().enable_tex_odd.StartBit() -
+                             TwoTevStageOrders().enable_tex_even.StartBit()));
 
   // Disable texturing when there are no texgens (for now)
   if (numTexgen != 0)

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -37,20 +37,20 @@ static void TexMtx_ReadDirect_UByte(VertexLoader* loader)
 
 static void TexMtx_Write_Float(VertexLoader* loader)
 {
-  DataWrite(float(loader->m_curtexmtx[loader->m_texmtxwrite++]));
+  DataWrite(static_cast<float>(loader->m_curtexmtx[loader->m_texmtxwrite++]));
 }
 
 static void TexMtx_Write_Float2(VertexLoader* loader)
 {
   DataWrite(0.f);
-  DataWrite(float(loader->m_curtexmtx[loader->m_texmtxwrite++]));
+  DataWrite(static_cast<float>(loader->m_curtexmtx[loader->m_texmtxwrite++]));
 }
 
 static void TexMtx_Write_Float3(VertexLoader* loader)
 {
   DataWrite(0.f);
   DataWrite(0.f);
-  DataWrite(float(loader->m_curtexmtx[loader->m_texmtxwrite++]));
+  DataWrite(static_cast<float>(loader->m_curtexmtx[loader->m_texmtxwrite++]));
 }
 
 static void SkipVertex(VertexLoader* loader)

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -29,7 +29,7 @@ constexpr float FracAdjust(T val)
   // auto const U16FRAC = 1.f / (1u << 15);
 
   // TODO: is this right?
-  return val / float(1u << (sizeof(T) * 8 - std::is_signed_v<T> - 1));
+  return val / static_cast<float>(1u << (sizeof(T) * 8 - std::is_signed_v<T> - 1));
 }
 
 template <>

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -573,7 +573,7 @@ void VertexManagerBase::Flush()
         const auto cache_entry = g_texture_cache->Load(TextureInfo::FromStage(i));
         if (!cache_entry)
           continue;
-        const float custom_tex_scale = cache_entry->GetWidth() / float(cache_entry->native_width);
+        const float custom_tex_scale = cache_entry->GetWidth() / static_cast<float>(cache_entry->native_width);
         samplers[i] = TextureCacheBase::GetSamplerState(
             i, custom_tex_scale, cache_entry->is_custom_tex, cache_entry->has_arbitrary_mips);
       }
@@ -591,7 +591,7 @@ void VertexManagerBase::Flush()
             texture_units.push_back(i);
           }
 
-          const float custom_tex_scale = cache_entry->GetWidth() / float(cache_entry->native_width);
+          const float custom_tex_scale = cache_entry->GetWidth() / static_cast<float>(cache_entry->native_width);
           samplers[i] = TextureCacheBase::GetSamplerState(
               i, custom_tex_scale, cache_entry->is_custom_tex, cache_entry->has_arbitrary_mips);
         }

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -257,9 +257,9 @@ void VertexShaderManager::SetConstants(const std::vector<std::string>& textures,
         else
           return f;
       };
-      double norm = double(light.ddir[0]) * double(light.ddir[0]) +
-                    double(light.ddir[1]) * double(light.ddir[1]) +
-                    double(light.ddir[2]) * double(light.ddir[2]);
+      double norm = static_cast<double>(light.ddir[0]) * static_cast<double>(light.ddir[0]) +
+                    static_cast<double>(light.ddir[1]) * static_cast<double>(light.ddir[1]) +
+                    static_cast<double>(light.ddir[2]) * static_cast<double>(light.ddir[2]);
       norm = 1.0 / sqrt(norm);
       dstlight.dir[0] = sanitize(static_cast<float>(light.ddir[0] * norm));
       dstlight.dir[1] = sanitize(static_cast<float>(light.ddir[1] * norm));

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -194,7 +194,7 @@ void VideoConfig::Refresh()
 void VideoConfig::VerifyValidity()
 {
   // TODO: Check iMaxAnisotropy value
-  if (iAdapter < 0 || iAdapter > ((int)g_backend_info.Adapters.size() - 1))
+  if (iAdapter < 0 || iAdapter > (static_cast<int>(g_backend_info.Adapters.size()) - 1))
     iAdapter = 0;
 
   if (!Common::Contains(g_backend_info.AAModes, iMultisamples))

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -390,7 +390,7 @@ struct VideoConfig final
   u32 GetShaderCompilerThreads() const;
   u32 GetShaderPrecompilerThreads() const;
 
-  float GetCustomAspectRatio() const { return (float)custom_aspect_width / custom_aspect_height; }
+  float GetCustomAspectRatio() const { return static_cast<float>(custom_aspect_width) / custom_aspect_height; }
 };
 
 extern VideoConfig g_Config;

--- a/Source/Core/VideoCommon/XFStateManager.cpp
+++ b/Source/Core/VideoCommon/XFStateManager.cpp
@@ -53,36 +53,36 @@ void XFStateManager::DoState(PointerWrap& p)
 
 void XFStateManager::InvalidateXFRange(int start, int end)
 {
-  if (((u32)start >= (u32)g_main_cp_state.matrix_index_a.PosNormalMtxIdx * 4 &&
-       (u32)start < (u32)g_main_cp_state.matrix_index_a.PosNormalMtxIdx * 4 + 12) ||
-      ((u32)start >=
-           XFMEM_NORMALMATRICES + ((u32)g_main_cp_state.matrix_index_a.PosNormalMtxIdx & 31) * 3 &&
-       (u32)start < XFMEM_NORMALMATRICES +
-                        ((u32)g_main_cp_state.matrix_index_a.PosNormalMtxIdx & 31) * 3 + 9))
+  if ((static_cast<u32>(start) >= static_cast<u32>(g_main_cp_state.matrix_index_a.PosNormalMtxIdx) * 4 &&
+       static_cast<u32>(start) < static_cast<u32>(g_main_cp_state.matrix_index_a.PosNormalMtxIdx) * 4 + 12) ||
+      (static_cast<u32>(start) >=
+           XFMEM_NORMALMATRICES + (static_cast<u32>(g_main_cp_state.matrix_index_a.PosNormalMtxIdx) & 31) * 3 &&
+       static_cast<u32>(start) < XFMEM_NORMALMATRICES +
+                        (static_cast<u32>(g_main_cp_state.matrix_index_a.PosNormalMtxIdx) & 31) * 3 + 9))
   {
     m_pos_normal_matrix_changed = true;
   }
 
-  if (((u32)start >= (u32)g_main_cp_state.matrix_index_a.Tex0MtxIdx * 4 &&
-       (u32)start < (u32)g_main_cp_state.matrix_index_a.Tex0MtxIdx * 4 + 12) ||
-      ((u32)start >= (u32)g_main_cp_state.matrix_index_a.Tex1MtxIdx * 4 &&
-       (u32)start < (u32)g_main_cp_state.matrix_index_a.Tex1MtxIdx * 4 + 12) ||
-      ((u32)start >= (u32)g_main_cp_state.matrix_index_a.Tex2MtxIdx * 4 &&
-       (u32)start < (u32)g_main_cp_state.matrix_index_a.Tex2MtxIdx * 4 + 12) ||
-      ((u32)start >= (u32)g_main_cp_state.matrix_index_a.Tex3MtxIdx * 4 &&
-       (u32)start < (u32)g_main_cp_state.matrix_index_a.Tex3MtxIdx * 4 + 12))
+  if ((static_cast<u32>(start) >= static_cast<u32>(g_main_cp_state.matrix_index_a.Tex0MtxIdx) * 4 &&
+       static_cast<u32>(start) < static_cast<u32>(g_main_cp_state.matrix_index_a.Tex0MtxIdx) * 4 + 12) ||
+      (static_cast<u32>(start) >= static_cast<u32>(g_main_cp_state.matrix_index_a.Tex1MtxIdx) * 4 &&
+       static_cast<u32>(start) < static_cast<u32>(g_main_cp_state.matrix_index_a.Tex1MtxIdx) * 4 + 12) ||
+      (static_cast<u32>(start) >= static_cast<u32>(g_main_cp_state.matrix_index_a.Tex2MtxIdx) * 4 &&
+       static_cast<u32>(start) < static_cast<u32>(g_main_cp_state.matrix_index_a.Tex2MtxIdx) * 4 + 12) ||
+      (static_cast<u32>(start) >= static_cast<u32>(g_main_cp_state.matrix_index_a.Tex3MtxIdx) * 4 &&
+       static_cast<u32>(start) < static_cast<u32>(g_main_cp_state.matrix_index_a.Tex3MtxIdx) * 4 + 12))
   {
     m_tex_matrices_changed[0] = true;
   }
 
-  if (((u32)start >= (u32)g_main_cp_state.matrix_index_b.Tex4MtxIdx * 4 &&
-       (u32)start < (u32)g_main_cp_state.matrix_index_b.Tex4MtxIdx * 4 + 12) ||
-      ((u32)start >= (u32)g_main_cp_state.matrix_index_b.Tex5MtxIdx * 4 &&
-       (u32)start < (u32)g_main_cp_state.matrix_index_b.Tex5MtxIdx * 4 + 12) ||
-      ((u32)start >= (u32)g_main_cp_state.matrix_index_b.Tex6MtxIdx * 4 &&
-       (u32)start < (u32)g_main_cp_state.matrix_index_b.Tex6MtxIdx * 4 + 12) ||
-      ((u32)start >= (u32)g_main_cp_state.matrix_index_b.Tex7MtxIdx * 4 &&
-       (u32)start < (u32)g_main_cp_state.matrix_index_b.Tex7MtxIdx * 4 + 12))
+  if ((static_cast<u32>(start) >= static_cast<u32>(g_main_cp_state.matrix_index_b.Tex4MtxIdx) * 4 &&
+       static_cast<u32>(start) < static_cast<u32>(g_main_cp_state.matrix_index_b.Tex4MtxIdx) * 4 + 12) ||
+      (static_cast<u32>(start) >= static_cast<u32>(g_main_cp_state.matrix_index_b.Tex5MtxIdx) * 4 &&
+       static_cast<u32>(start) < static_cast<u32>(g_main_cp_state.matrix_index_b.Tex5MtxIdx) * 4 + 12) ||
+      (static_cast<u32>(start) >= static_cast<u32>(g_main_cp_state.matrix_index_b.Tex6MtxIdx) * 4 &&
+       static_cast<u32>(start) < static_cast<u32>(g_main_cp_state.matrix_index_b.Tex6MtxIdx) * 4 + 12) ||
+      (static_cast<u32>(start) >= static_cast<u32>(g_main_cp_state.matrix_index_b.Tex7MtxIdx) * 4 &&
+       static_cast<u32>(start) < static_cast<u32>(g_main_cp_state.matrix_index_b.Tex7MtxIdx) * 4 + 12))
   {
     m_tex_matrices_changed[1] = true;
   }

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -100,7 +100,7 @@ static void XFRegWritten(Core::System& system, XFStateManager& xf_state_manager,
       break;
 
     case XFMEM_DUALTEX:
-      if (xfmem.dualTexTrans.enabled != bool(value & 1))
+      if (xfmem.dualTexTrans.enabled != static_cast<bool>(value & 1))
         g_vertex_manager->Flush();
       xf_state_manager.SetTexMatrixInfoChanged(-1);
       break;

--- a/Source/UnitTests/Common/BitFieldTest.cpp
+++ b/Source/UnitTests/Common/BitFieldTest.cpp
@@ -58,7 +58,7 @@ TEST(BitField, Storage)
 {
   TestUnion object;
 
-  EXPECT_EQ((void*)&object.hex, (void*)&object.regular_field_unsigned);
+  EXPECT_EQ(static_cast<void*>(&object.hex), static_cast<void*>(&object.regular_field_unsigned));
   EXPECT_EQ(sizeof(TestUnion), sizeof(object.hex));
   EXPECT_EQ(sizeof(TestUnion), sizeof(object.full_u64));
   EXPECT_EQ(sizeof(TestUnion), sizeof(object.full_s64));
@@ -93,14 +93,14 @@ TEST(BitField, Read)
     object.hex = val;
 
     // Make sure reading/casting does not behave completely idiotic
-    EXPECT_EQ(object.full_u64, (u64)object.full_u64);
-    EXPECT_EQ(object.full_s64, (s64)object.full_s64);
-    EXPECT_EQ(object.regular_field_unsigned, (u64)object.regular_field_unsigned);
-    EXPECT_EQ(object.regular_field_unsigned2, (u64)object.regular_field_unsigned2);
-    EXPECT_EQ(object.regular_field_signed, (s64)object.regular_field_signed);
-    EXPECT_EQ(object.at_dword_boundary, (s64)object.at_dword_boundary);
-    EXPECT_EQ(object.signed_1bit, (s64)object.signed_1bit);
-    EXPECT_EQ(object.flag, (bool)object.flag);
+    EXPECT_EQ(object.full_u64, static_cast<u64>(object.full_u64));
+    EXPECT_EQ(object.full_s64, static_cast<s64>(object.full_s64));
+    EXPECT_EQ(object.regular_field_unsigned, static_cast<u64>(object.regular_field_unsigned));
+    EXPECT_EQ(object.regular_field_unsigned2, static_cast<u64>(object.regular_field_unsigned2));
+    EXPECT_EQ(object.regular_field_signed, static_cast<s64>(object.regular_field_signed));
+    EXPECT_EQ(object.at_dword_boundary, static_cast<s64>(object.at_dword_boundary));
+    EXPECT_EQ(object.signed_1bit, static_cast<s64>(object.signed_1bit));
+    EXPECT_EQ(object.flag, static_cast<bool>(object.flag));
     EXPECT_EQ(object.enum_1, static_cast<TestEnum>(object.enum_1));
     EXPECT_EQ(object.enum_2, static_cast<TestEnum>(object.enum_2));
 
@@ -109,10 +109,10 @@ TEST(BitField, Read)
     EXPECT_EQ(*(s64*)&val, object.full_s64);
     EXPECT_EQ((val >> 9) & 0x7, object.regular_field_unsigned);
     EXPECT_EQ((val >> 9) & 0x7, object.regular_field_unsigned2);
-    EXPECT_EQ(((s64)(object.hex << 52)) >> 61, object.regular_field_signed);
-    EXPECT_EQ(((s64)(object.hex << 30)) >> 60, object.at_dword_boundary);
+    EXPECT_EQ(static_cast<s64>(object.hex << 52) >> 61, object.regular_field_signed);
+    EXPECT_EQ(static_cast<s64>(object.hex << 30) >> 60, object.at_dword_boundary);
     EXPECT_EQ(((object.hex >> 15) & 1) ? -1 : 0, object.signed_1bit);
-    EXPECT_EQ((bool)object.flag, ((object.hex >> 63) & 1));
+    EXPECT_EQ(static_cast<bool>(object.flag), ((object.hex >> 63) & 1));
     EXPECT_EQ(static_cast<TestEnum>((object.hex >> 16) & 3), object.enum_1);
     EXPECT_EQ(static_cast<TestEnum>((object.hex >> 48) & 3), object.enum_2);
   }
@@ -128,20 +128,20 @@ TEST(BitField, Assignment)
     object.full_u64 = val;
     EXPECT_EQ(val, object.full_u64);
 
-    object.full_s64 = (s64)val;
+    object.full_s64 = static_cast<s64>(val);
     EXPECT_EQ(val, object.full_u64);
 
     object.regular_field_unsigned = val;
     EXPECT_EQ(val & 0x7, object.regular_field_unsigned);
 
     object.at_dword_boundary = val;
-    EXPECT_EQ(((s64)(val << 60)) >> 60, object.at_dword_boundary);
+    EXPECT_EQ(static_cast<s64>(val << 60) >> 60, object.at_dword_boundary);
 
     object.signed_1bit = val;
     EXPECT_EQ((val & 1) ? -1 : 0, object.signed_1bit);
 
     object.regular_field_signed = val;
-    EXPECT_EQ(((s64)(object.hex << 61)) >> 61, object.regular_field_signed);
+    EXPECT_EQ(static_cast<s64>(object.hex << 61) >> 61, object.regular_field_signed);
 
     // Assignment from other BitField
     object.at_dword_boundary = object.regular_field_signed;
@@ -175,20 +175,20 @@ TEST(BitField, Alignment)
     object.full_u64 = val;
     EXPECT_EQ(val, object.full_u64);
 
-    object.full_s64 = (s64)val;
+    object.full_s64 = static_cast<s64>(val);
     EXPECT_EQ(val, object.full_u64);
 
     object.regular_field_unsigned = val;
     EXPECT_EQ(val & 0x7, object.regular_field_unsigned);
 
     object.at_dword_boundary = val;
-    EXPECT_EQ(((s64)(val << 60)) >> 60, object.at_dword_boundary);
+    EXPECT_EQ(static_cast<s64>(val << 60) >> 60, object.at_dword_boundary);
 
     object.signed_1bit = val;
     EXPECT_EQ((val & 1) ? -1 : 0, object.signed_1bit);
 
     object.regular_field_signed = val;
-    EXPECT_EQ(((s64)(object.hex << 61)) >> 61, object.regular_field_signed);
+    EXPECT_EQ(static_cast<s64>(object.hex << 61) >> 61, object.regular_field_signed);
 
     // Assignment from other BitField
     object.at_dword_boundary = object.regular_field_signed;

--- a/Source/UnitTests/Common/BitSetTest.cpp
+++ b/Source/UnitTests/Common/BitSetTest.cpp
@@ -27,7 +27,7 @@ TEST(BitSet, BitGetSet)
   bs[3] = bs[8] = bs[11] = true;
   EXPECT_TRUE(bs[3]);
   EXPECT_FALSE(bs[4]);
-  EXPECT_EQ((u32)((1 << 3) | (1 << 8) | (1 << 11)), bs.m_val);
+  EXPECT_EQ(static_cast<u32>((1 << 3) | (1 << 8) | (1 << 11)), bs.m_val);
 }
 
 TEST(BitSet, Count)

--- a/Source/UnitTests/Common/BitUtilsTest.cpp
+++ b/Source/UnitTests/Common/BitUtilsTest.cpp
@@ -68,23 +68,23 @@ TEST(BitUtils, IsValidLowMask)
   EXPECT_FALSE(Common::IsValidLowMask(0b10000u));
   EXPECT_FALSE(Common::IsValidLowMask(0b101111u));
 
-  EXPECT_TRUE(Common::IsValidLowMask((u8)~0b0));
-  EXPECT_FALSE(Common::IsValidLowMask((u8)(~0b0 - 1)));
-  EXPECT_FALSE(Common::IsValidLowMask((u8) ~(0b10000)));
-  EXPECT_FALSE(Common::IsValidLowMask((u8)(~((u8)(~0b0) >> 1) | 0b1111)));
+  EXPECT_TRUE(Common::IsValidLowMask(static_cast<u8>(~0b0)));
+  EXPECT_FALSE(Common::IsValidLowMask(static_cast<u8>(~0b0 - 1)));
+  EXPECT_FALSE(Common::IsValidLowMask(static_cast<u8>(~(0b10000))));
+  EXPECT_FALSE(Common::IsValidLowMask((u8)(~(static_cast<u8>(~0b0) >> 1) | 0b1111)));
 
-  EXPECT_TRUE(Common::IsValidLowMask((u16)~0b0));
-  EXPECT_FALSE(Common::IsValidLowMask((u16)(~0b0 - 1)));
-  EXPECT_FALSE(Common::IsValidLowMask((u16) ~(0b10000)));
-  EXPECT_FALSE(Common::IsValidLowMask((u16)(~((u16)(~0b0) >> 1) | 0b1111)));
+  EXPECT_TRUE(Common::IsValidLowMask(static_cast<u16>(~0b0)));
+  EXPECT_FALSE(Common::IsValidLowMask(static_cast<u16>(~0b0 - 1)));
+  EXPECT_FALSE(Common::IsValidLowMask(static_cast<u16>(~(0b10000))));
+  EXPECT_FALSE(Common::IsValidLowMask((u16)(~(static_cast<u16>(~0b0) >> 1) | 0b1111)));
 
-  EXPECT_TRUE(Common::IsValidLowMask((u32)~0b0));
-  EXPECT_FALSE(Common::IsValidLowMask((u32)(~0b0 - 1)));
-  EXPECT_FALSE(Common::IsValidLowMask((u32) ~(0b10000)));
-  EXPECT_FALSE(Common::IsValidLowMask((u32)(~((u32)(~0b0) >> 1) | 0b1111)));
+  EXPECT_TRUE(Common::IsValidLowMask(static_cast<u32>(~0b0)));
+  EXPECT_FALSE(Common::IsValidLowMask(static_cast<u32>(~0b0 - 1)));
+  EXPECT_FALSE(Common::IsValidLowMask(static_cast<u32>(~(0b10000))));
+  EXPECT_FALSE(Common::IsValidLowMask((u32)(~(static_cast<u32>(~0b0) >> 1) | 0b1111)));
 
-  EXPECT_TRUE(Common::IsValidLowMask((u64)~0b0));
-  EXPECT_FALSE(Common::IsValidLowMask((u64)(~0b0 - 1)));
-  EXPECT_FALSE(Common::IsValidLowMask((u64) ~(0b10000)));
-  EXPECT_FALSE(Common::IsValidLowMask((u64)(~((u64)(~0b0) >> 1) | 0b1111)));
+  EXPECT_TRUE(Common::IsValidLowMask(static_cast<u64>(~0b0)));
+  EXPECT_FALSE(Common::IsValidLowMask(static_cast<u64>(~0b0 - 1)));
+  EXPECT_FALSE(Common::IsValidLowMask(static_cast<u64>(~(0b10000))));
+  EXPECT_FALSE(Common::IsValidLowMask((u64)(~(static_cast<u64>(~0b0) >> 1) | 0b1111)));
 }

--- a/Source/UnitTests/Common/MathUtilTest.cpp
+++ b/Source/UnitTests/Common/MathUtilTest.cpp
@@ -64,8 +64,8 @@ TEST(MathUtil, SaturatingCast)
   EXPECT_EQ(std::numeric_limits<s32>::min(),
             MathUtil::SaturatingCast<s32>(-std::numeric_limits<float>::infinity()));
   // 16777217 = 2^24 + 1 is the first integer that cannot be represented correctly with a f32.
-  EXPECT_EQ(16777216, MathUtil::SaturatingCast<s32>(float(16777216)));
-  EXPECT_EQ(16777216, MathUtil::SaturatingCast<s32>(float(16777217)));
+  EXPECT_EQ(16777216, MathUtil::SaturatingCast<s32>(static_cast<float>(16777216)));
+  EXPECT_EQ(16777216, MathUtil::SaturatingCast<s32>(static_cast<float>(16777217)));
 }
 
 TEST(MathUtil, RectangleEquality)

--- a/Source/UnitTests/Core/IOS/ES/FormatsTest.cpp
+++ b/Source/UnitTests/Core/IOS/ES/FormatsTest.cpp
@@ -141,7 +141,7 @@ TEST_F(GameTMDReaderTest, ContentInfo)
   EXPECT_FALSE(m_tmd.GetContent(1, &content)) << "Content with index 1 should not exist";
 
   const std::vector<IOS::ES::Content> contents = m_tmd.GetContents();
-  ASSERT_EQ(contents.size(), size_t(1));
+  ASSERT_EQ(contents.size(), static_cast<size_t>(1));
   check_is_expected_content(contents.at(0));
 }
 
@@ -205,7 +205,7 @@ TEST_F(IOSTMDReaderTest, ContentInfo)
   };
 
   const std::vector<IOS::ES::Content> contents = m_tmd.GetContents();
-  ASSERT_EQ(contents.size(), size_t(23));
+  ASSERT_EQ(contents.size(), static_cast<size_t>(23));
 
   IOS::ES::Content content;
 

--- a/Source/UnitTests/Core/MMIOTest.cpp
+++ b/Source/UnitTests/Core/MMIOTest.cpp
@@ -133,7 +133,7 @@ TEST_F(MappingTest, ReadWriteComplex)
 
   u8 val = m_mapping->Read<u8>(*m_system, 0x0C001234);
   EXPECT_EQ(0x12, val);
-  m_mapping->Write(*m_system, 0x0C001234, (u8)0x34);
+  m_mapping->Write(*m_system, 0x0C001234, static_cast<u8>(0x34));
 
   EXPECT_TRUE(read_called);
   EXPECT_TRUE(write_called);

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -66,7 +66,7 @@ public:
 
 static void ASAN_DISABLE perform_invalid_access(void* data)
 {
-  *(volatile int*)data = 5;
+  *static_cast<volatile int*>(data) = 5;
 }
 
 TEST(PageFault, PageFault)

--- a/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
+++ b/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
@@ -65,7 +65,7 @@ protected:
   {
     m_loader = VertexLoaderBase::CreateVertexLoader(m_vtx_desc, m_vtx_attr);
     ASSERT_EQ(input_size, m_loader->m_vertex_size);
-    ASSERT_EQ((int)output_size, m_loader->m_native_vtx_decl.stride);
+    ASSERT_EQ(static_cast<int>(output_size), m_loader->m_native_vtx_decl.stride);
   }
 
   template <typename T>
@@ -166,7 +166,7 @@ TEST_P(VertexLoaderParamTest, PositionAll)
   ASSERT_EQ(0u, values.size() % 2);
   ASSERT_EQ(0u, values.size() % 3);
 
-  int count = (int)values.size() / elem_count;
+  int count = static_cast<int>(values.size()) / elem_count;
   size_t input_size = elem_count * elem_size;
   if (IsIndexed(addr))
   {
@@ -975,7 +975,7 @@ TEST_P(VertexLoaderSkippedTexCoordsTest, SkippedTextures)
   for (size_t i = 0; i < NUM_COMPONENTS_TO_TEST; i++)
   {
     if (enable_matrix[i])
-      Input<u8>(u8(20 + i));
+      Input<u8>(static_cast<u8>(20 + i));
   }
   Input<u8>(1);  // Position
   for (size_t i = 0; i < NUM_COMPONENTS_TO_TEST; i++)
@@ -987,7 +987,7 @@ TEST_P(VertexLoaderSkippedTexCoordsTest, SkippedTextures)
   for (size_t i = 0; i < NUM_COMPONENTS_TO_TEST; i++)
   {
     if (enable_matrix[i])
-      Input<u8>(u8(10 + i));
+      Input<u8>(static_cast<u8>(10 + i));
   }
   Input<u8>(0);  // Position
   for (size_t i = 0; i < NUM_COMPONENTS_TO_TEST; i++)


### PR DESCRIPTION
This pull request includes several changes to improve type safety by replacing C-style casts with `static_cast` in various files. The changes ensure better type checking and readability of the code.