### PR TITLE
VideoCommon/NetPlayChatUI: Replace msg with structured binding

### DIFF
--- a/Source/Core/VideoCommon/NetPlayChatUI.cpp
+++ b/Source/Core/VideoCommon/NetPlayChatUI.cpp
@@ -35,11 +35,10 @@ void NetPlayChatUI::Display()
   }
 
   ImGui::BeginChild("Scrolling", ImVec2(0, -30 * scale), true, ImGuiWindowFlags_None);
-  for (const auto& msg : m_messages)
+  for (const auto& [text, color] : m_messages)
   {
-    auto c = msg.second;
     ImGui::PushTextWrapPos(0.0f);
-    ImGui::TextColored(ImVec4(c[0], c[1], c[2], 1.0f), "%s", msg.first.c_str());
+    ImGui::TextColored(ImVec4(color[0], color[1], color[2], 1.0f), "%s", text.c_str());
     ImGui::PopTextWrapPos();
   }
 


### PR DESCRIPTION
This pull request includes a small change to the `NetPlayChatUI` component to improve code readability and maintainability. Specifically, it updates the loop in the `Display` method to use structured bindings for better clarity when iterating over `m_messages`.

* [`Source/Core/VideoCommon/NetPlayChatUI.cpp`](diffhunk://#diff-b3f5e754d2d8526911c432b43835ee2f51b47390631cf72f8748dad22f313275L38-R41): Updated the loop in `NetPlayChatUI::Display()` to use structured bindings (`[text, color]`) instead of accessing elements via `.first` and `.second`. This improves code readability and aligns with modern C++ practices.