### PR TITLE
SI: Fix GBA link by having a separate response for "error" and "no data".

### DIFF
--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -562,15 +562,18 @@ void SerialInterfaceManager::UpdateDevices()
   {
     // ERRLATCH bit is maintained.
     u32 errlatch = m_channel[i].in_hi.ERRLATCH.Value();
-    if (m_channel[i].device->GetData(m_channel[i].in_hi.hex, m_channel[i].in_lo.hex))
+    switch (m_channel[i].device->GetData(m_channel[i].in_hi.hex, m_channel[i].in_lo.hex))
     {
+    case DataResponse::Success:
       m_status_reg.hex |= GetRDSTBit(i);
-    }
-    else
-    {
+      break;
+    case DataResponse::ErrorNoResponse:
+      SetNoResponse(i);
+      [[fallthrough]];
+    case DataResponse::NoData:
       errlatch = 1;
       m_channel[i].in_hi.ERRSTAT = 1;
-      SetNoResponse(i);
+      break;
     }
 
     m_channel[i].in_hi.ERRLATCH = errlatch;

--- a/Source/Core/Core/HW/SI/SI_Device.h
+++ b/Source/Core/Core/HW/SI/SI_Device.h
@@ -106,6 +106,13 @@ enum SIDevices : int
   SIDEVICE_COUNT,
 };
 
+enum class DataResponse
+{
+  NoData,
+  Success,
+  ErrorNoResponse,
+};
+
 class ISIDevice
 {
 public:
@@ -119,8 +126,7 @@ public:
   virtual int RunBuffer(u8* buffer, int request_length);
   virtual int TransferInterval();
 
-  // Return true on new data
-  virtual bool GetData(u32& hi, u32& low) = 0;
+  virtual DataResponse GetData(u32& hi, u32& low) = 0;
 
   // Send a command directly (no detour per buffer)
   virtual void SendCommand(u32 command, u8 poll) = 0;

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
@@ -60,13 +60,13 @@ u32 CSIDevice_DanceMat::MapPadStatus(const GCPadStatus& pad_status)
   return (u32)(map << 16) | 0x8080;
 }
 
-bool CSIDevice_DanceMat::GetData(u32& hi, u32& low)
+DataResponse CSIDevice_DanceMat::GetData(u32& hi, u32& low)
 {
   CSIDevice_GCController::GetData(hi, low);
 
   // Identifies the dance mat
   low = 0x8080ffff;
 
-  return true;
+  return DataResponse::Success;
 }
 }  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
@@ -17,6 +17,6 @@ public:
 
   int RunBuffer(u8* buffer, int request_length) override;
   u32 MapPadStatus(const GCPadStatus& pad_status) override;
-  bool GetData(u32& hi, u32& low) override;
+  DataResponse GetData(u32& hi, u32& low) override;
 };
 }  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
@@ -348,9 +348,9 @@ int CSIDevice_GBA::TransferInterval()
   return SIDevice_GetGBATransferTime(m_system.GetSystemTimers(), m_last_cmd);
 }
 
-bool CSIDevice_GBA::GetData(u32& hi, u32& low)
+DataResponse CSIDevice_GBA::GetData(u32& hi, u32& low)
 {
-  return false;
+  return DataResponse::NoData;
 }
 
 void CSIDevice_GBA::SendCommand(u32 command, u8 poll)

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.h
@@ -47,7 +47,7 @@ public:
 
   int RunBuffer(u8* buffer, int request_length) override;
   int TransferInterval() override;
-  bool GetData(u32& hi, u32& low) override;
+  DataResponse GetData(u32& hi, u32& low) override;
   void SendCommand(u32 command, u8 poll) override;
 
 private:

--- a/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.cpp
@@ -120,7 +120,7 @@ int CSIDevice_GBAEmu::TransferInterval()
   return SIDevice_GetGBATransferTime(m_system.GetSystemTimers(), m_last_cmd);
 }
 
-bool CSIDevice_GBAEmu::GetData(u32& hi, u32& low)
+DataResponse CSIDevice_GBAEmu::GetData(u32& hi, u32& low)
 {
   GCPadStatus pad_status{};
   if (!NetPlay::IsNetPlayRunning())
@@ -149,7 +149,7 @@ bool CSIDevice_GBAEmu::GetData(u32& hi, u32& low)
   if (pad_status.button & PadButton::PAD_BUTTON_X)
     m_core->Reset();
 
-  return false;
+  return DataResponse::NoData;
 }
 
 void CSIDevice_GBAEmu::SendCommand(u32 command, u8 poll)

--- a/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBAEmu.h
@@ -25,7 +25,7 @@ public:
 
   int RunBuffer(u8* buffer, int request_length) override;
   int TransferInterval() override;
-  bool GetData(u32& hi, u32& low) override;
+  DataResponse GetData(u32& hi, u32& low) override;
   void SendCommand(u32 command, u8 poll) override;
   void DoState(PointerWrap& p) override;
   void OnEvent(u64 userdata, s64 cycles_late) override;

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -69,7 +69,7 @@ int CSIDevice_GCAdapter::RunBuffer(u8* buffer, int request_length)
   return CSIDevice_GCController::RunBuffer(buffer, request_length);
 }
 
-bool CSIDevice_GCAdapter::GetData(u32& hi, u32& low)
+DataResponse CSIDevice_GCAdapter::GetData(u32& hi, u32& low)
 {
   CSIDevice_GCController::GetData(hi, low);
 
@@ -78,7 +78,7 @@ bool CSIDevice_GCAdapter::GetData(u32& hi, u32& low)
     hi &= CSIDevice_TaruKonga::HI_BUTTON_MASK;
   }
 
-  return true;
+  return DataResponse::Success;
 }
 
 void CSIDevice_GCController::Rumble(int pad_num, ControlState strength, SIDevices device)

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
@@ -17,7 +17,7 @@ public:
   GCPadStatus GetPadStatus() override;
   int RunBuffer(u8* buffer, int request_length) override;
 
-  bool GetData(u32& hi, u32& low) override;
+  DataResponse GetData(u32& hi, u32& low) override;
 
 private:
   bool m_simulate_konga{};

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -170,12 +170,12 @@ GCPadStatus CSIDevice_GCController::GetPadStatus()
 // [00?SYXBA] [1LRZUDRL] [x] [y] [cx] [cy] [l] [r]
 //  |\_ ERR_LATCH (error latched - check SISR)
 //  |_ ERR_STATUS (error on last GetData or SendCmd?)
-bool CSIDevice_GCController::GetData(u32& hi, u32& low)
+DataResponse CSIDevice_GCController::GetData(u32& hi, u32& low)
 {
   GCPadStatus pad_status = GetPadStatus();
 
   if (!pad_status.isConnected)
-    return false;
+    return DataResponse::ErrorNoResponse;
 
   if (HandleButtonCombos(pad_status) == COMBO_ORIGIN)
     pad_status.button |= PAD_GET_ORIGIN;
@@ -227,7 +227,7 @@ bool CSIDevice_GCController::GetData(u32& hi, u32& low)
     low |= pad_status.substickX << 24;  // All 8 bits
   }
 
-  return true;
+  return DataResponse::Success;
 }
 
 u32 CSIDevice_GCController::MapPadStatus(const GCPadStatus& pad_status)
@@ -343,7 +343,7 @@ CSIDevice_TaruKonga::CSIDevice_TaruKonga(Core::System& system, SIDevices device,
 {
 }
 
-bool CSIDevice_TaruKonga::GetData(u32& hi, u32& low)
+DataResponse CSIDevice_TaruKonga::GetData(u32& hi, u32& low)
 {
   CSIDevice_GCController::GetData(hi, low);
 
@@ -351,7 +351,7 @@ bool CSIDevice_TaruKonga::GetData(u32& hi, u32& low)
   // and all buttons except: A, B, X, Y, Start, R
   hi &= HI_BUTTON_MASK;
 
-  return true;
+  return DataResponse::Success;
 }
 
 }  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.h
@@ -63,8 +63,7 @@ public:
   // Run the SI Buffer
   int RunBuffer(u8* buffer, int request_length) override;
 
-  // Return true on new data
-  bool GetData(u32& hi, u32& low) override;
+  DataResponse GetData(u32& hi, u32& low) override;
 
   // Send a command directly
   void SendCommand(u32 command, u8 poll) override;
@@ -96,7 +95,7 @@ class CSIDevice_TaruKonga final : public CSIDevice_GCController
 public:
   CSIDevice_TaruKonga(Core::System& system, SIDevices device, int device_number);
 
-  bool GetData(u32& hi, u32& low) override;
+  DataResponse GetData(u32& hi, u32& low) override;
 
   static const u32 HI_BUTTON_MASK =
       (PAD_BUTTON_A | PAD_BUTTON_B | PAD_BUTTON_X | PAD_BUTTON_Y | PAD_BUTTON_START | PAD_TRIGGER_R)

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
@@ -43,7 +43,7 @@ int CSIDevice_GCSteeringWheel::RunBuffer(u8* buffer, int request_length)
   }
 }
 
-bool CSIDevice_GCSteeringWheel::GetData(u32& hi, u32& low)
+DataResponse CSIDevice_GCSteeringWheel::GetData(u32& hi, u32& low)
 {
   if (m_mode == 6)
   {
@@ -95,7 +95,7 @@ bool CSIDevice_GCSteeringWheel::GetData(u32& hi, u32& low)
     return CSIDevice_GCController::GetData(hi, low);
   }
 
-  return true;
+  return DataResponse::Success;
 }
 
 void CSIDevice_GCSteeringWheel::SendCommand(u32 command, u8 poll)

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.h
@@ -13,7 +13,7 @@ public:
   CSIDevice_GCSteeringWheel(Core::System& system, SIDevices device, int device_number);
 
   int RunBuffer(u8* buffer, int request_length) override;
-  bool GetData(u32& hi, u32& low) override;
+  DataResponse GetData(u32& hi, u32& low) override;
   void SendCommand(u32 command, u8 poll) override;
 
 private:

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
@@ -68,7 +68,7 @@ KeyboardStatus CSIDevice_Keyboard::GetKeyboardStatus() const
   return Keyboard::GetStatus(m_device_number);
 }
 
-bool CSIDevice_Keyboard::GetData(u32& hi, u32& low)
+DataResponse CSIDevice_Keyboard::GetData(u32& hi, u32& low)
 {
   const KeyboardStatus key_status = GetKeyboardStatus();
   const KeyArray key = MapKeys(key_status);
@@ -77,7 +77,7 @@ bool CSIDevice_Keyboard::GetData(u32& hi, u32& low)
   hi = m_counter << 24;
   low = key[0] << 24 | key[1] << 16 | key[2] << 8 | checksum;
 
-  return true;
+  return DataResponse::Success;
 }
 
 void CSIDevice_Keyboard::SendCommand(u32 command, u8 poll)

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
@@ -21,8 +21,7 @@ public:
   // Run the SI Buffer
   int RunBuffer(u8* buffer, int request_length) override;
 
-  // Return true on new data
-  bool GetData(u32& hi, u32& low) override;
+  DataResponse GetData(u32& hi, u32& low) override;
 
   KeyboardStatus GetKeyboardStatus() const;
 

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
@@ -15,9 +15,9 @@ int CSIDevice_Null::RunBuffer(u8* buffer, int request_length)
   return -1;
 }
 
-bool CSIDevice_Null::GetData(u32& hi, u32& low)
+DataResponse CSIDevice_Null::GetData(u32& hi, u32& low)
 {
-  return false;
+  return DataResponse::ErrorNoResponse;
 }
 
 void CSIDevice_Null::SendCommand(u32 command, u8 poll)

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.h
@@ -15,7 +15,7 @@ public:
   CSIDevice_Null(Core::System& system, SIDevices device, int device_number);
 
   int RunBuffer(u8* buffer, int request_length) override;
-  bool GetData(u32& hi, u32& low) override;
+  DataResponse GetData(u32& hi, u32& low) override;
   void SendCommand(u32 command, u8 poll) override;
 };
 }  // namespace SerialInterface


### PR DESCRIPTION
This fixes a regression that I caused in PR #13365

The GBA device `GetData` implementations returned `false` to signify "no data", but that caused `SetNoResponse` to be called.

`GetData` now returns an enum. This makes the meaning of the return value less confusing and allows the GBAs to return no data without signaling no response.

Fixes: https://bugs.dolphin-emu.org/issues/13786