### PR TITLE
UnitTests: Check that ApprovedInis.json matches embedded hash

### DIFF
--- a/Source/Core/Common/JsonUtil.cpp
+++ b/Source/Core/Common/JsonUtil.cpp
@@ -60,6 +60,7 @@ bool JsonFromFile(const std::string& filename, picojson::value* root, std::strin
   std::string json_data;
   if (!File::ReadFileToString(filename, json_data))
   {
+    *error = "Failed to read " + filename;
     return false;
   }
 

--- a/Source/UnitTests/Core/PatchAllowlistTest.cpp
+++ b/Source/UnitTests/Core/PatchAllowlistTest.cpp
@@ -18,6 +18,7 @@
 #include "Common/IOFile.h"
 #include "Common/IniFile.h"
 #include "Common/JsonUtil.h"
+#include "Core/AchievementManager.h"
 #include "Core/ActionReplay.h"
 #include "Core/CheatCodes.h"
 #include "Core/GeckoCode.h"
@@ -38,7 +39,14 @@ void ReadVerified(const Common::IniFile& ini, const std::string& filename,
 void CheckHash(const std::string& game_id, GameHashes* game_hashes, const std::string& hash,
                const std::string& patch_name);
 
-TEST(PatchAllowlist, VerifyHashes)
+TEST(PatchAllowlist, VerifyJsonMatchesExecutable)
+{
+  std::string error;
+  if (!AchievementManager::GetInstance().IsApprovedCodesListValid(&error))
+    ADD_FAILURE() << error;
+}
+
+TEST(PatchAllowlist, VerifyInisMatchJson)
 {
   // Load allowlist
   static constexpr std::string_view APPROVED_LIST_FILENAME = "ApprovedInis.json";

--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -103,6 +103,7 @@
   <Import Project="$(ExternalsDir)Bochs_disasm\exports.props" />
   <Import Project="$(ExternalsDir)fmt\exports.props" />
   <Import Project="$(ExternalsDir)picojson\exports.props" />
+  <Import Project="$(ExternalsDir)rcheevos\exports.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
Previously we were only checking that game INIs matched ApprovedInis.json, not that ApprovedInis.json matched the hash embedded into the binary.