### PR TITLE
DiscIO: Make classes final

### DIFF
--- a/Source/Core/DiscIO/CISOBlob.h
+++ b/Source/Core/DiscIO/CISOBlob.h
@@ -30,7 +30,7 @@ struct CISOHeader
   u8 map[CISO_MAP_SIZE];
 };
 
-class CISOFileReader : public BlobReader
+class CISOFileReader final : public BlobReader
 {
 public:
   static std::unique_ptr<CISOFileReader> Create(File::IOFile file);

--- a/Source/Core/DiscIO/CompressedBlob.h
+++ b/Source/Core/DiscIO/CompressedBlob.h
@@ -40,7 +40,7 @@ struct CompressedBlobHeader  // 32 bytes
   u32 num_blocks;
 };
 
-class CompressedBlobReader : public SectorReader
+class CompressedBlobReader final : public SectorReader
 {
 public:
   static std::unique_ptr<CompressedBlobReader> Create(File::IOFile file,

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -244,7 +244,7 @@ private:
   std::optional<DiscIO::Partition> m_wrapped_partition = std::nullopt;
 };
 
-class DirectoryBlobReader : public BlobReader
+class DirectoryBlobReader final : public BlobReader
 {
   friend DiscContent;
 

--- a/Source/Core/DiscIO/FileBlob.h
+++ b/Source/Core/DiscIO/FileBlob.h
@@ -13,7 +13,7 @@
 
 namespace DiscIO
 {
-class PlainFileReader : public BlobReader
+class PlainFileReader final : public BlobReader
 {
 public:
   static std::unique_ptr<PlainFileReader> Create(File::IOFile file);

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -19,7 +19,7 @@ namespace DiscIO
 class VolumeDisc;
 struct Partition;
 
-class FileInfoGCWii : public FileInfo
+class FileInfoGCWii final : public FileInfo
 {
 public:
   // None of the constructors take ownership of FST pointers
@@ -84,7 +84,7 @@ private:
   u32 m_total_file_infos;
 };
 
-class FileSystemGCWii : public FileSystem
+class FileSystemGCWii final : public FileSystem
 {
 public:
   FileSystemGCWii(const VolumeDisc* volume, const Partition& partition);

--- a/Source/Core/DiscIO/NFSBlob.h
+++ b/Source/Core/DiscIO/NFSBlob.h
@@ -38,7 +38,7 @@ struct NFSHeader
 };
 static_assert(sizeof(NFSHeader) == 0x200);
 
-class NFSFileReader : public BlobReader
+class NFSFileReader final : public BlobReader
 {
 public:
   static std::unique_ptr<NFSFileReader> Create(File::IOFile first_file,

--- a/Source/Core/DiscIO/RiivolutionPatcher.h
+++ b/Source/Core/DiscIO/RiivolutionPatcher.h
@@ -45,7 +45,7 @@ public:
   ResolveSavegameRedirectPath(std::string_view external_relative_path) = 0;
 };
 
-class FileDataLoaderHostFS : public FileDataLoader
+class FileDataLoaderHostFS final : public FileDataLoader
 {
 public:
   // sd_root should be an absolute path to the folder representing our virtual SD card

--- a/Source/Core/DiscIO/ScrubbedBlob.h
+++ b/Source/Core/DiscIO/ScrubbedBlob.h
@@ -13,7 +13,7 @@ namespace DiscIO
 {
 // This class wraps another BlobReader and zeroes out data that has been
 // identified by DiscScrubber as unused.
-class ScrubbedBlob : public BlobReader
+class ScrubbedBlob final : public BlobReader
 {
 public:
   static std::unique_ptr<ScrubbedBlob> Create(const std::string& path);

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -25,7 +25,7 @@ enum class Language;
 enum class Region;
 enum class Platform;
 
-class VolumeGC : public VolumeDisc
+class VolumeGC final : public VolumeDisc
 {
 public:
   VolumeGC(std::unique_ptr<BlobReader> reader);

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -23,7 +23,7 @@ enum class Language;
 enum class Region;
 enum class Platform;
 
-class VolumeWAD : public Volume
+class VolumeWAD final : public Volume
 {
 public:
   VolumeWAD(std::unique_ptr<BlobReader> reader);

--- a/Source/Core/DiscIO/VolumeWii.h
+++ b/Source/Core/DiscIO/VolumeWii.h
@@ -31,7 +31,7 @@ enum class Language;
 enum class Region;
 enum class Platform;
 
-class VolumeWii : public VolumeDisc
+class VolumeWii final : public VolumeDisc
 {
 public:
   static constexpr size_t AES_KEY_SIZE = Common::AES::Context::KEY_SIZE;

--- a/Source/Core/DiscIO/WIABlob.h
+++ b/Source/Core/DiscIO/WIABlob.h
@@ -41,7 +41,7 @@ constexpr u32 WIA_MAGIC = 0x01414957;  // "WIA\x1" (byteswapped to little endian
 constexpr u32 RVZ_MAGIC = 0x015A5652;  // "RVZ\x1" (byteswapped to little endian)
 
 template <bool RVZ>
-class WIARVZFileReader : public BlobReader
+class WIARVZFileReader final : public BlobReader
 {
 public:
   ~WIARVZFileReader();

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -15,7 +15,7 @@ namespace DiscIO
 {
 static constexpr u32 WBFS_MAGIC = 0x53464257;  // "WBFS" (byteswapped to little endian)
 
-class WbfsFileReader : public BlobReader
+class WbfsFileReader final : public BlobReader
 {
 public:
   ~WbfsFileReader();


### PR DESCRIPTION
This pull request updates several classes in the `DiscIO` module to use the `final` specifier, ensuring that these classes cannot be further subclassed. This change improves code clarity and enforces stricter type safety by explicitly marking these classes as non-extendable.