### PR TITLE
Common/Timer: Change HANDLE to void* to avoid including Windows.h to fix cmake build.

### DIFF
--- a/Source/Core/Common/Timer.h
+++ b/Source/Core/Common/Timer.h
@@ -5,10 +5,6 @@
 
 #include "Common/CommonTypes.h"
 
-#ifdef _WIN32
-#include <Windows.h>
-#endif
-
 namespace Common
 {
 class Timer
@@ -49,7 +45,8 @@ public:
 
 private:
 #ifdef _WIN32
-  HANDLE m_timer_handle;
+  // Using void* to avoid including Windows.h in this header just for HANDLE.
+  void* m_timer_handle;
 #endif
 };
 


### PR DESCRIPTION
`RemoveDirectory` macro in windows.h was breaking the cmake build.